### PR TITLE
docs(afk): add fast-death taxonomy naming host-config class

### DIFF
--- a/packaging/pi/dev/skills/engineering/afk/TROUBLESHOOTING.md
+++ b/packaging/pi/dev/skills/engineering/afk/TROUBLESHOOTING.md
@@ -262,3 +262,28 @@ supervisor.
 Supervisor snapshots persist slot pids so takeover is automatic. This playbook
 is the manual verification path for #2067 and should stay aligned with the
 state snapshot contract.
+
+## Fast-death taxonomy
+
+A "fast death" is any worker exit the circuit breaker counts within its window
+(`CIRCUIT_K` deaths inside `CIRCUIT_WINDOW_S`). These are the named classes:
+
+- **stale-claims boot crash (dominant)**: Worker boots, reads a poisoned
+  stale-claim file, and dies before the sandcastle spawn directory is created
+  (`{issue}-{worker}/` absent from the worker dir). Signature: worker dir
+  contains only `worker.pid`, no spawn subdirectory, +0/-0 diff. Not OOM, not
+  quota. Cured by purging the stale claim and rebooting the fleet.
+
+- **gh rate-limit misread as auth failure**: A transient GitHub API rate-limit
+  burst makes `gh auth status` exit non-zero, tricking the boot pre-check into
+  reporting "gh not authenticated". Fixed — `ghAuthenticated` now discriminates
+  report text so a transient rate-limit never bricks the fleet.
+
+- **host-config: missing interpreter or cwd (terminal, non-retryable)**: Worker
+  spawn fails with `spawn sh ENOENT` (no POSIX shell on PATH) or `cwd does not
+  exist`. Previously mis-classified as `runner-transient`, which caused the
+  cooldown circuit to retry a permanent host defect indefinitely. Now classified
+  as `host-config` — no retry is scheduled, the terminal envelope names the
+  defect, and the issue is released back to the queue. Fix the host environment
+  (install or restore `sh`; confirm the configured workspace path exists) and
+  rerun.

--- a/plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md
+++ b/plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md
@@ -262,3 +262,28 @@ supervisor.
 Supervisor snapshots persist slot pids so takeover is automatic. This playbook
 is the manual verification path for #2067 and should stay aligned with the
 state snapshot contract.
+
+## Fast-death taxonomy
+
+A "fast death" is any worker exit the circuit breaker counts within its window
+(`CIRCUIT_K` deaths inside `CIRCUIT_WINDOW_S`). These are the named classes:
+
+- **stale-claims boot crash (dominant)**: Worker boots, reads a poisoned
+  stale-claim file, and dies before the sandcastle spawn directory is created
+  (`{issue}-{worker}/` absent from the worker dir). Signature: worker dir
+  contains only `worker.pid`, no spawn subdirectory, +0/-0 diff. Not OOM, not
+  quota. Cured by purging the stale claim and rebooting the fleet.
+
+- **gh rate-limit misread as auth failure**: A transient GitHub API rate-limit
+  burst makes `gh auth status` exit non-zero, tricking the boot pre-check into
+  reporting "gh not authenticated". Fixed — `ghAuthenticated` now discriminates
+  report text so a transient rate-limit never bricks the fleet.
+
+- **host-config: missing interpreter or cwd (terminal, non-retryable)**: Worker
+  spawn fails with `spawn sh ENOENT` (no POSIX shell on PATH) or `cwd does not
+  exist`. Previously mis-classified as `runner-transient`, which caused the
+  cooldown circuit to retry a permanent host defect indefinitely. Now classified
+  as `host-config` — no retry is scheduled, the terminal envelope names the
+  defect, and the issue is released back to the queue. Fix the host environment
+  (install or restore `sh`; confirm the configured workspace path exists) and
+  rerun.


### PR DESCRIPTION
## Summary

- Adds a **Fast-death taxonomy** section to `plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md` (and its packaging mirror) naming the three known fast-death patterns, including the new `host-config` class.
- The runtime reclassification (`spawn sh ENOENT` → `host-config`, not `runner-transient`) and its pinned classifier fixtures were delivered in #2476; this slice closes the doc gap called out by #2625.

## Test plan

- [x] Existing `runAgent — fatal host configuration` fixture: `spawn sh ENOENT` / `cwd does not exist` → `host-config` outcome, non-retryable (`invocations === 1`), message contains "fatal host configuration" and "not retryable"
- [x] Existing `isTransientRunnerError` fixture: ENOENT and missing-cwd excluded from transient pattern
- [x] `tests/execution-run-agent.test.ts` — 44 tests pass
- [x] `tests/doctor-docs.test.ts` — 14 tests pass (no doc-contract breakage)
- [x] `pnpm typecheck` — green (no code changes)
- [x] `pnpm codex:manifests:check`, `pnpm pi:manifests:check`, `pnpm pi:packages:check` — green

Closes #2625

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787438388&installation_model_id=20659&pr_number=2635&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2635&signature=211669ef473939c38b0029e1c064f970fdd086095be5dcaf090399677bd4edaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->