### PR TITLE
fix: #2208 S2: Adversarial review — bounded re-seed correction loop

### DIFF
--- a/apps/dev/src/core/adversarial-review.ts
+++ b/apps/dev/src/core/adversarial-review.ts
@@ -60,11 +60,13 @@ export function resolveAdversarialReviewConfig(get: (key: string) => string): Ad
 }
 
 export function decideAdversarialReview(
-  _findings: AdversarialReviewFindings,
-  _iteration: number,
-  _cap: number,
+  findings: AdversarialReviewFindings,
+  iteration: number,
+  cap: number,
 ): AdversarialReviewDecision {
-  return "pass";
+  const hasBlocking = findings.findings.some((finding) => finding.blocking);
+  if (!hasBlocking) return "pass";
+  return iteration <= cap ? "correct" : "pass";
 }
 
 export function buildAdversarialReviewPrompt(context: AdversarialReviewContext): string {
@@ -125,10 +127,16 @@ export function renderAdversarialReviewComment(
   findings: AdversarialReviewFindings,
   decision: AdversarialReviewDecision,
 ): string {
+  const decisionText =
+    decision === "correct"
+      ? "correct (blocking)"
+      : decision === "park"
+        ? "park (blocking)"
+        : "pass (advisory)";
   const lines = [
     "## AFK adversarial review",
     "",
-    `Decision: ${decision} (advisory)`,
+    `Decision: ${decisionText}`,
     "",
     findings.summary,
     "",
@@ -147,6 +155,47 @@ export function renderAdversarialReviewComment(
     });
   }
   return lines.join("\n");
+}
+
+function tailLines(text: string, maxLines: number): string {
+  const lines = text.split("\n");
+  return lines.slice(Math.max(0, lines.length - maxLines)).join("\n");
+}
+
+export function appendAdversarialReviewCorrectionHandoff(
+  handoff: string,
+  opts: {
+    diff: string;
+    findings: AdversarialReviewFindings;
+    retry: number;
+    cap: number;
+  },
+): string {
+  const blocking = opts.findings.findings.filter((finding) => finding.blocking);
+  return [
+    handoff.replace(/\n+$/, ""),
+    "",
+    "<adversarial-review-correction>",
+    `A blocking adversarial review found confirmed defects or acceptance-criteria gaps. This is bounded correction retry ${opts.retry}/${opts.cap}.`,
+    "Fix only the blocking findings below on the existing branch, keep unrelated nits/style/suggestions out of scope, run the relevant gate, commit only the needed changes, then emit the required terminal sentinel.",
+    "",
+    "<review-critiques>",
+    opts.findings.summary,
+    ...blocking.flatMap((finding, idx) => [
+      "",
+      `${idx + 1}. ${finding.path}:${finding.line}`,
+      finding.body,
+    ]),
+    "</review-critiques>",
+    "",
+    '<pr-diff data-untrusted="true">',
+    "```diff",
+    tailLines(opts.diff, 200),
+    "```",
+    "</pr-diff>",
+    "</adversarial-review-correction>",
+    "",
+  ].join("\n");
 }
 
 export function makeExtractAdversarialReview(

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -146,7 +146,7 @@ export interface LandingDeps {
    * never affects whether/how the PR merges. Absent (the default) or on the
    * direct path (no PR) → never called.
    */
-  onPrResolved?: (prNumber: number) => Promise<void>;
+  onPrResolved?: (prNumber: number) => Promise<void | "abort">;
   /**
    * Opt-in post-merge-integration gate (#1335). When present, the landing re-runs
    * the package-scoped feedback gate against the INTEGRATED tree (the worker branch
@@ -346,6 +346,7 @@ export type LandingResult =
         | "pr-merge-failed"
         | "infra"
         | "main-red-untracked"
+        | "adversarial-correction"
         // Legacy ADR 0083 landing-precondition route. New trunk freshness uses
         // the fleet-owned `red-trunk` mirror and no longer emits this from
         // landing, but older callers/tests may still reference the result shape.
@@ -556,6 +557,9 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
   // longer unlocked-only — lock=X + openPr=true also lands through here.
   if (r.reason === "ci-failed") return { ok: false, reason: "ci-failed", locked: input.locked, prNumber: r.prNumber };
   if (r.reason === "ci-pending") return { ok: false, reason: "ci-pending", locked: input.locked, prNumber: r.prNumber };
+  if (r.reason === "pr-resolved-abort") {
+    return { ok: false, reason: "adversarial-correction", locked: input.locked, prNumber: r.prNumber };
+  }
   if (r.reason === "conflict") return { ok: false, reason: "pr-conflict", locked: input.locked, prNumber: r.prNumber };
   if (r.reason === "merge-failed" && r.prNumber !== undefined) {
     return { ok: false, reason: "pr-merge-failed", locked: input.locked, prNumber: r.prNumber };

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -588,7 +588,7 @@ export interface LandPrInput {
    * a rejection is swallowed here so it can never fail or alter the landing.
    * Absent (the default) → never called.
    */
-  onPrResolved?: (prNumber: number) => Promise<void>;
+  onPrResolved?: (prNumber: number) => Promise<void | "abort">;
   /**
    * Native merge queue (#1337). True when `<target>` has the forge's merge queue
    * configured, so the merge is ENQUEUED (`gh pr merge --auto`) instead of merged
@@ -607,6 +607,7 @@ export interface LandPrInput {
 export type LandPrFailReason =
   | "push-failed"
   | "no-pr"
+  | "pr-resolved-abort"
   | "conflict"
   | "ci-failed"
   | "ci-pending"
@@ -885,7 +886,9 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
   // decoupled: a rejection is swallowed so it can never fail or alter the landing.
   if (onPrResolved) {
     try {
-      await onPrResolved(prNumber);
+      if ((await onPrResolved(prNumber)) === "abort") {
+        return { ok: false, reason: "pr-resolved-abort", prNumber };
+      }
     } catch {
       // observability only — never let a failed review post block the merge.
     }

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -118,6 +118,7 @@ import {
 } from "../issue-lifecycle.js";
 import { allowlistExternalWidened, ALLOWLIST_PATH } from "../shared-gate.js";
 import {
+  appendAdversarialReviewCorrectionHandoff,
   decideAdversarialReview,
   renderAdversarialReviewComment,
   type AdversarialReviewFindings,
@@ -384,6 +385,10 @@ export async function processIssue(
   let mainRedRepairSyncFailure: string | null = null;
   let currentHandoff = handoff;
   let goVerifyRetriesUsed = 0;
+  let adversarialReviewCorrectionsUsed = 0;
+  let pendingAdversarialCorrection:
+    | { diff: string; findings: AdversarialReviewFindings; retry: number; cap: number }
+    | undefined;
   let salvagedUncommittedFiles = 0;
   let salvagedUncommittedOutcome: RunAgentResult["outcome"] | undefined;
   let salvagedRunCommitCount = 0;
@@ -919,8 +924,7 @@ export async function processIssue(
       backpressure_records: backpressureSidecar.length,
       scope: feedback.validationScope?.type ?? "",
     });
-    break;
-  }
+
   markProcessSafetyStep("post-barrier:landing-start");
   const locked = await deps.lookups.isLocked();
   const openPr = deps.worktreeLaunchesPr !== false;
@@ -939,7 +943,7 @@ export async function processIssue(
     });
     deps.markPhase?.(phase);
   };
-  const runAdversarialReview = async (pr: number): Promise<void> => {
+  const runAdversarialReview = async (pr: number): Promise<"abort" | void> => {
     const config = deps.adversarialReview;
     if (!config?.enabled || !deps.extractAdversarialReview || !deps.postAdversarialReview) return;
     try {
@@ -957,13 +961,23 @@ export async function processIssue(
         effort: deps.effort,
         maxIterations: config.maxIterations,
       });
-      const decision = decideAdversarialReview(findings, 1, config.maxIterations);
+      const retry = adversarialReviewCorrectionsUsed + 1;
+      const decision = decideAdversarialReview(findings, retry, config.maxIterations);
       await deps.postAdversarialReview({
         pr,
         issue: input.issue,
         findings,
         body: renderAdversarialReviewComment(findings, decision),
       });
+      if (decision === "correct") {
+        pendingAdversarialCorrection = {
+          diff: diff.code === 0 ? diff.stdout : "",
+          findings,
+          retry,
+          cap: config.maxIterations,
+        };
+        return "abort";
+      }
     } catch (error) {
       deps.appendIterLog(`[adversarial-review] advisory pass failed: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -988,7 +1002,7 @@ export async function processIssue(
       landLock: deps.landLock,
       onPrResolved: async (pr) => {
         await emitBackpressureReview(common, pr);
-        await runAdversarialReview(pr);
+        return await runAdversarialReview(pr);
       },
       postMergeGate: async (mergedTreeDir) => {
         const mergedFeedback = await runFeedback(deps.pnpm, {
@@ -1079,6 +1093,28 @@ export async function processIssue(
     },
   );
   if (!landing.ok) {
+    if (landing.reason === "adversarial-correction") {
+      const correction = pendingAdversarialCorrection;
+      pendingAdversarialCorrection = undefined;
+      if (!correction) {
+        return await mergeFailed(common, "adversarial correction requested without captured findings", landing.locked);
+      }
+      adversarialReviewCorrectionsUsed = correction.retry;
+      attemptN += 1;
+      currentHandoff = appendAdversarialReviewCorrectionHandoff(handoff, correction);
+      deps.appendIterLog(
+        `🤖 /afk: adversarial review found blocking issue(s); correction retry ${correction.retry}/${correction.cap}.`,
+      );
+      if (
+        !(await fireHook(
+          "pre_attempt",
+          hookContext({ issue, title: input.title, workspace: branch, runner: activeRunner, attempt_n: attemptN }),
+        ))
+      ) {
+        return await abortAfterClaim(deps, input, branch, base, hooksFired, "pre_attempt");
+      }
+      continue;
+    }
     if (landing.reason === "trunk-diverged") {
       return await trunkDivergedBlocked(
         common,
@@ -1166,4 +1202,5 @@ export async function processIssue(
     preserved: true,
     swept: true,
   };
+  }
 }

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -148,7 +148,7 @@ describe("config", () => {
     });
   });
 
-  it("keeps adversarial review advisory for this slice (#2207)", () => {
+  it("retries only blocking adversarial review findings within the configured cap (#2208)", () => {
     expect(
       decideAdversarialReview(
         {
@@ -156,6 +156,26 @@ describe("config", () => {
           findings: [{ path: "src/a.ts", line: 1, body: "bug", blocking: true }],
         },
         1,
+        1,
+      ),
+    ).toBe("correct");
+    expect(
+      decideAdversarialReview(
+        {
+          summary: "nit only",
+          findings: [{ path: "src/a.ts", line: 1, body: "style", blocking: false }],
+        },
+        1,
+        1,
+      ),
+    ).toBe("pass");
+    expect(
+      decideAdversarialReview(
+        {
+          summary: "cap exhausted",
+          findings: [{ path: "src/a.ts", line: 1, body: "bug", blocking: true }],
+        },
+        2,
         1,
       ),
     ).toBe("pass");

--- a/apps/dev/tests/landing.test-support.ts
+++ b/apps/dev/tests/landing.test-support.ts
@@ -147,6 +147,8 @@ export interface Opts {
   landLock?: LandLock;
   /** Native merge queue (#1337): set `input.nativeMergeQueue`. */
   nativeMergeQueue?: boolean;
+  /** Explicit PR-resolved callback abort used by adversarial correction before merge. */
+  onPrResolvedAbort?: boolean;
 }
 
 export function harness(opts: Opts = {}): Harness {
@@ -317,6 +319,7 @@ export function harness(opts: Opts = {}): Harness {
             mainRedRepairLookups += 1;
             return opts.mainRedRepairIssue ? { number: 123 } : null;
           },
+    onPrResolved: opts.onPrResolvedAbort ? async () => "abort" : undefined,
     // Post-merge-integration gate (#1335): only wired when the test opts in.
     postMergeGate: opts.postMergeGate
       ? async (dir) => {

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -29,6 +29,13 @@ describe("doLanding — happy paths", () => {
     expect(mergeIdx).toBeGreaterThan(checksIdx);
   });
 
+  it("unlocked + explicit PR-resolved abort → stops before admin-merge", async () => {
+    const h = harness({ locked: false, onPrResolvedAbort: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "adversarial-correction", locked: false, prNumber: 42 });
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
+  });
+
   it("unlocked, default (no wait_for_review) → never polls review checks", async () => {
     const h = harness({ locked: false });
     const r = await doLanding(h.deps, h.input, h.hooks);

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -886,6 +886,17 @@ describe("processIssue — advisory adversarial review (#2207)", () => {
       locked: false,
       body: issueBody,
       adversarialReview: { enabled: true, maxIterations: 2 },
+      adversarialFindings: {
+        summary: "Stubbed adversarial review summary.",
+        findings: [
+          {
+            path: "packages/x/src/a.ts",
+            line: 1,
+            body: "Acceptance criteria conformance finding.",
+            blocking: false,
+          },
+        ],
+      },
     });
     const result = await processIssue(deps, input);
 
@@ -904,10 +915,87 @@ describe("processIssue — advisory adversarial review (#2207)", () => {
     const body = trace.adversarialReviews[0]?.body ?? "";
     expect(body).toContain("AFK adversarial review");
     expect(body).toContain("Decision: pass (advisory)");
-    expect(body).toContain("blocking: true");
+    expect(body).toContain("blocking: false");
     expect(body).toContain("Acceptance criteria conformance finding.");
     expect(trace.comments).toContainEqual({ issue: 42, body });
     expect(trace.comments).toContainEqual({ issue: 9, body });
+  });
+
+  it("blocking finding re-seeds the implementer with diff plus critiques, then clean review lands (#2208)", async () => {
+    const { deps, input, trace } = harness({
+      outcomes: ["done", "done"],
+      feedbackOk: true,
+      locked: false,
+      adversarialReview: { enabled: true, maxIterations: 1 },
+      adversarialFindingsSequence: [
+        {
+          summary: "One blocking acceptance gap.",
+          findings: [
+            {
+              path: "packages/x/src/a.ts",
+              line: 1,
+              body: "The implementation does not satisfy the acceptance criterion.",
+              blocking: true,
+            },
+            {
+              path: "packages/x/src/a.ts",
+              line: 1,
+              body: "Prefer a clearer name.",
+              blocking: false,
+            },
+          ],
+        },
+        {
+          summary: "Clean after correction.",
+          findings: [],
+        },
+      ],
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.adversarialReviewContexts).toHaveLength(2);
+    expect(trace.closed).toEqual([9]);
+
+    const retryHandoff = trace.runAgentCalls[1]?.handoffContent ?? "";
+    expect(retryHandoff).toContain("<adversarial-review-correction>");
+    expect(retryHandoff).toContain("bounded correction retry 1/1");
+    expect(retryHandoff).toContain("The implementation does not satisfy the acceptance criterion.");
+    expect(retryHandoff).not.toContain("Prefer a clearer name.");
+    expect(retryHandoff).toContain("<pr-diff data-untrusted=\"true\">");
+    expect(retryHandoff).toContain("diff --git");
+
+    expect(trace.adversarialReviews[0]?.body).toContain("Decision: correct (blocking)");
+    expect(trace.adversarialReviews[1]?.body).toContain("Decision: pass (advisory)");
+    expect(trace.iterLogs.some((line) => line.includes("correction retry 1/1"))).toBe(true);
+  });
+
+  it("non-blocking findings stay advisory and do not re-seed the implementer (#2208)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: false,
+      adversarialReview: { enabled: true, maxIterations: 1 },
+      adversarialFindings: {
+        summary: "Only suggestions.",
+        findings: [
+          {
+            path: "packages/x/src/a.ts",
+            line: 1,
+            body: "Consider shorter wording.",
+            blocking: false,
+          },
+        ],
+      },
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.adversarialReviewContexts).toHaveLength(1);
+    expect(trace.closed).toEqual([9]);
+    expect(trace.adversarialReviews[0]?.body).toContain("Decision: pass (advisory)");
   });
 });
 

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -238,6 +238,7 @@ export interface HarnessOptions {
   /** Advisory adversarial review tracer (#2207). */
   adversarialReview?: ProcessIssueDeps["adversarialReview"];
   adversarialFindings?: AdversarialReviewFindings;
+  adversarialFindingsSequence?: AdversarialReviewFindings[];
   /** CI-aware merge (#812). When set, register the `ciAwait` port and drive the
    * `gh pr view` verdict the unlocked landing polls before admin-merging. */
   ciAware?: "merge" | "ci-failed" | "ci-pending" | "conflict";
@@ -551,7 +552,7 @@ export function harness(opts: HarnessOptions = {}): {
     extractAdversarialReview: opts.adversarialReview
       ? async ({ context, maxIterations }) => {
           trace.adversarialReviewContexts.push({ ...context, maxIterations });
-          return opts.adversarialFindings ?? {
+          return opts.adversarialFindingsSequence?.[trace.adversarialReviewContexts.length - 1] ?? opts.adversarialFindings ?? {
             summary: "Stubbed adversarial review summary.",
             findings: [
               {


### PR DESCRIPTION
Automated AFK landing for #2208. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2208

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787081447&installation_id=129708444&pr_number=2215&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2215&signature=05c58a6d09dd783babe7ade0a72ab18a6462a17d75394f81ea644bf0f9a9c269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->