### PR TITLE
chore: #2389 CI: authenticate the pinned tq installer fetch — anonymous raw.githubusercontent curl 403s on shared runners

### DIFF
--- a/.github/workflows/red-rsp-benchmark-ci.yml
+++ b/.github/workflows/red-rsp-benchmark-ci.yml
@@ -30,7 +30,15 @@ jobs:
       - name: Install pinned tq
         env:
           TQ_VERSION: v0.3.0
-        run: curl -fsSL "https://raw.githubusercontent.com/reddb-io/toon/${TQ_VERSION}/install.sh" | sh
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl --fail --silent --show-error \
+            --retry 1 --retry-delay 2 --retry-connrefused \
+            -H "Accept: application/vnd.github.raw+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/reddb-io/toon/contents/install.sh?ref=${TQ_VERSION}" |
+            sh
 
       - name: Install workspace dependencies
         env:

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -110,7 +110,15 @@ jobs:
       - name: Install pinned tq
         env:
           TQ_VERSION: v0.3.0
-        run: curl -fsSL "https://raw.githubusercontent.com/reddb-io/toon/${TQ_VERSION}/install.sh" | sh
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl --fail --silent --show-error \
+            --retry 1 --retry-delay 2 --retry-connrefused \
+            -H "Accept: application/vnd.github.raw+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/reddb-io/toon/contents/install.sh?ref=${TQ_VERSION}" |
+            sh
 
       - name: Install workspace dependencies
         env:

--- a/scripts/test-workflow-security-pins.sh
+++ b/scripts/test-workflow-security-pins.sh
@@ -51,6 +51,20 @@ grep -qF 'ref: ${{ github.event.pull_request.base.sha || github.event.repository
 grep -qF 'ref: ${{ github.event.pull_request.base.sha }}' .github/workflows/red-hitl-card.yml ||
   fail "red-hitl-card.yml must checkout the base PR SHA before running the launcher"
 
+for workflow in \
+  .github/workflows/red-workspace-ci.yml \
+  .github/workflows/red-rsp-benchmark-ci.yml; do
+  grep -qF 'https://api.github.com/repos/reddb-io/toon/contents/install.sh?ref=${TQ_VERSION}' "$workflow" ||
+    fail "$workflow must fetch the pinned tq installer through the GitHub API"
+  grep -qF 'Authorization: Bearer ${GH_TOKEN}' "$workflow" ||
+    fail "$workflow must authenticate the pinned tq installer fetch"
+  grep -qF 'GH_TOKEN: ${{ github.token }}' "$workflow" ||
+    fail "$workflow must source tq installer authentication from github.token"
+  if grep -qF 'raw.githubusercontent.com/reddb-io/toon/${TQ_VERSION}/install.sh' "$workflow"; then
+    fail "$workflow must not fetch the pinned tq installer anonymously"
+  fi
+done
+
 if (( failures > 0 )); then
   exit 1
 fi


### PR DESCRIPTION
Automated AFK landing for #2389. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2389

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787334034&installation_model_id=20659&pr_number=2497&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2497&signature=ede57c8d2c1ef2b4779ecbacda671cbcaf020331cc545ca23e3fa7597c60e179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->