### PR TITLE
chore: #2667 Decompose buildProcessDeps into per-context port builders; retire the MAX_LINES budget

### DIFF
--- a/apps/dev/src/commands/run/attempt.ts
+++ b/apps/dev/src/commands/run/attempt.ts
@@ -1,0 +1,6 @@
+/** Per-issue mutable context the session-scoped process deps close over — the
+ * attempt dir the envelope markers / iter-log write into. buildProcessInput
+ * resets it before each processIssue call. */
+export interface CurrentAttempt {
+  attemptDir: string;
+}

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -330,21 +330,20 @@ export async function runCommand(options: RunOptions): Promise<number> {
       }
       return result;
     },
-    processDeps: buildProcessDeps(
+    processDeps: buildProcessDeps({
       ctx,
-      settings.model,
-      settings.sandbox,
+      model: settings.model,
+      sandbox: settings.sandbox,
       feedback,
       current,
-      flags.fallbackRunner,
+      fallbackRunner: flags.fallbackRunner,
       runner,
-      undefined,
-      settings.maxIterations,
-      settings.laneIdle,
-      flags.verifyCommand,
-      flags.goVerifyRetries,
+      maxIterations: settings.maxIterations,
+      laneIdle: settings.laneIdle,
+      inlineVerifyCommand: flags.verifyCommand,
+      goVerifyRetries: flags.goVerifyRetries,
       workerId,
-    ),
+    }),
     // Session-scoped lifecycle hooks (PRD #207): the castle drain owns the
     // session state machine, while dev supplies the existing hook dispatcher so
     // the configured hook surface and output stay unchanged.

--- a/apps/dev/src/commands/run/ports/envelope.ts
+++ b/apps/dev/src/commands/run/ports/envelope.ts
@@ -1,0 +1,31 @@
+import type { ProcessIssueDeps } from "../../../core/process-issue.js";
+import * as ghx from "../../../runtime/gh.js";
+import * as gitx from "../../../runtime/git.js";
+import * as fsx from "../../../runtime/fs.js";
+import type { GhContext } from "../../../runtime/gh.js";
+import type { GitContext } from "../../../runtime/git.js";
+import type { CurrentAttempt } from "../attempt.js";
+
+/**
+ * Terminal-Envelope port — the one small surface that genuinely reads BOTH the
+ * gh and git contexts (it posts the envelope and stamps the head it describes),
+ * plus the per-issue attempt dir its markers land in.
+ */
+export function buildEnvelopePort(
+  ghCtx: GhContext,
+  gitCtx: GitContext,
+  current: CurrentAttempt,
+): NonNullable<ProcessIssueDeps["envelope"]> {
+  return {
+    git: gitx.gitExec(gitCtx),
+    poster: async (issue, body) => {
+      await ghx.comment(ghCtx, issue, body);
+      return true;
+    },
+    // Markers/posted land in the CURRENT attempt dir, set per issue by
+    // buildProcessInput before each processIssue call.
+    writeMarkers: (markers) => fsx.writeFailureMarkers(current.attemptDir, markers),
+    writePosted: (posted) => fsx.writeEnvelopePosted(current.attemptDir, posted),
+    issueReference: (issue) => ghx.issueReference(ghCtx, issue),
+  };
+}

--- a/apps/dev/src/commands/run/ports/fs.ts
+++ b/apps/dev/src/commands/run/ports/fs.ts
@@ -1,0 +1,19 @@
+import type { ProcessIssueDeps } from "../../../core/process-issue.js";
+import * as fsx from "../../../runtime/fs.js";
+import type { AfkPaths } from "../../../runtime/wire.js";
+
+/**
+ * Filesystem port: the only context it binds is the resolved AFK path set, so a
+ * fake `AfkPaths` over a tmpdir exercises it end to end.
+ */
+export function buildFsPort(paths: AfkPaths): NonNullable<ProcessIssueDeps["fs"]> {
+  return {
+    ensureAttemptDir: (dir) => fsx.ensureDir(dir),
+    writeHandoff: (path, content) => fsx.writeHandoff(path, content),
+    readText: (path) => fsx.readText(path),
+    // $ITER_DIR/validation.jsonl — the machine-readable feedback sidecar the
+    // Memory bridge consumes (SKILL.md §Validation Sidecar).
+    writeValidationSidecar: (path, lines) => fsx.writeValidationSidecar(path, lines),
+    completionSweep: (issue) => fsx.completionSweep(paths.workersRoot, issue),
+  };
+}

--- a/apps/dev/src/commands/run/ports/gh.ts
+++ b/apps/dev/src/commands/run/ports/gh.ts
@@ -1,0 +1,96 @@
+import type { ProcessIssueDeps } from "../../../core/process-issue.js";
+import * as ghx from "../../../runtime/gh.js";
+import type { GhContext } from "../../../runtime/gh.js";
+import { buildReviewGh } from "../../../runtime/review-gh.js";
+
+/**
+ * GitHub-issue port: every closure here binds ONE context (`ghCtx`) and nothing
+ * else. `ghCtx.cwd` is the repo root and `ghCtx.repo` the `owner/name` slug, so
+ * a caller never has to hand the builder a second, crossed context.
+ */
+export function buildGhPort(ghCtx: GhContext): ProcessIssueDeps["gh"] {
+  return {
+    viewLabels: (issue) => ghx.viewLabels(ghCtx, issue),
+    editLabels: (issue, remove, add) => ghx.editLabels(ghCtx, issue, remove, add),
+    ensureLabel: async (name) => {
+      try {
+        await ghx.ensureLabel(ghCtx, name);
+      } catch {
+        // best-effort: a missing typed label must never fail the close.
+      }
+    },
+    comment: (issue, body) => ghx.comment(ghCtx, issue, body),
+    editBody: (issue, body) => ghx.editBody(ghCtx, issue, body),
+    close: (issue) => ghx.closeIssue(ghCtx, issue),
+    listByLabel: (label) => ghx.listByLabel(ghCtx, label),
+    issueClosed: (n) => ghx.issueClosed(ghCtx, n),
+    issueReference: (n) => ghx.issueReference(ghCtx, n),
+    // Trust-gate provenance (#621): author + promoter label actor, read from the
+    // issue timeline. The promoter label is the LANE the claim was selected under
+    // (`ready-for-agent`, `lane:go`, `lane:scout`) so a /go/scout issue resolves its
+    // maintainer minter, not an absent `ready-for-agent` actor (#2602, #1101).
+    issueTrust: (issue, promoterLabel) => ghx.issueTrust(ghCtx, issue, promoterLabel),
+    // Repository visibility (#1101): folds into the trust policy so a PUBLIC
+    // repo with no allowlist fails closed while a private one stays permissive.
+    repoVisibility: () => ghx.repoVisibility(ghCtx),
+    // Dynamic-base trust signals (write-access / CODEOWNERS) for the fail-closed author + promoter check (#1101, reusing #747).
+    actorTrustSignals: (actor) => ghx.actorTrustSignals(ghCtx, actor),
+    externalApprovalActors: (issue) => ghx.externalApprovalActors(ghCtx, issue), // /approve-external authors, trust-resolved on claim (#2603)
+    // HITL decision card (#935, S11a): post/update the card on escalation.
+    // Best-effort: errors are caught in routeRecovery so they never block
+    // the recovery path. Runs in the worktree root so gh resolves the repo.
+    renderDecisionCard: async (issue) => {
+      const { hitlCardCommand } = await import("../../hitl-card.js");
+      await hitlCardCommand(["render", `--issue=${issue}`, `--root=${ghCtx.cwd}`]);
+    },
+  };
+}
+
+/**
+ * Claim-arbiter port (ADR 0066): the atomic GitHub-native claim surface. Numeric
+ * comment ids (via `gh api`) are the cross-host total order.
+ */
+export function buildClaimGhPort(ghCtx: GhContext): NonNullable<ProcessIssueDeps["claimGh"]> {
+  return {
+    postClaim: (issue, body) => ghx.postClaimComment(ghCtx, issue, body),
+    listClaims: (issue) => ghx.listClaimComments(ghCtx, issue),
+    concede: async (issue, body) => {
+      try {
+        await ghx.postClaimComment(ghCtx, issue, body);
+      } catch {
+        // best-effort: a failed concede ages out via the staleness predicate.
+      }
+    },
+    // One human-visible audit comment when we recover a stale cross-host claim
+    // (#627). Best-effort: a failed audit never abandons the won claim.
+    audit: async (issue, body) => {
+      try {
+        await ghx.comment(ghCtx, issue, body);
+      } catch {
+        // best-effort observability; the claim is already won.
+      }
+    },
+  };
+}
+
+/**
+ * PR-review ports: the two evidence surfaces that post through `ReviewGh` rather
+ * than the plain issue API. Same single context as the issue port.
+ */
+export function buildReviewPorts(ghCtx: GhContext): Required<
+  Pick<ProcessIssueDeps, "postBackpressureReview" | "postAdversarialReview">
+> {
+  return {
+    // Non-blocking backpressure evidence review (#1279): render the executed
+    // backpressure checks as ONE aggregated `event: COMMENT` review on the PR.
+    // Reuses ReviewGh.postReview (COMMENT-only, no APPROVE/REQUEST_CHANGES) with
+    // no inline comments — purely a top-level evidence ledger. Observability only;
+    // it never touches the merge/park decision.
+    postBackpressureReview: (pr, body) =>
+      buildReviewGh(ghCtx).postReview(pr, { summary: body, comments: [] }),
+    postAdversarialReview: async ({ pr, issue, body }) => {
+      await buildReviewGh(ghCtx).comment(pr, body);
+      await ghx.comment(ghCtx, issue, body);
+    },
+  };
+}

