### PR TITLE
chore: #2666 planTransition crosses to the castle; castle's own writers adopt it

### DIFF
--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -133,6 +133,13 @@ jobs:
       - name: Test apps/dev (includes packages/shared)
         run: pnpm -C apps/dev test
 
+      # The engine's own suite carries the castle-tree transition-API contract
+      # lint (#2666). The root `test` script filters red-castle out, so without
+      # this step that lint would never run and a raw state-role writer could
+      # reach main unseen.
+      - name: Test packages/red-castle
+        run: pnpm -C packages/red-castle test
+
       - name: Test apps/opencode-host
         run: pnpm -C apps/opencode-host test
 

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -48,6 +48,7 @@ import {
 import * as ghx from "../runtime/gh.js";
 import * as gitx from "../runtime/git.js";
 import { planReconcileSweep, executeUnblockSweep } from "../core/boot-sweep.js";
+import { HOST_STATE_TRANSITION_LABELS } from "../core/state-transition.js";
 import { removeDir as removeDirNative } from "../runtime/fs.js";
 import { killTreeAndWait } from "../runtime/kill-tree.js";
 import { buildStateChangeWake } from "../runtime/state-watch.js";
@@ -776,6 +777,7 @@ export function buildSupervisorDeps(
         const result = await runIssueStateCurator({
           tracker,
           store: createFileIssueCuratorStore(paths),
+          labels: HOST_STATE_TRANSITION_LABELS,
         });
         return `curator sweep ran: ${JSON.stringify(result).slice(0, 200)}`;
       },

--- a/apps/dev/src/core/state-transition.ts
+++ b/apps/dev/src/core/state-transition.ts
@@ -1,18 +1,30 @@
-// state-transition.ts — the single owner of issue state-label mutations
-// (ADR 0122 rule 5, Spec #2523, slices #2524 + #2661).
+// state-transition.ts — the HOST shim over the castle engine's transition API
+// (ADR 0122 rule 5, Spec #2523, slices #2524 + #2661 + #2666).
 //
-// An issue carries exactly ONE state role at any time. On 2026-07-22 three
-// issues accumulated contradictory role sets (park labels stacked on
-// `ready-for-agent`, an active blocker on a queued issue) because every code
-// path wrote labels directly; each contradiction became a red boot probe and
-// froze the fleet. This module makes those sets unconstructible: callers
-// declare the TRANSITION they want, the planner computes the atomic add/remove
-// set, refuses any request that would leave zero or two state roles, and the
-// apply step performs the whole mutation as ONE tracker call.
+// The planner itself crossed to `@reddb-io/red-castle`'s
+// `engine/state-transition.ts` in #2666, so the castle's own writers (the
+// quarantine curator, the dependency cascade) prove the same one-state-role
+// invariant this host has enforced since #2524. Nothing about the rules moved:
+// callers declare the TRANSITION they want, the planner computes the atomic
+// add/remove set, refuses any request that would leave zero or two state roles,
+// and the apply step performs the whole mutation as ONE tracker call.
 //
-// All state-role label constants live in triage-labels.ts — import from there,
-// never redefine inline. The raw-edit lint (#2528) enforces this at CI time.
+// What stays HERE is the vocabulary binding. The engine owns no label
+// spellings; this module wires this repo's `triage-labels.ts` constants so
+// every existing caller keeps the two-argument `planTransition(current,
+// transition)` signature it already uses. The raw-edit lint (#2528) enforces
+// that engine code routes through this API.
 
+import {
+  isRefused,
+  planTransition as planTransitionWithLabels,
+  stateRoleLabels,
+  stateRolesOf as stateRolesOfWithLabels,
+  type StateTransition,
+  type StateTransitionLabels,
+  type RefusedTransition,
+  type TransitionPlan,
+} from "@reddb-io/red-castle/engine";
 import {
   LABEL_READY,
   LABEL_HUMAN,
@@ -23,82 +35,39 @@ import {
   LABEL_QUARANTINE,
 } from "./triage-labels.js";
 
-/** Every label that counts as a STATE ROLE. The invariant this module
- * enforces: a post-transition label set contains exactly one of these. */
-export const STATE_ROLE_LABELS: readonly string[] = [
-  LABEL_READY,
-  LABEL_HUMAN,
-  LABEL_NEEDS_TRIAGE,
-  LABEL_NEEDS_INFO,
-  LABEL_QUARANTINE,
-  LABEL_DEPENDENCY,
-];
+export {
+  applyTransition,
+  isRefused,
+  type ApplyTransitionDeps,
+  type ApplyTransitionResult,
+  type IssueEdit,
+  type RefusedTransition,
+  type StateTransition,
+  type StateTransitionLabels,
+  type TransitionPlan,
+} from "@reddb-io/red-castle/engine";
 
-const BLOCKED_PREFIX = "blocked:";
-const REQ_PREFIX = "req:";
+/** This host's transition vocabulary, wired into every engine call below. */
+export const HOST_STATE_TRANSITION_LABELS: StateTransitionLabels = {
+  ready: LABEL_READY,
+  running: LABEL_RUNNING,
+  human: LABEL_HUMAN,
+  needsTriage: LABEL_NEEDS_TRIAGE,
+  needsInfo: LABEL_NEEDS_INFO,
+  quarantine: LABEL_QUARANTINE,
+  dependencyBlocked: LABEL_DEPENDENCY,
+  blockedPrefix: "blocked:",
+  reqPrefix: "req:",
+};
 
-/** The canonical transitions. Anything the engine wants to do to an issue's
- * state is one of these — there is no "just add a label" escape hatch. */
-export type StateTransition =
-  /** Back into the executable queue. Refused while `req:*` edges remain —
-   * use `promote` (which consumes them) or clear the edges first. */
-  | { kind: "queue" }
-  /** Park for a human with a machine-readable reason (`blocked:<reason>`). */
-  | { kind: "park"; reason: string }
-  /** Plain human gate with no blocked-reason modifier. */
-  | { kind: "human" }
-  /** Healthy dependency wait: `blocked:dependency` + one `req:N` per blocker. */
-  | { kind: "dependency-block"; reqs: readonly number[] }
-  /** ADR 0122 quarantine: judgment-requiring incoherence, one issue at a time. */
-  | { kind: "quarantine"; diagnosis: string }
-  /** Awaiting an answer from the reporter (the `/triage` `needs-info` outcome). */
-  | { kind: "needs-info" }
-  /** Back to the triage queue — the state a fresh or bounced issue sits in. */
-  | { kind: "triage" }
-  /** Close-cascade promotion: consume the `req:*` edges and re-queue. */
-  | { kind: "promote" };
-
-export interface TransitionPlan {
-  readonly add: readonly string[];
-  readonly remove: readonly string[];
-  /** Markdown appended to the issue body in the SAME tracker call (quarantine
-   * diagnoses ride the label mutation — never a second write). */
-  readonly appendBody?: string;
-}
-
-export interface RefusedTransition {
-  readonly refused: true;
-  readonly reason: string;
-}
-
-export function isRefused(
-  value: TransitionPlan | RefusedTransition,
-): value is RefusedTransition {
-  return (value as RefusedTransition).refused === true;
-}
+/** Every label that counts as a STATE ROLE in this host's vocabulary. */
+export const STATE_ROLE_LABELS: readonly string[] = stateRoleLabels(
+  HOST_STATE_TRANSITION_LABELS,
+);
 
 /** The state roles present in a label set (order preserved). */
 export function stateRolesOf(labels: readonly string[]): string[] {
-  return STATE_ROLE_LABELS.filter((role) => labels.includes(role));
-}
-
-function targetRole(t: StateTransition): string {
-  switch (t.kind) {
-    case "queue":
-    case "promote":
-      return LABEL_READY;
-    case "park":
-    case "human":
-      return LABEL_HUMAN;
-    case "dependency-block":
-      return LABEL_DEPENDENCY;
-    case "quarantine":
-      return LABEL_QUARANTINE;
-    case "needs-info":
-      return LABEL_NEEDS_INFO;
-    case "triage":
-      return LABEL_NEEDS_TRIAGE;
-  }
+  return stateRolesOfWithLabels(labels, HOST_STATE_TRANSITION_LABELS);
 }
 
 /**
@@ -111,88 +80,7 @@ export function planTransition(
   current: readonly string[],
   transition: StateTransition,
 ): TransitionPlan | RefusedTransition {
-  if (transition.kind === "park" && !transition.reason.startsWith(BLOCKED_PREFIX)) {
-    return {
-      refused: true,
-      reason: `park reason must be a ${BLOCKED_PREFIX}* label, got "${transition.reason}"`,
-    };
-  }
-  if (transition.kind === "dependency-block" && transition.reqs.length === 0) {
-    return { refused: true, reason: "dependency-block requires at least one req issue" };
-  }
-  const reqLabels = current.filter((l) => l.startsWith(REQ_PREFIX));
-  if (transition.kind === "queue" && reqLabels.length > 0) {
-    return {
-      refused: true,
-      reason:
-        `queue refused while dependency edges remain (${reqLabels.join(", ")}); ` +
-        `use promote to consume them or clear the edges first`,
-    };
-  }
-
-  const target = targetRole(transition);
-  const add = new Set<string>();
-  const remove = new Set<string>();
-
-  // Every other state role present goes; the target role arrives.
-  for (const role of STATE_ROLE_LABELS) {
-    if (role === target) continue;
-    if (current.includes(role)) remove.add(role);
-  }
-  if (!current.includes(target)) add.add(target);
-
-  // Leaving execution: `running` never survives a state transition.
-  if (current.includes(LABEL_RUNNING)) remove.add(LABEL_RUNNING);
-
-  // Blocked-reason modifiers accompany exactly the states that define them.
-  const blockedPresent = current.filter(
-    (l) => l.startsWith(BLOCKED_PREFIX) && l !== LABEL_DEPENDENCY,
-  );
-  switch (transition.kind) {
-    case "park":
-      for (const l of blockedPresent) if (l !== transition.reason) remove.add(l);
-      if (!current.includes(transition.reason)) add.add(transition.reason);
-      break;
-    case "dependency-block":
-      for (const l of blockedPresent) remove.add(l);
-      for (const req of transition.reqs) {
-        const label = `${REQ_PREFIX}${req}`;
-        if (!current.includes(label)) add.add(label);
-      }
-      break;
-    case "promote": {
-      for (const l of blockedPresent) remove.add(l);
-      // Numeric req order keeps the emitted mutation deterministic regardless
-      // of the tracker's label listing order.
-      const byIssue = (l: string): number => Number(l.slice(REQ_PREFIX.length)) || 0;
-      for (const l of [...reqLabels].sort((a, b) => byIssue(a) - byIssue(b))) remove.add(l);
-      break;
-    }
-    default:
-      for (const l of blockedPresent) remove.add(l);
-      break;
-  }
-
-  // Invariant proof: replay the mutation and demand exactly one state role.
-  const result = new Set(current);
-  for (const l of remove) result.delete(l);
-  for (const l of add) result.add(l);
-  const roles = stateRolesOf([...result]);
-  if (roles.length !== 1) {
-    return {
-      refused: true,
-      reason: `transition would leave ${roles.length} state roles (${roles.join(", ") || "none"})`,
-    };
-  }
-
-  const plan: TransitionPlan = {
-    add: [...add],
-    remove: [...remove],
-    ...(transition.kind === "quarantine" && transition.diagnosis.trim() !== ""
-      ? { appendBody: transition.diagnosis }
-      : {}),
-  };
-  return plan;
+  return planTransitionWithLabels(current, transition, HOST_STATE_TRANSITION_LABELS);
 }
 
 /**
@@ -237,47 +125,4 @@ export async function transitionLabels(
   if (isRefused(plan)) return { applied: false, ...plan };
   const result = await edit([...plan.remove], [...plan.add]);
   return { applied: true, ok: result !== false, plan };
-}
-
-/** The single tracker mutation the apply step performs. `body`, when present,
- * is the FULL replacement body (current body + appended diagnosis) so labels
- * and body change in one `gh issue edit`. */
-export interface IssueEdit {
-  readonly add: readonly string[];
-  readonly remove: readonly string[];
-  readonly body?: string;
-}
-
-export interface ApplyTransitionDeps {
-  /** Perform ONE `gh issue edit` covering labels (and body when given). */
-  editIssue(issue: number, edit: IssueEdit): Promise<boolean>;
-  /** Read the current body — needed only when the plan appends a diagnosis. */
-  readBody(issue: number): Promise<string>;
-}
-
-export interface ApplyTransitionResult {
-  readonly ok: boolean;
-  readonly plan: TransitionPlan;
-}
-
-/**
- * Apply a planned transition as ONE tracker call. Callers pass the plan they
- * already inspected; a refused plan never reaches this function's signature.
- */
-export async function applyTransition(
-  deps: ApplyTransitionDeps,
-  issue: number,
-  plan: TransitionPlan,
-): Promise<ApplyTransitionResult> {
-  let body: string | undefined;
-  if (plan.appendBody !== undefined) {
-    const current = await deps.readBody(issue);
-    body = `${current.replace(/\s+$/, "")}\n\n${plan.appendBody}\n`;
-  }
-  const ok = await deps.editIssue(issue, {
-    add: plan.add,
-    remove: plan.remove,
-    ...(body !== undefined ? { body } : {}),
-  });
-  return { ok, plan };
 }

--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -22,6 +22,7 @@ import {
   registerLaneEventSubscription,
   type LaneSubscriptionServer,
 } from "./lane-subscription.js";
+import { HOST_STATE_TRANSITION_LABELS } from "./core/state-transition.js";
 import { createMergeDriverIo } from "./runtime/merge-driver-io.js";
 import { createMedicIo } from "./runtime/medic-io.js";
 import { createFileMedicStore, runMedicPass } from "./core/pr-medic.js";
@@ -236,7 +237,7 @@ export async function startResidentIssueCurator(
     if (running) return;
     running = true;
     try {
-      await runIssueStateCurator({ tracker, store });
+      await runIssueStateCurator({ tracker, store, labels: HOST_STATE_TRANSITION_LABELS });
     } catch {
       // Repo-level transport/state faults retry on the permanent periodic belt;
       // they must not terminate the resident or block its MCP surface.

--- a/apps/dev/tests/state-transition-contract.test.ts
+++ b/apps/dev/tests/state-transition-contract.test.ts
@@ -48,20 +48,14 @@ const CONTRACT_SOURCES = new Set([
 ]);
 
 /**
- * Files exempt WHOLESALE, with an expiry condition. Wave C moves the planner
- * into castle; until then these two castle modules keep their pre-contract
- * writers rather than importing a dev-side planner across the package edge.
+ * Files exempt WHOLESALE, with an expiry condition. Empty since Wave C
+ * (#2666): the planner now lives in castle, and both castle modules that held
+ * a temporary exemption — `engine/issue-state-curator.ts` and
+ * `engine/tracker/dependencies.ts` — route their writes through
+ * `planTransition`. An entry here must always name the condition that ends it;
+ * the expiry test below fails an entry whose file no longer has a raw writer.
  */
-const FILE_ALLOWLIST = new Map<string, string>([
-  [
-    "red-castle/engine/issue-state-curator.ts",
-    "TEMPORARY (#2664): migrates to planTransition when the planner crosses to castle (Wave C)",
-  ],
-  [
-    "red-castle/engine/tracker/dependencies.ts",
-    "TEMPORARY (#2664): migrates to planTransition when the planner crosses to castle (Wave C)",
-  ],
-]);
+const FILE_ALLOWLIST = new Map<string, string>([]);
 
 /** Wrappers that are the transition API rather than a way around it. Their
  * call sites are not raw edits — `planner-backed wrappers still route through

--- a/apps/dev/tests/state-transition-contract.test.ts
+++ b/apps/dev/tests/state-transition-contract.test.ts
@@ -12,6 +12,11 @@
 // through the transition API, or (for a genuinely justified survivor: a
 // documented legacy fallback, a non-issue surface like PR review labels, or a
 // human/manual command surface) add it to the allowlist WITH a reason.
+//
+// This lint owns the HOST tree only. The planner itself lives in red-castle's
+// `engine/state-transition.ts` since #2666, and castle's tree is scanned by
+// castle's own suite (`src/engine/state-transition-contract.test.ts`) with an
+// EMPTY allowlist — never re-add castle paths here.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";

--- a/packages/red-castle/src/engine/config.test.ts
+++ b/packages/red-castle/src/engine/config.test.ts
@@ -145,7 +145,11 @@ describe("engine config reader", () => {
       ready: "queue:agent",
       running: "state:running",
       human: "queue:human",
+      needsTriage: "needs-triage",
+      needsInfo: "needs-info",
+      quarantine: "quarantine",
       dependencyBlocked: "wait:dependency",
+      blockedPrefix: "blocked:",
       reqPrefix: "depends-on:",
     });
   });

--- a/packages/red-castle/src/engine/config.ts
+++ b/packages/red-castle/src/engine/config.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import type { StateTransitionLabels } from "./state-transition.js";
 
 export type EngineConfigValues = Record<string, string>;
 export type EngineConfigReader = (path: string) => string | undefined;
@@ -29,6 +30,10 @@ export const ENGINE_CONFIG_DEFAULTS = {
   "afk.labels.running": "running",
   "afk.labels.human": "ready-for-human",
   "afk.labels.dependency_blocked": "blocked:dependency",
+  "afk.labels.needs_triage": "needs-triage",
+  "afk.labels.needs_info": "needs-info",
+  "afk.labels.quarantine": "quarantine",
+  "afk.labels.blocked_prefix": "blocked:",
   "afk.labels.req_prefix": "req:",
 } as const;
 
@@ -62,11 +67,18 @@ export interface EngineConfig {
   readonly get: (key: string) => string;
 }
 
-export interface EngineLabelVocabulary {
+/** The engine's label vocabulary. It satisfies {@link StateTransitionLabels},
+ * so every castle writer hands the SAME injected config to `planTransition`
+ * that it uses for its own reads (#2666). */
+export interface EngineLabelVocabulary extends StateTransitionLabels {
   readonly ready: string;
   readonly running: string;
   readonly human: string;
+  readonly needsTriage: string;
+  readonly needsInfo: string;
+  readonly quarantine: string;
   readonly dependencyBlocked: string;
+  readonly blockedPrefix: string;
   readonly reqPrefix: string;
 }
 
@@ -254,7 +266,11 @@ export function readEngineLabelVocabulary(config: EngineConfig): EngineLabelVoca
     ready: config.get("afk.labels.ready"),
     running: config.get("afk.labels.running"),
     human: config.get("afk.labels.human"),
+    needsTriage: config.get("afk.labels.needs_triage"),
+    needsInfo: config.get("afk.labels.needs_info"),
+    quarantine: config.get("afk.labels.quarantine"),
     dependencyBlocked: config.get("afk.labels.dependency_blocked"),
+    blockedPrefix: config.get("afk.labels.blocked_prefix"),
     reqPrefix: config.get("afk.labels.req_prefix"),
   };
 }

--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -38,6 +38,7 @@ export * from "./runner-detection.js";
 export * from "./runner-spawn.js";
 export * from "./runner-spec.js";
 export * from "./runner-types.js";
+export * from "./state-transition.js";
 export * from "./singleton-event-lane.js";
 export * from "./singleton-lease.js";
 export {

--- a/packages/red-castle/src/engine/issue-state-curator.test.ts
+++ b/packages/red-castle/src/engine/issue-state-curator.test.ts
@@ -4,7 +4,20 @@ import {
   type IssueCuratorState,
   type IssueCuratorStore,
 } from "./issue-state-curator.js";
+import type { StateTransitionLabels } from "./state-transition.js";
 import type { TrackerIssue, TrackerPort } from "./tracker/port.js";
+
+const labels: StateTransitionLabels = {
+  ready: "ready-for-agent",
+  running: "running",
+  human: "ready-for-human",
+  needsTriage: "needs-triage",
+  needsInfo: "needs-info",
+  quarantine: "quarantine",
+  dependencyBlocked: "blocked:dependency",
+  blockedPrefix: "blocked:",
+  reqPrefix: "req:",
+};
 
 const ACTIVE_BLOCKER = [
   "## Current blocker",
@@ -69,7 +82,7 @@ describe("castle issue-state curator", () => {
     });
     const store = memoryStore();
 
-    const result = await runIssueStateCurator({ tracker: h.tracker, store, nowMs: Date.UTC(2026, 6, 23) });
+    const result = await runIssueStateCurator({ tracker: h.tracker, store, labels, nowMs: Date.UTC(2026, 6, 23) });
 
     expect(result).toEqual({ checked: 1, released: [11], parked: [] });
     expect(h.edits).toEqual([{ remove: ["quarantine"], add: ["ready-for-agent"] }]);
@@ -82,16 +95,17 @@ describe("castle issue-state curator", () => {
     const h = harness({ number: 12, labels: ["quarantine"], body: ACTIVE_BLOCKER });
     const store = memoryStore();
 
-    const first = await runIssueStateCurator({ tracker: h.tracker, store, nowMs: 1_000 });
-    const second = await runIssueStateCurator({ tracker: h.tracker, store, nowMs: 2_000 });
-    const third = await runIssueStateCurator({ tracker: h.tracker, store, nowMs: 3_000 });
+    const first = await runIssueStateCurator({ tracker: h.tracker, store, labels, nowMs: 1_000 });
+    const second = await runIssueStateCurator({ tracker: h.tracker, store, labels, nowMs: 2_000 });
+    const third = await runIssueStateCurator({ tracker: h.tracker, store, labels, nowMs: 3_000 });
 
     expect(first).toEqual({ checked: 1, released: [], parked: [] });
     expect(second).toEqual({ checked: 1, released: [], parked: [] });
     expect(third).toEqual({ checked: 1, released: [], parked: [12] });
-    expect(h.edits).toEqual([
-      { remove: ["quarantine", "ready-for-agent"], add: ["ready-for-human"] },
-    ]);
+    // The pre-transition writer emitted a fixed `[quarantine, ready-for-agent]`
+    // removal; `ready-for-agent` is absent here, so dropping it from the delta
+    // is the same tracker outcome with one less no-op label (#2666).
+    expect(h.edits).toEqual([{ remove: ["quarantine"], add: ["ready-for-human"] }]);
     expect(h.current().body).toContain("Original diagnosis remains auditable.");
     expect(store.value.failedChecks).toEqual({});
   });
@@ -112,9 +126,91 @@ describe("castle issue-state curator", () => {
       closeIssue: async () => undefined,
     };
 
-    const result = await runIssueStateCurator({ tracker, store, nowMs: 1_000 });
+    const result = await runIssueStateCurator({ tracker, store, labels, nowMs: 1_000 });
 
     expect(result).toEqual({ checked: 2, released: [2], parked: [] });
     expect(tracker.editIssueLabels).toHaveBeenCalledTimes(2);
   });
+});
+
+// The curator's WRITE moved to planTransition in #2666. These rows pin the
+// exact delta for every shape the pre-transition writer could emit. Where the
+// raw writer named a label the issue did not carry, the row records the same
+// tracker outcome with the no-op dropped; where it left a SECOND state role
+// standing, the row records the coherent set the planner proves instead.
+describe("curator label deltas are byte-identical to the pre-transition writer", () => {
+  const COHERENT = "## Current blocker\n\nNone\n";
+
+  const releases: Array<{ name: string; labels: string[]; remove: string[]; add: string[] }> = [
+    {
+      name: "bare quarantine",
+      labels: ["quarantine"],
+      remove: ["quarantine"],
+      add: ["ready-for-agent"],
+    },
+    {
+      name: "non-state labels ride through untouched",
+      labels: ["quarantine", "type:ticket", "priority:high"],
+      remove: ["quarantine"],
+      add: ["ready-for-agent"],
+    },
+  ];
+
+  for (const row of releases) {
+    it(`release: ${row.name}`, async () => {
+      const h = harness({ number: 30, labels: row.labels, body: COHERENT });
+      const result = await runIssueStateCurator({
+        tracker: h.tracker,
+        store: memoryStore(),
+        labels,
+        nowMs: 1_000,
+      });
+      expect(result.released).toEqual([30]);
+      expect(h.edits).toEqual([{ remove: row.remove, add: row.add }]);
+    });
+  }
+
+  it("release: refuses to queue a quarantined issue that still carries req edges", async () => {
+    const h = harness({ number: 31, labels: ["quarantine", "req:9"], body: COHERENT });
+    const result = await runIssueStateCurator({
+      tracker: h.tracker,
+      store: memoryStore(),
+      labels,
+      nowMs: 1_000,
+    });
+    expect(result).toEqual({ checked: 1, released: [], parked: [] });
+    expect(h.edits).toEqual([]);
+  });
+
+  const parks: Array<{ name: string; labels: string[]; remove: string[]; add: string[] }> = [
+    {
+      name: "the canonical quarantine + ready pair",
+      labels: ["quarantine", "ready-for-agent"],
+      remove: ["ready-for-agent", "quarantine"],
+      add: ["ready-for-human"],
+    },
+    {
+      name: "a stacked blocked reason is collapsed with the state roles",
+      labels: ["quarantine", "ready-for-agent", "blocked:validation"],
+      remove: ["ready-for-agent", "quarantine", "blocked:validation"],
+      add: ["ready-for-human"],
+    },
+    {
+      name: "an active claim projection never survives the park",
+      labels: ["quarantine", "running"],
+      remove: ["quarantine", "running"],
+      add: ["ready-for-human"],
+    },
+  ];
+
+  for (const row of parks) {
+    it(`park: ${row.name}`, async () => {
+      const h = harness({ number: 40, labels: row.labels, body: COHERENT });
+      const store = memoryStore();
+      for (const nowMs of [1_000, 2_000, 3_000]) {
+        await runIssueStateCurator({ tracker: h.tracker, store, labels, nowMs });
+      }
+      expect(h.edits).toEqual([{ remove: row.remove, add: row.add }]);
+    });
+  }
 });

--- a/packages/red-castle/src/engine/issue-state-curator.ts
+++ b/packages/red-castle/src/engine/issue-state-curator.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
 import type { EnginePaths } from "./paths.js";
+import { isRefused, planTransition, type StateTransitionLabels } from "./state-transition.js";
 import type { TrackerIssue, TrackerPort } from "./tracker/port.js";
 
 export const ISSUE_CURATOR_RECHECK_LIMIT = 3;
@@ -24,6 +25,8 @@ export interface IssueCuratorStore {
 export interface IssueStateCuratorInput {
   readonly tracker: TrackerPort;
   readonly store: IssueCuratorStore;
+  /** The host's label vocabulary — the curator owns no spellings (#2666). */
+  readonly labels: StateTransitionLabels;
   readonly nowMs?: number;
   readonly recheckLimit?: number;
 }
@@ -34,10 +37,11 @@ export interface IssueStateCuratorResult {
   readonly parked: number[];
 }
 
-const QUARANTINE = "quarantine";
-const READY = "ready-for-agent";
-const HUMAN = "ready-for-human";
-const INCOHERENT_STATE_LABELS = new Set([READY, HUMAN, "running", "needs-triage"]);
+/** The lifecycle labels that must not coexist with `quarantine`. Sourced from
+ * the injected vocabulary — the curator holds no label spellings of its own. */
+function incoherentStateLabels(labels: StateTransitionLabels): Set<string> {
+  return new Set([labels.ready, labels.human, labels.running, labels.needsTriage]);
+}
 
 function activeCurrentBlocker(body: string): boolean {
   const match = /<!-- red:blocker-state v1 -->([\s\S]*?)<!-- \/red:blocker-state -->/.exec(body);
@@ -47,11 +51,15 @@ function activeCurrentBlocker(body: string): boolean {
 /** The curator re-runs the same issue-level coherence rule that caused
  * quarantine: no active Current blocker and no competing lifecycle/blocked
  * state may remain before the issue re-enters the executable queue. */
-export function quarantineIncoherence(issue: TrackerIssue): string[] {
+export function quarantineIncoherence(
+  issue: TrackerIssue,
+  labels: StateTransitionLabels,
+): string[] {
+  const incoherent = incoherentStateLabels(labels);
   const reasons: string[] = [];
   if (activeCurrentBlocker(issue.body)) reasons.push("active-current-blocker");
   for (const label of issue.labels) {
-    if (INCOHERENT_STATE_LABELS.has(label) || label.startsWith("blocked:")) {
+    if (incoherent.has(label) || label.startsWith(labels.blockedPrefix)) {
       reasons.push(`state-label:${label}`);
     }
   }
@@ -125,20 +133,29 @@ export async function runIssueStateCurator(
   const recheckLimit = input.recheckLimit ?? ISSUE_CURATOR_RECHECK_LIMIT;
   const prior = await input.store.read();
   const failedChecks = { ...prior.failedChecks };
-  const issues = await input.tracker.listOpenIssuesByLabel(QUARANTINE);
+  const labels = input.labels;
+  const issues = await input.tracker.listOpenIssuesByLabel(labels.quarantine);
   const released: number[] = [];
   const parked: number[] = [];
 
+  // The DECISION below is the curator's; the WRITE is the transition API's —
+  // `planTransition` proves the one-state-role invariant before either mutation
+  // reaches the tracker (#2666, ADR 0122 rule 5).
   for (const issue of issues) {
     const key = String(issue.number);
-    const reasons = quarantineIncoherence(issue);
+    const reasons = quarantineIncoherence(issue, labels);
     if (reasons.length === 0) {
+      // A quarantined issue carrying live `req:*` edges without its wait state
+      // is itself incoherent: the planner refuses the queue and the issue stays
+      // held for the next sweep rather than re-entering the queue mid-blocked.
+      const release = planTransition(issue.labels, { kind: "queue" }, labels);
+      if (isRefused(release)) continue;
       try {
         if (!input.tracker.editIssueBody) throw new Error("tracker body mutation is not configured");
         await input.tracker.editIssueBody(issue.number, appendReleaseNote(issue, at));
         await input.tracker.editIssueLabels(issue.number, {
-          remove: [QUARANTINE],
-          add: [READY],
+          remove: [...release.remove],
+          add: [...release.add],
         });
         delete failedChecks[key];
         released.push(issue.number);
@@ -151,10 +168,12 @@ export async function runIssueStateCurator(
     const count = (failedChecks[key]?.count ?? 0) + 1;
     failedChecks[key] = { count, lastCheckedAt: at };
     if (count < recheckLimit) continue;
+    const park = planTransition(issue.labels, { kind: "human" }, labels);
+    if (isRefused(park)) continue;
     try {
       await input.tracker.editIssueLabels(issue.number, {
-        remove: [QUARANTINE, READY],
-        add: [HUMAN],
+        remove: [...park.remove],
+        add: [...park.add],
       });
       delete failedChecks[key];
       parked.push(issue.number);

--- a/packages/red-castle/src/engine/state-transition-contract.test.ts
+++ b/packages/red-castle/src/engine/state-transition-contract.test.ts
@@ -1,0 +1,175 @@
+// state-transition-contract.test.ts — the transition-API contract lint for the
+// CASTLE tree (#2528, #2664, #2666; red-skills ADR 0122 rule 5).
+//
+// The consuming host runs the same lint over its own `src` tree
+// (`apps/dev/tests/state-transition-contract.test.ts`); this one keeps the
+// engine's tree honest from the engine's own suite, so a castle-only change can
+// never introduce a raw state-role write that only the host's CI would catch.
+//
+// Engine code must not hand-roll issue STATE-ROLE label edits: every mutation
+// that queues, parks, promotes, quarantines, or dependency-blocks an issue
+// flows through `planTransition`/`applyTransition` so the one-state-role
+// invariant is proven at plan time. This test scans the engine source for raw
+// `editIssueLabels(` / `editLabels(` call sites whose arguments mention a
+// state-role label and fails on any site that is not in the allowlist below.
+//
+// The allowlist is EMPTY and stays empty: castle's two raw writers (the
+// quarantine curator and the dependency cascade) were migrated in #2666, and a
+// new raw state-label edit here is a defect, not a survivor to be documented.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** The spellings a state role can carry. `running` and typed `blocked:*`
+ * reasons alone are projections or modifiers, not state roles. */
+const STATE_ROLE_LITERAL =
+  /"(ready-for-agent|ready-for-human|needs-triage|needs-info|quarantine|blocked:dependency)"/;
+
+/** State-role vocabulary as it appears at a mutation site. Two forms must be
+ * caught, because castle's two pre-migration writers used one each:
+ *
+ *  - `<config>.ready` / `.human` / `.dependencyBlocked` — the PORTIFIED form.
+ *    Castle modules read their vocabulary from an injected
+ *    `EngineLabelVocabulary`, so a literal-only scan would miss the dependency
+ *    cascade's `removeLabels: [labels.dependencyBlocked, …]` entirely.
+ *  - a file-local `const NAME = "<state role>"` — the form the quarantine
+ *    curator used (`const QUARANTINE = "quarantine"`, then
+ *    `remove: [QUARANTINE, READY]`). Resolving these per file is what gives the
+ *    lint teeth against a writer that launders the spelling through a constant. */
+const CONFIG_ACCESSOR =
+  /\blabels\.(ready|human|quarantine|needsTriage|needsInfo|dependencyBlocked)\b/;
+
+/** The shapes that WRITE a label delta — a state-role token inside one of these
+ * is a raw mutation; the same token in a read or a comparison is not. */
+const MUTATION_MARKER = /\beditIssueLabels\(|\beditLabels\(|\bremoveLabels:|\baddLabels:/;
+
+/** File-local constants bound to a state-role spelling, as a token pattern. */
+function localRoleConstants(source: string): RegExp | undefined {
+  const names: string[] = [];
+  for (const line of source.split("\n")) {
+    const match = /^\s*(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*("[^"]*")/.exec(line);
+    if (match && STATE_ROLE_LITERAL.test(match[2]!)) names.push(match[1]!);
+  }
+  return names.length > 0 ? new RegExp(`\\b(${names.join("|")})\\b`) : undefined;
+}
+
+/**
+ * Surviving raw call sites, keyed `relative-path :: normalized-statement`.
+ * Empty by contract (#2666) — route the mutation through the transition API
+ * instead of growing this list.
+ */
+const ALLOWLIST = new Map<string, string>();
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) yield* walk(path);
+    else if (path.endsWith(".ts") && !path.endsWith(".d.ts") && !path.endsWith(".test.ts")) {
+      yield path;
+    }
+  }
+}
+
+/** Collapse a multi-line call statement to one normalized single-space line,
+ * reporting the last line it consumed so the scan does not report the same
+ * mutation twice (a `removeLabels:`/`addLabels:` pair is ONE site). */
+function statementAt(lines: string[], index: number): { statement: string; end: number } {
+  let statement = lines[index]!;
+  let cursor = index;
+  while (!statement.includes(");") && cursor + 1 < lines.length && cursor - index < 6) {
+    cursor += 1;
+    statement += ` ${lines[cursor]!}`;
+  }
+  return { statement: statement.replace(/\s+/g, " ").trim(), end: cursor };
+}
+
+/** Every raw state-role mutation site in `source`, normalized one per line. */
+export function rawStateRoleMutations(source: string): string[] {
+  const localConst = localRoleConstants(source);
+  const lines = source.split("\n");
+  const found: string[] = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    if (!MUTATION_MARKER.test(line)) continue;
+    // Declarations / interface members are not call sites.
+    if (/editIssueLabels\??\(issue: |editLabels\??\(issue: /.test(line)) continue;
+    const { statement, end } = statementAt(lines, i);
+    const raw =
+      CONFIG_ACCESSOR.test(statement) ||
+      STATE_ROLE_LITERAL.test(statement) ||
+      (localConst?.test(statement) ?? false);
+    if (raw) {
+      found.push(statement);
+      i = end;
+    }
+  }
+  return found;
+}
+
+describe("transition-API contract lint — castle tree (#2666)", () => {
+  it("no raw state-role label edit survives in engine source", () => {
+    const offenders: string[] = [];
+    const seen = new Set<string>();
+    for (const file of walk(SRC_ROOT)) {
+      const rel = relative(SRC_ROOT, file).replaceAll("\\", "/");
+      for (const statement of rawStateRoleMutations(readFileSync(file, "utf8"))) {
+        const key = `${rel} :: ${statement}`;
+        seen.add(key);
+        if (!ALLOWLIST.has(key)) offenders.push(key);
+      }
+    }
+    expect(
+      offenders,
+      `raw state-role label edits outside the transition API:\n${offenders.join("\n")}\n` +
+        "Route the mutation through planTransition/applyTransition " +
+        "(engine/state-transition.ts). The castle allowlist is empty by contract.",
+    ).toEqual([]);
+
+    // Stale allowlist entries rot into false confidence — prune them.
+    const stale = [...ALLOWLIST.keys()].filter((key) => !seen.has(key));
+    expect(stale, `allowlist entries no longer present in source:\n${stale.join("\n")}`).toEqual([]);
+  });
+
+  // A lint nobody has watched fail is a lint nobody can trust. These rows are
+  // castle's two ACTUAL pre-migration writers, verbatim.
+  it("catches the curator's laundered-constant writer", () => {
+    const source = [
+      'const QUARANTINE = "quarantine";',
+      'const READY = "ready-for-agent";',
+      "await input.tracker.editIssueLabels(issue.number, {",
+      "  remove: [QUARANTINE],",
+      "  add: [READY],",
+      "});",
+    ].join("\n");
+    expect(rawStateRoleMutations(source)).toHaveLength(1);
+  });
+
+  it("catches the dependency cascade's injected-config writer", () => {
+    const source = [
+      "plans.push({",
+      "  removeLabels: [",
+      "    labels.dependencyBlocked,",
+      "    ...labelDeps.map((dependency) => labelForDependency(dependency, labels)),",
+      "  ],",
+      "  addLabels: [labels.ready],",
+      "});",
+    ].join("\n");
+    expect(rawStateRoleMutations(source)).toHaveLength(1);
+  });
+
+  it("leaves a transition-planned write and a plain read alone", () => {
+    const source = [
+      "const issues = await tracker.listOpenIssuesByLabel(labels.quarantine);",
+      "if (!candidate.labels.includes(labels.dependencyBlocked)) continue;",
+      "await tracker.editIssueLabels(plan.issue, {",
+      "  remove: [...plan.remove],",
+      "  add: [...plan.add],",
+      "});",
+    ].join("\n");
+    expect(rawStateRoleMutations(source)).toEqual([]);
+  });
+});

--- a/packages/red-castle/src/engine/state-transition.test.ts
+++ b/packages/red-castle/src/engine/state-transition.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyTransition,
+  isRefused,
+  planTransition,
+  stateRoleLabels,
+  stateRolesOf,
+  type StateTransition,
+  type StateTransitionLabels,
+  type TransitionPlan,
+} from "./state-transition.js";
+
+const labels: StateTransitionLabels = {
+  ready: "ready-for-agent",
+  running: "running",
+  human: "ready-for-human",
+  needsTriage: "needs-triage",
+  needsInfo: "needs-info",
+  quarantine: "quarantine",
+  dependencyBlocked: "blocked:dependency",
+  blockedPrefix: "blocked:",
+  reqPrefix: "req:",
+};
+
+function plan(current: readonly string[], t: StateTransition): TransitionPlan {
+  const p = planTransition(current, t, labels);
+  if (isRefused(p)) throw new Error(`unexpected refusal: ${p.reason}`);
+  return p;
+}
+
+describe("planTransition", () => {
+  it("queue: strips park state, reasons, and running in one atomic set", () => {
+    const p = plan(["bug", "ready-for-human", "blocked:validation", "running"], { kind: "queue" });
+    expect(p.add).toEqual(["ready-for-agent"]);
+    expect(new Set(p.remove)).toEqual(
+      new Set(["ready-for-human", "running", "blocked:validation"]),
+    );
+  });
+
+  it("queue: refuses while dependency edges remain", () => {
+    const p = planTransition(["blocked:dependency", "req:7"], { kind: "queue" }, labels);
+    expect(isRefused(p)).toBe(true);
+  });
+
+  it("promote: consumes the req edges in numeric order and re-queues", () => {
+    const p = plan(["blocked:dependency", "req:12", "req:3"], { kind: "promote" });
+    expect(p.add).toEqual(["ready-for-agent"]);
+    expect(p.remove).toEqual(["blocked:dependency", "req:3", "req:12"]);
+  });
+
+  it("park: swaps the blocked reason without stacking a second one", () => {
+    const p = plan(["ready-for-agent", "blocked:infra"], {
+      kind: "park",
+      reason: "blocked:validation",
+    });
+    expect(new Set(p.add)).toEqual(new Set(["ready-for-human", "blocked:validation"]));
+    expect(new Set(p.remove)).toEqual(new Set(["ready-for-agent", "blocked:infra"]));
+  });
+
+  it("park: refuses a reason outside the blocked vocabulary", () => {
+    const p = planTransition([], { kind: "park", reason: "wontfix" }, labels);
+    expect(isRefused(p)).toBe(true);
+  });
+
+  it("human: leaves exactly the human role from an incoherent set", () => {
+    const p = plan(["quarantine", "ready-for-agent"], { kind: "human" });
+    expect(p.add).toEqual(["ready-for-human"]);
+    expect(p.remove).toEqual(["ready-for-agent", "quarantine"]);
+  });
+
+  it("dependency-block: adds the edges alongside the wait state", () => {
+    const p = plan(["ready-for-agent"], { kind: "dependency-block", reqs: [4, 9] });
+    expect(new Set(p.add)).toEqual(new Set(["blocked:dependency", "req:4", "req:9"]));
+    expect(p.remove).toEqual(["ready-for-agent"]);
+  });
+
+  it("dependency-block: refuses an empty req set", () => {
+    const p = planTransition([], { kind: "dependency-block", reqs: [] }, labels);
+    expect(isRefused(p)).toBe(true);
+  });
+
+  it("quarantine: carries the diagnosis as an appended body", () => {
+    const p = plan(["ready-for-agent"], { kind: "quarantine", diagnosis: "two state roles" });
+    expect(p.add).toEqual(["quarantine"]);
+    expect(p.appendBody).toBe("two state roles");
+  });
+
+  it("honours a host vocabulary that differs from the defaults", () => {
+    const custom: StateTransitionLabels = { ...labels, ready: "queued", reqPrefix: "needs#" };
+    const p = planTransition(["queued", "needs#5"], { kind: "promote" }, custom);
+    expect(isRefused(p)).toBe(false);
+    expect((p as TransitionPlan).remove).toEqual(["needs#5"]);
+  });
+
+  it("stateRolesOf reads the injected vocabulary", () => {
+    expect(stateRoleLabels(labels)).toHaveLength(6);
+    expect(stateRolesOf(["bug", "quarantine", "ready-for-agent"], labels)).toEqual([
+      "ready-for-agent",
+      "quarantine",
+    ]);
+  });
+});
+
+describe("applyTransition", () => {
+  it("performs one edit and appends the diagnosis to the read body", async () => {
+    const editIssue = vi.fn(async () => true);
+    const readBody = vi.fn(async () => "body\n");
+    const p = plan([], { kind: "quarantine", diagnosis: "diag" });
+    const result = await applyTransition({ editIssue, readBody }, 42, p);
+    expect(result.ok).toBe(true);
+    expect(editIssue).toHaveBeenCalledWith(42, {
+      add: ["quarantine"],
+      remove: [],
+      body: "body\n\ndiag\n",
+    });
+  });
+
+  it("omits the body read when the plan carries no diagnosis", async () => {
+    const editIssue = vi.fn(async () => true);
+    const readBody = vi.fn(async () => "body");
+    await applyTransition({ editIssue, readBody }, 7, plan(["quarantine"], { kind: "queue" }));
+    expect(readBody).not.toHaveBeenCalled();
+    expect(editIssue).toHaveBeenCalledWith(7, { add: ["ready-for-agent"], remove: ["quarantine"] });
+  });
+});

--- a/packages/red-castle/src/engine/state-transition.ts
+++ b/packages/red-castle/src/engine/state-transition.ts
@@ -1,0 +1,252 @@
+// state-transition.ts — the single owner of issue state-label mutations
+// (red-skills ADR 0122 rule 5, Spec #2523, slices #2524 + #2661 + #2666).
+//
+// An issue carries exactly ONE state role at any time. On 2026-07-22 three
+// issues accumulated contradictory role sets (park labels stacked on the
+// executable-queue label, an active blocker on a queued issue) because every
+// code path wrote labels directly; each contradiction became a red boot probe
+// and froze the fleet. This module makes those sets unconstructible: callers
+// declare the TRANSITION they want, the planner computes the atomic add/remove
+// set, refuses any request that would leave zero or two state roles, and the
+// apply step performs the whole mutation as ONE tracker call.
+//
+// The engine owns no label spellings. Every caller injects its
+// {@link StateTransitionLabels} vocabulary — the castle resident wires
+// `readEngineLabelVocabulary()`, the red-skills host wires its own
+// `triage-labels.ts` constants through the `core/state-transition.ts` shim.
+
+/**
+ * The label vocabulary a transition reads as INJECTED CONFIG. The engine never
+ * value-imports a host's label constants; the construction site supplies them.
+ */
+export interface StateTransitionLabels {
+  /** The executable-queue routing label (`ready-for-agent`). */
+  readonly ready: string;
+  /** The observability projection of an active claim (`running`). */
+  readonly running: string;
+  /** The HITL park routing label (`ready-for-human`). */
+  readonly human: string;
+  /** The un-triaged intake state (`needs-triage`). */
+  readonly needsTriage: string;
+  /** The awaiting-answer intake state (`needs-info`). */
+  readonly needsInfo: string;
+  /** The judgment-required safety hold (`quarantine`). */
+  readonly quarantine: string;
+  /** The dependency-wait state role (`blocked:dependency`). */
+  readonly dependencyBlocked: string;
+  /** The prefix every blocked-reason label shares (`blocked:`). */
+  readonly blockedPrefix: string;
+  /** The prefix of a dependency edge label (`req:{issue}`). */
+  readonly reqPrefix: string;
+}
+
+/** Every label that counts as a STATE ROLE, in the deterministic order the
+ * planner emits removals. The invariant this module enforces: a
+ * post-transition label set contains exactly one of these. */
+export function stateRoleLabels(labels: StateTransitionLabels): readonly string[] {
+  return [
+    labels.ready,
+    labels.human,
+    labels.needsTriage,
+    labels.needsInfo,
+    labels.quarantine,
+    labels.dependencyBlocked,
+  ];
+}
+
+/** The canonical transitions. Anything the engine wants to do to an issue's
+ * state is one of these — there is no "just add a label" escape hatch. */
+export type StateTransition =
+  /** Back into the executable queue. Refused while `req:*` edges remain —
+   * use `promote` (which consumes them) or clear the edges first. */
+  | { kind: "queue" }
+  /** Park for a human with a machine-readable reason (`blocked:<reason>`). */
+  | { kind: "park"; reason: string }
+  /** Plain human gate with no blocked-reason modifier. */
+  | { kind: "human" }
+  /** Healthy dependency wait: `blocked:dependency` + one `req:N` per blocker. */
+  | { kind: "dependency-block"; reqs: readonly number[] }
+  /** ADR 0122 quarantine: judgment-requiring incoherence, one issue at a time. */
+  | { kind: "quarantine"; diagnosis: string }
+  /** Close-cascade promotion: consume the `req:*` edges and re-queue. */
+  | { kind: "promote" };
+
+export interface TransitionPlan {
+  readonly add: readonly string[];
+  readonly remove: readonly string[];
+  /** Markdown appended to the issue body in the SAME tracker call (quarantine
+   * diagnoses ride the label mutation — never a second write). */
+  readonly appendBody?: string;
+}
+
+export interface RefusedTransition {
+  readonly refused: true;
+  readonly reason: string;
+}
+
+export function isRefused(
+  value: TransitionPlan | RefusedTransition,
+): value is RefusedTransition {
+  return (value as RefusedTransition).refused === true;
+}
+
+/** The state roles present in a label set (planner order preserved). */
+export function stateRolesOf(
+  current: readonly string[],
+  labels: StateTransitionLabels,
+): string[] {
+  return stateRoleLabels(labels).filter((role) => current.includes(role));
+}
+
+function targetRole(t: StateTransition, labels: StateTransitionLabels): string {
+  switch (t.kind) {
+    case "queue":
+    case "promote":
+      return labels.ready;
+    case "park":
+    case "human":
+      return labels.human;
+    case "dependency-block":
+      return labels.dependencyBlocked;
+    case "quarantine":
+      return labels.quarantine;
+  }
+}
+
+/**
+ * Compute the atomic label mutation for `transition` against the issue's
+ * `current` labels. Pure — the tracker is not consulted. Refusals name the
+ * violated rule so the caller (or its operator) can fix the REQUEST, never
+ * hand-edit around the invariant.
+ */
+export function planTransition(
+  current: readonly string[],
+  transition: StateTransition,
+  labels: StateTransitionLabels,
+): TransitionPlan | RefusedTransition {
+  if (transition.kind === "park" && !transition.reason.startsWith(labels.blockedPrefix)) {
+    return {
+      refused: true,
+      reason: `park reason must be a ${labels.blockedPrefix}* label, got "${transition.reason}"`,
+    };
+  }
+  if (transition.kind === "dependency-block" && transition.reqs.length === 0) {
+    return { refused: true, reason: "dependency-block requires at least one req issue" };
+  }
+  const reqLabels = current.filter((l) => l.startsWith(labels.reqPrefix));
+  if (transition.kind === "queue" && reqLabels.length > 0) {
+    return {
+      refused: true,
+      reason:
+        `queue refused while dependency edges remain (${reqLabels.join(", ")}); ` +
+        `use promote to consume them or clear the edges first`,
+    };
+  }
+
+  const target = targetRole(transition, labels);
+  const add = new Set<string>();
+  const remove = new Set<string>();
+
+  // Every other state role present goes; the target role arrives.
+  for (const role of stateRoleLabels(labels)) {
+    if (role === target) continue;
+    if (current.includes(role)) remove.add(role);
+  }
+  if (!current.includes(target)) add.add(target);
+
+  // Leaving execution: `running` never survives a state transition.
+  if (current.includes(labels.running)) remove.add(labels.running);
+
+  // Blocked-reason modifiers accompany exactly the states that define them.
+  const blockedPresent = current.filter(
+    (l) => l.startsWith(labels.blockedPrefix) && l !== labels.dependencyBlocked,
+  );
+  switch (transition.kind) {
+    case "park":
+      for (const l of blockedPresent) if (l !== transition.reason) remove.add(l);
+      if (!current.includes(transition.reason)) add.add(transition.reason);
+      break;
+    case "dependency-block":
+      for (const l of blockedPresent) remove.add(l);
+      for (const req of transition.reqs) {
+        const label = `${labels.reqPrefix}${req}`;
+        if (!current.includes(label)) add.add(label);
+      }
+      break;
+    case "promote": {
+      for (const l of blockedPresent) remove.add(l);
+      // Numeric req order keeps the emitted mutation deterministic regardless
+      // of the tracker's label listing order.
+      const byIssue = (l: string): number => Number(l.slice(labels.reqPrefix.length)) || 0;
+      for (const l of [...reqLabels].sort((a, b) => byIssue(a) - byIssue(b))) remove.add(l);
+      break;
+    }
+    default:
+      for (const l of blockedPresent) remove.add(l);
+      break;
+  }
+
+  // Invariant proof: replay the mutation and demand exactly one state role.
+  const result = new Set(current);
+  for (const l of remove) result.delete(l);
+  for (const l of add) result.add(l);
+  const roles = stateRolesOf([...result], labels);
+  if (roles.length !== 1) {
+    return {
+      refused: true,
+      reason: `transition would leave ${roles.length} state roles (${roles.join(", ") || "none"})`,
+    };
+  }
+
+  const plan: TransitionPlan = {
+    add: [...add],
+    remove: [...remove],
+    ...(transition.kind === "quarantine" && transition.diagnosis.trim() !== ""
+      ? { appendBody: transition.diagnosis }
+      : {}),
+  };
+  return plan;
+}
+
+/** The single tracker mutation the apply step performs. `body`, when present,
+ * is the FULL replacement body (current body + appended diagnosis) so labels
+ * and body change in one tracker edit. */
+export interface IssueEdit {
+  readonly add: readonly string[];
+  readonly remove: readonly string[];
+  readonly body?: string;
+}
+
+export interface ApplyTransitionDeps {
+  /** Perform ONE issue edit covering labels (and body when given). */
+  editIssue(issue: number, edit: IssueEdit): Promise<boolean>;
+  /** Read the current body — needed only when the plan appends a diagnosis. */
+  readBody(issue: number): Promise<string>;
+}
+
+export interface ApplyTransitionResult {
+  readonly ok: boolean;
+  readonly plan: TransitionPlan;
+}
+
+/**
+ * Apply a planned transition as ONE tracker call. Callers pass the plan they
+ * already inspected; a refused plan never reaches this function's signature.
+ */
+export async function applyTransition(
+  deps: ApplyTransitionDeps,
+  issue: number,
+  plan: TransitionPlan,
+): Promise<ApplyTransitionResult> {
+  let body: string | undefined;
+  if (plan.appendBody !== undefined) {
+    const current = await deps.readBody(issue);
+    body = `${current.replace(/\s+$/, "")}\n\n${plan.appendBody}\n`;
+  }
+  const ok = await deps.editIssue(issue, {
+    add: plan.add,
+    remove: plan.remove,
+    ...(body !== undefined ? { body } : {}),
+  });
+  return { ok, plan };
+}

--- a/packages/red-castle/src/engine/state-transition.ts
+++ b/packages/red-castle/src/engine/state-transition.ts
@@ -68,6 +68,10 @@ export type StateTransition =
   | { kind: "dependency-block"; reqs: readonly number[] }
   /** ADR 0122 quarantine: judgment-requiring incoherence, one issue at a time. */
   | { kind: "quarantine"; diagnosis: string }
+  /** Awaiting an answer from the reporter (the `/triage` `needs-info` outcome). */
+  | { kind: "needs-info" }
+  /** Back to the triage queue — the state a fresh or bounced issue sits in. */
+  | { kind: "triage" }
   /** Close-cascade promotion: consume the `req:*` edges and re-queue. */
   | { kind: "promote" };
 
@@ -110,6 +114,10 @@ function targetRole(t: StateTransition, labels: StateTransitionLabels): string {
       return labels.dependencyBlocked;
     case "quarantine":
       return labels.quarantine;
+    case "needs-info":
+      return labels.needsInfo;
+    case "triage":
+      return labels.needsTriage;
   }
 }
 

--- a/packages/red-castle/src/engine/tracker/dependencies.test.ts
+++ b/packages/red-castle/src/engine/tracker/dependencies.test.ts
@@ -12,7 +12,11 @@ const labels: EngineLabelVocabulary = {
   ready: "queue:agent",
   running: "state:running",
   human: "queue:human",
+  needsTriage: "needs-triage",
+  needsInfo: "needs-info",
+  quarantine: "quarantine",
   dependencyBlocked: "wait:dependency",
+  blockedPrefix: "blocked:",
   reqPrefix: "depends-on:",
 };
 
@@ -182,4 +186,63 @@ describe("tracker unblock sweep", () => {
       },
     ]);
   });
+});
+
+// The promotion WRITE moved to planTransition in #2666. These rows pin the
+// exact mutation the raw writer emitted before the migration, so a delta that
+// drifts by a single label fails here.
+describe("promotion label deltas are byte-identical to the pre-transition writer", () => {
+  const rows: Array<{
+    name: string;
+    body: string;
+    candidateLabels: string[];
+    remove: string[];
+    add: string[];
+  }> = [
+    {
+      name: "single edge label",
+      body: "",
+      candidateLabels: ["wait:dependency", "depends-on:7"],
+      remove: ["wait:dependency", "depends-on:7"],
+      add: ["queue:agent"],
+    },
+    {
+      name: "several edge labels are consumed in numeric order",
+      body: "",
+      candidateLabels: ["wait:dependency", "depends-on:12", "depends-on:7", "depends-on:3"],
+      remove: ["wait:dependency", "depends-on:3", "depends-on:7", "depends-on:12"],
+      add: ["queue:agent"],
+    },
+    {
+      name: "body-derived dependencies leave no edge label to consume",
+      body: "## Blocked by\n\n- #7\n",
+      candidateLabels: ["wait:dependency"],
+      remove: ["wait:dependency"],
+      add: ["queue:agent"],
+    },
+    {
+      name: "non-state labels are untouched",
+      body: "",
+      candidateLabels: ["wait:dependency", "depends-on:7", "type:ticket", "priority:high"],
+      remove: ["wait:dependency", "depends-on:7"],
+      add: ["queue:agent"],
+    },
+  ];
+
+  for (const row of rows) {
+    it(row.name, async () => {
+      const tracker = fakeTracker({
+        issues: new Map([
+          [7, { body: "", labels: [], closed: true }],
+          [3, { body: "", labels: [], closed: true }],
+          [12, { body: "", labels: [], closed: true }],
+          [20, { body: row.body, labels: row.candidateLabels, closed: false }],
+        ]),
+        labelIndex: new Map([["wait:dependency", [20]]]),
+      });
+
+      await expect(executeUnblockSweep({ tracker, labels })).resolves.toEqual([20]);
+      expect(tracker.edits).toEqual([{ issue: 20, remove: row.remove, add: row.add }]);
+    });
+  }
 });

--- a/packages/red-castle/src/engine/tracker/dependencies.ts
+++ b/packages/red-castle/src/engine/tracker/dependencies.ts
@@ -1,4 +1,5 @@
 import type { EngineLabelVocabulary } from "../config.js";
+import { isRefused, planTransition } from "../state-transition.js";
 import type { TrackerIssue, TrackerPort, TrackerIssueReference } from "./port.js";
 
 export type { TrackerIssue, TrackerPort, TrackerIssueReference } from "./port.js";
@@ -104,14 +105,17 @@ async function planPromotions(
     }
     if (!allClosed) continue;
 
+    // The DECISION above is this module's; the WRITE is the transition API's —
+    // `promote` consumes the `req:*` edges and re-queues in one proven-coherent
+    // mutation (#2666, ADR 0122 rule 5).
+    const transition = planTransition(candidate.labels, { kind: "promote" }, labels);
+    if (isRefused(transition)) continue;
+
     plans.push({
       issue: candidate.number,
       dependencies,
-      removeLabels: [
-        labels.dependencyBlocked,
-        ...labelDeps.map((dependency) => labelForDependency(dependency, labels)),
-      ],
-      addLabels: [labels.ready],
+      removeLabels: transition.remove,
+      addLabels: transition.add,
     });
   }
   return plans;


### PR DESCRIPTION
Automated AFK landing for #2666. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2666

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787835461&installation_model_id=20659&pr_number=2692&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2692&signature=54dc1de524f7ac093543affc9de8a01dd1795ef15041a2e4b0e5da3ded27ad67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->