### PR TITLE
fix: #2103 rsp git status --short reports a dirty tree as clean (fabricated "clean: 0 changes")

### DIFF
--- a/apps/rsp/src/git-wrapper.ts
+++ b/apps/rsp/src/git-wrapper.ts
@@ -70,7 +70,26 @@ export async function renderGitContract(
   }
 
   const subcommand = parseGitSubcommand(parsedCommand.argv);
-  const payload = parseGitPayload(subcommand, parsedCommand.argv, contract.stdout, parsedCommand.query);
+  let payload: JsonObject;
+  try {
+    payload = parseGitPayload(subcommand, parsedCommand.argv, contract.stdout, parsedCommand.query);
+  } catch (err) {
+    if (err instanceof GitStatusPassthroughError) {
+      return {
+        stdout: Buffer.from(contract.stdout),
+        stderr: Buffer.from(contract.stderr),
+        status: contract.status,
+        signal: contract.signal,
+        rawOutput: Buffer.from(contract.stdout),
+        degradation: {
+          reason: err.reason,
+          family: "git status",
+          stderrHead: err.message,
+        },
+      };
+    }
+    throw err;
+  }
 
   const fullToon = encode(payload);
   if (shouldEmitFull(subcommand, fullToon, parsedCommand.full, options)) {
@@ -247,32 +266,130 @@ function parseGitPayload(subcommand: GitSubcommand, command: readonly string[], 
 function parseStatus(command: readonly string[], stdout: string, query?: string): JsonObject {
   let branch = "";
   const rows: JsonObject[] = [];
-  for (const raw of stdout.split("\0")) {
+  let recognized = false;
+  let sawContent = false;
+  for (const raw of statusRecords(stdout)) {
     if (!raw) continue;
+    sawContent = true;
     if (raw.startsWith("# branch.head ")) {
       branch = raw.slice("# branch.head ".length);
+      recognized = true;
       continue;
     }
-    if (!raw.startsWith("1 ")) continue;
-    const parts = raw.split(" ");
-    const xy = parts[1] ?? "..";
-    const path = parts.slice(8).join(" ");
-    rows.push({
-      path,
-      index: xy[0] ?? ".",
-      worktree: xy[1] ?? ".",
-      state: statusState(xy),
-    });
+    if (raw.startsWith("# ")) {
+      recognized = true;
+      continue;
+    }
+    if (raw.startsWith("## ")) {
+      branch = shortStatusBranch(raw);
+      recognized = true;
+      continue;
+    }
+    const v2 = parsePorcelainV2StatusRow(raw);
+    if (v2) {
+      recognized = true;
+      rows.push(v2);
+      continue;
+    }
+    const short = parseShortStatusRow(raw);
+    if (short) {
+      recognized = true;
+      rows.push(short);
+    }
   }
-  if (rows.length === 0) return cleanStatusPayload(command.join(" "), branch);
+  if (rows.length === 0) {
+    if (!sawContent || recognized) return cleanStatusPayload(command.join(" "), branch);
+    throw new GitStatusPassthroughError("git-status-unparseable");
+  }
   const filteredRows = filterRows(rows, query);
   const counts = countBy(filteredRows, "state");
   return helpIfQueried({
     command: command.join(" "),
     branch,
     rows: filteredRows as JsonValue,
-    summary: `${query ? `${filteredRows.length}/${rows.length}` : filteredRows.length} changes: ${counts.added ?? 0} added, ${counts.modified ?? 0} modified, ${counts.deleted ?? 0} deleted`,
+    summary: statusSummary(filteredRows.length, rows.length, counts, query),
   }, query, ["rsp git diff --query <path>", "rsp git log --query <subject>"]);
+}
+
+function statusRecords(stdout: string): string[] {
+  return stdout.includes("\0") ? stdout.split("\0") : stdout.split(/\r?\n/);
+}
+
+function parsePorcelainV2StatusRow(raw: string): JsonObject | null {
+  if (raw.startsWith("1 ")) {
+    const parts = raw.split(" ");
+    const xy = parts[1] ?? "..";
+    const path = parts.slice(8).join(" ");
+    return statusRow(path, xy);
+  }
+  if (raw.startsWith("2 ")) {
+    const parts = raw.split(" ");
+    const xy = parts[1] ?? "..";
+    return statusRow(parts.slice(9).join(" "), xy);
+  }
+  if (raw.startsWith("u ")) {
+    const parts = raw.split(" ");
+    const xy = parts[1] ?? "..";
+    return statusRow(parts.slice(10).join(" "), xy);
+  }
+  if (raw.startsWith("? ")) return statusRow(raw.slice(2), "??");
+  return null;
+}
+
+function parseShortStatusRow(raw: string): JsonObject | null {
+  if (raw.length < 4 || raw[2] !== " ") return null;
+  const xy = raw.slice(0, 2);
+  if (!/^[ MADRCU?!][ MADRCU?!?]$/.test(xy)) return null;
+  return statusRow(shortStatusPath(raw.slice(3), xy), xy);
+}
+
+function statusRow(path: string, xy: string): JsonObject {
+  const index = normalizeStatusCode(xy[0] ?? ".");
+  const worktree = normalizeStatusCode(xy[1] ?? ".");
+  return {
+    path: decodeGitQuotedPath(path),
+    index,
+    worktree,
+    state: statusState(`${index}${worktree}`),
+  };
+}
+
+function normalizeStatusCode(code: string): string {
+  return code === " " ? "." : code;
+}
+
+function shortStatusBranch(raw: string): string {
+  const branch = raw.slice(3).split("...")[0]?.trim() ?? "";
+  return branch === "HEAD (no branch)" ? "HEAD" : branch;
+}
+
+function shortStatusPath(rawPath: string, xy: string): string {
+  if (!xy.includes("R") && !xy.includes("C")) return rawPath;
+  const arrow = rawPath.lastIndexOf(" -> ");
+  return arrow >= 0 ? rawPath.slice(arrow + " -> ".length) : rawPath;
+}
+
+function decodeGitQuotedPath(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed.startsWith("\"") || !trimmed.endsWith("\"")) return trimmed;
+  try {
+    return JSON.parse(trimmed) as string;
+  } catch {
+    return trimmed.slice(1, -1);
+  }
+}
+
+function statusSummary(
+  filtered: number,
+  total: number,
+  counts: Record<string, number>,
+  query: string | undefined,
+): string {
+  const extras: string[] = [];
+  if (counts.renamed) extras.push(`${counts.renamed} renamed`);
+  if (counts.untracked) extras.push(`${counts.untracked} untracked`);
+  if (counts.changed) extras.push(`${counts.changed} changed`);
+  return `${query ? `${filtered}/${total}` : filtered} changes: ${counts.added ?? 0} added, ${counts.modified ?? 0} modified, ${counts.deleted ?? 0} deleted${extras.length ? `, ${extras.join(", ")}` : ""}`;
 }
 
 export function cleanStatusPayload(command = "git status", branch = ""): JsonObject {
@@ -398,6 +515,12 @@ export class StructuredUsageError extends Error {
   }
 }
 
+class GitStatusPassthroughError extends Error {
+  constructor(readonly reason: string) {
+    super("git status output was not recognized; passing raw stdout through");
+  }
+}
+
 function parseBlame(command: readonly string[], stdout: string, query?: string): JsonObject {
   const lines = stdout.split("\n");
   const attributions: Array<{ line_start: number; line_end: number; author: string; commit: string; path: string }> = [];
@@ -517,6 +640,7 @@ function helpIfQueried(payload: JsonObject, query: string | undefined, help: rea
 
 
 function statusState(xy: string): string {
+  if (xy === "??") return "untracked";
   if (xy.includes("A")) return "added";
   if (xy.includes("D")) return "deleted";
   if (xy.includes("R")) return "renamed";

--- a/apps/rsp/tests/git-wrapper.test.ts
+++ b/apps/rsp/tests/git-wrapper.test.ts
@@ -198,6 +198,63 @@ describe("rsp git fidelity fixtures", () => {
     }
   });
 
+  it.each(["--short", "-s"])("parses git status %s rows instead of reporting clean", async (flag) => {
+    const result = await renderGitContract(["git", "status", flag], {
+      stdout: [
+        "## feature/rsp",
+        " M apps/rsp/src/git-wrapper.ts",
+        "?? apps/rsp/src/new-file.ts",
+        "R  old-name.ts -> new-name.ts",
+        "",
+      ].join("\n"),
+      stderr: "",
+      status: 0,
+      signal: null,
+    }, { level: "lossless" });
+    const decoded = decode(result.stdout.toString("utf8")) as {
+      branch: string;
+      rows: Array<{ path: string; index: string; worktree: string; state: string }>;
+      summary: string;
+    };
+
+    expect(result.status).toBe(0);
+    expect(decoded.branch).toBe("feature/rsp");
+    expect(decoded.rows).toEqual([
+      { path: "apps/rsp/src/git-wrapper.ts", index: ".", worktree: "M", state: "modified" },
+      { path: "apps/rsp/src/new-file.ts", index: "?", worktree: "?", state: "untracked" },
+      { path: "new-name.ts", index: "R", worktree: ".", state: "renamed" },
+    ]);
+    expect(decoded.summary).toContain("3 changes");
+    expect(decoded.summary).not.toContain("clean");
+  });
+
+  it("fails open to raw stdout when git status output is non-empty but unparseable", async () => {
+    const result = await renderGitContract(["git", "status", "--porcelain"], {
+      stdout: "not a git status format\n",
+      stderr: "",
+      status: 0,
+      signal: null,
+    }, { level: "lossless" });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString("utf8")).toBe("not a git status format\n");
+    expect(result.payload).toBeUndefined();
+    expect(result.degradation).toMatchObject({ reason: "git-status-unparseable", family: "git status" });
+  });
+
+  it("reports git status clean only when status stdout is genuinely empty", async () => {
+    const result = await renderGitContract(["git", "status", "--short"], {
+      stdout: "",
+      stderr: "",
+      status: 0,
+      signal: null,
+    }, { level: "lossless" });
+    const decoded = decode(result.stdout.toString("utf8")) as { category: string; empty: boolean; summary: string };
+
+    expect(result.status).toBe(0);
+    expect(decoded).toMatchObject({ category: "no-op", empty: true, summary: "git status clean: 0 changes" });
+  });
+
   it("reports already-satisfied git push as an explicit no-op", async () => {
     const result = await renderGitContract(["git", "push"], {
       stdout: [


### PR DESCRIPTION
Automated AFK landing for #2103. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2103

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786993617&installation_id=129708444&pr_number=2140&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2140&signature=1e3b6d5faa269ab032e639268970be0656c2eda3ed120083eb3f6c89ae71023a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->