### PR TITLE
hotfix(config): disable adversarial review (claude runner cannot run the pinned codex reviewer model; advisory failure kills landing)

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -35,7 +35,13 @@ plugins:
     #   so the worst case is one extra correction round and the PR still lands.
     #   Raising max_iterations to 2+ enables parking to ready-for-human.
     review:
-      enabled: true
+      # TEMPORARILY disabled (2026-07-21): the reviewer pass invokes the
+      # claude-code CLI with the codex model pinned below (gpt-5.6-sol), which
+      # claude cannot run — the "advisory" pass then exits 1 and KILLS every
+      # claude worker after push, before landing (fleet-wide landing outage;
+      # three stranded branches adopted by hand). Re-enable when the fix for
+      # the advisory-fatality + per-runner reviewer-model resolution lands.
+      enabled: false
       max_iterations: 1
       reviewer_count: 1
       quorum: any


### PR DESCRIPTION
Kill-switch: `dev.review.enabled: false` with an inline comment explaining why.

The adversarial reviewer (ADR 0110) is pinned to `model: gpt-5.6-sol` in `.red/config.yaml`, but the pass is executed through the **claude-code** CLI under the claude fleet runner — claude cannot run a codex model, the CLI exits 1, and the *advisory* pass kills the worker AFTER the exit-barrier push and BEFORE landing. Every claude worker dies at landing: three completed branches stranded this hour (#2330 adopted+merged by hand, #2340 and #2291 adoption in flight).

Re-enable when the code fix lands (advisory must never be fatal + reviewer model resolved per runner).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787231872&installation_model_id=20659&pr_number=2349&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2349&signature=20aea87fab0e4a7ababb0d02b373d7f363e00a3c6694ea3c89ff512e556f8fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->