### PR TITLE
chore: #2661 state-transition CONTRACT 1/3: one label vocabulary — kill the QUARANTINE and companion-io duplicates

### DIFF
--- a/apps/dev/src/core/state-transition.ts
+++ b/apps/dev/src/core/state-transition.ts
@@ -1,5 +1,5 @@
 // state-transition.ts — the single owner of issue state-label mutations
-// (ADR 0122 rule 5, Spec #2523, slice #2524 — the EXPAND half).
+// (ADR 0122 rule 5, Spec #2523, slices #2524 + #2661).
 //
 // An issue carries exactly ONE state role at any time. On 2026-07-22 three
 // issues accumulated contradictory role sets (park labels stacked on
@@ -10,9 +10,8 @@
 // set, refuses any request that would leave zero or two state roles, and the
 // apply step performs the whole mutation as ONE tracker call.
 //
-// This slice lands the API alongside the existing writers, fully tested and
-// deliberately uncalled. Call-site migration + the raw-edit lint is the
-// CONTRACT half (#2528).
+// All state-role label constants live in triage-labels.ts — import from there,
+// never redefine inline. The raw-edit lint (#2528) enforces this at CI time.
 
 import {
   LABEL_READY,
@@ -21,11 +20,8 @@ import {
   LABEL_NEEDS_INFO,
   LABEL_RUNNING,
   LABEL_DEPENDENCY,
+  LABEL_QUARANTINE,
 } from "./triage-labels.js";
-
-/** The quarantine state role (ADR 0122 rule 2). Kept local until the curator
- * slice's vocabulary lands; #2528 unifies the constant into triage-labels. */
-export const LABEL_QUARANTINE = "quarantine";
 
 /** Every label that counts as a STATE ROLE. The invariant this module
  * enforces: a post-transition label set contains exactly one of these. */

--- a/apps/dev/src/runtime/companion-io.ts
+++ b/apps/dev/src/runtime/companion-io.ts
@@ -38,13 +38,12 @@ import {
   type CompanionPlan,
 } from "../core/companion.js";
 import { getConfig, type ConfigValues } from "../core/config.js";
+import { LABEL_READY, LABEL_HUMAN } from "../core/triage-labels.js";
 import type { AfkState } from "../types/state.js";
 
 /** The issue-body section the correction directive lands in — the next attempt's
  * brief. Kept stable so a re-correction REPLACES the section rather than stacking. */
 export const COMPANION_BRIEF_HEADING = AGENT_BRIEF_HEADING;
-export const LABEL_READY_FOR_AGENT = "ready-for-agent";
-export const LABEL_READY_FOR_HUMAN = "ready-for-human";
 
 /** Fallback drift cap if the reason were ever absent from the recovery table
  * (it is registered there with this same default — belt and suspenders). */
@@ -250,7 +249,7 @@ export async function runCompanionPass(options: CompanionPassOptions): Promise<C
     if (plan.kind === "correct") {
       await ghx.editBody(options.ctx, id.issue, applyCorrectionBody(view.body, plan.note, plan.signal));
       await ghx.comment(options.ctx, id.issue, auditComment(plan, id.issue, id.attempt));
-      await ghx.editLabels(options.ctx, id.issue, [], has(LABEL_READY_FOR_AGENT) ? [] : [LABEL_READY_FOR_AGENT]);
+      await ghx.editLabels(options.ctx, id.issue, [], has(LABEL_READY) ? [] : [LABEL_READY]);
       outcomes.push({ issue: id.issue, attempt: id.attempt, disposition: "corrected", signal: plan.signal });
     } else {
       await ghx.editBody(options.ctx, id.issue, applyEscalationBody(view.body, plan.signal, plan.reason));
@@ -258,8 +257,8 @@ export async function runCompanionPass(options: CompanionPassOptions): Promise<C
       await ghx.editLabels(
         options.ctx,
         id.issue,
-        has(LABEL_READY_FOR_AGENT) ? [LABEL_READY_FOR_AGENT] : [],
-        has(LABEL_READY_FOR_HUMAN) ? [] : [LABEL_READY_FOR_HUMAN],
+        has(LABEL_READY) ? [LABEL_READY] : [],
+        has(LABEL_HUMAN) ? [] : [LABEL_HUMAN],
       );
       outcomes.push({ issue: id.issue, attempt: id.attempt, disposition: "escalated", signal: plan.signal });
     }

--- a/apps/dev/tests/state-transition-contract.test.ts
+++ b/apps/dev/tests/state-transition-contract.test.ts
@@ -76,6 +76,15 @@ const ALLOWLIST = new Map<string, string>([
     "core/review.ts :: await gh.editLabels(pr, [LABEL_RUNNING], [LABEL_VALIDATION, LABEL_HUMAN]);",
     "PR review-lane labels, not issue state",
   ],
+  // --- companion drift correction: exposed once the local label copies died (#2661) ---
+  [
+    "runtime/companion-io.ts :: await ghx.editLabels(options.ctx, id.issue, [], has(LABEL_READY) ? [] : [LABEL_READY]);",
+    "migrated to planTransition in #2663",
+  ],
+  [
+    "runtime/companion-io.ts :: await ghx.editLabels( options.ctx, id.issue, has(LABEL_READY) ? [LABEL_READY] : [], has(LABEL_HUMAN) ? [] : [LABEL_HUMAN], );",
+    "migrated to planTransition in #2663",
+  ],
   // --- human/manual command surfaces (outside the engine contract by design) ---
   [
     "commands/requeue.ts :: await gh.editLabels(input.issue, [LABEL_READY], []);",

--- a/apps/dev/tests/state-transition.test.ts
+++ b/apps/dev/tests/state-transition.test.ts
@@ -4,9 +4,9 @@ import {
   isRefused,
   planTransition,
   stateRolesOf,
-  LABEL_QUARANTINE,
   type TransitionPlan,
 } from "../src/core/state-transition.js";
+import { LABEL_QUARANTINE } from "../src/core/triage-labels.js";
 
 function plan(current: readonly string[], t: Parameters<typeof planTransition>[1]): TransitionPlan {
   const p = planTransition(current, t);


### PR DESCRIPTION
Automated AFK landing for #2661. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2661

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787827739&installation_model_id=20659&pr_number=2680&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2680&signature=692b95865d25b10b0738d8189289f3b928022bc02809b8343336e3278a7a2fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->