### PR TITLE
fix: #2203 hard-silence stall backstop — reap a hung worker even with a live descendant

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -618,8 +618,8 @@ function buildSupervisorDeps(
       sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     },
     fs: {
-      workerLivenessVerdict: (slot, laneIdleMs) =>
-        workerLivenessFor(tmpDir, slotPids.get(slot) ?? null, laneIdleMs),
+      workerLivenessVerdict: (slot, laneIdleMs, laneHardIdleMs) =>
+        workerLivenessFor(tmpDir, slotPids.get(slot) ?? null, laneIdleMs, laneHardIdleMs),
       resolveIterDir: (slot) => resolveIterDirInfo(tmpDir, slotPids.get(slot) ?? null, now()),
       teardownIterDir: async (info) => {
         await teardownIterDirNative(info, root);

--- a/apps/dev/src/core/supervisor/reaper.ts
+++ b/apps/dev/src/core/supervisor/reaper.ts
@@ -296,7 +296,11 @@ export async function pollStallDetector(
 
     // Evaluator verdict: stale lane + no live descendants → stalled. Live
     // descendants → alive even when the lane is silent (wedged substrate guard).
-    const verdict = deps.fs.workerLivenessVerdict(i, config.stallThresholdS * 1000);
+    const verdict = deps.fs.workerLivenessVerdict(
+      i,
+      config.stallThresholdS * 1000,
+      config.stallKillThresholdS * 1000,
+    );
     const flagged = verdict !== null && verdict.status === "stalled";
 
     if (flagged) {

--- a/apps/dev/src/core/supervisor/types.ts
+++ b/apps/dev/src/core/supervisor/types.ts
@@ -80,7 +80,11 @@ export interface SupervisorFs {
    * Returns null when no iter dir is found (worker between iterations or died
    * pre-claim). Replaces the old `agentLaneMtime` firehose-mtime check.
    */
-  workerLivenessVerdict(slot: number, laneIdleMs: number): LivenessVerdict | null;
+  workerLivenessVerdict(
+    slot: number,
+    laneIdleMs: number,
+    laneHardIdleMs?: number,
+  ): LivenessVerdict | null;
   /** Resolve the slot's current iteration dir + the state it carries, or null
    * when the worker is between iterations / died pre-claim. Mirrors
    * find_slot_iter_dir + the jq reads in reap_stalled_slot. */

--- a/apps/dev/src/runtime/supervisor-fs.ts
+++ b/apps/dev/src/runtime/supervisor-fs.ts
@@ -205,6 +205,7 @@ export function workerLivenessFor(
   tmpDir: string,
   slotPid: number | null,
   laneIdleMs: number,
+  laneHardIdleMs?: number,
 ): LivenessVerdict | null {
   const dir = findSlotIterDir(tmpDir, slotPid);
   if (dir === null) return null;
@@ -244,6 +245,7 @@ export function workerLivenessFor(
       laneRecencyMs,
       now: Date.now(),
       laneIdleMs,
+      laneHardIdleMs,
       crossCheckArmed,
       hasLiveDescendants,
     });

--- a/apps/dev/src/runtime/wire/settings.ts
+++ b/apps/dev/src/runtime/wire/settings.ts
@@ -133,6 +133,7 @@ export function resolveRunSettings(
 export function agentLivenessVerdictSync(
   attemptDir: string,
   laneIdleMs: number,
+  laneHardIdleMs?: number,
 ): LivenessVerdict | null {
   const lanePath = join(attemptDir, LIVENESS_LANE_FILENAME);
   let laneRecencyMs: number | undefined;
@@ -150,7 +151,7 @@ export function agentLivenessVerdictSync(
     ? createProcessDescendantProbe({ agentPid: process.pid })
     : undefined;
   try {
-    return evaluateLiveness({ laneRecencyMs, now: Date.now(), laneIdleMs, crossCheckArmed, hasLiveDescendants });
+    return evaluateLiveness({ laneRecencyMs, now: Date.now(), laneIdleMs, laneHardIdleMs, crossCheckArmed, hasLiveDescendants });
   } catch {
     return null;
   }
@@ -307,7 +308,11 @@ export function makeRunAgent(
             // Clean liveness signal: the evaluator over the attempt's
             // liveness.lane.jsonl — the un-poisonable lane (#1022, ADR 0083 §3).
             livenessVerdictProbe: () =>
-              agentLivenessVerdictSync(laneAttemptDir, laneIdleCfg.stallThresholdS * 1000),
+              agentLivenessVerdictSync(
+                laneAttemptDir,
+                laneIdleCfg.stallThresholdS * 1000,
+                laneIdleCfg.stallKillThresholdS * 1000,
+              ),
             // Inner-agent tree is a descendant of this worker process; the native
             // inspector is safe-by-default (a failed ps reports busy, never reaps).
             inspectTree: () => inspectProcessTreeNative(process.pid),

--- a/apps/dev/tests/supervisor.config-stall.test.ts
+++ b/apps/dev/tests/supervisor.config-stall.test.ts
@@ -699,6 +699,26 @@ describe("pollStallDetector reaper gating", () => {
     expect(state.slots[0]!.pid).toBe(4242);
   });
 
+  it("forwards the soft AND hard-silence thresholds to the liveness verdict (#2203 wiring)", async () => {
+    // Locks the backstop wiring: the reaper must pass stallKillThresholdS as
+    // laneHardIdleMs so a hung worker with a live child is still flagged stalled.
+    // A refactor that drops the 3rd arg silently disables the #2203 fix.
+    const verdict = vi.fn((): LivenessVerdict => stalledVerdict(120));
+    const { deps } = makeDeps({
+      workerLivenessVerdict: verdict,
+      inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => [{ command: "vitest", cpu: 0 }]),
+    });
+    const cfg = config();
+
+    await pollStallDetector(stalledState(), deps, cfg);
+
+    expect(verdict).toHaveBeenCalledWith(
+      0,
+      cfg.stallThresholdS * 1000,
+      cfg.stallKillThresholdS * 1000,
+    );
+  });
+
   it("retries a genuinely-stalled slot UNDER the cap (kill + envelope + CLEAN re-queue)", async () => {
     const { deps, io } = makeDeps({
       workerLivenessVerdict: vi.fn((): LivenessVerdict => stalledVerdict(120)),

--- a/packages/red-castle/src/LivenessEvaluator.test.ts
+++ b/packages/red-castle/src/LivenessEvaluator.test.ts
@@ -121,6 +121,63 @@ describe("evaluateLiveness — lane idle, cross-check armed", () => {
   });
 });
 
+describe("evaluateLiveness — hard-silence backstop (#2203)", () => {
+  it("lane silent past the hard cap → stalled even with live descendants", () => {
+    // A wedged agent (a live child at flat cpu that stops advancing the lane)
+    // must never hold a slot forever: past laneHardIdleMs the descendant check
+    // is overridden, and the probe is not even consulted.
+    let probed = false;
+    const verdict = evaluateLiveness({
+      laneRecencyMs: 1_000,
+      now: 2_000_000, // laneAgeMs = 1_999_000ms, well past the hard cap
+      laneIdleMs: 5_000,
+      laneHardIdleMs: 1_800_000, // 30 min
+      crossCheckArmed: true,
+      hasLiveDescendants: () => {
+        probed = true;
+        return true;
+      },
+    });
+    expect(verdict.status).toBe("stalled");
+    expect(verdict.reason).toContain("hard-silence");
+    expect(probed).toBe(false);
+  });
+
+  it("fires under a disarmed cross-check too (container silent past the hard cap)", () => {
+    const verdict = evaluateLiveness({
+      laneRecencyMs: 1_000,
+      now: 2_000_000,
+      laneIdleMs: 5_000,
+      laneHardIdleMs: 1_800_000,
+      crossCheckArmed: false,
+    });
+    expect(verdict.status).toBe("stalled");
+  });
+
+  it("does not fire before the hard cap — live descendants still read alive", () => {
+    const verdict = evaluateLiveness({
+      laneRecencyMs: 1_000,
+      now: 100_000, // laneAgeMs = 99_000ms: past soft idle, under the hard cap
+      laneIdleMs: 5_000,
+      laneHardIdleMs: 1_800_000,
+      crossCheckArmed: true,
+      hasLiveDescendants: () => true,
+    });
+    expect(verdict.status).toBe("alive");
+  });
+
+  it("undefined laneHardIdleMs preserves the pre-#2203 behaviour", () => {
+    const verdict = evaluateLiveness({
+      laneRecencyMs: 1_000,
+      now: 2_000_000,
+      laneIdleMs: 5_000,
+      crossCheckArmed: true,
+      hasLiveDescendants: () => true,
+    });
+    expect(verdict.status).toBe("alive");
+  });
+});
+
 describe("evaluateLiveness — lane idle, cross-check disarmed (container)", () => {
   it("cannot corroborate without the host tree → unknown, probe never called", () => {
     let probed = false;

--- a/packages/red-castle/src/LivenessEvaluator.ts
+++ b/packages/red-castle/src/LivenessEvaluator.ts
@@ -77,6 +77,15 @@ export interface EvaluateLivenessInput {
    * fresh. Injected so tests supply a fake probe.
    */
   readonly hasLiveDescendants?: () => boolean;
+  /**
+   * Hard-silence backstop (#2203): once the lane has been idle for at least
+   * this many ms, the verdict is `stalled` regardless of live descendants or
+   * cross-check arming — a wedged agent (a hung child at flat cpu that keeps
+   * the process alive but never advances the lane) must never hold a slot
+   * forever. `undefined` disables the backstop (the pre-#2203 behaviour). Must
+   * be well above `laneIdleMs`.
+   */
+  readonly laneHardIdleMs?: number;
 }
 
 /**
@@ -111,6 +120,27 @@ export function evaluateLiveness(
     laneAgeMs === undefined
       ? "lane empty"
       : `lane idle (${laneAgeMs}ms > ${laneIdleMs}ms)`;
+
+  // Hard-silence backstop (#2203): once the liveness lane has been silent past
+  // the hard cap, the attempt is stalled regardless of live descendants or
+  // cross-check arming — a wedged agent (a live child at flat cpu that stops
+  // advancing the lane) must never hold a slot forever. Placed before the
+  // arming/descendant checks so neither can veto it; the reaper's kill
+  // predicate still gates the irreversible kill on a flat-cpu / no-build tree,
+  // and genuine work keeps its lane fresh, so this never fires for real work.
+  if (
+    laneAgeMs !== undefined &&
+    input.laneHardIdleMs !== undefined &&
+    laneAgeMs >= input.laneHardIdleMs
+  ) {
+    return {
+      status: "stalled",
+      laneFresh: false,
+      laneAgeMs,
+      crossCheckArmed,
+      reason: `${ageDesc} past hard-silence cap (${input.laneHardIdleMs}ms) — descendant/cross-check overridden`,
+    };
+  }
 
   // Lane is idle or empty. The lane alone would call this stalled, but a wedged
   // substrate can stop writing the lane while the agent keeps working — the


### PR DESCRIPTION
Closes #2203.

## The bug

A worker whose inner agent hangs (a codex child alive at 0% cpu, the liveness lane frozen) is **never reaped**, so it holds a fleet slot for hours. Two backstops both miss it:

- **The liveness detector** `evaluateLiveness` (red-castle, ADR 0083 §3) only returns `stalled` when the lane is idle **AND there are no live descendants**. The descendant probe is cpu/kind-blind — *any* live child forces `alive`. A hung child is a live child → never flagged → the kill predicate (`decideReaperSignal`, which *would* kill a flat-cpu non-build tree) is never reached.
- **The attempt-guard hard cap** (5400s) is gated on `!committed`. The stuck workers **committed then hung in `landing`**, so the commit-anchored guard treats them as progressed and never fires.

Net: no descendant-independent backstop exists — a committed-then-hung worker hangs until a human kills it (observed: 5h and 2h50m).

## The fix

A **hard-silence backstop** in `evaluateLiveness`: once the liveness lane has been silent for `laneHardIdleMs`, return `stalled` **regardless of live descendants or cross-check arming**. Wired in both reap loops (fleet `pollStallDetector`, solo `lane-idle-reaper`) with `laneHardIdleMs = stallKillThresholdS * 1000` (30 min, tunable via `RED_AFK_STALL_KILL_THRESHOLD_S`).

Safety preserved by construction:
- The **cross-check window still applies** between the soft (600s) and hard (1800s) thresholds — a wedged-substrate-but-working agent stays `alive` there.
- The **irreversible kill still goes through `decideReaperSignal`** (flat cpu + no active build/test descendant) and the `on_stall_reap` veto hook — a genuine long build (active vitest/tsc, busy cpu) is never killed even when flagged.

## Tests

- 4 behavioral cases on `evaluateLiveness` (fires with live descendants; fires disarmed; does **not** fire before the cap; disabled when `laneHardIdleMs` is undefined) — proven RED→GREEN.
- 1 wiring-lock on `pollStallDetector` so a refactor can't silently drop the hard threshold.
- Typecheck clean (red-castle + apps/dev); the reaper/supervisor/lane-idle/reaper-signal suites (89 tests) stay green.

Amends the ADR 0083 §3 cross-check semantics (adds a hard override above the soft window).

**Please merge by hand** — this changes the fleet reaper itself, and auto-merge of the reaper is exactly the failure the change guards against.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787095058&installation_id=129708444&pr_number=2226&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2226&signature=1a3206c5e078e64a6842907520a25d371611006e4b8507d8e63c8bbd6b427dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->