### PR TITLE
Statusline: lifecycle bar in wine-ramp red tones

### DIFF
--- a/.changeset/statusline-bar-red-tones.md
+++ b/.changeset/statusline-bar-red-tones.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Statusline lifecycle bar recolored to the wine ramp: completed cells full-bodied red, healthy cursor pale pink, future cells dark wine; the failure cursor keeps the saturated red.

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -303,13 +303,21 @@ function progressCell(phase: string, activity: string): string {
   return [phase, activity].filter(Boolean).join("·");
 }
 
+// Lifecycle-bar ramp: three steps of the statusline's wine family, so the bar
+// reads as part of the identity zone instead of a green/yellow traffic light.
+// The failure cursor stays the saturated {@link RED} — clearly hotter than the
+// pale-pink healthy cursor.
+const BAR_DONE = "\x1b[38;2;240;110;120m"; // completed cells: full-bodied red
+const BAR_CURRENT = "\x1b[38;2;255;214;214m"; // healthy cursor: brightest pale pink in the ramp
+const BAR_AHEAD = "\x1b[38;2;146;84;94m"; // future cells: receded dark wine
+
 function lifecycleBar(phase: string, failed: boolean): string {
   const macroPhase = LANDING_PHASES.has(phase) ? "merging" : phase;
   const current = Math.max(0, (AFK_PHASE_ORDER as readonly string[]).indexOf(macroPhase));
   if (current === AFK_PHASE_ORDER.length - 1) {
-    return `${GREEN}${"█".repeat(AFK_PHASE_ORDER.length)}${SOFT}`;
+    return `${BAR_DONE}${"█".repeat(AFK_PHASE_ORDER.length)}${SOFT}`;
   }
-  return `${GREEN}${"█".repeat(current)}${failed ? RED : YELLOW}▶${DIM}${"░".repeat(AFK_PHASE_ORDER.length - current - 1)}${SOFT}`;
+  return `${BAR_DONE}${"█".repeat(current)}${failed ? RED : BAR_CURRENT}▶${BAR_AHEAD}${"░".repeat(AFK_PHASE_ORDER.length - current - 1)}${SOFT}`;
 }
 
 function workerCells(worker: CompactWorker, now: number): WorkerCells {

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -25,6 +25,9 @@ const DIM = "\x1b[38;2;201;150;158m";
 const GREEN = "\x1b[38;2;96;214;128m";
 const RED = "\x1b[38;2;255;95;95m";
 const YELLOW = "\x1b[38;2;240;200;120m";
+const BAR_DONE = "\x1b[38;2;240;110;120m";
+const BAR_CURRENT = "\x1b[38;2;255;214;214m";
+const BAR_AHEAD = "\x1b[38;2;146;84;94m";
 const BOLD = "\x1b[1m";
 const RESET = "\x1b[0m";
 
@@ -220,7 +223,7 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
     expect(stripAnsi(renderWorkerLine(w, NOW)).match(/[█▶░]{5}/)?.[0]).toBe("▶░░░░");
   });
 
-  it("colors completed, current, and future lifecycle cells green, yellow, and dim", () => {
+  it("colors completed, current, and future lifecycle cells along the wine ramp", () => {
     const validating = worker({
       state: {
         ...worker().state,
@@ -234,8 +237,8 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
       },
     });
 
-    expect(renderWorkerLine(validating, NOW)).toContain(`${GREEN}██${YELLOW}▶${DIM}░░${SOFT}`);
-    expect(renderWorkerLine(done, NOW)).toContain(`${GREEN}█████${SOFT}`);
+    expect(renderWorkerLine(validating, NOW)).toContain(`${BAR_DONE}██${BAR_CURRENT}▶${BAR_AHEAD}░░${SOFT}`);
+    expect(renderWorkerLine(done, NOW)).toContain(`${BAR_DONE}█████${SOFT}`);
   });
 
   it.each([
@@ -250,7 +253,7 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
       },
     });
 
-    expect(renderWorkerLine(w, NOW)).toContain(`${GREEN}██${RED}▶${DIM}░░${SOFT}`);
+    expect(renderWorkerLine(w, NOW)).toContain(`${BAR_DONE}██${RED}▶${BAR_AHEAD}░░${SOFT}`);
   });
 
   it("renders the terse colored k=v line: bold-red wID, k=v tokens, iss=number, bare stage, elapsed, loc, tks, individual vitals", () => {


### PR DESCRIPTION
Maintainer feedback on the v2.87.0 bar: the green/yellow palette clashes with the statusline's wine identity. The bar now uses a three-step wine ramp — completed cells full-bodied red (240;110;120), healthy cursor pale pink (255;214;214, the KEY tone), future cells receded dark wine (146;84;94). The failure cursor keeps the saturated RED (255;95;95), which stays clearly hotter than the pale healthy cursor.

statusline-style suite 45/45; typecheck clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787414323&installation_model_id=20659&pr_number=2593&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2593&signature=39cbb9d210fe954a32b074eb9e144aaa00c6dac61be1087fea0b6126ad3208fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->