### PR TITLE
chore(config): disable adversarial review in this repo

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -35,7 +35,10 @@ plugins:
     #   so the worst case is one extra correction round and the PR still lands.
     #   Raising max_iterations to 2+ enables parking to ready-for-human.
     review:
-      enabled: true
+      # Maintainer decision 2026-07-22: review OFF in this repo — the extra
+      # bounded round was still costing wall-clock on every landing during the
+      # reliability push. Re-enable by flipping this back to true.
+      enabled: false
       max_iterations: 1
       reviewer_count: 1
       quorum: any


### PR DESCRIPTION
Maintainer directive: turn off `plugins.dev.review.enabled` — every landing was paying the extra bounded review round during the reliability push. Config-only change; future workers branch from main and inherit it. Re-enable by flipping the flag.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787328576&installation_model_id=20659&pr_number=2492&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2492&signature=2d409662a4dd41f30345adcb2edc374d1c6e64e9aa5c344143390a024d754a34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->