### PR TITLE
chore: #2429 Gated deadend healing: per-class opt-in allowlist over sanctioned cores

### DIFF
--- a/apps/dev/src/core/deadend-audit.ts
+++ b/apps/dev/src/core/deadend-audit.ts
@@ -106,6 +106,14 @@ export interface DeadendFinding {
   readonly subject: string;
   /** Human-readable evidence of why it is stuck. */
   readonly detail: string;
+  /**
+   * Numeric target for mechanical healing: the issue or PR number the sanctioned
+   * core should act on. Present for every mechanically-healable class; absent for
+   * non-mechanical ones (`human_queue_age_outlier`, `stale_worktree`).
+   * For `red_pr_dead_owner` this is the Ticket number (not the PR number) since
+   * the heal action requeues the Ticket.
+   */
+  readonly healTarget?: number;
 }
 
 /** The per-class roll-up the report always emits, even at count 0. */
@@ -168,6 +176,7 @@ function danglingClaims(inputs: DeadendAuditInputs, live: ReadonlySet<string>): 
       cure: CURE_BY_CLASS.dangling_claim,
       subject: `#${claim.issue}`,
       detail: `claim held by dead worker ${claim.worker}`,
+      healTarget: claim.issue,
     });
   }
   return findings;
@@ -184,6 +193,9 @@ function redPrsWithDeadOwners(inputs: DeadendAuditInputs, live: ReadonlySet<stri
       cure: CURE_BY_CLASS.red_pr_dead_owner,
       subject: `PR #${pr.number}`,
       detail: `failing checks with dead owner ${pr.owner}`,
+      // healTarget is the Ticket to requeue, not the PR; absent when the PR has
+      // no linked Ticket so the heal module safely skips it.
+      healTarget: pr.issue,
     });
   }
   return findings;
@@ -210,6 +222,7 @@ function supersededPrs(inputs: DeadendAuditInputs): DeadendFinding[] {
         cure: CURE_BY_CLASS.superseded_pr,
         subject: `PR #${pr.number}`,
         detail: `superseded by PR #${current.number} on Ticket #${issue}`,
+        healTarget: pr.number,
       });
     }
   }
@@ -226,6 +239,7 @@ function activeCurrentBlockers(inputs: DeadendAuditInputs): DeadendFinding[] {
       cure: CURE_BY_CLASS.active_current_blocker,
       subject: `#${issue.number}`,
       detail: "ready-for-agent Ticket carries an active Current blocker",
+      healTarget: issue.number,
     });
   }
   return findings;
@@ -244,6 +258,7 @@ function dependencyAllClosed(inputs: DeadendAuditInputs): DeadendFinding[] {
       cure: CURE_BY_CLASS.dependency_all_closed,
       subject: `#${issue.number}`,
       detail: `blocked:dependency with all req targets closed (${reqs.map((n) => `#${n}`).join(", ")})`,
+      healTarget: issue.number,
     });
   }
   return findings;

