### PR TITLE
fix: #2334 Castle-MCP H3: confirm posture for dangerous mutating tools

### DIFF
--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -14,6 +14,7 @@ import {
 } from "./mcp/review.js";
 import { createRunnerTools, type RunnerDependencies } from "./mcp/runner.js";
 import type { CastleMcpTool } from "./mcp/tool.js";
+import { applyDangerPosture, type DangerPosture } from "./mcp/posture.js";
 import { createWaitTools, type WaitDependencies } from "./mcp/wait.js";
 import { createWorkerTools, type WorkerDependencies } from "./mcp/worker.js";
 import {
@@ -22,6 +23,7 @@ import {
 } from "./mcp/worktree.js";
 
 export type { CastleMcpTool } from "./mcp/tool.js";
+export type { DangerPosture } from "./mcp/posture.js";
 export type {
   FleetSelectorInput,
   FleetCreateInput,
@@ -75,11 +77,17 @@ export interface CastleMcpDependencies
  * Compose the published dev:afk tool surface from the per-domain registries.
  * The concatenation order IS the published order — `mcp-tool-surface.test.ts`
  * freezes it.
+ *
+ * `posture` controls how tools that declare a `dangerClass` are gated:
+ *   - `"allow"` (default) — unchanged behavior.
+ *   - `"confirm"` — dangerous tools require `confirmation: true` in the input.
+ *   - `"deny"` — dangerous tools always return a structured refusal.
  */
 export function createCastleMcpTools(
   deps: CastleMcpDependencies,
+  posture: DangerPosture = "allow",
 ): CastleMcpTool[] {
-  return [
+  const tools = [
     ...createFleetTools(deps),
     ...createObservabilityTools(deps),
     ...createWorkerTools(deps),
@@ -92,4 +100,5 @@ export function createCastleMcpTools(
     ...createWaitTools(deps),
     ...createReviewTools(deps),
   ];
+  return applyDangerPosture(tools, posture);
 }

--- a/packages/red-castle/src/mcp/gate.ts
+++ b/packages/red-castle/src/mcp/gate.ts
@@ -17,6 +17,7 @@ export function createGateTools(deps: GateDependencies): CastleMcpTool[] {
       title: "Run the AFK gate",
       description:
         "MUTATING: materialize the branch's feedback worktree and run the package-scoped validation gate against it.",
+      dangerClass: "mutating",
       inputSchema: {
         branch: z.string().min(1),
         base: z.string().min(1).optional(),

--- a/packages/red-castle/src/mcp/landing.ts
+++ b/packages/red-castle/src/mcp/landing.ts
@@ -25,6 +25,7 @@ export function createLandingTools(deps: LandingDependencies): CastleMcpTool[] {
       title: "Land AFK branch",
       description:
         "MUTATING: land one validated worker branch into its base through the complete landing sequence.",
+      dangerClass: "mutating",
       inputSchema: {
         issue: z.number().int().positive(),
         branch: z.string().min(1),

--- a/packages/red-castle/src/mcp/posture.test.ts
+++ b/packages/red-castle/src/mcp/posture.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod/v3";
+import { applyDangerPosture } from "./posture.js";
+import type { CastleMcpTool } from "./tool.js";
+
+function safeTool(): CastleMcpTool {
+  return {
+    name: "safe_op",
+    title: "Safe operation",
+    description: "A read-only tool with no danger class.",
+    inputSchema: { id: z.string() },
+    invoke: vi.fn(async () => ({ ok: true })),
+  };
+}
+
+function dangerousTool(): CastleMcpTool {
+  return {
+    name: "dangerous_op",
+    title: "Dangerous operation",
+    description: "MUTATING: does something irreversible.",
+    dangerClass: "mutating",
+    inputSchema: { branch: z.string() },
+    invoke: vi.fn(async (input) => ({ branch: input["branch"], done: true })),
+  };
+}
+
+describe("applyDangerPosture", () => {
+  describe("allow posture (default)", () => {
+    it("returns the same tool array instance unchanged", () => {
+      const tools = [safeTool(), dangerousTool()];
+      const result = applyDangerPosture(tools, "allow");
+      expect(result).toBe(tools);
+    });
+
+    it("executes dangerous tools without restriction", async () => {
+      const tools = applyDangerPosture([dangerousTool()], "allow");
+      await expect(
+        tools[0]!.invoke({ branch: "afk/w80UR/1234" }),
+      ).resolves.toEqual({ branch: "afk/w80UR/1234", done: true });
+    });
+  });
+
+  describe("deny posture", () => {
+    it("returns a structured refusal for dangerous tools", async () => {
+      const tools = applyDangerPosture([dangerousTool()], "deny");
+      await expect(tools[0]!.invoke({ branch: "afk/w80UR/1234" })).resolves.toEqual({
+        refused: true,
+        posture: "deny",
+        action: "dangerous_op",
+        reason: expect.stringContaining("denied"),
+      });
+    });
+
+    it("never calls the underlying invoke for dangerous tools", async () => {
+      const tool = dangerousTool();
+      const tools = applyDangerPosture([tool], "deny");
+      await tools[0]!.invoke({ branch: "afk/w80UR/1234" });
+      expect(tool.invoke).not.toHaveBeenCalled();
+    });
+
+    it("passes safe tools through unchanged", async () => {
+      const tool = safeTool();
+      const tools = applyDangerPosture([tool], "deny");
+      await tools[0]!.invoke({ id: "abc" });
+      expect(tool.invoke).toHaveBeenCalledWith({ id: "abc" });
+    });
+
+    it("does not add confirmation to the schema of dangerous tools", () => {
+      const tools = applyDangerPosture([dangerousTool()], "deny");
+      expect(Object.keys(tools[0]!.inputSchema)).not.toContain("confirmation");
+    });
+  });
+
+  describe("confirm posture", () => {
+    it("returns a structured refusal when confirmation is absent", async () => {
+      const tools = applyDangerPosture([dangerousTool()], "confirm");
+      await expect(
+        tools[0]!.invoke({ branch: "afk/w80UR/1234" }),
+      ).resolves.toEqual({
+        refused: true,
+        posture: "confirm",
+        action: "dangerous_op",
+        reason: expect.stringContaining("confirmation"),
+      });
+    });
+
+    it("returns a structured refusal when confirmation is explicitly false", async () => {
+      const tools = applyDangerPosture([dangerousTool()], "confirm");
+      const result = await tools[0]!.invoke({
+        branch: "afk/w80UR/1234",
+        confirmation: false,
+      });
+      expect(result).toMatchObject({ refused: true, posture: "confirm" });
+    });
+
+    it("executes when confirmation is true and strips the confirmation key", async () => {
+      const tool = dangerousTool();
+      const tools = applyDangerPosture([tool], "confirm");
+      const result = await tools[0]!.invoke({
+        branch: "afk/w80UR/1234",
+        confirmation: true,
+      });
+      expect(result).toEqual({ branch: "afk/w80UR/1234", done: true });
+      expect(tool.invoke).toHaveBeenCalledWith({ branch: "afk/w80UR/1234" });
+    });
+
+    it("never calls the underlying invoke without confirmation", async () => {
+      const tool = dangerousTool();
+      const tools = applyDangerPosture([tool], "confirm");
+      await tools[0]!.invoke({ branch: "afk/w80UR/1234" });
+      expect(tool.invoke).not.toHaveBeenCalled();
+    });
+
+    it("adds confirmation to the input schema of dangerous tools", () => {
+      const tools = applyDangerPosture([dangerousTool()], "confirm");
+      expect(Object.keys(tools[0]!.inputSchema)).toContain("confirmation");
+    });
+
+    it("preserves original schema keys alongside confirmation", () => {
+      const tools = applyDangerPosture([dangerousTool()], "confirm");
+      expect(Object.keys(tools[0]!.inputSchema)).toContain("branch");
+    });
+
+    it("passes safe tools through without adding confirmation", async () => {
+      const tool = safeTool();
+      const tools = applyDangerPosture([tool], "confirm");
+      await tools[0]!.invoke({ id: "abc" });
+      expect(tool.invoke).toHaveBeenCalledWith({ id: "abc" });
+      expect(Object.keys(tools[0]!.inputSchema)).not.toContain("confirmation");
+    });
+  });
+
+  describe("mixed tool lists", () => {
+    it("deny posture only intercepts dangerous tools, safe tools execute normally", async () => {
+      const safe = safeTool();
+      const dangerous = dangerousTool();
+      const tools = applyDangerPosture([safe, dangerous], "deny");
+
+      await tools[0]!.invoke({ id: "x" });
+      expect(safe.invoke).toHaveBeenCalledWith({ id: "x" });
+
+      const result = await tools[1]!.invoke({ branch: "main" });
+      expect(result).toMatchObject({ refused: true });
+      expect(dangerous.invoke).not.toHaveBeenCalled();
+    });
+
+    it("confirm posture only intercepts dangerous tools, safe tools execute normally", async () => {
+      const safe = safeTool();
+      const dangerous = dangerousTool();
+      const tools = applyDangerPosture([safe, dangerous], "confirm");
+
+      await tools[0]!.invoke({ id: "x" });
+      expect(safe.invoke).toHaveBeenCalledWith({ id: "x" });
+
+      const refusedResult = await tools[1]!.invoke({ branch: "main" });
+      expect(refusedResult).toMatchObject({ refused: true });
+
+      const okResult = await tools[1]!.invoke({ branch: "main", confirmation: true });
+      expect(okResult).toEqual({ branch: "main", done: true });
+    });
+  });
+});

--- a/packages/red-castle/src/mcp/posture.ts
+++ b/packages/red-castle/src/mcp/posture.ts
@@ -1,0 +1,69 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export type DangerPosture = "allow" | "confirm" | "deny";
+
+export interface DangerRefusal {
+  refused: true;
+  posture: DangerPosture;
+  action: string;
+  reason: string;
+}
+
+function refusal(posture: DangerPosture, toolName: string): DangerRefusal {
+  return {
+    refused: true,
+    posture,
+    action: toolName,
+    reason:
+      posture === "confirm"
+        ? "dangerous tool requires explicit confirmation — retry with confirmation: true"
+        : "dangerous tool is denied by the configured posture",
+  };
+}
+
+/**
+ * Wrap all tools that carry a `dangerClass` with the caller-supplied posture:
+ *
+ * - `allow`  (default) — no wrapping, behavior unchanged.
+ * - `confirm` — adds `confirmation?: boolean` to each dangerous tool's input
+ *   schema; invocations without `confirmation: true` receive a structured
+ *   refusal instead of executing.
+ * - `deny`   — every invocation of a dangerous tool returns a structured
+ *   refusal regardless of inputs.
+ */
+export function applyDangerPosture(
+  tools: CastleMcpTool[],
+  posture: DangerPosture,
+): CastleMcpTool[] {
+  if (posture === "allow") return tools;
+
+  return tools.map((tool) => {
+    if (!tool.dangerClass) return tool;
+
+    if (posture === "deny") {
+      return {
+        ...tool,
+        invoke: async (_input) => refusal("deny", tool.name),
+      };
+    }
+
+    // posture === "confirm"
+    const augmentedSchema: Record<string, z.ZodType> = {
+      ...tool.inputSchema,
+      confirmation: z.boolean().optional(),
+    };
+    const realInvoke = tool.invoke.bind(tool);
+    return {
+      ...tool,
+      inputSchema: augmentedSchema,
+      invoke: async (input) => {
+        if (input["confirmation"] !== true) {
+          return refusal("confirm", tool.name);
+        }
+        const { confirmation: _c, ...rest } = input;
+        return realInvoke(rest);
+      },
+    };
+  });
+}

--- a/packages/red-castle/src/mcp/tool.ts
+++ b/packages/red-castle/src/mcp/tool.ts
@@ -3,11 +3,15 @@ import type { z } from "zod/v3";
 /**
  * One published dev:afk MCP tool. A description starting with `MUTATING:` is
  * the declared mutation mode — the client docs contract reads that prefix.
+ *
+ * `dangerClass` marks tools that the posture gate intercepts.  Domain modules
+ * set it on declaration; the aggregator wires the gate centrally.
  */
 export interface CastleMcpTool {
   name: string;
   title: string;
   description: string;
   inputSchema: Record<string, z.ZodType>;
+  dangerClass?: string;
   invoke(input: Record<string, unknown>): Promise<unknown>;
 }


### PR DESCRIPTION
Automated AFK landing for #2334. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2334

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787265999&installation_model_id=20659&pr_number=2410&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2410&signature=2a48bea450ef5d31f2f699eb664b5a261cf0f93266b6d8688a3000e808c24fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->