### PR TITLE
chore: changeset for the self-healing wave (v2.82.0)

### DIFF
--- a/.changeset/self-healing-wave.md
+++ b/.changeset/self-healing-wave.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": minor
+---
+
+Self-healing wave (ADR 0122): boot auto-concede of dead own-machine claims, quarantine curator + heal ledger + probe posture change (#2521), activity-independent wall-clock ceiling (#2286), gate teardown leak fix (#2432), fleet_create idempotent respawn (#2471), fleet-scoped stop (#2472), requeue blocked:base-stale lane (#2474), and the resident webhook singleton (#2425)


### PR DESCRIPTION
The ADR 0122 wave landed without changeset files, so changesets sees nothing to version and no Version PR is minted. This adds the aggregate minor changeset so v2.82.0 can cut — activating boot auto-concede, the quarantine curator, and the wall-clock ceiling on the running fleet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787372758&installation_model_id=20659&pr_number=2537&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2537&signature=5daa1f765acb44d65b8cf4810c444c1705c88d3b2fe71641b718368c1c0c24a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->