### PR TITLE
merge: #2307 Castle-MCP S4: gate + landing + claim + worktree tools (sensitive engine ops)

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,4 +1,6 @@
-import { join, relative, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, readdir } from "node:fs/promises";
+import { join, relative, resolve, sep } from "node:path";
 import { Writable } from "node:stream";
 import {
   castleLanePath,
@@ -10,14 +12,20 @@ import {
   readFleetProfiles,
   removeFleetProfile,
   upsertFleetProfile,
+  CASTLE_WORKTREE_LANES,
   type FleetProfile,
 } from "@reddb-io/red-castle/engine";
 import type {
+  ClaimIssueInput,
+  ClaimReleaseInput,
   CastleMcpDependencies,
   FleetCreateInput,
   FleetEditInput,
   FleetNameInput,
+  GateRunInput,
+  LandBranchInput,
   LogsInput,
+  WorktreeRemoveInput,
 } from "../../../packages/red-castle/src/mcp-server.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { collectDashboardReport } from "./commands/dashboard.js";
@@ -27,6 +35,7 @@ import {
   resolveSupervisorConfig,
 } from "./core/supervisor.js";
 import { listCandidates, listHitlCandidates } from "./runtime/gh.js";
+import * as ghx from "./runtime/gh.js";
 import { isLivePid } from "./runtime/kill-tree.js";
 import { spawnSupervisor } from "./runtime/supervisor-spawn.js";
 import { discoverLiveSupervisorPid } from "./runtime/supervisor-state.js";
@@ -37,6 +46,295 @@ import {
   resolveRepoContext,
 } from "./runtime/wire.js";
 import { readAllWorkerStates } from "./core/worker-state-reader.js";
+import { parseClaimRecords, renderClaimComment } from "./core/claim.js";
+import {
+  relevantScopes,
+  runFeedback,
+  type Exec as FeedbackExec,
+  type PackageLayout,
+} from "./core/feedback.js";
+import {
+  doLanding,
+  type LandingDeps,
+  type LandingHookContexts,
+} from "./core/landing.js";
+import { makeFeedbackWorktree } from "./runtime/feedback-worktree.js";
+import { createLandLock } from "./runtime/land-lock.js";
+import { pnpm as runPnpm } from "./runtime/exec.js";
+import * as gitx from "./runtime/git.js";
+
+export interface DevAfkMcpSensitiveOperations {
+  gateRun(input: GateRunInput): Promise<unknown>;
+  gateBaselineStatus(): Promise<unknown>;
+  landBranch(input: LandBranchInput): Promise<unknown>;
+  cascadeStatus(): Promise<unknown>;
+  claimStatus(input: ClaimIssueInput): Promise<unknown>;
+  claimRelease(input: ClaimReleaseInput): Promise<unknown>;
+  worktreeList(): Promise<unknown>;
+  worktreeRemove(input: WorktreeRemoveInput): Promise<unknown>;
+}
+
+function layoutAt(root: string): PackageLayout {
+  return {
+    hasPackage(scope) {
+      return existsSync(
+        join(scope === "." ? root : join(root, scope), "package.json"),
+      );
+    },
+    hasScript(scope, script) {
+      try {
+        const dir = scope === "." ? root : join(root, scope);
+        const pkg = JSON.parse(
+          readFileSync(join(dir, "package.json"), "utf8"),
+        ) as {
+          scripts?: Record<string, unknown>;
+        };
+        return Boolean(pkg.scripts && script in pkg.scripts);
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+function isWithin(parent: string, child: string): boolean {
+  const rel = relative(resolve(parent), resolve(child));
+  return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== "..");
+}
+
+function slug(value: string): string {
+  return (
+    value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") ||
+    "worktree"
+  );
+}
+
+export function createDefaultDevAfkMcpSensitiveOperations(
+  root: string,
+): DevAfkMcpSensitiveOperations {
+  const paths = afkPaths(root);
+  const gitContext: gitx.GitContext = { cwd: root };
+
+  async function gateRun(input: GateRunInput) {
+    const branch = input.branch;
+    const localWorktree = input.worktree
+      ? resolve(root, input.worktree)
+      : undefined;
+    if (localWorktree && !isWithin(root, localWorktree)) {
+      throw new Error("gate worktree must resolve inside the repository");
+    }
+    const manager = branch
+      ? makeFeedbackWorktree(root, paths.feedbackWorktreesDir)
+      : undefined;
+    const layout = manager?.layout ?? layoutAt(localWorktree!);
+    const changedFiles =
+      input.changedFiles ??
+      (await gitx.changedFiles(
+        { cwd: localWorktree ?? root },
+        branch ?? "HEAD",
+        input.base ?? "main",
+      ));
+    const scopes = relevantScopes(layout, changedFiles);
+    const feedbackExec: FeedbackExec = manager
+      ? manager.pnpm
+      : async (args, opts) => {
+          const commandArgs = args[0] === "pnpm" ? args.slice(1) : args;
+          const result = await runPnpm(commandArgs, {
+            cwd: localWorktree!,
+            env: opts?.env,
+          });
+          return {
+            code: result.code,
+            stdout: result.stdout,
+            stderr: result.stderr,
+          };
+        };
+    try {
+      return await runFeedback(feedbackExec, {
+        worktree: branch ?? localWorktree!,
+        scopes,
+        layout,
+        now: Date.now,
+        ...(branch && input.base ? { baselineWorktree: input.base } : {}),
+      });
+    } finally {
+      await manager?.cleanup();
+    }
+  }
+
+  async function baselineStatus() {
+    const context = await resolveRepoContext(root);
+    const issue = await ghx.findMainRedRepairIssue({
+      cwd: context.root,
+      repo: context.repo,
+    });
+    return { red: issue !== null, issue };
+  }
+
+  function landingDeps(input: LandBranchInput): LandingDeps {
+    const makeWorktree = async (laneRoot: string, ref: string) => {
+      await mkdir(laneRoot, { recursive: true });
+      const dest = join(laneRoot, `${slug(ref)}-mcp-${process.pid}`);
+      await gitx.worktreeRemove(gitContext, dest);
+      return (await gitx.worktreeAdd(gitContext, dest, ref)) ? dest : null;
+    };
+    return {
+      mergeExec: gitx.mergeExec(gitContext),
+      remoteGit: gitx.gitExec(gitContext),
+      fireHook: async () => true,
+      makeLandingWorktree: (base) =>
+        makeWorktree(paths.landingWorktreesDir, base),
+      removeLandingWorktree: (dir) => gitx.worktreeRemove(gitContext, dir),
+      makeRebaseWorktree: (branch) =>
+        makeWorktree(paths.rebaseWorktreesDir, branch),
+      removeRebaseWorktree: (dir) => gitx.worktreeRemove(gitContext, dir),
+      getDiffPaths: async () => ({
+        changedFiles: await gitx.changedFiles(
+          gitContext,
+          input.branch,
+          input.base,
+        ),
+        packageJsonDiff: "",
+      }),
+      findMainRedRepairIssue: async () => {
+        const context = await resolveRepoContext(root);
+        return ghx.findMainRedRepairIssue({
+          cwd: context.root,
+          repo: context.repo,
+        });
+      },
+      postMergeGate: async (worktree) => {
+        const result = await gateRun({
+          worktree,
+          base: input.base,
+          changedFiles: await gitx.changedFiles(
+            gitContext,
+            input.branch,
+            input.base,
+          ),
+        });
+        return { ok: Boolean((result as { ok?: boolean }).ok) };
+      },
+      landLock: createLandLock(paths.tmpDir, `mcp-${process.pid}`),
+    };
+  }
+
+  return {
+    gateRun,
+    gateBaselineStatus: baselineStatus,
+    async landBranch(input) {
+      if (input.gatePassed !== true) {
+        throw new Error("land_branch requires a passing gate verdict");
+      }
+      const context = await resolveRepoContext(root);
+      if (!context.repo)
+        throw new Error("land_branch could not resolve the repository slug");
+      const baseline = await baselineStatus();
+      const hooks: LandingHookContexts = {
+        preMerge: () =>
+          JSON.stringify({ issue: input.issue, branch: input.branch }),
+        postMerge: (mergeSha) =>
+          JSON.stringify({
+            issue: input.issue,
+            branch: input.branch,
+            mergeSha,
+          }),
+      };
+      return doLanding(
+        landingDeps(input),
+        {
+          openPr: input.openPr ?? true,
+          locked: false,
+          repo: context.repo,
+          repoDir: root,
+          remote: context.remote,
+          branch: input.branch,
+          validatedBranchTip: input.validatedBranchTip,
+          base: input.base,
+          trunk: input.trunk ?? input.base,
+          issue: input.issue,
+          title: input.title,
+          mainRed: (baseline as { red: boolean }).red,
+        },
+        hooks,
+      );
+    },
+    async cascadeStatus() {
+      const records = await readAllWorkerStates(paths.tmpDir);
+      return records
+        .filter(({ state }) => state.current.phase === "cascade")
+        .map(({ state, live, active }) => ({
+          worker: state.worker_id,
+          issue: state.current.number,
+          phase: state.current.phase,
+          live,
+          active,
+        }));
+    },
+    async claimStatus(input) {
+      const context = await resolveRepoContext(root);
+      const comments = await ghx.listClaimComments(
+        { cwd: context.root, repo: context.repo },
+        input.issue,
+      );
+      return parseClaimRecords(comments);
+    },
+    async claimRelease(input) {
+      const context = await resolveRepoContext(root);
+      await ghx.comment(
+        { cwd: context.root, repo: context.repo },
+        input.issue,
+        renderClaimComment(
+          { worker: input.worker, runner: input.runner },
+          "concede",
+        ),
+      );
+      return { released: true, issue: input.issue, worker: input.worker };
+    },
+    async worktreeList() {
+      const worktreesRoot = createEnginePaths(join(root, ".red")).worktreesRoot;
+      const entries: Array<{ lane: string; name: string; path: string }> = [];
+      for (const lane of CASTLE_WORKTREE_LANES) {
+        const laneRoot = join(worktreesRoot, lane);
+        const children = await readdir(laneRoot, { withFileTypes: true }).catch(
+          () => [],
+        );
+        for (const child of children) {
+          if (child.isDirectory()) {
+            entries.push({
+              lane,
+              name: child.name,
+              path: join(laneRoot, child.name),
+            });
+          }
+        }
+      }
+      return entries;
+    },
+    async worktreeRemove(input) {
+      const worktreesRoot = createEnginePaths(join(root, ".red")).worktreesRoot;
+      const candidate = resolve(worktreesRoot, input.worktree);
+      const rel = relative(worktreesRoot, candidate);
+      const [lane, name, ...rest] = rel.split(sep);
+      if (
+        !lane ||
+        !name ||
+        rest.length > 0 ||
+        !(CASTLE_WORKTREE_LANES as readonly string[]).includes(lane) ||
+        !isWithin(worktreesRoot, candidate)
+      ) {
+        throw new Error(
+          "worktree_remove requires <lane>/<name> inside a canonical worktree lane",
+        );
+      }
+      await gitx.worktreeRemove(gitContext, candidate);
+      if (existsSync(candidate)) {
+        throw new Error(`worktree removal failed for ${lane}/${name}`);
+      }
+      return { removed: true, lane, name };
+    },
+  };
+}
 
 function registryPath(root: string): string {
   return fleetRegistryPath(createEnginePaths(join(root, ".red")));
@@ -244,6 +542,7 @@ async function workerVitals(root: string) {
 
 export function createDevAfkMcpDependencies(
   root = process.cwd(),
+  sensitive = createDefaultDevAfkMcpSensitiveOperations(root),
 ): CastleMcpDependencies {
   return {
     fleetList: () => readFleetProfiles(registryPath(root)),
@@ -287,5 +586,13 @@ export function createDevAfkMcpDependencies(
         },
       };
     },
+    gateRun: (input) => sensitive.gateRun(input),
+    gateBaselineStatus: () => sensitive.gateBaselineStatus(),
+    landBranch: (input) => sensitive.landBranch(input),
+    cascadeStatus: () => sensitive.cascadeStatus(),
+    claimStatus: (input) => sensitive.claimStatus(input),
+    claimRelease: (input) => sensitive.claimRelease(input),
+    worktreeList: () => sensitive.worktreeList(),
+    worktreeRemove: (input) => sensitive.worktreeRemove(input),
   };
 }

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -9,7 +9,11 @@ import {
   fleetRegistryPath,
   upsertFleetProfile,
 } from "@reddb-io/red-castle/engine";
-import { createDevAfkMcpDependencies } from "../src/mcp-adapter.js";
+import {
+  createDefaultDevAfkMcpSensitiveOperations,
+  createDevAfkMcpDependencies,
+  type DevAfkMcpSensitiveOperations,
+} from "../src/mcp-adapter.js";
 
 const roots: string[] = [];
 
@@ -70,5 +74,48 @@ describe("dev:afk MCP host adapter", () => {
     await expect(
       deps.logs({ lane: "worker", id: "../../outside" }),
     ).rejects.toThrow("escapes its Castle lane root");
+  });
+
+  it("delegates gate and landing to the sensitive engine operations", async () => {
+    const cwd = await root();
+    const operations: DevAfkMcpSensitiveOperations = {
+      gateRun: async () => ({ ok: true, checks: [] }),
+      gateBaselineStatus: async () => ({ red: false, issue: null }),
+      landBranch: async (input) => ({ ok: true, branch: input.branch }),
+      cascadeStatus: async () => [],
+      claimStatus: async () => [],
+      claimRelease: async () => ({ released: true }),
+      worktreeList: async () => [],
+      worktreeRemove: async () => ({ removed: true }),
+    };
+    const deps = createDevAfkMcpDependencies(cwd, operations);
+
+    await expect(
+      deps.gateRun({ branch: "afk/wAAAA/2307-tools", base: "main" }),
+    ).resolves.toMatchObject({ ok: true });
+    await expect(
+      deps.landBranch({
+        issue: 2307,
+        title: "Sensitive tools",
+        branch: "afk/wAAAA/2307-tools",
+        base: "main",
+        gatePassed: true,
+      }),
+    ).resolves.toMatchObject({ branch: "afk/wAAAA/2307-tools" });
+  });
+
+  it("enumerates canonical worktree lanes and rejects removal path escapes", async () => {
+    const cwd = await root();
+    await mkdir(join(cwd, ".red", "tmp", "worktrees", "landing", "main-0"), {
+      recursive: true,
+    });
+    const operations = createDefaultDevAfkMcpSensitiveOperations(cwd);
+
+    await expect(operations.worktreeList()).resolves.toEqual([
+      expect.objectContaining({ lane: "landing", name: "main-0" }),
+    ]);
+    await expect(
+      operations.worktreeRemove({ worktree: "../../outside" }),
+    ).rejects.toThrow("canonical worktree lane");
   });
 });

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -34,6 +34,14 @@ function deps(): CastleMcpDependencies {
       ready_for_agent: [],
       ready_for_human: [],
     })),
