### PR TITLE
chore: #2659 rsp: one command classifier module for hook/proxy/telemetry/CLI/MCP

### DIFF
--- a/apps/rsp/src/command-classifier.ts
+++ b/apps/rsp/src/command-classifier.ts
@@ -1,0 +1,60 @@
+/**
+ * The one command classifier for every rsp surface.
+ *
+ * The pre-exec hook (`intercept.ts`), the universal proxy (`proxy.ts`), and
+ * telemetry reporting (`telemetry/reports.ts`) all read command shape through
+ * this module, so a `command_family` telemetry key means the same thing no
+ * matter which surface minted it. Classification answers "what shape is this
+ * command?" and nothing else — deciding how to *invoke* rsp (binary
+ * resolution, invocation prefix) stays with the surface that runs commands.
+ *
+ * Adding a family here changes telemetry keys everywhere at once; pin the new
+ * key in `tests/command-classifier.test.ts`.
+ */
+
+/** Splits a command into whitespace-separated words, dropping empty runs. */
+export function commandWords(command: string): string[] {
+  return command.trim().split(/\s+/).filter(Boolean);
+}
+
+/** Splits a command line into shell segments on `&&`, `;`, and `|`. */
+export function commandSegments(command: string): string[] {
+  return command.split(/&&|[;|]/).map((segment) => segment.trim()).filter(Boolean);
+}
+
+/**
+ * Splits one segment into words on spaces and tabs. A leading `env` keyword is
+ * blanked rather than dropped, so callers reading `tokens[0]` see an empty
+ * command word and treat the segment as ambiguous.
+ */
+export function shellishWords(segment: string): string[] {
+  return segment.split(/[ \t]+/).filter(Boolean).map((token) => token.replace(/^env$/, ""));
+}
+
+/** The telemetry `command_family` key for a raw command string. */
+export function commandFamily(command: string): string {
+  const parts = commandWords(command);
+  if (parts.length === 0) return "unknown";
+  if (parts[0] === "git" && parts[1]) return `git ${parts[1]}`;
+  if (isGhJsonJqSelection(parts) && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]} json-jq`;
+  if (isGhJsonJqSelection(parts) && parts[1]) return `gh ${parts[1]} json-jq`;
+  if (isGhJsonJqSelection(parts)) return "gh json-jq";
+  if (parts[0] === "gh" && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]}`;
+  if (parts[0] === "gh" && parts[1]) return `gh ${parts[1]}`;
+  if (parts[0] === "cargo" && parts[1]) return `cargo ${parts[1]}`;
+  if (parts[0] === "vitest") return "vitest";
+  return parts[0]!;
+}
+
+/** True when the tokens are a `gh` call whose output is already a selection. */
+export function isGhJsonJqSelection(tokens: readonly string[]): boolean {
+  return tokens[0] === "gh" && tokens.some(isJsonJqSelectionFlag);
+}
+
+export function isJsonJqSelectionFlag(token: string): boolean {
+  return token === "--json" || token === "--jq" || token.startsWith("--json=") || token.startsWith("--jq=");
+}
+
+export function isEnvAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token);
+}

--- a/apps/rsp/src/elision-store/helpers.ts
+++ b/apps/rsp/src/elision-store/helpers.ts
@@ -7,6 +7,7 @@ import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { commandWords } from "../command-classifier.js";
 import { RSP_ELISION_COLLECTION, type RspExpiredHandle, type RspLossMeta, type RspMintMeta, type RspRecoveryHandle, type RspStorageClass, type RspStorageClassStats } from "./public.js";
 import type { IndexDocument, IndexEntry, ResidentRecallHit, RspDerivationRecipe, RspReexecutionRecipe, StoreDocument, StoredBlob, StoredRecord } from "./model.js";
 
