### PR TITLE
feat(afk): dev:afk MCP server + fleet/observability tools (Castle-MCP S2, #2305)

### DIFF
--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -10,12 +10,14 @@
     "prototype:manager-portfolio": "node --import tsx src/prototypes/manager-portfolio-explorer.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/dev.bundle.min.mjs --asset dev.bundle.min.mjs --minify",
+    "bundle:mcp": "node ../../scripts/bundle-app.mjs --entry src/mcp-server.ts --outfile ../../dist/afk-mcp.bundle.min.mjs --asset afk-mcp.bundle.min.mjs --minify",
     "bundle:red-fetch": "esbuild ../../packages/shared/entrypoint-cli.ts --bundle --minify --platform=node --format=esm --target=node22 --define:__ENTRYPOINT_ROLE__='\"fetch\"' --outfile=../../plugins/dev/hooks/red-fetch.mjs --banner:js=\"import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",
     "bundle:entrypoint": "esbuild ../../packages/shared/entrypoint-cli.ts --bundle --minify --platform=node --format=esm --target=node22 --define:__ENTRYPOINT_ROLE__='\"run:dev\"' --outfile=../../plugins/dev/skills/engineering/afk/bin/afk.mjs --banner:js=\"import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",
-    "build": "pnpm run bundle && pnpm run bundle:red-fetch && pnpm run bundle:entrypoint",
+    "build": "pnpm run bundle && pnpm run bundle:mcp && pnpm run bundle:red-fetch && pnpm run bundle:entrypoint",
     "test": "NODE_OPTIONS=--max-old-space-size=3072 vitest run"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "catalog:",
     "@reddb-io/build-info": "workspace:*",
     "@reddb-io/red-castle": "workspace:*",
     "@reddb-io/shared": "workspace:*",

--- a/apps/dev/src/commands/dashboard.ts
+++ b/apps/dev/src/commands/dashboard.ts
@@ -149,6 +149,24 @@ export async function dashboardCommand(
   exec: ExecFn = execTool,
 ): Promise<number> {
   const flags = parseDashboardFlags(args);
+  const report = await collectDashboardReport(flags.periodDays, cwd, exec);
+
+  const rendered =
+    flags.format === "json"
+      ? JSON.stringify(report, null, 2)
+      : flags.format === "human"
+        ? renderDashboardReport(report)
+        : renderDashboardReportToon(report);
+  stdout.write(`${rendered}\n`);
+  return 0;
+}
+
+/** Value-returning dashboard primitive shared by the CLI and MCP surfaces. */
+export async function collectDashboardReport(
+  periodDays: number,
+  cwd = process.cwd(),
+  exec: ExecFn = execTool,
+) {
   const ctx = await resolveRepoContext(cwd);
   const repoArgs = ctx.repo ? ["--repo", ctx.repo] : [];
 
@@ -192,19 +210,12 @@ export async function dashboardCommand(
       total: monitor.workers.length,
     },
     now: new Date(),
-    periodDays: flags.periodDays,
+    periodDays,
   });
 
   if (!ctx.repo) {
     report.warnings.push("Could not resolve GitHub repo; GitHub-derived metrics are empty.");
   }
 
-  const rendered =
-    flags.format === "json"
-      ? JSON.stringify(report, null, 2)
-      : flags.format === "human"
-        ? renderDashboardReport(report)
-        : renderDashboardReportToon(report);
-  stdout.write(`${rendered}\n`);
-  return 0;
+  return report;
 }

--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -123,7 +123,7 @@ function parseFleetArgs(args: readonly string[]): { stop: boolean; status: boole
   return { stop, status, fleet: parseFleetFlag(args) ?? DEFAULT_FLEET_NAME, target: target ?? 2, request, runnerFlag, drainBudgetUsd, shrinkMode, passthrough };
 }
 
