### PR TITLE
feat: #2514 ETag conditional-polling event transport with pluggable webhook composition

### DIFF
--- a/.changeset/etag-event-ingestion.md
+++ b/.changeset/etag-event-ingestion.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": minor
+---
+
+Event ingestion transport (#2514, Spec #2511 slice 3): the castle resident's webhook lane gains an ETag conditional-polling transport — `If-None-Match` reads where 304s are rate-limit-free, cadence honoring `X-Poll-Interval`, repo events deduped by id, and check-run snapshot diffing that emits exactly one `check.completed` delivery per transition for merge-driver-armed PR heads. The default resident transport is now a composite: the `gh webhook forward` child when its handshake holds, the poller as the always-armed fallback filling the same lane — consumers never see which transport delivered.

--- a/apps/dev/src/core/etag-polling.ts
+++ b/apps/dev/src/core/etag-polling.ts
@@ -1,0 +1,109 @@
+/**
+ * ETag conditional-polling core (#2514, Spec #2511 slice 3) — the PURE half of
+ * the polling transport. GitHub REST reads are made conditional with
+ * `If-None-Match`; a 304 is free against the rate limit and produces no
+ * events. Check-run transitions are derived by snapshot diffing so one
+ * completed check emits exactly one `check.completed` delivery, and the poll
+ * cadence honors the server's `X-Poll-Interval`.
+ *
+ * Rate-limit budget: with E armed endpoints and a cadence of max(60,
+ * X-Poll-Interval) seconds, steady state costs E requests/minute of which
+ * unchanged ones are 304s (not counted against the core limit) — the warm
+ * resident answers PR-state questions from the lane instead of fresh `gh`
+ * spawns.
+ */
+
+export interface ConditionalResponse {
+  /** HTTP status: 200 (changed), 304 (unchanged), anything else = error. */
+  readonly status: number;
+  readonly etag?: string;
+  /** Server-requested minimum poll interval in seconds (X-Poll-Interval). */
+  readonly pollIntervalS?: number;
+  /** Parsed JSON body when status is 200. */
+  readonly body?: unknown;
+}
+
+/** Parse a raw `gh api -i` response (headers + blank line + body). */
+export function parseConditionalResponse(raw: string): ConditionalResponse {
+  const separator = raw.indexOf("\r\n\r\n") >= 0 ? "\r\n\r\n" : "\n\n";
+  const cut = raw.indexOf(separator);
+  const head = cut >= 0 ? raw.slice(0, cut) : raw;
+  const bodyText = cut >= 0 ? raw.slice(cut + separator.length).trim() : "";
+  const statusMatch = /^HTTP\/[\d.]+\s+(\d{3})/m.exec(head);
+  const status = statusMatch ? Number(statusMatch[1]) : 0;
+  const etagMatch = /^etag:\s*(.+)$/im.exec(head);
+  const pollMatch = /^x-poll-interval:\s*(\d+)$/im.exec(head);
+  let body: unknown;
+  if (status === 200 && bodyText !== "") {
+    try {
+      body = JSON.parse(bodyText);
+    } catch {
+      body = undefined;
+    }
+  }
+  return {
+    status,
+    ...(etagMatch ? { etag: etagMatch[1]!.trim() } : {}),
+    ...(pollMatch ? { pollIntervalS: Number(pollMatch[1]) } : {}),
+    ...(body !== undefined ? { body } : {}),
+  };
+}
+
+/** Next poll delay: the server's X-Poll-Interval always wins when larger than
+ * the configured floor; absent, the floor applies. */
+export function nextPollDelayMs(pollIntervalS: number | undefined, floorS: number): number {
+  return Math.max(floorS, pollIntervalS ?? 0) * 1000;
+}
+
+/** Per-check snapshot for one PR head: check name → `status/conclusion`. */
+export type CheckSnapshot = Readonly<Record<string, string>>;
+
+export interface CheckDelivery {
+  readonly event: "check_run";
+  readonly action: "completed";
+  readonly pr: number;
+  readonly check: string;
+  readonly conclusion: string;
+}
+
+/** Snapshot a check-runs API body (`{check_runs: [{name,status,conclusion}]}`). */
+export function snapshotCheckRuns(body: unknown): CheckSnapshot {
+  const runs =
+    body && typeof body === "object" && Array.isArray((body as { check_runs?: unknown[] }).check_runs)
+      ? ((body as { check_runs: unknown[] }).check_runs as {
+          name?: string;
+          status?: string;
+          conclusion?: string | null;
+        }[])
+      : [];
+  const snapshot: Record<string, string> = {};
+  for (const run of runs) {
+    if (!run || typeof run.name !== "string") continue;
+    snapshot[run.name] = `${run.status ?? ""}/${run.conclusion ?? ""}`;
+  }
+  return snapshot;
+}
+
+/** Exactly one `check.completed` delivery per check that TRANSITIONED to
+ * completed since the previous snapshot — an unchanged completed check never
+ * re-emits. */
+export function diffCheckRuns(
+  pr: number,
+  previous: CheckSnapshot,
+  next: CheckSnapshot,
+): CheckDelivery[] {
+  const deliveries: CheckDelivery[] = [];
+  for (const [check, state] of Object.entries(next)) {
+    const [status, conclusion] = state.split("/");
+    if (status !== "completed") continue;
+    if (previous[check] === state) continue;
+    deliveries.push({
+      event: "check_run",
+      action: "completed",
+      pr,
+      check,
+      conclusion: conclusion ?? "",
+    });
+  }
+  return deliveries;
+}

--- a/apps/dev/src/resident-webhook.ts
+++ b/apps/dev/src/resident-webhook.ts
@@ -12,7 +12,6 @@ import {
 import {
   GITHUB_WEBHOOK_DELIVERY_KIND,
   GITHUB_WEBHOOK_SINGLETON,
-  WebhookForwarder,
 } from "@reddb-io/shared/github-webhook.js";
 import { resolveRepoRoot } from "@reddb-io/shared/repo-root.js";
 import { readPidStartTime } from "./core/state.js";

--- a/apps/dev/src/resident-webhook.ts
+++ b/apps/dev/src/resident-webhook.ts
@@ -16,6 +16,7 @@ import {
 } from "@reddb-io/shared/github-webhook.js";
 import { resolveRepoRoot } from "@reddb-io/shared/repo-root.js";
 import { readPidStartTime } from "./core/state.js";
+import { createCompositeTransport } from "./runtime/etag-transport.js";
 import { killTreeAndWait } from "./runtime/kill-tree.js";
 
 
@@ -54,16 +55,16 @@ export function createResidentWebhook(
   const lane = options.lane ?? createSingletonEventLane(paths);
   const makeForwarder =
     options.makeForwarder ??
+    // Composite transport (#2514): the `gh webhook forward` child when
+    // available, with the ETag conditional poller as the always-armed fallback
+    // filling the SAME lane — consumers never see which transport delivered.
     ((root: string, cancelSignal: AbortSignal) =>
-      new WebhookForwarder(
-        { cwd: root, cancelSignal },
-        async (child, graceMs) => {
-          if (!child.pid) return;
-          const pollMs = 100;
-          const graceTries = Math.max(1, Math.ceil(graceMs / pollMs));
-          await killTreeAndWait(child.pid, { graceTries, pollMs });
-        },
-      ));
+      createCompositeTransport(root, cancelSignal, async (child, graceMs) => {
+        if (!child.pid) return;
+        const pollMs = 100;
+        const graceTries = Math.max(1, Math.ceil(graceMs / pollMs));
+        await killTreeAndWait(child.pid, { graceTries, pollMs });
+      }));
   const notice =
     options.notice ??
     ((message: string) =>

--- a/apps/dev/src/runtime/etag-transport.ts
+++ b/apps/dev/src/runtime/etag-transport.ts
@@ -1,0 +1,161 @@
+import { EventEmitter } from "node:events";
+import { join } from "node:path";
+import {
+  createEnginePaths,
+  createFileMergeDriverStore,
+} from "@reddb-io/red-castle/engine";
+import { WebhookForwarder } from "@reddb-io/shared/github-webhook.js";
+import type { ResidentWebhookForwarder } from "../resident-webhook.js";
+import {
+  diffCheckRuns,
+  nextPollDelayMs,
+  parseConditionalResponse,
+  snapshotCheckRuns,
+  type CheckSnapshot,
+} from "../core/etag-polling.js";
+import { type ExecFn, execTool } from "./exec.js";
+
+export const ETAG_POLL_FLOOR_S = 60;
+
+export interface EtagPollingOptions {
+  readonly root: string;
+  readonly exec?: ExecFn;
+  /** Poll floor in seconds; the server's X-Poll-Interval wins when larger. */
+  readonly floorS?: number;
+  /** True while a sibling webhook transport is live — polling then idles so
+   * the two transports never double-emit. */
+  readonly paused?: () => boolean;
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * The ETag conditional-polling transport (#2514): one `ResidentWebhookForwarder`
+ * implementation that fills the SAME delivery lane the `gh webhook forward`
+ * child fills — consumers cannot tell the transports apart. Each cycle:
+ *
+ *   1. `repos/{slug}/events` with If-None-Match — 304 → nothing; 200 → one
+ *      delivery per new event envelope.
+ *   2. check-runs for every merge-driver-armed PR head — snapshot-diffed so a
+ *      completed check emits exactly one `check.completed` delivery.
+ */
+export class EtagPollingForwarder extends EventEmitter implements ResidentWebhookForwarder {
+  private dead = false;
+  private etags = new Map<string, string>();
+  private checkSnapshots = new Map<number, CheckSnapshot>();
+  private seenEventIds = new Set<string>();
+
+  constructor(private readonly options: EtagPollingOptions) {
+    super();
+  }
+
+  start(): void {
+    void this.loop();
+  }
+
+  async stop(): Promise<void> {
+    this.dead = true;
+  }
+
+  private async loop(): Promise<void> {
+    const sleep =
+      this.options.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms).unref?.()));
+    while (!this.dead) {
+      let pollIntervalS: number | undefined;
+      try {
+        if (!this.options.paused?.()) {
+          pollIntervalS = await this.pollOnce();
+        }
+      } catch {
+        // transport fault — retry after the floor.
+      }
+      await sleep(nextPollDelayMs(pollIntervalS, this.options.floorS ?? ETAG_POLL_FLOOR_S));
+    }
+  }
+
+  /** One conditional poll cycle. Returns the server's X-Poll-Interval, if any. */
+  async pollOnce(): Promise<number | undefined> {
+    const exec = this.options.exec ?? execTool;
+    const conditional = async (path: string): Promise<ReturnType<typeof parseConditionalResponse>> => {
+      const etag = this.etags.get(path);
+      const args = ["api", "-i", path, ...(etag ? ["-H", `If-None-Match: ${etag}`] : [])];
+      const r = await exec("gh", args, { cwd: this.options.root });
+      const parsed = parseConditionalResponse(r.stdout);
+      if (parsed.etag) this.etags.set(path, parsed.etag);
+      return parsed;
+    };
+
+    const events = await conditional("repos/{owner}/{repo}/events");
+    if (events.status === 200 && Array.isArray(events.body)) {
+      for (const event of events.body as { id?: string; type?: string; payload?: { action?: string } }[]) {
+        const id = String(event.id ?? "");
+        if (id !== "" && this.seenEventIds.has(id)) continue;
+        if (id !== "") this.seenEventIds.add(id);
+        this.emit("delivery", {
+          event: String(event.type ?? "unknown"),
+          action: String(event.payload?.action ?? ""),
+          transport: "etag-polling",
+          id,
+        });
+      }
+      if (this.seenEventIds.size > 2000) {
+        this.seenEventIds = new Set([...this.seenEventIds].slice(-1000));
+      }
+    }
+
+    // Check-runs for merge-driver-armed PR heads: the PRs someone is actively
+    // waiting on are exactly the ones whose check transitions matter.
+    const store = createFileMergeDriverStore(createEnginePaths(join(this.options.root, ".red")));
+    const state = await store.read();
+    for (const record of Object.values(state.prs)) {
+      if (record.status !== "armed") continue;
+      const head = await exec(
+        "gh",
+        ["pr", "view", String(record.pr), "--json", "headRefOid", "--jq", ".headRefOid"],
+        { cwd: this.options.root },
+      );
+      const sha = head.stdout.trim();
+      if (head.code !== 0 || sha === "") continue;
+      const checks = await conditional(`repos/{owner}/{repo}/commits/${sha}/check-runs`);
+      if (checks.status !== 200) continue;
+      const next = snapshotCheckRuns(checks.body);
+      const previous = this.checkSnapshots.get(record.pr) ?? {};
+      for (const delivery of diffCheckRuns(record.pr, previous, next)) {
+        this.emit("delivery", { ...delivery, transport: "etag-polling" });
+      }
+      this.checkSnapshots.set(record.pr, next);
+    }
+
+    return events.pollIntervalS;
+  }
+}
+
+/**
+ * Composite transport: the `gh webhook forward` child when available, with the
+ * ETag poller as the always-armed fallback. The poller idles while the webhook
+ * handshake holds (`mode === "webhook"`), so the two never double-emit; the
+ * moment the webhook child dies or was never installed, polling resumes on the
+ * next cycle with no consumer change — the pluggable-transport contract.
+ */
+export function createCompositeTransport(
+  root: string,
+  cancelSignal: AbortSignal,
+  terminate: ConstructorParameters<typeof WebhookForwarder>[1],
+): ResidentWebhookForwarder {
+  const webhook = new WebhookForwarder({ cwd: root, cancelSignal }, terminate);
+  const poller = new EtagPollingForwarder({
+    root,
+    paused: () => webhook.mode === "webhook" && !webhook.dead,
+  });
+  const composite = new EventEmitter() as EventEmitter & ResidentWebhookForwarder;
+  webhook.on("delivery", (d) => composite.emit("delivery", d));
+  webhook.on("malformed-delivery", (d) => composite.emit("malformed-delivery", d));
+  poller.on("delivery", (d) => composite.emit("delivery", d));
+  composite.start = () => {
+    webhook.start();
+    poller.start();
+  };
+  composite.stop = async () => {
+    await Promise.all([webhook.stop(), poller.stop()]);
+  };
+  return composite;
+}

--- a/apps/dev/tests/etag-polling.test.ts
+++ b/apps/dev/tests/etag-polling.test.ts
@@ -1,0 +1,164 @@
+// etag-polling.test.ts — event ingestion via ETag conditional polling with a
+// pluggable webhook transport (#2514, Spec #2511 slice 3).
+
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  diffCheckRuns,
+  nextPollDelayMs,
+  parseConditionalResponse,
+  snapshotCheckRuns,
+} from "../src/core/etag-polling.js";
+import { EtagPollingForwarder } from "../src/runtime/etag-transport.js";
+import { createResidentWebhook, type ResidentWebhookForwarder } from "../src/resident-webhook.js";
+
+function httpResponse(status: number, headers: Record<string, string>, body?: unknown): string {
+  const head = [`HTTP/2.0 ${status} ${status === 304 ? "Not Modified" : "OK"}`]
+    .concat(Object.entries(headers).map(([k, v]) => `${k}: ${v}`))
+    .join("\r\n");
+  return `${head}\r\n\r\n${body === undefined ? "" : JSON.stringify(body)}`;
+}
+
+describe("conditional response parsing + cadence", () => {
+  it("parses status, etag, and X-Poll-Interval", () => {
+    const parsed = parseConditionalResponse(
+      httpResponse(200, { ETag: '"abc"', "X-Poll-Interval": "77" }, [{ id: "1" }]),
+    );
+    expect(parsed.status).toBe(200);
+    expect(parsed.etag).toBe('"abc"');
+    expect(parsed.pollIntervalS).toBe(77);
+    expect(parsed.body).toEqual([{ id: "1" }]);
+  });
+
+  it("a 304 carries no body and produces no events downstream", () => {
+    const parsed = parseConditionalResponse(httpResponse(304, { ETag: '"abc"' }));
+    expect(parsed.status).toBe(304);
+    expect(parsed.body).toBeUndefined();
+  });
+
+  it("the server's X-Poll-Interval wins over the floor when larger", () => {
+    expect(nextPollDelayMs(120, 60)).toBe(120_000);
+    expect(nextPollDelayMs(10, 60)).toBe(60_000);
+    expect(nextPollDelayMs(undefined, 60)).toBe(60_000);
+  });
+});
+
+describe("check-run snapshot diffing", () => {
+  const completed = (name: string, conclusion: string) => ({ name, status: "completed", conclusion });
+
+  it("a check transition produces exactly one check.completed event", () => {
+    const before = snapshotCheckRuns({ check_runs: [{ name: "test", status: "in_progress", conclusion: null }] });
+    const after = snapshotCheckRuns({ check_runs: [completed("test", "success")] });
+    expect(diffCheckRuns(42, before, after)).toEqual([
+      { event: "check_run", action: "completed", pr: 42, check: "test", conclusion: "success" },
+    ]);
+    // Unchanged completed state re-diffed → no re-emission.
+    expect(diffCheckRuns(42, after, after)).toEqual([]);
+  });
+});
+
+describe("ETag polling transport", () => {
+  let dir: string | undefined;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  it("unchanged state (304) emits nothing; the second cycle sends If-None-Match", async () => {
+    dir = mkdtempSync(join(tmpdir(), "etag-"));
+    const calls: string[][] = [];
+    const exec = vi.fn(async (_cmd: string, args: readonly string[]) => {
+      calls.push([...args]);
+      if (args[0] === "api" && String(args[2]).includes("/events")) {
+        const conditional = args.includes("-H");
+        return {
+          code: 0,
+          stdout: conditional
+            ? httpResponse(304, { ETag: '"e1"' })
+            : httpResponse(200, { ETag: '"e1"' }, []),
+          stderr: "",
+        };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    const forwarder = new EtagPollingForwarder({ root: dir, exec });
+    const deliveries: unknown[] = [];
+    forwarder.on("delivery", (d) => deliveries.push(d));
+
+    await forwarder.pollOnce();
+    await forwarder.pollOnce();
+
+    expect(deliveries).toEqual([]);
+    const second = calls.filter((args) => String(args[2]).includes("/events"))[1]!;
+    expect(second).toContain("-H");
+    expect(second.join(" ")).toContain('If-None-Match: "e1"');
+  });
+
+  it("a new repo event becomes one delivery, deduped by id across cycles", async () => {
+    dir = mkdtempSync(join(tmpdir(), "etag-"));
+    const exec = vi.fn(async (_cmd: string, args: readonly string[]) => {
+      if (args[0] === "api" && String(args[2]).includes("/events")) {
+        return {
+          code: 0,
+          stdout: httpResponse(200, { ETag: '"e2"' }, [
+            { id: "9", type: "PullRequestEvent", payload: { action: "closed" } },
+          ]),
+          stderr: "",
+        };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    const forwarder = new EtagPollingForwarder({ root: dir, exec });
+    const deliveries: unknown[] = [];
+    forwarder.on("delivery", (d) => deliveries.push(d));
+
+    await forwarder.pollOnce();
+    await forwarder.pollOnce();
+
+    expect(deliveries).toEqual([
+      { event: "PullRequestEvent", action: "closed", transport: "etag-polling", id: "9" },
+    ]);
+  });
+});
+
+describe("pluggable transport contract", () => {
+  it("a test-double transport fills the same lane envelope as any other transport", async () => {
+    const appended: Record<string, unknown>[] = [];
+    const lane = {
+      append: async (record: { singleton: string; kind: string; payload: Record<string, unknown> }) => {
+        appended.push(record as unknown as Record<string, unknown>);
+        return { seq: appended.length };
+      },
+    };
+    const leases = {
+      acquire: async () => ({ acquired: true }),
+      release: async () => undefined,
+    };
+    class DoubleTransport extends EventEmitter implements ResidentWebhookForwarder {
+      start(): void {
+        this.emit("delivery", { event: "check_run", action: "completed", pr: 7, transport: "double" });
+      }
+      async stop(): Promise<void> {}
+    }
+    const webhook = createResidentWebhook({
+      root: process.cwd(),
+      leases: leases as never,
+      lane: lane as never,
+      makeForwarder: () => new DoubleTransport(),
+      notice: () => undefined,
+    });
+
+    await webhook.start();
+    await webhook.stop();
+
+    expect(appended).toHaveLength(1);
+    expect(appended[0]).toMatchObject({
+      singleton: "github-webhook",
+      kind: "github.webhook.delivery",
+      payload: { event: "check_run", action: "completed", pr: 7, transport: "double" },
+    });
+  });
+});


### PR DESCRIPTION
Closes #2514 — Spec #2511 slice 3.

## What

- **Pure core** (`core/etag-polling.ts`): conditional-response parsing (status/ETag/X-Poll-Interval), cadence rule (server interval wins over the floor), check-run snapshotting and diffing (exactly one `check.completed` per transition). Rate-limit budget documented in the module header — unchanged endpoints answer 304, free against the core limit.
- **Transport** (`runtime/etag-transport.ts`): `EtagPollingForwarder` implements the existing `ResidentWebhookForwarder` seam — repo events via `If-None-Match` (deduped by id), check-runs polled only for merge-driver-armed PR heads (the PRs someone is actively waiting on).
- **Pluggable composition**: the resident's default transport is now webhook-child + poller; the poller idles while the webhook handshake holds (`mode === "webhook"`), resumes the moment it drops — same lane, same envelope, consumers unchanged.
- The lane already feeds `events_since` (E8, #2370), so warm consumers read PR/check state from records instead of fresh `gh` spawns.

## Tests

7 tests: header parsing, 304-carries-nothing, X-Poll-Interval cadence, one-event-per-transition (and no re-emission), 304 cycle sends If-None-Match and emits nothing, id-dedup across cycles, and a transport-double proving the lane envelope is transport-agnostic.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787385192&installation_model_id=20659&pr_number=2556&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2556&signature=175c98a65819ac052c388b48764553e892cc1baea14912718c233093b641cc48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->