### PR TITLE
feat(manager): S3 routing + inline session-bound handoff

### DIFF
--- a/apps/dev/src/commands/manager.ts
+++ b/apps/dev/src/commands/manager.ts
@@ -1,16 +1,21 @@
 // commands/manager.ts — the operator front door of the Manager (Spec #2290,
-// slices #2291, #2292, #2295; architecture in ADR 0109).
+// slices #2291, #2292, #2293, #2295; architecture in ADR 0109).
 //
-// Five shapes:
-//   `manager <intent>`         — mint an effort from the intent and persist it.
-//   `manager status [id]`      — render the brief for one effort (newest by default).
-//   `manager resume [id]`      — transition inbox/paused effort → active, acquire lease.
-//   `manager end [id]`         — transition active effort → completed, release lease.
-//   `manager dispatch [id]`    — dispatch an autonomous execution for the effort and
-//                                record the tracker issue number (slice #2295).
+// Lifecycle operations understood by this command:
+//   `manager <intent>`              — mint an effort from the intent and persist it.
+//   `manager status [id]`           — render the brief for one effort (newest by default).
+//   `manager resume [id]`           — transition inbox/paused effort → active, acquire lease.
+//   `manager end [id]`              — transition active effort → completed, release lease.
+//   `manager dispatch [id]`         — dispatch an autonomous execution for the effort and
+//                                     record the tracker issue number (slice #2295).
+//   `manager route <id> <skill>`    — record the ask-red route for an effort.
+//   `manager artifact <id> <ref>`   — capture an artifact reference from an
+//                                     inline session-bound skill run.
 //
 // The command is conversation-first: anything that is not a lifecycle keyword IS
-// the intent. Routing and reconciliation happen at render time via the GH layer.
+// the intent. Routing classification (intent → skill) is ask-red's job at the
+// SKILL.md/agent layer; this command only stores the route that ask-red returned
+// and the artifact references that inline skills produce.
 
 import { homedir } from "node:os";
 import { resolveManagerRoot } from "@reddb-io/shared/red-paths.js";
@@ -55,14 +60,16 @@ export interface ManagerCommandDeps {
 }
 
 const USAGE = [
-  "usage: afk manager <intent>          start an effort from an intent",
-  "       afk manager status [effort]   render an effort brief (default: the newest)",
-  "       afk manager resume [effort]   transition an effort to active and acquire the lease",
-  "       afk manager end [effort]      transition an active effort to completed",
-  "       afk manager dispatch [effort] dispatch autonomous execution for the effort",
+  "usage: afk manager <intent>                  start an effort from an intent",
+  "       afk manager status [effort]           render an effort brief (default: newest)",
+  "       afk manager resume [effort]           transition an effort to active and acquire the lease",
+  "       afk manager end [effort]              transition an active effort to completed",
+  "       afk manager dispatch [effort]         dispatch autonomous execution for the effort",
+  "       afk manager route <effort> <skill>    record the ask-red route",
+  "       afk manager artifact <effort> <ref>   capture an artifact reference",
 ].join("\n");
 
