### PR TITLE
fix: #2631 fleet_create must never leave an orphaned worker: register-before-dispatch or reap-on-failure

### DIFF
--- a/apps/dev/src/core/fleet-create-reap.ts
+++ b/apps/dev/src/core/fleet-create-reap.ts
@@ -1,0 +1,53 @@
+// fleet-create-reap — reap orphaned workers on fleet_create failure.
+//
+// When fleet_create detects a fast-death (supervisor pid file never appeared),
+// the supervisor may have dispatched one or more workers before dying. Those
+// workers are left orphaned — no supervisor to respawn/land them. This module
+// kills their process groups and concedes their GitHub claims so a failed create
+// leaves zero residue (no live worker process, no held claim).
+
+import { readFleetState } from '../runtime/wire.js';
+import { readAllWorkerStates } from './worker-state-reader.js';
+import { signalTree } from '../runtime/kill-tree.js';
+
+/**
+ * Kill any worker processes the dying supervisor dispatched (via slot_pids in
+ * the fleet state file), and concede their GitHub claims.
+ *
+ * Called by fleet_create on failure — AFTER the profile rollback — as a
+ * best-effort cleanup. Each step swallows its own errors so a failed reap
+ * never shadows the real spawn error.
+ */
+export async function reapOrphanedFleetWorkers(
+  fleetStatePath: string,
+  tmpDir: string,
+  concedeClaim: (issue: number, worker: { id: string; runner: string }) => Promise<void>,
+): Promise<void> {
+  const state = await readFleetState(fleetStatePath).catch(() => null);
+  const slotPids = state?.slotPids;
+  if (!slotPids?.length) return;
+
+  const pidSet = new Set<number>();
+  for (const { pid } of slotPids) {
+    if (pid > 0) pidSet.add(pid);
+  }
+  if (pidSet.size === 0) return;
+
+  for (const pid of pidSet) {
+    signalTree(pid, 'SIGKILL');
+  }
+
+  const workers = await readAllWorkerStates(tmpDir).catch(() => []);
+  const conceded = new Set<number>();
+  for (const record of workers) {
+    const { pid, worker_id, runner, current } = record.state;
+    if (!pidSet.has(pid)) continue;
+    const rawIssue = current.number;
+    if (!rawIssue) continue;
+    const issue =
+      typeof rawIssue === 'number' ? rawIssue : parseInt(String(rawIssue), 10);
+    if (!Number.isFinite(issue) || issue <= 0 || conceded.has(issue)) continue;
+    conceded.add(issue);
+    await concedeClaim(issue, { id: worker_id, runner }).catch(() => undefined);
+  }
+}

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -117,6 +117,7 @@ import {
   renderClaimComment,
   type ClaimRecord,
 } from "./core/claim.js";
+import { reapOrphanedFleetWorkers } from "./core/fleet-create-reap.js";
 import { parseReqLabels, planCloseCascade, type DependentIssue } from "./core/boot-sweep.js";
 import {
   branchesToReap,
@@ -934,7 +935,11 @@ async function fleetStatus(
   };
 }
 
