### PR TITLE
fix: #2368 Castle-MCP E6: status dieting — live_only defaults, field projection, terse refusals

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -901,9 +901,9 @@ async function laneLogs(root: string, input: LogsInput) {
   return filtered.length <= limit ? filtered : filtered.slice(-limit);
 }
 
-async function workerVitals(root: string) {
+async function workerVitals(root: string, opts: { live_only?: boolean } = {}) {
   const records = await readAllWorkerStates(afkPaths(root).tmpDir);
-  return records.map(({ state, ...record }) => ({
+  const all = records.map(({ state, ...record }) => ({
     worker: {
       id: state.worker_id,
       pid: state.pid,
@@ -941,6 +941,22 @@ async function workerVitals(root: string) {
     liveness: record.liveness,
     liveness_verdict: record.livenessVerdict,
   }));
+  return opts.live_only !== false ? all.filter((r) => r.live === true) : all;
+}
+
+function projectFields(
+  records: Array<Record<string, unknown>>,
+  fields: string[] | undefined,
+): unknown[] {
+  if (!fields || fields.length === 0) return records;
+  const fieldSet = new Set(fields);
+  return records.map((r) => {
+    const out: Record<string, unknown> = {};
+    for (const key of fieldSet) {
+      if (Object.prototype.hasOwnProperty.call(r, key)) out[key] = r[key];
+    }
+    return out;
+  });
 }
 
 /** Every checkout under the disposable `.red/tmp/worktrees/<lane>/` lanes, in
@@ -997,7 +1013,10 @@ export function createDevAfkMcpDependencies(
       return { fleet: input.name ?? "default", ...result };
     },
     logs: (input) => laneLogs(root, input),
-    workerVitals: () => workerVitals(root),
+    workerVitals: async (input) => {
+      const records = await workerVitals(root, { live_only: input.live_only });
+      return projectFields(records as Array<Record<string, unknown>>, input.fields);
+    },
     dashboard: ({ periodDays }) => collectDashboardReport(periodDays, root),
     monitor: () => collectMonitorInputs(root),
     history: async ({ limit }) => {
@@ -1039,11 +1058,12 @@ export function createDevAfkMcpDependencies(
       }
       throw new Error("worker dispatch requires an issue or demand");
     },
-    workerStatus: async ({ worker }) => {
-      const workers = await workerVitals(root);
-      return worker === undefined
-        ? workers
-        : workers.filter((record) => record.worker.id === worker);
+    workerStatus: async ({ worker, live_only, fields }) => {
+      const records = await workerVitals(root, { live_only });
+      const filtered = worker === undefined
+        ? records
+        : records.filter((record) => record.worker.id === worker);
+      return projectFields(filtered as Array<Record<string, unknown>>, fields);
     },
     workerStop: (input) => operations.stopWorker(root, input),
     runnerList: async () =>

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -26,7 +26,7 @@ function deps(): CastleMcpDependencies {
     logs: vi.fn(async () => [
       { at: "2026-07-21T00:00:00.000Z", kind: "worker.started" },
     ]),
-    workerVitals: vi.fn(async () => []),
+    workerVitals: vi.fn(async (_input) => []),
     dashboard: vi.fn(async () => ({ schema_version: "red.dev.dashboard.v1" })),
     monitor: vi.fn(async () => ({ workers: [], events: [], fleet: null })),
     history: vi.fn(async () => []),
@@ -351,6 +351,73 @@ describe("dev:afk MCP tools", () => {
     expect(
       tools.find((tool) => tool.name === "wait_start")!.description,
     ).toMatch(/^MUTATING:/);
+  });
+
+  it("passes live_only and fields through to the worker_vitals dep", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await tools.find((tool) => tool.name === "worker_vitals")!.invoke({});
+    expect(d.workerVitals).toHaveBeenCalledWith(
+      expect.objectContaining({ live_only: true }),
+    );
+
+    await tools
+      .find((tool) => tool.name === "worker_vitals")!
+      .invoke({ live_only: false, fields: ["worker", "live"] });
+    expect(d.workerVitals).toHaveBeenLastCalledWith({
+      live_only: false,
+      fields: ["worker", "live"],
+    });
+  });
+
+  it("passes live_only and fields through to the worker_status dep", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await tools.find((tool) => tool.name === "worker_status")!.invoke({});
+    expect(d.workerStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ live_only: true }),
+    );
+
+    await tools
+      .find((tool) => tool.name === "worker_status")!
+      .invoke({ worker: "wVM2Z", live_only: false, fields: ["worker"] });
+    expect(d.workerStatus).toHaveBeenLastCalledWith({
+      worker: "wVM2Z",
+      live_only: false,
+      fields: ["worker"],
+    });
+  });
+
+  it("returns a terse refusal when worker_dispatch receives both issue and demand", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await expect(
+      tools
+        .find((tool) => tool.name === "worker_dispatch")!
+        .invoke({ issue: 2306, demand: "fix the gate" }),
+    ).resolves.toMatchObject({
+      refused: true,
+      reason: expect.stringContaining("exactly one"),
+    });
+    expect(d.workerDispatch).not.toHaveBeenCalled();
+  });
+
+  it("returns a terse refusal when worker_request receives both issue and demand", async () => {
+    const d = deps();
+    const tools = createCastleMcpTools(d);
+
+    await expect(
+      tools
+        .find((tool) => tool.name === "worker_request")!
+        .invoke({ issue: 2306, demand: "fix the gate", text: "Use TDD." }),
+    ).resolves.toMatchObject({
+      refused: true,
+      reason: expect.stringContaining("exactly one"),
+    });
+    expect(d.workerRequest).not.toHaveBeenCalled();
   });
 
   it("enumerates and removes disposable worktrees", async () => {

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -30,7 +30,7 @@ export type {
   FleetEditInput,
   FleetNameInput,
 } from "./mcp/fleet.js";
-export type { LogsInput } from "./mcp/observability.js";
+export type { LogsInput, WorkerVitalsInput } from "./mcp/observability.js";
 export type {
   WorkerDispatchInput,
   WorkerStatusInput,

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -61,8 +61,9 @@ const SURFACE: ReadonlyArray<{
   {
     name: "worker_vitals",
     title: "Read worker vitals",
-    description: "Return the liveness-qualified state of all local workers.",
-    schema: [],
+    description:
+      "Return the liveness-qualified state of local workers. Defaults to live workers only; pass `live_only: false` to include stopped/dead workers. Pass `fields` to project top-level keys.",
+    schema: ["live_only", "fields"],
   },
   {
     name: "dashboard",
@@ -102,8 +103,8 @@ const SURFACE: ReadonlyArray<{
     name: "worker_status",
     title: "Read worker status",
     description:
-      "Return normalized, liveness-qualified state for one worker or every local worker.",
-    schema: ["worker"],
+      "Return normalized, liveness-qualified state for one worker or every local worker. Defaults to live workers only; pass `live_only: false` to include stopped/dead workers.",
+    schema: ["worker", "live_only", "fields"],
   },
   {
     name: "worker_stop",

--- a/packages/red-castle/src/mcp/observability.ts
+++ b/packages/red-castle/src/mcp/observability.ts
@@ -8,9 +8,14 @@ export interface LogsInput {
   kind?: string;
 }
 
+export interface WorkerVitalsInput {
+  live_only?: boolean;
+  fields?: string[];
+}
+
 export interface ObservabilityDependencies {
   logs(input: LogsInput): Promise<unknown>;
-  workerVitals(): Promise<unknown>;
+  workerVitals(input: WorkerVitalsInput): Promise<unknown>;
   dashboard(input: { periodDays: number }): Promise<unknown>;
   monitor(): Promise<unknown>;
   history(input: { limit?: number }): Promise<unknown>;
@@ -37,9 +42,17 @@ export function createObservabilityTools(
     {
       name: "worker_vitals",
       title: "Read worker vitals",
-      description: "Return the liveness-qualified state of all local workers.",
-      inputSchema: {},
-      invoke: () => deps.workerVitals(),
+      description:
+        "Return the liveness-qualified state of local workers. Defaults to live workers only; pass `live_only: false` to include stopped/dead workers. Pass `fields` to project top-level keys.",
+      inputSchema: {
+        live_only: z.boolean().default(true),
+        fields: z.array(z.string().min(1)).optional(),
+      },
+      invoke: (input) =>
+        deps.workerVitals({
+          live_only: (input.live_only ?? true) as boolean,
+          fields: input.fields as string[] | undefined,
+        }),
     },
     {
       name: "dashboard",

--- a/packages/red-castle/src/mcp/runner.ts
+++ b/packages/red-castle/src/mcp/runner.ts
@@ -4,6 +4,7 @@ import {
   dispatchInput,
   dispatchShape,
   type WorkerDispatchInput,
+  type WorkerInputRefusal,
 } from "./worker.js";
 
 export interface RunnerDetectInput {
@@ -69,11 +70,18 @@ export function createRunnerTools(deps: RunnerDependencies): CastleMcpTool[] {
         ...dispatchShape,
         text: z.string().min(1),
       },
-      invoke: (input) =>
-        deps.workerRequest({
-          ...dispatchInput(input),
-          text: input.text as string,
-        }),
+      invoke: (input) => {
+        let parsed: WorkerDispatchInput;
+        try {
+          parsed = dispatchInput(input);
+        } catch (err) {
+          return Promise.resolve<WorkerInputRefusal>({
+            refused: true,
+            reason: err instanceof Error ? err.message : String(err),
+          });
+        }
+        return deps.workerRequest({ ...parsed, text: input.text as string });
+      },
     },
   ];
 }

--- a/packages/red-castle/src/mcp/worker.ts
+++ b/packages/red-castle/src/mcp/worker.ts
@@ -10,11 +10,18 @@ export interface WorkerDispatchInput {
 
 export interface WorkerStatusInput {
   worker?: string;
+  live_only?: boolean;
+  fields?: string[];
 }
 
 export interface WorkerStopInput {
   worker: string;
   recycle: boolean;
+}
+
+export interface WorkerInputRefusal {
+  refused: true;
+  reason: string;
 }
 
 export interface WorkerDependencies {
@@ -52,16 +59,35 @@ export function createWorkerTools(deps: WorkerDependencies): CastleMcpTool[] {
       description:
         "MUTATING: run one tracked issue or mint and run one disposable demand through the AFK worker lifecycle.",
       inputSchema: dispatchShape,
-      invoke: (input) => deps.workerDispatch(dispatchInput(input)),
+      invoke: (input) => {
+        let parsed: WorkerDispatchInput;
+        try {
+          parsed = dispatchInput(input);
+        } catch (err) {
+          return Promise.resolve<WorkerInputRefusal>({
+            refused: true,
+            reason: err instanceof Error ? err.message : String(err),
+          });
+        }
+        return deps.workerDispatch(parsed);
+      },
     },
     {
       name: "worker_status",
       title: "Read worker status",
       description:
-        "Return normalized, liveness-qualified state for one worker or every local worker.",
-      inputSchema: { worker: z.string().min(1).optional() },
-      invoke: ({ worker }) =>
-        deps.workerStatus({ worker: worker as string | undefined }),
+        "Return normalized, liveness-qualified state for one worker or every local worker. Defaults to live workers only; pass `live_only: false` to include stopped/dead workers.",
+      inputSchema: {
+        worker: z.string().min(1).optional(),
+        live_only: z.boolean().default(true),
+        fields: z.array(z.string().min(1)).optional(),
+      },
+      invoke: ({ worker, live_only, fields }) =>
+        deps.workerStatus({
+          worker: worker as string | undefined,
+          live_only: (live_only ?? true) as boolean,
+          fields: fields as string[] | undefined,
+        }),
     },
     {
       name: "worker_stop",


### PR DESCRIPTION
Automated AFK landing for #2368. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2368

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787275849&installation_model_id=20659&pr_number=2435&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2435&signature=98b8f9be87268474bd03d724e04acd20f8528bc67fdb06bbf7012b10b3c588b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->