### PR TITLE
fix: #2494 Sandboxes stop mutating the host global gitconfig; lock collision becomes infra-transient

### DIFF
--- a/.changeset/sandbox-gitconfig.md
+++ b/.changeset/sandbox-gitconfig.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Sandboxes stop writing the HOST global gitconfig (#2494): safe.directory and identity setup are skipped for the `none` provider (same-UID worktree, and the shared-file lock races across concurrent workers) and kept for container providers; a setup-phase `could not lock config file` failure is classified infra-transient, never a no-sentinel death

--- a/apps/dev/src/core/execution/runtime.ts
+++ b/apps/dev/src/core/execution/runtime.ts
@@ -823,7 +823,7 @@ export function isTransientRunnerError(error: unknown): boolean {
 }
 
 const runnerTransientPattern =
-  /failed to connect to websocket|HTTP error:\s*502 Bad Gateway|HTTP error:\s*503 Service Unavailable|\b529\b|overloaded|wss:\/\/chatgpt\.com\/backend-api\/codex\/responses|thread\/start failed|failed to load configuration|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ECONNRESET/i;
+  /failed to connect to websocket|HTTP error:\s*502 Bad Gateway|HTTP error:\s*503 Service Unavailable|\b529\b|overloaded|wss:\/\/chatgpt\.com\/backend-api\/codex\/responses|thread\/start failed|failed to load configuration|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ECONNRESET|could not lock config file/i;
 
 type HostConfigFailure = "missing-interpreter" | "missing-cwd";
 

--- a/apps/dev/tests/execution-run-agent.test.ts
+++ b/apps/dev/tests/execution-run-agent.test.ts
@@ -272,6 +272,14 @@ describe("isTransientRunnerError", () => {
     expect(isTransientRunnerError(new Error("cwd does not exist: /tmp/worker-attempt"))).toBe(false);
   });
 
+  it("matches a gitconfig lock collision during sandbox setup — infra-transient, never a no-sentinel death (#2494)", () => {
+    expect(
+      isTransientRunnerError(
+        new Error('Command failed (exit 255): git config --global --add safe.directory "x"\nerror: could not lock config file /home/user/.gitconfig: File exists'),
+      ),
+    ).toBe(true);
+  });
+
   it("matches provider server-side overload (529 / overloaded_error / 503) — temporary, not a crash", () => {
     expect(
       isTransientRunnerError(

--- a/packages/red-castle/src/SandboxLifecycle.test.ts
+++ b/packages/red-castle/src/SandboxLifecycle.test.ts
@@ -95,6 +95,35 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     return { hostDir, worktreeDir, sandbox };
   };
 
+
+  it("hostSharedGitConfig skips every git config --global setup write (#2494)", async () => {
+    const { hostDir, worktreeDir } = await setupWorktree();
+    const commands: string[] = [];
+    const real = makeLocalSandbox(worktreeDir);
+    const sandbox: SandboxService = {
+      ...real,
+      exec: (command, options) => {
+        commands.push(command);
+        return real.exec(command, options);
+      },
+    };
+
+    await Effect.runPromise(
+      withSandboxLifecycle(
+        {
+          hostRepoDir: hostDir,
+          sandboxRepoDir: worktreeDir,
+          hostSharedGitConfig: true,
+        },
+        sandbox,
+        () => Effect.void,
+      ).pipe(Effect.provide(testDisplayLayer)),
+    );
+
+    expect(commands.some((c) => c.includes("--global"))).toBe(false);
+    expect(commands.some((c) => c.includes("safe.directory"))).toBe(false);
+  });
+
   it("skips sync-in — worktree files are already accessible", async () => {
     const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 

--- a/packages/red-castle/src/SandboxLifecycle.ts
+++ b/packages/red-castle/src/SandboxLifecycle.ts
@@ -161,6 +161,12 @@ export interface SandboxLifecycleOptions {
    *  detach-and-delete of the source branch so the worktree handle stays usable for
    *  subsequent `wt.run()` / `wt.interactive()` calls. */
   readonly keepSourceBranch?: boolean;
+  /** True when the sandbox's exec shares the HOST's git config (the `none`
+   *  provider). All `git config --global` setup writes are skipped: the
+   *  worktree is same-UID (safe.directory never fires) and the host identity
+   *  is already the host identity — while writing would race the shared
+   *  `~/.gitconfig` lock across concurrent workers (#2494). */
+  readonly hostSharedGitConfig?: boolean;
 }
 
 export interface SandboxContext {
@@ -231,28 +237,33 @@ export const withSandboxLifecycle = <A>(
       Effect.gen(function* () {
         // The bind-mounted worktree may be owned by a different UID (host user
         // vs sandbox user). Mark it safe so git doesn't reject it with
-        // "dubious ownership".
-        yield* execOkWithGitTimeout(
-          sandbox,
-          `git config --global --add safe.directory "${sandboxRepoDir}"`,
-          gitSetupTimeoutMs,
-        );
+        // "dubious ownership". Skipped entirely when the sandbox shares the
+        // host git config (#2494): same-UID worktree, and a `--global` write
+        // would race the shared host gitconfig lock across workers.
+        if (!options.hostSharedGitConfig) {
+          yield* execOkWithGitTimeout(
+            sandbox,
+            `git config --global --add safe.directory "${sandboxRepoDir}"`,
+            gitSetupTimeoutMs,
+          );
 
-        // Propagate host git identity into the sandbox so commits are attributed
-        // to the actual developer without requiring manual setup.
-        if (hostGitName) {
-          yield* execOkWithGitTimeout(
-            sandbox,
-            `git config --global user.name "${hostGitName.replace(/"/g, '\\"')}"`,
-            gitSetupTimeoutMs,
-          );
-        }
-        if (hostGitEmail) {
-          yield* execOkWithGitTimeout(
-            sandbox,
-            `git config --global user.email "${hostGitEmail.replace(/"/g, '\\"')}"`,
-            gitSetupTimeoutMs,
-          );
+          // Propagate host git identity into the sandbox so commits are
+          // attributed to the actual developer without requiring manual setup.
+          // (Host-shared config already IS the host identity.)
+          if (hostGitName) {
+            yield* execOkWithGitTimeout(
+              sandbox,
+              `git config --global user.name "${hostGitName.replace(/"/g, '\\"')}"`,
+              gitSetupTimeoutMs,
+            );
+          }
+          if (hostGitEmail) {
+            yield* execOkWithGitTimeout(
+              sandbox,
+              `git config --global user.email "${hostGitEmail.replace(/"/g, '\\"')}"`,
+              gitSetupTimeoutMs,
+            );
+          }
         }
 
         // Repo is bind-mounted — discover branch directly

--- a/packages/red-castle/src/createSandbox.ts
+++ b/packages/red-castle/src/createSandbox.ts
@@ -614,6 +614,7 @@ const buildSandboxHandle = (
                 applyToHost,
                 timeouts,
                 keepSourceBranch: mergeToHead,
+                hostSharedGitConfig: ctx.providerTag === "none",
               },
               sandbox,
               (ctx) =>
@@ -832,9 +833,15 @@ export const createSandboxFromWorktree = async (
   if (sandboxOnReady?.length || hostOnReady?.length) {
     await Effect.runPromise(
       Effect.gen(function* () {
-        yield* sandbox.exec(
-          `git config --global --add safe.directory "${sandboxRepoDir}"`,
-        );
+        // safe.directory exists for cross-UID bind mounts. Under `none` the
+        // exec IS the host shell: the worktree is same-UID (the check never
+        // fires) and `--global` writes the REAL user gitconfig — a shared
+        // file whose lock races across concurrent workers (#2494).
+        if (options.sandbox.tag !== "none") {
+          yield* sandbox.exec(
+            `git config --global --add safe.directory "${sandboxRepoDir}"`,
+          );
+        }
         const sandboxEffects = (sandboxOnReady ?? []).map((hook) =>
           sandbox.exec(hook.command, {
             cwd: sandboxRepoDir,
@@ -1020,9 +1027,13 @@ export const createSandbox = async (
 
           if (sandboxOnReady?.length || hostOnReady?.length) {
             yield* Effect.gen(function* () {
-              yield* sandbox.exec(
-                `git config --global --add safe.directory "${sandboxRepoDir}"`,
-              );
+              // Same gate as the run() path: never write the HOST's global
+              // gitconfig from a `none` sandbox (#2494).
+              if (options.sandbox.tag !== "none") {
+                yield* sandbox.exec(
+                  `git config --global --add safe.directory "${sandboxRepoDir}"`,
+                );
+              }
               const sandboxEffects = (sandboxOnReady ?? []).map((hook) =>
                 sandbox.exec(hook.command, {
                   cwd: sandboxRepoDir,


### PR DESCRIPTION
Maintainer decision (grilling 2026-07-22): surgical removal, not wholesale. The three safe.directory call sites now gate on the provider tag — under the `none` provider (exec IS the host shell) ALL `git config --global` setup writes are skipped: the worktree is same-UID (dubious-ownership never fires) and the write raced the shared host gitconfig lock across workers (burned a gate-correction retry on #2481; 3,632 junk entries / 557KB accumulated in the maintainer's gitconfig). Container providers keep the setup — their global config is the container's own. Plus: `could not lock config file` during setup is now classified infra-transient (retries same round), never a no-sentinel agent death. Tests: lifecycle pin (zero --global writes under hostSharedGitConfig) + transient classification pin; both package typechecks green.

Closes #2494

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787375175&installation_model_id=20659&pr_number=2543&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2543&signature=01fa9177bccbc66cfd373f03eb6237dcec49424a2fce386ecbfa09437fbe229d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->