### PR TITLE
fix: #2650 Document rsp provisioning end to end: what it is, how it activates, escape hatches

### DIFF
--- a/apps/rsp/README.md
+++ b/apps/rsp/README.md
@@ -37,6 +37,50 @@ and the benchmark guide is at [bench/README.md](bench/README.md).
   `rsp hook codex-pre-exec` are the hook interception surfaces used by
   supported agent hosts.
 
+## Provisioning
+
+`rsp` ships as a bundled Node.js entry point (`dist/rsp.bundle.min.mjs`) inside
+the RedSkills plugin distribution. No global `npm install -g` is required.
+Supported agent hosts wire the hook command as:
+
+```sh
+node "${CLAUDE_PLUGIN_ROOT}/dist/rsp.bundle.min.mjs" hook claude-pre-exec
+```
+
+This resolves the binary from the active plugin root rather than `PATH`. If the
+bundled entry point cannot be resolved, the hook passes the original command
+through unchanged — never `command not found`.
+
+**Optional PATH shim.** For interactive shell use,
+`plugins/dev/skills/engineering/red-setup/scripts/install-runtime-shim.sh`
+installs a thin `rsp` shim at `${XDG_BIN_HOME:-$HOME/.local/bin}/rsp`. The
+shim prefers the active CLI plugin-root env var, then scans known plugin caches
+and the warmed bundle cache under
+`${RED_SKILLS_CACHE_DIR:-$HOME/.cache/red-skills/bundles}`. It never runs `npm`
+or performs network resolution during session startup.
+
+**Opt-ins.** Hook rewrites and proxy routing are off by default. Enable them
+per-repository in `.red/config.yaml`:
+
+- `rsp.enabled: true` — activates hook rewrites for supported command families.
+- `rsp.proxy.enabled: true` — additionally routes every eligible command through
+  `rsp proxy` for universal coverage (see [Permanent Proxy Model](#permanent-proxy-model)).
+
+Absent `rsp.enabled`, the hook is fully inert and all commands pass through
+unchanged.
+
+**Escape hatches.** To skip proxy routing for a single command invocation, set
+`RSP_NO_PROXY=1` or `RED_SKILLS_RSP_NO_PROXY=1` in the environment. To disable
+proxy routing for the whole repository while keeping explicit wrapper rewrites
+active, set `rsp.proxy.enabled: false` in `.red/config.yaml`.
+
+**Failure semantics.** If the bundled entry point cannot be resolved, the hook
+passes the original command through raw. If a wrapper or resident path fails,
+`rsp` degrades to the raw command preserving stdout, stderr, and exit status.
+Token efficiency is opportunistic; loss of `rsp` never causes a broken or
+missing command result. See
+[Fail-Open Invariant](docs/ARCHITECTURE.md#fail-open-invariant).
+
 ## Permanent Proxy Model
 
 The pre-exec hook has two modes after `rsp.enabled: true` is set. Without the

--- a/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -111,6 +111,8 @@ Three things to verify after setup:
 
 The per-host ambient instruction surface that replaces legacy host-local terminal guidance is tracked in #1415 and generated from `apps/rsp/generated/AMBIENT-SKILL.md`; do not block setup on it.
 
+The full provisioning story — how the binary reaches a host without a global install, the opt-in knobs, the escape hatches (`RSP_NO_PROXY=1` / `RED_SKILLS_RSP_NO_PROXY=1`), and the failure semantics — is documented in `apps/rsp/README.md` under **Provisioning**.
+
 **Section E1 — Runtime launcher (strongly recommended).**
 
 > Explainer: `CLAUDE_PLUGIN_ROOT`, `CODEX_PLUGIN_ROOT`, and similar variables are plugin/hook environment variables. They are not guaranteed in the interactive shell where an agent runs `/afk`, `/go`, `/dashboard`, or `/retake`. Setting those names globally is brittle because they point at versioned plugin-cache directories and can become stale after an update. The cross-CLI surface should be a stable command, not a global fake plugin-root variable.

--- a/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -111,6 +111,8 @@ Three things to verify after setup:
 
 The per-host ambient instruction surface that replaces legacy host-local terminal guidance is tracked in #1415 and generated from `apps/rsp/generated/AMBIENT-SKILL.md`; do not block setup on it.
 
+The full provisioning story — how the binary reaches a host without a global install, the opt-in knobs, the escape hatches (`RSP_NO_PROXY=1` / `RED_SKILLS_RSP_NO_PROXY=1`), and the failure semantics — is documented in `apps/rsp/README.md` under **Provisioning**.
+
 **Section E1 — Runtime launcher (strongly recommended).**
 
 > Explainer: `CLAUDE_PLUGIN_ROOT`, `CODEX_PLUGIN_ROOT`, and similar variables are plugin/hook environment variables. They are not guaranteed in the interactive shell where an agent runs `/afk`, `/go`, `/dashboard`, or `/retake`. Setting those names globally is brittle because they point at versioned plugin-cache directories and can become stale after an update. The cross-CLI surface should be a stable command, not a global fake plugin-root variable.


### PR DESCRIPTION
Automated AFK landing for #2650. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2650

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787455169&installation_model_id=20659&pr_number=2653&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2653&signature=c36e428146f44bc3ae8b931861cf1358c79c7480fca2fec8ba29bc908707646f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->