### PR TITLE
fix: #2292 Manager S2: effort lease + five-state lifecycle

### DIFF
--- a/apps/dev/src/commands/manager.ts
+++ b/apps/dev/src/commands/manager.ts
@@ -1,14 +1,14 @@
 // commands/manager.ts — the operator front door of the Manager (Spec #2290,
-// slice #2291; architecture in ADR 0109).
+// slices #2291, #2292; architecture in ADR 0109).
 //
-// Two shapes, matching the walking skeleton's acceptance:
-//   `manager <intent>`  — mint an effort from the intent and persist it.
-//   `manager status [id]` — render the brief for one effort (the most recently
-//                           started one by default) from OWNED state.
+// Four shapes:
+//   `manager <intent>`         — mint an effort from the intent and persist it.
+//   `manager status [id]`      — render the brief for one effort (newest by default).
+//   `manager resume [id]`      — transition inbox/paused effort → active, acquire lease.
+//   `manager end [id]`         — transition active effort → completed, release lease.
 //
-// The command is conversation-first, not a subcommand tree: anything that is
-// not a lifecycle operation IS the intent. Routing, dispatch, and reconciliation
-// are later slices — this one only proves an effort survives the session.
+// The command is conversation-first: anything that is not a lifecycle keyword IS
+// the intent. Routing, dispatch, and reconciliation are later slices.
 
 import { homedir } from "node:os";
 import { resolveManagerRoot } from "@reddb-io/shared/red-paths.js";
@@ -19,6 +19,7 @@ import {
   readEffort,
   startEffort,
 } from "../core/manager/effort-store.js";
