### PR TITLE
chore(release): changeset to cut the post-migration reliability tail

### DIFF
--- a/.changeset/tidy-rivers-check.md
+++ b/.changeset/tidy-rivers-check.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/dev": patch
+---
+
+Ship the changesets-flow reliability tail that landed after the v2.79.0 npm
+publish was cut from the pre-migration branch: ordered publish retries with
+tail reconciliation, CI running on the `changeset-release/main` branch, the
+bypass-credential check scoped to the release flow, and the release/README
+documentation for the Version Packages PR + tag-triggered `red-publish` flow
+(ADR 0121). This cut also re-aligns the published npm content with `main`,
+which the transitional v2.79.0 tarball predates.


### PR DESCRIPTION
Adds a patch changeset so the changesets flow (ADR 0121) opens a Version Packages PR and cuts the next version. The published npm v2.79.0 tarball was cut from the pre-migration branch and predates the changesets-flow reliability fixes now on `main`; this cut re-aligns published content with `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787312972&installation_model_id=20659&pr_number=2458&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2458&signature=8b2bfcac5c1c2cbf205d7ceea97655097f3987c2023c3c4f159076a1701e3ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->