### PR TITLE
fix: #2450 v2.79.0 fleet: node_modules files vanish mid-vitest, then the idle reaper kills the agent during its silent recovery install

### DIFF
--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -127,6 +127,10 @@ function renderHuman(
       `applied stale workers: ${applied.staleWorkers.length}`,
       `applied unknown tmp roots: ${applied.unknownTmpRoots.length}`,
       `protected live workers: ${applied.protectedLiveWorkers.length}`,
+      `protected live feedback worktrees: ${applied.protectedLiveFeedback.length}`,
+      ...applied.removals.map(
+        (removal) => `  remove=${rel(root, removal.path)} liveness=${removal.livenessVerdict}`,
+      ),
     );
   }
   return `${lines.join("\n")}\n`;
@@ -195,6 +199,11 @@ function renderToon(
           staleWorkers: applied.staleWorkers.map((path) => rel(root, path)),
           unknownTmpRoots: applied.unknownTmpRoots.map((path) => rel(root, path)),
           protectedLiveWorkers: applied.protectedLiveWorkers.map((path) => rel(root, path)),
+          protectedLiveFeedback: applied.protectedLiveFeedback.map((path) => rel(root, path)),
+          removals: applied.removals.map((removal) => ({
+            path: rel(root, removal.path),
+            livenessVerdict: removal.livenessVerdict,
+          })),
         }
       : null,
   });

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -432,12 +432,16 @@ export function formatBootSweepResult(result: BootResult): string {
   const ds = result.docsSweep?.plan;
   const us = result.unblockSweep;
   const st = result.straggler;
+  const janitorRemovalLog = (tj?.removals ?? [])
+    .map((removal) => ` | tmp-janitor remove=${removal.path} liveness=${removal.livenessVerdict}`)
+    .join("");
   return (
     "boot sweeps complete: " +
     `orphans removed=${oc?.removed.length ?? 0} restored=${oc?.restored.length ?? 0} kept=${oc?.kept.length ?? 0}` +
     ` | attempt-cap reclaimed=${ac?.reclaimed.length ?? 0}` +
     ` | branches remote=${bc?.remoteLiveReaped.length ?? 0} local=${bc?.localLiveReaped.length ?? 0}` +
-    ` | tmp-janitor expired=${tj?.expiredLanes.length ?? 0} workers=${tj?.staleWorkers.length ?? 0} unknown=${tj?.unknownTmpRoots.length ?? 0} protected=${tj?.protectedLiveWorkers.length ?? 0}` +
+    ` | tmp-janitor expired=${tj?.expiredLanes.length ?? 0} workers=${tj?.staleWorkers.length ?? 0} unknown=${tj?.unknownTmpRoots.length ?? 0} protected=${(tj?.protectedLiveWorkers.length ?? 0) + (tj?.protectedLiveFeedback.length ?? 0)}` +
+    janitorRemovalLog +
     ` | docs-sweep ${ds?.action ?? "clean"} files=${ds?.files.length ?? 0}` +
     ` | unblocked=${us?.promoted.length ?? 0}` +
     ` | stragglers unlabeled=${st?.counts.unlabeled ?? 0} triage=${st?.counts.needsTriage ?? 0} info=${st?.counts.needsInfo ?? 0}`

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -219,6 +219,10 @@ export interface BootFs {
   removeDir(path: string): Promise<void>;
   /** Final worker.pid liveness guard before removing a whole worker dir. */
   workerPidLive?(workerDir: string): Promise<boolean>;
+  /** Fresh owner-liveness verdict before removing a feedback worktree. */
+  feedbackWorktreeLiveness?(
+    path: string,
+  ): Promise<"owner-live" | "owner-dead" | "no-live-workers">;
   /** Best-effort cleanup of dead empty worker.pid shells after orphan cleanup. */
   reapDeadEmptyWorkerShells?(tmpDir: string): Promise<unknown>;
 }
@@ -633,6 +637,11 @@ export interface TmpJanitorSweepResult {
   staleWorkers: string[];
   unknownTmpRoots: string[];
   protectedLiveWorkers: string[];
+  protectedLiveFeedback: string[];
+  removals: Array<{
+    path: string;
+    livenessVerdict: "not-worker-workspace" | "worker-dead" | "owner-dead" | "no-live-workers";
+  }>;
 }
 
 /** The boot run outcome. On a precheck failure the sequence short-circuits and
@@ -809,6 +818,8 @@ async function runTmpJanitorSweep(
     staleWorkers: [],
     unknownTmpRoots: [],
     protectedLiveWorkers: [],
+    protectedLiveFeedback: [],
+    removals: [],
   };
   if (!sweep) return result;
 
@@ -819,8 +830,22 @@ async function runTmpJanitorSweep(
     ...sweep.plan.feedbackWorktrees.reclaim,
     ...sweep.plan.legacySlotLogs.reclaim,
   ];
+  const feedbackPaths = new Set(sweep.plan.feedbackWorktrees.reclaim.map((entry) => entry.path));
   for (const entry of expired) {
+    if (feedbackPaths.has(entry.path)) {
+      const verdict = await deps.fs.feedbackWorktreeLiveness?.(entry.path).catch(() => "owner-live" as const)
+        ?? "owner-live";
+      if (verdict === "owner-live") {
+        result.protectedLiveFeedback.push(entry.path);
+        continue;
+      }
+      await deps.fs.removeDir(entry.path);
+      result.removals.push({ path: entry.path, livenessVerdict: verdict });
+      result.expiredLanes.push(entry.path);
+      continue;
+    }
     await deps.fs.removeDir(entry.path);
+    result.removals.push({ path: entry.path, livenessVerdict: "not-worker-workspace" });
     result.expiredLanes.push(entry.path);
   }
 
@@ -831,12 +856,14 @@ async function runTmpJanitorSweep(
       continue;
     }
     await deps.fs.removeDir(worker.path);
+    result.removals.push({ path: worker.path, livenessVerdict: "worker-dead" });
     result.staleWorkers.push(worker.path);
   }
 
   for (const name of sweep.plan.unknownTmpRoots) {
     const path = join(options.bootstrap.tmpDir, name);
     await deps.fs.removeDir(path);
+    result.removals.push({ path, livenessVerdict: "not-worker-workspace" });
     result.unknownTmpRoots.push(path);
   }
 

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -364,7 +364,8 @@ export function formatValidationLine(record: ValidationRecord): string {
  * `summary` containing one of those markers — or an exit-code-137 (SIGKILL,
  * the Linux OOM killer signature), or a `maxBuffer length exceeded` capture
  * overflow (a green-but-verbose suite Node killed for its OUTPUT size, not a
- * test failure) anywhere in the gate output — flips this classifier to true.
+ * test failure), or a missing file below `node_modules` anywhere in the gate
+ * output — flips this classifier to true.
  * The detection is substring-based on purpose: it has to survive pnpm's
  * error-wrapping, multi-line output, and minor message drift.
  */
@@ -392,6 +393,21 @@ export function isInfraFeedbackFailure(feedback: RunFeedbackResult): boolean {
     // output was too large — so this is an environment/config problem, not a
     // worker-code failure. Route through bounded validation-infra recovery.
     if (summary.includes("maxBuffer length exceeded")) {
+      return true;
+    }
+    // A dependency tree that disappears after setup is an infrastructure
+    // failure even when the runner surfaces it from inside vitest. Limit the
+    // heuristic to node_modules paths so an application-owned missing fixture
+    // remains a semantic failure.
+    if (
+      summary.includes("node_modules") &&
+      (
+        summary.includes("ERR_MODULE_NOT_FOUND") ||
+        summary.includes("Cannot find module") ||
+        summary.includes("Cannot find package") ||
+        /ENOENT:[^\n]*no such file or directory/i.test(summary)
+      )
+    ) {
       return true;
     }
   }

--- a/apps/dev/src/runtime/tmp-janitor.ts
+++ b/apps/dev/src/runtime/tmp-janitor.ts
@@ -1,5 +1,5 @@
 import { readdir, rm, stat, readFile } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
   isLegacySlotLogName,
   planTmpJanitor,
@@ -30,8 +30,15 @@ export interface TmpJanitorApplyResult {
   staleWorkers: string[];
   unknownTmpRoots: string[];
   protectedLiveWorkers: string[];
+  /** Feedback worktrees spared because their owning worker is live. */
+  protectedLiveFeedback: string[];
   /** Orphaned feedback worktrees that were removed. */
   orphanFeedback: string[];
+  /** Every destructive action, including the liveness verdict authorising it. */
+  removals: Array<{
+    path: string;
+    livenessVerdict: "not-worker-workspace" | "worker-dead" | "owner-dead" | "no-live-workers";
+  }>;
 }
 
 export interface TmpJanitorRunResult extends TmpJanitorReport {
@@ -139,6 +146,17 @@ async function buildWorkerLivenessIndex(tmpDir: string): Promise<{ liveWorkers: 
   return { liveWorkers, anyAlive };
 }
 
+function feedbackIssueFromBasename(name: string): number | null {
+  const match = /^afk-[A-Za-z0-9]+-([1-9][0-9]*)-/.exec(name);
+  return match?.[1] ? Number(match[1]) : null;
+}
+
+async function feedbackClaimIsLive(tmpDir: string, name: string): Promise<boolean> {
+  const issue = feedbackIssueFromBasename(name);
+  if (issue === null) return false;
+  return pidAlive(await readText(join(tmpDir, "claims", String(issue), "pid")));
+}
+
 async function collectOrphanFeedbackEntries(tmpDir: string): Promise<{
   entries: OrphanFeedbackEntry[];
   anyWorkerAlive: boolean;
@@ -159,7 +177,10 @@ async function collectOrphanFeedbackEntries(tmpDir: string): Promise<{
     const workerSlug = parseFeedbackWorktreeWorkerSlug(name);
     let ownerAlive: boolean | null;
     if (workerSlug !== null) {
-      ownerAlive = liveWorkers.has(workerSlug);
+      // A re-claim may resume an old worker's branch, so the branch slug is not
+      // always the current process owner. The active issue claim is an equal
+      // liveness anchor and must spare that resumed workspace.
+      ownerAlive = liveWorkers.has(workerSlug) || await feedbackClaimIsLive(tmpDir, name);
     } else {
       // Non-afk entry (e.g. 'main'): liveness is inferred from anyAlive
       ownerAlive = null;
@@ -167,6 +188,25 @@ async function collectOrphanFeedbackEntries(tmpDir: string): Promise<{
     entries.push({ path, basename: name, mtimeS, ownerAlive });
   }
   return { entries, anyWorkerAlive: anyAlive };
+}
+
+async function feedbackRemovalVerdict(
+  tmpDir: string,
+  path: string,
+): Promise<
+  | { safe: false; verdict: "owner-live" }
+  | { safe: true; verdict: "owner-dead" | "no-live-workers" }
+> {
+  const workerSlug = parseFeedbackWorktreeWorkerSlug(basename(path));
+  const { liveWorkers, anyAlive } = await buildWorkerLivenessIndex(tmpDir);
+  if (workerSlug !== null) {
+    return liveWorkers.has(workerSlug) || await feedbackClaimIsLive(tmpDir, basename(path))
+      ? { safe: false, verdict: "owner-live" }
+      : { safe: true, verdict: "owner-dead" };
+  }
+  return anyAlive
+    ? { safe: false, verdict: "owner-live" }
+    : { safe: true, verdict: "no-live-workers" };
 }
 
 export async function collectTmpJanitorReport(
@@ -186,6 +226,8 @@ export async function collectTmpJanitorReport(
       collectOrphanFeedbackEntries(tmpDir),
     ]);
   const legacySlotLogEntries = tmpRootEntries.filter((entry) => isLegacySlotLogName(basename(entry.path)));
+  const orphanFeedback = planOrphanFeedbackWorktreeSweep(orphanFeedbackData.entries, orphanFeedbackData.anyWorkerAlive);
+  const feedbackSafeToAge = new Set(orphanFeedback.reclaim.map((entry) => entry.path));
 
   return {
     plan: planTmpJanitor({
@@ -193,12 +235,14 @@ export async function collectTmpJanitorReport(
       logEntries,
       scratchEntries,
       diagnosticsEntries,
-      feedbackEntries,
+      // TTL must never overrule owner liveness. The owner-aware orphan plan is
+      // the authority for which feedback worktrees are safe even to consider.
+      feedbackEntries: feedbackEntries.filter((entry) => feedbackSafeToAge.has(entry.path)),
       legacySlotLogEntries,
       tmpRootNames,
     }),
     staleWorkers: planWorkerDirJanitor(workers),
-    orphanFeedback: planOrphanFeedbackWorktreeSweep(orphanFeedbackData.entries, orphanFeedbackData.anyWorkerAlive),
+    orphanFeedback,
   };
 }
 
@@ -219,11 +263,34 @@ export async function applyTmpJanitorReport(
     staleWorkers: [],
     unknownTmpRoots: [],
     protectedLiveWorkers: [],
+    protectedLiveFeedback: [],
     orphanFeedback: [],
+    removals: [],
   };
+  const feedbackDir = join(tmpDir, "worktrees", "feedback");
+  const removedFeedback = new Set<string>();
+  const protectFeedback = (path: string) => {
+    if (!result.protectedLiveFeedback.includes(path)) result.protectedLiveFeedback.push(path);
+  };
+  for (const entry of report.orphanFeedback.spare) {
+    protectFeedback(entry.path);
+  }
 
   for (const entry of expired) {
+    if (dirname(entry.path) === feedbackDir) {
+      const liveness = await feedbackRemovalVerdict(tmpDir, entry.path);
+      if (!liveness.safe) {
+        protectFeedback(entry.path);
+        continue;
+      }
+      await rm(entry.path, { recursive: true, force: true });
+      removedFeedback.add(entry.path);
+      result.removals.push({ path: entry.path, livenessVerdict: liveness.verdict });
+      result.expiredLanes.push(entry.path);
+      continue;
+    }
     await rm(entry.path, { recursive: true, force: true });
+    result.removals.push({ path: entry.path, livenessVerdict: "not-worker-workspace" });
     result.expiredLanes.push(entry.path);
   }
 
@@ -233,17 +300,28 @@ export async function applyTmpJanitorReport(
       continue;
     }
     await rm(worker.path, { recursive: true, force: true });
+    result.removals.push({ path: worker.path, livenessVerdict: "worker-dead" });
     result.staleWorkers.push(worker.path);
   }
 
   for (const name of report.plan.unknownTmpRoots) {
     const path = join(tmpDir, name);
     await rm(path, { recursive: true, force: true });
+    result.removals.push({ path, livenessVerdict: "not-worker-workspace" });
     result.unknownTmpRoots.push(path);
   }
 
   for (const entry of report.orphanFeedback.reclaim) {
-    await rm(entry.path, { recursive: true, force: true });
+    const liveness = await feedbackRemovalVerdict(tmpDir, entry.path);
+    if (!liveness.safe) {
+      protectFeedback(entry.path);
+      continue;
+    }
+    if (!removedFeedback.has(entry.path)) {
+      await rm(entry.path, { recursive: true, force: true });
+      removedFeedback.add(entry.path);
+      result.removals.push({ path: entry.path, livenessVerdict: liveness.verdict });
+    }
     result.orphanFeedback.push(entry.path);
   }
 

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -398,6 +398,25 @@ export async function buildBootDeps(
         const pid = Number(raw.trim());
         return Number.isInteger(pid) && pid > 0 && isLivePid(pid);
       },
+      feedbackWorktreeLiveness: async (path) => {
+        // Re-collect immediately before deletion: the boot plan may have been
+        // built before another fleet spawned the feedback worktree's owner.
+        const current = await collectTmpJanitorReport(
+          paths.tmpDir,
+          Math.floor(Date.now() / 1000),
+          () => "UNKNOWN",
+        );
+        const entries = [
+          ...current.orphanFeedback.reclaim,
+          ...current.orphanFeedback.spare,
+        ];
+        const entry = entries.find((candidate) => candidate.path === path);
+        if (!entry || entry.ownerAlive === true) return "owner-live";
+        if (entry.ownerAlive === false) return "owner-dead";
+        return current.orphanFeedback.reclaim.some((candidate) => candidate.path === path)
+          ? "no-live-workers"
+          : "owner-live";
+      },
       reapDeadEmptyWorkerShells: fsx.reapDeadEmptyWorkerShells,
     },
     gh: {

--- a/apps/dev/tests/boot-cleanup.test.ts
+++ b/apps/dev/tests/boot-cleanup.test.ts
@@ -54,6 +54,13 @@ describe("runBoot tmp janitor", () => {
       staleWorkers: ["/p/.red/tmp/workers/wOLD"],
       unknownTmpRoots: ["/p/.red/tmp/work-old"],
       protectedLiveWorkers: [],
+      protectedLiveFeedback: [],
+      removals: [
+        { path: "/p/.red/tmp/logs/old", livenessVerdict: "not-worker-workspace" },
+        { path: "/p/.red/tmp/scratch/old", livenessVerdict: "not-worker-workspace" },
+        { path: "/p/.red/tmp/workers/wOLD", livenessVerdict: "worker-dead" },
+        { path: "/p/.red/tmp/work-old", livenessVerdict: "not-worker-workspace" },
+      ],
     });
   });
 
@@ -87,6 +94,32 @@ describe("runBoot tmp janitor", () => {
 
     expect(fsCalls.removeDir).toEqual([]);
     expect(result.tmpJanitor?.protectedLiveWorkers).toEqual(["/p/.red/tmp/workers/wLIVE"]);
+  });
+
+  it("rechecks feedback ownership before removal and records the liveness verdict", async () => {
+    const { deps, fsCalls } = makeDeps();
+    deps.fs.feedbackWorktreeLiveness = async () => "owner-live";
+    const feedback = "/p/.red/tmp/worktrees/feedback/afk-wLIVE-2450-live-gate";
+    const result = await runBoot(
+      deps,
+      options({
+        tmpJanitor: {
+          plan: {
+            logs: { reclaim: [], spare: [] },
+            scratch: { reclaim: [], spare: [] },
+            diagnostics: { reclaim: [], spare: [] },
+            feedbackWorktrees: { reclaim: [{ path: feedback, mtimeS: 1 }], spare: [] },
+            legacySlotLogs: { reclaim: [], spare: [] },
+            unknownTmpRoots: [],
+          },
+          staleWorkers: { reclaim: [], spare: [] },
+        },
+      }),
+    );
+
+    expect(fsCalls.removeDir).toEqual([]);
+    expect(result.tmpJanitor?.protectedLiveFeedback).toEqual([feedback]);
+    expect(result.tmpJanitor?.removals).toEqual([]);
   });
 });
 

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -504,6 +504,20 @@ describe("isInfraFeedbackFailure — INFRA root cause detection", () => {
     expect(isInfraFeedbackFailure(result)).toBe(true);
   });
 
