### PR TITLE
fix(rsp): rewrites target the plugin-bundled entrypoint, never a bare PATH shim

### DIFF
--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -5,6 +5,7 @@ import {
   kickResidentServer,
   resolveResidentPaths,
 } from "./resident-client.js";
+import { resolveRspInvocationPrefix } from "./rsp-cli.js";
 import {
   appendTelemetryEvent,
   RSP_DECISIONS_COLLECTION,
@@ -48,6 +49,7 @@ export interface HookDecisionOptions {
   wakeResident?: (cwd: string) => void | Promise<void>;
   rewrite?: (command: string) => RewriteDecision;
   resolveBinary?: () => boolean;
+  rspInvocationPrefix?: string[];
 }
 
 let _cachedBinaryResolved: boolean | undefined;
@@ -120,25 +122,25 @@ export function rewriteTableFromCapabilities(capabilities: readonly RspWrapperCa
   return table;
 }
 
-export function rewriteCommand(command: string): RewriteDecision {
+export function rewriteCommand(command: string, rspPrefix: string[] = resolveRspInvocationPrefix()): RewriteDecision {
   const losslessGh = losslessGhJsonJqPassthrough(command);
   if (losslessGh) return losslessGh;
 
   const parsed = parseCertainSimpleCommand(command);
-  if (!parsed) return rewriteCompoundCommand(command);
+  if (!parsed) return rewriteCompoundCommand(command, rspPrefix);
   const tokens = parsed.tokens.map((token) => token.text);
-  if (tokens.length > 0 && isEnvAssignment(tokens[0]!)) return rewriteCompoundCommand(command);
+  if (tokens.length > 0 && isEnvAssignment(tokens[0]!)) return rewriteCompoundCommand(command, rspPrefix);
 
-  const fileRead = rewriteFileReadCommand(parsed);
+  const fileRead = rewriteFileReadCommand(parsed, rspPrefix);
   if (fileRead) return fileRead;
 
-  if (parsed.tokens.some((token) => token.quoted)) return rewriteCompoundCommand(command);
+  if (parsed.tokens.some((token) => token.quoted)) return rewriteCompoundCommand(command, rspPrefix);
 
   const capability = [...RSP_WRAPPER_CAPABILITIES]
     .sort((left, right) => right.command.length - left.command.length)
     .find((entry) => tokensStartWith(tokens, entry.command));
-  if (!capability) return rewriteCompoundCommand(command);
-  const rewritten = ["rsp", ...capability.wrapper, ...tokens.slice(capability.command.length)];
+  if (!capability) return rewriteCompoundCommand(command, rspPrefix);
+  const rewritten = [...rspPrefix, ...capability.wrapper, ...tokens.slice(capability.command.length)];
   const redirectSuffix = formatRedirectSuffix(parsed.redirectSuffix);
   return {
     kind: "rewrite",
@@ -147,15 +149,16 @@ export function rewriteCommand(command: string): RewriteDecision {
   };
 }
 
-function rewriteFileReadCommand(parsed: ParsedSimpleCommand): RewriteDecision | null {
+function rewriteFileReadCommand(parsed: ParsedSimpleCommand, rspPrefix: string[]): RewriteDecision | null {
   const tokens = parsed.tokens.map((token) => token.text);
   const command = tokens[0];
   const redirectSuffix = formatRedirectSuffix(parsed.redirectSuffix);
+  const prefix = rspPrefix.map(shellQuoteIfNeeded);
   if (command === "cat" && tokens.length === 2 && isPlainFileToken(tokens[1]!)) {
-    return { kind: "rewrite", command: ["rsp", "cat", shellQuoteIfNeeded(tokens[1]!), ...redirectSuffix].join(" "), capabilityId: "cat:file" };
+    return { kind: "rewrite", command: [...prefix, "cat", shellQuoteIfNeeded(tokens[1]!), ...redirectSuffix].join(" "), capabilityId: "cat:file" };
   }
   if ((command === "head" || command === "tail") && tokens.length === 2 && isPlainFileToken(tokens[1]!)) {
-    return { kind: "rewrite", command: ["rsp", "cat", `--${command}`, "10", shellQuoteIfNeeded(tokens[1]!), ...redirectSuffix].join(" "), capabilityId: `cat:${command}` };
+    return { kind: "rewrite", command: [...prefix, "cat", `--${command}`, "10", shellQuoteIfNeeded(tokens[1]!), ...redirectSuffix].join(" "), capabilityId: `cat:${command}` };
   }
   if (
     (command === "head" || command === "tail") &&
@@ -164,7 +167,7 @@ function rewriteFileReadCommand(parsed: ParsedSimpleCommand): RewriteDecision | 
     /^[1-9][0-9]*$/.test(tokens[2]!) &&
     isPlainFileToken(tokens[3]!)
   ) {
-    return { kind: "rewrite", command: ["rsp", "cat", `--${command}`, tokens[2]!, shellQuoteIfNeeded(tokens[3]!), ...redirectSuffix].join(" "), capabilityId: `cat:${command}` };
+    return { kind: "rewrite", command: [...prefix, "cat", `--${command}`, tokens[2]!, shellQuoteIfNeeded(tokens[3]!), ...redirectSuffix].join(" "), capabilityId: `cat:${command}` };
   }
   if (
     (command === "head" || command === "tail") &&
@@ -172,7 +175,7 @@ function rewriteFileReadCommand(parsed: ParsedSimpleCommand): RewriteDecision | 
     /^-[1-9][0-9]*$/.test(tokens[1]!) &&
     isPlainFileToken(tokens[2]!)
   ) {
-    return { kind: "rewrite", command: ["rsp", "cat", `--${command}`, tokens[1]!.slice(1), shellQuoteIfNeeded(tokens[2]!), ...redirectSuffix].join(" "), capabilityId: `cat:${command}` };
+    return { kind: "rewrite", command: [...prefix, "cat", `--${command}`, tokens[1]!.slice(1), shellQuoteIfNeeded(tokens[2]!), ...redirectSuffix].join(" "), capabilityId: `cat:${command}` };
   }
   return null;
 }
@@ -250,7 +253,10 @@ async function hookDecisionResultFromPreExecJson(
 
   const started = process.hrtime.bigint();
   const config = resolveRspConfig(cwd, process.env);
-  const decision = config.proxyEnabled ? proxyCommand(command) : (options.rewrite ?? rewriteCommand)(command);
+  const rspPrefix = options.rspInvocationPrefix ?? resolveRspInvocationPrefix();
+  const decision = config.proxyEnabled
+    ? proxyCommand(command, rspPrefix)
+    : (options.rewrite ?? ((cmd: string) => rewriteCommand(cmd, rspPrefix)))(command);
   const decisionMs = Number(process.hrtime.bigint() - started) / 1_000_000;
   if (decision.kind !== "rewrite") {
     const passed = decision.reason ? decision : { ...decision, reason: "unsupported-command" };
@@ -561,14 +567,21 @@ function shellQuoteIfNeeded(value: string): string {
   return /[^\w@%+=:,./-]/.test(value) ? shellSingleQuote(value) : value;
 }
 
-function proxyCommand(command: string): RewriteDecision {
+function proxyCommand(command: string, rspPrefix: string[]): RewriteDecision {
   const reason = universalProxyPassthroughReason(command);
   if (reason) return { kind: "passthrough", reason };
+  const prefixStr = rspPrefix.map(shellQuoteIfNeeded).join(" ");
   return {
     kind: "rewrite",
-    command: `rsp proxy -- ${shellSingleQuote(command.trim())}`,
+    command: `${prefixStr} proxy -- ${shellSingleQuote(command.trim())}`,
     capabilityId: "proxy:universal",
   };
+}
+
+function isRspBundledCommand(command: string): boolean {
+  if (!process.argv[1]) return false;
+  const tokens = shellTokens(command);
+  return tokens[0]?.text === process.execPath && tokens[1]?.text === process.argv[1];
 }
 
 function universalProxyPassthroughReason(command: string): string | undefined {
@@ -578,16 +591,18 @@ function universalProxyPassthroughReason(command: string): string | undefined {
   if (/\b(?:RSP_NO_PROXY|RED_SKILLS_RSP_NO_PROXY)=1\b/.test(trimmed)) return "opt-out";
   const first = shellishWords(commandSegments(trimmed)[0] ?? "")[0];
   if (first === "rsp") return "opt-out";
+  if (isRspBundledCommand(trimmed)) return "opt-out";
   if (first && INTERACTIVE_COMMANDS.has(first)) return "interactive";
   return undefined;
 }
 
-function rewriteCompoundCommand(command: string): RewriteDecision {
+function rewriteCompoundCommand(command: string, rspPrefix: string[]): RewriteDecision {
   const trimmed = command.trim();
   if (!isSafeNoisyCompoundCommand(trimmed)) return { kind: "passthrough" };
+  const prefixStr = rspPrefix.map(shellQuoteIfNeeded).join(" ");
   return {
     kind: "rewrite",
-    command: `rsp exec -- ${shellSingleQuote(trimmed)}`,
+    command: `${prefixStr} exec -- ${shellSingleQuote(trimmed)}`,
     capabilityId: "exec:compound",
   };
 }

--- a/apps/rsp/src/proxy.ts
+++ b/apps/rsp/src/proxy.ts
@@ -1,5 +1,10 @@
 import { spawn } from "node:child_process";
+import { resolveRspInvocationPrefix } from "./rsp-cli.js";
 import { appendTelemetryEvent, RSP_DECISIONS_COLLECTION, RSP_TELEMETRY_INVOCATIONS_COLLECTION } from "./telemetry.js";
+
+function shellQuoteIfNeeded(value: string): string {
+  return /[^\w@%+=:,./-]/.test(value) ? `'${value.replace(/'/g, "'\\''")}'` : value;
+}
 
 export interface ProxyRunOptions {
   telemetryRoot: string;
@@ -72,7 +77,7 @@ export async function runProxy(argv: readonly string[], options: ProxyRunOptions
   return status;
 }
 
-export function rewriteProxyCommandLine(commandLine: string, level: ProxyLossLevel = "lossless"): {
+export function rewriteProxyCommandLine(commandLine: string, level: ProxyLossLevel = "lossless", rspPrefix: string[] = resolveRspInvocationPrefix()): {
   commandLine: string;
   matches: ProxySegmentMatch[];
 } {
@@ -81,7 +86,7 @@ export function rewriteProxyCommandLine(commandLine: string, level: ProxyLossLev
   const rewritten = parts.map((part, index) => {
     if (part.kind === "operator") return part.text;
     if (nextOperator(parts, index) === "|") return part.text;
-    const rewrittenSegment = rewriteProxySegment(part.text, level);
+    const rewrittenSegment = rewriteProxySegment(part.text, level, rspPrefix);
     if (!rewrittenSegment) return part.text;
     matches.push(rewrittenSegment.match);
     return rewrittenSegment.text;
@@ -144,7 +149,7 @@ async function runShellVerbatim(commandLine: string): Promise<number> {
   });
 }
 
-function rewriteProxySegment(segment: string, level: ProxyLossLevel): { text: string; match: ProxySegmentMatch } | null {
+function rewriteProxySegment(segment: string, level: ProxyLossLevel, rspPrefix: string[]): { text: string; match: ProxySegmentMatch } | null {
   const leading = segment.match(/^\s*/)?.[0] ?? "";
   const trailing = segment.match(/\s*$/)?.[0] ?? "";
   const core = segment.trim();
@@ -171,7 +176,7 @@ function rewriteProxySegment(segment: string, level: ProxyLossLevel): { text: st
 
   const prefix = words.slice(0, commandStart).map((word) => word.raw);
   const loss = level === "lossless" ? [] : [`--${level}`];
-  const rewrittenCore = [...prefix, "rsp", ...loss, ...match.wrapperWords].join(" ");
+  const rewrittenCore = [...prefix, ...rspPrefix.map(shellQuoteIfNeeded), ...loss, ...match.wrapperWords].join(" ");
   return {
     text: `${leading}${rewrittenCore}${trailing}`,
     match: {

--- a/apps/rsp/src/rsp-cli.ts
+++ b/apps/rsp/src/rsp-cli.ts
@@ -1,0 +1,14 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+function isRspOnPath(): boolean {
+  for (const dir of (process.env.PATH ?? "").split(":")) {
+    if (dir && existsSync(join(dir, "rsp"))) return true;
+  }
+  return false;
+}
+
+export function resolveRspInvocationPrefix(): string[] {
+  if (isRspOnPath()) return ["rsp"];
+  return [process.execPath, process.argv[1]!];
+}

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -15,6 +15,8 @@ import {
   rewriteTableFromCapabilities,
   _testOnlyResetBinaryState,
 } from "../src/intercept.js";
+
+const RSP_PREFIX = ["rsp"] as const;
 import {
   RSP_DECISIONS_COLLECTION,
   telemetrySpoolPath,
@@ -38,10 +40,22 @@ afterEach(async () => {
 describe("rsp interception pure rewrite table", () => {
   it("rewrites every wrapper capability form from the table", () => {
     for (const entry of RSP_WRAPPER_CAPABILITIES) {
-      const decision = rewriteCommand(entry.command.join(" "));
+      const decision = rewriteCommand(entry.command.join(" "), [...RSP_PREFIX]);
       expect(decision, entry.id).toEqual({
         kind: "rewrite",
         command: ["rsp", ...entry.wrapper].join(" "),
+        capabilityId: entry.id,
+      });
+    }
+  });
+
+  it("rewrites every capability using the bundled entrypoint when rsp is not on PATH", () => {
+    const prefix = ["/fake/node", "/fake/rsp.bundle.mjs"];
+    for (const entry of RSP_WRAPPER_CAPABILITIES) {
+      const decision = rewriteCommand(entry.command.join(" "), prefix);
+      expect(decision, entry.id).toEqual({
+        kind: "rewrite",
+        command: ["/fake/node", "/fake/rsp.bundle.mjs", ...entry.wrapper].join(" "),
         capabilityId: entry.id,
       });
     }
@@ -66,7 +80,14 @@ describe("rsp interception pure rewrite table", () => {
     ["tail-n-file", "tail -n 25 apps/rsp/src/cli.ts", "rsp cat --tail 25 apps/rsp/src/cli.ts", "cat:tail"],
     ["tail-short-n-file", "tail -25 apps/rsp/src/cli.ts", "rsp cat --tail 25 apps/rsp/src/cli.ts", "cat:tail"],
   ])("rewrites conservative file dump shape %s", (_name, command, rewritten, capabilityId) => {
-    expect(rewriteCommand(command)).toEqual({ kind: "rewrite", command: rewritten, capabilityId });
+    expect(rewriteCommand(command, [...RSP_PREFIX])).toEqual({ kind: "rewrite", command: rewritten, capabilityId });
+  });
+
+  it.each([
+    ["cat-bundled", "cat apps/rsp/src/cli.ts", "/fake/node /fake/rsp.bundle.mjs cat apps/rsp/src/cli.ts", "cat:file"],
+    ["head-bundled", "head -n 5 apps/rsp/src/cli.ts", "/fake/node /fake/rsp.bundle.mjs cat --head 5 apps/rsp/src/cli.ts", "cat:head"],
+  ])("rewrites file dump %s via bundled entrypoint", (_name, command, rewritten, capabilityId) => {
+    expect(rewriteCommand(command, ["/fake/node", "/fake/rsp.bundle.mjs"])).toEqual({ kind: "rewrite", command: rewritten, capabilityId });
   });
 
   it.each([
@@ -75,7 +96,7 @@ describe("rsp interception pure rewrite table", () => {
     ["git-status-stderr-null", "git status --short 2>/dev/null", "rsp git status --short 2>/dev/null", "git:status"],
     ["git-log-stderr-merge", "git log --oneline 2>&1", "rsp git log --oneline 2>&1", "git:log"],
   ])("rewrites flagged or stderr-only family shape %s", (_name, command, rewritten, capabilityId) => {
-    expect(rewriteCommand(command)).toEqual({ kind: "rewrite", command: rewritten, capabilityId });
+    expect(rewriteCommand(command, [...RSP_PREFIX])).toEqual({ kind: "rewrite", command: rewritten, capabilityId });
   });
 
   it.each([
@@ -83,7 +104,7 @@ describe("rsp interception pure rewrite table", () => {
     ["jq-expression", "gh run view 9001 --json databaseId --jq '.databaseId'"],
     ["api-jq", "gh api repos/reddb-io/red-skills --jq .name"],
   ])("passes through lossless gh json/jq selector family %s", (_name, command) => {
-    expect(rewriteCommand(command)).toEqual({ kind: "passthrough", reason: "lossless-gh-json-jq" });
+    expect(rewriteCommand(command, [...RSP_PREFIX])).toEqual({ kind: "passthrough", reason: "lossless-gh-json-jq" });
   });
 
   it.each([
@@ -101,7 +122,7 @@ describe("rsp interception pure rewrite table", () => {
     ["subshell-is-ambiguous", "$(git status)"],
     ["quoted-command-name-is-ambiguous", "\"git\" status"],
   ])("passes through adversarial fixture %s", (_name, command) => {
-    expect(rewriteCommand(command)).toEqual({ kind: "passthrough" });
+    expect(rewriteCommand(command, [...RSP_PREFIX])).toEqual({ kind: "passthrough" });
   });
 
   it.each([
@@ -111,9 +132,17 @@ describe("rsp interception pure rewrite table", () => {
     ["piped-vitest", "vitest run | tail -20"],
     ["chained-cargo-test", "cd crates/core && cargo test"],
   ])("rewrites safe compound noisy command %s through rsp exec", (_name, command) => {
-    expect(rewriteCommand(command)).toEqual({
+    expect(rewriteCommand(command, [...RSP_PREFIX])).toEqual({
       kind: "rewrite",
       command: `rsp exec -- '${command}'`,
+      capabilityId: "exec:compound",
+    });
+  });
+
+  it("rewrites compound noisy command through bundled exec entrypoint", () => {
+    expect(rewriteCommand("cd apps && git log --oneline", ["/fake/node", "/fake/bundle.mjs"])).toEqual({
+      kind: "rewrite",
+      command: "/fake/node /fake/bundle.mjs exec -- 'cd apps && git log --oneline'",
       capabilityId: "exec:compound",
     });
   });
@@ -126,7 +155,7 @@ describe("rsp interception pure rewrite table", () => {
     ["here-doc", "cat <<EOF"],
     ["silent-predicate", "git log | grep -q fix"],
   ])("passes through unsafe compound fixture %s", (_name, command) => {
-    expect(rewriteCommand(command)).toEqual({ kind: "passthrough" });
+    expect(rewriteCommand(command, [...RSP_PREFIX])).toEqual({ kind: "passthrough" });
   });
 });
 
@@ -138,7 +167,7 @@ describe("rsp Claude pre-execution hook integration", () => {
 
     const decision = await hookDecisionFromCodexPreExecJson(
       JSON.stringify({ cwd: root, tool_name: "bash", tool_input: { command: "printf ok | sed s/ok/OK/" } }),
-      { cwd: root, wakeResident: () => undefined },
+      { cwd: root, wakeResident: () => undefined, rspInvocationPrefix: [...RSP_PREFIX] },
     );
 
     expect(decision).toEqual({
@@ -158,6 +187,24 @@ describe("rsp Claude pre-execution hook integration", () => {
     });
   });
 
+  it("routes through bundled entrypoint proxy when rsp is not on PATH", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: true\n", "utf8");
+
+    const prefix = ["/fake/node", "/fake/rsp.bundle.mjs"];
+    const decision = await hookDecisionFromCodexPreExecJson(
+      JSON.stringify({ cwd: root, tool_name: "bash", tool_input: { command: "printf ok | sed s/ok/OK/" } }),
+      { cwd: root, wakeResident: () => undefined, rspInvocationPrefix: prefix },
+    );
+
+    expect(decision).toEqual({
+      kind: "rewrite",
+      command: "/fake/node /fake/rsp.bundle.mjs proxy -- 'printf ok | sed s/ok/OK/'",
+      capabilityId: "proxy:universal",
+    });
+  });
+
   it.each([
     ["interactive", "vim file.txt", "interactive"],
     ["background", "sleep 1 &", "background"],
@@ -170,8 +217,21 @@ describe("rsp Claude pre-execution hook integration", () => {
 
     await expect(hookDecisionFromCodexPreExecJson(
       JSON.stringify({ cwd: root, tool_name: "bash", tool_input: { command } }),
-      { cwd: root },
+      { cwd: root, rspInvocationPrefix: [...RSP_PREFIX] },
     )).resolves.toEqual({ kind: "passthrough", reason });
+  });
+
+  it("opts out of re-proxying a bundled rsp invocation", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: true\n", "utf8");
+
+    // A command that IS the bundled invocation must not be proxied again
+    const bundledCommand = `${process.execPath} ${process.argv[1]} git status`;
+    await expect(hookDecisionFromCodexPreExecJson(
+      JSON.stringify({ cwd: root, tool_name: "bash", tool_input: { command: bundledCommand } }),
+      { cwd: root, rspInvocationPrefix: [process.execPath, process.argv[1]!] },
+    )).resolves.toEqual({ kind: "passthrough", reason: "opt-out" });
   });
 
   it("accepts Claude hook JSON on stdin through the CLI and emits updatedInput", async () => {
@@ -189,7 +249,7 @@ describe("rsp Claude pre-execution hook integration", () => {
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "allow",
-        updatedInput: { command: "rsp git status" },
+        updatedInput: { command: expect.stringContaining("git status") },
       },
     });
     expect(res.stderr).toEqual(Buffer.alloc(0));
@@ -199,7 +259,7 @@ describe("rsp Claude pre-execution hook integration", () => {
   it("reports rewrite and parse decisions under RSP_DEBUG", async () => {
     const root = await tempRoot();
     await mkdir(join(root, ".red"), { recursive: true });
-    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: false\n", "utf8");
 
     const rewrite = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "claude-pre-exec"], {
       cwd: root,
@@ -237,6 +297,7 @@ describe("rsp Claude pre-execution hook integration", () => {
         wakeResident: () => {
           wakeCalls += 1;
         },
+        rspInvocationPrefix: [...RSP_PREFIX],
       },
     );
 
@@ -262,6 +323,7 @@ describe("rsp Claude pre-execution hook integration", () => {
         cwd: root,
         isEnabled: () => true,
         isResidentHealthy: async () => true,
+        rspInvocationPrefix: [...RSP_PREFIX],
       },
     );
 
@@ -293,6 +355,7 @@ describe("rsp Claude pre-execution hook integration", () => {
         wakeResident: () => {
           wakeCalls += 1;
         },
+        rspInvocationPrefix: [...RSP_PREFIX],
       },
     );
 
@@ -327,6 +390,7 @@ describe("rsp Claude pre-execution hook integration", () => {
         wakeResident: () => {
           wakeCalls += 1;
         },
+        rspInvocationPrefix: [...RSP_PREFIX],
       },
     );
     const elapsedMs = performance.now() - started;
@@ -373,6 +437,7 @@ describe("rsp Codex pre-execution hook integration", () => {
         cwd: root,
         isEnabled: () => true,
         isResidentHealthy: async () => true,
+        rspInvocationPrefix: [...RSP_PREFIX],
       },
     );
 
@@ -423,7 +488,7 @@ describe("rsp Codex pre-execution hook integration", () => {
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "allow",
-        updatedInput: { command: "rsp git status" },
+        updatedInput: { command: expect.stringContaining("git status") },
       },
     });
     expect(res.stderr).toEqual(Buffer.alloc(0));
@@ -433,7 +498,7 @@ describe("rsp Codex pre-execution hook integration", () => {
   it("records exactly one decision event for a Codex hook invocation", async () => {
     const root = await tempRoot();
     await mkdir(join(root, ".red"), { recursive: true });
-    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: false\n", "utf8");
 
     const res = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "codex-pre-exec"], {
       cwd: root,
@@ -457,7 +522,7 @@ describe("rsp Codex pre-execution hook integration", () => {
   it("records gh json/jq selectors as lossless passthrough decisions", async () => {
     const root = await tempRoot();
     await mkdir(join(root, ".red"), { recursive: true });
-    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: false\n", "utf8");
 
     const res = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "codex-pre-exec"], {
       cwd: root,

--- a/apps/rsp/tests/proxy.test.ts
+++ b/apps/rsp/tests/proxy.test.ts
@@ -33,27 +33,27 @@ afterEach(async () => {
 
 describe("rsp proxy segment recognition", () => {
   it("rewrites recognized stdout-tail segments and leaves pipeline producers raw", () => {
-    expect(rewriteProxyCommandLine("cd apps && git log", "terse")).toMatchObject({
+    expect(rewriteProxyCommandLine("cd apps && git log", "terse", ["rsp"])).toMatchObject({
       commandLine: "cd apps && rsp --terse git log",
       matches: [expect.objectContaining({ capabilityId: "git:log", command: "git log" })],
     });
-    expect(rewriteProxyCommandLine("git branch -av", "brief")).toMatchObject({
+    expect(rewriteProxyCommandLine("git branch -av", "brief", ["rsp"])).toMatchObject({
       commandLine: "rsp --brief git branch -av",
       matches: [expect.objectContaining({ capabilityId: "git:branch:av", command: "git branch -av" })],
     });
-    expect(rewriteProxyCommandLine("printf 'x\\n' | grep x", "brief")).toMatchObject({
+    expect(rewriteProxyCommandLine("printf 'x\\n' | grep x", "brief", ["rsp"])).toMatchObject({
       commandLine: "printf 'x\\n' | grep x",
       matches: [],
     });
-    expect(rewriteProxyCommandLine("git log | tail -5", "brief")).toMatchObject({
+    expect(rewriteProxyCommandLine("git log | tail -5", "brief", ["rsp"])).toMatchObject({
       commandLine: "git log | tail -5",
       matches: [],
     });
-    expect(rewriteProxyCommandLine("printf before; gh pr list --limit 5", "brief")).toMatchObject({
+    expect(rewriteProxyCommandLine("printf before; gh pr list --limit 5", "brief", ["rsp"])).toMatchObject({
       commandLine: "printf before; rsp --brief gh pr list --limit 5",
       matches: [expect.objectContaining({ capabilityId: "gh:pr:list", command: "gh pr list --limit 5" })],
     });
-    expect(rewriteProxyCommandLine("printf before; gh pr list --json number,title --jq '.[] | .number'", "brief")).toMatchObject({
+    expect(rewriteProxyCommandLine("printf before; gh pr list --json number,title --jq '.[] | .number'", "brief", ["rsp"])).toMatchObject({
       commandLine: "printf before; gh pr list --json number,title --jq '.[] | .number'",
       matches: [
         expect.objectContaining({
@@ -63,6 +63,18 @@ describe("rsp proxy segment recognition", () => {
           reason: "lossless-gh-json-jq",
         }),
       ],
+    });
+  });
+
+  it("rewrites proxy segments via bundled entrypoint when rsp is not on PATH", () => {
+    const prefix = ["/fake/node", "/fake/rsp.bundle.mjs"];
+    expect(rewriteProxyCommandLine("cd apps && git log", "terse", prefix)).toMatchObject({
+      commandLine: "cd apps && /fake/node /fake/rsp.bundle.mjs --terse git log",
+      matches: [expect.objectContaining({ capabilityId: "git:log", command: "git log" })],
+    });
+    expect(rewriteProxyCommandLine("printf before; gh pr list --limit 5", "brief", prefix)).toMatchObject({
+      commandLine: "printf before; /fake/node /fake/rsp.bundle.mjs --brief gh pr list --limit 5",
+      matches: [expect.objectContaining({ capabilityId: "gh:pr:list", command: "gh pr list --limit 5" })],
     });
   });
 


### PR DESCRIPTION
## Summary

- Introduces `apps/rsp/src/rsp-cli.ts` with `resolveRspInvocationPrefix()` — the single-source resolver that returns `["rsp"]` when a bare shim is on PATH and `[process.execPath, process.argv[1]]` (the bundled form) otherwise.
- Threads `rspPrefix` through `rewriteCommand`, `proxyCommand`, and `rewriteProxyCommandLine` so every rewritten command targets the bundled entrypoint when no global shim is present.
- Adds `isRspBundledCommand()` in `intercept.ts` to detect already-bundled invocations and return "opt-out" in `universalProxyPassthroughReason`, preventing double-proxy loops.
- Adds `shellQuoteIfNeeded` in `proxy.ts` (local, same pattern as in `intercept.ts`) to handle path tokens with special characters.
- All unit tests now pass `["rsp"]` explicitly so assertions are deterministic regardless of the test host's PATH.
- Three existing integration tests that tested non-proxy direct-match behavior now explicitly set `proxy: enabled: false` — they were broken by the proxy-by-default design (#2649 pre-dates this PR; fixed here as a bonus).
- New tests cover: every direct-match capability via bundled prefix, file-dump cat/head via bundled prefix, compound exec via bundled prefix, proxy mode via bundled prefix, and bundled-form opt-out detection.

## Test plan

- [x] `pnpm -C apps/rsp run typecheck` — no errors
- [x] `pnpm -C apps/rsp run test` — 204/204 unit tests pass
- [x] `pnpm -C apps/rsp run test:integration -t "RSP_DEBUG|records exactly one|records gh json"` — 3 previously failing tests now pass
- [x] `pnpm -C apps/rsp run test:integration` — 205/208 pass; 3 remaining failures are pre-existing RedDB→TOON store migration issues unrelated to this PR

Closes #2649

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787457286&installation_model_id=20659&pr_number=2656&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2656&signature=873ad83479ee91513c7ea45db3a255412eacf2b91ef1eeafb3586687008d1fd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->