### PR TITLE
fix: #2263 main-red repair: baseline probe failures on main

### DIFF
--- a/packages/red-castle/src/Orchestrator.test.ts
+++ b/packages/red-castle/src/Orchestrator.test.ts
@@ -480,7 +480,7 @@ describe("Orchestrator", () => {
       const content = await readFile(join(hostDir, `iter-${i}.txt`), "utf-8");
       expect(content).toBe(`iteration ${i}`);
     }
-  });
+  }, 15_000);
 
   it("handles iteration with no agent commits gracefully", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "orch-host-"));
@@ -641,7 +641,7 @@ describe("OrchestrateResult", () => {
     // All shas should be unique
     const uniqueShas = new Set(result.commits.map((c) => c.sha));
     expect(uniqueShas.size).toBe(3);
-  });
+  }, 15_000);
 
   it("returns empty commits and branch when agent makes no commits", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "orch-result-"));

--- a/packages/red-castle/src/createSandbox.test.ts
+++ b/packages/red-castle/src/createSandbox.test.ts
@@ -1629,7 +1629,7 @@ describe("createSandbox", () => {
       await sandbox.close();
       await rm(hostDir, { recursive: true, force: true });
     }
-  });
+  }, 15_000);
 
   it("sandbox.interactive() invokes interactiveExec and returns result", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandbox-test-"));


### PR DESCRIPTION
Automated AFK landing for #2263. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2263

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787141018&installation_id=129708444&pr_number=2266&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2266&signature=7d4827ecdb9deb176b9efc01ba640d50bad99f8a6bb792405282bbeff0a12331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->