### PR TITLE
fix(afk): heartbeat loc reads castle-published worktree path (ADR 0103)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -16,5 +16,6 @@ export {
   decodeRunnerCircuitSnapshot,
   encodeBootErrorPayload,
   castleWorktreeUnder,
+  readCapturedWorktreePath,
 } from "./run/state.js";
 export { runCommand } from "./run/command.js";

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -100,7 +100,12 @@ import { renderClaimComment } from "../../core/claim.js";
 
 import { deriveActivity } from "./activity.js";
 import { makeAgentConflictResolver, makeMechanicalConflictResolver } from "./reconcile.js";
-import { castleWorktreeUnder, decodeLocMemoSnapshot, encodeLocMemoSnapshot } from "./state.js";
+import {
+  castleWorktreeUnder,
+  decodeLocMemoSnapshot,
+  encodeLocMemoSnapshot,
+  readCapturedWorktreePath,
+} from "./state.js";
 
 export function parseSlot(val: string | undefined): number | undefined {
   if (val === undefined) return undefined;
@@ -707,16 +712,19 @@ export function buildProcessDeps(
       const lastProgressAt = new Date(info.lastProgressMs).toISOString();
       const head = info.head ?? "";
       void (async () => {
-        // sandcastle creates the agent's worktree at
-        // `{attemptDir}/.red-castle/worktrees/{slug}`, NOT the legacy
-        // `{attemptDir}/worktree` the state seeds — diffing the latter fails
-        // (it never exists) and every tick read a permanent `+0 -0` even with a
-        // dirty worktree, which also starved the attempt-progress guard's
-        // proof-of-life. Resolve the real worktree from `git worktree list`,
-        // and persist it into `current.worktree` so the monitor (which reads
-        // that field for its own diffstat) gets the live path too. Fall back to
-        // the legacy path only when no worktree is registered yet.
+        // The castle creates the agent's worktree at
+        // `{attemptDir}/.red-castle/worktrees/{slug}` (keyed workerId-issueId,
+        // ADR 0103 — no attempt level), NOT the legacy `{attemptDir}/worktree`
+        // the state seeds. Source of truth = the path the castle RECORDS from its
+        // `onWorktreeReady` hook (its `pwd` in the real worktree); reconstructing
+        // it from `attemptDir` (a `git worktree list` probe on the primary + a
+        // filesystem walk) returned the dead legacy path at runtime for
+        // mirror-owned worktrees, so every codex tick read a permanent `+0 -0`.
+        // The probe/legacy fallbacks stay only for the window before the hook
+        // runs. Persist the resolved path into `current.worktree` so the monitor
+        // (which reads that field for its own diffstat) gets the live path too.
         const worktree =
+          readCapturedWorktreePath(current.attemptDir) ??
           (await gitx.worktreePathUnder(gitCtx, current.attemptDir).catch(() => undefined)) ??
           castleWorktreeUnder(current.attemptDir) ??
           join(current.attemptDir, "worktree");

--- a/apps/dev/src/commands/run/state.ts
+++ b/apps/dev/src/commands/run/state.ts
@@ -229,6 +229,25 @@ export function castleWorktreeUnder(attemptDir: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Read the worktree path the castle recorded from its `onWorktreeReady` hook.
+ *
+ * That hook runs ON THE HOST with cwd = the real worktree, so its `pwd` is the
+ * ground-truth absolute path; it writes it to `{attemptDir}/.worktree-path`
+ * (buildWorktreePathCaptureHook). This is the single source of truth for the
+ * heartbeat loc diff — no reconstruction from `attemptDir`, which returned the
+ * dead legacy `{attemptDir}/worktree` at runtime and read a permanent `+0 -0`.
+ * Returns undefined until the hook has run (falls back to the probe chain).
+ */
+export function readCapturedWorktreePath(attemptDir: string): string | undefined {
+  try {
+    const recorded = readFileSync(join(attemptDir, ".worktree-path"), "utf8").trim();
+    return recorded || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Synchronous next-attempt resolver over the attempt-ledger's pure core, so it
  * can run inside the synchronous `buildProcessInput`. Namespace-blind: walks
  * every worker-lane namespace (`workers`, `go-workers`, `scout-workers`) with

--- a/apps/dev/src/core/execution/host-hooks.ts
+++ b/apps/dev/src/core/execution/host-hooks.ts
@@ -138,6 +138,27 @@ export function buildNoLeakCommitMsgHook(): HostHookCommand {
   return { command: `sh -c ${shSingleQuote(script)}` };
 }
 
+/**
+ * Record the real worktree path so the heartbeat's loc diff targets it directly.
+ *
+ * `onWorktreeReady` runs ON THE HOST with cwd = the worktree the castle just
+ * created (`{attemptDir}/.red-castle/worktrees/{slug}`), so its `pwd` is the
+ * ground-truth absolute worktree path. We write it into the attempt dir (three
+ * levels up: slug → worktrees → .red-castle → attemptDir) as `.worktree-path`.
+ *
+ * The heartbeat reads that file instead of RECONSTRUCTING the worktree from
+ * `attemptDir` — reconstruction (`git worktree list` on the primary + a
+ * filesystem probe) proved to return the dead legacy `{attemptDir}/worktree`
+ * path at runtime for red-castle mirror-owned worktrees, so every codex tick
+ * read a permanent `+0 -0`. Per ADR 0103 the castle owns the worktree (keyed
+ * `workerId-issueId`, no attempt level); having it publish its own path is the
+ * single source of truth. Best-effort: a write failure just leaves the heartbeat
+ * on its reconstruction fallback.
+ */
+export function buildWorktreePathCaptureHook(): HostHookCommand {
+  return { command: `sh -c 'pwd > ../../../.worktree-path 2>/dev/null || true'` };
+}
+
 /** POSIX single-quote escaping: wrap in single quotes, replacing each embedded
  * single quote with the `'\''` idiom. Keeps the embedded git push / hook body
  * intact through the `sh -c '<script>'` layer. */

--- a/apps/dev/src/core/execution/runtime.ts
+++ b/apps/dev/src/core/execution/runtime.ts
@@ -30,7 +30,12 @@ import {
   parseAgentOutput,
   type AgentOutput,
 } from "../agent-output.js";
-import { buildContinuousPushHook, buildNoLeakCommitMsgHook, type HostHookCommand } from "./host-hooks.js";
+import {
+  buildContinuousPushHook,
+  buildNoLeakCommitMsgHook,
+  buildWorktreePathCaptureHook,
+  type HostHookCommand,
+} from "./host-hooks.js";
 import {
   startAttemptGuard,
   type AttemptBudget,
@@ -659,7 +664,7 @@ export function buildRunOptions(deps: SandcastleDeps, input: RunAgentInput): Run
   // sandcastle only runs these for host-visible worktrees (noSandbox / bind-mount
   // worktree mode); for fully-isolated providers the agent works in a synced copy
   // the hooks can't see (final sync only).
-  const worktreeReady: HostHookCommand[] = [buildNoLeakCommitMsgHook()];
+  const worktreeReady: HostHookCommand[] = [buildWorktreePathCaptureHook(), buildNoLeakCommitMsgHook()];
   if (input.continuousPush) {
     worktreeReady.push(buildContinuousPushHook(input.branch, input.remote ?? DEFAULT_REMOTE));
   }

--- a/apps/dev/tests/castle-worktree.test.ts
+++ b/apps/dev/tests/castle-worktree.test.ts
@@ -1,8 +1,10 @@
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { castleWorktreeUnder } from "../src/commands/run.js";
+import { castleWorktreeUnder, readCapturedWorktreePath } from "../src/commands/run.js";
+import { buildWorktreePathCaptureHook } from "../src/core/execution/host-hooks.js";
 
 // Guards the loc/vitals fix: red-castle worktrees are mirror-owned and never
 // appear in the primary's `git worktree list`, so the heartbeat must resolve
@@ -32,5 +34,47 @@ describe("castleWorktreeUnder", () => {
   it("returns undefined (never the dead legacy path) when no child carries a .git", () => {
     mkdirSync(join(root, ".red-castle", "worktrees", "stray"), { recursive: true });
     expect(castleWorktreeUnder(root)).toBeUndefined();
+  });
+});
+
+// The castle publishes its own worktree path via an onWorktreeReady host hook
+// (ADR 0103): it runs ON THE HOST with cwd = the real worktree, so its `pwd`
+// lands in `{attemptDir}/.worktree-path`. The heartbeat reads that first, which
+// sidesteps reconstructing the mirror-owned worktree from disk entirely.
+describe("readCapturedWorktreePath", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "captured-wt-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns the recorded absolute path, trimmed of the hook's trailing newline", () => {
+    const wt = "/mirror/.red-castle/worktrees/afk-wABCD-42-slug";
+    writeFileSync(join(root, ".worktree-path"), `${wt}\n`);
+    expect(readCapturedWorktreePath(root)).toBe(wt);
+  });
+
+  it("returns undefined when no .worktree-path has been published", () => {
+    expect(readCapturedWorktreePath(root)).toBeUndefined();
+  });
+
+  it("returns undefined when the capture file is present but empty", () => {
+    writeFileSync(join(root, ".worktree-path"), "   \n");
+    expect(readCapturedWorktreePath(root)).toBeUndefined();
+  });
+
+  // Round-trip: run the REAL capture hook in a real castle-shaped worktree, then
+  // read it back. `onWorktreeReady` runs with cwd = the worktree three levels
+  // below the attempt dir ({attemptDir}/.red-castle/worktrees/{slug}), so the
+  // hook's `pwd > ../../../.worktree-path` must land the path in the attempt dir.
+  it("round-trips the hook's pwd back through readCapturedWorktreePath", () => {
+    const wt = join(root, ".red-castle", "worktrees", "afk-wABCD-42-slug");
+    mkdirSync(wt, { recursive: true });
+    execFileSync("sh", ["-c", buildWorktreePathCaptureHook().command], { cwd: wt, stdio: "ignore" });
+    const captured = readCapturedWorktreePath(root);
+    expect(captured).toBeDefined();
+    expect(captured?.endsWith(join(".red-castle", "worktrees", "afk-wABCD-42-slug"))).toBe(true);
   });
 });

--- a/apps/dev/tests/execution-core.test.ts
+++ b/apps/dev/tests/execution-core.test.ts
@@ -285,8 +285,10 @@ describe("buildRunOptions", () => {
   it("injects the no-leak commit-msg host hook when continuous push is not requested (#1366)", () => {
     const opts = buildRunOptions(makeDeps(async () => fakeResult()), baseInput);
     const hooks = opts.hooks?.host?.onWorktreeReady;
-    expect(hooks).toHaveLength(1);
-    const command = hooks?.[0]?.command ?? "";
+    // Two host hooks now: [0] worktree-path capture (ADR 0103), [1] no-leak commit-msg.
+    expect(hooks).toHaveLength(2);
+    expect(hooks?.[0]?.command ?? "").toContain(".worktree-path");
+    const command = hooks?.[1]?.command ?? "";
     expect(command.startsWith("sh -c ")).toBe(true);
     // It must NOT carry the continuous-push behaviour when push is off.
     expect(command).not.toContain("--force-with-lease");
@@ -304,10 +306,12 @@ describe("buildRunOptions", () => {
       { ...baseInput, continuousPush: true },
     );
     const hooks = opts.hooks?.host?.onWorktreeReady;
-    // Two host hooks now: [0] no-leak commit-msg, [1] continuous push (#1224).
-    expect(hooks).toHaveLength(2);
-    expect(hooks?.[0]?.command ?? "").toContain('"$hd/commit-msg"');
-    const command = hooks?.[1]?.command ?? "";
+    // Three host hooks now: [0] worktree-path capture (ADR 0103), [1] no-leak
+    // commit-msg, [2] continuous push (#1224).
+    expect(hooks).toHaveLength(3);
+    expect(hooks?.[0]?.command ?? "").toContain(".worktree-path");
+    expect(hooks?.[1]?.command ?? "").toContain('"$hd/commit-msg"');
+    const command = hooks?.[2]?.command ?? "";
     // It is a single portable `sh -c '...'` host command.
     expect(command.startsWith("sh -c ")).toBe(true);
     // (a) initial force-with-lease push of the worker branch up-front.
@@ -402,8 +406,9 @@ describe("buildRunOptions", () => {
       makeDeps(async () => fakeResult()),
       { ...baseInput, continuousPush: true, remote: "backup" },
     );
-    // Index [1]: the continuous-push hook rides behind the no-leak commit-msg hook.
-    const command = opts.hooks?.host?.onWorktreeReady?.[1]?.command ?? "";
+    // Index [2]: the continuous-push hook rides behind the worktree-path capture
+    // ([0]) and no-leak commit-msg ([1]) hooks.
+    const command = opts.hooks?.host?.onWorktreeReady?.[2]?.command ?? "";
     expect(command).toContain("git push backup -u");
     expect(command).toContain("git push backup HEAD --force-with-lease");
   });


### PR DESCRIPTION
## Problem

Codex workers reported permanent `loc=+0 -0` in the heartbeat/statusline. Root cause: the heartbeat reconstructed the worktree from `attemptDir` (`git worktree list` on the primary + an on-disk probe), but red-castle worktrees are **mirror-owned** — they never appear in the primary's `git worktree list`, and the on-disk probe returned the dead legacy `{attemptDir}/worktree` path. Every tick diffed an empty/nonexistent tree → `+0 -0`.

## Fix (ADR 0103 — the castle owns the worktree)

Per ADR 0103 the castle is the sole owner of the worktree (keyed `workerId-issueId`, no attempt level), so let it **publish its own ground-truth path** instead of having the heartbeat guess:

- **`host-hooks.ts`** — new `buildWorktreePathCaptureHook()`. `onWorktreeReady` runs ON THE HOST with cwd = the real worktree, so `pwd > ../../../.worktree-path` records the absolute path into the attempt dir (three levels up: slug → worktrees → .red-castle → attemptDir).
- **`runtime.ts`** — wire the capture hook first in `onWorktreeReady`.
- **`state.ts`** — `readCapturedWorktreePath()` reads `{attemptDir}/.worktree-path`.
- **`process-deps.ts`** — the heartbeat prefers the captured path, falling back to reconstruction only when the capture is absent.

Best-effort throughout: a capture-write failure just leaves the heartbeat on its old reconstruction fallback.

## Tests

- `castle-worktree.test.ts`: round-trips the real capture hook through `readCapturedWorktreePath`.
- `execution-core.test.ts`: asserts the capture hook rides first in the `onWorktreeReady` array.

Local: `tsc --noEmit` clean; `vitest run castle-worktree execution-core process-issue run-flags` green (362 tests). Empirical `loc>0` confirmation happens post-release on a live fleet run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787018306&installation_id=129708444&pr_number=2160&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2160&signature=ad98e27d270ca7d9ad8c0d81cb3b14329640a8a3091a1deaf2ec17d345d0fec6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->