### PR TITLE
fix: #2602 trust gate breaks /go and /go --scout on public repos: lane:go claims refused for missing ready-for-agent promoter

### DIFF
--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -312,11 +312,11 @@ export function buildProcessDeps(
       listByLabel: (label) => ghx.listByLabel(ghCtx, label),
       issueClosed: (n) => ghx.issueClosed(ghCtx, n),
       issueReference: (n) => ghx.issueReference(ghCtx, n),
-      // Trust-gate provenance (#621): author + ready-for-agent label actor, read
-      // from the issue timeline. Consulted at claim time only when an allowlist
-      // is configured (plugins.dev.afk.trust-gate.allowlist) or the repo fails
-      // closed (public + no allowlist, #1101).
-      issueTrust: (issue) => ghx.issueTrust(ghCtx, issue),
+      // Trust-gate provenance (#621): author + promoter label actor, read from the
+      // issue timeline. The promoter label is the LANE the claim was selected under
+      // (`ready-for-agent`, `lane:go`, `lane:scout`) so a /go/scout issue resolves its
+      // maintainer minter, not an absent `ready-for-agent` actor (#2602, #1101).
+      issueTrust: (issue, promoterLabel) => ghx.issueTrust(ghCtx, issue, promoterLabel),
       // Repository visibility (#1101): folds into the trust policy so a PUBLIC
       // repo with no allowlist fails closed while a private one stays permissive.
       repoVisibility: () => ghx.repoVisibility(ghCtx),

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -249,7 +249,11 @@ export async function processIssue(
   const trustPolicy = parseTrustPolicy(deps.hooks.config, visibility);
   let provenance: TrustProvenance | undefined;
   if (deps.gh.issueTrust) {
-    provenance = await deps.gh.issueTrust(issue);
+    // Resolve the promoter from the LANE label the issue was claimed under (#2602):
+    // `lane:go` / `lane:scout` issues never carry `ready-for-agent`, so the lane
+    // label's own applier is the promoter analog. For /afk, `laneLabel` is
+    // `ready-for-agent` — unchanged behaviour.
+    provenance = await deps.gh.issueTrust(issue, laneLabel);
   }
   const canFailClosed = !!(trustPolicy.failClosed && deps.gh.actorTrustSignals);
   if ((trustPolicy.enabled || canFailClosed) && provenance) {

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -134,7 +134,7 @@ export interface ProcessGh {
   listByLabel(label: string): Promise<{ number: number; labels: string[] }[]>;
   issueClosed(n: number): Promise<boolean>;
   issueReference?(issue: number): Promise<{ number: number; title?: string; url?: string } | undefined>;
-  issueTrust?(issue: number): Promise<TrustProvenance>;
+  issueTrust?(issue: number, promoterLabel?: string): Promise<TrustProvenance>;
   repoVisibility?(): Promise<RepoVisibility | undefined>;
   actorTrustSignals?(actor: string): Promise<ActorTrustSignals>;
   renderDecisionCard?(issue: number): Promise<void>;

--- a/apps/dev/src/runtime/gh/trust.ts
+++ b/apps/dev/src/runtime/gh/trust.ts
@@ -6,10 +6,18 @@ import { apiPath, repoArgs, runGh, type GhContext } from "./common.js";
 export async function issueTrust(
   ctx: GhContext,
   issue: number,
+  promoterLabel: string = LABEL_READY,
 ): Promise<{ author?: string; authorSourceTrust?: SourceTrustLevel; readyForAgentActor?: string }> {
+  // The PROMOTER label is the lane label the issue was selected under (#2602):
+  // `ready-for-agent` for the fleet, `lane:go` / `lane:scout` for the isolated
+  // /go/scout lanes. A lane:go/lane:scout issue never carries `ready-for-agent`
+  // (lane isolation is by design), so resolving the promoter from the lane
+  // label's own `labeled` event is what lets the trust gate see the maintainer
+  // who minted the dispatch — otherwise every /go dies at claim time under any
+  // non-permissive posture.
   const [author, actor] = await Promise.all([
     issueAuthorProfile(ctx, issue),
-    readyForAgentActor(ctx, issue),
+    labelActor(ctx, issue, promoterLabel),
   ]);
   return { author: author.login, authorSourceTrust: author.sourceTrust, readyForAgentActor: actor };
 }
@@ -86,11 +94,13 @@ async function issueAuthorProfileLegacy(
   }
 }
 
-/** Read the login of the actor who applied `ready-for-agent` from the issue
- * timeline (REST `…/issues/{n}/timeline`). Returns the MOST RECENT `labeled`
- * event for the label — a re-applied label reflects the latest promoter.
- * undefined when the read fails or no such event exists. */
-async function readyForAgentActor(ctx: GhContext, issue: number): Promise<string | undefined> {
+/** Read the login of the actor who applied `label` from the issue timeline
+ * (REST `…/issues/{n}/timeline`). Returns the MOST RECENT `labeled` event for
+ * the label — a re-applied label reflects the latest promoter. undefined when
+ * the read fails or no such event exists. `label` is the promoter label the
+ * claim was selected under (`ready-for-agent`, `lane:go`, `lane:scout`), so the
+ * lane label's applier is the promoter analog for the isolated lanes (#2602). */
+async function labelActor(ctx: GhContext, issue: number, label: string): Promise<string | undefined> {
   const r = await runGh(ctx, [
     "api",
     `repos/{owner}/{repo}/issues/${issue}/timeline`,
@@ -108,7 +118,7 @@ async function readyForAgentActor(ctx: GhContext, issue: number): Promise<string
     let actor: string | undefined;
     for (const ev of events) {
       const e = ev as { event?: string; label?: { name?: string }; actor?: { login?: string } };
-      if (e.event === "labeled" && e.label?.name === LABEL_READY && e.actor?.login) {
+      if (e.event === "labeled" && e.label?.name === label && e.actor?.login) {
         actor = String(e.actor.login); // keep the last (most recent) match
       }
     }

--- a/apps/dev/tests/gh-issue-trust-lane.test.ts
+++ b/apps/dev/tests/gh-issue-trust-lane.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { issueTrust, type GhContext } from "../src/runtime/gh.js";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+
+/**
+ * Lane-aware claim provenance (#2602): a `lane:go` / `lane:scout` issue NEVER
+ * carries `ready-for-agent` (lane isolation is by design), so resolving the
+ * promoter from `ready-for-agent` alone leaves `readyForAgentActor` undefined and
+ * the trust gate refuses every /go dispatch under a non-permissive posture. The
+ * fix teaches `issueTrust` the promoter label the issue was selected under: the
+ * lane label's own `labeled` timeline event is the promoter analog.
+ */
+
+interface TimelineEvent {
+  event: string;
+  label?: { name: string };
+  actor?: { login: string };
+}
+
+/** A gh fake that answers `issue view --json author…` and the timeline `api`
+ * call, so the real `issueTrust` closure can be driven without touching gh. */
+function ghWith(opts: {
+  author: string;
+  timeline: TimelineEvent[];
+}): { ctx: GhContext; calls: string[][] } {
+  const calls: string[][] = [];
+  const exec: ExecFn = (_bin, args) => {
+    calls.push([...args]);
+    let out: ExecOutput = { code: 0, stdout: "", stderr: "" };
+    if (args[0] === "issue" && args[1] === "view") {
+      out = { code: 0, stdout: JSON.stringify({ author: { login: opts.author }, authorAssociation: "OWNER" }), stderr: "" };
+    } else if (args[0] === "api") {
+      out = { code: 0, stdout: JSON.stringify(opts.timeline), stderr: "" };
+    }
+    return Promise.resolve(out);
+  };
+  return { ctx: { cwd: "/r", repo: "acme/widgets", exec }, calls };
+}
+
+const labeled = (name: string, login: string): TimelineEvent => ({
+  event: "labeled",
+  label: { name },
+  actor: { login },
+});
+
+describe("issueTrust — lane-aware promoter resolution (#2602)", () => {
+  it("resolves the promoter from the lane:go label event when the promoter label is lane:go", async () => {
+    const { ctx } = ghWith({
+      author: "maint",
+      // A lane:go issue: it carries the lane label applied by the maintainer's
+      // `go` mint, and NEVER `ready-for-agent`.
+      timeline: [labeled("lane:go", "maint")],
+    });
+    const trust = await issueTrust(ctx, 2600, "lane:go");
+    expect(trust.readyForAgentActor).toBe("maint");
+  });
+
+  it("resolves the promoter from the lane:scout label event for the scout lane", async () => {
+    const { ctx } = ghWith({
+      author: "maint",
+      timeline: [labeled("lane:scout", "maint")],
+    });
+    const trust = await issueTrust(ctx, 2601, "lane:scout");
+    expect(trust.readyForAgentActor).toBe("maint");
+  });
+
+  it("defaults to the ready-for-agent event when no promoter label is passed (fleet lane)", async () => {
+    const { ctx } = ghWith({
+      author: "reporter",
+      timeline: [labeled("ready-for-agent", "maint"), labeled("lane:go", "stranger")],
+    });
+    const trust = await issueTrust(ctx, 42);
+    expect(trust.readyForAgentActor).toBe("maint");
+  });
+
+  it("returns the MOST RECENT lane-label applier when the lane was re-applied", async () => {
+    const { ctx } = ghWith({
+      author: "maint",
+      timeline: [labeled("lane:go", "first"), labeled("lane:go", "second")],
+    });
+    const trust = await issueTrust(ctx, 2600, "lane:go");
+    expect(trust.readyForAgentActor).toBe("second");
+  });
+
+  it("leaves the promoter undefined when the lane label carries no labeled event", async () => {
+    const { ctx } = ghWith({
+      author: "maint",
+      timeline: [labeled("ready-for-agent", "maint")],
+    });
+    const trust = await issueTrust(ctx, 2600, "lane:go");
+    expect(trust.readyForAgentActor).toBeUndefined();
+  });
+});

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -90,6 +90,9 @@ export interface Trace {
   handoffs: Array<{ path: string; content: string }>;
   /** Fresh-branch preparation calls before sandcastle can reuse a worktree. */
   freshWorkerBranchCalls: Array<{ branch: string; baseRef: string; force: boolean }>;
+  /** Promoter labels passed into gh.issueTrust at claim time (#2602): the lane the
+   * claim was selected under, so /go/scout provenance resolves from the lane label. */
+  issueTrustCalls: Array<string | undefined>;
 }
 
 export interface HarnessOptions {
@@ -291,6 +294,7 @@ export function harness(opts: HarnessOptions = {}): {
     pnpmArgs: [],
     handoffs: [],
     freshWorkerBranchCalls: [],
+    issueTrustCalls: [],
   };
 
   const outcome = opts.outcome ?? "done";
@@ -336,7 +340,12 @@ export function harness(opts: HarnessOptions = {}): {
       },
       // Trust-gate provenance port (#621): registered only when the test opts in,
       // so legacy-shaped tests omit it and the gate never fires (permissive).
-      issueTrust: opts.trust ? async () => opts.trust! : undefined,
+      issueTrust: opts.trust
+        ? async (_issue: number, promoterLabel?: string) => {
+            trace.issueTrustCalls.push(promoterLabel);
+            return opts.trust!;
+          }
+        : undefined,
       // Visibility-aware default ports (#1101): registered only when the test opts
       // in, so legacy-shaped tests omit them and the default stays permissive.
       repoVisibility: opts.visibility ? async () => opts.visibility! : undefined,

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -775,6 +775,77 @@ describe("processIssue — visibility-aware default (#1101)", () => {
 });
 
 
+describe("processIssue — lane-aware claim provenance (#2602)", () => {
+  it("resolves the promoter from the lane:go label (a lane:go issue never carries ready-for-agent)", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      outcome: "done",
+      feedbackOk: true,
+      trust: { author: "maint", readyForAgentActor: "maint" },
+    });
+    await processIssue(deps, input);
+    // The claim reads provenance under the lane label the issue was selected
+    // under, not a hardcoded `ready-for-agent` that a lane:go issue never has.
+    expect(trace.issueTrustCalls).toEqual(["lane:go"]);
+  });
+
+  it("scout lane resolves provenance under lane:scout", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:scout"],
+      laneLabel: "lane:scout",
+      runMode: "scout",
+      outcome: "done",
+      trust: { author: "maint", readyForAgentActor: "maint" },
+    });
+    await processIssue(deps, input);
+    expect(trace.issueTrustCalls).toEqual(["lane:scout"]);
+  });
+
+  it("/afk defaults the promoter label to ready-for-agent (unchanged fleet behaviour)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      trust: { author: "maint", readyForAgentActor: "maint" },
+    });
+    await processIssue(deps, input);
+    expect(trace.issueTrustCalls).toEqual(["ready-for-agent"]);
+  });
+
+  it("PUBLIC repo + fail-closed + lane:go minted by a maintainer → executable", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      visibility: "public",
+      maintainers: ["maint"],
+      outcome: "done",
+      feedbackOk: true,
+      // Provenance the lane-aware resolver returns: the lane:go applier IS the
+      // maintainer minter, so the fail-closed promoter check passes.
+      trust: { author: "maint", readyForAgentActor: "maint" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+  });
+
+  it("PUBLIC repo + fail-closed + lane:go applied by an untrusted actor → still refused", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      visibility: "public",
+      maintainers: ["maint"],
+      trust: { author: "maint", readyForAgentActor: "stranger" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("claim-lost");
+    expect(trace.runAgentCalls).toEqual([]);
+    expect(
+      trace.iterLogs.some((l) => /trust gate refused #9 \[fail-closed\].*promoter/.test(l)),
+    ).toBe(true);
+  });
+});
+
 describe("processIssue — claim sheds stale blocked:* on promote to running (#402)", () => {
   it("removes every blocked:* label the issue carried in the SAME claim edit", async () => {
     const { deps, input, trace } = harness({


### PR DESCRIPTION
Automated AFK landing for #2602. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2602

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787425923&installation_model_id=20659&pr_number=2618&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2618&signature=0aab3b5717e7ae0a5736067a949f76b76c55add4cfbab89dabd3807c3fd0cf65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->