### PR TITLE
fix: #2464 go --scout dies pre-attempt with claim-lost on its own freshly minted issue (2x consecutive)

### DIFF
--- a/apps/dev/src/core/claim.ts
+++ b/apps/dev/src/core/claim.ts
@@ -324,13 +324,14 @@ export function reconcileClaim(
   };
 
   // Did WE just post the marker we are reconciling? True when `self.commentId`
-  // out-orders every marker the list already carries for our identity — i.e. our
-  // claim is the freshest word on the issue. A caller re-reconciling an OLD claim
+  // is at least as new as every marker the list already carries — i.e. our claim
+  // is the freshest word on the issue. Equality is required because verified
+  // read-back includes our just-posted marker. A caller re-reconciling an OLD claim
   // of its own (the returning stale owner) is not fresh, and stays subject to the
   // staleness predicate that reclaimed its issue.
   const selfPostedFresh =
     Number.isFinite(self.commentId) &&
-    records.every((r) => r.worker !== self.worker || r.commentId < self.commentId);
+    records.every((r) => r.commentId <= self.commentId);
 
   for (const r of records) ingest(r);
   // Always merge self in (read-after-write safety). Our own marker is a `claim`.

--- a/apps/dev/tests/claim.test.ts
+++ b/apps/dev/tests/claim.test.ts
@@ -354,6 +354,16 @@ describe("sole-claimant verification (#2385)", () => {
     expect(gh.conceded).toHaveLength(0);
   });
 
+  it("keeps the verified fresh claim alive when pre-boot liveness rejects its marker", async () => {
+    const gh = fakeGh([]);
+    const d = await acquireClaim(gh, { worker: "h:me" }, 5, {
+      isStale: (record) => record.worker === "h:me",
+    });
+
+    expect(d).toMatchObject({ verdict: "won", winner: "h:me" });
+    expect(gh.conceded).toHaveLength(0);
+  });
+
   it("fails loudly — never 'lost' — when the read-back never shows our claim", async () => {
     const gh = fakeGh([]);
     gh.listClaims = async () => []; // e.g. every `gh api` list call failed


### PR DESCRIPTION
Automated AFK landing for #2464. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2464

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787363890&installation_model_id=20659&pr_number=2530&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2530&signature=1292f4e23563d729c97af7960dde49d2fab9ded30f5744ed9964264d117d4b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->