### PR TITLE
fix: #2437 Landing revalidations race on the shared feedback/main baseline worktree

### DIFF
--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -27,9 +27,21 @@
 // dominant cost when 5+ workers race-claim the same branch (Pattern 7 of the
 // claude-minimax spike investigation). The flag is opt-out via
 // `cacheEnabled: false` for callers that need a strict per-session manager.
+//
+// A worktree path is a SINGLETON across every process on the host — most
+// sharply the `feedback/main` baseline every landing revalidation probes
+// against. Materialising it (`worktree add` + `pnpm install`) therefore runs
+// under a host-wide file lock (#2437): concurrent landings serialize instead of
+// corrupting each other's setup, and the waiter re-checks the cache once it has
+// the lock, so the usual outcome of losing the race is a free cache hit. When
+// the wait itself times out, setup is reported as RETRYABLE — a failed setup is
+// only latched (blocking the rest of the session) after three consecutive
+// failures, because latching the first one turned one collision into a whole
+// ~25-minute revalidation cycle failing every check as inconclusive.
 
 import { accessSync, constants, readFileSync } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { mkdir } from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
 import {
   buildFeedbackSubprocessEnv,
   type Exec as PnpmExec,
@@ -39,6 +51,7 @@ import type { BackpressureExec } from "../core/backpressure.js";
 import type { PostAttemptFormatExec } from "../core/post-attempt-format.js";
 import { execTool, pnpm as runPnpm, type ExecOptions, type ExecOutput } from "./exec.js";
 import * as gitx from "./git.js";
+import { createPathLock } from "./land-lock.js";
 
 /**
  * Is `token` an ALREADY-MATERIALISED checkout rather than a branch name (#2339)?
@@ -157,7 +170,38 @@ export interface FeedbackWorktreeIO {
   pnpm(args: readonly string[], opts: ExecOptions): Promise<ExecOutput>;
   /** Run an arbitrary tool (used by the backpressure `sh -c` executor). */
   exec(cmd: string, args: readonly string[], opts: ExecOptions): Promise<ExecOutput>;
+  /**
+   * Host-wide mutual exclusion over ONE worktree path (#2437). The feedback
+   * baseline worktree (`feedback/main`) is a singleton shared by every landing
+   * revalidation on this host; without a lock two concurrent revalidations
+   * `worktree add` + `pnpm install` the same directory and the loser's setup
+   * fails ("already exists" / a half-installed `node_modules`), failing EVERY
+   * check of a ~25-minute cycle as `inconclusive`. Resolves to a release
+   * closure once the caller owns `dest`, or `null` when the wait timed out
+   * (the caller then treats setup as retryable, never as a hard failure).
+   *
+   * Optional: an injected IO without it (every test fake) serializes only
+   * in-process, which is all a single-process fixture needs.
+   */
+  lock?(dest: string): Promise<(() => Promise<void>) | null>;
 }
