### PR TITLE
fix: #2436 Fleet trunk mirror refresh builds a bogus 'origin/when' ref and parks untouched issues as base-stale

### DIFF
--- a/apps/dev/src/core/pin-reader.ts
+++ b/apps/dev/src/core/pin-reader.ts
@@ -15,9 +15,12 @@
 
 // A canonical `branch:` line: optional leading whitespace, an optional markdown
 // list marker (`-`/`*` plus whitespace), the literal lowercase key `branch:`,
-// whitespace, then a single non-whitespace branch token. Prose like
-// "this branch: foo" never matches because the key must start the line.
-const BRANCH_LINE = /^[ \t]*(?:[-*][ \t]+)?branch:[ \t]+(\S+)/;
+// whitespace, then a single non-whitespace branch token, then only optional
+// trailing spaces/tabs and an optional `#…` comment before end-of-line. Prose
+// like "branch: when the PR lands" never matches because trailing words
+// (non-`#` content) fail the anchor; "this branch: foo" never matches because
+// the key must start the line.
+const BRANCH_LINE = /^[ \t]*(?:[-*][ \t]+)?branch:[ \t]+(\S+)[ \t]*(?:#.*)?$/;
 
 // The first `Spec #<n>` reference (the `## Parent` convention from /to-tickets).
 // Not anchored — it matches anywhere on a line and tolerates spaces around `#`.

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -363,9 +363,17 @@ export async function processIssue(
       model: deps.model,
       effort: deps.effort,
       resolvedBase: baseResolution,
+      // The worker branch was never pushed — suppress the live-branch link.
+      noBranchLink: true,
     };
-    const message = baseResolution.message ?? "Base is stale; remote is unreachable and local ref is behind.";
-    return await terminalFailure(staleCommon, "base-stale", "base-stale", {
+    const message = baseResolution.message ?? "could not refresh fleet trunk mirror; remote unreachable or ref missing.";
+    // Classify as runner-transient (infrastructure / network failure), not
+    // base-stale.  base-stale implies the base ref exists but the local copy is
+    // behind; a mirror-refresh failure at boot (origin/when, network down, etc.)
+    // is an infra transient that clears on the next attempt.  base-stale is
+    // non-recoverable (escalates to human); runner-transient auto-retries up to
+    // the bounded cap, which is the right policy here.
+    return await terminalFailure(staleCommon, "runner-transient", "runner-transient", {
       notes: message,
       log: message,
     });

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -207,6 +207,10 @@ export interface StageCommon {
   effort?: AgentEffort;
   resolvedBase?: WorkerBaseResolution;
   backpressureChecks?: readonly BackpressureCheck[];
+  /** When true, emitFailure suppresses the `live branch:` link in the envelope
+   * diff section — used for pre-push boot failures where the worker branch was
+   * never pushed to origin. */
+  noBranchLink?: boolean;
 }
 export async function emitBackpressureReview(
   c: StageCommon,
@@ -237,7 +241,7 @@ export async function emitFailure(
     branch: c.branch,
     attempt: input.attempt,
     diff: diffLabel,
-    repo: input.repo,
+    repo: c.noBranchLink ? "" : input.repo,
     repoDir: input.repoDir,
     worktreeRel: input.attemptDir,
     diffstat: "",

--- a/apps/dev/tests/pin-reader.test.ts
+++ b/apps/dev/tests/pin-reader.test.ts
@@ -30,6 +30,18 @@ describe("parseBranchPin", () => {
   it("does not match prose 'branch:' mid-sentence", () => {
     expect(parseBranchPin("This branch: is a sentence, not a pin.\nWe will branch: later maybe")).toBeUndefined();
   });
+
+  it("does not match a branch: line whose value is followed by more words", () => {
+    // Regression for #2436: "branch: when the PR lands" at line start captured
+    // "when" as the branch name and poisoned the fleet trunk mirror refresh.
+    expect(parseBranchPin("branch: when the PR lands")).toBeUndefined();
+    expect(parseBranchPin("branch: after we merge")).toBeUndefined();
+    expect(parseBranchPin("branch: once all tests pass")).toBeUndefined();
+  });
+
+  it("accepts a branch: line with a trailing # comment", () => {
+    expect(parseBranchPin("branch: main # the trunk")).toBe("main");
+  });
 });
 
 describe("parseParentSpec", () => {

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -1320,3 +1320,26 @@ describe("processIssue — active Current blocker preflight", () => {
     expect(trace.ensuredLabels).not.toContain("blocked:spec");
   });
 });
+
+describe("processIssue — trunk-mirror boot failure (#2436)", () => {
+  it("parks as runner-transient (not base-stale) when resolveFreshBase fails", async () => {
+    // Regression: attempts on issues with prose like "branch: when the PR lands"
+    // in their body caused parseBranchPin to extract "when" as the branch pin,
+    // which made resolveFreshBase({ base: "when" }) fail.  The issue was then
+    // parked as base-stale (non-recoverable → human), misrepresenting an
+    // unstarted issue as finished work awaiting merge.  The fix classifies this
+    // as runner-transient so the fleet auto-retries up to the bounded cap.
+    const { deps, input, trace } = harness({ freshBaseFail: true });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("runner-transient");
+    // No agent work ran — no runAgent calls.
+    expect(trace.runAgentCalls).toEqual([]);
+    // No fresh branch was prepared — the branch was never pushed.
+    expect(trace.freshWorkerBranchCalls).toEqual([]);
+    // Park comment must not contain a live-branch link (branch was never pushed).
+    const envelope = trace.envelopeBodies[0] ?? "";
+    expect(envelope).not.toMatch(/live branch:/);
+  });
+});

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -177,6 +177,9 @@ export interface HarnessOptions {
   fallbackRunner?: boolean;
   /** Records each git fetch-base call (the ADR 0031 start-point fetch). */
   fetchedBases?: string[];
+  /** When true, resolveFreshBase returns ok:false (simulating a boot-time
+   * mirror refresh failure — the regression path for #2436). */
+  freshBaseFail?: boolean;
   /** Restart-informed context block returned by the attempt ledger lookup. */
   priorAttemptContext?: string;
   /** The configured Trunk (`plugins.dev.trunk`, ADR 0083) injected into base resolution. */
@@ -400,12 +403,24 @@ export function harness(opts: HarnessOptions = {}): {
       async deleteLocalBranch() {},
       async resolveFreshBase({ base, remote }) {
         if (opts.fetchedBases) opts.fetchedBases.push(base);
+        if (opts.freshBaseFail) {
+          return {
+            ok: false,
+            base,
+            baseRef: `${remote}/${base}`,
+            sha: "",
+            source: "mirror" as const,
+            remoteReachable: false,
+            reason: "base-stale" as const,
+            message: `could not refresh fleet trunk mirror red-trunk from ${remote}/${base}`,
+          };
+        }
         return {
           ok: true,
           base,
           baseRef: "red-trunk",
           sha: `${remote}/${base}-tip`,
-          source: "mirror",
+          source: "mirror" as const,
           remoteReachable: true,
         };
       },


### PR DESCRIPTION
Automated AFK landing for #2436. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2436

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787280413&installation_model_id=20659&pr_number=2439&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2439&signature=366c729335ad0c0f423ff14e8737da040a7a18736f25f69b5549d1ebd50c3dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->