### PR TITLE
chore: #2428 deadend_audit: read-only MCP tool, cron-refreshed, doctor-consumed

### DIFF
--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -25,6 +25,8 @@ import {
 } from "../core/host-toolchain-doctor.js";
 import { getConfig, loadConfig } from "../core/config.js";
 import { auditExecutableAcceptanceCriteria, type ExecutableAcceptanceDoctorReport } from "../core/executable-acceptance-doctor.js";
+import { collectDeadendAuditReport } from "../runtime/deadend-audit-report.js";
+import { emptyDeadendReport, type DeadendAuditReport } from "../core/deadend-audit.js";
 import { LABEL_READY } from "../core/triage-labels.js";
 import { fastForwardLocalTarget } from "../core/merge.js";
 import { execTool } from "../runtime/exec.js";
@@ -130,6 +132,7 @@ function renderHuman(
   executableAcceptanceReport: ExecutableAcceptanceDoctorReport,
   report: TmpJanitorReport,
   hostReport: HostToolchainReport,
+  deadendReport: DeadendAuditReport,
   applied?: TmpJanitorApplyResult,
   probeFixes: readonly OperationalProbeFixResult[] = [],
   hostFixes: readonly HostToolchainFixReceipt[] = [],
@@ -178,6 +181,12 @@ function renderHuman(
     ...workers.map((path) => `  ${path}`),
     `unknown tmp roots: ${unknown.length}`,
     ...unknown.map((path) => `  ${path}`),
+    "",
+    "red-doctor deadend audit",
+    `deadends: ${deadendReport.total}`,
+    ...deadendReport.classes.flatMap((cls) =>
+      cls.findings.map((finding) => `  ${finding.deadendClass} ${finding.subject} → cure: ${finding.cure} (${finding.detail})`),
+    ),
   ];
   if (applied) {
     lines.push(
@@ -201,6 +210,7 @@ function renderToon(
   executableAcceptanceReport: ExecutableAcceptanceDoctorReport,
   report: TmpJanitorReport,
   hostReport: HostToolchainReport,
+  deadendReport: DeadendAuditReport,
   applied?: TmpJanitorApplyResult,
   probeFixes: readonly OperationalProbeFixResult[] = [],
   hostFixes: readonly HostToolchainFixReceipt[] = [],
@@ -255,6 +265,19 @@ function renderToon(
         kind: finding.kind,
         verdict: finding.verdict,
         fix: finding.canonicalFix,
+      })),
+    },
+    deadendAudit: {
+      total: deadendReport.total,
+      classes: deadendReport.classes.map((cls) => ({
+        deadendClass: cls.deadendClass,
+        cure: cls.cure,
+        count: cls.count,
+        findings: cls.findings.map((finding) => ({
+          subject: finding.subject,
+          cure: finding.cure,
+          detail: finding.detail,
+        })),
       })),
     },
     executableAcceptance: {
@@ -364,10 +387,16 @@ export async function redDoctorCommand(args: readonly string[], cwd = process.cw
       },
     );
     const applied = flags.fix ? await applyTmpJanitorReport(paths.tmpDir, report) : undefined;
+    // Detection only — /red-doctor consumes the same read-only deadend audit
+    // the `deadend_audit` MCP tool serves; it renders findings and never mutates.
+    // A gather failure degrades to an empty section, never a failed doctor.
+    const deadendReport = await collectDeadendAuditReport(ctx.root).catch(() =>
+      emptyDeadendReport(Date.now()),
+    );
     process.stdout.write(
       flags.json
-        ? renderToon(ctx.root, probeReport, castleReport, executableAcceptanceReport, report, hostReport, applied, probeFixes, hostFixes)
-        : renderHuman(ctx.root, probeReport, castleReport, executableAcceptanceReport, report, hostReport, applied, probeFixes, hostFixes),
+        ? renderToon(ctx.root, probeReport, castleReport, executableAcceptanceReport, report, hostReport, deadendReport, applied, probeFixes, hostFixes)
+        : renderHuman(ctx.root, probeReport, castleReport, executableAcceptanceReport, report, hostReport, deadendReport, applied, probeFixes, hostFixes),
     );
     return 0;
   } catch (error) {

--- a/apps/dev/src/core/deadend-audit-collect.ts
+++ b/apps/dev/src/core/deadend-audit-collect.ts
@@ -1,0 +1,76 @@
+// deadend-audit-collect.ts — assemble the deadend audit from a read-only
+// gateway and run the pure detector (issue #2428).
+//
+// The gateway is the ONLY seam the collector touches, and it is read-only by
+// type. A consumer builds a gateway over the GitHub read helpers and local
+// state; a test builds one over fakes (including a mutation recorder) to pin
+// that this slice mutates nothing.
+
+import {
+  auditDeadends,
+  type DeadendAuditReport,
+  type DeadendClaim,
+  type DeadendIssue,
+  type DeadendPr,
+  type DeadendWorktree,
+  type IssueState,
+} from "./deadend-audit.js";
+
+/** Default human-queue outlier threshold: parked longer than two days. */
+export const DEFAULT_HUMAN_QUEUE_MAX_AGE_MS = 2 * 24 * 60 * 60 * 1000;
+
+/**
+ * The read-only data source the collector pulls from. Every method is a read;
+ * the interface carries no mutation, so a collector built on it cannot change
+ * repository or local state.
+ */
+export interface DeadendAuditReader {
+  /** Wall clock in epoch ms. */
+  now(): number;
+  /** Ids of workers currently live. */
+  liveWorkers(): Promise<readonly string[]>;
+  /** Open Tickets with labels + body + last-moved timestamp. */
+  openIssues(): Promise<readonly DeadendIssue[]>;
+  /** Open PRs with owner + failing-checks flag + linked Ticket. */
+  openPrs(): Promise<readonly DeadendPr[]>;
+  /** Live claim holders across in-flight Tickets. */
+  claims(): Promise<readonly DeadendClaim[]>;
+  /** Disposable worktree checkouts with a liveness flag. */
+  worktrees(): Promise<readonly DeadendWorktree[]>;
+  /** State of every Ticket, for resolving `req:*` dependency targets. */
+  issueStates(): Promise<ReadonlyMap<number, IssueState>>;
+}
+
+export interface CollectDeadendAuditOptions {
+  readonly humanQueueMaxAgeMs?: number;
+}
+
+/**
+ * Gather every deadend input from the reader and run the pure detector. Read
+ * only: the collector never writes through the gateway.
+ */
+export async function collectDeadendAudit(
+  reader: DeadendAuditReader,
+  options: CollectDeadendAuditOptions = {},
+): Promise<DeadendAuditReport> {
+  const [liveWorkers, issues, prs, claims, worktrees, issueStates] =
+    await Promise.all([
+      reader.liveWorkers(),
+      reader.openIssues(),
+      reader.openPrs(),
+      reader.claims(),
+      reader.worktrees(),
+      reader.issueStates(),
+    ]);
+  return auditDeadends({
+    nowMs: reader.now(),
+    liveWorkers,
+    issues,
+    prs,
+    claims,
+    worktrees,
+    issueStates,
+    humanQueueMaxAgeMs:
+      options.humanQueueMaxAgeMs ?? DEFAULT_HUMAN_QUEUE_MAX_AGE_MS,
+  });
+}

--- a/apps/dev/src/core/deadend-audit.ts
+++ b/apps/dev/src/core/deadend-audit.ts
@@ -1,0 +1,334 @@
+// deadend-audit.ts — the pure deadend detector (issue #2428).
+//
+// A "deadend" is a stuck AFK pattern that will never drain on its own: a claim
+// held by a worker that is gone, a red PR whose owner is gone, a superseded PR
+// nobody closed, an executable Ticket whose body still carries an active
+// Current blocker, a dependency-blocked Ticket whose req targets all closed, a
+// human-queue Ticket that has aged past the outlier threshold, and a stale
+// feedback/base worktree left by a dead worker.
+//
+// This module is DETECTION ONLY — it never mutates. Each detected class carries
+// its recommended cure, pinned by {@link CURE_BY_CLASS}, so a consumer
+// (the `deadend_audit` MCP tool, /red-doctor) can name the fix without
+// re-deriving it. The audit takes already-gathered, plain-data inputs so it is
+// trivially testable against fakes and holds zero IO.
+
+/** The stuck-pattern taxonomy. One entry per detected deadend class. */
+export type DeadendClass =
+  | "dangling_claim"
+  | "red_pr_dead_owner"
+  | "superseded_pr"
+  | "active_current_blocker"
+  | "dependency_all_closed"
+  | "human_queue_age_outlier"
+  | "stale_worktree";
+
+/**
+ * The recommended cure per class, pinned. A read tool renders these verbatim;
+ * changing one is a deliberate protocol change the audit test freezes.
+ */
+export const CURE_BY_CLASS: Readonly<Record<DeadendClass, string>> = {
+  dangling_claim: "claim_release",
+  red_pr_dead_owner: "retake",
+  superseded_pr: "close_superseded_pr",
+  active_current_blocker: "quarantine",
+  dependency_all_closed: "unblock_sweep",
+  human_queue_age_outlier: "hitl_review",
+  stale_worktree: "worktree_remove",
+};
+
+/** The canonical class order the report always renders in. */
+export const DEADEND_CLASS_ORDER: readonly DeadendClass[] = [
+  "dangling_claim",
+  "red_pr_dead_owner",
+  "superseded_pr",
+  "active_current_blocker",
+  "dependency_all_closed",
+  "human_queue_age_outlier",
+  "stale_worktree",
+];
+
+export type IssueState = "OPEN" | "CLOSED" | "UNKNOWN";
+
+/** One open Ticket, reduced to the fields the audit inspects. */
+export interface DeadendIssue {
+  readonly number: number;
+  readonly labels: readonly string[];
+  readonly body: string;
+  /** ISO timestamp the Ticket last moved; the age seam for the human queue. */
+  readonly updatedAt?: string;
+}
+
+/** One open PR, reduced to the fields the audit inspects. */
+export interface DeadendPr {
+  readonly number: number;
+  /** The Ticket this PR closes, when known — the supersede grouping key. */
+  readonly issue?: number;
+  /** The worker id (or login) that owns the branch. */
+  readonly owner: string;
+  /** Whether the PR's required checks are failing. */
+  readonly checksRed: boolean;
+}
+
+/** One live claim marker: worker `worker` currently holds Ticket `issue`. */
+export interface DeadendClaim {
+  readonly issue: number;
+  readonly worker: string;
+}
+
+/** One disposable worktree checkout under `.red/tmp/worktrees/<lane>/`. */
+export interface DeadendWorktree {
+  readonly lane: string;
+  readonly path: string;
+  /** Whether the owning worker/process is still live. */
+  readonly live: boolean;
+}
+
+export interface DeadendAuditInputs {
+  readonly nowMs: number;
+  /** Live worker ids — a claim or PR owner absent here is "dead". */
+  readonly liveWorkers: readonly string[];
+  readonly issues: readonly DeadendIssue[];
+  readonly prs: readonly DeadendPr[];
+  readonly claims: readonly DeadendClaim[];
+  readonly worktrees: readonly DeadendWorktree[];
+  /** State of every Ticket referenced by a `req:*` label, for class (d). */
+  readonly issueStates: ReadonlyMap<number, IssueState>;
+  /** A ready-for-human Ticket older than this is an age outlier. */
+  readonly humanQueueMaxAgeMs: number;
+}
+
+/** One detected deadend, tagged with its class and pinned cure. */
+export interface DeadendFinding {
+  readonly deadendClass: DeadendClass;
+  readonly cure: string;
+  /** A short, stable identifier of the stuck subject (e.g. "#123", "worker w8"). */
+  readonly subject: string;
+  /** Human-readable evidence of why it is stuck. */
+  readonly detail: string;
+}
+
+/** The per-class roll-up the report always emits, even at count 0. */
+export interface DeadendClassReport {
+  readonly deadendClass: DeadendClass;
+  readonly cure: string;
+  readonly count: number;
+  readonly findings: readonly DeadendFinding[];
+}
+
+export interface DeadendAuditReport {
+  readonly generatedAtMs: number;
+  readonly total: number;
+  readonly classes: readonly DeadendClassReport[];
+}
+
+const LABEL_READY = "ready-for-agent";
+const LABEL_HUMAN = "ready-for-human";
+const LABEL_DEPENDENCY = "blocked:dependency";
+const REQ_LABEL_RE = /^req:(\d+)$/;
+
+/** The `req:N` Ticket numbers a label set declares. */
+function reqTargets(labels: readonly string[]): number[] {
+  const out: number[] = [];
+  for (const label of labels) {
+    const match = REQ_LABEL_RE.exec(label);
+    if (match) out.push(Number(match[1]));
+  }
+  return out;
+}
+
+/**
+ * Whether the anchored Current-blocker region carries an active blocker. Kept
+ * local (not importing blocker-state) so the detector stays IO- and
+ * dependency-free; the collector normalizes the body before handing it in.
+ */
+const BLOCKER_OPEN = "<!-- red:blocker-state v1 -->";
+const BLOCKER_CLOSE = "<!-- /red:blocker-state -->";
+
+function hasActiveBlocker(body: string): boolean {
+  const start = body.indexOf(BLOCKER_OPEN);
+  if (start < 0) return false;
+  const end = body.indexOf(BLOCKER_CLOSE, start + BLOCKER_OPEN.length);
+  if (end < 0) return false;
+  const inner = body.slice(start + BLOCKER_OPEN.length, end);
+  const fields: Record<string, string> = {};
+  for (const line of inner.split("\n")) {
+    const match = /^([a-z_]+):\s*(.*)$/.exec(line.trim());
+    if (match) fields[match[1]!] = match[2]!.trim();
+  }
+  return fields.status === "blocked" && Boolean(fields.summary) && Boolean(fields.next);
+}
+
+function danglingClaims(inputs: DeadendAuditInputs, live: ReadonlySet<string>): DeadendFinding[] {
+  const findings: DeadendFinding[] = [];
+  for (const claim of inputs.claims) {
+    if (live.has(claim.worker)) continue;
+    findings.push({
+      deadendClass: "dangling_claim",
+      cure: CURE_BY_CLASS.dangling_claim,
+      subject: `#${claim.issue}`,
+      detail: `claim held by dead worker ${claim.worker}`,
+    });
+  }
+  return findings;
+}
+
+function redPrsWithDeadOwners(inputs: DeadendAuditInputs, live: ReadonlySet<string>): DeadendFinding[] {
+  const findings: DeadendFinding[] = [];
+  for (const pr of inputs.prs) {
+    // An unknown owner is never "dead" — only a named worker absent from the
+    // live set counts, so an unclaimed red PR is not misread as a deadend.
+    if (!pr.checksRed || pr.owner.trim() === "" || live.has(pr.owner)) continue;
+    findings.push({
+      deadendClass: "red_pr_dead_owner",
+      cure: CURE_BY_CLASS.red_pr_dead_owner,
+      subject: `PR #${pr.number}`,
+      detail: `failing checks with dead owner ${pr.owner}`,
+    });
+  }
+  return findings;
+}
+
+function supersededPrs(inputs: DeadendAuditInputs): DeadendFinding[] {
+  // Group open PRs by the Ticket they close; when more than one PR targets the
+  // same Ticket, the highest-numbered PR is current and the rest are superseded.
+  const byIssue = new Map<number, DeadendPr[]>();
+  for (const pr of inputs.prs) {
+    if (pr.issue === undefined) continue;
+    const bucket = byIssue.get(pr.issue);
+    if (bucket) bucket.push(pr);
+    else byIssue.set(pr.issue, [pr]);
+  }
+  const findings: DeadendFinding[] = [];
+  for (const [issue, prs] of byIssue) {
+    if (prs.length < 2) continue;
+    const current = prs.reduce((a, b) => (b.number > a.number ? b : a));
+    for (const pr of prs) {
+      if (pr.number === current.number) continue;
+      findings.push({
+        deadendClass: "superseded_pr",
+        cure: CURE_BY_CLASS.superseded_pr,
+        subject: `PR #${pr.number}`,
+        detail: `superseded by PR #${current.number} on Ticket #${issue}`,
+      });
+    }
+  }
+  return findings;
+}
+
+function activeCurrentBlockers(inputs: DeadendAuditInputs): DeadendFinding[] {
+  const findings: DeadendFinding[] = [];
+  for (const issue of inputs.issues) {
+    if (!issue.labels.includes(LABEL_READY)) continue;
+    if (!hasActiveBlocker(issue.body)) continue;
+    findings.push({
+      deadendClass: "active_current_blocker",
+      cure: CURE_BY_CLASS.active_current_blocker,
+      subject: `#${issue.number}`,
+      detail: "ready-for-agent Ticket carries an active Current blocker",
+    });
+  }
+  return findings;
+}
+
+function dependencyAllClosed(inputs: DeadendAuditInputs): DeadendFinding[] {
+  const findings: DeadendFinding[] = [];
+  for (const issue of inputs.issues) {
+    if (!issue.labels.includes(LABEL_DEPENDENCY)) continue;
+    const reqs = reqTargets(issue.labels);
+    if (reqs.length === 0) continue;
+    const allClosed = reqs.every((n) => inputs.issueStates.get(n) === "CLOSED");
+    if (!allClosed) continue;
+    findings.push({
+      deadendClass: "dependency_all_closed",
+      cure: CURE_BY_CLASS.dependency_all_closed,
+      subject: `#${issue.number}`,
+      detail: `blocked:dependency with all req targets closed (${reqs.map((n) => `#${n}`).join(", ")})`,
+    });
+  }
+  return findings;
+}
+
+function humanQueueAgeOutliers(inputs: DeadendAuditInputs): DeadendFinding[] {
+  const findings: DeadendFinding[] = [];
+  for (const issue of inputs.issues) {
+    if (!issue.labels.includes(LABEL_HUMAN)) continue;
+    if (!issue.updatedAt) continue;
+    const movedMs = Date.parse(issue.updatedAt);
+    if (!Number.isFinite(movedMs)) continue;
+    const ageMs = inputs.nowMs - movedMs;
+    if (ageMs <= inputs.humanQueueMaxAgeMs) continue;
+    const ageHours = Math.floor(ageMs / (60 * 60 * 1000));
+    findings.push({
+      deadendClass: "human_queue_age_outlier",
+      cure: CURE_BY_CLASS.human_queue_age_outlier,
+      subject: `#${issue.number}`,
+      detail: `ready-for-human for ${ageHours}h, past the age threshold`,
+    });
+  }
+  return findings;
+}
+
+function staleWorktrees(inputs: DeadendAuditInputs): DeadendFinding[] {
+  const findings: DeadendFinding[] = [];
+  for (const worktree of inputs.worktrees) {
+    if (worktree.live) continue;
+    findings.push({
+      deadendClass: "stale_worktree",
+      cure: CURE_BY_CLASS.stale_worktree,
+      subject: worktree.path,
+      detail: `stale ${worktree.lane} worktree with no live owner`,
+    });
+  }
+  return findings;
+}
+
+const DETECTORS: Readonly<
+  Record<DeadendClass, (inputs: DeadendAuditInputs, live: ReadonlySet<string>) => DeadendFinding[]>
+> = {
+  dangling_claim: danglingClaims,
+  red_pr_dead_owner: redPrsWithDeadOwners,
+  superseded_pr: (inputs) => supersededPrs(inputs),
+  active_current_blocker: (inputs) => activeCurrentBlockers(inputs),
+  dependency_all_closed: (inputs) => dependencyAllClosed(inputs),
+  human_queue_age_outlier: (inputs) => humanQueueAgeOutliers(inputs),
+  stale_worktree: (inputs) => staleWorktrees(inputs),
+};
+
+/**
+ * A findings-free report — one empty entry per class, cures pinned. Used as the
+ * doctor's fallback when the live gather fails so one section can never crash
+ * the whole command.
+ */
+export function emptyDeadendReport(nowMs: number): DeadendAuditReport {
+  return {
+    generatedAtMs: nowMs,
+    total: 0,
+    classes: DEADEND_CLASS_ORDER.map((deadendClass) => ({
+      deadendClass,
+      cure: CURE_BY_CLASS[deadendClass],
+      count: 0,
+      findings: [],
+    })),
+  };
+}
+
+/**
+ * Run every deadend detector against pre-gathered inputs and return the
+ * per-class roll-up with pinned cures. Pure: no IO, no mutation.
+ */
+export function auditDeadends(inputs: DeadendAuditInputs): DeadendAuditReport {
+  const live = new Set(inputs.liveWorkers);
+  let total = 0;
+  const classes: DeadendClassReport[] = DEADEND_CLASS_ORDER.map((deadendClass) => {
+    const findings = DETECTORS[deadendClass](inputs, live);
+    total += findings.length;
+    return {
+      deadendClass,
+      cure: CURE_BY_CLASS[deadendClass],
+      count: findings.length,
+      findings,
+    };
+  });
+  return { generatedAtMs: inputs.nowMs, total, classes };
+}

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -122,9 +122,11 @@ import { executeRespond } from "./commands/respond.js";
 import {
   ResidentReadCache,
   QUEUE_STATUS_KEY,
+  DEADEND_AUDIT_KEY,
   claimStatusKey,
   cascadeStatusKey,
 } from "./resident-read-cache.js";
+import { collectDeadendAuditReport } from "./runtime/deadend-audit-report.js";
 
 interface DispatchOperationInput extends WorkerDispatchInput {
   request?: string;
@@ -162,6 +164,7 @@ export interface DevAfkMcpOperations {
   weeklyReview(input: WeeklyReviewInput): Promise<unknown>;
   triage(input: TriageToolInput): Promise<unknown>;
   respond(input: RespondToolInput): Promise<unknown>;
+  deadendAudit(): Promise<unknown>;
 }
 
 export interface DevAfkMcpRuntime {
@@ -773,6 +776,7 @@ export function createDefaultDevAfkMcpOperations(
         },
         { cwd: root },
       ),
+    deadendAudit: () => collectDeadendAuditReport(root),
   };
 }
 