-async function createFleet(root: string, rawInput: FleetCreateInput) {
+async function createFleet(
+  root: string,
+  rawInput: FleetCreateInput,
+  concedeClaim: (issue: number, worker: { id: string; runner: string }) => Promise<void>,
+) {
   const input: FleetCreateInput = {
     ...rawInput,
     ...(rawInput.selector
@@ -1005,6 +1010,14 @@ async function createFleet(root: string, rawInput: FleetCreateInput) {
     } catch {
       // The failure below must not claim that registry rollback succeeded.
     }
+    // Reap any workers the fast-dying supervisor dispatched before it could write
+    // its pid file. Best-effort: swallow all errors so the reap never shadows the
+    // real spawn error.
+    await reapOrphanedFleetWorkers(
+      paths.fleetStatePath,
+      afkPaths(root).tmpDir,
+      concedeClaim,
+    ).catch(() => undefined);
     let tail = "";
     if (supervisorLogStart !== undefined && !spawnErr) {
       try {
@@ -1626,7 +1639,21 @@ export function createCastleMcpDependencies(
   const baseDeps: CastleMcpDependencies = {
     fleetList: () => readFleetProfiles(registryPath(root)),
     fleetStatus: (input) => fleetStatus(root, input),
-    fleetCreate: (input) => createFleet(root, input),
+    fleetCreate: async (input) => {
+      const concedeClaim = async (issue: number, worker: { id: string; runner: string }) => {
+        try {
+          const context = await resolveRepoContext(root);
+          await ghx.postClaimComment(
+            { cwd: root, repo: context.repo },
+            issue,
+            renderClaimComment({ worker: worker.id, runner: worker.runner }, "concede", "released"),
+          );
+        } catch {
+          // best-effort — never shadow the real spawn error
+        }
+      };
+      return createFleet(root, input, concedeClaim);
+    },
     fleetEdit: (input) => editFleet(root, input),
     fleetStop: async (input) => {
       const silent = new Writable({

--- a/apps/dev/tests/fleet-create-reap.test.ts
+++ b/apps/dev/tests/fleet-create-reap.test.ts
@@ -1,0 +1,170 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseState } from "../src/core/state.js";
+import type { WorkerStateRecord } from "../src/core/worker-state-reader.js";
+
+vi.mock("../src/runtime/wire.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/runtime/wire.js")>();
+  return { ...actual, readFleetState: vi.fn() };
+});
+
+vi.mock("../src/core/worker-state-reader.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/core/worker-state-reader.js")>();
+  return { ...actual, readAllWorkerStates: vi.fn() };
+});
+
+vi.mock("../src/runtime/kill-tree.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/runtime/kill-tree.js")>();
+  return { ...actual, signalTree: vi.fn() };
+});
+
+import { reapOrphanedFleetWorkers } from "../src/core/fleet-create-reap.js";
+import { readFleetState } from "../src/runtime/wire.js";
+import { readAllWorkerStates } from "../src/core/worker-state-reader.js";
+import { signalTree } from "../src/runtime/kill-tree.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+beforeEach(() => {
+  vi.mocked(readFleetState).mockReset();
+  vi.mocked(readAllWorkerStates).mockReset();
+  vi.mocked(signalTree).mockReset();
+});
+
+async function tmpRoot(): Promise<string> {
+  const value = await mkdtemp(join(tmpdir(), "fleet-create-reap-"));
+  roots.push(value);
+  return value;
+}
+
+function makeWorkerRecord(pid: number, issue: number | string, workerId = "wTEST", runner = "codex"): WorkerStateRecord {
+  return {
+    path: `/fake/${workerId}/1/afk.state.toon`,
+    state: parseState({ pid, worker_id: workerId, runner, current: { number: issue } }),
+    live: true,
+    active: true,
+    liveness: "active",
+    livenessVerdict: { status: "alive", laneFresh: true, crossCheckArmed: false, reason: "test" },
+    pidIdentityLive: true,
+    hostPidLive: false,
+    renderableLive: true,
+  };
+}
+
+function fakeFleetState(slotPids: Array<{ slot: number; pid: number }>) {
+  return {
+    ts: "2026-07-23T00:00:00Z",
+    epoch: 0,
+    runner: "codex",
+    readyForAgent: 0,
+    slotsBusy: slotPids.length,
+    slotsFree: 0,
+    slotsTotal: slotPids.length,
+    slotsParked: 0,
+    spawnsThisTick: slotPids.length,
+    slotPids,
+  };
+}
+
+describe("reapOrphanedFleetWorkers", () => {
+  it("does nothing when the fleet state has no slot_pids", async () => {
+    const cwd = await tmpRoot();
+    vi.mocked(readFleetState).mockResolvedValue(fakeFleetState([]));
+    vi.mocked(readAllWorkerStates).mockResolvedValue([]);
+
+    const concedeClaim = vi.fn();
+    await reapOrphanedFleetWorkers("/fake/state.toonl", cwd, concedeClaim);
+
+    expect(signalTree).not.toHaveBeenCalled();
+    expect(concedeClaim).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the fleet state is unreadable", async () => {
+    const cwd = await tmpRoot();
+    vi.mocked(readFleetState).mockRejectedValue(new Error("ENOENT"));
+
+    const concedeClaim = vi.fn();
+    await reapOrphanedFleetWorkers("/fake/state.toonl", cwd, concedeClaim);
+
+    expect(signalTree).not.toHaveBeenCalled();
+    expect(concedeClaim).not.toHaveBeenCalled();
+  });
+
+  it("kills each slot pid and concedes the matching worker's claim", async () => {
+    const cwd = await tmpRoot();
+    vi.mocked(readFleetState).mockResolvedValue(
+      fakeFleetState([{ slot: 0, pid: 77_001 }, { slot: 1, pid: 77_002 }]),
+    );
+    vi.mocked(readAllWorkerStates).mockResolvedValue([
+      makeWorkerRecord(77_001, 2601, "wAAA1", "codex"),
+      makeWorkerRecord(77_002, 2602, "wAAA2", "claude"),
+    ]);
+
+    const concedeClaim = vi.fn().mockResolvedValue(undefined);
+    await reapOrphanedFleetWorkers("/fake/state.toonl", cwd, concedeClaim);
+
+    expect(signalTree).toHaveBeenCalledWith(77_001, "SIGKILL");
+    expect(signalTree).toHaveBeenCalledWith(77_002, "SIGKILL");
+
+    expect(concedeClaim).toHaveBeenCalledWith(2601, { id: "wAAA1", runner: "codex" });
+    expect(concedeClaim).toHaveBeenCalledWith(2602, { id: "wAAA2", runner: "claude" });
+  });
+
+  it("skips claim concession for workers with no identified issue", async () => {
+    const cwd = await tmpRoot();
+    vi.mocked(readFleetState).mockResolvedValue(fakeFleetState([{ slot: 0, pid: 77_003 }]));
+    vi.mocked(readAllWorkerStates).mockResolvedValue([
+      makeWorkerRecord(77_003, "", "wBBB1"),
+    ]);
+
+    const concedeClaim = vi.fn();
+    await reapOrphanedFleetWorkers("/fake/state.toonl", cwd, concedeClaim);
+
+    expect(signalTree).toHaveBeenCalledWith(77_003, "SIGKILL");
+    expect(concedeClaim).not.toHaveBeenCalled();
+  });
+
+  it("skips workers whose pid does not match any slot pid", async () => {
+    const cwd = await tmpRoot();
+    vi.mocked(readFleetState).mockResolvedValue(fakeFleetState([{ slot: 0, pid: 77_004 }]));
+    // Worker with a DIFFERENT pid — not an orphan
+    vi.mocked(readAllWorkerStates).mockResolvedValue([
+      makeWorkerRecord(99_999, 2603, "wCCC1"),
+    ]);
+
+    const concedeClaim = vi.fn();
+    await reapOrphanedFleetWorkers("/fake/state.toonl", cwd, concedeClaim);
+
+    expect(signalTree).toHaveBeenCalledWith(77_004, "SIGKILL");
+    expect(concedeClaim).not.toHaveBeenCalled();
+  });
+
+  it("swallows concedeClaim errors so one failed concession does not stop others", async () => {
+    const cwd = await tmpRoot();
+    vi.mocked(readFleetState).mockResolvedValue(
+      fakeFleetState([{ slot: 0, pid: 77_005 }, { slot: 1, pid: 77_006 }]),
+    );
+    vi.mocked(readAllWorkerStates).mockResolvedValue([
+      makeWorkerRecord(77_005, 2604, "wDDD1"),
+      makeWorkerRecord(77_006, 2605, "wDDD2"),
+    ]);
+
+    const concedeClaim = vi.fn()
+      .mockRejectedValueOnce(new Error("GitHub API 503"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      reapOrphanedFleetWorkers("/fake/state.toonl", cwd, concedeClaim),
+    ).resolves.toBeUndefined();
+
+    expect(concedeClaim).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/dev/tests/mcp-fleet-create.test.ts
+++ b/apps/dev/tests/mcp-fleet-create.test.ts
@@ -21,11 +21,17 @@ vi.mock("@reddb-io/red-castle/engine", async (importOriginal) => {
   return {
     ...actual,
     removeFleetProfile: vi.fn(actual.removeFleetProfile),
+    upsertFleetProfile: vi.fn(actual.upsertFleetProfile),
   };
 });
 
+vi.mock("../src/core/fleet-create-reap.js", () => ({
+  reapOrphanedFleetWorkers: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { createCastleMcpDependencies } from "../src/mcp-adapter.js";
 import { spawnSupervisor } from "../src/runtime/supervisor-spawn.js";
+import { reapOrphanedFleetWorkers } from "../src/core/fleet-create-reap.js";
 import { afkPaths } from "../src/runtime/wire.js";
 
 const roots: string[] = [];
@@ -39,6 +45,8 @@ afterEach(async () => {
 beforeEach(() => {
   vi.mocked(spawnSupervisor).mockReset();
   vi.mocked(removeFleetProfile).mockClear();
+  vi.mocked(upsertFleetProfile).mockClear();
+  vi.mocked(reapOrphanedFleetWorkers).mockClear();
 });
 
 async function root(): Promise<string> {
@@ -245,5 +253,81 @@ describe("fleet_create startup probe", () => {
         "rollback-failure",
       ),
     ).resolves.toMatchObject({ name: "rollback-failure", runner: "codex" });
+  });
+});
+
+describe("fleet_create register-before-dispatch ordering", () => {
+  it("registers the profile on disk before spawning the supervisor", async () => {
+    const cwd = await root();
+    let profileExistedAtSpawn = false;
+
+    vi.mocked(spawnSupervisor).mockImplementation(async (opts) => {
+      const profile = await readFleetProfile(
+        fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),
+        "ordering-fleet",
+      );
+      profileExistedAtSpawn = profile !== undefined;
+      return 43130;
+    });
+
+    await createCastleMcpDependencies(cwd).fleetCreate({
+      name: "ordering-fleet",
+      runner: "codex",
+      target: 1,
+    });
+
+    expect(profileExistedAtSpawn).toBe(true);
+  });
+});
+
+describe("fleet_create reap-on-failure", () => {
+  it("reaps orphaned workers and leaves no profile when the supervisor fast-dies", async () => {
+    const cwd = await root();
+    const paths = afkPaths(cwd, "zero-residue");
+    vi.mocked(spawnSupervisor).mockResolvedValue(null);
+
+    const failure = await createCastleMcpDependencies(cwd)
+      .fleetCreate({ name: "zero-residue", runner: "codex", target: 1 })
+      .catch((e: unknown) => e);
+
+    // profile was rolled back (no profile)
+    await expect(
+      readFleetProfile(
+        fleetRegistryPath(createEnginePaths(join(cwd, ".red"))),
+        "zero-residue",
+      ),
+    ).resolves.toBeUndefined();
+
+    // reap was triggered with the fleet state path and tmp dir (kills workers +
+    // concedes claims via reapOrphanedFleetWorkers)
+    expect(reapOrphanedFleetWorkers).toHaveBeenCalledWith(
+      paths.fleetStatePath,
+      afkPaths(cwd).tmpDir,
+      expect.any(Function),
+    );
+
+    // the original error is still surfaced
+    expect(failure).toBeInstanceOf(Error);
+  });
+
+  it("reaps orphaned workers when the spawn syscall itself fails", async () => {
+    const cwd = await root();
+    const paths = afkPaths(cwd, "spawn-reap");
+    vi.mocked(spawnSupervisor).mockRejectedValueOnce(
+      Object.assign(new Error("spawn /bad/node ENOENT"), {
+        code: "ENOENT",
+        syscall: "spawn",
+      }),
+    );
+
+    await createCastleMcpDependencies(cwd)
+      .fleetCreate({ name: "spawn-reap", runner: "codex", target: 1 })
+      .catch(() => undefined);
+
+    expect(reapOrphanedFleetWorkers).toHaveBeenCalledWith(
+      paths.fleetStatePath,
+      afkPaths(cwd).tmpDir,
+      expect.any(Function),
+    );
   });
 });


### PR DESCRIPTION
Automated AFK landing for #2631. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2631

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787443475&installation_model_id=20659&pr_number=2643&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2643&signature=6bf9937c8e152da1e07e18d0b0ee56d53b7d94642a70ed7e97fb8219d7eca5e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->