### PR TITLE
fix: #2179 Prototype Manager portfolio transitions and crash recovery

### DIFF
--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "node --import tsx src/cli.ts",
+    "prototype:manager-portfolio": "node --import tsx src/prototypes/manager-portfolio-explorer.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/dev.bundle.min.mjs --asset dev.bundle.min.mjs --minify",
     "bundle:red-fetch": "esbuild ../../packages/shared/entrypoint-cli.ts --bundle --minify --platform=node --format=esm --target=node22 --define:__ENTRYPOINT_ROLE__='\"fetch\"' --outfile=../../plugins/dev/hooks/red-fetch.mjs --banner:js=\"import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",

--- a/apps/dev/src/prototypes/manager-portfolio-NOTES.md
+++ b/apps/dev/src/prototypes/manager-portfolio-NOTES.md
@@ -1,0 +1,63 @@
+# Manager portfolio transition prototype
+
+> PROTOTYPE — delete the terminal shell after these decisions are absorbed into
+> the Manager storage and runtime contract.
+
+## Question
+
+What concrete state machine best exposes Manager portfolio lifecycle,
+effort-scoped leases, optimistic-generation conflicts, pause/resume, crash
+recovery, checkpoint authority transfer, and partial cross-repository
+publication before a storage engine is selected?
+
+Run the explorer from the repository root:
+
+```sh
+pnpm --dir apps/dev prototype:manager-portfolio
+```
+
+The useful walkthrough is `r`, `1`, `2`, `g`, `e`, `r`, `c`, `v`, `3`, `x`,
+`i`, `o`, `m`. The explorer redraws the complete focused effort and portfolio
+authority after every action. Use `f` to show that another effort can carry an
+independent lease.
+
+## Answer exposed by the prototype
+
+- Keep the five-state effort lifecycle small: `inbox`, `active`, `paused`,
+  `completed`, and `abandoned`. Publication failure, crash, and generation
+  conflict are transition results or projections, not extra lifecycle states.
+- Put the writer lease and generation on each effort record. Different sessions
+  can write different efforts, while every same-effort mutation is a compare-and-
+  swap against the expected generation.
+- `end` is a local Manager transition: it pauses the effort and releases its
+  lease without rolling back maps or cancelling owner work already published.
+- A process crash does not get to rewrite durable state. It leaves an orphaned
+  lease that a later session can recover only after liveness evidence identifies
+  the old session as crashed; recovery itself advances the generation.
+- Checkpoint import is an authority transfer, not synchronization. It advances
+  the authority epoch and effort generations, invalidates source leases, and
+  lets the destination acquire fresh leases without changing published facts.
+- Cross-repository publication needs one durable projection per repository with
+  a stable idempotency key. A later repository failure must not roll back an
+  earlier successful map; retry fills the missing projection without duplicating
+  the successful one.
+- Completion must reject an effort while any in-scope repository projection is
+  missing. The eventual runtime will add the stronger ADR 0109 acceptance and
+  artifact-disposition checks on top of this prototype guard.
+
+## Decisions this intentionally leaves open
+
+1. What proves an orphaned lease is recoverable: host-session liveness, a lease
+   timeout, an explicit operator takeover, or a combination?
+2. Should checkpoint import preserve an `active` lifecycle with no lease, or
+   force every non-terminal effort to `paused` until reconciliation completes?
+3. Does the store expose effort-level compare-and-swap directly, or append
+   transitions to a log and derive the current generation?
+4. Is cross-repository publication represented as an outbox, a transition log,
+   or fields embedded in each repository projection?
+5. Which failed-attempt and tombstone details survive compaction, and which stay
+   with tracker-owned artifacts and operational telemetry?
+
+Those choices should be made from the next storage/checkpoint and recovery
+decision tickets. The prototype demonstrates the required observable behavior
+without treating its in-memory object shape as the storage schema.

