### PR TITLE
merge: #2307 Castle-MCP S4: gate + landing + claim + worktree tools (sensitive engine ops)

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { worktreesDir } from "@reddb-io/shared/red-paths.js";
 import { Writable } from "node:stream";
 import { decode as decodeToon } from "@reddb-io/toon";
 import {
@@ -19,10 +20,15 @@ import {
   type FleetProfile,
 } from "@reddb-io/red-castle/engine";
 import type {
+  CascadeStatusInput,
   CastleMcpDependencies,
+  ClaimIssueInput,
   FleetCreateInput,
   FleetEditInput,
   FleetNameInput,
+  GateBaselineStatusInput,
+  GateRunInput,
+  LandBranchInput,
   LogsInput,
   RequeueToolInput,
   RetakeToolInput,
@@ -30,6 +36,7 @@ import type {
   WorkerRequestInput,
   WorkerSteerInput,
   WorkerStopInput,
+  WorktreeRemoveInput,
 } from "../../../packages/red-castle/src/mcp-server.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { collectDashboardReport } from "./commands/dashboard.js";
@@ -57,7 +64,26 @@ import {
   dispatchGo,
   type DisposableIssueSpec,
 } from "./core/go.js";
-import { loadConfig, readBackpressure } from "./core/config.js";
+import {
+  getConfig,
+  loadConfig,
+  readBackpressure,
+  readValidationResourceBudget,
+} from "./core/config.js";
+import * as gitx from "./runtime/git.js";
+import { makeFeedbackWorktree } from "./runtime/feedback-worktree.js";
+import { relevantScopes, runFeedback } from "./core/feedback.js";
+import { doLanding } from "./core/landing.js";
+import {
+  parseClaimRecords,
+  renderClaimComment,
+  type ClaimRecord,
+} from "./core/claim.js";
+import { parseReqLabels, planCloseCascade, type DependentIssue } from "./core/boot-sweep.js";
+import {
+  MAIN_RED_REPAIR_MARKER,
+  mainRedRepairFailuresFromBody,
+} from "./core/main-red-repair.js";
 import {
   branchesToReap,
   planLiveBranchCleanup,
@@ -84,6 +110,12 @@ export interface DevAfkMcpOperations {
   retake(input: RetakeToolInput): Promise<unknown>;
   reap(): Promise<unknown>;
   unblockSweep(): Promise<unknown>;
+  gateRun(input: GateRunInput): Promise<unknown>;
+  gateBaselineStatus(input: GateBaselineStatusInput): Promise<unknown>;
+  landBranch(input: LandBranchInput): Promise<unknown>;
+  cascadeStatus(input: CascadeStatusInput): Promise<unknown>;
+  claimStatus(input: ClaimIssueInput): Promise<unknown>;
+  claimRelease(input: ClaimIssueInput): Promise<unknown>;
 }
 
 export interface DevAfkMcpRuntime {
@@ -183,6 +215,27 @@ const defaultMcpRuntime: DevAfkMcpRuntime = {
   },
   executeRequeue: (root, input) => executeRequeue(input, { cwd: root }),
 };
+
+/** Resolve the base branch a gate/landing runs against: explicit input first,
+ * then the configured trunk, then `main`. */
+function resolveConfiguredBase(root: string, base?: string): string {
+  if (base) return base;
+  const config = loadConfig(afkPaths(root).configPath, { warn: () => undefined });
+  return getConfig(config, "dev.trunk") || "main";
+}
+
+/** Fold claim markers to the LATEST record per worker — the same
+ * highest-comment-id-wins order the reconciler uses. */
+function latestClaimPerWorker(
+  records: readonly ClaimRecord[],
+): Map<string, ClaimRecord> {
+  const latest = new Map<string, ClaimRecord>();
+  for (const record of records) {
+    const seen = latest.get(record.worker);
+    if (!seen || record.commentId > seen.commentId) latest.set(record.worker, record);
+  }
+  return latest;
+}
 
 export function createDefaultDevAfkMcpOperations(
   root: string,
@@ -301,6 +354,178 @@ export function createDefaultDevAfkMcpOperations(
         },
       );
       return { promoted };
+    },
+    async gateRun(input) {
+      const paths = afkPaths(root);
+      const config = loadConfig(paths.configPath, { warn: () => undefined });
+      const base = resolveConfiguredBase(root, input.base);
+      const feedback = makeFeedbackWorktree(
+        root,
+        paths.feedbackWorktreesDir,
+        undefined,
+        { resourceBudget: readValidationResourceBudget(config) },
+      );
+      try {
+        const changedFiles = await gitx.changedFiles({ cwd: root }, input.branch, base);
+        const result = await runFeedback(feedback.pnpm, {
+          worktree: input.branch,
+          scopes: relevantScopes(feedback.layout, changedFiles),
+          layout: feedback.layout,
+          now: () => Date.now(),
+          baselineWorktree: base,
+        });
+        return {
+          branch: input.branch,
+          base,
+          ok: result.ok,
+          changed_files: changedFiles,
+          checks: result.checks.map((check) => ({
+            name: check.name,
+            script: check.script,
+            scope: check.scope,
+            status: check.status,
+          })),
+          baseline_probe_ran: result.baselineProbeRan === true,
+          baseline_downgraded: result.baselineDowngraded,
+          baseline_failures: result.baselineFailures ?? [],
+        };
+      } finally {
+        await feedback.cleanup();
+      }
+    },
+    async gateBaselineStatus(input) {
+      const context = await resolveRepoContext(root);
+      const gh = { cwd: context.root, repo: context.repo };
+      const tracked = (await ghx.listMainRedRepairIssues(gh)).filter((issue) =>
+        issue.body?.includes(MAIN_RED_REPAIR_MARKER),
+      );
+      return {
+        base: resolveConfiguredBase(root, input.base),
+        main_red: tracked.length > 0,
+        repair_issues: tracked.map((issue) => ({
+          number: issue.number,
+          title: issue.title ?? "",
+          failures: mainRedRepairFailuresFromBody(issue.body),
+        })),
+      };
+    },
+    async landBranch(input) {
+      const context = await resolveRepoContext(root);
+      const paths = afkPaths(root);
+      const gitCtx: gitx.GitContext = { cwd: root };
+      const base = resolveConfiguredBase(root, input.base);
+      const changedFiles = await gitx.changedFiles(gitCtx, input.branch, base);
+      const slug = (value: string) =>
+        value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "base";
+      const result = await doLanding(
+        {
+          mergeExec: gitx.mergeExec(gitCtx),
+          remoteGit: gitx.gitExec(gitCtx),
+          fireHook: async () => true,
+          makeLandingWorktree: async (target) => {
+            const dest = join(paths.landingWorktreesDir, `${slug(target)}-mcp-${input.issue}`);
+            await gitx.worktreeRemove(gitCtx, dest);
+            return (await gitx.worktreeAdd(gitCtx, dest, target)) ? dest : null;
+          },
+          removeLandingWorktree: (dir) => gitx.worktreeRemove(gitCtx, dir),
+          makeRebaseWorktree: async (branch) => {
+            const dest = join(paths.rebaseWorktreesDir, `${slug(branch)}-mcp-${input.issue}`);
+            await gitx.worktreeRemove(gitCtx, dest);
+            return (await gitx.worktreeAdd(gitCtx, dest, branch)) ? dest : null;
+          },
+          removeRebaseWorktree: (dir) => gitx.worktreeRemove(gitCtx, dir),
+        },
+        {
+          openPr: input.openPr !== false,
+          locked: false,
+          repo: context.repo,
+          repoDir: root,
+          remote: context.remote,
+          branch: input.branch,
+          base,
+          trunk: base,
+          issue: input.issue,
+          title: input.title ?? `Issue #${input.issue}`,
+          changedFiles,
+        },
+        {
+          preMerge: () => `pre_merge #${input.issue} (${input.branch} → ${base})`,
+          postMerge: (mergeSha) =>
+            `post_merge #${input.issue} (${input.branch} → ${base}${mergeSha ? ` @ ${mergeSha}` : ""})`,
+        },
+      );
+      return { issue: input.issue, branch: input.branch, base, ...result };
+    },
+    async cascadeStatus(input) {
+      const context = await resolveRepoContext(root);
+      const gh = { cwd: context.root, repo: context.repo };
+      const states = await ghx.listIssueStates(gh);
+      const dependents: DependentIssue[] = [];
+      for (const [number, row] of states) {
+        if (row.state.toUpperCase() !== "OPEN") continue;
+        const reqs = parseReqLabels(row.labels);
+        if (!reqs.includes(input.issue)) continue;
+        dependents.push({
+          number,
+          reqs: reqs.map((n) => ({
+            n,
+            closed: (states.get(n)?.state ?? "").toUpperCase() === "CLOSED",
+          })),
+        });
+      }
+      return {
+        issue: input.issue,
+        dependents: dependents.map((dependent) => ({
+          number: dependent.number,
+          reqs: dependent.reqs,
+        })),
+        promotable: planCloseCascade(input.issue, dependents).map((plan) => ({
+          number: plan.number,
+          refs: plan.refs,
+          req_labels: plan.reqLabels,
+        })),
+      };
+    },
+    async claimStatus(input) {
+      const context = await resolveRepoContext(root);
+      const gh = { cwd: context.root, repo: context.repo };
+      const records = parseClaimRecords(await ghx.listClaimComments(gh, input.issue));
+      const latest = latestClaimPerWorker(records);
+      const holders = [...latest.values()].filter((record) => record.kind === "claim");
+      return {
+        issue: input.issue,
+        records: records.map((record) => ({
+          comment_id: record.commentId,
+          worker: record.worker,
+          kind: record.kind,
+          runner: record.runner ?? "",
+          created_at: record.createdAt ?? "",
+        })),
+        holders: holders.map((record) => ({
+          worker: record.worker,
+          comment_id: record.commentId,
+          runner: record.runner ?? "",
+          created_at: record.createdAt ?? "",
+        })),
+      };
+    },
+    async claimRelease(input) {
+      const context = await resolveRepoContext(root);
+      const gh = { cwd: context.root, repo: context.repo };
+      const records = parseClaimRecords(await ghx.listClaimComments(gh, input.issue));
+      const holders = [...latestClaimPerWorker(records).values()].filter(
+        (record) => record.kind === "claim",
+      );
+      const conceded: string[] = [];
+      for (const holder of holders) {
+        await ghx.postClaimComment(
+          gh,
+          input.issue,
+          renderClaimComment({ worker: holder.worker, runner: holder.runner }, "concede"),
+        );
+        conceded.push(holder.worker);
+      }
+      return { issue: input.issue, conceded };
     },
   };
 }
