### PR TITLE
chore: #2333 Castle-MCP H5: review and triage tool domains

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -25,6 +25,7 @@ import type {
   CascadeStatusInput,
   CastleMcpDependencies,
   ClaimIssueInput,
+  DailyReviewInput,
   FleetCreateInput,
   FleetEditInput,
   FleetNameInput,
@@ -32,9 +33,12 @@ import type {
   LandBranchInput,
   LogsInput,
   RequeueToolInput,
+  RespondToolInput,
   RetakeToolInput,
   WaitStartInput,
   WaitStatusInput,
+  TriageToolInput,
+  WeeklyReviewInput,
   WorkerDispatchInput,
   WorkerRequestInput,
   WorkerSteerInput,
@@ -94,6 +98,9 @@ import {
 } from "./core/branch-cleanup.js";
 import { executeUnblockSweep } from "./core/boot-sweep.js";
 import { collectReapInputs } from "./runtime/wire/reap.js";
+import { activityReviewCommand } from "./commands/activity-review.js";
+import { triageCommand } from "./commands/triage.js";
+import { respondCommand } from "./commands/respond.js";
 
 interface DispatchOperationInput extends WorkerDispatchInput {
   request?: string;
@@ -119,6 +126,10 @@ export interface DevAfkMcpOperations {
   claimStatus(input: ClaimIssueInput): Promise<unknown>;
   claimRelease(input: ClaimIssueInput): Promise<unknown>;
   waitStart(input: WaitStartInput): Promise<unknown>;
+  dailyReview(input: DailyReviewInput): Promise<unknown>;
+  weeklyReview(input: WeeklyReviewInput): Promise<unknown>;
+  triage(input: TriageToolInput): Promise<unknown>;
+  respond(input: RespondToolInput): Promise<unknown>;
 }
 
 export interface DevAfkMcpRuntime {
@@ -649,6 +660,33 @@ export function createDefaultDevAfkMcpOperations(
       });
       const pid = await runtime.launchRspWait(args, root);
       return { id, pid, result_file: resultFile, status: "spawned" };
+    async dailyReview(_input) {
+      const capture = captureStream();
+      const exitCode = await activityReviewCommand("daily", [], root, capture.stream);
+      return parsedCommandOutput(capture.text(), exitCode, "toon");
+    },
+    async weeklyReview(_input) {
+      const capture = captureStream();
+      const exitCode = await activityReviewCommand("weekly", [], root, capture.stream);
+      return parsedCommandOutput(capture.text(), exitCode, "toon");
+    },
+    async triage(input) {
+      const args: string[] = [String(input.issue), "--decision", input.decision, "--json"];
+      if (input.summon) args.push("--summon");
+      if (input.repo) args.push("--repo", input.repo);
+      const capture = captureStream();
+      const exitCode = await triageCommand(args, root, capture.stream);
+      return parsedCommandOutput(capture.text(), exitCode, "json");
+    },
+    async respond(input) {
+      const args: string[] = ["--body", input.body, "--number", String(input.number)];
+      if (input.author) args.push("--author", input.author);
+      if (input.is_pr) args.push("--is-pr");
+      if (input.runner) args.push("--runner", input.runner);
+      if (input.repo) args.push("--repo", input.repo);
+      const capture = captureStream();
+      const exitCode = await respondCommand(args, root, capture.stream);
+      return parsedCommandOutput(capture.text(), exitCode, "toon");
     },
   };
 }
@@ -1048,5 +1086,9 @@ export function createDevAfkMcpDependencies(
     waitStart: (input) => operations.waitStart(input),
     waitList: () => listRspWaits(root),
     waitStatus: (input) => waitStatusImpl(root, input),
+    dailyReview: (input) => operations.dailyReview(input),
+    weeklyReview: (input) => operations.weeklyReview(input),
+    triage: (input) => operations.triage(input),
+    respond: (input) => operations.respond(input),
   };
 }

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -660,6 +660,7 @@ export function createDefaultDevAfkMcpOperations(
       });
       const pid = await runtime.launchRspWait(args, root);
       return { id, pid, result_file: resultFile, status: "spawned" };
+    },
     async dailyReview(_input) {
       const capture = captureStream();
       const exitCode = await activityReviewCommand("daily", [], root, capture.stream);

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -319,6 +319,36 @@ describe("dev:afk MCP host adapter", () => {
     });
   });
 