+  it("classifies dependency files vanishing mid-gate as INFRA", () => {
+    const missingModule = failedCheck(
+      "test:apps/dev",
+      "Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/repo/node_modules/.pnpm/tinypool@1.1.1/node_modules/tinypool/dist/entry/process.js' imported from /repo/node_modules/.pnpm/vitest@2.1.9/node_modules/vitest/dist/chunks/resolveConfig.js",
+    );
+    const missingFile = failedCheck(
+      "test:apps/dev",
+      "Error: ENOENT: no such file or directory, open '/repo/node_modules/.pnpm/tinypool@1.1.1/node_modules/tinypool/dist/entry/process.js'",
+    );
+
+    expect(isInfraFeedbackFailure(missingModule)).toBe(true);
+    expect(isInfraFeedbackFailure(missingFile)).toBe(true);
+  });
+
   it("matches the OOM-killer signature (exit 137 / SIGKILL)", () => {
     const a = failedCheck("test:apps/dev", "vitest worker killed by SIGKILL");
     const b = failedCheck("test:apps/dev", "pnpm: signal SIGKILL");

--- a/apps/dev/tests/supervise-passthrough.test.ts
+++ b/apps/dev/tests/supervise-passthrough.test.ts
@@ -178,4 +178,27 @@ describe("formatBootSweepResult — supervisor boot log shape (#623)", () => {
       "boot sweeps: precheck FAILED (not-on-trunk: current=main expected=feat/x source=pin) — workers will run their own precheck",
     );
   });
+
+  it("logs every janitor removal with its target and liveness verdict", () => {
+    const result: BootResult = {
+      precheck: { ok: true, warnings: [] },
+      tmpJanitor: {
+        expiredLanes: [".red/tmp/worktrees/feedback/afk-wDEAD-2450-gate"],
+        staleWorkers: [],
+        unknownTmpRoots: [],
+        protectedLiveWorkers: [],
+        protectedLiveFeedback: [],
+        removals: [
+          {
+            path: ".red/tmp/worktrees/feedback/afk-wDEAD-2450-gate",
+            livenessVerdict: "owner-dead",
+          },
+        ],
+      },
+    };
+
+    expect(formatBootSweepResult(result)).toContain(
+      "remove=.red/tmp/worktrees/feedback/afk-wDEAD-2450-gate liveness=owner-dead",
+    );
+  });
 });

