### PR TITLE
feat: #2084 TOON completion S2 — migrate apps/dev JSON to TOON

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -19,50 +19,14 @@
       "classification": "migrate"
     },
     {
-      "id": "apps/dev/src/commands/activity-review.ts#json-parse-file-read#7155e41a10b1",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/dev/src/commands/activity-review.ts#json-stringify-file-write#fb01f23f34a6",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/dev/src/commands/requeue.ts#json-stringify-file-write#e451b52ded48",
-      "classification": "migrate"
-    },
-    {
       "id": "apps/dev/src/commands/run.ts#json-parse-file-read#01a38c1e6f6a",
       "classification": "external",
       "reason": "Fetched plugin manifest remains JSON at the package boundary."
     },
     {
-      "id": "apps/dev/src/commands/run.ts#json-parse-file-read#78cdbf004ef3",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/dev/src/commands/run.ts#json-parse-file-read#c6341de5e558",
-      "classification": "migrate"
-    },
-    {
       "id": "apps/dev/src/commands/run.ts#json-stringify-file-write#3368a1bbf848",
       "classification": "external",
       "reason": "Temporary Brain CLI handoff payload is an interop export."
-    },
-    {
-      "id": "apps/dev/src/commands/run.ts#json-stringify-file-write#5a38957c5d3c",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/dev/src/commands/run.ts#json-stringify-file-write#982a128ff187",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/dev/src/commands/run.ts#json-stringify-file-write#b7e3f9d05b27",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/dev/src/core/bundle-version.ts#json-parse-file-read#3a978a412439",
-      "classification": "migrate"
     },
     {
       "id": "apps/dev/src/core/toon-json-guard.ts#json-parse-file-read#0f36cd7ce70f",

--- a/apps/dev/src/commands/activity-review.ts
+++ b/apps/dev/src/commands/activity-review.ts
@@ -22,6 +22,7 @@ import {
 import { readHistoryRecords, type HistoryRecord } from "../core/history.js";
 import { collectMonitorInputs, afkPaths, resolveRepoContext } from "../runtime/wire.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
+import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 
 /** Output format. TOON is the default agent-facing wire format (PRD #928 / ADR
  * 0081); `--json` forces raw JSON (tooling/escape hatch), `--human` the prose. */
@@ -332,7 +333,7 @@ function validTokenFileCache(value: unknown): TokenFileCache | null {
 
 async function readTokenSummaryCache(path: string): Promise<TokenSummaryCache> {
   try {
-    const parsed = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    const parsed = decodeDevSnapshotSniff(await readFile(path, "utf8")) as Record<string, unknown>;
     if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
     const out: TokenSummaryCache = {};
     for (const [file, value] of Object.entries(parsed)) {
@@ -346,7 +347,7 @@ async function readTokenSummaryCache(path: string): Promise<TokenSummaryCache> {
 }
 
 async function writeTokenSummaryCache(path: string, cache: TokenSummaryCache): Promise<void> {
-  await writeFile(path, `${JSON.stringify(cache)}\n`, "utf8");
+  await writeFile(path, encodeDevSnapshotToon(cache as unknown as Parameters<typeof encodeDevSnapshotToon>[0]), "utf8");
 }
 
 async function listRetainedLogFiles(workersRoot: string): Promise<string[]> {

--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -19,6 +19,7 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
+import { encodeLines } from "@reddb-io/toon";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
 import { scrubOutbound } from "../runtime/outbound-redaction.js";
@@ -231,7 +232,7 @@ function appendAdoptLivenessRecord(attemptDir: string): void {
     mkdirSync(attemptDir, { recursive: true });
     appendFileSync(
       join(attemptDir, LIVENESS_LANE_FILENAME),
-      `${JSON.stringify({ at: Date.now(), kind: "iteration-start" })}\n`,
+      encodeLines().push({ at: Date.now(), kind: "iteration-start" }),
     );
   } catch {
     // best-effort: the presence row still renders on pid liveness alone.

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -88,6 +88,7 @@ import { join } from "node:path";
 import { hostFingerprintPrefix, workerIdentity } from "../core/host-identity.js";
 import { appendAgentRecord, appendRecordToonlTaggedRow } from "../core/jsonl-log.js";
 import { initStateSync, readPidStartTime, updateState, writeIdentitySync } from "../core/state.js";
+import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat.js";
 import { resolveAttemptLoc, locMemoPath, type LocMemo } from "../core/loc-memo.js";
 import { createActivityMeter } from "../core/activity-meter.js";
@@ -1442,16 +1443,11 @@ export function buildProcessDeps(
           computeUncommitted: () =>
             gitx.diffstatUncommitted({ cwd: worktree }).catch(() => ({ added: 0, removed: 0 })),
           readMemo: () => {
-            try {
-              const m = JSON.parse(readFileSync(memoPath, "utf8")) as Partial<LocMemo>;
-              return { sha: String(m.sha ?? ""), added: Number(m.added ?? 0), removed: Number(m.removed ?? 0) };
-            } catch {
-              return null;
-            }
+            return decodeLocMemoSnapshot(readFileSync(memoPath, "utf8"));
           },
           writeMemo: (m) => {
             try {
-              writeFileSync(memoPath, JSON.stringify(m), "utf8");
+              writeFileSync(memoPath, encodeLocMemoSnapshot(m), "utf8");
             } catch {
               // best-effort, like the surrounding heartbeat writes
             }
@@ -1794,17 +1790,57 @@ interface CurrentAttempt {
 
 const DEFAULT_RUNNER_TRANSIENT_COOLDOWN_S = 300;
 
+export function decodeLocMemoSnapshot(text: string): LocMemo | null {
+  try {
+    const m = decodeDevSnapshotSniff(text) as Partial<LocMemo>;
+    return { sha: String(m.sha ?? ""), added: Number(m.added ?? 0), removed: Number(m.removed ?? 0) };
+  } catch {
+    return null;
+  }
+}
+
+export function encodeLocMemoSnapshot(memo: LocMemo): string {
+  return encodeDevSnapshotToon(memo as unknown as Parameters<typeof encodeDevSnapshotToon>[0]);
+}
+
+export function encodeRunnerCircuitSnapshot(state: {
+  runner: Runner;
+  opened_at: number;
+  expires_at: number;
+  reason: "runner-transient";
+}): string {
+  return encodeDevSnapshotToon(state);
+}
+
+export function decodeRunnerCircuitSnapshot(text: string): { expires_at?: unknown } {
+  return decodeDevSnapshotSniff(text) as { expires_at?: unknown };
+}
+
+export function encodeBootErrorPayload(payload: {
+  type: "boot-error" | "session-error";
+  at: string;
+  message: string;
+  stack?: string;
+}): string {
+  return encodeDevSnapshotToon(payload);
+}
+
 async function recordBootError(workerDir: string, type: "boot-error" | "session-error", err: unknown): Promise<void> {
   const message = err instanceof Error ? err.message : String(err);
   const stack = err instanceof Error ? err.stack : undefined;
-  const payload = {
+  const payload: {
+    type: "boot-error" | "session-error";
+    at: string;
+    message: string;
+    stack?: string;
+  } = {
     type,
     at: new Date().toISOString(),
     message,
     stack,
   };
   await fsx.ensureDir(workerDir);
-  await writeFile(join(workerDir, `${type}.log`), `${JSON.stringify(payload)}\n`, "utf8");
+  await writeFile(join(workerDir, `${type}.log`), encodeBootErrorPayload(payload), "utf8");
   process.stderr.write(`[afk] ${type}: ${message}\n`);
 }
 
@@ -1831,12 +1867,12 @@ async function openRunnerCircuit(
   await fsx.ensureDir(circuitDir);
   await writeFile(
     runnerCircuitPath(circuitDir, runner),
-    `${JSON.stringify({
+    encodeRunnerCircuitSnapshot({
       runner,
       opened_at: nowS,
       expires_at: nowS + cooldownS,
       reason: "runner-transient",
-    })}\n`,
+    }),
     "utf8",
   );
 }
@@ -1848,7 +1884,7 @@ async function runnerCircuitOpen(
 ): Promise<boolean> {
   try {
     const raw = await readFile(runnerCircuitPath(circuitDir, runner), "utf8");
-    const parsed = JSON.parse(raw) as { expires_at?: unknown };
+    const parsed = decodeRunnerCircuitSnapshot(raw);
     return typeof parsed.expires_at === "number" && parsed.expires_at > nowS;
   } catch {
     return false;

--- a/apps/dev/src/core/bundle-version.ts
+++ b/apps/dev/src/core/bundle-version.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { fetchNewestSameMajor } from "@reddb-io/shared/bundle-fetch.js";
 import { pointerFileName, readPointer, statusFileName, type SelfUpdateStateRecord } from "@reddb-io/shared/self-update.js";
+import { decodeDevSnapshotSniff } from "./toon-snapshot.js";
 
 export function semverParts(version: string | undefined): [number, number, number] | null {
   const m = /^(\d+)\.(\d+)\.(\d+)/.exec(String(version ?? "").trim());
@@ -106,7 +107,7 @@ function readPointerVersion(path: string): string | undefined {
 
 function readSelfUpdateState(path: string): SelfUpdateStateRecord {
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    const parsed = decodeDevSnapshotSniff(readFileSync(path, "utf8")) as Record<string, unknown>;
     return {
       ...(Number.isFinite(parsed.lastFailureAtMs) ? { lastFailureAtMs: Number(parsed.lastFailureAtMs) } : {}),
       ...(typeof parsed.lastError === "string" ? { lastError: parsed.lastError } : {}),

--- a/apps/dev/tests/activity-review.test.ts
+++ b/apps/dev/tests/activity-review.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -250,6 +250,11 @@ describe("activity review", () => {
 
     const first = await collectTokenSummary(root, start, end);
     expect(first).toEqual({ available: true, input: 7, output: 11, total: null, sourceRecords: 1 });
+    const cacheRaw = await readFile(join(root, ".activity-review-token-cursors.json"), "utf8");
+    expect(cacheRaw.trimStart().startsWith("{")).toBe(false);
+    expect(Object.values(decode(cacheRaw) as Record<string, unknown>)[0]).toMatchObject({
+      rows: [{ input: 7, output: 11, total: 0 }],
+    });
 
     await appendRecordToonlTaggedRow(log, "raw", { iteration: 2, line: "{\"inputTokens\":13,\"outputTokens\":17}" }, {
       ts: "2026-07-15T12:05:00.000Z",

--- a/apps/dev/tests/bundle-version.test.ts
+++ b/apps/dev/tests/bundle-version.test.ts
@@ -1,0 +1,34 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { statusFileName } from "@reddb-io/shared/self-update.js";
+import { describe, expect, it } from "vitest";
+import { readDevBundleCacheState } from "../src/core/bundle-version.js";
+import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
+
+describe("dev bundle cache state", () => {
+  it("reads the self-update state through the TOON sniff decoder", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dev-bundle-cache-"));
+    try {
+      mkdirSync(root, { recursive: true });
+      writeFileSync(
+        join(root, statusFileName("dev")),
+        encodeDevSnapshotToon({
+          lastFailureAtMs: 100,
+          lastError: "fetch failed",
+        }),
+        "utf8",
+      );
+
+      expect(readDevBundleCacheState("2.71.0", { RED_SKILLS_CACHE_DIR: root }, 160)).toMatchObject({
+        installedVersion: "2.71.0",
+        lastFailureAtMs: 100,
+        lastFailureAgeMs: 60,
+        lastError: "fetch failed",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/dev/tests/run-flags.test.ts
+++ b/apps/dev/tests/run-flags.test.ts
@@ -1,5 +1,16 @@
+import { decode } from "@reddb-io/toon";
 import { describe, expect, it } from "vitest";
-import { parseRunFlags, RunFlagError, deriveActivity, resolveRunDispatchIdentity } from "../src/commands/run.js";
+import {
+  decodeLocMemoSnapshot,
+  decodeRunnerCircuitSnapshot,
+  encodeBootErrorPayload,
+  encodeLocMemoSnapshot,
+  encodeRunnerCircuitSnapshot,
+  parseRunFlags,
+  RunFlagError,
+  deriveActivity,
+  resolveRunDispatchIdentity,
+} from "../src/commands/run.js";
 import type { AgentStreamEvent } from "../src/core/execution.js";
 
 describe("deriveActivity (native-path monitor stage detection)", () => {
@@ -91,6 +102,44 @@ describe("deriveActivity (native-path monitor stage detection)", () => {
 
   it("returns undefined for an unrecognised tool with no stage signal", () => {
     expect(deriveActivity(tool("WebFetch", "https://example.com"))).toBeUndefined();
+  });
+});
+
+describe("run command TOON state snapshots", () => {
+  it("round-trips the LOC memo through TOON and still reads legacy JSON", () => {
+    const memo = { sha: "abc123", added: 12, removed: 3 };
+    const toon = encodeLocMemoSnapshot(memo);
+
+    expect(toon.trimStart().startsWith("{")).toBe(false);
+    expect(decodeLocMemoSnapshot(toon)).toEqual(memo);
+    expect(decodeLocMemoSnapshot(JSON.stringify(memo))).toEqual(memo);
+  });
+
+  it("round-trips the runner circuit through TOON and still reads legacy JSON", () => {
+    const state = {
+      runner: "codex" as const,
+      opened_at: 100,
+      expires_at: 400,
+      reason: "runner-transient" as const,
+    };
+    const toon = encodeRunnerCircuitSnapshot(state);
+
+    expect(toon.trimStart().startsWith("{")).toBe(false);
+    expect(decodeRunnerCircuitSnapshot(toon)).toEqual(state);
+    expect(decodeRunnerCircuitSnapshot(JSON.stringify(state))).toEqual(state);
+  });
+
+  it("writes worker boot/session error payloads as TOON", () => {
+    const payload = {
+      type: "boot-error" as const,
+      at: "2026-07-18T00:00:00.000Z",
+      message: "runner unavailable",
+      stack: "Error: runner unavailable",
+    };
+    const toon = encodeBootErrorPayload(payload);
+
+    expect(toon.trimStart().startsWith("{")).toBe(false);
+    expect(decode(toon)).toEqual(payload);
   });
 });
 


### PR DESCRIPTION
Lands the completed S2 migration (worker wQJ6E's branch) by PR, bypassing the fleet's false-merge-conflict landing loop (branch is provably linear on main). Closes #2084.

Diff-aware gate E2E: this shrinks the apps/dev `migrate` allowlist entries — the first real test that the diff-aware sensitive-path gate + snippet-anchored guard land a shrink-only allowlist edit through CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786969787&installation_id=129708444&pr_number=2095&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2095&signature=ed5df622a7d386bedbd73805ada3b55961163be99c801ad185256f522214b1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->