### PR TITLE
feat(afk): re-claim resumes from existing pushed branch by default

### DIFF
--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -543,6 +543,9 @@ export function buildProcessDeps(
       // already landed in <base>, distinguishing own-merge close (done) from a
       // foreign close (claim-lost) when the guard observes the issue CLOSED.
       branchMerged: (branch, base) => gitx.branchMergedInto(gitCtx, branch, base),
+      // Branch-resume discovery (issue #2397): list all remote afk/* refs so the
+      // lifecycle can detect a prior pushed branch and resume instead of rebuilding.
+      discoverBranches: () => gitx.listRemoteBranches(gitCtx, "afk/"),
     },
     envelope: {
       git: gitx.gitExec(gitCtx),

--- a/apps/dev/src/core/branch-resume.ts
+++ b/apps/dev/src/core/branch-resume.ts
@@ -1,0 +1,98 @@
+// branch-resume — pure decision layer for branch-resume on re-claim (issue #2397).
+//
+// When a worker re-claims an issue, these functions determine whether a prior
+// attempt's pushed branch exists and whether it reached a gate-green state. The
+// caller (lifecycle.ts) skips prepareFreshWorkerBranch, injects a
+// <resume-from-branch> section into the handoff, and for gate-green branches
+// bypasses the agent entirely (validate + land directly).
+
+import type { BranchRef } from "./branch-cleanup.js";
+
+const LIVE_REF_ISSUE_RE = /^afk\/[^/]+\/([0-9]+)-[a-z0-9-]+$/;
+
+function issueFromRef(branch: string): number | null {
+  const m = LIVE_REF_ISSUE_RE.exec(branch);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Select the newest branch (by commitS) for `issue` from a list of remote refs.
+ * Returns null when no matching branch exists.
+ */
+export function discoverResumableBranch(refs: readonly BranchRef[], issue: number): BranchRef | null {
+  const candidates = refs.filter((r) => issueFromRef(r.branch) === issue);
+  if (candidates.length === 0) return null;
+  return candidates.reduce((best, cur) => {
+    const bs = best.commitS ?? -Infinity;
+    const cs = cur.commitS ?? -Infinity;
+    return cs > bs ? cur : best;
+  });
+}
+
+/**
+ * Extract the `prev-failure-reason:` value from a prior-attempt-context block.
+ * Returns undefined when the marker is absent or the context is empty.
+ */
+export function extractFailureReason(priorAttemptContext: string | undefined): string | undefined {
+  if (!priorAttemptContext) return undefined;
+  const marker = "prev-failure-reason:";
+  const idx = priorAttemptContext.indexOf(marker);
+  if (idx === -1) return undefined;
+  return priorAttemptContext.slice(idx + marker.length).trim();
+}
+
+// Gate-stage failure reasons: when the prior attempt failed for one of these,
+// the gate did NOT pass — a full agent iteration is still required.
+const GATE_STAGE_REASONS = new Set([
+  "feedback-failed",
+  "no-sentinel",
+  "stalled",
+  "blocked",
+  "base-stale",
+  "merge-conflict",
+  "runner-transient",
+  "exhausted",
+  "signal-killed",
+]);
+
+/**
+ * True when `failureReason` is present and does NOT name a gate-stage failure —
+ * meaning the prior attempt's gate passed and only the landing step remains.
+ * A missing/empty reason returns false (first attempt; safe to run the agent).
+ */
+export function isGateGreenBranch(failureReason: string | undefined): boolean {
+  if (!failureReason) return false;
+  // Strip trailing colon (e.g. "feedback-failed: detail text") before lookup.
+  const first = (failureReason.trim().split(/\s+/)[0] ?? "").replace(/:$/, "");
+  return first.length > 0 && !GATE_STAGE_REASONS.has(first);
+}
+
+/**
+ * True when the assembled human guidance explicitly requests a full restart or
+ * rebuild, overriding the automatic resume behaviour.
+ */
+export function isExplicitRestartRequested(humanGuidance: string): boolean {
+  return /\brestart\b|\brebuild\b/i.test(humanGuidance);
+}
+
+/**
+ * Build the content for the `<resume-from-branch>` handoff section.
+ * Gate-green variant: agent verifies + gates, no re-implementation.
+ * Non-gate-green variant: agent continues from where the branch left off.
+ */
+export function buildResumeInstruction(branch: string, isGateGreen: boolean): string {
+  if (isGateGreen) {
+    return [
+      `Branch \`${branch}\` was pushed in a prior attempt and its gate already passed.`,
+      "Checkout this branch in your worktree, verify the base is still fresh,",
+      "re-run the merge gate, and emit `<promise>DONE</promise>` when it passes.",
+      "Do NOT re-implement — the work is already there.",
+    ].join(" ");
+  }
+  return [
+    `Branch \`${branch}\` was pushed in a prior attempt.`,
+    "Checkout this branch in your worktree and continue from where it left off —",
+    "do NOT start over. Run `git log --oneline origin/main..HEAD` to see what was",
+    "already committed, then satisfy the merge gate and emit `<promise>DONE</promise>`.",
+  ].join(" ");
+}

--- a/apps/dev/src/core/handoff.ts
+++ b/apps/dev/src/core/handoff.ts
@@ -97,6 +97,14 @@ export interface HandoffInput {
    * the steered arm and carries phrasing constraints, never task semantics.
    */
   outputShaping?: OutputShapingAssignment;
+  /**
+   * Branch from a prior attempt to resume from (issue #2397). When set, a
+   * `<resume-from-branch>` section is emitted immediately after `<issue-body>`,
+   * instructing the agent to checkout this branch instead of starting fresh.
+   * Gate-green fast path: the orchestrator skips the agent entirely when it
+   * detects the branch's prior gate already passed.
+   */
+  resumeFromBranch?: string;
 }
 
 /** Trimmed-of-all-whitespace emptiness test (bash `[[ -n "$x" ]]` after capture). */
@@ -327,6 +335,13 @@ export function buildHandoff(input: HandoffInput): string {
   lines.push('<issue-body data-untrusted="true">');
   lines.push(input.body);
   lines.push("</issue-body>");
+
+  if (isPresent(input.resumeFromBranch)) {
+    lines.push("");
+    lines.push("<resume-from-branch>");
+    lines.push(input.resumeFromBranch);
+    lines.push("</resume-from-branch>");
+  }
 
   const mergeGate = buildMergeGate(input.mergeGateCommands);
   if (isPresent(mergeGate)) {

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -6,7 +6,14 @@ import {
   slugifyRef,
   type GitExec,
 } from "../remote-branch.js";
-import { buildHandoff, exitProtocolFor, type HandoffComment } from "../handoff.js";
+import { buildHandoff, buildHumanGuidance, exitProtocolFor, type HandoffComment } from "../handoff.js";
+import {
+  buildResumeInstruction,
+  discoverResumableBranch,
+  extractFailureReason,
+  isExplicitRestartRequested,
+  isGateGreenBranch,
+} from "../branch-resume.js";
 import { assignOutputShaping, type OutputShapingConfig } from "../output-shaping.js";
 import { evaluateGoalPredicate } from "../goal-predicate.js";
 import {
@@ -274,6 +281,18 @@ export async function processIssue(
   const comments = await deps.lookups.comments(issue);
   const url = await deps.lookups.issueUrl(issue);
   const priorAttemptContext = await deps.lookups.priorAttemptContext(issue);
+  // Branch-resume logic (issue #2397): discover a prior pushed branch so re-claim
+  // can continue instead of rebuilding from scratch. Explicit restart overrides.
+  const allBranches = await deps.lookups.discoverBranches?.() ?? [];
+  const humanGuidanceForResume = buildHumanGuidance(comments);
+  const explicitRestart = isExplicitRestartRequested(humanGuidanceForResume);
+  const resumableBranch = explicitRestart ? null : discoverResumableBranch(allBranches, issue);
+  const failureReason = extractFailureReason(priorAttemptContext);
+  const resumeIsGateGreen = resumableBranch !== null && isGateGreenBranch(failureReason);
+  const resumeInstruction =
+    resumableBranch !== null
+      ? buildResumeInstruction(resumableBranch.branch, resumeIsGateGreen)
+      : undefined;
   const outputShaping = assignOutputShaping(issue, deps.outputShaping ?? { terseSteering: false });
   const handoff = buildHandoff({
     issue,
@@ -288,6 +307,7 @@ export async function processIssue(
     specRef: input.specRef,
     mergeGateCommands: deps.backpressureCommands ?? [],
     outputShaping,
+    resumeFromBranch: resumeInstruction,
   });
   deps.markState?.({
     "current.output_shaping_enabled": outputShaping.enabled,
@@ -356,11 +376,15 @@ export async function processIssue(
     });
   }
   const baseRef = baseResolution.baseRef;
-  await deps.git.prepareFreshWorkerBranch?.({
-    branch,
-    baseRef,
-    force: isMergeConflictRetry(priorAttemptContext),
-  });
+  // Skip branch preparation when resuming from a prior pushed branch: the branch
+  // already exists on origin and must not be deleted or reset (issue #2397).
+  if (!resumableBranch) {
+    await deps.git.prepareFreshWorkerBranch?.({
+      branch,
+      baseRef,
+      force: isMergeConflictRetry(priorAttemptContext),
+    });
+  }
   let activeRunner: Runner = toAgentRunner(input.runner);
   let attemptN = input.attempt;
   let activeTaskClass: AfkModelTier = taskClass;
@@ -423,114 +447,129 @@ export async function processIssue(
       hookContext({ issue, title: input.title, workspace: branch, runner: activeRunner, attempt_n: attemptN }),
     );
   };
+  // Gate-green fast path (issue #2397): when a prior branch already cleared the
+  // feedback gate, skip the agent entirely on re-claim and re-validate directly.
+  let gateGreenSkip = resumeIsGateGreen;
   while (true) {
     const initialTier = resolveSpawnTier(deps, activeRunner, activeTaskClass);
-    const baseAgentInput: RunAgentInput = {
-      runner: activeRunner,
-      model: initialTier.model,
-      effort: initialTier.effort,
-      handoffPath,
-      handoffContent: currentHandoff,
-      systemPrompt: exitProtocolFor({
-        runMode: input.runMode,
-        structuredOutput: runnerSupportsStructuredOutput(toAgentRunner(activeRunner)),
+    let run: RunAgentResult;
+    if (gateGreenSkip) {
+      // Consume the flag — subsequent loop iterations (e.g. go-verify retries)
+      // run the agent normally.
+      gateGreenSkip = false;
+      const fastBranch = resumableBranch!.branch;
+      deps.appendIterLog(
+        `🤖 /afk #${issue}: gate-green fast path — re-validating \`${fastBranch}\`, agent skipped.`,
+      );
+      run = { outcome: "done", branch: fastBranch, commits: [], stdout: "" };
+    } else {
+      const baseAgentInput: RunAgentInput = {
         runner: activeRunner,
-      }),
-      branch,
-      base: baseRef,
-      cwd: input.attemptDir,
-      logPath: `${input.attemptDir}/afk.log`,
-      onAgentEvent: agentEventSink,
-      onHeartbeat: (info) => {
-        const vitals = deps.heartbeatVitals?.();
-        void fireHook(
-          "on_heartbeat",
-          hookContext({
-            issue,
-            title: input.title,
-            workspace: branch,
-            runner: activeRunner,
-            attempt_n: attemptN,
-            ...(vitals ? { vitals } : {}),
-          }),
-        );
-        deps.emitHeartbeat?.({ ...info, base });
-      },
-      remote: input.remote,
-      continuousPush: input.runMode !== "scout",
-      goalProbe: () => deps.gh.issueClosed(issue),
-      env: agentEnv,
-      sandboxMode: sandboxDecision.sandboxMode,
-    };
-    const notesLoopCfg: NotesLoopConfig = deps.notesLoop ?? {
-      enabled: false,
-      maxIterations: 1,
-      innerMaxIterations: 0,
-      tokenBudget: 0,
-      wallClockS: 0,
-    };
-    const notesOutcome = await runNotesLoop({
-      config: notesLoopCfg,
-      baseHandoff: currentHandoff,
-      runOnce: ({ handoff: iterationHandoff }) =>
-        deps.runAgent({
-          ...baseAgentInput,
-          handoffContent: iterationHandoff,
-          ...(notesLoopCfg.enabled && notesLoopCfg.innerMaxIterations > 0
-            ? { maxIterations: notesLoopCfg.innerMaxIterations }
-            : {}),
-        }),
-      persistNotes: (content) => deps.writeNotes?.(notesPath(input.attemptDir), content),
-      now: () => deps.nowEpoch() * 1000,
-      tokensSpent: () => {
-        const vitals = deps.heartbeatVitals?.();
-        return vitals ? (vitals.input_tokens ?? 0) + (vitals.output_tokens ?? 0) : 0;
-      },
-      log: (message) => deps.appendIterLog(message),
-    });
-    let run: RunAgentResult = notesOutcome.run;
-    if (isRunnerRecoverableOutcome(run.outcome)) {
-      if (!deps.fallbackRunner) {
-        return await runnerRecoverable(deps, input, branch, base, hooksFired, activeRunner, run.outcome, false);
-      }
-      await fireHook("post_attempt", postAttemptContext({ ...input, attempt: attemptN }, branch, "fail", run.outcome));
-      const other: Runner = activeRunner === "claude" ? "codex" : "claude";
-      activeRunner = other;
-      attemptN += 1;
-      if (
-        !(await fireHook(
-          "pre_attempt",
-          hookContext({ issue, title: input.title, workspace: branch, runner: activeRunner, attempt_n: attemptN }),
-        ))
-      ) {
-        return await abortAfterClaim(deps, input, branch, base, hooksFired, "pre_attempt");
-      }
-      const fallbackTier = resolveSpawnTier(deps, other, activeTaskClass);
-      run = await deps.runAgent({
-        runner: other,
-        model: fallbackTier.model,
-        effort: fallbackTier.effort,
+        model: initialTier.model,
+        effort: initialTier.effort,
         handoffPath,
         handoffContent: currentHandoff,
         systemPrompt: exitProtocolFor({
           runMode: input.runMode,
-          structuredOutput: runnerSupportsStructuredOutput(toAgentRunner(other)),
-          runner: other,
+          structuredOutput: runnerSupportsStructuredOutput(toAgentRunner(activeRunner)),
+          runner: activeRunner,
         }),
         branch,
-        base,
+        base: baseRef,
         cwd: input.attemptDir,
         logPath: `${input.attemptDir}/afk.log`,
         onAgentEvent: agentEventSink,
+        onHeartbeat: (info) => {
+          const vitals = deps.heartbeatVitals?.();
+          void fireHook(
+            "on_heartbeat",
+            hookContext({
+              issue,
+              title: input.title,
+              workspace: branch,
+              runner: activeRunner,
+              attempt_n: attemptN,
+              ...(vitals ? { vitals } : {}),
+            }),
+          );
+          deps.emitHeartbeat?.({ ...info, base });
+        },
         remote: input.remote,
         continuousPush: input.runMode !== "scout",
         goalProbe: () => deps.gh.issueClosed(issue),
         env: agentEnv,
         sandboxMode: sandboxDecision.sandboxMode,
+      };
+      const notesLoopCfg: NotesLoopConfig = deps.notesLoop ?? {
+        enabled: false,
+        maxIterations: 1,
+        innerMaxIterations: 0,
+        tokenBudget: 0,
+        wallClockS: 0,
+      };
+      const notesOutcome = await runNotesLoop({
+        config: notesLoopCfg,
+        baseHandoff: currentHandoff,
+        runOnce: ({ handoff: iterationHandoff }) =>
+          deps.runAgent({
+            ...baseAgentInput,
+            handoffContent: iterationHandoff,
+            ...(notesLoopCfg.enabled && notesLoopCfg.innerMaxIterations > 0
+              ? { maxIterations: notesLoopCfg.innerMaxIterations }
+              : {}),
+          }),
+        persistNotes: (content) => deps.writeNotes?.(notesPath(input.attemptDir), content),
+        now: () => deps.nowEpoch() * 1000,
+        tokensSpent: () => {
+          const vitals = deps.heartbeatVitals?.();
+          return vitals ? (vitals.input_tokens ?? 0) + (vitals.output_tokens ?? 0) : 0;
+        },
+        log: (message) => deps.appendIterLog(message),
       });
+      run = notesOutcome.run;
       if (isRunnerRecoverableOutcome(run.outcome)) {
+        if (!deps.fallbackRunner) {
+          return await runnerRecoverable(deps, input, branch, base, hooksFired, activeRunner, run.outcome, false);
+        }
         await fireHook("post_attempt", postAttemptContext({ ...input, attempt: attemptN }, branch, "fail", run.outcome));
-        return await runnerRecoverable(deps, input, branch, base, hooksFired, activeRunner, run.outcome, true);
+        const other: Runner = activeRunner === "claude" ? "codex" : "claude";
+        activeRunner = other;
+        attemptN += 1;
+        if (
+          !(await fireHook(
+            "pre_attempt",
+            hookContext({ issue, title: input.title, workspace: branch, runner: activeRunner, attempt_n: attemptN }),
+          ))
+        ) {
+          return await abortAfterClaim(deps, input, branch, base, hooksFired, "pre_attempt");
+        }
+        const fallbackTier = resolveSpawnTier(deps, other, activeTaskClass);
+        run = await deps.runAgent({
+          runner: other,
+          model: fallbackTier.model,
+          effort: fallbackTier.effort,
+          handoffPath,
+          handoffContent: currentHandoff,
+          systemPrompt: exitProtocolFor({
+            runMode: input.runMode,
+            structuredOutput: runnerSupportsStructuredOutput(toAgentRunner(other)),
+            runner: other,
+          }),
+          branch,
+          base,
+          cwd: input.attemptDir,
+          logPath: `${input.attemptDir}/afk.log`,
+          onAgentEvent: agentEventSink,
+          remote: input.remote,
+          continuousPush: input.runMode !== "scout",
+          goalProbe: () => deps.gh.issueClosed(issue),
+          env: agentEnv,
+          sandboxMode: sandboxDecision.sandboxMode,
+        });
+        if (isRunnerRecoverableOutcome(run.outcome)) {
+          await fireHook("post_attempt", postAttemptContext({ ...input, attempt: attemptN }, branch, "fail", run.outcome));
+          return await runnerRecoverable(deps, input, branch, base, hooksFired, activeRunner, run.outcome, true);
+        }
       }
     }
     workerBranch = run.branch || branch;

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -1,4 +1,5 @@
 import { resolveBase, type ResolveBaseDeps, type ResolveBaseInput } from "../base-resolver.js";
+import type { BranchRef } from "../branch-cleanup.js";
 import {
   buildRefFromSlug,
   deleteRemote,
@@ -173,6 +174,9 @@ export interface ProcessLookups {
   diffstat(branch: string, base: string): Promise<string>;
   branchPresent?(branch: string): Promise<boolean>;
   branchMerged?(branch: string, base: string): Promise<boolean>;
+  /** Discover all remote afk/* branches (issue #2397). Used to detect a prior
+   * pushed attempt so re-claim can resume instead of rebuilding from scratch. */
+  discoverBranches?(): Promise<BranchRef[]>;
 }
 export function remoteTrackingBaseRef(remote: string, base: string): string {
   if (/^[0-9a-f]{7,40}$/i.test(base) || base.startsWith("refs/") || base.startsWith(`${remote}/`)) {

--- a/apps/dev/tests/branch-resume.test.ts
+++ b/apps/dev/tests/branch-resume.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildResumeInstruction,
+  discoverResumableBranch,
+  extractFailureReason,
+  isExplicitRestartRequested,
+  isGateGreenBranch,
+} from "../src/core/branch-resume.js";
+import type { BranchRef } from "../src/core/branch-cleanup.js";
+
+// Refs #2397
+
+describe("discoverResumableBranch", () => {
+  it("returns null for an empty ref list", () => {
+    expect(discoverResumableBranch([], 42)).toBeNull();
+  });
+
+  it("returns null when no branch matches the issue", () => {
+    const refs: BranchRef[] = [
+      { branch: "afk/wAB12/10-other-issue", commitS: 1000 },
+      { branch: "afk/wAB12/11-another", commitS: 2000 },
+    ];
+    expect(discoverResumableBranch(refs, 9)).toBeNull();
+  });
+
+  it("returns the single matching branch", () => {
+    const refs: BranchRef[] = [
+      { branch: "afk/wAB12/9-fix-the-thing", commitS: 1000 },
+      { branch: "afk/wAB12/10-other-issue", commitS: 2000 },
+    ];
+    expect(discoverResumableBranch(refs, 9)).toEqual({
+      branch: "afk/wAB12/9-fix-the-thing",
+      commitS: 1000,
+    });
+  });
+
+  it("selects the branch with the highest commitS when multiple match", () => {
+    const refs: BranchRef[] = [
+      { branch: "afk/wAB12/9-fix-the-thing", commitS: 1000 },
+      { branch: "afk/wXX99/9-fix-the-thing", commitS: 3000 },
+      { branch: "afk/wYY01/9-fix-the-thing", commitS: 2000 },
+    ];
+    expect(discoverResumableBranch(refs, 9)?.branch).toBe("afk/wXX99/9-fix-the-thing");
+  });
+
+  it("prefers a branch with a commitS over one without", () => {
+    const refs: BranchRef[] = [
+      { branch: "afk/wAB12/9-fix-the-thing" },
+      { branch: "afk/wXX99/9-fix-the-thing", commitS: 1 },
+    ];
+    expect(discoverResumableBranch(refs, 9)?.branch).toBe("afk/wXX99/9-fix-the-thing");
+  });
+
+  it("returns a branch even when commitS is absent on all candidates", () => {
+    const refs: BranchRef[] = [
+      { branch: "afk/wAB12/9-fix-the-thing" },
+    ];
+    expect(discoverResumableBranch(refs, 9)?.branch).toBe("afk/wAB12/9-fix-the-thing");
+  });
+
+  it("ignores snapshot branches (afk-attempts/*) and other namespaces", () => {
+    const refs: BranchRef[] = [
+      { branch: "afk-attempts/wAB12/9-fix-the-thing", commitS: 9999 },
+      { branch: "main", commitS: 9999 },
+      { branch: "afk/wAB12/9-fix-the-thing", commitS: 100 },
+    ];
+    expect(discoverResumableBranch(refs, 9)?.branch).toBe("afk/wAB12/9-fix-the-thing");
+  });
+});
+
+describe("extractFailureReason", () => {
+  it("returns undefined for undefined context", () => {
+    expect(extractFailureReason(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when the marker is absent", () => {
+    expect(extractFailureReason("prev-snapshot-branch: afk/wAB12/9-fix")).toBeUndefined();
+  });
+
+  it("extracts the reason after prev-failure-reason:", () => {
+    const ctx = "prev-attempt: 1\nprev-failure-reason:\nlanding-quota-exceeded\n";
+    expect(extractFailureReason(ctx)).toBe("landing-quota-exceeded");
+  });
+
+  it("trims surrounding whitespace from the extracted reason", () => {
+    const ctx = "prev-failure-reason:   feedback-failed   ";
+    expect(extractFailureReason(ctx)).toBe("feedback-failed");
+  });
+
+  it("handles multi-word reason text", () => {
+    const ctx = "prev-failure-reason:\nsome custom reason here\n";
+    expect(extractFailureReason(ctx)).toBe("some custom reason here");
+  });
+});
+
+describe("isGateGreenBranch", () => {
+  it("returns false for undefined reason (first attempt — no prior context)", () => {
+    expect(isGateGreenBranch(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string reason", () => {
+    expect(isGateGreenBranch("")).toBe(false);
+  });
+
+  it.each([
+    "feedback-failed",
+    "no-sentinel",
+    "stalled",
+    "blocked",
+    "base-stale",
+    "merge-conflict",
+    "runner-transient",
+    "exhausted",
+    "signal-killed",
+  ])("returns false for gate-stage failure reason %s", (reason) => {
+    expect(isGateGreenBranch(reason)).toBe(false);
+  });
+
+  it.each([
+    "landing-quota-exceeded",
+    "landing-conflict",
+    "pr-open-failed",
+    "some-other-post-gate-reason",
+  ])("returns true for post-gate failure reason %s", (reason) => {
+    expect(isGateGreenBranch(reason)).toBe(true);
+  });
+
+  it("checks only the first token, ignoring subsequent words", () => {
+    expect(isGateGreenBranch("landing-quota-exceeded: GitHub API rate limit")).toBe(true);
+    expect(isGateGreenBranch("feedback-failed: tests failed")).toBe(false);
+  });
+});
+
+describe("isExplicitRestartRequested", () => {
+  it("returns false for empty guidance", () => {
+    expect(isExplicitRestartRequested("")).toBe(false);
+  });
+
+  it("returns false for guidance that does not mention restart/rebuild", () => {
+    expect(isExplicitRestartRequested("Please fix the typo in the commit message.")).toBe(false);
+  });
+
+  it("returns true when guidance contains 'restart' as a whole word", () => {
+    expect(isExplicitRestartRequested("Please restart from scratch.")).toBe(true);
+  });
+
+  it("returns true when guidance contains 'rebuild'", () => {
+    expect(isExplicitRestartRequested("We need to rebuild this from the ground up.")).toBe(true);
+  });
+
+  it("returns true case-insensitively", () => {
+    expect(isExplicitRestartRequested("RESTART the implementation.")).toBe(true);
+    expect(isExplicitRestartRequested("Rebuild with a different approach.")).toBe(true);
+  });
+
+  it("does not match 'restarting' because the trailing word boundary prevents a partial-stem match", () => {
+    expect(isExplicitRestartRequested("restarting the service")).toBe(false);
+  });
+});
+
+describe("buildResumeInstruction", () => {
+  it("includes the branch name in both variants", () => {
+    const branch = "afk/wAB12/9-fix-the-thing";
+    expect(buildResumeInstruction(branch, true)).toContain(branch);
+    expect(buildResumeInstruction(branch, false)).toContain(branch);
+  });
+
+  it("gate-green variant mentions 'gate already passed' and advises not re-implementing", () => {
+    const text = buildResumeInstruction("afk/wAB12/9-fix", true);
+    expect(text).toContain("gate already passed");
+    expect(text).toContain("Do NOT re-implement");
+  });
+
+  it("non-gate-green variant tells the agent to continue from where it left off", () => {
+    const text = buildResumeInstruction("afk/wAB12/9-fix", false);
+    expect(text).toContain("continue from where it left off");
+    expect(text).toContain("do NOT start over");
+  });
+});

--- a/apps/dev/tests/process-issue-resume.test.ts
+++ b/apps/dev/tests/process-issue-resume.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import type { BranchRef } from "../src/core/branch-cleanup.js";
+import { harness } from "./process-issue.test-helpers.js";
+import { installProcessSafety, noopSafetyLogger } from "./process-issue.test-helpers.js";
+
+// Refs #2397
+
+installProcessSafety(noopSafetyLogger);
+
+const PRIOR_BRANCH = "afk/wOLD1/9-fix-the-thing";
+
+/** A priorAttemptContext whose failure reason is post-gate (gate was green). */
+function gateGreenContext(reason = "landing-quota-exceeded"): string {
+  return `prev-attempt: 1\nprev-snapshot-branch: ${PRIOR_BRANCH}\nprev-failure-reason:\n${reason}\n`;
+}
+
+/** A priorAttemptContext whose failure reason is a gate-stage failure. */
+function gateStageFailed(reason = "feedback-failed"): string {
+  return `prev-attempt: 1\nprev-snapshot-branch: ${PRIOR_BRANCH}\nprev-failure-reason:\n${reason}\n`;
+}
+
+const PRIOR_REFS: BranchRef[] = [
+  { branch: PRIOR_BRANCH, commitS: 9000 },
+];
+
+describe("branch-resume: gate-green fast path (issue #2397)", () => {
+  it("skips runAgent and re-validates directly when prior branch is gate-green", async () => {
+    const { deps, input, trace } = harness({
+      priorAttemptContext: gateGreenContext(),
+    });
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+
+    const result = await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    expect(result.outcome).toBe("done");
+    // Agent must NOT have run — the fast path synthesises the done result.
+    expect(trace.runAgentCalls).toHaveLength(0);
+    // The resumable branch must be used as the worker branch (visible in push argv).
+    const pushCalls = trace.pushedAttempt;
+    expect(pushCalls.some((argv) => argv.join(" ").includes(PRIOR_BRANCH))).toBe(true);
+    // An iter-log message must mention gate-green fast path.
+    expect(trace.iterLogs.some((l) => l.includes("gate-green fast path"))).toBe(true);
+  });
+
+  it("does NOT call prepareFreshWorkerBranch when a resumable branch is found", async () => {
+    const { deps, input, trace } = harness({
+      priorAttemptContext: gateGreenContext(),
+    });
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+
+    await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    expect(trace.freshWorkerBranchCalls).toHaveLength(0);
+  });
+
+  it("includes <resume-from-branch> section in the handoff for gate-green branch", async () => {
+    const { deps, input, trace } = harness({
+      priorAttemptContext: gateGreenContext(),
+    });
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+
+    await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    const handoff = trace.handoffs[0]?.content ?? "";
+    expect(handoff).toContain("<resume-from-branch>");
+    expect(handoff).toContain(PRIOR_BRANCH);
+    expect(handoff).toContain("gate already passed");
+  });
+});
+
+describe("branch-resume: non-gate-green resume path (issue #2397)", () => {
+  it("runs the agent when the prior branch exists but failed at a gate stage", async () => {
+    const { deps, input, trace } = harness({
+      priorAttemptContext: gateStageFailed("feedback-failed"),
+    });
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+
+    const result = await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    expect(result.outcome).toBe("done");
+    // Agent MUST run for a non-gate-green branch.
+    expect(trace.runAgentCalls).toHaveLength(1);
+  });
+
+  it("includes <resume-from-branch> in handoff for non-gate-green branch (agent continues)", async () => {
+    const { deps, input, trace } = harness({
+      priorAttemptContext: gateStageFailed("no-sentinel"),
+    });
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+
+    await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    const handoff = trace.handoffs[0]?.content ?? "";
+    expect(handoff).toContain("<resume-from-branch>");
+    expect(handoff).toContain(PRIOR_BRANCH);
+    expect(handoff).toContain("continue from where it left off");
+  });
+
+  it("does NOT call prepareFreshWorkerBranch when a prior branch exists (even non-gate-green)", async () => {
+    const { deps, input, trace } = harness({
+      priorAttemptContext: gateStageFailed(),
+    });
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+
+    await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    expect(trace.freshWorkerBranchCalls).toHaveLength(0);
+  });
+});
+
+describe("branch-resume: explicit restart override (issue #2397)", () => {
+  it("runs the agent and calls prepareFreshWorkerBranch when guidance says restart", async () => {
+    const { deps, input, trace } = harness({
+      priorAttemptContext: gateGreenContext(),
+      // Inject a trusted restart directive via comments override
+    });
+    // Inject a trusted restart directive via discoverBranches + comments override
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+    // Override comments to return a trusted restart directive
+    deps.lookups.comments = async () => [
+      {
+        body: "<details data-kind=\"directive\">\n<summary>directive</summary>\nPlease restart from scratch.\n</details>",
+        author: "maintainer",
+        sourceTrust: "trusted" as const,
+      },
+    ];
+
+    const result = await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    expect(result.outcome).toBe("done");
+    // Agent MUST run when restart is explicitly requested.
+    expect(trace.runAgentCalls).toHaveLength(1);
+    // prepareFreshWorkerBranch MUST be called when no resume is in effect.
+    expect(trace.freshWorkerBranchCalls).toHaveLength(1);
+  });
+
+  it("omits <resume-from-branch> from handoff when restart is requested", async () => {
+    const { deps, input, trace } = harness({
+      priorAttemptContext: gateGreenContext(),
+    });
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+    deps.lookups.comments = async () => [
+      {
+        body: "<details data-kind=\"directive\">\n<summary>directive</summary>\nPlease restart from scratch.\n</details>",
+        author: "maintainer",
+        sourceTrust: "trusted" as const,
+      },
+    ];
+
+    await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    const handoff = trace.handoffs[0]?.content ?? "";
+    expect(handoff).not.toContain("<resume-from-branch>");
+  });
+});
+
+describe("branch-resume: no prior branch (issue #2397)", () => {
+  it("runs the agent and calls prepareFreshWorkerBranch when no prior branch exists", async () => {
+    const { deps, input, trace } = harness({});
+    deps.lookups.discoverBranches = async () => [];
+
+    const result = await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.freshWorkerBranchCalls).toHaveLength(1);
+  });
+
+  it("omits <resume-from-branch> from handoff when no prior branch exists", async () => {
+    const { deps, input, trace } = harness({});
+    deps.lookups.discoverBranches = async () => [];
+
+    await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    const handoff = trace.handoffs[0]?.content ?? "";
+    expect(handoff).not.toContain("<resume-from-branch>");
+  });
+
+  it("runs normally when discoverBranches is not wired (undefined)", async () => {
+    // Existing callers that have not yet wired discoverBranches get normal behaviour.
+    const { deps, input, trace } = harness({});
+    // discoverBranches is NOT set on deps.lookups (it's optional)
+
+    const result = await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements issue #2397: when a worker re-claims an issue, it now detects any existing `origin/afk/*/<issue>-*` branch and resumes from it instead of rebuilding from scratch.

- **Branch discovery**: `discoverResumableBranch` selects the newest (by `commitS`) remote `afk/*/<issue>-*` branch on re-claim.
- **Automatic resume handoff**: `<resume-from-branch>` section is injected into the handoff — no human comment needed.
- **Gate-green fast path**: if the prior branch's failure reason is post-gate (e.g. `landing-quota-exceeded`), the agent loop is bypassed entirely; a synthetic `{ outcome: "done" }` result flows through re-validate + land.
- **Fresh rebuild only when**: no prior branch exists, OR a trusted human comment says `restart`/`rebuild`.
- **Backward compatible**: `discoverBranches?` is optional in `ProcessLookups` — callers without it get normal flow.

## Changes

- `apps/dev/src/core/branch-resume.ts` — new pure module (5 exported functions)
- `apps/dev/tests/branch-resume.test.ts` — 37 unit tests
- `apps/dev/src/core/handoff.ts` — `resumeFromBranch?` field + emission
- `apps/dev/src/core/process-issue/types.ts` — `discoverBranches?` optional port on `ProcessLookups`
- `apps/dev/src/core/process-issue/lifecycle.ts` — branch discovery, resume wiring, gate-green fast path
- `apps/dev/src/commands/run/process-deps.ts` — wires `discoverBranches` via `gitx.listRemoteBranches`
- `apps/dev/tests/process-issue-resume.test.ts` — 11 integration tests

## Test plan

- [x] Unit tests: `branch-resume.test.ts` 37/37 pass
- [x] Integration tests: `process-issue-resume.test.ts` 11/11 pass
- [x] Handoff tests: `handoff.test.ts` 61/61 pass
- [x] TypeScript typecheck passes
- [ ] CI full suite

Closes #2397

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787263165&installation_model_id=20659&pr_number=2401&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2401&signature=ea5fccf2a8859e182507d1ebd1c2712d2f589a03d01714f6ac8e1cfaf90a73de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->