### PR TITLE
fix: #2280 main-red repair: baseline probe failures on main

### DIFF
--- a/packages/red-castle/src/WorktreeManager.test.ts
+++ b/packages/red-castle/src/WorktreeManager.test.ts
@@ -576,7 +576,7 @@ describe("WorktreeManager.create", () => {
 
     await execAsync("git rebase --abort", { cwd: first.path }).catch(() => {});
     await run(remove(first.path));
-  });
+  }, 15_000);
 
   it("reuses worktree with unpushed commits (not considered dirty)", async () => {
     const repoDir = await setupRepo();

--- a/packages/red-castle/src/createSandbox.test.ts
+++ b/packages/red-castle/src/createSandbox.test.ts
@@ -1560,7 +1560,7 @@ describe("createSandbox", () => {
       await sandbox.close();
       await rm(hostDir, { recursive: true, force: true });
     }
-  });
+  }, 15_000);
 
   it("isolated provider: close() cleans up properly", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandbox-test-"));


### PR DESCRIPTION
Automated AFK landing for #2280. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2280

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787164158&installation_model_id=20659&pr_number=2282&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2282&signature=1ae51b4b08629ec65368ed8d6a8f7099828a5162a66ab30ac01e335242df8489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->