-const LIFECYCLE_WORDS = new Set(["status", "resume", "end", "dispatch"]);
+const LIFECYCLE_WORDS = new Set(["status", "resume", "end", "dispatch", "route", "artifact"]);
 
 function resolveRoot(deps: ManagerCommandDeps): string {
   return deps.root ?? resolveManagerRoot({ homeDir: homedir(), env: process.env });
@@ -178,6 +185,55 @@ async function dispatchCommand(
   return 0;
 }
 
+async function routeCommand(
+  effortId: string | undefined,
+  skill: string | undefined,
+  root: string,
+  write: (text: string) => void,
+  fail: (text: string) => void,
+  now: (() => Date) | undefined,
+): Promise<number> {
+  if (!effortId || !skill) {
+    fail(`${USAGE}\n`);
+    return 2;
+  }
+  const effort = await readEffort(root, effortId);
+  if (!effort) {
+    fail(`[manager] no effort ${effortId} in this portfolio\n`);
+    return 1;
+  }
+  const updated = await saveEffort(root, { ...effort, route: skill }, { now });
+  write(`${renderEffortBrief(updated)}\n`);
+  return 0;
+}
+
+async function artifactCommand(
+  effortId: string | undefined,
+  ref: string | undefined,
+  root: string,
+  write: (text: string) => void,
+  fail: (text: string) => void,
+  now: (() => Date) | undefined,
+): Promise<number> {
+  if (!effortId || !ref) {
+    fail(`${USAGE}\n`);
+    return 2;
+  }
+  const effort = await readEffort(root, effortId);
+  if (!effort) {
+    fail(`[manager] no effort ${effortId} in this portfolio\n`);
+    return 1;
+  }
+  const existing = effort.artifact_refs ?? [];
+  const updated = await saveEffort(
+    root,
+    { ...effort, artifact_refs: [...existing, ref] },
+    { now },
+  );
+  write(`${renderEffortBrief(updated)}\n`);
+  return 0;
+}
+
 export async function managerCommand(
   args: readonly string[],
   deps: ManagerCommandDeps = {},
@@ -196,6 +252,12 @@ export async function managerCommand(
     if (words[0] === "resume") return await resumeCommand(words[1], root, write, fail, deps);
     if (words[0] === "end") return await endCommand(words[1], root, write, fail, deps);
     if (words[0] === "dispatch") return await dispatchCommand(words[1], root, write, fail, deps);
+    if (words[0] === "route") {
+      return await routeCommand(words[1], words[2], root, write, fail, deps.now);
+    }
+    if (words[0] === "artifact") {
+      return await artifactCommand(words[1], words[2], root, write, fail, deps.now);
+    }
     // Anything that is not a known lifecycle keyword is the intent.
     if (LIFECYCLE_WORDS.has(words[0])) {
       fail(`[manager] unknown subcommand "${words[0]}"\n`);

--- a/apps/dev/src/core/manager/brief.ts
+++ b/apps/dev/src/core/manager/brief.ts
@@ -29,6 +29,10 @@ export function renderEffortBrief(effort: EffortRecord): string {
     intent: effort.intent,
     created_at: effort.created_at,
     updated_at: effort.updated_at,
+    ...(effort.route !== undefined ? { route: effort.route } : {}),
+    ...(effort.artifact_refs !== undefined && effort.artifact_refs.length > 0
+      ? { artifact_refs: [...effort.artifact_refs] }
+      : {}),
   });
 }
 

--- a/apps/dev/src/core/manager/effort-store.ts
+++ b/apps/dev/src/core/manager/effort-store.ts
@@ -60,6 +60,10 @@ export interface EffortRecord {
    * evidence, never stored here.
    */
   dispatch_issue?: number;
+  /** Skill name ask-red recommended for this effort (S3: routing slice). */
+  route?: string;
+  /** Artifact references captured from inline session-bound skill runs (S3). */
+  artifact_refs?: readonly string[];
 }
 
 /** Base class for every refusal this store raises. */
@@ -155,7 +159,22 @@ export function encodeEffortDocument(effort: EffortRecord): string {
     schema: MANAGER_EFFORT_SCHEMA,
     version: MANAGER_EFFORT_SCHEMA_VERSION,
   };
-  const body: ToonlRecord = { kind: "manager.effort", ...effort };
+  const body: ToonlRecord = {
+    kind: "manager.effort",
+    effort_id: effort.effort_id,
+    name: effort.name,
+    intent: effort.intent,
+    lifecycle: effort.lifecycle,
+    generation: effort.generation,
+    created_at: effort.created_at,
+    updated_at: effort.updated_at,
+  };
+  if (effort.route !== undefined) body.route = effort.route;
+  // ToonlRecord is flat (no arrays), so encode the list as newline-separated.
+  // URLs never contain newlines, so the delimiter is unambiguous.
+  if (effort.artifact_refs !== undefined && effort.artifact_refs.length > 0) {
+    body.artifact_refs = effort.artifact_refs.join("\n");
+  }
   return encodeRecords([header, body]);
 }
 
@@ -207,6 +226,14 @@ export function decodeEffortDocument(text: string): EffortRecord {
   if (typeof generation !== "number" || !Number.isInteger(generation) || generation < 1) {
     throw new ManagerSchemaError("manager effort document has a non-integer generation");
   }
+  const route = typeof body["route"] === "string" ? body["route"] : undefined;
+  // artifact_refs is stored as a newline-separated string (ToonlRecord is flat).
+  const rawRefs = body["artifact_refs"];
+  const artifact_refs =
+    typeof rawRefs === "string" && rawRefs.length > 0
+      ? rawRefs.split("\n")
+      : undefined;
+
   const record: EffortRecord = {
     effort_id: requireString(body, "effort_id"),
     name: requireString(body, "name"),
@@ -215,6 +242,8 @@ export function decodeEffortDocument(text: string): EffortRecord {
     generation,
     created_at: requireString(body, "created_at"),
     updated_at: requireString(body, "updated_at"),
+    ...(route !== undefined ? { route } : {}),
+    ...(artifact_refs !== undefined ? { artifact_refs } : {}),
   };
   // dispatch_issue is optional — absent in efforts that predate slice #2295.
   const rawDispatch = body.dispatch_issue;

--- a/apps/dev/src/core/manager/effort-store.ts
+++ b/apps/dev/src/core/manager/effort-store.ts
@@ -169,6 +169,7 @@ export function encodeEffortDocument(effort: EffortRecord): string {
     created_at: effort.created_at,
     updated_at: effort.updated_at,
   };
+  if (effort.dispatch_issue !== undefined) body.dispatch_issue = effort.dispatch_issue;
   if (effort.route !== undefined) body.route = effort.route;
   // ToonlRecord is flat (no arrays), so encode the list as newline-separated.
   // URLs never contain newlines, so the delimiter is unambiguous.

--- a/apps/dev/src/core/manager/router.ts
+++ b/apps/dev/src/core/manager/router.ts
@@ -1,0 +1,57 @@
+// core/manager/router.ts — the ask-red routing table, structured as data for
+// the Manager to consume (Spec #2290, slice #2293; architecture in ADR 0109).
+//
+// The classification of *intent text* into a skill is ask-red's job (done at
+// the SKILL.md/agent layer via /ask-red). This module answers a different
+// question: given a skill name that ask-red returned, is it session-bound or
+// autonomous? That split is Spec #2290 Decision #2182, and this module is its
+// canonical encoding.
+//
+// Manager consumes this table — it does not re-implement the classifier or make
+// the operator choose a Skill when the inventory already has an answer. That is
+// the ADR 0109 constraint: "it does not copy the classifier".
+
+/**
+ * How a skill integrates with the Manager session.
+ *
+ * `session-bound` — runs inline in the Manager's operator session; the Manager
+ *   holds the conversation, the skill runs as a subroutine, and the artifact
+ *   reference is captured into the effort.
+ *
+ * `autonomous` — dispatched to a separate execution lane (afk, go); the Manager
+ *   reconciles the outcome from the tracker rather than waiting inline.
+ *
+ * `unknown` — a skill not in the ask-red routing table (should not appear in
+ *   normal use; surfaced for diagnostics only).
+ */
+export type RouteKind = "session-bound" | "autonomous" | "unknown";
+
+// Skills that run inline as subroutines in the Manager session.
+// Source: Spec #2290 Decision #2182 (start, research, to-spec, to-tickets).
+const SESSION_BOUND_SKILLS: ReadonlySet<string> = new Set([
+  "start",
+  "research",
+  "to-spec",
+  "to-tickets",
+]);
+
+// Skills that are dispatched and then reconciled from the tracker.
+// Source: Spec #2290 Decision #2182 (afk, go).
+const AUTONOMOUS_SKILLS: ReadonlySet<string> = new Set(["afk", "go"]);
+
+/**
+ * Classify a skill name from ask-red's routing inventory into a route kind.
+ *
+ * This is the ask-red split encoded as data — not a re-implementation of
+ * ask-red's intent classifier, which runs at the agent/SKILL.md layer.
+ */
+export function classifyRouteKind(skill: string): RouteKind {
+  if (SESSION_BOUND_SKILLS.has(skill)) return "session-bound";
+  if (AUTONOMOUS_SKILLS.has(skill)) return "autonomous";
+  return "unknown";
+}
+
+/** True for a skill that runs inline in the Manager session. */
+export function isSessionBound(skill: string): boolean {
+  return classifyRouteKind(skill) === "session-bound";
+}

--- a/apps/dev/tests/manager-effort-store.test.ts
+++ b/apps/dev/tests/manager-effort-store.test.ts
@@ -72,9 +72,12 @@ describe("effort document", () => {
   });
 
   it("refuses a document whose schema version is not the one this bundle owns", () => {
+    // Spread must go through `as ToonlRecord` because EffortRecord carries
+    // optional array fields (artifact_refs) that ToonlRecord (flat) won't accept.
+    const { artifact_refs: _a, route: _r, ...flatEffort } = effort;
     const foreign = encodeRecords([
       { kind: "manager.effort.schema", schema: MANAGER_EFFORT_SCHEMA, version: 99 },
-      { kind: "manager.effort", ...effort },
+      { kind: "manager.effort", ...flatEffort },
     ]);
     expect(() => decodeEffortDocument(foreign)).toThrow(/schema version/);
   });

--- a/apps/dev/tests/manager-router.test.ts
+++ b/apps/dev/tests/manager-router.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { classifyRouteKind, isSessionBound } from "../src/core/manager/router.js";
+
+describe("classifyRouteKind — session-bound skills (Spec #2290 Decision #2182)", () => {
+  it.each(["start", "research", "to-spec", "to-tickets"])(
+    "classifies %s as session-bound",
+    (skill) => {
+      expect(classifyRouteKind(skill)).toBe("session-bound");
+    },
+  );
+});
+
+describe("classifyRouteKind — autonomous skills (Spec #2290 Decision #2182)", () => {
+  it.each(["afk", "go"])("classifies %s as autonomous", (skill) => {
+    expect(classifyRouteKind(skill)).toBe("autonomous");
+  });
+});
+
+describe("classifyRouteKind — unknown skills", () => {
+  it("returns unknown for a skill not in the ask-red routing inventory", () => {
+    expect(classifyRouteKind("not-a-skill")).toBe("unknown");
+    expect(classifyRouteKind("")).toBe("unknown");
+    expect(classifyRouteKind("to-tickets-extra")).toBe("unknown");
+  });
+});
+
+describe("isSessionBound", () => {
+  it("returns true only for session-bound skills", () => {
+    expect(isSessionBound("to-spec")).toBe(true);
+    expect(isSessionBound("to-tickets")).toBe(true);
+    expect(isSessionBound("afk")).toBe(false);
+    expect(isSessionBound("go")).toBe(false);
+    expect(isSessionBound("unknown-skill")).toBe(false);
+  });
+});

--- a/apps/dev/tests/manager-s3-routing.test.ts
+++ b/apps/dev/tests/manager-s3-routing.test.ts
@@ -1,0 +1,182 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { decode } from "@reddb-io/toon";
+import { beforeEach, describe, expect, it } from "vitest";
+import { managerCommand } from "../src/commands/manager.js";
+import { readEffort } from "../src/core/manager/effort-store.js";
+
+let root: string;
+let out: string[];
+let err: string[];
+
+function deps(): Parameters<typeof managerCommand>[1] {
+  return {
+    root,
+    stdout: (text: string) => out.push(text),
+    stderr: (text: string) => err.push(text),
+  };
+}
+
+function brief(): Record<string, unknown> {
+  return decode(out.join("")) as Record<string, unknown>;
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "manager-s3-"));
+  out = [];
+  err = [];
+});
+
+describe("manager route — records the ask-red route in an effort", () => {
+  it("stores the route and returns an updated brief", async () => {
+    await managerCommand(["write a spec for the auth feature"], deps());
+    const effortId = String(brief().effort_id);
+    out = [];
+
+    expect(await managerCommand(["route", effortId, "to-spec"], deps())).toBe(0);
+    const stored = await readEffort(root, effortId);
+    expect(stored?.route).toBe("to-spec");
+    expect(brief().route).toBe("to-spec");
+  });
+
+  it("bumps the generation when recording a route", async () => {
+    await managerCommand(["an intent"], deps());
+    const effortId = String(brief().effort_id);
+    out = [];
+
+    await managerCommand(["route", effortId, "afk"], deps());
+    const stored = await readEffort(root, effortId);
+    expect(stored?.generation).toBe(2);
+  });
+
+  it("accepts any skill name from ask-red's inventory", async () => {
+    await managerCommand(["an intent"], deps());
+    const id = String(brief().effort_id);
+    out = [];
+
+    expect(await managerCommand(["route", id, "afk"], deps())).toBe(0);
+    expect((await readEffort(root, id))?.route).toBe("afk");
+  });
+
+  it("returns 1 and names the id for an unknown effort", async () => {
+    expect(
+      await managerCommand(["route", "eff_zzzzzzzzzzzzzzzzzzzzzzzzzz", "to-spec"], deps()),
+    ).toBe(1);
+    expect(out).toEqual([]);
+    expect(err.join("")).toMatch(/eff_zzzz/);
+  });
+
+  it("returns 2 with usage when the skill argument is missing", async () => {
+    await managerCommand(["an intent"], deps());
+    const id = String(brief().effort_id);
+    out = [];
+
+    expect(await managerCommand(["route", id], deps())).toBe(2);
+    expect(err.join("")).toMatch(/usage/i);
+  });
+
+  it("returns 2 with usage when both effort and skill are missing", async () => {
+    expect(await managerCommand(["route"], deps())).toBe(2);
+    expect(err.join("")).toMatch(/usage/i);
+  });
+});
+
+describe("manager artifact — captures artifact references from inline skill runs", () => {
+  it("stores the artifact reference and returns an updated brief", async () => {
+    await managerCommand(["spec the auth feature"], deps());
+    const effortId = String(brief().effort_id);
+    out = [];
+
+    const ref = "https://github.com/reddb-io/red-skills/issues/999";
+    expect(await managerCommand(["artifact", effortId, ref], deps())).toBe(0);
+    const stored = await readEffort(root, effortId);
+    expect(stored?.artifact_refs).toEqual([ref]);
+    expect(brief().artifact_refs).toEqual([ref]);
+  });
+
+  it("accumulates multiple artifact references without overwriting earlier ones", async () => {
+    await managerCommand(["an effort"], deps());
+    const id = String(brief().effort_id);
+    out = [];
+
+    await managerCommand(
+      ["artifact", id, "https://github.com/reddb-io/red-skills/issues/1"],
+      deps(),
+    );
+    out = [];
+    await managerCommand(
+      ["artifact", id, "https://github.com/reddb-io/red-skills/issues/2"],
+      deps(),
+    );
+
+    const stored = await readEffort(root, id);
+    expect(stored?.artifact_refs).toEqual([
+      "https://github.com/reddb-io/red-skills/issues/1",
+      "https://github.com/reddb-io/red-skills/issues/2",
+    ]);
+    expect(brief().artifact_refs).toEqual([
+      "https://github.com/reddb-io/red-skills/issues/1",
+      "https://github.com/reddb-io/red-skills/issues/2",
+    ]);
+  });
+
+  it("returns 1 and names the id for an unknown effort", async () => {
+    expect(
+      await managerCommand(
+        ["artifact", "eff_zzzzzzzzzzzzzzzzzzzzzzzzzz", "https://github.com/x"],
+        deps(),
+      ),
+    ).toBe(1);
+    expect(out).toEqual([]);
+    expect(err.join("")).toMatch(/eff_zzzz/);
+  });
+
+  it("returns 2 with usage when the ref argument is missing", async () => {
+    await managerCommand(["an intent"], deps());
+    const id = String(brief().effort_id);
+    out = [];
+
+    expect(await managerCommand(["artifact", id], deps())).toBe(2);
+    expect(err.join("")).toMatch(/usage/i);
+  });
+
+  it("returns 2 with usage when both effort and ref are missing", async () => {
+    expect(await managerCommand(["artifact"], deps())).toBe(2);
+    expect(err.join("")).toMatch(/usage/i);
+  });
+});
+
+describe("brief — route and artifact_refs appear only when present", () => {
+  it("omits route and artifact_refs from a fresh effort brief", async () => {
+    await managerCommand(["an intent"], deps());
+    const rendered = brief();
+    expect(rendered).not.toHaveProperty("route");
+    expect(rendered).not.toHaveProperty("artifact_refs");
+  });
+
+  it("includes route in the brief once recorded", async () => {
+    await managerCommand(["an intent"], deps());
+    const id = String(brief().effort_id);
+    out = [];
+
+    await managerCommand(["route", id, "to-spec"], deps());
+    const rendered = brief();
+    expect(rendered.route).toBe("to-spec");
+    expect(rendered).not.toHaveProperty("artifact_refs");
+  });
+
+  it("includes both route and artifact_refs once both are recorded", async () => {
+    await managerCommand(["an intent"], deps());
+    const id = String(brief().effort_id);
+    out = [];
+
+    await managerCommand(["route", id, "to-spec"], deps());
+    out = [];
+    await managerCommand(["artifact", id, "https://github.com/x/issues/1"], deps());
+
+    const rendered = brief();
+    expect(rendered.route).toBe("to-spec");
+    expect(rendered.artifact_refs).toEqual(["https://github.com/x/issues/1"]);
+  });
+});

