### PR TITLE
feat: #2306 Castle-MCP S3: worker/dispatch + runner + hygiene tools

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -18,6 +18,7 @@
 
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { Writable } from "node:stream";
 import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 import { encodeLines } from "@reddb-io/toon";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
@@ -79,6 +80,44 @@ export type RequeueAdoptRunner = (
   branch: string,
   issueData: RequeueAdoptData,
 ) => Promise<"landed" | "parked" | "skipped">;
+
+export interface RequeueExecutionInput {
+  issue: number;
+  guidance: string;
+  repo?: string;
+  dryRun?: boolean;
+  adoptBranch?: string;
+}
+
+export type RequeueExecutionOutcome =
+  | "applied"
+  | "no-op"
+  | "dry-run"
+  | "closed"
+  | "refused"
+  | "landed"
+  | "parked"
+  | "skipped";
+
+export interface RequeueExecutionResult {
+  issue: number;
+  plan: RequeuePlan | null;
+  applied: boolean;
+  outcome: RequeueExecutionOutcome;
+  exitCode: number;
+  reason?: string;
+  adoptBranch?: string;
+  removeLabels?: string[];
+  addLabels?: string[];
+}
+
+export interface RequeueExecutionOptions {
+  cwd?: string;
+  gh?: RequeueGh;
+  adoptRunner?: RequeueAdoptRunner;
+  /** Optional sink for the adopt gate's live progress. MCP callers omit it. */
+  progress?: NodeJS.WritableStream;
+}
 
 const REQUEUE_FLAG_SCHEMA = {
   guidance: { kind: "value", coerce: (raw: string): string => raw },
@@ -479,6 +518,209 @@ async function runAdoptLanding(
  * reconcile) after the requeue transition; `adoptRunnerOverride` is injectable
  * for tests.
  */
+export async function executeRequeue(
+  input: RequeueExecutionInput,
+  options: RequeueExecutionOptions = {},
+): Promise<RequeueExecutionResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const guidance = input.guidance.trim();
+  const adoptBranch = input.adoptBranch?.trim() || undefined;
+  if (!Number.isSafeInteger(input.issue) || input.issue <= 0) {
+    throw new Error("requeue requires a positive issue number");
+  }
+  if (!guidance) {
+    throw new Error("requeue requires guidance with the retry decision");
+  }
+
+  const repo = options.gh ? "" : await resolveRepo(cwd, input.repo);
+  const gh = options.gh ?? ghFor(cwd, repo);
+  const issueState = await gh.view(input.issue);
+  if (issueState.state.toUpperCase() !== "OPEN") {
+    return {
+      issue: input.issue,
+      plan: null,
+      applied: false,
+      outcome: "closed",
+      exitCode: 1,
+      reason: `issue is ${issueState.state || "unknown"}, not OPEN`,
+      ...(adoptBranch ? { adoptBranch } : {}),
+    };
+  }
+
+  const wasSensitivePathPark =
+    issueState.labels.includes(LABEL_SENSITIVE_PATH) ||
+    parseCurrentBlocker(issueState.body)?.kind === "sensitive-path";
+  const plan = planRequeue({
+    body: issueState.body,
+    labels: issueState.labels,
+    guidance,
+    adoptBranch: adoptBranch !== undefined,
+  });
+  if (!plan.requeueable) {
+    if (plan.refuseForHitl) {
+      return {
+        issue: input.issue,
+        plan,
+        applied: false,
+        outcome: "refused",
+        exitCode: 1,
+        reason: plan.reason,
+        ...(adoptBranch ? { adoptBranch } : {}),
+      };
+    }
+    if (!adoptBranch) {
+      return {
+        issue: input.issue,
+        plan,
+        applied: false,
+        outcome: "no-op",
+        exitCode: 0,
+        reason: plan.reason,
+      };
+    }
+  }
+
+  if (input.dryRun) {
+    return {
+      issue: input.issue,
+      plan,
+      applied: false,
+      outcome: "dry-run",
+      exitCode: 0,
+      ...(adoptBranch ? { adoptBranch } : {}),
+    };
+  }
+
+  const withholdReady = adoptBranch !== undefined;
+  let readyWithheld = false;
+  let removeLabels: string[] | undefined;
+  let addLabels: string[] | undefined;
+  if (plan.requeueable) {
+    await sweepRequeueClaims(gh, input.issue);
+    if (plan.bodyChanged) await gh.editBody(input.issue, plan.body);
+    await gh.comment(input.issue, directiveComment(plan, guidance));
+    addLabels = withholdReady
+      ? plan.addLabels.filter((label) => label !== LABEL_READY)
+      : [...plan.addLabels];
+    removeLabels =
+      withholdReady && issueState.labels.includes(LABEL_READY)
+        ? [...plan.removeLabels, LABEL_READY]
+        : [...plan.removeLabels];
+    await gh.editLabels(input.issue, removeLabels, addLabels);
+    if (withholdReady) readyWithheld = true;
+  } else if (adoptBranch && issueState.labels.includes(LABEL_READY)) {
+    await gh.editLabels(input.issue, [LABEL_READY], []);
+    readyWithheld = true;
+  }
+
+  const baseResult = {
+    issue: input.issue,
+    plan,
+    applied: plan.requeueable,
+    ...(removeLabels ? { removeLabels } : {}),
+    ...(addLabels ? { addLabels } : {}),
+  };
+  if (!adoptBranch) {
+    return { ...baseResult, outcome: "applied", exitCode: 0 };
+  }
+
+  const restoreQueueLabel = async (): Promise<void> => {
+    if (readyWithheld) await gh.editLabels(input.issue, [], [LABEL_READY]);
+  };
+  const postLabels = plan.requeueable
+    ? issueState.labels.filter(
+        (label) => !plan.removeLabels.includes(label) && label !== LABEL_READY,
+      )
+    : issueState.labels.filter((label) => label !== LABEL_READY);
+  const adoptData: RequeueAdoptData = {
+    title: "",
+    body: plan.requeueable ? plan.body : issueState.body,
+    labels: postLabels,
+    sensitivePathApproved: wasSensitivePathPark,
+  };
+  if (wasSensitivePathPark) {
+    await gh.comment(
+      input.issue,
+      await sensitivePathAdoptAudit(cwd, adoptBranch, guidance),
+    );
+  }
+
+  const silent = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+  const runner =
+    options.adoptRunner ??
+    ((issue, branch, data) =>
+      runAdoptLanding(
+        issue,
+        branch,
+        data,
+        cwd,
+        repo,
+        options.progress ?? silent,
+      ));
+  let outcome: "landed" | "parked" | "skipped";
+  try {
+    outcome = await runner(input.issue, adoptBranch, adoptData);
+  } catch (error) {
+    await restoreQueueLabel().catch(() => {});
+    throw error;
+  }
+  if (outcome === "skipped") await restoreQueueLabel();
+  return {
+    ...baseResult,
+    outcome,
+    exitCode: outcome === "parked" ? 1 : 0,
+    adoptBranch,
+  };
+}
+
+function renderRequeueResult(
+  result: RequeueExecutionResult,
+  json: boolean,
+  stdout: NodeJS.WritableStream,
+): void {
+  if (json) {
+    stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+  const issue = result.issue;
+  if (result.outcome === "closed") {
+    process.stderr.write(`[afk] requeue #${issue}: ${result.reason}\n`);
+  } else if (result.outcome === "refused") {
+    process.stderr.write(`[afk] requeue #${issue}: refused — ${result.reason}\n`);
+  } else if (result.outcome === "no-op") {
+    stdout.write(`Requeue #${issue}: no-op — ${result.reason}\n`);
+  } else if (result.outcome === "dry-run") {
+    stdout.write(
+      `Requeue #${issue} (dry-run): clear blocker=${result.plan?.bodyChanged ?? false} ` +
+        `remove=[${result.plan?.removeLabels.join(",") ?? ""}] ` +
+        `add=[${result.plan?.addLabels.join(",") ?? ""}]` +
+        `${result.adoptBranch ? ` adopt-branch=${result.adoptBranch}` : ""}\n`,
+    );
+  } else if (result.outcome === "applied") {
+    stdout.write(
+      `Requeue #${issue}: cleared blocker=${result.plan?.bodyChanged ?? false}, ` +
+        `removed [${result.removeLabels?.join(",") ?? ""}], ` +
+        `added [${result.addLabels?.join(",") ?? ""}].\n`,
+    );
+  } else if (result.outcome === "landed") {
+    stdout.write(
+      `Requeue #${issue}: \`${result.adoptBranch}\` validated and landed.\n`,
+    );
+  } else if (result.outcome === "parked") {
+    process.stderr.write(
+      `[afk] requeue #${issue}: gate failed — \`${result.adoptBranch}\` was parked to ready-for-human.\n`,
+    );
+  } else {
+    stdout.write(
+      `Requeue #${issue}: adopt skipped (branch carries no work vs base or branch absent).\n`,
+    );
+  }
+}
+
 export async function requeueCommand(
   args: readonly string[],
   cwd = process.cwd(),
@@ -493,164 +735,34 @@ export async function requeueCommand(
     return 2;
   }
   const guidance = (values.guidance as string | undefined)?.trim();
-  const json = values.json === true;
-  const dryRun = values["dry-run"] === true;
-  const adoptBranch = (values["adopt-branch"] as string | undefined)?.trim() || undefined;
-
   if (!guidance) {
-    process.stderr.write("[afk] requeue requires --guidance with the retry decision so it can be recorded as Human guidance\n");
+    process.stderr.write(
+      "[afk] requeue requires --guidance with the retry decision so it can be recorded as Human guidance\n",
+    );
     return 2;
   }
-
-  const repo = ghOverride ? "" : await resolveRepo(cwd, values.repo as string | undefined);
-  const gh = ghOverride ?? ghFor(cwd, repo);
-
-  const issueState = await gh.view(issue);
-  if (issueState.state.toUpperCase() !== "OPEN") {
-    process.stderr.write(`[afk] requeue #${issue}: issue is ${issueState.state || "unknown"}, not OPEN\n`);
-    return 1;
-  }
-
-  // #1171: an active `blocked:sensitive-path` park is requeueable ONLY when the
-  // maintainer is adopting a reviewed branch (`--adopt-branch`). Detect it from
-  // the PRE-transition state so the audit comment + guard bypass fire only here.
-  const wasSensitivePathPark =
-    issueState.labels.includes(LABEL_SENSITIVE_PATH) ||
-    parseCurrentBlocker(issueState.body)?.kind === "sensitive-path";
-
-  const plan = planRequeue({
-    body: issueState.body,
-    labels: issueState.labels,
-    guidance,
-    adoptBranch: adoptBranch !== undefined,
-  });
-  if (!plan.requeueable) {
-    if (plan.refuseForHitl) {
-      process.stderr.write(`[afk] requeue #${issue}: refused — ${plan.reason}\n`);
-      return 1;
-    }
-    // Not parked — no-op for the requeue transition (may still adopt below).
-    if (!adoptBranch) {
-      stdout.write(`Requeue #${issue}: no-op — ${plan.reason}\n`);
-      return 0;
-    }
-  }
-
-  if (dryRun) {
-    stdout.write(
-      json
-        ? `${JSON.stringify({ issue, plan, adoptBranch }, null, 2)}\n`
-        : `Requeue #${issue} (dry-run): clear blocker=${plan.bodyChanged} remove=[${plan.removeLabels.join(",")}] add=[${plan.addLabels.join(",")}]${adoptBranch ? ` adopt-branch=${adoptBranch}` : ""}\n`,
-    );
-    return 0;
-  }
-
-  // #1307: during an `--adopt-branch` gate the Ticket must never be claimable. The
-  // fleet's candidate query AND its pre-claim state-validity recheck both key on
-  // `ready-for-agent`, so applying it before the minutes-long gate opens a window
-  // where a concurrent worker claims and re-runs the same branch on the same base
-  // (double-land risk). We therefore WITHHOLD the queue label for the whole gate
-  // and restore it only when the gate neither lands nor parks the Ticket (skip /
-  // interruption) — leaving a recoverable, still-queued state. A bare requeue is
-  // unchanged: it applies `ready-for-agent` immediately.
-  const withholdReady = adoptBranch !== undefined;
-  // Whether a `ready-for-agent` we withheld must be restorable on a skip/throw.
-  let readyWithheld = false;
-
-  // Apply the requeue transition when the issue is parked and requeueable.
-  if (plan.requeueable) {
-    await sweepRequeueClaims(gh, issue);
-    if (plan.bodyChanged) await gh.editBody(issue, plan.body);
-    await gh.comment(issue, directiveComment(plan, guidance));
-    // Under `--adopt-branch`, drop `ready-for-agent` from the add set (it is the
-    // requeue's target) and also remove any pre-existing one, so the Ticket carries
-    // no queue label for the gate. The withheld label is restored on skip/throw.
-    const addLabels = withholdReady ? plan.addLabels.filter((l) => l !== LABEL_READY) : plan.addLabels;
-    const removeLabels =
-      withholdReady && issueState.labels.includes(LABEL_READY)
-        ? [...plan.removeLabels, LABEL_READY]
-        : plan.removeLabels;
-    await gh.editLabels(issue, removeLabels, addLabels);
-    if (withholdReady) readyWithheld = true;
-    stdout.write(
-      json
-        ? `${JSON.stringify({ issue, plan, applied: true }, null, 2)}\n`
-        : `Requeue #${issue}: cleared blocker=${plan.bodyChanged}, removed [${removeLabels.join(",")}], added [${addLabels.join(",")}].\n`,
-    );
-  } else if (adoptBranch) {
-    // Not parked, but adopting: if the Ticket already carries `ready-for-agent`,
-    // strip it for the gate window so a concurrent worker can't claim it mid-land.
-    if (issueState.labels.includes(LABEL_READY)) {
-      await gh.editLabels(issue, [LABEL_READY], []);
-      readyWithheld = true;
-    }
-  } else {
-    stdout.write(`Requeue #${issue}: no-op — ${plan.reason}\n`);
-    return 0;
-  }
-
-  // Adopt mode (ADR 0081): route the branch through the no-agent landing lane.
+  const adoptBranch =
+    (values["adopt-branch"] as string | undefined)?.trim() || undefined;
   if (adoptBranch) {
-    // Restore the queue label we withheld (#1307) — used when the gate skips or is
-    // interrupted, so the Ticket returns to a recoverable, still-queued state. On a
-    // land the Ticket is closed and on a park reconcile applies `ready-for-human`,
-    // so neither restores.
-    const restoreQueueLabel = async (): Promise<void> => {
-      if (readyWithheld) await gh.editLabels(issue, [], [LABEL_READY]);
-    };
-
-    // Post-transition labels/body — pass the reconcile guard the state AFTER the
-    // requeue cleared any blocked:* labels + active blocker. `ready-for-agent` is
-    // withheld for the gate (#1307), so it is never part of the reconcile input.
-    const postLabels = plan.requeueable
-      ? issueState.labels.filter((l) => !plan.removeLabels.includes(l) && l !== LABEL_READY)
-      : issueState.labels.filter((l) => l !== LABEL_READY);
-    const postBody = plan.requeueable ? plan.body : issueState.body;
-    const adoptData: RequeueAdoptData = {
-      title: "",
-      body: postBody,
-      labels: postLabels,
-      sensitivePathApproved: wasSensitivePathPark,
-    };
-
-    // #1171 audit trail: a sensitive-path adopt is a human bypass of the landing
-    // guard — never silent. Record who approved + when, and the guidance, BEFORE
-    // the land so the approval is on the thread even if the land later parks.
-    if (wasSensitivePathPark) {
-      await gh.comment(issue, await sensitivePathAdoptAudit(cwd, adoptBranch, guidance));
-    }
-
-    stdout.write(`Requeue #${issue}: adopting branch \`${adoptBranch}\` through the no-agent landing lane (ADR 0055)…\n`);
-
-    const runner = adoptRunnerOverride
-      ?? ((n, b, d) => runAdoptLanding(n, b, d, cwd, repo, stdout));
-
-    let outcome: "landed" | "parked" | "skipped";
-    try {
-      outcome = await runner(issue, adoptBranch, adoptData);
-    } catch (err) {
-      // Interrupted mid-gate (#1307): never leave the Ticket stranded without a
-      // queue label. The claim window is already closed (the gate is no longer
-      // running), so restoring `ready-for-agent` is safe and keeps it recoverable.
-      await restoreQueueLabel().catch(() => {});
-      throw err;
-    }
-
-    if (outcome === "landed") {
-      stdout.write(`Requeue #${issue}: \`${adoptBranch}\` validated and landed.\n`);
-      return 0;
-    }
-    if (outcome === "parked") {
-      process.stderr.write(`[afk] requeue #${issue}: gate failed — \`${adoptBranch}\` was parked to ready-for-human.\n`);
-      return 1;
-    }
-    // skipped (no-commits, branch-absent, etc.) — not a failure but worth noting.
-    // The gate neither landed nor parked, so restore the withheld queue label
-    // (#1307) to return the Ticket to a recoverable, still-queued state.
-    await restoreQueueLabel();
-    stdout.write(`Requeue #${issue}: adopt skipped (branch carries no work vs base or branch absent).\n`);
-    return 0;
+    stdout.write(
+      `Requeue #${issue}: adopting branch \`${adoptBranch}\` through the no-agent landing lane (ADR 0055)…\n`,
+    );
   }
-
-  return 0;
+  const result = await executeRequeue(
+    {
+      issue,
+      guidance,
+      repo: values.repo as string | undefined,
+      dryRun: values["dry-run"] === true,
+      adoptBranch,
+    },
+    {
+      cwd,
+      gh: ghOverride,
+      adoptRunner: adoptRunnerOverride,
+      progress: stdout,
+    },
+  );
+  renderRequeueResult(result, values.json === true, stdout);
+  return result.exitCode;
 }

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,5 +1,6 @@
 import { join, relative, resolve } from "node:path";
 import { Writable } from "node:stream";
+import { decode as decodeToon } from "@reddb-io/toon";
 import {
   castleLanePath,
   createEnginePaths,
@@ -10,6 +11,8 @@ import {
   readFleetProfiles,
   removeFleetProfile,
   upsertFleetProfile,
+  RUNNER_SPECS,
+  detectRunner,
   type FleetProfile,
 } from "@reddb-io/red-castle/engine";
 import type {
@@ -18,6 +21,11 @@ import type {
   FleetEditInput,
   FleetNameInput,
   LogsInput,
+  RequeueToolInput,
+  RetakeToolInput,
+  WorkerDispatchInput,
+  WorkerRequestInput,
+  WorkerStopInput,
 } from "../../../packages/red-castle/src/mcp-server.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { collectDashboardReport } from "./commands/dashboard.js";
@@ -27,6 +35,7 @@ import {
   resolveSupervisorConfig,
 } from "./core/supervisor.js";
 import { listCandidates, listHitlCandidates } from "./runtime/gh.js";
+import * as ghx from "./runtime/gh.js";
 import { isLivePid } from "./runtime/kill-tree.js";
 import { spawnSupervisor } from "./runtime/supervisor-spawn.js";
 import { discoverLiveSupervisorPid } from "./runtime/supervisor-state.js";
@@ -37,6 +46,178 @@ import {
   resolveRepoContext,
 } from "./runtime/wire.js";
 import { readAllWorkerStates } from "./core/worker-state-reader.js";
+import { runCommand } from "./commands/run.js";
+import { goCommand } from "./commands/go.js";
+import { stopCommand } from "./commands/stop.js";
+import { requeueCommand } from "./commands/requeue.js";
+import { retakeCommand } from "./commands/retake.js";
+import {
+  branchesToReap,
+  planLiveBranchCleanup,
+  planLocalBranchCleanup,
+} from "./core/branch-cleanup.js";
+import { executeUnblockSweep } from "./core/boot-sweep.js";
+import { collectReapInputs } from "./runtime/wire/reap.js";
+
+interface DispatchOperationInput extends WorkerDispatchInput {
+  request?: string;
+}
+
+export interface DevAfkMcpOperations {
+  dispatchIssue(
+    root: string,
+    input: DispatchOperationInput & { issue: number },
+  ): Promise<unknown>;
+  dispatchDemand(
+    root: string,
+    input: DispatchOperationInput & { demand: string },
+  ): Promise<unknown>;
+  stopWorker(root: string, input: WorkerStopInput): Promise<unknown>;
+  requeue(input: RequeueToolInput): Promise<unknown>;
+  retake(input: RetakeToolInput): Promise<unknown>;
+  reap(): Promise<unknown>;
+  unblockSweep(): Promise<unknown>;
+}
+
+function captureStream(): {
+  stream: Writable;
+  text(): string;
+} {
+  let output = "";
+  return {
+    stream: new Writable({
+      write(chunk, _encoding, callback) {
+        output += String(chunk);
+        callback();
+      },
+    }),
+    text: () => output,
+  };
+}
+
+function parsedCommandOutput(
+  output: string,
+  exitCode: number,
+  format: "json" | "toon",
+): unknown {
+  const trimmed = output.trim();
+  if (trimmed === "") return { exit_code: exitCode };
+  try {
+    const value = format === "json" ? JSON.parse(trimmed) : decodeToon(trimmed);
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      return { ...(value as Record<string, unknown>), exit_code: exitCode };
+    }
+    return { value, exit_code: exitCode };
+  } catch {
+    return { output: trimmed, exit_code: exitCode };
+  }
+}
+
+function dispatchArgs(input: DispatchOperationInput): string[] {
+  const args: string[] = [];
+  if (input.runner) args.push("--runner", input.runner);
+  if (input.request) args.push("--request", input.request);
+  return args;
+}
+
+function defaultOperations(root: string): DevAfkMcpOperations {
+  return {
+    async dispatchIssue(cwd, input) {
+      const exitCode = await runCommand({
+        cwd,
+        args: [
+          "--issues",
+          String(input.issue),
+          "--once",
+          ...dispatchArgs(input),
+        ],
+      });
+      return { kind: "afk", issue: input.issue, exit_code: exitCode };
+    },
+    async dispatchDemand(cwd, input) {
+      const args = [input.demand, ...dispatchArgs(input)];
+      if (input.mode) args.push("--mode", input.mode);
+      const exitCode = await goCommand(args, cwd);
+      return { kind: "go", demand: input.demand, exit_code: exitCode };
+    },
+    async stopWorker(cwd, input) {
+      const capture = captureStream();
+      const exitCode = await stopCommand(
+        ["--worker", input.worker],
+        cwd,
+        capture.stream,
+      );
+      return {
+        ...(parsedCommandOutput(capture.text(), exitCode, "toon") as object),
+        recycle: input.recycle,
+      };
+    },
+    async requeue(input) {
+      const args = [
+        String(input.issue),
+        "--guidance",
+        input.guidance,
+        "--json",
+      ];
+      if (input.repo) args.push("--repo", input.repo);
+      if (input.dryRun) args.push("--dry-run");
+      if (input.adoptBranch) args.push("--adopt-branch", input.adoptBranch);
+      const capture = captureStream();
+      const exitCode = await requeueCommand(args, root, capture.stream);
+      return parsedCommandOutput(capture.text(), exitCode, "json");
+    },
+    async retake(input) {
+      const args = [String(input.issue), "--json"];
+      if (input.repo) args.push("--repo", input.repo);
+      if (input.prLimit) args.push("--pr-limit", String(input.prLimit));
+      const capture = captureStream();
+      const exitCode = await retakeCommand(args, root, capture.stream);
+      return parsedCommandOutput(capture.text(), exitCode, "json");
+    },
+    async reap() {
+      const context = await resolveRepoContext(root);
+      const inputs = await collectReapInputs(context);
+      const nowS = Math.floor(Date.now() / 1_000);
+      const remotePlan = planLiveBranchCleanup(
+        inputs.remoteLiveRefs,
+        inputs.lookup,
+        nowS,
+      );
+      const localPlan = planLocalBranchCleanup(
+        inputs.localLiveRefs,
+        inputs.lookup,
+        nowS,
+      );
+      const remoteReaped = branchesToReap(remotePlan).map((item) => item.branch);
+      const localReaped = branchesToReap(localPlan).map((item) => item.branch);
+      for (const branch of remoteReaped) await inputs.deleteRemote(branch);
+      for (const branch of localReaped) await inputs.deleteLocal(branch);
+      return {
+        remote_found: inputs.remoteLiveRefs.length,
+        local_found: inputs.localLiveRefs.length,
+        remote_reaped: remoteReaped,
+        local_reaped: localReaped,
+      };
+    },
+    async unblockSweep() {
+      const context = await resolveRepoContext(root);
+      const gh = { cwd: context.root, repo: context.repo };
+      const candidates = await ghx.listUnblockCandidates(gh);
+      const promoted = await executeUnblockSweep(
+        candidates,
+        async (issue) => ((await ghx.issueClosed(gh, issue)) ? "CLOSED" : "OPEN"),
+        {
+          editLabels: async (issue, remove, add) => {
+            await ghx.editLabels(gh, issue, remove, add);
+          },
+          comment: (issue, body) => ghx.comment(gh, issue, body),
+          issueReference: (issue) => ghx.issueReference(gh, issue),
+        },
+      );
+      return { promoted };
+    },
+  };
+}
 
 function registryPath(root: string): string {
   return fleetRegistryPath(createEnginePaths(join(root, ".red")));
@@ -244,6 +425,7 @@ async function workerVitals(root: string) {
 
 export function createDevAfkMcpDependencies(
   root = process.cwd(),
+  operations: DevAfkMcpOperations = defaultOperations(root),
 ): CastleMcpDependencies {
   return {
     fleetList: () => readFleetProfiles(registryPath(root)),
@@ -287,5 +469,66 @@ export function createDevAfkMcpDependencies(
         },
       };
     },
+    workerDispatch: (input) => {
+      if (input.issue !== undefined) {
+        return operations.dispatchIssue(root, {
+          ...input,
+          issue: input.issue,
+        });
+      }
+      if (input.demand !== undefined) {
+        return operations.dispatchDemand(root, {
+          ...input,
+          demand: input.demand,
+        });
+      }
+      throw new Error("worker dispatch requires an issue or demand");
+    },
+    workerStatus: async ({ worker }) => {
+      const workers = await workerVitals(root);
+      return worker === undefined
+        ? workers
+        : workers.filter((record) => record.worker.id === worker);
+    },
+    workerStop: (input) => operations.stopWorker(root, input),
+    runnerList: async () =>
+      Object.fromEntries(
+        Object.entries(RUNNER_SPECS).map(([runner, spec]) => [
+          runner,
+          {
+            efforts: spec.efforts,
+            channel: spec.channel,
+            factory: spec.factory,
+            ...(spec.forcedModel ? { forced_model: spec.forcedModel } : {}),
+            ...(spec.defaultEffort
+              ? { default_effort: spec.defaultEffort }
+              : {}),
+            structured_output: spec.structuredOutput === true,
+            auth_env: spec.resolveAuthEnv !== undefined,
+          },
+        ]),
+      ),
+    runnerDetect: async ({ runner }) => detectRunner({ flag: runner }),
+    workerRequest: (input: WorkerRequestInput) => {
+      const dispatch = { ...input, request: input.text };
+      delete (dispatch as Partial<WorkerRequestInput>).text;
+      if (dispatch.issue !== undefined) {
+        return operations.dispatchIssue(root, {
+          ...dispatch,
+          issue: dispatch.issue,
+        });
+      }
+      if (dispatch.demand !== undefined) {
+        return operations.dispatchDemand(root, {
+          ...dispatch,
+          demand: dispatch.demand,
+        });
+      }
+      throw new Error("worker request requires an issue or demand");
+    },
+    requeue: (input) => operations.requeue(input),
+    retake: (input) => operations.retake(input),
+    reap: () => operations.reap(),
+    unblockSweep: () => operations.unblockSweep(),
   };
 }

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { join, relative, resolve } from "node:path";
 import { Writable } from "node:stream";
 import { decode as decodeToon } from "@reddb-io/toon";
@@ -46,11 +47,14 @@ import {
   resolveRepoContext,
 } from "./runtime/wire.js";
 import { readAllWorkerStates } from "./core/worker-state-reader.js";
-import { runCommand } from "./commands/run.js";
-import { goCommand } from "./commands/go.js";
 import { stopCommand } from "./commands/stop.js";
-import { requeueCommand } from "./commands/requeue.js";
+import { executeRequeue } from "./commands/requeue.js";
 import { retakeCommand } from "./commands/retake.js";
+import {
+  dispatchGo,
+  type DisposableIssueSpec,
+} from "./core/go.js";
+import { loadConfig, readBackpressure } from "./core/config.js";
 import {
   branchesToReap,
   planLiveBranchCleanup,
@@ -77,6 +81,13 @@ export interface DevAfkMcpOperations {
   retake(input: RetakeToolInput): Promise<unknown>;
   reap(): Promise<unknown>;
   unblockSweep(): Promise<unknown>;
+}
+
+export interface DevAfkMcpRuntime {
+  launchRun(root: string, args: readonly string[]): Promise<{ pid: number }>;
+  ensureLabel(root: string, name: string): Promise<void>;
+  createIssue(root: string, spec: DisposableIssueSpec): Promise<number>;
+  executeRequeue(root: string, input: RequeueToolInput): Promise<unknown>;
 }
 
 function captureStream(): {
@@ -120,25 +131,91 @@ function dispatchArgs(input: DispatchOperationInput): string[] {
   return args;
 }
 
-function defaultOperations(root: string): DevAfkMcpOperations {
+async function launchDetachedRun(
+  root: string,
+  args: readonly string[],
+): Promise<{ pid: number }> {
+  const bundle = process.argv[1];
+  if (!bundle) throw new Error("cannot dispatch worker: bundle path is missing");
+  const child = spawn(process.execPath, [bundle, "run", ...args], {
+    cwd: root,
+    env: process.env,
+    detached: true,
+    stdio: "ignore",
+  });
+  const pid = child.pid;
+  if (!pid) throw new Error("cannot dispatch worker: spawn returned no pid");
+  child.unref();
+  return { pid };
+}
+
+const defaultMcpRuntime: DevAfkMcpRuntime = {
+  launchRun: launchDetachedRun,
+  async ensureLabel(root, name) {
+    const context = await resolveRepoContext(root);
+    await ghx.ensureLabel({ cwd: context.root, repo: context.repo }, name);
+  },
+  async createIssue(root, spec) {
+    const context = await resolveRepoContext(root);
+    return ghx.createIssue({ cwd: context.root, repo: context.repo }, spec);
+  },
+  executeRequeue: (root, input) => executeRequeue(input, { cwd: root }),
+};
+
+export function createDefaultDevAfkMcpOperations(
+  root: string,
+  overrides: Partial<DevAfkMcpRuntime> = {},
+): DevAfkMcpOperations {
+  const runtime: DevAfkMcpRuntime = { ...defaultMcpRuntime, ...overrides };
   return {
     async dispatchIssue(cwd, input) {
-      const exitCode = await runCommand({
-        cwd,
-        args: [
-          "--issues",
-          String(input.issue),
-          "--once",
-          ...dispatchArgs(input),
-        ],
-      });
-      return { kind: "afk", issue: input.issue, exit_code: exitCode };
+      const args = [
+        "--issues",
+        String(input.issue),
+        "--once",
+        ...dispatchArgs(input),
+      ];
+      const launch = await runtime.launchRun(cwd, args);
+      return {
+        kind: "afk",
+        issue: input.issue,
+        worker_pid: launch.pid,
+        status: "dispatched",
+      };
     },
     async dispatchDemand(cwd, input) {
-      const args = [input.demand, ...dispatchArgs(input)];
-      if (input.mode) args.push("--mode", input.mode);
-      const exitCode = await goCommand(args, cwd);
-      return { kind: "go", demand: input.demand, exit_code: exitCode };
+      let workerPid: number | undefined;
+      const configuredBackpressure = readBackpressure(
+        loadConfig(afkPaths(cwd).configPath, { warn: () => undefined }),
+      );
+      const result = await dispatchGo(
+        {
+          ensureLabel: (name) => runtime.ensureLabel(cwd, name),
+          createIssue: (spec) => runtime.createIssue(cwd, spec),
+          runEngine: async (args) => {
+            const launch = await runtime.launchRun(cwd, args);
+            workerPid = launch.pid;
+            return 0;
+          },
+        },
+        input.demand,
+        {
+          runner: input.runner,
+          mode: input.mode,
+          request: input.request,
+          hasHarness: configuredBackpressure.length > 0,
+        },
+      );
+      if (workerPid === undefined) {
+        throw new Error("cannot dispatch demand: worker was not spawned");
+      }
+      return {
+        kind: "go",
+        demand: input.demand,
+        issue: result.issue,
+        worker_pid: workerPid,
+        status: "dispatched",
+      };
     },
     async stopWorker(cwd, input) {
       const capture = captureStream();
@@ -152,20 +229,7 @@ function defaultOperations(root: string): DevAfkMcpOperations {
         recycle: input.recycle,
       };
     },
-    async requeue(input) {
-      const args = [
-        String(input.issue),
-        "--guidance",
-        input.guidance,
-        "--json",
-      ];
-      if (input.repo) args.push("--repo", input.repo);
-      if (input.dryRun) args.push("--dry-run");
-      if (input.adoptBranch) args.push("--adopt-branch", input.adoptBranch);
-      const capture = captureStream();
-      const exitCode = await requeueCommand(args, root, capture.stream);
-      return parsedCommandOutput(capture.text(), exitCode, "json");
-    },
+    requeue: (input) => runtime.executeRequeue(root, input),
     async retake(input) {
       const args = [String(input.issue), "--json"];
       if (input.repo) args.push("--repo", input.repo);
@@ -425,7 +489,7 @@ async function workerVitals(root: string) {
 
 export function createDevAfkMcpDependencies(
   root = process.cwd(),
-  operations: DevAfkMcpOperations = defaultOperations(root),
+  operations: DevAfkMcpOperations = createDefaultDevAfkMcpOperations(root),
 ): CastleMcpDependencies {
   return {
     fleetList: () => readFleetProfiles(registryPath(root)),

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { Writable } from "node:stream";
 import { decode as decodeToon } from "@reddb-io/toon";
@@ -140,6 +141,9 @@ async function launchDetachedRun(
     throw new Error("cannot dispatch worker: MCP bundle path is missing");
   }
   const bundle = resolveDevCliBundle(mcpBundle);
+  if (!existsSync(bundle)) {
+    throw new Error("cannot dispatch worker: sibling dev bundle is missing");
+  }
   const child = spawn(process.execPath, [bundle, "run", ...args], {
     cwd: root,
     env: process.env,

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { join, relative, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { Writable } from "node:stream";
 import { decode as decodeToon } from "@reddb-io/toon";
 import {
@@ -135,8 +135,11 @@ async function launchDetachedRun(
   root: string,
   args: readonly string[],
 ): Promise<{ pid: number }> {
-  const bundle = process.argv[1];
-  if (!bundle) throw new Error("cannot dispatch worker: bundle path is missing");
+  const mcpBundle = process.argv[1];
+  if (!mcpBundle) {
+    throw new Error("cannot dispatch worker: MCP bundle path is missing");
+  }
+  const bundle = resolveDevCliBundle(mcpBundle);
   const child = spawn(process.execPath, [bundle, "run", ...args], {
     cwd: root,
     env: process.env,
@@ -147,6 +150,19 @@ async function launchDetachedRun(
   if (!pid) throw new Error("cannot dispatch worker: spawn returned no pid");
   child.unref();
   return { pid };
+}
+
+export function resolveDevCliBundle(mcpBundle: string): string {
+  const file = basename(mcpBundle);
+  if (file === "afk-mcp.bundle.min.mjs") {
+    return join(dirname(mcpBundle), "dev.bundle.min.mjs");
+  }
+  if (file.startsWith("afk-mcp-") && file.endsWith(".bundle.min.mjs")) {
+    return join(dirname(mcpBundle), file.replace(/^afk-mcp-/, "dev-"));
+  }
+  throw new Error(
+    `cannot dispatch worker: unrecognized MCP bundle name ${JSON.stringify(file)}`,
+  );
 }
 
 const defaultMcpRuntime: DevAfkMcpRuntime = {

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   createDefaultDevAfkMcpOperations,
   createDevAfkMcpDependencies,
+  resolveDevCliBundle,
   type DevAfkMcpOperations,
 } from "../src/mcp-adapter.js";
 
@@ -30,6 +31,17 @@ async function root(): Promise<string> {
 }
 
 describe("dev:afk MCP host adapter", () => {
+  it("resolves the sibling dev CLI bundle from local and cached MCP assets", () => {
+    expect(
+      resolveDevCliBundle(join("dist", "afk-mcp.bundle.min.mjs")),
+    ).toBe(join("dist", "dev.bundle.min.mjs"));
+    expect(
+      resolveDevCliBundle(
+        join("cache", "afk-mcp-2.76.1.bundle.min.mjs"),
+      ),
+    ).toBe(join("cache", "dev-2.76.1.bundle.min.mjs"));
+  });
+
   it("lists registered fleets through the Castle registry primitive", async () => {
     const cwd = await root();
     const paths = createEnginePaths(join(cwd, ".red"));

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -10,6 +10,7 @@ import {
   upsertFleetProfile,
 } from "@reddb-io/red-castle/engine";
 import {
+  createDefaultDevAfkMcpOperations,
   createDevAfkMcpDependencies,
   type DevAfkMcpOperations,
 } from "../src/mcp-adapter.js";
@@ -100,6 +101,57 @@ describe("dev:afk MCP host adapter", () => {
       runner: "claude",
       mode: "no-mistakes",
     });
+  });
+
+  it("detaches MCP dispatches without writing progress to stdout", async () => {
+    const cwd = await root();
+    const launchRun = vi.fn(async () => ({ pid: 73 }));
+    const createIssue = vi.fn(async () => 2308);
+    const ensureLabel = vi.fn(async () => undefined);
+    const stdout = vi.spyOn(process.stdout, "write");
+    const operations = createDefaultDevAfkMcpOperations(cwd, {
+      launchRun,
+      createIssue,
+      ensureLabel,
+    });
+
+    try {
+      await expect(
+        operations.dispatchIssue(cwd, { issue: 2306, runner: "codex" }),
+      ).resolves.toMatchObject({
+        kind: "afk",
+        issue: 2306,
+        worker_pid: 73,
+        status: "dispatched",
+      });
+      await expect(
+        operations.dispatchDemand(cwd, {
+          demand: "--repair release",
+          runner: "codex",
+          mode: "direct-PR",
+        }),
+      ).resolves.toMatchObject({
+        kind: "go",
+        demand: "--repair release",
+        issue: 2308,
+        worker_pid: 73,
+        status: "dispatched",
+      });
+    } finally {
+      stdout.mockRestore();
+    }
+
+    expect(launchRun).toHaveBeenNthCalledWith(
+      1,
+      cwd,
+      ["--issues", "2306", "--once", "--runner", "codex"],
+    );
+    expect(createIssue.mock.calls[0]?.[1]).toMatchObject({
+      labels: ["lane:go"],
+    });
+    expect(createIssue.mock.calls[0]?.[1].body).toContain("--repair release");
+    expect(launchRun.mock.calls[1]?.[2]).not.toContain("--repair release");
+    expect(stdout).not.toHaveBeenCalled();
   });
 
   it("injects worker_request only into a newly dispatched worker", async () => {

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   appendCastleLaneRecord,
   castleLanePath,
@@ -9,7 +9,10 @@ import {
   fleetRegistryPath,
   upsertFleetProfile,
 } from "@reddb-io/red-castle/engine";
-import { createDevAfkMcpDependencies } from "../src/mcp-adapter.js";
+import {
+  createDevAfkMcpDependencies,
+  type DevAfkMcpOperations,
+} from "../src/mcp-adapter.js";
 
 const roots: string[] = [];
 
@@ -71,4 +74,121 @@ describe("dev:afk MCP host adapter", () => {
       deps.logs({ lane: "worker", id: "../../outside" }),
     ).rejects.toThrow("escapes its Castle lane root");
   });
+
+  it("routes issue and demand dispatches through their value operations", async () => {
+    const cwd = await root();
+    const operations = fakeOperations();
+    const deps = createDevAfkMcpDependencies(cwd, operations);
+
+    await expect(
+      deps.workerDispatch({ issue: 2306, runner: "codex" }),
+    ).resolves.toEqual({ kind: "afk", exit_code: 0 });
+    expect(operations.dispatchIssue).toHaveBeenCalledWith(cwd, {
+      issue: 2306,
+      runner: "codex",
+    });
+
+    await expect(
+      deps.workerDispatch({
+        demand: "repair the release gate",
+        runner: "claude",
+        mode: "no-mistakes",
+      }),
+    ).resolves.toEqual({ kind: "go", exit_code: 0 });
+    expect(operations.dispatchDemand).toHaveBeenCalledWith(cwd, {
+      demand: "repair the release gate",
+      runner: "claude",
+      mode: "no-mistakes",
+    });
+  });
+
+  it("injects worker_request only into a newly dispatched worker", async () => {
+    const cwd = await root();
+    const operations = fakeOperations();
+    const deps = createDevAfkMcpDependencies(cwd, operations);
+
+    await deps.workerRequest({
+      issue: 2306,
+      runner: "codex",
+      text: "Run the focused package gate.",
+    });
+
+    expect(operations.dispatchIssue).toHaveBeenCalledWith(cwd, {
+      issue: 2306,
+      runner: "codex",
+      request: "Run the focused package gate.",
+    });
+  });
+
+  it("stops and recycles workers through the shared stop operation", async () => {
+    const cwd = await root();
+    const operations = fakeOperations();
+    const deps = createDevAfkMcpDependencies(cwd, operations);
+
+    await expect(
+      deps.workerStop({ worker: "wVM2Z", recycle: false }),
+    ).resolves.toMatchObject({ worker: "wVM2Z", worker_status: "stopped" });
+    await deps.workerStop({ worker: "wVM2Z", recycle: true });
+    expect(operations.stopWorker).toHaveBeenNthCalledWith(1, cwd, {
+      worker: "wVM2Z",
+      recycle: false,
+    });
+    expect(operations.stopWorker).toHaveBeenNthCalledWith(2, cwd, {
+      worker: "wVM2Z",
+      recycle: true,
+    });
+  });
+
+  it("returns runner specs and deterministic explicit detection", async () => {
+    const cwd = await root();
+    const deps = createDevAfkMcpDependencies(cwd, fakeOperations());
+
+    await expect(deps.runnerList()).resolves.toMatchObject({
+      codex: { channel: "effort", factory: "codex" },
+      claude: { channel: "effort", factory: "claudeCode" },
+    });
+    await expect(deps.runnerDetect({ runner: "codex" })).resolves.toEqual({
+      runner: "codex",
+      method: "flag",
+      detail: "--runner",
+    });
+  });
+
+  it("returns structured hygiene operation results", async () => {
+    const cwd = await root();
+    const operations = fakeOperations();
+    const deps = createDevAfkMcpDependencies(cwd, operations);
+
+    await expect(
+      deps.requeue({ issue: 2306, guidance: "Retry after repair." }),
+    ).resolves.toEqual({ issue: 2306, applied: true });
+    await expect(deps.retake({ issue: 2306 })).resolves.toEqual({
+      issue: { number: 2306 },
+    });
+    await expect(deps.reap()).resolves.toEqual({
+      remote_reaped: ["afk/wOLD/1-old"],
+      local_reaped: [],
+    });
+    await expect(deps.unblockSweep()).resolves.toEqual({ promoted: [2307] });
+  });
 });
+
+function fakeOperations(): DevAfkMcpOperations {
+  return {
+    dispatchIssue: vi.fn(async () => ({ kind: "afk" as const, exit_code: 0 })),
+    dispatchDemand: vi.fn(async () => ({ kind: "go" as const, exit_code: 0 })),
+    stopWorker: vi.fn(async (_root, input) => ({
+      worker: input.worker,
+      worker_pid: 42,
+      worker_status: "stopped",
+      recycle: input.recycle,
+    })),
+    requeue: vi.fn(async (input) => ({ issue: input.issue, applied: true })),
+    retake: vi.fn(async (input) => ({ issue: { number: input.issue } })),
+    reap: vi.fn(async () => ({
+      remote_reaped: ["afk/wOLD/1-old"],
+      local_reaped: [],
+    })),
+    unblockSweep: vi.fn(async () => ({ promoted: [2307] })),
+  };
+}

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -117,8 +117,8 @@ describe("dev:afk MCP host adapter", () => {
 
   it("detaches MCP dispatches without writing progress to stdout", async () => {
     const cwd = await root();
-    const launchRun = vi.fn(async () => ({ pid: 73 }));
-    const createIssue = vi.fn(async () => 2308);
+    const launchRun = vi.fn(async (_cwd: string, _args: string[]) => ({ pid: 73 }));
+    const createIssue = vi.fn(async (_title: string, _opts: { labels: string[]; body: string }) => 2308);
     const ensureLabel = vi.fn(async () => undefined);
     const stdout = vi.spyOn(process.stdout, "write");
     const operations = createDefaultDevAfkMcpOperations(cwd, {

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -150,7 +150,7 @@ describe("dev:afk MCP host adapter", () => {
       labels: ["lane:go"],
     });
     expect(createIssue.mock.calls[0]?.[1].body).toContain("--repair release");
-    expect(launchRun.mock.calls[1]?.[2]).not.toContain("--repair release");
+    expect(launchRun.mock.calls[1]?.[1]).not.toContain("--repair release");
     expect(stdout).not.toHaveBeenCalled();
   });
 

--- a/apps/dev/tests/requeue-command.test.ts
+++ b/apps/dev/tests/requeue-command.test.ts
@@ -3,7 +3,12 @@ import { Writable } from "node:stream";
 import { formatCurrentBlocker } from "../src/core/blocker-state.js";
 import { renderClaimComment } from "../src/core/claim.js";
 import { isRequeueComplete } from "../src/core/requeue.js";
-import { requeueCommand, type RequeueGh, type RequeueAdoptRunner } from "../src/commands/requeue.js";
+import {
+  executeRequeue,
+  requeueCommand,
+  type RequeueGh,
+  type RequeueAdoptRunner,
+} from "../src/commands/requeue.js";
 
 function capture(): { stream: Writable; text: () => string; stderr: () => string } {
   let buf = "";
@@ -87,6 +92,28 @@ const specBodyMismatch = `## Summary\nDo it.\n\n## Current blocker\n\n${formatCu
 const sensitivePathBody = `## Summary\nDo it.\n\n## Current blocker\n\n${formatCurrentBlocker(sensitivePathBlocker)}\n`;
 
 describe("requeue command — happy path", () => {
+  it("returns a stable structured result for a non-parked no-op", async () => {
+    const { gh, calls } = fakeGh({
+      state: "OPEN",
+      body: "## Summary\nNothing.\n",
+      labels: ["ready-for-agent"],
+    });
+
+    await expect(
+      executeRequeue(
+        { issue: 42, guidance: "Retry." },
+        { cwd: "/tmp", gh },
+      ),
+    ).resolves.toMatchObject({
+      issue: 42,
+      applied: false,
+      outcome: "no-op",
+      exitCode: 0,
+      plan: { requeueable: false },
+    });
+    expect(calls.editBody + calls.editLabels + calls.comment).toBe(0);
+  });
+
   it("applies the full transition so a label flip alone is never the requeue", async () => {
     const { gh, calls, state } = fakeGh({
       state: "OPEN",

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -34,6 +34,28 @@ function deps(): CastleMcpDependencies {
       ready_for_agent: [],
       ready_for_human: [],
     })),
+    workerDispatch: vi.fn(async (input) => ({
+      status: "completed",
+      target: input.issue ?? input.demand,
+    })),
+    workerStatus: vi.fn(async () => []),
+    workerStop: vi.fn(async (input) => ({
+      worker: input.worker,
+      status: "stopped",
+    })),
+    runnerList: vi.fn(async () => ({ codex: { efforts: ["low"] } })),
+    runnerDetect: vi.fn(async (input) => ({
+      runner: input.runner ?? "codex",
+      method: input.runner ? "flag" : "env-var",
+    })),
+    workerRequest: vi.fn(async (input) => ({
+      status: "completed",
+      request: input.text,
+    })),
+    requeue: vi.fn(async (input) => ({ issue: input.issue, applied: true })),
+    retake: vi.fn(async (input) => ({ issue: { number: input.issue } })),
+    reap: vi.fn(async () => ({ remote: [], local: [] })),
+    unblockSweep: vi.fn(async () => ({ promoted: [] })),
   };
 }
 
@@ -51,6 +73,17 @@ describe("dev:afk MCP tools", () => {
       "monitor",
       "history",
       "queue_status",
+      "worker_dispatch",
+      "worker_status",
+      "worker_stop",
+      "worker_recycle",
+      "runner_list",
+      "runner_detect",
+      "worker_request",
+      "requeue",
+      "retake",
+      "reap",
+      "unblock_sweep",
     ]);
   });
 
@@ -86,5 +119,83 @@ describe("dev:afk MCP tools", () => {
     ).resolves.toEqual([
       { at: "2026-07-21T00:00:00.000Z", kind: "worker.started" },
     ]);
+  });
+
+  it("dispatches and stops workers through mutating worker tools", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await tools
+      .find((tool) => tool.name === "worker_dispatch")!
+      .invoke({ issue: 2306, runner: "codex" });
+    expect(d.workerDispatch).toHaveBeenCalledWith({
+      issue: 2306,
+      runner: "codex",
+    });
+
+    await tools
+      .find((tool) => tool.name === "worker_stop")!
+      .invoke({ worker: "wVM2Z" });
+    await tools
+      .find((tool) => tool.name === "worker_recycle")!
+      .invoke({ worker: "wVM2Z" });
+    expect(d.workerStop).toHaveBeenNthCalledWith(1, {
+      worker: "wVM2Z",
+      recycle: false,
+    });
+    expect(d.workerStop).toHaveBeenNthCalledWith(2, {
+      worker: "wVM2Z",
+      recycle: true,
+    });
+
+    for (const name of ["worker_dispatch", "worker_stop", "worker_recycle"]) {
+      expect(tools.find((tool) => tool.name === name)!.description).toMatch(
+        /^MUTATING:/,
+      );
+    }
+  });
+
+  it("lists and detects runners and injects a spawn-time worker request", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await expect(
+      tools.find((tool) => tool.name === "runner_list")!.invoke({}),
+    ).resolves.toEqual({ codex: { efforts: ["low"] } });
+    await tools
+      .find((tool) => tool.name === "runner_detect")!
+      .invoke({ runner: "codex" });
+    expect(d.runnerDetect).toHaveBeenCalledWith({ runner: "codex" });
+
+    await tools
+      .find((tool) => tool.name === "worker_request")!
+      .invoke({ issue: 2306, runner: "codex", text: "Use TDD." });
+    expect(d.workerRequest).toHaveBeenCalledWith({
+      issue: 2306,
+      runner: "codex",
+      text: "Use TDD.",
+    });
+  });
+
+  it("wraps structured requeue, retake, reap, and unblock-sweep cores", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await tools
+      .find((tool) => tool.name === "requeue")!
+      .invoke({ issue: 2306, guidance: "Retry after fixing the gate." });
+    expect(d.requeue).toHaveBeenCalledWith({
+      issue: 2306,
+      guidance: "Retry after fixing the gate.",
+    });
+
+    await tools
+      .find((tool) => tool.name === "retake")!
+      .invoke({ issue: 2306 });
+    expect(d.retake).toHaveBeenCalledWith({ issue: 2306 });
+    await tools.find((tool) => tool.name === "reap")!.invoke({});
+    expect(d.reap).toHaveBeenCalledOnce();
+    await tools.find((tool) => tool.name === "unblock_sweep")!.invoke({});
+    expect(d.unblockSweep).toHaveBeenCalledOnce();
   });
 });

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -35,6 +35,44 @@ export interface LogsInput {
   id: string;
 }
 
+export interface WorkerDispatchInput {
+  issue?: number;
+  demand?: string;
+  runner?: string;
+  mode?: "no-mistakes" | "direct-PR" | "local-only";
+}
+
+export interface WorkerStatusInput {
+  worker?: string;
+}
+
+export interface WorkerStopInput {
+  worker: string;
+  recycle: boolean;
+}
+
+export interface RunnerDetectInput {
+  runner?: string;
+}
+
+export interface WorkerRequestInput extends WorkerDispatchInput {
+  text: string;
+}
+
+export interface RequeueToolInput {
+  issue: number;
+  guidance: string;
+  repo?: string;
+  dryRun?: boolean;
+  adoptBranch?: string;
+}
+
+export interface RetakeToolInput {
+  issue: number;
+  repo?: string;
+  prLimit?: number;
+}
+
 export interface CastleMcpDependencies {
   fleetList(): Promise<unknown>;
   fleetStatus(input: FleetNameInput): Promise<unknown>;
@@ -47,6 +85,16 @@ export interface CastleMcpDependencies {
   monitor(): Promise<unknown>;
   history(input: { limit?: number }): Promise<unknown>;
   queueStatus(): Promise<unknown>;
+  workerDispatch(input: WorkerDispatchInput): Promise<unknown>;
+  workerStatus(input: WorkerStatusInput): Promise<unknown>;
+  workerStop(input: WorkerStopInput): Promise<unknown>;
+  runnerList(): Promise<unknown>;
+  runnerDetect(input: RunnerDetectInput): Promise<unknown>;
+  workerRequest(input: WorkerRequestInput): Promise<unknown>;
+  requeue(input: RequeueToolInput): Promise<unknown>;
+  retake(input: RetakeToolInput): Promise<unknown>;
+  reap(): Promise<unknown>;
+  unblockSweep(): Promise<unknown>;
 }
 
 export interface CastleMcpTool {
@@ -68,6 +116,24 @@ const fleetConfig = z.record(
   z.string(),
   z.union([z.string(), z.number(), z.boolean()]),
 );
+
+const dispatchShape = {
+  issue: z.number().int().positive().optional(),
+  demand: z.string().min(1).optional(),
+  runner: z.string().min(1).optional(),
+  mode: z.enum(["no-mistakes", "direct-PR", "local-only"]).optional(),
+};
+
+function dispatchInput(input: Record<string, unknown>): WorkerDispatchInput {
+  const value = input as unknown as WorkerDispatchInput;
+  if ((value.issue === undefined) === (value.demand === undefined)) {
+    throw new Error("exactly one of issue or demand is required");
+  }
+  if (value.issue !== undefined && value.mode !== undefined) {
+    throw new Error("mode is only valid for demand dispatches");
+  }
+  return value;
+}
 
 export function createCastleMcpTools(
   deps: CastleMcpDependencies,
@@ -182,6 +248,113 @@ export function createCastleMcpTools(
         "Return ready-for-agent and ready-for-human queue candidates.",
       inputSchema: {},
       invoke: () => deps.queueStatus(),
+    },
+    {
+      name: "worker_dispatch",
+      title: "Dispatch AFK worker",
+      description:
+        "MUTATING: run one tracked issue or mint and run one disposable demand through the AFK worker lifecycle.",
+      inputSchema: dispatchShape,
+      invoke: (input) => deps.workerDispatch(dispatchInput(input)),
+    },
+    {
+      name: "worker_status",
+      title: "Read worker status",
+      description:
+        "Return normalized, liveness-qualified state for one worker or every local worker.",
+      inputSchema: { worker: z.string().min(1).optional() },
+      invoke: ({ worker }) =>
+        deps.workerStatus({ worker: worker as string | undefined }),
+    },
+    {
+      name: "worker_stop",
+      title: "Stop AFK worker",
+      description: "MUTATING: terminate one worker process tree.",
+      inputSchema: { worker: z.string().min(1) },
+      invoke: ({ worker }) =>
+        deps.workerStop({ worker: worker as string, recycle: false }),
+    },
+    {
+      name: "worker_recycle",
+      title: "Recycle AFK worker",
+      description:
+        "MUTATING: terminate one fleet worker so its supervisor can replace the slot.",
+      inputSchema: { worker: z.string().min(1) },
+      invoke: ({ worker }) =>
+        deps.workerStop({ worker: worker as string, recycle: true }),
+    },
+    {
+      name: "runner_list",
+      title: "List AFK runners",
+      description: "Return the canonical runner specification registry.",
+      inputSchema: {},
+      invoke: () => deps.runnerList(),
+    },
+    {
+      name: "runner_detect",
+      title: "Detect AFK runner",
+      description:
+        "Resolve the runner selected by an explicit override or the current host environment.",
+      inputSchema: { runner: z.string().min(1).optional() },
+      invoke: ({ runner }) =>
+        deps.runnerDetect({ runner: runner as string | undefined }),
+    },
+    {
+      name: "worker_request",
+      title: "Dispatch worker with request",
+      description:
+        "MUTATING: dispatch a new worker and inject a special request into its spawn-time handoff.",
+      inputSchema: {
+        ...dispatchShape,
+        text: z.string().min(1),
+      },
+      invoke: (input) =>
+        deps.workerRequest({
+          ...dispatchInput(input),
+          text: input.text as string,
+        }),
+    },
+    {
+      name: "requeue",
+      title: "Requeue AFK issue",
+      description:
+        "MUTATING: apply the complete parked-issue requeue transition and record human guidance.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        guidance: z.string().min(1),
+        repo: z.string().min(1).optional(),
+        dryRun: z.boolean().optional(),
+        adoptBranch: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.requeue(input as unknown as RequeueToolInput),
+    },
+    {
+      name: "retake",
+      title: "Recommend AFK retake",
+      description:
+        "Return the structured issue, PR, branch, worktree, worker-state, and recommended-next-action report.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        repo: z.string().min(1).optional(),
+        prLimit: z.number().int().positive().max(1_000).optional(),
+      },
+      invoke: (input) => deps.retake(input as unknown as RetakeToolInput),
+    },
+    {
+      name: "reap",
+      title: "Reap AFK branches",
+      description:
+        "MUTATING: classify and delete stale local and remote AFK branches.",
+      inputSchema: {},
+      invoke: () => deps.reap(),
+    },
+    {
+      name: "unblock_sweep",
+      title: "Sweep dependency blocks",
+      description:
+        "MUTATING: promote dependency-blocked issues whose requirements are all closed.",
+      inputSchema: {},
+      invoke: () => deps.unblockSweep(),
     },
   ];
 }


### PR DESCRIPTION
Automated AFK landing for #2306.

Closes #2306

## Changes

- **packages/red-castle**: Adds `mcp-server.ts` with worker_dispatch, worker_stop, worker_status, worker_request, runner_list, runner_detect, requeue, retake, reap, and unblock_sweep MCP tool definitions.
- **apps/dev/src/mcp-adapter.ts**: Wires the Castle MCP tool contracts to the dev runtime: detached subprocess dispatch (transport-safe, no stdout contamination), structured requeue execution, retake/reap/unblock-sweep hygiene cores, runner specs and detection.
- **apps/dev/src/commands/requeue.ts**: Refactors to expose `executeRequeue` as a value-returning function for MCP and CLI alike (eliminates the parse-stdout coupling).

## Key design decisions

- Worker dispatches are fully detached (`spawn(..., detached: true, stdio: 'ignore')`); the MCP adapter returns the PID without blocking on the child, keeping the stdio transport clean.
- Demand dispatch goes through `dispatchGo` (the approved `/go` value core) with caller-provided DoD and verification contracts injected through the operations interface.
- `stopWorker`, `executeRequeue`, and other hygiene tools call shared value-returning cores rather than wrapping CLI print-and-exit renderers.

Refs #2306

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787223808&installation_model_id=20659&pr_number=2324&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2324&signature=b89d76676ea899416cedf22a374bbd6d62fab666005ab40c9772202f0a3e79e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->