### PR TITLE
fix: #2087 supervisor pid anchor — restore statusline fleet block + fleet stop

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -80,11 +80,11 @@
       "reason": "GitHub review API --input payload is JSON."
     },
     {
-      "id": "apps/dev/src/runtime/wire.ts:1010:5#json-stringify-file-write#f306ace1e8f7",
+      "id": "apps/dev/src/runtime/wire.ts:1011:5#json-stringify-file-write#906a47ac66dc",
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/runtime/wire.ts:1017:7#json-stringify-file-write#53a9d6fef012",
+      "id": "apps/dev/src/runtime/wire.ts:1018:7#json-stringify-file-write#7fb7403d3202",
       "classification": "migrate"
     },
     {

--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -1,5 +1,4 @@
-import { constants } from "node:fs";
-import { access, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { encode as encodeToon } from "@reddb-io/toon";
 import {
@@ -17,7 +16,7 @@ import { teardownWedgedSupervisor } from "../core/watchdog.js";
 import { buildWatchdogIO } from "../runtime/watchdog-io.js";
 import { spawnSupervisor } from "../runtime/supervisor-spawn.js";
 import { isLivePid, killTreeAndWait } from "../runtime/kill-tree.js";
-import { reapStaleSupervisorState } from "../runtime/supervisor-state.js";
+import { discoverLiveSupervisorPid, reapStaleSupervisorState } from "../runtime/supervisor-state.js";
 
 export interface FleetLaunchResult {
   status: "launched" | "resized";
@@ -32,15 +31,6 @@ export interface FleetStopResult {
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await access(path, constants.F_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 function parsePositiveNumber(raw: string | undefined, flag: string): number {
   if (raw === undefined) throw new Error(`${flag} requires a value`);
@@ -172,22 +162,24 @@ export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStr
       stdout.write(`terminated ${killed} orphaned worker${killed === 1 ? "" : "s"} and reconciled their claims.\n`);
     }
   };
-  const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
-  if (supervisor.status === "stale") {
-    await sweepOrphans();
-    stdout.write(`no fleet running (reason=dead supervisor pid; stale files cleaned).\n`);
-    return { status: "stale", ...(supervisor.pid !== undefined ? { pid: supervisor.pid } : {}) };
-  }
-  const pid = supervisor.pid;
-  if (!pid) {
+  const liveSupervisor = await discoverLiveSupervisorPid(stateAfk, isLivePid);
+  if (!liveSupervisor) {
+    const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
+    if (supervisor.status === "stale") {
+      await sweepOrphans();
+      stdout.write(`no fleet running (reason=dead supervisor pid; stale files cleaned).\n`);
+      return { status: "stale", ...(supervisor.pid !== undefined ? { pid: supervisor.pid } : {}) };
+    }
     await sweepOrphans();
     stdout.write("no fleet running (reason=no supervisor pid).\n");
     return { status: "none" };
   }
+  const pid = liveSupervisor.pid;
+  await mkdir(dirname(stopFile), { recursive: true });
   await writeFile(stopFile, "", "utf8");
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
-    if (!(await fileExists(pidFile)) || !isLivePid(pid)) {
+    if (!isLivePid(pid)) {
       // The supervisor's own terminateAll should have killed its slots on clean
       // exit, but sweep detached survivors anyway — a slot the loop lost track of
       // (moved-pid, mid-spawn) would otherwise outlive the "stopped" report.

--- a/apps/dev/src/runtime/supervisor-state.ts
+++ b/apps/dev/src/runtime/supervisor-state.ts
@@ -1,6 +1,6 @@
 import { constants } from "node:fs";
 import { access, readdir, readFile, rm } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { isLivePid as defaultIsLivePid } from "./kill-tree.js";
 
 export interface SupervisorStateReapResult {
@@ -18,6 +18,49 @@ export async function readSupervisorPid(pidFile: string): Promise<number | null>
   } catch {
     return null;
   }
+}
+
+export interface SupervisorPidDiscovery {
+  pid: number;
+  source: "pid-file" | "snapshot-dir";
+  path: string;
+}
+
+export async function discoverLiveSupervisorPid(
+  supervisorRuntimeDir: string,
+  isLivePid: (pid: number) => boolean = defaultIsLivePid,
+): Promise<SupervisorPidDiscovery | null> {
+  const pidFile = join(supervisorRuntimeDir, "afk-supervisor.pid");
+  const pid = await readSupervisorPid(pidFile);
+  if (pid !== null && isLivePid(pid)) {
+    return { pid, source: "pid-file", path: pidFile };
+  }
+
+  let entries: string[];
+  const supervisorsRoot = dirname(supervisorRuntimeDir);
+  try {
+    entries = await readdir(supervisorsRoot);
+  } catch {
+    return null;
+  }
+
+  const candidates = entries
+    .map((entry) => {
+      const match = /^s([1-9][0-9]*)$/.exec(entry);
+      if (!match) return null;
+      const lanePid = Number(match[1]);
+      if (!Number.isSafeInteger(lanePid) || lanePid <= 0) return null;
+      return { pid: lanePid, path: join(supervisorsRoot, entry) };
+    })
+    .filter((candidate): candidate is { pid: number; path: string } => candidate !== null)
+    .sort((a, b) => b.pid - a.pid);
+
+  for (const candidate of candidates) {
+    if (isLivePid(candidate.pid)) {
+      return { pid: candidate.pid, source: "snapshot-dir", path: candidate.path };
+    }
+  }
+  return null;
 }
 
 async function exists(path: string): Promise<boolean> {

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -53,6 +53,7 @@ import * as gitx from "./git.js";
 import * as fsx from "./fs.js";
 import { collectLogLineCounts } from "./log-cursor.js";
 import { isLivePid } from "./kill-tree.js";
+import { discoverLiveSupervisorPid } from "./supervisor-state.js";
 import { execTool } from "./exec.js";
 import { collectTmpJanitorReport } from "./tmp-janitor.js";
 import { collectFleetTruthProbeInput } from "../core/operational-probes.js";
@@ -1269,15 +1270,6 @@ export async function collectStatuslineAfk(
 
 const STATUSLINE_FLEET_MAX_AGE_S = 120;
 
-function readSupervisorPid(path: string): number | null {
-  try {
-    const pid = Number.parseInt(readFileSync(path, "utf8").trim(), 10);
-    return Number.isInteger(pid) && pid > 0 ? pid : null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Repo-summary fleet segment input. It is intentionally independent of live
  * worker rows: the supervisor can be landing, validating, merging, or idle
@@ -1289,12 +1281,11 @@ export async function collectStatuslineFleet(
   nowS: number = Math.floor(Date.now() / 1000),
 ): Promise<FleetInput | undefined> {
   const paths = afkPaths(ctx.root);
-  const pid = readSupervisorPid(paths.supervisorPidPath);
-  if (pid === null || !isLivePid(pid)) return undefined;
-
   const state = await readFleetState(paths.fleetStatePath);
   if (!state) return undefined;
   if (nowS - state.epoch > maxAgeS) return undefined;
+  const supervisor = await discoverLiveSupervisorPid(paths.supervisorRuntimeDir, isLivePid);
+  if (!supervisor) return undefined;
   const workers = currentRenderableWorkerRecords(
     await readAllWorkerStates(paths.tmpDir, { nowMs: nowS * 1000 }),
   );

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -191,6 +191,26 @@ describe("fleet command stale supervisor state", () => {
     }
   });
 
+  it("stopFleet discovers a live supervisor from the structured lane when the pid anchor is missing", async () => {
+    const root = scratch();
+    try {
+      const paths = afkPaths(root);
+      mkdirSync(join(dirname(paths.supervisorRuntimeDir), "s12345"), { recursive: true });
+      vi.mocked(isLivePid).mockImplementation((pid) => {
+        if (pid !== 12345) return false;
+        return vi.mocked(isLivePid).mock.calls.length <= 1;
+      });
+
+      const result = await stopFleet(root, stream());
+
+      expect(result).toEqual({ status: "stopped", pid: 12345 });
+      expect(existsSync(paths.supervisorStopPath)).toBe(true);
+      expect(killTreeMocks.killTreeAndWait).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("launchFleet writes a resize request when a healthy supervisor is already running", async () => {
       const root = scratch();
     try {

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -688,6 +688,20 @@ describe("statusline command — rendered line", () => {
     expect(stripAnsi(out.text())).not.toContain("flt=codex 1/1†");
   });
 
+  it("renders the fleet segment when the pid anchor is missing but the supervisor lane is live", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 2, 0);
+    await writeFleetSnapshot(root);
+    await rm(afkPaths(root).supervisorPidPath, { force: true });
+    await mkdir(join(dirname(afkPaths(root).supervisorRuntimeDir), `s${process.pid}`), { recursive: true });
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).toContain("flt=codex 1/1");
+    expect(stripAnsi(out.text())).toContain("q=2");
+  });
+
   it("suppresses the fleet segment when the supervisor pid is dead", async () => {
     await seedFreshRepoCache(root, 0, 0);
     await seedFreshCache(root, 2, 0);


### PR DESCRIPTION
## Fix supervisor pid anchor — restore statusline fleet block + `fleet stop`

`.red/tmp/supervisors/default/afk-supervisor.pid` can be empty/absent while the supervisor is alive (its pid only lives in the `s<pid>/` snapshot dirname). Both `collectStatuslineFleet` (wire.ts) and `stopFleet` (fleet.ts) read only that pid file → returned `undefined`/`none` while a supervisor was demonstrably running. Result: the `flt=` statusline block silently dropped, and `fleet stop` reported "no fleet running".

### Fix
New `discoverLiveSupervisorPid(supervisorRuntimeDir)` in `supervisor-state.ts`:
1. fast path — read `afk-supervisor.pid`;
2. fallback — scan `dirname(supervisorRuntimeDir)` for `s<pid>/` snapshot dirs, parse the pid from the dirname, pick the highest **live** one.

Wired into the statusline (`collectStatuslineFleet`) and `fleet stop`. Landing this un-breaks `fleet stop`, which is a precondition for cleanly restarting the fleet on the current bundle.

### Proof
Run against the **live** supervisor on this machine:
```
discoverLiveSupervisorPid -> {"pid":473304,"source":"snapshot-dir","path":".../.red/tmp/supervisors/s473304"}
```
Covered by new tests in `statusline-command.test.ts` (missing pid anchor) and `fleet-command.test.ts` (stop via snapshot-dir pid).

### Provenance
This is the freshest AFK attempt (worker `wS13V`) for #2087, landed by hand. The issue had looped 8× on `merge-conflict` because the running **2.69.2** fleet *concedes-and-requeues* on conflict instead of parking; each attempt collided with the concurrently-landing castle/trunk-freshness PRs. Once those settled, `origin/main` == this branch's base and the change applies cleanly (+5 commits, no conflict).

Closes #2087

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786945244&installation_id=129708444&pr_number=2092&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2092&signature=ff401afe010746696a26cfa3711249d3f4587f8962240f6e8fefd7dfb135b2d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->