### PR TITLE
fix: #2668 MCP-first compliance sweep: statusline/fleet/docs still suggest '[REDACTED_SECRET]-dev monitor' CLI instead of the castle MCP tools

### DIFF
--- a/apps/dev/src/commands/codex-statusline.ts
+++ b/apps/dev/src/commands/codex-statusline.ts
@@ -72,7 +72,9 @@ function renderPlain(path: string, inspection: CodexStatuslineInspection, change
     lines.push("note: Codex will use its built-in default footer, which does not include task-progress.");
     lines.push("fix: afk codex-statusline --fix");
   }
-  lines.push("boundary: Codex supports built-in footer IDs only; use /afk monitor for rich AFK worker state.");
+  lines.push(
+    "boundary: Codex supports built-in footer IDs only; read rich AFK worker state from the castle `monitor` and `worker_vitals` tools (no-MCP fallback: /afk monitor).",
+  );
   lines.push("opencode: AFK API-auth runner only; no interactive host footer/plugin UI.");
   return `${lines.join("\n")}\n`;
 }

--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -219,6 +219,18 @@ function parseFleetArgs(args: readonly string[]): {
  * relaunch keeps the stale runner" trap: kill fleet, relaunch with
  * RED_AFK_RUNNER=claude, supervisor resumes codex from fleets.toonl.
  */
+/**
+ * The launch banner's monitoring line. Names the castle MCP read tools first
+ * (ADR 0120/0123); the slash command and the raw log tail are the no-MCP
+ * fallback for hosts that never loaded the castle server.
+ */
+export function fleetMonitorSuggestion(fleet: string): string {
+  return (
+    "monitor: call the castle `monitor` tool (and `worker_vitals` for liveness); " +
+    `no-MCP fallback: run /dev:afk monitor or tail .red/tmp/supervisors/${fleet}/supervisor.log.toonl manually.`
+  );
+}
+
 export function resolveLaunchRunnerPin(
   flag: string | undefined,
   env: NodeJS.ProcessEnv,
@@ -808,9 +820,7 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
   stdout.write(`   self-heal: armed (watchdog pid=${watchdogPid})\n`);
   stdout.write(`   log:   .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl\n`);
   stdout.write(`   stop:  /dev:afk fleet stop${named}\n`);
-  stdout.write(
-    `   monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/${paths.fleet}/supervisor.log.toonl manually.\n`,
-  );
+  stdout.write(`   ${fleetMonitorSuggestion(paths.fleet)}\n`);
   return { status: "launched", pid: supervisorPid, target, log: logFile };
 }
 

--- a/apps/dev/src/core/codex-monitor-agent.ts
+++ b/apps/dev/src/core/codex-monitor-agent.ts
@@ -31,6 +31,10 @@ export interface CodexMonitorAgentPromptOptions {
 
 export const DEFAULT_CODEX_MONITOR_INTERVAL_SECONDS = 30;
 
+/**
+ * The castle `monitor` tool is the canonical read (ADR 0120/0123); this CLI
+ * invocation is the no-MCP fallback for hosts that cannot reach the MCP.
+ */
 export const DEFAULT_CODEX_MONITOR_COMMAND =
   "env RED_AFK_RUNNER=codex red-skills-dev monitor --once";
 
@@ -63,11 +67,12 @@ export function renderCodexMonitorAgentPrompt(options: CodexMonitorAgentPromptOp
     "Purpose: keep AFK progress visible in the Codex UI while the main session continues working.",
     "",
     "Loop:",
-    `1. Every ${intervalSeconds} seconds, from the project root, run:`,
+    `1. Every ${intervalSeconds} seconds, read live state from the castle MCP: call the castle \`monitor\` tool for the current workers, history events, and fleet inputs, and \`worker_vitals\` when you must tell a quiet-but-alive worker from a dead one.`,
+    "2. When the castle MCP is not reachable from this host, say so once, then use the no-MCP fallback from the project root:",
     `   ${monitorCommand}`,
-    "2. Report a concise progress update when live worker state changes, when a worker becomes stale/wedged, or at least every five minutes.",
-    "3. Exit once there is no live .red/tmp/supervisors/default/afk-supervisor.pid and the monitor output has no [live] or [quiet] workers.",
-    "4. If the monitor command fails three times in a row, report the failure and exit.",
+    "3. Report a concise progress update when live worker state changes, when a worker becomes stale/wedged, or at least every five minutes.",
+    "4. Exit once there is no live .red/tmp/supervisors/default/afk-supervisor.pid and the monitor read has no [live] or [quiet] workers.",
+    "5. If the monitor read fails three times in a row, report the failure and exit.",
     "",
     "Hard read-only rules:",
     "- Do not edit files.",
@@ -76,7 +81,7 @@ export function renderCodexMonitorAgentPrompt(options: CodexMonitorAgentPromptOp
     "- Do not repair state. Only observe and report.",
     "",
     "Allowed actions:",
-    "- Run the AFK monitor command above.",
+    "- Call the read-only castle tools above (`monitor`, `worker_vitals`), or the fallback command when the MCP is unreachable.",
     "- Use read-only process/file checks such as ps, test -f, cat, tail, and ls when needed to decide whether to exit.",
     "- Summarize worker id, issue number, runner, stage, live/stale/wedged state, duration, and diffstat.",
   ].join("\n") + "\n";

--- a/apps/dev/tests/codex-monitor-agent.test.ts
+++ b/apps/dev/tests/codex-monitor-agent.test.ts
@@ -71,6 +71,9 @@ describe("codex monitor agent prompt", () => {
     expect(prompt).toContain("Project root: /repo");
     expect(prompt).toContain("AFK launch mode: fleet");
     expect(prompt).toContain("Every 10 seconds");
+    expect(prompt).toContain("castle `monitor` tool");
+    expect(prompt).toContain("`worker_vitals`");
+    expect(prompt).toContain("no-MCP fallback");
     expect(prompt).toContain("env RED_AFK_RUNNER=codex red-skills-dev monitor --once");
     expect(prompt).not.toContain(`${"r"}${"t"}${"k"} `);
     expect(prompt).toContain("red-skills-dev monitor --once");

--- a/apps/dev/tests/mcp-first-suggestions.test.ts
+++ b/apps/dev/tests/mcp-first-suggestions.test.ts
@@ -1,0 +1,93 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { fleetMonitorSuggestion } from "../src/commands/fleet.js";
+import { renderCodexMonitorAgentPrompt } from "../src/core/codex-monitor-agent.js";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+/**
+ * ADR 0120/0123: the castle MCP is the canonical interface, so every
+ * agent-facing suggestion names the MCP tool first. A `red-skills-dev` CLI
+ * invocation survives only when the surrounding text labels it, verbatim, as
+ * the `no-MCP fallback` — an exact phrase so the label has to be deliberate.
+ */
+const NO_MCP_LABEL = "no-MCP fallback";
+const LABEL_WINDOW = 3;
+
+/** Surfaces from the #2668 census, plus the docs that pin their printed strings. */
+const CENSUS = [
+  "apps/dev/src/commands/fleet.ts",
+  "apps/dev/src/commands/codex-statusline.ts",
+  "apps/dev/src/core/codex-monitor-agent.ts",
+  "plugins/dev/skills/engineering/afk/monitor.md",
+  "plugins/dev/skills/engineering/afk/fleet.md",
+  "plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md",
+  "plugins/dev/skills/engineering/afk/docs/CONFIG.md",
+  "plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md",
+  "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
+] as const;
+
+function readRepoFile(path: string): Promise<string> {
+  return readFile(join(ROOT, path), "utf8");
+}
+
+/** Lines mentioning the monitor CLI that no nearby `no-MCP fallback` label covers. */
+function unlabelledCliSuggestions(text: string): string[] {
+  const lines = text.split("\n");
+  return lines
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => line.includes("red-skills-dev monitor"))
+    .filter(({ index }) =>
+      !lines
+        .slice(Math.max(0, index - LABEL_WINDOW), index + 1)
+        .some((candidate) => candidate.toLowerCase().includes(NO_MCP_LABEL.toLowerCase())),
+    )
+    .map(({ line, index }) => `${index + 1}: ${line.trim()}`);
+}
+
+describe("MCP-first suggestion compliance", () => {
+  it("labels every surviving monitor CLI suggestion as the no-MCP fallback", async () => {
+    for (const path of CENSUS) {
+      const text = await readRepoFile(path);
+      expect(unlabelledCliSuggestions(text), `${path} names the CLI without a ${NO_MCP_LABEL} label`)
+        .toEqual([]);
+    }
+  });
+
+  it("names castle MCP tools verbatim wherever the monitor CLI still appears", async () => {
+    const mcpDoc = await readRepoFile("plugins/dev/skills/engineering/afk/MCP.md");
+    const toolNames = Array.from(
+      mcpDoc.matchAll(/^\| `([a-z][a-z_]*)` \| (?:read|mutating) \|/gm),
+      (match) => match[1] as string,
+    );
+    expect(toolNames.length).toBeGreaterThan(0);
+
+    for (const path of CENSUS) {
+      const text = await readRepoFile(path);
+      if (!text.includes("red-skills-dev monitor")) continue;
+      const named = toolNames.filter((tool) => text.includes(`\`${tool}\``));
+      expect(named, `${path} should name a castle tool from MCP.md verbatim`).not.toEqual([]);
+    }
+  });
+
+  it("points the fleet launch banner at the castle monitor tool first", () => {
+    const suggestion = fleetMonitorSuggestion("default");
+
+    expect(suggestion).toContain("`monitor`");
+    expect(suggestion).toContain("`worker_vitals`");
+    expect(suggestion.indexOf("monitor` tool")).toBeLessThan(suggestion.indexOf("/dev:afk monitor"));
+    expect(suggestion).toContain(NO_MCP_LABEL);
+  });
+
+  it("makes the Codex monitor agent poll the castle monitor tool first", () => {
+    const prompt = renderCodexMonitorAgentPrompt({ projectRoot: "/repo", mode: "fleet" });
+
+    expect(prompt).toContain("castle `monitor` tool");
+    expect(prompt).toContain("`worker_vitals`");
+    expect(prompt.indexOf("castle `monitor` tool")).toBeLessThan(
+      prompt.indexOf("red-skills-dev monitor --once"),
+    );
+    expect(prompt).toContain(NO_MCP_LABEL);
+  });
+});

--- a/apps/opencode-host/src/statusline.ts
+++ b/apps/opencode-host/src/statusline.ts
@@ -159,7 +159,7 @@ export const AFKStatusline: Plugin = async (ctx) => {
       const block = [
         "## AFK live state",
         s,
-        "If the user resumes this session, /afk monitor is the source of truth for current worker state — re-run it before acting on any compaction summary.",
+        "If the user resumes this session, the castle \`monitor\` tool is the source of truth for current worker state (\`worker_vitals\` for liveness) — re-read it before acting on any compaction summary; without the MCP, /afk monitor is the fallback.",
         "",
       ].join("\\n");
       output.context.push(block);

--- a/packaging/pi/dev/skills/engineering/afk/TROUBLESHOOTING.md
+++ b/packaging/pi/dev/skills/engineering/afk/TROUBLESHOOTING.md
@@ -11,7 +11,9 @@ not empty.
 
 ### Confirm
 
-1. Run the read-only queue view: `red-skills-dev monitor --once`.
+1. Read the queue with the castle `queue_status` tool, and the live workers with
+   `monitor` — both are read tools, free to call. No-MCP fallback:
+   `red-skills-dev monitor --once`.
 2. Compare `ready-for-agent` with open non-Spec issues in the issue tracker.
 3. Census the gates by label family: `blocked:dependency`, `needs-triage`,
    `ready-for-human`, `type:spec`, and any unsupported `blocked:*` label.

--- a/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
@@ -98,8 +98,9 @@ resolved tiers as documented by the model-tier policy.
 
 Every spawn appends a route line to the Worker log and stamps
 `current.model_tier`, `current.model`, and `current.effort` in the Worker state.
-`red-skills-dev monitor` renders the active tier as `tier:<name>` on the Worker
-row, alongside the existing vitals.
+The castle `monitor` and `worker_vitals` tools carry the active tier as a field;
+the no-MCP fallback `red-skills-dev monitor` renders it as `tier:<name>` on the
+Worker row, alongside the existing vitals.
 
 ```yaml
 plugins:

--- a/packaging/pi/dev/skills/engineering/afk/fleet.md
+++ b/packaging/pi/dev/skills/engineering/afk/fleet.md
@@ -45,8 +45,8 @@ $ /dev:afk fleet 1   # every worker sees both vars
 
 Fleet mode is **runner-portable**: the supervisor is plain process orchestration, not a Claude Code primitive. Claude Code, Codex, and bare terminals may all launch and stop the supervisor when the normal AFK hard preconditions pass. Runner-specific observability degrades independently:
 
-- Claude Code: launch fleet. For manual monitoring, run `/dev:afk monitor` or tail `.red/tmp/supervisors/default/supervisor.log.toonl`.
-- Codex: launch fleet with `RED_AFK_RUNNER=codex` and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl manually.`
+- Claude Code: launch fleet. For manual monitoring, read the castle `monitor` and `fleet_status` tools; without the MCP, run `/dev:afk monitor` or tail `.red/tmp/supervisors/default/supervisor.log.toonl`.
+- Codex: launch fleet with `RED_AFK_RUNNER=codex` and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print the monitor status line below.
 - Bare terminal / unknown runner: launch fleet and print the manual-monitor guidance.
 
 **Self-heal is not a monitor side effect.** Every successful fleet launch also
@@ -95,8 +95,8 @@ not part of the current fleet contract.
    ```
    The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/supervisors/default/afk-supervisor.pid` to appear and contain a live pinned PID, then arms the repo-scoped self-heal watchdog and prints both PIDs plus the target. Failure to arm either process fails the launch; supervisor failure reports the tail of `.red/tmp/supervisors/default/supervisor.log.toonl`. Capture the reported supervisor PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
 4. **Attach the best available monitor surface.**
-   - Claude Code: no automatic monitor cron. Tell the user to run `/dev:afk monitor` manually or tail `.red/tmp/supervisors/default/supervisor.log.toonl`.
-   - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query: `spawn agent background monitor`). If available, emit the canonical prompt with `RED_AFK_RUNNER=codex red-skills-dev codex-monitor-agent --project-root "$PWD" --mode fleet` and spawn exactly one read-only Codex monitor agent for this newly-launched supervisor. Its task: from the project root, periodically run `/dev:afk monitor --once` (the bundle's `monitor --once`), report concise progress, and auto-close when `.red/tmp/supervisors/default/afk-supervisor.pid` is missing/dead and no `[live]` workers remain. It must never edit files, claim issues, stop workers, or run merges. The user may close it manually; workers continue. If the primitive is unavailable, skip and use the manual-monitor line.
+   - Claude Code: no automatic monitor cron. Tell the user to read the castle `monitor` tool (with `worker_vitals` for liveness), or — without the MCP — to run `/dev:afk monitor` manually or tail `.red/tmp/supervisors/default/supervisor.log.toonl`.
+   - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query: `spawn agent background monitor`). If available, emit the canonical prompt with `RED_AFK_RUNNER=codex red-skills-dev codex-monitor-agent --project-root "$PWD" --mode fleet` and spawn exactly one read-only Codex monitor agent for this newly-launched supervisor. Its task: periodically read the castle `monitor` tool (falling back to `monitor --once` from the project root when the MCP is unreachable), report concise progress, and auto-close when `.red/tmp/supervisors/default/afk-supervisor.pid` is missing/dead and no `[live]` workers remain. It must never edit files, claim issues, stop workers, or run merges. The user may close it manually; workers continue. If the primitive is unavailable, skip and use the manual-monitor line.
    - Bare/unknown: skip native monitor setup and use the manual-monitor line.
 5. **Report back.** Print:
    ```
@@ -107,10 +107,9 @@ not part of the current fleet contract.
       <monitor-status-line>
    ```
    Monitor status line choices:
-   - Claude Code: `monitor: run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl`
-   - Codex monitor agent spawned: `Codex monitor agent spawned — auto-closes when fleet exits; manual monitor: /dev:afk monitor.`
-   - Codex monitor unavailable: `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl manually.`
-   - Bare/unknown: `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl manually.`
+   The line is the same one `fleetMonitorSuggestion()` prints from the bundle — MCP tool first, CLI labelled as the fallback:
+   - Claude Code / Codex monitor unavailable / bare/unknown: `monitor: call the castle monitor tool (and worker_vitals for liveness); no-MCP fallback: run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl manually.`
+   - Codex monitor agent spawned: `Codex monitor agent spawned — auto-closes when fleet exits; manual monitor: the castle monitor tool, or /dev:afk monitor without the MCP.`
 
 ### `/dev:afk fleet stop [--force]` — graceful shutdown or scoped hard teardown
 

--- a/packaging/pi/dev/skills/engineering/afk/monitor.md
+++ b/packaging/pi/dev/skills/engineering/afk/monitor.md
@@ -31,7 +31,7 @@ non-empty open backlog is a flow bug to diagnose, never a clean stop.
 
 ## Dashboard
 
-`/afk monitor` is the readonly aggregated view across all live workers. **Run the bundle's `monitor` command — do not reinvent the rendering in inline bash.** It:
+`/afk monitor` is the readonly aggregated view across all live workers. **Call the castle `monitor` tool for the data, and pair it with `worker_vitals` when liveness is the question — do not reinvent the rendering in inline bash.** The bundle's `monitor` command renders the same truth for a human terminal and is the no-MCP fallback. Either way it:
 
 1. Globs `.red/tmp/workers/*/*/afk.state.json` and renders one section per active attempt.
 2. Verifies liveness via the orchestrator PID recorded in `afk.state.json` (`.pid` field), paired with `pid_start_time` when the platform exposes a stable process-start token. Attempts whose PID identity is dead or mismatched are flagged `stale`/`gone`; PID-live but agent-lane-quiet workers render `[quiet]` and are still counted as running.
@@ -39,7 +39,7 @@ non-empty open backlog is a flow bug to diagnose, never a clean stop.
 4. Renders WorkerVitals activity counters (`tools:<n> reason:<n> text:<n> wait:<n>`) so a quiet but pid-live worker can show useful progress signals.
 5. Renders the 48h sparkline header (next subsection) on every refresh.
 
-To invoke, from the project root:
+The **no-MCP fallback** renders the same dashboard from the project root — for a headless cron or a host that never loaded the `castle` server:
 
 ```bash
 RED_AFK_RUNNER=<runner> npx -y -p @reddb-io/red-skills@<version> red-skills-dev monitor
@@ -124,7 +124,7 @@ The mirror is a pure diff: it reconciles the live worker state files against the
 
 1. Fetch `TaskCreate`, `TaskUpdate`, and `TaskList` via `ToolSearch` if not already loaded (deferred tools).
 2. **Build the tracked set.** `TaskList` → keep the mirror-owned tasks (those whose title matches `w<id> [<…>] #<n> <slug>`). For each, emit one JSONL line `{"key":"<worker_id>:<issue>","stage":"<last stage>","phase":"<last phase>"}`, reading the key (`worker_id` from the leading token, `issue` from the `#<n>`) and the **phase** (the word inside the title's `[…]` bracket, after any `n/5 `) from the title, and the **stage** from the description (`stage: <x>`). Keep a key→task_id map for step 4.
-3. **Compute the plan.** Pipe the tracked JSONL from step 2 into the bundle's `monitor --mirror-plan` subcommand:
+3. **Compute the plan.** The mirror reconciler is host-plumbing, not castle truth, so it has **no castle tool** — this is a standing no-MCP fallback, not a lapse. Pipe the tracked JSONL from step 2 into the bundle's `monitor --mirror-plan` subcommand:
    ```bash
    printf '%s\n' "$tracked" | red-skills-dev monitor --mirror-plan
    ```
@@ -166,7 +166,7 @@ supervisor under Codex:
 1. Fetch a sub-agent spawn primitive via `ToolSearch` (query:
    `spawn agent background monitor`).
 2. If unavailable, continue the worker launch and print:
-   `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/workers/*/*/afk.log manually.`
+   `monitor loop unavailable in this runner; call the castle monitor tool (and worker_vitals for liveness); no-MCP fallback: run /dev:afk monitor or tail .red/tmp/workers/*/*/afk.log manually.`
 3. If available, emit the canonical prompt from the bundle (use `--mode run` for a
    single worker, `--mode fleet` for a supervisor, so the read-only rules stay
    identical across launches):
@@ -174,11 +174,12 @@ supervisor under Codex:
    RED_AFK_RUNNER=codex npx -y -p @reddb-io/red-skills@<version> red-skills-dev codex-monitor-agent --project-root "$PWD" --mode run
    ```
    Spawn exactly one monitor agent with that prompt. The monitor agent is a
-   presentation consumer only: it periodically runs `/dev:afk monitor --once`,
-   reports concise progress in the Codex UI, and exits once no supervisor or
-   live workers remain.
+   presentation consumer only: it periodically reads the castle `monitor` tool
+   (with `worker_vitals` for liveness), reports concise progress in the Codex
+   UI, and exits once no supervisor or live workers remain. Its prompt carries
+   the `/dev:afk monitor --once` CLI form as the no-MCP fallback.
 4. Tell the user one line:
-   `Codex monitor agent spawned — auto-closes when AFK exits; manual monitor: /dev:afk monitor.`
+   `Codex monitor agent spawned — auto-closes when AFK exits; manual monitor: the castle monitor tool, or /dev:afk monitor without the MCP.`
 
 Hard boundaries for the monitor agent are non-negotiable: it must never edit
 files, claim issues, change labels, comment, stop workers, run validation, push,

--- a/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -128,7 +128,7 @@ The script writes `${XDG_BIN_HOME:-$HOME/.local/bin}/red-skills-dev` and `${XDG_
 - prefers the active CLI plugin-root env var when the host exposes one;
 - otherwise finds the latest installed dev plugin under `~/.codex/plugins/cache/red-skills/dev/*` or `~/.claude/plugins/cache/red-skills/dev/*`;
 - falls back to the latest warmed dev bundle under `~/.cache/red-skills/bundles/`;
-- forwards all arguments to the dev runtime, so skills can say `red-skills-dev go ...`, `red-skills-dev dashboard`, or `RED_AFK_RUNNER=codex red-skills-dev monitor --once`;
+- forwards all arguments to the dev runtime, so skills reach the same cores the castle `monitor`, `dashboard`, and `worker_dispatch` tools drive — as the no-MCP fallback, e.g. `red-skills-dev go ...`, `red-skills-dev dashboard`, or `RED_AFK_RUNNER=codex red-skills-dev monitor --once`;
 - stores no secrets and does not replace the `.red/config.yaml` opt-in gate.
 
 The `rsp` shim uses the same local-first shape: active plugin-root env var, installed host plugin cache, then the warmed rsp bundle under `${RED_SKILLS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/red-skills/bundles}`. It never runs npm, installs a global package, or performs network resolution during session startup.

--- a/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -30,7 +30,8 @@ Install or inspect the RedSkills statusline for this repository. The shared prod
 
   The **`/afk monitor` dashboard keeps its fuller per-worker row** (title, `[live]`/`[quiet]`, `wait`, `log`) — it is a full dashboard, not a compact statusline — but its vitals tokens are the same `tls`/`rsn`/`txt` vocabulary as the statusline.
 
-  For an on-demand decode table, run `red-skills-dev statusline --legend` or `red-skills-dev monitor --legend`. The legend prints `token / name / gloss` rows and exits without rendering the live statusline or monitor surface.
+  The same per-worker fields arrive as structured data from the castle `statusline_aggregate` and `worker_vitals` tools, so an agent decodes the tokens by reading the fields instead of the legend.
+  For an on-demand human decode table — the no-MCP fallback — run `red-skills-dev statusline --legend` or `red-skills-dev monitor --legend`. The legend prints `token / name / gloss` rows and exits without rendering the live statusline or monitor surface.
 - **Codex — single line.** The `tui.status_line` footer is single-line only, so the plain producer stays ONE aggregate line (project · model · context · usage · repo counts · the AFK block). The multi-line layout is Claude-Code-only.
 
 The AFK rows are quiet when no worker is active. Hosts that cannot run a command-backed statusline still get a useful native footer plus `/afk monitor` for live AFK visibility.

--- a/plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md
+++ b/plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md
@@ -11,7 +11,9 @@ not empty.
 
 ### Confirm
 
-1. Run the read-only queue view: `red-skills-dev monitor --once`.
+1. Read the queue with the castle `queue_status` tool, and the live workers with
+   `monitor` — both are read tools, free to call. No-MCP fallback:
+   `red-skills-dev monitor --once`.
 2. Compare `ready-for-agent` with open non-Spec issues in the issue tracker.
 3. Census the gates by label family: `blocked:dependency`, `needs-triage`,
    `ready-for-human`, `type:spec`, and any unsupported `blocked:*` label.

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -98,8 +98,9 @@ resolved tiers as documented by the model-tier policy.
 
 Every spawn appends a route line to the Worker log and stamps
 `current.model_tier`, `current.model`, and `current.effort` in the Worker state.
-`red-skills-dev monitor` renders the active tier as `tier:<name>` on the Worker
-row, alongside the existing vitals.
+The castle `monitor` and `worker_vitals` tools carry the active tier as a field;
+the no-MCP fallback `red-skills-dev monitor` renders it as `tier:<name>` on the
+Worker row, alongside the existing vitals.
 
 ```yaml
 plugins:

--- a/plugins/dev/skills/engineering/afk/fleet.md
+++ b/plugins/dev/skills/engineering/afk/fleet.md
@@ -45,8 +45,8 @@ $ /dev:afk fleet 1   # every worker sees both vars
 
 Fleet mode is **runner-portable**: the supervisor is plain process orchestration, not a Claude Code primitive. Claude Code, Codex, and bare terminals may all launch and stop the supervisor when the normal AFK hard preconditions pass. Runner-specific observability degrades independently:
 
-- Claude Code: launch fleet. For manual monitoring, run `/dev:afk monitor` or tail `.red/tmp/supervisors/default/supervisor.log.toonl`.
-- Codex: launch fleet with `RED_AFK_RUNNER=codex` and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl manually.`
+- Claude Code: launch fleet. For manual monitoring, read the castle `monitor` and `fleet_status` tools; without the MCP, run `/dev:afk monitor` or tail `.red/tmp/supervisors/default/supervisor.log.toonl`.
+- Codex: launch fleet with `RED_AFK_RUNNER=codex` and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print the monitor status line below.
 - Bare terminal / unknown runner: launch fleet and print the manual-monitor guidance.
 
 **Self-heal is not a monitor side effect.** Every successful fleet launch also
@@ -95,8 +95,8 @@ not part of the current fleet contract.
    ```
    The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/supervisors/default/afk-supervisor.pid` to appear and contain a live pinned PID, then arms the repo-scoped self-heal watchdog and prints both PIDs plus the target. Failure to arm either process fails the launch; supervisor failure reports the tail of `.red/tmp/supervisors/default/supervisor.log.toonl`. Capture the reported supervisor PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
 4. **Attach the best available monitor surface.**
-   - Claude Code: no automatic monitor cron. Tell the user to run `/dev:afk monitor` manually or tail `.red/tmp/supervisors/default/supervisor.log.toonl`.
-   - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query: `spawn agent background monitor`). If available, emit the canonical prompt with `RED_AFK_RUNNER=codex red-skills-dev codex-monitor-agent --project-root "$PWD" --mode fleet` and spawn exactly one read-only Codex monitor agent for this newly-launched supervisor. Its task: from the project root, periodically run `/dev:afk monitor --once` (the bundle's `monitor --once`), report concise progress, and auto-close when `.red/tmp/supervisors/default/afk-supervisor.pid` is missing/dead and no `[live]` workers remain. It must never edit files, claim issues, stop workers, or run merges. The user may close it manually; workers continue. If the primitive is unavailable, skip and use the manual-monitor line.
+   - Claude Code: no automatic monitor cron. Tell the user to read the castle `monitor` tool (with `worker_vitals` for liveness), or — without the MCP — to run `/dev:afk monitor` manually or tail `.red/tmp/supervisors/default/supervisor.log.toonl`.
+   - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query: `spawn agent background monitor`). If available, emit the canonical prompt with `RED_AFK_RUNNER=codex red-skills-dev codex-monitor-agent --project-root "$PWD" --mode fleet` and spawn exactly one read-only Codex monitor agent for this newly-launched supervisor. Its task: periodically read the castle `monitor` tool (falling back to `monitor --once` from the project root when the MCP is unreachable), report concise progress, and auto-close when `.red/tmp/supervisors/default/afk-supervisor.pid` is missing/dead and no `[live]` workers remain. It must never edit files, claim issues, stop workers, or run merges. The user may close it manually; workers continue. If the primitive is unavailable, skip and use the manual-monitor line.
    - Bare/unknown: skip native monitor setup and use the manual-monitor line.
 5. **Report back.** Print:
    ```
@@ -107,10 +107,9 @@ not part of the current fleet contract.
       <monitor-status-line>
    ```
    Monitor status line choices:
-   - Claude Code: `monitor: run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl`
-   - Codex monitor agent spawned: `Codex monitor agent spawned — auto-closes when fleet exits; manual monitor: /dev:afk monitor.`
-   - Codex monitor unavailable: `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl manually.`
-   - Bare/unknown: `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl manually.`
+   The line is the same one `fleetMonitorSuggestion()` prints from the bundle — MCP tool first, CLI labelled as the fallback:
+   - Claude Code / Codex monitor unavailable / bare/unknown: `monitor: call the castle monitor tool (and worker_vitals for liveness); no-MCP fallback: run /dev:afk monitor or tail .red/tmp/supervisors/default/supervisor.log.toonl manually.`
+   - Codex monitor agent spawned: `Codex monitor agent spawned — auto-closes when fleet exits; manual monitor: the castle monitor tool, or /dev:afk monitor without the MCP.`
 
 ### `/dev:afk fleet stop [--force]` — graceful shutdown or scoped hard teardown
 

--- a/plugins/dev/skills/engineering/afk/monitor.md
+++ b/plugins/dev/skills/engineering/afk/monitor.md
@@ -31,7 +31,7 @@ non-empty open backlog is a flow bug to diagnose, never a clean stop.
 
 ## Dashboard
 
-`/afk monitor` is the readonly aggregated view across all live workers. **Run the bundle's `monitor` command — do not reinvent the rendering in inline bash.** It:
+`/afk monitor` is the readonly aggregated view across all live workers. **Call the castle `monitor` tool for the data, and pair it with `worker_vitals` when liveness is the question — do not reinvent the rendering in inline bash.** The bundle's `monitor` command renders the same truth for a human terminal and is the no-MCP fallback. Either way it:
 
 1. Globs `.red/tmp/workers/*/*/afk.state.json` and renders one section per active attempt.
 2. Verifies liveness via the orchestrator PID recorded in `afk.state.json` (`.pid` field), paired with `pid_start_time` when the platform exposes a stable process-start token. Attempts whose PID identity is dead or mismatched are flagged `stale`/`gone`; PID-live but agent-lane-quiet workers render `[quiet]` and are still counted as running.
@@ -39,7 +39,7 @@ non-empty open backlog is a flow bug to diagnose, never a clean stop.
 4. Renders WorkerVitals activity counters (`tools:<n> reason:<n> text:<n> wait:<n>`) so a quiet but pid-live worker can show useful progress signals.
 5. Renders the 48h sparkline header (next subsection) on every refresh.
 
-To invoke, from the project root:
+The **no-MCP fallback** renders the same dashboard from the project root — for a headless cron or a host that never loaded the `castle` server:
 
 ```bash
 RED_AFK_RUNNER=<runner> npx -y -p @reddb-io/red-skills@<version> red-skills-dev monitor
@@ -124,7 +124,7 @@ The mirror is a pure diff: it reconciles the live worker state files against the
 
 1. Fetch `TaskCreate`, `TaskUpdate`, and `TaskList` via `ToolSearch` if not already loaded (deferred tools).
 2. **Build the tracked set.** `TaskList` → keep the mirror-owned tasks (those whose title matches `w<id> [<…>] #<n> <slug>`). For each, emit one JSONL line `{"key":"<worker_id>:<issue>","stage":"<last stage>","phase":"<last phase>"}`, reading the key (`worker_id` from the leading token, `issue` from the `#<n>`) and the **phase** (the word inside the title's `[…]` bracket, after any `n/5 `) from the title, and the **stage** from the description (`stage: <x>`). Keep a key→task_id map for step 4.
-3. **Compute the plan.** Pipe the tracked JSONL from step 2 into the bundle's `monitor --mirror-plan` subcommand:
+3. **Compute the plan.** The mirror reconciler is host-plumbing, not castle truth, so it has **no castle tool** — this is a standing no-MCP fallback, not a lapse. Pipe the tracked JSONL from step 2 into the bundle's `monitor --mirror-plan` subcommand:
    ```bash
    printf '%s\n' "$tracked" | red-skills-dev monitor --mirror-plan
    ```
@@ -166,7 +166,7 @@ supervisor under Codex:
 1. Fetch a sub-agent spawn primitive via `ToolSearch` (query:
    `spawn agent background monitor`).
 2. If unavailable, continue the worker launch and print:
-   `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/workers/*/*/afk.log manually.`
+   `monitor loop unavailable in this runner; call the castle monitor tool (and worker_vitals for liveness); no-MCP fallback: run /dev:afk monitor or tail .red/tmp/workers/*/*/afk.log manually.`
 3. If available, emit the canonical prompt from the bundle (use `--mode run` for a
    single worker, `--mode fleet` for a supervisor, so the read-only rules stay
    identical across launches):
@@ -174,11 +174,12 @@ supervisor under Codex:
    RED_AFK_RUNNER=codex npx -y -p @reddb-io/red-skills@<version> red-skills-dev codex-monitor-agent --project-root "$PWD" --mode run
    ```
    Spawn exactly one monitor agent with that prompt. The monitor agent is a
-   presentation consumer only: it periodically runs `/dev:afk monitor --once`,
-   reports concise progress in the Codex UI, and exits once no supervisor or
-   live workers remain.
+   presentation consumer only: it periodically reads the castle `monitor` tool
+   (with `worker_vitals` for liveness), reports concise progress in the Codex
+   UI, and exits once no supervisor or live workers remain. Its prompt carries
+   the `/dev:afk monitor --once` CLI form as the no-MCP fallback.
 4. Tell the user one line:
-   `Codex monitor agent spawned — auto-closes when AFK exits; manual monitor: /dev:afk monitor.`
+   `Codex monitor agent spawned — auto-closes when AFK exits; manual monitor: the castle monitor tool, or /dev:afk monitor without the MCP.`
 
 Hard boundaries for the monitor agent are non-negotiable: it must never edit
 files, claim issues, change labels, comment, stop workers, run validation, push,

--- a/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -128,7 +128,7 @@ The script writes `${XDG_BIN_HOME:-$HOME/.local/bin}/red-skills-dev` and `${XDG_
 - prefers the active CLI plugin-root env var when the host exposes one;
 - otherwise finds the latest installed dev plugin under `~/.codex/plugins/cache/red-skills/dev/*` or `~/.claude/plugins/cache/red-skills/dev/*`;
 - falls back to the latest warmed dev bundle under `~/.cache/red-skills/bundles/`;
-- forwards all arguments to the dev runtime, so skills can say `red-skills-dev go ...`, `red-skills-dev dashboard`, or `RED_AFK_RUNNER=codex red-skills-dev monitor --once`;
+- forwards all arguments to the dev runtime, so skills reach the same cores the castle `monitor`, `dashboard`, and `worker_dispatch` tools drive — as the no-MCP fallback, e.g. `red-skills-dev go ...`, `red-skills-dev dashboard`, or `RED_AFK_RUNNER=codex red-skills-dev monitor --once`;
 - stores no secrets and does not replace the `.red/config.yaml` opt-in gate.
 
 The `rsp` shim uses the same local-first shape: active plugin-root env var, installed host plugin cache, then the warmed rsp bundle under `${RED_SKILLS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/red-skills/bundles}`. It never runs npm, installs a global package, or performs network resolution during session startup.

--- a/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -30,7 +30,8 @@ Install or inspect the RedSkills statusline for this repository. The shared prod
 
   The **`/afk monitor` dashboard keeps its fuller per-worker row** (title, `[live]`/`[quiet]`, `wait`, `log`) — it is a full dashboard, not a compact statusline — but its vitals tokens are the same `tls`/`rsn`/`txt` vocabulary as the statusline.
 
-  For an on-demand decode table, run `red-skills-dev statusline --legend` or `red-skills-dev monitor --legend`. The legend prints `token / name / gloss` rows and exits without rendering the live statusline or monitor surface.
+  The same per-worker fields arrive as structured data from the castle `statusline_aggregate` and `worker_vitals` tools, so an agent decodes the tokens by reading the fields instead of the legend.
+  For an on-demand human decode table — the no-MCP fallback — run `red-skills-dev statusline --legend` or `red-skills-dev monitor --legend`. The legend prints `token / name / gloss` rows and exits without rendering the live statusline or monitor surface.
 - **Codex — single line.** The `tui.status_line` footer is single-line only, so the plain producer stays ONE aggregate line (project · model · context · usage · repo counts · the AFK block). The multi-line layout is Claude-Code-only.
 
 The AFK rows are quiet when no worker is active. Hosts that cannot run a command-backed statusline still get a useful native footer plus `/afk monitor` for live AFK visibility.


### PR DESCRIPTION
Automated AFK landing for #2668. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2668

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787485131&installation_model_id=20659&pr_number=2675&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2675&signature=b6184bb50a9c873b7694959a201f531d9aa335f4fc867f62e0bb93542ea1bcce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->