### PR TITLE
fix: #2260 Shared CLI arg layer silently drops arguments (boolean short flag + positional containing '=')

### DIFF
--- a/packages/shared/args.test.ts
+++ b/packages/shared/args.test.ts
@@ -9,8 +9,14 @@ const SCHEMA = {
   },
   n: { kind: "value", coerce: (raw: string) => Number(raw) },
   once: { kind: "boolean" },
+  verbose: { kind: "boolean", aliases: ["v"] },
+  offset: { kind: "value", coerce: (raw: string) => Number(raw) },
   runner: { kind: "value", coerce: (raw: string) => raw },
   request: { kind: "value", aliases: ["r"], coerce: (raw: string) => raw },
+} satisfies FlagSchema;
+
+const REPEATED_SCHEMA = {
+  change: { kind: "value", type: "array", aliases: ["c"], coerce: (raw: string) => raw },
 } satisfies FlagSchema;
 
 describe("parseFlags", () => {
@@ -48,8 +54,16 @@ describe("parseFlags", () => {
     expect(() => parseFlags(["--prd"], SCHEMA)).toThrow("--prd requires a value");
   });
 
-  it("lets the last occurrence of a flag win", () => {
+  it("lets the last occurrence of a scalar flag win", () => {
     expect(parseFlags(["--runner", "claude", "--runner", "codex"], SCHEMA).values.runner).toBe("codex");
+  });
+
+  it("accumulates repeated value flags when the schema opts into an array", () => {
+    expect(parseFlags(["--change", "alpha", "-c", "beta", "--change=gamma"], REPEATED_SCHEMA).values.change).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
   });
 
   it("ignores unknown flags rather than throwing", () => {
@@ -63,6 +77,28 @@ describe("parseFlags", () => {
 
   it("collects positionals not matched by a flag", () => {
     expect(parseFlags(["alpha", "--once", "beta"], SCHEMA).positionals).toEqual(["alpha", "beta"]);
+  });
+
+  it("does not let a boolean short flag consume the following positional", () => {
+    expect(parseFlags(["-v", "mycommand"], SCHEMA)).toEqual({
+      values: { verbose: true },
+      positionals: ["mycommand"],
+    });
+  });
+
+  it("preserves a positional containing an equals sign", () => {
+    expect(parseFlags(["foo=bar", "--once"], SCHEMA)).toEqual({
+      values: { once: true },
+      positionals: ["foo=bar"],
+    });
+  });
+
+  it("does not consume a following flag as a value", () => {
+    expect(() => parseFlags(["--offset", "--once"], SCHEMA)).toThrow("--offset requires a value");
+  });
+
+  it("accepts a negative number as a value", () => {
+    expect(parseFlags(["-n", "-5"], SCHEMA).values.n).toBe(-5);
   });
 });
 

--- a/packages/shared/args.test.ts
+++ b/packages/shared/args.test.ts
@@ -66,6 +66,10 @@ describe("parseFlags", () => {
     ]);
   });
 
+  it("preserves each raw array occurrence without splitting or coercing it", () => {
+    expect(parseFlags(["--change=a,b", "--change=001"], REPEATED_SCHEMA).values.change).toEqual(["a,b", "001"]);
+  });
+
   it("ignores unknown flags rather than throwing", () => {
     expect(parseFlags(["--unknown", "x", "--once"], SCHEMA).values.once).toBe(true);
   });
@@ -84,6 +88,18 @@ describe("parseFlags", () => {
       values: { verbose: true },
       positionals: ["mycommand"],
     });
+  });
+
+  it("does not let a canonical one-character boolean consume the following positional", () => {
+    const schema = { v: { kind: "boolean" } } satisfies FlagSchema;
+    expect(parseFlags(["-v", "mycommand"], schema)).toEqual({
+      values: { v: true },
+      positionals: ["mycommand"],
+    });
+  });
+
+  it("throws when a canonical one-character value flag is followed by another flag", () => {
+    expect(() => parseFlags(["-n", "--once"], SCHEMA)).toThrow("-n requires a value");
   });
 
   it("preserves a positional containing an equals sign", () => {

--- a/packages/shared/args.ts
+++ b/packages/shared/args.ts
@@ -23,7 +23,7 @@
  *
  * Dependency-light by design: the only import is `cli-args-parser`.
  */
-import { createParser, tokenize, type OptionDefinition, type Token } from "cli-args-parser";
+import { createParser, looksLikeValue, tokenize, type OptionDefinition, type Token } from "cli-args-parser";
 
 /** A flag that is present-or-absent, e.g. `--once`. */
 export interface BooleanFlagSpec {
@@ -73,11 +73,45 @@ function buildParserOptions(schema: FlagSchema): Record<string, OptionDefinition
   const options: Record<string, OptionDefinition> = {};
   for (const [name, spec] of Object.entries(schema)) {
     options[name] = {
-      type: spec.kind === "boolean" ? "boolean" : spec.type ?? "string",
+      type: spec.kind === "boolean" ? "boolean" : "string",
+      ...(name.length === 1 ? { short: name } : {}),
       ...(spec.aliases === undefined ? {} : { aliases: spec.aliases }),
     };
   }
   return options;
+}
+
+function collectArrayValues(argv: readonly string[], schema: FlagSchema): Map<string, string[]> {
+  const names = new Map<string, string>();
+  for (const [name, spec] of Object.entries(schema)) {
+    if (spec.kind !== "value" || spec.type !== "array") continue;
+    names.set(name, name);
+    for (const alias of spec.aliases ?? []) names.set(alias, name);
+  }
+
+  const values = new Map<string, string[]>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === "--") break;
+
+    const match = arg.match(/^--([^=]+)(?:=(.*))?$/) ?? arg.match(/^-([^=])(?:=(.*))?$/);
+    if (match === null) continue;
+
+    const canonical = names.get(match[1]!);
+    if (canonical === undefined) continue;
+
+    let raw = match[2];
+    if (raw === undefined && looksLikeValue(argv[index + 1])) {
+      raw = argv[index + 1];
+      index += 1;
+    }
+    if (raw === undefined) continue;
+
+    const accumulated = values.get(canonical) ?? [];
+    accumulated.push(raw);
+    values.set(canonical, accumulated);
+  }
+  return values;
 }
 
 /**
@@ -107,6 +141,7 @@ export function parseFlags<Schema extends FlagSchema>(
   });
   const parsed = parser.parse([...argv]);
   const values: Record<string, unknown> = {};
+  const arrayValues = collectArrayValues(argv, schema);
   const missingValue = parsed.errors.find((error) => /^Option --?\S+ requires a value$/.test(error));
   if (missingValue !== undefined) {
     throw new Error(missingValue.replace(/^Option /, ""));
@@ -120,8 +155,7 @@ export function parseFlags<Schema extends FlagSchema>(
     if (spec.kind === "boolean") {
       values[name] = raw;
     } else if (spec.type === "array") {
-      const items = Array.isArray(raw) ? raw : [raw];
-      values[name] = items.map((item) => spec.coerce(String(item)));
+      values[name] = (arrayValues.get(name) ?? []).map((item) => spec.coerce(item));
     } else {
       values[name] = spec.coerce(String(raw));
     }

--- a/packages/shared/args.ts
+++ b/packages/shared/args.ts
@@ -10,9 +10,10 @@
  *    typed `{ values, positionals }` result. Each flag declares its kind
  *    (`boolean` / `value`), its aliases, and an optional `coerce` mapping the
  *    raw string to the value the caller wants. Built on the library's
- *    `tokenize` primitive so `--flag`, `--flag=value`, `--flag value`, `-f`,
- *    and `-f value` are all recognised consistently, with a single, shared
- *    "<flag> requires a value" error for value flags missing their argument.
+ *    schema-aware `createParser` surface so `--flag`, `--flag=value`,
+ *    `--flag value`, `-f`, and `-f value` are all recognised consistently,
+ *    with a single, shared "<flag> requires a value" error for value flags
+ *    missing their argument.
  *
  *  - `routeCommand(argv, commands)` — a minimal command router: it peels the
  *    leading token, matches it (or an alias) against the known command set, and
@@ -22,7 +23,7 @@
  *
  * Dependency-light by design: the only import is `cli-args-parser`.
  */
-import { tokenize, type Token } from "cli-args-parser";
+import { createParser, tokenize, type OptionDefinition, type Token } from "cli-args-parser";
 
 /** A flag that is present-or-absent, e.g. `--once`. */
 export interface BooleanFlagSpec {
@@ -34,6 +35,8 @@ export interface BooleanFlagSpec {
 /** A flag that consumes a value, e.g. `--spec 42` / `--spec=42`. */
 export interface ValueFlagSpec<T> {
   kind: "value";
+  /** Accumulate repeated occurrences in order instead of keeping the last. */
+  type?: "array";
   /** Alternate spellings (long or short), without leading dashes. */
   aliases?: string[];
   /** Map the raw string value to the typed value the caller wants. */
@@ -47,7 +50,9 @@ export type FlagSchema = Record<string, FlagSpec>;
 
 /** Infer the value type produced by a single flag spec. */
 type FlagValue<S> = S extends ValueFlagSpec<infer T>
-  ? T
+  ? S extends { type: "array" }
+    ? T[]
+    : T
   : S extends BooleanFlagSpec
     ? boolean
     : never;
@@ -64,94 +69,65 @@ export interface LooseParsedArgs {
   flags: Record<string, string | boolean>;
 }
 
-function buildAliasIndex(schema: FlagSchema): Map<string, string> {
-  const index = new Map<string, string>();
+function buildParserOptions(schema: FlagSchema): Record<string, OptionDefinition> {
+  const options: Record<string, OptionDefinition> = {};
   for (const [name, spec] of Object.entries(schema)) {
-    index.set(name, name);
-    for (const alias of spec.aliases ?? []) index.set(alias, name);
+    options[name] = {
+      type: spec.kind === "boolean" ? "boolean" : spec.type ?? "string",
+      ...(spec.aliases === undefined ? {} : { aliases: spec.aliases }),
+    };
   }
-  return index;
+  return options;
 }
 
 /**
  * Parse `argv` against a flag `schema`, returning typed values and positionals.
  *
- * Tokenisation is delegated to `cli-args-parser`'s `tokenize`, so the supported
- * surface — `--flag`, `--no-flag`, `--opt=value`, `-f`, `-o value`, combined
- * short flags — is the library's, shared across the whole monorepo. The wrapper
- * then folds those tokens into the declared schema:
+ * Parsing is delegated to `cli-args-parser`'s schema-aware `createParser`, so
+ * the supported surface — `--flag`, `--no-flag`, `--opt=value`, `-f`,
+ * `-o value`, combined short flags — is the library's, shared across the whole
+ * monorepo. The wrapper then maps the parsed values into the declared schema:
  *
  *  - boolean flag present → `true`
  *  - value flag with `=value` or a following token → `coerce(value)`
  *  - value flag with no available value → throws `"<flag> requires a value"`
  *
- * Last occurrence wins for repeated flags. Unknown flags are ignored (left for
+ * Last occurrence wins unless a value flag opts into `type: "array"`, which
+ * accumulates occurrences in input order. Unknown flags are ignored (left for
  * the caller to handle elsewhere), matching the permissive scan dev relied on.
  */
 export function parseFlags<Schema extends FlagSchema>(
   argv: readonly string[],
   schema: Schema,
 ): ParseFlagsResult<Schema> {
-  const aliasIndex = buildAliasIndex(schema);
-  const args = [...argv];
-  const tokens: Token[] = tokenize(args);
-
+  const parser = createParser({
+    options: buildParserOptions(schema),
+    separators: {},
+    allowUnknown: true,
+  });
+  const parsed = parser.parse([...argv]);
   const values: Record<string, unknown> = {};
-  const positionals: string[] = [];
-
-  for (let i = 0; i < tokens.length; i += 1) {
-    const tok = tokens[i]!;
-    const key = tok.key;
-
-    if ((tok.type === "positional" || tok.type === "separator") && key === undefined) {
-      positionals.push(tok.raw);
-      continue;
-    }
-
-    // Tokens carrying a key are flag-long / flag-short / option-long /
-    // option-short / negation. Resolve to a canonical schema name.
-    if (key === undefined) {
-      positionals.push(tok.raw);
-      continue;
-    }
-
-    const canonical = aliasIndex.get(key);
-    if (canonical === undefined) {
-      // Unknown flag — preserve permissive behaviour, ignore it.
-      continue;
-    }
-    const spec = schema[canonical]!;
-
-    if (spec.kind === "boolean") {
-      values[canonical] = true;
-      continue;
-    }
-
-    // Value flag. The token may already carry an inline value (--flag=value or
-    // -f=value). Otherwise consume the next argv token as the value.
-    let raw: string | undefined = tok.value;
-    if (raw === undefined) {
-      const next = args[tok.index + 1];
-      if (next !== undefined) {
-        raw = next;
-        // Skip the token we just consumed as a value so it is not re-read as a
-        // positional / flag on a later iteration.
-        for (let j = i + 1; j < tokens.length; j += 1) {
-          if (tokens[j]!.index === tok.index + 1) {
-            tokens.splice(j, 1);
-            break;
-          }
-        }
-      }
-    }
-    if (raw === undefined) {
-      const display = key.length === 1 ? `-${key}` : `--${key}`;
-      throw new Error(`${display} requires a value`);
-    }
-    values[canonical] = spec.coerce(raw);
+  const missingValue = parsed.errors.find((error) => /^Option --?\S+ requires a value$/.test(error));
+  if (missingValue !== undefined) {
+    throw new Error(missingValue.replace(/^Option /, ""));
   }
 
-  return { values, positionals } as ParseFlagsResult<Schema>;
+  if (parsed.errors.length > 0) throw new Error(parsed.errors[0]);
+
+  for (const [name, spec] of Object.entries(schema)) {
+    const raw = parsed.options[name];
+    if (raw === undefined) continue;
+    if (spec.kind === "boolean") {
+      values[name] = raw;
+    } else if (spec.type === "array") {
+      const items = Array.isArray(raw) ? raw : [raw];
+      values[name] = items.map((item) => spec.coerce(String(item)));
+    } else {
+      values[name] = spec.coerce(String(raw));
+    }
+  }
+
+  return { values, positionals: parsed.rest } as ParseFlagsResult<Schema>;
 }
 
 /**


### PR DESCRIPTION
Automated AFK landing for #2260. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2260

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787138575&installation_id=129708444&pr_number=2262&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2262&signature=ef6099c2bd8d16ac67f4a8e4b6f8fd97ab7dc9b0e583587255cc655273c4510e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->