### PR TITLE
fix: #2209 S3: Adversarial review — park ready-for-human at exhaustion

### DIFF
--- a/apps/dev/src/core/adversarial-review.ts
+++ b/apps/dev/src/core/adversarial-review.ts
@@ -66,7 +66,8 @@ export function decideAdversarialReview(
 ): AdversarialReviewDecision {
   const hasBlocking = findings.findings.some((finding) => finding.blocking);
   if (!hasBlocking) return "pass";
-  return iteration <= cap ? "correct" : "pass";
+  if (iteration <= cap) return "correct";
+  return cap >= 2 ? "park" : "pass";
 }
 
 export function buildAdversarialReviewPrompt(context: AdversarialReviewContext): string {
@@ -155,6 +156,22 @@ export function renderAdversarialReviewComment(
     });
   }
   return lines.join("\n");
+}
+
+export function renderAdversarialReviewBlockerSummary(
+  findings: AdversarialReviewFindings,
+  cap: number,
+): string {
+  const blocking = findings.findings.filter((finding) => finding.blocking);
+  const renderedFindings = blocking
+    .map((finding, idx) => `${idx + 1}. ${finding.path}:${finding.line} ${finding.body}`)
+    .join("; ");
+  const retryWord = cap === 1 ? "retry" : "retries";
+  return [
+    `Adversarial review budget exhausted after ${cap} correction ${retryWord}`,
+    `with ${blocking.length} blocking finding(s):`,
+    renderedFindings || findings.summary || "Blocking adversarial review findings remain.",
+  ].join(" ");
 }
 
 function tailLines(text: string, maxLines: number): string {

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -120,6 +120,7 @@ import { allowlistExternalWidened, ALLOWLIST_PATH } from "../shared-gate.js";
 import {
   appendAdversarialReviewCorrectionHandoff,
   decideAdversarialReview,
+  renderAdversarialReviewBlockerSummary,
   renderAdversarialReviewComment,
   type AdversarialReviewFindings,
 } from "../adversarial-review.js";
@@ -388,6 +389,9 @@ export async function processIssue(
   let adversarialReviewCorrectionsUsed = 0;
   let pendingAdversarialCorrection:
     | { diff: string; findings: AdversarialReviewFindings; retry: number; cap: number }
+    | undefined;
+  let pendingAdversarialPark:
+    | { findings: AdversarialReviewFindings; cap: number }
     | undefined;
   let salvagedUncommittedFiles = 0;
   let salvagedUncommittedOutcome: RunAgentResult["outcome"] | undefined;
@@ -978,6 +982,10 @@ export async function processIssue(
         };
         return "abort";
       }
+      if (decision === "park") {
+        pendingAdversarialPark = { findings, cap: config.maxIterations };
+        return "abort";
+      }
     } catch (error) {
       deps.appendIterLog(`[adversarial-review] advisory pass failed: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -1094,6 +1102,22 @@ export async function processIssue(
   );
   if (!landing.ok) {
     if (landing.reason === "adversarial-correction") {
+      const park = pendingAdversarialPark;
+      pendingAdversarialPark = undefined;
+      if (park) {
+        const validation = renderAdversarialReviewBlockerSummary(park.findings, park.cap);
+        deps.appendIterLog(`🤖 /afk: ${validation} Parked to ready-for-human.`);
+        return await terminalFailure(
+          common,
+          "feedback-failed",
+          "feedback",
+          {
+            notes: "Blocking adversarial review findings remained after the configured correction budget. The worker branch was not merged.",
+            validation,
+          },
+          { validationSummary: validation },
+        );
+      }
       const correction = pendingAdversarialCorrection;
       pendingAdversarialCorrection = undefined;
       if (!correction) {

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -179,6 +179,16 @@ describe("config", () => {
         1,
       ),
     ).toBe("pass");
+    expect(
+      decideAdversarialReview(
+        {
+          summary: "raised cap exhausted",
+          findings: [{ path: "src/a.ts", line: 1, body: "bug", blocking: true }],
+        },
+        3,
+        2,
+      ),
+    ).toBe("park");
   });
 
   it("folds the namespaced `plugins.dev.lock.primary-branch` onto `dev.lock.primary-branch`", () => {

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -997,6 +997,47 @@ describe("processIssue — advisory adversarial review (#2207)", () => {
     expect(trace.closed).toEqual([9]);
     expect(trace.adversarialReviews[0]?.body).toContain("Decision: pass (advisory)");
   });
+
+  it("raised review budget parks ready-for-human when blocking findings remain at exhaustion (#2209)", async () => {
+    const blocking = {
+      summary: "Blocking acceptance gaps remain.",
+      findings: [
+        {
+          path: "packages/x/src/a.ts",
+          line: 1,
+          body: "The implementation still omits the required audit trail.",
+          blocking: true,
+        },
+      ],
+    };
+    const { deps, input, trace } = harness({
+      outcomes: ["done", "done", "done"],
+      feedbackOk: true,
+      locked: false,
+      adversarialReview: { enabled: true, maxIterations: 2 },
+      adversarialFindingsSequence: [blocking, blocking, blocking],
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.runAgentCalls).toHaveLength(3);
+    expect(trace.adversarialReviewContexts).toHaveLength(3);
+    expect(trace.closed).toEqual([]);
+    expect(labelTrace(trace)).toContain("-running|+ready-for-human+blocked:validation");
+    expect(trace.adversarialReviews[0]?.body).toContain("Decision: correct (blocking)");
+    expect(trace.adversarialReviews[1]?.body).toContain("Decision: correct (blocking)");
+    expect(trace.adversarialReviews[2]?.body).toContain("Decision: park (blocking)");
+
+    const blocker = parseCurrentBlocker(trace.bodyEdits.at(-1)?.body ?? "");
+    expect(blocker).toMatchObject({
+      status: "blocked",
+      kind: "validation",
+      summary: expect.stringContaining("packages/x/src/a.ts:1"),
+      next: expect.stringContaining("Decide whether to fix forward"),
+    });
+    expect(blocker?.summary).toContain("The implementation still omits the required audit trail.");
+    expect(trace.envelopeBodies.at(-1)).toContain("Adversarial review budget exhausted");
+  });
 });
 
 


### PR DESCRIPTION
Automated AFK landing for #2209. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2209

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787082330&installation_id=129708444&pr_number=2216&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2216&signature=8810b8595033741d664e1dbac61bdd95ea8426668cf11c5f9e026d8821e803bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->