### PR TITLE
chore: #2703 attempt record: the resident writes one durable narrative per worker × ticket × try

### DIFF
--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -130,6 +130,14 @@ _Avoid_: main repo, root checkout
 A single AFK orchestrator instance, identified by `w` + 4 characters (e.g. `wZ2R4`). It owns `.red/tmp/workers/{wid}/` and a single `worker.pid` liveness anchor, written once at bootstrap and removed on exit.
 _Avoid_: agent, slot, runner
 
+**Attempt**:
+One **Worker** × one **Ticket** × one try — the unit of truth of the execution plane (ADR 0128). A Ticket's history is the ordered list of its Attempts and a Worker's history is the ordered list of the Attempts it ran; both are derived views, never separately maintained state.
+_Avoid_: try, run, execution (these name a phase of an Attempt, not the unit); attempt ordinal (retired by ADR 0103 — a retry is a fresh Worker)
+
+**Attempt record**:
+The **Attempt**'s whole narrative and every pointer it produced — claim and concede, the routing decision, iteration events, commits, branch, PR, gate verdicts, landing steps, terminal outcome, resource consumption, and the artifacts it left with their reclaim eligibility. It lives on the append-only TOONL lane `.red/state/castle/attempts.toonl` (**State tier**, contract `red.castle.attempt.v1`), and the record for an Attempt is the fold of every entry sharing its `attempt_id`. Two rules are load-bearing: the **Fleet supervisor** resident writes it and the **Worker** never does, because the record matters most once the Worker is already gone; and the write path degrades to append-and-continue, because the record is diagnostic and must never fail an Attempt.
+_Avoid_: worker log, attempt log (the `worker.log.toonl` **Tmp tier** lane is disposable and worker-written, not this); attempt state (nothing is rewritten in place)
+
 **Worker kind**:
 The castle engine provenance stamp that distinguishes why a **Worker** exists while all new workers share `.red/tmp/workers/`: `current.kind=afk` for queue-draining fleet work, `current.kind=go` for approved one-off `/go` dispatch, and `current.kind=scout` for read-only `/go --scout` investigations. The legacy `.red/tmp/go-workers/` and `.red/tmp/scout-workers/` roots are read only as transitional observability inputs until they age out; they are not the live isolation contract.
 _Avoid_: worker namespace, go-workers root, scout-workers root
@@ -160,11 +168,11 @@ _Avoid_: implementer payload list, full-environment inheritance
 
 **Worker outcome**:
 How a **Worker**'s execution of an **Issue** ended, and what that ending *means* for the **Issue**: the single concept that maps a terminal result to its `blocked:<reason>` label, its envelope status, and its bounded-recovery policy key. The historical three-enum smear (`ProcessOutcome` / `BlockedReason` / `RecoveryReason`) is resolved — adding an outcome now touches one set of exhaustive switches.