+
+/**
+ * How long a landing revalidation waits for the baseline worktree before giving
+ * up. The holder keeps the lock only for `worktree add` + `pnpm install` +
+ * rebase (never for the test run itself), so the real contention window is a
+ * couple of minutes; 10 is generous headroom on a loaded fleet host and still
+ * far under the revalidation cycle it protects.
+ */
+const WORKTREE_LOCK_WAIT_MS = 10 * 60_000;
+/** A holder that has not finished a materialise in this long has crashed. */
+const WORKTREE_LOCK_STALE_MS = 20 * 60_000;
+/**
+ * Consecutive failed setups before a branch is latched as permanently broken.
+ * Above 1 so a transient contention loss is retried; low enough that a genuine
+ * lockfile drift costs three installs, not one per check in the cycle.
+ */
+const MAX_SETUP_ATTEMPTS = 3;
 
 const defaultIO: FeedbackWorktreeIO = {
   worktreeAdd: gitx.worktreeAdd,
@@ -188,6 +232,17 @@ const defaultIO: FeedbackWorktreeIO = {
   },
   pnpm: runPnpm,
   exec: execTool,
+  lock: async (dest) => {
+    // The lock file sits BESIDE the worktree, not inside it — `git worktree
+    // add` refuses a non-empty destination, so a lock file within `dest` would
+    // block the very operation it guards.
+    await mkdir(dirname(dest), { recursive: true });
+    return createPathLock(`${dest}.lock`, `feedback-worktree:${dest}`, {
+      waitTimeoutMs: WORKTREE_LOCK_WAIT_MS,
+      staleAfterMs: WORKTREE_LOCK_STALE_MS,
+      pollMs: 500,
+    }).acquire();
+  },
 };
 
 export interface FeedbackWorktree {
@@ -267,12 +322,49 @@ export function makeFeedbackWorktree(
   // removes. A cache hit (worktree reused from a prior session) is NOT in
   // this set, so cleanup leaves it alone.
   const created = new Set<string>();
+  // In-flight materialise per branch: two validation calls for the same branch
+  // in ONE process must share a single setup, not race each other into a
+  // duplicate `worktree add`.
+  const inflight = new Map<string, Promise<string | null>>();
+  // Consecutive setup failures per branch (#2437). A setup failure is treated
+  // as TRANSIENT until proven otherwise — contention on the shared baseline
+  // worktree looks exactly like a hard failure at the first attempt, and
+  // latching it made one collision fail every remaining check of the cycle.
+  const setupFailures = new Map<string, number>();
+
+  /**
+   * Record a failed materialise. The branch is only latched as permanently
+   * broken (`resolved -> null`, every later call short-circuits) after
+   * {@link MAX_SETUP_ATTEMPTS} consecutive failures; before that the next
+   * validation call retries the baseline step from scratch.
+   */
+  function noteSetupFailure(branch: string): null {
+    const attempts = (setupFailures.get(branch) ?? 0) + 1;
+    setupFailures.set(branch, attempts);
+    if (attempts >= MAX_SETUP_ATTEMPTS) resolved.set(branch, null);
+    return null;
+  }
 
   async function pathFor(branch: string): Promise<string | null> {
     if (!branch) return root;
     const cached = resolved.get(branch);
     if (cached !== undefined) return cached;
+    const pending = inflight.get(branch);
+    if (pending !== undefined) return pending;
+    const run = materialise(branch).finally(() => inflight.delete(branch));
+    inflight.set(branch, run);
+    return run;
+  }
 
+  /** True when the worktree already at `dest` is at the live branch HEAD. */
+  async function cacheHit(branch: string, dest: string): Promise<boolean> {
+    if (!cacheEnabled) return false;
+    const expectedSha = await io.branchHead(gitCtx, branch);
+    const actualSha = await io.worktreeHead(gitCtx, dest);
+    return Boolean(expectedSha && actualSha && expectedSha === actualSha);
+  }
+
+  async function materialise(branch: string): Promise<string | null> {
     // The token is ALREADY a materialised checkout (#2339). The post-merge
     // integration gate (#1335) hands the gate the isolated rebase/landing
     // worktree DIR, not a branch name — the caller provisioned it, so there is
@@ -295,15 +387,50 @@ export function makeFeedbackWorktree(
     // of the claude-minimax spike investigation). SHA mismatch is the only
     // invalidation signal; no mtime/TTL GC. Cached worktrees are not torn down
     // by `cleanup()` so the next session reuses them.
-    if (cacheEnabled) {
-      const expectedSha = await io.branchHead(gitCtx, branch);
-      const actualSha = await io.worktreeHead(gitCtx, dest);
-      if (expectedSha && actualSha && expectedSha === actualSha) {
-        resolved.set(branch, dest);
-        return dest; // cache hit — don't add to `created`, don't re-install
-      }
-      // Mismatch (or dest is not a worktree, or lookup failed): fall through
-      // to a clean re-materialise.
+    if (await cacheHit(branch, dest)) {
+      resolved.set(branch, dest);
+      return dest; // cache hit — don't add to `created`, don't re-install
+    }
+    // Mismatch (or dest is not a worktree, or lookup failed): fall through
+    // to a clean re-materialise — under the host-wide lock (#2437), because a
+    // worktree path is a singleton and two processes materialising it at once
+    // corrupt each other's setup.
+    const release = io.lock ? await io.lock(dest) : null;
+    if (io.lock && release === null) {
+      // Timed out waiting for the holder. This is CONTENTION, not corruption:
+      // report it as a retryable setup failure so the next validation call
+      // tries again (the holder will normally have finished by then) instead
+      // of latching the whole revalidation cycle as blocked.
+      process.stderr.write(
+        `warn: feedback worktree ${dest} is busy (lock wait timed out); ` +
+          `baseline setup for ${branch} will be retried\n`,
+      );
+      return noteSetupFailure(branch);
+    }
+    try {
+      return await materialiseLocked(branch, dest, release !== null);
+    } finally {
+      await release?.();
+    }
+  }
+
+  /**
+   * The materialise steps that require exclusive ownership of `dest`.
+   * `locked` says the caller actually took a lock and so may have WAITED — only
+   * then is a second cache probe worth its two git calls.
+   */
+  async function materialiseLocked(
+    branch: string,
+    dest: string,
+    locked: boolean,
+  ): Promise<string | null> {
+    // Re-check the cache now that we hold the lock: while we waited, the prior
+    // holder very likely materialised the exact worktree we want. Turning the
+    // lost race into a cache hit is what makes contention free rather than
+    // merely survivable — the loser does no add and no install.
+    if (locked && (await cacheHit(branch, dest))) {
+      resolved.set(branch, dest);
+      return dest;
     }
 
     let added = await io.worktreeAdd(gitCtx, dest, branch);
@@ -327,8 +454,7 @@ export function makeFeedbackWorktree(
         `error: feedback worktree add failed for ${branch}; blocking validation: ` +
           `${added.stderr?.trim() || "no git detail"}\n`,
       );
-      resolved.set(branch, null);
-      return null;
+      return noteSetupFailure(branch);
     }
     // A freshly added worktree has NO node_modules. Without an install here,
     // the feedback gate's `pnpm -C <dest> test/build` calls fail with
@@ -345,8 +471,7 @@ export function makeFeedbackWorktree(
         `error: feedback worktree install failed for ${branch} (exit ${ins.code}); ` +
           `blocking validation\n${ins.stderr.trim()}\n`,
       );
-      resolved.set(branch, null);
-      return null;
+      return noteSetupFailure(branch);
     }
     // AFK runner improvement (Pattern 2): best-effort rebase onto the session
     // base so a worker test written against a now-moved main validates against
@@ -366,6 +491,7 @@ export function makeFeedbackWorktree(
     }
     created.add(dest);
     resolved.set(branch, dest);
+    setupFailures.delete(branch);
     return dest;
   }
 
@@ -497,6 +623,7 @@ export function makeFeedbackWorktree(
       }
       created.clear();
       resolved.clear();
+      setupFailures.clear();
     },
   };
 }

