### PR TITLE
fix: #2487 Targeted worker_dispatch runs another issue's reconcile gate before claiming its target — urgent dispatches delayed minutes, invisibly

### DIFF
--- a/.changeset/targeted-claim-gate.md
+++ b/.changeset/targeted-claim-gate.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Claim explicitly dispatched issues before shared boot hygiene, expose booting workers in vitals, and serialize validation gates host-wide.

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -6,6 +6,7 @@ export {
   checkBootGuard,
   parseRunFlags,
   resolveRunDispatchIdentity,
+  shouldSkipBootSweeps,
 } from "./run/flags.js";
 export { deriveActivity } from "./run/activity.js";
 export { buildProcessDeps } from "./run/process-deps.js";
@@ -17,5 +18,6 @@ export {
   encodeBootErrorPayload,
   castleWorktreeUnder,
   readCapturedWorktreePath,
+  initBootWorkerState,
 } from "./run/state.js";
 export { runCommand } from "./run/command.js";

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -82,7 +82,7 @@ import {
   type AttemptDirEntry,
 } from "../../core/attempt-ledger.js";
 import { isValidWorkerId, WORKER_NAMESPACES } from "../../core/worker-paths.js";
-import { readdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readdirSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { isLivePid } from "../../runtime/kill-tree.js";
 import { specialUserRequestBlock, claudeSpawnArgs, codexSpawnArgs } from "../../core/runner-spawn.js";
@@ -97,7 +97,7 @@ import {
   safetyLogPath,
   deathCauseForRecoveredWorker,
 } from "../../core/process-safety.js";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { hostFingerprintPrefix, workerIdentity } from "../../core/host-identity.js";
 import { appendAgentRecord, appendRecordToonlTaggedRow } from "../../core/jsonl-log.js";
 import { initStateSync, readPidStartTime, updateState, writeIdentitySync } from "../../core/state.js";
@@ -112,10 +112,10 @@ import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../../core
 import { renderClaimComment } from "../../core/claim.js";
 import { HOST_CONFIG_EXIT_CODE } from "../../core/attempt-outcome.js";
 
-import { checkBootGuard, isNamespacedDispatch, parseRunFlags, resolveRunDispatchIdentity, type RunOptions } from "./flags.js";
+import { checkBootGuard, isNamespacedDispatch, parseRunFlags, resolveRunDispatchIdentity, shouldSkipBootSweeps, type RunOptions } from "./flags.js";
 import { buildProcessDeps, parseSlot, type CurrentAttempt } from "./process-deps.js";
 import { makeBootReconcileRunner, runReconcileWorker } from "./reconcile.js";
-import { nextAttemptSync, openRunnerCircuit, recordBootError, runnerCircuitOpen } from "./state.js";
+import { initBootWorkerState, nextAttemptSync, openRunnerCircuit, recordBootError, runnerCircuitOpen } from "./state.js";
 
 export async function runCommand(options: RunOptions): Promise<number> {
   const cwd = options.cwd ?? process.cwd();
@@ -174,6 +174,17 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // to resolve all workers that ran in a parked slot — this stamp must appear
   // even when the worker fast-dies before writing worker.pid.
   process.stdout.write(`[afk] worker: ${workerId}\n`);
+  const bootStatePath = await initBootWorkerState({
+    tmpDir: paths.tmpDir,
+    workerId,
+    pid: process.pid,
+    pidStartTime,
+    runner,
+    origin: dispatchIdentity.origin,
+    kind: dispatchIdentity.kind,
+    model: settings.model,
+    effort: settings.effort,
+  }).catch(() => undefined);
 
   // AFK runner improvement — Pattern 5 diagnostic: every spike worker died
   // post-commit + vitest with no exit code / signal / stack trace. Install
@@ -201,12 +212,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
   });
   const nowS = Math.floor(Date.now() / 1000);
 
