### PR TITLE
fix(dev): attachSubIssue sends sub_issue_id as integer (-F not -f) — native sub-issue edges were 422ing

### DIFF
--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -452,7 +452,9 @@ export async function attachSubIssue(ctx: GhContext, parent: number, child: numb
     "-X",
     "POST",
     apiPath(ctx, `issues/${parent}/sub_issues`),
-    "-f",
+    // `-F` (not `-f`): sub_issue_id is a JSON integer field, and `-f` would send
+    // it as a string, which the sub-issues endpoint rejects with HTTP 422.
+    "-F",
     `sub_issue_id=${childId}`,
   ]);
   if (r.code !== 0) {

--- a/apps/dev/tests/gh-spec-subissues.test.ts
+++ b/apps/dev/tests/gh-spec-subissues.test.ts
@@ -86,7 +86,7 @@ describe("attachSubIssue", () => {
       },
       {
         cmd: "gh",
-        args: ["api", "-X", "POST", "repos/acme/widgets/issues/42/sub_issues", "-f", "sub_issue_id=12345"],
+        args: ["api", "-X", "POST", "repos/acme/widgets/issues/42/sub_issues", "-F", "sub_issue_id=12345"],
       },
     ]);
   });

--- a/apps/dev/tests/label-vocabulary-docs.test.ts
+++ b/apps/dev/tests/label-vocabulary-docs.test.ts
@@ -77,9 +77,9 @@ describe("label vocabulary docs", () => {
 
     expect(tracker).toContain("## Dependency & hierarchy operations");
     expect(tracker).toContain("/issues/<parent-number>/sub_issues");
-    expect(tracker).toContain("-f \"sub_issue_id=$child_id\"");
+    expect(tracker).toContain("-F \"sub_issue_id=$child_id\"");
     expect(tracker).toContain("/issues/<child-number>/dependencies/blocked_by");
-    expect(tracker).toContain("-f \"issue_id=$blocker_id\"");
+    expect(tracker).toContain("-F \"issue_id=$blocker_id\"");
     expect(tracker).toContain("numeric database id from the REST issue `.id` field");
     expect(tracker).toContain("never the GitHub issue `#number`");
     expect(tracker).toContain("never the GraphQL `node_id`");

--- a/plugins/dev/skills/engineering/red-setup/issue-tracker-github.md
+++ b/plugins/dev/skills/engineering/red-setup/issue-tracker-github.md
@@ -27,24 +27,24 @@ Use GitHub's native issue relationships for the human-facing graph, and keep the
 
 ### Create a native sub-issue relationship
 
-Create the child issue first, then attach it to its parent Spec or map with the sub-issues endpoint:
+Create the child issue first, then attach it to its parent Spec or map with the sub-issues endpoint. Pass the child's numeric database id with `-F` (typed field) so `gh` sends it as a JSON integer — `-f` sends a string and the endpoint rejects it with HTTP 422:
 
 ```bash
 child_id="$(gh api "repos/{owner}/{repo}/issues/<child-number>" --jq '.id')"
 gh api --method POST "repos/{owner}/{repo}/issues/<parent-number>/sub_issues" \
-  -f "sub_issue_id=$child_id"
+  -F "sub_issue_id=$child_id"
 ```
 
 For Spec slicing, also apply `spec:<parent-number>` to the child. For `/wayfinder`, the parent carries `wayfinder:map` and the child carries exactly one `wayfinder:<type>` label.
 
 ### Create a native blocked-by relationship
 
-Use the child's dependency endpoint and pass the blocker issue's numeric database id:
+Use the child's dependency endpoint and pass the blocker issue's numeric database id (again with `-F`, for the same reason):
 
 ```bash
 blocker_id="$(gh api "repos/{owner}/{repo}/issues/<blocker-number>" --jq '.id')"
 gh api --method POST "repos/{owner}/{repo}/issues/<child-number>/dependencies/blocked_by" \
-  -f "issue_id=$blocker_id"
+  -F "issue_id=$blocker_id"
 ```
 
 **Trap:** `issue_id` must be the blocker's numeric database id from the REST issue `.id` field. It is never the GitHub issue `#number`, and it is never the GraphQL `node_id`. Passing the wrong value can link the wrong issue silently.


### PR DESCRIPTION
The AFK spec-subissue reconciler's native sub-issue edge writer (`attachSubIssue`) POSTs `sub_issue_id` with `gh api -f`, sending it as a JSON **string**. The sub-issues endpoint types that field as an **integer** and rejects the string with **HTTP 422**. The reconciler swallows the throw as best-effort (`catch { /* leaves the Spec for the next sweep */ }`), so every AFK boot sweep has silently failed to create the human-facing native hierarchy — the `spec:N` label carried the real machinery, masking it.

## Fix
Use `-F` (typed field) so `gh` sends a JSON integer — the same way `gh.ts` already passes its GraphQL variables two functions down.

- `gh.ts` `attachSubIssue`: `-f` → `-F` (+ inline reason)
- `red-setup/issue-tracker-github.md`: the documented `sub_issues` **and** `blocked_by` examples both used `-f`; corrected to `-F` with the reason inline (blocked_by is doc-only — no runtime path creates it, so no code change there)
- `gh-spec-subissues.test.ts` + `label-vocabulary-docs.test.ts`: expectations updated (both pinned the old `-f`, encoding the bug)

## Evidence
Hit live this session while wiring 27 file-split tickets to their Spec: `gh api -f sub_issue_id=<id>` → HTTP 422; switching to `-F` attached all 27 native sub-issue edges successfully. Local: `vitest run gh-spec-subissues label-vocabulary-docs` → 19/19 green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786985088&installation_id=129708444&pr_number=2132&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2132&signature=f42bc8097f91233e616222cf0ea6c4e449d21bfe3fb865a29fd7d2c6dca6fef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->