--- a/apps/dev/src/core/deadend-heal.ts
+++ b/apps/dev/src/core/deadend-heal.ts
@@ -1,0 +1,153 @@
+// deadend-heal.ts — gated per-class mechanical healing over sanctioned cores (#2429).
+//
+// The HEALABLE_CLASSES closed set names every deadend class that has a mechanical
+// cure path through one of three sanctioned mutation cores: hitl_resolve, requeue,
+// and concede. Nothing mutates until the repo config's allowlist opts a class in
+// (default-empty). Non-mechanical classes are excluded from HEALABLE_CLASSES and
+// can never be healed regardless of config.
+//
+// Each class's cure is pinned to exactly one core call sequence:
+//   dangling_claim        → concede(issue) then comment(issue, auditBody)
+//   red_pr_dead_owner     → hitlResolve(ticket, "requeue", auditBody)
+//   superseded_pr         → hitlResolve(prNumber, "close", auditBody)
+//   active_current_blocker → hitlResolve(issue, "park", auditBody)
+//   dependency_all_closed → requeue(issue, auditGuidance)
+
+import type { DeadendClass, DeadendFinding } from "./deadend-audit.js";
+import type { HitlDecision } from "./hitl-resolve.js";
+
+/** Classes that can be mechanically healed via a sanctioned mutation core. */
+export const HEALABLE_CLASSES = new Set<DeadendClass>([
+  "dangling_claim",
+  "red_pr_dead_owner",
+  "superseded_pr",
+  "active_current_blocker",
+  "dependency_all_closed",
+]);
+
+export type HealableClass = Extract<
+  DeadendClass,
+  | "dangling_claim"
+  | "red_pr_dead_owner"
+  | "superseded_pr"
+  | "active_current_blocker"
+  | "dependency_all_closed"
+>;
+
+/** Returns true iff the class has a mechanical cure path through a sanctioned core. */
+export function isHealable(cls: DeadendClass): cls is HealableClass {
+  return HEALABLE_CLASSES.has(cls);
+}
+
+/** The per-class heal allowlist parsed from the repo config. */
+export interface DeadendHealConfig {
+  /** Empty set = no healing permitted. Entries are restricted to HEALABLE_CLASSES. */
+  readonly allowedClasses: ReadonlySet<HealableClass>;
+}
+
+/** The default heal config: empty allowlist, zero mutations. */
+export const EMPTY_HEAL_CONFIG: DeadendHealConfig = { allowedClasses: new Set() };
+
+/** Thrown when an unknown class name appears in the config allowlist. */
+export class UnknownHealClassError extends Error {
+  constructor(name: string) {
+    super(
+      `unknown deadend heal class "${name}" — valid classes: ${[...HEALABLE_CLASSES].join(", ")}`,
+    );
+    this.name = "UnknownHealClassError";
+  }
+}
+
+/**
+ * Parse the comma-separated class allowlist from the config value.
+ *
+ * Config key: `afk.deadend.heal.allowed-classes` (default absent / empty).
+ * Empty or whitespace-only value returns {@link EMPTY_HEAL_CONFIG}.
+ * Any unrecognized name (including non-mechanical classes) throws
+ * {@link UnknownHealClassError} immediately — unknown names are rejected at
+ * load so the operator learns about the typo before the automation runs.
+ */
+export function parseDeadendHealConfig(value: string): DeadendHealConfig {
+  const trimmed = value.trim();
+  if (!trimmed) return EMPTY_HEAL_CONFIG;
+  const allowed = new Set<HealableClass>();
+  for (const raw of trimmed.split(",")) {
+    const name = raw.trim() as DeadendClass;
+    if (!HEALABLE_CLASSES.has(name)) throw new UnknownHealClassError(name);
+    allowed.add(name as HealableClass);
+  }
+  return { allowedClasses: allowed };
+}
+
+/**
+ * The three sanctioned mutation cores exposed to the heal module.
+ * No direct GitHub mutation is permitted — every write goes through one of these.
+ */
+export interface DeadendHealDeps {
+  /** hitl_resolve core: post rationale comment + label transition (+ optional close/claims). */
+  hitlResolve(issue: number, decision: HitlDecision, rationale: string): Promise<void>;
+  /** requeue core: apply the full parked-issue requeue transition with guidance. */
+  requeue(issue: number, guidance: string): Promise<void>;
+  /** concede core: release all dangling claim markers on the issue. */
+  concede(issue: number): Promise<void>;
+  /** Post an audit comment on the Ticket after a concede or requeue that has no built-in comment. */
+  comment(issue: number, body: string): Promise<void>;
+}
+
+function healAuditBody(cls: DeadendClass, detail: string): string {
+  return `🤖 deadend-heal: automated cure for **${cls}** — ${detail}`;
+}
+
+/**
+ * Apply the mechanical heal for one finding, subject to the allowlist.
+ *
+ * Returns without side effects when:
+ * - the class is not in HEALABLE_CLASSES (non-mechanical guard)
+ * - the class is not in the allowlist (opt-in gate)
+ * - the finding carries no healTarget (e.g. a red PR with no linked Ticket)
+ *
+ * Every successful heal posts an audit comment on the affected Ticket
+ * (either via the sanctioned core's built-in comment or an explicit call).
+ */
+export async function healDeadendFinding(
+  deps: DeadendHealDeps,
+  finding: DeadendFinding,
+  config: DeadendHealConfig,
+): Promise<void> {
+  // Non-mechanical guard: checked first so it holds even if allowedClasses is
+  // constructed outside parseDeadendHealConfig (defence in depth).
+  if (!isHealable(finding.deadendClass)) return;
+  if (!config.allowedClasses.has(finding.deadendClass)) return;
+
+  const target = finding.healTarget;
+  if (target === undefined) return;
+
+  const auditBody = healAuditBody(finding.deadendClass, finding.detail);
+
+  switch (finding.deadendClass) {
+    case "dangling_claim":
+      // concede → comment (concede does not post its own audit comment)
+      await deps.concede(target);
+      await deps.comment(target, auditBody);
+      break;
+
+    case "red_pr_dead_owner":
+      // hitl_resolve always posts the rationale as its own comment
+      await deps.hitlResolve(target, "requeue", auditBody);
+      break;
+
+    case "superseded_pr":
+      await deps.hitlResolve(target, "close", auditBody);
+      break;
+
+    case "active_current_blocker":
+      // quarantine = park to ready-for-human
+      await deps.hitlResolve(target, "park", auditBody);
+      break;
+
+    case "dependency_all_closed":
+      // requeue core posts guidance as the audit trail
+      await deps.requeue(target, auditBody);
+      break;
+  }
+}

