### PR TITLE
fix: #2477 Hook detection moves into the Node engine: gradle/cargo library hooks become leaf actions, POSIX-safe

### DIFF
--- a/apps/dev/src/core/hook-config.ts
+++ b/apps/dev/src/core/hook-config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { ConfigValues } from "./config.js";
 
@@ -15,8 +15,8 @@ import type { ConfigValues } from "./config.js";
  *   - within a point, built-in DEFAULTS run first (fixed registration order,
  *     never reorderable), then user-declared commands in declaration order;
  *   - users can *shadow* a built-in default by placing a same-named script in
- *     `.red/hooks/` (the shadow wins over the library script); to disable a
- *     default entirely, shadow it with a no-op script that exits 0;
+ *     `.red/hooks/` (the shadow wins over the library script), or disable one
+ *     with `afk.hooks.defaults.<name>: false`;
  *   - a bare string is shorthand for a one-element list.
  *
  * The resolution is pure: it reads the already-parsed flat config map and a
@@ -207,9 +207,8 @@ export interface ResolveHooksOptions {
  * into its elements with blanks dropped. An unknown hook name throws
  * `UnknownHookError`.
  *
- * The `afk.hooks.defaults.<name>: false` toggle is no longer honored — shadow
- * the built-in with a same-named no-op script in `.red/hooks/` instead. Old
- * configs that still carry the key are silently ignored (no error).
+ * `afk.hooks.defaults.<name>: false` disables that built-in default. A
+ * project-local same-named script may still shadow an enabled default.
  *
  * Supports two forms for multi-command hooks: a newline-joined block scalar or
  * a YAML list. The YAML parser flattens a list into indexed keys of the form
@@ -226,13 +225,15 @@ export function resolveHooks(
   // validating hook names eagerly. Entries accumulate as {index, command}
   // pairs so YAML-list indexed keys (`name.N`) sort before bare-string entries
   // (which use MAX_SAFE_INTEGER as their sort key).
-  const userEntries = new Map<HookName, Array<{ index: number; command: string }>>();
+  const userEntries = new Map<
+    HookName,
+    Array<{ index: number; command: string }>
+  >();
 
   for (const [key, value] of Object.entries(config)) {
     if (!key.startsWith(HOOKS_PREFIX)) continue;
 
-    // afk.hooks.defaults.* keys are legacy disable toggles — silently ignored
-    // now that same-filename shadowing in .red/hooks/ replaces them.
+    // Defaults are applied below; they are not lifecycle point declarations.
     if (key.startsWith(DEFAULTS_PREFIX)) continue;
 
     const rawName = key.slice(HOOKS_PREFIX.length);
@@ -251,7 +252,10 @@ export function resolveHooks(
     const entries = userEntries.get(name) ?? [];
     commands.forEach((command, offset) => {
       entries.push({
-        index: explicitIndex === undefined ? Number.MAX_SAFE_INTEGER + offset : explicitIndex + offset,
+        index:
+          explicitIndex === undefined
+            ? Number.MAX_SAFE_INTEGER + offset
+            : explicitIndex + offset,
         command,
       });
     });
@@ -275,9 +279,11 @@ export function resolveHooks(
   for (const name of CANONICAL_HOOK_NAMES) {
     const list: string[] = [];
 
-    const defaults = HOOK_DEFAULTS_REGISTRY[name as keyof typeof HOOK_DEFAULTS_REGISTRY];
+    const defaults =
+      HOOK_DEFAULTS_REGISTRY[name as keyof typeof HOOK_DEFAULTS_REGISTRY];
     if (defaults) {
       for (const defaultName of defaults) {
+        if (config[`${DEFAULTS_PREFIX}${defaultName}`] === "false") continue;
         const command = defaultCommand(defaultName);
         if (command !== undefined) list.push(command);
       }
@@ -286,7 +292,15 @@ export function resolveHooks(
     // Directory scripts (library + project, merged, shadowed) run after defaults
     // and before inline config entries.
     if (libraryHooksDir !== undefined || projectHooksDir !== undefined) {
-      list.push(...resolveDirScripts(name, libraryHooksDir, projectHooksDir, listFiles, dirExists));
+      list.push(
+        ...resolveDirScripts(
+          name,
+          libraryHooksDir,
+          projectHooksDir,
+          listFiles,
+          dirExists,
+        ),
+      );
     }
 
     const userCommands = userLists.get(name);
@@ -324,15 +338,34 @@ export function validateHookConfig(config: ConfigValues): void {
  * wins over the library script — this is the mechanism by which operators customize
  * or disable a built-in default (place a no-op script in `.red/hooks/red-<name>`).
  *
- * Returns `undefined` when neither the shadow nor the library script is present,
- * mirroring the shell loader's `-x "$hooks_dir/<script>"` presence guard. The
- * `exists` predicate is injectable for testing.
+ * Cargo and Gradle applicability is decided here from project build-file
+ * presence, before any shell action can execute. Returns `undefined` when the
+ * project does not apply or neither the shadow nor library script is present.
+ * Filesystem operations are injectable for tests.
  */
 export function scriptDefaultResolver(
   libHooksDir: string,
-  projectHooksDir?: string,
-  exists: (path: string) => boolean = existsSync,
+  projectHooksDirOrOptions?:
+    | string
+    | {
+        projectHooksDir?: string;
+        projectRoot?: string;
+        exists?: (path: string) => boolean;
+        isFile?: (path: string) => boolean;
+        listFiles?: ListFiles;
+      },
+  legacyExists: (path: string) => boolean = existsSync,
 ): HookDefaultResolver {
+  const options =
+    typeof projectHooksDirOrOptions === "string"
+      ? {
+          projectHooksDir: projectHooksDirOrOptions,
+          exists: legacyExists,
+        }
+      : (projectHooksDirOrOptions ?? {});
+  const exists = options.exists ?? existsSync;
+  const isFile = options.isFile ?? ((path: string) => statSync(path).isFile());
+  const listFiles = options.listFiles ?? ((dir: string) => readdirSync(dir));
   const scripts: Record<HookDefaultName, string> = {
     cargo: "red-cargo",
     gradle: "red-gradle",
@@ -341,13 +374,36 @@ export function scriptDefaultResolver(
     validation: "red-validation",
   };
   return (name) => {
+    if (options.projectRoot !== undefined) {
+      if (
+        name === "cargo" &&
+        (!exists(join(options.projectRoot, "Cargo.toml")) ||
+          !isFile(join(options.projectRoot, "Cargo.toml")))
+      ) {
+        return undefined;
+      }
+      if (name === "gradle") {
+        let hasGradleBuild = false;
+        try {
+          hasGradleBuild = listFiles(options.projectRoot).some(
+            (file) =>
+              file.startsWith("build.gradle") &&
+              isFile(join(options.projectRoot!, file)),
+          );
+        } catch {
+          hasGradleBuild = false;
+        }
+        if (!hasGradleBuild) return undefined;
+      }
+    }
+
     const filename = scripts[name];
     // Project shadow wins over library script.
-    if (projectHooksDir) {
-      const shadowPath = `${projectHooksDir}/${filename}`;
+    if (options.projectHooksDir) {
+      const shadowPath = join(options.projectHooksDir, filename);
       if (exists(shadowPath)) return shadowPath;
     }
-    const libPath = `${libHooksDir}/${filename}`;
+    const libPath = join(libHooksDir, filename);
     return exists(libPath) ? libPath : undefined;
   };
 }

--- a/apps/dev/src/runtime/hooks.ts
+++ b/apps/dev/src/runtime/hooks.ts
@@ -13,7 +13,10 @@ import { join } from "node:path";
 import { hooksDir } from "@reddb-io/shared/red-paths.js";
 import { execTool } from "./exec.js";
 import type { HookExec } from "../core/hook-dispatcher.js";
-import { scriptDefaultResolver, type ResolveHooksOptions } from "../core/hook-config.js";
+import {
+  scriptDefaultResolver,
+  type ResolveHooksOptions,
+} from "../core/hook-config.js";
 import { skillDirFromModule } from "../platform/skill-paths.js";
 
 /**
@@ -54,10 +57,13 @@ export function makeHookExec(cwd: string, libraryHooksDir?: string): HookExec {
  * so an install without the scripts simply runs no default for that point — and
  * the library hooks dir is left undefined (no library-dir contribution).
  */
-export function makeHookResolveOptions(root: string): ResolveHooksOptions {
+export function makeHookResolveOptions(
+  root: string,
+  locateSkillDir: () => string = skillDirFromModule,
+): ResolveHooksOptions {
   let skillDir: string | undefined;
   try {
-    skillDir = skillDirFromModule();
+    skillDir = locateSkillDir();
   } catch {
     skillDir = undefined;
   }
@@ -68,7 +74,11 @@ export function makeHookResolveOptions(root: string): ResolveHooksOptions {
   const projectHooksDir = hooksDir(root);
 
   return {
-    defaultCommand: scriptDefaultResolver(libHooksDir, projectHooksDir, existsSync),
+    defaultCommand: scriptDefaultResolver(libHooksDir, {
+      projectHooksDir,
+      projectRoot: root,
+      exists: existsSync,
+    }),
     libraryHooksDir: skillDir ? join(skillDir, "hooks") : undefined,
     projectHooksDir,
   };
@@ -78,7 +88,12 @@ export function makeHookResolveOptions(root: string): ResolveHooksOptions {
  * The base RED_AFK_* env handed to every hook command. Event-specific context
  * can override RED_AFK_WORKSPACE when dispatchHooks layers per-hook variables.
  */
-export function hookEnv(repo: string, root: string, slot?: number, runner?: string): Record<string, string> {
+export function hookEnv(
+  repo: string,
+  root: string,
+  slot?: number,
+  runner?: string,
+): Record<string, string> {
   const env: Record<string, string> = {
     RED_AFK_REPO: repo,
     RED_AFK_ROOT: root,

--- a/apps/dev/tests/hook-config.test.ts
+++ b/apps/dev/tests/hook-config.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   CANONICAL_HOOK_NAMES,
@@ -39,6 +42,72 @@ function resolve(config: Record<string, string>): ResolvedHooks {
 }
 
 describe("hook-config resolution", () => {
+  it("does not resolve cargo or gradle defaults when the project has no matching build files", () => {
+    const root = mkdtempSync(join(tmpdir(), "hook-config-node-project-"));
+    const libraryHooksDir = join(root, "library-hooks");
+    mkdirSync(libraryHooksDir);
+    writeFileSync(join(libraryHooksDir, "red-cargo"), "#!/usr/bin/env bash\n");
+    writeFileSync(join(libraryHooksDir, "red-gradle"), "#!/usr/bin/env bash\n");
+
+    const resolved = resolveHooks(
+      {},
+      {
+        defaultCommand: scriptDefaultResolver(libraryHooksDir, {
+          projectRoot: root,
+        }),
+      },
+    );
+
+    expect(resolved.pre_worktree).toEqual([]);
+  });
+
+  it("does not resolve a matching build hook when config disables that default", () => {
+    const root = mkdtempSync(join(tmpdir(), "hook-config-build-project-"));
+    const libraryHooksDir = join(root, "library-hooks");
+    mkdirSync(libraryHooksDir);
+    writeFileSync(join(root, "Cargo.toml"), '[package]\nname = "demo"\n');
+    writeFileSync(join(root, "build.gradle.kts"), "// gradle\n");
+    writeFileSync(join(libraryHooksDir, "red-cargo"), "#!/usr/bin/env bash\n");
+    writeFileSync(join(libraryHooksDir, "red-gradle"), "#!/usr/bin/env bash\n");
+
+    const resolved = resolveHooks(
+      { "afk.hooks.defaults.cargo": "false" },
+      {
+        defaultCommand: scriptDefaultResolver(libraryHooksDir, {
+          projectRoot: root,
+        }),
+      },
+    );
+
+    expect(resolved.pre_worktree).toEqual([
+      join(libraryHooksDir, "red-gradle"),
+    ]);
+  });
+
+  it("uses a project shadow after Node determines the build hook applies", () => {
+    const root = mkdtempSync(join(tmpdir(), "hook-config-shadow-project-"));
+    const libraryHooksDir = join(root, "library-hooks");
+    const projectHooksDir = join(root, ".red", "hooks");
+    mkdirSync(libraryHooksDir);
+    mkdirSync(projectHooksDir, { recursive: true });
+    writeFileSync(join(root, "Cargo.toml"), '[package]\nname = "demo"\n');
+    writeFileSync(join(libraryHooksDir, "red-cargo"), "#!/usr/bin/env bash\n");
+    const shadow = join(projectHooksDir, "red-cargo");
+    writeFileSync(shadow, "#!/usr/bin/env bash\n");
+
+    const resolved = resolveHooks(
+      {},
+      {
+        defaultCommand: scriptDefaultResolver(libraryHooksDir, {
+          projectHooksDir,
+          projectRoot: root,
+        }),
+      },
+    );
+
+    expect(resolved.pre_worktree).toEqual([shadow]);
+  });
+
   it("attaches built-in defaults to their lifecycle points", () => {
     const resolved = resolve({});
     expect(resolved.pre_worktree).toEqual([
@@ -62,9 +131,16 @@ describe("hook-config resolution", () => {
 
   it("preserves declaration order within a user hook list", () => {
     const resolved = resolve({
-      "afk.hooks.post_session": ["first", "second", "third", "fourth"].join("\n"),
+      "afk.hooks.post_session": ["first", "second", "third", "fourth"].join(
+        "\n",
+      ),
     });
-    expect(resolved.post_session).toEqual(["first", "second", "third", "fourth"]);
+    expect(resolved.post_session).toEqual([
+      "first",
+      "second",
+      "third",
+      "fourth",
+    ]);
   });
 
   it("runs built-in defaults first, then user-declared commands", () => {
@@ -79,12 +155,9 @@ describe("hook-config resolution", () => {
     ]);
   });
 
-  it("silently ignores legacy defaults.<name>: false toggles (no error, no disable)", () => {
-    // Old configs may still carry afk.hooks.defaults.cargo: false — these are
-    // now silently ignored (shadowing in .red/hooks/ is the new mechanism).
+  it("disables a built-in default via defaults.<name>: false", () => {
     const resolved = resolve({ "afk.hooks.defaults.cargo": "false" });
-    // cargo is still present — the legacy toggle no longer disables it.
-    expect(resolved.pre_worktree).toEqual([DEFAULT_CMDS.cargo, DEFAULT_CMDS.gradle]);
+    expect(resolved.pre_worktree).toEqual([DEFAULT_CMDS.gradle]);
   });
 
   it("shadows a default via scriptDefaultResolver when projectHooksDir has a same-named script", () => {
@@ -103,14 +176,18 @@ describe("hook-config resolution", () => {
     );
     expect(resolverGradle("gradle")).toBe("/lib/hooks/red-gradle");
     // heartbeat has no shadow and lib also missing → undefined.
-    const resolverMissing = scriptDefaultResolver("/lib/hooks", "/project/.red/hooks", () => false);
+    const resolverMissing = scriptDefaultResolver(
+      "/lib/hooks",
+      "/project/.red/hooks",
+      () => false,
+    );
     expect(resolverMissing("heartbeat")).toBeUndefined();
   });
 
   it("throws a hard error on an unknown hook name", () => {
-    expect(() => resolve({ "afk.hooks.pre_doesnotexist": "echo nope" })).toThrow(
-      /unknown hook name 'pre_doesnotexist'/,
-    );
+    expect(() =>
+      resolve({ "afk.hooks.pre_doesnotexist": "echo nope" }),
+    ).toThrow(/unknown hook name 'pre_doesnotexist'/);
   });
 
   it("mixes bare-string and block-list points, defaults intact", () => {
@@ -134,7 +211,10 @@ describe("hook-config resolution", () => {
     expect(CANONICAL_HOOK_NAMES).toContain("post_attempt");
     expect(CANONICAL_HOOK_NAMES).not.toContain("post_worker");
     expect(HOOK_DEFAULTS_REGISTRY.pre_worktree).toEqual(["cargo", "gradle"]);
-    expect(HOOK_DEFAULTS_REGISTRY.post_attempt).toEqual(["heartbeat", "envelope"]);
+    expect(HOOK_DEFAULTS_REGISTRY.post_attempt).toEqual([
+      "heartbeat",
+      "envelope",
+    ]);
     expect(HOOK_DEFAULTS_REGISTRY.post_merge).toEqual(["validation"]);
   });
 
@@ -162,9 +242,15 @@ describe("hook-config resolution", () => {
       "afk.hooks.pre_session.2": "echo third",
     });
     const scalarForm = resolve({
-      "afk.hooks.pre_session": ["echo first", "echo second", "echo third"].join("\n"),
+      "afk.hooks.pre_session": ["echo first", "echo second", "echo third"].join(
+        "\n",
+      ),
     });
-    expect(listForm.pre_session).toEqual(["echo first", "echo second", "echo third"]);
+    expect(listForm.pre_session).toEqual([
+      "echo first",
+      "echo second",
+      "echo third",
+    ]);
     expect(listForm.pre_session).toEqual(scalarForm.pre_session);
   });
 

--- a/apps/dev/tests/hook-scripts.test.ts
+++ b/apps/dev/tests/hook-scripts.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, writeFileSync, existsSync, readFileSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  mkdirSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execTool } from "../src/runtime/exec.js";
@@ -16,7 +22,23 @@ import { execTool } from "../src/runtime/exec.js";
 
 const here = new URL(import.meta.url).pathname; // .../apps/dev/tests/hook-scripts.test.ts
 const repoRoot = here.slice(0, here.indexOf("/apps/dev/"));
-const hooksDir = join(repoRoot, "plugins", "dev", "skills", "engineering", "afk", "hooks");
+const hooksDir = join(
+  repoRoot,
+  "plugins",
+  "dev",
+  "skills",
+  "engineering",
+  "afk",
+  "hooks",
+);
+const afkSkillDir = join(
+  repoRoot,
+  "plugins",
+  "dev",
+  "skills",
+  "engineering",
+  "afk",
+);
 
 function scriptPath(name: string): string {
   return join(hooksDir, name);
@@ -42,19 +64,39 @@ async function runScript(
   return { code: r.code, stdout: r.stdout };
 }
 
+describe("Gradle shell portability", () => {
+  it("keeps the cheap Gradle leaf and legacy applicability surfaces POSIX-parseable", async () => {
+    for (const relative of [
+      "hooks/red-gradle",
+      "detectors/gradle.sh",
+      "defaults/gradle-pre-worktree.sh",
+    ]) {
+      const result = await execTool("sh", ["-n", join(afkSkillDir, relative)]);
+      expect(result.code, relative).toBe(0);
+    }
+  });
+});
+
 describe("red-cargo parity", () => {
-  it("pass-through with empty stdout when no Cargo.toml present", async () => {
+  it("acts as a leaf without repeating Cargo.toml detection", async () => {
     if (skipIfMissing("red-cargo")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-cargo-"));
-    const r = await runScript("red-cargo", { PROJECT_ROOT: tmp, RED_AFK_SLOT: "2" }, "{}");
+    const base = join(tmp, "cargo-target");
+    const r = await runScript(
+      "red-cargo",
+      { PROJECT_ROOT: tmp, RED_AFK_SLOT: "2", RED_AFK_CARGO_TARGET_BASE: base },
+      "{}",
+    );
     expect(r.code).toBe(0);
-    expect(r.stdout.trim()).toBe("");
+    expect(JSON.parse(r.stdout.trim()).env.CARGO_TARGET_DIR).toBe(
+      `${base}/slot-2`,
+    );
   });
 
   it("injects CARGO_TARGET_DIR into env when Cargo.toml present", async () => {
     if (skipIfMissing("red-cargo")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-cargo-"));
-    writeFileSync(join(tmp, "Cargo.toml"), "[package]\nname = \"test\"\n");
+    writeFileSync(join(tmp, "Cargo.toml"), '[package]\nname = "test"\n');
     const base = join(tmp, "cargo-target");
     const r = await runScript(
       "red-cargo",
@@ -69,7 +111,7 @@ describe("red-cargo parity", () => {
   it("merges with existing env object in context", async () => {
     if (skipIfMissing("red-cargo")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-cargo-"));
-    writeFileSync(join(tmp, "Cargo.toml"), "[package]\nname = \"test\"\n");
+    writeFileSync(join(tmp, "Cargo.toml"), '[package]\nname = "test"\n');
     const base = join(tmp, "cargo-target");
     const ctx = JSON.stringify({ env: { EXISTING_VAR: "kept" } });
     const r = await runScript(
@@ -85,23 +127,34 @@ describe("red-cargo parity", () => {
 });
 
 describe("red-gradle parity", () => {
-  it("pass-through when no build.gradle present", async () => {
+  it("acts as a leaf without repeating build.gradle detection", async () => {
     if (skipIfMissing("red-gradle")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-gradle-"));
+    const base = join(tmp, "gradle-home");
     const r = await runScript(
       "red-gradle",
-      { PROJECT_ROOT: tmp, RED_AFK_SLOT: "1", RED_AFK_GRADLE_USER_HOME_BASE: "/tmp/gradle" },
+      {
+        PROJECT_ROOT: tmp,
+        RED_AFK_SLOT: "1",
+        RED_AFK_GRADLE_USER_HOME_BASE: base,
+      },
       "{}",
     );
     expect(r.code).toBe(0);
-    expect(r.stdout.trim()).toBe("");
+    expect(JSON.parse(r.stdout.trim()).env.GRADLE_USER_HOME).toBe(
+      `${base}/slot-1`,
+    );
   });
 
   it("pass-through when RED_AFK_GRADLE_USER_HOME_BASE is unset (opt-in)", async () => {
     if (skipIfMissing("red-gradle")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-gradle-"));
     writeFileSync(join(tmp, "build.gradle"), "// gradle");
-    const r = await runScript("red-gradle", { PROJECT_ROOT: tmp, RED_AFK_SLOT: "0" }, "{}");
+    const r = await runScript(
+      "red-gradle",
+      { PROJECT_ROOT: tmp, RED_AFK_SLOT: "0" },
+      "{}",
+    );
     expect(r.code).toBe(0);
     expect(r.stdout.trim()).toBe("");
   });
@@ -113,7 +166,11 @@ describe("red-gradle parity", () => {
     const base = join(tmp, "gradle-home");
     const r = await runScript(
       "red-gradle",
-      { PROJECT_ROOT: tmp, RED_AFK_SLOT: "2", RED_AFK_GRADLE_USER_HOME_BASE: base },
+      {
+        PROJECT_ROOT: tmp,
+        RED_AFK_SLOT: "2",
+        RED_AFK_GRADLE_USER_HOME_BASE: base,
+      },
       "{}",
     );
     expect(r.code).toBe(0);
@@ -134,8 +191,15 @@ describe("red-heartbeat parity", () => {
     if (skipIfMissing("red-heartbeat")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-heartbeat-"));
     const logPath = join(tmp, "afk.log");
-    writeFileSync(logPath, "[heartbeat] iteration started for #1 at 2026-01-01T00:00:00Z\n");
-    const r = await runScript("red-heartbeat", { RED_AFK_ITER_LOG: logPath }, "{}");
+    writeFileSync(
+      logPath,
+      "[heartbeat] iteration started for #1 at 2026-01-01T00:00:00Z\n",
+    );
+    const r = await runScript(
+      "red-heartbeat",
+      { RED_AFK_ITER_LOG: logPath },
+      "{}",
+    );
     expect(r.code).toBe(0);
     expect(r.stdout.trim()).toBe("");
     const content = readFileSync(logPath, "utf8");
@@ -144,7 +208,11 @@ describe("red-heartbeat parity", () => {
 
   it("skips boundary marker write when RED_AFK_ITER_LOG file does not exist", async () => {
     if (skipIfMissing("red-heartbeat")) return;
-    const r = await runScript("red-heartbeat", { RED_AFK_ITER_LOG: "/tmp/no-such-file-xyz.log" }, "{}");
+    const r = await runScript(
+      "red-heartbeat",
+      { RED_AFK_ITER_LOG: "/tmp/no-such-file-xyz.log" },
+      "{}",
+    );
     expect(r.code).toBe(0);
   });
 
@@ -159,7 +227,9 @@ describe("red-heartbeat parity", () => {
 describe("red-envelope parity", () => {
   it("no-ops when RED_AFK_STATE_FILE is unset", async () => {
     if (skipIfMissing("red-envelope")) return;
-    const ctx = JSON.stringify({ result: { status: "success", outcome: "done" } });
+    const ctx = JSON.stringify({
+      result: { status: "success", outcome: "done" },
+    });
     const r = await runScript("red-envelope", {}, ctx);
     expect(r.code).toBe(0);
     expect(r.stdout.trim()).toBe("");
@@ -167,8 +237,14 @@ describe("red-envelope parity", () => {
 
   it("no-ops when state file does not exist", async () => {
     if (skipIfMissing("red-envelope")) return;
-    const ctx = JSON.stringify({ result: { status: "fail", outcome: "no-sentinel" } });
-    const r = await runScript("red-envelope", { RED_AFK_STATE_FILE: "/tmp/no-such-state.json" }, ctx);
+    const ctx = JSON.stringify({
+      result: { status: "fail", outcome: "no-sentinel" },
+    });
+    const r = await runScript(
+      "red-envelope",
+      { RED_AFK_STATE_FILE: "/tmp/no-such-state.json" },
+      ctx,
+    );
     expect(r.code).toBe(0);
   });
 
@@ -176,9 +252,18 @@ describe("red-envelope parity", () => {
     if (skipIfMissing("red-envelope")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-envelope-"));
     const stateFile = join(tmp, "afk.state.toon");
-    writeFileSync(stateFile, JSON.stringify({ current: { activity: "running" } }));
-    const ctx = JSON.stringify({ result: { status: "success", outcome: "done" } });
-    const r = await runScript("red-envelope", { RED_AFK_STATE_FILE: stateFile }, ctx);
+    writeFileSync(
+      stateFile,
+      JSON.stringify({ current: { activity: "running" } }),
+    );
+    const ctx = JSON.stringify({
+      result: { status: "success", outcome: "done" },
+    });
+    const r = await runScript(
+      "red-envelope",
+      { RED_AFK_STATE_FILE: stateFile },
+      ctx,
+    );
     expect(r.code).toBe(0);
     expect(r.stdout.trim()).toBe("");
     const state = JSON.parse(readFileSync(stateFile, "utf8"));
@@ -191,7 +276,11 @@ describe("red-envelope parity", () => {
     const tmp = mkdtempSync(join(tmpdir(), "red-envelope-"));
     const stateFile = join(tmp, "afk.state.toon");
     writeFileSync(stateFile, JSON.stringify({ current: {} }));
-    const r = await runScript("red-envelope", { RED_AFK_STATE_FILE: stateFile, RED_AFK_RESULT_STATUS: "fail" }, "{}");
+    const r = await runScript(
+      "red-envelope",
+      { RED_AFK_STATE_FILE: stateFile, RED_AFK_RESULT_STATUS: "fail" },
+      "{}",
+    );
     expect(r.code).toBe(0);
     const state = JSON.parse(readFileSync(stateFile, "utf8"));
     expect(state.current.result_status).toBe("fail");
@@ -213,7 +302,11 @@ describe("red-validation parity", () => {
     if (skipIfMissing("red-validation")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-validation-"));
     const ctx = JSON.stringify({ issue: { number: 2 }, workspace: tmp });
-    const r = await runScript("red-validation", { RED_AFK_WORKSPACE: tmp }, ctx);
+    const r = await runScript(
+      "red-validation",
+      { RED_AFK_WORKSPACE: tmp },
+      ctx,
+    );
     expect(r.code).toBe(0);
     const out = JSON.parse(r.stdout.trim());
     expect(out.result.validation_status).toBe("skipped");
@@ -224,12 +317,25 @@ describe("red-validation parity", () => {
     if (skipIfMissing("red-validation")) return;
     const tmp = mkdtempSync(join(tmpdir(), "red-validation-"));
     // package.json with no scripts → all skipped → passes
-    writeFileSync(join(tmp, "package.json"), JSON.stringify({ name: "test", scripts: {} }));
-    const ctx = JSON.stringify({ issue: { number: 3 }, workspace: tmp, merge_commit: { sha: "abc" } });
-    const r = await runScript("red-validation", { RED_AFK_WORKSPACE: tmp }, ctx);
+    writeFileSync(
+      join(tmp, "package.json"),
+      JSON.stringify({ name: "test", scripts: {} }),
+    );
+    const ctx = JSON.stringify({
+      issue: { number: 3 },
+      workspace: tmp,
+      merge_commit: { sha: "abc" },
+    });
+    const r = await runScript(
+      "red-validation",
+      { RED_AFK_WORKSPACE: tmp },
+      ctx,
+    );
     expect(r.code).toBe(0);
     const out = JSON.parse(r.stdout.trim());
-    expect(["passed", "failed", "skipped"]).toContain(out.result.validation_status);
+    expect(["passed", "failed", "skipped"]).toContain(
+      out.result.validation_status,
+    );
     // original context fields preserved
     expect(out.issue.number).toBe(3);
     expect(out.merge_commit.sha).toBe("abc");

--- a/apps/dev/tests/runtime-hooks.test.ts
+++ b/apps/dev/tests/runtime-hooks.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { hookEnv, makeHookExec, makeHookResolveOptions } from "../src/runtime/hooks.js";
+import {
+  hookEnv,
+  makeHookExec,
+  makeHookResolveOptions,
+} from "../src/runtime/hooks.js";
 import { skillDirFromModule } from "../src/platform/skill-paths.js";
 import { resolveHooks } from "../src/core/hook-config.js";
 
@@ -25,7 +30,16 @@ describe("makeHookResolveOptions (gap 6: built-in defaults anchor on the plugin)
       // The bundle ships at <plugin>/bin/afk.mjs; resolve from there.
       const here = new URL(import.meta.url).pathname; // .../apps/dev/tests/runtime-hooks.test.ts
       const repoRoot = here.slice(0, here.indexOf("/apps/dev/"));
-      const binMjs = join(repoRoot, "plugins", "dev", "skills", "engineering", "afk", "bin", "afk.mjs");
+      const binMjs = join(
+        repoRoot,
+        "plugins",
+        "dev",
+        "skills",
+        "engineering",
+        "afk",
+        "bin",
+        "afk.mjs",
+      );
       skillDir = skillDirFromModule(new URL(`file://${binMjs}`).href);
     } catch {
       // The skill/bundle isn't laid out in this checkout — skip the strong assertion.
@@ -42,17 +56,19 @@ describe("makeHookResolveOptions (gap 6: built-in defaults anchor on the plugin)
     // resolveHooks must register the cargo + gradle defaults at pre_worktree.
     const resolved = resolveHooks(
       {},
-      { defaultCommand: (name) => {
-        const scripts: Record<string, string> = {
-          cargo: "red-cargo",
-          gradle: "red-gradle",
-          heartbeat: "red-heartbeat",
-          envelope: "red-envelope",
-          validation: "red-validation",
-        };
-        const p = join(hooksDir, scripts[name]!);
-        return existsSync(p) ? p : undefined;
-      } },
+      {
+        defaultCommand: (name) => {
+          const scripts: Record<string, string> = {
+            cargo: "red-cargo",
+            gradle: "red-gradle",
+            heartbeat: "red-heartbeat",
+            envelope: "red-envelope",
+            validation: "red-validation",
+          };
+          const p = join(hooksDir, scripts[name]!);
+          return existsSync(p) ? p : undefined;
+        },
+      },
     );
     expect(resolved.pre_worktree).toEqual([
       join(hooksDir, "red-cargo"),
@@ -62,19 +78,21 @@ describe("makeHookResolveOptions (gap 6: built-in defaults anchor on the plugin)
     expect(resolved.post_merge).toContain(join(hooksDir, "red-validation"));
   });
 
-  it("never points at the consuming project's .red unless the skill dir is unreachable", () => {
-    // makeHookResolveOptions(root) must NOT default to `<root>/.red/hooks/lib`
-    // when the plugin is reachable — that path never ships the scripts. We assert
-    // the resolver returns undefined for a fictional project root (no library
-    // scripts under it), proving it does not silently read project-local paths.
-    const opts = makeHookResolveOptions("/tmp/no-such-afk-project-xyz");
-    // Whatever the anchor, a fictional project has no scripts, so cargo resolves
-    // to undefined only if the anchor is NOT a populated plugin dir. When the
-    // anchor IS the real plugin (source-tree run throws → project fallback), cargo
-    // is undefined because the fallback dir is empty — either way it is a string
-    // path or undefined, never a crash.
-    const cargo = opts.defaultCommand("cargo");
-    expect(cargo === undefined || typeof cargo === "string").toBe(true);
+  it("omits cargo and gradle defaults for a consuming repo with no matching build files", () => {
+    const root = mkdtempSync(join(tmpdir(), "runtime-hooks-node-project-"));
+    const skillDir = join(root, "installed-afk-skill");
+    const hooksDir = join(skillDir, "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    for (const script of ["red-cargo", "red-gradle", "red-heartbeat"]) {
+      writeFileSync(join(hooksDir, script), "#!/usr/bin/env bash\n");
+    }
+    const opts = makeHookResolveOptions(root, () => skillDir);
+
+    expect(opts.defaultCommand("cargo")).toBeUndefined();
+    expect(opts.defaultCommand("gradle")).toBeUndefined();
+    expect(opts.defaultCommand("heartbeat")).toBe(
+      join(hooksDir, "red-heartbeat"),
+    );
   });
 });
 
@@ -87,7 +105,9 @@ describe("hookEnv (per-slot RED_AFK_SLOT in hook environment)", () => {
   });
 
   it("includes RED_AFK_RUNNER when the caller supplies the resolved runner", () => {
-    expect(hookEnv("owner/repo", "/repo", undefined, "codex").RED_AFK_RUNNER).toBe("codex");
+    expect(
+      hookEnv("owner/repo", "/repo", undefined, "codex").RED_AFK_RUNNER,
+    ).toBe("codex");
   });
 
   it("omits RED_AFK_SLOT when no slot is given", () => {
@@ -101,7 +121,9 @@ describe("hookEnv (per-slot RED_AFK_SLOT in hook environment)", () => {
   });
 
   it("each slot gets a distinct RED_AFK_SLOT value", () => {
-    const slots = [0, 1, 2].map((s) => hookEnv("owner/repo", "/repo", s).RED_AFK_SLOT);
+    const slots = [0, 1, 2].map(
+      (s) => hookEnv("owner/repo", "/repo", s).RED_AFK_SLOT,
+    );
     expect(slots).toEqual(["0", "1", "2"]);
   });
 });
@@ -111,7 +133,11 @@ describe("makeHookExec", () => {
     const exec = makeHookExec(process.cwd());
 
     await expect(
-      exec('read -r _; shopt -s extglob; [[ foobar == +(foo|bar) ]] && printf \'extglob-ok\'', {}, "{}\n"),
+      exec(
+        "read -r _; shopt -s extglob; [[ foobar == +(foo|bar) ]] && printf 'extglob-ok'",
+        {},
+        "{}\n",
+      ),
     ).resolves.toEqual({ code: 0, stdout: "extglob-ok" });
   });
 });

--- a/packages/red-castle/src/engine/lifecycle-hooks.test.ts
+++ b/packages/red-castle/src/engine/lifecycle-hooks.test.ts
@@ -41,9 +41,13 @@ describe("castle lifecycle hooks", () => {
 
   it("discovers skin hook bodies with project shadows and pre_worktree defaults", () => {
     const root = tempDir();
+    const projectRoot = join(root, "project");
     const libraryHooksDir = join(root, "plugin", "hooks");
     const projectHooksDir = join(root, ".red", "hooks");
-    const cargo = touch(join(libraryHooksDir, "red-cargo"));
+    touch(join(projectRoot, "Cargo.toml"));
+    touch(join(projectRoot, "build.gradle.kts"));
+    const cargo = touch(join(projectHooksDir, "red-cargo"));
+    touch(join(libraryHooksDir, "red-cargo"));
     const gradle = touch(join(libraryHooksDir, "red-gradle"));
     const libWorkerStart = touch(join(libraryHooksDir, "worker_start"));
     const projectWorkerStart = touch(join(projectHooksDir, "worker_start"));
@@ -63,6 +67,7 @@ describe("castle lifecycle hooks", () => {
       {
         libraryHooksDir,
         projectHooksDir,
+        projectRoot,
       },
     );
 
@@ -80,6 +85,37 @@ describe("castle lifecycle hooks", () => {
       "echo post-merge-a",
       "echo post-merge-b",
     ]);
+  });
+
+  it("resolves no build hook commands for a project with no matching build files", () => {
+    const root = tempDir();
+    const libraryHooksDir = join(root, "plugin", "hooks");
+    touch(join(libraryHooksDir, "red-cargo"));
+    touch(join(libraryHooksDir, "red-gradle"));
+
+    const resolved = resolveCastleHooks(
+      {},
+      { libraryHooksDir, projectRoot: join(root, "project") },
+    );
+
+    expect(resolved.pre_worktree).toEqual([]);
+  });
+
+  it("does not resolve a matching build hook when config disables that default", () => {
+    const root = tempDir();
+    const projectRoot = join(root, "project");
+    const libraryHooksDir = join(root, "plugin", "hooks");
+    touch(join(projectRoot, "Cargo.toml"));
+    touch(join(projectRoot, "build.gradle"));
+    touch(join(libraryHooksDir, "red-cargo"));
+    const gradle = touch(join(libraryHooksDir, "red-gradle"));
+
+    const resolved = resolveCastleHooks(
+      { "afk.hooks.defaults.cargo": "false" },
+      { libraryHooksDir, projectRoot },
+    );
+
+    expect(resolved.pre_worktree).toEqual([gradle]);
   });
 
   it("invokes bodies with the frozen RED_AFK env contract and mutable stdin JSON", async () => {

--- a/packages/red-castle/src/engine/lifecycle-hooks.ts
+++ b/packages/red-castle/src/engine/lifecycle-hooks.ts
@@ -79,6 +79,7 @@ export interface CastleHookDispatchResult {
 export interface ResolveCastleHooksOptions {
   readonly libraryHooksDir?: string;
   readonly projectHooksDir?: string;
+  readonly projectRoot?: string;
   readonly defaultCommand?: CastleHookDefaultResolver;
   readonly listFiles?: (dir: string) => string[];
   readonly exists?: (path: string) => boolean;
@@ -243,13 +244,37 @@ function flatPointBody(
 export function castleHookDefaultResolver(
   libraryHooksDir: string,
   projectHooksDir?: string,
+  projectRoot?: string,
   exists: (path: string) => boolean = existsSync,
+  listFiles: (dir: string) => string[] = readdirSync,
+  isFile: (path: string) => boolean = (path) => statSync(path).isFile(),
 ): CastleHookDefaultResolver {
   const scripts: Record<CastleHookDefaultName, string> = {
     cargo: "red-cargo",
     gradle: "red-gradle",
   };
   return (name) => {
+    if (
+      name === "cargo" &&
+      projectRoot !== undefined &&
+      (!exists(join(projectRoot, "Cargo.toml")) ||
+        !isFile(join(projectRoot, "Cargo.toml")))
+    ) {
+      return undefined;
+    }
+    if (name === "gradle" && projectRoot !== undefined) {
+      let hasGradleBuild = false;
+      try {
+        hasGradleBuild = listFiles(projectRoot).some(
+          (file) =>
+            file.startsWith("build.gradle") && isFile(join(projectRoot, file)),
+        );
+      } catch {
+        hasGradleBuild = false;
+      }
+      if (!hasGradleBuild) return undefined;
+    }
+
     const filename = scripts[name];
     if (projectHooksDir !== undefined) {
       const project = join(projectHooksDir, filename);
@@ -324,7 +349,10 @@ export function resolveCastleHooks(
       : castleHookDefaultResolver(
           options.libraryHooksDir,
           options.projectHooksDir,
+          options.projectRoot,
           exists,
+          listFiles,
+          isFile,
         ));
   const inline = collectInlineHookCommands(config);
 
@@ -338,6 +366,7 @@ export function resolveCastleHooks(
 
     if (defaults) {
       for (const defaultName of defaults) {
+        if (config[`afk.hooks.defaults.${defaultName}`] === "false") continue;
         const command = defaultCommand(defaultName);
         if (command !== undefined) commands.push(command);
       }

--- a/packaging/pi/dev/skills/engineering/afk/defaults/gradle-pre-worktree.sh
+++ b/packaging/pi/dev/skills/engineering/afk/defaults/gradle-pre-worktree.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # gradle-pre-worktree.sh — built-in pre_worktree default for Gradle projects.
 #
 # Contract (PRD #207, issue #211):
@@ -15,20 +15,23 @@
 #
 # Disable with `afk.hooks.defaults.gradle: false` in `.red/config.yaml`.
 
-set -uo pipefail
+set -u
 
 project_root="${PROJECT_ROOT:-$(pwd)}"
 ctx="$(timeout "${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}" cat 2>/dev/null || true)"
-[[ -z "$ctx" ]] && ctx='{}'
+[ -n "$ctx" ] || ctx='{}'
 
-shopt -s nullglob
-matches=("$project_root"/build.gradle*)
-shopt -u nullglob
-if [[ "${#matches[@]}" -eq 0 ]]; then
+has_gradle_build=false
+for candidate in "$project_root"/build.gradle*; do
+  [ -f "$candidate" ] || continue
+  has_gradle_build=true
+  break
+done
+if [ "$has_gradle_build" = false ]; then
   exit 0
 fi
 
-if [[ -z "${RED_AFK_GRADLE_USER_HOME_BASE:-}" ]]; then
+if [ -z "${RED_AFK_GRADLE_USER_HOME_BASE:-}" ]; then
   exit 0
 fi
 

--- a/packaging/pi/dev/skills/engineering/afk/detectors/gradle.sh
+++ b/packaging/pi/dev/skills/engineering/afk/detectors/gradle.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # gradle.sh — afk pre-spawn detector for Gradle projects.
 #
 # Applies when a build.gradle* file exists at PROJECT_ROOT AND the
@@ -18,10 +18,13 @@ set -u
 
 project_root="${PROJECT_ROOT:-$(pwd)}"
 
-shopt -s nullglob
-matches=("$project_root"/build.gradle*)
-shopt -u nullglob
-[ "${#matches[@]}" -gt 0 ] || exit 1
+has_gradle_build=false
+for candidate in "$project_root"/build.gradle*; do
+  [ -f "$candidate" ] || continue
+  has_gradle_build=true
+  break
+done
+[ "$has_gradle_build" = true ] || exit 1
 
 [ -n "${RED_AFK_GRADLE_USER_HOME_BASE:-}" ] || exit 1
 

--- a/packaging/pi/dev/skills/engineering/afk/hooks/red-cargo
+++ b/packaging/pi/dev/skills/engineering/afk/hooks/red-cargo
@@ -3,10 +3,10 @@
 #
 # Contract (ADR 0026, PRD #207, issue #211):
 #   stdin   — JSON object: pre_worktree context (issue, target, branch, env).
-#   stdout  — empty (context unchanged) when no Cargo.toml is present at
-#             $PROJECT_ROOT, OR a JSON object that merges
+#   applicability — decided by the Node resolver before this leaf runs.
+#   stdout  — a JSON object that merges
 #             {env: {CARGO_TARGET_DIR: <slot dir>}} into the context.
-#   exit    — 0 on either branch. Never aborts the chain.
+#   exit    — 0. Never aborts the chain.
 #
 # Side effect: mkdir -p the slot target dir so cargo can use it immediately.
 # CARGO_TARGET_DIR=${RED_AFK_CARGO_TARGET_BASE:-/opt/cargo-target}/slot-${RED_AFK_SLOT:-0}
@@ -22,16 +22,10 @@
 # Shadowing: place a same-named file in .red/hooks/red-cargo to replace this
 # default with a project-local variant. An empty (exit-0) file disables it.
 
-set -uo pipefail
+set -u
 
-project_root="${PROJECT_ROOT:-$(pwd)}"
 ctx="$(timeout "${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}" cat 2>/dev/null || true)"
-[[ -z "$ctx" ]] && ctx='{}'
-
-if [[ ! -f "$project_root/Cargo.toml" ]]; then
-  # Not a Rust project — pass-through.
-  exit 0
-fi
+[ -n "$ctx" ] || ctx='{}'
 
 slot="${RED_AFK_SLOT:-0}"
 base="${RED_AFK_CARGO_TARGET_BASE:-/opt/cargo-target}"

--- a/packaging/pi/dev/skills/engineering/afk/hooks/red-gradle
+++ b/packaging/pi/dev/skills/engineering/afk/hooks/red-gradle
@@ -3,9 +3,9 @@
 #
 # Contract (ADR 0026, PRD #207, issue #211):
 #   stdin   — JSON object: pre_worktree context (issue, target, branch, env).
-#   stdout  — empty (context unchanged) when no build.gradle* is present at
-#             $PROJECT_ROOT, OR when RED_AFK_GRADLE_USER_HOME_BASE is unset
-#             (opt-in by env var — we do not claim a path on the user's
+#   applicability — decided by the Node resolver before this leaf runs.
+#   stdout  — empty (context unchanged) when RED_AFK_GRADLE_USER_HOME_BASE is
+#             unset (opt-in by env var — we do not claim a path on the user's
 #             filesystem without their consent). Otherwise a JSON object
 #             that merges {env: {GRADLE_USER_HOME: <slot dir>}} into ctx.
 #   exit    — 0 on either branch. Never aborts the chain.
@@ -23,20 +23,12 @@
 # Shadowing: place a same-named file in .red/hooks/red-gradle to replace this
 # default with a project-local variant. An empty (exit-0) file disables it.
 
-set -uo pipefail
+set -u
 
-project_root="${PROJECT_ROOT:-$(pwd)}"
 ctx="$(timeout "${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}" cat 2>/dev/null || true)"
-[[ -z "$ctx" ]] && ctx='{}'
+[ -n "$ctx" ] || ctx='{}'
 
-shopt -s nullglob
-matches=("$project_root"/build.gradle*)
-shopt -u nullglob
-if [[ "${#matches[@]}" -eq 0 ]]; then
-  exit 0
-fi
-
-if [[ -z "${RED_AFK_GRADLE_USER_HOME_BASE:-}" ]]; then
+if [ -z "${RED_AFK_GRADLE_USER_HOME_BASE:-}" ]; then
   exit 0
 fi
 

--- a/packaging/pi/dev/skills/misc/branch-lock/scripts/tests/codex-hook.test.sh
+++ b/packaging/pi/dev/skills/misc/branch-lock/scripts/tests/codex-hook.test.sh
@@ -64,6 +64,7 @@ payload() {
 manifest_hook="$(jq -r '.hooks.PreToolUse[0].hooks[] | select(.command | contains("branch-lock-codex.sh")) | .command' "$MANIFEST")"
 expect_contains "manifest: wires branch-lock-codex.sh" "branch-lock-codex.sh" "$manifest_hook"
 expect_contains "manifest: wrapper drains stdin before hook" 'cat >"$tmp"' "$manifest_hook"
+expect_contains "manifest: invokes bash-dependent hook explicitly" 'bash "$hook"' "$manifest_hook"
 
 out="$tmp/manifest-out"
 err="$tmp/manifest-err"

--- a/plugins/dev/hooks/codex.hooks.json
+++ b/plugins/dev/hooks/codex.hooks.json
@@ -31,7 +31,7 @@
           },
           {
             "type": "command",
-            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; hook=\"${CODEX_PLUGIN_ROOT}/hooks/branch-lock-codex.sh\"; if [ -x \"$hook\" ]; then timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-3s}\" \"$hook\" <\"$tmp\" || printf \"{}\"; else printf \"{}\"; fi'"
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; hook=\"${CODEX_PLUGIN_ROOT}/hooks/branch-lock-codex.sh\"; if [ -f \"$hook\" ]; then timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-3s}\" bash \"$hook\" <\"$tmp\" || printf \"{}\"; else printf \"{}\"; fi'"
           },
           {
             "type": "command",

--- a/plugins/dev/skills/engineering/afk/defaults/gradle-pre-worktree.sh
+++ b/plugins/dev/skills/engineering/afk/defaults/gradle-pre-worktree.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # gradle-pre-worktree.sh — built-in pre_worktree default for Gradle projects.
 #
 # Contract (PRD #207, issue #211):
@@ -15,20 +15,23 @@
 #
 # Disable with `afk.hooks.defaults.gradle: false` in `.red/config.yaml`.
 
-set -uo pipefail
+set -u
 
 project_root="${PROJECT_ROOT:-$(pwd)}"
 ctx="$(timeout "${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}" cat 2>/dev/null || true)"
-[[ -z "$ctx" ]] && ctx='{}'
+[ -n "$ctx" ] || ctx='{}'
 
-shopt -s nullglob
-matches=("$project_root"/build.gradle*)
-shopt -u nullglob
-if [[ "${#matches[@]}" -eq 0 ]]; then
+has_gradle_build=false
+for candidate in "$project_root"/build.gradle*; do
+  [ -f "$candidate" ] || continue
+  has_gradle_build=true
+  break
+done
+if [ "$has_gradle_build" = false ]; then
   exit 0
 fi
 
-if [[ -z "${RED_AFK_GRADLE_USER_HOME_BASE:-}" ]]; then
+if [ -z "${RED_AFK_GRADLE_USER_HOME_BASE:-}" ]; then
   exit 0
 fi
 

--- a/plugins/dev/skills/engineering/afk/detectors/gradle.sh
+++ b/plugins/dev/skills/engineering/afk/detectors/gradle.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # gradle.sh — afk pre-spawn detector for Gradle projects.
 #
 # Applies when a build.gradle* file exists at PROJECT_ROOT AND the
@@ -18,10 +18,13 @@ set -u
 
 project_root="${PROJECT_ROOT:-$(pwd)}"
 
-shopt -s nullglob
-matches=("$project_root"/build.gradle*)
-shopt -u nullglob
-[ "${#matches[@]}" -gt 0 ] || exit 1
+has_gradle_build=false
+for candidate in "$project_root"/build.gradle*; do
+  [ -f "$candidate" ] || continue
+  has_gradle_build=true
+  break
+done
+[ "$has_gradle_build" = true ] || exit 1
 
 [ -n "${RED_AFK_GRADLE_USER_HOME_BASE:-}" ] || exit 1
 

--- a/plugins/dev/skills/engineering/afk/hooks/red-cargo
+++ b/plugins/dev/skills/engineering/afk/hooks/red-cargo
@@ -3,10 +3,10 @@
 #
 # Contract (ADR 0026, PRD #207, issue #211):
 #   stdin   — JSON object: pre_worktree context (issue, target, branch, env).
-#   stdout  — empty (context unchanged) when no Cargo.toml is present at
-#             $PROJECT_ROOT, OR a JSON object that merges
+#   applicability — decided by the Node resolver before this leaf runs.
+#   stdout  — a JSON object that merges
 #             {env: {CARGO_TARGET_DIR: <slot dir>}} into the context.
-#   exit    — 0 on either branch. Never aborts the chain.
+#   exit    — 0. Never aborts the chain.
 #
 # Side effect: mkdir -p the slot target dir so cargo can use it immediately.
 # CARGO_TARGET_DIR=${RED_AFK_CARGO_TARGET_BASE:-/opt/cargo-target}/slot-${RED_AFK_SLOT:-0}
@@ -22,16 +22,10 @@
 # Shadowing: place a same-named file in .red/hooks/red-cargo to replace this
 # default with a project-local variant. An empty (exit-0) file disables it.
 
-set -uo pipefail
+set -u
 
-project_root="${PROJECT_ROOT:-$(pwd)}"
 ctx="$(timeout "${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}" cat 2>/dev/null || true)"
-[[ -z "$ctx" ]] && ctx='{}'
-
-if [[ ! -f "$project_root/Cargo.toml" ]]; then
-  # Not a Rust project — pass-through.
-  exit 0
-fi
+[ -n "$ctx" ] || ctx='{}'
 
 slot="${RED_AFK_SLOT:-0}"
 base="${RED_AFK_CARGO_TARGET_BASE:-/opt/cargo-target}"

--- a/plugins/dev/skills/engineering/afk/hooks/red-gradle
+++ b/plugins/dev/skills/engineering/afk/hooks/red-gradle
@@ -3,9 +3,9 @@
 #
 # Contract (ADR 0026, PRD #207, issue #211):
 #   stdin   — JSON object: pre_worktree context (issue, target, branch, env).
-#   stdout  — empty (context unchanged) when no build.gradle* is present at
-#             $PROJECT_ROOT, OR when RED_AFK_GRADLE_USER_HOME_BASE is unset
-#             (opt-in by env var — we do not claim a path on the user's
+#   applicability — decided by the Node resolver before this leaf runs.
+#   stdout  — empty (context unchanged) when RED_AFK_GRADLE_USER_HOME_BASE is
+#             unset (opt-in by env var — we do not claim a path on the user's
 #             filesystem without their consent). Otherwise a JSON object
 #             that merges {env: {GRADLE_USER_HOME: <slot dir>}} into ctx.
 #   exit    — 0 on either branch. Never aborts the chain.
@@ -23,20 +23,12 @@
 # Shadowing: place a same-named file in .red/hooks/red-gradle to replace this
 # default with a project-local variant. An empty (exit-0) file disables it.
 
-set -uo pipefail
+set -u
 
-project_root="${PROJECT_ROOT:-$(pwd)}"
 ctx="$(timeout "${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}" cat 2>/dev/null || true)"
-[[ -z "$ctx" ]] && ctx='{}'
+[ -n "$ctx" ] || ctx='{}'
 
-shopt -s nullglob
-matches=("$project_root"/build.gradle*)
-shopt -u nullglob
-if [[ "${#matches[@]}" -eq 0 ]]; then
-  exit 0
-fi
-
-if [[ -z "${RED_AFK_GRADLE_USER_HOME_BASE:-}" ]]; then
+if [ -z "${RED_AFK_GRADLE_USER_HOME_BASE:-}" ]; then
   exit 0
 fi
 

--- a/plugins/dev/skills/misc/branch-lock/scripts/tests/codex-hook.test.sh
+++ b/plugins/dev/skills/misc/branch-lock/scripts/tests/codex-hook.test.sh
@@ -64,6 +64,7 @@ payload() {
 manifest_hook="$(jq -r '.hooks.PreToolUse[0].hooks[] | select(.command | contains("branch-lock-codex.sh")) | .command' "$MANIFEST")"
 expect_contains "manifest: wires branch-lock-codex.sh" "branch-lock-codex.sh" "$manifest_hook"
 expect_contains "manifest: wrapper drains stdin before hook" 'cat >"$tmp"' "$manifest_hook"
+expect_contains "manifest: invokes bash-dependent hook explicitly" 'bash "$hook"' "$manifest_hook"
 
 out="$tmp/manifest-out"
 err="$tmp/manifest-err"


### PR DESCRIPTION
Automated AFK landing for #2477. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2477

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787375371&installation_model_id=20659&pr_number=2544&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2544&signature=63568de273a1b346e5abbbca96ac9833e1465f90c649f01c7afab8269727f70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->