### PR TITLE
chore(release): changeset for the npx-canonical skill docs

### DIFF
--- a/.changeset/brave-shims-wave.md
+++ b/.changeset/brave-shims-wave.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/dev": patch
+---
+
+Skill docs now teach the npx direct-run form (`npx -y -p @reddb-io/red-skills@<version>
+red-skills-dev ...`) as the canonical invocation everywhere; a bare `red-skills-dev`
+shim is demoted to a warm-cache optimization. Field installs without the shim
+followed the old docs into command-not-found failures.


### PR DESCRIPTION
Patch changeset so PR #2465 (npx canonical invocation docs) ships to npm/Pi installations, not only marketplace readers of main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787316822&installation_model_id=20659&pr_number=2468&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2468&signature=1a7f24a7a80e5d07d52478acd83bc20507d9c6ffc37640a8030c6a65930e8f43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->