### PR TITLE
fix: #2568 drop per-worker fleet-attribution tokens from the statusline

### DIFF
--- a/.changeset/drop-flt-attribution.md
+++ b/.changeset/drop-flt-attribution.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Statusline drops the per-worker fleet-attribution tokens (#2568): no more `flt=unattributed` / `flt=<name>` in worker lines — maintainer-confirmed display noise. Fleet ownership stays available in `fleet_status`/`worker_status`; the fleet chip header is unchanged.

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -69,12 +69,11 @@ const RESET = "\x1b[0m";
 const BRANCH_MAX = 28;
 const WORKER_GUTTER = "  ";
 
-type WorkerColumn = "workerId" | "run" | "org" | "fleet" | "iss" | "phase" | "elapsed" | "loc" | "tks" | "tls" | "rsn" | "txt";
+type WorkerColumn = "workerId" | "run" | "org" | "iss" | "phase" | "elapsed" | "loc" | "tks" | "tls" | "rsn" | "txt";
 const WORKER_COLUMNS: readonly WorkerColumn[] = [
   "workerId",
   "run",
   "org",
-  "fleet",
   "iss",
   "phase",
   "elapsed",
@@ -278,7 +277,6 @@ function workerCells(worker: CompactWorker, now: number): WorkerCells {
     workerId: f.workerId,
     run: `run=${runVal}`,
     org: `org=${landing ? "landing" : f.origin || "afk"}`,
-    fleet: `flt=${worker.state.fleet || "unattributed"}`,
     iss: f.issue === null ? "" : `iss=${String(f.issue)}`,
     phase: f.issue === null ? "" : progressCell(f.phase, f.activity),
     elapsed: f.elapsed,
@@ -327,7 +325,7 @@ function renderWorkerLines(
 
 /** The TERSE per-worker line for the Claude Code statusline (issue #1175, #1176):
  *
- *   <wID>  run=<runner> <model> <effort>  org=<afk|go>  flt=<name|unattributed>  iss=<issue-number>  <phase>  <elapsed>  loc=+A -R  tks=<h>  tls=<t> rsn=<r> txt=<x>
+ *   <wID>  run=<runner> <model> <effort>  org=<afk|go>  iss=<issue-number>  <phase>  <elapsed>  loc=+A -R  tks=<h>  tls=<t> rsn=<r> txt=<x>
  *
  * A visual sibling of line 1: the `wID` is BOLD + red, and every k=v token
  * (`run=`/`iss=`/`loc=`/`tks=` and each vital `tls=`/`rsn=`/`txt=`) reuses the
@@ -367,10 +365,9 @@ export function renderWorkerLine(worker: CompactWorker, now: number, preset: Sta
   // worker, so default the display to afk.
   const landing = LANDING_PHASES.has(f.phase);
   parts.push(kv("org", landing ? "landing" : f.origin || "afk"));
-  // flt=<name|unattributed> — ownership is independent of origin: targeted,
-  // `/go`, and secondary-supervisor Workers can share an origin while belonging
-  // to different fleets (or no fleet at all).
-  parts.push(kv("flt", worker.state.fleet || "unattributed"));
+  // Per-worker fleet attribution is deliberately NOT rendered (#2568): which
+  // fleet owns a worker stays available in fleet_status/worker_status; on the
+  // statusline it was noise.
   // iss=<issue-number> from current.number (both /afk and /go lanes); the
   // <phase·activity> cell follows bare and the legacy standalone #<n> token is
   // dropped.

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -247,13 +247,13 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
     expect(stripAnsi(renderWorkerLine(afk, NOW))).toContain("org=afk");
   });
 
-  it("shows named-fleet attribution and marks standalone Workers as unattributed", () => {
+  it("renders no per-worker fleet-attribution token (#2568 — display noise; fleet_status keeps the data)", () => {
     const attributed = worker({
       state: { ...worker().state, fleet: "alpha" },
     });
 
-    expect(stripAnsi(renderWorkerLine(attributed, NOW))).toContain("flt=alpha");
-    expect(stripAnsi(renderWorkerLine(worker(), NOW))).toContain("flt=unattributed");
+    expect(stripAnsi(renderWorkerLine(attributed, NOW))).not.toContain("flt=");
+    expect(stripAnsi(renderWorkerLine(worker(), NOW))).not.toContain("unattributed");
   });
 
   it("short preset keeps only worker id, issue, status, and timer", () => {


### PR DESCRIPTION
Closes #2568.

Maintainer feedback on the #2488 change: the per-worker `flt=<name|unattributed>` token is display noise. Removed the column and both render sites; the #2488 correctness half (claimed workers of any supervisor render) is untouched, and fleet ownership stays available in `fleet_status`/`worker_status` — display-only removal. Render test repointed to pin the absence; 129 statusline tests green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787403565&installation_model_id=20659&pr_number=2572&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2572&signature=e8a53262f4bdfbfc72e0316ba1b26ac223a05d540108305702ad03d5481a562e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->