### PR TITLE
fix: #2269 main-red repair issues report a check name, not a failure — and file duplicates

### DIFF
--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -305,7 +305,7 @@ export function buildProcessDeps(
         const { hitlCardCommand } = await import("../hitl-card.js");
         await hitlCardCommand(["render", `--issue=${issue}`, `--root=${ctx.root}`]);
       },
-      findMainRedRepairIssue: () => ghx.findMainRedRepairIssue(ghCtx),
+      findMainRedRepairIssue: (failures) => ghx.findMainRedRepairIssue(ghCtx, failures),
       createMainRedRepairIssue: (spec) => ghx.createMainRedRepairIssue(ghCtx, spec),
       updateMainRedRepairIssue: (issue, spec) => ghx.updateMainRedRepairIssue(ghCtx, issue, spec),
       closeMainRedRepairIssue: (issue, closeComment) => ghx.closeMainRedRepairIssue(ghCtx, issue, closeComment),

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -305,6 +305,7 @@ export function buildProcessDeps(
         const { hitlCardCommand } = await import("../hitl-card.js");
         await hitlCardCommand(["render", `--issue=${issue}`, `--root=${ctx.root}`]);
       },
+      listMainRedRepairIssues: () => ghx.listMainRedRepairIssues(ghCtx),
       findMainRedRepairIssue: (failures) => ghx.findMainRedRepairIssue(ghCtx, failures),
       createMainRedRepairIssue: (spec) => ghx.createMainRedRepairIssue(ghCtx, spec),
       updateMainRedRepairIssue: (issue, spec) => ghx.updateMainRedRepairIssue(ghCtx, issue, spec),

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -567,6 +567,12 @@ function boundedFailureOutputTail(output: string): string {
   return output.replace(/\n+$/, "").split("\n").slice(-20).join("\n").slice(-4_000);
 }
 
+function joinCommandOutput(stdout: string, stderr: string): string {
+  if (stdout === "") return stderr;
+  if (stderr === "") return stdout;
+  return stdout.endsWith("\n") || stderr.startsWith("\n") ? `${stdout}${stderr}` : `${stdout}\n${stderr}`;
+}
+
 /**
  * Internal: run a list of FEEDBACK_SCRIPTS over a list of scopes against a
  * concrete worktree path, using the same per-check shape `runFeedback` emits.
@@ -597,7 +603,7 @@ async function runChecksForBaseline(
       out.set(name, { status: "passed" });
       continue;
     }
-    const output = `${result.stdout}${result.stderr}`;
+    const output = joinCommandOutput(result.stdout, result.stderr);
     out.set(name, {
       status: "failed",
       evidence: {
@@ -729,7 +735,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       const durationMs = now() - start;
       const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
       if (status === "failed") failed = true;
-      const summary = outputSummary(status, `${result.stdout}${result.stderr}`);
+      const summary = outputSummary(status, joinCommandOutput(result.stdout, result.stderr));
       const record = buildValidationRecord({ name, status, command, exitCode: result.code, durationMs, summary });
       push({ name, script, label, scope, status, record });
     }
@@ -754,7 +760,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     const durationMs = now() - start;
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") failed = true;
-    const summary = outputSummary(status, `${result.stdout}${result.stderr}`);
+    const summary = outputSummary(status, joinCommandOutput(result.stdout, result.stderr));
     const record = buildValidationRecord({ name, status, command, exitCode: result.code, durationMs, summary });
     push({ name, script: "typecheck", label, scope, status, record });
   }

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -526,6 +526,8 @@ export interface RunFeedbackResult {
    * about the baseline's state, not the worker reclassification mechanism.
    */
   baselineFailures?: readonly string[];