--- a/apps/dev/src/runtime/land-lock.ts
+++ b/apps/dev/src/runtime/land-lock.ts
@@ -60,10 +60,27 @@ function isHolderAlive(pid: number): boolean {
   }
 }
 
-/** Build the host-backed global land-lock for this worker process. */
-export function createLandLock(tmpDir: string, holder: string, pid: number = process.pid): LandLock {
+/**
+ * Build a host-backed file lock at an ARBITRARY path — the same acquire/steal
+ * sequencing as the land-lock, aimed at any other resource that is shared by
+ * every process on this host (#2437: the singleton feedback baseline worktree).
+ * Timings are caller-supplied because the contention windows differ by orders
+ * of magnitude: a land holds its lock for a push, a worktree materialise holds
+ * it for a `pnpm install`.
+ */
+export function createPathLock(
+  path: string,
+  holder: string,
+  options: { waitTimeoutMs?: number; pollMs?: number; staleAfterMs?: number } = {},
+  pid: number = process.pid,
+): LandLock {
   return createFileLandLock(
     { fs: nodeLandLockFs, clock: { now: () => Date.now(), sleep: (ms) => delay(ms) }, isHolderAlive },
-    { path: landLockPath(tmpDir), holder, pid },
+    { path, holder, pid, ...options },
   );
+}
+
+/** Build the host-backed global land-lock for this worker process. */
+export function createLandLock(tmpDir: string, holder: string, pid: number = process.pid): LandLock {
+  return createPathLock(landLockPath(tmpDir), holder, {}, pid);
 }

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -676,3 +676,209 @@ describe("gate test subprocess env (#1215 / #1224 Part C)", () => {
     }
   });
 });
