### PR TITLE
feat: add Pi (pi-coding-agent) host support

### DIFF
--- a/.github/workflows/red-marketplace-ci.yml
+++ b/.github/workflows/red-marketplace-ci.yml
@@ -9,6 +9,10 @@ on:
       - "scripts/validate-marketplace-manifests.sh"
       - "scripts/test-validate-marketplace-manifests.sh"
       - "scripts/fixtures/marketplace-manifests/**"
+      - "scripts/generate-pi-manifests.mjs"
+      - "scripts/install-pi.sh"
+      - "scripts/install.sh"
+      - "scripts/validate-install-metadata.sh"
   push:
     branches: [main]
     paths:
@@ -18,6 +22,10 @@ on:
       - "scripts/validate-marketplace-manifests.sh"
       - "scripts/test-validate-marketplace-manifests.sh"
       - "scripts/fixtures/marketplace-manifests/**"
+      - "scripts/generate-pi-manifests.mjs"
+      - "scripts/install-pi.sh"
+      - "scripts/install.sh"
+      - "scripts/validate-install-metadata.sh"
 
 permissions:
   contents: read
@@ -34,3 +42,6 @@ jobs:
 
       - name: Test marketplace manifest validator
         run: scripts/test-validate-marketplace-manifests.sh
+
+      - name: Validate install metadata (claude/codex/pi)
+        run: scripts/validate-install-metadata.sh

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Check generated Codex manifests
         run: pnpm codex:manifests:check
 
+      - name: Check generated Pi manifests
+        run: pnpm pi:manifests:check
+
       - name: Typecheck workspace (apps + packages, excludes red-castle)
         run: pnpm typecheck
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ manifest is generated from it. Any runtime code for a plugin lives under
 ## Rules
 
 1. Every skill in `engineering/`, `knowledge/`, `productivity/`, or `misc/` must be listed in the root `README.md` **and** in the owning plugin's `.claude-plugin/plugin.json` (e.g. `plugins/dev/.claude-plugin/plugin.json`). Skills in `in-progress/` appear in neither.
-2. Codex manifests are generated artifacts. Do not hand-edit `.agents/plugins/marketplace.json` or `plugins/*/.codex-plugin/plugin.json`; change the Claude-side manifests or plugin tree, then run `pnpm codex:manifests`.
+2. Codex manifests are generated artifacts. Do not hand-edit `.agents/plugins/marketplace.json` or `plugins/*/.codex-plugin/plugin.json`; change the Claude-side manifests or plugin tree, then run `pnpm codex:manifests`. Pi packages are generated the same way: never hand-edit `plugins/*/package.json`; run `pnpm pi:manifests` after editing the Claude-side manifests or the plugin tree.
 3. Each entry in `README.md` links the skill name to its `SKILL.md`.
 4. Each bucket has its own `README.md` listing the bucket's skills with a one-line description.
 5. `LICENSE` is Apache-2.0. The `NOTICE` file preserves Matt Pocock's original MIT copyright for the upstream-derived skills under `plugins/dev/skills/` — **do not remove or alter that attribution**. See ADR 0004.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <strong>The operating system for agentic engineering work.</strong><br>
 RedSkills turns GitHub issues into reviewed PRs, remembers the operational
 evidence that prevents repeated mistakes, and gives every repo a local knowledge
-surface for Claude Code, Codex, OpenCode, and GitHub Actions.
+surface for Claude Code, Codex, OpenCode, Pi, and GitHub Actions.
 
 </div>
 
@@ -40,14 +40,15 @@ curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/inst
 
 The installer resolves the latest GitHub Release, stores it under
 `~/.red-skills/versions/<tag>`, updates `~/.red-skills/current`, detects which
-supported CLIs are present (`claude`, `codex`, `opencode`), then installs the
-right surface for each host:
+supported CLIs are present (`claude`, `codex`, `opencode`, `pi`), then installs
+the right surface for each host:
 
 | Host | What the installer does |
 | --- | --- |
 | Claude Code | Registers the RedSkills marketplace and installs `dev`, `memory`, and `brain`. |
 | Codex CLI | Registers the RedSkills marketplace and installs `dev`, `memory`, and `brain`. |
 | OpenCode | Generates and installs OpenCode plugin modules, skills, MCP config, provider config, and TUI attention config. |
+| Pi | Registers one Pi package per plugin via `pi install`, exposes the same skill buckets through the standard agent skills protocol. |
 
 OpenCode installs use the published `opencode-host.bundle.min.mjs` asset when
 available, so normal installs need `node` but do not need a local workspace
@@ -62,6 +63,7 @@ curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/inst
 
 # install only one host
 curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/install.sh | bash -s -- --only opencode
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/install.sh | bash -s -- --only pi
 
 # pin a release
 curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/install.sh | bash -s -- --version v2.6.0
@@ -162,6 +164,21 @@ pnpm codex:manifests
 CI runs `pnpm codex:manifests:check` and fails when committed Codex manifests
 drift from the generator output.
 
+### Pi Manifest Maintenance
+
+Pi packages are generated artifacts. Do not hand-edit
+`plugins/<name>/package.json`. Change the Claude-side plugin manifest or
+plugin tree, then run:
+
+```bash
+pnpm pi:manifests
+```
+
+CI runs `pnpm pi:manifests:check` and fails when committed Pi packages drift
+from the generator output. The install script runs the same generator before
+calling `pi install`, so a manual regeneration is only required when working
+on Pi support itself.
+
 ### Manual: OpenCode
 
 OpenCode support is generated from the same plugin source tree as Claude Code
@@ -199,6 +216,56 @@ opencode .
 Use `/connect` inside OpenCode or export one of `OPENAI_API_KEY`,
 `MINIMAX_API_KEY`, or `OPENROUTER_API_KEY`. Generated config never stores auth
 secrets. Details live in [apps/opencode-host](./apps/opencode-host/README.md).
