### PR TITLE
merge: #2332 Castle-MCP H4: MCP landings fire the real lifecycle hooks

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -74,6 +74,9 @@ import * as gitx from "./runtime/git.js";
 import { makeFeedbackWorktree } from "./runtime/feedback-worktree.js";
 import { relevantScopes, runFeedback } from "./core/feedback.js";
 import { doLanding } from "./core/landing.js";
+import { dispatchHooks, type HookExec } from "./core/hook-dispatcher.js";
+import { resolveHooks } from "./core/hook-config.js";
+import { makeHookExec, makeHookResolveOptions } from "./runtime/hooks.js";
 import {
   parseClaimRecords,
   renderClaimComment,
@@ -123,6 +126,8 @@ export interface DevAfkMcpRuntime {
   ensureLabel(root: string, name: string): Promise<void>;
   createIssue(root: string, spec: DisposableIssueSpec): Promise<number>;
   executeRequeue(root: string, input: RequeueToolInput): Promise<unknown>;
+  /** Injected in tests to intercept hook execution without spawning a shell. */
+  hookExec?: HookExec;
 }
 
 function captureStream(): {
@@ -235,6 +240,26 @@ function latestClaimPerWorker(
     if (!seen || record.commentId > seen.commentId) latest.set(record.worker, record);
   }
   return latest;
+}
+
+/**
+ * Build the `fireHook` closure used by MCP-initiated landings.
+ * Resolves the configured hook command list once at call time, then dispatches
+ * via `dispatchHooks` on each invocation. Exported for direct unit-testing with
+ * an injected `HookExec` fake.
+ */
+export function buildMcpLandingFireHook(
+  root: string,
+  exec: HookExec,
+): (name: "pre_merge" | "post_merge", context: string) => Promise<boolean> {
+  const paths = afkPaths(root);
+  const config = loadConfig(paths.configPath, { warn: () => undefined });
+  const resolveOptions = makeHookResolveOptions(root);
+  const resolved = resolveHooks(config, resolveOptions);
+  return async (name, context) => {
+    const result = await dispatchHooks(name, resolved[name], context, exec);
+    return !result.aborted;
+  };
 }
 
 export function createDefaultDevAfkMcpOperations(
@@ -417,11 +442,12 @@ export function createDefaultDevAfkMcpOperations(
       const changedFiles = await gitx.changedFiles(gitCtx, input.branch, base);
       const slug = (value: string) =>
         value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "base";
+      const fireHook = buildMcpLandingFireHook(root, runtime.hookExec ?? makeHookExec(root));
       const result = await doLanding(
         {
           mergeExec: gitx.mergeExec(gitCtx),
           remoteGit: gitx.gitExec(gitCtx),
-          fireHook: async () => true,
+          fireHook,
           makeLandingWorktree: async (target) => {
             const dest = join(paths.landingWorktreesDir, `${slug(target)}-mcp-${input.issue}`);
             await gitx.worktreeRemove(gitCtx, dest);
@@ -449,9 +475,20 @@ export function createDefaultDevAfkMcpOperations(
           changedFiles,
         },
         {
-          preMerge: () => `pre_merge #${input.issue} (${input.branch} → ${base})`,
+          preMerge: () =>
+            JSON.stringify({
+              issue: { number: input.issue, title: input.title ?? `Issue #${input.issue}` },
+              workspace: root,
+              branch: input.branch,
+              merge_base: base,
+            }),
           postMerge: (mergeSha) =>
-            `post_merge #${input.issue} (${input.branch} → ${base}${mergeSha ? ` @ ${mergeSha}` : ""})`,
+            JSON.stringify({
+              issue: { number: input.issue, title: input.title ?? `Issue #${input.issue}` },
+              workspace: root,
+              branch: input.branch,
+              ...(mergeSha ? { merge_commit: { sha: mergeSha, short: mergeSha.slice(0, 7) } } : {}),
+            }),
         },
       );
       return { issue: input.issue, branch: input.branch, base, ...result };

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -10,11 +10,13 @@ import {
   upsertFleetProfile,
 } from "@reddb-io/red-castle/engine";
 import {
+  buildMcpLandingFireHook,
   createDefaultDevAfkMcpOperations,
   createDevAfkMcpDependencies,
   resolveDevCliBundle,
   type DevAfkMcpOperations,
 } from "../src/mcp-adapter.js";
+import type { HookExec } from "../src/core/hook-dispatcher.js";
 
 const roots: string[] = [];
 
@@ -293,6 +295,73 @@ describe("dev:afk MCP host adapter", () => {
     await expect(
       deps.worktreeRemove({ path: join("..", "elsewhere") }),
     ).rejects.toThrow(/escapes/);
+  });
+});
+
+describe("buildMcpLandingFireHook — lifecycle hook wiring", () => {
+  async function writeHookConfig(cwd: string, hookYaml: string): Promise<void> {
+    await mkdir(join(cwd, ".red"), { recursive: true });
+    await writeFile(
+      join(cwd, ".red", "config.yaml"),
+      `plugins:\n  dev:\n    enabled: "true"\nafk:\n  hooks:\n${hookYaml}`,
+      "utf8",
+    );
+  }
+
+  it("invokes configured pre_merge hook commands via the injected exec", async () => {
+    const cwd = await root();
+    const fired: Array<{ command: string; code: number }> = [];
+    const exec: HookExec = async (command) => {
+      fired.push({ command, code: 0 });
+      return { code: 0, stdout: "" };
+    };
+
+    await writeHookConfig(cwd, "    pre_merge: probe-pre\n");
+
+    const fireHook = buildMcpLandingFireHook(cwd, exec);
+    const ok = await fireHook("pre_merge", "{}");
+
+    expect(ok).toBe(true);
+    expect(fired).toEqual([{ command: "probe-pre", code: 0 }]);
+  });
+
+  it("returns false and aborts when a pre_merge hook exits non-zero", async () => {
+    const cwd = await root();
+    const exec: HookExec = async () => ({ code: 1, stdout: "" });
+
+    await writeHookConfig(cwd, "    pre_merge: veto-hook\n");
+
+    const fireHook = buildMcpLandingFireHook(cwd, exec);
+    const ok = await fireHook("pre_merge", "{}");
+
+    expect(ok).toBe(false);
+  });
+
+  it("returns true for post_merge even when the hook exits non-zero (continue policy)", async () => {
+    const cwd = await root();
+    const exec: HookExec = async () => ({ code: 99, stdout: "" });
+
+    await writeHookConfig(cwd, "    post_merge: noisy-hook\n");
+
+    const fireHook = buildMcpLandingFireHook(cwd, exec);
+    const ok = await fireHook("post_merge", "{}");
+
+    expect(ok).toBe(true);
+  });
+
+  it("returns true and fires no exec when no hooks are configured", async () => {
+    const cwd = await root();
+    const fired: string[] = [];
+    const exec: HookExec = async (command) => {
+      fired.push(command);
+      return { code: 0, stdout: "" };
+    };
+
+    const fireHook = buildMcpLandingFireHook(cwd, exec);
+    const ok = await fireHook("pre_merge", "{}");
+
+    expect(ok).toBe(true);
+    expect(fired).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #2332. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2332

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787239000&installation_model_id=20659&pr_number=2363&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2363&signature=d5d90439e58ad16921ecbf74c979e3f1fbf51c3698e6b4322743a09b6a049fbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->