### PR TITLE
feat: #2085 TOON completion S3 — migrate apps/memory JSON to TOON

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -48,18 +48,6 @@
       "classification": "migrate"
     },
     {
-      "id": "apps/memory/src/backup.ts#json-parse-file-read#1d64c7ed63c2",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/memory/src/backup.ts#json-stringify-file-write#319d7ee767e0",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/memory/src/backup.ts#json-stringify-file-write#d490a167d82e",
-      "classification": "migrate"
-    },
-    {
       "id": "apps/memory/src/bench-eval.ts#json-parse-file-read#9f8ee3a49186",
       "classification": "external",
       "reason": "Benchmark question fixtures are JSON inputs."
@@ -95,14 +83,6 @@
       "reason": "Export command deliberately emits JSON artifacts."
     },
     {
-      "id": "apps/memory/src/competitive-baseline.ts#json-stringify-file-write#1fd6fed03b3a",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/memory/src/config.ts#json-parse-file-read#2b08c55aae9a",
-      "classification": "migrate"
-    },
-    {
       "id": "apps/memory/src/export.ts#json-stringify-file-write#f2d8c9d8ed18",
       "classification": "external",
       "reason": "Memory export command deliberately emits JSON."
@@ -126,14 +106,6 @@
       "id": "apps/memory/src/import-ams.ts#json-parse-file-read#84cfe0136522",
       "classification": "external",
       "reason": "AMS import accepts external JSON dump format."
-    },
-    {
-      "id": "apps/memory/src/inbox.ts#json-parse-file-read#3ed29a34b863",
-      "classification": "migrate"
-    },
-    {
-      "id": "apps/memory/src/inbox.ts#json-stringify-file-write#edcbaa2eb421",
-      "classification": "migrate"
     },
     {
       "id": "apps/opencode-host/src/emit.ts#json-stringify-file-write#9bc9165f331e",

--- a/apps/memory/src/backup.ts
+++ b/apps/memory/src/backup.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
-import { copyFile, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, readdir, rm, stat } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { DEFAULT_STORE_PATH, readConfig, type MemoryConfig } from "./config.js";
+import { readMemoryStateFile, writeMemoryStateFile } from "./toon-state.js";
 
 export interface MemoryBackupFile {
   path: string;
@@ -46,7 +47,8 @@ export interface MemoryRestoreResult {
   warnings: string[];
 }
 
-const MANIFEST = "manifest.json";
+const MANIFEST = "manifest.toon";
+const LEGACY_MANIFEST = "manifest.json";
 const BACKUPS_DIR = "backups";
 
 export async function createMemoryBackup(
@@ -68,10 +70,10 @@ export async function createMemoryBackup(
   const copied: MemoryBackupFile[] = [];
   for (const file of files) {
     // The config now lives in `.red/config.yaml` (ADR 0042), not under
-    // `.red/memory`. We synthesize a self-contained `config.json` snapshot
+    // `.red/memory`. We synthesize a self-contained `config.toon` snapshot
     // below from the resolved config, so skip any legacy in-tree copy to avoid
     // a duplicate manifest entry.
-    if (file === "config.json") continue;
+    if (file === "config.json" || file === "config.toon") continue;
     const src = join(memoryDir, file);
     const dest = join(dataDir, file);
     await mkdir(dirname(dest), { recursive: true });
@@ -81,8 +83,8 @@ export async function createMemoryBackup(
 
   // Embed a normalized config snapshot so the backup is self-contained and the
   // manifest is stable regardless of where the live config is stored.
-  await writeFile(join(dataDir, "config.json"), `${JSON.stringify(config, null, 2)}\n`, "utf8");
-  copied.push(await fileManifest(dataDir, "config.json"));
+  await writeMemoryStateFile(join(dataDir, "config.toon"), config);
+  copied.push(await fileManifest(dataDir, "config.toon"));
 
   const manifest: MemoryBackupManifest = {
     schema_version: "memory.backup.v1",
@@ -95,7 +97,7 @@ export async function createMemoryBackup(
     warnings,
   };
   const manifestPath = join(backupDir, MANIFEST);
-  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  await writeMemoryStateFile(manifestPath, manifest);
   return {
     manifest,
     backup_dir: backupDir,
@@ -140,11 +142,20 @@ export async function readMemoryBackupManifest(
   name: string,
 ): Promise<MemoryBackupManifest> {
   const backupDir = backupPath(rootDir, name);
-  const manifest = JSON.parse(await readFile(join(backupDir, MANIFEST), "utf8")) as MemoryBackupManifest;
+  const manifest = await readBackupManifestFile(backupDir);
   if (manifest.schema_version !== "memory.backup.v1") {
     throw new Error(`unsupported Memory backup manifest in ${backupDir}`);
   }
   return manifest;
+}
+
+async function readBackupManifestFile(backupDir: string): Promise<MemoryBackupManifest> {
+  try {
+    return await readMemoryStateFile<MemoryBackupManifest>(join(backupDir, MANIFEST));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  return readMemoryStateFile<MemoryBackupManifest>(join(backupDir, LEGACY_MANIFEST));
 }
 
 export async function restoreMemoryBackup(

--- a/apps/memory/src/competitive-baseline.ts
+++ b/apps/memory/src/competitive-baseline.ts
@@ -38,6 +38,7 @@ import { buildReadinessEnvelope } from "./readiness.js";
 import { buildMemoryRoutingGuide, SUPPORTED_ROUTING_AGENTS } from "./routing-guide.js";
 import type { EdgeLabel } from "./schema.js";
 import { classifyCandidateMemory } from "./store-classifier.js";
+import { writeMemoryStateFile } from "./toon-state.js";
 import { commitMemoryGraph } from "./vcs-commit.js";
 
 type Claim = "advantage" | "parity" | "mixed" | "conceded-gap" | "not-claimed";
@@ -1841,16 +1842,16 @@ async function scaffoldFederationRoot(
   const dir = join(parent, name);
   const notesDir = join(dir, ".red/memory/notes");
   await mkdir(notesDir, { recursive: true });
-  await writeFile(
-    join(dir, ".red/memory/config.json"),
-    JSON.stringify({
+  await writeMemoryStateFile(
+    join(dir, ".red/memory/config.toon"),
+    {
       version: 1,
       mode: "markdown-only",
       notesDir: ".red/memory/notes",
       hooks: { sessionStart: false, postToolUse: false, stop: false, preCompact: false },
       mcp: false,
       reddb: false,
-    }),
+    },
   );
   for (const [file, body] of Object.entries(notes)) {
     await writeFile(join(notesDir, file), body);

--- a/apps/memory/src/config.ts
+++ b/apps/memory/src/config.ts
@@ -3,6 +3,7 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import type { AiProviderConfig } from "./extract-conversation.js";
 import type { RecallRankingConfig } from "./recall-ranking.js";
 import { mergeMemoryBlock, parsePluginsMemory } from "./shared-config.js";
+import { readMemoryStateFile } from "./toon-state.js";
 
 /** Storage backends the `memory init` wizard can configure. */
 export type StorageMode = "markdown-only" | "graph" | "hybrid";
@@ -193,6 +194,10 @@ export function legacyConfigPath(rootDir: string): string {
   return resolve(rootDir, ".red/memory/config.json");
 }
 
+export function legacyToonConfigPath(rootDir: string): string {
+  return resolve(rootDir, ".red/memory/config.toon");
+}
+
 /** Resolve a config's `notesDir` (always repo-relative) to an absolute path. */
 export function resolveNotesDir(rootDir: string, config: MemoryConfig): string {
   return isAbsolute(config.notesDir)
@@ -244,13 +249,18 @@ export async function readConfig(rootDir: string): Promise<MemoryConfig | null> 
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
   }
 
-  try {
-    const raw = await readFile(legacyConfigPath(rootDir), "utf8");
-    return JSON.parse(raw) as MemoryConfig;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw err;
+  return readLegacyStandaloneConfig(rootDir);
+}
+
+async function readLegacyStandaloneConfig(rootDir: string): Promise<MemoryConfig | null> {
+  for (const path of [legacyToonConfigPath(rootDir), legacyConfigPath(rootDir)]) {
+    try {
+      return await readMemoryStateFile<MemoryConfig>(path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
   }
+  return null;
 }
 
 export interface StorePathMigrationResult {

--- a/apps/memory/src/curate-skill/archive-engine.ts
+++ b/apps/memory/src/curate-skill/archive-engine.ts
@@ -32,6 +32,7 @@ import {
   type CandidateRejection,
   type RestoreReceipt,
 } from "./types.js";
+import { decodeMemoryStateDocument, encodeMemoryStateToon } from "../toon-state.js";
 
 /**
  * Minimal filesystem surface the engine uses. Each member maps to a
@@ -76,6 +77,8 @@ export interface ArchiveEngineOptions {
 }
 
 const DEFAULT_ARCHIVE_DIR = ".red/memory/skill-archive";
+const ARCHIVE_MANIFEST = "manifest.toon";
+const LEGACY_ARCHIVE_MANIFEST = "manifest.json";
 
 interface ResolvedOptions {
   rootDir: string;
@@ -188,8 +191,8 @@ export async function executeArchive(
     reason: candidate.reason,
     files,
   };
-  const manifestPath = join(archiveRoot, "manifest.json");
-  await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  const manifestPath = join(archiveRoot, ARCHIVE_MANIFEST);
+  await fs.writeFile(manifestPath, encodeMemoryStateToon(manifest));
 
   return {
     ok: true,
@@ -214,11 +217,11 @@ export async function executeRestore(
 ): Promise<RestoreReceipt> {
   const { archiveBaseDir, fs } = resolveOptions(options);
   const archiveRoot = join(archiveBaseDir, name);
-  const manifestPath = join(archiveRoot, "manifest.json");
+  const manifestPath = await archiveManifestPath(fs, archiveRoot);
   const payloadRoot = join(archiveRoot, "payload");
 
   const manifestRaw = (await fs.readFile(manifestPath)).toString("utf8");
-  const manifest = JSON.parse(manifestRaw) as ArchiveManifest;
+  const manifest = decodeMemoryStateDocument<ArchiveManifest>(manifestRaw);
 
   if (await pathExists(fs, manifest.originalRoot)) {
     throw new Error(
@@ -251,6 +254,12 @@ export async function executeRestore(
     restoredRoot: manifest.originalRoot,
     files: manifest.files,
   };
+}
+
+async function archiveManifestPath(fs: ArchiveFs, archiveRoot: string): Promise<string> {
+  const toonPath = join(archiveRoot, ARCHIVE_MANIFEST);
+  if (await pathExists(fs, toonPath)) return toonPath;
+  return join(archiveRoot, LEGACY_ARCHIVE_MANIFEST);
 }
 
 /** Surfaces the resolved archive base directory for the CLI. */

--- a/apps/memory/src/inbox.ts
+++ b/apps/memory/src/inbox.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { classifyCandidateMemory, type StoreClassification } from "./store-classifier.js";
 import {
@@ -8,6 +8,7 @@ import {
   type PrivacyFinding,
 } from "./privacy.js";
 import type { Confidence, MemoryProvenance, MemoryScope } from "./schema.js";
+import { readMemoryStateFile, writeMemoryStateFile } from "./toon-state.js";
 
 export type InboxStatus = "quarantined" | "approved" | "rejected" | "promoted";
 
@@ -105,16 +106,17 @@ export async function listInboxItems(rootDir: string): Promise<MemoryInboxItem[]
   }
   const items: MemoryInboxItem[] = [];
   for (const entry of entries) {
-    if (!entry.endsWith(".json")) continue;
-    items.push(await readInboxItem(rootDir, entry.slice(0, -".json".length)));
+    const id = inboxIdFromFile(entry);
+    if (!id) continue;
+    items.push(await readInboxItem(rootDir, id));
   }
   return items.sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.id.localeCompare(b.id));
 }
 
 export async function readInboxItem(rootDir: string, id: string): Promise<MemoryInboxItem> {
-  const path = inboxPath(rootDir, id);
+  const path = await existingInboxPath(rootDir, id);
   try {
-    return JSON.parse(await readFile(path, "utf8")) as MemoryInboxItem;
+    return await readMemoryStateFile<MemoryInboxItem>(path);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new Error(`memory inbox item not found: ${id}`);
@@ -202,12 +204,29 @@ export function inboxItemToProvenance(item: MemoryInboxItem): MemoryProvenance {
 
 async function writeInboxItem(rootDir: string, item: MemoryInboxItem): Promise<void> {
   await mkdir(inboxRoot(rootDir), { recursive: true });
-  await writeFile(inboxPath(rootDir, item.id), `${JSON.stringify(item, null, 2)}\n`, "utf8");
+  await writeMemoryStateFile(inboxPath(rootDir, item.id), item);
 }
 
 function inboxPath(rootDir: string, id: string): string {
   if (!/^inbox-[a-f0-9]{12}$/.test(id)) throw new Error(`invalid memory inbox id: ${id}`);
+  return join(inboxRoot(rootDir), `${id}.toon`);
+}
+
+async function existingInboxPath(rootDir: string, id: string): Promise<string> {
+  const toonPath = inboxPath(rootDir, id);
+  try {
+    await readFile(toonPath);
+    return toonPath;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  if (!/^inbox-[a-f0-9]{12}$/.test(id)) throw new Error(`invalid memory inbox id: ${id}`);
   return join(inboxRoot(rootDir), `${id}.json`);
+}
+
+function inboxIdFromFile(file: string): string | null {
+  const match = /^(inbox-[a-f0-9]{12})\.(?:toon|json)$/.exec(file);
+  return match?.[1] ?? null;
 }
 
 function normalizeProvenance(input: Partial<InboxProvenanceContext> = {}): InboxProvenanceContext {

--- a/apps/memory/src/toon-state.ts
+++ b/apps/memory/src/toon-state.ts
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { decode, type JsonValue } from "@reddb-io/toon";
+import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
+
+export function encodeMemoryStateToon(value: unknown): string {
+  return `${encodeSnapshotToon(value as JsonValue)}\n`;
+}
+
+export function decodeMemoryStateDocument<T = unknown>(raw: string): T {
+  const body = raw.trim();
+  if (!body) return null as T;
+  try {
+    return JSON.parse(body) as T;
+  } catch {
+    return decode(body) as T;
+  }
+}
+
+export async function readMemoryStateFile<T = unknown>(path: string): Promise<T> {
+  return decodeMemoryStateDocument<T>(await readFile(path, "utf8"));
+}
+
+export async function writeMemoryStateFile(path: string, value: unknown): Promise<void> {
+  await writeFile(path, encodeMemoryStateToon(value), "utf8");
+}

--- a/apps/memory/tests/backup.test.ts
+++ b/apps/memory/tests/backup.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/backup.js";
 import { readConfig } from "../src/config.js";
 import { initGraph, initMarkdownOnly } from "../src/init.js";
+import { decodeMemoryStateDocument } from "../src/toon-state.js";
 
 const TIMEOUT = 40_000;
 const pkgRoot = resolve(__dirname, "..");
@@ -48,9 +49,15 @@ describe("Memory backup snapshots", () => {
       mode: "markdown-only",
     });
     expect(first.manifest.files.map((file) => file.path)).toEqual(
-      expect.arrayContaining(["config.json", "notes/auth.md"]),
+      expect.arrayContaining(["config.toon", "notes/auth.md"]),
     );
     expect(first.manifest.files.some((file) => file.path.startsWith("backups/"))).toBe(false);
+    await expect(readFile(join(root, ".red/memory/backups/before-auth/manifest.json"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    const manifestRaw = await readFile(join(root, ".red/memory/backups/before-auth/manifest.toon"), "utf8");
+    expect(manifestRaw.trimStart().startsWith("{")).toBe(false);
+    expect(decodeMemoryStateDocument(manifestRaw)).toMatchObject({ name: "before-auth" });
 
     const manifest = await readMemoryBackupManifest(root, "before-auth");
     expect(manifest.files.every((file) => /^[a-f0-9]{64}$/.test(file.sha256))).toBe(true);
@@ -122,7 +129,7 @@ describe("Memory backup snapshots", () => {
       const created = runMemory(["backup", "create", "--root", root, "--name", "before-new", "--json"]);
       expect(created.status, created.stderr).toBe(0);
       const backup = JSON.parse(created.stdout) as { manifest: { files: Array<{ path: string }> } };
-      expect(backup.manifest.files.some((file) => file.path === "config.json")).toBe(true);
+      expect(backup.manifest.files.some((file) => file.path === "config.toon")).toBe(true);
       expect(backup.manifest.files.some((file) => file.path.startsWith("graph.rdb"))).toBe(true);
 
       const newStore = runMemory(["store", "Database passwords live in Vault.", "--root", root]);

--- a/apps/memory/tests/curate-skill.test.ts
+++ b/apps/memory/tests/curate-skill.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../src/curate-skill/archive-engine.js";
 import type { ArchiveFs } from "../src/curate-skill/archive-engine.js";
 import type { ArchiveCandidate, CuratorReportEnvelope } from "../src/curate-skill/types.js";
+import { decodeMemoryStateDocument } from "../src/toon-state.js";
 
 const TIMEOUT = 30_000;
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -259,7 +260,16 @@ describe("archive-engine — archive + restore round-trip", () => {
 
       // Manifest is well-formed and records both files with hashes.
       const manifestRaw = await readFile(archived.receipt.manifestPath, "utf8");
-      const manifest = JSON.parse(manifestRaw);
+      expect(archived.receipt.manifestPath.endsWith("manifest.toon")).toBe(true);
+      expect(manifestRaw.trimStart().startsWith("{")).toBe(false);
+      const manifest = decodeMemoryStateDocument<{
+        name: string;
+        originalRoot: string;
+        archivedAt: string;
+        category: string;
+        reason: string;
+        files: Array<{ relativePath: string }>;
+      }>(manifestRaw);
       expect(manifest.name).toBe("demo-skill");
       expect(manifest.originalRoot).toBe(skillDir);
       expect(manifest.archivedAt).toBe("2026-05-22T16:00:00.000Z");

--- a/apps/memory/tests/inbox-cli.test.ts
+++ b/apps/memory/tests/inbox-cli.test.ts
@@ -1,8 +1,9 @@
 import { spawnSync } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
+import { decodeMemoryStateDocument } from "../src/toon-state.js";
 
 const TIMEOUT = 40_000;
 const pkgRoot = resolve(__dirname, "..");
@@ -61,6 +62,13 @@ describe("memory inbox CLI", () => {
       expect.arrayContaining([expect.objectContaining({ kind: "openai-token" })]),
     );
     expect(JSON.stringify(created)).not.toContain(token);
+    const toonPath = join(root, ".red/memory/inbox", `${created.item.id}.toon`);
+    const toonRaw = await readFile(toonPath, "utf8");
+    expect(toonRaw.trimStart().startsWith("{")).toBe(false);
+    expect(decodeMemoryStateDocument(toonRaw)).toMatchObject({ id: created.item.id, status: "quarantined" });
+    await expect(readFile(join(root, ".red/memory/inbox", `${created.item.id}.json`), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
 
     const inspect = runMemory(["inbox", "inspect", created.item.id, "--root", root]);
     expect(inspect.status, inspect.stderr).toBe(0);
@@ -71,6 +79,12 @@ describe("memory inbox CLI", () => {
     expect(inspect.stdout).toContain("privacy: openai-token");
     expect(inspect.stdout).toContain("provenance: hook writer=codex hook=Stop confidence=AMBIGUOUS");
     expect(inspect.stdout).not.toContain(token);
+
+    await rm(toonPath);
+    await writeFile(join(root, ".red/memory/inbox", `${created.item.id}.json`), `${JSON.stringify(created.item, null, 2)}\n`);
+    const legacyInspect = runMemory(["inbox", "inspect", created.item.id, "--root", root]);
+    expect(legacyInspect.status, legacyInspect.stderr).toBe(0);
+    expect(legacyInspect.stdout).toContain("status: quarantined");
 
     const stats = runMemory(["stats", "--root", root]);
     expect(stats.status, stats.stderr).toBe(0);

--- a/apps/memory/tests/shared-config.test.ts
+++ b/apps/memory/tests/shared-config.test.ts
@@ -12,6 +12,7 @@ import {
   parsePluginsMemory,
   parseYamlFlat,
 } from "../src/shared-config.js";
+import { writeMemoryStateFile } from "../src/toon-state.js";
 
 const roots: string[] = [];
 
@@ -226,6 +227,16 @@ describe("plugins.memory.enabled (ADR 0067 activation flag)", () => {
 });
 
 describe("migrateStorePathToRepoStore", () => {
+  test("readConfig sniffs legacy standalone TOON config before JSON fallback", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red", "memory"), { recursive: true });
+    await writeMemoryStateFile(join(root, ".red", "memory", "config.toon"), markdownOnlyConfig());
+
+    await expect(readConfig(root)).resolves.toMatchObject({ mode: "markdown-only" });
+    const raw = await readFile(join(root, ".red", "memory", "config.toon"), "utf8");
+    expect(raw.trimStart().startsWith("{")).toBe(false);
+  });
+
   test("copies a legacy standalone graph store and repoints memory config", async () => {
     const root = await tempRoot();
     await mkdir(join(root, ".red", "memory"), { recursive: true });


### PR DESCRIPTION
Lands the completed S3 migration (worker wIX60, 11 commits, provably linear on main), bypassing the fleet's phantom-conflict landing loop. Closes #2085.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786973133&installation_id=129708444&pr_number=2097&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2097&signature=2f6c96966e768257350570f1480bcd191a19cd525d0f5f044e00e669db4b4ab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->