### PR TITLE
fix: #2379 tmp-janitor: sweep orphaned feedback worktrees so a stale feedback/main can never fake a main-red

### DIFF
--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -602,6 +602,17 @@ function isCrashOrOom(code: number, output: string): boolean {
 }
 
 /**
+ * A baseline probe run that failed because the worktree itself could not be
+ * materialised (stale detached worktree, git lock, missing ref) must never
+ * claim that main is red — it is an infra failure of the probe, not a real
+ * test signal. Detect the sentinel stderr the feedback worktree manager writes
+ * when pathFor returns null and treat it as inconclusive (#2379).
+ */
+function isWorktreeSetupFailure(output: string): boolean {
+  return output.includes("feedback worktree setup failed");
+}
+
+/**
  * The sidecar summary for an `inconclusive` check — the comparison evidence a
  * human needs to read the `blocked:validation` park without re-running anything.
  */
@@ -662,6 +673,23 @@ async function runChecksForBaseline(
         evidence: {
           check: name,
           summary: "baseline probe inconclusive (crash/OOM) — not a confirmed baseline failure",
+          outputTail: boundedFailureOutputTail(output),
+        },
+      });
+      continue;
+    }
+    if (isWorktreeSetupFailure(output)) {
+      // The baseline probe's worktree materialisation failed (stale detached
+      // worktree, lock, missing ref — infra, not a test result). Treat as
+      // inconclusive so the failure is NOT counted as a pre-existing baseline
+      // failure. Without this, a setup failure makes every check appear to also
+      // fail on the baseline, falsely attributing the block to a baseline flake
+      // rather than the branch's code (#2379).
+      out.set(name, {
+        status: "inconclusive",
+        evidence: {
+          check: name,
+          summary: "baseline probe inconclusive (worktree setup failed) — not a confirmed baseline failure",
           outputTail: boundedFailureOutputTail(output),
         },
       });

--- a/apps/dev/src/core/tmp-janitor.ts
+++ b/apps/dev/src/core/tmp-janitor.ts
@@ -190,6 +190,77 @@ export function planTmpJanitor(input: TmpJanitorInput): TmpJanitorPlan {
   };
 }
 