+  /** Actionable evidence retained from each failed baseline command. */
+  baselineFailureEvidence?: readonly BaselineFailureEvidence[];
   /**
    * Quarantine entries that were active for this gate run — the full validated
    * list from `RunFeedbackInput.quarantine`. Always empty when no quarantine
@@ -550,6 +552,21 @@ export interface BaselineCheckRef {
   scope: string;
 }
 
+export interface BaselineFailureEvidence {
+  check: string;
+  summary: string;
+  outputTail: string;
+}
+
+interface BaselineCheckResult {
+  status: "passed" | "failed";
+  evidence?: BaselineFailureEvidence;
+}
+
+function boundedFailureOutputTail(output: string): string {
+  return output.replace(/\n+$/, "").split("\n").slice(-20).join("\n").slice(-4_000);
+}
+
 /**
  * Internal: run a list of FEEDBACK_SCRIPTS over a list of scopes against a
  * concrete worktree path, using the same per-check shape `runFeedback` emits.
@@ -570,13 +587,25 @@ async function runChecksForBaseline(
   layout: PackageLayout,
   now: () => number,
   env: NodeJS.ProcessEnv,
-): Promise<Map<string, "passed" | "failed">> {
-  const out = new Map<string, "passed" | "failed">();
+): Promise<Map<string, BaselineCheckResult>> {
+  const out = new Map<string, BaselineCheckResult>();
   for (const { name, script, scope } of refs) {
     if (!layout.hasScript(scope, script)) continue;
     const dir = scopeDir(baselineWorktree, scope);
     const result = await exec(["pnpm", "-C", dir, script], { env });
-    out.set(name, result.code === 0 ? "passed" : "failed");
+    if (result.code === 0) {
+      out.set(name, { status: "passed" });
+      continue;
+    }
+    const output = `${result.stdout}${result.stderr}`;
+    out.set(name, {
+      status: "failed",
+      evidence: {
+        check: name,
+        summary: outputSummary("failed", output),
+        outputTail: boundedFailureOutputTail(output),
+      },
+    });
   }
   // `now` is part of the signature for symmetry with the main run; the
   // baseline probe is intentionally cheaper (no per-check timing emitted
@@ -738,13 +767,17 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       .map((c) => ({ name: c.name, script: c.script, scope: c.scope }));
     const baselineResults = await runChecksForBaseline(exec, baselineWorktree, failing, layout, now, subprocessEnv);
     const baselineFailing = [...baselineResults.entries()]
-      .filter(([, status]) => status === "failed")
+      .filter(([, result]) => result.status === "failed")
       .map(([name]) => name);
     const gateDecision = decideBaselineDiffGate(
       failing.map((check) => check.name),
       baselineFailing,
     );
     const preExisting = new Set(gateDecision.preExistingFailures);
+    const baselineFailureEvidence = gateDecision.preExistingFailures.flatMap((name) => {
+      const evidence = baselineResults.get(name)?.evidence;
+      return evidence ? [evidence] : [];
+    });
 
     // Re-classify any check that ALSO failed on the baseline as
     // `skipped (pre-existing failure on baseline)`. Rebuild the sidecar
@@ -775,6 +808,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       baselineDowngraded: downgraded,
       baselineProbeRan: true,
       baselineFailures: gateDecision.preExistingFailures,
+      baselineFailureEvidence,
       quarantined: quarantine,
       validationScope,
     };

--- a/apps/dev/src/core/main-red-repair.ts
+++ b/apps/dev/src/core/main-red-repair.ts
@@ -10,10 +10,21 @@ export interface MainRedRepairIssue {
   labels?: readonly string[];
 }
 
+export interface BaselineFailureEvidence {
+  check: string;
+  summary: string;
+  outputTail: string;
+}
+
+export interface MainRedRepairObservation {
+  sha: string;
+  failures: readonly BaselineFailureEvidence[];
+}
+
 export type MainRedRepairPlan =
   | { action: "noop" }
   | { action: "create"; title: string; body: string; labels: readonly string[] }
-  | { action: "update"; issue: number; title: string; body: string; labels: readonly string[] }
+  | { action: "comment"; issue: number; comment: string }
   | { action: "close"; issue: number; comment: string };
 
 export type MainRedAdminMergeDecision = { ok: true } | { ok: false; message: string };
@@ -22,9 +33,58 @@ export function normalizeBaselineFailures(failures: readonly string[]): string[]
   return [...new Set(failures.map((f) => f.trim()).filter((f) => f.length > 0))].sort();
 }
 
-export function renderMainRedRepairBody(failures: readonly string[]): string {
-  const normalized = normalizeBaselineFailures(failures);
-  const list = normalized.map((failure) => `- ${failure}`).join("\n");
+const MAX_FAILURE_OUTPUT_LINES = 20;
+const MAX_FAILURE_OUTPUT_CHARS = 4_000;
+
+function boundedOutputTail(output: string): string {
+  const lines = output.replace(/\n+$/, "").split("\n").slice(-MAX_FAILURE_OUTPUT_LINES);
+  return lines.join("\n").slice(-MAX_FAILURE_OUTPUT_CHARS);
+}
+
+function normalizeEvidence(failures: readonly BaselineFailureEvidence[]): BaselineFailureEvidence[] {
+  const byCheck = new Map<string, BaselineFailureEvidence>();
+  for (const failure of failures) {
+    const check = failure.check.trim();
+    if (check === "" || byCheck.has(check)) continue;
+    byCheck.set(check, {
+      check,
+      summary: failure.summary.trim() || "command exited non-zero",
+      outputTail: boundedOutputTail(failure.outputTail),
+    });
+  }
+  return [...byCheck.values()].sort((a, b) => a.check.localeCompare(b.check));
+}
+
+function renderIndentedOutput(output: string): string {
+  if (output === "") return "    (no captured output)";
+  return output.split("\n").map((line) => `    ${line}`).join("\n");
+}
+
+export function renderMainRedRepairObservation(observation: MainRedRepairObservation): string {
+  const failures = normalizeEvidence(observation.failures);
+  const sha = observation.sha.trim().slice(0, 64) || "(unresolved)";
+  const evidence = failures.flatMap((failure) => [
+    `### ${failure.check}`,
+    "",
+    `Failure: ${failure.summary}`,
+    "",
+    "Bounded output tail:",
+    "",
+    renderIndentedOutput(failure.outputTail),
+    "",
+  ]);
+  return [
+    `## Observation at ${sha}`,
+    "",
+    `Evaluated commit: \`${sha}\``,
+    "",
+    ...evidence,
+  ].join("\n").replace(/\n+$/, "");
+}
+
+export function renderMainRedRepairBody(observation: MainRedRepairObservation): string {
+  const normalized = normalizeEvidence(observation.failures);
+  const list = normalized.map((failure) => `- ${failure.check}`).join("\n");
   return [
     MAIN_RED_REPAIR_MARKER,
     "",
@@ -36,17 +96,46 @@ export function renderMainRedRepairBody(failures: readonly string[]): string {
     "",
     list || "- (none)",
     "",
+    renderMainRedRepairObservation({ ...observation, failures: normalized }),
+    "",
     "## Source",
     "",
     "Auto-filed by the AFK feedback baseline probe.",
   ].join("\n");
 }
 
+export function mainRedRepairFailuresFromBody(body: string | undefined): string[] {
+  if (!body || !body.includes(MAIN_RED_REPAIR_MARKER)) return [];
+  const section = body.match(/(?:^|\n)## Failing checks\s*\n([\s\S]*?)(?=\n## |$)/)?.[1] ?? "";
+  return normalizeBaselineFailures(
+    section
+      .split("\n")
+      .map((line) => line.match(/^\s*-\s+(.+?)\s*$/)?.[1] ?? "")
+      .filter((failure) => failure !== "" && failure !== "(none)"),
+  );
+}
+
+function sameFailures(left: readonly string[], right: readonly string[]): boolean {
+  const a = normalizeBaselineFailures(left);
+  const b = normalizeBaselineFailures(right);
+  return a.length === b.length && a.every((failure, index) => failure === b[index]);
+}
+
+export function selectMainRedRepairIssue(
+  issues: readonly MainRedRepairIssue[],
+  failures: readonly string[],
+): MainRedRepairIssue | null {
+  return issues
+    .filter((issue) => issue.body?.includes(MAIN_RED_REPAIR_MARKER))
+    .filter((issue) => sameFailures(mainRedRepairFailuresFromBody(issue.body), failures))
+    .sort((a, b) => a.number - b.number)[0] ?? null;
+}
+
 export function planMainRedRepair(
-  baselineFailures: readonly string[],
+  observation: MainRedRepairObservation,
   currentOpenIssue: MainRedRepairIssue | null,
 ): MainRedRepairPlan {
-  const failures = normalizeBaselineFailures(baselineFailures);
+  const failures = normalizeEvidence(observation.failures);
   if (failures.length === 0) {
     if (!currentOpenIssue) return { action: "noop" };
     return {
@@ -56,17 +145,18 @@ export function planMainRedRepair(
     };
   }
 
-  const body = renderMainRedRepairBody(failures);
+  const body = renderMainRedRepairBody({ ...observation, failures });
   const labels = [LABEL_READY, LABEL_URGENT, LABEL_BUG];
-  if (!currentOpenIssue) {
+  if (
+    !currentOpenIssue ||
+    !sameFailures(mainRedRepairFailuresFromBody(currentOpenIssue.body), failures.map((failure) => failure.check))
+  ) {
     return { action: "create", title: MAIN_RED_REPAIR_TITLE, body, labels };
   }
   return {
-    action: "update",
+    action: "comment",
     issue: currentOpenIssue.number,
-    title: MAIN_RED_REPAIR_TITLE,
-    body,
-    labels,
+    comment: renderMainRedRepairObservation({ ...observation, failures }),
   };
 }
 

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -837,7 +837,7 @@ export async function processIssue(
       );
     }
     mainRed = feedback.baselineProbeRan === true && (feedback.baselineFailures?.length ?? 0) > 0;
-    mainRedRepairSyncFailure = await syncMainRedRepairIssue(deps, feedback);
+    mainRedRepairSyncFailure = await syncMainRedRepairIssue(deps, feedback, baseResolution.sha);
     await fireHook(
       "post_feedback",
       hookContext({

--- a/apps/dev/src/core/process-issue/recovery.ts
+++ b/apps/dev/src/core/process-issue/recovery.ts
@@ -396,20 +396,26 @@ async function releaseOwnedClaim(deps: ProcessIssueDeps, input: ProcessIssueInpu
 export async function syncMainRedRepairIssue(
   deps: ProcessIssueDeps,
   feedback: RunFeedbackResult,
+  evaluatedSha: string,
 ): Promise<string | null> {
   if (!feedback.baselineProbeRan) return null;
   const {
     findMainRedRepairIssue,
     createMainRedRepairIssue,
-    updateMainRedRepairIssue,
     closeMainRedRepairIssue,
   } = deps.gh;
-  if (!findMainRedRepairIssue || !createMainRedRepairIssue || !updateMainRedRepairIssue || !closeMainRedRepairIssue) {
+  if (!findMainRedRepairIssue || !createMainRedRepairIssue || !closeMainRedRepairIssue) {
     return null;
   }
   try {
-    const current = await findMainRedRepairIssue();
-    const plan = planMainRedRepair(feedback.baselineFailures ?? [], current);
+    const fallbackEvidence = (feedback.baselineFailures ?? []).map((check) => ({
+      check,
+      summary: "command exited non-zero",
+      outputTail: "",
+    }));
+    const failures = feedback.baselineFailureEvidence ?? fallbackEvidence;
+    const current = await findMainRedRepairIssue(failures.map((failure) => failure.check));
+    const plan = planMainRedRepair({ sha: evaluatedSha, failures }, current);
     switch (plan.action) {
       case "noop":
         return null;
@@ -422,13 +428,9 @@ export async function syncMainRedRepairIssue(
         deps.appendIterLog(`🤖 /afk baseline probe: opened main-red repair issue #${created}.`);
         return null;
       }
-      case "update":
-        await updateMainRedRepairIssue(plan.issue, {
-          title: plan.title,
-          body: plan.body,
-          labels: plan.labels,
-        });
-        deps.appendIterLog(`🤖 /afk baseline probe: updated main-red repair issue #${plan.issue}.`);
+      case "comment":
+        await deps.gh.comment(plan.issue, plan.comment);
+        deps.appendIterLog(`🤖 /afk baseline probe: added an observation to main-red repair issue #${plan.issue}.`);
         return null;
       case "close":
         await closeMainRedRepairIssue(plan.issue, plan.comment);

--- a/apps/dev/src/core/process-issue/recovery.ts
+++ b/apps/dev/src/core/process-issue/recovery.ts
@@ -28,6 +28,7 @@ import {
 } from "../feedback.js";
 import {
   planMainRedRepair,
+  selectMainRedRepairIssue,
   type MainRedRepairIssue,
 } from "../main-red-repair.js";
 import {
@@ -400,11 +401,11 @@ export async function syncMainRedRepairIssue(
 ): Promise<string | null> {
   if (!feedback.baselineProbeRan) return null;
   const {
-    findMainRedRepairIssue,
+    listMainRedRepairIssues,
     createMainRedRepairIssue,
     closeMainRedRepairIssue,
   } = deps.gh;
-  if (!findMainRedRepairIssue || !createMainRedRepairIssue || !closeMainRedRepairIssue) {
+  if (!listMainRedRepairIssues || !createMainRedRepairIssue || !closeMainRedRepairIssue) {
     return null;
   }
   try {
@@ -414,9 +415,19 @@ export async function syncMainRedRepairIssue(
       outputTail: "",
     }));
     const failures = feedback.baselineFailureEvidence ?? fallbackEvidence;
-    const current = failures.length === 0
-      ? await findMainRedRepairIssue()
-      : await findMainRedRepairIssue(failures.map((failure) => failure.check));
+    const observation = { sha: evaluatedSha, failures };
+    const issues = [...await listMainRedRepairIssues()];
+    if (failures.length === 0) {
+      for (const issue of issues) {
+        const closePlan = planMainRedRepair(observation, issue);
+        if (closePlan.action !== "close") continue;
+        await closeMainRedRepairIssue(closePlan.issue, closePlan.comment);
+        deps.appendIterLog(`🤖 /afk baseline probe: closed main-red repair issue #${closePlan.issue}.`);
+      }
+      return null;
+    }
+    const failureChecks = failures.map((failure) => failure.check);
+    const current = selectMainRedRepairIssue(issues, failureChecks);
     const plan = planMainRedRepair({ sha: evaluatedSha, failures }, current);
     switch (plan.action) {
       case "noop":
@@ -427,16 +438,42 @@ export async function syncMainRedRepairIssue(
           body: plan.body,
           labels: plan.labels,
         });
-        deps.appendIterLog(`🤖 /afk baseline probe: opened main-red repair issue #${created}.`);
+        const refreshed = [...await listMainRedRepairIssues()].map((issue) => issue.number === created
+          ? { ...issue, title: issue.title ?? plan.title, body: issue.body ?? plan.body, labels: issue.labels ?? plan.labels }
+          : issue);
+        if (!refreshed.some((issue) => issue.number === created)) {
+          refreshed.push({ number: created, title: plan.title, body: plan.body, labels: plan.labels });
+        }
+        const canonical = selectMainRedRepairIssue(refreshed, failureChecks);
+        if (!canonical) throw new Error("created main-red repair issue could not be reconciled");
+        if (canonical.number !== created) {
+          const commentPlan = planMainRedRepair(observation, canonical);
+          if (commentPlan.action === "comment") await deps.gh.comment(commentPlan.issue, commentPlan.comment);
+        }
+        for (const duplicate of refreshed) {
+          if (duplicate.number === canonical.number) continue;
+          if (selectMainRedRepairIssue([duplicate], failureChecks)?.number !== duplicate.number) continue;
+          await closeMainRedRepairIssue(
+            duplicate.number,
+            `🤖 /afk baseline probe: closing duplicate of canonical main-red repair issue #${canonical.number}.`,
+          );
+        }
+        deps.appendIterLog(`🤖 /afk baseline probe: synchronized main-red repair issue #${canonical.number}.`);
         return null;
       }
       case "comment":
         await deps.gh.comment(plan.issue, plan.comment);
+        for (const duplicate of issues) {
+          if (duplicate.number === plan.issue) continue;
+          if (selectMainRedRepairIssue([duplicate], failureChecks)?.number !== duplicate.number) continue;
+          await closeMainRedRepairIssue(
+            duplicate.number,
+            `🤖 /afk baseline probe: closing duplicate of canonical main-red repair issue #${plan.issue}.`,
+          );
+        }
         deps.appendIterLog(`🤖 /afk baseline probe: added an observation to main-red repair issue #${plan.issue}.`);
         return null;
       case "close":
-        await closeMainRedRepairIssue(plan.issue, plan.comment);
-        deps.appendIterLog(`🤖 /afk baseline probe: closed main-red repair issue #${plan.issue}.`);
         return null;
     }
   } catch (err) {

--- a/apps/dev/src/core/process-issue/recovery.ts
+++ b/apps/dev/src/core/process-issue/recovery.ts
@@ -414,7 +414,9 @@ export async function syncMainRedRepairIssue(
       outputTail: "",
     }));
     const failures = feedback.baselineFailureEvidence ?? fallbackEvidence;
-    const current = await findMainRedRepairIssue(failures.map((failure) => failure.check));
+    const current = failures.length === 0
+      ? await findMainRedRepairIssue()
+      : await findMainRedRepairIssue(failures.map((failure) => failure.check));
     const plan = planMainRedRepair({ sha: evaluatedSha, failures }, current);
     switch (plan.action) {
       case "noop":

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -137,7 +137,7 @@ export interface ProcessGh {
   repoVisibility?(): Promise<RepoVisibility | undefined>;
   actorTrustSignals?(actor: string): Promise<ActorTrustSignals>;
   renderDecisionCard?(issue: number): Promise<void>;
-  findMainRedRepairIssue?(): Promise<MainRedRepairIssue | null>;
+  findMainRedRepairIssue?(failures?: readonly string[]): Promise<MainRedRepairIssue | null>;
   createMainRedRepairIssue?(spec: { title: string; body: string; labels: readonly string[] }): Promise<number>;
   updateMainRedRepairIssue?(
     issue: number,

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -137,6 +137,7 @@ export interface ProcessGh {
   repoVisibility?(): Promise<RepoVisibility | undefined>;
   actorTrustSignals?(actor: string): Promise<ActorTrustSignals>;
   renderDecisionCard?(issue: number): Promise<void>;
+  listMainRedRepairIssues?(): Promise<readonly MainRedRepairIssue[]>;
   findMainRedRepairIssue?(failures?: readonly string[]): Promise<MainRedRepairIssue | null>;
   createMainRedRepairIssue?(spec: { title: string; body: string; labels: readonly string[] }): Promise<number>;
   updateMainRedRepairIssue?(

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -14,6 +14,7 @@ export {
   createIssue,
   attachSubIssue,
   listSpecSubIssueCandidates,
+  listMainRedRepairIssues,
   findMainRedRepairIssue,
   createMainRedRepairIssue,
   updateMainRedRepairIssue,

--- a/apps/dev/src/runtime/gh/issues.ts
+++ b/apps/dev/src/runtime/gh/issues.ts
@@ -8,7 +8,7 @@ import {
   type MainRedRepairIssue,
 } from "../../core/main-red-repair.js";
 import { scrubOutbound } from "../outbound-redaction.js";
-import { repoArgs, runGh, type GhContext } from "./common.js";
+import { apiPath, repoArgs, runGh, type GhContext } from "./common.js";
 
 export async function viewLabels(ctx: GhContext, issue: number): Promise<string[]> {
   const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "labels"]);
@@ -282,32 +282,27 @@ export async function listSpecSubIssueCandidates(
   return candidates;
 }
 
-/** Find an open marked main-red repair issue, optionally matching a failing-check set. */
-export async function findMainRedRepairIssue(
-  ctx: GhContext,
-  failures?: readonly string[],
-): Promise<MainRedRepairIssue | null> {
+/** List every open marked main-red repair issue across all GitHub result pages. */
+export async function listMainRedRepairIssues(ctx: GhContext): Promise<MainRedRepairIssue[]> {
   const r = await runGh(ctx, [
-    "issue",
-    "list",
-    ...repoArgs(ctx),
-    "--state",
-    "open",
-    "--limit",
-    "200",
-    "--json",
-    "number,title,body,labels",
+    "api",
+    "--paginate",
+    "--slurp",
+    apiPath(ctx, "issues?state=open&per_page=100"),
   ]);
-  if (r.code !== 0) return null;
+  if (r.code !== 0) {
+    throw new Error(`gh: failed to list main-red repair issues (code ${r.code}): ${(r.stderr || r.stdout).trim()}`);
+  }
   try {
-    const rows = JSON.parse(r.stdout || "[]") as Array<{
+    const parsed = JSON.parse(r.stdout || "[]") as unknown;
+    if (!Array.isArray(parsed)) throw new Error("expected an array");
+    const rows = parsed.flatMap((page) => Array.isArray(page) ? page : [page]) as Array<{
       number?: number;
       title?: string;
       body?: string;
       labels?: Array<{ name?: string }>;
     }>;
-    if (!Array.isArray(rows)) return null;
-    const issues = rows
+    return rows
       .filter((item) => String(item.body ?? "").includes(MAIN_RED_REPAIR_MARKER))
       .map((row) => ({
         number: Number(row.number),
@@ -317,10 +312,19 @@ export async function findMainRedRepairIssue(
       }))
       .filter((issue) => Number.isInteger(issue.number) && issue.number > 0)
       .sort((a, b) => a.number - b.number);
-    return failures === undefined ? issues[0] ?? null : selectMainRedRepairIssue(issues, failures);
-  } catch {
-    return null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`gh: invalid main-red repair issue response: ${message}`);
   }
+}
+
+/** Find an open marked main-red repair issue, optionally matching a failing-check set. */
+export async function findMainRedRepairIssue(
+  ctx: GhContext,
+  failures?: readonly string[],
+): Promise<MainRedRepairIssue | null> {
+  const issues = await listMainRedRepairIssues(ctx);
+  return failures === undefined ? issues[0] ?? null : selectMainRedRepairIssue(issues, failures);
 }
 
 /** Create the auto-filed main-red repair issue. */

--- a/apps/dev/src/runtime/gh/issues.ts
+++ b/apps/dev/src/runtime/gh/issues.ts
@@ -294,9 +294,7 @@ export async function findMainRedRepairIssue(
     "--state",
     "open",
     "--limit",
-    "50",
-    "--search",
-    `"red-skills:main-red-repair v1" in:body`,
+    "200",
     "--json",
     "number,title,body,labels",
   ]);

--- a/apps/dev/src/runtime/gh/issues.ts
+++ b/apps/dev/src/runtime/gh/issues.ts
@@ -8,7 +8,7 @@ import {
   type MainRedRepairIssue,
 } from "../../core/main-red-repair.js";
 import { scrubOutbound } from "../outbound-redaction.js";
-import { apiPath, repoArgs, runGh, type GhContext } from "./common.js";
+import { repoArgs, runGh, type GhContext } from "./common.js";
 
 export async function viewLabels(ctx: GhContext, issue: number): Promise<string[]> {
   const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "labels"]);

