### PR TITLE
chore: #2424 Host capability profiles: runners, gate weight class, width routing

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -1,12 +1,4 @@
-import {
-  mkdir,
-  readFile,
-  readdir,
-  rename,
-  rm,
-  stat,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { encode as encodeToon } from "@reddb-io/toon";
 import { readBuildInfo } from "@reddb-io/build-info";
@@ -21,20 +13,11 @@ import {
   upsertFleetProfile,
   type CastleLaneRecord,
 } from "@reddb-io/red-castle/engine";
-import {
-  afkPaths,
-  collectMonitorInputs,
-  readFleetState,
-  resolveRepoSlug,
-} from "../runtime/wire.js";
+import { afkPaths, collectMonitorInputs, readFleetState, resolveRepoSlug } from "../runtime/wire.js";
 import { migrateLegacyDevPaths } from "../runtime/red-path-migration.js";
 import { parseRunnerFlag, detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "../runtime/caller-process.js";
-import {
-  classifySupervisor,
-  resolveSupervisorConfig,
-  type ElasticShrinkMode,
-} from "../core/supervisor.js";
+import { classifySupervisor, resolveSupervisorConfig, type ElasticShrinkMode } from "../core/supervisor.js";
 import { teardownWedgedSupervisor } from "../core/watchdog.js";
 import { buildWatchdogIO } from "../runtime/watchdog-io.js";
 import { spawnSupervisor } from "../runtime/supervisor-spawn.js";
@@ -66,15 +49,11 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 function parsePositiveNumber(raw: string | undefined, flag: string): number {
   if (raw === undefined) throw new Error(`${flag} requires a value`);
   const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0)
-    throw new Error(`${flag} requires a positive number`);
+  if (!Number.isFinite(n) || n <= 0) throw new Error(`${flag} requires a positive number`);
   return n;
 }
 
-function parseShrinkMode(
-  raw: string | undefined,
-  flag: string,
-): ElasticShrinkMode {
+function parseShrinkMode(raw: string | undefined, flag: string): ElasticShrinkMode {
   if (raw === undefined) throw new Error(`${flag} requires a value`);
   if (raw === "hard-kill" || raw === "drain-then-retire") return raw;
   throw new Error(`${flag} must be hard-kill or drain-then-retire`);
@@ -129,8 +108,7 @@ function parseFleetArgs(args: readonly string[]): {
     }
     if (arg === "--runner") {
       runnerFlag = args[++i];
-      if (runnerFlag === undefined)
-        throw new Error("--runner requires a value");
+      if (runnerFlag === undefined) throw new Error("--runner requires a value");
       continue;
     }
     if (arg.startsWith("--runner=")) {
@@ -142,17 +120,11 @@ function parseFleetArgs(args: readonly string[]): {
       continue;
     }
     if (arg.startsWith("--budget-usd=")) {
-      drainBudgetUsd = parsePositiveNumber(
-        arg.slice("--budget-usd=".length),
-        "--budget-usd",
-      );
+      drainBudgetUsd = parsePositiveNumber(arg.slice("--budget-usd=".length), "--budget-usd");
       continue;
     }
     if (arg.startsWith("--drain-budget-usd=")) {
-      drainBudgetUsd = parsePositiveNumber(
-        arg.slice("--drain-budget-usd=".length),
-        "--drain-budget-usd",
-      );
+      drainBudgetUsd = parsePositiveNumber(arg.slice("--drain-budget-usd=".length), "--drain-budget-usd");
       continue;
     }
     if (arg === "--shrink-mode") {
@@ -160,10 +132,7 @@ function parseFleetArgs(args: readonly string[]): {
       continue;
     }
     if (arg.startsWith("--shrink-mode=")) {
-      shrinkMode = parseShrinkMode(
-        arg.slice("--shrink-mode=".length),
-        "--shrink-mode",
-      );
+      shrinkMode = parseShrinkMode(arg.slice("--shrink-mode=".length), "--shrink-mode");
       continue;
     }
     if (/^[0-9]+$/.test(arg) && target === undefined) {
@@ -198,7 +167,11 @@ export async function writeResizeRequest(
     ...(runner !== undefined ? { runner } : {}),
     shrink_mode: shrinkMode,
   };
-  await writeFile(tmp, encodeToon(request), "utf8");
+  await writeFile(
+    tmp,
+    encodeToon(request),
+    "utf8",
+  );
   await rename(tmp, path);
 }
 
@@ -209,10 +182,8 @@ function directiveAck(
   if (!state) return "pending";
   const appliedTarget = state.target ?? state.slotsTotal;
   if (appliedTarget !== request.target) return "pending";
-  if ((state.shrinkMode ?? request.shrinkMode) !== request.shrinkMode)
-    return "pending";
-  if (request.runner !== undefined && state.runner !== request.runner)
-    return "pending";
+  if ((state.shrinkMode ?? request.shrinkMode) !== request.shrinkMode) return "pending";
+  if (request.runner !== undefined && state.runner !== request.runner) return "pending";
   return "applied";
 }
 
@@ -240,9 +211,7 @@ export async function stopFleet(
   ) {
     const watchdogDead = await killTreeAndWait(watchdogIdentity.pid);
     if (!watchdogDead) {
-      stdout.write(
-        `✗ fleet watchdog pid=${watchdogIdentity.pid} survived termination; stop remains armed.\n`,
-      );
+      stdout.write(`✗ fleet watchdog pid=${watchdogIdentity.pid} survived termination; stop remains armed.\n`);
       return { status: "timeout", pid: watchdogIdentity.pid };
     }
   }
@@ -258,25 +227,16 @@ export async function stopFleet(
     const killed = await io.killWorkers();
     if (killed > 0) {
       await io.reconcile();
-      stdout.write(
-        `terminated ${killed} orphaned worker${killed === 1 ? "" : "s"} and reconciled their claims.\n`,
-      );
+      stdout.write(`terminated ${killed} orphaned worker${killed === 1 ? "" : "s"} and reconciled their claims.\n`);
     }
   };
-  const liveSupervisor = await discoverLiveSupervisorPid(stateAfk, isLivePid, {
-    fleet: paths.fleet,
-  });
+  const liveSupervisor = await discoverLiveSupervisorPid(stateAfk, isLivePid, { fleet: paths.fleet });
   if (!liveSupervisor) {
     const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
     if (supervisor.status === "stale" && supervisor.pid !== undefined) {
       await sweepOrphans();
-      stdout.write(
-        `no fleet running (reason=dead supervisor pid; stale files cleaned).\n`,
-      );
-      return {
-        status: "stale",
-        ...(supervisor.pid !== undefined ? { pid: supervisor.pid } : {}),
-      };
+      stdout.write(`no fleet running (reason=dead supervisor pid; stale files cleaned).\n`);
+      return { status: "stale", ...(supervisor.pid !== undefined ? { pid: supervisor.pid } : {}) };
     }
     await sweepOrphans();
     stdout.write("no fleet running (reason=no supervisor pid).\n");
@@ -290,9 +250,7 @@ export async function stopFleet(
       // exit, but sweep detached survivors anyway — a slot the loop lost track of
       // (moved-pid, mid-spawn) would otherwise outlive the "stopped" report.
       await sweepOrphans();
-      stdout.write(
-        `🛑 fleet stopped (reason=operator stop requested; supervisor pid=${pid} exited).\n`,
-      );
+      stdout.write(`🛑 fleet stopped (reason=operator stop requested; supervisor pid=${pid} exited).\n`);
       return { status: "stopped", pid };
     }
     await sleep(1_000);
@@ -314,9 +272,7 @@ export async function stopFleet(
     await rm(paths.supervisorRecoveryPath, { force: true });
     // killTree of the supervisor pid misses the detached workers — sweep them.
     await sweepOrphans();
-    stdout.write(
-      `🛑 fleet stopped (reason=graceful stop timeout; supervisor pid=${pid} killed).\n`,
-    );
+    stdout.write(`🛑 fleet stopped (reason=graceful stop timeout; supervisor pid=${pid} killed).\n`);
     return { status: "stopped", pid };
   }
   stdout.write(
@@ -368,10 +324,7 @@ function parseFleetLogsArgs(args: readonly string[]): FleetLogsArgs {
   let follow = false;
 
   function setMode(next: FleetLogMode): void {
-    if (mode !== undefined)
-      throw new Error(
-        "fleet logs accepts only one of --supervisor, --worker, or --all",
-      );
+    if (mode !== undefined) throw new Error("fleet logs accepts only one of --supervisor, --worker, or --all");
     mode = next;
   }
 
@@ -404,10 +357,7 @@ function parseFleetLogsArgs(args: readonly string[]): FleetLogsArgs {
     throw new Error(`unknown fleet logs argument: ${arg}`);
   }
 
-  if (mode === undefined)
-    throw new Error(
-      "fleet logs requires --supervisor, --worker <id>, or --all",
-    );
+  if (mode === undefined) throw new Error("fleet logs requires --supervisor, --worker <id>, or --all");
   return { mode, follow };
 }
 
@@ -456,19 +406,13 @@ async function supervisorLogSources(root: string): Promise<FleetLogSource[]> {
   return sources;
 }
 
-async function workerLogSources(
-  root: string,
-  mode: Extract<FleetLogMode, { kind: "worker" | "all" }>,
-): Promise<FleetLogSource[]> {
+async function workerLogSources(root: string, mode: Extract<FleetLogMode, { kind: "worker" | "all" }>): Promise<FleetLogSource[]> {
   const paths = createEnginePaths(join(root, ".red"));
-  const workerIds =
-    mode.kind === "worker"
-      ? [mode.workerId]
-      : await childDirs(paths.workersRoot);
+  const workerIds = mode.kind === "worker" ? [mode.workerId] : await childDirs(paths.workersRoot);
   const sources: FleetLogSource[] = [];
   for (const workerId of workerIds) {
     const path = castleLanePath(paths, "worker", workerId);
-    if (mode.kind === "worker" || (await readableFile(path))) {
+    if (mode.kind === "worker" || await readableFile(path)) {
       sources.push({
         id: `worker:${workerId}`,
         path,
@@ -479,10 +423,7 @@ async function workerLogSources(
   return sources;
 }
 
-async function fleetLogSources(
-  root: string,
-  mode: FleetLogMode,
-): Promise<FleetLogSource[]> {
+async function fleetLogSources(root: string, mode: FleetLogMode): Promise<FleetLogSource[]> {
   if (mode.kind === "supervisor") return supervisorLogSources(root);
   return workerLogSources(root, mode);
 }
@@ -494,9 +435,7 @@ function payloadText(payload: Record<string, unknown> | undefined): string {
   const parts: string[] = [];
   for (const [key, value] of Object.entries(payload)) {
     if (value === undefined) continue;
-    parts.push(
-      `${key}=${typeof value === "string" ? value : JSON.stringify(value)}`,
-    );
+    parts.push(`${key}=${typeof value === "string" ? value : JSON.stringify(value)}`);
   }
   return parts.join(" ");
 }
@@ -509,9 +448,7 @@ function renderRecord(record: CastleLaneRecord, prefix: string): string {
   return `${prefix}${parts.join(" ")}${payload ? ` ${payload}` : ""}`;
 }
 
-async function readLogEntries(
-  source: FleetLogSource,
-): Promise<FleetLogEntry[]> {
+async function readLogEntries(source: FleetLogSource): Promise<FleetLogEntry[]> {
   const records = await readCastleLaneRecords(source.path);
   return records.map((record, index) => ({
     sourceId: source.id,
@@ -531,22 +468,17 @@ function sortEntries(entries: FleetLogEntry[]): FleetLogEntry[] {
   });
 }
 
-const wait = (ms: number, signal?: AbortSignal) =>
-  new Promise<void>((resolve) => {
-    if (signal?.aborted) {
-      resolve();
-      return;
-    }
-    const timer = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      { once: true },
-    );
-  });
+const wait = (ms: number, signal?: AbortSignal) => new Promise<void>((resolve) => {
+  if (signal?.aborted) {
+    resolve();
+    return;
+  }
+  const timer = setTimeout(resolve, ms);
+  signal?.addEventListener("abort", () => {
+    clearTimeout(timer);
+    resolve();
+  }, { once: true });
+});
 
 /**
  * `fleet logs` is the read-only human view over the structured castle lanes.
@@ -606,35 +538,20 @@ export async function statusFleet(
   const paths = afkPaths(root, fleetName);
   const io = buildWatchdogIO(root, stdout, paths.fleet);
   const liveness = await io.liveness();
-  const liveSupervisor = await discoverLiveSupervisorPid(
-    paths.supervisorRuntimeDir,
-    isLivePid,
-    { fleet: paths.fleet },
-  );
+  const liveSupervisor = await discoverLiveSupervisorPid(paths.supervisorRuntimeDir, isLivePid, { fleet: paths.fleet });
   if (liveSupervisor) {
     liveness.pid = liveSupervisor.pid;
     liveness.pidAlive = true;
   }
   const cfg = resolveSupervisorConfig();
   const now = Math.floor(Date.now() / 1000);
-  const health = classifySupervisor(
-    liveness,
-    now,
-    cfg.supervisorStaleS,
-    cfg.progressStaleS,
-  );
+  const health = classifySupervisor(liveness, now, cfg.supervisorStaleS, cfg.progressStaleS);
   const repo = await resolveRepoSlug(root).catch(() => "");
   const inputs = await collectMonitorInputs(root, repo);
   const fleet = inputs.fleet;
-  const latestBundleVersion =
-    fleet?.latestBundleVersion || readBuildInfo("dev").version;
-  const liveWorkers = inputs.workers.filter(
-    (w) => w.pidLive === true || w.live,
-  );
-  const heartbeatAgeS =
-    liveness.lastHeartbeatEpoch !== null
-      ? now - liveness.lastHeartbeatEpoch
-      : -1;
+  const latestBundleVersion = fleet?.latestBundleVersion || readBuildInfo("dev").version;
+  const liveWorkers = inputs.workers.filter((w) => w.pidLive === true || w.live);
+  const heartbeatAgeS = liveness.lastHeartbeatEpoch !== null ? now - liveness.lastHeartbeatEpoch : -1;
 
   // A dead supervisor with ready-for-agent work and fewer live workers than the
   // target is what the watchdog would respawn — surface it so an operator who
@@ -653,13 +570,11 @@ export async function statusFleet(
       target: fleet?.target ?? fleet?.slotsTotal ?? 0,
       bundle_version: fleet?.bundleVersion ?? "",
       bundle_latest: latestBundleVersion,
-      version_skew: Number(
-        Boolean(
-          fleet?.bundleVersion &&
-          latestBundleVersion &&
-          fleet.bundleVersion !== latestBundleVersion,
-        ),
-      ),
+      version_skew: Number(Boolean(
+        fleet?.bundleVersion &&
+        latestBundleVersion &&
+        fleet.bundleVersion !== latestBundleVersion
+      )),
       heartbeat_age_s: heartbeatAgeS,
       would_respawn: wouldRespawn,
     },
@@ -686,11 +601,7 @@ export async function statusFleet(
   return { status: "reported" };
 }
 
-export async function launchFleet(
-  args: readonly string[],
-  root = process.cwd(),
-  stdout: NodeJS.WritableStream = process.stdout,
-): Promise<FleetLaunchResult> {
+export async function launchFleet(args: readonly string[], root = process.cwd(), stdout: NodeJS.WritableStream = process.stdout): Promise<FleetLaunchResult> {
   const parsed = parseFleetArgs(args);
   const enginePaths = createEnginePaths(join(root, ".red"));
   const paths = afkPaths(root, parsed.fleet);
@@ -708,9 +619,7 @@ export async function launchFleet(
     throw new Error("fleet target must be a non-negative integer");
   const pidFile = paths.supervisorPidPath;
   const logFile = paths.supervisorLogPath;
-  const priorFleetState = await readFleetState(paths.fleetStatePath).catch(
-    () => null,
-  );
+  const priorFleetState = await readFleetState(paths.fleetStatePath).catch(() => null);
   // A registered fleet launches from its PROFILE: the registry supplies the
   // runner and the work-scope selector, and explicit flags still override.
   const profile = await readFleetProfile(
@@ -732,21 +641,11 @@ export async function launchFleet(
     const cfg = resolveSupervisorConfig();
     const io = buildWatchdogIO(root, stdout, paths.fleet);
     const liveness = await io.liveness();
-    const health = classifySupervisor(
-      liveness,
-      io.now(),
-      cfg.supervisorStaleS,
-      cfg.progressStaleS,
-    );
+    const health = classifySupervisor(liveness, io.now(), cfg.supervisorStaleS, cfg.progressStaleS);
     if (health !== "quiescent") {
-      const watchdogPid = await spawnSupervisorWatchdog({
-        root,
-        fleet: paths.fleet,
-      });
+      const watchdogPid = await spawnSupervisorWatchdog({ root, fleet: paths.fleet });
       if (!watchdogPid) {
-        throw new Error(
-          "fleet launch failed: supervisor self-heal watchdog did not arm",
-        );
+        throw new Error("fleet launch failed: supervisor self-heal watchdog did not arm");
       }
       const shrinkMode = parsed.shrinkMode ?? cfg.shrinkMode;
       const directiveRunner = parsed.runnerFlag
@@ -769,10 +668,7 @@ export async function launchFleet(
       );
       return { status: "resized", pid: existing, target, log: logFile };
     }
-    const staleForS =
-      liveness.lastHeartbeatEpoch !== null
-        ? io.now() - liveness.lastHeartbeatEpoch
-        : null;
+    const staleForS = liveness.lastHeartbeatEpoch !== null ? io.now() - liveness.lastHeartbeatEpoch : null;
     io.log(
       `⚠️  fleet pre-check: supervisor pid=${existing} is QUIESCENT — heartbeat stale ` +
         `${staleForS ?? "?"}s ≥ ${cfg.supervisorStaleS}s; recovering before relaunch.`,
@@ -790,13 +686,7 @@ export async function launchFleet(
   // so this fleet only ever claims issues inside its own scope. An explicit
   // filter flag on the command line wins over the registered scope.
   const scoped =
-    profile?.selector &&
-    !parsed.passthrough.some(
-      (a) =>
-        a.startsWith("--spec") ||
-        a.startsWith("--issues") ||
-        a.startsWith("--selector"),
-    )
+    profile?.selector && !parsed.passthrough.some((a) => a.startsWith("--spec") || a.startsWith("--issues") || a.startsWith("--selector"))
       ? ["--selector", JSON.stringify(profile.selector)]
       : [];
 
@@ -819,23 +709,14 @@ export async function launchFleet(
     } catch {
       // ignore
     }
-    throw new Error(
-      `fleet launch failed: supervisor pid file did not appear. log: .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n${tail}`,
-    );
+    throw new Error(`fleet launch failed: supervisor pid file did not appear. log: .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n${tail}`);
   }
-  const watchdogPid = await spawnSupervisorWatchdog({
-    root,
-    fleet: paths.fleet,
-  });
+  const watchdogPid = await spawnSupervisorWatchdog({ root, fleet: paths.fleet });
   if (!watchdogPid) {
     await killTreeAndWait(supervisorPid).catch(() => false);
     await rm(paths.supervisorPidPath, { force: true }).catch(() => undefined);
-    await rm(paths.supervisorPidStartPath, { force: true }).catch(
-      () => undefined,
-    );
-    throw new Error(
-      "fleet launch failed: supervisor self-heal watchdog did not arm",
-    );
+    await rm(paths.supervisorPidStartPath, { force: true }).catch(() => undefined);
+    throw new Error("fleet launch failed: supervisor self-heal watchdog did not arm");
   }
 
   // Persist the profile so CLI-launched fleets are always in the registry (#2358).
@@ -853,9 +734,7 @@ export async function launchFleet(
     `🚀 fleet ${paths.fleet} launched (supervisor pid=${supervisorPid}, target=${target})\n`,
   );
   stdout.write(`   self-heal: armed (watchdog pid=${watchdogPid})\n`);
-  stdout.write(
-    `   log:   .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n`,
-  );
+  stdout.write(`   log:   .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n`);
   stdout.write(`   stop:  /dev:afk fleet stop${named}\n`);
   stdout.write(
     `   monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl manually.\n`,
@@ -863,10 +742,7 @@ export async function launchFleet(
   return { status: "launched", pid: supervisorPid, target, log: logFile };
 }
 
-export async function fleetCommand(
-  args: string[],
-  cwd = process.cwd(),
-): Promise<number> {
+export async function fleetCommand(args: string[], cwd = process.cwd()): Promise<number> {
   if (args[0] === "logs") {
     try {
       await logsFleet(args.slice(1), cwd);

--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -1,4 +1,12 @@
-import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { encode as encodeToon } from "@reddb-io/toon";
 import { readBuildInfo } from "@reddb-io/build-info";
@@ -8,14 +16,25 @@ import {
   fleetRegistryPath,
   readCastleLaneRecords,
   readFleetProfile,
+  readHostCapabilityProfile,
+  resolveHostCapabilities,
   upsertFleetProfile,
   type CastleLaneRecord,
 } from "@reddb-io/red-castle/engine";
-import { afkPaths, collectMonitorInputs, readFleetState, resolveRepoSlug } from "../runtime/wire.js";
+import {
+  afkPaths,
+  collectMonitorInputs,
+  readFleetState,
+  resolveRepoSlug,
+} from "../runtime/wire.js";
 import { migrateLegacyDevPaths } from "../runtime/red-path-migration.js";
 import { parseRunnerFlag, detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "../runtime/caller-process.js";
-import { classifySupervisor, resolveSupervisorConfig, type ElasticShrinkMode } from "../core/supervisor.js";
+import {
+  classifySupervisor,
+  resolveSupervisorConfig,
+  type ElasticShrinkMode,
+} from "../core/supervisor.js";
 import { teardownWedgedSupervisor } from "../core/watchdog.js";
 import { buildWatchdogIO } from "../runtime/watchdog-io.js";
 import { spawnSupervisor } from "../runtime/supervisor-spawn.js";
@@ -47,17 +66,32 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 function parsePositiveNumber(raw: string | undefined, flag: string): number {
   if (raw === undefined) throw new Error(`${flag} requires a value`);
   const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) throw new Error(`${flag} requires a positive number`);
+  if (!Number.isFinite(n) || n <= 0)
+    throw new Error(`${flag} requires a positive number`);
   return n;
 }
 
-function parseShrinkMode(raw: string | undefined, flag: string): ElasticShrinkMode {
+function parseShrinkMode(
+  raw: string | undefined,
+  flag: string,
+): ElasticShrinkMode {
   if (raw === undefined) throw new Error(`${flag} requires a value`);
   if (raw === "hard-kill" || raw === "drain-then-retire") return raw;
   throw new Error(`${flag} must be hard-kill or drain-then-retire`);
 }
 
-function parseFleetArgs(args: readonly string[]): { stop: boolean; status: boolean; fleet: string; target: number; request?: string; runnerFlag?: string; drainBudgetUsd?: number; shrinkMode?: ElasticShrinkMode; passthrough: string[] } {
+function parseFleetArgs(args: readonly string[]): {
+  stop: boolean;
+  status: boolean;
+  fleet: string;
+  target: number;
+  targetExplicit: boolean;
+  request?: string;
+  runnerFlag?: string;
+  drainBudgetUsd?: number;
+  shrinkMode?: ElasticShrinkMode;
+  passthrough: string[];
+} {
   const passthrough: string[] = [];
   let stop = false;
   let status = false;
@@ -95,7 +129,8 @@ function parseFleetArgs(args: readonly string[]): { stop: boolean; status: boole
     }
     if (arg === "--runner") {
       runnerFlag = args[++i];
-      if (runnerFlag === undefined) throw new Error("--runner requires a value");
+      if (runnerFlag === undefined)
+        throw new Error("--runner requires a value");
       continue;
     }
     if (arg.startsWith("--runner=")) {
@@ -107,11 +142,17 @@ function parseFleetArgs(args: readonly string[]): { stop: boolean; status: boole
       continue;
     }
     if (arg.startsWith("--budget-usd=")) {
-      drainBudgetUsd = parsePositiveNumber(arg.slice("--budget-usd=".length), "--budget-usd");
+      drainBudgetUsd = parsePositiveNumber(
+        arg.slice("--budget-usd=".length),
+        "--budget-usd",
+      );
       continue;
     }
     if (arg.startsWith("--drain-budget-usd=")) {
-      drainBudgetUsd = parsePositiveNumber(arg.slice("--drain-budget-usd=".length), "--drain-budget-usd");
+      drainBudgetUsd = parsePositiveNumber(
+        arg.slice("--drain-budget-usd=".length),
+        "--drain-budget-usd",
+      );
       continue;
     }
     if (arg === "--shrink-mode") {
@@ -119,7 +160,10 @@ function parseFleetArgs(args: readonly string[]): { stop: boolean; status: boole
       continue;
     }
     if (arg.startsWith("--shrink-mode=")) {
-      shrinkMode = parseShrinkMode(arg.slice("--shrink-mode=".length), "--shrink-mode");
+      shrinkMode = parseShrinkMode(
+        arg.slice("--shrink-mode=".length),
+        "--shrink-mode",
+      );
       continue;
     }
     if (/^[0-9]+$/.test(arg) && target === undefined) {
@@ -128,7 +172,18 @@ function parseFleetArgs(args: readonly string[]): { stop: boolean; status: boole
     }
     passthrough.push(arg);
   }
-  return { stop, status, fleet: parseFleetFlag(args) ?? DEFAULT_FLEET_NAME, target: target ?? 2, request, runnerFlag, drainBudgetUsd, shrinkMode, passthrough };
+  return {
+    stop,
+    status,
+    fleet: parseFleetFlag(args) ?? DEFAULT_FLEET_NAME,
+    target: target ?? 2,
+    targetExplicit: target !== undefined,
+    request,
+    runnerFlag,
+    drainBudgetUsd,
+    shrinkMode,
+    passthrough,
+  };
 }
 
 export async function writeResizeRequest(
@@ -143,11 +198,7 @@ export async function writeResizeRequest(
     ...(runner !== undefined ? { runner } : {}),
     shrink_mode: shrinkMode,
   };
-  await writeFile(
-    tmp,
-    encodeToon(request),
-    "utf8",
-  );
+  await writeFile(tmp, encodeToon(request), "utf8");
   await rename(tmp, path);
 }
 
@@ -158,8 +209,10 @@ function directiveAck(
   if (!state) return "pending";
   const appliedTarget = state.target ?? state.slotsTotal;
   if (appliedTarget !== request.target) return "pending";
-  if ((state.shrinkMode ?? request.shrinkMode) !== request.shrinkMode) return "pending";
-  if (request.runner !== undefined && state.runner !== request.runner) return "pending";
+  if ((state.shrinkMode ?? request.shrinkMode) !== request.shrinkMode)
+    return "pending";
+  if (request.runner !== undefined && state.runner !== request.runner)
+    return "pending";
   return "applied";
 }
 
@@ -187,7 +240,9 @@ export async function stopFleet(
   ) {
     const watchdogDead = await killTreeAndWait(watchdogIdentity.pid);
     if (!watchdogDead) {
-      stdout.write(`✗ fleet watchdog pid=${watchdogIdentity.pid} survived termination; stop remains armed.\n`);
+      stdout.write(
+        `✗ fleet watchdog pid=${watchdogIdentity.pid} survived termination; stop remains armed.\n`,
+      );
       return { status: "timeout", pid: watchdogIdentity.pid };
     }
   }
@@ -203,16 +258,25 @@ export async function stopFleet(
     const killed = await io.killWorkers();
     if (killed > 0) {
       await io.reconcile();
-      stdout.write(`terminated ${killed} orphaned worker${killed === 1 ? "" : "s"} and reconciled their claims.\n`);
+      stdout.write(
+        `terminated ${killed} orphaned worker${killed === 1 ? "" : "s"} and reconciled their claims.\n`,
+      );
     }
   };
-  const liveSupervisor = await discoverLiveSupervisorPid(stateAfk, isLivePid, { fleet: paths.fleet });
+  const liveSupervisor = await discoverLiveSupervisorPid(stateAfk, isLivePid, {
+    fleet: paths.fleet,
+  });
   if (!liveSupervisor) {
     const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
     if (supervisor.status === "stale" && supervisor.pid !== undefined) {
       await sweepOrphans();
-      stdout.write(`no fleet running (reason=dead supervisor pid; stale files cleaned).\n`);
-      return { status: "stale", ...(supervisor.pid !== undefined ? { pid: supervisor.pid } : {}) };
+      stdout.write(
+        `no fleet running (reason=dead supervisor pid; stale files cleaned).\n`,
+      );
+      return {
+        status: "stale",
+        ...(supervisor.pid !== undefined ? { pid: supervisor.pid } : {}),
+      };
     }
     await sweepOrphans();
     stdout.write("no fleet running (reason=no supervisor pid).\n");
@@ -226,7 +290,9 @@ export async function stopFleet(
       // exit, but sweep detached survivors anyway — a slot the loop lost track of
       // (moved-pid, mid-spawn) would otherwise outlive the "stopped" report.
       await sweepOrphans();
-      stdout.write(`🛑 fleet stopped (reason=operator stop requested; supervisor pid=${pid} exited).\n`);
+      stdout.write(
+        `🛑 fleet stopped (reason=operator stop requested; supervisor pid=${pid} exited).\n`,
+      );
       return { status: "stopped", pid };
     }
     await sleep(1_000);
@@ -248,7 +314,9 @@ export async function stopFleet(
     await rm(paths.supervisorRecoveryPath, { force: true });
     // killTree of the supervisor pid misses the detached workers — sweep them.
     await sweepOrphans();
-    stdout.write(`🛑 fleet stopped (reason=graceful stop timeout; supervisor pid=${pid} killed).\n`);
+    stdout.write(
+      `🛑 fleet stopped (reason=graceful stop timeout; supervisor pid=${pid} killed).\n`,
+    );
     return { status: "stopped", pid };
   }
   stdout.write(
@@ -300,7 +368,10 @@ function parseFleetLogsArgs(args: readonly string[]): FleetLogsArgs {
   let follow = false;
 
   function setMode(next: FleetLogMode): void {
-    if (mode !== undefined) throw new Error("fleet logs accepts only one of --supervisor, --worker, or --all");
+    if (mode !== undefined)
+      throw new Error(
+        "fleet logs accepts only one of --supervisor, --worker, or --all",
+      );
     mode = next;
   }
 
@@ -333,7 +404,10 @@ function parseFleetLogsArgs(args: readonly string[]): FleetLogsArgs {
     throw new Error(`unknown fleet logs argument: ${arg}`);
   }
 
-  if (mode === undefined) throw new Error("fleet logs requires --supervisor, --worker <id>, or --all");
+  if (mode === undefined)
+    throw new Error(
+      "fleet logs requires --supervisor, --worker <id>, or --all",
+    );
   return { mode, follow };
 }
 
@@ -382,13 +456,19 @@ async function supervisorLogSources(root: string): Promise<FleetLogSource[]> {
   return sources;
 }
 
-async function workerLogSources(root: string, mode: Extract<FleetLogMode, { kind: "worker" | "all" }>): Promise<FleetLogSource[]> {
+async function workerLogSources(
+  root: string,
+  mode: Extract<FleetLogMode, { kind: "worker" | "all" }>,
+): Promise<FleetLogSource[]> {
   const paths = createEnginePaths(join(root, ".red"));
-  const workerIds = mode.kind === "worker" ? [mode.workerId] : await childDirs(paths.workersRoot);
+  const workerIds =
+    mode.kind === "worker"
+      ? [mode.workerId]
+      : await childDirs(paths.workersRoot);
   const sources: FleetLogSource[] = [];
   for (const workerId of workerIds) {
     const path = castleLanePath(paths, "worker", workerId);
-    if (mode.kind === "worker" || await readableFile(path)) {
+    if (mode.kind === "worker" || (await readableFile(path))) {
       sources.push({
         id: `worker:${workerId}`,
         path,
@@ -399,7 +479,10 @@ async function workerLogSources(root: string, mode: Extract<FleetLogMode, { kind
   return sources;
 }
 
-async function fleetLogSources(root: string, mode: FleetLogMode): Promise<FleetLogSource[]> {
+async function fleetLogSources(
+  root: string,
+  mode: FleetLogMode,
+): Promise<FleetLogSource[]> {
   if (mode.kind === "supervisor") return supervisorLogSources(root);
   return workerLogSources(root, mode);
 }
@@ -411,7 +494,9 @@ function payloadText(payload: Record<string, unknown> | undefined): string {
   const parts: string[] = [];
   for (const [key, value] of Object.entries(payload)) {
     if (value === undefined) continue;
-    parts.push(`${key}=${typeof value === "string" ? value : JSON.stringify(value)}`);
+    parts.push(
+      `${key}=${typeof value === "string" ? value : JSON.stringify(value)}`,
+    );
   }
   return parts.join(" ");
 }
@@ -424,7 +509,9 @@ function renderRecord(record: CastleLaneRecord, prefix: string): string {
   return `${prefix}${parts.join(" ")}${payload ? ` ${payload}` : ""}`;
 }
 
-async function readLogEntries(source: FleetLogSource): Promise<FleetLogEntry[]> {
+async function readLogEntries(
+  source: FleetLogSource,
+): Promise<FleetLogEntry[]> {
   const records = await readCastleLaneRecords(source.path);
   return records.map((record, index) => ({
     sourceId: source.id,
@@ -444,17 +531,22 @@ function sortEntries(entries: FleetLogEntry[]): FleetLogEntry[] {
   });
 }
 
-const wait = (ms: number, signal?: AbortSignal) => new Promise<void>((resolve) => {
-  if (signal?.aborted) {
-    resolve();
-    return;
-  }
-  const timer = setTimeout(resolve, ms);
-  signal?.addEventListener("abort", () => {
-    clearTimeout(timer);
-    resolve();
-  }, { once: true });
-});
+const wait = (ms: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
 
 /**
  * `fleet logs` is the read-only human view over the structured castle lanes.
@@ -514,20 +606,35 @@ export async function statusFleet(
   const paths = afkPaths(root, fleetName);
   const io = buildWatchdogIO(root, stdout, paths.fleet);
   const liveness = await io.liveness();
-  const liveSupervisor = await discoverLiveSupervisorPid(paths.supervisorRuntimeDir, isLivePid, { fleet: paths.fleet });
+  const liveSupervisor = await discoverLiveSupervisorPid(
+    paths.supervisorRuntimeDir,
+    isLivePid,
+    { fleet: paths.fleet },
+  );
   if (liveSupervisor) {
     liveness.pid = liveSupervisor.pid;
     liveness.pidAlive = true;
   }
   const cfg = resolveSupervisorConfig();
   const now = Math.floor(Date.now() / 1000);
-  const health = classifySupervisor(liveness, now, cfg.supervisorStaleS, cfg.progressStaleS);
+  const health = classifySupervisor(
+    liveness,
+    now,
+    cfg.supervisorStaleS,
+    cfg.progressStaleS,
+  );
   const repo = await resolveRepoSlug(root).catch(() => "");
   const inputs = await collectMonitorInputs(root, repo);
   const fleet = inputs.fleet;
-  const latestBundleVersion = fleet?.latestBundleVersion || readBuildInfo("dev").version;
-  const liveWorkers = inputs.workers.filter((w) => w.pidLive === true || w.live);
-  const heartbeatAgeS = liveness.lastHeartbeatEpoch !== null ? now - liveness.lastHeartbeatEpoch : -1;
+  const latestBundleVersion =
+    fleet?.latestBundleVersion || readBuildInfo("dev").version;
+  const liveWorkers = inputs.workers.filter(
+    (w) => w.pidLive === true || w.live,
+  );
+  const heartbeatAgeS =
+    liveness.lastHeartbeatEpoch !== null
+      ? now - liveness.lastHeartbeatEpoch
+      : -1;
 
   // A dead supervisor with ready-for-agent work and fewer live workers than the
   // target is what the watchdog would respawn — surface it so an operator who
@@ -546,11 +653,13 @@ export async function statusFleet(
       target: fleet?.target ?? fleet?.slotsTotal ?? 0,
       bundle_version: fleet?.bundleVersion ?? "",
       bundle_latest: latestBundleVersion,
-      version_skew: Number(Boolean(
-        fleet?.bundleVersion &&
-        latestBundleVersion &&
-        fleet.bundleVersion !== latestBundleVersion
-      )),
+      version_skew: Number(
+        Boolean(
+          fleet?.bundleVersion &&
+          latestBundleVersion &&
+          fleet.bundleVersion !== latestBundleVersion,
+        ),
+      ),
       heartbeat_age_s: heartbeatAgeS,
       would_respawn: wouldRespawn,
     },
@@ -577,9 +686,13 @@ export async function statusFleet(
   return { status: "reported" };
 }
 
-export async function launchFleet(args: readonly string[], root = process.cwd(), stdout: NodeJS.WritableStream = process.stdout): Promise<FleetLaunchResult> {
+export async function launchFleet(
+  args: readonly string[],
+  root = process.cwd(),
+  stdout: NodeJS.WritableStream = process.stdout,
+): Promise<FleetLaunchResult> {
   const parsed = parseFleetArgs(args);
-  if (!Number.isInteger(parsed.target) || parsed.target < 0) throw new Error("fleet target must be a non-negative integer");
+  const enginePaths = createEnginePaths(join(root, ".red"));
   const paths = afkPaths(root, parsed.fleet);
   const stateAfk = dirname(paths.supervisorPidPath);
   await mkdir(paths.tmpDir, { recursive: true });
@@ -587,13 +700,21 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
   // One-time boot migration: relocate legacy `.red/tmp` / state artifacts to
   // their canonical state or supervisor tmp lane before any supervisor path is read/written.
   await migrateLegacyDevPaths(root).catch(() => undefined);
+  const hostProfile = await readHostCapabilityProfile(enginePaths);
+  const target = parsed.targetExplicit
+    ? parsed.target
+    : resolveHostCapabilities(hostProfile).defaultFleetWidth;
+  if (!Number.isInteger(target) || target < 0)
+    throw new Error("fleet target must be a non-negative integer");
   const pidFile = paths.supervisorPidPath;
   const logFile = paths.supervisorLogPath;
-  const priorFleetState = await readFleetState(paths.fleetStatePath).catch(() => null);
+  const priorFleetState = await readFleetState(paths.fleetStatePath).catch(
+    () => null,
+  );
   // A registered fleet launches from its PROFILE: the registry supplies the
   // runner and the work-scope selector, and explicit flags still override.
   const profile = await readFleetProfile(
-    fleetRegistryPath(createEnginePaths(join(root, ".red"))),
+    fleetRegistryPath(enginePaths),
     paths.fleet,
   ).catch(() => undefined);
   const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
@@ -611,27 +732,47 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     const cfg = resolveSupervisorConfig();
     const io = buildWatchdogIO(root, stdout, paths.fleet);
     const liveness = await io.liveness();
-    const health = classifySupervisor(liveness, io.now(), cfg.supervisorStaleS, cfg.progressStaleS);
+    const health = classifySupervisor(
+      liveness,
+      io.now(),
+      cfg.supervisorStaleS,
+      cfg.progressStaleS,
+    );
     if (health !== "quiescent") {
-      const watchdogPid = await spawnSupervisorWatchdog({ root, fleet: paths.fleet });
+      const watchdogPid = await spawnSupervisorWatchdog({
+        root,
+        fleet: paths.fleet,
+      });
       if (!watchdogPid) {
-        throw new Error("fleet launch failed: supervisor self-heal watchdog did not arm");
+        throw new Error(
+          "fleet launch failed: supervisor self-heal watchdog did not arm",
+        );
       }
       const shrinkMode = parsed.shrinkMode ?? cfg.shrinkMode;
-      const directiveRunner = parsed.runnerFlag ? detectRunner({ flag: parsed.runnerFlag }).runner : undefined;
-      await writeResizeRequest(paths.supervisorResizePath, parsed.target, shrinkMode, directiveRunner);
+      const directiveRunner = parsed.runnerFlag
+        ? detectRunner({ flag: parsed.runnerFlag }).runner
+        : undefined;
+      await writeResizeRequest(
+        paths.supervisorResizePath,
+        target,
+        shrinkMode,
+        directiveRunner,
+      );
       const ack = directiveAck(await readFleetState(paths.fleetStatePath), {
-        target: parsed.target,
+        target,
         shrinkMode,
         ...(directiveRunner !== undefined ? { runner: directiveRunner } : {}),
       });
       stdout.write(
-        `fleet directive ${ack} (supervisor pid=${existing}, target=${parsed.target}` +
+        `fleet directive ${ack} (supervisor pid=${existing}, target=${target}` +
           `${directiveRunner !== undefined ? `, runner=${directiveRunner}` : ""}, shrink-mode=${shrinkMode})\n`,
       );
-      return { status: "resized", pid: existing, target: parsed.target, log: logFile };
+      return { status: "resized", pid: existing, target, log: logFile };
     }
-    const staleForS = liveness.lastHeartbeatEpoch !== null ? io.now() - liveness.lastHeartbeatEpoch : null;
+    const staleForS =
+      liveness.lastHeartbeatEpoch !== null
+        ? io.now() - liveness.lastHeartbeatEpoch
+        : null;
     io.log(
       `⚠️  fleet pre-check: supervisor pid=${existing} is QUIESCENT — heartbeat stale ` +
         `${staleForS ?? "?"}s ≥ ${cfg.supervisorStaleS}s; recovering before relaunch.`,
@@ -649,13 +790,19 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
   // so this fleet only ever claims issues inside its own scope. An explicit
   // filter flag on the command line wins over the registered scope.
   const scoped =
-    profile?.selector && !parsed.passthrough.some((a) => a.startsWith("--spec") || a.startsWith("--issues") || a.startsWith("--selector"))
+    profile?.selector &&
+    !parsed.passthrough.some(
+      (a) =>
+        a.startsWith("--spec") ||
+        a.startsWith("--issues") ||
+        a.startsWith("--selector"),
+    )
       ? ["--selector", JSON.stringify(profile.selector)]
       : [];
 
   const supervisorPid = await spawnSupervisor({
     root,
-    target: parsed.target,
+    target,
     runner: detection.runner,
     passthrough: [...parsed.passthrough, ...scoped],
     request: parsed.request,
@@ -672,18 +819,27 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     } catch {
       // ignore
     }
-    throw new Error(`fleet launch failed: supervisor pid file did not appear. log: .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n${tail}`);
+    throw new Error(
+      `fleet launch failed: supervisor pid file did not appear. log: .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n${tail}`,
+    );
   }
-  const watchdogPid = await spawnSupervisorWatchdog({ root, fleet: paths.fleet });
+  const watchdogPid = await spawnSupervisorWatchdog({
+    root,
+    fleet: paths.fleet,
+  });
   if (!watchdogPid) {
     await killTreeAndWait(supervisorPid).catch(() => false);
     await rm(paths.supervisorPidPath, { force: true }).catch(() => undefined);
-    await rm(paths.supervisorPidStartPath, { force: true }).catch(() => undefined);
-    throw new Error("fleet launch failed: supervisor self-heal watchdog did not arm");
+    await rm(paths.supervisorPidStartPath, { force: true }).catch(
+      () => undefined,
+    );
+    throw new Error(
+      "fleet launch failed: supervisor self-heal watchdog did not arm",
+    );
   }
 
   // Persist the profile so CLI-launched fleets are always in the registry (#2358).
-  await upsertFleetProfile(fleetRegistryPath(createEnginePaths(join(root, ".red"))), {
+  await upsertFleetProfile(fleetRegistryPath(enginePaths), {
     name: paths.fleet,
     runner: detection.runner,
     ...(profile?.selector ? { selector: profile.selector } : {}),
@@ -691,16 +847,26 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     ...(profile?.base ? { base: profile.base } : {}),
   }).catch(() => undefined);
 
-  const named = paths.fleet === DEFAULT_FLEET_NAME ? "" : ` --fleet ${paths.fleet}`;
-  stdout.write(`🚀 fleet ${paths.fleet} launched (supervisor pid=${supervisorPid}, target=${parsed.target})\n`);
+  const named =
+    paths.fleet === DEFAULT_FLEET_NAME ? "" : ` --fleet ${paths.fleet}`;
+  stdout.write(
+    `🚀 fleet ${paths.fleet} launched (supervisor pid=${supervisorPid}, target=${target})\n`,
+  );
   stdout.write(`   self-heal: armed (watchdog pid=${watchdogPid})\n`);
-  stdout.write(`   log:   .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n`);
+  stdout.write(
+    `   log:   .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n`,
+  );
   stdout.write(`   stop:  /dev:afk fleet stop${named}\n`);
-  stdout.write(`   monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl manually.\n`);
-  return { status: "launched", pid: supervisorPid, target: parsed.target, log: logFile };
+  stdout.write(
+    `   monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl manually.\n`,
+  );
+  return { status: "launched", pid: supervisorPid, target, log: logFile };
 }
 
-export async function fleetCommand(args: string[], cwd = process.cwd()): Promise<number> {
+export async function fleetCommand(
+  args: string[],
+  cwd = process.cwd(),
+): Promise<number> {
   if (args[0] === "logs") {
     try {
       await logsFleet(args.slice(1), cwd);

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -9,35 +9,16 @@ import {
   type IssueCandidate,
 } from "../../core/session.js";
 import { genWorkerId } from "../../core/session.js";
-import {
-  runBoot,
-  type BootDeps,
-  type BootOptions,
-  type BootResult,
-  type BootstrapInput,
-  type ReconcileBootRunner,
-} from "../../core/boot.js";
-import {
-  reconcile,
-  type ReconcileDeps,
-  type ReconcileInput,
-} from "../../core/reconcile.js";
+import { runBoot, type BootDeps, type BootOptions, type BootResult, type BootstrapInput, type ReconcileBootRunner } from "../../core/boot.js";
+import { reconcile, type ReconcileDeps, type ReconcileInput } from "../../core/reconcile.js";
 import { resolveBase } from "../../core/base-resolver.js";
-import {
-  findOwnedBranch,
-  type ReconcileSweepPlan,
-} from "../../core/boot-sweep.js";
+import { findOwnedBranch, type ReconcileSweepPlan } from "../../core/boot-sweep.js";
 import {
   classifyConflictedFileKind,
   partitionConflicts,
   type ConflictFinding,
 } from "../../core/merge-conflict-reconcile.js";
-import {
-  processIssue,
-  type ProcessIssueDeps,
-  type ProcessIssueInput,
-  type ProcessIssueResult,
-} from "../../core/process-issue.js";
+import { processIssue, type ProcessIssueDeps, type ProcessIssueInput, type ProcessIssueResult } from "../../core/process-issue.js";
 import {
   toMemoryPayload,
   resolveMemoryCli,
@@ -59,10 +40,7 @@ import {
   type AfkPaths,
 } from "../../runtime/wire.js";
 import type { LaneIdleStallConfig } from "../../core/lane-idle-reaper.js";
-import {
-  workerDir as workerDirPath,
-  workerPidFile,
-} from "../../core/worker-paths.js";
+import { workerDir as workerDirPath, workerPidFile } from "../../core/worker-paths.js";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { pluginEnabledInConfig } from "@reddb-io/shared/plugin-gate.js";
 import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
@@ -75,15 +53,7 @@ import type { GhContext } from "../../runtime/gh.js";
 import { buildReviewGh } from "../../runtime/review-gh.js";
 import type { GitContext } from "../../runtime/git.js";
 import { execTool, type ExecFn } from "../../runtime/exec.js";
-import {
-  getConfig,
-  loadConfig,
-  readBackpressure,
-  readPostAttemptFormat,
-  readValidationResourceBudget,
-  resolveTier,
-  resolveCiTimeoutSeconds,
-} from "../../core/config.js";
+import { getConfig, loadConfig, readBackpressure, readPostAttemptFormat, readValidationResourceBudget, resolveTier, resolveCiTimeoutSeconds } from "../../core/config.js";
 import { parseTrustPolicy, resolveActorTrust } from "../../core/trust-gate.js";
 import { resolveNotesLoopConfig } from "../../core/notes-loop.js";
 import { resolveOutputShapingConfig } from "../../core/output-shaping.js";
@@ -92,20 +62,10 @@ import {
   resolveReviewGate,
   type IssueClassificationMetadata,
 } from "../../core/issue-classifier.js";
-import {
-  LABEL_READY_FOR_REVIEW,
-  LABEL_GO_LANE,
-  LABEL_SCOUT_LANE,
-  LABEL_MERGE_CONFLICT,
-} from "../../core/triage-labels.js";
+import { LABEL_READY_FOR_REVIEW, LABEL_GO_LANE, LABEL_SCOUT_LANE, LABEL_MERGE_CONFLICT } from "../../core/triage-labels.js";
 import { GO_KIND, GO_ORIGIN } from "../../core/go.js";
 import { SCOUT_ORIGIN, SCOUT_WORKERS_SEGMENT } from "../../core/scout.js";
-import {
-  resolveHooks,
-  validateHookConfig,
-  UnknownHookError,
-  type HookName,
-} from "../../core/hook-config.js";
+import { resolveHooks, validateHookConfig, UnknownHookError, type HookName } from "../../core/hook-config.js";
 import { dispatchHooks } from "../../core/hook-dispatcher.js";
 import {
   createEnginePaths,
@@ -125,27 +85,12 @@ import { isValidWorkerId, WORKER_NAMESPACES } from "../../core/worker-paths.js";
 import { readdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { isLivePid } from "../../runtime/kill-tree.js";
-import {
-  specialUserRequestBlock,
-  claudeSpawnArgs,
-  codexSpawnArgs,
-} from "../../core/runner-spawn.js";
+import { specialUserRequestBlock, claudeSpawnArgs, codexSpawnArgs } from "../../core/runner-spawn.js";
 import { buildWorkerAttemptPath } from "../../core/worker-paths.js";
 import { createLandLock } from "../../runtime/land-lock.js";
-import {
-  branchLockPath,
-  readLockedBranch,
-  isLocked,
-} from "../../runtime/lock.js";
-import {
-  makeHookExec,
-  makeHookResolveOptions,
-  hookEnv,
-} from "../../runtime/hooks.js";
-import {
-  makeFeedbackWorktree,
-  type FeedbackWorktree,
-} from "../../runtime/feedback-worktree.js";
+import { branchLockPath, readLockedBranch, isLocked } from "../../runtime/lock.js";
+import { makeHookExec, makeHookResolveOptions, hookEnv } from "../../runtime/hooks.js";
+import { makeFeedbackWorktree, type FeedbackWorktree } from "../../runtime/feedback-worktree.js";
 import {
   installProcessSafety,
   fileSafetyLogger,
@@ -153,63 +98,24 @@ import {
   deathCauseForRecoveredWorker,
 } from "../../core/process-safety.js";
 import { join } from "node:path";
-import {
-  hostFingerprintPrefix,
-  workerIdentity,
-} from "../../core/host-identity.js";
-import {
-  appendAgentRecord,
-  appendRecordToonlTaggedRow,
-} from "../../core/jsonl-log.js";
-import {
-  initStateSync,
-  readPidStartTime,
-  updateState,
-  writeIdentitySync,
-} from "../../core/state.js";
-import {
-  decodeDevSnapshotSniff,
-  encodeDevSnapshotToon,
-} from "../../core/toon-snapshot.js";
-import {
-  buildProgressHeartbeat,
-  formatIterationMarker,
-} from "../../core/heartbeat.js";
-import {
-  resolveAttemptLoc,
-  locMemoPath,
-  type LocMemo,
-} from "../../core/loc-memo.js";
+import { hostFingerprintPrefix, workerIdentity } from "../../core/host-identity.js";
+import { appendAgentRecord, appendRecordToonlTaggedRow } from "../../core/jsonl-log.js";
+import { initStateSync, readPidStartTime, updateState, writeIdentitySync } from "../../core/state.js";
+import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../../core/toon-snapshot.js";
+import { buildProgressHeartbeat, formatIterationMarker } from "../../core/heartbeat.js";
+import { resolveAttemptLoc, locMemoPath, type LocMemo } from "../../core/loc-memo.js";
 import { createActivityMeter } from "../../core/activity-meter.js";
 import { createCastleWorkerLaneBridge } from "../../core/castle-worker-lane-bridge.js";
 import { DEFAULT_MAX_ITERATIONS } from "../../core/execution.js";
 import type { AgentStreamEvent } from "../../core/execution.js";
-import {
-  makeStaleClaimPredicate,
-  resolveClaimStalenessConfig,
-} from "../../core/claim-staleness.js";
+import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../../core/claim-staleness.js";
 import { renderClaimComment } from "../../core/claim.js";
 import { HOST_CONFIG_EXIT_CODE } from "../../core/attempt-outcome.js";
 
-import {
-  checkBootGuard,
-  isNamespacedDispatch,
-  parseRunFlags,
-  resolveRunDispatchIdentity,
-  type RunOptions,
-} from "./flags.js";
-import {
-  buildProcessDeps,
-  parseSlot,
-  type CurrentAttempt,
-} from "./process-deps.js";
+import { checkBootGuard, isNamespacedDispatch, parseRunFlags, resolveRunDispatchIdentity, type RunOptions } from "./flags.js";
+import { buildProcessDeps, parseSlot, type CurrentAttempt } from "./process-deps.js";
 import { makeBootReconcileRunner, runReconcileWorker } from "./reconcile.js";
-import {
-  nextAttemptSync,
-  openRunnerCircuit,
-  recordBootError,
-  runnerCircuitOpen,
-} from "./state.js";
+import { nextAttemptSync, openRunnerCircuit, recordBootError, runnerCircuitOpen } from "./state.js";
 
 export async function runCommand(options: RunOptions): Promise<number> {
   const cwd = options.cwd ?? process.cwd();
@@ -227,9 +133,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     processTree: callerProcessTreeNative(),
     scriptPath: process.argv[1],
   });
-  const runner: Runner = isRunner(detection.runner)
-    ? detection.runner
-    : "claude";
+  const runner: Runner = isRunner(detection.runner) ? detection.runner : "claude";
 
   const ctx = await resolveRepoContext(cwd);
   const settings = resolveRunSettings(cwd, process.env, runner);
@@ -249,30 +153,19 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // fleet-owned and the supervisor already holds the pid. A `/go`/`--scout`
   // dispatch (#1087) is exempt too: its isolated namespace/lane/origin can
   // never collide with the fleet, so it must boot whether or not a fleet is up.
-  if (
-    flags.reconcileIssue === undefined &&
-    process.env.RED_AFK_SWEEPS_DONE !== "1"
-  ) {
+  if (flags.reconcileIssue === undefined && process.env.RED_AFK_SWEEPS_DONE !== "1") {
     const pidFile = paths.supervisorPidPath;
     const exempt = isNamespacedDispatch({
       origin: dispatchIdentity.origin,
       kind: dispatchIdentity.kind,
       lane: dispatchIdentity.lane,
     });
-    const guard = await checkBootGuard(
-      pidFile,
-      flags.force,
-      process.stdout,
-      isLivePid,
-      exempt,
-    );
+    const guard = await checkBootGuard(pidFile, flags.force, process.stdout, isLivePid, exempt);
     if (guard === "refused") return 1;
   }
 
   // Worker id — probe the workers root for collisions.
-  const existing = new Set(
-    (await collectMonitorInputs(cwd)).workers.map((w) => w.state.worker_id),
-  );
+  const existing = new Set((await collectMonitorInputs(cwd)).workers.map((w) => w.state.worker_id));
   const workerId = genWorkerId(Math.random, (id) => existing.has(id));
   const pidStartTime = readPidStartTime(process.pid) ?? "";
   // Emit the per-slot boot-stamp immediately so the supervisor's slot log
@@ -300,13 +193,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // Supervisor-dispatched reconcile worker: bypass the normal boot+session and
   // validate-and-land the specific parked branch for `--reconcile-issue <n>`.
   if (flags.reconcileIssue !== undefined) {
-    return runReconcileWorker(
-      flags.reconcileIssue,
-      runner,
-      ctx,
-      paths,
-      workerId,
-    );
+    return runReconcileWorker(flags.reconcileIssue, runner, ctx, paths, workerId);
   }
 
   const facts = await collectPrecheckFacts(ctx);
@@ -377,9 +264,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     }
   } catch (err) {
     await recordBootError(bootstrap.workerDir, "boot-error", err).catch(() => {
-      process.stderr.write(
-        `[afk] boot-error: ${err instanceof Error ? err.message : String(err)}\n`,
-      );
+      process.stderr.write(`[afk] boot-error: ${err instanceof Error ? err.message : String(err)}\n`);
     });
     return 1;
   }
@@ -389,31 +274,17 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // the `afk.feedback.rebase_on_base` flag is on; undefined → no rebase
   // (default behaviour unchanged).
   const config = loadConfig(paths.configPath, { warn: () => undefined });
-  const feedback = makeFeedbackWorktree(
-    ctx.root,
-    paths.feedbackWorktreesDir,
-    undefined,
-    {
-      rebaseOnto: settings.feedbackRebaseBase,
-      resourceBudget: readValidationResourceBudget(config),
-    },
-  );
+  const feedback = makeFeedbackWorktree(ctx.root, paths.feedbackWorktreesDir, undefined, {
+    rebaseOnto: settings.feedbackRebaseBase,
+    resourceBudget: readValidationResourceBudget(config),
+  });
 
   // Wire the boot reconcile runner into bootDeps (step 7, ADR 0055). A
   // supervisor-owned boot skips every sweep (including reconcile) and the fleet
   // dispatches reconcile per-tick instead, so the runner is wired only on the
   // solo / sweep-running path.
   if (!sweepsDone) {
-    bootDeps = {
-      ...bootDeps,
-      reconcileRunner: makeBootReconcileRunner(
-        ctx,
-        paths,
-        workerId,
-        runner,
-        feedback,
-      ),
-    };
+    bootDeps = { ...bootDeps, reconcileRunner: makeBootReconcileRunner(ctx, paths, workerId, runner, feedback) };
   }
 
   // Per-issue mutable attempt context the process deps' envelope/iter-log close
@@ -437,18 +308,13 @@ export async function runCommand(options: RunOptions): Promise<number> {
   try {
     validateHookConfig(sessionHooksConfig);
   } catch (err) {
-    const msg =
-      err instanceof UnknownHookError
-        ? `[afk:config] fatal: ${err.message} in .red/config.yaml — fix the hook name and restart the fleet`
-        : `[afk:config] fatal: hook config error: ${err instanceof Error ? err.message : String(err)}`;
+    const msg = err instanceof UnknownHookError
+      ? `[afk:config] fatal: ${err.message} in .red/config.yaml — fix the hook name and restart the fleet`
+      : `[afk:config] fatal: hook config error: ${err instanceof Error ? err.message : String(err)}`;
     process.stderr.write(`${msg}\n`);
     const retireFile = process.env.RED_AFK_RETIRE_FILE;
     if (retireFile) {
-      try {
-        writeFileSync(retireFile, "");
-      } catch {
-        /* best-effort */
-      }
+      try { writeFileSync(retireFile, ""); } catch { /* best-effort */ }
     }
     return 1;
   }
@@ -457,17 +323,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
     config: sessionHooksConfig,
     resolveOptions: makeHookResolveOptions(ctx.root),
     exec: makeHookExec(ctx.root),
-    env: hookEnv(
-      ctx.repo,
-      ctx.root,
-      parseSlot(process.env.RED_AFK_SLOT),
-      runner,
-    ),
+    env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT), runner),
   };
-  const resolvedSessionHooks = resolveHooks(
-    sessionHooks.config,
-    sessionHooks.resolveOptions,
-  );
+  const resolvedSessionHooks = resolveHooks(sessionHooks.config, sessionHooks.resolveOptions);
 
   const deps: CastleWorkerDrainDeps<
     BootDeps,
@@ -478,9 +336,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     ProcessIssueResult,
     SessionIssueTemplate
   > = {
-    gh: {
-      listCandidates: () => ghx.listCandidates(ghCtx, dispatchIdentity.lane),
-    },
+    gh: { listCandidates: () => ghx.listCandidates(ghCtx, dispatchIdentity.lane) },
     runBoot,
     bootDeps,
     bootOptions,
@@ -493,12 +349,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     processIssue: async (pd, pi) => {
       const result = await processIssue(pd, pi);
       if (result.outcome === "runner-transient") {
-        await openRunnerCircuit(
-          paths.runnerCircuitDir,
-          pi.runner,
-          Math.floor(Date.now() / 1000),
-          process.env,
-        ).catch(() => {});
+        await openRunnerCircuit(paths.runnerCircuitDir, pi.runner, Math.floor(Date.now() / 1000), process.env).catch(() => {});
       }
       // Abandon means DELETE (#644): buildProcessInput pre-creates the attempt
       // dir + state (current.number, live pid) BEFORE the claim, so a lost race
@@ -511,9 +362,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       }
       const sp = join(pi.attemptDir, "afk.state.toon");
       if (await fsx.pathExists(sp)) {
-        await updateState(sp, { pid: 0 }, { allowPidReset: true }).catch(
-          () => {},
-        );
+        await updateState(sp, { pid: 0 }, { allowPidReset: true }).catch(() => {});
         await castleBridge.snapshot().catch(() => {});
       }
       return result;
@@ -536,10 +385,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     // Session-scoped lifecycle hooks (PRD #207): the castle drain owns the
     // session state machine, while dev supplies the existing hook dispatcher so
     // the configured hook surface and output stay unchanged.
-    dispatchSessionHook: async (
-      name: CastleSessionHookName,
-      context: string,
-    ) => {
+    dispatchSessionHook: async (name: CastleSessionHookName, context: string) => {
       const result = await dispatchHooks(
         name as HookName,
         resolvedSessionHooks[name as HookName],
@@ -553,31 +399,15 @@ export async function runCommand(options: RunOptions): Promise<number> {
       return { aborted: result.aborted };
     },
     runnerCircuit: {
-      isOpen: (r) =>
-        runnerCircuitOpen(
-          paths.runnerCircuitDir,
-          r,
-          Math.floor(Date.now() / 1000),
-        ),
+      isOpen: (r) => runnerCircuitOpen(paths.runnerCircuitDir, r, Math.floor(Date.now() / 1000)),
     },
-    buildProcessInput: (
-      candidate: IssueCandidate,
-      c: SessionContext,
-    ): ProcessIssueInput => {
-      const recoveryOrdinal = nextAttemptSync(
-        c.issueTemplate.tmpDir,
-        candidate.number,
-      );
+    buildProcessInput: (candidate: IssueCandidate, c: SessionContext): ProcessIssueInput => {
+      const recoveryOrdinal = nextAttemptSync(c.issueTemplate.tmpDir, candidate.number);
       // Long-running workers key workspaces by workerId+issueId. The retry
       // ordinal remains separate policy data for per-class recovery caps and
       // prior-failure prompt context; it no longer shapes the directory name.
       const attempt = 1;
-      const attemptDir = buildWorkerAttemptPath(
-        c.issueTemplate.tmpDir,
-        c.workerId,
-        candidate.number,
-        attempt,
-      );
+      const attemptDir = buildWorkerAttemptPath(c.issueTemplate.tmpDir, c.workerId, candidate.number, attempt);
       // Point the session-scoped envelope/iter-log closures at this attempt.
       current.attemptDir = attemptDir;
       // Native-path observability (sibling of #350): the shell era's iter_open
@@ -644,9 +474,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       }
       // Append the --request block into the handoff body so the inner agent
       // (which reads handoff.md as its prompt) sees the special request.
-      const body = requestBlock
-        ? `${candidate.body}\n\n${requestBlock}`
-        : candidate.body;
+      const body = requestBlock ? `${candidate.body}\n\n${requestBlock}` : candidate.body;
       return {
         issue: candidate.number,
         title: candidate.title,
@@ -666,10 +494,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         repoDir: c.issueTemplate.repoDir,
         remote: c.issueTemplate.remote,
         baseInput: { issueBody: candidate.body },
-        runMode: runModeForCandidate(
-          candidate,
-          flags.prePr ? "no-mistakes" : flags.runMode,
-        ),
+        runMode: runModeForCandidate(candidate, flags.prePr ? "no-mistakes" : flags.runMode),
         // Lane-aware claim preflight (#1045): the pre-claim state-validity recheck
         // must validate against the label this issue was SELECTED under (the
         // `--lane` value), not a hardcoded `ready-for-agent`. `flags.lane` is
@@ -685,13 +510,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
   try {
     summary = await runCastleWorkerDrain(deps, sessionCtx);
   } catch (err) {
-    await recordBootError(bootstrap.workerDir, "session-error", err).catch(
-      () => {
-        process.stderr.write(
-          `[afk] session-error: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
-      },
-    );
+    await recordBootError(bootstrap.workerDir, "session-error", err).catch(() => {
+      process.stderr.write(`[afk] session-error: ${err instanceof Error ? err.message : String(err)}\n`);
+    });
     return 1;
   } finally {
     await feedback.cleanup();
@@ -707,15 +528,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // it) ends the run with exit 75 (EX_TEMPFAIL) so a supervisor retries once the
   // quota resets, rather than treating it as a clean drain (0) or hard fail (1).
   if (summary.exhausted) {
-    process.stderr.write(
-      `[afk] runner exhausted — exiting 75 (EX_TEMPFAIL); rerun when quota resets\n`,
-    );
+    process.stderr.write(`[afk] runner exhausted — exiting 75 (EX_TEMPFAIL); rerun when quota resets\n`);
     return 75;
   }
   if (summary.runnerTransient) {
-    process.stderr.write(
-      `[afk] runner transport/setup failed — exiting 75 (EX_TEMPFAIL); rerun when the runner backend is healthy\n`,
-    );
+    process.stderr.write(`[afk] runner transport/setup failed — exiting 75 (EX_TEMPFAIL); rerun when the runner backend is healthy\n`);
     return 75;
   }
   if (summary.hostConfig) {
@@ -728,14 +545,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // A targeted dispatch that attempted nothing is a failure, never a clean drain
   // (#2385): `/go` reported `progress: 1/1 (100%)` + exit 0 over a claim the
   // worker conceded without doing any work.
-  const zeroAttempt = zeroAttemptDispatchFailure(
-    flags.filter?.kind === "issues",
-    summary.processed,
-  );
+  const zeroAttempt = zeroAttemptDispatchFailure(flags.filter?.kind === "issues", summary.processed);
   if (zeroAttempt) {
-    process.stderr.write(
-      `[afk] targeted dispatch attempted no work: ${zeroAttempt} — exiting 1\n`,
-    );
+    process.stderr.write(`[afk] targeted dispatch attempted no work: ${zeroAttempt} — exiting 1\n`);
     return 1;
   }
 

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -9,16 +9,35 @@ import {
   type IssueCandidate,
 } from "../../core/session.js";
 import { genWorkerId } from "../../core/session.js";
-import { runBoot, type BootDeps, type BootOptions, type BootResult, type BootstrapInput, type ReconcileBootRunner } from "../../core/boot.js";
-import { reconcile, type ReconcileDeps, type ReconcileInput } from "../../core/reconcile.js";
+import {
+  runBoot,
+  type BootDeps,
+  type BootOptions,
+  type BootResult,
+  type BootstrapInput,
+  type ReconcileBootRunner,
+} from "../../core/boot.js";
+import {
+  reconcile,
+  type ReconcileDeps,
+  type ReconcileInput,
+} from "../../core/reconcile.js";
 import { resolveBase } from "../../core/base-resolver.js";
-import { findOwnedBranch, type ReconcileSweepPlan } from "../../core/boot-sweep.js";
+import {
+  findOwnedBranch,
+  type ReconcileSweepPlan,
+} from "../../core/boot-sweep.js";
 import {
   classifyConflictedFileKind,
   partitionConflicts,
   type ConflictFinding,
 } from "../../core/merge-conflict-reconcile.js";
-import { processIssue, type ProcessIssueDeps, type ProcessIssueInput, type ProcessIssueResult } from "../../core/process-issue.js";
+import {
+  processIssue,
+  type ProcessIssueDeps,
+  type ProcessIssueInput,
+  type ProcessIssueResult,
+} from "../../core/process-issue.js";
 import {
   toMemoryPayload,
   resolveMemoryCli,
@@ -40,7 +59,10 @@ import {
   type AfkPaths,
 } from "../../runtime/wire.js";
 import type { LaneIdleStallConfig } from "../../core/lane-idle-reaper.js";
-import { workerDir as workerDirPath, workerPidFile } from "../../core/worker-paths.js";
+import {
+  workerDir as workerDirPath,
+  workerPidFile,
+} from "../../core/worker-paths.js";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { pluginEnabledInConfig } from "@reddb-io/shared/plugin-gate.js";
 import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
@@ -53,7 +75,15 @@ import type { GhContext } from "../../runtime/gh.js";
 import { buildReviewGh } from "../../runtime/review-gh.js";
 import type { GitContext } from "../../runtime/git.js";
 import { execTool, type ExecFn } from "../../runtime/exec.js";
-import { getConfig, loadConfig, readBackpressure, readPostAttemptFormat, readValidationResourceBudget, resolveTier, resolveCiTimeoutSeconds } from "../../core/config.js";
+import {
+  getConfig,
+  loadConfig,
+  readBackpressure,
+  readPostAttemptFormat,
+  readValidationResourceBudget,
+  resolveTier,
+  resolveCiTimeoutSeconds,
+} from "../../core/config.js";
 import { parseTrustPolicy, resolveActorTrust } from "../../core/trust-gate.js";
 import { resolveNotesLoopConfig } from "../../core/notes-loop.js";
 import { resolveOutputShapingConfig } from "../../core/output-shaping.js";
@@ -62,23 +92,60 @@ import {
   resolveReviewGate,
   type IssueClassificationMetadata,
 } from "../../core/issue-classifier.js";
-import { LABEL_READY_FOR_REVIEW, LABEL_GO_LANE, LABEL_SCOUT_LANE, LABEL_MERGE_CONFLICT } from "../../core/triage-labels.js";
+import {
+  LABEL_READY_FOR_REVIEW,
+  LABEL_GO_LANE,
+  LABEL_SCOUT_LANE,
+  LABEL_MERGE_CONFLICT,
+} from "../../core/triage-labels.js";
 import { GO_KIND, GO_ORIGIN } from "../../core/go.js";
 import { SCOUT_ORIGIN, SCOUT_WORKERS_SEGMENT } from "../../core/scout.js";
-import { resolveHooks, validateHookConfig, UnknownHookError, type HookName } from "../../core/hook-config.js";
+import {
+  resolveHooks,
+  validateHookConfig,
+  UnknownHookError,
+  type HookName,
+} from "../../core/hook-config.js";
 import { dispatchHooks } from "../../core/hook-dispatcher.js";
-import { runCastleWorkerDrain, type CastleSessionHookName, type CastleWorkerDrainDeps } from "@reddb-io/red-castle/engine";
-import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../../core/attempt-ledger.js";
+import {
+  createEnginePaths,
+  readHostCapabilityProfile,
+  runCastleWorkerDrain,
+  type CastleSessionHookName,
+  type CastleWorkerDrainDeps,
+  type HostCapabilityProfile,
+} from "@reddb-io/red-castle/engine";
+import {
+  attemptLedgerContext,
+  formatAttemptContext,
+  highestAttempt,
+  type AttemptDirEntry,
+} from "../../core/attempt-ledger.js";
 import { isValidWorkerId, WORKER_NAMESPACES } from "../../core/worker-paths.js";
 import { readdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { isLivePid } from "../../runtime/kill-tree.js";
-import { specialUserRequestBlock, claudeSpawnArgs, codexSpawnArgs } from "../../core/runner-spawn.js";
+import {
+  specialUserRequestBlock,
+  claudeSpawnArgs,
+  codexSpawnArgs,
+} from "../../core/runner-spawn.js";
 import { buildWorkerAttemptPath } from "../../core/worker-paths.js";
 import { createLandLock } from "../../runtime/land-lock.js";
-import { branchLockPath, readLockedBranch, isLocked } from "../../runtime/lock.js";
-import { makeHookExec, makeHookResolveOptions, hookEnv } from "../../runtime/hooks.js";
-import { makeFeedbackWorktree, type FeedbackWorktree } from "../../runtime/feedback-worktree.js";
+import {
+  branchLockPath,
+  readLockedBranch,
+  isLocked,
+} from "../../runtime/lock.js";
+import {
+  makeHookExec,
+  makeHookResolveOptions,
+  hookEnv,
+} from "../../runtime/hooks.js";
+import {
+  makeFeedbackWorktree,
+  type FeedbackWorktree,
+} from "../../runtime/feedback-worktree.js";
 import {
   installProcessSafety,
   fileSafetyLogger,
@@ -86,24 +153,63 @@ import {
   deathCauseForRecoveredWorker,
 } from "../../core/process-safety.js";
 import { join } from "node:path";
-import { hostFingerprintPrefix, workerIdentity } from "../../core/host-identity.js";
-import { appendAgentRecord, appendRecordToonlTaggedRow } from "../../core/jsonl-log.js";
-import { initStateSync, readPidStartTime, updateState, writeIdentitySync } from "../../core/state.js";
-import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../../core/toon-snapshot.js";
-import { buildProgressHeartbeat, formatIterationMarker } from "../../core/heartbeat.js";
-import { resolveAttemptLoc, locMemoPath, type LocMemo } from "../../core/loc-memo.js";
+import {
+  hostFingerprintPrefix,
+  workerIdentity,
+} from "../../core/host-identity.js";
+import {
+  appendAgentRecord,
+  appendRecordToonlTaggedRow,
+} from "../../core/jsonl-log.js";
+import {
+  initStateSync,
+  readPidStartTime,
+  updateState,
+  writeIdentitySync,
+} from "../../core/state.js";
+import {
+  decodeDevSnapshotSniff,
+  encodeDevSnapshotToon,
+} from "../../core/toon-snapshot.js";
+import {
+  buildProgressHeartbeat,
+  formatIterationMarker,
+} from "../../core/heartbeat.js";
+import {
+  resolveAttemptLoc,
+  locMemoPath,
+  type LocMemo,
+} from "../../core/loc-memo.js";
 import { createActivityMeter } from "../../core/activity-meter.js";
 import { createCastleWorkerLaneBridge } from "../../core/castle-worker-lane-bridge.js";
 import { DEFAULT_MAX_ITERATIONS } from "../../core/execution.js";
 import type { AgentStreamEvent } from "../../core/execution.js";
-import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../../core/claim-staleness.js";
+import {
+  makeStaleClaimPredicate,
+  resolveClaimStalenessConfig,
+} from "../../core/claim-staleness.js";
 import { renderClaimComment } from "../../core/claim.js";
 import { HOST_CONFIG_EXIT_CODE } from "../../core/attempt-outcome.js";
 
-import { checkBootGuard, isNamespacedDispatch, parseRunFlags, resolveRunDispatchIdentity, type RunOptions } from "./flags.js";
-import { buildProcessDeps, parseSlot, type CurrentAttempt } from "./process-deps.js";
+import {
+  checkBootGuard,
+  isNamespacedDispatch,
+  parseRunFlags,
+  resolveRunDispatchIdentity,
+  type RunOptions,
+} from "./flags.js";
+import {
+  buildProcessDeps,
+  parseSlot,
+  type CurrentAttempt,
+} from "./process-deps.js";
 import { makeBootReconcileRunner, runReconcileWorker } from "./reconcile.js";
-import { nextAttemptSync, openRunnerCircuit, recordBootError, runnerCircuitOpen } from "./state.js";
+import {
+  nextAttemptSync,
+  openRunnerCircuit,
+  recordBootError,
+  runnerCircuitOpen,
+} from "./state.js";
 
 export async function runCommand(options: RunOptions): Promise<number> {
   const cwd = options.cwd ?? process.cwd();
@@ -121,7 +227,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
     processTree: callerProcessTreeNative(),
     scriptPath: process.argv[1],
   });
-  const runner: Runner = isRunner(detection.runner) ? detection.runner : "claude";
+  const runner: Runner = isRunner(detection.runner)
+    ? detection.runner
+    : "claude";
 
   const ctx = await resolveRepoContext(cwd);
   const settings = resolveRunSettings(cwd, process.env, runner);
@@ -131,6 +239,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // canonical state or supervisor tmp lanes before this worker reads/writes supervisor/circuit state
   // (issue #1685). Idempotent + best-effort — a second boot is a no-op.
   await migrateLegacyDevPaths(cwd).catch(() => undefined);
+  const hostProfile = await readHostCapabilityProfile(
+    createEnginePaths(join(ctx.root, ".red")),
+  );
 
   // Boot guard (#1027): refuse to start if a fleet supervisor is already live.
   // Supervisor-dispatched paths bypass this: --reconcile-issue workers are
@@ -138,19 +249,30 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // fleet-owned and the supervisor already holds the pid. A `/go`/`--scout`
   // dispatch (#1087) is exempt too: its isolated namespace/lane/origin can
   // never collide with the fleet, so it must boot whether or not a fleet is up.
-  if (flags.reconcileIssue === undefined && process.env.RED_AFK_SWEEPS_DONE !== "1") {
+  if (
+    flags.reconcileIssue === undefined &&
+    process.env.RED_AFK_SWEEPS_DONE !== "1"
+  ) {
     const pidFile = paths.supervisorPidPath;
     const exempt = isNamespacedDispatch({
       origin: dispatchIdentity.origin,
       kind: dispatchIdentity.kind,
       lane: dispatchIdentity.lane,
     });
-    const guard = await checkBootGuard(pidFile, flags.force, process.stdout, isLivePid, exempt);
+    const guard = await checkBootGuard(
+      pidFile,
+      flags.force,
+      process.stdout,
+      isLivePid,
+      exempt,
+    );
     if (guard === "refused") return 1;
   }
 
   // Worker id — probe the workers root for collisions.
-  const existing = new Set((await collectMonitorInputs(cwd)).workers.map((w) => w.state.worker_id));
+  const existing = new Set(
+    (await collectMonitorInputs(cwd)).workers.map((w) => w.state.worker_id),
+  );
   const workerId = genWorkerId(Math.random, (id) => existing.has(id));
   const pidStartTime = readPidStartTime(process.pid) ?? "";
   // Emit the per-slot boot-stamp immediately so the supervisor's slot log
@@ -178,7 +300,13 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // Supervisor-dispatched reconcile worker: bypass the normal boot+session and
   // validate-and-land the specific parked branch for `--reconcile-issue <n>`.
   if (flags.reconcileIssue !== undefined) {
-    return runReconcileWorker(flags.reconcileIssue, runner, ctx, paths, workerId);
+    return runReconcileWorker(
+      flags.reconcileIssue,
+      runner,
+      ctx,
+      paths,
+      workerId,
+    );
   }
 
   const facts = await collectPrecheckFacts(ctx);
@@ -191,7 +319,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // runs the full sweep suite exactly as before.
   const sweepsDone = process.env.RED_AFK_SWEEPS_DONE === "1";
 
-  const sessionCtx: SessionContext = {
+  const sessionCtx: SessionContext & { hostProfile?: HostCapabilityProfile } = {
     runner,
     workerId,
     iterCap: flags.iterCap,
@@ -202,6 +330,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     // Reported by the --boot-only line so the dry-run states whether this worker
     // ran the sweeps or inherited them from the supervisor.
     sweepsSkipped: sweepsDone,
+    ...(hostProfile !== undefined ? { hostProfile } : {}),
     issueTemplate: {
       tmpDir: paths.tmpDir,
       repo: ctx.repo,
@@ -248,7 +377,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
     }
   } catch (err) {
     await recordBootError(bootstrap.workerDir, "boot-error", err).catch(() => {
-      process.stderr.write(`[afk] boot-error: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.stderr.write(
+        `[afk] boot-error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
     });
     return 1;
   }
@@ -258,17 +389,31 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // the `afk.feedback.rebase_on_base` flag is on; undefined → no rebase
   // (default behaviour unchanged).
   const config = loadConfig(paths.configPath, { warn: () => undefined });
-  const feedback = makeFeedbackWorktree(ctx.root, paths.feedbackWorktreesDir, undefined, {
-    rebaseOnto: settings.feedbackRebaseBase,
-    resourceBudget: readValidationResourceBudget(config),
-  });
+  const feedback = makeFeedbackWorktree(
+    ctx.root,
+    paths.feedbackWorktreesDir,
+    undefined,
+    {
+      rebaseOnto: settings.feedbackRebaseBase,
+      resourceBudget: readValidationResourceBudget(config),
+    },
+  );
 
   // Wire the boot reconcile runner into bootDeps (step 7, ADR 0055). A
   // supervisor-owned boot skips every sweep (including reconcile) and the fleet
   // dispatches reconcile per-tick instead, so the runner is wired only on the
   // solo / sweep-running path.
   if (!sweepsDone) {
-    bootDeps = { ...bootDeps, reconcileRunner: makeBootReconcileRunner(ctx, paths, workerId, runner, feedback) };
+    bootDeps = {
+      ...bootDeps,
+      reconcileRunner: makeBootReconcileRunner(
+        ctx,
+        paths,
+        workerId,
+        runner,
+        feedback,
+      ),
+    };
   }
 
   // Per-issue mutable attempt context the process deps' envelope/iter-log close
@@ -292,13 +437,18 @@ export async function runCommand(options: RunOptions): Promise<number> {
   try {
     validateHookConfig(sessionHooksConfig);
   } catch (err) {
-    const msg = err instanceof UnknownHookError
-      ? `[afk:config] fatal: ${err.message} in .red/config.yaml — fix the hook name and restart the fleet`
-      : `[afk:config] fatal: hook config error: ${err instanceof Error ? err.message : String(err)}`;
+    const msg =
+      err instanceof UnknownHookError
+        ? `[afk:config] fatal: ${err.message} in .red/config.yaml — fix the hook name and restart the fleet`
+        : `[afk:config] fatal: hook config error: ${err instanceof Error ? err.message : String(err)}`;
     process.stderr.write(`${msg}\n`);
     const retireFile = process.env.RED_AFK_RETIRE_FILE;
     if (retireFile) {
-      try { writeFileSync(retireFile, ""); } catch { /* best-effort */ }
+      try {
+        writeFileSync(retireFile, "");
+      } catch {
+        /* best-effort */
+      }
     }
     return 1;
   }
@@ -307,9 +457,17 @@ export async function runCommand(options: RunOptions): Promise<number> {
     config: sessionHooksConfig,
     resolveOptions: makeHookResolveOptions(ctx.root),
     exec: makeHookExec(ctx.root),
-    env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT), runner),
+    env: hookEnv(
+      ctx.repo,
+      ctx.root,
+      parseSlot(process.env.RED_AFK_SLOT),
+      runner,
+    ),
   };
-  const resolvedSessionHooks = resolveHooks(sessionHooks.config, sessionHooks.resolveOptions);
+  const resolvedSessionHooks = resolveHooks(
+    sessionHooks.config,
+    sessionHooks.resolveOptions,
+  );
 
   const deps: CastleWorkerDrainDeps<
     BootDeps,
@@ -320,7 +478,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
     ProcessIssueResult,
     SessionIssueTemplate
   > = {
-    gh: { listCandidates: () => ghx.listCandidates(ghCtx, dispatchIdentity.lane) },
+    gh: {
+      listCandidates: () => ghx.listCandidates(ghCtx, dispatchIdentity.lane),
+    },
     runBoot,
     bootDeps,
     bootOptions,
@@ -333,7 +493,12 @@ export async function runCommand(options: RunOptions): Promise<number> {
     processIssue: async (pd, pi) => {
       const result = await processIssue(pd, pi);
       if (result.outcome === "runner-transient") {
-        await openRunnerCircuit(paths.runnerCircuitDir, pi.runner, Math.floor(Date.now() / 1000), process.env).catch(() => {});
+        await openRunnerCircuit(
+          paths.runnerCircuitDir,
+          pi.runner,
+          Math.floor(Date.now() / 1000),
+          process.env,
+        ).catch(() => {});
       }
       // Abandon means DELETE (#644): buildProcessInput pre-creates the attempt
       // dir + state (current.number, live pid) BEFORE the claim, so a lost race
@@ -346,7 +511,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
       }
       const sp = join(pi.attemptDir, "afk.state.toon");
       if (await fsx.pathExists(sp)) {
-        await updateState(sp, { pid: 0 }, { allowPidReset: true }).catch(() => {});
+        await updateState(sp, { pid: 0 }, { allowPidReset: true }).catch(
+          () => {},
+        );
         await castleBridge.snapshot().catch(() => {});
       }
       return result;
@@ -369,7 +536,10 @@ export async function runCommand(options: RunOptions): Promise<number> {
     // Session-scoped lifecycle hooks (PRD #207): the castle drain owns the
     // session state machine, while dev supplies the existing hook dispatcher so
     // the configured hook surface and output stay unchanged.
-    dispatchSessionHook: async (name: CastleSessionHookName, context: string) => {
+    dispatchSessionHook: async (
+      name: CastleSessionHookName,
+      context: string,
+    ) => {
       const result = await dispatchHooks(
         name as HookName,
         resolvedSessionHooks[name as HookName],
@@ -383,15 +553,31 @@ export async function runCommand(options: RunOptions): Promise<number> {
       return { aborted: result.aborted };
     },
     runnerCircuit: {
-      isOpen: (r) => runnerCircuitOpen(paths.runnerCircuitDir, r, Math.floor(Date.now() / 1000)),
+      isOpen: (r) =>
+        runnerCircuitOpen(
+          paths.runnerCircuitDir,
+          r,
+          Math.floor(Date.now() / 1000),
+        ),
     },
-    buildProcessInput: (candidate: IssueCandidate, c: SessionContext): ProcessIssueInput => {
-      const recoveryOrdinal = nextAttemptSync(c.issueTemplate.tmpDir, candidate.number);
+    buildProcessInput: (
+      candidate: IssueCandidate,
+      c: SessionContext,
+    ): ProcessIssueInput => {
+      const recoveryOrdinal = nextAttemptSync(
+        c.issueTemplate.tmpDir,
+        candidate.number,
+      );
       // Long-running workers key workspaces by workerId+issueId. The retry
       // ordinal remains separate policy data for per-class recovery caps and
       // prior-failure prompt context; it no longer shapes the directory name.
       const attempt = 1;
-      const attemptDir = buildWorkerAttemptPath(c.issueTemplate.tmpDir, c.workerId, candidate.number, attempt);
+      const attemptDir = buildWorkerAttemptPath(
+        c.issueTemplate.tmpDir,
+        c.workerId,
+        candidate.number,
+        attempt,
+      );
       // Point the session-scoped envelope/iter-log closures at this attempt.
       current.attemptDir = attemptDir;
       // Native-path observability (sibling of #350): the shell era's iter_open
@@ -458,7 +644,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
       }
       // Append the --request block into the handoff body so the inner agent
       // (which reads handoff.md as its prompt) sees the special request.
-      const body = requestBlock ? `${candidate.body}\n\n${requestBlock}` : candidate.body;
+      const body = requestBlock
+        ? `${candidate.body}\n\n${requestBlock}`
+        : candidate.body;
       return {
         issue: candidate.number,
         title: candidate.title,
@@ -478,7 +666,10 @@ export async function runCommand(options: RunOptions): Promise<number> {
         repoDir: c.issueTemplate.repoDir,
         remote: c.issueTemplate.remote,
         baseInput: { issueBody: candidate.body },
-        runMode: runModeForCandidate(candidate, flags.prePr ? "no-mistakes" : flags.runMode),
+        runMode: runModeForCandidate(
+          candidate,
+          flags.prePr ? "no-mistakes" : flags.runMode,
+        ),
         // Lane-aware claim preflight (#1045): the pre-claim state-validity recheck
         // must validate against the label this issue was SELECTED under (the
         // `--lane` value), not a hardcoded `ready-for-agent`. `flags.lane` is
@@ -494,9 +685,13 @@ export async function runCommand(options: RunOptions): Promise<number> {
   try {
     summary = await runCastleWorkerDrain(deps, sessionCtx);
   } catch (err) {
-    await recordBootError(bootstrap.workerDir, "session-error", err).catch(() => {
-      process.stderr.write(`[afk] session-error: ${err instanceof Error ? err.message : String(err)}\n`);
-    });
+    await recordBootError(bootstrap.workerDir, "session-error", err).catch(
+      () => {
+        process.stderr.write(
+          `[afk] session-error: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      },
+    );
     return 1;
   } finally {
     await feedback.cleanup();
@@ -512,11 +707,15 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // it) ends the run with exit 75 (EX_TEMPFAIL) so a supervisor retries once the
   // quota resets, rather than treating it as a clean drain (0) or hard fail (1).
   if (summary.exhausted) {
-    process.stderr.write(`[afk] runner exhausted — exiting 75 (EX_TEMPFAIL); rerun when quota resets\n`);
+    process.stderr.write(
+      `[afk] runner exhausted — exiting 75 (EX_TEMPFAIL); rerun when quota resets\n`,
+    );
     return 75;
   }
   if (summary.runnerTransient) {
-    process.stderr.write(`[afk] runner transport/setup failed — exiting 75 (EX_TEMPFAIL); rerun when the runner backend is healthy\n`);
+    process.stderr.write(
+      `[afk] runner transport/setup failed — exiting 75 (EX_TEMPFAIL); rerun when the runner backend is healthy\n`,
+    );
     return 75;
   }
   if (summary.hostConfig) {
@@ -529,9 +728,14 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // A targeted dispatch that attempted nothing is a failure, never a clean drain
   // (#2385): `/go` reported `progress: 1/1 (100%)` + exit 0 over a claim the
   // worker conceded without doing any work.
-  const zeroAttempt = zeroAttemptDispatchFailure(flags.filter?.kind === "issues", summary.processed);
+  const zeroAttempt = zeroAttemptDispatchFailure(
+    flags.filter?.kind === "issues",
+    summary.processed,
+  );
   if (zeroAttempt) {
-    process.stderr.write(`[afk] targeted dispatch attempted no work: ${zeroAttempt} — exiting 1\n`);
+    process.stderr.write(
+      `[afk] targeted dispatch attempted no work: ${zeroAttempt} — exiting 1\n`,
+    );
     return 1;
   }
 

--- a/apps/dev/tests/fleet-cli-upsert.test.ts
+++ b/apps/dev/tests/fleet-cli-upsert.test.ts
@@ -5,7 +5,13 @@ import { vi, describe, it, expect, afterEach } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createEnginePaths, fleetRegistryPath, readFleetProfile } from "@reddb-io/red-castle/engine";
+import {
+  createEnginePaths,
+  fleetRegistryPath,
+  readFleetProfile,
+  writeHostCapabilityProfile,
+} from "@reddb-io/red-castle/engine";
+import { spawnSupervisor } from "../src/runtime/supervisor-spawn.js";
 
 vi.mock("../src/runtime/supervisor-spawn.js", () => ({
   spawnSupervisor: vi.fn(async () => 7777),
@@ -21,6 +27,7 @@ const { launchFleet } = await import("../src/commands/fleet.js");
 const roots: string[] = [];
 
 afterEach(async () => {
+  vi.mocked(spawnSupervisor).mockClear();
   await Promise.all(
     roots.splice(0).map((r) => rm(r, { recursive: true, force: true })),
   );
@@ -52,12 +59,34 @@ describe("CLI fleet N launch — profile upsert", () => {
     const cwd = await root();
     const silent = { write: () => true } as unknown as NodeJS.WritableStream;
 
-    await launchFleet(["2", "--runner", "codex", "--fleet", "alpha"], cwd, silent);
+    await launchFleet(
+      ["2", "--runner", "codex", "--fleet", "alpha"],
+      cwd,
+      silent,
+    );
 
     const profile = await readFleetProfile(
       fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),
       "alpha",
     );
     expect(profile).toMatchObject({ name: "alpha", runner: "codex" });
+  });
+
+  it("uses the host profile's default width when the launch omits a target", async () => {
+    const cwd = await root();
+    const silent = { write: () => true } as unknown as NodeJS.WritableStream;
+    await writeHostCapabilityProfile(createEnginePaths(join(cwd, ".red")), {
+      machineIdHash: "8cb3eafdcbd2",
+      runners: ["claude", "codex"],
+      maxGateWeight: "full-workspace",
+      defaultFleetWidth: 5,
+    });
+
+    const result = await launchFleet(["--runner", "claude"], cwd, silent);
+
+    expect(result.target).toBe(5);
+    expect(spawnSupervisor).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 5 }),
+    );
   });
 });

--- a/apps/dev/tests/fleet-cli-upsert.test.ts
+++ b/apps/dev/tests/fleet-cli-upsert.test.ts
@@ -59,11 +59,7 @@ describe("CLI fleet N launch — profile upsert", () => {
     const cwd = await root();
     const silent = { write: () => true } as unknown as NodeJS.WritableStream;
 
-    await launchFleet(
-      ["2", "--runner", "codex", "--fleet", "alpha"],
-      cwd,
-      silent,
-    );
+    await launchFleet(["2", "--runner", "codex", "--fleet", "alpha"], cwd, silent);
 
     const profile = await readFleetProfile(
       fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),

--- a/packages/red-castle/src/engine/gate-executor.test.ts
+++ b/packages/red-castle/src/engine/gate-executor.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { CASTLE_VALIDATION_SCHEMA } from "./gate-constants.js";
 import { makeHeadlessGateSink, makeInteractiveGateSink } from "./gate-sink.js";
-import {
-  classifyFinding,
-  runCastleGate,
-  type RunCastleGateInput,
-} from "./gate-executor.js";
+import { classifyFinding, runCastleGate, type RunCastleGateInput } from "./gate-executor.js";
 
 function baseInput(): RunCastleGateInput {
   let tick = 0;
@@ -17,9 +13,7 @@ function baseInput(): RunCastleGateInput {
         return [".", "packages/core", "apps/dev"].includes(scope);
       },
       hasScript(scope, script) {
-        return (
-          scope === "packages/core" && ["test", "typecheck"].includes(script)
-        );
+        return scope === "packages/core" && ["test", "typecheck"].includes(script);
       },
     },
     graph: {
@@ -32,11 +26,7 @@ function baseInput(): RunCastleGateInput {
       askIntent: async () => "approved",
     }),
     feedbackExec: vi.fn(async () => ({ code: 0, stdout: "ok", stderr: "" })),
-    backpressureExec: vi.fn(async () => ({
-      code: 0,
-      stdout: "ok",
-      stderr: "",
-    })),
+    backpressureExec: vi.fn(async () => ({ code: 0, stdout: "ok", stderr: "" })),
     applyMechanical: vi.fn(async () => {}),
     now: () => ++tick,
   };
@@ -44,12 +34,8 @@ function baseInput(): RunCastleGateInput {
 
 describe("castle gate executor", () => {
   it("classifies only versioned mechanical kinds as mechanical", () => {
-    expect(classifyFinding({ kind: "formatter", description: "format" })).toBe(
-      "mechanical",
-    );
-    expect(
-      classifyFinding({ kind: "refactor", description: "logic changed" }),
-    ).toBe("intent");
+    expect(classifyFinding({ kind: "formatter", description: "format" })).toBe("mechanical");
+    expect(classifyFinding({ kind: "refactor", description: "logic changed" })).toBe("intent");
   });
 
   it("runs scoped feedback, skips missing scripts, then runs configured backpressure", async () => {
@@ -64,23 +50,14 @@ describe("castle gate executor", () => {
       triggerPackages: ["packages/core"],
       packages: ["apps/dev", "packages/core"],
     });
-    expect(input.feedbackExec).toHaveBeenCalledWith([
-      "pnpm",
-      "-C",
-      "/repo/packages/core",
-      "test",
-    ]);
+    expect(input.feedbackExec).toHaveBeenCalledWith(["pnpm", "-C", "/repo/packages/core", "test"]);
     expect(input.backpressureExec).toHaveBeenCalledWith({
       command: "pnpm smoke",
       cwd: "/repo",
       timeoutMs: 600000,
     });
-    expect(result.checks.map((check) => check.name)).toContain(
-      "backpressure:pnpm smoke",
-    );
-    expect(JSON.parse(result.sidecar[0]!).schema).toBe(
-      CASTLE_VALIDATION_SCHEMA,
-    );
+    expect(result.checks.map((check) => check.name)).toContain("backpressure:pnpm smoke");
+    expect(JSON.parse(result.sidecar[0]!).schema).toBe(CASTLE_VALIDATION_SCHEMA);
   });
 
   it("blocks through the headless sink on intent findings before validation evidence is recorded", async () => {
@@ -100,11 +77,7 @@ describe("castle gate executor", () => {
 
   it("does not run backpressure when feedback fails", async () => {
     const input = baseInput();
-    input.feedbackExec = vi.fn(async () => ({
-      code: 1,
-      stdout: "",
-      stderr: "failed",
-    }));
+    input.feedbackExec = vi.fn(async () => ({ code: 1, stdout: "", stderr: "failed" }));
     input.backpressureCommands = ["pnpm smoke"];
 
     const result = await runCastleGate(input);
@@ -143,10 +116,7 @@ describe("castle gate executor", () => {
 
   it("a diff touching .github/workflows/ passes through the gate without blocking", async () => {
     const input = baseInput();
-    input.changedFiles = [
-      ".github/workflows/ci.yml",
-      "packages/core/src/index.ts",
-    ];
+    input.changedFiles = [".github/workflows/ci.yml", "packages/core/src/index.ts"];
 
     const result = await runCastleGate(input);
 

--- a/packages/red-castle/src/engine/gate-executor.test.ts
+++ b/packages/red-castle/src/engine/gate-executor.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { CASTLE_VALIDATION_SCHEMA } from "./gate-constants.js";
 import { makeHeadlessGateSink, makeInteractiveGateSink } from "./gate-sink.js";
-import { classifyFinding, runCastleGate, type RunCastleGateInput } from "./gate-executor.js";
+import {
+  classifyFinding,
+  runCastleGate,
+  type RunCastleGateInput,
+} from "./gate-executor.js";
 
 function baseInput(): RunCastleGateInput {
   let tick = 0;
@@ -13,7 +17,9 @@ function baseInput(): RunCastleGateInput {
         return [".", "packages/core", "apps/dev"].includes(scope);
       },
       hasScript(scope, script) {
-        return scope === "packages/core" && ["test", "typecheck"].includes(script);
+        return (
+          scope === "packages/core" && ["test", "typecheck"].includes(script)
+        );
       },
     },
     graph: {
@@ -26,7 +32,11 @@ function baseInput(): RunCastleGateInput {
       askIntent: async () => "approved",
     }),
     feedbackExec: vi.fn(async () => ({ code: 0, stdout: "ok", stderr: "" })),
-    backpressureExec: vi.fn(async () => ({ code: 0, stdout: "ok", stderr: "" })),
+    backpressureExec: vi.fn(async () => ({
+      code: 0,
+      stdout: "ok",
+      stderr: "",
+    })),
     applyMechanical: vi.fn(async () => {}),
     now: () => ++tick,
   };
@@ -34,8 +44,12 @@ function baseInput(): RunCastleGateInput {
 
 describe("castle gate executor", () => {
   it("classifies only versioned mechanical kinds as mechanical", () => {
-    expect(classifyFinding({ kind: "formatter", description: "format" })).toBe("mechanical");
-    expect(classifyFinding({ kind: "refactor", description: "logic changed" })).toBe("intent");
+    expect(classifyFinding({ kind: "formatter", description: "format" })).toBe(
+      "mechanical",
+    );
+    expect(
+      classifyFinding({ kind: "refactor", description: "logic changed" }),
+    ).toBe("intent");
   });
 
   it("runs scoped feedback, skips missing scripts, then runs configured backpressure", async () => {
@@ -50,14 +64,23 @@ describe("castle gate executor", () => {
       triggerPackages: ["packages/core"],
       packages: ["apps/dev", "packages/core"],
     });
-    expect(input.feedbackExec).toHaveBeenCalledWith(["pnpm", "-C", "/repo/packages/core", "test"]);
+    expect(input.feedbackExec).toHaveBeenCalledWith([
+      "pnpm",
+      "-C",
+      "/repo/packages/core",
+      "test",
+    ]);
     expect(input.backpressureExec).toHaveBeenCalledWith({
       command: "pnpm smoke",
       cwd: "/repo",
       timeoutMs: 600000,
     });
-    expect(result.checks.map((check) => check.name)).toContain("backpressure:pnpm smoke");
-    expect(JSON.parse(result.sidecar[0]!).schema).toBe(CASTLE_VALIDATION_SCHEMA);
+    expect(result.checks.map((check) => check.name)).toContain(
+      "backpressure:pnpm smoke",
+    );
+    expect(JSON.parse(result.sidecar[0]!).schema).toBe(
+      CASTLE_VALIDATION_SCHEMA,
+    );
   });
 
   it("blocks through the headless sink on intent findings before validation evidence is recorded", async () => {
@@ -77,7 +100,11 @@ describe("castle gate executor", () => {
 
   it("does not run backpressure when feedback fails", async () => {
     const input = baseInput();
-    input.feedbackExec = vi.fn(async () => ({ code: 1, stdout: "", stderr: "failed" }));
+    input.feedbackExec = vi.fn(async () => ({
+      code: 1,
+      stdout: "",
+      stderr: "failed",
+    }));
     input.backpressureCommands = ["pnpm smoke"];
 
     const result = await runCastleGate(input);
@@ -86,9 +113,40 @@ describe("castle gate executor", () => {
     expect(input.backpressureExec).not.toHaveBeenCalled();
   });
 
+  it("refuses an over-class gate with an explicit verdict before executing commands", async () => {
+    const input = baseInput();
+    input.hostProfile = {
+      machineIdHash: "8cb3eafdcbd2",
+      runners: ["codex"],
+      maxGateWeight: "light-cone",
+      defaultFleetWidth: 1,
+    };
+    input.gateWeight = "heavy-cone";
+    input.backpressureCommands = ["pnpm smoke"];
+
+    const result = await runCastleGate(input);
+
+    expect(result).toMatchObject({
+      ok: false,
+      admission: {
+        admitted: false,
+        verdict: "refused-over-class",
+        required: "heavy-cone",
+        maximum: "light-cone",
+      },
+      checks: [],
+      sidecar: [],
+    });
+    expect(input.feedbackExec).not.toHaveBeenCalled();
+    expect(input.backpressureExec).not.toHaveBeenCalled();
+  });
+
   it("a diff touching .github/workflows/ passes through the gate without blocking", async () => {
     const input = baseInput();
-    input.changedFiles = [".github/workflows/ci.yml", "packages/core/src/index.ts"];
+    input.changedFiles = [
+      ".github/workflows/ci.yml",
+      "packages/core/src/index.ts",
+    ];
 
     const result = await runCastleGate(input);
 

--- a/packages/red-castle/src/engine/gate-executor.ts
+++ b/packages/red-castle/src/engine/gate-executor.ts
@@ -7,7 +7,19 @@ import {
   type FeedbackScript,
 } from "./gate-constants.js";
 import type { GateFinding, GateSink, GateSinkOutcome } from "./gate-sink.js";
-import { computeValidationScope, scopesForValidationScope, type PackageLayout, type ValidationScope, type WorkspaceGraph } from "./validation-cone.js";
+import {
+  computeValidationScope,
+  scopesForValidationScope,
+  type PackageLayout,
+  type ValidationScope,
+  type WorkspaceGraph,
+} from "./validation-cone.js";
+import {
+  evaluateHostGateAdmission,
+  type GateWeightClass,
+  type HostCapabilityProfile,
+  type HostGateAdmission,
+} from "./host-capability-profile.js";
 
 export type ValidationStatus = "passed" | "failed" | "skipped";
 
@@ -57,6 +69,10 @@ export interface RunCastleGateInput {
   applyMechanical: (finding: GateFinding) => Promise<void>;
   now: () => number;
   backpressureTimeoutMs?: number;
+  /** This machine's durable capability declaration. Absent keeps legacy permissive routing. */
+  hostProfile?: HostCapabilityProfile;
+  /** Explicit gate weight when the caller has already classified the run. */
+  gateWeight?: GateWeightClass;
 }
 
 export interface CastleGateResult {
@@ -66,10 +82,18 @@ export interface CastleGateResult {
   sidecar: string[];
   sinkOutcomes: GateSinkOutcome[];
   mechanicalApplied: number;
+  admission: HostGateAdmission;
+}
+
+function gateWeightForScope(scope: ValidationScope): GateWeightClass {
+  if (scope.type === "whole-workspace") return "full-workspace";
+  return scope.packages.length > 1 ? "heavy-cone" : "light-cone";
 }
 
 export function classifyFinding(finding: GateFinding): "mechanical" | "intent" {
-  return (MECHANICAL_KINDS as readonly string[]).includes(finding.kind) ? "mechanical" : "intent";
+  return (MECHANICAL_KINDS as readonly string[]).includes(finding.kind)
+    ? "mechanical"
+    : "intent";
 }
 
 function scopeLabel(scope: string): string {
@@ -100,14 +124,21 @@ function validationRecord(input: {
     name: input.name,
     status: input.status,
   };
-  if (input.command !== undefined && input.command !== "") record.command = input.command;
-  if (input.exitCode !== undefined && Number.isFinite(input.exitCode)) record.exitCode = Math.trunc(input.exitCode);
+  if (input.command !== undefined && input.command !== "")
+    record.command = input.command;
+  if (input.exitCode !== undefined && Number.isFinite(input.exitCode))
+    record.exitCode = Math.trunc(input.exitCode);
   if (input.durationMs !== undefined) record.durationMs = input.durationMs;
-  if (input.summary !== undefined && input.summary !== "") record.summary = input.summary;
+  if (input.summary !== undefined && input.summary !== "")
+    record.summary = input.summary;
   return record;
 }
 
-function pushCheck(checks: ValidationCheck[], sidecar: string[], check: ValidationCheck): void {
+function pushCheck(
+  checks: ValidationCheck[],
+  sidecar: string[],
+  check: ValidationCheck,
+): void {
   checks.push(check);
   sidecar.push(JSON.stringify(check.record));
 }
@@ -125,7 +156,11 @@ async function runFeedbackChecks(
       pushCheck(checks, sidecar, {
         name,
         status: "skipped",
-        record: validationRecord({ name, status: "skipped", summary: "no package.json" }),
+        record: validationRecord({
+          name,
+          status: "skipped",
+          summary: "no package.json",
+        }),
       });
       continue;
     }
@@ -137,7 +172,11 @@ async function runFeedbackChecks(
         pushCheck(checks, sidecar, {
           name,
           status: "skipped",
-          record: validationRecord({ name, status: "skipped", summary: "script missing" }),
+          record: validationRecord({
+            name,
+            status: "skipped",
+            summary: "script missing",
+          }),
         });
         continue;
       }
@@ -172,35 +211,70 @@ async function runBackpressureChecks(
   sidecar: string[],
 ): Promise<boolean> {
   let ok = true;
-  const timeoutMs = input.backpressureTimeoutMs ?? DEFAULT_BACKPRESSURE_TIMEOUT_MS;
+  const timeoutMs =
+    input.backpressureTimeoutMs ?? DEFAULT_BACKPRESSURE_TIMEOUT_MS;
   for (const raw of input.backpressureCommands ?? []) {
     const command = raw.trim();
     if (command === "") continue;
     const name = `backpressure:${command}`;
     const start = input.now();
-    const result = await input.backpressureExec({ command, cwd: input.worktree, timeoutMs });
+    const result = await input.backpressureExec({
+      command,
+      cwd: input.worktree,
+      timeoutMs,
+    });
     const durationMs = input.now() - start;
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") ok = false;
-    const summary = result.code === KILLED_EXIT_CODE
-      ? `command timed out after ${timeoutMs}ms`
-      : outputSummary(status, `${result.stdout}${result.stderr}`);
+    const summary =
+      result.code === KILLED_EXIT_CODE
+        ? `command timed out after ${timeoutMs}ms`
+        : outputSummary(status, `${result.stdout}${result.stderr}`);
     pushCheck(checks, sidecar, {
       name,
       status,
-      record: validationRecord({ name, status, command, exitCode: result.code, durationMs, summary }),
+      record: validationRecord({
+        name,
+        status,
+        command,
+        exitCode: result.code,
+        durationMs,
+        summary,
+      }),
     });
   }
   return ok;
 }
 
-export async function runCastleGate(input: RunCastleGateInput): Promise<CastleGateResult> {
-  const validationScope = computeValidationScope(input.changedFiles, input.layout, input.graph);
+export async function runCastleGate(
+  input: RunCastleGateInput,
+): Promise<CastleGateResult> {
+  const validationScope = computeValidationScope(
+    input.changedFiles,
+    input.layout,
+    input.graph,
+  );
+  const admission = evaluateHostGateAdmission(
+    input.hostProfile,
+    input.gateWeight ?? gateWeightForScope(validationScope),
+  );
   const checks: ValidationCheck[] = [];
   const sidecar: string[] = [];
   const sinkOutcomes: GateSinkOutcome[] = [];
   let mechanicalApplied = 0;
   let ok = true;
+
+  if (!admission.admitted) {
+    return {
+      ok: false,
+      validationScope,
+      checks,
+      sidecar,
+      sinkOutcomes,
+      mechanicalApplied,
+      admission,
+    };
+  }
 
   for (const finding of input.findings ?? []) {
     if (classifyFinding(finding) === "mechanical") {
@@ -213,12 +287,25 @@ export async function runCastleGate(input: RunCastleGateInput): Promise<CastleGa
     }
   }
 
-  const feedbackOk = await runFeedbackChecks(input, scopesForValidationScope(validationScope), checks, sidecar);
+  const feedbackOk = await runFeedbackChecks(
+    input,
+    scopesForValidationScope(validationScope),
+    checks,
+    sidecar,
+  );
   ok = ok && feedbackOk;
 
   if (feedbackOk) {
-    ok = ok && await runBackpressureChecks(input, checks, sidecar);
+    ok = ok && (await runBackpressureChecks(input, checks, sidecar));
   }
 
-  return { ok, validationScope, checks, sidecar, sinkOutcomes, mechanicalApplied };
+  return {
+    ok,
+    validationScope,
+    checks,
+    sidecar,
+    sinkOutcomes,
+    mechanicalApplied,
+    admission,
+  };
 }

--- a/packages/red-castle/src/engine/gate-executor.ts
+++ b/packages/red-castle/src/engine/gate-executor.ts
@@ -91,9 +91,7 @@ function gateWeightForScope(scope: ValidationScope): GateWeightClass {
 }
 
 export function classifyFinding(finding: GateFinding): "mechanical" | "intent" {
-  return (MECHANICAL_KINDS as readonly string[]).includes(finding.kind)
-    ? "mechanical"
-    : "intent";
+  return (MECHANICAL_KINDS as readonly string[]).includes(finding.kind) ? "mechanical" : "intent";
 }
 
 function scopeLabel(scope: string): string {
@@ -124,21 +122,14 @@ function validationRecord(input: {
     name: input.name,
     status: input.status,
   };
-  if (input.command !== undefined && input.command !== "")
-    record.command = input.command;
-  if (input.exitCode !== undefined && Number.isFinite(input.exitCode))
-    record.exitCode = Math.trunc(input.exitCode);
+  if (input.command !== undefined && input.command !== "") record.command = input.command;
+  if (input.exitCode !== undefined && Number.isFinite(input.exitCode)) record.exitCode = Math.trunc(input.exitCode);
   if (input.durationMs !== undefined) record.durationMs = input.durationMs;
-  if (input.summary !== undefined && input.summary !== "")
-    record.summary = input.summary;
+  if (input.summary !== undefined && input.summary !== "") record.summary = input.summary;
   return record;
 }
 
-function pushCheck(
-  checks: ValidationCheck[],
-  sidecar: string[],
-  check: ValidationCheck,
-): void {
+function pushCheck(checks: ValidationCheck[], sidecar: string[], check: ValidationCheck): void {
   checks.push(check);
   sidecar.push(JSON.stringify(check.record));
 }
@@ -156,11 +147,7 @@ async function runFeedbackChecks(
       pushCheck(checks, sidecar, {
         name,
         status: "skipped",
-        record: validationRecord({
-          name,
-          status: "skipped",
-          summary: "no package.json",
-        }),
+        record: validationRecord({ name, status: "skipped", summary: "no package.json" }),
       });
       continue;
     }
@@ -172,11 +159,7 @@ async function runFeedbackChecks(
         pushCheck(checks, sidecar, {
           name,
           status: "skipped",
-          record: validationRecord({
-            name,
-            status: "skipped",
-            summary: "script missing",
-          }),
+          record: validationRecord({ name, status: "skipped", summary: "script missing" }),
         });
         continue;
       }
@@ -211,36 +194,23 @@ async function runBackpressureChecks(
   sidecar: string[],
 ): Promise<boolean> {
   let ok = true;
-  const timeoutMs =
-    input.backpressureTimeoutMs ?? DEFAULT_BACKPRESSURE_TIMEOUT_MS;
+  const timeoutMs = input.backpressureTimeoutMs ?? DEFAULT_BACKPRESSURE_TIMEOUT_MS;
   for (const raw of input.backpressureCommands ?? []) {
     const command = raw.trim();
     if (command === "") continue;
     const name = `backpressure:${command}`;
     const start = input.now();
-    const result = await input.backpressureExec({
-      command,
-      cwd: input.worktree,
-      timeoutMs,
-    });
+    const result = await input.backpressureExec({ command, cwd: input.worktree, timeoutMs });
     const durationMs = input.now() - start;
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") ok = false;
-    const summary =
-      result.code === KILLED_EXIT_CODE
-        ? `command timed out after ${timeoutMs}ms`
-        : outputSummary(status, `${result.stdout}${result.stderr}`);
+    const summary = result.code === KILLED_EXIT_CODE
+      ? `command timed out after ${timeoutMs}ms`
+      : outputSummary(status, `${result.stdout}${result.stderr}`);
     pushCheck(checks, sidecar, {
       name,
       status,
-      record: validationRecord({
-        name,
-        status,
-        command,
-        exitCode: result.code,
-        durationMs,
-        summary,
-      }),
+      record: validationRecord({ name, status, command, exitCode: result.code, durationMs, summary }),
     });
   }
   return ok;
@@ -287,16 +257,11 @@ export async function runCastleGate(
     }
   }
 
-  const feedbackOk = await runFeedbackChecks(
-    input,
-    scopesForValidationScope(validationScope),
-    checks,
-    sidecar,
-  );
+  const feedbackOk = await runFeedbackChecks(input, scopesForValidationScope(validationScope), checks, sidecar);
   ok = ok && feedbackOk;
 
   if (feedbackOk) {
-    ok = ok && (await runBackpressureChecks(input, checks, sidecar));
+    ok = ok && await runBackpressureChecks(input, checks, sidecar);
   }
 
   return {

--- a/packages/red-castle/src/engine/host-capability-profile.test.ts
+++ b/packages/red-castle/src/engine/host-capability-profile.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createEnginePaths } from "./paths.js";
+import { createSingletonEventLane } from "./singleton-event-lane.js";
+import {
+  readHostCapabilityProfile,
+  resolveHostCapabilities,
+  writeHostCapabilityProfile,
+  type HostCapabilityProfile,
+} from "./host-capability-profile.js";
+
+describe("host capability profile", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      roots.map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it("round-trips one host's capabilities through the durable Castle state tier", async () => {
+    const root = await mkdtemp(join(tmpdir(), "castle-host-capabilities-"));
+    roots.push(root);
+    const paths = createEnginePaths(join(root, ".red"));
+    const profile: HostCapabilityProfile = {
+      machineIdHash: "8cb3eafdcbd2",
+      runners: ["codex", "opencode"],
+      maxGateWeight: "heavy-cone",
+      defaultFleetWidth: 3,
+    };
+
+    await writeHostCapabilityProfile(paths, profile);
+
+    expect(await readHostCapabilityProfile(paths)).toEqual(profile);
+  });
+
+  it("registers a present profile in the singleton event lane without raw machine identity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "castle-host-registration-"));
+    roots.push(root);
+    const paths = createEnginePaths(join(root, ".red"));
+
+    await writeHostCapabilityProfile(paths, {
+      machineIdHash: "8cb3eafdcbd2",
+      runners: ["codex"],
+      maxGateWeight: "light-cone",
+      defaultFleetWidth: 1,
+    });
+
+    const events = await createSingletonEventLane(paths).read();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      singleton: "host-capabilities",
+      kind: "host.capability-profile.registered",
+      payload: {
+        machine_id_hash: "8cb3eafdcbd2",
+        runners: ["codex"],
+        max_gate_weight: "light-cone",
+        default_fleet_width: 1,
+      },
+    });
+    expect(JSON.stringify(events[0])).not.toMatch(
+      /hostname|home_path|username/,
+    );
+  });
+
+  it("uses today's permissive runner, gate, and width defaults when no profile exists", () => {
+    expect(resolveHostCapabilities(undefined)).toEqual({
+      runners: ["claude", "codex", "hermes", "opencode", "claude-minimax"],
+      maxGateWeight: "full-workspace",
+      defaultFleetWidth: 2,
+      source: "permissive-default",
+    });
+  });
+});

--- a/packages/red-castle/src/engine/host-capability-profile.ts
+++ b/packages/red-castle/src/engine/host-capability-profile.ts
@@ -1,0 +1,162 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import type { EnginePaths } from "./paths.js";
+import { isRunner, runners, type Runner } from "./runner-types.js";
+import { createSingletonEventLane } from "./singleton-event-lane.js";
+
+export const GATE_WEIGHT_CLASSES = [
+  "light-cone",
+  "heavy-cone",
+  "full-workspace",
+] as const;
+
+export type GateWeightClass = (typeof GATE_WEIGHT_CLASSES)[number];
+
+export interface HostCapabilityProfile {
+  readonly machineIdHash: string;
+  readonly runners: readonly Runner[];
+  readonly maxGateWeight: GateWeightClass;
+  readonly defaultFleetWidth: number;
+}
+
+export interface ResolvedHostCapabilities {
+  readonly runners: readonly Runner[];
+  readonly maxGateWeight: GateWeightClass;
+  readonly defaultFleetWidth: number;
+  readonly source: "profile" | "permissive-default";
+}
+
+export interface HostGateAdmission {
+  readonly admitted: boolean;
+  readonly verdict: "admitted" | "refused-over-class";
+  readonly required: GateWeightClass;
+  readonly maximum: GateWeightClass;
+}
+
+export function evaluateHostGateAdmission(
+  profile: HostCapabilityProfile | undefined,
+  required: GateWeightClass,
+): HostGateAdmission {
+  const maximum = resolveHostCapabilities(profile).maxGateWeight;
+  const admitted =
+    GATE_WEIGHT_CLASSES.indexOf(required) <=
+    GATE_WEIGHT_CLASSES.indexOf(maximum);
+  return {
+    admitted,
+    verdict: admitted ? "admitted" : "refused-over-class",
+    required,
+    maximum,
+  };
+}
+
+export function resolveHostCapabilities(
+  profile: HostCapabilityProfile | undefined,
+): ResolvedHostCapabilities {
+  if (profile === undefined) {
+    return {
+      runners: [...runners],
+      maxGateWeight: "full-workspace",
+      defaultFleetWidth: 2,
+      source: "permissive-default",
+    };
+  }
+  const validated = validateHostCapabilityProfile(profile);
+  return {
+    runners: validated.runners,
+    maxGateWeight: validated.maxGateWeight,
+    defaultFleetWidth: validated.defaultFleetWidth,
+    source: "profile",
+  };
+}
+
+const MACHINE_ID_HASH_RE = /^[0-9a-f]{12}$/;
+
+function validateHostCapabilityProfile(value: unknown): HostCapabilityProfile {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("host capability profile must be a record");
+  }
+  const raw = value as Record<string, unknown>;
+  if (
+    typeof raw.machineIdHash !== "string" ||
+    !MACHINE_ID_HASH_RE.test(raw.machineIdHash)
+  ) {
+    throw new Error(
+      "host capability profile machineIdHash must be a 12-character lowercase hex hash",
+    );
+  }
+  if (
+    !Array.isArray(raw.runners) ||
+    raw.runners.length === 0 ||
+    !raw.runners.every(
+      (runner) => typeof runner === "string" && isRunner(runner),
+    )
+  ) {
+    throw new Error(
+      "host capability profile runners must contain supported runners",
+    );
+  }
+  if (
+    !(GATE_WEIGHT_CLASSES as readonly unknown[]).includes(raw.maxGateWeight)
+  ) {
+    throw new Error("host capability profile maxGateWeight is invalid");
+  }
+  if (
+    !Number.isSafeInteger(raw.defaultFleetWidth) ||
+    (raw.defaultFleetWidth as number) <= 0
+  ) {
+    throw new Error(
+      "host capability profile defaultFleetWidth must be a positive integer",
+    );
+  }
+  return {
+    machineIdHash: raw.machineIdHash,
+    runners: [...new Set(raw.runners as Runner[])],
+    maxGateWeight: raw.maxGateWeight as GateWeightClass,
+    defaultFleetWidth: raw.defaultFleetWidth as number,
+  };
+}
+
+export function hostCapabilityProfilePath(paths: EnginePaths): string {
+  return join(paths.castleStateRoot, "host-capability.toon");
+}
+
+export async function readHostCapabilityProfile(
+  paths: EnginePaths,
+): Promise<HostCapabilityProfile | undefined> {
+  try {
+    return validateHostCapabilityProfile(
+      decode(await readFile(hostCapabilityProfilePath(paths), "utf8")),
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+export async function writeHostCapabilityProfile(
+  paths: EnginePaths,
+  profile: HostCapabilityProfile,
+): Promise<HostCapabilityProfile> {
+  const validated = validateHostCapabilityProfile(profile);
+  const path = hostCapabilityProfilePath(paths);
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = `${path}.tmp-${process.pid}-${crypto.randomUUID()}`;
+  await writeFile(
+    temporary,
+    encode(validated as unknown as JsonValue, { keyedMapCollapse: true }),
+    "utf8",
+  );
+  await rename(temporary, path);
+  await createSingletonEventLane(paths).append({
+    singleton: "host-capabilities",
+    kind: "host.capability-profile.registered",
+    payload: {
+      machine_id_hash: validated.machineIdHash,
+      runners: [...validated.runners],
+      max_gate_weight: validated.maxGateWeight,
+      default_fleet_width: validated.defaultFleetWidth,
+    },
+  });
+  return validated;
+}

--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -24,6 +24,7 @@ export * from "./validation-cone.js";
 export * from "./worker-drain.js";
 export * from "./config.js";
 export * from "./fleet-registry.js";
+export * from "./host-capability-profile.js";
 export * from "./contracts/index.js";
 export * from "./minimax-env.js";
 export * from "./opencode-env.js";

--- a/packages/red-castle/src/engine/worker-drain.test.ts
+++ b/packages/red-castle/src/engine/worker-drain.test.ts
@@ -9,6 +9,7 @@ import {
   type CastleWorkerOutcome,
 } from "./worker-drain.js";
 import type { Runner } from "./runner-types.js";
+import type { HostCapabilityProfile } from "./host-capability-profile.js";
 
 const boot = { precheck: { ok: true } };
 const processDeps = {};
@@ -40,6 +41,7 @@ interface DrainHarnessOptions {
     name: CastleSessionHookName,
     context: string,
   ) => Promise<{ aborted: boolean }>;
+  hostProfile?: HostCapabilityProfile;
 }
 
 function makeDrainHarness(options: DrainHarnessOptions = {}) {
@@ -91,6 +93,7 @@ function makeDrainHarness(options: DrainHarnessOptions = {}) {
         iterCap: options.iterCap,
         issueTemplate: {},
         policy: options.policy,
+        hostProfile: options.hostProfile,
       },
     );
 
@@ -409,6 +412,32 @@ describe("castle worker drain", () => {
     });
     expect(harness.emitted).toEqual([
       "runner claude circuit open — stopping before claiming more issues",
+      "worker stop: runner-unavailable",
+    ]);
+  });
+
+  it("skips dispatch before claiming when the host profile lacks the selected runner", async () => {
+    const harness = makeDrainHarness({
+      runner: "claude",
+      hostProfile: {
+        machineIdHash: "8cb3eafdcbd2",
+        runners: ["codex"],
+        maxGateWeight: "full-workspace",
+        defaultFleetWidth: 2,
+      },
+    });
+
+    const result = await harness.run();
+
+    expect(harness.builtInputs).toEqual([]);
+    expect(harness.processIssue).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      blocked: 0,
+      failed: 0,
+      stopReason: "runner-unavailable",
+    });
+    expect(harness.emitted).toEqual([
+      "runner claude unavailable in host capability profile — skipping dispatch",
       "worker stop: runner-unavailable",
     ]);
   });

--- a/packages/red-castle/src/engine/worker-drain.ts
+++ b/packages/red-castle/src/engine/worker-drain.ts
@@ -1,5 +1,9 @@
 import type { FleetSelector } from "./fleet-registry.js";
 import type { Runner } from "./runner-types.js";
+import {
+  resolveHostCapabilities,
+  type HostCapabilityProfile,
+} from "./host-capability-profile.js";
 
 export interface CastleIssueCandidate {
   number: number;
@@ -21,10 +25,20 @@ export function matchesFleetSelector(
   candidate: CastleIssueCandidate,
   selector: FleetSelector,
 ): boolean {
-  if (selector.spec !== undefined && !matchesSpec(candidate, selector.spec)) return false;
-  if (selector.lane !== undefined && !hasLabel(candidate, `lane:${selector.lane}`)) return false;
-  if (selector.label !== undefined && !hasLabel(candidate, selector.label)) return false;
-  if (selector.issues !== undefined && !selector.issues.includes(candidate.number)) return false;
+  if (selector.spec !== undefined && !matchesSpec(candidate, selector.spec))
+    return false;
+  if (
+    selector.lane !== undefined &&
+    !hasLabel(candidate, `lane:${selector.lane}`)
+  )
+    return false;
+  if (selector.label !== undefined && !hasLabel(candidate, selector.label))
+    return false;
+  if (
+    selector.issues !== undefined &&
+    !selector.issues.includes(candidate.number)
+  )
+    return false;
   return true;
 }
 
@@ -78,12 +92,16 @@ export function selectCastleIssues(
   filter: CastleSelectionFilter,
   labels: CastleSelectionLabels = DEFAULT_CASTLE_SELECTION_LABELS,
 ): CastleIssueCandidate[] {
-  const excluded = candidates.filter((candidate) => !hasLabel(candidate, labels.typeSpec));
+  const excluded = candidates.filter(
+    (candidate) => !hasLabel(candidate, labels.typeSpec),
+  );
   // A named fleet's scope applies BEFORE the urgent prepend, so an urgent issue
   // another fleet owns is never pulled across the boundary into a double-claim.
   const pool =
     filter.kind === "selector"
-      ? excluded.filter((candidate) => matchesFleetSelector(candidate, filter.selector))
+      ? excluded.filter((candidate) =>
+          matchesFleetSelector(candidate, filter.selector),
+        )
       : excluded;
   const urgent = pool
     .filter((candidate) => hasLabel(candidate, labels.urgent))
@@ -93,7 +111,9 @@ export function selectCastleIssues(
   let filtered: CastleIssueCandidate[];
   switch (filter.kind) {
     case "issues": {
-      const byNumber = new Map(pool.map((candidate) => [candidate.number, candidate] as const));
+      const byNumber = new Map(
+        pool.map((candidate) => [candidate.number, candidate] as const),
+      );
       const ordered: CastleIssueCandidate[] = [];
       const missing: number[] = [];
       for (const number of filter.numbers) {
@@ -124,7 +144,10 @@ export function selectCastleIssues(
   }
 
   const urgentNumbers = new Set(urgent.map((candidate) => candidate.number));
-  return [...urgent, ...filtered.filter((candidate) => !urgentNumbers.has(candidate.number))];
+  return [
+    ...urgent,
+    ...filtered.filter((candidate) => !urgentNumbers.has(candidate.number)),
+  ];
 }
 
 export type CastleWorkerOutcome =
@@ -185,6 +208,8 @@ export interface CastleWorkerDrainContext<TIssueTemplate = unknown> {
   sweepsSkipped?: boolean;
   issueTemplate: TIssueTemplate;
   policy?: CastleWorkerDrainPolicy;
+  /** This machine's durable capability declaration. Absent keeps legacy permissive routing. */
+  hostProfile?: HostCapabilityProfile;
 }
 
 export interface CastleWorkerDrainProcessed {
@@ -224,7 +249,10 @@ export interface CastleWorkerDrainDeps<
   runBoot(deps: TBootDeps, options: TBootOptions): Promise<TBootResult>;
   bootDeps: TBootDeps;
   bootOptions: TBootOptions;
-  processIssue(deps: TProcessDeps, input: TProcessInput): Promise<TProcessResult>;
+  processIssue(
+    deps: TProcessDeps,
+    input: TProcessInput,
+  ): Promise<TProcessResult>;
   processDeps: TProcessDeps;
   buildProcessInput(
     candidate: CastleIssueCandidate,
@@ -262,8 +290,12 @@ function classify(outcome: CastleWorkerOutcome): "done" | "blocked" | "failed" {
   }
 }
 
-function budgetSpent(snapshot: CastleWorkerDrainBudgetSnapshot | undefined): boolean {
-  return snapshot !== undefined && snapshot.cap > 0 && snapshot.used >= snapshot.cap;
+function budgetSpent(
+  snapshot: CastleWorkerDrainBudgetSnapshot | undefined,
+): boolean {
+  return (
+    snapshot !== undefined && snapshot.cap > 0 && snapshot.used >= snapshot.cap
+  );
 }
 
 export async function runCastleWorkerDrain<
@@ -287,7 +319,10 @@ export async function runCastleWorkerDrain<
   ctx: CastleWorkerDrainContext<TIssueTemplate>,
 ): Promise<CastleWorkerDrainSummary<TBootResult>> {
   const sessionHooksFired: CastleSessionHookName[] = [];
-  const fireSessionHook = async (name: CastleSessionHookName, context: string): Promise<boolean> => {
+  const fireSessionHook = async (
+    name: CastleSessionHookName,
+    context: string,
+  ): Promise<boolean> => {
     if (!deps.dispatchSessionHook) return true;
     sessionHooksFired.push(name);
     const result = await deps.dispatchSessionHook(name, context);
@@ -331,13 +366,17 @@ export async function runCastleWorkerDrain<
   }
 
   try {
-    if (!(await fireSessionHook("pre_session", statsContext(0, 0, 0)))) return empty;
+    if (!(await fireSessionHook("pre_session", statsContext(0, 0, 0))))
+      return empty;
 
     await fireSessionHook("pre_pick", JSON.stringify({ filter: ctx.filter }));
     const candidates = await deps.gh.listCandidates();
     const queue = selectCastleIssues(candidates, ctx.filter, deps.labels);
     const total = queue.length;
-    await fireSessionHook("post_pick", JSON.stringify({ issues: queue.map((candidate) => candidate.number) }));
+    await fireSessionHook(
+      "post_pick",
+      JSON.stringify({ issues: queue.map((candidate) => candidate.number) }),
+    );
 
     if (total === 0) {
       await fireSessionHook("on_idle", statsContext(0, 0, 0));
@@ -356,6 +395,7 @@ export async function runCastleWorkerDrain<
     let hostConfigStop = false;
     let stopReason: CastleWorkerStopReason | undefined;
     let activeRunner: Runner = ctx.runner;
+    const hostCapabilities = resolveHostCapabilities(ctx.hostProfile);
 
     for (let i = 0; i < queue.length; i++) {
       if (ctx.policy?.supervisorKilled?.()) {
@@ -366,11 +406,17 @@ export async function runCastleWorkerDrain<
         stopReason = "budget-cap";
         break;
       }
-      if (ctx.policy?.maxRuntimeMs !== undefined && nowMs() - startedMs >= ctx.policy.maxRuntimeMs) {
+      if (
+        ctx.policy?.maxRuntimeMs !== undefined &&
+        nowMs() - startedMs >= ctx.policy.maxRuntimeMs
+      ) {
         stopReason = "lifetime-cap";
         break;
       }
-      if (ctx.policy?.maxIssues !== undefined && processed.length >= ctx.policy.maxIssues) {
+      if (
+        ctx.policy?.maxIssues !== undefined &&
+        processed.length >= ctx.policy.maxIssues
+      ) {
         stopReason = "lifetime-cap";
         break;
       }
@@ -381,15 +427,29 @@ export async function runCastleWorkerDrain<
 
       const candidate = queue[i]!;
       const issueRunner = ctx.alternate ? activeRunner : ctx.runner;
-      if (deps.runnerCircuit && (await deps.runnerCircuit.isOpen(issueRunner))) {
+      if (!hostCapabilities.runners.includes(issueRunner)) {
+        stopReason = "runner-unavailable";
+        deps.emit(
+          `runner ${issueRunner} unavailable in host capability profile — skipping dispatch`,
+        );
+        break;
+      }
+      if (
+        deps.runnerCircuit &&
+        (await deps.runnerCircuit.isOpen(issueRunner))
+      ) {
         runnerTransientStop = true;
         stopReason = "runner-unavailable";
-        deps.emit(`runner ${issueRunner} circuit open — stopping before claiming more issues`);
+        deps.emit(
+          `runner ${issueRunner} circuit open — stopping before claiming more issues`,
+        );
         break;
       }
 
       const input = deps.buildProcessInput(candidate, ctx);
-      const perIssueInput = ctx.alternate ? { ...input, runner: issueRunner } : input;
+      const perIssueInput = ctx.alternate
+        ? { ...input, runner: issueRunner }
+        : input;
       const result = await deps.processIssue(deps.processDeps, perIssueInput);
       const bucket = classify(result.outcome);
       if (bucket === "done") done++;
@@ -453,7 +513,9 @@ export async function runCastleWorkerDrain<
       JSON.stringify({
         runner: ctx.runner,
         worker_id: ctx.workerId,
-        error: { message: error instanceof Error ? error.message : String(error) },
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+        },
       }),
     );
     throw error;

--- a/packages/red-castle/src/engine/worker-drain.ts
+++ b/packages/red-castle/src/engine/worker-drain.ts
@@ -25,20 +25,10 @@ export function matchesFleetSelector(
   candidate: CastleIssueCandidate,
   selector: FleetSelector,
 ): boolean {
-  if (selector.spec !== undefined && !matchesSpec(candidate, selector.spec))
-    return false;
-  if (
-    selector.lane !== undefined &&
-    !hasLabel(candidate, `lane:${selector.lane}`)
-  )
-    return false;
-  if (selector.label !== undefined && !hasLabel(candidate, selector.label))
-    return false;
-  if (
-    selector.issues !== undefined &&
-    !selector.issues.includes(candidate.number)
-  )
-    return false;
+  if (selector.spec !== undefined && !matchesSpec(candidate, selector.spec)) return false;
+  if (selector.lane !== undefined && !hasLabel(candidate, `lane:${selector.lane}`)) return false;
+  if (selector.label !== undefined && !hasLabel(candidate, selector.label)) return false;
+  if (selector.issues !== undefined && !selector.issues.includes(candidate.number)) return false;
   return true;
 }
 
@@ -92,16 +82,12 @@ export function selectCastleIssues(
   filter: CastleSelectionFilter,
   labels: CastleSelectionLabels = DEFAULT_CASTLE_SELECTION_LABELS,
 ): CastleIssueCandidate[] {
-  const excluded = candidates.filter(
-    (candidate) => !hasLabel(candidate, labels.typeSpec),
-  );
+  const excluded = candidates.filter((candidate) => !hasLabel(candidate, labels.typeSpec));
   // A named fleet's scope applies BEFORE the urgent prepend, so an urgent issue
   // another fleet owns is never pulled across the boundary into a double-claim.
   const pool =
     filter.kind === "selector"
-      ? excluded.filter((candidate) =>
-          matchesFleetSelector(candidate, filter.selector),
-        )
+      ? excluded.filter((candidate) => matchesFleetSelector(candidate, filter.selector))
       : excluded;
   const urgent = pool
     .filter((candidate) => hasLabel(candidate, labels.urgent))
@@ -111,9 +97,7 @@ export function selectCastleIssues(
   let filtered: CastleIssueCandidate[];
   switch (filter.kind) {
     case "issues": {
-      const byNumber = new Map(
-        pool.map((candidate) => [candidate.number, candidate] as const),
-      );
+      const byNumber = new Map(pool.map((candidate) => [candidate.number, candidate] as const));
       const ordered: CastleIssueCandidate[] = [];
       const missing: number[] = [];
       for (const number of filter.numbers) {
@@ -144,10 +128,7 @@ export function selectCastleIssues(
   }
 
   const urgentNumbers = new Set(urgent.map((candidate) => candidate.number));
-  return [
-    ...urgent,
-    ...filtered.filter((candidate) => !urgentNumbers.has(candidate.number)),
-  ];
+  return [...urgent, ...filtered.filter((candidate) => !urgentNumbers.has(candidate.number))];
 }
 
 export type CastleWorkerOutcome =
@@ -249,10 +230,7 @@ export interface CastleWorkerDrainDeps<
   runBoot(deps: TBootDeps, options: TBootOptions): Promise<TBootResult>;
   bootDeps: TBootDeps;
   bootOptions: TBootOptions;
-  processIssue(
-    deps: TProcessDeps,
-    input: TProcessInput,
-  ): Promise<TProcessResult>;
+  processIssue(deps: TProcessDeps, input: TProcessInput): Promise<TProcessResult>;
   processDeps: TProcessDeps;
   buildProcessInput(
     candidate: CastleIssueCandidate,
@@ -290,12 +268,8 @@ function classify(outcome: CastleWorkerOutcome): "done" | "blocked" | "failed" {
   }
 }
 
-function budgetSpent(
-  snapshot: CastleWorkerDrainBudgetSnapshot | undefined,
-): boolean {
-  return (
-    snapshot !== undefined && snapshot.cap > 0 && snapshot.used >= snapshot.cap
-  );
+function budgetSpent(snapshot: CastleWorkerDrainBudgetSnapshot | undefined): boolean {
+  return snapshot !== undefined && snapshot.cap > 0 && snapshot.used >= snapshot.cap;
 }
 
 export async function runCastleWorkerDrain<
@@ -319,10 +293,7 @@ export async function runCastleWorkerDrain<
   ctx: CastleWorkerDrainContext<TIssueTemplate>,
 ): Promise<CastleWorkerDrainSummary<TBootResult>> {
   const sessionHooksFired: CastleSessionHookName[] = [];
-  const fireSessionHook = async (
-    name: CastleSessionHookName,
-    context: string,
-  ): Promise<boolean> => {
+  const fireSessionHook = async (name: CastleSessionHookName, context: string): Promise<boolean> => {
     if (!deps.dispatchSessionHook) return true;
     sessionHooksFired.push(name);
     const result = await deps.dispatchSessionHook(name, context);
@@ -366,17 +337,13 @@ export async function runCastleWorkerDrain<
   }
 
   try {
-    if (!(await fireSessionHook("pre_session", statsContext(0, 0, 0))))
-      return empty;
+    if (!(await fireSessionHook("pre_session", statsContext(0, 0, 0)))) return empty;
 
     await fireSessionHook("pre_pick", JSON.stringify({ filter: ctx.filter }));
     const candidates = await deps.gh.listCandidates();
     const queue = selectCastleIssues(candidates, ctx.filter, deps.labels);
     const total = queue.length;
-    await fireSessionHook(
-      "post_pick",
-      JSON.stringify({ issues: queue.map((candidate) => candidate.number) }),
-    );
+    await fireSessionHook("post_pick", JSON.stringify({ issues: queue.map((candidate) => candidate.number) }));
 
     if (total === 0) {
       await fireSessionHook("on_idle", statsContext(0, 0, 0));
@@ -406,17 +373,11 @@ export async function runCastleWorkerDrain<
         stopReason = "budget-cap";
         break;
       }
-      if (
-        ctx.policy?.maxRuntimeMs !== undefined &&
-        nowMs() - startedMs >= ctx.policy.maxRuntimeMs
-      ) {
+      if (ctx.policy?.maxRuntimeMs !== undefined && nowMs() - startedMs >= ctx.policy.maxRuntimeMs) {
         stopReason = "lifetime-cap";
         break;
       }
-      if (
-        ctx.policy?.maxIssues !== undefined &&
-        processed.length >= ctx.policy.maxIssues
-      ) {
+      if (ctx.policy?.maxIssues !== undefined && processed.length >= ctx.policy.maxIssues) {
         stopReason = "lifetime-cap";
         break;
       }
@@ -440,16 +401,12 @@ export async function runCastleWorkerDrain<
       ) {
         runnerTransientStop = true;
         stopReason = "runner-unavailable";
-        deps.emit(
-          `runner ${issueRunner} circuit open — stopping before claiming more issues`,
-        );
+        deps.emit(`runner ${issueRunner} circuit open — stopping before claiming more issues`);
         break;
       }
 
       const input = deps.buildProcessInput(candidate, ctx);
-      const perIssueInput = ctx.alternate
-        ? { ...input, runner: issueRunner }
-        : input;
+      const perIssueInput = ctx.alternate ? { ...input, runner: issueRunner } : input;
       const result = await deps.processIssue(deps.processDeps, perIssueInput);
       const bucket = classify(result.outcome);
       if (bucket === "done") done++;
@@ -513,9 +470,7 @@ export async function runCastleWorkerDrain<
       JSON.stringify({
         runner: ctx.runner,
         worker_id: ctx.workerId,
-        error: {
-          message: error instanceof Error ? error.message : String(error),
-        },
+        error: { message: error instanceof Error ? error.message : String(error) },
       }),
     );
     throw error;


### PR DESCRIPTION
Automated AFK landing for #2424. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2424

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787357207&installation_model_id=20659&pr_number=2518&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2518&signature=6882a9be5c8f878669657386ea46a77c2a0cb2ad0309be6337b9d0346632a30c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->