### PR TITLE
fix(fleet): fleet_create surfaces the real spawn error (#2629)

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,11 +1,11 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
-import { readFile, readdir, stat } from "node:fs/promises";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { logsDir, waitsDir, worktreesDir } from "@reddb-io/shared/red-paths.js";
 import { Writable } from "node:stream";
-import { decode as decodeToon } from "@reddb-io/toon";
+import { decode as decodeToon, encode as encodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
 import {
   aggregateFederatedFleetView,
   armPr,
@@ -977,17 +977,25 @@ async function createFleet(root: string, rawInput: FleetCreateInput) {
       supervisorLogStart = 0;
     }
   }
-  const pid = await spawnSupervisor({
-    root,
-    target: input.target,
-    runner: profile.runner,
-    base: profile.base,
-    fleet: profile.name,
-    passthrough: profile.selector
-      ? ["--selector", JSON.stringify(profile.selector)]
-      : [],
-    adoptSlotPids: priorFleetState?.slotPids ?? [],
-  });
+  type ErrnoError = Error & { code?: string; syscall?: string };
+  let spawnErr: ErrnoError | undefined;
+  let pid: number | null;
+  try {
+    pid = await spawnSupervisor({
+      root,
+      target: input.target,
+      runner: profile.runner,
+      base: profile.base,
+      fleet: profile.name,
+      passthrough: profile.selector
+        ? ["--selector", JSON.stringify(profile.selector)]
+        : [],
+      adoptSlotPids: priorFleetState?.slotPids ?? [],
+    });
+  } catch (err) {
+    spawnErr = err instanceof Error ? (err as ErrnoError) : new Error(String(err));
+    pid = null;
+  }
   if (pid === null) {
     let rollbackConfirmed = false;
     try {
@@ -998,7 +1006,7 @@ async function createFleet(root: string, rawInput: FleetCreateInput) {
       // The failure below must not claim that registry rollback succeeded.
     }
     let tail = "";
-    if (supervisorLogStart !== undefined) {
+    if (supervisorLogStart !== undefined && !spawnErr) {
       try {
         const bytes = await readFile(paths.supervisorLogPath);
         const launchBytes =
@@ -1015,10 +1023,39 @@ async function createFleet(root: string, rawInput: FleetCreateInput) {
         // from a caller-visible but unexplained registry rollback.
       }
     }
-    const evidence = tail || "(no supervisor log output was captured)";
+    // Best-effort diagnostic artifact: always leave a spawn-failure.toon when
+    // spawn itself throws so the caller has a pinned artifact to inspect even
+    // when no supervisor log was written.
+    if (spawnErr) {
+      try {
+        await mkdir(paths.supervisorRuntimeDir, { recursive: true });
+        const doc: ToonValue = {
+          kind: "spawn-failed",
+          fleet: profile.name,
+          runner: profile.runner,
+          error: spawnErr.message,
+          ...(spawnErr.code ? { code: spawnErr.code } : {}),
+          ...(spawnErr.syscall ? { syscall: spawnErr.syscall } : {}),
+        };
+        await writeFile(
+          join(paths.supervisorRuntimeDir, "spawn-failure.toon"),
+          encodeToon(doc),
+          "utf8",
+        );
+      } catch {
+        // Diagnostic write must not shadow the real spawn error.
+      }
+    }
     const rollback = rollbackConfirmed
       ? "profile rolled back."
       : "profile rollback was attempted but could not be confirmed.";
+    if (spawnErr) {
+      throw new Error(
+        `fleet ${JSON.stringify(profile.name)} failed to start: spawn failed: ${spawnErr.message}; ` +
+          `${rollback} diagnostic: .red/tmp/supervisors/${paths.fleet}/spawn-failure.toon`,
+      );
+    }
+    const evidence = tail || "(no supervisor log output was captured)";
     throw new Error(
       `fleet ${JSON.stringify(profile.name)} failed to start: supervisor pid file did not appear; ` +
         `${rollback} log: .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n${evidence}`,

--- a/apps/dev/tests/mcp-fleet-create.test.ts
+++ b/apps/dev/tests/mcp-fleet-create.test.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
@@ -191,6 +191,35 @@ describe("fleet_create startup probe", () => {
       readFleetProfile(
         fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),
         "fast-death",
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("surfaces the spawn error and writes spawn-failure.toon when the process cannot be started", async () => {
+    const cwd = await root();
+    const paths = afkPaths(cwd, "spawn-error");
+    vi.mocked(spawnSupervisor).mockRejectedValueOnce(
+      Object.assign(new Error("spawn /bad/node ENOENT"), {
+        code: "ENOENT",
+        syscall: "spawn",
+      }),
+    );
+
+    const failure = await createCastleMcpDependencies(cwd)
+      .fleetCreate({ name: "spawn-error", runner: "codex", target: 1 })
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toMatch(/spawn \/bad\/node ENOENT/);
+
+    const spawnFailurePath = join(paths.supervisorRuntimeDir, "spawn-failure.toon");
+    const artifact = await readFile(spawnFailurePath, "utf8");
+    expect(artifact).toMatch(/spawn \/bad\/node ENOENT/);
+
+    await expect(
+      readFleetProfile(
+        fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),
+        "spawn-error",
       ),
     ).resolves.toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- When `spawnSupervisor` throws (e.g. ENOENT for a bad node path), `fleet_create` now catches the error, surfaces the real error message in the thrown `Error`, and writes a `spawn-failure.toon` diagnostic artifact under `.red/tmp/supervisors/<fleet>/`
- Fleet profile is rolled back on spawn failure (same as the existing pid-probe-timeout path)
- The existing pid-probe-timeout path (`spawnSupervisor` returns `null` — supervisor started but pid file never appeared) is unchanged: log tail still surfaces in the error

## Test plan

- [ ] `apps/dev/tests/mcp-fleet-create.test.ts` — new test: "surfaces the spawn error and writes spawn-failure.toon when the process cannot be started" (mocks `spawnSupervisor` to throw ENOENT, asserts error message contains real error, asserts `spawn-failure.toon` exists with correct content, asserts profile rolled back)
- [ ] All 5 existing `fleet_create` tests still pass (6 total now)
- [ ] `pnpm typecheck` clean
- [ ] CI gate green

Closes #2629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787441579&installation_model_id=20659&pr_number=2640&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2640&signature=a77e2a222016b3b320696a5476911c84a69cb451ca64492264253cfb22ee01a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->