### PR TITLE
fix: #2576 land-failed retry cap survives worker replacement; landing failures keep their diagnostic

### DIFF
--- a/.changeset/land-failed-loop.md
+++ b/.changeset/land-failed-loop.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Land-failed retry loop killed (#2576): merge-retry accounting now consults the ADR 0122 heal ledger so the RED_AFK_RETRY_MERGE cap survives worker replacement — a replacement worker restarting at attempt 1 can no longer loop 100+ identical land-failed cycles; the 3rd durable strike escalates. Landing failures also preserve their real diagnostic (push failure vs merge-step reason) into the blocker record and envelope instead of a generic `merge-conflict` with `(no merge log captured)`.

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -67,7 +67,7 @@ import { GO_KIND, GO_ORIGIN } from "../../core/go.js";
 import { SCOUT_ORIGIN, SCOUT_WORKERS_SEGMENT } from "../../core/scout.js";
 import { resolveHooks, type HookName } from "../../core/hook-config.js";
 import { dispatchHooks } from "../../core/hook-dispatcher.js";
-import { runCastleWorkerDrain, type CastleSessionHookName, type CastleWorkerDrainDeps } from "@reddb-io/red-castle/engine";
+import { createEnginePaths, createFileHealLedgerStore, runCastleWorkerDrain, type CastleSessionHookName, type CastleWorkerDrainDeps } from "@reddb-io/red-castle/engine";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../../core/attempt-ledger.js";
 import { isValidWorkerId, WORKER_NAMESPACES } from "../../core/worker-paths.js";
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -1026,6 +1026,9 @@ export function buildProcessDeps(
     historyClock: { ts: new Date().toISOString(), epoch: Math.floor(Date.now() / 1000) },
     // BOUNDED auto-recovery reads its RED_AFK_RETRY_* caps from the process env.
     recoveryEnv: process.env,
+    // ADR 0122 heal ledger (#2576): merge-retry accounting shared with the
+    // death-sweep and boot healer — one per-issue budget across all belts.
+    healLedger: createFileHealLedgerStore(createEnginePaths(join(ctx.root, ".red"))),
     // ADR 0017: best-effort AFK→Memory "reasoning attempt" recording. Serialise
     // the payload to a temp JSON file under the attempt dir, then exec the memory
     // CLI DIRECTLY (`<memoryCli> attempt record --root <root>` with the payload on

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -410,7 +410,14 @@ export async function doLanding(
   await deps.landingPhase?.("gate");
   const pushed = await pushAttempt(deps.remoteGit, input.repoDir, input.branch, input.branch);
   if (!pushed.ok) {
-    return { ok: false, reason: "land-failed", locked };
+    // Carry the REAL failure into the terminal record (#2576): a generic
+    // land-failed with no diagnostic was being misread as a merge conflict.
+    return {
+      ok: false,
+      reason: "land-failed",
+      locked,
+      message: `worker branch push failed${"warn" in pushed && pushed.warn ? `: ${pushed.warn}` : ""} — nothing was merged; the true cause is the push, not a merge conflict`,
+    };
   }
 
   // 2. pre_merge hook.
@@ -597,7 +604,13 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
       if (result.reason === "merge-failed" && result.prNumber !== undefined) {
         return { ok: false, reason: "pr-merge-failed", locked: input.locked, prNumber: result.prNumber };
       }
-      return { ok: false, reason: "land-failed", locked: input.locked, prNumber: result.prNumber };
+      return {
+        ok: false,
+        reason: "land-failed",
+        locked: input.locked,
+        prNumber: result.prNumber,
+        message: `landing failed at the merge step (underlying reason: ${String((result as { reason?: string }).reason ?? "unmapped")})`,
+      };
     };
     if (r.deferred) {
       cleanupDeferred = true;

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1380,7 +1380,11 @@ export async function processIssue(
         { validationSummary: validation },
       );
     }
-    return await mergeFailed(common, landing.reason, landing.locked);
+    return await mergeFailed(
+      common,
+      [landing.reason, landing.message].filter(Boolean).join(" — "),
+      landing.locked,
+    );
   }
   return await finishSuccessfulLanding(landing, true);
   }

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -111,6 +111,7 @@ import {
 } from "../issue-lifecycle.js";
 import type { ProcessIssueDeps, ProcessIssueInput, ProcessIssueResult, ProcessOutcome, WorkerBaseResolution } from "./types.js";
 import { formatBaseResolution, markTerminalState, recoveryOrdinalFor } from "./types.js";
