### PR TITLE
fix: #2331 Castle-MCP H2: bounded logs reads — limit and kind filter

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -676,6 +676,8 @@ async function editFleet(root: string, input: FleetEditInput) {
   return { status: "edited", profile, directive };
 }
 
+const LOGS_DEFAULT_LIMIT = 200;
+
 async function laneLogs(root: string, input: LogsInput) {
   const paths = createEnginePaths(join(root, ".red"));
   const laneRoot =
@@ -689,7 +691,13 @@ async function laneLogs(root: string, input: LogsInput) {
   if (rel.startsWith("..") || resolve(laneRoot) === path) {
     throw new Error("log lane id escapes its Castle lane root");
   }
-  return readCastleLaneRecords(path);
+  const records = await readCastleLaneRecords(path);
+  const filtered =
+    input.kind !== undefined
+      ? records.filter((r) => r.kind === input.kind)
+      : records;
+  const limit = input.limit ?? LOGS_DEFAULT_LIMIT;
+  return filtered.length <= limit ? filtered : filtered.slice(-limit);
 }
 
 async function workerVitals(root: string) {

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -88,6 +88,46 @@ describe("dev:afk MCP host adapter", () => {
     ).rejects.toThrow("escapes its Castle lane root");
   });
 
+  it("bounds logs reads by limit and filters by kind before the limit", async () => {
+    const cwd = await root();
+    const paths = createEnginePaths(join(cwd, ".red"));
+    const lanePath = castleLanePath(paths, "worker", "worker-2");
+
+    // Write 6 records alternating heartbeat / completed so we have a lane
+    // larger than the limit used in assertions below.
+    for (let i = 0; i < 6; i++) {
+      await appendCastleLaneRecord(lanePath, {
+        at: `2026-07-21T00:00:0${i}.000Z`,
+        kind: i % 2 === 0 ? "worker.heartbeat" : "worker.completed",
+      });
+    }
+
+    const deps = createDevAfkMcpDependencies(cwd);
+
+    // limit=2 returns the NEWEST 2 records
+    await expect(
+      deps.logs({ lane: "worker", id: "worker-2", limit: 2 }),
+    ).resolves.toEqual([
+      { at: "2026-07-21T00:00:04.000Z", kind: "worker.heartbeat" },
+      { at: "2026-07-21T00:00:05.000Z", kind: "worker.completed" },
+    ]);
+
+    // kind filter applied before limit: 3 heartbeats (indices 0, 2, 4)
+    const heartbeats = await deps.logs({
+      lane: "worker",
+      id: "worker-2",
+      kind: "worker.heartbeat",
+    }) as unknown[];
+    expect(heartbeats).toHaveLength(3);
+
+    // kind + limit: newest 1 heartbeat
+    await expect(
+      deps.logs({ lane: "worker", id: "worker-2", kind: "worker.heartbeat", limit: 1 }),
+    ).resolves.toEqual([
+      { at: "2026-07-21T00:00:04.000Z", kind: "worker.heartbeat" },
+    ]);
+  });
+
   it("routes issue and demand dispatches through their value operations", async () => {
     const cwd = await root();
     const operations = fakeOperations();

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -55,8 +55,8 @@ const SURFACE: ReadonlyArray<{
     name: "logs",
     title: "Read Castle logs",
     description:
-      "Return raw CastleLaneRecord entries from one structured lane.",
-    schema: ["lane", "id"],
+      "Return the newest CastleLaneRecord entries from one structured lane; bounded by `limit` (default 200, max 10 000). Pass `kind` to filter before the limit.",
+    schema: ["lane", "id", "limit", "kind"],
   },
   {
     name: "worker_vitals",

--- a/packages/red-castle/src/mcp/observability.ts
+++ b/packages/red-castle/src/mcp/observability.ts
@@ -4,6 +4,8 @@ import type { CastleMcpTool } from "./tool.js";
 export interface LogsInput {
   lane: "worker" | "supervisor" | "monitor" | "liveness";
   id: string;
+  limit?: number;
+  kind?: string;
 }
 
 export interface ObservabilityDependencies {
@@ -23,10 +25,12 @@ export function createObservabilityTools(
       name: "logs",
       title: "Read Castle logs",
       description:
-        "Return raw CastleLaneRecord entries from one structured lane.",
+        "Return the newest CastleLaneRecord entries from one structured lane; bounded by `limit` (default 200, max 10 000). Pass `kind` to filter before the limit.",
       inputSchema: {
         lane: z.enum(["worker", "supervisor", "monitor", "liveness"]),
         id: z.string().min(1),
+        limit: z.number().int().positive().max(10_000).default(200),
+        kind: z.string().optional(),
       },
       invoke: (input) => deps.logs(input as unknown as LogsInput),
     },


### PR DESCRIPTION
Automated AFK landing for #2331. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2331

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787238315&installation_model_id=20659&pr_number=2361&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2361&signature=6bf0fa568e16e4cf167a93d677fe68342491b16a41e03c3d3c1e96765ddd190e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->