### PR TITLE
fix: #2251 Decide memory's migration given handlers that read process.argv directly

### DIFF
--- a/apps/memory/src/cli/core.ts
+++ b/apps/memory/src/cli/core.ts
@@ -857,9 +857,8 @@ export function evidenceCardInputFromFlags(args: ParsedArgs): CreateEvidenceCard
 }
 
 export function collectEvidenceFlagValues(args: ParsedArgs, key: string): string[] {
-  const values = collectRepeatedFlag(process.argv.slice(2), key);
-  const single = stringFlag(args.flags, key);
-  if (values.length === 0 && single) values.push(single);
+  const flag = args.flags[key];
+  const values = Array.isArray(flag) ? flag : typeof flag === "string" ? [flag] : [];
   return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
 }
 

--- a/apps/memory/src/cli/core.ts
+++ b/apps/memory/src/cli/core.ts
@@ -858,7 +858,7 @@ export function evidenceCardInputFromFlags(args: ParsedArgs): CreateEvidenceCard
 
 export function collectEvidenceFlagValues(args: ParsedArgs, key: string): string[] {
   const flag = args.flags[key];
-  const values = Array.isArray(flag) ? flag : typeof flag === "string" ? [flag] : [];
+  const values = args.repeatedFlags?.[key] ?? (typeof flag === "string" ? [flag] : []);
   return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
 }
 

