### PR TITLE
fix: #2330 Castle-MCP H1: split the tool registry into per-domain modules

### DIFF
--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -1,488 +1,79 @@
 #!/usr/bin/env node
-import { z } from "zod/v3";
+import { createClaimTools, type ClaimDependencies } from "./mcp/claim.js";
+import { createFleetTools, type FleetDependencies } from "./mcp/fleet.js";
+import { createGateTools, type GateDependencies } from "./mcp/gate.js";
+import { createHygieneTools, type HygieneDependencies } from "./mcp/hygiene.js";
+import { createLandingTools, type LandingDependencies } from "./mcp/landing.js";
+import {
+  createObservabilityTools,
+  type ObservabilityDependencies,
+} from "./mcp/observability.js";
+import { createRunnerTools, type RunnerDependencies } from "./mcp/runner.js";
+import type { CastleMcpTool } from "./mcp/tool.js";
+import { createWorkerTools, type WorkerDependencies } from "./mcp/worker.js";
+import {
+  createWorktreeTools,
+  type WorktreeDependencies,
+} from "./mcp/worktree.js";
 
-export interface FleetSelectorInput {
-  spec?: number;
-  lane?: string;
-  label?: string;
-  issues?: number[];
-}
+export type { CastleMcpTool } from "./mcp/tool.js";
+export type {
+  FleetSelectorInput,
+  FleetCreateInput,
+  FleetEditInput,
+  FleetNameInput,
+} from "./mcp/fleet.js";
+export type { LogsInput } from "./mcp/observability.js";
+export type {
+  WorkerDispatchInput,
+  WorkerStatusInput,
+  WorkerStopInput,
+} from "./mcp/worker.js";
+export type {
+  RunnerDetectInput,
+  WorkerSteerInput,
+  WorkerRequestInput,
+} from "./mcp/runner.js";
+export type { RequeueToolInput, RetakeToolInput } from "./mcp/hygiene.js";
+export type { GateRunInput, GateBaselineStatusInput } from "./mcp/gate.js";
+export type { LandBranchInput, CascadeStatusInput } from "./mcp/landing.js";
+export type { ClaimIssueInput } from "./mcp/claim.js";
+export type { WorktreeRemoveInput } from "./mcp/worktree.js";
 
-export interface FleetCreateInput {
-  name: string;
-  runner: string;
-  target: number;
-  selector?: FleetSelectorInput;
-  config?: Record<string, string | number | boolean>;
-  base?: string;
-}
+/**
+ * The host adapter implements every capability domain at once, so the
+ * dependency contract is the union of the per-domain contracts. A new tool
+ * extends its own domain's interface — this composition never changes.
+ */
+export interface CastleMcpDependencies
+  extends
+    FleetDependencies,
+    ObservabilityDependencies,
+    WorkerDependencies,
+    RunnerDependencies,
+    HygieneDependencies,
+    GateDependencies,
+    LandingDependencies,
+    ClaimDependencies,
+    WorktreeDependencies {}
 
