### PR TITLE
fix: #2233 Draft the entry-point drift test that makes castle ownership falsifiable

### DIFF
--- a/apps/dev/tests/castle-entry-point-drift.draft.ts
+++ b/apps/dev/tests/castle-entry-point-drift.draft.ts
@@ -1,0 +1,29 @@
+/**
+ * Intentionally red ownership draft for ADR 0102 / Ticket #2233.
+ *
+ * This file uses a `.draft.ts` suffix, outside Vitest's CI include, while the
+ * migration is in progress. Run it directly with:
+ *
+ *   pnpm --filter @reddb-io/dev exec tsx tests/castle-entry-point-drift.draft.ts
+ *
+ * It becomes green monotonically: every castle relocation removes findings;
+ * no current-tree verb inventory needs to be rewritten along the way.
+ */
+import {
+  currentTreeEngineVerbs,
+  currentTreeFindings,
+  renderFindings,
+} from "./support/castle-entry-point-drift.js";
+
+const findings = currentTreeFindings();
+const retainedVerbs = currentTreeEngineVerbs();
+
+if (findings.length > 0 || retainedVerbs.length > 0) {
+  throw new Error(
+    [
+      `Retained dev orchestration verbs: ${retainedVerbs.join(", ") || "none"}`,
+      "apps/dev/src control flow over castle engine entities:",
+      renderFindings(findings) || "none",
+    ].join("\n"),
+  );
+}

