### PR TITLE
feat: #2083 TOON ratchet guard + frozen allowlist (S1)

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -1,0 +1,284 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "id": "apps/benchmark-code-understanding/src/runner.ts:97:9#json-stringify-file-write#c9345d716e00",
+      "classification": "external",
+      "reason": "MCP runtime config is JSON for MCP client interoperability."
+    },
+    {
+      "id": "apps/brain/src/hook-runtime.ts:15:9#json-stringify-file-write#3d8f9a0e734e",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/brain/src/scheduled-ingestion.ts:54:12#json-parse-file-read#9581dce4f6da",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/brain/src/scheduled-ingestion.ts:63:9#json-stringify-file-write#76820ec0cff4",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/commands/activity-review.ts:335:20#json-parse-file-read#1e6c06036cd8",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/commands/activity-review.ts:349:9#json-stringify-file-write#ce2f54a1ed1c",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/commands/requeue.ts:232:5#json-stringify-file-write#73e266428283",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/commands/run.ts:1446:25#json-parse-file-read#61d090f580f9",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/commands/run.ts:1454:15#json-stringify-file-write#ebdfef068ac4",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/commands/run.ts:1675:16#json-parse-file-read#b69a317dc57f",
+      "classification": "external",
+      "reason": "Fetched plugin manifest remains JSON at the package boundary."
+    },
+    {
+      "id": "apps/dev/src/commands/run.ts:1751:13#json-stringify-file-write#27b9a7137312",
+      "classification": "external",
+      "reason": "Temporary Brain CLI handoff payload is an interop export."
+    },
+    {
+      "id": "apps/dev/src/commands/run.ts:1807:9#json-stringify-file-write#25fc383a7c1f",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/commands/run.ts:1832:9#json-stringify-file-write#a8168d7dcd7c",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/commands/run.ts:1851:20#json-parse-file-read#86c344997d9c",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/core/bundle-version.ts:109:20#json-parse-file-read#2354ffad933d",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/core/toon-json-guard.ts:112:18#json-parse-file-read#0eceada6ed44",
+      "classification": "external",
+      "reason": "Checked-in guard allowlist is JSON by contract."
+    },
+    {
+      "id": "apps/dev/src/runtime/feedback-worktree.ts:323:21#json-parse-file-read#0aa5c33b3d62",
+      "classification": "external",
+      "reason": "package.json is ecosystem JSON."
+    },
+    {
+      "id": "apps/dev/src/runtime/review-gh.ts:93:9#json-stringify-file-write#a2a5d957db20",
+      "classification": "external",
+      "reason": "GitHub review API --input payload is JSON."
+    },
+    {
+      "id": "apps/dev/src/runtime/wire.ts:1010:5#json-stringify-file-write#f306ace1e8f7",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/runtime/wire.ts:1017:7#json-stringify-file-write#53a9d6fef012",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/memory/src/backup.ts:143:20#json-parse-file-read#dda0e20f7f1e",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/memory/src/backup.ts:84:9#json-stringify-file-write#fc291fc6ac22",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/memory/src/backup.ts:98:9#json-stringify-file-write#efaf12324749",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/memory/src/bench-eval.ts:387:18#json-parse-file-read#4c10a115b739",
+      "classification": "external",
+      "reason": "Benchmark question fixtures are JSON inputs."
+    },
+    {
+      "id": "apps/memory/src/bench-eval.ts:394:18#json-parse-file-read#2b849c38340c",
+      "classification": "external",
+      "reason": "Benchmark question fixtures are JSON inputs."
+    },
+    {
+      "id": "apps/memory/src/bench-latency.ts:484:20#json-parse-file-read#ff426a366dd8",
+      "classification": "external",
+      "reason": "Benchmark workload fixture is JSON input."
+    },
+    {
+      "id": "apps/memory/src/bench-mistake-avoided.ts:111:18#json-parse-file-read#2c8e3a5a961c",
+      "classification": "external",
+      "reason": "Benchmark scenario fixture is JSON input."
+    },
+    {
+      "id": "apps/memory/src/bench-recall.ts:47:18#json-parse-file-read#8216e51fd1ec",
+      "classification": "external",
+      "reason": "Benchmark query fixtures are JSON inputs."
+    },
+    {
+      "id": "apps/memory/src/bench-recall.ts:54:18#json-parse-file-read#7dc5d84f72b1",
+      "classification": "external",
+      "reason": "Benchmark query fixtures are JSON inputs."
+    },
+    {
+      "id": "apps/memory/src/cli.ts:3108:7#json-stringify-file-write#05834a8e8826",
+      "classification": "external",
+      "reason": "Export command deliberately emits JSON artifacts."
+    },
+    {
+      "id": "apps/memory/src/cli.ts:3110:7#json-stringify-file-write#1a28d0d80ff3",
+      "classification": "external",
+      "reason": "Export command deliberately emits JSON metadata."
+    },
+    {
+      "id": "apps/memory/src/cli.ts:8037:17#json-parse-file-read#c824a01ef376",
+      "classification": "external",
+      "reason": "User-supplied graph contract may be JSON."
+    },
+    {
+      "id": "apps/memory/src/competitive-baseline.ts:1844:9#json-stringify-file-write#079e569527d8",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/memory/src/config.ts:249:12#json-parse-file-read#517090196539",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/memory/src/export.ts:182:5#json-stringify-file-write#c80da12dd8ce",
+      "classification": "external",
+      "reason": "Memory export command deliberately emits JSON."
+    },
+    {
+      "id": "apps/memory/src/extract-dev-artifact.ts:154:20#json-parse-file-read#3a88947ab6d9",
+      "classification": "external",
+      "reason": "package.json script extraction reads ecosystem JSON."
+    },
+    {
+      "id": "apps/memory/src/hook-coverage.ts:112:22#json-parse-file-read#9b71e6bdb888",
+      "classification": "external",
+      "reason": "Plugin manifest files are JSON by host contract."
+    },
+    {
+      "id": "apps/memory/src/hook-coverage.ts:192:12#json-parse-file-read#dc24826c7405",
+      "classification": "external",
+      "reason": "Coverage manifest is a deliberate JSON report input."
+    },
+    {
+      "id": "apps/memory/src/import-ams.ts:184:14#json-parse-file-read#be6d4e2a7a95",
+      "classification": "external",
+      "reason": "AMS import accepts external JSON dump format."
+    },
+    {
+      "id": "apps/memory/src/inbox.ts:117:12#json-parse-file-read#bfb372ea2744",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/memory/src/inbox.ts:205:9#json-stringify-file-write#40e5b2ff1cf7",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/opencode-host/src/emit.ts:98:5#json-stringify-file-write#b44f40dea7d5",
+      "classification": "external",
+      "reason": "opencode.json is an OpenCode host manifest."
+    },
+    {
+      "id": "apps/opencode-host/src/generate.ts:264:5#json-stringify-file-write#e5e4aaa124d5",
+      "classification": "external",
+      "reason": "Generated OpenCode manifest is JSON by host contract."
+    },
+    {
+      "id": "apps/opencode-host/src/hooks-to-events.ts:564:13#json-parse-file-read#88fea6286137",
+      "classification": "external",
+      "reason": "OpenCode hook config is external JSON."
+    },
+    {
+      "id": "apps/opencode-host/src/mcp-passthrough.ts:70:12#json-parse-file-read#5c2085922680",
+      "classification": "external",
+      "reason": ".mcp.json is MCP ecosystem JSON."
+    },
+    {
+      "id": "apps/rsp/src/elision-store.ts:1341:20#json-parse-file-read#99e6919848c4",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/rsp/src/elision-store.ts:1400:9#json-stringify-file-write#0c59c09ca48a",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/rsp/src/two-axis-benchmark.ts:422:18#json-parse-file-read#cf04ec9f7556",
+      "classification": "external",
+      "reason": "Benchmark baseline fixture is JSON input."
+    },
+    {
+      "id": "apps/rsp/src/two-axis-benchmark.ts:428:18#json-parse-file-read#2acb36d5b74d",
+      "classification": "external",
+      "reason": "Benchmark baseline fixture is JSON input."
+    },
+    {
+      "id": "packages/browser-bridge/session.ts:133:3#json-stringify-file-write#270772003fae",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/browser-bridge/session.ts:160:3#json-stringify-file-write#cc2a0b9cb869",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/browser-bridge/session.ts:168:3#json-stringify-file-write#ec1ecd13fd33",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/browser-bridge/session.ts:55:12#json-parse-file-read#d2f26452dc19",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/browser-bridge/session.ts:89:3#json-stringify-file-write#9da22d37f254",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/red-castle/.red-castle/agent-workflows/shared/common.ts:44:3#json-stringify-file-write#dcc9303b3180",
+      "classification": "external",
+      "reason": "Castle workflow helper writes JSON interop artifacts."
+    },
+    {
+      "id": "packages/red-castle/src/WorktreeLock.ts:182:24#json-parse-file-read#3ba17a080cd9",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/red-castle/src/WorktreeLock.ts:53:22#json-parse-file-read#5a64faac4443",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/red-castle/src/WorktreeLock.ts:95:18#json-parse-file-read#e740dec46214",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/red-castle/tsup.config.ts:4:13#json-parse-file-read#6714d89c2000",
+      "classification": "external",
+      "reason": "package.json is ecosystem JSON."
+    },
+    {
+      "id": "packages/shared/entrypoint-cli.ts:257:12#json-parse-file-read#da57542f7f85",
+      "classification": "external",
+      "reason": "Plugin manifest files are JSON by host contract."
+    },
+    {
+      "id": "packages/shared/toon-migration.ts:366:10#json-parse-file-read#15afb48d3ad6",
+      "classification": "external",
+      "reason": "TOON migration accepts legacy JSON inputs."
+    },
+    {
+      "id": "packages/shared/toon-migration.ts:469:12#json-parse-file-read#d7206ae9aa16",
+      "classification": "external",
+      "reason": "TOON migration accepts legacy JSON inputs."
+    }
+  ]
+}

