### PR TITLE
fix: #2066 fleet logs: unified read of the supervisor and every worker's log

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -1,7 +1,13 @@
 import { constants } from "node:fs";
-import { access, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { encode as encodeToon } from "@reddb-io/toon";
+import {
+  castleLanePath,
+  createEnginePaths,
+  readCastleLaneRecords,
+  type CastleLaneRecord,
+} from "@reddb-io/red-castle/engine";
 import { afkPaths, collectMonitorInputs, readFleetState, resolveRepoSlug } from "../runtime/wire.js";
 import { migrateLegacyDevPaths } from "../runtime/red-path-migration.js";
 import { parseRunnerFlag, detectRunner } from "../core/runner-detection.js";
@@ -219,6 +225,232 @@ export interface FleetStatusResult {
   status: "reported";
 }
 
+type FleetLogMode =
+  | { kind: "supervisor" }
+  | { kind: "worker"; workerId: string }
+  | { kind: "all" };
+
+interface FleetLogsArgs {
+  mode: FleetLogMode;
+  follow: boolean;
+}
+
+interface FleetLogSource {
+  id: string;
+  path: string;
+  prefix: string;
+}
+
+interface FleetLogEntry {
+  sourceId: string;
+  index: number;
+  at: string;
+  line: string;
+}
+
+export interface FleetLogsResult {
+  status: "logged";
+  follow: boolean;
+  sources: number;
+}
+
+export interface FleetLogsOptions {
+  followPollMs?: number;
+  signal?: AbortSignal;
+}
+
+function parseFleetLogsArgs(args: readonly string[]): FleetLogsArgs {
+  let mode: FleetLogMode | undefined;
+  let follow = false;
+
+  function setMode(next: FleetLogMode): void {
+    if (mode !== undefined) throw new Error("fleet logs accepts only one of --supervisor, --worker, or --all");
+    mode = next;
+  }
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === "--follow" || arg === "-f") {
+      follow = true;
+      continue;
+    }
+    if (arg === "--supervisor") {
+      setMode({ kind: "supervisor" });
+      continue;
+    }
+    if (arg === "--all") {
+      setMode({ kind: "all" });
+      continue;
+    }
+    if (arg === "--worker" || arg === "-w") {
+      const workerId = args[++i];
+      if (!workerId) throw new Error(`${arg} requires a worker id`);
+      setMode({ kind: "worker", workerId });
+      continue;
+    }
+    if (arg.startsWith("--worker=")) {
+      const workerId = arg.slice("--worker=".length);
+      if (!workerId) throw new Error("--worker requires a worker id");
+      setMode({ kind: "worker", workerId });
+      continue;
+    }
+    throw new Error(`unknown fleet logs argument: ${arg}`);
+  }
+
+  if (mode === undefined) throw new Error("fleet logs requires --supervisor, --worker <id>, or --all");
+  return { mode, follow };
+}
+
+async function childDirs(path: string): Promise<string[]> {
+  try {
+    return (await readdir(path, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+async function readableFile(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
+  }
+}
+
+async function supervisorLogSources(root: string): Promise<FleetLogSource[]> {
+  const paths = createEnginePaths(join(root, ".red"));
+  const ids = await childDirs(paths.supervisorsRoot);
+  const sources: FleetLogSource[] = [];
+  for (const id of ids) {
+    const path = castleLanePath(paths, "supervisor", id);
+    if (await readableFile(path)) {
+      sources.push({ id: `supervisor:${id}`, path, prefix: "" });
+    }
+  }
+  return sources;
+}
+
+async function workerLogSources(root: string, mode: Extract<FleetLogMode, { kind: "worker" | "all" }>): Promise<FleetLogSource[]> {
+  const paths = createEnginePaths(join(root, ".red"));
+  const workerIds = mode.kind === "worker" ? [mode.workerId] : await childDirs(paths.workersRoot);
+  const sources: FleetLogSource[] = [];
+  for (const workerId of workerIds) {
+    const path = castleLanePath(paths, "worker", workerId);
+    if (mode.kind === "worker" || await readableFile(path)) {
+      sources.push({
+        id: `worker:${workerId}`,
+        path,
+        prefix: mode.kind === "all" ? `[${workerId}] ` : "",
+      });
+    }
+  }
+  return sources;
+}
+
+async function fleetLogSources(root: string, mode: FleetLogMode): Promise<FleetLogSource[]> {
+  if (mode.kind === "supervisor") return supervisorLogSources(root);
+  return workerLogSources(root, mode);
+}
+
+function payloadText(payload: Record<string, unknown> | undefined): string {
+  if (!payload) return "";
+  const message = payload.message;
+  if (typeof message === "string") return message;
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(payload)) {
+    if (value === undefined) continue;
+    parts.push(`${key}=${typeof value === "string" ? value : JSON.stringify(value)}`);
+  }
+  return parts.join(" ");
+}
+
+function renderRecord(record: CastleLaneRecord, prefix: string): string {
+  const parts = [record.at, record.kind];
+  if (record.issue !== undefined) parts.push(`#${record.issue}`);
+  if (record.attempt !== undefined) parts.push(`a${record.attempt}`);
+  const payload = payloadText(record.payload);
+  return `${prefix}${parts.join(" ")}${payload ? ` ${payload}` : ""}`;
+}
+
+async function readLogEntries(source: FleetLogSource): Promise<FleetLogEntry[]> {
+  const records = await readCastleLaneRecords(source.path);
+  return records.map((record, index) => ({
+    sourceId: source.id,
+    index,
+    at: record.at,
+    line: renderRecord(record, source.prefix),
+  }));
+}
+
+function sortEntries(entries: FleetLogEntry[]): FleetLogEntry[] {
+  return entries.sort((a, b) => {
+    const at = a.at.localeCompare(b.at);
+    if (at !== 0) return at;
+    const source = a.sourceId.localeCompare(b.sourceId);
+    if (source !== 0) return source;
+    return a.index - b.index;
+  });
+}
+
+const wait = (ms: number, signal?: AbortSignal) => new Promise<void>((resolve) => {
+  if (signal?.aborted) {
+    resolve();
+    return;
+  }
+  const timer = setTimeout(resolve, ms);
+  signal?.addEventListener("abort", () => {
+    clearTimeout(timer);
+    resolve();
+  }, { once: true });
+});
+
+/**
+ * `fleet logs` is the read-only human view over the structured castle lanes.
+ * It never asks GitHub or mutates local state: it decodes supervisor/worker
+ * TOONL lanes and renders prose only at read time (ADR 0084).
+ */
+export async function logsFleet(
+  args: readonly string[],
+  root = process.cwd(),
+  stdout: NodeJS.WritableStream = process.stdout,
+  options: FleetLogsOptions = {},
+): Promise<FleetLogsResult> {
+  const parsed = parseFleetLogsArgs(args);
+  const emitted = new Map<string, number>();
+  let sourcesSeen = 0;
+
+  async function emitAvailable(): Promise<void> {
+    const sources = await fleetLogSources(root, parsed.mode);
+    sourcesSeen = Math.max(sourcesSeen, sources.length);
+    const nextEntries: FleetLogEntry[] = [];
+    for (const source of sources) {
+      const entries = await readLogEntries(source);
+      const previous = emitted.get(source.id) ?? 0;
+      if (entries.length < previous) emitted.set(source.id, 0);
+      const start = entries.length < previous ? 0 : previous;
+      nextEntries.push(...entries.slice(start));
+      emitted.set(source.id, entries.length);
+    }
+    for (const entry of sortEntries(nextEntries)) {
+      stdout.write(`${entry.line}\n`);
+    }
+  }
+
+  await emitAvailable();
+  while (parsed.follow && !options.signal?.aborted) {
+    await wait(options.followPollMs ?? 250, options.signal);
+    if (options.signal?.aborted) break;
+    await emitAvailable();
+  }
+
+  return { status: "logged", follow: parsed.follow, sources: sourcesSeen };
+}
+
 /**
  * Read-only fleet ground truth in one place (#2060). Answers "what is actually
  * running right now?" — the question that today requires cross-referencing the
@@ -369,6 +601,16 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
 }
 
 export async function fleetCommand(args: string[], cwd = process.cwd()): Promise<number> {
+  if (args[0] === "logs") {
+    try {
+      await logsFleet(args.slice(1), cwd);
+      return 0;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`✗ ${message}`);
+      return 1;
+    }
+  }
   const parsed = parseFleetArgs(args);
   try {
     if (parsed.status) {

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { decode } from "@reddb-io/toon";
+import { createCastleLaneWriters, createEnginePaths } from "@reddb-io/red-castle/engine";
 
 const killTreeMocks = vi.hoisted(() => ({
   isLivePid: vi.fn((_pid: number) => false),
@@ -18,7 +19,7 @@ vi.mock("../src/runtime/supervisor-spawn.js", () => ({
   spawnSupervisor: vi.fn(async () => 43210),
 }));
 
-import { launchFleet, statusFleet, stopFleet } from "../src/commands/fleet.js";
+import { launchFleet, logsFleet, statusFleet, stopFleet } from "../src/commands/fleet.js";
 import { isLivePid } from "../src/runtime/kill-tree.js";
 import { spawnSupervisor } from "../src/runtime/supervisor-spawn.js";
 import { afkPaths } from "../src/runtime/wire.js";
@@ -268,6 +269,116 @@ describe("fleet command stale supervisor state", () => {
         runner: "codex",
         shrink_mode: "drain-then-retire",
       });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("fleet logs", () => {
+  it("renders the supervisor structured lane as human-readable lines (#2066)", async () => {
+    const root = scratch();
+    try {
+      const writers = createCastleLaneWriters(createEnginePaths(join(root, ".red")), {
+        clock: () => "2026-07-18T00:00:00.000Z",
+      });
+      await writers.supervisor("s123").append({
+        kind: "supervisor.message",
+        supervisor_id: "s123",
+        payload: { message: "fleet tick target=2 ready=1" },
+      });
+      const writes: string[] = [];
+      const out = { write: vi.fn((s: string) => { writes.push(s); return true; }) } as unknown as NodeJS.WritableStream;
+
+      await logsFleet(["--supervisor"], root, out);
+
+      expect(writes.join("")).toContain("2026-07-18T00:00:00.000Z supervisor.message fleet tick target=2 ready=1");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("renders one worker's structured stream (#2066)", async () => {
+    const root = scratch();
+    try {
+      const writers = createCastleLaneWriters(createEnginePaths(join(root, ".red")), {
+        clock: () => "2026-07-18T00:01:00.000Z",
+      });
+      await writers.worker("wAAAA").append({
+        kind: "worker.claimed",
+        worker_id: "wAAAA",
+        issue: 2066,
+        attempt: 1,
+        payload: { message: "claimed issue" },
+      });
+      const writes: string[] = [];
+      const out = { write: vi.fn((s: string) => { writes.push(s); return true; }) } as unknown as NodeJS.WritableStream;
+
+      await logsFleet(["--worker", "wAAAA"], root, out);
+
+      expect(writes.join("")).toContain("2026-07-18T00:01:00.000Z worker.claimed #2066 a1 claimed issue");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("merges every worker stream with per-worker prefixes (#2066)", async () => {
+    const root = scratch();
+    try {
+      const writers = createCastleLaneWriters(createEnginePaths(join(root, ".red")));
+      await writers.worker("wBBBB").append({
+        at: "2026-07-18T00:03:00.000Z",
+        kind: "worker.heartbeat",
+        worker_id: "wBBBB",
+        payload: { message: "second" },
+      });
+      await writers.worker("wAAAA").append({
+        at: "2026-07-18T00:02:00.000Z",
+        kind: "worker.heartbeat",
+        worker_id: "wAAAA",
+        payload: { message: "first" },
+      });
+      const writes: string[] = [];
+      const out = { write: vi.fn((s: string) => { writes.push(s); return true; }) } as unknown as NodeJS.WritableStream;
+
+      await logsFleet(["--all"], root, out);
+
+      expect(writes.join("")).toBe(
+        "[wAAAA] 2026-07-18T00:02:00.000Z worker.heartbeat first\n" +
+        "[wBBBB] 2026-07-18T00:03:00.000Z worker.heartbeat second\n",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("streams appended records in follow mode (#2066)", async () => {
+    const root = scratch();
+    try {
+      const writers = createCastleLaneWriters(createEnginePaths(join(root, ".red")));
+      const writes: string[] = [];
+      const out = { write: vi.fn((s: string) => { writes.push(s); return true; }) } as unknown as NodeJS.WritableStream;
+      const controller = new AbortController();
+      const running = logsFleet(["--worker", "wLIVE", "--follow"], root, out, {
+        followPollMs: 10,
+        signal: controller.signal,
+      });
+
+      await writers.worker("wLIVE").append({
+        at: "2026-07-18T00:04:00.000Z",
+        kind: "worker.heartbeat",
+        worker_id: "wLIVE",
+        payload: { message: "still working" },
+      });
+
+      const deadline = Date.now() + 1000;
+      while (!writes.join("").includes("still working") && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      controller.abort();
+      await running;
+
+      expect(writes.join("")).toContain("2026-07-18T00:04:00.000Z worker.heartbeat still working");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: afk
 description: Autonomous loop that drains the `ready-for-agent` queue on the issue tracker. Each iteration claims an issue, runs it in an isolated worktree, executes with claude or codex, merges back to main, and closes the issue. Use when the user wants to run AFK execution, drain a Spec, hammer specific issues, or otherwise let agents grind through the backlog.
-argument-hint: "[--spec N | --issues N,N,N] [--runner claude|codex|opencode] [--alternate] [--fallback-runner] [--request TEXT] [-n N] [--once] [--boot-only] | fleet [N] | fleet stop | fleet status | monitor | dashboard | daily-review | weekly-review | retake N | reap"
+argument-hint: "[--spec N | --issues N,N,N] [--runner claude|codex|opencode] [--alternate] [--fallback-runner] [--request TEXT] [-n N] [--once] [--boot-only] | fleet [N] | fleet stop | fleet status | fleet logs --supervisor|--worker ID|--all [--follow] | monitor | dashboard | daily-review | weekly-review | retake N | reap"
 ---
 
 # /afk
@@ -67,6 +67,10 @@ contract live in [`docs/OPERATIONS.md`](./docs/OPERATIONS.md).
   verdict, runner, slot occupancy, bundle version/skew, churn, live workers, and
   whether a watchdog respawn would fire. Answers "what is actually running?"
   without cross-referencing pid files and snapshots by hand.
+- `/afk fleet logs --supervisor|--worker <id>|--all [--follow]` - read-only
+  local log view over the structured castle lanes. Supervisor logs render the
+  supervisor lane; worker logs render a single worker lane; `--all` merges all
+  worker lanes and prefixes every line with the worker id.
 - `/afk reap` - run branch hygiene without starting a worker.
 
 For GitHub Actions adoption, use [`actions-lane.md`](./actions-lane.md). The

--- a/plugins/dev/skills/engineering/afk/fleet.md
+++ b/plugins/dev/skills/engineering/afk/fleet.md
@@ -85,6 +85,20 @@ Steps, in order:
    - Bare/unknown: print `no native monitor teardown for this runner.`
 4. **Idempotency.** Re-running `/dev:afk fleet stop` after a successful stop just hits the "file missing" branch in step 1 and the runner-specific teardown no-op in step 3. Exit 0 either way.
 
+### `/dev:afk fleet logs` — local structured log reader
+
+`/dev:afk fleet logs --supervisor`, `/dev:afk fleet logs --worker <id>`, and
+`/dev:afk fleet logs --all` are read-only local views over the castle lanes.
+They do not call GitHub and do not mutate fleet state. They decode structured
+TOONL records and render human-readable lines only at read time:
+
+- `--supervisor` reads supervisor lanes under `.red/tmp/supervisors/`.
+- `--worker <id>` reads that worker's `.red/tmp/workers/<id>/worker.log.toonl`.
+- `--all` reads every worker lane, merges records by timestamp, and prefixes
+  each rendered line with `[worker-id]`.
+- `--follow` keeps polling the selected lane set and streams appended records
+  until the caller stops the command.
+
 ### Circuit Trip Sweep
 
 When the circuit breaker parks a slot (`CIRCUIT_K` fast deaths inside `CIRCUIT_WINDOW_S`) the supervisor — not a human — runs `sweep_parked_slot` to clean up after the burned workers. Three actions, in order, gated on the trip:


### PR DESCRIPTION
Automated AFK landing for #2066. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2066

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786936844&installation_id=129708444&pr_number=2090&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2090&signature=c893450e7ca2284979fa476c505e0a470968e58fe363670eb6dc9f24587cacfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->