### PR TITLE
feat(castle-mcp): E4 wait tools — wait_start, wait_list, wait_status

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,7 +1,9 @@
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { worktreesDir } from "@reddb-io/shared/red-paths.js";
+import { waitsDir, worktreesDir } from "@reddb-io/shared/red-paths.js";
 import { Writable } from "node:stream";
 import { decode as decodeToon } from "@reddb-io/toon";
 import {
@@ -32,12 +34,15 @@ import type {
   LogsInput,
   RequeueToolInput,
   RetakeToolInput,
+  WaitStartInput,
+  WaitStatusInput,
   WorkerDispatchInput,
   WorkerRequestInput,
   WorkerSteerInput,
   WorkerStopInput,
   WorktreeRemoveInput,
 } from "../../../packages/red-castle/src/mcp-server.js";
+import { listWaits as listRspWaits } from "../../rsp/src/wait/registry.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { collectDashboardReport } from "./commands/dashboard.js";
 import { stopFleet, writeResizeRequest } from "./commands/fleet.js";
@@ -119,10 +124,13 @@ export interface DevAfkMcpOperations {
   cascadeStatus(input: CascadeStatusInput): Promise<unknown>;
   claimStatus(input: ClaimIssueInput): Promise<unknown>;
   claimRelease(input: ClaimIssueInput): Promise<unknown>;
+  waitStart(input: WaitStartInput): Promise<unknown>;
 }
 
 export interface DevAfkMcpRuntime {
   launchRun(root: string, args: readonly string[]): Promise<{ pid: number }>;
+  /** Spawn rsp wait detached; returns the child PID. */
+  launchRspWait(args: readonly string[], cwd: string): Promise<number>;
   ensureLabel(root: string, name: string): Promise<void>;
   createIssue(root: string, spec: DisposableIssueSpec): Promise<number>;
   executeRequeue(root: string, input: RequeueToolInput): Promise<unknown>;
@@ -208,8 +216,68 @@ export function resolveDevCliBundle(mcpBundle: string): string {
   );
 }
 
+export function resolveRspCliBundle(mcpBundle: string): string {
+  const file = basename(mcpBundle);
+  if (file === "afk-mcp.bundle.min.mjs") {
+    return join(dirname(mcpBundle), "rsp.bundle.min.mjs");
+  }
+  if (file.startsWith("afk-mcp-") && file.endsWith(".bundle.min.mjs")) {
+    return join(dirname(mcpBundle), file.replace(/^afk-mcp-/, "rsp-"));
+  }
+  throw new Error(
+    `cannot spawn rsp wait: unrecognized MCP bundle name ${JSON.stringify(file)}`,
+  );
+}
+
+async function launchDetachedRspWait(
+  args: readonly string[],
+  cwd: string,
+): Promise<number> {
+  const mcpBundle = process.argv[1];
+  if (!mcpBundle) {
+    throw new Error("cannot spawn rsp wait: MCP bundle path is missing");
+  }
+  const bundle = resolveRspCliBundle(mcpBundle);
+  if (!existsSync(bundle)) {
+    throw new Error("cannot spawn rsp wait: sibling rsp bundle is missing");
+  }
+  const child = spawn(process.execPath, [bundle, ...args], {
+    cwd,
+    env: process.env,
+    detached: true,
+    stdio: "ignore",
+  });
+  const pid = child.pid;
+  if (!pid) throw new Error("cannot spawn rsp wait: spawn returned no pid");
+  child.unref();
+  return pid;
+}
+
+function buildWaitArgs(
+  kind: WaitStartInput["kind"],
+  target: string,
+  resultFile: string,
+  opts: { timeout_ms?: number; reason?: string },
+): string[] {
+  const args: string[] = ["wait", kind];
+  if (kind !== "cmd" && kind !== "release") {
+    args.push(target);
+  }
+  if (kind === "release" && target !== "*") {
+    args.push("--tag", target);
+  }
+  if (opts.timeout_ms !== undefined) args.push("--timeout", String(opts.timeout_ms));
+  if (opts.reason) args.push("--reason", opts.reason);
+  args.push("--result-file", resultFile);
+  if (kind === "cmd") {
+    args.push("--", target);
+  }
+  return args;
+}
+
 const defaultMcpRuntime: DevAfkMcpRuntime = {
   launchRun: launchDetachedRun,
+  launchRspWait: launchDetachedRspWait,
   async ensureLabel(root, name) {
     const context = await resolveRepoContext(root);
     await ghx.ensureLabel({ cwd: context.root, repo: context.repo }, name);
@@ -564,7 +632,32 @@ export function createDefaultDevAfkMcpOperations(
       }
       return { issue: input.issue, conceded };
     },
+    async waitStart(input) {
+      const id = randomUUID();
+      const resultFile = join(waitsDir(root), `${id}.toon`);
+      const args = buildWaitArgs(input.kind, input.target, resultFile, {
+        timeout_ms: input.timeout_ms,
+        reason: input.reason,
+      });
+      const pid = await runtime.launchRspWait(args, root);
+      return { id, pid, result_file: resultFile, status: "spawned" };
+    },
   };
+}
+
+async function waitStatusImpl(root: string, input: WaitStatusInput): Promise<unknown> {
+  const resultFile = join(waitsDir(root), `${input.id}.toon`);
+  try {
+    const raw = await readFile(resultFile, "utf8");
+    const trimmed = raw.trim();
+    if (trimmed) {
+      return { id: input.id, status: "finished", result: decodeToon(trimmed) };
+    }
+  } catch {
+    // result file not present — wait is still running or never started
+  }
+  const active = await listRspWaits(root);
+  return { id: input.id, status: "running", waits: active };
 }
 
 function registryPath(root: string): string {
@@ -945,5 +1038,8 @@ export function createDevAfkMcpDependencies(
     claimRelease: (input) => operations.claimRelease(input),
     worktreeList: () => listDisposableWorktrees(root),
     worktreeRemove: (input) => removeDisposableWorktree(root, input),
+    waitStart: (input) => operations.waitStart(input),
+    waitList: () => listRspWaits(root),
+    waitStatus: (input) => waitStatusImpl(root, input),
   };
 }

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -1,6 +1,9 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { JsonObject } from "@reddb-io/toon";
+import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
+import { waitsDir } from "@reddb-io/shared/red-paths.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   appendCastleLaneRecord,
@@ -14,6 +17,7 @@ import {
   createDefaultDevAfkMcpOperations,
   createDevAfkMcpDependencies,
   resolveDevCliBundle,
+  resolveRspCliBundle,
   type DevAfkMcpOperations,
 } from "../src/mcp-adapter.js";
 import type { HookExec } from "../src/core/hook-dispatcher.js";
