### PR TITLE
fix: #2476 Reclassify missing-interpreter (spawn sh ENOENT) from runner-transient to fatal host-config

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -98,6 +98,7 @@ import { DEFAULT_MAX_ITERATIONS } from "../../core/execution.js";
 import type { AgentStreamEvent } from "../../core/execution.js";
 import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../../core/claim-staleness.js";
 import { renderClaimComment } from "../../core/claim.js";
+import { HOST_CONFIG_EXIT_CODE } from "../../core/attempt-outcome.js";
 
 import { checkBootGuard, isNamespacedDispatch, parseRunFlags, resolveRunDispatchIdentity, type RunOptions } from "./flags.js";
 import { buildProcessDeps, parseSlot, type CurrentAttempt } from "./process-deps.js";
@@ -517,6 +518,12 @@ export async function runCommand(options: RunOptions): Promise<number> {
   if (summary.runnerTransient) {
     process.stderr.write(`[afk] runner transport/setup failed — exiting 75 (EX_TEMPFAIL); rerun when the runner backend is healthy\n`);
     return 75;
+  }
+  if (summary.hostConfig) {
+    process.stderr.write(
+      `[afk] fatal host configuration — exiting ${HOST_CONFIG_EXIT_CODE} (EX_CONFIG); fix the required shell/workspace before restarting this worker\n`,
+    );
+    return HOST_CONFIG_EXIT_CODE;
   }
 
   // A targeted dispatch that attempted nothing is a failure, never a clean drain

--- a/apps/dev/src/core/attempt-outcome.ts
+++ b/apps/dev/src/core/attempt-outcome.ts
@@ -25,6 +25,7 @@ import type { AttemptStatus } from "./envelope.js";
 import {
   LABEL_QUOTA,
   LABEL_RUNNER_TRANSIENT,
+  LABEL_HOST_CONFIG,
   LABEL_MERGE_CONFLICT,
   LABEL_CI,
   LABEL_SPEC,
@@ -87,6 +88,9 @@ export type AttemptOutcome =
   | "hook-aborted"
   | "exhausted"
   | "runner-transient"
+  // Permanent runner-host defect: a required interpreter or cwd is missing.
+  // No cooldown/fallback retry can repair host configuration.
+  | "host-config"
   | "stalled"
   // AFK runner improvement (#908): a per-attempt resource ceiling aborted the
   // attempt (token / cost / tool-call / waiting-window). Parked for a human —
@@ -139,6 +143,8 @@ export function blockedLabelFor(o: AttemptOutcome): string | null {
       return LABEL_QUOTA;
     case "runner-transient":
       return LABEL_RUNNER_TRANSIENT;
+    case "host-config":
+      return LABEL_HOST_CONFIG;
     case "merge-conflict":
       return LABEL_MERGE_CONFLICT;
     case "ci-failed":
@@ -227,6 +233,7 @@ export function envelopeStatusFor(o: AttemptOutcome): AttemptStatus {
     case "hook-aborted":
     case "exhausted":
     case "runner-transient":
+    case "host-config":
     case "claim-lost":
     case "stalled":
     case "budget-exceeded":
@@ -297,6 +304,7 @@ export function recoveryReasonFor(o: AttemptOutcome): RecoveryReason | null {
     case "ci-failed":
     case "ci-pending":
     case "blocked":
+    case "host-config":
     case "feedback-failed":
     case "stalled":
     // #908: a budget abort is NOT auto-recoverable — re-running the inner agent
@@ -322,3 +330,6 @@ export function recoveryReasonFor(o: AttemptOutcome): RecoveryReason | null {
       return null;
   }
 }
+
+/** sysexits(3) EX_CONFIG: permanent host configuration failure. */
+export const HOST_CONFIG_EXIT_CODE = 78;

--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -20,6 +20,7 @@ export {
   interpretCompletion,
   interpretOutcome,
   isExhaustionError,
+  isHostConfigRunnerError,
   isTransientRunnerError,
   parseIdleTimeout,
   parseMaxIterations,

--- a/apps/dev/src/core/execution/runtime.ts
+++ b/apps/dev/src/core/execution/runtime.ts
@@ -100,6 +100,7 @@ export type AgentOutcome =
   | "signal-killed"
   | "exhausted"
   | "runner-transient"
+  | "host-config"
   | "goal-moot";
 
 /** Unix signal exit-code convention: exit code = 128 + signal number. */
@@ -767,7 +768,7 @@ export function isExhaustionError(error: unknown): boolean {
  * worker crashes that kill the orchestrator and orphan the issue in `running`.
  *
  * Covers two families: (a) Codex transport/setup hiccups (websocket, thread
- * start, spawn/cwd); and (b) **provider server-side overload** — a `529
+ * start); and (b) **provider server-side overload** — a `529
  * Overloaded` / `overloaded_error` (Anthropic) or `503 Service Unavailable`,
  * which is temporary and server-side, not your code or your quota. Before this,
  * a 529 matched neither the exhaustion nor the transient pattern, so it hit the
@@ -783,7 +784,30 @@ export function isTransientRunnerError(error: unknown): boolean {
 }
 
 const runnerTransientPattern =
-  /failed to connect to websocket|HTTP error:\s*502 Bad Gateway|HTTP error:\s*503 Service Unavailable|\b529\b|overloaded|wss:\/\/chatgpt\.com\/backend-api\/codex\/responses|thread\/start failed|failed to load configuration|spawn sh ENOENT|cwd does not exist|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ECONNRESET/i;
+  /failed to connect to websocket|HTTP error:\s*502 Bad Gateway|HTTP error:\s*503 Service Unavailable|\b529\b|overloaded|wss:\/\/chatgpt\.com\/backend-api\/codex\/responses|thread\/start failed|failed to load configuration|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ECONNRESET/i;
+
+type HostConfigFailure = "missing-interpreter" | "missing-cwd";
+
+function hostConfigFailure(error: unknown): HostConfigFailure | null {
+  if (error === null || error === undefined) return null;
+  const parts: string[] = [];
+  collectErrorStrings(error, parts, new Set(), 0);
+  if (parts.some((part) => /spawn\s+sh\s+ENOENT/i.test(part))) return "missing-interpreter";
+  if (parts.some((part) => /cwd does not exist/i.test(part))) return "missing-cwd";
+  return null;
+}
+
+/** Permanent runner-host defects that cannot heal through cooldown or fallback. */
+export function isHostConfigRunnerError(error: unknown): boolean {
+  return hostConfigFailure(error) !== null;
+}
+
+function hostConfigOperatorMessage(error: unknown): string {
+  if (hostConfigFailure(error) === "missing-interpreter") {
+    return "afk: fatal host configuration: required POSIX shell `sh` could not be spawned (spawn sh ENOENT). Install or restore the required shell, then rerun; this failure is not retryable.";
+  }
+  return "afk: fatal host configuration: the worker current directory does not exist. Restore the configured workspace/current directory, then rerun; this failure is not retryable.";
+}
 
 /** Recursively gather string values reachable from an error-ish value, bounded
  * by depth and a visited set so cyclic Effect `Cause` graphs terminate. */
@@ -821,6 +845,7 @@ function defaultSchedule(fn: () => void, ms: number): () => void {
  * whose message matches the exhaustion patterns (the common case — the provider
  * raises on a 429 / usage-limit), or by completing with exhaustion text on
  * stdout. Both map to the `exhausted` outcome (no commits, no sentinel). A
+ * missing interpreter/current-directory defect maps to fatal `host-config`; a
  * transient transport / server-overload error maps to `runner-transient`; any
  * OTHER thrown error maps to `no-sentinel` (a recoverable crash) rather than
  * propagating — so an unrecognized runner failure never kills the drain or
@@ -1013,6 +1038,14 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
     }
     if (isExhaustionError(error)) {
       return { outcome: "exhausted", branch: input.branch, commits: [], stdout: "" };
+    }
+    if (isHostConfigRunnerError(error)) {
+      return {
+        outcome: "host-config",
+        branch: input.branch,
+        commits: [],
+        stdout: hostConfigOperatorMessage(error),
+      };
     }
     if (isTransientRunnerError(error)) {
       return {

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -677,6 +677,12 @@ export async function processIssue(
           notes: `_(inner agent emitted BLOCKED — see iteration log at \`${input.attemptDir}\`)_`,
         });
       }
+      if (run.outcome === "host-config") {
+        return await terminalFailure(common, "host-config", "host-config", {
+          notes: run.stdout,
+          log: run.stdout,
+        });
+      }
     }
     if (input.runMode === "scout") {
       const report = scoutReportFrom(scoutTextChunks, run.stdout);

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -282,6 +282,13 @@ export function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodi
         summary: oneLine(sections.log, "Inner agent exited without an AFK completion sentinel."),
         next: "Review the attempt log and decide whether to retry or revise the issue brief.",
       };
+    case "host-config":
+      return {
+        status: "blocked",
+        kind: "host-config",
+        summary: oneLine(sections.log ?? sections.notes, "Required runner host configuration is unavailable."),
+        next: "Install or restore the required shell/workspace on the host, then requeue this issue.",
+      };
     case "stalled":
       return {
         status: "blocked",
@@ -358,6 +365,7 @@ export const ACTIONABLE_BLOCKER_KINDS = new Set([
   "decision",
   "trunk-diverged",
   "infra",
+  "host-config",
 ]);
 export function shouldPreserveCurrentBlocker(existing: CurrentBlocker | null, next: CurrentBlocker): boolean {
   if (!existing) return false;

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -64,6 +64,7 @@ import { dispose } from "../disposition.js";
 import {
   blockedLabelFor,
   envelopeStatusFor,
+  HOST_CONFIG_EXIT_CODE,
   type AttemptOutcome,
 } from "../attempt-outcome.js";
 import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookName } from "../hook-config.js";
@@ -386,6 +387,13 @@ export function stateExitPatch(outcome: ProcessOutcome): Record<string, unknown>
       ...base,
       "current.last_exit_code": CRASH_EXIT_CODE,
       "current.failure_kind": "signal-killed",
+    };
+  }
+  if (outcome === "host-config") {
+    return {
+      ...base,
+      "current.last_exit_code": HOST_CONFIG_EXIT_CODE,
+      "current.failure_kind": "host-config",
     };
   }
   return { ...base, "current.last_exit_code": CRASH_EXIT_CODE };

--- a/apps/dev/src/core/supervisor/slot-actions.ts
+++ b/apps/dev/src/core/supervisor/slot-actions.ts
@@ -8,6 +8,7 @@ import type { SupervisorConfig } from "./config.js";
 import type { TickResult } from "./result.js";
 import type { SlotState, SupervisorState } from "./state.js";
 import type { ReconcileCandidate, SpawnPolicy, SupervisorDeps } from "./types.js";
+import { HOST_CONFIG_EXIT_CODE } from "../attempt-outcome.js";
 
 export async function handleDeadSlot(
   slot: number,
@@ -21,6 +22,23 @@ export async function handleDeadSlot(
     if (spawnPolicy === "hard-stop") return null;
     return spawnPolicy ? deps.proc.spawnSlot(slot, spawnPolicy) : deps.proc.spawnSlot(slot);
   };
+  const exitCode = deps.proc.lastExitCode?.(slot) ?? null;
+
+  // EX_CONFIG is a permanent host defect, not a fast runner death. Park the
+  // slot indefinitely without adding to the circuit ring, sweeping work, or
+  // spawning a cooldown probe that can only fail the same way.
+  if (exitCode === HOST_CONFIG_EXIT_CODE) {
+    state.pid = null;
+    state.parked = true;
+    state.fatalReason = "host-config";
+    state.halfOpen = false;
+    state.tripEpoch = 0;
+    deps.log?.(
+      `fatal host configuration: slot ${slot} parked without retry; fix the required shell/workspace and restart the fleet`,
+    );
+    return { parked: true };
+  }
+
   // Half-open probe death: resolve the circuit transition before the normal path.
   if (state.parked && state.halfOpen) {
     const now = deps.now();
@@ -76,7 +94,6 @@ export async function handleDeadSlot(
     return { parked: false };
   }
 
-  const exitCode = deps.proc.lastExitCode?.(slot) ?? null;
   const cleanExit = exitCode === 0;
 
   if (cleanExit) {

--- a/apps/dev/src/core/supervisor/state.ts
+++ b/apps/dev/src/core/supervisor/state.ts
@@ -19,6 +19,8 @@ export interface SlotState {
   /** Fast-death ring, pruned to the window (SLOT_FAST_DEATHS). */
   deaths: number[];
   parked: boolean;
+  /** Fatal, non-retryable reason that parked this slot outside the circuit. */
+  fatalReason: "host-config" | null;
   tripEpoch: number;
   /** SLOT_SWEPT — the trip sweep fired once. */
   swept: boolean;
@@ -56,6 +58,7 @@ export function freshSlot(): SlotState {
     spawnEpoch: 0,
     deaths: [],
     parked: false,
+    fatalReason: null,
     tripEpoch: 0,
     swept: false,
     stalled: false,

--- a/apps/dev/src/core/supervisor/tick.ts
+++ b/apps/dev/src/core/supervisor/tick.ts
@@ -181,7 +181,7 @@ export async function superviseTick(
     const now = deps.now();
     for (let i = 0; i < state.slots.length; i += 1) {
       const slot = state.slots[i]!;
-      if (!slot.parked || slot.halfOpen || slot.spawning) continue;
+      if (!slot.parked || slot.halfOpen || slot.spawning || slot.fatalReason === "host-config") continue;
       if (spawnPolicy === "hard-stop") continue;
       if (!isHalfOpenDue(slot.tripEpoch, slot.backoffStep, now, config)) continue;
       deps.log?.(

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -81,6 +81,9 @@ export const LABEL_DEPENDENCY = "blocked:dependency";
 export const LABEL_SPEC = "blocked:spec";
 export const LABEL_QUOTA = "blocked:quota";
 export const LABEL_RUNNER_TRANSIENT = "blocked:runner-transient";
+// Permanent host prerequisite/configuration failure (for example a missing
+// `sh` interpreter or vanished worker cwd). Never auto-retried.
+export const LABEL_HOST_CONFIG = "blocked:host-config";
 export const LABEL_MERGE_CONFLICT = "blocked:merge-conflict";
 // AFK runner improvement (#812): an UNLOCKED admin-merge cannot bypass required
 // status checks on an `enforce_admins` base. A completed, MERGEABLE PR whose

--- a/apps/dev/tests/attempt-outcome.test.ts
+++ b/apps/dev/tests/attempt-outcome.test.ts
@@ -26,6 +26,7 @@ const TABLE: Row[] = [
   // recoverable: carry both a typed label and a recovery policy key
   { outcome: "exhausted", label: "blocked:quota", recovery: "quota" },
   { outcome: "runner-transient", label: "blocked:runner-transient", recovery: "runner-transient" },
+  { outcome: "host-config", label: "blocked:host-config", recovery: null },
   { outcome: "no-sentinel", label: "blocked:crashed", recovery: "crashed" },
   // #1308: signal-killed is a distinct crash class (OS signal, SIGKILL/SIGTERM).
   // Same `crashed` recovery policy as no-sentinel; the label is distinct so the
@@ -83,6 +84,7 @@ describe("attempt-outcome — exhaustive outcome → (label, recovery) table", (
       "hook-aborted",
       "exhausted",
       "runner-transient",
+      "host-config",
       "stalled",
       "budget-exceeded",
       "base-stale",
@@ -143,6 +145,7 @@ describe("attempt-outcome — exhaustive outcome → envelope status table", () 
     { outcome: "hook-aborted", status: "blocked" },
     { outcome: "exhausted", status: "blocked" },
     { outcome: "runner-transient", status: "blocked" },
+    { outcome: "host-config", status: "blocked" },
     { outcome: "claim-lost", status: "blocked" },
     { outcome: "stalled", status: "blocked" },
     { outcome: "budget-exceeded", status: "blocked" },
@@ -171,6 +174,7 @@ describe("attempt-outcome — exhaustive outcome → envelope status table", () 
       "hook-aborted",
       "exhausted",
       "runner-transient",
+      "host-config",
       "stalled",
       "budget-exceeded",
       "base-stale",

--- a/apps/dev/tests/disposition.test.ts
+++ b/apps/dev/tests/disposition.test.ts
@@ -35,6 +35,7 @@ const ROWS: Row[] = [
   // non-recoverable: always escalate, no retry budget
   { outcome: "blocked", typedLabel: "blocked:spec", envelopeStatus: "blocked", policyKey: null, cap: null },
   { outcome: "feedback-failed", typedLabel: "blocked:validation", envelopeStatus: "blocked", policyKey: null, cap: null },
+  { outcome: "host-config", typedLabel: "blocked:host-config", envelopeStatus: "blocked", policyKey: null, cap: null },
   { outcome: "infra", typedLabel: "blocked:infra", envelopeStatus: "blocked", policyKey: null, cap: null },
   { outcome: "done", typedLabel: null, envelopeStatus: "done", policyKey: null, cap: null },
   { outcome: "claim-lost", typedLabel: null, envelopeStatus: "blocked", policyKey: null, cap: null },

--- a/apps/dev/tests/execution-run-agent.test.ts
+++ b/apps/dev/tests/execution-run-agent.test.ts
@@ -7,6 +7,7 @@ import {
   interpretCompletion,
   enforceStructuredOutput,
   isExhaustionError,
+  isHostConfigRunnerError,
   isTransientRunnerError,
   extractSignalKill,
   runAgent,
@@ -264,8 +265,11 @@ describe("isTransientRunnerError", () => {
         new Error("Error: thread/start: thread/start failed: failed to load configuration: No such file or directory (os error 2)"),
       ),
     ).toBe(true);
-    expect(isTransientRunnerError(new Error("exec failed: exec failed: spawn sh ENOENT"))).toBe(true);
-    expect(isTransientRunnerError(new Error("cwd does not exist: /tmp/.red/tmp/workers/wAAAA/17-a1"))).toBe(true);
+  });
+
+  it("excludes permanent missing-interpreter and missing-cwd host defects", () => {
+    expect(isTransientRunnerError(new Error("exec failed: exec failed: spawn sh ENOENT"))).toBe(false);
+    expect(isTransientRunnerError(new Error("cwd does not exist: /tmp/worker-attempt"))).toBe(false);
   });
 
   it("matches provider server-side overload (529 / overloaded_error / 503) — temporary, not a crash", () => {
@@ -284,6 +288,31 @@ describe("isTransientRunnerError", () => {
     // A 529 elsewhere in unrelated prose is overwhelmingly the status code; a
     // bare number like 5290 must NOT match (word-boundary guard).
     expect(isTransientRunnerError(new Error("processed 5290 records"))).toBe(false);
+  });
+});
+
+describe("runAgent — fatal host configuration", () => {
+  it.each([
+    "exec failed: exec failed: spawn sh ENOENT",
+    "cwd does not exist: /tmp/worker-attempt",
+  ])("maps %s to one actionable host-config outcome", async (message) => {
+    let invocations = 0;
+    const error = new Error(message);
+    expect(isHostConfigRunnerError(error)).toBe(true);
+
+    const r = await runAgent(
+      makeDeps(async () => {
+        invocations += 1;
+        throw error;
+      }),
+      baseInput,
+    );
+
+    expect(invocations).toBe(1);
+    expect(r.outcome).toBe("host-config");
+    expect(r.commits).toEqual([]);
+    expect(r.stdout).toContain("fatal host configuration");
+    expect(r.stdout).toContain("not retryable");
   });
 });
 

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -1016,6 +1016,27 @@ describe("processIssue — runner transient transport/setup failure", () => {
   });
 });
 
+describe("processIssue — fatal host configuration", () => {
+  it("runs once, never falls back, and escalates with an actionable host-config label", async () => {
+    const { deps, input, trace } = harness({ outcome: "host-config", fallbackRunner: true });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("host-config");
+    expect(result.preserved).toBe(true);
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(labelTrace(trace)).toEqual([
+      "-ready-for-agent|+running",
+      "-running|+ready-for-human+blocked:host-config",
+    ]);
+    expect(trace.ensuredLabels).toContain("blocked:host-config");
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    expect(trace.released).toEqual([9]);
+    expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "post_attempt"]);
+    expect(trace.bodyEdits[0]?.body).toContain("kind: host-config");
+    expect(trace.bodyEdits[0]?.body).toContain("Install or restore the required shell");
+  });
+});
+
 
 describe("processIssue — base reaches sandcastle (ADR 0031)", () => {
   it("fetches the resolved base and forks the worker branch off it (not HEAD)", async () => {
@@ -1248,4 +1269,3 @@ describe("processIssue — /afk post-DONE gate-correction convergence (#2285)", 
     expect(trace.closed).toEqual([]);
   });
 });
-

--- a/apps/dev/tests/supervisor.config-stall.test.ts
+++ b/apps/dev/tests/supervisor.config-stall.test.ts
@@ -506,7 +506,7 @@ describe("circuit trip and sweep", () => {
     expect(slot.swept).toBe(false);
     expect(io.spawnSlot).not.toHaveBeenCalled();
     expect(io.parkedSlotWork).not.toHaveBeenCalled();
-    expect(io.log).toHaveBeenCalledWith(expect.stringContaining("fatal host configuration"));
+    expect(io.logLines).toContainEqual(expect.stringContaining("fatal host configuration"));
   });
 
   it("trips after K fast deaths, parks the slot, and runs the trip sweep", async () => {

--- a/apps/dev/tests/supervisor.config-stall.test.ts
+++ b/apps/dev/tests/supervisor.config-stall.test.ts
@@ -489,6 +489,26 @@ describe("recordDeath", () => {
 });
 
 describe("circuit trip and sweep", () => {
+  it("parks a fatal host-config death without retrying or feeding the fast-death circuit", async () => {
+    const { deps, io } = makeDeps();
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.deaths = [NOW - 40, NOW - 30, NOW - 20, NOW - 10];
+    slot.spawnEpoch = NOW - 5;
+    io.lastExitCode.mockReturnValue(78);
+
+    const { parked } = await handleDeadSlot(0, slot, deps, config());
+
+    expect(parked).toBe(true);
+    expect(slot.parked).toBe(true);
+    expect(slot.fatalReason).toBe("host-config");
+    expect(slot.deaths).toEqual([NOW - 40, NOW - 30, NOW - 20, NOW - 10]);
+    expect(slot.swept).toBe(false);
+    expect(io.spawnSlot).not.toHaveBeenCalled();
+    expect(io.parkedSlotWork).not.toHaveBeenCalled();
+    expect(io.log).toHaveBeenCalledWith(expect.stringContaining("fatal host configuration"));
+  });
+
   it("trips after K fast deaths, parks the slot, and runs the trip sweep", async () => {
     const { deps, io } = makeDeps({
       parkedSlotWork: vi.fn(

--- a/packages/red-castle/src/engine/worker-drain.test.ts
+++ b/packages/red-castle/src/engine/worker-drain.test.ts
@@ -314,6 +314,7 @@ describe("castle worker drain", () => {
       expected: "exhausted",
       exhausted: true,
       runnerTransient: false,
+      hostConfig: false,
       retirementChecks: 0,
     },
     {
@@ -321,6 +322,15 @@ describe("castle worker drain", () => {
       expected: "runner-unavailable",
       exhausted: false,
       runnerTransient: true,
+      hostConfig: false,
+      retirementChecks: 0,
+    },
+    {
+      outcome: "host-config" as const,
+      expected: "host-config",
+      exhausted: false,
+      runnerTransient: false,
+      hostConfig: true,
       retirementChecks: 0,
     },
     {
@@ -328,6 +338,7 @@ describe("castle worker drain", () => {
       expected: "once",
       exhausted: false,
       runnerTransient: false,
+      hostConfig: false,
       retirementChecks: 0,
     },
     {
@@ -335,6 +346,7 @@ describe("castle worker drain", () => {
       expected: "graceful-retirement",
       exhausted: false,
       runnerTransient: false,
+      hostConfig: false,
       retirementChecks: 1,
     },
   ])(
@@ -344,6 +356,7 @@ describe("castle worker drain", () => {
       expected,
       exhausted,
       runnerTransient,
+      hostConfig,
       retirementChecks,
     }) => {
       const shouldRetire = vi.fn(() => true);
@@ -360,6 +373,7 @@ describe("castle worker drain", () => {
         stopReason: expected,
         exhausted,
         runnerTransient,
+        hostConfig,
       });
       expect(shouldRetire).toHaveBeenCalledTimes(retirementChecks);
       expect(harness.processedRunners).toEqual(["claude"]);

--- a/packages/red-castle/src/engine/worker-drain.ts
+++ b/packages/red-castle/src/engine/worker-drain.ts
@@ -133,6 +133,7 @@ export type CastleWorkerOutcome =
   | "hook-aborted"
   | "exhausted"
   | "runner-transient"
+  | "host-config"
   | (string & {});
 
 export interface CastleWorkerProcessResult {
@@ -162,6 +163,7 @@ export type CastleWorkerStopReason =
   | "iter-cap"
   | "once"
   | "runner-unavailable"
+  | "host-config"
   | "exhausted";
 
 export type CastleSessionHookName =
@@ -202,6 +204,7 @@ export interface CastleWorkerDrainSummary<TBootResult = unknown> {
   drained: boolean;
   exhausted: boolean;
   runnerTransient: boolean;
+  hostConfig: boolean;
   sessionHooksFired: CastleSessionHookName[];
   stopReason?: CastleWorkerStopReason;
 }
@@ -312,6 +315,7 @@ export async function runCastleWorkerDrain<
     drained: false,
     exhausted: false,
     runnerTransient: false,
+    hostConfig: false,
     sessionHooksFired,
   };
 
@@ -349,6 +353,7 @@ export async function runCastleWorkerDrain<
     let failed = 0;
     let exhaustedStop = false;
     let runnerTransientStop = false;
+    let hostConfigStop = false;
     let stopReason: CastleWorkerStopReason | undefined;
     let activeRunner: Runner = ctx.runner;
 
@@ -407,6 +412,11 @@ export async function runCastleWorkerDrain<
         stopReason = "runner-unavailable";
         break;
       }
+      if (result.outcome === "host-config") {
+        hostConfigStop = true;
+        stopReason = "host-config";
+        break;
+      }
       if (ctx.once && result.outcome !== "claim-lost") {
         stopReason = "once";
         break;
@@ -433,6 +443,7 @@ export async function runCastleWorkerDrain<
       drained: false,
       exhausted: exhaustedStop,
       runnerTransient: runnerTransientStop,
+      hostConfig: hostConfigStop,
       sessionHooksFired,
       stopReason,
     };


### PR DESCRIPTION
Automated AFK landing for #2476. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2476

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787328371&installation_model_id=20659&pr_number=2491&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2491&signature=05a6aef230ecf2b9f7c187b0956aaa23fc426316be734c952ec23ad9b0734777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->