@@ -509,6 +734,41 @@ async function workerVitals(root: string) {
   }));
 }
 
+/** Every checkout under the disposable `.red/tmp/worktrees/<lane>/` lanes, in
+ * lane-then-name order. A missing lane root is an empty list, not an error. */
+async function listDisposableWorktrees(root: string) {
+  const { readdir } = await import("node:fs/promises");
+  const worktreesRoot = worktreesDir(root);
+  const lanes = await readdir(worktreesRoot, { withFileTypes: true }).catch(() => []);
+  const out: { lane: string; name: string; path: string }[] = [];
+  for (const lane of lanes.filter((entry) => entry.isDirectory()).sort((a, b) => a.name.localeCompare(b.name))) {
+    const entries = await readdir(join(worktreesRoot, lane.name), {
+      withFileTypes: true,
+    }).catch(() => []);
+    for (const entry of entries.filter((e) => e.isDirectory()).sort((a, b) => a.name.localeCompare(b.name))) {
+      out.push({
+        lane: lane.name,
+        name: entry.name,
+        path: relative(root, join(worktreesRoot, lane.name, entry.name)),
+      });
+    }
+  }
+  return out;
+}
+
+/** Remove ONE checkout under the disposable worktree lanes. A path that escapes
+ * `.red/tmp/worktrees/` is refused — the tool never removes a real checkout. */
+async function removeDisposableWorktree(root: string, input: WorktreeRemoveInput) {
+  const worktreesRoot = resolve(worktreesDir(root));
+  const target = resolve(root, input.path);
+  const rel = relative(worktreesRoot, target);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error("worktree path escapes the disposable worktree lanes");
+  }
+  await gitx.worktreeRemove({ cwd: root }, target);
+  return { path: relative(root, target), removed: !existsSync(target) };
+}
+
 export function createDevAfkMcpDependencies(
   root = process.cwd(),
   operations: DevAfkMcpOperations = createDefaultDevAfkMcpOperations(root),
@@ -632,5 +892,13 @@ export function createDevAfkMcpDependencies(
     retake: (input) => operations.retake(input),
     reap: () => operations.reap(),
     unblockSweep: () => operations.unblockSweep(),
+    gateRun: (input) => operations.gateRun(input),
+    gateBaselineStatus: (input) => operations.gateBaselineStatus(input),
+    landBranch: (input) => operations.landBranch(input),
+    cascadeStatus: (input) => operations.cascadeStatus(input),
+    claimStatus: (input) => operations.claimStatus(input),
+    claimRelease: (input) => operations.claimRelease(input),
+    worktreeList: () => listDisposableWorktrees(root),
+    worktreeRemove: (input) => removeDisposableWorktree(root, input),
   };
 }

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -235,6 +235,65 @@ describe("dev:afk MCP host adapter", () => {
     });
     await expect(deps.unblockSweep()).resolves.toEqual({ promoted: [2307] });
   });
