### PR TITLE
fix: #2677 MCP fleet_create spawns slots against the castle-mcp bundle, which cannot route `run` — every slot dies, zero drainage

### DIFF
--- a/.changeset/mcp-fleet-slot-worker-entry.md
+++ b/.changeset/mcp-fleet-slot-worker-entry.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+MCP-launched fleets drain again (#2677): the supervisor no longer infers the slot's worker entry from `process.argv[1]`. Under the ADR 0120 MCP lane the supervisor is itself the castle-mcp bundle, whose entry does not route `run`, so every slot booted a second resident/stdio host, lost the singleton lease and died — `deaths == respawns`, `slots_busy=0`, zero drainage. `spawnSlot`/`spawnReconcileWorker` now resolve the sibling dev bundle (the entry that routes `run`), and the castle-mcp entry refuses an unroutable subcommand by name instead of silently falling through to the resident path.

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -35,6 +35,7 @@ import {
 } from "../runtime/wire.js";
 import { formatPreconditionFailure, runBoot, type BootResult, type BootstrapInput } from "../core/boot.js";
 import { inspectProcessTreeNative } from "../runtime/proc-tree.js";
+import { resolveDevScriptPath } from "../runtime/supervisor-spawn.js";
 import {
   workerLivenessFor,
   slotLogDir,
@@ -511,7 +512,7 @@ export function buildSupervisorBootSweeps(
  * (mirroring SLOT_PIDS[$slot] in bash, which is how find_slot_iter_dir /
  * agentLaneMtime / inspectTree all reach the running worker tree).
  */
-function buildSupervisorDeps(
+export function buildSupervisorDeps(
   root: string,
   tmpDir: string,
   slotLogsDir: string,
@@ -527,7 +528,11 @@ function buildSupervisorDeps(
   hookEnvBase: Record<string, string>,
   adoptSlotPids: readonly HeartbeatSlotPid[] = [],
 ): SupervisorDeps {
-  const bundle = process.argv[1];
+  // Slots run `run --once`, which ONLY the dev entry routes. Never infer the
+  // worker entry from argv[1]: under the MCP lane this supervisor is itself the
+  // castle-mcp bundle, whose entry does not route `run`, so every slot booted a
+  // second resident, lost the singleton lease and died on the spot (#2677).
+  const bundle = resolveDevScriptPath(process.argv[1] ?? "");
   const bundleVersion = readBuildInfo("dev").version;
   const now = () => Math.floor(Date.now() / 1000);
   // The lane lives INSIDE the fleet's runtime dir (`supervisors/<fleet>/s<pid>/`)

--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -279,6 +279,21 @@ export async function main(
     );
     return 0;
   }
+  // Any OTHER leading token is a role this bundle does not own — `run`,
+  // `--once`, `monitor`, … all belong to the dev entry. Falling through would
+  // open a SECOND resident/stdio host that contends on the singleton leases and
+  // dies with an opaque lease error, which is exactly how MCP-launched slots
+  // burned as `deaths == respawns` forever (#2677). Fail with a named error
+  // instead, so the misrouted spawn is legible in the slot log.
+  const leading = argv[0];
+  if (leading !== undefined) {
+    process.stderr.write(
+      `castle MCP: unroutable subcommand ${JSON.stringify(leading)} — ` +
+        "the castle-mcp bundle routes only `__supervise` and `--version`; " +
+        "worker subcommands belong to the dev entry (red-skills-dev)\n",
+    );
+    return 2;
+  }
   await dependencies.startCurator();
   await dependencies.startMergeDriver();
   await dependencies.connect();

--- a/apps/dev/tests/mcp-server-routing.test.ts
+++ b/apps/dev/tests/mcp-server-routing.test.ts
@@ -22,6 +22,29 @@ describe("dev:afk MCP entrypoint routing", () => {
     expect(startCurator).not.toHaveBeenCalled();
   });
 
+  // #2677: a slot spawned against this bundle used to fall through to the
+  // resident path, contend on the singleton leases and die with an opaque
+  // "singleton lease pid" error — deaths == respawns, zero drainage.
+  it.each([["run"], ["run", "--once"], ["--once"], ["monitor"]])(
+    "refuses the worker subcommand %s by name instead of opening a second resident",
+    async (...argv: string[]) => {
+      const connect = vi.fn(async () => undefined);
+      const startCurator = vi.fn(async () => undefined);
+      const startMergeDriver = vi.fn(async () => undefined);
+      const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+      await expect(
+        main(argv, { supervise: async () => 0, connect, startCurator, startMergeDriver }),
+      ).resolves.toBe(2);
+
+      expect(connect).not.toHaveBeenCalled();
+      expect(startCurator).not.toHaveBeenCalled();
+      expect(startMergeDriver).not.toHaveBeenCalled();
+      expect(stderr.mock.calls[0]![0]).toContain(`unroutable subcommand ${JSON.stringify(argv[0])}`);
+      stderr.mockRestore();
+    },
+  );
+
   it("starts the issue curator in the castle resident before opening stdio", async () => {
     const calls: string[] = [];
 

--- a/apps/dev/tests/supervise-slot-entry.test.ts
+++ b/apps/dev/tests/supervise-slot-entry.test.ts
@@ -1,0 +1,147 @@
+// Slot spawn argv — the worker entry must never be inferred from argv[1]
+// (#2677). Under the MCP lane the supervisor IS the castle-mcp bundle, whose
+// entry does not route `run`; spawning slots against it made every slot die on
+// a singleton-lease error and the fleet drain nothing.
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import type { SpawnOptions } from "node:child_process";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawn = vi.hoisted(() =>
+  vi.fn((_command: string, _args: readonly string[], _options: SpawnOptions) => ({
+    on: vi.fn(),
+    unref: vi.fn(),
+    pid: 4242,
+  })),
+);
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn,
+}));
+
+import { buildSupervisorDeps } from "../src/commands/supervise.js";
+import { parseCli } from "../src/cli.js";
+import { main as mcpMain } from "../src/mcp-server.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  spawn.mockClear();
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function root(): Promise<string> {
+  const value = await mkdtemp(join(tmpdir(), "supervise-slot-entry-"));
+  roots.push(value);
+  await mkdir(join(value, ".red", "tmp", "slot-logs"), { recursive: true });
+  return value;
+}
+
+async function deps(cwd: string) {
+  return buildSupervisorDeps(
+    cwd,
+    join(cwd, ".red", "tmp"),
+    join(cwd, ".red", "tmp", "slot-logs"),
+    join(cwd, ".red", "tmp", "firehose.toonl"),
+    join(cwd, ".red", "tmp", "state.toon"),
+    "s1234",
+    "default",
+    "claude",
+    300,
+    { cwd, repo: "reddb-io/red-skills" },
+    "main",
+    [],
+    {},
+  );
+}
+
+/** argv[1] shapes a supervisor can be re-exec'd under. */
+const MCP_BUNDLE = "/opt/red/dist/castle-mcp.bundle.min.mjs";
+const VERSIONED_MCP_BUNDLE = "/opt/red/dist/castle-mcp-2.90.0.bundle.min.mjs";
+
+describe("spawnSlot worker entry (#2677)", () => {
+  it("spawns the dev bundle — not the castle-mcp bundle — when the supervisor is the MCP entry", async () => {
+    const cwd = await root();
+    vi.spyOn(process, "argv", "get").mockReturnValue([process.execPath, MCP_BUNDLE, "__supervise"]);
+
+    const { proc } = await deps(cwd);
+    await proc.spawnSlot(0, undefined);
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const args = spawn.mock.calls[0]![1] as readonly string[];
+    expect(basename(args[0]!)).toBe("dev.bundle.min.mjs");
+    expect(args).not.toContain(MCP_BUNDLE);
+    expect(args.slice(1, 3)).toEqual(["run", "--once"]);
+  });
+
+  it("resolves the versioned dev sibling for a versioned castle-mcp bundle", async () => {
+    const cwd = await root();
+    vi.spyOn(process, "argv", "get").mockReturnValue([
+      process.execPath,
+      VERSIONED_MCP_BUNDLE,
+      "__supervise",
+    ]);
+
+    const { proc } = await deps(cwd);
+    await proc.spawnSlot(0, undefined);
+
+    expect(basename((spawn.mock.calls[0]![1] as readonly string[])[0]!)).toBe(
+      "dev-2.90.0.bundle.min.mjs",
+    );
+  });
+
+  it("leaves the CLI lane untouched — a dev bundle argv[1] is spawned unchanged", async () => {
+    const cwd = await root();
+    const devBundle = "/opt/red/dist/dev.bundle.min.mjs";
+    vi.spyOn(process, "argv", "get").mockReturnValue([process.execPath, devBundle, "__supervise"]);
+
+    const { proc } = await deps(cwd);
+    await proc.spawnSlot(0, undefined);
+
+    expect((spawn.mock.calls[0]![1] as readonly string[])[0]).toBe(devBundle);
+  });
+
+  it("spawns the dev bundle for reconcile workers too", async () => {
+    const cwd = await root();
+    vi.spyOn(process, "argv", "get").mockReturnValue([process.execPath, MCP_BUNDLE, "__supervise"]);
+
+    const { proc } = await deps(cwd);
+    await proc.spawnReconcileWorker?.(1, { issue: 42 } as never);
+
+    const args = spawn.mock.calls[0]![1] as readonly string[];
+    expect(basename(args[0]!)).toBe("dev.bundle.min.mjs");
+    expect(args).toContain("--reconcile-issue");
+  });
+});
+
+describe("MCP-launched fleet regression: the slot boots a worker instead of dying (#2677)", () => {
+  it("routes the produced slot argv through the dev entry as `run` (never the mcp entry)", async () => {
+    const cwd = await root();
+    vi.spyOn(process, "argv", "get").mockReturnValue([process.execPath, MCP_BUNDLE, "__supervise"]);
+
+    const { proc } = await deps(cwd);
+    await proc.spawnSlot(0, undefined);
+    const [entry, ...slotArgv] = spawn.mock.calls[0]![1] as readonly string[];
+
+    // The entry is the one that routes `run` — a real worker boots and writes
+    // its worker directory, so the slot occupies its slot instead of dying.
+    expect(basename(entry!)).toBe("dev.bundle.min.mjs");
+    expect(parseCli(slotArgv).command).toBe("run");
+
+    // And the pre-fix target can no longer swallow the same argv silently: the
+    // castle-mcp entry refuses it by name rather than opening a second resident.
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    await expect(
+      mcpMain(slotArgv, {
+        supervise: async () => 0,
+        startCurator: async () => expect.unreachable("curator must not start for `run`"),
+        startMergeDriver: async () => expect.unreachable("merge driver must not start for `run`"),
+        connect: async () => expect.unreachable("stdio transport must not open for `run`"),
+      }),
+    ).resolves.toBe(2);
+    expect(stderr.mock.calls[0]![0]).toContain("unroutable subcommand");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2677. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2677

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787829488&installation_model_id=20659&pr_number=2682&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2682&signature=5ff853f0a463c4014004b1ed4571c72d721c5639e29ccefa7aa815f1af6ee930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->