--- a/apps/memory/src/cli/docs.ts
+++ b/apps/memory/src/cli/docs.ts
@@ -136,9 +136,6 @@ export function operationNeedsGraphStore(operation: ReadOnlyMemoryOperation): bo
 
 export function flagsForRegistryTransport(args: ParsedArgs): Record<string, unknown> {
   const flags: Record<string, unknown> = { ...args.flags };
-  for (const [key, values] of Object.entries(repeatedFlags(process.argv.slice(2)))) {
-    if (values.length > 1) flags[key] = values;
-  }
   const operation = registryCliOperationFor(args.command, args.positional);
   if (
     operation &&

--- a/apps/memory/src/cli/docs.ts
+++ b/apps/memory/src/cli/docs.ts
@@ -135,7 +135,10 @@ export function operationNeedsGraphStore(operation: ReadOnlyMemoryOperation): bo
 }
 
 export function flagsForRegistryTransport(args: ParsedArgs): Record<string, unknown> {
-  const flags: Record<string, unknown> = { ...args.flags };
+  const flags: Record<string, unknown> = {
+    ...args.flags,
+    ...(args.repeatedFlags ?? {}),
+  };
   const operation = registryCliOperationFor(args.command, args.positional);
   if (
     operation &&

--- a/apps/memory/src/cli/entry.ts
+++ b/apps/memory/src/cli/entry.ts
@@ -21,7 +21,12 @@ import { HOOK_EVENTS, parseComplementaryMapKind, readStdin, resolveBootstrapPath
 
 const MEMORY_CLI_FLAG_SCHEMA = {
   change: { kind: "value", type: "array", coerce: (raw: string) => raw },
-  "changed-files": { kind: "value", type: "array", coerce: (raw: string) => raw },
+  "changed-files": {
+    kind: "value",
+    type: "array",
+    aliases: ["changed-file"],
+    coerce: (raw: string) => raw,
+  },
   citation: { kind: "value", type: "array", coerce: (raw: string) => raw },
   "privacy-note": { kind: "value", type: "array", coerce: (raw: string) => raw },
   tag: { kind: "value", type: "array", coerce: (raw: string) => raw },

--- a/apps/memory/src/cli/entry.ts
+++ b/apps/memory/src/cli/entry.ts
@@ -19,8 +19,16 @@ import { parseChangedFiles, parseHubRankBy, parseRid, printConflicts, printPrePr
 import type { TimelineToonEntry } from './graph-reports.js';
 import { HOOK_EVENTS, parseComplementaryMapKind, readStdin, resolveBootstrapPath, resolveHooksDir, resolveOverviewContract, runAfkFinalize, runArchitectureOverview, runAttempt, runAttemptLearn, runAttemptLearnApply, runDoctor, runExport, runGlobalSearch, runHook, runImport, runPromoteCmd, runStats, runVcs, runVcsInstallHooks, runVcsRefresh, runVcsUninstallHooks, runVector, VCS_EVENTS } from './operations.js';
 
+const MEMORY_CLI_FLAG_SCHEMA = {
+  change: { kind: "value", type: "array", coerce: (raw: string) => raw },
+  "changed-files": { kind: "value", type: "array", coerce: (raw: string) => raw },
+  citation: { kind: "value", type: "array", coerce: (raw: string) => raw },
+  "privacy-note": { kind: "value", type: "array", coerce: (raw: string) => raw },
+  tag: { kind: "value", type: "array", coerce: (raw: string) => raw },
+} as const;
+
 export async function main(): Promise<void> {
-  const args = parseLooseArgs(process.argv.slice(2));
+  const args = parseLooseArgs(process.argv.slice(2), MEMORY_CLI_FLAG_SCHEMA);
   if (args.command === "--version" || args.command === "-v" || args.command === "version" || args.flags.version === true || args.flags.v === true) {
     const info = readBuildInfo("memory");
     process.stdout.write(args.flags.json ? `${JSON.stringify(info)}\n` : `${renderVersion(info)}\n`);

--- a/apps/memory/src/cli/entry.ts
+++ b/apps/memory/src/cli/entry.ts
@@ -24,7 +24,7 @@ const MEMORY_CLI_FLAG_SCHEMA = {
   "changed-files": {
     kind: "value",
     type: "array",
-    aliases: ["changed-file"],
+    aliases: ["changed-file"] as string[],
     coerce: (raw: string) => raw,
   },
   citation: { kind: "value", type: "array", coerce: (raw: string) => raw },

--- a/apps/memory/src/cli/recall.ts
+++ b/apps/memory/src/cli/recall.ts
@@ -371,9 +371,12 @@ export async function runReasoningReplay(args: ParsedArgs): Promise<void> {
 }
 
 export async function runWhatif(args: ParsedArgs): Promise<void> {
-  // Collect every `--change <value>` from process.argv since the shared
-  // parser only keeps the last value per flag.
-  const rawChanges = collectRepeatedFlag(process.argv.slice(2), "change");
+  const changeFlag = args.flags.change;
+  const rawChanges = Array.isArray(changeFlag)
+    ? changeFlag
+    : typeof changeFlag === "string"
+      ? [changeFlag]
+      : [];
   const positionalChanges = args.positional.filter((p) => p.length > 0);
   const sources = [...rawChanges, ...positionalChanges];
   if (sources.length === 0) {

--- a/apps/memory/src/cli/recall.ts
+++ b/apps/memory/src/cli/recall.ts
@@ -372,11 +372,8 @@ export async function runReasoningReplay(args: ParsedArgs): Promise<void> {
 
 export async function runWhatif(args: ParsedArgs): Promise<void> {
   const changeFlag = args.flags.change;
-  const rawChanges = Array.isArray(changeFlag)
-    ? changeFlag
-    : typeof changeFlag === "string"
-      ? [changeFlag]
-      : [];
+  const rawChanges =
+    args.repeatedFlags?.change ?? (typeof changeFlag === "string" ? [changeFlag] : []);
   const positionalChanges = args.positional.filter((p) => p.length > 0);
   const sources = [...rawChanges, ...positionalChanges];
   if (sources.length === 0) {

--- a/apps/memory/tests/cli-argument-binding.test.ts
+++ b/apps/memory/tests/cli-argument-binding.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -89,5 +89,25 @@ describe("memory CLI argument binding", () => {
       "review the first source",
       "review the second source",
     ]);
+  });
+
+  test("passes repeated array flags through the operation registry", async () => {
+    const root = await initRoot();
+    const out = join(root, "pre-pr-review.html");
+    const result = runMemory([
+      "pre-pr-review-viewer",
+      "--root",
+      root,
+      "--changed-files=src/first.ts",
+      "--changed-files",
+      "src/second.ts",
+      "--out",
+      out,
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const html = await readFile(out, "utf8");
+    expect(html).toContain("src/first.ts");
+    expect(html).toContain("src/second.ts");
   });
 });

--- a/apps/memory/tests/cli-argument-binding.test.ts
+++ b/apps/memory/tests/cli-argument-binding.test.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+const TIMEOUT = 60_000;
+const pkgRoot = resolve(__dirname, "..");
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function runMemory(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    cwd: pkgRoot,
+    encoding: "utf8",
+    timeout: TIMEOUT,
+  });
+}
+
+async function initRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "memory-cli-argument-binding-"));
+  roots.push(root);
+  const init = runMemory(["init", "--mode", "graph", "--root", root, "--yes"]);
+  expect(init.status, init.stderr).toBe(0);
+  return root;
+}
+
+describe("memory CLI argument binding", () => {
+  test("preserves repeated what-if flags before positional changes", async () => {
+    const root = await initRoot();
+    const result = runMemory([
+      "whatif",
+      "rename alpha to beta",
+      "--change=edit src/a.ts#one",
+      "--change",
+      "delete src/b.ts",
+      "--root",
+      root,
+      "--json",
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const body = JSON.parse(result.stdout) as {
+      changes: Array<{ description: string }>;
+    };
+    expect(body.changes.map((change) => change.description)).toEqual([
+      "edit src/a.ts#one",
+      "delete src/b.ts",
+      "rename alpha to beta",
+    ]);
+  });
+});

--- a/apps/memory/tests/cli-argument-binding.test.ts
+++ b/apps/memory/tests/cli-argument-binding.test.ts
@@ -110,4 +110,24 @@ describe("memory CLI argument binding", () => {
     expect(html).toContain("src/first.ts");
     expect(html).toContain("src/second.ts");
   });
+
+  test("preserves repeated changed-file aliases", async () => {
+    const root = await initRoot();
+    const out = join(root, "pre-pr-review-alias.html");
+    const result = runMemory([
+      "pre-pr-review-viewer",
+      "--root",
+      root,
+      "--changed-file=src/first.ts",
+      "--changed-file",
+      "src/second.ts",
+      "--out",
+      out,
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const html = await readFile(out, "utf8");
+    expect(html).toContain("src/first.ts");
+    expect(html).toContain("src/second.ts");
+  });
 });

--- a/apps/memory/tests/cli-argument-binding.test.ts
+++ b/apps/memory/tests/cli-argument-binding.test.ts
@@ -52,4 +52,42 @@ describe("memory CLI argument binding", () => {
       "rename alpha to beta",
     ]);
   });
+
+  test("binds repeated Evidence citations and privacy notes in order", async () => {
+    const root = await initRoot();
+    const result = runMemory([
+      "evidence",
+      "create",
+      "--root",
+      root,
+      "--summary",
+      "The CLI binds every repeated Evidence value.",
+      "--source-ref",
+      "issue 2251",
+      "--citation=first|https://example.invalid/first|first quote",
+      "--citation",
+      "second|https://example.invalid/second|second quote",
+      "--lesson",
+      "Parse repeated values once at the CLI boundary.",
+      "--privacy-note= review the first source ",
+      "--privacy-note",
+      "review the second source",
+      "--privacy-note",
+      " review the second source ",
+      "--json",
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const body = JSON.parse(result.stdout) as {
+      card: {
+        citations: Array<{ label: string }>;
+        privacy: { notes: string[] };
+      };
+    };
+    expect(body.card.citations.map((citation) => citation.label)).toEqual(["first", "second"]);
+    expect(body.card.privacy.notes).toEqual([
+      "review the first source",
+      "review the second source",
+    ]);
+  });
 });

--- a/packages/shared/args.test.ts
+++ b/packages/shared/args.test.ts
@@ -142,6 +142,20 @@ describe("parseLooseArgs", () => {
       flags: { j: true, iterations: "10" },
     });
   });
+
+  it("retains ordered values for schema-declared array flags", () => {
+    expect(
+      parseLooseArgs(
+        ["whatif", "rename alpha to beta", "--change=edit src/a.ts", "--change", "delete src/b.ts"],
+        { change: { kind: "value", type: "array", coerce: (raw) => raw } },
+      ),
+    ).toEqual({
+      command: "whatif",
+      positional: ["rename alpha to beta"],
+      flags: { change: "delete src/b.ts" },
+      repeatedFlags: { change: ["edit src/a.ts", "delete src/b.ts"] },
+    });
+  });
 });
 
 type Cmd = "run" | "monitor" | "fleet" | "reap";

--- a/packages/shared/args.test.ts
+++ b/packages/shared/args.test.ts
@@ -156,6 +156,20 @@ describe("parseLooseArgs", () => {
       repeatedFlags: { change: ["edit src/a.ts", "delete src/b.ts"] },
     });
   });
+
+  it("accepts a single-dash value for schema-declared array flags", () => {
+    expect(
+      parseLooseArgs(
+        ["evidence", "--privacy-note", "- internal-only"],
+        { "privacy-note": { kind: "value", type: "array", coerce: (raw) => raw } },
+      ),
+    ).toEqual({
+      command: "evidence",
+      positional: [],
+      flags: { "privacy-note": "- internal-only" },
+      repeatedFlags: { "privacy-note": ["- internal-only"] },
+    });
+  });
 });
 
 type Cmd = "run" | "monitor" | "fleet" | "reap";