+  it("routes review and triage tools through their operations", async () => {
+    const cwd = await root();
+    const operations = fakeOperations();
+    const deps = createDevAfkMcpDependencies(cwd, operations);
+
+    await expect(deps.dailyReview({})).resolves.toMatchObject({
+      kind: "daily",
+    });
+    await expect(deps.weeklyReview({})).resolves.toMatchObject({
+      kind: "weekly",
+    });
+    await expect(
+      deps.triage({ issue: 2333, decision: "ready-for-agent" }),
+    ).resolves.toMatchObject({ issue: 2333 });
+    await expect(
+      deps.respond({ body: "/dev explain what is AFK?", number: 2333 }),
+    ).resolves.toMatchObject({ action: "ignored" });
+
+    expect(operations.dailyReview).toHaveBeenCalledWith({});
+    expect(operations.weeklyReview).toHaveBeenCalledWith({});
+    expect(operations.triage).toHaveBeenCalledWith({
+      issue: 2333,
+      decision: "ready-for-agent",
+    });
+    expect(operations.respond).toHaveBeenCalledWith({
+      body: "/dev explain what is AFK?",
+      number: 2333,
+    });
+  });
+
   it("enumerates the disposable worktree lanes and refuses escapes on removal", async () => {
     const cwd = await root();
     await mkdir(join(cwd, ".red", "tmp", "worktrees", "landing", "main-2307"), {
@@ -528,5 +558,9 @@ function fakeOperations(): DevAfkMcpOperations {
     claimStatus: vi.fn(async (input) => ({ issue: input.issue, holders: [] })),
     claimRelease: vi.fn(async (input) => ({ issue: input.issue, conceded: [] })),
     waitStart: vi.fn(async () => ({ id: "a1b2c3d4-uuid", pid: 73, status: "spawned" })),
+    dailyReview: vi.fn(async () => ({ kind: "daily" })),
+    weeklyReview: vi.fn(async () => ({ kind: "weekly" })),
+    triage: vi.fn(async (input) => ({ issue: input.issue, action: "apply" })),
+    respond: vi.fn(async () => ({ action: "ignored" })),
   };
 }

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -91,6 +91,10 @@ function deps(): CastleMcpDependencies {
       status: "finished",
       result: { schema: "rsp.wait.result", version: 1 },
     })),
+    dailyReview: vi.fn(async () => ({ kind: "daily" })),
+    weeklyReview: vi.fn(async () => ({ kind: "weekly" })),
+    triage: vi.fn(async (input) => ({ issue: input.issue, action: "apply" })),
+    respond: vi.fn(async () => ({ action: "ignored" })),
   };
 }
 
@@ -130,6 +134,10 @@ describe("dev:afk MCP tools", () => {
       "wait_start",
       "wait_list",
       "wait_status",
+      "daily_review",
+      "weekly_review",
+      "triage",
+      "respond",
     ]);
   });
 

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -8,6 +8,10 @@ import {
   createObservabilityTools,
   type ObservabilityDependencies,
 } from "./mcp/observability.js";
+import {
+  createReviewTools,
+  type ReviewDependencies,
+} from "./mcp/review.js";
 import { createRunnerTools, type RunnerDependencies } from "./mcp/runner.js";
 import type { CastleMcpTool } from "./mcp/tool.js";
 import { createWaitTools, type WaitDependencies } from "./mcp/wait.js";
@@ -41,6 +45,12 @@ export type { LandBranchInput, CascadeStatusInput } from "./mcp/landing.js";
 export type { ClaimIssueInput } from "./mcp/claim.js";
 export type { WorktreeRemoveInput } from "./mcp/worktree.js";
 export type { WaitStartInput, WaitStatusInput } from "./mcp/wait.js";
