### PR TITLE
fix: #2678 bundle-coherence probe halts every fleet boot on a superseded self-update failure, and the canonical fix cannot clear it

### DIFF
--- a/apps/dev/src/core/bundle-version.ts
+++ b/apps/dev/src/core/bundle-version.ts
@@ -73,13 +73,20 @@ export function readDevBundleCacheState(
   const pointerVersion = readPointerVersion(join(cacheDir, pointerFileName("dev")));
   const laneNewestVersion = newestCachedDevBundleVersion(installedVersion, env);
   const state = readSelfUpdateState(join(cacheDir, statusFileName("dev")));
+  // A failure only counts once it is newer than the last success — the same rule
+  // `resolveActiveVersionDetailed` applies. Without it a single old failure keeps
+  // the coherence probe red forever, however many checks have succeeded since.
+  const live =
+    state.lastFailureAtMs !== undefined && state.lastFailureAtMs > (state.lastSuccessAtMs ?? 0)
+      ? state
+      : {};
   return {
     ...(installedVersion ? { installedVersion } : {}),
     ...(pointerVersion ? { pointerVersion } : {}),
     ...(laneNewestVersion ? { laneNewestVersion } : {}),
-    ...(state.lastFailureAtMs !== undefined ? { lastFailureAtMs: state.lastFailureAtMs } : {}),
-    ...(state.lastFailureAtMs !== undefined ? { lastFailureAgeMs: Math.max(0, nowMs - state.lastFailureAtMs) } : {}),
-    ...(state.lastError ? { lastError: state.lastError } : {}),
+    ...(live.lastFailureAtMs !== undefined ? { lastFailureAtMs: live.lastFailureAtMs } : {}),
+    ...(live.lastFailureAtMs !== undefined ? { lastFailureAgeMs: Math.max(0, nowMs - live.lastFailureAtMs) } : {}),
+    ...(live.lastError ? { lastError: live.lastError } : {}),
   };
 }
 
