### PR TITLE
chore: #2336 Castle-MCP E2: castle lane event subscriptions

### DIFF
--- a/apps/dev/src/lane-subscription.ts
+++ b/apps/dev/src/lane-subscription.ts
@@ -1,0 +1,148 @@
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { encode, type JsonValue } from "@reddb-io/toon";
+import type {
+  CastleLaneRecord,
+  LaneEvent,
+  LaneFollower,
+} from "@reddb-io/red-castle/engine";
+
+/** The single subscribable resource that streams castle lane events. */
+export const LANE_EVENTS_RESOURCE_URI = "castle://lanes/events";
+
+/**
+ * The subset of the low-level MCP `Server` this wiring drives. Passing the real
+ * `McpServer.server` satisfies it structurally; a fake satisfies it in tests.
+ */
+export interface LaneSubscriptionServer {
+  registerCapabilities(capabilities: {
+    resources: { subscribe: true };
+  }): void;
+  setRequestHandler(
+    schema: unknown,
+    handler: (request: unknown) => unknown,
+  ): void;
+  sendResourceUpdated(params: { uri: string }): void | Promise<void>;
+}
+
+export interface LaneSubscriptionOptions {
+  /** Poll cadence for the follower once at least one client is subscribed. */
+  readonly intervalMs?: number;
+  /** Cap on records buffered between reads; oldest are dropped past the cap. */
+  readonly bufferLimit?: number;
+}
+
+export interface LaneSubscriptionHandle {
+  /** Read newly appended lane records once and fan them out. */
+  poll(): Promise<number>;
+  /** Tear down the follower's polling loop. */
+  stop(): void;
+}
+
+const DEFAULT_BUFFER_LIMIT = 1_000;
+
+function toon(value: unknown): string {
+  return encode(JSON.parse(JSON.stringify(value ?? null)) as JsonValue, {
+    keyedMapCollapse: true,
+  });
+}
+
+/**
+ * Expose castle lane events as an MCP subscription surface. A client subscribes
+ * to {@link LANE_EVENTS_RESOURCE_URI}; each lane append the follower observes
+ * buffers the record, notifies the client with `resources/updated`, and the
+ * client re-reads the resource to drain the byte-compatible records. No new
+ * write path is introduced — the follower only reads existing lane files.
+ *
+ * The follower runs a single shared subscription refcounted across clients:
+ * the first subscribe starts polling, the last unsubscribe stops it.
+ */
+export function registerLaneEventSubscription(
+  server: LaneSubscriptionServer,
+  follower: LaneFollower,
+  options: LaneSubscriptionOptions = {},
+): LaneSubscriptionHandle {
+  const bufferLimit = options.bufferLimit ?? DEFAULT_BUFFER_LIMIT;
+  const buffer: CastleLaneRecord[] = [];
+  let refcount = 0;
+  let unsubscribeFollower: (() => void) | undefined;
+
+  const onEvent = (event: LaneEvent): void => {
+    buffer.push(event.record);
+    if (buffer.length > bufferLimit) buffer.splice(0, buffer.length - bufferLimit);
+    void server.sendResourceUpdated({ uri: LANE_EVENTS_RESOURCE_URI });
+  };
+
+  server.registerCapabilities({ resources: { subscribe: true } });
+
+  server.setRequestHandler(ListResourcesRequestSchema, () => ({
+    resources: [
+      {
+        uri: LANE_EVENTS_RESOURCE_URI,
+        name: "Castle lane events",
+        description:
+          "Subscribe to receive castle lane records (worker landings, deaths, " +
+          "lost claims, supervisor halts) appended after subscription. Payloads " +
+          "are byte-compatible with the `logs` tool's CastleLaneRecord shape.",
+        mimeType: "application/toon",
+      },
+    ],
+  }));
+
+  server.setRequestHandler(ReadResourceRequestSchema, (request) => {
+    const uri = resourceUri(request);
+    if (uri !== LANE_EVENTS_RESOURCE_URI) {
+      throw new Error(`unknown resource ${JSON.stringify(uri)}`);
+    }
+    const drained = buffer.splice(0, buffer.length);
+    return {
+      contents: [
+        {
+          uri: LANE_EVENTS_RESOURCE_URI,
+          mimeType: "application/toon",
+          text: toon({ events: drained }),
+        },
+      ],
+    };
+  });
+
+  server.setRequestHandler(SubscribeRequestSchema, async (request) => {
+    if (resourceUri(request) !== LANE_EVENTS_RESOURCE_URI) return {};
+    refcount += 1;
+    if (refcount === 1) {
+      unsubscribeFollower = await follower.subscribe(onEvent);
+      follower.start(options.intervalMs);
+    }
+    return {};
+  });
+
+  server.setRequestHandler(UnsubscribeRequestSchema, (request) => {
+    if (resourceUri(request) !== LANE_EVENTS_RESOURCE_URI) return {};
+    if (refcount > 0) refcount -= 1;
+    if (refcount === 0) {
+      unsubscribeFollower?.();
+      unsubscribeFollower = undefined;
+      follower.stop();
+    }
+    return {};
+  });
+
+  return {
+    poll: () => follower.poll(),
+    stop: () => {
+      unsubscribeFollower?.();
+      unsubscribeFollower = undefined;
+      follower.stop();
+    },
+  };
+}
+
+function resourceUri(request: unknown): string {
+  const params = (request as { params?: { uri?: unknown } } | undefined)
+    ?.params;
+  return typeof params?.uri === "string" ? params.uri : "";
+}