@@ -43,7 +44,7 @@ export function redDbIdentifier(value: string): string {
 }
 
 export function storageClassForCommand(command: string): RspStorageClass {
-  const argv = command.trim().split(/\s+/).filter(Boolean);
+  const argv = commandWords(command);
   const executable = argv[0] ?? "";
   if (executable === "cat") return "derivable";
   if (executable === "git") {
@@ -171,7 +172,7 @@ export function gitOutput(cwd: string, args: string[]): string | null {
 }
 
 export function deriveReexecutionRecipe(bytes: Buffer, command: string): RspReexecutionRecipe | null {
-  const argv = command.trim().split(/\s+/).filter(Boolean);
+  const argv = commandWords(command);
   if (!isReExecutableArgv(argv)) return null;
   const current = runReexecutionCommand(process.cwd(), argv, bytes.length);
   if (!current || contentHash(current) !== contentHash(bytes)) return null;

--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -1,5 +1,12 @@
 import { accessSync, constants, existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import {
+  commandFamily,
+  commandSegments,
+  isEnvAssignment,
+  isGhJsonJqSelection,
+  shellishWords,
+} from "./command-classifier.js";
 import { resolveRspConfig, type RspRuntimeConfig } from "./config.js";
 import {
   kickResidentServer,
@@ -551,14 +558,6 @@ function losslessGhJsonJqPassthrough(command: string): RewriteDecision | null {
   return { kind: "passthrough", reason: LOSSLESS_GH_JSON_JQ_REASON };
 }
 
-function isGhJsonJqSelection(tokens: readonly string[]): boolean {
-  return tokens[0] === "gh" && tokens.some(isJsonJqSelectionFlag);
-}
-
-function isJsonJqSelectionFlag(token: string): boolean {
-  return token === "--json" || token === "--jq" || token.startsWith("--json=") || token.startsWith("--jq=");
-}
-
 function formatRedirectSuffix(tokens: readonly ShellToken[]): string[] {
   return tokens.map((token) => token.text);
 }
@@ -681,34 +680,8 @@ function containsQuietGrep(command: string): boolean {
   });
 }
 
-function commandSegments(command: string): string[] {
-  return command.split(/&&|[;|]/).map((segment) => segment.trim()).filter(Boolean);
-}
-
-function shellishWords(segment: string): string[] {
-  return segment.split(/[ \t]+/).filter(Boolean).map((token) => token.replace(/^env$/, ""));
-}
-
 function shellSingleQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-
-function commandFamily(command: string): string {
-  const parts = command.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return "unknown";
-  if (parts[0] === "git" && parts[1]) return `git ${parts[1]}`;
-  if (isGhJsonJqSelection(parts) && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]} json-jq`;
-  if (isGhJsonJqSelection(parts) && parts[1]) return `gh ${parts[1]} json-jq`;
-  if (isGhJsonJqSelection(parts)) return "gh json-jq";
-  if (parts[0] === "gh" && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]}`;
-  if (parts[0] === "gh" && parts[1]) return `gh ${parts[1]}`;
-  if (parts[0] === "cargo" && parts[1]) return `cargo ${parts[1]}`;
-  if (parts[0] === "vitest") return "vitest";
-  return parts[0]!;
-}
-
-function isEnvAssignment(token: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token);
 }
 
 function commandKey(tokens: readonly string[]): string {

--- a/apps/rsp/src/proxy.ts
+++ b/apps/rsp/src/proxy.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { commandFamily, isEnvAssignment, isGhJsonJqSelection } from "./command-classifier.js";
 import { resolveRspInvocationPrefix } from "./rsp-cli.js";
 import { appendTelemetryEvent, RSP_DECISIONS_COLLECTION, RSP_TELEMETRY_INVOCATIONS_COLLECTION } from "./telemetry.js";
 
@@ -346,30 +347,4 @@ function parseShellWords(segment: string): ShellWord[] | null {
   if (quote || escaped) return null;
   push();
   return words;
-}
-
-function commandFamily(command: string): string {
-  const parts = command.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return "unknown";
-  if (parts[0] === "git" && parts[1]) return `git ${parts[1]}`;
-  if (isGhJsonJqSelection(parts) && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]} json-jq`;
-  if (isGhJsonJqSelection(parts) && parts[1]) return `gh ${parts[1]} json-jq`;
-  if (isGhJsonJqSelection(parts)) return "gh json-jq";
-  if (parts[0] === "gh" && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]}`;
-  if (parts[0] === "gh" && parts[1]) return `gh ${parts[1]}`;
-  if (parts[0] === "cargo" && parts[1]) return `cargo ${parts[1]}`;
-  if (parts[0] === "vitest") return "vitest";
-  return parts[0]!;
-}
-
-function isGhJsonJqSelection(tokens: readonly string[]): boolean {
-  return tokens[0] === "gh" && tokens.some(isJsonJqSelectionFlag);
-}
-
-function isJsonJqSelectionFlag(token: string): boolean {
-  return token === "--json" || token === "--jq" || token.startsWith("--json=") || token.startsWith("--jq=");
-}
-
-function isEnvAssignment(token: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token);
 }

