### PR TITLE
fix: #2169 AFK freshness gate: uncommitted primary WIP + local main behind → auto-FF refused → workers stall the whole queue

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -363,15 +363,17 @@ async function tryBootAutoApplyBaseFreshness(
   return true;
 }
 
-/** True when this base-freshness finding has guard=passed and finding=local-trunk-behind-origin.
+/** True when this base-freshness finding is safe to downgrade for worker boot.
  * Worker sessions (skipSweeps) can skip the fatal halt for this case because they branch from
  * origin/main directly — a behind local main does not affect their work. */
-function isGuardPassedBaseFreshnessFinding(
+function isWorkerExemptBaseFreshnessFinding(
   finding: OperationalProbeReport["findings"][number],
 ): boolean {
   if (finding.id !== BASE_FRESHNESS_PROBE_ID) return false;
   const data = finding.data as Partial<BaseFreshnessProbeData> | undefined;
-  return data?.finding === "local-trunk-behind-origin" && data.guard?.guard === "passed";
+  if (data?.finding !== "local-trunk-behind-origin") return false;
+  if (data.guard?.guard === "passed") return true;
+  return data.guard?.failedCondition === "clean-tree";
 }
 
 // ---------- step inputs ----------
@@ -619,9 +621,9 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
     if (!applied) {
       // Worker sessions (skipSweeps) branch from origin/main, so local-main-behind-origin
       // does not affect their branch base. The guarded FF dep is absent on this path; when
-      // the guard passes, downgrade to a non-fatal finding instead of halting the session.
-      // Guard-refused cases (dirty, off-trunk, diverged) still refuse regardless.
-      const workerSessionExempt = options.skipSweeps === true && isGuardPassedBaseFreshnessFinding(redProbe);
+      // the guard passes, or only refuses because the primary has uncommitted WIP, downgrade
+      // to a non-fatal finding instead of halting the session.
+      const workerSessionExempt = options.skipSweeps === true && isWorkerExemptBaseFreshnessFinding(redProbe);
       if (!workerSessionExempt) throw new BootHaltError("operational-probe", redProbe);
     }
     const nextRedProbe = operationalProbes.findings[1];

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -699,6 +699,43 @@ describe("runBoot skipSweeps — supervisor-owned boot (#623)", () => {
     expect(fsCalls.ensureDir).toContain("/p/.red/tmp");
   });
 
+  it("does NOT halt when local main is behind and primary WIP refuses auto-FF", async () => {
+    const { deps, fsCalls } = makeDeps();
+
+    const result = await runBoot(
+      deps,
+      options({
+        skipSweeps: true,
+        operationalProbes: {
+          remoteUrls: [],
+          baseFreshness: {
+            trunk: "main",
+            remote: "origin",
+            localSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+            remoteSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ahead: 0,
+            behind: 1,
+            remoteReachable: true,
+            guard: {
+              guard: "refused",
+              target: "main",
+              remote: "origin",
+              currentBranch: "main",
+              failed: "dirty-tree",
+              failedCondition: "clean-tree",
+              evidence: "condition failed: clean-tree (1 dirty path(s))",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.bootstrap).toEqual({ ok: true });
+    expect(result.operationalProbes?.findings).toHaveLength(1);
+    expect(result.operationalProbes?.findings[0]?.evidence).toContain("guard=refused");
+    expect(fsCalls.ensureDir).toContain("/p/.red/tmp");
+  });
+
   it.each([
     [
       "off-trunk",
@@ -710,18 +747,6 @@ describe("runBoot skipSweeps — supervisor-owned boot (#623)", () => {
         failed: "not-on-trunk" as const,
         failedCondition: "on-trunk" as const,
         evidence: "condition failed: on-trunk (current=feature/work expected=main)",
-      },
-    ],
-    [
-      "dirty tree",
-      {
-        guard: "refused" as const,
-        target: "main",
-        remote: "origin",
-        currentBranch: "main",
-        failed: "dirty-tree" as const,
-        failedCondition: "clean-tree" as const,
-        evidence: "condition failed: clean-tree (1 dirty path(s))",
       },
     ],
     [

--- a/plugins/brain/package.json
+++ b/plugins/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-brain",
-  "version": "2.75.1",
+  "version": "2.75.2",
   "private": true,
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "license": "Apache-2.0",

--- a/plugins/dev/package.json
+++ b/plugins/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-dev",
-  "version": "2.75.1",
+  "version": "2.75.2",
   "private": true,
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "license": "Apache-2.0",

--- a/plugins/memory/package.json
+++ b/plugins/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-memory",
-  "version": "2.75.1",
+  "version": "2.75.2",
   "private": true,
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Automated AFK landing for #2169. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2169

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787057648&installation_id=129708444&pr_number=2199&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2199&signature=a7eadbe2c8d025fb6fe1e8464d741261b9f5d2f3a00c457ce7f1381eb7c7f24f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->