### PR TITLE
chore: #2665 Cross core/reconcile.ts to the castle engine (Option A: portify effectful imports first) — maintainer session

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -33,6 +33,7 @@ import {
 import { parseClaimRecords, renderClaimComment, type RawClaimComment } from "../core/claim.js";
 import { LABEL_READY } from "../core/triage-labels.js";
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
+import { HOST_RECONCILE_PORTS } from "../core/reconcile-ports.js";
 import {
   REQUEUE_ORIGIN,
   withAdoptPresence,
@@ -401,6 +402,7 @@ async function runAdoptLanding(
     } catch { /* best-effort */ }
 
     const reconcileDeps: ReconcileDeps = {
+      ...HOST_RECONCILE_PORTS,
       gh: {
         editLabels: async (n, remove, add) => {
           return editLabelsWithStatuslineCache(

--- a/apps/dev/src/commands/run/reconcile.ts
+++ b/apps/dev/src/commands/run/reconcile.ts
@@ -1,5 +1,6 @@
 import type { ReconcileBootRunner } from "../../core/boot.js";
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../../core/reconcile.js";
+import { HOST_RECONCILE_PORTS } from "../../core/reconcile-ports.js";
 import { resolveBase } from "../../core/base-resolver.js";
 import { findOwnedBranch, type ReconcileSweepPlan } from "../../core/boot-sweep.js";
 import {
@@ -181,6 +182,7 @@ export function makeBootReconcileRunner(
       return { outcome: "skipped" as const };
     }
     const reconcileDeps: ReconcileDeps = {
+      ...HOST_RECONCILE_PORTS,
       gh: {
         editLabels: async (issue, remove, add) => {
           await ghx.editLabels(ghCtx, issue, remove, add);

--- a/apps/dev/src/core/reconcile-ports.ts
+++ b/apps/dev/src/core/reconcile-ports.ts
@@ -1,0 +1,53 @@
+// reconcile-ports — the ONE place the host's real implementations are bound to
+// reconcile's injected ports.
+//
+// `core/reconcile.ts` value-imports nothing effectful: landing, the feedback
+// gate, the envelope emitter, the remote-branch push/delete pair, and the
+// triage-label vocabulary all arrive through `ReconcileDeps`. This module is the
+// host adapter that supplies them, so every construction site
+// (`commands/run/reconcile.ts`, `commands/requeue.ts`) spreads ONE constant
+// instead of re-wiring the same five members. When reconcile crosses into the
+// castle engine, this file is the only edge that follows the move.
+
+import { doLanding } from "./landing.js";
+import {
+  buildValidationRecord,
+  formatValidationLine,
+  isInfraFeedbackFailure,
+  relevantScopes,
+  runFeedback,
+} from "./feedback.js";
+import { emitEnvelope } from "./envelope-emit.js";
+import { deleteRemote, pushAttempt } from "./remote-branch.js";
+import { DEFAULT_TRIAGE_LABELS } from "./triage-labels.js";
+import type {
+  ReconcileEnvelopeEmitPort,
+  ReconcileFeedbackPort,
+  ReconcileLandingPort,
+  ReconcileRemoteBranchPort,
+} from "./reconcile.js";
+import type { TriageLabelConfig } from "./triage-labels.js";
+
+/** The five injected members every real (non-test) reconcile shares. */
+export interface HostReconcilePorts {
+  landing: ReconcileLandingPort;
+  feedback: ReconcileFeedbackPort;
+  envelopeEmit: ReconcileEnvelopeEmitPort;
+  remoteBranch: ReconcileRemoteBranchPort;
+  labels: TriageLabelConfig;
+}
+
+/** This host's real wiring — spread into every `ReconcileDeps` literal. */
+export const HOST_RECONCILE_PORTS: HostReconcilePorts = {
+  landing: { doLanding },
+  feedback: {
+    runFeedback,
+    relevantScopes,
+    isInfraFeedbackFailure,
+    buildValidationRecord,
+    formatValidationLine,
+  },
+  envelopeEmit: { emitEnvelope },
+  remoteBranch: { pushAttempt, deleteRemote },
+  labels: DEFAULT_TRIAGE_LABELS,
+};

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -21,30 +21,38 @@
 //   4b. red       → ready-for-human with the REAL failing checks (blocked:validation).
 //
 // PURE SEQUENCING over injected IO: every git/gh/pnpm/fs touch is a port, so the
-// whole decision tree is unit-testable with zero subprocesses. `ReconcileDeps`
-// is a structural SUBSET of `ProcessIssueDeps`, so process-issue's terminal path
-// passes its own `deps` (plus the landing `fireHook`) straight through.
+// whole decision tree is unit-testable with zero subprocesses. Since #2665 the
+// EFFECTFUL COLLABORATORS are ports too (landing, the feedback gate, the
+// envelope emitter, the remote-branch pair, and the label vocabulary), so the
+// module's only runtime imports are pure companions. The nested member shapes
+// still mirror `ProcessIssueDeps`, and the two real construction sites
+// (`commands/run/reconcile.ts`, `commands/requeue.ts`) spread ONE host wiring
+// constant, `HOST_RECONCILE_PORTS` (core/reconcile-ports.ts).
 
-import {
+// PORTIFIED IMPORTS: every EFFECTFUL collaborator below is imported `type`-only
+// and injected through {@link ReconcileDeps}. The value-imports that used to sit
+// here (`doLanding`, `runFeedback` + its four helpers, `emitEnvelope`,
+// `pushAttempt`/`deleteRemote`, and the `LABEL_*` constants) are gone, so this
+// module carries no runtime edge into the host — the precondition for crossing
+// it into the castle engine. The remaining value-imports are PURE companions
+// that cross WITH reconcile (`blocker-state`, `boot-sweep` planners,
+// `disposition`).
+import type {
   buildValidationRecord,
   formatValidationLine,
   relevantScopes,
   runFeedback,
   isInfraFeedbackFailure,
-  type Exec as PnpmExec,
-  type FeedbackCheck,
-  type PackageLayout,
-  type RunFeedbackResult,
+  Exec as PnpmExec,
+  FeedbackCheck,
+  PackageLayout,
+  RunFeedbackResult,
 } from "./feedback.js";
-import { doLanding, type LandingPostMergeValidation } from "./landing.js";
+import type { doLanding, LandingPostMergeValidation } from "./landing.js";
 import { type CiAwaitInput, type ConflictResolver, type Exec as MergeExec, type WaitForReviewInput } from "./merge.js";
-import {
-  deleteRemote,
-  pushAttempt,
-  type GitExec,
-} from "./remote-branch.js";
+import type { deleteRemote, pushAttempt, GitExec } from "./remote-branch.js";
 import { type LandLock } from "./land-lock.js";
-import { emitEnvelope, type EmitEnvelopeDeps } from "./envelope-emit.js";
+import type { emitEnvelope, EmitEnvelopeDeps } from "./envelope-emit.js";
 import { parseCurrentBlocker } from "./blocker-state.js";
 import { cascadeAuditCommentFor, parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
 import { type RecoveryEnv } from "./recovery.js";
@@ -52,18 +60,7 @@ import { dispose } from "./disposition.js";
 import type { AttemptStatus } from "./envelope.js";
 import type { HistoryClock } from "./history.js";
 import type { Runner } from "../types/runner.js";
-
-import {
-  LABEL_READY,
-  LABEL_RUNNING,
-  LABEL_HUMAN,
-  LABEL_VALIDATION,
-  LABEL_DEPENDENCY,
-  LABEL_POLICY,
-  LABEL_INFRA,
-  LABEL_MERGE_CONFLICT,
-  LABEL_SPEC,
-} from "./triage-labels.js";
+import type { TriageLabelConfig } from "./triage-labels.js";
 
 /**
  * The blocked-failure classes reconcile is allowed to act on: MECHANICAL ones
@@ -81,7 +78,9 @@ const MECHANICAL_BLOCKER_KINDS = new Set(["stalled", "crashed", "merge-conflict"
  * must resolve, `blocked:dependency` is a dependency wait, and policy/infra
  * blocks need operator action outside the worker branch.
  */
-const NON_MECHANICAL_LABELS = [LABEL_SPEC, LABEL_VALIDATION, LABEL_DEPENDENCY, LABEL_POLICY, LABEL_INFRA];
+function nonMechanicalLabels(labels: TriageLabelConfig): string[] {
+  return [labels.spec, labels.validation, labels.dependency, labels.policy, labels.infra];
+}
 
 // ---------- injected IO ----------
 
@@ -130,6 +129,43 @@ export interface ReconcileLookups {
   isLocked(): Promise<boolean>;
 }
 
+/** The landing port: the host's `doLanding`, injected instead of imported. */
+export interface ReconcileLandingPort {
+  doLanding: typeof doLanding;
+}
+
+/** The feedback-gate port: `runFeedback` plus the four helpers reconcile reads
+ * around it (scope resolution, the infra-root classifier, and the two
+ * validation-record formatters used by the post-merge sidecar line). */
+export interface ReconcileFeedbackPort {
+  runFeedback: typeof runFeedback;
+  relevantScopes: typeof relevantScopes;
+  isInfraFeedbackFailure: typeof isInfraFeedbackFailure;
+  buildValidationRecord: typeof buildValidationRecord;
+  formatValidationLine: typeof formatValidationLine;
+}
+
+/**
+ * The envelope-emitter port. Named `envelopeEmit`, NOT `envelope`, because
+ * {@link ReconcileDeps.envelope} already names the emitter's injected IO
+ * (poster / marker writer / posted writer / git) — the function and the IO it
+ * consumes are two different ports and both are needed.
+ */
+export interface ReconcileEnvelopeEmitPort {
+  emitEnvelope: typeof emitEnvelope;
+}
+
+/**
+ * The remote-branch port. Named `remoteBranch`, NOT `remoteGit`, because
+ * {@link ReconcileDeps.remoteGit} already names the `GitExec` these two
+ * functions (and `doLanding`) execute through — portifying the functions does
+ * not remove the executor reconcile must still thread into the landing deps.
+ */
+export interface ReconcileRemoteBranchPort {
+  pushAttempt: typeof pushAttempt;
+  deleteRemote: typeof deleteRemote;
+}
+
 function remoteTrackingBaseRef(remote: string, base: string): string {
   if (/^[0-9a-f]{7,40}$/i.test(base) || base.startsWith("refs/") || base.startsWith(`${remote}/`)) {
     return base;
@@ -148,6 +184,16 @@ export interface ReconcileDeps {
   git: ReconcileGit;
   fs: ReconcileFs;
   lookups: ReconcileLookups;
+  /** The landing implementation (`core/landing.ts` on this host). */
+  landing: ReconcileLandingPort;
+  /** The feedback gate + its four helpers (`core/feedback.ts` on this host). */
+  feedback: ReconcileFeedbackPort;
+  /** The envelope emitter (`core/envelope-emit.ts` on this host). */
+  envelopeEmit: ReconcileEnvelopeEmitPort;
+  /** The remote-branch push/delete pair (`core/remote-branch.ts` on this host). */
+  remoteBranch: ReconcileRemoteBranchPort;
+  /** The triage-label vocabulary, injected as config (castle convention). */
+  labels: TriageLabelConfig;
   /** git executor for merge.ts (integrateOrigin / landMerge / landPr). */
   mergeExec: MergeExec;
   /** git executor for remote-branch.ts (pushAttempt / deleteRemote). */
@@ -305,7 +351,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   const baseRef = remoteTrackingBaseRef(input.remote, base);
 
   // ---- 1. guard: mechanical class only ----
-  const disqualifier = mechanicalDisqualifier(labels, body);
+  const disqualifier = mechanicalDisqualifier(labels, body, deps.labels);
   if (disqualifier) {
     deps.appendIterLog(
       `🤖 /afk reconcile #${issue}: skipped (${disqualifier}) — not a mechanical reconcile candidate; leaving routing to the caller.`,
@@ -322,7 +368,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   // committed work is preserved — a dirty worktree is never salvage-committed
   // here. Best-effort: a failed push is logged and reconcile falls through to the
   // normal fetch gate (which then skips with "branch-absent" / "no-commits").
-  const safetyPush = await pushAttempt(deps.remoteGit, input.repoDir, branch, branch);
+  const safetyPush = await deps.remoteBranch.pushAttempt(deps.remoteGit, input.repoDir, branch, branch);
   if (!safetyPush.ok) {
     deps.appendIterLog(
       `🤖 /afk reconcile #${issue}: pre-fetch push failed (${safetyPush.warn ?? "unknown"}) — continuing to fetch gate`,
@@ -395,9 +441,9 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     // comparison probe can classify a branch failure that also reproduces on
     // the base as `inconclusive` rather than the branch's fault (#2380).
     // Mirrors the DONE path.
-    feedback = await runFeedback(deps.pnpm, {
+    feedback = await deps.feedback.runFeedback(deps.pnpm, {
       worktree: branch,
-      scopes: relevantScopes(deps.layout, changedFiles),
+      scopes: deps.feedback.relevantScopes(deps.layout, changedFiles),
       layout: deps.layout,
       now: deps.nowEpoch,
       baselineWorktree: input.base,
@@ -410,7 +456,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     // and the recovery policy should retry it (bounded, default cap 2). Skip
     // the park-to-human path; let `routeRecovery` re-queue or escalate the
     // same way the DONE path does, so the green branch isn't stranded.
-    if (!feedback.ok && isInfraFeedbackFailure(feedback)) {
+    if (!feedback.ok && deps.feedback.isInfraFeedbackFailure(feedback)) {
       return await parkInfraRetry(deps, input, feedback, startedEpoch);
     }
     if (!feedback.ok) {
@@ -437,7 +483,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   const openPr = deps.worktreeLaunchesPr !== false;
   // Presence stage (#1306): the adopt-landing lane's row now shows `landing`.
   await deps.markStage?.("landing").catch(() => {});
-  const landing = await doLanding(
+  const landing = await deps.landing.doLanding(
     {
       mergeExec: deps.mergeExec,
       remoteGit: deps.remoteGit,
@@ -454,9 +500,9 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
       makeRebaseWorktree: deps.makeRebaseWorktree,
       removeRebaseWorktree: deps.removeRebaseWorktree,
       postMergeGate: async (mergedTreeDir) => {
-        const mergedFeedback = await runFeedback(deps.pnpm, {
+        const mergedFeedback = await deps.feedback.runFeedback(deps.pnpm, {
           worktree: mergedTreeDir,
-          scopes: relevantScopes(deps.layout, changedFiles),
+          scopes: deps.feedback.relevantScopes(deps.layout, changedFiles),
           layout: deps.layout,
           now: deps.nowEpoch,
           baselineWorktree: input.base,
@@ -507,7 +553,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   if (landing.postMergeValidation) {
     feedback = {
       ...feedback,
-      sidecar: [...feedback.sidecar, postMergeValidationSidecarLine(landing.postMergeValidation)],
+      sidecar: [...feedback.sidecar, postMergeValidationSidecarLine(deps, landing.postMergeValidation)],
     };
     await writeValidationSidecar(deps, input.attemptDir, feedback.sidecar);
   }
@@ -520,8 +566,8 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   const durationS = deps.nowEpoch() - startedEpoch;
   const posted = await emitDone(deps, input, mergeSha, durationS, feedback.sidecar);
   await deps.gh.close(issue);
-  await deps.gh.editLabels(issue, landDropLabels(labels), []);
-  await deleteRemote(deps.remoteGit, input.repoDir, branch);
+  await deps.gh.editLabels(issue, landDropLabels(labels, deps.labels), []);
+  await deps.remoteBranch.deleteRemote(deps.remoteGit, input.repoDir, branch);
   await deps.git.deleteLocalBranch(branch);
   await deps.fs.completionSweep(issue);
   await runCloseCascade(deps, issue);
@@ -556,8 +602,13 @@ async function resolveFreshRemoteBranchTip(
  * crashed blocker is mechanical and therefore allowed — it is exactly the parked
  * state reconcile exists to clear.
  */
-export function mechanicalDisqualifier(labels: string[], body: string): "not-mechanical" | "active-blocker" | null {
-  if (labels.some((l) => NON_MECHANICAL_LABELS.includes(l))) return "not-mechanical";
+export function mechanicalDisqualifier(
+  labels: string[],
+  body: string,
+  config: TriageLabelConfig,
+): "not-mechanical" | "active-blocker" | null {
+  const nonMechanical = nonMechanicalLabels(config);
+  if (labels.some((l) => nonMechanical.includes(l))) return "not-mechanical";
   const blocker = parseCurrentBlocker(body);
   if (blocker && !MECHANICAL_BLOCKER_KINDS.has(blocker.kind)) return "active-blocker";
   return null;
@@ -565,9 +616,13 @@ export function mechanicalDisqualifier(labels: string[], body: string): "not-mec
 
 /** Routing/blocked labels to shed on a successful land — domain labels (type:,
  * priority:, slice:, req:) are left untouched. */
-function landDropLabels(labels: string[]): string[] {
+function landDropLabels(labels: string[], config: TriageLabelConfig): string[] {
   return labels.filter(
-    (l) => l === LABEL_RUNNING || l === LABEL_HUMAN || l === LABEL_READY || l.startsWith("blocked:"),
+    (l) =>
+      l === config.running ||
+      l === config.human ||
+      l === config.ready ||
+      l.startsWith(config.blockedPrefix),
   );
 }
 
@@ -593,7 +648,7 @@ async function park(
   const disp = dispose("feedback-failed", input.attempt, deps.recoveryEnv ?? {});
   const typed = disp.typedLabel!;
   await deps.gh.ensureLabel(typed);
-  await deps.gh.editLabels(issue, parkDropLabels(labels), [LABEL_HUMAN, typed]);
+  await deps.gh.editLabels(issue, parkDropLabels(labels, deps.labels), [deps.labels.human, typed]);
   await deps.gh.comment(
     issue,
     `🤖 /afk reconcile validated parked branch \`${input.branch}\` WITHOUT re-running the agent — validation FAILED, so it was not landed:\n${formatFailingChecks(failed)}`,
@@ -639,7 +694,7 @@ async function parkInfraRetry(
     // misleading) `blocked:validation-infra` from a prior attempt, add
     // `ready-for-agent` so the issue resurfaces. The branch is left on the
     // remote (no deleteRemote) — the next attempt can re-validate it.
-    const infraLabels = labels.filter((l) => l !== typed && l !== LABEL_READY);
+    const infraLabels = labels.filter((l) => l !== typed && l !== deps.labels.ready);
     await deps.gh.editLabels(issue, infraLabels, disp.addLabels);
     await deps.gh.comment(
       issue,
@@ -657,7 +712,7 @@ async function parkInfraRetry(
   // Cap exhausted → escalate to ready-for-human (page a maintainer). The
   // infra flake is sticky; the issue needs a human to look at the gate setup.
   await deps.gh.ensureLabel(typed);
-  await deps.gh.editLabels(issue, parkDropLabels(labels), disp.addLabels);
+  await deps.gh.editLabels(issue, parkDropLabels(labels, deps.labels), disp.addLabels);
   await deps.gh.comment(
     issue,
     `🤖 /afk reconcile #${issue}: feedback gate INFRA failure retry budget exhausted (attempt ${input.attempt}/${cap}) on \`${input.branch}\` — escalating to ready-for-human:\n${failedSummary}`,
@@ -681,9 +736,9 @@ async function parkInfraLanding(
 ): Promise<ReconcileResult> {
   const { issue, labels } = input;
   const disp = dispose("infra", input.attempt, deps.recoveryEnv ?? {});
-  const typed = disp.typedLabel ?? LABEL_INFRA;
+  const typed = disp.typedLabel ?? deps.labels.infra;
   await deps.gh.ensureLabel(typed);
-  await deps.gh.editLabels(issue, parkDropLabels(labels), [LABEL_HUMAN, typed]);
+  await deps.gh.editLabels(issue, parkDropLabels(labels, deps.labels), [deps.labels.human, typed]);
   const posted = await emitFailure(deps, input, disp.envelopeStatus, startedEpoch, {
     log: `reconcile land infra failure: ${reason}`,
   });
@@ -709,7 +764,7 @@ async function parkMergeConflict(
   const disp = dispose("merge-conflict", input.attempt, deps.recoveryEnv ?? {});
   const typed = disp.typedLabel!;
   await deps.gh.ensureLabel(typed);
-  await deps.gh.editLabels(issue, parkDropLabels(labels), [LABEL_HUMAN, typed]);
+  await deps.gh.editLabels(issue, parkDropLabels(labels, deps.labels), [deps.labels.human, typed]);
   const posted = await emitFailure(deps, input, disp.envelopeStatus, startedEpoch, {
     log: `reconcile land failed: ${reason}`,
   });
@@ -722,12 +777,12 @@ async function parkMergeConflict(
 /** Routing/blocked labels to shed when parking — keeps `blocked:validation`
  * (re-added below) and domain labels; drops `running`/`ready-for-agent` + the
  * mechanical blocked reasons that no longer describe the state. */
-function parkDropLabels(labels: string[]): string[] {
+function parkDropLabels(labels: string[], config: TriageLabelConfig): string[] {
   return labels.filter(
     (l) =>
-      l === LABEL_RUNNING ||
-      l === LABEL_READY ||
-      (l.startsWith("blocked:") && l !== LABEL_VALIDATION && l !== LABEL_MERGE_CONFLICT),
+      l === config.running ||
+      l === config.ready ||
+      (l.startsWith(config.blockedPrefix) && l !== config.validation && l !== config.mergeConflict),
   );
 }
 
@@ -745,7 +800,7 @@ async function emitDone(
   durationS: number,
   validationSidecar: string[],
 ): Promise<boolean> {
-  const result = await emitEnvelope(deps.envelope, {
+  const result = await deps.envelopeEmit.emitEnvelope(deps.envelope, {
     status: "done",
     issue: input.issue,
     worker: input.workerId,
@@ -769,7 +824,7 @@ async function emitFailure(
   startedEpoch: number,
   sections: { validation?: string; log?: string },
 ): Promise<boolean> {
-  const result = await emitEnvelope(deps.envelope, {
+  const result = await deps.envelopeEmit.emitEnvelope(deps.envelope, {
     status,
     issue: input.issue,
     worker: input.workerId,
@@ -801,8 +856,8 @@ async function writeValidationSidecar(deps: ReconcileDeps, attemptDir: string, l
   }
 }
 
-function postMergeValidationSidecarLine(validation: LandingPostMergeValidation): string {
-  return formatValidationLine(buildValidationRecord({
+function postMergeValidationSidecarLine(deps: ReconcileDeps, validation: LandingPostMergeValidation): string {
+  return deps.feedback.formatValidationLine(deps.feedback.buildValidationRecord({
     name: `post-merge:${validation.path}`,
     status: "passed",
     summary: validation.reason,
@@ -841,7 +896,7 @@ async function runCloseCascade(deps: ReconcileDeps, closedIssue: number): Promis
     }
 
     for (const p of planCloseCascade(closedIssue, dependents)) {
-      await deps.gh.editLabels(p.number, [LABEL_DEPENDENCY, ...p.reqLabels], [LABEL_READY]);
+      await deps.gh.editLabels(p.number, [deps.labels.dependency, ...p.reqLabels], [deps.labels.ready]);
       const reqs = p.refs.map((ref) => Number(ref.slice(1))).filter((n) => Number.isFinite(n));
       await deps.gh.comment(p.number, await cascadeAuditCommentFor(reqs, deps.gh.issueReference));
     }

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -154,3 +154,51 @@ export const EXTERNAL_APPROVAL_MARKER = "/approve-external";
 
 // Auxiliary labels
 export const LABEL_RUNNER_ERROR = "runner-error";
+
+/**
+ * The label vocabulary an engine module reads as INJECTED CONFIG rather than as
+ * a value-import of this host module — the castle port convention
+ * (`CastleSelectionLabels` in red-castle's `engine/worker-drain.ts`). A module
+ * that crosses into the engine cannot import host constants, so it declares the
+ * slice of the vocabulary it needs and the host wires
+ * {@link DEFAULT_TRIAGE_LABELS} at its construction site.
+ */
+export interface TriageLabelConfig {
+  /** `ready-for-agent` — the executable-queue routing label. */
+  ready: string;
+  /** `running` — the observability projection of an active claim. */
+  running: string;
+  /** `ready-for-human` — the HITL park routing label. */
+  human: string;
+  /** `blocked:validation` — a gate failure a human must resolve. */
+  validation: string;
+  /** `blocked:dependency` — a `req:*` dependency wait. */
+  dependency: string;
+  /** `blocked:policy` — an operator-action policy block. */
+  policy: string;
+  /** `blocked:infra` — an operator-action infrastructure block. */
+  infra: string;
+  /** `blocked:merge-conflict` — a land-time conflict park. */
+  mergeConflict: string;
+  /** `blocked:spec` — the human-decision boundary the ADR calls out. */
+  spec: string;
+  /** `blocked:` — the prefix every blocked-reason label shares. */
+  blockedPrefix: string;
+  /** `req:` — the prefix of a dependency edge label (`req:{issue}`). */
+  reqPrefix: string;
+}
+
+/** This host's real vocabulary, wired into every engine construction site. */
+export const DEFAULT_TRIAGE_LABELS: TriageLabelConfig = {
+  ready: LABEL_READY,
+  running: LABEL_RUNNING,
+  human: LABEL_HUMAN,
+  validation: LABEL_VALIDATION,
+  dependency: LABEL_DEPENDENCY,
+  policy: LABEL_POLICY,
+  infra: LABEL_INFRA,
+  mergeConflict: LABEL_MERGE_CONFLICT,
+  spec: LABEL_SPEC,
+  blockedPrefix: "blocked:",
+  reqPrefix: "req:",
+};

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -5,6 +5,11 @@ import {
   type ReconcileDeps,
   type ReconcileInput,
 } from "../src/core/reconcile.js";
+// The effectful collaborators are now injected (#2665). The harness wires the
+// REAL host implementations, so every assertion below still exercises the same
+// doLanding / runFeedback / emitEnvelope / push-delete code over the fake execs.
+import { HOST_RECONCILE_PORTS } from "../src/core/reconcile-ports.js";
+import { DEFAULT_TRIAGE_LABELS } from "../src/core/triage-labels.js";
 import { upsertCurrentBlocker } from "../src/core/blocker-state.js";
 
 // Everything injected is a fake — no real gh / git / pnpm / fs ever runs. The
@@ -83,6 +88,7 @@ function harness(opts: HarnessOptions = {}): {
   };
 
   const deps: ReconcileDeps = {
+    ...HOST_RECONCILE_PORTS,
     gh: {
       async editLabels(issue, remove, add) {
         trace.labelEdits.push({ issue, remove, add });
@@ -564,17 +570,17 @@ describe("reconcile — guards (mechanical class only)", () => {
 
 describe("mechanicalDisqualifier", () => {
   it("returns null for a clean mechanical state", () => {
-    expect(mechanicalDisqualifier(["running"], "## body")).toBeNull();
-    expect(mechanicalDisqualifier(["ready-for-human", "blocked:stalled"], "## body")).toBeNull();
-    expect(mechanicalDisqualifier(["ready-for-human", "blocked:crashed"], "## body")).toBeNull();
+    expect(mechanicalDisqualifier(["running"], "## body", DEFAULT_TRIAGE_LABELS)).toBeNull();
+    expect(mechanicalDisqualifier(["ready-for-human", "blocked:stalled"], "## body", DEFAULT_TRIAGE_LABELS)).toBeNull();
+    expect(mechanicalDisqualifier(["ready-for-human", "blocked:crashed"], "## body", DEFAULT_TRIAGE_LABELS)).toBeNull();
   });
 
   it("flags human-decision blocked labels", () => {
-    expect(mechanicalDisqualifier(["blocked:spec"], "x")).toBe("not-mechanical");
-    expect(mechanicalDisqualifier(["blocked:validation"], "x")).toBe("not-mechanical");
-    expect(mechanicalDisqualifier(["blocked:dependency"], "x")).toBe("not-mechanical");
-    expect(mechanicalDisqualifier(["blocked:policy"], "x")).toBe("not-mechanical");
-    expect(mechanicalDisqualifier(["blocked:infra"], "x")).toBe("not-mechanical");
+    expect(mechanicalDisqualifier(["blocked:spec"], "x", DEFAULT_TRIAGE_LABELS)).toBe("not-mechanical");
+    expect(mechanicalDisqualifier(["blocked:validation"], "x", DEFAULT_TRIAGE_LABELS)).toBe("not-mechanical");
+    expect(mechanicalDisqualifier(["blocked:dependency"], "x", DEFAULT_TRIAGE_LABELS)).toBe("not-mechanical");
+    expect(mechanicalDisqualifier(["blocked:policy"], "x", DEFAULT_TRIAGE_LABELS)).toBe("not-mechanical");
+    expect(mechanicalDisqualifier(["blocked:infra"], "x", DEFAULT_TRIAGE_LABELS)).toBe("not-mechanical");
   });
 
   it("flags an active non-mechanical Current blocker", () => {
@@ -584,7 +590,7 @@ describe("mechanicalDisqualifier", () => {
       summary: "Tests fail and need a call.",
       next: "Human decides scope.",
     });
-    expect(mechanicalDisqualifier(["blocked:stalled"], body)).toBe("active-blocker");
+    expect(mechanicalDisqualifier(["blocked:stalled"], body, DEFAULT_TRIAGE_LABELS)).toBe("active-blocker");
   });
 });
 

--- a/apps/dev/tests/state-transition-contract.test.ts
+++ b/apps/dev/tests/state-transition-contract.test.ts
@@ -20,11 +20,16 @@ import { describe, expect, it } from "vitest";
 
 const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
 
-/** State-role vocabulary (constants and literals) that marks an edit as a
- * STATE mutation. `running`/`contested`/typed `blocked:*` reasons alone are
- * projections or modifiers, not state roles. */
+/** State-role vocabulary (constants, literals, and injected-config accessors)
+ * that marks an edit as a STATE mutation. `running`/`contested`/typed
+ * `blocked:*` reasons alone are projections or modifiers, not state roles.
+ *
+ * The `<config>.ready` / `.human` / `.dependency` accessors keep PORTIFIED
+ * engine code covered (#2665): a module that reads its label vocabulary from an
+ * injected `TriageLabelConfig` instead of value-importing `LABEL_*` would
+ * otherwise fall out of this scan entirely and take its call sites with it. */
 const STATE_ROLE_PATTERN =
-  /LABEL_READY\b|LABEL_HUMAN\b|LABEL_QUARANTINE\b|LABEL_TRIAGE\b|LABEL_NEEDS_INFO\b|LABEL_DEPENDENCY\b|"ready-for-agent"|"ready-for-human"|"needs-triage"|"needs-info"|"quarantine"|"blocked:dependency"/;
+  /LABEL_READY\b|LABEL_HUMAN\b|LABEL_QUARANTINE\b|LABEL_TRIAGE\b|LABEL_NEEDS_INFO\b|LABEL_DEPENDENCY\b|\blabels\.(ready|human|quarantine|needsTriage|needsInfo|dependency)\b|"ready-for-agent"|"ready-for-human"|"needs-triage"|"needs-info"|"quarantine"|"blocked:dependency"/;
 
 /**
  * Surviving raw call sites, keyed `relative-path :: normalized-statement`.
@@ -60,11 +65,11 @@ const ALLOWLIST = new Map<string, string>([
   ],
   // --- ADR 0055 reconcile lane: deliberate typed parks over pre-read labels ---
   [
-    "core/reconcile.ts :: await deps.gh.editLabels(issue, parkDropLabels(labels), [LABEL_HUMAN, typed]);",
+    "core/reconcile.ts :: await deps.gh.editLabels(issue, parkDropLabels(labels, deps.labels), [deps.labels.human, typed]);",
     "reconcile typed park; parkDropLabels collapses stale state first",
   ],
   [
-    "core/reconcile.ts :: await deps.gh.editLabels(p.number, [LABEL_DEPENDENCY, ...p.reqLabels], [LABEL_READY]);",
+    "core/reconcile.ts :: await deps.gh.editLabels(p.number, [deps.labels.dependency, ...p.reqLabels], [deps.labels.ready]);",
     "reconcile-lane cascade mirror; migration tracked by ADR 0122 rule 7",
   ],
   // --- non-issue surfaces: PR review-lane labels, not issue state ---

--- a/apps/dev/tests/tsconfig-import-hygiene.test.ts
+++ b/apps/dev/tests/tsconfig-import-hygiene.test.ts
@@ -19,10 +19,8 @@ const DEV_UNUSED_IMPORT_DEBT: Record<string, number> = {
   "src/commands/requeue.ts": 1,
   "src/commands/retake.ts": 1,
   "src/commands/route-model-tier.ts": 1,
-  "src/commands/run/command.ts": 1,
   "src/commands/run/process-deps.ts": 1,
   "src/commands/statusline.ts": 1,
-  "src/commands/stop.ts": 5,
   "src/core/dashboard.ts": 1,
   "src/core/process-issue/lifecycle.ts": 61,
   "src/core/process-issue/recovery.ts": 92,
@@ -126,6 +124,13 @@ async function unusedImportDebt(): Promise<Record<string, number>> {
 
     const visit = (node: ts.Node): void => {
       if (ts.isImportDeclaration(node) || ts.isImportEqualsDeclaration(node)) return;
+      // A shorthand property (`{ doLanding }`) resolves to the PROPERTY symbol,
+      // not to the imported binding it reads — counting only `getSymbolAtLocation`
+      // would report a port-wiring module's every import as unused debt (#2665).
+      if (ts.isShorthandPropertyAssignment(node)) {
+        const shorthand = checker.getShorthandAssignmentValueSymbol(node);
+        if (shorthand) referenced.add(shorthand);
+      }
       if (ts.isIdentifier(node)) {
         const symbol = checker.getSymbolAtLocation(node);
         if (symbol) referenced.add(symbol);


### PR DESCRIPTION
Automated AFK landing for #2665. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2665

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787828738&installation_model_id=20659&pr_number=2681&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2681&signature=e1465593f6aa87d4599370e45ac43d004c1053db61cd95d57cdbd0b0d6fa7bf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->