### PR TITLE
feat: #2513 PR medic — bounded mechanical CI/conflict healer before escalation

### DIFF
--- a/.changeset/pr-medic.md
+++ b/.changeset/pr-medic.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": minor
+---
+
+PR medic (#2513, Spec #2511 slice 2): when the merge driver classifies a PR needs-medic, a bounded mechanical healing round runs in an isolated feedback-lane worktree before any escalation — stale staged Pi mirrors are regenerated, registered identifier renames applied, and additive conflicts union-resolved; anything semantic escalates untouched. Two failed rounds per PR escalate to needs-human, every action ledgered in `.red/state/castle/pr-medic.toon`; a healed push re-arms the PR on the driver.

--- a/apps/dev/src/core/pr-medic.ts
+++ b/apps/dev/src/core/pr-medic.ts
@@ -1,0 +1,328 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import type { EnginePaths } from "@reddb-io/red-castle/engine";
+
+/**
+ * PR medic (Spec #2511 slice 2, #2513): when the merge driver classifies a PR
+ * `needs-medic`, run a BOUNDED mechanical healing pass before any human
+ * escalation — covering exactly the failure classes hand-fixed on 2026-07-22:
+ * stale generated Pi mirrors, identifier renames landed on main after the
+ * branch forked, and additive merge conflicts where both sides only add lines.
+ * Anything else is semantic and escalates untouched. Two failed rounds per PR
+ * → escalate, never loop.
+ */
+
+export const MEDIC_MAX_ROUNDS = 2;
+
+/** Old→new identifier renames the medic may apply mechanically. Grows only
+ * with renames that landed on main and keep breaking stale branches. */
+export const MEDIC_RENAME_REGISTRY: Readonly<Record<string, string>> = {
+  createDevAfkMcpDependencies: "createCastleMcpDependencies",
+};
+
+export type MedicFailureClass =
+  | "stale-pi"
+  | "stale-rename"
+  | "additive-conflict"
+  | "semantic";
+
+/** Classify one failing-CI diagnosis into a healable class. Conservative: the
+ * medic only claims a failure it has a mechanical cure for. */
+export function classifyMedicFailure(input: {
+  /** Tail of the failing check log. */
+  logTail: string;
+  /** Conflicted file contents by path (empty when CI failed without conflict). */
+  conflicts: Readonly<Record<string, string>>;
+  /** File contents by path for rename scanning (changed files after merge). */
+  files: Readonly<Record<string, string>>;
+  registry?: Readonly<Record<string, string>>;
+}): MedicFailureClass {
+  const registry = input.registry ?? MEDIC_RENAME_REGISTRY;
+  if (Object.keys(input.conflicts).length > 0) {
+    const resolvable = Object.values(input.conflicts).every(
+      (text) => unionResolveConflicts(text) !== null,
+    );
+    return resolvable ? "additive-conflict" : "semantic";
+  }
+  if (/staged Pi packages are stale|pi-package-builder/i.test(input.logTail)) return "stale-pi";
+  const renamed = Object.keys(registry).some((old) =>
+    Object.values(input.files).some((text) => text.includes(old)),
+  );
+  if (renamed) return "stale-rename";
+  return "semantic";
+}
+
+/** Apply the rename registry to one file. Returns the rewritten text and the
+ * replacement count (0 = untouched). */
+export function applyRenameRegistry(
+  text: string,
+  registry: Readonly<Record<string, string>> = MEDIC_RENAME_REGISTRY,
+): { text: string; replacements: number } {
+  let out = text;
+  let replacements = 0;
+  for (const [old, next] of Object.entries(registry)) {
+    const re = new RegExp(`\\b${old}\\b`, "g");
+    out = out.replace(re, () => {
+      replacements += 1;
+      return next;
+    });
+  }
+  return { text: out, replacements };
+}
+
+/** A line the union resolver accepts as "additive context": an import, a
+ * quoted registry entry, a spread registration, or a bare identifier row —
+ * the shapes of import blocks, tool registrations, and test-list fixtures. */
+const ADDITIVE_LINE_RE =
+  /^\s*(import\s.+|export \{.*|"[^"]*",?|'[^']*',?|\.\.\..+,?|[\w$]+(: [\w$().\s]+)?,?|\s*)$/;
+
+/**
+ * Union-resolve every conflict hunk in `text`, or return null when ANY hunk is
+ * not provably additive. Additive means: no base overlap (each side only adds),
+ * the two sides share no conflicting rewrite of a common line, and every line
+ * on both sides matches the additive-context shapes. The union keeps ours-then-
+ * theirs order and drops exact duplicates.
+ */
+export function unionResolveConflicts(text: string): string | null {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    if (!line.startsWith("<<<<<<<")) {
+      out.push(line);
+      i += 1;
+      continue;
+    }
+    const ours: string[] = [];
+    const theirs: string[] = [];
+    let cursor = i + 1;
+    let section: "ours" | "base" | "theirs" = "ours";
+    let closed = false;
+    for (; cursor < lines.length; cursor += 1) {
+      const current = lines[cursor]!;
+      if (current.startsWith("|||||||")) {
+        section = "base";
+        continue;
+      }
+      if (current.startsWith("=======")) {
+        section = "theirs";
+        continue;
+      }
+      if (current.startsWith(">>>>>>>")) {
+        closed = true;
+        break;
+      }
+      if (section === "ours") ours.push(current);
+      else if (section === "theirs") theirs.push(current);
+      else if (current.trim() !== "") return null; // non-empty base → both sides EDITED, not additive
+    }
+    if (!closed) return null;
+    if (ours.length + theirs.length === 0) return null;
+    if (![...ours, ...theirs].every((l) => ADDITIVE_LINE_RE.test(l))) return null;
+    // Same-key rewrites are edits, not additions: when a line's key (the text
+    // before `:`/`=`) appears on both sides with different content, the two
+    // sides are rewriting one entity and the merge is semantic.
+    const keyOf = (l: string): string => l.trim().split(/[:=]/)[0]!.trim();
+    const rewritten = ours.some((l) => {
+      if (l.trim() === "") return false;
+      return theirs.some(
+        (t) => t.trim() !== "" && t.trim() !== l.trim() && keyOf(t) === keyOf(l),
+      );
+    });
+    if (rewritten) return null;
+    const seen = new Set<string>();
+    for (const l of [...ours, ...theirs]) {
+      const key = l.trim();
+      if (key !== "" && seen.has(key)) continue;
+      seen.add(key);
+      out.push(l);
+    }
+    i = cursor + 1;
+  }
+  return out.join("\n");
+}
+
+// ---------- durable rounds ledger ----------
+
+export interface MedicPrRecord {
+  readonly pr: number;
+  readonly rounds: number;
+  readonly outcome: "healing" | "healed" | "escalated";
+  readonly updatedAtEpoch: number;
+  readonly actions: readonly string[];
+}
+
+export interface MedicState {
+  readonly version: 1;
+  readonly prs: Record<string, MedicPrRecord>;
+}
+
+export interface MedicStore {
+  read(): Promise<MedicState>;
+  write(state: MedicState): Promise<void>;
+}
+
+export function medicStatePath(paths: EnginePaths): string {
+  return join(paths.castleStateRoot, "pr-medic.toon");
+}
+
+function validateMedicState(value: unknown): MedicState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return { version: 1, prs: {} };
+  const raw = value as Partial<MedicState>;
+  if (raw.version !== 1 || !raw.prs || typeof raw.prs !== "object") return { version: 1, prs: {} };
+  const prs: Record<string, MedicPrRecord> = {};
+  for (const [key, record] of Object.entries(raw.prs)) {
+    if (!/^\d+$/.test(key) || !record || typeof record !== "object") continue;
+    const r = record as Partial<MedicPrRecord>;
+    if (!Number.isSafeInteger(r.pr)) continue;
+    prs[key] = {
+      pr: r.pr as number,
+      rounds: Number.isSafeInteger(r.rounds) ? (r.rounds as number) : 0,
+      outcome: r.outcome === "healed" || r.outcome === "escalated" ? r.outcome : "healing",
+      updatedAtEpoch: Number.isSafeInteger(r.updatedAtEpoch) ? (r.updatedAtEpoch as number) : 0,
+      actions: Array.isArray(r.actions) ? r.actions.filter((a): a is string => typeof a === "string") : [],
+    };
+  }
+  return { version: 1, prs };
+}
+
+export function createFileMedicStore(paths: EnginePaths): MedicStore {
+  const path = medicStatePath(paths);
+  return {
+    async read() {
+      try {
+        return validateMedicState(decode(await readFile(path, "utf8")));
+      } catch {
+        return { version: 1, prs: {} };
+      }
+    },
+    async write(state) {
+      await mkdir(dirname(path), { recursive: true });
+      const temporary = `${path}.tmp-${process.pid}-${crypto.randomUUID()}`;
+      await writeFile(temporary, encode(validateMedicState(state) as unknown as JsonValue, { keyedMapCollapse: true }), "utf8");
+      await rename(temporary, path);
+    },
+  };
+}
+
+// ---------- the bounded healing pass ----------
+
+/** IO port for one healing round, executed inside an isolated worktree the
+ * host creates and destroys around the call. */
+export interface MedicIo {
+  /** Gather the diagnosis inputs for the PR (failing log tail, conflicted and
+   * changed file contents). */
+  diagnose(pr: number): Promise<{
+    logTail: string;
+    conflicts: Record<string, string>;
+    files: Record<string, string>;
+  }>;
+  /** Regenerate the staged Pi mirrors (`node scripts/build-pi-packages.mjs`). */
+  regenPi(pr: number): Promise<void>;
+  /** Write one healed file back into the PR worktree. */
+  writeFile(pr: number, path: string, text: string): Promise<void>;
+  /** Commit every staged heal and push the PR branch. */
+  commitPush(pr: number, message: string): Promise<void>;
+  /** Remove the isolated worktree (always called, healed or not). */
+  cleanup(pr: number): Promise<void>;
+  log?(line: string): void;
+}
+
+export interface MedicPassResult {
+  readonly pr: number;
+  readonly outcome: "healed" | "escalated" | "exhausted";
+  readonly clazz: MedicFailureClass | null;
+  readonly actions: readonly string[];
+}
+
+/**
+ * Run ONE healing round for `pr`. Rounds are ledger-bounded: the
+ * `MEDIC_MAX_ROUNDS`-th failed round escalates (`exhausted` → needs-human)
+ * without touching the branch again. A `semantic` classification escalates
+ * immediately and leaves the worktree cleaned. Every action is logged.
+ */
+export async function runMedicPass(
+  io: MedicIo,
+  store: MedicStore,
+  pr: number,
+  options: { nowEpoch: number; maxRounds?: number; registry?: Readonly<Record<string, string>> },
+): Promise<MedicPassResult> {
+  const maxRounds = options.maxRounds ?? MEDIC_MAX_ROUNDS;
+  const state = await store.read();
+  const prior = state.prs[String(pr)];
+  const rounds = (prior?.rounds ?? 0) + 1;
+  const actions: string[] = [];
+  const record = async (outcome: MedicPrRecord["outcome"]): Promise<void> => {
+    await store.write({
+      version: 1,
+      prs: {
+        ...state.prs,
+        [String(pr)]: {
+          pr,
+          rounds,
+          outcome,
+          updatedAtEpoch: options.nowEpoch,
+          actions: [...(prior?.actions ?? []), ...actions],
+        },
+      },
+    });
+  };
+
+  if (rounds > maxRounds) {
+    actions.push(`round ${rounds} exceeds the ${maxRounds}-round budget — escalating`);
+    io.log?.(`medic #${pr}: ${actions.at(-1)}`);
+    await record("escalated");
+    return { pr, outcome: "exhausted", clazz: null, actions };
+  }
+
+  try {
+    const diagnosis = await io.diagnose(pr);
+    const clazz = classifyMedicFailure({ ...diagnosis, registry: options.registry });
+    actions.push(`round ${rounds}: classified ${clazz}`);
+    io.log?.(`medic #${pr}: ${actions.at(-1)}`);
+
+    if (clazz === "semantic") {
+      actions.push("semantic failure — escalated untouched");
+      io.log?.(`medic #${pr}: ${actions.at(-1)}`);
+      await record("escalated");
+      return { pr, outcome: "escalated", clazz, actions };
+    }
+    if (clazz === "stale-pi") {
+      await io.regenPi(pr);
+      actions.push("regenerated staged Pi mirrors");
+    } else if (clazz === "stale-rename") {
+      for (const [path, text] of Object.entries(diagnosis.files)) {
+        const healed = applyRenameRegistry(text, options.registry);
+        if (healed.replacements > 0) {
+          await io.writeFile(pr, path, healed.text);
+          actions.push(`renamed ${healed.replacements} identifier(s) in ${path}`);
+        }
+      }
+    } else {
+      for (const [path, text] of Object.entries(diagnosis.conflicts)) {
+        const resolved = unionResolveConflicts(text);
+        if (resolved === null) {
+          actions.push(`conflict in ${path} is not additive — escalated untouched`);
+          io.log?.(`medic #${pr}: ${actions.at(-1)}`);
+          await record("escalated");
+          return { pr, outcome: "escalated", clazz, actions };
+        }
+        await io.writeFile(pr, path, resolved);
+        actions.push(`union-resolved additive conflict in ${path}`);
+      }
+    }
+    await io.commitPush(pr, `fix: PR medic round ${rounds} (${clazz}) Refs #2513`);
+    actions.push("committed and pushed the heal");
+    for (const a of actions) io.log?.(`medic #${pr}: ${a}`);
+    await record("healed");
+    return { pr, outcome: "healed", clazz, actions };
+  } finally {
+    try {
+      await io.cleanup(pr);
+    } catch {
+      // best-effort — a leaked worktree is reaped by the lane janitor.
+    }
+  }
+}

