### PR TITLE
fix: #2375 fix(hook-config): accept YAML list form for lifecycle hooks and validate at boot

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -65,7 +65,7 @@ import {
 import { LABEL_READY_FOR_REVIEW, LABEL_GO_LANE, LABEL_SCOUT_LANE, LABEL_MERGE_CONFLICT } from "../../core/triage-labels.js";
 import { GO_KIND, GO_ORIGIN } from "../../core/go.js";
 import { SCOUT_ORIGIN, SCOUT_WORKERS_SEGMENT } from "../../core/scout.js";
-import { resolveHooks, type HookName } from "../../core/hook-config.js";
+import { resolveHooks, validateHookConfig, UnknownHookError, type HookName } from "../../core/hook-config.js";
 import { dispatchHooks } from "../../core/hook-dispatcher.js";
 import { runCastleWorkerDrain, type CastleSessionHookName, type CastleWorkerDrainDeps } from "@reddb-io/red-castle/engine";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../../core/attempt-ledger.js";
@@ -281,8 +281,28 @@ export async function runCommand(options: RunOptions): Promise<number> {
 
   // --request/-r special block, threaded into the handoff the agent reads.
   const requestBlock = specialUserRequestBlock(flags.request);
+  const sessionHooksConfig = loadConfig(afkPaths(ctx.root).configPath);
+
+  // Validate hook names once before the session loop. An unknown hook name
+  // (including a misspelled name where the user intended a list entry) must not
+  // crash the worker at first issue pick-up and trigger a supervisor churn loop.
+  // Write the retire file so the supervisor does not respawn this slot on exit.
+  try {
+    validateHookConfig(sessionHooksConfig);
+  } catch (err) {
+    const msg = err instanceof UnknownHookError
+      ? `[afk:config] fatal: ${err.message} in .red/config.yaml — fix the hook name and restart the fleet`
+      : `[afk:config] fatal: hook config error: ${err instanceof Error ? err.message : String(err)}`;
+    process.stderr.write(`${msg}\n`);
+    const retireFile = process.env.RED_AFK_RETIRE_FILE;
+    if (retireFile) {
+      try { writeFileSync(retireFile, ""); } catch { /* best-effort */ }
+    }
+    return 1;
+  }
+
   const sessionHooks = {
-    config: loadConfig(afkPaths(ctx.root).configPath),
+    config: sessionHooksConfig,
     resolveOptions: makeHookResolveOptions(ctx.root),
     exec: makeHookExec(ctx.root),
     env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT), runner),

--- a/apps/dev/src/core/hook-config.ts
+++ b/apps/dev/src/core/hook-config.ts
@@ -118,6 +118,7 @@ function isCanonical(name: string): name is HookName {
 
 const HOOKS_PREFIX = "afk.hooks.";
 const DEFAULTS_PREFIX = "afk.hooks.defaults.";
+const INDEXED_KEY_RE = /^([^.]+)(?:\.(\d+))?$/;
 
 /** Injectable directory lister — returns filenames (not full paths). */
 export type ListFiles = (dir: string) => string[];
@@ -209,6 +210,11 @@ export interface ResolveHooksOptions {
  * The `afk.hooks.defaults.<name>: false` toggle is no longer honored — shadow
  * the built-in with a same-named no-op script in `.red/hooks/` instead. Old
  * configs that still carry the key are silently ignored (no error).
+ *
+ * Supports two forms for multi-command hooks: a newline-joined block scalar or
+ * a YAML list. The YAML parser flattens a list into indexed keys of the form
+ * `afk.hooks.<name>.<N>`, which are collected in index order and merged with
+ * any bare-scalar entry for the same point.
  */
 export function resolveHooks(
   config: ConfigValues,
@@ -217,8 +223,10 @@ export function resolveHooks(
   const { defaultCommand } = options;
 
   // Walk the flat config once, collecting per-point user command lists and
-  // validating hook names eagerly.
-  const userLists = new Map<HookName, string[]>();
+  // validating hook names eagerly. Entries accumulate as {index, command}
+  // pairs so YAML-list indexed keys (`name.N`) sort before bare-string entries
+  // (which use MAX_SAFE_INTEGER as their sort key).
+  const userEntries = new Map<HookName, Array<{ index: number; command: string }>>();
 
   for (const [key, value] of Object.entries(config)) {
     if (!key.startsWith(HOOKS_PREFIX)) continue;
@@ -227,15 +235,36 @@ export function resolveHooks(
     // now that same-filename shadowing in .red/hooks/ replaces them.
     if (key.startsWith(DEFAULTS_PREFIX)) continue;
 
-    const name = key.slice(HOOKS_PREFIX.length);
+    const rawName = key.slice(HOOKS_PREFIX.length);
+    const match = INDEXED_KEY_RE.exec(rawName);
+    if (!match) throw new UnknownHookError(rawName);
+
+    const name = match[1]!;
     if (!isCanonical(name)) throw new UnknownHookError(name);
 
+    const explicitIndex = match[2] === undefined ? undefined : Number(match[2]);
     const commands = value
       .split("\n")
       .map((line) => line.trim())
       .filter((line) => line.length > 0);
-    userLists.set(name, commands);
+
+    const entries = userEntries.get(name) ?? [];
+    commands.forEach((command, offset) => {
+      entries.push({
+        index: explicitIndex === undefined ? Number.MAX_SAFE_INTEGER + offset : explicitIndex + offset,
+        command,
+      });
+    });
+    userEntries.set(name, entries);
   }
+
+  // Sort each hook's entries by index and flatten to a string list.
+  const userLists = new Map<HookName, string[]>(
+    [...userEntries.entries()].map(([name, entries]) => [
+      name,
+      entries.sort((a, b) => a.index - b.index).map((e) => e.command),
+    ]),
+  );
 
   const { libraryHooksDir, projectHooksDir } = options;
   const listFiles = options.listFiles ?? ((dir) => readdirSync(dir));
@@ -267,6 +296,25 @@ export function resolveHooks(
   }
 
   return resolved;
+}
+
+/**
+ * Validate the hook names in a config without resolving scripts. Throws
+ * `UnknownHookError` for the first key whose name component (after stripping
+ * any `.N` index suffix) is not a canonical lifecycle point. Call this once at
+ * worker startup to surface config errors loudly before the session loop begins
+ * rather than crashing on first issue pick-up.
+ */
+export function validateHookConfig(config: ConfigValues): void {
+  for (const key of Object.keys(config)) {
+    if (!key.startsWith(HOOKS_PREFIX)) continue;
+    if (key.startsWith(DEFAULTS_PREFIX)) continue;
+    const rawName = key.slice(HOOKS_PREFIX.length);
+    const match = INDEXED_KEY_RE.exec(rawName);
+    if (!match) throw new UnknownHookError(rawName);
+    const name = match[1]!;
+    if (!isCanonical(name)) throw new UnknownHookError(name);
+  }
 }
 
 /**

--- a/apps/dev/tests/hook-config.test.ts
+++ b/apps/dev/tests/hook-config.test.ts
@@ -3,6 +3,8 @@ import {
   CANONICAL_HOOK_NAMES,
   HOOK_DEFAULTS_REGISTRY,
   resolveHooks,
+  validateHookConfig,
+  UnknownHookError,
   scriptDefaultResolver,
   type ResolvedHooks,
 } from "../src/core/hook-config.js";
@@ -151,5 +153,77 @@ describe("hook-config resolution", () => {
       // None of the new points ship a built-in default → resolve to the empty list.
       expect(resolve({})[name]).toEqual([]);
     }
+  });
+
+  it("resolves YAML list-form (indexed keys) identically to the newline-joined scalar form", () => {
+    const listForm = resolve({
+      "afk.hooks.pre_session.0": "echo first",
+      "afk.hooks.pre_session.1": "echo second",
+      "afk.hooks.pre_session.2": "echo third",
+    });
+    const scalarForm = resolve({
+      "afk.hooks.pre_session": ["echo first", "echo second", "echo third"].join("\n"),
+    });
+    expect(listForm.pre_session).toEqual(["echo first", "echo second", "echo third"]);
+    expect(listForm.pre_session).toEqual(scalarForm.pre_session);
+  });
+
+  it("pins dispatch order for list-form hooks by explicit index", () => {
+    const resolved = resolve({
+      "afk.hooks.post_session.2": "echo c",
+      "afk.hooks.post_session.0": "echo a",
+      "afk.hooks.post_session.1": "echo b",
+    });
+    expect(resolved.post_session).toEqual(["echo a", "echo b", "echo c"]);
+  });
+
+  it("list-form for any lifecycle point does not throw UnknownHookError", () => {
+    for (const name of CANONICAL_HOOK_NAMES) {
+      expect(() =>
+        resolve({ [`afk.hooks.${name}.0`]: "echo test" }),
+      ).not.toThrow();
+    }
+  });
+
+  it("list-form and bare-string form for the same point merge in index-then-scalar order", () => {
+    // Indexed entries sort before the bare scalar (which uses MAX_SAFE_INTEGER as index).
+    const resolved = resolve({
+      "afk.hooks.post_session": "echo bare",
+      "afk.hooks.post_session.0": "echo indexed",
+    });
+    expect(resolved.post_session).toEqual(["echo indexed", "echo bare"]);
+  });
+
+  it("throws UnknownHookError for a genuinely unknown hook name in indexed form", () => {
+    expect(() =>
+      resolve({ "afk.hooks.not_a_real_hook.0": "echo nope" }),
+    ).toThrow(/unknown hook name 'not_a_real_hook'/);
+  });
+
+  it("validateHookConfig passes a valid config silently", () => {
+    expect(() =>
+      validateHookConfig({
+        "afk.hooks.pre_session": "echo boot",
+        "afk.hooks.pre_merge.0": "echo first",
+        "afk.hooks.pre_merge.1": "echo second",
+      }),
+    ).not.toThrow();
+  });
+
+  it("validateHookConfig throws UnknownHookError naming the offending key", () => {
+    let caught: unknown;
+    try {
+      validateHookConfig({ "afk.hooks.bad_hook_name": "echo nope" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(UnknownHookError);
+    expect((caught as UnknownHookError).hookName).toBe("bad_hook_name");
+  });
+
+  it("validateHookConfig throws for a malformed key that does not match name[.N]", () => {
+    expect(() =>
+      validateHookConfig({ "afk.hooks.pre_session.foo": "echo nope" }),
+    ).toThrow(UnknownHookError);
   });
 });

--- a/apps/dev/tests/tsconfig-import-hygiene.test.ts
+++ b/apps/dev/tests/tsconfig-import-hygiene.test.ts
@@ -20,7 +20,7 @@ const DEV_UNUSED_IMPORT_DEBT: Record<string, number> = {
   "src/commands/retake.ts": 1,
   "src/commands/route-model-tier.ts": 1,
   "src/commands/run/activity.ts": 143,
-  "src/commands/run/command.ts": 87,
+  "src/commands/run/command.ts": 86,
   "src/commands/run/flags.ts": 133,
   "src/commands/run/process-deps.ts": 74,
   "src/commands/run/reconcile.ts": 110,

--- a/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
@@ -108,7 +108,7 @@ External advisory reviewers (CodeRabbit and the like) are **not** binding: the w
 - Output: empty stdout → context unchanged; JSON object on stdout → AFK replaces the documented mutable slice with the returned value. Non-JSON stdout is treated as a parse failure.
 - Exit code: `0` continues the chain; non-zero is routed through a per-hook policy table — `pre_*` aborts the step, `post_*` / `on_idle` / `on_*_error` log and continue so a broken notifier never wedges AFK.
 
-Within a single hook list, **built-in defaults run first, user-declared commands run after**, and declaration order is preserved inside each group. A bare string is shorthand for a one-element list. An unknown hook name in `.red/config.yaml` is a hard error at session boot. Disable a built-in default with `afk.hooks.defaults.<name>: false` — reordering is not supported.
+Within a single hook list, **built-in defaults run first, user-declared commands run after**, and declaration order is preserved inside each group. Two equivalent forms declare a multi-command hook: a bare scalar (one command, or commands joined by `\n`) and a **YAML list** (each element becomes one command, executed top-to-bottom). Both forms are accepted for every lifecycle point. An unknown hook name in `.red/config.yaml` is a hard error at session boot (surfaced before the first issue pick-up, so it does not cause a spawn/death churn loop). Disable a built-in default with `afk.hooks.defaults.<name>: false` — reordering is not supported.
 
 Every hook command emits explicit dispatch breadcrumbs around the shell call:
 `[afk:hooks] <point>: enter: <command>` and
@@ -223,7 +223,11 @@ Example configuration:
 ```yaml
 afk:
   hooks:
-    pre_session: "echo boot"            # bare-string shorthand
+    pre_session: "echo boot"            # bare-string shorthand (one command)
+    pre_merge:
+      # YAML list form — each element is one command, executed in order.
+      # Equivalent to the bare scalar "bash .red/hooks/fmt.sh" for a single entry.
+      - bash .red/hooks/pre_merge/red-rust-fmt.sh
     post_pick:
       # filter the queue to issues you opened — RED_AFK_GITHUB_LOGIN must be set
       - "RED_AFK_GITHUB_LOGIN=$(gh api user --jq .login) \

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -108,7 +108,7 @@ External advisory reviewers (CodeRabbit and the like) are **not** binding: the w
 - Output: empty stdout → context unchanged; JSON object on stdout → AFK replaces the documented mutable slice with the returned value. Non-JSON stdout is treated as a parse failure.
 - Exit code: `0` continues the chain; non-zero is routed through a per-hook policy table — `pre_*` aborts the step, `post_*` / `on_idle` / `on_*_error` log and continue so a broken notifier never wedges AFK.
 
-Within a single hook list, **built-in defaults run first, user-declared commands run after**, and declaration order is preserved inside each group. A bare string is shorthand for a one-element list. An unknown hook name in `.red/config.yaml` is a hard error at session boot. Disable a built-in default with `afk.hooks.defaults.<name>: false` — reordering is not supported.
+Within a single hook list, **built-in defaults run first, user-declared commands run after**, and declaration order is preserved inside each group. Two equivalent forms declare a multi-command hook: a bare scalar (one command, or commands joined by `\n`) and a **YAML list** (each element becomes one command, executed top-to-bottom). Both forms are accepted for every lifecycle point. An unknown hook name in `.red/config.yaml` is a hard error at session boot (surfaced before the first issue pick-up, so it does not cause a spawn/death churn loop). Disable a built-in default with `afk.hooks.defaults.<name>: false` — reordering is not supported.
 
 Every hook command emits explicit dispatch breadcrumbs around the shell call:
 `[afk:hooks] <point>: enter: <command>` and
@@ -223,7 +223,11 @@ Example configuration:
 ```yaml
 afk:
   hooks:
-    pre_session: "echo boot"            # bare-string shorthand
+    pre_session: "echo boot"            # bare-string shorthand (one command)
+    pre_merge:
+      # YAML list form — each element is one command, executed in order.
+      # Equivalent to the bare scalar "bash .red/hooks/fmt.sh" for a single entry.
+      - bash .red/hooks/pre_merge/red-rust-fmt.sh
     post_pick:
       # filter the queue to issues you opened — RED_AFK_GITHUB_LOGIN must be set
       - "RED_AFK_GITHUB_LOGIN=$(gh api user --jq .login) \


### PR DESCRIPTION
Automated AFK landing for #2375. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2375

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787262026&installation_model_id=20659&pr_number=2399&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2399&signature=493c71fe49ccfab19e81d8b7b4becbcaa7a82e5a913df2c61af22dc07e14b818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->