+import { endEffort, manageEffort } from "../core/manager/effort-lease.js";
 
 export interface ManagerCommandDeps {
   /** The directory that CONTAINS `.red/manager`; defaults to the operator home. */
@@ -26,15 +27,38 @@ export interface ManagerCommandDeps {
   stdout?: (text: string) => void;
   stderr?: (text: string) => void;
   now?: () => Date;
+  /** Injected host name, so tests can pin it without touching `os.hostname()`. */
+  host?: string;
 }
 
 const USAGE = [
   "usage: afk manager <intent>          start an effort from an intent",
   "       afk manager status [effort]   render an effort brief (default: the newest)",
+  "       afk manager resume [effort]   transition an effort to active and acquire the lease",
+  "       afk manager end [effort]      transition an active effort to completed",
 ].join("\n");
+
+const LIFECYCLE_WORDS = new Set(["status", "resume", "end"]);
 
 function resolveRoot(deps: ManagerCommandDeps): string {
   return deps.root ?? resolveManagerRoot({ homeDir: homedir(), env: process.env });
+}
+
+async function resolveEffort(
+  effortId: string | undefined,
+  root: string,
+  fail: (text: string) => void,
+) {
+  const effort = effortId ? await readEffort(root, effortId) : await latestEffort(root);
+  if (!effort) {
+    if (effortId) {
+      fail(`[manager] no effort ${effortId} in this portfolio\n`);
+    } else {
+      fail("[manager] no effort in this portfolio; start one with: afk manager <intent>\n");
+    }
+    return null;
+  }
+  return effort;
 }
 
 async function statusCommand(
@@ -56,6 +80,37 @@ async function statusCommand(
   return 0;
 }
 
+async function resumeCommand(
+  effortId: string | undefined,
+  root: string,
+  write: (text: string) => void,
+  fail: (text: string) => void,
+  deps: ManagerCommandDeps,
+): Promise<number> {
+  const effort = await resolveEffort(effortId, root, fail);
+  if (!effort) return 1;
+  const { effort: managed } = await manageEffort(root, effort, {
+    now: deps.now,
+    host: deps.host,
+  });
+  write(`${renderEffortBrief(managed)}\n`);
+  return 0;
+}
+
+async function endCommand(
+  effortId: string | undefined,
+  root: string,
+  write: (text: string) => void,
+  fail: (text: string) => void,
+  deps: ManagerCommandDeps,
+): Promise<number> {
+  const effort = await resolveEffort(effortId, root, fail);
+  if (!effort) return 1;
+  const completed = await endEffort(root, effort, { now: deps.now });
+  write(`${renderEffortBrief(completed)}\n`);
+  return 0;
+}
+
 export async function managerCommand(
   args: readonly string[],
   deps: ManagerCommandDeps = {},
@@ -71,6 +126,13 @@ export async function managerCommand(
   const root = resolveRoot(deps);
   try {
     if (words[0] === "status") return await statusCommand(words[1], root, write, fail);
+    if (words[0] === "resume") return await resumeCommand(words[1], root, write, fail, deps);
+    if (words[0] === "end") return await endCommand(words[1], root, write, fail, deps);
+    // Anything that is not a known lifecycle keyword is the intent.
+    if (LIFECYCLE_WORDS.has(words[0])) {
+      fail(`[manager] unknown subcommand "${words[0]}"\n`);
+      return 1;
+    }
     const effort = await startEffort({ root, intent: words.join(" "), now: deps.now });
     write(`${renderEffortBrief(effort)}\n`);
     return 0;

--- a/apps/dev/src/core/manager/effort-lease.ts
+++ b/apps/dev/src/core/manager/effort-lease.ts
@@ -1,0 +1,258 @@
+// core/manager/effort-lease.ts — per-effort writer lease (Spec #2290, slice #2292).
+//
+// One lease, one file: `<manager root>/.red/manager/leases/<effort-id>.toonl`.
+// The lease records which host+session currently holds the write cursor for an
+// effort. Acquire on manage (start or resume), release on end. No daemon — the
+// only crash recovery is TTL expiry: a stale lease is reclaimed by the next
+// session with a generation bump, so a resurrected old writer fails closed on
+// its next saveEffort call (its generation no longer matches the stored one).
+//
+// Generation semantics:
+//   The lease records the effort's generation at acquisition time. On a stale
+//   reclaim the reclaimer saves the effort first (bumping generation N → N+1),
+//   then writes the lease at N+1. The old writer still holds generation N and
+//   receives ManagerGenerationError on its next saveEffort — this is the
+//   "fails closed" guarantee.
+//
+// Lifecycle transitions:
+//   manageEffort — inbox | paused → active (+ acquire/reclaim lease)
+//   endEffort    — active → completed (+ release lease)
+
+import { randomBytes } from "node:crypto";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { hostname } from "node:os";
+import { managerLeaseFile } from "@reddb-io/shared/red-paths.js";
+import { encodeRecords, parseRecords, type ToonlRecord } from "@reddb-io/toon";
+import {
+  ManagerSchemaError,
+  ManagerStoreError,
+  saveEffort,
+  type EffortRecord,
+  type EffortLifecycle,
+} from "./effort-store.js";
+
+export const MANAGER_LEASE_SCHEMA = "red.manager.lease";
+export const MANAGER_LEASE_SCHEMA_VERSION = 1;
+
+/** Default lease TTL: 1 hour. With no daemon, recovery is purely TTL-based. */
+export const LEASE_DEFAULT_TTL_MS = 60 * 60 * 1000;
+
+export interface EffortLease {
+  effort_id: string;
+  /** The hostname that holds the write cursor. */
+  host: string;
+  /** Matches the effort's generation at acquisition time. */
+  generation: number;
+  acquired_at: string;
+  /** Lease expires at this instant; after which any session may reclaim it. */
+  expires_at: string;
+}
+
+/** Raised when a live lease is held by a different host. */
+export class ManagerLeaseConflictError extends ManagerStoreError {}
+
+/** Raised when a lifecycle transition is not valid from the current state. */
+export class ManagerLifecycleError extends ManagerStoreError {}
+
+/** True when the lease's TTL has lapsed. */
+export function isLeaseExpired(lease: EffortLease, now = new Date()): boolean {
+  return new Date(lease.expires_at) <= now;
+}
+
+// ── Lease document encoding ────────────────────────────────────────────────
+
+export function encodeLeaseDocument(lease: EffortLease): string {
+  const header: ToonlRecord = {
+    kind: "manager.lease.schema",
+    schema: MANAGER_LEASE_SCHEMA,
+    version: MANAGER_LEASE_SCHEMA_VERSION,
+  };
+  const body: ToonlRecord = { kind: "manager.lease", ...lease };
+  return encodeRecords([header, body]);
+}
+
+function requireString(row: ToonlRecord, field: string): string {
+  const value = row[field];
+  if (typeof value !== "string" || value === "") {
+    throw new ManagerSchemaError(`manager lease document is missing "${field}"`);
+  }
+  return value;
+}
+
+export function decodeLeaseDocument(text: string): EffortLease {
+  let rows: ToonlRecord[];
+  try {
+    rows = parseRecords(text);
+  } catch (error) {
+    throw new ManagerSchemaError(
+      `manager lease document is not readable TOONL: ${(error as Error).message}`,
+    );
+  }
+  const header = rows.find((row) => row.kind === "manager.lease.schema");
+  if (!header) throw new ManagerSchemaError("manager lease document has no schema header");
+  if (header.schema !== MANAGER_LEASE_SCHEMA) {
+    throw new ManagerSchemaError(`manager lease document has foreign schema "${header.schema}"`);
+  }
+  if (header.version !== MANAGER_LEASE_SCHEMA_VERSION) {
+    throw new ManagerSchemaError(
+      `manager lease document has schema version ${String(header.version)}, this bundle owns ${MANAGER_LEASE_SCHEMA_VERSION}`,
+    );
+  }
+  const body = rows.find((row) => row.kind === "manager.lease");
+  if (!body) throw new ManagerSchemaError("manager lease document has no lease record");
+  const generation = body.generation;
+  if (typeof generation !== "number" || !Number.isInteger(generation) || generation < 1) {
+    throw new ManagerSchemaError("manager lease document has a non-integer generation");
+  }
+  return {
+    effort_id: requireString(body, "effort_id"),
+    host: requireString(body, "host"),
+    generation,
+    acquired_at: requireString(body, "acquired_at"),
+    expires_at: requireString(body, "expires_at"),
+  };
+}
+
+async function writeLeaseAtomic(path: string, lease: EffortLease): Promise<void> {
+  const document = encodeLeaseDocument(lease);
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
+  try {
+    await writeFile(tmp, document, "utf8");
+    await rename(tmp, path);
+  } catch (error) {
+    await unlink(tmp).catch(() => undefined);
+    throw error;
+  }
+}
+
+// ── Lease I/O ──────────────────────────────────────────────────────────────
+
+/** Read the lease for an effort, or `null` when none exists. */
+export async function readLease(root: string, effortId: string): Promise<EffortLease | null> {
+  let text: string;
+  try {
+    text = await readFile(managerLeaseFile(root, effortId), "utf8");
+  } catch {
+    return null;
+  }
+  return decodeLeaseDocument(text);
+}
+
+/** Delete the lease file. Called on `end`; idempotent. */
+export async function releaseLease(root: string, effortId: string): Promise<void> {
+  try {
+    await unlink(managerLeaseFile(root, effortId));
+  } catch {
+    // Already released or never written — idempotent.
+  }
+}
+
+// ── Lifecycle transitions ──────────────────────────────────────────────────
+
+const RESUMABLE: readonly EffortLifecycle[] = ["inbox", "paused"];
+const TERMINAL: readonly EffortLifecycle[] = ["completed", "abandoned"];
+
+export interface ManageEffortOptions {
+  now?: () => Date;
+  ttlMs?: number;
+  host?: string;
+}
+
+/**
+ * Transition an effort to `active` and acquire (or reclaim) its lease.
+ *
+ * Fresh-acquire (no existing lease): valid from `inbox`, `paused`. Transitions
+ * lifecycle → active and writes the lease at the new generation.
+ *
+ * Stale-reclaim (lease exists and is TTL-expired): valid from any non-terminal
+ * state. The effort may already be `active` (crashed session left it there).
+ * Saves the effort — bumping the generation — and writes the lease at the new
+ * generation, so a resurrected old writer receives ManagerGenerationError on
+ * its next saveEffort call.
+ *
+ * Live lease held by a different host → fail closed (ManagerLeaseConflictError).
+ */
+export async function manageEffort(
+  root: string,
+  effort: EffortRecord,
+  options: ManageEffortOptions = {},
+): Promise<{ effort: EffortRecord; lease: EffortLease }> {
+  const nowFn = options.now ?? (() => new Date());
+  const now = nowFn();
+  const ttlMs = options.ttlMs ?? LEASE_DEFAULT_TTL_MS;
+  const host = options.host ?? hostname();
+
+  // Read the existing lease BEFORE any mutation; fail closed against a live foreign lease.
+  const existingLease = await readLease(root, effort.effort_id);
+  const leaseIsLive = existingLease !== null && !isLeaseExpired(existingLease, now);
+  const isReclaim = existingLease !== null && isLeaseExpired(existingLease, now);
+
+  if (leaseIsLive && existingLease!.host !== host) {
+    throw new ManagerLeaseConflictError(
+      `effort ${effort.effort_id} lease held by ${existingLease!.host}; expires ${existingLease!.expires_at}`,
+    );
+  }
+
+  // Lifecycle guard: fresh-acquire requires inbox/paused; reclaim allows non-terminal.
+  if (isReclaim) {
+    if (TERMINAL.includes(effort.lifecycle)) {
+      throw new ManagerLifecycleError(
+        `cannot reclaim lease for a ${effort.lifecycle} effort ${effort.effort_id}`,
+      );
+    }
+  } else {
+    if (!RESUMABLE.includes(effort.lifecycle)) {
+      throw new ManagerLifecycleError(
+        `cannot manage (resume) an effort in "${effort.lifecycle}" state; valid from: ${RESUMABLE.join(", ")}`,
+      );
+    }
+  }
+
+  // Target lifecycle: transition if coming from inbox/paused; keep as-is otherwise (reclaim).
+  const targetLifecycle: EffortLifecycle =
+    effort.lifecycle === "inbox" || effort.lifecycle === "paused" ? "active" : effort.lifecycle;
+
+  // Save the effort (bumps generation), then write the lease.
+  const saved = await saveEffort(root, { ...effort, lifecycle: targetLifecycle }, { now: () => now });
+
+  const lease: EffortLease = {
+    effort_id: saved.effort_id,
+    host,
+    generation: saved.generation,
+    acquired_at: now.toISOString(),
+    expires_at: new Date(now.getTime() + ttlMs).toISOString(),
+  };
+  await writeLeaseAtomic(managerLeaseFile(root, saved.effort_id), lease);
+
+  return { effort: saved, lease };
+}
+
+export interface EndEffortOptions {
+  now?: () => Date;
+}
+
+/**
+ * Transition an effort from `active` to `completed` and release its lease.
+ *
+ * Valid from: `active`.
+ *
+ * The lease is deleted after the effort is saved; `releaseLease` is idempotent
+ * so a missing lease file does not cause an error.
+ */
+export async function endEffort(
+  root: string,
+  effort: EffortRecord,
+  options: EndEffortOptions = {},
+): Promise<EffortRecord> {
+  if (effort.lifecycle !== "active") {
+    throw new ManagerLifecycleError(
+      `cannot end an effort in "${effort.lifecycle}" state; valid from: active`,
+    );
+  }
+  const now = (options.now ?? (() => new Date()))();
+  const completed = await saveEffort(root, { ...effort, lifecycle: "completed" }, { now: () => now });
+  await releaseLease(root, completed.effort_id);
+  return completed;
+}

--- a/apps/dev/tests/manager-command.test.ts
+++ b/apps/dev/tests/manager-command.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { parseCli } from "../src/cli.js";
 import { managerCommand } from "../src/commands/manager.js";
 import { readEffort } from "../src/core/manager/effort-store.js";
+import { readLease } from "../src/core/manager/effort-lease.js";
 
 let root: string;
 let out: string[];
@@ -94,6 +95,105 @@ describe("manager status", () => {
   });
 });
 
+describe("manager resume", () => {
+  it("transitions an effort to active and prints its brief", async () => {
+    await managerCommand(["start this effort"], deps());
+    const started = brief();
+    expect(started.lifecycle).toBe("inbox");
+    out = [];
+
+    expect(await managerCommand(["resume", String(started.effort_id)], deps())).toBe(0);
+    const resumed = brief();
+    expect(resumed.lifecycle).toBe("active");
+    expect(resumed.effort_id).toBe(started.effort_id);
+  });
+
+  it("resumes the most recently started effort when no id is given", async () => {
+    await managerCommand(["the latest effort"], deps());
+    out = [];
+
+    expect(await managerCommand(["resume"], deps())).toBe(0);
+    expect(brief().lifecycle).toBe("active");
+  });
+
+  it("acquires a lease visible via readLease", async () => {
+    await managerCommand(["leased effort"], deps());
+    const started = brief();
+    out = [];
+
+    await managerCommand(["resume", String(started.effort_id)], { ...deps(), host: "test-host" });
+    const lease = await readLease(root, String(started.effort_id));
+    expect(lease).not.toBeNull();
+    expect(lease?.host).toBe("test-host");
+  });
+
+  it("reports an error when no portfolio exists", async () => {
+    expect(await managerCommand(["resume"], deps())).toBe(1);
+    expect(err.join("")).toMatch(/no effort/i);
+  });
+
+  it("reports a lifecycle error when the effort cannot be resumed", async () => {
+    await managerCommand(["already done"], deps());
+    const started = brief();
+    out = [];
+    // End it
+    await managerCommand(["resume", String(started.effort_id)], deps());
+    out = [];
+    await managerCommand(["end", String(started.effort_id)], deps());
+    out = [];
+    // Try to resume a completed effort
+    expect(await managerCommand(["resume", String(started.effort_id)], deps())).toBe(1);
+    expect(err.join("")).toMatch(/\[manager\]/);
+  });
+});
+
+describe("manager end", () => {
+  it("transitions an active effort to completed and prints its brief", async () => {
+    await managerCommand(["finish this effort"], deps());
+    const started = brief();
+    out = [];
+    await managerCommand(["resume", String(started.effort_id)], deps());
+    out = [];
+
+    expect(await managerCommand(["end", String(started.effort_id)], deps())).toBe(0);
+    const ended = brief();
+    expect(ended.lifecycle).toBe("completed");
+    expect(ended.effort_id).toBe(started.effort_id);
+
+    const stored = await readEffort(root, String(started.effort_id));
+    expect(stored?.lifecycle).toBe("completed");
+  });
+
+  it("releases the lease on end", async () => {
+    await managerCommand(["releaseme"], deps());
+    const started = brief();
+    out = [];
+    await managerCommand(["resume", String(started.effort_id)], { ...deps(), host: "h1" });
+    out = [];
+
+    const leaseBefore = await readLease(root, String(started.effort_id));
+    expect(leaseBefore).not.toBeNull();
+
+    await managerCommand(["end", String(started.effort_id)], deps());
+    const leaseAfter = await readLease(root, String(started.effort_id));
+    expect(leaseAfter).toBeNull();
+  });
+
+  it("reports an error when no portfolio exists", async () => {
+    expect(await managerCommand(["end"], deps())).toBe(1);
+    expect(err.join("")).toMatch(/no effort/i);
+  });
+
+  it("reports a lifecycle error when the effort is not active", async () => {
+    await managerCommand(["not active"], deps());
+    const started = brief();
+    out = [];
+    // Effort is in inbox, not active — end should fail
+    expect(await managerCommand(["end", String(started.effort_id)], deps())).toBe(1);
+    expect(err.join("")).toMatch(/\[manager\]/);
+  });
+});
+
 describe("cli routing", () => {
   it("routes manager with its intent preserved", () => {
     expect(parseCli(["manager", "ship", "the", "skeleton"])).toEqual({
@@ -101,5 +201,7 @@ describe("cli routing", () => {
       args: ["ship", "the", "skeleton"],
     });
     expect(parseCli(["manager", "status"])).toEqual({ command: "manager", args: ["status"] });
+    expect(parseCli(["manager", "resume"])).toEqual({ command: "manager", args: ["resume"] });
+    expect(parseCli(["manager", "end"])).toEqual({ command: "manager", args: ["end"] });
   });
 });

--- a/apps/dev/tests/manager-effort-lease.test.ts
+++ b/apps/dev/tests/manager-effort-lease.test.ts
@@ -1,0 +1,262 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MANAGER_LEASE_SCHEMA,
+  MANAGER_LEASE_SCHEMA_VERSION,
+  LEASE_DEFAULT_TTL_MS,
+  ManagerLeaseConflictError,
+  ManagerLifecycleError,
+  decodeLeaseDocument,
+  encodeLeaseDocument,
+  isLeaseExpired,
+  readLease,
+  releaseLease,
+  manageEffort,
+  endEffort,
+  type EffortLease,
+} from "../src/core/manager/effort-lease.js";
+import {
+  ManagerGenerationError,
+  readEffort,
+  startEffort,
+  type EffortRecord,
+} from "../src/core/manager/effort-store.js";
+import { encodeRecords, parseRecords } from "@reddb-io/toon";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "manager-lease-"));
+});
+
+afterEach(() => {
+  root = "";
+});
+
+// ── Lease document encoding ────────────────────────────────────────────────
+
+describe("lease document", () => {
+  const lease: EffortLease = {
+    effort_id: "eff_abcdefghijklmnopqrstuvwxyz",
+    host: "builder-1",
+    generation: 1,
+    acquired_at: "2026-07-21T00:00:00.000Z",
+    expires_at: "2026-07-21T01:00:00.000Z",
+  };
+
+  it("writes a versioned schema header ahead of the lease row", () => {
+    const records = parseRecords(encodeLeaseDocument(lease));
+    expect(records[0]).toMatchObject({
+      kind: "manager.lease.schema",
+      schema: MANAGER_LEASE_SCHEMA,
+      version: MANAGER_LEASE_SCHEMA_VERSION,
+    });
+    expect(records[1]).toMatchObject({ kind: "manager.lease", effort_id: lease.effort_id });
+  });
+
+  it("round-trips through the lease encoding", () => {
+    expect(decodeLeaseDocument(encodeLeaseDocument(lease))).toEqual(lease);
+  });
+
+  it("refuses a document whose schema version is not the one this bundle owns", () => {
+    const foreign = encodeRecords([
+      { kind: "manager.lease.schema", schema: MANAGER_LEASE_SCHEMA, version: 99 },
+      { kind: "manager.lease", ...lease },
+    ]);
+    expect(() => decodeLeaseDocument(foreign)).toThrow(/schema version/);
+  });
+});
+
+// ── isLeaseExpired ─────────────────────────────────────────────────────────
+
+describe("isLeaseExpired", () => {
+  it("returns false when the lease expires in the future", () => {
+    const lease: EffortLease = {
+      effort_id: "eff_abc",
+      host: "h",
+      generation: 1,
+      acquired_at: "2026-07-21T00:00:00.000Z",
+      expires_at: "2026-07-21T02:00:00.000Z",
+    };
+    expect(isLeaseExpired(lease, new Date("2026-07-21T01:00:00.000Z"))).toBe(false);
+  });
+
+  it("returns true when the lease expires at or before now", () => {
+    const lease: EffortLease = {
+      effort_id: "eff_abc",
+      host: "h",
+      generation: 1,
+      acquired_at: "2026-07-21T00:00:00.000Z",
+      expires_at: "2026-07-21T01:00:00.000Z",
+    };
+    expect(isLeaseExpired(lease, new Date("2026-07-21T01:00:00.000Z"))).toBe(true);
+    expect(isLeaseExpired(lease, new Date("2026-07-21T02:00:00.000Z"))).toBe(true);
+  });
+});
+
+// ── readLease ──────────────────────────────────────────────────────────────
+
+describe("readLease", () => {
+  it("returns null for an effort that has no lease", async () => {
+    expect(await readLease(root, "eff_missing")).toBeNull();
+  });
+});
+
+// ── releaseLease ───────────────────────────────────────────────────────────
+
+describe("releaseLease", () => {
+  it("is idempotent: releasing an absent lease does not throw", async () => {
+    await expect(releaseLease(root, "eff_noexist")).resolves.toBeUndefined();
+  });
+});
+
+// ── manageEffort ───────────────────────────────────────────────────────────
+
+describe("manageEffort", () => {
+  const FAKE_HOST = "test-host";
+  const AT = "2026-07-21T10:00:00.000Z";
+  const now = () => new Date(AT);
+  const opts = { now, host: FAKE_HOST, ttlMs: LEASE_DEFAULT_TTL_MS };
+
+  it("transitions an inbox effort to active and writes a lease at the effort's generation", async () => {
+    const effort = await startEffort({ root, intent: "build something", now });
+    expect(effort.lifecycle).toBe("inbox");
+    expect(effort.generation).toBe(1);
+
+    const { effort: managed, lease } = await manageEffort(root, effort, opts);
+
+    expect(managed.lifecycle).toBe("active");
+    expect(managed.generation).toBe(2);
+    expect(lease.host).toBe(FAKE_HOST);
+    expect(lease.generation).toBe(2);
+    expect(lease.acquired_at).toBe(AT);
+
+    const stored = await readEffort(root, effort.effort_id);
+    expect(stored?.lifecycle).toBe("active");
+    expect(stored?.generation).toBe(2);
+  });
+
+  it("transitions a paused effort to active", async () => {
+    const effort = await startEffort({ root, intent: "paused one", now });
+    // Put it in paused state directly via saveEffort
+    const { saveEffort } = await import("../src/core/manager/effort-store.js");
+    const paused = await saveEffort(root, { ...effort, lifecycle: "paused" }, { now });
+
+    const { effort: managed } = await manageEffort(root, paused, opts);
+    expect(managed.lifecycle).toBe("active");
+  });
+
+  it("refuses to manage an already-active effort (idempotent guard)", async () => {
+    const effort = await startEffort({ root, intent: "active already", now });
+    const { effort: managed } = await manageEffort(root, effort, opts);
+    await expect(manageEffort(root, managed, opts)).rejects.toBeInstanceOf(ManagerLifecycleError);
+  });
+
+  it("refuses to manage a completed effort", async () => {
+    const effort = await startEffort({ root, intent: "done already", now });
+    const { saveEffort } = await import("../src/core/manager/effort-store.js");
+    const completed = await saveEffort(root, { ...effort, lifecycle: "completed" }, { now });
+    await expect(manageEffort(root, completed, opts)).rejects.toBeInstanceOf(ManagerLifecycleError);
+  });
+
+  it("writes the lease file under the leases lane", async () => {
+    const effort = await startEffort({ root, intent: "check lease file", now });
+    await manageEffort(root, effort, opts);
+    const stored = await readLease(root, effort.effort_id);
+    expect(stored).not.toBeNull();
+    expect(stored?.host).toBe(FAKE_HOST);
+  });
+
+  it("fails closed when a live lease is held by a different host", async () => {
+    const effort = await startEffort({ root, intent: "contested", now });
+    await manageEffort(root, effort, { ...opts, host: "session-a" });
+
+    const effort2 = await readEffort(root, effort.effort_id);
+    await expect(manageEffort(root, effort2!, { ...opts, host: "session-b" })).rejects.toBeInstanceOf(
+      ManagerLeaseConflictError,
+    );
+  });
+
+  it("reclaims a TTL-expired lease with a generation bump", async () => {
+    const effort = await startEffort({ root, intent: "expired lease", now });
+    // Acquire with a very short TTL so it expires immediately
+    const past = new Date(AT);
+    await manageEffort(root, effort, { host: "session-a", now: () => past, ttlMs: 0 });
+
+    const effort2 = await readEffort(root, effort.effort_id);
+    const genBefore = effort2!.generation;
+
+    // Reclaim: lease is expired
+    const later = new Date(past.getTime() + 1000);
+    const { effort: reclaimed, lease } = await manageEffort(root, effort2!, {
+      host: "session-b",
+      now: () => later,
+      ttlMs: LEASE_DEFAULT_TTL_MS,
+    });
+
+    expect(reclaimed.generation).toBe(genBefore + 1);
+    expect(lease.host).toBe("session-b");
+    expect(lease.generation).toBe(genBefore + 1);
+  });
+
+  it("after stale reclaim, the old writer's saveEffort fails with ManagerGenerationError", async () => {
+    const effort = await startEffort({ root, intent: "reclaim fences old writer", now });
+    const past = new Date(AT);
+    const { effort: oldManaged } = await manageEffort(root, effort, {
+      host: "session-a",
+      now: () => past,
+      ttlMs: 0,
+    });
+    // old writer holds oldManaged (generation N)
+    const effort2 = await readEffort(root, effort.effort_id);
+    const later = new Date(past.getTime() + 1000);
+    // session-b reclaims, bumps to N+1
+    await manageEffort(root, effort2!, { host: "session-b", now: () => later });
+
+    // old writer tries to save with its stale generation → fails closed
+    const { saveEffort } = await import("../src/core/manager/effort-store.js");
+    await expect(
+      saveEffort(root, { ...oldManaged, name: "stale write" }),
+    ).rejects.toBeInstanceOf(ManagerGenerationError);
+  });
+});
+
+// ── endEffort ──────────────────────────────────────────────────────────────
+
+describe("endEffort", () => {
+  const FAKE_HOST = "test-host";
+  const AT = "2026-07-21T10:00:00.000Z";
+  const now = () => new Date(AT);
+  const opts = { now, host: FAKE_HOST };
+
+  it("transitions an active effort to completed and removes the lease", async () => {
+    const effort = await startEffort({ root, intent: "finish me", now });
+    const { effort: managed } = await manageEffort(root, effort, opts);
+    expect(managed.lifecycle).toBe("active");
+
+    const completed = await endEffort(root, managed, { now });
+    expect(completed.lifecycle).toBe("completed");
+    expect(completed.generation).toBe(managed.generation + 1);
+
+    const stored = await readEffort(root, effort.effort_id);
+    expect(stored?.lifecycle).toBe("completed");
+
+    const lease = await readLease(root, effort.effort_id);
+    expect(lease).toBeNull();
+  });
+
+  it("refuses to end an effort that is not active", async () => {
+    const effort = await startEffort({ root, intent: "not active", now });
+    await expect(endEffort(root, effort, { now })).rejects.toBeInstanceOf(ManagerLifecycleError);
+  });
+
+  it("releases the lease even when there is no lease file (idempotent)", async () => {
+    const effort = await startEffort({ root, intent: "no lease", now });
+    const { saveEffort } = await import("../src/core/manager/effort-store.js");
+    const active = await saveEffort(root, { ...effort, lifecycle: "active" }, { now });
+    // No lease file exists — end should still succeed
+    await expect(endEffort(root, active, { now })).resolves.toMatchObject({ lifecycle: "completed" });
+  });
+});