--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -12,10 +12,16 @@ import {
   armPr,
   createFileMergeDriverStore,
   createGitHubTrackerAdapter,
+  createLaneFollower,
   createSingletonLeaseStore,
+  listCastleLaneFiles,
   runIssueStateCurator,
   runMergeDriverPass,
 } from "@reddb-io/red-castle/engine";
+import {
+  registerLaneEventSubscription,
+  type LaneSubscriptionServer,
+} from "./lane-subscription.js";
 import { createMergeDriverIo } from "./runtime/merge-driver-io.js";
 import { createMedicIo } from "./runtime/medic-io.js";
 import { createFileMedicStore, runMedicPass } from "./core/pr-medic.js";
@@ -42,7 +48,7 @@ function toon(value: unknown): string {
   });
 }
 
-export function createCastleMcpServer(): McpServer {
+export function createCastleMcpServer(root = process.cwd()): McpServer {
   const server = new McpServer({ name: "castle", version: buildInfo.version });
   const registerTool = server.registerTool.bind(server) as (
     name: string,
@@ -70,6 +76,13 @@ export function createCastleMcpServer(): McpServer {
       }),
     );
   }
+  const paths = createEnginePaths(join(root, ".red"));
+  registerLaneEventSubscription(
+    server.server as unknown as LaneSubscriptionServer,
+    createLaneFollower({
+      list: () => listCastleLaneFiles(paths, ["worker", "supervisor"]),
+    }),
+  );
   return server;
 }
 

