### PR TITLE
fix: #2243 memory map-contract is documented in the CLI but always errors (unknown command)

### DIFF
--- a/apps/memory/src/cli/entry.ts
+++ b/apps/memory/src/cli/entry.ts
@@ -237,6 +237,9 @@ export async function main(): Promise<void> {
     case "export":
     case "graph":
       return runExport(args);
+    case "map-contract":
+      if (!registryOperation) throw new Error("map-contract operation is not registered");
+      return runRegistryCliOperation(registryOperation, args);
     case "architecture-overview":
       return runArchitectureOverview(args);
     case "hook":

--- a/apps/memory/tests/map-contract-cli.test.ts
+++ b/apps/memory/tests/map-contract-cli.test.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { initGraph } from "../src/init.js";
+
+const TIMEOUT = 40_000;
+const pkgRoot = resolve(__dirname, "..");
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function runMemory(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    cwd: pkgRoot,
+    encoding: "utf8",
+    timeout: TIMEOUT,
+  });
+}
+
+describe("memory map-contract CLI", () => {
+  test.each([{ flags: [] }, { flags: ["--json"] }])(
+    "routes the documented report command with flags $flags",
+    async ({ flags }) => {
+      const root = await mkdtemp(join(tmpdir(), "memory-map-contract-cli-"));
+      roots.push(root);
+      await initGraph(root);
+
+      const result = runMemory(["map-contract", "--root", root, ...flags]);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        version: "2.0.0",
+        stats: { node_count: 0, edge_count: 0 },
+      });
+    },
+  );
+});


### PR DESCRIPTION
Automated AFK landing for #2243. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2243

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787113727&installation_id=129708444&pr_number=2257&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2257&signature=8ac1df424a7d23cced9defb20722dc2cd59e42b733f8a1dfa461a8b8266427b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->