### PR TITLE
chore(release): rename RED_RELEASE_TOKEN to the real org secret RELEASE_PAT

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -679,9 +679,8 @@ jobs:
           # Optional. A repo-admin PAT / GitHub App installation token with
           # contents:write pushes the bump straight to protected main; absent,
           # the helper degrades to a side-branch PR instead of failing the cut.
-          # The org provisions this as RELEASE_PAT; a repo-level
-          # RED_RELEASE_TOKEN, when present, still wins.
-          RED_RELEASE_TOKEN: ${{ secrets.RED_RELEASE_TOKEN || secrets.RELEASE_PAT }}
+          # The org provisions this as the RELEASE_PAT secret.
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
           RED_BUILD_VERSION: ${{ steps.version.outputs.next }}
           RED_BUILD_GIT_SHA: ${{ github.sha }}
           RED_BUILD_TIME: ${{ github.event.head_commit.timestamp }}

--- a/scripts/release-push-bump.sh
+++ b/scripts/release-push-bump.sh
@@ -11,7 +11,7 @@
 #
 # Three layered strategies, most-preferred first:
 #
-#   1. RED_RELEASE_TOKEN — a repo-admin PAT or GitHub App installation token
+#   1. RELEASE_PAT — a repo-admin PAT or GitHub App installation token
 #      with contents:write. `enforce_admins` is disabled on main, so an admin
 #      credential pushes straight through while PR protection stays exactly as
 #      strict as it is for everyone else. Set this secret and the release is
@@ -31,8 +31,8 @@
 #   BASE_BRANCH         default: main
 #   PUSH_REMOTE         default: origin
 #   BUMP_PUSH_ATTEMPTS  default: 3
-#   RED_RELEASE_TOKEN   optional bypass-capable token
-#   GITHUB_REPOSITORY   owner/repo, required to use RED_RELEASE_TOKEN
+#   RELEASE_PAT   optional bypass-capable token
+#   GITHUB_REPOSITORY   owner/repo, required to use RELEASE_PAT
 
 set -euo pipefail
 
@@ -42,13 +42,13 @@ PUSH_REMOTE="${PUSH_REMOTE:-origin}"
 ATTEMPTS="${BUMP_PUSH_ATTEMPTS:-3}"
 
 target="$PUSH_REMOTE"
-if [ -n "${RED_RELEASE_TOKEN:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ]; then
+if [ -n "${RELEASE_PAT:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ]; then
   git remote remove release-push >/dev/null 2>&1 || true
-  git remote add release-push "https://x-access-token:${RED_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+  git remote add release-push "https://x-access-token:${RELEASE_PAT}@github.com/${GITHUB_REPOSITORY}.git"
   target=release-push
-  echo "bump push: using the bypass-capable RED_RELEASE_TOKEN credentials"
+  echo "bump push: using the bypass-capable RELEASE_PAT credentials"
 else
-  echo "bump push: RED_RELEASE_TOKEN absent — using the default workflow credentials"
+  echo "bump push: RELEASE_PAT absent — using the default workflow credentials"
 fi
 
 pushed=0
@@ -94,7 +94,7 @@ fi
 
 branch="release/bump-${NEXT}"
 git push --force "$target" "HEAD:refs/heads/${branch}"
-echo "::warning::branch protection declined the direct $NEXT bump push to $BASE_BRANCH; the bump is parked on ${branch}. Add a bypass-capable RED_RELEASE_TOKEN secret (repo-admin PAT with contents:write) to restore the direct push."
+echo "::warning::branch protection declined the direct $NEXT bump push to $BASE_BRANCH; the bump is parked on ${branch}. Add a bypass-capable RELEASE_PAT secret (repo-admin PAT with contents:write) to restore the direct push."
 
 if command -v gh >/dev/null 2>&1; then
   gh pr create \
@@ -106,7 +106,7 @@ if command -v gh >/dev/null 2>&1; then
       "" \
       "\`${NEXT}\` is already published to npm, tagged, and released — only the in-repo manifest versions are waiting on this merge." \
       "" \
-      "To make this automatic again, add a bypass-capable \`RED_RELEASE_TOKEN\` repository secret (repo-admin PAT or GitHub App installation token with contents:write). \`enforce_admins\` is off on \`${BASE_BRANCH}\`, so an admin credential pushes through without weakening PR protection." \
+      "To make this automatic again, add a bypass-capable \`RELEASE_PAT\` repository secret (repo-admin PAT or GitHub App installation token with contents:write). \`enforce_admins\` is off on \`${BASE_BRANCH}\`, so an admin credential pushes through without weakening PR protection." \
       "" \
       "Note: this PR was opened with \`GITHUB_TOKEN\`, whose events cannot trigger \`pull_request\` workflows, so the required checks will not start on their own — merge it as an admin or re-open it from a user account.")" \
     || echo "no new PR opened for ${branch} (one is probably already open)"

--- a/scripts/test-red-release-bump-push-contract.sh
+++ b/scripts/test-red-release-bump-push-contract.sh
@@ -41,16 +41,16 @@ else
   fail "release workflow must push the bump commit via scripts/release-push-bump.sh"
 fi
 
-if grep -qF 'RED_RELEASE_TOKEN: ${{ secrets.RED_RELEASE_TOKEN || secrets.RELEASE_PAT }}' "$WORKFLOW"; then
+if grep -qF 'RELEASE_PAT: ${{ secrets.RELEASE_PAT }}' "$WORKFLOW"; then
   pass "release workflow passes the optional bypass-capable token"
 else
-  fail "release workflow must pass RED_RELEASE_TOKEN to the bump push"
+  fail "release workflow must pass RELEASE_PAT to the bump push"
 fi
 
-if grep -qF 'x-access-token:${RED_RELEASE_TOKEN}' "$HELPER"; then
-  pass "helper prefers RED_RELEASE_TOKEN credentials when the secret is set"
+if grep -qF 'x-access-token:${RELEASE_PAT}' "$HELPER"; then
+  pass "helper prefers RELEASE_PAT credentials when the secret is set"
 else
-  fail "helper must push with RED_RELEASE_TOKEN when it is available"
+  fail "helper must push with RELEASE_PAT when it is available"
 fi
 
 if grep -qF 'rebase --autostash' "$HELPER"; then


### PR DESCRIPTION
The release bump-push path referenced an invented `RED_RELEASE_TOKEN` env var that only worked via a `|| secrets.RELEASE_PAT` fallback. The org secret is `RELEASE_PAT`; this renames the variable across `.github/workflows/red-release.yml`, `scripts/release-push-bump.sh`, and the contract test so no phantom secret name remains. Maintainer-directed cleanup (2026-07-21).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787271049&installation_model_id=20659&pr_number=2414&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2414&signature=3f73da39090eb41e00e898f5f5d146473f3514f7b92a2525fe263d40b4fd7630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->