### PR TITLE
feat: launch the AFK fleet in its own systemd scope

### DIFF
--- a/scripts/fleet-scoped.sh
+++ b/scripts/fleet-scoped.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Launch an AFK fleet inside its OWN systemd scope, so the fleet's memory is
+# charged to a cgroup of its own instead of the terminal emulator's.
+#
+# Why this exists: `red-skills-dev fleet N` inherits the caller's cgroup. Launched
+# from a terminal, every worker, every gate `pnpm install`, and every vitest fork
+# is accounted to the terminal's scope. On a systemd-oomd host the fleet then makes
+# the TERMINAL the largest cgroup, and oomd's pressure kill takes every terminal
+# window, every agent session, and every MCP server with it — while the fleet is
+# what actually generated the pressure.
+#
+# With its own scope the blast radius is the fleet: oomd (or MemoryHigh throttling)
+# hits the scope that caused the pressure, the supervisor's watchdog respawns, and
+# the terminals survive.
+#
+# Usage:
+#   scripts/fleet-scoped.sh [target] [-- extra fleet args...]
+#
+# Environment:
+#   RED_FLEET_NAME        scope/fleet name          (default: default)
+#   RED_FLEET_MEMORY_HIGH soft cap, reclaim above   (default: 6G)
+#   RED_AFK_RUNNER        runner passed through     (default: claude)
+#   RED_SKILLS_VERSION    bundle version to dispatch (default: read from the plugin manifest)
+#
+# Without systemd --user (non-Linux, no session bus), it falls back to a direct
+# launch and says so, rather than silently dropping the isolation.
+set -euo pipefail
+
+TARGET="${1:-2}"
+[ $# -gt 0 ] && shift || true
+[ "${1:-}" = "--" ] && shift || true
+
+FLEET_NAME="${RED_FLEET_NAME:-default}"
+MEMORY_HIGH="${RED_FLEET_MEMORY_HIGH:-6G}"
+RUNNER="${RED_AFK_RUNNER:-claude}"
+SCOPE_UNIT="red-fleet-${FLEET_NAME}.scope"
+
+resolve_version() {
+  if [ -n "${RED_SKILLS_VERSION:-}" ]; then
+    printf '%s' "$RED_SKILLS_VERSION"
+    return
+  fi
+  local manifest
+  manifest="$(dirname "$0")/../plugins/dev/.claude-plugin/plugin.json"
+  if [ -r "$manifest" ]; then
+    sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest" | head -1
+  fi
+}
+
+VERSION="$(resolve_version)"
+if [ -z "$VERSION" ]; then
+  echo "fleet-scoped: could not resolve the bundle version; set RED_SKILLS_VERSION" >&2
+  exit 1
+fi
+
+# ADR 0091 canonical dispatch — never the bare shim.
+FLEET_CMD=(npx -y -p "@reddb-io/red-skills@${VERSION}" red-skills-dev fleet "$TARGET" "$@")
+
+if ! command -v systemd-run >/dev/null 2>&1 || ! systemctl --user show-environment >/dev/null 2>&1; then
+  echo "fleet-scoped: no systemd --user session — launching WITHOUT cgroup isolation" >&2
+  RED_AFK_RUNNER="$RUNNER" exec "${FLEET_CMD[@]}"
+fi
+
+if systemctl --user is-active --quiet "$SCOPE_UNIT" 2>/dev/null; then
+  echo "fleet-scoped: $SCOPE_UNIT is already active — stop that fleet first" >&2
+  exit 1
+fi
+
+echo "fleet-scoped: launching fleet '$FLEET_NAME' (target=$TARGET, runner=$RUNNER) in $SCOPE_UNIT"
+echo "fleet-scoped: MemoryHigh=$MEMORY_HIGH, oomd pressure kill scoped to the fleet"
+
+# --scope: the fleet launcher returns immediately after spawning a detached
+# supervisor; the scope stays alive as long as any of its processes do, so the
+# supervisor and every worker it spawns keep inheriting this cgroup.
+# Delegate=yes lets the supervisor place its own children without asking systemd.
+RED_AFK_RUNNER="$RUNNER" exec systemd-run --user --scope \
+  --unit="red-fleet-${FLEET_NAME}" \
+  --description="RedSkills AFK fleet ${FLEET_NAME}" \
+  --property=Delegate=yes \
+  --property="MemoryHigh=${MEMORY_HIGH}" \
+  --property=ManagedOOMMemoryPressure=kill \
+  --property=ManagedOOMMemoryPressureLimit=80% \
+  -- "${FLEET_CMD[@]}"


### PR DESCRIPTION
## Why

`red-skills-dev fleet N` inherits the caller's cgroup. Launched from a terminal — which is how every local fleet starts — the supervisor, every worker, every gate `pnpm install`, and every vitest fork are accounted to the terminal emulator's scope.

On a systemd-oomd host that inverts the blast radius. Measured on a 15 GB dev box today:

- the fleet supervisor's cgroup was `app-gnome-wezterm-*.scope` — the same scope as every terminal window, agent session, and MCP server;
- that scope reached 7.4 G (peak 7.8 G) with 42 processes, of which only 1.9 G was anonymous memory — the rest was page cache and slab from ~29 per-worktree `node_modules` trees and ~1250 worker directories;
- `systemd-oomd` killed the scope on PSI pressure (`73.30% > 50.00% for > 10s`), taking **56 processes** with it. Same pattern on 7 separate days.

So the process that generated the pressure (the fleet) took down everything that merely shared its cgroup (the terminals). The fleet has a watchdog and recovers; the terminals do not.

## What this does

`scripts/fleet-scoped.sh [target]` launches the fleet inside `red-fleet-<name>.scope`, a sibling cgroup of the terminal's, with `MemoryHigh` (reclaim, no kill) and oomd's pressure kill scoped to the fleet itself.

Verified on the same box: with the scope in place the supervisor and its workers report `…/app.slice/red-fleet-default.scope`, and the terminal scope no longer grows with fleet activity.

Falls back to a direct launch, with an explicit warning on stderr, where there is no systemd `--user` session — the isolation is never silently dropped.

## Follow-up

The durable fix belongs in the launcher (`apps/dev/src/commands/fleet.ts`), so `fleet N` self-scopes on Linux without a wrapper — filed separately. This script is the immediate, reviewable step.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787838920&installation_model_id=20659&pr_number=2696&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2696&signature=f522e8f9ffb23809d179edf3fc276813db64b9dd536bcb1218c57b35e588bfc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->