+
+  it("routes the sensitive gate, landing, and claim tools through their operations", async () => {
+    const cwd = await root();
+    const operations = fakeOperations();
+    const deps = createDevAfkMcpDependencies(cwd, operations);
+
+    await expect(
+      deps.gateRun({ branch: "afk/w80UR/2307-castle-mcp-s4" }),
+    ).resolves.toMatchObject({ ok: true });
+    await expect(
+      deps.landBranch({ issue: 2307, branch: "afk/w80UR/2307-castle-mcp-s4" }),
+    ).resolves.toMatchObject({ issue: 2307, ok: true });
+    await expect(deps.gateBaselineStatus({})).resolves.toEqual({
+      main_red: false,
+    });
+    await expect(deps.cascadeStatus({ issue: 2307 })).resolves.toMatchObject({
+      issue: 2307,
+    });
+    await expect(deps.claimStatus({ issue: 2307 })).resolves.toMatchObject({
+      issue: 2307,
+    });
+    await expect(deps.claimRelease({ issue: 2307 })).resolves.toMatchObject({
+      issue: 2307,
+    });
+    expect(operations.gateRun).toHaveBeenCalledWith({
+      branch: "afk/w80UR/2307-castle-mcp-s4",
+    });
+    expect(operations.landBranch).toHaveBeenCalledWith({
+      issue: 2307,
+      branch: "afk/w80UR/2307-castle-mcp-s4",
+    });
+  });
+
+  it("enumerates the disposable worktree lanes and refuses escapes on removal", async () => {
+    const cwd = await root();
+    await mkdir(join(cwd, ".red", "tmp", "worktrees", "landing", "main-2307"), {
+      recursive: true,
+    });
+    await mkdir(join(cwd, ".red", "tmp", "worktrees", "feedback", "afk-2307"), {
+      recursive: true,
+    });
+    const deps = createDevAfkMcpDependencies(cwd, fakeOperations());
+
+    await expect(deps.worktreeList()).resolves.toEqual([
+      {
+        lane: "feedback",
+        name: "afk-2307",
+        path: join(".red", "tmp", "worktrees", "feedback", "afk-2307"),
+      },
+      {
+        lane: "landing",
+        name: "main-2307",
+        path: join(".red", "tmp", "worktrees", "landing", "main-2307"),
+      },
+    ]);
+    await expect(
+      deps.worktreeRemove({ path: join("..", "elsewhere") }),
+    ).rejects.toThrow(/escapes/);
+  });
 });
 
 function fakeOperations(): DevAfkMcpOperations {
@@ -254,5 +313,14 @@ function fakeOperations(): DevAfkMcpOperations {
       local_reaped: [],
     })),
     unblockSweep: vi.fn(async () => ({ promoted: [2307] })),
