### PR TITLE
chore: #2688 rsp cutover: hook, proxy, wrappers and MCP all become resident clients

### DIFF
--- a/.changeset/rsp-resident-sole-core.md
+++ b/.changeset/rsp-resident-sole-core.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Every rsp surface is now a client of the resident core (#2688, ADR 0126). The pre-exec proxy, the CLI wrappers, `show`/`gains`, the bare dashboard, `stats`, `wait` capture and the MCP tool handlers previously each built their own store or opened a second connection to the same file; they all go through `residentElisionStore()` and the resident protocol instead, so the resident is the sole writer of the elision store and of the telemetry lanes it drains. Store construction is left in exactly two places — the store module (which owns the one-shot `rsp setup` provisioning open) and the resident server — and a contract test fails the build if a third appears. The fail-open guarantee is unchanged: an unreachable socket still yields the raw command's stdout, stderr and exit status, the dashboard and `stats` degrade to an empty snapshot, and `wait` keeps its spooled bytes rather than claiming a handle nothing can recover.

--- a/apps/rsp/docs/ARCHITECTURE.md
+++ b/apps/rsp/docs/ARCHITECTURE.md
@@ -87,6 +87,12 @@ The resident process:
 - Opens the configured RedDB store once with `allowResidentOpen: true`.
 - Acts as the single embedded writer for elision, telemetry stats, telemetry
   gains, memory, and brain requests.
+- Is the only *running* opener of the store (ADR 0126). Every other surface —
+  the pre-exec hook and proxy, the CLI wrappers, `show`/`gains`/`stats`, the
+  bare dashboard, `wait` capture, and the MCP tool handlers — reaches it through
+  `residentElisionStore()` in `resident-store.ts`. The store module keeps one
+  further opener, `provisionElisionStore()`, for the `rsp setup` moment when no
+  resident can exist yet because the file itself does not.
 - Writes a PID file and a PID registry entry containing the socket path,
   store URI, and resident version.
 - Resets an idle timer on each accepted socket and request.
@@ -115,6 +121,8 @@ Supported resident operations include:
 - `ping`
 - `handover`
 - `stats`
+- `recovery-handles`
+- `accounting-stats`
 - `telemetry-stats`
 - `telemetry-gains`
 - `mint`
@@ -357,6 +365,11 @@ Important fail-open paths:
 - `gh --json`/`--jq` selector commands are recorded as `lossless-gh-json-jq`
   passes and execute byte-identically.
 - Binary file reads pass through unchanged.
+- An unreachable resident socket costs the elision, never the command: wrappers
+  and the proxy hand back the raw stdout, stderr, and exit status, `stats` and
+  the bare dashboard degrade to the empty snapshot, `wait` keeps its spooled
+  bytes rather than claiming a handle nothing can recover, and the MCP tools
+  return the payload they were handed.
 - Telemetry append, telemetry drain, status summary, and cold drain nudges are
   best-effort.
 - `rsp exec` preserves stderr and exit status even when stdout is summarized.

--- a/apps/rsp/src/cli/dashboard.ts
+++ b/apps/rsp/src/cli/dashboard.ts
@@ -47,19 +47,21 @@ export function renderDashboard(snapshot: DashboardSnapshot): string {
   return `${encodeSnapshotToon(payload)}\n`;
 }
 
+/**
+ * The pending handles come from the resident, the only process that owns the
+ * store (ADR 0126). No store, no resident, no answer — the dashboard renders an
+ * empty recovery lane rather than failing the whole snapshot.
+ */
 async function readRecoveryHandles(config: RspRuntimeConfig): Promise<RspRecoveryHandle[]> {
   if (!config.storeUri.startsWith("file://")) return [];
   const path = fileURLToPath(config.storeUri);
   if (!existsSync(path)) return [];
-  const { RspElisionStore } = await import("../elision-store.js");
-  const store = await RspElisionStore.open({
-    uri: config.storeUri,
-    ttlDays: config.ttlDays,
-    ephemeralTtlHours: config.ephemeralTtlHours,
-    byteBudget: config.byteBudget,
-  });
+  const { residentElisionStore } = await import("../resident-store.js");
+  const store = residentElisionStore(process.cwd(), config);
   try {
     return await store.recoveryHandles(5);
+  } catch {
+    return [];
   } finally {
     await store.close();
   }

--- a/apps/rsp/src/cli/main.ts
+++ b/apps/rsp/src/cli/main.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from "node:url";
 import { type JsonObject } from "@reddb-io/toon";
 import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
 import { readBuildInfo } from "@reddb-io/build-info";
-import type { RspElisionStore } from "../elision-store.js";
 import { renderStructuredError } from "../structured-error.js";
 import {
   isHelpRequest,
@@ -31,7 +30,6 @@ import {
 } from "./passthrough.js";
 import { readStatsSnapshot, renderGainsReportToon, renderSetupResult, renderStats } from "./stats.js";
 import { LazyRspElisionStore, runColdWrappedCommand } from "./store-lifecycle.js";
-import type { ElisionStoreLike, ParsedArgs, TelemetryGainsStore } from "./types.js";
 
 async function main(argv = process.argv.slice(2)): Promise<number> {
   const buildInfo = readBuildInfo("rsp");
@@ -105,7 +103,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     const started = process.hrtime.bigint();
     return await emitWrappedResult(args, await runFastGitStatus(), started, undefined, await fastTelemetryRoot(process.cwd()));
   }
-  const { resolveResidentPaths, ResidentRspElisionStore, ensureResidentServer } = await import("../resident-client.js");
+  const { resolveResidentPaths, ensureResidentServer } = await import("../resident-client.js");
   const residentPaths = resolveResidentPaths(process.cwd());
   if (wrapperCommand && shouldUseControlHoldout(config.measurementHoldoutShare)) {
     return await runControlHoldout(args, residentPaths.rootDir, config.measurementHoldoutShare);
@@ -217,42 +215,13 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     }));
     return 1;
   }
