### PR TITLE
fix: build Pi packages at the release NEXT version — unbreaks red-release

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -587,6 +587,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NEXT: ${{ steps.version.outputs.next }}
+          # Stamp the resolved NEXT onto the built Pi packages: the plugin
+          # manifest sync/bump runs AFTER this step, so build-pi-packages must
+          # publish NEXT rather than the still-previous manifest version, or the
+          # registry smoke below fails on the missing NEXT tag.
+          RED_BUILD_VERSION: ${{ steps.version.outputs.next }}
         run: |
           set -euo pipefail
           version="${NEXT#v}"

--- a/apps/dev/tests/pi-package-builder.test.ts
+++ b/apps/dev/tests/pi-package-builder.test.ts
@@ -171,4 +171,47 @@ description: afk
   it("matches the builder output for the repo's committed plugin manifests", async () => {
     await execFileAsync("node", [builder, "--root", ROOT, "--check"]);
   });
+
+  it("stamps RED_BUILD_VERSION over the plugin manifest version (release build)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "red-skills-pi-ver-"));
+    await mkdir(join(root, ".claude-plugin"), { recursive: true });
+    await mkdir(join(root, "plugins/dev/.claude-plugin"), { recursive: true });
+    await mkdir(join(root, "plugins/dev/skills/engineering/afk"), {
+      recursive: true,
+    });
+    await writeJson(join(root, ".claude-plugin/marketplace.json"), {
+      name: "red-skills",
+      plugins: [
+        { name: "dev", source: "./plugins/dev", description: "Dev plugin." },
+      ],
+    });
+    await writeJson(join(root, "plugins/dev/.claude-plugin/plugin.json"), {
+      name: "dev",
+      version: "9.9.9", // stale committed manifest version at Pi-build time
+      description: "Dev plugin.",
+      skills: ["./skills/engineering/afk"],
+    });
+    await writeFile(
+      join(root, "plugins/dev/skills/engineering/afk/SKILL.md"),
+      `---
+name: afk
+description: Test afk skill.
+---
+
+# afk
+`,
+      "utf8",
+    );
+
+    await execFileAsync("node", [builder, "--root", root], {
+      env: { ...process.env, RED_BUILD_VERSION: "v1.2.3" },
+    });
+
+    const pkg = JSON.parse(
+      await readFile(join(root, "packaging/pi/dev/package.json"), "utf8"),
+    );
+    // The resolved NEXT (RED_BUILD_VERSION) wins over the stale 9.9.9 manifest,
+    // so the published package matches what the registry smoke expects.
+    expect(pkg.version).toBe("1.2.3");
+  });
 });

--- a/scripts/build-pi-packages.mjs
+++ b/scripts/build-pi-packages.mjs
@@ -82,8 +82,17 @@ function buildNpmPackageJson(claudePlugin) {
   // - tighten files to just skills + package.json (no source tree leakage)
   const base = buildPiPackage(claudePlugin);
   const { private: _private, ...publishable } = base;
+  // During a release, RED_BUILD_VERSION (the resolved NEXT) is the source of
+  // truth for the published Pi version. At Pi-build time the committed plugin
+  // manifests still carry the PREVIOUS release's version — red-release.yml runs
+  // the manifest-version sync + bump commit AFTER this build — so reading
+  // claudePlugin.version would publish a stale version and fail the "Smoke
+  // published Pi packages" step. Absent the env (local build / --check), fall
+  // back to the manifest version.
+  const releaseVersion = process.env.RED_BUILD_VERSION?.replace(/^v/, "").trim();
   return {
     ...publishable,
+    ...(releaseVersion ? { version: releaseVersion } : {}),
     publishConfig: { access: "public" },
     files: ["skills/**/*", "package.json", "README.md"],
   };


### PR DESCRIPTION
Follow-up to #2202 (per-plugin Pi packages), which broke every release.

## The bug

`red-release.yml` publishes the Pi packages (`@reddb-io/red-skills-<plugin>`) at their **stale committed manifest version**, then smoke-tests them at the release `NEXT`, which does not exist → the smoke step fails and the run never reaches Tag + GitHub Release. Every retry recomputes the same `NEXT` and dies at the same step.

Root cause: the step order is **Build+publish Pi (30) → Smoke Pi (31) → Sync plugin manifest versions (33)**. At Pi-build time the plugin manifests still carry the previous release's version (`dev/memory/brain@2.75.2`, `internal@2.1.0`), and `build-pi-packages.mjs` reads `claudePlugin.version` — so it publishes the old version. The step computed `version=${NEXT#v}` but never passed it to the build (unlike the main package, which stamps `process.env.NEXT` inline).

This is why `v2.76.0` published to npm but has **no git tag** — the run failed at the Pi smoke before tagging.

## The fix

- `build-pi-packages.mjs`: when `RED_BUILD_VERSION` is set (the resolved `NEXT`), stamp it over the manifest version — mirroring how the main package is versioned. Absent the env (local build / `--check`), fall back to the manifest, so the metadata check stays consistent.
- `red-release.yml`: pass `RED_BUILD_VERSION: ${{ steps.version.outputs.next }}` into the Pi build/publish step.

## Tests

- New `pi-package-builder` case: with `RED_BUILD_VERSION=v1.2.3` and a `9.9.9` manifest, the staged package.json is `1.2.3`. The existing cases (no env → manifest version, `--check`) stay green — no regression.

Workflows run from `main`, so the next `red-release` run picks up the fix and can finally tag + publish the Pi packages at the right version.

**Please merge by hand** — this changes the release workflow (sensitive path).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787105110&installation_id=129708444&pr_number=2229&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2229&signature=005690515394609fe2af1657358f80d7288142f167e928a96e7997d835fbb19b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->