### PR TITLE
merge: #2471 fleet_create idempotent respawn: dead-but-registered profile adopts and respawns with adoptSlotPids

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -831,9 +831,7 @@ async function fleetStatus(root: string, input: FleetNameInput) {
 
 async function createFleet(root: string, input: FleetCreateInput) {
   const path = registryPath(root);
-  if (await readFleetProfile(path, input.name)) {
-    throw new Error(`fleet ${JSON.stringify(input.name)} already exists`);
-  }
+  const existing = await readFleetProfile(path, input.name);
   const paths = afkPaths(root, input.name);
   const running = await discoverLiveSupervisorPid(
     paths.supervisorRuntimeDir,
@@ -841,10 +839,17 @@ async function createFleet(root: string, input: FleetCreateInput) {
     { fleet: paths.fleet },
   );
   if (running) {
+    if (existing) {
+      throw new Error(`fleet ${JSON.stringify(input.name)} already exists`);
+    }
     throw new Error(`fleet ${JSON.stringify(paths.fleet)} is already running`);
   }
 
-  const profile = await upsertFleetProfile(path, profileForCreate(input));
+  const profile =
+    existing ?? (await upsertFleetProfile(path, profileForCreate(input)));
+  const priorFleetState = await readFleetState(paths.fleetStatePath).catch(
+    () => null,
+  );
   let supervisorLogStart: number | undefined;
   try {
     supervisorLogStart = (await stat(paths.supervisorLogPath)).size;
@@ -861,6 +866,7 @@ async function createFleet(root: string, input: FleetCreateInput) {
     passthrough: profile.selector
       ? ["--selector", JSON.stringify(profile.selector)]
       : [],
+    adoptSlotPids: priorFleetState?.slotPids ?? [],
   });
   if (pid === null) {
     let rollbackConfirmed = false;

--- a/apps/dev/tests/mcp-fleet-create.test.ts
+++ b/apps/dev/tests/mcp-fleet-create.test.ts
@@ -6,6 +6,7 @@ import {
   fleetRegistryPath,
   readFleetProfile,
   removeFleetProfile,
+  upsertFleetProfile,
 } from "@reddb-io/red-castle/engine";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -63,6 +64,85 @@ describe("fleet_create startup probe", () => {
       target: 2,
       profile: { name: "healthy", runner: "codex" },
     });
+  });
+
+  it("respawns a dead registered fleet from its persisted profile", async () => {
+    const cwd = await root();
+    await upsertFleetProfile(
+      fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),
+      {
+        name: "recoverable",
+        runner: "claude",
+        selector: { spec: 2467 },
+      },
+    );
+    vi.mocked(spawnSupervisor).mockResolvedValue(43121);
+
+    await expect(
+      createCastleMcpDependencies(cwd).fleetCreate({
+        name: "recoverable",
+        runner: "codex",
+        target: 2,
+      }),
+    ).resolves.toMatchObject({
+      status: "launched",
+      pid: 43121,
+      target: 2,
+      profile: {
+        name: "recoverable",
+        runner: "claude",
+        selector: { spec: 2467 },
+      },
+    });
+    expect(spawnSupervisor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fleet: "recoverable",
+        runner: "claude",
+        passthrough: ["--selector", JSON.stringify({ spec: 2467 })],
+      }),
+    );
+  });
+
+  it("passes persisted slot pids to the respawn for worker adoption", async () => {
+    const cwd = await root();
+    const paths = afkPaths(cwd, "adopting");
+    await mkdir(dirname(paths.fleetStatePath), { recursive: true });
+    await writeFile(
+      paths.fleetStatePath,
+      JSON.stringify({
+        ts: "2026-07-23T03:00:00Z",
+        epoch: 1_774_493_200,
+        runner: "codex",
+        ready_for_agent: 0,
+        slots: { busy: 2, free: 0, total: 2, parked: 0 },
+        spawns_this_tick: 0,
+        slot_pids: [
+          { slot: 0, pid: 51_001 },
+          { slot: 1, pid: 51_002 },
+        ],
+      }),
+      "utf8",
+    );
+    await upsertFleetProfile(
+      fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),
+      { name: "adopting", runner: "codex" },
+    );
+    vi.mocked(spawnSupervisor).mockResolvedValue(43122);
+
+    await createCastleMcpDependencies(cwd).fleetCreate({
+      name: "adopting",
+      runner: "codex",
+      target: 2,
+    });
+
+    expect(spawnSupervisor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adoptSlotPids: [
+          { slot: 0, pid: 51_001 },
+          { slot: 1, pid: 51_002 },
+        ],
+      }),
+    );
   });
 
   it("surfaces only this launch's supervisor death evidence and rolls back the profile", async () => {


### PR DESCRIPTION
Automated AFK landing for #2471. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2471

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787368266&installation_model_id=20659&pr_number=2533&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2533&signature=a66194a9917da92f437f9c46a58e905345d48207a48562f6712aa854a2985133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->