### PR TITLE
fix: #2345 Castle-MCP H7: fleet_status must count only the named fleet's workers (multi-fleet correctness)

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -1,4 +1,5 @@
 import { parseRunnerFlag, detectRunner } from "../../core/runner-detection.js";
+import { FLEET_NAME_ENV } from "../../core/fleet-name.js";
 import { callerProcessTreeNative } from "../../runtime/caller-process.js";
 import {
   runModeForCandidate,
@@ -276,6 +277,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     redRoot: join(ctx.root, ".red"),
     workerId,
     attemptDir: () => current.attemptDir,
+    fleetName: process.env[FLEET_NAME_ENV] || undefined,
   });
 
   // --request/-r special block, threaded into the handoff the agent reads.

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -61,7 +61,7 @@ import {
   writeCastleStateSnapshot,
 } from "@reddb-io/red-castle/engine";
 import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../core/toon-snapshot.js";
-import { resolveFleetFromArgs } from "../core/fleet-name.js";
+import { resolveFleetFromArgs, FLEET_NAME_ENV } from "../core/fleet-name.js";
 
 function isAlive(pid: number): boolean {
   try {
@@ -552,7 +552,10 @@ function buildSupervisorDeps(
   // the environment survive. RED_AFK_RUNNER is re-added explicitly below so the
   // worker's detection cascade pins the supervisor's runner.
   let activeRunner = runner;
-  let workerEnv = buildWorkerEnv(process.env, activeRunner);
+  // Stamp the fleet name into the worker env so spawned workers can write it to
+  // their castle state snapshot (as supervisor_id). fleet_status reads this back
+  // to partition workers without relying solely on the slot-pid map (issue #2345).
+  let workerEnv = { ...buildWorkerEnv(process.env, activeRunner), [FLEET_NAME_ENV]: fleet };
   let hookEnv = { ...hookEnvBase, RED_AFK_RUNNER: activeRunner };
 
   return {

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -773,7 +773,7 @@ function buildSupervisorDeps(
     resizeRequest: async () => readResizeRequest(afkPaths(root, fleet).supervisorResizePath),
     configureRunner: (nextRunner) => {
       activeRunner = nextRunner;
-      workerEnv = buildWorkerEnv(process.env, activeRunner);
+      workerEnv = { ...buildWorkerEnv(process.env, activeRunner), [FLEET_NAME_ENV]: fleet };
       hookEnv = { ...hookEnvBase, RED_AFK_RUNNER: activeRunner };
     },
     // Fleet-scoped lifecycle hooks (#833). Commands are resolved from the same

--- a/apps/dev/src/core/castle-worker-lane-bridge.ts
+++ b/apps/dev/src/core/castle-worker-lane-bridge.ts
@@ -32,6 +32,10 @@ export interface CastleWorkerLaneBridgeOptions {
   attemptDir: () => string;
   nowIso?: () => string;
   nowMs?: () => number;
+  /** Named fleet this worker belongs to. When set, stamped as `supervisor_id`
+   * in every castle state snapshot so `fleet_status` can partition workers by
+   * fleet without relying solely on the supervisor's slot-pid map. */
+  fleetName?: string;
 }
 
 function currentIssue(state: AfkState): number | undefined {
@@ -52,6 +56,7 @@ function snapshotFromState(
   workerId: string,
   state: AfkState,
   updatedAt: string,
+  fleetName?: string,
 ): CastleStateSnapshot {
   return {
     kind: "worker",
@@ -64,6 +69,7 @@ function snapshotFromState(
     started_at: state.started_at || state.current.started_at || updatedAt,
     current: compactCurrent(state),
     envelope: state.envelope,
+    ...(fleetName ? { supervisor_id: fleetName } : {}),
   };
 }
 
@@ -89,7 +95,7 @@ export function createCastleWorkerLaneBridge(
     if (!state) return;
     await writeCastleStateSnapshot(
       castleStateSnapshotPath(paths, "worker", options.workerId),
-      snapshotFromState(options.workerId, state, nowIso()),
+      snapshotFromState(options.workerId, state, nowIso(), options.fleetName),
     );
   }
 

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -745,9 +745,25 @@ async function fleetStatus(root: string, input: FleetNameInput) {
     config.supervisorStaleS,
     config.progressStaleS,
   );
-  const liveWorkers = monitor.workers.filter(
+  // Build a PID set for the slot-pid fallback: workers without a fleet stamp
+  // (legacy or pre-stamp) are attributed to this fleet if their pid appears in
+  // the supervisor's slot map. Workers with a stamp that differs from this fleet
+  // name go to the unattributed bucket even if their pid matches.
+  const fleetPidSet = new Set(
+    (fleet?.slotPids ?? []).map((sp) => sp.pid).filter((pid) => pid > 0),
+  );
+  const allLiveWorkers = monitor.workers.filter(
     (worker) => worker.pidLive === true || worker.live,
   );
+  function attributedToThisFleet(worker: (typeof allLiveWorkers)[number]): boolean {
+    const stampedFleet = worker.state.fleet;
+    // Stamped workers: use the stamp as the definitive source of truth.
+    if (stampedFleet !== undefined) return stampedFleet === paths.fleet;
+    // Legacy/unstamped workers: fall back to the supervisor's slot-pid map.
+    return fleetPidSet.has(worker.state.pid);
+  }
+  const liveWorkers = allLiveWorkers.filter(attributedToThisFleet);
+  const unattributedWorkers = allLiveWorkers.filter((w) => !attributedToThisFleet(w));
   const latestBundleVersion =
     fleet?.latestBundleVersion ?? readBuildInfo("dev").version;
   return {
@@ -786,6 +802,14 @@ async function fleetStatus(root: string, input: FleetNameInput) {
       issue: String(worker.state.current.number),
       activity: worker.state.current.activity,
       origin: worker.state.origin ?? "afk",
+    })),
+    unattributed_workers: unattributedWorkers.map((worker) => ({
+      id: worker.state.worker_id,
+      pid: worker.state.pid,
+      issue: String(worker.state.current.number),
+      activity: worker.state.current.activity,
+      origin: worker.state.origin ?? "afk",
+      fleet: worker.state.fleet ?? null,
     })),
   };
 }

--- a/apps/dev/tests/fleet-status-partition.test.ts
+++ b/apps/dev/tests/fleet-status-partition.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Pins the multi-fleet worker partition introduced by #2345.
+ *
+ * Two named fleets ("alpha" and "beta") each own one live worker, stamped with
+ * their fleet via `supervisor_id` in the castle state snapshot.  Each
+ * `fleet_status` call must report only its own worker in `live_workers` and
+ * place the other fleet's worker in `unattributed_workers`.
+ */
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  castleStateSnapshotPath,
+  createCastleLaneWriters,
+  createEnginePaths,
+  writeCastleStateSnapshot,
+} from "@reddb-io/red-castle/engine";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDevAfkMcpDependencies } from "../src/mcp-adapter.js";
+import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
+
+const NOW_ISO = "2026-07-21T12:00:00.000Z";
+const NOW_MS = Date.parse(NOW_ISO);
+const NOW_EPOCH = Math.floor(NOW_MS / 1000);
+
+function workerSnapshot(
+  id: string,
+  issue: number,
+  pid: number,
+  fleetName: string,
+) {
+  return {
+    kind: "worker" as const,
+    id,
+    worker_id: id,
+    version: 1,
+    updated_at: NOW_ISO,
+    started_at: NOW_ISO,
+    runner: "claude",
+    pid,
+    supervisor_id: fleetName,
+    current: {
+      origin: "afk",
+      number: issue,
+      title: `Issue ${issue}`,
+      activity: "implementing",
+      phase: "implementing",
+    },
+    queue: [issue],
+    completed: [],
+    envelope: { posted: false },
+  };
+}
+
+describe("fleet_status worker partition (#2345)", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.map((r) => rm(r, { recursive: true, force: true })));
+    roots.length = 0;
+  });
+
+  it("partitions stamped workers to their owning fleet", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fleet-partition-"));
+    roots.push(root);
+
+    const enginePaths = createEnginePaths(join(root, ".red"));
+    const lanes = createCastleLaneWriters(enginePaths, {
+      clock: () => NOW_ISO,
+    });
+
+    // Write castle state snapshots — each stamped with their owning fleet.
+    await writeCastleStateSnapshot(
+      castleStateSnapshotPath(enginePaths, "worker", "w_alpha"),
+      workerSnapshot("w_alpha", 100, 1001, "alpha"),
+    );
+    await writeCastleStateSnapshot(
+      castleStateSnapshotPath(enginePaths, "worker", "w_beta"),
+      workerSnapshot("w_beta", 200, 2001, "beta"),
+    );
+
+    // Write recent liveness lane records so both workers appear live to the monitor.
+    await lanes.liveness("w_alpha").append({
+      kind: "worker.heartbeat",
+      worker_id: "w_alpha",
+      issue: 100,
+      payload: {},
+    });
+    await lanes.liveness("w_beta").append({
+      kind: "worker.heartbeat",
+      worker_id: "w_beta",
+      issue: 200,
+      payload: {},
+    });
+
+    // Write minimal fleet-state files so readFleetState doesn't return null.
+    // The slot_pids fallback isn't exercised here (all workers have stamps),
+    // but the epoch field prevents parseFleetState from returning null.
+    const fleetState = (epoch: number) =>
+      encodeDevSnapshotToon({
+        ts: NOW_ISO,
+        epoch,
+        runner: "claude",
+        ready_for_agent: 0,
+        slots: { busy: 1, free: 0, total: 1, parked: 0 },
+        spawns_this_tick: 1,
+        churn: { deaths: 0, respawns: 0, window_s: 300 },
+      });
+
+    const alphaSupervisorDir = join(root, ".red", "tmp", "supervisors", "alpha");
+    const betaSupervisorDir = join(root, ".red", "tmp", "supervisors", "beta");
+    await mkdir(alphaSupervisorDir, { recursive: true });
+    await mkdir(betaSupervisorDir, { recursive: true });
+    await writeFile(join(alphaSupervisorDir, "state.toon"), fleetState(NOW_EPOCH));
+    await writeFile(join(betaSupervisorDir, "state.toon"), fleetState(NOW_EPOCH));
+
+    // Use a fixed nowMs so liveness records (written at NOW_ISO) are within the
+    // 180-second idle window — they appear as NOW_MS which equals nowMs exactly.
+    const mcp = createDevAfkMcpDependencies(root);
+
+    const alphaStatus = await mcp.fleetStatus({ name: "alpha" });
+    const betaStatus = await mcp.fleetStatus({ name: "beta" });
+
+    // Alpha fleet: sees its own worker, not beta's.
+    const alphaLive = alphaStatus.live_workers.map((w: { id: string }) => w.id);
+    const alphaUnattributed = alphaStatus.unattributed_workers.map(
+      (w: { id: string }) => w.id,
+    );
+    expect(alphaLive).toContain("w_alpha");
+    expect(alphaLive).not.toContain("w_beta");
+    expect(alphaUnattributed).not.toContain("w_alpha");
+
+    // Beta fleet: sees its own worker, not alpha's.
+    const betaLive = betaStatus.live_workers.map((w: { id: string }) => w.id);
+    const betaUnattributed = betaStatus.unattributed_workers.map(
+      (w: { id: string }) => w.id,
+    );
+    expect(betaLive).toContain("w_beta");
+    expect(betaLive).not.toContain("w_alpha");
+    expect(betaUnattributed).not.toContain("w_beta");
+  });
+});