--- a/packages/shared/red-paths.test.ts
+++ b/packages/shared/red-paths.test.ts
@@ -33,6 +33,8 @@ import {
   managerDir,
   managerEffortFile,
   managerEffortsDir,
+  managerLeaseFile,
+  managerLeasesDir,
   memoryDir,
   rebaseWorktreesDir,
   resolveManagerRoot,
@@ -87,8 +89,16 @@ describe("manager portfolio store", () => {
     );
   });
 
+  it("derives the operator-scoped lease lane from a home root", () => {
+    expect(managerLeasesDir("/home/op")).toBe("/home/op/.red/manager/leases");
+    expect(managerLeaseFile("/home/op", "eff_abc")).toBe(
+      "/home/op/.red/manager/leases/eff_abc.toonl",
+    );
+  });
+
   it("rejects an empty effort id instead of writing the lane directory itself", () => {
     expect(() => managerEffortFile("/home/op", "")).toThrow(/effortId is required/);
+    expect(() => managerLeaseFile("/home/op", "")).toThrow(/effortId is required/);
   });
 
   it("defaults the manager root to the operator home and honors the override", () => {

--- a/packages/shared/red-paths.ts
+++ b/packages/shared/red-paths.ts
@@ -119,6 +119,17 @@ export function managerEffortFile(root: string, effortId: string): string {
   return join(managerEffortsDir(root), `${effortId}.toonl`);
 }
 
+/** Per-effort lease lane: `<root>/.red/manager/leases`. */
+export function managerLeasesDir(root: string): string {
+  return join(managerDir(root), "leases");
+}
+
+/** One effort's lease file: `<root>/.red/manager/leases/<effortId>.toonl`. */
+export function managerLeaseFile(root: string, effortId: string): string {
+  if (!effortId) throw new Error("effortId is required");
+  return join(managerLeasesDir(root), `${effortId}.toonl`);
+}
+
 // ── State-tier lanes (ADR 0098 §2) ──────────────────────────────────────────
 
 /** Castle engine state lane: `.red/state/castle`. */


### PR DESCRIPTION
Automated AFK landing for #2292. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2292

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787235999&installation_model_id=20659&pr_number=2359&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2359&signature=bc240bc38be6cdea6bf2a41786c0023bda1f183b5bbed269e7450f3ff0033a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->