@@ -338,6 +342,94 @@ describe("dev:afk MCP host adapter", () => {
   });
 });
 
+describe("rsp wait MCP tools", () => {
+  it("resolves the sibling rsp CLI bundle from local and cached MCP assets", () => {
+    expect(
+      resolveRspCliBundle(join("dist", "afk-mcp.bundle.min.mjs")),
+    ).toBe(join("dist", "rsp.bundle.min.mjs"));
+    expect(
+      resolveRspCliBundle(
+        join("cache", "afk-mcp-2.76.1.bundle.min.mjs"),
+      ),
+    ).toBe(join("cache", "rsp-2.76.1.bundle.min.mjs"));
+  });
+
+  it("spawns a detached rsp wait and returns its id without writing to stdout", async () => {
+    const cwd = await root();
+    const launchRspWait = vi.fn(async (_args: readonly string[], _cwd: string) => 73);
+    const stdout = vi.spyOn(process.stdout, "write");
+    const operations = createDefaultDevAfkMcpOperations(cwd, { launchRspWait });
+
+    try {
+      const result = await operations.waitStart({ kind: "pr", target: "2364", reason: "CI check" }) as Record<string, unknown>;
+      expect(result).toMatchObject({ pid: 73, status: "spawned" });
+      expect(typeof result.id).toBe("string");
+    } finally {
+      stdout.mockRestore();
+    }
+
+    expect(stdout).not.toHaveBeenCalled();
+    expect(launchRspWait.mock.calls[0]?.[0]).toEqual(
+      expect.arrayContaining(["wait", "pr", "2364", "--reason", "CI check"]),
+    );
+  });
+
+  it("passes kind-specific arguments for pr, run, release, and cmd targets", async () => {
+    const cwd = await root();
+    const launchRspWait = vi.fn(async (_args: readonly string[], _cwd: string) => 99);
+    const operations = createDefaultDevAfkMcpOperations(cwd, { launchRspWait });
+
+    await operations.waitStart({ kind: "run", target: "987654321" });
+    expect(launchRspWait.mock.calls[0]?.[0]).toEqual(
+      expect.arrayContaining(["wait", "run", "987654321"]),
+    );
+
+    await operations.waitStart({ kind: "release", target: "v2.*" });
+    expect(launchRspWait.mock.calls[1]?.[0]).toEqual(
+      expect.arrayContaining(["wait", "release", "--tag", "v2.*"]),
+    );
+
+    await operations.waitStart({ kind: "cmd", target: "pnpm build" });
+    const cmdArgs = launchRspWait.mock.calls[2]?.[0] as string[] | undefined;
+    expect(cmdArgs).toContain("--");
+    expect(cmdArgs?.[cmdArgs.indexOf("--") + 1]).toBe("pnpm build");
+  });
+
+  it("lists active waits from the registry directory", async () => {
+    const cwd = await root();
+    const deps = createDevAfkMcpDependencies(cwd, fakeOperations());
+    await expect(deps.waitList()).resolves.toEqual([]);
+  });
+
+  it("reads the sealed result envelope for a finished wait", async () => {
+    const cwd = await root();
+    const id = "a1b2c3d4-finished-wait";
+    const envelope = {
+      schema: "rsp.wait.result",
+      version: 1,
+      wait: { id: "rsp-internal-uuid", status: "success" },
+    };
+    const dir = waitsDir(cwd);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, `${id}.toon`),
+      encodeSnapshotToon(envelope as unknown as JsonObject) + "\n",
+      "utf8",
+    );
+
+    const deps = createDevAfkMcpDependencies(cwd, fakeOperations());
+    const result = await deps.waitStatus({ id }) as Record<string, unknown>;
+    expect(result).toMatchObject({ id, status: "finished", result: { schema: "rsp.wait.result" } });
+  });
+
+  it("returns running status with active registry when result file is absent", async () => {
+    const cwd = await root();
+    const deps = createDevAfkMcpDependencies(cwd, fakeOperations());
+    const result = await deps.waitStatus({ id: "no-such-wait" }) as Record<string, unknown>;
+    expect(result).toMatchObject({ id: "no-such-wait", status: "running", waits: [] });
+  });
+});
+
 describe("buildMcpLandingFireHook — lifecycle hook wiring", () => {
   async function writeHookConfig(cwd: string, hookYaml: string): Promise<void> {
     await mkdir(join(cwd, ".red"), { recursive: true });
@@ -431,5 +523,6 @@ function fakeOperations(): DevAfkMcpOperations {
     })),
     claimStatus: vi.fn(async (input) => ({ issue: input.issue, holders: [] })),
     claimRelease: vi.fn(async (input) => ({ issue: input.issue, conceded: [] })),
+    waitStart: vi.fn(async () => ({ id: "a1b2c3d4-uuid", pid: 73, status: "spawned" })),
   };
 }

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -85,6 +85,13 @@ function deps(): CastleMcpDependencies {
       { lane: "landing", name: "main-adopt-2307", path: ".red/tmp/worktrees/landing/main-adopt-2307" },
     ]),
     worktreeRemove: vi.fn(async (input) => ({ path: input.path, removed: true })),