@@ -1487,6 +1491,15 @@ export function withCachedDeps(
       cache.set(key, result);
       return result;
     },
+    deadendAudit: async () => {
+      // The resident cron refreshes this envelope; repeated tool calls within
+      // the refresh window are served from cache and cost zero GitHub quota.
+      const cached = cache.get(DEADEND_AUDIT_KEY);
+      if (cached !== undefined) return cached;
+      const result = await deps.deadendAudit();
+      cache.set(DEADEND_AUDIT_KEY, result);
+      return result;
+    },
     claimRelease: async (input) => {
       for (const issue of input.issues ?? (input.issue !== undefined ? [input.issue] : [])) {
         cache.invalidate(claimStatusKey(issue));
@@ -1684,6 +1697,7 @@ export function createCastleMcpDependencies(
     weeklyReview: (input) => operations.weeklyReview(input),
     triage: (input) => operations.triage(input),
     respond: (input) => operations.respond(input),
+    deadendAudit: () => operations.deadendAudit(),
     statuslineAggregate: () => collectStatuslineAggregate(root),
     eventsSince: (input) => eventsSinceImpl(root, input),
   };

--- a/apps/dev/src/resident-read-cache.ts
+++ b/apps/dev/src/resident-read-cache.ts
@@ -38,5 +38,6 @@ export class ResidentReadCache {
 }
 
 export const QUEUE_STATUS_KEY = "queue_status";
+export const DEADEND_AUDIT_KEY = "deadend_audit";
 export const claimStatusKey = (issue: number): string => `claim_status:${issue}`;
 export const cascadeStatusKey = (issue: number): string => `cascade_status:${issue}`;

--- a/apps/dev/src/runtime/deadend-audit-report.ts
+++ b/apps/dev/src/runtime/deadend-audit-report.ts
@@ -1,0 +1,228 @@
+// deadend-audit-report.ts — build the live deadend audit from GitHub reads and
+// local state, shared by the `deadend_audit` MCP tool and /red-doctor so both
+// render byte-identical results (issue #2428).
+//
+// Every source below is a READ. The builder assembles a read-only
+// DeadendAuditReader and hands it to the pure collector; it never mutates the
+// repository or local state.
+
+import {
+  collectDeadendAudit,
+  type CollectDeadendAuditOptions,
+  type DeadendAuditReader,
+} from "../core/deadend-audit-collect.js";
+import type {
+  DeadendAuditReport,
+  DeadendClaim,
+  DeadendIssue,
+  DeadendPr,
+  DeadendWorktree,
+  IssueState,
+} from "../core/deadend-audit.js";
+import { issueFromAFKBranch } from "../core/boot-sweep.js";
+import { parseClaimRecords } from "../core/claim.js";
+import { LABEL_DEPENDENCY, LABEL_RUNNING } from "../core/triage-labels.js";
+import { collectTmpJanitorReport } from "./tmp-janitor.js";
+import {
+  listCandidates,
+  listHitlCandidates,
+  listClaimComments,
+  listIssueStates,
+  type GhContext,
+} from "./gh.js";
+import { runGh, isRecord } from "./gh/common.js";
+import { afkPaths, collectMonitorInputs, resolveRepoContext } from "./wire.js";
+
+function issueStateOf(raw: string): IssueState {
+  const upper = raw.toUpperCase();
+  return upper === "CLOSED" ? "CLOSED" : upper === "OPEN" ? "OPEN" : "UNKNOWN";
+}
+
+/** Fold claim markers to the latest record per worker and keep active holders. */
+function claimHolders(comments: { id: number; body: string; createdAt?: string }[]): string[] {
+  const records = parseClaimRecords(
+    comments.map((c) => ({ id: c.id, body: c.body, createdAt: c.createdAt })),
+  );
+  const latest = new Map<string, { commentId: number; kind: string }>();
+  for (const record of records) {
+    const seen = latest.get(record.worker);
+    if (!seen || record.commentId > seen.commentId) {
+      latest.set(record.worker, { commentId: record.commentId, kind: record.kind });
+    }
+  }
+  const holders: string[] = [];
+  for (const [worker, record] of latest) {
+    if (record.kind === "claim") holders.push(worker);
+  }
+  return holders;
+}
+
+interface RollupState {
+  statusCheckRollup?: Array<{ conclusion?: string | null; state?: string | null }>;
+}
+
+function rollupIsRed(pr: RollupState): boolean {
+  const rollup = pr.statusCheckRollup ?? [];
+  return rollup.some((check) => {
+    const verdict = String(check.conclusion ?? check.state ?? "").toUpperCase();
+    return verdict === "FAILURE" || verdict === "ERROR" || verdict === "TIMED_OUT";
+  });
+}
+
+async function listOpenAfkPrs(gh: GhContext): Promise<Array<{ number: number; issue: number; red: boolean }>> {
+  const result = await runGh(gh, [
+    "pr",
+    "list",
+    "--repo",
+    gh.repo,
+    "--state",
+    "open",
+    "--limit",
+    "200",
+    "--json",
+    "number,headRefName,statusCheckRollup",
+  ]);
+  if (result.code !== 0) return [];
+  let rows: unknown;
+  try {
+    rows = JSON.parse(result.stdout ?? "[]");
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(rows)) return [];
+  const out: Array<{ number: number; issue: number; red: boolean }> = [];
+  for (const row of rows) {
+    if (!isRecord(row)) continue;
+    const branch = String(row.headRefName ?? "");
+    const issue = issueFromAFKBranch(branch);
+    if (issue === null) continue;
+    out.push({
+      number: Number(row.number),
+      issue,
+      red: rollupIsRed(row as RollupState),
+    });
+  }
+  return out;
+}
+
+/**
+ * Build the live deadend audit for `root`. Read-only end to end.
+ */
+export async function collectDeadendAuditReport(
+  root: string,
+  options: CollectDeadendAuditOptions = {},
+): Promise<DeadendAuditReport> {
+  const context = await resolveRepoContext(root);
+  const gh: GhContext = { cwd: context.root, repo: context.repo };
+  const paths = afkPaths(root);
+
+  const reader: DeadendAuditReader = {
+    now: () => Date.now(),
+
+    async liveWorkers() {
+      const monitor = await collectMonitorInputs(root);
+      return monitor.workers
+        .filter((worker) => worker.pidLive === true || worker.live === true)
+        .map((worker) => worker.state.worker_id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0);
+    },
+
+    async openIssues() {
+      const [ready, human, states] = await Promise.all([
+        listCandidates(gh),
+        listHitlCandidates(gh),
+        listIssueStates(gh),
+      ]);
+      const byNumber = new Map<number, { labels: Set<string>; body: string; updatedAt?: string }>();
+      const merge = (number: number, labels: readonly string[], body?: string, updatedAt?: string) => {
+        const entry = byNumber.get(number) ?? { labels: new Set<string>(), body: "" };
+        for (const label of labels) entry.labels.add(label);
+        if (body) entry.body = body;
+        if (updatedAt) entry.updatedAt = updatedAt;
+        byNumber.set(number, entry);
+      };
+      for (const candidate of ready) merge(candidate.number, candidate.labels, candidate.body);
+      for (const candidate of human) {
+        merge(candidate.number, candidate.labels, undefined, candidate.createdAt ?? undefined);
+      }
+      for (const [number, row] of states) {
+        if (issueStateOf(row.state) !== "OPEN") continue;
+        if (!row.labels.includes(LABEL_DEPENDENCY)) continue;
+        merge(number, row.labels);
+      }
+      const issues: DeadendIssue[] = [];
+      for (const [number, entry] of byNumber) {
+        issues.push({
+          number,
+          labels: [...entry.labels],
+          body: entry.body,
+          ...(entry.updatedAt ? { updatedAt: entry.updatedAt } : {}),
+        });
+      }
+      return issues;
+    },
+
+    async openPrs() {
+      const [prs, states] = await Promise.all([listOpenAfkPrs(gh), listIssueStates(gh)]);
+      const holderByIssue = new Map<number, string>();
+      const runningIssues = [...states].filter(
+        ([, row]) => issueStateOf(row.state) === "OPEN" && row.labels.includes(LABEL_RUNNING),
+      );
+      await Promise.all(
+        runningIssues.map(async ([issue]) => {
+          const holders = claimHolders(await listClaimComments(gh, issue));
+          if (holders.length > 0) holderByIssue.set(issue, holders[0]!);
+        }),
+      );
+      const out: DeadendPr[] = [];
+      for (const pr of prs) {
+        out.push({
+          number: pr.number,
+          issue: pr.issue,
+          owner: holderByIssue.get(pr.issue) ?? "",
+          checksRed: pr.red,
+        });
+      }
+      return out;
+    },
+
+    async claims() {
+      const states = await listIssueStates(gh);
+      const runningIssues = [...states].filter(
+        ([, row]) => issueStateOf(row.state) === "OPEN" && row.labels.includes(LABEL_RUNNING),
+      );
+      const out: DeadendClaim[] = [];
+      await Promise.all(
+        runningIssues.map(async ([issue]) => {
+          for (const worker of claimHolders(await listClaimComments(gh, issue))) {
+            out.push({ issue, worker });
+          }
+        }),
+      );
+      return out;
+    },
+
+    async worktrees() {
+      const states = await listIssueStates(gh);
+      const report = await collectTmpJanitorReport(
+        paths.tmpDir,
+        Math.floor(Date.now() / 1000),
+        (issue) => issueStateOf(states.get(issue)?.state ?? "UNKNOWN"),
+      );
+      const out: DeadendWorktree[] = [];
+      for (const entry of report.orphanFeedback.reclaim) {
+        out.push({ lane: "feedback", path: entry.path, live: false });
+      }
+      return out;
+    },
+
+    async issueStates() {
+      const states = await listIssueStates(gh);
+      const out = new Map<number, IssueState>();
+      for (const [number, row] of states) out.set(number, issueStateOf(row.state));
+      return out;
+    },
+  };
+
+  return collectDeadendAudit(reader, options);
+}

--- a/apps/dev/tests/deadend-audit-collect.test.ts
+++ b/apps/dev/tests/deadend-audit-collect.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  collectDeadendAudit,
+  DEFAULT_HUMAN_QUEUE_MAX_AGE_MS,
+  type DeadendAuditReader,
+} from "../src/core/deadend-audit-collect.js";
+import type { IssueState } from "../src/core/deadend-audit.js";
+
+const NOW = Date.parse("2026-07-23T12:00:00Z");
+
+/**
+ * A fake gateway that satisfies the read-only reader AND carries a mutation
+ * surface. The collector only ever calls reads, so `mutations` must stay empty
+ * — this fake is the mutation recorder the "zero mutations" acceptance pins.
+ */
+class RecordingGateway implements DeadendAuditReader {
+  readonly mutations: string[] = [];
+  readonly readCounts: Record<string, number> = {};
+
+  private count(name: string): void {
+    this.readCounts[name] = (this.readCounts[name] ?? 0) + 1;
+  }
+
+  now(): number {
+    return NOW;
+  }
+  async liveWorkers() {
+    this.count("liveWorkers");
+    return ["wLIVE"];
+  }
+  async openIssues() {
+    this.count("openIssues");
+    return [
+      { number: 400, labels: ["blocked:dependency", "req:10"], body: "" },
+    ];
+  }
+  async openPrs() {
+    this.count("openPrs");
+    return [];
+  }
+  async claims() {
+    this.count("claims");
+    return [{ issue: 100, worker: "wDEAD" }];
+  }
+  async worktrees() {
+    this.count("worktrees");
+    return [{ lane: "feedback", path: "p", live: false }];
+  }
+  async issueStates(): Promise<ReadonlyMap<number, IssueState>> {
+    this.count("issueStates");
+    return new Map<number, IssueState>([[10, "CLOSED"]]);
+  }
+
+  // Mutation surface — present so the recorder can prove none fire.
+  async comment(issue: number, body: string) {
+    this.mutations.push(`comment(${issue},${body})`);
+  }
+  async editLabels(issue: number) {
+    this.mutations.push(`editLabels(${issue})`);
+  }
+  async closeIssue(issue: number) {
+    this.mutations.push(`closeIssue(${issue})`);
+  }
+  async releaseClaim(issue: number) {
+    this.mutations.push(`releaseClaim(${issue})`);
+  }
+  async removeWorktree(path: string) {
+    this.mutations.push(`removeWorktree(${path})`);
+  }
+}
+
+describe("collectDeadendAudit", () => {
+  it("composes reads into the pure audit report", async () => {
+    const gateway = new RecordingGateway();
+    const report = await collectDeadendAudit(gateway);
+
+    expect(report.total).toBe(3); // dangling claim + all-req-closed dep + stale worktree
+    expect(report.generatedAtMs).toBe(NOW);
+    const dangling = report.classes.find((c) => c.deadendClass === "dangling_claim")!;
+    expect(dangling.findings).toHaveLength(1);
+    const dep = report.classes.find((c) => c.deadendClass === "dependency_all_closed")!;
+    expect(dep.findings).toHaveLength(1);
+  });
+
+  it("mutates nothing — the recorder stays empty", async () => {
+    const gateway = new RecordingGateway();
+    await collectDeadendAudit(gateway);
+    expect(gateway.mutations).toEqual([]);
+  });
+
+  it("reads each source exactly once", async () => {
+    const gateway = new RecordingGateway();
+    await collectDeadendAudit(gateway);
+    for (const source of [
+      "liveWorkers",
+      "openIssues",
+      "openPrs",
+      "claims",
+      "worktrees",
+      "issueStates",
+    ]) {
+      expect(gateway.readCounts[source]).toBe(1);
+    }
+  });
+
+  it("honors a custom human-queue age threshold", async () => {
+    const reader: DeadendAuditReader = {
+      now: () => NOW,
+      liveWorkers: vi.fn(async () => []),
+      openIssues: vi.fn(async () => [
+        {
+          number: 500,
+          labels: ["ready-for-human"],
+          body: "",
+          updatedAt: new Date(NOW - 60 * 60 * 1000).toISOString(), // 1h old
+        },
+      ]),
+      openPrs: vi.fn(async () => []),
+      claims: vi.fn(async () => []),
+      worktrees: vi.fn(async () => []),
+      issueStates: vi.fn(async () => new Map()),
+    };
+    const strict = await collectDeadendAudit(reader, { humanQueueMaxAgeMs: 30 * 60 * 1000 });
+    expect(strict.classes.find((c) => c.deadendClass === "human_queue_age_outlier")!.count).toBe(1);
+    const lenient = await collectDeadendAudit(reader);
+    expect(lenient.classes.find((c) => c.deadendClass === "human_queue_age_outlier")!.count).toBe(0);
+    expect(DEFAULT_HUMAN_QUEUE_MAX_AGE_MS).toBe(2 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/apps/dev/tests/deadend-audit.test.ts
+++ b/apps/dev/tests/deadend-audit.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  auditDeadends,
+  CURE_BY_CLASS,
+  DEADEND_CLASS_ORDER,
+  type DeadendAuditInputs,
+  type DeadendClass,
+} from "../src/core/deadend-audit.js";
+
+const NOW = Date.parse("2026-07-23T12:00:00Z");
+
+function baseInputs(over: Partial<DeadendAuditInputs> = {}): DeadendAuditInputs {
+  return {
+    nowMs: NOW,
+    liveWorkers: [],
+    issues: [],
+    prs: [],
+    claims: [],
+    worktrees: [],
+    issueStates: new Map(),
+    humanQueueMaxAgeMs: 24 * 60 * 60 * 1000,
+    ...over,
+  };
+}
+
+function activeBlockerBody(): string {
+  return [
+    "## Current blocker",
+    "",
+    "<!-- red:blocker-state v1 -->",
+    "status: blocked",
+    "kind: runner",
+    "summary: Agent idle for 600 seconds",
+    "next: human guidance required",
+    "<!-- /red:blocker-state -->",
+  ].join("\n");
+}
+
+function findingsFor(report: ReturnType<typeof auditDeadends>, cls: DeadendClass) {
+  return report.classes.find((c) => c.deadendClass === cls)!;
+}
+
+describe("auditDeadends — per-class detection with pinned cure", () => {
+  it("always reports every class in canonical order, even with no findings", () => {
+    const report = auditDeadends(baseInputs());
+    expect(report.classes.map((c) => c.deadendClass)).toEqual(DEADEND_CLASS_ORDER);
+    expect(report.total).toBe(0);
+    for (const cls of report.classes) {
+      expect(cls.cure).toBe(CURE_BY_CLASS[cls.deadendClass]);
+      expect(cls.count).toBe(0);
+    }
+  });
+
+  it("detects a dangling claim from a dead worker → claim_release", () => {
+    const report = auditDeadends(
+      baseInputs({
+        liveWorkers: ["wLIVE"],
+        claims: [
+          { issue: 100, worker: "wDEAD" },
+          { issue: 101, worker: "wLIVE" },
+        ],
+      }),
+    );
+    const cls = findingsFor(report, "dangling_claim");
+    expect(cls.cure).toBe("claim_release");
+    expect(cls.findings).toHaveLength(1);
+    expect(cls.findings[0]!.subject).toBe("#100");
+    expect(cls.findings[0]!.detail).toContain("wDEAD");
+  });
+
+  it("detects a red PR with a dead owner → retake", () => {
+    const report = auditDeadends(
+      baseInputs({
+        liveWorkers: ["wLIVE"],
+        prs: [
+          { number: 5, issue: 100, owner: "wDEAD", checksRed: true },
+          { number: 6, issue: 101, owner: "wDEAD", checksRed: false }, // green: not stuck
+          { number: 7, issue: 102, owner: "wLIVE", checksRed: true }, // live owner: not stuck
+          { number: 8, issue: 103, owner: "", checksRed: true }, // unknown owner: not stuck
+        ],
+      }),
+    );
+    const cls = findingsFor(report, "red_pr_dead_owner");
+    expect(cls.cure).toBe("retake");
+    expect(cls.findings.map((f) => f.subject)).toEqual(["PR #5"]);
+  });
+
+  it("detects a superseded PR left open → close_superseded_pr", () => {
+    const report = auditDeadends(
+      baseInputs({
+        liveWorkers: ["w1"],
+        prs: [
+          { number: 10, issue: 200, owner: "w1", checksRed: false },
+          { number: 12, issue: 200, owner: "w1", checksRed: false }, // newest → current
+          { number: 30, issue: 201, owner: "w1", checksRed: false }, // lone PR: not superseded
+        ],
+      }),
+    );
+    const cls = findingsFor(report, "superseded_pr");
+    expect(cls.cure).toBe("close_superseded_pr");
+    expect(cls.findings.map((f) => f.subject)).toEqual(["PR #10"]);
+    expect(cls.findings[0]!.detail).toContain("#12");
+  });
+
+  it("detects an executable Ticket with an active Current blocker → quarantine", () => {
+    const report = auditDeadends(
+      baseInputs({
+        issues: [
+          { number: 300, labels: ["ready-for-agent"], body: activeBlockerBody() },
+          { number: 301, labels: ["ready-for-agent"], body: "no blocker here" },
+          { number: 302, labels: ["ready-for-human"], body: activeBlockerBody() }, // not executable
+        ],
+      }),
+    );
+    const cls = findingsFor(report, "active_current_blocker");
+    expect(cls.cure).toBe("quarantine");
+    expect(cls.findings.map((f) => f.subject)).toEqual(["#300"]);
+  });
+
+  it("detects a dependency-blocked Ticket whose req targets all closed → unblock_sweep", () => {
+    const report = auditDeadends(
+      baseInputs({
+        issues: [
+          { number: 400, labels: ["blocked:dependency", "req:10", "req:11"], body: "" },
+          { number: 401, labels: ["blocked:dependency", "req:12", "req:13"], body: "" },
+        ],
+        issueStates: new Map([
+          [10, "CLOSED"],
+          [11, "CLOSED"],
+          [12, "CLOSED"],
+          [13, "OPEN"], // one still open → 401 stays blocked
+        ]),
+      }),
+    );
+    const cls = findingsFor(report, "dependency_all_closed");
+    expect(cls.cure).toBe("unblock_sweep");
+    expect(cls.findings.map((f) => f.subject)).toEqual(["#400"]);
+  });
+
+  it("detects a human-queue age outlier → hitl_review", () => {
+    const dayMs = 24 * 60 * 60 * 1000;
+    const report = auditDeadends(
+      baseInputs({
+        humanQueueMaxAgeMs: dayMs,
+        issues: [
+          {
+            number: 500,
+            labels: ["ready-for-human"],
+            body: "",
+            updatedAt: new Date(NOW - 3 * dayMs).toISOString(),
+          },
+          {
+            number: 501,
+            labels: ["ready-for-human"],
+            body: "",
+            updatedAt: new Date(NOW - dayMs / 2).toISOString(), // fresh
+          },
+        ],
+      }),
+    );
+    const cls = findingsFor(report, "human_queue_age_outlier");
+    expect(cls.cure).toBe("hitl_review");
+    expect(cls.findings.map((f) => f.subject)).toEqual(["#500"]);
+  });
+
+  it("detects a stale feedback/base worktree → worktree_remove", () => {
+    const report = auditDeadends(
+      baseInputs({
+        worktrees: [
+          { lane: "feedback", path: ".red/tmp/worktrees/feedback/dead", live: false },
+          { lane: "base", path: ".red/tmp/worktrees/base/live", live: true },
+        ],
+      }),
+    );
+    const cls = findingsFor(report, "stale_worktree");
+    expect(cls.cure).toBe("worktree_remove");
+    expect(cls.findings.map((f) => f.subject)).toEqual([
+      ".red/tmp/worktrees/feedback/dead",
+    ]);
+  });
+
+  it("sums total across all classes", () => {
+    const report = auditDeadends(
+      baseInputs({
+        claims: [{ issue: 1, worker: "wDEAD" }],
+        worktrees: [{ lane: "feedback", path: "p", live: false }],
+      }),
+    );
+    expect(report.total).toBe(2);
+    expect(report.generatedAtMs).toBe(NOW);
+  });
+});

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -789,5 +789,6 @@ function fakeOperations(): DevAfkMcpOperations {
     weeklyReview: vi.fn(async () => ({ kind: "weekly" })),
     triage: vi.fn(async (input) => ({ issue: input.issue, action: "apply" })),
     respond: vi.fn(async () => ({ action: "ignored" })),
+    deadendAudit: vi.fn(async () => ({ total: 0, classes: [] })),
   };
 }

--- a/apps/dev/tests/red-doctor-command.test.ts
+++ b/apps/dev/tests/red-doctor-command.test.ts
@@ -54,6 +54,25 @@ vi.mock("../src/core/operational-probes.js", () => ({
   terminateSupervisorPid: vi.fn(async () => undefined),
 }));
 
+const deadendReport = {
+  generatedAtMs: 1_700_000_000_000,
+  total: 1,
+  classes: [
+    {
+      deadendClass: "dangling_claim",
+      cure: "claim_release",
+      count: 1,
+      findings: [
+        { deadendClass: "dangling_claim", cure: "claim_release", subject: "#100", detail: "claim held by dead worker wDEAD" },
+      ],
+    },
+  ],
+};
+
+vi.mock("../src/runtime/deadend-audit-report.js", () => ({
+  collectDeadendAuditReport: vi.fn(async () => deadendReport),
+}));
+
 vi.mock("../src/core/castle-state-doctor.js", () => ({
   auditCastleStateLane: vi.fn(async () => ({
     status: "ok",
@@ -92,6 +111,43 @@ describe("redDoctorCommand — executable acceptance criteria lint", () => {
     expect(output).toContain("red-doctor executable acceptance criteria");
     expect(output).toContain("warn #2403: acceptance criteria item is not machine-checkable");
     expect(output).toContain("fix: refresh ## Acceptance criteria");
+    stdout.mockRestore();
+  });
+
+  it("renders the same read-only deadend audit with each class cure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "red-doctor-deadend-"));
+    roots.push(root);
+    const writes: string[] = [];
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    const { redDoctorCommand } = await import("../src/commands/red-doctor.js");
+
+    await expect(redDoctorCommand(["--root", root], root)).resolves.toBe(0);
+
+    const human = writes.join("");
+    expect(human).toContain("red-doctor deadend audit");
+    expect(human).toContain("deadends: 1");
+    expect(human).toContain("dangling_claim #100 → cure: claim_release");
+    stdout.mockRestore();
+  });
+
+  it("renders the deadend audit in the --json (TOON) form", async () => {
+    const root = await mkdtemp(join(tmpdir(), "red-doctor-deadend-json-"));
+    roots.push(root);
+    const writes: string[] = [];
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    const { redDoctorCommand } = await import("../src/commands/red-doctor.js");
+
+    await expect(redDoctorCommand(["--root", root, "--json"], root)).resolves.toBe(0);
+
+    const toon = writes.join("");
+    expect(toon).toContain("deadendAudit");
+    expect(toon).toContain("claim_release");
     stdout.mockRestore();
   });
 });

--- a/apps/dev/tests/resident-read-cache.test.ts
+++ b/apps/dev/tests/resident-read-cache.test.ts
@@ -77,6 +77,7 @@ function makeFakeDeps(): Pick<
   | "requeue"
   | "unblockSweep"
   | "triage"
+  | "deadendAudit"
 > & { callCounts: Record<string, number> } {
   const callCounts: Record<string, number> = {};
   function count(name: string): void {
@@ -92,6 +93,7 @@ function makeFakeDeps(): Pick<
     requeue: vi.fn(async () => { count("requeue"); return { applied: true }; }),
     unblockSweep: vi.fn(async () => { count("unblockSweep"); return { promoted: [] }; }),
     triage: vi.fn(async () => { count("triage"); return { action: "apply" }; }),
+    deadendAudit: vi.fn(async () => { count("deadendAudit"); return { total: 0, classes: [] }; }),
   };
 }
 
@@ -106,6 +108,18 @@ describe("withCachedDeps — zero gh calls within TTL", () => {
     await wrapped.queueStatus();
 
     expect(fake.callCounts["queueStatus"]).toBe(1);
+  });
+
+  it("serves deadendAudit from cache on repeated calls within TTL — zero gh", async () => {
+    const fake = makeFakeDeps();
+    const cache = new ResidentReadCache(15_000);
+    const wrapped = withCachedDeps(fake as unknown as CastleMcpDependencies, cache);
+
+    await wrapped.deadendAudit();
+    await wrapped.deadendAudit();
+    await wrapped.deadendAudit();
+
+    expect(fake.callCounts["deadendAudit"]).toBe(1);
   });
 
   it("invalidates queue_status when requeue is called", async () => {

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -35,6 +35,7 @@ function deps(): CastleMcpDependencies {
       ready_for_agent: [],
       ready_for_human: [],
     })),
+    deadendAudit: vi.fn(async () => ({ total: 0, classes: [] })),
     eventsSince: vi.fn(async (input) => {
       if (input.cursor === undefined) {
         return { events: [], history: [], lane_records: [], cursor: "eyJ2IjoxLCJhdCI6IjIwMjYtMDctMjJUMDA6MDA6MDAuMDAwWiJ9" };
@@ -132,6 +133,7 @@ describe("castle MCP tools", () => {
       "history",
       "queue_status",
       "events_since",
+      "deadend_audit",
       "worker_dispatch",
       "worker_status",
       "worker_stop",

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -4,6 +4,7 @@ import { createMergeTools, type MergeDependencies } from "./mcp/merge.js";
 import { createHitlTools, type HitlDependencies } from "./mcp/hitl.js";
 import { createFleetTools, type FleetDependencies } from "./mcp/fleet.js";
 import { createGateTools, type GateDependencies } from "./mcp/gate.js";
+import { createDeadendTools, type DeadendDependencies } from "./mcp/deadend.js";
 import { createHygieneTools, type HygieneDependencies } from "./mcp/hygiene.js";
 import { createLandingTools, type LandingDependencies } from "./mcp/landing.js";
 import {
@@ -39,6 +40,7 @@ export type {
   FleetRegisterInput,
 } from "./mcp/fleet.js";
 export type { EventsSinceInput, LogsInput, QueueStatusInput, WorkerVitalsInput } from "./mcp/observability.js";
+export type { DeadendDependencies } from "./mcp/deadend.js";
 export type {
   WorkerDispatchInput,
   WorkerStatusInput,
@@ -73,6 +75,7 @@ export interface CastleMcpDependencies
   extends
     FleetDependencies,
     ObservabilityDependencies,
+    DeadendDependencies,
     WorkerDependencies,
     RunnerDependencies,
     HygieneDependencies,
@@ -103,6 +106,7 @@ export function createCastleMcpTools(
   const tools = [
     ...createFleetTools(deps),
     ...createObservabilityTools(deps),
+    ...createDeadendTools(deps),
     ...createWorkerTools(deps),
     ...createRunnerTools(deps),
     ...createHygieneTools(deps),

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -109,6 +109,13 @@ const SURFACE: ReadonlyArray<{
     schema: ["cursor"],
   },
   {
+    name: "deadend_audit",
+    title: "Audit AFK deadends",
+    description:
+      "Return the read-only deadend audit: dangling claims, red PRs with dead owners, superseded PRs, executable Tickets carrying an active Current blocker, dependency blocks whose req targets all closed, human-queue age outliers, and stale worktrees — each class paired with its recommended cure. Cache-backed: repeated calls within the refresh window cost zero GitHub quota.",
+    schema: [],
+  },
+  {
     name: "worker_dispatch",
     title: "Dispatch AFK worker",
     description:

--- a/packages/red-castle/src/mcp/deadend.ts
+++ b/packages/red-castle/src/mcp/deadend.ts
@@ -1,0 +1,24 @@
+import type { CastleMcpTool } from "./tool.js";
+
+export interface DeadendDependencies {
+  /**
+   * Return the cron-refreshed, cache-backed deadend audit: every stuck AFK
+   * pattern with its recommended cure. Read-only — the host implementation
+   * mutates nothing and repeated calls within the refresh window cost zero
+   * GitHub quota.
+   */
+  deadendAudit(): Promise<unknown>;
+}
+
+export function createDeadendTools(deps: DeadendDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "deadend_audit",
+      title: "Audit AFK deadends",
+      description:
+        "Return the read-only deadend audit: dangling claims, red PRs with dead owners, superseded PRs, executable Tickets carrying an active Current blocker, dependency blocks whose req targets all closed, human-queue age outliers, and stale worktrees — each class paired with its recommended cure. Cache-backed: repeated calls within the refresh window cost zero GitHub quota.",
+      inputSchema: {},
+      invoke: () => deps.deadendAudit(),
+    },
+  ];
+}

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -171,9 +171,14 @@ state survives resident restarts in `.red/state/castle/merge-driver.toon`.
 | --- | --- | --- |
 | `queue_status` | read | `ready-for-agent` and `ready-for-human` queue candidates. Optional `selector` previews one fleet's scoped view (same facets as fleet selectors, e.g. `tags`/`user`). |
 | `events_since` | read | Castle history events and worker lane records after an opaque cursor, plus the next cursor. |
+| `deadend_audit` | read | Every stuck AFK pattern with its recommended cure: dangling claims, red PRs with dead owners, superseded PRs, executable Tickets carrying an active Current blocker, dependency blocks whose `req:*` targets all closed, human-queue age outliers, and stale worktrees. Cache-backed — repeated calls within the refresh window cost zero GitHub quota. Detection only. |
 
 `queue_status` is the first call of any drain: an empty `ready-for-agent` queue
 with a non-empty open backlog is a flow bug to census, not a clean stop.
+
+`deadend_audit` is the census surface for that flow bug: it names each stuck
+pattern and the cure to apply, without mutating anything. The resident cron
+refreshes it and `/red-doctor` renders the same report.
 
 `events_since` is the incremental read surface: use it instead of re-calling
 `queue_status`, `worker_status`, or `fleet_status` on every polling tick. **Cost

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -171,9 +171,14 @@ state survives resident restarts in `.red/state/castle/merge-driver.toon`.
 | --- | --- | --- |
 | `queue_status` | read | `ready-for-agent` and `ready-for-human` queue candidates. Optional `selector` previews one fleet's scoped view (same facets as fleet selectors, e.g. `tags`/`user`). |
 | `events_since` | read | Castle history events and worker lane records after an opaque cursor, plus the next cursor. |
+| `deadend_audit` | read | Every stuck AFK pattern with its recommended cure: dangling claims, red PRs with dead owners, superseded PRs, executable Tickets carrying an active Current blocker, dependency blocks whose `req:*` targets all closed, human-queue age outliers, and stale worktrees. Cache-backed — repeated calls within the refresh window cost zero GitHub quota. Detection only. |
 
 `queue_status` is the first call of any drain: an empty `ready-for-agent` queue
 with a non-empty open backlog is a flow bug to census, not a clean stop.
+
+`deadend_audit` is the census surface for that flow bug: it names each stuck
+pattern and the cure to apply, without mutating anything. The resident cron
+refreshes it and `/red-doctor` renders the same report.
 
 `events_since` is the incremental read surface: use it instead of re-calling
 `queue_status`, `worker_status`, or `fleet_status` on every polling tick. **Cost


### PR DESCRIPTION
Automated AFK landing for #2428. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2428

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787420356&installation_model_id=20659&pr_number=2604&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2604&signature=d54b0a9d9e2172a67b0533730885d67abfe09dbf2e18a3b6ddd4ac44fb2316db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->