-export interface FleetEditInput {
-  name: string;
-  runner?: string;
-  target?: number;
-  selector?: FleetSelectorInput;
-  config?: Record<string, string | number | boolean>;
-  base?: string;
-}
-
-export interface FleetNameInput {
-  name?: string;
-}
-
-export interface LogsInput {
-  lane: "worker" | "supervisor" | "monitor" | "liveness";
-  id: string;
-}
-
-export interface WorkerDispatchInput {
-  issue?: number;
-  demand?: string;
-  runner?: string;
-  mode?: "no-mistakes" | "direct-PR" | "local-only";
-}
-
-export interface WorkerStatusInput {
-  worker?: string;
-}
-
-export interface WorkerStopInput {
-  worker: string;
-  recycle: boolean;
-}
-
-export interface RunnerDetectInput {
-  runner?: string;
-}
-
-export interface WorkerSteerInput {
-  worker: string;
-  text: string;
-}
-
-export interface WorkerRequestInput extends WorkerDispatchInput {
-  text: string;
-}
-
-export interface RequeueToolInput {
-  issue: number;
-  guidance: string;
-  repo?: string;
-  dryRun?: boolean;
-  adoptBranch?: string;
-}
-
-export interface RetakeToolInput {
-  issue: number;
-  repo?: string;
-  prLimit?: number;
-}
-
-export interface GateRunInput {
-  branch: string;
-  base?: string;
-}
-
-export interface GateBaselineStatusInput {
-  base?: string;
-}
-
-export interface LandBranchInput {
-  issue: number;
-  branch: string;
-  base?: string;
-  title?: string;
-  openPr?: boolean;
-}
-
-export interface CascadeStatusInput {
-  issue: number;
-}
-
-export interface ClaimIssueInput {
-  issue: number;
-}
-
-export interface WorktreeRemoveInput {
-  path: string;
-}
-
-export interface CastleMcpDependencies {
-  fleetList(): Promise<unknown>;
-  fleetStatus(input: FleetNameInput): Promise<unknown>;
-  fleetCreate(input: FleetCreateInput): Promise<unknown>;
-  fleetEdit(input: FleetEditInput): Promise<unknown>;
-  fleetStop(input: FleetNameInput): Promise<unknown>;
-  logs(input: LogsInput): Promise<unknown>;
-  workerVitals(): Promise<unknown>;
-  dashboard(input: { periodDays: number }): Promise<unknown>;
-  monitor(): Promise<unknown>;
-  history(input: { limit?: number }): Promise<unknown>;
-  queueStatus(): Promise<unknown>;
-  workerDispatch(input: WorkerDispatchInput): Promise<unknown>;
-  workerStatus(input: WorkerStatusInput): Promise<unknown>;
-  workerStop(input: WorkerStopInput): Promise<unknown>;
-  runnerList(): Promise<unknown>;
-  runnerDetect(input: RunnerDetectInput): Promise<unknown>;
-  runnerSteer(input: WorkerSteerInput): Promise<unknown>;
-  workerRequest(input: WorkerRequestInput): Promise<unknown>;
-  requeue(input: RequeueToolInput): Promise<unknown>;
-  retake(input: RetakeToolInput): Promise<unknown>;
-  reap(): Promise<unknown>;
-  unblockSweep(): Promise<unknown>;
-  gateRun(input: GateRunInput): Promise<unknown>;
-  gateBaselineStatus(input: GateBaselineStatusInput): Promise<unknown>;
-  landBranch(input: LandBranchInput): Promise<unknown>;
-  cascadeStatus(input: CascadeStatusInput): Promise<unknown>;
-  claimStatus(input: ClaimIssueInput): Promise<unknown>;
-  claimRelease(input: ClaimIssueInput): Promise<unknown>;
-  worktreeList(): Promise<unknown>;
-  worktreeRemove(input: WorktreeRemoveInput): Promise<unknown>;
-}
-
-export interface CastleMcpTool {
-  name: string;
-  title: string;
-  description: string;
-  inputSchema: Record<string, z.ZodType>;
-  invoke(input: Record<string, unknown>): Promise<unknown>;
-}
-
-const fleetSelectorShape = {
-  spec: z.number().int().positive().optional(),
-  lane: z.string().min(1).optional(),
-  label: z.string().min(1).optional(),
-  issues: z.array(z.number().int().positive()).optional(),
-};
-
-const fleetConfig = z.record(
-  z.string(),
-  z.union([z.string(), z.number(), z.boolean()]),
-);
-
-const dispatchShape = {
-  issue: z.number().int().positive().optional(),
-  demand: z.string().min(1).optional(),
-  runner: z.string().min(1).optional(),
-  mode: z.enum(["no-mistakes", "direct-PR", "local-only"]).optional(),
-};
-
-function dispatchInput(input: Record<string, unknown>): WorkerDispatchInput {
-  const value = input as unknown as WorkerDispatchInput;
-  if ((value.issue === undefined) === (value.demand === undefined)) {
-    throw new Error("exactly one of issue or demand is required");
-  }
-  if (value.issue !== undefined && value.mode !== undefined) {
-    throw new Error("mode is only valid for demand dispatches");
-  }
-  return value;
-}
-
+/**
+ * Compose the published dev:afk tool surface from the per-domain registries.
+ * The concatenation order IS the published order — `mcp-tool-surface.test.ts`
+ * freezes it.
+ */
 export function createCastleMcpTools(
   deps: CastleMcpDependencies,
 ): CastleMcpTool[] {
   return [
-    {
-      name: "fleet_list",
-      title: "List AFK fleets",
-      description: "List every registered named AFK fleet profile.",
-      inputSchema: {},
-      invoke: () => deps.fleetList(),
-    },
-    {
-      name: "fleet_status",
-      title: "Get AFK fleet status",
-      description:
-        "Return structured supervisor, slots, churn, and live-worker status for a named fleet.",
-      inputSchema: { fleet: z.string().min(1).optional() },
-      invoke: ({ fleet }) =>
-        deps.fleetStatus({ name: fleet as string | undefined }),
-    },
-    {
-      name: "fleet_create",
-      title: "Create AFK fleet",
-      description:
-        "MUTATING: persist a named fleet profile and spawn its supervisor.",
-      inputSchema: {
-        name: z.string().min(1),
-        runner: z.string().min(1),
-        target: z.number().int().min(0).default(2),
-        selector: z.object(fleetSelectorShape).optional(),
-        config: fleetConfig.optional(),
-        base: z.string().min(1).optional(),
-      },
-      invoke: (input) => deps.fleetCreate(input as unknown as FleetCreateInput),
-    },
-    {
-      name: "fleet_edit",
-      title: "Edit AFK fleet",
-      description:
-        "MUTATING: update a named fleet profile and send a live resize directive when requested.",
-      inputSchema: {
-        name: z.string().min(1),
-        runner: z.string().min(1).optional(),
-        target: z.number().int().min(0).optional(),
-        selector: z.object(fleetSelectorShape).optional(),
-        config: fleetConfig.optional(),
-        base: z.string().min(1).optional(),
-      },
-      invoke: (input) => deps.fleetEdit(input as unknown as FleetEditInput),
-    },
-    {
-      name: "fleet_stop",
-      title: "Stop AFK fleet",
-      description: "MUTATING: stop one named fleet and its detached workers.",
-      inputSchema: { fleet: z.string().min(1).optional() },
-      invoke: ({ fleet }) =>
-        deps.fleetStop({ name: fleet as string | undefined }),
-    },
-    {
-      name: "logs",
-      title: "Read Castle logs",
-      description:
-        "Return raw CastleLaneRecord entries from one structured lane.",
-      inputSchema: {
-        lane: z.enum(["worker", "supervisor", "monitor", "liveness"]),
-        id: z.string().min(1),
-      },
-      invoke: (input) => deps.logs(input as unknown as LogsInput),
-    },
-    {
-      name: "worker_vitals",
-      title: "Read worker vitals",
-      description: "Return the liveness-qualified state of all local workers.",
-      inputSchema: {},
-      invoke: () => deps.workerVitals(),
-    },
-    {
-      name: "dashboard",
-      title: "Build AFK dashboard",
-      description:
-        "Build the structured operational dashboard from GitHub and local state.",
-      inputSchema: {
-        periodDays: z.number().int().positive().default(30),
-      },
-      invoke: ({ periodDays }) =>
-        deps.dashboard({ periodDays: periodDays as number }),
-    },
-    {
-      name: "monitor",
-      title: "Read AFK monitor",
-      description:
-        "Return the current workers, history events, and fleet monitor inputs.",
-      inputSchema: {},
-      invoke: () => deps.monitor(),
-    },
-    {
-      name: "history",
-      title: "Read Castle history",
-      description:
-        "Return structured Castle history records, newest records last.",
-      inputSchema: {
-        limit: z.number().int().positive().max(10_000).optional(),
-      },
-      invoke: ({ limit }) =>
-        deps.history({ limit: limit as number | undefined }),
-    },
-    {
-      name: "queue_status",
-      title: "Read AFK queues",
-      description:
-        "Return ready-for-agent and ready-for-human queue candidates.",
-      inputSchema: {},
-      invoke: () => deps.queueStatus(),
-    },
-    {
-      name: "worker_dispatch",
-      title: "Dispatch AFK worker",
-      description:
-        "MUTATING: run one tracked issue or mint and run one disposable demand through the AFK worker lifecycle.",
-      inputSchema: dispatchShape,
-      invoke: (input) => deps.workerDispatch(dispatchInput(input)),
-    },
-    {
-      name: "worker_status",
-      title: "Read worker status",
-      description:
-        "Return normalized, liveness-qualified state for one worker or every local worker.",
-      inputSchema: { worker: z.string().min(1).optional() },
-      invoke: ({ worker }) =>
-        deps.workerStatus({ worker: worker as string | undefined }),
-    },
-    {
-      name: "worker_stop",
-      title: "Stop AFK worker",
-      description: "MUTATING: terminate one worker process tree.",
-      inputSchema: { worker: z.string().min(1) },
-      invoke: ({ worker }) =>
-        deps.workerStop({ worker: worker as string, recycle: false }),
-    },
-    {
-      name: "worker_recycle",
-      title: "Recycle AFK worker",
-      description:
-        "MUTATING: terminate one fleet worker so its supervisor can replace the slot.",
-      inputSchema: { worker: z.string().min(1) },
-      invoke: ({ worker }) =>
-        deps.workerStop({ worker: worker as string, recycle: true }),
-    },
-    {
-      name: "runner_list",
-      title: "List AFK runners",
-      description: "Return the canonical runner specification registry.",
-      inputSchema: {},
-      invoke: () => deps.runnerList(),
-    },
-    {
-      name: "runner_detect",
-      title: "Detect AFK runner",
-      description:
-        "Resolve the runner selected by an explicit override or the current host environment.",
-      inputSchema: { runner: z.string().min(1).optional() },
-      invoke: ({ runner }) =>
-        deps.runnerDetect({ runner: runner as string | undefined }),
-    },
-    {
-      name: "runner_steer",
-      title: "Steer live AFK worker",
-      description:
-        "MUTATING: write a live-steer request into a running worker's next iteration.",
-      inputSchema: {
-        worker: z.string().min(1),
-        text: z.string().min(1),
-      },
-      invoke: (input) => deps.runnerSteer(input as unknown as WorkerSteerInput),
-    },
-    {
-      name: "worker_request",
-      title: "Dispatch worker with request",
-      description:
-        "MUTATING: dispatch a new worker and inject a special request into its spawn-time handoff.",
-      inputSchema: {
-        ...dispatchShape,
-        text: z.string().min(1),
-      },
-      invoke: (input) =>
-        deps.workerRequest({
-          ...dispatchInput(input),
-          text: input.text as string,
-        }),
-    },
-    {
-      name: "requeue",
-      title: "Requeue AFK issue",
-      description:
-        "MUTATING: apply the complete parked-issue requeue transition and record human guidance.",
-      inputSchema: {
-        issue: z.number().int().positive(),
-        guidance: z.string().min(1),
-        repo: z.string().min(1).optional(),
-        dryRun: z.boolean().optional(),
-        adoptBranch: z.string().min(1).optional(),
-      },
-      invoke: (input) => deps.requeue(input as unknown as RequeueToolInput),
-    },
-    {
-      name: "retake",
-      title: "Recommend AFK retake",
-      description:
-        "Return the structured issue, PR, branch, worktree, worker-state, and recommended-next-action report.",
-      inputSchema: {
-        issue: z.number().int().positive(),
-        repo: z.string().min(1).optional(),
-        prLimit: z.number().int().positive().max(1_000).optional(),
-      },
-      invoke: (input) => deps.retake(input as unknown as RetakeToolInput),
-    },
-    {
-      name: "reap",
-      title: "Reap AFK branches",
-      description:
-        "MUTATING: classify and delete stale local and remote AFK branches.",
-      inputSchema: {},
-      invoke: () => deps.reap(),
-    },
-    {
-      name: "unblock_sweep",
-      title: "Sweep dependency blocks",
-      description:
-        "MUTATING: promote dependency-blocked issues whose requirements are all closed.",
-      inputSchema: {},
-      invoke: () => deps.unblockSweep(),
-    },
-    {
-      name: "gate_run",
-      title: "Run the AFK gate",
-      description:
-        "MUTATING: materialize the branch's feedback worktree and run the package-scoped validation gate against it.",
-      inputSchema: {
-        branch: z.string().min(1),
-        base: z.string().min(1).optional(),
-      },
-      invoke: (input) => deps.gateRun(input as unknown as GateRunInput),
-    },
-    {
-      name: "gate_baseline_status",
-      title: "Read gate baseline status",
-      description:
-        "Return whether the base branch is tracked-red and the open main-red repair issues that track it.",
-      inputSchema: { base: z.string().min(1).optional() },
-      invoke: ({ base }) =>
-        deps.gateBaselineStatus({ base: base as string | undefined }),
-    },
-    {
-      name: "land_branch",
-      title: "Land AFK branch",
-      description:
-        "MUTATING: land one validated worker branch into its base through the complete landing sequence.",
-      inputSchema: {
-        issue: z.number().int().positive(),
-        branch: z.string().min(1),
-        base: z.string().min(1).optional(),
-        title: z.string().min(1).optional(),
-        openPr: z.boolean().optional(),
-      },
-      invoke: (input) => deps.landBranch(input as unknown as LandBranchInput),
-    },
-    {
-      name: "cascade_status",
-      title: "Read close cascade",
-      description:
-        "Return the dependents of one issue and which of them the close cascade would promote.",
-      inputSchema: { issue: z.number().int().positive() },
-      invoke: ({ issue }) => deps.cascadeStatus({ issue: issue as number }),
-    },
-    {
-      name: "claim_status",
-      title: "Read AFK claim",
-      description:
-        "Return the parsed claim marker records for one issue and the worker currently holding it.",
-      inputSchema: { issue: z.number().int().positive() },
-      invoke: ({ issue }) => deps.claimStatus({ issue: issue as number }),
-    },
-    {
-      name: "claim_release",
-      title: "Release AFK claim",
-      description:
-        "MUTATING: post a concede marker for every un-conceded claim holder so the issue becomes claimable again.",
-      inputSchema: { issue: z.number().int().positive() },
-      invoke: ({ issue }) => deps.claimRelease({ issue: issue as number }),
-    },
-    {
-      name: "worktree_list",
-      title: "List disposable worktrees",
-      description:
-        "Enumerate every checkout under the disposable `.red/tmp/worktrees/*` lanes.",
-      inputSchema: {},
-      invoke: () => deps.worktreeList(),
-    },
-    {
-      name: "worktree_remove",
-      title: "Remove disposable worktree",
-      description:
-        "MUTATING: remove one checkout under the disposable `.red/tmp/worktrees/*` lanes.",
-      inputSchema: { path: z.string().min(1) },
-      invoke: ({ path }) => deps.worktreeRemove({ path: path as string }),
-    },
+    ...createFleetTools(deps),
+    ...createObservabilityTools(deps),
+    ...createWorkerTools(deps),
+    ...createRunnerTools(deps),
+    ...createHygieneTools(deps),
+    ...createGateTools(deps),
+    ...createLandingTools(deps),
+    ...createClaimTools(deps),
+    ...createWorktreeTools(deps),
   ];
 }

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCastleMcpTools,
+  type CastleMcpDependencies,
+} from "./mcp-server.js";
+
+/**
+ * Frozen snapshot of the aggregated dev:afk MCP tool surface.
+ *
+ * Domain modules may be split, merged, or reordered internally; this table is
+ * the contract that the composed surface — order, names, titles, descriptions,
+ * MUTATING prefixes, and input-schema keys — stays byte-identical. Changing an
+ * entry here is a deliberate protocol change, never a refactor side effect.
+ */
+const SURFACE: ReadonlyArray<{
+  name: string;
+  title: string;
+  description: string;
+  schema: string[];
+}> = [
+  {
+    name: "fleet_list",
+    title: "List AFK fleets",
+    description: "List every registered named AFK fleet profile.",
+    schema: [],
+  },
+  {
+    name: "fleet_status",
+    title: "Get AFK fleet status",
+    description:
+      "Return structured supervisor, slots, churn, and live-worker status for a named fleet.",
+    schema: ["fleet"],
+  },
+  {
+    name: "fleet_create",
+    title: "Create AFK fleet",
+    description:
+      "MUTATING: persist a named fleet profile and spawn its supervisor.",
+    schema: ["name", "runner", "target", "selector", "config", "base"],
+  },
+  {
+    name: "fleet_edit",
+    title: "Edit AFK fleet",
+    description:
+      "MUTATING: update a named fleet profile and send a live resize directive when requested.",
+    schema: ["name", "runner", "target", "selector", "config", "base"],
+  },
+  {
+    name: "fleet_stop",
+    title: "Stop AFK fleet",
+    description: "MUTATING: stop one named fleet and its detached workers.",
+    schema: ["fleet"],
+  },
+  {
+    name: "logs",
+    title: "Read Castle logs",
+    description:
+      "Return raw CastleLaneRecord entries from one structured lane.",
+    schema: ["lane", "id"],
+  },
+  {
+    name: "worker_vitals",
+    title: "Read worker vitals",
+    description: "Return the liveness-qualified state of all local workers.",
+    schema: [],
+  },
+  {
+    name: "dashboard",
+    title: "Build AFK dashboard",
+    description:
+      "Build the structured operational dashboard from GitHub and local state.",
+    schema: ["periodDays"],
+  },
+  {
+    name: "monitor",
+    title: "Read AFK monitor",
+    description:
+      "Return the current workers, history events, and fleet monitor inputs.",
+    schema: [],
+  },
+  {
+    name: "history",
+    title: "Read Castle history",
+    description:
+      "Return structured Castle history records, newest records last.",
+    schema: ["limit"],
+  },
+  {
+    name: "queue_status",
+    title: "Read AFK queues",
+    description: "Return ready-for-agent and ready-for-human queue candidates.",
+    schema: [],
+  },
+  {
+    name: "worker_dispatch",
+    title: "Dispatch AFK worker",
+    description:
+      "MUTATING: run one tracked issue or mint and run one disposable demand through the AFK worker lifecycle.",
+    schema: ["issue", "demand", "runner", "mode"],
+  },
+  {
+    name: "worker_status",
+    title: "Read worker status",
+    description:
+      "Return normalized, liveness-qualified state for one worker or every local worker.",
+    schema: ["worker"],
+  },
+  {
+    name: "worker_stop",
+    title: "Stop AFK worker",
+    description: "MUTATING: terminate one worker process tree.",
+    schema: ["worker"],
+  },
+  {
+    name: "worker_recycle",
+    title: "Recycle AFK worker",
+    description:
+      "MUTATING: terminate one fleet worker so its supervisor can replace the slot.",
+    schema: ["worker"],
+  },
+  {
+    name: "runner_list",
+    title: "List AFK runners",
+    description: "Return the canonical runner specification registry.",
+    schema: [],
+  },
+  {
+    name: "runner_detect",
+    title: "Detect AFK runner",
+    description:
+      "Resolve the runner selected by an explicit override or the current host environment.",
+    schema: ["runner"],
+  },
+  {
+    name: "runner_steer",
+    title: "Steer live AFK worker",
+    description:
+      "MUTATING: write a live-steer request into a running worker's next iteration.",
+    schema: ["worker", "text"],
+  },
+  {
+    name: "worker_request",
+    title: "Dispatch worker with request",
+    description:
+      "MUTATING: dispatch a new worker and inject a special request into its spawn-time handoff.",
+    schema: ["issue", "demand", "runner", "mode", "text"],
+  },
+  {
+    name: "requeue",
+    title: "Requeue AFK issue",
+    description:
+      "MUTATING: apply the complete parked-issue requeue transition and record human guidance.",
+    schema: ["issue", "guidance", "repo", "dryRun", "adoptBranch"],
+  },
+  {
+    name: "retake",
+    title: "Recommend AFK retake",
+    description:
+      "Return the structured issue, PR, branch, worktree, worker-state, and recommended-next-action report.",
+    schema: ["issue", "repo", "prLimit"],
+  },
+  {
+    name: "reap",
+    title: "Reap AFK branches",
+    description:
+      "MUTATING: classify and delete stale local and remote AFK branches.",
+    schema: [],
+  },
+  {
+    name: "unblock_sweep",
+    title: "Sweep dependency blocks",
+    description:
+      "MUTATING: promote dependency-blocked issues whose requirements are all closed.",
+    schema: [],
+  },
+  {
+    name: "gate_run",
+    title: "Run the AFK gate",
+    description:
+      "MUTATING: materialize the branch's feedback worktree and run the package-scoped validation gate against it.",
+    schema: ["branch", "base"],
+  },
+  {
+    name: "gate_baseline_status",
+    title: "Read gate baseline status",
+    description:
+      "Return whether the base branch is tracked-red and the open main-red repair issues that track it.",
+    schema: ["base"],
+  },
+  {
+    name: "land_branch",
+    title: "Land AFK branch",
+    description:
+      "MUTATING: land one validated worker branch into its base through the complete landing sequence.",
+    schema: ["issue", "branch", "base", "title", "openPr"],
+  },
+  {
+    name: "cascade_status",
+    title: "Read close cascade",
+    description:
+      "Return the dependents of one issue and which of them the close cascade would promote.",
+    schema: ["issue"],
+  },
+  {
+    name: "claim_status",
+    title: "Read AFK claim",
+    description:
+      "Return the parsed claim marker records for one issue and the worker currently holding it.",
+    schema: ["issue"],
+  },
+  {
+    name: "claim_release",
+    title: "Release AFK claim",
+    description:
+      "MUTATING: post a concede marker for every un-conceded claim holder so the issue becomes claimable again.",
+    schema: ["issue"],
+  },
+  {
+    name: "worktree_list",
+    title: "List disposable worktrees",
+    description:
+      "Enumerate every checkout under the disposable `.red/tmp/worktrees/*` lanes.",
+    schema: [],
+  },
+  {
+    name: "worktree_remove",
+    title: "Remove disposable worktree",
+    description:
+      "MUTATING: remove one checkout under the disposable `.red/tmp/worktrees/*` lanes.",
+    schema: ["path"],
+  },
+];
+
+describe("aggregated dev:afk MCP tool surface", () => {
+  const tools = createCastleMcpTools({} as CastleMcpDependencies);
+
+  it("composes the frozen tool surface in order", () => {
+    expect(
+      tools.map((tool) => ({
+        name: tool.name,
+        title: tool.title,
+        description: tool.description,
+        schema: Object.keys(tool.inputSchema),
+      })),
+    ).toEqual(SURFACE);
+  });
+
+  it("publishes every tool name exactly once", () => {
+    expect(new Set(tools.map((tool) => tool.name)).size).toBe(tools.length);
+  });
+});

