### PR TITLE
fix: #2352 adversarial review — coherent reviewer tuple + advisory never fatal; re-enable review

### DIFF
--- a/.red/adr/0110-adversarial-review-reseed-correction-loop.md
+++ b/.red/adr/0110-adversarial-review-reseed-correction-loop.md
@@ -56,6 +56,21 @@ implementer's** — context isolation, not model diversity, is what the pattern
 proved — with cross-model as a configurable upgrade. **Model, effort, and runner
 are all configurable** under `plugins.dev.review.*`.
 
+**Amendment (#2352, 2026-07-21).** Two properties the first implementation
+lacked, learned from a fleet-wide landing outage:
+
+- **The reviewer is one coherent (runner, model, effort) tuple, not three
+  independent knobs.** A configured model is honoured only on a runner whose CLI
+  can dispatch it — the runner spec registry owns that answer — and an
+  unsupported pin is substituted with that runner's review-tier default under a
+  logged notice. A codex model pinned repo-wide and spawned through the claude
+  CLI is not a degraded review; it is an immediate non-zero exit.
+- **Advisory failure is never fatal.** The pass has exactly three legal verdicts
+  — pass, correct, park. Infrastructure failure of the reviewer itself is none of
+  them: the attempt is already machine-validated when the pass runs, so a
+  crashed reviewer degrades to "pass with a logged warning" plus an attempt-ledger
+  record, and the landing proceeds.
+
 ## Considered options
 
 - **Advisory-only** (keep `review.ts`'s shape): rejected — advisory findings do

--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -35,16 +35,14 @@ plugins:
     #   so the worst case is one extra correction round and the PR still lands.
     #   Raising max_iterations to 2+ enables parking to ready-for-human.
     review:
-      # TEMPORARILY disabled (2026-07-21): the reviewer pass invokes the
-      # claude-code CLI with the codex model pinned below (gpt-5.6-sol), which
-      # claude cannot run — the "advisory" pass then exits 1 and KILLS every
-      # claude worker after push, before landing (fleet-wide landing outage;
-      # three stranded branches adopted by hand). Re-enable when the fix for
-      # the advisory-fatality + per-runner reviewer-model resolution lands.
-      enabled: false
+      enabled: true
       max_iterations: 1
       reviewer_count: 1
       quorum: any
+      # The model is honoured only on a runner whose CLI can dispatch it (#2352):
+      # under the claude fleet this codex slug is substituted for claude's own
+      # review-tier default with a logged notice, never spawned. Pin
+      # `runner: codex` here to make the reviewer actually run this model.
       model: gpt-5.6-sol       # adversarial reviewer runs on the newer model...
       effort: medium           # ...at medium effort — the review pass is bounded
                                # to one iteration, so depth matters less than the

--- a/apps/dev/src/core/adversarial-review.ts
+++ b/apps/dev/src/core/adversarial-review.ts
@@ -1,6 +1,6 @@
 import type { AgentEffort, AgentRunner } from "./execution.js";
 import type { RunOptions } from "@reddb-io/red-castle";
-import type { AfkModelTier } from "./config.js";
+import { defaultTier, type AfkModelTier } from "./config.js";
 import {
   reviewFindingsSchema,
   resolveMaxRetries,
@@ -9,7 +9,7 @@ import {
   type StandardSchemaLike,
 } from "./review.js";
 import type { ReviewExtractDeps } from "./review-extract.js";
-import { toAgentRunner } from "./runner-spec.js";
+import { RUNNER_SPECS, runnerSupportsModel, toAgentRunner } from "./runner-spec.js";
 import { isRunner } from "../types/runner.js";
 
 export interface AdversarialReviewConfig {
@@ -109,16 +109,70 @@ export interface AdversarialReviewerResolutionInput {
   };
 }
 
-export function resolveAdversarialReviewer(input: AdversarialReviewerResolutionInput): {
-  runner: AgentRunner;
-  model: string;
-  effort?: AgentEffort;
-} {
+export interface AdversarialReviewerResolution {
+  readonly runner: AgentRunner;
+  readonly model: string;
+  readonly effort?: AgentEffort;
+  /**
+   * Human-readable substitution notices, present ONLY when the requested tuple
+   * was incoherent and had to be corrected. The caller logs them.
+   */
+  readonly notices?: readonly string[];
+}
+
+/**
+ * Resolve the reviewer as a COHERENT (runner, model, effort) tuple, not three
+ * independent knobs (#2352). A configured model is honoured only on a runner
+ * whose CLI can dispatch it (the runner spec registry answers that); otherwise
+ * it is substituted — first with the runner's own resolved tier, then with the
+ * runner's shipped tier-table default — and the substitution is reported in
+ * `notices`. Effort is gated the same way against the runner's accepted set.
+ * A cross-runner pin (a codex model on the claude CLI) is not a degraded review:
+ * the CLI exits non-zero immediately, which is what took the fleet down.
+ */
+export function resolveAdversarialReviewer(
+  input: AdversarialReviewerResolutionInput,
+): AdversarialReviewerResolution {
   const runner = input.config.runner ?? input.implementer.runner;
   const tier = input.config.runner ? input.resolveTier?.(runner, input.taskClass) : undefined;
-  const model = input.config.model ?? tier?.model ?? input.implementer.model;
-  const effort = input.config.effort ?? tier?.effort ?? input.implementer.effort;
-  return { runner, model, ...(effort ? { effort } : {}) };
+  const fallbackTier = tier ?? input.resolveTier?.(runner, input.taskClass);
+  const shipped = defaultTier(runner, input.taskClass);
+  const sameRunner = runner === input.implementer.runner;
+  const notices: string[] = [];
+
+  let model = input.config.model ?? tier?.model ?? input.implementer.model;
+  if (!runnerSupportsModel(runner, model)) {
+    const substitute =
+      [fallbackTier?.model, sameRunner ? input.implementer.model : undefined].find(
+        (candidate): candidate is string => !!candidate && runnerSupportsModel(runner, candidate),
+      ) ?? shipped.model;
+    notices.push(
+      `[adversarial-review] runner '${runner}' cannot run model '${model}'; ` +
+        `substituting its review-tier default '${substitute}'.`,
+    );
+    model = substitute;
+  }
+
+  const accepted = RUNNER_SPECS[runner].efforts;
+  let effort = input.config.effort ?? tier?.effort ?? input.implementer.effort;
+  if (effort && !accepted.includes(effort)) {
+    const substitute =
+      [fallbackTier?.effort, sameRunner ? input.implementer.effort : undefined, shipped.effort].find(
+        (candidate): candidate is AgentEffort => !!candidate && accepted.includes(candidate),
+      ) ?? RUNNER_SPECS[runner].defaultEffort;
+    notices.push(
+      `[adversarial-review] runner '${runner}' does not accept effort '${effort}' ` +
+        `(accepted: ${accepted.join(", ")}); substituting '${substitute ?? "provider default"}'.`,
+    );
+    effort = substitute;
+  }
+
+  return {
+    runner,
+    model,
+    ...(effort ? { effort } : {}),
+    ...(notices.length > 0 ? { notices } : {}),
+  };
 }
 
 function quorumThreshold(quorum: AdversarialReviewQuorum, reviewerCount: number): number {

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -879,6 +879,23 @@ export function resolveTier(
 }
 
 /**
+ * The tier table's OWN default model/effort for a runner — the shipped pair,
+ * with no file overrides, no legacy scalars, and no env applied. Every runner
+ * ships a full table, so this pair is always runnable on that runner: it is the
+ * last-resort substitute when an operator pins a model the runner's CLI cannot
+ * dispatch (#2352). An unknown runner folds onto the claude table via
+ * `toAgentRunner`, exactly as {@link resolveTier} does.
+ */
+export function defaultTier(runner: string, taskClass: AfkModelTier = "think"): ResolvedTier {
+  const tierRunner = toAgentRunner(runner as Runner);
+  const tier = (AFK_MODEL_TIERS as readonly string[]).includes(taskClass) ? taskClass : "think";
+  return {
+    model: CONFIG_DEFAULTS[defaultTierKey(tierRunner, tier, "model")!],
+    effort: CONFIG_DEFAULTS[defaultTierKey(tierRunner, tier, "effort")!] as AgentEffort,
+  };
+}
+
+/**
  * Read the operator-declared backpressure command list (`afk.backpressure`),
  * in declaration order (issue #430). The list form
  *

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -991,6 +991,9 @@ export async function processIssue(
         taskClass: activeTaskClass,
         resolveTier: deps.resolveTier,
       });
+      // An incoherent (runner, model, effort) pin is corrected, never spawned:
+      // log every substitution so the operator sees which knob was overridden.
+      for (const notice of reviewer.notices ?? []) deps.appendIterLog(notice);
       const reviews: AdversarialReviewFindings[] = [];
       for (let i = 0; i < config.reviewerCount; i++) {
         reviews.push(
@@ -1026,7 +1029,20 @@ export async function processIssue(
         return "abort";
       }
     } catch (error) {
-      deps.appendIterLog(`[adversarial-review] advisory pass failed: ${error instanceof Error ? error.message : String(error)}`);
+      // An advisory pass has exactly three legal verdicts — pass, correct, park.
+      // Infrastructure failure of the reviewer itself is NONE of them: the
+      // attempt is already machine-validated here, so a crashed/non-zero
+      // reviewer CLI degrades to "pass with a logged warning" and the landing
+      // proceeds. Killing the run instead stranded three pushed branches and
+      // took every claude fleet worker down at landing (#2352).
+      const reason = error instanceof Error ? error.message : String(error);
+      deps.appendIterLog(`[adversarial-review] advisory pass failed, degraded to pass: ${reason}`);
+      deps.recordWorkerEvent?.("worker.review_degraded", {
+        issue: input.issue,
+        pr,
+        decision: "pass",
+        reason,
+      });
     }
   };
   markLandingPhase("gate");

--- a/apps/dev/src/core/runner-spec.ts
+++ b/apps/dev/src/core/runner-spec.ts
@@ -3,6 +3,7 @@ export {
   CODEX_EFFORTS,
   MINIMAX_EFFORTS,
   RUNNER_SPECS,
+  runnerSupportsModel,
   runnerSupportsStructuredOutput,
   toAgentRunner,
 } from "@reddb-io/red-castle/engine";

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -347,6 +347,50 @@ describe("config", () => {
     ).toEqual({ runner: "codex", model: "gpt-validate", effort: "low" });
   });
 
+  it("keeps a configured reviewer model the runner CAN dispatch (#2352)", () => {
+    const values = loadConfig("/x/.red/config.yaml", { ignoreActivationGate: true,
+      read: () => "plugins:\n  dev:\n    review:\n      runner: codex\n      model: gpt-5.6-sol\n      effort: high\n",
+    });
+    const config = resolveAdversarialReviewConfig((key) => getConfig(values, key));
+    expect(
+      resolveAdversarialReviewer({
+        config,
+        implementer: { runner: "claude", model: "claude-opus-4-8", effort: "high" },
+        taskClass: "complex",
+        resolveTier: () => ({ model: "gpt-5.5", effort: "medium" }),
+      }),
+    ).toEqual({ runner: "codex", model: "gpt-5.6-sol", effort: "high" });
+  });
+
+  it("substitutes a cross-runner model pin with the runner's review-tier default (#2352)", () => {
+    // The #2352 outage: a codex model pinned repo-wide, run through the claude CLI.
+    const values = loadConfig("/x/.red/config.yaml", { ignoreActivationGate: true,
+      read: () => "plugins:\n  dev:\n    review:\n      enabled: true\n      model: gpt-5.6-sol\n      effort: medium\n",
+    });
+    const config = resolveAdversarialReviewConfig((key) => getConfig(values, key));
+    const resolved = resolveAdversarialReviewer({
+      config,
+      implementer: { runner: "claude", model: "claude-opus-4-8", effort: "high" },
+      taskClass: "complex",
+      resolveTier: () => ({ model: "claude-opus-4-8", effort: "medium" }),
+    });
+    expect(resolved).toMatchObject({ runner: "claude", model: "claude-opus-4-8", effort: "medium" });
+    expect(resolved.notices?.[0]).toContain("cannot run model 'gpt-5.6-sol'");
+    expect(resolved.notices?.[0]).toContain("claude-opus-4-8");
+  });
+
+  it("falls back to the shipped tier table when no tier resolver can supply a runnable model (#2352)", () => {
+    const resolved = resolveAdversarialReviewer({
+      config: { enabled: true, maxIterations: 1, reviewerCount: 1, quorum: "any", runner: "codex" },
+      implementer: { runner: "claude", model: "claude-opus-4-8", effort: "max" },
+      taskClass: "complex",
+    });
+    // codex can run neither the implementer's claude model nor its `max` effort.
+    expect(resolved).toMatchObject({ runner: "codex", model: "gpt-5.5", effort: "medium" });
+    expect(resolved.notices).toHaveLength(2);
+    expect(resolved.notices?.[1]).toContain("does not accept effort 'max'");
+  });
+
   it("aggregates adversarial blocking findings by quorum (#2210)", () => {
     const one = {
       summary: "one",

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -1113,6 +1113,71 @@ describe("processIssue — advisory adversarial review (#2207)", () => {
     expect(blocker?.summary).toContain("The implementation still omits the required audit trail.");
     expect(trace.envelopeBodies.at(-1)).toContain("Adversarial review budget exhausted");
   });
+
+  it("a crashing reviewer CLI degrades to pass — the worker survives and lands (#2352)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: false,
+      adversarialReview: { enabled: true, maxIterations: 1, reviewerCount: 1, quorum: "any" },
+      adversarialExtractError: "claude-code exited with code 1",
+    });
+    const result = await processIssue(deps, input);
+
+    // The advisory pass ran and blew up — the machine-validated attempt still lands.
+    expect(trace.adversarialReviewContexts).toHaveLength(1);
+    expect(result.outcome).toBe("done");
+    expect(trace.closed).toEqual([9]);
+    // No verdict was posted, and the implementer was NOT re-seeded.
+    expect(trace.adversarialReviews).toEqual([]);
+    expect(trace.runAgentCalls).toHaveLength(1);
+    // The failure is logged AND recorded in the attempt ledger.
+    expect(
+      trace.iterLogs.some((line) =>
+        line.includes("[adversarial-review] advisory pass failed, degraded to pass: claude-code exited with code 1"),
+      ),
+    ).toBe(true);
+    expect(trace.workerEvents).toContainEqual({
+      kind: "worker.review_degraded",
+      payload: { issue: 9, pr: 42, decision: "pass", reason: "claude-code exited with code 1" },
+    });
+  });
+
+  it("substitutes a reviewer model the host runner cannot dispatch and logs it (#2352)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: false,
+      classifyIssue: async () => "complex",
+      resolveTier: () => ({ model: "claude-opus-4-8", effort: "medium" }),
+      // The repo pins a codex model, but the host runner is claude (the #2352 outage).
+      adversarialReview: {
+        enabled: true,
+        maxIterations: 1,
+        reviewerCount: 1,
+        quorum: "any",
+        model: "gpt-5.6-sol",
+        effort: "medium",
+      },
+      adversarialFindings: { summary: "Clean.", findings: [] },
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.adversarialReviewContexts).toHaveLength(1);
+    expect(trace.adversarialReviewContexts[0]).toMatchObject({
+      runner: "claude",
+      model: "claude-opus-4-8",
+      effort: "medium",
+    });
+    expect(
+      trace.iterLogs.some(
+        (line) =>
+          line.includes("cannot run model 'gpt-5.6-sol'") && line.includes("claude-opus-4-8"),
+      ),
+    ).toBe(true);
+    expect(trace.closed).toEqual([9]);
+  });
 });
 
 

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -80,6 +80,8 @@ export interface Trace {
   classifierCalls: IssueClassificationMetadata[];
   /** Lines appended to the iteration log (deps.appendIterLog). */
   iterLogs: string[];
+  /** Attempt-ledger records emitted through deps.recordWorkerEvent. */
+  workerEvents: Array<{ kind: string; payload?: Record<string, unknown> }>;
   /** Main-red repair issue create attempts from the baseline probe sync path. */
   /** Compact state patches written to afk.state.toon. */
   statePatches: Array<Record<string, unknown>>;
@@ -253,6 +255,8 @@ export interface HarnessOptions {
   adversarialReview?: ProcessIssueDeps["adversarialReview"];
   adversarialFindings?: AdversarialReviewFindings;
   adversarialFindingsSequence?: AdversarialReviewFindings[];
+  /** Reviewer CLI failure (#2352): the extract port rejects with this message. */
+  adversarialExtractError?: string;
   /** CI-aware merge (#812). When set, register the `ciAwait` port and drive the
    * `gh pr view` verdict the unlocked landing polls before admin-merging. */
   ciAware?: "merge" | "ci-failed" | "ci-pending" | "conflict";
@@ -297,6 +301,7 @@ export function harness(opts: HarnessOptions = {}): {
     salvageCalls: [],
     classifierCalls: [],
     iterLogs: [],
+    workerEvents: [],
     statePatches: [],
     cascadeRebaseAttempts: [],
     changedFileCalls: [],
@@ -549,6 +554,7 @@ export function harness(opts: HarnessOptions = {}): {
     extractAdversarialReview: opts.adversarialReview
       ? async ({ context, runner, model, effort, maxIterations }) => {
           trace.adversarialReviewContexts.push({ ...context, runner, model, effort, maxIterations });
+          if (opts.adversarialExtractError) throw new Error(opts.adversarialExtractError);
           return opts.adversarialFindingsSequence?.[trace.adversarialReviewContexts.length - 1] ?? opts.adversarialFindings ?? {
             summary: "Stubbed adversarial review summary.",
             findings: [
@@ -707,6 +713,9 @@ export function harness(opts: HarnessOptions = {}): {
     nowIso: () => "2026-05-30T00:00:00Z",
     appendIterLog: (line) => {
       trace.iterLogs.push(line);
+    },
+    recordWorkerEvent: (kind, payload) => {
+      trace.workerEvents.push({ kind, ...(payload ? { payload } : {}) });
     },
     markState: (patch) => {
       trace.statePatches.push(patch);

--- a/packages/red-castle/src/engine/runner-registry.test.ts
+++ b/packages/red-castle/src/engine/runner-registry.test.ts
@@ -17,6 +17,7 @@ import {
   parseRunnerFlag,
   resolveMiniMaxClaudeEnv,
   resolveOpenCodeAuth,
+  runnerSupportsModel,
   runnerSupportsStructuredOutput,
   toAgentRunner,
   type AgentRunner,
@@ -55,6 +56,23 @@ describe("engine runner registry", () => {
     expect(openCodeAuthEnv(resolveOpenCodeAuth({ MINIMAX_API_KEY: "mm" }))).toEqual({ MINIMAX_API_KEY: "mm" });
     expect(runnerSupportsStructuredOutput("claude")).toBe(true);
     expect(runnerSupportsStructuredOutput("codex")).toBe(false);
+  });
+
+  it("answers whether a runner's CLI can dispatch a model slug (#2352)", () => {
+    expect(runnerSupportsModel("claude", "claude-opus-4-8")).toBe(true);
+    expect(runnerSupportsModel("claude", "sonnet")).toBe(true);
+    expect(runnerSupportsModel("claude", "us.anthropic.claude-opus-4-8-v1:0")).toBe(true);
+    expect(runnerSupportsModel("claude", "gpt-5.6-sol")).toBe(false);
+    expect(runnerSupportsModel("codex", "gpt-5.6-sol")).toBe(true);
+    expect(runnerSupportsModel("codex", "o3")).toBe(true);
+    expect(runnerSupportsModel("codex", "claude-opus-4-8")).toBe(false);
+    expect(runnerSupportsModel("opencode", "openrouter/anthropic/claude-opus-4")).toBe(true);
+    expect(runnerSupportsModel("opencode", "claude-opus-4-8")).toBe(false);
+    // A forcedModel runner accepts exactly its forced slug.
+    expect(runnerSupportsModel("claude-minimax", MINIMAX_M3_MODEL)).toBe(true);
+    expect(runnerSupportsModel("claude-minimax", "claude-opus-4-8")).toBe(false);
+    // A blank slug is never runnable.
+    expect(runnerSupportsModel("claude", "  ")).toBe(false);
   });
 
   it("keeps runner detection and spawn argv parity in the engine unit", () => {

--- a/packages/red-castle/src/engine/runner-spec.ts
+++ b/packages/red-castle/src/engine/runner-spec.ts
@@ -14,6 +14,14 @@ export interface RunnerSpec {
   defaultEffort?: AgentEffort;
   resolveAuthEnv?: (env: NodeJS.ProcessEnv) => Record<string, string> | undefined;
   structuredOutput?: boolean;
+  /**
+   * Model-slug families this runner's CLI can dispatch. A runner with a
+   * `forcedModel` accepts that slug only; a runner with no families listed
+   * accepts any slug. Consulted by callers that must resolve runner+model as a
+   * coherent PAIR before spawning — pinning a codex slug on the claude CLI is
+   * not a degraded run, it is an immediate non-zero exit.
+   */
+  modelFamilies?: readonly RegExp[];
 }
 
 export const RUNNER_SPECS: Record<AgentRunner, RunnerSpec> = {
@@ -22,17 +30,23 @@ export const RUNNER_SPECS: Record<AgentRunner, RunnerSpec> = {
     channel: "effort",
     factory: "claudeCode",
     structuredOutput: true,
+    // Full ids (`claude-opus-4-8`, `us.anthropic.claude-…`) plus the CLI's own
+    // short aliases.
+    modelFamilies: [/claude/i, /^(opus|sonnet|haiku|opusplan|default)$/i],
   },
   codex: {
     efforts: CODEX_EFFORTS,
     channel: "effort",
     factory: "codex",
+    modelFamilies: [/^gpt-/i, /^o\d/i, /^codex/i],
   },
   opencode: {
     efforts: CLAUDE_EFFORTS,
     channel: "variant",
     factory: "opencode",
     resolveAuthEnv: (env) => openCodeAuthEnv(resolveOpenCodeAuth(env)),
+    // `<provider>/<model>` — the leading segment routes the endpoint (ADR 0059).
+    modelFamilies: [/^[^/\s]+\/.+$/],
   },
   "claude-minimax": {
     efforts: MINIMAX_EFFORTS,
@@ -50,4 +64,20 @@ export function toAgentRunner(r: Runner): AgentRunner {
 
 export function runnerSupportsStructuredOutput(runner: AgentRunner): boolean {
   return RUNNER_SPECS[runner].structuredOutput === true;
+}
+
+/**
+ * Can `runner`'s CLI actually dispatch `model`? A blank slug is never runnable;
+ * a `forcedModel` runner accepts only that slug; a runner without declared
+ * families accepts anything. This is the registry seam for resolving a
+ * runner/model PAIR, so an operator's cross-runner model pin is substituted
+ * before spawn instead of exiting non-zero at run time.
+ */
+export function runnerSupportsModel(runner: AgentRunner, model: string): boolean {
+  const spec = RUNNER_SPECS[runner];
+  const slug = model.trim();
+  if (slug.length === 0) return false;
+  if (spec.forcedModel) return slug === spec.forcedModel;
+  if (!spec.modelFamilies || spec.modelFamilies.length === 0) return true;
+  return spec.modelFamilies.some((family) => family.test(slug));
 }


### PR DESCRIPTION
Closes #2352

Implements the two doctrine fixes from the 2026-07-21 fleet-wide landing outage: the reviewer is one coherent (runner, model, effort) tuple resolved by the runner-spec registry (unsupported pins substitute the runner's review-tier default with a logged notice, never a crash), and advisory-pass infrastructure failure is never fatal (degrades to pass-with-warning + attempt-ledger record). Re-enables plugins.dev.review with the pin semantics documented in config. ADR 0110 amended. Built by fleet worker w5AN7; rebased onto current main in session (one test-helper conflict resolved: kept workerEvents, dropped the retired mainRedRepairCreates); sensitive .red/ diff human-reviewed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787258655&installation_model_id=20659&pr_number=2393&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2393&signature=ff1f2ac709b92a39acbc59710e134648675b3f783c3fa534b4ba37e97fad5cf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->