### PR TITLE
fix: gate merge-readiness on GitHub mergeable — kill the residual phantom conflict

### DIFF
--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -437,6 +437,10 @@ function checkPending(entry: RollupEntry): boolean {
 
 interface MergeStateView {
   mergeStateStatus: string;
+  /** GitHub `mergeable`: MERGEABLE | CONFLICTING | UNKNOWN (empty when a caller
+   * did not fetch it). The settled-vs-computing signal: `mergeStateStatus` alone
+   * can read a transient value before GitHub finishes computing mergeability. */
+  mergeable: string;
   anyFailed: boolean;
   anyPending: boolean;
 }
@@ -446,50 +450,59 @@ interface MergeStateView {
  * keeps polling rather than mis-deciding on a transient gh hiccup. */
 export function parseMergeStateView(stdout: string): MergeStateView {
   const text = stdout.trim();
-  if (text === "") return { mergeStateStatus: "", anyFailed: false, anyPending: false };
+  if (text === "") return { mergeStateStatus: "", mergeable: "", anyFailed: false, anyPending: false };
   try {
     const parsed: unknown = JSON.parse(text);
     if (typeof parsed !== "object" || parsed === null) {
-      return { mergeStateStatus: "", anyFailed: false, anyPending: false };
+      return { mergeStateStatus: "", mergeable: "", anyFailed: false, anyPending: false };
     }
     const mergeStateStatus = (parsed as { mergeStateStatus?: unknown }).mergeStateStatus;
+    const mergeable = (parsed as { mergeable?: unknown }).mergeable;
     const rollup = (parsed as { statusCheckRollup?: unknown }).statusCheckRollup;
     const entries: RollupEntry[] = Array.isArray(rollup)
       ? rollup.filter((e): e is RollupEntry => typeof e === "object" && e !== null)
       : [];
     return {
       mergeStateStatus: typeof mergeStateStatus === "string" ? mergeStateStatus : "",
+      mergeable: typeof mergeable === "string" ? mergeable : "",
       anyFailed: entries.some(checkFailed),
       anyPending: entries.some(checkPending),
     };
   } catch {
-    return { mergeStateStatus: "", anyFailed: false, anyPending: false };
+    return { mergeStateStatus: "", mergeable: "", anyFailed: false, anyPending: false };
   }
 }
 
 /**
- * Decide the merge readiness from the parsed merge state. Order matters:
- *   1. DIRTY → a genuine conflict (GitHub `mergeable=CONFLICTING`) → `conflict`.
- *   2. any required check FAILED → `ci-failed` (even when GitHub still reports
- *      BLOCKED — a failed check never clears by waiting).
- *   3. BEHIND → the head is merely out of date vs the base (still MERGEABLE,
- *      unlike DIRTY). NOT a conflict: `preMergeRebase` already integrated the
- *      base before the PR, so a BEHIND at check time is GitHub still settling
- *      mergeability or a benign race → `pending` (re-poll; it settles to
- *      CLEAN/UNSTABLE → `merge`, or the poll times out and the OPEN PR is handed
- *      off). Treating BEHIND as a conflict caused the #2084 phantom-conflict
- *      concede-loop — a provably fast-forwardable branch looping forever.
- *   4. CLEAN → `merge`.
- *   5. any check still running → `pending` (keep waiting).
- *   6. BLOCKED with neither failures nor pending checks → likely blocked by a
- *      required REVIEW; attempts merge, which surfaces as `merge-failed` if the
- *      repository's branch protection requires a review (correct: honored, not
- *      bypassed) → `merge`.
- *   7. UNSTABLE / HAS_HOOKS (mergeable; only non-required checks unsettled) → `merge`.
- *   8. UNKNOWN / DRAFT / empty → `pending` (GitHub still computing mergeability).
+ * Decide the merge readiness from the parsed merge state. `mergeable` is the
+ * settled-vs-computing AUTHORITY: `mergeStateStatus` alone can read a transient
+ * value (even a spurious `DIRTY`) before GitHub finishes computing mergeability,
+ * and classifying that pre-settle read as a terminal `conflict` is exactly the
+ * #2084/#2085 phantom-conflict concede-loop on a provably fast-forwardable
+ * branch. Order matters:
+ *   1. mergeable=CONFLICTING → a settled, genuine conflict → `conflict`.
+ *   2. mergeable=UNKNOWN → GitHub is still computing mergeability → `pending`
+ *      (re-poll until it settles; the poll budget accommodates it). A transient
+ *      `mergeStateStatus` is never terminal while mergeability is unsettled.
+ *   3. DIRTY → `conflict`. Fallback for callers/tests that did NOT fetch
+ *      `mergeable` (it is empty). Unreachable once `mergeable` is fetched — case
+ *      1 covers real conflicts — but kept for back-compat.
+ *   4. any required check FAILED → `ci-failed` (never clears by waiting).
+ *   5. BEHIND → out of date vs base but still MERGEABLE (unlike DIRTY);
+ *      `preMergeRebase` already integrated the base, so a BEHIND at check time is
+ *      a benign race → `pending` (re-poll).
+ *   6. CLEAN → `merge`.
+ *   7. any check still running → `pending`.
+ *   8. BLOCKED (no failures/pending) → likely a required REVIEW; attempts merge,
+ *      surfacing as `merge-failed` if branch protection requires it → `merge`.
+ *   9. UNSTABLE / HAS_HOOKS (mergeable; only non-required checks unsettled) → `merge`.
+ *  10. UNKNOWN / DRAFT / empty mergeStateStatus → `pending`.
  */
 export function classifyMergeState(view: MergeStateView): MergeReadiness {
   const s = up(view.mergeStateStatus);
+  const m = up(view.mergeable);
+  if (m === "CONFLICTING") return "conflict";
+  if (m === "UNKNOWN") return "pending";
   if (s === "DIRTY") return "conflict";
   if (view.anyFailed) return "ci-failed";
   if (s === "BEHIND") return "pending";
@@ -517,7 +530,7 @@ export async function waitForMergeReady(
 
   for (let attempt = 0; attempt < maxPolls; attempt++) {
     const res = await exec([
-      "gh", "-R", repo, "pr", "view", String(prNumber), "--json", "mergeStateStatus,statusCheckRollup",
+      "gh", "-R", repo, "pr", "view", String(prNumber), "--json", "mergeStateStatus,mergeable,statusCheckRollup",
     ]);
     const verdict = classifyMergeState(parseMergeStateView(res.stdout));
     if (verdict !== "pending") return verdict;

--- a/apps/dev/tests/afk-e2e-local.test.ts
+++ b/apps/dev/tests/afk-e2e-local.test.ts
@@ -492,11 +492,18 @@ describe("AFK e2e (real local git) — full lifecycle through processIssue", () 
     expect(onMain).not.toContain(WORKER_MARKER);
   });
 
-  it("classifyMergeState honors the #2096 fix in both directions (BEHIND→pending, DIRTY→conflict)", () => {
+  it("classifyMergeState honors the phantom-conflict fixes (BEHIND→pending + mergeable-gate)", () => {
     // The unit invariant the two real-git flows above exercise end-to-end: a
     // transient BEHIND must re-poll (land), a real DIRTY must park.
-    expect(classifyMergeState({ mergeStateStatus: "BEHIND", anyFailed: false, anyPending: false })).toBe("pending");
-    expect(classifyMergeState({ mergeStateStatus: "CLEAN", anyFailed: false, anyPending: false })).toBe("merge");
-    expect(classifyMergeState({ mergeStateStatus: "DIRTY", anyFailed: false, anyPending: false })).toBe("conflict");
+    const v = (mergeStateStatus: string, mergeable = "") => ({ mergeStateStatus, mergeable, anyFailed: false, anyPending: false });
+    expect(classifyMergeState(v("BEHIND"))).toBe("pending");
+    expect(classifyMergeState(v("CLEAN"))).toBe("merge");
+    expect(classifyMergeState(v("DIRTY"))).toBe("conflict");
+    // mergeable-gate (the deeper #2085 layer): a DIRTY read taken before GitHub
+    // settles mergeability (mergeable=UNKNOWN) must NOT terminally park a
+    // fast-forwardable branch — re-poll. Only mergeable=CONFLICTING is a conflict.
+    expect(classifyMergeState(v("DIRTY", "UNKNOWN"))).toBe("pending");
+    expect(classifyMergeState(v("DIRTY", "CONFLICTING"))).toBe("conflict");
+    expect(classifyMergeState(v("CLEAN", "MERGEABLE"))).toBe("merge");
   });
 });

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -630,8 +630,8 @@ describe("CI-aware merge classification (#812)", () => {
   });
 
   it("parseMergeStateView tolerates non-JSON / empty stdout", () => {
-    expect(parseMergeStateView("")).toEqual({ mergeStateStatus: "", anyFailed: false, anyPending: false });
-    expect(parseMergeStateView("not json")).toEqual({ mergeStateStatus: "", anyFailed: false, anyPending: false });
+    expect(parseMergeStateView("")).toEqual({ mergeStateStatus: "", mergeable: "", anyFailed: false, anyPending: false });
+    expect(parseMergeStateView("not json")).toEqual({ mergeStateStatus: "", mergeable: "", anyFailed: false, anyPending: false });
   });
 });
 
@@ -656,7 +656,7 @@ describe("waitForMergeReady (#812 poll loop)", () => {
     const r = await waitForMergeReady(exec, "o/r", 77, { sleep: noSleep });
     expect(r).toBe("merge");
     expect(calls.filter((c) => c.join(" ").includes("pr view 77")).length).toBe(3);
-    expect(calls[0].join(" ")).toContain("--json mergeStateStatus,statusCheckRollup");
+    expect(calls[0].join(" ")).toContain("--json mergeStateStatus,mergeable,statusCheckRollup");
   });
 
   it("returns ci-failed immediately on a failed required check (no further polls)", async () => {

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -548,8 +548,8 @@ describe("landPr wait_for_review wiring", () => {
 });
 
 describe("CI-aware merge classification (#812)", () => {
-  const view = (mergeStateStatus: string, rollup: unknown[] = []) =>
-    parseMergeStateView(JSON.stringify({ mergeStateStatus, statusCheckRollup: rollup }));
+  const view = (mergeStateStatus: string, rollup: unknown[] = [], mergeable = "") =>
+    parseMergeStateView(JSON.stringify({ mergeStateStatus, mergeable, statusCheckRollup: rollup }));
 
   it("CLEAN → merge", () => {
     expect(classifyMergeState(view("CLEAN"))).toBe("merge");
@@ -557,6 +557,24 @@ describe("CI-aware merge classification (#812)", () => {
 
   it("DIRTY (real git conflict) → conflict", () => {
     expect(classifyMergeState(view("DIRTY"))).toBe("conflict");
+  });
+
+  it("mergeable=CONFLICTING → conflict (the authoritative, settled conflict signal)", () => {
+    expect(classifyMergeState(view("DIRTY", [], "CONFLICTING"))).toBe("conflict");
+    expect(classifyMergeState(view("UNKNOWN", [], "CONFLICTING"))).toBe("conflict");
+  });
+
+  it("mergeable=UNKNOWN → pending even when mergeStateStatus transiently reads DIRTY (the #2085 phantom-conflict fix)", () => {
+    // GitHub is still computing mergeability; a pre-settle DIRTY must NOT
+    // terminally park a provably fast-forwardable branch — re-poll until it
+    // settles. This is the deeper layer the BEHIND-only fix (#2096) missed.
+    expect(classifyMergeState(view("DIRTY", [], "UNKNOWN"))).toBe("pending");
+    expect(classifyMergeState(view("BEHIND", [], "UNKNOWN"))).toBe("pending");
+    expect(classifyMergeState(view("", [], "UNKNOWN"))).toBe("pending");
+  });
+
+  it("mergeable=MERGEABLE + CLEAN → merge (settled and mergeable)", () => {
+    expect(classifyMergeState(view("CLEAN", [], "MERGEABLE"))).toBe("merge");
   });
 
   it("BEHIND (out of date, still mergeable) → pending, NOT conflict (the #2084 phantom-conflict loop)", () => {


### PR DESCRIPTION
**The deeper layer of the phantom-conflict bug** the BEHIND fix (#2096) didn't reach. #2085's provably-linear apps/memory branch still phantom-conflicted on 2.72.0.

**Root cause:** `parseMergeStateView` fetched only `mergeStateStatus`, never `mergeable`. So a read taken *before GitHub finishes computing mergeability* (a transient/spurious `DIRTY`) was classified as a terminal conflict → the worker conceded a fast-forwardable branch → a fresh worker re-did + re-conceded it → loop.

**Fix:** fetch `mergeable` and make it the settled-vs-computing **authority** in `classifyMergeState`:
- `mergeable=CONFLICTING` → `conflict` (authoritative, settled).
- `mergeable=UNKNOWN` → `pending` (still computing → re-poll; the 30×10s budget covers it).
- `DIRTY → conflict` kept only as a back-compat fallback for callers/tests that don't fetch `mergeable`.

**Empirically confirmed:** PRs #2095/#2097 opened from the exact branches the fleet called 'conflict' reported `mergeable=MERGEABLE` and merged clean.

**Backward compatible:** without `mergeable` (empty), the existing mergeStateStatus logic is unchanged — the new unit tests cover CONFLICTING→conflict, UNKNOWN+DIRTY→pending (the fix), and MERGEABLE+CLEAN→merge, and would fail on the old code.

Follow-up: an end-to-end scenario (transient UNKNOWN→MERGEABLE lands) will be added to `afk-e2e-local.test.ts` once this is on main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786976036&installation_id=129708444&pr_number=2099&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2099&signature=00c3c23a227df6318f19ec61d5e0bf3bcb438f70a655c59464b43e71418ab341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->