--- a/apps/dev/tests/deadend-heal.test.ts
+++ b/apps/dev/tests/deadend-heal.test.ts
@@ -1,0 +1,338 @@
+// deadend-heal.test.ts — pins for gated per-class healing (#2429).
+//
+// Acceptance criteria:
+//   AC1. Default-empty allowlist performs ZERO mutations (mutation-recorder fake).
+//   AC2. Each allowlisted class pins its exact sanctioned-core call sequence + audit comment.
+//   AC3. Unknown class names in config are rejected loudly at load.
+//   AC4. Non-mechanical findings are never healable regardless of config.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  EMPTY_HEAL_CONFIG,
+  healDeadendFinding,
+  isHealable,
+  parseDeadendHealConfig,
+  UnknownHealClassError,
+  type DeadendHealDeps,
+} from "../src/core/deadend-heal.js";
+import type { DeadendFinding } from "../src/core/deadend-audit.js";
+
+function makeDeps(): {
+  deps: DeadendHealDeps;
+  callOrder: string[];
+} {
+  const callOrder: string[] = [];
+  const deps: DeadendHealDeps = {
+    hitlResolve: vi.fn(async () => {
+      callOrder.push("hitlResolve");
+    }),
+    requeue: vi.fn(async () => {
+      callOrder.push("requeue");
+    }),
+    concede: vi.fn(async () => {
+      callOrder.push("concede");
+    }),
+    comment: vi.fn(async () => {
+      callOrder.push("comment");
+    }),
+  };
+  return { deps, callOrder };
+}
+
+// ─── AC1: Default-empty allowlist → zero mutations ───────────────────────────
+
+describe("AC1: empty allowlist performs zero mutations", () => {
+  it("parseDeadendHealConfig empty/whitespace returns EMPTY_HEAL_CONFIG", () => {
+    expect(parseDeadendHealConfig("")).toEqual(EMPTY_HEAL_CONFIG);
+    expect(parseDeadendHealConfig("   ")).toEqual(EMPTY_HEAL_CONFIG);
+  });
+
+  it("EMPTY_HEAL_CONFIG fires no core call for any healable finding", async () => {
+    const { deps } = makeDeps();
+    const findings: DeadendFinding[] = [
+      {
+        deadendClass: "dangling_claim",
+        cure: "claim_release",
+        subject: "#100",
+        detail: "claim held by dead worker wDEAD",
+        healTarget: 100,
+      },
+      {
+        deadendClass: "red_pr_dead_owner",
+        cure: "retake",
+        subject: "PR #5",
+        detail: "failing checks with dead owner wDEAD",
+        healTarget: 200,
+      },
+      {
+        deadendClass: "superseded_pr",
+        cure: "close_superseded_pr",
+        subject: "PR #10",
+        detail: "superseded by PR #12 on Ticket #200",
+        healTarget: 10,
+      },
+      {
+        deadendClass: "active_current_blocker",
+        cure: "quarantine",
+        subject: "#300",
+        detail: "ready-for-agent Ticket carries an active Current blocker",
+        healTarget: 300,
+      },
+      {
+        deadendClass: "dependency_all_closed",
+        cure: "unblock_sweep",
+        subject: "#400",
+        detail: "blocked:dependency with all req targets closed (#10, #11)",
+        healTarget: 400,
+      },
+    ];
+
+    for (const finding of findings) {
+      await healDeadendFinding(deps, finding, EMPTY_HEAL_CONFIG);
+    }
+
+    expect(deps.hitlResolve).not.toHaveBeenCalled();
+    expect(deps.requeue).not.toHaveBeenCalled();
+    expect(deps.concede).not.toHaveBeenCalled();
+    expect(deps.comment).not.toHaveBeenCalled();
+  });
+});
+
+// ─── AC2: Per-class pinned call sequences ────────────────────────────────────
+
+describe("AC2: each allowlisted class pins its exact sanctioned-core call sequence", () => {
+  it("dangling_claim: concede(issue) THEN comment(issue, body-containing-class)", async () => {
+    const { deps, callOrder } = makeDeps();
+    const finding: DeadendFinding = {
+      deadendClass: "dangling_claim",
+      cure: "claim_release",
+      subject: "#100",
+      detail: "claim held by dead worker wDEAD",
+      healTarget: 100,
+    };
+    await healDeadendFinding(deps, finding, parseDeadendHealConfig("dangling_claim"));
+
+    expect(deps.concede).toHaveBeenCalledTimes(1);
+    expect(deps.concede).toHaveBeenCalledWith(100);
+    expect(deps.comment).toHaveBeenCalledTimes(1);
+    expect(deps.comment).toHaveBeenCalledWith(100, expect.stringContaining("dangling_claim"));
+    // Audit comment must reference the detail so the reader has context
+    expect(String((deps.comment as ReturnType<typeof vi.fn>).mock.calls[0]![1])).toContain(
+      "wDEAD",
+    );
+    // Order: concede fires before comment
+    expect(callOrder).toEqual(["concede", "comment"]);
+    expect(deps.hitlResolve).not.toHaveBeenCalled();
+    expect(deps.requeue).not.toHaveBeenCalled();
+  });
+
+  it("red_pr_dead_owner: hitlResolve(ticket, 'requeue', body) — no other cores", async () => {
+    const { deps } = makeDeps();
+    const finding: DeadendFinding = {
+      deadendClass: "red_pr_dead_owner",
+      cure: "retake",
+      subject: "PR #5",
+      detail: "failing checks with dead owner wDEAD",
+      healTarget: 200, // Ticket #200, not the PR
+    };
+    await healDeadendFinding(deps, finding, parseDeadendHealConfig("red_pr_dead_owner"));
+
+    expect(deps.hitlResolve).toHaveBeenCalledTimes(1);
+    expect(deps.hitlResolve).toHaveBeenCalledWith(
+      200,
+      "requeue",
+      expect.stringContaining("red_pr_dead_owner"),
+    );
+    expect(deps.concede).not.toHaveBeenCalled();
+    expect(deps.requeue).not.toHaveBeenCalled();
+    expect(deps.comment).not.toHaveBeenCalled();
+  });
+
+  it("red_pr_dead_owner with no linked Ticket (healTarget absent): no-op", async () => {
+    const { deps } = makeDeps();
+    const finding: DeadendFinding = {
+      deadendClass: "red_pr_dead_owner",
+      cure: "retake",
+      subject: "PR #7",
+      detail: "failing checks with dead owner wDEAD",
+      // healTarget absent — PR has no linked Ticket
+    };
+    await healDeadendFinding(deps, finding, parseDeadendHealConfig("red_pr_dead_owner"));
+
+    expect(deps.hitlResolve).not.toHaveBeenCalled();
+  });
+
+  it("superseded_pr: hitlResolve(prNumber, 'close', body) — no other cores", async () => {
+    const { deps } = makeDeps();
+    const finding: DeadendFinding = {
+      deadendClass: "superseded_pr",
+      cure: "close_superseded_pr",
+      subject: "PR #10",
+      detail: "superseded by PR #12 on Ticket #200",
+      healTarget: 10,
+    };
+    await healDeadendFinding(deps, finding, parseDeadendHealConfig("superseded_pr"));
+
+    expect(deps.hitlResolve).toHaveBeenCalledTimes(1);
+    expect(deps.hitlResolve).toHaveBeenCalledWith(
+      10,
+      "close",
+      expect.stringContaining("superseded_pr"),
+    );
+    expect(deps.concede).not.toHaveBeenCalled();
+    expect(deps.requeue).not.toHaveBeenCalled();
+    expect(deps.comment).not.toHaveBeenCalled();
+  });
+
+  it("active_current_blocker: hitlResolve(issue, 'park', body) — no other cores", async () => {
+    const { deps } = makeDeps();
+    const finding: DeadendFinding = {
+      deadendClass: "active_current_blocker",
+      cure: "quarantine",
+      subject: "#300",
+      detail: "ready-for-agent Ticket carries an active Current blocker",
+      healTarget: 300,
+    };
+    await healDeadendFinding(deps, finding, parseDeadendHealConfig("active_current_blocker"));
+
+    expect(deps.hitlResolve).toHaveBeenCalledTimes(1);
+    expect(deps.hitlResolve).toHaveBeenCalledWith(
+      300,
+      "park",
+      expect.stringContaining("active_current_blocker"),
+    );
+    expect(deps.concede).not.toHaveBeenCalled();
+    expect(deps.requeue).not.toHaveBeenCalled();
+    expect(deps.comment).not.toHaveBeenCalled();
+  });
+
+  it("dependency_all_closed: requeue(issue, guidance-containing-class) — no other cores", async () => {
+    const { deps } = makeDeps();
+    const finding: DeadendFinding = {
+      deadendClass: "dependency_all_closed",
+      cure: "unblock_sweep",
+      subject: "#400",
+      detail: "blocked:dependency with all req targets closed (#10, #11)",
+      healTarget: 400,
+    };
+    await healDeadendFinding(deps, finding, parseDeadendHealConfig("dependency_all_closed"));
+
+    expect(deps.requeue).toHaveBeenCalledTimes(1);
+    expect(deps.requeue).toHaveBeenCalledWith(400, expect.stringContaining("dependency_all_closed"));
+    expect(deps.hitlResolve).not.toHaveBeenCalled();
+    expect(deps.concede).not.toHaveBeenCalled();
+    expect(deps.comment).not.toHaveBeenCalled();
+  });
+
+  it("only the allowlisted class fires; others are skipped", async () => {
+    const { deps } = makeDeps();
+    const config = parseDeadendHealConfig("superseded_pr");
+
+    const superseded: DeadendFinding = {
+      deadendClass: "superseded_pr",
+      cure: "close_superseded_pr",
+      subject: "PR #10",
+      detail: "superseded by PR #12 on Ticket #200",
+      healTarget: 10,
+    };
+    const dangling: DeadendFinding = {
+      deadendClass: "dangling_claim",
+      cure: "claim_release",
+      subject: "#100",
+      detail: "claim held by dead worker wDEAD",
+      healTarget: 100,
+    };
+
+    await healDeadendFinding(deps, superseded, config);
+    await healDeadendFinding(deps, dangling, config);
+
+    expect(deps.hitlResolve).toHaveBeenCalledTimes(1);
+    expect(deps.concede).not.toHaveBeenCalled();
+  });
+});
+
+// ─── AC3: Unknown class names rejected at load ────────────────────────────────
+
+describe("AC3: unknown class names rejected loudly at load", () => {
+  it("throws UnknownHealClassError for an unrecognized name", () => {
+    expect(() => parseDeadendHealConfig("unknown_class")).toThrow(UnknownHealClassError);
+    expect(() => parseDeadendHealConfig("unknown_class")).toThrow("unknown_class");
+  });
+
+  it("non-mechanical class names are also rejected (not in HEALABLE_CLASSES)", () => {
+    expect(() => parseDeadendHealConfig("human_queue_age_outlier")).toThrow(UnknownHealClassError);
+    expect(() => parseDeadendHealConfig("stale_worktree")).toThrow(UnknownHealClassError);
+  });
+
+  it("rejects on the first invalid name in a multi-class list", () => {
+    expect(() => parseDeadendHealConfig("dangling_claim,invalid,superseded_pr")).toThrow(
+      UnknownHealClassError,
+    );
+  });
+
+  it("accepts all valid healable class names in one list", () => {
+    expect(() =>
+      parseDeadendHealConfig(
+        "dangling_claim,red_pr_dead_owner,superseded_pr,active_current_blocker,dependency_all_closed",
+      ),
+    ).not.toThrow();
+  });
+});
+
+// ─── AC4: Non-mechanical findings never healable ──────────────────────────────
+
+describe("AC4: non-mechanical findings never healable regardless of config", () => {
+  it("isHealable returns false for non-mechanical classes", () => {
+    expect(isHealable("human_queue_age_outlier")).toBe(false);
+    expect(isHealable("stale_worktree")).toBe(false);
+  });
+
+  it("isHealable returns true for every mechanical class", () => {
+    expect(isHealable("dangling_claim")).toBe(true);
+    expect(isHealable("red_pr_dead_owner")).toBe(true);
+    expect(isHealable("superseded_pr")).toBe(true);
+    expect(isHealable("active_current_blocker")).toBe(true);
+    expect(isHealable("dependency_all_closed")).toBe(true);
+  });
+
+  it("human_queue_age_outlier: no-op even when config is forced to include it", async () => {
+    const { deps } = makeDeps();
+    const finding: DeadendFinding = {
+      deadendClass: "human_queue_age_outlier",
+      cure: "hitl_review",
+      subject: "#500",
+      detail: "ready-for-human for 72h, past the age threshold",
+    };
+    // Bypass parseDeadendHealConfig to test the runtime non-mechanical guard
+    const forcedConfig = {
+      allowedClasses: new Set(["human_queue_age_outlier"]) as unknown as ReadonlySet<
+        "dangling_claim"
+      >,
+    };
+    await healDeadendFinding(deps, finding, forcedConfig);
+
+    expect(deps.hitlResolve).not.toHaveBeenCalled();
+    expect(deps.requeue).not.toHaveBeenCalled();
+    expect(deps.concede).not.toHaveBeenCalled();
+    expect(deps.comment).not.toHaveBeenCalled();
+  });
+
+  it("stale_worktree: no-op even when config is forced to include it", async () => {
+    const { deps } = makeDeps();
+    const finding: DeadendFinding = {
+      deadendClass: "stale_worktree",
+      cure: "worktree_remove",
+      subject: ".red/tmp/worktrees/feedback/dead",
+      detail: "stale feedback worktree with no live owner",
+    };
+    const forcedConfig = {
+      allowedClasses: new Set(["stale_worktree"]) as unknown as ReadonlySet<"dangling_claim">,
+    };
+    await healDeadendFinding(deps, finding, forcedConfig);
+
+    expect(deps.hitlResolve).not.toHaveBeenCalled();
+    expect(deps.requeue).not.toHaveBeenCalled();
+    expect(deps.concede).not.toHaveBeenCalled();
+    expect(deps.comment).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2429. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2429

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787422312&installation_model_id=20659&pr_number=2605&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2605&signature=d96527f449554f9a831e95c418e88d020cf40985cab003e635e04c7fd79fad18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->