### PR TITLE
fix(#2139): rename TOON-content worker files .json/.jsonl -> .toon/.toonl

### DIFF
--- a/apps/benchmark-code-understanding/tests/report.test.ts
+++ b/apps/benchmark-code-understanding/tests/report.test.ts
@@ -21,7 +21,7 @@ function record(overrides: Partial<RunRecord>): RunRecord {
     duration_ms: 1000,
     exit_code: 0,
     signal: null,
-    log_path: "/tmp/log.jsonl",
+    log_path: "/tmp/log.toonl",
     mcp_config_path: "/tmp/mcp.json",
     command: ["claude"],
     metrics: {

--- a/apps/dev/src/commands/activity-review.ts
+++ b/apps/dev/src/commands/activity-review.ts
@@ -366,8 +366,8 @@ async function listRetainedLogFiles(workersRoot: string): Promise<string[]> {
       continue;
     }
     for (const attempt of attempts) {
-      out.push(join(workersRoot, worker, attempt, "log.jsonl"));
-      out.push(join(workersRoot, worker, attempt, "agent.log.jsonl"));
+      out.push(join(workersRoot, worker, attempt, "log.toonl"));
+      out.push(join(workersRoot, worker, attempt, "agent.log.toonl"));
     }
   }
   return out;

--- a/apps/dev/src/commands/run/activity.ts
+++ b/apps/dev/src/commands/run/activity.ts
@@ -108,7 +108,7 @@ import { renderClaimComment } from "../../core/claim.js";
  * (Opus effort=high) and carry no exclusive activity signal; returning `undefined`
  * prevents them from clobbering a concrete activity already set by the preceding
  * tool call. Used by `recordAgentEvent` to advance `current.activity` in
- * afk.state.json so the monitor reflects progress.
+ * afk.state.toon so the monitor reflects progress.
  */
 type DerivedActivity =
   | "explore"

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -321,7 +321,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         await fsx.removeDir(pi.attemptDir).catch(() => {});
         return result;
       }
-      const sp = join(pi.attemptDir, "afk.state.json");
+      const sp = join(pi.attemptDir, "afk.state.toon");
       if (await fsx.pathExists(sp)) {
         await updateState(sp, { pid: 0 }, { allowPidReset: true }).catch(() => {});
         await castleBridge.snapshot().catch(() => {});
@@ -372,7 +372,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       // Point the session-scoped envelope/iter-log closures at this attempt.
       current.attemptDir = attemptDir;
       // Native-path observability (sibling of #350): the shell era's iter_open
-      // initialised afk.state.json here; the TS port's ensureAttemptDir is
+      // initialised afk.state.toon here; the TS port's ensureAttemptDir is
       // mkdir-only, so every live native worker was invisible to `monitor` /
       // `statusline` and the fleet stall-detector (which key off this file's
       // pid + current.{number,activity} and its mtime). Restore it: write the
@@ -388,7 +388,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       // vitals but NO identity (rendered as a pid-0 `?`/idle ghost in monitor /
       // statusline). Seeding synchronously guarantees the identity exists before
       // any updateState runs, so every later read preserves it.
-      const statePath = join(attemptDir, "afk.state.json");
+      const statePath = join(attemptDir, "afk.state.toon");
       const startedAt = new Date().toISOString();
       try {
         initStateSync(statePath, {
@@ -420,7 +420,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         // Durable write-once identity sidecar (issue #1219): the immutable
         // worker_id/runner/origin/number/started_at the isolation fallback in
         // readWorkerState reads so a live isolation worker whose host-side
-        // afk.state.json is still zeroed renders its real identity instead of the
+        // afk.state.toon is still zeroed renders its real identity instead of the
         // `?  run=-  00:00:00` ghost. Never clobbered by vitals updateState writes.
         writeIdentitySync(attemptDir, {
           worker_id: c.workerId,

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -558,7 +558,7 @@ export function buildProcessDeps(
       // the meter + iteration markers. Returning here also narrows `event` to the
       // non-raw variants for the rest of the handler.
       if (event.type === "raw") {
-        void appendRecordToonlTaggedRow(join(current.attemptDir, "log.jsonl"), "raw", {
+        void appendRecordToonlTaggedRow(join(current.attemptDir, "log.toonl"), "raw", {
           iteration: event.iteration,
           line: event.line,
         }, {
@@ -567,7 +567,7 @@ export function buildProcessDeps(
         return;
       }
       if (event.type === "sessionId") {
-        void appendRecordToonlTaggedRow(join(current.attemptDir, "log.jsonl"), "session", `session ${event.sessionId}`, {
+        void appendRecordToonlTaggedRow(join(current.attemptDir, "log.toonl"), "session", `session ${event.sessionId}`, {
           ts,
           fields: {
             extra: {
@@ -610,7 +610,7 @@ export function buildProcessDeps(
       if (event.iteration !== lastIter) {
         const emit = (line: string, phase: string, n: number): void => {
           void fsx.appendLine(join(dir0, "afk.log"), line);
-          void appendRecordToonlTaggedRow(join(dir0, "log.jsonl"), "iteration", line, {
+          void appendRecordToonlTaggedRow(join(dir0, "log.toonl"), "iteration", line, {
             ts,
             fields: { extra: { iteration: String(n), phase } },
           }).catch(() => {});
@@ -618,7 +618,7 @@ export function buildProcessDeps(
         if (lastIter > 0) emit(formatIterationMarker(lastIter, "ended", iterMax), "ended", lastIter);
         lastIter = event.iteration;
         emit(formatIterationMarker(lastIter, "started", iterMax), "started", lastIter);
-        void updateState(join(dir0, "afk.state.json"), { "current.iteration": String(lastIter) }).catch(() => {});
+        void updateState(join(dir0, "afk.state.toon"), { "current.iteration": String(lastIter) }).catch(() => {});
       }
       const msg =
         event.type === "text"
@@ -634,7 +634,7 @@ export function buildProcessDeps(
               : event.type === "result"
                 ? `result: ${event.result}`
                 : `→ ${event.name} ${event.formattedArgs}`;
-      void appendAgentRecord(join(current.attemptDir, "agent.log.jsonl"), msg, {
+      void appendAgentRecord(join(current.attemptDir, "agent.log.toonl"), msg, {
         ts,
         fields: { extra: { iteration: String(event.iteration), kind: event.type } },
       }).catch(() => {});
@@ -645,14 +645,14 @@ export function buildProcessDeps(
       // Firehose lane (issue #250): every record in the uniform envelope. The
       // native port left this unopened; restore it so the post-mortem firehose
       // carries the agent turns alongside the (future) heartbeat/hook records.
-      void appendRecordToonlTaggedRow(join(current.attemptDir, "log.jsonl"), "agent", msg, {
+      void appendRecordToonlTaggedRow(join(current.attemptDir, "log.toonl"), "agent", msg, {
         ts,
         fields: { extra: { iteration: String(event.iteration), kind: event.type } },
       }).catch(() => {});
       // The plaintext `[agent] …` mirror into afk.log is intentionally gone:
       // red-castle's file-log now points at the SAME afk.log (process-issue.ts), so
       // it already renders agent text + tool calls there — re-appending here would
-      // double every turn. The structured per-event record stays in agent.log.jsonl
+      // double every turn. The structured per-event record stays in agent.log.toonl
       // + the firehose above, where the rich reasoning/usage glyphs live.
       // Advance the monitor's state view on recognised tool-call transitions
       // (bounded write rate vs every text chunk — the lane mtime above is the
@@ -683,7 +683,7 @@ export function buildProcessDeps(
             }
           : {};
       if (activity || discrete) {
-        void updateState(join(current.attemptDir, "afk.state.json"), {
+        void updateState(join(current.attemptDir, "afk.state.toon"), {
           ...(activity ? { "current.activity": activity, "current.last_stream_line": msg.slice(0, 200) } : {}),
           // Any inner-agent stream activity means we are in the macro `coding`
           // phase (collapses explore/impl/tests/commit — the fine activity lives in
@@ -772,12 +772,12 @@ export function buildProcessDeps(
           removed,
           activity,
         });
-        await appendRecordToonlTaggedRow(join(current.attemptDir, "log.jsonl"), "heartbeat", hb.msg, {
+        await appendRecordToonlTaggedRow(join(current.attemptDir, "log.toonl"), "heartbeat", hb.msg, {
           ts,
           fields: { extra: hb.extra },
         }).catch(() => {});
         await fsx.appendLine(join(current.attemptDir, "afk.log"), `[heartbeat] ${hb.msg}`);
-        await updateState(join(current.attemptDir, "afk.state.json"), {
+        await updateState(join(current.attemptDir, "afk.state.toon"), {
           ...hb.statePatch,
           "current.loc_peak_added": peakLocAdded,
           "current.loc_peak_removed": peakLocRemoved,
@@ -829,7 +829,7 @@ export function buildProcessDeps(
     // signal must never fail the run.
     markPhase: (phase) => {
       void (async () => {
-        await updateState(join(current.attemptDir, "afk.state.json"), {
+        await updateState(join(current.attemptDir, "afk.state.toon"), {
           "current.phase": phase,
         }).catch(() => {});
         await castleBridge.snapshot().catch(() => {});
@@ -837,7 +837,7 @@ export function buildProcessDeps(
     },
     markState: (patch) => {
       void (async () => {
-        await updateState(join(current.attemptDir, "afk.state.json"), patch).catch(() => {});
+        await updateState(join(current.attemptDir, "afk.state.toon"), patch).catch(() => {});
         await castleBridge.snapshot().catch(() => {});
       })();
     },

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -699,7 +699,7 @@ function buildSupervisorDeps(
     now,
     // Event-driven wake (#934): a recursive fs.watch over the workers root resolves
     // the supervisor's inter-tick wait the instant a worker rewrites its
-    // afk.state.json (claim / stage / phase / progress transition), so the loop
+    // afk.state.toon (claim / stage / phase / progress transition), so the loop
     // reacts to a state change immediately instead of waiting out the safety-net
     // timer. Best-effort: a watch failure degrades to pure-timer polling.
     wake: buildStateChangeWake(join(tmpDir, "workers")),

--- a/apps/dev/src/core/adopt-presence.ts
+++ b/apps/dev/src/core/adopt-presence.ts
@@ -39,7 +39,7 @@ export type AdoptPresenceStage = "validating" | "landing";
 /** The immutable identity + issue fields a {@link AdoptPresenceIo.seed} writes
  * onto the presence state file. */
 export interface AdoptPresenceSeed {
-  /** Absolute path of the presence `afk.state.json`. */
+  /** Absolute path of the presence `afk.state.toon`. */
   statePath: string;
   /** The attempt dir the state file (and its liveness lane) live in. */
   attemptDir: string;
@@ -105,7 +105,7 @@ export async function withAdoptPresence<T>(
     params.issue,
     REQUEUE_ADOPT_ATTEMPT,
   );
-  const statePath = join(attemptDir, "afk.state.json");
+  const statePath = join(attemptDir, "afk.state.toon");
   io.seed({
     statePath,
     attemptDir,

--- a/apps/dev/src/core/castle-worker-lane-bridge.test.ts
+++ b/apps/dev/src/core/castle-worker-lane-bridge.test.ts
@@ -20,7 +20,7 @@ describe("createCastleWorkerLaneBridge", () => {
     const workerId = "wAB12";
     const attemptDir = join(redRoot, "tmp", "workers", workerId, "2064-a1");
     await mkdir(attemptDir, { recursive: true });
-    initStateSync(join(attemptDir, "afk.state.json"), {
+    initStateSync(join(attemptDir, "afk.state.toon"), {
       worker_id: workerId,
       pid: 1234,
       runner: "codex",

--- a/apps/dev/src/core/castle-worker-lane-bridge.ts
+++ b/apps/dev/src/core/castle-worker-lane-bridge.ts
@@ -75,7 +75,7 @@ function snapshotFromState(
 function readAttemptState(attemptDir: string): AfkState | null {
   if (!attemptDir) return null;
   try {
-    return parseStateDocument(readFileSync(join(attemptDir, "afk.state.json"), "utf8"));
+    return parseStateDocument(readFileSync(join(attemptDir, "afk.state.toon"), "utf8"));
   } catch {
     return null;
   }

--- a/apps/dev/src/core/event-wake.ts
+++ b/apps/dev/src/core/event-wake.ts
@@ -17,7 +17,7 @@ export type WakeReason = "event" | "timer";
 
 /**
  * A source of worker state-change events. `waitForEvent` resolves the moment the
- * next state change is observed (a worker writing its afk.state.json / appending
+ * next state change is observed (a worker writing its afk.state.toon / appending
  * a heartbeat-firehose record). The `signal` is aborted by {@link waitForNextWake}
  * when the OTHER lane (the timer) wins the race, so the implementation must tear
  * down its watcher on abort — never leak an fs.watch per loop iteration. A throw

--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -311,7 +311,7 @@ export interface RunAgentInput {
    * captures the stream itself). When set together with {@link logPath},
    * `buildRunOptions` wires it into sandcastle's `logging.onAgentStreamEvent`,
    * yielding one callback per text chunk / tool call. process-issue forwards
-   * each event to `agent.log.jsonl` (the clean lane `reaper-signal` /
+   * each event to `agent.log.toonl` (the clean lane `reaper-signal` /
    * `supervisor-fs` read for liveness) + the firehose — without it the lanes'
    * mtime freezes at iteration start and the stall detector / monitor go blind
    * to a live agent. sandcastle swallows any error this callback throws.
@@ -445,7 +445,7 @@ export interface SandcastleDeps {
    * Build the sandbox provider for a mode. `opts.mountPath` (issue #405) is the
    * absolute host attempt dir: under docker/podman it is added as a bind-mount at
    * the identical path inside the container so the attempt dir's proof-of-life
-   * lane (afk.state.json / agent.log.jsonl / log.jsonl) AND the worktree
+   * lane (afk.state.toon / agent.log.toonl / log.toonl) AND the worktree
    * sandcastle creates under it are host-visible in real time — the precondition
    * for arming the progress guard + heartbeat under isolation. Ignored for the
    * host-native `none` mode (no container to mount into).

--- a/apps/dev/src/core/heartbeat.ts
+++ b/apps/dev/src/core/heartbeat.ts
@@ -24,7 +24,7 @@ export interface HeartbeatVitals {
   rss: number;
 }
 
-/** Per-tick state re-read from afk.state.json. */
+/** Per-tick state re-read from afk.state.toon. */
 export interface HeartbeatState {
   activity: string;
   lastStreamLine: string;
@@ -283,7 +283,7 @@ export function buildHeartbeatRecord(
 
 /** Injected per-tick IO: re-read state, read process vitals, get a clock. */
 export interface HeartbeatTickIO {
-  /** Re-read `current.activity` / `current.last_stream_line` from afk.state.json. */
+  /** Re-read `current.activity` / `current.last_stream_line` from afk.state.toon. */
   readState: () => HeartbeatState;
   /** Best-effort cpu/rss from `ps` against the orchestrator pid. */
   readVitals: () => HeartbeatVitals;

--- a/apps/dev/src/core/lane-idle-reaper.ts
+++ b/apps/dev/src/core/lane-idle-reaper.ts
@@ -23,7 +23,7 @@
 //
 // SIGNAL HYGIENE (#243 / #1022): the liveness signal is the red-castle
 // `evaluateLiveness` evaluator over the attempt's `liveness.lane.jsonl` —
-// never `afk.log` or the firehose `agent.log.jsonl`, which the per-minute
+// never `afk.log` or the firehose `agent.log.toonl`, which the per-minute
 // heartbeat keeps fresh and would mask a real stall. The caller wires
 // `livenessVerdict` to a sync probe that reads the liveness lane and calls
 // the evaluator (runtime/wire.ts `agentLivenessVerdictSync`).

--- a/apps/dev/src/core/loc-memo.ts
+++ b/apps/dev/src/core/loc-memo.ts
@@ -3,7 +3,7 @@
 // Issue #1210 (Part B): the statusline/monitor render paths must NEVER shell out
 // to `git diff --shortstat` — that ownership moves to the WRITERS (the per-attempt
 // heartbeat and/or post-commit hook), which stamp `loc_added`/`loc_removed` into
-// `afk.state.json` for ALL runners (codex included — the writer is runner-agnostic,
+// `afk.state.toon` for ALL runners (codex included — the writer is runner-agnostic,
 // so the historical codex `0/0` gap that forced the render fallback disappears).
 //
 // The diffstat is EXPENSIVE (two git subprocesses via {@link diffstatShortstat}),

--- a/apps/dev/src/core/mirror.ts
+++ b/apps/dev/src/core/mirror.ts
@@ -3,7 +3,7 @@
 // Read-only reflection of live AFK workers onto the runner's native task list.
 // Three layers, the diff/map ones pure:
 //
-//   reader      readWorkers(states) — normalizes raw afk.state.json reads (keyed
+//   reader      readWorkers(states) — normalizes raw afk.state.toon reads (keyed
 //     worker_id:issue) into one WorkerRecord per worker that currently owns a
 //     task. Idle workers (no current issue) own no task and are omitted. Liveness
 //     is supplied by the caller via each state's `live` flag, so this stays pure.

--- a/apps/dev/src/core/output-shaping-report.ts
+++ b/apps/dev/src/core/output-shaping-report.ts
@@ -58,7 +58,7 @@ function listStateFiles(dir: string): string[] {
   for (const entry of entries) {
     const path = join(dir, entry.name);
     if (entry.isDirectory()) files.push(...listStateFiles(path));
-    else if (entry.isFile() && entry.name === "afk.state.json") files.push(path);
+    else if (entry.isFile() && entry.name === "afk.state.toon") files.push(path);
   }
   return files;
 }

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -1087,7 +1087,7 @@ export function postAttemptContext(
     result: { status, outcome },
     attempt_n: input.attempt,
     iter_log: `${input.attemptDir}/afk.log`,
-    state_file: `${input.attemptDir}/afk.state.json`,
+    state_file: `${input.attemptDir}/afk.state.toon`,
   });
 }
 export function onErrorContext(input: ProcessIssueInput, workspace: string, errClass: string, attempt: number): string {

--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -20,11 +20,11 @@ export const IDENTITY_FILENAME = "identity.json";
 
 /**
  * The immutable spawn-time identity of one attempt (issue #1219). Written once by
- * {@link writeIdentitySync} beside `afk.state.json` and NEVER clobbered by the
+ * {@link writeIdentitySync} beside `afk.state.toon` and NEVER clobbered by the
  * vitals `updateState` read-modify-writes. It is the durable source the isolation
  * fallback in {@link readWorkerState} reads to render a live worker's real
  * `worker_id`/`runner`/`origin`/`started_at`/issue number when the host-side
- * `afk.state.json` is still zeroed (pid 0, empty identity) pre-sync — so a live
+ * `afk.state.toon` is still zeroed (pid 0, empty identity) pre-sync — so a live
  * worker can never render as the `?  run=-  00:00:00` ghost.
  */
 export interface WorkerIdentity {
@@ -85,7 +85,7 @@ export function readIdentitySync(attemptDir: string): WorkerIdentity | null {
 /**
  * One-release back-compat read shim (ADR 0065): map legacy worker-vitals keys on
  * `current` onto their canonical names when the canonical key is absent, so a NEW
- * bundle reads an OLD afk.state.json without losing the value. The state file is
+ * bundle reads an OLD afk.state.toon without losing the value. The state file is
  * ephemeral (rewritten each ~60s heartbeat), so this only bridges the upgrade
  * window. Remove the shim — and the legacy keys — one release after S1 lands.
  */

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -800,7 +800,7 @@ export type SupervisorEventRecord = Omit<CastleLaneRecord, "at" | "kind"> & {
 };
 
 /** The slot's current iteration, resolved from the filesystem. Mirrors the
- * fields reap_stalled_slot pulls out of afk.state.json. */
+ * fields reap_stalled_slot pulls out of afk.state.toon. */
 export interface IterDirInfo {
   path: string;
   /** .current.number, or null when the worker died before claiming. */
@@ -843,7 +843,7 @@ export interface SupervisorDeps {
   now(): number;
   /**
    * Event-driven wake source (#934): resolves the instant a worker's state
-   * changes (its afk.state.json is rewritten / a heartbeat-firehose record is
+   * changes (its afk.state.toon is rewritten / a heartbeat-firehose record is
    * appended), letting the health-check loop react WITHOUT waiting out the full
    * `pollIntervalS` timer. The timer is always retained as the safety-net
    * fallback — whichever fires first wins the per-iteration race. Absent → the

--- a/apps/dev/src/core/worker-state-reader.ts
+++ b/apps/dev/src/core/worker-state-reader.ts
@@ -1,6 +1,6 @@
-// core/worker-state-reader.ts — the ONE owner for reading afk.state.json.
+// core/worker-state-reader.ts — the ONE owner for reading afk.state.toon.
 //
-// Every consumer that turns an `afk.state.json` on disk into a usable worker
+// Every consumer that turns an `afk.state.toon` on disk into a usable worker
 // record — the monitor/statusline collectors, the mirror feed, boot facts, and
 // the fleet supervisor's reaper — goes through here, so there is a SINGLE parse
 // path: JSON.parse → `parseState` (schema + the ADR 0065 legacy-key shim) →
@@ -31,7 +31,7 @@ export type WorkerLivenessVerdict = "active" | "quiet-but-live" | "dead";
 
 /** One normalized, liveness-tagged worker state read. */
 export interface WorkerStateRecord {
-  /** Absolute path of the `afk.state.json` this record was read from. */
+  /** Absolute path of the `afk.state.toon` this record was read from. */
   path: string;
   /** Parsed state with the schema + ADR 0065 legacy-key shim applied. */
   state: AfkState;
@@ -219,7 +219,7 @@ export interface WorkerStateReadOpts {
    * `{dirname(dirname(path))}/worker.pid` from disk. Only consulted when
    * `state.pid === 0` and the primary evaluator returns "stalled" — this is
    * the host-side liveness signal for isolation workers (docker/podman) where
-   * the host's `afk.state.json.pid` is never populated during the run.
+   * the host's `afk.state.toon.pid` is never populated during the run.
    */
   workerPidContent?: string;
   /**
@@ -254,7 +254,7 @@ function verdictToLiveness(v: LivenessVerdict): WorkerLivenessVerdict {
 }
 
 /**
- * Read and normalize ONE `afk.state.json`. Synchronous so the supervisor reaper
+ * Read and normalize ONE `afk.state.toon`. Synchronous so the supervisor reaper
  * can call it inside its sync closures. Returns `null` when the file is missing,
  * unreadable, not valid JSON, or fails the schema — the safe value every caller
  * already degrades to (issue null / worker skipped). A present-but-partial file
@@ -305,12 +305,12 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
   // the attempt stalled (empty lane + no descendants), probe the per-worker
   // worker.pid file instead. The supervisor writes it on the host regardless of
   // sandbox mode, so it is the reliable host-side liveness signal for isolation
-  // workers even before afk.state.json syncs back at run end.
+  // workers even before afk.state.toon syncs back at run end.
   let finalVerdict = livenessVerdict;
   let hostPidLive = false;
   if (livenessVerdict.status === "stalled" && state.pid === 0 && isNewestAttemptDirForWorker(path)) {
     // worker.pid lives one directory above the attempt dir:
-    // {workersRoot}/{workerId}/{N}-a{n}/afk.state.json → {workersRoot}/{workerId}/worker.pid
+    // {workersRoot}/{workerId}/{N}-a{n}/afk.state.toon → {workersRoot}/{workerId}/worker.pid
     const workerPidPath = join(dirname(dirname(path)), "worker.pid");
     let hostPidText: string | null;
     if (opts.workerPidContent !== undefined) {
@@ -334,7 +334,7 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
       if (hostPidAlive) {
         hostPidLive = true;
         // Synthesize a "quiet-but-live" verdict: the orchestrator is running on
-        // the host but afk.state.json has not synced yet (isolation pre-sync).
+        // the host but afk.state.toon has not synced yet (isolation pre-sync).
         finalVerdict = {
           status: "alive",
           laneFresh: false,
@@ -342,7 +342,7 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
           reason: `state.pid=0 but worker.pid=${hostPid} is alive (isolation worker)`,
         };
         // Durable identity fallback (issue #1219): a live isolation worker whose
-        // host-side afk.state.json is still zeroed (pid 0, empty worker_id/runner)
+        // host-side afk.state.toon is still zeroed (pid 0, empty worker_id/runner)
         // must NOT render as the `?  run=-  00:00:00` ghost. Read the write-once
         // identity.json sidecar and populate the zeroed identity fields from it —
         // never overwriting a value the state file already carries.

--- a/apps/dev/src/runtime/fs.ts
+++ b/apps/dev/src/runtime/fs.ts
@@ -234,7 +234,7 @@ export async function readText(path: string): Promise<string | null> {
 }
 
 /**
- * Glob the worker state files `.../workers/*\/*\/afk.state.json` under a workers
+ * Glob the worker state files `.../workers/*\/*\/afk.state.toon` under a workers
  * root, returning absolute paths. Two levels deep (worker dir → attempt dir).
  */
 export async function globWorkerStates(workersRoot: string): Promise<string[]> {
@@ -254,7 +254,7 @@ export async function globWorkerStates(workersRoot: string): Promise<string[]> {
       continue;
     }
     for (const attempt of attempts) {
-      const stateFile = join(workerPath, attempt, "afk.state.json");
+      const stateFile = join(workerPath, attempt, "afk.state.toon");
       if (await pathExists(stateFile)) out.push(stateFile);
     }
   }
@@ -284,14 +284,14 @@ export async function writeFailureMarkers(attemptDir: string, markers: FailureMa
 /** Persist the `envelope.posted` signal into the iteration state file. Best
  * effort: a malformed/absent state file degrades to writing a minimal object. */
 export async function writeEnvelopePosted(attemptDir: string, posted: boolean): Promise<void> {
-  await updateState(join(attemptDir, "afk.state.json"), { "envelope.posted": posted });
+  await updateState(join(attemptDir, "afk.state.toon"), { "envelope.posted": posted });
 }
 
 /** Read the `envelope.posted` flag from an attempt state file (false when
  * absent/malformed). */
 export async function readEnvelopePosted(attemptDir: string): Promise<boolean> {
   try {
-    return (await readState(join(attemptDir, "afk.state.json"))).envelope.posted === true;
+    return (await readState(join(attemptDir, "afk.state.toon"))).envelope.posted === true;
   } catch {
     return false;
   }

--- a/apps/dev/src/runtime/red-path-migration.test.ts
+++ b/apps/dev/src/runtime/red-path-migration.test.ts
@@ -42,7 +42,7 @@ describe("migrateLegacyDevPaths", () => {
     await writeFile(join(tmp, "afk-supervisor.state.json"), "state", "utf8");
     await writeFile(join(tmp, "statusline-cache.json"), "{}", "utf8");
     await writeFile(join(tmp, "afk-supervisor.log"), "log", "utf8");
-    await writeFile(join(tmp, "afk-supervisor.log.jsonl"), "{}", "utf8");
+    await writeFile(join(tmp, "afk-supervisor.log.toonl"), "{}", "utf8");
     await writeFile(join(tmp, "monitor-log-cursors.json"), "cursors", "utf8");
     await mkdir(join(tmp, "runner-circuit"), { recursive: true });
     await writeFile(join(tmp, "runner-circuit", "claude.json"), "{}", "utf8");
@@ -63,7 +63,7 @@ describe("migrateLegacyDevPaths", () => {
     // The retired human prose log is not dual-written into a new lane.
     expect(await readFile(join(tmp, "afk-supervisor.log"), "utf8")).toBe("log");
     expect(moved).toContain("afk-supervisor.pid");
-    expect(moved).toContain("afk-supervisor.log.jsonl");
+    expect(moved).toContain("afk-supervisor.log.toonl");
   });
 
   it("renames legacy statusline state cache files to .toon", async () => {

--- a/apps/dev/src/runtime/red-path-migration.ts
+++ b/apps/dev/src/runtime/red-path-migration.ts
@@ -76,7 +76,7 @@ export async function migrateLegacyDevPaths(root: string): Promise<DevPathMigrat
   }
   if (await convertLegacyJsonlHistoryIfSafe(root)) moved.push("afk-history.jsonl");
   // Retire the old tmp-root structured supervisor firehose
-  // (afk-supervisor.log.jsonl -> supervisor.log.toonl). Human prose
+  // (afk-supervisor.log.toonl -> supervisor.log.toonl). Human prose
   // afk-supervisor.log is not moved or dual-written into a new lane.
   const { legacyDir, currentDir, logPrefix } = supervisorLogMigration(root);
   let entries: string[] = [];
@@ -87,7 +87,7 @@ export async function migrateLegacyDevPaths(root: string): Promise<DevPathMigrat
   }
   for (const name of entries) {
     if (!name.startsWith(logPrefix)) continue;
-    if (name !== "afk-supervisor.log.jsonl" && name !== "afk-supervisor.log.toonl") continue;
+    if (name !== "afk-supervisor.log.toonl" && name !== "afk-supervisor.log.toonl") continue;
     const currentName = "supervisor.log.toonl";
     if (await moveIfSafe(join(legacyDir, name), join(currentDir, currentName))) moved.push(name);
   }

--- a/apps/dev/src/runtime/state-watch.ts
+++ b/apps/dev/src/runtime/state-watch.ts
@@ -1,7 +1,7 @@
 // runtime/state-watch.ts — the REAL worker-state-change event source backing the
 // supervisor's event-driven wake (#934). A recursive fs.watch over the workers
 // root (.red/tmp/workers) resolves the supervisor's per-iteration wait the moment
-// a worker rewrites its `afk.state.json` (every claim / stage / phase / progress
+// a worker rewrites its `afk.state.toon` (every claim / stage / phase / progress
 // transition writes that file atomically). The supervisor races this against its
 // safety-net timer, so a state change is reacted to immediately while the timer
 // still guarantees a wake if an event is ever missed.
@@ -18,12 +18,12 @@ import type { WakeSource } from "../core/event-wake.js";
  * event naming this file is a genuine state change worth waking the supervisor
  * for; events on the noisier log/firehose siblings are ignored so a `tail -f`
  * churn does not wake the loop. */
-const STATE_FILENAME = "afk.state.json";
+const STATE_FILENAME = "afk.state.toon";
 
 /**
  * Build the supervisor's worker-state-change {@link WakeSource} over a recursive
  * fs.watch of `workersRoot`. Each `waitForEvent` call installs a fresh watcher
- * that resolves on the FIRST `afk.state.json` change (then tears itself down) or
+ * that resolves on the FIRST `afk.state.toon` change (then tears itself down) or
  * on abort (the supervisor's timer won the race). A watch that cannot be
  * established — directory missing, recursive unsupported, fs error — resolves
  * only on abort, so the supervisor falls back to its timer with no spurious wakes.

--- a/apps/dev/src/runtime/supervisor-fs.ts
+++ b/apps/dev/src/runtime/supervisor-fs.ts
@@ -6,7 +6,7 @@
 //   find_slot_iter_dir         (slot pid → worker dir → newest attempt dir)
 //   workerLivenessFor          (iter dir → liveness lane → evaluator verdict)
 //   iter_dirs_for_worker       (worker dir → every attempt dir)
-//   iter_dir_issue_number      (afk.state.json → .current.number)
+//   iter_dir_issue_number      (afk.state.toon → .current.number)
 //   reap_stalled_slot reads    (notes, afk.log tail, duration)
 //
 // Every export is BEST-EFFORT: a failed read / stat / glob degrades to the safe
@@ -124,7 +124,7 @@ export function sumWorkerCostUsd(tmpDir: string): number {
       continue;
     }
     for (const attempt of attempts) {
-      const rec = readWorkerState(join(wdir, attempt, "afk.state.json"));
+      const rec = readWorkerState(join(wdir, attempt, "afk.state.toon"));
       if (rec === null) continue;
       const cost = rec.state.current.cost_usd;
       if (Number.isFinite(cost) && cost > 0) total += cost;
@@ -133,12 +133,12 @@ export function sumWorkerCostUsd(tmpDir: string): number {
   return total;
 }
 
-/** `.current.number` from a dir's afk.state.json, or null. Mirrors
+/** `.current.number` from a dir's afk.state.toon, or null. Mirrors
  * iter_dir_issue_number. Reads through the single owner
  * (core/worker-state-reader) so the schema + legacy-key shim apply — no private
  * JSON.parse. */
 export function iterDirIssueNumber(dir: string): number | null {
-  const rec = readWorkerState(join(dir, "afk.state.json"));
+  const rec = readWorkerState(join(dir, "afk.state.toon"));
   const n = rec?.state.current.number;
   return typeof n === "number" && Number.isInteger(n) ? n : null;
 }
@@ -228,7 +228,7 @@ export function workerLivenessFor(
   // Worker pid from the state file for the descendant probe.
   let agentPid = 0;
   try {
-    const rec = readWorkerState(join(dir, "afk.state.json"));
+    const rec = readWorkerState(join(dir, "afk.state.toon"));
     if (rec !== null) agentPid = rec.state.pid;
   } catch {
     // best-effort
@@ -268,7 +268,7 @@ function tailFile(path: string, n: number): string {
 
 /**
  * resolveIterDir backing: the slot's current iteration + the envelope material
- * reap_stalled_slot pulls from afk.state.json (issue, worker_id, started_at →
+ * reap_stalled_slot pulls from afk.state.toon (issue, worker_id, started_at →
  * duration), handoff.md (notes), and afk.log (log tail). Returns null when no
  * iter dir resolves. Best-effort: missing pieces degrade to empty / 0.
  */
@@ -286,7 +286,7 @@ export function resolveIterDirInfo(
   let branch: string | undefined;
   // Single owner (core/worker-state-reader): null when the dir has no/malformed
   // state, in which case issue/worker stay empty and teardown still proceeds.
-  const rec = readWorkerState(join(dir, "afk.state.json"));
+  const rec = readWorkerState(join(dir, "afk.state.toon"));
   if (rec !== null) {
     const n = rec.state.current.number;
     if (typeof n === "number" && Number.isInteger(n)) issue = n;

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -286,7 +286,7 @@ export function resolveRunSettings(
  *
  * Replaces the old `agentLaneMtimeSeconds` firehose-mtime probe (#1022): the
  * liveness lane is the un-poisonable signal that the substrate's own control
- * flow refreshes — never afk.log / agent.log.jsonl / the heartbeat (#243).
+ * flow refreshes — never afk.log / agent.log.toonl / the heartbeat (#243).
  */
 export function agentLivenessVerdictSync(
   attemptDir: string,
@@ -1635,7 +1635,7 @@ export async function collectBootOptions(
     // Cap-pass liveness keeps the pid-identity verdict (a live attempt is
     // excluded from the cap even when briefly quiet), read through the single
     // owner so the schema + legacy-key shim apply here too.
-    const live = readWorkerState(join(o.path, "afk.state.json"))?.live ?? false;
+    const live = readWorkerState(join(o.path, "afk.state.toon"))?.live ?? false;
     const mtimeS = nowS - o.ageS;
     const list = byIssue.get(parsed.issue) ?? [];
     list.push({ path: o.path, mtimeS, live });

--- a/apps/dev/tests/activity-review.test.ts
+++ b/apps/dev/tests/activity-review.test.ts
@@ -211,7 +211,7 @@ describe("activity review", () => {
     const root = await mkdtemp(join(tmpdir(), "activity-review-firehose-"));
     const attemptDir = join(root, "wAAAA", "1824-a1");
     await mkdir(attemptDir, { recursive: true });
-    const log = join(attemptDir, "log.jsonl");
+    const log = join(attemptDir, "log.toonl");
     const tagged: string[] = [];
     const sink = async (_p: string, line: string) => void tagged.push(line);
     await appendRecordToonlTaggedRow(log, "raw", { iteration: 1, line: "{\"inputTokens\":7,\"outputTokens\":11}" }, {
@@ -240,7 +240,7 @@ describe("activity review", () => {
     const root = await mkdtemp(join(tmpdir(), "activity-review-cursor-"));
     const attemptDir = join(root, "wAAAA", "1825-a1");
     await mkdir(attemptDir, { recursive: true });
-    const log = join(attemptDir, "log.jsonl");
+    const log = join(attemptDir, "log.toonl");
     await appendRecordToonlTaggedRow(log, "raw", { iteration: 1, line: "{\"inputTokens\":7,\"outputTokens\":11}" }, {
       ts: "2026-07-15T12:00:00.000Z",
       fields: { extra: { iteration: "1" } },

--- a/apps/dev/tests/adopt-presence-io.test.ts
+++ b/apps/dev/tests/adopt-presence-io.test.ts
@@ -29,7 +29,7 @@ describe("makeAdoptPresenceIo — real state file, read through the shipped read
     const tmpDir = join(root, ".red", "tmp");
     const io = makeAdoptPresenceIo("claude");
     const dir = attemptDir(tmpDir, 42);
-    const statePath = join(dir, "afk.state.json");
+    const statePath = join(dir, "afk.state.toon");
 
     const outcome = await withAdoptPresence(
       io,
@@ -65,7 +65,7 @@ describe("makeAdoptPresenceIo — real state file, read through the shipped read
     await expect(
       withAdoptPresence(io, { tmpDir, issue: 7, title: "Boom", runner: "claude" }, async () => {
         // The row exists while the body runs.
-        expect(existsSync(join(dir, "afk.state.json"))).toBe(true);
+        expect(existsSync(join(dir, "afk.state.toon"))).toBe(true);
         throw new Error("gate exploded");
       }),
     ).rejects.toThrow("gate exploded");

--- a/apps/dev/tests/adopt-presence.test.ts
+++ b/apps/dev/tests/adopt-presence.test.ts
@@ -60,7 +60,7 @@ describe("withAdoptPresence — seed", () => {
     expect(seed.stage).toBe("validating");
     // Canonical `workers/` root (never go-workers/scout-workers) + stable issue id.
     expect(seed.attemptDir).toBe("/tmp/.red/tmp/workers/requeue-adopt/42");
-    expect(seed.statePath).toBe("/tmp/.red/tmp/workers/requeue-adopt/42/afk.state.json");
+    expect(seed.statePath).toBe("/tmp/.red/tmp/workers/requeue-adopt/42/afk.state.toon");
   });
 
   it("uses a distinct requeue provenance constant", () => {
@@ -120,7 +120,7 @@ describe("withAdoptPresence — stage progression", () => {
     expect(r.stages.map((s) => s.stage)).toEqual(["validating", "landing"]);
     // Stage updates target the seeded presence state file.
     for (const s of r.stages) {
-      expect(s.statePath).toBe("/tmp/.red/tmp/workers/requeue-adopt/42/afk.state.json");
+      expect(s.statePath).toBe("/tmp/.red/tmp/workers/requeue-adopt/42/afk.state.toon");
     }
     // Order: seed → stages → teardown last.
     expect(r.events).toEqual(["seed", "stage:validating", "stage:landing", "teardown"]);

--- a/apps/dev/tests/castle-engine-toon-uniformity.test.ts
+++ b/apps/dev/tests/castle-engine-toon-uniformity.test.ts
@@ -82,7 +82,7 @@ describe("castle-engine write-surface TOON uniformity", () => {
 
   it("the per-attempt worker state snapshot is TOON, never raw JSON", async () => {
     const dir = await mkdtemp(join(tmpdir(), "castle-toon-state-"));
-    const path = join(dir, "afk.state.json");
+    const path = join(dir, "afk.state.toon");
     const state = defaultState();
     await writeStateAtomic(path, state);
     const bytes = await readFile(path, "utf8");

--- a/apps/dev/tests/companion-io.test.ts
+++ b/apps/dev/tests/companion-io.test.ts
@@ -21,7 +21,7 @@ import type { WorkerStateRecord } from "../src/core/worker-state-reader.js";
 // A worker-state record whose path encodes (issue, attempt) for parseWorkerAttemptPath.
 function record(issue: number, attempt: number, current: Record<string, unknown>, live = true): WorkerStateRecord {
   return {
-    path: `/r/.red/tmp/workers/host-w/${issue}-a${attempt}/afk.state.json`,
+    path: `/r/.red/tmp/workers/host-w/${issue}-a${attempt}/afk.state.toon`,
     state: parseState({ current: { number: issue, ...current } }),
     live,
     active: live,

--- a/apps/dev/tests/fs-envelope.test.ts
+++ b/apps/dev/tests/fs-envelope.test.ts
@@ -8,7 +8,7 @@ import { readEnvelopePosted, writeEnvelopePosted } from "../src/runtime/fs.js";
 describe("envelope posted state persistence", () => {
   it("preserves accumulated worker state while updating the envelope flag", async () => {
     const attemptDir = await mkdtemp(join(tmpdir(), "afk-envelope-"));
-    const statePath = join(attemptDir, "afk.state.json");
+    const statePath = join(attemptDir, "afk.state.toon");
     const original = `${JSON.stringify({
       worker_id: "wENV",
       pid: 123,

--- a/apps/dev/tests/fs-sweep.test.ts
+++ b/apps/dev/tests/fs-sweep.test.ts
@@ -408,7 +408,7 @@ describe("reapDeadEmptyWorkerShells (#1355)", () => {
       const preservedWorker = join(root, "scout-workers", "wPRESERVE");
       const preservedAttempt = join(preservedWorker, "13-a1");
       mkdirSync(preservedAttempt, { recursive: true });
-      writeFileSync(join(preservedAttempt, "agent.log.jsonl"), "blocked evidence");
+      writeFileSync(join(preservedAttempt, "agent.log.toonl"), "blocked evidence");
       writeFileSync(join(preservedWorker, "worker.pid"), DEAD_PID);
 
       const result = await reapDeadEmptyWorkerShells(root);
@@ -416,7 +416,7 @@ describe("reapDeadEmptyWorkerShells (#1355)", () => {
       expect(result.workerDirs).toEqual([emptyWorker]);
       expect(result.emptyAttemptDirs).toEqual([join(emptyWorker, "12-a1")]);
       expect(existsSync(emptyWorker)).toBe(false);
-      expect(readdirSync(preservedAttempt)).toEqual(["agent.log.jsonl"]);
+      expect(readdirSync(preservedAttempt)).toEqual(["agent.log.toonl"]);
       expect(readFileSync(join(preservedWorker, "worker.pid"), "utf8")).toBe(DEAD_PID);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/apps/dev/tests/hook-dispatcher.test.ts
+++ b/apps/dev/tests/hook-dispatcher.test.ts
@@ -382,12 +382,12 @@ describe("deriveHookEnv (documented per-event RED_AFK_* contract)", () => {
         result: { status: "success", outcome: "done" },
         attempt_n: 1,
         iter_log: "/repo/.red/tmp/workers/w0/42-1/afk.log",
-        state_file: "/repo/.red/tmp/workers/w0/42-1/afk.state.json",
+        state_file: "/repo/.red/tmp/workers/w0/42-1/afk.state.toon",
       }),
     );
 
     expect(env.RED_AFK_ITER_LOG).toBe("/repo/.red/tmp/workers/w0/42-1/afk.log");
-    expect(env.RED_AFK_STATE_FILE).toBe("/repo/.red/tmp/workers/w0/42-1/afk.state.json");
+    expect(env.RED_AFK_STATE_FILE).toBe("/repo/.red/tmp/workers/w0/42-1/afk.state.toon");
   });
 
   it("leaves RED_AFK_ITER_LOG and RED_AFK_STATE_FILE unset when absent from context", () => {

--- a/apps/dev/tests/hook-scripts.test.ts
+++ b/apps/dev/tests/hook-scripts.test.ts
@@ -175,7 +175,7 @@ describe("red-envelope parity", () => {
   it("writes result_status from context into state file", async () => {
     if (skipIfMissing("red-envelope")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-envelope-"));
-    const stateFile = join(tmp, "afk.state.json");
+    const stateFile = join(tmp, "afk.state.toon");
     writeFileSync(stateFile, JSON.stringify({ current: { activity: "running" } }));
     const ctx = JSON.stringify({ result: { status: "success", outcome: "done" } });
     const r = await runScript("red-envelope", { RED_AFK_STATE_FILE: stateFile }, ctx);
@@ -189,7 +189,7 @@ describe("red-envelope parity", () => {
   it("falls back to RED_AFK_RESULT_STATUS env when ctx.result.status absent", async () => {
     if (skipIfMissing("red-envelope")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-envelope-"));
-    const stateFile = join(tmp, "afk.state.json");
+    const stateFile = join(tmp, "afk.state.toon");
     writeFileSync(stateFile, JSON.stringify({ current: {} }));
     const r = await runScript("red-envelope", { RED_AFK_STATE_FILE: stateFile, RED_AFK_RESULT_STATUS: "fail" }, "{}");
     expect(r.code).toBe(0);

--- a/apps/dev/tests/jsonl-log.test.ts
+++ b/apps/dev/tests/jsonl-log.test.ts
@@ -185,22 +185,22 @@ describe("jsonl-log lane routing", () => {
     const firehose: string[] = [];
     const sink = async (_p: string, line: string) => void firehose.push(line);
 
-    await appendRecordToonlTaggedRow("/attempt/log.jsonl", "raw", { iteration: 1, line: "{\"inputTokens\":3}" }, {
+    await appendRecordToonlTaggedRow("/attempt/log.toonl", "raw", { iteration: 1, line: "{\"inputTokens\":3}" }, {
       ts: TS,
       fields: { extra: { iteration: "1" } },
       sink,
     });
-    await appendRecordToonlTaggedRow("/attempt/log.jsonl", "agent", "hello", {
+    await appendRecordToonlTaggedRow("/attempt/log.toonl", "agent", "hello", {
       ts: TS,
       fields: { extra: { iteration: "1", kind: "text" } },
       sink,
     });
-    await appendRecordToonlTaggedRow("/attempt/log.jsonl", "raw", { iteration: 2, line: "{\"outputTokens\":5}" }, {
+    await appendRecordToonlTaggedRow("/attempt/log.toonl", "raw", { iteration: 2, line: "{\"outputTokens\":5}" }, {
       ts: TS,
       fields: { extra: { iteration: "2" } },
       sink,
     });
-    await appendRecordToonlTaggedRow("/attempt/log.jsonl", "agent", "again", {
+    await appendRecordToonlTaggedRow("/attempt/log.toonl", "agent", "again", {
       ts: TS,
       fields: { extra: { kind: "text", iteration: "2" } },
       sink,
@@ -267,7 +267,7 @@ describe("jsonl-log append accumulation and readers", () => {
 
   it("writes stable-schema TOONL lanes with one header and appended rows", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-toonl-row-"));
-    const lane = join(dir, "afk-supervisor.log.jsonl");
+    const lane = join(dir, "afk-supervisor.log.toonl");
     await appendRecordToonlRow(lane, "heartbeat", "first", {
       ts: TS,
       fields: { worker: "fleet", extra: { scope: "fleet", runner: "codex" } },

--- a/apps/dev/tests/log-cursor.test.ts
+++ b/apps/dev/tests/log-cursor.test.ts
@@ -56,7 +56,7 @@ describe("monitor log cursor", () => {
 
   it("counts appended TOONL records from a structured-lane cursor", async () => {
     const root = await mkdtemp(join(tmpdir(), "afk-log-cursor-"));
-    const log = join(root, "log.jsonl");
+    const log = join(root, "log.toonl");
     const cache = join(root, "monitor-log-cursors.json");
     await appendRecordToonlTaggedRow(log, "agent", "first", {
       ts: "2026-07-15T12:00:00.000Z",

--- a/apps/dev/tests/output-shaping-report.test.ts
+++ b/apps/dev/tests/output-shaping-report.test.ts
@@ -14,7 +14,7 @@ function writeState(root: string, worker: string, attempt: string, variant: stri
   const dir = join(root, ".red", "tmp", "workers", worker, attempt);
   mkdirSync(dir, { recursive: true });
   writeFileSync(
-    join(dir, "afk.state.json"),
+    join(dir, "afk.state.toon"),
     JSON.stringify({
       current: {
         number: Number(attempt.split("-")[0]),
@@ -59,7 +59,7 @@ describe("AFK output shaping report", () => {
     mkdirSync(toonDir, { recursive: true });
     mkdirSync(legacyDir, { recursive: true });
     writeFileSync(
-      join(toonDir, "afk.state.json"),
+      join(toonDir, "afk.state.toon"),
       encode({
         current: {
           number: 8,
@@ -70,7 +70,7 @@ describe("AFK output shaping report", () => {
       "utf8",
     );
     writeFileSync(
-      join(legacyDir, "afk.state.json"),
+      join(legacyDir, "afk.state.toon"),
       JSON.stringify({
         current: {
           number: 9,

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -59,7 +59,7 @@ interface Trace {
   iterLogs: string[];
   /** Main-red repair issue create attempts from the baseline probe sync path. */
   mainRedRepairCreates: Array<{ title: string; body: string; labels: readonly string[] }>;
-  /** Compact state patches written to afk.state.json. */
+  /** Compact state patches written to afk.state.toon. */
   statePatches: Array<Record<string, unknown>>;
   /** Branches for which cascadeRebase.rebaseAndPush was called (#1007). */
   cascadeRebaseAttempts: string[];

--- a/apps/dev/tests/retake.test.ts
+++ b/apps/dev/tests/retake.test.ts
@@ -79,7 +79,7 @@ describe("recommendRetake", () => {
       branches: [{ name: "origin/codex/123-retake", remote: true }],
       worktrees: [],
       workerState: {
-        path: "/repo/.red/tmp/workers/wAAAA/123-a2/afk.state.json",
+        path: "/repo/.red/tmp/workers/wAAAA/123-a2/afk.state.toon",
         attemptDir: "/repo/.red/tmp/workers/wAAAA/123-a2",
         issue: 123,
         attempt: 2,
@@ -169,7 +169,7 @@ describe("recommendRetake", () => {
       branches: [{ name: "origin/codex/123-retake", remote: true }],
       worktrees: [],
       workerState: {
-        path: "/repo/.red/tmp/workers/wAAAA/123-a2/afk.state.json",
+        path: "/repo/.red/tmp/workers/wAAAA/123-a2/afk.state.toon",
         attemptDir: "/repo/.red/tmp/workers/wAAAA/123-a2",
         issue: 123,
         attempt: 2,

--- a/apps/dev/tests/state-watch.test.ts
+++ b/apps/dev/tests/state-watch.test.ts
@@ -14,7 +14,7 @@ function settledWithin(p: Promise<unknown>, ms: number): Promise<boolean> {
 }
 
 describe("buildStateChangeWake", () => {
-  it("resolves when a worker rewrites its afk.state.json (event-driven wake)", async () => {
+  it("resolves when a worker rewrites its afk.state.toon (event-driven wake)", async () => {
     const root = mkdtempSync(join(tmpdir(), "rs-statewatch-"));
     const workersRoot = join(root, "workers");
     const workerDir = join(workersRoot, "w1");
@@ -25,7 +25,7 @@ describe("buildStateChangeWake", () => {
       const fired = wake.waitForEvent(controller.signal);
       // Give the watcher a beat to attach, then write the state file.
       await new Promise((r) => setTimeout(r, 20));
-      writeFileSync(join(workerDir, "afk.state.json"), '{"stage":"impl"}');
+      writeFileSync(join(workerDir, "afk.state.toon"), '{"stage":"impl"}');
       expect(await settledWithin(fired, 1000)).toBe(true);
       controller.abort();
     } finally {

--- a/apps/dev/tests/state.test.ts
+++ b/apps/dev/tests/state.test.ts
@@ -25,7 +25,7 @@ describe("state", () => {
 
   it("writes atomically and supports dotted updates", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
-    const path = join(dir, "afk.state.json");
+    const path = join(dir, "afk.state.toon");
     await initState(path, { worker_id: "wAAAA", pid: 123, "current.activity": "impl" });
     await updateState(path, { "current.activity": "tests", "envelope.posted": true, queue: [2, 3] });
     const state = await readState(path);
@@ -39,7 +39,7 @@ describe("state", () => {
 
   it("round-trips resolved base provenance fields through state updates", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
-    const path = join(dir, "afk.state.json");
+    const path = join(dir, "afk.state.toon");
     await initState(path, { worker_id: "wAAAA", pid: 123, "current.activity": "setup" });
 
     await updateState(path, {
@@ -68,7 +68,7 @@ describe("state", () => {
 
   it("initStateSync seeds identity synchronously so a later updateState preserves it", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
-    const path = join(dir, "afk.state.json");
+    const path = join(dir, "afk.state.toon");
 
     // Synchronous seed — the file MUST exist with full identity the instant the
     // call returns (the whole point: it beats the async sink's read-modify-write).
@@ -98,7 +98,7 @@ describe("state", () => {
 
   it("records and preserves the castle worker kind under current.kind", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
-    const path = join(dir, "afk.state.json");
+    const path = join(dir, "afk.state.toon");
 
     initStateSync(path, {
       worker_id: "wGO12",
@@ -122,7 +122,7 @@ describe("state", () => {
 
   it("preserves stamped identity, vitals, and loc when a stage writer carries default identity fields", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
-    const path = join(dir, "afk.state.json");
+    const path = join(dir, "afk.state.toon");
 
     initStateSync(path, {
       worker_id: "w8UV2",
@@ -178,7 +178,7 @@ describe("state", () => {
 
   it("preserves live pid and current identity when stamping the validating phase", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
-    const path = join(dir, "afk.state.json");
+    const path = join(dir, "afk.state.toon");
 
     initStateSync(path, {
       worker_id: "wSVD3",
@@ -218,7 +218,7 @@ describe("state", () => {
 
   it("only allows pid to reset to zero when the caller marks a real teardown", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
-    const path = join(dir, "afk.state.json");
+    const path = join(dir, "afk.state.toon");
 
     initStateSync(path, { worker_id: "wLIVE", pid: 99, "current.number": 1238 });
 
@@ -277,8 +277,8 @@ describe("state", () => {
 
   it("read-shims legacy worker-vitals keys onto their canonical names (ADR 0065)", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
-    const path = join(dir, "afk.state.json");
-    // An OLD afk.state.json written by a pre-S1 bundle: legacy keys only.
+    const path = join(dir, "afk.state.toon");
+    // An OLD afk.state.toon written by a pre-S1 bundle: legacy keys only.
     const legacy = {
       version: 1,
       current: {
@@ -299,7 +299,7 @@ describe("state", () => {
 
   it("prefers the canonical key over the legacy alias when both are present", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
-    const path = join(dir, "afk.state.json");
+    const path = join(dir, "afk.state.toon");
     const both = { version: 1, current: { loc_added: 99, diff_added: 1 } };
     await writeFile(path, JSON.stringify(both), "utf8");
     const state = await readState(path);

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -61,7 +61,7 @@ async function writeWorkerState(
 ): Promise<void> {
   const dir = join(root, ".red", "tmp", namespace, worker, attempt);
   await mkdir(dir, { recursive: true });
-  await writeFile(join(dir, "afk.state.json"), JSON.stringify({ pid: process.pid, ...state }), "utf8");
+  await writeFile(join(dir, "afk.state.toon"), JSON.stringify({ pid: process.pid, ...state }), "utf8");
 }
 
 /** Write a FRESH liveness lane record into an attempt dir so the red-castle

--- a/apps/dev/tests/supervisor-fs.test.ts
+++ b/apps/dev/tests/supervisor-fs.test.ts
@@ -97,7 +97,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
     }
   });
 
-  it("resolves worker ID + claimed issue from slot log + afk.state.json", () => {
+  it("resolves worker ID + claimed issue from slot log + afk.state.toon", () => {
     const tmp = scratch();
     try {
       const logs = slotLogDir(tmp, new Date("2026-07-17T12:00:00.000Z"));
@@ -107,7 +107,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       const iterDir = join(tmp, "workers", "wAAAA", "42-a1");
       mkdirSync(iterDir, { recursive: true });
       writeFileSync(
-        join(iterDir, "afk.state.json"),
+        join(iterDir, "afk.state.toon"),
         JSON.stringify({ current: { number: 42 } }),
         "utf8",
       );
@@ -124,7 +124,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
     }
   });
 
-  it("handles a pre-claim worker (no afk.state.json → issue null)", () => {
+  it("handles a pre-claim worker (no afk.state.toon → issue null)", () => {
     const tmp = scratch();
     try {
       const logs = slotLogDir(tmp, new Date("2026-07-17T12:00:00.000Z"));
@@ -132,7 +132,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       writeFileSync(slotLogPath(tmp, 1, logs), "[afk] worker: wBBBB\n", "utf8");
       const iterDir = join(tmp, "workers", "wBBBB", "7-a1");
       mkdirSync(iterDir, { recursive: true });
-      // No afk.state.json — worker died before claiming.
+      // No afk.state.toon — worker died before claiming.
 
       const work = parkedSlotWorkFor(tmp, 1, null, undefined, logs);
       expect(work.workers).toHaveLength(1);
@@ -157,7 +157,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       const ccDir = join(tmp, "workers", "wCCCC", "10-a1");
       mkdirSync(ccDir, { recursive: true });
       writeFileSync(
-        join(ccDir, "afk.state.json"),
+        join(ccDir, "afk.state.toon"),
         JSON.stringify({ current: { number: 10 } }),
         "utf8",
       );
@@ -165,7 +165,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       const ddDir = join(tmp, "workers", "wDDDD", "11-a1");
       mkdirSync(ddDir, { recursive: true });
       writeFileSync(
-        join(ddDir, "afk.state.json"),
+        join(ddDir, "afk.state.toon"),
         JSON.stringify({ current: { number: 11 } }),
         "utf8",
       );
@@ -218,7 +218,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       const iterDir = join(workerPath, "55-a1");
       mkdirSync(iterDir, { recursive: true });
       writeFileSync(
-        join(iterDir, "afk.state.json"),
+        join(iterDir, "afk.state.toon"),
         JSON.stringify({ current: { number: 55 } }),
         "utf8",
       );
@@ -234,7 +234,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
     }
   });
 
-  it("PID fallback returns pre-claim worker (no afk.state.json) with issue null", () => {
+  it("PID fallback returns pre-claim worker (no afk.state.toon) with issue null", () => {
     const tmp = scratch();
     try {
       const wid = "wQQQQ";
@@ -244,7 +244,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       mkdirSync(workerPath, { recursive: true });
       writeFileSync(join(workerPath, "worker.pid"), String(pid), "utf8");
 
-      // Iter dir created but worker died before writing afk.state.json.
+      // Iter dir created but worker died before writing afk.state.toon.
       const iterDir = join(workerPath, "7-a1");
       mkdirSync(iterDir, { recursive: true });
 
@@ -297,7 +297,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       const logIterDir = join(tmp, "workers", logWid, "20-a1");
       mkdirSync(logIterDir, { recursive: true });
       writeFileSync(
-        join(logIterDir, "afk.state.json"),
+        join(logIterDir, "afk.state.toon"),
         JSON.stringify({ current: { number: 20 } }),
         "utf8",
       );
@@ -309,7 +309,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       const pidIterDir = join(pidWorkerPath, "21-a1");
       mkdirSync(pidIterDir, { recursive: true });
       writeFileSync(
-        join(pidIterDir, "afk.state.json"),
+        join(pidIterDir, "afk.state.toon"),
         JSON.stringify({ current: { number: 21 } }),
         "utf8",
       );
@@ -332,7 +332,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       const iterDir = join(tmp, "workers", "wOLD1", "88-a1");
       mkdirSync(iterDir, { recursive: true });
       writeFileSync(
-        join(iterDir, "afk.state.json"),
+        join(iterDir, "afk.state.toon"),
         JSON.stringify({ current: { number: 88 } }),
         "utf8",
       );

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -791,7 +791,7 @@ describe("circuit trip — real FS integration (slot-log boot-stamp path)", () =
       // boot-stamp so the slot log records them. Only the second claimed an issue.
       writeFileSync(slotLogPath(tmp, 0, logs), "[afk] worker: wAAA1\n[afk] worker: wBBB2\n", "utf8");
 
-      // wAAA1 — died before claiming (no afk.state.json → issue null).
+      // wAAA1 — died before claiming (no afk.state.toon → issue null).
       const dir1 = join(tmp, "workers", "wAAA1", "9-a1");
       mkdirSync(dir1, { recursive: true });
 
@@ -799,7 +799,7 @@ describe("circuit trip — real FS integration (slot-log boot-stamp path)", () =
       const dir2 = join(tmp, "workers", "wBBB2", "99-a1");
       mkdirSync(dir2, { recursive: true });
       writeFileSync(
-        join(dir2, "afk.state.json"),
+        join(dir2, "afk.state.toon"),
         JSON.stringify({ current: { number: 99 } }),
         "utf8",
       );

--- a/apps/dev/tests/toon-docs.test.ts
+++ b/apps/dev/tests/toon-docs.test.ts
@@ -39,7 +39,7 @@ describe("TOONL operational docs", () => {
   it("keeps the documented tq examples valid against produced TOONL lane files", async () => {
     const dir = await mkdtemp(join(tmpdir(), "red-skills-toon-docs-"));
     try {
-      const agentLane = join(dir, "agent.log.jsonl");
+      const agentLane = join(dir, "agent.log.toonl");
       const historyLane = join(dir, "afk-history.toonl");
       const supervisorFirehose = join(dir, "supervisor.log.toonl");
       await writeFile(

--- a/apps/dev/tests/wire-reclaim.test.ts
+++ b/apps/dev/tests/wire-reclaim.test.ts
@@ -15,7 +15,7 @@ function record(
   renderableLive: boolean,
 ): WorkerStateRecord {
   return {
-    path: `${root}/.red/tmp/workers/${worker}/${issue}-a1/afk.state.json`,
+    path: `${root}/.red/tmp/workers/${worker}/${issue}-a1/afk.state.toon`,
     state: parseState({ worker_id: worker, current: { number: issue } }),
     live: renderableLive,
     active: renderableLive,

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -43,7 +43,7 @@ function writeRenderableAttempt(root: string, worker: string, issue: number, sta
   const attemptDir = join(root, ".red", "tmp", "workers", worker, `${issue}-a1`);
   mkdirSync(attemptDir, { recursive: true });
   writeFileSync(
-    join(attemptDir, "afk.state.json"),
+    join(attemptDir, "afk.state.toon"),
     JSON.stringify({
       worker_id: worker,
       pid: process.pid,
@@ -395,7 +395,7 @@ describe("collectMonitorInputs", () => {
       // renderableLive gate (#1219: the dashboard now drops dead/stale rows;
       // dead-worker filtering is covered by worker-state-reader's isRenderableLive suite).
       writeFileSync(
-        join(attemptDir, "afk.state.json"),
+        join(attemptDir, "afk.state.toon"),
         JSON.stringify({ worker_id: "wAB12", pid: process.pid, runner: "claude", total: 3, done: 1 }),
       );
       writeFileSync(join(attemptDir, "afk.log"), "a\nb\n");
@@ -944,7 +944,7 @@ describe("collectStatuslineAfk — cache discipline", () => {
       const dir = join(tmpDir, "workers", "wQ", "55-a1");
       mkdirSync(dir, { recursive: true });
       writeFileSync(
-        join(dir, "afk.state.json"),
+        join(dir, "afk.state.toon"),
         JSON.stringify({
           pid: process.pid, // alive
           current: {
@@ -988,7 +988,7 @@ describe("collectStatuslineAfk — cache discipline", () => {
       const dir = join(tmpDir, "workers", "wZ", "77-a1");
       mkdirSync(dir, { recursive: true });
       writeFileSync(
-        join(dir, "afk.state.json"),
+        join(dir, "afk.state.toon"),
         JSON.stringify({
           pid: process.pid,
           current: {
@@ -1309,14 +1309,14 @@ describe("resolveStatuslineCacheTtl (#1217)", () => {
 
 // ---------------------------------------------------------------------------
 // collectMonitorInputs — layout discovery (#1029)
-// Both sandcastle and legacy layouts put afk.state.json at the same path
-// ({workersRoot}/{workerID}/{attemptDir}/afk.state.json) — the difference is
+// Both sandcastle and legacy layouts put afk.state.toon at the same path
+// ({workersRoot}/{workerID}/{attemptDir}/afk.state.toon) — the difference is
 // where the git worktree lives. This suite verifies both layouts are discovered
 // by the Worker state reader, satisfying the "no monitor-private globbing" contract.
 // ---------------------------------------------------------------------------
 
 describe("collectMonitorInputs — layout discovery (#1029)", () => {
-  it("discovers a sandcastle-layout worker (state at attemptDir/afk.state.json, worktree absent pre-heartbeat)", async () => {
+  it("discovers a sandcastle-layout worker (state at attemptDir/afk.state.toon, worktree absent pre-heartbeat)", async () => {
     const root = scratch();
     try {
       // Sandcastle layout: state file at the standard path; worktree field not yet
@@ -1325,7 +1325,7 @@ describe("collectMonitorInputs — layout discovery (#1029)", () => {
       const attemptDir = join(root, ".red", "tmp", "workers", "wSC", "42-a1");
       mkdirSync(attemptDir, { recursive: true });
       writeFileSync(
-        join(attemptDir, "afk.state.json"),
+        join(attemptDir, "afk.state.toon"),
         JSON.stringify({ worker_id: "wSC", pid: process.pid, runner: "claude", total: 5, done: 2 }),
       );
       const { workers } = await collectMonitorInputs(root);
@@ -1339,7 +1339,7 @@ describe("collectMonitorInputs — layout discovery (#1029)", () => {
     }
   });
 
-  it("discovers a legacy-layout worker (state at attemptDir/afk.state.json, worktree at attemptDir/worktree)", async () => {
+  it("discovers a legacy-layout worker (state at attemptDir/afk.state.toon, worktree at attemptDir/worktree)", async () => {
     const root = scratch();
     try {
       const attemptDir = join(root, ".red", "tmp", "workers", "wLG", "7-a1");
@@ -1347,7 +1347,7 @@ describe("collectMonitorInputs — layout discovery (#1029)", () => {
       // Legacy layout: current.worktree points to {attemptDir}/worktree (doesn't
       // exist here; git call fails gracefully, diffstat returns 0,0 safely).
       writeFileSync(
-        join(attemptDir, "afk.state.json"),
+        join(attemptDir, "afk.state.toon"),
         JSON.stringify({
           // Live pid → survives the #1219 renderableLive gate; legacy-layout discovery is what's tested.
           worker_id: "wLG",
@@ -1375,7 +1375,7 @@ describe("collectMonitorInputs — layout discovery (#1029)", () => {
       // Use process.pid so isStateLive → true (pid is alive).
       const attemptDir = join(root, ".red", "tmp", "workers", "wLIVE", "99-a1");
       mkdirSync(attemptDir, { recursive: true });
-      const stateFile = join(attemptDir, "afk.state.json");
+      const stateFile = join(attemptDir, "afk.state.toon");
       writeFileSync(
         stateFile,
         JSON.stringify({

--- a/apps/dev/tests/worker-state-reader.test.ts
+++ b/apps/dev/tests/worker-state-reader.test.ts
@@ -29,7 +29,7 @@ function psWithChild(pid: number, childPid: number): string {
 
 async function writeState(dir: string, raw: unknown): Promise<string> {
   await mkdir(dir, { recursive: true });
-  const path = join(dir, "afk.state.json");
+  const path = join(dir, "afk.state.toon");
   await writeFile(path, JSON.stringify(raw), "utf8");
   return path;
 }
@@ -122,7 +122,7 @@ describe("worker-state-reader", () => {
 
   it("reads a TOON attempt-state snapshot through the same schema path", async () => {
     const base = await mkdtemp(join(tmpdir(), "wsr-toon-"));
-    const path = join(base, "afk.state.json");
+    const path = join(base, "afk.state.toon");
     await mkdir(base, { recursive: true });
     await writeFile(
       path,
@@ -149,7 +149,7 @@ describe("worker-state-reader", () => {
 
   it("writes the attempt-state snapshot as spec-valid TOON", async () => {
     const base = await mkdtemp(join(tmpdir(), "wsr-write-toon-"));
-    const path = join(base, "afk.state.json");
+    const path = join(base, "afk.state.toon");
     initStateSync(path, {
       worker_id: "wWRITE",
       pid: 4242,
@@ -165,12 +165,12 @@ describe("worker-state-reader", () => {
   });
 
   it("returns null for a missing file", () => {
-    expect(readWorkerState(join(tmpdir(), "nope", "afk.state.json"))).toBeNull();
+    expect(readWorkerState(join(tmpdir(), "nope", "afk.state.toon"))).toBeNull();
   });
 
   it("returns null for malformed JSON", async () => {
     const base = await mkdtemp(join(tmpdir(), "wsr-bad-"));
-    const path = join(base, "afk.state.json");
+    const path = join(base, "afk.state.toon");
     await writeFile(path, "{ not json", "utf8");
     expect(readWorkerState(path)).toBeNull();
   });
@@ -197,7 +197,7 @@ describe("worker-state-reader", () => {
     const recs = await readWorkerStates(root, {
       nowMs: NOW,
       psSnapshot: () => psWithChild(2, 9999), // pid 2 has a child → wB is quiet-but-live
-      glob: async () => [live, stale, join(root, "ghost", "afk.state.json")],
+      glob: async () => [live, stale, join(root, "ghost", "afk.state.toon")],
     });
     expect(recs).toHaveLength(2);
     const byId = Object.fromEntries(recs.map((r) => [r.state.worker_id, r]));
@@ -250,9 +250,9 @@ describe("worker-state-reader", () => {
     expect(union.map((r) => r.state.worker_id)).toEqual(single.map((r) => r.state.worker_id));
   });
 
-  // Isolation fallback: worker.pid liveness when afk.state.json.pid === 0
+  // Isolation fallback: worker.pid liveness when afk.state.toon.pid === 0
   it("isolation: live worker.pid + pid:0 state → quiet-but-live, issue derived from path", async () => {
-    // Path must look like {worker}/{N}-a{n}/afk.state.json so issue derivation works.
+    // Path must look like {worker}/{N}-a{n}/afk.state.toon so issue derivation works.
     const base = await mkdtemp(join(tmpdir(), "wsr-iso-live-"));
     const attemptDir = join(base, "wISO", "1085-a1");
     const path = await writeState(attemptDir, { pid: 0, current: {} });

--- a/packages/red-castle/src/LivenessLane.ts
+++ b/packages/red-castle/src/LivenessLane.ts
@@ -32,7 +32,7 @@ export interface LivenessRecord {
 
 /**
  * Canonical filename for the lane inside an attempt state directory. Kept
- * distinct from the firehose (`log.jsonl`) and proof-of-life (`afk.state.json`)
+ * distinct from the firehose (`log.toonl`) and proof-of-life (`afk.state.toon`)
  * so nothing that writes those can refresh the lane by accident.
  *
  * The filename keeps its `.jsonl` suffix for compatibility, but the content is

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -167,7 +167,7 @@ export interface CompactCurrent {
   waiting_count?: number;
 }
 
-/** The subset of afk.state.json the compact line reads. */
+/** The subset of afk.state.toon the compact line reads. */
 export interface CompactState {
   worker_id: string;
   pid: number;

--- a/packages/shared/toon-migration.test.ts
+++ b/packages/shared/toon-migration.test.ts
@@ -71,14 +71,14 @@ describe("shared TOON migration registry", () => {
         expect.objectContaining({
           id: "dev.agent-log",
           plugin: "dev",
-          legacyPath: ".red/tmp/agent.log.jsonl",
+          legacyPath: ".red/tmp/agent.log.toonl",
           toonPath: ".red/tmp/agent.log.toonl",
           kind: "toonl",
         }),
         expect.objectContaining({
           id: "dev.supervisor-firehose",
           plugin: "dev",
-          legacyPath: ".red/tmp/afk-supervisor.log.jsonl",
+          legacyPath: ".red/tmp/afk-supervisor.log.toonl",
           toonPath: ".red/tmp/supervisors/default/supervisor.log.toonl",
           kind: "toonl",
           migration: "sniff-read",
@@ -93,8 +93,8 @@ describe("shared TOON migration registry", () => {
         expect.objectContaining({
           id: "dev.attempt-state",
           plugin: "dev",
-          legacyPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.json",
-          toonPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.json",
+          legacyPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.toon",
+          toonPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.toon",
           kind: "toon",
         }),
         expect.objectContaining({
@@ -237,7 +237,7 @@ describe("shared TOON migration registry", () => {
     const root = await scratch();
     await write(
       root,
-      ".red/tmp/agent.log.jsonl",
+      ".red/tmp/agent.log.toonl",
       [
         JSON.stringify({ ts: "t1", worker: "wA", type: "agent", msg: "line A", iteration: "1", kind: "text" }),
         "{torn crash tail",
@@ -265,7 +265,7 @@ describe("shared TOON migration registry", () => {
     const root = await scratch();
     await write(
       root,
-      ".red/tmp/afk-supervisor.log.jsonl",
+      ".red/tmp/afk-supervisor.log.toonl",
       [
         JSON.stringify({ ts: "t1", worker: "fleet", type: "heartbeat", msg: "legacy" }),
         encode([{ ts: "t2", worker: "fleet", type: "heartbeat", msg: "toon" }]),
@@ -273,9 +273,9 @@ describe("shared TOON migration registry", () => {
       ].join("\n"),
     );
 
-    const before = await readFile(join(root, ".red/tmp/afk-supervisor.log.jsonl"), "utf8");
+    const before = await readFile(join(root, ".red/tmp/afk-supervisor.log.toonl"), "utf8");
     const report = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
-    const after = await readFile(join(root, ".red/tmp/afk-supervisor.log.jsonl"), "utf8");
+    const after = await readFile(join(root, ".red/tmp/afk-supervisor.log.toonl"), "utf8");
 
     expect(report.converted).not.toContain("dev.supervisor-firehose");
     expect(report.skipped).toContain("dev.supervisor-firehose");
@@ -349,7 +349,7 @@ describe("shared TOON migration registry", () => {
     const root = await scratch();
     await write(
       root,
-      ".red/tmp/workers/wA/1783-a1/afk.state.json",
+      ".red/tmp/workers/wA/1783-a1/afk.state.toon",
       JSON.stringify({ worker_id: "wA", pid: 0, current: { number: 1783, activity: "impl" } }),
     );
     await write(root, ".red/tmp/statusline-cache.json", JSON.stringify({ queue: 4, human: 1, ts: 100 }));
@@ -383,7 +383,7 @@ describe("shared TOON migration registry", () => {
         "dev.rsp-wait-registry",
       ]),
     );
-    const stateRaw = await readFile(join(root, ".red/tmp/workers/wA/1783-a1/afk.state.json"), "utf8");
+    const stateRaw = await readFile(join(root, ".red/tmp/workers/wA/1783-a1/afk.state.toon"), "utf8");
     const countRaw = await readFile(join(root, ".red/state/statusline/statusline-cache.toon"), "utf8");
     const repoRaw = await readFile(join(root, ".red/state/statusline/statusline-repo-cache.toon"), "utf8");
     const residentRaw = await readFile(join(root, ".red/state/rsp/rsp-resident.pid.json"), "utf8");

--- a/packages/shared/toon-migration.ts
+++ b/packages/shared/toon-migration.ts
@@ -72,14 +72,14 @@ export const DEV_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
   {
     id: "dev.agent-log",
     plugin: "dev",
-    legacyPath: ".red/tmp/agent.log.jsonl",
+    legacyPath: ".red/tmp/agent.log.toonl",
     toonPath: ".red/tmp/agent.log.toonl",
     kind: "toonl",
   },
   {
     id: "dev.supervisor-firehose",
     plugin: "dev",
-    legacyPath: ".red/tmp/afk-supervisor.log.jsonl",
+    legacyPath: ".red/tmp/afk-supervisor.log.toonl",
     toonPath: ".red/tmp/supervisors/default/supervisor.log.toonl",
     kind: "toonl",
     migration: "sniff-read",
@@ -94,8 +94,8 @@ export const DEV_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
   {
     id: "dev.attempt-state",
     plugin: "dev",
-    legacyPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.json",
-    toonPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.json",
+    legacyPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.toon",
+    toonPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.toon",
     kind: "toon",
   },
   {
@@ -308,7 +308,7 @@ async function expandSurfaceTargets(rootDir: string, surface: RegisteredToonSurf
         continue;
       }
       for (const attempt of attempts) {
-        const path = join(workerRoot, attempt, "afk.state.json");
+        const path = join(workerRoot, attempt, "afk.state.toon");
         if (await pathExists(path)) out.push({ surface, legacyPath: path, toonPath: path });
       }
     }


### PR DESCRIPTION
`afk.state.json`/`agent.log.jsonl`/`log.jsonl` carried TOON/TOONL content but were named `.json/.jsonl` (the extension-lie). Coordinated rename across all 53 writer+reader+test sites → `.toon`/`.toonl`. Content unchanged (already TOON); `.red/tmp` disposable so old files age out, no migration. Verified: dev tsc clean, 665 tests pass. Closes #2139.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787005114&installation_id=129708444&pr_number=2149&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2149&signature=ec18bc27cfaa3b50a5dae576fe72fc58fbadbe898f254a9d6d78e6fbb652d285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->