+    waitStart: vi.fn(async () => ({ id: "a1b2c3d4-uuid", pid: 42, status: "spawned" })),
+    waitList: vi.fn(async () => []),
+    waitStatus: vi.fn(async () => ({
+      id: "a1b2c3d4-uuid",
+      status: "finished",
+      result: { schema: "rsp.wait.result", version: 1 },
+    })),
   };
 }
 
@@ -122,6 +129,9 @@ describe("dev:afk MCP tools", () => {
       "claim_release",
       "worktree_list",
       "worktree_remove",
+      "wait_start",
+      "wait_list",
+      "wait_status",
     ]);
   });
 
@@ -307,6 +317,37 @@ describe("dev:afk MCP tools", () => {
     expect(d.claimRelease).toHaveBeenCalledWith({ issue: 2307 });
     expect(
       tools.find((tool) => tool.name === "claim_release")!.description,
+    ).toMatch(/^MUTATING:/);
+  });
+
+  it("starts, lists, and reads wait status through the Wait domain", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await expect(
+      tools.find((tool) => tool.name === "wait_start")!.invoke({
+        kind: "pr",
+        target: "2364",
+        reason: "CI check",
+      }),
+    ).resolves.toMatchObject({ id: "a1b2c3d4-uuid", pid: 42, status: "spawned" });
+    expect(d.waitStart).toHaveBeenCalledWith({
+      kind: "pr",
+      target: "2364",
+      reason: "CI check",
+    });
+
+    await expect(
+      tools.find((tool) => tool.name === "wait_list")!.invoke({}),
+    ).resolves.toEqual([]);
+
+    await expect(
+      tools.find((tool) => tool.name === "wait_status")!.invoke({ id: "a1b2c3d4-uuid" }),
+    ).resolves.toMatchObject({ status: "finished", result: { schema: "rsp.wait.result" } });
+    expect(d.waitStatus).toHaveBeenCalledWith({ id: "a1b2c3d4-uuid" });
+
+    expect(
+      tools.find((tool) => tool.name === "wait_start")!.description,
     ).toMatch(/^MUTATING:/);
   });
 

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -10,6 +10,7 @@ import {
 } from "./mcp/observability.js";
 import { createRunnerTools, type RunnerDependencies } from "./mcp/runner.js";
 import type { CastleMcpTool } from "./mcp/tool.js";
