### PR TITLE
fix: #2210 S4: Adversarial review — configurable reviewer (count/quorum + model/effort/runner)

### DIFF
--- a/apps/dev/src/core/adversarial-review.ts
+++ b/apps/dev/src/core/adversarial-review.ts
@@ -1,5 +1,6 @@
 import type { AgentEffort, AgentRunner } from "./execution.js";
 import type { RunOptions } from "@reddb-io/red-castle";
+import type { AfkModelTier } from "./config.js";
 import {
   reviewFindingsSchema,
   resolveMaxRetries,
@@ -8,11 +9,20 @@ import {
   type StandardSchemaLike,
 } from "./review.js";
 import type { ReviewExtractDeps } from "./review-extract.js";
+import { toAgentRunner } from "./runner-spec.js";
+import { isRunner } from "../types/runner.js";
 
 export interface AdversarialReviewConfig {
   readonly enabled: boolean;
   readonly maxIterations: number;
+  readonly reviewerCount: number;
+  readonly quorum: AdversarialReviewQuorum;
+  readonly runner?: AgentRunner;
+  readonly model?: string;
+  readonly effort?: AgentEffort;
 }
+
+export type AdversarialReviewQuorum = "any" | "all" | number;
 
 export interface AdversarialReviewFinding extends InlineComment {
   readonly blocking: boolean;
@@ -51,12 +61,107 @@ export interface AdversarialReviewExtractInput {
 
 export const ADVERSARIAL_REVIEW_OUTPUT_TAG = "output";
 
+const AGENT_EFFORTS: readonly AgentEffort[] = ["low", "medium", "high", "xhigh", "max"];
+
+function readPositiveInteger(raw: string, fallback: number): number {
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readQuorum(raw: string): AdversarialReviewQuorum {
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "all") return "all";
+  if (normalized === "any" || normalized === "") return "any";
+  const parsed = Number(normalized);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : "any";
+}
+
+function readEffort(raw: string): AgentEffort | undefined {
+  return (AGENT_EFFORTS as readonly string[]).includes(raw) ? (raw as AgentEffort) : undefined;
+}
+
 export function resolveAdversarialReviewConfig(get: (key: string) => string): AdversarialReviewConfig {
-  const parsed = Number(get("review.max_iterations"));
+  const runner = get("review.runner").trim();
+  const model = get("review.model").trim();
+  const effort = readEffort(get("review.effort"));
   return {
     enabled: get("review.enabled") === "true",
-    maxIterations: Number.isInteger(parsed) && parsed > 0 ? parsed : 1,
+    maxIterations: readPositiveInteger(get("review.max_iterations"), 1),
+    reviewerCount: readPositiveInteger(get("review.reviewer_count"), 1),
+    quorum: readQuorum(get("review.quorum")),
+    ...(runner && isRunner(runner) ? { runner: toAgentRunner(runner) } : {}),
+    ...(model ? { model } : {}),
+    ...(effort ? { effort } : {}),
   };
+}
+
+export interface AdversarialReviewerResolutionInput {
+  readonly config: AdversarialReviewConfig;
+  readonly implementer: {
+    readonly runner: AgentRunner;
+    readonly model: string;
+    readonly effort?: AgentEffort;
+  };
+  readonly taskClass?: AfkModelTier;
+  readonly resolveTier?: (runner: AgentRunner, taskClass?: AfkModelTier) => {
+    readonly model: string;
+    readonly effort?: AgentEffort;
+  };
+}
+
+export function resolveAdversarialReviewer(input: AdversarialReviewerResolutionInput): {
+  runner: AgentRunner;
+  model: string;
+  effort?: AgentEffort;
+} {
+  const runner = input.config.runner ?? input.implementer.runner;
+  const tier = input.config.runner ? input.resolveTier?.(runner, input.taskClass) : undefined;
+  const model = input.config.model ?? tier?.model ?? input.implementer.model;
+  const effort = input.config.effort ?? tier?.effort ?? input.implementer.effort;
+  return { runner, model, ...(effort ? { effort } : {}) };
+}
+
+function quorumThreshold(quorum: AdversarialReviewQuorum, reviewerCount: number): number {
+  if (quorum === "all") return Math.max(1, reviewerCount);
+  if (quorum === "any") return 1;
+  return Math.max(1, quorum);
+}
+
+function findingKey(finding: AdversarialReviewFinding): string {
+  return [finding.path, finding.line, finding.body.trim()].join("\0");
+}
+
+export function aggregateAdversarialReviewFindings(
+  reviews: readonly AdversarialReviewFindings[],
+  quorum: AdversarialReviewQuorum,
+): AdversarialReviewFindings {
+  if (reviews.length === 0) {
+    return { summary: "No adversarial reviewers ran.", findings: [] };
+  }
+  const threshold = quorumThreshold(quorum, reviews.length);
+  const byKey = new Map<string, AdversarialReviewFinding>();
+  const blockingVotes = new Map<string, number>();
+  for (const review of reviews) {
+    const seen = new Set<string>();
+    for (const finding of review.findings) {
+      const key = findingKey(finding);
+      if (!byKey.has(key)) byKey.set(key, finding);
+      if (!finding.blocking) continue;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      blockingVotes.set(key, (blockingVotes.get(key) ?? 0) + 1);
+    }
+  }
+  const findings = Array.from(byKey.entries()).map(([key, finding]) => ({
+    ...finding,
+    blocking: (blockingVotes.get(key) ?? 0) >= threshold,
+  }));
+  const summary =
+    reviews.length === 1
+      ? reviews[0]!.summary
+      : `Aggregated ${reviews.length} adversarial reviewer(s) with quorum ${String(quorum)}. ` +
+        reviews.map((review, idx) => `Reviewer ${idx + 1}: ${review.summary}`).join(" ");
+  return { summary, findings };
 }
 
 export function decideAdversarialReview(

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -144,6 +144,8 @@ export const CONFIG_DEFAULTS = {
   // advisory verdict. Folded from `plugins.dev.review.*` to `review.*`.
   "review.enabled": "false",
   "review.max_iterations": "1",
+  "review.reviewer_count": "1",
+  "review.quorum": "any",
   // Release channel the ADR 0038 launcher tracks (ADR 0058). `stable` is the
   // version-pinned release (today's behaviour); `canary` tracks npm's canary
   // dist-tag. The launcher reads this (or `RED_SKILLS_CHANNEL`); moving canary is

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -118,10 +118,12 @@ import {
 } from "../issue-lifecycle.js";
 import { allowlistExternalWidened, ALLOWLIST_PATH } from "../shared-gate.js";
 import {
+  aggregateAdversarialReviewFindings,
   appendAdversarialReviewCorrectionHandoff,
   decideAdversarialReview,
   renderAdversarialReviewBlockerSummary,
   renderAdversarialReviewComment,
+  resolveAdversarialReviewer,
   type AdversarialReviewFindings,
 } from "../adversarial-review.js";
 import type { ProcessIssueDeps, ProcessIssueInput, ProcessIssueResult, WorkerBaseResolution, ProcessOutcome } from "./types.js";
@@ -952,19 +954,37 @@ export async function processIssue(
     if (!config?.enabled || !deps.extractAdversarialReview || !deps.postAdversarialReview) return;
     try {
       const diff = await deps.mergeExec(["gh", "-R", input.repo, "pr", "diff", String(pr)]);
-      const findings: AdversarialReviewFindings = await deps.extractAdversarialReview({
-        context: {
-          issueNumber: input.issue,
-          issueTitle: input.title,
-          issueBody: input.body,
-          prNumber: pr,
-          diff: diff.code === 0 ? diff.stdout : "",
+      const context = {
+        issueNumber: input.issue,
+        issueTitle: input.title,
+        issueBody: input.body,
+        prNumber: pr,
+        diff: diff.code === 0 ? diff.stdout : "",
+      };
+      const implementerTier = resolveSpawnTier(deps, activeRunner, activeTaskClass);
+      const reviewer = resolveAdversarialReviewer({
+        config,
+        implementer: {
+          runner: toAgentRunner(activeRunner),
+          model: implementerTier.model,
+          effort: implementerTier.effort,
         },
-        runner: input.runner,
-        model: deps.model,
-        effort: deps.effort,
-        maxIterations: config.maxIterations,
+        taskClass: activeTaskClass,
+        resolveTier: deps.resolveTier,
       });
+      const reviews: AdversarialReviewFindings[] = [];
+      for (let i = 0; i < config.reviewerCount; i++) {
+        reviews.push(
+          await deps.extractAdversarialReview({
+            context,
+            runner: reviewer.runner,
+            model: reviewer.model,
+            effort: reviewer.effort,
+            maxIterations: config.maxIterations,
+          }),
+        );
+      }
+      const findings = aggregateAdversarialReviewFindings(reviews, config.quorum);
       const retry = adversarialReviewCorrectionsUsed + 1;
       const decision = decideAdversarialReview(findings, retry, config.maxIterations);
       await deps.postAdversarialReview({

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -17,7 +17,12 @@ import {
   DEFAULT_MERGE_CI_TIMEOUT_S,
   rootDevConfigCollisionsFromText,
 } from "../src/core/config.js";
-import { decideAdversarialReview, resolveAdversarialReviewConfig } from "../src/core/adversarial-review.js";
+import {
+  aggregateAdversarialReviewFindings,
+  decideAdversarialReview,
+  resolveAdversarialReviewer,
+  resolveAdversarialReviewConfig,
+} from "../src/core/adversarial-review.js";
 
 async function writeConfig(yaml: string): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "afk-config-"));
@@ -131,9 +136,13 @@ describe("config", () => {
     const defaults = loadConfig("/nonexistent/.red/config.yaml", { warn: () => {} });
     expect(getConfig(defaults, "review.enabled")).toBe("false");
     expect(getConfig(defaults, "review.max_iterations")).toBe("1");
+    expect(getConfig(defaults, "review.reviewer_count")).toBe("1");
+    expect(getConfig(defaults, "review.quorum")).toBe("any");
     expect(resolveAdversarialReviewConfig((key) => getConfig(defaults, key))).toEqual({
       enabled: false,
       maxIterations: 1,
+      reviewerCount: 1,
+      quorum: "any",
     });
 
     const values = loadConfig("/x/.red/config.yaml", {
@@ -145,7 +154,97 @@ describe("config", () => {
     expect(resolveAdversarialReviewConfig((key) => getConfig(values, key))).toEqual({
       enabled: true,
       maxIterations: 3,
+      reviewerCount: 1,
+      quorum: "any",
     });
+  });
+
+  it("resolves adversarial reviewer count/quorum and reviewer runner overrides (#2210)", () => {
+    const values = loadConfig("/x/.red/config.yaml", {
+      read: () =>
+        [
+          "plugins:",
+          "  dev:",
+          "    review:",
+          "      enabled: true",
+          "      reviewer_count: 3",
+          "      quorum: 2",
+          "      runner: codex",
+          "      model: gpt-review",
+          "      effort: medium",
+          "",
+        ].join("\n"),
+    });
+    const config = resolveAdversarialReviewConfig((key) => getConfig(values, key));
+    expect(config).toEqual({
+      enabled: true,
+      maxIterations: 1,
+      reviewerCount: 3,
+      quorum: 2,
+      runner: "codex",
+      model: "gpt-review",
+      effort: "medium",
+    });
+    expect(
+      resolveAdversarialReviewer({
+        config,
+        implementer: { runner: "claude", model: "claude-opus-4-8", effort: "high" },
+        taskClass: "complex",
+        resolveTier: () => ({ model: "gpt-tier", effort: "low" }),
+      }),
+    ).toEqual({ runner: "codex", model: "gpt-review", effort: "medium" });
+  });
+
+  it("defaults the adversarial reviewer to the implementer's resolved runner/model/effort (#2210)", () => {
+    const config = resolveAdversarialReviewConfig((key) => getConfig(loadConfig("/missing", { warn: () => {} }), key));
+    expect(
+      resolveAdversarialReviewer({
+        config,
+        implementer: { runner: "claude", model: "claude-opus-4-8", effort: "high" },
+        taskClass: "simple",
+        resolveTier: () => ({ model: "unused", effort: "low" }),
+      }),
+    ).toEqual({ runner: "claude", model: "claude-opus-4-8", effort: "high" });
+  });
+
+  it("uses the model-tier table when only review.runner is overridden (#2210)", () => {
+    const values = loadConfig("/x/.red/config.yaml", {
+      read: () => "plugins:\n  dev:\n    review:\n      runner: codex\n",
+    });
+    const config = resolveAdversarialReviewConfig((key) => getConfig(values, key));
+    expect(
+      resolveAdversarialReviewer({
+        config,
+        implementer: { runner: "claude", model: "claude-opus-4-8", effort: "high" },
+        taskClass: "validate",
+        resolveTier: (runner, tier) => {
+          expect(runner).toBe("codex");
+          expect(tier).toBe("validate");
+          return { model: "gpt-validate", effort: "low" };
+        },
+      }),
+    ).toEqual({ runner: "codex", model: "gpt-validate", effort: "low" });
+  });
+
+  it("aggregates adversarial blocking findings by quorum (#2210)", () => {
+    const one = {
+      summary: "one",
+      findings: [
+        { path: "src/a.ts", line: 7, body: "real bug", blocking: true },
+        { path: "src/a.ts", line: 8, body: "solo bug", blocking: true },
+      ],
+    };
+    const two = {
+      summary: "two",
+      findings: [
+        { path: "src/a.ts", line: 7, body: "real bug", blocking: true },
+        { path: "src/a.ts", line: 9, body: "nit", blocking: false },
+      ],
+    };
+    const aggregated = aggregateAdversarialReviewFindings([one, two], 2);
+    expect(aggregated.findings.filter((finding) => finding.body === "real bug").every((finding) => finding.blocking)).toBe(true);
+    expect(aggregated.findings.find((finding) => finding.body === "solo bug")?.blocking).toBe(false);
+    expect(aggregated.findings.find((finding) => finding.body === "nit")?.blocking).toBe(false);
   });
 
   it("retries only blocking adversarial review findings within the configured cap (#2208)", () => {

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -885,7 +885,7 @@ describe("processIssue — advisory adversarial review (#2207)", () => {
       feedbackOk: true,
       locked: false,
       body: issueBody,
-      adversarialReview: { enabled: true, maxIterations: 2 },
+      adversarialReview: { enabled: true, maxIterations: 2, reviewerCount: 1, quorum: "any" },
       adversarialFindings: {
         summary: "Stubbed adversarial review summary.",
         findings: [
@@ -926,7 +926,7 @@ describe("processIssue — advisory adversarial review (#2207)", () => {
       outcomes: ["done", "done"],
       feedbackOk: true,
       locked: false,
-      adversarialReview: { enabled: true, maxIterations: 1 },
+      adversarialReview: { enabled: true, maxIterations: 1, reviewerCount: 1, quorum: "any" },
       adversarialFindingsSequence: [
         {
           summary: "One blocking acceptance gap.",
@@ -976,7 +976,7 @@ describe("processIssue — advisory adversarial review (#2207)", () => {
       outcome: "done",
       feedbackOk: true,
       locked: false,
-      adversarialReview: { enabled: true, maxIterations: 1 },
+      adversarialReview: { enabled: true, maxIterations: 1, reviewerCount: 1, quorum: "any" },
       adversarialFindings: {
         summary: "Only suggestions.",
         findings: [
@@ -998,6 +998,58 @@ describe("processIssue — advisory adversarial review (#2207)", () => {
     expect(trace.adversarialReviews[0]?.body).toContain("Decision: pass (advisory)");
   });
 
+  it("runs configured reviewer count and applies quorum with reviewer runner resolution (#2210)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: false,
+      classifyIssue: async () => "validate",
+      resolveTier: (runner, taskClass) => {
+        if (runner === "codex" && taskClass === "validate") {
+          return { model: "gpt-review", effort: "low" };
+        }
+        return { model: "claude-opus-4-8", effort: "high" };
+      },
+      adversarialReview: {
+        enabled: true,
+        maxIterations: 1,
+        reviewerCount: 2,
+        quorum: 2,
+        runner: "codex",
+      },
+      adversarialFindingsSequence: [
+        {
+          summary: "First reviewer found a bug.",
+          findings: [
+            {
+              path: "packages/x/src/a.ts",
+              line: 1,
+              body: "Quorum-only blocking defect.",
+              blocking: true,
+            },
+          ],
+        },
+        {
+          summary: "Second reviewer found no bug.",
+          findings: [],
+        },
+      ],
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.adversarialReviewContexts).toHaveLength(2);
+    expect(trace.adversarialReviewContexts.map(({ runner, model, effort }) => ({ runner, model, effort }))).toEqual([
+      { runner: "codex", model: "gpt-review", effort: "low" },
+      { runner: "codex", model: "gpt-review", effort: "low" },
+    ]);
+    expect(trace.adversarialReviews).toHaveLength(1);
+    expect(trace.adversarialReviews[0]?.body).toContain("Decision: pass (advisory)");
+    expect(trace.adversarialReviews[0]?.body).toContain("blocking: false");
+    expect(trace.closed).toEqual([9]);
+  });
+
   it("raised review budget parks ready-for-human when blocking findings remain at exhaustion (#2209)", async () => {
     const blocking = {
       summary: "Blocking acceptance gaps remain.",
@@ -1014,7 +1066,7 @@ describe("processIssue — advisory adversarial review (#2207)", () => {
       outcomes: ["done", "done", "done"],
       feedbackOk: true,
       locked: false,
-      adversarialReview: { enabled: true, maxIterations: 2 },
+      adversarialReview: { enabled: true, maxIterations: 2, reviewerCount: 1, quorum: "any" },
       adversarialFindingsSequence: [blocking, blocking, blocking],
     });
     const result = await processIssue(deps, input);

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -63,6 +63,9 @@ export interface Trace {
     issueBody: string;
     prNumber: number;
     diff: string;
+    runner: string;
+    model: string;
+    effort?: AgentEffort;
     maxIterations: number;
   }>;
   /** Memory reasoning-attempt records fired after a terminal envelope. */
@@ -550,8 +553,8 @@ export function harness(opts: HarnessOptions = {}): {
     },
     adversarialReview: opts.adversarialReview,
     extractAdversarialReview: opts.adversarialReview
-      ? async ({ context, maxIterations }) => {
-          trace.adversarialReviewContexts.push({ ...context, maxIterations });
+      ? async ({ context, runner, model, effort, maxIterations }) => {
+          trace.adversarialReviewContexts.push({ ...context, runner, model, effort, maxIterations });
           return opts.adversarialFindingsSequence?.[trace.adversarialReviewContexts.length - 1] ?? opts.adversarialFindings ?? {
             summary: "Stubbed adversarial review summary.",
             findings: [


### PR DESCRIPTION
Automated AFK landing for #2210. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2210

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787083432&installation_id=129708444&pr_number=2217&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2217&signature=f7c537c3b4bba4f9e1fd99176fb23aad377658efcba2de795803a68a50e456c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->