--- a/apps/dev/src/prototypes/manager-portfolio-NOTES.md
+++ b/apps/dev/src/prototypes/manager-portfolio-NOTES.md
@@ -17,26 +17,31 @@ pnpm --dir apps/dev prototype:manager-portfolio
 ```
 
 The useful walkthrough is `r`, `1`, `2`, `g`, `e`, `r`, `c`, `v`, `3`, `x`,
-`i`, `o`, `m`. The explorer redraws the complete focused effort and portfolio
-authority after every action. Use `f` to show that another effort can carry an
-independent lease.
+`i`, `o`, `r`, `m`. After import, `o` shows the old host rejected by the retired
+source replica; the following `r` acquires a fresh destination lease before
+completion. The explorer redraws the complete focused effort, actor fencing
+credentials, and portfolio authority after every action. Use `f` to show that
+another effort can carry an independent lease.
 
 ## Answer exposed by the prototype
 
 - Keep the five-state effort lifecycle small: `inbox`, `active`, `paused`,
   `completed`, and `abandoned`. Publication failure, crash, and generation
   conflict are transition results or projections, not extra lifecycle states.
-- Put the writer lease and generation on each effort record. Different sessions
-  can write different efforts, while every same-effort mutation is a compare-and-
-  swap against the expected generation.
+- Put the writer lease and generation on each effort record. Every mutation
+  presents the current authority epoch, and lease-owning mutations also present
+  the exact lease token. Different sessions can write different efforts, while
+  stale epochs, reused session IDs, stale tokens, and stale generations are all
+  fenced independently.
 - `end` is a local Manager transition: it pauses the effort and releases its
   lease without rolling back maps or cancelling owner work already published.
 - A process crash does not get to rewrite durable state. It leaves an orphaned
   lease that a later session can recover only after liveness evidence identifies
   the old session as crashed; recovery itself advances the generation.
-- Checkpoint import is an authority transfer, not synchronization. It advances
-  the authority epoch and effort generations, invalidates source leases, and
-  lets the destination acquire fresh leases without changing published facts.
+- Checkpoint import is an authority transfer, not synchronization. The transfer
+  advances the authority epoch and effort generations, explicitly retires the
+  source replica, invalidates source leases, and lets the destination acquire
+  fresh leases without changing published facts.
 - Cross-repository publication needs one durable projection per repository with
   a stable idempotency key. A later repository failure must not roll back an
   earlier successful map; retry fills the missing projection without duplicating

--- a/apps/dev/src/prototypes/manager-portfolio-explorer.ts
+++ b/apps/dev/src/prototypes/manager-portfolio-explorer.ts
@@ -9,17 +9,32 @@ import {
   exportCheckpoint,
   importCheckpoint,
   type ManagerActor,
+  type ManagerAction,
   type ManagerCheckpoint,
   type ManagerPortfolio,
+  type TransitionResult,
 } from "./manager-portfolio-machine.js";
+
+type ShellWriteAction = Extract<ManagerAction, { effortId: string }> extends infer Action
+  ? Action extends ManagerAction
+    ? Omit<Action, "actor" | "expectedGeneration">
+    : never
+  : never;
 
 const bold = "\x1b[1m";
 const dim = "\x1b[2m";
 const reset = "\x1b[0m";
 
 let state = createPrototypePortfolio();
-let actor: ManagerActor = { hostId: "host-a", sessionId: "session-a" };
+let actor: ManagerActor = {
+  hostId: "host-a",
+  sessionId: "session-a",
+  authorityEpoch: 1,
+  leaseToken: null,
+};
 let checkpoint: ManagerCheckpoint | null = null;
+let sourceReplica: ManagerPortfolio | null = null;
+let lastSourceResult: TransitionResult | null = null;
 
 function focusedEffort() {
   return state.efforts[state.focusEffortId]!;
@@ -48,11 +63,12 @@ function render(): void {
     .join(", ");
 
   console.log(`${bold}Manager portfolio transition explorer${reset} ${dim}(PROTOTYPE — in memory)${reset}`);
-  console.log(`${bold}authority${reset}: ${state.authority.hostId}@epoch-${state.authority.epoch}`);
+  console.log(`${bold}authority${reset}: ${state.authority.hostId}@epoch-${state.authority.epoch} replica=${state.replicaStatus}`);
   console.log(`${bold}portfolio generation${reset}: ${state.portfolioGeneration}`);
-  console.log(`${bold}current actor${reset}: ${actor.hostId}/${actor.sessionId}`);
+  console.log(`${bold}current actor${reset}: ${actor.hostId}/${actor.sessionId}@epoch-${actor.authorityEpoch} lease-token=${actor.leaseToken ?? "-"}`);
   console.log(`${bold}sessions${reset}: ${JSON.stringify(state.sessions)}`);
   console.log(`${bold}checkpoint slot${reset}: ${checkpoint ? `exported@g${checkpoint.portfolioGeneration}` : "empty"}`);
+  console.log(`${bold}source replica${reset}: ${sourceReplica ? `${sourceReplica.replicaStatus}; last-write=${lastSourceResult?.code ?? "not-tried"}` : "not transferred"}`);
   console.log(`${bold}other efforts${reset}: ${otherEfforts || "none"}`);
   console.log();
   console.log(`${bold}focused effort${reset}: ${effort.id} — ${effort.name}`);
@@ -78,10 +94,18 @@ function render(): void {
 
 function act(action: Parameters<typeof applyManagerAction>[1]): void {
   state = applyManagerAction(state, action);
+  if (action.actor.hostId === actor.hostId && action.actor.sessionId === actor.sessionId) {
+    const lease = focusedEffort().lease;
+    actor = {
+      ...actor,
+      authorityEpoch: state.authority.epoch,
+      leaseToken: lease?.sessionId === actor.sessionId ? lease.token : null,
+    };
+  }
 }
 
 function writeAction(
-  action: Omit<Extract<Parameters<typeof applyManagerAction>[1], { effortId: string }>, "actor" | "expectedGeneration">,
+  action: ShellWriteAction,
 ): void {
   act({ ...action, actor, expectedGeneration: generation() } as Parameters<typeof applyManagerAction>[1]);
 }
@@ -109,7 +133,7 @@ async function main(): Promise<void> {
           act({ type: "crash-session", actor });
           break;
         case "v": {
-          actor = { ...actor, sessionId: "recovery-session" };
+          actor = { ...actor, sessionId: "recovery-session", leaseToken: null };
           writeAction({ type: "recover-lease", effortId: state.focusEffortId });
           break;
         }
@@ -158,17 +182,33 @@ async function main(): Promise<void> {
           break;
         case "i":
           if (checkpoint) {
-            state = importCheckpoint(checkpoint, "host-b");
-            actor = { hostId: "host-b", sessionId: "imported-session" };
+            const transfer = importCheckpoint(state, checkpoint, "host-b");
+            sourceReplica = transfer.source;
+            state = transfer.destination;
+            actor = {
+              hostId: "host-b",
+              sessionId: "imported-session",
+              authorityEpoch: state.authority.epoch,
+              leaseToken: null,
+            };
+            lastSourceResult = null;
           }
           break;
         case "o":
-          act({
-            type: "resume",
-            effortId: state.focusEffortId,
-            actor: { hostId: "host-a", sessionId: "source-session" },
-            expectedGeneration: generation(),
-          });
+          if (sourceReplica && checkpoint) {
+            sourceReplica = applyManagerAction(sourceReplica, {
+              type: "resume",
+              effortId: sourceReplica.focusEffortId,
+              actor: {
+                hostId: checkpoint.sourceAuthority.hostId,
+                sessionId: "source-session",
+                authorityEpoch: checkpoint.sourceAuthority.epoch,
+                leaseToken: checkpoint.efforts[sourceReplica.focusEffortId]!.lease?.token ?? null,
+              },
+              expectedGeneration: sourceReplica.efforts[sourceReplica.focusEffortId]!.generation,
+            });
+            lastSourceResult = sourceReplica.lastResult;
+          }
           break;
         case "m":
           writeAction({ type: "complete", effortId: state.focusEffortId });
@@ -182,12 +222,21 @@ async function main(): Promise<void> {
           actor = {
             hostId: state.authority.hostId,
             sessionId: state.focusEffortId === "effort-alpha" ? "session-a" : "session-b",
+            authorityEpoch: state.authority.epoch,
+            leaseToken: null,
           };
           break;
         case "z":
           state = createPrototypePortfolio();
-          actor = { hostId: "host-a", sessionId: "session-a" };
+          actor = {
+            hostId: "host-a",
+            sessionId: "session-a",
+            authorityEpoch: 1,
+            leaseToken: null,
+          };
           checkpoint = null;
+          sourceReplica = null;
+          lastSourceResult = null;
           break;
       }
     }

--- a/apps/dev/src/prototypes/manager-portfolio-explorer.ts
+++ b/apps/dev/src/prototypes/manager-portfolio-explorer.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+/** PROTOTYPE terminal shell. The state machine lives in manager-portfolio-machine.ts. */
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import {
+  applyManagerAction,
+  createPrototypePortfolio,
+  exportCheckpoint,
+  importCheckpoint,
+  type ManagerActor,
+  type ManagerCheckpoint,
+  type ManagerPortfolio,
+} from "./manager-portfolio-machine.js";
+
+const bold = "\x1b[1m";
+const dim = "\x1b[2m";
+const reset = "\x1b[0m";
+
+let state = createPrototypePortfolio();
+let actor: ManagerActor = { hostId: "host-a", sessionId: "session-a" };
+let checkpoint: ManagerCheckpoint | null = null;
+
+function focusedEffort() {
+  return state.efforts[state.focusEffortId]!;
+}
+
+function generation(): number {
+  return focusedEffort().generation;
+}
+
+function projectionLine(repository: string): string {
+  const item = focusedEffort().projections[repository]!;
+  const ref = item.mapRef ?? "-";
+  const failure = item.lastFailure ? ` failure=${item.lastFailure}` : "";
+  return `  ${repository}: ${item.status} attempts=${item.attempts} map=${ref} owner-work=${item.ownerWork}${failure}`;
+}
+
+function render(): void {
+  stdout.write("\x1b[2J\x1b[H");
+  const effort = focusedEffort();
+  const otherEfforts = Object.values(state.efforts)
+    .filter((item) => item.id !== effort.id)
+    .map(
+      (item) =>
+        `${item.id}:${item.lifecycle}@g${item.generation} lease=${item.lease?.sessionId ?? "-"}`,
+    )
+    .join(", ");
+
+  console.log(`${bold}Manager portfolio transition explorer${reset} ${dim}(PROTOTYPE — in memory)${reset}`);
+  console.log(`${bold}authority${reset}: ${state.authority.hostId}@epoch-${state.authority.epoch}`);
+  console.log(`${bold}portfolio generation${reset}: ${state.portfolioGeneration}`);
+  console.log(`${bold}current actor${reset}: ${actor.hostId}/${actor.sessionId}`);
+  console.log(`${bold}sessions${reset}: ${JSON.stringify(state.sessions)}`);
+  console.log(`${bold}checkpoint slot${reset}: ${checkpoint ? `exported@g${checkpoint.portfolioGeneration}` : "empty"}`);
+  console.log(`${bold}other efforts${reset}: ${otherEfforts || "none"}`);
+  console.log();
+  console.log(`${bold}focused effort${reset}: ${effort.id} — ${effort.name}`);
+  console.log(`${bold}destination${reset}: ${effort.destination}`);
+  console.log(`${bold}lifecycle${reset}: ${effort.lifecycle}`);
+  console.log(`${bold}generation${reset}: ${effort.generation}`);
+  console.log(`${bold}lease${reset}: ${effort.lease ? JSON.stringify(effort.lease) : "none"}`);
+  console.log(`${bold}unmaterialised intent${reset}: ${JSON.stringify(effort.unmaterialisedIntent)}`);
+  console.log(`${bold}last transition${reset}: ${effort.lastTransition}`);
+  console.log(`${bold}repository projections${reset}:`);
+  console.log(Object.keys(effort.projections).map(projectionLine).join("\n"));
+  console.log();
+  console.log(
+    `${bold}last result${reset}: ${state.lastResult.kind}/${state.lastResult.code} — ${state.lastResult.message}`,
+  );
+  console.log();
+  console.log(`${bold}Transitions${reset}`);
+  console.log("[r] resume/acquire lease  [e] end/pause  [c] crash session  [v] recover lease");
+  console.log("[1] publish repo-red  [2] fail repo-blue  [3] retry repo-blue  [g] stale write");
+  console.log("[x] export checkpoint  [i] import on host-b  [o] old-host write  [m] complete");
+  console.log("[f] focus other effort  [z] reset  [q] quit");
+}
+
+function act(action: Parameters<typeof applyManagerAction>[1]): void {
+  state = applyManagerAction(state, action);
+}
+
+function writeAction(
+  action: Omit<Extract<Parameters<typeof applyManagerAction>[1], { effortId: string }>, "actor" | "expectedGeneration">,
+): void {
+  act({ ...action, actor, expectedGeneration: generation() } as Parameters<typeof applyManagerAction>[1]);
+}
+
+function chooseRepository(name: string): boolean {
+  return Boolean(focusedEffort().projections[name]);
+}
+
+async function main(): Promise<void> {
+  const terminal = createInterface({ input: stdin, output: stdout });
+  try {
+    while (true) {
+      render();
+      const command = (await terminal.question(`${bold}>${reset} `)).trim().toLowerCase();
+      if (command === "q") break;
+
+      switch (command) {
+        case "r":
+          writeAction({ type: "resume", effortId: state.focusEffortId });
+          break;
+        case "e":
+          writeAction({ type: "end", effortId: state.focusEffortId });
+          break;
+        case "c":
+          act({ type: "crash-session", actor });
+          break;
+        case "v": {
+          actor = { ...actor, sessionId: "recovery-session" };
+          writeAction({ type: "recover-lease", effortId: state.focusEffortId });
+          break;
+        }
+        case "1":
+          if (chooseRepository("repo-red")) {
+            writeAction({
+              type: "publish-map",
+              effortId: state.focusEffortId,
+              repository: "repo-red",
+              outcome: "published",
+            });
+          }
+          break;
+        case "2":
+          if (chooseRepository("repo-blue")) {
+            writeAction({
+              type: "publish-map",
+              effortId: state.focusEffortId,
+              repository: "repo-blue",
+              outcome: "failed",
+            });
+          }
+          break;
+        case "3":
+          if (chooseRepository("repo-blue")) {
+            writeAction({
+              type: "publish-map",
+              effortId: state.focusEffortId,
+              repository: "repo-blue",
+              outcome: "published",
+            });
+          }
+          break;
+        case "g":
+          act({
+            type: "publish-map",
+            effortId: state.focusEffortId,
+            repository: Object.keys(focusedEffort().projections)[0]!,
+            outcome: "published",
+            actor,
+            expectedGeneration: Math.max(0, generation() - 1),
+          });
+          break;
+        case "x":
+          checkpoint = exportCheckpoint(state);
+          break;
+        case "i":
+          if (checkpoint) {
+            state = importCheckpoint(checkpoint, "host-b");
+            actor = { hostId: "host-b", sessionId: "imported-session" };
+          }
+          break;
+        case "o":
+          act({
+            type: "resume",
+            effortId: state.focusEffortId,
+            actor: { hostId: "host-a", sessionId: "source-session" },
+            expectedGeneration: generation(),
+          });
+          break;
+        case "m":
+          writeAction({ type: "complete", effortId: state.focusEffortId });
+          break;
+        case "f":
+          state = {
+            ...state,
+            focusEffortId:
+              state.focusEffortId === "effort-alpha" ? "effort-beta" : "effort-alpha",
+          };
+          actor = {
+            hostId: state.authority.hostId,
+            sessionId: state.focusEffortId === "effort-alpha" ? "session-a" : "session-b",
+          };
+          break;
+        case "z":
+          state = createPrototypePortfolio();
+          actor = { hostId: "host-a", sessionId: "session-a" };
+          checkpoint = null;
+          break;
+      }
+    }
+  } finally {
+    terminal.close();
+  }
+}
+
+await main();

--- a/apps/dev/src/prototypes/manager-portfolio-machine.ts
+++ b/apps/dev/src/prototypes/manager-portfolio-machine.ts
@@ -56,6 +56,7 @@ export interface TransitionResult {
 
 export interface ManagerPortfolio {
   prototype: true;
+  replicaStatus: "active" | "retired";
   authority: { hostId: string; epoch: number };
   portfolioGeneration: number;
   focusEffortId: string;
@@ -141,6 +142,7 @@ function effort(
 export function createPrototypePortfolio(): ManagerPortfolio {
   return {
     prototype: true,
+    replicaStatus: "active",
     authority: { hostId: "host-a", epoch: 1 },
     portfolioGeneration: 0,
     focusEffortId: "effort-alpha",
@@ -207,6 +209,14 @@ function guardMutation(
       result: rejected(
         "authority-epoch-conflict",
         `Actor epoch ${action.actor.authorityEpoch} is fenced; durable authority epoch is ${state.authority.epoch}.`,
+      ),
+    };
+  }
+  if (state.replicaStatus === "retired") {
+    return {
+      result: rejected(
+        "replica-retired",
+        "Checkpoint transfer retired this replica; only the destination replica may mutate.",
       ),
     };
   }
@@ -453,6 +463,15 @@ export function applyManagerAction(
         ),
       );
     }
+    if (state.replicaStatus === "retired") {
+      return withResult(
+        state,
+        rejected(
+          "replica-retired",
+          "Checkpoint transfer retired this replica; only the destination replica may mutate.",
+        ),
+      );
+    }
     return {
       ...state,
       sessions: { ...state.sessions, [sessionKey(action.actor)]: "crashed" },
@@ -514,6 +533,7 @@ export function importCheckpoint(
   const portfolioGeneration = checkpoint.portfolioGeneration + 1;
   const sourceReplica: ManagerPortfolio = {
     ...source,
+    replicaStatus: "retired",
     authority,
     portfolioGeneration,
     focusEffortId: checkpoint.focusEffortId,
@@ -525,6 +545,7 @@ export function importCheckpoint(
   };
   const destination: ManagerPortfolio = {
     prototype: true,
+    replicaStatus: "active",
     authority,
     portfolioGeneration,
     focusEffortId: checkpoint.focusEffortId,

--- a/apps/dev/src/prototypes/manager-portfolio-machine.ts
+++ b/apps/dev/src/prototypes/manager-portfolio-machine.ts
@@ -16,6 +16,8 @@ export type ProjectionStatus = "unpublished" | "failed" | "published";
 export interface ManagerActor {
   hostId: string;
   sessionId: string;
+  authorityEpoch: number;
+  leaseToken: string | null;
 }
 
 export interface EffortLease {
@@ -68,6 +70,11 @@ export interface ManagerCheckpoint {
   portfolioGeneration: number;
   focusEffortId: string;
   efforts: Record<string, ManagerEffort>;
+}
+
+export interface ManagerCheckpointTransfer {
+  source: ManagerPortfolio;
+  destination: ManagerPortfolio;
 }
 
 type EffortMutation = {
@@ -195,6 +202,14 @@ function guardMutation(
       ),
     };
   }
+  if (action.actor.authorityEpoch !== state.authority.epoch) {
+    return {
+      result: rejected(
+        "authority-epoch-conflict",
+        `Actor epoch ${action.actor.authorityEpoch} is fenced; durable authority epoch is ${state.authority.epoch}.`,
+      ),
+    };
+  }
   const current = state.efforts[action.effortId];
   if (!current) {
     return { result: rejected("effort-not-found", `Unknown effort ${action.effortId}.`) };
@@ -223,6 +238,12 @@ function requireLease(
       `Effort ${effortRecord.id} is leased by ${effortRecord.lease.sessionId}.`,
     );
   }
+  if (effortRecord.lease.token !== actor.leaseToken) {
+    return rejected(
+      "lease-token-conflict",
+      `The supplied lease token is fenced for effort ${effortRecord.id}.`,
+    );
+  }
   return null;
 }
 
@@ -241,6 +262,18 @@ function applyResume(
     return withResult(
       state,
       rejected("lease-held", `Effort ${effortRecord.id} is leased by ${effortRecord.lease.sessionId}.`),
+    );
+  }
+  if (effortRecord.lease && effortRecord.lease.token !== actor.leaseToken) {
+    return withResult(
+      state,
+      rejected("lease-token-conflict", `The supplied lease token is fenced for effort ${effortRecord.id}.`),
+    );
+  }
+  if (!effortRecord.lease && actor.leaseToken !== null) {
+    return withResult(
+      state,
+      rejected("lease-token-conflict", `The supplied lease token no longer owns effort ${effortRecord.id}.`),
     );
   }
   if (effortRecord.lease?.sessionId === actor.sessionId && effortRecord.lifecycle === "active") {
@@ -342,6 +375,12 @@ function applyRecovery(
   effortRecord: ManagerEffort,
   actor: ManagerActor,
 ): ManagerPortfolio {
+  if (actor.leaseToken !== null) {
+    return withResult(
+      state,
+      rejected("lease-token-conflict", "Lease recovery must acquire a fresh fencing token."),
+    );
+  }
   if (!effortRecord.lease) {
     return withResult(state, rejected("no-orphaned-lease", "There is no lease to recover."));
   }
@@ -405,6 +444,15 @@ export function applyManagerAction(
     if (action.actor.hostId !== state.authority.hostId) {
       return withResult(state, rejected("not-authority", "Only the active host has this session."));
     }
+    if (action.actor.authorityEpoch !== state.authority.epoch) {
+      return withResult(
+        state,
+        rejected(
+          "authority-epoch-conflict",
+          `Actor epoch ${action.actor.authorityEpoch} is fenced; durable authority epoch is ${state.authority.epoch}.`,
+        ),
+      );
+    }
     return {
       ...state,
       sessions: { ...state.sessions, [sessionKey(action.actor)]: "crashed" },
@@ -447,9 +495,10 @@ export function exportCheckpoint(state: ManagerPortfolio): ManagerCheckpoint {
 }
 
 export function importCheckpoint(
+  source: ManagerPortfolio,
   checkpoint: ManagerCheckpoint,
   destinationHostId: string,
-): ManagerPortfolio {
+): ManagerCheckpointTransfer {
   const efforts = Object.fromEntries(
     Object.entries(cloneEfforts(checkpoint.efforts)).map(([id, record]) => [
       id,
@@ -461,16 +510,30 @@ export function importCheckpoint(
       },
     ]),
   );
-  return {
+  const authority = { hostId: destinationHostId, epoch: checkpoint.sourceAuthority.epoch + 1 };
+  const portfolioGeneration = checkpoint.portfolioGeneration + 1;
+  const sourceReplica: ManagerPortfolio = {
+    ...source,
+    authority,
+    portfolioGeneration,
+    focusEffortId: checkpoint.focusEffortId,
+    efforts: cloneEfforts(efforts),
+    lastResult: applied(
+      "checkpoint-source-retired",
+      `${source.authority.hostId} retired at authority epoch ${authority.epoch}; its prior credentials are fenced.`,
+    ),
+  };
+  const destination: ManagerPortfolio = {
     prototype: true,
-    authority: { hostId: destinationHostId, epoch: checkpoint.sourceAuthority.epoch + 1 },
-    portfolioGeneration: checkpoint.portfolioGeneration + 1,
+    authority,
+    portfolioGeneration,
     focusEffortId: checkpoint.focusEffortId,
     sessions: {},
-    efforts,
+    efforts: cloneEfforts(efforts),
     lastResult: applied(
       "checkpoint-imported",
       `${destinationHostId} is the sole writer; source leases cannot mutate this generation.`,
     ),
   };
+  return { source: sourceReplica, destination };
 }

--- a/apps/dev/src/prototypes/manager-portfolio-machine.ts
+++ b/apps/dev/src/prototypes/manager-portfolio-machine.ts
@@ -1,0 +1,476 @@
+/**
+ * PROTOTYPE — delete or absorb after the Manager storage decisions are settled.
+ *
+ * Question: can one small, storage-agnostic state machine make Manager's effort
+ * lifecycle, effort-scoped leases, optimistic generations, crash recovery,
+ * checkpoint authority transfer, and partial cross-repository publication
+ * concrete enough to expose disputed transitions before a store is selected?
+ *
+ * This module is deliberately pure and in-memory. The terminal explorer is a
+ * throwaway adapter; this reducer is the portable part under evaluation.
+ */
+
+export type ManagerLifecycle = "inbox" | "active" | "paused" | "completed" | "abandoned";
+export type ProjectionStatus = "unpublished" | "failed" | "published";
+
+export interface ManagerActor {
+  hostId: string;
+  sessionId: string;
+}
+
+export interface EffortLease {
+  sessionId: string;
+  token: string;
+  acquiredGeneration: number;
+}
+
+export interface RepositoryProjection {
+  repository: string;
+  status: ProjectionStatus;
+  attempts: number;
+  idempotencyKey: string;
+  mapRef: string | null;
+  ownerWork: "not-started" | "continues";
+  lastFailure: string | null;
+}
+
+export interface ManagerEffort {
+  id: string;
+  name: string;
+  destination: string;
+  lifecycle: ManagerLifecycle;
+  generation: number;
+  lease: EffortLease | null;
+  unmaterialisedIntent: string[];
+  projections: Record<string, RepositoryProjection>;
+  lastTransition: string;
+}
+
+export interface TransitionResult {
+  kind: "applied" | "rejected";
+  code: string;
+  message: string;
+}
+
+export interface ManagerPortfolio {
+  prototype: true;
+  authority: { hostId: string; epoch: number };
+  portfolioGeneration: number;
+  focusEffortId: string;
+  sessions: Record<string, "active" | "crashed">;
+  efforts: Record<string, ManagerEffort>;
+  lastResult: TransitionResult;
+}
+
+export interface ManagerCheckpoint {
+  prototype: true;
+  sourceAuthority: { hostId: string; epoch: number };
+  portfolioGeneration: number;
+  focusEffortId: string;
+  efforts: Record<string, ManagerEffort>;
+}
+
+type EffortMutation = {
+  effortId: string;
+  actor: ManagerActor;
+  expectedGeneration: number;
+};
+
+export type ManagerAction =
+  | (EffortMutation & { type: "resume" })
+  | (EffortMutation & { type: "end" })
+  | (EffortMutation & { type: "complete" })
+  | (EffortMutation & { type: "recover-lease" })
+  | (EffortMutation & {
+      type: "publish-map";
+      repository: string;
+      outcome: "published" | "failed";
+    })
+  | { type: "crash-session"; actor: ManagerActor };
+
+const applied = (code: string, message: string): TransitionResult => ({
+  kind: "applied",
+  code,
+  message,
+});
+
+const rejected = (code: string, message: string): TransitionResult => ({
+  kind: "rejected",
+  code,
+  message,
+});
+
+function projection(repository: string, effortId: string): RepositoryProjection {
+  return {
+    repository,
+    status: "unpublished",
+    attempts: 0,
+    idempotencyKey: `manager-map/${effortId}/${repository}`,
+    mapRef: null,
+    ownerWork: "not-started",
+    lastFailure: null,
+  };
+}
+
+function effort(
+  id: string,
+  name: string,
+  destination: string,
+  repositories: string[],
+): ManagerEffort {
+  return {
+    id,
+    name,
+    destination,
+    lifecycle: "inbox",
+    generation: 0,
+    lease: null,
+    unmaterialisedIntent: [`Clarify acceptance boundary for ${destination}`],
+    projections: Object.fromEntries(repositories.map((repo) => [repo, projection(repo, id)])),
+    lastTransition: "created in local inbox",
+  };
+}
+
+export function createPrototypePortfolio(): ManagerPortfolio {
+  return {
+    prototype: true,
+    authority: { hostId: "host-a", epoch: 1 },
+    portfolioGeneration: 0,
+    focusEffortId: "effort-alpha",
+    sessions: {},
+    efforts: {
+      "effort-alpha": effort(
+        "effort-alpha",
+        "Ship cross-repository Manager journey",
+        "Acceptance journey delivered in both repositories",
+        ["repo-red", "repo-blue"],
+      ),
+      "effort-beta": effort(
+        "effort-beta",
+        "Independent documentation effort",
+        "Operator guide published",
+        ["repo-docs"],
+      ),
+    },
+    lastResult: applied("ready", "Prototype portfolio initialised."),
+  };
+}
+
+function withResult(state: ManagerPortfolio, result: TransitionResult): ManagerPortfolio {
+  return { ...state, lastResult: result };
+}
+
+function sessionKey(actor: ManagerActor): string {
+  return `${actor.hostId}/${actor.sessionId}`;
+}
+
+function replaceEffort(
+  state: ManagerPortfolio,
+  previous: ManagerEffort,
+  patch: Partial<ManagerEffort>,
+  result: TransitionResult,
+): ManagerPortfolio {
+  const nextGeneration = previous.generation + 1;
+  return {
+    ...state,
+    portfolioGeneration: state.portfolioGeneration + 1,
+    sessions: { ...state.sessions },
+    efforts: {
+      ...state.efforts,
+      [previous.id]: { ...previous, ...patch, generation: nextGeneration },
+    },
+    lastResult: result,
+  };
+}
+
+function guardMutation(
+  state: ManagerPortfolio,
+  action: EffortMutation,
+): { effort: ManagerEffort } | { result: TransitionResult } {
+  if (action.actor.hostId !== state.authority.hostId) {
+    return {
+      result: rejected(
+        "not-authority",
+        `${action.actor.hostId} is retired; ${state.authority.hostId} owns writer epoch ${state.authority.epoch}.`,
+      ),
+    };
+  }
+  const current = state.efforts[action.effortId];
+  if (!current) {
+    return { result: rejected("effort-not-found", `Unknown effort ${action.effortId}.`) };
+  }
+  if (current.generation !== action.expectedGeneration) {
+    return {
+      result: rejected(
+        "generation-conflict",
+        `Expected generation ${action.expectedGeneration}; durable generation is ${current.generation}.`,
+      ),
+    };
+  }
+  return { effort: current };
+}
+
+function requireLease(
+  effortRecord: ManagerEffort,
+  actor: ManagerActor,
+): TransitionResult | null {
+  if (!effortRecord.lease) {
+    return rejected("lease-required", `Effort ${effortRecord.id} has no writer lease.`);
+  }
+  if (effortRecord.lease.sessionId !== actor.sessionId) {
+    return rejected(
+      "lease-held",
+      `Effort ${effortRecord.id} is leased by ${effortRecord.lease.sessionId}.`,
+    );
+  }
+  return null;
+}
+
+function applyResume(
+  state: ManagerPortfolio,
+  effortRecord: ManagerEffort,
+  actor: ManagerActor,
+): ManagerPortfolio {
+  if (effortRecord.lifecycle === "completed" || effortRecord.lifecycle === "abandoned") {
+    return withResult(
+      state,
+      rejected("terminal-effort", `${effortRecord.lifecycle} efforts cannot resume.`),
+    );
+  }
+  if (effortRecord.lease && effortRecord.lease.sessionId !== actor.sessionId) {
+    return withResult(
+      state,
+      rejected("lease-held", `Effort ${effortRecord.id} is leased by ${effortRecord.lease.sessionId}.`),
+    );
+  }
+  if (effortRecord.lease?.sessionId === actor.sessionId && effortRecord.lifecycle === "active") {
+    return withResult(state, applied("already-active", `${actor.sessionId} already owns the active effort.`));
+  }
+  const nextGeneration = effortRecord.generation + 1;
+  const next = replaceEffort(
+    state,
+    effortRecord,
+    {
+      lifecycle: "active",
+      lease: {
+        sessionId: actor.sessionId,
+        token: `${effortRecord.id}/lease/${nextGeneration}`,
+        acquiredGeneration: nextGeneration,
+      },
+      lastTransition: `resumed by ${actor.sessionId}`,
+    },
+    applied("resumed", `${effortRecord.id} is active under an effort-scoped lease.`),
+  );
+  next.sessions[sessionKey(actor)] = "active";
+  return next;
+}
+
+function applyEnd(
+  state: ManagerPortfolio,
+  effortRecord: ManagerEffort,
+  actor: ManagerActor,
+): ManagerPortfolio {
+  const leaseFailure = requireLease(effortRecord, actor);
+  if (leaseFailure) return withResult(state, leaseFailure);
+  if (effortRecord.lifecycle !== "active") {
+    return withResult(state, rejected("not-active", "Only an active effort can be ended."));
+  }
+  return replaceEffort(
+    state,
+    effortRecord,
+    {
+      lifecycle: "paused",
+      lease: null,
+      lastTransition: `ended by ${actor.sessionId}; owner work remains independent`,
+    },
+    applied("paused", `${effortRecord.id} paused; published owner work continues.`),
+  );
+}
+
+function applyPublish(
+  state: ManagerPortfolio,
+  effortRecord: ManagerEffort,
+  action: Extract<ManagerAction, { type: "publish-map" }>,
+): ManagerPortfolio {
+  const leaseFailure = requireLease(effortRecord, action.actor);
+  if (leaseFailure) return withResult(state, leaseFailure);
+  if (effortRecord.lifecycle !== "active") {
+    return withResult(state, rejected("not-active", "Map publication requires an active effort."));
+  }
+  const current = effortRecord.projections[action.repository];
+  if (!current) {
+    return withResult(
+      state,
+      rejected("repository-out-of-scope", `${action.repository} is not in the effort boundary.`),
+    );
+  }
+  if (current.status === "published") {
+    return withResult(
+      state,
+      applied("map-already-published", `${current.mapRef} already satisfies the idempotency key.`),
+    );
+  }
+  const published = action.outcome === "published";
+  const nextProjection: RepositoryProjection = {
+    ...current,
+    attempts: current.attempts + 1,
+    status: published ? "published" : "failed",
+    mapRef: published ? `${action.repository}#manager-map-${effortRecord.id}` : null,
+    ownerWork: published ? "continues" : "not-started",
+    lastFailure: published ? null : "simulated tracker rejection",
+  };
+  return replaceEffort(
+    state,
+    effortRecord,
+    {
+      projections: { ...effortRecord.projections, [action.repository]: nextProjection },
+      lastTransition: published
+        ? `published ${action.repository} Manager map`
+        : `${action.repository} publication failed after other writes may have succeeded`,
+    },
+    applied(
+      published ? "map-published" : "publication-partial",
+      published
+        ? `${action.repository} map published with a stable idempotency key.`
+        : `${action.repository} failed; successful repository maps remain authoritative.`,
+    ),
+  );
+}
+
+function applyRecovery(
+  state: ManagerPortfolio,
+  effortRecord: ManagerEffort,
+  actor: ManagerActor,
+): ManagerPortfolio {
+  if (!effortRecord.lease) {
+    return withResult(state, rejected("no-orphaned-lease", "There is no lease to recover."));
+  }
+  const previousSession = `${actor.hostId}/${effortRecord.lease.sessionId}`;
+  if (state.sessions[previousSession] !== "crashed") {
+    return withResult(
+      state,
+      rejected("lease-holder-live", `${effortRecord.lease.sessionId} is not recorded as crashed.`),
+    );
+  }
+  const nextGeneration = effortRecord.generation + 1;
+  const next = replaceEffort(
+    state,
+    effortRecord,
+    {
+      lease: {
+        sessionId: actor.sessionId,
+        token: `${effortRecord.id}/recovered-lease/${nextGeneration}`,
+        acquiredGeneration: nextGeneration,
+      },
+      lastTransition: `orphaned lease recovered by ${actor.sessionId}`,
+    },
+    applied("lease-recovered", `Recovered ${effortRecord.id} after the prior session crashed.`),
+  );
+  next.sessions[sessionKey(actor)] = "active";
+  return next;
+}
+
+function applyComplete(
+  state: ManagerPortfolio,
+  effortRecord: ManagerEffort,
+  actor: ManagerActor,
+): ManagerPortfolio {
+  const leaseFailure = requireLease(effortRecord, actor);
+  if (leaseFailure) return withResult(state, leaseFailure);
+  const incomplete = Object.values(effortRecord.projections).filter(
+    (item) => item.status !== "published",
+  );
+  if (incomplete.length > 0) {
+    return withResult(
+      state,
+      rejected(
+        "publication-incomplete",
+        `Cannot complete while ${incomplete.map((item) => item.repository).join(", ")} remain unpublished.`,
+      ),
+    );
+  }
+  return replaceEffort(
+    state,
+    effortRecord,
+    { lifecycle: "completed", lease: null, lastTransition: "acceptance journey completed" },
+    applied("completed", `${effortRecord.id} reached a terminal disposition.`),
+  );
+}
+
+export function applyManagerAction(
+  state: ManagerPortfolio,
+  action: ManagerAction,
+): ManagerPortfolio {
+  if (action.type === "crash-session") {
+    if (action.actor.hostId !== state.authority.hostId) {
+      return withResult(state, rejected("not-authority", "Only the active host has this session."));
+    }
+    return {
+      ...state,
+      sessions: { ...state.sessions, [sessionKey(action.actor)]: "crashed" },
+      lastResult: applied(
+        "session-crashed",
+        `Volatile session ${action.actor.sessionId} vanished; durable effort leases were not rewritten.`,
+      ),
+    };
+  }
+
+  const guarded = guardMutation(state, action);
+  if ("result" in guarded) return withResult(state, guarded.result);
+
+  switch (action.type) {
+    case "resume":
+      return applyResume(state, guarded.effort, action.actor);
+    case "end":
+      return applyEnd(state, guarded.effort, action.actor);
+    case "publish-map":
+      return applyPublish(state, guarded.effort, action);
+    case "recover-lease":
+      return applyRecovery(state, guarded.effort, action.actor);
+    case "complete":
+      return applyComplete(state, guarded.effort, action.actor);
+  }
+}
+
+function cloneEfforts(efforts: Record<string, ManagerEffort>): Record<string, ManagerEffort> {
+  return structuredClone(efforts);
+}
+
+export function exportCheckpoint(state: ManagerPortfolio): ManagerCheckpoint {
+  return {
+    prototype: true,
+    sourceAuthority: { ...state.authority },
+    portfolioGeneration: state.portfolioGeneration,
+    focusEffortId: state.focusEffortId,
+    efforts: cloneEfforts(state.efforts),
+  };
+}
+
+export function importCheckpoint(
+  checkpoint: ManagerCheckpoint,
+  destinationHostId: string,
+): ManagerPortfolio {
+  const efforts = Object.fromEntries(
+    Object.entries(cloneEfforts(checkpoint.efforts)).map(([id, record]) => [
+      id,
+      {
+        ...record,
+        generation: record.generation + 1,
+        lease: null,
+        lastTransition: `checkpoint imported by ${destinationHostId}; prior leases invalidated`,
+      },
+    ]),
+  );
+  return {
+    prototype: true,
+    authority: { hostId: destinationHostId, epoch: checkpoint.sourceAuthority.epoch + 1 },
+    portfolioGeneration: checkpoint.portfolioGeneration + 1,
+    focusEffortId: checkpoint.focusEffortId,
+    sessions: {},
+    efforts,
+    lastResult: applied(
+      "checkpoint-imported",
+      `${destinationHostId} is the sole writer; source leases cannot mutate this generation.`,
+    ),
+  };
+}

