### PR TITLE
chore: #2426 Resident crons + top-level janitor singleton with supervisor-boot fallback

### DIFF
--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -19,13 +19,20 @@ import {
 import { createMergeDriverIo } from "./runtime/merge-driver-io.js";
 import { createMedicIo } from "./runtime/medic-io.js";
 import { createFileMedicStore, runMedicPass } from "./core/pr-medic.js";
-import { resolveRepoContext } from "./runtime/wire.js";
-import { superviseCommand } from "./commands/supervise.js";
+import { resolveRepoContext, resolveRepoSlug } from "./runtime/wire.js";
+import {
+  buildSupervisorBootSweeps,
+  superviseCommand,
+} from "./commands/supervise.js";
 import { createCastleMcpDependencies } from "./mcp-adapter.js";
 import {
   createResidentWebhook,
   type ResidentWebhook,
 } from "./resident-webhook.js";
+import {
+  createResidentJanitor,
+  type ResidentJanitor,
+} from "./resident-cron.js";
 
 const buildInfo = readBuildInfo("castle");
 
@@ -75,12 +82,14 @@ export interface ConnectResidentMcpOptions {
   readonly server: ResidentMcpConnection;
   readonly transport: StdioServerTransport;
   readonly resident: ResidentWebhook;
+  readonly janitor: ResidentJanitor;
 }
 
 export async function connectResidentMcp(
   options: ConnectResidentMcpOptions,
 ): Promise<void> {
   await options.resident.start();
+  await options.janitor.start();
   let notifyClosed!: () => void;
   const closed = new Promise<void>((resolveClosed) => {
     notifyClosed = resolveClosed;
@@ -90,11 +99,12 @@ export async function connectResidentMcp(
     await options.server.connect(options.transport);
     await closed;
   } finally {
-    await options.resident.stop();
+    await Promise.all([options.janitor.stop(), options.resident.stop()]);
   }
 }
 
 async function run(): Promise<void> {
+  const root = process.cwd();
   const server = createCastleMcpServer();
   const close = () => {
     void server.close();
@@ -102,10 +112,24 @@ async function run(): Promise<void> {
   process.once("SIGINT", close);
   process.once("SIGTERM", close);
   try {
+    let sharedBootSweeps: (() => Promise<void>) | undefined;
     await connectResidentMcp({
       server,
       transport: new StdioServerTransport(),
-      resident: createResidentWebhook({ root: process.cwd() }),
+      resident: createResidentWebhook({ root }),
+      janitor: createResidentJanitor({
+        root,
+        sweep: async () => {
+          if (!sharedBootSweeps) {
+            const repo = await resolveRepoSlug(root).catch(() => "");
+            sharedBootSweeps = buildSupervisorBootSweeps(root, repo, (line) =>
+              process.stderr.write(`castle resident: ${line}\n`),
+            );
+          }
+          await sharedBootSweeps();
+        },
+        notice: (line) => process.stderr.write(`castle resident: ${line}\n`),
+      }),
     });
   } finally {
     process.removeListener("SIGINT", close);
@@ -179,10 +203,15 @@ export async function startResidentMergeDriver(root = process.cwd()): Promise<vo
  * The singleton lease prevents multiple stdio hosts for the same repo from
  * racing the durable ledger. The first sweep is detached from MCP startup; a
  * slow or unavailable tracker never delays the stdio handshake. */
-export async function startResidentIssueCurator(root = process.cwd()): Promise<void> {
+export async function startResidentIssueCurator(
+  root = process.cwd(),
+): Promise<void> {
   const paths = createEnginePaths(join(root, ".red"));
   const owner = { pid: process.pid, startTime: new Date().toISOString() };
-  const lease = await createSingletonLeaseStore(paths).acquire("issue-curator", owner);
+  const lease = await createSingletonLeaseStore(paths).acquire(
+    "issue-curator",
+    owner,
+  );
   if (!lease.acquired) return;
 
   const tracker = createGitHubTrackerAdapter({
@@ -232,8 +261,8 @@ export async function main(
   if (argv[0] === "--version" || argv[0] === "-v" || argv[0] === "version") {
     process.stdout.write(
       argv.includes("--json")
-      ? `${JSON.stringify(buildInfo)}\n`
-      : `${renderVersion(buildInfo)}\n`,
+        ? `${JSON.stringify(buildInfo)}\n`
+        : `${renderVersion(buildInfo)}\n`,
     );
     return 0;
   }
@@ -248,10 +277,12 @@ const isDirectExecution =
   resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
 
 if (isDirectExecution) {
-  void main().then((exitCode) => {
-    process.exitCode = exitCode;
-  }).catch((error) => {
-    process.stderr.write(`castle MCP fatal: ${String(error)}\n`);
-    process.exitCode = 1;
-  });
+  void main()
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      process.stderr.write(`castle MCP fatal: ${String(error)}\n`);
+      process.exitCode = 1;
+    });
 }

--- a/apps/dev/src/resident-cron.ts
+++ b/apps/dev/src/resident-cron.ts
@@ -1,0 +1,381 @@
+import * as fsPromises from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import {
+  createEnginePaths,
+  createSingletonEventLane,
+  createSingletonLeaseStore,
+  type SingletonEventLane,
+  type SingletonLeaseAcquireResult,
+  type SingletonLeaseOwner,
+  type SingletonLeaseStore,
+} from "@reddb-io/red-castle/engine";
+import { resolveRepoRoot } from "@reddb-io/shared/repo-root.js";
+import { readPidStartTime } from "./core/state.js";
+
+export interface ResidentCronSchedule {
+  readonly last_fired_at?: string;
+  readonly next_due_at: string;
+  readonly interval_ms: number;
+}
+
+export interface ResidentCronFs {
+  mkdir(path: string, options: { recursive: true }): Promise<unknown>;
+  readFile(path: string, encoding: "utf8"): Promise<string>;
+  writeFile(
+    path: string,
+    data: string,
+    options: { encoding: "utf8" },
+  ): Promise<unknown>;
+  rename(from: string, to: string): Promise<unknown>;
+}
+
+export interface ResidentCronTimers {
+  setInterval(callback: () => void, intervalMs: number): unknown;
+  clearInterval(timer: unknown): void;
+}
+
+export interface ResidentCronOptions {
+  readonly root: string;
+  readonly name: string;
+  readonly intervalMs: number;
+  readonly run: () => Promise<void>;
+  readonly fs?: ResidentCronFs;
+  readonly clock?: () => Date;
+  readonly timers?: ResidentCronTimers;
+  readonly lane?: SingletonEventLane;
+  readonly notice?: (message: string) => void;
+}
+
+export interface ResidentCron {
+  start(): Promise<void>;
+  tick(): Promise<boolean>;
+  stop(): Promise<void>;
+  schedule(): ResidentCronSchedule | undefined;
+}
+
+export const RESIDENT_JANITOR_INTERVAL_MS = 5 * 60 * 1000;
+export const RESIDENT_CRON_EVENT_KIND = "resident.cron";
+export const JANITOR_SWEEP_EVENT_KIND = "janitor.sweep";
+
+export interface ResidentJanitorOptions {
+  readonly root: string;
+  readonly sweep: () => Promise<void>;
+  readonly intervalMs?: number;
+  readonly owner?: SingletonLeaseOwner;
+  readonly leases?: SingletonLeaseStore;
+  readonly lane?: SingletonEventLane;
+  readonly fs?: ResidentCronFs;
+  readonly clock?: () => Date;
+  readonly timers?: ResidentCronTimers;
+  readonly notice?: (message: string) => void;
+}
+
+export interface ResidentJanitor {
+  start(): Promise<SingletonLeaseAcquireResult>;
+  stop(): Promise<void>;
+}
+
+const CRON_NAME_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+function assertOptions(options: ResidentCronOptions): void {
+  if (!CRON_NAME_RE.test(options.name)) {
+    throw new Error(
+      `invalid resident cron name ${JSON.stringify(options.name)}`,
+    );
+  }
+  if (!Number.isSafeInteger(options.intervalMs) || options.intervalMs <= 0) {
+    throw new Error("resident cron intervalMs must be a positive integer");
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function validateSchedule(value: unknown): ResidentCronSchedule {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("resident cron schedule must be a record");
+  }
+  const schedule = value as Record<string, unknown>;
+  if (
+    typeof schedule.next_due_at !== "string" ||
+    !Number.isFinite(Date.parse(schedule.next_due_at))
+  ) {
+    throw new Error("resident cron next_due_at must be an ISO timestamp");
+  }
+  if (
+    !Number.isSafeInteger(schedule.interval_ms) ||
+    (schedule.interval_ms as number) <= 0
+  ) {
+    throw new Error("resident cron interval_ms must be a positive integer");
+  }
+  if (
+    schedule.last_fired_at !== undefined &&
+    (typeof schedule.last_fired_at !== "string" ||
+      !Number.isFinite(Date.parse(schedule.last_fired_at)))
+  ) {
+    throw new Error("resident cron last_fired_at must be an ISO timestamp");
+  }
+  return {
+    ...(schedule.last_fired_at === undefined
+      ? {}
+      : { last_fired_at: schedule.last_fired_at as string }),
+    next_due_at: schedule.next_due_at,
+    interval_ms: schedule.interval_ms as number,
+  };
+}
+
+function nextCadence(
+  scheduledFor: string,
+  intervalMs: number,
+  nowMs: number,
+): string {
+  let nextMs = Date.parse(scheduledFor) + intervalMs;
+  if (nextMs <= nowMs) {
+    const missed = Math.floor((nowMs - nextMs) / intervalMs) + 1;
+    nextMs += missed * intervalMs;
+  }
+  return new Date(nextMs).toISOString();
+}
+
+export function residentCronSchedulePath(root: string, name: string): string {
+  if (!CRON_NAME_RE.test(name)) {
+    throw new Error(`invalid resident cron name ${JSON.stringify(name)}`);
+  }
+  const paths = createEnginePaths(join(root, ".red"));
+  return join(paths.castleStateRoot, "crons", `${name}.toon`);
+}
+
+export function createResidentCron(options: ResidentCronOptions): ResidentCron {
+  assertOptions(options);
+  const fs =
+    options.fs ??
+    ({
+      mkdir: fsPromises.mkdir,
+      readFile: fsPromises.readFile,
+      rename: fsPromises.rename,
+      writeFile: fsPromises.writeFile,
+    } satisfies ResidentCronFs);
+  const clock = options.clock ?? (() => new Date());
+  const timers =
+    options.timers ??
+    ({
+      setInterval(callback, intervalMs) {
+        const timer = setInterval(callback, intervalMs);
+        timer.unref();
+        return timer;
+      },
+      clearInterval(timer) {
+        clearInterval(timer as NodeJS.Timeout);
+      },
+    } satisfies ResidentCronTimers);
+  const notice = options.notice ?? (() => undefined);
+  const path = residentCronSchedulePath(options.root, options.name);
+  let current: ResidentCronSchedule | undefined;
+  let timer: unknown;
+  let running: Promise<boolean> | undefined;
+
+  async function readSchedule(): Promise<ResidentCronSchedule | undefined> {
+    try {
+      return validateSchedule(decode(await fs.readFile(path, "utf8")));
+    } catch (error) {
+      if (isMissing(error)) return undefined;
+      throw error;
+    }
+  }
+
+  async function writeSchedule(schedule: ResidentCronSchedule): Promise<void> {
+    await fs.mkdir(dirname(path), { recursive: true });
+    const temporary = `${path}.tmp-${process.pid}-${crypto.randomUUID()}`;
+    await fs.writeFile(
+      temporary,
+      encode(schedule as unknown as JsonValue, { keyedMapCollapse: true }),
+      { encoding: "utf8" },
+    );
+    await fs.rename(temporary, path);
+  }
+
+  async function runTick(): Promise<boolean> {
+    if (!current) return false;
+    const now = clock();
+    const scheduledFor = current.next_due_at;
+    if (now.getTime() < Date.parse(scheduledFor)) return false;
+
+    let status = "passed";
+    try {
+      await options.run();
+    } catch (error) {
+      status = "failed";
+      notice(
+        `cron ${options.name} failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    current = {
+      last_fired_at: now.toISOString(),
+      next_due_at: nextCadence(scheduledFor, options.intervalMs, now.getTime()),
+      interval_ms: options.intervalMs,
+    };
+    await writeSchedule(current);
+    if (options.lane) {
+      await options.lane
+        .append({
+          singleton: options.name,
+          kind: RESIDENT_CRON_EVENT_KIND,
+          payload: {
+            status,
+            scheduled_for: scheduledFor,
+            next_due_at: current.next_due_at,
+            catch_up: now.getTime() > Date.parse(scheduledFor),
+          },
+        })
+        .catch(() => notice(`cron ${options.name} event append failed`));
+    }
+    return true;
+  }
+
+  const cron: ResidentCron = {
+    async start() {
+      if (timer !== undefined) return;
+      current = await readSchedule();
+      if (!current) {
+        current = {
+          next_due_at: clock().toISOString(),
+          interval_ms: options.intervalMs,
+        };
+        await writeSchedule(current);
+      }
+      timer = timers.setInterval(() => {
+        void cron
+          .tick()
+          .catch((error) =>
+            notice(
+              `cron ${options.name} tick failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            ),
+          );
+      }, options.intervalMs);
+      void cron
+        .tick()
+        .catch((error) =>
+          notice(
+            `cron ${options.name} tick failed: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          ),
+        );
+    },
+
+    tick() {
+      if (running) return running;
+      running = runTick().finally(() => {
+        running = undefined;
+      });
+      return running;
+    },
+
+    async stop() {
+      if (timer !== undefined) {
+        timers.clearInterval(timer);
+        timer = undefined;
+      }
+      await running?.catch((error) =>
+        notice(
+          `cron ${options.name} drain failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        ),
+      );
+    },
+
+    schedule() {
+      return current;
+    },
+  };
+
+  return cron;
+}
+
+export function createResidentJanitor(
+  options: ResidentJanitorOptions,
+): ResidentJanitor {
+  const root = resolveRepoRoot(options.root);
+  const paths = createEnginePaths(join(root, ".red"));
+  const leases = options.leases ?? createSingletonLeaseStore(paths);
+  const lane = options.lane ?? createSingletonEventLane(paths);
+  const notice = options.notice ?? (() => undefined);
+  const owner = options.owner ?? {
+    pid: process.pid,
+    startTime: readPidStartTime(process.pid) ?? `pid-${process.pid}`,
+  };
+  let ownsLease = false;
+
+  const cron = createResidentCron({
+    root,
+    name: "janitor",
+    intervalMs: options.intervalMs ?? RESIDENT_JANITOR_INTERVAL_MS,
+    fs: options.fs,
+    clock: options.clock,
+    timers: options.timers,
+    lane,
+    notice,
+    run: async () => {
+      let status = "passed";
+      let failure: unknown;
+      try {
+        await options.sweep();
+      } catch (error) {
+        status = "failed";
+        failure = error;
+      }
+      await lane
+        .append({
+          singleton: "janitor",
+          kind: JANITOR_SWEEP_EVENT_KIND,
+          payload: {
+            status,
+            ...(failure === undefined
+              ? {}
+              : {
+                  error:
+                    failure instanceof Error
+                      ? failure.message
+                      : String(failure),
+                }),
+          },
+        })
+        .catch(() => notice("janitor sweep event append failed"));
+      if (failure !== undefined) throw failure;
+    },
+  });
+
+  return {
+    async start() {
+      const acquired = await leases.acquire("janitor", owner);
+      if (!acquired.acquired) return acquired;
+      ownsLease = true;
+      try {
+        await cron.start();
+      } catch (error) {
+        await leases.release("janitor", owner);
+        ownsLease = false;
+        throw error;
+      }
+      return acquired;
+    },
+
+    async stop() {
+      if (!ownsLease) return;
+      try {
+        await cron.stop();
+      } finally {
+        await leases.release("janitor", owner);
+        ownsLease = false;
+      }
+    },
+  };
+}

--- a/apps/dev/tests/mcp-server-routing.test.ts
+++ b/apps/dev/tests/mcp-server-routing.test.ts
@@ -9,7 +9,12 @@ describe("dev:afk MCP entrypoint routing", () => {
     const startMergeDriver = vi.fn(async () => undefined);
 
     await expect(
-      main(["__supervise", "--fleet", "codex"], { supervise, connect, startCurator, startMergeDriver }),
+      main(["__supervise", "--fleet", "codex"], {
+        supervise,
+        connect,
+        startCurator,
+        startMergeDriver,
+      }),
     ).resolves.toBe(0);
 
     expect(supervise).toHaveBeenCalledWith(["--fleet", "codex"]);
@@ -54,19 +59,26 @@ describe("dev:afk MCP entrypoint routing", () => {
       server: protocol,
       connect: vi.fn(async () => undefined),
     };
+    const janitor = {
+      start: vi.fn(async () => ({ acquired: true, reaped: false, lease: {} })),
+      stop: vi.fn(async () => undefined),
+    };
     let finished = false;
     const running = connectResidentMcp({
       server: server as never,
       transport: {} as never,
       resident: resident as never,
+      janitor: janitor as never,
     }).then(() => {
       finished = true;
     });
     await vi.waitFor(() => expect(server.connect).toHaveBeenCalledTimes(1));
+    expect(janitor.start).toHaveBeenCalledTimes(1);
 
     protocol.onclose?.();
 
     await vi.waitFor(() => expect(resident.stop).toHaveBeenCalledTimes(1));
+    expect(janitor.stop).toHaveBeenCalledTimes(1);
     await new Promise<void>((resolve) => setTimeout(resolve, 20));
     expect(finished).toBe(false);
     finishStop();

--- a/apps/dev/tests/resident-cron.test.ts
+++ b/apps/dev/tests/resident-cron.test.ts
@@ -1,0 +1,148 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createEnginePaths,
+  createSingletonEventLane,
+  createSingletonLeaseStore,
+} from "@reddb-io/red-castle/engine";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createResidentCron,
+  createResidentJanitor,
+  type ResidentCronFs,
+  type ResidentCronTimers,
+} from "../src/resident-cron.js";
+
+function memoryFs(): ResidentCronFs {
+  const files = new Map<string, string>();
+  return {
+    mkdir: vi.fn(async () => undefined),
+    readFile: vi.fn(async (path) => {
+      const value = files.get(path);
+      if (value !== undefined) return value;
+      throw Object.assign(new Error(`missing ${path}`), { code: "ENOENT" });
+    }),
+    writeFile: vi.fn(async (path, value) => {
+      files.set(path, value);
+    }),
+    rename: vi.fn(async (from, to) => {
+      const value = files.get(from);
+      if (value === undefined) {
+        throw Object.assign(new Error(`missing ${from}`), { code: "ENOENT" });
+      }
+      files.set(to, value);
+      files.delete(from);
+    }),
+  };
+}
+
+const idleTimers: ResidentCronTimers = {
+  setInterval: vi.fn(() => 1),
+  clearInterval: vi.fn(),
+};
+
+describe("resident repo cron", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      roots.map((root) => rm(root, { recursive: true, force: true })),
+    );
+    roots.length = 0;
+  });
+
+  it("round-trips its schedule and catches up one missed window on the next boot", async () => {
+    const fs = memoryFs();
+    let now = new Date("2026-07-23T00:00:00.000Z");
+    const firedAt: string[] = [];
+    const options = {
+      root: "/repo",
+      name: "janitor",
+      intervalMs: 60_000,
+      fs,
+      timers: idleTimers,
+      clock: () => now,
+      run: async () => {
+        firedAt.push(now.toISOString());
+      },
+    };
+
+    const firstBoot = createResidentCron(options);
+    await firstBoot.start();
+    await firstBoot.stop();
+    expect(firstBoot.schedule()).toEqual({
+      last_fired_at: "2026-07-23T00:00:00.000Z",
+      next_due_at: "2026-07-23T00:01:00.000Z",
+      interval_ms: 60_000,
+    });
+
+    now = new Date("2026-07-23T00:03:20.000Z");
+    const nextBoot = createResidentCron(options);
+    await nextBoot.start();
+    await nextBoot.stop();
+
+    expect(firedAt).toEqual([
+      "2026-07-23T00:00:00.000Z",
+      "2026-07-23T00:03:20.000Z",
+    ]);
+    expect(nextBoot.schedule()).toEqual({
+      last_fired_at: "2026-07-23T00:03:20.000Z",
+      next_due_at: "2026-07-23T00:04:00.000Z",
+      interval_ms: 60_000,
+    });
+  });
+
+  it("runs the shared hygiene sweep only under the janitor lease and records cron activity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "resident-janitor-"));
+    roots.push(root);
+    await mkdir(join(root, ".red"));
+    const paths = createEnginePaths(join(root, ".red"));
+    const leases = createSingletonLeaseStore(paths, {
+      clock: () => "2026-07-23T01:00:00.000Z",
+      isPidAlive: () => true,
+    });
+    const lane = createSingletonEventLane(paths, {
+      clock: () => "2026-07-23T01:00:00.000Z",
+    });
+    const sharedBootSweep = vi.fn(async () => undefined);
+    const losingSweep = vi.fn(async () => undefined);
+    const first = createResidentJanitor({
+      root,
+      owner: { pid: 4100, startTime: "first" },
+      leases,
+      lane,
+      clock: () => new Date("2026-07-23T01:00:00.000Z"),
+      timers: idleTimers,
+      sweep: sharedBootSweep,
+    });
+    const second = createResidentJanitor({
+      root,
+      owner: { pid: 4200, startTime: "second" },
+      leases,
+      lane,
+      clock: () => new Date("2026-07-23T01:00:00.000Z"),
+      timers: idleTimers,
+      sweep: losingSweep,
+    });
+
+    expect(await first.start()).toMatchObject({ acquired: true });
+    expect(await second.start()).toMatchObject({ acquired: false });
+    expect(sharedBootSweep).toHaveBeenCalledTimes(1);
+    expect(losingSweep).not.toHaveBeenCalled();
+    await first.stop();
+    await second.stop();
+    expect(
+      (await lane.read()).map((event) => ({
+        singleton: event.singleton,
+        kind: event.kind,
+        status: event.payload?.status,
+      })),
+    ).toEqual([
+      { singleton: "janitor", kind: "janitor.sweep", status: "passed" },
+      { singleton: "janitor", kind: "resident.cron", status: "passed" },
+    ]);
+
+    expect(await leases.read("janitor")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2426. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2426

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787389532&installation_model_id=20659&pr_number=2558&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2558&signature=8dd05021c7b62ad2ce1e5d2383ab44eaec7fcf8da9487c4fb25f3ea2f6d34c8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->