+    gateRun: vi.fn(async (input) => ({ branch: input.branch, ok: true })),
+    gateBaselineStatus: vi.fn(async () => ({ main_red: false })),
+    landBranch: vi.fn(async (input) => ({ issue: input.issue, ok: true })),
+    cascadeStatus: vi.fn(async (input) => ({
+      issue: input.issue,
+      promotable: [],
+    })),
+    claimStatus: vi.fn(async (input) => ({ issue: input.issue, holders: [] })),
+    claimRelease: vi.fn(async (input) => ({ issue: input.issue, conceded: [] })),
   };
 }

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -60,6 +60,31 @@ function deps(): CastleMcpDependencies {
     retake: vi.fn(async (input) => ({ issue: { number: input.issue } })),
     reap: vi.fn(async () => ({ remote: [], local: [] })),
     unblockSweep: vi.fn(async () => ({ promoted: [] })),
+    gateRun: vi.fn(async (input) => ({ branch: input.branch, ok: true, checks: [] })),
+    gateBaselineStatus: vi.fn(async () => ({ main_red: false, repair_issues: [] })),
+    landBranch: vi.fn(async (input) => ({
+      issue: input.issue,
+      branch: input.branch,
+      ok: true,
+    })),
+    cascadeStatus: vi.fn(async (input) => ({
+      issue: input.issue,
+      dependents: [],
+      promotable: [],
+    })),
+    claimStatus: vi.fn(async (input) => ({
+      issue: input.issue,
+      records: [],
+      holder: null,
+    })),
+    claimRelease: vi.fn(async (input) => ({
+      issue: input.issue,
+      conceded: ["w80UR"],
+    })),
+    worktreeList: vi.fn(async () => [
+      { lane: "landing", name: "main-adopt-2307", path: ".red/tmp/worktrees/landing/main-adopt-2307" },
+    ]),
+    worktreeRemove: vi.fn(async (input) => ({ path: input.path, removed: true })),
   };
 }
 
