### PR TITLE
fix: #2475 Boot preflight probe: host prerequisites (bash/git/jq/gh/node + bash version) with actionable BootHaltError

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -75,6 +75,7 @@ import {
   type OperationalProbeContext,
   type OperationalProbeReport,
 } from "./operational-probes.js";
+import { runHostPrerequisiteProbe } from "./operational-probes/host-prerequisites.js";
 import type { TmpJanitorPlan, WorkerDirJanitorPlan } from "./tmp-janitor.js";
 import { LABEL_HUMAN, LABEL_NEEDS_TRIAGE, LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
 
@@ -154,6 +155,8 @@ export interface PrecheckFacts {
   labelBodyCoherence?: OperationalProbeContext["labelBodyCoherence"];
   /** Optional local trunk freshness probe facts for red-doctor and boot visibility. */
   baseFreshness?: OperationalProbeContext["baseFreshness"];
+  /** Required command availability and Bash version facts for the earliest boot probe. */
+  hostPrerequisites?: OperationalProbeContext["hostPrerequisites"];
 }
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and
@@ -290,14 +293,17 @@ export class BootHaltError extends Error {
 
   constructor(phase: "docs-sweep", plan: DocsSweepPlan);
   constructor(phase: "operational-probe", probe: OperationalProbeReport["findings"][number]);
+  constructor(phase: "host-prereq", probe: OperationalProbeReport["findings"][number]);
   constructor(
-    readonly phase: "docs-sweep" | "operational-probe",
+    readonly phase: "docs-sweep" | "operational-probe" | "host-prereq",
     detail: DocsSweepPlan | OperationalProbeReport["findings"][number],
   ) {
     super(
       phase === "docs-sweep"
         ? `Docs Sweep halted (${(detail as DocsSweepPlan).haltReason ?? "unknown"}): ${renderDocsSweepFileList((detail as DocsSweepPlan).files)}`
-        : `Operational probe red: ${formatOperationalProbeFinding(detail as OperationalProbeReport["findings"][number])}`,
+        : `${phase === "host-prereq" ? "Host prerequisite probe red" : "Operational probe red"}: ${formatOperationalProbeFinding(
+            detail as OperationalProbeReport["findings"][number],
+          )}`,
     );
     this.name = "BootHaltError";
     if (phase === "docs-sweep") this.plan = detail as DocsSweepPlan;
@@ -655,6 +661,7 @@ export interface BootResult {
  * its plan through injected IO. The order is the parity target (afk.sh top-level
  * startup):
  *
+ *   0. host prerequisites   — required commands + Bash baseline; failure halts.
  *   1. precheck             — hard preconditions; a failure aborts the run.
  *   2. bootstrap            — ensure .red/tmp + .red/state, gitignore lines,
  *                             per-worker dir + worker.pid (via fs).
@@ -688,6 +695,9 @@ export interface BootResult {
  * bootstrap+claim only and never races peers over `.red/tmp` / branch / gh state.
  */
 export async function runBoot(deps: BootDeps, options: BootOptions): Promise<BootResult> {
+  const hostPrerequisite = runHostPrerequisiteProbe(options.operationalProbes ?? options.precheck);
+  if (hostPrerequisite.verdict === "red") throw new BootHaltError("host-prereq", hostPrerequisite);
+
   // ---- 1. precheck ----
   const pre = precheck(options.precheck);
   if (!pre.ok) return { precheck: pre };

--- a/apps/dev/src/core/operational-probes.ts
+++ b/apps/dev/src/core/operational-probes.ts
@@ -5,6 +5,7 @@ export * from "./operational-probes/claim-hygiene.js";
 export * from "./operational-probes/config-coherence.js";
 export * from "./operational-probes/fleet-truth.js";
 export * from "./operational-probes/focal-branch.js";
+export * from "./operational-probes/host-prerequisites.js";
 export * from "./operational-probes/https-remote.js";
 export * from "./operational-probes/label-body-coherence.js";
 export * from "./operational-probes/queue-visibility.js";

--- a/apps/dev/src/core/operational-probes/host-prerequisites.ts
+++ b/apps/dev/src/core/operational-probes/host-prerequisites.ts
@@ -61,7 +61,30 @@ export function runHostPrerequisiteProbe(context: OperationalProbeContext): Oper
   }
 
   const bashVersion = parseBashVersion(input.bashVersion);
-  if (bashVersion && olderThanMinimum(bashVersion)) {
+  if (!bashVersion) {
+    const observed = input.bashVersion?.trim() || "no output";
+    const failure = input.bashVersionError
+      ? input.bashVersionExitCode === undefined
+        ? `bash --version failed: ${input.bashVersionError}`
+        : `bash --version exited ${input.bashVersionExitCode}: ${input.bashVersionError}`
+      : input.bashVersionExitCode === undefined
+        ? `could not determine bash version from: ${observed}`
+        : `bash --version exited ${input.bashVersionExitCode} with no diagnostic`;
+    return {
+      id: HOST_PREREQUISITE_PROBE_ID,
+      name: HOST_PREREQUISITE_PROBE_NAME,
+      verdict: "red",
+      evidence: failure,
+      canonicalFix: `Install a working bash ${MINIMUM_BASH_VERSION} or newer and expose it on PATH. Verify after installation: bash --version`,
+      data: {
+        bashVersionOutput: observed,
+        bashVersionExitCode: input.bashVersionExitCode,
+        bashVersionError: input.bashVersionError,
+        minimumBashVersion: MINIMUM_BASH_VERSION,
+      },
+    };
+  }
+  if (olderThanMinimum(bashVersion)) {
     const observed = bashVersion.join(".");
     return {
       id: HOST_PREREQUISITE_PROBE_ID,

--- a/apps/dev/src/core/operational-probes/host-prerequisites.ts
+++ b/apps/dev/src/core/operational-probes/host-prerequisites.ts
@@ -1,0 +1,90 @@
+import type {
+  HostPrerequisiteCommand,
+  OperationalProbe,
+  OperationalProbeContext,
+  OperationalProbeResult,
+} from "./types.js";
+
+export const HOST_PREREQUISITE_PROBE_ID = "afk.host-prerequisites";
+export const HOST_PREREQUISITE_PROBE_NAME = "AFK host prerequisites";
+export const MINIMUM_BASH_VERSION = "3.2.0";
+export const HOST_PREREQUISITE_CANONICAL_FIX =
+  "Install every required AFK host tool, expose it on PATH, and use a supported Bash version.";
+
+export const HOST_PREREQUISITE_COMMANDS: readonly HostPrerequisiteCommand[] = [
+  "bash",
+  "git",
+  "jq",
+  "gh",
+  "node",
+  "timeout",
+  "ps",
+];
+
+function parseBashVersion(output: string | undefined): readonly [number, number, number] | undefined {
+  const match = output?.match(/version\s+(\d+)\.(\d+)(?:\.(\d+))?/i);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)];
+}
+
+function olderThanMinimum(version: readonly [number, number, number]): boolean {
+  const minimum = [3, 2, 0] as const;
+  for (let index = 0; index < version.length; index += 1) {
+    if (version[index] !== minimum[index]) return version[index]! < minimum[index]!;
+  }
+  return false;
+}
+
+export function runHostPrerequisiteProbe(context: OperationalProbeContext): OperationalProbeResult {
+  const input = context.hostPrerequisites;
+  if (!input) {
+    return {
+      id: HOST_PREREQUISITE_PROBE_ID,
+      name: HOST_PREREQUISITE_PROBE_NAME,
+      verdict: "ok",
+      evidence: "host prerequisite check not configured",
+      canonicalFix: HOST_PREREQUISITE_CANONICAL_FIX,
+    };
+  }
+
+  const missing = HOST_PREREQUISITE_COMMANDS.filter((command) => !input.commands[command]);
+  if (missing.length > 0) {
+    const names = missing.join(", ");
+    return {
+      id: HOST_PREREQUISITE_PROBE_ID,
+      name: HOST_PREREQUISITE_PROBE_NAME,
+      verdict: "red",
+      evidence: `missing required host tools: ${names}`,
+      canonicalFix: `Install missing host prerequisites: ${names}. Verify after installation: command -v ${missing.join(" ")}`,
+      data: { missing },
+    };
+  }
+
+  const bashVersion = parseBashVersion(input.bashVersion);
+  if (bashVersion && olderThanMinimum(bashVersion)) {
+    const observed = bashVersion.join(".");
+    return {
+      id: HOST_PREREQUISITE_PROBE_ID,
+      name: HOST_PREREQUISITE_PROBE_NAME,
+      verdict: "red",
+      evidence: `bash ${observed} is older than required ${MINIMUM_BASH_VERSION}`,
+      canonicalFix: `Upgrade bash to ${MINIMUM_BASH_VERSION} or newer and expose it on PATH. Verify after upgrade: bash --version`,
+      data: { bashVersion: observed, minimumBashVersion: MINIMUM_BASH_VERSION },
+    };
+  }
+
+  return {
+    id: HOST_PREREQUISITE_PROBE_ID,
+    name: HOST_PREREQUISITE_PROBE_NAME,
+    verdict: "ok",
+    evidence: "all required host tools are available",
+    canonicalFix: HOST_PREREQUISITE_CANONICAL_FIX,
+  };
+}
+
+export const hostPrerequisiteProbe: OperationalProbe = {
+  id: HOST_PREREQUISITE_PROBE_ID,
+  name: HOST_PREREQUISITE_PROBE_NAME,
+  canonicalFix: HOST_PREREQUISITE_CANONICAL_FIX,
+  run: runHostPrerequisiteProbe,
+};

--- a/apps/dev/src/core/operational-probes/registry.ts
+++ b/apps/dev/src/core/operational-probes/registry.ts
@@ -5,6 +5,7 @@ import { claimHygieneProbe } from "./claim-hygiene.js";
 import { configCoherenceProbe } from "./config-coherence.js";
 import { fleetTruthProbe } from "./fleet-truth.js";
 import { focalBranchProbe } from "./focal-branch.js";
+import { hostPrerequisiteProbe } from "./host-prerequisites.js";
 import { httpsRemoteProbe } from "./https-remote.js";
 import { labelBodyCoherenceProbe } from "./label-body-coherence.js";
 import { queueVisibilityProbe } from "./queue-visibility.js";
@@ -17,6 +18,7 @@ import type {
 } from "./types.js";
 
 export const OPERATIONAL_PROBES: readonly OperationalProbe[] = [
+  hostPrerequisiteProbe,
   httpsRemoteProbe,
   queueVisibilityProbe,
   focalBranchProbe,

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -19,6 +19,14 @@ export interface OperationalProbeContext {
   readonly claimHygiene?: ClaimHygieneProbeInput;
   readonly labelBodyCoherence?: LabelBodyCoherenceProbeInput;
   readonly baseFreshness?: BaseFreshnessProbeInput;
+  readonly hostPrerequisites?: HostPrerequisiteProbeInput;
+}
+
+export type HostPrerequisiteCommand = "bash" | "git" | "jq" | "gh" | "node" | "timeout" | "ps";
+
+export interface HostPrerequisiteProbeInput {
+  readonly commands: Readonly<Record<HostPrerequisiteCommand, boolean>>;
+  readonly bashVersion?: string;
 }
 
 export interface ConfigNamespacingProbeInput {

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -27,6 +27,8 @@ export type HostPrerequisiteCommand = "bash" | "git" | "jq" | "gh" | "node" | "t
 export interface HostPrerequisiteProbeInput {
   readonly commands: Readonly<Record<HostPrerequisiteCommand, boolean>>;
   readonly bashVersion?: string;
+  readonly bashVersionExitCode?: number;
+  readonly bashVersionError?: string;
 }
 
 export interface ConfigNamespacingProbeInput {

--- a/apps/dev/src/runtime/hooks.ts
+++ b/apps/dev/src/runtime/hooks.ts
@@ -17,7 +17,7 @@ import { scriptDefaultResolver, type ResolveHooksOptions } from "../core/hook-co
 import { skillDirFromModule } from "../platform/skill-paths.js";
 
 /**
- * A real `HookExec`: runs the hook command through `sh -c`, passing the
+ * A real `HookExec`: runs the hook command through `bash -c`, passing the
  * documented RED_AFK_* env and the mutable context JSON on stdin, and returns
  * the exit code + captured stdout. When `libraryHooksDir` is supplied it is
  * prepended to PATH so inline config entries can call library scripts by name
@@ -29,7 +29,7 @@ export function makeHookExec(cwd: string, libraryHooksDir?: string): HookExec {
     if (libraryHooksDir) {
       fullEnv.PATH = `${libraryHooksDir}${fullEnv.PATH ? `:${fullEnv.PATH}` : ""}`;
     }
-    const r = await execTool("sh", ["-c", command], {
+    const r = await execTool("bash", ["-c", command], {
       cwd,
       env: fullEnv,
       input: stdinJson,

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -11,12 +11,17 @@ import type { AttemptDir } from "../../core/reclaim.js";
 import { LABEL_HUMAN, LABEL_READY, LABEL_RUNNING } from "../../core/triage-labels.js";
 import { allWorkersRoots, parseReapableWorkerPath } from "../../core/worker-paths.js";
 import { parseClaimRecords } from "../../core/claim.js";
-import { collectFleetTruthProbeInput } from "../../core/operational-probes.js";
+import {
+  collectFleetTruthProbeInput,
+  HOST_PREREQUISITE_COMMANDS,
+  type HostPrerequisiteProbeInput,
+} from "../../core/operational-probes.js";
 import { resolveSupervisorConfig } from "../../core/supervisor.js";
 import { evaluateFastForwardLocalTarget, fastForwardLocalTarget } from "../../core/merge.js";
 import { liveIssueFromBranch, type IssueMeta } from "../../core/branch-cleanup.js";
 import { readWorkerState } from "../../core/worker-state-reader.js";
 import { isLivePid } from "../kill-tree.js";
+import { execTool, type ExecFn } from "../exec.js";
 import { collectTmpJanitorReport } from "../tmp-janitor.js";
 import { issueMeta, type GhContext, type IssueStateRow } from "../gh.js";
 import * as ghx from "../gh.js";
@@ -103,6 +108,24 @@ export async function collectBootOptions(
 
 export interface CollectPrecheckFactsOptions {
   readonly includeNpmBundleCoherence?: boolean;
+  readonly hostPrerequisiteExec?: ExecFn;
+}
+
+export async function collectHostPrerequisiteProbeInput(
+  exec: ExecFn = execTool,
+): Promise<HostPrerequisiteProbeInput> {
+  const availability = await Promise.all(
+    HOST_PREREQUISITE_COMMANDS.map(async (command) => {
+      const result = await exec("sh", ["-c", 'command -v "$1" >/dev/null 2>&1', "host-prereq", command]);
+      return [command, result.code === 0] as const;
+    }),
+  );
+  const commands = Object.fromEntries(availability) as Record<
+    (typeof HOST_PREREQUISITE_COMMANDS)[number],
+    boolean
+  >;
+  const bashVersion = commands.bash ? (await exec("bash", ["--version"])).stdout : undefined;
+  return { commands, bashVersion };
 }
 
 export async function collectPrecheckFacts(
@@ -121,7 +144,18 @@ export async function collectPrecheckFacts(
   const configLockedBranch = getConfig(config, "dev.lock.branch") || undefined;
   const configTrunk = getConfig(config, "dev.trunk") || undefined;
   const configuredTrunkSource = configLockedBranch?.trim() ? "pin" : "trunk";
-  const [ghInstalled, ghAuthenticated, isRepo, remoteUrls, hasMain, currentBranch, pnpmProbe, lockedBranch, lockRaw] =
+  const [
+    ghInstalled,
+    ghAuthenticated,
+    isRepo,
+    remoteUrls,
+    hasMain,
+    currentBranch,
+    pnpmProbe,
+    lockedBranch,
+    lockRaw,
+    hostPrerequisites,
+  ] =
     await Promise.all([
       ghx.ghInstalled(ghCtx),
       ghx.ghAuthenticated(ghCtx),
@@ -132,6 +166,7 @@ export async function collectPrecheckFacts(
       import("../exec.js").then((m) => m.pnpm(["--version"], { cwd: ctx.root })),
       readLockedBranch(lockPath),
       fsx.readText(lockPath),
+      collectHostPrerequisiteProbeInput(options.hostPrerequisiteExec),
     ]);
   const resolvedFocalBranch = await resolveBaseWithSource(
     { issueBody: "" },
@@ -207,6 +242,7 @@ export async function collectPrecheckFacts(
     configuredTrunk,
     configuredTrunkSource,
     pnpmInstalled,
+    hostPrerequisites,
     // CI lanes (the GHA Actions lane) check out an https remote token-authed by
     // GITHUB_TOKEN — the intended setup — so the SSH-only rule must not fire there.
     allowHttpsRemote:

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -124,8 +124,23 @@ export async function collectHostPrerequisiteProbeInput(
     (typeof HOST_PREREQUISITE_COMMANDS)[number],
     boolean
   >;
-  const bashVersion = commands.bash ? (await exec("bash", ["--version"])).stdout : undefined;
-  return { commands, bashVersion };
+  if (!commands.bash) return { commands };
+
+  try {
+    const result = await exec("bash", ["--version"]);
+    if (result.code === 0) return { commands, bashVersion: result.stdout };
+    return {
+      commands,
+      bashVersion: result.stdout,
+      bashVersionExitCode: result.code,
+      bashVersionError: result.stderr.trim() || undefined,
+    };
+  } catch (error) {
+    return {
+      commands,
+      bashVersionError: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 export async function collectPrecheckFacts(

--- a/apps/dev/tests/host-prerequisite.test.ts
+++ b/apps/dev/tests/host-prerequisite.test.ts
@@ -64,6 +64,21 @@ describe("AFK host prerequisite boot probe", () => {
     ]);
   });
 
+  it("preserves a failed bash version command for the operational diagnostic", async () => {
+    const exec: ExecFn = async (command) => {
+      if (command === "bash") {
+        return { code: 2, stdout: "", stderr: "bash: cannot execute" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+
+    await expect(collectHostPrerequisiteProbeInput(exec)).resolves.toMatchObject({
+      bashVersion: "",
+      bashVersionExitCode: 2,
+      bashVersionError: "bash: cannot execute",
+    });
+  });
+
   it("halts before bootstrap with an actionable fix when jq is missing", async () => {
     const { deps, calls } = makeDeps();
 
@@ -125,6 +140,41 @@ describe("AFK host prerequisite boot probe", () => {
       phase: "host-prereq",
       probe: {
         evidence: "bash 3.1.23 is older than required 3.2.0",
+        canonicalFix: expect.stringMatching(/bash --version$/),
+      },
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("halts before bootstrap when the bash version cannot be determined", async () => {
+    const { deps, calls } = makeDeps();
+
+    await expect(
+      runBoot(
+        deps,
+        options({
+          precheck: facts({
+            hostPrerequisites: {
+              commands: {
+                bash: true,
+                git: true,
+                jq: true,
+                gh: true,
+                node: true,
+                timeout: true,
+                ps: true,
+              },
+              bashVersion: "",
+              bashVersionExitCode: 2,
+              bashVersionError: "bash: cannot execute",
+            },
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({
+      phase: "host-prereq",
+      probe: {
+        evidence: "bash --version exited 2: bash: cannot execute",
         canonicalFix: expect.stringMatching(/bash --version$/),
       },
     });

--- a/apps/dev/tests/host-prerequisite.test.ts
+++ b/apps/dev/tests/host-prerequisite.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { runOperationalProbes } from "../src/core/operational-probes.js";
+import type { ExecFn } from "../src/runtime/exec.js";
+import { collectHostPrerequisiteProbeInput } from "../src/runtime/wire/boot.js";
+import { facts, makeDeps, options, runBoot } from "./boot.helpers.js";
+
+describe("AFK host prerequisite boot probe", () => {
+  it("is the first registered operational probe", async () => {
+    const report = await runOperationalProbes({
+      remoteUrls: [],
+      hostPrerequisites: {
+        commands: {
+          bash: true,
+          git: true,
+          jq: true,
+          gh: true,
+          node: true,
+          timeout: true,
+          ps: true,
+        },
+        bashVersion: "GNU bash, version 5.2.15(1)-release",
+      },
+    });
+
+    expect(report.probes[0]).toMatchObject({
+      id: "afk.host-prerequisites",
+      verdict: "ok",
+      evidence: "all required host tools are available",
+    });
+  });
+
+  it("collects command availability and the bash version through the process boundary", async () => {
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    const exec: ExecFn = async (command, args) => {
+      calls.push({ command, args });
+      if (command === "bash") {
+        return { code: 0, stdout: "GNU bash, version 5.2.15(1)-release\n", stderr: "" };
+      }
+      const tool = args[3];
+      return { code: tool === "jq" ? 127 : 0, stdout: "", stderr: "" };
+    };
+
+    await expect(collectHostPrerequisiteProbeInput(exec)).resolves.toEqual({
+      commands: {
+        bash: true,
+        git: true,
+        jq: false,
+        gh: true,
+        node: true,
+        timeout: true,
+        ps: true,
+      },
+      bashVersion: "GNU bash, version 5.2.15(1)-release\n",
+    });
+    expect(calls).toEqual([
+      { command: "sh", args: ["-c", 'command -v "$1" >/dev/null 2>&1', "host-prereq", "bash"] },
+      { command: "sh", args: ["-c", 'command -v "$1" >/dev/null 2>&1', "host-prereq", "git"] },
+      { command: "sh", args: ["-c", 'command -v "$1" >/dev/null 2>&1', "host-prereq", "jq"] },
+      { command: "sh", args: ["-c", 'command -v "$1" >/dev/null 2>&1', "host-prereq", "gh"] },
+      { command: "sh", args: ["-c", 'command -v "$1" >/dev/null 2>&1', "host-prereq", "node"] },
+      { command: "sh", args: ["-c", 'command -v "$1" >/dev/null 2>&1', "host-prereq", "timeout"] },
+      { command: "sh", args: ["-c", 'command -v "$1" >/dev/null 2>&1', "host-prereq", "ps"] },
+      { command: "bash", args: ["--version"] },
+    ]);
+  });
+
+  it("halts before bootstrap with an actionable fix when jq is missing", async () => {
+    const { deps, calls } = makeDeps();
+
+    await expect(
+      runBoot(
+        deps,
+        options({
+          precheck: facts({
+            hostPrerequisites: {
+              commands: {
+                bash: true,
+                git: true,
+                jq: false,
+                gh: true,
+                node: true,
+                timeout: true,
+                ps: true,
+              },
+              bashVersion: "GNU bash, version 5.2.15(1)-release",
+            },
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({
+      phase: "host-prereq",
+      probe: {
+        id: "afk.host-prerequisites",
+        evidence: "missing required host tools: jq",
+        canonicalFix: expect.stringMatching(/command -v jq$/),
+      },
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("halts before bootstrap when bash is older than the hook baseline", async () => {
+    const { deps, calls } = makeDeps();
+
+    await expect(
+      runBoot(
+        deps,
+        options({
+          precheck: facts({
+            hostPrerequisites: {
+              commands: {
+                bash: true,
+                git: true,
+                jq: true,
+                gh: true,
+                node: true,
+                timeout: true,
+                ps: true,
+              },
+              bashVersion: "GNU bash, version 3.1.23(1)-release",
+            },
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({
+      phase: "host-prereq",
+      probe: {
+        evidence: "bash 3.1.23 is older than required 3.2.0",
+        canonicalFix: expect.stringMatching(/bash --version$/),
+      },
+    });
+    expect(calls).toEqual([]);
+  });
+});

--- a/apps/dev/tests/operational-probes.test.ts
+++ b/apps/dev/tests/operational-probes.test.ts
@@ -47,6 +47,7 @@ describe("operational probe registry", () => {
     const decoded = decode(toon) as { probes: Array<{ id: string; verdict: string }>; findings: unknown[] };
 
     expect(decoded.probes).toEqual([
+      { id: "afk.host-prerequisites", name: "AFK host prerequisites", verdict: "ok" },
       { id: "git.remote.https-forbidden", name: "SSH-only git remotes", verdict: "red" },
       { id: "afk.queue-visibility", name: "AFK queue visibility", verdict: "ok" },
       { id: "afk.focal-branch-resolution", name: "AFK focal branch resolution", verdict: "ok" },

--- a/apps/dev/tests/runtime-hooks.test.ts
+++ b/apps/dev/tests/runtime-hooks.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { hookEnv, makeHookResolveOptions } from "../src/runtime/hooks.js";
+import { hookEnv, makeHookExec, makeHookResolveOptions } from "../src/runtime/hooks.js";
 import { skillDirFromModule } from "../src/platform/skill-paths.js";
 import { resolveHooks } from "../src/core/hook-config.js";
 
@@ -103,5 +103,15 @@ describe("hookEnv (per-slot RED_AFK_SLOT in hook environment)", () => {
   it("each slot gets a distinct RED_AFK_SLOT value", () => {
     const slots = [0, 1, 2].map((s) => hookEnv("owner/repo", "/repo", s).RED_AFK_SLOT);
     expect(slots).toEqual(["0", "1", "2"]);
+  });
+});
+
+describe("makeHookExec", () => {
+  it("runs bash-only lifecycle hooks with bash instead of the host sh interpreter", async () => {
+    const exec = makeHookExec(process.cwd());
+
+    await expect(
+      exec('read -r _; shopt -s extglob; [[ foobar == +(foo|bar) ]] && printf \'extglob-ok\'', {}, "{}\n"),
+    ).resolves.toEqual({ code: 0, stdout: "extglob-ok" });
   });
 });


### PR DESCRIPTION
Automated AFK landing for #2475. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2475

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787322722&installation_model_id=20659&pr_number=2486&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2486&signature=aff5986b6547b63612b5a8f501709819e9c1a439b22ac19eadf963bd713d17a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->