+// ---------- orphaned feedback worktree planner ----------
+
+/**
+ * Extract the worker ID from a feedback worktree basename.
+ *
+ * AFK worker branches follow the pattern `afk/<workerID>/<issue>-<slug>`, which
+ * slugForBranch converts to `afk-<workerID>-<issue>-<slug>`. Parsing that basename
+ * back to a worker ID lets the janitor decide whether the owning worker is still
+ * alive without knowing the full branch name.
+ *
+ * Returns the worker ID string (e.g. `wOF09`) or `null` when the basename is not
+ * an AFK-worker branch slug (e.g. `main`, `feature-foo`).
+ */
+export function parseFeedbackWorktreeWorkerSlug(basename: string): string | null {
+  // afk-<workerID>-<issueN>-... where workerID is [A-Za-z0-9]+
+  const m = /^afk-([A-Za-z0-9]+)-[1-9][0-9]*-/.exec(basename);
+  return m ? (m[1] ?? null) : null;
+}
+
+/** An entry under `.red/tmp/worktrees/feedback/` with owner-liveness context. */
+export interface OrphanFeedbackEntry extends JanitorEntry {
+  /** Directory basename (not the full path). */
+  basename: string;
+  /**
+   * Whether the owning AFK worker is alive:
+   * - `false` when the entry is for an AFK worker branch whose worker.pid is dead.
+   * - `true` when the owning worker is still alive.
+   * - `null` when the entry is NOT an AFK worker branch (e.g. `main`, trunk) and
+   *   liveness must be inferred from `anyWorkerAlive` instead.
+   */
+  ownerAlive: boolean | null;
+}
+
+export interface OrphanFeedbackSweepPlan {
+  /** Entries whose owning worker is confirmed dead or whose non-worker owner is
+   * absent (no live workers at all). These are safe to remove. */
+  reclaim: OrphanFeedbackEntry[];
+  /** Entries with a live owner — do not touch. */
+  spare: OrphanFeedbackEntry[];
+}
+
+/**
+ * Plan which feedback worktrees to remove based on dead ownership — independently
+ * of the mtime TTL sweep (which still runs on its own schedule).
+ *
+ * - AFK-worker entries (`ownerAlive === false`) → reclaim immediately: the owning
+ *   worker died and will never use this cache again.
+ * - Non-worker entries, e.g. the shared `main` / trunk baseline worktree
+ *   (`ownerAlive === null`) → reclaim only when `anyWorkerAlive` is false: any live
+ *   worker might be mid-baseline-probe right now, so removing while workers are
+ *   running is unsafe.
+ * - Live-owner entries (`ownerAlive === true`) → always spare.
+ */
+export function planOrphanFeedbackWorktreeSweep(
+  entries: readonly OrphanFeedbackEntry[],
+  anyWorkerAlive: boolean,
+): OrphanFeedbackSweepPlan {
+  const reclaim: OrphanFeedbackEntry[] = [];
+  const spare: OrphanFeedbackEntry[] = [];
+  for (const entry of entries) {
+    if (entry.ownerAlive === false) {
+      reclaim.push(entry);
+    } else if (entry.ownerAlive === null && !anyWorkerAlive) {
+      reclaim.push(entry);
+    } else {
+      spare.push(entry);
+    }
+  }
+  return { reclaim, spare };
+}
+
 // ---------- stale worker planner ----------
 
 export interface WorkerDirIssueState {

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -306,7 +306,19 @@ export function makeFeedbackWorktree(
       // to a clean re-materialise.
     }
 
-    const added = await io.worktreeAdd(gitCtx, dest, branch);
+    let added = await io.worktreeAdd(gitCtx, dest, branch);
+    if (!added.ok) {
+      // Self-heal: a stale registered-but-removed (or registered-but-dirty)
+      // worktree at `dest` causes git to refuse the add with "already exists" /
+      // "not empty". Remove-force the path and retry once so a single orphaned
+      // feedback/main worktree never permanently blocks the baseline probe.
+      const isAlreadyExists =
+        /already exists|is not empty/i.test(added.stderr ?? "");
+      if (isAlreadyExists) {
+        await io.worktreeRemove(gitCtx, dest);
+        added = await io.worktreeAdd(gitCtx, dest, branch);
+      }
+    }
     if (!added.ok) {
       // Carry the underlying git stderr (#2339): the field report that opened
       // this only had "add failed", so the real cause (`fatal: couldn't find

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -509,6 +509,15 @@ export async function worktreeRemove(ctx: GitContext, path: string): Promise<voi
   await runGit(ctx, ["worktree", "remove", "--force", path]);
 }
 
+/**
+ * Run `git worktree prune` to drop stale entries from git's internal worktree
+ * registry after orphaned worktree dirs have been removed from disk. Best-effort:
+ * never throws so a prune failure does not abort the janitor sweep.
+ */
+export async function worktreePrune(ctx: GitContext): Promise<void> {
+  await runGit(ctx, ["worktree", "prune"]);
+}
+
 /** The GitExec executor for remote-branch.ts live-branch push/delete helpers. */
 export function gitExec(ctx: GitContext): GitExec {
   return async (args: string[]): Promise<GitExecResult> => {

--- a/apps/dev/src/runtime/tmp-janitor.ts
+++ b/apps/dev/src/runtime/tmp-janitor.ts
@@ -4,7 +4,11 @@ import {
   isLegacySlotLogName,
   planTmpJanitor,
   planWorkerDirJanitor,
+  parseFeedbackWorktreeWorkerSlug,
+  planOrphanFeedbackWorktreeSweep,
   type JanitorEntry,
+  type OrphanFeedbackEntry,
+  type OrphanFeedbackSweepPlan,
   type TmpJanitorPlan,
   type WorkerDirJanitorEntry,
 } from "../core/tmp-janitor.js";
@@ -15,6 +19,10 @@ export type IssueStateLookup = (issue: number) => "OPEN" | "CLOSED" | "UNKNOWN";
 export interface TmpJanitorReport {
   plan: TmpJanitorPlan;
   staleWorkers: ReturnType<typeof planWorkerDirJanitor>;
+  /** Orphaned feedback worktrees whose owning worker is dead (or the shared
+   * baseline worktree when no workers are alive). Swept independently of the
+   * mtime TTL sweep so dead-owner entries age out immediately. */
+  orphanFeedback: OrphanFeedbackSweepPlan;
 }
 
 export interface TmpJanitorApplyResult {
@@ -22,6 +30,8 @@ export interface TmpJanitorApplyResult {
   staleWorkers: string[];
   unknownTmpRoots: string[];
   protectedLiveWorkers: string[];
+  /** Orphaned feedback worktrees that were removed. */
+  orphanFeedback: string[];
 }
 
 export interface TmpJanitorRunResult extends TmpJanitorReport {
@@ -108,12 +118,63 @@ async function collectWorkerEntries(tmpDir: string, lookup: IssueStateLookup): P
   return out;
 }
 
+/**
+ * Build the live-worker PID index: a map from worker ID to liveness so the
+ * orphan feedback sweep can decide per-entry without re-reading PID files.
+ * Returns null when any worker is alive (signals that the shared baseline
+ * worktree is in use and must be spared).
+ */
+async function buildWorkerLivenessIndex(tmpDir: string): Promise<{ liveWorkers: Set<string>; anyAlive: boolean }> {
+  const liveWorkers = new Set<string>();
+  let anyAlive = false;
+  for (const workersRoot of allWorkersRoots(tmpDir)) {
+    for (const workerDir of await listNames(workersRoot)) {
+      const pidFile = join(workersRoot, workerDir, "worker.pid");
+      if (pidAlive(await readText(pidFile))) {
+        liveWorkers.add(workerDir);
+        anyAlive = true;
+      }
+    }
+  }
+  return { liveWorkers, anyAlive };
+}
+
+async function collectOrphanFeedbackEntries(tmpDir: string): Promise<{
+  entries: OrphanFeedbackEntry[];
+  anyWorkerAlive: boolean;
+}> {
+  const feedbackDir = join(tmpDir, "worktrees", "feedback");
+  const names = await listNames(feedbackDir);
+  const { liveWorkers, anyAlive } = await buildWorkerLivenessIndex(tmpDir);
+  const entries: OrphanFeedbackEntry[] = [];
+  for (const name of names) {
+    const path = join(feedbackDir, name);
+    let mtimeS = 0;
+    try {
+      const st = await stat(path);
+      mtimeS = Math.floor(st.mtimeMs / 1000);
+    } catch {
+      continue; // raced away
+    }
+    const workerSlug = parseFeedbackWorktreeWorkerSlug(name);
+    let ownerAlive: boolean | null;
+    if (workerSlug !== null) {
+      ownerAlive = liveWorkers.has(workerSlug);
+    } else {
+      // Non-afk entry (e.g. 'main'): liveness is inferred from anyAlive
+      ownerAlive = null;
+    }
+    entries.push({ path, basename: name, mtimeS, ownerAlive });
+  }
+  return { entries, anyWorkerAlive: anyAlive };
+}
+
 export async function collectTmpJanitorReport(
   tmpDir: string,
   nowS: number,
   lookup: IssueStateLookup,
 ): Promise<TmpJanitorReport> {
-  const [tmpRootNames, tmpRootEntries, logEntries, scratchEntries, diagnosticsEntries, feedbackEntries, workers] =
+  const [tmpRootNames, tmpRootEntries, logEntries, scratchEntries, diagnosticsEntries, feedbackEntries, workers, orphanFeedbackData] =
     await Promise.all([
       listNames(tmpDir),
       listEntries(tmpDir),
@@ -122,6 +183,7 @@ export async function collectTmpJanitorReport(
       listEntries(join(tmpDir, "diagnostics")),
       listEntries(join(tmpDir, "worktrees", "feedback")),
       collectWorkerEntries(tmpDir, lookup),
+      collectOrphanFeedbackEntries(tmpDir),
     ]);
   const legacySlotLogEntries = tmpRootEntries.filter((entry) => isLegacySlotLogName(basename(entry.path)));
 
@@ -136,12 +198,14 @@ export async function collectTmpJanitorReport(
       tmpRootNames,
     }),
     staleWorkers: planWorkerDirJanitor(workers),
+    orphanFeedback: planOrphanFeedbackWorktreeSweep(orphanFeedbackData.entries, orphanFeedbackData.anyWorkerAlive),
   };
 }
 
 export async function applyTmpJanitorReport(
   tmpDir: string,
   report: TmpJanitorReport,
+  options: { worktreePrune?: () => Promise<void> } = {},
 ): Promise<TmpJanitorApplyResult> {
   const expired = [
     ...report.plan.logs.reclaim,
@@ -155,6 +219,7 @@ export async function applyTmpJanitorReport(
     staleWorkers: [],
     unknownTmpRoots: [],
     protectedLiveWorkers: [],
+    orphanFeedback: [],
   };
 
   for (const entry of expired) {
@@ -177,6 +242,17 @@ export async function applyTmpJanitorReport(
     result.unknownTmpRoots.push(path);
   }
 
+  for (const entry of report.orphanFeedback.reclaim) {
+    await rm(entry.path, { recursive: true, force: true });
+    result.orphanFeedback.push(entry.path);
+  }
+
+  // After removing orphaned feedback worktrees, ask git to prune its own
+  // internal registry so stale worktree entries do not accumulate there either.
+  if (result.orphanFeedback.length > 0 && options.worktreePrune) {
+    await options.worktreePrune().catch(() => {});
+  }
+
   return result;
 }
 
@@ -184,9 +260,9 @@ export async function runTmpJanitor(
   tmpDir: string,
   nowS: number,
   lookup: IssueStateLookup,
-  options: { fix?: boolean } = {},
+  options: { fix?: boolean; worktreePrune?: () => Promise<void> } = {},
 ): Promise<TmpJanitorRunResult> {
   const report = await collectTmpJanitorReport(tmpDir, nowS, lookup);
   if (!options.fix) return report;
-  return { ...report, applied: await applyTmpJanitorReport(tmpDir, report) };
+  return { ...report, applied: await applyTmpJanitorReport(tmpDir, report, options) };
 }

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -212,6 +212,47 @@ describe("makeFeedbackWorktree install (#458)", () => {
     expect(calls.filter((c) => c.op === "script")).toHaveLength(0);
   });
 
+  it("self-heals a stale worktree on 'already exists' — removes and recreates (#2379)", async () => {
+    // Model: first worktreeAdd fails with "already exists"; the manager removes
+    // the stale worktree and retries; the retry succeeds.
+    const calls: Array<{ op: string; dest: string }> = [];
+    let addAttempt = 0;
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async (_ctx, dest) => {
+        addAttempt += 1;
+        calls.push({ op: "add", dest });
+        if (addAttempt === 1) {
+          return { ok: false, stderr: "fatal: '/dest' already exists" };
+        }
+        return { ok: true, stderr: "" };
+      },
+      worktreeRemove: async (_ctx, dest) => {
+        calls.push({ op: "remove", dest });
+      },
+      pnpm: async (args, opts) => {
+        const isInstall = args[0] === "install";
+        calls.push({ op: isInstall ? "install" : "script", dest: opts.cwd ?? "" });
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      exec: async (_cmd, _args, opts) => {
+        calls.push({ op: "script", dest: opts.cwd ?? "" });
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      branchHead: async () => null,
+      worktreeHead: async () => null,
+      rebase: async () => ({ ok: true }),
+    };
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io, { cacheEnabled: false });
+
+    const result = await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+
+    // Self-heal succeeds: the gate runs normally.
+    expect(result.code).toBe(0);
+    // First add failed, then remove, then second add, then install, then script.
+    expect(calls.map((c) => c.op)).toEqual(["add", "remove", "add", "install", "script"]);
+    expect(addAttempt).toBe(2);
+  });
+
   it("surfaces the underlying git stderr on a failed worktree add (#2339)", async () => {
     const { io } = fakeIO(0, false, 0, { enabled: false });
     const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io, { cacheEnabled: false });

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -794,6 +794,46 @@ describe("runFeedback — baseline comparison classifies the branch verdict", ()
     // 4 scripts × 1 scope + 1 workspace typecheck = 5 invocations, no probe.
     expect(calls.length).toBe(5);
   });
+
+  it("baseline probe worktree setup failure → branch-fault, not inconclusive (#2379)", async () => {
+    // Model: the worker branch's test fails; the baseline probe's worktreeAdd
+    // failed for an infra reason (stale feedback/main), so the exec returns the
+    // 'feedback worktree setup failed' sentinel. That sentinel must NOT be treated
+    // as a confirmed baseline failure (which would make the worker's failure look
+    // pre-existing and dodge the block). Instead it is inconclusive for the PROBE
+    // only, and the branch failure stays attributed to the branch.
+    const exec: Exec = async (args) => {
+      const script = args[args.length - 1] ?? "";
+      const dir = args[args.indexOf("-C") + 1] ?? "";
+      const isBaseline = dir.includes("main");
+      if (script === "test" && !isBaseline) {
+        return { code: 1, stdout: "FAIL", stderr: "expected 1 to equal 2" };
+      }
+      if (isBaseline) {
+        // The baseline executor returns the sentinel when worktree setup failed.
+        return { code: 1, stdout: "", stderr: "feedback worktree setup failed for main; validation blocked" };
+      }
+      return { code: 0, stdout: "ok", stderr: "" };
+    };
+    const result = await runFeedback(exec, {
+      worktree: "afk/wX/123-slug",
+      scopes: ["apps/dev"],
+      layout: makeLayout(),
+      now: () => 0,
+      baselineWorktree: "main",
+    });
+    // The branch's failure is real; the probe failure is inconclusive.
+    // Verdict must be branch-fault (not inconclusive) because the baseline probe
+    // did NOT confirm the failure — worktree setup failed.
+    expect(result.ok).toBe(false);
+    expect(result.baselineProbeRan).toBe(true);
+    expect(result.baselineVerdict).toBe("branch-fault");
+    // The setup failure is inconclusive for the probe — it must NOT appear in
+    // baselineInconclusive (that list is branch-perspective, not probe-perspective).
+    expect(result.baselineInconclusive).toEqual([]);
+    const testCheck = result.checks.find((c) => c.name === "test:apps/dev")!;
+    expect(testCheck.status).toBe("failed");
+  });
 });
 
 // Workspace typecheck: a whole-workspace `typecheck` runs once after the

--- a/apps/dev/tests/tmp-janitor.test.ts
+++ b/apps/dev/tests/tmp-janitor.test.ts
@@ -5,14 +5,17 @@ import {
   FEEDBACK_TTL_S,
   KNOWN_TMP_LANES,
   LOGS_TTL_S,
+  parseFeedbackWorktreeWorkerSlug,
   planDiagnosticsJanitor,
   planFeedbackWorktreeJanitor,
   planLogsJanitor,
+  planOrphanFeedbackWorktreeSweep,
   planScratchJanitor,
   planTmpJanitor,
   planWorkerDirJanitor,
   SCRATCH_TTL_S,
   type JanitorEntry,
+  type OrphanFeedbackEntry,
   type WorkerDirJanitorEntry,
 } from "../src/core/tmp-janitor.js";
 
@@ -312,5 +315,94 @@ describe("planWorkerDirJanitor", () => {
   it("spares dead worker dirs with no issue-bearing attempts", () => {
     const entry = worker({ issues: [] });
     expect(planWorkerDirJanitor([entry])).toEqual({ reclaim: [], spare: [entry] });
+  });
+});
+
+// ---------- parseFeedbackWorktreeWorkerSlug ----------
+
+describe("parseFeedbackWorktreeWorkerSlug", () => {
+  it("extracts the worker ID from a canonical AFK feedback worktree slug", () => {
+    expect(parseFeedbackWorktreeWorkerSlug("afk-wOF09-2379-tmp-janitor-fix")).toBe("wOF09");
+  });
+
+  it("extracts the worker ID from a minimal valid slug", () => {
+    expect(parseFeedbackWorktreeWorkerSlug("afk-w1-42-fix")).toBe("w1");
+  });
+
+  it("extracts the worker ID when the slug has uppercase letters", () => {
+    expect(parseFeedbackWorktreeWorkerSlug("afk-W5LB-1234-some-slug")).toBe("W5LB");
+  });
+
+  it("returns null for the trunk/baseline worktree (no 'afk-' prefix)", () => {
+    expect(parseFeedbackWorktreeWorkerSlug("main")).toBeNull();
+  });
+
+  it("returns null for a feature branch slug without an issue number", () => {
+    // 'afk-worker' lacks the '<issueN>-' part
+    expect(parseFeedbackWorktreeWorkerSlug("afk-worker")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parseFeedbackWorktreeWorkerSlug("")).toBeNull();
+  });
+
+  it("returns null for a non-AFK slug", () => {
+    expect(parseFeedbackWorktreeWorkerSlug("feature-123-fix")).toBeNull();
+  });
+});
+
+// ---------- planOrphanFeedbackWorktreeSweep ----------
+
+describe("planOrphanFeedbackWorktreeSweep", () => {
+  function fbEntry(basename: string, ownerAlive: boolean | null): OrphanFeedbackEntry {
+    return { path: `/red/tmp/worktrees/feedback/${basename}`, basename, mtimeS: NOW, ownerAlive };
+  }
+
+  it("returns empty plans for an empty entry list", () => {
+    expect(planOrphanFeedbackWorktreeSweep([], false)).toEqual({ reclaim: [], spare: [] });
+  });
+
+  it("reclaims an AFK worker entry whose owning worker is dead (ownerAlive: false)", () => {
+    const dead = fbEntry("afk-wOF09-2379-fix", false);
+    expect(planOrphanFeedbackWorktreeSweep([dead], false)).toEqual({ reclaim: [dead], spare: [] });
+  });
+
+  it("spares an AFK worker entry whose owning worker is still alive (ownerAlive: true)", () => {
+    const live = fbEntry("afk-wP5LB-2379-fix", true);
+    expect(planOrphanFeedbackWorktreeSweep([live], true)).toEqual({ reclaim: [], spare: [live] });
+  });
+
+  it("reclaims a non-worker entry (e.g. main) when no workers are alive", () => {
+    const main = fbEntry("main", null);
+    expect(planOrphanFeedbackWorktreeSweep([main], false)).toEqual({ reclaim: [main], spare: [] });
+  });
+
+  it("spares a non-worker entry (e.g. main) when at least one worker is alive", () => {
+    const main = fbEntry("main", null);
+    expect(planOrphanFeedbackWorktreeSweep([main], true)).toEqual({ reclaim: [], spare: [main] });
+  });
+
+  it("partitions a mixed set: dead-owner reclaimed, live-owner spared, main reclaimed when no workers", () => {
+    const dead = fbEntry("afk-wOLD-1-fix", false);
+    const live = fbEntry("afk-wNEW-2-fix", true);
+    const main = fbEntry("main", null);
+    // anyWorkerAlive = true because wNEW is alive
+    const plan = planOrphanFeedbackWorktreeSweep([dead, live, main], true);
+    expect(plan.reclaim).toEqual([dead]);
+    expect(plan.spare).toEqual([live, main]);
+  });
+
+  it("reclaims main alongside dead-owner entries when no workers alive at all", () => {
+    const dead = fbEntry("afk-wOLD-1-fix", false);
+    const main = fbEntry("main", null);
+    const plan = planOrphanFeedbackWorktreeSweep([dead, main], false);
+    expect(plan.reclaim).toEqual([dead, main]);
+    expect(plan.spare).toEqual([]);
+  });
+
+  it("spares a live-owner entry even when anyWorkerAlive is false (ownerAlive: true wins)", () => {
+    // Should not happen in practice, but the rule is clear: ownerAlive: true → spare.
+    const live = fbEntry("afk-wABC-10-fix", true);
+    expect(planOrphanFeedbackWorktreeSweep([live], false)).toEqual({ reclaim: [], spare: [live] });
   });
 });


### PR DESCRIPTION
Automated AFK landing for #2379. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2379

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787265446&installation_model_id=20659&pr_number=2408&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2408&signature=7c8168a66e7c0dfbdcaefcf7d2807dc8b691c29a6484b4625ead57d236589e27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->