### PR TITLE
fix: #2536 codex runner: sandbox setup crashes on git-config --global lock race (no-sentinel, zero diagnostic); compounding fleet CLI/MCP state-desync issues

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -51,6 +51,43 @@ export interface FleetStopOptions {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const FLEET_USAGE = `Usage: red-skills-dev fleet [target] [options]
+       red-skills-dev fleet status [--fleet <name>]
+       red-skills-dev fleet stop [--fleet <name>] [--force]
+       red-skills-dev fleet logs [--fleet <name>]
+
+Options:
+  --runner <runner>
+  --request <text>, -r <text>
+  --fleet <name>
+  --budget-usd <amount>
+  --shrink-mode <hard-kill|drain-then-retire>
+  --help, -h
+`;
+
+const WORKER_PASSTHROUGH_FLAGS = new Set([
+  "--spec",
+  "--issues",
+  "--selector",
+  "-n",
+  "--once",
+  "--model",
+  "--effort",
+  "--alternate",
+  "--fallback-runner",
+  "--boot-only",
+  "--reconcile-issue",
+  "--origin",
+  "--kind",
+  "--lane",
+  "--pre-pr",
+  "--local-merge",
+  "--yolo",
+  "--verify",
+  "--go-verify-retries",
+  "--run-mode",
+]);
+
 function parsePositiveNumber(raw: string | undefined, flag: string): number {
   if (raw === undefined) throw new Error(`${flag} requires a value`);
   const n = Number(raw);
@@ -149,6 +186,12 @@ function parseFleetArgs(args: readonly string[]): {
     if (/^[0-9]+$/.test(arg) && target === undefined) {
       target = Number(arg);
       continue;
+    }
+    if (arg.startsWith("-")) {
+      const flag = arg.split("=", 1)[0]!;
+      if (!WORKER_PASSTHROUGH_FLAGS.has(flag)) {
+        throw new Error(`unknown fleet flag: ${flag}`);
+      }
     }
     passthrough.push(arg);
   }
@@ -769,6 +812,10 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
 }
 
 export async function fleetCommand(args: string[], cwd = process.cwd()): Promise<number> {
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(FLEET_USAGE);
+    return 0;
+  }
   if (args[0] === "logs") {
     try {
       await logsFleet(args.slice(1), cwd);
@@ -779,8 +826,8 @@ export async function fleetCommand(args: string[], cwd = process.cwd()): Promise
       return 1;
     }
   }
-  const parsed = parseFleetArgs(args);
   try {
+    const parsed = parseFleetArgs(args);
     if (parsed.status) {
       await statusFleet(cwd, process.stdout, parsed.fleet);
     } else if (parsed.stop) {

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -374,6 +374,7 @@ export function buildProcessDeps(
     fs: {
       ensureAttemptDir: (dir) => fsx.ensureDir(dir),
       writeHandoff: (path, content) => fsx.writeHandoff(path, content),
+      readText: (path) => fsx.readText(path),
       // $ITER_DIR/validation.jsonl — the machine-readable feedback sidecar the
       // Memory bridge consumes (SKILL.md §Validation Sidecar).
       writeValidationSidecar: (path, lines) => fsx.writeValidationSidecar(path, lines),

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -139,6 +139,27 @@ import type { ProcessIssueDeps, ProcessIssueInput, ProcessIssueResult, WorkerBas
 import { baseResolutionStatePatch, formatBaseResolution, isMergeConflictRetry, markTerminalState, recoveryOrdinalFor, remoteTrackingBaseRef, resolveSpawnTier } from "./types.js";
 import { MECHANICAL_BLOCKER_KINDS, appendAfkGateCorrectionHandoff, appendGoVerifyRetryHandoff, blockedLabelsIn, editIssueLifecycleLabels, formatNoSourceChangeWarning, hasLikelySourceChanges, parseFeedbackClass, refuseNoSandboxForUntrustedAuthor, resolveGoVerifyRetries, resolveStallConvergenceBudget, resolveUntrustedAuthorSandbox, scoutCapturedDone, scoutReportFrom } from "./recovery.js";
 import { abortAfterClaim, claimLost, emitBackpressureReview, emitDone, handoffForManualLanding, handoffForReview, hookContext, isRunnerRecoverableOutcome, mergeFailed, ciBlocked, prLandingBlocked, trunkDivergedBlocked, onErrorContext, parseHookEnv, postAttemptContext, recordAttemptBestEffort, releaseOwnedClaim, runCascadeRebase, runCloseCascade, runnerRecoverable, terminalFailure, writeValidationSidecar, type StageCommon } from "./terminal.js";
+
+function setupFailureExcerpt(log: string | null | undefined): string | undefined {
+  const lines = (log ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("[heartbeat]"));
+  let setupFailure = -1;
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]!;
+    if (
+      /command failed in sandbox/i.test(line) ||
+      /(?:sandbox|bootstrap|setup).*(?:error|fail)/i.test(line)
+    ) {
+      setupFailure = index;
+      break;
+    }
+  }
+  if (setupFailure < 0) return undefined;
+  return lines.slice(setupFailure, setupFailure + 4).join("\n");
+}
+
 export async function processIssue(
   deps: ProcessIssueDeps,
   input: ProcessIssueInput,
@@ -689,9 +710,16 @@ export async function processIssue(
         (!deps.lookups.branchPresent || (await deps.lookups.branchPresent(workerBranch)));
       if (!branchHasWork) {
         await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "no-sentinel", current.attempt));
+        const attemptLog = await deps.fs
+          .readText?.(`${input.attemptDir}/afk.log`)
+          .catch(() => null);
+        const diagnostic =
+          setupFailureExcerpt(attemptLog) ??
+          (run.stdout ? run.stdout.split("\n").slice(-1)[0] || undefined : undefined) ??
+          "(no captured stdout)";
         return await terminalFailure(common, "no-sentinel", "no-sentinel", {
           notes: "_(no Notes appended; inner agent exited without a sentinel and the branch carries no work)_",
-          log: run.stdout ? run.stdout.split("\n").slice(-1)[0] || "(no captured stdout)" : "(no captured stdout)",
+          log: diagnostic,
         });
       }
       salvaged = true;

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -146,6 +146,7 @@ export interface ProcessClaimLock {
 export interface ProcessFs {
   ensureAttemptDir(dir: string): Promise<void>;
   writeHandoff(path: string, content: string): Promise<void>;
+  readText?(path: string): Promise<string | null>;
   writeValidationSidecar?(path: string, lines: string[]): Promise<void>;
   completionSweep(issue: number): Promise<string[]>;
 }

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -33,7 +33,7 @@ vi.mock("../src/runtime/supervisor-watchdog-spawn.js", () => ({
   spawnSupervisorWatchdog: vi.fn(async () => 43211),
 }));
 
-import { launchFleet, logsFleet, statusFleet, stopFleet } from "../src/commands/fleet.js";
+import { fleetCommand, launchFleet, logsFleet, statusFleet, stopFleet } from "../src/commands/fleet.js";
 import { isLivePid } from "../src/runtime/kill-tree.js";
 import { spawnSupervisor } from "../src/runtime/supervisor-spawn.js";
 import { spawnSupervisorWatchdog } from "../src/runtime/supervisor-watchdog-spawn.js";
@@ -81,6 +81,43 @@ describe("fleet command stale supervisor state", () => {
     vi.mocked(spawnSupervisor).mockResolvedValue(43210);
     vi.mocked(spawnSupervisorWatchdog).mockClear();
     vi.mocked(spawnSupervisorWatchdog).mockResolvedValue(43211);
+  });
+
+  it("prints help without spawning a supervisor (#2536)", async () => {
+    const root = scratch();
+    const writes: string[] = [];
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    try {
+      const code = await fleetCommand(["--help"], root);
+
+      expect(code).toBe(0);
+      expect(writes.join("")).toContain("Usage: red-skills-dev fleet");
+      expect(spawnSupervisor).not.toHaveBeenCalled();
+    } finally {
+      stdout.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an unknown flag before spawning a supervisor (#2536)", async () => {
+    const root = scratch();
+    const errors: string[] = [];
+    const stderr = vi.spyOn(console, "error").mockImplementation((message) => {
+      errors.push(String(message));
+    });
+    try {
+      const code = await fleetCommand(["2", "--name", "drain"], root);
+
+      expect(code).not.toBe(0);
+      expect(errors.join("\n")).toContain("--name");
+      expect(spawnSupervisor).not.toHaveBeenCalled();
+    } finally {
+      stderr.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("launchFleet removes dead supervisor pid/state/log files before spawning", async () => {

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -755,6 +755,34 @@ describe("processIssue — BLOCKED", () => {
 
 
 describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
+  it("surfaces a sandbox setup failure from afk.log when runner stdout is empty (#2536)", async () => {
+    const { deps, input, trace } = harness({ outcome: "no-sentinel", changedFiles: [] });
+    Object.assign(deps.fs, {
+      readText: async () =>
+        [
+          "[heartbeat] iteration started for #9",
+          "Setting up sandbox",
+          'Command failed in sandbox (git config --global user.name "Worker"): Command failed (exit 255)',
+          "error: could not lock config file [REDACTED_HOME]/.gitconfig: File exists",
+        ].join("\n"),
+    });
+    deps.runAgent = async (runInput) => ({
+      outcome: "no-sentinel",
+      branch: runInput.branch,
+      commits: [],
+      stdout: "",
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("no-sentinel");
+    expect(parseCurrentBlocker(trace.bodyEdits.at(-1)!.body)).toMatchObject({
+      kind: "runner",
+      summary: expect.stringContaining("Command failed in sandbox"),
+    });
+    expect(trace.envelopeBodies.at(-1)).toContain("Command failed in sandbox");
+  });
+
   it("worker crash before Landing never snapshots or integrates the primary checkout", async () => {
     // No work on the branch: a real crash while the operator may have unrelated
     // dirty primary WIP. The attempt must terminate before every Landing git/


### PR DESCRIPTION
Automated AFK landing for #2536. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2536

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787403120&installation_model_id=20659&pr_number=2571&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2571&signature=2d1a453714385fd79a0adccc87ab7020d981f59f7f1a39529edacedcf8c04271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->