--- a/apps/dev/tests/manager-portfolio-prototype.test.ts
+++ b/apps/dev/tests/manager-portfolio-prototype.test.ts
@@ -207,6 +207,17 @@ describe("Manager portfolio transition prototype", () => {
     expect(rejected.portfolioGeneration).toBe(source.portfolioGeneration);
     expect(rejected.lastResult).toMatchObject({ kind: "rejected", code: "not-authority" });
 
+    const splitBrainWrite = applyManagerAction(source, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: actor(source, "session-b"),
+      expectedGeneration: effortGeneration(source),
+    });
+    expect(splitBrainWrite.lastResult).toMatchObject({
+      kind: "rejected",
+      code: "replica-retired",
+    });
+
     const resumed = applyManagerAction(imported, {
       type: "resume",
       effortId: "effort-alpha",

--- a/apps/dev/tests/manager-portfolio-prototype.test.ts
+++ b/apps/dev/tests/manager-portfolio-prototype.test.ts
@@ -4,13 +4,34 @@ import {
   createPrototypePortfolio,
   exportCheckpoint,
   importCheckpoint,
+  type ManagerActor,
 } from "../src/prototypes/manager-portfolio-machine.js";
 
+type Portfolio = ReturnType<typeof createPrototypePortfolio>;
+
 function effortGeneration(
-  state: ReturnType<typeof createPrototypePortfolio>,
+  state: Portfolio,
   effortId = "effort-alpha",
 ): number {
   return state.efforts[effortId]!.generation;
+}
+
+function actor(
+  state: Portfolio,
+  sessionId: string,
+  leaseToken: string | null = null,
+  hostId = state.authority.hostId,
+  authorityEpoch = state.authority.epoch,
+): ManagerActor {
+  return { hostId, sessionId, authorityEpoch, leaseToken };
+}
+
+function leaseActor(
+  state: Portfolio,
+  sessionId: string,
+  effortId = "effort-alpha",
+): ManagerActor {
+  return actor(state, sessionId, state.efforts[effortId]!.lease!.token);
 }
 
 describe("Manager portfolio transition prototype", () => {
@@ -20,13 +41,13 @@ describe("Manager portfolio transition prototype", () => {
     state = applyManagerAction(state, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: actor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
     state = applyManagerAction(state, {
       type: "resume",
       effortId: "effort-beta",
-      actor: { hostId: "host-a", sessionId: "session-b" },
+      actor: actor(state, "session-b"),
       expectedGeneration: effortGeneration(state, "effort-beta"),
     });
 
@@ -36,7 +57,7 @@ describe("Manager portfolio transition prototype", () => {
     const rejected = applyManagerAction(state, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-b" },
+      actor: actor(state, "session-b"),
       expectedGeneration: effortGeneration(state),
     });
 
@@ -51,7 +72,7 @@ describe("Manager portfolio transition prototype", () => {
     state = applyManagerAction(state, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: actor(state, "session-a"),
       expectedGeneration: staleGeneration,
     });
 
@@ -60,7 +81,7 @@ describe("Manager portfolio transition prototype", () => {
       effortId: "effort-alpha",
       repository: "repo-red",
       outcome: "published",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: leaseActor(state, "session-a"),
       expectedGeneration: staleGeneration,
     });
 
@@ -75,7 +96,7 @@ describe("Manager portfolio transition prototype", () => {
     state = applyManagerAction(state, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: actor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
     state = applyManagerAction(state, {
@@ -83,13 +104,13 @@ describe("Manager portfolio transition prototype", () => {
       effortId: "effort-alpha",
       repository: "repo-red",
       outcome: "published",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: leaseActor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
     state = applyManagerAction(state, {
       type: "end",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: leaseActor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
 
@@ -102,7 +123,7 @@ describe("Manager portfolio transition prototype", () => {
     state = applyManagerAction(state, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-b" },
+      actor: actor(state, "session-b"),
       expectedGeneration: effortGeneration(state),
     });
     expect(state.efforts["effort-alpha"]).toMatchObject({ lifecycle: "active" });
@@ -114,26 +135,50 @@ describe("Manager portfolio transition prototype", () => {
     state = applyManagerAction(state, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: actor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
     state = applyManagerAction(state, {
       type: "crash-session",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: leaseActor(state, "session-a"),
     });
 
     expect(state.efforts["effort-alpha"]!.lease?.sessionId).toBe("session-a");
     expect(state.sessions["host-a/session-a"]).toBe("crashed");
 
+    const abandonedToken = state.efforts["effort-alpha"]!.lease!.token;
     state = applyManagerAction(state, {
       type: "recover-lease",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "recovery-session" },
+      actor: actor(state, "recovery-session"),
       expectedGeneration: effortGeneration(state),
     });
 
     expect(state.efforts["effort-alpha"]!.lease?.sessionId).toBe("recovery-session");
     expect(state.lastResult).toMatchObject({ kind: "applied", code: "lease-recovered" });
+
+    const staleWriter = applyManagerAction(state, {
+      type: "publish-map",
+      effortId: "effort-alpha",
+      repository: "repo-red",
+      outcome: "published",
+      actor: actor(state, "recovery-session", abandonedToken),
+      expectedGeneration: effortGeneration(state),
+    });
+    expect(staleWriter.lastResult).toMatchObject({
+      kind: "rejected",
+      code: "lease-token-conflict",
+    });
+
+    state = applyManagerAction(state, {
+      type: "publish-map",
+      effortId: "effort-alpha",
+      repository: "repo-red",
+      outcome: "published",
+      actor: leaseActor(state, "recovery-session"),
+      expectedGeneration: effortGeneration(state),
+    });
+    expect(state.lastResult).toMatchObject({ kind: "applied", code: "map-published" });
   });
 
   it("transfers write authority on checkpoint import and invalidates source leases", () => {
@@ -141,32 +186,53 @@ describe("Manager portfolio transition prototype", () => {
     source = applyManagerAction(source, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: actor(source, "session-a"),
       expectedGeneration: effortGeneration(source),
     });
     const checkpoint = exportCheckpoint(source);
-    const imported = importCheckpoint(checkpoint, "host-b");
+    const transfer = importCheckpoint(source, checkpoint, "host-b");
+    source = transfer.source;
+    const imported = transfer.destination;
 
     expect(imported.authority).toEqual({ hostId: "host-b", epoch: 2 });
     expect(imported.efforts["effort-alpha"]!.lease).toBeNull();
 
-    const rejected = applyManagerAction(imported, {
+    const rejected = applyManagerAction(source, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-a" },
-      expectedGeneration: effortGeneration(imported),
+      actor: actor(source, "session-a", null, "host-a", 1),
+      expectedGeneration: effortGeneration(source),
     });
-    expect(rejected.efforts).toBe(imported.efforts);
-    expect(rejected.portfolioGeneration).toBe(imported.portfolioGeneration);
+    expect(rejected.efforts).toBe(source.efforts);
+    expect(rejected.portfolioGeneration).toBe(source.portfolioGeneration);
     expect(rejected.lastResult).toMatchObject({ kind: "rejected", code: "not-authority" });
 
     const resumed = applyManagerAction(imported, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-b", sessionId: "session-b" },
+      actor: actor(imported, "session-b"),
       expectedGeneration: effortGeneration(imported),
     });
     expect(resumed.efforts["effort-alpha"]!.lease?.sessionId).toBe("session-b");
+  });
+
+  it("fences a stale same-host writer after checkpoint authority advances", () => {
+    const original = createPrototypePortfolio();
+    const checkpoint = exportCheckpoint(original);
+    const transfer = importCheckpoint(original, checkpoint, "host-a");
+
+    const rejected = applyManagerAction(transfer.source, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: actor(transfer.source, "reused-session", null, "host-a", 1),
+      expectedGeneration: effortGeneration(transfer.source),
+    });
+
+    expect(transfer.source.authority).toEqual({ hostId: "host-a", epoch: 2 });
+    expect(rejected.lastResult).toMatchObject({
+      kind: "rejected",
+      code: "authority-epoch-conflict",
+    });
   });
 
   it("keeps partial publication explicit and retries idempotently", () => {
@@ -174,7 +240,7 @@ describe("Manager portfolio transition prototype", () => {
     state = applyManagerAction(state, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: actor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
     state = applyManagerAction(state, {
@@ -182,7 +248,7 @@ describe("Manager portfolio transition prototype", () => {
       effortId: "effort-alpha",
       repository: "repo-red",
       outcome: "published",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: leaseActor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
     state = applyManagerAction(state, {
@@ -190,7 +256,7 @@ describe("Manager portfolio transition prototype", () => {
       effortId: "effort-alpha",
       repository: "repo-blue",
       outcome: "failed",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: leaseActor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
 
@@ -204,7 +270,7 @@ describe("Manager portfolio transition prototype", () => {
       effortId: "effort-alpha",
       repository: "repo-blue",
       outcome: "published",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: leaseActor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
     const afterRetry = state;
@@ -213,7 +279,7 @@ describe("Manager portfolio transition prototype", () => {
       effortId: "effort-alpha",
       repository: "repo-blue",
       outcome: "published",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: leaseActor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
 
@@ -232,13 +298,13 @@ describe("Manager portfolio transition prototype", () => {
     state = applyManagerAction(state, {
       type: "resume",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: actor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
     const rejected = applyManagerAction(state, {
       type: "complete",
       effortId: "effort-alpha",
-      actor: { hostId: "host-a", sessionId: "session-a" },
+      actor: leaseActor(state, "session-a"),
       expectedGeneration: effortGeneration(state),
     });
 

--- a/apps/dev/tests/manager-portfolio-prototype.test.ts
+++ b/apps/dev/tests/manager-portfolio-prototype.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyManagerAction,
+  createPrototypePortfolio,
+  exportCheckpoint,
+  importCheckpoint,
+} from "../src/prototypes/manager-portfolio-machine.js";
+
+function effortGeneration(
+  state: ReturnType<typeof createPrototypePortfolio>,
+  effortId = "effort-alpha",
+): number {
+  return state.efforts[effortId]!.generation;
+}
+
+describe("Manager portfolio transition prototype", () => {
+  it("leases efforts independently but rejects a second writer for the same effort", () => {
+    let state = createPrototypePortfolio();
+
+    state = applyManagerAction(state, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+    state = applyManagerAction(state, {
+      type: "resume",
+      effortId: "effort-beta",
+      actor: { hostId: "host-a", sessionId: "session-b" },
+      expectedGeneration: effortGeneration(state, "effort-beta"),
+    });
+
+    expect(state.efforts["effort-alpha"]!.lease?.sessionId).toBe("session-a");
+    expect(state.efforts["effort-beta"]!.lease?.sessionId).toBe("session-b");
+
+    const rejected = applyManagerAction(state, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-b" },
+      expectedGeneration: effortGeneration(state),
+    });
+
+    expect(rejected.efforts).toBe(state.efforts);
+    expect(rejected.portfolioGeneration).toBe(state.portfolioGeneration);
+    expect(rejected.lastResult).toMatchObject({ kind: "rejected", code: "lease-held" });
+  });
+
+  it("rejects a stale generation instead of overwriting a newer transition", () => {
+    let state = createPrototypePortfolio();
+    const staleGeneration = effortGeneration(state);
+    state = applyManagerAction(state, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: staleGeneration,
+    });
+
+    const rejected = applyManagerAction(state, {
+      type: "publish-map",
+      effortId: "effort-alpha",
+      repository: "repo-red",
+      outcome: "published",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: staleGeneration,
+    });
+
+    expect(rejected.efforts).toBe(state.efforts);
+    expect(rejected.portfolioGeneration).toBe(state.portfolioGeneration);
+    expect(rejected.lastResult).toMatchObject({ kind: "rejected", code: "generation-conflict" });
+    expect(rejected.efforts["effort-alpha"]!.projections["repo-red"]!.status).toBe("unpublished");
+  });
+
+  it("end pauses and releases the lease without cancelling published owner work", () => {
+    let state = createPrototypePortfolio();
+    state = applyManagerAction(state, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+    state = applyManagerAction(state, {
+      type: "publish-map",
+      effortId: "effort-alpha",
+      repository: "repo-red",
+      outcome: "published",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+    state = applyManagerAction(state, {
+      type: "end",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+
+    expect(state.efforts["effort-alpha"]).toMatchObject({ lifecycle: "paused", lease: null });
+    expect(state.efforts["effort-alpha"]!.projections["repo-red"]).toMatchObject({
+      status: "published",
+      ownerWork: "continues",
+    });
+
+    state = applyManagerAction(state, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-b" },
+      expectedGeneration: effortGeneration(state),
+    });
+    expect(state.efforts["effort-alpha"]).toMatchObject({ lifecycle: "active" });
+    expect(state.efforts["effort-alpha"]!.lease?.sessionId).toBe("session-b");
+  });
+
+  it("leaves a durable lease after a crash and recovers it only from a crashed session", () => {
+    let state = createPrototypePortfolio();
+    state = applyManagerAction(state, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+    state = applyManagerAction(state, {
+      type: "crash-session",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+    });
+
+    expect(state.efforts["effort-alpha"]!.lease?.sessionId).toBe("session-a");
+    expect(state.sessions["host-a/session-a"]).toBe("crashed");
+
+    state = applyManagerAction(state, {
+      type: "recover-lease",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "recovery-session" },
+      expectedGeneration: effortGeneration(state),
+    });
+
+    expect(state.efforts["effort-alpha"]!.lease?.sessionId).toBe("recovery-session");
+    expect(state.lastResult).toMatchObject({ kind: "applied", code: "lease-recovered" });
+  });
+
+  it("transfers write authority on checkpoint import and invalidates source leases", () => {
+    let source = createPrototypePortfolio();
+    source = applyManagerAction(source, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(source),
+    });
+    const checkpoint = exportCheckpoint(source);
+    const imported = importCheckpoint(checkpoint, "host-b");
+
+    expect(imported.authority).toEqual({ hostId: "host-b", epoch: 2 });
+    expect(imported.efforts["effort-alpha"]!.lease).toBeNull();
+
+    const rejected = applyManagerAction(imported, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(imported),
+    });
+    expect(rejected.efforts).toBe(imported.efforts);
+    expect(rejected.portfolioGeneration).toBe(imported.portfolioGeneration);
+    expect(rejected.lastResult).toMatchObject({ kind: "rejected", code: "not-authority" });
+
+    const resumed = applyManagerAction(imported, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-b", sessionId: "session-b" },
+      expectedGeneration: effortGeneration(imported),
+    });
+    expect(resumed.efforts["effort-alpha"]!.lease?.sessionId).toBe("session-b");
+  });
+
+  it("keeps partial publication explicit and retries idempotently", () => {
+    let state = createPrototypePortfolio();
+    state = applyManagerAction(state, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+    state = applyManagerAction(state, {
+      type: "publish-map",
+      effortId: "effort-alpha",
+      repository: "repo-red",
+      outcome: "published",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+    state = applyManagerAction(state, {
+      type: "publish-map",
+      effortId: "effort-alpha",
+      repository: "repo-blue",
+      outcome: "failed",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+
+    expect(state.efforts["effort-alpha"]!.projections).toMatchObject({
+      "repo-red": { status: "published", attempts: 1 },
+      "repo-blue": { status: "failed", attempts: 1 },
+    });
+
+    state = applyManagerAction(state, {
+      type: "publish-map",
+      effortId: "effort-alpha",
+      repository: "repo-blue",
+      outcome: "published",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+    const afterRetry = state;
+    state = applyManagerAction(state, {
+      type: "publish-map",
+      effortId: "effort-alpha",
+      repository: "repo-blue",
+      outcome: "published",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+
+    expect(afterRetry.efforts["effort-alpha"]!.projections["repo-blue"]).toMatchObject({
+      status: "published",
+      mapRef: "repo-blue#manager-map-effort-alpha",
+      attempts: 2,
+    });
+    expect(state.efforts).toBe(afterRetry.efforts);
+    expect(state.portfolioGeneration).toBe(afterRetry.portfolioGeneration);
+    expect(state.lastResult).toMatchObject({ kind: "applied", code: "map-already-published" });
+  });
+
+  it("refuses completion while a repository projection is missing", () => {
+    let state = createPrototypePortfolio();
+    state = applyManagerAction(state, {
+      type: "resume",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+    const rejected = applyManagerAction(state, {
+      type: "complete",
+      effortId: "effort-alpha",
+      actor: { hostId: "host-a", sessionId: "session-a" },
+      expectedGeneration: effortGeneration(state),
+    });
+
+    expect(rejected.efforts).toBe(state.efforts);
+    expect(rejected.portfolioGeneration).toBe(state.portfolioGeneration);
+    expect(rejected.lastResult).toMatchObject({ kind: "rejected", code: "publication-incomplete" });
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2179. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2179

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787160951&installation_model_id=20659&pr_number=2281&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2281&signature=93e94a1027ae31b68428f79d8a1a0748afbe87389cab80d8337618ceca1ebe45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->