### PR TITLE
fix: #2222 S3: ADR lifecycle — mechanical operation helpers

### DIFF
--- a/apps/dev/src/core/adr-operations.ts
+++ b/apps/dev/src/core/adr-operations.ts
@@ -26,8 +26,10 @@ export interface ArchiveMoveInput extends StatusAndSuccessorInput {
 export interface ArchiveMovePlan {
   from: string;
   to: string;
+  originalAdrText: string;
   adrText: string;
   indexPath: string;
+  originalIndexText: string;
   indexText: string;
 }
 
@@ -54,6 +56,8 @@ export interface AdrOperationIo {
 
 /** Set an ADR's terminal status and successor pointer without editing its Decision. */
 export function planStatusAndSuccessor(input: StatusAndSuccessorInput): AdrTextPlan {
+  const invalidSuccessor = input.successors.find((number) => !/^\d{4}$/.test(number));
+  if (invalidSuccessor) throw new Error(`Invalid ADR successor: ${invalidSuccessor}`);
   const successor = input.successors[0];
   if (!successor && input.status !== "inert") {
     throw new Error(`A ${input.status} ADR must name a successor`);
@@ -66,22 +70,30 @@ export function planStatusAndSuccessor(input: StatusAndSuccessorInput): AdrTextP
       : `Superseded by ADR ${successor}.`;
   const pointer = input.successors.length > 0 ? input.successors.join(", ") : "none (inert)";
 
-  const status = [
-    "## Status",
-    "",
-    statusLine,
-    "",
-    `superseded-by: ${pointer}`,
-    "",
-    "",
-  ].join("\n");
+  const pointerLine = `superseded-by: ${pointer}`;
+  const status = ["## Status", "", statusLine, "", pointerLine, "", ""].join("\n");
   const heading = /^##\s+Status\s*$/m.exec(input.text);
   let text: string;
   if (heading) {
     const bodyStart = heading.index + heading[0].length;
     const nextHeading = /^##\s+/m.exec(input.text.slice(bodyStart));
     const sectionEnd = nextHeading ? bodyStart + nextHeading.index : input.text.length;
-    text = input.text.slice(0, heading.index) + status + input.text.slice(sectionEnd);
+    const originalBody = input.text.slice(bodyStart, sectionEnd);
+    const declaration = /^([ \t]*)(\S.*)$/m.exec(originalBody);
+    if (!declaration) throw new Error(`ADR Status has no declaration: ${input.path}`);
+    const declarationStart = declaration.index + declaration[1]!.length;
+    let body = originalBody.slice(0, declarationStart)
+      + statusLine
+      + originalBody.slice(declarationStart + declaration[2]!.length);
+    const existingPointer = /^[ \t]*superseded-by:.*$/m.exec(body);
+    if (existingPointer) {
+      body = body.slice(0, existingPointer.index) + pointerLine + body.slice(existingPointer.index + existingPointer[0].length);
+    } else {
+      body = body.slice(0, declarationStart + statusLine.length)
+        + `\n\n${pointerLine}`
+        + body.slice(declarationStart + statusLine.length);
+    }
+    text = input.text.slice(0, bodyStart) + body + input.text.slice(sectionEnd);
   } else {
     const title = /^#\s+.+$/m.exec(input.text);
     if (!title) throw new Error(`ADR has no title: ${input.path}`);
@@ -147,17 +159,36 @@ export function planArchiveMove(input: ArchiveMoveInput): ArchiveMovePlan {
   return {
     from: input.path,
     to: `.red/adr/archive/${file}`,
+    originalAdrText: input.text,
     adrText: status.text,
     indexPath: index.path,
+    originalIndexText: input.indexText,
     indexText: index.text,
   };
 }
 
 /** Apply an archive plan with a real git move between the two planned writes. */
 export async function applyArchiveMove(plan: ArchiveMovePlan, io: AdrOperationIo): Promise<void> {
-  await io.fs.writeFile(plan.from, plan.adrText);
-  await io.git.mv(plan.from, plan.to);
-  await io.fs.writeFile(plan.indexPath, plan.indexText);
+  try {
+    await io.fs.writeFile(plan.from, plan.adrText);
+  } catch (error) {
+    await io.fs.writeFile(plan.from, plan.originalAdrText);
+    throw error;
+  }
+  try {
+    await io.git.mv(plan.from, plan.to);
+  } catch (error) {
+    await io.fs.writeFile(plan.from, plan.originalAdrText);
+    throw error;
+  }
+  try {
+    await io.fs.writeFile(plan.indexPath, plan.indexText);
+  } catch (error) {
+    await io.fs.writeFile(plan.indexPath, plan.originalIndexText);
+    await io.git.mv(plan.to, plan.from);
+    await io.fs.writeFile(plan.from, plan.originalAdrText);
+    throw error;
+  }
 }
 
 /** Replace a backticked stale path outside `## Decision`, recording why it moved. */

--- a/apps/dev/src/core/adr-operations.ts
+++ b/apps/dev/src/core/adr-operations.ts
@@ -1,0 +1,191 @@
+/** Pure planners and injected IO shells for ADR 0112 lifecycle operations. */
+
+export interface StatusAndSuccessorInput {
+  path: string;
+  text: string;
+  status: "superseded" | "deprecated" | "inert";
+  successors: readonly string[];
+}
+
+export interface AdrTextPlan {
+  path: string;
+  text: string;
+}
+
+export interface IndexArchiveInput {
+  path: string;
+  text: string;
+  number: string;
+}
+
+export interface ArchiveMoveInput extends StatusAndSuccessorInput {
+  indexPath: string;
+  indexText: string;
+}
+
+export interface ArchiveMovePlan {
+  from: string;
+  to: string;
+  adrText: string;
+  indexPath: string;
+  indexText: string;
+}
+
+export interface StalePathFixInput {
+  path: string;
+  text: string;
+  stalePath: string;
+  replacementPath: string;
+  note: string;
+}
+
+export interface AdrOperationFs {
+  writeFile(path: string, text: string): Promise<void>;
+}
+
+export interface AdrOperationGit {
+  mv(from: string, to: string): Promise<void>;
+}
+
+export interface AdrOperationIo {
+  fs: AdrOperationFs;
+  git: AdrOperationGit;
+}
+
+/** Set an ADR's terminal status and successor pointer without editing its Decision. */
+export function planStatusAndSuccessor(input: StatusAndSuccessorInput): AdrTextPlan {
+  const successor = input.successors[0];
+  if (!successor && input.status !== "inert") {
+    throw new Error(`A ${input.status} ADR must name a successor`);
+  }
+
+  const statusLine = input.status === "inert"
+    ? "Inert — fully shipped, no longer guidance."
+    : input.status === "deprecated"
+      ? `Deprecated; superseded by ADR ${successor}.`
+      : `Superseded by ADR ${successor}.`;
+  const pointer = input.successors.length > 0 ? input.successors.join(", ") : "none (inert)";
+
+  const status = [
+    "## Status",
+    "",
+    statusLine,
+    "",
+    `superseded-by: ${pointer}`,
+    "",
+    "",
+  ].join("\n");
+  const heading = /^##\s+Status\s*$/m.exec(input.text);
+  let text: string;
+  if (heading) {
+    const bodyStart = heading.index + heading[0].length;
+    const nextHeading = /^##\s+/m.exec(input.text.slice(bodyStart));
+    const sectionEnd = nextHeading ? bodyStart + nextHeading.index : input.text.length;
+    text = input.text.slice(0, heading.index) + status + input.text.slice(sectionEnd);
+  } else {
+    const title = /^#\s+.+$/m.exec(input.text);
+    if (!title) throw new Error(`ADR has no title: ${input.path}`);
+    const titleEnd = title.index + title[0].length;
+    text = input.text.slice(0, titleEnd)
+      + "\n\n"
+      + status
+      + input.text.slice(titleEnd).replace(/^\n+/, "");
+  }
+  return { path: input.path, text };
+}
+
+/** Apply a planned status edit through an injected filesystem. */
+export async function applyStatusAndSuccessor(
+  plan: AdrTextPlan,
+  fs: AdrOperationFs,
+): Promise<void> {
+  await fs.writeFile(plan.path, plan.text);
+}
+
+/** Move one ADR's existing INDEX bullet into the Archived section. */
+export function planIndexArchive(input: IndexArchiveInput): AdrTextPlan {
+  if (!/^\d{4}$/.test(input.number)) throw new Error(`Invalid ADR number: ${input.number}`);
+  const lines = input.text.split("\n");
+  const bulletIndex = lines.findIndex((line) => new RegExp(`^- \\*\\*${input.number}\\*\\*`).test(line));
+  if (bulletIndex < 0) throw new Error(`ADR ${input.number} has no INDEX bullet`);
+  const [bullet] = lines.splice(bulletIndex, 1);
+
+  const archivedStart = lines.findIndex((line) => /^## Archived\s*$/.test(line));
+  if (archivedStart < 0) throw new Error("ADR INDEX has no Archived section");
+  const nextHeadingOffset = lines.slice(archivedStart + 1).findIndex((line) => /^##\s+/.test(line));
+  const archivedEnd = nextHeadingOffset < 0 ? lines.length : archivedStart + 1 + nextHeadingOffset;
+  const empty = "_The archive is empty — no ADR has been retired yet._";
+  const emptyIndex = lines.findIndex((line, index) => index > archivedStart && index < archivedEnd && line === empty);
+  if (emptyIndex >= 0) {
+    lines[emptyIndex] = bullet!;
+  } else {
+    const archivedBullets = lines
+      .map((line, index) => ({ line, index }))
+      .filter(({ line, index }) => index > archivedStart && index < archivedEnd && /^- \*\*\d{4}\*\*/.test(line));
+    const insertAt = archivedBullets.at(-1)?.index;
+    lines.splice(insertAt === undefined ? archivedEnd : insertAt + 1, 0, bullet!);
+  }
+  return { path: input.path, text: lines.join("\n") };
+}
+
+/** Apply a planned INDEX resync through an injected filesystem. */
+export async function applyIndexArchive(plan: AdrTextPlan, fs: AdrOperationFs): Promise<void> {
+  await fs.writeFile(plan.path, plan.text);
+}
+
+/** Plan the status, history-preserving archive path, and INDEX change together. */
+export function planArchiveMove(input: ArchiveMoveInput): ArchiveMovePlan {
+  const match = input.path.match(/^\.red\/adr\/(\d{4}-.+\.md)$/);
+  if (!match) throw new Error(`ADR is not in the active lane: ${input.path}`);
+  const file = match[1]!;
+  const status = planStatusAndSuccessor(input);
+  const index = planIndexArchive({
+    path: input.indexPath,
+    text: input.indexText,
+    number: file.slice(0, 4),
+  });
+  return {
+    from: input.path,
+    to: `.red/adr/archive/${file}`,
+    adrText: status.text,
+    indexPath: index.path,
+    indexText: index.text,
+  };
+}
+
+/** Apply an archive plan with a real git move between the two planned writes. */
+export async function applyArchiveMove(plan: ArchiveMovePlan, io: AdrOperationIo): Promise<void> {
+  await io.fs.writeFile(plan.from, plan.adrText);
+  await io.git.mv(plan.from, plan.to);
+  await io.fs.writeFile(plan.indexPath, plan.indexText);
+}
+
+/** Replace a backticked stale path outside `## Decision`, recording why it moved. */
+export function planStalePathFix(input: StalePathFixInput): AdrTextPlan {
+  const heading = /^##\s+Decisions?\s*$/m.exec(input.text);
+  const replace = (text: string): string =>
+    text.replaceAll(
+      `\`${input.stalePath}\``,
+      `\`${input.replacementPath}\` *(stale-path note: ${input.note})*`,
+    );
+
+  let text: string;
+  if (!heading) {
+    text = replace(input.text);
+  } else {
+    const bodyStart = heading.index + heading[0].length;
+    const nextHeading = /^##\s+/m.exec(input.text.slice(bodyStart));
+    const bodyEnd = nextHeading ? bodyStart + nextHeading.index : input.text.length;
+    text = replace(input.text.slice(0, heading.index))
+      + input.text.slice(heading.index, bodyEnd)
+      + replace(input.text.slice(bodyEnd));
+  }
+
+  if (text === input.text) throw new Error(`No editable stale-path occurrence: ${input.stalePath}`);
+  return { path: input.path, text };
+}
+
+/** Apply a planned stale-path prose repair through an injected filesystem. */
+export async function applyStalePathFix(plan: AdrTextPlan, fs: AdrOperationFs): Promise<void> {
+  await fs.writeFile(plan.path, plan.text);
+}

--- a/apps/dev/tests/adr-operations.test.ts
+++ b/apps/dev/tests/adr-operations.test.ts
@@ -109,6 +109,39 @@ describe("planStatusAndSuccessor", () => {
     expect(decision(plan.text)).toBe(decision(compact));
   });
 
+  it("preserves compact ADR history and related links inside Status", () => {
+    const compact = ADR.replace(
+      "Accepted.",
+      "Accepted.\n\nShipped incrementally after the original rollout.\n\nRelated: ADR 0001 and issue #42.",
+    );
+    const plan = planStatusAndSuccessor({
+      path: ".red/adr/0002-retired.md",
+      text: compact,
+      status: "superseded",
+      successors: ["0113"],
+    });
+
+    expect(plan.text).toBe(compact.replace(
+      "Accepted.",
+      "Superseded by ADR 0113.\n\nsuperseded-by: 0113",
+    ));
+    expect(plan.text).toContain("Shipped incrementally after the original rollout.");
+    expect(plan.text).toContain("Related: ADR 0001 and issue #42.");
+    expect(decision(plan.text)).toBe(decision(compact));
+  });
+
+  it.each([
+    ["a non-numeric successor", ["next"]],
+    ["an invalid later successor", ["0113", "next"]],
+  ])("rejects %s", (_case, successors) => {
+    expect(() => planStatusAndSuccessor({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      status: "superseded",
+      successors,
+    })).toThrow("Invalid ADR successor: next");
+  });
+
   it("applies the planned ADR text through the injected filesystem", async () => {
     const writes: Array<[string, string]> = [];
     const plan = planStatusAndSuccessor({
@@ -190,11 +223,13 @@ describe("planArchiveMove", () => {
     expect(plan).toEqual({
       from: ".red/adr/0002-retired.md",
       to: ".red/adr/archive/0002-retired.md",
+      originalAdrText: ADR,
       adrText: ADR.replace(
         "## Status\n\nAccepted.",
         "## Status\n\nSuperseded by ADR 0113.\n\nsuperseded-by: 0113",
       ),
       indexPath: ".red/adr/INDEX.md",
+      originalIndexText: INDEX,
       indexText: INDEX.replace("- **0002** Retired decision\n", "").replace(
         "_The archive is empty — no ADR has been retired yet._",
         "- **0002** Retired decision",
@@ -231,6 +266,108 @@ describe("planArchiveMove", () => {
       "write:.red/adr/0002-retired.md:adr",
       "git-mv:.red/adr/0002-retired.md:.red/adr/archive/0002-retired.md",
       "write:.red/adr/INDEX.md:index",
+    ]);
+  });
+
+  it("restores the original ADR when the terminal metadata write fails", async () => {
+    const events: string[] = [];
+    const plan = planArchiveMove({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      indexPath: ".red/adr/INDEX.md",
+      indexText: INDEX,
+      status: "superseded",
+      successors: ["0113"],
+    });
+    let writes = 0;
+
+    await expect(applyArchiveMove(plan, {
+      fs: {
+        writeFile: async (path, text) => {
+          events.push(`write:${path}:${text === ADR ? "original" : "planned"}`);
+          if (writes++ === 0) throw new Error("ADR write failed");
+        },
+      },
+      git: {
+        mv: async (from, to) => {
+          events.push(`git-mv:${from}:${to}`);
+        },
+      },
+    })).rejects.toThrow("ADR write failed");
+
+    expect(events).toEqual([
+      "write:.red/adr/0002-retired.md:planned",
+      "write:.red/adr/0002-retired.md:original",
+    ]);
+  });
+
+  it("restores the original ADR when git mv fails", async () => {
+    const events: string[] = [];
+    const plan = planArchiveMove({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      indexPath: ".red/adr/INDEX.md",
+      indexText: INDEX,
+      status: "superseded",
+      successors: ["0113"],
+    });
+
+    await expect(applyArchiveMove(plan, {
+      fs: {
+        writeFile: async (path, text) => {
+          events.push(`write:${path}:${text === ADR ? "original" : "planned"}`);
+        },
+      },
+      git: {
+        mv: async (from, to) => {
+          events.push(`git-mv:${from}:${to}`);
+          throw new Error("git mv failed");
+        },
+      },
+    })).rejects.toThrow("git mv failed");
+
+    expect(events).toEqual([
+      "write:.red/adr/0002-retired.md:planned",
+      "git-mv:.red/adr/0002-retired.md:.red/adr/archive/0002-retired.md",
+      "write:.red/adr/0002-retired.md:original",
+    ]);
+  });
+
+  it("restores the INDEX, move, and ADR when the INDEX write fails", async () => {
+    const events: string[] = [];
+    const plan = planArchiveMove({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      indexPath: ".red/adr/INDEX.md",
+      indexText: INDEX,
+      status: "superseded",
+      successors: ["0113"],
+    });
+
+    await expect(applyArchiveMove(plan, {
+      fs: {
+        writeFile: async (path, text) => {
+          const version = text === ADR || text === INDEX ? "original" : "planned";
+          events.push(`write:${path}:${version}`);
+          if (path === plan.indexPath && text === plan.indexText) {
+            throw new Error("INDEX write failed");
+          }
+        },
+      },
+      git: {
+        mv: async (from, to) => {
+          events.push(`git-mv:${from}:${to}`);
+        },
+      },
+    })).rejects.toThrow("INDEX write failed");
+
+    expect(events).toEqual([
+      "write:.red/adr/0002-retired.md:planned",
+      "git-mv:.red/adr/0002-retired.md:.red/adr/archive/0002-retired.md",
+      "write:.red/adr/INDEX.md:planned",
+      "write:.red/adr/INDEX.md:original",
+      "git-mv:.red/adr/archive/0002-retired.md:.red/adr/0002-retired.md",
+      "write:.red/adr/0002-retired.md:original",
     ]);
   });
 });

--- a/apps/dev/tests/adr-operations.test.ts
+++ b/apps/dev/tests/adr-operations.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyArchiveMove,
+  applyIndexArchive,
+  applyStalePathFix,
+  applyStatusAndSuccessor,
+  planArchiveMove,
+  planIndexArchive,
+  planStalePathFix,
+  planStatusAndSuccessor,
+} from "../src/core/adr-operations.js";
+
+const ADR = [
+  "# Retired decision",
+  "",
+  "## Status",
+  "",
+  "Accepted.",
+  "",
+  "## Context",
+  "",
+  "The old runtime lives at `apps/old/runtime.ts`.",
+  "",
+  "## Decision",
+  "",
+  "Keep `apps/old/runtime.ts` as the canonical runtime.",
+  "",
+  "## Consequences",
+  "",
+  "Callers use the old runtime.",
+  "",
+].join("\n");
+
+const INDEX = [
+  "# ADR Index",
+  "",
+  "## Active",
+  "",
+  "- **0001** Live decision",
+  "- **0002** Retired decision",
+  "",
+  "## Archived",
+  "",
+  "Retired records stay documented here.",
+  "",
+  "_The archive is empty — no ADR has been retired yet._",
+  "",
+].join("\n");
+
+function decision(text: string): string {
+  return text.match(/^## Decision\s*$([\s\S]*?)(?=^##\s|$(?![\s\S]))/m)?.[1] ?? "";
+}
+
+describe("planStatusAndSuccessor", () => {
+  it("sets a terminal status and successor pointer without changing the Decision", () => {
+    const plan = planStatusAndSuccessor({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      status: "superseded",
+      successors: ["0113"],
+    });
+
+    expect(plan).toEqual({
+      path: ".red/adr/0002-retired.md",
+      text: ADR.replace(
+        "## Status\n\nAccepted.",
+        "## Status\n\nSuperseded by ADR 0113.\n\nsuperseded-by: 0113",
+      ),
+    });
+    expect(decision(plan.text)).toBe(decision(ADR));
+  });
+
+  it.each([
+    {
+      status: "deprecated" as const,
+      successors: ["0113"],
+      rendered: "Deprecated; superseded by ADR 0113.\n\nsuperseded-by: 0113",
+    },
+    {
+      status: "inert" as const,
+      successors: [],
+      rendered: "Inert — fully shipped, no longer guidance.\n\nsuperseded-by: none (inert)",
+    },
+  ])("renders the $status terminal status and governance pointer", ({ status, successors, rendered }) => {
+    const plan = planStatusAndSuccessor({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      status,
+      successors,
+    });
+
+    expect(plan.text).toBe(ADR.replace("## Status\n\nAccepted.", `## Status\n\n${rendered}`));
+    expect(decision(plan.text)).toBe(decision(ADR));
+  });
+
+  it("adds Status frontmatter when a compact ADR has none", () => {
+    const compact = ADR.replace("\n## Status\n\nAccepted.\n", "");
+    const plan = planStatusAndSuccessor({
+      path: ".red/adr/0002-retired.md",
+      text: compact,
+      status: "superseded",
+      successors: ["0113"],
+    });
+
+    expect(plan.text).toBe(compact.replace(
+      "# Retired decision\n",
+      "# Retired decision\n\n## Status\n\nSuperseded by ADR 0113.\n\nsuperseded-by: 0113\n",
+    ));
+    expect(decision(plan.text)).toBe(decision(compact));
+  });
+
+  it("applies the planned ADR text through the injected filesystem", async () => {
+    const writes: Array<[string, string]> = [];
+    const plan = planStatusAndSuccessor({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      status: "superseded",
+      successors: ["0113"],
+    });
+
+    await applyStatusAndSuccessor(plan, {
+      writeFile: async (path, text) => {
+        writes.push([path, text]);
+      },
+    });
+
+    expect(writes).toEqual([[plan.path, plan.text]]);
+  });
+});
+
+describe("planIndexArchive", () => {
+  it("moves the ADR bullet into Archived without changing its text", () => {
+    const plan = planIndexArchive({
+      path: ".red/adr/INDEX.md",
+      text: INDEX,
+      number: "0002",
+    });
+
+    expect(plan).toEqual({
+      path: ".red/adr/INDEX.md",
+      text: INDEX.replace("- **0002** Retired decision\n", "").replace(
+        "_The archive is empty — no ADR has been retired yet._",
+        "- **0002** Retired decision",
+      ),
+    });
+  });
+
+  it("appends the moved bullet when Archived already contains records", () => {
+    const nonEmpty = INDEX.replace(
+      "_The archive is empty — no ADR has been retired yet._",
+      "- **0003** Previously retired decision",
+    );
+    const plan = planIndexArchive({ path: ".red/adr/INDEX.md", text: nonEmpty, number: "0002" });
+
+    expect(plan.text).toBe(
+      nonEmpty
+        .replace("- **0002** Retired decision\n", "")
+        .replace(
+          "- **0003** Previously retired decision",
+          "- **0003** Previously retired decision\n- **0002** Retired decision",
+        ),
+    );
+  });
+
+  it("applies the INDEX resync through the injected filesystem", async () => {
+    const writes: Array<[string, string]> = [];
+    const plan = planIndexArchive({ path: ".red/adr/INDEX.md", text: INDEX, number: "0002" });
+
+    await applyIndexArchive(plan, {
+      writeFile: async (path, text) => {
+        writes.push([path, text]);
+      },
+    });
+
+    expect(writes).toEqual([[plan.path, plan.text]]);
+  });
+});
+
+describe("planArchiveMove", () => {
+  it("plans a terminal ADR move and INDEX resync as one reversible change", () => {
+    const plan = planArchiveMove({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      indexPath: ".red/adr/INDEX.md",
+      indexText: INDEX,
+      status: "superseded",
+      successors: ["0113"],
+    });
+
+    expect(plan).toEqual({
+      from: ".red/adr/0002-retired.md",
+      to: ".red/adr/archive/0002-retired.md",
+      adrText: ADR.replace(
+        "## Status\n\nAccepted.",
+        "## Status\n\nSuperseded by ADR 0113.\n\nsuperseded-by: 0113",
+      ),
+      indexPath: ".red/adr/INDEX.md",
+      indexText: INDEX.replace("- **0002** Retired decision\n", "").replace(
+        "_The archive is empty — no ADR has been retired yet._",
+        "- **0002** Retired decision",
+      ),
+    });
+    expect(decision(plan.adrText)).toBe(decision(ADR));
+  });
+
+  it("writes terminal metadata, uses git mv, then writes the resynced INDEX", async () => {
+    const events: string[] = [];
+    const plan = planArchiveMove({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      indexPath: ".red/adr/INDEX.md",
+      indexText: INDEX,
+      status: "superseded",
+      successors: ["0113"],
+    });
+
+    await applyArchiveMove(plan, {
+      fs: {
+        writeFile: async (path, text) => {
+          events.push(`write:${path}:${text === plan.adrText ? "adr" : "index"}`);
+        },
+      },
+      git: {
+        mv: async (from, to) => {
+          events.push(`git-mv:${from}:${to}`);
+        },
+      },
+    });
+
+    expect(events).toEqual([
+      "write:.red/adr/0002-retired.md:adr",
+      "git-mv:.red/adr/0002-retired.md:.red/adr/archive/0002-retired.md",
+      "write:.red/adr/INDEX.md:index",
+    ]);
+  });
+});
+
+describe("planStalePathFix", () => {
+  it("replaces stale prose with a note while leaving the Decision occurrence intact", () => {
+    const plan = planStalePathFix({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      stalePath: "apps/old/runtime.ts",
+      replacementPath: "apps/new/runtime.ts",
+      note: "moved in ADR 0113",
+    });
+
+    expect(plan).toEqual({
+      path: ".red/adr/0002-retired.md",
+      text: ADR.replace(
+        "`apps/old/runtime.ts`.",
+        "`apps/new/runtime.ts` *(stale-path note: moved in ADR 0113)*.",
+      ),
+    });
+    expect(decision(plan.text)).toBe(decision(ADR));
+    expect(decision(plan.text)).toContain("`apps/old/runtime.ts`");
+  });
+
+  it("applies the prose repair through the injected filesystem", async () => {
+    const writes: Array<[string, string]> = [];
+    const plan = planStalePathFix({
+      path: ".red/adr/0002-retired.md",
+      text: ADR,
+      stalePath: "apps/old/runtime.ts",
+      replacementPath: "apps/new/runtime.ts",
+      note: "moved in ADR 0113",
+    });
+
+    await applyStalePathFix(plan, {
+      writeFile: async (path, text) => {
+        writes.push([path, text]);
+      },
+    });
+
+    expect(writes).toEqual([[plan.path, plan.text]]);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2222. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2222

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787151674&installation_id=129708444&pr_number=2275&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2275&signature=6f5ece772aa1a4e33dc880aa0a4b870a1d99a6fb09faaa73abb36611ef472b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->