+
+### Manual: Pi
+
+Pi support ships one Pi package per RedSkills plugin. The packages live at
+`plugins/<name>/package.json` and are generated from the same Claude-side
+manifests the other hosts consume. Pi uses the agent skills protocol, so the
+install exposes the same skill buckets (`engineering`, `knowledge`,
+`productivity`, `misc`, `core`) Claude Code and Codex already see.
+
+```bash
+# user-scoped install into ~/.pi/agent/settings.json
+scripts/install-pi.sh
+
+# project-scoped install into <repo>/.pi/settings.json
+scripts/install-pi.sh --project /path/to/your-project
+
+# dry-run + inspect
+scripts/install-pi.sh --project . --dry-run
+
+# user-scoped uninstall
+scripts/install-pi.sh --uninstall
+```
+
+The install script regenerates every `plugins/<name>/package.json` via
+`scripts/generate-pi-manifests.mjs` so the published manifest stays in sync with
+the Claude/Codex sources of truth, then calls `pi install <plugin-dir>` once per
+published plugin (dev, memory, brain). It records the install in
+`~/.pi/agent/redskills-install-manifest.json` (or
+`<project>/.pi/redskills-install-manifest.json`) so a subsequent
+`scripts/install-pi.sh --uninstall` cleanly removes every package this script
+registered. Re-run the install script whenever you bump RedSkills to pick up new
+skill buckets.
+
+Known limitations versus the other hosts:
+
+- Pi does not run lifecycle hooks, so the Codex/Claude `SessionStart`/`Stop`
+  hooks (the rsp interception bridge, red-fetch, command-guard, branch-lock,
+  statusline wiring) are not active in Pi. Skills that depend on those hooks
+  lose telemetry but stay navigable; AFK runners and code-nav MCP servers are
+  unaffected.
+- Two plugins (`memory` and `brain`) ship a skill with the same `name: view`.
+  Pi warns on duplicate skill names and keeps the first one registered, so
+  install `memory` or `brain` last depending on which `view` you want as the
+  primary entry point.
+- Pi does not advertise the plugin display metadata Codex uses; the package
+  description is the only user-visible summary in `pi list`.
+
+After installing, restart any open Pi session so the new skills reload.
+`scripts/install-pi.sh --help` documents the user/project scope split and the
+`--uninstall` flow.
 
 ### No Marketplace
 
@@ -367,6 +434,7 @@ knowledge the human wants preserved, searched, and cited later.
 | Claude Code | Marketplace plugins, slash commands, skills, hooks, MCP servers | Primary interactive host. |
 | Codex CLI | Marketplace plugins, `$skill` invocation, MCP servers, footer integration | Namespace-qualified skill names may appear depending on client version. |
 | OpenCode | Generated `.opencode/skills`, plugin modules, MCP config, provider config, TUI attention config | Installed through `scripts/install-opencode.sh`. |
+| Pi | One Pi package per plugin (`plugins/<name>/package.json`) carrying the shared skill buckets | Installed through `scripts/install-pi.sh` (`--user` or `--project`). |
 | GitHub Actions | Reusable AFK attempt workflow and composable action | Runs one AFK attempt per issue in adopter repos. |
 
 ## Plugin Boundaries

--- a/apps/dev/tests/manifest-parity.test.ts
+++ b/apps/dev/tests/manifest-parity.test.ts
@@ -12,6 +12,11 @@ async function readCodexManifest(): Promise<{ skills: string[] }> {
   return JSON.parse(raw) as { skills: string[] };
 }
 
