### PR TITLE
fix: #2474 requeue supports blocked:base-stale with a freshness-verified clear

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -103,10 +103,20 @@ export interface RequeueExecutionResult {
   addLabels?: string[];
 }
 
+export interface RequeueBaseFreshnessResult {
+  ok: boolean;
+  evidence: string;
+}
+
+export type RequeueBaseFreshnessVerifier = (
+  issueBody: string,
+) => Promise<RequeueBaseFreshnessResult>;
+
 export interface RequeueExecutionOptions {
   cwd?: string;
   gh?: RequeueGh;
   adoptRunner?: RequeueAdoptRunner;
+  verifyBaseFreshness?: RequeueBaseFreshnessVerifier;
   /** Optional sink for the adopt gate's live progress. MCP callers omit it. */
   progress?: NodeJS.WritableStream;
 }
@@ -168,6 +178,34 @@ function ghFor(cwd: string, repo: string): RequeueGh {
     postClaim: async (issue, body) => {
       await ghx.postClaimComment({ cwd, repo }, issue, body);
     },
+  };
+}
+
+async function verifyFreshBase(
+  cwd: string,
+  issueBody: string,
+): Promise<RequeueBaseFreshnessResult> {
+  const paths = afkPaths(cwd);
+  const config = loadConfig(paths.configPath, { warn: () => undefined });
+  const base = await resolveBase(
+    { issueBody },
+    {
+      readLockedBranch: () => readLockedBranch(branchLockPath(cwd)),
+      configLockedBranch: getConfig(config, "dev.lock.branch") || undefined,
+      configTrunk: getConfig(config, "dev.trunk") || undefined,
+      fetchIssueBody: async () => undefined,
+    },
+  );
+  const resolved = await gitx.resolveFreshBase({ cwd }, { base });
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      evidence: resolved.message ?? `could not refresh base ${base}`,
+    };
+  }
+  return {
+    ok: true,
+    evidence: `refreshed ${base} from origin/${base}`,
   };
 }
 
@@ -538,6 +576,26 @@ export async function executeRequeue(
     }
   }
 
