### PR TITLE
fix: #2221 S2: ADR lifecycle — triage classifier (+ subject filter)

### DIFF
--- a/apps/dev/src/core/adr-triage.ts
+++ b/apps/dev/src/core/adr-triage.ts
@@ -1,0 +1,361 @@
+/**
+ * Pure ADR triage classifier (ADR 0112, Spec #2219 / S2).
+ *
+ * The read-only detection pass of `/review-adrs` needs to look at every ADR
+ * cheaply and say which ones carry debt. This module is that cheap pass: it
+ * takes already-parsed ADR records and buckets each one from status, age,
+ * inbound links, stale path references, supersession, and subject overlap.
+ *
+ * It moves nothing and writes nothing — the IO shell (archive `git mv`,
+ * frontmatter edits, INDEX resync) lives elsewhere and consumes this report.
+ */
+
+export type AdrBucket =
+  | "keep"
+  | "stale-reference"
+  | "missing-supersession"
+  | "merge-candidate"
+  | "split-candidate"
+  | "archive-candidate";
+
+const BUCKETS: readonly AdrBucket[] = [
+  "keep",
+  "stale-reference",
+  "missing-supersession",
+  "merge-candidate",
+  "split-candidate",
+  "archive-candidate",
+];
+
+export interface AdrRecord {
+  /** Zero-padded ADR number, e.g. `"0112"`. */
+  number: string;
+  /** Repo-relative path of the record. */
+  path: string;
+  title: string;
+  /** The prose under `## Status` — the supersession/deprecation signal lives here. */
+  status: string;
+  /** The rest of the record, from `## Context` onwards. */
+  body: string;
+  /** Days since the record last changed substantively. Absent reads as fresh. */
+  ageDays?: number;
+}
+
+/** One INDEX.md theme section, so a subject filter can name a section. */
+export interface AdrIndexSection {
+  title: string;
+  numbers: readonly string[];
+}
+
+export interface AdrTriageContext {
+  adrs: readonly AdrRecord[];
+  /**
+   * Repo-relative paths that currently exist. Stale-path detection is skipped
+   * entirely when absent — an empty inventory would flag every reference.
+   */
+  existingPaths?: readonly string[];
+  indexSections?: readonly AdrIndexSection[];
+  /** An unlinked ADR older than this is inert. Default 365. */
+  inertAfterDays?: number;
+  /** Decision points at/above which an ADR is overloaded. Default 5. */
+  splitDecisionThreshold?: number;
+  /** Shared title terms at/above which two ADRs cover one subject. Default 3. */
+  mergeOverlapThreshold?: number;
+}
+
+export type AdrSubjectFilter =
+  | { kind: "numbers"; numbers: readonly string[] }
+  | { kind: "text"; query: string }
+  | { kind: "index-section"; section: string };
+
+export interface AdrTriageOptions {
+  subject?: AdrSubjectFilter;
+}
+
+export interface AdrTriageEntry {
+  number: string;
+  path: string;
+  title: string;
+  bucket: AdrBucket;
+  /** Machine-readable evidence, e.g. `superseded-by:0003`, `inbound-links:0`. */
+  signals: string[];
+  /** One line explaining the bucket to a human. */
+  reason: string;
+}
+
+export interface AdrTriageSubjectReport {
+  kind: AdrSubjectFilter["kind"];
+  matched: string[];
+  /** Requested numbers absent from the tree. Only for the `numbers` filter. */
+  unmatched?: string[];
+}
+
+export interface AdrTriageReport {
+  entries: AdrTriageEntry[];
+  countsByBucket: Record<AdrBucket, number>;
+  subject?: AdrTriageSubjectReport;
+}
+
+const DEFAULT_INERT_AFTER_DAYS = 365;
+const DEFAULT_SPLIT_THRESHOLD = 5;
+const DEFAULT_MERGE_OVERLAP = 3;
+
+/** Title words too common to mean two ADRs share a subject. */
+const TITLE_STOPWORDS = new Set([
+  "a",
+  "adr",
+  "an",
+  "and",
+  "as",
+  "at",
+  "by",
+  "for",
+  "from",
+  "in",
+  "into",
+  "of",
+  "on",
+  "one",
+  "or",
+  "over",
+  "the",
+  "to",
+  "via",
+  "with",
+]);
+
+// ---------------------------------------------------------------------------
+// signal extraction
+// ---------------------------------------------------------------------------
+
+/** `Superseded by ADR-0112` in an ADR's own status — the terminal marker. */
+function supersededBy(record: AdrRecord): string | undefined {
+  return /supersed(?:ed|es)\s+by\s+(?:ADR[-\s]?)?(\d{4})/i.exec(record.status)?.[1];
+}
+
+function claimsSupersession(record: AdrRecord): boolean {
+  return /supersed/i.test(record.status);
+}
+
+function isDeprecated(record: AdrRecord): boolean {
+  return /\bdeprecat/i.test(record.status);
+}
+
+/** `Supersedes ADR-0004` anywhere in another record — the inbound marker. */
+function supersedes(record: AdrRecord): string[] {
+  const text = `${record.status}\n${record.body}`;
+  return Array.from(text.matchAll(/\bsupersedes\s+(?:ADR[-\s]?)?(\d{4})/gi), (match) => match[1]!);
+}
+
+function referencesAdr(record: AdrRecord, number: string): boolean {
+  const text = `${record.status}\n${record.body}`;
+  return new RegExp(`\\bADR[-\\s]?${number}\\b|\\b${number}-`, "i").test(text);
+}
+
+/** Backticked tokens that look like a file path — `apps/dev/src/cli.ts`. */
+function referencedPaths(record: AdrRecord): string[] {
+  const text = `${record.status}\n${record.body}`;
+  const quoted = Array.from(text.matchAll(/`([^`\n]+)`/g), (match) => match[1]!.trim());
+  const paths = quoted.filter((token) => /^[\w.@-]+(?:\/[\w.@-]+)+$/.test(token) && /\.\w+$/.test(token));
+  return Array.from(new Set(paths));
+}
+
+/** Top-level `- **Bold.**` bullets under `## Decision`. */
+function decisionPoints(record: AdrRecord): number {
+  const heading = /^##\s+Decision\s*$/m.exec(record.body);
+  if (!heading) return 0;
+  const rest = record.body.slice(heading.index + heading[0].length);
+  const next = /^##\s/m.exec(rest);
+  const section = next ? rest.slice(0, next.index) : rest;
+  return Array.from(section.matchAll(/^- \*\*/gm)).length;
+}
+
+function titleTerms(record: AdrRecord): Set<string> {
+  const terms = record.title
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((term) => term.length > 1 && !TITLE_STOPWORDS.has(term) && !/^\d+$/.test(term));
+  return new Set(terms);
+}
+
+// ---------------------------------------------------------------------------
+// classification
+// ---------------------------------------------------------------------------
+
+interface Classification {
+  bucket: AdrBucket;
+  signals: string[];
+  reason: string;
+}
+
+function classify(record: AdrRecord, context: AdrTriageContext): Classification {
+  const inertAfterDays = context.inertAfterDays ?? DEFAULT_INERT_AFTER_DAYS;
+  const splitThreshold = context.splitDecisionThreshold ?? DEFAULT_SPLIT_THRESHOLD;
+  const mergeThreshold = context.mergeOverlapThreshold ?? DEFAULT_MERGE_OVERLAP;
+
+  const others = context.adrs.filter((other) => other.number !== record.number);
+  const signals: string[] = [];
+
+  const successor = supersededBy(record);
+  if (successor) signals.push(`superseded-by:${successor}`);
+  if (isDeprecated(record)) signals.push("deprecated");
+
+  const inboundSupersessions = others
+    .filter((other) => supersedes(other).includes(record.number))
+    .map((other) => other.number);
+  const inboundLinks = others.filter((other) => referencesAdr(other, record.number)).length;
+  signals.push(`inbound-links:${inboundLinks}`);
+
+  const points = decisionPoints(record);
+  signals.push(`decision-points:${points}`);
+
+  const stalePaths = context.existingPaths
+    ? referencedPaths(record).filter((path) => !context.existingPaths!.includes(path))
+    : [];
+  for (const path of stalePaths) signals.push(`stale-path:${path}`);
+
+  const terms = titleTerms(record);
+  const overlapping = others.filter((other) => {
+    const shared = Array.from(titleTerms(other)).filter((term) => terms.has(term));
+    return shared.length >= mergeThreshold;
+  });
+  for (const other of overlapping) signals.push(`overlaps:${other.number}`);
+
+  const ageDays = record.ageDays ?? 0;
+  signals.push(`age-days:${ageDays}`);
+
+  // Precedence runs most-specific first: a record whose status lies about its
+  // own supersession must be corrected before anything else is proposed.
+  if (!successor && inboundSupersessions.length > 0) {
+    for (const number of inboundSupersessions) signals.push(`superseded-without-status:${number}`);
+    return {
+      bucket: "missing-supersession",
+      signals,
+      reason: `ADR ${inboundSupersessions.join(", ")} supersedes this record, but its status never says so.`,
+    };
+  }
+
+  if (!successor && claimsSupersession(record)) {
+    signals.push("successor-unnamed");
+    return {
+      bucket: "missing-supersession",
+      signals,
+      reason: "Status claims supersession without naming the successor ADR.",
+    };
+  }
+
+  if (successor) {
+    return {
+      bucket: "archive-candidate",
+      signals,
+      reason: `Superseded by ADR-${successor}; terminal record, safe to archive.`,
+    };
+  }
+
+  if (isDeprecated(record)) {
+    return { bucket: "archive-candidate", signals, reason: "Deprecated; terminal record, safe to archive." };
+  }
+
+  if (ageDays >= inertAfterDays && inboundLinks === 0) {
+    return {
+      bucket: "archive-candidate",
+      signals,
+      reason: `Inert: ${ageDays} days old and no ADR links to it.`,
+    };
+  }
+
+  if (points >= splitThreshold) {
+    return {
+      bucket: "split-candidate",
+      signals,
+      reason: `Carries ${points} distinct decisions; a focused split reads better.`,
+    };
+  }
+
+  if (overlapping.length > 0) {
+    const partners = overlapping.map((other) => other.number).join(", ");
+    return {
+      bucket: "merge-candidate",
+      signals,
+      reason: `Shares its subject with ADR ${partners}; consider consolidating.`,
+    };
+  }
+
+  if (stalePaths.length > 0) {
+    return {
+      bucket: "stale-reference",
+      signals,
+      reason: `Cites path(s) that no longer exist: ${stalePaths.join(", ")}.`,
+    };
+  }
+
+  return { bucket: "keep", signals, reason: "Live decision with no detected debt." };
+}
+
+// ---------------------------------------------------------------------------
+// subject filter
+// ---------------------------------------------------------------------------
+
+function matchesSubject(record: AdrRecord, subject: AdrSubjectFilter, context: AdrTriageContext): boolean {
+  if (subject.kind === "numbers") return subject.numbers.includes(record.number);
+
+  if (subject.kind === "text") {
+    const haystack = `${record.title}\n${record.path}\n${record.status}\n${record.body}`.toLowerCase();
+    const tokens = subject.query.toLowerCase().split(/\s+/).filter(Boolean);
+    return tokens.length > 0 && tokens.every((token) => haystack.includes(token));
+  }
+
+  const section = (context.indexSections ?? []).find(
+    (candidate) => candidate.title.toLowerCase() === subject.section.toLowerCase(),
+  );
+  return section ? section.numbers.includes(record.number) : false;
+}
+
+// ---------------------------------------------------------------------------
+// entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Bucket every ADR in the tree, optionally reporting only a subject-filtered
+ * subset. Classification always runs against the whole tree — supersession and
+ * inbound links are cross-record signals, so a narrow filter must never change
+ * an ADR's bucket, only which buckets you are shown.
+ */
+export function triageAdrs(context: AdrTriageContext, options: AdrTriageOptions = {}): AdrTriageReport {
+  const classified = context.adrs.map((record) => ({ record, ...classify(record, context) }));
+  const subject = options.subject;
+  const scoped = subject
+    ? classified.filter((item) => matchesSubject(item.record, subject, context))
+    : classified;
+
+  const entries: AdrTriageEntry[] = scoped.map((item) => ({
+    number: item.record.number,
+    path: item.record.path,
+    title: item.record.title,
+    bucket: item.bucket,
+    signals: item.signals,
+    reason: item.reason,
+  }));
+
+  const countsByBucket = Object.fromEntries(
+    BUCKETS.map((bucket) => [bucket, entries.filter((entry) => entry.bucket === bucket).length]),
+  ) as Record<AdrBucket, number>;
+
+  const report: AdrTriageReport = { entries, countsByBucket };
+
+  if (subject) {
+    const matched = entries.map((entry) => entry.number);
+    report.subject =
+      subject.kind === "numbers"
+        ? {
+            kind: subject.kind,
+            matched,
+            unmatched: subject.numbers.filter(
+              (number) => !context.adrs.some((record) => record.number === number),
+            ),
+          }
+        : { kind: subject.kind, matched };
+  }
+
+  return report;
+}

--- a/apps/dev/tests/adr-triage.test.ts
+++ b/apps/dev/tests/adr-triage.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AdrRecord,
+  type AdrTriageContext,
+  triageAdrs,
+} from "../src/core/adr-triage.js";
+
+// ---------------------------------------------------------------------------
+// fixture ADR tree
+// ---------------------------------------------------------------------------
+
+function adr(number: string, overrides: Partial<AdrRecord> = {}): AdrRecord {
+  return {
+    number,
+    path: `.red/adr/${number}-fixture.md`,
+    title: `Fixture ADR ${number}`,
+    status: "Accepted.",
+    body: "## Decision\n\n- **Do the thing.** Because.\n",
+    ageDays: 10,
+    ...overrides,
+  };
+}
+
+/** A tree with one ADR per bucket, plus the partners those buckets need. */
+function fixtureTree(): AdrTriageContext {
+  return {
+    adrs: [
+      // keep — live, linked, recent, single decision, no stale paths
+      adr("0001", {
+        title: "Memory transport adapters",
+        body: "## Decision\n\n- **Register adapters.** See `apps/memory/src/index.ts`.\n",
+      }),
+      // archive-candidate — terminal status
+      adr("0002", { status: "Superseded by ADR-0003." }),
+      // the successor, which keeps 0002 honest
+      adr("0003", {
+        title: "Successor record",
+        body: "## Decision\n\n- **Supersedes ADR-0002.** New shape.\n",
+      }),
+      // missing-supersession — 0005 supersedes it, but its own status never said so
+      adr("0004", { status: "Accepted." }),
+      adr("0005", {
+        title: "Replacement record",
+        body: "## Decision\n\n- **Supersedes ADR-0004.** Newer shape.\n",
+      }),
+      // stale-reference — cites a path that no longer exists
+      adr("0006", {
+        body: "## Decision\n\n- **Read the launcher.** See `apps/dev/src/gone.ts`.\n",
+      }),
+      // split-candidate — one ADR carrying many decisions
+      adr("0007", {
+        body: [
+          "## Decision",
+          "",
+          "- **One.** a",
+          "- **Two.** b",
+          "- **Three.** c",
+          "- **Four.** d",
+          "- **Five.** e",
+          "",
+        ].join("\n"),
+      }),
+      // merge-candidate pair — near-identical subjects
+      adr("0008", { title: "AFK worker heartbeat protocol" }),
+      adr("0009", { title: "AFK worker heartbeat sampling" }),
+      // archive-candidate — accepted but old and nothing links to it
+      adr("0010", { title: "Inert shipped decision", ageDays: 900 }),
+    ],
+    existingPaths: ["apps/memory/src/index.ts", "apps/dev/src/cli.ts"],
+    indexSections: [{ title: "AFK", numbers: ["0008", "0009"] }],
+  };
+}
+
+function bucketsByNumber(context: AdrTriageContext, subject?: Parameters<typeof triageAdrs>[1]) {
+  const report = triageAdrs(context, subject);
+  return Object.fromEntries(report.entries.map((entry) => [entry.number, entry.bucket]));
+}
+
+// ---------------------------------------------------------------------------
+// classification
+// ---------------------------------------------------------------------------
+
+describe("triageAdrs", () => {
+  it("buckets every ADR in the fixture tree", () => {
+    expect(bucketsByNumber(fixtureTree())).toEqual({
+      "0001": "keep",
+      "0002": "archive-candidate",
+      "0003": "keep",
+      "0004": "missing-supersession",
+      "0005": "keep",
+      "0006": "stale-reference",
+      "0007": "split-candidate",
+      "0008": "merge-candidate",
+      "0009": "merge-candidate",
+      "0010": "archive-candidate",
+    });
+  });
+
+  it("counts each bucket", () => {
+    const report = triageAdrs(fixtureTree());
+
+    expect(report.countsByBucket).toEqual({
+      keep: 3,
+      "stale-reference": 1,
+      "missing-supersession": 1,
+      "merge-candidate": 2,
+      "split-candidate": 1,
+      "archive-candidate": 2,
+    });
+  });
+
+  it("names the evidence behind each bucket", () => {
+    const report = triageAdrs(fixtureTree());
+    const entry = (number: string) => report.entries.find((item) => item.number === number)!;
+
+    expect(entry("0002").signals).toContain("superseded-by:0003");
+    expect(entry("0004").signals).toContain("superseded-without-status:0005");
+    expect(entry("0006").signals).toContain("stale-path:apps/dev/src/gone.ts");
+    expect(entry("0007").signals).toContain("decision-points:5");
+    expect(entry("0008").signals).toContain("overlaps:0009");
+    expect(entry("0010").signals).toContain("inbound-links:0");
+    expect(entry("0002").reason).toMatch(/supersed/i);
+  });
+
+  it("skips stale-path detection when the caller supplies no path inventory", () => {
+    const context = { ...fixtureTree(), existingPaths: undefined };
+
+    expect(bucketsByNumber(context)["0006"]).toBe("keep");
+  });
+
+  it("treats a superseded status with no successor number as missing supersession", () => {
+    const context: AdrTriageContext = {
+      adrs: [adr("0020", { status: "Superseded." })],
+    };
+    const report = triageAdrs(context);
+
+    expect(report.entries[0]!.bucket).toBe("missing-supersession");
+    expect(report.entries[0]!.signals).toContain("successor-unnamed");
+  });
+
+  it("archives a deprecated ADR", () => {
+    const context: AdrTriageContext = { adrs: [adr("0021", { status: "Deprecated." })] };
+
+    expect(triageAdrs(context).entries[0]!.bucket).toBe("archive-candidate");
+  });
+
+  it("keeps an old ADR that other ADRs still link to", () => {
+    const context: AdrTriageContext = {
+      adrs: [
+        adr("0030", { title: "Old but load-bearing", ageDays: 900 }),
+        adr("0031", { body: "## Decision\n\n- **Follow ADR-0030.** Still current.\n" }),
+      ],
+    };
+
+    expect(bucketsByNumber(context)["0030"]).toBe("keep");
+  });
+
+  it("is pure — it does not mutate the records it classifies", () => {
+    const context = fixtureTree();
+    const snapshot = JSON.parse(JSON.stringify(context));
+
+    triageAdrs(context);
+
+    expect(JSON.parse(JSON.stringify(context))).toEqual(snapshot);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subject filter
+// ---------------------------------------------------------------------------
+
+describe("triageAdrs subject filter", () => {
+  it("scopes the report to an explicit set of ADR numbers", () => {
+    const report = triageAdrs(fixtureTree(), { subject: { kind: "numbers", numbers: ["0002", "0007"] } });
+
+    expect(report.entries.map((entry) => entry.number)).toEqual(["0002", "0007"]);
+    expect(report.subject).toEqual({ kind: "numbers", matched: ["0002", "0007"], unmatched: [] });
+  });
+
+  it("reports numbers the tree does not contain", () => {
+    const report = triageAdrs(fixtureTree(), { subject: { kind: "numbers", numbers: ["0002", "9999"] } });
+
+    expect(report.subject?.unmatched).toEqual(["9999"]);
+  });
+
+  it("scopes the report to a free-text subject", () => {
+    const report = triageAdrs(fixtureTree(), { subject: { kind: "text", query: "AFK heartbeat" } });
+
+    expect(report.entries.map((entry) => entry.number)).toEqual(["0008", "0009"]);
+  });
+
+  it("scopes the report to an INDEX section", () => {
+    const report = triageAdrs(fixtureTree(), { subject: { kind: "index-section", section: "afk" } });
+
+    expect(report.entries.map((entry) => entry.number)).toEqual(["0008", "0009"]);
+  });
+
+  it("returns nothing for an unknown INDEX section", () => {
+    const report = triageAdrs(fixtureTree(), { subject: { kind: "index-section", section: "nope" } });
+
+    expect(report.entries).toEqual([]);
+  });
+
+  it("classifies against the whole tree even when the report is scoped", () => {
+    // 0004's bucket depends on 0005, which the filter excludes. The signal must survive.
+    const report = triageAdrs(fixtureTree(), { subject: { kind: "numbers", numbers: ["0004"] } });
+
+    expect(report.entries[0]!.bucket).toBe("missing-supersession");
+  });
+
+  it("counts only the scoped entries", () => {
+    const report = triageAdrs(fixtureTree(), { subject: { kind: "numbers", numbers: ["0002"] } });
+
+    expect(report.countsByBucket["archive-candidate"]).toBe(1);
+    expect(report.countsByBucket.keep).toBe(0);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2221. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2221

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787095100&installation_id=129708444&pr_number=2227&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2227&signature=dd41c0f8e2551950c8d4341ffeccf64023a4ec3d4ce43895ba8dd582d1ee3139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->