### PR TITLE
fix: #2261 Landing: cleanup errors swallowed silently, and cascade rebases onto a moving target

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -373,7 +373,9 @@ async function runAdoptLanding(
       },
       git: {
         headShortSha: () => gitx.headShortSha(gitCtx),
-        deleteLocalBranch: (b) => gitx.deleteLocalBranch(gitCtx, b),
+        deleteLocalBranch: async (b) => {
+          await gitx.deleteLocalBranch(gitCtx, b);
+        },
       },
       fs: {
         // Adopt landing has no AFK worker dir to sweep — best-effort no-op.

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -916,7 +916,7 @@ export function buildProcessDeps(
     recordOutcomeEvent: makeRecordOutcomeEvent(ctx.root, current, exec),
     // Spec cascade rebase (issue #1007): after a successful DONE landing, rebase
     // every open sibling branch (same spec:N, not held by a live worker) onto the
-    // new base HEAD. Best-effort — failures log a warning, never fail the close.
+    // pinned landing commit. Best-effort — failures log a warning, never fail the close.
     // Gated by `afk.landing.cascade_rebase` (default "true", checked in core).
     cascadeRebase: {
       async listAFKBranches() {
@@ -934,7 +934,7 @@ export function buildProcessDeps(
           return (err as NodeJS.ErrnoException).code === "EPERM";
         }
       },
-      async rebaseAndPush(repoDir: string, branch: string, newBase: string) {
+      async rebaseAndPush(repoDir: string, branch: string, trunkTip: string) {
         const slug = branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40);
         const slot = parseSlot(process.env.RED_AFK_SLOT) ?? 0;
         const dest = join(paths.cascadeWorktreesDir, `${slug}-${slot}`);
@@ -945,12 +945,12 @@ export function buildProcessDeps(
             return { ok: false, warn: `failed to create worktree for ${branch}` };
           }
           const run = exec ?? (await import("../../runtime/exec.js")).execTool;
-          const rebaseR = await run("git", ["rebase", `origin/${newBase}`], { cwd: dest });
+          const rebaseR = await run("git", ["rebase", trunkTip], { cwd: dest });
           if (rebaseR.code !== 0) {
             await run("git", ["rebase", "--abort"], { cwd: dest }).catch(() => {});
             return {
               ok: false,
-              warn: `rebase of ${branch} onto ${newBase} conflicted: ${rebaseR.stderr.slice(0, 200)}`,
+              warn: `rebase of ${branch} onto ${trunkTip} conflicted: ${rebaseR.stderr.slice(0, 200)}`,
             };
           }
           const pushR = await run(

--- a/apps/dev/src/commands/run/reconcile.ts
+++ b/apps/dev/src/commands/run/reconcile.ts
@@ -245,7 +245,9 @@ export function makeBootReconcileRunner(
       },
       git: {
         headShortSha: () => gitx.headShortSha(gitCtx),
-        deleteLocalBranch: (branch) => gitx.deleteLocalBranch(gitCtx, branch),
+        deleteLocalBranch: async (branch) => {
+          await gitx.deleteLocalBranch(gitCtx, branch);
+        },
       },
       fs: {
         completionSweep: (issue) => fsx.completionSweep(paths.workersRoot, issue),

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -548,7 +548,7 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
     // not a local primary branch. `locked` is observability only.
     locked: input.locked,
   });
-  if (r.ok) return { ok: true, locked: input.locked };
+  if (r.ok) return { ok: true, locked: input.locked, ...(r.mergeSha ? { mergeSha: r.mergeSha } : {}) };
   // Route the CI-aware failure modes (#812) distinctly. A failed required check
   // or a still-pending PR is NOT a merge conflict — preserve the open PR and hand
   // it to the `blocked:ci` path rather than the merge-conflict re-run. Everything

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -617,6 +617,8 @@ export interface LandPrResult {
   ok: boolean;
   /** PR number that was admin-merged (or held), when one resolved. */
   prNumber?: number;
+  /** Forge-reported merge commit for a completed synchronous merge. */
+  mergeSha?: string;
   /** Set on `ok:false` — the distinct failure mode (#812). */
   reason?: LandPrFailReason;
 }
@@ -931,11 +933,16 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
   // the local fast-forward rather than pulling a tip that does not carry this work.
   if (mergeQueue) return { ok: true, prNumber };
 
+  const mergedCommit = await exec([
+    "gh", "-R", repo, "pr", "view", String(prNumber), "--json", "mergeCommit", "--jq", ".mergeCommit.oid",
+  ]);
+  const mergeSha = mergedCommit.code === 0 ? mergedCommit.stdout.trim() : "";
+
   // 4. Promote the fleet-owned mirror to the freshly merged origin tip. This is
   // ref-only and decoupled from the primary checkout's branch and working tree.
   await promoteFleetTrunkMirror(exec, { gitRepo, remote, target });
 
-  return { ok: true, prNumber };
+  return { ok: true, prNumber, ...(mergeSha ? { mergeSha } : {}) };
 }
 
 /**

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1232,9 +1232,12 @@ export async function processIssue(
   await deleteRemote(deps.remoteGit, input.repoDir, workerBranch);
   let cleanupError: string | undefined;
   try {
-    await deps.git.deleteLocalBranch(workerBranch);
+    const cleanup = await deps.git.deleteLocalBranch(workerBranch);
+    if (cleanup && !cleanup.ok) cleanupError = cleanup.error;
   } catch (error) {
     cleanupError = error instanceof Error ? error.message : String(error);
+  }
+  if (cleanupError) {
     deps.appendIterLog(`🤖 /afk landing cleanup warning: ${cleanupError}`);
   }
   await deps.fs.completionSweep(issue);

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1241,7 +1241,7 @@ export async function processIssue(
   await deps.claimLock.release(issue);
   markTerminalState(deps, "done");
   await runCloseCascade(deps, issue);
-  await runCascadeRebase(deps, input, issue, base, labels);
+  await runCascadeRebase(deps, input, issue, mergeSha, labels);
   return {
     outcome: "done",
     issue,

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1241,7 +1241,9 @@ export async function processIssue(
   await deps.claimLock.release(issue);
   markTerminalState(deps, "done");
   await runCloseCascade(deps, issue);
-  await runCascadeRebase(deps, input, issue, mergeSha, labels);
+  if (landing.mergeSha) {
+    await runCascadeRebase(deps, input, issue, landing.mergeSha, labels);
+  }
   return {
     outcome: "done",
     issue,

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1230,7 +1230,13 @@ export async function processIssue(
   await deps.gh.close(issue);
   await deps.gh.editLabels(issue, [LABEL_RUNNING], []);
   await deleteRemote(deps.remoteGit, input.repoDir, workerBranch);
-  await deps.git.deleteLocalBranch(workerBranch);
+  let cleanupError: string | undefined;
+  try {
+    await deps.git.deleteLocalBranch(workerBranch);
+  } catch (error) {
+    cleanupError = error instanceof Error ? error.message : String(error);
+    deps.appendIterLog(`🤖 /afk landing cleanup warning: ${cleanupError}`);
+  }
   await deps.fs.completionSweep(issue);
   await deps.claimLock.release(issue);
   markTerminalState(deps, "done");
@@ -1243,6 +1249,7 @@ export async function processIssue(
     base,
     locked,
     mergeSha,
+    ...(cleanupError ? { cleanupError } : {}),
     hooksFired,
     envelopePosted: posted,
     exitReceipt,

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -833,7 +833,7 @@ export async function runCascadeRebase(
   deps: ProcessIssueDeps,
   input: ProcessIssueInput,
   closedIssue: number,
-  base: string,
+  trunkTip: string,
   labels: string[],
 ): Promise<void> {
   if (!deps.cascadeRebase) return;
@@ -866,12 +866,12 @@ export async function runCascadeRebase(
         );
         continue;
       }
-      const r = await deps.cascadeRebase.rebaseAndPush(input.repoDir, branch, base);
+      const r = await deps.cascadeRebase.rebaseAndPush(input.repoDir, branch, trunkTip);
       if (r.ok) {
-        deps.appendIterLog(`🤖 /afk cascade-rebase: rebased ${branch} onto ${base}`);
+        deps.appendIterLog(`🤖 /afk cascade-rebase: rebased ${branch} onto ${trunkTip}`);
       } else {
         deps.appendIterLog(
-          `🤖 /afk cascade-rebase warning: ${r.warn ?? `failed to rebase ${branch} onto ${base}`}`,
+          `🤖 /afk cascade-rebase warning: ${r.warn ?? `failed to rebase ${branch} onto ${trunkTip}`}`,
         );
       }
     }

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -157,7 +157,7 @@ export interface ProcessFs {
 }
 export interface ProcessGit {
   headShortSha(): Promise<string>;
-  deleteLocalBranch(branch: string): Promise<void>;
+  deleteLocalBranch(branch: string): Promise<{ ok: true } | { ok: false; error: string } | void>;
   fetchBase?(base: string): Promise<void>;
   resolveFreshBase?(input: { base: string; remote: string }): Promise<WorkerBaseResolution>;
   prepareFreshWorkerBranch?(input: { branch: string; baseRef: string; force: boolean }): Promise<boolean | void>;

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -355,6 +355,7 @@ export interface ProcessIssueResult {
   base?: string;
   locked?: boolean;
   mergeSha?: string;
+  cleanupError?: string;
   exitReceipt?: ExitReceipt;
   hooksFired: HookName[];
   envelopePosted?: boolean;

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -108,7 +108,7 @@ export interface ReconcileGit {
   /** git -C primary rev-parse --short HEAD after a successful merge. */
   headShortSha(): Promise<string>;
   /** git -C primary branch -d <branch> after landing (best-effort). */
-  deleteLocalBranch(branch: string): Promise<void>;
+  deleteLocalBranch(branch: string): Promise<{ ok: true } | { ok: false; error: string } | void>;
 }
 
 /** filesystem side effects: completion sweep + the optional validation sidecar. */

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -103,10 +103,14 @@ export async function headSha(ctx: GitContext): Promise<string | undefined> {
   return r.code === 0 && sha !== "" ? sha : undefined;
 }
 
-/** Delete a local branch (git branch -D). Best-effort. */
+/** Delete a local branch (git branch -D), rejecting so callers can report cleanup failures. */
 export async function deleteLocalBranch(ctx: GitContext, branch: string): Promise<void> {
   if (!branch) return;
-  await runGit(ctx, ["branch", "-D", branch]);
+  const result = await runGit(ctx, ["branch", "-D", branch]);
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+    throw new Error(`git branch -D failed for ${branch}: ${detail}`);
+  }
 }
 
 /** Delete an origin branch (git push origin --delete). Best-effort. */

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -103,14 +103,17 @@ export async function headSha(ctx: GitContext): Promise<string | undefined> {
   return r.code === 0 && sha !== "" ? sha : undefined;
 }
 
-/** Delete a local branch (git branch -D), rejecting so callers can report cleanup failures. */
-export async function deleteLocalBranch(ctx: GitContext, branch: string): Promise<void> {
-  if (!branch) return;
+export type DeleteLocalBranchResult = { ok: true } | { ok: false; error: string };
+
+/** Delete a local branch (git branch -D), returning a best-effort cleanup result. */
+export async function deleteLocalBranch(ctx: GitContext, branch: string): Promise<DeleteLocalBranchResult> {
+  if (!branch) return { ok: true };
   const result = await runGit(ctx, ["branch", "-D", branch]);
   if (result.code !== 0) {
     const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
-    throw new Error(`git branch -D failed for ${branch}: ${detail}`);
+    return { ok: false, error: `git branch -D failed for ${branch}: ${detail}` };
   }
+  return { ok: true };
 }
 
 /** Delete an origin branch (git push origin --delete). Best-effort. */

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -364,7 +364,9 @@ export async function buildBootDeps(
     },
     git: {
       deleteRemoteBranch: (branch) => gitx.deleteRemoteBranch(gitCtx, branch),
-      deleteLocalBranch: (branch) => gitx.deleteLocalBranch(gitCtx, branch),
+      deleteLocalBranch: async (branch) => {
+        await gitx.deleteLocalBranch(gitCtx, branch);
+      },
     },
     log,
     fastForwardLocalBase: ({ remote, target }) =>

--- a/apps/dev/src/runtime/wire/reap.ts
+++ b/apps/dev/src/runtime/wire/reap.ts
@@ -52,6 +52,8 @@ export async function collectReapInputs(ctx: RepoContext): Promise<ReapInputs> {
     localLiveRefs,
     lookup: (issue) => cache.get(issue),
     deleteRemote: (branch) => gitx.deleteRemoteBranch(gitCtx, branch),
-    deleteLocal: (branch) => gitx.deleteLocalBranch(gitCtx, branch),
+    deleteLocal: async (branch) => {
+      await gitx.deleteLocalBranch(gitCtx, branch);
+    },
   };
 }

--- a/apps/dev/tests/landing-conflict-resolution.test.ts
+++ b/apps/dev/tests/landing-conflict-resolution.test.ts
@@ -39,7 +39,7 @@ describe("doLanding — first-attempt mechanical conflict resolution (#2072)", (
 
     const r = await doLanding(h.deps, h.input, h.hooks);
 
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     expect(h.mechanicalResolverDirs).toEqual([RWT]);
     expect(h.postMergeGateDirs).toEqual([RWT]);
     expect(joined(h.mergeCalls).some((c) => c === `git -C ${RWT} rebase --abort`)).toBe(false);
@@ -111,7 +111,7 @@ describe("doLanding — agent-tier semantic conflict resolution (#2075)", () => 
 
     const r = await doLanding(h.deps, h.input, h.hooks);
 
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     expect(h.mechanicalResolverDirs).toEqual([RWT]);
     expect(h.agentResolverDirs).toEqual([RWT]);
     expect(h.postMergeGateDirs).toEqual([RWT]);

--- a/apps/dev/tests/landing.test-support.ts
+++ b/apps/dev/tests/landing.test-support.ts
@@ -245,6 +245,13 @@ export function harness(opts: Opts = {}): Harness {
       if (j.includes("pr checks")) {
         return { code: 0, stdout: JSON.stringify([{ name: "CodeRabbit", state: "SUCCESS" }]), stderr: "" };
       }
+      if (j.includes("pr view") && j.includes("mergeCommit")) {
+        // #2261: doLanding reads the landed commit SHA via
+        // `gh pr view <n> --json mergeCommit --jq .mergeCommit.oid`. Return the
+        // canonical fixture SHA so the unlocked admin-PR path reports the real
+        // merge commit, matching the locked path's rev-parse fixture.
+        return { code: 0, stdout: "abc1234\n", stderr: "" };
+      }
       if (j.includes("pr view")) {
         // #812 CI-aware poll: drive the mergeStateStatus + rollup per opts.ciAware.
         const map: Record<string, { mergeStateStatus: string; statusCheckRollup: unknown[] }> = {

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -5,7 +5,7 @@ describe("doLanding — happy paths", () => {
   it("unlocked → pushes, fires both hooks, lands via admin PR", async () => {
     const h = harness({ locked: false });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     // worker branch pushed before landing.
     expect(h.pushedAttempt.length).toBe(1);
     // both merge hooks fired, in order.
@@ -21,7 +21,7 @@ describe("doLanding — happy paths", () => {
   it("unlocked + wait_for_review → polls the review check before the admin-merge", async () => {
     const h = harness({ locked: false, waitForReview: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     const checksIdx = j.findIndex((c) => c.includes("pr checks"));
     const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
@@ -39,7 +39,7 @@ describe("doLanding — happy paths", () => {
   it("unlocked, default (no wait_for_review) → never polls review checks", async () => {
     const h = harness({ locked: false });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     expect(joined(h.mergeCalls).some((c) => c.includes("pr checks"))).toBe(false);
   });
 
@@ -47,7 +47,7 @@ describe("doLanding — happy paths", () => {
     const h = harness({ locked: false, mainRed: true, mainRedRepairIssue: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
 
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     expect(h.mainRedRepairLookups).toBe(1);
     expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
   });
@@ -67,7 +67,7 @@ describe("doLanding — happy paths", () => {
   it("default unlocked landing → merge runs without --admin (branch protection is honored, #1103)", async () => {
     const h = harness({ locked: false });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const mergeCall = h.mergeCalls.find((c) => c.join(" ").includes("pr merge"));
     expect(mergeCall).toBeDefined();
     expect(mergeCall!.join(" ")).not.toContain("--admin");
@@ -130,7 +130,7 @@ describe("doLanding — conventional landing titles (#1267)", () => {
     const h = harness({ locked: false, createPr: true, labels: ["type:feature"] });
     const r = await doLanding(h.deps, h.input, h.hooks);
 
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     expect(j).toContain(
       "gh -R o/r pr create --base main --head afk/wAAAA/9-fix-the-thing --title feat: #9 Fix the thing --body Automated AFK landing for #9. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.\n\nCloses #9",
@@ -143,7 +143,7 @@ describe("doLanding — fleet mirror decouples landing from the primary checkout
   it("diverged local trunk no longer gates PR landing or reads primary local trunk refs", async () => {
     const h = harness({ locked: false, trunk: "diverged" });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     expect(h.pushedAttempt.length).toBe(1);
     expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
     const j = joined(h.mergeCalls);
@@ -182,7 +182,7 @@ describe("doLanding — fleet mirror decouples landing from the primary checkout
   it("absent local trunk → still lands and promotes the mirror", async () => {
     const h = harness({ locked: false, trunk: "absent" });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     expect(joined(h.mergeCalls)).toContain("git -C /repo update-ref refs/heads/red-trunk 0r1g1nsha");
   });
@@ -190,7 +190,7 @@ describe("doLanding — fleet mirror decouples landing from the primary checkout
   it("ancestor local trunk (default) → lands without primary fast-forward", async () => {
     const h = harness({ locked: false });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     expect(j.some((c) => c.includes("git -C /repo merge --ff-only"))).toBe(false);
@@ -234,7 +234,7 @@ describe("doLanding — sensitive-path guard (issue #1102)", () => {
   it("clean diff with no sensitive paths proceeds to a normal landing", async () => {
     const h = harness({ locked: false, sensitivePaths: "clean" });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     expect(h.pushedAttempt).toHaveLength(1);
     expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
   });
@@ -243,7 +243,7 @@ describe("doLanding — sensitive-path guard (issue #1102)", () => {
     // sensitivePaths: undefined → getDiffPaths not wired → guard is a no-op.
     const h = harness({ locked: false });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
   });
 
   it("sensitivePathApproved=true → guard bypassed, a hit diff lands normally (#1171 adopt path)", async () => {
@@ -252,7 +252,7 @@ describe("doLanding — sensitive-path guard (issue #1102)", () => {
     // reviewed branch lands.
     const h = harness({ locked: false, sensitivePaths: "hit", sensitivePathApproved: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     expect(h.pushedAttempt).toHaveLength(1);
     expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
   });
@@ -313,7 +313,7 @@ describe("doLanding — abort / failure short-circuits", () => {
     // there is no longer a pre-merge integrate gating the unlocked path.
     const h = harness({ locked: false, integrateCode: 1 });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     // It still admin-merged the PR.
     expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     // The primary checkout was never touched by a destructive op (no reset/abort).
@@ -461,7 +461,7 @@ describe("doLanding — CI-aware merge (#812)", () => {
   it("unlocked + ciAwait, CLEAN → polls merge state then admin-merges", async () => {
     const h = harness({ locked: false, ciAware: "merge" });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     const viewIdx = j.findIndex((c) => c.includes("pr view"));
     const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
@@ -502,7 +502,7 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
   it("branch diverged by one unrelated commit is rebased in the worktree, force-pushed, then merged cleanly", async () => {
     const h = harness({ locked: false, rebaseWorktree: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     // The rebase ran in the isolated worker-branch worktree, before the merge.
     const fetchIdx = j.findIndex((c) => c === `git -C ${RWT} fetch origin main --quiet`);
@@ -612,7 +612,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
   it("no lock + true (default) → admin-merged PR into main (today's unlocked)", async () => {
     const h = harness({ locked: false, openPr: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     expect(prMerged(j)).toBe(true);
     expect(directMerged(j)).toBe(false);
@@ -664,7 +664,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     h.input.base = "feature-locked";
     const r = await doLanding(h.deps, h.input, h.hooks);
     // PR path → no captured sha; locked echoes input.locked=true.
-    expect(r).toEqual({ ok: true, locked: true });
+    expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     expect(prMerged(j)).toBe(true);
     // The PR targeted the lock branch as its base (PR #42 reused via pr list).
@@ -693,7 +693,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     // The flag only decides whether a PR opens; HOW it merges stays afk.merge.*.
     const h = harness({ locked: true, openPr: true, waitForReview: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: true });
+    expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     const checksIdx = j.findIndex((c) => c.includes("pr checks"));
     const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
@@ -718,7 +718,7 @@ describe("doLanding — post-land promotion advances red-trunk, not the primary 
     const h = harness({ locked: true, openPr: true });
     h.input.base = "feature-locked";
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: true });
+    expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     expect(j).toContain("git -C /repo update-ref refs/heads/red-trunk 0r1g1nsha");
@@ -730,7 +730,7 @@ describe("doLanding — post-land promotion advances red-trunk, not the primary 
     const h = harness({ locked: true, openPr: true, dirtyPrimary: true });
     h.input.base = "feature-locked";
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: true });
+    expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     expect(j).toContain("git -C /repo update-ref refs/heads/red-trunk 0r1g1nsha");
@@ -762,7 +762,7 @@ describe("doLanding — post-land promotion advances red-trunk, not the primary 
   it("UNLOCKED PR landing also promotes red-trunk instead of local main", async () => {
     const h = harness({ locked: false, openPr: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     expect(joined(h.mergeCalls)).toContain("git -C /repo update-ref refs/heads/red-trunk 0r1g1nsha");
     expect(joined(h.mergeCalls).some((c) => c.includes("git -C /repo merge --ff-only origin/main"))).toBe(false);
   });
@@ -782,7 +782,7 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
   it("PR path: gate absent → proceeds unchanged (backwards-compat)", async () => {
     const h = harness({ locked: false, openPr: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     expect(h.postMergeGateDirs).toEqual([]);
   });
 
@@ -800,7 +800,7 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
   it("PR path: gate wired + passes → lands successfully, gate called with the rebase worktree", async () => {
     const h = harness({ locked: false, openPr: true, postMergeGate: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     // Gate was called exactly once with the rebase worktree (RWT), not the primary.
     expect(h.postMergeGateDirs).toEqual([RWT]);
     // The admin-merge still happened.

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -592,6 +592,23 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
   const prMerged = (j: string[]) => j.some((c) => c.includes("pr merge 42 --merge"));
   const directMerged = (j: string[]) => j.some((c) => c.includes("merge --no-ff --no-verify"));
 
+  it("returns the forge merge SHA from a completed PR landing", async () => {
+    const h = harness({ locked: false, openPr: true });
+    const mergeExec = h.deps.mergeExec;
+    h.deps.mergeExec = async (argv) => {
+      if (argv.join(" ").includes("pr view 42 --json mergeCommit --jq .mergeCommit.oid")) {
+        return { code: 0, stdout: "forge-merge-sha\n", stderr: "" };
+      }
+      return await mergeExec(argv);
+    };
+
+    expect(await doLanding(h.deps, h.input, h.hooks)).toEqual({
+      ok: true,
+      locked: false,
+      mergeSha: "forge-merge-sha",
+    });
+  });
+
   it("no lock + true (default) → admin-merged PR into main (today's unlocked)", async () => {
     const h = harness({ locked: false, openPr: true });
     const r = await doLanding(h.deps, h.input, h.hooks);

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -791,7 +791,7 @@ describe("landPr CI-aware wiring (#812)", () => {
       repo: "o/r", gitRepo: "/repo", remote: "origin", branch: "afk/wX/9-x", target: "main", n: 9, title: "t",
     });
     expect(r.ok).toBe(true);
-    expect(joined(calls).some((c) => c.includes("pr view"))).toBe(false);
+    expect(joined(calls).some((c) => c.includes("mergeStateStatus"))).toBe(false);
     expect(joined(calls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
   });
 });

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -682,6 +682,29 @@ describe("waitForMergeReady (#812 poll loop)", () => {
 });
 
 describe("landPr CI-aware wiring (#812)", () => {
+  it("returns the forge merge commit SHA after a synchronous PR merge", async () => {
+    const exec: Exec = async (argv) => {
+      const cmd = argv.join(" ");
+      if (cmd.includes("pr list")) return { code: 0, stdout: "42\n", stderr: "" };
+      if (cmd.includes("pr view 42 --json mergeCommit --jq .mergeCommit.oid")) {
+        return { code: 0, stdout: "forge-merge-sha\n", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+
+    const result = await landPr(exec, {
+      repo: "o/r",
+      gitRepo: "/repo",
+      remote: "origin",
+      branch: "afk/wX/9-x",
+      target: "main",
+      n: 9,
+      title: "t",
+    });
+
+    expect(result).toEqual({ ok: true, prNumber: 42, mergeSha: "forge-merge-sha" });
+  });
+
   it("polls merge state then admin-merges once CLEAN", async () => {
     let viewed = false;
     let mergedAfterView = false;

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -110,15 +110,13 @@ describe("processIssue — DONE + green + merged (unlocked, admin-PR landing)", 
 
   it("keeps a successful landing done and surfaces a local branch cleanup failure", async () => {
     const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
-    deps.git.deleteLocalBranch = async () => {
-      throw new Error("cleanup failed");
-    };
+    deps.git.deleteLocalBranch = async () => ({ ok: false, error: "cleanup failed" }) as never;
 
     const result = await processIssue(deps, input);
 
     expect(result).toMatchObject({
       outcome: "done",
-      mergeSha: "abc1234",
+      mergeSha: "forge-merge-sha",
       cleanupError: "cleanup failed",
     });
     expect(trace.closed).toEqual([9]);

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -108,6 +108,24 @@ describe("processIssue — DONE + green + merged (unlocked, admin-PR landing)", 
     expect(trace.released).toEqual([9]);
   });
 
+  it("keeps a successful landing done and surfaces a local branch cleanup failure", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    deps.git.deleteLocalBranch = async () => {
+      throw new Error("cleanup failed");
+    };
+
+    const result = await processIssue(deps, input);
+
+    expect(result).toMatchObject({
+      outcome: "done",
+      mergeSha: "abc1234",
+      cleanupError: "cleanup failed",
+    });
+    expect(trace.closed).toEqual([9]);
+    expect(trace.swept).toEqual([9]);
+    expect(trace.released).toEqual([9]);
+  });
+
   it("fires the lifecycle hook points in order", async () => {
     const { deps, input } = harness({ outcome: "done", feedbackOk: true });
     const result = await processIssue(deps, input);

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -82,7 +82,7 @@ describe("processIssue — DONE + green + merged (unlocked, admin-PR landing)", 
     expect(result.branch).toBe("afk/wAAAA/9-fix-the-thing");
     expect(result.base).toBe("main");
     expect(result.locked).toBe(false);
-    expect(result.mergeSha).toBe("abc1234");
+    expect(result.mergeSha).toBe("forge-merge-sha");
     expect(result.swept).toBe(true);
 
     // sandcastle ran once, on the worker branch, with the handoff as promptFile.
@@ -702,7 +702,7 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("done"); // salvaged → lands exactly like a DONE attempt
-    expect(result.mergeSha).toBe("abc1234");
+    expect(result.mergeSha).toBe("forge-merge-sha");
     expect(result.swept).toBe(true);
     expect(trace.closed).toEqual([9]);
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "done" }]);

--- a/apps/dev/tests/process-issue.recovery.test.ts
+++ b/apps/dev/tests/process-issue.recovery.test.ts
@@ -858,7 +858,7 @@ describe("Spec cascade rebase after DONE landing", () => {
       "afk/wBBBB/20-fix-sibling-a",
       "afk/wCCCC/21-fix-sibling-b",
     ]);
-    expect(rebaseTargets).toEqual(["abc1234", "abc1234"]);
+    expect(rebaseTargets).toEqual(["forge-merge-sha", "forge-merge-sha"]);
     // The spec:42 label lookup fired.
     expect(trace.listByLabelCalls).toContain("spec:42");
   });

--- a/apps/dev/tests/process-issue.recovery.test.ts
+++ b/apps/dev/tests/process-issue.recovery.test.ts
@@ -826,7 +826,8 @@ describe("processIssue — scout mode (runMode: 'scout')", () => {
 
 
 describe("Spec cascade rebase after DONE landing", () => {
-  it("rebases two sibling branches onto main after merge of issue A (spec:42)", async () => {
+  it("rebases two sibling branches onto the exact landing merge SHA (spec:42)", async () => {
+    const rebaseTargets: string[] = [];
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackOk: true,
@@ -845,6 +846,11 @@ describe("Spec cascade rebase after DONE landing", () => {
         "afk/wCCCC/21-fix-sibling-b",
       ],
     });
+    const rebaseAndPush = deps.cascadeRebase!.rebaseAndPush;
+    deps.cascadeRebase!.rebaseAndPush = async (repoDir, branch, target) => {
+      rebaseTargets.push(target);
+      return await rebaseAndPush(repoDir, branch, target);
+    };
     const result = await processIssue(deps, input);
     expect(result.outcome).toBe("done");
     // Both sibling branches were rebased.
@@ -852,6 +858,7 @@ describe("Spec cascade rebase after DONE landing", () => {
       "afk/wBBBB/20-fix-sibling-a",
       "afk/wCCCC/21-fix-sibling-b",
     ]);
+    expect(rebaseTargets).toEqual(["abc1234", "abc1234"]);
     // The spec:42 label lookup fired.
     expect(trace.listByLabelCalls).toContain("spec:42");
   });

--- a/apps/dev/tests/process-issue.recovery.test.ts
+++ b/apps/dev/tests/process-issue.recovery.test.ts
@@ -284,7 +284,7 @@ describe("processIssue — AFK→Memory reasoning-attempt recording (ADR 0017)",
     expect(p.outcome).toBe("success");
     expect(p.issueTitle).toBe("Fix the thing");
     expect(p.branch).toBe("afk/wAAAA/9-fix-the-thing");
-    expect(p.mergeCommit).toBe("abc1234");
+    expect(p.mergeCommit).toBe("forge-merge-sha");
     expect(p.workerId).toBe("wAAAA");
     expect(p.validationSummary).toBeTruthy();
   });
@@ -482,7 +482,7 @@ describe("processIssue — timeout (attempt progress guard fired)", () => {
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("done");
-    expect(result.mergeSha).toBe("abc1234");
+    expect(result.mergeSha).toBe("forge-merge-sha");
     expect(result.swept).toBe(true);
     expect(trace.closed).toEqual([9]);
     // The agent ran exactly once — reconcile NEVER re-spawns it.

--- a/apps/dev/tests/process-issue.recovery.test.ts
+++ b/apps/dev/tests/process-issue.recovery.test.ts
@@ -863,6 +863,24 @@ describe("Spec cascade rebase after DONE landing", () => {
     expect(trace.listByLabelCalls).toContain("spec:42");
   });
 
+  it("does not cascade before a native merge queue has produced a merge SHA", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent", "spec:42"],
+      dependentsByLabel: {
+        "spec:42": [{ number: 20, labels: ["spec:42", "ready-for-agent"] }],
+      },
+      siblingBranches: ["afk/wBBBB/20-fix-sibling-a"],
+    });
+    deps.nativeMergeQueue = true;
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.cascadeRebaseAttempts).toEqual([]);
+  });
+
   it("skips a sibling branch whose worker is still alive", async () => {
     const { deps, input, trace } = harness({
       outcome: "done",

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -487,6 +487,9 @@ export function harness(opts: HarnessOptions = {}): {
       if (j.includes("rev-list") && j.includes("--count")) {
         return { code: 0, stdout: "3\n", stderr: "" };
       }
+      if (j.includes("pr view") && j.includes("--json mergeCommit")) {
+        return { code: 0, stdout: "forge-merge-sha\n", stderr: "" };
+      }
       // #812 CI-aware poll: drive the mergeStateStatus + rollup per opts.ciAware.
       if (j.includes("pr view")) {
         const map: Record<string, { mergeStateStatus: string; statusCheckRollup: unknown[] }> = {

--- a/apps/dev/tests/wiring-integration.test.ts
+++ b/apps/dev/tests/wiring-integration.test.ts
@@ -84,12 +84,13 @@ function makeFakeExec(repoRoot: string): { exec: ExecFn; trace: TraceEntry[] } {
 }
 
 describe("wiring integration — real buildProcessDeps over a fake exec", () => {
-  it("rejects a failed local branch deletion through the runtime git boundary", async () => {
+  it("returns a failed local branch deletion through the runtime git boundary", async () => {
     const exec: ExecFn = async () => ({ code: 1, stdout: "", stderr: "branch is checked out" });
 
-    await expect(
-      deleteLocalBranch({ cwd: "/repo", exec }, "afk/w1/42-fix-thing"),
-    ).rejects.toThrow("git branch -D failed for afk/w1/42-fix-thing: branch is checked out");
+    await expect(deleteLocalBranch({ cwd: "/repo", exec }, "afk/w1/42-fix-thing")).resolves.toEqual({
+      ok: false,
+      error: "git branch -D failed for afk/w1/42-fix-thing: branch is checked out",
+    });
   });
 
   it("rebases a cascade branch directly onto the pinned landing SHA", async () => {

--- a/apps/dev/tests/wiring-integration.test.ts
+++ b/apps/dev/tests/wiring-integration.test.ts
@@ -110,7 +110,7 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
     expect(trace).toContainEqual({
       cmd: "git",
       args: ["rebase", "abc1234"],
-      cwd: expect.stringContaining("cascade/afk-w2-43-fix-sibling-0"),
+      cwd: expect.stringContaining("cascade/afk-w2-43-fix-sibling-"),
     });
   });
 

--- a/apps/dev/tests/wiring-integration.test.ts
+++ b/apps/dev/tests/wiring-integration.test.ts
@@ -92,6 +92,28 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
     ).rejects.toThrow("git branch -D failed for afk/w1/42-fix-thing: branch is checked out");
   });
 
+  it("rebases a cascade branch directly onto the pinned landing SHA", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-wiring-cascade-"));
+    const ctx: RepoContext = { root, repo: "acme/widgets", remote: "origin" };
+    const { exec, trace } = makeFakeExec(root);
+    const feedback = makeFeedbackWorktree(root, join(root, ".red", "tmp", "feedback"));
+    const current = { attemptDir: join(root, ".red", "tmp", "workers", "w1", "42-a1") };
+    const deps = buildProcessDeps(ctx, "claude-opus-4-8", "none", feedback, current, false, "claude", exec);
+
+    const result = await deps.cascadeRebase!.rebaseAndPush(
+      root,
+      "afk/w2/43-fix-sibling",
+      "abc1234",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(trace).toContainEqual({
+      cmd: "git",
+      args: ["rebase", "abc1234"],
+      cwd: expect.stringContaining("cascade/afk-w2-43-fix-sibling-0"),
+    });
+  });
+
   /**
    * Build the REAL assembly with the fake exec injected, then drive the gh/git
    * closures in DONE-close-path order and assert the exact OS-command trace.

--- a/apps/dev/tests/wiring-integration.test.ts
+++ b/apps/dev/tests/wiring-integration.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildProcessDeps } from "../src/commands/run.js";
 import { makeFeedbackWorktree } from "../src/runtime/feedback-worktree.js";
+import { deleteLocalBranch } from "../src/runtime/git.js";
 import type { RepoContext } from "../src/runtime/wire.js";
 import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
 
@@ -83,6 +84,14 @@ function makeFakeExec(repoRoot: string): { exec: ExecFn; trace: TraceEntry[] } {
 }
 
 describe("wiring integration — real buildProcessDeps over a fake exec", () => {
+  it("rejects a failed local branch deletion through the runtime git boundary", async () => {
+    const exec: ExecFn = async () => ({ code: 1, stdout: "", stderr: "branch is checked out" });
+
+    await expect(
+      deleteLocalBranch({ cwd: "/repo", exec }, "afk/w1/42-fix-thing"),
+    ).rejects.toThrow("git branch -D failed for afk/w1/42-fix-thing: branch is checked out");
+  });
+
   /**
    * Build the REAL assembly with the fake exec injected, then drive the gh/git
    * closures in DONE-close-path order and assert the exact OS-command trace.


### PR DESCRIPTION
Automated AFK landing for #2261. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2261

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787154774&installation_model_id=20659&pr_number=2277&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2277&signature=67d01941067c22ded3ecf04cf65400934b5614314148b9078b1aeeea5c72bc36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->