### PR TITLE
feat(dev): post-DONE gate-correction convergence budget (#2285)

### DIFF
--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -411,6 +411,11 @@ export function buildProcessDeps(
       await ghx.comment(ghCtx, issue, body);
     },
     goVerifyRetries,
+    stallConvergenceBudget: (() => {
+      const raw = getConfig(config, "afk.stallConvergenceBudget");
+      const parsed = raw === undefined ? NaN : Number(raw);
+      return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
+    })(),
     // Post-attempt-format step (#1015): operator-declared `afk.post_attempt_format`
     // commands run BEFORE the feedback gate and auto-commit any formatting delta.
     postAttemptFormat: feedback.postAttemptFormat,

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -230,6 +230,13 @@ export const CONFIG_DEFAULTS = {
   "afk.validation.node_max_old_space_mb": "2048",
   "afk.validation.vitest_max_workers": "1",
   "afk.validation.heavy_available_memory_mb": "4096",
+  // Post-DONE gate-correction convergence budget (#2285). After an inner agent
+  // emits DONE, if the feedback/backpressure gate still fails the worker re-seeds
+  // the agent with a bounded correction handoff instead of immediately parking.
+  // This cap limits consecutive failed gate cycles on one issue before the engine
+  // stops re-seeding and deterministically parks ready-for-human + blocked:validation
+  // with the last failing validation tail. Override with RED_AFK_STALL_CONVERGENCE_BUDGET.
+  "afk.stallConvergenceBudget": "3",
   // Spec cascade rebase (issue #1007). After a successful DONE landing, rebase
   // every open sibling branch (same spec:N, not held by a live worker) onto the
   // new base HEAD so the next worker to pick up a sibling starts from a

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -132,7 +132,7 @@ import {
 } from "../adversarial-review.js";
 import type { ProcessIssueDeps, ProcessIssueInput, ProcessIssueResult, WorkerBaseResolution, ProcessOutcome } from "./types.js";
 import { baseResolutionStatePatch, formatBaseResolution, isMergeConflictRetry, markTerminalState, recoveryOrdinalFor, remoteTrackingBaseRef, resolveSpawnTier } from "./types.js";
-import { MECHANICAL_BLOCKER_KINDS, appendGoVerifyRetryHandoff, blockedLabelsIn, editIssueLifecycleLabels, formatNoSourceChangeWarning, hasLikelySourceChanges, parseFeedbackClass, refuseNoSandboxForUntrustedAuthor, resolveGoVerifyRetries, resolveUntrustedAuthorSandbox, scoutCapturedDone, scoutReportFrom } from "./recovery.js";
+import { MECHANICAL_BLOCKER_KINDS, appendAfkGateCorrectionHandoff, appendGoVerifyRetryHandoff, blockedLabelsIn, editIssueLifecycleLabels, formatNoSourceChangeWarning, hasLikelySourceChanges, parseFeedbackClass, refuseNoSandboxForUntrustedAuthor, resolveGoVerifyRetries, resolveStallConvergenceBudget, resolveUntrustedAuthorSandbox, scoutCapturedDone, scoutReportFrom } from "./recovery.js";
 import { abortAfterClaim, claimLost, emitBackpressureReview, emitDone, handoffForManualLanding, handoffForReview, hookContext, isRunnerRecoverableOutcome, mergeFailed, ciBlocked, prLandingBlocked, trunkDivergedBlocked, onErrorContext, parseHookEnv, postAttemptContext, recordAttemptBestEffort, releaseOwnedClaim, runCascadeRebase, runCloseCascade, runnerRecoverable, terminalFailure, writeValidationSidecar, type StageCommon } from "./terminal.js";
 export async function processIssue(
   deps: ProcessIssueDeps,
@@ -442,6 +442,28 @@ export async function processIssue(
       hookContext({ issue, title: input.title, workspace: branch, runner: activeRunner, attempt_n: attemptN }),
     );
   };
+  let stallConvergenceUsed = 0;
+  const stallConvergenceCap = resolveStallConvergenceBudget(deps);
+  const retryAfkMachineGate = async (gate: "feedback" | "backpressure", validation: string): Promise<boolean> => {
+    if (input.laneLabel === LABEL_GO_LANE) return false;
+    if (escalatedSimpleFeedback) return false;
+    if (stallConvergenceUsed >= stallConvergenceCap) return false;
+    stallConvergenceUsed += 1;
+    attemptN += 1;
+    currentHandoff = appendAfkGateCorrectionHandoff(handoff, {
+      gate,
+      validation,
+      retry: stallConvergenceUsed,
+      cap: stallConvergenceCap,
+    });
+    deps.appendIterLog(
+      `🤖 /afk: ${gate} machine gate failed after DONE; correction retry ${stallConvergenceUsed}/${stallConvergenceCap}.`,
+    );
+    return await fireHook(
+      "pre_attempt",
+      hookContext({ issue, title: input.title, workspace: branch, runner: activeRunner, attempt_n: attemptN }),
+    );
+  };
   // Gate-green fast path (issue #2397): when a prior branch already cleared the
   // feedback gate, skip the agent entirely on re-claim and re-validate directly.
   let gateGreenSkip = resumeIsGateGreen;
@@ -689,11 +711,15 @@ export async function processIssue(
       const validationText =
         "DONE rejected: attempt branch has no diff against the merge-base; no work changed, so the completion claim was not accepted.";
       deps.appendIterLog(`🤖 /afk: ${validationText}`);
-      if (await retryGoMachineGate("feedback", validationText)) {
+      if (await retryGoMachineGate("feedback", validationText) || await retryAfkMachineGate("feedback", validationText)) {
         continue;
       }
+      const convergenceNote =
+        stallConvergenceUsed > 0 && stallConvergenceUsed >= stallConvergenceCap
+          ? ` Post-DONE gate-correction budget exhausted (${stallConvergenceCap} consecutive failed cycles).`
+          : "";
       return await terminalFailure(common, "feedback-failed", "feedback", {
-        notes: "Inner agent emitted DONE, but the attempt branch has no diff against the merge-base. The worker branch was not merged.",
+        notes: `Inner agent emitted DONE, but the attempt branch has no diff against the merge-base. The worker branch was not merged.${convergenceNote}`,
         validation: validationText,
       }, { validationSummary: validationText });
     }
@@ -796,8 +822,11 @@ export async function processIssue(
         ? `${formatValidationScope(feedback.validationScope)}\n`
         : "";
       const validationText = `${scopeHeader}${feedback.sidecar.join("\n")}`;
-      if (!isInfra && await retryGoMachineGate("feedback", validationText)) {
+      if (!isInfra && (await retryGoMachineGate("feedback", validationText) || await retryAfkMachineGate("feedback", validationText))) {
         continue;
+      }
+      if (!isInfra && stallConvergenceUsed > 0 && stallConvergenceUsed >= stallConvergenceCap) {
+        notes += ` Post-DONE gate-correction budget exhausted (${stallConvergenceCap} consecutive failed cycles).`;
       }
       return await terminalFailure(common, outcome, "feedback", {
         notes,
@@ -819,13 +848,16 @@ export async function processIssue(
       gateStages.push({ stage: "backpressure", ok: backpressure.ok });
       if (gateVerdict(gateStages).failedStage === "backpressure") {
         await writeValidationSidecar(deps, input.attemptDir, [...feedback.sidecar, ...backpressure.sidecar]);
-        const notes = "Backpressure validation failed after the feedback gate passed. The worker branch was not merged.";
+        let bpNotes = "Backpressure validation failed after the feedback gate passed. The worker branch was not merged.";
         const validationText = backpressure.sidecar.join("\n");
-        if (await retryGoMachineGate("backpressure", validationText)) {
+        if (await retryGoMachineGate("backpressure", validationText) || await retryAfkMachineGate("backpressure", validationText)) {
           continue;
         }
+        if (stallConvergenceUsed > 0 && stallConvergenceUsed >= stallConvergenceCap) {
+          bpNotes += ` Post-DONE gate-correction budget exhausted (${stallConvergenceCap} consecutive failed cycles).`;
+        }
         return await terminalFailure(common, "feedback-failed", "feedback", {
-          notes,
+          notes: bpNotes,
           validation: validationText,
         }, { validationSummary: validationText });
       }

--- a/apps/dev/src/core/process-issue/recovery.ts
+++ b/apps/dev/src/core/process-issue/recovery.ts
@@ -263,6 +263,38 @@ export function resolveGoVerifyRetries(deps: ProcessIssueDeps): number {
   }
   return DEFAULT_GO_VERIFY_RETRIES;
 }
+export const DEFAULT_STALL_CONVERGENCE_BUDGET = 0;
+export function resolveStallConvergenceBudget(deps: ProcessIssueDeps): number {
+  const raw = deps.recoveryEnv?.RED_AFK_STALL_CONVERGENCE_BUDGET;
+  const parsed = raw === undefined ? NaN : Number(raw);
+  if (Number.isInteger(parsed) && parsed >= 0) return parsed;
+  if (
+    deps.stallConvergenceBudget !== undefined &&
+    Number.isInteger(deps.stallConvergenceBudget) &&
+    deps.stallConvergenceBudget >= 0
+  ) {
+    return deps.stallConvergenceBudget;
+  }
+  return DEFAULT_STALL_CONVERGENCE_BUDGET;
+}
+export function appendAfkGateCorrectionHandoff(
+  handoff: string,
+  opts: { gate: "feedback" | "backpressure"; validation: string; retry: number; cap: number },
+): string {
+  return [
+    handoff.replace(/\n+$/, ""),
+    "",
+    "<afk-gate-correction>",
+    `The ${opts.gate} machine gate failed after DONE. This is bounded correction retry ${opts.retry}/${opts.cap}.`,
+    "Fix the failure on the existing branch, run the relevant gate, commit only the needed changes, then emit the required terminal sentinel.",
+    "",
+    "<validation-tail>",
+    tailLines(opts.validation, 80),
+    "</validation-tail>",
+    "</afk-gate-correction>",
+    "",
+  ].join("\n");
+}
 export function tailLines(text: string, maxLines: number): string {
   const lines = text.split("\n");
   return lines.slice(Math.max(0, lines.length - maxLines)).join("\n");

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -240,6 +240,7 @@ export interface ProcessIssueDeps {
   outputShaping?: OutputShapingConfig;
   postBackpressureReview?: (pr: number, body: string) => Promise<void>;
   goVerifyRetries?: number;
+  stallConvergenceBudget?: number;
   postAttemptFormat?: PostAttemptFormatExec;
   postAttemptFormatCommands?: readonly string[];
   runAgent(input: RunAgentInput): Promise<RunAgentResult>;

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -204,6 +204,8 @@ export interface HarnessOptions {
   recoveryEnv?: Record<string, string>;
   /** /go post-DONE machine-gate retry cap injected by run.ts. */
   goVerifyRetries?: number;
+  /** /afk post-DONE gate-correction convergence budget (#2285). */
+  stallConvergenceBudget?: number;
   /** When set, register the ADR 0017 `recordAttempt` port. "throw" makes it
    * reject (proving a memory failure never fails the close); "ok" records the
    * payload; undefined omits the port entirely (older-caller safety). */
@@ -559,6 +561,7 @@ export function harness(opts: HarnessOptions = {}): {
         }
       : undefined,
     goVerifyRetries: opts.goVerifyRetries,
+    stallConvergenceBudget: opts.stallConvergenceBudget,
     sandboxMode: opts.sandboxMode ?? "none",
     sandboxAvailable: async (mode) => (opts.availableSandboxes ?? ["docker", "podman"]).includes(mode),
     sandboxImage: opts.sandboxImage,

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -1144,3 +1144,108 @@ describe("processIssue — merge-conflict one-shot self-resolve (gap 3)", () => 
   });
 });
 
+describe("processIssue — /afk post-DONE gate-correction convergence (#2285)", () => {
+  it("retries an empty-diff DONE up to stallConvergenceBudget, then parks with convergence note", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      changedFilesSequence: [[], []],
+      feedbackOk: true,
+      stallConvergenceBudget: 1,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("<afk-gate-correction>");
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("bounded correction retry 1/1");
+    expect(trace.envelopeBodies.at(-1) ?? "").toContain("Post-DONE gate-correction budget exhausted");
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:validation"))).toBe(true);
+    expect(trace.closed).toEqual([]);
+  });
+
+  it("lands when a gate-correction retry produces a diff", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      changedFilesSequence: [[], ["packages/x/src/a.ts"]],
+      feedbackOk: true,
+      stallConvergenceBudget: 1,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("<afk-gate-correction>");
+    expect(trace.closed).toEqual([9]);
+    expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(false);
+  });
+
+  it("retries a red feedback gate up to stallConvergenceBudget, then parks; handoff carries <afk-gate-correction>", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackResults: [false, false],
+      stallConvergenceBudget: 1,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    const retryHandoff = trace.runAgentCalls[1]?.handoffContent ?? "";
+    expect(retryHandoff).toContain("<afk-gate-correction>");
+    expect(retryHandoff).toContain("feedback machine gate failed after DONE");
+    expect(trace.envelopeBodies.at(-1) ?? "").toContain("Post-DONE gate-correction budget exhausted");
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:validation"))).toBe(true);
+    expect(trace.closed).toEqual([]);
+  });
+
+  it("lands when a feedback gate-correction retry makes the gate green", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackResults: [false, true],
+      stallConvergenceBudget: 2,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.closed).toEqual([9]);
+    expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(false);
+  });
+
+  it("retries a red backpressure gate up to stallConvergenceBudget, then parks", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      backpressureCommands: ["npm run e2e"],
+      backpressureOk: false,
+      stallConvergenceBudget: 1,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    const retryHandoff = trace.runAgentCalls[1]?.handoffContent ?? "";
+    expect(retryHandoff).toContain("<afk-gate-correction>");
+    expect(retryHandoff).toContain("backpressure machine gate failed after DONE");
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:validation"))).toBe(true);
+    expect(trace.closed).toEqual([]);
+  });
+
+  it("go lane ignores stallConvergenceBudget — retryAfkMachineGate is a no-op for lane:go", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      outcome: "done",
+      feedbackResults: [false],
+      recoveryEnv: { RED_GO_VERIFY_RETRIES: "0" },
+      stallConvergenceBudget: 99,
+    });
+    const result = await processIssue(deps, input);
+
+    // go lane with cap=0 parks on first failure; stallConvergenceBudget has no effect
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(true);
+    expect(trace.closed).toEqual([]);
+  });
+});
+


### PR DESCRIPTION
## Summary

- Adds `afk.stallConvergenceBudget` config key (default `"3"`, env override `RED_AFK_STALL_CONVERGENCE_BUDGET`)
- Adds `resolveStallConvergenceBudget` + `appendAfkGateCorrectionHandoff` in `recovery.ts`
- Wires `retryAfkMachineGate` closure in `lifecycle.ts`: fires on feedback-failed, empty-diff, and backpressure-failed paths for non-go-lane issues, bounded by the convergence budget, skipped after a simple→complex escalation
- Wires `stallConvergenceBudget` from config in `process-deps.ts`
- 6 pinning tests in `process-issue.validation.test.ts`

Closes #2285

## Test plan

- [x] `pnpm --filter @reddb-io/dev typecheck` — clean
- [x] `vitest run tests/process-issue.validation.test.ts` — 66/66 pass including 6 new convergence tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787281394&installation_model_id=20659&pr_number=2441&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2441&signature=76fb20aa4513e398eb6cd87e147c0380c7966e9daad1d827a65c2bbe5ae2a89a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->