### PR TITLE
fix: #2566 Live gap: worker-session boots still red-halt on own-dead ghost claims (running-labeled issues escape the probe's heal window) and 57 fast deaths never tripped the slot circuit

### DIFF
--- a/apps/dev/src/core/supervisor/slot-actions.ts
+++ b/apps/dev/src/core/supervisor/slot-actions.ts
@@ -96,52 +96,16 @@ export async function handleDeadSlot(
 
   const cleanExit = exitCode === 0;
 
-  if (cleanExit) {
-    if (queueDepth === 0) {
-      // Clean drain with empty queue → idle-park (no sweep, no discard envelope).
-      state.pid = null;
-      state.idleParked = true;
-      return { parked: true };
-    }
-    // Clean drain but queue has work → respawn immediately without feeding the breaker.
-    state.spawning = true;
-    try {
-      const spawned = await spawn();
-      if (spawned === null) {
-        state.pid = null;
-        return { parked: true };
-      }
-      state.pid = spawned.pid;
-      state.spawnEpoch = spawned.spawnEpoch;
-    } finally {
-      state.spawning = false;
-    }
-    state.stalled = false;
-    state.stallSinceEpoch = 0;
-    state.reaped = false;
-    // Clean-exit respawn: on_slot_spawn + on_respawn. Best-effort.
-    if (deps.dispatchFleetHook) {
-      try {
-        await deps.dispatchFleetHook("on_slot_spawn", {
-          event: "on_slot_spawn",
-          runner: config.runner,
-          slot,
-          ...(state.pid !== null ? { pid: state.pid } : {}),
-        });
-        await deps.dispatchFleetHook("on_respawn", {
-          event: "on_respawn",
-          runner: config.runner,
-          slot,
-          ...(state.pid !== null ? { pid: state.pid } : {}),
-        });
-      } catch {
-        // best-effort
-      }
-    }
-    return { parked: false };
+  if (cleanExit && queueDepth === 0) {
+    // Clean drain with empty queue → idle-park (no sweep, no discard envelope).
+    state.pid = null;
+    state.idleParked = true;
+    return { parked: true };
   }
 
-  // Non-clean exit: record against the circuit breaker.
+  // A fast worker death while work remains is a boot-death signal regardless
+  // of its exit code. Session errors can return cleanly, so excluding exit 0
+  // makes deterministic boot crashloops invisible to the slot circuit.
   const now = deps.now();
   const decision = recordDeath(state.deaths, state.spawnEpoch, now, config);
   state.deaths = decision.deaths;
@@ -170,7 +134,7 @@ export async function handleDeadSlot(
   state.stalled = false;
   state.stallSinceEpoch = 0;
   state.reaped = false;
-  // Non-clean respawn: on_slot_spawn + on_respawn. Best-effort.
+  // Respawn after a death: on_slot_spawn + on_respawn. Best-effort.
   if (deps.dispatchFleetHook) {
     try {
       await deps.dispatchFleetHook("on_slot_spawn", {

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -15,6 +15,8 @@ import { parseClaimRecords } from "../../core/claim.js";
 import {
   collectFleetTruthProbeInput,
   HOST_PREREQUISITE_COMMANDS,
+  type ClaimHygieneCommentInput,
+  type ClaimHygieneIssueInput,
   type HostPrerequisiteProbeInput,
 } from "../../core/operational-probes.js";
 import { resolveSupervisorConfig } from "../../core/supervisor.js";
@@ -114,6 +116,30 @@ export interface CollectPrecheckFactsOptions {
 
 export interface CollectBootPrecheckFactsOptions extends CollectPrecheckFactsOptions {
   readonly log?: (line: string) => void;
+}
+
+export interface ClaimHygieneIssueScanDeps {
+  readonly listCandidates: (label: string) => Promise<readonly { readonly number: number }[]>;
+  readonly listClaimComments: (issue: number) => Promise<readonly ClaimHygieneCommentInput[]>;
+}
+
+/** Claim hygiene spans both executable and active lifecycle states. A fleet
+ * relaunch must see claims stranded on `running` issues before workers spawn,
+ * even when a later label reconcile would return those issues to the queue. */
+export async function collectClaimHygieneIssues(
+  deps: ClaimHygieneIssueScanDeps,
+): Promise<readonly ClaimHygieneIssueInput[]> {
+  const pools = await Promise.all([
+    deps.listCandidates(LABEL_READY),
+    deps.listCandidates(LABEL_RUNNING),
+  ]);
+  const issueNumbers = [...new Set(pools.flat().map((candidate) => candidate.number))];
+  return Promise.all(
+    issueNumbers.map(async (number) => ({
+      number,
+      comments: await deps.listClaimComments(number),
+    })),
+  );
 }
 
 /**
@@ -294,15 +320,11 @@ export async function collectPrecheckFacts(
     claimHygiene: ctx.repo
       ? {
           ownWorkerPrefix: hostFingerprintPrefix(),
-          listOpenQueueIssues: async () => {
-            const candidates = await ghx.listCandidates(ghCtx, LABEL_READY);
-            return Promise.all(
-              candidates.map(async (candidate) => ({
-                number: candidate.number,
-                comments: await ghx.listClaimComments(ghCtx, candidate.number),
-              })),
-            );
-          },
+          listOpenQueueIssues: () =>
+            collectClaimHygieneIssues({
+              listCandidates: (label) => ghx.listCandidates(ghCtx, label),
+              listClaimComments: (issue) => ghx.listClaimComments(ghCtx, issue),
+            }),
           workerPidState,
           // Enables the ADR 0066 TTL classification of unknown-pid markers
           // (#2525): an own-namespace claim whose owner stopped refreshing past

--- a/apps/dev/tests/boot-claim-hygiene-wiring.test.ts
+++ b/apps/dev/tests/boot-claim-hygiene-wiring.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { LABEL_READY, LABEL_RUNNING } from "../src/core/triage-labels.js";
+import { collectClaimHygieneIssues } from "../src/runtime/wire/boot.js";
+
+describe("boot claim-hygiene wiring", () => {
+  it("scans ready and running open issues and reads each claim history once", async () => {
+    const listCandidates = vi.fn(async (label: string) =>
+      label === LABEL_READY
+        ? [{ number: 2480 }, { number: 2495 }]
+        : [{ number: 2495 }, { number: 2501 }],
+    );
+    const listClaimComments = vi.fn(async (issue: number) => [
+      {
+        id: issue,
+        body: `<!-- afk:claim v1 worker=local:w${issue} kind=claim runner=codex -->`,
+      },
+    ]);
+
+    const issues = await collectClaimHygieneIssues({
+      listCandidates,
+      listClaimComments,
+    });
+
+    expect(listCandidates.mock.calls).toEqual([[LABEL_READY], [LABEL_RUNNING]]);
+    expect(issues.map((issue) => issue.number)).toEqual([2480, 2495, 2501]);
+    expect(listClaimComments.mock.calls).toEqual([[2480], [2495], [2501]]);
+  });
+});

--- a/apps/dev/tests/poison-chain.test.ts
+++ b/apps/dev/tests/poison-chain.test.ts
@@ -12,6 +12,7 @@
 //   2. the incoherent issue is quarantined with its diagnosis (#2521 posture),
 //   3. the issue with 2 prior heals is quarantined on its 3rd heal (#2526),
 //   4. the healthy sibling is claimed and processed in the same run.
+//   5. a running-labeled dead-pid ghost is conceded before worker spawn (#2566).
 //
 // The per-mechanism tests below are mutation checks: removing any one healing
 // mechanism (auto-concede, quarantine, heal ledger) makes the incident class
@@ -24,6 +25,7 @@ import { NOW, makeDeps, options, runBoot } from "./boot.helpers.js";
 
 const GHOST_CLAIM = "<!-- afk:claim v1 worker=local:wGhost kind=claim runner=codex -->";
 const KILLER_CLAIM = "<!-- afk:claim v1 worker=local:wKiller kind=claim runner=codex -->";
+const RUNNING_GHOST_CLAIM = "<!-- afk:claim v1 worker=local:wRunningGhost kind=claim runner=codex -->";
 
 const BLOCKER_BODY = [
   "## Current blocker",
@@ -50,6 +52,7 @@ function incidentIssues(): {
   incoherent: MutableIssue;
   killer: MutableIssue;
   healthy: MutableIssue;
+  runningGhost: MutableIssue;
   all: MutableIssue[];
 } {
   const ghost: MutableIssue = {
@@ -76,7 +79,20 @@ function incidentIssues(): {
     labels: ["ready-for-agent", "priority:normal"],
     body: "## Agent brief\n\nShip the healthy slice.",
   };
-  return { ghost, incoherent, killer, healthy, all: [ghost, incoherent, killer, healthy] };
+  const runningGhost: MutableIssue = {
+    number: 3005,
+    title: "Running issue held by a dead worker's un-conceded claim",
+    labels: ["running"],
+    body: "## Agent brief\n\nResume the stranded running slice.",
+  };
+  return {
+    ghost,
+    incoherent,
+    killer,
+    healthy,
+    runningGhost,
+    all: [ghost, incoherent, killer, healthy, runningGhost],
+  };
 }
 
 function seededLedger(killerIssue: number, priorHeals: number): HealLedgerStore & { value: HealLedgerState } {
@@ -98,7 +114,12 @@ function seededLedger(killerIssue: number, priorHeals: number): HealLedgerStore 
   };
 }
 
-function incidentOptions(issues: MutableIssue[], ghost: MutableIssue, killer: MutableIssue) {
+function incidentOptions(
+  issues: MutableIssue[],
+  ghost: MutableIssue,
+  killer: MutableIssue,
+  runningGhost: MutableIssue,
+) {
   return options({
     operationalProbes: {
       remoteUrls: [],
@@ -107,6 +128,10 @@ function incidentOptions(issues: MutableIssue[], ghost: MutableIssue, killer: Mu
         listOpenQueueIssues: async () => [
           { number: ghost.number, comments: [{ id: 1, body: GHOST_CLAIM, createdAt: "2026-07-22T10:00:00Z" }] },
           { number: killer.number, comments: [{ id: 2, body: KILLER_CLAIM, createdAt: "2026-07-22T10:00:00Z" }] },
+          {
+            number: runningGhost.number,
+            comments: [{ id: 3, body: RUNNING_GHOST_CLAIM, createdAt: "2026-07-23T11:00:00Z" }],
+          },
         ],
         workerPidState: () => "dead",
       },
@@ -182,20 +207,27 @@ async function drainAfterBoot(
 
 describe("2026-07-22 poison-chain regression fixture (#2529)", () => {
   it("heals the whole incident class in one run while the fleet keeps draining", async () => {
-    const { ghost, incoherent, killer, healthy, all } = incidentIssues();
+    const { ghost, incoherent, killer, healthy, runningGhost, all } = incidentIssues();
     const { deps } = makeDeps();
     const ledger = seededLedger(killer.number, 2);
     const { concedeClaim, editBody } = wireDeps(deps, all, { ledger });
 
-    const { processed, result } = await drainAfterBoot(deps, all, incidentOptions(all, ghost, killer));
+    const { processed, result } = await drainAfterBoot(
+      deps,
+      all,
+      incidentOptions(all, ghost, killer, runningGhost),
+    );
 
     // Boot survived the full poison chain — no red halt, the fleet drains.
     expect(result.boot.bootstrap).toEqual({ ok: true });
 
-    // (1) Ghost claim conceded — exactly one concede, on the ghost issue only
-    // (the killer's dead claim routes to quarantine instead, see (3)).
-    expect(concedeClaim).toHaveBeenCalledTimes(1);
-    expect(concedeClaim.mock.calls[0]?.[0]).toBe(ghost.number);
+    // (1, 5) Both queue and running-labeled ghosts are conceded before worker
+    // spawn. The killer's dead claim routes to quarantine instead, see (3).
+    expect(concedeClaim).toHaveBeenCalledTimes(2);
+    expect(concedeClaim.mock.calls.map(([issue]) => issue)).toEqual([
+      ghost.number,
+      runningGhost.number,
+    ]);
 
     // (2) Incoherent issue quarantined with its diagnosis appended.
     expect(incoherent.labels).toContain("quarantine");
@@ -216,12 +248,14 @@ describe("2026-07-22 poison-chain regression fixture (#2529)", () => {
   });
 
   it("mutation check — without auto-concede, the ghost claim red-halts the boot again", async () => {
-    const { ghost, killer, all } = incidentIssues();
+    const { ghost, killer, runningGhost, all } = incidentIssues();
     const { deps } = makeDeps();
     wireDeps(deps, all, { ledger: seededLedger(killer.number, 2) });
     deps.concedeClaim = undefined;
 
-    await expect(runBoot(deps, incidentOptions(all, ghost, killer))).rejects.toBeInstanceOf(BootHaltError);
+    await expect(
+      runBoot(deps, incidentOptions(all, ghost, killer, runningGhost)),
+    ).rejects.toBeInstanceOf(BootHaltError);
   });
 
   it("mutation check — without the quarantine write, the poison stays on the tracker (local exclusion only)", async () => {
@@ -229,11 +263,15 @@ describe("2026-07-22 poison-chain regression fixture (#2529)", () => {
     // write excludes the issue from THIS drain but leaves the tracker poisoned
     // for the curator belt to retry. Without the quarantine mechanism, the
     // contradictory shape survives on the tracker — the incident class is back.
-    const { ghost, incoherent, killer, all } = incidentIssues();
+    const { ghost, incoherent, killer, runningGhost, all } = incidentIssues();
     const { deps } = makeDeps();
     wireDeps(deps, all, { ledger: seededLedger(killer.number, 2), failLabelsFor: incoherent.number });
 
-    const { processed } = await drainAfterBoot(deps, all, incidentOptions(all, ghost, killer));
+    const { processed } = await drainAfterBoot(
+      deps,
+      all,
+      incidentOptions(all, ghost, killer, runningGhost),
+    );
 
     expect(incoherent.labels).toContain("ready-for-agent");
     expect(incoherent.labels).toContain("ready-for-human");
@@ -242,14 +280,14 @@ describe("2026-07-22 poison-chain regression fixture (#2529)", () => {
   });
 
   it("mutation check — without the heal ledger, the killer issue is conceded forever instead of quarantined", async () => {
-    const { ghost, killer, all } = incidentIssues();
+    const { ghost, killer, runningGhost, all } = incidentIssues();
     const { deps } = makeDeps();
     const { concedeClaim } = wireDeps(deps, all, { ledger: undefined });
 
-    const result = await runBoot(deps, incidentOptions(all, ghost, killer));
+    const result = await runBoot(deps, incidentOptions(all, ghost, killer, runningGhost));
 
-    // Both dead claims conceded — the killer keeps burning workers.
-    expect(concedeClaim).toHaveBeenCalledTimes(2);
+    // All three dead claims conceded — the killer keeps burning workers.
+    expect(concedeClaim).toHaveBeenCalledTimes(3);
     expect(killer.labels).not.toContain("quarantine");
     expect(result.quarantinedIssues ?? []).not.toContain(killer.number);
   });

--- a/apps/dev/tests/supervisor.config-stall.test.ts
+++ b/apps/dev/tests/supervisor.config-stall.test.ts
@@ -510,6 +510,22 @@ describe("recordDeath", () => {
 });
 
 describe("circuit trip and sweep", () => {
+  it("trips after K fast clean boot deaths while the queue still has work", async () => {
+    const { deps, io } = makeDeps();
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.deaths = [NOW - 40, NOW - 30, NOW - 20, NOW - 10];
+    slot.spawnEpoch = NOW - 5;
+    io.lastExitCode.mockReturnValue(0);
+
+    const { parked } = await handleDeadSlot(0, slot, deps, config(), 1);
+
+    expect(parked).toBe(true);
+    expect(slot.parked).toBe(true);
+    expect(slot.deaths).toEqual([NOW - 40, NOW - 30, NOW - 20, NOW - 10, NOW]);
+    expect(io.spawnSlot).not.toHaveBeenCalled();
+  });
+
   it("parks a fatal host-config death without retrying or feeding the fast-death circuit", async () => {
     const { deps, io } = makeDeps();
     const state = initSupervisorState(1);

--- a/apps/dev/tests/supervisor.reconcile-guards.test.ts
+++ b/apps/dev/tests/supervisor.reconcile-guards.test.ts
@@ -144,7 +144,7 @@ describe("idle-drain: exit 0 idle-parks without tripping the circuit breaker", (
     expect(io.spawnSlot).not.toHaveBeenCalled();
   });
 
-  it("exit 0 with non-empty queue respawns immediately without counting as fast-death", async () => {
+  it("exit 0 with non-empty queue respawns and counts a fast boot death", async () => {
     const { deps, io } = makeDeps({
       isAlive: vi.fn(() => false),
       readyQueueDepth: vi.fn(async () => 2),
@@ -163,7 +163,7 @@ describe("idle-drain: exit 0 idle-parks without tripping the circuit breaker", (
     expect(result.parked).toEqual([]);
     expect(slot.idleParked).toBe(false);
     expect(slot.parked).toBe(false);
-    expect(slot.deaths).toEqual([]);
+    expect(slot.deaths).toEqual([NOW]);
     expect(slot.pid).toBe(8888);
     expect(io.spawnSlot).toHaveBeenCalledWith(0);
   });


### PR DESCRIPTION
Automated AFK landing for #2566. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2566

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787403798&installation_model_id=20659&pr_number=2574&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2574&signature=9a89ec7ad2f5d4f83863b482c3c9d47053f9ae99a5ee0ca32f7cdf55b1db0b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->