### PR TITLE
docs: land AFK boot docs sweep

### DIFF
--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -200,6 +200,14 @@ _Avoid_: GHA, reusable workflow (when referring to the lane), CI job
 An agent-loadable behavior package rooted at a `SKILL.md` plus optional support files.
 _Avoid_: command, plugin
 
+**Manager**:
+The single operator-facing `dev` **Skill** that acts as liaison over RedSkills' existing execution and control surfaces: it routes work through the appropriate workflow, supervises the resulting fleet, escalates only genuine operator decisions, and reports outcomes without replacing the underlying workers, queues, or landing contracts. It may persist a local inbox and continuity metadata before work is published; once an intent is materialised as a **Ticket** hierarchy, the **Issue tracker** is canonical and any local projection must be reconstructible from it.
+_Avoid_: FirstMate (the external reference), second fleet, parallel orchestrator
+
+**Manager map**:
+The canonical parent **Ticket** for one effort conducted by the **Manager** from initial intent through final delivery. It is an umbrella index over existing child artifacts — research and decision **Tickets**, Wayfinder maps, **Specs**, executable **Tickets**, and validation or landing outcomes — while native hierarchy and dependency relationships expose the actionable frontier. It does not replace those artifacts or restate the detail they own. Unlike a Wayfinder map, it continues after the route becomes clear; unlike a **Spec**, it may begin before the solution is sufficiently defined. Its local projection is reconstructible from the **Issue tracker**.
+_Avoid_: Wayfinder map (decision-only), Spec (solution contract), task list, universal task format
+
 **Codebase understanding surface**:
 A `dev` workflow surface for explaining repository architecture and change impact from graph-backed project knowledge.
 _Avoid_: wiki graph, understand plugin


### PR DESCRIPTION
Automated Docs Sweep landing for stranded .red documentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787022706&installation_id=129708444&pr_number=2165&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2165&signature=aa5d5323e087a225d2eb49ebde182db0aac5423c5e718c701e4fbe515b345362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->