### PR TITLE
fix: #2204 fleet status reports supervisor absent under bundle skew (running 2.75.0 vs stable 2.75.2)

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -452,8 +452,14 @@ export async function logsFleet(
  * watchdog respawn would fire, so "why is nothing running?" is answerable.
  */
 export async function statusFleet(root = process.cwd(), stdout: NodeJS.WritableStream = process.stdout): Promise<FleetStatusResult> {
+  const paths = afkPaths(root);
   const io = buildWatchdogIO(root, stdout);
   const liveness = await io.liveness();
+  const liveSupervisor = await discoverLiveSupervisorPid(paths.supervisorRuntimeDir, isLivePid);
+  if (liveSupervisor) {
+    liveness.pid = liveSupervisor.pid;
+    liveness.pidAlive = true;
+  }
   const cfg = resolveSupervisorConfig();
   const now = Math.floor(Date.now() / 1000);
   const health = classifySupervisor(liveness, now, cfg.supervisorStaleS, cfg.progressStaleS);
@@ -480,6 +486,11 @@ export async function statusFleet(root = process.cwd(), stdout: NodeJS.WritableS
       target: fleet?.target ?? fleet?.slotsTotal ?? 0,
       bundle_version: fleet?.bundleVersion ?? "",
       bundle_latest: fleet?.latestBundleVersion ?? "",
+      version_skew: Number(Boolean(
+        fleet?.bundleVersion &&
+        fleet.latestBundleVersion &&
+        fleet.bundleVersion !== fleet.latestBundleVersion
+      )),
       heartbeat_age_s: heartbeatAgeS,
       would_respawn: wouldRespawn,
     },

--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { encode as encodeToon } from "@reddb-io/toon";
+import { readBuildInfo } from "@reddb-io/build-info";
 import {
   castleLanePath,
   createEnginePaths,
@@ -466,6 +467,7 @@ export async function statusFleet(root = process.cwd(), stdout: NodeJS.WritableS
   const repo = await resolveRepoSlug(root).catch(() => "");
   const inputs = await collectMonitorInputs(root, repo);
   const fleet = inputs.fleet;
+  const latestBundleVersion = fleet?.latestBundleVersion || readBuildInfo("dev").version;
   const liveWorkers = inputs.workers.filter((w) => w.pidLive === true || w.live);
   const heartbeatAgeS = liveness.lastHeartbeatEpoch !== null ? now - liveness.lastHeartbeatEpoch : -1;
 
@@ -485,11 +487,11 @@ export async function statusFleet(root = process.cwd(), stdout: NodeJS.WritableS
       runner: fleet?.runner ?? "",
       target: fleet?.target ?? fleet?.slotsTotal ?? 0,
       bundle_version: fleet?.bundleVersion ?? "",
-      bundle_latest: fleet?.latestBundleVersion ?? "",
+      bundle_latest: latestBundleVersion,
       version_skew: Number(Boolean(
         fleet?.bundleVersion &&
-        fleet.latestBundleVersion &&
-        fleet.bundleVersion !== fleet.latestBundleVersion
+        latestBundleVersion &&
+        fleet.bundleVersion !== latestBundleVersion
       )),
       heartbeat_age_s: heartbeatAgeS,
       would_respawn: wouldRespawn,

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -233,6 +233,61 @@ describe("fleet command stale supervisor state", () => {
     }
   });
 
+  it("statusFleet reports reverse skew against the current dev bundle without cached bundles (#2204)", async () => {
+    const root = scratch();
+    const priorCacheDir = process.env.RED_SKILLS_CACHE_DIR;
+    const priorBuildVersion = process.env.RED_BUILD_VERSION;
+    try {
+      const paths = afkPaths(root);
+      const epoch = Math.floor(Date.now() / 1000);
+      mkdirSync(dirname(paths.fleetStatePath), { recursive: true });
+      writeFileSync(
+        paths.fleetStatePath,
+        JSON.stringify({
+          epoch,
+          last_progress_epoch: epoch,
+          runner: "codex",
+          bundle_version: "2.76.0",
+          ready_for_agent: 0,
+          slots: { busy: 0, free: 2, total: 2, parked: 0 },
+        }),
+        "utf8",
+      );
+      const emptyCacheDir = join(root, "empty-bundle-cache");
+      mkdirSync(emptyCacheDir, { recursive: true });
+      process.env.RED_SKILLS_CACHE_DIR = emptyCacheDir;
+      process.env.RED_BUILD_VERSION = "2.75.2";
+      const writes: string[] = [];
+      const out = {
+        write: vi.fn((s: string) => {
+          writes.push(s);
+          return true;
+        }),
+      } as unknown as NodeJS.WritableStream;
+
+      await statusFleet(root, out);
+
+      const report = decode(writes.join("")) as {
+        supervisor: {
+          bundle_version: string;
+          bundle_latest: string;
+          version_skew: number;
+        };
+      };
+      expect(report.supervisor).toMatchObject({
+        bundle_version: "2.76.0",
+        bundle_latest: "2.75.2",
+        version_skew: 1,
+      });
+    } finally {
+      if (priorCacheDir === undefined) delete process.env.RED_SKILLS_CACHE_DIR;
+      else process.env.RED_SKILLS_CACHE_DIR = priorCacheDir;
+      if (priorBuildVersion === undefined) delete process.env.RED_BUILD_VERSION;
+      else process.env.RED_BUILD_VERSION = priorBuildVersion;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("stopFleet leaves live supervisor files untouched", async () => {
     const root = scratch();
     try {

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -173,6 +173,66 @@ describe("fleet command stale supervisor state", () => {
     }
   });
 
+  it("statusFleet discovers a live supervisor from the structured lane and calls out bundle skew (#2204)", async () => {
+    const root = scratch();
+    const priorCacheDir = process.env.RED_SKILLS_CACHE_DIR;
+    try {
+      const paths = afkPaths(root);
+      const epoch = Math.floor(Date.now() / 1000);
+      mkdirSync(paths.supervisorRuntimeDir, { recursive: true });
+      mkdirSync(join(dirname(paths.supervisorRuntimeDir), "s12345"), { recursive: true });
+      writeFileSync(
+        paths.fleetStatePath,
+        JSON.stringify({
+          epoch,
+          last_progress_epoch: epoch,
+          runner: "codex",
+          bundle_version: "2.75.0",
+          ready_for_agent: 0,
+          slots: { busy: 0, free: 2, total: 2, parked: 0 },
+        }),
+        "utf8",
+      );
+      const cacheDir = join(root, "bundle-cache");
+      mkdirSync(cacheDir, { recursive: true });
+      writeFileSync(join(cacheDir, "dev-2.75.2.bundle.min.mjs"), "", "utf8");
+      process.env.RED_SKILLS_CACHE_DIR = cacheDir;
+      vi.mocked(isLivePid).mockImplementation((pid) => pid === 12345);
+      const writes: string[] = [];
+      const out = {
+        write: vi.fn((s: string) => {
+          writes.push(s);
+          return true;
+        }),
+      } as unknown as NodeJS.WritableStream;
+
+      await statusFleet(root, out);
+
+      const report = decode(writes.join("")) as {
+        supervisor: {
+          pid: number;
+          alive: boolean;
+          health: string;
+          bundle_version: string;
+          bundle_latest: string;
+          version_skew: number;
+        };
+      };
+      expect(report.supervisor).toMatchObject({
+        pid: 12345,
+        alive: true,
+        health: "healthy",
+        bundle_version: "2.75.0",
+        bundle_latest: "2.75.2",
+        version_skew: 1,
+      });
+    } finally {
+      if (priorCacheDir === undefined) delete process.env.RED_SKILLS_CACHE_DIR;
+      else process.env.RED_SKILLS_CACHE_DIR = priorCacheDir;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("stopFleet leaves live supervisor files untouched", async () => {
     const root = scratch();
     try {


### PR DESCRIPTION
Automated AFK landing for #2204. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2204

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787150008&installation_id=129708444&pr_number=2274&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2274&signature=bde121d6fcf65d747e626211587e21e33bb9f1d2630e955d82975cc73ca8cd81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->