### PR TITLE
fix: #2294 Manager S4: map publication + declarative reconcile

### DIFF
--- a/apps/dev/src/core/manager/brief.ts
+++ b/apps/dev/src/core/manager/brief.ts
@@ -1,19 +1,22 @@
-// core/manager/brief.ts — the Manager brief renderer (Spec #2290, slice #2291).
+// core/manager/brief.ts — the Manager brief renderer (Spec #2290, slices
+// #2291 and #2294; architecture in ADR 0109).
 //
 // The brief is a COMPUTED-ON-DEMAND render, never a stored snapshot: a stored
 // brief either goes stale against the tracker or duplicates state its owner
-// workflow already holds. This slice renders the owned lifecycle state alone;
-// the derived state (HITL, blocked, frontier) joins the render in the
-// reconciliation slice, freshly reconciled at render time — still never stored.
+// workflow already holds. Two render paths:
 //
-// `state_source: owned` says out loud which half of the brief the reader is
-// looking at, so a brief from this slice can never be mistaken for a reconciled
-// one once the derived half exists.
+//   renderEffortBrief          — owned lifecycle state only (slice #2291).
+//   renderEffortBriefWithDerived — owned + freshly reconciled derived state
+//                                 (slice #2294: map publication + children).
+//
+// `state_source` distinguishes the paths: "owned" vs "reconciled". A brief
+// from the owned path can never be mistaken for a reconciled one.
 
 import { encodeDevSnapshotToon } from "../toon-snapshot.js";
+import type { ManagerMapDerivedState } from "./map-reconciler.js";
 import type { EffortRecord } from "./effort-store.js";
 
