### PR TITLE
feat: diff-aware sensitive-path gate for TOON allowlist + line-tolerant guard ids

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -2,281 +2,249 @@
   "version": 1,
   "entries": [
     {
-      "id": "apps/benchmark-code-understanding/src/runner.ts:97:9#json-stringify-file-write#c9345d716e00",
+      "id": "apps/benchmark-code-understanding/src/runner.ts#json-stringify-file-write#1a95f6559ad4",
       "classification": "external",
       "reason": "MCP runtime config is JSON for MCP client interoperability."
     },
     {
-      "id": "apps/brain/src/hook-runtime.ts:15:9#json-stringify-file-write#3d8f9a0e734e",
+      "id": "apps/brain/src/hook-runtime.ts#json-stringify-file-write#785a7ac362b7",
       "classification": "migrate"
     },
     {
-      "id": "apps/brain/src/scheduled-ingestion.ts:54:12#json-parse-file-read#9581dce4f6da",
+      "id": "apps/brain/src/scheduled-ingestion.ts#json-parse-file-read#42423a2a3f01",
       "classification": "migrate"
     },
     {
-      "id": "apps/brain/src/scheduled-ingestion.ts:63:9#json-stringify-file-write#76820ec0cff4",
+      "id": "apps/brain/src/scheduled-ingestion.ts#json-stringify-file-write#58cce3d7e63e",
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/commands/activity-review.ts:335:20#json-parse-file-read#1e6c06036cd8",
+      "id": "apps/dev/src/commands/activity-review.ts#json-parse-file-read#7155e41a10b1",
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/commands/activity-review.ts:349:9#json-stringify-file-write#ce2f54a1ed1c",
+      "id": "apps/dev/src/commands/activity-review.ts#json-stringify-file-write#fb01f23f34a6",
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/commands/requeue.ts:232:5#json-stringify-file-write#73e266428283",
+      "id": "apps/dev/src/commands/requeue.ts#json-stringify-file-write#e451b52ded48",
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/commands/run.ts:1446:25#json-parse-file-read#61d090f580f9",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/dev/src/commands/run.ts:1454:15#json-stringify-file-write#ebdfef068ac4",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/dev/src/commands/run.ts:1675:16#json-parse-file-read#b69a317dc57f",
+      "id": "apps/dev/src/commands/run.ts#json-parse-file-read#01a38c1e6f6a",
       "classification": "external",
       "reason": "Fetched plugin manifest remains JSON at the package boundary."
     },
     {
-      "id": "apps/dev/src/commands/run.ts:1751:13#json-stringify-file-write#27b9a7137312",
+      "id": "apps/dev/src/commands/run.ts#json-parse-file-read#78cdbf004ef3",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/commands/run.ts#json-parse-file-read#c6341de5e558",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/dev/src/commands/run.ts#json-stringify-file-write#3368a1bbf848",
       "classification": "external",
       "reason": "Temporary Brain CLI handoff payload is an interop export."
     },
     {
-      "id": "apps/dev/src/commands/run.ts:1807:9#json-stringify-file-write#25fc383a7c1f",
+      "id": "apps/dev/src/commands/run.ts#json-stringify-file-write#5a38957c5d3c",
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/commands/run.ts:1832:9#json-stringify-file-write#a8168d7dcd7c",
+      "id": "apps/dev/src/commands/run.ts#json-stringify-file-write#982a128ff187",
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/commands/run.ts:1851:20#json-parse-file-read#86c344997d9c",
+      "id": "apps/dev/src/commands/run.ts#json-stringify-file-write#b7e3f9d05b27",
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/core/bundle-version.ts:109:20#json-parse-file-read#2354ffad933d",
+      "id": "apps/dev/src/core/bundle-version.ts#json-parse-file-read#3a978a412439",
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/core/toon-json-guard.ts:112:18#json-parse-file-read#0eceada6ed44",
+      "id": "apps/dev/src/core/toon-json-guard.ts#json-parse-file-read#0f36cd7ce70f",
       "classification": "external",
       "reason": "Checked-in guard allowlist is JSON by contract."
     },
     {
-      "id": "apps/dev/src/runtime/feedback-worktree.ts:323:21#json-parse-file-read#0aa5c33b3d62",
+      "id": "apps/dev/src/runtime/feedback-worktree.ts#json-parse-file-read#abf5b08523f6",
       "classification": "external",
       "reason": "package.json is ecosystem JSON."
     },
     {
-      "id": "apps/dev/src/runtime/review-gh.ts:93:9#json-stringify-file-write#a2a5d957db20",
+      "id": "apps/dev/src/runtime/review-gh.ts#json-stringify-file-write#d6ea528ec9b4",
       "classification": "external",
       "reason": "GitHub review API --input payload is JSON."
     },
     {
-      "id": "apps/dev/src/runtime/wire.ts:1011:5#json-stringify-file-write#906a47ac66dc",
+      "id": "apps/dev/src/runtime/wire.ts#json-stringify-file-write#1ded525e3fc7",
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/runtime/wire.ts:1018:7#json-stringify-file-write#7fb7403d3202",
+      "id": "apps/memory/src/backup.ts#json-parse-file-read#1d64c7ed63c2",
       "classification": "migrate"
     },
     {
-      "id": "apps/memory/src/backup.ts:143:20#json-parse-file-read#dda0e20f7f1e",
+      "id": "apps/memory/src/backup.ts#json-stringify-file-write#319d7ee767e0",
       "classification": "migrate"
     },
     {
-      "id": "apps/memory/src/backup.ts:84:9#json-stringify-file-write#fc291fc6ac22",
+      "id": "apps/memory/src/backup.ts#json-stringify-file-write#d490a167d82e",
       "classification": "migrate"
     },
     {
-      "id": "apps/memory/src/backup.ts:98:9#json-stringify-file-write#efaf12324749",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/memory/src/bench-eval.ts:387:18#json-parse-file-read#4c10a115b739",
+      "id": "apps/memory/src/bench-eval.ts#json-parse-file-read#9f8ee3a49186",
       "classification": "external",
       "reason": "Benchmark question fixtures are JSON inputs."
     },
     {
-      "id": "apps/memory/src/bench-eval.ts:394:18#json-parse-file-read#2b849c38340c",
-      "classification": "external",
-      "reason": "Benchmark question fixtures are JSON inputs."
-    },
-    {
-      "id": "apps/memory/src/bench-latency.ts:484:20#json-parse-file-read#ff426a366dd8",
+      "id": "apps/memory/src/bench-latency.ts#json-parse-file-read#c2af8acfa0f2",
       "classification": "external",
       "reason": "Benchmark workload fixture is JSON input."
     },
     {
-      "id": "apps/memory/src/bench-mistake-avoided.ts:111:18#json-parse-file-read#2c8e3a5a961c",
+      "id": "apps/memory/src/bench-mistake-avoided.ts#json-parse-file-read#e71d9417acbf",
       "classification": "external",
       "reason": "Benchmark scenario fixture is JSON input."
     },
     {
-      "id": "apps/memory/src/bench-recall.ts:47:18#json-parse-file-read#8216e51fd1ec",
+      "id": "apps/memory/src/bench-recall.ts#json-parse-file-read#cd9ba4816a71",
       "classification": "external",
       "reason": "Benchmark query fixtures are JSON inputs."
     },
     {
-      "id": "apps/memory/src/bench-recall.ts:54:18#json-parse-file-read#7dc5d84f72b1",
-      "classification": "external",
-      "reason": "Benchmark query fixtures are JSON inputs."
-    },
-    {
-      "id": "apps/memory/src/cli.ts:3108:7#json-stringify-file-write#05834a8e8826",
-      "classification": "external",
-      "reason": "Export command deliberately emits JSON artifacts."
-    },
-    {
-      "id": "apps/memory/src/cli.ts:3110:7#json-stringify-file-write#1a28d0d80ff3",
-      "classification": "external",
-      "reason": "Export command deliberately emits JSON metadata."
-    },
-    {
-      "id": "apps/memory/src/cli.ts:8037:17#json-parse-file-read#c824a01ef376",
+      "id": "apps/memory/src/cli.ts#json-parse-file-read#ed1088009085",
       "classification": "external",
       "reason": "User-supplied graph contract may be JSON."
     },
     {
-      "id": "apps/memory/src/competitive-baseline.ts:1844:9#json-stringify-file-write#079e569527d8",
+      "id": "apps/memory/src/cli.ts#json-stringify-file-write#0b91ffb44ffd",
+      "classification": "external",
+      "reason": "Export command deliberately emits JSON metadata."
+    },
+    {
+      "id": "apps/memory/src/cli.ts#json-stringify-file-write#0d38e8a06ad0",
+      "classification": "external",
+      "reason": "Export command deliberately emits JSON artifacts."
+    },
+    {
+      "id": "apps/memory/src/competitive-baseline.ts#json-stringify-file-write#1fd6fed03b3a",
       "classification": "migrate"
     },
     {
-      "id": "apps/memory/src/config.ts:249:12#json-parse-file-read#517090196539",
+      "id": "apps/memory/src/config.ts#json-parse-file-read#2b08c55aae9a",
       "classification": "migrate"
     },
     {
-      "id": "apps/memory/src/export.ts:182:5#json-stringify-file-write#c80da12dd8ce",
+      "id": "apps/memory/src/export.ts#json-stringify-file-write#f2d8c9d8ed18",
       "classification": "external",
       "reason": "Memory export command deliberately emits JSON."
     },
     {
-      "id": "apps/memory/src/extract-dev-artifact.ts:154:20#json-parse-file-read#3a88947ab6d9",
+      "id": "apps/memory/src/extract-dev-artifact.ts#json-parse-file-read#5fb73f71086b",
       "classification": "external",
       "reason": "package.json script extraction reads ecosystem JSON."
     },
     {
-      "id": "apps/memory/src/hook-coverage.ts:112:22#json-parse-file-read#9b71e6bdb888",
-      "classification": "external",
-      "reason": "Plugin manifest files are JSON by host contract."
-    },
-    {
-      "id": "apps/memory/src/hook-coverage.ts:192:12#json-parse-file-read#dc24826c7405",
+      "id": "apps/memory/src/hook-coverage.ts#json-parse-file-read#1277b6df964e",
       "classification": "external",
       "reason": "Coverage manifest is a deliberate JSON report input."
     },
     {
-      "id": "apps/memory/src/import-ams.ts:184:14#json-parse-file-read#be6d4e2a7a95",
-      "classification": "external",
-      "reason": "AMS import accepts external JSON dump format."
-    },
-    {
-      "id": "apps/memory/src/inbox.ts:117:12#json-parse-file-read#bfb372ea2744",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/memory/src/inbox.ts:205:9#json-stringify-file-write#40e5b2ff1cf7",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/opencode-host/src/emit.ts:98:5#json-stringify-file-write#b44f40dea7d5",
-      "classification": "external",
-      "reason": "opencode.json is an OpenCode host manifest."
-    },
-    {
-      "id": "apps/opencode-host/src/generate.ts:264:5#json-stringify-file-write#e5e4aaa124d5",
-      "classification": "external",
-      "reason": "Generated OpenCode manifest is JSON by host contract."
-    },
-    {
-      "id": "apps/opencode-host/src/hooks-to-events.ts:564:13#json-parse-file-read#88fea6286137",
-      "classification": "external",
-      "reason": "OpenCode hook config is external JSON."
-    },
-    {
-      "id": "apps/opencode-host/src/mcp-passthrough.ts:70:12#json-parse-file-read#5c2085922680",
-      "classification": "external",
-      "reason": ".mcp.json is MCP ecosystem JSON."
-    },
-    {
-      "id": "apps/rsp/src/elision-store.ts:1341:20#json-parse-file-read#99e6919848c4",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/rsp/src/elision-store.ts:1400:9#json-stringify-file-write#0c59c09ca48a",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/rsp/src/two-axis-benchmark.ts:422:18#json-parse-file-read#cf04ec9f7556",
-      "classification": "external",
-      "reason": "Benchmark baseline fixture is JSON input."
-    },
-    {
-      "id": "apps/rsp/src/two-axis-benchmark.ts:428:18#json-parse-file-read#2acb36d5b74d",
-      "classification": "external",
-      "reason": "Benchmark baseline fixture is JSON input."
-    },
-    {
-      "id": "packages/browser-bridge/session.ts:133:3#json-stringify-file-write#270772003fae",
-      "classification": "migrate"
-    },
-    {
-      "id": "packages/browser-bridge/session.ts:160:3#json-stringify-file-write#cc2a0b9cb869",
-      "classification": "migrate"
-    },
-    {
-      "id": "packages/browser-bridge/session.ts:168:3#json-stringify-file-write#ec1ecd13fd33",
-      "classification": "migrate"
-    },
-    {
-      "id": "packages/browser-bridge/session.ts:55:12#json-parse-file-read#d2f26452dc19",
-      "classification": "migrate"
-    },
-    {
-      "id": "packages/browser-bridge/session.ts:89:3#json-stringify-file-write#9da22d37f254",
-      "classification": "migrate"
-    },
-    {
-      "id": "packages/red-castle/.red-castle/agent-workflows/shared/common.ts:44:3#json-stringify-file-write#dcc9303b3180",
-      "classification": "external",
-      "reason": "Castle workflow helper writes JSON interop artifacts."
-    },
-    {
-      "id": "packages/red-castle/src/WorktreeLock.ts:182:24#json-parse-file-read#3ba17a080cd9",
-      "classification": "migrate"
-    },
-    {
-      "id": "packages/red-castle/src/WorktreeLock.ts:53:22#json-parse-file-read#5a64faac4443",
-      "classification": "migrate"
-    },
-    {
-      "id": "packages/red-castle/src/WorktreeLock.ts:95:18#json-parse-file-read#e740dec46214",
-      "classification": "migrate"
-    },
-    {
-      "id": "packages/red-castle/tsup.config.ts:4:13#json-parse-file-read#6714d89c2000",
-      "classification": "external",
-      "reason": "package.json is ecosystem JSON."
-    },
-    {
-      "id": "packages/shared/entrypoint-cli.ts:257:12#json-parse-file-read#da57542f7f85",
+      "id": "apps/memory/src/hook-coverage.ts#json-parse-file-read#4f72ffcb65b4",
       "classification": "external",
       "reason": "Plugin manifest files are JSON by host contract."
     },
     {
-      "id": "packages/shared/toon-migration.ts:366:10#json-parse-file-read#15afb48d3ad6",
+      "id": "apps/memory/src/import-ams.ts#json-parse-file-read#84cfe0136522",
       "classification": "external",
-      "reason": "TOON migration accepts legacy JSON inputs."
+      "reason": "AMS import accepts external JSON dump format."
     },
     {
-      "id": "packages/shared/toon-migration.ts:469:12#json-parse-file-read#d7206ae9aa16",
+      "id": "apps/memory/src/inbox.ts#json-parse-file-read#3ed29a34b863",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/memory/src/inbox.ts#json-stringify-file-write#edcbaa2eb421",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/opencode-host/src/emit.ts#json-stringify-file-write#9bc9165f331e",
+      "classification": "external",
+      "reason": "opencode.json is an OpenCode host manifest."
+    },
+    {
+      "id": "apps/opencode-host/src/generate.ts#json-stringify-file-write#daef2b897070",
+      "classification": "external",
+      "reason": "Generated OpenCode manifest is JSON by host contract."
+    },
+    {
+      "id": "apps/opencode-host/src/hooks-to-events.ts#json-parse-file-read#75c187c88bc1",
+      "classification": "external",
+      "reason": "OpenCode hook config is external JSON."
+    },
+    {
+      "id": "apps/opencode-host/src/mcp-passthrough.ts#json-parse-file-read#399ed3f05e9d",
+      "classification": "external",
+      "reason": ".mcp.json is MCP ecosystem JSON."
+    },
+    {
+      "id": "apps/rsp/src/elision-store.ts#json-parse-file-read#02b50089d194",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/rsp/src/elision-store.ts#json-stringify-file-write#4cd974a313ee",
+      "classification": "migrate"
+    },
+    {
+      "id": "apps/rsp/src/two-axis-benchmark.ts#json-parse-file-read#df5d9468826b",
+      "classification": "external",
+      "reason": "Benchmark baseline fixture is JSON input."
+    },
+    {
+      "id": "packages/browser-bridge/session.ts#json-parse-file-read#e5efe89c117e",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/browser-bridge/session.ts#json-stringify-file-write#03a88404dc0f",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/browser-bridge/session.ts#json-stringify-file-write#3838fbf06b17",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/browser-bridge/session.ts#json-stringify-file-write#72a74a329bd7",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/browser-bridge/session.ts#json-stringify-file-write#d657022a1604",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/red-castle/.red-castle/agent-workflows/shared/common.ts#json-stringify-file-write#8975f393e830",
+      "classification": "external",
+      "reason": "Castle workflow helper writes JSON interop artifacts."
+    },
+    {
+      "id": "packages/red-castle/src/WorktreeLock.ts#json-parse-file-read#231944fa112d",
+      "classification": "migrate"
+    },
+    {
+      "id": "packages/red-castle/tsup.config.ts#json-parse-file-read#3ec8644e7f1e",
+      "classification": "external",
+      "reason": "package.json is ecosystem JSON."
+    },
+    {
+      "id": "packages/shared/entrypoint-cli.ts#json-parse-file-read#19e906dc0db9",
+      "classification": "external",
+      "reason": "Plugin manifest files are JSON by host contract."
+    },
+    {
+      "id": "packages/shared/toon-migration.ts#json-parse-file-read#5c446b349f65",
       "classification": "external",
       "reason": "TOON migration accepts legacy JSON inputs."
     }

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -118,7 +118,16 @@ export interface LandingDeps {
    * Absent (the default) → the guard is skipped (safe for the direct path and
    * existing callers that have not yet wired the dep).
    */
-  getDiffPaths?: () => Promise<{ changedFiles: string[]; packageJsonDiff: string }>;
+  getDiffPaths?: () => Promise<{
+    changedFiles: string[];
+    packageJsonDiff: string;
+    /**
+     * Diff-aware exemption for the TOON guard allowlist. Present when the branch
+     * touched it; `safe` is true when the edit only shrank the allowlist (no
+     * `external` entry added or changed), so the sensitive-path guard skips it.
+     */
+    allowlistExemption?: { path: string; safe: boolean };
+  }>;
   /**
    * Opt-in CI-aware merge for the UNLOCKED PR landing (#812). Present →
    * landPr polls the PR's merge state and merges only once it is genuinely
@@ -417,8 +426,8 @@ export async function doLanding(
   const landingInput = diffPaths ? { ...input, changedFiles: diffPaths.changedFiles } : input;
 
   if (diffPaths && input.sensitivePathApproved !== true) {
-    const { changedFiles, packageJsonDiff } = diffPaths;
-    const hits = checkSensitivePaths(changedFiles, packageJsonDiff);
+    const { changedFiles, packageJsonDiff, allowlistExemption } = diffPaths;
+    const hits = checkSensitivePaths(changedFiles, packageJsonDiff, allowlistExemption);
     if (hits.length > 0) {
       return { ok: false, reason: "sensitive-paths", locked, sensitivePaths: hits };
     }

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -937,6 +937,8 @@ import {
   validateIssueLifecycleTransition,
   type IssueLifecycleEdge,
 } from "./issue-lifecycle.js";
+import { allowlistExternalWidened } from "./shared-gate.js";
+import { ALLOWLIST_PATH } from "./toon-json-guard.js";
 
 /**
  * The typed `blocked:*` labels present in a label set (#402). Promoting an issue
@@ -2623,7 +2625,23 @@ export async function processIssue(
           "--",
           "package.json", "**/package.json",
         ]);
