### PR TITLE
fix: #2190 AFK codex workers: input_tokens/output_tokens stay 0 while loc/tools/text stamp correctly

### DIFF
--- a/packages/red-castle/src/AgentProvider.test.ts
+++ b/packages/red-castle/src/AgentProvider.test.ts
@@ -906,6 +906,46 @@ describe("codex factory", () => {
     ]);
   });
 
+  it("parseStreamLine extracts live token usage from Codex token_count events", () => {
+    const provider = codex("gpt-5.4-mini");
+    const line = JSON.stringify({
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: {
+          total_token_usage: {
+            input_tokens: 97687,
+            cached_input_tokens: 36480,
+            output_tokens: 1470,
+            reasoning_output_tokens: 218,
+            total_tokens: 99157,
+          },
+          last_token_usage: {
+            input_tokens: 35542,
+            cached_input_tokens: 31616,
+            output_tokens: 503,
+            reasoning_output_tokens: 15,
+            total_tokens: 36045,
+          },
+          model_context_window: 258400,
+        },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      {
+        type: "usage",
+        usage: {
+          inputTokens: 3926,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 31616,
+          outputTokens: 503,
+          reasoningTokens: 15,
+        },
+      },
+      { type: "reasoning", tokens: 15 },
+    ]);
+  });
+
   it("parseStreamLine skips turn.completed with malformed usage", () => {
     const provider = codex("gpt-5.4-mini");
     const line = JSON.stringify({

--- a/packages/red-castle/src/AgentProvider.ts
+++ b/packages/red-castle/src/AgentProvider.ts
@@ -773,13 +773,15 @@ export const pi = (
 // ---------------------------------------------------------------------------
 
 /**
- * Map a Codex `turn.completed` usage object to the Claude-shaped IterationUsage.
+ * Map a Codex token-usage object to the Claude-shaped IterationUsage.
  *
- * OpenAI/Codex usage is `{ input_tokens, cached_input_tokens, output_tokens }`,
- * where `input_tokens` is the *total* prompt tokens and `cached_input_tokens` is
- * a subset already included in that total. There is no cache-creation concept.
- * To avoid double-counting cached tokens in the context-window display (which
- * sums input + cacheCreation + cacheRead), the cached portion maps to
+ * OpenAI/Codex usage is `{ input_tokens, cached_input_tokens, output_tokens }`.
+ * `turn.completed.usage` and the newer `token_count.info.last_token_usage`
+ * carry the same counters: `input_tokens` is the *total* prompt tokens and
+ * `cached_input_tokens` is a subset already included in that total. There is no
+ * cache-creation concept. To avoid double-counting cached tokens in the
+ * context-window display (which sums input + cacheCreation + cacheRead), the
+ * cached portion maps to
  * `cacheReadInputTokens` and the remainder to `inputTokens`.
  */
 const parseCodexUsage = (usage: unknown): IterationUsage | undefined => {
@@ -803,6 +805,15 @@ const parseCodexUsage = (usage: unknown): IterationUsage | undefined => {
     outputTokens: u.output_tokens,
     ...(reasoning !== undefined ? { reasoningTokens: reasoning } : {}),
   };
+};
+
+const codexUsageEvents = (usageInput: unknown): ParsedStreamEvent[] => {
+  const usage = parseCodexUsage(usageInput);
+  const events: ParsedStreamEvent[] = usage ? [{ type: "usage", usage }] : [];
+  if (usage?.reasoningTokens !== undefined && usage.reasoningTokens > 0) {
+    events.push({ type: "reasoning", tokens: usage.reasoningTokens });
+  }
+  return events;
 };
 
 const parseCodexStreamLine = (line: string): ParsedStreamEvent[] => {
@@ -844,20 +855,19 @@ const parseCodexStreamLine = (line: string): ParsedStreamEvent[] => {
       return msg ? [{ type: "result", result: msg }] : [];
     }
 
-    // turn.completed carries token usage for the turn. codex does NOT stream a
-    // discrete reasoning item — reasoning surfaces only as the per-turn
+    // Current Codex CLI JSONL reports token usage as an `event_msg` wrapper
+    // around `payload.type = "token_count"`. Use `last_token_usage`, not the
+    // cumulative `total_token_usage`, because AFK's activity meter sums events.
+    if (obj.type === "event_msg" && obj.payload?.type === "token_count") {
+      return codexUsageEvents(obj.payload.info?.last_token_usage);
+    }
+
+    // Older Codex JSONL carries token usage on turn.completed. Codex does NOT
+    // stream a discrete reasoning item — reasoning surfaces only as the per-turn
     // `reasoning_output_tokens` count, so emit a token-bearing reasoning event
     // (alongside the usage event) when the turn did any reasoning.
     if (obj.type === "turn.completed") {
-      const usage = parseCodexUsage(obj.usage);
-      const events: ParsedStreamEvent[] = usage
-        ? [{ type: "usage", usage }]
-        : [];
-      const rtok = obj.usage?.reasoning_output_tokens;
-      if (typeof rtok === "number" && rtok > 0) {
-        events.push({ type: "reasoning", tokens: rtok });
-      }
-      return events;
+      return codexUsageEvents(obj.usage);
     }
   } catch {
     // Not valid JSON — skip


### PR DESCRIPTION
Automated AFK landing for #2190. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2190

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787057379&installation_id=129708444&pr_number=2198&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2198&signature=0781fb202b11bd03fed1f7d91905c3101ed6bd3baca89151ccc95cb35a580eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->