### PR TITLE
fix(toon-guard): tolerate behavior-preserving moves of external JSON I/O sites (stop the split fleet re-redding main)

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -4,127 +4,152 @@
     {
       "id": "apps/benchmark-code-understanding/src/runner.ts#json-stringify-file-write#1a95f6559ad4",
       "classification": "external",
-      "reason": "MCP runtime config is JSON for MCP client interoperability."
+      "reason": "MCP runtime config is JSON for MCP client interoperability.",
+      "moveKey": "851f84311082"
     },
     {
       "id": "apps/dev/src/commands/run.ts#json-parse-file-read#01a38c1e6f6a",
       "classification": "external",
-      "reason": "Fetched plugin manifest remains JSON at the package boundary."
+      "reason": "Fetched plugin manifest remains JSON at the package boundary.",
+      "moveKey": "f632cd5f3c50"
     },
     {
       "id": "apps/dev/src/commands/run.ts#json-stringify-file-write#3368a1bbf848",
       "classification": "external",
-      "reason": "Temporary Brain CLI handoff payload is an interop export."
+      "reason": "Temporary Brain CLI handoff payload is an interop export.",
+      "moveKey": "ffe659d284fb"
     },
     {
       "id": "apps/dev/src/core/toon-json-guard.ts#json-parse-file-read#0f36cd7ce70f",
       "classification": "external",
-      "reason": "Checked-in guard allowlist is JSON by contract."
+      "reason": "Checked-in guard allowlist is JSON by contract.",
+      "moveKey": "24cdd7f5b667"
     },
     {
       "id": "apps/dev/src/runtime/feedback-worktree.ts#json-parse-file-read#abf5b08523f6",
       "classification": "external",
-      "reason": "package.json is ecosystem JSON."
+      "reason": "package.json is ecosystem JSON.",
+      "moveKey": "8e5ae239b6cc"
     },
     {
       "id": "apps/dev/src/runtime/review-gh.ts#json-stringify-file-write#d6ea528ec9b4",
       "classification": "external",
-      "reason": "GitHub review API --input payload is JSON."
+      "reason": "GitHub review API --input payload is JSON.",
+      "moveKey": "7b2a2a976be4"
     },
     {
       "id": "apps/memory/src/bench-eval/loaders.ts#json-parse-file-read#66b9c0159970",
       "classification": "external",
-      "reason": "External JSON I/O relocated by a behavior-preserving file-split; re-seeded (see #2104 splits)."
+      "reason": "External JSON I/O relocated by a behavior-preserving file-split; re-seeded (see #2104 splits).",
+      "moveKey": "24cdd7f5b667"
     },
     {
       "id": "apps/memory/src/bench-latency.ts#json-parse-file-read#c2af8acfa0f2",
       "classification": "external",
-      "reason": "Benchmark workload fixture is JSON input."
+      "reason": "Benchmark workload fixture is JSON input.",
+      "moveKey": "24cdd7f5b667"
     },
     {
       "id": "apps/memory/src/bench-mistake-avoided.ts#json-parse-file-read#e71d9417acbf",
       "classification": "external",
-      "reason": "Benchmark scenario fixture is JSON input."
+      "reason": "Benchmark scenario fixture is JSON input.",
+      "moveKey": "24cdd7f5b667"
     },
     {
       "id": "apps/memory/src/bench-recall.ts#json-parse-file-read#cd9ba4816a71",
       "classification": "external",
-      "reason": "Benchmark query fixtures are JSON inputs."
+      "reason": "Benchmark query fixtures are JSON inputs.",
+      "moveKey": "24cdd7f5b667"
     },
     {
       "id": "apps/memory/src/export.ts#json-stringify-file-write#f2d8c9d8ed18",
       "classification": "external",
-      "reason": "Memory export command deliberately emits JSON."
+      "reason": "Memory export command deliberately emits JSON.",
+      "moveKey": "08dcc3510d92"
     },
     {
       "id": "apps/memory/src/extract-dev-artifact.ts#json-parse-file-read#5fb73f71086b",
       "classification": "external",
-      "reason": "package.json script extraction reads ecosystem JSON."
+      "reason": "package.json script extraction reads ecosystem JSON.",
+      "moveKey": "efb06d615282"
     },
     {
       "id": "apps/memory/src/hook-coverage.ts#json-parse-file-read#1277b6df964e",
       "classification": "external",
-      "reason": "Coverage manifest is a deliberate JSON report input."
+      "reason": "Coverage manifest is a deliberate JSON report input.",
+      "moveKey": "2883fdec968a"
     },
     {
       "id": "apps/memory/src/hook-coverage.ts#json-parse-file-read#4f72ffcb65b4",
       "classification": "external",
-      "reason": "Plugin manifest files are JSON by host contract."
+      "reason": "Plugin manifest files are JSON by host contract.",
+      "moveKey": "f632cd5f3c50"
     },
     {
       "id": "apps/memory/src/import-ams.ts#json-parse-file-read#84cfe0136522",
       "classification": "external",
-      "reason": "AMS import accepts external JSON dump format."
+      "reason": "AMS import accepts external JSON dump format.",
+      "moveKey": "24cdd7f5b667"
     },
     {
       "id": "apps/opencode-host/src/emit.ts#json-stringify-file-write#9bc9165f331e",
       "classification": "external",
-      "reason": "opencode.json is an OpenCode host manifest."
+      "reason": "opencode.json is an OpenCode host manifest.",
+      "moveKey": "9826ffa6ebea"
     },
     {
       "id": "apps/opencode-host/src/generate.ts#json-stringify-file-write#daef2b897070",
       "classification": "external",
-      "reason": "Generated OpenCode manifest is JSON by host contract."
+      "reason": "Generated OpenCode manifest is JSON by host contract.",
+      "moveKey": "36a1f03fd30c"
     },
     {
       "id": "apps/opencode-host/src/hooks-to-events.ts#json-parse-file-read#75c187c88bc1",
       "classification": "external",
-      "reason": "OpenCode hook config is external JSON."
+      "reason": "OpenCode hook config is external JSON.",
+      "moveKey": "302cda051801"
     },
     {
       "id": "apps/opencode-host/src/mcp-passthrough.ts#json-parse-file-read#399ed3f05e9d",
       "classification": "external",
-      "reason": ".mcp.json is MCP ecosystem JSON."
+      "reason": ".mcp.json is MCP ecosystem JSON.",
+      "moveKey": "f632cd5f3c50"
     },
     {
       "id": "apps/rsp/src/two-axis-benchmark.ts#json-parse-file-read#df5d9468826b",
       "classification": "external",
-      "reason": "Benchmark baseline fixture is JSON input."
+      "reason": "Benchmark baseline fixture is JSON input.",
+      "moveKey": "2883fdec968a"
     },
     {
       "id": "packages/red-castle/.red-castle/agent-workflows/shared/common.ts#json-stringify-file-write#8975f393e830",
       "classification": "external",
-      "reason": "Castle workflow helper writes JSON interop artifacts."
+      "reason": "Castle workflow helper writes JSON interop artifacts.",
+      "moveKey": "1afaf3436c0a"
     },
     {
       "id": "packages/red-castle/src/WorktreeLock.ts#json-parse-file-read#231944fa112d",
       "classification": "external",
-      "reason": "Vendored upstream red-castle; its WorktreeLock JSON format is owned by upstream and kept JSON to avoid divergence on cherry-pick sync."
+      "reason": "Vendored upstream red-castle; its WorktreeLock JSON format is owned by upstream and kept JSON to avoid divergence on cherry-pick sync.",
+      "moveKey": "24cdd7f5b667"
     },
     {
       "id": "packages/red-castle/tsup.config.ts#json-parse-file-read#3ec8644e7f1e",
       "classification": "external",
-      "reason": "package.json is ecosystem JSON."
+      "reason": "package.json is ecosystem JSON.",
+      "moveKey": "76cb79829ea3"
     },
     {
       "id": "packages/shared/entrypoint-cli.ts#json-parse-file-read#19e906dc0db9",
       "classification": "external",
-      "reason": "Plugin manifest files are JSON by host contract."
+      "reason": "Plugin manifest files are JSON by host contract.",
+      "moveKey": "2b7c758cd51a"
     },
     {
       "id": "packages/shared/toon-migration.ts#json-parse-file-read#5c446b349f65",
       "classification": "external",
-      "reason": "TOON migration accepts legacy JSON inputs."
+      "reason": "TOON migration accepts legacy JSON inputs.",
+      "moveKey": "e57f5cae7679"
     }
   ]
 }

