### PR TITLE
fix(publish): FIFO scan skips stale incomplete releases instead of erroring

### DIFF
--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -102,10 +102,17 @@ jobs:
           }
 
           major_is_ahead() {
-            local candidate="$1" major major_sha pointed pointed_version candidate_version
+            local candidate="$1" major major_sha pointed pointed_version candidate_version newest
             major="$(major_for "$candidate")"
             major_sha="$(git rev-parse -q --verify "refs/tags/${major}^{commit}" 2>/dev/null || true)"
-            [ -n "$major_sha" ] || return 1
+            if [ -z "$major_sha" ]; then
+              # A major line with no moving ref (pre-scheme history, e.g. v0.x)
+              # can never become complete. When the repo has already moved on to
+              # a newer major, the whole line is stale, not pending.
+              newest="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=v:refname | tail -n1)"
+              [ -n "$newest" ] && [ "$(major_for "$newest")" != "$major" ] && return 0
+              return 1
+            fi
             candidate_version="${candidate#v}"
             while IFS= read -r pointed; do
               [ -n "$pointed" ] || continue
@@ -134,12 +141,19 @@ jobs:
           # FIFO is a correctness rule, not just a retry preference. If tags
           # accumulate during fleet deferral, newest-first would publish an old
           # version second and move npm/latest plus vX backwards.
+          # A stale incomplete release (its major line already moved past it, or
+          # its major line predates the moving-ref scheme entirely) can never be
+          # published — doing so would move npm/latest and vX backwards, which
+          # is exactly what FIFO exists to prevent. Skipping keeps the queue
+          # alive for genuinely pending tags; erroring here wedged EVERY publish
+          # behind hundreds of pre-flow tags that never had a release tail
+          # (first hit: v2.79.1 blocked behind v0.0.1, then v1.2.0 — #2460).
           oldest_pending=""
           while IFS= read -r candidate; do
             if ! release_complete "$candidate"; then
               if major_is_ahead "$candidate"; then
-                echo "::error::refusing stale incomplete release $candidate: its major ref already points to a newer release"
-                exit 1
+                echo "::warning::skipping stale incomplete release $candidate: its major line already points past it"
+                continue
               fi
               oldest_pending="$candidate"
               break

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -152,6 +152,16 @@ else
   fail "explicit targets must be rejected when an older release is incomplete"
 fi
 
+# Pre-flow tags never had a release tail and can never gain one (their major
+# line already moved past them, or has no moving ref at all). They must be
+# skipped, not fatal: erroring wedged every publish behind v0.0.1/v1.2.0 (#2460).
+if grep -qF 'skipping stale incomplete release' "$WORKFLOW" &&
+   ! grep -qF 'refusing stale incomplete release' "$WORKFLOW"; then
+  pass "stale incomplete releases are skipped, never fatal"
+else
+  fail "a stale incomplete release must be skipped by the FIFO scan, not error the run"
+fi
+
 # ADR 0121: the tag is the publish trigger. A `push: branches` trigger would put
 # the publish back on every commit to main, which is exactly the design this
 # replaced.


### PR DESCRIPTION
Fixes the red-publish queue jam from #2460: the oldest-pending FIFO scan hard-failed on the first stale incomplete release (pre-flow tags with no release tail), blocking v2.79.1 behind v0.0.1 and then v1.2.0.

- Stale incomplete releases (major line already past them) are now skipped with a warning instead of erroring the run — they can never be published anyway, since that would move npm/latest and the vX ref backwards.
- A major line with no moving ref (pre-scheme v0.x) is treated as stale once a newer major exists.
- Contract test pins the skip behavior and forbids the fatal path.

Closes #2460

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787314481&installation_model_id=20659&pr_number=2461&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2461&signature=806cfc6ea3c7c95d713077cafa2ce10be0eb50589d731570a29d5a297633e8db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->