+import { createWaitTools, type WaitDependencies } from "./mcp/wait.js";
 import { createWorkerTools, type WorkerDependencies } from "./mcp/worker.js";
 import {
   createWorktreeTools,
@@ -39,6 +40,7 @@ export type { GateRunInput, GateBaselineStatusInput } from "./mcp/gate.js";
 export type { LandBranchInput, CascadeStatusInput } from "./mcp/landing.js";
 export type { ClaimIssueInput } from "./mcp/claim.js";
 export type { WorktreeRemoveInput } from "./mcp/worktree.js";
+export type { WaitStartInput, WaitStatusInput } from "./mcp/wait.js";
 
 /**
  * The host adapter implements every capability domain at once, so the
@@ -55,7 +57,8 @@ export interface CastleMcpDependencies
     GateDependencies,
     LandingDependencies,
     ClaimDependencies,
-    WorktreeDependencies {}
+    WorktreeDependencies,
+    WaitDependencies {}
 
 /**
  * Compose the published dev:afk tool surface from the per-domain registries.
@@ -75,5 +78,6 @@ export function createCastleMcpTools(
     ...createLandingTools(deps),
     ...createClaimTools(deps),
     ...createWorktreeTools(deps),
+    ...createWaitTools(deps),
   ];
 }

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -229,6 +229,26 @@ const SURFACE: ReadonlyArray<{
       "MUTATING: remove one checkout under the disposable `.red/tmp/worktrees/*` lanes.",
     schema: ["path"],
   },
+  {
+    name: "wait_start",
+    title: "Start rsp wait",
+    description:
+      "MUTATING: spawn a detached rsp wait (pr | run | release | cmd) and return its registry id.",
+    schema: ["kind", "target", "timeout_ms", "reason"],
+  },
+  {
+    name: "wait_list",
+    title: "List active rsp waits",
+    description: "Return the active-wait registry from .red/tmp/waits.",
+    schema: [],
+  },
+  {
+    name: "wait_status",
+    title: "Read rsp wait status",
+    description:
+      "Return the registry entry for a running wait or the sealed result envelope for a finished one.",
+    schema: ["id"],
+  },
 ];
 
 describe("aggregated dev:afk MCP tool surface", () => {

--- a/packages/red-castle/src/mcp/wait.ts
+++ b/packages/red-castle/src/mcp/wait.ts
@@ -1,0 +1,54 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface WaitStartInput {
+  kind: "pr" | "run" | "release" | "cmd";
+  target: string;
+  timeout_ms?: number;
+  reason?: string;
+}
+
+export interface WaitStatusInput {
+  id: string;
+}
+
+export interface WaitDependencies {
+  waitStart(input: WaitStartInput): Promise<unknown>;
+  waitList(): Promise<unknown>;
+  waitStatus(input: WaitStatusInput): Promise<unknown>;
+}
+
+export function createWaitTools(deps: WaitDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "wait_start",
+      title: "Start rsp wait",
+      description:
+        "MUTATING: spawn a detached rsp wait (pr | run | release | cmd) and return its registry id.",
+      inputSchema: {
+        kind: z.enum(["pr", "run", "release", "cmd"]),
+        target: z.string().min(1),
+        timeout_ms: z.number().int().positive().optional(),
+        reason: z.string().optional(),
+      },
+      invoke: (input) => deps.waitStart(input as unknown as WaitStartInput),
+    },
+    {
+      name: "wait_list",
+      title: "List active rsp waits",
+      description: "Return the active-wait registry from .red/tmp/waits.",
+      inputSchema: {},
+      invoke: () => deps.waitList(),
+    },
+    {
+      name: "wait_status",
+      title: "Read rsp wait status",
+      description:
+        "Return the registry entry for a running wait or the sealed result envelope for a finished one.",
+      inputSchema: {
+        id: z.string().min(1),
+      },
+      invoke: ({ id }) => deps.waitStatus({ id: id as string }),
+    },
+  ];
+}

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -144,6 +144,19 @@ labels by hand.
 `queue_status` is the first call of any drain: an empty `ready-for-agent` queue
 with a non-empty open backlog is a flow bug to census, not a clean stop.
 
+### Wait — programmatic outcome polling
+
+| Tool | Mode | What it does |
+| --- | --- | --- |
+| `wait_start` | mutating | Spawn a detached rsp wait and return its registry id. |
+| `wait_list` | read | Active-wait registry from `.red/tmp/waits`. |
+| `wait_status` | read | Registry entry for a running wait or sealed result envelope for a finished one. |
+
+`wait_start` accepts `pr`, `run`, `release`, and `cmd` targets; `timeout_ms` and
+`reason` are optional. The returned `id` is the stable handle for `wait_status`.
+Finished waits are distinguished by a populated `result` field carrying the
+`rsp.wait.result` envelope; running waits carry `waits` with the active registry.
+
 ## Refs
 
 - ADR 0120 — red-castle is the AFK MCP; CLI and skills are clients.

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -144,6 +144,19 @@ labels by hand.
 `queue_status` is the first call of any drain: an empty `ready-for-agent` queue
 with a non-empty open backlog is a flow bug to census, not a clean stop.
 
+### Wait — programmatic outcome polling
+
+| Tool | Mode | What it does |
+| --- | --- | --- |
+| `wait_start` | mutating | Spawn a detached rsp wait and return its registry id. |
+| `wait_list` | read | Active-wait registry from `.red/tmp/waits`. |
+| `wait_status` | read | Registry entry for a running wait or sealed result envelope for a finished one. |
+
+`wait_start` accepts `pr`, `run`, `release`, and `cmd` targets; `timeout_ms` and
+`reason` are optional. The returned `id` is the stable handle for `wait_status`.
+Finished waits are distinguished by a populated `result` field carrying the
+`rsp.wait.result` envelope; running waits carry `waits` with the active registry.
+
 ## Refs
 
 - ADR 0120 — red-castle is the AFK MCP; CLI and skills are clients.


### PR DESCRIPTION
## Summary

- Adds three MCP tools to the `dev:afk` Castle-MCP server exposing the hardened `rsp wait` engine
- `wait_start` (`MUTATING:`) spawns ONE detached `rsp wait` (pr/run/release/cmd targets) and returns the wait registry id — transport-safe, no stdout pollution
- `wait_list` (read) returns the active-wait registry (`.red/tmp/waits/`), same truth as `rsp wait ls`
- `wait_status` (read) returns one wait's registry entry plus, when finished, its sealed `rsp.wait.result` envelope

## Changes

- **NEW** `packages/red-castle/src/mcp/wait.ts` — wait domain module with `WaitDependencies` interface and `createWaitTools()`
- **MODIFIED** `packages/red-castle/src/mcp-server.ts` — wires `WaitDependencies` into `CastleMcpDependencies` and composition
- **MODIFIED** `packages/red-castle/src/mcp-tool-surface.test.ts` — frozen surface extended with wait_start/wait_list/wait_status entries
- **MODIFIED** `packages/red-castle/src/mcp-server.test.ts` — Wait domain fakes + integration test
- **MODIFIED** `apps/dev/src/mcp-adapter.ts` — real implementations: `resolveRspCliBundle`, `buildWaitArgs` (4 kinds), `waitStart` (detached spawn), `waitList`, `waitStatusImpl`
- **MODIFIED** `apps/dev/tests/mcp-adapter.test.ts` — 6 new tests under `rsp wait MCP tools`
- **MODIFIED** `plugins/dev/skills/engineering/afk/MCP.md` — Wait domain section

## Test plan

- [x] `packages/red-castle`: 76 test files, 1647 tests passing
- [x] `apps/dev`: `mcp-adapter.test.ts` (22 tests) + `castle-mcp-client-docs.test.ts` (8 tests) passing
- [x] Input validation rejects unknown target kinds
- [x] Transport-safe: detached spawn, no stdout writes

Refs #2364

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787245694&installation_model_id=20659&pr_number=2371&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2371&signature=cc62455e1f562b5bae730273c954c43c4b64fc551ca9df555171f40827dfdcc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->