-/** Render one effort's brief from its owned state. */
+/** Render one effort's brief from its owned state only. */
 export function renderEffortBrief(effort: EffortRecord): string {
   return encodeDevSnapshotToon({
     kind: "manager.brief",
@@ -25,6 +28,30 @@ export function renderEffortBrief(effort: EffortRecord): string {
     intent: effort.intent,
     created_at: effort.created_at,
     updated_at: effort.updated_at,
+  });
+}
+
+/**
+ * Render one effort's brief with freshly reconciled derived state.
+ * The derived state is NEVER stored — it is reconciled from the tracker at
+ * render time so the brief can never go stale against the map's live children.
+ */
+export function renderEffortBriefWithDerived(
+  effort: EffortRecord,
+  derived: ManagerMapDerivedState,
+): string {
+  return encodeDevSnapshotToon({
+    kind: "manager.brief",
+    state_source: "reconciled",
+    effort_id: effort.effort_id,
+    name: effort.name,
+    lifecycle: effort.lifecycle,
+    generation: effort.generation,
+    intent: effort.intent,
+    created_at: effort.created_at,
+    updated_at: effort.updated_at,
+    map_issue: derived.map_issue,
+    child_count: derived.child_count,
   });
 }
 

--- a/apps/dev/src/core/manager/map-reconciler.ts
+++ b/apps/dev/src/core/manager/map-reconciler.ts
@@ -1,0 +1,126 @@
+// core/manager/map-reconciler.ts — the Manager map publication reconciler
+// (Spec #2290, slice #2294; architecture in ADR 0109).
+//
+// The reconciler is PURE: it reads desired state from the effort record and
+// current state from the caller-supplied tracker snapshot, then returns the
+// actions needed to converge. No I/O, no side effects — the I/O layer applies
+// the returned actions independently, so a partial failure reruns cleanly.
+//
+// The effort-ID marker is the single idempotence key:
+//   <!-- red-skills:manager-map effort-id=<effort_id> v1 -->
+// Embedded in the map body, it lets find-or-create and rename-rejoin work
+// without making the title, URL, or issue number canonical.
+//
+// Map body contract: marker + name + intent only. The body NEVER mirrors
+// frontier, workers, blockers, decisions, or state owned by child artifacts.
+
+import { LABEL_MANAGER_MAP } from "../triage-labels.js";
+import type { EffortRecord } from "./effort-store.js";
+
+export { LABEL_MANAGER_MAP };
+
+/** The prefix that identifies a Manager map in any issue body. */
+export const MANAGER_MAP_MARKER_PREFIX = "<!-- red-skills:manager-map";
+
+/** The regex that extracts an effort-ID from a map body marker. */
+const MARKER_PATTERN = /<!-- red-skills:manager-map effort-id=(eff_[0-9a-z]{26}) v1 -->/;
+
+/** Build the structured effort-ID marker for embedding in a map body. */
+export function buildEffortMarker(effortId: string): string {
+  return `<!-- red-skills:manager-map effort-id=${effortId} v1 -->`;
+}
+
+/**
+ * Extract the effort-ID from a map body, or null if the marker is absent.
+ * The match is against the canonical MARKER_PATTERN only — a manually edited
+ * or malformed marker is treated as absent, not partially matched.
+ */
+export function extractEffortIdFromBody(body: string): string | null {
+  const match = body.match(MARKER_PATTERN);
+  return match ? (match[1] ?? null) : null;
+}
+
+/**
+ * Build the minimal map body: marker + effort name + intent summary.
+ * The body carries ONLY what the map owns: the identification marker and the
+ * effort description. It NEVER mirrors frontier, workers, blockers, decisions,
+ * or other state owned by child artifacts.
+ */
+export function buildMapBody(effort: EffortRecord): string {
+  const marker = buildEffortMarker(effort.effort_id);
+  const summary = `**${effort.name}**: ${effort.intent}`;
+  return `${marker}\n\n${summary}`;
+}
+
+/** The map title: effort name prefixed so it is recognisable in issue lists. */
+export function buildMapTitle(effort: EffortRecord): string {
+  return `[manager] ${effort.name}`;
+}
+
+/** The desired label set for any Manager map. Always exactly one label. */
+export function computeDesiredLabels(): readonly string[] {
+  return [LABEL_MANAGER_MAP];
+}
+
+/**
+ * Diff desired vs existing labels — returns the labels to add.
+ * No labels are ever removed by the reconciler (other tools may own them).
+ */
+export function computeLabelsToAdd(existing: readonly string[], desired: readonly string[]): string[] {
+  const existingSet = new Set(existing);
+  return desired.filter((l) => !existingSet.has(l));
+}
+
+export type MapPublishAction = "create" | "update-labels" | "ok";
+
+export interface MapPublishPlan {
+  /** The minimal action that converges the map to the desired state. */
+  action: MapPublishAction;
+  /** Present when the map already exists. */
+  mapNumber?: number;
+  /** Present and non-empty only when action === "update-labels". */
+  labelsToAdd?: string[];
+}
+
+/**
+ * Compute the publish plan for a Manager map. The caller supplies the effort
+ * and the current tracker state; this function returns what to do next without
+ * touching the tracker. Re-running with the post-action state returns "ok".
+ */
+export function planMapPublish(
+  effort: EffortRecord,
+  existing: { number: number; labels: readonly string[] } | null,
+): MapPublishPlan {
+  // Suppress the unused-variable lint; effort is required by the signature
+  // so callers match the shape even when its fields are not yet consulted.
+  void effort;
+  if (!existing) return { action: "create" };
+  const desired = computeDesiredLabels();
+  const toAdd = computeLabelsToAdd(existing.labels, desired);
+  if (toAdd.length > 0) {
+    return { action: "update-labels", mapNumber: existing.number, labelsToAdd: toAdd };
+  }
+  return { action: "ok", mapNumber: existing.number };
+}
+
+/** The derived state the reconcile produces for the Manager brief. */
+export interface ManagerMapDerivedState {
+  /** The map issue number, or null if no map has been published yet. */
+  map_issue: number | null;
+  /** Count of native children read from the map issue's sub-issues. */
+  child_count: number;
+  /** Native child issue numbers. */
+  children: readonly number[];
+}
+
+/** Build the derived state from the reconciled tracker snapshot. */
+export function computeDerivedState(
+  mapNumber: number | null,
+  children: readonly number[],
+): ManagerMapDerivedState {
+  return {
+    map_issue: mapNumber,
+    child_count: children.length,
+    children,
+  };
+}

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -129,5 +129,10 @@ export const LABEL_BUDGET = "blocked:budget";
 // WITHOUT this label are dispatched as normal ship tasks (unaffected).
 export const LABEL_TYPE_SCOUT = "type:scout";
 
+// Manager map label (ADR 0109, Spec #2290, slice #2294).
+// Applied to the umbrella parent issue that carries the effort-ID marker.
+// Never applied to Specs, Tickets, or any other child artifact.
+export const LABEL_MANAGER_MAP = "type:manager-map";
+
 // Auxiliary labels
 export const LABEL_RUNNER_ERROR = "runner-error";

--- a/apps/dev/src/runtime/gh/manager-map.ts
+++ b/apps/dev/src/runtime/gh/manager-map.ts
@@ -1,0 +1,158 @@
+// runtime/gh/manager-map.ts — Manager map publication I/O layer
+// (Spec #2290, slice #2294).
+//
+// The pure plan lives in core/manager/map-reconciler.ts; this module executes
+// it against GitHub. Each step is independently idempotent:
+//   1. Find the map by marker — returns the existing one or null.
+//   2. If not found, create one.
+//   3. Apply any missing labels.
+//   4. Read native sub-issues.
+// A partial failure re-runs from step 1 and converges with no rollback.
+
+import { scrubOutbound } from "../outbound-redaction.js";
+import { apiPath, repoArgs, runGh, type GhContext } from "./common.js";
+import {
+  buildMapBody,
+  buildMapTitle,
+  computeDerivedState,
+  computeDesiredLabels,
+  computeLabelsToAdd,
+  extractEffortIdFromBody,
+  type ManagerMapDerivedState,
+} from "../../core/manager/map-reconciler.js";
+import type { EffortRecord } from "../../core/manager/effort-store.js";
+
+/** A single manager map issue as read from the tracker. */
+export interface ManagerMapIssue {
+  number: number;
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+/**
+ * Search for an existing Manager map by the effort-ID marker in its body.
+ * Returns null when none is found or when the search fails — the caller then
+ * creates a new map. The body is verified against the canonical marker pattern
+ * to rule out false positives from the full-text search.
+ */
+export async function findManagerMapByEffortId(
+  ctx: GhContext,
+  effortId: string,
+): Promise<ManagerMapIssue | null> {
+  const r = await runGh(ctx, [
+    "issue",
+    "list",
+    ...repoArgs(ctx),
+    "--search",
+    `in:body "manager-map effort-id=${effortId}"`,
+    "--state",
+    "all",
+    "--limit",
+    "10",
+    "--json",
+    "number,title,body,labels",
+  ]);
+  if (r.code !== 0) return null;
+  let rows: Array<{ number?: unknown; title?: unknown; body?: unknown; labels?: unknown }>;
+  try {
+    const parsed = JSON.parse(r.stdout || "[]");
+    rows = Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return null;
+  }
+  const match = rows.find((row) => extractEffortIdFromBody(String(row.body ?? "")) === effortId);
+  if (!match) return null;
+  return {
+    number: Number(match.number ?? 0),
+    title: String(match.title ?? ""),
+    body: String(match.body ?? ""),
+    labels: Array.isArray(match.labels)
+      ? (match.labels as Array<{ name?: unknown }>).map((l) => String(l.name ?? ""))
+      : [],
+  };
+}
+
+/** List the native sub-issues of a Manager map by paginated GitHub API. */
+async function listMapChildren(ctx: GhContext, mapNumber: number): Promise<number[]> {
+  const r = await runGh(ctx, [
+    "api",
+    "--paginate",
+    apiPath(ctx, `issues/${mapNumber}/sub_issues`),
+    "--jq",
+    ".[] | {number}",
+  ]);
+  if (r.code !== 0) return [];
+  const out: number[] = [];
+  for (const line of (r.stdout ?? "").split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const parsed = JSON.parse(t) as { number?: unknown };
+      const n = Number(parsed.number ?? 0);
+      if (Number.isInteger(n) && n > 0) out.push(n);
+    } catch {
+      // tolerate malformed jq lines; the reconciler retries on the next run
+    }
+  }
+  return out;
+}
+
+/**
+ * Publish the Manager map idempotently and reconcile derived state.
+ *
+ * Declarative converge — each step is independently idempotent and a partial
+ * failure re-runs cleanly from step 1. No rollback is ever performed.
+ *
+ * Step 1: Find the existing map by effort-ID marker.
+ * Step 2: If absent, create the map issue (title + body + label).
+ * Step 3: Apply any missing labels to an existing map.
+ * Step 4: Read native sub-issues.
+ * Step 5: Return derived state for the brief.
+ */
+export async function publishAndReconcileManagerMap(
+  ctx: GhContext,
+  effort: EffortRecord,
+): Promise<ManagerMapDerivedState> {
+  // Step 1: find
+  const existing = await findManagerMapByEffortId(ctx, effort.effort_id);
+  let mapNumber: number;
+
+  if (!existing) {
+    // Step 2: create
+    const labelArgs = computeDesiredLabels().flatMap((l) => ["--label", l]);
+    const r = await runGh(ctx, [
+      "issue",
+      "create",
+      ...repoArgs(ctx),
+      "--title",
+      scrubOutbound(buildMapTitle(effort)),
+      "--body",
+      scrubOutbound(buildMapBody(effort)),
+      ...labelArgs,
+    ]);
+    const urlMatch = (r.stdout ?? "").match(/\/issues\/(\d+)\b/);
+    const num = urlMatch ? Number(urlMatch[1]) : NaN;
+    if (r.code !== 0 || !Number.isInteger(num) || num <= 0) {
+      throw new Error(
+        `gh: failed to create manager map for effort ${effort.effort_id} (code ${r.code})`,
+      );
+    }
+    mapNumber = num;
+  } else {
+    mapNumber = existing.number;
+    // Step 3: apply missing labels
+    const toAdd = computeLabelsToAdd(existing.labels, computeDesiredLabels());
+    if (toAdd.length > 0) {
+      const args = ["issue", "edit", String(mapNumber), ...repoArgs(ctx)];
+      for (const label of toAdd) args.push("--add-label", label);
+      await runGh(ctx, args);
+    }
+  }
+
+  // Step 4: read children
+  const children = await listMapChildren(ctx, mapNumber);
+
+  // Step 5: return derived state
+  return computeDerivedState(mapNumber, children);
+}

--- a/apps/dev/tests/manager-brief.test.ts
+++ b/apps/dev/tests/manager-brief.test.ts
@@ -1,7 +1,12 @@
 import { decode } from "@reddb-io/toon";
 import { describe, expect, it } from "vitest";
 import type { EffortRecord } from "../src/core/manager/effort-store.js";
-import { renderEffortBrief, renderEmptyPortfolioBrief } from "../src/core/manager/brief.js";
+import {
+  renderEffortBrief,
+  renderEffortBriefWithDerived,
+  renderEmptyPortfolioBrief,
+} from "../src/core/manager/brief.js";
+import type { ManagerMapDerivedState } from "../src/core/manager/map-reconciler.js";
 
 const EFFORT: EffortRecord = {
   effort_id: "eff_abcdefghijklmnopqrstuvwxyz",
@@ -39,5 +44,72 @@ describe("effort brief", () => {
   it("renders an explicit empty brief when the portfolio holds no effort", () => {
     const brief = decode(renderEmptyPortfolioBrief()) as Record<string, unknown>;
     expect(brief).toEqual({ kind: "manager.brief", state_source: "owned", efforts: 0 });
+  });
+});
+
+describe("effort brief with derived state (slice #2294)", () => {
+  const DERIVED_WITH_MAP: ManagerMapDerivedState = {
+    map_issue: 42,
+    child_count: 3,
+    children: [10, 20, 30],
+  };
+
+  const DERIVED_NO_MAP: ManagerMapDerivedState = {
+    map_issue: null,
+    child_count: 0,
+    children: [],
+  };
+
+  it("renders state_source as reconciled, not owned", () => {
+    const brief = decode(renderEffortBriefWithDerived(EFFORT, DERIVED_WITH_MAP)) as Record<
+      string,
+      unknown
+    >;
+    expect(brief.state_source).toBe("reconciled");
+  });
+
+  it("carries the map issue number in map_issue", () => {
+    const brief = decode(renderEffortBriefWithDerived(EFFORT, DERIVED_WITH_MAP)) as Record<
+      string,
+      unknown
+    >;
+    expect(brief.map_issue).toBe(42);
+  });
+
+  it("carries the child count in child_count", () => {
+    const brief = decode(renderEffortBriefWithDerived(EFFORT, DERIVED_WITH_MAP)) as Record<
+      string,
+      unknown
+    >;
+    expect(brief.child_count).toBe(3);
+  });
+
+  it("carries null map_issue when no map has been published yet", () => {
+    const brief = decode(renderEffortBriefWithDerived(EFFORT, DERIVED_NO_MAP)) as Record<
+      string,
+      unknown
+    >;
+    expect(brief.map_issue).toBeNull();
+    expect(brief.child_count).toBe(0);
+  });
+
+  it("still carries all owned lifecycle fields alongside derived state", () => {
+    const brief = decode(renderEffortBriefWithDerived(EFFORT, DERIVED_WITH_MAP)) as Record<
+      string,
+      unknown
+    >;
+    expect(brief.effort_id).toBe(EFFORT.effort_id);
+    expect(brief.name).toBe(EFFORT.name);
+    expect(brief.lifecycle).toBe("inbox");
+    expect(brief.generation).toBe(3);
+    expect(brief.intent).toBe(EFFORT.intent);
+  });
+
+  it("does not store the children array in the brief — brief carries count only", () => {
+    const brief = decode(renderEffortBriefWithDerived(EFFORT, DERIVED_WITH_MAP)) as Record<
+      string,
+      unknown
+    >;
+    expect(Object.keys(brief)).not.toContain("children");
   });
 });

--- a/apps/dev/tests/manager-map-gh.test.ts
+++ b/apps/dev/tests/manager-map-gh.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+import {
+  findManagerMapByEffortId,
+  publishAndReconcileManagerMap,
+} from "../src/runtime/gh/manager-map.js";
+import { buildEffortMarker, LABEL_MANAGER_MAP } from "../src/core/manager/map-reconciler.js";
+import type { EffortRecord } from "../src/core/manager/effort-store.js";
+
+const EFFORT: EffortRecord = {
+  effort_id: "eff_abcdefghijklmnopqrstuvwxyz",
+  name: "walking skeleton",
+  intent: "prove the manager persists an effort",
+  lifecycle: "inbox",
+  generation: 1,
+  created_at: "2026-07-21T00:00:00.000Z",
+  updated_at: "2026-07-21T00:00:00.000Z",
+};
+
+const CTX_BASE = { repo: "acme/widgets", cwd: "/repo" };
+
+function makeMap(overrides: Partial<{ number: number; labels: string[] }> = {}): object {
+  return {
+    number: overrides.number ?? 99,
+    title: "[manager] walking skeleton",
+    body: `${buildEffortMarker(EFFORT.effort_id)}\n\n**walking skeleton**: prove the manager persists an effort`,
+    labels: (overrides.labels ?? [LABEL_MANAGER_MAP]).map((name) => ({ name })),
+  };
+}
+
+describe("findManagerMapByEffortId", () => {
+  it("returns null when the issue list returns no results", async () => {
+    const exec: ExecFn = () => Promise.resolve({ code: 0, stdout: "[]", stderr: "" });
+    const ctx = { ...CTX_BASE, exec };
+    expect(await findManagerMapByEffortId(ctx, EFFORT.effort_id)).toBeNull();
+  });
+
+  it("returns null when gh exits non-zero", async () => {
+    const exec: ExecFn = () => Promise.resolve({ code: 1, stdout: "", stderr: "error" });
+    const ctx = { ...CTX_BASE, exec };
+    expect(await findManagerMapByEffortId(ctx, EFFORT.effort_id)).toBeNull();
+  });
+
+  it("returns the matching issue when the marker is present in the body", async () => {
+    const exec: ExecFn = () =>
+      Promise.resolve({ code: 0, stdout: JSON.stringify([makeMap()]), stderr: "" });
+    const ctx = { ...CTX_BASE, exec };
+    const result = await findManagerMapByEffortId(ctx, EFFORT.effort_id);
+    expect(result).not.toBeNull();
+    expect(result?.number).toBe(99);
+    expect(result?.labels).toContain(LABEL_MANAGER_MAP);
+  });
+
+  it("rejects a result whose body carries a different effort-id (no false positives)", async () => {
+    const other = makeMap();
+    (other as Record<string, unknown>).body =
+      `${buildEffortMarker("eff_zzzzzzzzzzzzzzzzzzzzzzzzzz")}\n\nother effort`;
+    const exec: ExecFn = () =>
+      Promise.resolve({ code: 0, stdout: JSON.stringify([other]), stderr: "" });
+    const ctx = { ...CTX_BASE, exec };
+    expect(await findManagerMapByEffortId(ctx, EFFORT.effort_id)).toBeNull();
+  });
+
+  it("passes --search with the effort-id so the tracker pre-filters results", async () => {
+    const calls: string[][] = [];
+    const exec: ExecFn = (_tool, args) => {
+      calls.push([...args]);
+      return Promise.resolve({ code: 0, stdout: "[]", stderr: "" });
+    };
+    const ctx = { ...CTX_BASE, exec };
+    await findManagerMapByEffortId(ctx, EFFORT.effort_id);
+    const searchArg = calls[0] ?? [];
+    const searchIdx = searchArg.indexOf("--search");
+    expect(searchIdx).toBeGreaterThan(-1);
+    expect(searchArg[searchIdx + 1]).toContain(EFFORT.effort_id);
+  });
+});
+
+describe("publishAndReconcileManagerMap — create path", () => {
+  it("creates a map when none is found and returns derived state with the new number", async () => {
+    const calls: string[][] = [];
+    const exec: ExecFn = (_tool, args) => {
+      calls.push([...args]);
+      const isCreate = args[0] === "issue" && args[1] === "create";
+      const isSubIssues = String(args[2] ?? "").includes("sub_issues");
+      const out: ExecOutput = isCreate
+        ? { code: 0, stdout: "https://github.com/acme/widgets/issues/101", stderr: "" }
+        : isSubIssues
+          ? { code: 0, stdout: "", stderr: "" }
+          : { code: 0, stdout: "[]", stderr: "" };
+      return Promise.resolve(out);
+    };
+    const ctx = { ...CTX_BASE, exec };
+    const derived = await publishAndReconcileManagerMap(ctx, EFFORT);
+    expect(derived.map_issue).toBe(101);
+    expect(derived.child_count).toBe(0);
+    const createCall = calls.find((c) => c[0] === "issue" && c[1] === "create");
+    expect(createCall).toBeDefined();
+  });
+
+  it("throws when issue creation fails", async () => {
+    const exec: ExecFn = (_tool, args) => {
+      const isCreate = args[0] === "issue" && args[1] === "create";
+      return Promise.resolve({
+        code: isCreate ? 1 : 0,
+        stdout: isCreate ? "" : "[]",
+        stderr: "error",
+      });
+    };
+    const ctx = { ...CTX_BASE, exec };
+    await expect(publishAndReconcileManagerMap(ctx, EFFORT)).rejects.toThrow(/failed to create/);
+  });
+
+  it("includes the manager-map label in the create call", async () => {
+    const calls: string[][] = [];
+    const exec: ExecFn = (_tool, args) => {
+      calls.push([...args]);
+      const isCreate = args[0] === "issue" && args[1] === "create";
+      return Promise.resolve({
+        code: 0,
+        stdout: isCreate ? "https://github.com/acme/widgets/issues/55" : "[]",
+        stderr: "",
+      });
+    };
+    const ctx = { ...CTX_BASE, exec };
+    await publishAndReconcileManagerMap(ctx, EFFORT);
+    const createCall = calls.find((c) => c[0] === "issue" && c[1] === "create") ?? [];
+    const labelIdx = createCall.indexOf("--label");
+    expect(labelIdx).toBeGreaterThan(-1);
+    expect(createCall[labelIdx + 1]).toBe(LABEL_MANAGER_MAP);
+  });
+});
+
+describe("publishAndReconcileManagerMap — existing map path (idempotence)", () => {
+  function makeExecWithExisting(
+    existingLabels: string[],
+    children: Array<{ number: number }> = [],
+  ): ExecFn {
+    return (_tool, args) => {
+      const isList = args[0] === "issue" && args[1] === "list";
+      const isEdit = args[0] === "issue" && args[1] === "edit";
+      const isSubIssues = String(args[2] ?? "").includes("sub_issues");
+      let stdout = "[]";
+      if (isList) stdout = JSON.stringify([makeMap({ labels: existingLabels })]);
+      else if (isSubIssues) stdout = children.map((c) => JSON.stringify(c)).join("\n");
+      return Promise.resolve({ code: 0, stdout, stderr: "" });
+    };
+  }
+
+  it("skips creation when the map already exists — no create call", async () => {
+    const calls: string[][] = [];
+    const baseExec = makeExecWithExisting([LABEL_MANAGER_MAP]);
+    const exec: ExecFn = (tool, args, opts) => {
+      calls.push([...args]);
+      return baseExec(tool, args, opts);
+    };
+    const ctx = { ...CTX_BASE, exec };
+    await publishAndReconcileManagerMap(ctx, EFFORT);
+    const createCall = calls.find((c) => c[0] === "issue" && c[1] === "create");
+    expect(createCall).toBeUndefined();
+  });
+
+  it("returns the existing map number as map_issue", async () => {
+    const exec = makeExecWithExisting([LABEL_MANAGER_MAP]);
+    const ctx = { ...CTX_BASE, exec };
+    const derived = await publishAndReconcileManagerMap(ctx, EFFORT);
+    expect(derived.map_issue).toBe(99);
+  });
+
+  it("applies missing labels without recreating the map", async () => {
+    const calls: string[][] = [];
+    const baseExec = makeExecWithExisting([]);
+    const exec: ExecFn = (tool, args, opts) => {
+      calls.push([...args]);
+      return baseExec(tool, args, opts);
+    };
+    const ctx = { ...CTX_BASE, exec };
+    await publishAndReconcileManagerMap(ctx, EFFORT);
+    const editCall = calls.find((c) => c[0] === "issue" && c[1] === "edit");
+    expect(editCall).toBeDefined();
+    expect(editCall).toContain("--add-label");
+    expect(editCall).toContain(LABEL_MANAGER_MAP);
+    const createCall = calls.find((c) => c[0] === "issue" && c[1] === "create");
+    expect(createCall).toBeUndefined();
+  });
+
+  it("skips label edit when all desired labels are already present", async () => {
+    const calls: string[][] = [];
+    const baseExec = makeExecWithExisting([LABEL_MANAGER_MAP]);
+    const exec: ExecFn = (tool, args, opts) => {
+      calls.push([...args]);
+      return baseExec(tool, args, opts);
+    };
+    const ctx = { ...CTX_BASE, exec };
+    await publishAndReconcileManagerMap(ctx, EFFORT);
+    const editCall = calls.find((c) => c[0] === "issue" && c[1] === "edit");
+    expect(editCall).toBeUndefined();
+  });
+
+  it("reconciles native children into the derived state", async () => {
+    const children = [{ number: 10 }, { number: 20 }, { number: 30 }];
+    const exec = makeExecWithExisting([LABEL_MANAGER_MAP], children);
+    const ctx = { ...CTX_BASE, exec };
+    const derived = await publishAndReconcileManagerMap(ctx, EFFORT);
+    expect(derived.child_count).toBe(3);
+    expect(derived.children).toContain(10);
+    expect(derived.children).toContain(20);
+    expect(derived.children).toContain(30);
+  });
+
+  it("returns zero children when the map has no sub-issues yet", async () => {
+    const exec = makeExecWithExisting([LABEL_MANAGER_MAP], []);
+    const ctx = { ...CTX_BASE, exec };
+    const derived = await publishAndReconcileManagerMap(ctx, EFFORT);
+    expect(derived.child_count).toBe(0);
+    expect(derived.children).toEqual([]);
+  });
+});
+
+describe("publishAndReconcileManagerMap — partial-failure convergence", () => {
+  it("converges on rerun after a label-edit partial failure — best-effort converge, no rollback", async () => {
+    // Declarative converge: a failed label edit does not throw or roll back.
+    // The map is still found and returned; the next run re-applies the label.
+    const execWithFailingEdit: ExecFn = (_tool, args) => {
+      const isList = args[0] === "issue" && args[1] === "list";
+      const isEdit = args[0] === "issue" && args[1] === "edit";
+      const isSubIssues = String(args[2] ?? "").includes("sub_issues");
+      if (isEdit) return Promise.resolve({ code: 1, stdout: "", stderr: "transient" });
+      return Promise.resolve({
+        code: 0,
+        stdout: isList ? JSON.stringify([makeMap({ labels: [] })]) : isSubIssues ? "" : "[]",
+        stderr: "",
+      });
+    };
+    const ctx = { ...CTX_BASE, exec: execWithFailingEdit };
+    // First run: map found, label edit fails — still returns map_issue (no throw)
+    const first = await publishAndReconcileManagerMap(ctx, EFFORT);
+    expect(first.map_issue).toBe(99);
+
+    // Second run (rerun): label already present → no edit needed, fully converges
+    const execConverged: ExecFn = (_tool, args) => {
+      const isList = args[0] === "issue" && args[1] === "list";
+      const isSubIssues = String(args[2] ?? "").includes("sub_issues");
+      return Promise.resolve({
+        code: 0,
+        stdout: isList
+          ? JSON.stringify([makeMap({ labels: [LABEL_MANAGER_MAP] })])
+          : isSubIssues
+            ? ""
+            : "[]",
+        stderr: "",
+      });
+    };
+    const ctx2 = { ...CTX_BASE, exec: execConverged };
+    const second = await publishAndReconcileManagerMap(ctx2, EFFORT);
+    expect(second.map_issue).toBe(99);
+  });
+
+  it("rename-rejoin — finds the map by marker even after the title was changed", async () => {
+    const renamedMap = {
+      ...makeMap(),
+      title: "[manager] new name after rename",
+    };
+    const exec: ExecFn = (_tool, args) => {
+      const isList = args[0] === "issue" && args[1] === "list";
+      const isSubIssues = String(args[2] ?? "").includes("sub_issues");
+      return Promise.resolve({
+        code: 0,
+        stdout: isList ? JSON.stringify([renamedMap]) : isSubIssues ? "" : "[]",
+        stderr: "",
+      });
+    };
+    const ctx = { ...CTX_BASE, exec };
+    const derived = await publishAndReconcileManagerMap(ctx, EFFORT);
+    // The marker in the body identifies the effort even though the title changed
+    expect(derived.map_issue).toBe(99);
+  });
+});

--- a/apps/dev/tests/manager-map-reconciler.test.ts
+++ b/apps/dev/tests/manager-map-reconciler.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  LABEL_MANAGER_MAP,
+  MANAGER_MAP_MARKER_PREFIX,
+  buildEffortMarker,
+  buildMapBody,
+  buildMapTitle,
+  computeDerivedState,
+  computeDesiredLabels,
+  computeLabelsToAdd,
+  extractEffortIdFromBody,
+  planMapPublish,
+} from "../src/core/manager/map-reconciler.js";
+import type { EffortRecord } from "../src/core/manager/effort-store.js";
+
+const EFFORT: EffortRecord = {
+  effort_id: "eff_abcdefghijklmnopqrstuvwxyz",
+  name: "walking skeleton",
+  intent: "prove the manager persists an effort",
+  lifecycle: "inbox",
+  generation: 1,
+  created_at: "2026-07-21T00:00:00.000Z",
+  updated_at: "2026-07-21T00:00:00.000Z",
+};
+
+describe("effort-ID marker", () => {
+  it("round-trips through extract", () => {
+    const marker = buildEffortMarker(EFFORT.effort_id);
+    expect(extractEffortIdFromBody(marker)).toBe(EFFORT.effort_id);
+  });
+
+  it("returns null when the marker is absent", () => {
+    expect(extractEffortIdFromBody("no marker here")).toBeNull();
+  });
+
+  it("returns null for a marker whose effort-id does not match the eff_ pattern", () => {
+    expect(
+      extractEffortIdFromBody("<!-- red-skills:manager-map effort-id=not-an-id v1 -->"),
+    ).toBeNull();
+  });
+
+  it("returns null when the version tag differs", () => {
+    expect(
+      extractEffortIdFromBody(
+        `<!-- red-skills:manager-map effort-id=${EFFORT.effort_id} v2 -->`,
+      ),
+    ).toBeNull();
+  });
+
+  it("the built marker starts with MANAGER_MAP_MARKER_PREFIX", () => {
+    expect(buildEffortMarker(EFFORT.effort_id).startsWith(MANAGER_MAP_MARKER_PREFIX)).toBe(true);
+  });
+});
+
+describe("map body", () => {
+  it("embeds the marker as the first line so it is always present after find-or-create", () => {
+    const body = buildMapBody(EFFORT);
+    expect(body.split("\n")[0]).toBe(buildEffortMarker(EFFORT.effort_id));
+  });
+
+  it("carries the effort name and intent", () => {
+    const body = buildMapBody(EFFORT);
+    expect(body).toContain(EFFORT.name);
+    expect(body).toContain(EFFORT.intent);
+  });
+
+  it("does not mirror child-owned fields — frontier, workers, blockers, decisions are absent", () => {
+    const body = buildMapBody(EFFORT).toLowerCase();
+    for (const field of ["hitl", "blocked", "frontier", "worker", "children", "child_count"]) {
+      expect(body).not.toContain(field);
+    }
+  });
+
+  it("the extracted effort-id from the built body matches the effort", () => {
+    const body = buildMapBody(EFFORT);
+    expect(extractEffortIdFromBody(body)).toBe(EFFORT.effort_id);
+  });
+});
+
+describe("map title", () => {
+  it("prefixes the effort name with [manager]", () => {
+    expect(buildMapTitle(EFFORT)).toBe(`[manager] ${EFFORT.name}`);
+  });
+});
+
+describe("labels", () => {
+  it("desired label set always includes LABEL_MANAGER_MAP", () => {
+    expect(computeDesiredLabels()).toContain(LABEL_MANAGER_MAP);
+  });
+
+  it("computeLabelsToAdd returns labels not already present", () => {
+    expect(computeLabelsToAdd([], [LABEL_MANAGER_MAP])).toEqual([LABEL_MANAGER_MAP]);
+  });
+
+  it("computeLabelsToAdd returns empty when all desired labels are present", () => {
+    expect(computeLabelsToAdd([LABEL_MANAGER_MAP], [LABEL_MANAGER_MAP])).toEqual([]);
+  });
+
+  it("computeLabelsToAdd is additive only — it never removes existing labels", () => {
+    const existing = [LABEL_MANAGER_MAP, "some-other-label"];
+    const desired = [LABEL_MANAGER_MAP];
+    const toAdd = computeLabelsToAdd(existing, desired);
+    expect(toAdd).toEqual([]);
+    expect(existing).toContain("some-other-label");
+  });
+});
+
+describe("planMapPublish", () => {
+  it("plans create when no existing map is found", () => {
+    const plan = planMapPublish(EFFORT, null);
+    expect(plan.action).toBe("create");
+    expect(plan.mapNumber).toBeUndefined();
+  });
+
+  it("plans ok when the existing map already has all desired labels", () => {
+    const plan = planMapPublish(EFFORT, { number: 42, labels: [LABEL_MANAGER_MAP] });
+    expect(plan.action).toBe("ok");
+    expect(plan.mapNumber).toBe(42);
+  });
+
+  it("plans update-labels when the map is missing a desired label", () => {
+    const plan = planMapPublish(EFFORT, { number: 42, labels: [] });
+    expect(plan.action).toBe("update-labels");
+    expect(plan.mapNumber).toBe(42);
+    expect(plan.labelsToAdd).toContain(LABEL_MANAGER_MAP);
+  });
+
+  it("converges — a rerun after update-labels applied the label returns ok", () => {
+    const plan = planMapPublish(EFFORT, { number: 42, labels: [LABEL_MANAGER_MAP] });
+    expect(plan.action).toBe("ok");
+  });
+
+  it("rename-rejoin — the plan is ok when a renamed map still carries the marker label", () => {
+    const renamed = { number: 42, labels: [LABEL_MANAGER_MAP] };
+    expect(planMapPublish(EFFORT, renamed).action).toBe("ok");
+  });
+});
+
+describe("computeDerivedState", () => {
+  it("carries the map issue number and a child count matching the array length", () => {
+    const derived = computeDerivedState(99, [1, 2, 3]);
+    expect(derived.map_issue).toBe(99);
+    expect(derived.child_count).toBe(3);
+    expect(derived.children).toEqual([1, 2, 3]);
+  });
+
+  it("carries null map_issue and zero children when no map has been published", () => {
+    const derived = computeDerivedState(null, []);
+    expect(derived.map_issue).toBeNull();
+    expect(derived.child_count).toBe(0);
+    expect(derived.children).toEqual([]);
+  });
+
+  it("child_count matches the children array even with many children", () => {
+    const children = Array.from({ length: 50 }, (_, i) => i + 1);
+    const derived = computeDerivedState(7, children);
+    expect(derived.child_count).toBe(50);
+    expect(derived.children).toHaveLength(50);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2294. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2294

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787238982&installation_model_id=20659&pr_number=2362&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2362&signature=7d922ec37a1b8889a1d307c7a943b69ceefbfe114ab7dca4d420983beed48116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->