--- a/apps/dev/tests/fleet-status-partition.test.ts
+++ b/apps/dev/tests/fleet-status-partition.test.ts
@@ -19,9 +19,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createDevAfkMcpDependencies } from "../src/mcp-adapter.js";
 import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
 
-const NOW_ISO = "2026-07-21T12:00:00.000Z";
-const NOW_MS = Date.parse(NOW_ISO);
-const NOW_EPOCH = Math.floor(NOW_MS / 1000);
+// Snapshot timestamps are fixed; liveness records use real wall-clock time so
+// the 180-second idle window in readCastleMonitorWorkers sees them as fresh.
+const SNAPSHOT_ISO = "2026-07-21T12:00:00.000Z";
 
 function workerSnapshot(
   id: string,
@@ -34,8 +34,8 @@ function workerSnapshot(
     id,
     worker_id: id,
     version: 1,
-    updated_at: NOW_ISO,
-    started_at: NOW_ISO,
+    updated_at: SNAPSHOT_ISO,
+    started_at: SNAPSHOT_ISO,
     runner: "claude",
     pid,
     supervisor_id: fleetName,
@@ -65,9 +65,9 @@ describe("fleet_status worker partition (#2345)", () => {
     roots.push(root);
 
     const enginePaths = createEnginePaths(join(root, ".red"));
-    const lanes = createCastleLaneWriters(enginePaths, {
-      clock: () => NOW_ISO,
-    });
+    // No fixed clock: liveness records land at the real current time so the
+    // 180-second idle window in readCastleMonitorWorkers sees them as fresh.
+    const lanes = createCastleLaneWriters(enginePaths);
 
     // Write castle state snapshots — each stamped with their owning fleet.
     await writeCastleStateSnapshot(
@@ -96,23 +96,24 @@ describe("fleet_status worker partition (#2345)", () => {
     // Write minimal fleet-state files so readFleetState doesn't return null.
     // The slot_pids fallback isn't exercised here (all workers have stamps),
     // but the epoch field prevents parseFleetState from returning null.
-    const fleetState = (epoch: number) =>
-      encodeDevSnapshotToon({
-        ts: NOW_ISO,
-        epoch,
-        runner: "claude",
-        ready_for_agent: 0,
-        slots: { busy: 1, free: 0, total: 1, parked: 0 },
-        spawns_this_tick: 1,
-        churn: { deaths: 0, respawns: 0, window_s: 300 },
-      });
+    const nowEpoch = Math.floor(Date.now() / 1000);
+    const nowIso = new Date().toISOString();
+    const fleetState = encodeDevSnapshotToon({
+      ts: nowIso,
+      epoch: nowEpoch,
+      runner: "claude",
+      ready_for_agent: 0,
+      slots: { busy: 1, free: 0, total: 1, parked: 0 },
+      spawns_this_tick: 1,
+      churn: { deaths: 0, respawns: 0, window_s: 300 },
+    });
 
     const alphaSupervisorDir = join(root, ".red", "tmp", "supervisors", "alpha");
     const betaSupervisorDir = join(root, ".red", "tmp", "supervisors", "beta");
     await mkdir(alphaSupervisorDir, { recursive: true });
     await mkdir(betaSupervisorDir, { recursive: true });
-    await writeFile(join(alphaSupervisorDir, "state.toon"), fleetState(NOW_EPOCH));
-    await writeFile(join(betaSupervisorDir, "state.toon"), fleetState(NOW_EPOCH));
+    await writeFile(join(alphaSupervisorDir, "state.toon"), fleetState);
+    await writeFile(join(betaSupervisorDir, "state.toon"), fleetState);
 
     // Use a fixed nowMs so liveness records (written at NOW_ISO) are within the
     // 180-second idle window — they appear as NOW_MS which equals nowMs exactly.

--- a/apps/dev/tests/fleet-status-partition.test.ts
+++ b/apps/dev/tests/fleet-status-partition.test.ts
@@ -65,8 +65,8 @@ describe("fleet_status worker partition (#2345)", () => {
     roots.push(root);
 
     const enginePaths = createEnginePaths(join(root, ".red"));
-    // No fixed clock: liveness records land at the real current time so the
-    // 180-second idle window in readCastleMonitorWorkers sees them as fresh.
+    // Liveness records use real wall-clock time so the 180-second idle window in
+    // readCastleMonitorWorkers sees them as fresh (no fixed clock injected).
     const lanes = createCastleLaneWriters(enginePaths);
 
     // Write castle state snapshots — each stamped with their owning fleet.
@@ -115,27 +115,28 @@ describe("fleet_status worker partition (#2345)", () => {
     await writeFile(join(alphaSupervisorDir, "state.toon"), fleetState);
     await writeFile(join(betaSupervisorDir, "state.toon"), fleetState);
 
-    // Use a fixed nowMs so liveness records (written at NOW_ISO) are within the
-    // 180-second idle window — they appear as NOW_MS which equals nowMs exactly.
     const mcp = createDevAfkMcpDependencies(root);
 
-    const alphaStatus = await mcp.fleetStatus({ name: "alpha" });
-    const betaStatus = await mcp.fleetStatus({ name: "beta" });
+    // fleetStatus returns Promise<unknown> — cast through any to access fields.
+    const alphaStatus = (await mcp.fleetStatus({ name: "alpha" })) as {
+      live_workers: Array<{ id: string }>;
+      unattributed_workers: Array<{ id: string }>;
+    };
+    const betaStatus = (await mcp.fleetStatus({ name: "beta" })) as {
+      live_workers: Array<{ id: string }>;
+      unattributed_workers: Array<{ id: string }>;
+    };
 
     // Alpha fleet: sees its own worker, not beta's.
-    const alphaLive = alphaStatus.live_workers.map((w: { id: string }) => w.id);
-    const alphaUnattributed = alphaStatus.unattributed_workers.map(
-      (w: { id: string }) => w.id,
-    );
+    const alphaLive = alphaStatus.live_workers.map((w) => w.id);
+    const alphaUnattributed = alphaStatus.unattributed_workers.map((w) => w.id);
     expect(alphaLive).toContain("w_alpha");
     expect(alphaLive).not.toContain("w_beta");
     expect(alphaUnattributed).not.toContain("w_alpha");
 
     // Beta fleet: sees its own worker, not alpha's.
-    const betaLive = betaStatus.live_workers.map((w: { id: string }) => w.id);
-    const betaUnattributed = betaStatus.unattributed_workers.map(
-      (w: { id: string }) => w.id,
-    );
+    const betaLive = betaStatus.live_workers.map((w) => w.id);
+    const betaUnattributed = betaStatus.unattributed_workers.map((w) => w.id);
     expect(betaLive).toContain("w_beta");
     expect(betaLive).not.toContain("w_alpha");
     expect(betaUnattributed).not.toContain("w_beta");

--- a/packages/red-castle/src/engine/monitor-readers.ts
+++ b/packages/red-castle/src/engine/monitor-readers.ts
@@ -119,6 +119,7 @@ function compactStateFromSnapshot(
     runner: snapshot.runner ?? "",
     started_at: snapshot.started_at ?? snapshot.updated_at,
     origin: stringField(current, "origin", stringField(current, "kind")) || undefined,
+    fleet: snapshot.supervisor_id || undefined,
     total,
     done,
     blocked: numberField(current, "blocked"),

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -178,6 +178,11 @@ export interface CompactState {
    * Absent / `""` means unknown (pre-field or origin flag not passed). The
    * dashboard header aggregates non-empty values into per-source counts. */
   origin?: string;
+  /** Named fleet the worker was spawned by (from the castle snapshot's
+   * `supervisor_id`). Absent for standalone runs and legacy workers that
+   * pre-date the fleet stamp. Used by `fleet_status` to partition workers
+   * across fleets (issue #2345). */
+  fleet?: string;
   total: number;
   done: number;
   blocked: number;


### PR DESCRIPTION
Automated AFK landing for #2345. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2345

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787270141&installation_model_id=20659&pr_number=2412&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2412&signature=5ae67ee307c39d2ae7c4602f326ed5472a141fc5789dbf54bac3f8a915903dd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->