### PR TITLE
fix: #2224 S5: ADR lifecycle — judgment ops (merge/split/supersede) → interview → Spec

### DIFF
--- a/apps/dev/tests/review-adrs-docs.test.ts
+++ b/apps/dev/tests/review-adrs-docs.test.ts
@@ -58,6 +58,38 @@ describe("review-adrs docs contract", () => {
     expect(skill).toContain("Merge and split remain judgment operations");
   });
 
+  it("offers merge, split, and supersede-a-live-decision in the judgment interview", async () => {
+    const skill = await readReviewAdrsSkill();
+
+    expect(skill).toContain("Judgment operation vocabulary");
+    for (const operation of ["merge", "split", "supersede a live decision"]) {
+      expect(skill).toContain(operation);
+    }
+    expect(skill).toContain("this decision is incoherent");
+    expect(skill).toContain("one `Q##` per turn");
+  });
+
+  it("shapes every judgment proposal as supersede-and-replace", async () => {
+    const skill = await readReviewAdrsSkill();
+
+    expect(skill).toContain("supersede-and-replace");
+    expect(skill).toContain("one consolidating ADR");
+    expect(skill).toContain("archives the N originals");
+    expect(skill).toContain("N focused ADRs");
+    expect(skill).toContain("`superseded-by`");
+    expect(skill).toContain("never in-place rewrites");
+  });
+
+  it("captures judgment agreements as Spec work items instead of in-session writes", async () => {
+    const skill = await readReviewAdrsSkill();
+
+    expect(skill).toContain("never applied in-session");
+    expect(skill).toContain("Human Decisions");
+    expect(skill).toContain("Decision/Why/Alternatives");
+    expect(skill).toContain("/to-tickets");
+    expect(skill).toContain("/afk");
+  });
+
   it("points doc-writing skills at the shared doc-landing finalizer", async () => {
     const start = await readSkill("plugins/dev/skills/engineering/start/SKILL.md");
     const reviewAdrs = await readSkill("plugins/dev/skills/engineering/review-adrs/SKILL.md");

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -126,6 +126,8 @@ through `/memory:view`, `memory docs reference-graph`, and
   promotes it ahead of every `--spec` / `--issues` filter.
 - `/review-adrs` triages the decision record read-only, may apply only explicitly
   confirmed mechanical ADR maintenance, and feeds judgment findings to `/to-spec`.
+  Merge, split, and supersede-a-live-decision never apply in-session — they become
+  supersede-and-replace Spec work items for `/to-tickets` + `/afk`.
 - `/model-tier-policy` answers runner/model tier choices.
 - `/zoom-out`, `/research`, `/handoff`, `/ff`, and `/reflect` are understanding
   or productivity routes that feed the main flow.

--- a/packaging/pi/dev/skills/engineering/review-adrs/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/review-adrs/SKILL.md
@@ -38,6 +38,13 @@ interview/Spec**. Detection and planning never authorize a write.
 - ❌ **Merge and split remain judgment operations.** So do renumbering, changing a
   live decision, choosing among plausible successors/replacement paths, and
   resolving contradictions. Never apply these through the mechanical gate.
+- ❌ **Judgment operations are never applied in-session.** They only ever become
+  Spec work items, executed later by `/to-tickets` + `/afk`. No confirmation, no
+  interview answer, and no maintainer instruction inside this skill authorizes
+  minting, rewriting, or archiving an ADR for a merge, split, or supersede.
+- ✅ Every judgment proposal is **supersede-and-replace** — mint the successor
+  ADR(s) and archive the original(s) with `superseded-by` pointers, **never
+  in-place rewrites** of a historical record (ADR 0112).
 - ❌ Do not silently propagate to the wiki or Memory graph. Their changes remain
   separate interview decisions and Spec items.
 - ❌ Do not stack judgment questions. Ask one `Q##` per turn, wait, then re-evaluate.
@@ -144,9 +151,33 @@ buckets. Do not commit or publish here; the doc-landing finalizer owns landing.
 
 ## Phase 5 — Reconcile judgment findings (`/start` style)
 
+### Judgment operation vocabulary
+
+Three operations carry real consequence for the record: **merge** mints one
+consolidating ADR and archives the N originals, **split** mints N focused ADRs and
+archives the original, and **supersede a live decision** mints the successor and
+archives the original. Each is proposed in the interview and, once agreed, recorded
+as a Spec work item in exactly this shape:
+
+| Operation | Trigger | Proposed work item (supersede-and-replace) |
+|---|---|---|
+| **merge** | `merge-candidate` — N records cover one decision | mint **one consolidating ADR** carrying the current decision, then archive **the N originals**, each `superseded-by` the new number |
+| **split** | `split-candidate` — one record carries many decisions | mint **N focused ADRs**, then archive the original `superseded-by` the list of new numbers |
+| **supersede a live decision** | the decision changed, contradicts another record, or "this decision is incoherent" | mint **the successor ADR** stating the new decision, then archive the original `superseded-by` the successor |
+
+Every shape mints new numbers and archives originals — the number set grows, which
+is the honest cost of an immutable record. Never propose editing `## Decision`,
+renumbering in place, or deleting a record; those are **never in-place rewrites**
+and no variant of them is offered as a branch.
+
+State in each proposal which ADRs are minted (as `ADR-NEW-1`, `ADR-NEW-2`, … until
+`/to-tickets` allocates real numbers) and which are archived with which pointer.
+
+### The interview loop
+
 Walk the judgment ledger highest-impact first: numbering collision → contradiction
-→ merge/split → ambiguous supersession/path/archive → structural or controversial
-decision. For each unresolved finding, ask one question:
+→ merge/split → supersede a live decision → ambiguous supersession/path/archive →
+structural or controversial decision. For each unresolved finding, ask one question:
 
 > **Q##:** [decision to reconcile]
 > **Branches:**
@@ -167,9 +198,16 @@ item, never an inline mutation.
 If the ledger contains agreed judgment or propagation work, hand it to `/to-spec`:
 
 - Problem/Solution: the decision debt and reconciliation plan;
-- User Stories: concrete merge/split/new-ADR, ambiguous metadata, INDEX clustering,
-  wiki, Memory, or implementation work;
-- Human Decisions: every `Q##` answer in Decision/Why/Alternatives shape.
+- User Stories: one story per agreed judgment operation — the ADRs to mint and the
+  originals to archive with their `superseded-by` pointers — plus ambiguous
+  metadata, INDEX clustering, wiki, Memory, or implementation work;
+- Human Decisions: every `Q##` answer in Decision/Why/Alternatives shape. Each
+  agreed merge, split, and supersede-a-live-decision lands here as its own Human
+  Decision, so the reason the record changes shape survives the handoff.
+
+The Spec is the only artifact this skill produces for judgment work; `/to-tickets`
+slices it and `/afk` executes it later. Emitting the Spec is not permission to
+start it.
 
 Publish with `type:spec` + `needs-slicing` (never `ready-for-agent`; `/to-spec`
 handles labels). Do not publish an empty Spec for a mechanical-only or read-only
@@ -206,6 +244,10 @@ before exiting. It remains silent when no docs changed.
   between plausible replacement paths is judgment.
 - Merge/split always mint replacement ADRs and archive originals later; they never
   rewrite historical Decisions in-session.
+- "This ADR is wrong now" is a supersede-a-live-decision proposal, not a status
+  edit: the live record stays live until the Spec's successor ADR lands.
+- Agreeing to a merge in the interview produces a Spec work item. Doing the `git mv`
+  in the same session is the failure this lane exists to prevent.
 - A run stopped before or at the gate is a successful read-only review, not a
   partially failed apply.
 

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -126,6 +126,8 @@ through `/memory:view`, `memory docs reference-graph`, and
   promotes it ahead of every `--spec` / `--issues` filter.
 - `/review-adrs` triages the decision record read-only, may apply only explicitly
   confirmed mechanical ADR maintenance, and feeds judgment findings to `/to-spec`.
+  Merge, split, and supersede-a-live-decision never apply in-session — they become
+  supersede-and-replace Spec work items for `/to-tickets` + `/afk`.
 - `/model-tier-policy` answers runner/model tier choices.
 - `/zoom-out`, `/research`, `/handoff`, `/ff`, and `/reflect` are understanding
   or productivity routes that feed the main flow.

--- a/plugins/dev/skills/engineering/review-adrs/SKILL.md
+++ b/plugins/dev/skills/engineering/review-adrs/SKILL.md
@@ -38,6 +38,13 @@ interview/Spec**. Detection and planning never authorize a write.
 - ❌ **Merge and split remain judgment operations.** So do renumbering, changing a
   live decision, choosing among plausible successors/replacement paths, and
   resolving contradictions. Never apply these through the mechanical gate.
+- ❌ **Judgment operations are never applied in-session.** They only ever become
+  Spec work items, executed later by `/to-tickets` + `/afk`. No confirmation, no
+  interview answer, and no maintainer instruction inside this skill authorizes
+  minting, rewriting, or archiving an ADR for a merge, split, or supersede.
+- ✅ Every judgment proposal is **supersede-and-replace** — mint the successor
+  ADR(s) and archive the original(s) with `superseded-by` pointers, **never
+  in-place rewrites** of a historical record (ADR 0112).
 - ❌ Do not silently propagate to the wiki or Memory graph. Their changes remain
   separate interview decisions and Spec items.
 - ❌ Do not stack judgment questions. Ask one `Q##` per turn, wait, then re-evaluate.
@@ -144,9 +151,33 @@ buckets. Do not commit or publish here; the doc-landing finalizer owns landing.
 
 ## Phase 5 — Reconcile judgment findings (`/start` style)
 
+### Judgment operation vocabulary
+
+Three operations carry real consequence for the record: **merge** mints one
+consolidating ADR and archives the N originals, **split** mints N focused ADRs and
+archives the original, and **supersede a live decision** mints the successor and
+archives the original. Each is proposed in the interview and, once agreed, recorded
+as a Spec work item in exactly this shape:
+
+| Operation | Trigger | Proposed work item (supersede-and-replace) |
+|---|---|---|
+| **merge** | `merge-candidate` — N records cover one decision | mint **one consolidating ADR** carrying the current decision, then archive **the N originals**, each `superseded-by` the new number |
+| **split** | `split-candidate` — one record carries many decisions | mint **N focused ADRs**, then archive the original `superseded-by` the list of new numbers |
+| **supersede a live decision** | the decision changed, contradicts another record, or "this decision is incoherent" | mint **the successor ADR** stating the new decision, then archive the original `superseded-by` the successor |
+
+Every shape mints new numbers and archives originals — the number set grows, which
+is the honest cost of an immutable record. Never propose editing `## Decision`,
+renumbering in place, or deleting a record; those are **never in-place rewrites**
+and no variant of them is offered as a branch.
+
+State in each proposal which ADRs are minted (as `ADR-NEW-1`, `ADR-NEW-2`, … until
+`/to-tickets` allocates real numbers) and which are archived with which pointer.
+
+### The interview loop
+
 Walk the judgment ledger highest-impact first: numbering collision → contradiction
-→ merge/split → ambiguous supersession/path/archive → structural or controversial
-decision. For each unresolved finding, ask one question:
+→ merge/split → supersede a live decision → ambiguous supersession/path/archive →
+structural or controversial decision. For each unresolved finding, ask one question:
 
 > **Q##:** [decision to reconcile]
 > **Branches:**
@@ -167,9 +198,16 @@ item, never an inline mutation.
 If the ledger contains agreed judgment or propagation work, hand it to `/to-spec`:
 
 - Problem/Solution: the decision debt and reconciliation plan;
-- User Stories: concrete merge/split/new-ADR, ambiguous metadata, INDEX clustering,
-  wiki, Memory, or implementation work;
-- Human Decisions: every `Q##` answer in Decision/Why/Alternatives shape.
+- User Stories: one story per agreed judgment operation — the ADRs to mint and the
+  originals to archive with their `superseded-by` pointers — plus ambiguous
+  metadata, INDEX clustering, wiki, Memory, or implementation work;
+- Human Decisions: every `Q##` answer in Decision/Why/Alternatives shape. Each
+  agreed merge, split, and supersede-a-live-decision lands here as its own Human
+  Decision, so the reason the record changes shape survives the handoff.
+
+The Spec is the only artifact this skill produces for judgment work; `/to-tickets`
+slices it and `/afk` executes it later. Emitting the Spec is not permission to
+start it.
 
 Publish with `type:spec` + `needs-slicing` (never `ready-for-agent`; `/to-spec`
 handles labels). Do not publish an empty Spec for a mechanical-only or read-only
@@ -206,6 +244,10 @@ before exiting. It remains silent when no docs changed.
   between plausible replacement paths is judgment.
 - Merge/split always mint replacement ADRs and archive originals later; they never
   rewrite historical Decisions in-session.
+- "This ADR is wrong now" is a supersede-a-live-decision proposal, not a status
+  edit: the live record stays live until the Spec's successor ADR lands.
+- Agreeing to a merge in the interview produces a Spec work item. Doing the `git mv`
+  in the same session is the failure this lane exists to prevent.
 - A run stopped before or at the gate is a successful read-only review, not a
   partially failed apply.
 


### PR DESCRIPTION
Automated AFK landing for #2224. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2224

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787229545&installation_model_id=20659&pr_number=2341&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2341&signature=5839d68a58cf9dd943b8568238d7d98c41e53645b628cffaf88a36fa26c4749c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->