-  const openResidentStore = (ensureResident = true) => Promise.resolve(new ResidentRspElisionStore(residentPaths, {
-    storeUri: config.storeUri,
-    ttlDays: config.ttlDays,
-    ephemeralTtlHours: config.ephemeralTtlHours,
-    byteBudget: config.byteBudget,
-    telemetryTtlDays: config.telemetryTtlDays,
-    telemetryByteBudget: config.telemetryByteBudget,
-    telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
-    telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
-    idleMs: config.idleMs,
-    clientVersion: buildInfo.version,
-  }, { ensureResident }));
-  const warmResidentStore = () => ensureResidentServer(residentPaths, {
-    storeUri: config.storeUri,
-    ttlDays: config.ttlDays,
-    ephemeralTtlHours: config.ephemeralTtlHours,
-    byteBudget: config.byteBudget,
-    telemetryTtlDays: config.telemetryTtlDays,
-    telemetryByteBudget: config.telemetryByteBudget,
-    telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
-    telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
-    idleMs: config.idleMs,
-    clientVersion: buildInfo.version,
-  });
-  const openDirectStore = async (): Promise<ElisionStoreLike & Pick<RspElisionStore, "get" | "stats">> => {
-    const { RspElisionStore } = await import("../elision-store.js");
-    return await RspElisionStore.open({
-      uri: config.storeUri,
-      ttlDays: config.ttlDays,
-      ephemeralTtlHours: config.ephemeralTtlHours,
-      byteBudget: config.byteBudget,
-    });
-  };
-  const openReadStore = () => !config.storeUri.endsWith("/red-skills.rdb")
-    ? openDirectStore()
-    : openResidentStore();
+  const { residentConfigFor, residentElisionStore } = await import("../resident-store.js");
+  const openResidentStore = (ensureResident = true) =>
+    Promise.resolve(residentElisionStore(process.cwd(), config, { ensureResident, paths: residentPaths }));
+  const warmResidentStore = () => ensureResidentServer(residentPaths, residentConfigFor(config, buildInfo.version));
+  // Reads go through the resident too: one core owns the store, so `show` and
+  // `gains` ask it rather than opening a second handle on the same file.
+  const openReadStore = () => openResidentStore();
   let closeStore: (() => Promise<void>) | undefined;
   try {
     if (args.command === "stats") {
@@ -264,11 +233,20 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     if (args.command === "gains") {
       const store = await openReadStore();
       closeStore = () => store.close();
-      if (!hasTelemetryGains(store)) {
-        process.stdout.write("error: rsp gains requires the shared RedDB store\n");
+      // A store without the telemetry lanes has no gains to report — the
+      // resident says so, and that stays a clean exit 1, not a stack trace.
+      let report;
+      try {
+        report = await store.telemetryGains(sinceDays(args.positional, 28));
+      } catch (err) {
+        process.stdout.write(renderStructuredError({
+          command: `rsp ${args.positional.join(" ")}`.trim(),
+          category: "real-error",
+          error: err instanceof Error ? err.message : "rsp gains unavailable",
+          help: "rsp gains requires the shared RedDB store",
+        }));
         return 1;
       }
-      const report = await store.telemetryGains(sinceDays(args.positional, 28));
       process.stdout.write(renderGainsReportToon(report));
       return 0;
     }
@@ -387,13 +365,6 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   } finally {
     await closeStore?.();
   }
-}
-
-function hasTelemetryGains(store: unknown): store is TelemetryGainsStore {
-  return typeof store === "object" &&
-    store !== null &&
-    "telemetryGains" in store &&
-    typeof (store as { telemetryGains?: unknown }).telemetryGains === "function";
 }
 
 export { main };

--- a/apps/rsp/src/cli/stats.ts
+++ b/apps/rsp/src/cli/stats.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { connect } from "@reddb-io/sdk";
 import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
 import type { JsonObject } from "@reddb-io/toon";
 import type { RspRuntimeConfig } from "../config.js";
@@ -8,6 +7,14 @@ import type { RspStorageClassStats } from "../elision-store.js";
 import { formatUsd } from "../pricing.js";
 import type { RspAccountingLaneStats, RspTelemetryGainsReport, RspTelemetryStats } from "../telemetry.js";
 
+/**
+ * Read the accounting and telemetry lanes through the resident (ADR 0126).
+ *
+ * `rsp stats` and the bare dashboard are readers, not owners: they ask the one
+ * process that holds the store instead of opening a second connection to the
+ * same file. An unprovisioned store or an unreachable resident degrades to the
+ * empty snapshot — a dashboard that renders zeroes beats one that throws.
+ */
 export async function readStatsSnapshot(
   config: RspRuntimeConfig,
   sinceDaysValue: number,
@@ -19,35 +26,22 @@ export async function readStatsSnapshot(
   if (!config.storeUri.startsWith("file://")) return empty;
   const path = fileURLToPath(config.storeUri);
   if (!existsSync(path)) return empty;
-  if (!path.endsWith("red-skills.rdb")) {
-    const { RspElisionStore } = await import("../elision-store.js");
-    const store = await RspElisionStore.open({
-      uri: config.storeUri,
-      ttlDays: config.ttlDays,
-      ephemeralTtlHours: config.ephemeralTtlHours,
-      byteBudget: config.byteBudget,
-    });
-    try {
-      return {
-        stats: await store.stats(),
-        telemetry: emptyTelemetryStats(sinceDaysValue),
-      };
-    } finally {
-      await store.close();
-    }
-  }
-
-  const { ensureReddbBinaryFromWarmCache } = await import("../elision-store.js");
-  await ensureReddbBinaryFromWarmCache();
-  const { readAccountingLaneStats, readTelemetryStats } = await import("../telemetry.js");
-  const db = await connect(config.storeUri);
+  const { residentElisionStore } = await import("../resident-store.js");
+  const store = residentElisionStore(process.cwd(), config);
   try {
+    // Only the shared RedDB store carries the telemetry lanes; a plain store
+    // still reports its own record accounting.
+    if (!path.endsWith("red-skills.rdb")) {
+      return { stats: await store.stats(), telemetry: emptyTelemetryStats(sinceDaysValue) };
+    }
     return {
-      stats: await readAccountingLaneStats(db, config.telemetryByteBudget),
-      telemetry: await readTelemetryStats(db, sinceDaysValue),
+      stats: await store.accountingStats(config.telemetryByteBudget),
+      telemetry: await store.telemetryStats(sinceDaysValue),
     };
+  } catch {
+    return empty;
   } finally {
-    await db.close();
+    await store.close();
   }
 }
 

--- a/apps/rsp/src/cli/types.ts
+++ b/apps/rsp/src/cli/types.ts
@@ -21,10 +21,6 @@ export type InvocationTelemetryStore = {
   lastResponseMetrics: () => ResidentResponseMetrics | undefined;
 };
 
-export type TelemetryGainsStore = {
-  telemetryGains: (sinceDays: number) => Promise<import("../telemetry.js").RspTelemetryGainsReport>;
-};
-
 export interface WrappedCommandResult {
   stdout: Buffer;
   stderr: Buffer;

--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -1,4 +1,5 @@
 export { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_EPHEMERAL_TTL_HOURS, DEFAULT_RSP_TTL_DAYS, RSP_ELISION_COLLECTION } from "./elision-store/public.js";
 export type { RspElisionRecord, RspElisionStoreOptions, RspExpiredHandle, RspLossLevel, RspLossMeta, RspMintMeta, RspRecoveryHandle, RspStorageClass, RspStorageClassStats, RspStoreStats } from "./elision-store/public.js";
 export { ensureReddbBinaryFromWarmCache, storageClassForCommand } from "./elision-store/helpers.js";
-export { RspElisionStore } from "./elision-store/store.js";
+export { contentHandle } from "./elision-store/helpers.js";
+export { provisionElisionStore, RspElisionStore } from "./elision-store/store.js";

--- a/apps/rsp/src/elision-store/store.ts
+++ b/apps/rsp/src/elision-store/store.ts
@@ -705,3 +705,16 @@ export class RspElisionStore {
     }
   }
 }
+
+/**
+ * Create the store file, then let go of it (ADR 0126).
+ *
+ * Provisioning is the one moment no resident can own the store: the file has to
+ * exist before anything can be a client of it. That construction belongs to the
+ * store module, not to the surface that asks for it — `rsp setup` calls this and
+ * never names `RspElisionStore`, so the resident stays the only *running* opener.
+ */
+export async function provisionElisionStore(opts: RspElisionStoreOptions): Promise<void> {
+  const store = await RspElisionStore.open({ ...opts, allowResidentOpen: true });
+  await store.close();
+}

--- a/apps/rsp/src/fidelity.ts
+++ b/apps/rsp/src/fidelity.ts
@@ -7,7 +7,8 @@ import { renderGhContract } from "./gh-wrapper.js";
 import { renderTestContract } from "./test-wrapper.js";
 import { renderCatContract } from "./cat-wrapper.js";
 import { renderExecContract } from "./exec-wrapper.js";
-import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
+import type { RspMintStore } from "./git-wrapper.js";
+import type { RspLossLevel } from "./elision-store.js";
 
 export interface FidelityAssertion {
   question: string;
@@ -33,7 +34,8 @@ export interface AssertionFailure {
 
 export interface FidelityRunOptions {
   level: RspLossLevel;
-  store: RspElisionStore;
+  /** Fidelity replays renderers offline, so it needs the mint port and nothing else. */
+  store: RspMintStore;
 }
 
 export interface FidelityRunResult extends GitRenderResult {

--- a/apps/rsp/src/mcp-server.ts
+++ b/apps/rsp/src/mcp-server.ts
@@ -5,7 +5,8 @@ import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
 import { resolveRspConfig, type RspRuntimeConfig } from "./config.js";
 import type { RspLossLevel } from "./elision-store.js";
 import { normalizeOutput, renderGenericJsonLane } from "./normalize.js";
-import { ResidentRspElisionStore, resolveResidentPaths } from "./resident-client.js";
+import type { ResidentRspElisionStore } from "./resident-client.js";
+import { residentElisionStore } from "./resident-store.js";
 
 interface JsonRpcRequest {
   jsonrpc?: string;
@@ -272,17 +273,7 @@ function countLines(bytes: Buffer): number {
 }
 
 function residentStore(config: RspRuntimeConfig): ResidentRspElisionStore {
-  return new ResidentRspElisionStore(resolveResidentPaths(process.cwd()), {
-    storeUri: config.storeUri,
-    ttlDays: config.ttlDays,
-    ephemeralTtlHours: config.ephemeralTtlHours,
-    byteBudget: config.byteBudget,
-    telemetryTtlDays: config.telemetryTtlDays,
-    telemetryByteBudget: config.telemetryByteBudget,
-    telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
-    telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
-    idleMs: config.idleMs,
-  });
+  return residentElisionStore(process.cwd(), config);
 }
 
 function renderStatus(config: RspRuntimeConfig): string {

--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -3,6 +3,7 @@ import type {
   RspElisionRecord,
   RspExpiredHandle,
   RspMintMeta,
+  RspRecoveryHandle,
   RspStoreStats,
 } from "./elision-store.js";
 import type { RspAccountingLaneStats } from "./telemetry.js";
@@ -85,6 +86,10 @@ export class ResidentRspElisionStore {
 
   async stats(): Promise<RspStoreStats> {
     return await this.request({ op: "stats" }) as RspStoreStats;
+  }
+
+  async recoveryHandles(limit = 5): Promise<RspRecoveryHandle[]> {
+    return await this.request({ op: "recovery-handles", limit }) as RspRecoveryHandle[];
   }
 
   async accountingStats(byteBudget: number): Promise<RspAccountingLaneStats> {

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -817,6 +817,7 @@ async function handleRequest(
   const store = state.store;
   if (request.op === "ping") return { pong: true, version: residentVersion };
   if (request.op === "stats") return await store.stats();
+  if (request.op === "recovery-handles") return await store.recoveryHandles(request.limit);
   if (request.op === "accounting-stats") {
     const db = store.redDb();
     if (!db) throw new Error("rsp accounting stats require the shared RedDB store");

--- a/apps/rsp/src/resident-store.ts
+++ b/apps/rsp/src/resident-store.ts
@@ -1,0 +1,53 @@
+/**
+ * resident-store.ts — the one door every rsp surface walks through (ADR 0126).
+ *
+ * The hook, the proxy, the CLI wrappers, the read commands, the dashboard, the
+ * wait capture and the MCP tools are all *clients*: they describe the store they
+ * want and get a `ResidentRspElisionStore` back, never an `RspElisionStore`. The
+ * resident process is the sole writer of the store and of the telemetry lanes it
+ * drains, so a surface that opened its own handle would be a second core.
+ *
+ * Keeping the config → `RspResidentConfig` mapping here also means an added
+ * knob reaches every surface at once instead of drifting per call site.
+ */
+import { readBuildInfo } from "@reddb-io/build-info";
+import type { RspRuntimeConfig } from "./config.js";
+import { ResidentRspElisionStore, resolveResidentPaths, type RspResidentPaths } from "./resident-client.js";
+import type { RspResidentConfig } from "./resident-protocol.js";
+
+export interface ResidentElisionStoreOptions {
+  /** Auto-spawn the resident when the socket is cold. Default true. */
+  ensureResident?: boolean;
+  /** Override the resolved paths; defaults to the paths for `cwd`. */
+  paths?: RspResidentPaths;
+}
+
+/** The resident config this runtime config asks for — nothing surface-specific. */
+export function residentConfigFor(config: RspRuntimeConfig, clientVersion?: string): RspResidentConfig {
+  return {
+    storeUri: config.storeUri,
+    ttlDays: config.ttlDays,
+    ephemeralTtlHours: config.ephemeralTtlHours,
+    byteBudget: config.byteBudget,
+    telemetryTtlDays: config.telemetryTtlDays,
+    telemetryByteBudget: config.telemetryByteBudget,
+    telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
+    telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
+    idleMs: config.idleMs,
+    ...(clientVersion ? { clientVersion } : {}),
+  };
+}
+
+/** A client of the resident core, for any surface, from one place. */
+export function residentElisionStore(
+  cwd: string,
+  config: RspRuntimeConfig,
+  opts: ResidentElisionStoreOptions = {},
+): ResidentRspElisionStore {
+  const paths = opts.paths ?? resolveResidentPaths(cwd);
+  return new ResidentRspElisionStore(
+    paths,
+    residentConfigFor(config, readBuildInfo("rsp").version),
+    { ensureResident: opts.ensureResident },
+  );
+}

--- a/apps/rsp/src/setup.ts
+++ b/apps/rsp/src/setup.ts
@@ -71,19 +71,17 @@ export async function provisionRspRepoStore(rootDir: string, opts: RspProvisionO
       await copyFile(legacyMemoryStore, storePath);
       memoryStoreMigrated = true;
     } else {
-      const { RspElisionStore } = await import("./elision-store.js");
+      const { provisionElisionStore } = await import("./elision-store.js");
       // Provisioning must not leak env into the caller: the store open may
       // resolve REDDB_BIN from the warm cache, so restore whatever was there.
       const priorReddbBin = process.env.REDDB_BIN;
       try {
-        const store = await RspElisionStore.open({
+        await provisionElisionStore({
           uri: `file://${storePath}`,
           ttlDays: opts.ttlDays ?? DEFAULT_RSP_TTL_DAYS,
           ephemeralTtlHours: opts.ephemeralTtlHours ?? DEFAULT_RSP_EPHEMERAL_TTL_HOURS,
           byteBudget: opts.byteBudget ?? DEFAULT_RSP_BYTE_BUDGET,
-          allowResidentOpen: true,
         });
-        await store.close();
       } finally {
         if (priorReddbBin === undefined) delete process.env.REDDB_BIN;
         else process.env.REDDB_BIN = priorReddbBin;

--- a/apps/rsp/src/two-axis-benchmark.ts
+++ b/apps/rsp/src/two-axis-benchmark.ts
@@ -1,11 +1,11 @@
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { decode, encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 import { encodingForModel } from "js-tiktoken";
 import { discoverFidelityFixtures, runFidelityFixture, type FidelityFixture } from "./fidelity.js";
-import { RspElisionStore } from "./elision-store.js";
+import { contentHandle } from "./elision-store.js";
+import type { RspMintStore } from "./git-wrapper.js";
 import { evaluateAdmission, type AdmissionFilterReport } from "./admission.js";
 
 export interface TwoAxisBenchmarkOptions {
@@ -238,48 +238,45 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
   const headroomByName = new Map(headroom.fixtures.map((fixture) => [fixture.name, fixture]));
   const measurements: FixtureMeasurement[] = [];
   const endTaskCandidates: EndTaskCandidate[] = [];
-  const tempRoot = await mkdtemp(join(tmpdir(), "rsp-two-axis-store-"));
-  const store = await RspElisionStore.open({ uri: `file://${join(tempRoot, "red.rdb")}` });
-  try {
-    for (const fixture of fixtures) {
-      const rtkFixture = rtkByName.get(fixture.name);
-      const headroomFixture = headroomByName.get(fixture.name);
-      const brief = await runFidelityFixture(fixture, { level: "lossless", store });
-      const terse = await runFidelityFixture(fixture, { level: "terse", store });
-      endTaskCandidates.push(...buildEndTaskCandidates(fixture, brief.stdout.toString("utf8"), brief.oneLine === true));
-      const active = admissionByFilter.get(filterName(fixture))?.mode === "active";
-      const rawTokens = tokenCount(fixture.recorded.stdout);
-      const briefTokens = tokenCount(brief.stdout.toString("utf8"));
-      const terseTokens = tokenCount(terse.stdout.toString("utf8"));
-      measurements.push({
-        fixture,
-        filter: filterName(fixture),
-        rawDelta: 0,
-        rawFidelity: true,
-        briefDelta: brief.tokenDelta,
-        briefFidelity: sameExitClass(brief.status, fixture.recorded.status) && brief.assertionFailures.length === 0,
-        terseDelta: terse.tokenDelta,
-        terseFidelity: sameExitClass(terse.status, fixture.recorded.status) && terse.assertionFailures.length === 0,
-        rtkDelta: rtkFixture ? tokenDelta(fixture.recorded.stdout, rtkFixture.stdout) : undefined,
-        rtkFidelity: rtkFixture?.fidelity_assertions_passed,
-        headroomDelta: headroomFixture?.coverage === "covered" && typeof headroomFixture.stdout === "string"
-          ? tokenDelta(fixture.recorded.stdout, headroomFixture.stdout)
-          : undefined,
-        headroomFidelity: headroomFixture?.coverage === "covered" ? headroomFixture.fidelity_assertions_passed : undefined,
-        headroomNotCoveredReason: headroomFixture?.coverage === "not-covered" ? headroomFixture.not_covered_reason : undefined,
-        rawTokens,
-        rspTokens: active ? briefTokens : rawTokens,
-        terseTokens: active ? terseTokens : rawTokens,
-        rtkTokens: rtkFixture ? tokenCount(rtkFixture.stdout) : undefined,
-        headroomTokens: headroomFixture?.coverage === "covered" && typeof headroomFixture.stdout === "string"
-          ? tokenCount(headroomFixture.stdout)
-          : undefined,
-        oracleTokens: await oracleTokenCount(fixture),
-      });
-    }
-  } finally {
-    await store.close();
-    await rm(tempRoot, { recursive: true, force: true });
+  // The benchmark measures rendered tokens, not persistence: it replays recorded
+  // fixtures offline. Minting content-addressed handles in-process keeps it a
+  // pure measurement — no store to own, and no second opener of one (ADR 0126).
+  const store: RspMintStore = { mint: async (original, meta) => contentHandle(Buffer.from(original), meta) };
+  for (const fixture of fixtures) {
+    const rtkFixture = rtkByName.get(fixture.name);
+    const headroomFixture = headroomByName.get(fixture.name);
+    const brief = await runFidelityFixture(fixture, { level: "lossless", store });
+    const terse = await runFidelityFixture(fixture, { level: "terse", store });
+    endTaskCandidates.push(...buildEndTaskCandidates(fixture, brief.stdout.toString("utf8"), brief.oneLine === true));
+    const active = admissionByFilter.get(filterName(fixture))?.mode === "active";
+    const rawTokens = tokenCount(fixture.recorded.stdout);
+    const briefTokens = tokenCount(brief.stdout.toString("utf8"));
+    const terseTokens = tokenCount(terse.stdout.toString("utf8"));
+    measurements.push({
+      fixture,
+      filter: filterName(fixture),
+      rawDelta: 0,
+      rawFidelity: true,
+      briefDelta: brief.tokenDelta,
+      briefFidelity: sameExitClass(brief.status, fixture.recorded.status) && brief.assertionFailures.length === 0,
+      terseDelta: terse.tokenDelta,
+      terseFidelity: sameExitClass(terse.status, fixture.recorded.status) && terse.assertionFailures.length === 0,
+      rtkDelta: rtkFixture ? tokenDelta(fixture.recorded.stdout, rtkFixture.stdout) : undefined,
+      rtkFidelity: rtkFixture?.fidelity_assertions_passed,
+      headroomDelta: headroomFixture?.coverage === "covered" && typeof headroomFixture.stdout === "string"
+        ? tokenDelta(fixture.recorded.stdout, headroomFixture.stdout)
+        : undefined,
+      headroomFidelity: headroomFixture?.coverage === "covered" ? headroomFixture.fidelity_assertions_passed : undefined,
+      headroomNotCoveredReason: headroomFixture?.coverage === "not-covered" ? headroomFixture.not_covered_reason : undefined,
+      rawTokens,
+      rspTokens: active ? briefTokens : rawTokens,
+      terseTokens: active ? terseTokens : rawTokens,
+      rtkTokens: rtkFixture ? tokenCount(rtkFixture.stdout) : undefined,
+      headroomTokens: headroomFixture?.coverage === "covered" && typeof headroomFixture.stdout === "string"
+        ? tokenCount(headroomFixture.stdout)
+        : undefined,
+      oracleTokens: await oracleTokenCount(fixture),
+    });
   }
 
   const rows = [...groupByFilter(measurements).entries()].sort(([a], [b]) => a.localeCompare(b)).map(([filter, rows]) =>

--- a/apps/rsp/src/wait/capture-store.ts
+++ b/apps/rsp/src/wait/capture-store.ts
@@ -4,10 +4,10 @@
  * Capture must not know how the store is opened, configured, or closed; it only
  * needs "give these bytes a recoverable handle". Expressing that as a port keeps
  * the store-unavailable path testable without a real store, and keeps the
- * concrete `RspElisionStore` construction in exactly one place.
+ * resident — the one owner of the store (ADR 0126) — behind a single seam.
  */
 import { resolveRspConfig } from "../config.js";
-import { RspElisionStore, type RspLossLevel } from "../elision-store.js";
+import type { RspLossLevel } from "../elision-store.js";
 
 /** What capture needs from a store — nothing more. */
 export interface WaitCaptureStore {
@@ -20,20 +20,15 @@ export interface WaitCaptureStore {
 }
 
 /**
- * The real adapter: opens the configured store for one mint and closes it again.
- * A wait is a long-lived, mostly idle process, so holding the store open for the
- * whole wait would pin the handle for an hour to write once at the end.
+ * The real adapter: one mint through the resident, then done.
+ * A wait is a long-lived, mostly idle process, so it stays a client that speaks
+ * once at the end rather than a second holder of the store for the whole hour.
  */
 export function defaultWaitCaptureStore(cwd: string, env: NodeJS.ProcessEnv = process.env): WaitCaptureStore {
   return {
     async mint(bytes, meta) {
-      const config = resolveRspConfig(cwd, env);
-      const store = await RspElisionStore.open({
-        uri: config.storeUri,
-        ttlDays: config.ttlDays,
-        ephemeralTtlHours: config.ephemeralTtlHours,
-        byteBudget: config.byteBudget,
-      });
+      const { residentElisionStore } = await import("../resident-store.js");
+      const store = residentElisionStore(cwd, resolveRspConfig(cwd, env));
       try {
         return await store.mint(bytes, meta);
       } finally {

--- a/apps/rsp/tests/resident-cutover.test.ts
+++ b/apps/rsp/tests/resident-cutover.test.ts
@@ -1,0 +1,147 @@
+// ADR 0126, Spec #2651 slice 2: the cutover that made every rsp surface a client.
+//
+// surface-parity.test.ts proves the four headline surfaces agree on one core.
+// This spec covers the two edges that cutover added: the pre-exec hook's own
+// rewritten command line must land in the resident and open nothing of its own,
+// and the surfaces the parity spec does not name — `wait` capture and the
+// read-only dashboard/stats lane — must fail open the way the wrappers do.
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import {
+  buildBundleOnce,
+  commitMany,
+  countTrackedResidentProcesses,
+  decode,
+  expectWarmResident,
+  extractHandle,
+  initGitRepo,
+  installRspShim,
+  join,
+  normalizedDurationMs,
+  readFile,
+  runBundleFromCwd,
+  runBundleHookFromCwd,
+  seedWarmRedCache,
+  shellQuote,
+  stat,
+  testChildEnv,
+  trackedResidentPaths,
+  writeFile,
+} from "./cli.helpers.js";
+
+const HANDLE_SHAPE = /^el:[a-f0-9]{12}$/;
+const HANDLE_ANYWHERE = /el:[a-f0-9]{12}/;
+
+describe("rsp resident cutover (ADR 0126)", () => {
+  it("runs the hook's own rewritten command line through the resident, opening no second store", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    await commitMany(root, 12);
+    const cacheDir = await seedWarmRedCache();
+    // RSP_FAIL_IF_STORE_OPEN turns "this surface opened its own store" into a
+    // hard failure, so a minted handle can only have come from the resident.
+    // The heavy-output threshold is pinned low so the hook's plain rewrite —
+    // which carries no loss flag — still reaches the elision path.
+    const env = {
+      RED_SKILLS_CACHE_DIR: cacheDir,
+      RSP_FAIL_IF_STORE_OPEN: "1",
+      RSP_HEAVY_GIT_BYTE_THRESHOLD: "1",
+    };
+    const setup = runBundleFromCwd(root, ["setup"], env);
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+    await expectWarmResident(root, env);
+    const proxyEnv = { ...env, PATH: await installRspShim(root) };
+
+    // The hook is the real entry point: it hands the host a rewritten command.
+    const hook = runBundleHookFromCwd(root, "git log", proxyEnv);
+    expect(hook.status, hook.stderr.toString("utf8")).toBe(0);
+    const rewritten = hookCommand(hook.stdout.toString("utf8"));
+    expect(rewritten).toContain("proxy --");
+
+    // Run exactly what the hook produced — no reconstruction, no shortcut.
+    const routed = runHookCommand(root, rewritten, proxyEnv);
+    expect(routed.status, `${routed.stdout.toString("utf8")}${routed.stderr.toString("utf8")}`).toBe(0);
+    const handle = extractHandle(routed.stdout);
+    expect(handle).toMatch(HANDLE_SHAPE);
+
+    // The bytes are in the one store, recoverable through the read surface...
+    const shown = runBundleFromCwd(root, ["show", handle], env);
+    expect(shown.status, `${shown.stdout.toString("utf8")}${shown.stderr.toString("utf8")}`).toBe(0);
+    expect(shown.stdout.length).toBeGreaterThan(routed.stdout.length);
+
+    // ...and the dashboard, another reader, lists the same handle without
+    // opening a store of its own.
+    const dashboard = runBundleFromCwd(root, [], env);
+    expect(dashboard.status, dashboard.stderr.toString("utf8")).toBe(0);
+    expect(dashboard.stdout.toString("utf8")).toContain(handle);
+
+    expect(await countTrackedResidentProcesses([root])).toBe(1);
+  }, 180_000);
+
+  it("fails open on the wait and dashboard surfaces when the resident socket is unreachable", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    await commitMany(root, 12);
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+
+    // The runtime socket directory hangs off XDG_RUNTIME_DIR, so pointing that
+    // at a regular file means no surface can reach a resident or spawn one.
+    const brokenXdg = join(root, "xdg-not-a-directory");
+    await writeFile(brokenXdg, "not a directory\n", "utf8");
+    const env = {
+      RED_SKILLS_CACHE_DIR: cacheDir,
+      XDG_RUNTIME_DIR: brokenXdg,
+      RSP_FAIL_IF_STORE_OPEN: "1",
+      RSP_RESIDENT_READY_TIMEOUT_MS: String(normalizedDurationMs(1_000)),
+    };
+
+    // wait cmd: the command's own exit code and bytes survive, no handle is
+    // claimed that nothing could recover, and the spool keeps the originals.
+    const script = "process.stdout.write('abcdefghijklmnopqrstuvwxyz'); process.exit(3)";
+    const command = `${shellQuote(process.execPath)} -e ${shellQuote(script)}`;
+    const waited = runBundleFromCwd(root, ["wait", "cmd", "--json", "--capture-bytes", "5", "--", command], env);
+    const result = JSON.parse(waited.stdout.toString("utf8")) as {
+      verdict: {
+        details: {
+          status: number;
+          stdout: { bytes: number; inline: string; handle?: string; recovery_error?: string; spool_path?: string };
+        };
+      };
+    };
+    expect(result.verdict.details.status).toBe(3);
+    const captured = result.verdict.details.stdout;
+    expect(captured).toMatchObject({ bytes: 26, inline: "abcde" });
+    expect(captured.handle).toBeUndefined();
+    expect(captured.recovery_error).toBeTruthy();
+    expect(await readFile(captured.spool_path!, "utf8")).toBe("fghijklmnopqrstuvwxyz");
+
+    // The readers degrade to an empty snapshot rather than to an error.
+    const dashboard = runBundleFromCwd(root, [], env);
+    expect(dashboard.status, dashboard.stderr.toString("utf8")).toBe(0);
+    expect(decode(dashboard.stdout.toString("utf8"))).toMatchObject({
+      recovery: { pending: 0 },
+      store: { records: 0, bytes: 0 },
+    });
+    expect(dashboard.stdout.toString("utf8")).not.toMatch(HANDLE_ANYWHERE);
+
+    const stats = runBundleFromCwd(root, ["stats", "--since", "7d"], env);
+    expect(stats.status, stats.stderr.toString("utf8")).toBe(0);
+    expect(decode(stats.stdout.toString("utf8"))).toMatchObject({ records: 0, savings: { empty: true } });
+
+    await expect(stat(trackedResidentPaths(root).socketPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await countTrackedResidentProcesses([root])).toBe(0);
+  }, 180_000);
+});
+
+function hookCommand(stdout: string): string {
+  const parsed = JSON.parse(stdout) as { hookSpecificOutput?: { updatedInput?: { command?: string } } };
+  const command = parsed.hookSpecificOutput?.updatedInput?.command;
+  expect(command, `hook emitted no rewritten command: ${stdout}`).toBeTruthy();
+  return command!;
+}
+
+function runHookCommand(cwd: string, command: string, env: Record<string, string>) {
+  return spawnSync(command, { cwd, shell: true, env: testChildEnv(env), encoding: "buffer" });
+}

--- a/apps/rsp/tests/resident-sole-core.test.ts
+++ b/apps/rsp/tests/resident-sole-core.test.ts
@@ -1,0 +1,66 @@
+// ADR 0126, Spec #2651 slice 2: the resident is the core, every surface is a client.
+//
+// The behavioural proof lives in surface-parity.test.ts. This spec guards the
+// structure that makes it hold: a surface that grows its own `RspElisionStore`
+// is a second core, and the parity assertions would only notice once the two
+// cores had already disagreed. Checking the source is the cheap, early alarm.
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative, resolve, sep } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const srcRoot = resolve(__dirname, "..", "src");
+
+/**
+ * The two places allowed to open the store, and why.
+ *
+ * `elision-store/store.ts` — the store defines itself, including the one-shot
+ * provisioning open that has to happen before any resident can exist.
+ * `resident-server.ts` — the resident: the only *running* owner of the file.
+ */
+const STORE_OWNERS = new Set([
+  join("elision-store", "store.ts"),
+  "resident-server.ts",
+]);
+
+const STORE_OPEN = /\bRspElisionStore\.open\s*\(|\bnew\s+RspElisionStore\s*\(/;
+
+describe("resident sole core (ADR 0126)", () => {
+  it("opens the elision store nowhere but the store module and the resident", async () => {
+    const offenders: string[] = [];
+    for (const file of await sourceFiles(srcRoot)) {
+      const rel = relative(srcRoot, file);
+      if (STORE_OWNERS.has(rel)) continue;
+      if (STORE_OPEN.test(await readFile(file, "utf8"))) offenders.push(rel.split(sep).join("/"));
+    }
+    expect(offenders, "these surfaces open their own store instead of asking the resident").toEqual([]);
+  });
+
+  it("keeps both declared owners honest — the allowlist names real openers", async () => {
+    for (const owner of STORE_OWNERS) {
+      expect(STORE_OPEN.test(await readFile(join(srcRoot, owner), "utf8")), owner).toBe(true);
+    }
+  });
+
+  it("gives every surface the same resident client, from one factory", async () => {
+    // A surface that hand-rolls the config mapping drifts the moment a knob is
+    // added, so the client is minted in exactly one module.
+    const offenders: string[] = [];
+    for (const file of await sourceFiles(srcRoot)) {
+      const rel = relative(srcRoot, file).split(sep).join("/");
+      if (rel === "resident-store.ts") continue;
+      if (/\bnew\s+ResidentRspElisionStore\s*\(/.test(await readFile(file, "utf8"))) offenders.push(rel);
+    }
+    expect(offenders, "construct the resident client through residentElisionStore()").toEqual([]);
+  });
+});
+
+async function sourceFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...await sourceFiles(full));
+    else if (entry.isFile() && entry.name.endsWith(".ts")) files.push(full);
+  }
+  return files;
+}

--- a/apps/rsp/vitest.suites.ts
+++ b/apps/rsp/vitest.suites.ts
@@ -12,6 +12,7 @@ export const INTEGRATION_TESTS: readonly string[] = [
   "elision-store.test.ts",
   "intercept.test.ts",
   "proxy.test.ts",
+  "resident-cutover.test.ts",
   "resident-memory.test.ts",
   "setup.test.ts",
   "shell-init.test.ts",

--- a/packages/shared/resident-protocol.ts
+++ b/packages/shared/resident-protocol.ts
@@ -19,6 +19,7 @@ export type RspResidentRequest =
   | { id: string; op: "ping" }
   | { id: string; op: "handover"; clientVersion: string }
   | { id: string; op: "stats" }
+  | { id: string; op: "recovery-handles"; limit: number }
   | { id: string; op: "accounting-stats"; byteBudget: number }
   | { id: string; op: "telemetry-stats"; sinceDays: number }
   | { id: string; op: "telemetry-gains"; sinceDays: number }


### PR DESCRIPTION
Automated AFK landing for #2688. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2688

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787851350&installation_model_id=20659&pr_number=2715&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2715&signature=e835ff10161901aacd5d8fae4260f2466594d6d3bc171bccb5b726f26db1a27b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->