### PR TITLE
fix: #2581 top-level --help never boots a worker; unknown leading flags error with usage

### DIFF
--- a/.changeset/toplevel-help.md
+++ b/.changeset/toplevel-help.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+`red-skills-dev --help` prints usage and exits 0 (#2581) — it no longer falls through to the run default and boots a live worker drain. Help short-circuits before any routing (bare, `-h`, `help`, and `<command> --help`), and a flag-led invocation whose leading flag is not one of the documented run-surface flags errors with usage instead of silently draining the queue.

--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -122,8 +122,52 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
   errorOnUnknownCommand: true,
 };
 
+/** Run-surface flags the flag-led default invocation may open with — the
+ * documented legacy `/afk` interface (`--issues 42`, `--spec 7`, …). Any OTHER
+ * leading flag is an error, never a silent queue drain (#2581: `--help` booted
+ * a live worker and iterated the queue). */
+const RUN_SURFACE_LEADING_FLAGS = new Set([
+  "--spec",
+  "--issues",
+  "--selector",
+  "--runner",
+  "--alternate",
+  "--fallback-runner",
+  "--request",
+  "-r",
+  "-n",
+  "--once",
+  "--boot-only",
+  "--base",
+]);
+
+export const CLI_USAGE = `Usage: red-skills-dev <command> [options]
+
+Commands: run (default), monitor, fleet, stop, go, manager, dashboard,
+  daily-review, weekly-review, reap, requeue, retake, review, respond, triage,
+  red-doctor, statusline, version, …
+
+Flag-led invocations route to the run surface: --issues N, --spec N,
+  --selector <json>, --runner <r>, -n <count>, --once, --boot-only.
+
+Run \`red-skills-dev <command> --help\` for a command's own usage.
+Docs: plugins/dev/skills/engineering/afk/SKILL.md
+`;
+
+export class HelpRequested extends Error {}
+
 export function parseCli(argv: readonly string[]): ParsedCli {
   if (argv[0] === "--version" || argv[0] === "-v") return { command: "version", args: argv.slice(1) };
+  // Help must short-circuit BEFORE any routing can reach the run default —
+  // a usage request never boots a worker or touches the queue (#2581).
+  if (argv[0] === "--help" || argv[0] === "-h" || argv[0] === "help") throw new HelpRequested();
+  const first = argv[0];
+  if (first !== undefined && first.startsWith("-")) {
+    const flagName = first.split("=")[0]!;
+    if (!RUN_SURFACE_LEADING_FLAGS.has(flagName)) {
+      throw new UnknownCommandError(first, [...RUN_SURFACE_LEADING_FLAGS]);
+    }
+  }
   return routeCommand(argv, CLI_ROUTER);
 }
 
@@ -132,11 +176,30 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   try {
     parsed = parseCli(argv);
   } catch (error) {
+    if (error instanceof HelpRequested) {
+      process.stdout.write(CLI_USAGE);
+      return 0;
+    }
     if (error instanceof UnknownCommandError) {
       process.stderr.write(`[afk] ${error.message}\n`);
+      process.stderr.write(CLI_USAGE);
       return 2;
     }
     throw error;
+  }
+  // `<command> --help` prints usage and exits BEFORE dispatch for every
+  // command (#2581 acceptance) — commands with richer usage (e.g. fleet) are
+  // never reached with a help flag, so their own handlers stay as docs.
+  if (
+    parsed.command !== "go" &&
+    (parsed.args.includes("--help") || parsed.args.includes("-h"))
+  ) {
+    if (parsed.command === "fleet") return fleetCommand(parsed.args);
+    process.stdout.write(
+      `Usage: red-skills-dev ${parsed.command} [options]\n` +
+        `No detailed usage registered for this command yet; see the afk skill docs.\n`,
+    );
+    return 0;
   }
   if (parsed.command === "version") {
     const info = readBuildInfo("dev");

--- a/apps/dev/tests/cli.test.ts
+++ b/apps/dev/tests/cli.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { parseCli } from "../src/cli.js";
+import { describe, expect, it, vi } from "vitest";
+import { HelpRequested, main, parseCli } from "../src/cli.js";
+import { UnknownCommandError } from "@reddb-io/shared/args.js";
 
 describe("cli parser", () => {
   it("preserves the legacy default /afk interface", () => {
@@ -33,5 +34,42 @@ describe("cli parser", () => {
       command: "afk-output-shaping",
       args: ["--human"],
     });
+  });
+});
+
+describe("top-level help and unknown flags never boot a worker (#2581)", () => {
+  it("--help / -h / help short-circuit before any routing", () => {
+    for (const argv of [["--help"], ["-h"], ["help"]]) {
+      expect(() => parseCli(argv)).toThrow(HelpRequested);
+    }
+  });
+
+  it("main prints usage and exits 0 on --help", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      await expect(main(["--help"])).resolves.toBe(0);
+      expect(String(write.mock.calls[0]![0])).toContain("Usage: red-skills-dev");
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it("an unknown leading flag errors instead of silently draining the queue", () => {
+    expect(() => parseCli(["--definitely-not-a-flag"])).toThrow(UnknownCommandError);
+  });
+
+  it("the documented run-surface flags still route to the run default", () => {
+    expect(parseCli(["--issues", "42"])).toEqual({ command: "run", args: ["--issues", "42"] });
+    expect(parseCli(["--spec", "7"])).toEqual({ command: "run", args: ["--spec", "7"] });
+  });
+
+  it("<command> --help exits 0 without dispatching the command", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      await expect(main(["requeue", "--help"])).resolves.toBe(0);
+      expect(String(write.mock.calls[0]![0])).toContain("red-skills-dev requeue");
+    } finally {
+      write.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Closes #2581.

## What

- `--help` / `-h` / `help` short-circuit in `parseCli` BEFORE any routing can reach the run default — usage prints, exit 0, no worker boot, no queue touch, no `.red/tmp` writes.
- `<command> --help` exits 0 pre-dispatch for every command (fleet keeps its richer usage handler).
- Flag-led invocations are now allowlisted to the documented run-surface flags (`--issues`, `--spec`, `--selector`, `--runner`, `-n`, `--once`, `--boot-only`, …); any other leading flag errors with usage instead of silently launching a drain — the general cure for the `--help`-boots-a-worker class (sibling of the `fleet --help` fix in #2536).

## Tests

5 new: help short-circuit (3 forms), main exits 0 with usage, unknown leading flag errors, run-surface flags still route to run, `requeue --help` exits pre-dispatch. CLI suite 10/10.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787408988&installation_model_id=20659&pr_number=2582&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2582&signature=e113396ef082837fa1650af376fe420086131ea9b139d9c1206f8c1af3731b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->