--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -9,6 +9,7 @@ import { createCastleMcpTools } from "../../../packages/red-castle/src/mcp-serve
 import {
   createEnginePaths,
   createFileIssueCuratorStore,
+  armPr,
   createFileMergeDriverStore,
   createGitHubTrackerAdapter,
   createSingletonLeaseStore,
@@ -16,6 +17,8 @@ import {
   runMergeDriverPass,
 } from "@reddb-io/red-castle/engine";
 import { createMergeDriverIo } from "./runtime/merge-driver-io.js";
+import { createMedicIo } from "./runtime/medic-io.js";
+import { createFileMedicStore, runMedicPass } from "./core/pr-medic.js";
 import { resolveRepoContext } from "./runtime/wire.js";
 import { superviseCommand } from "./commands/supervise.js";
 import { createCastleMcpDependencies } from "./mcp-adapter.js";
@@ -135,11 +138,31 @@ export async function startResidentMergeDriver(root = process.cwd()): Promise<vo
       const armed = Object.values(state.prs).some((record) => record.status === "armed");
       if (armed) {
         const context = await resolveRepoContext(root);
-        await runMergeDriverPass(
+        const entries = await runMergeDriverPass(
           createMergeDriverIo({ cwd: context.root, repo: context.repo }),
           store,
           { nowEpoch: Math.floor(Date.now() / 1000) },
         );
+        // PR medic (#2513): a terminal needs-medic classification gets ONE
+        // bounded mechanical healing round before any human sees it. A healed
+        // push re-arms the PR so the driver resumes ownership; the medic's own
+        // ledger escalates after MEDIC_MAX_ROUNDS failed rounds.
+        for (const entry of entries) {
+          if (entry.action !== "terminal-medic") continue;
+          try {
+            const medic = await runMedicPass(
+              createMedicIo(context.root),
+              createFileMedicStore(paths),
+              entry.pr,
+              { nowEpoch: Math.floor(Date.now() / 1000) },
+            );
+            if (medic.outcome === "healed") {
+              await armPr(store, entry.pr, Math.floor(Date.now() / 1000));
+            }
+          } catch {
+            // A failed heal leaves the terminal classification standing.
+          }
+        }
       }
     } catch {
       // Transport faults retry on the next interval; the resident never dies here.

--- a/apps/dev/src/runtime/medic-io.ts
+++ b/apps/dev/src/runtime/medic-io.ts
@@ -1,0 +1,98 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { git, gh, pnpm } from "./exec.js";
+import type { MedicIo } from "../core/pr-medic.js";
+
+const MEDIC_LOG_TAIL_CHARS = 4000;
+
+/** The dev-host implementation of the PR medic's IO port (#2513). Each healing
+ * round runs inside an isolated worktree under the registered feedback lane
+ * (`.red/tmp/worktrees/feedback/medic-<pr>`), created on first use and removed
+ * by `cleanup` whatever the outcome. */
+export function createMedicIo(root: string, log?: (line: string) => void): MedicIo {
+  const worktreeDir = (pr: number): string =>
+    join(root, ".red", "tmp", "worktrees", "feedback", `medic-${pr}`);
+  const branchOf = async (pr: number): Promise<string> => {
+    const r = await gh(["pr", "view", String(pr), "--json", "headRefName", "--jq", ".headRefName"], { cwd: root });
+    if (r.code !== 0) throw new Error(`gh pr view #${pr} failed: ${r.stderr.trim()}`);
+    return r.stdout.trim();
+  };
+  const ensureWorktree = async (pr: number): Promise<string> => {
+    const dir = worktreeDir(pr);
+    const branch = await branchOf(pr);
+    await git(["fetch", "origin", branch, "main"], { cwd: root });
+    const added = await git(["worktree", "add", dir, `origin/${branch}`], { cwd: root });
+    if (added.code !== 0 && !/already exists/.test(added.stderr)) {
+      throw new Error(`worktree add for medic #${pr} failed: ${added.stderr.trim()}`);
+    }
+    await git(["checkout", "-B", branch, `origin/${branch}`], { cwd: dir });
+    return dir;
+  };
+
+  return {
+    async diagnose(pr) {
+      const dir = await ensureWorktree(pr);
+      // Failing-log tail from the newest failed run on the PR branch.
+      let logTail = "";
+      const branch = await branchOf(pr);
+      const runs = await gh(
+        ["run", "list", "--branch", branch, "--limit", "5", "--json", "databaseId,conclusion", "--jq", '.[]|select(.conclusion=="failure")|.databaseId'],
+        { cwd: root },
+      );
+      const failedRun = runs.stdout.trim().split("\n").filter(Boolean)[0];
+      if (failedRun) {
+        const logs = await gh(["run", "view", failedRun, "--log-failed"], { cwd: root });
+        logTail = logs.stdout.slice(-MEDIC_LOG_TAIL_CHARS);
+      }
+      // Conflicts: attempt the merge from main; collect conflicted contents.
+      const conflicts: Record<string, string> = {};
+      const merged = await git(["merge", "origin/main", "--no-edit"], { cwd: dir });
+      if (merged.code !== 0) {
+        const listed = await git(["diff", "--name-only", "--diff-filter=U"], { cwd: dir });
+        for (const path of listed.stdout.trim().split("\n").filter(Boolean)) {
+          conflicts[path] = await readFile(join(dir, path), "utf8");
+        }
+      }
+      // Changed files vs main for rename scanning (post-merge tree when clean).
+      const files: Record<string, string> = {};
+      if (merged.code === 0) {
+        const changed = await git(["diff", "--name-only", "origin/main...HEAD"], { cwd: dir });
+        for (const path of changed.stdout.trim().split("\n").filter(Boolean).slice(0, 200)) {
+          if (!/\.(ts|mts|mjs|js|md|json)$/.test(path)) continue;
+          try {
+            files[path] = await readFile(join(dir, path), "utf8");
+          } catch {
+            // deleted file — nothing to scan.
+          }
+        }
+      }
+      return { logTail, conflicts, files };
+    },
+    async regenPi(pr) {
+      const dir = worktreeDir(pr);
+      const install = await pnpm(["install", "--frozen-lockfile", "--prefer-offline"], { cwd: dir, timeoutMs: 600_000 });
+      if (install.code !== 0) throw new Error(`pnpm install failed: ${install.stderr.slice(-400)}`);
+      const build = await pnpm(["pi:packages:build"], { cwd: dir, timeoutMs: 600_000 });
+      if (build.code !== 0) throw new Error(`pi:packages:build failed: ${build.stderr.slice(-400)}`);
+      await pnpm(["pi:manifests"], { cwd: dir, timeoutMs: 300_000 });
+    },
+    async writeFile(pr, path, text) {
+      await writeFile(join(worktreeDir(pr), path), text, "utf8");
+    },
+    async commitPush(pr, message) {
+      const dir = worktreeDir(pr);
+      await git(["add", "-A"], { cwd: dir });
+      const committed = await git(["commit", "-m", message], { cwd: dir });
+      if (committed.code !== 0 && !/nothing to commit/.test(committed.stdout + committed.stderr)) {
+        throw new Error(`medic commit for #${pr} failed: ${committed.stderr.trim()}`);
+      }
+      const pushed = await git(["push", "origin", "HEAD"], { cwd: dir });
+      if (pushed.code !== 0) throw new Error(`medic push for #${pr} failed: ${pushed.stderr.trim()}`);
+    },
+    async cleanup(pr) {
+      await git(["worktree", "remove", "--force", worktreeDir(pr)], { cwd: root });
+      await git(["worktree", "prune"], { cwd: root });
+    },
+    log,
+  };
+}

--- a/apps/dev/tests/pr-medic.test.ts
+++ b/apps/dev/tests/pr-medic.test.ts
@@ -1,0 +1,186 @@
+// pr-medic.test.ts — the mechanical CI/conflict healer (#2513, Spec #2511
+// slice 2). The medic heals exactly the classes hand-fixed on 2026-07-22
+// (stale Pi mirrors, registered identifier renames, additive conflicts) and
+// escalates everything else untouched, bounded at MEDIC_MAX_ROUNDS rounds.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  MEDIC_MAX_ROUNDS,
+  applyRenameRegistry,
+  classifyMedicFailure,
+  runMedicPass,
+  unionResolveConflicts,
+  type MedicIo,
+  type MedicState,
+  type MedicStore,
+} from "../src/core/pr-medic.js";
+
+const NOW = 1_800_000_000;
+
+function memoryStore(initial?: MedicState): MedicStore & { value: MedicState } {
+  return {
+    value: initial ?? { version: 1, prs: {} },
+    async read() {
+      return this.value;
+    },
+    async write(state) {
+      this.value = state;
+    },
+  };
+}
+
+function makeIo(diagnosis: {
+  logTail?: string;
+  conflicts?: Record<string, string>;
+  files?: Record<string, string>;
+}): MedicIo & {
+  regenPi: ReturnType<typeof vi.fn>;
+  writeFile: ReturnType<typeof vi.fn>;
+  commitPush: ReturnType<typeof vi.fn>;
+  cleanup: ReturnType<typeof vi.fn>;
+} {
+  return {
+    diagnose: vi.fn(async () => ({
+      logTail: diagnosis.logTail ?? "",
+      conflicts: diagnosis.conflicts ?? {},
+      files: diagnosis.files ?? {},
+    })),
+    regenPi: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+    commitPush: vi.fn(async () => undefined),
+    cleanup: vi.fn(async () => undefined),
+  };
+}
+
+const ADDITIVE_CONFLICT = [
+  "import { a } from './a.js';",
+  "<<<<<<< HEAD",
+  "import { b } from './b.js';",
+  "=======",
+  "import { c } from './c.js';",
+  ">>>>>>> origin/main",
+  "export const x = 1;",
+].join("\n");
+
+const SEMANTIC_CONFLICT = [
+  "<<<<<<< HEAD",
+  "const retries = computeRetries(env, 3);",
+  "=======",
+  "const retries = legacyRetries(env);",
+  ">>>>>>> origin/main",
+].join("\n");
+
+describe("union conflict resolver", () => {
+  it("unions an import-block conflict ours-then-theirs", () => {
+    expect(unionResolveConflicts(ADDITIVE_CONFLICT)).toBe(
+      [
+        "import { a } from './a.js';",
+        "import { b } from './b.js';",
+        "import { c } from './c.js';",
+        "export const x = 1;",
+      ].join("\n"),
+    );
+  });
+
+  it("refuses an overlapping-edit conflict (same key rewritten on both sides)", () => {
+    expect(unionResolveConflicts(SEMANTIC_CONFLICT)).toBeNull();
+  });
+
+  it("refuses a conflict with a non-empty base section (both sides edited)", () => {
+    const withBase = [
+      "<<<<<<< HEAD",
+      '"one",',
+      "|||||||",
+      '"orig",',
+      "=======",
+      '"two",',
+      ">>>>>>> origin/main",
+    ].join("\n");
+    expect(unionResolveConflicts(withBase)).toBeNull();
+  });
+});
+
+describe("classification + rename registry", () => {
+  it("classifies the 2026-07-22 classes", () => {
+    expect(
+      classifyMedicFailure({ logTail: "error: packaging/pi/<name>/ staged Pi packages are stale; run pnpm pi:packages:build", conflicts: {}, files: {} }),
+    ).toBe("stale-pi");
+    expect(
+      classifyMedicFailure({ logTail: "", conflicts: {}, files: { "a.ts": "createDevAfkMcpDependencies(cwd)" } }),
+    ).toBe("stale-rename");
+    expect(
+      classifyMedicFailure({ logTail: "", conflicts: { "a.ts": ADDITIVE_CONFLICT }, files: {} }),
+    ).toBe("additive-conflict");
+    expect(
+      classifyMedicFailure({ logTail: "1 failed", conflicts: { "a.ts": SEMANTIC_CONFLICT }, files: {} }),
+    ).toBe("semantic");
+  });
+
+  it("applies the registered rename with a count", () => {
+    const healed = applyRenameRegistry("const deps = createDevAfkMcpDependencies(cwd);");
+    expect(healed.text).toBe("const deps = createCastleMcpDependencies(cwd);");
+    expect(healed.replacements).toBe(1);
+  });
+});
+
+describe("bounded medic pass (#2513)", () => {
+  it("stale Pi mirrors heal to a push without escalation", async () => {
+    const store = memoryStore();
+    const io = makeIo({ logTail: "staged Pi packages are stale" });
+
+    const result = await runMedicPass(io, store, 90, { nowEpoch: NOW });
+
+    expect(result.outcome).toBe("healed");
+    expect(result.clazz).toBe("stale-pi");
+    expect(io.regenPi).toHaveBeenCalledTimes(1);
+    expect(io.regenPi).toHaveBeenCalledWith(90);
+    expect(io.commitPush).toHaveBeenCalledTimes(1);
+    expect(io.cleanup).toHaveBeenCalledTimes(1);
+    expect(store.value.prs["90"]!.outcome).toBe("healed");
+  });
+
+  it("a file referencing a registered old identifier is renamed and committed", async () => {
+    const store = memoryStore();
+    const io = makeIo({ files: { "src/x.ts": "createDevAfkMcpDependencies(cwd);" } });
+
+    const result = await runMedicPass(io, store, 91, { nowEpoch: NOW });
+
+    expect(result.outcome).toBe("healed");
+    expect(result.clazz).toBe("stale-rename");
+    expect(io.writeFile).toHaveBeenCalledWith(91, "src/x.ts", "createCastleMcpDependencies(cwd);");
+    expect(io.commitPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("a non-additive conflict escalates untouched and the worktree is cleaned", async () => {
+    const store = memoryStore();
+    const io = makeIo({ conflicts: { "src/y.ts": SEMANTIC_CONFLICT } });
+
+    const result = await runMedicPass(io, store, 92, { nowEpoch: NOW });
+
+    expect(result.outcome).toBe("escalated");
+    expect(io.writeFile).not.toHaveBeenCalled();
+    expect(io.commitPush).not.toHaveBeenCalled();
+    expect(io.cleanup).toHaveBeenCalledTimes(1);
+    expect(store.value.prs["92"]!.outcome).toBe("escalated");
+  });
+
+  it("healing rounds are bounded at MEDIC_MAX_ROUNDS and every action is ledgered", async () => {
+    const store = memoryStore({
+      version: 1,
+      prs: {
+        "93": { pr: 93, rounds: MEDIC_MAX_ROUNDS, outcome: "healing", updatedAtEpoch: NOW, actions: ["round 1", "round 2"] },
+      },
+    });
+    const io = makeIo({ logTail: "staged Pi packages are stale" });
+
+    const result = await runMedicPass(io, store, 93, { nowEpoch: NOW + 1 });
+
+    expect(result.outcome).toBe("exhausted");
+    expect(io.diagnose).not.toHaveBeenCalled();
+    expect(io.commitPush).not.toHaveBeenCalled();
+    const record = store.value.prs["93"]!;
+    expect(record.outcome).toBe("escalated");
+    expect(record.rounds).toBe(MEDIC_MAX_ROUNDS + 1);
+    expect(record.actions.some((a) => a.includes("escalating"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #2513 — Spec #2511 slice 2.

## What

- **Core** (`apps/dev/src/core/pr-medic.ts`): classification (`stale-pi` / `stale-rename` / `additive-conflict` / `semantic`), the rename registry (seeded with the 2026-07-22 rename), a conservative union conflict resolver (refuses non-empty base sections and same-key rewrites), and `runMedicPass` — one healing round, ledger-bounded at 2 rounds per PR, every action recorded in `.red/state/castle/pr-medic.toon`.
- **IO** (`runtime/medic-io.ts`): isolated worktree per PR under the feedback lane, diagnosis from the newest failed run log + a merge-from-main probe, Pi regen via the repo scripts, commit+push, cleanup always.
- **Wiring**: the resident merge-driver pass feeds every `terminal-medic` entry to the medic; a healed push re-arms the PR so the driver resumes ownership.

## Tests

9 tests: union resolver (additive union, same-key rewrite refusal, non-empty base refusal), classification of all four classes, rename registry, and the four acceptance fixtures (stale-Pi heals to push; rename healed+committed; non-additive escalates untouched with worktree cleaned; rounds bounded with ledgered actions).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787384659&installation_model_id=20659&pr_number=2555&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2555&signature=cd2301e52b8c049f9f1c6c46406d904aded578670d191da64df51cf001e128c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->