### PR TITLE
chore: #2420 Castle singleton substrate: on-disk lease + event lane

### DIFF
--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -32,6 +32,8 @@ export * from "./runner-detection.js";
 export * from "./runner-spawn.js";
 export * from "./runner-spec.js";
 export * from "./runner-types.js";
+export * from "./singleton-event-lane.js";
+export * from "./singleton-lease.js";
 export {
   acquireIssueLease,
   createFsIssueLeaseStore,

--- a/packages/red-castle/src/engine/singleton-event-lane.test.ts
+++ b/packages/red-castle/src/engine/singleton-event-lane.test.ts
@@ -13,11 +13,16 @@ describe("castle singleton event lane", () => {
   const roots: string[] = [];
 
   afterEach(async () => {
-    await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+    await Promise.all(
+      roots.map((root) => rm(root, { recursive: true, force: true })),
+    );
   });
 
   it("appends TOONL events and reads a bounded tail through injected IO", async () => {
-    const root = join(tmpdir(), `castle-singleton-events-${crypto.randomUUID()}`);
+    const root = join(
+      tmpdir(),
+      `castle-singleton-events-${crypto.randomUUID()}`,
+    );
     roots.push(root);
     const paths = createEnginePaths(join(root, ".red"));
     let tick = 0;

--- a/packages/red-castle/src/engine/singleton-event-lane.test.ts
+++ b/packages/red-castle/src/engine/singleton-event-lane.test.ts
@@ -1,0 +1,72 @@
+import { appendFile, mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseRecords } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+import { createEnginePaths } from "./paths.js";
+import {
+  createSingletonEventLane,
+  singletonEventLanePath,
+} from "./singleton-event-lane.js";
+
+describe("castle singleton event lane", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  it("appends TOONL events and reads a bounded tail through injected IO", async () => {
+    const root = join(tmpdir(), `castle-singleton-events-${crypto.randomUUID()}`);
+    roots.push(root);
+    const paths = createEnginePaths(join(root, ".red"));
+    let tick = 0;
+    const times = [
+      "2026-07-22T19:00:00.000Z",
+      "2026-07-22T19:00:01.000Z",
+      "2026-07-22T19:00:02.000Z",
+    ];
+    const lane = createSingletonEventLane(paths, {
+      fs: { appendFile, mkdir, readFile },
+      clock: () => times[tick++]!,
+    });
+
+    await lane.append({
+      singleton: "github-webhook",
+      kind: "github.delivery",
+      payload: { delivery: "d1" },
+    });
+    await lane.append({
+      singleton: "github-webhook",
+      kind: "github.delivery",
+      payload: { delivery: "d2" },
+    });
+    await lane.append({
+      singleton: "janitor",
+      kind: "janitor.completed",
+      payload: { swept: 3 },
+    });
+
+    expect(singletonEventLanePath(paths)).toBe(
+      join(paths.castleStateRoot, "singleton-events.toonl"),
+    );
+    expect(await lane.read({ tail: 2 })).toEqual([
+      {
+        at: "2026-07-22T19:00:01.000Z",
+        singleton: "github-webhook",
+        kind: "github.delivery",
+        payload: { delivery: "d2" },
+      },
+      {
+        at: "2026-07-22T19:00:02.000Z",
+        singleton: "janitor",
+        kind: "janitor.completed",
+        payload: { swept: 3 },
+      },
+    ]);
+
+    const bytes = await readFile(singletonEventLanePath(paths), "utf8");
+    expect(bytes.trimStart().startsWith("{")).toBe(false);
+    expect(parseRecords(bytes)).toHaveLength(3);
+  });
+});

--- a/packages/red-castle/src/engine/singleton-event-lane.ts
+++ b/packages/red-castle/src/engine/singleton-event-lane.ts
@@ -1,0 +1,139 @@
+/**
+ * Durable event distribution for repo-scoped singleton owners.
+ *
+ * Owners append uniform records to one TOONL lane in the Castle state tier;
+ * supervisors, waits, and views consume the same ordered stream. The open tail
+ * remains valid after a writer crash, following the existing Castle TOONL lane
+ * grammar rather than introducing a socket or RPC lifecycle.
+ */
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
+import type { EnginePaths } from "./paths.js";
+
+export interface SingletonEventRecord {
+  readonly at: string;
+  readonly singleton: string;
+  readonly kind: string;
+  readonly payload?: Record<string, unknown>;
+}
+
+export type SingletonEventInput = Omit<SingletonEventRecord, "at"> & {
+  readonly at?: string;
+};
+
+export interface SingletonEventLaneFs {
+  appendFile(path: string, data: string, encoding: "utf8"): Promise<unknown>;
+  mkdir(path: string, options: { recursive: true }): Promise<unknown>;
+  readFile(path: string, encoding: "utf8"): Promise<string>;
+}
+
+export interface SingletonEventLaneOptions {
+  readonly fs?: SingletonEventLaneFs;
+  readonly clock?: () => string;
+}
+
+export interface SingletonEventReadOptions {
+  /** Return at most the newest N records, preserving chronological order. */
+  readonly tail?: number;
+}
+
+export interface SingletonEventLane {
+  readonly path: string;
+  append(event: SingletonEventInput): Promise<SingletonEventRecord>;
+  read(options?: SingletonEventReadOptions): Promise<SingletonEventRecord[]>;
+}
+
+function assertNonEmpty(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`singleton event ${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function validateEvent(value: unknown): SingletonEventRecord {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("singleton event must be a record");
+  }
+  const raw = { ...(value as Record<string, unknown>) };
+  const payload = raw.payload;
+  if (typeof payload === "string") {
+    try {
+      raw.payload = JSON.parse(payload) as Record<string, unknown>;
+    } catch {
+      throw new Error("singleton event payload is not valid JSON");
+    }
+  }
+  if (
+    raw.payload !== undefined &&
+    (raw.payload === null ||
+      typeof raw.payload !== "object" ||
+      Array.isArray(raw.payload))
+  ) {
+    throw new Error("singleton event payload must be a record");
+  }
+  return {
+    at: assertNonEmpty(raw.at, "at"),
+    singleton: assertNonEmpty(raw.singleton, "singleton"),
+    kind: assertNonEmpty(raw.kind, "kind"),
+    ...(raw.payload === undefined
+      ? {}
+      : { payload: raw.payload as Record<string, unknown> }),
+  };
+}
+
+function toRow(event: SingletonEventRecord): ToonlRecord {
+  return {
+    at: event.at,
+    singleton: event.singleton,
+    kind: event.kind,
+    ...(event.payload === undefined
+      ? {}
+      : { payload: JSON.stringify(event.payload) }),
+  };
+}
+
+function assertTail(tail: number | undefined): void {
+  if (tail !== undefined && (!Number.isSafeInteger(tail) || tail < 0)) {
+    throw new Error("singleton event tail must be a non-negative integer");
+  }
+}
+
+export function singletonEventLanePath(paths: EnginePaths): string {
+  return join(paths.castleStateRoot, "singleton-events.toonl");
+}
+
+export function createSingletonEventLane(
+  paths: EnginePaths,
+  options: SingletonEventLaneOptions = {},
+): SingletonEventLane {
+  const fs = options.fs ?? { appendFile, mkdir, readFile };
+  const clock = options.clock ?? (() => new Date().toISOString());
+  const path = singletonEventLanePath(paths);
+
+  return {
+    path,
+
+    async append(input) {
+      const event = validateEvent({ at: input.at ?? clock(), ...input });
+      await fs.mkdir(dirname(path), { recursive: true });
+      await fs.appendFile(path, encodeLines().push(toRow(event)), "utf8");
+      return event;
+    },
+
+    async read(readOptions = {}) {
+      assertTail(readOptions.tail);
+      let text: string;
+      try {
+        text = await fs.readFile(path, "utf8");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+        throw error;
+      }
+      const events = parseRecords(text).map(validateEvent);
+      if (readOptions.tail === undefined) return events;
+      if (readOptions.tail === 0) return [];
+      return events.slice(-readOptions.tail);
+    },
+  };
+}

--- a/packages/red-castle/src/engine/singleton-lease.test.ts
+++ b/packages/red-castle/src/engine/singleton-lease.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEnginePaths } from "./paths.js";
 import {
   createSingletonLeaseStore,
+  SingletonLeaseOwnershipError,
   singletonLeasePath,
 } from "./singleton-lease.js";
 
@@ -62,5 +63,38 @@ describe("castle singleton lease", () => {
     expect(await store.release("github-webhook", owner)).toBe(true);
     expect(await store.read("github-webhook")).toBeUndefined();
     expect(isPidAlive).not.toHaveBeenCalled();
+  });
+
+  it("reaps a crashed holder when its recorded PID is dead", async () => {
+    const root = join(tmpdir(), `castle-stale-lease-${crypto.randomUUID()}`);
+    roots.push(root);
+    const paths = createEnginePaths(join(root, ".red"));
+    const fs = { mkdir, readFile, rename, rm, writeFile };
+    const crashedOwner = { pid: 5100, startTime: "2026-07-22T18:40:00.000Z" };
+    const replacement = { pid: 6100, startTime: "2026-07-22T18:42:00.000Z" };
+    const first = createSingletonLeaseStore(paths, {
+      fs,
+      clock: () => "2026-07-22T18:40:01.000Z",
+      isPidAlive: () => true,
+    });
+    await first.acquire("github-webhook", crashedOwner);
+    const isPidAlive = vi.fn((pid: number) => pid !== crashedOwner.pid);
+    const next = createSingletonLeaseStore(paths, {
+      fs,
+      clock: () => "2026-07-22T18:42:01.000Z",
+      isPidAlive,
+    });
+
+    const acquired = await next.acquire("github-webhook", replacement);
+
+    expect(acquired).toMatchObject({
+      acquired: true,
+      reaped: true,
+      lease: { pid: 6100, start_time: "2026-07-22T18:42:00.000Z" },
+    });
+    expect(isPidAlive).toHaveBeenCalledWith(5100);
+    await expect(first.release("github-webhook", crashedOwner)).rejects.toBeInstanceOf(
+      SingletonLeaseOwnershipError,
+    );
   });
 });

--- a/packages/red-castle/src/engine/singleton-lease.test.ts
+++ b/packages/red-castle/src/engine/singleton-lease.test.ts
@@ -1,0 +1,66 @@
+import {
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEnginePaths } from "./paths.js";
+import {
+  createSingletonLeaseStore,
+  singletonLeasePath,
+} from "./singleton-lease.js";
+
+describe("castle singleton lease", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  it("acquires, renews, and releases one lease through injected IO", async () => {
+    const root = join(tmpdir(), `castle-singleton-lease-${crypto.randomUUID()}`);
+    roots.push(root);
+    const paths = createEnginePaths(join(root, ".red"));
+    let now = "2026-07-22T18:30:00.000Z";
+    const isPidAlive = vi.fn(() => true);
+    const store = createSingletonLeaseStore(paths, {
+      fs: { mkdir, readFile, rename, rm, writeFile },
+      clock: () => now,
+      isPidAlive,
+    });
+    const owner = { pid: 4100, startTime: "2026-07-22T18:29:58.000Z" };
+
+    const acquired = await store.acquire("github-webhook", owner);
+
+    expect(acquired).toEqual({
+      acquired: true,
+      reaped: false,
+      lease: {
+        pid: 4100,
+        start_time: "2026-07-22T18:29:58.000Z",
+        acquired_at: "2026-07-22T18:30:00.000Z",
+        renewed_at: "2026-07-22T18:30:00.000Z",
+      },
+    });
+    expect(singletonLeasePath(paths, "github-webhook")).toBe(
+      join(paths.castleStateRoot, "singletons", "github-webhook", "lease.toon"),
+    );
+
+    now = "2026-07-22T18:31:00.000Z";
+    expect(await store.renew("github-webhook", owner)).toMatchObject({
+      renewed_at: "2026-07-22T18:31:00.000Z",
+    });
+    expect(await store.read("github-webhook")).toMatchObject({
+      pid: 4100,
+      renewed_at: "2026-07-22T18:31:00.000Z",
+    });
+
+    expect(await store.release("github-webhook", owner)).toBe(true);
+    expect(await store.read("github-webhook")).toBeUndefined();
+    expect(isPidAlive).not.toHaveBeenCalled();
+  });
+});

--- a/packages/red-castle/src/engine/singleton-lease.test.ts
+++ b/packages/red-castle/src/engine/singleton-lease.test.ts
@@ -1,10 +1,4 @@
-import {
-  mkdir,
-  readFile,
-  rename,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -19,11 +13,16 @@ describe("castle singleton lease", () => {
   const roots: string[] = [];
 
   afterEach(async () => {
-    await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })));
+    await Promise.all(
+      roots.map((root) => rm(root, { recursive: true, force: true })),
+    );
   });
 
   it("acquires, renews, and releases one lease through injected IO", async () => {
-    const root = join(tmpdir(), `castle-singleton-lease-${crypto.randomUUID()}`);
+    const root = join(
+      tmpdir(),
+      `castle-singleton-lease-${crypto.randomUUID()}`,
+    );
     roots.push(root);
     const paths = createEnginePaths(join(root, ".red"));
     let now = "2026-07-22T18:30:00.000Z";
@@ -93,8 +92,8 @@ describe("castle singleton lease", () => {
       lease: { pid: 6100, start_time: "2026-07-22T18:42:00.000Z" },
     });
     expect(isPidAlive).toHaveBeenCalledWith(5100);
-    await expect(first.release("github-webhook", crashedOwner)).rejects.toBeInstanceOf(
-      SingletonLeaseOwnershipError,
-    );
+    await expect(
+      first.release("github-webhook", crashedOwner),
+    ).rejects.toBeInstanceOf(SingletonLeaseOwnershipError);
   });
 });

--- a/packages/red-castle/src/engine/singleton-lease.ts
+++ b/packages/red-castle/src/engine/singleton-lease.ts
@@ -1,0 +1,209 @@
+/**
+ * Repo-scoped singleton ownership in the durable Castle state tier.
+ *
+ * A clean owner releases its lease during shutdown. A crash intentionally
+ * leaves the lease on disk; the next acquirer tests the recorded PID and reaps
+ * the stale record when that process is dead. `start_time` pins ownership so a
+ * former process cannot renew or release a later holder that reused its PID.
+ */
+import {
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import type { EnginePaths } from "./paths.js";
+
+export interface SingletonLeaseOwner {
+  readonly pid: number;
+  readonly startTime: string;
+}
+
+export interface SingletonLease {
+  readonly pid: number;
+  readonly start_time: string;
+  readonly acquired_at: string;
+  readonly renewed_at: string;
+}
+
+export type SingletonLeaseAcquireResult =
+  | { readonly acquired: true; readonly reaped: boolean; readonly lease: SingletonLease }
+  | { readonly acquired: false; readonly lease: SingletonLease };
+
+export interface SingletonLeaseFs {
+  mkdir(path: string, options: { recursive: true }): Promise<unknown>;
+  readFile(path: string, encoding: "utf8"): Promise<string>;
+  writeFile(
+    path: string,
+    data: string,
+    options: { encoding: "utf8"; flag?: string },
+  ): Promise<unknown>;
+  rename(from: string, to: string): Promise<unknown>;
+  rm(path: string, options: { force: true }): Promise<unknown>;
+}
+
+export interface SingletonLeaseStoreOptions {
+  readonly fs?: SingletonLeaseFs;
+  readonly clock?: () => string;
+  readonly isPidAlive?: (pid: number) => boolean | Promise<boolean>;
+}
+
+export interface SingletonLeaseStore {
+  read(name: string): Promise<SingletonLease | undefined>;
+  acquire(name: string, owner: SingletonLeaseOwner): Promise<SingletonLeaseAcquireResult>;
+  renew(name: string, owner: SingletonLeaseOwner): Promise<SingletonLease>;
+  release(name: string, owner: SingletonLeaseOwner): Promise<boolean>;
+}
+
+export class SingletonLeaseOwnershipError extends Error {
+  constructor(name: string) {
+    super(`singleton lease ${JSON.stringify(name)} is held by another owner`);
+    this.name = "SingletonLeaseOwnershipError";
+  }
+}
+
+const SINGLETON_NAME_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+function assertSingletonName(name: string): void {
+  if (!SINGLETON_NAME_RE.test(name) || name === "." || name === "..") {
+    throw new Error(`invalid singleton name ${JSON.stringify(name)}`);
+  }
+}
+
+function defaultPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function isExisting(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "EEXIST";
+}
+
+function validateLease(value: unknown): SingletonLease {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("singleton lease must be a record");
+  }
+  const lease = value as Record<string, unknown>;
+  if (!Number.isInteger(lease.pid) || (lease.pid as number) <= 0) {
+    throw new Error("singleton lease pid must be a positive integer");
+  }
+  for (const field of ["start_time", "acquired_at", "renewed_at"] as const) {
+    if (typeof lease[field] !== "string" || lease[field].length === 0) {
+      throw new Error(`singleton lease ${field} must be a non-empty string`);
+    }
+  }
+  return lease as unknown as SingletonLease;
+}
+
+function belongsTo(lease: SingletonLease, owner: SingletonLeaseOwner): boolean {
+  return lease.pid === owner.pid && lease.start_time === owner.startTime;
+}
+
+export function singletonLeasePath(paths: EnginePaths, name: string): string {
+  assertSingletonName(name);
+  return join(paths.castleStateRoot, "singletons", name, "lease.toon");
+}
+
+export function createSingletonLeaseStore(
+  paths: EnginePaths,
+  options: SingletonLeaseStoreOptions = {},
+): SingletonLeaseStore {
+  const fs = options.fs ?? { mkdir, readFile, rename, rm, writeFile };
+  const clock = options.clock ?? (() => new Date().toISOString());
+  const isPidAlive = options.isPidAlive ?? defaultPidAlive;
+
+  async function readLease(path: string): Promise<SingletonLease | undefined> {
+    try {
+      return validateLease(decode(await fs.readFile(path, "utf8")));
+    } catch (error) {
+      if (isMissing(error)) return undefined;
+      throw error;
+    }
+  }
+
+  async function replace(path: string, lease: SingletonLease): Promise<void> {
+    const temporary = `${path}.tmp-${lease.pid}-${crypto.randomUUID()}`;
+    await fs.writeFile(
+      temporary,
+      encode(lease as unknown as JsonValue, { keyedMapCollapse: true }),
+      { encoding: "utf8" },
+    );
+    await fs.rename(temporary, path);
+  }
+
+  return {
+    read(name) {
+      return readLease(singletonLeasePath(paths, name));
+    },
+
+    async acquire(name, owner) {
+      const path = singletonLeasePath(paths, name);
+      await fs.mkdir(dirname(path), { recursive: true });
+      let reaped = false;
+
+      for (;;) {
+        const now = clock();
+        const lease: SingletonLease = {
+          pid: owner.pid,
+          start_time: owner.startTime,
+          acquired_at: now,
+          renewed_at: now,
+        };
+        try {
+          await fs.writeFile(
+            path,
+            encode(lease as unknown as JsonValue, { keyedMapCollapse: true }),
+            { encoding: "utf8", flag: "wx" },
+          );
+          return { acquired: true, reaped, lease };
+        } catch (error) {
+          if (!isExisting(error)) throw error;
+        }
+
+        const existing = await readLease(path);
+        if (!existing) continue;
+        if (belongsTo(existing, owner)) {
+          return { acquired: true, reaped, lease: existing };
+        }
+        if (await isPidAlive(existing.pid)) {
+          return { acquired: false, lease: existing };
+        }
+        await fs.rm(path, { force: true });
+        reaped = true;
+      }
+    },
+
+    async renew(name, owner) {
+      const path = singletonLeasePath(paths, name);
+      const existing = await readLease(path);
+      if (!existing || !belongsTo(existing, owner)) {
+        throw new SingletonLeaseOwnershipError(name);
+      }
+      const renewed = { ...existing, renewed_at: clock() };
+      await replace(path, renewed);
+      return renewed;
+    },
+
+    async release(name, owner) {
+      const path = singletonLeasePath(paths, name);
+      const existing = await readLease(path);
+      if (!existing) return false;
+      if (!belongsTo(existing, owner)) {
+        throw new SingletonLeaseOwnershipError(name);
+      }
+      await fs.rm(path, { force: true });
+      return true;
+    },
+  };
+}

--- a/packages/red-castle/src/engine/singleton-lease.ts
+++ b/packages/red-castle/src/engine/singleton-lease.ts
@@ -6,13 +6,7 @@
  * the stale record when that process is dead. `start_time` pins ownership so a
  * former process cannot renew or release a later holder that reused its PID.
  */
-import {
-  mkdir,
-  readFile,
-  rename,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
 import type { EnginePaths } from "./paths.js";
@@ -30,7 +24,11 @@ export interface SingletonLease {
 }
 
 export type SingletonLeaseAcquireResult =
-  | { readonly acquired: true; readonly reaped: boolean; readonly lease: SingletonLease }
+  | {
+      readonly acquired: true;
+      readonly reaped: boolean;
+      readonly lease: SingletonLease;
+    }
   | { readonly acquired: false; readonly lease: SingletonLease };
 
 export interface SingletonLeaseFs {
@@ -53,7 +51,10 @@ export interface SingletonLeaseStoreOptions {
 
 export interface SingletonLeaseStore {
   read(name: string): Promise<SingletonLease | undefined>;
-  acquire(name: string, owner: SingletonLeaseOwner): Promise<SingletonLeaseAcquireResult>;
+  acquire(
+    name: string,
+    owner: SingletonLeaseOwner,
+  ): Promise<SingletonLeaseAcquireResult>;
   renew(name: string, owner: SingletonLeaseOwner): Promise<SingletonLease>;
   release(name: string, owner: SingletonLeaseOwner): Promise<boolean>;
 }


### PR DESCRIPTION
Automated AFK landing for #2420. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2420

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787337542&installation_model_id=20659&pr_number=2503&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2503&signature=db7b0530deb269e02d5e599471ebb53d085944bbc90ed901d1aad95ecda375c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->