### PR TITLE
fix(afk): boot self-heals dead own-machine dangling claims instead of halting (#2321)

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -61,7 +61,10 @@ import {
   type SpecSubIssueCandidate,
 } from "./spec-subissue-reconciler.js";
 import {
+  applyClaimHygieneFix,
+  autoHealableClaimHygiene,
   BASE_FRESHNESS_PROBE_ID,
+  CLAIM_HYGIENE_PROBE_ID,
   formatOperationalProbeFinding,
   runOperationalProbes,
   type BaseFreshnessProbeData,
@@ -321,6 +324,9 @@ export interface BootDeps {
     readonly action: "fast-forward" | "noop";
     readonly evidence: string;
   }>;
+  /** Posts an `afk:claim` concede comment. Wired so the boot sweep can
+   * auto-heal dead own-machine dangling claims instead of halting (#2321). */
+  concedeClaim?: (issue: number, body: string) => Promise<void>;
   /** Current epoch seconds (date +%s), injected so the run is deterministic. */
   nowS: number;
   /** Env for the cap/grace resolvers (defaults to process.env). */
@@ -360,6 +366,31 @@ async function tryBootAutoApplyBaseFreshness(
   deps.log?.(
     `boot operational probe auto-fix applied: ${finding.id} before=${shortSha(data.localSha)} after=${shortSha(data.remoteSha)}; ${result.evidence}`,
   );
+  return true;
+}
+
+/**
+ * Auto-heal a claim-hygiene red finding that is PURELY dead own-machine
+ * danglers. A stranded `afk:claim` from this machine's own dead-pid worker is
+ * provably safe to concede, so the boot sweep concedes it and continues instead
+ * of throwing BootHaltError — one orphan claim must never halt every supervisor
+ * boot (#2321). Foreign / unknown-pid markers are NOT healed here: they stay in
+ * the red findings and still halt, because they need a human to adjudicate.
+ */
+async function tryBootAutoApplyClaimHygiene(
+  deps: BootDeps,
+  finding: OperationalProbeReport["findings"][number],
+): Promise<boolean> {
+  if (finding.id !== CLAIM_HYGIENE_PROBE_ID) return false;
+  if (!autoHealableClaimHygiene(finding)) return false;
+  const concedeClaim = deps.concedeClaim;
+  if (!concedeClaim) return false;
+  const result = await applyClaimHygieneFix(finding, {
+    confirm: async () => true,
+    concedeClaim,
+  });
+  if (result.status !== "applied") return false;
+  deps.log?.(`boot operational probe auto-fix applied: ${finding.id}; ${result.evidence}`);
   return true;
 }
 
@@ -615,7 +646,16 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
 
   // ---- 1a. operational probes ----
   const operationalProbes = await runOperationalProbes(options.operationalProbes ?? options.precheck);
-  const redProbe = operationalProbes.findings[0];
+  // A dangling `afk:claim` from THIS machine's dead-pid worker is provably safe
+  // to concede, so auto-heal such claim-hygiene findings here instead of letting
+  // one stranded claim throw BootHaltError and kill every supervisor boot
+  // (#2321). Foreign / unknown-pid markers survive the filter and still halt.
+  const redFindings: OperationalProbeReport["findings"][number][] = [];
+  for (const finding of operationalProbes.findings) {
+    if (await tryBootAutoApplyClaimHygiene(deps, finding)) continue;
+    redFindings.push(finding);
+  }
+  const redProbe = redFindings[0];
   if (redProbe) {
     const applied = await tryBootAutoApplyBaseFreshness(deps, redProbe);
     if (!applied) {
@@ -626,7 +666,7 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
       const workerSessionExempt = options.skipSweeps === true && isWorkerExemptBaseFreshnessFinding(redProbe);
       if (!workerSessionExempt) throw new BootHaltError("operational-probe", redProbe);
     }
-    const nextRedProbe = operationalProbes.findings[1];
+    const nextRedProbe = redFindings[1];
     if (nextRedProbe) throw new BootHaltError("operational-probe", nextRedProbe);
   }
 

--- a/apps/dev/src/core/operational-probes/claim-hygiene.ts
+++ b/apps/dev/src/core/operational-probes/claim-hygiene.ts
@@ -208,6 +208,21 @@ function claimHygieneData(finding: OperationalProbeResult): ClaimHygieneProbeDat
   return rec as ClaimHygieneProbeData;
 }
 
+/**
+ * The claim-hygiene finding's data when it is SAFE to auto-heal at boot: PURELY
+ * dead own-namespace danglers (this machine's own dead-pid workers), with no
+ * foreign markers and no unknown-pid own markers that a human must adjudicate.
+ * Returns null otherwise. A boot sweep may auto-concede these without an
+ * operator, so one stranded claim never throws BootHaltError and kills the
+ * whole fleet (#2321).
+ */
+export function autoHealableClaimHygiene(finding: OperationalProbeResult): ClaimHygieneProbeData | null {
+  const data = claimHygieneData(finding);
+  if (!data || data.actions.length === 0) return null;
+  if (data.foreign.length > 0 || data.unknownOwn > 0) return null;
+  return data;
+}
+
 function groupActionsByIssue(actions: readonly ClaimHygieneConcedeAction[]): ClaimHygieneConcedeAction[][] {
   const byIssue = new Map<number, ClaimHygieneConcedeAction[]>();
   for (const action of actions) {

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -371,6 +371,11 @@ export async function buildBootDeps(
     log,
     fastForwardLocalBase: ({ remote, target }) =>
       fastForwardLocalTarget(gitx.mergeExec(gitCtx), { gitRepo: ctx.root, remote, target }),
+    concedeClaim: ctx.repo
+      ? async (issue, body) => {
+          await ghx.postClaimComment(ghCtx, issue, body);
+        }
+      : undefined,
     lookups: {
       // Live-claim ownership for the orphan sweep (#644): a dead attempt dir
       // naming an issue whose claims/{N}/pid is a LIVE process is claim-race

--- a/apps/dev/tests/claim-hygiene.test.ts
+++ b/apps/dev/tests/claim-hygiene.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   applyClaimHygieneFix,
+  autoHealableClaimHygiene,
   runClaimHygieneProbe,
 } from "../src/core/operational-probes/claim-hygiene.js";
 import type { OperationalProbeResult } from "../src/core/operational-probes.js";
@@ -101,5 +102,59 @@ describe("claim hygiene operational probe", () => {
       evidence: "no dead own-namespace dangling claims need repair",
     });
     expect(concedeClaim).not.toHaveBeenCalled();
+  });
+});
+
+describe("autoHealableClaimHygiene (boot self-heal gate, #2321)", () => {
+  const deadOwn = "<!-- afk:claim v1 worker=8cb3eafdcbd2:wDead kind=claim runner=claude -->";
+  const foreign = "<!-- stn:claim v1 worker=stone:wOther kind=claim runner=codex -->";
+  const unknownOwn = "<!-- afk:claim v1 worker=8cb3eafdcbd2:wHuh kind=claim runner=claude -->";
+
+  async function probe(
+    comments: { id: number; body: string; createdAt: string }[],
+    pidState: (worker: string) => "dead" | "live" | "unknown" | "foreign",
+  ) {
+    return runClaimHygieneProbe({
+      remoteUrls: [],
+      claimHygiene: {
+        ownWorkerPrefix: "8cb3eafdcbd2:",
+        listOpenQueueIssues: async () => [{ number: 2223, comments }],
+        workerPidState: pidState,
+      },
+    });
+  }
+
+  it("returns the data when the ONLY finding is dead own-machine danglers (boot may auto-concede)", async () => {
+    const result = await probe(
+      [{ id: 1, body: deadOwn, createdAt: "2026-07-21T10:00:00Z" }],
+      (worker) => (worker.endsWith(":wDead") ? "dead" : "unknown"),
+    );
+    const data = autoHealableClaimHygiene(result);
+    expect(data).not.toBeNull();
+    expect(data?.actions).toHaveLength(1);
+    expect(data?.foreign).toHaveLength(0);
+    expect(data?.unknownOwn).toBe(0);
+  });
+
+  it("returns null when a foreign-namespace dangler is present (needs a human — boot must still halt)", async () => {
+    const result = await probe(
+      [
+        { id: 1, body: deadOwn, createdAt: "2026-07-21T10:00:00Z" },
+        { id: 2, body: foreign, createdAt: "2026-07-21T10:01:00Z" },
+      ],
+      (worker) => (worker.endsWith(":wDead") ? "dead" : "foreign"),
+    );
+    expect(autoHealableClaimHygiene(result)).toBeNull();
+  });
+
+  it("returns null when an own dangler has an unknown (not-provably-dead) pid alongside a dead one", async () => {
+    const result = await probe(
+      [
+        { id: 1, body: deadOwn, createdAt: "2026-07-21T10:00:00Z" },
+        { id: 2, body: unknownOwn, createdAt: "2026-07-21T10:01:00Z" },
+      ],
+      (worker) => (worker.endsWith(":wDead") ? "dead" : "unknown"),
+    );
+    expect(autoHealableClaimHygiene(result)).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #2321

A single dangling `afk:claim` from this machine's dead-pid worker made the boot claim-hygiene probe return red → `BootHaltError` → **every supervisor died in ~30s on the same poison** (cost hours on 2026-07-21). The self-heal (`applyClaimHygieneFix`) already existed but was gated behind interactive `confirm`, which boot has no operator for → it halted instead of healing.

**Fix:** mirror `tryBootAutoApplyBaseFreshness` — at boot, auto-concede a claim-hygiene finding that is PURELY dead own-machine danglers (provably safe; the probe already classifies them as `data.actions`, distinct from `foreign`/`unknownOwn`), drop it from the red findings, and continue. Foreign / unknown-pid markers survive the filter and **still halt** (they need a human). `concedeClaim` wired into `BootDeps` (mirrors red-doctor).

New export `autoHealableClaimHygiene` gates the decision; tested for the heal path and both still-halt paths (foreign, unknown-pid).

**Human review (maintainer):** touches the boot/supervisor halt path — landing:manual (#1049).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787222151&installation_model_id=20659&pr_number=2323&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2323&signature=3e2fc1dfb3fdcf36c0a64496d7b2bf2cddae03e0bd7bc217bdcd4cf45f87e3db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->