### PR TITLE
fix: #2627 Codex worker host-env hygiene: allowlist by default, strip CLAUDE_*/BASH_ENV/snapshot pointers

### DIFF
--- a/apps/dev/src/core/host-env-allowlist.ts
+++ b/apps/dev/src/core/host-env-allowlist.ts
@@ -51,12 +51,29 @@ export const AFK_HOST_ENV_ALLOWLIST: readonly string[] = [
 ];
 
 /**
- * Resolve the effective allowlist. Codex drops the default `CLAUDE*` entry so
- * Claude Code shell-snapshot pointers cannot leak into its child shell.
- * `RED_AFK_HOST_ENV_ALLOW` extends the runner default with comma-separated
- * extra entries; the single literal `*` is the escape hatch that disables
- * minimization entirely (returns undefined → red-castle inherits the full host
- * env, the pre-#1368 behavior).
+ * Entries always stripped from the codex allowlist, regardless of what the
+ * base list or operator extensions admit. These are the known-poison variables
+ * that Claude Code injects on the host and that must never reach a codex
+ * worker's process environment (#2627):
+ *
+ * - `CLAUDE*` — Claude Code session state, snapshot pointers, entrypoint flags.
+ * - `BASH_ENV` — sourced by every non-interactive bash shell; a Claude Code
+ *   `BASH_ENV` value would inject Claude Code setup into the codex worker's
+ *   child shells.
+ * - `ENV` — the POSIX sh equivalent of `BASH_ENV`; same risk under sh.
+ *
+ * Operator passthrough via `RED_AFK_HOST_ENV_ALLOW` still re-admits these
+ * for the rare case where an operator explicitly needs them.
+ */
+const CODEX_ENV_STRIP = new Set(["CLAUDE*", "BASH_ENV", "ENV"]);
+
+/**
+ * Resolve the effective allowlist. Codex strips `CLAUDE*`, `BASH_ENV`, and
+ * `ENV` so Claude Code shell-snapshot pointers and shell-init file pointers
+ * cannot leak into its child shells (#2627). `RED_AFK_HOST_ENV_ALLOW` extends
+ * the runner default with comma-separated extra entries; the single literal `*`
+ * is the escape hatch that disables minimization entirely (returns undefined →
+ * red-castle inherits the full host env, the pre-#1368 behavior).
  */
 export function resolveHostEnvAllowlist(
   env: NodeJS.ProcessEnv = process.env,
@@ -70,7 +87,7 @@ export function resolveHostEnvAllowlist(
   if (extra.includes("*")) return undefined;
   const defaults =
     runner === "codex"
-      ? AFK_HOST_ENV_ALLOWLIST.filter((entry) => entry !== "CLAUDE*")
+      ? AFK_HOST_ENV_ALLOWLIST.filter((entry) => !CODEX_ENV_STRIP.has(entry))
       : AFK_HOST_ENV_ALLOWLIST;
   return extra.length > 0 ? [...defaults, ...extra] : defaults;
 }

--- a/apps/dev/tests/host-env-allowlist.test.ts
+++ b/apps/dev/tests/host-env-allowlist.test.ts
@@ -82,6 +82,15 @@ describe("resolveHostEnvAllowlist", () => {
     expect(out).toContain("PATH");
   });
 
+  it("pins BASH_ENV and ENV out of the codex defaults — shell-init pointer strip (#2627)", () => {
+    // Regression net: these are always stripped for codex regardless of future
+    // additions to AFK_HOST_ENV_ALLOWLIST. Operator passthrough still allowed.
+    const codexList = resolveHostEnvAllowlist({}, "codex");
+    expect(codexList).not.toContain("BASH_ENV");
+    expect(codexList).not.toContain("ENV");
+    expect(codexList).not.toContain("CLAUDE*");
+  });
+
   it("the literal * escape hatch disables minimization entirely", () => {
     expect(resolveHostEnvAllowlist({ RED_AFK_HOST_ENV_ALLOW: "*" })).toBeUndefined();
     expect(resolveHostEnvAllowlist({ RED_AFK_HOST_ENV_ALLOW: "FOO,*" })).toBeUndefined();


### PR DESCRIPTION
Automated AFK landing for #2627. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2627

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787440322&installation_model_id=20659&pr_number=2638&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2638&signature=4e10ccadbbe55a90b19e761c4b589e09f2fe9f7392c36481a781c8a5c8e5f736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->