--- a/packaging/pi/dev/skills/engineering/manager/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/manager/SKILL.md
@@ -15,6 +15,20 @@ Start or continue an effort — anything that is not a lifecycle operation IS th
 
 Run: `red-skills-dev manager <intent>`
 
+After the runtime starts the effort, **route it via `/ask-red`**: classify the
+intent and follow the returned route. Do NOT re-implement ask-red's classifier —
+invoke `/ask-red` and consume its answer.
+
+Record the ask-red route in the effort:
+
+Run: `red-skills-dev manager route <effort-id> <skill>`
+
+**For session-bound skills** (`to-spec`, `to-tickets`, `start`, `research`):
+run the skill **inline in this session** as a subroutine. When the skill
+produces an artifact (e.g., a GitHub issue URL from `/to-spec`), capture it:
+
+Run: `red-skills-dev manager artifact <effort-id> <url-or-ref>`
+
 Render the brief for an effort (the most recently started one by default):
 
 Run: `red-skills-dev manager status [effort-id]`
@@ -34,10 +48,12 @@ workflow) issues directives to the Manager.
 
 ## What this slice owns
 
-The first slice is the walking skeleton (Spec #2290, slice #2291): start,
-persist, status. Routing through `ask-red`, inline planning, autonomous
-dispatch, tracker reconciliation, leases, and `resume`/`end`/`checkpoint` are
-later slices of the same Spec.
+Slice #2291 (S1) is the walking skeleton: start, persist, status.
+Slice #2293 (S3) adds ask-red routing and inline session-bound skill handoff:
+the runtime stores the route and artifact references; the SKILL layer routes
+via `/ask-red` and runs session-bound skills inline.
+Autonomous dispatch, tracker reconciliation, leases, and
+`resume`/`end`/`checkpoint` are later slices of the same Spec.
 
 ## Where the portfolio lives
 

--- a/plugins/dev/skills/engineering/manager/SKILL.md
+++ b/plugins/dev/skills/engineering/manager/SKILL.md
@@ -15,6 +15,20 @@ Start or continue an effort — anything that is not a lifecycle operation IS th
 
 Run: `red-skills-dev manager <intent>`
 
+After the runtime starts the effort, **route it via `/ask-red`**: classify the
+intent and follow the returned route. Do NOT re-implement ask-red's classifier —
+invoke `/ask-red` and consume its answer.
+
+Record the ask-red route in the effort:
+
+Run: `red-skills-dev manager route <effort-id> <skill>`
+
+**For session-bound skills** (`to-spec`, `to-tickets`, `start`, `research`):
+run the skill **inline in this session** as a subroutine. When the skill
+produces an artifact (e.g., a GitHub issue URL from `/to-spec`), capture it:
+
+Run: `red-skills-dev manager artifact <effort-id> <url-or-ref>`
+
 Render the brief for an effort (the most recently started one by default):
 
 Run: `red-skills-dev manager status [effort-id]`
@@ -34,10 +48,12 @@ workflow) issues directives to the Manager.
 
 ## What this slice owns
 
