### PR TITLE
chore(toon): empty the migrate partition — final 3 TOON stragglers

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -7,10 +7,6 @@
       "reason": "MCP runtime config is JSON for MCP client interoperability."
     },
     {
-      "id": "apps/brain/src/hook-runtime.ts#json-stringify-file-write#785a7ac362b7",
-      "classification": "migrate"
-    },
-    {
       "id": "apps/dev/src/commands/run.ts#json-parse-file-read#01a38c1e6f6a",
       "classification": "external",
       "reason": "Fetched plugin manifest remains JSON at the package boundary."
@@ -34,10 +30,6 @@
       "id": "apps/dev/src/runtime/review-gh.ts#json-stringify-file-write#d6ea528ec9b4",
       "classification": "external",
       "reason": "GitHub review API --input payload is JSON."
-    },
-    {
-      "id": "apps/dev/src/runtime/wire.ts#json-stringify-file-write#1ded525e3fc7",
-      "classification": "migrate"
     },
     {
       "id": "apps/memory/src/bench-eval.ts#json-parse-file-read#9f8ee3a49186",
@@ -131,7 +123,8 @@
     },
     {
       "id": "packages/red-castle/src/WorktreeLock.ts#json-parse-file-read#231944fa112d",
-      "classification": "migrate"
+      "classification": "external",
+      "reason": "Vendored upstream red-castle; its WorktreeLock JSON format is owned by upstream and kept JSON to avoid divergence on cherry-pick sync."
     },
     {
       "id": "packages/red-castle/tsup.config.ts#json-parse-file-read#3ec8644e7f1e",

--- a/apps/brain/src/hook-runtime.ts
+++ b/apps/brain/src/hook-runtime.ts
@@ -1,8 +1,51 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
 import { withBrainRuntime } from "./runtime.js";
 
 export type Runner = "codex" | "claude" | "hermes" | "unknown";
+
+/** The SessionStart breadcrumb Brain drops on disk each session. */
+export interface LastSessionRecord {
+  runner: string;
+  lifecycle: string;
+  rootDir: string;
+  connectionString: string;
+  startedAt: string;
+}
+
+/**
+ * Encode the SessionStart breadcrumb as TOON (the stack's on-disk doctrine —
+ * every Brain-authored structured file is TOON, never JSON). The write and read
+ * halves convert together: {@link decodeLastSession} sniff-decodes the same
+ * format.
+ */
+export function encodeLastSession(record: LastSessionRecord): string {
+  return encode(record as unknown as JsonValue);
+}
+
+/**
+ * Sniff-decode a SessionStart breadcrumb: legacy raw JSON first, TOON fallback,
+ * so a file written by an older bundle (JSON) still reads after the flip. TOON
+ * `decode` throws on the JSON `{` header, so the JSON-first order never
+ * mis-parses a TOON document.
+ */
+export function decodeLastSession(text: string): LastSessionRecord {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = decode(text);
+  }
+  const rec = (parsed ?? {}) as Partial<LastSessionRecord>;
+  return {
+    runner: typeof rec.runner === "string" ? rec.runner : "",
+    lifecycle: typeof rec.lifecycle === "string" ? rec.lifecycle : "",
+    rootDir: typeof rec.rootDir === "string" ? rec.rootDir : "",
+    connectionString: typeof rec.connectionString === "string" ? rec.connectionString : "",
+    startedAt: typeof rec.startedAt === "string" ? rec.startedAt : "",
+  };
+}
 
 export async function handleHook(lifecycle: string, runner: Runner): Promise<Record<string, unknown>> {
   if (lifecycle !== "SessionStart") return {};
@@ -12,19 +55,17 @@ export async function handleHook(lifecycle: string, runner: Runner): Promise<Rec
   });
   const stateDir = join(config.rootDir, ".red", "brain", "sessions");
   await mkdir(stateDir, { recursive: true });
+  // Filename retained (wave-1 in-place convention); only the content flips to
+  // TOON, and decodeLastSession sniff-reads either format.
   await writeFile(
     join(stateDir, "last-session.json"),
-    JSON.stringify(
-      {
-        runner,
-        lifecycle,
-        rootDir: config.rootDir,
-        connectionString: config.connectionString,
-        startedAt: new Date().toISOString(),
-      },
-      null,
-      2,
-    ),
+    encodeLastSession({
+      runner,
+      lifecycle,
+      rootDir: config.rootDir,
+      connectionString: config.connectionString,
+      startedAt: new Date().toISOString(),
+    }),
     "utf8",
   );
   return {};

