### PR TITLE
fix: #2597 hitl_resolve requeue leaves the body Current blocker active — coherence probe re-quarantines and the fleet spawn-churns

### DIFF
--- a/apps/dev/src/core/hitl-resolve.ts
+++ b/apps/dev/src/core/hitl-resolve.ts
@@ -1,3 +1,4 @@
+import { clearCurrentBlocker, parseCurrentBlocker } from "./blocker-state.js";
 import { isRefused, planTransition } from "./state-transition.js";
 
 /**
@@ -17,6 +18,10 @@ export interface HitlResolveDeps {
   editLabels(issue: number, remove: string[], add: string[]): Promise<void>;
   /** Concede every dangling claim holder; returns the conceded worker ids. */
   releaseClaims(issue: number): Promise<string[]>;
+  /** Read the raw issue body markdown. */
+  viewBody(issue: number): Promise<string>;
+  /** Overwrite the issue body with the new markdown. */
+  editBody(issue: number, body: string): Promise<void>;
 }
 
 export interface HitlResolveResult {
@@ -60,6 +65,22 @@ export async function resolveHitlDecision(
   // (promote) instead of refusing the way the automated queue path must.
   const conceded = await deps.releaseClaims(input.issue);
   if (conceded.length > 0) actions.push(`claims conceded: ${conceded.join(", ")}`);
+
+  // Clear any active Current blocker so the issue passes the coherence probe
+  // after the label transition. A hitl_resolve is an explicit human decision,
+  // so every blocker kind is accepted here regardless of the narrower set the
+  // CLI requeue operator enforces (#2597).
+  const body = await deps.viewBody(input.issue);
+  const activeBlocker = parseCurrentBlocker(body);
+  if (activeBlocker) {
+    const clearedBody = clearCurrentBlocker(body, {
+      summary: activeBlocker.summary,
+      resolution: input.rationale.trim() || "Resolved via hitl_resolve.",
+    });
+    await deps.editBody(input.issue, clearedBody);
+    actions.push(`body blocker cleared (kind=${activeBlocker.kind})`);
+  }
+
   const hasReqEdges = labels.some((label) => label.startsWith("req:"));
   const plan = planTransition(labels, { kind: hasReqEdges ? "promote" : "queue" });
   if (isRefused(plan)) {

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -751,6 +751,10 @@ export function createDefaultDevAfkMcpOperations(
             const released = (await this.claimRelease({ issue })) as { conceded?: string[] };
             return released.conceded ?? [];
           },
+          viewBody: async (issue) => (await ghx.issueBody(gh, issue)) ?? "",
+          editBody: async (issue, body) => {
+            await ghx.editBody(gh, issue, body);
+          },
         },
         input,
       );

--- a/apps/dev/tests/hitl-resolve.test.ts
+++ b/apps/dev/tests/hitl-resolve.test.ts
@@ -5,19 +5,37 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { resolveHitlDecision, type HitlResolveDeps } from "../src/core/hitl-resolve.js";
+import { parseCurrentBlocker } from "../src/core/blocker-state.js";
 
-function makeDeps(labels: string[], conceded: string[] = []): HitlResolveDeps & {
+const ACTIVE_BLOCKER_BODY = `## Current blocker
+
+<!-- red:blocker-state v1 -->
+status: blocked
+kind: runner
+summary: Idle-timeout crash during attempt 2.
+next: Requeue when the runner environment stabilises.
+<!-- /red:blocker-state -->
+`;
+
+function makeDeps(labels: string[], conceded: string[] = [], body = ""): HitlResolveDeps & {
   comment: ReturnType<typeof vi.fn>;
   closeIssue: ReturnType<typeof vi.fn>;
   editLabels: ReturnType<typeof vi.fn>;
   releaseClaims: ReturnType<typeof vi.fn>;
+  viewBody: ReturnType<typeof vi.fn>;
+  editBody: ReturnType<typeof vi.fn>;
 } {
+  let currentBody = body;
   return {
     comment: vi.fn(async () => undefined),
     closeIssue: vi.fn(async () => undefined),
     viewLabels: vi.fn(async () => labels),
     editLabels: vi.fn(async () => undefined),
     releaseClaims: vi.fn(async () => conceded),
+    viewBody: vi.fn(async () => currentBody),
+    editBody: vi.fn(async (_, newBody: string) => {
+      currentBody = newBody;
+    }),
   };
 }
 
@@ -91,5 +109,50 @@ describe("hitl_resolve decisions (#2369)", () => {
     expect(deps.comment).toHaveBeenCalledTimes(1);
     expect(deps.editLabels).not.toHaveBeenCalled();
     expect(deps.releaseClaims).not.toHaveBeenCalled();
+  });
+
+  it("requeue: clears an active body blocker of any kind (runner) and archives the rationale (#2597)", async () => {
+    const deps = makeDeps(["ready-for-human", "blocked:runner"], [], ACTIVE_BLOCKER_BODY);
+
+    const result = await resolveHitlDecision(deps, {
+      issue: 2428,
+      decision: "requeue",
+      rationale: "runner environment has stabilised; safe to retry",
+    });
+
+    expect(deps.viewBody).toHaveBeenCalledWith(2428);
+    expect(deps.editBody).toHaveBeenCalledTimes(1);
+    const writtenBody = deps.editBody.mock.calls[0]![1] as string;
+    expect(parseCurrentBlocker(writtenBody)).toBeNull();
+    expect(writtenBody).toContain("Resolved blockers");
+    expect(result.actions.some((a) => a.includes("body blocker cleared"))).toBe(true);
+    expect(result.actions.some((a) => a.includes("kind=runner"))).toBe(true);
+  });
+
+  it("requeue: skips editBody when the issue has no active body blocker", async () => {
+    const deps = makeDeps(["ready-for-human"], [], "## Background\n\nNo blocker here.\n");
+
+    await resolveHitlDecision(deps, {
+      issue: 99,
+      decision: "requeue",
+      rationale: "just flipping labels",
+    });
+
+    expect(deps.editBody).not.toHaveBeenCalled();
+  });
+
+  it("requeue: after clearing blocker, issue body passes the coherence probe — no ready-for-agent + active-blocker pair (#2597)", async () => {
+    const deps = makeDeps(["ready-for-human", "blocked:runner"], [], ACTIVE_BLOCKER_BODY);
+
+    await resolveHitlDecision(deps, {
+      issue: 2428,
+      decision: "requeue",
+      rationale: "runner stabilised",
+    });
+
+    const writtenBody = deps.editBody.mock.calls[0]![1] as string;
+    // Coherence probe: ready-for-agent issues must NOT carry an active Current blocker.
+    // After hitl requeue the body blocker must be absent.
+    expect(parseCurrentBlocker(writtenBody)).toBeNull();
   });
 });


### PR DESCRIPTION
Automated AFK landing for #2597. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2597

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787427491&installation_model_id=20659&pr_number=2622&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2622&signature=7d16886d569c2289dc572cd7f33e50312fad03d5fae6b3e458248a1f65cc1d55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->