### PR TITLE
fix: #2411 hitl-card /approve merges with the org RELEASE_PAT credential

### DIFF
--- a/.github/workflows/red-hitl-card.yml
+++ b/.github/workflows/red-hitl-card.yml
@@ -72,6 +72,12 @@ jobs:
       !github.event.issue.pull_request &&
       contains(toJSON(github.event.issue.labels), '"ready-for-human"')
     runs-on: ubuntu-latest
+    # /approve merges the linked PR, which needs contents: write — the
+    # workflow-level block stays read-only for render/refresh.
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -83,7 +89,10 @@ jobs:
 
       - name: Execute card command
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Merging into protected main is declined for the default integration
+          # token; the org RELEASE_PAT (admin PAT) performs the /approve merge.
+          # Absent the secret, degrade to the default token (merge may fail).
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
           RED_AFK_SANDBOX: none
           # Pass via env to avoid shell-injection from public comment text.
           COMMENT_BODY: ${{ github.event.comment.body }}

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Test red-castle vendor contract
         run: scripts/test-red-castle-vendor-contract.sh
 
+      - name: Test hitl-card merge token contract
+        run: scripts/test-red-hitl-card-merge-token-contract.sh
+
       - name: Test marketplace manifest validator
         run: scripts/test-validate-marketplace-manifests.sh
 

--- a/scripts/test-red-hitl-card-merge-token-contract.sh
+++ b/scripts/test-red-hitl-card-merge-token-contract.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Static contract tests for the /approve merge credentials in red-hitl-card.yml.
+#
+# Regression guard for issue #2411: the act job merged with the default
+# integration token, which cannot merge into protected main
+# ("Resource not accessible by integration (mergePullRequest)"), so every
+# /approve failed and approved issues looped back through the fleet.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+WORKFLOW=".github/workflows/red-hitl-card.yml"
+failures=0
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+
+pass() {
+  printf 'PASS: %s\n' "$*"
+}
+
+# The act job must authenticate with the org RELEASE_PAT, falling back to the
+# default token only when the secret is absent.
+if grep -qF 'GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}' "$WORKFLOW"; then
+  pass "act job prefers the RELEASE_PAT credential for /approve merges"
+else
+  fail "act job must set GH_TOKEN to secrets.RELEASE_PAT with a github.token fallback"
+fi
+
+# Merging a PR writes repository contents; the act job needs contents: write.
+act_line="$(grep -nF '  act:' "$WORKFLOW" | head -n1 | cut -d: -f1 || true)"
+if [ -z "$act_line" ]; then
+  fail "missing act job in $WORKFLOW"
+else
+  if tail -n +"$act_line" "$WORKFLOW" | sed -n '1,20p' | grep -qF 'contents: write'; then
+    pass "act job elevates to contents: write for the merge"
+  else
+    fail "act job must declare contents: write in its permissions block"
+  fi
+fi
+
+# The workflow-level default must stay read-only so render/refresh keep the
+# least-privilege token.
+if grep -qF '  contents: read' "$WORKFLOW"; then
+  pass "workflow-level default permissions remain contents: read"
+else
+  fail "workflow-level permissions must keep contents: read as the default"
+fi
+
+# No invented credential names: RELEASE_PAT is the only secret this repo uses.
+if grep -q 'RED_RELEASE_TOKEN' "$WORKFLOW"; then
+  fail "workflow references the nonexistent RED_RELEASE_TOKEN secret"
+else
+  pass "no invented credential names in the workflow"
+fi
+
+if [ "$failures" -gt 0 ]; then
+  printf '\n%d hitl-card merge-token contract check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+
+printf '\nall hitl-card merge-token contract checks passed\n'


### PR DESCRIPTION
Closes #2411

The HITL card's `act` job merged with the default `github.token` under a workflow-level `contents: read`, so every `/approve` failed with `GraphQL: Resource not accessible by integration (mergePullRequest)` — approved issues stayed open, got requeued, and the fleet re-executed finished work (duplicate PRs, e.g. #2398/#2408 for #2379).

- `act` job now declares job-level `permissions` with `contents: write` (render/refresh keep the read-only workflow default).
- `GH_TOKEN` for `act` prefers the org secret `RELEASE_PAT`, falling back to `github.token` when absent.
- New static contract test `scripts/test-red-hitl-card-merge-token-contract.sh` wired into workspace CI: asserts the RELEASE_PAT wiring, the `contents: write` elevation, the read-only workflow default, and that no invented credential names appear.

Maintainer-directed manual land (2026-07-22).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787271712&installation_model_id=20659&pr_number=2419&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2419&signature=467e9e4338107cbb972cca4d73a4fd1ba77e747559e525ae8da67ad2cf38cb39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->