### PR TITLE
fix: Pi registry smoke compares npm-view version exactly (was always failing)

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -619,11 +619,14 @@ jobs:
           # (same budget as the @reddb-io/red-skills smoke above).
           for plugin in dev memory brain; do
             for attempt in 1 2 3 4 5 6 7 8 9 10; do
-              if output="$(npm view "@reddb-io/red-skills-${plugin}@${version}" name version 2>&1)"; then
-                if grep -qF "@reddb-io/red-skills-${plugin} ${version}" <<<"$output"; then
-                  echo "registry smoke returned @reddb-io/red-skills-${plugin}@${version}"
-                  continue 2
-                fi
+              # `npm view <pkg>@<version> version` prints just the resolved
+              # version string (e.g. `2.76.0`); compare it exactly. The prior
+              # `name version` + grep for "<name> <version>" never matched npm's
+              # multi-field `field = 'value'` output, so the smoke always failed
+              # even after the packages were published.
+              if resolved="$(npm view "@reddb-io/red-skills-${plugin}@${version}" version 2>/dev/null)" && [ "$resolved" = "${version}" ]; then
+                echo "registry smoke returned @reddb-io/red-skills-${plugin}@${version}"
+                continue 2
               fi
               echo "registry smoke attempt ${attempt}/10 for @reddb-io/red-skills-${plugin}@${version} not yet resolvable; sleeping ${attempt}*15s"
               sleep "$((attempt * 15))"


### PR DESCRIPTION
Second bug in the #2202 Pi release integration — the one still blocking the tag after #2229 got the Pi packages published at the right version.

## The bug

The Pi registry smoke ran:
```bash
output="$(npm view "@reddb-io/red-skills-${plugin}@${version}" name version)"
grep -qF "@reddb-io/red-skills-${plugin} ${version}" <<<"$output"
```
But `npm view <pkg>@<ver> name version` (multi-field) prints:
```
name = '@reddb-io/red-skills-dev'
version = '2.76.0'
```
The grep looks for `@reddb-io/red-skills-dev 2.76.0` (name **space** version) on one line — which **never appears** in that `field = 'value'` output. So the smoke reported "not yet resolvable" on every attempt and failed after 10, **even when the packages were published and resolvable** (confirmed: `red-skills-{dev,memory,brain,internal}@2.76.0` are live on npm right now).

This is why the run after #2229 still failed at the same step despite the Pi packages publishing correctly — and why `v2.76.0` still has no tag.

## The fix

Query the single `version` field (prints just `2.76.0`) and compare it exactly:
```bash
if resolved="$(npm view "@reddb-io/red-skills-${plugin}@${version}" version 2>/dev/null)" && [ "$resolved" = "${version}" ]; then …
```
Verified locally against the live `@reddb-io/red-skills-dev@2.76.0`: the new check passes, the old grep does not. (The main-package smoke is unaffected — it execs `npx … --version`, a different, working path.)

With #2229 (version) + this (smoke), the release finally reaches Tag + GitHub Release. **Please merge by hand** — release workflow (sensitive path).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787106936&installation_id=129708444&pr_number=2241&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2241&signature=79f4ee3578c3c4aad89bd525ee92e36ebaf5db80119607f4bebf5ead0efb2b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->