### PR TITLE
fix(afk): heartbeat resolves the red-castle (mirror-owned) worktree — kills the permanent loc +0 -0

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -1417,6 +1417,7 @@ export function buildProcessDeps(
         // the legacy path only when no worktree is registered yet.
         const worktree =
           (await gitx.worktreePathUnder(gitCtx, current.attemptDir).catch(() => undefined)) ??
+          castleWorktreeUnder(current.attemptDir) ??
           join(current.attemptDir, "worktree");
         // Fall back to the configured Trunk (ADR 0083), not a literal "main".
         const baseRef = info.base
@@ -1889,6 +1890,34 @@ async function runnerCircuitOpen(
   } catch {
     return false;
   }
+}
+
+/**
+ * Resolve the red-castle worktree from the filesystem. Red-castle creates the
+ * agent's worktree at `{attemptDir}/.red-castle/worktrees/{slug}` as a worktree
+ * of the red-trunk MIRROR, not the primary checkout, so it never appears in the
+ * primary's `git worktree list` — {@link worktreePathUnder} (which lists the
+ * primary via `gitCtx`) returns undefined for it, and the heartbeat then fell
+ * back to the non-existent legacy `{attemptDir}/worktree` and read a permanent
+ * `+0 -0` diff (blank `loc` on the statusline for every red-castle worker). This
+ * reads the real layout directly: the single `.git`-bearing subdirectory of
+ * `{attemptDir}/.red-castle/worktrees/`.
+ */
+export function castleWorktreeUnder(attemptDir: string): string | undefined {
+  const dir = join(attemptDir, ".red-castle", "worktrees");
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return undefined; // no castle worktree tree yet (attempt not started / cleaned)
+  }
+  for (const name of entries) {
+    const candidate = join(dir, name);
+    // A git worktree carries a `.git` gitdir pointer (a file for a linked
+    // worktree). Its presence distinguishes the real worktree from stray dirs.
+    if (existsSync(join(candidate, ".git"))) return candidate;
+  }
+  return undefined;
 }
 
 /** Synchronous next-attempt resolver over the attempt-ledger's pure core, so it

--- a/apps/dev/tests/castle-worktree.test.ts
+++ b/apps/dev/tests/castle-worktree.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { castleWorktreeUnder } from "../src/commands/run.js";
+
+// Guards the loc/vitals fix: red-castle worktrees are mirror-owned and never
+// appear in the primary's `git worktree list`, so the heartbeat must resolve
+// them from the on-disk layout `{attemptDir}/.red-castle/worktrees/{slug}` or it
+// falls back to the dead legacy `{attemptDir}/worktree` and reports `+0 -0`.
+describe("castleWorktreeUnder", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "castle-wt-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns undefined when there is no .red-castle/worktrees tree", () => {
+    expect(castleWorktreeUnder(root)).toBeUndefined();
+  });
+
+  it("resolves the .git-bearing worktree under .red-castle/worktrees", () => {
+    const wt = join(root, ".red-castle", "worktrees", "afk-wABCD-42-some-slug");
+    mkdirSync(wt, { recursive: true });
+    // A linked worktree's `.git` is a file (a gitdir pointer), not a directory.
+    writeFileSync(join(wt, ".git"), "gitdir: /mirror/.git/worktrees/afk-wABCD-42-some-slug\n");
+    expect(castleWorktreeUnder(root)).toBe(wt);
+  });
+
+  it("returns undefined (never the dead legacy path) when no child carries a .git", () => {
+    mkdirSync(join(root, ".red-castle", "worktrees", "stray"), { recursive: true });
+    expect(castleWorktreeUnder(root)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Symptom
Every red-castle worker shows a blank `loc` (+0 -0) on the statusline even while clearly busy (large diffs in its worktree). Reads as "no activity" → false "stuck" alarm.

## Root cause
The attempt heartbeat diffs the worktree to stamp `loc_added`/`loc_removed` for every runner (codex especially — it never commits, so ONLY its working-tree diff reflects its work). It resolved the worktree via `worktreePathUnder(gitCtx, attemptDir)` — `git worktree list` in the **primary** repo — and fell back to the legacy `{attemptDir}/worktree`.

But red-castle creates the agent's worktree as a worktree of the **red-trunk mirror**, not the primary, so it **never** appears in the primary's `git worktree list` (verified: 0 registered there). The resolver always returned `undefined`, the diff ran against the non-existent legacy path, `.catch` swallowed the ENOENT → permanent `loc +0 -0` for every worker. A prior fix (`worktreePathUnder`, documented in the code comment) was incomplete for mirror-owned worktrees.

## Fix
Filesystem resolver `castleWorktreeUnder(attemptDir)` reads the real on-disk layout `{attemptDir}/.red-castle/worktrees/{slug}` (the single `.git`-bearing child), inserted into the heartbeat's resolution chain **before** the dead legacy fallback. Repo-registration-independent, so it works for mirror-owned worktrees.

## Verification
- `git worktree list` in the primary: **0** red-castle worktrees (confirms the miss).
- New `castle-worktree.test.ts`: resolves the `.git`-bearing worktree; returns undefined (never the legacy path) with no tree / no `.git` child — 3/3.
- `run-flags` 33/33 (run.ts still loads), `tsc --noEmit` clean.

## Scope note
This fixes the **loc/diff** computation. Any residual zero on the tool/text **meter** counters is a separate meter-snapshot question, to verify once this ships. The running fleet won't retroactively fix — it needs the new bundle (release + the fleet picking it up / a restart).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786992452&installation_id=129708444&pr_number=2138&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2138&signature=233dae07c768237d9e1608b826f21dad60d0a3dd16234e82982625bb11851f48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->