### PR TITLE
fix(dev): drop gh api --slurp from repair-issue discovery (landing crash on old gh)

### DIFF
--- a/apps/dev/src/runtime/gh/issues.ts
+++ b/apps/dev/src/runtime/gh/issues.ts
@@ -282,40 +282,51 @@ export async function listSpecSubIssueCandidates(
   return candidates;
 }
 
-/** List every open marked main-red repair issue across all GitHub result pages. */
+/** Hard page cap for repair-issue discovery: 20 pages × 100 = 2000 open issues. */
+const MAIN_RED_REPAIR_MAX_PAGES = 20;
+
+/**
+ * List every open marked main-red repair issue across all GitHub result pages.
+ * Pages explicitly (`page=N`) instead of `gh api --paginate --slurp`: `--slurp`
+ * only exists on gh >= 2.47, and on an older host gh the unknown flag crashed
+ * every landing at this call.
+ */
 export async function listMainRedRepairIssues(ctx: GhContext): Promise<MainRedRepairIssue[]> {
-  const r = await runGh(ctx, [
-    "api",
-    "--paginate",
-    "--slurp",
-    apiPath(ctx, "issues?state=open&per_page=100"),
-  ]);
-  if (r.code !== 0) {
-    throw new Error(`gh: failed to list main-red repair issues (code ${r.code}): ${(r.stderr || r.stdout).trim()}`);
+  const rows: Array<{
+    number?: number;
+    title?: string;
+    body?: string;
+    labels?: Array<{ name?: string }>;
+  }> = [];
+  for (let page = 1; page <= MAIN_RED_REPAIR_MAX_PAGES; page++) {
+    const r = await runGh(ctx, [
+      "api",
+      apiPath(ctx, `issues?state=open&per_page=100&page=${page}`),
+    ]);
+    if (r.code !== 0) {
+      throw new Error(`gh: failed to list main-red repair issues (code ${r.code}): ${(r.stderr || r.stdout).trim()}`);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(r.stdout || "[]");
+      if (!Array.isArray(parsed)) throw new Error("expected an array");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`gh: invalid main-red repair issue response: ${message}`);
+    }
+    rows.push(...(parsed as typeof rows));
+    if (parsed.length < 100) break;
   }
-  try {
-    const parsed = JSON.parse(r.stdout || "[]") as unknown;
-    if (!Array.isArray(parsed)) throw new Error("expected an array");
-    const rows = parsed.flatMap((page) => Array.isArray(page) ? page : [page]) as Array<{
-      number?: number;
-      title?: string;
-      body?: string;
-      labels?: Array<{ name?: string }>;
-    }>;
-    return rows
-      .filter((item) => String(item.body ?? "").includes(MAIN_RED_REPAIR_MARKER))
-      .map((row) => ({
-        number: Number(row.number),
-        title: String(row.title ?? ""),
-        body: String(row.body ?? ""),
-        labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")) : [],
-      }))
-      .filter((issue) => Number.isInteger(issue.number) && issue.number > 0)
-      .sort((a, b) => a.number - b.number);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`gh: invalid main-red repair issue response: ${message}`);
-  }
+  return rows
+    .filter((item) => String(item.body ?? "").includes(MAIN_RED_REPAIR_MARKER))
+    .map((row) => ({
+      number: Number(row.number),
+      title: String(row.title ?? ""),
+      body: String(row.body ?? ""),
+      labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")) : [],
+    }))
+    .filter((issue) => Number.isInteger(issue.number) && issue.number > 0)
+    .sort((a, b) => a.number - b.number);
 }
 
 /** Find an open marked main-red repair issue, optionally matching a failing-check set. */

--- a/apps/dev/tests/gh-main-red-repair.test.ts
+++ b/apps/dev/tests/gh-main-red-repair.test.ts
@@ -30,9 +30,11 @@ describe("findMainRedRepairIssue", () => {
     const issue = await findMainRedRepairIssue(ctx, ["test:apps/dev"]);
 
     expect(issue?.number).toBe(21);
-    expect(calls[0]).toContain("--paginate");
-    expect(calls[0]).toContain("--slurp");
-    expect(calls[0]).toContain("repos/acme/widgets/issues?state=open&per_page=100");
+    // Explicit page params, never `--paginate --slurp`: `--slurp` needs gh >= 2.47
+    // and an older host gh crashed every landing on the unknown flag.
+    expect(calls[0]).not.toContain("--paginate");
+    expect(calls[0]).not.toContain("--slurp");
+    expect(calls[0]).toContain("repos/acme/widgets/issues?state=open&per_page=100&page=1");
   });
 
   it("examines every paginated open issue before selecting a match", async () => {
@@ -40,14 +42,22 @@ describe("findMainRedRepairIssue", () => {
       sha: "aaaa",
       failures: [{ check: "test:apps/dev", summary: "tests failed", outputTail: "tail" }],
     });
-    const exec: ExecFn = async () => ({
-      code: 0,
-      stdout: JSON.stringify([
-        [{ number: 20, body: "unrelated", labels: [] }],
-        [{ number: 321, body: matchingBody, labels: [] }],
-      ]),
-      stderr: "",
-    });
+    const fullFirstPage = Array.from({ length: 100 }, (_, i) => ({
+      number: i + 1,
+      body: "unrelated",
+      labels: [],
+    }));
+    const exec: ExecFn = async (_cmd, args) => {
+      const path = args[args.length - 1] ?? "";
+      const page = /[?&]page=([0-9]+)$/.exec(path)?.[1];
+      return {
+        code: 0,
+        stdout: JSON.stringify(
+          page === "1" ? fullFirstPage : [{ number: 321, body: matchingBody, labels: [] }],
+        ),
+        stderr: "",
+      };
+    };
 
     const issue = await findMainRedRepairIssue(
       { cwd: "/repo", repo: "acme/widgets", exec },


### PR DESCRIPTION
Every fleet landing on a host with gh < 2.47 crashed with `unknown flag: --slurp` inside `listMainRedRepairIssues` (introduced by 6b96e10d2, Refs #2269, shipped in v2.77.1). Crashed-parked #2364, #2293, #2333 today.

Replaces `gh api --paginate --slurp` with an explicit `page=N` loop (per_page=100, capped at 20 pages), which behaves identically on every gh version. Tests updated to pin the explicit-pagination contract and the multi-page sweep.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787245242&installation_model_id=20659&pr_number=2367&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2367&signature=5941f609ce0bf6635ada95b099b0f4a31feb007586a498b60a2a152f52b84d72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->