-_Avoid_: attempt outcome (retired vocabulary — "attempt" is purged repo-wide), process outcome, blocked reason, recovery reason (these were the three views now unified, not separate concepts)
+_Avoid_: attempt outcome (an **Attempt**'s terminal outcome is a field of its **Attempt record**, not this concept), process outcome, blocked reason, recovery reason (these were the three views now unified, not separate concepts)
 
 **Worker disposition**:
 What AFK *does* about a **Worker outcome** — the single owner that composes the outcome's recovery decision (retry vs escalate, from the cap policy), its typed `blocked:*` label, its envelope status, and the standard escalation announcement into one pure descriptor. The worker per-issue path, the no-agent **reconcile** path, and the **Fleet supervisor** stall-reaper all consume the same disposition instead of each re-deriving labels, statuses, and comments.
-_Avoid_: attempt disposition (retired vocabulary), recovery routing, park logic (per-site applications of one disposition)
+_Avoid_: attempt disposition (not a term — an **Attempt** carries an outcome, and disposition is what AFK does about it), recovery routing, park logic (per-site applications of one disposition)
 
 **Worktree**:
 An isolated `git worktree` created by AFK per **Worker** execution, inside the worker's workspace under `.red/tmp/workers/{wid}/{issue}/`. One worker = one issue execution = one worktree; a retry is a fresh worker, not a numbered sub-directory (ADR 0103).

--- a/.red/contracts/fixtures/attempt-record/invalid/attempt-id-mismatch.toon
+++ b/.red/contracts/fixtures/attempt-record/invalid/attempt-id-mismatch.toon
@@ -1,0 +1,8 @@
+schema: red.castle.attempt.v1
+attempt_id: "wP1FZ:2703:2"
+worker_id: wP1FZ
+issue: 2703
+try: 1
+at: "2026-07-28T15:00:00.000Z"
+event: attempt.claimed
+writer: resident

--- a/.red/contracts/fixtures/attempt-record/invalid/unknown-field.toon
+++ b/.red/contracts/fixtures/attempt-record/invalid/unknown-field.toon
@@ -1,0 +1,9 @@
+schema: red.castle.attempt.v1
+attempt_id: "wP1FZ:2703:1"
+worker_id: wP1FZ
+issue: 2703
+try: 1
+at: "2026-07-28T15:00:00.000Z"
+event: attempt.claimed
+writer: resident
+msg: prose does not belong on the lane

--- a/.red/contracts/fixtures/attempt-record/invalid/worker-written.toon
+++ b/.red/contracts/fixtures/attempt-record/invalid/worker-written.toon
@@ -1,0 +1,8 @@
+schema: red.castle.attempt.v1
+attempt_id: "wP1FZ:2703:1"
+worker_id: wP1FZ
+issue: 2703
+try: 1
+at: "2026-07-28T15:00:00.000Z"
+event: attempt.claimed
+writer: worker

--- a/.red/contracts/fixtures/attempt-record/valid/attempt.record.toon
+++ b/.red/contracts/fixtures/attempt-record/valid/attempt.record.toon
@@ -1,0 +1,144 @@
+attempt_id: "wP1FZ:2703:1"
+worker_id: wP1FZ
+issue: 2703
+try: 1
+opened_at: "2026-07-28T15:00:00.000Z"
+updated_at: "2026-07-28T15:21:40.000Z"
+closed: true
+commits[1]: 1f2e3d4
+gate[1]{name,status,summary}:
+  test,passed,412 passed
+landing[1]{step,status,detail}:
+  merge,done,squash
+artifacts[1]{kind,path,reclaimable,reclaim_after,reason}:
+  worktree,.red/tmp/workers/wP1FZ/2703/worktree,true,"2026-07-29T15:21:30.000Z",landed
+events[9]:
+  - schema: red.castle.attempt.v1
+    attempt_id: "wP1FZ:2703:1"
+    worker_id: wP1FZ
+    issue: 2703
+    try: 1
+    at: "2026-07-28T15:00:00.000Z"
+    event: attempt.claimed
+    writer: resident
+    claim:
+      state: claimed
+      by: resident
+  - schema: red.castle.attempt.v1
+    attempt_id: "wP1FZ:2703:1"
+    worker_id: wP1FZ
+    issue: 2703
+    try: 1
+    at: "2026-07-28T15:00:01.000Z"
+    event: attempt.routed
+    writer: resident
+    routing:
+      runner: claude
+      tier: complex
+      model: claude-opus-5
+      effort: medium
+  - schema: red.castle.attempt.v1
+    attempt_id: "wP1FZ:2703:1"
+    worker_id: wP1FZ
+    issue: 2703
+    try: 1
+    at: "2026-07-28T15:04:00.000Z"
+    event: attempt.progressed
+    writer: resident
+    note: iteration 1
+    payload:
+      tools: 12
+  - schema: red.castle.attempt.v1
+    attempt_id: "wP1FZ:2703:1"
+    worker_id: wP1FZ
+    issue: 2703
+    try: 1
+    at: "2026-07-28T15:12:00.000Z"
+    event: attempt.committed
+    writer: resident
+    branch: afk/2703-attempt-record
+    commit: 1f2e3d4
+  - schema: red.castle.attempt.v1
+    attempt_id: "wP1FZ:2703:1"
+    worker_id: wP1FZ
+    issue: 2703
+    try: 1
+    at: "2026-07-28T15:14:00.000Z"
+    event: attempt.pr-opened
+    writer: resident
+    pr: 2710
+  - schema: red.castle.attempt.v1
+    attempt_id: "wP1FZ:2703:1"
+    worker_id: wP1FZ
+    issue: 2703
+    try: 1
+    at: "2026-07-28T15:19:00.000Z"
+    event: attempt.gated
+    writer: resident
+    gate:
+      name: test
+      status: passed
+      summary: 412 passed
+  - schema: red.castle.attempt.v1
+    attempt_id: "wP1FZ:2703:1"
+    worker_id: wP1FZ
+    issue: 2703
+    try: 1
+    at: "2026-07-28T15:21:00.000Z"
+    event: attempt.landing
+    writer: resident
+    landing:
+      step: merge
+      status: done
+      detail: squash
+  - schema: red.castle.attempt.v1
+    attempt_id: "wP1FZ:2703:1"
+    worker_id: wP1FZ
+    issue: 2703
+    try: 1
+    at: "2026-07-28T15:21:30.000Z"
+    event: attempt.artifact
+    writer: resident
+    artifact:
+      kind: worktree
+      path: .red/tmp/workers/wP1FZ/2703/worktree
+      reclaimable: true
+      reclaim_after: "2026-07-29T15:21:30.000Z"
+      reason: landed
+  - schema: red.castle.attempt.v1
+    attempt_id: "wP1FZ:2703:1"
+    worker_id: wP1FZ
+    issue: 2703
+    try: 1
+    at: "2026-07-28T15:21:40.000Z"
+    event: attempt.closed
+    writer: resident
+    claim:
+      state: conceded
+      by: resident
+      reason: landed
+    outcome:
+      kind: done
+      detail: merged as 9a8b7c6
+    resources:
+      wall_clock_s: 1300
+      peak_rss_mb: 812
+      cost_usd: 1.42
+claim:
+  state: conceded
+  by: resident
+  reason: landed
+routing:
+  runner: claude
+  tier: complex
+  model: claude-opus-5
+  effort: medium
+branch: afk/2703-attempt-record
+pr: 2710
+resources:
+  wall_clock_s: 1300
+  peak_rss_mb: 812
+  cost_usd: 1.42
+outcome:
+  kind: done
+  detail: merged as 9a8b7c6

--- a/.red/contracts/fixtures/attempt-record/valid/attempt.toonl
+++ b/.red/contracts/fixtures/attempt-record/valid/attempt.toonl
@@ -1,0 +1,18 @@
+[]{schema,attempt_id,worker_id,issue,try,at,event,writer,claim}:
+red.castle.attempt.v1,"wP1FZ:2703:1",wP1FZ,2703,1,"2026-07-28T15:00:00.000Z",attempt.claimed,resident,"{\"state\":\"claimed\",\"by\":\"resident\"}"
+[]{schema,attempt_id,worker_id,issue,try,at,event,writer,routing}:
+red.castle.attempt.v1,"wP1FZ:2703:1",wP1FZ,2703,1,"2026-07-28T15:00:01.000Z",attempt.routed,resident,"{\"runner\":\"claude\",\"tier\":\"complex\",\"model\":\"claude-opus-5\",\"effort\":\"medium\"}"
+[]{schema,attempt_id,worker_id,issue,try,at,event,writer,note,payload}:
+red.castle.attempt.v1,"wP1FZ:2703:1",wP1FZ,2703,1,"2026-07-28T15:04:00.000Z",attempt.progressed,resident,iteration 1,"{\"tools\":12}"
+[]{schema,attempt_id,worker_id,issue,try,at,event,writer,branch,commit}:
+red.castle.attempt.v1,"wP1FZ:2703:1",wP1FZ,2703,1,"2026-07-28T15:12:00.000Z",attempt.committed,resident,afk/2703-attempt-record,1f2e3d4
+[]{schema,attempt_id,worker_id,issue,try,at,event,writer,pr}:
+red.castle.attempt.v1,"wP1FZ:2703:1",wP1FZ,2703,1,"2026-07-28T15:14:00.000Z",attempt.pr-opened,resident,2710
+[]{schema,attempt_id,worker_id,issue,try,at,event,writer,gate}:
+red.castle.attempt.v1,"wP1FZ:2703:1",wP1FZ,2703,1,"2026-07-28T15:19:00.000Z",attempt.gated,resident,"{\"name\":\"test\",\"status\":\"passed\",\"summary\":\"412 passed\"}"
+[]{schema,attempt_id,worker_id,issue,try,at,event,writer,landing}:
+red.castle.attempt.v1,"wP1FZ:2703:1",wP1FZ,2703,1,"2026-07-28T15:21:00.000Z",attempt.landing,resident,"{\"step\":\"merge\",\"status\":\"done\",\"detail\":\"squash\"}"
+[]{schema,attempt_id,worker_id,issue,try,at,event,writer,artifact}:
+red.castle.attempt.v1,"wP1FZ:2703:1",wP1FZ,2703,1,"2026-07-28T15:21:30.000Z",attempt.artifact,resident,"{\"kind\":\"worktree\",\"path\":\".red/tmp/workers/wP1FZ/2703/worktree\",\"reclaimable\":true,\"reclaim_after\":\"2026-07-29T15:21:30.000Z\",\"reason\":\"landed\"}"
+[]{schema,attempt_id,worker_id,issue,try,at,event,writer,claim,outcome,resources}:
+red.castle.attempt.v1,"wP1FZ:2703:1",wP1FZ,2703,1,"2026-07-28T15:21:40.000Z",attempt.closed,resident,"{\"state\":\"conceded\",\"by\":\"resident\",\"reason\":\"landed\"}","{\"kind\":\"done\",\"detail\":\"merged as 9a8b7c6\"}","{\"wall_clock_s\":1300,\"peak_rss_mb\":812,\"cost_usd\":1.42}"

--- a/.red/contracts/red.castle.attempt.v1.md
+++ b/.red/contracts/red.castle.attempt.v1.md
@@ -1,0 +1,68 @@
+# Castle Attempt Record
+
+schema id: `red.castle.attempt.v1`
+
+Exported TypeScript contract types: `CastleAttemptEntry`, `CastleAttemptRecord`,
+`CastleAttemptEvent`, `CastleAttemptWriter`, `CastleAttemptClaim`,
+`CastleAttemptRouting`, `CastleAttemptGateVerdict`, `CastleAttemptLandingStep`,
+`CastleAttemptOutcome`, `CastleAttemptOutcomeKind`, `CastleAttemptResources`,
+`CastleAttemptArtifact`.
+
+The **attempt** — one worker × one ticket × one try — is the unit of truth of
+the execution plane (ADR 0128). Its record is the append-only TOONL lane
+`.red/state/castle/attempts.toonl`: durable state per ADR 0098, never `.red/tmp/`,
+which holds only the attempt's disposable workspace.
+
+Three rules the writer enforces:
+
+1. **The resident writes it, never the worker.** Every entry carries
+   `writer: "resident"` and an entry stamped otherwise is rejected — the record
+   matters most exactly when the worker is already gone, so a self-reported one
+   is unavailable when it is needed.
+2. **The write path degrades, it never fails an attempt.** A malformed entry or
+   an unwritable lane is surfaced as a diagnostic and execution continues. The
+   record is diagnostic; it must never break execution.
+3. **The lane is append-only.** A later fact about an attempt is a new line, not
+   an edit of an earlier one. A prior attempt's record is never rewritten.
+
+An attempt's `CastleAttemptRecord` is the **fold** of every entry sharing its
+`attempt_id` (`<worker_id>:<issue>:<try>`). A ticket's history and a worker's
+history are filters over that fold — derived views, never separately maintained
+state.
+
+## Entry fields
+
+Required on every entry — a missing one is rejected before the lane is touched:
+
+- `schema`
+- `attempt_id`
+- `worker_id`
+- `issue`
+- `try`
+- `at`
+- `event`
+- `writer`
+
+Narrative and pointer fields, each optional and each carried by the event that
+learned it:
+
+- `claim` — claim and concede, with the reason
+- `routing` — the routing decision: runner, tier, model, effort
+- `branch` — the attempt's branch
+- `commit` — one commit; the fold accumulates them in order
+- `pr` — the pull request number
+- `gate` — one gate verdict; the fold accumulates them
+- `landing` — one landing step; the fold accumulates them
+- `outcome` — the terminal outcome; a `budget-exceeded` outcome NAMES its
+  budget and is never recorded as a stall
+- `resources` — wall clock, peak RSS, cost
+- `artifact` — one artifact left behind, with its reclaim eligibility, so the
+  janitor reclaims on the record's verdict rather than on a missing pid file
+- `note` — a one-line human-readable gloss
+- `payload` — event-specific detail that has no dedicated field yet
+
+## Pinned fixture
+
+`.red/contracts/fixtures/attempt-record/` pins the lane bytes and the folded
+record the writer must produce, plus the invalid entries it must reject. Both
+the writer and every reader are tested against it.

--- a/packages/red-castle/src/engine/attempt-record.test.ts
+++ b/packages/red-castle/src/engine/attempt-record.test.ts
@@ -1,0 +1,385 @@
+// attempt-record.test.ts — the pinned contract for the resident-owned attempt
+// record (ADR 0128, issue #2703).
+//
+// The fixture under `.red/contracts/fixtures/attempt-record/` is the schema:
+// the writer must reproduce its bytes, the fold must reproduce its record, and
+// every invalid entry beside it must be rejected before the lane is touched.
+
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { decode } from "@reddb-io/toon";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  CASTLE_ATTEMPT_REQUIRED_FIELDS,
+  CastleAttemptValidationError,
+  castleAttemptId,
+  createCastleAttemptRecorder,
+  foldCastleAttemptRecords,
+  readCastleAttemptEntries,
+  readCastleAttemptRecords,
+  validateCastleAttemptEntry,
+  type CastleAttemptEventFields,
+  type CastleAttemptLog,
+} from "./attempt-record.js";
+import {
+  CASTLE_ATTEMPT_SCHEMA_ID,
+  type CastleAttemptEntry,
+} from "./contracts/index.js";
+import { createEnginePaths } from "./paths.js";
+
+const FIXTURE_ROOT = resolve(
+  import.meta.dirname,
+  "../../../..",
+  ".red/contracts/fixtures/attempt-record",
+);
+const PINNED_LANE = join(FIXTURE_ROOT, "valid/attempt.toonl");
+const PINNED_RECORD = join(FIXTURE_ROOT, "valid/attempt.record.toon");
+
+const IDENTITY = { worker_id: "wP1FZ", issue: 2703, try: 1 } as const;
+
+/** The narrative the resident writes, event by event — the fixture's script. */
+const NARRATIVE: readonly [string, CastleAttemptEventFields][] = [
+  [
+    "attempt.claimed",
+    {
+      at: "2026-07-28T15:00:00.000Z",
+      claim: { state: "claimed", by: "resident" },
+    },
+  ],
+  [
+    "attempt.routed",
+    {
+      at: "2026-07-28T15:00:01.000Z",
+      routing: {
+        runner: "claude",
+        tier: "complex",
+        model: "claude-opus-5",
+        effort: "medium",
+      },
+    },
+  ],
+  [
+    "attempt.progressed",
+    { at: "2026-07-28T15:04:00.000Z", note: "iteration 1", payload: { tools: 12 } },
+  ],
+  [
+    "attempt.committed",
+    {
+      at: "2026-07-28T15:12:00.000Z",
+      branch: "afk/2703-attempt-record",
+      commit: "1f2e3d4",
+    },
+  ],
+  ["attempt.pr-opened", { at: "2026-07-28T15:14:00.000Z", pr: 2710 }],
+  [
+    "attempt.gated",
+    {
+      at: "2026-07-28T15:19:00.000Z",
+      gate: { name: "test", status: "passed", summary: "412 passed" },
+    },
+  ],
+  [
+    "attempt.landing",
+    {
+      at: "2026-07-28T15:21:00.000Z",
+      landing: { step: "merge", status: "done", detail: "squash" },
+    },
+  ],
+  [
+    "attempt.artifact",
+    {
+      at: "2026-07-28T15:21:30.000Z",
+      artifact: {
+        kind: "worktree",
+        path: ".red/tmp/workers/wP1FZ/2703/worktree",
+        reclaimable: true,
+        reclaim_after: "2026-07-29T15:21:30.000Z",
+        reason: "landed",
+      },
+    },
+  ],
+  [
+    "attempt.closed",
+    {
+      at: "2026-07-28T15:21:40.000Z",
+      claim: { state: "conceded", by: "resident", reason: "landed" },
+      outcome: { kind: "done", detail: "merged as 9a8b7c6" },
+      resources: { wall_clock_s: 1300, peak_rss_mb: 812, cost_usd: 1.42 },
+    },
+  ],
+];
+
+async function replayNarrative(log: CastleAttemptLog): Promise<void> {
+  for (const [event, fields] of NARRATIVE) {
+    const result = await log.record(event, fields);
+    expect(result.ok, `${event} should append`).toBe(true);
+  }
+}
+
+describe("resident-owned attempt record", () => {
+  let redRoot: string;
+
+  beforeEach(() => {
+    redRoot = join(
+      tmpdir(),
+      `castle-attempt-record-${process.pid}-${Math.random().toString(36).slice(2)}`,
+      ".red",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(resolve(redRoot, ".."), { recursive: true, force: true });
+  });
+
+  it("lands the lane under state/castle, never under tmp", () => {
+    const paths = createEnginePaths(redRoot);
+    expect(paths.castleAttempts).toBe(
+      join(redRoot, "state", "castle", "attempts.toonl"),
+    );
+    expect(paths.castleAttempts.includes(`${join(redRoot, "tmp")}`)).toBe(false);
+  });
+
+  it("writes exactly the bytes the pinned fixture defines", async () => {
+    const recorder = createCastleAttemptRecorder(createEnginePaths(redRoot));
+    await replayNarrative(recorder.attempt(IDENTITY));
+
+    expect(await readFile(recorder.path, "utf8")).toBe(
+      readFileSync(PINNED_LANE, "utf8"),
+    );
+  });
+
+  it("folds the pinned lane into the pinned attempt record", async () => {
+    const folded = await readCastleAttemptRecords(PINNED_LANE);
+
+    expect(folded).toHaveLength(1);
+    expect(folded[0]).toEqual(decode(readFileSync(PINNED_RECORD, "utf8")));
+    expect(folded[0]!.attempt_id).toBe(castleAttemptId(IDENTITY));
+  });
+
+  it("rejects an entry missing any required field, before touching the lane", async () => {
+    const paths = createEnginePaths(redRoot);
+    const recorder = createCastleAttemptRecorder(paths);
+    const complete = (await readCastleAttemptEntries(PINNED_LANE))[0]!;
+
+    for (const field of CASTLE_ATTEMPT_REQUIRED_FIELDS) {
+      const incomplete = { ...complete };
+      delete (incomplete as Record<string, unknown>)[field];
+      expect(
+        () => validateCastleAttemptEntry(incomplete as CastleAttemptEntry),
+        `missing ${field} must be rejected`,
+      ).toThrow(CastleAttemptValidationError);
+    }
+
+    // The writer degrades on the same rejection rather than throwing, and the
+    // lane stays untouched.
+    const result = await recorder
+      .attempt(IDENTITY)
+      .record("attempt.progressed", { at: "" });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostic?.reason).toBe("validation");
+    expect(existsSync(paths.castleAttempts)).toBe(false);
+  });
+
+  it("rejects every invalid entry the fixture pins", () => {
+    for (const name of [
+      "worker-written",
+      "unknown-field",
+      "attempt-id-mismatch",
+    ]) {
+      const entry = decode(
+        readFileSync(join(FIXTURE_ROOT, `invalid/${name}.toon`), "utf8"),
+      ) as unknown as CastleAttemptEntry;
+      expect(
+        () => validateCastleAttemptEntry(entry),
+        `${name} must be rejected`,
+      ).toThrow(CastleAttemptValidationError);
+    }
+  });
+
+  it("keeps the record of an attempt whose worker was killed mid-flight", async () => {
+    const paths = createEnginePaths(redRoot);
+    const recorder = createCastleAttemptRecorder(paths);
+    const log = recorder.attempt(IDENTITY);
+
+    // A real worker process, killed with no chance to report on itself.
+    const worker = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const exited = new Promise<void>((done) => worker.once("exit", () => done()));
+
+    await log.record("attempt.claimed", {
+      at: "2026-07-28T16:00:00.000Z",
+      claim: { state: "claimed", by: "resident" },
+    });
+    await log.record("attempt.routed", {
+      at: "2026-07-28T16:00:01.000Z",
+      routing: { runner: "claude", tier: "complex" },
+    });
+    await log.record("attempt.committed", {
+      at: "2026-07-28T16:10:00.000Z",
+      branch: "afk/2703-attempt-record",
+      commit: "deadbee",
+    });
+    await log.record("attempt.pr-opened", {
+      at: "2026-07-28T16:11:00.000Z",
+      pr: 2710,
+    });
+
+    worker.kill("SIGKILL");
+    await exited;
+    expect(worker.killed).toBe(true);
+
+    // The resident outlives the worker and closes the narrative itself.
+    await log.record("attempt.closed", {
+      at: "2026-07-28T16:11:05.000Z",
+      outcome: { kind: "killed", detail: "SIGKILL, worker gone" },
+      resources: { wall_clock_s: 665 },
+      artifact: {
+        kind: "pull-request",
+        ref: "2710",
+        reclaimable: false,
+        reason: "open PR carries complete work",
+      },
+    });
+
+    const record = await log.read();
+    expect(record).toBeDefined();
+    expect(record!.branch).toBe("afk/2703-attempt-record");
+    expect(record!.commits).toEqual(["deadbee"]);
+    expect(record!.pr).toBe(2710);
+    expect(record!.routing).toEqual({ runner: "claude", tier: "complex" });
+    expect(record!.outcome).toEqual({
+      kind: "killed",
+      detail: "SIGKILL, worker gone",
+    });
+    expect(record!.artifacts[0]?.reclaimable).toBe(false);
+    expect(record!.closed).toBe(true);
+    expect(record!.events.map((entry) => entry.event)).toEqual([
+      "attempt.claimed",
+      "attempt.routed",
+      "attempt.committed",
+      "attempt.pr-opened",
+      "attempt.closed",
+    ]);
+  });
+
+  it("surfaces an unwritable lane as a diagnostic, leaving the attempt running", async () => {
+    const paths = createEnginePaths(redRoot);
+    // A directory where the lane file belongs: every append fails, for any uid.
+    await mkdir(paths.castleAttempts, { recursive: true });
+
+    const seen: string[] = [];
+    const recorder = createCastleAttemptRecorder(paths, {
+      clock: () => "2026-07-28T17:00:00.000Z",
+      onDiagnostic: (diagnostic) => seen.push(diagnostic.reason),
+    });
+    const log = recorder.attempt(IDENTITY);
+
+    // The attempt's own control flow: it must reach the end regardless.
+    const steps: string[] = [];
+    for (const [event, fields] of NARRATIVE) {
+      const result = await log.record(event, fields);
+      expect(result.ok).toBe(false);
+      steps.push(event);
+    }
+
+    expect(steps).toEqual(NARRATIVE.map(([event]) => event));
+    expect(seen).toEqual(NARRATIVE.map(() => "write"));
+    expect(recorder.diagnostics()).toHaveLength(NARRATIVE.length);
+    expect(recorder.diagnostics()[0]).toMatchObject({
+      at: "2026-07-28T17:00:00.000Z",
+      reason: "write",
+      attempt_id: "wP1FZ:2703:1",
+      event: "attempt.claimed",
+    });
+  });
+
+  it("is append-only: a later attempt never rewrites a prior attempt's record", async () => {
+    const paths = createEnginePaths(redRoot);
+    const recorder = createCastleAttemptRecorder(paths);
+    const first = recorder.attempt(IDENTITY);
+    const second = recorder.attempt({ ...IDENTITY, try: 2 });
+
+    const snapshots: string[] = [];
+    const appends: [CastleAttemptLog, string, CastleAttemptEventFields][] = [
+      [first, "attempt.claimed", { at: "2026-07-28T18:00:00.000Z" }],
+      [first, "attempt.committed", { at: "2026-07-28T18:05:00.000Z", commit: "aaa1111" }],
+      [second, "attempt.claimed", { at: "2026-07-28T18:06:00.000Z" }],
+      [
+        first,
+        "attempt.closed",
+        { at: "2026-07-28T18:07:00.000Z", outcome: { kind: "blocked" } },
+      ],
+      [second, "attempt.committed", { at: "2026-07-28T18:09:00.000Z", commit: "bbb2222" }],
+    ];
+
+    for (const [log, event, fields] of appends) {
+      expect((await log.record(event, fields)).ok).toBe(true);
+      snapshots.push(await readFile(paths.castleAttempts, "utf8"));
+    }
+
+    // Every earlier state of the lane is a strict PREFIX of every later one —
+    // the only shape an in-place rewrite cannot survive.
+    for (let index = 1; index < snapshots.length; index += 1) {
+      expect(snapshots[index]!.startsWith(snapshots[index - 1]!)).toBe(true);
+      expect(snapshots[index]!.length).toBeGreaterThan(
+        snapshots[index - 1]!.length,
+      );
+    }
+
+    const records = await recorder.read();
+    expect(records.map((record) => record.attempt_id)).toEqual([
+      "wP1FZ:2703:1",
+      "wP1FZ:2703:2",
+    ]);
+    expect(records[0]!.commits).toEqual(["aaa1111"]);
+    expect(records[0]!.outcome).toEqual({ kind: "blocked" });
+    expect(records[1]!.commits).toEqual(["bbb2222"]);
+    expect(records[1]!.closed).toBe(false);
+  });
+
+  it("reads every complete entry when the lane's tail is torn by a kill", async () => {
+    const paths = createEnginePaths(redRoot);
+    const recorder = createCastleAttemptRecorder(paths);
+    await replayNarrative(recorder.attempt(IDENTITY));
+
+    const whole = await readFile(paths.castleAttempts, "utf8");
+    await writeFile(paths.castleAttempts, `${whole}[]{schema,attempt_`, "utf8");
+
+    const records = await readCastleAttemptRecords(paths.castleAttempts);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.events).toHaveLength(NARRATIVE.length);
+    expect(records[0]!.pr).toBe(2710);
+  });
+
+  it("folds a ticket's attempts and a worker's attempts from the one lane", () => {
+    const entry = (
+      worker_id: string,
+      issue: number,
+      tryNumber: number,
+    ): CastleAttemptEntry => ({
+      schema: CASTLE_ATTEMPT_SCHEMA_ID,
+      attempt_id: castleAttemptId({ worker_id, issue, try: tryNumber }),
+      worker_id,
+      issue,
+      try: tryNumber,
+      at: "2026-07-28T19:00:00.000Z",
+      event: "attempt.claimed",
+      writer: "resident",
+    });
+
+    const records = foldCastleAttemptRecords([
+      entry("wAAA1", 2703, 1),
+      entry("wBBB2", 2703, 2),
+      entry("wAAA1", 2704, 1),
+    ]);
+
+    expect(records.filter((record) => record.issue === 2703)).toHaveLength(2);
+    expect(
+      records.filter((record) => record.worker_id === "wAAA1"),
+    ).toHaveLength(2);
+  });
+});