--- a/apps/dev/tests/lane-subscription.test.ts
+++ b/apps/dev/tests/lane-subscription.test.ts
@@ -1,0 +1,135 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  createCastleLaneWriters,
+  createEnginePaths,
+  createLaneFollower,
+  listCastleLaneFiles,
+  type EnginePaths,
+} from "@reddb-io/red-castle/engine";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  LANE_EVENTS_RESOURCE_URI,
+  registerLaneEventSubscription,
+} from "../src/lane-subscription.js";
+
+/** Minimal stand-in for the low-level MCP server the wiring drives. */
+function fakeServer() {
+  const handlers = new Map<unknown, (request: unknown) => unknown>();
+  const capabilities: unknown[] = [];
+  const updated: Array<{ uri: string }> = [];
+  return {
+    handlers,
+    capabilities,
+    updated,
+    registerCapabilities(cap: unknown) {
+      capabilities.push(cap);
+    },
+    setRequestHandler(schema: unknown, handler: (request: unknown) => unknown) {
+      handlers.set(schema, handler);
+    },
+    async sendResourceUpdated(params: { uri: string }) {
+      updated.push(params);
+    },
+  };
+}
+
+describe("lane event MCP subscription", () => {
+  let dir: string;
+  let paths: EnginePaths;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "lane-sub-"));
+    paths = createEnginePaths(join(dir, ".red"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("declares the subscribe capability and lists the lane resource", async () => {
+    const server = fakeServer();
+    const handle = registerLaneEventSubscription(
+      server,
+      createLaneFollower({ list: () => listCastleLaneFiles(paths, ["worker"]) }),
+    );
+
+    expect(server.capabilities).toContainEqual({
+      resources: { subscribe: true },
+    });
+    const list = (await server.handlers.get(ListResourcesRequestSchema)!(
+      {},
+    )) as { resources: Array<{ uri: string }> };
+    expect(list.resources.map((r) => r.uri)).toContain(
+      LANE_EVENTS_RESOURCE_URI,
+    );
+    handle.stop();
+  });
+
+  it("drives a resource-updated notification from a synthetic lane append", async () => {
+    const server = fakeServer();
+    const handle = registerLaneEventSubscription(
+      server,
+      createLaneFollower({ list: () => listCastleLaneFiles(paths, ["worker"]) }),
+    );
+
+    await server.handlers.get(SubscribeRequestSchema)!({
+      params: { uri: LANE_EVENTS_RESOURCE_URI },
+    });
+
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-23T00:00:00.000Z",
+    });
+    await writers.worker("w1").append({
+      kind: "worker.completed",
+      worker_id: "w1",
+      issue: 42,
+    });
+    await handle.poll();
+
+    expect(server.updated).toContainEqual({ uri: LANE_EVENTS_RESOURCE_URI });
+
+    const read = server.handlers.get(ReadResourceRequestSchema)!;
+    const result = (await read({
+      params: { uri: LANE_EVENTS_RESOURCE_URI },
+    })) as { contents: Array<{ uri: string; text: string }> };
+    expect(result.contents[0].uri).toBe(LANE_EVENTS_RESOURCE_URI);
+    expect(result.contents[0].text).toContain("worker.completed");
+    handle.stop();
+  });
+
+  it("stops delivering after unsubscribe", async () => {
+    const server = fakeServer();
+    const handle = registerLaneEventSubscription(
+      server,
+      createLaneFollower({ list: () => listCastleLaneFiles(paths, ["worker"]) }),
+    );
+
+    await server.handlers.get(SubscribeRequestSchema)!({
+      params: { uri: LANE_EVENTS_RESOURCE_URI },
+    });
+    await server.handlers.get(UnsubscribeRequestSchema)!({
+      params: { uri: LANE_EVENTS_RESOURCE_URI },
+    });
+
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-23T00:00:00.000Z",
+    });
+    await writers.worker("w1").append({
+      kind: "worker.completed",
+      worker_id: "w1",
+      issue: 42,
+    });
+    await handle.poll();
+
+    expect(server.updated).toHaveLength(0);
+    handle.stop();
+  });
+});

--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -16,6 +16,7 @@ export * from "./gate-constants.js";
 export * from "./gate-executor.js";
 export * from "./gate-sink.js";
 export * from "./heal-ledger.js";
+export * from "./lane-follower.js";
 export * from "./lane-writers.js";
 export * from "./land-lock.js";
 export * from "./landing.js";