@@ -109,6 +116,7 @@ function readSelfUpdateState(path: string): SelfUpdateStateRecord {
   try {
     const parsed = decodeDevSnapshotSniff(readFileSync(path, "utf8")) as Record<string, unknown>;
     return {
+      ...(Number.isFinite(parsed.lastSuccessAtMs) ? { lastSuccessAtMs: Number(parsed.lastSuccessAtMs) } : {}),
       ...(Number.isFinite(parsed.lastFailureAtMs) ? { lastFailureAtMs: Number(parsed.lastFailureAtMs) } : {}),
       ...(typeof parsed.lastError === "string" ? { lastError: parsed.lastError } : {}),
     };

--- a/apps/dev/tests/bundle-version.test.ts
+++ b/apps/dev/tests/bundle-version.test.ts
@@ -31,4 +31,49 @@ describe("dev bundle cache state", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("suppresses the failure age when a later success supersedes the failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dev-bundle-cache-"));
+    try {
+      mkdirSync(root, { recursive: true });
+      writeFileSync(
+        join(root, statusFileName("dev")),
+        encodeDevSnapshotToon({
+          lastFailureAtMs: 100,
+          lastSuccessAtMs: 200,
+          lastStatus: "up-to-date",
+        }),
+        "utf8",
+      );
+
+      const state = readDevBundleCacheState("2.71.0", { RED_SKILLS_CACHE_DIR: root }, 100_000_000);
+      expect(state.lastFailureAgeMs).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the failure age when the failure is newer than the last success", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dev-bundle-cache-"));
+    try {
+      mkdirSync(root, { recursive: true });
+      writeFileSync(
+        join(root, statusFileName("dev")),
+        encodeDevSnapshotToon({
+          lastFailureAtMs: 300,
+          lastSuccessAtMs: 200,
+          lastStatus: "error",
+          lastError: "fetch failed",
+        }),
+        "utf8",
+      );
+
+      expect(readDevBundleCacheState("2.71.0", { RED_SKILLS_CACHE_DIR: root }, 100_000_000)).toMatchObject({
+        lastFailureAtMs: 300,
+        lastFailureAgeMs: 100_000_000 - 300,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/dev/tests/operational-probes.test.ts
+++ b/apps/dev/tests/operational-probes.test.ts
@@ -5,7 +5,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { decode } from "@reddb-io/toon";
+import { statusFileName } from "@reddb-io/shared/self-update.js";
 import { parseCurrentBlocker } from "../src/core/blocker-state.js";
+import { readDevBundleCacheState } from "../src/core/bundle-version.js";
+import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
 import {
   applyOperationalProbeFixes,
   classifyQueueVisibilityTransportFailure,
@@ -137,6 +140,38 @@ describe("operational probe registry", () => {
         evidence: expect.stringContaining("stale-failed-check"),
       }),
     ]);
+  });
+
+  it("stays ok when the last self-update success supersedes an old failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "probe-bundle-cache-"));
+    try {
+      await writeFile(
+        join(root, statusFileName("dev")),
+        encodeDevSnapshotToon({
+          lastCheckAtMs: 100_000_000,
+          lastSuccessAtMs: 100_000_000,
+          lastFailureAtMs: 100_000_000 - 91 * 60 * 60 * 1000,
+          lastStatus: "up-to-date",
+        }),
+        "utf8",
+      );
+
+      const report = await runOperationalProbes({
+        remoteUrls: [],
+        bundleCoherence: {
+          ...readDevBundleCacheState("2.87.3", { RED_SKILLS_CACHE_DIR: root }, 100_000_000),
+          pointerVersion: "2.87.3",
+        },
+      });
+
+      expect(report.findings).toEqual([]);
+      expect(report.probes.find((probe) => probe.id === "afk.bundle-coherence")).toMatchObject({
+        verdict: "ok",
+        data: { findings: [] },
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("surfaces malformed config fallback with the offending line and construct", async () => {

--- a/packages/shared/self-update.test.ts
+++ b/packages/shared/self-update.test.ts
@@ -275,8 +275,7 @@ describe("resolveActiveVersion (render/hook path — local reads only)", () => {
     expect(result.status).toBe("up-to-date");
     const written = new TextDecoder().decode(files[status]);
     expect(() => JSON.parse(written)).toThrow();
-    expect(decode(written)).toMatchObject({
-      lastFailureAtMs: legacyStatus.lastFailureAtMs,
+    expect(decode(written)).toEqual({
       lastCheckAtMs: nowMs,
       lastSuccessAtMs: nowMs,
       lastStatus: "up-to-date",
@@ -406,6 +405,37 @@ describe("backgroundSelfUpdate (registry discovery + npm materialize)", () => {
     expect(materializes).toEqual([]);
     expect(writes).toEqual([statusPath(CACHE, PLUGIN)]);
     expect(renames).toEqual([]);
+  });
+
+  it("a successful check clears a recorded failure so the record cannot rot", async () => {
+    const { io, files } = makeIO({
+      registryVersions: [INSTALLED],
+      packageBundles: { [INSTALLED]: bundleBytesFor(INSTALLED) },
+      files: {
+        [statusPath(CACHE, PLUGIN)]: enc(
+          JSON.stringify({
+            lastCheckAtMs: 1,
+            lastFailureAtMs: 1,
+            lastError: "ECONNREFUSED registry.npmjs.org",
+            lastStatus: "error",
+          }),
+        ),
+      },
+    });
+
+    const res = await backgroundSelfUpdate(io, {
+      plugin: PLUGIN,
+      installedVersion: INSTALLED,
+      repo: REPO,
+      cacheDir: CACHE,
+      channel: "stable",
+    });
+
+    expect(res).toEqual({ status: "up-to-date", version: INSTALLED });
+    const record = decode(new TextDecoder().decode(files[statusPath(CACHE, PLUGIN)])) as Record<string, unknown>;
+    expect(record.lastStatus).toBe("up-to-date");
+    expect(record).not.toHaveProperty("lastFailureAtMs");
+    expect(record).not.toHaveProperty("lastError");
   });
 
   it("registry offline: typed error, cache keeps serving, retried later", async () => {

--- a/packages/shared/self-update.ts
+++ b/packages/shared/self-update.ts
@@ -416,6 +416,10 @@ export async function backgroundSelfUpdate(
         lastCheckAtMs: nowMs(),
         lastSuccessAtMs: nowMs(),
         lastStatus: "up-to-date",
+        // Clearing the failure is what makes the canonical fix reachable: the
+        // merge-write keeps every prior key, so a failure left behind here can
+        // never be healed by running a shim, only by editing the file by hand.
+        lastFailureAtMs: undefined,
         lastError: undefined,
       });
       return { status: "up-to-date", version: current };
@@ -431,6 +435,7 @@ export async function backgroundSelfUpdate(
       lastCheckAtMs: nowMs(),
       lastSuccessAtMs: nowMs(),
       lastStatus: "updated",
+      lastFailureAtMs: undefined,
       lastError: undefined,
     });
     return { status: "updated", version: target };


### PR DESCRIPTION
Automated AFK landing for #2678. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2678

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787830384&installation_model_id=20659&pr_number=2684&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2684&signature=e74009f05915a77f156b14d1ae0d958db57e37602990a5b61e589ae783f7f181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->