### PR TITLE
fix: #2358 Castle-MCP H9: fleet_register — adopt a live unregistered supervisor into the fleet registry

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -8,6 +8,7 @@ import {
   fleetRegistryPath,
   readCastleLaneRecords,
   readFleetProfile,
+  upsertFleetProfile,
   type CastleLaneRecord,
 } from "@reddb-io/red-castle/engine";
 import { afkPaths, collectMonitorInputs, readFleetState, resolveRepoSlug } from "../runtime/wire.js";
@@ -641,6 +642,15 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     }
     throw new Error(`fleet launch failed: supervisor pid file did not appear. log: .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n${tail}`);
   }
+
+  // Persist the profile so CLI-launched fleets are always in the registry (#2358).
+  await upsertFleetProfile(fleetRegistryPath(createEnginePaths(join(root, ".red"))), {
+    name: paths.fleet,
+    runner: detection.runner,
+    ...(profile?.selector ? { selector: profile.selector } : {}),
+    ...(profile?.config ? { config: profile.config } : {}),
+    ...(profile?.base ? { base: profile.base } : {}),
+  }).catch(() => undefined);
 
   const named = paths.fleet === DEFAULT_FLEET_NAME ? "" : ` --fleet ${paths.fleet}`;
   stdout.write(`🚀 fleet ${paths.fleet} launched (supervisor pid=${supervisorPid}, target=${parsed.target})\n`);

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -29,6 +29,7 @@ import type {
   FleetCreateInput,
   FleetEditInput,
   FleetNameInput,
+  FleetRegisterInput,
   GateRunInput,
   LandBranchInput,
   LogsInput,
@@ -994,6 +995,27 @@ async function removeDisposableWorktree(root: string, input: WorktreeRemoveInput
   return { path: relative(root, target), removed: !existsSync(target) };
 }
 
+async function registerFleet(root: string, input: FleetRegisterInput) {
+  const path = registryPath(root);
+  const paths = afkPaths(root, input.name);
+  const running = await discoverLiveSupervisorPid(
+    paths.supervisorRuntimeDir,
+    isLivePid,
+    { fleet: paths.fleet },
+  );
+  if (!running) {
+    throw new Error(`fleet ${JSON.stringify(paths.fleet)} is not running`);
+  }
+  const profile = await upsertFleetProfile(path, {
+    name: paths.fleet,
+    runner: input.runner,
+    ...(input.selector ? { selector: input.selector } : {}),
+    ...(input.config ? { config: input.config } : {}),
+    ...(input.base ? { base: input.base } : {}),
+  });
+  return { status: "registered", profile, pid: running.pid };
+}
+
 export function createDevAfkMcpDependencies(
   root = process.cwd(),
   operations: DevAfkMcpOperations = createDefaultDevAfkMcpOperations(root),
@@ -1012,6 +1034,7 @@ export function createDevAfkMcpDependencies(
       const result = await stopFleet(root, silent, input.name);
       return { fleet: input.name ?? "default", ...result };
     },
+    fleetRegister: (input) => registerFleet(root, input),
     logs: (input) => laneLogs(root, input),
     workerVitals: async (input) => {
       const records = await workerVitals(root, { live_only: input.live_only });

--- a/apps/dev/tests/fleet-cli-upsert.test.ts
+++ b/apps/dev/tests/fleet-cli-upsert.test.ts
@@ -1,0 +1,59 @@
+// CLI fleet N launch must upsert its profile into the registry so the
+// registry never diverges from reality (#2358).
+
+import { vi, describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createEnginePaths, fleetRegistryPath, readFleetProfile } from "@reddb-io/red-castle/engine";
+
+vi.mock("../src/runtime/supervisor-spawn.js", () => ({
+  spawnSupervisor: vi.fn(async () => 7777),
+}));
+
+// Import after mock is hoisted so launchFleet picks up the stub.
+const { launchFleet } = await import("../src/commands/fleet.js");
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((r) => rm(r, { recursive: true, force: true })),
+  );
+});
+
+async function root(): Promise<string> {
+  const r = await mkdtemp(join(tmpdir(), "fleet-cli-upsert-"));
+  roots.push(r);
+  return r;
+}
+
+describe("CLI fleet N launch — profile upsert", () => {
+  it("registers its profile in the fleet registry after a successful spawn", async () => {
+    const cwd = await root();
+    const silent = { write: () => true } as unknown as NodeJS.WritableStream;
+
+    const result = await launchFleet(["2", "--runner", "claude"], cwd, silent);
+    expect(result.status).toBe("launched");
+    expect(result.pid).toBe(7777);
+
+    const profile = await readFleetProfile(
+      fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),
+      "default",
+    );
+    expect(profile).toMatchObject({ name: "default", runner: "claude" });
+  });
+
+  it("registers the named fleet's profile when --fleet is supplied", async () => {
+    const cwd = await root();
+    const silent = { write: () => true } as unknown as NodeJS.WritableStream;
+
+    await launchFleet(["2", "--runner", "codex", "--fleet", "alpha"], cwd, silent);
+
+    const profile = await readFleetProfile(
+      fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),
+      "alpha",
+    );
+    expect(profile).toMatchObject({ name: "alpha", runner: "codex" });
+  });
+});

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -10,8 +10,10 @@ import {
   castleLanePath,
   createEnginePaths,
   fleetRegistryPath,
+  readFleetProfile,
   upsertFleetProfile,
 } from "@reddb-io/red-castle/engine";
