### PR TITLE
fix: regenerate Pi manifests at v2.76.0 — unbreaks main

### DIFF
--- a/packaging/pi/brain/package.json
+++ b/packaging/pi/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-brain",
-  "version": "2.75.2",
+  "version": "2.76.0",
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/reddb-io/red-skills",

--- a/packaging/pi/dev/package.json
+++ b/packaging/pi/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-dev",
-  "version": "2.75.2",
+  "version": "2.76.0",
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/reddb-io/red-skills",

--- a/packaging/pi/memory/package.json
+++ b/packaging/pi/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-memory",
-  "version": "2.75.2",
+  "version": "2.76.0",
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/reddb-io/red-skills",

--- a/plugins/brain/package.json
+++ b/plugins/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-brain",
-  "version": "2.75.2",
+  "version": "2.76.0",
   "private": true,
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "license": "Apache-2.0",

--- a/plugins/dev/package.json
+++ b/plugins/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-dev",
-  "version": "2.75.2",
+  "version": "2.76.0",
   "private": true,
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "license": "Apache-2.0",

--- a/plugins/memory/package.json
+++ b/plugins/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-memory",
-  "version": "2.75.2",
+  "version": "2.76.0",
   "private": true,
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "license": "Apache-2.0",


### PR DESCRIPTION
`main` is red. Every PR opened after the v2.76.0 release fails the `typecheck` job, regardless of what it changes — this was caught by a **config-only YAML PR** (#2253) failing typecheck.

## Cause

The release commit `79e23518f` bumped every `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to 2.76.0, but left `plugins/*/package.json` — the generated **Pi manifests** — at 2.75.2.

`pnpm pi:manifests:check` regenerates and diffs against what is committed:

```
plugins/dev/package.json      -"version": "2.75.2"  +"version": "2.76.0"
plugins/memory/package.json   -"version": "2.75.2"  +"version": "2.76.0"
plugins/brain/package.json    -"version": "2.75.2"  +"version": "2.76.0"
```

## Fix

Ran `pnpm pi:manifests` and committed the result — the repo rule is that generated manifests are never hand-edited.

Three lines, versions only.

## This will recur

The release workflow bumps plugin manifests but does not regenerate the Pi manifests, so the **next release reproduces this exactly**. Filed as a follow-up; this PR only clears the current red.

Urgent because an AFK fleet is draining right now and every PR it produces will fail the same gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787113061&installation_id=129708444&pr_number=2255&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2255&signature=2da6bd236a3528a4de43b71965996a10488d3973dda53862f574791a48711065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->