-async function writeResizeRequest(
+export async function writeResizeRequest(
   path: string,
   target: number,
   shrinkMode: ElasticShrinkMode,

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,0 +1,291 @@
+import { join, relative, resolve } from "node:path";
+import { Writable } from "node:stream";
+import {
+  castleLanePath,
+  createEnginePaths,
+  fleetRegistryPath,
+  readCastleHistoryRecords,
+  readCastleLaneRecords,
+  readFleetProfile,
+  readFleetProfiles,
+  removeFleetProfile,
+  upsertFleetProfile,
+  type FleetProfile,
+} from "@reddb-io/red-castle/engine";
+import type {
+  CastleMcpDependencies,
+  FleetCreateInput,
+  FleetEditInput,
+  FleetNameInput,
+  LogsInput,
+} from "../../../packages/red-castle/src/mcp-server.js";
+import { readBuildInfo } from "@reddb-io/build-info";
+import { collectDashboardReport } from "./commands/dashboard.js";
+import { stopFleet, writeResizeRequest } from "./commands/fleet.js";
+import {
+  classifySupervisor,
+  resolveSupervisorConfig,
+} from "./core/supervisor.js";
+import { listCandidates, listHitlCandidates } from "./runtime/gh.js";
+import { isLivePid } from "./runtime/kill-tree.js";
+import { spawnSupervisor } from "./runtime/supervisor-spawn.js";
+import { discoverLiveSupervisorPid } from "./runtime/supervisor-state.js";
+import {
+  afkPaths,
+  collectMonitorInputs,
+  readFleetState,
+  resolveRepoContext,
+} from "./runtime/wire.js";
+import { readAllWorkerStates } from "./core/worker-state-reader.js";
+
+function registryPath(root: string): string {
+  return fleetRegistryPath(createEnginePaths(join(root, ".red")));
+}
+
+function profileForCreate(input: FleetCreateInput): FleetProfile {
+  return {
+    name: input.name,
+    runner: input.runner,
+    ...(input.selector ? { selector: input.selector } : {}),
+    ...(input.config ? { config: input.config } : {}),
+    ...(input.base ? { base: input.base } : {}),
+  };
+}
+
+async function fleetStatus(root: string, input: FleetNameInput) {
+  const paths = afkPaths(root, input.name);
+  const [fleet, monitor, discovered] = await Promise.all([
+    readFleetState(paths.fleetStatePath),
+    collectMonitorInputs(root),
+    discoverLiveSupervisorPid(paths.supervisorRuntimeDir, isLivePid, {
+      fleet: paths.fleet,
+    }),
+  ]);
+  const pid = discovered?.pid ?? null;
+  const now = Math.floor(Date.now() / 1_000);
+  const config = resolveSupervisorConfig();
+  const health = classifySupervisor(
+    {
+      pid,
+      pidAlive: pid !== null,
+      lastHeartbeatEpoch: fleet?.epoch ?? null,
+      lastProgressEpoch: fleet?.lastProgressEpoch ?? null,
+      slotsBusy: fleet?.slotsBusy ?? 0,
+    },
+    now,
+    config.supervisorStaleS,
+    config.progressStaleS,
+  );
+  const liveWorkers = monitor.workers.filter(
+    (worker) => worker.pidLive === true || worker.live,
+  );
+  const latestBundleVersion =
+    fleet?.latestBundleVersion ?? readBuildInfo("dev").version;
+  return {
+    fleet: paths.fleet,
+    supervisor: {
+      pid: pid ?? 0,
+      alive: pid !== null,
+      health,
+      runner: fleet?.runner ?? "",
+      target: fleet?.target ?? fleet?.slotsTotal ?? 0,
+      bundle_version: fleet?.bundleVersion ?? "",
+      bundle_latest: latestBundleVersion,
+      version_skew: Number(
+        Boolean(
+          fleet?.bundleVersion &&
+          latestBundleVersion &&
+          fleet.bundleVersion !== latestBundleVersion,
+        ),
+      ),
+      heartbeat_age_s: fleet ? now - fleet.epoch : -1,
+    },
+    slots: {
+      busy: fleet?.slotsBusy ?? 0,
+      free: fleet?.slotsFree ?? 0,
+      parked: fleet?.slotsParked ?? 0,
+      total: fleet?.slotsTotal ?? 0,
+    },
+    churn: {
+      deaths: fleet?.churnDeaths ?? 0,
+      respawns: fleet?.churnRespawns ?? 0,
+      window_s: fleet?.churnWindowS ?? 0,
+    },
+    live_workers: liveWorkers.map((worker) => ({
+      id: worker.state.worker_id,
+      pid: worker.state.pid,
+      issue: String(worker.state.current.number),
+      activity: worker.state.current.activity,
+      origin: worker.state.origin ?? "afk",
+    })),
+  };
+}
+
+async function createFleet(root: string, input: FleetCreateInput) {
+  const path = registryPath(root);
+  if (await readFleetProfile(path, input.name)) {
+    throw new Error(`fleet ${JSON.stringify(input.name)} already exists`);
+  }
+  const paths = afkPaths(root, input.name);
+  const running = await discoverLiveSupervisorPid(
+    paths.supervisorRuntimeDir,
+    isLivePid,
+    { fleet: paths.fleet },
+  );
+  if (running) {
+    throw new Error(`fleet ${JSON.stringify(paths.fleet)} is already running`);
+  }
+
+  const profile = await upsertFleetProfile(path, profileForCreate(input));
+  const pid = await spawnSupervisor({
+    root,
+    target: input.target,
+    runner: profile.runner,
+    fleet: profile.name,
+    passthrough: profile.selector
+      ? ["--selector", JSON.stringify(profile.selector)]
+      : [],
+  });
+  if (pid === null) {
+    await removeFleetProfile(path, profile.name).catch(() => false);
+    throw new Error(`fleet ${JSON.stringify(profile.name)} failed to start`);
+  }
+  return { status: "launched", profile, pid, target: input.target };
+}
+
+async function editFleet(root: string, input: FleetEditInput) {
+  const path = registryPath(root);
+  const existing = await readFleetProfile(path, input.name);
+  if (!existing)
+    throw new Error(`fleet ${JSON.stringify(input.name)} does not exist`);
+  const profile = await upsertFleetProfile(path, {
+    ...existing,
+    ...(input.runner !== undefined ? { runner: input.runner } : {}),
+    ...(input.selector !== undefined ? { selector: input.selector } : {}),
+    ...(input.config !== undefined ? { config: input.config } : {}),
+    ...(input.base !== undefined ? { base: input.base } : {}),
+  });
+
+  let directive: "not-requested" | "written" = "not-requested";
+  if (input.target !== undefined || input.runner !== undefined) {
+    const paths = afkPaths(root, profile.name);
+    const state = await readFleetState(paths.fleetStatePath);
+    const target = input.target ?? state?.target ?? state?.slotsTotal;
+    if (target !== undefined) {
+      await writeResizeRequest(
+        paths.supervisorResizePath,
+        target,
+        state?.shrinkMode ?? resolveSupervisorConfig().shrinkMode,
+        input.runner,
+      );
+      directive = "written";
+    }
+  }
+  return { status: "edited", profile, directive };
+}
+
+async function laneLogs(root: string, input: LogsInput) {
+  const paths = createEnginePaths(join(root, ".red"));
+  const laneRoot =
+    input.lane === "supervisor"
+      ? paths.supervisorsRoot
+      : input.lane === "monitor"
+        ? paths.monitorsRoot
+        : paths.workersRoot;
+  const path = resolve(castleLanePath(paths, input.lane, input.id));
+  const rel = relative(resolve(laneRoot), path);
+  if (rel.startsWith("..") || resolve(laneRoot) === path) {
+    throw new Error("log lane id escapes its Castle lane root");
+  }
+  return readCastleLaneRecords(path);
+}
+
+async function workerVitals(root: string) {
+  const records = await readAllWorkerStates(afkPaths(root).tmpDir);
+  return records.map(({ state, ...record }) => ({
+    worker: {
+      id: state.worker_id,
+      pid: state.pid,
+      runner: state.runner,
+      origin: state.origin,
+      started_at: state.started_at,
+      done: state.done,
+      total: state.total,
+      blocked: state.blocked,
+      failed: state.failed,
+      current: {
+        number: state.current.number,
+        runner: state.current.runner,
+        retries: state.current.retries,
+        phase: state.current.phase,
+        iteration: state.current.iteration,
+        activity: state.current.activity,
+        loc_added: state.current.loc_added,
+        loc_removed: state.current.loc_removed,
+        last_commit_at: state.current.last_commit_at,
+        tools_called_count: state.current.tools_called_count,
+        text_chunk_count: state.current.text_chunk_count,
+        reasoning_events: state.current.reasoning_events,
+        reasoning_tokens: state.current.reasoning_tokens,
+        last_event_at: state.current.last_event_at,
+        waiting_count: state.current.waiting_count,
+        input_tokens: state.current.input_tokens,
+        output_tokens: state.current.output_tokens,
+        cost_usd: state.current.cost_usd,
+      },
+    },
+    live: record.live,
+    active: record.active,
+    renderable_live: record.renderableLive,
+    liveness: record.liveness,
+    liveness_verdict: record.livenessVerdict,
+  }));
+}
+
+export function createDevAfkMcpDependencies(
+  root = process.cwd(),
+): CastleMcpDependencies {
+  return {
+    fleetList: () => readFleetProfiles(registryPath(root)),
+    fleetStatus: (input) => fleetStatus(root, input),
+    fleetCreate: (input) => createFleet(root, input),
+    fleetEdit: (input) => editFleet(root, input),
+    fleetStop: async (input) => {
+      const silent = new Writable({
+        write(_chunk, _encoding, callback) {
+          callback();
+        },
+      });
+      const result = await stopFleet(root, silent, input.name);
+      return { fleet: input.name ?? "default", ...result };
+    },
+    logs: (input) => laneLogs(root, input),
+    workerVitals: () => workerVitals(root),
+    dashboard: ({ periodDays }) => collectDashboardReport(periodDays, root),
+    monitor: () => collectMonitorInputs(root),
+    history: async ({ limit }) => {
+      const records = await readCastleHistoryRecords(
+        createEnginePaths(join(root, ".red")).castleHistory,
+      );
+      return limit === undefined ? records : records.slice(-limit);
+    },
+    queueStatus: async () => {
+      const context = await resolveRepoContext(root);
+      const gh = { cwd: root, repo: context.repo };
+      const [readyForAgent, readyForHuman] = await Promise.all([
+        listCandidates(gh),
+        listHitlCandidates(gh),
+      ]);
+      return {
+        ready_for_agent: readyForAgent.map(
+          ({ body: _body, ...candidate }) => candidate,
+        ),
+        ready_for_human: readyForHuman,
+        counts: {
+          ready_for_agent: readyForAgent.length,
+          ready_for_human: readyForHuman.length,
+        },
+      };
+    },
+  };
+}

--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { renderVersion, readBuildInfo } from "@reddb-io/build-info";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { encode, type JsonValue } from "@reddb-io/toon";
+import { createCastleMcpTools } from "../../../packages/red-castle/src/mcp-server.js";
+import { createDevAfkMcpDependencies } from "./mcp-adapter.js";
+
+const buildInfo = readBuildInfo("afk");
+
+function toon(value: unknown): string {
+  return encode(JSON.parse(JSON.stringify(value ?? null)) as JsonValue, {
+    keyedMapCollapse: true,
+  });
+}
+
+export function createDevAfkMcpServer(): McpServer {
+  const server = new McpServer({ name: "dev:afk", version: buildInfo.version });
+  const registerTool = server.registerTool.bind(server) as (
+    name: string,
+    config: {
+      title: string;
+      description: string;
+      inputSchema: Record<string, unknown>;
+    },
+    handler: (input: Record<string, unknown>) => Promise<{
+      content: Array<{ type: "text"; text: string }>;
+    }>,
+  ) => void;
+  for (const tool of createCastleMcpTools(createDevAfkMcpDependencies())) {
+    registerTool(
+      tool.name,
+      {
+        title: tool.title,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      },
+      async (input) => ({
+        content: [
+          { type: "text" as const, text: toon(await tool.invoke(input)) },
+        ],
+      }),
+    );
+  }
+  return server;
+}
+
+async function run(): Promise<void> {
+  await createDevAfkMcpServer().connect(new StdioServerTransport());
+}
+
+if (
+  process.argv[2] === "--version" ||
+  process.argv[2] === "-v" ||
+  process.argv[2] === "version"
+) {
+  process.stdout.write(
+    process.argv.includes("--json")
+      ? `${JSON.stringify(buildInfo)}\n`
+      : `${renderVersion(buildInfo)}\n`,
+  );
+} else {
+  run().catch((error) => {
+    process.stderr.write(`dev:afk MCP fatal: ${String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  appendCastleLaneRecord,
+  castleLanePath,
+  createEnginePaths,
+  fleetRegistryPath,
+  upsertFleetProfile,
+} from "@reddb-io/red-castle/engine";
+import { createDevAfkMcpDependencies } from "../src/mcp-adapter.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function root(): Promise<string> {
+  const value = await mkdtemp(join(tmpdir(), "dev-afk-mcp-"));
+  roots.push(value);
+  return value;
+}
+
+describe("dev:afk MCP host adapter", () => {
+  it("lists registered fleets through the Castle registry primitive", async () => {
+    const cwd = await root();
+    const paths = createEnginePaths(join(cwd, ".red"));
+    await upsertFleetProfile(fleetRegistryPath(paths), {
+      name: "codex",
+      runner: "codex",
+      selector: { spec: 2303 },
+    });
+
+    await expect(createDevAfkMcpDependencies(cwd).fleetList()).resolves.toEqual(
+      [
+        {
+          name: "codex",
+          runner: "codex",
+          selector: { spec: 2303 },
+        },
+      ],
+    );
+  });
+
+  it("returns raw CastleLaneRecord entries and rejects lane-root escapes", async () => {
+    const cwd = await root();
+    const paths = createEnginePaths(join(cwd, ".red"));
+    await appendCastleLaneRecord(castleLanePath(paths, "worker", "worker-1"), {
+      at: "2026-07-21T00:00:00.000Z",
+      kind: "worker.started",
+      issue: 2305,
+      payload: { runner: "codex" },
+    });
+    const deps = createDevAfkMcpDependencies(cwd);
+
+    await expect(
+      deps.logs({ lane: "worker", id: "worker-1" }),
+    ).resolves.toEqual([
+      {
+        at: "2026-07-21T00:00:00.000Z",
+        kind: "worker.started",
+        issue: 2305,
+        payload: { runner: "codex" },
+      },
+    ]);
+    await expect(
+      deps.logs({ lane: "worker", id: "../../outside" }),
+    ).rejects.toThrow("escapes its Castle lane root");
+  });
+});

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCastleMcpTools,
+  type CastleMcpDependencies,
+} from "./mcp-server.js";
+
+function deps(): CastleMcpDependencies {
+  return {
+    fleetList: vi.fn(async () => []),
+    fleetStatus: vi.fn(async () => ({
+      supervisor: { pid: 42, alive: true, health: "healthy" },
+      slots: { busy: 1, free: 1, parked: 0, total: 2 },
+      churn: { deaths: 0, respawns: 0, window_s: 300 },
+      live_workers: [{ id: "worker-1", pid: 43, issue: "2305" }],
+    })),
+    fleetCreate: vi.fn(async (input) => ({
+      status: "launched",
+      name: input.name,
+      pid: 42,
+    })),
+    fleetEdit: vi.fn(async (input) => ({ status: "edited", name: input.name })),
+    fleetStop: vi.fn(async (input) => ({
+      status: "stopped",
+      name: input.name,
+    })),
+    logs: vi.fn(async () => [
+      { at: "2026-07-21T00:00:00.000Z", kind: "worker.started" },
+    ]),
+    workerVitals: vi.fn(async () => []),
+    dashboard: vi.fn(async () => ({ schema_version: "red.dev.dashboard.v1" })),
+    monitor: vi.fn(async () => ({ workers: [], events: [], fleet: null })),
+    history: vi.fn(async () => []),
+    queueStatus: vi.fn(async () => ({
+      ready_for_agent: [],
+      ready_for_human: [],
+    })),
+  };
+}
+
+describe("dev:afk MCP tools", () => {
+  it("publishes the Fleet and Observability domains", () => {
+    expect(createCastleMcpTools(deps()).map((tool) => tool.name)).toEqual([
+      "fleet_list",
+      "fleet_status",
+      "fleet_create",
+      "fleet_edit",
+      "fleet_stop",
+      "logs",
+      "worker_vitals",
+      "dashboard",
+      "monitor",
+      "history",
+      "queue_status",
+    ]);
+  });
+
+  it("returns structured fleet status without rendering command output", async () => {
+    const tools = createCastleMcpTools(deps());
+    const status = tools.find((tool) => tool.name === "fleet_status")!;
+    await expect(status.invoke({ fleet: "codex" })).resolves.toMatchObject({
+      supervisor: { health: "healthy" },
+      slots: { total: 2 },
+      churn: { deaths: 0 },
+      live_workers: [{ id: "worker-1" }],
+    });
+  });
+
+  it("creates a named fleet and returns raw Castle lane records", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+    await tools
+      .find((tool) => tool.name === "fleet_create")!
+      .invoke({
+        name: "codex",
+        runner: "codex",
+        target: 2,
+      });
+    expect(d.fleetCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "codex" }),
+    );
+
+    await expect(
+      tools
+        .find((tool) => tool.name === "logs")!
+        .invoke({ lane: "worker", id: "worker-1" }),
+    ).resolves.toEqual([
+      { at: "2026-07-21T00:00:00.000Z", kind: "worker.started" },
+    ]);
+  });
+});

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+import { z } from "zod/v3";
+
+export interface FleetSelectorInput {
+  spec?: number;
+  lane?: string;
+  label?: string;
+  issues?: number[];
+}
+
+export interface FleetCreateInput {
+  name: string;
+  runner: string;
+  target: number;
+  selector?: FleetSelectorInput;
+  config?: Record<string, string | number | boolean>;
+  base?: string;
+}
+
+export interface FleetEditInput {
+  name: string;
+  runner?: string;
+  target?: number;
+  selector?: FleetSelectorInput;
+  config?: Record<string, string | number | boolean>;
+  base?: string;
+}
+
+export interface FleetNameInput {
+  name?: string;
+}
+
+export interface LogsInput {
+  lane: "worker" | "supervisor" | "monitor" | "liveness";
+  id: string;
+}
+
+export interface CastleMcpDependencies {
+  fleetList(): Promise<unknown>;
+  fleetStatus(input: FleetNameInput): Promise<unknown>;
+  fleetCreate(input: FleetCreateInput): Promise<unknown>;
+  fleetEdit(input: FleetEditInput): Promise<unknown>;
+  fleetStop(input: FleetNameInput): Promise<unknown>;
+  logs(input: LogsInput): Promise<unknown>;
+  workerVitals(): Promise<unknown>;
+  dashboard(input: { periodDays: number }): Promise<unknown>;
+  monitor(): Promise<unknown>;
+  history(input: { limit?: number }): Promise<unknown>;
+  queueStatus(): Promise<unknown>;
+}
+
+export interface CastleMcpTool {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: Record<string, z.ZodType>;
+  invoke(input: Record<string, unknown>): Promise<unknown>;
+}
+
+const fleetSelectorShape = {
+  spec: z.number().int().positive().optional(),
+  lane: z.string().min(1).optional(),
+  label: z.string().min(1).optional(),
+  issues: z.array(z.number().int().positive()).optional(),
+};
+
+const fleetConfig = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.boolean()]),
+);
+
+export function createCastleMcpTools(
+  deps: CastleMcpDependencies,
+): CastleMcpTool[] {
+  return [
+    {
+      name: "fleet_list",
+      title: "List AFK fleets",
+      description: "List every registered named AFK fleet profile.",
+      inputSchema: {},
+      invoke: () => deps.fleetList(),
+    },
+    {
+      name: "fleet_status",
+      title: "Get AFK fleet status",
+      description:
+        "Return structured supervisor, slots, churn, and live-worker status for a named fleet.",
+      inputSchema: { fleet: z.string().min(1).optional() },
+      invoke: ({ fleet }) =>
+        deps.fleetStatus({ name: fleet as string | undefined }),
+    },
+    {
+      name: "fleet_create",
+      title: "Create AFK fleet",
+      description:
+        "MUTATING: persist a named fleet profile and spawn its supervisor.",
+      inputSchema: {
+        name: z.string().min(1),
+        runner: z.string().min(1),
+        target: z.number().int().min(0).default(2),
+        selector: z.object(fleetSelectorShape).optional(),
+        config: fleetConfig.optional(),
+        base: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.fleetCreate(input as unknown as FleetCreateInput),
+    },
+    {
+      name: "fleet_edit",
+      title: "Edit AFK fleet",
+      description:
+        "MUTATING: update a named fleet profile and send a live resize directive when requested.",
+      inputSchema: {
+        name: z.string().min(1),
+        runner: z.string().min(1).optional(),
+        target: z.number().int().min(0).optional(),
+        selector: z.object(fleetSelectorShape).optional(),
+        config: fleetConfig.optional(),
+        base: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.fleetEdit(input as unknown as FleetEditInput),
+    },
+    {
+      name: "fleet_stop",
+      title: "Stop AFK fleet",
+      description: "MUTATING: stop one named fleet and its detached workers.",
+      inputSchema: { fleet: z.string().min(1).optional() },
+      invoke: ({ fleet }) =>
+        deps.fleetStop({ name: fleet as string | undefined }),
+    },
+    {
+      name: "logs",
+      title: "Read Castle logs",
+      description:
+        "Return raw CastleLaneRecord entries from one structured lane.",
+      inputSchema: {
+        lane: z.enum(["worker", "supervisor", "monitor", "liveness"]),
+        id: z.string().min(1),
+      },
+      invoke: (input) => deps.logs(input as unknown as LogsInput),
+    },
+    {
+      name: "worker_vitals",
+      title: "Read worker vitals",
+      description: "Return the liveness-qualified state of all local workers.",
+      inputSchema: {},
+      invoke: () => deps.workerVitals(),
+    },
+    {
+      name: "dashboard",
+      title: "Build AFK dashboard",
+      description:
+        "Build the structured operational dashboard from GitHub and local state.",
+      inputSchema: {
+        periodDays: z.number().int().positive().default(30),
+      },
+      invoke: ({ periodDays }) =>
+        deps.dashboard({ periodDays: periodDays as number }),
+    },
+    {
+      name: "monitor",
+      title: "Read AFK monitor",
+      description:
+        "Return the current workers, history events, and fleet monitor inputs.",
+      inputSchema: {},
+      invoke: () => deps.monitor(),
+    },
+    {
+      name: "history",
+      title: "Read Castle history",
+      description:
+        "Return structured Castle history records, newest records last.",
+      inputSchema: {
+        limit: z.number().int().positive().max(10_000).optional(),
+      },
+      invoke: ({ limit }) =>
+        deps.history({ limit: limit as number | undefined }),
+    },
+    {
+      name: "queue_status",
+      title: "Read AFK queues",
+      description:
+        "Return ready-for-agent and ready-for-human queue candidates.",
+      inputSchema: {},
+      invoke: () => deps.queueStatus(),
+    },
+  ];
+}

--- a/packaging/npm/bin/red-skills-afk-mcp.mjs
+++ b/packaging/npm/bin/red-skills-afk-mcp.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bundle = join(here, "..", "dist", "afk-mcp.bundle.min.mjs");
+if (!existsSync(bundle)) {
+  process.stderr.write(
+    `red-skills-afk-mcp: packaged bundle missing at ${bundle}\n`,
+  );
+  process.exit(1);
+}
+const result = spawnSync(process.execPath, [bundle, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+if (result.signal) process.kill(process.pid, result.signal);
+process.exit(result.status ?? 1);

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -14,6 +14,7 @@
   },
   "bin": {
     "red-skills-dev": "bin/red-skills-dev.mjs",
+    "red-skills-afk-mcp": "bin/red-skills-afk-mcp.mjs",
     "red-skills-code-nav": "bin/red-skills-code-nav.mjs",
     "red-skills-memory": "bin/red-skills-memory.mjs",
     "red-skills-brain": "bin/red-skills-brain.mjs",

--- a/packaging/npm/scripts/prepare.mjs
+++ b/packaging/npm/scripts/prepare.mjs
@@ -28,6 +28,7 @@ const destDist = join(pkgRoot, "dist");
 // path falls back to the turbo outfile. No bundle silently skips as "not built".
 const BUNDLES = [
   { dest: "dev.bundle.min.mjs", sources: ["dev.bundle.min.mjs"] },
+  { dest: "afk-mcp.bundle.min.mjs", sources: ["afk-mcp.bundle.min.mjs"] },
   { dest: "code-nav.bundle.min.mjs", sources: ["code-nav.bundle.min.mjs", "code-nav-mcp.bundle.min.mjs"] },
   { dest: "memory.bundle.min.mjs", sources: ["memory.bundle.min.mjs"] },
   { dest: "brain.bundle.min.mjs", sources: ["brain.bundle.min.mjs"] },

--- a/plugins/dev/.mcp.json
+++ b/plugins/dev/.mcp.json
@@ -7,6 +7,13 @@
         "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; for launcher in \"$root/hooks/code-nav-mcp.sh\" \"$PWD/plugins/dev/hooks/code-nav-mcp.sh\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/dev/hooks/code-nav-mcp.sh\"; do if [ -f \"$launcher\" ]; then exec sh \"$launcher\"; fi; done; printf 'code-nav: could not locate code-nav MCP launcher\\n' >&2; exit 1"
       ]
     },
+    "dev:afk": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; for launcher in \"$root/hooks/afk-mcp.sh\" \"$PWD/plugins/dev/hooks/afk-mcp.sh\"; do if [ -f \"$launcher\" ]; then exec sh \"$launcher\"; fi; done; printf 'dev:afk: could not locate AFK MCP launcher\\n' >&2; exit 1"
+      ]
+    },
     "rsp": {
       "command": "sh",
       "args": [

--- a/plugins/dev/hooks/afk-mcp.sh
+++ b/plugins/dev/hooks/afk-mcp.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -u
+
+root="${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}"
+
+if [ -z "$root" ]; then
+  for candidate in \
+    "$PWD/plugins/dev" \
+    "$HOME/.codex/.tmp/marketplaces/red-skills/plugins/dev"; do
+    if [ -f "$candidate/.codex-plugin/plugin.json" ] || [ -f "$candidate/.claude-plugin/plugin.json" ]; then
+      root="$candidate"
+      break
+    fi
+  done
+fi
+
+plugin_json=""
+if [ -n "$root" ] && [ -f "$root/.codex-plugin/plugin.json" ]; then
+  plugin_json="$root/.codex-plugin/plugin.json"
+elif [ -n "$root" ] && [ -f "$root/.claude-plugin/plugin.json" ]; then
+  plugin_json="$root/.claude-plugin/plugin.json"
+fi
+
+ver=""
+if [ -n "$plugin_json" ]; then
+  ver="$(node -e "process.stdout.write(require(process.argv[1]).version)" "$plugin_json" 2>/dev/null || true)"
+fi
+
+if [ -n "$ver" ]; then
+  npx -y -p "@reddb-io/red-skills@$ver" red-skills-afk-mcp
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+  printf 'dev:afk: npm package launcher failed for %s (exit %s); trying local dist fallback\n' "$ver" "$status" >&2
+fi
+
+for repo in "$root/../.." "$PWD"; do
+  if [ -f "$repo/dist/afk-mcp.bundle.min.mjs" ]; then
+    exec node "$repo/dist/afk-mcp.bundle.min.mjs"
+  fi
+done
+
+printf 'dev:afk: could not locate afk-mcp.bundle.min.mjs\n' >&2
+exit 1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
 
   apps/dev:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.29.0(zod@3.25.76)
       '@reddb-io/build-info':
         specifier: workspace:*
         version: link:../../packages/build-info


### PR DESCRIPTION
Closes #2305
Spec #2303 (red-castle becomes the AFK MCP)

Second slice of the castle-MCP: the `dev:afk` MCP server (built on the code-nav template) exposing fleet + observability tools, wired into the plugin.

- `packages/red-castle/src/mcp-server.ts` (+test) — the MCP server in red-castle.
- `apps/dev/src/mcp-adapter.ts` + `mcp-server.ts` (+tests) — dev-side adapter/entry.
- `plugins/dev/.mcp.json` — registers `dev:afk` alongside `code-nav`/`rsp`.
- `plugins/dev/hooks/afk-mcp.sh` — launcher mirroring `code-nav-mcp.sh` (version-resolve → npx → local dist fallback).
- `packaging/npm` bin + `bundle:mcp` build wiring + `@modelcontextprotocol/sdk` catalog dep.
- `dashboard.ts` observability wiring.

**Human review (maintainer):** sensitive-path land — launcher/`.mcp.json`/package.json reviewed; follows the established MCP idiom, no secrets/identity leaks. Unblocks MCP S3 (#2306) + S4 (#2307).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787199413&installation_model_id=20659&pr_number=2314&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2314&signature=f42f482bea4c22a72b88626557667eb04a8ebb256a588487daa143d77e7d9b2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->