### PR TITLE
feat: #2526 Death-sweep: atomic transition + heal-ledger quarantine when a worker dies

### DIFF
--- a/.changeset/death-sweep.md
+++ b/.changeset/death-sweep.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": minor
+---
+
+Death-sweep (ADR 0122, #2526): a reaped worker's issue is cleaned through the atomic transition API in one label edit, and the heal ledger quarantines an issue on its 3rd worker-death heal inside the window

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -59,6 +59,7 @@ import {
   castleStateSnapshotPath,
   createEnginePaths,
   createCastleLaneWriters,
+  createFileHealLedgerStore,
   writeCastleStateSnapshot,
 } from "@reddb-io/red-castle/engine";
 import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../core/toon-snapshot.js";
@@ -730,6 +731,10 @@ function buildSupervisorDeps(
     wake: buildStateChangeWake(join(tmpDir, "workers")),
     // Env for the bounded stalled re-claim cap (#402): RED_AFK_RETRY_STALLED.
     recoveryEnv: process.env,
+    // ADR 0122 heal ledger (#2526): the death-sweep consults the same castle
+    // store the boot healer writes, so worker-death heals and probe heals
+    // share one per-issue budget.
+    healLedger: createFileHealLedgerStore(createEnginePaths(join(root, ".red"))),
     // Derived human-readable messages are stored in the structured supervisor
     // lane, not dual-written to a prose supervisor log.
     log: logLine,

--- a/apps/dev/src/core/supervisor/envelopes.ts
+++ b/apps/dev/src/core/supervisor/envelopes.ts
@@ -4,6 +4,8 @@ import { renderLogTailToon } from "../envelope-emit.js";
 import { dispose } from "../disposition.js";
 import { workerIdentity } from "../host-identity.js";
 import { LABEL_READY, LABEL_RUNNING } from "../triage-labels.js";
+import { isRefused, planTransition, type StateTransition } from "../state-transition.js";
+import { recordIssueHeal } from "@reddb-io/red-castle/engine";
 import type { IterDirInfo, SupervisorDeps } from "./types.js";
 
 export function buildDiscardEnvelope(
@@ -107,7 +109,7 @@ export async function reconcileDeadWorkerClaim(
   if (info === null || info.issue === null) return null;
   if (!deps.gh.crashedClaimState) return null;
 
-  let claim: { ghOk: boolean; stillRunning: boolean; envelopePosted: boolean };
+  let claim: { ghOk: boolean; stillRunning: boolean; envelopePosted: boolean; labels?: string[] };
   try {
     claim = await deps.gh.crashedClaimState(info.issue);
   } catch {
@@ -127,6 +129,32 @@ export async function reconcileDeadWorkerClaim(
     renderClaimComment({ worker: workerIdentity(info.workerId) }, "concede", "released"),
   );
 
+  // 1b. ADR 0122 heal ledger (#2526): a death-sweep IS a heal of this issue.
+  // The 3rd heal inside the window stops re-queueing and quarantines instead —
+  // an issue that keeps killing workers is a signal, not a retry candidate.
+  // Best-effort: a ledger failure falls through to the normal disposition.
+  if (deps.healLedger) {
+    try {
+      const decision = await recordIssueHeal(deps.healLedger, info.issue);
+      if (decision.action === "quarantine") {
+        await deps.gh.ensureLabel("quarantine");
+        const applied = await applyDeathTransition(deps, info.issue, claim.labels, {
+          kind: "quarantine",
+          diagnosis: "",
+        });
+        if (applied) {
+          await deps.gh.comment(
+            info.issue,
+            `🤖 /afk death-sweep quarantined this issue: ${decision.history.length} worker-death heals inside the ledger window — it keeps killing workers and needs human judgment before another attempt (ADR 0122 heal budget).`,
+          );
+          return info.issue;
+        }
+      }
+    } catch {
+      // best-effort: fall through to the bounded recovery below.
+    }
+  }
+
   // 2. Bounded blocked:crashed recovery via the disposition composer (#402,
   // #822), mirroring the stall-reaper path below. The death-without-envelope
   // outcome is "no-sentinel" → recovery reason `crashed` + label `blocked:crashed`;
@@ -136,18 +164,49 @@ export async function reconcileDeadWorkerClaim(
   // was converted, breaking the apps/dev typecheck.)
   const disp = dispose("no-sentinel", info.attempt, deps.recoveryEnv ?? {});
   if (disp.decision === "retry") {
-    // CLEAN re-queue: no blocked:* tag rides a re-queued issue.
-    await deps.gh.editLabels(info.issue, disp.addLabels, disp.removeLabels);
+    // CLEAN re-queue through the transition API when labels are known — the
+    // atomic plan strips every park remnant in one edit and proves the
+    // one-state-role invariant (#2526). Legacy dispose sets remain the
+    // fallback for impls that do not report labels.
+    const applied = await applyDeathTransition(deps, info.issue, claim.labels, { kind: "queue" });
+    if (!applied) await deps.gh.editLabels(info.issue, disp.addLabels, disp.removeLabels);
   } else {
     if (disp.typedLabel !== null) await deps.gh.ensureLabel(disp.typedLabel);
+    const applied = await applyDeathTransition(
+      deps,
+      info.issue,
+      claim.labels,
+      disp.typedLabel !== null
+        ? { kind: "park", reason: disp.typedLabel }
+        : { kind: "human" },
+    );
     // Escalation also sheds any stale ready-for-agent — the crashed slot was
     // `running`, never re-queue it (matches the reaper path).
-    await deps.gh.editLabels(info.issue, disp.addLabels, [...disp.removeLabels, LABEL_READY]);
+    if (!applied) await deps.gh.editLabels(info.issue, disp.addLabels, [...disp.removeLabels, LABEL_READY]);
     if (disp.escalationComment !== null) {
       await deps.gh.comment(info.issue, disp.escalationComment);
     }
   }
   return info.issue;
+}
+
+/**
+ * Apply one ADR 0122 state transition for the death-sweep as a single label
+ * edit. Returns false when labels are unknown or the planner refuses (the
+ * caller then falls back to the legacy dispose label sets), so the sweep is
+ * never weaker than the pre-#2526 behavior.
+ */
+async function applyDeathTransition(
+  deps: SupervisorDeps,
+  issue: number,
+  labels: string[] | undefined,
+  transition: StateTransition,
+): Promise<boolean> {
+  if (!labels) return false;
+  const plan = planTransition(labels, transition);
+  if (isRefused(plan)) return false;
+  await deps.gh.editLabels(issue, [...plan.add], [...plan.remove]);
+  return true;
 }
 
 // ---------- actions (compose deciders, apply via injected IO) ----------

--- a/apps/dev/src/core/supervisor/types.ts
+++ b/apps/dev/src/core/supervisor/types.ts
@@ -157,6 +157,9 @@ export interface SupervisorGh {
     ghOk: boolean;
     stillRunning: boolean;
     envelopePosted: boolean;
+    /** The issue's current labels, when the impl fetched them — enables the
+     * death-sweep's atomic transition planning (#2526). */
+    labels?: string[];
   }>;
 }
 
@@ -330,6 +333,13 @@ export interface SupervisorDeps {
    * built-in cap) when absent, so tests can omit it.
    */
   recoveryEnv?: RecoveryEnv;
+  /**
+   * Optional ADR 0122 heal ledger (castle engine store). When present, the
+   * death-sweep consults it before re-queueing a dead worker's issue: the 3rd
+   * heal of the same issue in the window quarantines instead of retrying, so
+   * an issue that keeps killing workers surfaces as a signal (#2526).
+   */
+  healLedger?: import("@reddb-io/red-castle/engine").HealLedgerStore;
   /**
    * Optional liveness sink: one line per supervise tick (the CLI appends it to
    * supervisor.log.toonl). Makes a healthy fleet's heartbeat — and a wedged one's

--- a/apps/dev/src/runtime/gh/sweeps.ts
+++ b/apps/dev/src/runtime/gh/sweeps.ts
@@ -46,7 +46,7 @@ export async function orphanState(
 export async function crashedClaimState(
   ctx: GhContext,
   issue: number,
-): Promise<{ ghOk: boolean; stillRunning: boolean; envelopePosted: boolean }> {
+): Promise<{ ghOk: boolean; stillRunning: boolean; envelopePosted: boolean; labels?: string[] }> {
   const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "state,labels,comments"]);
   if (r.code !== 0) return { ghOk: false, stillRunning: false, envelopePosted: false };
   try {
@@ -60,7 +60,7 @@ export async function crashedClaimState(
     const envelopePosted = Array.isArray(parsed.comments)
       ? parsed.comments.some((c) => String(c.body ?? "").includes("data-attempt-status"))
       : false;
-    return { ghOk: true, stillRunning, envelopePosted };
+    return { ghOk: true, stillRunning, envelopePosted, labels };
   } catch {
     return { ghOk: false, stillRunning: false, envelopePosted: false };
   }

--- a/apps/dev/tests/death-sweep.test.ts
+++ b/apps/dev/tests/death-sweep.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { reconcileDeadWorkerClaim } from "../src/core/supervisor.js";
+import type { HealLedgerState, HealLedgerStore } from "@reddb-io/red-castle/engine";
+import { makeDeps } from "./supervisor-test-helpers.js";
+import type { IterDirInfo } from "../src/core/supervisor.js";
+
+function info(issue = 2526): IterDirInfo {
+  return { issue, workerId: "wTEST", attempt: 1, iterDir: "/tmp/x" } as unknown as IterDirInfo;
+}
+
+function memoryLedger(initial: Record<string, number[]> = {}): HealLedgerStore {
+  let state: HealLedgerState = { version: 1, issues: initial };
+  return {
+    read: async () => state,
+    write: async (next) => {
+      state = next;
+    },
+  };
+}
+
+describe("death-sweep (#2526, ADR 0122)", () => {
+  it("escalation parks through the atomic transition: exactly one state role survives in ONE edit", async () => {
+    const { deps, io } = makeDeps();
+    // crashed cap defaults to 1 and the fixture is attempt 1 → escalate/park.
+    io.crashedClaimState.mockImplementation(async () => ({
+      ghOk: true,
+      stillRunning: true,
+      envelopePosted: true,
+      labels: ["running", "ready-for-agent", "blocked:crashed", "ready-for-human", "bug"],
+    }));
+    const reconciled = await reconcileDeadWorkerClaim(info(), deps);
+    expect(reconciled).toBe(2526);
+    expect(io.editLabels).toHaveBeenCalledTimes(1);
+    const [, add, remove] = io.editLabels.mock.calls[0]!;
+    // Park keeps ready-for-human + blocked:crashed and atomically sheds the
+    // poison pair that froze fleets on 2026-07-22: ready-for-agent + running.
+    expect(new Set(remove as string[])).toEqual(new Set(["ready-for-agent", "running"]));
+    expect(add as string[]).toEqual([]);
+  });
+
+  it("re-queues under the retry cap through the atomic queue transition", async () => {
+    const { deps, io } = makeDeps();
+    deps.recoveryEnv = { RED_AFK_RETRY_CRASH: "3" };
+    io.crashedClaimState.mockImplementation(async () => ({
+      ghOk: true,
+      stillRunning: true,
+      envelopePosted: true,
+      labels: ["running", "ready-for-agent", "blocked:crashed", "ready-for-human", "bug"],
+    }));
+    const reconciled = await reconcileDeadWorkerClaim(info(), deps);
+    expect(reconciled).toBe(2526);
+    expect(io.editLabels).toHaveBeenCalledTimes(1);
+    const [, add, remove] = io.editLabels.mock.calls[0]!;
+    expect(new Set(remove as string[])).toEqual(
+      new Set(["running", "blocked:crashed", "ready-for-human"]),
+    );
+    expect(add as string[]).toEqual([]);
+  });
+
+  it("quarantines on the 3rd heal of the same issue inside the ledger window", async () => {
+    const { deps, io } = makeDeps();
+    const now = Date.now();
+    deps.healLedger = memoryLedger({ "2526": [now - 60_000, now - 30_000] });
+    io.crashedClaimState.mockImplementation(async () => ({
+      ghOk: true,
+      stillRunning: true,
+      envelopePosted: true,
+      labels: ["running", "ready-for-agent"],
+    }));
+    const reconciled = await reconcileDeadWorkerClaim(info(), deps);
+    expect(reconciled).toBe(2526);
+    expect(io.ensureLabel).toHaveBeenCalledWith("quarantine");
+    const [, add, remove] = io.editLabels.mock.calls[0]!;
+    expect(add as string[]).toContain("quarantine");
+    expect(new Set(remove as string[])).toEqual(new Set(["running", "ready-for-agent"]));
+    const comments = io.comment.mock.calls.map((c) => String(c[1]));
+    expect(comments.some((c) => c.includes("heal budget"))).toBe(true);
+  });
+
+  it("first heal of an issue still re-queues (ledger records, does not quarantine)", async () => {
+    const { deps, io } = makeDeps();
+    deps.healLedger = memoryLedger();
+    io.crashedClaimState.mockImplementation(async () => ({
+      ghOk: true,
+      stillRunning: true,
+      envelopePosted: true,
+      labels: ["running", "ready-for-agent"],
+    }));
+    await reconcileDeadWorkerClaim(info(), deps);
+    const [, add] = io.editLabels.mock.calls[0]!;
+    expect(add as string[]).not.toContain("quarantine");
+  });
+
+  it("is idempotent: a second reap of an already-reconciled claim performs no mutation", async () => {
+    const { deps, io } = makeDeps();
+    io.crashedClaimState.mockImplementation(async () => ({
+      ghOk: true,
+      stillRunning: false,
+      envelopePosted: true,
+      labels: ["ready-for-agent"],
+    }));
+    const reconciled = await reconcileDeadWorkerClaim(info(), deps);
+    expect(reconciled).toBeNull();
+    expect(io.editLabels).not.toHaveBeenCalled();
+    expect(io.comment).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the legacy dispose sets when the impl reports no labels", async () => {
+    const { deps, io } = makeDeps();
+    io.crashedClaimState.mockImplementation(async () => ({
+      ghOk: true,
+      stillRunning: true,
+      envelopePosted: true,
+    }));
+    const reconciled = await reconcileDeadWorkerClaim(info(), deps);
+    expect(reconciled).toBe(2526);
+    expect(io.editLabels).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Spec #2523 slice. The supervisor's dead-worker reconcile now (a) routes its re-queue/park label mutation through the #2524 transition API — one edit, one-state-role invariant proven, the 2026-07-22 poison pair (park stacked on ready-for-agent) atomically shed; (b) consults the curator's castle heal ledger: the 3rd worker-death heal of the same issue inside the window quarantines with a self-explanatory comment instead of blind re-queueing; (c) stays idempotent (stillRunning gate) and falls back to the legacy dispose sets when labels are unavailable, so it is never weaker than before. 6 pinning tests; typecheck green.

Closes #2526

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787374409&installation_model_id=20659&pr_number=2542&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2542&signature=bdcacc5bc3ea1f386f338198957932f704ad5a9f04f412f6f0065fd76c08cc03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->