+async function readPiManifest(): Promise<{ name: string; pi: { skills: string[] } }> {
+  const raw = await readFile(join(ROOT, "plugins/dev/package.json"), "utf8");
+  return JSON.parse(raw);
+}
+
 async function listSkillFiles(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
@@ -66,5 +71,22 @@ describe("dev plugin manifest + frontmatter hygiene", () => {
     // Every published bucket must be present; in-progress/ must be absent.
     const buckets = manifest.skills.map((s) => s.replace(/^\.\/skills\//, "").replace(/\/$/, ""));
     expect(buckets.sort()).toEqual(["engineering", "knowledge", "misc", "productivity"]);
+  });
+
+  it("Pi dev package mirrors the Codex dev manifest bucket list", async () => {
+    const codex = await readCodexManifest();
+    const pi = await readPiManifest();
+
+    // Same published buckets, with the leading `./skills/` prefix the Pi
+    // package manifest requires because it lives at plugins/dev/package.json.
+    expect(pi.name).toBe("@reddb-io/red-skills-dev");
+    const codexBuckets = codex.skills
+      .map((s) => s.replace(/^\.\/skills\//, "").replace(/\/$/, ""))
+      .sort();
+    const piBuckets = pi.pi.skills
+      .map((s) => s.replace(/^\.\/skills\//, "").replace(/\/$/, ""))
+      .sort();
+    expect(piBuckets).toEqual(codexBuckets);
+    expect(piBuckets).not.toContain("in-progress");
   });
 });

--- a/apps/dev/tests/pi-manifest-generator.test.ts
+++ b/apps/dev/tests/pi-manifest-generator.test.ts
@@ -1,0 +1,136 @@
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+const generator = join(ROOT, "scripts/generate-pi-manifests.mjs");
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+describe("Pi manifest generator", () => {
+  it("projects a Claude-side plugin tree into per-plugin Pi packages with bucket paths", async () => {
+    const root = await mkdtemp(join(tmpdir(), "red-skills-pi-manifests-"));
+
+    await mkdir(join(root, ".claude-plugin"), { recursive: true });
+    await mkdir(join(root, "plugins/dev/.claude-plugin"), { recursive: true });
+    await mkdir(join(root, "plugins/example/.claude-plugin"), { recursive: true });
+    await mkdir(join(root, "plugins/internal/.claude-plugin"), { recursive: true });
+
+    await writeJson(join(root, ".claude-plugin/marketplace.json"), {
+      name: "red-skills",
+      plugins: [
+        {
+          name: "dev",
+          source: "./plugins/dev",
+          description: "Development automation.",
+        },
+        {
+          name: "example",
+          source: "./plugins/example",
+          description: "Example plugin — shows fixture generation.",
+          dependencies: ["dev"],
+        },
+        {
+          name: "internal",
+          source: "./plugins/internal",
+          description: "Internal plugin — maintainer-only repository operations.",
+        },
+      ],
+    });
+
+    await writeJson(join(root, "plugins/dev/.claude-plugin/plugin.json"), {
+      name: "dev",
+      version: "9.9.9",
+      description: "Development automation.",
+      skills: ["./skills/engineering/afk", "./skills/knowledge/wiki"],
+    });
+
+    await writeJson(join(root, "plugins/example/.claude-plugin/plugin.json"), {
+      name: "example",
+      version: "9.9.9",
+      description: "Example plugin — shows fixture generation.",
+      dependencies: ["dev"],
+      skills: ["./skills/core/init", "./skills/core/recall"],
+    });
+
+    await writeJson(join(root, "plugins/internal/.claude-plugin/plugin.json"), {
+      name: "internal",
+      version: "9.9.9",
+      description: "Internal plugin — maintainer-only repository operations.",
+      skills: ["./skills/core/bootstrap"],
+    });
+
+    await execFileAsync("node", [generator, "--root", root]);
+
+    const devPackage = JSON.parse(await readFile(join(root, "plugins/dev/package.json"), "utf8"));
+    expect(devPackage).toMatchObject({
+      name: "@reddb-io/red-skills-dev",
+      version: "9.9.9",
+      private: true,
+      license: "Apache-2.0",
+      keywords: ["pi-package", "reddb-io", "red-skills"],
+      pi: {
+        skills: ["./skills/engineering/", "./skills/knowledge/"],
+      },
+    });
+
+    const examplePackage = JSON.parse(
+      await readFile(join(root, "plugins/example/package.json"), "utf8"),
+    );
+    // Dependencies propagate as `dep:<name>` keywords so pi users can search
+    // for them, mirroring the Codex manifest convention.
+    expect(examplePackage.keywords).toContain("dep:dev");
+
+    const internalPackage = JSON.parse(
+      await readFile(join(root, "plugins/internal/package.json"), "utf8"),
+    );
+    expect(internalPackage.pi.skills).toEqual(["./skills/core/"]);
+  });
+
+  it("fails --check when a committed Pi manifest drifts from the generator", async () => {
+    const root = await mkdtemp(join(tmpdir(), "red-skills-pi-manifests-check-"));
+
+    await mkdir(join(root, ".claude-plugin"), { recursive: true });
+    await mkdir(join(root, "plugins/dev/.claude-plugin"), { recursive: true });
+
+    await writeJson(join(root, ".claude-plugin/marketplace.json"), {
+      name: "red-skills",
+      plugins: [
+        {
+          name: "dev",
+          source: "./plugins/dev",
+          description: "Development automation.",
+        },
+      ],
+    });
+
+    await writeJson(join(root, "plugins/dev/.claude-plugin/plugin.json"), {
+      name: "dev",
+      version: "9.9.9",
+      description: "Development automation.",
+      skills: ["./skills/engineering/afk"],
+    });
+
+    await execFileAsync("node", [generator, "--root", root]);
+    const manifestPath = join(root, "plugins/dev/package.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    manifest.description = "hand edited";
+    await writeJson(manifestPath, manifest);
+
+    await expect(execFileAsync("node", [generator, "--root", root, "--check"])).rejects.toMatchObject(
+      {
+        stderr: expect.stringContaining("Pi manifests are stale"),
+      },
+    );
+  });
+
+  it("matches the generator output for the repo's committed plugin manifests", async () => {
+    await execFileAsync("node", [generator, "--root", ROOT, "--check"]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "audit:hooks": "bash scripts/audit-hook-hardening-contract.sh",
     "release:manifest": "node scripts/release-manifest.mjs",
     "codex:manifests": "node scripts/generate-codex-manifests.mjs",
-    "codex:manifests:check": "node scripts/generate-codex-manifests.mjs --check"
+    "codex:manifests:check": "node scripts/generate-codex-manifests.mjs --check",
+    "pi:manifests": "node scripts/generate-pi-manifests.mjs",
+    "pi:manifests:check": "node scripts/generate-pi-manifests.mjs --check"
   },
   "devDependencies": {
     "turbo": "^2.5.4",

--- a/plugins/brain/package.json
+++ b/plugins/brain/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@reddb-io/red-skills-brain",
+  "version": "2.74.6",
+  "private": true,
+  "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/reddb-io/red-skills",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/reddb-io/red-skills.git"
+  },
+  "keywords": [
+    "pi-package",
+    "reddb-io",
+    "red-skills"
+  ],
+  "pi": {
+    "skills": [
+      "./skills/core/"
+    ]
+  }
+}

--- a/plugins/dev/package.json
+++ b/plugins/dev/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@reddb-io/red-skills-dev",
+  "version": "2.74.6",
+  "private": true,
+  "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/reddb-io/red-skills",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/reddb-io/red-skills.git"
+  },
+  "keywords": [
+    "pi-package",
+    "reddb-io",
+    "red-skills"
+  ],
+  "pi": {
+    "skills": [
+      "./skills/engineering/",
+      "./skills/knowledge/",
+      "./skills/productivity/",
+      "./skills/misc/"
+    ]
+  }
+}

--- a/plugins/internal/package.json
+++ b/plugins/internal/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@reddb-io/red-skills-internal",
+  "version": "2.1.0",
+  "private": true,
+  "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/reddb-io/red-skills",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/reddb-io/red-skills.git"
+  },
+  "keywords": [
+    "pi-package",
+    "reddb-io",
+    "red-skills"
+  ],
+  "pi": {
+    "skills": [
+      "./skills/maintainer/"
+    ]
+  }
+}

--- a/plugins/memory/package.json
+++ b/plugins/memory/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@reddb-io/red-skills-memory",
+  "version": "2.74.6",
+  "private": true,
+  "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/reddb-io/red-skills",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/reddb-io/red-skills.git"
+  },
+  "keywords": [
+    "pi-package",
+    "reddb-io",
+    "red-skills",
+    "dep:dev"
+  ],
+  "pi": {
+    "skills": [
+      "./skills/core/"
+    ]
+  }
+}

--- a/scripts/generate-pi-manifests.mjs
+++ b/scripts/generate-pi-manifests.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+// Generates Pi-package manifests for every RedSkills plugin from the canonical
+// Claude-side plugin tree, mirroring scripts/generate-codex-manifests.mjs.
+//
+// Pi packages are installed via `pi install <local-path>` and need a
+// package.json with a `pi-package` keyword plus a `pi.skills` array pointing at
+// the same skill buckets the Claude/Codex manifests expose. This script keeps
+// the per-plugin package.json files under `plugins/<name>/package.json` in
+// sync with the source-of-truth Claude manifests; run `pnpm pi:manifests` to
+// regenerate, `pnpm pi:manifests:check` to fail on drift.
+//
+// The generated package.json intentionally lives alongside the existing
+// .claude-plugin/plugin.json and .codex-plugin/plugin.json so a single source
+// tree continues to serve every host without forking the plugin definitions.
+// Skills exposed here are the same bucket paths the Codex manifest lists, so
+// a `pi install ./plugins/dev` install gives the agent every published dev
+// skill (engineering/knowledge/productivity/misc) without the in-progress
+// drafts.
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const REPO_URL = "https://github.com/reddb-io/red-skills";
+const HOMEPAGE = "https://github.com/reddb-io/red-skills";
+const LICENSE = "Apache-2.0";
+const PREFERRED_SKILL_ROOT_ORDER = ["engineering", "knowledge", "productivity", "misc", "core"];
+const SCOPED_NAMESPACE = "@reddb-io";
+
+function parseArgs(argv) {
+  const args = {
+    root: process.cwd(),
+    check: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--check") {
+      args.check = true;
+      continue;
+    }
+    if (arg === "--root") {
+      const next = argv[index + 1];
+      if (!next) throw new Error("--root requires a path");
+      args.root = next;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
+function titleCaseName(name) {
+  return String(name)
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function normalizeSkillEntry(entry) {
+  return String(entry).replace(/\/+$/, "");
+}
+
+function deriveSkillRoots(skills) {
+  if (typeof skills === "string") {
+    return skills.startsWith("./skills/") || skills === "./skills/" ? skills : `./skills/${skills.replace(/^\.\//, "")}/`;
+  }
+  if (!Array.isArray(skills)) return [];
+
+  const roots = new Set();
+  for (const skill of skills) {
+    const normalized = normalizeSkillEntry(skill);
+    const match = normalized.match(/^\.\/skills\/([^/]+)/);
+    if (match) roots.add(match[1]);
+  }
+
+  const orderedRoots = [...roots].sort((left, right) => {
+    const leftIndex = PREFERRED_SKILL_ROOT_ORDER.indexOf(left);
+    const rightIndex = PREFERRED_SKILL_ROOT_ORDER.indexOf(right);
+    if (leftIndex !== -1 || rightIndex !== -1) {
+      return (leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex) -
+        (rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex);
+    }
+    return left.localeCompare(right);
+  });
+
+  // The Pi package manifest sits at plugins/<name>/package.json, so paths are
+  // rooted there and must include the shared `./skills/` prefix the Claude and
+  // Codex manifests also use. Pi auto-discovers SKILL.md files recursively
+  // beneath each listed directory.
+  return orderedRoots.map((root) => `./skills/${root}/`);
+}
+
+function descriptionText(input) {
+  return String(input ?? "")
+    .replace(/[`\u2018\u2019]/g, "")
+    .replace(/[\u201c\u201d]/g, '"')
+    .replace(/[\u2013\u2014]/g, "-")
+    .replace(/\u2026/g, "...")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function buildPiPackage(claudePlugin) {
+  const description = descriptionText(claudePlugin.description);
+  const packageName = `${SCOPED_NAMESPACE}/red-skills-${claudePlugin.name}`;
+  const skillRoots = deriveSkillRoots(claudePlugin.skills);
+  if (skillRoots.length === 0) {
+    throw new Error(
+      `${claudePlugin.name}: cannot derive skill buckets from Claude plugin manifest`,
+    );
+  }
+
+  const packageJson = {
+    name: packageName,
+    version: claudePlugin.version,
+    private: true,
+    description,
+    license: LICENSE,
+    homepage: HOMEPAGE,
+    repository: {
+      type: "git",
+      url: `${REPO_URL}.git`,
+    },
+    keywords: ["pi-package", "reddb-io", "red-skills", ...(claudePlugin.dependencies ?? []).map((dep) => `dep:${dep}`)],
+    pi: {
+      skills: skillRoots,
+    },
+  };
+
+  return packageJson;
+}
+
+function jsonBytes(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function writeGenerated(path, bytes, check, mismatches) {
+  if (!check) {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, bytes);
+    return;
+  }
+
+  let current = "";
+  try {
+    current = await readFile(path, "utf8");
+  } catch {
+    current = "";
+  }
+
+  if (current !== bytes) {
+    mismatches.push({ path, bytes });
+  }
+}
+
+async function printDiffs(root, mismatches) {
+  const tempRoot = await mkdtemp(join(tmpdir(), "red-skills-pi-manifest-diff-"));
+  try {
+    for (const mismatch of mismatches) {
+      const rel = relative(root, mismatch.path);
+      const expected = join(tempRoot, rel);
+      await mkdir(dirname(expected), { recursive: true });
+      await writeFile(expected, mismatch.bytes);
+      const diff = spawnSync("git", ["diff", "--no-index", "--", mismatch.path, expected], {
+        encoding: "utf8",
+      });
+      const output = `${diff.stdout}${diff.stderr}`.trim();
+      if (output) console.error(output);
+    }
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+export async function generatePiManifests({ root, check = false }) {
+  const mismatches = [];
+  const claudeMarketplacePath = join(root, ".claude-plugin/marketplace.json");
+  const claudeMarketplace = await readJson(claudeMarketplacePath);
+
+  for (const plugin of claudeMarketplace.plugins) {
+    const pluginRoot = join(root, plugin.source);
+    const claudePlugin = await readJson(join(pluginRoot, ".claude-plugin/plugin.json"));
+    const packageJson = buildPiPackage(claudePlugin);
+    await writeGenerated(
+      join(pluginRoot, "package.json"),
+      jsonBytes(packageJson),
+      check,
+      mismatches,
+    );
+  }
+
+  if (check && mismatches.length > 0) {
+    await printDiffs(root, mismatches);
+    throw new Error(
+      `Pi manifests are stale; run node scripts/generate-pi-manifests.mjs (${mismatches.length} file(s))`,
+    );
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  await generatePiManifests(args);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/install-pi.sh
+++ b/scripts/install-pi.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# scripts/install-pi.sh — install the RedSkills Pi packages into Pi's user or
+# project settings.
+#
+# Pi packages are installed via `pi install <local-path>` and registered in
+# ~/.pi/agent/settings.json (user scope) or <target>/.pi/settings.json
+# (project scope). This script resolves the released RedSkills checkout,
+# calls `pi install` once per published plugin (dev/memory/brain), and
+# records the resulting settings file plus the per-plugin local-path entries
+# so a subsequent --uninstall cleanly removes them.
+#
+# Usage:
+#   scripts/install-pi.sh [--user] [--project TARGET_DIR]
+#   scripts/install-pi.sh --uninstall [--user] [--project TARGET_DIR]
+#   scripts/install-pi.sh --dry-run
+#
+# --user: install packages into ~/.pi/agent/settings.json (default).
+# --project TARGET_DIR: install packages into <TARGET_DIR>/.pi/settings.json.
+#   Use this for repo-scoped installs that ship with the repo so teammates
+#   pick up the same RedSkills skills on first launch.
+# --uninstall: remove every package this script previously installed from
+#   the selected scope, and delete the manifest file we wrote.
+# --dry-run: print the steps without invoking `pi install`/`pi remove` or
+#   writing any manifest.
+#
+# Exit codes: 0 success; 1 `pi` not installed or `pi install` failed;
+# 2 usage error.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ACTION="install"
+SCOPE="user"
+TARGET_DIR=""
+DRY_RUN="false"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/install-pi.sh [--user | --project TARGET_DIR]
+                              [--uninstall] [--dry-run]
+
+Options:
+  --user                  install into ~/.pi/agent/settings.json (default)
+  --project TARGET_DIR    install into <TARGET_DIR>/.pi/settings.json
+  --uninstall             remove packages this script previously installed
+  --dry-run               print actions without invoking `pi` or writing files
+  -h, --help              show this help
+
+Examples:
+  scripts/install-pi.sh                           # user-scoped install
+  scripts/install-pi.sh --project /path/to/repo   # project-scoped install
+  scripts/install-pi.sh --uninstall               # user-scoped uninstall
+  scripts/install-pi.sh --project . --dry-run     # inspect project install
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --user)
+      SCOPE="user"
+      shift
+      ;;
+    --project)
+      [ $# -ge 2 ] || { echo "error: --project requires a path" >&2; usage; exit 2; }
+      SCOPE="project"
+      TARGET_DIR="$2"
+      shift 2
+      ;;
+    --uninstall)
+      ACTION="uninstall"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$SCOPE" = "project" ] && [ -z "$TARGET_DIR" ]; then
+  echo "error: --project requires a path" >&2
+  usage
+  exit 2
+fi
+
+if [ "$SCOPE" = "project" ]; then
+  TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+fi
+
+SETTINGS_FILE="$([ "$SCOPE" = "user" ] && printf '%s' "$HOME/.pi/agent/settings.json" || printf '%s' "$TARGET_DIR/.pi/settings.json")"
+MANIFEST_FILE="$([ "$SCOPE" = "user" ] && printf '%s' "$HOME/.pi/agent/redskills-install-manifest.json" || printf '%s' "$TARGET_DIR/.pi/redskills-install-manifest.json")"
+INSTALLED_PLUGINS=(dev memory brain)
+
+log() { printf 'install-pi: %s\n' "$*"; }
+die() { printf 'install-pi: %s\n' "$*" >&2; exit 1; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+if [ "$DRY_RUN" != "true" ]; then
+  require_cmd pi
+  require_cmd jq
+fi
+
+# Generate the per-plugin package.json manifests if they are missing or stale.
+regenerate_manifests() {
+  if [ "$DRY_RUN" = "true" ]; then
+    log "(dry-run) would run scripts/generate-pi-manifests.mjs"
+    return 0
+  fi
+  if [ ! -f "$REPO_ROOT/scripts/generate-pi-manifests.mjs" ]; then
+    die "scripts/generate-pi-manifests.mjs is missing from the source checkout"
+  fi
+  node "$REPO_ROOT/scripts/generate-pi-manifests.mjs" --root "$REPO_ROOT" \
+    || die "pi manifest generation failed"
+}
+
+assert_settings_file_present() {
+  [ -f "$SETTINGS_FILE" ] \
+    || die "Pi settings file is missing: $SETTINGS_FILE. Run \`pi\` once interactively to create it."
+}
+
+read_manifest() {
+  [ -f "$MANIFEST_FILE" ] || return 0
+  jq -r '.plugins[]? | "\(.name)\t\(.path)"' "$MANIFEST_FILE"
+}
+
+write_manifest() {
+  local plugin_name="$1"
+  local source_path="$2"
+  local tmp
+  tmp="$(mktemp)"
+  if [ -f "$MANIFEST_FILE" ]; then
+    jq --arg name "$plugin_name" --arg path "$source_path" \
+      '.plugins |= map(select(.name != $name)) + [{name: $name, path: $path}]' \
+      "$MANIFEST_FILE" > "$tmp"
+  else
+    mkdir -p "$(dirname "$MANIFEST_FILE")"
+    jq -n --arg name "$plugin_name" --arg path "$source_path" \
+      '{version: 1, scope: "'"$SCOPE"'", settings_file: "'"$SETTINGS_FILE"'", plugins: [{name: $name, path: $path}]}' \
+      > "$tmp"
+  fi
+  mv "$tmp" "$MANIFEST_FILE"
+}
+
+remove_from_manifest() {
+  local plugin_name="$1"
+  [ -f "$MANIFEST_FILE" ] || return 0
+  local tmp
+  tmp="$(mktemp)"
+  jq --arg name "$plugin_name" '.plugins |= map(select(.name != $name))' \
+    "$MANIFEST_FILE" > "$tmp"
+  mv "$tmp" "$MANIFEST_FILE"
+}
+
+invoke_pi_install() {
+  local plugin_name="$1"
+  local source_path="$2"
+  if [ "$DRY_RUN" = "true" ]; then
+    log "(dry-run) would run: pi install $source_path"
+    log "(dry-run) manifest entry: $plugin_name -> $source_path ($SETTINGS_FILE)"
+    return 0
+  fi
+  log "installing $plugin_name via \`pi install $source_path\`"
+  if [ "$SCOPE" = "project" ]; then
+    ( cd "$TARGET_DIR" && pi install -l "$source_path" )
+  else
+    pi install "$source_path"
+  fi
+  write_manifest "$plugin_name" "$source_path"
+}
+
+invoke_pi_remove() {
+  local plugin_name="$1"
+  local source_path="$2"
+  if [ "$DRY_RUN" = "true" ]; then
+    log "(dry-run) would run: pi remove $source_path"
+    log "(dry-run) manifest entry: $plugin_name -> $source_path"
+    return 0
+  fi
+  log "removing $plugin_name via \`pi remove $source_path\`"
+  pi remove "$source_path" || warn "pi remove reported an error for $plugin_name (continuing)"
+  remove_from_manifest "$plugin_name"
+}
+
+warn() { printf 'install-pi: warn: %s\n' "$*" >&2; }
+
+run_install() {
+  if [ "$DRY_RUN" != "true" ]; then
+    assert_settings_file_present
+  fi
+  regenerate_manifests
+  local plugin_dir
+  for plugin in "${INSTALLED_PLUGINS[@]}"; do
+    plugin_dir="$REPO_ROOT/plugins/$plugin"
+    if [ ! -d "$plugin_dir" ]; then
+      warn "skipping $plugin: source dir $plugin_dir not found"
+      continue
+    fi
+    invoke_pi_install "$plugin" "$plugin_dir"
+  done
+  if [ "$DRY_RUN" = "true" ]; then
+    log "(dry-run) would record manifest at $MANIFEST_FILE"
+  else
+    log "wrote install manifest $MANIFEST_FILE"
+  fi
+  log "restart any open pi sessions so the new skills reload"
+}
+
+run_uninstall() {
+  if [ "$DRY_RUN" != "true" ]; then
+    assert_settings_file_present
+  fi
+  if [ ! -f "$MANIFEST_FILE" ]; then
+    warn "no manifest at $MANIFEST_FILE; nothing to remove"
+    return 0
+  fi
+  local seen_plugin
+  seen_plugin=""
+  while IFS=$'\t' read -r plugin_name source_path; do
+    [ -n "$plugin_name" ] || continue
+    invoke_pi_remove "$plugin_name" "$source_path"
+    seen_plugin="$seen_plugin $plugin_name"
+  done < <(read_manifest)
+  if [ "$DRY_RUN" = "true" ]; then
+    log "(dry-run) would retain manifest at $MANIFEST_FILE"
+  else
+    # Remove the manifest file once empty so a fresh install starts clean.
+    local remaining
+    remaining="$(jq -r '.plugins | length' "$MANIFEST_FILE" 2>/dev/null || echo 0)"
+    if [ "$remaining" = "0" ]; then
+      rm -f "$MANIFEST_FILE"
+      log "removed empty manifest $MANIFEST_FILE"
+    fi
+  fi
+  log "restart any open pi sessions so the removed skills unload"
+}
+
+case "$ACTION" in
+  install) run_install ;;
+  uninstall) run_uninstall ;;
+  *) die "internal: unknown ACTION $ACTION" ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,6 +22,8 @@ VERSION="${RED_SKILLS_VERSION:-latest}"
 INSTALL_ROOT="${RED_SKILLS_INSTALL_ROOT:-$HOME/.red-skills}"
 ONLY="${RED_SKILLS_ONLY:-auto}"
 CLAUDE_SCOPE="${RED_SKILLS_CLAUDE_SCOPE:-user}"
+PI_SCOPE="${RED_SKILLS_PI_SCOPE:-user}"
+PI_PROJECT_DIR=""
 SOURCE_DIR="${RED_SKILLS_SOURCE_DIR:-}"
 ACTION="${RED_SKILLS_ACTION:-install}"
 FORCE="${RED_SKILLS_FORCE:-false}"
@@ -38,12 +40,15 @@ Installs RedSkills into every detected supported CLI:
   claude   -> Claude Code marketplace + dev/memory/brain plugins
   codex    -> Codex marketplace + dev/memory/brain plugins
   opencode -> generated OpenCode plugins, skills, MCP config, and TUI config
+  pi       -> per-plugin Pi packages installed via `pi install`, registered in
+              ~/.pi/agent/settings.json (or .pi/settings.json with --project)
 
 Options:
   --version <tag>       Install a specific release tag (default: latest release)
   --install-root <dir>  Install source cache here (default: ~/.red-skills)
-  --only <list>         Comma list: claude,codex,opencode (default: auto-detect)
+  --only <list>         Comma list: claude,codex,opencode,pi (default: auto-detect)
   --claude-scope <s>    Claude install scope: user, project, or local (default: user)
+  --pi-scope <s>        Pi install scope: user or project (default: user)
   --source-dir <dir>    Use an existing red-skills checkout instead of downloading
   --uninstall           Remove RedSkills from detected/specified CLIs
   --force               Reinstall plugins where the host supports removal
@@ -55,8 +60,8 @@ Options:
 
 Environment:
   RED_SKILLS_VERSION, RED_SKILLS_INSTALL_ROOT, RED_SKILLS_ONLY,
-  RED_SKILLS_CLAUDE_SCOPE, RED_SKILLS_SOURCE_DIR, RED_SKILLS_ACTION,
-  RED_SKILLS_FORCE, RED_SKILLS_PURGE, RED_SKILLS_REFRESH,
+  RED_SKILLS_CLAUDE_SCOPE, RED_SKILLS_PI_SCOPE, RED_SKILLS_SOURCE_DIR,
+  RED_SKILLS_ACTION, RED_SKILLS_FORCE, RED_SKILLS_PURGE, RED_SKILLS_REFRESH,
   RED_SKILLS_OPENCODE_COPY, GITHUB_TOKEN.
 EOF
 }
@@ -116,6 +121,11 @@ has_uninstall_target() {
     opencode)
       command -v opencode >/dev/null 2>&1 && return 0
       [[ -d "${XDG_CONFIG_HOME:-$HOME/.config}/opencode" ]] && return 0
+      return 1
+      ;;
+    pi)
+      command -v pi >/dev/null 2>&1 && return 0
+      [[ -d "$HOME/.pi/agent" ]] && return 0
       return 1
       ;;
     *)
@@ -336,6 +346,27 @@ install_opencode() {
   run "${args[@]}"
 }
 
+install_pi() {
+  if ! command -v pi >/dev/null 2>&1; then
+    warn "pi not found; skipping Pi"
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" != "true" ]]; then
+    [[ -x "$SOURCE_DIR/scripts/install-pi.sh" ]] || die "source is missing executable scripts/install-pi.sh"
+    require_cmd node
+  fi
+
+  local args=("$SOURCE_DIR/scripts/install-pi.sh")
+  if [[ "$PI_SCOPE" == "project" ]]; then
+    args+=("--project" "${PI_PROJECT_DIR:-$PWD}")
+  else
+    args+=("--user")
+  fi
+  log "installing Pi packages from $SOURCE_DIR ($PI_SCOPE scope)"
+  run "${args[@]}"
+}
+
 remove_generated_config() {
   local file="$1"
   [[ -f "$file" ]] || return 0
@@ -464,6 +495,37 @@ opencode_source_dir_for_uninstall() {
   return 1
 }
 
+uninstall_pi() {
+  local manifest_user="$HOME/.pi/agent/redskills-install-manifest.json"
+  local manifest_project=""
+  if [[ -n "$PI_PROJECT_DIR" ]]; then
+    manifest_project="$(cd "$PI_PROJECT_DIR" 2>/dev/null && pwd)/.pi/redskills-install-manifest.json"
+  fi
+
+  if ! command -v pi >/dev/null 2>&1; then
+    warn "pi not found; skipping Pi uninstall"
+    if [[ -f "$manifest_user" ]]; then
+      rm -f "$manifest_user"
+      log "removed stale manifest $manifest_user"
+    fi
+    return 0
+  fi
+
+  local source
+  if source="$(opencode_source_dir_for_uninstall)"; then
+    log "uninstalling Pi RedSkills packages via $source/scripts/install-pi.sh"
+    if [[ -f "$manifest_user" ]]; then
+      run "$source/scripts/install-pi.sh" --uninstall --user
+    fi
+    if [[ -n "$manifest_project" && -f "$manifest_project" ]]; then
+      ( cd "$PI_PROJECT_DIR" && run "$source/scripts/install-pi.sh" --uninstall --project "$PI_PROJECT_DIR" )
+    fi
+    return 0
+  fi
+
+  warn "no RedSkills source checkout found; skipped Pi uninstall"
+}
+
 uninstall_opencode() {
   local source
   if source="$(opencode_source_dir_for_uninstall)"; then
@@ -523,13 +585,17 @@ run_uninstall() {
     uninstall_opencode
     touched_any="true"
   fi
+  if has_uninstall_target pi; then
+    uninstall_pi
+    touched_any="true"
+  fi
 
   if [[ "$PURGE" == "true" ]]; then
     run rm -rf "$INSTALL_ROOT"
   fi
 
   if [[ "$touched_any" != "true" ]]; then
-    warn "no supported CLIs/configs detected (claude, codex, opencode)"
+    warn "no supported CLIs/configs detected (claude, codex, opencode, pi)"
   fi
 }
 
@@ -553,6 +619,17 @@ while [[ $# -gt 0 ]]; do
     --claude-scope)
       [[ $# -ge 2 ]] || die "$1 requires a value"
       CLAUDE_SCOPE="$2"
+      shift 2
+      ;;
+    --pi-scope)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      PI_SCOPE="$2"
+      shift 2
+      ;;
+    --pi-project-dir)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      PI_PROJECT_DIR="$2"
+      PI_SCOPE="project"
       shift 2
       ;;
     --source-dir)
@@ -599,6 +676,11 @@ case "$CLAUDE_SCOPE" in
   *) die "--claude-scope must be user, project, or local" ;;
 esac
 
+case "$PI_SCOPE" in
+  user|project) ;;
+  *) die "--pi-scope must be user or project" ;;
+esac
+
 case "$ACTION" in
   install|uninstall) ;;
   *) die "RED_SKILLS_ACTION must be install or uninstall" ;;
@@ -610,7 +692,7 @@ case "$ONLY" in
     IFS=',' read -r -a requested_targets <<<"$ONLY"
     for target in "${requested_targets[@]}"; do
       case "$target" in
-        claude|codex|opencode) ;;
+        claude|codex|opencode|pi) ;;
         *) die "--only contains unsupported target '$target'" ;;
       esac
     done
@@ -639,9 +721,13 @@ if has_target opencode; then
   install_opencode
   installed_any="true"
 fi
+if has_target pi; then
+  install_pi
+  installed_any="true"
+fi
 
 if [[ "$installed_any" != "true" ]]; then
-  warn "no supported CLIs detected (claude, codex, opencode)"
+  warn "no supported CLIs detected (claude, codex, opencode, pi)"
 fi
 
 log "done"

--- a/scripts/validate-install-metadata.sh
+++ b/scripts/validate-install-metadata.sh
@@ -16,6 +16,9 @@ trap 'rm -rf "$tmp"' EXIT
 
 bash -n scripts/install.sh || fail "scripts/install.sh has invalid bash syntax"
 bash -n scripts/install-opencode.sh || fail "scripts/install-opencode.sh has invalid bash syntax"
+bash -n scripts/install-pi.sh || fail "scripts/install-pi.sh has invalid bash syntax"
+node scripts/generate-pi-manifests.mjs --root "$REPO" --check \
+  || fail "plugins/<name>/package.json Pi manifests are stale; run pnpm pi:manifests"
 
 # Validate one plugin's install metadata: Claude skill list matches the SKILL.md
 # tree on disk, Claude/Codex versions agree, and the Codex plugin exposes the
@@ -107,6 +110,30 @@ validate_plugin() {
   jq -e --arg p "./$dir" '.plugins[] | select(.source == $p)' \
     .claude-plugin/marketplace.json >/dev/null \
     || fail "$plugin: Claude marketplace must expose ./$dir"
+
+  # Pi package manifest: must exist, declare the pi-package keyword, carry the
+  # same version as the Claude/Codex manifests, and enumerate only buckets
+  # that exist on disk under ./skills/.
+  local pi_pkg="$dir/package.json"
+  [ -f "$pi_pkg" ] \
+    || fail "$plugin: Pi package.json missing: $pi_pkg"
+  jq -e '.keywords | index("pi-package")' "$pi_pkg" >/dev/null \
+    || fail "$plugin: $pi_pkg must declare the pi-package keyword"
+  jq -e --arg plugin "$plugin" \
+    '(.name | startswith("@reddb-io/red-skills-" + $plugin))' "$pi_pkg" >/dev/null \
+    || fail "$plugin: $pi_pkg name must be @reddb-io/red-skills-$plugin"
+  jq -e --slurp '.[0].version == .[1].version' \
+    "$dir/.claude-plugin/plugin.json" "$pi_pkg" >/dev/null \
+    || fail "$plugin: $pi_pkg version must match Claude/Codex manifests"
+  jq -e '.pi.skills | type == "array" and length > 0' "$pi_pkg" >/dev/null \
+    || fail "$plugin: $pi_pkg pi.skills must be a non-empty array"
+  local bucket
+  while IFS= read -r bucket; do
+    [[ "$bucket" == ./skills/* ]] \
+      || fail "$plugin: Pi skill bucket must start with ./skills/: $bucket"
+    [[ -d "$dir/${bucket#./}" ]] \
+      || fail "$plugin: Pi skill bucket not found on disk: $bucket"
+  done < <(jq -r '.pi.skills[]' "$pi_pkg")
 }
 
 validate_plugin dev


### PR DESCRIPTION
## Summary

Wire **Pi** (@earendil-works/pi-coding-agent) into the RedSkills host matrix alongside Claude Code, Codex, and OpenCode. Pi consumes the Agent Skills protocol, so the same SKILL.md files under `plugins/<name>/skills/` are exposed via generated Pi packages instead of being copied or duplicated.

## How Pi maps to what we already ship

| Pi concept | RedSkills source | What this PR does |
| --- | --- | --- |
| Packages (`npm:`/`git:`/local-path) | one per plugin | `plugins/<name>/package.json` with the `pi-package` keyword |
| Skills (Agent Skills protocol) | `plugins/<name>/skills/<bucket>/<skill>/SKILL.md` | enumerated under `pi.skills` with the existing `./skills/<bucket>/` paths |
| Marketplace | n/a — Pi has no marketplace, only a [gallery](https://pi.dev/packages) | omitted; install is per-package via `pi install <local-dir>` |
| Hooks (SessionStart/Stop/PreCompact) | `plugins/<name>/hooks/{claude,codex}.hooks.json` | **not mapped** — Pi has no equivalent lifecycle surface; documented as a known limitation |
| MCP servers | `plugins/<name>/.mcp.json` | **not mapped** — Pi does not include MCP by design; documented as a known limitation |

## Changes

- `scripts/generate-pi-manifests.mjs` — derives `plugins/<name>/package.json` from the canonical `.claude-plugin/plugin.json`, mirroring `generate-codex-manifests.mjs`. Skill buckets stay under `./skills/<bucket>/` so pi recursive discovery picks up the same published set Claude and Codex already expose; `in-progress/` drafts stay excluded.
- `scripts/install-pi.sh` — regenerates the Pi packages, calls `pi install <plugin-dir>` once per published plugin (dev/memory/brain), records the install in `~/.pi/agent/redskills-install-manifest.json` (or `<project>/.pi/redskills-install-manifest.json` for `--project`), and supports `--uninstall` with idempotent manifest-based cleanup.
- `scripts/install.sh` — new `pi` host target with `--only pi`, `--pi-scope`, and `--pi-project-dir` flags; `pi` is detected through `command -v pi` or the presence of `~/.pi/agent/`, the same pattern the existing opencode detector follows.
- `scripts/validate-install-metadata.sh` — gates `plugins/<name>/package.json` on the `pi-package` keyword, version parity with the Claude/Codex manifests, and `./skills/<bucket>/` buckets that exist on disk.
- `.github/workflows/red-marketplace-ci.yml` + `red-workspace-ci.yml` — run `pnpm pi:manifests:check` and the install-metadata validator in CI.
- `apps/dev/tests/{pi-manifest-generator,manifest-parity}.test.ts` — fixture-based coverage for the generator plus a parity check that the Pi package bucket list matches the Codex bucket list.
- `package.json` — `pnpm pi:manifests` / `pnpm pi:manifests:check` scripts.
- `README.md` + `CLAUDE.md` — document the new host, the install/uninstall flow, and the generator-as-artifact invariant for `package.json`.

## Known limitations (documented in README.md)

1. **Hooks are inert in Pi.** Pi does not run lifecycle hooks, so Codex/Claude `SessionStart`/`Stop` telemetry (`rsp` interception, `red-fetch`, `command-guard`, `branch-lock`, statusline wiring) stays disabled. Skills remain navigable; `/afk` and `/go` invoke the `red-skills-dev` bundle via npx and are unaffected.
2. **`view` skill collision.** `memory` and `brain` both ship a skill with `name: view`. Pi warns on collision and keeps the first match — install the package whose `view` you want as primary last. Renaming would touch the Codex/Claude manifests and the marketplace, so left as a known limitation.
3. **No Codex-style display metadata.** Pi does not read the `interface` block; only the `package.json` `description` shows up in `pi list`.
4. **MCP servers are not auto-wired.** Pi has no MCP by design. The `.mcp.json` files for `code-nav`, `rsp`, `memory-mcp`, `brain-mcp` are not bridged into Pi. Operators wanting those tools need an MCP stdio→Pi extension (out of scope for this slice).

## Validation

```bash
$ bash scripts/validate-install-metadata.sh && bash scripts/validate-marketplace-manifests.sh \
   && bash scripts/run-plugin-structural-smokes.sh \
   && pnpm pi:manifests:check && pnpm codex:manifests:check
… ALL_GREEN

$ pnpm test --filter @reddb-io/dev -- --run --reporter=dot \
    codex-manifest-generator pi-manifest-generator manifest-parity
 Test Files  3 passed (3)
       Tests  9 passed (9)
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787024501&installation_id=129708444&pr_number=2167&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2167&signature=ee693ce31b8d94e4add58ee5f1b14641cf75801eab2940b7d89244cee053ca68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->