--- a/packages/red-castle/src/mcp/claim.ts
+++ b/packages/red-castle/src/mcp/claim.ts
@@ -1,0 +1,32 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface ClaimIssueInput {
+  issue: number;
+}
+
+export interface ClaimDependencies {
+  claimStatus(input: ClaimIssueInput): Promise<unknown>;
+  claimRelease(input: ClaimIssueInput): Promise<unknown>;
+}
+
+export function createClaimTools(deps: ClaimDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "claim_status",
+      title: "Read AFK claim",
+      description:
+        "Return the parsed claim marker records for one issue and the worker currently holding it.",
+      inputSchema: { issue: z.number().int().positive() },
+      invoke: ({ issue }) => deps.claimStatus({ issue: issue as number }),
+    },
+    {
+      name: "claim_release",
+      title: "Release AFK claim",
+      description:
+        "MUTATING: post a concede marker for every un-conceded claim holder so the issue becomes claimable again.",
+      inputSchema: { issue: z.number().int().positive() },
+      invoke: ({ issue }) => deps.claimRelease({ issue: issue as number }),
+    },
+  ];
+}

--- a/packages/red-castle/src/mcp/fleet.ts
+++ b/packages/red-castle/src/mcp/fleet.ts
@@ -1,0 +1,110 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface FleetSelectorInput {
+  spec?: number;
+  lane?: string;
+  label?: string;
+  issues?: number[];
+}
+
+export interface FleetCreateInput {
+  name: string;
+  runner: string;
+  target: number;
+  selector?: FleetSelectorInput;
+  config?: Record<string, string | number | boolean>;
+  base?: string;
+}
+
+export interface FleetEditInput {
+  name: string;
+  runner?: string;
+  target?: number;
+  selector?: FleetSelectorInput;
+  config?: Record<string, string | number | boolean>;
+  base?: string;
+}
+
+export interface FleetNameInput {
+  name?: string;
+}
+
+export interface FleetDependencies {
+  fleetList(): Promise<unknown>;
+  fleetStatus(input: FleetNameInput): Promise<unknown>;
+  fleetCreate(input: FleetCreateInput): Promise<unknown>;
+  fleetEdit(input: FleetEditInput): Promise<unknown>;
+  fleetStop(input: FleetNameInput): Promise<unknown>;
+}
+
+const fleetSelectorShape = {
+  spec: z.number().int().positive().optional(),
+  lane: z.string().min(1).optional(),
+  label: z.string().min(1).optional(),
+  issues: z.array(z.number().int().positive()).optional(),
+};
+
+const fleetConfig = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.boolean()]),
+);
+
+export function createFleetTools(deps: FleetDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "fleet_list",
+      title: "List AFK fleets",
+      description: "List every registered named AFK fleet profile.",
+      inputSchema: {},
+      invoke: () => deps.fleetList(),
+    },
+    {
+      name: "fleet_status",
+      title: "Get AFK fleet status",
+      description:
+        "Return structured supervisor, slots, churn, and live-worker status for a named fleet.",
+      inputSchema: { fleet: z.string().min(1).optional() },
+      invoke: ({ fleet }) =>
+        deps.fleetStatus({ name: fleet as string | undefined }),
+    },
+    {
+      name: "fleet_create",
+      title: "Create AFK fleet",
+      description:
+        "MUTATING: persist a named fleet profile and spawn its supervisor.",
+      inputSchema: {
+        name: z.string().min(1),
+        runner: z.string().min(1),
+        target: z.number().int().min(0).default(2),
+        selector: z.object(fleetSelectorShape).optional(),
+        config: fleetConfig.optional(),
+        base: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.fleetCreate(input as unknown as FleetCreateInput),
+    },
+    {
+      name: "fleet_edit",
+      title: "Edit AFK fleet",
+      description:
+        "MUTATING: update a named fleet profile and send a live resize directive when requested.",
+      inputSchema: {
+        name: z.string().min(1),
+        runner: z.string().min(1).optional(),
+        target: z.number().int().min(0).optional(),
+        selector: z.object(fleetSelectorShape).optional(),
+        config: fleetConfig.optional(),
+        base: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.fleetEdit(input as unknown as FleetEditInput),
+    },
+    {
+      name: "fleet_stop",
+      title: "Stop AFK fleet",
+      description: "MUTATING: stop one named fleet and its detached workers.",
+      inputSchema: { fleet: z.string().min(1).optional() },
+      invoke: ({ fleet }) =>
+        deps.fleetStop({ name: fleet as string | undefined }),
+    },
+  ];
+}