--- a/packages/shared/args.ts
+++ b/packages/shared/args.ts
@@ -203,23 +203,23 @@ export function parseLooseArgs(
       continue;
     }
 
+    const canonical = aliasIndex.get(key) ?? key;
+    const spec = schema[canonical];
     let value: string | boolean | undefined = tok.value;
     if (value === undefined) {
       const next = args[tok.index + 1];
-      if (next !== undefined && !next.startsWith("-")) {
+      const acceptsSingleDashValue = spec?.kind === "value" && !next?.startsWith("--");
+      if (next !== undefined && (!next.startsWith("-") || acceptsSingleDashValue)) {
         value = next;
-        for (let j = i + 1; j < tokens.length; j += 1) {
+        for (let j = tokens.length - 1; j > i; j -= 1) {
           if (tokens[j]!.index === tok.index + 1) {
             tokens.splice(j, 1);
-            break;
           }
         }
       } else {
         value = true;
       }
     }
-    const canonical = aliasIndex.get(key) ?? key;
-    const spec = schema[canonical];
     if (spec?.kind === "value" && spec.type === "array") {
       if (value === true) {
         const display = key.length === 1 ? `-${key}` : `--${key}`;

--- a/packages/shared/args.ts
+++ b/packages/shared/args.ts
@@ -66,7 +66,7 @@ export interface ParseFlagsResult<Schema extends FlagSchema> {
 export interface LooseParsedArgs {
   command: string | undefined;
   positional: string[];
-  flags: Record<string, string | boolean>;
+  flags: Record<string, string | boolean | string[]>;
 }
 
 function buildParserOptions(schema: FlagSchema): Record<string, OptionDefinition> {
@@ -170,13 +170,23 @@ export function parseFlags<Schema extends FlagSchema>(
  * This keeps the familiar `{ command, positional, flags }` shape used by the
  * Memory CLIs while delegating tokenisation to `cli-args-parser`, so long/short
  * flags and `--flag=value` behave consistently with the schema-driven parser.
+ * Callers may declare value options with `type: "array"` to accumulate their
+ * occurrences in input order while unknown options retain loose parsing.
  */
-export function parseLooseArgs(argv: readonly string[]): LooseParsedArgs {
+export function parseLooseArgs(
+  argv: readonly string[],
+  schema: FlagSchema = {},
+): LooseParsedArgs {
   const [command, ...rest] = argv;
-  const flags: Record<string, string | boolean> = {};
+  const flags: Record<string, string | boolean | string[]> = {};
   const positional: string[] = [];
   const args = [...rest];
   const tokens: Token[] = tokenize(args);
+  const aliasIndex = new Map<string, string>();
+  for (const [name, spec] of Object.entries(schema)) {
+    aliasIndex.set(name, name);
+    for (const alias of spec.aliases ?? []) aliasIndex.set(alias, name);
+  }
 
   for (let i = 0; i < tokens.length; i += 1) {
     const tok = tokens[i]!;
@@ -205,7 +215,18 @@ export function parseLooseArgs(argv: readonly string[]): LooseParsedArgs {
         value = true;
       }
     }
-    flags[key] = value;
+    const canonical = aliasIndex.get(key) ?? key;
+    const spec = schema[canonical];
+    if (spec?.kind === "value" && spec.type === "array") {
+      if (value === true) {
+        const display = key.length === 1 ? `-${key}` : `--${key}`;
+        throw new Error(`${display} requires a value`);
+      }
+      const existing = flags[canonical];
+      flags[canonical] = Array.isArray(existing) ? [...existing, value] : [value];
+    } else {
+      flags[canonical] = value;
+    }
   }
 
   return { command, positional, flags };

--- a/packages/shared/args.ts
+++ b/packages/shared/args.ts
@@ -66,7 +66,9 @@ export interface ParseFlagsResult<Schema extends FlagSchema> {
 export interface LooseParsedArgs {
   command: string | undefined;
   positional: string[];
-  flags: Record<string, string | boolean | string[]>;
+  flags: Record<string, string | boolean>;
+  /** Full ordered values for schema-declared array options. */
+  repeatedFlags?: Record<string, string[]>;
 }
 
 function buildParserOptions(schema: FlagSchema): Record<string, OptionDefinition> {
@@ -178,7 +180,8 @@ export function parseLooseArgs(
   schema: FlagSchema = {},
 ): LooseParsedArgs {
   const [command, ...rest] = argv;
-  const flags: Record<string, string | boolean | string[]> = {};
+  const flags: Record<string, string | boolean> = {};
+  const repeatedFlags: Record<string, string[]> = {};
   const positional: string[] = [];
   const args = [...rest];
   const tokens: Token[] = tokenize(args);
@@ -222,14 +225,19 @@ export function parseLooseArgs(
         const display = key.length === 1 ? `-${key}` : `--${key}`;
         throw new Error(`${display} requires a value`);
       }
-      const existing = flags[canonical];
-      flags[canonical] = Array.isArray(existing) ? [...existing, value] : [value];
+      (repeatedFlags[canonical] ??= []).push(value);
+      flags[canonical] = value;
     } else {
       flags[canonical] = value;
     }
   }
 
-  return { command, positional, flags };
+  return {
+    command,
+    positional,
+    flags,
+    ...(Object.keys(repeatedFlags).length > 0 ? { repeatedFlags } : {}),
+  };
 }
 
 /** Result of `routeCommand`. */


### PR DESCRIPTION
Automated AFK landing for #2251. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2251

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787142942&installation_id=129708444&pr_number=2267&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2267&signature=547b6ecc8e20eb15e9770d655841c5d12ea6deb14a8dc87a314f08da4bb1d614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->