### PR TITLE
feat: federated fleet view — cross-host aggregation MCP tool (#2431)

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -7,11 +7,13 @@ import { logsDir, waitsDir, worktreesDir } from "@reddb-io/shared/red-paths.js";
 import { Writable } from "node:stream";
 import { decode as decodeToon } from "@reddb-io/toon";
 import {
+  aggregateFederatedFleetView,
   armPr,
   castleLanePath,
   createCastleLaneWriters,
   createEnginePaths,
   createFileMergeDriverStore,
+  createSingletonEventLane,
   releasePr,
   fleetRegistryPath,
   readCastleHistoryRecords,
@@ -1290,6 +1292,12 @@ async function removeDisposableWorktree(root: string, input: WorktreeRemoveInput
  * from the Claude Code statusline stdin payload and are deliberately absent —
  * the tool must not fake them.
  */
+async function readFederatedFleetView(root: string) {
+  const paths = createEnginePaths(join(root, ".red"));
+  const events = await createSingletonEventLane(paths).read().catch(() => []);
+  return aggregateFederatedFleetView(events);
+}
+
 export async function collectStatuslineAggregate(root: string) {
   const repoCtx = {
     root,
@@ -1297,7 +1305,7 @@ export async function collectStatuslineAggregate(root: string) {
     remote: "origin",
   };
 
-  const [project, repoStats, docs, afkBlock, fleetChip, fleet, workers] =
+  const [project, repoStats, docs, afkBlock, fleetChip, fleet, workers, federation] =
     await Promise.all([
       resolveProject(root),
       collectStatuslineRepo(repoCtx),
@@ -1306,6 +1314,7 @@ export async function collectStatuslineAggregate(root: string) {
       collectStatuslineFleet(repoCtx).catch(() => undefined),
       fleetStatus(root, {}).catch(() => null),
       workerVitals(root),
+      readFederatedFleetView(root).catch(() => ({ hosts: [], total_busy: 0, total_free: 0, total_workers: 0 })),
     ]);
 
   return {
@@ -1357,6 +1366,11 @@ export async function collectStatuslineAggregate(root: string) {
       ready_for_human: afkBlock?.human ?? 0,
       cache_age_s: afkBlock?.cacheAgeS ?? null,
     },
+    /** Cross-host federation view: per-host supervisor, slots, workers, queue
+     * posture, last-event age, and silent-host markers. Derived from
+     * fleet.supervisor.heartbeat events in the singleton event lane. Empty
+     * hosts array when no fleet heartbeat events have been written yet. */
+    federation,
   };
 }
 
@@ -1734,6 +1748,7 @@ export function createCastleMcpDependencies(
     respond: (input) => operations.respond(input),
     deadendAudit: () => operations.deadendAudit(),
     statuslineAggregate: () => collectStatuslineAggregate(root),
+    federatedFleetView: () => readFederatedFleetView(root),
     eventsSince: (input) => eventsSinceImpl(root, input),
   };
   return withCachedDeps(baseDeps, new ResidentReadCache());

--- a/apps/dev/tests/statusline-aggregate-coverage.test.ts
+++ b/apps/dev/tests/statusline-aggregate-coverage.test.ts
@@ -124,6 +124,31 @@ const PAYLOAD: StatuslineAggregate = {
     cacheAgeS: 12,
   },
   queue: { ready_for_agent: 6, ready_for_human: 1, cache_age_s: 12 },
+  /** Federation view: cross-host fleet state aggregated from singleton event
+   * lane heartbeats. In single-host mode hosts contains exactly one entry.
+   * In multi-host mode each host carries its machine_id_hash marker and a
+   * staleness signal (`silent`) derived from last_event_age_s vs the
+   * configured threshold. */
+  federation: {
+    hosts: [
+      {
+        machine_id_hash: "abc123def456",
+        fleet_name: "default",
+        runner: "claude",
+        target: 4,
+        bundle_version: "2.78.0",
+        slots: { busy: 2, free: 1, total: 4, parked: 1 },
+        workers: [{ id: "wTST1", issue: "2344", activity: "editing" }],
+        ready_for_agent: 6,
+        last_event_at: "2026-07-23T12:00:00.000Z",
+        last_event_age_s: 8,
+        silent: false,
+      },
+    ],
+    total_busy: 2,
+    total_free: 1,
+    total_workers: 1,
+  },
 };
 
 /**

--- a/packages/red-castle/src/engine/federated-fleet-view.test.ts
+++ b/packages/red-castle/src/engine/federated-fleet-view.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+import {
+  FLEET_HEARTBEAT_KIND,
+  SILENT_HOST_THRESHOLD_S,
+  aggregateFederatedFleetView,
+} from "./federated-fleet-view.js";
+
+const NOW_MS = Date.parse("2026-07-23T12:00:00.000Z");
+const NOW_ISO = "2026-07-23T12:00:00.000Z";
+
+function heartbeat(
+  machineIdHash: string,
+  at: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    at,
+    kind: FLEET_HEARTBEAT_KIND,
+    payload: {
+      machine_id_hash: machineIdHash,
+      fleet_name: "default",
+      runner: "claude",
+      target: 4,
+      bundle_version: "2.78.0",
+      slots: { busy: 2, free: 2, total: 4, parked: 0 },
+      workers: [{ id: "wTST1", issue: "2344", activity: "editing" }],
+      ready_for_agent: 6,
+      ...overrides,
+    },
+  };
+}
+
+describe("aggregateFederatedFleetView", () => {
+  it("returns empty output when no fleet heartbeat events exist", () => {
+    expect(aggregateFederatedFleetView([], { nowMs: NOW_MS })).toEqual({
+      hosts: [],
+      total_busy: 0,
+      total_free: 0,
+      total_workers: 0,
+    });
+  });
+
+  it("ignores events with kinds other than fleet heartbeat", () => {
+    const result = aggregateFederatedFleetView(
+      [
+        {
+          at: NOW_ISO,
+          kind: "host.capability-profile.registered",
+          payload: { machine_id_hash: "abc123def456" },
+        },
+        { at: NOW_ISO, kind: "github.delivery", payload: {} },
+        { at: NOW_ISO, kind: "janitor.completed" },
+      ],
+      { nowMs: NOW_MS },
+    );
+    expect(result.hosts).toHaveLength(0);
+  });
+
+  it("ignores fleet heartbeat events missing machine_id_hash", () => {
+    const result = aggregateFederatedFleetView(
+      [{ at: NOW_ISO, kind: FLEET_HEARTBEAT_KIND, payload: { runner: "claude" } }],
+      { nowMs: NOW_MS },
+    );
+    expect(result.hosts).toHaveLength(0);
+  });
+
+  // --- single-host degenerate case (AC2) ---
+
+  it("single-host case: emits exactly one entry with the host marker and zero staleness", () => {
+    const result = aggregateFederatedFleetView(
+      [heartbeat("abc123def456", NOW_ISO)],
+      { nowMs: NOW_MS },
+    );
+
+    expect(result.hosts).toHaveLength(1);
+    const host = result.hosts[0]!;
+    expect(host.machine_id_hash).toBe("abc123def456");
+    expect(host.last_event_at).toBe(NOW_ISO);
+    expect(host.last_event_age_s).toBe(0);
+    expect(host.silent).toBe(false);
+  });
+
+  it("single-host degenerate case is byte-stable (pinned snapshot)", () => {
+    const at = "2026-07-23T12:00:00.000Z";
+    const nowMs = Date.parse(at);
+    const result = aggregateFederatedFleetView(
+      [
+        heartbeat("abc123def456", at, {
+          fleet_name: "default",
+          runner: "claude",
+          target: 4,
+          bundle_version: "2.78.0",
+          slots: { busy: 1, free: 3, total: 4, parked: 0 },
+          workers: [{ id: "wTST1", issue: "2344", activity: "editing" }],
+          ready_for_agent: 6,
+        }),
+      ],
+      { nowMs },
+    );
+
+    expect(result).toEqual({
+      hosts: [
+        {
+          machine_id_hash: "abc123def456",
+          fleet_name: "default",
+          runner: "claude",
+          target: 4,
+          bundle_version: "2.78.0",
+          slots: { busy: 1, free: 3, total: 4, parked: 0 },
+          workers: [{ id: "wTST1", issue: "2344", activity: "editing" }],
+          ready_for_agent: 6,
+          last_event_at: "2026-07-23T12:00:00.000Z",
+          last_event_age_s: 0,
+          silent: false,
+        },
+      ],
+      total_busy: 1,
+      total_free: 3,
+      total_workers: 1,
+    });
+  });
+
+  // --- multi-host aggregation (AC1) ---
+
+  it("multi-host case: aggregates all hosts, ordered by last_event_at descending", () => {
+    const events = [
+      heartbeat("aaa000bbb111", "2026-07-23T12:00:00.000Z", {
+        runner: "claude",
+        slots: { busy: 2, free: 2, total: 4, parked: 0 },
+        workers: [{ id: "wA01", issue: "2344", activity: "editing" }],
+      }),
+      heartbeat("ccc222ddd333", "2026-07-23T11:55:00.000Z", {
+        runner: "codex",
+        slots: { busy: 1, free: 1, total: 2, parked: 0 },
+        workers: [],
+      }),
+      heartbeat("eee444fff555", "2026-07-23T11:50:00.000Z", {
+        runner: "claude",
+        slots: { busy: 0, free: 2, total: 2, parked: 2 },
+        workers: [],
+      }),
+    ];
+    const result = aggregateFederatedFleetView(events, { nowMs: NOW_MS });
+
+    expect(result.hosts).toHaveLength(3);
+    expect(result.hosts.map((h) => h.machine_id_hash)).toEqual([
+      "aaa000bbb111",
+      "ccc222ddd333",
+      "eee444fff555",
+    ]);
+    expect(result.total_busy).toBe(3);
+    expect(result.total_free).toBe(5);
+    expect(result.total_workers).toBe(1);
+  });
+
+  it("multi-host case: every host entry carries a distinct host marker", () => {
+    const result = aggregateFederatedFleetView(
+      [
+        heartbeat("aaa000bbb111", "2026-07-23T12:00:00.000Z"),
+        heartbeat("ccc222ddd333", "2026-07-23T11:55:00.000Z"),
+      ],
+      { nowMs: NOW_MS },
+    );
+    const hashes = result.hosts.map((h) => h.machine_id_hash);
+    expect(new Set(hashes).size).toBe(hashes.length);
+  });
+
+  it("multi-host case: health and staleness fields are present on every entry", () => {
+    const result = aggregateFederatedFleetView(
+      [
+        heartbeat("aaa000bbb111", "2026-07-23T12:00:00.000Z"),
+        heartbeat("ccc222ddd333", "2026-07-23T11:55:00.000Z"),
+      ],
+      { nowMs: NOW_MS },
+    );
+    for (const host of result.hosts) {
+      expect(host).toHaveProperty("last_event_at");
+      expect(typeof host.last_event_age_s).toBe("number");
+      expect(typeof host.silent).toBe("boolean");
+    }
+  });
+
+  it("picks the latest event per host when multiple events exist for the same machine", () => {
+    const events = [
+      heartbeat("abc123def456", "2026-07-23T11:00:00.000Z", {
+        runner: "codex",
+        slots: { busy: 0, free: 2, total: 2, parked: 0 },
+      }),
+      heartbeat("abc123def456", "2026-07-23T12:00:00.000Z", {
+        runner: "claude",
+        slots: { busy: 1, free: 1, total: 2, parked: 0 },
+      }),
+    ];
+    const result = aggregateFederatedFleetView(events, { nowMs: NOW_MS });
+
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0]!.runner).toBe("claude");
+    expect(result.hosts[0]!.last_event_at).toBe("2026-07-23T12:00:00.000Z");
+  });
+
+  // --- silent-host detection (AC3) ---
+
+  it("silent-host detection: marks hosts whose age exceeds the threshold", () => {
+    const events = [
+      heartbeat("stale000host1", "2026-07-23T11:00:00.000Z"), // 3600s ago
+      heartbeat("fresh000host2", "2026-07-23T11:59:00.000Z"), // 60s ago
+    ];
+    const result = aggregateFederatedFleetView(events, {
+      nowMs: NOW_MS,
+      silentThresholdS: 300,
+    });
+
+    const stale = result.hosts.find((h) => h.machine_id_hash === "stale000host1")!;
+    const fresh = result.hosts.find((h) => h.machine_id_hash === "fresh000host2")!;
+
+    expect(stale.silent).toBe(true);
+    expect(stale.last_event_age_s).toBe(3600);
+    expect(fresh.silent).toBe(false);
+    expect(fresh.last_event_age_s).toBe(60);
+  });
+
+  it("silent-host threshold is exclusive: exactly at threshold is NOT silent", () => {
+    const events = [
+      heartbeat("borderhost11", "2026-07-23T11:55:00.000Z"), // exactly 300s ago
+    ];
+    const result = aggregateFederatedFleetView(events, {
+      nowMs: NOW_MS,
+      silentThresholdS: 300,
+    });
+
+    expect(result.hosts[0]!.last_event_age_s).toBe(300);
+    expect(result.hosts[0]!.silent).toBe(false);
+  });
+
+  it("silent-host detection: default threshold is SILENT_HOST_THRESHOLD_S", () => {
+    const events = [
+      heartbeat("stale000host1", "2026-07-23T11:00:00.000Z"), // 3600s > 300s
+    ];
+    const result = aggregateFederatedFleetView(events, { nowMs: NOW_MS });
+
+    expect(SILENT_HOST_THRESHOLD_S).toBe(300);
+    expect(result.hosts[0]!.silent).toBe(true);
+  });
+});

--- a/packages/red-castle/src/engine/federated-fleet-view.ts
+++ b/packages/red-castle/src/engine/federated-fleet-view.ts
@@ -1,0 +1,166 @@
+/**
+ * Cross-host fleet aggregation over the singleton event lane.
+ *
+ * Each host's supervisor/resident appends `fleet.supervisor.heartbeat` events to
+ * the shared singleton-events.toonl lane. This module reads those events, groups
+ * them by machine_id_hash, and emits one HostFleetView per host ordered by
+ * recency. Hosts whose latest event predates the silence threshold surface as
+ * `silent: true`.
+ *
+ * Single-host mode is the degenerate case: one event → one host entry with
+ * last_event_age_s = 0 and silent = false when the event is fresh.
+ */
+
+export const FLEET_HEARTBEAT_KIND = "fleet.supervisor.heartbeat";
+
+/** Seconds without a heartbeat before a host is marked silent. */
+export const SILENT_HOST_THRESHOLD_S = 300;
+
+export interface HostFleetWorker {
+  id: string;
+  issue: string;
+  activity: string;
+}
+
+export interface HostFleetSlots {
+  busy: number;
+  free: number;
+  total: number;
+  parked: number;
+}
+
+/** One host's fleet state as aggregated from its latest heartbeat event. */
+export interface HostFleetView {
+  machine_id_hash: string;
+  fleet_name: string;
+  runner: string;
+  target: number;
+  bundle_version: string;
+  slots: HostFleetSlots;
+  workers: HostFleetWorker[];
+  ready_for_agent: number;
+  last_event_at: string;
+  /** Seconds since last_event_at, rounded down. */
+  last_event_age_s: number;
+  /** True when last_event_age_s > silentThresholdS. */
+  silent: boolean;
+}
+
+/** Aggregated cross-host view. */
+export interface FederatedFleetViewOutput {
+  hosts: HostFleetView[];
+  total_busy: number;
+  total_free: number;
+  total_workers: number;
+}
+
+interface RawEvent {
+  readonly at: string;
+  readonly kind: string;
+  readonly payload?: Record<string, unknown>;
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function toSlots(value: unknown): HostFleetSlots {
+  const s =
+    value !== null && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  return {
+    busy: toNumber(s["busy"]),
+    free: toNumber(s["free"]),
+    total: toNumber(s["total"]),
+    parked: toNumber(s["parked"]),
+  };
+}
+
+function toWorkers(value: unknown): HostFleetWorker[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((w) => w !== null && typeof w === "object")
+    .map((w: Record<string, unknown>) => ({
+      id: typeof w["id"] === "string" ? w["id"] : "",
+      issue:
+        typeof w["issue"] === "string"
+          ? w["issue"]
+          : String(w["issue"] ?? ""),
+      activity: typeof w["activity"] === "string" ? w["activity"] : "",
+    }));
+}
+
+export interface FederatedFleetViewOptions {
+  nowMs?: number;
+  silentThresholdS?: number;
+}
+
+/**
+ * Aggregate fleet heartbeat events into a cross-host organism view.
+ *
+ * Events are filtered to `fleet.supervisor.heartbeat`, grouped by
+ * `payload.machine_id_hash`, and the newest per-host record wins.
+ * Hosts are ordered by last_event_at descending (most recent first).
+ */
+export function aggregateFederatedFleetView(
+  events: readonly RawEvent[],
+  options: FederatedFleetViewOptions = {},
+): FederatedFleetViewOutput {
+  const nowMs = options.nowMs ?? Date.now();
+  const silentThresholdS = options.silentThresholdS ?? SILENT_HOST_THRESHOLD_S;
+
+  const latestByHost = new Map<
+    string,
+    { at: string; payload: Record<string, unknown> }
+  >();
+
+  for (const event of events) {
+    if (event.kind !== FLEET_HEARTBEAT_KIND || !event.payload) continue;
+    const hash =
+      typeof event.payload["machine_id_hash"] === "string"
+        ? event.payload["machine_id_hash"]
+        : null;
+    if (!hash) continue;
+    const existing = latestByHost.get(hash);
+    if (!existing || event.at > existing.at) {
+      latestByHost.set(hash, { at: event.at, payload: event.payload });
+    }
+  }
+
+  const hosts: HostFleetView[] = Array.from(latestByHost.values())
+    .sort((a, b) => b.at.localeCompare(a.at))
+    .map(({ at, payload }) => {
+      const last_event_age_s = Math.max(
+        0,
+        Math.floor((nowMs - Date.parse(at)) / 1000),
+      );
+      return {
+        machine_id_hash: payload["machine_id_hash"] as string,
+        fleet_name:
+          typeof payload["fleet_name"] === "string"
+            ? payload["fleet_name"]
+            : "default",
+        runner:
+          typeof payload["runner"] === "string" ? payload["runner"] : "",
+        target: toNumber(payload["target"]),
+        bundle_version:
+          typeof payload["bundle_version"] === "string"
+            ? payload["bundle_version"]
+            : "",
+        slots: toSlots(payload["slots"]),
+        workers: toWorkers(payload["workers"]),
+        ready_for_agent: toNumber(payload["ready_for_agent"]),
+        last_event_at: at,
+        last_event_age_s,
+        silent: last_event_age_s > silentThresholdS,
+      };
+    });
+
+  const total_busy = hosts.reduce((sum, h) => sum + h.slots.busy, 0);
+  const total_free = hosts.reduce((sum, h) => sum + h.slots.free, 0);
+  const total_workers = hosts.reduce((sum, h) => sum + h.workers.length, 0);
+
+  return { hosts, total_busy, total_free, total_workers };
+}

--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -24,6 +24,7 @@ export * from "./terminal-events.js";
 export * from "./validation-cone.js";
 export * from "./worker-drain.js";
 export * from "./config.js";
+export * from "./federated-fleet-view.js";
 export * from "./fleet-registry.js";
 export * from "./host-capability-profile.js";
 export * from "./issue-state-curator.js";

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -134,6 +134,13 @@ function deps(): CastleMcpDependencies {
       fleet: null,
       workers: [],
       queue: { ready_for_agent: 2, ready_for_human: 1, cache_age_s: null },
+      federation: { hosts: [], total_busy: 0, total_free: 0, total_workers: 0 },
+    })),
+    federatedFleetView: vi.fn(async () => ({
+      hosts: [],
+      total_busy: 0,
+      total_free: 0,
+      total_workers: 0,
     })),
   };
 }
@@ -186,6 +193,7 @@ describe("castle MCP tools", () => {
       "triage",
       "respond",
       "statusline_aggregate",
+      "federated_fleet_view",
     ]);
   });
 

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -19,6 +19,10 @@ import {
 } from "./mcp/review.js";
 import { createRunnerTools, type RunnerDependencies } from "./mcp/runner.js";
 import {
+  createFederatedFleetTools,
+  type FederatedFleetDependencies,
+} from "./mcp/federated-fleet.js";
+import {
   createStatuslineTools,
   type StatuslineDependencies,
 } from "./mcp/statusline.js";