--- a/apps/brain/tests/hook-runtime.test.ts
+++ b/apps/brain/tests/hook-runtime.test.ts
@@ -1,0 +1,32 @@
+import { decode } from "@reddb-io/toon";
+import { describe, expect, it } from "vitest";
+import {
+  decodeLastSession,
+  encodeLastSession,
+  type LastSessionRecord,
+} from "../src/hook-runtime.js";
+
+describe("brain SessionStart breadcrumb — TOON round-trip seam", () => {
+  const record: LastSessionRecord = {
+    runner: "claude",
+    lifecycle: "SessionStart",
+    rootDir: "/repo",
+    connectionString: "postgres://brain",
+    startedAt: "2026-07-18T00:00:00.000Z",
+  };
+
+  it("round-trips encode -> decode losslessly", () => {
+    expect(decodeLastSession(encodeLastSession(record))).toEqual(record);
+  });
+
+  it("emits TOON content, not JSON, decodable by the toon reader", () => {
+    const encoded = encodeLastSession(record);
+    expect(encoded.trimStart().startsWith("{")).toBe(false);
+    expect(decode(encoded)).toEqual(record);
+  });
+
+  it("sniff-decodes a legacy JSON breadcrumb written by an older bundle", () => {
+    const legacy = JSON.stringify(record, null, 2);
+    expect(decodeLastSession(legacy)).toEqual(record);
+  });
+});

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -1006,7 +1006,10 @@ function releaseStatuslineRefreshLock(lockPath: string): void {
 
 function acquireStatuslineRefreshLock(lockPath: string, nowS: number): boolean {
   mkdirSync(dirname(lockPath), { recursive: true });
-  const payload = JSON.stringify({ pid: process.pid, ts: nowS });
+  // Lock payload is TOON on-disk (the stack's snapshot doctrine); the read side
+  // (readStatuslineCache → decodeCacheDocument) sniff-decodes JSON-then-TOON, so
+  // a legacy JSON lock written by an older bundle still reads back its `ts`.
+  const payload = encodeDevSnapshotToon({ pid: process.pid, ts: nowS } as unknown as ToonValue);
   try {
     writeFileSync(lockPath, payload, { encoding: "utf8", flag: "wx" });
     return true;

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -23,6 +23,7 @@ import {
   collectStatuslineRepo,
   collectStatuslineDocs,
   statuslineCountCachePath,
+  startDetachedStatuslineCountRefresh,
   STATUSLINE_CACHE_TTL_S,
   applyStatuslineCountCacheLabelDelta,
   editLabelsWithStatuslineCache,
@@ -713,6 +714,61 @@ function readToonCache<T>(path: string): T {
 // ---------------------------------------------------------------------------
 // collectStatuslineAfk — cache discipline (#818)
 // ---------------------------------------------------------------------------
+
+describe("statusline refresh lock — TOON round-trip seam", () => {
+  const lockPathFor = (root: string): string => `${statuslineCountCachePath(root)}.refresh.lock`;
+
+  it("writes a TOON lock (not JSON) and re-reads its ts to refuse a concurrent refresh", () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-lock-"));
+    try {
+      const rec = detachedSpawnRecorder();
+      const ctx = { root, repo: "o/r", remote: "origin" };
+      const now = nowS();
+
+      // WRITE half: acquire the lock (spawns one detached refresh).
+      const first = startDetachedStatuslineCountRefresh(ctx, { spawn: rec.spawn, argv1: "/tmp/afk.mjs", nowS: now });
+      expect(first).toBe(true);
+      expect(rec.calls).toHaveLength(1);
+
+      // On disk it is TOON, not JSON, and decodes back to the { pid, ts } payload.
+      const raw = readFileSync(lockPathFor(root), "utf8");
+      expect(raw.trimStart().startsWith("{")).toBe(false);
+      const decoded = decode(raw) as { pid: number; ts: number };
+      expect(decoded.pid).toBe(process.pid);
+      expect(decoded.ts).toBe(now);
+
+      // READ half: a second acquire re-reads the fresh TOON lock's ts and refuses
+      // (no second spawn). If the sniff-read could not recover ts, it would treat
+      // the lock as stale and re-acquire — so this proves the round-trip.
+      const second = startDetachedStatuslineCountRefresh(ctx, { spawn: rec.spawn, argv1: "/tmp/afk.mjs", nowS: now + 1 });
+      expect(second).toBe(false);
+      expect(rec.calls).toHaveLength(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("sniff-reads a legacy JSON lock written by an older bundle", () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-lock-"));
+    try {
+      const rec = detachedSpawnRecorder();
+      const ctx = { root, repo: "o/r", remote: "origin" };
+      const now = nowS();
+
+      // Pre-seed a fresh legacy JSON lock, as an older bundle would have written.
+      const lockPath = lockPathFor(root);
+      mkdirSync(dirname(lockPath), { recursive: true });
+      writeFileSync(lockPath, JSON.stringify({ pid: process.pid, ts: now }), "utf8");
+
+      // The read half sniff-decodes the legacy JSON ts and refuses (still fresh).
+      const acquired = startDetachedStatuslineCountRefresh(ctx, { spawn: rec.spawn, argv1: "/tmp/afk.mjs", nowS: now + 1 });
+      expect(acquired).toBe(false);
+      expect(rec.calls).toHaveLength(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("collectStatuslineAfk — cache discipline", () => {
   it("cold cache: awaits gh + writes cache before returning", async () => {


### PR DESCRIPTION
Completes the TOON file-I/O migration (Spec #2081). The guard allowlist's `migrate` partition is now **empty** — every stack-owned JSON file I/O site is either converted to TOON or classified `external` with a documented reason.

## Changes
- **wire.ts** — statusline refresh-lock write emits TOON (`encodeDevSnapshotToon`); the read side (`readStatuslineCache` → `decodeCacheDocument`) already sniff-decodes JSON-then-TOON, so a legacy JSON lock still reads.
- **brain/hook-runtime.ts** — SessionStart breadcrumb write flips to TOON via a new `encodeLastSession`; adds the read half `decodeLastSession` (sniff: JSON-first, TOON fallback) + the `LastSessionRecord` type.
- **red-castle/WorktreeLock.ts** — reclassified `migrate` → `external`. Vendored upstream; its JSON lock format is owned by upstream and kept JSON to avoid divergence on cherry-pick sync.
- Round-trip tests for both converted seams.

## Verification (local, single-file)
- `toon-json-guard` live-allowlist ratchet: **0 violations, migrate=0**
- `wire` 72 + `wire-reclaim` 5 pass; brain `hook-runtime` 3/3
- `tsc --noEmit` clean (dev + brain)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786982433&installation_id=129708444&pr_number=2102&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2102&signature=d90f2247da5753d8e0a4ef86b4a6417fb3daa74a76a9f19be3cbbfb4bfb594dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->