### PR TITLE
fix: #2442 Fleet supervisor dies silently at drain steady-state and self-heal never respawns it

### DIFF
--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -25,6 +25,7 @@ import { routeModelTierCommand } from "./commands/route-model-tier.js";
 import { rspInstructionsCommand } from "./commands/rsp-instructions.js";
 import { statuslineCommand, statuslineRefreshCountsCommand } from "./commands/statusline.js";
 import { superviseCommand } from "./commands/supervise.js";
+import { supervisorWatchdogCommand } from "./commands/supervisor-watchdog.js";
 import { triageCommand } from "./commands/triage.js";
 import { toonBumpCommand } from "./commands/toon-bump.js";
 import { toonMigrateCommand } from "./commands/toon-migrate.js";
@@ -63,7 +64,8 @@ export type CliCommand =
   | "toon-bump"
   | "toon-migrate"
   | "version"
-  | "__supervise";
+  | "__supervise"
+  | "__watchdog";
 
 export interface ParsedCli {
   command: CliCommand;
@@ -113,6 +115,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     "toon-migrate": {},
     version: {},
     __supervise: {},
+    __watchdog: {},
   },
   default: "run",
   keepArgvOnDefault: true,
@@ -170,6 +173,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "toon-bump") return toonBumpCommand(parsed.args);
   if (parsed.command === "toon-migrate") return toonMigrateCommand(parsed.args);
   if (parsed.command === "__supervise") return superviseCommand(parsed.args);
+  if (parsed.command === "__watchdog") return supervisorWatchdogCommand(parsed.args);
   return runCommand({ args: parsed.args });
 }
 

--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -19,6 +19,7 @@ import { classifySupervisor, resolveSupervisorConfig, type ElasticShrinkMode } f
 import { teardownWedgedSupervisor } from "../core/watchdog.js";
 import { buildWatchdogIO } from "../runtime/watchdog-io.js";
 import { spawnSupervisor } from "../runtime/supervisor-spawn.js";
+import { spawnSupervisorWatchdog } from "../runtime/supervisor-watchdog-spawn.js";
 import { isLivePid, killTreeAndWait } from "../runtime/kill-tree.js";
 import { discoverLiveSupervisorPid, reapStaleSupervisorState } from "../runtime/supervisor-state.js";
 import { parseFleetFlag, DEFAULT_FLEET_NAME } from "../core/fleet-name.js";
@@ -642,6 +643,10 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     }
     throw new Error(`fleet launch failed: supervisor pid file did not appear. log: .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n${tail}`);
   }