--- a/apps/dev/src/commands/run/ports/git.ts
+++ b/apps/dev/src/commands/run/ports/git.ts
@@ -1,0 +1,32 @@
+import type { ProcessIssueDeps } from "../../../core/process-issue.js";
+import * as gitx from "../../../runtime/git.js";
+import type { GitContext } from "../../../runtime/git.js";
+
+/**
+ * Git ports: `git`, `mergeExec`, and `remoteGit` all bind the SAME `gitCtx`.
+ * The remote name is the one non-context scalar the branch primitives need, so
+ * it travels with the context instead of being read off a repo context here.
+ */
+export function buildGitPorts(
+  gitCtx: GitContext,
+  remote: string,
+): Required<Pick<ProcessIssueDeps, "git" | "mergeExec" | "remoteGit">> {
+  return {
+    git: {
+      headShortSha: () => gitx.headShortSha(gitCtx),
+      deleteLocalBranch: (branch) => gitx.deleteLocalBranch(gitCtx, branch),
+      // Make the resolved base ref current before sandcastle forks off it
+      // (ADR 0031/#1380). Online workers fork from freshly-fetched
+      // origin/<base>; offline workers may use the local base only when it is not
+      // behind the last-known origin tip.
+      resolveFreshBase: (input) => gitx.resolveFreshBase(gitCtx, input),
+      fetchBase: async (base) => {
+        await gitx.gitExec(gitCtx)(["fetch", remote, base]);
+      },
+      prepareFreshWorkerBranch: (input) =>
+        gitx.prepareFreshWorkerBranch(gitCtx, { ...input, remote }),
+    },
+    mergeExec: gitx.mergeExec(gitCtx),
+    remoteGit: gitx.gitExec(gitCtx),
+  };
+}

--- a/apps/dev/src/commands/run/ports/hooks.ts
+++ b/apps/dev/src/commands/run/ports/hooks.ts
@@ -1,0 +1,37 @@
+import type { ProcessIssueDeps } from "../../../core/process-issue.js";
+import type { ConfigValues } from "../../../core/config.js";
+import type { Runner } from "../../../types/runner.js";
+import { resolveHooks, type ResolveHooksOptions } from "../../../core/hook-config.js";
+import { makeHookExec, makeHookResolveOptions, hookEnv } from "../../../runtime/hooks.js";
+
+export interface HooksPortContext {
+  config: ConfigValues;
+  root: string;
+  repo: string;
+  runner: Runner;
+  slot?: number;
+  /** Injected only by tests that need to pin the resolve options. */
+  resolveOptions?: ResolveHooksOptions;
+}
+
+/**
+ * Lifecycle-hook port: config + the repo it is anchored to. `resolveHooks` runs
+ * once here to surface a malformed-hook-name error early; process-issue
+ * re-resolves per run from the same config + options.
+ */
+export function buildHooks({
+  config,
+  root,
+  repo,
+  runner,
+  slot,
+  resolveOptions = makeHookResolveOptions(root),
+}: HooksPortContext): NonNullable<ProcessIssueDeps["hooks"]> {
+  resolveHooks(config, resolveOptions);
+  return {
+    config,
+    resolveOptions,
+    exec: makeHookExec(root),
+    env: hookEnv(repo, root, slot, runner),
+  };
+}