--- a/apps/dev/tests/tmp-janitor-runtime.test.ts
+++ b/apps/dev/tests/tmp-janitor-runtime.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readdir, rm, utimes, writeFile } from "node:fs/promises";
+import { access, mkdtemp, mkdir, readdir, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -58,5 +58,65 @@ describe("tmp janitor runtime", () => {
     expect(applied.staleWorkers).toEqual([]);
     expect(applied.protectedLiveWorkers).toEqual([worker]);
     expect(await readdir(worker)).toEqual(["1961-a1", "worker.pid"]);
+  });
+
+  it("never TTL-reclaims a feedback worktree owned by a live worker", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const worker = join(tmp, "workers", "wLIVE");
+    const feedback = join(tmp, "worktrees", "feedback", "afk-wLIVE-2450-live-gate");
+    await mkdir(worker, { recursive: true });
+    await mkdir(join(feedback, "node_modules", "tinypool", "dist", "entry"), { recursive: true });
+    await writeFile(join(worker, "worker.pid"), String(process.pid), "utf8");
+    await writeFile(join(feedback, "node_modules", "tinypool", "dist", "entry", "process.js"), "export {};\n", "utf8");
+    await utimes(feedback, 1, 1);
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "OPEN");
+
+    expect(report.plan.feedbackWorktrees.reclaim).toEqual([]);
+    expect(report.orphanFeedback.reclaim).toEqual([]);
+    const applied = await applyTmpJanitorReport(tmp, report);
+    await expect(access(join(feedback, "node_modules", "tinypool", "dist", "entry", "process.js"))).resolves.toBeUndefined();
+    expect(applied.protectedLiveFeedback).toEqual([feedback]);
+  });
+
+  it("rechecks feedback ownership at removal time and logs the liveness verdict", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const worker = join(tmp, "workers", "wRACE");
+    const feedback = join(tmp, "worktrees", "feedback", "afk-wRACE-2450-race");
+    await mkdir(worker, { recursive: true });
+    await mkdir(feedback, { recursive: true });
+    await writeFile(join(worker, "worker.pid"), "999999999", "utf8");
+    await utimes(feedback, 1, 1);
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "CLOSED");
+    await writeFile(join(worker, "worker.pid"), String(process.pid), "utf8");
+
+    const applied = await applyTmpJanitorReport(tmp, report);
+    await expect(access(feedback)).resolves.toBeUndefined();
+    expect(applied.protectedLiveFeedback).toEqual([feedback]);
+    expect(applied.removals).not.toContainEqual(expect.objectContaining({ path: feedback }));
+  });
+
+  it("spares a resumed branch when its old worker is dead but the issue claim is live", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const oldWorker = join(tmp, "workers", "wOLD");
+    const feedback = join(tmp, "worktrees", "feedback", "afk-wOLD-2450-resumed-branch");
+    await mkdir(oldWorker, { recursive: true });
+    await mkdir(feedback, { recursive: true });
+    await mkdir(join(tmp, "claims", "2450"), { recursive: true });
+    await writeFile(join(oldWorker, "worker.pid"), "999999999", "utf8");
+    await writeFile(join(tmp, "claims", "2450", "pid"), String(process.pid), "utf8");
+    await utimes(feedback, 1, 1);
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "OPEN");
+    expect(report.plan.feedbackWorktrees.reclaim).toEqual([]);
+    expect(report.orphanFeedback.reclaim).toEqual([]);
+
+    const applied = await applyTmpJanitorReport(tmp, report);
+    await expect(access(feedback)).resolves.toBeUndefined();
+    expect(applied.protectedLiveFeedback).toEqual([feedback]);
   });
 });

