### PR TITLE
fix: #2545 launch runner cascade — operator env beats stale profile; register orphan profiles on create

### DIFF
--- a/.changeset/launch-runner-cascade.md
+++ b/.changeset/launch-runner-cascade.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Fleet launch runner cascade (#2545): a fresh `fleet N` launch honors the operator's `RED_AFK_RUNNER` env over the stale registered profile (flag > env > profile — the profile no longer shadows the env as a pseudo-flag), an invalid explicit runner errors loudly instead of silently resuming the old one, and `fleet_create` against a live-but-unregistered supervisor registers the orphan profile so `fleet_edit`/`fleet_status` work instead of the create-says-running/edit-says-not-exists trap.

--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -9,6 +9,7 @@ import {
   readCastleLaneRecords,
   readFleetProfile,
   readHostCapabilityProfile,
+  runnerFromExplicitEnv,
   resolveHostCapabilities,
   upsertFleetProfile,
   type CastleLaneRecord,
@@ -164,6 +165,21 @@ function parseFleetArgs(args: readonly string[]): {
     force,
     passthrough,
   };
+}
+
+/**
+ * Launch runner cascade (#2545): explicit --runner flag > the operator's
+ * RED_AFK_RUNNER env AT THIS LAUNCH > the registered profile. The profile must
+ * never shadow the env the operator just set — that is exactly the "fresh
+ * relaunch keeps the stale runner" trap: kill fleet, relaunch with
+ * RED_AFK_RUNNER=claude, supervisor resumes codex from fleets.toonl.
+ */
+export function resolveLaunchRunnerPin(
+  flag: string | undefined,
+  env: NodeJS.ProcessEnv,
+  profileRunner: string | undefined,
+): string | undefined {
+  return flag ?? runnerFromExplicitEnv(env.RED_AFK_RUNNER) ?? profileRunner;
 }
 
 export async function writeResizeRequest(
@@ -687,7 +703,7 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
   }
 
   const detection = detectRunner({
-    flag: parsed.runnerFlag ?? parseRunnerFlag(args) ?? profile?.runner,
+    flag: resolveLaunchRunnerPin(parsed.runnerFlag ?? parseRunnerFlag(args), process.env, profile?.runner),
     processTree: callerProcessTreeNative(),
     scriptPath: process.argv[1],
   });

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -927,7 +927,15 @@ async function createFleet(root: string, input: FleetCreateInput) {
     if (existing) {
       throw new Error(`fleet ${JSON.stringify(input.name)} already exists`);
     }
-    throw new Error(`fleet ${JSON.stringify(paths.fleet)} is already running`);
+    // A live supervisor with NO registered profile is the create/edit desync
+    // trap (#2545): create says "already running", edit says "does not exist",
+    // and there is no MCP-only way out. Register the orphan profile so
+    // fleet_edit/fleet_status work, then refuse the duplicate launch.
+    await upsertFleetProfile(path, profileForCreate(input));
+    throw new Error(
+      `fleet ${JSON.stringify(paths.fleet)} is already running; its missing registry profile ` +
+        `was registered from this request — use fleet_edit/fleet_status to operate it`,
+    );
   }
 
   const profile =

--- a/apps/dev/tests/fleet-launch-runner.test.ts
+++ b/apps/dev/tests/fleet-launch-runner.test.ts
@@ -1,0 +1,34 @@
+// fleet-launch-runner.test.ts — the launch runner cascade (#2545).
+//
+// A fresh `fleet N` launch must honor, in order: the explicit --runner flag,
+// the operator's RED_AFK_RUNNER env AT THIS LAUNCH, and only then the
+// registered profile. The 2026-07-23 trap: kill the codex fleet, relaunch with
+// RED_AFK_RUNNER=claude, and the supervisor resumed codex from the stale
+// fleets.toonl profile because the profile was fed to detectRunner as the flag.
+
+import { describe, expect, it } from "vitest";
+import { resolveLaunchRunnerPin } from "../src/commands/fleet.js";
+
+describe("resolveLaunchRunnerPin (#2545)", () => {
+  it("explicit flag wins over everything", () => {
+    expect(resolveLaunchRunnerPin("codex", { RED_AFK_RUNNER: "claude" }, "opencode")).toBe("codex");
+  });
+
+  it("the operator's RED_AFK_RUNNER env beats the stale registered profile", () => {
+    expect(resolveLaunchRunnerPin(undefined, { RED_AFK_RUNNER: "claude" }, "codex")).toBe("claude");
+  });
+
+  it("the registered profile applies when neither flag nor env pin a runner", () => {
+    expect(resolveLaunchRunnerPin(undefined, {}, "codex")).toBe("codex");
+  });
+
+  it("an invalid RED_AFK_RUNNER value errors loudly instead of silently resuming the profile", () => {
+    expect(() => resolveLaunchRunnerPin(undefined, { RED_AFK_RUNNER: "gpt" }, "codex")).toThrow(
+      "unsupported runner",
+    );
+  });
+
+  it("nothing pinned → undefined (ambient detection decides)", () => {
+    expect(resolveLaunchRunnerPin(undefined, {}, undefined)).toBeUndefined();
+  });
+});

--- a/packages/red-castle/src/engine/runner-detection.ts
+++ b/packages/red-castle/src/engine/runner-detection.ts
@@ -15,7 +15,7 @@ function envHasAny(env: NodeJS.ProcessEnv, keys: string[]): string | undefined {
   return keys.find((key) => env[key] !== undefined && env[key] !== "");
 }
 
-function runnerFromExplicitEnv(value: string | undefined): Runner | undefined {
+export function runnerFromExplicitEnv(value: string | undefined): Runner | undefined {
   if (value === undefined || value === "") return undefined;
   if (!isRunner(value)) throw new Error(`unsupported runner: ${value}`);
   return value;


### PR DESCRIPTION
Closes #2545.

## What

- **Launch cascade** (`resolveLaunchRunnerPin`, pure + tested): explicit `--runner` flag > the operator's `RED_AFK_RUNNER` env AT THIS LAUNCH > registered profile. Root cause of the stickiness: the profile's runner was fed to `detectRunner` as the FLAG, shadowing the env the operator just set — kill fleet, relaunch with `RED_AFK_RUNNER=claude`, supervisor resumed codex from `fleets.toonl`.
- An invalid explicit runner value errors loudly instead of silently resuming the stale one.
- **create/edit desync**: `fleet_create` against a live-but-unregistered supervisor now registers the orphan profile before refusing the duplicate launch, so `fleet_edit`/`fleet_status` work — no more MCP dead-end (create: "already running" / edit: "does not exist").
- The live mid-run runner switch (directive + `configureRunner`, #2065) was already correct and is untouched.

## Tests

5 cascade tests (flag>env>profile, loud invalid-env error, ambient fallthrough) + adapter suite green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787401695&installation_model_id=20659&pr_number=2569&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2569&signature=91abbb5bad893a6d37733c46454c7448b93a558799e28c192b93e29be410edf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->