+    gateRun: vi.fn(async () => ({ ok: true, checks: [] })),
+    gateBaselineStatus: vi.fn(async () => ({ red: false, issue: null })),
+    landBranch: vi.fn(async () => ({ ok: true, mergeSha: "abc123" })),
+    cascadeStatus: vi.fn(async () => []),
+    claimStatus: vi.fn(async () => [{ worker: "host:worker-1", kind: "claim" }]),
+    claimRelease: vi.fn(async () => ({ released: true })),
+    worktreeList: vi.fn(async () => [{ lane: "landing", name: "main-0" }]),
+    worktreeRemove: vi.fn(async () => ({ removed: true })),
   };
 }
 
@@ -51,6 +59,14 @@ describe("dev:afk MCP tools", () => {
       "monitor",
       "history",
       "queue_status",
+      "gate_run",
+      "gate_baseline_status",
+      "land_branch",
+      "cascade_status",
+      "claim_status",
+      "claim_release",
+      "worktree_list",
+      "worktree_remove",
     ]);
   });
 
@@ -86,5 +102,41 @@ describe("dev:afk MCP tools", () => {
     ).resolves.toEqual([
       { at: "2026-07-21T00:00:00.000Z", kind: "worker.started" },
     ]);
+  });
+
+  it("returns the feedback verdict and gates landing on an acknowledged pass", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await expect(
+      tools.find((tool) => tool.name === "gate_run")!.invoke({
+        branch: "afk/wAAAA/2307-sensitive-tools",
+        base: "main",
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(d.gateRun).toHaveBeenCalledWith({
+      branch: "afk/wAAAA/2307-sensitive-tools",
+      base: "main",
+    });
+
+    await tools.find((tool) => tool.name === "land_branch")!.invoke({
+      issue: 2307,
+      title: "Sensitive tools",
+      branch: "afk/wAAAA/2307-sensitive-tools",
+      base: "main",
+      gatePassed: true,
+    });
+    expect(d.landBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ issue: 2307, gatePassed: true }),
+    );
+  });
+
+  it("publishes mutating claim and worktree operations with explicit warnings", () => {
+    const tools = createCastleMcpTools(deps());
+    for (const name of ["gate_run", "land_branch", "claim_release", "worktree_remove"]) {
+      expect(tools.find((tool) => tool.name === name)!.description).toMatch(
+        /^MUTATING:/,
+      );
+    }
   });
 });

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -38,7 +38,9 @@ function deps(): CastleMcpDependencies {
     gateBaselineStatus: vi.fn(async () => ({ red: false, issue: null })),
     landBranch: vi.fn(async () => ({ ok: true, mergeSha: "abc123" })),
     cascadeStatus: vi.fn(async () => []),
-    claimStatus: vi.fn(async () => [{ worker: "host:worker-1", kind: "claim" }]),
+    claimStatus: vi.fn(async () => [
+      { worker: "host:worker-1", kind: "claim" },
+    ]),
     claimRelease: vi.fn(async () => ({ released: true })),
     worktreeList: vi.fn(async () => [{ lane: "landing", name: "main-0" }]),
     worktreeRemove: vi.fn(async () => ({ removed: true })),
@@ -109,23 +111,27 @@ describe("dev:afk MCP tools", () => {
     const tools = createCastleMcpTools(d);
 
     await expect(
-      tools.find((tool) => tool.name === "gate_run")!.invoke({
-        branch: "afk/wAAAA/2307-sensitive-tools",
-        base: "main",
-      }),
+      tools
+        .find((tool) => tool.name === "gate_run")!
+        .invoke({
+          branch: "afk/wAAAA/2307-sensitive-tools",
+          base: "main",
+        }),
     ).resolves.toMatchObject({ ok: true });
     expect(d.gateRun).toHaveBeenCalledWith({
       branch: "afk/wAAAA/2307-sensitive-tools",
       base: "main",
     });
 
-    await tools.find((tool) => tool.name === "land_branch")!.invoke({
-      issue: 2307,
-      title: "Sensitive tools",
-      branch: "afk/wAAAA/2307-sensitive-tools",
-      base: "main",
-      gatePassed: true,
-    });
+    await tools
+      .find((tool) => tool.name === "land_branch")!
+      .invoke({
+        issue: 2307,
+        title: "Sensitive tools",
+        branch: "afk/wAAAA/2307-sensitive-tools",
+        base: "main",
+        gatePassed: true,
+      });
     expect(d.landBranch).toHaveBeenCalledWith(
       expect.objectContaining({ issue: 2307, gatePassed: true }),
     );
@@ -133,7 +139,12 @@ describe("dev:afk MCP tools", () => {
 
   it("publishes mutating claim and worktree operations with explicit warnings", () => {
     const tools = createCastleMcpTools(deps());
-    for (const name of ["gate_run", "land_branch", "claim_release", "worktree_remove"]) {
+    for (const name of [
+      "gate_run",
+      "land_branch",
+      "claim_release",
+      "worktree_remove",
+    ]) {
       expect(tools.find((tool) => tool.name === name)!.description).toMatch(
         /^MUTATING:/,
       );

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -35,6 +35,37 @@ export interface LogsInput {
   id: string;
 }
 
+export interface GateRunInput {
+  worktree?: string;
+  branch?: string;
+  base?: string;
+  changedFiles?: string[];
+}
+
+export interface LandBranchInput {
+  issue: number;
+  title: string;
+  branch: string;
+  base: string;
+  gatePassed: true;
+  openPr?: boolean;
+  trunk?: string;
+  validatedBranchTip?: string;
+}
+
+export interface ClaimIssueInput {
+  issue: number;
+}
+
+export interface ClaimReleaseInput extends ClaimIssueInput {
+  worker: string;
+  runner?: string;
+}
+
+export interface WorktreeRemoveInput {
+  worktree: string;
+}
+
 export interface CastleMcpDependencies {
   fleetList(): Promise<unknown>;
   fleetStatus(input: FleetNameInput): Promise<unknown>;
@@ -47,6 +78,14 @@ export interface CastleMcpDependencies {
   monitor(): Promise<unknown>;
   history(input: { limit?: number }): Promise<unknown>;
   queueStatus(): Promise<unknown>;
+  gateRun(input: GateRunInput): Promise<unknown>;
+  gateBaselineStatus(): Promise<unknown>;
+  landBranch(input: LandBranchInput): Promise<unknown>;
+  cascadeStatus(): Promise<unknown>;
+  claimStatus(input: ClaimIssueInput): Promise<unknown>;
+  claimRelease(input: ClaimReleaseInput): Promise<unknown>;
+  worktreeList(): Promise<unknown>;
+  worktreeRemove(input: WorktreeRemoveInput): Promise<unknown>;
 }
 
 export interface CastleMcpTool {
@@ -182,6 +221,97 @@ export function createCastleMcpTools(
         "Return ready-for-agent and ready-for-human queue candidates.",
       inputSchema: {},
       invoke: () => deps.queueStatus(),
+    },
+    {
+      name: "gate_run",
+      title: "Run AFK feedback gate",
+      description:
+        "MUTATING: materialize a branch when needed, execute its package-scoped feedback checks, and return the structured verdict.",
+      inputSchema: {
+        worktree: z.string().min(1).optional(),
+        branch: z.string().min(1).optional(),
+        base: z.string().min(1).optional(),
+        changedFiles: z.array(z.string().min(1)).optional(),
+      },
+      invoke: (input) => {
+        const value = input as unknown as GateRunInput;
+        if ((value.worktree === undefined) === (value.branch === undefined)) {
+          throw new Error("exactly one of worktree or branch is required");
+        }
+        return deps.gateRun(value);
+      },
+    },
+    {
+      name: "gate_baseline_status",
+      title: "Read AFK gate baseline status",
+      description:
+        "Return the open main-red repair record that represents the current feedback baseline status.",
+      inputSchema: {},
+      invoke: () => deps.gateBaselineStatus(),
+    },
+    {
+      name: "land_branch",
+      title: "Land validated AFK branch",
+      description:
+        "MUTATING: call the canonical landing operation for a branch whose feedback gate passed.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        title: z.string().min(1),
+        branch: z.string().min(1),
+        base: z.string().min(1),
+        gatePassed: z.literal(true),
+        openPr: z.boolean().optional(),
+        trunk: z.string().min(1).optional(),
+        validatedBranchTip: z.string().min(1).optional(),
+      },
+      invoke: (input) =>
+        deps.landBranch(input as unknown as LandBranchInput),
+    },
+    {
+      name: "cascade_status",
+      title: "Read landing cascade status",
+      description:
+        "Return workers currently in the post-landing cascade phase.",
+      inputSchema: {},
+      invoke: () => deps.cascadeStatus(),
+    },
+    {
+      name: "claim_status",
+      title: "Read issue claims",
+      description:
+        "Return parsed claim records for one issue, excluding unrelated discussion.",
+      inputSchema: { issue: z.number().int().positive() },
+      invoke: ({ issue }) => deps.claimStatus({ issue: issue as number }),
+    },
+    {
+      name: "claim_release",
+      title: "Release issue claim",
+      description:
+        "MUTATING: append a concede marker that releases one worker claim.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        worker: z.string().min(1),
+        runner: z.string().min(1).optional(),
+      },
+      invoke: (input) =>
+        deps.claimRelease(input as unknown as ClaimReleaseInput),
+    },
+    {
+      name: "worktree_list",
+      title: "List managed worktrees",
+      description:
+        "Enumerate worktrees in the canonical .red/tmp/worktrees lanes.",
+      inputSchema: {},
+      invoke: () => deps.worktreeList(),
+    },
+    {
+      name: "worktree_remove",
+      title: "Remove managed worktree",
+      description:
+        "MUTATING: force-remove one worktree only when it resolves inside a canonical .red/tmp/worktrees lane.",
+      inputSchema: { worktree: z.string().min(1) },
+      invoke: ({ worktree }) =>
+        deps.worktreeRemove({ worktree: worktree as string }),
     },
   ];
 }

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -264,8 +264,7 @@ export function createCastleMcpTools(
         trunk: z.string().min(1).optional(),
         validatedBranchTip: z.string().min(1).optional(),
       },
-      invoke: (input) =>
-        deps.landBranch(input as unknown as LandBranchInput),
+      invoke: (input) => deps.landBranch(input as unknown as LandBranchInput),
     },
     {
       name: "cascade_status",


### PR DESCRIPTION
Automated AFK landing for #2307. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2307

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787209472&installation_model_id=20659&pr_number=2319&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2319&signature=32af940d75ce14a8c383ba099329a8af95244aac8e42f4e4f0e8eeaeea5e6872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->