--- a/apps/dev/src/commands/run/ports/lookups.ts
+++ b/apps/dev/src/commands/run/ports/lookups.ts
@@ -1,0 +1,133 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ProcessIssueDeps } from "../../../core/process-issue.js";
+import type { ConfigValues } from "../../../core/config.js";
+import { getConfig } from "../../../core/config.js";
+import * as ghx from "../../../runtime/gh.js";
+import * as gitx from "../../../runtime/git.js";
+import type { GhContext } from "../../../runtime/gh.js";
+import type { GitContext } from "../../../runtime/git.js";
+import { execTool, type ExecFn } from "../../../runtime/exec.js";
+import type { AfkPaths } from "../../../runtime/wire.js";
+import { branchLockPath, readLockedBranch, isLocked } from "../../../runtime/lock.js";
+import { parseTrustPolicy, resolveActorTrust } from "../../../core/trust-gate.js";
+import { buildHandoffEnrichment } from "../../../core/handoff-enrichment.js";
+import { lookupPrevFailureContext } from "../../../core/prev-failure.js";
+
+export interface LookupsPortContext {
+  ghCtx: GhContext;
+  gitCtx: GitContext;
+  paths: AfkPaths;
+  config: ConfigValues;
+  exec?: ExecFn;
+}
+
+/**
+ * Read-only lookup port — the ONE genuinely multi-context builder: base
+ * resolution reads the lock file + config, the guidance channel reads gh, and
+ * the branch/diff probes read git. Every other builder binds a single context.
+ */
+export function buildLookups({
+  ghCtx,
+  gitCtx,
+  paths,
+  config,
+  exec,
+}: LookupsPortContext): NonNullable<ProcessIssueDeps["lookups"]> {
+  const root = ghCtx.cwd;
+  const lockPath = branchLockPath(root);
+  // Trust policy for the guidance-channel source-trust projection (issue #1100).
+  const trustPolicy = parseTrustPolicy(config);
+
+  return {
+    base: {
+      readLockedBranch: () => readLockedBranch(lockPath),
+      configLockedBranch: getConfig(config, "dev.lock.branch") || undefined,
+      configTrunk:
+        (process.env.RED_AFK_TRUNK ?? "").trim() ||
+        getConfig(config, "dev.trunk") ||
+        undefined,
+      fetchIssueBody: (n) => ghx.issueBody(ghCtx, n),
+    },
+    isLocked: () => isLocked(lockPath),
+    // Source-trust classification for the guidance channel (issue #1100): each
+    // comment's author is resolved through the `resolveActorTrust` primitive so
+    // only a trusted-source directive can become authoritative `<human-guidance>`.
+    comments: (issue) =>
+      ghx.issueComments(ghCtx, issue, (actor) =>
+        resolveActorTrust(trustPolicy, actor, (login) => ghx.actorTrustSignals(ghCtx, login)),
+      ),
+    issueUrl: (issue) => ghx.issueUrl(ghCtx, issue),
+    // The ONE ADR 0103 carry-forward: on an automatic re-queue, surface the
+    // previous failure reason + its Envelope reference in the next prompt.
+    prevFailureContext: (issue) => lookupPrevFailureContext(paths.tmpDir, issue),
+    handoffEnrichment: ({ issue: _issue, ...metadata }) =>
+      buildHandoffEnrichment(metadata, {
+        readText: (path) => readFile(join(root, path), "utf8"),
+        gitLog: async (paths) => {
+          if (paths.length === 0) return "";
+          const run = exec ?? execTool;
+          const result = await run(
+            "git",
+            ["log", "-n", "24", "--format=%H%x1f%s%x1f%b%x1e", "--", ...paths],
+            { cwd: root, timeoutMs: 5_000, maxBuffer: 512 * 1024 },
+          );
+          return result.code === 0 ? result.stdout : "";
+        },
+      }),
+    changedFiles: (branch, base) => gitx.changedFiles(gitCtx, branch, base),
+    diffstat: (branch, base) => gitx.diffstat(gitCtx, branch, base),
+    // FIX E: confirm the sandcastle worker branch actually landed on the host
+    // before the merge gate. Try once, fetch on a miss, then re-check — a still
+    // -absent branch escalates instead of silently bypassing feedback.
+    branchPresent: async (branch) => {
+      if (await gitx.branchExists(gitCtx, branch)) return true;
+      await gitx.fetchBranch(gitCtx, branch);
+      return gitx.branchExists(gitCtx, branch);
+    },
+    // Goal predicate own-merge signal (ADR 0057): true iff the worker branch
+    // already landed in <base>, distinguishing own-merge close (done) from a
+    // foreign close (claim-lost) when the guard observes the issue CLOSED.
+    branchMerged: (branch, base) => gitx.branchMergedInto(gitCtx, branch, base),
+    // Branch-resume discovery (issue #2397): list all remote afk/* refs so the
+    // lifecycle can detect a prior pushed branch and resume instead of rebuilding.
+    discoverBranches: () => gitx.listRemoteBranches(gitCtx, "afk/"),
+    // Attempt-adoption sanity check (#2416): one cheap open-PR census before
+    // any agent run. The lifecycle owns exact body/head matching and adoption.
+    discoverOpenPullRequests: async () => {
+      const run = exec ?? execTool;
+      const result = await run(
+        "gh",
+        [
+          "pr",
+          "list",
+          "--repo",
+          ghCtx.repo,
+          "--state",
+          "open",
+          "--limit",
+          "100",
+          "--json",
+          "number,headRefName,body",
+        ],
+        { cwd: root },
+      );
+      if (result.code !== 0) return [];
+      try {
+        const rows = JSON.parse(result.stdout || "[]") as unknown;
+        if (!Array.isArray(rows)) return [];
+        return rows
+          .map((row) => row as { number?: unknown; headRefName?: unknown; body?: unknown })
+          .map((row) => ({
+            number: Number(row.number ?? 0),
+            headRefName: String(row.headRefName ?? ""),
+            body: typeof row.body === "string" ? row.body : undefined,
+          }))
+          .filter((row) => row.number > 0 && row.headRefName.length > 0);
+      } catch {
+        return [];
+      }
+    },
+  };
+}

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -9,11 +9,9 @@ import type { LaneIdleStallConfig } from "../../core/lane-idle-reaper.js";
 import { workerPidFile } from "../../core/worker-paths.js";
 import { makeClaimLock } from "./claim-lease.js";
 import { Output } from "@reddb-io/red-castle";
-import * as ghx from "../../runtime/gh.js";
 import * as gitx from "../../runtime/git.js";
 import * as fsx from "../../runtime/fs.js";
 import type { GhContext } from "../../runtime/gh.js";
-import { buildReviewGh } from "../../runtime/review-gh.js";
 import type { GitContext } from "../../runtime/git.js";
 import { execTool, type ExecFn } from "../../runtime/exec.js";
 import { getConfig, loadConfig, readBackpressure, readPostWorkerFormat, readValidationResourceBudget, resolveTier, resolveCiTimeoutSeconds } from "../../core/config.js";
@@ -24,10 +22,8 @@ import {
 } from "../../core/adversarial-review.js";
 import { defaultSandcastleDeps, DEFAULT_MAX_ITERATIONS } from "../../core/execution.js";
 import { resolveSandboxImageName } from "../../core/execution/sandbox-image.js";
-import { parseTrustPolicy, resolveActorTrust } from "../../core/trust-gate.js";
 import { resolveNotesLoopConfig } from "../../core/notes-loop.js";
 import { resolveOutputShapingConfig } from "../../core/output-shaping.js";
