### PR TITLE
fix: #2488 Statusline shows only claimed fleet-attributed workers — targeted dispatches, pre-claim boots, and multi-supervisor/alternative flows are invisible

### DIFF
--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -69,11 +69,12 @@ const RESET = "\x1b[0m";
 const BRANCH_MAX = 28;
 const WORKER_GUTTER = "  ";
 
-type WorkerColumn = "workerId" | "run" | "org" | "iss" | "phase" | "elapsed" | "loc" | "tks" | "tls" | "rsn" | "txt";
+type WorkerColumn = "workerId" | "run" | "org" | "fleet" | "iss" | "phase" | "elapsed" | "loc" | "tks" | "tls" | "rsn" | "txt";
 const WORKER_COLUMNS: readonly WorkerColumn[] = [
   "workerId",
   "run",
   "org",
+  "fleet",
   "iss",
   "phase",
   "elapsed",
@@ -277,6 +278,7 @@ function workerCells(worker: CompactWorker, now: number): WorkerCells {
     workerId: f.workerId,
     run: `run=${runVal}`,
     org: `org=${landing ? "landing" : f.origin || "afk"}`,
+    fleet: `flt=${worker.state.fleet || "unattributed"}`,
     iss: f.issue === null ? "" : `iss=${String(f.issue)}`,
     phase: f.issue === null ? "" : progressCell(f.phase, f.activity),
     elapsed: f.elapsed,
@@ -325,7 +327,7 @@ function renderWorkerLines(
 
 /** The TERSE per-worker line for the Claude Code statusline (issue #1175, #1176):
  *
- *   <wID>  run=<runner> <model> <effort>  org=<afk|go>  iss=<issue-number>  <phase>  <elapsed>  loc=+A -R  tks=<h>  tls=<t> rsn=<r> txt=<x>
+ *   <wID>  run=<runner> <model> <effort>  org=<afk|go>  flt=<name|unattributed>  iss=<issue-number>  <phase>  <elapsed>  loc=+A -R  tks=<h>  tls=<t> rsn=<r> txt=<x>
  *
  * A visual sibling of line 1: the `wID` is BOLD + red, and every k=v token
  * (`run=`/`iss=`/`loc=`/`tks=` and each vital `tls=`/`rsn=`/`txt=`) reuses the
@@ -365,6 +367,10 @@ export function renderWorkerLine(worker: CompactWorker, now: number, preset: Sta
   // worker, so default the display to afk.
   const landing = LANDING_PHASES.has(f.phase);
   parts.push(kv("org", landing ? "landing" : f.origin || "afk"));
+  // flt=<name|unattributed> — ownership is independent of origin: targeted,
+  // `/go`, and secondary-supervisor Workers can share an origin while belonging
+  // to different fleets (or no fleet at all).
+  parts.push(kv("flt", worker.state.fleet || "unattributed"));
   // iss=<issue-number> from current.number (both /afk and /go lanes); the
   // <phase·activity> cell follows bare and the legacy standalone #<n> token is
   // dropped.

--- a/apps/dev/src/runtime/wire/statusline.ts
+++ b/apps/dev/src/runtime/wire/statusline.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync, renameSync, mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { readFileSync, writeFileSync, renameSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { type JsonValue as ToonValue } from "@reddb-io/toon";
 import { encodeDevSnapshotToon } from "../../core/toon-snapshot.js";
 import type { CompactWorker } from "../../core/monitor.js";
@@ -8,11 +8,21 @@ import type { WorkerVitals } from "../../types/state.js";
 import type { GhContext } from "../gh.js";
 import { discoverLiveSupervisorPid } from "../supervisor-state.js";
 import { isLivePid } from "../kill-tree.js";
-import { createEnginePaths } from "@reddb-io/red-castle/engine";
+import {
+  castleLanePath,
+  castleStateSnapshotPath,
+  createEnginePaths,
+  readCastleLaneRecords,
+  readCastleStateSnapshot,
+  type CastleLaneRecord,
+  type CastleStateSnapshot,
+  type EnginePaths,
+} from "@reddb-io/red-castle/engine";
 import { createFileBootBreakerStore, isBreakerOpen } from "../../core/supervisor/boot-breaker.js";
 import * as ghx from "../gh.js";
 import * as gitx from "../git.js";
 import { readAllWorkerStates, currentRenderableWorkerRecords } from "../../core/worker-state-reader.js";
+import { allWorkersRoots } from "../../core/worker-paths.js";
 import { afkPaths, type RepoContext } from "./paths.js";
 import { readFleetState } from "./monitor.js";
 import {
@@ -275,6 +285,7 @@ export async function collectStatuslineWorkers(ctx: RepoContext): Promise<Compac
   const nowMs = Date.now();
   const records = currentRenderableWorkerRecords(await readAllWorkerStates(paths.tmpDir, { nowMs }));
   const workers: CompactWorker[] = [];
+  const enginePaths = createEnginePaths(join(ctx.root, ".red"));
   for (const { state, active, live: pidLive, liveness, livenessVerdict } of records) {
     // The shared current-worker selector applies the `renderableLive` gate and
     // collapses retained sibling attempt dirs to one row per worker.
@@ -282,6 +293,7 @@ export async function collectStatuslineWorkers(ctx: RepoContext): Promise<Compac
     // straight from the state file (the heartbeat owns it for every runner).
     const added = state.current.loc_added;
     const removed = state.current.loc_removed;
+    const observability = await readWorkerObservability(enginePaths, state.worker_id);
     workers.push({
       state: {
         worker_id: state.worker_id,
@@ -289,6 +301,7 @@ export async function collectStatuslineWorkers(ctx: RepoContext): Promise<Compac
         runner: state.runner,
         started_at: state.started_at,
         origin: state.origin || undefined,
+        fleet: observability.snapshot?.supervisor_id || observability.fleet,
         total: state.total,
         done: state.done,
         blocked: state.blocked,
@@ -318,6 +331,21 @@ export async function collectStatuslineWorkers(ctx: RepoContext): Promise<Compac
       diffRemoved: removed,
     });
   }
+  const represented = new Set(workers.map((worker) => worker.state.worker_id));
+  for (const workersRoot of allWorkersRoots(paths.tmpDir)) {
+    for (const entry of workerDirectories(workersRoot)) {
+      if (represented.has(entry.name)) continue;
+      const worker = await bootWorkerFromDirectory(
+        join(workersRoot, entry.name),
+        entry.name,
+        enginePaths,
+        nowMs,
+      );
+      if (!worker) continue;
+      workers.push(worker);
+      represented.add(entry.name);
+    }
+  }
   // Deterministic order: oldest worker first (by top-level start, then per-attempt).
   workers.sort((a, b) => {
     const ka = a.state.started_at || a.state.current.started_at || "";
@@ -325,6 +353,150 @@ export async function collectStatuslineWorkers(ctx: RepoContext): Promise<Compac
     return ka < kb ? -1 : ka > kb ? 1 : 0;
   });
   return workers;
+}
+
+function workerDirectories(workersRoot: string): Array<{ name: string }> {
+  try {
+    return readdirSync(workersRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => ({ name: entry.name }));
+  } catch {
+    return [];
+  }
+}
+
+function stringField(
+  record: Record<string, unknown> | undefined,
+  ...fields: string[]
+): string | undefined {
+  if (!record) return undefined;
+  for (const field of fields) {
+    const value = record[field];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+interface WorkerObservability {
+  snapshot?: CastleStateSnapshot;
+  latest?: CastleLaneRecord;
+  heartbeatAt?: string;
+  fleet?: string;
+}
+
+async function readWorkerObservability(
+  paths: EnginePaths,
+  workerId: string,
+): Promise<WorkerObservability> {
+  const [snapshot, lane, liveness] = await Promise.all([
+    readCastleStateSnapshot(castleStateSnapshotPath(paths, "worker", workerId)).catch(() => undefined),
+    readCastleLaneRecords(castleLanePath(paths, "worker", workerId)).catch(() => []),
+    readCastleLaneRecords(castleLanePath(paths, "liveness", workerId)).catch(() => []),
+  ]);
+  const latest = lane.at(-1);
+  return {
+    snapshot,
+    latest,
+    heartbeatAt: liveness.at(-1)?.at,
+    fleet:
+      latest?.supervisor_id ||
+      stringField(latest?.payload, "supervisor_id", "fleet"),
+  };
+}
+
+function liveWorkerPid(workerDir: string): { pid: number; startedAt: string } | null {
+  const path = join(workerDir, "worker.pid");
+  try {
+    const pid = Number.parseInt(readFileSync(path, "utf8").trim(), 10);
+    if (!Number.isInteger(pid) || pid <= 0 || !isLivePid(pid)) return null;
+    return { pid, startedAt: statSync(path).mtime.toISOString() };
+  } catch {
+    return null;
+  }
+}
+
+function workspaceIssue(workerDir: string): number | undefined {
+  try {
+    return readdirSync(workerDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && /^[1-9][0-9]*$/.test(entry.name))
+      .map((entry) => ({
+        issue: Number(entry.name),
+        mtimeMs: statSync(join(workerDir, entry.name)).mtimeMs,
+      }))
+      .sort((a, b) => b.mtimeMs - a.mtimeMs || b.issue - a.issue)[0]?.issue;
+  } catch {
+    return undefined;
+  }
+}
+
+function issueField(value: unknown): number | string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) return value.trim();
+  return undefined;
+}
+
+async function bootWorkerFromDirectory(
+  workerDir: string,
+  workerId: string,
+  paths: EnginePaths,
+  nowMs: number,
+): Promise<CompactWorker | null> {
+  const anchor = liveWorkerPid(workerDir);
+  if (!anchor) return null;
+  const { snapshot, latest, heartbeatAt, fleet } = await readWorkerObservability(paths, workerId);
+  const current = snapshot?.current;
+  const payload = latest?.payload;
+  const issue =
+    workspaceIssue(workerDir) ??
+    issueField(current?.number ?? current?.issue) ??
+    latest?.issue ??
+    "";
+  const heartbeat = heartbeatAt || latest?.at || snapshot?.updated_at || anchor.startedAt;
+  const laneAgeMs = Math.max(0, nowMs - Date.parse(heartbeat));
+  const laneFresh = laneAgeMs <= 180_000;
+  const namespace = basename(dirname(workerDir));
+  const origin =
+    stringField(payload, "origin", "kind") ||
+    stringField(current, "origin", "kind") ||
+    (namespace === "go-workers" ? "go" : namespace === "scout-workers" ? "scout" : undefined);
+
+  return {
+    state: {
+      worker_id: workerId,
+      pid: anchor.pid,
+      runner:
+        snapshot?.runner ||
+        stringField(payload, "runner") ||
+        stringField(current, "runner") ||
+        "",
+      started_at: snapshot?.started_at || anchor.startedAt,
+      origin,
+      fleet: snapshot?.supervisor_id || fleet,
+      total: issue === "" ? 0 : 1,
+      done: 0,
+      blocked: 0,
+      failed: 0,
+      current: {
+        number: issue,
+        title: stringField(current, "title", "slug") || "",
+        phase: stringField(payload, "phase") || stringField(current, "phase") || "boot",
+        activity:
+          stringField(payload, "activity", "stage", "probe", "task") ||
+          stringField(current, "activity") ||
+          (latest?.kind === "worker.heartbeat"
+            ? ""
+            : latest?.kind.replace(/^worker\./, "") || ""),
+        started_at: heartbeat,
+        model: stringField(payload, "model") || stringField(current, "model"),
+        effort: stringField(payload, "effort") || stringField(current, "effort"),
+      },
+    },
+    liveness: laneFresh ? "active" : "quiet-but-live",
+    live: laneFresh,
+    pidLive: true,
+    diffAdded: 0,
+    diffRemoved: 0,
+  };
 }
 
 interface RepoStatsCache {

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -247,6 +247,15 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
     expect(stripAnsi(renderWorkerLine(afk, NOW))).toContain("org=afk");
   });
 
+  it("shows named-fleet attribution and marks standalone Workers as unattributed", () => {
+    const attributed = worker({
+      state: { ...worker().state, fleet: "alpha" },
+    });
+
+    expect(stripAnsi(renderWorkerLine(attributed, NOW))).toContain("flt=alpha");
+    expect(stripAnsi(renderWorkerLine(worker(), NOW))).toContain("flt=unattributed");
+  });
+
   it("short preset keeps only worker id, issue, status, and timer", () => {
     const t = stripAnsi(renderWorkerLine(worker(), NOW, "short"));
     expect(t).toContain("w1");

--- a/apps/dev/tests/wire-statusline.test.ts
+++ b/apps/dev/tests/wire-statusline.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createCastleLaneWriters } from "@reddb-io/red-castle/engine";
 import {
   afkPaths,
   appendCastleHistoryRecord,
@@ -288,6 +289,99 @@ describe("collectStatuslineAfk — cache discipline", () => {
       expect(result!.added).toBe(84);
       expect(result!.removed).toBe(5);
       expect(result!.locIsPeak).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("collectStatuslineWorkers — live pre-claim workers", () => {
+  it("renders a live Worker before an attempt state exists", async () => {
+    const root = scratch();
+    try {
+      const workerId = "wBOOT";
+      const issue = 2488;
+      const workerDir = join(root, ".red", "tmp", "workers", workerId);
+      mkdirSync(join(workerDir, String(issue)), { recursive: true });
+      writeFileSync(join(workerDir, "worker.pid"), String(process.pid), "utf8");
+      const enginePaths = createEnginePaths(join(root, ".red"));
+      await createCastleLaneWriters(enginePaths).worker(workerId).append({
+        kind: "worker.heartbeat",
+        worker_id: workerId,
+        payload: { phase: "boot", activity: "reconcile-gate", runner: "codex" },
+      });
+      const heartbeatAt = new Date(Date.now() - 30_000).toISOString();
+      await createCastleLaneWriters(enginePaths, { clock: () => heartbeatAt }).liveness(workerId).append({
+        kind: "worker.heartbeat",
+        worker_id: workerId,
+        payload: {},
+      });
+
+      const workers = await collectStatuslineWorkers({
+        root,
+        repo: "reddb-io/red-skills",
+        remote: "origin",
+      });
+
+      expect(workers).toHaveLength(1);
+      expect(workers[0]).toMatchObject({
+        state: {
+          worker_id: workerId,
+          runner: "codex",
+          current: {
+            number: issue,
+            phase: "boot",
+            activity: "reconcile-gate",
+            started_at: heartbeatAt,
+          },
+        },
+        pidLive: true,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("renders Workers owned by different named fleets with their attribution", async () => {
+    const root = scratch();
+    try {
+      const paths = createEnginePaths(join(root, ".red"));
+      const startedAt = new Date().toISOString();
+      for (const [workerId, issue, fleet] of [
+        ["wALPHA", 2481, "alpha"],
+        ["wBETA", 2482, "beta"],
+      ] as const) {
+        writeRenderableAttempt(root, workerId, issue, startedAt);
+        await writeCastleStateSnapshot(
+          castleStateSnapshotPath(paths, "worker", workerId),
+          {
+            kind: "worker",
+            id: workerId,
+            worker_id: workerId,
+            supervisor_id: fleet,
+            version: 1,
+            updated_at: startedAt,
+            pid: process.pid,
+            current: { number: issue, phase: "coding" },
+          },
+        );
+      }
+
+      const workers = await collectStatuslineWorkers({
+        root,
+        repo: "reddb-io/red-skills",
+        remote: "origin",
+      });
+
+      expect(
+        workers.map((worker) => ({
+          id: worker.state.worker_id,
+          fleet: worker.state.fleet,
+        })),
+      ).toEqual([
+        { id: "wALPHA", fleet: "alpha" },
+        { id: "wBETA", fleet: "beta" },
+      ]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Automated AFK landing for #2488. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2488

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787386073&installation_model_id=20659&pr_number=2557&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2557&signature=b43d652370b375fb1fb997c8d62a07128b79376a60979f0d43e8aaa01c85f2eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->