--- a/packages/red-castle/src/mcp/gate.ts
+++ b/packages/red-castle/src/mcp/gate.ts
@@ -1,0 +1,41 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface GateRunInput {
+  branch: string;
+  base?: string;
+}
+
+export interface GateBaselineStatusInput {
+  base?: string;
+}
+
+export interface GateDependencies {
+  gateRun(input: GateRunInput): Promise<unknown>;
+  gateBaselineStatus(input: GateBaselineStatusInput): Promise<unknown>;
+}
+
+export function createGateTools(deps: GateDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "gate_run",
+      title: "Run the AFK gate",
+      description:
+        "MUTATING: materialize the branch's feedback worktree and run the package-scoped validation gate against it.",
+      inputSchema: {
+        branch: z.string().min(1),
+        base: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.gateRun(input as unknown as GateRunInput),
+    },
+    {
+      name: "gate_baseline_status",
+      title: "Read gate baseline status",
+      description:
+        "Return whether the base branch is tracked-red and the open main-red repair issues that track it.",
+      inputSchema: { base: z.string().min(1).optional() },
+      invoke: ({ base }) =>
+        deps.gateBaselineStatus({ base: base as string | undefined }),
+    },
+  ];
+}

--- a/packages/red-castle/src/mcp/hygiene.ts
+++ b/packages/red-castle/src/mcp/hygiene.ts
@@ -1,0 +1,70 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface RequeueToolInput {
+  issue: number;
+  guidance: string;
+  repo?: string;
+  dryRun?: boolean;
+  adoptBranch?: string;
+}
+
+export interface RetakeToolInput {
+  issue: number;
+  repo?: string;
+  prLimit?: number;
+}
+
+export interface HygieneDependencies {
+  requeue(input: RequeueToolInput): Promise<unknown>;
+  retake(input: RetakeToolInput): Promise<unknown>;
+  reap(): Promise<unknown>;
+  unblockSweep(): Promise<unknown>;
+}
+
+export function createHygieneTools(deps: HygieneDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "requeue",
+      title: "Requeue AFK issue",
+      description:
+        "MUTATING: apply the complete parked-issue requeue transition and record human guidance.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        guidance: z.string().min(1),
+        repo: z.string().min(1).optional(),
+        dryRun: z.boolean().optional(),
+        adoptBranch: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.requeue(input as unknown as RequeueToolInput),
+    },
+    {
+      name: "retake",
+      title: "Recommend AFK retake",
+      description:
+        "Return the structured issue, PR, branch, worktree, worker-state, and recommended-next-action report.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        repo: z.string().min(1).optional(),
+        prLimit: z.number().int().positive().max(1_000).optional(),
+      },
+      invoke: (input) => deps.retake(input as unknown as RetakeToolInput),
+    },
+    {
+      name: "reap",
+      title: "Reap AFK branches",
+      description:
+        "MUTATING: classify and delete stale local and remote AFK branches.",
+      inputSchema: {},
+      invoke: () => deps.reap(),
+    },
+    {
+      name: "unblock_sweep",
+      title: "Sweep dependency blocks",
+      description:
+        "MUTATING: promote dependency-blocked issues whose requirements are all closed.",
+      inputSchema: {},
+      invoke: () => deps.unblockSweep(),
+    },
+  ];
+}

