### PR TITLE
fix: #2143 Codex worker telemetry (loc + tools/text) stays 0: attempt-guard progress heartbeat doesn't fire during codex's single long iteration

### DIFF
--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -1274,8 +1274,37 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
   let timeoutReason: AttemptTimeoutReason | undefined;
   let laneReaper: { stop: () => void; firedReap: () => boolean } | undefined;
   let controller: AbortController | undefined;
+  let heartbeatIntervalMs = 60_000;
+  let lastHeartbeatEmitMs: number | undefined;
+  const emitHeartbeat = (info: AttemptProgressInfo): void => {
+    lastHeartbeatEmitMs = info.nowMs;
+    input.onHeartbeat?.(info);
+  };
+  const pulseCodexHeartbeatFromStream = (event: AgentStreamEvent): void => {
+    if (!input.onHeartbeat || input.runner !== "codex" || !input.headProbe) return;
+    if (event.type === "raw" || event.type === "sessionId") return;
+    const nowMs = now();
+    if (lastHeartbeatEmitMs !== undefined && nowMs - lastHeartbeatEmitMs < heartbeatIntervalMs) return;
+    void (async () => {
+      let head: string | undefined;
+      try {
+        head = await input.headProbe?.();
+      } catch {
+        head = undefined;
+      }
+      emitHeartbeat({ head, lastProgressMs: nowMs, nowMs });
+    })();
+  };
+  const agentEventSink: RunAgentInput["onAgentEvent"] | undefined =
+    input.onAgentEvent || input.runner === "codex"
+      ? (event) => {
+          input.onAgentEvent?.(event);
+          pulseCodexHeartbeatFromStream(event);
+        }
+      : undefined;
   if (input.attemptTimeoutSeconds && input.attemptTimeoutSeconds > 0 && input.headProbe) {
     const capMs = input.attemptTimeoutSeconds * 1000;
+    heartbeatIntervalMs = Math.min(capMs, 60_000);
     controller = makeController();
     const cap = input.attemptTimeoutSeconds;
     const hardCap = input.attemptHardCapSeconds;
@@ -1310,7 +1339,7 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
       // Externalized proof-of-life (PR-B): each poll fires the caller's opaque
       // heartbeat sink (firehose record + state.last_progress_at + on_heartbeat
       // hook). execution.ts stays ignorant of what it does.
-      ...(input.onHeartbeat ? { onTick: input.onHeartbeat } : {}),
+      ...(input.onHeartbeat ? { onTick: emitHeartbeat } : {}),
     });
   }
 
@@ -1352,7 +1381,7 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
 
   let result: RunResult;
   try {
-    const options = buildRunOptions(deps, input);
+    const options = buildRunOptions(deps, agentEventSink ? { ...input, onAgentEvent: agentEventSink } : input);
     result = await deps.run(controller ? { ...options, signal: controller.signal } : options);
   } catch (error) {
     // The lane-idle reaper aborted: agent lane silent past the kill threshold

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -2192,4 +2192,87 @@ describe("runAgent — forwards onHeartbeat to the guard tick", () => {
     const res = await p;
     expect(res.outcome).toBe("done");
   });
+
+  it("pulses the heartbeat from codex stream activity before the first guard poll", async () => {
+    let clock = 0;
+    const sched = manualScheduler();
+    const ticks: AttemptProgressInfo[] = [];
+    let resolveRun: ((r: RunResult) => void) | undefined;
+    const deps: SandcastleDeps = {
+      ...makeDeps(
+        (o) =>
+          new Promise<RunResult>((res) => {
+            resolveRun = res;
+            if (o.logging?.type === "file") {
+              o.logging.onAgentStreamEvent?.({
+                type: "toolCall",
+                name: "Bash",
+                formattedArgs: "pnpm test",
+                iteration: 1,
+                timestamp: new Date(clock),
+              });
+            }
+          }),
+      ),
+      now: () => clock,
+      schedule: sched.schedule,
+      makeAbortController: () => new AbortController(),
+    };
+    const p = runAgent(deps, {
+      ...baseInput,
+      runner: "codex",
+      model: "gpt-5.4",
+      logPath: "/tmp/afk.log",
+      attemptTimeoutSeconds: 60,
+      headProbe: async () => "static",
+      onHeartbeat: (i) => ticks.push(i),
+    });
+    await flush();
+    expect(ticks).toHaveLength(1);
+    expect(ticks[0]!.head).toBe("static");
+    expect(ticks[0]!.nowMs).toBe(0);
+    resolveRun?.(fakeResult({ completionSignal: DONE_SIGNAL }));
+    const res = await p;
+    expect(res.outcome).toBe("done");
+  });
+
+  it("keeps non-codex stream activity on the scheduled guard cadence", async () => {
+    const sched = manualScheduler();
+    const ticks: AttemptProgressInfo[] = [];
+    let resolveRun: ((r: RunResult) => void) | undefined;
+    const deps: SandcastleDeps = {
+      ...makeDeps(
+        (o) =>
+          new Promise<RunResult>((res) => {
+            resolveRun = res;
+            if (o.logging?.type === "file") {
+              o.logging.onAgentStreamEvent?.({
+                type: "toolCall",
+                name: "Bash",
+                formattedArgs: "pnpm test",
+                iteration: 1,
+                timestamp: new Date(0),
+              });
+            }
+          }),
+      ),
+      now: () => 0,
+      schedule: sched.schedule,
+      makeAbortController: () => new AbortController(),
+    };
+    const p = runAgent(deps, {
+      ...baseInput,
+      logPath: "/tmp/afk.log",
+      attemptTimeoutSeconds: 60,
+      headProbe: async () => "static",
+      onHeartbeat: (i) => ticks.push(i),
+    });
+    await flush();
+    expect(ticks).toHaveLength(0);
+    await sched.tick();
+    expect(ticks).toHaveLength(1);
+    resolveRun?.(fakeResult({ completionSignal: DONE_SIGNAL }));
+    const res = await p;
+    expect(res.outcome).toBe("done");
+  });
 });


### PR DESCRIPTION
Automated AFK landing for #2143. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2143

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787003318&installation_id=129708444&pr_number=2147&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2147&signature=508fd71ce0f44a375e4f8948b3d31ac0d61fe066075f93b582b1a3914c4151e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->