### PR TITLE
chore(release): v2.77.1 manifest bump (parked by the GH006 fallback)

### DIFF
--- a/apps/benchmark-code-understanding/package.json
+++ b/apps/benchmark-code-understanding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/benchmark-code-understanding",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "description": "Internal A/B benchmark for RedSkills code understanding against CodeGraph and native agent search.",
   "license": "Apache-2.0",

--- a/apps/benchmark-memory/package.json
+++ b/apps/benchmark-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/benchmark-memory",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "description": "Internal benchmark and reference-eval app for RedSkills Memory.",
   "license": "Apache-2.0",

--- a/apps/brain/package.json
+++ b/apps/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/brain",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "description": "reddb.io brain plugin — project-local RedDB knowledge repository for freeform captures and graph connections.",
   "license": "Apache-2.0",

--- a/apps/code-nav/package.json
+++ b/apps/code-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/code-nav-mcp",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "description": "LSP-backed code navigation as an MCP server: symbol-level goto-definition, find-references, document/workspace symbols and hover for code agents.",
   "license": "Apache-2.0",

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/dev",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "description": "RedSkills dev plugin implementation — the AFK TypeScript runtime (typed CLI, state-machine modules, sandcastle execution) under apps/dev. Built to dist/dev.bundle.min.mjs (ADR 0034, relocated by ADR 0060).",
   "license": "Apache-2.0",

--- a/apps/memory/package.json
+++ b/apps/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/memory",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "description": "reddb.io memory plugin — governed operational memory for code agents: markdown notes, RedDB graph memory, governed recall, lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "license": "Apache-2.0",

--- a/apps/opencode-host/package.json
+++ b/apps/opencode-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "description": "RedSkills opencode-host — the adapter layer that emits opencode.json (provider, model, mcp, plugins) from the canonical .red/config.yaml + ADR 0059 env-precedence rule. Slice 1: provider block only.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-skills",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.5.0",

--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/build-info",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "type": "module",
   "description": "Shared runtime build metadata helpers for RedSkills bundled apps.",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/shared",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "type": "module",
   "description": "Code shared across RedSkills runtime apps (ADR 0034): CLI arg parsing over cli-args-parser, and the dynamic plugin-bundle fetch.",

--- a/packaging/pi/brain/package.json
+++ b/packaging/pi/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-brain",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/reddb-io/red-skills",

--- a/packaging/pi/dev/package.json
+++ b/packaging/pi/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-dev",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/reddb-io/red-skills",

--- a/packaging/pi/memory/package.json
+++ b/packaging/pi/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-memory",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/reddb-io/red-skills",

--- a/plugins/brain/.claude-plugin/plugin.json
+++ b/plugins/brain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brain",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "description": "reddb.io brain plugin — project-local RedDB knowledge repository for freeform captures and graph connections.",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/claude.hooks.json",

--- a/plugins/brain/.codex-plugin/plugin.json
+++ b/plugins/brain/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brain",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "author": {
     "name": "reddb.io",

--- a/plugins/brain/package.json
+++ b/plugins/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-brain",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "license": "Apache-2.0",

--- a/plugins/dev/.claude-plugin/plugin.json
+++ b/plugins/dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "description": "reddb.io dev plugin — engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, …)",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/claude.hooks.json",

--- a/plugins/dev/.codex-plugin/plugin.json
+++ b/plugins/dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "author": {
     "name": "reddb.io",

--- a/plugins/dev/package.json
+++ b/plugins/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-dev",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "license": "Apache-2.0",

--- a/plugins/memory/.claude-plugin/plugin.json
+++ b/plugins/memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "description": "reddb.io memory plugin — governed operational memory for code agents that lives on top of `dev`. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "dependencies": [
     "dev"

--- a/plugins/memory/.codex-plugin/plugin.json
+++ b/plugins/memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "author": {
     "name": "reddb.io",

--- a/plugins/memory/package.json
+++ b/plugins/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-memory",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "private": true,
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Lands the v2.77.1 version bump across package.json + plugin/marketplace manifests (rebased onto main, version conflicts resolved to 2.77.1, Pi packages restaged). Until this lands, `/plugin` resolves dev at 2.77.0 and the dev:afk MCP is absent from installed sessions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787234394&installation_model_id=20659&pr_number=2357&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2357&signature=f0d0d6a9df1d601f674444caead4647cf5eb9905cbcdad7223d8d8b2f142b617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->