+import { afkPaths } from "../src/runtime/wire.js";
 import {
   buildMcpLandingFireHook,
   createDefaultDevAfkMcpOperations,
@@ -374,6 +376,49 @@ describe("dev:afk MCP host adapter", () => {
     await expect(
       deps.worktreeRemove({ path: join("..", "elsewhere") }),
     ).rejects.toThrow(/escapes/);
+  });
+});
+
+describe("fleet_register — adopt a live unregistered fleet", () => {
+  it("persists the profile for a live fleet without touching the supervisor", async () => {
+    const cwd = await root();
+    const paths = afkPaths(cwd);
+    await mkdir(paths.supervisorRuntimeDir, { recursive: true });
+    await writeFile(paths.supervisorPidPath, String(process.pid), "utf8");
+
+    const result = await createDevAfkMcpDependencies(cwd).fleetRegister({
+      runner: "claude",
+      selector: { spec: 2303 },
+    }) as Record<string, unknown>;
+
+    expect(result).toMatchObject({ status: "registered", pid: process.pid });
+    expect(result.profile).toMatchObject({ name: "default", runner: "claude", selector: { spec: 2303 } });
+
+    const profile = await readFleetProfile(
+      fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),
+      "default",
+    );
+    expect(profile).toEqual({ name: "default", runner: "claude", selector: { spec: 2303 } });
+  });
+
+  it("refuses adoption when the fleet supervisor is not running", async () => {
+    const cwd = await root();
+    await expect(
+      createDevAfkMcpDependencies(cwd).fleetRegister({ runner: "claude" }),
+    ).rejects.toThrow(/not running/);
+  });
+
+  it("fleet_edit works immediately after fleet_register persists the profile", async () => {
+    const cwd = await root();
+    const paths = afkPaths(cwd, "alpha");
+    await mkdir(paths.supervisorRuntimeDir, { recursive: true });
+    await writeFile(paths.supervisorPidPath, String(process.pid), "utf8");
+
+    const deps = createDevAfkMcpDependencies(cwd);
+    await deps.fleetRegister({ name: "alpha", runner: "claude" });
+    await expect(
+      deps.fleetEdit({ name: "alpha", runner: "codex" }),
+    ).resolves.toMatchObject({ status: "edited" });
   });
 });
 

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -23,6 +23,7 @@ function deps(): CastleMcpDependencies {
       status: "stopped",
       name: input.name,
     })),
+    fleetRegister: vi.fn(async () => ({ status: "registered" })),
     logs: vi.fn(async () => [
       { at: "2026-07-21T00:00:00.000Z", kind: "worker.started" },
     ]),
