### PR TITLE
merge: #2308 Castle-MCP S5: runner live-steer (new surface)

### DIFF
--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -447,13 +447,14 @@ export function buildProcessDeps(
     postAttemptFormatCommands: readPostAttemptFormat(config),
     // Thread a live activity probe off this attempt's activity meter. The
     // progress guard uses it as a soft progress signal when armed.
-    runAgent: makeRunAgent(
-      sandbox,
-      process.env,
-      maxIterations,
-      laneIdle,
-      () => activityMeter.peek(),
-    ),
+    // Inject the worker's steer-file path so the live-steer MCP surface
+    // (runner_steer) can write a pending directive that the Orchestrator picks
+    // up between iterations without AFK knowing about the file at claim time.
+    runAgent: (() => {
+      const inner = makeRunAgent(sandbox, process.env, maxIterations, laneIdle, () => activityMeter.peek());
+      const steerFilePath = join(ctx.root, ".red", "tmp", "workers", workerId, "steer.toon");
+      return (input: Parameters<typeof inner>[0]) => inner({ ...input, steerFile: steerFilePath });
+    })(),
     sandboxMode: sandbox,
     sandboxAvailable: async (mode) => {
       const run = exec ?? execTool;

--- a/apps/dev/src/core/execution/runtime.ts
+++ b/apps/dev/src/core/execution/runtime.ts
@@ -406,6 +406,12 @@ export interface RunAgentInput {
    */
   goalProbe?: () => Promise<boolean | undefined>;
   /**
+   * Absolute path to the worker's live-steer file (`steer.toon`). When set,
+   * `buildRunOptions` creates a steer provider that reads (and consumes) the file
+   * between Orchestrator iterations, injecting its text as a `specialUserRequestBlock`.
+   */
+  steerFile?: string;
+  /**
    * Lane-idle stall reaper (issue #363) — the solo-path port of the fleet's
    * passive stall detector + hard stall reaper. COMPLEMENTARY to the #400
    * attempt PROGRESS guard above (which is commit-anchored and caps the whole
@@ -747,6 +753,23 @@ export function buildRunOptions(deps: SandcastleDeps, input: RunAgentInput): Run
     idleTimeoutSeconds: input.idleTimeoutSeconds ?? DEFAULT_IDLE_TIMEOUT_S,
     ...(hooks ? { hooks } : {}),
     ...(logging ? { logging } : {}),
+    ...(input.steerFile
+      ? {
+          steerProvider: async () => {
+            const { readFile, unlink } = await import("node:fs/promises");
+            const { decode } = await import("@reddb-io/toon");
+            try {
+              const content = await readFile(input.steerFile!, "utf8");
+              const doc = decode(content) as Record<string, unknown>;
+              const text = typeof doc.text === "string" ? doc.text : undefined;
+              if (text) await unlink(input.steerFile!).catch(() => {});
+              return text;
+            } catch {
+              return undefined;
+            }
+          },
+        }
+      : {}),
   };
 }
 

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -5,6 +5,7 @@ import { Writable } from "node:stream";
 import { decode as decodeToon } from "@reddb-io/toon";
 import {
   castleLanePath,
+  createCastleLaneWriters,
   createEnginePaths,
   fleetRegistryPath,
   readCastleHistoryRecords,
@@ -27,6 +28,7 @@ import type {
   RetakeToolInput,
   WorkerDispatchInput,
   WorkerRequestInput,
+  WorkerSteerInput,
   WorkerStopInput,
 } from "../../../packages/red-castle/src/mcp-server.js";
 import { readBuildInfo } from "@reddb-io/build-info";
@@ -593,6 +595,22 @@ export function createDevAfkMcpDependencies(
         ]),
       ),
     runnerDetect: async ({ runner }) => detectRunner({ flag: runner }),
+    runnerSteer: async (input: WorkerSteerInput) => {
+      const paths = createEnginePaths(join(root, ".red"));
+      const steerPath = paths.workerSteerFile(input.worker);
+      const { writeFile: writeFileAsync, mkdir: mkdirAsync } = await import("node:fs/promises");
+      const { dirname } = await import("node:path");
+      await mkdirAsync(dirname(steerPath), { recursive: true });
+      const { encode } = await import("@reddb-io/toon");
+      await writeFileAsync(steerPath, encode({ text: input.text }), "utf8");
+      const writers = createCastleLaneWriters(paths);
+      await writers.worker(input.worker).append({
+        kind: "worker.steered",
+        worker_id: input.worker,
+        payload: { reason: input.text.slice(0, 200) },
+      });
+      return { worker: input.worker, steer: "written" };
+    },
     workerRequest: (input: WorkerRequestInput) => {
       const dispatch = { ...input, request: input.text };
       delete (dispatch as Partial<WorkerRequestInput>).text;

--- a/packages/red-castle/src/Orchestrator.ts
+++ b/packages/red-castle/src/Orchestrator.ts
@@ -15,6 +15,7 @@ import type { AgentProvider, IterationUsage } from "./AgentProvider.js";
 import type { Timeouts } from "./run.js";
 import { TextDeltaBuffer } from "./TextDeltaBuffer.js";
 import { attachAbortMetadata } from "./AbortMetadata.js";
+import { specialUserRequestBlock } from "./engine/runner-spawn.js";
 
 export type { ParsedStreamEvent, IterationUsage } from "./AgentProvider.js";
 
@@ -325,6 +326,12 @@ export interface OrchestrateOptions {
   readonly timeouts?: Timeouts;
   /** Forwarded to `withSandboxLifecycle` — see `SandboxLifecycleOptions.keepSourceBranch`. */
   readonly keepSourceBranch?: boolean;
+  /**
+   * Live-steer provider. Called BEFORE each iteration after the first; resolves
+   * the steer text to inject as a `specialUserRequestBlock` into that iteration's
+   * prompt, or `undefined` when no steer is pending.
+   */
+  readonly steerProvider?: () => Promise<string | undefined>;
 }
 
 /** Per-iteration result carrying an optional session ID. */
@@ -398,6 +405,12 @@ export const orchestrate = (
       yield* checkAbort();
       yield* display.status(label(`Iteration ${i}/${iterations}`), "info");
 
+      // Check for live steer between iterations (only from i=2 onward).
+      const iterSteerText: string | undefined =
+        i > 1 && options.steerProvider
+          ? yield* Effect.promise(() => options.steerProvider!())
+          : undefined;
+
       const sandboxResult = yield* factory.withSandbox(
         (
           { hostWorktreePath, sandboxRepoPath, applyToHost, bindMountHandle },
@@ -452,10 +465,18 @@ export const orchestrate = (
 
                 // Preprocess prompt (run !`command` expressions inside sandbox).
                 // Inline prompts pass through literally — skip expansion.
+                // Between iterations, inject any pending live-steer text as a
+                // specialUserRequestBlock appended to the base prompt.
+                const steerBlock = iterSteerText
+                  ? specialUserRequestBlock(iterSteerText)
+                  : null;
+                const iterPrompt = steerBlock
+                  ? `${prompt}\n\n${steerBlock}`
+                  : prompt;
                 const fullPrompt = options.skipPromptExpansion
-                  ? prompt
+                  ? iterPrompt
                   : yield* preprocessPrompt(
-                      prompt,
+                      iterPrompt,
                       ctx.sandbox,
                       ctx.sandboxRepoDir,
                     );

--- a/packages/red-castle/src/engine/paths.ts
+++ b/packages/red-castle/src/engine/paths.ts
@@ -28,6 +28,8 @@ export interface EnginePaths {
   readonly fleet: (name: string) => string;
   readonly workersRoot: string;
   readonly worker: (workerId: string) => string;
+  /** Live-steer file for a running worker (`workers/<id>/steer.toon`). */
+  readonly workerSteerFile: (workerId: string) => string;
   readonly monitorsRoot: string;
   readonly monitor: (id: string) => string;
   readonly worktreesRoot: string;
@@ -63,6 +65,7 @@ export function createEnginePaths(redRoot: string): EnginePaths {
     fleet: (name) => resolve(supervisorsRoot, name),
     workersRoot,
     worker: (workerId) => resolve(workersRoot, workerId),
+    workerSteerFile: (workerId) => resolve(workersRoot, workerId, "steer.toon"),
     monitorsRoot,
     monitor: (id) => resolve(monitorsRoot, id),
     worktreesRoot,

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -48,6 +48,10 @@ function deps(): CastleMcpDependencies {
       runner: input.runner ?? "codex",
       method: input.runner ? "flag" : "env-var",
     })),
+    runnerSteer: vi.fn(async (input) => ({
+      worker: input.worker,
+      steer: "written",
+    })),
     workerRequest: vi.fn(async (input) => ({
       status: "completed",
       request: input.text,
@@ -79,6 +83,7 @@ describe("dev:afk MCP tools", () => {
       "worker_recycle",
       "runner_list",
       "runner_detect",
+      "runner_steer",
       "worker_request",
       "requeue",
       "retake",
@@ -175,6 +180,24 @@ describe("dev:afk MCP tools", () => {
       runner: "codex",
       text: "Use TDD.",
     });
+  });
+
+  it("writes a live-steer request into a running worker via runner_steer", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await expect(
+      tools
+        .find((tool) => tool.name === "runner_steer")!
+        .invoke({ worker: "wVM2Z", text: "Focus on the failing test first." }),
+    ).resolves.toMatchObject({ worker: "wVM2Z", steer: "written" });
+    expect(d.runnerSteer).toHaveBeenCalledWith({
+      worker: "wVM2Z",
+      text: "Focus on the failing test first.",
+    });
+    expect(
+      tools.find((tool) => tool.name === "runner_steer")!.description,
+    ).toMatch(/^MUTATING:/);
   });
 
   it("wraps structured requeue, retake, reap, and unblock-sweep cores", async () => {

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -55,6 +55,11 @@ export interface RunnerDetectInput {
   runner?: string;
 }
 
+export interface WorkerSteerInput {
+  worker: string;
+  text: string;
+}
+
 export interface WorkerRequestInput extends WorkerDispatchInput {
   text: string;
 }
@@ -90,6 +95,7 @@ export interface CastleMcpDependencies {
   workerStop(input: WorkerStopInput): Promise<unknown>;
   runnerList(): Promise<unknown>;
   runnerDetect(input: RunnerDetectInput): Promise<unknown>;
+  runnerSteer(input: WorkerSteerInput): Promise<unknown>;
   workerRequest(input: WorkerRequestInput): Promise<unknown>;
   requeue(input: RequeueToolInput): Promise<unknown>;
   retake(input: RetakeToolInput): Promise<unknown>;
@@ -298,6 +304,17 @@ export function createCastleMcpTools(
       inputSchema: { runner: z.string().min(1).optional() },
       invoke: ({ runner }) =>
         deps.runnerDetect({ runner: runner as string | undefined }),
+    },
+    {
+      name: "runner_steer",
+      title: "Steer live AFK worker",
+      description:
+        "MUTATING: write a live-steer request into a running worker's next iteration.",
+      inputSchema: {
+        worker: z.string().min(1),
+        text: z.string().min(1),
+      },
+      invoke: (input) => deps.runnerSteer(input as unknown as WorkerSteerInput),
     },
     {
       name: "worker_request",

--- a/packages/red-castle/src/run.ts
+++ b/packages/red-castle/src/run.ts
@@ -470,6 +470,12 @@ export interface RunOptions<A extends AgentProvider = AgentProvider> {
    */
   readonly allowIterResume?: boolean;
   /**
+   * Live-steer provider. Called before each iteration after the first; resolves
+   * the steer text to inject as a `specialUserRequestBlock`, or `undefined` when
+   * no steer is pending.
+   */
+  readonly steerProvider?: () => Promise<string | undefined>;
+  /**
    * An `AbortSignal` that cancels the run when aborted.
    *
    * - If `signal.aborted` is already `true` at entry, `run()` rejects
@@ -832,6 +838,7 @@ export async function run(
       signal: options.signal,
       skipPromptExpansion: isInlinePrompt,
       timeouts: options.timeouts,
+      ...(options.steerProvider ? { steerProvider: options.steerProvider } : {}),
     });
 
     const completion = buildCompletionMessage(


### PR DESCRIPTION
Automated AFK landing for #2308. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2308

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787226380&installation_model_id=20659&pr_number=2326&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2326&signature=d5d8b7086f6bb1cd9664c88608cf4c94cb300f834a44574f7158c07ed0456fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->