+import { recordIssueHeal } from "@reddb-io/red-castle/engine";
 import { editLabelsTagged, routeRecovery } from "./recovery.js";
 export async function writeValidationSidecar(
   deps: ProcessIssueDeps,
@@ -473,7 +474,21 @@ export async function emitDone(
 export async function mergeFailed(c: StageCommon, _reason: string, locked = false): Promise<ProcessIssueResult> {
   const { deps, input } = c;
   deps.recordWorkerEvent?.("worker.blocked", { outcome: "merge-conflict", reason: _reason });
-  const decision = await routeRecovery(deps, input.issue, "merge-conflict", recoveryOrdinalFor(input));
+  // Durable retry accounting (#2576): the worker-local attempt ordinal resets
+  // to 1 on every replacement worker (ADR 0103 flat workspaces), so the
+  // RED_AFK_RETRY_MERGE cap alone never trips across reclaims — the 2026-07-23
+  // incidents looped 100+ identical land-failed cycles. The ADR 0122 heal
+  // ledger supplies the per-issue consecutive count that survives replacement.
+  let ordinal = recoveryOrdinalFor(input);
+  if (deps.healLedger) {
+    try {
+      const heal = await recordIssueHeal(deps.healLedger, input.issue, deps.nowEpoch() * 1000);
+      ordinal = Math.max(ordinal, heal.history.length);
+    } catch {
+      // best-effort: a ledger fault falls back to worker-local accounting.
+    }
+  }
+  const decision = await routeRecovery(deps, input.issue, "merge-conflict", ordinal);
   if (decision === "escalate") {
     await writeCurrentBlockerBestEffort(
       deps,
@@ -482,7 +497,7 @@ export async function mergeFailed(c: StageCommon, _reason: string, locked = fals
     );
   }
   const posted = await emitFailure(c, envelopeStatusFor("merge-conflict"), "merge-conflict", {
-    log: "(no merge log captured)",
+    log: _reason || "(no merge log captured)",
   });
   await recordAttemptBestEffort(c, "merge-conflict", {
     durationS: deps.nowEpoch() - c.startedEpoch,

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -331,6 +331,10 @@ export interface ProcessIssueDeps {
   historyPath?: string;
   historyClock?: HistoryClock;
   recoveryEnv?: RecoveryEnv;
+  /** ADR 0122 heal ledger (#2576): durable per-issue retry accounting so the
+   * merge-retry cap survives worker replacement. Optional; absent in tests
+   * that predate it (worker-local ordinal then applies alone). */
+  healLedger?: import("@reddb-io/red-castle/engine").HealLedgerStore;
   recordAttempt?(payload: AttemptRecordPayload): Promise<void>;
   recordOutcomeEvent?(event: OutcomeEvent): Promise<void>;
   cascadeRebase?: CascadeRebasePort;

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -193,7 +193,8 @@ describe("doLanding — abort / failure short-circuits", () => {
     // Simulate the continuous-push hook having failed: the initial push also fails.
     h.deps.remoteGit = async () => ({ code: 1, stdout: "", stderr: "fatal: authentication failed" });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "land-failed", locked: false });
+    expect(r).toMatchObject({ ok: false, reason: "land-failed", locked: false });
+    expect((r as { message?: string }).message).toContain("push failed");
     // No hooks should fire — the push is the first mandatory step.
     expect(h.firedHooks).toEqual([]);
   });
@@ -242,7 +243,7 @@ describe("doLanding — abort / failure short-circuits", () => {
   it("land failure (locked, no resolver) → { ok:false, land-failed, locked:true }", async () => {
     const h = harness({ locked: true, mergeNoFfCode: 1 });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
+    expect(r).toMatchObject({ ok: false, reason: "land-failed", locked: true });
     // post_merge never fires on a failed land.
     expect(h.firedHooks).toEqual(["pre_merge"]);
   });
@@ -252,7 +253,7 @@ describe("doLanding — abort / failure short-circuits", () => {
     // on the locked path, wrongly closing the issue as done. Guard must catch this.
     const h = harness({ locked: true, commitCount: 0 });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
+    expect(r).toMatchObject({ ok: false, reason: "land-failed", locked: true });
     // No merge --no-ff must have been attempted.
     expect(joined(h.mergeCalls).some((c) => c.includes("merge --no-ff"))).toBe(false);
     // post_merge must not fire.
@@ -277,7 +278,7 @@ describe("doLanding — locked conflict self-resolve", () => {
   it("resolver fails → aborts the merge in the worktree, { ok:false, land-failed }", async () => {
     const h = harness({ locked: true, mergeNoFfCode: 1, conflictResolve: "fail" });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
+    expect(r).toMatchObject({ ok: false, reason: "land-failed", locked: true });
     const j = joined(h.mergeCalls);
     expect(j).toContain(`git -C ${WT} merge --abort`);
     expect(h.firedHooks).toEqual(["pre_merge"]);
@@ -286,7 +287,7 @@ describe("doLanding — locked conflict self-resolve", () => {
   it("resolved but the locked push is rejected → resets the worktree to preMergeSha, land-failed", async () => {
     const h = harness({ locked: true, mergeNoFfCode: 1, conflictResolve: "resolve", resolvePushCode: 1 });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
+    expect(r).toMatchObject({ ok: false, reason: "land-failed", locked: true });
     const j = joined(h.mergeCalls);
     // The rollback rewinds the throwaway worktree, NOT the primary checkout (#572).
     expect(j).toContain(`git -C ${WT} reset --hard abc1234`);
@@ -304,7 +305,8 @@ describe("doLanding — locked conflict self-resolve", () => {
       return { code: 0, stdout: "", stderr: "" };
     };
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "land-failed", locked: false });
+    expect(r).toMatchObject({ ok: false, reason: "land-failed", locked: false });
+    expect((r as { message?: string }).message).toContain("merge step");
   });
 });
 
@@ -344,7 +346,7 @@ describe("doLanding — the primary checkout is sacred (#572)", () => {
       };
     })();
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
+    expect(r).toMatchObject({ ok: false, reason: "land-failed", locked: true });
     const j = joined(h.mergeCalls);
     expect(j).toContain(`git -C ${WT} reset --hard abc1234`);
     assertPrimaryUntouched(h);
@@ -368,7 +370,7 @@ describe("doLanding — the primary checkout is sacred (#572)", () => {
     // (parks to ready-for-human) so the primary checkout is never at risk.
     const h = harness({ locked: true, noWorktree: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
+    expect(r).toMatchObject({ ok: false, reason: "land-failed", locked: true });
     // Nothing merged/reset anywhere — no worktree, no land.
     expect(h.mergeCalls.some((c) => c.includes("merge --no-ff"))).toBe(false);
     assertPrimaryUntouched(h);

--- a/apps/dev/tests/process-issue.recovery.test.ts
+++ b/apps/dev/tests/process-issue.recovery.test.ts
@@ -55,6 +55,39 @@ describe("processIssue — BOUNDED auto-recovery routing (the policy wired in)",
     ).toBe(true);
   });
 
+  it("merge-conflict at worker-local attempt 1 but 2 prior ledgered land-heals → ESCALATE (#2576: cap survives worker replacement)", async () => {
+    // The 2026-07-23 incidents: every replacement worker restarts at attempt 1,
+    // so the worker-local cap never trips and identical land-failed cycles loop
+    // 100+ times. The ADR 0122 heal ledger supplies the durable per-issue count.
+    // The harness clock is nowEpoch()=1000 (seconds) → the ledger window filter
+    // compares against 1000*1000 ms; prior heals must sit just before that.
+    const NOW_MS = 1000 * 1000;
+    const ledger = {
+      value: { version: 1 as const, issues: { "9": [NOW_MS - 120_000, NOW_MS - 60_000] } },
+      async read() {
+        return this.value;
+      },
+      async write(v: typeof this.value) {
+        this.value = v;
+      },
+    };
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: true,
+      mergeNoFfCode: 1,
+      attempt: 1,
+    });
+    (deps as { healLedger?: unknown }).healLedger = ledger;
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("merge-conflict");
+    const edit = trace.labelEdits.at(-1)!;
+    expect(edit.add).toContain("ready-for-human");
+    expect(edit.add).toContain("blocked:merge-conflict");
+    // The heal was recorded — 3 entries now, budget consumed durably.
+    expect(ledger.value.issues["9"]).toHaveLength(3);
+  });
+
   it("quota (exhausted) at attempt < cap → RETRY: CLEAN ready-for-agent, no blocked:* tag (#402)", async () => {
     const { deps, input, trace } = harness({ outcome: "exhausted", fallbackRunner: false, attempt: 2 });
     const result = await processIssue(deps, input);


### PR DESCRIPTION
Closes #2576 (dup #2573 closed onto it).

## The loop (2026-07-23 incidents: 100+/70+/212 identical cycles)

gate-green fast path skips the agent → landing returns generic `land-failed` → terminal maps it to `merge-conflict` with `(no merge log captured)` → recovery sees the worker-LOCAL attempt ordinal (always 1 on a replacement worker, ADR 0103) → `1 < RED_AFK_RETRY_MERGE` → requeue → fresh worker → repeat forever.

## Fix

- **Durable retry accounting**: `mergeFailed` records each land-heal in the ADR 0122 heal ledger (same per-issue budget as the death-sweep and boot healer) and feeds `max(worker-local, ledger count)` to the recovery router — the 3rd durable strike escalates to ready-for-human + blocked:merge-conflict regardless of worker replacement. Ledger faults fall back to the old worker-local accounting.
- **Diagnostics preserved**: the branch-push failure and the merge-step fall-through now carry their real reason in `LandingResult.message`, threaded into the blocker record and the failure envelope — no more bare `(no merge log captured)` when a cause was known.

## Tests

New regression: worker-local attempt 1 + 2 prior ledgered land-heals → ESCALATE (and the 3rd heal is recorded durably). Full recovery suite green (52).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787406018&installation_model_id=20659&pr_number=2579&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2579&signature=c6c7bb442b5a18eb5e98a6e51b0bcd9851ebb1d964feb26161dec4da8de0219d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->