+  const isBaseStale =
+    plan.activeBlocker?.kind === "base-stale" ||
+    plan.removeLabels.includes("blocked:base-stale");
+  if (plan.requeueable && isBaseStale) {
+    const freshness = await (
+      options.verifyBaseFreshness ?? ((body) => verifyFreshBase(cwd, body))
+    )(issueState.body);
+    if (!freshness.ok) {
+      return {
+        issue: input.issue,
+        plan,
+        applied: false,
+        outcome: "refused",
+        exitCode: 1,
+        reason: `base freshness verification failed: ${freshness.evidence}`,
+        ...(adoptBranch ? { adoptBranch } : {}),
+      };
+    }
+  }
+
   if (input.dryRun) {
     return {
       issue: input.issue,
@@ -678,6 +736,7 @@ export async function requeueCommand(
   stdout: NodeJS.WritableStream = process.stdout,
   ghOverride?: RequeueGh,
   adoptRunnerOverride?: RequeueAdoptRunner,
+  baseFreshnessVerifierOverride?: RequeueBaseFreshnessVerifier,
 ): Promise<number> {
   const { values, positionals } = parseFlags(args, REQUEUE_FLAG_SCHEMA);
   const issue = parseIssue(positionals[0]);
@@ -711,6 +770,7 @@ export async function requeueCommand(
       cwd,
       gh: ghOverride,
       adoptRunner: adoptRunnerOverride,
+      verifyBaseFreshness: baseFreshnessVerifierOverride,
       progress: stdout,
     },
   );

--- a/apps/dev/src/core/requeue.ts
+++ b/apps/dev/src/core/requeue.ts
@@ -11,8 +11,10 @@
 // are its IO callers.
 //
 // #860 narrows the scope to explicitly supported transient parks. Alongside
-// `blocked:validation` and `blocked:spec`, `blocked:infra` is requeueable because
-// a recovered infrastructure fault needs no new human decision. Mixed
+// `blocked:validation` and `blocked:spec`, `blocked:infra` and
+// `blocked:base-stale` are requeueable because a recovered mechanical fault
+// needs no new human decision. The IO caller freshness-gates `base-stale`
+// before applying this pure plan. Mixed
 // `blocked:*` states and label/body kind mismatches are refused without mutation
 // and direct the maintainer to `/hitl`.
 
@@ -40,7 +42,12 @@ export const MECHANICAL_BLOCKER_KINDS = new Set(["stalled", "crashed", "merge-co
  * any other human-input kind still requires `/hitl` (the interactive decision
  * path); those must not be auto-cleared without the full HITL interview.
  */
-export const REQUEUE_SUPPORTED_KINDS = new Set(["validation", "spec", "infra"]);
+export const REQUEUE_SUPPORTED_KINDS = new Set([
+  "validation",
+  "spec",
+  "infra",
+  "base-stale",
+]);
 
 export interface RequeueInput {
   /** The current issue body markdown. */
@@ -54,7 +61,8 @@ export interface RequeueInput {
 }
 
 /**
- * Is `kind` requeueable? The supported set is `{validation, spec, infra}`.
+ * Is `kind` requeueable? The supported set is
+ * `{validation, spec, infra, base-stale}`.
  */
 function kindRequeueable(kind: string): boolean {
   return REQUEUE_SUPPORTED_KINDS.has(kind);
@@ -122,8 +130,9 @@ export function isRequeueComplete(body: string, labels: readonly string[]): bool
  * is active so the transition can never degrade into a label-only flip.
  *
  * Narrowed to explicit transient parks: `blocked:validation`, `blocked:spec`,
- * and `blocked:infra`. Mixed `blocked:*` states and label/body kind mismatches
- * set `refuseForHitl: true` and direct the caller to `/hitl` instead.
+ * `blocked:infra`, and freshness-gated `blocked:base-stale`. Mixed `blocked:*`
+ * states and label/body kind mismatches set `refuseForHitl: true` and direct
+ * the caller to `/hitl` instead.
  */
 export function planRequeue(input: RequeueInput): RequeuePlan {
   const activeBlocker = parseCurrentBlocker(input.body);
@@ -165,7 +174,7 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
   // Unsupported label kind → /hitl handles other human-input blocker types.
   if (labelKind !== null && !kindRequeueable(labelKind)) {
     return refuse(
-      `blocked:${labelKind} is not in the supported set (validation, spec, infra): use /hitl`,
+      `blocked:${labelKind} is not in the supported set (validation, spec, infra, base-stale): use /hitl`,
       true,
       activeBlocker,
       input.body,
@@ -179,7 +188,7 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
     !kindRequeueable(activeBlocker.kind)
   ) {
     return refuse(
-      `active blocker kind "${activeBlocker.kind}" is not in the supported set (validation, spec, infra): use /hitl`,
+      `active blocker kind "${activeBlocker.kind}" is not in the supported set (validation, spec, infra, base-stale): use /hitl`,
       true,
       activeBlocker,
       input.body,

--- a/apps/dev/tests/requeue-command.test.ts
+++ b/apps/dev/tests/requeue-command.test.ts
@@ -80,10 +80,45 @@ const specBlocker = {
   next: "Human must clarify before work proceeds.",
 };
 
+const baseStaleBlocker = {
+  status: "blocked" as const,
+  kind: "base-stale",
+  summary: "The worker could not refresh its base.",
+  next: "Refresh the local base from origin, then requeue.",
+};
+
 const parkedBody = `## Summary\nDo it.\n\n## Current blocker\n\n${formatCurrentBlocker(validationBlocker)}\n`;
 const specBodyMismatch = `## Summary\nDo it.\n\n## Current blocker\n\n${formatCurrentBlocker(specBlocker)}\n`;
+const baseStaleBody = `## Summary\nDo it.\n\n## Current blocker\n\n${formatCurrentBlocker(baseStaleBlocker)}\n`;
 
 describe("requeue command — happy path", () => {
+  it("requeues blocked:base-stale through the CLI after freshness is verified", async () => {
+    const fixture = fakeGh({
+      state: "OPEN",
+      body: baseStaleBody,
+      labels: ["ready-for-human", "blocked:base-stale"],
+    });
+    const { stream } = capture();
+
+    const code = await requeueCommand(
+      ["#42", "--guidance", "Base freshness verified."],
+      "/tmp",
+      stream,
+      fixture.gh,
+      undefined,
+      async () => ({ ok: true, evidence: "origin/main is fresh" }),
+    );
+
+    expect(code).toBe(0);
+    expect(fixture.calls.editBody).toBe(1);
+    expect(fixture.calls.editLabels).toBe(1);
+    expect(fixture.lastRemove).toEqual(
+      expect.arrayContaining(["ready-for-human", "blocked:base-stale"]),
+    );
+    expect(fixture.lastAdd).toEqual(["ready-for-agent"]);
+    expect(isRequeueComplete(fixture.state.body, fixture.state.labels)).toBe(true);
+  });
+
   it("returns a stable structured result for a non-parked no-op", async () => {
     const { gh, calls } = fakeGh({
       state: "OPEN",
@@ -220,6 +255,36 @@ describe("requeue command — usage errors (exit 2)", () => {
 });
 
 describe("requeue command — /hitl refusals (exit 1, no mutation)", () => {
+  it("refuses blocked:base-stale without mutation when freshness verification still fails", async () => {
+    const { gh, calls } = fakeGh({
+      state: "OPEN",
+      body: baseStaleBody,
+      labels: ["ready-for-human", "blocked:base-stale"],
+    });
+
+    const result = await executeRequeue(
+      { issue: 42, guidance: "Retry after refreshing the base." },
+      {
+        cwd: "/tmp",
+        gh,
+        verifyBaseFreshness: async () => ({
+          ok: false,
+          evidence: "could not refresh origin/main: remote unavailable",
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      applied: false,
+      outcome: "refused",
+      exitCode: 1,
+      reason: expect.stringContaining(
+        "could not refresh origin/main: remote unavailable",
+      ),
+    });
+    expect(calls.editBody + calls.editLabels + calls.comment).toBe(0);
+  });
+
   it("refuses mixed blocked:* labels and exits 1 without mutation", async () => {
     const { gh, calls } = fakeGh({
       state: "OPEN",

--- a/apps/dev/tests/requeue.test.ts
+++ b/apps/dev/tests/requeue.test.ts
@@ -30,6 +30,13 @@ const infraBlocker = {
   next: "Retry after the transient infrastructure fault clears.",
 };
 
+const baseStaleBlocker = {
+  status: "blocked" as const,
+  kind: "base-stale",
+  summary: "The worker could not refresh its base.",
+  next: "Refresh the local base from origin, then requeue.",
+};
+
 const parkedBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${formatCurrentBlocker(
   validationBlocker,
 )}\n\n## Acceptance\n- [ ] Done\n`;
@@ -44,6 +51,10 @@ const decisionBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${forma
 
 const infraBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${formatCurrentBlocker(
   infraBlocker,
+)}\n`;
+
+const baseStaleBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${formatCurrentBlocker(
+  baseStaleBlocker,
 )}\n`;
 
 describe("requeue — label flip invariant", () => {
@@ -64,7 +75,7 @@ describe("requeue — label flip invariant", () => {
   });
 });
 
-describe("requeue — supported kinds (validation, spec, infra)", () => {
+describe("requeue — supported kinds (validation, spec, infra, base-stale)", () => {
   it("clears the active blocker in the rewritten body instead of requiring manual editing", () => {
     const plan = planRequeue({
       body: parkedBody,
@@ -141,6 +152,21 @@ describe("requeue — supported kinds (validation, spec, infra)", () => {
     expect(plan.refuseForHitl).toBe(false);
     expect(plan.activeBlocker?.kind).toBe("infra");
     expect(plan.removeLabels).toEqual(expect.arrayContaining(["ready-for-human", "blocked:infra"]));
+    expect(plan.addLabels).toEqual(["ready-for-agent"]);
+  });
+
+  it("plans a freshness-gated blocked:base-stale requeue without requiring /hitl", () => {
+    const plan = planRequeue({
+      body: baseStaleBody,
+      labels: ["ready-for-human", "blocked:base-stale"],
+      guidance: "Base freshness verified.",
+    });
+    expect(plan.requeueable).toBe(true);
+    expect(plan.refuseForHitl).toBe(false);
+    expect(plan.activeBlocker?.kind).toBe("base-stale");
+    expect(plan.removeLabels).toEqual(
+      expect.arrayContaining(["ready-for-human", "blocked:base-stale"]),
+    );
     expect(plan.addLabels).toEqual(["ready-for-agent"]);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #2474. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2474

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787374093&installation_model_id=20659&pr_number=2541&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2541&signature=7936eb94ef8035a140547d4b0d48fd4a6e02c913e6df06e50ef7e355ce01a256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->