--- a/packages/red-castle/src/engine/attempt-record.ts
+++ b/packages/red-castle/src/engine/attempt-record.ts
@@ -1,0 +1,406 @@
+// attempt-record.ts — the resident-owned attempt record (ADR 0128).
+//
+// Two constraints from the ADR shape every line below:
+//
+//  1. THE RESIDENT WRITES IT, NEVER THE WORKER. `writer` is validated to
+//     `"resident"`, and the record must survive the worker's death — that is
+//     the case it exists for.
+//  2. THE WRITE PATH DEGRADES, IT NEVER FAILS AN ATTEMPT. `record()` resolves
+//     with a diagnostic instead of throwing, on validation errors and on I/O
+//     errors alike. The record is diagnostic; it must never break execution.
+//
+// The lane is append-only: a prior attempt's record is NEVER rewritten in
+// place. An attempt's record is the FOLD of every entry sharing its
+// `attempt_id`, so a later fact is a new line, not an edit.
+
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
+import {
+  CASTLE_ATTEMPT_SCHEMA_ID,
+  CASTLE_PUBLISHED_CONTRACTS,
+  type CastleAttemptEntry,
+  type CastleAttemptEvent,
+  type CastleAttemptRecord,
+} from "./contracts/index.js";
+import type { EnginePaths } from "./paths.js";
+
+export class CastleAttemptValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CastleAttemptValidationError";
+  }
+}
+
+/** Every field a caller must supply. Missing any one of them is a rejection. */
+export const CASTLE_ATTEMPT_REQUIRED_FIELDS = [
+  "schema",
+  "attempt_id",
+  "worker_id",
+  "issue",
+  "try",
+  "at",
+  "event",
+  "writer",
+] as const satisfies readonly (keyof CastleAttemptEntry)[];
+
+const ATTEMPT_FIELDS = new Set<string>(
+  CASTLE_PUBLISHED_CONTRACTS.find(
+    (candidate) => candidate.schemaId === CASTLE_ATTEMPT_SCHEMA_ID,
+  )!.fields,
+);
+
+/** Object-valued fields, stored as JSON scalars in the TOONL row. */
+const NESTED_FIELDS = [
+  "claim",
+  "routing",
+  "gate",
+  "landing",
+  "outcome",
+  "resources",
+  "artifact",
+  "payload",
+] as const;
+
+export interface CastleAttemptIdentity {
+  worker_id: string;
+  issue: number;
+  try: number;
+}
+
+/** The attempt's stable identity: one worker × one ticket × one try. */
+export function castleAttemptId(identity: CastleAttemptIdentity): string {
+  return `${identity.worker_id}:${identity.issue}:${identity.try}`;
+}
+
+function reject(message: string): never {
+  throw new CastleAttemptValidationError(message);
+}
+
+function assertNonEmptyString(
+  raw: Record<string, unknown>,
+  field: string,
+): void {
+  if (typeof raw[field] !== "string" || raw[field].length === 0) {
+    reject(`attempt entry needs string ${field}`);
+  }
+}
+
+function assertPositiveInteger(
+  raw: Record<string, unknown>,
+  field: string,
+): void {
+  const value = raw[field];
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    reject(`attempt entry ${field} must be a positive integer`);
+  }
+}
+
+function assertOptionalObject(
+  raw: Record<string, unknown>,
+  field: string,
+): void {
+  const value = raw[field];
+  if (value === undefined) return;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    reject(`attempt entry ${field} must be an object`);
+  }
+}
+
+export function validateCastleAttemptEntry(
+  entry: CastleAttemptEntry,
+): CastleAttemptEntry {
+  const raw = entry as unknown as Record<string, unknown>;
+  for (const field of Object.keys(raw)) {
+    if (!ATTEMPT_FIELDS.has(field)) {
+      reject(
+        `${CASTLE_ATTEMPT_SCHEMA_ID} rejects unknown field ${JSON.stringify(field)}`,
+      );
+    }
+  }
+  for (const field of CASTLE_ATTEMPT_REQUIRED_FIELDS) {
+    if (raw[field] === undefined) {
+      reject(`attempt entry is missing required field ${field}`);
+    }
+  }
+  if (raw.schema !== CASTLE_ATTEMPT_SCHEMA_ID) {
+    reject(`attempt entry schema must be ${CASTLE_ATTEMPT_SCHEMA_ID}`);
+  }
+  // ADR 0128 §2: the resident owns the write. A worker-stamped entry is the
+  // self-report the ADR forbids, so it never reaches the lane.
+  if (raw.writer !== "resident") {
+    reject("attempt entry writer must be resident, never the worker");
+  }
+  for (const field of ["attempt_id", "worker_id", "at", "event"]) {
+    assertNonEmptyString(raw, field);
+  }
+  for (const field of ["issue", "try"]) assertPositiveInteger(raw, field);
+  if (raw.attempt_id !== castleAttemptId(entry)) {
+    reject(
+      `attempt_id must be ${castleAttemptId(entry)} for this worker, issue, and try`,
+    );
+  }
+  for (const field of NESTED_FIELDS) assertOptionalObject(raw, field);
+  for (const field of ["branch", "commit", "note"]) {
+    if (raw[field] !== undefined) assertNonEmptyString(raw, field);
+  }
+  if (raw.pr !== undefined) assertPositiveInteger(raw, "pr");
+  return entry;
+}
+
+function toToonlRow(entry: CastleAttemptEntry): ToonlRecord {
+  const row: ToonlRecord = {};
+  for (const [key, value] of Object.entries(entry)) {
+    if (value === undefined) continue;
+    row[key] =
+      value === null ||
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+        ? value
+        : JSON.stringify(value);
+  }
+  return row;
+}
+
+function fromToonlRow(row: unknown): CastleAttemptEntry {
+  if (row === null || typeof row !== "object") {
+    reject("attempt entry must be an object");
+  }
+  const raw = { ...(row as Record<string, unknown>) };
+  for (const field of NESTED_FIELDS) {
+    if (typeof raw[field] !== "string") continue;
+    try {
+      raw[field] = JSON.parse(raw[field]) as Record<string, unknown>;
+    } catch {
+      reject(`attempt entry ${field} is not valid JSON`);
+    }
+  }
+  return validateCastleAttemptEntry(raw as unknown as CastleAttemptEntry);
+}
+
+/**
+ * Parse a lane whose TAIL MAY BE TORN. A worker killed mid-flight can leave the
+ * resident's last append half-written; dropping physical lines from the end
+ * until the remainder parses keeps every complete entry readable, which is the
+ * whole point of the record.
+ */
+function parseTolerantly(raw: string): ToonlRecord[] {
+  const lines = raw.split("\n");
+  while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  for (let end = lines.length; end > 0; end--) {
+    try {
+      return parseRecords(`${lines.slice(0, end).join("\n")}\n`);
+    } catch {
+      // Torn tail — retry without the last physical line.
+    }
+  }
+  return [];
+}
+
+async function readLane(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw err;
+  }
+}
+
+/** Every complete entry on the lane, oldest first. */
+export async function readCastleAttemptEntries(
+  path: string,
+): Promise<CastleAttemptEntry[]> {
+  const raw = await readLane(path);
+  if (raw === undefined) return [];
+  return parseTolerantly(raw).map(fromToonlRow);
+}
+
+/**
+ * Fold entries into one record per attempt, in first-seen order. A ticket's
+ * history and a worker's history are both filters over this — derived views,
+ * never separately maintained state (ADR 0128 §1).
+ */
+export function foldCastleAttemptRecords(
+  entries: readonly CastleAttemptEntry[],
+): CastleAttemptRecord[] {
+  const records = new Map<string, CastleAttemptRecord>();
+  for (const entry of entries) {
+    let record = records.get(entry.attempt_id);
+    if (!record) {
+      record = {
+        attempt_id: entry.attempt_id,
+        worker_id: entry.worker_id,
+        issue: entry.issue,
+        try: entry.try,
+        opened_at: entry.at,
+        updated_at: entry.at,
+        closed: false,
+        commits: [],
+        gate: [],
+        landing: [],
+        artifacts: [],
+        events: [],
+      };
+      records.set(entry.attempt_id, record);
+    }
+    record.updated_at = entry.at;
+    record.events.push(entry);
+    if (entry.claim) record.claim = entry.claim;
+    if (entry.routing) record.routing = entry.routing;
+    if (entry.branch) record.branch = entry.branch;
+    if (entry.commit && !record.commits.includes(entry.commit)) {
+      record.commits.push(entry.commit);
+    }
+    if (entry.pr !== undefined) record.pr = entry.pr;
+    if (entry.gate) record.gate.push(entry.gate);
+    if (entry.landing) record.landing.push(entry.landing);
+    if (entry.resources) record.resources = entry.resources;
+    if (entry.artifact) record.artifacts.push(entry.artifact);
+    if (entry.outcome) {
+      record.outcome = entry.outcome;
+      record.closed = true;
+    }
+  }
+  return [...records.values()];
+}
+
+export async function readCastleAttemptRecords(
+  path: string,
+): Promise<CastleAttemptRecord[]> {
+  return foldCastleAttemptRecords(await readCastleAttemptEntries(path));
+}
+
+export interface CastleAttemptDiagnostic {
+  at: string;
+  /** `validation` — the entry was malformed; `write` — the lane was unwritable. */
+  reason: "validation" | "write";
+  message: string;
+  attempt_id?: string;
+  event?: string;
+}
+
+export interface CastleAttemptAppendResult {
+  ok: boolean;
+  entry?: CastleAttemptEntry;
+  diagnostic?: CastleAttemptDiagnostic;
+}
+
+/** The narrative fields a caller supplies alongside the event. `at` defaults to
+ * the recorder's clock, so the resident stamps the time it OBSERVED the fact. */
+export type CastleAttemptEventFields = Omit<
+  CastleAttemptEntry,
+  | "schema"
+  | "attempt_id"
+  | "worker_id"
+  | "issue"
+  | "try"
+  | "at"
+  | "event"
+  | "writer"
+> & { at?: string };
+
+export interface CastleAttemptLog {
+  readonly attempt_id: string;
+  readonly path: string;
+  record(
+    event: CastleAttemptEvent,
+    fields?: CastleAttemptEventFields,
+  ): Promise<CastleAttemptAppendResult>;
+  read(): Promise<CastleAttemptRecord | undefined>;
+}
+
+export interface CastleAttemptRecorderOptions {
+  readonly clock?: () => string;
+  /** Where a degraded write is surfaced. Called instead of throwing. */
+  readonly onDiagnostic?: (diagnostic: CastleAttemptDiagnostic) => void;
+}
+
+export interface CastleAttemptRecorder {
+  readonly path: string;
+  /** Open the resident's writer for one attempt. */
+  attempt(identity: CastleAttemptIdentity): CastleAttemptLog;
+  /** Every diagnostic this recorder degraded through, oldest first. */
+  diagnostics(): readonly CastleAttemptDiagnostic[];
+  read(): Promise<CastleAttemptRecord[]>;
+}
+
+async function appendEntry(
+  path: string,
+  entry: CastleAttemptEntry,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, encodeLines().push(toToonlRow(entry)), "utf8");
+}
+
+/**
+ * Create the resident's attempt recorder for a `.red` root. Nothing here
+ * throws: a caller can `await` every `record()` inside the attempt's own
+ * control flow and know the attempt survives a broken lane.
+ */
+export function createCastleAttemptRecorder(
+  paths: EnginePaths,
+  options: CastleAttemptRecorderOptions = {},
+): CastleAttemptRecorder {
+  const path = paths.castleAttempts;
+  const clock = options.clock ?? (() => new Date().toISOString());
+  const diagnostics: CastleAttemptDiagnostic[] = [];
+
+  function degrade(
+    reason: CastleAttemptDiagnostic["reason"],
+    err: unknown,
+    context: { attempt_id?: string; event?: string },
+  ): CastleAttemptAppendResult {
+    const diagnostic: CastleAttemptDiagnostic = {
+      at: clock(),
+      reason,
+      message: err instanceof Error ? err.message : String(err),
+      ...context,
+    };
+    diagnostics.push(diagnostic);
+    options.onDiagnostic?.(diagnostic);
+    return { ok: false, diagnostic };
+  }
+
+  return {
+    path,
+    diagnostics: () => diagnostics,
+    read: () => readCastleAttemptRecords(path),
+    attempt(identity) {
+      const attempt_id = castleAttemptId(identity);
+      return {
+        attempt_id,
+        path,
+        async record(event, fields = {}) {
+          const { at, ...narrative } = fields;
+          let entry: CastleAttemptEntry;
+          try {
+            entry = validateCastleAttemptEntry({
+              schema: CASTLE_ATTEMPT_SCHEMA_ID,
+              attempt_id,
+              worker_id: identity.worker_id,
+              issue: identity.issue,
+              try: identity.try,
+              at: at ?? clock(),
+              event,
+              writer: "resident",
+              ...narrative,
+            });
+          } catch (err) {
+            return degrade("validation", err, { attempt_id, event });
+          }
+          try {
+            await appendEntry(path, entry);
+          } catch (err) {
+            return degrade("write", err, { attempt_id, event });
+          }
+          return { ok: true, entry };
+        },
+        async read() {
+          const records = await readCastleAttemptRecords(path);
+          return records.find((record) => record.attempt_id === attempt_id);
+        },
+      };
+    },
+  };
+}

