### PR TITLE
merge: #2307 Castle-MCP S4: gate + landing + claim + worktree tools (sensitive engine ops)

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -37,6 +37,7 @@ import {
   resolveRepoContext,
 } from "./runtime/wire.js";
 import { readAllWorkerStates } from "./core/worker-state-reader.js";
+import { createSensitiveMcpDependencies } from "./mcp-sensitive-adapter.js";
 
 function registryPath(root: string): string {
   return fleetRegistryPath(createEnginePaths(join(root, ".red")));
@@ -246,6 +247,7 @@ export function createDevAfkMcpDependencies(
   root = process.cwd(),
 ): CastleMcpDependencies {
   return {
+    ...createSensitiveMcpDependencies(root),
     fleetList: () => readFleetProfiles(registryPath(root)),
     fleetStatus: (input) => fleetStatus(root, input),
     fleetCreate: (input) => createFleet(root, input),

--- a/apps/dev/src/mcp-sensitive-adapter.ts
+++ b/apps/dev/src/mcp-sensitive-adapter.ts
@@ -1,0 +1,328 @@
+// mcp-sensitive-adapter.ts — the dev:afk MCP's sensitive engine-op deps.
+//
+// The Gate, Landing, Claim, and Worktree domains all reach primitives that RUN
+// the repo's own commands, merge into the trunk, or mutate coordination state,
+// so they live apart from the read-mostly Fleet/Observability wiring in
+// mcp-adapter.ts. Every dep here wraps a value-returning primitive — never the
+// print-and-exit command layer — and returns a plain structured object the MCP
+// server encodes as TOON.
+
+import { readdir } from "node:fs/promises";
+import { join, relative, resolve, sep } from "node:path";
+import type {
+  ClaimIssueInput,
+  ClaimReleaseInput,
+  GateRunInput,
+  LandBranchInput,
+  WorktreeRemoveInput,
+} from "../../../packages/red-castle/src/mcp-server.js";
+import {
+  classifyIssueClaims,
+  makeStaleClaimPredicate,
+} from "./core/claim-staleness.js";
+import { parseClaimRecords, renderClaimComment } from "./core/claim.js";
+import { getConfig, loadConfig, readValidationResourceBudget } from "./core/config.js";
+import { relevantScopes, runFeedback } from "./core/feedback.js";
+import { doLanding, landingMergeTitle } from "./core/landing.js";
+import { mainRedRepairFailuresFromBody } from "./core/main-red-repair.js";
+import * as ghx from "./runtime/gh.js";
+import * as gitx from "./runtime/git.js";
+import { makeFeedbackWorktree } from "./runtime/feedback-worktree.js";
+import { isLocked, readLockedBranch } from "./runtime/lock.js";
+import { afkPaths, resolveRepoContext } from "./runtime/wire.js";
+
+/** The disposable worktree lanes (ADR 0098) `worktree_list`/`worktree_remove` own. */
+const WORKTREE_LANES = [
+  "manual",
+  "feedback",
+  "landing",
+  "rebase",
+  "cascade",
+  "adopt",
+  "docs",
+  "reconcile",
+] as const;
+
+function worktreesRoot(root: string): string {
+  return join(root, ".red", "tmp", "worktrees");
+}
+
+function isUnder(parent: string, child: string): boolean {
+  const rel = relative(resolve(parent), resolve(child));
+  return rel !== "" && !rel.startsWith("..") && !rel.startsWith(`${sep}`) && !rel.startsWith("/");
+}
+
+/** Base resolution shared by the gate and the landing: lock > config trunk > main. */
+async function resolveTargetBase(root: string, requested?: string): Promise<string> {
+  if (requested) return requested;
+  const paths = afkPaths(root);
+  const locked = await readLockedBranch(paths.branchLockPath);
+  if (locked) return locked;
+  const config = loadConfig(paths.configPath, { warn: () => undefined });
+  return getConfig(config, "dev.trunk") || "main";
+}
+
+async function gateRun(root: string, input: GateRunInput) {
+  const paths = afkPaths(root);
+  const config = loadConfig(paths.configPath, { warn: () => undefined });
+  const gitCtx: gitx.GitContext = { cwd: root };
+  const base = await resolveTargetBase(root, input.base);
+  const feedback = makeFeedbackWorktree(root, paths.feedbackWorktreesDir, undefined, {
+    resourceBudget: readValidationResourceBudget(config),
+  });
+  try {
+    const changedFiles = await gitx.changedFiles(gitCtx, input.branch, base);
+    const scopes = relevantScopes(feedback.layout, changedFiles);
+    const result = await runFeedback(feedback.pnpm, {
+      worktree: input.branch,
+      scopes,
+      layout: feedback.layout,
+      now: () => Date.now(),
+      baselineWorktree: base,
+      resourceBudget: readValidationResourceBudget(config),
+    });
+    return {
+      branch: input.branch,
+      base,
+      scopes,
+      changed_files: changedFiles.length,
+      ok: result.ok,
+      checks: result.checks.map((check) => ({
+        name: check.name,
+        script: check.script,
+        scope: check.scope,
+        status: check.status,
+      })),
+      baseline_probe_ran: result.baselineProbeRan === true,
+      baseline_downgraded: result.baselineDowngraded,
+      baseline_failures: result.baselineFailures ?? [],
+    };
+  } finally {
+    await feedback.cleanup().catch(() => undefined);
+  }
+}
+
+async function gateBaselineStatus(root: string) {
+  const context = await resolveRepoContext(root);
+  const issue = await ghx.findMainRedRepairIssue({ cwd: root, repo: context.repo });
+  return {
+    main_red: issue !== null,
+    repair_issue: issue ? { number: issue.number, title: issue.title } : null,
+    failures: issue ? mainRedRepairFailuresFromBody(issue.body) : [],
+  };
+}
+
+async function landBranch(root: string, input: LandBranchInput) {
+  const paths = afkPaths(root);
+  const config = loadConfig(paths.configPath, { warn: () => undefined });
+  const context = await resolveRepoContext(root);
+  const gitCtx: gitx.GitContext = { cwd: root };
+  const base = await resolveTargetBase(root, input.base);
+  const trunk = getConfig(config, "dev.trunk") || "main";
+  const issueData = await ghx.viewIssueFull({ cwd: root, repo: context.repo }, input.issue);
+  if (!issueData) throw new Error(`issue #${input.issue} could not be read`);
+  const changedFiles = await gitx.changedFiles(gitCtx, input.branch, base);
+  const worktreeSlug = (value: string): string =>
+    value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "branch";
+
+  const result = await doLanding(
+    {
+      mergeExec: gitx.mergeExec(gitCtx),
+      remoteGit: gitx.gitExec(gitCtx),
+      fireHook: async () => true,
+      makeLandingWorktree: async (target) => {
+        const dest = join(paths.landingWorktreesDir, `${worktreeSlug(target)}-mcp-${input.issue}`);
+        await gitx.worktreeRemove(gitCtx, dest);
+        return (await gitx.worktreeAdd(gitCtx, dest, target)) ? dest : null;
+      },
+      removeLandingWorktree: (dir) => gitx.worktreeRemove(gitCtx, dir),
+      makeRebaseWorktree: async (branch) => {
+        const dest = join(paths.rebaseWorktreesDir, `${worktreeSlug(branch)}-mcp-${input.issue}`);
+        await gitx.worktreeRemove(gitCtx, dest);
+        return (await gitx.worktreeAdd(gitCtx, dest, branch)) ? dest : null;
+      },
+      removeRebaseWorktree: (dir) => gitx.worktreeRemove(gitCtx, dir),
+      getDiffPaths: async () => ({
+        changedFiles,
+        packageJsonDiff: "",
+      }),
+      findMainRedRepairIssue: () =>
+        ghx.findMainRedRepairIssue({ cwd: root, repo: context.repo }),
+    },
+    {
+      openPr: input.openPr !== false,
+      locked: await isLocked(paths.branchLockPath),
+      repo: context.repo,
+      repoDir: root,
+      remote: "origin",
+      branch: input.branch,
+      base,
+      trunk,
+      issue: input.issue,
+      title: issueData.title,
+      labels: issueData.labels,
+      changedFiles,
+      ...(input.sensitivePathApproved ? { sensitivePathApproved: true } : {}),
+    },
+    {
+      preMerge: () => `mcp land_branch #${input.issue} ${input.branch} -> ${base}`,
+      postMerge: (mergeSha) =>
+        `mcp land_branch #${input.issue} merged ${mergeSha ?? "(no sha)"} into ${base}`,
+    },
+  );
+
+  return {
+    issue: input.issue,
+    branch: input.branch,
+    base,
+    merge_title: landingMergeTitle({
+      issue: input.issue,
+      title: issueData.title,
+      labels: issueData.labels,
+      changedFiles,
+    }),
+    ...result,
+  };
+}
+
+const AFK_BRANCH_RE = /^afk\/([^/]+)\/(\d+)-/;
+
+async function cascadeStatus(root: string) {
+  const gitCtx: gitx.GitContext = { cwd: root };
+  const trunk = await resolveTargetBase(root);
+  const trunkTip = await gitx.resolveRef(gitCtx, `origin/${trunk}`);
+  const refs = await gitx.listRemoteBranches(gitCtx, "afk/");
+  const branches = [];
+  for (const ref of refs) {
+    const match = AFK_BRANCH_RE.exec(ref.branch);
+    const onTrunkTip = trunkTip
+      ? await gitx.isAncestor(gitCtx, trunkTip, `origin/${ref.branch}`)
+      : undefined;
+    branches.push({
+      branch: ref.branch,
+      worker: match?.[1] ?? "",
+      issue: match ? Number(match[2]) : 0,
+      last_commit_s: ref.commitS ?? 0,
+      // undefined => the object is not local, so "needs a rebase" is unknown.
+      needs_rebase: onTrunkTip === undefined ? "unknown" : String(!onTrunkTip),
+    });
+  }
+  return {
+    trunk,
+    trunk_tip: trunkTip ?? "",
+    branches,
+    worktrees: await listLaneWorktrees(root, ["cascade"]),
+  };
+}
+
+async function claimStatus(root: string, input: ClaimIssueInput) {
+  const context = await resolveRepoContext(root);
+  const comments = await ghx.listClaimComments(
+    { cwd: root, repo: context.repo },
+    input.issue,
+  );
+  const records = parseClaimRecords(comments);
+  const state = classifyIssueClaims(
+    records,
+    makeStaleClaimPredicate(Math.floor(Date.now() / 1_000)),
+  );
+  return {
+    issue: input.issue,
+    live_owner: state.liveOwner,
+    stale_owners: state.staleOwners,
+    conceded_owners: state.concededOwners,
+    records: records.map((record) => ({
+      comment_id: record.commentId,
+      worker: record.worker,
+      kind: record.kind,
+      runner: record.runner ?? "",
+      created_at: record.createdAt ?? "",
+    })),
+  };
+}
+
+async function claimRelease(root: string, input: ClaimReleaseInput) {
+  const context = await resolveRepoContext(root);
+  const ghCtx = { cwd: root, repo: context.repo };
+  const commentId = await ghx.postClaimComment(
+    ghCtx,
+    input.issue,
+    renderClaimComment(
+      { worker: input.worker, createdAt: new Date().toISOString() },
+      "concede",
+    ),
+  );
+  const state = classifyIssueClaims(
+    parseClaimRecords(await ghx.listClaimComments(ghCtx, input.issue)),
+    makeStaleClaimPredicate(Math.floor(Date.now() / 1_000)),
+  );
+  return {
+    issue: input.issue,
+    worker: input.worker,
+    status: "conceded",
+    comment_id: commentId,
+    live_owner: state.liveOwner,
+  };
+}
+
+/** Enumerate the on-disk dirs of the requested lanes, joined to their git state. */
+async function listLaneWorktrees(root: string, lanes: readonly string[]) {
+  const registered = new Map(
+    (await gitx.listWorktrees({ cwd: root })).map((entry) => [resolve(entry.path), entry]),
+  );
+  const out = [];
+  for (const lane of lanes) {
+    const laneDir = join(worktreesRoot(root), lane);
+    let entries: string[];
+    try {
+      entries = await readdir(laneDir);
+    } catch {
+      continue; // lane never used on this host
+    }
+    for (const name of entries.sort()) {
+      const path = join(laneDir, name);
+      const git = registered.get(resolve(path));
+      out.push({
+        lane,
+        name,
+        path: relative(root, path),
+        registered: git !== undefined,
+        branch: git?.branch ?? "",
+        head: git?.head ?? "",
+        detached: git?.detached === true,
+      });
+    }
+  }
+  return out;
+}
+
+async function worktreeList(root: string) {
+  return {
+    root: relative(root, worktreesRoot(root)),
+    lanes: WORKTREE_LANES,
+    worktrees: await listLaneWorktrees(root, WORKTREE_LANES),
+  };
+}
+
+async function worktreeRemove(root: string, input: WorktreeRemoveInput) {
+  const path = resolve(root, input.path);
+  if (!isUnder(worktreesRoot(root), path)) {
+    throw new Error("worktree_remove refuses a path outside .red/tmp/worktrees");
+  }
+  await gitx.worktreeRemove({ cwd: root }, path);
+  return { path: relative(root, path), status: "removed" };
+}
+
+/** Build the Gate / Landing / Claim / Worktree deps for the dev:afk MCP server. */
+export function createSensitiveMcpDependencies(root = process.cwd()) {
+  return {
+    gateRun: (input: GateRunInput) => gateRun(root, input),
+    gateBaselineStatus: () => gateBaselineStatus(root),
+    landBranch: (input: LandBranchInput) => landBranch(root, input),
+    cascadeStatus: () => cascadeStatus(root),
+    claimStatus: (input: ClaimIssueInput) => claimStatus(root, input),
+    claimRelease: (input: ClaimReleaseInput) => claimRelease(root, input),
+    worktreeList: () => worktreeList(root),
+    worktreeRemove: (input: WorktreeRemoveInput) => worktreeRemove(root, input),
+  };
+}

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -211,6 +211,27 @@ async function revParse(ctx: GitContext, ref: string): Promise<string | undefine
   return r.code === 0 && sha !== "" ? sha : undefined;
 }
 
+/** Resolve any ref to its sha, or undefined when git cannot. */
+export async function resolveRef(ctx: GitContext, ref: string): Promise<string | undefined> {
+  return revParse(ctx, ref);
+}
+
+/**
+ * True when `ancestor` is reachable from `descendant` (`git merge-base
+ * --is-ancestor`). `undefined` when either object is missing locally, so a
+ * caller can report "unknown" rather than a false "needs rebase".
+ */
+export async function isAncestor(
+  ctx: GitContext,
+  ancestor: string,
+  descendant: string,
+): Promise<boolean | undefined> {
+  if (!(await revParse(ctx, ancestor)) || !(await revParse(ctx, descendant))) return undefined;
+  const r = await runGit(ctx, ["merge-base", "--is-ancestor", ancestor, descendant]);
+  if (r.code === 0) return true;
+  return r.code === 1 ? false : undefined;
+}
+
 async function localAheadBehind(
   ctx: GitContext,
   localRef: string,
@@ -514,6 +535,42 @@ export async function checkedOutBranches(ctx: GitContext): Promise<Set<string>> 
   }
   const cur = await currentBranch(ctx);
   if (cur) out.add(cur);
+  return out;
+}
+
+/** One entry of `git worktree list --porcelain`. */
+export interface WorktreeEntry {
+  path: string;
+  head?: string;
+  branch?: string;
+  detached: boolean;
+}
+
+/**
+ * Enumerate every registered git worktree, parsed from `git worktree list
+ * --porcelain`. Returns an empty list on a non-zero exit so a caller enumerating
+ * disposable lanes degrades to "none registered" instead of throwing.
+ */
+export async function listWorktrees(ctx: GitContext): Promise<WorktreeEntry[]> {
+  const r = await runGit(ctx, ["worktree", "list", "--porcelain"]);
+  if (r.code !== 0) return [];
+  const out: WorktreeEntry[] = [];
+  let current: WorktreeEntry | undefined;
+  for (const raw of r.stdout.split("\n")) {
+    const line = raw.trim();
+    const w = /^worktree\s+(.+)$/.exec(line);
+    if (w && w[1]) {
+      current = { path: w[1], detached: false };
+      out.push(current);
+      continue;
+    }
+    if (!current) continue;
+    const h = /^HEAD\s+(.+)$/.exec(line);
+    if (h && h[1]) current.head = h[1];
+    const b = /^branch\s+refs\/heads\/(.+)$/.exec(line);
+    if (b && b[1]) current.branch = b[1];
+    if (line === "detached") current.detached = true;
+  }
   return out;
 }
 

--- a/apps/dev/tests/mcp-sensitive-adapter.test.ts
+++ b/apps/dev/tests/mcp-sensitive-adapter.test.ts
@@ -1,0 +1,116 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createSensitiveMcpDependencies } from "../src/mcp-sensitive-adapter.js";
+import { isAncestor, listWorktrees } from "../src/runtime/git.js";
+import type { GitContext } from "../src/runtime/git.js";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function root(): Promise<string> {
+  const value = await mkdtemp(join(tmpdir(), "dev-afk-mcp-sensitive-"));
+  roots.push(value);
+  return value;
+}
+
+function fakeExec(responder: (args: readonly string[]) => ExecOutput): ExecFn {
+  return async (_cmd, args) => responder(args);
+}
+
+describe("dev:afk MCP sensitive-op adapter", () => {
+  it("enumerates the disposable worktree lanes under .red/tmp/worktrees", async () => {
+    const cwd = await root();
+    await mkdir(join(cwd, ".red/tmp/worktrees/manual/slice-a"), { recursive: true });
+    await mkdir(join(cwd, ".red/tmp/worktrees/landing/main-2307"), { recursive: true });
+
+    const listed = (await createSensitiveMcpDependencies(cwd).worktreeList()) as {
+      root: string;
+      worktrees: Array<{ lane: string; name: string; registered: boolean }>;
+    };
+
+    expect(listed.root).toBe(join(".red", "tmp", "worktrees"));
+    expect(listed.worktrees).toEqual([
+      expect.objectContaining({ lane: "manual", name: "slice-a", registered: false }),
+      expect.objectContaining({ lane: "landing", name: "main-2307", registered: false }),
+    ]);
+  });
+
+  it("refuses to remove a worktree outside the disposable lanes", async () => {
+    const cwd = await root();
+    const deps = createSensitiveMcpDependencies(cwd);
+
+    await expect(deps.worktreeRemove({ path: "src" })).rejects.toThrow(
+      /outside \.red\/tmp\/worktrees/,
+    );
+    await expect(deps.worktreeRemove({ path: "../escape" })).rejects.toThrow(
+      /outside \.red\/tmp\/worktrees/,
+    );
+    await expect(
+      deps.worktreeRemove({ path: ".red/tmp/worktrees" }),
+    ).rejects.toThrow(/outside \.red\/tmp\/worktrees/);
+  });
+
+  it("removes a worktree that lives inside a lane", async () => {
+    const cwd = await root();
+    await mkdir(join(cwd, ".red/tmp/worktrees/feedback/branch-a"), { recursive: true });
+
+    await expect(
+      createSensitiveMcpDependencies(cwd).worktreeRemove({
+        path: ".red/tmp/worktrees/feedback/branch-a",
+      }),
+    ).resolves.toEqual({
+      path: join(".red", "tmp", "worktrees", "feedback", "branch-a"),
+      status: "removed",
+    });
+  });
+});
+
+describe("worktree + ancestry git primitives", () => {
+  const ctx = (exec: ExecFn): GitContext => ({ cwd: "/repo", exec });
+
+  it("parses git worktree list --porcelain into entries", async () => {
+    const stdout = [
+      "worktree /repo",
+      "HEAD aaaa",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.red/tmp/worktrees/landing/main-2307",
+      "HEAD bbbb",
+      "detached",
+      "",
+    ].join("\n");
+
+    await expect(
+      listWorktrees(ctx(fakeExec(() => ({ code: 0, stdout, stderr: "" })))),
+    ).resolves.toEqual([
+      { path: "/repo", head: "aaaa", branch: "main", detached: false },
+      {
+        path: "/repo/.red/tmp/worktrees/landing/main-2307",
+        head: "bbbb",
+        detached: true,
+      },
+    ]);
+  });
+
+  it("reports an unknown ancestry when an object is missing locally", async () => {
+    const missing = fakeExec((args) =>
+      args[0] === "rev-parse" ? { code: 1, stdout: "", stderr: "" } : { code: 0, stdout: "", stderr: "" },
+    );
+    await expect(isAncestor(ctx(missing), "aaaa", "bbbb")).resolves.toBeUndefined();
+
+    const present = fakeExec((args) =>
+      args[0] === "rev-parse"
+        ? { code: 0, stdout: "aaaa\n", stderr: "" }
+        : { code: 1, stdout: "", stderr: "" },
+    );
+    await expect(isAncestor(ctx(present), "aaaa", "bbbb")).resolves.toBe(false);
+  });
+});

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -34,6 +34,41 @@ function deps(): CastleMcpDependencies {
       ready_for_agent: [],
       ready_for_human: [],
     })),