--- a/packages/red-castle/src/mcp/landing.ts
+++ b/packages/red-castle/src/mcp/landing.ts
@@ -1,0 +1,46 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface LandBranchInput {
+  issue: number;
+  branch: string;
+  base?: string;
+  title?: string;
+  openPr?: boolean;
+}
+
+export interface CascadeStatusInput {
+  issue: number;
+}
+
+export interface LandingDependencies {
+  landBranch(input: LandBranchInput): Promise<unknown>;
+  cascadeStatus(input: CascadeStatusInput): Promise<unknown>;
+}
+
+export function createLandingTools(deps: LandingDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "land_branch",
+      title: "Land AFK branch",
+      description:
+        "MUTATING: land one validated worker branch into its base through the complete landing sequence.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        branch: z.string().min(1),
+        base: z.string().min(1).optional(),
+        title: z.string().min(1).optional(),
+        openPr: z.boolean().optional(),
+      },
+      invoke: (input) => deps.landBranch(input as unknown as LandBranchInput),
+    },
+    {
+      name: "cascade_status",
+      title: "Read close cascade",
+      description:
+        "Return the dependents of one issue and which of them the close cascade would promote.",
+      inputSchema: { issue: z.number().int().positive() },
+      invoke: ({ issue }) => deps.cascadeStatus({ issue: issue as number }),
+    },
+  ];
+}