--- a/packages/red-castle/src/Orchestrator.test.ts
+++ b/packages/red-castle/src/Orchestrator.test.ts
@@ -2464,6 +2464,69 @@ describe("Orchestrator Display integration", () => {
     expect(exitResult._tag).toBe("Success");
   }, 10_000);
 
+  it("does not idle-timeout while a streamed tool call remains in flight", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-idle-tool-flight-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
+      const real = makeLocalSandbox(dir);
+      return {
+        exec: (command, options) => {
+          if (command.startsWith("claude ") && options?.onLine) {
+            const onLine = options.onLine;
+            return Effect.gen(function* () {
+              yield* Effect.promise(
+                () => new Promise((resolve) => setTimeout(resolve, 50)),
+              );
+              onLine(
+                JSON.stringify({
+                  type: "assistant",
+                  message: {
+                    content: [
+                      {
+                        type: "tool_use",
+                        name: "Bash",
+                        input: { command: "pnpm install" },
+                      },
+                    ],
+                  },
+                }),
+              );
+              // The child command stays silent for longer than the text-silence
+              // timeout, then the agent emits its terminal result.
+              yield* Effect.promise(
+                () => new Promise((resolve) => setTimeout(resolve, 250)),
+              );
+              onLine(JSON.stringify({ type: "result", result: "done" }));
+              return { stdout: "", stderr: "", exitCode: 0 };
+            });
+          }
+          return real.exec(command, options);
+        },
+        copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
+        copyFileOut: (sandboxPath, hostPath) =>
+          real.copyFileOut(sandboxPath, hostPath),
+      };
+    });
+
+    const exitResult = await Effect.runPromise(
+      orchestrate({
+        provider: testProvider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "test",
+        idleTimeoutSeconds: 0.1,
+      }).pipe(
+        Effect.provide(Layer.merge(factoryLayer, testDisplayLayer)),
+        Effect.exit,
+      ),
+    );
+
+    expect(exitResult._tag).toBe("Success");
+  }, 10_000);
+
   it("resets the idle timer on unparsed stdout lines (no structured events)", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "orch-idle-raw-"));
 