--- a/apps/dev/src/runtime/gh/issues.ts
+++ b/apps/dev/src/runtime/gh/issues.ts
@@ -3,7 +3,8 @@ import {
 } from "../../core/triage-labels.js";
 import type { SpecSubIssueCandidate } from "../../core/spec-subissue-reconciler.js";
 import {
-  MAIN_RED_REPAIR_TITLE,
+  MAIN_RED_REPAIR_MARKER,
+  selectMainRedRepairIssue,
   type MainRedRepairIssue,
 } from "../../core/main-red-repair.js";
 import { scrubOutbound } from "../outbound-redaction.js";
@@ -281,8 +282,11 @@ export async function listSpecSubIssueCandidates(
   return candidates;
 }
 
-/** Find the single open auto-filed main-red repair issue by its stable title. */
-export async function findMainRedRepairIssue(ctx: GhContext): Promise<MainRedRepairIssue | null> {
+/** Find an open marked main-red repair issue, optionally matching a failing-check set. */
+export async function findMainRedRepairIssue(
+  ctx: GhContext,
+  failures?: readonly string[],
+): Promise<MainRedRepairIssue | null> {
   const r = await runGh(ctx, [
     "issue",
     "list",
@@ -292,7 +296,7 @@ export async function findMainRedRepairIssue(ctx: GhContext): Promise<MainRedRep
     "--limit",
     "50",
     "--search",
-    `"${MAIN_RED_REPAIR_TITLE}" in:title`,
+    `"red-skills:main-red-repair v1" in:body`,
     "--json",
     "number,title,body,labels",
   ]);
@@ -305,16 +309,17 @@ export async function findMainRedRepairIssue(ctx: GhContext): Promise<MainRedRep
       labels?: Array<{ name?: string }>;
     }>;
     if (!Array.isArray(rows)) return null;
-    const row = rows
-      .filter((item) => String(item.title ?? "") === MAIN_RED_REPAIR_TITLE)
-      .sort((a, b) => Number(a.number ?? 0) - Number(b.number ?? 0))[0];
-    if (!row || !Number(row.number)) return null;
-    return {
-      number: Number(row.number),
-      title: String(row.title ?? ""),
-      body: String(row.body ?? ""),
-      labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")) : [],
-    };
+    const issues = rows
+      .filter((item) => String(item.body ?? "").includes(MAIN_RED_REPAIR_MARKER))
+      .map((row) => ({
+        number: Number(row.number),
+        title: String(row.title ?? ""),
+        body: String(row.body ?? ""),
+        labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")) : [],
+      }))
+      .filter((issue) => Number.isInteger(issue.number) && issue.number > 0)
+      .sort((a, b) => a.number - b.number);
+    return failures === undefined ? issues[0] ?? null : selectMainRedRepairIssue(issues, failures);
   } catch {
     return null;
   }

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -673,7 +673,7 @@ describe("runFeedback — baseline probe downgrades pre-existing failures", () =
     expect(result.baselineFailureEvidence).toEqual([
       {
         check: "test:apps/dev",
-        summary: "FAIL\nexpected 1 to equal 2",
+        summary: "FAIL expected 1 to equal 2",
         outputTail: "FAIL\nexpected 1 to equal 2",
       },
     ]);

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -673,8 +673,8 @@ describe("runFeedback — baseline probe downgrades pre-existing failures", () =
     expect(result.baselineFailureEvidence).toEqual([
       {
         check: "test:apps/dev",
-        summary: "FAILexpected 1 to equal 2",
-        outputTail: "FAILexpected 1 to equal 2",
+        summary: "FAIL\nexpected 1 to equal 2",
+        outputTail: "FAIL\nexpected 1 to equal 2",
       },
     ]);
     const testCheck = result.checks.find((c) => c.name === "test:apps/dev")!;

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -670,6 +670,13 @@ describe("runFeedback — baseline probe downgrades pre-existing failures", () =
     expect(result.baselineDowngraded).toEqual(["test:apps/dev"]);
     expect(result.baselineProbeRan).toBe(true);
     expect(result.baselineFailures).toEqual(["test:apps/dev"]);
+    expect(result.baselineFailureEvidence).toEqual([
+      {
+        check: "test:apps/dev",
+        summary: "FAILexpected 1 to equal 2",
+        outputTail: "FAILexpected 1 to equal 2",
+      },
+    ]);
     const testCheck = result.checks.find((c) => c.name === "test:apps/dev")!;
     expect(testCheck.status).toBe("skipped");
     expect(testCheck.record.summary).toBe("pre-existing failure on baseline");

--- a/apps/dev/tests/gh-export-surface.test.ts
+++ b/apps/dev/tests/gh-export-surface.test.ts
@@ -48,6 +48,7 @@ const EXPECTED_GH_EXPORTS = [
   "listClaimComments",
   "listHitlCandidates",
   "listIssueStates",
+  "listMainRedRepairIssues",
   "listParkedMechanicalCandidates",
   "listSpecSubIssueCandidates",
   "listUnblockCandidates",

--- a/apps/dev/tests/gh-main-red-repair.test.ts
+++ b/apps/dev/tests/gh-main-red-repair.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderMainRedRepairBody } from "../src/core/main-red-repair.js";
-import { findMainRedRepairIssue, type GhContext } from "../src/runtime/gh.js";
+import { findMainRedRepairIssue, listMainRedRepairIssues, type GhContext } from "../src/runtime/gh.js";
 import type { ExecFn } from "../src/runtime/exec.js";
 
 describe("findMainRedRepairIssue", () => {
@@ -30,8 +30,38 @@ describe("findMainRedRepairIssue", () => {
     const issue = await findMainRedRepairIssue(ctx, ["test:apps/dev"]);
 
     expect(issue?.number).toBe(21);
-    expect(calls[0]).toContain("--state");
-    expect(calls[0]).toContain("open");
-    expect(calls[0]).not.toContain("--search");
+    expect(calls[0]).toContain("--paginate");
+    expect(calls[0]).toContain("--slurp");
+    expect(calls[0]).toContain("repos/acme/widgets/issues?state=open&per_page=100");
+  });
+
+  it("examines every paginated open issue before selecting a match", async () => {
+    const matchingBody = renderMainRedRepairBody({
+      sha: "aaaa",
+      failures: [{ check: "test:apps/dev", summary: "tests failed", outputTail: "tail" }],
+    });
+    const exec: ExecFn = async () => ({
+      code: 0,
+      stdout: JSON.stringify([
+        [{ number: 20, body: "unrelated", labels: [] }],
+        [{ number: 321, body: matchingBody, labels: [] }],
+      ]),
+      stderr: "",
+    });
+
+    const issue = await findMainRedRepairIssue(
+      { cwd: "/repo", repo: "acme/widgets", exec },
+      ["test:apps/dev"],
+    );
+
+    expect(issue?.number).toBe(321);
+  });
+
+  it("propagates lookup failures instead of treating them as no match", async () => {
+    const exec: ExecFn = async () => ({ code: 1, stdout: "", stderr: "temporary GitHub failure" });
+
+    await expect(listMainRedRepairIssues({ cwd: "/repo", repo: "acme/widgets", exec })).rejects.toThrow(
+      "temporary GitHub failure",
+    );
   });
 });

--- a/apps/dev/tests/gh-main-red-repair.test.ts
+++ b/apps/dev/tests/gh-main-red-repair.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { renderMainRedRepairBody } from "../src/core/main-red-repair.js";
+import { findMainRedRepairIssue, type GhContext } from "../src/runtime/gh.js";
+import type { ExecFn } from "../src/runtime/exec.js";
+
+describe("findMainRedRepairIssue", () => {
+  it("lists live open issues and selects the marked issue with the same failing set", async () => {
+    const calls: string[][] = [];
+    const matchingBody = renderMainRedRepairBody({
+      sha: "aaaa",
+      failures: [{ check: "test:apps/dev", summary: "tests failed", outputTail: "tail" }],
+    });
+    const otherBody = renderMainRedRepairBody({
+      sha: "bbbb",
+      failures: [{ check: "lint:apps/dev", summary: "lint failed", outputTail: "tail" }],
+    });
+    const exec: ExecFn = async (_cmd, args) => {
+      calls.push([...args]);
+      return {
+        code: 0,
+        stdout: JSON.stringify([
+          { number: 20, title: "other", body: otherBody, labels: [] },
+          { number: 21, title: "matching", body: matchingBody, labels: [{ name: "priority:urgent" }] },
+        ]),
+        stderr: "",
+      };
+    };
+    const ctx: GhContext = { cwd: "/repo", repo: "acme/widgets", exec };
+
+    const issue = await findMainRedRepairIssue(ctx, ["test:apps/dev"]);
+
+    expect(issue?.number).toBe(21);
+    expect(calls[0]).toContain("--state");
+    expect(calls[0]).toContain("open");
+    expect(calls[0]).not.toContain("--search");
+  });
+});

--- a/apps/dev/tests/main-red-repair-sync.test.ts
+++ b/apps/dev/tests/main-red-repair-sync.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { renderMainRedRepairBody, type MainRedRepairIssue } from "../src/core/main-red-repair.js";
+import { syncMainRedRepairIssue } from "../src/core/process-issue/recovery.js";
+import type { ProcessIssueDeps } from "../src/core/process-issue.js";
+import type { RunFeedbackResult } from "../src/core/feedback.js";
+
+function feedback(failures: RunFeedbackResult["baselineFailureEvidence"]): RunFeedbackResult {
+  return { baselineProbeRan: true, baselineFailureEvidence: failures } as RunFeedbackResult;
+}
+
+function repair(number: number, check: string): MainRedRepairIssue {
+  return {
+    number,
+    body: renderMainRedRepairBody({
+      sha: `sha-${number}`,
+      failures: [{ check, summary: "failed", outputTail: "tail" }],
+    }),
+  };
+}
+
+describe("syncMainRedRepairIssue", () => {
+  it("closes every marked repair issue when the baseline becomes green", async () => {
+    const closed: number[] = [];
+    const issues = [repair(20, "test:apps/dev"), repair(21, "lint:apps/dev")];
+    const deps = {
+      appendIterLog() {},
+      gh: {
+        listMainRedRepairIssues: async () => issues,
+        findMainRedRepairIssue: async () => issues[0] ?? null,
+        createMainRedRepairIssue: async () => 99,
+        closeMainRedRepairIssue: async (issue: number) => { closed.push(issue); },
+      },
+    } as unknown as ProcessIssueDeps;
+
+    await syncMainRedRepairIssue(deps, feedback([]), "green-sha");
+
+    expect(closed).toEqual([20, 21]);
+  });
+
+  it("reconciles a concurrent create to the lowest-numbered canonical issue", async () => {
+    const closed: number[] = [];
+    const comments: number[] = [];
+    const matching = [repair(41, "test:apps/dev"), repair(42, "test:apps/dev")];
+    let listCalls = 0;
+    const deps = {
+      appendIterLog() {},
+      gh: {
+        listMainRedRepairIssues: async () => (++listCalls === 1 ? [] : matching),
+        findMainRedRepairIssue: async () => null,
+        createMainRedRepairIssue: async () => 42,
+        closeMainRedRepairIssue: async (issue: number) => { closed.push(issue); },
+        comment: async (issue: number) => { comments.push(issue); },
+      },
+    } as unknown as ProcessIssueDeps;
+
+    await syncMainRedRepairIssue(
+      deps,
+      feedback([{ check: "test:apps/dev", summary: "new failure", outputTail: "new tail" }]),
+      "new-sha",
+    );
+
+    expect(comments).toEqual([41]);
+    expect(closed).toEqual([42]);
+  });
+});

--- a/apps/dev/tests/main-red-repair.test.ts
+++ b/apps/dev/tests/main-red-repair.test.ts
@@ -6,12 +6,30 @@ import {
   MAIN_RED_REPAIR_TITLE,
   planMainRedRepair,
   renderMainRedRepairBody,
+  selectMainRedRepairIssue,
 } from "../src/core/main-red-repair.js";
 import { LABEL_BUG, LABEL_READY, LABEL_URGENT } from "../src/core/triage-labels.js";
 
 describe("planMainRedRepair", () => {
   it("creates one urgent tracked repair issue when baseline failures exist and none is open", () => {
-    const plan = planMainRedRepair(["test:apps/dev", "typecheck:workspace"], null);
+    const plan = planMainRedRepair(
+      {
+        sha: "0123456789abcdef0123456789abcdef01234567",
+        failures: [
+          {
+            check: "test:apps/dev",
+            summary: "failing: FAIL tests/pi-package-builder.test.ts > builds the package",
+            outputTail: "AssertionError: expected stale manifest to equal generated manifest",
+          },
+          {
+            check: "typecheck:workspace",
+            summary: "error TS2322 in src/index.ts",
+            outputTail: "src/index.ts(4,2): error TS2322: Type 'number' is not assignable to type 'string'",
+          },
+        ],
+      },
+      null,
+    );
 
     expect(plan.action).toBe("create");
     if (plan.action !== "create") throw new Error("unreachable");
@@ -19,23 +37,49 @@ describe("planMainRedRepair", () => {
     expect(plan.labels).toEqual([LABEL_READY, LABEL_URGENT, LABEL_BUG]);
     expect(plan.body).toContain("- test:apps/dev");
     expect(plan.body).toContain("- typecheck:workspace");
+    expect(plan.body).toContain("`0123456789abcdef0123456789abcdef01234567`");
+    expect(plan.body).toContain("FAIL tests/pi-package-builder.test.ts > builds the package");
+    expect(plan.body).toContain("AssertionError: expected stale manifest to equal generated manifest");
   });
 
-  it("updates the existing repair issue instead of creating a duplicate for same or overlapping failures", () => {
-    const plan = planMainRedRepair(["test:apps/dev", "test:apps/dev", "lint:apps/dev"], {
-      number: 123,
-      labels: [LABEL_URGENT],
+  it("comments on the matching issue instead of creating a duplicate", () => {
+    const previous = renderMainRedRepairBody({
+      sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      failures: [{ check: "test:apps/dev", summary: "old failure", outputTail: "old tail" }],
     });
+    const plan = planMainRedRepair(
+      {
+        sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        failures: [{ check: "test:apps/dev", summary: "new failure", outputTail: "new tail" }],
+      },
+      { number: 123, body: previous, labels: [LABEL_URGENT] },
+    );
 
-    expect(plan.action).toBe("update");
-    if (plan.action !== "update") throw new Error("unreachable");
+    expect(plan.action).toBe("comment");
+    if (plan.action !== "comment") throw new Error("unreachable");
     expect(plan.issue).toBe(123);
-    expect(plan.body.match(/test:apps\/dev/g)).toHaveLength(1);
-    expect(plan.body).toContain("- lint:apps/dev");
+    expect(plan.comment).toContain("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    expect(plan.comment).toContain("new failure");
+  });
+
+  it("creates a separate issue when the open repair issue has a different failing set", () => {
+    const previous = renderMainRedRepairBody({
+      sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      failures: [{ check: "lint:apps/dev", summary: "lint failed", outputTail: "lint tail" }],
+    });
+    const plan = planMainRedRepair(
+      {
+        sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        failures: [{ check: "test:apps/dev", summary: "tests failed", outputTail: "test tail" }],
+      },
+      { number: 123, body: previous },
+    );
+
+    expect(plan.action).toBe("create");
   });
 
   it("closes the open repair issue when the next baseline probe is green", () => {
-    const plan = planMainRedRepair([], { number: 55 });
+    const plan = planMainRedRepair({ sha: "feedface", failures: [] }, { number: 55 });
 
     expect(plan).toEqual({
       action: "close",
@@ -45,17 +89,56 @@ describe("planMainRedRepair", () => {
   });
 
   it("does nothing when main is green and no repair issue exists", () => {
-    expect(planMainRedRepair([], null)).toEqual({ action: "noop" });
+    expect(planMainRedRepair({ sha: "feedface", failures: [] }, null)).toEqual({ action: "noop" });
   });
 });
 
 describe("renderMainRedRepairBody", () => {
-  it("names each failing baseline check in a stable body", () => {
-    const body = renderMainRedRepairBody([" typecheck:workspace ", "test:apps/dev"]);
+  it("bounds the captured output tail while preserving failure identity", () => {
+    const outputTail = Array.from({ length: 30 }, (_, i) => `diagnostic line ${i + 1}`).join("\n");
+    const body = renderMainRedRepairBody({
+      sha: "feedface",
+      failures: [
+        {
+          check: " test:apps/dev ",
+          summary: "failing: FAIL tests/createSandbox.test.ts > creates a sandbox",
+          outputTail,
+        },
+      ],
+    });
 
     expect(body).toContain("## Failing checks");
     expect(body).toContain("- test:apps/dev");
-    expect(body).toContain("- typecheck:workspace");
+    expect(body).toContain("FAIL tests/createSandbox.test.ts > creates a sandbox");
+    expect(body).toContain("diagnostic line 30");
+    expect(body).not.toContain("diagnostic line 10\n");
+  });
+});
+
+describe("selectMainRedRepairIssue", () => {
+  it("selects the marked open issue with the same normalized failing-check set", () => {
+    const matchingBody = renderMainRedRepairBody({
+      sha: "aaaaaaaa",
+      failures: [
+        { check: "test:apps/dev", summary: "tests failed", outputTail: "tail" },
+        { check: "lint:apps/dev", summary: "lint failed", outputTail: "tail" },
+      ],
+    });
+    const otherBody = renderMainRedRepairBody({
+      sha: "bbbbbbbb",
+      failures: [{ check: "typecheck:workspace", summary: "types failed", outputTail: "tail" }],
+    });
+
+    expect(
+      selectMainRedRepairIssue(
+        [
+          { number: 10, body: otherBody },
+          { number: 11, body: matchingBody },
+          { number: 12, body: matchingBody.replace("red-skills:main-red-repair", "not-the-marker") },
+        ],
+        [" lint:apps/dev", "test:apps/dev", "test:apps/dev"],
+      )?.number,
+    ).toBe(11);
   });
 });
 

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -252,6 +252,10 @@ describe("processIssue — main-red-untracked landing park (#1473)", () => {
     expect(result.preserved).toBe(true);
     expect(result.branch).toBe("afk/wAAAA/9-fix-the-thing");
     expect(trace.mainRedRepairCreates).toHaveLength(1);
+    expect(trace.mainRedRepairCreates[0]?.body).toContain("Evaluated commit: `origin/main-tip`");
+    expect(trace.mainRedRepairCreates[0]?.body).toContain("## Observation at origin/main-tip");
+    expect(trace.mainRedRepairCreates[0]?.body).toContain("### test:root");
+    expect(trace.mainRedRepairCreates[0]?.body).toContain("Bounded output tail:");
     expect(trace.iterLogs).toContain("warn: main-red repair issue sync failed: gh issue create failed");
     expect(trace.ensuredLabels).toContain("blocked:main-red-untracked");
     expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:main-red-untracked"))).toBe(

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -349,6 +349,10 @@ export function harness(opts: HarnessOptions = {}): {
             inCodeowners: false,
           })
         : undefined,
+      listMainRedRepairIssues:
+        opts.baselineFails || opts.mainRedRepairIssue !== undefined || opts.mainRedRepairCreateError
+          ? async () => currentMainRedRepairIssue ? [currentMainRedRepairIssue] : []
+          : undefined,
       findMainRedRepairIssue:
         opts.baselineFails || opts.mainRedRepairIssue !== undefined || opts.mainRedRepairCreateError
           ? async () => currentMainRedRepairIssue


### PR DESCRIPTION
Automated AFK landing for #2269. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2269

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787146647&installation_id=129708444&pr_number=2271&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2271&signature=5f861da247cce71d2c0632209051debb8e8c3d7596f1e39237a86e7778fe8df6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->