### PR TITLE
feat: #2369 batch claim operations and the atomic hitl_resolve verb

### DIFF
--- a/.changeset/batch-claims-hitl.md
+++ b/.changeset/batch-claims-hitl.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": minor
+---
+
+Castle-MCP E7 (#2369): `claim_status`/`claim_release` accept a batch `issues` array (response keyed per issue, per-issue errors) alongside the single-issue form, and the new `hitl_resolve` verb encodes one human decision on a parked issue atomically — `requeue` (concede claims + one ADR 0122 transition, consuming dangling req:* edges on human override), `retake` (same freeing transition routed to the no-agent landing lane), `park`, or `close` — always posting the rationale as the audit trail. Collapses the 10-round-trip unpark sequences into one call.

--- a/apps/dev/src/core/hitl-resolve.ts
+++ b/apps/dev/src/core/hitl-resolve.ts
@@ -1,0 +1,76 @@
+import { isRefused, planTransition } from "./state-transition.js";
+
+/**
+ * hitl_resolve core (#2369, Spec #2329 E7): one human decision on a parked
+ * issue becomes ONE atomic mutation sequence — claims conceded, labels
+ * transitioned through the ADR 0122 API, rationale posted for the audit trail.
+ * Collapses the 10-round-trip unpark sequences observed in live operation into
+ * a single verb.
+ */
+
+export type HitlDecision = "requeue" | "retake" | "park" | "close";
+
+export interface HitlResolveDeps {
+  comment(issue: number, body: string): Promise<void>;
+  closeIssue(issue: number): Promise<void>;
+  viewLabels(issue: number): Promise<string[]>;
+  editLabels(issue: number, remove: string[], add: string[]): Promise<void>;
+  /** Concede every dangling claim holder; returns the conceded worker ids. */
+  releaseClaims(issue: number): Promise<string[]>;
+}
+
+export interface HitlResolveResult {
+  issue: number;
+  decision: HitlDecision;
+  actions: string[];
+  refused?: string;
+}
+
+export async function resolveHitlDecision(
+  deps: HitlResolveDeps,
+  input: { issue: number; decision: HitlDecision; rationale: string },
+): Promise<HitlResolveResult> {
+  const actions: string[] = [];
+  const rationaleComment =
+    "> *This was recorded by the maintainer's session agent.*\n\n" +
+    `🤖 HITL decision **${input.decision}** on #${input.issue}: ${input.rationale}`;
+  // Every decision leaves the rationale on the issue — the audit trail is not optional.
+  await deps.comment(input.issue, rationaleComment);
+  actions.push("rationale comment posted");
+
+  if (input.decision === "close") {
+    await deps.closeIssue(input.issue);
+    actions.push("issue closed");
+    return { issue: input.issue, decision: input.decision, actions };
+  }
+
+  const labels = await deps.viewLabels(input.issue);
+
+  if (input.decision === "park") {
+    const plan = planTransition(labels, { kind: "human" });
+    if (!isRefused(plan) && (plan.add.length > 0 || plan.remove.length > 0)) {
+      await deps.editLabels(input.issue, [...plan.remove], [...plan.add]);
+      actions.push(`park labels reconciled (+${plan.add.join(",") || "∅"} -${plan.remove.join(",") || "∅"})`);
+    }
+    return { issue: input.issue, decision: input.decision, actions };
+  }
+
+  // requeue / retake both free the issue: concede dangling claims first, then
+  // one atomic transition. A HUMAN decision consumes dangling req:* edges
+  // (promote) instead of refusing the way the automated queue path must.
+  const conceded = await deps.releaseClaims(input.issue);
+  if (conceded.length > 0) actions.push(`claims conceded: ${conceded.join(", ")}`);
+  const hasReqEdges = labels.some((label) => label.startsWith("req:"));
+  const plan = planTransition(labels, { kind: hasReqEdges ? "promote" : "queue" });
+  if (isRefused(plan)) {
+    return { issue: input.issue, decision: input.decision, actions, refused: plan.reason };
+  }
+  await deps.editLabels(input.issue, [...plan.remove], [...plan.add]);
+  actions.push(`labels transitioned (+${plan.add.join(",") || "∅"} -${plan.remove.join(",") || "∅"})`);
+  if (input.decision === "retake") {
+    actions.push(
+      "routed to the no-agent landing lane (ADR 0055): the reconcile dispatcher adopts the existing branch",
+    );
+  }
+  return { issue: input.issue, decision: input.decision, actions };
+}

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -29,6 +29,7 @@ import type {
   CascadeStatusInput,
   CastleMcpDependencies,
   ClaimIssueInput,
+  HitlResolveInput,
   DailyReviewInput,
   EventsSinceInput,
   FleetCreateInput,
@@ -60,6 +61,7 @@ import {
   resolveSupervisorConfig,
 } from "./core/supervisor.js";
 import { listCandidates, listHitlCandidates } from "./runtime/gh.js";
+import { resolveHitlDecision } from "./core/hitl-resolve.js";
 import * as ghx from "./runtime/gh.js";
 import { isLivePid } from "./runtime/kill-tree.js";
 import { spawnSupervisor } from "./runtime/supervisor-spawn.js";
@@ -143,6 +145,7 @@ export interface DevAfkMcpOperations {
   cascadeStatus(input: CascadeStatusInput): Promise<unknown>;
   claimStatus(input: ClaimIssueInput): Promise<unknown>;
   claimRelease(input: ClaimIssueInput): Promise<unknown>;
+  hitlResolve(input: HitlResolveInput): Promise<unknown>;
   mergeArm(input: { pr: number }): Promise<unknown>;
   mergeStatus(): Promise<unknown>;
   mergeRelease(input: { pr: number }): Promise<unknown>;
@@ -661,43 +664,92 @@ export function createDefaultDevAfkMcpOperations(
     async claimStatus(input) {
       const context = await resolveRepoContext(root);
       const gh = { cwd: context.root, repo: context.repo };
-      const records = parseClaimRecords(await ghx.listClaimComments(gh, input.issue));
-      const latest = latestClaimPerWorker(records);
-      const holders = [...latest.values()].filter((record) => record.kind === "claim");
-      return {
-        issue: input.issue,
-        records: records.map((record) => ({
-          comment_id: record.commentId,
-          worker: record.worker,
-          kind: record.kind,
-          runner: record.runner ?? "",
-          created_at: record.createdAt ?? "",
-        })),
-        holders: holders.map((record) => ({
-          worker: record.worker,
-          comment_id: record.commentId,
-          runner: record.runner ?? "",
-          created_at: record.createdAt ?? "",
-        })),
+      const statusOf = async (issue: number) => {
+        const records = parseClaimRecords(await ghx.listClaimComments(gh, issue));
+        const latest = latestClaimPerWorker(records);
+        const holders = [...latest.values()].filter((record) => record.kind === "claim");
+        return {
+          issue,
+          records: records.map((record) => ({
+            comment_id: record.commentId,
+            worker: record.worker,
+            kind: record.kind,
+            runner: record.runner ?? "",
+            created_at: record.createdAt ?? "",
+          })),
+          holders: holders.map((record) => ({
+            worker: record.worker,
+            comment_id: record.commentId,
+            runner: record.runner ?? "",
+            created_at: record.createdAt ?? "",
+          })),
+        };
       };
+      // Single-issue form keeps its historic shape; the batch form (#2369) is
+      // keyed per issue, with per-issue errors instead of one failed call.
+      if (input.issue !== undefined) return statusOf(input.issue);
+      const issues = input.issues ?? [];
+      if (issues.length === 0) return { error: "provide `issue` or a non-empty `issues`" };
+      const byIssue: Record<string, unknown> = {};
+      for (const issue of issues) {
+        try {
+          byIssue[String(issue)] = await statusOf(issue);
+        } catch (error) {
+          byIssue[String(issue)] = { issue, error: error instanceof Error ? error.message : String(error) };
+        }
+      }
+      return { issues: byIssue };
     },
     async claimRelease(input) {
       const context = await resolveRepoContext(root);
       const gh = { cwd: context.root, repo: context.repo };
-      const records = parseClaimRecords(await ghx.listClaimComments(gh, input.issue));
-      const holders = [...latestClaimPerWorker(records).values()].filter(
-        (record) => record.kind === "claim",
-      );
-      const conceded: string[] = [];
-      for (const holder of holders) {
-        await ghx.postClaimComment(
-          gh,
-          input.issue,
-          renderClaimComment({ worker: holder.worker, runner: holder.runner }, "concede", "released"),
+      const releaseOf = async (issue: number) => {
+        const records = parseClaimRecords(await ghx.listClaimComments(gh, issue));
+        const holders = [...latestClaimPerWorker(records).values()].filter(
+          (record) => record.kind === "claim",
         );
-        conceded.push(holder.worker);
+        const conceded: string[] = [];
+        for (const holder of holders) {
+          await ghx.postClaimComment(
+            gh,
+            issue,
+            renderClaimComment({ worker: holder.worker, runner: holder.runner }, "concede", "released"),
+          );
+          conceded.push(holder.worker);
+        }
+        return { issue, conceded };
+      };
+      if (input.issue !== undefined) return releaseOf(input.issue);
+      const issues = input.issues ?? [];
+      if (issues.length === 0) return { error: "provide `issue` or a non-empty `issues`" };
+      const byIssue: Record<string, unknown> = {};
+      for (const issue of issues) {
+        try {
+          byIssue[String(issue)] = await releaseOf(issue);
+        } catch (error) {
+          byIssue[String(issue)] = { issue, error: error instanceof Error ? error.message : String(error) };
+        }
       }
-      return { issue: input.issue, conceded };
+      return { issues: byIssue };
+    },
+    async hitlResolve(input) {
+      const context = await resolveRepoContext(root);
+      const gh = { cwd: context.root, repo: context.repo };
+      return resolveHitlDecision(
+        {
+          comment: (issue, body) => ghx.comment(gh, issue, body),
+          closeIssue: (issue) => ghx.closeIssue(gh, issue),
+          viewLabels: (issue) => ghx.viewLabels(gh, issue),
+          editLabels: async (issue, remove, add) => {
+            await ghx.editLabels(gh, issue, remove, add);
+          },
+          releaseClaims: async (issue) => {
+            const released = (await this.claimRelease({ issue })) as { conceded?: string[] };
+            return released.conceded ?? [];
+          },
+        },
+        input,
+      );
     },
     async waitStart(input) {
       const id = randomUUID();
@@ -1388,6 +1440,8 @@ export function withCachedDeps(
       return result;
     },
     claimStatus: async (input) => {
+      // Batch reads (#2369) bypass the single-issue cache key.
+      if (input.issue === undefined) return deps.claimStatus(input);
       const key = claimStatusKey(input.issue);
       const cached = cache.get(key);
       if (cached !== undefined) return cached;
@@ -1404,7 +1458,9 @@ export function withCachedDeps(
       return result;
     },
     claimRelease: async (input) => {
-      cache.invalidate(claimStatusKey(input.issue));
+      for (const issue of input.issues ?? (input.issue !== undefined ? [input.issue] : [])) {
+        cache.invalidate(claimStatusKey(issue));
+      }
       return deps.claimRelease(input);
     },
     landBranch: async (input) => {
@@ -1561,6 +1617,7 @@ export function createCastleMcpDependencies(
     cascadeStatus: (input) => operations.cascadeStatus(input),
     claimStatus: (input) => operations.claimStatus(input),
     claimRelease: (input) => operations.claimRelease(input),
+    hitlResolve: (input) => operations.hitlResolve(input),
     mergeArm: (input) => operations.mergeArm(input),
     mergeStatus: () => operations.mergeStatus(),
     mergeRelease: (input) => operations.mergeRelease(input),

--- a/apps/dev/tests/hitl-resolve.test.ts
+++ b/apps/dev/tests/hitl-resolve.test.ts
@@ -1,0 +1,95 @@
+// hitl-resolve.test.ts — the atomic HITL decision verb (#2369, Spec #2329 E7).
+// One human decision on a parked issue = one mutation sequence: rationale
+// comment always, claims conceded, labels transitioned through the ADR 0122
+// API. Each decision is pinned against injected fakes.
+
+import { describe, expect, it, vi } from "vitest";
+import { resolveHitlDecision, type HitlResolveDeps } from "../src/core/hitl-resolve.js";
+
+function makeDeps(labels: string[], conceded: string[] = []): HitlResolveDeps & {
+  comment: ReturnType<typeof vi.fn>;
+  closeIssue: ReturnType<typeof vi.fn>;
+  editLabels: ReturnType<typeof vi.fn>;
+  releaseClaims: ReturnType<typeof vi.fn>;
+} {
+  return {
+    comment: vi.fn(async () => undefined),
+    closeIssue: vi.fn(async () => undefined),
+    viewLabels: vi.fn(async () => labels),
+    editLabels: vi.fn(async () => undefined),
+    releaseClaims: vi.fn(async () => conceded),
+  };
+}
+
+describe("hitl_resolve decisions (#2369)", () => {
+  it("requeue: concedes claims, strips park labels, adds ready-for-agent — one edit", async () => {
+    const deps = makeDeps(["ready-for-human", "blocked:crashed", "running"], ["local:wDEAD"]);
+
+    const result = await resolveHitlDecision(deps, {
+      issue: 2404,
+      decision: "requeue",
+      rationale: "crash was environmental; safe to delegate again",
+    });
+
+    expect(deps.comment).toHaveBeenCalledTimes(1);
+    expect(String(deps.comment.mock.calls[0]![1])).toContain("HITL decision **requeue**");
+    expect(deps.releaseClaims).toHaveBeenCalledWith(2404);
+    expect(deps.editLabels).toHaveBeenCalledTimes(1);
+    const [, remove, add] = deps.editLabels.mock.calls[0]!;
+    expect(new Set(remove as string[])).toEqual(new Set(["ready-for-human", "blocked:crashed", "running"]));
+    expect(add).toEqual(["ready-for-agent"]);
+    expect(result.actions.some((a) => a.includes("claims conceded: local:wDEAD"))).toBe(true);
+    expect(result.refused).toBeUndefined();
+  });
+
+  it("requeue over dangling req:* edges promotes (human override) instead of refusing", async () => {
+    const deps = makeDeps(["ready-for-human", "req:2526"]);
+
+    await resolveHitlDecision(deps, { issue: 7, decision: "requeue", rationale: "deps shipped" });
+
+    const [, remove, add] = deps.editLabels.mock.calls[0]!;
+    expect(remove).toContain("req:2526");
+    expect(add).toEqual(["ready-for-agent"]);
+  });
+
+  it("retake: same freeing transition, routed to the no-agent landing lane", async () => {
+    const deps = makeDeps(["ready-for-human", "blocked:validation"]);
+
+    const result = await resolveHitlDecision(deps, {
+      issue: 2432,
+      decision: "retake",
+      rationale: "branch is complete; validate and land without the agent",
+    });
+
+    expect(deps.editLabels).toHaveBeenCalledTimes(1);
+    expect(result.actions.some((a) => a.includes("no-agent landing lane"))).toBe(true);
+  });
+
+  it("park: keeps ready-for-human, records why, no claim mutation", async () => {
+    const deps = makeDeps(["ready-for-agent", "blocked:crashed"]);
+
+    const result = await resolveHitlDecision(deps, {
+      issue: 9,
+      decision: "park",
+      rationale: "needs a design call before another attempt",
+    });
+
+    expect(deps.releaseClaims).not.toHaveBeenCalled();
+    expect(deps.closeIssue).not.toHaveBeenCalled();
+    const [, remove, add] = deps.editLabels.mock.calls[0]!;
+    expect(add).toContain("ready-for-human");
+    expect(remove).toContain("ready-for-agent");
+    expect(result.actions.some((a) => a.includes("rationale comment posted"))).toBe(true);
+  });
+
+  it("close: closes with the rationale on record and touches nothing else", async () => {
+    const deps = makeDeps(["ready-for-human"]);
+
+    await resolveHitlDecision(deps, { issue: 10, decision: "close", rationale: "superseded by #2523" });
+
+    expect(deps.closeIssue).toHaveBeenCalledWith(10);
+    expect(deps.comment).toHaveBeenCalledTimes(1);
+    expect(deps.editLabels).not.toHaveBeenCalled();
+    expect(deps.releaseClaims).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -687,6 +687,7 @@ describe("buildMcpLandingFireHook — lifecycle hook wiring", () => {
 
 function fakeOperations(): DevAfkMcpOperations {
   return {
+    hitlResolve: vi.fn(async (input) => ({ resolved: input })),
     mergeArm: vi.fn(async (input) => ({ armed: input })),
     mergeStatus: vi.fn(async () => ({ prs: [] })),
     mergeRelease: vi.fn(async (input) => ({ released: input })),

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -86,6 +86,7 @@ function deps(): CastleMcpDependencies {
     mergeArm: vi.fn(async (input) => ({ armed: input })),
     mergeStatus: vi.fn(async () => ({ prs: [] })),
     mergeRelease: vi.fn(async (input) => ({ released: input })),
+    hitlResolve: vi.fn(async (input) => ({ resolved: input })),
     claimRelease: vi.fn(async (input) => ({
       issue: input.issue,
       conceded: ["w80UR"],
@@ -151,6 +152,7 @@ describe("castle MCP tools", () => {
       "merge_arm",
       "merge_status",
       "merge_release",
+      "hitl_resolve",
       "worktree_list",
       "worktree_remove",
       "wait_start",

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { createClaimTools, type ClaimDependencies } from "./mcp/claim.js";
 import { createMergeTools, type MergeDependencies } from "./mcp/merge.js";
+import { createHitlTools, type HitlDependencies } from "./mcp/hitl.js";
 import { createFleetTools, type FleetDependencies } from "./mcp/fleet.js";
 import { createGateTools, type GateDependencies } from "./mcp/gate.js";
 import { createHygieneTools, type HygieneDependencies } from "./mcp/hygiene.js";
@@ -53,6 +54,7 @@ export type { GateRunInput } from "./mcp/gate.js";
 export type { LandBranchInput, CascadeStatusInput } from "./mcp/landing.js";
 export type { ClaimIssueInput } from "./mcp/claim.js";
 export type { MergeArmInput } from "./mcp/merge.js";
+export type { HitlResolveInput, HitlDecision } from "./mcp/hitl.js";
 export type { WorktreeRemoveInput } from "./mcp/worktree.js";
 export type { WaitStartInput, WaitStatusInput } from "./mcp/wait.js";
 export type {
@@ -78,6 +80,7 @@ export interface CastleMcpDependencies
     LandingDependencies,
     ClaimDependencies,
     MergeDependencies,
+    HitlDependencies,
     WorktreeDependencies,
     WaitDependencies,
     ReviewDependencies,
@@ -107,6 +110,7 @@ export function createCastleMcpTools(
     ...createLandingTools(deps),
     ...createClaimTools(deps),
     ...createMergeTools(deps),
+    ...createHitlTools(deps),
     ...createWorktreeTools(deps),
     ...createWaitTools(deps),
     ...createReviewTools(deps),

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -214,15 +214,17 @@ const SURFACE: ReadonlyArray<{
     name: "claim_status",
     title: "Read AFK claim",
     description:
-      "Return the parsed claim marker records for one issue and the worker currently holding it.",
-    schema: ["issue"],
+      "Return the parsed claim marker records and current holder for one issue (`issue`) " +
+      "or a batch (`issues`), keyed per issue.",
+    schema: ["issue", "issues"],
   },
   {
     name: "claim_release",
     title: "Release AFK claim",
     description:
-      "MUTATING: post a concede marker for every un-conceded claim holder so the issue becomes claimable again.",
-    schema: ["issue"],
+      "MUTATING: post a concede marker for every un-conceded claim holder so the issue (`issue`) " +
+      "or each issue in a batch (`issues`) becomes claimable again.",
+    schema: ["issue", "issues"],
   },
   {
     name: "merge_arm",
@@ -247,6 +249,16 @@ const SURFACE: ReadonlyArray<{
     description:
       "MUTATING: stop driver ownership of one PR. The record is kept as released for observability.",
     schema: ["pr"],
+  },
+  {
+    name: "hitl_resolve",
+    title: "Resolve parked issue with a human decision",
+    description:
+      "MUTATING: encode one human decision on a parked issue atomically — " +
+      "requeue (concede dangling claims, strip park labels, ready-for-agent), " +
+      "retake (route to the no-agent landing lane), park (keep ready-for-human, record why), " +
+      "or close. The rationale is posted as an issue comment for the audit trail.",
+    schema: ["issue", "decision", "rationale"],
   },
   {
     name: "worktree_list",

--- a/packages/red-castle/src/mcp/claim.ts
+++ b/packages/red-castle/src/mcp/claim.ts
@@ -2,7 +2,10 @@ import { z } from "zod/v3";
 import type { CastleMcpTool } from "./tool.js";
 
 export interface ClaimIssueInput {
-  issue: number;
+  /** Single-issue form (back-compat). Exactly one of `issue`/`issues` is set. */
+  issue?: number;
+  /** Batch form (#2369): one call, response keyed per issue. */
+  issues?: number[];
 }
 
 export interface ClaimDependencies {
@@ -16,17 +19,25 @@ export function createClaimTools(deps: ClaimDependencies): CastleMcpTool[] {
       name: "claim_status",
       title: "Read AFK claim",
       description:
-        "Return the parsed claim marker records for one issue and the worker currently holding it.",
-      inputSchema: { issue: z.number().int().positive() },
-      invoke: ({ issue }) => deps.claimStatus({ issue: issue as number }),
+        "Return the parsed claim marker records and current holder for one issue (`issue`) " +
+        "or a batch (`issues`), keyed per issue.",
+      inputSchema: {
+        issue: z.number().int().positive().optional(),
+        issues: z.array(z.number().int().positive()).min(1).optional(),
+      },
+      invoke: (input) => deps.claimStatus(input as ClaimIssueInput),
     },
     {
       name: "claim_release",
       title: "Release AFK claim",
       description:
-        "MUTATING: post a concede marker for every un-conceded claim holder so the issue becomes claimable again.",
-      inputSchema: { issue: z.number().int().positive() },
-      invoke: ({ issue }) => deps.claimRelease({ issue: issue as number }),
+        "MUTATING: post a concede marker for every un-conceded claim holder so the issue (`issue`) " +
+        "or each issue in a batch (`issues`) becomes claimable again.",
+      inputSchema: {
+        issue: z.number().int().positive().optional(),
+        issues: z.array(z.number().int().positive()).min(1).optional(),
+      },
+      invoke: (input) => deps.claimRelease(input as ClaimIssueInput),
     },
   ];
 }

--- a/packages/red-castle/src/mcp/hitl.ts
+++ b/packages/red-castle/src/mcp/hitl.ts
@@ -1,0 +1,36 @@
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+/** The closed decision vocabulary for one human call on a parked issue. */
+export const HITL_DECISIONS = ["requeue", "retake", "park", "close"] as const;
+export type HitlDecision = (typeof HITL_DECISIONS)[number];
+
+export interface HitlResolveInput {
+  issue: number;
+  decision: HitlDecision;
+  rationale: string;
+}
+
+export interface HitlDependencies {
+  hitlResolve(input: HitlResolveInput): Promise<unknown>;
+}
+
+export function createHitlTools(deps: HitlDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "hitl_resolve",
+      title: "Resolve parked issue with a human decision",
+      description:
+        "MUTATING: encode one human decision on a parked issue atomically — " +
+        "requeue (concede dangling claims, strip park labels, ready-for-agent), " +
+        "retake (route to the no-agent landing lane), park (keep ready-for-human, record why), " +
+        "or close. The rationale is posted as an issue comment for the audit trail.",
+      inputSchema: {
+        issue: z.number().int().positive(),
+        decision: z.enum(HITL_DECISIONS),
+        rationale: z.string().min(1),
+      },
+      invoke: (input) => deps.hitlResolve(input as unknown as HitlResolveInput),
+    },
+  ];
+}

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -110,8 +110,9 @@ never tracks the base branch as red (#2380).
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `claim_status` | read | Parsed claim markers for one issue and the worker holding it. |
-| `claim_release` | mutating | Concede every un-conceded claim so the issue is claimable again. |
+| `claim_status` | read | Parsed claim markers for one issue (`issue`) or a batch (`issues`), keyed per issue. |
+| `claim_release` | mutating | Concede every un-conceded claim so the issue — or each issue in a batch — is claimable again. |
+| `hitl_resolve` | mutating | One atomic human decision on a parked issue: `requeue`, `retake`, `park`, or `close`, with the rationale posted for the audit trail. |
 
 `claim_release` is the cure for a ghost claim — an issue that instantly reports
 `1/1 100%` with no attempt. Release it through the tool, never by flipping

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -110,8 +110,9 @@ never tracks the base branch as red (#2380).
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `claim_status` | read | Parsed claim markers for one issue and the worker holding it. |
-| `claim_release` | mutating | Concede every un-conceded claim so the issue is claimable again. |
+| `claim_status` | read | Parsed claim markers for one issue (`issue`) or a batch (`issues`), keyed per issue. |
+| `claim_release` | mutating | Concede every un-conceded claim so the issue — or each issue in a batch — is claimable again. |
+| `hitl_resolve` | mutating | One atomic human decision on a parked issue: `requeue`, `retake`, `park`, or `close`, with the rationale posted for the audit trail. |
 
 `claim_release` is the cure for a ghost claim — an issue that instantly reports
 `1/1 100%` with no attempt. Release it through the tool, never by flipping


### PR DESCRIPTION
Closes #2369 — Spec #2329 E7.

## What

- `claim_status` / `claim_release` accept `issues: number[]` alongside the single-issue form — batch responses keyed per issue with per-issue errors; the read cache serves single-issue keys and bypasses batches; release invalidates every issue in the batch.
- New `hitl_resolve(issue, decision, rationale)` in its own castle MCP domain module (H1 split), `decision` a closed zod enum (`requeue`/`retake`/`park`/`close`), `MUTATING:` description contract, frozen into the tool-surface test.
- Core `resolveHitlDecision` (dev, injected deps): rationale comment always (audit trail), `close` → close; `park` → ADR 0122 `human` transition; `requeue`/`retake` → concede dangling claims via the claim-release core + ONE atomic transition — a human decision consumes dangling `req:*` edges (promote) instead of refusing like the automated path; `retake` notes the ADR 0055 no-agent landing routing.
- No parallel GitHub mutation path: reuses `ghx.comment/viewLabels/editLabels/closeIssue` and the existing claim cores.

## Tests

5 decision tests against injected fakes (requeue with claims+park labels → one edit; promote-over-req on human override; retake routing; park keeps ready-for-human; close touches nothing else) + castle tool-surface/mcp-server updates + adapter suite green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787394004&installation_model_id=20659&pr_number=2563&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2563&signature=14bfdaf7ee19c10e159224ee060500770191b10497b09a59b2add5d38353f958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->