--- a/packages/red-castle/src/Orchestrator.ts
+++ b/packages/red-castle/src/Orchestrator.ts
@@ -76,6 +76,11 @@ const invokeAgent = (
     >();
     let timeoutFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
     let completionDetected = false;
+    // A streamed tool_call is the agent's proof that it handed work to a child
+    // process. Agent CLIs do not emit a matching completion event while that
+    // child is silent, so keep the text-silence timer renewable until the next
+    // parsed agent event demonstrates that control returned.
+    let toolCallInFlight = false;
 
     // Periodic idle warning state
     let warningFiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
@@ -101,6 +106,25 @@ const invokeAgent = (
       );
     };
 
+    const armIdleTimer = () => {
+      timeoutFiber = Effect.runFork(
+        Effect.gen(function* () {
+          yield* Effect.sleep(Duration.millis(idleTimeoutMs));
+          if (toolCallInFlight) {
+            armIdleTimer();
+            return;
+          }
+          yield* Deferred.fail(
+            timeoutSignal,
+            new AgentIdleTimeoutError({
+              message: `Agent idle for ${idleTimeoutMs / 1000} seconds — no output received. Consider increasing the idle timeout with --idle-timeout.`,
+              timeoutMs: idleTimeoutMs,
+            }),
+          );
+        }),
+      );
+    };
+
     const resetTimer = () => {
       interruptFiber(timeoutFiber);
       if (completionDetected) {
@@ -117,19 +141,9 @@ const invokeAgent = (
           }),
         );
       } else {
-        // Pre-signal idle window — failure on expiry.
-        timeoutFiber = Effect.runFork(
-          Effect.gen(function* () {
-            yield* Effect.sleep(Duration.millis(idleTimeoutMs));
-            yield* Deferred.fail(
-              timeoutSignal,
-              new AgentIdleTimeoutError({
-                message: `Agent idle for ${idleTimeoutMs / 1000} seconds — no output received. Consider increasing the idle timeout with --idle-timeout.`,
-                timeoutMs: idleTimeoutMs,
-              }),
-            );
-          }),
-        );
+        // Pre-signal idle window — failure on expiry unless a streamed tool
+        // call still owns a live child-operation window.
+        armIdleTimer();
         // Reset warning interval on activity, idle-phase only.
         startWarningInterval();
       }
