### PR TITLE
fix(dev): resolve sibling dev bundle for supervisor/watchdog spawn in MCP context

### DIFF
--- a/apps/dev/src/runtime/supervisor-spawn.ts
+++ b/apps/dev/src/runtime/supervisor-spawn.ts
@@ -6,7 +6,7 @@
 
 import { spawn } from "node:child_process";
 import { closeSync, mkdirSync, openSync, renameSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 import type { ElasticShrinkMode, HeartbeatSlotPid } from "../core/supervisor.js";
 import { afkPaths } from "./wire.js";
@@ -16,6 +16,23 @@ import { migrateLegacyDevPaths } from "./red-path-migration.js";
 import { isSupervisorIdentityLive, readSupervisorIdentity, reapStaleSupervisorState } from "./supervisor-state.js";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Resolve the dev CLI bundle path from argv[1]. In MCP context argv[1] is the
+ * castle-mcp bundle, which has no `__supervise` entry point; the sibling dev
+ * bundle does. Falls back to argv1 unchanged so the CLI path (argv[1] already
+ * is the dev bundle or a shim) is unaffected.
+ */
+export function resolveDevScriptPath(argv1: string): string {
+  const file = basename(argv1);
+  if (file === "castle-mcp.bundle.min.mjs") {
+    return join(dirname(argv1), "dev.bundle.min.mjs");
+  }
+  if (file.startsWith("castle-mcp-") && file.endsWith(".bundle.min.mjs")) {
+    return join(dirname(argv1), file.replace(/^castle-mcp-/, "dev-"));
+  }
+  return argv1;
+}
 
 function isLivePid(pid: number): boolean {
   try {
@@ -106,7 +123,7 @@ export async function spawnSupervisor(opts: SpawnSupervisorOptions): Promise<num
     stderrFd = undefined;
   }
   try {
-    const child = spawn(process.execPath, [process.argv[1]!, "__supervise", ...childArgs], {
+    const child = spawn(process.execPath, [resolveDevScriptPath(process.argv[1] ?? ""), "__supervise", ...childArgs], {
       cwd: opts.root,
       env,
       detached: true,

--- a/apps/dev/src/runtime/supervisor-watchdog-spawn.ts
+++ b/apps/dev/src/runtime/supervisor-watchdog-spawn.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { resolveDevScriptPath } from "./supervisor-spawn.js";
 import { afkPaths } from "./wire.js";
 import { readPidStartTime } from "../core/state.js";
 import { isSupervisorIdentityLive, readSupervisorIdentity } from "./supervisor-state.js";
@@ -42,7 +43,7 @@ export async function spawnSupervisorWatchdog(
 
   const child = spawn(
     process.execPath,
-    [process.argv[1]!, "__watchdog", "--fleet", paths.fleet],
+    [resolveDevScriptPath(process.argv[1] ?? ""), "__watchdog", "--fleet", paths.fleet],
     {
       cwd: options.root,
       env: process.env,

--- a/apps/dev/tests/supervisor-spawn.test.ts
+++ b/apps/dev/tests/supervisor-spawn.test.ts
@@ -23,7 +23,7 @@ vi.mock("node:fs/promises", async (importOriginal) => ({
   readFile,
 }));
 
-import { spawnSupervisor } from "../src/runtime/supervisor-spawn.js";
+import { spawnSupervisor, resolveDevScriptPath } from "../src/runtime/supervisor-spawn.js";
 import { afkPaths } from "../src/runtime/wire.js";
 
 const roots: string[] = [];
@@ -108,5 +108,81 @@ describe("spawnSupervisor", () => {
 
     const options = spawn.mock.calls.at(-1)?.[2] as SpawnOptions | undefined;
     expect(options?.env?.RED_AFK_TRUNK).toBe("develop");
+  });
+
+  it("resolves the sibling dev bundle when argv[1] is the castle-mcp bundle (MCP context)", async () => {
+    const cwd = await root();
+    const saved = process.argv[1];
+    process.argv[1] = join("dist", "castle-mcp.bundle.min.mjs");
+    try {
+      await spawnSupervisor({
+        root: cwd,
+        target: 1,
+        runner: "claude",
+        probeDeadlineMs: 0,
+      });
+      const args = spawn.mock.calls.at(-1)?.[1] as string[] | undefined;
+      expect(args?.[0]).toBe(join("dist", "dev.bundle.min.mjs"));
+    } finally {
+      process.argv[1] = saved;
+    }
+  });
+
+  it("resolves the sibling dev bundle when argv[1] is a versioned castle-mcp bundle (MCP context)", async () => {
+    const cwd = await root();
+    const saved = process.argv[1];
+    process.argv[1] = join("/npx-cache", "castle-mcp-2.76.1.bundle.min.mjs");
+    try {
+      await spawnSupervisor({
+        root: cwd,
+        target: 1,
+        runner: "claude",
+        probeDeadlineMs: 0,
+      });
+      const args = spawn.mock.calls.at(-1)?.[1] as string[] | undefined;
+      expect(args?.[0]).toBe(join("/npx-cache", "dev-2.76.1.bundle.min.mjs"));
+    } finally {
+      process.argv[1] = saved;
+    }
+  });
+
+  it("passes argv[1] through unchanged when already the dev bundle (CLI context)", async () => {
+    const cwd = await root();
+    const saved = process.argv[1];
+    process.argv[1] = join("/npx-cache", "dev-2.76.1.bundle.min.mjs");
+    try {
+      await spawnSupervisor({
+        root: cwd,
+        target: 1,
+        runner: "claude",
+        probeDeadlineMs: 0,
+      });
+      const args = spawn.mock.calls.at(-1)?.[1] as string[] | undefined;
+      expect(args?.[0]).toBe(join("/npx-cache", "dev-2.76.1.bundle.min.mjs"));
+    } finally {
+      process.argv[1] = saved;
+    }
+  });
+});
+
+describe("resolveDevScriptPath", () => {
+  it("returns the sibling dev bundle for the generic castle-mcp bundle name", () => {
+    expect(resolveDevScriptPath(join("dist", "castle-mcp.bundle.min.mjs")))
+      .toBe(join("dist", "dev.bundle.min.mjs"));
+  });
+
+  it("returns the sibling dev bundle for a versioned castle-mcp bundle name", () => {
+    expect(resolveDevScriptPath(join("cache", "castle-mcp-2.76.1.bundle.min.mjs")))
+      .toBe(join("cache", "dev-2.76.1.bundle.min.mjs"));
+  });
+
+  it("passes through a dev bundle path unchanged", () => {
+    const devBundle = join("dist", "dev.bundle.min.mjs");
+    expect(resolveDevScriptPath(devBundle)).toBe(devBundle);
+  });
+
+  it("passes through an arbitrary CLI shim path unchanged (no PATH-dependent shim lookup)", () => {
+    const shim = "/usr/local/bin/red-skills-dev";
+    expect(resolveDevScriptPath(shim)).toBe(shim);
   });
 });


### PR DESCRIPTION
## Summary

- `spawnSupervisor` and `spawnSupervisorWatchdog` both used `process.argv[1]` directly to resolve the script to exec for `__supervise`/`__watchdog`. In MCP context `process.argv[1]` is `castle-mcp.bundle.min.mjs`, which has no `__supervise` entry point — so `fleet_create` always failed while the CLI worked.
- Adds `resolveDevScriptPath(argv1)` in `supervisor-spawn.ts`: maps `castle-mcp*.bundle.min.mjs` → sibling `dev*.bundle.min.mjs`; passes any other path through unchanged (CLI, arbitrary shim).
- Both spawn sites now call `resolveDevScriptPath(process.argv[1] ?? "")` — one shared implementation, no PATH-dependent shim lookup.
- Regression harness in `supervisor-spawn.test.ts` pins the MCP-context resolution (both generic and versioned bundle names) and the CLI pass-through.

## Test plan

- [ ] Typecheck passes (`pnpm -C apps/dev run typecheck`)
- [ ] New `resolveDevScriptPath` unit tests pass in `supervisor-spawn.test.ts`
- [ ] New MCP-context spawn regression tests pass (verify `spawn` receives the dev bundle, not the MCP bundle)
- [ ] Existing `spawnSupervisor` tests continue to pass
- [ ] CI gate green

Refs #2630

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787441892&installation_model_id=20659&pr_number=2641&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2641&signature=8c7bf6c2cf578e3ae2dc9d5c9bdd26490f9c7c689db34ff4ec0a9b9e8a2636e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->