### PR TITLE
fix(landing): squash attempt micro-history before the pre-merge rebase; adopted branches sync base first

### DIFF
--- a/.changeset/calm-rivers-land.md
+++ b/.changeset/calm-rivers-land.md
@@ -1,0 +1,10 @@
+---
+"@reddb-io/dev": minor
+---
+
+Landing squashes a worker branch's own micro-history to one commit at its fork
+point before the pre-merge rebase, so a 60-commit retry chain presents ONE
+consolidated conflict set instead of replaying every continuous-push commit
+sequentially onto fresh trunk. Branch adoption (re-claim resume) now opens with
+a mandatory base sync instruction — fetch + rebase onto origin/<base>, resolving
+conflicts while the agent is present and drift is smallest. (#2481)

--- a/apps/dev/src/core/branch-resume.ts
+++ b/apps/dev/src/core/branch-resume.ts
@@ -79,20 +79,34 @@ export function isExplicitRestartRequested(humanGuidance: string): boolean {
  * Build the content for the `<resume-from-branch>` handoff section.
  * Gate-green variant: agent verifies + gates, no re-implementation.
  * Non-gate-green variant: agent continues from where the branch left off.
+ *
+ * Both variants open with a MANDATORY base sync (issue #2481): an adopted
+ * branch carries every prior attempt's commits on an ever-staler base, and
+ * deferring the sync to landing turns small drift into a massive sequential
+ * rebase. Resolving conflicts now — while the agent is present and the drift
+ * is at its smallest — is the cheap moment.
  */
-export function buildResumeInstruction(branch: string, isGateGreen: boolean): string {
+export function buildResumeInstruction(branch: string, isGateGreen: boolean, base = "main"): string {
+  const syncFirst = [
+    `FIRST, before anything else, sync the branch with the current base:`,
+    `run \`git fetch origin ${base}\` then \`git rebase origin/${base}\`.`,
+    "If the rebase conflicts, resolve every conflict NOW (honor both sides),",
+    "`git rebase --continue`, and push the synced branch with",
+    "`git push --force-with-lease`. Only then proceed.",
+  ].join(" ");
   if (isGateGreen) {
     return [
       `Branch \`${branch}\` was pushed in a prior attempt and its gate already passed.`,
-      "Checkout this branch in your worktree, verify the base is still fresh,",
-      "re-run the merge gate, and emit `<promise>DONE</promise>` when it passes.",
+      `Checkout this branch in your worktree. ${syncFirst}`,
+      "Re-run the merge gate, and emit `<promise>DONE</promise>` when it passes.",
       "Do NOT re-implement — the work is already there.",
     ].join(" ");
   }
   return [
     `Branch \`${branch}\` was pushed in a prior attempt.`,
-    "Checkout this branch in your worktree and continue from where it left off —",
-    "do NOT start over. Run `git log --oneline origin/main..HEAD` to see what was",
+    `Checkout this branch in your worktree. ${syncFirst}`,
+    "Continue from where it left off —",
+    `do NOT start over. Run \`git log --oneline origin/${base}..HEAD\` to see what was`,
     "already committed, then satisfy the merge gate and emit `<promise>DONE</promise>`.",
   ].join(" ");
 }

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -124,6 +124,16 @@ export interface PreMergeRebaseInput {
   resolveAgent?: (repo: string) => Promise<boolean>;
   /** Small attempt budget for `resolveAgent`; default 2. */
   maxAgentResolveAttempts?: number;
+  /**
+   * Squash the branch's own commits into one before rebasing when the branch is
+   * more than this many commits ahead of its fork point (issue #2481). Replaying
+   * dozens of continuous-push micro-commits one at a time onto a moved base
+   * multiplies every conflict by the number of commits touching that file; the
+   * landing value is the NET diff, so the rebase presents one consolidated
+   * conflict set instead. Default 1 (any multi-commit branch squashes);
+   * `Infinity` disables.
+   */
+  squashAheadThreshold?: number;
 }
 
 /** Why a {@link preMergeRebase} did not land the rebased branch on the remote. */
@@ -156,6 +166,40 @@ export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Pr
   const maxAgentResolveAttempts = Math.max(0, input.maxAgentResolveAttempts ?? 2);
   const baseRef = `${remote}/${base}`;
 
+  // Squash the branch's own micro-history down to one commit at its fork point
+  // (issue #2481). Field pathology: a five-worker retry chain accumulated 65
+  // continuous-push commits on an ever-staler base; the landing rebase then
+  // replayed them ONE AT A TIME onto fresh trunk, re-hitting the same conflicts
+  // file by file for 40+ minutes. The squash runs in the ISOLATED rebase
+  // worktree (never the primary) and the pre-squash history survives on the
+  // pushed remote branch until the force-push publishes the squashed result.
+  // Best-effort: any failure leaves the branch unsquashed and the rebase
+  // proceeds exactly as before.
+  const squashThreshold = input.squashAheadThreshold ?? 1;
+  const squashOwnHistory = async (): Promise<void> => {
+    const fork = await exec(["git", "-C", repo, "merge-base", baseRef, "HEAD"]);
+    const forkSha = fork.stdout.trim();
+    if (fork.code !== 0 || forkSha.length === 0) return;
+    const count = await exec(["git", "-C", repo, "rev-list", "--count", `${forkSha}..HEAD`]);
+    const ahead = Number.parseInt(count.stdout.trim(), 10);
+    if (count.code !== 0 || !Number.isFinite(ahead) || ahead <= squashThreshold) return;
+    const subjects = await exec([
+      "git", "-C", repo, "log", "--reverse", "--format=%s", `${forkSha}..HEAD`,
+    ]);
+    const body = subjects.code === 0
+      ? subjects.stdout.trim().split("\n").slice(0, 50).map((s) => `- ${s}`).join("\n")
+      : "";
+    const reset = await exec(["git", "-C", repo, "reset", "--soft", forkSha]);
+    if (reset.code !== 0) return;
+    const message = `land: squash ${ahead} attempt commits from ${branch}${body ? `\n\n${body}` : ""}`;
+    const commit = await exec(["git", "-C", repo, "commit", "-m", message, "--quiet"]);
+    if (commit.code !== 0) {
+      // A failed commit after a soft reset would leave staged-but-uncommitted
+      // work; restore the original tip so the plain rebase still runs.
+      await exec(["git", "-C", repo, "reset", "--soft", "HEAD@{1}"]);
+    }
+  };
+
   // Fetch the base tip and rebase the worker branch onto it. Reused by the
   // push-retry loop so a racing base advance is re-integrated before each retry.
   const rebaseOntoBase = async (): Promise<PreMergeRebaseResult & { alreadyIntegrated?: boolean }> => {
@@ -163,6 +207,7 @@ export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Pr
     if (fetch.code !== 0) return { ok: false, reason: "fetch-failed" };
     const alreadyIntegrated = await exec(["git", "-C", repo, "merge-base", "--is-ancestor", baseRef, "HEAD"]);
     if (alreadyIntegrated.code === 0) return { ok: true, alreadyIntegrated: true };
+    await squashOwnHistory();
     const rebase = await exec(["git", "-C", repo, "rebase", baseRef]);
     if (rebase.code !== 0) {
       // #1095: give the opt-in mechanical resolver a chance to auto-resolve

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -286,7 +286,7 @@ export async function processIssue(
   const resumeIsGateGreen = resumableBranch !== null && isGateGreenBranch(failureReason);
   const resumeInstruction =
     resumableBranch !== null
-      ? buildResumeInstruction(resumableBranch.branch, resumeIsGateGreen)
+      ? buildResumeInstruction(resumableBranch.branch, resumeIsGateGreen, base)
       : undefined;
   const outputShaping = assignOutputShaping(issue, deps.outputShaping ?? { terseSteering: false });
   const handoff = buildHandoff({

--- a/apps/dev/tests/branch-resume.test.ts
+++ b/apps/dev/tests/branch-resume.test.ts
@@ -173,7 +173,23 @@ describe("buildResumeInstruction", () => {
 
   it("non-gate-green variant tells the agent to continue from where it left off", () => {
     const text = buildResumeInstruction("afk/wAB12/9-fix", false);
-    expect(text).toContain("continue from where it left off");
+    expect(text).toContain("Continue from where it left off");
     expect(text).toContain("do NOT start over");
+  });
+
+  it("both variants open with a mandatory base sync before any work (#2481)", () => {
+    for (const gateGreen of [true, false]) {
+      const text = buildResumeInstruction("afk/wAB12/9-fix", gateGreen);
+      expect(text).toContain("FIRST, before anything else, sync the branch");
+      expect(text).toContain("git rebase origin/main");
+      expect(text).toContain("git push --force-with-lease");
+    }
+  });
+
+  it("sync instruction names the configured base branch", () => {
+    const text = buildResumeInstruction("afk/wAB12/9-fix", false, "develop");
+    expect(text).toContain("git fetch origin develop");
+    expect(text).toContain("git rebase origin/develop");
+    expect(text).toContain("origin/develop..HEAD");
   });
 });

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -875,6 +875,75 @@ describe("preMergeRebase (#1006)", () => {
   const base = { repo: "/wt", remote: "origin", base: "main", branch: "afk/w/9-x" };
   const needsRebase = { match: (a: string[]) => a.includes("merge-base"), result: { code: 1 } };
 
+  // #2481 squash rules: fork-point discovery answers a sha, rev-list answers a
+  // multi-commit count, so squashOwnHistory engages. `needsRebase` above matches
+  // ANY argv containing "merge-base", so squash-specific tests use these finer
+  // rules instead.
+  const ancestorCheckFails = {
+    match: (a: string[]) => a.includes("--is-ancestor"),
+    result: { code: 1 },
+  };
+  const forkPoint = {
+    match: (a: string[]) => a.includes("merge-base") && !a.includes("--is-ancestor"),
+    result: { code: 0, stdout: "forksha\n" },
+  };
+  const aheadBy = (n: number) => ({
+    match: (a: string[]) => a.includes("rev-list"),
+    result: { code: 0, stdout: `${n}\n` },
+  });
+
+  it("multi-commit branch squashes to one commit at the fork point before rebasing (#2481)", async () => {
+    const { exec, calls } = fakeExec([ancestorCheckFails, forkPoint, aheadBy(65)]);
+    const r = await preMergeRebase(exec, base);
+    expect(r).toEqual({ ok: true });
+    const j = joined(calls);
+    expect(j).toContain("git -C /wt reset --soft forksha");
+    const commit = calls.find((c) => c.includes("commit"));
+    expect(commit?.join(" ")).toContain("land: squash 65 attempt commits from afk/w/9-x");
+    // Squash happens BEFORE the rebase replays onto the base.
+    const resetIdx = j.findIndex((c) => c.includes("reset --soft forksha"));
+    const rebaseIdx = j.findIndex((c) => c === "git -C /wt rebase origin/main");
+    expect(resetIdx).toBeGreaterThanOrEqual(0);
+    expect(rebaseIdx).toBeGreaterThan(resetIdx);
+  });
+
+  it("single-commit branch does not squash (#2481)", async () => {
+    const { exec, calls } = fakeExec([ancestorCheckFails, forkPoint, aheadBy(1)]);
+    const r = await preMergeRebase(exec, base);
+    expect(r).toEqual({ ok: true });
+    const j = joined(calls);
+    expect(j.some((c) => c.includes("reset --soft"))).toBe(false);
+    expect(j).toContain("git -C /wt rebase origin/main");
+  });
+
+  it("squashAheadThreshold: Infinity disables the squash entirely (#2481)", async () => {
+    const { exec, calls } = fakeExec([ancestorCheckFails, forkPoint, aheadBy(65)]);
+    const r = await preMergeRebase(exec, { ...base, squashAheadThreshold: Infinity });
+    expect(r).toEqual({ ok: true });
+    expect(joined(calls).some((c) => c.includes("reset --soft"))).toBe(false);
+  });
+
+  it("a failed squash commit restores the tip and the plain rebase still runs (#2481)", async () => {
+    const { exec, calls } = fakeExec([
+      ancestorCheckFails,
+      forkPoint,
+      aheadBy(3),
+      { match: (a) => a.includes("commit"), result: { code: 1 } },
+    ]);
+    const r = await preMergeRebase(exec, base);
+    expect(r).toEqual({ ok: true });
+    const j = joined(calls);
+    expect(j).toContain("git -C /wt reset --soft HEAD@{1}");
+    expect(j).toContain("git -C /wt rebase origin/main");
+  });
+
+  it("fork-point discovery failure skips the squash silently (#2481)", async () => {
+    const { exec, calls } = fakeExec([needsRebase]);
+    const r = await preMergeRebase(exec, base);
+    expect(r).toEqual({ ok: true });
+    expect(joined(calls).some((c) => c.includes("reset --soft"))).toBe(false);
+  });
+
   it("clean rebase → fetches base, rebases, force-pushes the branch, ok", async () => {
     const { exec, calls } = fakeExec([needsRebase]);
     const r = await preMergeRebase(exec, base);

--- a/apps/dev/tests/process-issue-resume.test.ts
+++ b/apps/dev/tests/process-issue-resume.test.ts
@@ -103,7 +103,8 @@ describe("branch-resume: non-gate-green resume path (issue #2397)", () => {
     const handoff = trace.handoffs[0]?.content ?? "";
     expect(handoff).toContain("<resume-from-branch>");
     expect(handoff).toContain(PRIOR_BRANCH);
-    expect(handoff).toContain("continue from where it left off");
+    expect(handoff).toContain("Continue from where it left off");
+    expect(handoff).toContain("FIRST, before anything else, sync the branch");
   });
 
   it("does NOT call prepareFreshWorkerBranch when a prior branch exists (even non-gate-green)", async () => {


### PR DESCRIPTION
Implements the two highest-leverage items of #2481:

1. **Squash before the landing rebase** — `preMergeRebase` collapses the branch's own commits to one at the fork point before rebasing onto fresh trunk. A 65-commit retry chain now presents one consolidated conflict set instead of 65 sequential replays. Runs only in the isolated rebase worktree; best-effort with fallback to prior behavior; `squashAheadThreshold: Infinity` disables.
2. **Adopted branches sync base first** — the resume handoff (both gate-green and continue variants) now opens with a mandatory `git fetch origin <base> && git rebase origin/<base>` + conflict resolution + `--force-with-lease` push, executed by the inner agent at claim time while drift is smallest.

Remaining #2481 items (periodic in-attempt trunk sync; stale-branch landing guardrail) become much smaller after this and stay on the issue as follow-up slices.

Tests: 115/115 in `merge.test.ts` + `branch-resume.test.ts` (5 new squash tests, 2 new sync-instruction tests); typecheck green. Includes a minor changeset — cut a release after merge per maintainer directive.

Refs #2481

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787319022&installation_model_id=20659&pr_number=2482&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2482&signature=468070d674c5a3bd894d6db5c56c96854114e790f438cc466bf5b9f46d564a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->