### PR TITLE
fix: baseline probe treats a local OOM/crash as inconclusive, not main-red

### DIFF
--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -559,12 +559,25 @@ export interface BaselineFailureEvidence {
 }
 
 interface BaselineCheckResult {
-  status: "passed" | "failed";
+  status: "passed" | "failed" | "inconclusive";
   evidence?: BaselineFailureEvidence;
 }
 
 function boundedFailureOutputTail(output: string): string {
   return output.replace(/\n+$/, "").split("\n").slice(-20).join("\n").slice(-4_000);
+}
+
+/**
+ * A baseline check that exited by SIGKILL (137, the usual OOM kill) or whose
+ * output carries a V8 heap-exhaustion / fatal-crash signature did not produce a
+ * clean test verdict — the run was killed by the environment, not by a red
+ * assertion. On the resource-constrained fleet host the full-suite baseline
+ * probe can OOM where CI (a fresh runner) passes, so a crash must NOT be read as
+ * "main is red". Treat it as inconclusive instead.
+ */
+function isCrashOrOom(code: number, output: string): boolean {
+  if (code === 137) return true;
+  return /JavaScript heap out of memory|Reached heap limit|FATAL ERROR|out of memory|\bKilled\b/i.test(output);
 }
 
 function joinCommandOutput(stdout: string, stderr: string): string {
@@ -604,6 +617,24 @@ async function runChecksForBaseline(
       continue;
     }
     const output = joinCommandOutput(result.stdout, result.stderr);
+    if (isCrashOrOom(result.code, output)) {
+      // Inconclusive, NOT a confirmed pre-existing failure. Main's CI is the
+      // validation authority; a local probe OOM/crash on the resource-constrained
+      // fleet host must not manufacture a main-red verdict CI never saw. The
+      // caller filters `status === "failed"` into the baseline-failing set, so an
+      // inconclusive result is excluded — the branch failure is attributed to the
+      // branch (a per-worker block) instead of being filed as a cross-fleet
+      // main-red repair that re-fires the whole CI/CD on a non-bug.
+      out.set(name, {
+        status: "inconclusive",
+        evidence: {
+          check: name,
+          summary: "baseline probe inconclusive (crash/OOM) — not a confirmed main-red failure",
+          outputTail: boundedFailureOutputTail(output),
+        },
+      });
+      continue;
+    }
     out.set(name, {
       status: "failed",
       evidence: {

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -705,6 +705,41 @@ describe("runFeedback — baseline probe downgrades pre-existing failures", () =
     expect(testCheck.status).toBe("failed");
   });
 
+  it("a baseline check that OOMs/crashes is INCONCLUSIVE — never a pre-existing main-red (a fleet-host OOM must not manufacture a main-red CI never saw)", async () => {
+    const exec: Exec = async (args) => {
+      const script = args[args.length - 1] ?? "";
+      const dir = args[args.indexOf("-C") + 1] ?? "";
+      const isBaseline = dir.includes("main");
+      // The worker's test fails with a clean assertion; the SAME test OOMs on the
+      // baseline (SIGKILL 137 + a V8 heap-exhaustion signature) — the exact
+      // resource-constrained-host false-positive #2300 hit.
+      if (script === "test" && !isBaseline) return { code: 1, stdout: "FAIL", stderr: "expected 1 to equal 2" };
+      if (script === "test" && isBaseline)
+        return {
+          code: 137,
+          stdout: "",
+          stderr: "<--- Last few GCs --->\nFATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory",
+        };
+      return { code: 0, stdout: "ok", stderr: "" };
+    };
+    const result = await runFeedback(exec, {
+      worktree: "afk/wX/123-slug",
+      scopes: ["apps/dev"],
+      layout: makeLayout(),
+      now: () => 0,
+      baselineWorktree: "main",
+    });
+    // The baseline OOM is inconclusive: it is NOT added to the baseline-failing
+    // set, so no main-red is filed and the worker's failure is not downgraded to
+    // "pre-existing". The worker's own clean failure still blocks that one worker.
+    expect(result.baselineProbeRan).toBe(true);
+    expect(result.baselineFailures).toEqual([]);
+    expect(result.baselineDowngraded).toEqual([]);
+    expect(result.ok).toBe(false);
+    const testCheck = result.checks.find((c) => c.name === "test:apps/dev")!;
+    expect(testCheck.status).toBe("failed");
+  });
+
   it("a mix: one baseline-failing, one worker-only-failing → only the second blocks the gate", async () => {
     const exec: Exec = async (args) => {
       const script = args[args.length - 1] ?? "";


### PR DESCRIPTION
Kills the expensive false main-red loop.

**Root cause:** the AFK feedback baseline probe re-runs each failing check against main locally (`pnpm -C <dir> <script>`). On the resource-constrained fleet host the full apps/dev suite runs in one 3GB-capped vitest process and OOMs where CI (a fresh runner) passes. The probe read that OOM as a *pre-existing failure on main* → filed a main-red repair issue (e.g. #2300) → blocked every land until an expensive repair PR re-fired all of CI/CD on a non-bug.

**Fix:** main's CI is the validation authority. A baseline check that exits by SIGKILL (137) or carries a V8 heap-exhaustion / fatal-crash signature is now **inconclusive** — excluded from the baseline-failing set, so it never manufactures a main-red verdict CI never saw. The branch's own clean failure still blocks that one worker, not the whole fleet.

Contained change to `runChecksForBaseline` + one `isCrashOrOom` helper; the caller already filters `status === "failed"`. New feedback.test.ts case asserts a baseline OOM → no main-red. This is the safe first cut of "the probe trusts CI, not a local re-run"; a fuller CI-verdict read is a possible follow-up.

Landing:manual — this is the core validation gate; I review + merge (the PR's own CI on a fresh runner is the parity the fix relies on).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787189432&installation_model_id=20659&pr_number=2301&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2301&signature=0473cb3a16696e3ae9ba0d15337c5618a74faeeb0bae22f4765d254e1eb4f7e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->