### PR TITLE
fix: #2339 feedback gate treats the post-merge rebase worktree dir as a branch — blocks all validation, phantom merge-conflict

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -438,8 +438,9 @@ async function runAdoptLanding(
         const slug = bas.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "base";
         const dest = join(paths.landingWorktreesDir, `${slug}-adopt-${issue}`);
         await gitx.worktreeRemove(gitCtx, dest);
-        const ok = await gitx.worktreeAdd(gitCtx, dest, bas);
-        return ok ? dest : null;
+        const added = await gitx.worktreeAdd(gitCtx, dest, bas);
+        if (!added.ok) gitx.warnWorktreeAdd(dest, bas, added.stderr);
+        return added.ok ? dest : null;
       },
       removeLandingWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
       // Isolated worker-branch worktree for the PR path's pre-merge rebase (#1006).
@@ -447,8 +448,9 @@ async function runAdoptLanding(
         const slug = branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "branch";
         const dest = join(paths.rebaseWorktreesDir, `${slug}-adopt-${issue}`);
         await gitx.worktreeRemove(gitCtx, dest);
-        const ok = await gitx.worktreeAdd(gitCtx, dest, branch);
-        return ok ? dest : null;
+        const added = await gitx.worktreeAdd(gitCtx, dest, branch);
+        if (!added.ok) gitx.warnWorktreeAdd(dest, branch, added.stderr);
+        return added.ok ? dest : null;
       },
       removeRebaseWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
       envelope: {

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -504,8 +504,9 @@ export function buildProcessDeps(
       const slug = base.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "base";
       const dest = join(paths.landingWorktreesDir, `${slug}-${slot}`);
       await gitx.worktreeRemove(gitCtx, dest);
-      const ok = await gitx.worktreeAdd(gitCtx, dest, base);
-      return ok ? dest : null;
+      const added = await gitx.worktreeAdd(gitCtx, dest, base);
+      if (!added.ok) gitx.warnWorktreeAdd(dest, base, added.stderr);
+      return added.ok ? dest : null;
     },
     removeLandingWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
     // Isolated worker-branch worktree for the PR path's pre-merge rebase (#1006):
@@ -515,8 +516,9 @@ export function buildProcessDeps(
       const slug = branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "branch";
       const dest = join(paths.rebaseWorktreesDir, `${slug}-${slot}`);
       await gitx.worktreeRemove(gitCtx, dest);
-      const ok = await gitx.worktreeAdd(gitCtx, dest, branch);
-      return ok ? dest : null;
+      const added = await gitx.worktreeAdd(gitCtx, dest, branch);
+      if (!added.ok) gitx.warnWorktreeAdd(dest, branch, added.stderr);
+      return added.ok ? dest : null;
     },
     removeRebaseWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
     hooks: {
@@ -942,9 +944,12 @@ export function buildProcessDeps(
         const dest = join(paths.cascadeWorktreesDir, `${slug}-${slot}`);
         try {
           await gitx.worktreeRemove(gitCtx, dest);
-          const ok = await gitx.worktreeAdd(gitCtx, dest, branch);
-          if (!ok) {
-            return { ok: false, warn: `failed to create worktree for ${branch}` };
+          const added = await gitx.worktreeAdd(gitCtx, dest, branch);
+          if (!added.ok) {
+            return {
+              ok: false,
+              warn: `failed to create worktree for ${branch}: ${added.stderr || "no git detail"}`,
+            };
           }
           const run = exec ?? (await import("../../runtime/exec.js")).execTool;
           const rebaseR = await run("git", ["rebase", trunkTip], { cwd: dest });

--- a/apps/dev/src/commands/run/reconcile.ts
+++ b/apps/dev/src/commands/run/reconcile.ts
@@ -272,8 +272,9 @@ export function makeBootReconcileRunner(
         const slug = base.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "base";
         const dest = join(paths.landingWorktreesDir, `${slug}-boot-${slot}`);
         await gitx.worktreeRemove(gitCtx, dest);
-        const ok = await gitx.worktreeAdd(gitCtx, dest, base);
-        return ok ? dest : null;
+        const added = await gitx.worktreeAdd(gitCtx, dest, base);
+        if (!added.ok) gitx.warnWorktreeAdd(dest, base, added.stderr);
+        return added.ok ? dest : null;
       },
       removeLandingWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
       // Isolated worker-branch worktree for the PR path's pre-merge rebase (#1006):
@@ -283,8 +284,9 @@ export function makeBootReconcileRunner(
         const slug = branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "branch";
         const dest = join(paths.rebaseWorktreesDir, `${slug}-boot-${slot}`);
         await gitx.worktreeRemove(gitCtx, dest);
-        const ok = await gitx.worktreeAdd(gitCtx, dest, branch);
-        return ok ? dest : null;
+        const added = await gitx.worktreeAdd(gitCtx, dest, branch);
+        if (!added.ok) gitx.warnWorktreeAdd(dest, branch, added.stderr);
+        return added.ok ? dest : null;
       },
       removeRebaseWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
       // #1095: only the merge-conflict reland auto-resolves mechanical rebase

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1286,6 +1286,27 @@ export async function processIssue(
         `the open PR merge was rejected by GitHub, usually because branch protection or CI is not satisfied`,
       );
     }
+    if (landing.reason === "post-merge-gate") {
+      // The post-merge integration gate (#1335) rejected the integrated tree —
+      // a VALIDATION outcome, never a merge conflict (#2339). The rebase that
+      // precedes it already succeeded, so parking `blocked:merge-conflict` sent
+      // humans down the wrong recovery path (same class as #2096), most visibly
+      // when the gate could not even materialise its worktree and every check
+      // short-circuited with `durationMs: 0`.
+      const validation =
+        validationSidecar.join("\n") ||
+        "The post-merge integration gate failed on the rebased tree; nothing was merged.";
+      return await terminalFailure(
+        common,
+        "feedback-failed",
+        "feedback",
+        {
+          notes: "The post-merge integration gate failed; the worker branch was not merged.",
+          validation,
+        },
+        { validationSummary: validation },
+      );
+    }
     return await mergeFailed(common, landing.reason, landing.locked);
   }
   const mergeSha = landing.mergeSha ?? (await deps.git.headShortSha());

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -425,13 +425,13 @@ export function createDefaultDevAfkMcpOperations(
           makeLandingWorktree: async (target) => {
             const dest = join(paths.landingWorktreesDir, `${slug(target)}-mcp-${input.issue}`);
             await gitx.worktreeRemove(gitCtx, dest);
-            return (await gitx.worktreeAdd(gitCtx, dest, target)) ? dest : null;
+            return (await gitx.worktreeAdd(gitCtx, dest, target)).ok ? dest : null;
           },
           removeLandingWorktree: (dir) => gitx.worktreeRemove(gitCtx, dir),
           makeRebaseWorktree: async (branch) => {
             const dest = join(paths.rebaseWorktreesDir, `${slug(branch)}-mcp-${input.issue}`);
             await gitx.worktreeRemove(gitCtx, dest);
-            return (await gitx.worktreeAdd(gitCtx, dest, branch)) ? dest : null;
+            return (await gitx.worktreeAdd(gitCtx, dest, branch)).ok ? dest : null;
           },
           removeRebaseWorktree: (dir) => gitx.worktreeRemove(gitCtx, dir),
         },

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -29,7 +29,7 @@
 // `cacheEnabled: false` for callers that need a strict per-session manager.
 
 import { accessSync, constants, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import {
   buildFeedbackSubprocessEnv,
   type Exec as PnpmExec,
@@ -39,6 +39,34 @@ import type { BackpressureExec } from "../core/backpressure.js";
 import type { PostAttemptFormatExec } from "../core/post-attempt-format.js";
 import { execTool, pnpm as runPnpm, type ExecOptions, type ExecOutput } from "./exec.js";
 import * as gitx from "./git.js";
+
+/**
+ * Is `token` an ALREADY-MATERIALISED checkout rather than a branch name (#2339)?
+ *
+ * The feedback gate's `-C` token is normally a branch, but the post-merge
+ * integration gate (#1335) passes the isolated rebase/landing worktree DIR it
+ * just provisioned. Treating that dir as a branch made `git fetch origin
+ * <dir>` fail and blocked ALL validation.
+ *
+ * The discriminator is git's own: a checkout root carries a `.git` entry (a
+ * DIR in a primary clone, a FILE in a linked worktree). Branch names never
+ * do — `afk/<worker>/<n>-<slug>` is not a directory on disk — so the check
+ * cannot mistake a branch for a path. Returns the resolved checkout path
+ * (relative tokens are tried against `root` first, then the cwd), or `null`
+ * when the token is a plain branch name.
+ */
+export function resolveCheckoutDir(token: string, root: string): string | null {
+  const candidates = isAbsolute(token) ? [token] : [join(root, token), token];
+  for (const candidate of candidates) {
+    try {
+      accessSync(join(candidate, ".git"), constants.F_OK);
+      return candidate;
+    } catch {
+      // Not a checkout at this candidate — try the next.
+    }
+  }
+  return null;
+}
 
 function slugForBranch(branch: string): string {
   return branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "wt";
@@ -90,7 +118,16 @@ export function splitBranchDir(
  * (the safe default — re-materialise from scratch).
  */
 export interface FeedbackWorktreeIO {
-  worktreeAdd(ctx: gitx.GitContext, dest: string, branch: string): Promise<boolean>;
+  /**
+   * Materialise `branch` at `dest`. Returns the real git stderr alongside the
+   * verdict (#2339) — a bare boolean forced every field report to guess why the
+   * gate never got a checkout.
+   */
+  worktreeAdd(
+    ctx: gitx.GitContext,
+    dest: string,
+    branch: string,
+  ): Promise<{ ok: boolean; stderr?: string }>;
   worktreeRemove(ctx: gitx.GitContext, dest: string): Promise<void>;
   /**
    * Resolve `branch` (local or remote) to its HEAD SHA. Returns `null` when
@@ -235,6 +272,20 @@ export function makeFeedbackWorktree(
     if (!branch) return root;
     const cached = resolved.get(branch);
     if (cached !== undefined) return cached;
+
+    // The token is ALREADY a materialised checkout (#2339). The post-merge
+    // integration gate (#1335) hands the gate the isolated rebase/landing
+    // worktree DIR, not a branch name — the caller provisioned it, so there is
+    // nothing to fetch or add. Without this seam the dir was treated as a
+    // branch: `git fetch origin .red/tmp/worktrees/rebase/<slug>-0` failed,
+    // every validation call short-circuited to code 1 with `durationMs: 0`, and
+    // the landing parked as a phantom merge-conflict.
+    const materialised = resolveCheckoutDir(branch, root);
+    if (materialised) {
+      resolved.set(branch, materialised);
+      return materialised;
+    }
+
     const dest = join(feedbackRoot, slugForBranch(branch));
 
     // AFK runner improvement — cross-session cache: a worktree already at
@@ -255,10 +306,14 @@ export function makeFeedbackWorktree(
       // to a clean re-materialise.
     }
 
-    const ok = await io.worktreeAdd(gitCtx, dest, branch);
-    if (!ok) {
+    const added = await io.worktreeAdd(gitCtx, dest, branch);
+    if (!added.ok) {
+      // Carry the underlying git stderr (#2339): the field report that opened
+      // this only had "add failed", so the real cause (`fatal: couldn't find
+      // remote ref <x>`) had to be guessed.
       process.stderr.write(
-        `error: feedback worktree add failed for ${branch}; blocking validation\n`,
+        `error: feedback worktree add failed for ${branch}; blocking validation: ` +
+          `${added.stderr?.trim() || "no git detail"}\n`,
       );
       resolved.set(branch, null);
       return null;

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -454,16 +454,53 @@ export async function recentCommits(ctx: GitContext, ref = "main", count = 5): P
 }
 
 /**
+ * Outcome of {@link worktreeAdd}. `stderr` carries the UNDERLYING git failure
+ * (fetch and/or `worktree add`) so a caller's error line names the real cause
+ * (#2339). A bare boolean forced every field report to guess why the gate's
+ * worktree never materialised — keep the detail attached to the failure.
+ */
+export interface WorktreeAddResult {
+  ok: boolean;
+  /** Combined git stderr, trimmed. Empty when git said nothing. */
+  stderr: string;
+}
+
+/**
  * Add a detached worktree for `branch` under `path` (fetching origin first so a
- * sandcastle-pushed worker branch is visible locally). Returns true on success.
+ * sandcastle-pushed worker branch is visible locally). Returns `{ ok: true }` on
+ * success and `{ ok: false, stderr }` with the real git stderr otherwise.
  * Best-effort cleanup is the caller's via {@link worktreeRemove}.
  */
-export async function worktreeAdd(ctx: GitContext, path: string, branch: string): Promise<boolean> {
-  await runGit(ctx, ["fetch", "origin", branch]);
+export async function worktreeAdd(
+  ctx: GitContext,
+  path: string,
+  branch: string,
+): Promise<WorktreeAddResult> {
+  const fetched = await runGit(ctx, ["fetch", "origin", branch]);
   // Always use the freshly-fetched origin tip so validation never runs against
   // a stale local ref that diverges from what was pushed.
   const r = await runGit(ctx, ["worktree", "add", "--force", "--detach", path, `origin/${branch}`]);
-  return r.code === 0;
+  if (r.code === 0) return { ok: true, stderr: "" };
+  // A failed fetch is usually the ROOT cause (the ref does not exist, e.g. a
+  // filesystem path passed where a branch belongs), and the `worktree add` that
+  // follows only reports the missing `origin/<branch>` — carry both.
+  const stderr = [fetched.code === 0 ? "" : fetched.stderr, r.stderr]
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .join("\n");
+  return { ok: false, stderr };
+}
+
+/**
+ * Emit the one diagnostic line a failed {@link worktreeAdd} owes the operator
+ * (#2339): dest, the ref we tried to check out, and the REAL git stderr. Every
+ * landing/rebase provisioner collapses the failure to `null`, so without this
+ * the only field evidence was a silent refusal.
+ */
+export function warnWorktreeAdd(dest: string, branch: string, stderr: string): void {
+  process.stderr.write(
+    `error: worktree add failed for ${branch} at ${dest}: ${stderr || "no git detail"}\n`,
+  );
 }
 
 /** Remove a worktree previously added by {@link worktreeAdd} (best-effort). */

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -1,6 +1,10 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   makeFeedbackWorktree,
+  resolveCheckoutDir,
   splitBranchDir,
   type FeedbackWorktreeIO,
 } from "../src/runtime/feedback-worktree.js";
@@ -99,7 +103,10 @@ function fakeIO(
   const io: FeedbackWorktreeIO = {
     worktreeAdd: async (_ctx, dest) => {
       calls.push({ op: "add", dest });
-      return addOk;
+      // A refused add carries the real git stderr (#2339), never a bare false.
+      return addOk
+        ? { ok: true, stderr: "" }
+        : { ok: false, stderr: "fatal: couldn't find remote ref refs/heads/nope" };
     },
     pnpm: async (args, opts) => {
       const isInstall = args[0] === "install";
@@ -203,6 +210,87 @@ describe("makeFeedbackWorktree install (#458)", () => {
     // No install or script should run after a failed worktree add.
     expect(calls.filter((c) => c.op === "install")).toHaveLength(0);
     expect(calls.filter((c) => c.op === "script")).toHaveLength(0);
+  });
+
+  it("surfaces the underlying git stderr on a failed worktree add (#2339)", async () => {
+    const { io } = fakeIO(0, false, 0, { enabled: false });
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io, { cacheEnabled: false });
+
+    const written: string[] = [];
+    const realWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      written.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+    } finally {
+      process.stderr.write = realWrite;
+    }
+
+    // Field reports had to GUESS the root cause from "add failed" alone (#2338).
+    const line = written.find((l) => l.includes("feedback worktree add failed"));
+    expect(line).toContain("fatal: couldn't find remote ref refs/heads/nope");
+  });
+});
+
+// #2339: the post-merge integration gate (#1335) hands the feedback executors
+// the isolated rebase/landing worktree DIR, not a branch name. Treating that dir
+// as a branch made `git fetch origin <dir>` fail, blocked ALL validation
+// (`durationMs: 0` on every check), and parked a phantom merge-conflict.
+describe("makeFeedbackWorktree — already-materialised checkout token (#2339)", () => {
+  /**
+   * A temp primary checkout (so the layout probe sees `apps/dev` as a real
+   * package) plus a sibling dir that looks to git like a linked worktree: a
+   * `.git` FILE at its root, exactly what `git worktree add` writes.
+   */
+  function makeFixture(): { root: string; dir: string; cleanup: () => void } {
+    const base = mkdtempSync(join(tmpdir(), "red-gate-"));
+    const root = join(base, "repo");
+    mkdirSync(join(root, "apps", "dev"), { recursive: true });
+    writeFileSync(join(root, "apps", "dev", "package.json"), JSON.stringify({ name: "dev" }));
+    const dir = join(base, "rebase-wt");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, ".git"), "gitdir: /elsewhere/.git/worktrees/x\n");
+    return { root, dir, cleanup: () => rmSync(base, { recursive: true, force: true }) };
+  }
+
+  it("recognises a checkout dir and never fetches it as a branch", () => {
+    const { root, dir, cleanup } = makeFixture();
+    try {
+      expect(resolveCheckoutDir(dir, root)).toBe(dir);
+      // A worker branch name is never mistaken for a path.
+      expect(resolveCheckoutDir("afk/w1/42-fix", root)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("runs the gate IN the rebase worktree instead of blocking validation", async () => {
+    const { root, dir, cleanup } = makeFixture();
+    try {
+      // addOk=false models the field failure exactly: fetching a filesystem
+      // path as a branch always fails, so any add attempt here blocks the gate.
+      const { io, calls } = fakeIO(0, false, 0, { enabled: false });
+      const fb = makeFeedbackWorktree(root, join(root, ".red/tmp/feedback"), io, {
+        cacheEnabled: false,
+      });
+
+      // The exact call shape of postMergeGate: a `-C <rebase-worktree>/<scope>`
+      // token plus a root-scoped backpressure command in the same dir.
+      const gate = await fb.pnpm(["pnpm", "-C", `${dir}/apps/dev`, "test"]);
+      const bp = await fb.backpressure({ command: "pnpm test", cwd: dir, timeoutMs: 1000 });
+
+      expect(gate.code).toBe(0);
+      expect(bp.code).toBe(0);
+      // The caller already provisioned the checkout — no add, no re-install.
+      expect(calls.filter((c) => c.op === "add")).toHaveLength(0);
+      expect(calls.filter((c) => c.op === "install")).toHaveLength(0);
+      // And the commands ran in that dir, not the primary checkout.
+      expect(calls.filter((c) => c.op === "script").map((c) => c.dest)).toContain(dir);
+    } finally {
+      cleanup();
+    }
   });
 });
 
@@ -471,7 +559,7 @@ describe("gate test subprocess env (#1215 / #1224 Part C)", () => {
   function captureEnvIO(): { io: FeedbackWorktreeIO; envsFor: (script: string) => NodeJS.ProcessEnv[] } {
     const seen: Array<{ script: string; env: NodeJS.ProcessEnv | undefined }> = [];
     const io: FeedbackWorktreeIO = {
-      worktreeAdd: async () => true,
+      worktreeAdd: async () => ({ ok: true, stderr: "" }),
       pnpm: async (args, opts) => {
         // The gate rewrites the token to ["-C", <path>, <script>]; "install" is
         // the materialise step, everything else is a gate check.

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -235,6 +235,29 @@ describe("processIssue — CI-aware unlocked landing (#812)", () => {
     expect(trace.runAgentCalls.length).toBe(1);
   });
 
+  it("a post-merge-gate failure parks blocked:validation, NEVER merge-conflict (#2339)", async () => {
+    // #2338 field report: the gate could not materialise its worktree, every
+    // check short-circuited with `durationMs: 0`, and the attempt was parked as
+    // blocked:merge-conflict — sending humans down the wrong recovery path even
+    // though the pre-merge rebase had already succeeded (same class as #2096).
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: false,
+      postMergeGateOk: false,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(true);
+    expect(trace.labelEdits.some((e) => e.add.includes("blocked:merge-conflict"))).toBe(false);
+    expect(trace.ensuredLabels).not.toContain("blocked:merge-conflict");
+    // The work is preserved: nothing merged, agent not re-run.
+    expect(trace.closed).toEqual([]);
+    expect(trace.runAgentCalls.length).toBe(1);
+  });
+
   it("admin-merge rejected after PR exists parks the PR instead of re-queueing for a fresh agent", async () => {
     const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true, locked: false, prMergeCode: 1 });
     const result = await processIssue(deps, input);

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -112,6 +112,14 @@ export interface HarnessOptions {
   feedbackOk?: boolean;
   /** When true, the feedback baseline probe fails the same check as the worker. */
   baselineFails?: boolean;
+  /**
+   * When false, the POST-MERGE integration gate (#1335) fails while the
+   * pre-landing gate still passes. Detected by the `-C` dir: the post-merge gate
+   * is the only run whose token is the isolated landing/rebase worktree path
+   * ("/wt" / "/rwt") rather than a branch name. Models #2339, where the gate
+   * could not even materialise a worktree in that dir.
+   */
+  postMergeGateOk?: boolean;
   /** Existing main-red repair issue returned by the finder. false/null means missing. */
   mainRedRepairIssue?: boolean;
   /** When set, creating the main-red repair issue throws this message. */
@@ -532,6 +540,11 @@ export function harness(opts: HarnessOptions = {}): {
       const dir = cIdx >= 0 ? (args[cIdx + 1] ?? "") : "";
       if (dir === "main" || dir.startsWith("main/")) {
         return { code: opts.baselineFails ? 1 : 0, stdout: "", stderr: "" };
+      }
+      // The post-merge integration gate runs against the landing/rebase
+      // worktree PATH, never a branch name — so the dir discriminates it.
+      if (dir === "/wt" || dir.startsWith("/wt/") || dir === "/rwt" || dir.startsWith("/rwt/")) {
+        return { code: opts.postMergeGateOk === false ? 1 : 0, stdout: "", stderr: "" };
       }
       const feedbackRun = Math.floor(pnpmCalls / 4);
       pnpmCalls += 1;


### PR DESCRIPTION
Adopted landing of the completed w0ZNJ branch (agent finished DONE; worker was terminated during post-DONE collection — maintainer reviewed the diff).

- `resolveCheckoutDir` seam: the feedback gate's `-C` token can be an already-materialised checkout (the #1335 post-merge integration gate passes the rebase/landing worktree DIR); use it directly instead of treating it as a branch (`git fetch origin <dir>` previously failed and blocked ALL validation with `durationMs: 0`)
- `worktreeAdd` now returns the real git stderr (fetch + add), so field reports never guess the cause again
- Post-merge-gate failure classification pinned to `blocked:validation` (never phantom `merge-conflict`)

Field report: #2338 (external install, `@2.76.1`).

Closes #2339

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787230521&installation_model_id=20659&pr_number=2343&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2343&signature=0bba1f63716f4fb69c5fcefa6b8dfe3a9e7ca8ddb79255c0a125458a25b20b40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->