### PR TITLE
fix: #2385 /go lane broken: worker claims the freshly minted issue, immediately self-concedes, engine reports 1/1 success with zero work

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -25,6 +25,7 @@ import {
   type AttemptRecordPayload,
 } from "../../core/attempt-record.js";
 import { isRunner, type Runner } from "../../types/runner.js";
+import { zeroAttemptDispatchFailure } from "../../core/go.js";
 import {
   afkPaths,
   collectPrecheckFacts,
@@ -495,6 +496,15 @@ export async function runCommand(options: RunOptions): Promise<number> {
   if (summary.runnerTransient) {
     process.stderr.write(`[afk] runner transport/setup failed — exiting 75 (EX_TEMPFAIL); rerun when the runner backend is healthy\n`);
     return 75;
+  }
+
+  // A targeted dispatch that attempted nothing is a failure, never a clean drain
+  // (#2385): `/go` reported `progress: 1/1 (100%)` + exit 0 over a claim the
+  // worker conceded without doing any work.
+  const zeroAttempt = zeroAttemptDispatchFailure(flags.filter?.kind === "issues", summary.processed);
+  if (zeroAttempt) {
+    process.stderr.write(`[afk] targeted dispatch attempted no work: ${zeroAttempt} — exiting 1\n`);
+    return 1;
   }
 
   return 0;

--- a/apps/dev/src/core/claim.ts
+++ b/apps/dev/src/core/claim.ts
@@ -42,6 +42,20 @@ export const CLAIM_MARKER_VERSION = 1;
  * releases voluntarily). */
 export type ClaimKind = "claim" | "concede";
 
+/** Why a `concede` was posted. The two causes are operationally opposite — one
+ * says another worker owns the issue, the other says we owned it and let go —
+ * and the single ambiguous sentence they used to share ("lost the claim race or
+ * released") turned a crashed worker's release into a phantom claim race in
+ * every post-mortem (#2385). `unspecified` keeps legacy callers rendering the
+ * old wording. */
+export type ConcedeReason = "lost" | "released" | "unspecified";
+
+const CONCEDE_WORDING: Record<ConcedeReason, string> = {
+  lost: "lost the claim race to an earlier claimant",
+  released: "released the claim it held",
+  unspecified: "lost the claim race or released",
+};
+
 /** One parsed claim marker. `commentId` is GitHub's server-assigned monotonic
  * comment id — the total order that makes the primitive atomic across hosts. */
 export interface ClaimRecord {
@@ -67,6 +81,20 @@ export interface ClaimSelf {
 }
 
 export type ClaimVerdict = "won" | "lost";
+
+/**
+ * A claim could not be VERIFIED — our own just-posted marker never came back
+ * from the read-back, or reconciliation dropped it. Thrown, never folded into a
+ * `lost` verdict: "we could not check" is not "somebody else won" (#2385). The
+ * caller surfaces it as a session error so the dispatch fails loudly instead of
+ * conceding an issue nobody else contends.
+ */
+export class ClaimVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClaimVerificationError";
+  }
+}
 
 export interface ClaimDecision {
   verdict: ClaimVerdict;
@@ -149,19 +177,21 @@ export function renderRecoveryAudit(
 export function renderClaimComment(
   self: { worker: string; runner?: string; createdAt?: string },
   kind: ClaimKind = "claim",
+  reason?: ConcedeReason,
 ): string {
   const fields = [
     `v${CLAIM_MARKER_VERSION}`,
     `worker=${escapeField(self.worker)}`,
     `kind=${kind}`,
   ];
+  if (kind === "concede" && reason) fields.push(`reason=${escapeField(reason)}`);
   if (self.runner) fields.push(`runner=${escapeField(self.runner)}`);
   if (self.createdAt) fields.push(`ts=${escapeField(self.createdAt)}`);
   const marker = `${MARKER_OPEN} ${fields.join(" ")} -->`;
   const human =
     kind === "claim"
       ? `🤖 AFK claim by worker \`${self.worker}\`${self.runner ? ` (runner \`${self.runner}\`)` : ""}.`
-      : `🤖 AFK worker \`${self.worker}\` conceded this issue (lost the claim race or released).`;
+      : `🤖 AFK worker \`${self.worker}\` conceded this issue (${CONCEDE_WORDING[reason ?? "unspecified"]}).`;
   return `${marker}\n${human}`;
 }
 
@@ -252,6 +282,16 @@ export function reconcileClaim(
 ): ClaimDecision {
   const isStale = opts.isStale ?? (() => false);
 
+  // An unusable identity means the claim could not be VERIFIED at all — an
+  // unparseable POST response or a blank worker key. Never fold that into
+  // "lost": the caller must retry or fail, not concede to nobody (#2385).
+  if (!Number.isFinite(self.commentId) || self.worker === "") {
+    throw new ClaimVerificationError(
+      `claim verification failed: unusable claimant identity (worker ${JSON.stringify(self.worker)}, ` +
+        `comment id ${String(self.commentId)})`,
+    );
+  }
+
   // Per-worker fold: earliest claim id + latest marker (kind + record).
   interface Fold {
     earliestClaimId: number | null;
@@ -283,6 +323,15 @@ export function reconcileClaim(
     }
   };
 
+  // Did WE just post the marker we are reconciling? True when `self.commentId`
+  // out-orders every marker the list already carries for our identity — i.e. our
+  // claim is the freshest word on the issue. A caller re-reconciling an OLD claim
+  // of its own (the returning stale owner) is not fresh, and stays subject to the
+  // staleness predicate that reclaimed its issue.
+  const selfPostedFresh =
+    Number.isFinite(self.commentId) &&
+    records.every((r) => r.worker !== self.worker || r.commentId < self.commentId);
+
   for (const r of records) ingest(r);
   // Always merge self in (read-after-write safety). Our own marker is a `claim`.
   ingest({
@@ -300,7 +349,12 @@ export function reconcileClaim(
   for (const [worker, f] of folds) {
     if (f.latestKind === "concede") continue; // withdrew
     if (f.earliestClaimId === null) continue; // only ever conceded — not a claim
-    if (isStale(f.latestRecord)) {
+    // A JUST-POSTED self is never stale (#2385): we wrote that marker moments
+    // ago, so a predicate rejecting it can only be a clock-skew or
+    // timestamp-parse defect — and dropping ourselves made a SOLE claimant fall
+    // through to "no live claim contends" and concede its own freshly minted
+    // issue. A returning owner re-reading its OLD claim stays stale-eligible.
+    if (!(worker === self.worker && selfPostedFresh) && isStale(f.latestRecord)) {
       stale.push({ worker, claimId: f.earliestClaimId }); // dead/expired — recovered
       continue;
     }
@@ -308,6 +362,18 @@ export function reconcileClaim(
   }
 
   if (contenders.length === 0) {
+    if (selfPostedFresh) {
+      // Unreachable for a just-posted claim: `self` is merged in as a live claim
+      // above and is stale-exempt, so an empty contender set means our own
+      // identity was unusable (empty worker key). That is a VERIFICATION
+      // failure, never a lost race — fail loudly instead of conceding (#2385).
+      throw new ClaimVerificationError(
+        `claim verification failed on the reconciler: our own claim (worker ${JSON.stringify(self.worker)}, ` +
+          `comment id ${String(self.commentId)}) did not survive reconciliation — no live claim contends`,
+      );
+    }
+    // Not a fresh post: we are re-reading an old claim of ours that has since
+    // been conceded or aged out. Nobody contends and we do not hold it.
     return { verdict: "lost", winner: null, reason: "no live claim contends", recovered: [] };
   }
 
@@ -374,6 +440,55 @@ export interface AcquireClaimOptions extends ClaimReconcileOptions {
    * wording.
    */
   deathFor?: (recoveredWorker: string) => string | null;
+  /** Read-back attempts allowed before a claim is declared unverifiable (#2385).
+   * GitHub's comment list is read-your-write in practice but not guaranteed, and
+   * the gh layer degrades a failed list call to an empty array — both looked
+   * exactly like "nobody claimed, including us". Default 3. */
+  verifyAttempts?: number;
+  /** Milliseconds to wait between read-back attempts. Default 1000. */
+  verifyDelayMs?: number;
+  /** Injected sleep so the retry loop is testable without a real clock. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_VERIFY_ATTEMPTS = 3;
+const DEFAULT_VERIFY_DELAY_MS = 1000;
+
+const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Read the issue's claim markers back until OUR OWN marker is visible (the
+ * verification step). Retries a list that has not yet propagated and a list call
+ * that failed outright; throws `ClaimVerificationError` when every attempt is
+ * exhausted. Never returns a list that lacks our marker — that ambiguity is what
+ * made a sole claimant concede its own freshly minted issue (#2385).
+ */
+async function listVerifiedClaims(
+  gh: ClaimGh,
+  issue: number,
+  commentId: number,
+  opts: AcquireClaimOptions,
+): Promise<RawClaimComment[]> {
+  const attempts = Math.max(1, opts.verifyAttempts ?? DEFAULT_VERIFY_ATTEMPTS);
+  const delayMs = opts.verifyDelayMs ?? DEFAULT_VERIFY_DELAY_MS;
+  const sleep = opts.sleep ?? realSleep;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (attempt > 0 && delayMs > 0) await sleep(delayMs);
+    let raw: RawClaimComment[];
+    try {
+      raw = await gh.listClaims(issue);
+    } catch (error) {
+      lastError = error;
+      continue;
+    }
+    if (raw.some((c) => c.id === commentId)) return raw;
+    lastError = new Error(`our claim comment ${commentId} was absent from ${raw.length} listed comment(s)`);
+  }
+  const detail = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new ClaimVerificationError(
+    `claim verification failed on #${issue} after ${attempts} read-back attempt(s): ${detail}`,
+  );
 }
 
 /**
@@ -393,13 +508,13 @@ export async function acquireClaim(
     issue,
     renderClaimComment({ worker: self.worker, runner: self.runner, createdAt: self.createdAt }, "claim"),
   );
-  const raw = await gh.listClaims(issue);
+  const raw = await listVerifiedClaims(gh, issue, commentId, opts);
   const records = parseClaimRecords(raw);
   const decision = reconcileClaim(records, { ...self, commentId }, opts);
   if (decision.verdict === "lost" && !opts.suppressConcede) {
     await gh.concede(
       issue,
-      renderClaimComment({ worker: self.worker, runner: self.runner }, "concede"),
+      renderClaimComment({ worker: self.worker, runner: self.runner }, "concede", "lost"),
     );
   }
   // One audit comment when we won by recovering a stale cross-host claim (#627).

--- a/apps/dev/src/core/go.ts
+++ b/apps/dev/src/core/go.ts
@@ -253,3 +253,35 @@ export async function dispatchGo(
   );
   return { issue, engineExit };
 }
+
+// ---------- zero-attempt dispatch verdict (#2385) ----------
+//
+// A targeted dispatch (`--issues N` — every `/go`, and a hand-aimed `/afk`)
+// exists to make ONE issue progress. When that issue is claimed and immediately
+// released, or never selected at all, the engine used to still exit 0 and the
+// progress line still read `1/1 (100%)` — a false success over zero work, which
+// is exactly how three broken `/go` runs read as clean. A run that attempted
+// nothing is a FAILURE and must say so in its exit code.
+
+/** Outcomes that mean the worker never attempted the issue — it withdrew before
+ * (or instead of) doing any work. */
+export const NO_ATTEMPT_OUTCOMES: readonly string[] = ["claim-lost", "hook-aborted"];
+
+/**
+ * Decide whether a targeted dispatch ran ZERO attempts (pure). Returns the
+ * operator-facing reason when the run must exit non-zero, or null when at least
+ * one issue was genuinely attempted.
+ *
+ * `targeted` is false for an open-ended `/afk` drain, where picking up nothing
+ * (an empty queue, an issue another fleet worker won) is normal and stays exit 0.
+ */
+export function zeroAttemptDispatchFailure(
+  targeted: boolean,
+  processed: readonly { issue: number; outcome: string }[],
+): string | null {
+  if (!targeted) return null;
+  if (processed.length === 0) return "no targeted issue was selected or processed";
+  const attempted = processed.filter((p) => !NO_ATTEMPT_OUTCOMES.includes(p.outcome));
+  if (attempted.length > 0) return null;
+  return `no attempt ran (${processed.map((p) => `#${p.issue}: ${p.outcome}`).join(", ")})`;
+}

--- a/apps/dev/src/core/process-issue/recovery.ts
+++ b/apps/dev/src/core/process-issue/recovery.ts
@@ -407,7 +407,7 @@ async function releaseOwnedClaim(deps: ProcessIssueDeps, input: ProcessIssueInpu
   if (deps.claimGh) {
     await deps.claimGh.concede(
       input.issue,
-      renderClaimComment({ worker: input.claimant ?? input.workerId, runner: input.runner }, "concede"),
+      renderClaimComment({ worker: input.claimant ?? input.workerId, runner: input.runner }, "concede", "released"),
     );
   }
   await deps.claimLock.release(input.issue);

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -936,7 +936,7 @@ export async function releaseOwnedClaim(deps: ProcessIssueDeps, input: ProcessIs
   if (deps.claimGh) {
     await deps.claimGh.concede(
       input.issue,
-      renderClaimComment({ worker: input.claimant ?? input.workerId, runner: input.runner }, "concede"),
+      renderClaimComment({ worker: input.claimant ?? input.workerId, runner: input.runner }, "concede", "released"),
     );
   }
   await deps.claimLock.release(input.issue);

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,9 +1,9 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { waitsDir, worktreesDir } from "@reddb-io/shared/red-paths.js";
+import { logsDir, waitsDir, worktreesDir } from "@reddb-io/shared/red-paths.js";
 import { Writable } from "node:stream";
 import { decode as decodeToon } from "@reddb-io/toon";
 import {
@@ -122,7 +122,7 @@ export interface DevAfkMcpOperations {
 }
 
 export interface DevAfkMcpRuntime {
-  launchRun(root: string, args: readonly string[]): Promise<{ pid: number }>;
+  launchRun(root: string, args: readonly string[]): Promise<{ pid: number; log?: string }>;
   /** Spawn rsp wait detached; returns the child PID. */
   launchRspWait(args: readonly string[], cwd: string): Promise<number>;
   ensureLabel(root: string, name: string): Promise<void>;
@@ -173,10 +173,19 @@ function dispatchArgs(input: DispatchOperationInput): string[] {
   return args;
 }
 
+/** Where a detached worker's boot stdout/stderr is persisted, in the disposable
+ * logs lane (ADR 0098). A worker that dies before it writes its own state used
+ * to leave nothing but `worker.pid` — three silent spawn deaths in a row with
+ * zero evidence anywhere (#2385, #2376). The dispatch keeps the bytes. */
+export function dispatchLogPath(root: string, stampIso: string): string {
+  const safe = stampIso.replace(/[:.]/g, "-");
+  return join(logsDir(root, stampIso.slice(0, 10)), `dispatch-${safe}.log`);
+}
+
 async function launchDetachedRun(
   root: string,
   args: readonly string[],
-): Promise<{ pid: number }> {
+): Promise<{ pid: number; log?: string }> {
   const mcpBundle = process.argv[1];
   if (!mcpBundle) {
     throw new Error("cannot dispatch worker: MCP bundle path is missing");
@@ -185,16 +194,31 @@ async function launchDetachedRun(
   if (!existsSync(bundle)) {
     throw new Error("cannot dispatch worker: sibling dev bundle is missing");
   }
-  const child = spawn(process.execPath, [bundle, "run", ...args], {
-    cwd: root,
-    env: process.env,
-    detached: true,
-    stdio: "ignore",
-  });
-  const pid = child.pid;
-  if (!pid) throw new Error("cannot dispatch worker: spawn returned no pid");
-  child.unref();
-  return { pid };
+  // Capture boot stdout+stderr to a discoverable file. Best-effort: if the log
+  // cannot be opened, the dispatch still runs (with the old blind stdio) rather
+  // than failing over an observability concern.
+  const logFile = dispatchLogPath(root, `${new Date().toISOString()}-${randomUUID().slice(0, 8)}`);
+  let fd: number | undefined;
+  try {
+    mkdirSync(dirname(logFile), { recursive: true });
+    fd = openSync(logFile, "a");
+  } catch {
+    fd = undefined;
+  }
+  try {
+    const child = spawn(process.execPath, [bundle, "run", ...args], {
+      cwd: root,
+      env: process.env,
+      detached: true,
+      stdio: fd === undefined ? "ignore" : ["ignore", fd, fd],
+    });
+    const pid = child.pid;
+    if (!pid) throw new Error("cannot dispatch worker: spawn returned no pid");
+    child.unref();
+    return { pid, log: fd === undefined ? undefined : logFile };
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
 }
 
 export function resolveDevCliBundle(mcpBundle: string): string {
@@ -342,11 +366,15 @@ export function createDefaultDevAfkMcpOperations(
         kind: "afk",
         issue: input.issue,
         worker_pid: launch.pid,
+        // Post-mortem handle for a worker that dies before writing its own
+        // state (#2385): its boot stdout/stderr lands here.
+        worker_log: launch.log,
         status: "dispatched",
       };
     },
     async dispatchDemand(cwd, input) {
       let workerPid: number | undefined;
+      let workerLog: string | undefined;
       const configuredBackpressure = readBackpressure(
         loadConfig(afkPaths(cwd).configPath, { warn: () => undefined }),
       );
@@ -357,6 +385,7 @@ export function createDefaultDevAfkMcpOperations(
           runEngine: async (args) => {
             const launch = await runtime.launchRun(cwd, args);
             workerPid = launch.pid;
+            workerLog = launch.log;
             return 0;
           },
         },
@@ -376,6 +405,7 @@ export function createDefaultDevAfkMcpOperations(
         demand: input.demand,
         issue: result.issue,
         worker_pid: workerPid,
+        worker_log: workerLog,
         status: "dispatched",
       };
     },
@@ -604,7 +634,7 @@ export function createDefaultDevAfkMcpOperations(
         await ghx.postClaimComment(
           gh,
           input.issue,
-          renderClaimComment({ worker: holder.worker, runner: holder.runner }, "concede"),
+          renderClaimComment({ worker: holder.worker, runner: holder.runner }, "concede", "released"),
         );
         conceded.push(holder.worker);
       }

--- a/apps/dev/tests/claim.test.ts
+++ b/apps/dev/tests/claim.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   acquireClaim,
+  ClaimVerificationError,
   parseClaimRecords,
   reconcileClaim,
   renderClaimComment,
@@ -305,5 +306,98 @@ describe("acquireClaim orchestration", () => {
     const d = await acquireClaim(gh, { worker: "h:me" }, 5);
     expect(d.verdict).toBe("won");
     expect(gh.audited).toHaveLength(0);
+  });
+});
+
+// ---- sole claimant on a freshly minted issue (#2385) ----
+//
+// Three `/go` dispatches in a row claimed the issue the engine had just minted,
+// immediately conceded it with no other claimant present, and reported success
+// over zero work. The claim substrate must make that verdict unreachable: a sole
+// claimant always wins its own mint, and an unverifiable claim fails loudly.
+describe("sole-claimant verification (#2385)", () => {
+  it("wins its own freshly minted issue even when the staleness predicate rejects everything", () => {
+    // A clock-skew or timestamp-parse defect that marks EVERY record stale used
+    // to drop self too, leaving zero contenders → `lost` → self-concede.
+    const d = reconcileClaim([], self("h:me", 10), { isStale: () => true });
+    expect(d.verdict).toBe("won");
+    expect(d.winner).toBe("h:me");
+  });
+
+  it("still loses to a live earlier claimant while self is stale-exempt", () => {
+    const d = reconcileClaim([rec(5, "other:host")], self("h:me", 10), {
+      isStale: (r) => r.worker === "h:me",
+    });
+    expect(d.verdict).toBe("lost");
+    expect(d.winner).toBe("other:host");
+  });
+
+  it("throws instead of conceding when our own claim id is unusable", () => {
+    expect(() => reconcileClaim([], self("h:me", Number.NaN))).toThrow(ClaimVerificationError);
+  });
+
+  it("retries the read-back until our claim marker is visible", async () => {
+    const gh = fakeGh([]);
+    const real = gh.listClaims.bind(gh);
+    let calls = 0;
+    gh.listClaims = async (issue: number) => {
+      calls += 1;
+      return calls < 3 ? [] : real(issue); // eventual consistency after the POST
+    };
+    const slept: number[] = [];
+    const d = await acquireClaim(gh, { worker: "h:me" }, 5, {
+      sleep: async (ms) => void slept.push(ms),
+    });
+    expect(d.verdict).toBe("won");
+    expect(calls).toBe(3);
+    expect(slept).toHaveLength(2);
+    expect(gh.conceded).toHaveLength(0);
+  });
+
+  it("fails loudly — never 'lost' — when the read-back never shows our claim", async () => {
+    const gh = fakeGh([]);
+    gh.listClaims = async () => []; // e.g. every `gh api` list call failed
+    await expect(
+      acquireClaim(gh, { worker: "h:me" }, 5, { sleep: async () => undefined }),
+    ).rejects.toBeInstanceOf(ClaimVerificationError);
+    expect(gh.conceded).toHaveLength(0);
+  });
+
+  it("fails loudly when every read-back attempt throws", async () => {
+    const gh = fakeGh([]);
+    gh.listClaims = async () => {
+      throw new Error("gh api: network unreachable");
+    };
+    await expect(
+      acquireClaim(gh, { worker: "h:me" }, 5, { sleep: async () => undefined }),
+    ).rejects.toThrow(/network unreachable/);
+    expect(gh.conceded).toHaveLength(0);
+  });
+});
+
+// ---- concede wording (#2385) ----
+describe("concede reason wording", () => {
+  it("names the lost race distinctly from a voluntary release", () => {
+    const lost = renderClaimComment({ worker: "h:me" }, "concede", "lost");
+    const released = renderClaimComment({ worker: "h:me" }, "concede", "released");
+    expect(lost).toContain("reason=lost");
+    expect(lost).toContain("lost the claim race to an earlier claimant");
+    expect(released).toContain("reason=released");
+    expect(released).toContain("released the claim it held");
+    expect(released).not.toContain("lost the claim race");
+  });
+
+  it("keeps the legacy ambiguous wording when no reason is supplied", () => {
+    const legacy = renderClaimComment({ worker: "h:me" }, "concede");
+    expect(legacy).toContain("lost the claim race or released");
+    expect(legacy).not.toContain("reason=");
+  });
+
+  it("parses a reason-bearing concede marker as a concede", () => {
+    const [record] = parseClaimRecords([
+      { id: 7, body: renderClaimComment({ worker: "h:me" }, "concede", "released") },
+    ]);
+    expect(record?.kind).toBe("concede");
+    expect(record?.worker).toBe("h:me");
   });
 });

--- a/apps/dev/tests/go.test.ts
+++ b/apps/dev/tests/go.test.ts
@@ -9,6 +9,7 @@ import {
   GO_ORIGIN,
   LABEL_GO_LANE,
   buildDisposableIssue,
+  zeroAttemptDispatchFailure,
   buildGoEngineArgs,
   dispatchGo,
   parseGoMode,
@@ -248,5 +249,30 @@ describe("dispatchGo", () => {
       { runner: "claude" },
     );
     expect(result.engineExit).toBe(1);
+  });
+});
+
+// A targeted dispatch that ran zero attempts is a failure, never a clean drain
+// (#2385): `/go` reported `progress: 1/1 (100%)` and exit 0 over an issue the
+// worker claimed and immediately conceded without doing any work.
+describe("zeroAttemptDispatchFailure", () => {
+  it("fails a targeted dispatch whose only outcome was a concede", () => {
+    const reason = zeroAttemptDispatchFailure(true, [{ issue: 2383, outcome: "claim-lost" }]);
+    expect(reason).toContain("no attempt ran");
+    expect(reason).toContain("#2383: claim-lost");
+  });
+
+  it("fails a targeted dispatch that selected nothing at all", () => {
+    expect(zeroAttemptDispatchFailure(true, [])).toContain("no targeted issue was selected");
+  });
+
+  it("passes a targeted dispatch that genuinely attempted the issue", () => {
+    expect(zeroAttemptDispatchFailure(true, [{ issue: 2383, outcome: "done" }])).toBeNull();
+    expect(zeroAttemptDispatchFailure(true, [{ issue: 2383, outcome: "blocked" }])).toBeNull();
+  });
+
+  it("leaves an open-ended /afk drain alone — picking up nothing is normal there", () => {
+    expect(zeroAttemptDispatchFailure(false, [])).toBeNull();
+    expect(zeroAttemptDispatchFailure(false, [{ issue: 1, outcome: "claim-lost" }])).toBeNull();
   });
 });

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -16,6 +16,7 @@ import {
   buildMcpLandingFireHook,
   createDefaultDevAfkMcpOperations,
   createDevAfkMcpDependencies,
+  dispatchLogPath,
   resolveDevCliBundle,
   resolveRspCliBundle,
   type DevAfkMcpOperations,
@@ -46,6 +47,13 @@ describe("dev:afk MCP host adapter", () => {
         join("cache", "afk-mcp-2.76.1.bundle.min.mjs"),
       ),
     ).toBe(join("cache", "dev-2.76.1.bundle.min.mjs"));
+  });
+
+  // Three consecutive dispatches died silently leaving only `worker.pid` — the
+  // spawn discarded stdout/stderr, so a boot death left zero evidence (#2385).
+  it("parks worker boot output in the dated logs lane", () => {
+    const path = dispatchLogPath("/repo", "2026-07-21T19:18:38.920Z-abc12345");
+    expect(path).toBe(join("/repo", ".red", "tmp", "logs", "2026-07-21", "dispatch-2026-07-21T19-18-38-920Z-abc12345.log"));
   });
 
   it("lists registered fleets through the Castle registry primitive", async () => {

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -272,6 +272,7 @@ export function harness(opts: HarnessOptions = {}): {
   input: ProcessIssueInput;
   trace: Trace;
 } {
+  const postedClaims: { id: number; body: string }[] = [];
   const trace: Trace = {
     labelEdits: [],
     comments: [],
@@ -362,13 +363,16 @@ export function harness(opts: HarnessOptions = {}): {
       ? {
           async postClaim(_issue, body) {
             trace.comments.push({ issue: 9, body });
-            return 100; // our claim gets id 100
+            postedClaims.push({ id: 100, body }); // our claim gets id 100
+            return 100;
           },
           async listClaims() {
+            // The read-back ALWAYS echoes our own claim (#2385): a list that
+            // omits it is a verification failure, not a lost race.
             // "other" wins by posting an earlier id (50); "self" wins solo.
             return opts.claim?.winner === "other"
-              ? [{ id: 50, body: "<!-- afk:claim v1 worker=otherhost:wZZZZ kind=claim -->" }]
-              : [];
+              ? [{ id: 50, body: "<!-- afk:claim v1 worker=otherhost:wZZZZ kind=claim -->" }, ...postedClaims]
+              : [...postedClaims];
           },
           async concede(_issue, body) {
             trace.comments.push({ issue: 9, body });


### PR DESCRIPTION
Automated AFK landing for #2385. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2385

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787256527&installation_model_id=20659&pr_number=2392&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2392&signature=d36dc356929ddb8a931398b5c15c68465afb87a401f25dd4f1fd763b01a15178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->