### PR TITLE
fix: #2473 Boot janitor quarantines broken worktree refs (locked/initializing orphans with dangling HEAD); loud trunk-refresh errors

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -28,7 +28,7 @@ import { isRunner, type Runner } from "../../types/runner.js";
 import { zeroAttemptDispatchFailure } from "../../core/go.js";
 import {
   afkPaths,
-  collectPrecheckFacts,
+  collectBootPrecheckFacts,
   collectBootOptions,
   collectMonitorInputs,
   buildBootDeps,
@@ -196,7 +196,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
     return runReconcileWorker(flags.reconcileIssue, runner, ctx, paths, workerId);
   }
 
-  const facts = await collectPrecheckFacts(ctx);
+  const facts = await collectBootPrecheckFacts(ctx, {
+    log: (line) => process.stdout.write(`[afk] ${line}\n`),
+  });
   const nowS = Math.floor(Date.now() / 1000);
 
   // Fleet supervisor owns the boot (#623): a worker spawned by the supervisor

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -27,7 +27,7 @@ import { appendRecordToonlRow } from "../core/jsonl-log.js";
 import {
   afkPaths,
   resolveRepoSlug,
-  collectPrecheckFacts,
+  collectBootPrecheckFacts,
   collectBootOptions,
   buildBootDeps,
   readFleetState,
@@ -471,7 +471,7 @@ export function buildSupervisorBootSweeps(
   const paths = afkPaths(root, fleet);
   return async (): Promise<void> => {
     const nowS = Math.floor(Date.now() / 1000);
-    const facts = await collectPrecheckFacts(ctx);
+    const facts = await collectBootPrecheckFacts(ctx, { log });
     const bootstrap: BootstrapInput = {
       tmpDir: paths.tmpDir,
       stateDir: paths.stateDir,

--- a/apps/dev/src/core/supervisor/envelopes.ts
+++ b/apps/dev/src/core/supervisor/envelopes.ts
@@ -1,6 +1,8 @@
 import { buildEnvelope } from "../envelope.js";
+import { renderClaimComment } from "../claim.js";
 import { renderLogTailToon } from "../envelope-emit.js";
 import { dispose } from "../disposition.js";
+import { workerIdentity } from "../host-identity.js";
 import { LABEL_READY, LABEL_RUNNING } from "../triage-labels.js";
 import type { IterDirInfo, SupervisorDeps } from "./types.js";
 
@@ -120,6 +122,10 @@ export async function reconcileDeadWorkerClaim(
   if (!claim.envelopePosted) {
     await deps.gh.comment(info.issue, buildCrashEnvelope(info));
   }
+  await deps.gh.comment(
+    info.issue,
+    renderClaimComment({ worker: workerIdentity(info.workerId) }, "concede", "released"),
+  );
 
   // 2. Bounded blocked:crashed recovery via the disposition composer (#402,
   // #822), mirroring the stall-reaper path below. The death-without-envelope
@@ -145,4 +151,3 @@ export async function reconcileDeadWorkerClaim(
 }
 
 // ---------- actions (compose deciders, apply via injected IO) ----------
-

--- a/apps/dev/src/core/supervisor/reaper.ts
+++ b/apps/dev/src/core/supervisor/reaper.ts
@@ -67,6 +67,14 @@ export async function sweepParkedSlot(
           work.supervisorLogPath,
         );
         await deps.gh.comment(pair.issue, body);
+        await deps.gh.comment(
+          pair.issue,
+          renderClaimComment(
+            { worker: workerIdentity(worker.workerId), runner: config.runner },
+            "concede",
+            "released",
+          ),
+        );
         await deps.gh.editLabels(
           pair.issue,
           [LABEL_READY, LABEL_RUNNER_ERROR],

--- a/apps/dev/src/core/supervisor/reaper.ts
+++ b/apps/dev/src/core/supervisor/reaper.ts
@@ -1,6 +1,8 @@
 import { encode as encodeToon } from "@reddb-io/toon";
+import { renderClaimComment } from "../claim.js";
 import { decideReaperSignal, deriveSnapshot } from "../reaper-signal.js";
 import { dispose } from "../disposition.js";
+import { workerIdentity } from "../host-identity.js";
 import { validateIssueLifecycleTransition } from "../issue-lifecycle.js";
 import {
   LABEL_CONTESTED,
@@ -125,6 +127,10 @@ export async function reapStalledSlot(
   // exactly like the per-issue routeRecovery escalation.
   if (info && info.issue !== null) {
     await deps.gh.comment(info.issue, buildReaperEnvelope(info));
+    await deps.gh.comment(
+      info.issue,
+      renderClaimComment({ worker: workerIdentity(info.workerId) }, "concede", "released"),
+    );
     // The composer owns the bounded re-claim decision + label sets + the
     // budget-exhausted page comment (core/disposition, total map → `stalled` is
     // recoverable, #402). gh.editLabels here is the (issue, add, remove) shape,

--- a/apps/dev/src/core/supervisor/tick.ts
+++ b/apps/dev/src/core/supervisor/tick.ts
@@ -61,6 +61,9 @@ async function refreshTrunkMirrorIfDue(
       message: err instanceof Error ? err.message : String(err),
     };
   }
+  if (outcome.status === "failed") {
+    deps.log?.(`trunk mirror refresh failed: ${outcome.message ?? "unknown git error"}`);
+  }
   state.lastTrunkFreshness = outcome;
   return outcome;
 }

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -340,6 +340,7 @@ export async function resolveFreshBase(
     }
     const updated = await runGit(ctx, ["update-ref", FLEET_TRUNK_REF, remoteSha]);
     if (updated.code !== 0) {
+      const detail = updated.stderr.trim() || `git update-ref exited ${updated.code}`;
       return {
         ok: false,
         base,
@@ -348,7 +349,7 @@ export async function resolveFreshBase(
         source: "mirror",
         remoteReachable: true,
         reason: "base-stale",
-        message: `could not update fleet trunk mirror ${FLEET_TRUNK} from ${remoteRef}`,
+        message: `could not update fleet trunk mirror ${FLEET_TRUNK} from ${remoteRef}: ${detail}`,
       };
     }
     return {
@@ -361,6 +362,10 @@ export async function resolveFreshBase(
     };
   }
 
+  const detail = fetch.code !== 0
+    ? fetch.stderr.trim() || `git fetch exited ${fetch.code}`
+    : `${remoteRef} did not resolve after fetch`;
+
   return {
     ok: false,
     base,
@@ -369,7 +374,7 @@ export async function resolveFreshBase(
     source: "mirror",
     remoteReachable: false,
     reason: "base-stale",
-    message: `could not refresh fleet trunk mirror ${FLEET_TRUNK} from ${remoteRef}`,
+    message: `could not refresh fleet trunk mirror ${FLEET_TRUNK} from ${remoteRef}: ${detail}`,
   };
 }
 

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -49,6 +49,82 @@ function runGit(ctx: GitContext, args: readonly string[]): Promise<ExecOutput> {
   return (ctx.exec ?? execTool)("git", args, opts(ctx));
 }
 
+interface PorcelainWorktree {
+  path: string;
+  head?: string;
+  locked?: string;
+}
+
+export interface BrokenWorktreeQuarantine {
+  path: string;
+  reason: string;
+  removed: boolean;
+  error?: string;
+}
+
+function parseWorktreePorcelain(output: string): PorcelainWorktree[] {
+  const worktrees: PorcelainWorktree[] = [];
+  let current: PorcelainWorktree | undefined;
+  for (const line of output.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      if (current) worktrees.push(current);
+      current = { path: line.slice("worktree ".length) };
+    } else if (current && line.startsWith("HEAD ")) {
+      current.head = line.slice("HEAD ".length).trim();
+    } else if (current && (line === "locked" || line.startsWith("locked "))) {
+      current.locked = line.slice("locked".length).trim();
+    }
+  }
+  if (current) worktrees.push(current);
+  return worktrees;
+}
+
+/**
+ * Remove linked worktrees that can poison every repository-level git command.
+ * Git leaves an `initializing` lock while `worktree add` is in flight; a killed
+ * creator can strand that lock with a HEAD whose object was later collected.
+ * `git worktree remove --force` refuses locked entries, so quarantine first
+ * unlocks, then force-removes, and finally prunes the shared registry.
+ *
+ * The first porcelain entry is the primary checkout and is never eligible.
+ * Healthy linked worktrees, including deliberately locked ones whose reason is
+ * not `initializing`, are left untouched.
+ */
+export async function quarantineBrokenWorktrees(
+  ctx: GitContext,
+): Promise<BrokenWorktreeQuarantine[]> {
+  const listed = await runGit(ctx, ["worktree", "list", "--porcelain"]);
+  if (listed.code !== 0) return [];
+
+  const quarantined: BrokenWorktreeQuarantine[] = [];
+  const linked = parseWorktreePorcelain(listed.stdout).slice(1);
+  for (const worktree of linked) {
+    const initializing = worktree.locked === "initializing";
+    const head = worktree.head;
+    const headExists = head
+      ? (await runGit(ctx, ["cat-file", "-e", `${head}^{commit}`])).code === 0
+      : false;
+    if (!initializing && headExists) continue;
+
+    const reasons = [initializing ? "initializing-lock" : "", !headExists ? "dangling-head" : ""]
+      .filter(Boolean)
+      .join(",");
+    await runGit(ctx, ["worktree", "unlock", worktree.path]);
+    const removed = await runGit(ctx, ["worktree", "remove", "--force", worktree.path]);
+    quarantined.push({
+      path: worktree.path,
+      reason: reasons,
+      removed: removed.code === 0,
+      ...(removed.code === 0
+        ? {}
+        : { error: removed.stderr.trim() || `git worktree remove exited ${removed.code}` }),
+    });
+  }
+
+  if (quarantined.length > 0) await runGit(ctx, ["worktree", "prune"]);
+  return quarantined;
+}
+
 export async function isGitRepo(ctx: GitContext): Promise<boolean> {
   const r = await runGit(ctx, ["rev-parse", "--is-inside-work-tree"]);
   return r.code === 0 && r.stdout.trim() === "true";

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -46,5 +46,11 @@ export { collectStatuslineDocs, collectDocsSweepInput, landDocsSweep } from "./w
 export type { ReapInputs } from "./wire/reap.js";
 export { collectReapInputs } from "./wire/reap.js";
 
-export type { CollectPrecheckFactsOptions } from "./wire/boot.js";
-export { collectBootOptions, collectPrecheckFacts, buildBootDeps, buildMinimalBootDeps } from "./wire/boot.js";
+export type { CollectPrecheckFactsOptions, CollectBootPrecheckFactsOptions } from "./wire/boot.js";
+export {
+  collectBootOptions,
+  collectPrecheckFacts,
+  collectBootPrecheckFacts,
+  buildBootDeps,
+  buildMinimalBootDeps,
+} from "./wire/boot.js";

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -111,6 +111,33 @@ export interface CollectPrecheckFactsOptions {
   readonly hostPrerequisiteExec?: ExecFn;
 }
 
+export interface CollectBootPrecheckFactsOptions extends CollectPrecheckFactsOptions {
+  readonly log?: (line: string) => void;
+}
+
+/**
+ * Boot-only precheck collector. The worktree quarantine must run before any
+ * fetch-backed operational probe: a single initializing worktree with a
+ * dangling HEAD can otherwise make the probe itself fail on every boot.
+ * Read-only callers such as red-doctor continue to use collectPrecheckFacts.
+ */
+export async function collectBootPrecheckFacts(
+  ctx: RepoContext,
+  options: CollectBootPrecheckFactsOptions = {},
+): Promise<PrecheckFacts> {
+  const quarantined = await gitx.quarantineBrokenWorktrees({ cwd: ctx.root });
+  for (const worktree of quarantined) {
+    if (worktree.removed) {
+      options.log?.(`boot janitor quarantined worktree path=${worktree.path} reason=${worktree.reason}`);
+    } else {
+      options.log?.(
+        `boot janitor failed to quarantine worktree path=${worktree.path} reason=${worktree.reason}: ${worktree.error ?? "unknown git error"}`,
+      );
+    }
+  }
+  return collectPrecheckFacts(ctx, options);
+}
+
 export async function collectHostPrerequisiteProbeInput(
   exec: ExecFn = execTool,
 ): Promise<HostPrerequisiteProbeInput> {

--- a/apps/dev/tests/boot-runtime.test.ts
+++ b/apps/dev/tests/boot-runtime.test.ts
@@ -108,6 +108,49 @@ describe("runBoot precheck short-circuit", () => {
     );
   });
 
+  it("auto-concedes a seeded same-machine dead-pid ghost claim and continues boot", async () => {
+    const concedeClaim = vi.fn(async (_issue: number, _body: string) => {});
+    const log = vi.fn();
+    const { deps, fsCalls } = makeDeps({ log });
+    deps.concedeClaim = concedeClaim;
+
+    const result = await runBoot(
+      deps,
+      options({
+        skipSweeps: true,
+        operationalProbes: {
+          remoteUrls: [],
+          claimHygiene: {
+            ownWorkerPrefix: "testhost:",
+            listOpenQueueIssues: async () => [
+              {
+                number: 2473,
+                comments: [
+                  {
+                    id: 10,
+                    body: "<!-- afk:claim v1 worker=testhost:wGHOST kind=claim runner=codex -->",
+                  },
+                ],
+              },
+            ],
+            workerPidState: () => "dead",
+          },
+        },
+      }),
+    );
+
+    expect(result.bootstrap).toEqual({ ok: true });
+    expect(fsCalls.workerPid).toHaveLength(1);
+    expect(concedeClaim).toHaveBeenCalledOnce();
+    expect(concedeClaim.mock.calls[0]?.[0]).toBe(2473);
+    expect(concedeClaim.mock.calls[0]?.[1]).toContain(
+      "worker=testhost:wGHOST kind=concede runner=codex",
+    );
+    expect(log).toHaveBeenCalledWith(
+      "boot operational probe auto-fix applied: afk.claim-hygiene; posted 1 concede marker",
+    );
+  });
+
   it("auto-applies guarded base-freshness before bootstrap and logs the before/after SHAs", async () => {
     const fastForwardLocalBase = vi.fn(async () => ({
       action: "fast-forward" as const,

--- a/apps/dev/tests/runtime-git-branch.test.ts
+++ b/apps/dev/tests/runtime-git-branch.test.ts
@@ -132,7 +132,9 @@ describe("resolveFreshBase (worker base freshness)", () => {
   it("parks typed when origin cannot refresh the mirror instead of falling back to the primary branch", async () => {
     const { exec } = recordingExec((_cmd, args) => {
       const joined = args.join(" ");
-      if (joined === "fetch origin main") return fail();
+      if (joined === "fetch origin main") {
+        return { code: 128, stdout: "", stderr: "fatal: bad object refs/worktree/HEAD" };
+      }
       if (joined === "rev-parse --verify --quiet origin/main") return ok("remote-tip\n");
       return fail();
     });
@@ -144,6 +146,7 @@ describe("resolveFreshBase (worker base freshness)", () => {
       sha: "remote-tip",
       source: "mirror",
       remoteReachable: false,
+      message: expect.stringContaining("fatal: bad object refs/worktree/HEAD"),
     });
   });
 });

--- a/apps/dev/tests/supervisor-boot.test.ts
+++ b/apps/dev/tests/supervisor-boot.test.ts
@@ -140,7 +140,7 @@ describe("runSupervisor — supervisor owns the boot (#623)", () => {
           id: "git.remote.https-forbidden",
           name: "SSH-only git remotes",
           verdict: "red",
-          evidence: "1 forbidden https remote observed",
+          evidence: "git fetch failed: fatal: bad object refs/worktree/HEAD",
           canonicalFix: "Use SSH git remotes for local AFK boot.",
         });
       }),
@@ -151,6 +151,7 @@ describe("runSupervisor — supervisor owns the boot (#623)", () => {
 
     expect(spawnSlot).not.toHaveBeenCalled();
     expect(log.mock.calls.some((c) => String(c[0]).includes("SSH-only git remotes"))).toBe(true);
+    expect(log.mock.calls.some((c) => String(c[0]).includes("fatal: bad object refs/worktree/HEAD"))).toBe(true);
     expect(log.mock.calls.some((c) => String(c[0]).includes("Use SSH git remotes"))).toBe(true);
   });
 

--- a/apps/dev/tests/supervisor.config-stall.test.ts
+++ b/apps/dev/tests/supervisor.config-stall.test.ts
@@ -656,10 +656,13 @@ describe("circuit trip — real FS integration (slot-log boot-stamp path)", () =
       expect(slot.parked).toBe(true);
 
       // Discard envelope posted only for the worker that held a claim (#99).
-      expect(io.comment).toHaveBeenCalledOnce();
-      const [issue, body] = io.comment.mock.calls[0]!;
+      expect(io.comment).toHaveBeenCalledTimes(2);
+      const [issue, body] = io.comment.mock.calls.find((call) =>
+        String(call[1]).includes('data-attempt-status="discarded"'),
+      )!;
       expect(issue).toBe(99);
       expect(body).toContain('data-attempt-status="discarded"');
+      expect(io.comment.mock.calls.some((call) => String(call[1]).includes("kind=concede"))).toBe(true);
       // Fast-death count must reflect the circuit ring (5 deaths), not 0.
       expect(body).toContain("fast deaths: 5");
       expect(body).toContain("slot parked after 5 fast deaths");
@@ -1055,8 +1058,10 @@ describe("pollStallDetector reaper gating", () => {
     expect(reaped).toEqual([0]);
     expect(io.killTree).toHaveBeenCalledWith(4242);
     // The reap envelope plus a self-explanatory "budget exhausted" page comment.
-    expect(io.comment).toHaveBeenCalledTimes(2);
-    const pageBody = io.comment.mock.calls[1]![1] as string;
+    expect(io.comment).toHaveBeenCalledTimes(3);
+    const pageBody = io.comment.mock.calls.find((call) =>
+      String(call[1]).includes("ready-for-human"),
+    )![1] as string;
     expect(pageBody).toContain("ready-for-human");
     expect(pageBody).toContain("attempt 3/3");
     // Escalation carries blocked:stalled (allowed alongside ready-for-human) and

--- a/apps/dev/tests/supervisor.config-stall.test.ts
+++ b/apps/dev/tests/supervisor.config-stall.test.ts
@@ -552,10 +552,13 @@ describe("circuit trip and sweep", () => {
     expect(slot.swept).toBe(true);
     expect(io.spawnSlot).not.toHaveBeenCalled();
     // Discard envelope posted + labels restored for the claimed issue.
-    expect(io.comment).toHaveBeenCalledOnce();
-    const [issue, body] = io.comment.mock.calls[0]!;
+    expect(io.comment).toHaveBeenCalledTimes(2);
+    const [issue, body] = io.comment.mock.calls.find((call) =>
+      String(call[1]).includes('data-attempt-status="discarded"'),
+    )!;
     expect(issue).toBe(7);
     expect(body).toContain('data-attempt-status="discarded"');
+    expect(io.comment.mock.calls.some((call) => String(call[1]).includes("kind=concede"))).toBe(true);
     expect(io.editLabels).toHaveBeenCalledWith(
       7,
       ["ready-for-agent", "runner-error"],

--- a/apps/dev/tests/supervisor.config-stall.test.ts
+++ b/apps/dev/tests/supervisor.config-stall.test.ts
@@ -868,11 +868,14 @@ describe("pollStallDetector reaper gating", () => {
 
     expect(reaped).toEqual([0]);
     expect(io.killTree).toHaveBeenCalledWith(4242);
-    expect(io.comment).toHaveBeenCalledOnce();
-    const [issue, body] = io.comment.mock.calls[0]!;
+    expect(io.comment).toHaveBeenCalledTimes(2);
+    const [issue, body] = io.comment.mock.calls.find((call) =>
+      String(call[1]).includes('data-attempt-status="no-sentinel"'),
+    )!;
     expect(issue).toBe(190);
     expect(body).toContain('data-attempt-status="no-sentinel"');
     expect(body).toContain("stalled tool call");
+    expect(io.comment.mock.calls.some((call) => String(call[1]).includes("kind=concede"))).toBe(true);
     // #1197: the retry first opens a bounded contest window. The issue is not
     // ready-for-agent yet, so a second worker cannot double-run it while the
     // original branch may still report late commits.

--- a/apps/dev/tests/supervisor.tick-run.test.ts
+++ b/apps/dev/tests/supervisor.tick-run.test.ts
@@ -328,10 +328,13 @@ describe("reconcileDeadWorkerClaim", () => {
 
     expect(issue).toBe(807);
     // No-sentinel envelope carrying the afk.log tail.
-    expect(io.comment).toHaveBeenCalledTimes(1);
-    const body = io.comment.mock.calls[0]![1] as string;
+    expect(io.comment).toHaveBeenCalledTimes(2);
+    const body = io.comment.mock.calls.find((call) =>
+      String(call[1]).includes('data-attempt-status="no-sentinel"'),
+    )![1] as string;
     expect(body).toContain('data-attempt-status="no-sentinel"');
     expect(body).toContain("agent finished after 1 iteration");
+    expect(io.comment.mock.calls.some((call) => String(call[1]).includes("kind=concede"))).toBe(true);
     // running → ready-for-agent CLEAN (no blocked label rides along).
     expect(io.editLabels).toHaveBeenCalledWith(807, ["ready-for-agent"], ["running"]);
   });

--- a/apps/dev/tests/supervisor.tick-run.test.ts
+++ b/apps/dev/tests/supervisor.tick-run.test.ts
@@ -362,7 +362,9 @@ describe("reconcileDeadWorkerClaim", () => {
     deps.recoveryEnv = { RED_AFK_RETRY_CRASH: "2" };
 
     await reconcileDeadWorkerClaim(crashInfo(), deps);
-    expect(io.comment).not.toHaveBeenCalled();
+    expect(io.comment).toHaveBeenCalledOnce();
+    expect(String(io.comment.mock.calls[0]?.[1])).toContain("kind=concede");
+    expect(String(io.comment.mock.calls[0]?.[1])).not.toContain('data-attempt-status="no-sentinel"');
     expect(io.editLabels).toHaveBeenCalledWith(807, ["ready-for-agent"], ["running"]);
   });
 

--- a/apps/dev/tests/supervisor.trunk-half-open.test.ts
+++ b/apps/dev/tests/supervisor.trunk-half-open.test.ts
@@ -463,7 +463,7 @@ describe("half-open circuit breaker: probe outcome — re-park on failure", () =
     await handleDeadSlot(0, slot, deps, config({ circuitK: 5, halfOpenBaseS: 60, halfOpenCapS: 3600 }));
     expect(slot.parked).toBe(true);
     expect(slot.swept).toBe(true);
-    expect(io.comment).toHaveBeenCalledTimes(1); // discard envelope posted
+    expect(io.comment).toHaveBeenCalledTimes(2); // discard envelope + claim concession
 
     // Now simulate a probe fast-death: swept should block re-sweep.
     io.comment.mockClear();

--- a/apps/dev/tests/supervisor.trunk-half-open.test.ts
+++ b/apps/dev/tests/supervisor.trunk-half-open.test.ts
@@ -135,6 +135,7 @@ describe("superviseTick — continuous trunk freshness (#2074)", () => {
       refreshedAtEpoch: NOW,
       intervalS: 60,
     });
+    expect(io.logLines).toContain("trunk mirror refresh failed: fetch failed");
   });
 
   it("surfaces the latest freshness outcome in heartbeat and structured tick events", async () => {

--- a/apps/dev/tests/worktree-quarantine.test.ts
+++ b/apps/dev/tests/worktree-quarantine.test.ts
@@ -1,0 +1,57 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { quarantineBrokenWorktrees } from "../src/runtime/git.js";
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout.trim();
+}
+
+async function setupRepo(): Promise<{ repo: string; worktree: string }> {
+  const root = await mkdtemp(join(tmpdir(), "boot-worktree-quarantine-"));
+  const remote = join(root, "origin.git");
+  const repo = join(root, "repo");
+  const worktree = join(root, "worker-worktree");
+
+  await git(root, ["init", "--bare", "--initial-branch=main", remote]);
+  await git(root, ["init", "--initial-branch=main", repo]);
+  await git(repo, ["config", "user.email", "agent@example.test"]);
+  await git(repo, ["config", "user.name", "Agent"]);
+  await writeFile(join(repo, "tracked.txt"), "initial\n", "utf8");
+  await git(repo, ["add", "tracked.txt"]);
+  await git(repo, ["commit", "-m", "initial"]);
+  await git(repo, ["remote", "add", "origin", remote]);
+  await git(repo, ["push", "-u", "origin", "main"]);
+  await git(repo, ["worktree", "add", "-b", "afk/test/2473-broken", worktree, "HEAD"]);
+
+  return { repo, worktree };
+}
+
+describe("boot worktree quarantine", () => {
+  it("quarantines an initializing locked worktree with a dangling HEAD before git probes", async () => {
+    const { repo, worktree } = await setupRepo();
+    const gitDir = await git(repo, ["rev-parse", "--absolute-git-dir"]);
+    const [entryName] = await readdir(join(gitDir, "worktrees"));
+    const entry = join(gitDir, "worktrees", entryName!);
+    await writeFile(join(entry, "locked"), "initializing\n", "utf8");
+    await writeFile(join(entry, "HEAD"), `${"0".repeat(40)}\n`, "utf8");
+
+    const result = await quarantineBrokenWorktrees({ cwd: repo });
+
+    expect(result).toEqual([
+      {
+        path: worktree,
+        reason: "initializing-lock,dangling-head",
+        removed: true,
+      },
+    ]);
+    expect(await git(repo, ["worktree", "list", "--porcelain"])).not.toContain(worktree);
+    await expect(git(repo, ["fetch", "origin", "main"])).resolves.toBe("");
+  });
+});

--- a/apps/dev/tests/worktree-quarantine.test.ts
+++ b/apps/dev/tests/worktree-quarantine.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
+import { runOperationalProbes } from "../src/core/operational-probes.js";
 import { quarantineBrokenWorktrees } from "../src/runtime/git.js";
+import { collectBootPrecheckFacts } from "../src/runtime/wire/boot.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -33,14 +35,18 @@ async function setupRepo(): Promise<{ repo: string; worktree: string }> {
   return { repo, worktree };
 }
 
+async function poisonWorktree(repo: string): Promise<void> {
+  const gitDir = await git(repo, ["rev-parse", "--absolute-git-dir"]);
+  const [entryName] = await readdir(join(gitDir, "worktrees"));
+  const entry = join(gitDir, "worktrees", entryName!);
+  await writeFile(join(entry, "locked"), "initializing\n", "utf8");
+  await writeFile(join(entry, "HEAD"), `${"0".repeat(40)}\n`, "utf8");
+}
+
 describe("boot worktree quarantine", () => {
   it("quarantines an initializing locked worktree with a dangling HEAD before git probes", async () => {
     const { repo, worktree } = await setupRepo();
-    const gitDir = await git(repo, ["rev-parse", "--absolute-git-dir"]);
-    const [entryName] = await readdir(join(gitDir, "worktrees"));
-    const entry = join(gitDir, "worktrees", entryName!);
-    await writeFile(join(entry, "locked"), "initializing\n", "utf8");
-    await writeFile(join(entry, "HEAD"), `${"0".repeat(40)}\n`, "utf8");
+    await poisonWorktree(repo);
 
     const result = await quarantineBrokenWorktrees({ cwd: repo });
 
@@ -53,5 +59,23 @@ describe("boot worktree quarantine", () => {
     ]);
     expect(await git(repo, ["worktree", "list", "--porcelain"])).not.toContain(worktree);
     await expect(git(repo, ["fetch", "origin", "main"])).resolves.toBe("");
+  });
+
+  it("runs quarantine before collecting operational probe facts", async () => {
+    const { repo, worktree } = await setupRepo();
+    await poisonWorktree(repo);
+    const log: string[] = [];
+
+    const facts = await collectBootPrecheckFacts(
+      { root: repo, repo: "", remote: "origin" },
+      { log: (line) => log.push(line) },
+    );
+    const probes = await runOperationalProbes(facts);
+
+    expect(probes.findings.map((finding) => finding.id)).not.toContain("afk.base-freshness");
+    expect(await git(repo, ["worktree", "list", "--porcelain"])).not.toContain(worktree);
+    expect(log).toEqual([
+      `boot janitor quarantined worktree path=${worktree} reason=initializing-lock,dangling-head`,
+    ]);
   });
 });

--- a/packages/red-castle/src/WorktreeManager.test.ts
+++ b/packages/red-castle/src/WorktreeManager.test.ts
@@ -180,6 +180,27 @@ describe("WorktreeManager.create", () => {
     expect((await stat(path)).isDirectory()).toBe(true);
   });
 
+  it("cleans a locked dangling worktree when initialization fails", async () => {
+    const repoDir = await setupRepo();
+    const workspace = await mkdtemp(join(tmpdir(), "worker-workspace-"));
+    const worktreePath = join(workspace, "worktree");
+    await run(create(repoDir, { branch: "init-crash", path: worktreePath }));
+    const gitDir = (await execAsync("git rev-parse --absolute-git-dir", { cwd: repoDir })).stdout.trim();
+    const [entryName] = await readdir(join(gitDir, "worktrees"));
+    const entry = join(gitDir, "worktrees", entryName!);
+    await writeFile(join(entry, "locked"), "initializing\n");
+    await writeFile(join(entry, "HEAD"), `${"0".repeat(40)}\n`);
+
+    await expect(
+      run(create(repoDir, { branch: "init-crash", path: worktreePath })),
+    ).rejects.toThrow();
+
+    const { stdout } = await execAsync("git worktree list --porcelain", {
+      cwd: repoDir,
+    });
+    expect(stdout).not.toContain(worktreePath);
+  });
+
   it("returns the branch name", async () => {
     const repoDir = await setupRepo();
     const { branch } = await run(create(repoDir));

--- a/packages/red-castle/src/WorktreeManager.ts
+++ b/packages/red-castle/src/WorktreeManager.ts
@@ -120,6 +120,10 @@ export interface WorktreeEntry {
   path: string;
   /** `null` for a detached HEAD (e.g. mid-rebase). */
   branch: string | null;
+  /** Resolved HEAD object printed by git porcelain. */
+  head?: string;
+  /** Git worktree lock reason, when present. */
+  locked?: string;
 }
 
 /**
@@ -173,27 +177,81 @@ const listWorktrees = (
       const entries: WorktreeEntry[] = [];
       let currentPath: string | null = null;
       let currentBranch: string | null = null;
+      let currentHead: string | undefined;
+      let currentLocked: string | undefined;
 
       for (const line of output.split("\n")) {
         if (line.startsWith("worktree ")) {
           if (currentPath !== null) {
-            entries.push({ path: currentPath, branch: currentBranch });
+            entries.push({
+              path: currentPath,
+              branch: currentBranch,
+              ...(currentHead ? { head: currentHead } : {}),
+              ...(currentLocked !== undefined ? { locked: currentLocked } : {}),
+            });
           }
           currentPath = line.slice("worktree ".length).trim();
           currentBranch = null;
+          currentHead = undefined;
+          currentLocked = undefined;
+        } else if (line.startsWith("HEAD ")) {
+          currentHead = line.slice("HEAD ".length).trim();
         } else if (line.startsWith("branch ")) {
           // "branch refs/heads/my-branch" -> "my-branch"
           currentBranch = line.slice("branch refs/heads/".length).trim();
+        } else if (line === "locked" || line.startsWith("locked ")) {
+          currentLocked = line.slice("locked".length).trim();
         }
       }
 
       if (currentPath !== null) {
-        entries.push({ path: currentPath, branch: currentBranch });
+        entries.push({
+          path: currentPath,
+          branch: currentBranch,
+          ...(currentHead ? { head: currentHead } : {}),
+          ...(currentLocked !== undefined ? { locked: currentLocked } : {}),
+        });
       }
 
       return entries;
     }),
   );
+
+/** Best-effort rollback for a failed create. Healthy registered worktrees are
+ * never removed: only the exact target with git's `initializing` lock or an
+ * unresolvable HEAD is eligible. */
+const cleanupFailedCreation = (
+  repoDir: string,
+  worktreePath: string,
+): Effect.Effect<void, never> =>
+  Effect.gen(function* () {
+    const worktrees = yield* listWorktrees(repoDir).pipe(
+      Effect.catchAll(() => Effect.succeed([])),
+    );
+    const entry = worktrees.find(
+      (candidate) => toPosix(candidate.path) === toPosix(worktreePath),
+    );
+    if (!entry) return;
+
+    const headExists = entry.head
+      ? yield* execGit(["cat-file", "-e", `${entry.head}^{commit}`], repoDir).pipe(
+          Effect.as(true),
+          Effect.catchAll(() => Effect.succeed(false)),
+        )
+      : false;
+    if (entry.locked !== "initializing" && headExists) return;
+
+    yield* execGit(["worktree", "unlock", worktreePath], repoDir).pipe(
+      Effect.catchAll(() => Effect.void),
+    );
+    yield* execGit(
+      ["worktree", "remove", "--force", worktreePath],
+      repoDir,
+    ).pipe(Effect.catchAll(() => Effect.void));
+    yield* execGit(["worktree", "prune"], repoDir).pipe(
+      Effect.catchAll(() => Effect.void),
+    );
+  });
 
 /**
  * On the clean-reuse path, fetches `origin/<branch>` into the worktree and
@@ -305,8 +363,9 @@ export const create = (
   WorktreeInfo,
   WorktreeError | WorktreeTimeoutError,
   FileSystem.FileSystem
-> =>
-  Effect.gen(function* () {
+> => {
+  let cleanupPath: string | undefined;
+  return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const worktreesDir = join(repoDir, ".red-castle", "worktrees");
     const explicitWorktreePath = opts?.path
@@ -342,6 +401,7 @@ export const create = (
 
     const worktreePath =
       explicitWorktreePath ?? join(worktreesDir, worktreeName);
+    cleanupPath = worktreePath;
 
     if (opts?.branch) {
       // Proactively detect collision before git produces a confusing error.
@@ -446,7 +506,13 @@ export const create = (
           operation: "create",
         }),
     ),
+    Effect.tapErrorCause(() =>
+      cleanupPath
+        ? cleanupFailedCreation(repoDir, cleanupPath)
+        : Effect.void,
+    ),
   );
+};
 
 /**
  * Returns true if the worktree at `worktreePath` has any uncommitted changes:


### PR DESCRIPTION
Automated AFK landing for #2473. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2473

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787367212&installation_model_id=20659&pr_number=2532&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2532&signature=c25e9b83e403009d09742cd1b48939cbc5d544e8fe981c9190309b765ad698b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->