+
+// #2437: the `feedback/main` baseline worktree is a singleton shared by every
+// landing revalidation on the host. Three landing tails failed in one night with
+// `feedback worktree setup failed for main; validation blocked` while a sibling
+// worker was landing — the loser of an unserialized `worktree add` + `pnpm
+// install` race. Each collision burned a full ~25-minute revalidation cycle.
+describe("makeFeedbackWorktree — shared baseline serialization (#2437)", () => {
+  const BRANCH = "main";
+  const DEST = "/root/.red/tmp/feedback/main";
+  const SHA = "base1234";
+
+  /**
+   * Two managers (modelling two worker PROCESSES) over one shared baseline
+   * worktree. `shas[DEST]` is the on-disk state both see, so a materialise by
+   * one manager is visible to the other — exactly the shared-singleton
+   * semantics of the real directory.
+   *
+   * `worktreeAdd` is deliberately hostile: it refuses with git's real "already
+   * exists" while another add/install is in flight, and it takes a turn of the
+   * event loop, so an unserialized pair of managers reproduces the field
+   * failure. `lock` is a shared in-memory mutex keyed by path, standing in for
+   * the O_EXCL lock file the production IO uses.
+   */
+  function sharedBaselineIO(opts: { serialize: boolean }): {
+    ioFor: () => FeedbackWorktreeIO;
+    calls: Array<{ op: Op; dest: string }>;
+    maxConcurrentSetups: () => number;
+  } {
+    const calls: Array<{ op: Op; dest: string }> = [];
+    const shas: Record<string, string> = {};
+    const busy = new Set<string>();
+    let setupsInFlight = 0;
+    let maxSetups = 0;
+    // One mutex per path, shared by every manager this helper builds.
+    const held = new Set<string>();
+    const waiters: Array<() => void> = [];
+
+    const io = (): FeedbackWorktreeIO => ({
+      worktreeAdd: async (_ctx, dest) => {
+        calls.push({ op: "add", dest });
+        if (busy.has(dest)) {
+          return { ok: false, stderr: `fatal: '${dest}' already exists` };
+        }
+        busy.add(dest);
+        setupsInFlight += 1;
+        maxSetups = Math.max(maxSetups, setupsInFlight);
+        await Promise.resolve();
+        return { ok: true, stderr: "" };
+      },
+      pnpm: async (args, opts2) => {
+        const isInstall = args[0] === "install";
+        // An install runs with `cwd` at the worktree; a check runs from the
+        // primary root with the worktree in its rewritten `-C` arg.
+        const cIdx = args.indexOf("-C");
+        const dest = isInstall ? (opts2.cwd ?? "") : (args[cIdx + 1] ?? opts2.cwd ?? "");
+        calls.push({ op: isInstall ? "install" : "script", dest });
+        if (!isInstall) return { code: 0, stdout: "", stderr: "" };
+        // The install is the long pole — yield so a concurrent manager gets a
+        // chance to collide with it.
+        await Promise.resolve();
+        shas[opts2.cwd ?? ""] = SHA;
+        busy.delete(opts2.cwd ?? "");
+        setupsInFlight -= 1;
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      exec: async (_cmd, _args, opts2) => {
+        calls.push({ op: "script", dest: opts2.cwd ?? "" });
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      worktreeRemove: async (_ctx, dest) => {
+        calls.push({ op: "remove", dest });
+        busy.delete(dest);
+        delete shas[dest];
+      },
+      branchHead: async (_ctx, branch) => (branch === BRANCH ? SHA : null),
+      worktreeHead: async (_ctx, dest) => shas[dest] ?? null,
+      rebase: async () => ({ ok: true }),
+      ...(opts.serialize
+        ? {
+            lock: async (dest: string) => {
+              while (held.has(dest)) {
+                await new Promise<void>((resolve) => waiters.push(resolve));
+              }
+              held.add(dest);
+              return async () => {
+                held.delete(dest);
+                for (const wake of waiters.splice(0)) wake();
+              };
+            },
+          }
+        : {}),
+    });
+
+    return { ioFor: io, calls, maxConcurrentSetups: () => maxSetups };
+  }
+
+  it("serializes two concurrent revalidations — the loser gets a cache hit, not a failure", async () => {
+    const shared = sharedBaselineIO({ serialize: true });
+    const a = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", shared.ioFor());
+    const b = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", shared.ioFor());
+
+    const [ra, rb] = await Promise.all([
+      a.pnpm(["pnpm", "-C", BRANCH, "test"]),
+      b.pnpm(["pnpm", "-C", BRANCH, "test"]),
+    ]);
+
+    // Neither revalidation is blocked — this is the whole point of the fix.
+    expect(ra.code).toBe(0);
+    expect(rb.code).toBe(0);
+    // Only ONE manager materialised: the waiter re-checked the cache under the
+    // lock, found the freshly-installed worktree, and skipped add + install.
+    expect(shared.calls.filter((c) => c.op === "add")).toHaveLength(1);
+    expect(shared.calls.filter((c) => c.op === "install")).toHaveLength(1);
+    expect(shared.maxConcurrentSetups()).toBe(1);
+    // Both still ran their check against the shared baseline.
+    expect(shared.calls.filter((c) => c.op === "script" && c.dest === DEST)).toHaveLength(2);
+  });
+
+  it("without the lock the two setups collide on one directory — the regression this guards", async () => {
+    // Same fixture, serialization removed. The loser's add is refused
+    // ("already exists"), it force-removes the winner's half-installed
+    // worktree, and both processes end up materialising the same directory at
+    // once — the corruption that surfaced as `setup failed for main`.
+    const shared = sharedBaselineIO({ serialize: false });
+    const a = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", shared.ioFor());
+    const b = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", shared.ioFor());
+
+    await Promise.all([
+      a.pnpm(["pnpm", "-C", BRANCH, "test"]),
+      b.pnpm(["pnpm", "-C", BRANCH, "test"]),
+    ]);
+
+    // Two adds and two installs against ONE path, overlapping in time, plus the
+    // loser ripping out the winner's checkout mid-install.
+    expect(shared.calls.filter((c) => c.op === "add").length).toBeGreaterThan(1);
+    expect(shared.calls.filter((c) => c.op === "remove").length).toBeGreaterThan(0);
+    expect(shared.maxConcurrentSetups()).toBe(2);
+  });
+
+  it("retries a contended setup instead of latching the whole session as blocked", async () => {
+    // First materialise attempt fails (a collision); the next validation call
+    // must try again rather than short-circuit to code 1 for the rest of the
+    // ~25-minute cycle.
+    let attempt = 0;
+    const shas: Record<string, string> = {};
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async (_ctx, dest) => {
+        attempt += 1;
+        if (attempt === 1) return { ok: false, stderr: "fatal: unable to lock ref" };
+        shas[dest] = SHA;
+        return { ok: true, stderr: "" };
+      },
+      worktreeRemove: async () => {},
+      pnpm: async () => ({ code: 0, stdout: "", stderr: "" }),
+      exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+      branchHead: async (_ctx, branch) => (branch === BRANCH ? SHA : null),
+      worktreeHead: async (_ctx, dest) => shas[dest] ?? null,
+      rebase: async () => ({ ok: true }),
+    };
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    const first = await fb.pnpm(["pnpm", "-C", BRANCH, "test"]);
+    const second = await fb.pnpm(["pnpm", "-C", BRANCH, "build"]);
+
+    expect(first.code).toBe(1);
+    expect(second.code).toBe(0);
+    expect(attempt).toBe(2);
+  });
+
+  it("latches after three consecutive failures so a truly broken baseline stops retrying", async () => {
+    let adds = 0;
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async () => {
+        adds += 1;
+        return { ok: false, stderr: "fatal: couldn't find remote ref refs/heads/main" };
+      },
+      worktreeRemove: async () => {},
+      pnpm: async () => ({ code: 0, stdout: "", stderr: "" }),
+      exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+      branchHead: async () => null,
+      worktreeHead: async () => null,
+      rebase: async () => ({ ok: true }),
+    };
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    for (let i = 0; i < 5; i++) {
+      expect((await fb.pnpm(["pnpm", "-C", BRANCH, "test"])).code).toBe(1);
+    }
+    // Three attempts, then the branch is latched — no unbounded retry storm.
+    expect(adds).toBe(3);
+  });
+
+  it("shares one materialise across concurrent calls in the same process", async () => {
+    const shared = sharedBaselineIO({ serialize: true });
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", shared.ioFor());
+
+    await Promise.all([
+      fb.pnpm(["pnpm", "-C", BRANCH, "test"]),
+      fb.pnpm(["pnpm", "-C", BRANCH, "build"]),
+      fb.backpressure({ command: "pnpm test", cwd: BRANCH, timeoutMs: 1000 }),
+    ]);
+
+    expect(shared.calls.filter((c) => c.op === "add")).toHaveLength(1);
+    expect(shared.calls.filter((c) => c.op === "install")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2437. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2437

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787280823&installation_model_id=20659&pr_number=2440&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2440&signature=c79f6d8d28e83875754914759541728fd3ac9fa31b0c3a4e7b7c2c3c972eb6d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->