### PR TITLE
docs(skills): make npx direct-run the canonical red-skills-dev invocation

### DIFF
--- a/apps/dev/tests/afk-invocation-contract-docs.test.ts
+++ b/apps/dev/tests/afk-invocation-contract-docs.test.ts
@@ -13,7 +13,7 @@ describe("AFK invocation contract docs (#1946)", () => {
   it("AFK documents runtime resolution, npm direct-run fallback, and valid subcommands", async () => {
     const skill = await readSkill("afk/SKILL.md");
 
-    expect(skill).toContain("installed `red-skills-dev` shim on `PATH` first");
+    expect(skill).toContain("canonical\nform is the ADR 0091 npm direct-run");
     expect(skill).toContain("npx -y -p @reddb-io/red-skills@<version> red-skills-dev");
     expect(skill).toContain("The AFK queue-drain subcommand is `run`");
     expect(skill).toContain("There is no\n`red-skills-dev afk` subcommand");
@@ -22,10 +22,10 @@ describe("AFK invocation contract docs (#1946)", () => {
   it("shared report-runtime wrapper owns the binary precedence and missing-shim action", async () => {
     const wrapper = await readSkill("_report-runtime/WRAPPER.md");
 
-    expect(wrapper).toContain("Prefer an installed `red-skills-dev` shim on `PATH`");
-    expect(wrapper).toContain("Otherwise use the ADR 0091 npm direct-run transport");
+    expect(wrapper).toContain("The npm direct-run form is the canonical invocation");
+    expect(wrapper).toContain("warm-cache\noptimization");
     expect(wrapper).toContain("npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand> [args]");
-    expect(wrapper).toContain("do not report a bare command-not-found");
+    expect(wrapper).toContain("fall through to the npx form silently");
     expect(wrapper).toContain("There is no `red-skills-dev afk` subcommand");
   });
 

--- a/packaging/pi/dev/skills/engineering/_report-runtime/WRAPPER.md
+++ b/packaging/pi/dev/skills/engineering/_report-runtime/WRAPPER.md
@@ -3,33 +3,36 @@
 All RedSkills operational-report skills delegate to the dev runtime; they never
 hand-calculate metrics.
 
-## Run shim
+## Canonical invocation: npx direct-run
 
-Resolve the RedSkills dev runtime the same way for every operational skill:
-
-1. Prefer an installed `red-skills-dev` shim on `PATH` when `command -v
-   red-skills-dev` succeeds. This is the short form used by prepared hosts.
-2. Otherwise use the ADR 0091 npm direct-run transport. Pin a known version when
-   the caller or repo provides one; use the current dist-tag only when no pin is
-   available:
+**The npm direct-run form is the canonical invocation** (ADR 0091) — it works
+on EVERY installation, because npm is the one transport every host already has.
+A bare `red-skills-dev` only exists where an installer created the shim, so a
+skill that leads with the bare form breaks on exactly the hosts that need it
+most. Always write and run:
 
 ```bash
 npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand> [args]
 ```
 
-If `red-skills-dev` is missing, do not report a bare command-not-found. Say that
-the host lacks the shim and run, or ask the operator to run, the `npx -y -p
-@reddb-io/red-skills@<version> red-skills-dev ...` fallback.
+Resolve `<version>` from the installed plugin (the statusline `vX.Y.Z`, or the
+plugin's `plugin.json`); use the `latest` dist-tag only when no pin is known.
+
+A host MAY use an installed `red-skills-dev` shim on `PATH` as a warm-cache
+optimization when `command -v red-skills-dev` succeeds — same engine, same
+arguments, faster start. The shim is never required, and its absence is not an
+error: fall through to the npx form silently instead of surfacing a
+command-not-found.
 
 The valid dev CLI subcommands for these skills are explicit: `run`, `fleet`,
 `monitor`, `dashboard`, `daily-review`, `weekly-review`, `retake`, and
 `requeue`. There is no `red-skills-dev afk` subcommand; `/afk` maps to
 `red-skills-dev run` or to the bare run flags documented by the AFK skill.
 
-When the shim is available, run it with the skill-specific subcommand:
+The skill-specific subcommand always rides the canonical form:
 
 ```bash
-red-skills-dev <subcommand> [--json]
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand> [--json]
 ```
 
 When developing inside the red-skills source checkout, this repo-local path is

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -23,8 +23,10 @@ by the server. Read the fields; do not re-parse rendered text.
 CLI — never hand-roll the operation.** The CLI is the same engine behind the
 same cores, so the fallback is a transport change, not a behavior change.
 Resolve the runtime through [`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md):
-an installed `red-skills-dev` shim on `PATH` first, otherwise the ADR 0091
-npm direct-run form `npx -y -p @reddb-io/red-skills@<version> red-skills-dev …`.
+the canonical ADR 0091 npm direct-run form
+`npx -y -p @reddb-io/red-skills@<version> red-skills-dev …`, which works on
+every installation; an installed shim on `PATH` is only a warm-cache
+optimization for the same command.
 
 ## Mutation modes are binding
 

--- a/packaging/pi/dev/skills/engineering/afk/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/afk/SKILL.md
@@ -36,16 +36,16 @@ CLI** — the same engine over the same cores, so the fallback changes transport
 not behavior. The invoking LLM is responsible for setting `RED_AFK_RUNNER` to
 its own host runner (`codex` from Codex, `claude` from Claude Code). Resolve the
 runtime through the shared contract in
-[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): use an
-installed `red-skills-dev` shim on `PATH` first, otherwise use the ADR 0091 npm
-direct-run fallback
-`npx -y -p @reddb-io/red-skills@<version> red-skills-dev ...`. If the shim is
-missing, name that fallback instead of surfacing a bare command-not-found.
+[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): the canonical
+form is the ADR 0091 npm direct-run
+`npx -y -p @reddb-io/red-skills@<version> red-skills-dev ...`, which works on
+every installation; an installed `red-skills-dev` shim on `PATH` is only a
+warm-cache optimization for the same command.
 
 Run the bundle, not the source:
 
 ```bash
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev <command> [params]
+RED_AFK_RUNNER=<claude|codex|opencode> npx -y -p @reddb-io/red-skills@<version> red-skills-dev <command> [params]
 ```
 
 `afk.mjs` is a dedicated forwarder to the `dev` bundle. Every argument reaches

--- a/packaging/pi/dev/skills/engineering/afk/docs/OPERATIONS.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/OPERATIONS.md
@@ -15,7 +15,7 @@ Drain the agent-ready backlog. Single skill that owns issue selection, worktree 
 The skill ships a single committed runtime bundle. Invoke it as:
 
 ```
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev <command> [params]
+RED_AFK_RUNNER=<claude|codex|opencode> npx -y -p @reddb-io/red-skills@<version> red-skills-dev <command> [params]
 ```
 
 The invoking LLM is responsible for setting `RED_AFK_RUNNER` to its own host runner (`codex` from Codex, `claude` from Claude Code). Do not infer a different runner from binaries on `PATH`; use `--runner` only when the user explicitly pinned one.

--- a/packaging/pi/dev/skills/engineering/afk/fleet.md
+++ b/packaging/pi/dev/skills/engineering/afk/fleet.md
@@ -73,7 +73,7 @@ not part of the current fleet contract.
    That remains the model for truly conflicting second supervisors, but `fleet <N>` is now the supported live resize/switch surface. A stale PID file (file exists but `kill -0` fails) is left alone — the `fleet` command clears it itself when it acquires the supervisor lock.
 3. **Launch the fleet.** From the project root, run the bundle's `fleet` command with the target and any flags:
    ```bash
-   RED_AFK_RUNNER=<runner> red-skills-dev fleet <N> [--request <text>]
+   RED_AFK_RUNNER=<runner> npx -y -p @reddb-io/red-skills@<version> red-skills-dev fleet <N> [--request <text>]
    ```
    The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/supervisors/default/afk-supervisor.pid` to appear and contain a live PID, then prints the launched supervisor PID and target; on failure it reports the tail of `.red/tmp/supervisors/default/supervisor.log.toonl`. Capture the reported PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
 4. **Attach the best available monitor surface.**

--- a/packaging/pi/dev/skills/engineering/afk/monitor.md
+++ b/packaging/pi/dev/skills/engineering/afk/monitor.md
@@ -42,7 +42,7 @@ non-empty open backlog is a flow bug to diagnose, never a clean stop.
 To invoke, from the project root:
 
 ```bash
-RED_AFK_RUNNER=<runner> red-skills-dev monitor
+RED_AFK_RUNNER=<runner> npx -y -p @reddb-io/red-skills@<version> red-skills-dev monitor
 ```
 
 The command has **two modes**, auto-selected by stdout type:
@@ -171,7 +171,7 @@ supervisor under Codex:
    single worker, `--mode fleet` for a supervisor, so the read-only rules stay
    identical across launches):
    ```bash
-   RED_AFK_RUNNER=codex red-skills-dev codex-monitor-agent --project-root "$PWD" --mode run
+   RED_AFK_RUNNER=codex npx -y -p @reddb-io/red-skills@<version> red-skills-dev codex-monitor-agent --project-root "$PWD" --mode run
    ```
    Spawn exactly one monitor agent with that prompt. The monitor agent is a
    presentation consumer only: it periodically runs `/dev:afk monitor --once`,

--- a/packaging/pi/dev/skills/engineering/go/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/go/SKILL.md
@@ -54,19 +54,20 @@ behavior.
 **Run the bundle — do not read its source.** This SKILL.md is the contract; the `dev` bundle's `go` command is a build artifact.
 
 Resolve the `red-skills-dev` runtime through the shared contract in
-[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): use an
-installed shim on `PATH` first, otherwise use the ADR 0091 npm direct-run form
-`npx -y -p @reddb-io/red-skills@<version> red-skills-dev go ...`. If the shim
-is missing, name that fallback instead of surfacing a bare command-not-found.
+[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): the canonical
+form is the ADR 0091 npm direct-run
+`npx -y -p @reddb-io/red-skills@<version> red-skills-dev go ...`, which works on
+every installation; an installed `red-skills-dev` shim on `PATH` is only a
+warm-cache optimization for the same command.
 
 Invoke the dev CLI's `go` command with the demand as a single quoted argument:
 
 ```
 # Standard /go — ships a PR (direct-PR is the default mode)
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go "<approved-task>" --dod "<definition-of-done>" [--request "<inner-agent-instruction>"] [--verify "<cmd>"] [--mode <mode>] [--runner <runner>] [+yolo]
+RED_AFK_RUNNER=<claude|codex|opencode> npx -y -p @reddb-io/red-skills@<version> red-skills-dev go "<approved-task>" --dod "<definition-of-done>" [--request "<inner-agent-instruction>"] [--verify "<cmd>"] [--mode <mode>] [--runner <runner>] [+yolo]
 
 # Scout mode — read-only investigation, posts a report comment, no branch/PR/merge
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go --scout "<question>" [--runner <runner>]
+RED_AFK_RUNNER=<claude|codex|opencode> npx -y -p @reddb-io/red-skills@<version> red-skills-dev go --scout "<question>" [--runner <runner>]
 ```
 
 Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex` from Codex). Use `--runner` only when the user explicitly pinned a backend. `/go` does not accept a short `-r` form; use long `--runner` for backend pinning and long `--request` for per-dispatch inner-agent instructions.

--- a/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -135,7 +135,7 @@ After installing, verify:
 ```bash
 command -v red-skills-dev
 command -v rsp
-red-skills-dev dashboard --json
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev dashboard --json
 rsp git status
 ```
 

--- a/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -126,8 +126,8 @@ footer items and persisting them to `config.toml`. The dev bundle also exposes
 an explicit inspector/fixer:
 
 ```bash
-red-skills-dev codex-statusline
-red-skills-dev codex-statusline --fix
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev codex-statusline
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev codex-statusline --fix
 ```
 
 The inspector reports the active `tui.status_line`, flags a missing

--- a/packaging/pi/dev/skills/engineering/retake/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/retake/SKILL.md
@@ -19,13 +19,14 @@ the label claims `ready-for-human`, but the truth is in the worktree.
 
 Resolve the `red-skills-dev` runtime through the shared contract in
 [`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): use an
-installed shim on `PATH` first, otherwise use the ADR 0091 npm direct-run form
+canonical ADR 0091 npm direct-run form (an installed shim on `PATH` is only a
+warm-cache optimization for the same command):
 `npx -y -p @reddb-io/red-skills@<version> red-skills-dev retake ...`. If the
 shim is missing, name that fallback instead of surfacing a bare
 command-not-found.
 
 ```bash
-red-skills-dev retake 123
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev retake 123
 ```
 
 The runtime accepts `123` and `#123`; quote `'#123'` when a shell would read it
@@ -81,7 +82,7 @@ Pick by verdict, never by label alone:
 ### Plain requeue — put a parked issue back in the queue
 
 ```bash
-red-skills-dev requeue 123 --guidance "Retry with the documented guidance; the gate flake is fixed."
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev requeue 123 --guidance "Retry with the documented guidance; the gate flake is fixed."
 ```
 
 One atomic transition: archive the active `## Current blocker` into
@@ -91,7 +92,7 @@ drop `ready-for-human` and every `blocked:*` label, add `ready-for-agent`.
 ### Adopt-branch landing — validate and land hand-done work
 
 ```bash
-red-skills-dev requeue 123 --adopt-branch my-feature-branch --guidance "Manual implementation complete; run gate."
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev requeue 123 --adopt-branch my-feature-branch --guidance "Manual implementation complete; run gate."
 ```
 
 After the requeue transition, the branch routes through the **no-agent landing

--- a/plugins/dev/skills/engineering/_report-runtime/WRAPPER.md
+++ b/plugins/dev/skills/engineering/_report-runtime/WRAPPER.md
@@ -3,33 +3,36 @@
 All RedSkills operational-report skills delegate to the dev runtime; they never
 hand-calculate metrics.
 
-## Run shim
+## Canonical invocation: npx direct-run
 
-Resolve the RedSkills dev runtime the same way for every operational skill:
-
-1. Prefer an installed `red-skills-dev` shim on `PATH` when `command -v
-   red-skills-dev` succeeds. This is the short form used by prepared hosts.
-2. Otherwise use the ADR 0091 npm direct-run transport. Pin a known version when
-   the caller or repo provides one; use the current dist-tag only when no pin is
-   available:
+**The npm direct-run form is the canonical invocation** (ADR 0091) — it works
+on EVERY installation, because npm is the one transport every host already has.
+A bare `red-skills-dev` only exists where an installer created the shim, so a
+skill that leads with the bare form breaks on exactly the hosts that need it
+most. Always write and run:
 
 ```bash
 npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand> [args]
 ```
 
-If `red-skills-dev` is missing, do not report a bare command-not-found. Say that
-the host lacks the shim and run, or ask the operator to run, the `npx -y -p
-@reddb-io/red-skills@<version> red-skills-dev ...` fallback.
+Resolve `<version>` from the installed plugin (the statusline `vX.Y.Z`, or the
+plugin's `plugin.json`); use the `latest` dist-tag only when no pin is known.
+
+A host MAY use an installed `red-skills-dev` shim on `PATH` as a warm-cache
+optimization when `command -v red-skills-dev` succeeds — same engine, same
+arguments, faster start. The shim is never required, and its absence is not an
+error: fall through to the npx form silently instead of surfacing a
+command-not-found.
 
 The valid dev CLI subcommands for these skills are explicit: `run`, `fleet`,
 `monitor`, `dashboard`, `daily-review`, `weekly-review`, `retake`, and
 `requeue`. There is no `red-skills-dev afk` subcommand; `/afk` maps to
 `red-skills-dev run` or to the bare run flags documented by the AFK skill.
 
-When the shim is available, run it with the skill-specific subcommand:
+The skill-specific subcommand always rides the canonical form:
 
 ```bash
-red-skills-dev <subcommand> [--json]
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand> [--json]
 ```
 
 When developing inside the red-skills source checkout, this repo-local path is

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -23,8 +23,10 @@ by the server. Read the fields; do not re-parse rendered text.
 CLI — never hand-roll the operation.** The CLI is the same engine behind the
 same cores, so the fallback is a transport change, not a behavior change.
 Resolve the runtime through [`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md):
-an installed `red-skills-dev` shim on `PATH` first, otherwise the ADR 0091
-npm direct-run form `npx -y -p @reddb-io/red-skills@<version> red-skills-dev …`.
+the canonical ADR 0091 npm direct-run form
+`npx -y -p @reddb-io/red-skills@<version> red-skills-dev …`, which works on
+every installation; an installed shim on `PATH` is only a warm-cache
+optimization for the same command.
 
 ## Mutation modes are binding
 

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -36,16 +36,16 @@ CLI** — the same engine over the same cores, so the fallback changes transport
 not behavior. The invoking LLM is responsible for setting `RED_AFK_RUNNER` to
 its own host runner (`codex` from Codex, `claude` from Claude Code). Resolve the
 runtime through the shared contract in
-[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): use an
-installed `red-skills-dev` shim on `PATH` first, otherwise use the ADR 0091 npm
-direct-run fallback
-`npx -y -p @reddb-io/red-skills@<version> red-skills-dev ...`. If the shim is
-missing, name that fallback instead of surfacing a bare command-not-found.
+[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): the canonical
+form is the ADR 0091 npm direct-run
+`npx -y -p @reddb-io/red-skills@<version> red-skills-dev ...`, which works on
+every installation; an installed `red-skills-dev` shim on `PATH` is only a
+warm-cache optimization for the same command.
 
 Run the bundle, not the source:
 
 ```bash
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev <command> [params]
+RED_AFK_RUNNER=<claude|codex|opencode> npx -y -p @reddb-io/red-skills@<version> red-skills-dev <command> [params]
 ```
 
 `afk.mjs` is a dedicated forwarder to the `dev` bundle. Every argument reaches

--- a/plugins/dev/skills/engineering/afk/docs/OPERATIONS.md
+++ b/plugins/dev/skills/engineering/afk/docs/OPERATIONS.md
@@ -15,7 +15,7 @@ Drain the agent-ready backlog. Single skill that owns issue selection, worktree 
 The skill ships a single committed runtime bundle. Invoke it as:
 
 ```
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev <command> [params]
+RED_AFK_RUNNER=<claude|codex|opencode> npx -y -p @reddb-io/red-skills@<version> red-skills-dev <command> [params]
 ```
 
 The invoking LLM is responsible for setting `RED_AFK_RUNNER` to its own host runner (`codex` from Codex, `claude` from Claude Code). Do not infer a different runner from binaries on `PATH`; use `--runner` only when the user explicitly pinned one.

--- a/plugins/dev/skills/engineering/afk/fleet.md
+++ b/plugins/dev/skills/engineering/afk/fleet.md
@@ -73,7 +73,7 @@ not part of the current fleet contract.
    That remains the model for truly conflicting second supervisors, but `fleet <N>` is now the supported live resize/switch surface. A stale PID file (file exists but `kill -0` fails) is left alone — the `fleet` command clears it itself when it acquires the supervisor lock.
 3. **Launch the fleet.** From the project root, run the bundle's `fleet` command with the target and any flags:
    ```bash
-   RED_AFK_RUNNER=<runner> red-skills-dev fleet <N> [--request <text>]
+   RED_AFK_RUNNER=<runner> npx -y -p @reddb-io/red-skills@<version> red-skills-dev fleet <N> [--request <text>]
    ```
    The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/supervisors/default/afk-supervisor.pid` to appear and contain a live PID, then prints the launched supervisor PID and target; on failure it reports the tail of `.red/tmp/supervisors/default/supervisor.log.toonl`. Capture the reported PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
 4. **Attach the best available monitor surface.**

--- a/plugins/dev/skills/engineering/afk/monitor.md
+++ b/plugins/dev/skills/engineering/afk/monitor.md
@@ -42,7 +42,7 @@ non-empty open backlog is a flow bug to diagnose, never a clean stop.
 To invoke, from the project root:
 
 ```bash
-RED_AFK_RUNNER=<runner> red-skills-dev monitor
+RED_AFK_RUNNER=<runner> npx -y -p @reddb-io/red-skills@<version> red-skills-dev monitor
 ```
 
 The command has **two modes**, auto-selected by stdout type:
@@ -171,7 +171,7 @@ supervisor under Codex:
    single worker, `--mode fleet` for a supervisor, so the read-only rules stay
    identical across launches):
    ```bash
-   RED_AFK_RUNNER=codex red-skills-dev codex-monitor-agent --project-root "$PWD" --mode run
+   RED_AFK_RUNNER=codex npx -y -p @reddb-io/red-skills@<version> red-skills-dev codex-monitor-agent --project-root "$PWD" --mode run
    ```
    Spawn exactly one monitor agent with that prompt. The monitor agent is a
    presentation consumer only: it periodically runs `/dev:afk monitor --once`,

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -54,19 +54,20 @@ behavior.
 **Run the bundle — do not read its source.** This SKILL.md is the contract; the `dev` bundle's `go` command is a build artifact.
 
 Resolve the `red-skills-dev` runtime through the shared contract in
-[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): use an
-installed shim on `PATH` first, otherwise use the ADR 0091 npm direct-run form
-`npx -y -p @reddb-io/red-skills@<version> red-skills-dev go ...`. If the shim
-is missing, name that fallback instead of surfacing a bare command-not-found.
+[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): the canonical
+form is the ADR 0091 npm direct-run
+`npx -y -p @reddb-io/red-skills@<version> red-skills-dev go ...`, which works on
+every installation; an installed `red-skills-dev` shim on `PATH` is only a
+warm-cache optimization for the same command.
 
 Invoke the dev CLI's `go` command with the demand as a single quoted argument:
 
 ```
 # Standard /go — ships a PR (direct-PR is the default mode)
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go "<approved-task>" --dod "<definition-of-done>" [--request "<inner-agent-instruction>"] [--verify "<cmd>"] [--mode <mode>] [--runner <runner>] [+yolo]
+RED_AFK_RUNNER=<claude|codex|opencode> npx -y -p @reddb-io/red-skills@<version> red-skills-dev go "<approved-task>" --dod "<definition-of-done>" [--request "<inner-agent-instruction>"] [--verify "<cmd>"] [--mode <mode>] [--runner <runner>] [+yolo]
 
 # Scout mode — read-only investigation, posts a report comment, no branch/PR/merge
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go --scout "<question>" [--runner <runner>]
+RED_AFK_RUNNER=<claude|codex|opencode> npx -y -p @reddb-io/red-skills@<version> red-skills-dev go --scout "<question>" [--runner <runner>]
 ```
 
 Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex` from Codex). Use `--runner` only when the user explicitly pinned a backend. `/go` does not accept a short `-r` form; use long `--runner` for backend pinning and long `--request` for per-dispatch inner-agent instructions.

--- a/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -135,7 +135,7 @@ After installing, verify:
 ```bash
 command -v red-skills-dev
 command -v rsp
-red-skills-dev dashboard --json
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev dashboard --json
 rsp git status
 ```
 

--- a/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -126,8 +126,8 @@ footer items and persisting them to `config.toml`. The dev bundle also exposes
 an explicit inspector/fixer:
 
 ```bash
-red-skills-dev codex-statusline
-red-skills-dev codex-statusline --fix
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev codex-statusline
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev codex-statusline --fix
 ```
 
 The inspector reports the active `tui.status_line`, flags a missing

--- a/plugins/dev/skills/engineering/retake/SKILL.md
+++ b/plugins/dev/skills/engineering/retake/SKILL.md
@@ -19,13 +19,14 @@ the label claims `ready-for-human`, but the truth is in the worktree.
 
 Resolve the `red-skills-dev` runtime through the shared contract in
 [`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): use an
-installed shim on `PATH` first, otherwise use the ADR 0091 npm direct-run form
+canonical ADR 0091 npm direct-run form (an installed shim on `PATH` is only a
+warm-cache optimization for the same command):
 `npx -y -p @reddb-io/red-skills@<version> red-skills-dev retake ...`. If the
 shim is missing, name that fallback instead of surfacing a bare
 command-not-found.
 
 ```bash
-red-skills-dev retake 123
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev retake 123
 ```
 
 The runtime accepts `123` and `#123`; quote `'#123'` when a shell would read it
@@ -81,7 +82,7 @@ Pick by verdict, never by label alone:
 ### Plain requeue — put a parked issue back in the queue
 
 ```bash
-red-skills-dev requeue 123 --guidance "Retry with the documented guidance; the gate flake is fixed."
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev requeue 123 --guidance "Retry with the documented guidance; the gate flake is fixed."
 ```
 
 One atomic transition: archive the active `## Current blocker` into
@@ -91,7 +92,7 @@ drop `ready-for-human` and every `blocked:*` label, add `ready-for-agent`.
 ### Adopt-branch landing — validate and land hand-done work
 
 ```bash
-red-skills-dev requeue 123 --adopt-branch my-feature-branch --guidance "Manual implementation complete; run gate."
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev requeue 123 --adopt-branch my-feature-branch --guidance "Manual implementation complete; run gate."
 ```
 
 After the requeue transition, the branch routes through the **no-agent landing


### PR DESCRIPTION
Maintainer directive: skills must lead with the universal invocation. Bare `red-skills-dev` breaks on every installation without the shim; field reports of 'command not found' style failures track back to skills teaching the bare form first.

- `_report-runtime/WRAPPER.md`: npx direct-run is canonical; shim demoted to warm-cache optimization.
- All 14 command examples across afk/go/retake/fleet/monitor/statusline/red-setup docs now show the npx form.
- Shim-first prose in afk/SKILL.md, go/SKILL.md, retake/SKILL.md, afk/MCP.md inverted.
- `afk-invocation-contract-docs.test.ts` repointed; affected doc tests green locally (16/16).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787316309&installation_model_id=20659&pr_number=2465&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2465&signature=cd692f5052998937dddac2b1ba04f67a92d5d3e519ba0c439bcccc3665f2d792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->