-  // Fleet supervisor owns the boot (#623): a worker spawned by the supervisor
-  // carries RED_AFK_SWEEPS_DONE, signalling the shared sweeps already ran once
-  // pre-spawn. Such a worker boots bootstrap+claim only — it skips every sweep
-  // (cheap respawns; no race over `.red/tmp`). A solo `run` has no marker and
-  // runs the full sweep suite exactly as before.
-  const sweepsDone = process.env.RED_AFK_SWEEPS_DONE === "1";
+  // Fleet workers inherit completed sweeps (#623). Explicit issue dispatches
+  // defer shared hygiene to fleet/untargeted boots (#2487), so reconcile work
+  // cannot delay the named target before claim. Both paths use minimal boot.
+  const supervisorSweepsDone = process.env.RED_AFK_SWEEPS_DONE === "1";
+  const skipSweeps = shouldSkipBootSweeps(flags.filter, supervisorSweepsDone);
 
   const sessionCtx: SessionContext & { hostProfile?: HostCapabilityProfile } = {
     runner,
@@ -218,7 +228,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     bootOnly: flags.bootOnly,
     // Reported by the --boot-only line so the dry-run states whether this worker
     // ran the sweeps or inherited them from the supervisor.
-    sweepsSkipped: sweepsDone,
+    sweepsSkipped: skipSweeps,
     ...(hostProfile !== undefined ? { hostProfile } : {}),
     issueTemplate: {
       tmpDir: paths.tmpDir,
@@ -245,8 +255,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
   let bootOptions: BootOptions;
   let bootDeps: BootDeps;
   try {
-    if (sweepsDone) {
-      // Supervisor-owned boot (#623): skip the expensive discovery (branch
+    if (skipSweeps) {
+      // Minimal boot (#623, #2487): skip the expensive discovery (branch
       // listings, orphan walk, unblock-candidate + parked-mechanical gh probes)
       // AND the sweep work itself. The minimal options carry empty sweep inputs
       // + skipSweeps:true; the minimal deps wire only the bootstrap fs calls.
@@ -281,11 +291,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
     resourceBudget: readValidationResourceBudget(config),
   });
 
-  // Wire the boot reconcile runner into bootDeps (step 7, ADR 0055). A
-  // supervisor-owned boot skips every sweep (including reconcile) and the fleet
-  // dispatches reconcile per-tick instead, so the runner is wired only on the
-  // solo / sweep-running path.
-  if (!sweepsDone) {
+  // Wire the boot reconcile runner only when this boot actually owns sweeps.
+  if (!skipSweeps) {
     bootDeps = { ...bootDeps, reconcileRunner: makeBootReconcileRunner(ctx, paths, workerId, runner, feedback) };
   }
 
@@ -404,6 +411,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
       isOpen: (r) => runnerCircuitOpen(paths.runnerCircuitDir, r, Math.floor(Date.now() / 1000)),
     },
     buildProcessInput: (candidate: IssueCandidate, c: SessionContext): ProcessIssueInput => {
+      if (bootStatePath) {
+        rmSync(dirname(bootStatePath), { recursive: true, force: true });
+      }
       const recoveryOrdinal = nextAttemptSync(c.issueTemplate.tmpDir, candidate.number);
       // Long-running workers key workspaces by workerId+issueId. The retry
       // ordinal remains separate policy data for per-class recovery caps and

--- a/apps/dev/src/commands/run/flags.ts
+++ b/apps/dev/src/commands/run/flags.ts
@@ -166,6 +166,18 @@ export interface RunDispatchIdentity {
   lane?: string;
 }
 
+/**
+ * Shared fleet hygiene must never delay an explicit target. A supervisor has
+ * already run the sweeps for its workers; a targeted solo dispatch defers them
+ * to the next fleet/untargeted boot so its first issue operation is the claim.
+ */
+export function shouldSkipBootSweeps(
+  filter: SelectionFilter,
+  supervisorSweepsDone: boolean,
+): boolean {
+  return supervisorSweepsDone || filter.kind === "issues";
+}
+
 /** Raised when --alternate is combined with --runner (mutually exclusive). */
 export class RunFlagError extends Error {
   constructor(message: string) {

--- a/apps/dev/src/commands/run/state.ts
+++ b/apps/dev/src/commands/run/state.ts
@@ -102,8 +102,61 @@ import { DEFAULT_MAX_ITERATIONS } from "../../core/execution.js";
 import type { AgentStreamEvent } from "../../core/execution.js";
 import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../../core/claim-staleness.js";
 import { renderClaimComment } from "../../core/claim.js";
+import { LivenessLane, LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 
 const DEFAULT_RUNNER_TRANSIENT_COOLDOWN_S = 300;
+
+export interface BootWorkerStateInput {
+  tmpDir: string;
+  workerId: string;
+  pid: number;
+  pidStartTime?: string;
+  runner: Runner;
+  origin: string;
+  kind: string;
+  model?: string;
+  effort?: string;
+  nowMs?: () => number;
+}
+
+/**
+ * Publish the pre-claim worker row before boot discovery or sweeps begin.
+ * The synthetic `boot` attempt is replaced by the real issue attempt at pick.
+ */
+export async function initBootWorkerState(input: BootWorkerStateInput): Promise<string> {
+  const attemptDir = join(workerDirPath(input.tmpDir, input.workerId), "boot");
+  const statePath = join(attemptDir, "afk.state.toon");
+  const nowMs = input.nowMs ?? (() => Date.now());
+  const startedAt = new Date(nowMs()).toISOString();
+  initStateSync(statePath, {
+    worker_id: input.workerId,
+    pid: input.pid,
+    pid_start_time: input.pidStartTime ?? "",
+    runner: input.runner,
+    origin: input.origin,
+    started_at: startedAt,
+    "current.kind": input.kind,
+    "current.number": "",
+    "current.started_at": startedAt,
+    "current.runner": input.runner,
+    "current.model": input.model ?? "",
+    "current.effort": input.effort ?? "",
+    "current.activity": "boot",
+    "current.phase": "boot",
+  });
+  writeIdentitySync(attemptDir, {
+    worker_id: input.workerId,
+    runner: input.runner,
+    origin: input.origin,
+    number: "",
+    started_at: startedAt,
+  });
+  await new LivenessLane({
+    path: join(attemptDir, LIVENESS_LANE_FILENAME),
+    clock: nowMs,
+  }).record("iteration-start");
+  return statePath;
+}
 
 export function decodeLocMemoSnapshot(text: string): LocMemo | null {
   try {

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -184,6 +184,11 @@ export interface FeedbackWorktreeIO {
    * in-process, which is all a single-process fixture needs.
    */
   lock?(dest: string): Promise<(() => Promise<void>) | null>;
+  /**
+   * Host-wide capacity-one semaphore for validation commands. Every live worker
+   * and no-agent reconcile manager binds the same `.red/state` lock.
+   */
+  gateLock?(root: string): Promise<(() => Promise<void>) | null>;
 }
 
 /**
@@ -196,6 +201,8 @@ export interface FeedbackWorktreeIO {
 const WORKTREE_LOCK_WAIT_MS = 10 * 60_000;
 /** A holder that has not finished a materialise in this long has crashed. */
 const WORKTREE_LOCK_STALE_MS = 20 * 60_000;
+const GATE_LOCK_WAIT_MS = 60 * 60_000;
+const GATE_LOCK_STALE_MS = 24 * 60 * 60_000;
 /**
  * Consecutive failed setups before a branch is latched as permanently broken.
  * Above 1 so a transient contention loss is retried; low enough that a genuine
@@ -242,6 +249,19 @@ const defaultIO: FeedbackWorktreeIO = {
       staleAfterMs: WORKTREE_LOCK_STALE_MS,
       pollMs: 500,
     }).acquire();
+  },
+  gateLock: async (root) => {
+    const stateDir = join(root, ".red", "state");
+    await mkdir(stateDir, { recursive: true });
+    return createPathLock(
+      join(stateDir, "validation-gate.lock"),
+      `validation-gate:${process.pid}`,
+      {
+        waitTimeoutMs: GATE_LOCK_WAIT_MS,
+        staleAfterMs: GATE_LOCK_STALE_MS,
+        pollMs: 500,
+      },
+    ).acquire();
   },
 };
 
@@ -331,6 +351,25 @@ export function makeFeedbackWorktree(
   // worktree looks exactly like a hard failure at the first attempt, and
   // latching it made one collision fail every remaining check of the cycle.
   const setupFailures = new Map<string, number>();
+
+  async function runValidationCommand(
+    run: () => Promise<ExecOutput>,
+  ): Promise<ExecOutput> {
+    if (!io.gateLock) return run();
+    const release = await io.gateLock(root);
+    if (release === null) {
+      return {
+        code: 1,
+        stdout: "",
+        stderr: "host-wide validation gate lock timed out; validation blocked",
+      };
+    }
+    try {
+      return await run();
+    } finally {
+      await release();
+    }
+  }
 
   /**
    * Record a failed materialise. The branch is only latched as permanently
@@ -538,11 +577,13 @@ export function makeFeedbackWorktree(
       }
       const rewritten = scope === "." ? base : join(base, scope);
       const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
-      const r = await io.pnpm(["-C", rewritten, ...rest], { cwd: root, env });
+      const r = await runValidationCommand(
+        () => io.pnpm(["-C", rewritten, ...rest], { cwd: root, env }),
+      );
       return { code: r.code, stdout: r.stdout, stderr: r.stderr };
     }
     const head = args[0] === "pnpm" ? args.slice(1) : args;
-    const r = await io.pnpm(head, { cwd: root, env });
+    const r = await runValidationCommand(() => io.pnpm(head, { cwd: root, env }));
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };
 
@@ -560,7 +601,9 @@ export function makeFeedbackWorktree(
       return { code: 1, stdout: "", stderr: `feedback worktree setup failed for ${cwd}; validation blocked` };
     }
     const env = buildFeedbackSubprocessEnv(process.env, resourceBudget);
-    const r = await io.exec("sh", ["-c", command], { cwd: dir, timeoutMs, env });
+    const r = await runValidationCommand(
+      () => io.exec("sh", ["-c", command], { cwd: dir, timeoutMs, env }),
+    );
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };
 

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -275,6 +275,58 @@ describe("makeFeedbackWorktree install (#458)", () => {
   });
 });
 
+describe("host-wide validation gate semaphore (#2487)", () => {
+  it("never runs a reconcile gate command alongside a live worker gate command", async () => {
+    let held = false;
+    const waiters: Array<() => void> = [];
+    const releases: Array<() => void> = [];
+    let active = 0;
+    let maxActive = 0;
+
+    const ioFor = (): FeedbackWorktreeIO => {
+      const base = fakeIO(0, true, 0, { enabled: false }).io;
+      return {
+        ...base,
+        gateLock: async () => {
+          if (held) await new Promise<void>((resolve) => waiters.push(resolve));
+          held = true;
+          return async () => {
+            held = false;
+            waiters.shift()?.();
+          };
+        },
+        pnpm: async (args, opts) => {
+          if (args[0] === "install") return base.pnpm(args, opts);
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise<void>((resolve) => releases.push(resolve));
+          active -= 1;
+          return { code: 0, stdout: "", stderr: "" };
+        },
+      } as FeedbackWorktreeIO;
+    };
+
+    const worker = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", ioFor(), {
+      cacheEnabled: false,
+    });
+    const reconcile = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", ioFor(), {
+      cacheEnabled: false,
+    });
+
+    const first = worker.pnpm(["pnpm", "-C", "afk/wLIVE/1-work", "test"]);
+    while (releases.length < 1) await new Promise<void>((resolve) => setImmediate(resolve));
+    const second = reconcile.pnpm(["pnpm", "-C", "afk/wBOOT/2-reconcile", "test"]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(maxActive).toBe(1);
+    releases.shift()?.();
+    while (releases.length < 1) await new Promise<void>((resolve) => setImmediate(resolve));
+    releases.shift()?.();
+    await Promise.all([first, second]);
+    expect(maxActive).toBe(1);
+  });
+});
+
 // #2339: the post-merge integration gate (#1335) hands the feedback executors
 // the isolated rebase/landing worktree DIR, not a branch name. Treating that dir
 // as a branch made `git fetch origin <dir>` fail, blocked ALL validation

--- a/apps/dev/tests/run-flags.test.ts
+++ b/apps/dev/tests/run-flags.test.ts
@@ -1,4 +1,7 @@
 import { decode } from "@reddb-io/toon";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   decodeLocMemoSnapshot,
@@ -10,8 +13,11 @@ import {
   RunFlagError,
   deriveActivity,
   resolveRunDispatchIdentity,
+  shouldSkipBootSweeps,
+  initBootWorkerState,
 } from "../src/commands/run.js";
 import type { AgentStreamEvent } from "../src/core/execution.js";
+import { readWorkerState } from "../src/core/worker-state-reader.js";
 
 describe("deriveActivity (native-path monitor stage detection)", () => {
   const tool = (name: string, formattedArgs: string): AgentStreamEvent => ({
@@ -106,6 +112,34 @@ describe("deriveActivity (native-path monitor stage detection)", () => {
 });
 
 describe("run command TOON state snapshots", () => {
+  it("publishes a renderable boot-phase worker before issue selection or claim (#2487)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-boot-state-"));
+    try {
+      const statePath = await initBootWorkerState({
+        tmpDir: root,
+        workerId: "wBOOT",
+        pid: 4242,
+        runner: "codex",
+        origin: "afk",
+        kind: "afk",
+        nowMs: () => 1_000,
+      });
+
+      const record = readWorkerState(statePath, {
+        nowMs: 1_000,
+        kill: () => true,
+      });
+      expect(record?.state.current).toMatchObject({
+        number: "",
+        phase: "boot",
+        activity: "boot",
+      });
+      expect(record?.renderableLive).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("round-trips the LOC memo through TOON and still reads legacy JSON", () => {
     const memo = { sha: "abc123", added: 12, removed: 3 };
     const toon = encodeLocMemoSnapshot(memo);
@@ -241,6 +275,12 @@ describe("parseRunFlags", () => {
   it("parses --issues into an ordered number list", () => {
     expect(parseRunFlags(["--issues", "3,1,2"]).filter).toEqual({ kind: "issues", numbers: [3, 1, 2] });
     expect(parseRunFlags(["--issues=10, 20"]).filter).toEqual({ kind: "issues", numbers: [10, 20] });
+  });
+
+  it("skips shared boot sweeps for an explicit issue dispatch so claim work starts first (#2487)", () => {
+    expect(shouldSkipBootSweeps(parseRunFlags(["--issues", "2481"]).filter, false)).toBe(true);
+    expect(shouldSkipBootSweeps(parseRunFlags([]).filter, false)).toBe(false);
+    expect(shouldSkipBootSweeps(parseRunFlags([]).filter, true)).toBe(true);
   });
 
   it("throws RunFlagError on an all-invalid --issues value instead of selecting zero (#589)", () => {

--- a/apps/dev/tests/tsconfig-import-hygiene.test.ts
+++ b/apps/dev/tests/tsconfig-import-hygiene.test.ts
@@ -24,7 +24,7 @@ const DEV_UNUSED_IMPORT_DEBT: Record<string, number> = {
   "src/commands/run/flags.ts": 131,
   "src/commands/run/process-deps.ts": 73,
   "src/commands/run/reconcile.ts": 108,
-  "src/commands/run/state.ts": 127,
+  "src/commands/run/state.ts": 124,
   "src/commands/statusline.ts": 1,
   "src/commands/stop.ts": 5,
   "src/core/dashboard.ts": 1,


### PR DESCRIPTION
Automated AFK landing for #2487. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2487

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787391160&installation_model_id=20659&pr_number=2561&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2561&signature=7055442ca3c6d989593c3676dd20b03357e1f870ebdde21f3bf049e55922409f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->