--- a/apps/dev/tests/castle-entry-point-drift.test.ts
+++ b/apps/dev/tests/castle-entry-point-drift.test.ts
@@ -1,200 +1,38 @@
-import { readdirSync, readFileSync } from "node:fs";
-import { dirname, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { inspectSource } from "./support/castle-entry-point-drift.js";
 
-const here = dirname(fileURLToPath(import.meta.url));
-const devSourceRoot = resolve(here, "../src");
+describe("castle entry-point ownership drift scanner", () => {
+  it.each([
+    ["commands/statusline.ts", "statuslineCommand"],
+    ["core/hook-dispatcher.ts", "deriveHookEnv"],
+    ["platform/skill-paths.ts", "skillDirFromModule"],
+  ])(
+    "exempts only the named host boundary in %s",
+    (path, allowedFunction) => {
+      const findings = inspectSource(
+        path,
+        `
+          export function ${allowedFunction}(worker: { ticket: number }) {
+            if (worker.ticket) return "host output";
+          }
 
-/**
- * ADR 0102 leaves these path families in dev because they adapt a host to the
- * castle; they do not own Worker, Ticket, Lane, or PR decisions.
- */
-const HOST_ADAPTER_PATH_EXEMPTIONS = [
-  "cli.ts",
-  "**/*statusline*.ts",
-  "**/*hook*.ts",
-  "**/*skill*.ts",
-  "**/*monitor-agent*.ts",
-  "commands/inject-development-workflow.ts",
-  "core/development-workflow.ts",
-] as const;
+          export function decideWorkerLane(worker: { lane: string }) {
+            if (worker.lane) return "engine decision";
+          }
+        `,
+      );
 
-const ENGINE_VERB_PATHS = {
-  "gate-executor": [
-    "core/backpressure.ts",
-    "core/feedback.ts",
-    "core/shared-gate.ts",
-    "core/trust-gate.ts",
-    "core/process-issue/lifecycle.ts",
-  ],
-  landing: [
-    "core/landing.ts",
-    "core/merge.ts",
-    "core/process-issue/terminal.ts",
-    "commands/run/reconcile.ts",
-  ],
-  config: ["core/config.ts"],
-  "worker-drain": ["commands/run/command.ts", "core/session.ts"],
-} as const;
-
-type EngineEntity = "Worker" | "Ticket" | "Lane" | "PR";
-type EngineVerb = keyof typeof ENGINE_VERB_PATHS;
-
-interface DriftFinding {
-  path: string;
-  line: number;
-  entities: EngineEntity[];
-  verb?: EngineVerb;
-}
-
-const ENTITY_TOKENS: Record<EngineEntity, ReadonlySet<string>> = {
-  Worker: new Set(["worker", "workers", "supervisor", "supervisors", "fleet"]),
-  Ticket: new Set(["ticket", "tickets", "issue", "issues", "candidate", "candidates"]),
-  Lane: new Set(["lane", "lanes", "queue", "queues", "claim", "claims", "lease", "leases"]),
-  PR: new Set([
-    "pr",
-    "prs",
-    "pullrequest",
-    "branch",
-    "branches",
-    "diff",
-    "feedback",
-    "gate",
-    "landing",
-    "merge",
-    "review",
-    "validation",
-  ]),
-};
-
-function sourceFilesUnder(root: string): string[] {
-  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
-    const path = resolve(root, entry.name);
-    if (entry.isDirectory()) return sourceFilesUnder(path);
-    return entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")
-      ? [path]
-      : [];
-  });
-}
-
-function matchesPathPattern(path: string, pattern: string): boolean {
-  if (!pattern.startsWith("**/")) return path === pattern;
-  const basenamePattern = pattern.slice(3).replaceAll(".", "\\.").replaceAll("*", ".*");
-  return new RegExp(`(?:^|/)${basenamePattern}$`).test(path);
-}
-
-function isHostAdapterPath(path: string): boolean {
-  return HOST_ADAPTER_PATH_EXEMPTIONS.some((pattern) => matchesPathPattern(path, pattern));
-}
-
-function engineVerbFor(path: string): EngineVerb | undefined {
-  return (Object.entries(ENGINE_VERB_PATHS) as Array<[EngineVerb, readonly string[]]>).find(
-    ([, paths]) => paths.includes(path),
-  )?.[0];
-}
-
-function controllingNodes(node: ts.Node): readonly ts.Node[] {
-  if (ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)) {
-    return [node.expression];
-  }
-  if (ts.isConditionalExpression(node)) return [node.condition];
-  if (ts.isSwitchStatement(node)) return [node.expression];
-  if (ts.isForInStatement(node) || ts.isForOfStatement(node)) {
-    return [node.initializer, node.expression];
-  }
-  if (ts.isForStatement(node)) {
-    const controls: ts.Node[] = [];
-    if (node.initializer) controls.push(node.initializer);
-    if (node.condition) controls.push(node.condition);
-    if (node.incrementor) controls.push(node.incrementor);
-    return controls;
-  }
-  return [];
-}
-
-function tokensIn(node: ts.Node): Set<string> {
-  const tokens = new Set<string>();
-  const collect = (child: ts.Node): void => {
-    if (ts.isIdentifier(child) || ts.isStringLiteralLike(child)) {
-      const words = child.getText().replaceAll(/["']/g, "").split(/[^a-zA-Z0-9]+|(?=[A-Z])/);
-      for (const word of words) {
-        if (word !== "") tokens.add(word.toLowerCase());
-      }
-    }
-    ts.forEachChild(child, collect);
-  };
-  collect(node);
-  return tokens;
-}
-
-function entitiesIn(nodes: readonly ts.Node[]): EngineEntity[] {
-  const tokens = new Set(nodes.flatMap((node) => [...tokensIn(node)]));
-  return (Object.entries(ENTITY_TOKENS) as Array<[EngineEntity, ReadonlySet<string>]>).flatMap(
-    ([entity, entityTokens]) => [...tokens].some((token) => entityTokens.has(token)) ? [entity] : [],
+      expect(findings).toEqual([
+        {
+          path,
+          line: 7,
+          entities: ["Worker", "Lane"],
+        },
+      ]);
+    },
   );
-}
 
-function inspectSource(path: string, source: string): DriftFinding[] {
-  if (isHostAdapterPath(path)) return [];
-  const sourceFile = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-  const entities = new Set<EngineEntity>();
-  let firstLine: number | undefined;
-  const visit = (node: ts.Node): void => {
-    const controls = controllingNodes(node);
-    const controlledEntities = entitiesIn(controls);
-    if (controlledEntities.length > 0) {
-      firstLine ??= sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
-      for (const entity of controlledEntities) entities.add(entity);
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
-  if (firstLine === undefined) return [];
-  const verb = engineVerbFor(path);
-  return [{ path, line: firstLine, entities: [...entities], ...(verb ? { verb } : {}) }];
-}
-
-let currentTreeFindingCache: DriftFinding[] | undefined;
-
-function currentTreeFindings(): DriftFinding[] {
-  currentTreeFindingCache ??= sourceFilesUnder(devSourceRoot).flatMap((absolutePath) => {
-    const path = relative(devSourceRoot, absolutePath).replaceAll("\\", "/");
-    return inspectSource(path, readFileSync(absolutePath, "utf8"));
-  });
-  return currentTreeFindingCache;
-}
-
-function renderFindings(findings: readonly DriftFinding[]): string {
-  return findings
-    .map((finding) =>
-      `${finding.verb ? `[${finding.verb}] ` : ""}${finding.path}:${finding.line} controls ${finding.entities.join(", ")}`,
-    )
-    .join("\n");
-}
-
-describe("castle entry-point ownership drift", () => {
-  it("ignores the explicit host-adapter path families", () => {
-    const hostAdapterSource = `
-      export function render(worker: { ticket: number; lane: string; pr: number }) {
-        if (worker.ticket && worker.lane && worker.pr) return "host output";
-      }
-    `;
-    const exemptExamples = [
-      "cli.ts",
-      "commands/statusline.ts",
-      "core/hook-dispatcher.ts",
-      "platform/skill-paths.ts",
-      "commands/codex-monitor-agent.ts",
-      "commands/inject-development-workflow.ts",
-      "core/development-workflow.ts",
-    ];
-
-    expect(exemptExamples.flatMap((path) => inspectSource(path, hostAdapterSource))).toEqual([]);
-  });
-
-  it("detects control flow over all four engine entities outside host adapters", () => {
+  it("detects control flow over all four engine entities", () => {
     const findings = inspectSource(
       "core/engine-owner.ts",
       `
@@ -213,13 +51,37 @@ describe("castle entry-point ownership drift", () => {
     ]);
   });
 
-  it("names the four retained orchestration verb families on today's tree", () => {
-    const verbs = [...new Set(currentTreeFindings().flatMap((finding) => finding.verb ?? []))].sort();
+  it.each(["pullRequest", "PullRequest", "pull_request"])(
+    "detects the canonical PR identifier spelling %s",
+    (identifier) => {
+      const findings = inspectSource(
+        "core/engine-owner.ts",
+        `if (${identifier}.open) return "engine decision";`,
+      );
 
-    expect(verbs).toEqual(["config", "gate-executor", "landing", "worker-drain"]);
+      expect(findings[0]?.entities).toContain("PR");
+    },
+  );
+
+  it("does not mistake adjacent orchestration vocabulary for an engine entity", () => {
+    const findings = inspectSource(
+      "core/host-output.ts",
+      `
+        if (candidate.review && validation.diff && feedback.gate) {
+          return "host output";
+        }
+      `,
+    );
+
+    expect(findings).toEqual([]);
   });
 
-  it.fails("has no dev-local control flow over Worker, Ticket, Lane, or PR entities", () => {
-    expect(renderFindings(currentTreeFindings())).toBe("");
+  it.each([
+    ["core/feedback.ts", "gate-executor"],
+    ["core/landing.ts", "landing"],
+    ["core/config.ts", "config"],
+    ["commands/run/command.ts", "worker-drain"],
+  ])("labels a finding in %s with the %s verb", (path, verb) => {
+    expect(inspectSource(path, "if (worker.ticket) return;")[0]?.verb).toBe(verb);
   });
 });

--- a/apps/dev/tests/castle-entry-point-drift.test.ts
+++ b/apps/dev/tests/castle-entry-point-drift.test.ts
@@ -1,0 +1,225 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const devSourceRoot = resolve(here, "../src");
+
+/**
+ * ADR 0102 leaves these path families in dev because they adapt a host to the
+ * castle; they do not own Worker, Ticket, Lane, or PR decisions.
+ */
+const HOST_ADAPTER_PATH_EXEMPTIONS = [
+  "cli.ts",
+  "**/*statusline*.ts",
+  "**/*hook*.ts",
+  "**/*skill*.ts",
+  "**/*monitor-agent*.ts",
+  "commands/inject-development-workflow.ts",
+  "core/development-workflow.ts",
+] as const;
+
+const ENGINE_VERB_PATHS = {
+  "gate-executor": [
+    "core/backpressure.ts",
+    "core/feedback.ts",
+    "core/shared-gate.ts",
+    "core/trust-gate.ts",
+    "core/process-issue/lifecycle.ts",
+  ],
+  landing: [
+    "core/landing.ts",
+    "core/merge.ts",
+    "core/process-issue/terminal.ts",
+    "commands/run/reconcile.ts",
+  ],
+  config: ["core/config.ts"],
+  "worker-drain": ["commands/run/command.ts", "core/session.ts"],
+} as const;
+
+type EngineEntity = "Worker" | "Ticket" | "Lane" | "PR";
+type EngineVerb = keyof typeof ENGINE_VERB_PATHS;
+
+interface DriftFinding {
+  path: string;
+  line: number;
+  entities: EngineEntity[];
+  verb?: EngineVerb;
+}
+
+const ENTITY_TOKENS: Record<EngineEntity, ReadonlySet<string>> = {
+  Worker: new Set(["worker", "workers", "supervisor", "supervisors", "fleet"]),
+  Ticket: new Set(["ticket", "tickets", "issue", "issues", "candidate", "candidates"]),
+  Lane: new Set(["lane", "lanes", "queue", "queues", "claim", "claims", "lease", "leases"]),
+  PR: new Set([
+    "pr",
+    "prs",
+    "pullrequest",
+    "branch",
+    "branches",
+    "diff",
+    "feedback",
+    "gate",
+    "landing",
+    "merge",
+    "review",
+    "validation",
+  ]),
+};
+
+function sourceFilesUnder(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(root, entry.name);
+    if (entry.isDirectory()) return sourceFilesUnder(path);
+    return entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")
+      ? [path]
+      : [];
+  });
+}
+
+function matchesPathPattern(path: string, pattern: string): boolean {
+  if (!pattern.startsWith("**/")) return path === pattern;
+  const basenamePattern = pattern.slice(3).replaceAll(".", "\\.").replaceAll("*", ".*");
+  return new RegExp(`(?:^|/)${basenamePattern}$`).test(path);
+}
+
+function isHostAdapterPath(path: string): boolean {
+  return HOST_ADAPTER_PATH_EXEMPTIONS.some((pattern) => matchesPathPattern(path, pattern));
+}
+
+function engineVerbFor(path: string): EngineVerb | undefined {
+  return (Object.entries(ENGINE_VERB_PATHS) as Array<[EngineVerb, readonly string[]]>).find(
+    ([, paths]) => paths.includes(path),
+  )?.[0];
+}
+
+function controllingNodes(node: ts.Node): readonly ts.Node[] {
+  if (ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)) {
+    return [node.expression];
+  }
+  if (ts.isConditionalExpression(node)) return [node.condition];
+  if (ts.isSwitchStatement(node)) return [node.expression];
+  if (ts.isForInStatement(node) || ts.isForOfStatement(node)) {
+    return [node.initializer, node.expression];
+  }
+  if (ts.isForStatement(node)) {
+    const controls: ts.Node[] = [];
+    if (node.initializer) controls.push(node.initializer);
+    if (node.condition) controls.push(node.condition);
+    if (node.incrementor) controls.push(node.incrementor);
+    return controls;
+  }
+  return [];
+}
+
+function tokensIn(node: ts.Node): Set<string> {
+  const tokens = new Set<string>();
+  const collect = (child: ts.Node): void => {
+    if (ts.isIdentifier(child) || ts.isStringLiteralLike(child)) {
+      const words = child.getText().replaceAll(/["']/g, "").split(/[^a-zA-Z0-9]+|(?=[A-Z])/);
+      for (const word of words) {
+        if (word !== "") tokens.add(word.toLowerCase());
+      }
+    }
+    ts.forEachChild(child, collect);
+  };
+  collect(node);
+  return tokens;
+}
+
+function entitiesIn(nodes: readonly ts.Node[]): EngineEntity[] {
+  const tokens = new Set(nodes.flatMap((node) => [...tokensIn(node)]));
+  return (Object.entries(ENTITY_TOKENS) as Array<[EngineEntity, ReadonlySet<string>]>).flatMap(
+    ([entity, entityTokens]) => [...tokens].some((token) => entityTokens.has(token)) ? [entity] : [],
+  );
+}
+
+function inspectSource(path: string, source: string): DriftFinding[] {
+  if (isHostAdapterPath(path)) return [];
+  const sourceFile = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const entities = new Set<EngineEntity>();
+  let firstLine: number | undefined;
+  const visit = (node: ts.Node): void => {
+    const controls = controllingNodes(node);
+    const controlledEntities = entitiesIn(controls);
+    if (controlledEntities.length > 0) {
+      firstLine ??= sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+      for (const entity of controlledEntities) entities.add(entity);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (firstLine === undefined) return [];
+  const verb = engineVerbFor(path);
+  return [{ path, line: firstLine, entities: [...entities], ...(verb ? { verb } : {}) }];
+}
+
+let currentTreeFindingCache: DriftFinding[] | undefined;
+
+function currentTreeFindings(): DriftFinding[] {
+  currentTreeFindingCache ??= sourceFilesUnder(devSourceRoot).flatMap((absolutePath) => {
+    const path = relative(devSourceRoot, absolutePath).replaceAll("\\", "/");
+    return inspectSource(path, readFileSync(absolutePath, "utf8"));
+  });
+  return currentTreeFindingCache;
+}
+
+function renderFindings(findings: readonly DriftFinding[]): string {
+  return findings
+    .map((finding) =>
+      `${finding.verb ? `[${finding.verb}] ` : ""}${finding.path}:${finding.line} controls ${finding.entities.join(", ")}`,
+    )
+    .join("\n");
+}
+
+describe("castle entry-point ownership drift", () => {
+  it("ignores the explicit host-adapter path families", () => {
+    const hostAdapterSource = `
+      export function render(worker: { ticket: number; lane: string; pr: number }) {
+        if (worker.ticket && worker.lane && worker.pr) return "host output";
+      }
+    `;
+    const exemptExamples = [
+      "cli.ts",
+      "commands/statusline.ts",
+      "core/hook-dispatcher.ts",
+      "platform/skill-paths.ts",
+      "commands/codex-monitor-agent.ts",
+      "commands/inject-development-workflow.ts",
+      "core/development-workflow.ts",
+    ];
+
+    expect(exemptExamples.flatMap((path) => inspectSource(path, hostAdapterSource))).toEqual([]);
+  });
+
+  it("detects control flow over all four engine entities outside host adapters", () => {
+    const findings = inspectSource(
+      "core/engine-owner.ts",
+      `
+        export function decide(worker: { ticket: number; lane: string; pr: number }) {
+          if (worker.ticket && worker.lane && worker.pr) return "engine decision";
+        }
+      `,
+    );
+
+    expect(findings).toEqual([
+      {
+        path: "core/engine-owner.ts",
+        line: 3,
+        entities: ["Worker", "Ticket", "Lane", "PR"],
+      },
+    ]);
+  });
+
+  it("names the four retained orchestration verb families on today's tree", () => {
+    const verbs = [...new Set(currentTreeFindings().flatMap((finding) => finding.verb ?? []))].sort();
+
+    expect(verbs).toEqual(["config", "gate-executor", "landing", "worker-drain"]);
+  });
+
+  it.fails("has no dev-local control flow over Worker, Ticket, Lane, or PR entities", () => {
+    expect(renderFindings(currentTreeFindings())).toBe("");
+  });
+});

--- a/apps/dev/tests/support/castle-entry-point-drift.ts
+++ b/apps/dev/tests/support/castle-entry-point-drift.ts
@@ -1,0 +1,255 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const devSourceRoot = resolve(here, "../../src");
+
+/**
+ * Known host-facing functions whose control flow renders or wires castle data.
+ * The exemption is deliberately scoped to named functions, never whole files.
+ */
+const HOST_ADAPTER_BOUNDARIES = [
+  {
+    path: "commands/statusline.ts",
+    functions: ["resolveProject", "statuslineCommand"],
+  },
+  {
+    path: "core/statusline-style.ts",
+    functions: [
+      "projectContent",
+      "repoCountsKv",
+      "renderHeaderLine",
+      "workerCells",
+      "colorWorkerCell",
+      "renderWorkerLine",
+    ],
+  },
+  {
+    path: "core/statusline.ts",
+    functions: [
+      "renderProjectBlock",
+      "afkTokens",
+      "renderRepoBlock",
+      "renderShortRepoBlock",
+      "renderFleetBlock",
+      "renderStatuslineWithPreset",
+    ],
+  },
+  {
+    path: "runtime/wire/statusline-cache.ts",
+    functions: ["inferGitHubRepoSlug", "applyStatuslineCountCacheLabelDelta"],
+  },
+  {
+    path: "runtime/wire/statusline.ts",
+    functions: ["collectStatuslineAfk", "collectStatuslineFleet"],
+  },
+  {
+    path: "core/fleet-hook-dispatcher.ts",
+    functions: ["deriveFleetHookEnv"],
+  },
+  {
+    path: "core/hook-config.ts",
+    functions: ["compareFilenames"],
+  },
+  {
+    path: "core/hook-dispatcher.ts",
+    functions: ["deriveHookEnv"],
+  },
+  {
+    path: "platform/skill-paths.ts",
+    functions: ["skillDirFromModule"],
+  },
+  {
+    path: "commands/codex-monitor-agent.ts",
+    functions: ["parseMode"],
+  },
+  {
+    path: "core/codex-monitor-agent.ts",
+    functions: ["decideCodexMonitorAgent"],
+  },
+] as const;
+
+const ENGINE_VERB_PATHS = {
+  "gate-executor": [
+    "core/backpressure.ts",
+    "core/feedback.ts",
+    "core/shared-gate.ts",
+    "core/trust-gate.ts",
+    "core/process-issue/lifecycle.ts",
+  ],
+  landing: [
+    "core/landing.ts",
+    "core/merge.ts",
+    "core/process-issue/terminal.ts",
+    "commands/run/reconcile.ts",
+  ],
+  config: ["core/config.ts"],
+  "worker-drain": ["commands/run/command.ts", "core/session.ts"],
+} as const;
+
+export type EngineEntity = "Worker" | "Ticket" | "Lane" | "PR";
+export type EngineVerb = keyof typeof ENGINE_VERB_PATHS;
+
+export interface DriftFinding {
+  path: string;
+  line: number;
+  entities: EngineEntity[];
+  verb?: EngineVerb;
+}
+
+const ENTITY_TOKENS: Record<EngineEntity, ReadonlySet<string>> = {
+  Worker: new Set(["worker", "workers", "supervisor", "supervisors", "fleet"]),
+  Ticket: new Set(["ticket", "tickets", "issue", "issues"]),
+  Lane: new Set(["lane", "lanes", "queue", "queues", "claim", "claims", "lease", "leases"]),
+  PR: new Set(["pr", "prs", "pullrequest"]),
+};
+
+function sourceFilesUnder(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(root, entry.name);
+    if (entry.isDirectory()) return sourceFilesUnder(path);
+    return entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")
+      ? [path]
+      : [];
+  });
+}
+
+function engineVerbFor(path: string): EngineVerb | undefined {
+  return (Object.entries(ENGINE_VERB_PATHS) as Array<[EngineVerb, readonly string[]]>).find(
+    ([, paths]) => paths.includes(path),
+  )?.[0];
+}
+
+function controllingNodes(node: ts.Node): readonly ts.Node[] {
+  if (ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)) {
+    return [node.expression];
+  }
+  if (ts.isConditionalExpression(node)) return [node.condition];
+  if (ts.isSwitchStatement(node)) return [node.expression];
+  if (ts.isForInStatement(node) || ts.isForOfStatement(node)) {
+    return [node.initializer, node.expression];
+  }
+  if (ts.isForStatement(node)) {
+    const controls: ts.Node[] = [];
+    if (node.initializer) controls.push(node.initializer);
+    if (node.condition) controls.push(node.condition);
+    if (node.incrementor) controls.push(node.incrementor);
+    return controls;
+  }
+  return [];
+}
+
+function declaredFunctionName(node: ts.Node, sourceFile: ts.SourceFile): string | undefined {
+  if (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node)) {
+    return node.name?.getText(sourceFile);
+  }
+  if (ts.isFunctionExpression(node) || ts.isArrowFunction(node)) {
+    if (ts.isVariableDeclaration(node.parent)) return node.parent.name.getText(sourceFile);
+    if (ts.isPropertyAssignment(node.parent)) return node.parent.name.getText(sourceFile);
+  }
+  return undefined;
+}
+
+function isAllowedHostAdapterControl(
+  path: string,
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+): boolean {
+  const boundary = HOST_ADAPTER_BOUNDARIES.find((candidate) => candidate.path === path);
+  if (!boundary) return false;
+  const allowedFunctions = new Set<string>(boundary.functions);
+  for (let ancestor: ts.Node | undefined = node; ancestor; ancestor = ancestor.parent) {
+    const name = declaredFunctionName(ancestor, sourceFile);
+    if (name && allowedFunctions.has(name)) return true;
+  }
+  return false;
+}
+
+function identifierTermsIn(node: ts.Node, sourceFile: ts.SourceFile): string[][] {
+  const identifiers: string[][] = [];
+  const collect = (child: ts.Node): void => {
+    if (ts.isIdentifier(child)) {
+      const terms = child
+        .getText(sourceFile)
+        .split(/[^a-zA-Z0-9]+|(?=[A-Z])/)
+        .filter(Boolean)
+        .map((term) => term.toLowerCase());
+      if (terms.length > 0) identifiers.push(terms);
+    }
+    ts.forEachChild(child, collect);
+  };
+  collect(node);
+  return identifiers;
+}
+
+function entitiesIn(nodes: readonly ts.Node[], sourceFile: ts.SourceFile): EngineEntity[] {
+  const identifiers = nodes.flatMap((node) => identifierTermsIn(node, sourceFile));
+  const tokens = new Set(identifiers.flat());
+  const hasPullRequestSequence = identifiers.some((terms) =>
+    terms.some((term, index) => term === "pull" && terms[index + 1] === "request"),
+  );
+
+  return (Object.entries(ENTITY_TOKENS) as Array<[EngineEntity, ReadonlySet<string>]>).flatMap(
+    ([entity, entityTokens]) =>
+      [...tokens].some((token) => entityTokens.has(token)) ||
+      (entity === "PR" && hasPullRequestSequence)
+        ? [entity]
+        : [],
+  );
+}
+
+export function inspectSource(path: string, source: string): DriftFinding[] {
+  const sourceFile = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const entities = new Set<EngineEntity>();
+  let firstLine: number | undefined;
+  const visit = (node: ts.Node): void => {
+    const controls = controllingNodes(node);
+    if (controls.length > 0 && !isAllowedHostAdapterControl(path, node, sourceFile)) {
+      const controlledEntities = entitiesIn(controls, sourceFile);
+      if (controlledEntities.length > 0) {
+        firstLine ??= sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+        for (const entity of controlledEntities) entities.add(entity);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (firstLine === undefined) return [];
+  const verb = engineVerbFor(path);
+  return [{ path, line: firstLine, entities: [...entities], ...(verb ? { verb } : {}) }];
+}
+
+let currentTreeFindingCache: DriftFinding[] | undefined;
+let currentTreeSourcePathCache: string[] | undefined;
+
+function currentTreeSourcePaths(): string[] {
+  currentTreeSourcePathCache ??= sourceFilesUnder(devSourceRoot).map((absolutePath) =>
+    relative(devSourceRoot, absolutePath).replaceAll("\\", "/"),
+  );
+  return currentTreeSourcePathCache;
+}
+
+export function currentTreeFindings(): DriftFinding[] {
+  currentTreeFindingCache ??= currentTreeSourcePaths().flatMap((path) => {
+    const absolutePath = resolve(devSourceRoot, path);
+    return inspectSource(path, readFileSync(absolutePath, "utf8"));
+  });
+  return currentTreeFindingCache;
+}
+
+export function currentTreeEngineVerbs(): EngineVerb[] {
+  const paths = new Set(currentTreeSourcePaths());
+  return (Object.entries(ENGINE_VERB_PATHS) as Array<[EngineVerb, readonly string[]]>)
+    .flatMap(([verb, verbPaths]) => (verbPaths.some((path) => paths.has(path)) ? [verb] : []))
+    .sort();
+}
+
+export function renderFindings(findings: readonly DriftFinding[]): string {
+  return findings
+    .map((finding) =>
+      `${finding.verb ? `[${finding.verb}] ` : ""}${finding.path}:${finding.line} controls ${finding.entities.join(", ")}`,
+    )
+    .join("\n");
+}


### PR DESCRIPTION
Automated AFK landing for #2233. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2233

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787152820&installation_id=129708444&pr_number=2276&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2276&signature=e7574d991b3aa7dc8387a7156063076159d33aae5583f987fba9991a0245c681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->