### PR TITLE
fix: #2679 boot tmp-janitor deletes the live .red/tmp/supervisors lane, blinding fleet_status and monitor

### DIFF
--- a/.changeset/janitor-supervisor-lane-anchors.md
+++ b/.changeset/janitor-supervisor-lane-anchors.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The boot tmp-janitor no longer deletes the live supervisor lane (#2679). Its supervisor sweep keyed liveness off `afk-supervisor.pid` alone, so a supervisor still ticking without that file — its lane swept, or booted from a bundle predating the pid re-pin — was judged dead and had its runtime dir removed, after which `fleet_status` and `monitor` reported `pid 0, alive false` for a healthy fleet. A lane is now spared on ANY live anchor (pid file, the pid stamped into the fleet `state.toon` snapshot, or a live `s<pid>/` log dir), the supervisor stamps its pid into that snapshot on every heartbeat, and both the boot sweep and the runtime janitor refuse to delete a registered `.red/tmp` lane through the unknown-entry path.

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -105,6 +105,7 @@ export function fleetHeartbeatState(hb: FleetHeartbeat): string {
     runner: hb.runner,
     ...(hb.shrinkMode !== undefined ? { shrink_mode: hb.shrinkMode } : {}),
     ...(hb.bundleVersion ? { bundle_version: hb.bundleVersion } : {}),
+    ...(hb.pid !== undefined ? { pid: hb.pid } : {}),
     ready_for_agent: hb.readyForAgent,
     slots: {
       busy: hb.slotsBusy,
@@ -850,7 +851,9 @@ export function buildSupervisorDeps(
       });
     },
     emitFleetHeartbeat: async (hb): Promise<FleetHeartbeatEmitResult> => {
-      const stamped = { ...hb, bundleVersion };
+      // `pid` makes the snapshot itself a janitor liveness anchor, so a swept
+      // pid file can no longer make a running supervisor look dead (#2679).
+      const stamped = { ...hb, bundleVersion, pid: process.pid };
       let stateWritten = false;
       let firehoseWritten = false;
       let stateError: string | undefined;
@@ -979,7 +982,7 @@ export function buildSupervisorDeps(
       };
     },
     repairFleetHeartbeat: async (hb): Promise<FleetHeartbeatEmitResult> => {
-      const stamped = { ...hb, bundleVersion };
+      const stamped = { ...hb, bundleVersion, pid: process.pid };
       try {
         writeFleetStateAtomic(statePath, stamped);
         return { stateWritten: true };

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -83,6 +83,7 @@ import {
   type QueueVisibilityProbeData,
 } from "./operational-probes.js";
 import { runHostPrerequisiteProbe } from "./operational-probes/host-prerequisites.js";
+import { removableUnknownTmpRoots } from "./tmp-janitor.js";
 import type { TmpJanitorPlan, WorkerDirJanitorPlan } from "./tmp-janitor.js";
 import { LABEL_HUMAN, LABEL_QUARANTINE, LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
 import { isRefused, planTransition, type StateTransition } from "./state-transition.js";
@@ -1037,7 +1038,10 @@ async function runTmpJanitorSweep(
     result.staleWorkers.push(worker.path);
   }
 
-  for (const name of sweep.plan.unknownTmpRoots) {
+  // A registered lane is never removable through the unknown-entry path, even
+  // if the plan named one (issue #2679: a worker boot deleted the live
+  // `supervisors` lane this way and blinded fleet_status).
+  for (const name of removableUnknownTmpRoots(sweep.plan.unknownTmpRoots)) {
     const path = join(options.bootstrap.tmpDir, name);
     await deps.fs.removeDir(path);
     result.removals.push({ path, livenessVerdict: "not-worker-workspace" });

--- a/apps/dev/src/core/supervisor/types.ts
+++ b/apps/dev/src/core/supervisor/types.ts
@@ -227,6 +227,9 @@ export interface FleetHeartbeat {
   shrinkMode: ElasticShrinkMode;
   /** Dev bundle version the running supervisor was launched from. */
   bundleVersion?: string;
+  /** PID of the supervisor process that wrote this snapshot. A janitor liveness
+   * anchor that survives when the pid file does not (issue #2679). */
+  pid?: number;
   readyForAgent: number;
   slotsBusy: number;
   slotsFree: number;

--- a/apps/dev/src/core/tmp-janitor.ts
+++ b/apps/dev/src/core/tmp-janitor.ts
@@ -149,6 +149,21 @@ export function auditTmpRoot(names: readonly string[]): TmpRootAudit {
   return { unknown };
 }
 
+/**
+ * The apply-time gate for the unknown-entry removal path: a REGISTERED lane can
+ * never be deleted as an unknown tmp-root entry, whatever the plan claims.
+ *
+ * `auditTmpRoot` already excludes known lanes when the plan is built, so this is
+ * the second, non-negotiable barrier — a plan produced by an older bundle, a
+ * hand-built plan, or a future lane-registry drift must not be able to take out
+ * a live lane root (issue #2679: `supervisors` was removed this way, blinding
+ * `fleet_status` for a healthy fleet). Lane roots are only ever reclaimed by
+ * their own owner-aware sweeps.
+ */
+export function removableUnknownTmpRoots(names: readonly string[]): string[] {
+  return names.filter((name) => !KNOWN_TMP_LANES.has(name));
+}
+
 // ---------- combined planner ----------
 
 export interface TmpJanitorInput {
@@ -299,14 +314,31 @@ export function planWorkerDirJanitor(entries: readonly WorkerDirJanitorEntry[]):
 
 // ---------- supervisor lane planner ----------
 
-/** One fleet dir under `.red/tmp/supervisors/`. */
+/** One fleet dir under `.red/tmp/supervisors/`.
+ *
+ * Liveness carries THREE independent anchors, not one. The pid file is the
+ * authoritative lock when present, but a supervisor whose lane was swept (or
+ * that booted from a bundle predating the pid re-pin) keeps ticking while the
+ * pid file is absent — its state snapshot and its `s<pid>/` log dir still name
+ * the live process. Keying the sweep off the pid file alone deleted the runtime
+ * dir of a running supervisor and blinded `fleet_status` (issue #2679). */
 export interface SupervisorLaneEntry {
   /** Absolute path of the fleet dir (e.g. `.red/tmp/supervisors/default`). */
   path: string;
   /** Fleet name (the basename of the fleet dir). */
   fleet: string;
-  /** Whether the pid file in this fleet dir names a live process. */
+  /** Whether `afk-supervisor.pid` in this fleet dir names a live process. */
   pidAlive: boolean;
+  /** Whether the fleet state snapshot (`state.toon`) names a live process. */
+  statePidAlive?: boolean;
+  /** Whether an `s<pid>/` supervisor log dir in this fleet names a live process. */
+  snapshotPidAlive?: boolean;
+}
+
+/** Whether ANY liveness anchor in a fleet dir names a live process. A lane with
+ * a live anchor is never reclaimable. */
+export function supervisorLaneIsLive(entry: SupervisorLaneEntry): boolean {
+  return entry.pidAlive || entry.statePidAlive === true || entry.snapshotPidAlive === true;
 }
 
 export interface SupervisorLanePlan {
@@ -316,14 +348,14 @@ export interface SupervisorLanePlan {
   spare: SupervisorLaneEntry[];
 }
 
-/** Plan supervisor lane cleanup. A fleet dir is reclaimable only when its
- * `afk-supervisor.pid` does not name a live process. Live supervisors are
- * always spared regardless of mtime. */
+/** Plan supervisor lane cleanup. A fleet dir is reclaimable only when NO
+ * liveness anchor — pid file, state snapshot, or `s<pid>/` log dir — names a
+ * live process. Live supervisors are always spared regardless of mtime. */
 export function planSupervisorLaneJanitor(entries: readonly SupervisorLaneEntry[]): SupervisorLanePlan {
   const reclaim: SupervisorLaneEntry[] = [];
   const spare: SupervisorLaneEntry[] = [];
   for (const entry of entries) {
-    if (entry.pidAlive) spare.push(entry);
+    if (supervisorLaneIsLive(entry)) spare.push(entry);
     else reclaim.push(entry);
   }
   return { reclaim, spare };

--- a/apps/dev/src/runtime/tmp-janitor.ts
+++ b/apps/dev/src/runtime/tmp-janitor.ts
@@ -7,6 +7,8 @@ import {
   planSupervisorLaneJanitor,
   parseFeedbackWorktreeWorkerSlug,
   planOrphanFeedbackWorktreeSweep,
+  removableUnknownTmpRoots,
+  supervisorLaneIsLive,
   type JanitorEntry,
   type OrphanFeedbackEntry,
   type OrphanFeedbackSweepPlan,
@@ -15,6 +17,7 @@ import {
   type SupervisorLaneEntry,
   type SupervisorLanePlan,
 } from "../core/tmp-janitor.js";
+import { decodeDevSnapshotSniff } from "../core/toon-snapshot.js";
 import { allWorkersRoots, parseReapableWorkerPath } from "../core/worker-paths.js";
 import { execTool } from "./exec.js";
 import { killTreeAndWait } from "./kill-tree.js";
@@ -141,16 +144,20 @@ async function listEntries(path: string): Promise<JanitorEntry[]> {
   return entries;
 }
 
-function pidAlive(raw: string | null): boolean {
-  if (raw === null) return false;
-  const trimmed = raw.trim();
-  if (!/^[1-9][0-9]*$/.test(trimmed)) return false;
+function livePid(pid: number): boolean {
   try {
-    process.kill(Number(trimmed), 0);
+    process.kill(pid, 0);
     return true;
   } catch (err) {
     return (err as NodeJS.ErrnoException).code === "EPERM";
   }
+}
+
+function pidAlive(raw: string | null): boolean {
+  if (raw === null) return false;
+  const trimmed = raw.trim();
+  if (!/^[1-9][0-9]*$/.test(trimmed)) return false;
+  return livePid(Number(trimmed));
 }
 
 async function readText(path: string): Promise<string | null> {
@@ -198,7 +205,55 @@ async function collectWorkerEntries(tmpDir: string, lookup: IssueStateLookup): P
   return out;
 }
 
-/** Collect supervisor fleet dirs under `.red/tmp/supervisors/` with pid liveness. */
+/** Read the supervisor pid recorded in a fleet's `state.toon` snapshot.
+ * Returns null when the file is absent, undecodable, or carries no pid — an
+ * older bundle's snapshot simply contributes no anchor. */
+async function readFleetStatePid(fleetDir: string): Promise<number | null> {
+  const text = await readText(join(fleetDir, "state.toon"));
+  if (text === null) return null;
+  let decoded: unknown;
+  try {
+    decoded = decodeDevSnapshotSniff(text);
+  } catch {
+    return null;
+  }
+  if (decoded === null || typeof decoded !== "object") return null;
+  const pid = Number((decoded as { pid?: unknown }).pid);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
+}
+
+/** Find a live supervisor pid from the `s<pid>/` log dirs inside a fleet dir.
+ * The supervisor names its own log lane after its pid, so the dir survives as a
+ * liveness anchor even when the pid file was swept away. */
+async function snapshotDirPidAlive(fleetDir: string): Promise<boolean> {
+  for (const name of await listNames(fleetDir)) {
+    const match = /^s([1-9][0-9]*)$/.exec(name);
+    if (!match) continue;
+    if (livePid(Number(match[1]))) return true;
+  }
+  return false;
+}
+
+/** Resolve every liveness anchor for one fleet dir. */
+async function readSupervisorLaneLiveness(
+  fleetDir: string,
+  fleet: string,
+): Promise<SupervisorLaneEntry> {
+  const [pidFile, statePid, snapshotAlive] = await Promise.all([
+    readText(join(fleetDir, "afk-supervisor.pid")),
+    readFleetStatePid(fleetDir),
+    snapshotDirPidAlive(fleetDir),
+  ]);
+  return {
+    path: fleetDir,
+    fleet,
+    pidAlive: pidAlive(pidFile),
+    statePidAlive: statePid !== null && livePid(statePid),
+    snapshotPidAlive: snapshotAlive,
+  };
+}
+
+/** Collect supervisor fleet dirs under `.red/tmp/supervisors/` with liveness. */
 async function collectSupervisorEntries(tmpDir: string): Promise<SupervisorLaneEntry[]> {
   const supervisorsRoot = join(tmpDir, "supervisors");
   const fleets = await listNames(supervisorsRoot);
@@ -211,8 +266,7 @@ async function collectSupervisorEntries(tmpDir: string): Promise<SupervisorLaneE
     } catch {
       continue;
     }
-    const alive = pidAlive(await readText(join(fleetDir, "afk-supervisor.pid")));
-    entries.push({ path: fleetDir, fleet, pidAlive: alive });
+    entries.push(await readSupervisorLaneLiveness(fleetDir, fleet));
   }
   return entries;
 }
@@ -407,10 +461,11 @@ export async function applyTmpJanitorReport(
     result.staleWorkers.push(worker.path);
   }
 
-  // Re-check supervisor pid at apply time — a supervisor may have started
-  // between collect and apply (same pattern as the worker liveness re-check).
+  // Re-check every supervisor anchor at apply time — a supervisor may have
+  // started between collect and apply (same pattern as the worker liveness
+  // re-check), and a live lane must survive whichever anchor it still carries.
   for (const supervisor of report.staleSupervisors.reclaim) {
-    if (pidAlive(await readText(join(supervisor.path, "afk-supervisor.pid")))) {
+    if (supervisorLaneIsLive(await readSupervisorLaneLiveness(supervisor.path, supervisor.fleet))) {
       result.protectedLiveSupervisors.push(supervisor.path);
       continue;
     }
@@ -422,7 +477,9 @@ export async function applyTmpJanitorReport(
     result.protectedLiveSupervisors.push(supervisor.path);
   }
 
-  for (const name of report.plan.unknownTmpRoots) {
+  // A registered lane is never removable through the unknown-entry path, even
+  // if the plan named one (issue #2679).
+  for (const name of removableUnknownTmpRoots(report.plan.unknownTmpRoots)) {
     const path = join(tmpDir, name);
     await rm(path, { recursive: true, force: true });
     result.removals.push({ path, livenessVerdict: "not-worker-workspace" });

--- a/apps/dev/tests/boot-cleanup.test.ts
+++ b/apps/dev/tests/boot-cleanup.test.ts
@@ -13,6 +13,7 @@ import {
   type OrphanDir,
   type UnblockCandidate,
 } from "./boot.helpers.js";
+import { KNOWN_TMP_LANES } from "../src/core/tmp-janitor.js";
 
 describe("runBoot tmp janitor", () => {
   it("reaps orphan test-runner groups and records an audit row", async () => {
@@ -86,6 +87,32 @@ describe("runBoot tmp janitor", () => {
         { path: "/p/.red/tmp/work-old", livenessVerdict: "not-worker-workspace" },
       ],
     });
+  });
+
+  it("refuses to remove a registered lane named as an unknown tmp root (#2679)", async () => {
+    const { deps, fsCalls } = makeDeps();
+    const result = await runBoot(
+      deps,
+      options({
+        tmpJanitor: {
+          plan: {
+            logs: { reclaim: [], spare: [] },
+            scratch: { reclaim: [], spare: [] },
+            diagnostics: { reclaim: [], spare: [] },
+            feedbackWorktrees: { reclaim: [], spare: [] },
+            legacySlotLogs: { reclaim: [], spare: [] },
+            // A plan from an older bundle (pre-lane-registry) misclassified the
+            // live supervisors lane; the apply path must still spare it.
+            unknownTmpRoots: [...KNOWN_TMP_LANES, "work-old"],
+          },
+          staleWorkers: { reclaim: [], spare: [] },
+        },
+      }),
+    );
+
+    expect(fsCalls.removeDir).toEqual(["/p/.red/tmp/work-old"]);
+    expect(result.tmpJanitor?.unknownTmpRoots).toEqual(["/p/.red/tmp/work-old"]);
+    expect(result.tmpJanitor?.removals.map((r) => r.path)).not.toContain("/p/.red/tmp/supervisors");
   });
 
   it("rechecks worker.pid before removing a stale worker dir and protects live anchors", async () => {

--- a/apps/dev/tests/tmp-janitor-runtime.test.ts
+++ b/apps/dev/tests/tmp-janitor-runtime.test.ts
@@ -2,11 +2,33 @@ import { access, mkdtemp, mkdir, readdir, rm, utimes, writeFile } from "node:fs/
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { applyTmpJanitorReport, collectTmpJanitorReport, selectOrphanTestRunners } from "../src/runtime/tmp-janitor.js";
-import { LOGS_TTL_S, SCRATCH_TTL_S } from "../src/core/tmp-janitor.js";
+import {
+  applyTmpJanitorReport,
+  collectTmpJanitorReport,
+  runTmpJanitor,
+  selectOrphanTestRunners,
+} from "../src/runtime/tmp-janitor.js";
+import { KNOWN_TMP_LANES, LOGS_TTL_S, SCRATCH_TTL_S } from "../src/core/tmp-janitor.js";
+import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
+import { discoverLiveSupervisorPid } from "../src/runtime/supervisor-state.js";
+import { readPidStartTime } from "../src/core/state.js";
 
 const NOW = 1_800_000_000;
 const roots: string[] = [];
+
+/** A fleet `state.toon` whose supervisor liveness anchor is `pid`. */
+function fleetSnapshot(pid: number): string {
+  return encodeDevSnapshotToon({
+    ts: new Date(NOW * 1000).toISOString(),
+    epoch: NOW,
+    runner: "claude",
+    pid,
+    ready_for_agent: 0,
+    slots: { busy: 0, free: 1, total: 1, parked: 0 },
+    slot_pids: [],
+    spawns_this_tick: 0,
+  });
+}
 
 async function tempRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "red-skills-janitor-"));
@@ -220,5 +242,102 @@ describe("tmp janitor runtime", () => {
     await expect(access(supervisorDir)).resolves.toBeUndefined();
     expect(applied.protectedLiveSupervisors).toContain(supervisorDir);
     expect(applied.staleSupervisors).toEqual([]);
+  });
+
+  // ---------- #2679: the live lane must survive without a pid file ----------
+
+  it("spares a supervisor fleet dir whose state snapshot names a live pid and has no pid file", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const supervisorDir = join(tmp, "supervisors", "default");
+    await mkdir(supervisorDir, { recursive: true });
+    await writeFile(join(supervisorDir, "state.toon"), fleetSnapshot(process.pid), "utf8");
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "UNKNOWN");
+
+    expect(report.staleSupervisors.spare.map((e) => e.path)).toEqual([supervisorDir]);
+    expect(report.staleSupervisors.reclaim).toEqual([]);
+
+    const applied = await applyTmpJanitorReport(tmp, report);
+    await expect(access(supervisorDir)).resolves.toBeUndefined();
+    expect(applied.protectedLiveSupervisors).toContain(supervisorDir);
+    expect(applied.removals.map((r) => r.path)).not.toContain(supervisorDir);
+  });
+
+  it("reaps a supervisor fleet dir whose state snapshot names a dead pid", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const supervisorDir = join(tmp, "supervisors", "default");
+    await mkdir(supervisorDir, { recursive: true });
+    await writeFile(join(supervisorDir, "state.toon"), fleetSnapshot(999_999_999), "utf8");
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "UNKNOWN");
+
+    expect(report.staleSupervisors.reclaim.map((e) => e.path)).toEqual([supervisorDir]);
+
+    const applied = await applyTmpJanitorReport(tmp, report);
+    await expect(access(supervisorDir)).rejects.toThrow();
+    expect(applied.staleSupervisors).toContain(supervisorDir);
+  });
+
+  it("spares a supervisor fleet dir whose s<pid> log dir names a live pid", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const supervisorDir = join(tmp, "supervisors", "default");
+    await mkdir(join(supervisorDir, `s${process.pid}`), { recursive: true });
+    await writeFile(join(supervisorDir, `s${process.pid}`, "supervisor.log.toonl"), "", "utf8");
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "UNKNOWN");
+
+    expect(report.staleSupervisors.spare.map((e) => e.path)).toEqual([supervisorDir]);
+
+    const applied = await applyTmpJanitorReport(tmp, report);
+    await expect(access(supervisorDir)).resolves.toBeUndefined();
+    expect(applied.protectedLiveSupervisors).toContain(supervisorDir);
+  });
+
+  it("never removes a registered lane through the unknown-entry path", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const supervisorDir = join(tmp, "supervisors", "default");
+    await mkdir(supervisorDir, { recursive: true });
+    await writeFile(join(supervisorDir, "state.toon"), fleetSnapshot(process.pid), "utf8");
+    await mkdir(join(tmp, "work-old"), { recursive: true });
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "UNKNOWN");
+    expect(report.plan.unknownTmpRoots).toEqual(["work-old"]);
+    // Simulate a plan built by an older bundle (or a drifted lane registry) that
+    // named a registered lane as unknown — apply must still refuse to delete it.
+    report.plan.unknownTmpRoots = [...KNOWN_TMP_LANES, "work-old"];
+
+    const applied = await applyTmpJanitorReport(tmp, report);
+    for (const lane of KNOWN_TMP_LANES) {
+      expect(applied.removals.map((r) => r.path)).not.toContain(join(tmp, lane));
+      expect(applied.unknownTmpRoots).not.toContain(join(tmp, lane));
+    }
+    await expect(access(supervisorDir)).resolves.toBeUndefined();
+    expect(applied.unknownTmpRoots).toEqual([join(tmp, "work-old")]);
+  });
+
+  it("keeps fleet-truth pid discovery working after a boot sweep on a live fleet", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const supervisorDir = join(tmp, "supervisors", "default");
+    await mkdir(supervisorDir, { recursive: true });
+    await writeFile(join(supervisorDir, "afk-supervisor.pid"), String(process.pid), "utf8");
+    await writeFile(
+      join(supervisorDir, "afk-supervisor.pid.start"),
+      readPidStartTime(process.pid) ?? "",
+      "utf8",
+    );
+    await writeFile(join(supervisorDir, "state.toon"), fleetSnapshot(process.pid), "utf8");
+
+    await runTmpJanitor(tmp, NOW, () => "UNKNOWN", { fix: true });
+
+    // This is what `fleet_status` resolves: an absent runtime dir reports
+    // `pid 0, alive false` for a provably live supervisor (#2679).
+    const discovered = await discoverLiveSupervisorPid(supervisorDir);
+    expect(discovered).not.toBeNull();
+    expect(discovered?.pid).toBe(process.pid);
   });
 });

--- a/apps/dev/tests/tmp-janitor.test.ts
+++ b/apps/dev/tests/tmp-janitor.test.ts
@@ -11,11 +11,15 @@ import {
   planLogsJanitor,
   planOrphanFeedbackWorktreeSweep,
   planScratchJanitor,
+  planSupervisorLaneJanitor,
   planTmpJanitor,
   planWorkerDirJanitor,
+  removableUnknownTmpRoots,
   SCRATCH_TTL_S,
+  supervisorLaneIsLive,
   type JanitorEntry,
   type OrphanFeedbackEntry,
+  type SupervisorLaneEntry,
   type WorkerDirJanitorEntry,
 } from "../src/core/tmp-janitor.js";
 
@@ -404,5 +408,53 @@ describe("planOrphanFeedbackWorktreeSweep", () => {
     // Should not happen in practice, but the rule is clear: ownerAlive: true → spare.
     const live = fbEntry("afk-wABC-10-fix", true);
     expect(planOrphanFeedbackWorktreeSweep([live], false)).toEqual({ reclaim: [], spare: [live] });
+  });
+});
+
+// ---------- planSupervisorLaneJanitor (#2679) ----------
+
+describe("planSupervisorLaneJanitor", () => {
+  function lane(over: Partial<SupervisorLaneEntry> = {}): SupervisorLaneEntry {
+    return { path: "/red/tmp/supervisors/default", fleet: "default", pidAlive: false, ...over };
+  }
+
+  it("spares a fleet dir whose pid file names a live process", () => {
+    const live = lane({ pidAlive: true });
+    expect(planSupervisorLaneJanitor([live])).toEqual({ reclaim: [], spare: [live] });
+  });
+
+  it("spares a fleet dir whose state snapshot names a live pid and has no pid file", () => {
+    const live = lane({ pidAlive: false, statePidAlive: true });
+    expect(planSupervisorLaneJanitor([live])).toEqual({ reclaim: [], spare: [live] });
+  });
+
+  it("spares a fleet dir whose s<pid> log dir names a live pid and has no pid file", () => {
+    const live = lane({ pidAlive: false, snapshotPidAlive: true });
+    expect(planSupervisorLaneJanitor([live])).toEqual({ reclaim: [], spare: [live] });
+  });
+
+  it("reclaims a fleet dir whose every anchor is dead", () => {
+    const dead = lane({ pidAlive: false, statePidAlive: false, snapshotPidAlive: false });
+    expect(planSupervisorLaneJanitor([dead])).toEqual({ reclaim: [dead], spare: [] });
+  });
+
+  it("supervisorLaneIsLive is true when any single anchor is live", () => {
+    expect(supervisorLaneIsLive(lane({ pidAlive: true }))).toBe(true);
+    expect(supervisorLaneIsLive(lane({ statePidAlive: true }))).toBe(true);
+    expect(supervisorLaneIsLive(lane({ snapshotPidAlive: true }))).toBe(true);
+    expect(supervisorLaneIsLive(lane())).toBe(false);
+  });
+});
+
+// ---------- removableUnknownTmpRoots (#2679) ----------
+
+describe("removableUnknownTmpRoots", () => {
+  it("never returns an entry named in KNOWN_TMP_LANES", () => {
+    const lanes = [...KNOWN_TMP_LANES];
+    expect(removableUnknownTmpRoots(lanes)).toEqual([]);
+  });
+
+  it("still returns genuinely unknown names", () => {
+    expect(removableUnknownTmpRoots(["supervisors", "work-old", "workers"])).toEqual(["work-old"]);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #2679. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2679

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787831543&installation_model_id=20659&pr_number=2685&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2685&signature=fd6994e9e28f48b2c14dc739aefd819b30a4e0a353d76098397e4383edb21a6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->