### PR TITLE
fix(toon-guard): re-seed json-io allowlist after file-splits relocated sites (unblock red main)

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -32,9 +32,9 @@
       "reason": "GitHub review API --input payload is JSON."
     },
     {
-      "id": "apps/memory/src/bench-eval.ts#json-parse-file-read#9f8ee3a49186",
+      "id": "apps/memory/src/bench-eval/loaders.ts#json-parse-file-read#66b9c0159970",
       "classification": "external",
-      "reason": "Benchmark question fixtures are JSON inputs."
+      "reason": "External JSON I/O relocated by a behavior-preserving file-split; re-seeded (see #2104 splits)."
     },
     {
       "id": "apps/memory/src/bench-latency.ts#json-parse-file-read#c2af8acfa0f2",
@@ -50,21 +50,6 @@
       "id": "apps/memory/src/bench-recall.ts#json-parse-file-read#cd9ba4816a71",
       "classification": "external",
       "reason": "Benchmark query fixtures are JSON inputs."
-    },
-    {
-      "id": "apps/memory/src/cli.ts#json-parse-file-read#ed1088009085",
-      "classification": "external",
-      "reason": "User-supplied graph contract may be JSON."
-    },
-    {
-      "id": "apps/memory/src/cli.ts#json-stringify-file-write#0b91ffb44ffd",
-      "classification": "external",
-      "reason": "Export command deliberately emits JSON metadata."
-    },
-    {
-      "id": "apps/memory/src/cli.ts#json-stringify-file-write#0d38e8a06ad0",
-      "classification": "external",
-      "reason": "Export command deliberately emits JSON artifacts."
     },
     {
       "id": "apps/memory/src/export.ts#json-stringify-file-write#f2d8c9d8ed18",


### PR DESCRIPTION
See commit. Splits relocate external JSON I/O to new submodules → snippet+path-anchored guard IDs change → stale + unallowlisted → live-allowlist ratchet fails → main red, blocking all CI. Re-seeds preserving classifications by id; the one relocated read (bench-eval/loaders.ts) stays external; migrate=0. Guard: 0 violations. Immediate un-block; durable move-tolerant-guard fix tracked separately, fleet paused until then.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786994634&installation_id=129708444&pr_number=2141&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2141&signature=c4360207c2248676b50def8bd277f164de366f326ddb71470e71da98ad602dae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->