+    gateRun: vi.fn(async (input) => ({
+      branch: input.branch,
+      base: input.base ?? "main",
+      ok: true,
+      checks: [{ name: "test:apps/dev", status: "passed" }],
+    })),
+    gateBaselineStatus: vi.fn(async () => ({
+      main_red: false,
+      repair_issue: null,
+      failures: [],
+    })),
+    landBranch: vi.fn(async (input) => ({
+      ok: true,
+      issue: input.issue,
+      branch: input.branch,
+      locked: false,
+    })),
+    cascadeStatus: vi.fn(async () => ({ trunk: "main", branches: [] })),
+    claimStatus: vi.fn(async (input) => ({
+      issue: input.issue,
+      live_owner: "host:wABCD",
+      stale_owners: [],
+      conceded_owners: [],
+      records: [{ comment_id: 1, worker: "host:wABCD", kind: "claim" }],
+    })),
+    claimRelease: vi.fn(async (input) => ({
+      issue: input.issue,
+      worker: input.worker,
+      status: "conceded",
+    })),
+    worktreeList: vi.fn(async () => ({ lanes: [], worktrees: [] })),
+    worktreeRemove: vi.fn(async (input) => ({
+      path: input.path,
+      status: "removed",
+    })),
   };
 }
 
@@ -51,7 +86,69 @@ describe("dev:afk MCP tools", () => {
       "monitor",
       "history",
       "queue_status",
+      "gate_run",
+      "gate_baseline_status",
+      "land_branch",
+      "cascade_status",
+      "claim_status",
+      "claim_release",
+      "worktree_list",
+      "worktree_remove",
     ]);
