### PR TITLE
chore: #2660 manifest-core: single-source the pi/codex generation helpers + turbo change-path wiring

### DIFF
--- a/apps/dev/tests/pi-package-builder.test.ts
+++ b/apps/dev/tests/pi-package-builder.test.ts
@@ -4,6 +4,14 @@ import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
+import { buildPiPackages } from "../../../scripts/build-pi-packages.mjs";
+import {
+  jsonBytes,
+  normalizeSkillEntry,
+  normalizeText,
+  parseArgs,
+  titleCaseName,
+} from "../../../scripts/lib/manifest-core.mjs";
 
 const execFileAsync = promisify(execFile);
 const ROOT = join(import.meta.dirname, "..", "..", "..");
@@ -13,8 +21,63 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+describe("manifest-core helpers", () => {
+  it("parseArgs returns defaults with no argv", () => {
+    const args = parseArgs([]);
+    expect(args).toEqual({ root: process.cwd(), check: false });
+  });
+
+  it("parseArgs parses --root and --check", () => {
+    expect(parseArgs(["--root", "/tmp/x", "--check"])).toEqual({ root: "/tmp/x", check: true });
+    expect(parseArgs(["--check", "--root", "/tmp/y"])).toEqual({ root: "/tmp/y", check: true });
+  });
+
+  it("parseArgs throws on unknown argument", () => {
+    expect(() => parseArgs(["--unknown"])).toThrow("unknown argument: --unknown");
+  });
+
+  it("parseArgs throws when --root has no value", () => {
+    expect(() => parseArgs(["--root"])).toThrow("--root requires a path");
+  });
+
+  it("titleCaseName capitalizes hyphen-separated words", () => {
+    expect(titleCaseName("dev")).toBe("Dev");
+    expect(titleCaseName("red-skills")).toBe("Red Skills");
+    expect(titleCaseName("build-info")).toBe("Build Info");
+  });
+
+  it("normalizeSkillEntry strips trailing slashes", () => {
+    expect(normalizeSkillEntry("./skills/engineering/")).toBe("./skills/engineering");
+    expect(normalizeSkillEntry("./skills/engineering//")).toBe("./skills/engineering");
+    expect(normalizeSkillEntry("./skills/engineering")).toBe("./skills/engineering");
+  });
+
+  it("normalizeText sanitizes unicode punctuation", () => {
+    // backtick and smart single quotes → removed
+    expect(normalizeText("don’t")).toBe("dont");
+    expect(normalizeText("`backtick`")).toBe("backtick");
+    // smart double quotes → regular double quotes
+    expect(normalizeText("“smart”")).toBe('"smart"');
+    // en/em dashes → hyphen
+    expect(normalizeText("a–b")).toBe("a-b");
+    expect(normalizeText("a—b")).toBe("a-b");
+    // ellipsis → ...
+    expect(normalizeText("wait…")).toBe("wait...");
+    // collapses whitespace
+    expect(normalizeText("  too   many   spaces  ")).toBe("too many spaces");
+    // null/undefined → empty string
+    expect(normalizeText(null)).toBe("");
+    expect(normalizeText(undefined)).toBe("");
+  });
+
+  it("jsonBytes serializes with two-space indent and trailing newline", () => {
+    expect(jsonBytes({ a: 1 })).toBe('{\n  "a": 1\n}\n');
+    expect(jsonBytes([1, 2])).toBe('[\n  1,\n  2\n]\n');
+  });
+});
+
 describe("Pi package builder", () => {
-  it("stages per-plugin npm-ready packages with skills copied under packaging/pi/", async () => {
+  it("stages per-plugin npm-ready packages with skills copied under packaging/pi/ (module API)", async () => {
     const root = await mkdtemp(join(tmpdir(), "red-skills-pi-build-"));
 
     await mkdir(join(root, ".claude-plugin"), { recursive: true });
@@ -86,7 +149,7 @@ description: Test init skill.
       "utf8",
     );
 
-    await execFileAsync("node", [builder, "--root", root]);
+    await buildPiPackages({ root });
 
     // npm-ready package.json shape
     const devPkg = JSON.parse(
@@ -126,7 +189,7 @@ description: Test init skill.
     expect(memoryPkg.pi.skills).toEqual(["./skills/core/"]);
   });
 
-  it("fails --check when a staged Pi package drifts from the source", async () => {
+  it("fails --check when a staged Pi package drifts from the source (module API)", async () => {
     const root = await mkdtemp(join(tmpdir(), "red-skills-pi-build-check-"));
 
     await mkdir(join(root, ".claude-plugin"), { recursive: true });
@@ -155,24 +218,23 @@ description: afk
       "utf8",
     );
 
-    await execFileAsync("node", [builder, "--root", root]);
+    await buildPiPackages({ root });
     const staged = join(root, "packaging/pi/dev/package.json");
     const pkg = JSON.parse(await readFile(staged, "utf8"));
     pkg.description = "hand-edited drift";
     await writeJson(staged, pkg);
 
-    await expect(
-      execFileAsync("node", [builder, "--root", root, "--check"]),
-    ).rejects.toMatchObject({
-      stderr: expect.stringContaining("Pi packages are stale"),
-    });
+    await expect(buildPiPackages({ root, check: true })).rejects.toThrow("Pi packages are stale");
   });
 
-  it("matches the builder output for the repo's committed plugin manifests", async () => {
+  it("matches the builder output for the repo's committed plugin manifests (subprocess smoke)", async () => {
+    // One subprocess call pins the main()-guard CLI contract: the script must
+    // be directly executable as `node build-pi-packages.mjs` in addition to
+    // being importable as a module.
     await execFileAsync("node", [builder, "--root", ROOT, "--check"]);
   });
 
-  it("stamps RED_BUILD_VERSION over the plugin manifest version (release build)", async () => {
+  it("stamps RED_BUILD_VERSION over the plugin manifest version (module API)", async () => {
     const root = await mkdtemp(join(tmpdir(), "red-skills-pi-ver-"));
     await mkdir(join(root, ".claude-plugin"), { recursive: true });
     await mkdir(join(root, "plugins/dev/.claude-plugin"), { recursive: true });
@@ -203,9 +265,17 @@ description: Test afk skill.
       "utf8",
     );
 
-    await execFileAsync("node", [builder, "--root", root], {
-      env: { ...process.env, RED_BUILD_VERSION: "v1.2.3" },
-    });
+    const prev = process.env.RED_BUILD_VERSION;
+    process.env.RED_BUILD_VERSION = "v1.2.3";
+    try {
+      await buildPiPackages({ root });
+    } finally {
+      if (prev === undefined) {
+        delete process.env.RED_BUILD_VERSION;
+      } else {
+        process.env.RED_BUILD_VERSION = prev;
+      }
+    }
 
     const pkg = JSON.parse(
       await readFile(join(root, "packaging/pi/dev/package.json"), "utf8"),

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "version:sync": "node scripts/sync-version.mjs",
     "version:sync:check": "node scripts/sync-version.mjs --check",
     "release:manifest": "node scripts/release-manifest.mjs",
+    "generate-manifests": "node scripts/generate-codex-manifests.mjs && node scripts/generate-pi-manifests.mjs",
     "codex:manifests": "node scripts/generate-codex-manifests.mjs",
     "codex:manifests:check": "node scripts/generate-codex-manifests.mjs --check",
     "pi:manifests": "node scripts/generate-pi-manifests.mjs",

--- a/scripts/build-pi-packages.d.mts
+++ b/scripts/build-pi-packages.d.mts
@@ -1,0 +1,1 @@
+export declare function buildPiPackages(options: { root: string; check?: boolean }): Promise<void>;

--- a/scripts/build-pi-packages.mjs
+++ b/scripts/build-pi-packages.mjs
@@ -19,45 +19,23 @@
 //
 // Exit codes: 0 success; 1 drift detected; 2 usage error.
 
-import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, relative } from "node:path";
-import { spawnSync } from "node:child_process";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildPiPackage } from "./generate-pi-manifests.mjs";
+import {
+  jsonBytes,
+  parseArgs,
+  printDiffs,
+  readJson,
+  writeGenerated,
+} from "./lib/manifest-core.mjs";
 
 const PUBLISHED_BUCKETS = ["engineering", "knowledge", "productivity", "misc", "core", "maintainer"];
 const SKIP_BUCKETS = new Set(["in-progress", "deprecated"]);
 const NPM_SCOPE = "@reddb-io";
 const PACKAGING_ROOT = "packaging/pi";
-
-function parseArgs(argv) {
-  const args = { root: process.cwd(), check: false };
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--check") {
-      args.check = true;
-      continue;
-    }
-    if (arg === "--root") {
-      const next = argv[index + 1];
-      if (!next) throw new Error("--root requires a path");
-      args.root = next;
-      index += 1;
-      continue;
-    }
-    throw new Error(`unknown argument: ${arg}`);
-  }
-  return args;
-}
-
-async function readJson(path) {
-  return JSON.parse(await readFile(path, "utf8"));
-}
-
-function jsonBytes(value) {
-  return `${JSON.stringify(value, null, 2)}\n`;
-}
 
 function isPublishedBucket(name) {
   return PUBLISHED_BUCKETS.includes(name);
@@ -115,7 +93,7 @@ async function stagePackage({ root, plugin, claudePlugin, packagingDir, mismatch
   }
 
   // 1. Stage package.json
-  await writeOrCheck(
+  await writeGenerated(
     join(targetDir, "package.json"),
     jsonBytes(packageJson),
     check,
@@ -157,7 +135,7 @@ async function stagePackage({ root, plugin, claudePlugin, packagingDir, mismatch
 
   // 3. Stage a small README so `npm view` shows project context, not just an
   // auto-generated "no description" stub.
-  await writeOrCheck(
+  await writeGenerated(
     join(targetDir, "README.md"),
     renderPackageReadme({ pluginName, packageJson, buckets }),
     check,
@@ -195,23 +173,6 @@ pnpm pi:packages:build
 
 Apache-2.0.
 `;
-}
-
-async function writeOrCheck(path, bytes, check, mismatches) {
-  if (!check) {
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, bytes);
-    return;
-  }
-  let current = "";
-  try {
-    current = await readFile(path, "utf8");
-  } catch {
-    current = "";
-  }
-  if (current !== bytes) {
-    mismatches.push({ path, bytes });
-  }
 }
 
 async function diffDirs(leftDir, rightDir) {
@@ -252,29 +213,6 @@ async function diffDirs(leftDir, rightDir) {
   return drift;
 }
 
-async function printDiffs(root, mismatches) {
-  const tempRoot = await mkdtemp(join(tmpdir(), "red-skills-pi-pkg-diff-"));
-  try {
-    for (const mismatch of mismatches) {
-      if (mismatch.note) {
-        console.error(`# ${relative(root, mismatch.path)}\n${mismatch.note.join("\n")}`);
-        continue;
-      }
-      const rel = relative(root, mismatch.path);
-      const expected = join(tempRoot, rel);
-      await mkdir(dirname(expected), { recursive: true });
-      await writeFile(expected, mismatch.bytes);
-      const diff = spawnSync("git", ["diff", "--no-index", "--", mismatch.path, expected], {
-        encoding: "utf8",
-      });
-      const output = `${diff.stdout}${diff.stderr}`.trim();
-      if (output) console.error(output);
-    }
-  } finally {
-    await rm(tempRoot, { recursive: true, force: true });
-  }
-}
-
 export async function buildPiPackages({ root, check = false }) {
   const mismatches = [];
   const claudeMarketplacePath = join(root, ".claude-plugin/marketplace.json");
@@ -288,7 +226,7 @@ export async function buildPiPackages({ root, check = false }) {
   }
 
   if (check && mismatches.length > 0) {
-    await printDiffs(root, mismatches);
+    await printDiffs(root, mismatches, { tempLabel: "red-skills-pi-pkg-diff-" });
     throw new Error(
       `Pi packages are stale; run pnpm pi:packages:build (${mismatches.length} mismatched file(s) or dir(s))`,
     );

--- a/scripts/generate-codex-manifests.mjs
+++ b/scripts/generate-codex-manifests.mjs
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join, relative } from "node:path";
-import { spawnSync } from "node:child_process";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  jsonBytes,
+  normalizeSkillEntry,
+  normalizeText,
+  parseArgs,
+  printDiffs,
+  readJson,
+  titleCaseName,
+  writeGenerated,
+} from "./lib/manifest-core.mjs";
 
 const REPO_URL = "https://github.com/reddb-io/red-skills";
 const AUTHOR = {
@@ -12,49 +19,6 @@ const AUTHOR = {
 };
 const CAPABILITIES = ["Interactive", "Read", "Write", "Shell"];
 const PREFERRED_SKILL_ROOT_ORDER = ["engineering", "knowledge", "productivity", "misc", "core"];
-
-function parseArgs(argv) {
-  const args = {
-    root: process.cwd(),
-    check: false,
-  };
-
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--check") {
-      args.check = true;
-      continue;
-    }
-    if (arg === "--root") {
-      const next = argv[index + 1];
-      if (!next) throw new Error("--root requires a path");
-      args.root = next;
-      index += 1;
-      continue;
-    }
-    throw new Error(`unknown argument: ${arg}`);
-  }
-
-  return args;
-}
-
-function codexText(input) {
-  return String(input ?? "")
-    .replace(/[`\u2018\u2019]/g, "")
-    .replace(/[\u201c\u201d]/g, '"')
-    .replace(/[\u2013\u2014]/g, "-")
-    .replace(/\u2026/g, "...")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function titleCaseName(name) {
-  return String(name)
-    .split(/[-_\s]+/)
-    .filter(Boolean)
-    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
-    .join(" ");
-}
 
 function marketplaceDisplayName(name) {
   if (name === "red-skills") return "RedSkills";
@@ -70,10 +34,6 @@ function pluginKeywords(name) {
   const keywords = ["codex", "claude-code", "skills", "agents"];
   if (name === "dev") return [...keywords, "github-issues", "tdd"];
   return [...keywords, name];
-}
-
-function normalizeSkillEntry(entry) {
-  return String(entry).replace(/\/+$/, "");
 }
 
 function deriveCodexSkillRoots(skills) {
@@ -140,7 +100,7 @@ export function buildCodexMarketplace(claudeMarketplace) {
         },
       };
       maybeSet(codexPlugin, "dependencies", plugin.dependencies);
-      maybeSet(codexPlugin, "description", codexText(plugin.description));
+      maybeSet(codexPlugin, "description", normalizeText(plugin.description));
       codexPlugin.category = "Developer Tools";
       return codexPlugin;
     }),
@@ -148,7 +108,7 @@ export function buildCodexMarketplace(claudeMarketplace) {
 }
 
 export function buildCodexPluginManifest(claudePlugin) {
-  const description = codexText(claudePlugin.description);
+  const description = normalizeText(claudePlugin.description);
   const manifest = {
     name: claudePlugin.name,
     version: claudePlugin.version,
@@ -179,52 +139,6 @@ export function buildCodexPluginManifest(claudePlugin) {
   return manifest;
 }
 
-function jsonBytes(value) {
-  return `${JSON.stringify(value, null, 2)}\n`;
-}
-
-async function readJson(path) {
-  return JSON.parse(await readFile(path, "utf8"));
-}
-
-async function writeGenerated(path, bytes, check, mismatches) {
-  if (!check) {
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, bytes);
-    return;
-  }
-
-  let current = "";
-  try {
-    current = await readFile(path, "utf8");
-  } catch {
-    current = "";
-  }
-
-  if (current !== bytes) {
-    mismatches.push({ path, bytes });
-  }
-}
-
-async function printDiffs(root, mismatches) {
-  const tempRoot = await mkdtemp(join(tmpdir(), "red-skills-codex-manifest-diff-"));
-  try {
-    for (const mismatch of mismatches) {
-      const rel = relative(root, mismatch.path);
-      const expected = join(tempRoot, rel);
-      await mkdir(dirname(expected), { recursive: true });
-      await writeFile(expected, mismatch.bytes);
-      const diff = spawnSync("git", ["diff", "--no-index", "--", mismatch.path, expected], {
-        encoding: "utf8",
-      });
-      const output = `${diff.stdout}${diff.stderr}`.trim();
-      if (output) console.error(output);
-    }
-  } finally {
-    await rm(tempRoot, { recursive: true, force: true });
-  }
-}
-
 export async function generateCodexManifests({ root, check = false }) {
   const mismatches = [];
   const claudeMarketplacePath = join(root, ".claude-plugin/marketplace.json");
@@ -244,7 +158,7 @@ export async function generateCodexManifests({ root, check = false }) {
   }
 
   if (check && mismatches.length > 0) {
-    await printDiffs(root, mismatches);
+    await printDiffs(root, mismatches, { tempLabel: "red-skills-codex-manifest-diff-" });
     throw new Error(`Codex manifests are stale; run node scripts/generate-codex-manifests.mjs (${mismatches.length} file(s))`);
   }
 }

--- a/scripts/generate-pi-manifests.mjs
+++ b/scripts/generate-pi-manifests.mjs
@@ -17,54 +17,23 @@
 // skill (engineering/knowledge/productivity/misc) without the in-progress
 // drafts.
 
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join, relative } from "node:path";
-import { spawnSync } from "node:child_process";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  jsonBytes,
+  normalizeSkillEntry,
+  normalizeText,
+  parseArgs,
+  printDiffs,
+  readJson,
+  writeGenerated,
+} from "./lib/manifest-core.mjs";
 
 const REPO_URL = "https://github.com/reddb-io/red-skills";
 const HOMEPAGE = "https://github.com/reddb-io/red-skills";
 const LICENSE = "Apache-2.0";
 const PREFERRED_SKILL_ROOT_ORDER = ["engineering", "knowledge", "productivity", "misc", "core"];
 const SCOPED_NAMESPACE = "@reddb-io";
-
-function parseArgs(argv) {
-  const args = {
-    root: process.cwd(),
-    check: false,
-  };
-
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--check") {
-      args.check = true;
-      continue;
-    }
-    if (arg === "--root") {
-      const next = argv[index + 1];
-      if (!next) throw new Error("--root requires a path");
-      args.root = next;
-      index += 1;
-      continue;
-    }
-    throw new Error(`unknown argument: ${arg}`);
-  }
-
-  return args;
-}
-
-function titleCaseName(name) {
-  return String(name)
-    .split(/[-_\s]+/)
-    .filter(Boolean)
-    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
-    .join(" ");
-}
-
-function normalizeSkillEntry(entry) {
-  return String(entry).replace(/\/+$/, "");
-}
 
 function deriveSkillRoots(skills) {
   if (typeof skills === "string") {
@@ -96,18 +65,8 @@ function deriveSkillRoots(skills) {
   return orderedRoots.map((root) => `./skills/${root}/`);
 }
 
-function descriptionText(input) {
-  return String(input ?? "")
-    .replace(/[`\u2018\u2019]/g, "")
-    .replace(/[\u201c\u201d]/g, '"')
-    .replace(/[\u2013\u2014]/g, "-")
-    .replace(/\u2026/g, "...")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
 export function buildPiPackage(claudePlugin) {
-  const description = descriptionText(claudePlugin.description);
+  const description = normalizeText(claudePlugin.description);
   const packageName = `${SCOPED_NAMESPACE}/red-skills-${claudePlugin.name}`;
   const skillRoots = deriveSkillRoots(claudePlugin.skills);
   if (skillRoots.length === 0) {
@@ -136,52 +95,6 @@ export function buildPiPackage(claudePlugin) {
   return packageJson;
 }
 
-function jsonBytes(value) {
-  return `${JSON.stringify(value, null, 2)}\n`;
-}
-
-async function readJson(path) {
-  return JSON.parse(await readFile(path, "utf8"));
-}
-
-async function writeGenerated(path, bytes, check, mismatches) {
-  if (!check) {
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, bytes);
-    return;
-  }
-
-  let current = "";
-  try {
-    current = await readFile(path, "utf8");
-  } catch {
-    current = "";
-  }
-
-  if (current !== bytes) {
-    mismatches.push({ path, bytes });
-  }
-}
-
-async function printDiffs(root, mismatches) {
-  const tempRoot = await mkdtemp(join(tmpdir(), "red-skills-pi-manifest-diff-"));
-  try {
-    for (const mismatch of mismatches) {
-      const rel = relative(root, mismatch.path);
-      const expected = join(tempRoot, rel);
-      await mkdir(dirname(expected), { recursive: true });
-      await writeFile(expected, mismatch.bytes);
-      const diff = spawnSync("git", ["diff", "--no-index", "--", mismatch.path, expected], {
-        encoding: "utf8",
-      });
-      const output = `${diff.stdout}${diff.stderr}`.trim();
-      if (output) console.error(output);
-    }
-  } finally {
-    await rm(tempRoot, { recursive: true, force: true });
-  }
-}
-
 export async function generatePiManifests({ root, check = false }) {
   const mismatches = [];
   const claudeMarketplacePath = join(root, ".claude-plugin/marketplace.json");
@@ -200,7 +113,7 @@ export async function generatePiManifests({ root, check = false }) {
   }
 
   if (check && mismatches.length > 0) {
-    await printDiffs(root, mismatches);
+    await printDiffs(root, mismatches, { tempLabel: "red-skills-pi-manifest-diff-" });
     throw new Error(
       `Pi manifests are stale; run node scripts/generate-pi-manifests.mjs (${mismatches.length} file(s))`,
     );

--- a/scripts/lib/manifest-core.d.mts
+++ b/scripts/lib/manifest-core.d.mts
@@ -1,0 +1,17 @@
+export declare function parseArgs(argv: string[]): { root: string; check: boolean };
+export declare function titleCaseName(name: string): string;
+export declare function normalizeSkillEntry(entry: string): string;
+export declare function normalizeText(input: unknown): string;
+export declare function jsonBytes(value: unknown): string;
+export declare function readJson(path: string): Promise<unknown>;
+export declare function writeGenerated(
+  path: string,
+  bytes: string,
+  check: boolean,
+  mismatches: Array<{ path: string; bytes: string }>,
+): Promise<void>;
+export declare function printDiffs(
+  root: string,
+  mismatches: Array<{ path: string; bytes: string; note?: string[] }>,
+  options?: { tempLabel?: string },
+): Promise<void>;

--- a/scripts/lib/manifest-core.mjs
+++ b/scripts/lib/manifest-core.mjs
@@ -1,0 +1,106 @@
+// Shared helpers for generate-codex-manifests.mjs, generate-pi-manifests.mjs,
+// and build-pi-packages.mjs. Single source of truth — import from here instead
+// of duplicating.
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { spawnSync } from "node:child_process";
+
+export function parseArgs(argv) {
+  const args = { root: process.cwd(), check: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--check") {
+      args.check = true;
+      continue;
+    }
+    if (arg === "--root") {
+      const next = argv[index + 1];
+      if (!next) throw new Error("--root requires a path");
+      args.root = next;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+export function titleCaseName(name) {
+  return String(name)
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+export function normalizeSkillEntry(entry) {
+  return String(entry).replace(/\/+$/, "");
+}
+
+// Sanitize unicode smart quotes, dashes, and ellipses so generated JSON
+// serialises cleanly in any terminal and across manifest formats.
+export function normalizeText(input) {
+  return String(input ?? "")
+    .replace(/[`‘’]/g, "")
+    .replace(/[“”]/g, '"')
+    .replace(/[–—]/g, "-")
+    .replace(/…/g, "...")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function jsonBytes(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+export async function writeGenerated(path, bytes, check, mismatches) {
+  if (!check) {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, bytes);
+    return;
+  }
+
+  let current = "";
+  try {
+    current = await readFile(path, "utf8");
+  } catch {
+    current = "";
+  }
+
+  if (current !== bytes) {
+    mismatches.push({ path, bytes });
+  }
+}
+
+// Print git diffs for mismatched generated files. `tempLabel` customises the
+// temp-dir prefix so error output identifies which generator produced it.
+// Mismatches with a `note` string array are printed as plain text (used by
+// build-pi-packages for directory-tree diffs that have no single file to diff).
+export async function printDiffs(root, mismatches, { tempLabel = "red-skills-diff-" } = {}) {
+  const tempRoot = await mkdtemp(join(tmpdir(), tempLabel));
+  try {
+    for (const mismatch of mismatches) {
+      if (mismatch.note) {
+        console.error(`# ${relative(root, mismatch.path)}\n${mismatch.note.join("\n")}`);
+        continue;
+      }
+      const rel = relative(root, mismatch.path);
+      const expected = join(tempRoot, rel);
+      await mkdir(dirname(expected), { recursive: true });
+      await writeFile(expected, mismatch.bytes);
+      const diff = spawnSync("git", ["diff", "--no-index", "--", mismatch.path, expected], {
+        encoding: "utf8",
+      });
+      const output = `${diff.stdout}${diff.stderr}`.trim();
+      if (output) console.error(output);
+    }
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
+    "generate-manifests": {
+      "inputs": [
+        "plugins/**",
+        "scripts/generate-*-manifests.mjs",
+        "scripts/lib/manifest-core.mjs"
+      ],
+      "outputs": [
+        ".agents/plugins/marketplace.json",
+        "plugins/*/.codex-plugin/plugin.json",
+        "plugins/*/package.json"
+      ]
+    },
     "typecheck": {
       "dependsOn": ["^build"],
       "outputs": []
@@ -10,7 +22,7 @@
       "outputs": []
     },
     "bundle": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "//generate-manifests"],
       "cache": false
     },
     "@reddb-io/dev#bundle": {
@@ -27,7 +39,7 @@
       "cache": false
     },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "//generate-manifests"],
       "cache": false
     }
   }


### PR DESCRIPTION
Automated AFK landing for #2660. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2660

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787481608&installation_model_id=20659&pr_number=2672&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2672&signature=55d7f4f9e0d842bee219f33681d77b2e0dfe8d89bc8c4522eaa1a74d07db6080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->