### PR TITLE
chore: #2421 Implementer environment: per-runner projection from config activation gates

### DIFF
--- a/packages/red-castle/src/engine/__snapshots__/runner-registry.test.ts.snap
+++ b/packages/red-castle/src/engine/__snapshots__/runner-registry.test.ts.snap
@@ -1,0 +1,490 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`engine runner registry > projects the exact claude implementer constraint for one activation gate 1`] = `
+{
+  "flags": [
+    "--bare",
+    "--strict-mcp-config",
+  ],
+  "kind": "claude-settings",
+  "settings": {
+    "hooks": [],
+    "mcpServers": [
+      "navigator",
+    ],
+    "plugins": [
+      "dev",
+    ],
+    "rsp": false,
+  },
+}
+`;
+
+exports[`engine runner registry > projects the exact claude implementer constraint for one activation gate 2`] = `
+{
+  "flags": [
+    "--bare",
+    "--strict-mcp-config",
+  ],
+  "kind": "claude-settings",
+  "settings": {
+    "hooks": [],
+    "mcpServers": [
+      "navigator",
+      "red-memory",
+    ],
+    "plugins": [
+      "dev",
+      "memory",
+    ],
+    "rsp": false,
+  },
+}
+`;
+
+exports[`engine runner registry > projects the exact claude implementer constraint for one activation gate 3`] = `
+{
+  "flags": [
+    "--bare",
+    "--strict-mcp-config",
+  ],
+  "kind": "claude-settings",
+  "settings": {
+    "hooks": [],
+    "mcpServers": [
+      "navigator",
+      "brain",
+    ],
+    "plugins": [
+      "dev",
+      "brain",
+    ],
+    "rsp": false,
+  },
+}
+`;
+
+exports[`engine runner registry > projects the exact claude implementer constraint for one activation gate 4`] = `
+{
+  "flags": [
+    "--bare",
+    "--strict-mcp-config",
+  ],
+  "kind": "claude-settings",
+  "settings": {
+    "hooks": [],
+    "mcpServers": [
+      "navigator",
+      "red-ui",
+    ],
+    "plugins": [
+      "dev",
+    ],
+    "rsp": false,
+  },
+}
+`;
+
+exports[`engine runner registry > projects the exact claude implementer constraint for one activation gate 5`] = `
+{
+  "flags": [
+    "--bare",
+    "--strict-mcp-config",
+  ],
+  "kind": "claude-settings",
+  "settings": {
+    "hooks": [],
+    "mcpServers": [
+      "navigator",
+      "rsp",
+    ],
+    "plugins": [
+      "dev",
+    ],
+    "rsp": true,
+  },
+}
+`;
+
+exports[`engine runner registry > projects the exact codex implementer constraint for one activation gate 1`] = `
+{
+  "config": {
+    "hooks": false,
+    "mcpServers": {
+      "brain": false,
+      "castle": false,
+      "navigator": true,
+      "red-memory": false,
+      "red-ui": false,
+      "rsp": false,
+    },
+    "plugins": {
+      "brain@red-skills": false,
+      "dev@red-skills": true,
+      "memory@red-skills": false,
+    },
+    "rsp": false,
+  },
+  "kind": "codex-config",
+}
+`;
+
+exports[`engine runner registry > projects the exact codex implementer constraint for one activation gate 2`] = `
+{
+  "config": {
+    "hooks": false,
+    "mcpServers": {
+      "brain": false,
+      "castle": false,
+      "navigator": true,
+      "red-memory": true,
+      "red-ui": false,
+      "rsp": false,
+    },
+    "plugins": {
+      "brain@red-skills": false,
+      "dev@red-skills": true,
+      "memory@red-skills": true,
+    },
+    "rsp": false,
+  },
+  "kind": "codex-config",
+}
+`;
+
+exports[`engine runner registry > projects the exact codex implementer constraint for one activation gate 3`] = `
+{
+  "config": {
+    "hooks": false,
+    "mcpServers": {
+      "brain": true,
+      "castle": false,
+      "navigator": true,
+      "red-memory": false,
+      "red-ui": false,
+      "rsp": false,
+    },
+    "plugins": {
+      "brain@red-skills": true,
+      "dev@red-skills": true,
+      "memory@red-skills": false,
+    },
+    "rsp": false,
+  },
+  "kind": "codex-config",
+}
+`;
+
+exports[`engine runner registry > projects the exact codex implementer constraint for one activation gate 4`] = `
+{
+  "config": {
+    "hooks": false,
+    "mcpServers": {
+      "brain": false,
+      "castle": false,
+      "navigator": true,
+      "red-memory": false,
+      "red-ui": true,
+      "rsp": false,
+    },
+    "plugins": {
+      "brain@red-skills": false,
+      "dev@red-skills": true,
+      "memory@red-skills": false,
+    },
+    "rsp": false,
+  },
+  "kind": "codex-config",
+}
+`;
+
+exports[`engine runner registry > projects the exact codex implementer constraint for one activation gate 5`] = `
+{
+  "config": {
+    "hooks": false,
+    "mcpServers": {
+      "brain": false,
+      "castle": false,
+      "navigator": true,
+      "red-memory": false,
+      "red-ui": false,
+      "rsp": true,
+    },
+    "plugins": {
+      "brain@red-skills": false,
+      "dev@red-skills": true,
+      "memory@red-skills": false,
+    },
+    "rsp": true,
+  },
+  "kind": "codex-config",
+}
+`;
+
+exports[`engine runner registry > projects the exact opencode implementer constraint for one activation gate 1`] = `
+{
+  "config": {
+    "mcp": {
+      "brain": {
+        "enabled": false,
+      },
+      "castle": {
+        "enabled": false,
+      },
+      "navigator": {
+        "enabled": true,
+      },
+      "red-memory": {
+        "enabled": false,
+      },
+      "red-ui": {
+        "enabled": false,
+      },
+      "rsp": {
+        "enabled": false,
+      },
+    },
+    "pluginEvents": [],
+    "plugins": [
+      "dev",
+    ],
+    "rsp": false,
+  },
+  "kind": "opencode-config",
+}
+`;
+
+exports[`engine runner registry > projects the exact opencode implementer constraint for one activation gate 2`] = `
+{
+  "config": {
+    "mcp": {
+      "brain": {
+        "enabled": false,
+      },
+      "castle": {
+        "enabled": false,
+      },
+      "navigator": {
+        "enabled": true,
+      },
+      "red-memory": {
+        "enabled": true,
+      },
+      "red-ui": {
+        "enabled": false,
+      },
+      "rsp": {
+        "enabled": false,
+      },
+    },
+    "pluginEvents": [],
+    "plugins": [
+      "dev",
+      "memory",
+    ],
+    "rsp": false,
+  },
+  "kind": "opencode-config",
+}
+`;
+
+exports[`engine runner registry > projects the exact opencode implementer constraint for one activation gate 3`] = `
+{
+  "config": {
+    "mcp": {
+      "brain": {
+        "enabled": true,
+      },
+      "castle": {
+        "enabled": false,
+      },
+      "navigator": {
+        "enabled": true,
+      },
+      "red-memory": {
+        "enabled": false,
+      },
+      "red-ui": {
+        "enabled": false,
+      },
+      "rsp": {
+        "enabled": false,
+      },
+    },
+    "pluginEvents": [],
+    "plugins": [
+      "dev",
+      "brain",
+    ],
+    "rsp": false,
+  },
+  "kind": "opencode-config",
+}
+`;
+
+exports[`engine runner registry > projects the exact opencode implementer constraint for one activation gate 4`] = `
+{
+  "config": {
+    "mcp": {
+      "brain": {
+        "enabled": false,
+      },
+      "castle": {
+        "enabled": false,
+      },
+      "navigator": {
+        "enabled": true,
+      },
+      "red-memory": {
+        "enabled": false,
+      },
+      "red-ui": {
+        "enabled": true,
+      },
+      "rsp": {
+        "enabled": false,
+      },
+    },
+    "pluginEvents": [],
+    "plugins": [
+      "dev",
+    ],
+    "rsp": false,
+  },
+  "kind": "opencode-config",
+}
+`;
+
+exports[`engine runner registry > projects the exact opencode implementer constraint for one activation gate 5`] = `
+{
+  "config": {
+    "mcp": {
+      "brain": {
+        "enabled": false,
+      },
+      "castle": {
+        "enabled": false,
+      },
+      "navigator": {
+        "enabled": true,
+      },
+      "red-memory": {
+        "enabled": false,
+      },
+      "red-ui": {
+        "enabled": false,
+      },
+      "rsp": {
+        "enabled": true,
+      },
+    },
+    "pluginEvents": [],
+    "plugins": [
+      "dev",
+    ],
+    "rsp": true,
+  },
+  "kind": "opencode-config",
+}
+`;
+
+exports[`engine runner registry > projects the exact pi implementer constraint for one activation gate 1`] = `
+{
+  "extensions": [
+    "navigator",
+  ],
+  "flags": [
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+  ],
+  "kind": "pi-flags",
+  "rsp": false,
+  "skills": [
+    "dev",
+  ],
+}
+`;
+
+exports[`engine runner registry > projects the exact pi implementer constraint for one activation gate 2`] = `
+{
+  "extensions": [
+    "navigator",
+    "red-memory",
+  ],
+  "flags": [
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+  ],
+  "kind": "pi-flags",
+  "rsp": false,
+  "skills": [
+    "dev",
+    "memory",
+  ],
+}
+`;
+
+exports[`engine runner registry > projects the exact pi implementer constraint for one activation gate 3`] = `
+{
+  "extensions": [
+    "navigator",
+    "brain",
+  ],
+  "flags": [
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+  ],
+  "kind": "pi-flags",
+  "rsp": false,
+  "skills": [
+    "dev",
+    "brain",
+  ],
+}
+`;
+
+exports[`engine runner registry > projects the exact pi implementer constraint for one activation gate 4`] = `
+{
+  "extensions": [
+    "navigator",
+    "red-ui",
+  ],
+  "flags": [
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+  ],
+  "kind": "pi-flags",
+  "rsp": false,
+  "skills": [
+    "dev",
+  ],
+}
+`;
+
+exports[`engine runner registry > projects the exact pi implementer constraint for one activation gate 5`] = `
+{
+  "extensions": [
+    "navigator",
+    "rsp",
+  ],
+  "flags": [
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+  ],
+  "kind": "pi-flags",
+  "rsp": true,
+  "skills": [
+    "dev",
+  ],
+}
+`;