+export type {
+  DailyReviewInput,
+  WeeklyReviewInput,
+  TriageToolInput,
+  RespondToolInput,
+} from "./mcp/review.js";
 
 /**
  * The host adapter implements every capability domain at once, so the
@@ -58,7 +68,8 @@ export interface CastleMcpDependencies
     LandingDependencies,
     ClaimDependencies,
     WorktreeDependencies,
-    WaitDependencies {}
+    WaitDependencies,
+    ReviewDependencies {}
 
 /**
  * Compose the published dev:afk tool surface from the per-domain registries.
@@ -79,5 +90,6 @@ export function createCastleMcpTools(
     ...createClaimTools(deps),
     ...createWorktreeTools(deps),
     ...createWaitTools(deps),
+    ...createReviewTools(deps),
   ];
 }

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -242,6 +242,34 @@ const SURFACE: ReadonlyArray<{
       "Return the registry entry for a running wait or the sealed result envelope for a finished one.",
     schema: ["id"],
   },
+  {
+    name: "daily_review",
+    title: "Build daily activity review",
+    description:
+      "Return the structured daily activity review report for the local window.",
+    schema: [],
+  },
+  {
+    name: "weekly_review",
+    title: "Build weekly activity review",
+    description:
+      "Return the structured weekly activity review report for the local window.",
+    schema: [],
+  },
+  {
+    name: "triage",
+    title: "Apply triage decision",
+    description:
+      "MUTATING: apply the decided triage transition to one issue, gated by the per-repo trust policy.",
+    schema: ["issue", "decision", "summon", "repo"],
+  },
+  {
+    name: "respond",
+    title: "Handle comment event",
+    description:
+      "MUTATING: parse a /dev comment summon, authorize the commenter, and route the advisory or mutation verb.",
+    schema: ["body", "number", "author", "is_pr", "runner", "repo"],
+  },
 ];
 
 describe("aggregated dev:afk MCP tool surface", () => {

--- a/packages/red-castle/src/mcp/review.ts
+++ b/packages/red-castle/src/mcp/review.ts
@@ -1,0 +1,87 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface DailyReviewInput {
+  // rooted at the server cwd — no explicit repo needed
+}
+
+export interface WeeklyReviewInput {
+  // rooted at the server cwd — no explicit repo needed
+}
+
+export interface TriageToolInput {
+  issue: number;
+  decision: "ready-for-agent" | "needs-info" | "ready-for-human" | "wontfix";
+  summon?: boolean;
+  repo?: string;
+}
+
+export interface RespondToolInput {
+  body: string;
+  number: number;
+  author?: string;
+  is_pr?: boolean;
+  runner?: string;
+  repo?: string;
+}
+
+export interface ReviewDependencies {
+  dailyReview(input: DailyReviewInput): Promise<unknown>;
+  weeklyReview(input: WeeklyReviewInput): Promise<unknown>;
+  triage(input: TriageToolInput): Promise<unknown>;
+  respond(input: RespondToolInput): Promise<unknown>;
+}
+
+export function createReviewTools(deps: ReviewDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "daily_review",
+      title: "Build daily activity review",
+      description:
+        "Return the structured daily activity review report for the local window.",
+      inputSchema: {},
+      invoke: () => deps.dailyReview({}),
+    },
+    {
+      name: "weekly_review",
+      title: "Build weekly activity review",
+      description:
+        "Return the structured weekly activity review report for the local window.",
+      inputSchema: {},
+      invoke: () => deps.weeklyReview({}),
+    },
+    {
+      name: "triage",
+      title: "Apply triage decision",
+      description:
+        "MUTATING: apply the decided triage transition to one issue, gated by the per-repo trust policy.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        decision: z.enum([
+          "ready-for-agent",
+          "needs-info",
+          "ready-for-human",
+          "wontfix",
+        ]),
+        summon: z.boolean().optional(),
+        repo: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.triage(input as unknown as TriageToolInput),
+    },
+    {
+      name: "respond",
+      title: "Handle comment event",
+      description:
+        "MUTATING: parse a /dev comment summon, authorize the commenter, and route the advisory or mutation verb.",
+      inputSchema: {
+        body: z.string(),
+        number: z.number().int().positive(),
+        author: z.string().min(1).optional(),
+        is_pr: z.boolean().optional(),
+        runner: z.string().min(1).optional(),
+        repo: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.respond(input as unknown as RespondToolInput),
+    },
+  ];
+}

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -156,6 +156,21 @@ with a non-empty open backlog is a flow bug to census, not a clean stop.
 `reason` are optional. The returned `id` is the stable handle for `wait_status`.
 Finished waits are distinguished by a populated `result` field carrying the
 `rsp.wait.result` envelope; running waits carry `waits` with the active registry.
+### Review and Triage — activity reporting and issue routing
+
+| Tool | Mode | What it does |
+| --- | --- | --- |
+| `daily_review` | read | Structured daily activity review report for the local window. |
+| `weekly_review` | read | Structured weekly activity review report for the local window. |
+| `triage` | mutating | Apply the decided triage transition to one issue, gated by the per-repo trust policy. |
+| `respond` | mutating | Parse a `/dev` comment summon, authorize the commenter, and route the advisory or mutation verb. |
+
+`daily_review` and `weekly_review` are always rooted at the server's cwd — they
+auto-resolve the repo and the time window, so no parameters are required.
+`triage` requires `issue` and `decision` (`ready-for-agent` / `needs-info` /
+`ready-for-human` / `wontfix`); pass `summon: true` to release an untrusted
+author's issue. `respond` requires `body` and `number`; pass `is_pr: true` when
+the comment is on a pull request.
 
 ## Refs
 

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -156,6 +156,21 @@ with a non-empty open backlog is a flow bug to census, not a clean stop.
 `reason` are optional. The returned `id` is the stable handle for `wait_status`.
 Finished waits are distinguished by a populated `result` field carrying the
 `rsp.wait.result` envelope; running waits carry `waits` with the active registry.
+### Review and Triage — activity reporting and issue routing
+
+| Tool | Mode | What it does |
+| --- | --- | --- |
+| `daily_review` | read | Structured daily activity review report for the local window. |
+| `weekly_review` | read | Structured weekly activity review report for the local window. |
+| `triage` | mutating | Apply the decided triage transition to one issue, gated by the per-repo trust policy. |
+| `respond` | mutating | Parse a `/dev` comment summon, authorize the commenter, and route the advisory or mutation verb. |
+
+`daily_review` and `weekly_review` are always rooted at the server's cwd — they
+auto-resolve the repo and the time window, so no parameters are required.
+`triage` requires `issue` and `decision` (`ready-for-agent` / `needs-info` /
+`ready-for-human` / `wontfix`); pass `summon: true` to release an untrusted
+author's issue. `respond` requires `body` and `number`; pass `is_pr: true` when
+the comment is on a pull request.
 
 ## Refs
 


### PR DESCRIPTION
Automated AFK landing for #2333. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2333

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787242606&installation_model_id=20659&pr_number=2366&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2366&signature=16dd758703e8da0361df73a90e7150600436b38a7cca34a2ac5f69fffbbae5c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->