### PR TITLE
fix: BEHIND merge-state is not a conflict — stop the phantom-conflict land loop

### DIFF
--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -380,8 +380,9 @@ export async function waitForReviewCheck(
  *   - `merge`     — ready to merge (CLEAN, or non-required checks flaky; BLOCKED
  *                   by a required review is attempted and surfaces as `merge-failed`
  *                   rather than being bypassed).
- *   - `conflict`  — a real git conflict / DIRTY / BEHIND (non-fast-forward). Maps
- *                   to the existing bounded `merge-conflict` recovery.
+ *   - `conflict`  — a genuine git conflict (DIRTY / `mergeable=CONFLICTING`).
+ *                   Maps to the existing bounded `merge-conflict` recovery.
+ *                   BEHIND is deliberately NOT here — see `classifyMergeState`.
  *   - `ci-failed` — a required check FAILED. A distinct outcome so the next
  *                   attempt fixes the red check, not a blind full re-run.
  *   - `pending`   — required checks still running / GitHub still computing. The
@@ -468,22 +469,30 @@ export function parseMergeStateView(stdout: string): MergeStateView {
 
 /**
  * Decide the merge readiness from the parsed merge state. Order matters:
- *   1. DIRTY / BEHIND → a real git conflict / non-fast-forward → `conflict`.
+ *   1. DIRTY → a genuine conflict (GitHub `mergeable=CONFLICTING`) → `conflict`.
  *   2. any required check FAILED → `ci-failed` (even when GitHub still reports
  *      BLOCKED — a failed check never clears by waiting).
- *   3. CLEAN → `merge`.
- *   4. any check still running → `pending` (keep waiting).
- *   5. BLOCKED with neither failures nor pending checks → likely blocked by a
+ *   3. BEHIND → the head is merely out of date vs the base (still MERGEABLE,
+ *      unlike DIRTY). NOT a conflict: `preMergeRebase` already integrated the
+ *      base before the PR, so a BEHIND at check time is GitHub still settling
+ *      mergeability or a benign race → `pending` (re-poll; it settles to
+ *      CLEAN/UNSTABLE → `merge`, or the poll times out and the OPEN PR is handed
+ *      off). Treating BEHIND as a conflict caused the #2084 phantom-conflict
+ *      concede-loop — a provably fast-forwardable branch looping forever.
+ *   4. CLEAN → `merge`.
+ *   5. any check still running → `pending` (keep waiting).
+ *   6. BLOCKED with neither failures nor pending checks → likely blocked by a
  *      required REVIEW; attempts merge, which surfaces as `merge-failed` if the
  *      repository's branch protection requires a review (correct: honored, not
  *      bypassed) → `merge`.
- *   6. UNSTABLE / HAS_HOOKS (mergeable; only non-required checks unsettled) → `merge`.
- *   7. UNKNOWN / DRAFT / empty → `pending` (GitHub still computing mergeability).
+ *   7. UNSTABLE / HAS_HOOKS (mergeable; only non-required checks unsettled) → `merge`.
+ *   8. UNKNOWN / DRAFT / empty → `pending` (GitHub still computing mergeability).
  */
 export function classifyMergeState(view: MergeStateView): MergeReadiness {
   const s = up(view.mergeStateStatus);
-  if (s === "DIRTY" || s === "BEHIND") return "conflict";
+  if (s === "DIRTY") return "conflict";
   if (view.anyFailed) return "ci-failed";
+  if (s === "BEHIND") return "pending";
   if (s === "CLEAN") return "merge";
   if (view.anyPending) return "pending";
   if (s === "BLOCKED") return "merge";

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -559,8 +559,16 @@ describe("CI-aware merge classification (#812)", () => {
     expect(classifyMergeState(view("DIRTY"))).toBe("conflict");
   });
 
-  it("BEHIND (non-fast-forward) → conflict", () => {
-    expect(classifyMergeState(view("BEHIND"))).toBe("conflict");
+  it("BEHIND (out of date, still mergeable) → pending, NOT conflict (the #2084 phantom-conflict loop)", () => {
+    // preMergeRebase already integrated the base before the PR, so a BEHIND at
+    // check time is transient / a benign race — resolved by re-polling, never a
+    // terminal merge-conflict concede-loop on a provably fast-forwardable branch.
+    expect(classifyMergeState(view("BEHIND"))).toBe("pending");
+  });
+
+  it("BEHIND with a FAILED required check → ci-failed (surface the real failure, do not loop)", () => {
+    const v = view("BEHIND", [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }]);
+    expect(classifyMergeState(v)).toBe("ci-failed");
   });
 
   it("BLOCKED with a FAILED required check → ci-failed", () => {


### PR DESCRIPTION
## BEHIND is not a conflict — stop the phantom-conflict land loop

**This is the root cause of the recurring TOON-slice rework.** `classifyMergeState` (merge.ts) treated GitHub's `mergeStateStatus === "BEHIND"` as `"conflict"`, the same terminal outcome as `DIRTY`. But the two are different:
- **DIRTY** = `mergeable=CONFLICTING` — a genuine, unresolvable merge conflict.
- **BEHIND** = `mergeable=MERGEABLE` — the head is merely *out of date* vs the base. Fully mergeable, just needs the branch updated.

`preMergeRebase` already integrates the base before the PR is opened, so a `BEHIND` at merge-check time is GitHub still settling mergeability (async) or a benign race. Classifying it as a conflict made the landing **park/concede a provably fast-forwardable branch** → a fresh worker re-did the whole slice → hit the same phantom `BEHIND` → conceded again → forever.

### Proof
#2084's worker branch was reported `merge-conflict` (with "no merge log captured" — a *state read*, not a git conflict) and concede-looped for hours. The **identical branch**, opened as PR #2095, reported `mergeable=MERGEABLE, mergeStateStatus=UNSTABLE` and merged green — delivering S2. The work was always fine; the classifier was wrong.

### Fix
`BEHIND` now routes to `pending`: re-poll until it settles to `CLEAN`/`UNSTABLE` (→ `merge`), or the poll times out and the **OPEN PR is handed off** (never re-run, never a concede-loop). `DIRTY` remains `conflict`; `BEHIND` with a failed required check still surfaces as `ci-failed`. Flips the stale test that asserted the buggy `BEHIND → conflict`, and adds the ci-failed-precedence case.

Unblocks the fleet from re-draining #2085/#2086 (and all future work) without the phantom loop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786970173&installation_id=129708444&pr_number=2096&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2096&signature=727a8799888295a4b85578056d11ce5abd6bc499bbc9fad01c622d3ee0976e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->