-The first slice is the walking skeleton (Spec #2290, slice #2291): start,
-persist, status. Routing through `ask-red`, inline planning, autonomous
-dispatch, tracker reconciliation, leases, and `resume`/`end`/`checkpoint` are
-later slices of the same Spec.
+Slice #2291 (S1) is the walking skeleton: start, persist, status.
+Slice #2293 (S3) adds ask-red routing and inline session-bound skill handoff:
+the runtime stores the route and artifact references; the SKILL layer routes
+via `/ask-red` and runs session-bound skills inline.
+Autonomous dispatch, tracker reconciliation, leases, and
+`resume`/`end`/`checkpoint` are later slices of the same Spec.
 
 ## Where the portfolio lives
 


### PR DESCRIPTION
## Summary

- Adds `core/manager/router.ts` — classifies skill names as session-bound vs autonomous by consuming ask-red's routing split (ADR 0109, Spec #2290 Decision #2182), so the Manager delegates classification to ask-red and never copies its intent classifier
- Extends `EffortRecord` with `route?: string` and `artifact_refs?: readonly string[]`; arrays serialised as newline-separated strings since `ToonlRecord` is flat
- Adds `manager route <id> <skill>` subcommand to record the ask-red route after ask-red classifies the intent
- Adds `manager artifact <id> <ref>` subcommand to accumulate artifact references from inline session-bound skill runs
- Updates `brief.ts` to render route and artifact_refs when present
- Adds unit tests for the router and integration tests for both subcommands and brief rendering
- Updates manager `SKILL.md` to document the S3 routing workflow
- Rebuilds `packaging/pi/` to sync `manager/SKILL.md` changes

Closes #2293

## Merge context

Cherry-picks from prior attempt (wBDC6) with conflict resolution: kept `dispatch` subcommand from slice #2295 (already on main) AND added `route` + `artifact` subcommands from this slice. Fixed missing `dispatch_issue` encoding in `encodeEffortDocument` revealed by the explicit-field encoder introduced here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787254270&installation_model_id=20659&pr_number=2391&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2391&signature=5459d36b4577a85052834c3b94e6e912b3322d16d1f9fe1b93a4abdd8e20f92b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->