+  });
+
+  it("marks every landing/claim/worktree tool that mutates", () => {
+    const tools = createCastleMcpTools(deps());
+    const mutating = tools
+      .filter((tool) => tool.description.startsWith("MUTATING:"))
+      .map((tool) => tool.name);
+    expect(mutating).toEqual(
+      expect.arrayContaining([
+        "land_branch",
+        "claim_release",
+        "worktree_remove",
+      ]),
+    );
+    expect(mutating).not.toContain("gate_baseline_status");
+    expect(mutating).not.toContain("claim_status");
+    expect(mutating).not.toContain("worktree_list");
+    expect(mutating).not.toContain("cascade_status");
+  });
+
+  it("runs the gate for a branch and lands it through doLanding", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+    await expect(
+      tools
+        .find((tool) => tool.name === "gate_run")!
+        .invoke({ branch: "afk/wABCD/2307-slice", base: "main" }),
+    ).resolves.toMatchObject({ ok: true, base: "main" });
+    expect(d.gateRun).toHaveBeenCalledWith({
+      branch: "afk/wABCD/2307-slice",
+      base: "main",
+    });
+
+    await expect(
+      tools
+        .find((tool) => tool.name === "land_branch")!
+        .invoke({ issue: 2307, branch: "afk/wABCD/2307-slice" }),
+    ).resolves.toMatchObject({ ok: true, issue: 2307 });
+  });
+
+  it("reads claim records and enumerates the worktree lanes", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+    await expect(
+      tools.find((tool) => tool.name === "claim_status")!.invoke({ issue: 2307 }),
+    ).resolves.toMatchObject({
+      live_owner: "host:wABCD",
+      records: [{ worker: "host:wABCD", kind: "claim" }],
+    });
+
+    await expect(
+      tools.find((tool) => tool.name === "worktree_list")!.invoke({}),
+    ).resolves.toEqual({ lanes: [], worktrees: [] });
+    expect(d.worktreeList).toHaveBeenCalled();
   });
 
   it("returns structured fleet status without rendering command output", async () => {

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -35,6 +35,32 @@ export interface LogsInput {
   id: string;
 }
 
+export interface GateRunInput {
+  branch: string;
+  base?: string;
+}
+
+export interface LandBranchInput {
+  issue: number;
+  branch: string;
+  base?: string;
+  openPr?: boolean;
+  sensitivePathApproved?: boolean;
+}
+
+export interface ClaimIssueInput {
+  issue: number;
+}
+
+export interface ClaimReleaseInput {
+  issue: number;
+  worker: string;
+}
+
+export interface WorktreeRemoveInput {
+  path: string;
+}
+
 export interface CastleMcpDependencies {
   fleetList(): Promise<unknown>;
   fleetStatus(input: FleetNameInput): Promise<unknown>;
@@ -47,6 +73,14 @@ export interface CastleMcpDependencies {
   monitor(): Promise<unknown>;
   history(input: { limit?: number }): Promise<unknown>;
   queueStatus(): Promise<unknown>;
+  gateRun(input: GateRunInput): Promise<unknown>;
+  gateBaselineStatus(): Promise<unknown>;
+  landBranch(input: LandBranchInput): Promise<unknown>;
+  cascadeStatus(): Promise<unknown>;
+  claimStatus(input: ClaimIssueInput): Promise<unknown>;
+  claimRelease(input: ClaimReleaseInput): Promise<unknown>;
+  worktreeList(): Promise<unknown>;
+  worktreeRemove(input: WorktreeRemoveInput): Promise<unknown>;
 }
 
 export interface CastleMcpTool {
@@ -182,6 +216,94 @@ export function createCastleMcpTools(
         "Return ready-for-agent and ready-for-human queue candidates.",
       inputSchema: {},
       invoke: () => deps.queueStatus(),
+    },
+    {
+      name: "gate_run",
+      title: "Run the feedback gate",
+      description:
+        "Run the package-scoped feedback gate for one branch and return its verdict. " +
+        "Runs the repo's own test/typecheck/lint/build commands in an isolated " +
+        "feedback worktree — expensive, never a read-only probe.",
+      inputSchema: {
+        branch: z.string().min(1),
+        base: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.gateRun(input as unknown as GateRunInput),
+    },
+    {
+      name: "gate_baseline_status",
+      title: "Read baseline gate status",
+      description:
+        "Return whether the trunk baseline is tracked red, with the open main-red " +
+        "repair issue and its recorded baseline failures.",
+      inputSchema: {},
+      invoke: () => deps.gateBaselineStatus(),
+    },
+    {
+      name: "land_branch",
+      title: "Land a branch",
+      description:
+        "MUTATING: land one attempt branch into its base — push, serialize, merge " +
+        "(PR or direct), and promote. Merges code into the trunk; the sensitive-path " +
+        "guard still applies unless a reviewed branch is explicitly approved.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        branch: z.string().min(1),
+        base: z.string().min(1).optional(),
+        openPr: z.boolean().optional(),
+        sensitivePathApproved: z.boolean().optional(),
+      },
+      invoke: (input) => deps.landBranch(input as unknown as LandBranchInput),
+    },
+    {
+      name: "cascade_status",
+      title: "Read cascade rebase status",
+      description:
+        "Return every open AFK attempt branch with whether it still sits on a stale " +
+        "trunk tip, plus the live cascade worktrees.",
+      inputSchema: {},
+      invoke: () => deps.cascadeStatus(),
+    },
+    {
+      name: "claim_status",
+      title: "Read issue claims",
+      description:
+        "Return the parsed claim marker records for one issue with its live owner, " +
+        "stale owners, and conceded owners.",
+      inputSchema: { issue: z.number().int().positive() },
+      invoke: (input) => deps.claimStatus(input as unknown as ClaimIssueInput),
+    },
+    {
+      name: "claim_release",
+      title: "Release an issue claim",
+      description:
+        "MUTATING: post a concede marker on an issue so the named worker withdraws " +
+        "its claim and the issue returns to the executable pool.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        worker: z.string().min(1),
+      },
+      invoke: (input) =>
+        deps.claimRelease(input as unknown as ClaimReleaseInput),
+    },
+    {
+      name: "worktree_list",
+      title: "List Castle worktrees",
+      description:
+        "Enumerate the disposable worktree lanes under .red/tmp/worktrees with their " +
+        "registered git worktree state.",
+      inputSchema: {},
+      invoke: () => deps.worktreeList(),
+    },
+    {
+      name: "worktree_remove",
+      title: "Remove a Castle worktree",
+      description:
+        "MUTATING: remove one worktree under a .red/tmp/worktrees lane. Refuses any " +
+        "path outside those disposable lanes.",
+      inputSchema: { path: z.string().min(1) },
+      invoke: (input) =>
+        deps.worktreeRemove(input as unknown as WorktreeRemoveInput),
     },
   ];
 }


### PR DESCRIPTION
Automated AFK landing for #2307. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2307

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787224352&installation_model_id=20659&pr_number=2325&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2325&signature=f7146657f19f3de7f571e7433e0e682c0de731a0d0bbc45544a8de250c44026f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->