--- a/packages/red-castle/src/engine/lane-follower.test.ts
+++ b/packages/red-castle/src/engine/lane-follower.test.ts
@@ -1,0 +1,155 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CastleLaneRecord } from "./contracts/index.js";
+import {
+  castleLanePath,
+  createCastleLaneWriters,
+  readCastleLaneRecords,
+} from "./lane-writers.js";
+import {
+  createLaneFollower,
+  listCastleLaneFiles,
+  type LaneEvent,
+} from "./lane-follower.js";
+import { createEnginePaths, type EnginePaths } from "./paths.js";
+
+describe("castle lane follower", () => {
+  let dir: string;
+  let paths: EnginePaths;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "lane-follower-"));
+    paths = createEnginePaths(join(dir, ".red"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("delivers records appended after subscription, not pre-existing ones", async () => {
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-23T00:00:00.000Z",
+    });
+    // A record that exists BEFORE anyone subscribes.
+    await writers.worker("w1").append({
+      kind: "worker.claimed",
+      worker_id: "w1",
+      issue: 100,
+    });
+
+    const follower = createLaneFollower({
+      list: () => listCastleLaneFiles(paths, ["worker"]),
+    });
+    const events: LaneEvent[] = [];
+    const unsubscribe = await follower.subscribe((event) => {
+      events.push(event);
+    });
+
+    // A synthetic lane append AFTER subscription drives an event.
+    await writers.worker("w1").append({
+      kind: "worker.completed",
+      worker_id: "w1",
+      issue: 100,
+    });
+    const delivered = await follower.poll();
+    unsubscribe();
+
+    expect(delivered).toBe(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.record.kind).toBe("worker.completed");
+    // The pre-existing worker.claimed record is never delivered.
+    expect(events.some((e) => e.record.kind === "worker.claimed")).toBe(false);
+  });
+
+  it("delivers records byte-compatible with the logs tool record shape", async () => {
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-23T01:02:03.000Z",
+    });
+    const follower = createLaneFollower({
+      list: () => listCastleLaneFiles(paths, ["worker", "supervisor"]),
+    });
+    const events: LaneEvent[] = [];
+    await follower.subscribe((event) => events.push(event));
+
+    await writers.supervisor("s1").append({
+      kind: "supervisor.retired",
+      supervisor_id: "s1",
+      payload: { reason: "halt", slots: 3 },
+    });
+    await follower.poll();
+
+    const lanePath = castleLanePath(paths, "supervisor", "s1");
+    const [logsRecord] = await readCastleLaneRecords(lanePath);
+    // The pushed event record equals the record the logs tool would return.
+    expect(events[0]!.record).toEqual(logsRecord as CastleLaneRecord);
+    expect(events[0]!.path).toBe(lanePath);
+  });
+
+  it("discovers lane files appended after subscription (new workers)", async () => {
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-23T02:00:00.000Z",
+    });
+    const follower = createLaneFollower({
+      list: () => listCastleLaneFiles(paths, ["worker"]),
+    });
+    const events: LaneEvent[] = [];
+    await follower.subscribe((event) => events.push(event));
+
+    // A worker that did not exist at subscription time appears later.
+    await writers.worker("late").append({
+      kind: "worker.blocked",
+      worker_id: "late",
+      issue: 7,
+    });
+    await follower.poll();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.record.worker_id).toBe("late");
+  });
+
+  it("introduces no write path: following never mutates lane files", async () => {
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-23T03:00:00.000Z",
+    });
+    await writers.worker("w1").append({
+      kind: "worker.claimed",
+      worker_id: "w1",
+      issue: 1,
+    });
+    const lanePath = castleLanePath(paths, "worker", "w1");
+    const before = await readFile(lanePath, "utf8");
+
+    const follower = createLaneFollower({
+      list: () => listCastleLaneFiles(paths, ["worker"]),
+    });
+    await follower.subscribe(() => {});
+    await follower.poll();
+    await follower.poll();
+
+    const after = await readFile(lanePath, "utf8");
+    expect(after).toBe(before);
+  });
+
+  it("stops delivering to unsubscribed listeners", async () => {
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-23T04:00:00.000Z",
+    });
+    const follower = createLaneFollower({
+      list: () => listCastleLaneFiles(paths, ["worker"]),
+    });
+    const events: LaneEvent[] = [];
+    const unsubscribe = await follower.subscribe((e) => events.push(e));
+    unsubscribe();
+
+    await writers.worker("w1").append({
+      kind: "worker.completed",
+      worker_id: "w1",
+      issue: 1,
+    });
+    await follower.poll();
+
+    expect(events).toHaveLength(0);
+  });
+});

