### PR TITLE
chore: #2404 Model tier routing defaults: route slice complexity to the configured runner tier

### DIFF
--- a/apps/dev/src/core/issue-classifier.ts
+++ b/apps/dev/src/core/issue-classifier.ts
@@ -50,6 +50,7 @@ const RISK_KEYWORDS = [
 
 const THINK_KEYWORDS =
   /\b(architecture|architectural|adr|design decision|routing decision|strategy|tradeoff|choose|classifier|planner|planning)\b/i;
+const SPEC_FAMILY_LABEL = /^spec:\d+$/i;
 
 const DOC_EXTENSIONS = new Set(["md", "mdx", "txt", "rst", "adoc"]);
 const VALIDATION_WORDS = /\b(validate|validation|lint|format|formatting|schema check|typecheck|type check)\b/i;
@@ -88,6 +89,9 @@ export async function classifyIssue(
   metadata: IssueClassificationMetadata,
   modelCall?: IssueClassifierModelCall,
 ): Promise<TaskClass> {
+  const explicitTier = explicitTierLabel(metadata.labels);
+  if (explicitTier) return explicitTier;
+
   const deterministic = deterministicTaskClass(metadata);
   const modelTier = modelCall ? parseTaskClass(await modelCall({ prompt: classifierPrompt(metadata), metadata })) : undefined;
 
@@ -96,6 +100,14 @@ export async function classifyIssue(
   }
 
   return maxTier(deterministic, modelTier ?? "validate");
+}
+
+function explicitTierLabel(labels: readonly string[]): TaskClass | undefined {
+  for (const label of labels) {
+    const match = /^tier:(validate|simple|complex|think)$/i.exec(label.trim());
+    if (match) return match[1]!.toLowerCase() as TaskClass;
+  }
+  return undefined;
 }
 
 /**
@@ -194,6 +206,7 @@ export function classifierPrompt(metadata: IssueClassificationMetadata): string 
 function deterministicTaskClass(metadata: IssueClassificationMetadata): TaskClass {
   const searchable = `${metadata.title}\n${metadata.summary}\n${metadata.labels.join("\n")}`;
   if (THINK_KEYWORDS.test(searchable)) return "think";
+  if (metadata.labels.some((label) => SPEC_FAMILY_LABEL.test(label.trim()))) return "complex";
   if (metadata.riskKeywords.length > 0) return "complex";
   if (metadata.scopePaths.length >= 3 || metadata.referencedFileCount >= 6 || metadata.diffSize === "large") {
     return "complex";

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -429,9 +429,9 @@ export async function processIssue(
     handoff: handoffPath,
     output_shaping: outputShaping.variant,
   });
-  const taskClass =
-    (await deps
-      .classifyIssue?.(
+  const taskClass = deps.classifyIssue
+    ? (await deps
+      .classifyIssue(
         buildIssueClassificationMetadata({
           issue,
           title: input.title,
@@ -439,7 +439,8 @@ export async function processIssue(
           labels,
         }),
       )
-      .catch(() => undefined)) ?? "think";
+      .catch(() => undefined)) ?? "simple"
+    : "think";
   if (
     !(await fireHook(
       "pre_attempt",
@@ -591,6 +592,22 @@ export async function processIssue(
   let gateGreenSkip = resumeIsGateGreen;
   while (true) {
     const initialTier = resolveSpawnTier(deps, activeRunner, activeTaskClass);
+    const routedEffort = initialTier.effort ?? "";
+    deps.appendIterLog(
+      `🤖 /afk route #${issue}: tier=${activeTaskClass} runner=${activeRunner} model=${initialTier.model} effort=${routedEffort || "default"}.`,
+    );
+    deps.markState?.({
+      "current.runner": activeRunner,
+      "current.model_tier": activeTaskClass,
+      "current.model": initialTier.model,
+      "current.effort": routedEffort,
+    });
+    deps.recordWorkerEvent?.("worker.routed", {
+      runner: activeRunner,
+      model_tier: activeTaskClass,
+      model: initialTier.model,
+      effort: routedEffort,
+    });
     let run: RunAgentResult;
     if (gateGreenSkip) {
       // Consume the flag — subsequent loop iterations (e.g. go-verify retries)

--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -177,6 +177,15 @@ function restoreStampedDotted(
   setDotted(target, key, prev);
 }
 
+function dottedValue(target: Record<string, unknown>, key: string): unknown {
+  let value: unknown = target;
+  for (const part of key.split(".").filter(Boolean)) {
+    if (!isRecord(value)) return undefined;
+    value = value[part];
+  }
+  return value;
+}
+
 const IMMUTABLE_STATE_FIELDS = [
   "worker_id",
   "pid_start_time",
@@ -187,9 +196,9 @@ const IMMUTABLE_STATE_FIELDS = [
   "current.number",
   "current.started_at",
   "current.runner",
-  "current.model",
-  "current.effort",
 ] as const;
+
+const STICKY_NONEMPTY_STATE_FIELDS = ["current.model_tier", "current.model", "current.effort"] as const;
 
 export interface UpdateStateOptions {
   /** Only true at real attempt teardown, when the worker is no longer live. */
@@ -205,6 +214,9 @@ function preserveStampedIdentity(
 ): void {
   const prev = previous as unknown as Record<string, unknown>;
   for (const key of IMMUTABLE_STATE_FIELDS) restoreStampedDotted(next, prev, key);
+  for (const key of STICKY_NONEMPTY_STATE_FIELDS) {
+    if (!isStampedIdentityValue(dottedValue(next, key))) restoreStampedDotted(next, prev, key);
+  }
   if (previous.pid > 0 && !options.allowPidReset) {
     next.pid = previous.pid;
   } else if (previous.pid > 0 && next.pid !== 0) {

--- a/apps/dev/src/types/state.ts
+++ b/apps/dev/src/types/state.ts
@@ -31,6 +31,9 @@ export const AfkCurrentSchema = z.object({
   /** Model identifier resolved for this attempt (e.g. `claude-opus-4-8`). Stamped
    * once at attempt start. Used by the statusline to show which model is running. */
   model: z.string().default(""),
+  /** Classifier-selected AFK tier that resolved `model`/`effort`. Kept beside
+   * the concrete runner settings so monitor readers can explain the route. */
+  model_tier: z.string().default(""),
   /** Effort level resolved for this attempt (e.g. `high`, `max`). Paired with
    * `model` on the statusline runner label. */
   effort: z.string().default(""),

--- a/apps/dev/tests/issue-classifier.test.ts
+++ b/apps/dev/tests/issue-classifier.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildIssueClassificationMetadata,
   classifierPrompt,
@@ -11,6 +11,30 @@ import {
 } from "../src/core/issue-classifier.js";
 
 describe("issue classifier", () => {
+  it.each([
+    {
+      name: "mechanical docs",
+      labels: ["type:docs"],
+      body: "Update README.md copy only.",
+      expected: "validate",
+    },
+    {
+      name: "standard bug",
+      labels: ["type:bug"],
+      body: "Fix src/parser.ts and keep its focused test green.",
+      expected: "simple",
+    },
+    {
+      name: "complex cross-scope feature",
+      labels: ["type:feature"],
+      body: "Change apps/api/src/route.ts, apps/web/src/client.ts, and packages/shared/src/types.ts.",
+      expected: "complex",
+    },
+  ])("routes the $name label/body fixture to $expected", async ({ labels, body, expected }) => {
+    const metadata = buildIssueClassificationMetadata({ issue: 1, title: "Fixture", body, labels });
+    await expect(classifyIssue(metadata)).resolves.toBe(expected);
+  });
+
   it("extracts cheap metadata from deterministic issue text", () => {
     const metadata = buildIssueClassificationMetadata({
       issue: 42,
@@ -40,6 +64,19 @@ describe("issue classifier", () => {
     await expect(classifyIssue(metadata, async () => ({ tier: "simple" }))).resolves.toBe("simple");
   });
 
+  it("lets an explicit tier label override every inferred signal without calling the classifier model", async () => {
+    const metadata = buildIssueClassificationMetadata({
+      issue: 12,
+      title: "Choose architecture for an auth migration",
+      body: "Change the database schema across apps/api/src/auth.ts and apps/web/src/session.ts.",
+      labels: ["tier:simple", "spec:99"],
+    });
+    const modelCall = vi.fn(async () => ({ tier: "think" }));
+
+    await expect(classifyIssue(metadata, modelCall)).resolves.toBe("simple");
+    expect(modelCall).not.toHaveBeenCalled();
+  });
+
   it("risk keywords push the final tier to complex even when the model under-calls it", async () => {
     const metadata = buildIssueClassificationMetadata({
       issue: 8,
@@ -58,6 +95,17 @@ describe("issue classifier", () => {
     });
 
     await expect(classifyIssue(metadata, async () => '{"tier":"complex"}')).resolves.toBe("think");
+  });
+
+  it("treats a Spec-family implementation slice as complex by default", async () => {
+    const metadata = buildIssueClassificationMetadata({
+      issue: 13,
+      title: "Wire the next implementation slice",
+      body: "Touch apps/dev/src/core/router.ts and keep its focused tests green.",
+      labels: ["type:feature", "spec:88"],
+    });
+
+    await expect(classifyIssue(metadata)).resolves.toBe("complex");
   });
 
   it("trivial docs and validation work stays in validate/simple despite a noisy model response", async () => {

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -78,6 +78,18 @@ describe("monitor — compact line", () => {
     expect(renderWorkerCompactLine(go, 1780140600)).toContain(" org=go  ");
   });
 
+  it("shows the classifier-selected model tier on the active worker row", () => {
+    const base = baseWorker();
+    const routed = baseWorker({
+      state: {
+        ...base.state,
+        current: { ...base.state.current, model_tier: "simple" },
+      },
+    });
+
+    expect(renderWorkerCompactLine(routed, 1780140600)).toContain(" tier:simple");
+  });
+
   it("appends per-worker token spend (and $cost when reported) when usage streamed", () => {
     const base = baseWorker();
     const withCost = baseWorker({

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -286,6 +286,58 @@ describe("processIssue — DONE + green + merged (unlocked, admin-PR landing)", 
     expect(trace.runAgentCalls[0]?.model).toBe("claude-complex-model");
     expect(trace.runAgentCalls[0]?.effort).toBe("medium");
   });
+
+  it("falls back to the standard simple tier when classification is unavailable", async () => {
+    const tiers: string[] = [];
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      classifyIssue: async () => {
+        throw new Error("classifier unavailable");
+      },
+      resolveTier: (_runner, taskClass) => {
+        tiers.push(taskClass ?? "missing");
+        return { model: `claude-${taskClass}-model`, effort: "high" };
+      },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(tiers).toEqual(["simple"]);
+    expect(trace.runAgentCalls[0]?.model).toBe("claude-simple-model");
+  });
+
+  it("records the resolved routing decision in the worker lane before spawn", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      classifyIssue: async () => "complex",
+      resolveTier: () => ({ model: "claude-complex-model", effort: "medium" }),
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.iterLogs).toContain(
+      "🤖 /afk route #9: tier=complex runner=claude model=claude-complex-model effort=medium.",
+    );
+    expect(trace.statePatches).toContainEqual({
+      "current.runner": "claude",
+      "current.model_tier": "complex",
+      "current.model": "claude-complex-model",
+      "current.effort": "medium",
+    });
+    expect(trace.workerEvents).toContainEqual({
+      kind: "worker.routed",
+      payload: {
+        runner: "claude",
+        model_tier: "complex",
+        model: "claude-complex-model",
+        effort: "medium",
+      },
+    });
+  });
 });
 
 

--- a/apps/dev/tests/state.test.ts
+++ b/apps/dev/tests/state.test.ts
@@ -188,6 +188,30 @@ describe("state", () => {
     expect(after.current.last_event_at).toBe("2026-07-06T20:01:00.000Z");
   });
 
+  it("replaces the provisional spawn model with the resolved issue route", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
+    const path = join(dir, "afk.state.toon");
+
+    initStateSync(path, {
+      worker_id: "wROUT",
+      pid: 4242,
+      "current.model": "claude-think-model",
+      "current.effort": "high",
+    });
+
+    const after = await updateState(path, {
+      "current.model_tier": "simple",
+      "current.model": "claude-simple-model",
+      "current.effort": "medium",
+    });
+
+    expect(after.current).toMatchObject({
+      model_tier: "simple",
+      model: "claude-simple-model",
+      effort: "medium",
+    });
+  });
+
   it("preserves live pid and current identity when stamping the validating phase", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
     const path = join(dir, "afk.state.toon");

--- a/packages/red-castle/src/engine/monitor-readers.ts
+++ b/packages/red-castle/src/engine/monitor-readers.ts
@@ -94,6 +94,7 @@ function currentFromSnapshot(
       snapshot.started_at ?? snapshot.updated_at,
     ),
     model: stringField(current, "model") || undefined,
+    model_tier: stringField(current, "model_tier") || undefined,
     effort: stringField(current, "effort") || undefined,
     input_tokens: numberField(current, "input_tokens"),
     output_tokens: numberField(current, "output_tokens"),

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -150,6 +150,8 @@ export interface CompactCurrent {
    * Absent on pre-schema state files. Surfaced (shortened) on the themed
    * per-worker `run=` label (issue #1175). */
   model?: string;
+  /** Classifier-selected AFK model tier (`validate|simple|complex|think`). */
+  model_tier?: string;
   /** Reasoning-effort level this worker's attempt ran with (e.g. `high`, `max`).
    * Absent when the state/config did not carry it — the `run=` label then omits
    * just the effort word (issue #1175). */
@@ -499,7 +501,8 @@ export function renderWorkerCompactLine(worker: CompactWorker, now: number): str
   if (!isNoIssue(state.current.number)) {
     const title = state.current.title.slice(0, TITLE_MAX);
     const elapsed = formatElapsed(elapsedSeconds(state, now));
-    cur = `  #${state.current.number} ${title}  activity:${state.current.activity}  ${elapsed}${diff}${costFrag}${vitalsFrag}${logFrag}`;
+    const tierFrag = state.current.model_tier ? ` tier:${state.current.model_tier}` : "";
+    cur = `  #${state.current.number} ${title}  activity:${state.current.activity}${tierFrag}  ${elapsed}${diff}${costFrag}${vitalsFrag}${logFrag}`;
   } else {
     cur = `  idle${diff}${logFrag}`;
   }

--- a/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
@@ -76,6 +76,31 @@ MCP, and non-essential host hooks are absent from every projection.
 | `afk.companion.*` (cap) | `RED_AFK_RETRY_DRIFT` | `2` | Companion bounded re-enqueue budget. Each detected drift on an attempt injects **one** correction (write-only, idempotent via a fingerprint, rewriting `## Agent brief`); once the attempt count reaches this cap the companion **escalates** to `ready-for-human` (a `## Current blocker` of kind `drift`) instead of correcting again. Shares the bounded-recovery policy (`core/recovery.ts`); never kills a process — termination/respawn is the reaper + fleet's job. |
 | `afk.drain.max_cost_usd` | `RED_AFK_DRAIN_MAX_COST_USD` / `fleet --budget-usd` | _(unset)_ | Per-drain USD budget for the fleet supervisor. Spend is read from WorkerVitals (`current.cost_usd`) in worker state files, not a parallel ledger. Tiers are OK below 75%, WARNING at 75%, CRITICAL at 90%, and HARD_STOP at 100%. CRITICAL spawns new workers with one model-tier-policy downgrade; HARD_STOP stops all new spawns, lets in-flight workers finish, and records a TOON budget event in `.red/tmp/supervisors/default/supervisor.log.toonl`. |
 
+### Tier routing
+
+AFK classifies each claimed Ticket before spawning its runner and resolves the
+selected tier through `afk.models.<runner>.<tier>.{model,effort}`. The default
+router uses cheap Ticket metadata: type and mechanical labels, referenced paths
+and scope count in the body, risk/design keywords, and `spec:<number>` family
+membership. Docs/validation-only work routes to `validate`, ordinary
+single-scope implementation routes to the standard `simple` tier, cross-scope or
+risk-sensitive work routes to `complex`, and explicit design/routing work routes
+to `think`. If classification is unavailable or unknown, AFK continues on
+`simple`; classification never blocks a Worker.
+
+An explicit `tier:validate`, `tier:simple`, `tier:complex`, or `tier:think`
+Ticket label always wins over inferred signals. Repository overrides remain the
+normal model table above: for example, setting
+`plugins.dev.afk.models.codex.simple.model` changes what the standard route
+spawns without changing the classifier. Runtime `--model`/`RED_AFK_MODEL` and
+`--effort`/`RED_AFK_EFFORT` overrides still take precedence and flatten the
+resolved tiers as documented by the model-tier policy.
+
+Every spawn appends a route line to the Worker log and stamps
+`current.model_tier`, `current.model`, and `current.effort` in the Worker state.
+`red-skills-dev monitor` renders the active tier as `tier:<name>` on the Worker
+row, alongside the existing vitals.
+
 ```yaml
 plugins:
   dev:

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -76,6 +76,31 @@ MCP, and non-essential host hooks are absent from every projection.
 | `afk.companion.*` (cap) | `RED_AFK_RETRY_DRIFT` | `2` | Companion bounded re-enqueue budget. Each detected drift on an attempt injects **one** correction (write-only, idempotent via a fingerprint, rewriting `## Agent brief`); once the attempt count reaches this cap the companion **escalates** to `ready-for-human` (a `## Current blocker` of kind `drift`) instead of correcting again. Shares the bounded-recovery policy (`core/recovery.ts`); never kills a process — termination/respawn is the reaper + fleet's job. |
 | `afk.drain.max_cost_usd` | `RED_AFK_DRAIN_MAX_COST_USD` / `fleet --budget-usd` | _(unset)_ | Per-drain USD budget for the fleet supervisor. Spend is read from WorkerVitals (`current.cost_usd`) in worker state files, not a parallel ledger. Tiers are OK below 75%, WARNING at 75%, CRITICAL at 90%, and HARD_STOP at 100%. CRITICAL spawns new workers with one model-tier-policy downgrade; HARD_STOP stops all new spawns, lets in-flight workers finish, and records a TOON budget event in `.red/tmp/supervisors/default/supervisor.log.toonl`. |
 
+### Tier routing
+
+AFK classifies each claimed Ticket before spawning its runner and resolves the
+selected tier through `afk.models.<runner>.<tier>.{model,effort}`. The default
+router uses cheap Ticket metadata: type and mechanical labels, referenced paths
+and scope count in the body, risk/design keywords, and `spec:<number>` family
+membership. Docs/validation-only work routes to `validate`, ordinary
+single-scope implementation routes to the standard `simple` tier, cross-scope or
+risk-sensitive work routes to `complex`, and explicit design/routing work routes
+to `think`. If classification is unavailable or unknown, AFK continues on
+`simple`; classification never blocks a Worker.
+
+An explicit `tier:validate`, `tier:simple`, `tier:complex`, or `tier:think`
+Ticket label always wins over inferred signals. Repository overrides remain the
+normal model table above: for example, setting
+`plugins.dev.afk.models.codex.simple.model` changes what the standard route
+spawns without changing the classifier. Runtime `--model`/`RED_AFK_MODEL` and
+`--effort`/`RED_AFK_EFFORT` overrides still take precedence and flatten the
+resolved tiers as documented by the model-tier policy.
+
+Every spawn appends a route line to the Worker log and stamps
+`current.model_tier`, `current.model`, and `current.effort` in the Worker state.
+`red-skills-dev monitor` renders the active tier as `tier:<name>` on the Worker
+row, alongside the existing vitals.
+
 ```yaml
 plugins:
   dev:


### PR DESCRIPTION
Automated AFK landing for #2404. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2404

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787436235&installation_model_id=20659&pr_number=2633&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2633&signature=f14f3f0d2434251e24310f86a1aa7aa4b91a1c3527011e0acb2f9f6120bf57fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->