+  const watchdogPid = await spawnSupervisorWatchdog({ root, fleet: paths.fleet });
+  if (!watchdogPid) {
+    throw new Error("fleet launch failed: supervisor self-heal watchdog did not arm");
+  }
 
   // Persist the profile so CLI-launched fleets are always in the registry (#2358).
   await upsertFleetProfile(fleetRegistryPath(createEnginePaths(join(root, ".red"))), {
@@ -654,6 +659,7 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
 
   const named = paths.fleet === DEFAULT_FLEET_NAME ? "" : ` --fleet ${paths.fleet}`;
   stdout.write(`🚀 fleet ${paths.fleet} launched (supervisor pid=${supervisorPid}, target=${parsed.target})\n`);
+  stdout.write(`   self-heal: armed (watchdog pid=${watchdogPid})\n`);
   stdout.write(`   log:   .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n`);
   stdout.write(`   stop:  /dev:afk fleet stop${named}\n`);
   stdout.write(`   monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl manually.\n`);

--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -171,7 +171,7 @@ export async function stopFleet(
   // path must sweep them — otherwise a "stopped" report is a lie while orphaned
   // workers keep claiming, committing, and merging. Reuse the watchdog's
   // detached-worker killer + claim reconcile so no issue is stranded in `running`.
-  const io = buildWatchdogIO(root, stdout);
+  const io = buildWatchdogIO(root, stdout, paths.fleet);
   const sweepOrphans = async (): Promise<void> => {
     const killed = await io.killWorkers();
     if (killed > 0) {
@@ -485,7 +485,7 @@ export async function statusFleet(
   fleetName?: string,
 ): Promise<FleetStatusResult> {
   const paths = afkPaths(root, fleetName);
-  const io = buildWatchdogIO(root, stdout);
+  const io = buildWatchdogIO(root, stdout, paths.fleet);
   const liveness = await io.liveness();
   const liveSupervisor = await discoverLiveSupervisorPid(paths.supervisorRuntimeDir, isLivePid, { fleet: paths.fleet });
   if (liveSupervisor) {
@@ -582,7 +582,7 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     // wedged supervisor down and fall through to a clean relaunch. A FRESH
     // heartbeat still refuses the launch, exactly as before.
     const cfg = resolveSupervisorConfig();
-    const io = buildWatchdogIO(root, stdout);
+    const io = buildWatchdogIO(root, stdout, paths.fleet);
     const liveness = await io.liveness();
     const health = classifySupervisor(liveness, io.now(), cfg.supervisorStaleS, cfg.progressStaleS);
     if (health !== "quiescent") {

--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -586,6 +586,10 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     const liveness = await io.liveness();
     const health = classifySupervisor(liveness, io.now(), cfg.supervisorStaleS, cfg.progressStaleS);
     if (health !== "quiescent") {
+      const watchdogPid = await spawnSupervisorWatchdog({ root, fleet: paths.fleet });
+      if (!watchdogPid) {
+        throw new Error("fleet launch failed: supervisor self-heal watchdog did not arm");
+      }
       const shrinkMode = parsed.shrinkMode ?? cfg.shrinkMode;
       const directiveRunner = parsed.runnerFlag ? detectRunner({ flag: parsed.runnerFlag }).runner : undefined;
       await writeResizeRequest(paths.supervisorResizePath, parsed.target, shrinkMode, directiveRunner);
@@ -645,6 +649,9 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
   }
   const watchdogPid = await spawnSupervisorWatchdog({ root, fleet: paths.fleet });
   if (!watchdogPid) {
+    await killTreeAndWait(supervisorPid).catch(() => false);
+    await rm(paths.supervisorPidPath, { force: true }).catch(() => undefined);
+    await rm(paths.supervisorPidStartPath, { force: true }).catch(() => undefined);
     throw new Error("fleet launch failed: supervisor self-heal watchdog did not arm");
   }
 

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -7,7 +7,7 @@
 // native — no bash anywhere in the loop.
 
 import { spawn } from "node:child_process";
-import { existsSync, openSync, closeSync, readFileSync, writeFileSync, rmSync, renameSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, openSync, closeSync, readFileSync, writeFileSync, rmSync, renameSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { readBuildInfo } from "@reddb-io/build-info";
 import {
@@ -62,6 +62,9 @@ import {
 } from "@reddb-io/red-castle/engine";
 import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 import { resolveFleetFromArgs, FLEET_NAME_ENV } from "../core/fleet-name.js";
+import { createSupervisorExitRecorder } from "../core/supervisor-exit.js";
+import { readPidStartTime } from "../core/state.js";
+import { encodeLines, type ToonlRecord } from "@reddb-io/toon";
 
 function isAlive(pid: number): boolean {
   try {
@@ -915,6 +918,7 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
     }
   }
   writeFileSync(pidFile, String(process.pid), "utf8");
+  writeFileSync(paths.supervisorPidStartPath, readPidStartTime(process.pid) ?? "", "utf8");
   // clear any stale stop file
   if (existsSync(stopFile)) rmSync(stopFile, { force: true });
   rmSync(paths.supervisorResizePath, { force: true });
@@ -938,6 +942,42 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   };
   const deps = buildSupervisorDeps(root, tmp, slotLogsDir, firehoseFile, stateFile, supervisorId, fleet, config.runner, ghCtx, trunk, slotArgs, hookEnvBase, adoptSlotPids);
 
+  const exitWriter = createCastleLaneWriters(
+    createEnginePaths(join(root, ".red")),
+  ).supervisor(join(fleet, supervisorId));
+  const exitRecorder = createSupervisorExitRecorder({
+    supervisorId,
+    append: async (record) => {
+      await exitWriter.append(record);
+    },
+    appendSync: (record) => {
+      try {
+        mkdirSync(dirname(exitWriter.path), { recursive: true });
+        const row: ToonlRecord = {
+          at: new Date().toISOString(),
+          kind: record.kind,
+          supervisor_id: supervisorId,
+          payload: JSON.stringify(record.payload ?? {}),
+        };
+        appendFileSync(exitWriter.path, encodeLines().push(row), "utf8");
+      } catch {
+        // a process-exit fallback is necessarily best-effort.
+      }
+    },
+  });
+  const onProcessExit = (code: number): void => {
+    exitRecorder.recordSync("process-exit", { code });
+  };
+  const onUncaughtException = (error: Error, origin: NodeJS.UncaughtExceptionOrigin): void => {
+    exitRecorder.recordSync("exception", {
+      name: error.name,
+      message: error.message,
+      origin,
+    });
+  };
+  process.once("exit", onProcessExit);
+  process.once("uncaughtExceptionMonitor", onUncaughtException);
+
   const stopRequested = (): boolean => existsSync(stopFile);
 
   // A bare `kill <supervisor-pid>` (SIGTERM/SIGINT) must not orphan the detached
@@ -947,28 +987,42 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   // every live slot (SIGTERM→grace→SIGKILL→confirm via terminateAll), clean the
   // control files, then exit with the conventional 128+signal code.
   let shuttingDown = false;
-  const onSignal = (signal: "SIGTERM" | "SIGINT"): void => {
+  const onSignal = (signal: "SIGTERM" | "SIGINT" | "SIGHUP"): void => {
     if (shuttingDown) return;
     shuttingDown = true;
     void (async () => {
+      await exitRecorder.record("signal", { signal });
       try {
         await terminateAll(state, deps);
       } catch {
         // best-effort — still clean control files and exit.
       }
-      rmSync(pidFile, { force: true });
-      rmSync(stopFile, { force: true });
-      process.exit(signal === "SIGINT" ? 130 : 143);
+      process.exit(signal === "SIGINT" ? 130 : signal === "SIGHUP" ? 129 : 143);
     })();
   };
   process.once("SIGTERM", () => onSignal("SIGTERM"));
   process.once("SIGINT", () => onSignal("SIGINT"));
+  process.once("SIGHUP", () => onSignal("SIGHUP"));
 
+  let completed = false;
   try {
     await runSupervisor(state, deps, config, stopRequested);
+    completed = true;
+    await exitRecorder.record(stopRequested() ? "explicit-stop" : "completed");
+  } catch (error) {
+    await exitRecorder.record("exception", {
+      name: error instanceof Error ? error.name : "Error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
   } finally {
-    rmSync(pidFile, { force: true });
-    rmSync(stopFile, { force: true });
+    process.removeListener("exit", onProcessExit);
+    process.removeListener("uncaughtExceptionMonitor", onUncaughtException);
+    if (completed) {
+      rmSync(pidFile, { force: true });
+      rmSync(paths.supervisorPidStartPath, { force: true });
+      rmSync(stopFile, { force: true });
+    }
   }
   return 0;
 }

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -21,6 +21,7 @@ import {
   terminateAll,
   type SpawnPolicy,
   type SupervisorDeps,
+  type SupervisorState,
 } from "../core/supervisor.js";
 import { appendRecordToonlRow } from "../core/jsonl-log.js";
 import {
@@ -902,46 +903,21 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
       ? []
       : ((await readFleetState(stateFile).catch(() => null))?.slotPids ?? []);
   const adoptSlotPids = envAdoptSlotPids.length > 0 ? envAdoptSlotPids : stateAdoptSlotPids;
-  await reapStaleSupervisorState(stateAfk, isAlive);
+  const priorSupervisor = await reapStaleSupervisorState(stateAfk, isAlive);
   // One supervisor PER NAMED FLEET. The lock is the fleet's own pid file inside
   // `supervisors/<fleet>/`, so a second `alpha` supervisor is refused while
   // `beta` boots freely alongside it.
-  if (existsSync(pidFile)) {
-    try {
-      const prev = Number(require("node:fs").readFileSync(pidFile, "utf8").trim());
-      if (prev && isAlive(prev)) {
-        process.stderr.write(`supervisor already running for fleet ${fleet} (pid=${prev})\n`);
-        return 1;
-      }
-    } catch {
-      // stale — overwrite
-    }
+  if (priorSupervisor.status === "live") {
+    process.stderr.write(
+      `supervisor already running for fleet ${fleet} (pid=${priorSupervisor.pid})\n`,
+    );
+    return 1;
   }
+  const ownStartTime = readPidStartTime(process.pid);
+  if (ownStartTime === null) throw new Error("cannot pin supervisor process start time");
+  writeFileSync(paths.supervisorPidStartPath, ownStartTime, "utf8");
   writeFileSync(pidFile, String(process.pid), "utf8");
-  writeFileSync(paths.supervisorPidStartPath, readPidStartTime(process.pid) ?? "", "utf8");
-  // clear any stale stop file
-  if (existsSync(stopFile)) rmSync(stopFile, { force: true });
-  rmSync(paths.supervisorResizePath, { force: true });
-
-  const values = loadConfig(paths.configPath, { warn: () => undefined });
-  const config = resolveSupervisorConfig(process.env, (key) => getConfig(values, key));
-  const state = initSupervisorState(config.target);
-  const repo = await resolveRepoSlug(root).catch(() => "");
-  const trunk = getConfig(values, "dev.trunk") || "main";
-  const ghCtx = { cwd: root, repo };
   const supervisorId = `s${process.pid}`;
-  // The filter/policy flags fleet.ts forwarded (--spec/--issues/--alternate/
-  // --fallback-runner/--request), threaded into every slot's `run --once`.
-  const slotArgs = slotFilterArgs(args);
-  // Base env for fleet hooks: RED_AFK_REPO, RED_AFK_ROOT, RED_AFK_RUNNER.
-  const hookEnvBase: Record<string, string> = {
-    RED_AFK_ROOT: root,
-    RED_AFK_WORKSPACE: root,
-    RED_AFK_RUNNER: config.runner,
-    ...(repo.length > 0 ? { RED_AFK_REPO: repo } : {}),
-  };
-  const deps = buildSupervisorDeps(root, tmp, slotLogsDir, firehoseFile, stateFile, supervisorId, fleet, config.runner, ghCtx, trunk, slotArgs, hookEnvBase, adoptSlotPids);
-
   const exitWriter = createCastleLaneWriters(
     createEnginePaths(join(root, ".red")),
   ).supervisor(join(fleet, supervisorId));
@@ -979,33 +955,66 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   process.once("uncaughtExceptionMonitor", onUncaughtException);
 
   const stopRequested = (): boolean => existsSync(stopFile);
-
-  // A bare `kill <supervisor-pid>` (SIGTERM/SIGINT) must not orphan the detached
-  // slot workers or leave the pid/stop control files behind (#2056). Without a
-  // handler the signal skips the `finally` below, stranding both. Translate the
-  // signal into the same clean shutdown the stop-file path performs: terminate
-  // every live slot (SIGTERM→grace→SIGKILL→confirm via terminateAll), clean the
-  // control files, then exit with the conventional 128+signal code.
+  let state: SupervisorState | undefined;
+  let deps: SupervisorDeps | undefined;
   let shuttingDown = false;
   const onSignal = (signal: "SIGTERM" | "SIGINT" | "SIGHUP"): void => {
     if (shuttingDown) return;
     shuttingDown = true;
     void (async () => {
       await exitRecorder.record("signal", { signal });
-      try {
-        await terminateAll(state, deps);
-      } catch {
-        // best-effort — still clean control files and exit.
+      if (state !== undefined && deps !== undefined) {
+        try {
+          await terminateAll(state, deps);
+        } catch {
+          // best-effort — still clean control files and exit.
+        }
       }
       process.exit(signal === "SIGINT" ? 130 : signal === "SIGHUP" ? 129 : 143);
     })();
   };
-  process.once("SIGTERM", () => onSignal("SIGTERM"));
-  process.once("SIGINT", () => onSignal("SIGINT"));
-  process.once("SIGHUP", () => onSignal("SIGHUP"));
+  const onSigterm = (): void => onSignal("SIGTERM");
+  const onSigint = (): void => onSignal("SIGINT");
+  const onSighup = (): void => onSignal("SIGHUP");
+  process.once("SIGTERM", onSigterm);
+  process.once("SIGINT", onSigint);
+  process.once("SIGHUP", onSighup);
 
   let completed = false;
   try {
+    // Everything after publishing the pinned identity is inside this lifecycle
+    // boundary, including configuration and dependency construction.
+    if (existsSync(stopFile)) rmSync(stopFile, { force: true });
+    rmSync(paths.supervisorResizePath, { force: true });
+
+    const values = loadConfig(paths.configPath, { warn: () => undefined });
+    const config = resolveSupervisorConfig(process.env, (key) => getConfig(values, key));
+    state = initSupervisorState(config.target);
+    const repo = await resolveRepoSlug(root).catch(() => "");
+    const trunk = getConfig(values, "dev.trunk") || "main";
+    const ghCtx = { cwd: root, repo };
+    const slotArgs = slotFilterArgs(args);
+    const hookEnvBase: Record<string, string> = {
+      RED_AFK_ROOT: root,
+      RED_AFK_WORKSPACE: root,
+      RED_AFK_RUNNER: config.runner,
+      ...(repo.length > 0 ? { RED_AFK_REPO: repo } : {}),
+    };
+    deps = buildSupervisorDeps(
+      root,
+      tmp,
+      slotLogsDir,
+      firehoseFile,
+      stateFile,
+      supervisorId,
+      fleet,
+      config.runner,
+      ghCtx,
+      trunk,
+      slotArgs,
+      hookEnvBase,
+      adoptSlotPids,
+    );
     await runSupervisor(state, deps, config, stopRequested);
     completed = true;
     await exitRecorder.record(stopRequested() ? "explicit-stop" : "completed");
@@ -1018,6 +1027,9 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   } finally {
     process.removeListener("exit", onProcessExit);
     process.removeListener("uncaughtExceptionMonitor", onUncaughtException);
+    process.removeListener("SIGTERM", onSigterm);
+    process.removeListener("SIGINT", onSigint);
+    process.removeListener("SIGHUP", onSighup);
     if (completed) {
       rmSync(pidFile, { force: true });
       rmSync(paths.supervisorPidStartPath, { force: true });

--- a/apps/dev/src/commands/supervisor-watchdog.ts
+++ b/apps/dev/src/commands/supervisor-watchdog.ts
@@ -1,22 +1,80 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { resolveSupervisorConfig } from "../core/supervisor.js";
 import { runSupervisorWatchdogLoop, runWatchdog } from "../core/watchdog.js";
 import { resolveFleetFromArgs } from "../core/fleet-name.js";
 import { afkPaths } from "../runtime/wire.js";
 import { buildWatchdogIO } from "../runtime/watchdog-io.js";
 import { isLivePid } from "../runtime/kill-tree.js";
+import { readPidStartTime } from "../core/state.js";
+import { isSupervisorIdentityLive, type SupervisorIdentity } from "../runtime/supervisor-state.js";
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-function recordedLivePid(path: string): number | null {
+function recordedIdentity(pidPath: string, startPath: string): SupervisorIdentity | null {
   try {
-    const raw = readFileSync(path, "utf8").trim();
+    const raw = readFileSync(pidPath, "utf8").trim();
     if (!/^[1-9][0-9]*$/.test(raw)) return null;
-    const pid = Number(raw);
-    return isLivePid(pid) ? pid : null;
+    return { pid: Number(raw), startTime: readFileSync(startPath, "utf8").trim() };
   } catch {
     return null;
   }
+}
+
+function recordedLivePid(pidPath: string, startPath: string): number | null {
+  const identity = recordedIdentity(pidPath, startPath);
+  return identity && isSupervisorIdentityLive(identity, isLivePid, readPidStartTime)
+    ? identity.pid
+    : null;
+}
+
+async function acquireWatchdogOwnership(paths: ReturnType<typeof afkPaths>): Promise<boolean> {
+  const ownStartTime = readPidStartTime(process.pid);
+  if (ownStartTime === null) return false;
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    try {
+      mkdirSync(paths.supervisorWatchdogLockPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      const lockPid = `${paths.supervisorWatchdogLockPath}/pid`;
+      const lockStart = `${paths.supervisorWatchdogLockPath}/pid.start`;
+      if (recordedLivePid(lockPid, lockStart) === null) {
+        const stale = `${paths.supervisorWatchdogLockPath}.stale-${process.pid}`;
+        try {
+          renameSync(paths.supervisorWatchdogLockPath, stale);
+          rmSync(stale, { recursive: true, force: true });
+        } catch {
+          // Another contender reclaimed the stale acquisition lane first.
+        }
+      } else {
+        await sleep(25);
+      }
+      continue;
+    }
+
+    try {
+      writeFileSync(`${paths.supervisorWatchdogLockPath}/pid.start`, ownStartTime, "utf8");
+      writeFileSync(`${paths.supervisorWatchdogLockPath}/pid`, String(process.pid), "utf8");
+      const existing = recordedLivePid(
+        paths.supervisorWatchdogPidPath,
+        paths.supervisorWatchdogPidStartPath,
+      );
+      if (existing !== null && existing !== process.pid) return false;
+      writeFileSync(paths.supervisorWatchdogPidStartPath, ownStartTime, "utf8");
+      writeFileSync(paths.supervisorWatchdogPidPath, String(process.pid), "utf8");
+      return true;
+    } finally {
+      rmSync(paths.supervisorWatchdogLockPath, { recursive: true, force: true });
+    }
+  }
+  return false;
 }
 
 /** Hidden, detached owner of the supervisor self-heal loop. */
@@ -26,9 +84,12 @@ export async function supervisorWatchdogCommand(
 ): Promise<number> {
   const fleet = resolveFleetFromArgs(args);
   const paths = afkPaths(cwd, fleet);
-  const existing = recordedLivePid(paths.supervisorWatchdogPidPath);
+  const existing = recordedLivePid(
+    paths.supervisorWatchdogPidPath,
+    paths.supervisorWatchdogPidStartPath,
+  );
   if (existing !== null && existing !== process.pid) return 0;
-  writeFileSync(paths.supervisorWatchdogPidPath, String(process.pid), "utf8");
+  if (!(await acquireWatchdogOwnership(paths))) return 1;
 
   const config = resolveSupervisorConfig();
   const io = buildWatchdogIO(cwd, process.stdout, fleet);
@@ -70,8 +131,12 @@ export async function supervisorWatchdogCommand(
     process.removeListener("SIGTERM", stop);
     process.removeListener("SIGINT", stop);
     process.removeListener("SIGHUP", stop);
-    if (recordedLivePid(paths.supervisorWatchdogPidPath) === process.pid) {
+    if (
+      recordedLivePid(paths.supervisorWatchdogPidPath, paths.supervisorWatchdogPidStartPath) ===
+      process.pid
+    ) {
       rmSync(paths.supervisorWatchdogPidPath, { force: true });
+      rmSync(paths.supervisorWatchdogPidStartPath, { force: true });
     }
   }
   return 0;

--- a/apps/dev/src/commands/supervisor-watchdog.ts
+++ b/apps/dev/src/commands/supervisor-watchdog.ts
@@ -1,0 +1,78 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolveSupervisorConfig } from "../core/supervisor.js";
+import { runSupervisorWatchdogLoop, runWatchdog } from "../core/watchdog.js";
+import { resolveFleetFromArgs } from "../core/fleet-name.js";
+import { afkPaths } from "../runtime/wire.js";
+import { buildWatchdogIO } from "../runtime/watchdog-io.js";
+import { isLivePid } from "../runtime/kill-tree.js";
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function recordedLivePid(path: string): number | null {
+  try {
+    const raw = readFileSync(path, "utf8").trim();
+    if (!/^[1-9][0-9]*$/.test(raw)) return null;
+    const pid = Number(raw);
+    return isLivePid(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Hidden, detached owner of the supervisor self-heal loop. */
+export async function supervisorWatchdogCommand(
+  args: string[],
+  cwd = process.cwd(),
+): Promise<number> {
+  const fleet = resolveFleetFromArgs(args);
+  const paths = afkPaths(cwd, fleet);
+  const existing = recordedLivePid(paths.supervisorWatchdogPidPath);
+  if (existing !== null && existing !== process.pid) return 0;
+  writeFileSync(paths.supervisorWatchdogPidPath, String(process.pid), "utf8");
+
+  const config = resolveSupervisorConfig();
+  const io = buildWatchdogIO(cwd);
+  let stopping = false;
+  const stop = (): void => {
+    stopping = true;
+  };
+  process.once("SIGTERM", stop);
+  process.once("SIGINT", stop);
+  process.once("SIGHUP", stop);
+
+  try {
+    await runSupervisorWatchdogLoop({
+      pollMs: config.pollIntervalS * 1000,
+      shouldStop: () => stopping,
+      sleep,
+      pass: async () => {
+        if (existsSync(paths.supervisorStopPath)) {
+          stopping = true;
+          return;
+        }
+        const result = await runWatchdog(
+          io,
+          config.supervisorStaleS,
+          config.progressStaleS,
+          {
+            maxRestarts: config.supervisorMaxRestarts,
+            windowS: config.supervisorRestartWindowS,
+          },
+        );
+        // A missing repo pid means the supervisor completed its explicit stop
+        // and cleaned its identity. A stale recorded pid stays non-null and is
+        // exactly the crash case the next pass must keep trying to recover.
+        if (result.health === "absent" && result.pid === null) stopping = true;
+        if (result.crashLoopSuppressed) stopping = true;
+      },
+    });
+  } finally {
+    process.removeListener("SIGTERM", stop);
+    process.removeListener("SIGINT", stop);
+    process.removeListener("SIGHUP", stop);
+    if (recordedLivePid(paths.supervisorWatchdogPidPath) === process.pid) {
+      rmSync(paths.supervisorWatchdogPidPath, { force: true });
+    }
+  }
+  return 0;
+}

--- a/apps/dev/src/commands/supervisor-watchdog.ts
+++ b/apps/dev/src/commands/supervisor-watchdog.ts
@@ -31,7 +31,7 @@ export async function supervisorWatchdogCommand(
   writeFileSync(paths.supervisorWatchdogPidPath, String(process.pid), "utf8");
 
   const config = resolveSupervisorConfig();
-  const io = buildWatchdogIO(cwd);
+  const io = buildWatchdogIO(cwd, process.stdout, fleet);
   let stopping = false;
   const stop = (): void => {
     stopping = true;

--- a/apps/dev/src/core/supervisor-exit.ts
+++ b/apps/dev/src/core/supervisor-exit.ts
@@ -1,0 +1,53 @@
+import type { CastleLaneRecord } from "@reddb-io/red-castle/engine";
+
+export type SupervisorExitReason =
+  | "signal"
+  | "exception"
+  | "explicit-stop"
+  | "completed"
+  | "process-exit";
+
+type SupervisorExitRecord = Omit<CastleLaneRecord, "at">;
+
+export interface SupervisorExitRecorderOptions {
+  supervisorId: string;
+  append(record: SupervisorExitRecord): Promise<void>;
+  appendSync(record: SupervisorExitRecord): void;
+}
+
+export interface SupervisorExitRecorder {
+  record(reason: SupervisorExitReason, detail?: Record<string, unknown>): Promise<void>;
+  recordSync(reason: SupervisorExitReason, detail?: Record<string, unknown>): void;
+}
+
+export function createSupervisorExitRecorder(
+  options: SupervisorExitRecorderOptions,
+): SupervisorExitRecorder {
+  let recorded = false;
+  const terminalRecord = (
+    reason: SupervisorExitReason,
+    detail: Record<string, unknown> = {},
+  ): SupervisorExitRecord => ({
+    kind: "supervisor.exit",
+    supervisor_id: options.supervisorId,
+    payload: { reason, ...detail },
+  });
+
+  return {
+    async record(reason, detail): Promise<void> {
+      if (recorded) return;
+      recorded = true;
+      const record = terminalRecord(reason, detail);
+      try {
+        await options.append(record);
+      } catch {
+        options.appendSync(record);
+      }
+    },
+    recordSync(reason, detail): void {
+      if (recorded) return;
+      recorded = true;
+      options.appendSync(terminalRecord(reason, detail));
+    },
+  };
+}

--- a/apps/dev/src/core/supervisor/config.ts
+++ b/apps/dev/src/core/supervisor/config.ts
@@ -63,7 +63,8 @@ export interface SupervisorConfig {
    * RED_AFK_SUPERVISOR_STALE_S — the EXTERNAL watchdog's quiescence threshold
    * (default 300). A supervisor whose #406 heartbeat has not advanced within this
    * many seconds is treated as hard-hung (alive PID, drain loop wedged) and
-   * recovered by an already-alive surface (fleet pre-check / monitor tick) — see
+   * recovered by the detached fleet watchdog (with fleet pre-check / opt-in
+   * monitor tick as secondary surfaces) — see
    * watchdog.ts + classifySupervisor. This is the recovery half of the
    * unwedgeable-loop work: tickTimeoutS keeps a SINGLE tick from freezing the
    * loop; this knob catches the case where the whole process is hung below the
@@ -113,8 +114,8 @@ export interface SupervisorConfig {
    * RED_AFK_SUPERVISOR_MAX_RESTARTS — crash-loop bound for the dead-supervisor
    * watchdog (#1097, default 5). When a supervisor is found DEAD (its pid file
    * points to a no-longer-alive process) with a non-empty `ready-for-agent` queue
-   * and live workers below target, an already-alive surface (the monitor tick)
-   * respawns the fleet and records the restart epoch. Once this many restarts land
+   * and live workers below target, the detached fleet watchdog respawns the
+   * fleet and records the restart epoch. Once this many restarts land
    * inside `supervisorRestartWindowS` the watchdog STOPS respawning and surfaces
    * the crash loop instead of hiding it behind an endless respawn. 0 / non-numeric
    * falls back to the default so a typo can never disable the bound (and never

--- a/apps/dev/src/core/watchdog.ts
+++ b/apps/dev/src/core/watchdog.ts
@@ -41,8 +41,9 @@ export interface WatchdogIO {
    * in `running` across the restart (reuse the trip-sweep / reap cleanup). */
   reconcile(): Promise<void>;
   /** Spawn a fresh `__supervise` and stamp a fresh heartbeat so the next tick is
-   * not itself misread as quiescent during the boot window. */
-  relaunch(): Promise<void>;
+   * not itself misread as quiescent during the boot window. Returns true only
+   * after the new pinned supervisor identity is observable. */
+  relaunch(): Promise<boolean>;
   /**
    * Point-in-time signals for the DEAD-supervisor respawn decision (#1097),
    * gathered only when the supervisor is found dead (pid file present but its pid
@@ -275,10 +276,15 @@ export async function runWatchdog(
     `⚠️  watchdog: supervisor pid=${liveness.pid ?? "?"} is QUIESCENT — ${reason}. Recovering.`,
   );
   await teardownWedgedSupervisor(io, liveness.pid);
+  let relaunched = false;
   try {
-    await io.relaunch();
+    relaunched = await io.relaunch();
   } catch (err) {
     io.log(`watchdog: relaunch failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!relaunched) {
+    io.log("watchdog: relaunch failed: no pinned supervisor identity appeared; recovery remains armed.");
+    return base;
   }
   io.log(`watchdog: wedged supervisor recovered — fresh fleet relaunched.`);
   return { ...base, recovered: true };
@@ -289,8 +295,10 @@ export async function runWatchdog(
  * the supervisor is classified absent WITH a recorded (dead) pid: a silent
  * mid-drain crash. Gathers the observable fleet state, runs the pure
  * {@link decideDeadSupervisorRespawn} decision, and — on "respawn" — records the
- * restart, clears the stale control files, reconciles stranded claims, and
- * relaunches. Unlike the quiescent path it does NOT kill workers: detached workers
+ * restart, reconciles stranded claims, and relaunches. The stale pinned identity
+ * deliberately remains until the new supervisor atomically replaces it, so a
+ * failed boot is still visible to the next watchdog pass. Unlike the quiescent
+ * path it does NOT kill workers: detached workers
  * that outlived the crash are still legitimately draining their claims, so killing
  * them would throw away in-flight work. Every step is best-effort.
  *
@@ -354,24 +362,24 @@ async function recoverDeadSupervisor(
   );
 
   try {
-    await io.writeRestartLedger?.(decision.restarts);
-  } catch {
-    // best-effort: a failed ledger write only weakens the crash-loop bound.
-  }
-  try {
-    await io.clearControlFiles();
-  } catch {
-    // best-effort: the stale pid file may already be gone.
-  }
-  try {
     await io.reconcile();
   } catch {
     // best-effort: the relaunched workers' boot sweep also reconciles.
   }
+  let relaunched = false;
   try {
-    await io.relaunch();
+    relaunched = await io.relaunch();
   } catch (err) {
     io.log(`watchdog: relaunch failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!relaunched) {
+    io.log("watchdog: relaunch failed: no pinned supervisor identity appeared; recovery remains armed.");
+    return base;
+  }
+  try {
+    await io.writeRestartLedger?.(decision.restarts);
+  } catch {
+    // best-effort: a failed ledger write only weakens the crash-loop bound.
   }
   io.log(
     `watchdog: dead supervisor respawned — reason=${signals.readyForAgent} ready stranded, ` +

--- a/apps/dev/src/core/watchdog.ts
+++ b/apps/dev/src/core/watchdog.ts
@@ -154,6 +154,29 @@ export interface WatchdogResult {
   crashLoopSuppressed: boolean;
 }
 
+export interface SupervisorWatchdogLoopOptions {
+  pollMs: number;
+  pass(): Promise<void>;
+  shouldStop(): boolean;
+  sleep(ms: number): Promise<void>;
+}
+
+/**
+ * Keep the already-existing watchdog decision armed for the whole fleet
+ * lifetime. The loop is deliberately pure over injected process/fs IO so the
+ * command owner can remain repo-scoped and tests can kill the modeled
+ * supervisor without wall-clock sleeps.
+ */
+export async function runSupervisorWatchdogLoop(
+  options: SupervisorWatchdogLoopOptions,
+): Promise<void> {
+  while (!options.shouldStop()) {
+    await options.pass();
+    if (options.shouldStop()) return;
+    await options.sleep(options.pollMs);
+  }
+}
+
 /**
  * Tear down a supervisor proven quiescent: kill its tree, kill its detached
  * workers (#579), clear the control files, then reconcile any claims/labels it

--- a/apps/dev/src/core/watchdog.ts
+++ b/apps/dev/src/core/watchdog.ts
@@ -1,9 +1,9 @@
 // watchdog — the EXTERNAL recovery layer for a hard-hung fleet supervisor
 // (#407). The HITL decision (2026-06-08) was: a live-but-quiescent supervisor
 // (alive PID, drain loop wedged, #406 heartbeat gone stale) cannot re-arm
-// itself, so recovery is driven by an ALREADY-ALIVE surface — the fleet-launch
-// pre-check (fleet.ts) and an opt-in monitor tick (`monitor --watchdog`) — never a new
-// standalone daemon.
+// itself, so recovery is driven by the detached repo-scoped fleet watchdog.
+// The fleet-launch pre-check and opt-in `monitor --watchdog` tick remain
+// secondary manual recovery surfaces over this same pure sequencer.
 //
 // This module is PURE SEQUENCING over injected IO, mirroring supervisor.ts:
 // every side effect (reading the pid/heartbeat, killing a tree, clearing the

--- a/apps/dev/src/runtime/supervisor-spawn.ts
+++ b/apps/dev/src/runtime/supervisor-spawn.ts
@@ -6,12 +6,13 @@
 
 import { spawn } from "node:child_process";
 import { mkdirSync, renameSync, writeFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 import type { ElasticShrinkMode, HeartbeatSlotPid } from "../core/supervisor.js";
 import { afkPaths } from "./wire.js";
 import { FLEET_NAME_ENV } from "../core/fleet-name.js";
+import { readPidStartTime } from "../core/state.js";
+import { isSupervisorIdentityLive, readSupervisorIdentity } from "./supervisor-state.js";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -24,21 +25,17 @@ function isLivePid(pid: number): boolean {
   }
 }
 
-async function readPid(path: string): Promise<number | null> {
-  try {
-    const raw = (await readFile(path, "utf8")).trim();
-    if (!/^\d+$/.test(raw)) return null;
-    return Number(raw);
-  } catch {
-    return null;
-  }
-}
-
-async function waitForPidFile(pidFile: string, deadlineMs: number): Promise<number | null> {
+async function waitForPinnedPid(
+  pidFile: string,
+  pidStartFile: string,
+  deadlineMs: number,
+): Promise<number | null> {
   const deadline = Date.now() + deadlineMs;
   while (Date.now() < deadline) {
-    const pid = await readPid(pidFile);
-    if (pid && isLivePid(pid)) return pid;
+    const identity = await readSupervisorIdentity(pidFile, pidStartFile);
+    if (identity && isSupervisorIdentityLive(identity, isLivePid, readPidStartTime)) {
+      return identity.pid;
+    }
     await sleep(100);
   }
   return null;
@@ -101,7 +98,7 @@ export async function spawnSupervisor(opts: SpawnSupervisorOptions): Promise<num
   });
   child.unref();
 
-  return waitForPidFile(pidFile, 3_000);
+  return waitForPinnedPid(pidFile, paths.supervisorPidStartPath, 3_000);
 }
 
 /**

--- a/apps/dev/src/runtime/supervisor-state.ts
+++ b/apps/dev/src/runtime/supervisor-state.ts
@@ -2,6 +2,27 @@ import { constants } from "node:fs";
 import { access, readdir, readFile, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { isLivePid as defaultIsLivePid } from "./kill-tree.js";
+import { readPidStartTime } from "../core/state.js";
+
+export interface SupervisorIdentity {
+  pid: number;
+  startTime: string;
+}
+
+/**
+ * Verify the repo-owned supervisor identity, not merely PID existence. A PID
+ * reused by another process (including a same-command supervisor in a sibling
+ * repo) is dead for this lane when its stable process-start token differs.
+ */
+export function isSupervisorIdentityLive(
+  identity: SupervisorIdentity,
+  isLivePid: (pid: number) => boolean = defaultIsLivePid,
+  pidStartTime: (pid: number) => string | null = readPidStartTime,
+): boolean {
+  if (!isLivePid(identity.pid)) return false;
+  if (identity.startTime === "") return true;
+  return pidStartTime(identity.pid) === identity.startTime;
+}
 
 export interface SupervisorStateReapResult {
   status: "absent" | "live" | "stale";

--- a/apps/dev/src/runtime/supervisor-state.ts
+++ b/apps/dev/src/runtime/supervisor-state.ts
@@ -20,8 +20,9 @@ export function isSupervisorIdentityLive(
   pidStartTime: (pid: number) => string | null = readPidStartTime,
 ): boolean {
   if (!isLivePid(identity.pid)) return false;
-  if (identity.startTime === "") return true;
-  return pidStartTime(identity.pid) === identity.startTime;
+  if (identity.startTime === "") return false;
+  const actualStartTime = pidStartTime(identity.pid);
+  return actualStartTime !== null && actualStartTime === identity.startTime;
 }
 
 export interface SupervisorStateReapResult {
@@ -41,6 +42,20 @@ export async function readSupervisorPid(pidFile: string): Promise<number | null>
   }
 }
 
+export async function readSupervisorIdentity(
+  pidFile: string,
+  pidStartFile = `${pidFile}.start`,
+): Promise<SupervisorIdentity | null> {
+  const pid = await readSupervisorPid(pidFile);
+  if (pid === null) return null;
+  try {
+    const startTime = (await readFile(pidStartFile, "utf8")).trim();
+    return { pid, startTime };
+  } catch {
+    return { pid, startTime: "" };
+  }
+}
+
 export interface SupervisorPidDiscovery {
   pid: number;
   source: "pid-file" | "snapshot-dir";
@@ -56,6 +71,8 @@ export interface DiscoverSupervisorPidOptions {
    * can never report fleet B's pid.
    */
   fleet?: string;
+  /** Injectable stable process-start lookup for deterministic identity tests. */
+  pidStartTime?: (pid: number) => string | null;
 }
 
 /** Collect the live `s<pid>` supervisor-lane dirs directly under `dir`, newest
@@ -97,9 +114,12 @@ export async function discoverLiveSupervisorPid(
   options: DiscoverSupervisorPidOptions = {},
 ): Promise<SupervisorPidDiscovery | null> {
   const pidFile = join(supervisorRuntimeDir, "afk-supervisor.pid");
-  const pid = await readSupervisorPid(pidFile);
-  if (pid !== null && isLivePid(pid)) {
-    return { pid, source: "pid-file", path: pidFile };
+  const identity = await readSupervisorIdentity(pidFile);
+  if (
+    identity !== null &&
+    isSupervisorIdentityLive(identity, isLivePid, options.pidStartTime ?? readPidStartTime)
+  ) {
+    return { pid: identity.pid, source: "pid-file", path: pidFile };
   }
 
   const own = await liveLaneDirs(supervisorRuntimeDir, isLivePid);
@@ -151,14 +171,19 @@ async function supervisorArtifactPaths(dir: string): Promise<string[]> {
 export async function reapStaleSupervisorState(
   dirs: string | readonly string[],
   isLivePid: (pid: number) => boolean = defaultIsLivePid,
+  pidStartTime: (pid: number) => string | null = readPidStartTime,
 ): Promise<SupervisorStateReapResult> {
   const dirList = typeof dirs === "string" ? [dirs] : [...dirs];
   let pid: number | null = null;
   for (const dir of dirList) {
-    pid = await readSupervisorPid(join(dir, "afk-supervisor.pid"));
-    if (pid !== null) break;
+    const identity = await readSupervisorIdentity(join(dir, "afk-supervisor.pid"));
+    if (identity === null) continue;
+    pid = identity.pid;
+    if (isSupervisorIdentityLive(identity, isLivePid, pidStartTime)) {
+      return { status: "live", pid, removed: [] };
+    }
+    break;
   }
-  if (pid !== null && isLivePid(pid)) return { status: "live", pid, removed: [] };
 
   const artifacts = (await Promise.all(dirList.map((d) => supervisorArtifactPaths(d)))).flat();
   const present: string[] = [];

--- a/apps/dev/src/runtime/supervisor-state.ts
+++ b/apps/dev/src/runtime/supervisor-state.ts
@@ -123,6 +123,7 @@ async function exists(path: string): Promise<boolean> {
 async function supervisorArtifactPaths(dir: string): Promise<string[]> {
   const out = [
     join(dir, "afk-supervisor.pid"),
+    join(dir, "afk-supervisor.pid.start"),
     join(dir, "afk-supervisor-boot.pid"),
     join(dir, "state.toon"),
     join(dir, "state.toon.tmp"),

--- a/apps/dev/src/runtime/supervisor-watchdog-spawn.ts
+++ b/apps/dev/src/runtime/supervisor-watchdog-spawn.ts
@@ -1,8 +1,9 @@
 import { spawn } from "node:child_process";
 import { mkdirSync } from "node:fs";
-import { readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { afkPaths } from "./wire.js";
+import { readPidStartTime } from "../core/state.js";
+import { isSupervisorIdentityLive, readSupervisorIdentity } from "./supervisor-state.js";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -15,15 +16,11 @@ function isLivePid(pid: number): boolean {
   }
 }
 
-async function readLivePid(path: string): Promise<number | null> {
-  try {
-    const raw = (await readFile(path, "utf8")).trim();
-    if (!/^[1-9][0-9]*$/.test(raw)) return null;
-    const pid = Number(raw);
-    return isLivePid(pid) ? pid : null;
-  } catch {
-    return null;
-  }
+async function readLiveWatchdogPid(pidPath: string, startPath: string): Promise<number | null> {
+  const identity = await readSupervisorIdentity(pidPath, startPath);
+  return identity && isSupervisorIdentityLive(identity, isLivePid, readPidStartTime)
+    ? identity.pid
+    : null;
 }
 
 export interface SpawnSupervisorWatchdogOptions {
@@ -37,7 +34,10 @@ export async function spawnSupervisorWatchdog(
 ): Promise<number | null> {
   const paths = afkPaths(options.root, options.fleet);
   mkdirSync(dirname(paths.supervisorWatchdogPidPath), { recursive: true });
-  const existing = await readLivePid(paths.supervisorWatchdogPidPath);
+  const existing = await readLiveWatchdogPid(
+    paths.supervisorWatchdogPidPath,
+    paths.supervisorWatchdogPidStartPath,
+  );
   if (existing !== null) return existing;
 
   const child = spawn(
@@ -54,7 +54,10 @@ export async function spawnSupervisorWatchdog(
 
   const deadline = Date.now() + 3_000;
   while (Date.now() < deadline) {
-    const pid = await readLivePid(paths.supervisorWatchdogPidPath);
+    const pid = await readLiveWatchdogPid(
+      paths.supervisorWatchdogPidPath,
+      paths.supervisorWatchdogPidStartPath,
+    );
     if (pid !== null) return pid;
     await sleep(100);
   }

--- a/apps/dev/src/runtime/supervisor-watchdog-spawn.ts
+++ b/apps/dev/src/runtime/supervisor-watchdog-spawn.ts
@@ -1,0 +1,62 @@
+import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { afkPaths } from "./wire.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isLivePid(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readLivePid(path: string): Promise<number | null> {
+  try {
+    const raw = (await readFile(path, "utf8")).trim();
+    if (!/^[1-9][0-9]*$/.test(raw)) return null;
+    const pid = Number(raw);
+    return isLivePid(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface SpawnSupervisorWatchdogOptions {
+  root: string;
+  fleet?: string;
+}
+
+/** Arm exactly one detached watchdog for one repo-scoped fleet lane. */
+export async function spawnSupervisorWatchdog(
+  options: SpawnSupervisorWatchdogOptions,
+): Promise<number | null> {
+  const paths = afkPaths(options.root, options.fleet);
+  mkdirSync(dirname(paths.supervisorWatchdogPidPath), { recursive: true });
+  const existing = await readLivePid(paths.supervisorWatchdogPidPath);
+  if (existing !== null) return existing;
+
+  const child = spawn(
+    process.execPath,
+    [process.argv[1]!, "__watchdog", "--fleet", paths.fleet],
+    {
+      cwd: options.root,
+      env: process.env,
+      detached: true,
+      stdio: ["ignore", "ignore", "ignore"],
+    },
+  );
+  child.unref();
+
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    const pid = await readLivePid(paths.supervisorWatchdogPidPath);
+    if (pid !== null) return pid;
+    await sleep(100);
+  }
+  return null;
+}

--- a/apps/dev/src/runtime/watchdog-io.ts
+++ b/apps/dev/src/runtime/watchdog-io.ts
@@ -1,5 +1,6 @@
 // watchdog-io — REAL process / fs IO backing the external supervisor watchdog
-// (core/watchdog.ts). Built once per surface (fleet pre-check / monitor tick),
+// (core/watchdog.ts). Built for the persistent repo-scoped watchdog and reused
+// by the fleet pre-check / opt-in monitor recovery surfaces,
 // bound to a repo root. Every closure is best-effort, mirroring the supervisor's
 // own injected IO: a failed kill / stat / spawn degrades to the safe value and
 // never throws out of the closure.

--- a/apps/dev/src/runtime/watchdog-io.ts
+++ b/apps/dev/src/runtime/watchdog-io.ts
@@ -25,7 +25,7 @@ import { appendRecordToonl } from "../core/jsonl-log.js";
 // files on exit, so the relaunch must not write a fresh pid file until the dying
 // process has finished cleaning up — otherwise it would clobber the new one.
 import { isLivePid, killTreeAndWait } from "./kill-tree.js";
-import { isSupervisorIdentityLive } from "./supervisor-state.js";
+import { isSupervisorIdentityLive, readSupervisorIdentity } from "./supervisor-state.js";
 import { readPidStartTime } from "../core/state.js";
 
 async function readPid(path: string): Promise<number | null> {
@@ -179,13 +179,22 @@ export function buildWatchdogIO(
           processTree: callerProcessTreeNative(),
           scriptPath: process.argv[1],
         }).runner;
-      await spawnSupervisor({
+      const spawnedPid = await spawnSupervisor({
         root,
         target: lastTarget,
         runner,
         adoptSlotPids: lastSlotPids,
         fleet: paths.fleet,
       });
+      if (spawnedPid === null) return false;
+      const identity = await readSupervisorIdentity(pidFile, pidStartFile);
+      if (
+        identity === null ||
+        identity.pid !== spawnedPid ||
+        !isSupervisorIdentityLive(identity, isLivePid, readPidStartTime)
+      ) {
+        return false;
+      }
       // Stamp a fresh heartbeat so the very next watchdog pass (a monitor cron
       // tick firing every poll) sees the new supervisor as healthy and does not
       // double-fire while it boots.
@@ -194,6 +203,7 @@ export function buildWatchdogIO(
       } catch {
         // best-effort
       }
+      return true;
     },
 
     deadSupervisorSignals: async (): Promise<DeadSupervisorSignals> => {

--- a/apps/dev/src/runtime/watchdog-io.ts
+++ b/apps/dev/src/runtime/watchdog-io.ts
@@ -56,8 +56,9 @@ async function fileExists(path: string): Promise<boolean> {
 export function buildWatchdogIO(
   root: string,
   stdout: NodeJS.WritableStream = process.stdout,
+  fleet?: string,
 ): WatchdogIO {
-  const paths = afkPaths(root);
+  const paths = afkPaths(root, fleet);
   const pidFile = paths.supervisorPidPath;
   const pidStartFile = paths.supervisorPidStartPath;
   const stopFile = paths.supervisorStopPath;
@@ -177,7 +178,13 @@ export function buildWatchdogIO(
           processTree: callerProcessTreeNative(),
           scriptPath: process.argv[1],
         }).runner;
-      await spawnSupervisor({ root, target: lastTarget, runner, adoptSlotPids: lastSlotPids });
+      await spawnSupervisor({
+        root,
+        target: lastTarget,
+        runner,
+        adoptSlotPids: lastSlotPids,
+        fleet: paths.fleet,
+      });
       // Stamp a fresh heartbeat so the very next watchdog pass (a monitor cron
       // tick firing every poll) sees the new supervisor as healthy and does not
       // double-fire while it boots.

--- a/apps/dev/src/runtime/watchdog-io.ts
+++ b/apps/dev/src/runtime/watchdog-io.ts
@@ -24,6 +24,8 @@ import { appendRecordToonl } from "../core/jsonl-log.js";
 // files on exit, so the relaunch must not write a fresh pid file until the dying
 // process has finished cleaning up — otherwise it would clobber the new one.
 import { isLivePid, killTreeAndWait } from "./kill-tree.js";
+import { isSupervisorIdentityLive } from "./supervisor-state.js";
+import { readPidStartTime } from "../core/state.js";
 
 async function readPid(path: string): Promise<number | null> {
   try {
@@ -57,6 +59,7 @@ export function buildWatchdogIO(
 ): WatchdogIO {
   const paths = afkPaths(root);
   const pidFile = paths.supervisorPidPath;
+  const pidStartFile = paths.supervisorPidStartPath;
   const stopFile = paths.supervisorStopPath;
   const logFile = paths.supervisorLogPath;
   const restartLedgerFile = paths.supervisorRestartsPath;
@@ -97,6 +100,7 @@ export function buildWatchdogIO(
 
     liveness: async (): Promise<SupervisorLiveness> => {
       const pid = await readPid(pidFile);
+      const startTime = await readFile(pidStartFile, "utf8").then((value) => value.trim()).catch(() => "");
       const fleet = await readFleetState(paths.fleetStatePath);
       if (fleet) {
         if (fleet.slotsTotal > 0) lastTarget = fleet.slotsTotal;
@@ -105,7 +109,9 @@ export function buildWatchdogIO(
       }
       return {
         pid,
-        pidAlive: pid !== null && isLivePid(pid),
+        pidAlive:
+          pid !== null &&
+          isSupervisorIdentityLive({ pid, startTime }, isLivePid, readPidStartTime),
         lastHeartbeatEpoch: fleet ? fleet.epoch : null,
         lastProgressEpoch: fleet?.lastProgressEpoch ?? null,
         slotsBusy: fleet?.slotsBusy ?? 0,
@@ -148,6 +154,7 @@ export function buildWatchdogIO(
 
     clearControlFiles: async () => {
       await rm(pidFile, { force: true });
+      await rm(pidStartFile, { force: true });
       await rm(stopFile, { force: true });
     },
 

--- a/apps/dev/src/runtime/wire/paths.ts
+++ b/apps/dev/src/runtime/wire/paths.ts
@@ -46,6 +46,10 @@ export interface AfkPaths {
   supervisorPidStartPath: string;
   /** External self-heal watchdog pid file (same repo-scoped fleet lane). */
   supervisorWatchdogPidPath: string;
+  /** Stable process-start token paired with the watchdog pid lock. */
+  supervisorWatchdogPidStartPath: string;
+  /** Atomic single-owner acquisition lane for watchdog startup. */
+  supervisorWatchdogLockPath: string;
   /** Supervisor stop sentinel (tmp supervisor lane). */
   supervisorStopPath: string;
   /** Supervisor human-readable view source (structured TOONL firehose). */
@@ -109,6 +113,8 @@ export function afkPaths(root: string, fleetName?: string): AfkPaths {
     supervisorPidPath: join(supervisorRuntime, "afk-supervisor.pid"),
     supervisorPidStartPath: join(supervisorRuntime, "afk-supervisor.pid.start"),
     supervisorWatchdogPidPath: join(supervisorRuntime, "afk-supervisor-watchdog.pid"),
+    supervisorWatchdogPidStartPath: join(supervisorRuntime, "afk-supervisor-watchdog.pid.start"),
+    supervisorWatchdogLockPath: join(supervisorRuntime, "afk-supervisor-watchdog.lock"),
     supervisorStopPath: join(supervisorRuntime, "afk-supervisor.stop"),
     supervisorLogPath: join(supervisorRuntime, "supervisor.log.toonl"),
     supervisorResizePath: join(supervisorRuntime, "resize.toon"),

--- a/apps/dev/src/runtime/wire/paths.ts
+++ b/apps/dev/src/runtime/wire/paths.ts
@@ -42,6 +42,10 @@ export interface AfkPaths {
   monitorLogCursorPath: string;
   /** Supervisor pid file (tmp supervisor lane). */
   supervisorPidPath: string;
+  /** Stable process-start token paired with the supervisor pid lock. */
+  supervisorPidStartPath: string;
+  /** External self-heal watchdog pid file (same repo-scoped fleet lane). */
+  supervisorWatchdogPidPath: string;
   /** Supervisor stop sentinel (tmp supervisor lane). */
   supervisorStopPath: string;
   /** Supervisor human-readable view source (structured TOONL firehose). */
@@ -103,6 +107,8 @@ export function afkPaths(root: string, fleetName?: string): AfkPaths {
     fleetFirehosePath: join(supervisorRuntime, "supervisor.log.toonl"),
     monitorLogCursorPath: join(supervisorRuntime, "monitor-log-cursors.toon"),
     supervisorPidPath: join(supervisorRuntime, "afk-supervisor.pid"),
+    supervisorPidStartPath: join(supervisorRuntime, "afk-supervisor.pid.start"),
+    supervisorWatchdogPidPath: join(supervisorRuntime, "afk-supervisor-watchdog.pid"),
     supervisorStopPath: join(supervisorRuntime, "afk-supervisor.stop"),
     supervisorLogPath: join(supervisorRuntime, "supervisor.log.toonl"),
     supervisorResizePath: join(supervisorRuntime, "resize.toon"),

--- a/apps/dev/tests/fleet-cli-upsert.test.ts
+++ b/apps/dev/tests/fleet-cli-upsert.test.ts
@@ -11,6 +11,10 @@ vi.mock("../src/runtime/supervisor-spawn.js", () => ({
   spawnSupervisor: vi.fn(async () => 7777),
 }));
 
+vi.mock("../src/runtime/supervisor-watchdog-spawn.js", () => ({
+  spawnSupervisorWatchdog: vi.fn(async () => 7778),
+}));
+
 // Import after mock is hoisted so launchFleet picks up the stub.
 const { launchFleet } = await import("../src/commands/fleet.js");
 

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -15,6 +15,11 @@ vi.mock("../src/runtime/kill-tree.js", () => ({
   killTreeAndWait: killTreeMocks.killTreeAndWait,
 }));
 
+vi.mock("../src/core/state.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/core/state.js")>();
+  return { ...actual, readPidStartTime: (pid: number) => `start-${pid}` };
+});
+
 vi.mock("../src/runtime/supervisor-spawn.js", () => ({
   spawnSupervisor: vi.fn(async () => 43210),
 }));
@@ -44,6 +49,9 @@ function writeSupervisorArtifacts(root: string, pid: number | string): Record<st
     firehose: paths0.fleetFirehosePath,
   };
   writeFileSync(paths.pid, String(pid), "utf8");
+  if (typeof pid === "number") {
+    writeFileSync(paths0.supervisorPidStartPath, `start-${pid}`, "utf8");
+  }
   writeFileSync(paths.state, "{not json", "utf8");
   writeFileSync(paths.log, "old supervisor log\n", "utf8");
   writeFileSync(paths.firehose, "old firehose\n", "utf8");
@@ -340,6 +348,7 @@ describe("fleet command stale supervisor state", () => {
       const stateAfk = dirname(afkPaths(root).supervisorPidPath);
       mkdirSync(stateAfk, { recursive: true });
       writeFileSync(join(stateAfk, "afk-supervisor.pid"), "12345", "utf8");
+      writeFileSync(join(stateAfk, "afk-supervisor.pid.start"), "start-12345", "utf8");
       const epoch = Math.floor(Date.now() / 1000);
       writeFileSync(
         join(stateAfk, "state.toon"),
@@ -364,6 +373,7 @@ describe("fleet command stale supervisor state", () => {
 
       expect(result).toMatchObject({ status: "resized", pid: 12345, target: 4 });
       expect(spawnSupervisor).not.toHaveBeenCalled();
+      expect(spawnSupervisorWatchdog).toHaveBeenCalledWith({ root, fleet: "default" });
       expect(writes.join("")).toContain("fleet directive pending");
       expect(decode(readFileSync(afkPaths(root).supervisorResizePath, "utf8"))).toEqual({
         target: 4,
@@ -374,15 +384,35 @@ describe("fleet command stale supervisor state", () => {
     }
   });
 
+  it("rolls back a newly launched supervisor when watchdog arming fails", async () => {
+    const root = scratch();
+    try {
+      vi.mocked(spawnSupervisorWatchdog).mockResolvedValueOnce(null);
+      const paths = afkPaths(root);
+      mkdirSync(paths.supervisorRuntimeDir, { recursive: true });
+      writeFileSync(paths.supervisorPidPath, "43210", "utf8");
+      writeFileSync(paths.supervisorPidStartPath, "start-43210", "utf8");
+
+      await expect(launchFleet(["1"], root, stream())).rejects.toThrow("watchdog did not arm");
+
+      expect(killTreeMocks.killTreeAndWait).toHaveBeenCalledWith(43210);
+      expect(existsSync(paths.supervisorPidPath)).toBe(false);
+      expect(existsSync(paths.supervisorPidStartPath)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("launchFleet reports applied when a live runner directive already matches the heartbeat", async () => {
     const root = scratch();
     try {
-      const stateAfk = join(root, ".red", "state", "castle");
+      const stateAfk = dirname(afkPaths(root).supervisorPidPath);
       mkdirSync(stateAfk, { recursive: true });
       writeFileSync(join(stateAfk, "afk-supervisor.pid"), "12345", "utf8");
+      writeFileSync(join(stateAfk, "afk-supervisor.pid.start"), "start-12345", "utf8");
       const epoch = Math.floor(Date.now() / 1000);
       writeFileSync(
-        join(stateAfk, "afk-supervisor.state.json"),
+        join(stateAfk, "state.toon"),
         JSON.stringify({
           epoch,
           last_progress_epoch: epoch,

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -19,9 +19,14 @@ vi.mock("../src/runtime/supervisor-spawn.js", () => ({
   spawnSupervisor: vi.fn(async () => 43210),
 }));
 
+vi.mock("../src/runtime/supervisor-watchdog-spawn.js", () => ({
+  spawnSupervisorWatchdog: vi.fn(async () => 43211),
+}));
+
 import { launchFleet, logsFleet, statusFleet, stopFleet } from "../src/commands/fleet.js";
 import { isLivePid } from "../src/runtime/kill-tree.js";
 import { spawnSupervisor } from "../src/runtime/supervisor-spawn.js";
+import { spawnSupervisorWatchdog } from "../src/runtime/supervisor-watchdog-spawn.js";
 import { afkPaths } from "../src/runtime/wire.js";
 
 function scratch(): string {
@@ -57,6 +62,8 @@ describe("fleet command stale supervisor state", () => {
     killTreeMocks.killTreeAndWait.mockResolvedValue(false);
     vi.mocked(spawnSupervisor).mockClear();
     vi.mocked(spawnSupervisor).mockResolvedValue(43210);
+    vi.mocked(spawnSupervisorWatchdog).mockClear();
+    vi.mocked(spawnSupervisorWatchdog).mockResolvedValue(43211);
   });
 
   it("launchFleet removes dead supervisor pid/state/log files before spawning", async () => {
@@ -67,6 +74,7 @@ describe("fleet command stale supervisor state", () => {
       await launchFleet(["1"], root, stream());
 
       expect(spawnSupervisor).toHaveBeenCalledTimes(1);
+      expect(spawnSupervisorWatchdog).toHaveBeenCalledWith({ root, fleet: "default" });
       expect(existsSync(paths.pid)).toBe(false);
       expect(existsSync(paths.state)).toBe(false);
       expect(existsSync(paths.log)).toBe(false);

--- a/apps/dev/tests/named-fleet-paths.test.ts
+++ b/apps/dev/tests/named-fleet-paths.test.ts
@@ -22,10 +22,12 @@ function seedPidFile(root: string, fleet: string, pid: number): string {
   const paths = afkPaths(root, fleet);
   mkdirSync(paths.supervisorRuntimeDir, { recursive: true });
   writeFileSync(paths.supervisorPidPath, String(pid), "utf8");
+  writeFileSync(paths.supervisorPidStartPath, `start-${pid}`, "utf8");
   return paths.supervisorRuntimeDir;
 }
 
 const alive = (pids: number[]) => (pid: number) => pids.includes(pid);
+const pinnedStart = (pid: number) => `start-${pid}`;
 
 describe("afkPaths — named fleet lanes", () => {
   it("defaults to the `default` lane when unnamed", () => {
@@ -86,11 +88,11 @@ describe("discoverLiveSupervisorPid — per-fleet pid locks", () => {
     const betaDir = seedPidFile(root, "beta", 222);
     const isLive = alive([111, 222]);
 
-    expect(await discoverLiveSupervisorPid(alphaDir, isLive, { fleet: "alpha" })).toMatchObject({
+    expect(await discoverLiveSupervisorPid(alphaDir, isLive, { fleet: "alpha", pidStartTime: pinnedStart })).toMatchObject({
       pid: 111,
       source: "pid-file",
     });
-    expect(await discoverLiveSupervisorPid(betaDir, isLive, { fleet: "beta" })).toMatchObject({
+    expect(await discoverLiveSupervisorPid(betaDir, isLive, { fleet: "beta", pidStartTime: pinnedStart })).toMatchObject({
       pid: 222,
       source: "pid-file",
     });
@@ -100,7 +102,7 @@ describe("discoverLiveSupervisorPid — per-fleet pid locks", () => {
     const root = scratch();
     const alphaDir = seedPidFile(root, "alpha", 111);
     seedPidFile(root, "beta", 222);
-    expect(await discoverLiveSupervisorPid(alphaDir, alive([222]), { fleet: "alpha" })).toBeNull();
+    expect(await discoverLiveSupervisorPid(alphaDir, alive([222]), { fleet: "alpha", pidStartTime: pinnedStart })).toBeNull();
   });
 
   it("never crosses fleets through the s<pid> lane-dir fallback", async () => {

--- a/apps/dev/tests/supervise-startup-exit.test.ts
+++ b/apps/dev/tests/supervise-startup-exit.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCastleLaneWriters, createEnginePaths } from "@reddb-io/red-castle/engine";
+
+vi.mock("../src/core/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/core/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => {
+      throw new Error("injected post-lock startup failure");
+    },
+  };
+});
+
+const { superviseCommand } = await import("../src/commands/supervise.js");
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("supervisor startup terminal record (#2442)", () => {
+  it("records an exception raised after acquiring the pinned pid lock", async () => {
+    const root = mkdtempSync(join(tmpdir(), "supervise-startup-exit-"));
+    roots.push(root);
+    await expect(superviseCommand([], root)).rejects.toThrow("injected post-lock startup failure");
+
+    const lane = createCastleLaneWriters(createEnginePaths(join(root, ".red")))
+      .supervisor(join("default", `s${process.pid}`));
+    const rows = readFileSync(lane.path, "utf8");
+    expect(rows).toContain("supervisor.exit");
+    expect(rows).toContain("exception");
+  });
+});

--- a/apps/dev/tests/supervisor-exit-lifecycle.test.ts
+++ b/apps/dev/tests/supervisor-exit-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createSupervisorExitRecorder } from "../src/core/supervisor-exit.js";
+import { runSupervisorWatchdogLoop } from "../src/core/watchdog.js";
 
 describe("fleet supervisor terminal lifecycle (#2442)", () => {
   it("writes exactly one terminal lane record naming the received signal", async () => {
@@ -21,5 +22,33 @@ describe("fleet supervisor terminal lifecycle (#2442)", () => {
       payload: { reason: "signal", signal: "SIGTERM" },
     });
     expect(appendSync).not.toHaveBeenCalled();
+  });
+});
+
+describe("fleet supervisor steady-state self-heal (#2442)", () => {
+  it("detects a killed supervisor and respawns it within one fleet poll window", async () => {
+    let supervisorAlive = true;
+    let respawns = 0;
+    const sleep = vi.fn(async () => {
+      supervisorAlive = false;
+    });
+    const pass = vi.fn(async () => {
+      if (!supervisorAlive) {
+        supervisorAlive = true;
+        respawns += 1;
+      }
+    });
+
+    await runSupervisorWatchdogLoop({
+      pollMs: 15_000,
+      pass,
+      shouldStop: () => respawns === 1,
+      sleep,
+    });
+
+    expect(pass).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(15_000);
+    expect(respawns).toBe(1);
   });
 });

--- a/apps/dev/tests/supervisor-exit-lifecycle.test.ts
+++ b/apps/dev/tests/supervisor-exit-lifecycle.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSupervisorExitRecorder } from "../src/core/supervisor-exit.js";
+
+describe("fleet supervisor terminal lifecycle (#2442)", () => {
+  it("writes exactly one terminal lane record naming the received signal", async () => {
+    const append = vi.fn(async () => {});
+    const appendSync = vi.fn();
+    const recorder = createSupervisorExitRecorder({
+      supervisorId: "s4242",
+      append,
+      appendSync,
+    });
+
+    await recorder.record("signal", { signal: "SIGTERM" });
+    recorder.recordSync("process-exit", { code: 143 });
+
+    expect(append).toHaveBeenCalledTimes(1);
+    expect(append).toHaveBeenCalledWith({
+      kind: "supervisor.exit",
+      supervisor_id: "s4242",
+      payload: { reason: "signal", signal: "SIGTERM" },
+    });
+    expect(appendSync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dev/tests/supervisor-exit-lifecycle.test.ts
+++ b/apps/dev/tests/supervisor-exit-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createSupervisorExitRecorder } from "../src/core/supervisor-exit.js";
 import { runSupervisorWatchdogLoop } from "../src/core/watchdog.js";
+import { isSupervisorIdentityLive } from "../src/runtime/supervisor-state.js";
 
 describe("fleet supervisor terminal lifecycle (#2442)", () => {
   it("writes exactly one terminal lane record naming the received signal", async () => {
@@ -50,5 +51,15 @@ describe("fleet supervisor steady-state self-heal (#2442)", () => {
     expect(sleep).toHaveBeenCalledTimes(1);
     expect(sleep).toHaveBeenCalledWith(15_000);
     expect(respawns).toBe(1);
+  });
+
+  it("rejects a live recycled pid whose start-time differs from this repo's pin", () => {
+    expect(
+      isSupervisorIdentityLive(
+        { pid: 4242, startTime: "repo-a-start" },
+        () => true,
+        () => "sibling-or-recycled-start",
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/dev/tests/supervisor-state.test.ts
+++ b/apps/dev/tests/supervisor-state.test.ts
@@ -2,7 +2,12 @@ import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { reapDeadSupervisorSnapshotDirs } from "../src/runtime/supervisor-state.js";
+import {
+  discoverLiveSupervisorPid,
+  isSupervisorIdentityLive,
+  reapDeadSupervisorSnapshotDirs,
+  reapStaleSupervisorState,
+} from "../src/runtime/supervisor-state.js";
 
 function scratch(): string {
   return mkdtempSync(join(tmpdir(), "afk-supervisor-state-"));
@@ -33,6 +38,35 @@ describe("reapDeadSupervisorSnapshotDirs", () => {
       expect(existsSync(live)).toBe(true);
       expect(existsSync(current)).toBe(true);
       expect(existsSync(named)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("pinned supervisor identity", () => {
+  it("fails closed when the process-start pin is missing", () => {
+    expect(isSupervisorIdentityLive({ pid: 4242, startTime: "" }, () => true, () => "live-start"))
+      .toBe(false);
+  });
+
+  it("rejects a recycled pid in discovery and reaps its stale state", async () => {
+    const root = scratch();
+    try {
+      const runtime = join(root, ".red", "tmp", "supervisors", "default");
+      mkdirSync(runtime, { recursive: true });
+      writeFileSync(join(runtime, "afk-supervisor.pid"), "4242", "utf8");
+      writeFileSync(join(runtime, "afk-supervisor.pid.start"), "recorded-start", "utf8");
+
+      const pidStartTime = () => "recycled-start";
+      expect(
+        await discoverLiveSupervisorPid(runtime, () => true, { pidStartTime }),
+      ).toBeNull();
+      expect(
+        await reapStaleSupervisorState(runtime, () => true, pidStartTime),
+      ).toMatchObject({ status: "stale", pid: 4242 });
+      expect(existsSync(join(runtime, "afk-supervisor.pid"))).toBe(false);
+      expect(existsSync(join(runtime, "afk-supervisor.pid.start"))).toBe(false);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/dev/tests/supervisor-watchdog-command.test.ts
+++ b/apps/dev/tests/supervisor-watchdog-command.test.ts
@@ -1,0 +1,81 @@
+import { once } from "node:events";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
+import { readPidStartTime } from "../src/core/state.js";
+import { afkPaths } from "../src/runtime/wire.js";
+
+const spawnSupervisor = vi.hoisted(() => vi.fn(async () => process.pid));
+
+vi.mock("../src/runtime/supervisor-spawn.js", () => ({ spawnSupervisor }));
+vi.mock("../src/runtime/gh.js", () => ({ countReadyForAgent: vi.fn(async () => 3) }));
+vi.mock("../src/runtime/wire.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/runtime/wire.js")>();
+  return { ...actual, resolveRepoSlug: vi.fn(async () => "owner/repo") };
+});
+
+const { supervisorWatchdogCommand } = await import("../src/commands/supervisor-watchdog.js");
+
+const roots: string[] = [];
+const children: ChildProcess[] = [];
+
+afterEach(async () => {
+  delete process.env.RED_AFK_POLL_S;
+  for (const child of children.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+  }
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  spawnSupervisor.mockClear();
+});
+
+describe("persistent supervisor watchdog command (#2442)", () => {
+  it("respawns within one poll window after the pinned steady-state supervisor is killed", async () => {
+    const root = await import("node:fs/promises").then(({ mkdtemp }) =>
+      mkdtemp(join(tmpdir(), "supervisor-watchdog-")),
+    );
+    roots.push(root);
+    const paths = afkPaths(root);
+    await mkdir(paths.supervisorRuntimeDir, { recursive: true });
+
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    children.push(child);
+    expect(child.pid).toBeTypeOf("number");
+    const pid = child.pid!;
+    const startTime = readPidStartTime(pid);
+    expect(startTime).not.toBeNull();
+    await writeFile(paths.supervisorPidPath, String(pid), "utf8");
+    await writeFile(paths.supervisorPidStartPath, startTime!, "utf8");
+    const epoch = Math.floor(Date.now() / 1000);
+    await writeFile(
+      paths.fleetStatePath,
+      encodeDevSnapshotToon({
+        ts: new Date(epoch * 1000).toISOString(),
+        epoch,
+        last_progress_epoch: epoch,
+        target: 1,
+        runner: "codex",
+        ready_for_agent: 3,
+        slots: { busy: 0, free: 1, total: 1, parked: 0 },
+        slot_pids: [],
+        spawns_this_tick: 0,
+      }),
+      "utf8",
+    );
+
+    process.env.RED_AFK_POLL_S = "1";
+    const started = Date.now();
+    const watchdog = supervisorWatchdogCommand([], root);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    child.kill("SIGKILL");
+    await once(child, "exit");
+    await watchdog;
+
+    expect(spawnSupervisor).toHaveBeenCalledTimes(1);
+    expect(Date.now() - started).toBeLessThan(2_500);
+  });
+});

--- a/apps/dev/tests/supervisor-watchdog-command.test.ts
+++ b/apps/dev/tests/supervisor-watchdog-command.test.ts
@@ -16,6 +16,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { readPidStartTime } from "../src/core/state.js";
 import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
 import { afkPaths } from "../src/runtime/wire.js";
+import { supervisorWatchdogCommand } from "../src/commands/supervisor-watchdog.js";
 
 const roots: string[] = [];
 const children: ChildProcess[] = [];
@@ -60,6 +61,26 @@ afterEach(async () => {
 });
 
 describe("persistent supervisor watchdog command (#2442)", () => {
+  it("reclaims a watchdog pid reused by an unrelated live process", async () => {
+    const root = mkdtempSync(join(tmpdir(), "supervisor-watchdog-owner-"));
+    roots.push(root);
+    const paths = afkPaths(root);
+    mkdirSync(paths.supervisorRuntimeDir, { recursive: true });
+    const unrelated = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    children.push(unrelated);
+    const unrelatedPid = await waitFor(() => unrelated.pid ?? null);
+    writeFileSync(paths.supervisorWatchdogPidPath, String(unrelatedPid), "utf8");
+    writeFileSync(paths.supervisorWatchdogPidStartPath, "recycled-start", "utf8");
+    writeFileSync(paths.supervisorStopPath, "stop", "utf8");
+
+    await expect(supervisorWatchdogCommand([], root)).resolves.toBe(0);
+
+    expect(existsSync(paths.supervisorWatchdogPidPath)).toBe(false);
+    expect(existsSync(paths.supervisorWatchdogPidStartPath)).toBe(false);
+  });
+
   it("respawns a real steady-state supervisor and reconciles its dead claim", async () => {
     const root = mkdtempSync(join(tmpdir(), "supervisor-watchdog-integration-"));
     roots.push(root);

--- a/apps/dev/tests/supervisor-watchdog-command.test.ts
+++ b/apps/dev/tests/supervisor-watchdog-command.test.ts
@@ -1,57 +1,126 @@
 import { once } from "node:events";
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it } from "vitest";
 import { readPidStartTime } from "../src/core/state.js";
+import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
 import { afkPaths } from "../src/runtime/wire.js";
-
-const spawnSupervisor = vi.hoisted(() => vi.fn(async () => process.pid));
-
-vi.mock("../src/runtime/supervisor-spawn.js", () => ({ spawnSupervisor }));
-vi.mock("../src/runtime/gh.js", () => ({ countReadyForAgent: vi.fn(async () => 3) }));
-vi.mock("../src/runtime/wire.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../src/runtime/wire.js")>();
-  return { ...actual, resolveRepoSlug: vi.fn(async () => "owner/repo") };
-});
-
-const { supervisorWatchdogCommand } = await import("../src/commands/supervisor-watchdog.js");
 
 const roots: string[] = [];
 const children: ChildProcess[] = [];
 
+function live(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pinnedPid(pidPath: string, startPath: string): number | null {
+  try {
+    const pid = Number(readFileSync(pidPath, "utf8").trim());
+    const start = readFileSync(startPath, "utf8").trim();
+    return Number.isSafeInteger(pid) && pid > 0 && live(pid) && readPidStartTime(pid) === start
+      ? pid
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function waitFor<T>(probe: () => T | null, timeoutMs = 30_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = probe();
+    if (value !== null) return value;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("timed out waiting for integration condition");
+}
+
 afterEach(async () => {
-  delete process.env.RED_AFK_POLL_S;
   for (const child of children.splice(0)) {
     if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
   }
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
-  spawnSupervisor.mockClear();
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
 describe("persistent supervisor watchdog command (#2442)", () => {
-  it("respawns within one poll window after the pinned steady-state supervisor is killed", async () => {
-    const root = await import("node:fs/promises").then(({ mkdtemp }) =>
-      mkdtemp(join(tmpdir(), "supervisor-watchdog-")),
-    );
+  it("respawns a real steady-state supervisor and reconciles its dead claim", async () => {
+    const root = mkdtempSync(join(tmpdir(), "supervisor-watchdog-integration-"));
     roots.push(root);
     const paths = afkPaths(root);
-    await mkdir(paths.supervisorRuntimeDir, { recursive: true });
+    const bin = join(root, "bin");
+    const claim = join(paths.claimsDir, "2442");
+    mkdirSync(bin, { recursive: true });
+    mkdirSync(claim, { recursive: true });
+    writeFileSync(join(claim, "pid"), "999999999", "utf8");
 
-    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
-      stdio: "ignore",
+    const gh = join(bin, "gh");
+    writeFileSync(
+      gh,
+      `#!/bin/sh
+case "$*" in
+  *"repo view"*) printf 'owner/repo\\n' ;;
+  *"issue list"*)
+    if [ -f "$PWD/.ready-once" ]; then
+      rm -f "$PWD/.ready-once"
+      printf '[{"number":2442}]\\n'
+    else
+      printf '[]\\n'
+    fi
+    ;;
+  *) printf '[]\\n' ;;
+esac
+`,
+      "utf8",
+    );
+    chmodSync(gh, 0o755);
+
+    const cli = join(process.cwd(), "src", "cli.ts");
+    const tsxImport = createRequire(import.meta.url).resolve("tsx");
+    const env = {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${tsxImport}`.trim(),
+      RED_AFK_POLL_S: "1",
+      RED_AFK_WAKE_FALLBACK_S: "1",
+      RED_AFK_TARGET: "1",
+      RED_AFK_RUNNER: "codex",
+    };
+
+    const supervisor = spawn(process.execPath, [cli, "__supervise"], {
+      cwd: root,
+      env,
+      stdio: ["ignore", "ignore", "pipe"],
     });
-    children.push(child);
-    expect(child.pid).toBeTypeOf("number");
-    const pid = child.pid!;
-    const startTime = readPidStartTime(pid);
-    expect(startTime).not.toBeNull();
-    await writeFile(paths.supervisorPidPath, String(pid), "utf8");
-    await writeFile(paths.supervisorPidStartPath, startTime!, "utf8");
+    children.push(supervisor);
+    let supervisorStderr = "";
+    supervisor.stderr?.on("data", (chunk) => {
+      supervisorStderr += String(chunk);
+    });
+    const firstPid = await waitFor(() => {
+      if (supervisor.exitCode !== null) {
+        throw new Error(`real supervisor exited during startup: ${supervisorStderr}`);
+      }
+      return pinnedPid(paths.supervisorPidPath, paths.supervisorPidStartPath);
+    });
     const epoch = Math.floor(Date.now() / 1000);
-    await writeFile(
+    writeFileSync(
       paths.fleetStatePath,
       encodeDevSnapshotToon({
         ts: new Date(epoch * 1000).toISOString(),
@@ -59,7 +128,7 @@ describe("persistent supervisor watchdog command (#2442)", () => {
         last_progress_epoch: epoch,
         target: 1,
         runner: "codex",
-        ready_for_agent: 3,
+        ready_for_agent: 0,
         slots: { busy: 0, free: 1, total: 1, parked: 0 },
         slot_pids: [],
         spawns_this_tick: 0,
@@ -67,15 +136,31 @@ describe("persistent supervisor watchdog command (#2442)", () => {
       "utf8",
     );
 
-    process.env.RED_AFK_POLL_S = "1";
-    const started = Date.now();
-    const watchdog = supervisorWatchdogCommand([], root);
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    child.kill("SIGKILL");
-    await once(child, "exit");
-    await watchdog;
+    const watchdog = spawn(process.execPath, [cli, "__watchdog"], {
+      cwd: root,
+      env,
+      stdio: "ignore",
+    });
+    children.push(watchdog);
+    await waitFor(() =>
+      pinnedPid(paths.supervisorWatchdogPidPath, paths.supervisorWatchdogPidStartPath),
+    );
 
-    expect(spawnSupervisor).toHaveBeenCalledTimes(1);
-    expect(Date.now() - started).toBeLessThan(2_500);
-  });
+    writeFileSync(join(root, ".ready-once"), "1", "utf8");
+    const supervisorExit = once(supervisor, "exit");
+    supervisor.kill("SIGKILL");
+    await supervisorExit;
+
+    const replacementPid = await waitFor(() => {
+      const pid = pinnedPid(paths.supervisorPidPath, paths.supervisorPidStartPath);
+      return pid !== null && pid !== firstPid ? pid : null;
+    });
+    await waitFor(() => (!existsSync(claim) ? true : null));
+
+    expect(replacementPid).not.toBe(firstPid);
+    expect(pinnedPid(paths.supervisorWatchdogPidPath, paths.supervisorWatchdogPidStartPath))
+      .not.toBeNull();
+
+    process.kill(replacementPid, "SIGKILL");
+  }, 90_000);
 });

--- a/apps/dev/tests/watchdog.test.ts
+++ b/apps/dev/tests/watchdog.test.ts
@@ -53,7 +53,7 @@ function makeIo(
     killWorkers: vi.fn(async () => {}),
     clearControlFiles: vi.fn(async () => {}),
     reconcile: vi.fn(async () => {}),
-    relaunch: vi.fn(async () => {}),
+    relaunch: vi.fn(async () => true),
     deadSupervisorSignals: vi.fn(async () => signals),
     readRestartLedger: vi.fn(async () => ledger),
     writeRestartLedger: vi.fn(async () => {}),
@@ -136,7 +136,7 @@ describe("runWatchdog — quiescent supervisor recovery (#407)", () => {
     expect(fake.relaunch).toHaveBeenCalledTimes(1);
   });
 
-  it("recovers even if relaunch throws (logged, never rejects)", async () => {
+  it("does not report recovery when relaunch throws", async () => {
     const { io, fake } = makeIo(
       makeLiveness({ pid: 4242, pidAlive: true, lastHeartbeatEpoch: NOW - 9999 }),
     );
@@ -144,7 +144,7 @@ describe("runWatchdog — quiescent supervisor recovery (#407)", () => {
 
     const result = await runWatchdog(io, STALE, PROGRESS_STALE);
 
-    expect(result.recovered).toBe(true);
+    expect(result.recovered).toBe(false);
     expect(fake.killTree).toHaveBeenCalledTimes(1);
     expect(fake.log).toHaveBeenCalledWith(expect.stringContaining("relaunch failed"));
   });
@@ -262,7 +262,7 @@ describe("runWatchdog — dead-supervisor safety net (#1097)", () => {
   const BOUND = { maxRestarts: 3, windowS: 300 };
   const deadPid = makeLiveness({ pid: 4242, pidAlive: false });
 
-  it("respawns a dead supervisor: records restart, clears files, reconciles, relaunches", async () => {
+  it("respawns a dead supervisor: reconciles, relaunches, then records the restart", async () => {
     const { io, fake } = makeIo(deadPid, makeSignals({ readyForAgent: 3, liveWorkers: 0, target: 2 }));
 
     const result = await runWatchdog(io, STALE, PROGRESS_STALE, BOUND);
@@ -273,7 +273,9 @@ describe("runWatchdog — dead-supervisor safety net (#1097)", () => {
     expect(result.recovered).toBe(false); // that flag is the quiescent (#407) path
 
     expect(fake.writeRestartLedger).toHaveBeenCalledWith([NOW]);
-    expect(fake.clearControlFiles).toHaveBeenCalledTimes(1);
+    // The stale pinned identity stays present until the new supervisor replaces
+    // it, so a failed boot remains detectable on the next watchdog pass.
+    expect(fake.clearControlFiles).not.toHaveBeenCalled();
     expect(fake.reconcile).toHaveBeenCalledTimes(1);
     expect(fake.relaunch).toHaveBeenCalledTimes(1);
     // The dead-supervisor path must NOT kill the surviving detached workers.
@@ -330,14 +332,26 @@ describe("runWatchdog — dead-supervisor safety net (#1097)", () => {
     expect(fake.log).toHaveBeenCalledWith(expect.stringContaining("max-restarts cap"));
   });
 
-  it("still records the respawn + relaunches even when relaunch throws (logged)", async () => {
+  it("keeps recovery armed and does not consume the restart budget when relaunch fails", async () => {
     const { io, fake } = makeIo(deadPid, makeSignals({ readyForAgent: 3, liveWorkers: 0, target: 2 }));
     fake.relaunch.mockRejectedValueOnce(new Error("spawn failed"));
 
     const result = await runWatchdog(io, STALE, PROGRESS_STALE, BOUND);
 
-    expect(result.respawnedDeadSupervisor).toBe(true);
-    expect(fake.writeRestartLedger).toHaveBeenCalledWith([NOW]);
+    expect(result.respawnedDeadSupervisor).toBe(false);
+    expect(fake.writeRestartLedger).not.toHaveBeenCalled();
+    expect(fake.clearControlFiles).not.toHaveBeenCalled();
+    expect(fake.log).toHaveBeenCalledWith(expect.stringContaining("relaunch failed"));
+  });
+
+  it("treats a null supervisor spawn as a failed relaunch", async () => {
+    const { io, fake } = makeIo(deadPid, makeSignals({ readyForAgent: 3, liveWorkers: 0, target: 2 }));
+    fake.relaunch.mockResolvedValueOnce(false);
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE, BOUND);
+
+    expect(result.respawnedDeadSupervisor).toBe(false);
+    expect(fake.writeRestartLedger).not.toHaveBeenCalled();
     expect(fake.log).toHaveBeenCalledWith(expect.stringContaining("relaunch failed"));
   });
 

--- a/packaging/pi/dev/skills/engineering/afk/fleet.md
+++ b/packaging/pi/dev/skills/engineering/afk/fleet.md
@@ -45,6 +45,20 @@ Fleet mode is **runner-portable**: the supervisor is plain process orchestration
 - Codex: launch fleet with `RED_AFK_RUNNER=codex` and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl manually.`
 - Bare terminal / unknown runner: launch fleet and print the manual-monitor guidance.
 
+**Self-heal is not a monitor side effect.** Every successful fleet launch also
+arms one detached watchdog in that fleet's repo-scoped runtime lane. It probes
+the exact `afk-supervisor.pid` plus `afk-supervisor.pid.start` identity once per
+`RED_AFK_POLL_S` (15 seconds by default), so a same-command supervisor in a
+sibling repo and a recycled PID cannot satisfy the liveness check. A dead
+supervisor with `ready-for-agent > 0` and live workers below target is relaunched
+within one poll window, subject to the existing bounded-restart guard. The new
+supervisor boot runs the stale local/cross-host claim reconciliation before
+draining again. Every catchable terminal path writes one `supervisor.exit`
+record with `reason=signal|exception|explicit-stop|completed`; the process-exit
+hook is the synchronous best-effort fallback for exits that bypass the awaited
+path. SIGKILL cannot run user-space cleanup, so its retained pinned PID plus the
+watchdog recovery record is the forensic signal.
+
 **Release recycle rule.** A fleet supervisor keeps running the exact dev bundle
 version it was launched from. After any RedSkills release that changes AFK or
 castle engine behavior, stop and relaunch the fleet before starting or counting
@@ -59,7 +73,7 @@ not part of the current fleet contract.
 `N` is optional and defaults to `2`. Parse it as a non-negative integer; reject anything else (including `stop`, which is the other subcommand and routes below). Steps the agent must perform, in order:
 
 1. **Resolve runner.** Determine the active runner using the same intent as the normal AFK cascade: explicit user `--runner` if present, else `RED_AFK_RUNNER`, else runner env/process/path signals, else `claude`. The resolved value is carried into the supervisor as `RED_AFK_RUNNER=<runner>` so detached workers do not fall through to the supervisor's historical `claude` fallback. Under Codex, this must resolve to `codex`.
-2. **PID-file pre-check / live directive.** Read `.red/tmp/supervisors/default/afk-supervisor.pid`. If it exists and `kill -0 <pid>` succeeds, do not launch a second supervisor. Instead the bundle command writes the `afk-supervisor.resize` directive file in the supervisor runtime lane (`.red/tmp/supervisors/default/`) as the live directive:
+2. **PID-file pre-check / live directive.** Read `.red/tmp/supervisors/default/afk-supervisor.pid` and its `.pid.start` process-start pin. If the PID is live and the current start token matches, do not launch a second supervisor. Instead the bundle command writes the `afk-supervisor.resize` directive file in the supervisor runtime lane (`.red/tmp/supervisors/default/`) as the live directive:
    - `fleet <N>` changes the desired worker count while keeping the current runner.
    - `fleet <N> --shrink-mode hard-kill|drain-then-retire` changes the resize shrink behavior. The default is `drain-then-retire`.
    - `fleet <N> --runner <runner>` asks the running supervisor to switch runner. A changed runner is applied by re-pinning the supervisor's worker env, marking every live slot `drain-then-retire`, letting in-flight claims finish, then respawning replacement slots on the new runner. An unchanged runner is a no-op.
@@ -75,7 +89,7 @@ not part of the current fleet contract.
    ```bash
    RED_AFK_RUNNER=<runner> red-skills-dev fleet <N> [--request <text>]
    ```
-   The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/supervisors/default/afk-supervisor.pid` to appear and contain a live PID, then prints the launched supervisor PID and target; on failure it reports the tail of `.red/tmp/supervisors/default/supervisor.log.toonl`. Capture the reported PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
+   The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/supervisors/default/afk-supervisor.pid` to appear and contain a live pinned PID, then arms the repo-scoped self-heal watchdog and prints both PIDs plus the target. Failure to arm either process fails the launch; supervisor failure reports the tail of `.red/tmp/supervisors/default/supervisor.log.toonl`. Capture the reported supervisor PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
 4. **Attach the best available monitor surface.**
    - Claude Code: no automatic monitor cron. Tell the user to run `/dev:afk monitor` manually or tail `.red/tmp/supervisors/default/supervisor.log.toonl`.
    - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query: `spawn agent background monitor`). If available, emit the canonical prompt with `RED_AFK_RUNNER=codex red-skills-dev codex-monitor-agent --project-root "$PWD" --mode fleet` and spawn exactly one read-only Codex monitor agent for this newly-launched supervisor. Its task: from the project root, periodically run `/dev:afk monitor --once` (the bundle's `monitor --once`), report concise progress, and auto-close when `.red/tmp/supervisors/default/afk-supervisor.pid` is missing/dead and no `[live]` workers remain. It must never edit files, claim issues, stop workers, or run merges. The user may close it manually; workers continue. If the primitive is unavailable, skip and use the manual-monitor line.
@@ -83,6 +97,7 @@ not part of the current fleet contract.
 5. **Report back.** Print:
    ```
    🚀 fleet launched (supervisor pid=<pid>, target=<N>)
+      self-heal: armed (watchdog pid=<pid>)
       log:   .red/tmp/supervisors/default/supervisor.log.toonl
       stop:  /dev:afk fleet stop
       <monitor-status-line>

--- a/plugins/dev/skills/engineering/afk/fleet.md
+++ b/plugins/dev/skills/engineering/afk/fleet.md
@@ -45,6 +45,20 @@ Fleet mode is **runner-portable**: the supervisor is plain process orchestration
 - Codex: launch fleet with `RED_AFK_RUNNER=codex` and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl manually.`
 - Bare terminal / unknown runner: launch fleet and print the manual-monitor guidance.
 
+**Self-heal is not a monitor side effect.** Every successful fleet launch also
+arms one detached watchdog in that fleet's repo-scoped runtime lane. It probes
+the exact `afk-supervisor.pid` plus `afk-supervisor.pid.start` identity once per
+`RED_AFK_POLL_S` (15 seconds by default), so a same-command supervisor in a
+sibling repo and a recycled PID cannot satisfy the liveness check. A dead
+supervisor with `ready-for-agent > 0` and live workers below target is relaunched
+within one poll window, subject to the existing bounded-restart guard. The new
+supervisor boot runs the stale local/cross-host claim reconciliation before
+draining again. Every catchable terminal path writes one `supervisor.exit`
+record with `reason=signal|exception|explicit-stop|completed`; the process-exit
+hook is the synchronous best-effort fallback for exits that bypass the awaited
+path. SIGKILL cannot run user-space cleanup, so its retained pinned PID plus the
+watchdog recovery record is the forensic signal.
+
 **Release recycle rule.** A fleet supervisor keeps running the exact dev bundle
 version it was launched from. After any RedSkills release that changes AFK or
 castle engine behavior, stop and relaunch the fleet before starting or counting
@@ -59,7 +73,7 @@ not part of the current fleet contract.
 `N` is optional and defaults to `2`. Parse it as a non-negative integer; reject anything else (including `stop`, which is the other subcommand and routes below). Steps the agent must perform, in order:
 
 1. **Resolve runner.** Determine the active runner using the same intent as the normal AFK cascade: explicit user `--runner` if present, else `RED_AFK_RUNNER`, else runner env/process/path signals, else `claude`. The resolved value is carried into the supervisor as `RED_AFK_RUNNER=<runner>` so detached workers do not fall through to the supervisor's historical `claude` fallback. Under Codex, this must resolve to `codex`.
-2. **PID-file pre-check / live directive.** Read `.red/tmp/supervisors/default/afk-supervisor.pid`. If it exists and `kill -0 <pid>` succeeds, do not launch a second supervisor. Instead the bundle command writes the `afk-supervisor.resize` directive file in the supervisor runtime lane (`.red/tmp/supervisors/default/`) as the live directive:
+2. **PID-file pre-check / live directive.** Read `.red/tmp/supervisors/default/afk-supervisor.pid` and its `.pid.start` process-start pin. If the PID is live and the current start token matches, do not launch a second supervisor. Instead the bundle command writes the `afk-supervisor.resize` directive file in the supervisor runtime lane (`.red/tmp/supervisors/default/`) as the live directive:
    - `fleet <N>` changes the desired worker count while keeping the current runner.
    - `fleet <N> --shrink-mode hard-kill|drain-then-retire` changes the resize shrink behavior. The default is `drain-then-retire`.
    - `fleet <N> --runner <runner>` asks the running supervisor to switch runner. A changed runner is applied by re-pinning the supervisor's worker env, marking every live slot `drain-then-retire`, letting in-flight claims finish, then respawning replacement slots on the new runner. An unchanged runner is a no-op.
@@ -75,7 +89,7 @@ not part of the current fleet contract.
    ```bash
    RED_AFK_RUNNER=<runner> red-skills-dev fleet <N> [--request <text>]
    ```
-   The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/supervisors/default/afk-supervisor.pid` to appear and contain a live PID, then prints the launched supervisor PID and target; on failure it reports the tail of `.red/tmp/supervisors/default/supervisor.log.toonl`. Capture the reported PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
+   The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/supervisors/default/afk-supervisor.pid` to appear and contain a live pinned PID, then arms the repo-scoped self-heal watchdog and prints both PIDs plus the target. Failure to arm either process fails the launch; supervisor failure reports the tail of `.red/tmp/supervisors/default/supervisor.log.toonl`. Capture the reported supervisor PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
 4. **Attach the best available monitor surface.**
    - Claude Code: no automatic monitor cron. Tell the user to run `/dev:afk monitor` manually or tail `.red/tmp/supervisors/default/supervisor.log.toonl`.
    - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query: `spawn agent background monitor`). If available, emit the canonical prompt with `RED_AFK_RUNNER=codex red-skills-dev codex-monitor-agent --project-root "$PWD" --mode fleet` and spawn exactly one read-only Codex monitor agent for this newly-launched supervisor. Its task: from the project root, periodically run `/dev:afk monitor --once` (the bundle's `monitor --once`), report concise progress, and auto-close when `.red/tmp/supervisors/default/afk-supervisor.pid` is missing/dead and no `[live]` workers remain. It must never edit files, claim issues, stop workers, or run merges. The user may close it manually; workers continue. If the primitive is unavailable, skip and use the manual-monitor line.
@@ -83,6 +97,7 @@ not part of the current fleet contract.
 5. **Report back.** Print:
    ```
    🚀 fleet launched (supervisor pid=<pid>, target=<N>)
+      self-heal: armed (watchdog pid=<pid>)
       log:   .red/tmp/supervisors/default/supervisor.log.toonl
       stop:  /dev:afk fleet stop
       <monitor-status-line>


### PR DESCRIPTION
Automated AFK landing for #2442. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2442

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787290057&installation_model_id=20659&pr_number=2445&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2445&signature=56d947ce0680fcf9ca5e9ba653c0c051a79764bdaa4d319602f881e012477b14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->