--- a/packages/red-castle/src/engine/lane-follower.ts
+++ b/packages/red-castle/src/engine/lane-follower.ts
@@ -1,0 +1,171 @@
+import { readdir } from "node:fs/promises";
+import type { CastleLaneRecord } from "./contracts/index.js";
+import {
+  castleLanePath,
+  readCastleLaneRecords,
+  type CastleLaneName,
+} from "./lane-writers.js";
+import type { EnginePaths } from "./paths.js";
+
+/**
+ * One lane record surfaced by the follower, tagged with the lane file it came
+ * from. `record` is the exact `CastleLaneRecord` the `logs` tool returns for
+ * the same append — push and pull views never disagree (ADR: red.castle.lane.v1).
+ */
+export interface LaneEvent {
+  readonly path: string;
+  readonly record: CastleLaneRecord;
+}
+
+export type LaneEventListener = (event: LaneEvent) => void;
+
+/** Enumerate lane files that carry namespaced event records right now. */
+async function childDirNames(path: string): Promise<string[]> {
+  try {
+    return (await readdir(path, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+/**
+ * Resolve the concrete lane file paths for the requested lane families. Worker
+ * and supervisor lanes are the event-bearing lanes (landings, deaths, lost
+ * claims, supervisor halts); `liveness`/`monitor` may be requested too. A lane
+ * file that does not exist yet is still listed — the follower reads it as empty
+ * until its producer appends, and picks up the first record the moment it lands.
+ */
+export async function listCastleLaneFiles(
+  paths: EnginePaths,
+  lanes: readonly CastleLaneName[] = ["worker", "supervisor"],
+): Promise<string[]> {
+  const files: string[] = [];
+  for (const lane of lanes) {
+    switch (lane) {
+      case "worker":
+      case "liveness": {
+        for (const id of await childDirNames(paths.workersRoot)) {
+          files.push(castleLanePath(paths, lane, id));
+        }
+        break;
+      }
+      case "supervisor": {
+        for (const id of await childDirNames(paths.supervisorsRoot)) {
+          files.push(castleLanePath(paths, "supervisor", id));
+        }
+        break;
+      }
+      case "monitor": {
+        for (const id of await childDirNames(paths.monitorsRoot)) {
+          files.push(castleLanePath(paths, "monitor", id));
+        }
+        break;
+      }
+    }
+  }
+  return files;
+}
+
+export interface LaneFollowerOptions {
+  /** Source of the lane file paths to follow; re-evaluated on every poll. */
+  list(): Promise<string[]>;
+  /** Reader for one lane file; defaults to the shared `logs`-tool reader. */
+  readRecords?(path: string): Promise<CastleLaneRecord[]>;
+}
+
+export interface LaneFollower {
+  /**
+   * Register a listener. Records already present in the lane files at
+   * subscription time are the subscriber's baseline and are never delivered;
+   * only records appended afterwards reach the listener. Returns an unsubscribe
+   * handle.
+   */
+  subscribe(listener: LaneEventListener): Promise<() => void>;
+  /** Read newly appended records once and fan them out. Returns events delivered. */
+  poll(): Promise<number>;
+  /** Begin interval polling; the timer is unref'd so it never holds the process open. */
+  start(intervalMs?: number): void;
+  /** Stop interval polling. */
+  stop(): void;
+}
+
+interface Subscription {
+  readonly listener: LaneEventListener;
+  /** Records already fanned out to this subscriber, per lane file path. */
+  readonly delivered: Map<string, number>;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+
+/**
+ * A tail-follower over existing castle lane files. It never writes a lane —
+ * every event is a record another process appended, re-read through the same
+ * reader the `logs` tool uses, so the subscription stream and the polled logs
+ * are byte-identical. Feed it with a `list()` source (see `listCastleLaneFiles`).
+ */
+export function createLaneFollower(options: LaneFollowerOptions): LaneFollower {
+  const readRecords = options.readRecords ?? readCastleLaneRecords;
+  const subscriptions = new Set<Subscription>();
+  let timer: NodeJS.Timeout | undefined;
+
+  async function countsFor(files: string[]): Promise<Map<string, number>> {
+    const counts = new Map<string, number>();
+    for (const file of files) {
+      counts.set(file, (await readRecords(file)).length);
+    }
+    return counts;
+  }
+
+  return {
+    async subscribe(listener) {
+      const files = await options.list();
+      const subscription: Subscription = {
+        listener,
+        delivered: await countsFor(files),
+      };
+      subscriptions.add(subscription);
+      return () => {
+        subscriptions.delete(subscription);
+      };
+    },
+
+    async poll() {
+      if (subscriptions.size === 0) return 0;
+      const files = await options.list();
+      let delivered = 0;
+      for (const file of files) {
+        const records = await readRecords(file);
+        for (const subscription of subscriptions) {
+          const seen = subscription.delivered.get(file) ?? 0;
+          // A truncated/rotated file (fewer records than seen) resets cleanly.
+          const start = Math.min(seen, records.length);
+          for (const record of records.slice(start)) {
+            subscription.listener({ path: file, record });
+            delivered += 1;
+          }
+          subscription.delivered.set(file, records.length);
+        }
+      }
+      return delivered;
+    },
+
+    start(intervalMs = DEFAULT_POLL_INTERVAL_MS) {
+      if (timer) return;
+      timer = setInterval(() => {
+        void this.poll();
+      }, intervalMs);
+      timer.unref?.();
+    },
+
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    },
+  };
+}


### PR DESCRIPTION
Automated AFK landing for #2336. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2336

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787426482&installation_model_id=20659&pr_number=2619&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2619&signature=8482ae418de278d35d2ddd127838228d410a5d9b902e009852ee619b02fe7c9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->