### PR TITLE
fix(release): contract-test bare remote HEAD must name main (runner has no init.defaultBranch)

### DIFF
--- a/scripts/test-red-release-bump-push-contract.sh
+++ b/scripts/test-red-release-bump-push-contract.sh
@@ -73,6 +73,12 @@ seed_repo() {
   local remote="$TMP/$name-remote.git" work="$TMP/$name"
   rm -rf "$remote" "$work"
   git init -q --bare "$remote"
+  # The bare remote's HEAD must name main explicitly: on a runner with no
+  # init.defaultBranch the bare init points HEAD at master, so a later clone
+  # of this remote checks out nothing and its pushes fail with
+  # "src refspec main does not match any" (first seen killing the release
+  # workflow itself, 2026-07-21).
+  git -C "$remote" symbolic-ref HEAD refs/heads/main
   git init -q -b main "$work"
   git -C "$work" config user.email release@example.test
   git -C "$work" config user.name 'release bot'


### PR DESCRIPTION
The red-release self-test ("bump push contract") seeds a bare remote with plain `git init --bare`: on the CI runner (no `init.defaultBranch`) the bare HEAD points at `master` while the seeded branch is `main`, so the race scenario's clone checks out nothing and its `push origin main` dies with `src refspec main does not match any` — killing the whole release run (run 29834899978, the first real execution of the test #2313 introduced). Fix: `symbolic-ref HEAD refs/heads/main` on the bare remote. Verified locally under a stripped git config (`GIT_CONFIG_GLOBAL=/dev/null`): all contract checks pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787232891&installation_model_id=20659&pr_number=2353&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2353&signature=63a119c49fd3993c4b0c314a0988b962e20a965a2f7c481b7c67467ffd79d139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->