@@ -106,6 +107,7 @@ describe("dev:afk MCP tools", () => {
       "fleet_create",
       "fleet_edit",
       "fleet_stop",
+      "fleet_register",
       "logs",
       "worker_vitals",
       "dashboard",

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -29,6 +29,7 @@ export type {
   FleetCreateInput,
   FleetEditInput,
   FleetNameInput,
+  FleetRegisterInput,
 } from "./mcp/fleet.js";
 export type { LogsInput, WorkerVitalsInput } from "./mcp/observability.js";
 export type {

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -52,6 +52,13 @@ const SURFACE: ReadonlyArray<{
     schema: ["fleet"],
   },
   {
+    name: "fleet_register",
+    title: "Adopt AFK fleet",
+    description:
+      "MUTATING: persist a profile for an already-running supervisor without restarting it.",
+    schema: ["name", "runner", "selector", "config", "base"],
+  },
+  {
     name: "logs",
     title: "Read Castle logs",
     description:

--- a/packages/red-castle/src/mcp/fleet.ts
+++ b/packages/red-castle/src/mcp/fleet.ts
@@ -30,12 +30,21 @@ export interface FleetNameInput {
   name?: string;
 }
 
+export interface FleetRegisterInput {
+  name?: string;
+  runner: string;
+  selector?: FleetSelectorInput;
+  config?: Record<string, string | number | boolean>;
+  base?: string;
+}
+
 export interface FleetDependencies {
   fleetList(): Promise<unknown>;
   fleetStatus(input: FleetNameInput): Promise<unknown>;
   fleetCreate(input: FleetCreateInput): Promise<unknown>;
   fleetEdit(input: FleetEditInput): Promise<unknown>;
   fleetStop(input: FleetNameInput): Promise<unknown>;
+  fleetRegister(input: FleetRegisterInput): Promise<unknown>;
 }
 
 const fleetSelectorShape = {
@@ -105,6 +114,20 @@ export function createFleetTools(deps: FleetDependencies): CastleMcpTool[] {
       inputSchema: { fleet: z.string().min(1).optional() },
       invoke: ({ fleet }) =>
         deps.fleetStop({ name: fleet as string | undefined }),
+    },
+    {
+      name: "fleet_register",
+      title: "Adopt AFK fleet",
+      description:
+        "MUTATING: persist a profile for an already-running supervisor without restarting it.",
+      inputSchema: {
+        name: z.string().min(1).optional(),
+        runner: z.string().min(1),
+        selector: z.object(fleetSelectorShape).optional(),
+        config: fleetConfig.optional(),
+        base: z.string().min(1).optional(),
+      },
+      invoke: (input) => deps.fleetRegister(input as unknown as FleetRegisterInput),
     },
   ];
 }

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -49,9 +49,13 @@ claim keeps two fleets on the same backlog from double-claiming an issue.
 | `fleet_create` | mutating | Persist a named profile and spawn its supervisor. |
 | `fleet_edit` | mutating | Update a profile; sends a live resize directive when asked. |
 | `fleet_stop` | mutating | Stop one named fleet and its detached workers. |
+| `fleet_register` | mutating | Adopt an already-running supervisor into the registry without restarting it. |
 
 `selector` scopes what a fleet drains — `{spec, lane, label, issues}`. Omit
-`fleet` on the read and stop tools to address the `default` fleet.
+`fleet` on the read and stop tools to address the `default` fleet. Use
+`fleet_register` when a CLI-launched fleet shows up in `fleet_status` but
+not in `fleet_list` — it persists the profile in-place so `fleet_edit` works
+immediately after.
 
 ### Worker — one worker's lifecycle
 

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -49,9 +49,13 @@ claim keeps two fleets on the same backlog from double-claiming an issue.
 | `fleet_create` | mutating | Persist a named profile and spawn its supervisor. |
 | `fleet_edit` | mutating | Update a profile; sends a live resize directive when asked. |
 | `fleet_stop` | mutating | Stop one named fleet and its detached workers. |
+| `fleet_register` | mutating | Adopt an already-running supervisor into the registry without restarting it. |
 
 `selector` scopes what a fleet drains — `{spec, lane, label, issues}`. Omit
-`fleet` on the read and stop tools to address the `default` fleet.
+`fleet` on the read and stop tools to address the `default` fleet. Use
+`fleet_register` when a CLI-launched fleet shows up in `fleet_status` but
+not in `fleet_list` — it persists the profile in-place so `fleet_edit` works
+immediately after.
 
 ### Worker — one worker's lifecycle
 


### PR DESCRIPTION
Automated AFK landing for #2358. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2358

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787279443&installation_model_id=20659&pr_number=2438&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2438&signature=6075da9cc4b11d4e97aee793b2b091310710687f82915322e59e59ad17e284b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->