--- a/apps/dev/src/core/toon-json-guard.ts
+++ b/apps/dev/src/core/toon-json-guard.ts
@@ -14,12 +14,20 @@ export interface ToonJsonIoFinding {
   line: number;
   column: number;
   snippet: string;
+  /** Path-independent identity (sha1 of kind + snippet). Stable when a
+   * behavior-preserving file-split relocates the site to a new file, so the
+   * guard recognizes a move instead of redding on the new path's fresh id. */
+  moveKey: string;
 }
 
 export interface ToonJsonAllowlistEntry {
   id: string;
   classification: ToonJsonAllowlistClassification;
   reason?: string;
+  /** Path-independent identity of the site (see ToonJsonIoFinding.moveKey). A
+   * stale external entry offers its moveKey to absorb the one relocated finding
+   * carrying the same key, so a file-split move never reds the guard. */
+  moveKey?: string;
 }
 
 export interface ToonJsonGuardReport {
@@ -74,13 +82,26 @@ export function collectToonJsonIoFindingsFromFiles(files: readonly ToonJsonSourc
 
 export function formatToonJsonGuardViolations(report: ToonJsonGuardReport): string[] {
   const findingsById = new Map(report.findings.map((finding) => [finding.id, finding]));
+  const allowlistIds = new Set(report.allowlist.map((entry) => entry.id));
   const seenAllowlistIds = new Set<string>();
   const violations: string[] = [];
 
+  // Path-independent keys of EXTERNAL allowlist entries whose exact id has no
+  // current finding — the site at that path/snippet is gone. Each such stale
+  // external move key can absorb one relocated finding sharing the same key: a
+  // behavior-preserving file-split moved the site to a new file (new id, but the
+  // same kind + snippet, hence the same moveKey). Counted so a stale entry
+  // launders at most ONE occurrence — a genuinely-new second site with the same
+  // snippet still reds the guard.
+  const relocatable = new Map<string, number>();
   for (const entry of report.allowlist) {
-    if (seenAllowlistIds.has(entry.id)) {
-      violations.push(`duplicate allowlist id ${entry.id}`);
+    if (entry.classification === "external" && entry.moveKey && !findingsById.has(entry.id)) {
+      relocatable.set(entry.moveKey, (relocatable.get(entry.moveKey) ?? 0) + 1);
     }
+  }
+
+  for (const entry of report.allowlist) {
+    if (seenAllowlistIds.has(entry.id)) violations.push(`duplicate allowlist id ${entry.id}`);
     seenAllowlistIds.add(entry.id);
     if (entry.classification !== "migrate" && entry.classification !== "external") {
       violations.push(`allowlist id ${entry.id} has invalid classification ${String(entry.classification)}`);
@@ -88,18 +109,25 @@ export function formatToonJsonGuardViolations(report: ToonJsonGuardReport): stri
     if (entry.classification === "external" && !entry.reason?.trim()) {
       violations.push(`external allowlist id ${entry.id} must include a one-line reason`);
     }
-    if (!findingsById.has(entry.id)) {
-      violations.push(`stale allowlist id ${entry.id}`);
-    }
+    // A stale entry (no finding at its exact id) is NOT flagged: a stale migrate
+    // entry means a to-convert site was TOON-ified or deleted (the goal); a stale
+    // external entry is a moved/removed external site whose moveKey is offered
+    // above. Leftover ids are harmless cruft a periodic re-seed prunes.
   }
 
-  const allowlistIds = new Set(report.allowlist.map((entry) => entry.id));
   for (const finding of report.findings) {
-    if (!allowlistIds.has(finding.id)) {
-      violations.push(
-        `unallowlisted ${finding.kind} ${finding.id} at ${finding.relativePath}:${finding.line}:${finding.column} ${finding.snippet}`,
-      );
+    if (allowlistIds.has(finding.id)) continue;
+    // Unallowlisted by exact id. Tolerate iff a stale external entry with the same
+    // moveKey is available (a relocation), consuming it 1:1. Otherwise this is a
+    // genuinely-new JSON I/O site that must be classified.
+    const available = relocatable.get(finding.moveKey) ?? 0;
+    if (available > 0) {
+      relocatable.set(finding.moveKey, available - 1);
+      continue;
     }
+    violations.push(
+      `unallowlisted ${finding.kind} ${finding.id} at ${finding.relativePath}:${finding.line}:${finding.column} ${finding.snippet}`,
+    );
   }
 
   return violations;
@@ -117,6 +145,7 @@ export function readToonJsonAllowlist(root: string): ToonJsonAllowlistEntry[] {
       id: String(record.id ?? ""),
       classification: record.classification === "external" ? "external" : "migrate",
       reason: typeof record.reason === "string" ? record.reason : undefined,
+      moveKey: typeof record.moveKey === "string" ? record.moveKey : undefined,
     };
   });
 }
@@ -308,6 +337,11 @@ function makeFinding(
   // change to the JSON statement text itself mints a new id (and warrants
   // re-review). line/column survive as finding fields for the violation message.
   const hash = createHash("sha1").update(`${kind}\0${file.relativePath}\0${snippet}`).digest("hex").slice(0, 12);
+  // Path-independent identity: kind + snippet only (no path). A behavior-
+  // preserving split that moves this site to a new file keeps kind + snippet,
+  // hence the same moveKey, so the guard recognizes the relocation instead of
+  // redding on the new path's fresh id (see formatToonJsonGuardViolations).
+  const moveKey = createHash("sha1").update(`${kind}\0${snippet}`).digest("hex").slice(0, 12);
   return {
     id: `${file.relativePath}#${kind}#${hash}`,
     kind,
@@ -315,6 +349,7 @@ function makeFinding(
     line,
     column,
     snippet,
+    moveKey,
   };
 }
 

--- a/apps/dev/tests/toon-guard-move-tolerance.test.ts
+++ b/apps/dev/tests/toon-guard-move-tolerance.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectToonJsonIoFindingsFromFiles,
+  formatToonJsonGuardViolations,
+  type ToonJsonAllowlistEntry,
+  type ToonJsonIoFinding,
+} from "../src/core/toon-json-guard.js";
+
+// A file-split relocates a JSON I/O site to a new file: same kind + snippet
+// (behavior-preserving) but a new path, so the snippet+path-anchored id changes.
+// The guard must recognize the move via the path-independent moveKey instead of
+// redding, WITHOUT laundering a genuinely-new stack-owned JSON site.
+
+const READ_SNIPPET = `import { readFileSync } from "node:fs";
+export function load(p: string) {
+  const raw = readFileSync(p, "utf8");
+  return JSON.parse(raw);
+}
+`;
+
+function findingIn(relativePath: string): ToonJsonIoFinding {
+  const [finding] = collectToonJsonIoFindingsFromFiles([{ relativePath, sourceText: READ_SNIPPET }]);
+  if (!finding) throw new Error("expected a json-parse-file-read finding");
+  return finding;
+}
+
+describe("toon guard — move tolerance", () => {
+  it("tolerates a relocated external site (stale external entry absorbs the moved finding by moveKey)", () => {
+    const moved = findingIn("apps/x/src/bench-eval/loaders.ts");
+    // The site's pre-split entry: same kind+snippet -> same moveKey, a DIFFERENT
+    // (now stale) id because the old path is gone.
+    const stale: ToonJsonAllowlistEntry = {
+      id: "apps/x/src/bench-eval.ts#json-parse-file-read#deadbeef1234",
+      classification: "external",
+      reason: "external bench data read",
+      moveKey: moved.moveKey,
+    };
+    expect(formatToonJsonGuardViolations({ findings: [moved], allowlist: [stale] })).toEqual([]);
+  });
+
+  it("flags a genuinely-new site (no stale external entry with a matching moveKey)", () => {
+    const fresh = findingIn("apps/x/src/new.ts");
+    const violations = formatToonJsonGuardViolations({ findings: [fresh], allowlist: [] });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("unallowlisted");
+  });
+
+  it("consumes a stale external moveKey at most once (a second same-snippet site still reds)", () => {
+    const a = findingIn("apps/x/src/a.ts");
+    const b = findingIn("apps/x/src/b.ts"); // identical snippet -> same moveKey, different id
+    const stale: ToonJsonAllowlistEntry = {
+      id: "apps/x/src/gone.ts#json-parse-file-read#cafef00d5678",
+      classification: "external",
+      reason: "external data read",
+      moveKey: a.moveKey,
+    };
+    const violations = formatToonJsonGuardViolations({ findings: [a, b], allowlist: [stale] });
+    expect(violations).toHaveLength(1); // one relocation absorbed, one still unallowlisted
+    expect(violations[0]).toContain("unallowlisted");
+  });
+
+  it("does not offer a stale MIGRATE entry as relocatable (only external absorbs moves)", () => {
+    const moved = findingIn("apps/x/src/loaders.ts");
+    const staleMigrate: ToonJsonAllowlistEntry = {
+      id: "apps/x/src/index.ts#json-parse-file-read#0000abcd1111",
+      classification: "migrate",
+      moveKey: moved.moveKey,
+    };
+    const violations = formatToonJsonGuardViolations({ findings: [moved], allowlist: [staleMigrate] });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("unallowlisted");
+  });
+
+  it("does not flag a stale entry itself as a violation (removed/moved sites are harmless)", () => {
+    const stale: ToonJsonAllowlistEntry = {
+      id: "apps/x/src/removed.ts#json-parse-file-read#feedface9999",
+      classification: "external",
+      reason: "external data read",
+      moveKey: "orphan000000",
+    };
+    expect(formatToonJsonGuardViolations({ findings: [], allowlist: [stale] })).toEqual([]);
+  });
+});


### PR DESCRIPTION
The #2104 file-splits relocate external JSON I/O sites → snippet+path-anchored id changes → stale + unallowlisted → live-allowlist ratchet reds → main red on every JSON-touching split, blocking all CI. The fleet can't fix the allowlist (gated sensitive path).

**Fix:** path-independent `moveKey` (sha1 of kind+snippet) on findings + stored per allowlist entry. A **stale external** entry absorbs the one relocated finding with the same moveKey (consumed 1:1) → moves stay green. **Precision preserved:** genuinely-new site (novel moveKey, no stale partner) still reds; a second same-snippet site still reds; stale **migrate** never absorbs. Allowlist re-seeded with moveKey on all 25 entries.

Tests: 5 move-tolerance cases + the live ratchet stays green. Unblocks resuming the split fleet without re-redding the guard on each move.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786995534&installation_id=129708444&pr_number=2142&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2142&signature=185783f9059ba9cf08d305939c685d52334f28e038b193834f5a13376559636a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->