@@ -172,26 +186,36 @@ const invokeAgent = (
           } catch {
             // Swallow — must not skip parsing/timer logic below.
           }
-          for (const parsed of provider.parseStreamLine(line)) {
+          const parsedEvents = provider.parseStreamLine(line);
+          let sawToolCall = false;
+          let sawAgentProgress = false;
+          for (const parsed of parsedEvents) {
             if (parsed.type === "text") {
+              sawAgentProgress = true;
               onText(parsed.text);
               accumulatedOutput += parsed.text;
             } else if (parsed.type === "result") {
+              sawAgentProgress = true;
               resultText = parsed.result;
               accumulatedOutput += parsed.result;
               onResult?.(parsed.result);
             } else if (parsed.type === "tool_call") {
+              sawToolCall = true;
               onToolCall(parsed.name, parsed.args);
             } else if (parsed.type === "reasoning") {
+              sawAgentProgress = true;
               onReasoning?.(parsed.text ?? "", parsed.tokens);
             } else if (parsed.type === "session_id") {
               sessionId = parsed.sessionId;
               onObservedSessionId?.(parsed.sessionId);
             } else if (parsed.type === "usage") {
+              sawAgentProgress = true;
               usage = parsed.usage;
               onUsage?.(parsed.usage);
             }
           }
+          if (sawToolCall) toolCallInFlight = true;
+          else if (sawAgentProgress) toolCallInFlight = false;
           // Check for the completion signal AFTER parsing this line so the
           // accumulator contains everything seen so far. Flip to the
           // completion-grace timer the first time the signal appears.


### PR DESCRIPTION
Automated AFK landing for #2450. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2450

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787345287&installation_model_id=20659&pr_number=2510&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2510&signature=caa0251c6c9e16990be5a25f2f9c975ad53649c8d7d0732325a82277bce23b43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->