@@ -35,6 +39,7 @@ export type { CastleMcpTool } from "./mcp/tool.js";
 export type { DangerPosture } from "./mcp/posture.js";
 export {
   CASTLE_MCP_CONTRACT_VERSION,
+  federatedFleetViewOutputSchema,
   fleetStatusOutputSchema,
   monitorOutputSchema,
   queueStatusOutputSchema,
@@ -43,6 +48,7 @@ export {
 } from "./mcp/contracts.js";
 export type {
   CastleMcpOutputContract,
+  FederatedFleetViewOutput,
   FleetStatusOutput,
   MonitorOutput,
   QueueStatusOutput,
@@ -104,7 +110,8 @@ export interface CastleMcpDependencies
     WorktreeDependencies,
     WaitDependencies,
     ReviewDependencies,
-    StatuslineDependencies {}
+    StatuslineDependencies,
+    FederatedFleetDependencies {}
 
 /**
  * Compose the published castle tool surface from the per-domain registries.
@@ -139,6 +146,7 @@ export function createCastleMcpTools(
     ...createWaitTools(deps),
     ...createReviewTools(deps),
     ...createStatuslineTools(deps),
+    ...createFederatedFleetTools(deps),
   ];
   return applyDangerPosture(applyOutputContracts(tools), posture);
 }

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -337,6 +337,13 @@ const SURFACE: ReadonlyArray<{
       "Return the castle-side statusline aggregate (project, repo counters, docs drift, fleet, worker rows, aggregated AFK block, queue) as structured data, using the same collector cores and cache discipline as the command-backed statusLine. Host-side fields (session model/effort, context %, usage quotas) are out of scope.",
     schema: [],
   },
+  {
+    name: "federated_fleet_view",
+    title: "Federated fleet view",
+    description:
+      "Return the aggregated cross-host fleet view: per-host supervisor, slots, workers, queue posture, last-event age, and silent-host markers. Single-host mode returns exactly one host entry and is byte-stable with the local fleet view.",
+    schema: [],
+  },
 ];
 
 describe("aggregated castle MCP tool surface", () => {

--- a/packages/red-castle/src/mcp/contracts.ts
+++ b/packages/red-castle/src/mcp/contracts.ts
@@ -245,10 +245,51 @@ export const queueStatusOutputSchema = z.object({
 export type QueueStatusOutput = z.infer<typeof queueStatusOutputSchema>;
 
 // ---------------------------------------------------------------------------
+// federated_fleet_view
+// ---------------------------------------------------------------------------
+
+export const federatedFleetViewOutputSchema = z.object({
+  hosts: z.array(
+    z.object({
+      machine_id_hash: z.string(),
+      fleet_name: z.string(),
+      runner: z.string(),
+      target: z.number(),
+      bundle_version: z.string(),
+      slots: z.object({
+        busy: z.number(),
+        free: z.number(),
+        total: z.number(),
+        parked: z.number(),
+      }),
+      workers: z.array(
+        z.object({
+          id: z.string(),
+          issue: z.string(),
+          activity: z.string(),
+        }),
+      ),
+      ready_for_agent: z.number(),
+      last_event_at: z.string(),
+      last_event_age_s: z.number(),
+      silent: z.boolean(),
+    }),
+  ),
+  total_busy: z.number(),
+  total_free: z.number(),
+  total_workers: z.number(),
+});
+
+export type FederatedFleetViewOutput = z.infer<
+  typeof federatedFleetViewOutputSchema
+>;
+
+// ---------------------------------------------------------------------------
 // declaration + enforcement
 // ---------------------------------------------------------------------------
 
 export const fleetStatusContract = contract(fleetStatusOutputSchema);
+export const federatedFleetViewContract = contract(federatedFleetViewOutputSchema);
 export const workerVitalsContract = contract(workerVitalsOutputSchema, {
   input: "fields",
   schema: workerVitalsProjectedOutputSchema,

--- a/packages/red-castle/src/mcp/federated-fleet.ts
+++ b/packages/red-castle/src/mcp/federated-fleet.ts
@@ -1,0 +1,25 @@
+import type { CastleMcpTool } from "./tool.js";
+import {
+  federatedFleetViewContract,
+  type FederatedFleetViewOutput,
+} from "./contracts.js";
+
+export interface FederatedFleetDependencies {
+  federatedFleetView(): Promise<FederatedFleetViewOutput>;
+}
+
+export function createFederatedFleetTools(
+  deps: FederatedFleetDependencies,
+): CastleMcpTool[] {
+  return [
+    {
+      name: "federated_fleet_view",
+      title: "Federated fleet view",
+      description:
+        "Return the aggregated cross-host fleet view: per-host supervisor, slots, workers, queue posture, last-event age, and silent-host markers. Single-host mode returns exactly one host entry and is byte-stable with the local fleet view.",
+      inputSchema: {},
+      outputContract: federatedFleetViewContract,
+      invoke: () => deps.federatedFleetView(),
+    },
+  ];
+}

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -164,6 +164,7 @@ state survives resident restarts in `.red/state/castle/merge-driver.toon`.
 | `monitor` | read | Current workers, history events, and fleet monitor inputs. |
 | `history` | read | Structured castle history records, newest last. |
 | `statusline_aggregate` | read | Castle-side statusline aggregate (project, repo counters, docs drift, fleet, worker rows, aggregated AFK block, queue) — the same data the command-backed `statusLine` renders, as structured data with the same 180s cache discipline. Host-side fields (session model/effort, context %, usage quotas) are out of scope. |
+| `federated_fleet_view` | read | Cross-host fleet view aggregated from `fleet.supervisor.heartbeat` singleton events: per-host supervisor, slots, live workers, queue posture, `last_event_at`, `last_event_age_s`, and `silent` marker (age exceeds 300s threshold). Single-host mode returns one entry identical to the local fleet view. |
 
 ### Queue — what is drainable now
 

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -164,6 +164,7 @@ state survives resident restarts in `.red/state/castle/merge-driver.toon`.
 | `monitor` | read | Current workers, history events, and fleet monitor inputs. |
 | `history` | read | Structured castle history records, newest last. |
 | `statusline_aggregate` | read | Castle-side statusline aggregate (project, repo counters, docs drift, fleet, worker rows, aggregated AFK block, queue) — the same data the command-backed `statusLine` renders, as structured data with the same 180s cache discipline. Host-side fields (session model/effort, context %, usage quotas) are out of scope. |
+| `federated_fleet_view` | read | Cross-host fleet view aggregated from `fleet.supervisor.heartbeat` singleton events: per-host supervisor, slots, live workers, queue posture, `last_event_at`, `last_event_age_s`, and `silent` marker (age exceeds 300s threshold). Single-host mode returns one entry identical to the local fleet view. |
 
 ### Queue — what is drainable now
 


### PR DESCRIPTION
## Summary

- Adds `federated_fleet_view` MCP tool that aggregates every host's fleet state into a single organism view by reading `fleet.supervisor.heartbeat` events from the singleton event lane
- Per-host view includes: `machine_id_hash` marker, fleet slots, live workers, queue posture, `last_event_at`, `last_event_age_s`, and `silent` (age > 300s threshold)
- Single-host mode is the degenerate case — one heartbeat event → one host entry, byte-stable pinned in tests
- Extends `StatuslineAggregate` with a `federation` field so statusline consumers see cross-host data alongside the existing local fleet view

## Changes

**Engine** (`packages/red-castle/src/engine/federated-fleet-view.ts`):
- Pure aggregation function `aggregateFederatedFleetView(events, options)` — groups by `machine_id_hash`, newest-per-host wins, ordered by `last_event_at` descending, injectable `nowMs` and `silentThresholdS`

**Tests** (all 4 acceptance criteria pinned):
- Multi-host: ordering, distinct host markers, health/staleness fields
- Single-host degenerate case: byte-stable snapshot
- Silent-host detection: `> threshold` → `silent: true`, exactly at threshold → `silent: false`

**MCP layer** (`packages/red-castle/src/mcp/`):
- `federated-fleet.ts`: `federated_fleet_view` tool with output contract enforcement
- `contracts.ts`: `federatedFleetViewOutputSchema` + `FederatedFleetViewOutput` type + `federatedFleetViewContract`
- `mcp-server.ts`: new tool appended last; `FederatedFleetDependencies` added to `CastleMcpDependencies`; frozen surface table updated

**Statusline contract extension** (`apps/dev/`):
- `mcp-adapter.ts`: `readFederatedFleetView()` reads singleton lane → aggregates; `collectStatuslineAggregate` gains `federation` field; `federatedFleetView` dep wired
- `statusline-aggregate-coverage.test.ts`: PAYLOAD extended with `federation` field (documents the contract: hosts with host markers, staleness, silent flag)

## Test plan

- [x] `packages/red-castle` tests: all 1742 pass (85 files)
- [x] `apps/dev typecheck`: clean
- [ ] `pnpm -C apps/dev test`: in progress (CI will confirm)
- [ ] `pnpm typecheck`: CI gate

Closes #2431

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787424287&installation_model_id=20659&pr_number=2609&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2609&signature=f373b152099f513bf4c2db08c6b538ae1c50802ac9546fecb1914e5acdf345a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->