--- a/packages/red-castle/src/engine/runner-registry.test.ts
+++ b/packages/red-castle/src/engine/runner-registry.test.ts
@@ -31,32 +31,117 @@ import { runners, type Runner } from "./runner-types.js";
 describe("engine runner registry", () => {
   it.each([
     ["claude", {}, { plugins: ["dev"], mcp: ["navigator"], rsp: false }],
-    ["claude", { "plugins.memory.enabled": "true" }, { plugins: ["dev", "memory"], mcp: ["navigator", "red-memory"], rsp: false }],
-    ["claude", { "plugins.brain.enabled": "true" }, { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false }],
-    ["claude", { "plugins.red-ui.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false }],
-    ["claude", { "rsp.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true }],
+    [
+      "claude",
+      { "plugins.memory.enabled": "true" },
+      {
+        plugins: ["dev", "memory"],
+        mcp: ["navigator", "red-memory"],
+        rsp: false,
+      },
+    ],
+    [
+      "claude",
+      { "plugins.brain.enabled": "true" },
+      { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false },
+    ],
+    [
+      "claude",
+      { "plugins.red-ui.enabled": "true" },
+      { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false },
+    ],
+    [
+      "claude",
+      { "rsp.enabled": "true" },
+      { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true },
+    ],
     ["codex", {}, { plugins: ["dev"], mcp: ["navigator"], rsp: false }],
-    ["codex", { "plugins.memory.enabled": "true" }, { plugins: ["dev", "memory"], mcp: ["navigator", "red-memory"], rsp: false }],
-    ["codex", { "plugins.brain.enabled": "true" }, { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false }],
-    ["codex", { "plugins.red-ui.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false }],
-    ["codex", { "rsp.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true }],
+    [
+      "codex",
+      { "plugins.memory.enabled": "true" },
+      {
+        plugins: ["dev", "memory"],
+        mcp: ["navigator", "red-memory"],
+        rsp: false,
+      },
+    ],
+    [
+      "codex",
+      { "plugins.brain.enabled": "true" },
+      { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false },
+    ],
+    [
+      "codex",
+      { "plugins.red-ui.enabled": "true" },
+      { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false },
+    ],
+    [
+      "codex",
+      { "rsp.enabled": "true" },
+      { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true },
+    ],
     ["opencode", {}, { plugins: ["dev"], mcp: ["navigator"], rsp: false }],
-    ["opencode", { "plugins.memory.enabled": "true" }, { plugins: ["dev", "memory"], mcp: ["navigator", "red-memory"], rsp: false }],
-    ["opencode", { "plugins.brain.enabled": "true" }, { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false }],
-    ["opencode", { "plugins.red-ui.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false }],
-    ["opencode", { "rsp.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true }],
+    [
+      "opencode",
+      { "plugins.memory.enabled": "true" },
+      {
+        plugins: ["dev", "memory"],
+        mcp: ["navigator", "red-memory"],
+        rsp: false,
+      },
+    ],
+    [
+      "opencode",
+      { "plugins.brain.enabled": "true" },
+      { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false },
+    ],
+    [
+      "opencode",
+      { "plugins.red-ui.enabled": "true" },
+      { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false },
+    ],
+    [
+      "opencode",
+      { "rsp.enabled": "true" },
+      { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true },
+    ],
     ["pi", {}, { plugins: ["dev"], mcp: ["navigator"], rsp: false }],
-    ["pi", { "plugins.memory.enabled": "true" }, { plugins: ["dev", "memory"], mcp: ["navigator", "red-memory"], rsp: false }],
-    ["pi", { "plugins.brain.enabled": "true" }, { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false }],
-    ["pi", { "plugins.red-ui.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false }],
-    ["pi", { "rsp.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true }],
-  ] as const)("projects the exact %s implementer constraint for one activation gate", (runner, values, enabled) => {
-    const projection = projectImplementerEnvironment(runner, values);
+    [
+      "pi",
+      { "plugins.memory.enabled": "true" },
+      {
+        plugins: ["dev", "memory"],
+        mcp: ["navigator", "red-memory"],
+        rsp: false,
+      },
+    ],
+    [
+      "pi",
+      { "plugins.brain.enabled": "true" },
+      { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false },
+    ],
+    [
+      "pi",
+      { "plugins.red-ui.enabled": "true" },
+      { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false },
+    ],
+    [
+      "pi",
+      { "rsp.enabled": "true" },
+      { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true },
+    ],
+  ] as const)(
+    "projects the exact %s implementer constraint for one activation gate",
+    (runner, values, enabled) => {
+      const projection = projectImplementerEnvironment(runner, values);
 
-    expect(projection.enabled).toEqual(enabled);
-    expect(projection.constraint).toMatchSnapshot();
-    expect(JSON.stringify(projection)).not.toMatch(/statusline|hooks\/|hooks\\\\/);
-  });
+      expect(projection.enabled).toEqual(enabled);
+      expect(projection.constraint).toMatchSnapshot();
+      expect(JSON.stringify(projection)).not.toMatch(
+        /statusline|hooks\/|hooks\\\\/,
+      );
+    },
+  );
 
   it("owns the runner rows and provider-less projection", () => {
     const cases: Array<[Runner, AgentRunner]> = [
@@ -67,9 +152,17 @@ describe("engine runner registry", () => {
       ["hermes", "claude"],
     ];
     expect(cases.map(([r]) => r).sort()).toEqual([...runners].sort());
-    for (const [input, expected] of cases) expect(toAgentRunner(input)).toBe(expected);
+    for (const [input, expected] of cases)
+      expect(toAgentRunner(input)).toBe(expected);
     expect(Object.keys(RUNNER_SPECS).sort()).toEqual(
-      (["claude", "codex", "opencode", "claude-minimax"] satisfies AgentRunner[]).sort(),
+      (
+        [
+          "claude",
+          "codex",
+          "opencode",
+          "claude-minimax",
+        ] satisfies AgentRunner[]
+      ).sort(),
     );
   });
 
@@ -83,7 +176,9 @@ describe("engine runner registry", () => {
       ANTHROPIC_BASE_URL: "https://api.minimax.io/anthropic",
       CLAUDE_CODE_SIMPLE: "1",
     });
-    expect(openCodeAuthEnv(resolveOpenCodeAuth({ MINIMAX_API_KEY: "mm" }))).toEqual({ MINIMAX_API_KEY: "mm" });
+    expect(
+      openCodeAuthEnv(resolveOpenCodeAuth({ MINIMAX_API_KEY: "mm" })),
+    ).toEqual({ MINIMAX_API_KEY: "mm" });
     expect(runnerSupportsStructuredOutput("claude")).toBe(true);
     expect(runnerSupportsStructuredOutput("codex")).toBe(false);
   });
@@ -91,47 +186,67 @@ describe("engine runner registry", () => {
   it("answers whether a runner's CLI can dispatch a model slug (#2352)", () => {
     expect(runnerSupportsModel("claude", "claude-opus-4-8")).toBe(true);
     expect(runnerSupportsModel("claude", "sonnet")).toBe(true);
-    expect(runnerSupportsModel("claude", "us.anthropic.claude-opus-4-8-v1:0")).toBe(true);
+    expect(
+      runnerSupportsModel("claude", "us.anthropic.claude-opus-4-8-v1:0"),
+    ).toBe(true);
     expect(runnerSupportsModel("claude", "gpt-5.6-sol")).toBe(false);
     expect(runnerSupportsModel("codex", "gpt-5.6-sol")).toBe(true);
     expect(runnerSupportsModel("codex", "o3")).toBe(true);
     expect(runnerSupportsModel("codex", "claude-opus-4-8")).toBe(false);
-    expect(runnerSupportsModel("opencode", "openrouter/anthropic/claude-opus-4")).toBe(true);
+    expect(
+      runnerSupportsModel("opencode", "openrouter/anthropic/claude-opus-4"),
+    ).toBe(true);
     expect(runnerSupportsModel("opencode", "claude-opus-4-8")).toBe(false);
     // A forcedModel runner accepts exactly its forced slug.
     expect(runnerSupportsModel("claude-minimax", MINIMAX_M3_MODEL)).toBe(true);
-    expect(runnerSupportsModel("claude-minimax", "claude-opus-4-8")).toBe(false);
+    expect(runnerSupportsModel("claude-minimax", "claude-opus-4-8")).toBe(
+      false,
+    );
     // A blank slug is never runnable.
     expect(runnerSupportsModel("claude", "  ")).toBe(false);
   });
 
   it("keeps runner detection and spawn argv parity in the engine unit", () => {
-    expect(detectRunner({ flag: "opencode" })).toMatchObject({ runner: "opencode", method: "flag" });
-    expect(detectRunner({ env: { CODEX_SANDBOX: "danger-full-access" } })).toMatchObject({
+    expect(detectRunner({ flag: "opencode" })).toMatchObject({
+      runner: "opencode",
+      method: "flag",
+    });
+    expect(
+      detectRunner({ env: { CODEX_SANDBOX: "danger-full-access" } }),
+    ).toMatchObject({
       runner: "codex",
       method: "env-var",
     });
-    expect(detectRunner({ env: {}, processTree: "node /opt/opencode/bin/opencode" })).toMatchObject({
+    expect(
+      detectRunner({ env: {}, processTree: "node /opt/opencode/bin/opencode" }),
+    ).toMatchObject({
       runner: "claude",
       method: "env-fallback",
     });
     expect(parseRunnerFlag(["--runner=claude-minimax"])).toBe("claude-minimax");
-    expect(claudeSpawnArgs({ prompt: "PROMPT", worktree: "/wt" }).args).toEqual([
-      "--model",
-      "opus",
-      "--effort",
-      "medium",
-      "--permission-mode",
-      "bypassPermissions",
-      "--output-format",
-      "stream-json",
-      "--verbose",
-      "--print",
-      "PROMPT",
-    ]);
-    expect(codexSpawnArgs({ prompt: "PROMPT", worktree: "/wt", lastMessagePath: "/last", effort: "high" }).args).toContain(
-      "model_reasoning_effort=high",
+    expect(claudeSpawnArgs({ prompt: "PROMPT", worktree: "/wt" }).args).toEqual(
+      [
+        "--model",
+        "opus",
+        "--effort",
+        "medium",
+        "--permission-mode",
+        "bypassPermissions",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--print",
+        "PROMPT",
+      ],
     );
+    expect(
+      codexSpawnArgs({
+        prompt: "PROMPT",
+        worktree: "/wt",
+        lastMessagePath: "/last",
+        effort: "high",
+      }).args,
+    ).toContain("model_reasoning_effort=high");
     expect(isRunnerExhausted("Weekly cap reached")).toBe(true);
   });
 
@@ -140,11 +255,17 @@ describe("engine runner registry", () => {
     expect(BLOCKED_SIGNAL).toBe("<promise>BLOCKED</promise>");
     expect(NO_MORE_TASKS_SIGNAL).toBe("<promise>NO MORE TASKS</promise>");
     expect(COMPLETION_SIGNALS).toEqual([DONE_SIGNAL, BLOCKED_SIGNAL]);
-    expect(detectSentinelLine("x <promise>NO MORE TASKS</promise> y")?.kind).toBe("no_more_tasks");
+    expect(
+      detectSentinelLine("x <promise>NO MORE TASKS</promise> y")?.kind,
+    ).toBe("no_more_tasks");
 
     const _stream: AgentStreamEvent | undefined = undefined;
     const _result: RunResult | undefined = undefined;
     const _liveness: LivenessVerdict | undefined = undefined;
-    expect([_stream, _result, _liveness]).toEqual([undefined, undefined, undefined]);
+    expect([_stream, _result, _liveness]).toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
   });
 });

--- a/packages/red-castle/src/engine/runner-registry.test.ts
+++ b/packages/red-castle/src/engine/runner-registry.test.ts
@@ -15,6 +15,7 @@ import {
   isRunnerExhausted,
   openCodeAuthEnv,
   parseRunnerFlag,
+  projectImplementerEnvironment,
   resolveMiniMaxClaudeEnv,
   resolveOpenCodeAuth,
   runnerSupportsModel,
@@ -28,6 +29,35 @@ import {
 import { runners, type Runner } from "./runner-types.js";
 
 describe("engine runner registry", () => {
+  it.each([
+    ["claude", {}, { plugins: ["dev"], mcp: ["navigator"], rsp: false }],
+    ["claude", { "plugins.memory.enabled": "true" }, { plugins: ["dev", "memory"], mcp: ["navigator", "red-memory"], rsp: false }],
+    ["claude", { "plugins.brain.enabled": "true" }, { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false }],
+    ["claude", { "plugins.red-ui.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false }],
+    ["claude", { "rsp.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true }],
+    ["codex", {}, { plugins: ["dev"], mcp: ["navigator"], rsp: false }],
+    ["codex", { "plugins.memory.enabled": "true" }, { plugins: ["dev", "memory"], mcp: ["navigator", "red-memory"], rsp: false }],
+    ["codex", { "plugins.brain.enabled": "true" }, { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false }],
+    ["codex", { "plugins.red-ui.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false }],
+    ["codex", { "rsp.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true }],
+    ["opencode", {}, { plugins: ["dev"], mcp: ["navigator"], rsp: false }],
+    ["opencode", { "plugins.memory.enabled": "true" }, { plugins: ["dev", "memory"], mcp: ["navigator", "red-memory"], rsp: false }],
+    ["opencode", { "plugins.brain.enabled": "true" }, { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false }],
+    ["opencode", { "plugins.red-ui.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false }],
+    ["opencode", { "rsp.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true }],
+    ["pi", {}, { plugins: ["dev"], mcp: ["navigator"], rsp: false }],
+    ["pi", { "plugins.memory.enabled": "true" }, { plugins: ["dev", "memory"], mcp: ["navigator", "red-memory"], rsp: false }],
+    ["pi", { "plugins.brain.enabled": "true" }, { plugins: ["dev", "brain"], mcp: ["navigator", "brain"], rsp: false }],
+    ["pi", { "plugins.red-ui.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "red-ui"], rsp: false }],
+    ["pi", { "rsp.enabled": "true" }, { plugins: ["dev"], mcp: ["navigator", "rsp"], rsp: true }],
+  ] as const)("projects the exact %s implementer constraint for one activation gate", (runner, values, enabled) => {
+    const projection = projectImplementerEnvironment(runner, values);
+
+    expect(projection.enabled).toEqual(enabled);
+    expect(projection.constraint).toMatchSnapshot();
+    expect(JSON.stringify(projection)).not.toMatch(/statusline|hooks\/|hooks\\\\/);
+  });
+
   it("owns the runner rows and provider-less projection", () => {
     const cases: Array<[Runner, AgentRunner]> = [
       ["claude", "claude"],

--- a/packages/red-castle/src/engine/runner-spec.ts
+++ b/packages/red-castle/src/engine/runner-spec.ts
@@ -25,8 +25,14 @@ export type ImplementerSpawnConstraint =
   | {
       kind: "codex-config";
       config: {
-        plugins: Record<"dev@red-skills" | "memory@red-skills" | "brain@red-skills", boolean>;
-        mcpServers: Record<"navigator" | "castle" | "red-memory" | "brain" | "red-ui" | "rsp", boolean>;
+        plugins: Record<
+          "dev@red-skills" | "memory@red-skills" | "brain@red-skills",
+          boolean
+        >;
+        mcpServers: Record<
+          "navigator" | "castle" | "red-memory" | "brain" | "red-ui" | "rsp",
+          boolean
+        >;
         hooks: false;
         rsp: boolean;
       };
@@ -35,14 +41,22 @@ export type ImplementerSpawnConstraint =
       kind: "opencode-config";
       config: {
         plugins: ImplementerEnabledSurfaces["plugins"];
-        mcp: Record<"navigator" | "castle" | "red-memory" | "brain" | "red-ui" | "rsp", { enabled: boolean }>;
+        mcp: Record<
+          "navigator" | "castle" | "red-memory" | "brain" | "red-ui" | "rsp",
+          { enabled: boolean }
+        >;
         pluginEvents: readonly [];
         rsp: boolean;
       };
     }
   | {
       kind: "pi-flags";
-      flags: readonly ["--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes"];
+      flags: readonly [
+        "--no-extensions",
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-themes",
+      ];
       skills: ImplementerEnabledSurfaces["plugins"];
       extensions: ImplementerEnabledSurfaces["mcp"];
       rsp: boolean;
@@ -54,10 +68,23 @@ export interface ImplementerEnvironmentProjection {
   constraint: ImplementerSpawnConstraint;
 }
 
-type ImplementerProjector = (enabled: ImplementerEnabledSurfaces) => ImplementerSpawnConstraint;
+type ImplementerProjector = (
+  enabled: ImplementerEnabledSurfaces,
+) => ImplementerSpawnConstraint;
 
-export const CODEX_EFFORTS: readonly AgentEffort[] = ["low", "medium", "high", "xhigh"];
-export const CLAUDE_EFFORTS: readonly AgentEffort[] = ["low", "medium", "high", "xhigh", "max"];
+export const CODEX_EFFORTS: readonly AgentEffort[] = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+];
+export const CLAUDE_EFFORTS: readonly AgentEffort[] = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
 export const MINIMAX_EFFORTS: readonly AgentEffort[] = ["low"];
 
 export interface RunnerSpec {
@@ -66,7 +93,9 @@ export interface RunnerSpec {
   factory: "claudeCode" | "codex" | "opencode";
   forcedModel?: string;
   defaultEffort?: AgentEffort;
-  resolveAuthEnv?: (env: NodeJS.ProcessEnv) => Record<string, string> | undefined;
+  resolveAuthEnv?: (
+    env: NodeJS.ProcessEnv,
+  ) => Record<string, string> | undefined;
   structuredOutput?: boolean;
   /**
    * Model-slug families this runner's CLI can dispatch. A runner with a
@@ -131,7 +160,12 @@ const openCodeImplementerEnvironment: ImplementerProjector = (enabled) => ({
 
 const piImplementerEnvironment: ImplementerProjector = (enabled) => ({
   kind: "pi-flags",
-  flags: ["--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes"],
+  flags: [
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+  ],
   skills: [...enabled.plugins],
   extensions: [...enabled.mcp],
   rsp: enabled.rsp,
@@ -175,13 +209,19 @@ export const RUNNER_SPECS: Record<AgentRunner, RunnerSpec> = {
   },
 };
 
-function enabledImplementerSurfaces(values: ImplementerConfigValues): ImplementerEnabledSurfaces {
+function enabledImplementerSurfaces(
+  values: ImplementerConfigValues,
+): ImplementerEnabledSurfaces {
   const memory = values["plugins.memory.enabled"] === "true";
   const brain = values["plugins.brain.enabled"] === "true";
   const redUi = values["plugins.red-ui.enabled"] === "true";
   const rsp = values["rsp.enabled"] === "true";
   return {
-    plugins: ["dev", ...(memory ? ["memory" as const] : []), ...(brain ? ["brain" as const] : [])],
+    plugins: [
+      "dev",
+      ...(memory ? ["memory" as const] : []),
+      ...(brain ? ["brain" as const] : []),
+    ],
     mcp: [
       "navigator",
       ...(memory ? ["red-memory" as const] : []),
@@ -211,7 +251,9 @@ export function projectImplementerEnvironment(
 }
 
 export function toAgentRunner(r: Runner): AgentRunner {
-  return r === "codex" || r === "opencode" || r === "claude-minimax" ? r : "claude";
+  return r === "codex" || r === "opencode" || r === "claude-minimax"
+    ? r
+    : "claude";
 }
 
 export function runnerSupportsStructuredOutput(runner: AgentRunner): boolean {
@@ -225,7 +267,10 @@ export function runnerSupportsStructuredOutput(runner: AgentRunner): boolean {
  * runner/model PAIR, so an operator's cross-runner model pin is substituted
  * before spawn instead of exiting non-zero at run time.
  */
-export function runnerSupportsModel(runner: AgentRunner, model: string): boolean {
+export function runnerSupportsModel(
+  runner: AgentRunner,
+  model: string,
+): boolean {
   const spec = RUNNER_SPECS[runner];
   const slug = model.trim();
   if (slug.length === 0) return false;

--- a/packages/red-castle/src/engine/runner-spec.ts
+++ b/packages/red-castle/src/engine/runner-spec.ts
@@ -2,6 +2,60 @@ import type { AgentEffort, AgentRunner, Runner } from "./runner-types.js";
 import { MINIMAX_M3_MODEL, resolveMiniMaxClaudeEnv } from "./minimax-env.js";
 import { openCodeAuthEnv, resolveOpenCodeAuth } from "./opencode-env.js";
 
+export type ImplementerRunner = "claude" | "codex" | "opencode" | "pi";
+export type ImplementerConfigValues = Readonly<Record<string, string>>;
+
+export interface ImplementerEnabledSurfaces {
+  plugins: Array<"dev" | "memory" | "brain">;
+  mcp: Array<"navigator" | "red-memory" | "brain" | "red-ui" | "rsp">;
+  rsp: boolean;
+}
+
+export type ImplementerSpawnConstraint =
+  | {
+      kind: "claude-settings";
+      flags: readonly ["--bare", "--strict-mcp-config"];
+      settings: {
+        plugins: ImplementerEnabledSurfaces["plugins"];
+        mcpServers: ImplementerEnabledSurfaces["mcp"];
+        hooks: readonly [];
+        rsp: boolean;
+      };
+    }
+  | {
+      kind: "codex-config";
+      config: {
+        plugins: Record<"dev@red-skills" | "memory@red-skills" | "brain@red-skills", boolean>;
+        mcpServers: Record<"navigator" | "castle" | "red-memory" | "brain" | "red-ui" | "rsp", boolean>;
+        hooks: false;
+        rsp: boolean;
+      };
+    }
+  | {
+      kind: "opencode-config";
+      config: {
+        plugins: ImplementerEnabledSurfaces["plugins"];
+        mcp: Record<"navigator" | "castle" | "red-memory" | "brain" | "red-ui" | "rsp", { enabled: boolean }>;
+        pluginEvents: readonly [];
+        rsp: boolean;
+      };
+    }
+  | {
+      kind: "pi-flags";
+      flags: readonly ["--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes"];
+      skills: ImplementerEnabledSurfaces["plugins"];
+      extensions: ImplementerEnabledSurfaces["mcp"];
+      rsp: boolean;
+    };
+
+export interface ImplementerEnvironmentProjection {
+  runner: ImplementerRunner;
+  enabled: ImplementerEnabledSurfaces;
+  constraint: ImplementerSpawnConstraint;
+}
+
+type ImplementerProjector = (enabled: ImplementerEnabledSurfaces) => ImplementerSpawnConstraint;
+
 export const CODEX_EFFORTS: readonly AgentEffort[] = ["low", "medium", "high", "xhigh"];
 export const CLAUDE_EFFORTS: readonly AgentEffort[] = ["low", "medium", "high", "xhigh", "max"];
 export const MINIMAX_EFFORTS: readonly AgentEffort[] = ["low"];
@@ -22,7 +76,66 @@ export interface RunnerSpec {
    * not a degraded run, it is an immediate non-zero exit.
    */
   modelFamilies?: readonly RegExp[];
+  /** Native CLI constraint for an inner agent's config-gated environment. */
+  projectImplementerEnvironment: ImplementerProjector;
 }
+
+const claudeImplementerEnvironment: ImplementerProjector = (enabled) => ({
+  kind: "claude-settings",
+  flags: ["--bare", "--strict-mcp-config"],
+  settings: {
+    plugins: [...enabled.plugins],
+    mcpServers: [...enabled.mcp],
+    hooks: [],
+    rsp: enabled.rsp,
+  },
+});
+
+const codexImplementerEnvironment: ImplementerProjector = (enabled) => ({
+  kind: "codex-config",
+  config: {
+    plugins: {
+      "dev@red-skills": true,
+      "memory@red-skills": enabled.plugins.includes("memory"),
+      "brain@red-skills": enabled.plugins.includes("brain"),
+    },
+    mcpServers: {
+      navigator: true,
+      castle: false,
+      "red-memory": enabled.mcp.includes("red-memory"),
+      brain: enabled.mcp.includes("brain"),
+      "red-ui": enabled.mcp.includes("red-ui"),
+      rsp: enabled.mcp.includes("rsp"),
+    },
+    hooks: false,
+    rsp: enabled.rsp,
+  },
+});
+
+const openCodeImplementerEnvironment: ImplementerProjector = (enabled) => ({
+  kind: "opencode-config",
+  config: {
+    plugins: [...enabled.plugins],
+    mcp: {
+      navigator: { enabled: true },
+      castle: { enabled: false },
+      "red-memory": { enabled: enabled.mcp.includes("red-memory") },
+      brain: { enabled: enabled.mcp.includes("brain") },
+      "red-ui": { enabled: enabled.mcp.includes("red-ui") },
+      rsp: { enabled: enabled.mcp.includes("rsp") },
+    },
+    pluginEvents: [],
+    rsp: enabled.rsp,
+  },
+});
+
+const piImplementerEnvironment: ImplementerProjector = (enabled) => ({
+  kind: "pi-flags",
+  flags: ["--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes"],
+  skills: [...enabled.plugins],
+  extensions: [...enabled.mcp],
+  rsp: enabled.rsp,
+});
 
 export const RUNNER_SPECS: Record<AgentRunner, RunnerSpec> = {
   claude: {
@@ -33,12 +146,14 @@ export const RUNNER_SPECS: Record<AgentRunner, RunnerSpec> = {
     // Full ids (`claude-opus-4-8`, `us.anthropic.claude-…`) plus the CLI's own
     // short aliases.
     modelFamilies: [/claude/i, /^(opus|sonnet|haiku|opusplan|default)$/i],
+    projectImplementerEnvironment: claudeImplementerEnvironment,
   },
   codex: {
     efforts: CODEX_EFFORTS,
     channel: "effort",
     factory: "codex",
     modelFamilies: [/^gpt-/i, /^o\d/i, /^codex/i],
+    projectImplementerEnvironment: codexImplementerEnvironment,
   },
   opencode: {
     efforts: CLAUDE_EFFORTS,
@@ -47,6 +162,7 @@ export const RUNNER_SPECS: Record<AgentRunner, RunnerSpec> = {
     resolveAuthEnv: (env) => openCodeAuthEnv(resolveOpenCodeAuth(env)),
     // `<provider>/<model>` — the leading segment routes the endpoint (ADR 0059).
     modelFamilies: [/^[^/\s]+\/.+$/],
+    projectImplementerEnvironment: openCodeImplementerEnvironment,
   },
   "claude-minimax": {
     efforts: MINIMAX_EFFORTS,
@@ -55,8 +171,44 @@ export const RUNNER_SPECS: Record<AgentRunner, RunnerSpec> = {
     forcedModel: MINIMAX_M3_MODEL,
     defaultEffort: "low",
     resolveAuthEnv: resolveMiniMaxClaudeEnv,
+    projectImplementerEnvironment: claudeImplementerEnvironment,
   },
 };
+
+function enabledImplementerSurfaces(values: ImplementerConfigValues): ImplementerEnabledSurfaces {
+  const memory = values["plugins.memory.enabled"] === "true";
+  const brain = values["plugins.brain.enabled"] === "true";
+  const redUi = values["plugins.red-ui.enabled"] === "true";
+  const rsp = values["rsp.enabled"] === "true";
+  return {
+    plugins: ["dev", ...(memory ? ["memory" as const] : []), ...(brain ? ["brain" as const] : [])],
+    mcp: [
+      "navigator",
+      ...(memory ? ["red-memory" as const] : []),
+      ...(brain ? ["brain" as const] : []),
+      ...(redUi ? ["red-ui" as const] : []),
+      ...(rsp ? ["rsp" as const] : []),
+    ],
+    rsp,
+  };
+}
+
+/**
+ * Project the repo's existing activation gates onto one runner's native
+ * discovery constraint. Dev + navigator are the fixed implementer essentials;
+ * every optional surface is strict `enabled: true`, with no payload allowlist.
+ */
+export function projectImplementerEnvironment(
+  runner: ImplementerRunner,
+  values: ImplementerConfigValues,
+): ImplementerEnvironmentProjection {
+  const enabled = enabledImplementerSurfaces(values);
+  const projector =
+    runner === "pi"
+      ? piImplementerEnvironment
+      : RUNNER_SPECS[runner].projectImplementerEnvironment;
+  return { runner, enabled, constraint: projector(enabled) };
+}
 
 export function toAgentRunner(r: Runner): AgentRunner {
   return r === "codex" || r === "opencode" || r === "claude-minimax" ? r : "claude";

--- a/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
@@ -13,6 +13,28 @@ Scalar run settings live in `.red/config.yaml` under the `afk:` key (alongside t
 - **The directory must be opted in** (ADR 0116). Without an explicit `plugins.dev.enabled: true` (ADR 0067), the loader returns the documented defaults and **none** of the file's settings — every table below reads as its default. This is decided in the loader, not only at process entry, so no caller can read a disabled directory's settings.
 - **Retired keys are dropped and warned** (ADR 0117). A key on the tombstone list (`afk.attempt_timeout`, retired when the commit-anchored progress guard replaced the wall-clock cap) warns `RETIRED — it no longer does anything` and is unreadable. An **unknown** key stays silent for forward compatibility: silence means "not yet", a warning means "not any more".
 
+### Implementer environment
+
+An AFK inner agent does not inherit the host's full plugin, MCP, hook, or
+statusline environment. Castle projects the existing activation gates into a
+discovery-closed constraint owned by each runner-spec row:
+
+| Existing gate | Inner-agent surface |
+|---|---|
+| `plugins.dev.enabled: true` | Dev essentials and the `navigator` code-navigation MCP (always present for an AFK implementer) |
+| `plugins.memory.enabled: true` | Memory plugin and `red-memory` MCP |
+| `plugins.brain.enabled: true` | Brain plugin and `brain` MCP |
+| `plugins.red-ui.enabled: true` | `red-ui` MCP |
+| `rsp.enabled: true` | rsp MCP/instructions and runner integration |
+
+There is deliberately no implementer payload or allowlist key. Each optional
+surface is present only when its existing gate is exactly `true`; enabling one
+gate does not enable any sibling surface. Claude starts bare with strict MCP
+loading and explicit settings, Codex receives explicit plugin/MCP config,
+OpenCode receives an isolated config projection, and Pi disables discovery and
+receives explicit skills/extensions. Statusline integration, Castle's operator
+MCP, and non-essential host hooks are absent from every projection.
+
 | Config key | Env override | Default | Meaning |
 |---|---|---|---|
 | `afk.default_runner` | `RED_AFK_RUNNER` | `claude` | Caller runner identity/default backend consumed before ambient sniffing. |

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -13,6 +13,28 @@ Scalar run settings live in `.red/config.yaml` under the `afk:` key (alongside t
 - **The directory must be opted in** (ADR 0116). Without an explicit `plugins.dev.enabled: true` (ADR 0067), the loader returns the documented defaults and **none** of the file's settings — every table below reads as its default. This is decided in the loader, not only at process entry, so no caller can read a disabled directory's settings.
 - **Retired keys are dropped and warned** (ADR 0117). A key on the tombstone list (`afk.attempt_timeout`, retired when the commit-anchored progress guard replaced the wall-clock cap) warns `RETIRED — it no longer does anything` and is unreadable. An **unknown** key stays silent for forward compatibility: silence means "not yet", a warning means "not any more".
 
+### Implementer environment
+
+An AFK inner agent does not inherit the host's full plugin, MCP, hook, or
+statusline environment. Castle projects the existing activation gates into a
+discovery-closed constraint owned by each runner-spec row:
+
+| Existing gate | Inner-agent surface |
+|---|---|
+| `plugins.dev.enabled: true` | Dev essentials and the `navigator` code-navigation MCP (always present for an AFK implementer) |
+| `plugins.memory.enabled: true` | Memory plugin and `red-memory` MCP |
+| `plugins.brain.enabled: true` | Brain plugin and `brain` MCP |
+| `plugins.red-ui.enabled: true` | `red-ui` MCP |
+| `rsp.enabled: true` | rsp MCP/instructions and runner integration |
+
+There is deliberately no implementer payload or allowlist key. Each optional
+surface is present only when its existing gate is exactly `true`; enabling one
+gate does not enable any sibling surface. Claude starts bare with strict MCP
+loading and explicit settings, Codex receives explicit plugin/MCP config,
+OpenCode receives an isolated config projection, and Pi disables discovery and
+receives explicit skills/extensions. Statusline integration, Castle's operator
+MCP, and non-essential host hooks are absent from every projection.
+
 | Config key | Env override | Default | Meaning |
 |---|---|---|---|
 | `afk.default_runner` | `RED_AFK_RUNNER` | `claude` | Caller runner identity/default backend consumed before ambient sniffing. |


### PR DESCRIPTION
Automated AFK landing for #2421. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2421

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787338535&installation_model_id=20659&pr_number=2504&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2504&signature=2bdff87398d5e48e1a0c350957e7fb932519d6623db58f17d32b3a67a890a248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->