@@ -89,6 +114,14 @@ describe("dev:afk MCP tools", () => {
       "retake",
       "reap",
       "unblock_sweep",
+      "gate_run",
+      "gate_baseline_status",
+      "land_branch",
+      "cascade_status",
+      "claim_status",
+      "claim_release",
+      "worktree_list",
+      "worktree_remove",
     ]);
   });
 
@@ -220,5 +253,80 @@ describe("dev:afk MCP tools", () => {
     expect(d.reap).toHaveBeenCalledOnce();
     await tools.find((tool) => tool.name === "unblock_sweep")!.invoke({});
     expect(d.unblockSweep).toHaveBeenCalledOnce();
+  });
+
+  it("runs the gate and reports the baseline through the Gate domain", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await expect(
+      tools
+        .find((tool) => tool.name === "gate_run")!
+        .invoke({ branch: "afk/w80UR/2307-castle-mcp-s4" }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(d.gateRun).toHaveBeenCalledWith({
+      branch: "afk/w80UR/2307-castle-mcp-s4",
+    });
+
+    await expect(
+      tools.find((tool) => tool.name === "gate_baseline_status")!.invoke({}),
+    ).resolves.toEqual({ main_red: false, repair_issues: [] });
+  });
+
+  it("lands a validated branch and reports the close cascade", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await tools
+      .find((tool) => tool.name === "land_branch")!
+      .invoke({ issue: 2307, branch: "afk/w80UR/2307-castle-mcp-s4" });
+    expect(d.landBranch).toHaveBeenCalledWith({
+      issue: 2307,
+      branch: "afk/w80UR/2307-castle-mcp-s4",
+    });
+
+    await tools
+      .find((tool) => tool.name === "cascade_status")!
+      .invoke({ issue: 2307 });
+    expect(d.cascadeStatus).toHaveBeenCalledWith({ issue: 2307 });
+    expect(
+      tools.find((tool) => tool.name === "land_branch")!.description,
+    ).toMatch(/^MUTATING:/);
+  });
+
+  it("reads and releases claim records through the Claim domain", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await expect(
+      tools.find((tool) => tool.name === "claim_status")!.invoke({ issue: 2307 }),
+    ).resolves.toMatchObject({ issue: 2307, holder: null });
+    await tools
+      .find((tool) => tool.name === "claim_release")!
+      .invoke({ issue: 2307 });
+    expect(d.claimRelease).toHaveBeenCalledWith({ issue: 2307 });
+    expect(
+      tools.find((tool) => tool.name === "claim_release")!.description,
+    ).toMatch(/^MUTATING:/);
+  });
+
+  it("enumerates and removes disposable worktrees", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await expect(
+      tools.find((tool) => tool.name === "worktree_list")!.invoke({}),
+    ).resolves.toMatchObject([{ lane: "landing" }]);
+    await tools
+      .find((tool) => tool.name === "worktree_remove")!
+      .invoke({ path: ".red/tmp/worktrees/landing/main-adopt-2307" });
+    expect(d.worktreeRemove).toHaveBeenCalledWith({
+      path: ".red/tmp/worktrees/landing/main-adopt-2307",
+    });
+    for (const name of ["gate_run", "worktree_remove"]) {
+      expect(tools.find((tool) => tool.name === name)!.description).toMatch(
+        /^MUTATING:/,
+      );
+    }
   });
 });

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -78,6 +78,35 @@ export interface RetakeToolInput {
   prLimit?: number;
 }
 
