### PR TITLE
test(dev): pin host-prereq probe over all tools and ordering (#2624)

### DIFF
--- a/apps/dev/tests/host-prerequisite.test.ts
+++ b/apps/dev/tests/host-prerequisite.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { runOperationalProbes } from "../src/core/operational-probes.js";
+import {
+  HOST_PREREQUISITE_COMMANDS,
+  runHostPrerequisiteProbe,
+} from "../src/core/operational-probes/host-prerequisites.js";
 import type { ExecFn } from "../src/runtime/exec.js";
 import { collectHostPrerequisiteProbeInput } from "../src/runtime/wire/boot.js";
 import { facts, makeDeps, options, runBoot } from "./boot.helpers.js";
@@ -180,4 +184,70 @@ describe("AFK host prerequisite boot probe", () => {
     });
     expect(calls).toEqual([]);
   });
+
+  it("fires before claim acquisition or any boot sweep when a prerequisite is missing", async () => {
+    const { deps, calls } = makeDeps();
+
+    await expect(
+      runBoot(
+        deps,
+        options({
+          precheck: facts({
+            hostPrerequisites: {
+              commands: {
+                bash: true,
+                git: true,
+                jq: true,
+                gh: true,
+                node: false,
+                timeout: true,
+                ps: true,
+              },
+              bashVersion: "GNU bash, version 5.2.15(1)-release",
+            },
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({
+      phase: "host-prereq",
+      probe: {
+        evidence: expect.stringContaining("node"),
+        canonicalFix: expect.stringContaining("command -v node"),
+      },
+    });
+    // Probe is step 0 of runBoot — no fs, gh, or git IO ran.
+    // Structurally, the session loop (claim acquisition, snapshots, hooks)
+    // only starts after runBoot returns successfully, so it is unreachable
+    // when the probe halts here.
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("each missing host tool produces a named halt with its fix string", () => {
+  type Cmd = (typeof HOST_PREREQUISITE_COMMANDS)[number];
+  const allPresent: Record<Cmd, boolean> = {
+    bash: true,
+    git: true,
+    jq: true,
+    gh: true,
+    node: true,
+    timeout: true,
+    ps: true,
+  };
+
+  for (const tool of HOST_PREREQUISITE_COMMANDS) {
+    it(`${tool} missing → halt names "${tool}" with command-v fix`, () => {
+      const result = runHostPrerequisiteProbe({
+        remoteUrls: [],
+        hostPrerequisites: {
+          commands: { ...allPresent, [tool]: false },
+          bashVersion: "GNU bash, version 5.2.15(1)-release",
+        },
+      });
+
+      expect(result.verdict).toBe("red");
+      expect(result.evidence).toContain(tool);
+      expect(result.canonicalFix).toContain(`command -v ${tool}`);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

- Adds a `describe` block covering each of the 7 required host tools individually (bash/git/jq/gh/node/timeout/ps): calls `runHostPrerequisiteProbe` directly with one tool absent and asserts verdict `"red"`, evidence names the tool, and `canonicalFix` contains `command -v <tool>`.
- Adds an explicit ordering test `"fires before claim acquisition or any boot sweep when a prerequisite is missing"` using `runBoot` + `makeDeps`: asserts `calls == []` proving the probe halts at step 0 before any fs/gh/git IO — and structurally before the session loop that acquires claims and takes snapshots.

The implementation itself (`runHostPrerequisiteProbe` wired as step 0 of `runBoot`, throwing `BootHaltError("host-prereq")`) was already merged in main via #2475. These tests explicitly pin the acceptance criteria stated in #2624.

## Test plan

- [x] `pnpm -C apps/dev exec vitest run tests/host-prerequisite.test.ts` — 14 tests pass
- [x] `pnpm -C apps/dev typecheck` — clean
- [ ] CI gate green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787438207&installation_model_id=20659&pr_number=2634&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2634&signature=561d63175ca7411e15ebce61f649a2de761fb3bb5fb785c4a4713aaf1b892480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->