### PR TITLE
pin the claude AFK runner to claude-opus-5 on every tier

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -9,6 +9,16 @@ plugins:
       primary-branch: true       # primary-checkout branch-switch guard
     afk:
       models:
+        # Maintainer decision 2026-07-28: the claude runner is pinned to Opus 5
+        # on EVERY tier — validate included — so the local fleet never falls back
+        # to the 4.x defaults (`claude-haiku-4-5` / `claude-sonnet-4-6` /
+        # `claude-opus-4-8`). `base` is the per-runner one-liner (ADR 0049): it
+        # auto-populates all four tiers, and each tier keeps its own default
+        # effort (validate low, simple high, complex medium, think high). Pin a
+        # single tier back by giving it its own `<tier>.model`.
+        claude:
+          base:
+            model: claude-opus-5
         # GPT-5.6 (released 2026-07-09) for coding tiers; `validate` — the
         # fuzzy-validation / contract-review tier — deliberately stays on 5.5.
         # `gpt-5.6-sol` is the flagship of the sol/terra/luna family and is


### PR DESCRIPTION
Maintainer decision 2026-07-28: the local fleet's claude runner should never fall back to the 4.x tier defaults.

Uses the ADR 0049 per-runner `base` shortcut, so all four tiers resolve to `claude-opus-5` while each keeps its own default effort.

Verified through the real resolver (`loadConfig` + `resolveTier`):

```
claude  validate  claude-opus-5 low
claude  simple    claude-opus-5 high
claude  complex   claude-opus-5 medium
claude  think     claude-opus-5 high
codex   simple    gpt-5.6-sol   high   (untouched)
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787812235&installation_model_id=20659&pr_number=2676&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2676&signature=0a540d859d5f06b8e432187b889e7a53a5b97eaabe67a3b1e25e2520a8ef9a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->