+export interface GateRunInput {
+  branch: string;
+  base?: string;
+}
+
+export interface GateBaselineStatusInput {
+  base?: string;
+}
+
+export interface LandBranchInput {
+  issue: number;
+  branch: string;
+  base?: string;
+  title?: string;
+  openPr?: boolean;
+}
+
+export interface CascadeStatusInput {
+  issue: number;
+}
+
+export interface ClaimIssueInput {
+  issue: number;
+}
+
+export interface WorktreeRemoveInput {
+  path: string;
+}
+
 export interface CastleMcpDependencies {
   fleetList(): Promise<unknown>;
   fleetStatus(input: FleetNameInput): Promise<unknown>;
@@ -101,6 +130,14 @@ export interface CastleMcpDependencies {
   retake(input: RetakeToolInput): Promise<unknown>;
   reap(): Promise<unknown>;
   unblockSweep(): Promise<unknown>;
+  gateRun(input: GateRunInput): Promise<unknown>;
+  gateBaselineStatus(input: GateBaselineStatusInput): Promise<unknown>;
+  landBranch(input: LandBranchInput): Promise<unknown>;
+  cascadeStatus(input: CascadeStatusInput): Promise<unknown>;
+  claimStatus(input: ClaimIssueInput): Promise<unknown>;
+  claimRelease(input: ClaimIssueInput): Promise<unknown>;
+  worktreeList(): Promise<unknown>;
+  worktreeRemove(input: WorktreeRemoveInput): Promise<unknown>;
 }
 
 export interface CastleMcpTool {
@@ -372,6 +409,80 @@ export function createCastleMcpTools(
         "MUTATING: promote dependency-blocked issues whose requirements are all closed.",
       inputSchema: {},
       invoke: () => deps.unblockSweep(),
+    },
+    {
+      name: "gate_run",
+      title: "Run the AFK gate",
+      description:
+        "MUTATING: materialize the branch's feedback worktree and run the package-scoped validation gate against it.",
+      inputSchema: {
+        branch: z.string().min(1),
+        base: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.gateRun(input as unknown as GateRunInput),
+    },
+    {
+      name: "gate_baseline_status",
+      title: "Read gate baseline status",
+      description:
+        "Return whether the base branch is tracked-red and the open main-red repair issues that track it.",
+      inputSchema: { base: z.string().min(1).optional() },
+      invoke: ({ base }) =>
+        deps.gateBaselineStatus({ base: base as string | undefined }),
+    },
+    {
+      name: "land_branch",
+      title: "Land AFK branch",
+      description:
+        "MUTATING: land one validated worker branch into its base through the complete landing sequence.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        branch: z.string().min(1),
+        base: z.string().min(1).optional(),
+        title: z.string().min(1).optional(),
+        openPr: z.boolean().optional(),
+      },
+      invoke: (input) => deps.landBranch(input as unknown as LandBranchInput),
+    },
+    {
+      name: "cascade_status",
+      title: "Read close cascade",
+      description:
+        "Return the dependents of one issue and which of them the close cascade would promote.",
+      inputSchema: { issue: z.number().int().positive() },
+      invoke: ({ issue }) => deps.cascadeStatus({ issue: issue as number }),
+    },
+    {
+      name: "claim_status",
+      title: "Read AFK claim",
+      description:
+        "Return the parsed claim marker records for one issue and the worker currently holding it.",
+      inputSchema: { issue: z.number().int().positive() },
+      invoke: ({ issue }) => deps.claimStatus({ issue: issue as number }),
+    },
+    {
+      name: "claim_release",
+      title: "Release AFK claim",
+      description:
+        "MUTATING: post a concede marker for every un-conceded claim holder so the issue becomes claimable again.",
+      inputSchema: { issue: z.number().int().positive() },
+      invoke: ({ issue }) => deps.claimRelease({ issue: issue as number }),
+    },
+    {
+      name: "worktree_list",
+      title: "List disposable worktrees",
+      description:
+        "Enumerate every checkout under the disposable `.red/tmp/worktrees/*` lanes.",
+      inputSchema: {},
+      invoke: () => deps.worktreeList(),
+    },
+    {
+      name: "worktree_remove",
+      title: "Remove disposable worktree",
+      description:
+        "MUTATING: remove one checkout under the disposable `.red/tmp/worktrees/*` lanes.",
+      inputSchema: { path: z.string().min(1) },
+      invoke: ({ path }) => deps.worktreeRemove({ path: path as string }),
     },
   ];
 }


### PR DESCRIPTION
Automated AFK landing for #2307. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2307

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787227416&installation_model_id=20659&pr_number=2327&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2327&signature=4aa5c06c0c0c33d4275da5c208c75c0d3ef017d91e32e41385d73536f61b89ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->