--- a/packages/red-castle/src/mcp/observability.ts
+++ b/packages/red-castle/src/mcp/observability.ts
@@ -1,0 +1,79 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface LogsInput {
+  lane: "worker" | "supervisor" | "monitor" | "liveness";
+  id: string;
+}
+
+export interface ObservabilityDependencies {
+  logs(input: LogsInput): Promise<unknown>;
+  workerVitals(): Promise<unknown>;
+  dashboard(input: { periodDays: number }): Promise<unknown>;
+  monitor(): Promise<unknown>;
+  history(input: { limit?: number }): Promise<unknown>;
+  queueStatus(): Promise<unknown>;
+}
+
+export function createObservabilityTools(
+  deps: ObservabilityDependencies,
+): CastleMcpTool[] {
+  return [
+    {
+      name: "logs",
+      title: "Read Castle logs",
+      description:
+        "Return raw CastleLaneRecord entries from one structured lane.",
+      inputSchema: {
+        lane: z.enum(["worker", "supervisor", "monitor", "liveness"]),
+        id: z.string().min(1),
+      },
+      invoke: (input) => deps.logs(input as unknown as LogsInput),
+    },
+    {
+      name: "worker_vitals",
+      title: "Read worker vitals",
+      description: "Return the liveness-qualified state of all local workers.",
+      inputSchema: {},
+      invoke: () => deps.workerVitals(),
+    },
+    {
+      name: "dashboard",
+      title: "Build AFK dashboard",
+      description:
+        "Build the structured operational dashboard from GitHub and local state.",
+      inputSchema: {
+        periodDays: z.number().int().positive().default(30),
+      },
+      invoke: ({ periodDays }) =>
+        deps.dashboard({ periodDays: periodDays as number }),
+    },
+    {
+      name: "monitor",
+      title: "Read AFK monitor",
+      description:
+        "Return the current workers, history events, and fleet monitor inputs.",
+      inputSchema: {},
+      invoke: () => deps.monitor(),
+    },
+    {
+      name: "history",
+      title: "Read Castle history",
+      description:
+        "Return structured Castle history records, newest records last.",
+      inputSchema: {
+        limit: z.number().int().positive().max(10_000).optional(),
+      },
+      invoke: ({ limit }) =>
+        deps.history({ limit: limit as number | undefined }),
+    },
+    {
+      name: "queue_status",
+      title: "Read AFK queues",
+      description:
+        "Return ready-for-agent and ready-for-human queue candidates.",
+      inputSchema: {},
+      invoke: () => deps.queueStatus(),
+    },
+  ];
+}

