### PR TITLE
fix(janitor): protect live supervisor lane from unknown-root sweep

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -146,6 +146,8 @@ export function fleetHeartbeatState(hb: FleetHeartbeat): string {
 }
 
 function writeFleetStateAtomic(path: string, hb: FleetHeartbeat): void {
+  // mkdir -p ensures a swept lane self-heals on the next heartbeat tick.
+  mkdirSync(dirname(path), { recursive: true });
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, fleetHeartbeatState(hb), "utf8");
   renameSync(tmp, path);
@@ -848,6 +850,21 @@ function buildSupervisorDeps(
       let firehoseWritten = false;
       let stateError: string | undefined;
       let firehoseError: string | undefined;
+      // Self-heal: if the supervisor's runtime lane was removed mid-run (e.g. by
+      // a janitor bug or manual rm), re-pin the pid identity so the lane is
+      // protected on the next janitor sweep. The writeFleetStateAtomic mkdir
+      // recreates the directory; this re-writes the pid + start files.
+      try {
+        const runtimeDir = dirname(statePath);
+        const pidFilePath = join(runtimeDir, "afk-supervisor.pid");
+        if (!existsSync(pidFilePath)) {
+          const startTime = readPidStartTime(process.pid);
+          writeFileSync(pidFilePath, String(process.pid), "utf8");
+          if (startTime !== null) writeFileSync(`${pidFilePath}.start`, startTime, "utf8");
+        }
+      } catch {
+        // best-effort: a failed re-pin is logged implicitly via stateError below.
+      }
       try {
         writeFleetStateAtomic(statePath, stamped);
         stateWritten = true;

--- a/apps/dev/src/core/tmp-janitor.ts
+++ b/apps/dev/src/core/tmp-janitor.ts
@@ -43,6 +43,7 @@ export const KNOWN_TMP_LANES = new Set([
   "workers",
   "go-workers",
   "scout-workers",
+  "supervisors",
   "claims",
   "waits",
   "worktrees",
@@ -292,6 +293,38 @@ export function planWorkerDirJanitor(entries: readonly WorkerDirJanitorEntry[]):
     } else {
       spare.push(entry);
     }
+  }
+  return { reclaim, spare };
+}
+
+// ---------- supervisor lane planner ----------
+
+/** One fleet dir under `.red/tmp/supervisors/`. */
+export interface SupervisorLaneEntry {
+  /** Absolute path of the fleet dir (e.g. `.red/tmp/supervisors/default`). */
+  path: string;
+  /** Fleet name (the basename of the fleet dir). */
+  fleet: string;
+  /** Whether the pid file in this fleet dir names a live process. */
+  pidAlive: boolean;
+}
+
+export interface SupervisorLanePlan {
+  /** Fleet dirs whose supervisor pid is dead — safe to reclaim. */
+  reclaim: SupervisorLaneEntry[];
+  /** Fleet dirs whose supervisor pid is alive — must be spared. */
+  spare: SupervisorLaneEntry[];
+}
+
+/** Plan supervisor lane cleanup. A fleet dir is reclaimable only when its
+ * `afk-supervisor.pid` does not name a live process. Live supervisors are
+ * always spared regardless of mtime. */
+export function planSupervisorLaneJanitor(entries: readonly SupervisorLaneEntry[]): SupervisorLanePlan {
+  const reclaim: SupervisorLaneEntry[] = [];
+  const spare: SupervisorLaneEntry[] = [];
+  for (const entry of entries) {
+    if (entry.pidAlive) spare.push(entry);
+    else reclaim.push(entry);
   }
   return { reclaim, spare };
 }

--- a/apps/dev/src/runtime/tmp-janitor.ts
+++ b/apps/dev/src/runtime/tmp-janitor.ts
@@ -4,6 +4,7 @@ import {
   isLegacySlotLogName,
   planTmpJanitor,
   planWorkerDirJanitor,
+  planSupervisorLaneJanitor,
   parseFeedbackWorktreeWorkerSlug,
   planOrphanFeedbackWorktreeSweep,
   type JanitorEntry,
@@ -11,6 +12,8 @@ import {
   type OrphanFeedbackSweepPlan,
   type TmpJanitorPlan,
   type WorkerDirJanitorEntry,
+  type SupervisorLaneEntry,
+  type SupervisorLanePlan,
 } from "../core/tmp-janitor.js";
 import { allWorkersRoots, parseReapableWorkerPath } from "../core/worker-paths.js";
 import { execTool } from "./exec.js";
@@ -78,6 +81,9 @@ export type IssueStateLookup = (issue: number) => "OPEN" | "CLOSED" | "UNKNOWN";
 export interface TmpJanitorReport {
   plan: TmpJanitorPlan;
   staleWorkers: ReturnType<typeof planWorkerDirJanitor>;
+  /** Supervisor fleet dirs partitioned by pid liveness. Live dirs are spared;
+   * dead dirs are eligible for removal. */
+  staleSupervisors: SupervisorLanePlan;
   /** Orphaned feedback worktrees whose owning worker is dead (or the shared
    * baseline worktree when no workers are alive). Swept independently of the
    * mtime TTL sweep so dead-owner entries age out immediately. */
@@ -91,6 +97,10 @@ export interface TmpJanitorApplyResult {
   staleWorkers: string[];
   unknownTmpRoots: string[];
   protectedLiveWorkers: string[];
+  /** Supervisor fleet dirs spared because their pid is live. */
+  protectedLiveSupervisors: string[];
+  /** Supervisor fleet dirs removed because their pid was dead. */
+  staleSupervisors: string[];
   /** Feedback worktrees spared because their owning worker is live. */
   protectedLiveFeedback: string[];
   /** Orphaned feedback worktrees that were removed. */
@@ -100,7 +110,7 @@ export interface TmpJanitorApplyResult {
   /** Every destructive action, including the liveness verdict authorising it. */
   removals: Array<{
     path: string;
-    livenessVerdict: "not-worker-workspace" | "worker-dead" | "owner-dead" | "no-live-workers";
+    livenessVerdict: "not-worker-workspace" | "worker-dead" | "supervisor-dead" | "owner-dead" | "no-live-workers";
   }>;
 }
 
@@ -186,6 +196,25 @@ async function collectWorkerEntries(tmpDir: string, lookup: IssueStateLookup): P
     }
   }
   return out;
+}
+
+/** Collect supervisor fleet dirs under `.red/tmp/supervisors/` with pid liveness. */
+async function collectSupervisorEntries(tmpDir: string): Promise<SupervisorLaneEntry[]> {
+  const supervisorsRoot = join(tmpDir, "supervisors");
+  const fleets = await listNames(supervisorsRoot);
+  const entries: SupervisorLaneEntry[] = [];
+  for (const fleet of fleets) {
+    const fleetDir = join(supervisorsRoot, fleet);
+    try {
+      const st = await stat(fleetDir);
+      if (!st.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const alive = pidAlive(await readText(join(fleetDir, "afk-supervisor.pid")));
+    entries.push({ path: fleetDir, fleet, pidAlive: alive });
+  }
+  return entries;
 }
 
 /**
@@ -277,7 +306,7 @@ export async function collectTmpJanitorReport(
   nowS: number,
   lookup: IssueStateLookup,
 ): Promise<TmpJanitorReport> {
-  const [tmpRootNames, tmpRootEntries, logEntries, scratchEntries, diagnosticsEntries, feedbackEntries, workers, orphanFeedbackData] =
+  const [tmpRootNames, tmpRootEntries, logEntries, scratchEntries, diagnosticsEntries, feedbackEntries, workers, orphanFeedbackData, supervisorEntries] =
     await Promise.all([
       listNames(tmpDir),
       listEntries(tmpDir),
@@ -287,6 +316,7 @@ export async function collectTmpJanitorReport(
       listEntries(join(tmpDir, "worktrees", "feedback")),
       collectWorkerEntries(tmpDir, lookup),
       collectOrphanFeedbackEntries(tmpDir),
+      collectSupervisorEntries(tmpDir),
     ]);
   const legacySlotLogEntries = tmpRootEntries.filter((entry) => isLegacySlotLogName(basename(entry.path)));
   const orphanFeedback = planOrphanFeedbackWorktreeSweep(orphanFeedbackData.entries, orphanFeedbackData.anyWorkerAlive);
@@ -306,6 +336,7 @@ export async function collectTmpJanitorReport(
       tmpRootNames,
     }),
     staleWorkers: planWorkerDirJanitor(workers),
+    staleSupervisors: planSupervisorLaneJanitor(supervisorEntries),
     orphanFeedback,
     orphanTestRunners,
   };
@@ -332,6 +363,8 @@ export async function applyTmpJanitorReport(
     staleWorkers: [],
     unknownTmpRoots: [],
     protectedLiveWorkers: [],
+    protectedLiveSupervisors: [],
+    staleSupervisors: [],
     protectedLiveFeedback: [],
     orphanFeedback: [],
     orphanTestRunners: [],
@@ -372,6 +405,21 @@ export async function applyTmpJanitorReport(
     await rm(worker.path, { recursive: true, force: true });
     result.removals.push({ path: worker.path, livenessVerdict: "worker-dead" });
     result.staleWorkers.push(worker.path);
+  }
+
+  // Re-check supervisor pid at apply time — a supervisor may have started
+  // between collect and apply (same pattern as the worker liveness re-check).
+  for (const supervisor of report.staleSupervisors.reclaim) {
+    if (pidAlive(await readText(join(supervisor.path, "afk-supervisor.pid")))) {
+      result.protectedLiveSupervisors.push(supervisor.path);
+      continue;
+    }
+    await rm(supervisor.path, { recursive: true, force: true });
+    result.removals.push({ path: supervisor.path, livenessVerdict: "supervisor-dead" });
+    result.staleSupervisors.push(supervisor.path);
+  }
+  for (const supervisor of report.staleSupervisors.spare) {
+    result.protectedLiveSupervisors.push(supervisor.path);
   }
 
   for (const name of report.plan.unknownTmpRoots) {

--- a/apps/dev/tests/tmp-janitor-runtime.test.ts
+++ b/apps/dev/tests/tmp-janitor-runtime.test.ts
@@ -164,4 +164,61 @@ describe("tmp janitor runtime", () => {
     await expect(access(feedback)).resolves.toBeUndefined();
     expect(applied.protectedLiveFeedback).toEqual([feedback]);
   });
+
+  it("spares a supervisor fleet dir whose pid is live", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const supervisorDir = join(tmp, "supervisors", "default");
+    await mkdir(supervisorDir, { recursive: true });
+    await writeFile(join(supervisorDir, "afk-supervisor.pid"), String(process.pid), "utf8");
+    await writeFile(join(supervisorDir, "state.toon"), "{}", "utf8");
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "UNKNOWN");
+
+    expect(report.staleSupervisors.spare.map((e) => e.path)).toEqual([supervisorDir]);
+    expect(report.staleSupervisors.reclaim).toEqual([]);
+    expect(report.plan.unknownTmpRoots).not.toContain("supervisors");
+
+    const applied = await applyTmpJanitorReport(tmp, report);
+    await expect(access(supervisorDir)).resolves.toBeUndefined();
+    expect(applied.protectedLiveSupervisors).toContain(supervisorDir);
+    expect(applied.staleSupervisors).toEqual([]);
+  });
+
+  it("reaps a supervisor fleet dir whose pid is dead", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const supervisorDir = join(tmp, "supervisors", "default");
+    await mkdir(supervisorDir, { recursive: true });
+    await writeFile(join(supervisorDir, "afk-supervisor.pid"), "999999999", "utf8");
+    await writeFile(join(supervisorDir, "state.toon"), "{}", "utf8");
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "UNKNOWN");
+
+    expect(report.staleSupervisors.reclaim.map((e) => e.path)).toEqual([supervisorDir]);
+    expect(report.staleSupervisors.spare).toEqual([]);
+    expect(report.plan.unknownTmpRoots).not.toContain("supervisors");
+
+    const applied = await applyTmpJanitorReport(tmp, report);
+    await expect(access(supervisorDir)).rejects.toThrow();
+    expect(applied.staleSupervisors).toContain(supervisorDir);
+    expect(applied.protectedLiveSupervisors).toEqual([]);
+  });
+
+  it("re-checks supervisor pid at apply time and protects a now-live supervisor", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const supervisorDir = join(tmp, "supervisors", "default");
+    await mkdir(supervisorDir, { recursive: true });
+    await writeFile(join(supervisorDir, "afk-supervisor.pid"), "999999999", "utf8");
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "UNKNOWN");
+    // Simulate supervisor coming alive between collect and apply
+    await writeFile(join(supervisorDir, "afk-supervisor.pid"), String(process.pid), "utf8");
+
+    const applied = await applyTmpJanitorReport(tmp, report);
+    await expect(access(supervisorDir)).resolves.toBeUndefined();
+    expect(applied.protectedLiveSupervisors).toContain(supervisorDir);
+    expect(applied.staleSupervisors).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

- The tmp-janitor's unknown-root sweep was deleting `.red/tmp/supervisors/` because `"supervisors"` was missing from `KNOWN_TMP_LANES`. The live supervisor still held file descriptors to its pid file and heartbeat state, causing `fleet_status` to report `pid=0/absent` and the statusline fleet chip to disappear.
- Add `"supervisors"` to `KNOWN_TMP_LANES` so the unknown-root deleter never touches it.
- Add per-fleet liveness check (`SupervisorLaneEntry` / `planSupervisorLaneJanitor`): spare fleet dirs with a live pid, reclaim those with a dead pid. Re-checks pid at apply time (same race-guard pattern as workers).
- Add `protectedLiveSupervisors` / `staleSupervisors` to the apply result.
- Self-heal: `writeFleetStateAtomic` now does `mkdir -p` before every write; `emitFleetHeartbeat` re-pins the pid + start files if they are missing, so a swept lane recovers on the next heartbeat tick instead of failing silently.
- Three regression tests covering the live-spare / dead-reap / collect-apply-race scenarios.

## Test plan

- [ ] `pnpm --filter @reddb-io/dev test` passes in CI
- [ ] `apps/dev/tests/tmp-janitor-runtime.test.ts` — 10 tests pass (3 new)
- [ ] `apps/dev/tests/tmp-janitor.test.ts` — 52 tests pass
- [ ] `apps/dev/tests/lane-taxonomy-docs.test.ts` — 5 tests pass
- [ ] TypeScript `tsc --noEmit` clean

Refs #2669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787482710&installation_model_id=20659&pr_number=2673&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2673&signature=9a0b8f74d13b04bb52a0a7391edfb120700d3119a6254810f5137fdcc084fdd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->