-import { buildHandoffEnrichment } from "../../core/handoff-enrichment.js";
 import {
   classifyIssue,
   resolveReviewGate,
@@ -35,20 +31,16 @@ import {
 } from "../../core/issue-classifier.js";
 import { toAgentRunner } from "../../core/runner-spec.js";
 import { LABEL_READY_FOR_REVIEW } from "../../core/triage-labels.js";
-import { resolveHooks } from "../../core/hook-config.js";
 import { createEnginePaths, createFileHealLedgerStore } from "@reddb-io/red-castle/engine";
-import { lookupPrevFailureContext } from "../../core/prev-failure.js";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { pluginEnabledInConfig } from "@reddb-io/shared/plugin-gate.js";
 import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
 import { configFile } from "@reddb-io/shared/red-paths.js";
 import { spawn } from "node:child_process";
 import { claudeSpawnArgs, codexSpawnArgs } from "../../core/runner-spawn.js";
 import { createLandLock } from "../../runtime/land-lock.js";
-import { branchLockPath, readLockedBranch, isLocked } from "../../runtime/lock.js";
-import { makeHookExec, makeHookResolveOptions, hookEnv } from "../../runtime/hooks.js";
-import { makeFeedbackWorktree, type FeedbackWorktree } from "../../runtime/feedback-worktree.js";
+import type { FeedbackWorktree } from "../../runtime/feedback-worktree.js";
 import { deathCauseForRecoveredWorker } from "../../core/process-safety.js";
 import { join } from "node:path";
 import { hostFingerprintPrefix } from "../../core/host-identity.js";
@@ -61,10 +53,17 @@ import { resolveImplementerPluginRoots } from "../../runtime/implementer-environ
 import { createCastleWorkerLaneBridge } from "../../core/castle-worker-lane-bridge.js";
 import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../../core/claim-staleness.js";
 
+import type { CurrentAttempt } from "./attempt.js";
 import { deriveActivity } from "./activity.js";
 import { makeImplementerRunAgent } from "./implementer-run-agent.js";
 import { makeAgentConflictResolver, makeMechanicalConflictResolver } from "./reconcile.js";
 import { runLinkedSubagent } from "./linked-subagent.js";
+import { buildClaimGhPort, buildGhPort, buildReviewPorts } from "./ports/gh.js";
+import { buildGitPorts } from "./ports/git.js";
+import { buildFsPort } from "./ports/fs.js";
+import { buildHooks } from "./ports/hooks.js";
+import { buildEnvelopePort } from "./ports/envelope.js";
+import { buildLookups } from "./ports/lookups.js";
 import {
   castleWorktreeUnder,
   decodeLocMemoSnapshot,
@@ -80,21 +79,40 @@ export function parseSlot(val: string | undefined): number | undefined {
   return Number.isFinite(n) && n >= 0 ? n : undefined;
 }
 
-export function buildProcessDeps(
-  ctx: RepoContext,
-  model: string,
-  sandbox: ReturnType<typeof resolveRunSettings>["sandbox"],
-  feedback: FeedbackWorktree,
-  current: CurrentAttempt,
-  fallbackRunner: boolean,
-  runner: Runner,
-  exec?: ExecFn,
-  maxIterations?: number,
-  laneIdle?: LaneIdleStallConfig,
-  inlineVerifyCommand?: string,
-  goVerifyRetries?: number,
+/** Everything `buildProcessDeps` needs, named. Replaces the 13 positional
+ * params the assembly used to take — a call site could silently swap two
+ * same-typed neighbours (model/workerId, inlineVerifyCommand/…) and typecheck. */
+export interface BuildProcessDepsOptions {
+  ctx: RepoContext;
+  model: string;
+  sandbox: ReturnType<typeof resolveRunSettings>["sandbox"];
+  feedback: FeedbackWorktree;
+  current: CurrentAttempt;
+  fallbackRunner: boolean;
+  runner: Runner;
+  exec?: ExecFn;
+  maxIterations?: number;
+  laneIdle?: LaneIdleStallConfig;
+  inlineVerifyCommand?: string;
+  goVerifyRetries?: number;
+  workerId?: string;
+}
+
+export function buildProcessDeps({
+  ctx,
+  model,
+  sandbox,
+  feedback,
+  current,
+  fallbackRunner,
+  runner,
+  exec,
+  maxIterations,
+  laneIdle,
+  inlineVerifyCommand,
+  goVerifyRetries,
   workerId = "unknown",
-): ProcessIssueDeps {
+}: BuildProcessDepsOptions): ProcessIssueDeps {
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo, exec };
   const gitCtx: GitContext = { cwd: ctx.root, exec, ghProbeTimeoutMs: LANDING_GH_PROBE_TIMEOUT_MS };
   const paths = afkPaths(ctx.root);
@@ -103,7 +121,6 @@ export function buildProcessDeps(
     workerId,
     attemptDir: () => current.attemptDir,
   });
-  const lockPath = branchLockPath(ctx.root);
   // Per-agentic-iteration boundary tracking (observability): when sandcastle's
   // re-invocation count (event.iteration) ticks, emit "iteration N ended/started"
   // markers. Reset per attempt — a new attempt's run restarts at iteration 1
@@ -140,8 +157,6 @@ export function buildProcessDeps(
     repoRoot: ctx.root,
     env: process.env,
   });
-  // Trust policy for the guidance-channel source-trust projection (issue #1100).
-  const trustPolicy = parseTrustPolicy(config);
   // Repo-level container image for the isolation path (#2340) — resolved off the
   // repo root, never off the per-attempt worktree, so the tag is prebuildable.
   const sandboxImage = resolveSandboxImageName({
@@ -149,10 +164,6 @@ export function buildProcessDeps(
     configured: getConfig(config, "afk.sandbox_image"),
     envOverride: process.env.RED_AFK_SANDBOX_IMAGE,
   });
-  const resolveOptions = makeHookResolveOptions(ctx.root);
-  // resolveHooks runs once here to surface a malformed-hook-name error early;
-  // process-issue re-resolves per run from the same config + options.
-  resolveHooks(config, resolveOptions);
 
   // Merge-gate policy (ADR 0048). Default off → the unlocked admin-merge ignores
   // advisory review checks (drift-guard + in-process backpressure stay the
@@ -254,63 +265,8 @@ export function buildProcessDeps(
       : backpressureCommands;
 
   return {
-    gh: {
-      viewLabels: (issue) => ghx.viewLabels(ghCtx, issue),
-      editLabels: (issue, remove, add) => ghx.editLabels(ghCtx, issue, remove, add),
-      ensureLabel: async (name) => {
-        try {
-          await ghx.ensureLabel(ghCtx, name);
-        } catch {
-          // best-effort: a missing typed label must never fail the close.
-        }
-      },
-      comment: (issue, body) => ghx.comment(ghCtx, issue, body),
-      editBody: (issue, body) => ghx.editBody(ghCtx, issue, body),
-      close: (issue) => ghx.closeIssue(ghCtx, issue),
-      listByLabel: (label) => ghx.listByLabel(ghCtx, label),
-      issueClosed: (n) => ghx.issueClosed(ghCtx, n),
-      issueReference: (n) => ghx.issueReference(ghCtx, n),
-      // Trust-gate provenance (#621): author + promoter label actor, read from the
-      // issue timeline. The promoter label is the LANE the claim was selected under
-      // (`ready-for-agent`, `lane:go`, `lane:scout`) so a /go/scout issue resolves its
-      // maintainer minter, not an absent `ready-for-agent` actor (#2602, #1101).
-      issueTrust: (issue, promoterLabel) => ghx.issueTrust(ghCtx, issue, promoterLabel),
-      // Repository visibility (#1101): folds into the trust policy so a PUBLIC
-      // repo with no allowlist fails closed while a private one stays permissive.
-      repoVisibility: () => ghx.repoVisibility(ghCtx),
-      // Dynamic-base trust signals (write-access / CODEOWNERS) for the fail-closed author + promoter check (#1101, reusing #747).
-      actorTrustSignals: (actor) => ghx.actorTrustSignals(ghCtx, actor),
-      externalApprovalActors: (issue) => ghx.externalApprovalActors(ghCtx, issue), // /approve-external authors, trust-resolved on claim (#2603)
-      // HITL decision card (#935, S11a): post/update the card on escalation.
-      // Best-effort: errors are caught in routeRecovery so they never block
-      // the recovery path. Runs in the worktree root so gh resolves the repo.
-      renderDecisionCard: async (issue) => {
-        const { hitlCardCommand } = await import("../hitl-card.js");
-        await hitlCardCommand(["render", `--issue=${issue}`, `--root=${ctx.root}`]);
-      },
-    },
-    claimGh: {
-      // ADR 0066: the atomic GitHub-native claim arbiter. Numeric comment ids
-      // (via `gh api`) are the cross-host total order.
-      postClaim: (issue, body) => ghx.postClaimComment(ghCtx, issue, body),
-      listClaims: (issue) => ghx.listClaimComments(ghCtx, issue),
-      concede: async (issue, body) => {
-        try {
-          await ghx.postClaimComment(ghCtx, issue, body);
-        } catch {
-          // best-effort: a failed concede ages out via the staleness predicate.
-        }
-      },
-      // One human-visible audit comment when we recover a stale cross-host claim
-      // (#627). Best-effort: a failed audit never abandons the won claim.
-      audit: async (issue, body) => {
-        try {
-          await ghx.comment(ghCtx, issue, body);
-        } catch {
-          // best-effort observability; the claim is already won.
-        }
-      },
-    },
+    gh: buildGhPort(ghCtx),
+    claimGh: buildClaimGhPort(ghCtx),
     // Cross-host stale-claim recovery (#627, ADR 0066): a claim whose owner
     // stopped refreshing past `cadence × (tolerance + 1)` is presumed dead and
     // released by this sweep. The clock is sampled once per issue at deps build;
@@ -327,31 +283,8 @@ export function buildProcessDeps(
     recoveredWorkerDeathCause: (recoveredWorker) =>
       deathCauseForRecoveredWorker(paths.tmpDir, recoveredWorker, hostFingerprintPrefix()),
     claimLock: makeClaimLock(paths.tmpDir, workerId),
-    fs: {
-      ensureAttemptDir: (dir) => fsx.ensureDir(dir),
-      writeHandoff: (path, content) => fsx.writeHandoff(path, content),
-      readText: (path) => fsx.readText(path),
-      // $ITER_DIR/validation.jsonl — the machine-readable feedback sidecar the
-      // Memory bridge consumes (SKILL.md §Validation Sidecar).
-      writeValidationSidecar: (path, lines) => fsx.writeValidationSidecar(path, lines),
-      completionSweep: (issue) => fsx.completionSweep(paths.workersRoot, issue),
-    },
-    git: {
-      headShortSha: () => gitx.headShortSha(gitCtx),
-      deleteLocalBranch: (branch) => gitx.deleteLocalBranch(gitCtx, branch),
-      // Make the resolved base ref current before sandcastle forks off it
-      // (ADR 0031/#1380). Online workers fork from freshly-fetched
-      // origin/<base>; offline workers may use the local base only when it is not
-      // behind the last-known origin tip.
-      resolveFreshBase: (input) => gitx.resolveFreshBase(gitCtx, input),
-      fetchBase: async (base) => {
-        await gitx.gitExec(gitCtx)(["fetch", ctx.remote, base]);
-      },
-      prepareFreshWorkerBranch: (input) =>
-        gitx.prepareFreshWorkerBranch(gitCtx, { ...input, remote: ctx.remote }),
-    },
-    mergeExec: gitx.mergeExec(gitCtx),
-    remoteGit: gitx.gitExec(gitCtx),
+    fs: buildFsPort(paths),
+    ...buildGitPorts(gitCtx, ctx.remote),
     // ADR 0103: no exit-time salvage and no exit receipt. Work reaches origin as
     // the agent commits (the continuous-push hook, issue #191); a worktree still
     // dirty when the worker exits is disposable, and the terminal Envelope plus
@@ -366,19 +299,9 @@ export function buildProcessDeps(
     backpressure: feedback.backpressure,
     backpressureCommands: mergedBackpressureCommands,
     outputShaping,
-    // Non-blocking backpressure evidence review (#1279): render the executed
-    // backpressure checks as ONE aggregated `event: COMMENT` review on the PR.
-    // Reuses ReviewGh.postReview (COMMENT-only, no APPROVE/REQUEST_CHANGES) with
-    // no inline comments — purely a top-level evidence ledger. Observability only;
-    // it never touches the merge/park decision.
-    postBackpressureReview: (pr, body) =>
-      buildReviewGh(ghCtx).postReview(pr, { summary: body, comments: [] }),
+    ...buildReviewPorts(ghCtx),
     adversarialReview,
     extractAdversarialReview,
-    postAdversarialReview: async ({ pr, issue, body }) => {
-      await buildReviewGh(ghCtx).comment(pr, body);
-      await ghx.comment(ghCtx, issue, body);
-    },
     goVerifyRetries,
     stallConvergenceBudget: (() => {
       const raw = getConfig(config, "afk.stallConvergenceBudget");
@@ -539,114 +462,15 @@ export function buildProcessDeps(
       return added.ok ? dest : null;
     },
     removeRebaseWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
-    hooks: {
+    hooks: buildHooks({
       config,
-      resolveOptions,
-      exec: makeHookExec(ctx.root),
-      env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT), runner),
-    },
-    lookups: {
-      base: {
-        readLockedBranch: () => readLockedBranch(lockPath),
-        configLockedBranch: getConfig(config, "dev.lock.branch") || undefined,
-        configTrunk:
-          (process.env.RED_AFK_TRUNK ?? "").trim() ||
-          getConfig(config, "dev.trunk") ||
-          undefined,
-        fetchIssueBody: (n) => ghx.issueBody(ghCtx, n),
-      },
-      isLocked: () => isLocked(lockPath),
-      // Source-trust classification for the guidance channel (issue #1100): each
-      // comment's author is resolved through the `resolveActorTrust` primitive so
-      // only a trusted-source directive can become authoritative `<human-guidance>`.
-      comments: (issue) =>
-        ghx.issueComments(ghCtx, issue, (actor) =>
-          resolveActorTrust(trustPolicy, actor, (login) => ghx.actorTrustSignals(ghCtx, login)),
-        ),
-      issueUrl: (issue) => ghx.issueUrl(ghCtx, issue),
-      // The ONE ADR 0103 carry-forward: on an automatic re-queue, surface the
-      // previous failure reason + its Envelope reference in the next prompt.
-      prevFailureContext: (issue) => lookupPrevFailureContext(paths.tmpDir, issue),
-      handoffEnrichment: ({ issue: _issue, ...metadata }) =>
-        buildHandoffEnrichment(metadata, {
-          readText: (path) => readFile(join(ctx.root, path), "utf8"),
-          gitLog: async (paths) => {
-            if (paths.length === 0) return "";
-            const run = exec ?? execTool;
-            const result = await run(
-              "git",
-              ["log", "-n", "24", "--format=%H%x1f%s%x1f%b%x1e", "--", ...paths],
-              { cwd: ctx.root, timeoutMs: 5_000, maxBuffer: 512 * 1024 },
-            );
-            return result.code === 0 ? result.stdout : "";
-          },
-        }),
-      changedFiles: (branch, base) => gitx.changedFiles(gitCtx, branch, base),
-      diffstat: (branch, base) => gitx.diffstat(gitCtx, branch, base),
-      // FIX E: confirm the sandcastle worker branch actually landed on the host
-      // before the merge gate. Try once, fetch on a miss, then re-check — a still
-      // -absent branch escalates instead of silently bypassing feedback.
-      branchPresent: async (branch) => {
-        if (await gitx.branchExists(gitCtx, branch)) return true;
-        await gitx.fetchBranch(gitCtx, branch);
-        return gitx.branchExists(gitCtx, branch);
-      },
-      // Goal predicate own-merge signal (ADR 0057): true iff the worker branch
-      // already landed in <base>, distinguishing own-merge close (done) from a
-      // foreign close (claim-lost) when the guard observes the issue CLOSED.
-      branchMerged: (branch, base) => gitx.branchMergedInto(gitCtx, branch, base),
-      // Branch-resume discovery (issue #2397): list all remote afk/* refs so the
-      // lifecycle can detect a prior pushed branch and resume instead of rebuilding.
-      discoverBranches: () => gitx.listRemoteBranches(gitCtx, "afk/"),
-      // Attempt-adoption sanity check (#2416): one cheap open-PR census before
-      // any agent run. The lifecycle owns exact body/head matching and adoption.
-      discoverOpenPullRequests: async () => {
-        const run = exec ?? execTool;
-        const result = await run(
-          "gh",
-          [
-            "pr",
-            "list",
-            "--repo",
-            ctx.repo,
-            "--state",
-            "open",
-            "--limit",
-            "100",
-            "--json",
-            "number,headRefName,body",
-          ],
-          { cwd: ctx.root },
-        );
-        if (result.code !== 0) return [];
-        try {
-          const rows = JSON.parse(result.stdout || "[]") as unknown;
-          if (!Array.isArray(rows)) return [];
-          return rows
-            .map((row) => row as { number?: unknown; headRefName?: unknown; body?: unknown })
-            .map((row) => ({
-              number: Number(row.number ?? 0),
-              headRefName: String(row.headRefName ?? ""),
-              body: typeof row.body === "string" ? row.body : undefined,
-            }))
-            .filter((row) => row.number > 0 && row.headRefName.length > 0);
-        } catch {
-          return [];
-        }
-      },
-    },
-    envelope: {
-      git: gitx.gitExec(gitCtx),
-      poster: async (issue, body) => {
-        await ghx.comment(ghCtx, issue, body);
-        return true;
-      },
-      // Markers/posted land in the CURRENT attempt dir, set per issue by
-      // buildProcessInput before each processIssue call.
-      writeMarkers: (markers) => fsx.writeFailureMarkers(current.attemptDir, markers),
-      writePosted: (posted) => fsx.writeEnvelopePosted(current.attemptDir, posted),
-      issueReference: (issue) => ghx.issueReference(ghCtx, issue),
-    },
+      root: ctx.root,
+      repo: ctx.repo,
+      runner,
+      slot: parseSlot(process.env.RED_AFK_SLOT),
+    }),
+    lookups: buildLookups({ ghCtx, gitCtx, paths, config, exec }),
+    envelope: buildEnvelopePort(ghCtx, gitCtx, current),
     nowEpoch: () => Math.floor(Date.now() / 1000),
     nowIso: () => new Date().toISOString(),
     // The per-iteration afk.log heartbeat boundary lives in the attempt dir.
@@ -1149,9 +973,4 @@ function findOnPath(bin: string, pathValue: string | undefined): string | undefi
   return undefined;
 }
 
-/** Per-issue mutable context the session-scoped process deps close over — the
- * attempt dir the envelope markers / iter-log write into. buildProcessInput
- * resets it before each processIssue call. */
-export interface CurrentAttempt {
-  attemptDir: string;
-}
+export type { CurrentAttempt } from "./attempt.js";

--- a/apps/dev/tests/process-deps-ports.test.ts
+++ b/apps/dev/tests/process-deps-ports.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildClaimGhPort, buildGhPort, buildReviewPorts } from "../src/commands/run/ports/gh.js";
+import { buildGitPorts } from "../src/commands/run/ports/git.js";
+import { buildFsPort } from "../src/commands/run/ports/fs.js";
+import { buildHooks } from "../src/commands/run/ports/hooks.js";
+import { buildEnvelopePort } from "../src/commands/run/ports/envelope.js";
+import { buildLookups } from "../src/commands/run/ports/lookups.js";
+import { afkPaths } from "../src/runtime/wire.js";
+import { loadConfig } from "../src/core/config.js";
+import { makeHookResolveOptions } from "../src/runtime/hooks.js";
+import type { GhContext } from "../src/runtime/gh.js";
+import type { GitContext } from "../src/runtime/git.js";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+
+/**
+ * Per-context port-builder units (#2667). `buildProcessDeps` used to assemble
+ * every port inline from 13 positional params, so a mis-bound closure was only
+ * caught — if at all — by the whole-assembly wiring test. Each builder now takes
+ * ONE context, and each is driven here over a fake context: a recording fake
+ * exec for the gh/git surfaces, a tmpdir-rooted path set for the fs surfaces.
+ * The command trace is the assertion: a wrong-cwd or no-op closure makes it wrong.
+ */
+
+interface TraceEntry {
+  cmd: string;
+  args: string[];
+  cwd: string | undefined;
+}
+
+function makeFakeExec(reply: (cmd: string, joined: string) => string = () => ""): {
+  exec: ExecFn;
+  trace: TraceEntry[];
+} {
+  const trace: TraceEntry[] = [];
+  const exec: ExecFn = (cmd, args, opts) => {
+    trace.push({ cmd, args: [...args], cwd: opts?.cwd });
+    const out: ExecOutput = { code: 0, stdout: reply(cmd, args.join(" ")), stderr: "" };
+    return Promise.resolve(out);
+  };
+  return { exec, trace };
+}
+
+function ghContext(exec: ExecFn, root = "/repo"): GhContext {
+  return { cwd: root, repo: "acme/widgets", exec };
+}
+
+function gitContext(exec: ExecFn, root = "/repo"): GitContext {
+  return { cwd: root, exec };
+}
+
+describe("buildGhPort", () => {
+  it("binds every issue closure to the one gh context", async () => {
+    const { exec, trace } = makeFakeExec((_cmd, joined) =>
+      joined.includes("--json labels") ? JSON.stringify({ labels: [{ name: "running" }] }) : "",
+    );
+    const gh = buildGhPort(ghContext(exec));
+
+    expect(await gh.viewLabels(42)).toEqual(["running"]);
+    await gh.comment(42, "hello");
+    await gh.close(42);
+
+    expect(trace.every((entry) => entry.cmd === "gh" && entry.cwd === "/repo")).toBe(true);
+    expect(trace.every((entry) => entry.args.join(" ").includes("acme/widgets"))).toBe(true);
+  });
+
+  it("swallows an ensureLabel failure so a missing typed label never fails the close", async () => {
+    const gh = buildGhPort(ghContext(() => Promise.reject(new Error("gh down"))));
+    await expect(gh.ensureLabel("type:bug")).resolves.toBeUndefined();
+  });
+});
+
+describe("buildClaimGhPort", () => {
+  it("posts claims through the same gh context", async () => {
+    const { exec, trace } = makeFakeExec(() => "1234567");
+    const claimGh = buildClaimGhPort(ghContext(exec));
+
+    await claimGh.postClaim(42, "claiming");
+
+    expect(trace[0]?.cmd).toBe("gh");
+    expect(trace[0]?.cwd).toBe("/repo");
+  });
+
+  it("swallows concede and audit failures — both are best-effort", async () => {
+    const claimGh = buildClaimGhPort(ghContext(() => Promise.reject(new Error("gh down"))));
+    await expect(
+      (async () => {
+        await claimGh.concede(42, "conceding");
+        await claimGh.audit?.(42, "recovered");
+      })(),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("buildReviewPorts", () => {
+  it("posts the backpressure evidence as a COMMENT review on the PR", async () => {
+    const { exec, trace } = makeFakeExec();
+    const { postBackpressureReview } = buildReviewPorts(ghContext(exec));
+
+    await postBackpressureReview(99, "backpressure ledger");
+
+    const issued = trace.map((entry) => entry.args.join(" ")).join(" | ");
+    expect(issued).toContain("99");
+    expect(trace.every((entry) => entry.cwd === "/repo")).toBe(true);
+  });
+});
+
+describe("buildGitPorts", () => {
+  it("fetches the base from the remote it was built with", async () => {
+    const { exec, trace } = makeFakeExec();
+    const { git } = buildGitPorts(gitContext(exec), "upstream");
+
+    await git.fetchBase?.("main");
+
+    expect(trace).toEqual([{ cmd: "git", args: ["fetch", "upstream", "main"], cwd: "/repo" }]);
+  });
+
+  it("binds mergeExec and remoteGit to the same git context", async () => {
+    const { exec, trace } = makeFakeExec();
+    const { mergeExec, remoteGit } = buildGitPorts(gitContext(exec, "/checkout"), "origin");
+
+    await remoteGit(["rev-parse", "HEAD"]);
+    await mergeExec(["status"]);
+
+    expect(trace.map((entry) => entry.cwd)).toEqual(["/checkout", "/checkout"]);
+  });
+});
+
+describe("buildFsPort", () => {
+  it("sweeps completed attempts under the workers root it was built with", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-ports-fs-"));
+    const paths = afkPaths(root);
+    const attemptDir = join(paths.workersRoot, "wPORT", "2667-a1");
+    mkdirSync(attemptDir, { recursive: true });
+    const fs = buildFsPort(paths);
+
+    await fs.writeHandoff(join(attemptDir, "handoff.md"), "handoff body");
+    expect(await fs.readText?.(join(attemptDir, "handoff.md"))).toBe("handoff body");
+
+    expect(await fs.completionSweep(2667)).toEqual([attemptDir]);
+    expect(await fs.readText?.(join(attemptDir, "handoff.md"))).toBeNull();
+  });
+});
+
+describe("buildHooks", () => {
+  it("carries the config through and stamps the repo anchor into the hook env", () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-ports-hooks-"));
+    const config = loadConfig(join(root, ".red", "config.yaml"), { warn: () => undefined });
+
+    const hooks = buildHooks({ config, root, repo: "acme/widgets", runner: "claude", slot: 3 });
+
+    expect(hooks.config).toBe(config);
+    expect(hooks.env).toMatchObject({
+      RED_AFK_REPO: "acme/widgets",
+      RED_AFK_ROOT: root,
+      RED_AFK_RUNNER: "claude",
+      RED_AFK_SLOT: "3",
+    });
+  });
+
+  it("honours injected resolve options and omits the slot when unslotted", () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-ports-hooks-opts-"));
+    const config = loadConfig(join(root, ".red", "config.yaml"), { warn: () => undefined });
+    const resolveOptions = makeHookResolveOptions(root);
+
+    const hooks = buildHooks({ config, root, repo: "acme/widgets", runner: "codex", resolveOptions });
+
+    expect(hooks.resolveOptions).toBe(resolveOptions);
+    expect(hooks.env?.RED_AFK_SLOT).toBeUndefined();
+  });
+});
+
+describe("buildEnvelopePort", () => {
+  it("writes its markers into the CURRENT attempt dir and posts through gh", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-ports-envelope-"));
+    const first = join(root, "attempt-1");
+    const current = { attemptDir: first };
+    const { exec, trace } = makeFakeExec();
+    const envelope = buildEnvelopePort(ghContext(exec, root), gitContext(exec, root), current);
+
+    expect(await envelope.poster(42, "envelope body")).toBe(true);
+    expect(trace[0]?.cmd).toBe("gh");
+
+    await envelope.writeMarkers({ failureReason: "stalled\n" });
+    expect(readFileSync(join(first, "failure.reason"), "utf8")).toBe("stalled\n");
+
+    // The port reads the attempt dir per call, so buildProcessInput can move it
+    // between issues without rebuilding the deps.
+    const second = join(root, "attempt-2");
+    current.attemptDir = second;
+    await envelope.writeMarkers({ failureReason: "next\n" });
+    expect(readFileSync(join(second, "failure.reason"), "utf8")).toBe("next\n");
+  });
+});
+
+describe("buildLookups", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves the base from config and probes branches through the git context", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-ports-lookups-"));
+    mkdirSync(join(root, ".red"), { recursive: true });
+    const configPath = join(root, ".red", "config.yaml");
+    writeFileSync(
+      configPath,
+      "plugins:\n  dev:\n    enabled: true\n    trunk: trunk-branch\n",
+      "utf8",
+    );
+    const config = loadConfig(configPath, { warn: () => undefined });
+    const { exec, trace } = makeFakeExec();
+    // RED_AFK_TRUNK outranks the configured trunk, so pin it empty to read the
+    // config path this case is about; the override itself is pinned below.
+    vi.stubEnv("RED_AFK_TRUNK", "");
+
+    const lookups = buildLookups({
+      ghCtx: ghContext(exec, root),
+      gitCtx: gitContext(exec, root),
+      paths: afkPaths(root),
+      config,
+      exec,
+    });
+
+    expect(lookups.base.configTrunk).toBe("trunk-branch");
+    expect(await lookups.isLocked()).toBe(false);
+
+
+    await lookups.changedFiles("afk/2667", "main");
+    expect(trace.at(-1)?.cwd).toBe(root);
+  });
+
+  it("censuses open PRs through the gh slug and drops malformed rows", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-ports-lookups-prs-"));
+    const rows = JSON.stringify([
+      { number: 12, headRefName: "afk/2667", body: "Refs #2667" },
+      { number: 0, headRefName: "afk/broken" },
+      { number: 13, headRefName: "" },
+    ]);
+    const { exec, trace } = makeFakeExec((cmd) => (cmd === "gh" ? rows : ""));
+
+    const lookups = buildLookups({
+      ghCtx: ghContext(exec, root),
+      gitCtx: gitContext(exec, root),
+      paths: afkPaths(root),
+      config: loadConfig(join(root, ".red", "config.yaml"), { warn: () => undefined }),
+      exec,
+    });
+
+    expect(await lookups.discoverOpenPullRequests?.(2667)).toEqual([
+      { number: 12, headRefName: "afk/2667", body: "Refs #2667" },
+    ]);
+    expect(trace.at(-1)?.args).toContain("acme/widgets");
+  });
+
+  it("returns an empty census when the gh probe fails", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-ports-lookups-fail-"));
+    const exec: ExecFn = () => Promise.resolve({ code: 1, stdout: "", stderr: "boom" });
+
+    const lookups = buildLookups({
+      ghCtx: ghContext(exec, root),
+      gitCtx: gitContext(exec, root),
+      paths: afkPaths(root),
+      config: loadConfig(join(root, ".red", "config.yaml"), { warn: () => undefined }),
+      exec,
+    });
+
+    expect(await lookups.discoverOpenPullRequests?.(2667)).toEqual([]);
+  });
+});

