### PR TITLE
fix: #2187 main-red repair: baseline probe failures on main

### DIFF
--- a/apps/dev/tests/boot-cleanup.test.ts
+++ b/apps/dev/tests/boot-cleanup.test.ts
@@ -6,6 +6,7 @@ import {
   options,
   runBoot,
   NOW,
+  type AttemptDir,
   type BootDeps,
   type BranchRef,
   type IssueMeta,

--- a/apps/dev/tests/boot-reconcile.test.ts
+++ b/apps/dev/tests/boot-reconcile.test.ts
@@ -5,6 +5,7 @@ import {
   makeDeps,
   options,
   runBoot,
+  type AttemptDir,
   type BootDeps,
   type BranchRef,
   type IssueMeta,

--- a/apps/dev/tests/boot-runtime.test.ts
+++ b/apps/dev/tests/boot-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   makeDeps,
   options,
   runBoot,
+  type BootDeps,
 } from "./boot.helpers.js";
 
 describe("runBoot precheck short-circuit", () => {


### PR DESCRIPTION
Automated AFK landing for #2187. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2187

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787079524&installation_id=129708444&pr_number=2212&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2212&signature=6267d4d1189dab563381b74720cd1d5decb7fd239450a588bf612b6bdb9d733a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->