--- a/packages/red-castle/src/engine/contracts/index.ts
+++ b/packages/red-castle/src/engine/contracts/index.ts
@@ -22,6 +22,7 @@ function contract<T>(
 export const CASTLE_LANE_SCHEMA_ID = "red.castle.lane.v1" as const;
 export const CASTLE_STATE_SCHEMA_ID = "red.castle.state.v1" as const;
 export const CASTLE_HISTORY_SCHEMA_ID = "red.castle.history.v1" as const;
+export const CASTLE_ATTEMPT_SCHEMA_ID = "red.castle.attempt.v1" as const;
 export const CASTLE_VALIDATION_SCHEMA_ID = "red.castle.validation.v2" as const;
 export const CASTLE_ENVELOPE_SCHEMA_ID = "red.castle.envelope.v1" as const;
 export const CASTLE_HITL_CARD_SCHEMA_ID = "red.castle.hitl-card.v1" as const;
@@ -78,6 +79,139 @@ export interface CastleHistoryRecord {
   runner: string;
   merge_sha?: string;
   reason?: string;
+}
+
+/**
+ * The attempt — one worker × one ticket × one try — is the unit of truth, and
+ * the RESIDENT writes it (ADR 0128). `writer` is a single-member union on
+ * purpose: an entry stamped by anything but the resident is rejected, because
+ * the record exists for exactly the moment the worker is already gone.
+ */
+export type CastleAttemptWriter = "resident";
+
+export type CastleAttemptEvent =
+  | "attempt.claimed"
+  | "attempt.routed"
+  | "attempt.progressed"
+  | "attempt.committed"
+  | "attempt.pr-opened"
+  | "attempt.gated"
+  | "attempt.landing"
+  | "attempt.resourced"
+  | "attempt.artifact"
+  | "attempt.closed"
+  | (string & {});
+
+/** Terminal outcome. `budget-exceeded` NAMES its budget and is never a stall. */
+export type CastleAttemptOutcomeKind =
+  | "done"
+  | "blocked"
+  | "killed"
+  | "budget-exceeded"
+  | "discarded"
+  | (string & {});
+
+export interface CastleAttemptClaim {
+  state: "claimed" | "conceded";
+  by?: string;
+  reason?: string;
+}
+
+/** The routing decision, as taken (ADR 0128 §4). */
+export interface CastleAttemptRouting {
+  runner: string;
+  tier?: string;
+  model?: string;
+  effort?: string;
+}
+
+export interface CastleAttemptResources {
+  wall_clock_s?: number;
+  peak_rss_mb?: number;
+  cost_usd?: number;
+}
+
+/**
+ * An artifact the attempt left behind, with the reclaim verdict the janitor
+ * reads. Reclaim eligibility is stated by the record, never inferred from a
+ * missing pid file (ADR 0128, Consequences).
+ */
+export interface CastleAttemptArtifact {
+  kind: string;
+  ref?: string;
+  path?: string;
+  reclaimable: boolean;
+  reclaim_after?: string;
+  reason?: string;
+}
+
+export interface CastleAttemptGateVerdict {
+  name: string;
+  status: CastleValidationStatus;
+  summary?: string;
+}
+
+export interface CastleAttemptLandingStep {
+  step: string;
+  status: string;
+  detail?: string;
+}
+
+export interface CastleAttemptOutcome {
+  kind: CastleAttemptOutcomeKind;
+  detail?: string;
+  /** Set when `kind` is `budget-exceeded`: the budget that terminated it. */
+  budget?: string;
+}
+
+/**
+ * One append-only line of an attempt's narrative. The attempt RECORD
+ * (`CastleAttemptRecord`) is the fold of every entry sharing an `attempt_id` —
+ * never separately maintained state, so nothing is ever rewritten in place.
+ */
+export interface CastleAttemptEntry {
+  schema: typeof CASTLE_ATTEMPT_SCHEMA_ID;
+  attempt_id: string;
+  worker_id: string;
+  issue: number;
+  try: number;
+  at: string;
+  event: CastleAttemptEvent;
+  writer: CastleAttemptWriter;
+  claim?: CastleAttemptClaim;
+  routing?: CastleAttemptRouting;
+  branch?: string;
+  commit?: string;
+  pr?: number;
+  gate?: CastleAttemptGateVerdict;
+  landing?: CastleAttemptLandingStep;
+  outcome?: CastleAttemptOutcome;
+  resources?: CastleAttemptResources;
+  artifact?: CastleAttemptArtifact;
+  note?: string;
+  payload?: Record<string, unknown>;
+}
+
+/** The folded narrative of one attempt — a derived view, never a stored one. */
+export interface CastleAttemptRecord {
+  attempt_id: string;
+  worker_id: string;
+  issue: number;
+  try: number;
+  opened_at: string;
+  updated_at: string;
+  closed: boolean;
+  claim?: CastleAttemptClaim;
+  routing?: CastleAttemptRouting;
+  branch?: string;
+  commits: string[];
+  pr?: number;
+  gate: CastleAttemptGateVerdict[];
+  landing: CastleAttemptLandingStep[];
+  outcome?: CastleAttemptOutcome;
+  resources?: CastleAttemptResources;
+  artifacts: CastleAttemptArtifact[];
+  events: CastleAttemptEntry[];
 }
 
 export type CastleValidationStatus = "passed" | "failed" | "skipped";
@@ -183,6 +317,46 @@ export const CASTLE_PUBLISHED_CONTRACTS = [
       runner: true,
       merge_sha: true,
       reason: true,
+    },
+  }),
+  contract<CastleAttemptEntry>({
+    schemaId: CASTLE_ATTEMPT_SCHEMA_ID,
+    docPath: ".red/contracts/red.castle.attempt.v1.md",
+    typeNames: [
+      "CastleAttemptEntry",
+      "CastleAttemptRecord",
+      "CastleAttemptEvent",
+      "CastleAttemptWriter",
+      "CastleAttemptClaim",
+      "CastleAttemptRouting",
+      "CastleAttemptGateVerdict",
+      "CastleAttemptLandingStep",
+      "CastleAttemptOutcome",
+      "CastleAttemptOutcomeKind",
+      "CastleAttemptResources",
+      "CastleAttemptArtifact",
+    ],
+    fields: {
+      schema: true,
+      attempt_id: true,
+      worker_id: true,
+      issue: true,
+      try: true,
+      at: true,
+      event: true,
+      writer: true,
+      claim: true,
+      routing: true,
+      branch: true,
+      commit: true,
+      pr: true,
+      gate: true,
+      landing: true,
+      outcome: true,
+      resources: true,
+      artifact: true,
+      note: true,
+      payload: true,
     },
   }),
   contract<CastleValidationRecord>({

--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -12,6 +12,7 @@ export type {
 } from "../run.js";
 
 export * from "./worker-reader.js";
+export * from "./attempt-record.js";
 export * from "./gate-constants.js";
 export * from "./gate-executor.js";
 export * from "./gate-sink.js";

--- a/packages/red-castle/src/engine/paths.ts
+++ b/packages/red-castle/src/engine/paths.ts
@@ -18,6 +18,12 @@ export interface EnginePaths {
   readonly stateRoot: string;
   readonly castleStateRoot: string;
   readonly castleHistory: string;
+  /**
+   * The attempt lane — append-only, durable, one line per narrative event of
+   * one worker × ticket × try (ADR 0128). Never under `tmp/`: `tmp/` holds only
+   * the attempt's disposable workspace.
+   */
+  readonly castleAttempts: string;
   readonly castleValidation: string;
   /** Named-fleet profile registry (`name -> FleetProfile`). */
   readonly castleFleets: string;
@@ -57,6 +63,7 @@ export function createEnginePaths(redRoot: string): EnginePaths {
     stateRoot,
     castleStateRoot,
     castleHistory: resolve(castleStateRoot, "history.toonl"),
+    castleAttempts: resolve(castleStateRoot, "attempts.toonl"),
     castleValidation: resolve(castleStateRoot, "validation.toonl"),
     castleFleets: resolve(castleStateRoot, "fleets.toonl"),
     tmpRoot,


### PR DESCRIPTION
Automated AFK landing for #2703. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2703

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787846793&installation_model_id=20659&pr_number=2712&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2712&signature=dedc8042202b78e0931cb438a62300e48fb72759cd2eb14d8ffa7067284e9216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->