-        return { changedFiles, packageJsonDiff: diffRes.stdout };
+        // Diff-aware exemption for the TOON guard allowlist: a shrink-only edit
+        // (no `external` entry added or changed) is safe to auto-land, so a
+        // migration slice that only removes converted `migrate` entries does not
+        // park on the `.red/` sensitive-path guard. git show writes an empty
+        // stdout when the file is absent at a ref; the widening check fails
+        // closed on unparseable content.
+        let allowlistExemption: { path: string; safe: boolean } | undefined;
+        if (changedFiles.includes(ALLOWLIST_PATH)) {
+          const oldContent = (
+            await deps.mergeExec(["git", "-C", input.repoDir, "show", `${input.remote}/${base}:${ALLOWLIST_PATH}`])
+          ).stdout;
+          const newContent = (
+            await deps.mergeExec(["git", "-C", input.repoDir, "show", `${workerBranch}:${ALLOWLIST_PATH}`])
+          ).stdout;
+          allowlistExemption = { path: ALLOWLIST_PATH, safe: !allowlistExternalWidened(oldContent, newContent) };
+        }
+        return { changedFiles, packageJsonDiff: diffRes.stdout, allowlistExemption };
       },
       landingPhase: markLandingPhase,
     },

--- a/apps/dev/src/core/shared-gate.ts
+++ b/apps/dev/src/core/shared-gate.ts
@@ -243,6 +243,52 @@ export function hasLifecycleScriptInDiff(diffText: string): boolean {
 }
 
 /**
+ * Trust-preserving exemption for the TOON JSON-IO guard allowlist
+ * (`.red/contracts/toon-json-file-io-allowlist.json`). An `external` entry is a
+ * permanent JSON exception that BYPASSES the guard, so growing or changing that
+ * set is a trust decision that must be human-reviewed. A migration slice, by
+ * contrast, only ever SHRINKS the allowlist — it removes `migrate` entries as it
+ * converts JSON→TOON — which is safe to auto-land.
+ *
+ * Returns true when the `external` set GREW or CHANGED between `oldContent` and
+ * `newContent`: a new external id, or a changed reason on an existing one.
+ * Removing external entries, and any change to `migrate` entries, are safe (the
+ * guard still independently catches genuinely-new JSON). Unparseable new content
+ * is treated as widened — fail closed. PURE — no IO.
+ */
+export function allowlistExternalWidened(oldContent: string, newContent: string): boolean {
+  const externalSet = (content: string): Map<string, string> => {
+    const parsed = JSON.parse(content) as { entries?: unknown };
+    const out = new Map<string, string>();
+    if (Array.isArray(parsed.entries)) {
+      for (const entry of parsed.entries) {
+        const rec = entry as Record<string, unknown>;
+        if (rec.classification === "external") {
+          out.set(String(rec.id ?? ""), typeof rec.reason === "string" ? rec.reason : "");
+        }
+      }
+    }
+    return out;
+  };
+  let newExternal: Map<string, string>;
+  try {
+    newExternal = externalSet(newContent);
+  } catch {
+    return true; // fail closed: an unparseable new allowlist must be reviewed
+  }
+  let oldExternal: Map<string, string>;
+  try {
+    oldExternal = externalSet(oldContent);
+  } catch {
+    oldExternal = new Map(); // no trustworthy baseline → any external reads as new
+  }
+  for (const [id, reason] of newExternal) {
+    if (oldExternal.get(id) !== reason) return true;
+  }
+  return false;
+}
+
+/**
  * Scan `changedFiles` (repo-relative paths from the branch diff) and
  * `packageJsonDiff` (unified diff of any `package.json` files in the branch)
  * for sensitive-path hits. Returns an empty array when the diff is clean.
@@ -254,11 +300,16 @@ export function hasLifecycleScriptInDiff(diffText: string): boolean {
 export function checkSensitivePaths(
   changedFiles: string[],
   packageJsonDiff: string,
+  allowlistExemption?: { path: string; safe: boolean },
 ): SensitivePathHit[] {
   const hits: SensitivePathHit[] = [];
 
   for (const p of changedFiles) {
     if (isSensitivePath(p)) {
+      // Diff-aware exemption: a shrink-only edit to the TOON guard allowlist (no
+      // `external` entry added or changed) is safe to auto-land, so a migration
+      // slice that only removes converted `migrate` entries does not park.
+      if (allowlistExemption && p === allowlistExemption.path && allowlistExemption.safe) continue;
       hits.push({ path: p, reason: sensitivePathReason(p) });
     }
   }

--- a/apps/dev/src/core/toon-json-guard.ts
+++ b/apps/dev/src/core/toon-json-guard.ts
@@ -31,7 +31,7 @@ export interface ToonJsonSourceFile {
   sourceText: string;
 }
 
-const ALLOWLIST_PATH = ".red/contracts/toon-json-file-io-allowlist.json";
+export const ALLOWLIST_PATH = ".red/contracts/toon-json-file-io-allowlist.json";
 const SOURCE_EXTENSIONS = new Set([".js", ".cjs", ".mjs", ".ts", ".cts", ".mts", ".tsx"]);
 const SKIP_DIRS = new Set([
   ".git",
@@ -303,9 +303,13 @@ function makeFinding(
   const snippet = node.getText(sourceFile).replace(/\s+/g, " ").trim();
   const line = pos.line + 1;
   const column = pos.character + 1;
-  const hash = createHash("sha1").update(`${kind}\0${file.relativePath}\0${line}\0${column}\0${snippet}`).digest("hex").slice(0, 12);
+  // Snippet-anchored id: independent of line/column so a pure line shift (an
+  // unrelated edit above the site) never invalidates an allowlist entry. Only a
+  // change to the JSON statement text itself mints a new id (and warrants
+  // re-review). line/column survive as finding fields for the violation message.
+  const hash = createHash("sha1").update(`${kind}\0${file.relativePath}\0${snippet}`).digest("hex").slice(0, 12);
   return {
-    id: `${file.relativePath}:${line}:${column}#${kind}#${hash}`,
+    id: `${file.relativePath}#${kind}#${hash}`,
     kind,
     relativePath: file.relativePath,
     line,

--- a/apps/dev/tests/shared-gate.test.ts
+++ b/apps/dev/tests/shared-gate.test.ts
@@ -13,6 +13,7 @@ import {
   isSensitivePath,
   hasLifecycleScriptInDiff,
   checkSensitivePaths,
+  allowlistExternalWidened,
   type EscalationOutcome,
   type GateFinding,
   type SharedGateDeps,
@@ -496,6 +497,92 @@ describe("checkSensitivePaths — integrated guard", () => {
       "",
     );
     expect(hits).toHaveLength(0);
+  });
+});
+
+// ---------- diff-aware allowlist exemption ----------
+
+const ALLOWLIST_FILE = ".red/contracts/toon-json-file-io-allowlist.json";
+const allowlistJson = (entries: { id: string; classification: string; reason?: string }[]) =>
+  JSON.stringify({ version: 1, entries }, null, 2);
+const mig = (id: string) => ({ id, classification: "migrate" });
+const ext = (id: string, reason: string) => ({ id, classification: "external", reason });
+
+describe("checkSensitivePaths — diff-aware allowlist exemption", () => {
+  it("does NOT flag a shrink-only allowlist edit (safe exemption)", () => {
+    const hits = checkSensitivePaths([ALLOWLIST_FILE, "apps/memory/src/inbox.ts"], "", {
+      path: ALLOWLIST_FILE,
+      safe: true,
+    });
+    expect(hits).toHaveLength(0);
+  });
+
+  it("flags the allowlist when the exemption is unsafe (external widened)", () => {
+    const hits = checkSensitivePaths([ALLOWLIST_FILE], "", { path: ALLOWLIST_FILE, safe: false });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].path).toBe(ALLOWLIST_FILE);
+    expect(hits[0].reason).toMatch(/trust\/gate/);
+  });
+
+  it("flags the allowlist with no exemption provided (backwards-compatible default)", () => {
+    expect(checkSensitivePaths([ALLOWLIST_FILE], "")).toHaveLength(1);
+  });
+
+  it("the exemption covers only its own path — other .red/ files still flag", () => {
+    const hits = checkSensitivePaths([ALLOWLIST_FILE, ".red/config.yaml"], "", {
+      path: ALLOWLIST_FILE,
+      safe: true,
+    });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].path).toBe(".red/config.yaml");
+  });
+});
+
+describe("allowlistExternalWidened — trust-preserving allowlist diff", () => {
+  it("removing a migrate entry is safe (not widened)", () => {
+    const oldC = allowlistJson([mig("a#k#1"), mig("b#k#2"), ext("c#k#3", "MCP config")]);
+    const newC = allowlistJson([mig("a#k#1"), ext("c#k#3", "MCP config")]);
+    expect(allowlistExternalWidened(oldC, newC)).toBe(false);
+  });
+
+  it("removing an external entry is safe (shrinking the exception set)", () => {
+    const oldC = allowlistJson([ext("c#k#3", "MCP config"), mig("a#k#1")]);
+    const newC = allowlistJson([mig("a#k#1")]);
+    expect(allowlistExternalWidened(oldC, newC)).toBe(false);
+  });
+
+  it("adding a new external entry is widened (unsafe)", () => {
+    const oldC = allowlistJson([mig("a#k#1")]);
+    const newC = allowlistJson([mig("a#k#1"), ext("new#k#9", "sneaked in")]);
+    expect(allowlistExternalWidened(oldC, newC)).toBe(true);
+  });
+
+  it("changing an external entry's reason is widened (unsafe)", () => {
+    const oldC = allowlistJson([ext("c#k#3", "MCP config")]);
+    const newC = allowlistJson([ext("c#k#3", "now something else")]);
+    expect(allowlistExternalWidened(oldC, newC)).toBe(true);
+  });
+
+  it("flipping a migrate entry to external is widened (unsafe)", () => {
+    const oldC = allowlistJson([mig("a#k#1")]);
+    const newC = allowlistJson([ext("a#k#1", "reclassified")]);
+    expect(allowlistExternalWidened(oldC, newC)).toBe(true);
+  });
+
+  it("adding a migrate entry is safe (tracked debt, not a guard bypass)", () => {
+    const oldC = allowlistJson([mig("a#k#1")]);
+    const newC = allowlistJson([mig("a#k#1"), mig("b#k#2")]);
+    expect(allowlistExternalWidened(oldC, newC)).toBe(false);
+  });
+
+  it("unparseable new content fails closed (treated as widened)", () => {
+    const oldC = allowlistJson([mig("a#k#1")]);
+    expect(allowlistExternalWidened(oldC, "{ not json")).toBe(true);
+  });
+
+  it("identical content is not widened", () => {
+    const c = allowlistJson([mig("a#k#1"), ext("c#k#3", "MCP config")]);
+    expect(allowlistExternalWidened(c, c)).toBe(false);
   });
 });
 

--- a/apps/dev/tests/toon-json-guard.test.ts
+++ b/apps/dev/tests/toon-json-guard.test.ts
@@ -43,4 +43,18 @@ describe("toon JSON file I/O guard", () => {
 
     expect(formatToonJsonGuardViolations({ findings, allowlist })).toEqual([]);
   });
+
+  it("mints a line-independent id — a pure line shift keeps the allowlist entry valid", () => {
+    const write = `writeFileSync(join(root, "state.json"), JSON.stringify({ ok: true }), "utf8");`;
+    const near = `import { writeFileSync } from "node:fs";\nimport { join } from "node:path";\nexport function persistState(root: string) {\n  ${write}\n}\n`;
+    const shifted = `import { writeFileSync } from "node:fs";\nimport { join } from "node:path";\n// an unrelated comment\n// and another line\n// and a third line above the site\nexport function persistState(root: string) {\n  ${write}\n}\n`;
+    const [a] = collectToonJsonIoFindingsFromFiles([
+      { relativePath: "apps/example/src/state.ts", sourceText: near },
+    ]);
+    const [b] = collectToonJsonIoFindingsFromFiles([
+      { relativePath: "apps/example/src/state.ts", sourceText: shifted },
+    ]);
+    expect(a!.line).not.toBe(b!.line); // the statement genuinely moved
+    expect(a!.id).toBe(b!.id); // ...but the snippet-anchored id is stable
+  });
 });


### PR DESCRIPTION
## Diff-aware sensitive-path gate for the TOON allowlist + line-tolerant guard ids

**Unblocks the TOON migration (Spec #2081).** The ratchet guard from #2091 made every migration slice un-drainable: each slice must edit the trust-config allowlist (`.red/contracts/toon-json-file-io-allowlist.json`) to remove the `migrate` entries it converts, and **any** `.red/` edit trips the sensitive-path guard → `blocked:sensitive-path`. #2083 (S1) and #2084 (S2) both parked for exactly this. The fleet cannot drain the migration it was designed to drain.

### 1. Snippet-anchor the guard id (line-tolerance)
`id = hash(kind, path, snippet)` — the `line:col` is dropped from the id (kept as finding fields for messages). A pure line shift (an unrelated edit above a JSON site) no longer invalidates an allowlist entry; **only a change to the JSON statement text** mints a new id. This fixes the brittleness that red an unrelated PR (#2092 shifted `wire.ts` by one import line and had to re-anchor two entries).

Identical statements in one file now collapse to one entry. Verified there are **no mixed-classification collisions** — all 6 collision groups are the same statement with the same classification (e.g. two `writeFileSync(lockPath, payload, …)` in `wire.ts`, three `JSON.parse(raw)` in `WorktreeLock.ts`). 62 findings → **55 distinct statements** (27 external / 28 migrate).

### 2. Diff-aware sensitive-path exemption
A **shrink-only** allowlist edit — one that adds or changes no `external` entry — is safe to auto-land. Rationale: `external` is the *only* classification that **bypasses** the guard, so growing/changing that set is a trust decision that must be reviewed; `migrate` is tracked debt the guard still catches independently.

- `allowlistExternalWidened(oldContent, newContent)` (pure) — compares the `external` set (id → reason) of base vs branch. Returns true (park) if any external is **added**, has its **reason changed**, or a migrate is **flipped to external**. Removing external, and any migrate change, are safe. **Fails closed** on unparseable new content.
- The gate provider (`process-issue`) `git show`s both revisions of the allowlist and passes the verdict; `checkSensitivePaths` skips the hit **only** for the allowlist path **only** when safe. Every other `.red/` file still parks unconditionally.

### Net effect
Migration slices (S2/S3/S4) drain autonomously because they only *remove* `migrate` entries. Widening the trust exceptions (adding/altering `external`) still parks for human review — the security property is preserved.

### Tests
- `toon-json-guard.test.ts`: line-independent id (same statement at line 4 vs 7 → identical id).
- `shared-gate.test.ts`: 8 `allowlistExternalWidened` cases (remove/add/change × migrate/external, fail-closed) + 4 exemption-integration cases.
- All pure logic validated against the live tree (guard green: 62 findings / 55 entries / 0 violations; 14/14 logic checks).

Follow-up option: an ADR recording "allowlist shrink-only edits are exempt from sensitive-path review" for the audit trail — happy to add if wanted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786947194&installation_id=129708444&pr_number=2093&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2093&signature=18eebfaa2c4a834d3c1fb20afaab8839c364067c699bd5f9159ef5e8628ecfd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->