### PR TITLE
fix: #2256 release syncs Pi manifest versions

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -695,6 +695,9 @@ jobs:
             apps/code-nav/package.json
             packages/shared/package.json
             packages/build-info/package.json
+            plugins/dev/package.json
+            plugins/memory/package.json
+            plugins/brain/package.json
           )
           # ADR 0039: both committed entrypoints are built from entrypoint-cli.ts by
           # `pnpm build` above. Stage both so a source change ships; they carry no


### PR DESCRIPTION
The release **Sync plugin manifest versions** step bumped `plugins/*/.claude-plugin` + `.codex-plugin` and `apps/*`/`packages/*` `package.json`, but **omitted `plugins/{dev,memory,brain}/package.json`** (the generated Pi manifests). After a release they stay at the previous version while `pi:manifests:check` (typecheck job) regenerates them from the bumped `plugin.json` → **every subsequent PR's typecheck goes red** until someone re-runs `pnpm pi:manifests` by hand.

Fix: add the three Pi `package.json` to the bump array. `generate-pi-manifests.mjs:121` sets `version: claudePlugin.version`, so the jq version bump matches what `pi:manifests` generates.

Closes #2256.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787183756&installation_model_id=20659&pr_number=2298&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2298&signature=50f170b3cfd9cd48ca62d857db09257ec555164ae2580f9950b7a988a64c79da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->