### PR TITLE
fix: keep typescript out of the runtime bundle (decouple ALLOWLIST_PATH)

### DIFF
--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -937,8 +937,7 @@ import {
   validateIssueLifecycleTransition,
   type IssueLifecycleEdge,
 } from "./issue-lifecycle.js";
-import { allowlistExternalWidened } from "./shared-gate.js";
-import { ALLOWLIST_PATH } from "./toon-json-guard.js";
+import { allowlistExternalWidened, ALLOWLIST_PATH } from "./shared-gate.js";
 
 /**
  * The typed `blocked:*` labels present in a label set (#402). Promoting an issue

--- a/apps/dev/src/core/shared-gate.ts
+++ b/apps/dev/src/core/shared-gate.ts
@@ -185,6 +185,14 @@ export async function runSharedGate(
  * list AND update the issue. The default is SAFE: anything not on this list
  * proceeds normally.
  */
+/**
+ * The TOON JSON-IO guard allowlist path. Defined here (a typescript-free leaf
+ * module) rather than in `toon-json-guard.ts` so runtime code — `process-issue`
+ * consumes it for the diff-aware exemption — never imports the guard, which
+ * pulls the full `typescript` compiler into the bundle (it is test-only).
+ */
+export const ALLOWLIST_PATH = ".red/contracts/toon-json-file-io-allowlist.json";
+
 export const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
   /^\.github\/workflows\//,     // CI workflow files
   /^\.github\/actions\//,       // composite actions executed by CI workflows

--- a/apps/dev/src/core/toon-json-guard.ts
+++ b/apps/dev/src/core/toon-json-guard.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 import ts from "typescript";
+import { ALLOWLIST_PATH } from "./shared-gate.js";
 
 export type ToonJsonIoKind = "json-parse-file-read" | "json-stringify-file-write";
 export type ToonJsonAllowlistClassification = "migrate" | "external";
@@ -31,7 +32,6 @@ export interface ToonJsonSourceFile {
   sourceText: string;
 }
 
-export const ALLOWLIST_PATH = ".red/contracts/toon-json-file-io-allowlist.json";
 const SOURCE_EXTENSIONS = new Set([".js", ".cjs", ".mjs", ".ts", ".cts", ".mts", ".tsx"]);
 const SKIP_DIRS = new Set([
   ".git",

--- a/apps/dev/tests/toon-json-guard.test.ts
+++ b/apps/dev/tests/toon-json-guard.test.ts
@@ -1,4 +1,5 @@
-import { join } from "node:path";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   collectToonJsonGuardReport,
@@ -8,6 +9,7 @@ import {
 } from "../src/core/toon-json-guard.js";
 
 const ROOT = join(import.meta.dirname, "..", "..", "..");
+const DEV_SRC = join(import.meta.dirname, "..", "src");
 
 describe("toon JSON file I/O guard", () => {
   it("ratchets the live apps/packages JSON file I/O allowlist", async () => {
@@ -56,5 +58,28 @@ describe("toon JSON file I/O guard", () => {
     ]);
     expect(a!.line).not.toBe(b!.line); // the statement genuinely moved
     expect(a!.id).toBe(b!.id); // ...but the snippet-anchored id is stable
+  });
+
+  it("stays test-only — no runtime src imports the guard or typescript (keeps the compiler out of the bundle)", () => {
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(p);
+          continue;
+        }
+        if (!entry.name.endsWith(".ts") || entry.name.includes(".test.") || entry.name === "toon-json-guard.ts") continue;
+        const text = readFileSync(p, "utf8");
+        if (/from ["'][^"']*toon-json-guard(\.js)?["']/.test(text) || /from ["']typescript["']/.test(text)) {
+          offenders.push(relative(ROOT, p));
+        }
+      }
+    };
+    walk(DEV_SRC);
+    // The guard imports the full `typescript` compiler; if any other runtime src
+    // imports the guard (or typescript directly) it lands in dev.bundle.min.mjs
+    // — the regression the release contract check caught. Keep it test-only.
+    expect(offenders).toEqual([]);
   });
 });


### PR DESCRIPTION
## Keep `typescript` out of the runtime bundle

**The 2.71.0 release failed** at the producer/consumer contract check: it packed the bundle, ran it, and crashed at `dev.bundle.min.mjs:551` — which is TypeScript's tokenizer. The full `typescript` compiler (~10MB) had been bundled into the runtime.

**Cause:** #2093 added `import { ALLOWLIST_PATH } from "./toon-json-guard.js"` to `process-issue.ts` — a runtime module. `toon-json-guard.ts` imports `typescript` for AST parsing (it's a CI-test utility), so that single import made the compiler reachable from the `cli.ts` entry graph, and esbuild bundled it.

**Fix:** move `ALLOWLIST_PATH` (a plain string constant) into `shared-gate.ts` — a typescript-free leaf module. Both `process-issue.ts` and `toon-json-guard.ts` now import it from there. No runtime module reaches the guard, so the bundle drops `typescript`. Verified: zero runtime src files import the guard; the guard itself still runs green (62 findings / 55 allowlist / 0 violations).

**Regression guard:** a new test asserts no runtime `src` file imports the guard or `typescript`. The PR gate doesn't build the bundle (only the release contract check does — which is why this slipped to release time), so the test moves the invariant left into every PR.

Unblocks re-cutting 2.71.0 with the diff-aware gate (#2093), the pid-anchor fix (#2092), and the TOON guard (#2091).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786966089&installation_id=129708444&pr_number=2094&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2094&signature=66c25766b20ab1434e09fd8b070fa660252f37ffccf66af7d5278aaf8811fdd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->