### PR TITLE
feat(rsp): guard hook rewrites behind binary resolution check

### DIFF
--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -1,5 +1,4 @@
-import { readFileSync } from "node:fs";
-import { existsSync } from "node:fs";
+import { accessSync, constants, existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { resolveRspConfig, type RspRuntimeConfig } from "./config.js";
 import {
@@ -48,6 +47,44 @@ export interface HookDecisionOptions {
   isResidentHealthy?: (cwd: string) => boolean | Promise<boolean>;
   wakeResident?: (cwd: string) => void | Promise<void>;
   rewrite?: (command: string) => RewriteDecision;
+  resolveBinary?: () => boolean;
+}
+
+let _cachedBinaryResolved: boolean | undefined;
+let _binaryHintEmitted = false;
+
+export function _testOnlyResetBinaryState(): void {
+  _cachedBinaryResolved = undefined;
+  _binaryHintEmitted = false;
+}
+
+function resolveRspBinaryFromPath(): boolean {
+  const dirs = (process.env.PATH ?? "").split(":");
+  for (const dir of dirs) {
+    if (!dir) continue;
+    try {
+      accessSync(`${dir}/rsp`, constants.X_OK);
+      return true;
+    } catch {
+      // not in this dir
+    }
+  }
+  return false;
+}
+
+function resolveBinaryOnce(resolver: () => boolean): boolean {
+  if (_cachedBinaryResolved === undefined) {
+    _cachedBinaryResolved = resolver();
+  }
+  return _cachedBinaryResolved;
+}
+
+function emitBinaryHint(): void {
+  if (_binaryHintEmitted) return;
+  _binaryHintEmitted = true;
+  process.stderr.write(
+    "rsp: entrypoint not found on PATH; run `rsp setup` to provision. See apps/rsp/docs/TROUBLESHOOTING.md\n",
+  );
 }
 
 export const RSP_WRAPPER_CAPABILITIES: readonly RspWrapperCapability[] = [
@@ -200,6 +237,17 @@ async function hookDecisionResultFromPreExecJson(
       event: hookDecisionEvent({ hook, command, decision, reason: "missing-command" }),
     };
   }
+  const binaryResolved = resolveBinaryOnce(options.resolveBinary ?? resolveRspBinaryFromPath);
+  if (!binaryResolved) {
+    emitBinaryHint();
+    const decision: RewriteDecision = { kind: "passthrough", reason: "binary-unresolved" };
+    return {
+      decision,
+      telemetryRoot: cwd,
+      event: hookDecisionEvent({ hook, command, decision, reason: "binary-unresolved" }),
+    };
+  }
+
   const started = process.hrtime.bigint();
   const config = resolveRspConfig(cwd, process.env);
   const decision = config.proxyEnabled ? proxyCommand(command) : (options.rewrite ?? rewriteCommand)(command);

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -13,6 +13,7 @@ import {
   hookDecisionFromCodexPreExecJson,
   rewriteCommand,
   rewriteTableFromCapabilities,
+  _testOnlyResetBinaryState,
 } from "../src/intercept.js";
 import {
   RSP_DECISIONS_COLLECTION,
@@ -30,6 +31,7 @@ async function tempRoot(): Promise<string> {
 }
 
 afterEach(async () => {
+  _testOnlyResetBinaryState();
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
@@ -503,6 +505,79 @@ describe("rsp Codex pre-execution hook integration", () => {
     const contributed = events.filter((event) => event.decision === "contributed").length;
     expect(events).toHaveLength(corpus.length);
     expect(contributed / events.length).toBeGreaterThanOrEqual(0.25);
+  });
+});
+
+describe("rsp binary resolution guard", () => {
+  it("passes through with binary-unresolved when entrypoint is unresolvable", async () => {
+    const root = await tempRoot();
+    const decision = await hookDecisionFromClaudePreExecJson(
+      JSON.stringify({ cwd: root, tool_input: { command: "git status" } }),
+      { cwd: root, isEnabled: () => true, resolveBinary: () => false },
+    );
+    expect(decision).toEqual({ kind: "passthrough", reason: "binary-unresolved" });
+  });
+
+  it("raw command is untouched on unresolvable entrypoint (empty updatedInput)", async () => {
+    const root = await tempRoot();
+    const decision = await hookDecisionFromClaudePreExecJson(
+      JSON.stringify({ cwd: root, tool_input: { command: "git log --oneline" } }),
+      { cwd: root, isEnabled: () => true, resolveBinary: () => false },
+    );
+    expect(formatHookDecision(decision)).toEqual({ stdout: "", status: 0 });
+  });
+
+  it("caches the resolution result; resolver called once across multiple invocations", async () => {
+    const root = await tempRoot();
+    let callCount = 0;
+    const opts = {
+      cwd: root,
+      isEnabled: () => true as boolean,
+      resolveBinary: () => { callCount += 1; return false; },
+    };
+
+    for (let i = 0; i < 3; i++) {
+      await hookDecisionFromClaudePreExecJson(
+        JSON.stringify({ cwd: root, tool_input: { command: "git status" } }),
+        opts,
+      );
+    }
+
+    expect(callCount).toBe(1);
+  });
+
+  it("passes through with binary-unresolved in the proxy path too", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: true\n", "utf8");
+
+    const decision = await hookDecisionFromCodexPreExecJson(
+      JSON.stringify({ cwd: root, tool_name: "bash", tool_input: { command: "printf ok" } }),
+      { cwd: root, resolveBinary: () => false },
+    );
+    expect(decision).toEqual({ kind: "passthrough", reason: "binary-unresolved" });
+  });
+
+  it("records binary-unresolved in telemetry so rsp stats can render it", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+
+    const res = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "codex-pre-exec"], {
+      cwd: root,
+      input: Buffer.from(JSON.stringify({ cwd: root, tool_name: "bash", tool_input: { command: "git status" } })),
+      env: { ...process.env, PATH: "/no-rsp-here" },
+    });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toEqual(Buffer.alloc(0));
+    const events = await readSpoolEvents(root);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      collection: RSP_DECISIONS_COLLECTION,
+      decision: "passed",
+      reason: "binary-unresolved",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Before emitting any rewrite in `proxyCommand` and `rewriteCommand` paths, resolves the rsp entrypoint via PATH walk (`accessSync` over each PATH dir)
- Unresolvable → `passthrough` with reason `binary-unresolved`; emits a one-time stderr hint pointing at `apps/rsp/docs/TROUBLESHOOTING.md`
- Resolution is cached per session (module-level variable) — no per-command stat cost; `resolveBinary` option is injectable for testing, and `_testOnlyResetBinaryState()` resets cache between tests
- Telemetry event carries `reason: "binary-unresolved"`; surfaces automatically in `rsp stats` `top_pass_reasons`

## Test plan

- [ ] `pnpm typecheck` — green
- [ ] `pnpm -C apps/dev test` — 4550 passed, gate green
- [ ] `pnpm -C apps/opencode-host test` — 95 passed
- [ ] `pnpm -C apps/afk-container test` — 55 passed
- [ ] `apps/rsp` integration suite: 5 new tests in "rsp binary resolution guard" all pass; pre-existing 5 failures unchanged (pre-existing on main, confirmed via stash revert)

Closes #2648

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787455641&installation_model_id=20659&pr_number=2654&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2654&signature=b6b8a806f72a01c8f3d4f1ac40b9b26cf037aa7838540ff6e3704254cc3fd267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->