--- a/packages/red-castle/src/mcp/runner.ts
+++ b/packages/red-castle/src/mcp/runner.ts
@@ -1,0 +1,79 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+import {
+  dispatchInput,
+  dispatchShape,
+  type WorkerDispatchInput,
+} from "./worker.js";
+
+export interface RunnerDetectInput {
+  runner?: string;
+}
+
+export interface WorkerSteerInput {
+  worker: string;
+  text: string;
+}
+
+export interface WorkerRequestInput extends WorkerDispatchInput {
+  text: string;
+}
+
+export interface RunnerDependencies {
+  runnerList(): Promise<unknown>;
+  runnerDetect(input: RunnerDetectInput): Promise<unknown>;
+  runnerSteer(input: WorkerSteerInput): Promise<unknown>;
+  workerRequest(input: WorkerRequestInput): Promise<unknown>;
+}
+
+/**
+ * The runner domain owns runner selection plus the two request-injection
+ * tools — `runner_steer` (into a live worker) and `worker_request` (into a
+ * spawn-time handoff) — which are the same capability at two lifecycle points.
+ */
+export function createRunnerTools(deps: RunnerDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "runner_list",
+      title: "List AFK runners",
+      description: "Return the canonical runner specification registry.",
+      inputSchema: {},
+      invoke: () => deps.runnerList(),
+    },
+    {
+      name: "runner_detect",
+      title: "Detect AFK runner",
+      description:
+        "Resolve the runner selected by an explicit override or the current host environment.",
+      inputSchema: { runner: z.string().min(1).optional() },
+      invoke: ({ runner }) =>
+        deps.runnerDetect({ runner: runner as string | undefined }),
+    },
+    {
+      name: "runner_steer",
+      title: "Steer live AFK worker",
+      description:
+        "MUTATING: write a live-steer request into a running worker's next iteration.",
+      inputSchema: {
+        worker: z.string().min(1),
+        text: z.string().min(1),
+      },
+      invoke: (input) => deps.runnerSteer(input as unknown as WorkerSteerInput),
+    },
+    {
+      name: "worker_request",
+      title: "Dispatch worker with request",
+      description:
+        "MUTATING: dispatch a new worker and inject a special request into its spawn-time handoff.",
+      inputSchema: {
+        ...dispatchShape,
+        text: z.string().min(1),
+      },
+      invoke: (input) =>
+        deps.workerRequest({
+          ...dispatchInput(input),
+          text: input.text as string,
+        }),
+    },
+  ];
+}