--- a/apps/rsp/src/telemetry/reports.ts
+++ b/apps/rsp/src/telemetry/reports.ts
@@ -1,4 +1,5 @@
 import type { RedDB } from "@reddb-io/sdk";
+import { commandFamily } from "../command-classifier.js";
 import { storageClassForCommand, type RspStorageClass, type RspStorageClassStats } from "../elision-store.js";
 import { tokenSavingsEstimate } from "../pricing.js";
 import {
@@ -610,17 +611,6 @@ function latencyPercentiles(values: number[]): LatencyPercentiles {
 
 function round(value: number): number {
   return Math.round(value * 100) / 100;
-}
-
-function commandFamily(command: string): string {
-  const parts = command.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return "unknown";
-  if (parts[0] === "git" && parts[1]) return `git ${parts[1]}`;
-  if (parts[0] === "gh" && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]}`;
-  if (parts[0] === "gh" && parts[1]) return `gh ${parts[1]}`;
-  if (parts[0] === "cargo" && parts[1]) return `cargo ${parts[1]}`;
-  if (parts[0] === "vitest") return "vitest";
-  return parts[0]!;
 }
 
 function heatmapKeyFor(timestamp: string): string | null {

--- a/apps/rsp/tests/command-classifier.test.ts
+++ b/apps/rsp/tests/command-classifier.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Command-classifier suite (#2659).
+ *
+ * Every rsp surface — the pre-exec hook, the universal proxy, and telemetry
+ * reporting — classifies raw shell commands through `src/command-classifier.ts`.
+ * The classification cases live here once; each surface keeps a wired smoke
+ * proving it reads the shared module rather than its own copy.
+ *
+ * `TELEMETRY_KEY_CORPUS` is a byte-for-byte pin of the `command_family`
+ * telemetry keys. `family` holds the value captured from the pre-refactor
+ * hook/proxy copy; `legacyReportsFamily` is present only on the rows where the
+ * `telemetry/reports.ts` copy had drifted behind (it predated gh json/jq
+ * awareness) and is recorded here so the deliberate reconciliation stays
+ * auditable.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  commandFamily,
+  commandSegments,
+  commandWords,
+  isEnvAssignment,
+  isGhJsonJqSelection,
+  isJsonJqSelectionFlag,
+  shellishWords,
+} from "../src/command-classifier.js";
+import { rewriteCommand } from "../src/intercept.js";
+import { rewriteProxyCommandLine } from "../src/proxy.js";
+
+interface TelemetryKeyRow {
+  command: string;
+  family: string;
+  legacyReportsFamily?: string;
+}
+
+const TELEMETRY_KEY_CORPUS: readonly TelemetryKeyRow[] = [
+  { command: "", family: "unknown" },
+  { command: "   ", family: "unknown" },
+  { command: "git status", family: "git status" },
+  { command: "git status --short", family: "git status" },
+  { command: "git log --oneline --decorate=short", family: "git log" },
+  { command: "git diff --stat origin/main..HEAD", family: "git diff" },
+  { command: "git show HEAD", family: "git show" },
+  { command: "git blame src/a.ts", family: "git blame" },
+  { command: "git branch -av", family: "git branch" },
+  { command: "git commit -m 'x'", family: "git commit" },
+  { command: "git push origin HEAD", family: "git push" },
+  { command: "git", family: "git" },
+  { command: "gh pr list --limit 5", family: "gh pr list" },
+  { command: "gh pr view 1747", family: "gh pr view" },
+  { command: "gh issue list", family: "gh issue list" },
+  { command: "gh issue view 2659", family: "gh issue view" },
+  { command: "gh run list", family: "gh run list" },
+  { command: "gh run view 9001", family: "gh run view" },
+  { command: "gh api repos/o/r", family: "gh api repos/o/r" },
+  { command: "gh pr", family: "gh pr" },
+  { command: "gh", family: "gh" },
+  { command: "cargo test", family: "cargo test" },
+  { command: "cargo build", family: "cargo build" },
+  { command: "cargo", family: "cargo" },
+  { command: "vitest", family: "vitest" },
+  { command: "vitest run", family: "vitest" },
+  { command: "cat README.md", family: "cat" },
+  { command: "head -n 20 file.txt", family: "head" },
+  { command: "tail -n 5 file.txt", family: "tail" },
+  { command: "echo ok", family: "echo" },
+  { command: "grep -q needle file.txt", family: "grep" },
+  { command: "gh pr view 1747 --json number,title", family: "gh pr view json-jq", legacyReportsFamily: "gh pr view" },
+  { command: "gh pr list --json number,title --jq '.[0]'", family: "gh pr list json-jq", legacyReportsFamily: "gh pr list" },
+  { command: "gh run view 9001 --json databaseId --jq .databaseId", family: "gh run view json-jq", legacyReportsFamily: "gh run view" },
+  { command: "gh api repos/o/r --jq .name", family: "gh api repos/o/r json-jq", legacyReportsFamily: "gh api repos/o/r" },
+  { command: "gh --json x", family: "gh --json x json-jq", legacyReportsFamily: "gh --json x" },
+  { command: "gh pr --jq .", family: "gh pr --jq json-jq", legacyReportsFamily: "gh pr --jq" },
+  { command: "gh pr view --json=number", family: "gh pr view json-jq", legacyReportsFamily: "gh pr view" },
+  { command: "gh pr view --jq=.number", family: "gh pr view json-jq", legacyReportsFamily: "gh pr view" },
+];
+
+describe("command-classifier telemetry key stability (#2659)", () => {
+  it.each(TELEMETRY_KEY_CORPUS.map((row) => [row.command || "<blank>", row] as const))(
+    "pins the command_family key for %s",
+    (_label, row) => {
+      expect(commandFamily(row.command)).toBe(row.family);
+    },
+  );
+
+  it("changes no key outside the deliberate telemetry/reports reconciliation", () => {
+    const changed = TELEMETRY_KEY_CORPUS.filter((row) => row.legacyReportsFamily != null).map((row) => row.command);
+    expect(changed.every((command) => commandWords(command)[0] === "gh")).toBe(true);
+    expect(changed.every((command) => isGhJsonJqSelection(commandWords(command)))).toBe(true);
+  });
+});
+
+describe("commandFamily", () => {
+  it("reports unknown for an empty command", () => {
+    expect(commandFamily("")).toBe("unknown");
+    expect(commandFamily("  \t ")).toBe("unknown");
+  });
+
+  it("keeps the bare executable when no subcommand shape applies", () => {
+    expect(commandFamily("echo ok")).toBe("echo");
+    expect(commandFamily("vitest run --reporter dot")).toBe("vitest");
+  });
+});
+
+describe("isGhJsonJqSelection", () => {
+  // Moved here from tests/intercept.test.ts — these are classification cases,
+  // not rewrite cases; the hook keeps one wired smoke below.
+  it.each([
+    ["json-fields", "gh pr view 1747 --json number,title"],
+    ["jq-expression", "gh run view 9001 --json databaseId --jq '.databaseId'"],
+    ["api-jq", "gh api repos/reddb-io/red-skills --jq .name"],
+    ["json-equals-form", "gh pr view 1747 --json=number"],
+    ["jq-equals-form", "gh pr view 1747 --jq=.number"],
+  ])("recognises the lossless gh json/jq selector family %s", (_name, command) => {
+    expect(isGhJsonJqSelection(commandWords(command))).toBe(true);
+  });
+
+  it.each([
+    ["plain-gh", "gh pr list --limit 5"],
+    ["non-gh-executable", "git log --json"],
+    ["empty", ""],
+  ])("does not recognise %s as a json/jq selection", (_name, command) => {
+    expect(isGhJsonJqSelection(commandWords(command))).toBe(false);
+  });
+});
+
+describe("isJsonJqSelectionFlag", () => {
+  it.each(["--json", "--jq", "--json=number", "--jq=.number"])("accepts %s", (token) => {
+    expect(isJsonJqSelectionFlag(token)).toBe(true);
+  });
+
+  it.each(["--jsonl", "--jqx", "-json", "json", ""])("rejects %s", (token) => {
+    expect(isJsonJqSelectionFlag(token)).toBe(false);
+  });
+});
+
+describe("isEnvAssignment", () => {
+  it.each(["GIT_DIR=.git", "FOO=", "_x=1", "A1_B=value with spaces"])("accepts %s", (token) => {
+    expect(isEnvAssignment(token)).toBe(true);
+  });
+
+  it.each(["git", "1FOO=bar", "--flag=value", "=bar", ""])("rejects %s", (token) => {
+    expect(isEnvAssignment(token)).toBe(false);
+  });
+});
+
+describe("shell segment splitting", () => {
+  it("splits on the compound operators and trims each segment", () => {
+    expect(commandSegments("cd apps && git log | tail -5; echo ok")).toEqual([
+      "cd apps",
+      "git log",
+      "tail -5",
+      "echo ok",
+    ]);
+  });
+
+  it("drops empty segments", () => {
+    expect(commandSegments("  ")).toEqual([]);
+    expect(commandSegments("git status;;")).toEqual(["git status"]);
+  });
+
+  it("splits a segment into shellish words and blanks a leading env keyword", () => {
+    expect(shellishWords("git  log\t--oneline")).toEqual(["git", "log", "--oneline"]);
+    expect(shellishWords("env git status")).toEqual(["", "git", "status"]);
+  });
+
+  it("splits a command into words on any whitespace run", () => {
+    expect(commandWords("  git   log\t--oneline ")).toEqual(["git", "log", "--oneline"]);
+    expect(commandWords("   ")).toEqual([]);
+  });
+});
+
+describe("surfaces read the shared classifier", () => {
+  it("wires the hook rewrite to isGhJsonJqSelection", () => {
+    expect(rewriteCommand("gh pr view 1747 --json number,title", ["rsp"])).toEqual({
+      kind: "passthrough",
+      reason: "lossless-gh-json-jq",
+    });
+  });
+
+  it("wires the proxy segment match to commandFamily", () => {
+    expect(rewriteProxyCommandLine("gh pr list --json number,title --jq '.[0]'", "brief", ["rsp"]).matches).toEqual([
+      expect.objectContaining({ commandFamily: commandFamily("gh pr list --json number,title --jq '.[0]'") }),
+    ]);
+  });
+
+  // The telemetry/reports wired smoke needs a RedDB store, so it lives with the
+  // rest of the store-backed report specs: see "aggregates gh json/jq
+  // invocations under the shared command_family key" in
+  // tests/telemetry-resident.test.ts.
+});

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -99,13 +99,9 @@ describe("rsp interception pure rewrite table", () => {
     expect(rewriteCommand(command, [...RSP_PREFIX])).toEqual({ kind: "rewrite", command: rewritten, capabilityId });
   });
 
-  it.each([
-    ["json-fields", "gh pr view 1747 --json number,title"],
-    ["jq-expression", "gh run view 9001 --json databaseId --jq '.databaseId'"],
-    ["api-jq", "gh api repos/reddb-io/red-skills --jq .name"],
-  ])("passes through lossless gh json/jq selector family %s", (_name, command) => {
-    expect(rewriteCommand(command, [...RSP_PREFIX])).toEqual({ kind: "passthrough", reason: "lossless-gh-json-jq" });
-  });
+  // The gh json/jq selector shapes are classification cases and live in
+  // tests/command-classifier.test.ts (#2659); the hook keeps its wired smoke
+  // in "records gh json/jq selectors as lossless passthrough decisions" below.
 
   it.each([
     ["upstream-subcommand-identity-not-dropped", "git -C repo status"],

--- a/apps/rsp/tests/telemetry-resident.test.ts
+++ b/apps/rsp/tests/telemetry-resident.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { commandFamily } from "../src/command-classifier.js";
 import {
   appendTelemetryEvent,
   calibratedTelemetryTiming,
@@ -576,6 +577,36 @@ describe("rsp telemetry spool", () => {
       });
       const short = await readTelemetryGainsReport(db, 28, new Date("2026-07-10T00:00:00.000Z"));
       expect(short.window).toMatchObject({ requested_days: 28, data_days: 1, label: "window: 28d, data: 1d", empty: false });
+    } finally {
+      await db.close();
+    }
+  });
+
+  // Wired smoke for the telemetry surface of the shared command classifier
+  // (#2659): reports no longer keeps its own gh-blind copy, so a gh json/jq
+  // invocation aggregates under the same key the hook and proxy record.
+  it("aggregates gh json/jq invocations under the shared command_family key", async () => {
+    const root = await tempRoot();
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const db = await connect(storeUri);
+    try {
+      const command = "gh pr list --json number,title --jq '.[0]'";
+      await db.kv(RSP_TELEMETRY_INVOCATIONS_COLLECTION).put("gh-json-jq", {
+        created_at: "2026-07-09T23:00:00.000Z",
+        command,
+        elided: true,
+        raw_bytes: 4000,
+        emitted_bytes: 400,
+        tokens_raw: 1000,
+        tokens_emitted: 100,
+        wrapper_ms: 12,
+      });
+
+      const report = await readTelemetryGainsReport(db, 28, new Date("2026-07-10T00:00:00.000Z"));
+      expect(report.savings.top_commands_by_tokens_saved[0]).toMatchObject({
+        command_family: commandFamily(command),
+      });
+      expect(report.savings.top_commands_by_tokens_saved[0]?.command_family).toBe("gh pr list json-jq");
     } finally {
       await db.close();
     }

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -636,6 +636,15 @@ describe("rsp telemetry spool", () => {
           { reason: "lossless-gh-json-jq", count: 1 },
           { reason: "unsupported-command", count: 1 },
         ],
+        // Decision families are read back from the stored `command_family`
+        // field, never re-derived — the contribution lane reports whatever key
+        // the minting surface recorded.
+        by_command_family: [
+          { command_family: "git status", contributed: 0, passed: 2, failed_open: 0, contribution_rate: 0 },
+          { command_family: "gh api", contributed: 1, passed: 0, failed_open: 0, contribution_rate: 1 },
+          { command_family: "gh pr view json-jq", contributed: 0, passed: 1, failed_open: 0, contribution_rate: 0 },
+          { command_family: "unknown", contributed: 0, passed: 0, failed_open: 1, contribution_rate: 0 },
+        ],
       });
     } finally {
       await db.close();


### PR DESCRIPTION
Automated AFK landing for #2659. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2659

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787481305&installation_model_id=20659&pr_number=2671&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2671&signature=8824d846147f216e3d5a0e9f6f58c0cd0fc4f34245d8382426cdfba96e978a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->