### PR TITLE
fix: #2624 Boot preflight host-prereq probe: verify bash/git/jq/gh/node before any claim or snapshot

### DIFF
--- a/apps/dev/tests/host-prerequisite.test.ts
+++ b/apps/dev/tests/host-prerequisite.test.ts
@@ -221,6 +221,34 @@ describe("AFK host prerequisite boot probe", () => {
     // when the probe halts here.
     expect(calls).toEqual([]);
   });
+
+  it("all-present: boot continues past the host-prereq step without halting", async () => {
+    const { deps } = makeDeps();
+
+    // When all prerequisites are present the probe returns ok and runBoot
+    // proceeds to the precheck/bootstrap steps (it does not throw BootHaltError).
+    const result = await runBoot(
+      deps,
+      options({
+        precheck: facts({
+          hostPrerequisites: {
+            commands: {
+              bash: true,
+              git: true,
+              jq: true,
+              gh: true,
+              node: true,
+              timeout: true,
+              ps: true,
+            },
+            bashVersion: "GNU bash, version 5.2.15(1)-release",
+          },
+        }),
+      }),
+    );
+
+    expect(result.precheck?.ok).toBe(true);
+  });
 });
 
 describe("each missing host tool produces a named halt with its fix string", () => {


### PR DESCRIPTION
Automated AFK landing for #2624. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2624

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787440765&installation_model_id=20659&pr_number=2639&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2639&signature=a8ecca9e2a2606f261bfd11eb6a76a8c61e3e52cd2d370d7e4c79e2dc848a85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->