### PR TITLE
fix: #2211 S5: Adversarial review — wire into /go --mode no-mistakes

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -455,7 +455,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         repoDir: c.issueTemplate.repoDir,
         remote: c.issueTemplate.remote,
         baseInput: { issueBody: candidate.body },
-        runMode: runModeForCandidate(candidate, flags.runMode),
+        runMode: runModeForCandidate(candidate, flags.prePr ? "no-mistakes" : flags.runMode),
         // Lane-aware claim preflight (#1045): the pre-claim state-validity recheck
         // must validate against the label this issue was SELECTED under (the
         // `--lane` value), not a hardcoded `ready-for-agent`. `flags.lane` is

--- a/apps/dev/src/core/pre-pr-pipeline.ts
+++ b/apps/dev/src/core/pre-pr-pipeline.ts
@@ -8,6 +8,20 @@
 // are either mechanical-applied or human-approved.
 
 import type { Exec, PackageLayout } from "./feedback.js";
+import { LABEL_GO_LANE } from "./go.js";
+
+/**
+ * Returns true when the /go --mode no-mistakes adversarial review pipeline is
+ * active for this dispatch. Active only for /go lane issues running in
+ * no-mistakes mode; /afk and other lanes use the review.enabled config gate
+ * independently and return false here.
+ */
+export function isPrePrPipelineActive(
+  runMode: string | undefined,
+  laneLabel: string | undefined,
+): boolean {
+  return laneLabel === LABEL_GO_LANE && runMode === "no-mistakes";
+}
 
 /**
  * Input to the pre-PR pipeline. Wraps the concrete worktree state and the

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -117,6 +117,7 @@ import {
   type IssueLifecycleEdge,
 } from "../issue-lifecycle.js";
 import { allowlistExternalWidened, ALLOWLIST_PATH } from "../shared-gate.js";
+import { isPrePrPipelineActive } from "../pre-pr-pipeline.js";
 import {
   aggregateAdversarialReviewFindings,
   appendAdversarialReviewCorrectionHandoff,
@@ -952,6 +953,8 @@ export async function processIssue(
   const runAdversarialReview = async (pr: number): Promise<"abort" | void> => {
     const config = deps.adversarialReview;
     if (!config?.enabled || !deps.extractAdversarialReview || !deps.postAdversarialReview) return;
+    // /go direct-PR skips adversarial review; /go no-mistakes and /afk run it.
+    if (input.laneLabel === LABEL_GO_LANE && !isPrePrPipelineActive(input.runMode, input.laneLabel)) return;
     try {
       const diff = await deps.mergeExec(["gh", "-R", input.repo, "pr", "diff", String(pr)]);
       const context = {

--- a/apps/dev/tests/pre-pr-pipeline.test.ts
+++ b/apps/dev/tests/pre-pr-pipeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Exec, PackageLayout } from "../src/core/feedback.js";
-import { runPrePrPipeline, type PrePrPipelineInput } from "../src/core/pre-pr-pipeline.js";
+import { runPrePrPipeline, isPrePrPipelineActive, type PrePrPipelineInput } from "../src/core/pre-pr-pipeline.js";
+import { LABEL_GO_LANE } from "../src/core/go.js";
 
 describe("no-mistakes pre-PR pipeline (#913)", () => {
   function makeMockExec(results: Record<string, { code: number; stdout: string; stderr: string }>): Exec {
@@ -112,5 +113,27 @@ describe("no-mistakes pre-PR pipeline (#913)", () => {
     // The implementation will check the budget and abort.
     const result = await runPrePrPipeline(input);
     // Eventually: expect(result.passed).toBe(false); expect(result.reason).toMatch(/budget|timeout/i);
+  });
+});
+
+describe("isPrePrPipelineActive — /go pre-PR seam (#2211)", () => {
+  it("active for /go --mode no-mistakes (lane:go + runMode=no-mistakes)", () => {
+    expect(isPrePrPipelineActive("no-mistakes", LABEL_GO_LANE)).toBe(true);
+  });
+
+  it("inactive for /go default direct-PR (lane:go, runMode undefined)", () => {
+    expect(isPrePrPipelineActive(undefined, LABEL_GO_LANE)).toBe(false);
+  });
+
+  it("inactive for /go --mode direct-PR (explicit)", () => {
+    expect(isPrePrPipelineActive("direct-PR", LABEL_GO_LANE)).toBe(false);
+  });
+
+  it("inactive for /afk (no lane label — gates on review.enabled independently)", () => {
+    expect(isPrePrPipelineActive(undefined, undefined)).toBe(false);
+  });
+
+  it("inactive when no-mistakes mode is set outside the /go lane", () => {
+    expect(isPrePrPipelineActive("no-mistakes", undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #2211. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2211

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787094281&installation_id=129708444&pr_number=2225&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2225&signature=cc5847b2e34c6863206403227e94cee2d12309f7699f1c6b98ca459c26e6e9fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->