--- a/apps/dev/src/core/toon-json-guard.ts
+++ b/apps/dev/src/core/toon-json-guard.ts
@@ -1,0 +1,319 @@
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import ts from "typescript";
+
+export type ToonJsonIoKind = "json-parse-file-read" | "json-stringify-file-write";
+export type ToonJsonAllowlistClassification = "migrate" | "external";
+
+export interface ToonJsonIoFinding {
+  id: string;
+  kind: ToonJsonIoKind;
+  relativePath: string;
+  line: number;
+  column: number;
+  snippet: string;
+}
+
+export interface ToonJsonAllowlistEntry {
+  id: string;
+  classification: ToonJsonAllowlistClassification;
+  reason?: string;
+}
+
+export interface ToonJsonGuardReport {
+  findings: ToonJsonIoFinding[];
+  allowlist: ToonJsonAllowlistEntry[];
+}
+
+export interface ToonJsonSourceFile {
+  relativePath: string;
+  sourceText: string;
+}
+
+const ALLOWLIST_PATH = ".red/contracts/toon-json-file-io-allowlist.json";
+const SOURCE_EXTENSIONS = new Set([".js", ".cjs", ".mjs", ".ts", ".cts", ".mts", ".tsx"]);
+const SKIP_DIRS = new Set([
+  ".git",
+  ".red",
+  ".turbo",
+  "coverage",
+  "dist",
+  "docs",
+  "node_modules",
+  "test",
+  "tests",
+  "__tests__",
+  "fixtures",
+]);
+const READ_FILE_NAMES = new Set(["readFile", "readFileSync"]);
+const WRITE_FILE_NAMES = new Set(["appendFile", "appendFileSync", "writeFile", "writeFileSync"]);
+
+interface FsBindings {
+  readIdentifiers: Set<string>;
+  writeIdentifiers: Set<string>;
+  namespaces: Set<string>;
+}
+
+type JsonOrigin = "file-read" | "json-stringify";
+
+export function collectToonJsonGuardReport(root: string): ToonJsonGuardReport {
+  return {
+    findings: collectToonJsonIoFindings(root),
+    allowlist: readToonJsonAllowlist(root),
+  };
+}
+
+export function collectToonJsonIoFindings(root: string): ToonJsonIoFinding[] {
+  return collectToonJsonIoFindingsFromFiles(readSourceFiles(root));
+}
+
+export function collectToonJsonIoFindingsFromFiles(files: readonly ToonJsonSourceFile[]): ToonJsonIoFinding[] {
+  return files.flatMap((file) => collectFileFindings(file)).sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function formatToonJsonGuardViolations(report: ToonJsonGuardReport): string[] {
+  const findingsById = new Map(report.findings.map((finding) => [finding.id, finding]));
+  const seenAllowlistIds = new Set<string>();
+  const violations: string[] = [];
+
+  for (const entry of report.allowlist) {
+    if (seenAllowlistIds.has(entry.id)) {
+      violations.push(`duplicate allowlist id ${entry.id}`);
+    }
+    seenAllowlistIds.add(entry.id);
+    if (entry.classification !== "migrate" && entry.classification !== "external") {
+      violations.push(`allowlist id ${entry.id} has invalid classification ${String(entry.classification)}`);
+    }
+    if (entry.classification === "external" && !entry.reason?.trim()) {
+      violations.push(`external allowlist id ${entry.id} must include a one-line reason`);
+    }
+    if (!findingsById.has(entry.id)) {
+      violations.push(`stale allowlist id ${entry.id}`);
+    }
+  }
+
+  const allowlistIds = new Set(report.allowlist.map((entry) => entry.id));
+  for (const finding of report.findings) {
+    if (!allowlistIds.has(finding.id)) {
+      violations.push(
+        `unallowlisted ${finding.kind} ${finding.id} at ${finding.relativePath}:${finding.line}:${finding.column} ${finding.snippet}`,
+      );
+    }
+  }
+
+  return violations;
+}
+
+export function readToonJsonAllowlist(root: string): ToonJsonAllowlistEntry[] {
+  const allowlistPath = join(root, ALLOWLIST_PATH);
+  if (!existsSync(allowlistPath)) return [];
+  const raw = readFileSync(allowlistPath, "utf8");
+  const parsed = JSON.parse(raw) as { entries?: unknown };
+  if (!Array.isArray(parsed.entries)) return [];
+  return parsed.entries.map((entry) => {
+    const record = entry as Record<string, unknown>;
+    return {
+      id: String(record.id ?? ""),
+      classification: record.classification === "external" ? "external" : "migrate",
+      reason: typeof record.reason === "string" ? record.reason : undefined,
+    };
+  });
+}
+
+function readSourceFiles(root: string): ToonJsonSourceFile[] {
+  const roots = ["apps", "packages"];
+  const files: ToonJsonSourceFile[] = [];
+  for (const sourceRoot of roots) {
+    const absoluteRoot = join(root, sourceRoot);
+    if (existsSync(absoluteRoot)) collectSourceFiles(root, absoluteRoot, files);
+  }
+  return files;
+}
+
+function collectSourceFiles(root: string, dir: string, out: ToonJsonSourceFile[]): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) collectSourceFiles(root, join(dir, entry.name), out);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const absolutePath = join(dir, entry.name);
+    const relativePath = normalizePath(relative(root, absolutePath));
+    if (!isGuardedSourceFile(relativePath)) continue;
+    out.push({ relativePath, sourceText: readFileSync(absolutePath, "utf8") });
+  }
+}
+
+function isGuardedSourceFile(relativePath: string): boolean {
+  const base = relativePath.split("/").at(-1) ?? "";
+  if (base.includes(".test.") || base.includes(".spec.") || base.endsWith(".d.ts")) return false;
+  const dot = base.lastIndexOf(".");
+  return dot >= 0 && SOURCE_EXTENSIONS.has(base.slice(dot));
+}
+
+function collectFileFindings(file: ToonJsonSourceFile): ToonJsonIoFinding[] {
+  const sourceFile = ts.createSourceFile(file.relativePath, file.sourceText, ts.ScriptTarget.Latest, true);
+  const bindings = collectFsBindings(sourceFile);
+  const origins = new Map<string, JsonOrigin>();
+  const findings: ToonJsonIoFinding[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const origin = expressionOrigin(node.initializer, origins, bindings);
+      if (origin) origins.set(node.name.text, origin);
+    }
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left)
+    ) {
+      const origin = expressionOrigin(node.right, origins, bindings);
+      if (origin) origins.set(node.left.text, origin);
+    }
+    if (ts.isCallExpression(node)) {
+      if (isJsonParseCall(node) && node.arguments.some((arg) => expressionOrigin(arg, origins, bindings) === "file-read")) {
+        findings.push(makeFinding(file, sourceFile, node, "json-parse-file-read"));
+      }
+      if (isFileWriteCall(node, bindings) && node.arguments.slice(1).some((arg) => expressionOrigin(arg, origins, bindings) === "json-stringify")) {
+        findings.push(makeFinding(file, sourceFile, node, "json-stringify-file-write"));
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return findings;
+}
+
+function collectFsBindings(sourceFile: ts.SourceFile): FsBindings {
+  const bindings: FsBindings = {
+    readIdentifiers: new Set(),
+    writeIdentifiers: new Set(),
+    namespaces: new Set(),
+  };
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const moduleName = statement.moduleSpecifier;
+    if (!ts.isStringLiteral(moduleName) || !["fs", "node:fs", "node:fs/promises"].includes(moduleName.text)) continue;
+    const clause = statement.importClause;
+    if (!clause) continue;
+    if (clause.name) bindings.namespaces.add(clause.name.text);
+    const namedBindings = clause.namedBindings;
+    if (!namedBindings) continue;
+    if (ts.isNamespaceImport(namedBindings)) {
+      bindings.namespaces.add(namedBindings.name.text);
+      continue;
+    }
+    for (const element of namedBindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      const local = element.name.text;
+      if (READ_FILE_NAMES.has(imported)) bindings.readIdentifiers.add(local);
+      if (WRITE_FILE_NAMES.has(imported)) bindings.writeIdentifiers.add(local);
+      if (imported === "promises") bindings.namespaces.add(local);
+    }
+  }
+
+  return bindings;
+}
+
+function expressionOrigin(expression: ts.Expression, origins: ReadonlyMap<string, JsonOrigin>, bindings: FsBindings): JsonOrigin | null {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isIdentifier(unwrapped)) return origins.get(unwrapped.text) ?? null;
+  if (ts.isCallExpression(unwrapped)) {
+    if (isFileReadCall(unwrapped, bindings)) return "file-read";
+    if (isJsonStringifyCall(unwrapped)) return "json-stringify";
+  }
+  if (ts.isBinaryExpression(unwrapped)) {
+    const left = expressionOrigin(unwrapped.left, origins, bindings);
+    const right = expressionOrigin(unwrapped.right, origins, bindings);
+    if (left === "json-stringify" || right === "json-stringify") return "json-stringify";
+    if (left === "file-read" || right === "file-read") return "file-read";
+  }
+  if (ts.isTemplateExpression(unwrapped)) {
+    for (const span of unwrapped.templateSpans) {
+      const origin = expressionOrigin(span.expression, origins, bindings);
+      if (origin) return origin;
+    }
+  }
+  return null;
+}
+
+function unwrapExpression(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (ts.isAwaitExpression(current) || ts.isParenthesizedExpression(current) || ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isJsonParseCall(node: ts.CallExpression): boolean {
+  return isJsonCall(node, "parse");
+}
+
+function isJsonStringifyCall(node: ts.CallExpression): boolean {
+  return isJsonCall(node, "stringify");
+}
+
+function isJsonCall(node: ts.CallExpression, method: "parse" | "stringify"): boolean {
+  return (
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === method &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === "JSON"
+  );
+}
+
+function isFileReadCall(node: ts.CallExpression, bindings: FsBindings): boolean {
+  return isFsCall(node, bindings, READ_FILE_NAMES, bindings.readIdentifiers);
+}
+
+function isFileWriteCall(node: ts.CallExpression, bindings: FsBindings): boolean {
+  return isFsCall(node, bindings, WRITE_FILE_NAMES, bindings.writeIdentifiers);
+}
+
+function isFsCall(
+  node: ts.CallExpression,
+  bindings: FsBindings,
+  importedNames: ReadonlySet<string>,
+  importedIdentifiers: ReadonlySet<string>,
+): boolean {
+  const expression = node.expression;
+  if (ts.isIdentifier(expression)) return importedIdentifiers.has(expression.text);
+  if (!ts.isPropertyAccessExpression(expression) || !importedNames.has(expression.name.text)) return false;
+  const root = leftmostIdentifier(expression.expression);
+  return root ? bindings.namespaces.has(root.text) : false;
+}
+
+function leftmostIdentifier(expression: ts.Expression): ts.Identifier | null {
+  let current = expression;
+  while (ts.isPropertyAccessExpression(current)) current = current.expression;
+  return ts.isIdentifier(current) ? current : null;
+}
+
+function makeFinding(
+  file: ToonJsonSourceFile,
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  kind: ToonJsonIoKind,
+): ToonJsonIoFinding {
+  const start = node.getStart(sourceFile);
+  const pos = sourceFile.getLineAndCharacterOfPosition(start);
+  const snippet = node.getText(sourceFile).replace(/\s+/g, " ").trim();
+  const line = pos.line + 1;
+  const column = pos.character + 1;
+  const hash = createHash("sha1").update(`${kind}\0${file.relativePath}\0${line}\0${column}\0${snippet}`).digest("hex").slice(0, 12);
+  return {
+    id: `${file.relativePath}:${line}:${column}#${kind}#${hash}`,
+    kind,
+    relativePath: file.relativePath,
+    line,
+    column,
+    snippet,
+  };
+}
+
+function normalizePath(path: string): string {
+  return sep === "/" ? path : path.split(sep).join("/");
+}

--- a/apps/dev/tests/toon-json-guard.test.ts
+++ b/apps/dev/tests/toon-json-guard.test.ts
@@ -1,0 +1,46 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  collectToonJsonGuardReport,
+  collectToonJsonIoFindingsFromFiles,
+  formatToonJsonGuardViolations,
+  type ToonJsonAllowlistEntry,
+} from "../src/core/toon-json-guard.js";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+describe("toon JSON file I/O guard", () => {
+  it("ratchets the live apps/packages JSON file I/O allowlist", async () => {
+    const report = await collectToonJsonGuardReport(ROOT);
+
+    expect(formatToonJsonGuardViolations(report)).toEqual([]);
+  });
+
+  it("rejects a new stack-owned JSON.stringify file write until allowlisted", () => {
+    const source = `
+      import { writeFileSync } from "node:fs";
+      import { join } from "node:path";
+
+      export function persistState(root: string) {
+        writeFileSync(join(root, "state.json"), JSON.stringify({ ok: true }), "utf8");
+      }
+    `;
+    const findings = collectToonJsonIoFindingsFromFiles([
+      { relativePath: "apps/example/src/state.ts", sourceText: source },
+    ]);
+    expect(findings).toHaveLength(1);
+
+    expect(formatToonJsonGuardViolations({ findings, allowlist: [] })).toEqual([
+      expect.stringContaining(findings[0]!.id),
+    ]);
+
+    const allowlist: ToonJsonAllowlistEntry[] = [
+      {
+        id: findings[0]!.id,
+        classification: "migrate",
+      },
+    ];
+
+    expect(formatToonJsonGuardViolations({ findings, allowlist })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## TOON completion S1 — ratchet guard + frozen allowlist

Enabler slice for Spec #2081. Ships the CI-enforced invariant that stops new JSON state files immediately and makes "done" a provable state (empty `migrate` partition).

### What it does
- **AST guard** (`apps/dev/src/core/toon-json-guard.ts`) using the TypeScript compiler API — scans `apps/**` and `packages/**` for stack-owned-file JSON I/O (`JSON.parse` of a file read; `JSON.stringify` feeding `writeFile`/`appendFile`). It tracks `fs` bindings/namespaces so it targets **persisted file I/O only**, not in-memory `JSON.parse`/`stringify`.
- **Frozen allowlist** (`.red/contracts/toon-json-file-io-allowlist.json`) — the single source of truth for remaining debt. **62 entries: 31 `migrate` / 31 `external`.** Each `external` carries a one-line reason (MCP configs, `package.json`, GitHub API payloads, benchmark fixtures, deliberate interop exports, opencode manifests, the guard's own allowlist).
- **Ratchet fixture** — a test proves the guard fails on a new un-allowlisted `JSON.stringify`→file write and passes once the entry is added.

### Gate wiring
The guard is a vitest test under `apps/dev/tests/`, so it runs as part of the existing gate — no separate manual step.

### Provenance note
Adopted from the AFK attempt (parked `blocked:sensitive-path` because it adds a trust/gate contract file). The allowlist was **re-anchored against current `origin/main`**: id = `path:line:col#kind#hash`, so line shifts invalidate entries. Re-seed matched all 62 sites by semantic key `(path, kind, snippet)` — 31 external classifications carried over verbatim, 0 defaulted, 0 lost. Guard verified green against the current tree (62 findings / 62 allowlist / 0 violations).

Closes #2083

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786942913&installation_id=129708444&pr_number=2091&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2091&signature=d11b9971b44c514c6fddc25abeb25f471a0f77fd6583f8328de82c7204e41658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->