--- a/apps/dev/tests/run-structure.test.ts
+++ b/apps/dev/tests/run-structure.test.ts
@@ -1,31 +1,47 @@
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const MAX_LINES = 1200;
+/**
+ * Port-builder shape (#2667). This file used to assert a 1200-line budget over
+ * every run module — a proxy metric that said nothing about whether the
+ * assembly was actually decomposed, and that a single fat builder satisfies.
+ * The real invariant is CONTEXT ISOLATION: each `commands/run/ports/*` builder
+ * binds ONE effectful context, so `buildProcessDeps` is pure composition and a
+ * builder can be unit-tested over one fake. `lookups` and `envelope` are the
+ * two declared multi-context exceptions.
+ */
 
-function countLines(path: string): number {
-  return readFileSync(path, "utf8").split(/\r?\n/).length;
+const PORTS_DIR = join(process.cwd(), "src", "commands", "run", "ports");
+
+/** Which contexts each builder module is allowed to bind. */
+const ALLOWED_CONTEXTS: Record<string, readonly ("gh" | "git")[]> = {
+  "gh.ts": ["gh"],
+  "git.ts": ["git"],
+  "fs.ts": [],
+  "hooks.ts": [],
+  // The declared multi-context ports: the envelope posts (gh) the head it
+  // stamps (git), and lookups spans base/guidance/branch probes.
+  "envelope.ts": ["gh", "git"],
+  "lookups.ts": ["gh", "git"],
+};
+
+function boundContexts(source: string): ("gh" | "git")[] {
+  const bound: ("gh" | "git")[] = [];
+  if (/\bGhContext\b/.test(source)) bound.push("gh");
+  if (/\bGitContext\b/.test(source)) bound.push("git");
+  return bound;
 }
 
-function tsFilesUnder(dir: string): string[] {
-  return readdirSync(dir)
-    .flatMap((entry) => {
-      const path = join(dir, entry);
-      return statSync(path).isDirectory() ? tsFilesUnder(path) : [path];
-    })
-    .filter((path) => path.endsWith(".ts"));
-}
-
-describe("run command module shape", () => {
-  it("keeps the run barrel and split modules under the line budget", () => {
-    const commandDir = join(process.cwd(), "src", "commands");
-    const paths = [join(commandDir, "run.ts"), ...tsFilesUnder(join(commandDir, "run"))];
-
-    expect(
-      Object.fromEntries(paths.map((path) => [path.replace(`${commandDir}/`, ""), countLines(path)])),
-    ).toSatisfy((lineCounts: Record<string, number>) =>
-      Object.values(lineCounts).every((lineCount) => lineCount <= MAX_LINES),
+describe("run command port builders", () => {
+  it("binds one effectful context per builder, with lookups/envelope the declared exceptions", () => {
+    const bound = Object.fromEntries(
+      Object.keys(ALLOWED_CONTEXTS).map((file) => [
+        file,
+        boundContexts(readFileSync(join(PORTS_DIR, file), "utf8")),
+      ]),
     );
+
+    expect(bound).toEqual(ALLOWED_CONTEXTS);
   });
 });

--- a/apps/dev/tests/tsconfig-import-hygiene.test.ts
+++ b/apps/dev/tests/tsconfig-import-hygiene.test.ts
@@ -19,7 +19,6 @@ const DEV_UNUSED_IMPORT_DEBT: Record<string, number> = {
   "src/commands/requeue.ts": 1,
   "src/commands/retake.ts": 1,
   "src/commands/route-model-tier.ts": 1,
-  "src/commands/run/process-deps.ts": 1,
   "src/commands/statusline.ts": 1,
   "src/core/dashboard.ts": 1,
   "src/core/process-issue/lifecycle.ts": 61,

--- a/apps/dev/tests/wiring-integration.test.ts
+++ b/apps/dev/tests/wiring-integration.test.ts
@@ -106,21 +106,17 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
     };
     const ctx: RepoContext = { root, repo: "acme/widgets", remote: "origin" };
     const feedback = makeFeedbackWorktree(root, join(root, ".red", "tmp", "feedback"));
-    const deps = buildProcessDeps(
+    const deps = buildProcessDeps({
       ctx,
-      "gpt-5.5",
-      "none",
+      model: "gpt-5.5",
+      sandbox: "none",
       feedback,
-      { attemptDir },
-      false,
-      "codex",
+      current: { attemptDir },
+      fallbackRunner: false,
+      runner: "codex",
       exec,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "wLINK",
-    );
+      workerId: "wLINK",
+    });
 
     await deps.conflictResolver?.("resolve the conflict", root);
 
@@ -153,16 +149,16 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
     const previous = process.env.RED_AFK_TRUNK;
     process.env.RED_AFK_TRUNK = "develop";
     try {
-      const deps = buildProcessDeps(
+      const deps = buildProcessDeps({
         ctx,
-        "claude-opus-4-8",
-        "none",
+        model: "claude-opus-4-8",
+        sandbox: "none",
         feedback,
         current,
-        false,
-        "claude",
+        fallbackRunner: false,
+        runner: "claude",
         exec,
-      );
+      });
       expect(deps.lookups.base.configTrunk).toBe("develop");
     } finally {
       if (previous === undefined) delete process.env.RED_AFK_TRUNK;
@@ -181,7 +177,16 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
     const { exec, trace } = makeFakeExec(root);
     const feedback = makeFeedbackWorktree(root, join(root, ".red", "tmp", "feedback"));
     const current = { attemptDir: join(root, ".red", "tmp", "workers", "w1", "42-a1") };
-    const deps = buildProcessDeps(ctx, "claude-opus-4-8", "none", feedback, current, false, "claude", exec);
+    const deps = buildProcessDeps({
+      ctx,
+      model: "claude-opus-4-8",
+      sandbox: "none",
+      feedback,
+      current,
+      fallbackRunner: false,
+      runner: "claude",
+      exec,
+    });
     const run = vi.fn(async (_ciAlreadyGreen?: boolean) => ({ ok: true as const, locked: false }));
 
     const result = await deps.landingTailObserver!({
@@ -225,7 +230,16 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
     const { exec, trace } = makeFakeExec(root);
     const feedback = makeFeedbackWorktree(root, join(root, ".red", "tmp", "feedback"));
     const current = { attemptDir: join(root, ".red", "tmp", "workers", "w1", "42-a1") };
-    const deps = buildProcessDeps(ctx, "claude-opus-4-8", "none", feedback, current, false, "claude", exec);
+    const deps = buildProcessDeps({
+      ctx,
+      model: "claude-opus-4-8",
+      sandbox: "none",
+      feedback,
+      current,
+      fallbackRunner: false,
+      runner: "claude",
+      exec,
+    });
 
     const result = await deps.cascadeRebase!.rebaseAndPush(
       root,
@@ -258,16 +272,16 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
 
     // THE REAL ASSEMBLY. exec is the only injected seam; everything else is the
     // production binding (config loads to defaults from the empty tmp root).
-    const deps = buildProcessDeps(
+    const deps = buildProcessDeps({
       ctx,
-      "claude-opus-4-8",
-      "none",
+      model: "claude-opus-4-8",
+      sandbox: "none",
       feedback,
       current,
-      false,
-      "claude",
+      fallbackRunner: false,
+      runner: "claude",
       exec,
-    );
+    });
 
     const issue = 42;
     const base = "main";
@@ -356,7 +370,15 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
     const feedback = makeFeedbackWorktree(root, join(root, ".red", "tmp", "feedback"));
     const current = { attemptDir: join(root, ".red", "tmp", "workers", "w1", "1-a1") };
     // No exec arg → production binding. Assembling must not throw.
-    const deps = buildProcessDeps(ctx, "claude-opus-4-8", "none", feedback, current, false, "claude");
+    const deps = buildProcessDeps({
+      ctx,
+      model: "claude-opus-4-8",
+      sandbox: "none",
+      feedback,
+      current,
+      fallbackRunner: false,
+      runner: "claude",
+    });
     expect(typeof deps.gh.viewLabels).toBe("function");
     expect(typeof deps.remoteGit).toBe("function");
     expect(typeof deps.mergeExec).toBe("function");
@@ -369,7 +391,16 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
     const feedback = makeFeedbackWorktree(root, join(root, ".red", "tmp", "feedback"));
     const current = { attemptDir: join(root, ".red", "tmp", "workers", "w1", "42-a1") };
 
-    const deps = buildProcessDeps(ctx, "gpt-5.5", "none", feedback, current, false, "codex", exec);
+    const deps = buildProcessDeps({
+      ctx,
+      model: "gpt-5.5",
+      sandbox: "none",
+      feedback,
+      current,
+      fallbackRunner: false,
+      runner: "codex",
+      exec,
+    });
 
     await expect(
       deps.classifyIssue?.({


### PR DESCRIPTION
Automated AFK landing for #2667. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2667

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787834220&installation_model_id=20659&pr_number=2690&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2690&signature=eb35771b24e92584b5ef4d6d79d0e5758e43d48e533d1e7bbee83fcc580d5832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->