--- a/packages/red-castle/src/mcp/tool.ts
+++ b/packages/red-castle/src/mcp/tool.ts
@@ -1,0 +1,13 @@
+import type { z } from "zod/v3";
+
+/**
+ * One published dev:afk MCP tool. A description starting with `MUTATING:` is
+ * the declared mutation mode — the client docs contract reads that prefix.
+ */
+export interface CastleMcpTool {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: Record<string, z.ZodType>;
+  invoke(input: Record<string, unknown>): Promise<unknown>;
+}

--- a/packages/red-castle/src/mcp/worker.ts
+++ b/packages/red-castle/src/mcp/worker.ts
@@ -1,0 +1,84 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface WorkerDispatchInput {
+  issue?: number;
+  demand?: string;
+  runner?: string;
+  mode?: "no-mistakes" | "direct-PR" | "local-only";
+}
+
+export interface WorkerStatusInput {
+  worker?: string;
+}
+
+export interface WorkerStopInput {
+  worker: string;
+  recycle: boolean;
+}
+
+export interface WorkerDependencies {
+  workerDispatch(input: WorkerDispatchInput): Promise<unknown>;
+  workerStatus(input: WorkerStatusInput): Promise<unknown>;
+  workerStop(input: WorkerStopInput): Promise<unknown>;
+}
+
+/** Shared by `worker_dispatch` and the runner domain's `worker_request`. */
+export const dispatchShape = {
+  issue: z.number().int().positive().optional(),
+  demand: z.string().min(1).optional(),
+  runner: z.string().min(1).optional(),
+  mode: z.enum(["no-mistakes", "direct-PR", "local-only"]).optional(),
+};
+
+export function dispatchInput(
+  input: Record<string, unknown>,
+): WorkerDispatchInput {
+  const value = input as unknown as WorkerDispatchInput;
+  if ((value.issue === undefined) === (value.demand === undefined)) {
+    throw new Error("exactly one of issue or demand is required");
+  }
+  if (value.issue !== undefined && value.mode !== undefined) {
+    throw new Error("mode is only valid for demand dispatches");
+  }
+  return value;
+}
+
+export function createWorkerTools(deps: WorkerDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "worker_dispatch",
+      title: "Dispatch AFK worker",
+      description:
+        "MUTATING: run one tracked issue or mint and run one disposable demand through the AFK worker lifecycle.",
+      inputSchema: dispatchShape,
+      invoke: (input) => deps.workerDispatch(dispatchInput(input)),
+    },
+    {
+      name: "worker_status",
+      title: "Read worker status",
+      description:
+        "Return normalized, liveness-qualified state for one worker or every local worker.",
+      inputSchema: { worker: z.string().min(1).optional() },
+      invoke: ({ worker }) =>
+        deps.workerStatus({ worker: worker as string | undefined }),
+    },
+    {
+      name: "worker_stop",
+      title: "Stop AFK worker",
+      description: "MUTATING: terminate one worker process tree.",
+      inputSchema: { worker: z.string().min(1) },
+      invoke: ({ worker }) =>
+        deps.workerStop({ worker: worker as string, recycle: false }),
+    },
+    {
+      name: "worker_recycle",
+      title: "Recycle AFK worker",
+      description:
+        "MUTATING: terminate one fleet worker so its supervisor can replace the slot.",
+      inputSchema: { worker: z.string().min(1) },
+      invoke: ({ worker }) =>
+        deps.workerStop({ worker: worker as string, recycle: true }),
+    },
+  ];
+}

--- a/packages/red-castle/src/mcp/worktree.ts
+++ b/packages/red-castle/src/mcp/worktree.ts
@@ -1,0 +1,34 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface WorktreeRemoveInput {
+  path: string;
+}
+
+export interface WorktreeDependencies {
+  worktreeList(): Promise<unknown>;
+  worktreeRemove(input: WorktreeRemoveInput): Promise<unknown>;
+}
+
+export function createWorktreeTools(
+  deps: WorktreeDependencies,
+): CastleMcpTool[] {
+  return [
+    {
+      name: "worktree_list",
+      title: "List disposable worktrees",
+      description:
+        "Enumerate every checkout under the disposable `.red/tmp/worktrees/*` lanes.",
+      inputSchema: {},
+      invoke: () => deps.worktreeList(),
+    },
+    {
+      name: "worktree_remove",
+      title: "Remove disposable worktree",
+      description:
+        "MUTATING: remove one checkout under the disposable `.red/tmp/worktrees/*` lanes.",
+      inputSchema: { path: z.string().min(1) },
+      invoke: ({ path }) => deps.worktreeRemove({ path: path as string }),
+    },
+  ];
+}


### PR DESCRIPTION
Automated AFK landing for #2330. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2330

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787231501&installation_model_id=20659&pr_number=2348&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2348&signature=55ba03fb15cb8534e8e1b5a7d9d105739e817083ed711aaa67c43a6424a8eed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->