### PR TITLE
chore: #2706 MCP lane canary: the shipped fleet_create path must fail loudly, not silently drain nothing

### DIFF
--- a/.changeset/mcp-lane-canary.md
+++ b/.changeset/mcp-lane-canary.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The MCP lane now carries a canary (#2706, ADR 0128 §7). `castle-mcp __mcp-canary` walks the shipped lane end to end over the real MCP stdio transport — `fleet_create` → a slot that spawns a real worker → `fleet_status` → `fleet_stop` — and exits non-zero naming the step that went inert. A returned supervisor pid is explicitly not accepted as drainage: only a worker directory holding a live `worker.pid` is, which is exactly what #2677's dead slots never wrote. CI runs the same walk on every PR against two bundles that differ solely in whether the slot entry can route `run`, so a lane that silently drains nothing fails the gate instead of surviving unnoticed.

--- a/apps/dev/src/commands/mcp-lane-canary.ts
+++ b/apps/dev/src/commands/mcp-lane-canary.ts
@@ -1,0 +1,171 @@
+// `castle-mcp __mcp-canary` — run the MCP lane canary against a bundle.
+//
+// Internal by design (the `__` prefix): this is a probe CI and operators fire
+// deliberately, not a queue surface. It CREATES a real one-slot fleet through
+// the canonical MCP interface and stops it again, because that round trip is
+// the only thing that proves the lane is not inert (#2677, ADR 0128 §7).
+//
+// It is routed from the castle-mcp entry rather than the dev CLI: the canary
+// needs the MCP CLIENT SDK, whose bundled ajv leaves bare `require()` calls
+// that the dev bundle contract forbids.
+
+import { resolve } from "node:path";
+import {
+  renderMcpLaneCanaryToon,
+  runMcpLaneCanary,
+  type McpLaneCanaryResult,
+} from "../core/mcp-lane-canary.js";
+import {
+  connectMcpLaneCanary,
+  resolveShippedMcpEntry,
+} from "../runtime/mcp-lane-canary-io.js";
+
+interface McpLaneCanaryIO {
+  stdout: Pick<NodeJS.WritableStream, "write">;
+  stderr: Pick<NodeJS.WritableStream, "write">;
+}
+
+export interface ParsedMcpLaneCanaryArgs {
+  /** MCP server bundle entry the canary launches. */
+  entry: string;
+  root: string;
+  fleet: string;
+  runner: string;
+  target: number;
+  workerDeadlineMs: number;
+  teardownDeadlineMs: number;
+}
+
+const USAGE = `Usage: castle-mcp __mcp-canary [options]
+
+Drives the shipped MCP lane end to end — fleet_create -> a slot that spawns a
+real worker -> fleet_status -> fleet_stop — and fails loudly naming the step
+that went inert.
+
+  --entry <path>              MCP bundle entry (default: the castle-mcp bundle
+                              beside this process's own entry)
+  --root <dir>                repo the canary fleet is created in (default: cwd)
+  --fleet <name>              fleet name to create and stop (default: canary)
+  --runner <runner>           runner for the canary fleet (default: claude)
+  --worker-deadline-ms <n>    how long a healthy lane may take to produce a
+                              live worker (default: 45000)
+  --teardown-deadline-ms <n>  how long fleet_stop may take (default: 20000)
+`;
+
+export function parseMcpLaneCanaryArgs(
+  args: readonly string[],
+  cwd = process.cwd(),
+): ParsedMcpLaneCanaryArgs {
+  const parsed: ParsedMcpLaneCanaryArgs = {
+    entry: resolveShippedMcpEntry(process.argv[1] ?? ""),
+    root: cwd,
+    fleet: "canary",
+    runner: "claude",
+    target: 1,
+    workerDeadlineMs: 45_000,
+    teardownDeadlineMs: 20_000,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    const value = args[index + 1];
+    const require = (): string => {
+      if (value === undefined) throw new Error(`${flag} requires a value`);
+      index += 1;
+      return value;
+    };
+    switch (flag) {
+      case "--entry":
+        parsed.entry = resolve(cwd, require());
+        break;
+      case "--root":
+        parsed.root = resolve(cwd, require());
+        break;
+      case "--fleet":
+        parsed.fleet = require();
+        break;
+      case "--runner":
+        parsed.runner = require();
+        break;
+      case "--worker-deadline-ms":
+        parsed.workerDeadlineMs = positiveInteger(flag, require());
+        break;
+      case "--teardown-deadline-ms":
+        parsed.teardownDeadlineMs = positiveInteger(flag, require());
+        break;
+      default:
+        throw new Error(`unknown flag: ${String(flag)}`);
+    }
+  }
+  return parsed;
+}
+
+function positiveInteger(flag: string | undefined, raw: string): number {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${String(flag)} requires a positive integer, got ${raw}`);
+  }
+  return value;
+}
+
+/** Run one canary walk against `parsed.entry`, returning the walk itself so a
+ * caller can report it however it likes. */
+export async function runMcpLaneCanaryAgainstEntry(
+  parsed: ParsedMcpLaneCanaryArgs,
+): Promise<{ result: McpLaneCanaryResult; stderr: string }> {
+  const transport = await connectMcpLaneCanary({
+    args: [parsed.entry],
+    cwd: parsed.root,
+  });
+  try {
+    const result = await runMcpLaneCanary(transport, {
+      fleet: parsed.fleet,
+      runner: parsed.runner,
+      target: parsed.target,
+      workerDeadlineMs: parsed.workerDeadlineMs,
+      teardownDeadlineMs: parsed.teardownDeadlineMs,
+    });
+    return { result, stderr: transport.stderr() };
+  } finally {
+    await transport.close();
+  }
+}
+
+export async function mcpLaneCanaryCommand(
+  args: readonly string[],
+  io: McpLaneCanaryIO = { stdout: process.stdout, stderr: process.stderr },
+  cwd = process.cwd(),
+): Promise<number> {
+  if (args.includes("--help") || args.includes("-h")) {
+    io.stdout.write(USAGE);
+    return 0;
+  }
+  let parsed: ParsedMcpLaneCanaryArgs;
+  try {
+    parsed = parseMcpLaneCanaryArgs(args, cwd);
+  } catch (error) {
+    io.stderr.write(`[mcp-canary] ${error instanceof Error ? error.message : String(error)}\n`);
+    io.stderr.write(USAGE);
+    return 2;
+  }
+
+  let walk: { result: McpLaneCanaryResult; stderr: string };
+  try {
+    walk = await runMcpLaneCanaryAgainstEntry(parsed);
+  } catch (error) {
+    // A transport that never opened is itself the `connect` step going inert;
+    // report it in the canary's own vocabulary rather than as a stack trace.
+    io.stderr.write(
+      `[mcp-canary] connect went inert: could not open an MCP session against ${parsed.entry}: ` +
+        `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    return 1;
+  }
+
+  io.stdout.write(`${renderMcpLaneCanaryToon(walk.result)}\n`);
+  if (walk.result.ok) return 0;
+  io.stderr.write(`[mcp-canary] ${walk.result.summary}\n`);
+  if (walk.stderr.trim() !== "") {
+    io.stderr.write(`[mcp-canary] server stderr tail:\n${walk.stderr.trimEnd()}\n`);
+  }
+  return 1;
+}

--- a/apps/dev/src/core/mcp-lane-canary.ts
+++ b/apps/dev/src/core/mcp-lane-canary.ts
@@ -1,0 +1,407 @@
+// mcp-lane-canary — the MCP lane's own liveness proof (ADR 0128 §7).
+//
+// `fleet_create` once spawned every slot against a bundle that cannot route
+// `run`; each slot died before writing a worker directory, so a fleet created
+// through the CANONICAL interface drained zero issues while the CLI lane kept
+// working and no surface reported the difference (#2677). A merged fix proves
+// nothing there: the defect only exists in the shipped bundle, exercised
+// through the real MCP transport.
+//
+// This module is the step machine, kept IO-free so both the real transport
+// (runtime/mcp-lane-canary-io.ts) and the regression tests drive the same
+// ordered contract. Every step names itself on failure, so a red canary reports
+// WHICH step went inert instead of "the fleet did nothing".
+
+import { encode as encodeToon } from "@reddb-io/toon";
+
+/** The ordered lane the canary walks. A step name IS the failure vocabulary. */
+export type McpLaneCanaryStep =
+  | "connect"
+  | "fleet_create"
+  | "supervisor_live"
+  | "worker_spawn"
+  | "fleet_status"
+  | "fleet_stop";
+
+export const MCP_LANE_CANARY_STEPS: readonly McpLaneCanaryStep[] = [
+  "connect",
+  "fleet_create",
+  "supervisor_live",
+  "worker_spawn",
+  "fleet_status",
+  "fleet_stop",
+];
+
+/** The MCP tools the lane must expose before the canary can walk it at all. */
+export const MCP_LANE_CANARY_REQUIRED_TOOLS: readonly string[] = [
+  "fleet_create",
+  "fleet_status",
+  "fleet_stop",
+];
+
+/** One worker directory as observed on disk — the anchor `fleet_create`'s
+ * returned pid can never substitute for. */
+export interface CanaryWorker {
+  /** Worker id (the `.red/tmp/workers/<id>` directory name). */
+  readonly worker: string;
+  /** Absolute worker directory path. */
+  readonly dir: string;
+  /** The pid in `worker.pid`, or null when the file is absent/unparseable. */
+  readonly pid: number | null;
+  /** Whether that pid names a live process right now. */
+  readonly alive: boolean;
+}
+
+export interface McpLaneCanaryDeps {
+  /** Real `tools/list` over the transport. */
+  listTools(): Promise<readonly string[]>;
+  /** Real `tools/call` over the transport; returns the decoded payload. */
+  callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
+  /** Fresh on-disk scan of the worker lane. */
+  observeWorkers(): Promise<readonly CanaryWorker[]>;
+  /** Liveness for a pid the canary holds directly (the supervisor's). */
+  isLive(pid: number): boolean;
+  sleep(ms: number): Promise<void>;
+  now(): number;
+}
+
+export interface McpLaneCanaryOptions {
+  /** Fleet name to create. Use a canary-only name — this fleet is torn down. */
+  readonly fleet: string;
+  readonly runner: string;
+  /** Slots to ask for. One is enough to prove the lane is not inert. */
+  readonly target?: number;
+  /** How long a healthy lane may take to produce a live worker. */
+  readonly workerDeadlineMs?: number;
+  /** How long `fleet_stop` may take to retire the supervisor and its workers. */
+  readonly teardownDeadlineMs?: number;
+  readonly pollMs?: number;
+}
+
+export type McpLaneCanaryVerdict = "ok" | "inert" | "skipped";
+
+export interface McpLaneCanaryStepResult {
+  readonly step: McpLaneCanaryStep;
+  readonly verdict: McpLaneCanaryVerdict;
+  readonly detail: string;
+}
+
+export interface McpLaneCanaryResult {
+  readonly ok: boolean;
+  readonly fleet: string;
+  readonly steps: readonly McpLaneCanaryStepResult[];
+  /** The FIRST step that went inert. Absent on a green run. */
+  readonly inertStep?: McpLaneCanaryStep;
+  /** One line naming the inert step, or the green lane. */
+  readonly summary: string;
+  readonly supervisorPid?: number;
+  /** Live workers the canary observed at its high-water mark. */
+  readonly workers: readonly CanaryWorker[];
+}
+
+const DEFAULTS = {
+  target: 1,
+  workerDeadlineMs: 45_000,
+  teardownDeadlineMs: 20_000,
+  pollMs: 250,
+} as const;
+
+/** A step that proved inert. Carries the step name so the walker never has to
+ * guess which assertion failed. */
+class InertStepError extends Error {
+  constructor(
+    readonly step: McpLaneCanaryStep,
+    detail: string,
+  ) {
+    super(detail);
+  }
+}
+
+function inert(step: McpLaneCanaryStep, detail: string): never {
+  throw new InertStepError(step, detail);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Read a pid-shaped field, tolerating the TOON round-trip's string numbers. */
+function readPid(value: unknown): number | null {
+  const raw = typeof value === "string" ? Number(value) : value;
+  return typeof raw === "number" && Number.isInteger(raw) && raw > 0 ? raw : null;
+}
+
+function readCount(value: unknown): number {
+  const raw = typeof value === "string" ? Number(value) : value;
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
+}
+
+function readBool(value: unknown): boolean {
+  return value === true || value === "true" || value === 1 || value === "1";
+}
+
+function describe(worker: CanaryWorker): string {
+  return `${worker.worker} (pid=${worker.pid ?? "none"}, dir=${worker.dir})`;
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Walk the MCP lane end to end and report the first step that went inert.
+ *
+ * The load-bearing asymmetry lives in `worker_spawn`: a returned supervisor pid
+ * is NOT evidence of drainage. The lane is only alive once a worker directory
+ * with a live pid exists on disk, which is exactly what #2677's dead slots
+ * never produced.
+ *
+ * Teardown is unconditional after a successful `fleet_create` — a canary that
+ * leaves a live supervisor behind is worse than no canary.
+ */
+export async function runMcpLaneCanary(
+  deps: McpLaneCanaryDeps,
+  options: McpLaneCanaryOptions,
+): Promise<McpLaneCanaryResult> {
+  const target = options.target ?? DEFAULTS.target;
+  const workerDeadlineMs = options.workerDeadlineMs ?? DEFAULTS.workerDeadlineMs;
+  const teardownDeadlineMs = options.teardownDeadlineMs ?? DEFAULTS.teardownDeadlineMs;
+  const pollMs = options.pollMs ?? DEFAULTS.pollMs;
+
+  const steps: McpLaneCanaryStepResult[] = [];
+  const record = (step: McpLaneCanaryStep, verdict: McpLaneCanaryVerdict, detail: string): void => {
+    steps.push({ step, verdict, detail });
+  };
+  let supervisorPid: number | undefined;
+  let workers: readonly CanaryWorker[] = [];
+  let inertStep: McpLaneCanaryStep | undefined;
+
+  const call = async (
+    step: McpLaneCanaryStep,
+    tool: string,
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> => {
+    let payload: unknown;
+    try {
+      payload = await deps.callTool(tool, args);
+    } catch (error) {
+      inert(step, `${tool} threw over the MCP transport: ${errorText(error)}`);
+    }
+    const shaped = asRecord(payload);
+    if (!shaped) inert(step, `${tool} returned a non-object payload: ${JSON.stringify(payload)}`);
+    return shaped;
+  };
+
+  try {
+    // ---- 1. connect: the transport is real, and the lane's tools exist ----
+    let tools: readonly string[];
+    try {
+      tools = await deps.listTools();
+    } catch (error) {
+      inert("connect", `the MCP transport never handshook: ${errorText(error)}`);
+    }
+    const missing = MCP_LANE_CANARY_REQUIRED_TOOLS.filter((tool) => !tools.includes(tool));
+    if (missing.length > 0) {
+      inert("connect", `the MCP server exposes no ${missing.join(", ")} tool — the lane is not the castle surface`);
+    }
+    record("connect", "ok", `tools/list served ${tools.length} tools including ${MCP_LANE_CANARY_REQUIRED_TOOLS.join(", ")}`);
+
+    // ---- 2. fleet_create: the canonical interface accepts the launch ----
+    const created = await call("fleet_create", "fleet_create", {
+      name: options.fleet,
+      runner: options.runner,
+      target,
+    });
+    const status = created.status;
+    if (status !== "launched" && status !== "resized") {
+      inert("fleet_create", `fleet_create returned status=${JSON.stringify(status)} instead of launched`);
+    }
+    const pid = readPid(created.pid);
+    if (pid === null) {
+      inert("fleet_create", `fleet_create returned no supervisor pid (payload: ${JSON.stringify(created)})`);
+    }
+    supervisorPid = pid;
+    record("fleet_create", "ok", `fleet_create launched fleet ${options.fleet} with supervisor pid ${pid}`);
+
+    try {
+      // ---- 3. supervisor_live: the returned pid is a real process ----
+      if (!deps.isLive(pid)) {
+        inert("supervisor_live", `fleet_create returned supervisor pid ${pid} but no such process is alive — the supervisor died inside its own launch probe`);
+      }
+      record("supervisor_live", "ok", `supervisor pid ${pid} is alive`);
+
+      // ---- 4. worker_spawn: a worker directory AND a live worker pid ----
+      // The #2677 assertion. A supervisor pid proves the launch; only this
+      // proves the slot entry spawned something that boots.
+      const deadline = deps.now() + workerDeadlineMs;
+      let seen: readonly CanaryWorker[] = [];
+      let live: readonly CanaryWorker[] = [];
+      for (;;) {
+        seen = await deps.observeWorkers();
+        live = seen.filter((worker) => worker.alive);
+        if (live.length > 0) break;
+        if (deps.now() >= deadline) break;
+        if (!deps.isLive(pid)) {
+          inert("worker_spawn", `supervisor pid ${pid} died before any worker appeared — the fleet went inert during its first ticks`);
+        }
+        await deps.sleep(pollMs);
+      }
+      if (live.length === 0) {
+        const observed = seen.length === 0
+          ? "no worker directory was ever written"
+          : `only dead worker directories exist: ${seen.map(describe).join("; ")}`;
+        inert(
+          "worker_spawn",
+          `fleet_create returned supervisor pid ${pid} but ${observed} within ${workerDeadlineMs}ms — the slot entry spawned nothing that boots (the #2677 shape: a bundle whose slot entry cannot route \`run\`)`,
+        );
+      }
+      workers = live;
+      record("worker_spawn", "ok", `${live.length} live worker(s): ${live.map(describe).join("; ")}`);
+
+      // ---- 5. fleet_status: the canonical reader observes that worker ----
+      const observedStatus = await call("fleet_status", "fleet_status", { fleet: options.fleet });
+      const supervisor = asRecord(observedStatus.supervisor);
+      if (!supervisor || !readBool(supervisor.alive)) {
+        inert("fleet_status", `fleet_status reports the supervisor as not alive while pid ${pid} is running — the lane's reader and writer disagree`);
+      }
+      const reportedPid = readPid(supervisor.pid);
+      if (reportedPid !== pid) {
+        inert("fleet_status", `fleet_status reports supervisor pid ${reportedPid ?? "none"}, not the ${pid} fleet_create returned`);
+      }
+      const busy = readCount(asRecord(observedStatus.slots)?.busy);
+      if (busy < 1) {
+        inert("fleet_status", `fleet_status reports slots.busy=${busy} while ${live.length} live worker(s) exist on disk — the fleet cannot see its own workers`);
+      }
+      record("fleet_status", "ok", `fleet_status observes supervisor ${pid} with slots.busy=${busy}`);
+    } finally {
+      // ---- 6. fleet_stop: teardown, always attempted once a fleet exists ----
+      // Nothing thrown here may mask the walk's own verdict, so the teardown
+      // reports its failure as a step rather than as an exception.
+      try {
+        steps.push(await stopFleet());
+      } catch (error) {
+        steps.push({
+          step: "fleet_stop",
+          verdict: "inert",
+          detail: `teardown itself threw: ${errorText(error)}`,
+        });
+      }
+    }
+  } catch (error) {
+    if (!(error instanceof InertStepError)) throw error;
+    inertStep = error.step;
+    // The failing step is recorded in walk order, ahead of any teardown row.
+    const teardownAt = steps.findIndex((entry) => entry.step === "fleet_stop");
+    const failure: McpLaneCanaryStepResult = {
+      step: error.step,
+      verdict: "inert",
+      detail: error.message,
+    };
+    if (teardownAt === -1) steps.push(failure);
+    else steps.splice(teardownAt, 0, failure);
+  }
+
+  for (const step of MCP_LANE_CANARY_STEPS) {
+    if (steps.some((entry) => entry.step === step)) continue;
+    steps.push({
+      step,
+      verdict: "skipped",
+      detail: inertStep ? `not reached — the lane went inert at ${inertStep}` : "not reached",
+    });
+  }
+  steps.sort(
+    (a, b) => MCP_LANE_CANARY_STEPS.indexOf(a.step) - MCP_LANE_CANARY_STEPS.indexOf(b.step),
+  );
+
+  const ok = inertStep === undefined && steps.every((entry) => entry.verdict === "ok");
+  const failed = steps.find((entry) => entry.verdict === "inert");
+  const resolvedInert = inertStep ?? failed?.step;
+  return {
+    ok,
+    fleet: options.fleet,
+    steps,
+    ...(resolvedInert ? { inertStep: resolvedInert } : {}),
+    summary: ok
+      ? `MCP lane canary green: fleet_create → live worker → fleet_status → fleet_stop all answered on fleet ${options.fleet}`
+      : `MCP lane canary FAILED — the ${resolvedInert} step went inert: ${
+        steps.find((entry) => entry.step === resolvedInert)?.detail ?? "no detail"
+      }`,
+    ...(supervisorPid !== undefined ? { supervisorPid } : {}),
+    workers,
+  };
+
+  /** Stop the fleet and CONFIRM the supervisor and its workers are gone. */
+  async function stopFleet(): Promise<McpLaneCanaryStepResult> {
+    if (supervisorPid === undefined) {
+      return {
+        step: "fleet_stop",
+        verdict: "skipped",
+        detail: "no fleet was created, so there is nothing to stop",
+      };
+    }
+    const pid = supervisorPid;
+    let stopped: Record<string, unknown>;
+    try {
+      stopped = await call("fleet_stop", "fleet_stop", { fleet: options.fleet, force: true });
+    } catch (error) {
+      return {
+        step: "fleet_stop",
+        verdict: "inert",
+        detail: error instanceof InertStepError ? error.message : errorText(error),
+      };
+    }
+    if (stopped.status !== "stopped" && stopped.status !== "none") {
+      return {
+        step: "fleet_stop",
+        verdict: "inert",
+        detail: `fleet_stop returned status=${JSON.stringify(stopped.status)} for supervisor pid ${pid} — the canonical stop no-opped`,
+      };
+    }
+    const deadline = deps.now() + teardownDeadlineMs;
+    for (;;) {
+      const remaining = (await deps.observeWorkers()).filter((worker) => worker.alive);
+      if (!deps.isLive(pid) && remaining.length === 0) {
+        return {
+          step: "fleet_stop",
+          verdict: "ok",
+          detail: `fleet_stop retired supervisor ${pid} and every worker it spawned`,
+        };
+      }
+      if (deps.now() >= deadline) {
+        const survivors = deps.isLive(pid) ? [`supervisor ${pid}`] : [];
+        survivors.push(...remaining.map(describe));
+        return {
+          step: "fleet_stop",
+          verdict: "inert",
+          detail: `fleet_stop returned ${String(stopped.status)} but ${survivors.join(", ")} survived ${teardownDeadlineMs}ms`,
+        };
+      }
+      await deps.sleep(pollMs);
+    }
+  }
+}
+
+/** Render the walk as TOON (ADR 0097): the step table first, so the inert row
+ * is readable without parsing the summary sentence. */
+export function renderMcpLaneCanaryToon(result: McpLaneCanaryResult): string {
+  return encodeToon({
+    canary: "mcp-lane",
+    fleet: result.fleet,
+    ok: result.ok,
+    ...(result.inertStep ? { inert_step: result.inertStep } : {}),
+    ...(result.supervisorPid !== undefined ? { supervisor_pid: result.supervisorPid } : {}),
+    steps: result.steps.map((step) => ({
+      step: step.step,
+      verdict: step.verdict,
+      detail: step.detail,
+    })),
+    workers: result.workers.map((worker) => ({
+      worker: worker.worker,
+      pid: worker.pid ?? 0,
+      alive: worker.alive,
+    })),
+    summary: result.summary,
+  });
+}

--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -255,6 +255,9 @@ export interface McpEntrypointDependencies {
   startCurator(): Promise<void>;
   startMergeDriver(): Promise<void>;
   connect(): Promise<void>;
+  /** The lane's own canary (#2706). Optional so every existing caller keeps
+   * working; omitted means the real probe. */
+  canary?(args: string[]): Promise<number>;
 }
 
 /** Route every executable role shipped in the afk-mcp bundle. The supervisor
@@ -271,6 +274,16 @@ export async function main(
 ): Promise<number> {
   if (argv[0] === "__supervise") {
     return dependencies.supervise(argv.slice(1));
+  }
+  // The lane's canary lives in THIS bundle on purpose (#2706): it must launch
+  // the shipped MCP entry over the real transport, and the dev bundle contract
+  // forbids the client SDK's bundled `require()` calls landing there.
+  if (argv[0] === "__mcp-canary") {
+    const canary =
+      dependencies.canary ??
+      (async (args: string[]) =>
+        (await import("./commands/mcp-lane-canary.js")).mcpLaneCanaryCommand(args));
+    return canary(argv.slice(1));
   }
   if (argv[0] === "--version" || argv[0] === "-v" || argv[0] === "version") {
     process.stdout.write(

--- a/apps/dev/src/runtime/mcp-lane-canary-io.ts
+++ b/apps/dev/src/runtime/mcp-lane-canary-io.ts
@@ -1,0 +1,162 @@
+// mcp-lane-canary-io — the real transport behind the canary walk.
+//
+// The canary is only worth its name when it speaks the SAME protocol an agent
+// speaks: a child process launched from a bundle entry, an MCP stdio handshake,
+// and `tools/call`. An in-process core call would have stayed green through the
+// whole of #2677, because the defect lived in what the shipped bundle spawns,
+// not in what the core function returns.
+
+import { readFileSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { decode } from "@reddb-io/toon";
+import type { CanaryWorker, McpLaneCanaryDeps } from "../core/mcp-lane-canary.js";
+import { workersSegment } from "../core/worker-paths.js";
+import { afkPaths } from "./wire.js";
+
+/** How the canary reaches the MCP server under test. Defaults to the shipped
+ * castle-mcp bundle beside this process's own entry. */
+export interface McpLaneCanaryTarget {
+  /** Executable to launch. Defaults to this process's node. */
+  readonly command?: string;
+  /** Argv for it — the FIRST entry is the bundle whose lane is under test. */
+  readonly args: readonly string[];
+  /** Working directory the fleet is created in. */
+  readonly cwd: string;
+  readonly env?: Record<string, string>;
+}
+
+export interface McpLaneCanaryTransport extends McpLaneCanaryDeps {
+  close(): Promise<void>;
+  /** Whatever the server wrote to stderr, for a failure report. */
+  stderr(): string;
+}
+
+export function isLivePid(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists but belongs to another user — still live.
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Scan the worker lane the way every other reader does: a directory per worker
+ * holding the `worker.pid` liveness anchor (ADR 0128 §5). A missing lane reads
+ * as zero workers, never an error — "no worker directory" IS the finding the
+ * canary is looking for.
+ */
+export async function observeWorkersOnDisk(root: string): Promise<readonly CanaryWorker[]> {
+  const workersRoot = join(afkPaths(root).tmpDir, workersSegment());
+  let entries: string[];
+  try {
+    entries = (await readdir(workersRoot, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+  return entries.map((worker) => {
+    const dir = join(workersRoot, worker);
+    let pid: number | null = null;
+    try {
+      const parsed = Number(readFileSync(join(dir, "worker.pid"), "utf8").trim());
+      pid = Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    } catch {
+      pid = null;
+    }
+    return { worker, dir, pid, alive: pid !== null && isLivePid(pid) };
+  });
+}
+
+/** Decode one `tools/call` result. Castle tools answer TOON text (ADR 0097);
+ * a server that answers JSON still decodes, so the canary never fails on
+ * encoding when the lane itself is healthy. */
+export function decodeToolPayload(text: string): unknown {
+  const trimmed = text.trim();
+  if (trimmed === "") return {};
+  try {
+    return decode(trimmed);
+  } catch {
+    try {
+      return JSON.parse(trimmed) as unknown;
+    } catch {
+      return { text: trimmed };
+    }
+  }
+}
+
+/**
+ * Resolve the shipped castle-mcp bundle to canary. The whole point is to run
+ * against the SHIPPED artifact, so the default target is the running bundle
+ * itself (the canary ships inside castle-mcp) or its castle-mcp sibling when
+ * invoked from the dev entry — never a source file.
+ */
+export function resolveShippedMcpEntry(argv1: string): string {
+  const dir = dirname(argv1);
+  const file = argv1.slice(dir.length + 1);
+  if (file.startsWith("castle-mcp")) return argv1;
+  const versioned = file.match(/^dev-(.+)\.bundle\.min\.mjs$/);
+  if (versioned) return join(dir, `castle-mcp-${versioned[1]}.bundle.min.mjs`);
+  return join(dir, "castle-mcp.bundle.min.mjs");
+}
+
+/**
+ * Open a real MCP stdio session against `target` and return the canary's deps.
+ * The caller owns `close()` — a canary that leaks its server child is one more
+ * inert process on the host.
+ */
+export async function connectMcpLaneCanary(
+  target: McpLaneCanaryTarget,
+): Promise<McpLaneCanaryTransport> {
+  const transport = new StdioClientTransport({
+    command: target.command ?? process.execPath,
+    args: [...target.args],
+    cwd: target.cwd,
+    env: target.env ?? (process.env as Record<string, string>),
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "mcp-lane-canary", version: "1" }, { capabilities: {} });
+  let stderrText = "";
+  await client.connect(transport);
+  transport.stderr?.on("data", (chunk: Buffer) => {
+    // Bounded: a runaway server must not turn a canary report into a log dump.
+    stderrText = `${stderrText}${chunk.toString("utf8")}`.slice(-8_000);
+  });
+
+  return {
+    listTools: async () => (await client.listTools()).tools.map((tool) => tool.name),
+    callTool: async (name, args) => {
+      const result = await client.callTool({ name, arguments: args }, CallToolResultSchema);
+      if (result.isError === true) {
+        throw new Error(`${name} returned an error result: ${renderContent(result.content)}`);
+      }
+      return decodeToolPayload(renderContent(result.content));
+    },
+    observeWorkers: () => observeWorkersOnDisk(target.cwd),
+    isLive: isLivePid,
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    now: () => Date.now(),
+    stderr: () => stderrText,
+    close: async () => {
+      await client.close().catch(() => undefined);
+      await transport.close().catch(() => undefined);
+    },
+  };
+}
+
+function renderContent(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      const shaped = part as { type?: string; text?: string };
+      return shaped.type === "text" ? (shaped.text ?? "") : "";
+    })
+    .join("");
+}

--- a/apps/dev/tests/fixtures/mcp-lane-canary/canary-supervisor.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/canary-supervisor.ts
@@ -1,0 +1,118 @@
+// The canary harness's supervisor role.
+//
+// It is deliberately thin around ONE piece of production code: the real
+// `buildSupervisorDeps(...).proc.spawnSlot`, which is where #2677 lived — the
+// slot's worker entry was inferred from argv[1], so an MCP-launched supervisor
+// spawned every slot against a bundle that cannot route `run`. Everything else
+// here (pid anchor, heartbeat snapshot, stop handling) is the minimum a fleet
+// needs to be observable, so the harness needs no GitHub queue to drive the
+// lane end to end.
+
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildSupervisorDeps } from "../../../src/commands/supervise.js";
+import { readPidStartTime } from "../../../src/core/state.js";
+import { encodeDevSnapshotToon } from "../../../src/core/toon-snapshot.js";
+import { slotLogDir } from "../../../src/runtime/supervisor-fs.js";
+import { afkPaths } from "../../../src/runtime/wire.js";
+
+const HEARTBEAT_MS = 300;
+
+function fleetFromArgs(args: readonly string[]): string {
+  const at = args.indexOf("--fleet");
+  return at >= 0 ? (args[at + 1] ?? "default") : (process.env.RED_AFK_FLEET ?? "default");
+}
+
+export async function canarySupervise(args: readonly string[]): Promise<number> {
+  const root = process.cwd();
+  const fleet = fleetFromArgs(args);
+  const paths = afkPaths(root, fleet);
+  const slotLogsDir = slotLogDir(paths.tmpDir);
+  mkdirSync(paths.supervisorRuntimeDir, { recursive: true });
+  mkdirSync(slotLogsDir, { recursive: true });
+  mkdirSync(join(paths.tmpDir, "workers"), { recursive: true });
+
+  // The pinned identity anchor `fleet_create`'s launch probe and `fleet_status`
+  // both read. Without it the launch reads as a fast death.
+  const startTime = readPidStartTime(process.pid);
+  if (startTime === null) {
+    process.stderr.write("canary supervisor: cannot pin process start time\n");
+    return 1;
+  }
+  writeFileSync(paths.supervisorPidStartPath, startTime, "utf8");
+  writeFileSync(paths.supervisorPidPath, String(process.pid), "utf8");
+
+  const runner = process.env.RED_AFK_RUNNER ?? "claude";
+  const target = Number(process.env.RED_AFK_TARGET ?? "1") || 1;
+
+  const deps = buildSupervisorDeps(
+    root,
+    paths.tmpDir,
+    slotLogsDir,
+    paths.fleetFirehosePath,
+    paths.fleetStatePath,
+    `s${process.pid}`,
+    fleet,
+    runner,
+    300,
+    { cwd: root, repo: "" },
+    "main",
+    [],
+    {},
+  );
+
+  // THE assertion this harness exists for: the production slot spawn, with the
+  // production entry resolution, against whichever bundle sits beside argv[1].
+  const slot = await deps.proc.spawnSlot(0, undefined);
+
+  const publish = (): void => {
+    const epoch = Math.floor(Date.now() / 1000);
+    const alive = slot.pid > 0 && isLive(slot.pid);
+    const body = encodeDevSnapshotToon({
+      ts: new Date(epoch * 1000).toISOString(),
+      epoch,
+      last_progress_epoch: epoch,
+      target,
+      runner,
+      shrink_mode: "drain-then-retire",
+      ready_for_agent: 0,
+      slots: {
+        busy: alive ? 1 : 0,
+        free: alive ? target - 1 : target,
+        total: target,
+        parked: 0,
+      },
+      slot_pids: alive ? [{ slot: 0, pid: slot.pid }] : [],
+      spawns_this_tick: 0,
+    });
+    const tmp = `${paths.fleetStatePath}.tmp`;
+    writeFileSync(tmp, body, "utf8");
+    renameSync(tmp, paths.fleetStatePath);
+  };
+  publish();
+
+  return new Promise<number>((resolve) => {
+    const finish = (code: number): void => {
+      clearInterval(timer);
+      rmSync(paths.supervisorPidPath, { force: true });
+      rmSync(paths.supervisorPidStartPath, { force: true });
+      resolve(code);
+    };
+    const timer = setInterval(() => {
+      publish();
+      // `fleet_stop` without --force publishes intent through the stop file.
+      if (existsSync(paths.supervisorStopPath)) finish(0);
+    }, HEARTBEAT_MS);
+    process.once("SIGTERM", () => finish(143));
+    process.once("SIGINT", () => finish(130));
+  });
+}
+
+function isLive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}

--- a/apps/dev/tests/fixtures/mcp-lane-canary/canary-worker.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/canary-worker.ts
@@ -1,0 +1,46 @@
+// The canary harness's worker role — what a slot becomes when its entry can
+// actually route `run`.
+//
+// It reproduces the ONE thing the canary reads as drainage: a worker directory
+// under the workers lane holding a live `worker.pid` (ADR 0128 §5). It runs no
+// agent and touches no queue, because the lane's plumbing — not the drain — is
+// what went silently inert in #2677.
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { workerDir, workerPidFile } from "../../../src/core/worker-paths.js";
+import { afkPaths } from "../../../src/runtime/wire.js";
+
+const POLL_MS = 100;
+
+/** Worker ids are `w` + 4 chars; derive one from the pid so it is unique per
+ * slot process and needs no randomness. */
+function workerId(pid: number): string {
+  return `wC${String(pid).slice(-3).padStart(3, "0")}`;
+}
+
+export async function canaryWorker(): Promise<number> {
+  const root = process.cwd();
+  const paths = afkPaths(root, process.env.RED_AFK_FLEET);
+  const worker = workerId(process.pid);
+  mkdirSync(workerDir(paths.tmpDir, worker), { recursive: true });
+  const pidFile = workerPidFile(paths.tmpDir, worker);
+  writeFileSync(pidFile, String(process.pid), "utf8");
+
+  const retireFile = process.env.RED_AFK_RETIRE_FILE;
+  return new Promise<number>((resolve) => {
+    const finish = (code: number): void => {
+      clearInterval(timer);
+      rmSync(pidFile, { force: true });
+      resolve(code);
+    };
+    const timer = setInterval(() => {
+      // A real worker exits when its fleet retires it. Both signals are honoured
+      // so a forced `fleet_stop` (supervisor pid file removed) and a graceful
+      // slot retire leave no live worker behind.
+      if (!existsSync(paths.supervisorPidPath)) finish(0);
+      else if (retireFile !== undefined && retireFile !== "" && existsSync(retireFile)) finish(0);
+    }, POLL_MS);
+    process.once("SIGTERM", () => finish(143));
+    process.once("SIGINT", () => finish(130));
+  });
+}

--- a/apps/dev/tests/fixtures/mcp-lane-canary/dev-entry-healthy.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/dev-entry-healthy.ts
@@ -1,0 +1,16 @@
+// Harness stand-in for the shipped `dev.bundle.min.mjs` — the entry a slot is
+// spawned against. It routes BOTH roles the fleet needs: `__supervise` for the
+// supervisor the MCP lane launches, and `run` for the worker each slot becomes.
+
+import { canarySupervise } from "./canary-supervisor.js";
+import { canaryWorker } from "./canary-worker.js";
+
+const argv = process.argv.slice(2);
+if (argv[0] === "__supervise") {
+  process.exitCode = await canarySupervise(argv.slice(1));
+} else if (argv[0] === "run") {
+  process.exitCode = await canaryWorker();
+} else {
+  process.stderr.write(`canary dev entry: unknown role ${JSON.stringify(argv[0])}\n`);
+  process.exitCode = 2;
+}

--- a/apps/dev/tests/fixtures/mcp-lane-canary/dev-entry-unroutable.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/dev-entry-unroutable.ts
@@ -1,0 +1,21 @@
+// The #2677 shape: a slot entry that CANNOT route `run`.
+//
+// Byte-for-byte the pre-fix failure — the supervisor boots and lives, every
+// slot it spawns hits an entry that refuses the worker subcommand and dies on
+// the spot, so the fleet drains nothing while `fleet_create` reports success.
+// The canary must go red here; a canary that cannot catch its own motivating
+// bug is not a canary.
+
+import { canarySupervise } from "./canary-supervisor.js";
+
+const argv = process.argv.slice(2);
+if (argv[0] === "__supervise") {
+  process.exitCode = await canarySupervise(argv.slice(1));
+} else {
+  process.stderr.write(
+    `castle MCP: unroutable subcommand ${JSON.stringify(argv[0])} — ` +
+      "the castle-mcp bundle routes only `__supervise` and `--version`; " +
+      "worker subcommands belong to the dev entry (red-skills-dev)\n",
+  );
+  process.exitCode = 2;
+}

--- a/apps/dev/tests/fixtures/mcp-lane-canary/mcp-entry.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/mcp-entry.ts
@@ -1,0 +1,20 @@
+// Harness stand-in for the shipped `castle-mcp.bundle.min.mjs`.
+//
+// It bundles to a file with the SHIPPED NAME, so the production entry resolver
+// (`resolveDevScriptPath`) engages exactly as it does under a real MCP host,
+// and it drives the REAL `main` router plus the REAL `createCastleMcpServer`
+// tool surface. Only the resident lanes (curator, merge driver) are stubbed —
+// they reach GitHub and are not what #2677 broke.
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createCastleMcpServer, main } from "../../../src/mcp-server.js";
+import { canarySupervise } from "./canary-supervisor.js";
+
+process.exitCode = await main(process.argv.slice(2), {
+  supervise: (args) => canarySupervise(args),
+  startCurator: async () => undefined,
+  startMergeDriver: async () => undefined,
+  connect: async () => {
+    await createCastleMcpServer(process.cwd()).connect(new StdioServerTransport());
+  },
+});

--- a/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
@@ -1,0 +1,108 @@
+// Builds the canary harness's sandboxes: a scratch repo whose `dist/` holds
+// REAL esbuild bundles with the SHIPPED file names, so `fleet_create` launches
+// a supervisor from `castle-mcp.bundle.min.mjs` and that supervisor resolves
+// its slot entry to the `dev.bundle.min.mjs` sitting beside it — the exact
+// resolution #2677 got wrong.
+//
+// Two variants of the dev bundle exist. `healthy` routes `run`; `unroutable`
+// refuses it. Everything else about the two sandboxes is identical, so a
+// difference in the canary's verdict can only come from the slot entry.
+
+import { build } from "esbuild";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export type CanaryLaneVariant = "healthy" | "unroutable";
+
+export interface CanarySandbox {
+  /** Repo root the fleet is created in. */
+  readonly root: string;
+  /** The MCP bundle entry the canary launches. */
+  readonly mcpEntry: string;
+  readonly env: Record<string, string>;
+}
+
+interface BuiltBundles {
+  readonly dir: string;
+  readonly mcp: string;
+  readonly dev: Record<CanaryLaneVariant, string>;
+}
+
+let bundles: Promise<BuiltBundles> | undefined;
+const sandboxes: string[] = [];
+
+async function bundleOne(entry: string, outfile: string): Promise<void> {
+  await build({
+    entryPoints: [join(here, entry)],
+    outfile,
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    target: "node22",
+    logLevel: "silent",
+    banner: {
+      js: "import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);",
+    },
+  });
+}
+
+/** Build the three harness bundles once per test process. */
+export function buildCanaryBundles(): Promise<BuiltBundles> {
+  bundles ??= (async () => {
+    const dir = await mkdtemp(join(tmpdir(), "mcp-canary-bundles-"));
+    sandboxes.push(dir);
+    const mcp = join(dir, "castle-mcp.bundle.min.mjs");
+    const healthy = join(dir, "dev-healthy.bundle.min.mjs");
+    const unroutable = join(dir, "dev-unroutable.bundle.min.mjs");
+    await Promise.all([
+      bundleOne("mcp-entry.ts", mcp),
+      bundleOne("dev-entry-healthy.ts", healthy),
+      bundleOne("dev-entry-unroutable.ts", unroutable),
+    ]);
+    return { dir, mcp, dev: { healthy, unroutable } };
+  })();
+  return bundles;
+}
+
+/**
+ * Materialise one scratch repo wired to `variant`'s slot entry. The dev bundle
+ * always lands as `dev.bundle.min.mjs` beside the MCP bundle, because that
+ * sibling relationship IS what the production entry resolver looks for.
+ */
+export async function createCanarySandbox(
+  variant: CanaryLaneVariant,
+): Promise<CanarySandbox> {
+  const built = await buildCanaryBundles();
+  const root = await mkdtemp(join(tmpdir(), `mcp-canary-${variant}-`));
+  sandboxes.push(root);
+  const dist = join(root, "dist");
+  await mkdir(dist, { recursive: true });
+  await mkdir(join(root, ".red"), { recursive: true });
+  await writeFile(join(root, ".red", "config.yaml"), "plugins:\n  dev:\n    enabled: true\n", "utf8");
+  const mcpEntry = join(dist, "castle-mcp.bundle.min.mjs");
+  await copyFile(built.mcp, mcpEntry);
+  await copyFile(built.dev[variant], join(dist, "dev.bundle.min.mjs"));
+
+  return {
+    root,
+    mcpEntry,
+    env: {
+      ...(process.env as Record<string, string>),
+      // The harness runs many times in CI; a transient cgroup scope per launch
+      // is neither available nor relevant to what is under test (#2697).
+      RED_AFK_FLEET_SCOPE: "off",
+      RED_AFK_TARGET: "1",
+    },
+  };
+}
+
+export async function cleanupCanarySandboxes(): Promise<void> {
+  bundles = undefined;
+  await Promise.all(
+    sandboxes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+}

--- a/apps/dev/tests/mcp-lane-canary-e2e.test.ts
+++ b/apps/dev/tests/mcp-lane-canary-e2e.test.ts
@@ -1,0 +1,171 @@
+// The MCP lane canary, driven against real processes over the real MCP stdio
+// transport (#2706, ADR 0128 §7).
+//
+// This is the file that makes the canary a canary. It runs the SAME production
+// walk twice against two sandboxes that differ in exactly one byte-level fact —
+// whether the bundle beside the MCP entry can route `run` — and requires:
+//
+//   healthy    -> green, with a worker directory and a live worker pid
+//   unroutable -> RED at `worker_spawn`, reproducing #2677
+//
+// A canary that cannot catch its own motivating bug is not a canary, so the red
+// case is an assertion, not a smoke test.
+
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, describe, expect, it } from "vitest";
+import { decode } from "@reddb-io/toon";
+import { runMcpLaneCanary } from "../src/core/mcp-lane-canary.js";
+import { connectMcpLaneCanary } from "../src/runtime/mcp-lane-canary-io.js";
+import {
+  cleanupCanarySandboxes,
+  createCanarySandbox,
+  type CanaryLaneVariant,
+} from "./fixtures/mcp-lane-canary/sandbox.js";
+
+// Bundling three entries and driving two live process trees; be generous.
+const TIMEOUT = 180_000;
+
+async function walk(variant: CanaryLaneVariant, workerDeadlineMs = 20_000) {
+  const sandbox = await createCanarySandbox(variant);
+  const transport = await connectMcpLaneCanary({
+    args: [sandbox.mcpEntry],
+    cwd: sandbox.root,
+    env: sandbox.env,
+  });
+  try {
+    const result = await runMcpLaneCanary(transport, {
+      fleet: "canary",
+      runner: "claude",
+      target: 1,
+      workerDeadlineMs,
+      teardownDeadlineMs: 20_000,
+      pollMs: 150,
+    });
+    return { result, stderr: transport.stderr(), sandbox };
+  } finally {
+    await transport.close();
+  }
+}
+
+afterAll(async () => {
+  await cleanupCanarySandboxes();
+});
+
+describe("MCP lane canary over the real transport", () => {
+  it(
+    "goes green when the slot entry routes `run`, on evidence of a live worker",
+    async () => {
+      const { result } = await walk("healthy");
+
+      expect(result.inertStep).toBeUndefined();
+      expect(result.ok).toBe(true);
+      expect(result.steps.map((step) => step.verdict)).toEqual([
+        "ok",
+        "ok",
+        "ok",
+        "ok",
+        "ok",
+        "ok",
+      ]);
+      // Not "fleet_create returned a pid" — an actual worker directory holding
+      // an actual live pid, which is the thing #2677's dead slots never wrote.
+      expect(result.workers.length).toBeGreaterThan(0);
+      const worker = result.workers[0]!;
+      expect(worker.alive).toBe(true);
+      expect(worker.pid).toBeGreaterThan(0);
+      expect(worker.dir).toContain("/.red/tmp/workers/");
+      expect(result.supervisorPid).toBeGreaterThan(0);
+      // A probe that leaks a live fleet is worse than no probe.
+      expect(isLive(result.supervisorPid!)).toBe(false);
+      expect(isLive(worker.pid!)).toBe(false);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "goes RED at worker_spawn against a bundle whose slot entry cannot route `run` (#2677)",
+    async () => {
+      // Every slot dies on spawn here, so a short deadline is enough — the
+      // failure is deterministic, not a race the canary might lose.
+      const { result, stderr } = await walk("unroutable", 8_000);
+
+      expect(result.ok).toBe(false);
+      expect(result.inertStep).toBe("worker_spawn");
+      // The lane looked healthy right up to the step that matters: the tools
+      // answered, the fleet launched, the supervisor lived. That is exactly why
+      // #2677 survived unnoticed, and exactly what the canary must name.
+      const byStep = new Map(result.steps.map((step) => [step.step, step.verdict]));
+      expect(byStep.get("connect")).toBe("ok");
+      expect(byStep.get("fleet_create")).toBe("ok");
+      expect(byStep.get("supervisor_live")).toBe("ok");
+      expect(byStep.get("worker_spawn")).toBe("inert");
+      expect(result.workers).toHaveLength(0);
+      // The failure output names the step that went inert and why.
+      expect(result.summary).toContain("worker_spawn");
+      expect(result.summary).toContain("cannot route `run`");
+      expect(stderr).not.toContain("secret");
+      // An inert lane is still torn down: the canary never leaves the fleet it
+      // created running just because it failed.
+      expect(result.steps.find((step) => step.step === "fleet_stop")?.verdict).toBe("ok");
+      expect(isLive(result.supervisorPid!)).toBe(false);
+    },
+    TIMEOUT,
+  );
+});
+
+describe("the shipped castle-mcp bundle carries the canary", () => {
+  // Source-level greens are exactly what #2677 had. The probe must also work
+  // from the built artifact operators and CI actually run, whose bundled
+  // dependency graph differs from the source tree's.
+  it(
+    "runs `__mcp-canary` out of the built bundle and reports a green lane",
+    async () => {
+      const run = promisify(execFile);
+      const appRoot = join(import.meta.dirname, "..");
+      await run("pnpm", ["run", "bundle:mcp"], {
+        cwd: appRoot,
+        env: {
+          ...process.env,
+          RED_BUILD_VERSION: "0.0.0-test",
+          RED_BUILD_GIT_SHA: "test",
+          RED_BUILD_TIME: "2026-01-01T00:00:00.000Z",
+        },
+      });
+      const bundle = join(appRoot, "..", "..", "dist", "castle-mcp.bundle.min.mjs");
+      const sandbox = await createCanarySandbox("healthy");
+
+      const { stdout } = await run(
+        process.execPath,
+        [
+          bundle,
+          "__mcp-canary",
+          "--entry",
+          sandbox.mcpEntry,
+          "--root",
+          sandbox.root,
+          "--fleet",
+          "canary",
+          "--worker-deadline-ms",
+          "20000",
+        ],
+        { cwd: sandbox.root, env: sandbox.env },
+      );
+
+      const report = decode(stdout.trim()) as { ok: boolean; inert_step?: string };
+      expect(report.inert_step).toBeUndefined();
+      expect(report.ok).toBe(true);
+    },
+    TIMEOUT,
+  );
+});
+
+function isLive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/dev/tests/mcp-lane-canary.test.ts
+++ b/apps/dev/tests/mcp-lane-canary.test.ts
@@ -1,0 +1,310 @@
+// The canary's step contract. The e2e sibling proves the canary catches #2677
+// against real processes; this file pins WHAT each step asserts and that a red
+// run names the step that went inert.
+import { describe, expect, it, vi } from "vitest";
+import { decode } from "@reddb-io/toon";
+import {
+  MCP_LANE_CANARY_STEPS,
+  renderMcpLaneCanaryToon,
+  runMcpLaneCanary,
+  type CanaryWorker,
+  type McpLaneCanaryDeps,
+} from "../src/core/mcp-lane-canary.js";
+import { parseMcpLaneCanaryArgs } from "../src/commands/mcp-lane-canary.js";
+import { resolveShippedMcpEntry } from "../src/runtime/mcp-lane-canary-io.js";
+
+const SUPERVISOR_PID = 40_100;
+const WORKER_PID = 40_200;
+
+function worker(overrides: Partial<CanaryWorker> = {}): CanaryWorker {
+  return {
+    worker: "wCAN1",
+    dir: "/scratch/.red/tmp/workers/wCAN1",
+    pid: WORKER_PID,
+    alive: true,
+    ...overrides,
+  };
+}
+
+interface HarnessOptions {
+  tools?: readonly string[];
+  create?: unknown;
+  status?: unknown;
+  stop?: unknown;
+  /** Worker observations, consumed one per scan; the last repeats forever. */
+  observations?: readonly (readonly CanaryWorker[])[];
+  /** Pids that are alive; a pid absent here reads dead. */
+  livePids?: readonly number[];
+  /** Pids that stop being alive once fleet_stop has been called. */
+  diesOnStop?: readonly number[];
+}
+
+function harness(options: HarnessOptions = {}) {
+  let stopped = false;
+  let clock = 0;
+  const observations = options.observations ?? [[worker()]];
+  let scans = 0;
+  const live = new Set(options.livePids ?? [SUPERVISOR_PID, WORKER_PID]);
+  const diesOnStop = new Set(options.diesOnStop ?? [SUPERVISOR_PID, WORKER_PID]);
+  const calls: { tool: string; args: Record<string, unknown> }[] = [];
+
+  const deps: McpLaneCanaryDeps = {
+    listTools: async () =>
+      options.tools ?? ["fleet_create", "fleet_status", "fleet_stop", "worker_status"],
+    callTool: async (tool, args) => {
+      calls.push({ tool, args });
+      if (tool === "fleet_create") {
+        return options.create ?? { status: "launched", pid: SUPERVISOR_PID, target: 1 };
+      }
+      if (tool === "fleet_status") {
+        return (
+          options.status ?? {
+            fleet: "canary",
+            supervisor: { pid: SUPERVISOR_PID, alive: true },
+            slots: { busy: 1, free: 0, total: 1, parked: 0 },
+          }
+        );
+      }
+      if (tool === "fleet_stop") {
+        stopped = true;
+        return options.stop ?? { status: "stopped", pid: SUPERVISOR_PID };
+      }
+      throw new Error(`unexpected tool ${tool}`);
+    },
+    observeWorkers: async () => {
+      const at = Math.min(scans, observations.length - 1);
+      scans += 1;
+      const rows = observations[at] ?? [];
+      return stopped ? rows.filter((row) => !diesOnStop.has(row.pid ?? -1)) : rows;
+    },
+    isLive: (pid) => (stopped && diesOnStop.has(pid) ? false : live.has(pid)),
+    sleep: async (ms) => {
+      clock += ms;
+    },
+    now: () => {
+      clock += 1;
+      return clock;
+    },
+  };
+  return { deps, calls };
+}
+
+const OPTIONS = { fleet: "canary", runner: "claude", pollMs: 10, workerDeadlineMs: 200 };
+
+describe("MCP lane canary — green lane", () => {
+  it("walks every step and reports the lane alive", async () => {
+    const { deps, calls } = harness();
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.ok).toBe(true);
+    expect(result.inertStep).toBeUndefined();
+    expect(result.steps.map((step) => step.step)).toEqual([...MCP_LANE_CANARY_STEPS]);
+    expect(result.steps.every((step) => step.verdict === "ok")).toBe(true);
+    expect(result.supervisorPid).toBe(SUPERVISOR_PID);
+    expect(result.summary).toContain("green");
+    // The real tool surface was driven, in lane order.
+    expect(calls.map((call) => call.tool)).toEqual([
+      "fleet_create",
+      "fleet_status",
+      "fleet_stop",
+    ]);
+  });
+});
+
+describe("MCP lane canary — the #2677 shape", () => {
+  // The motivating bug: fleet_create answers with a supervisor pid, the
+  // supervisor lives, and every slot dies before writing a worker directory.
+  it("fails at worker_spawn when a returned pid produces no worker directory", async () => {
+    const { deps } = harness({ observations: [[]] });
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.ok).toBe(false);
+    expect(result.inertStep).toBe("worker_spawn");
+    expect(result.summary).toContain("worker_spawn");
+    expect(result.summary).toContain("no worker directory was ever written");
+    expect(result.summary).toContain("#2677");
+    // The steps BEFORE the inert one still read green — the failure is located,
+    // not smeared across the lane.
+    const byStep = new Map(result.steps.map((step) => [step.step, step.verdict]));
+    expect(byStep.get("fleet_create")).toBe("ok");
+    expect(byStep.get("supervisor_live")).toBe("ok");
+    expect(byStep.get("fleet_status")).toBe("skipped");
+  });
+
+  it("refuses to accept a dead worker directory as drainage", async () => {
+    const { deps } = harness({
+      observations: [[worker({ alive: false })]],
+      livePids: [SUPERVISOR_PID],
+    });
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.inertStep).toBe("worker_spawn");
+    expect(result.summary).toContain("only dead worker directories exist");
+    expect(result.summary).toContain("wCAN1");
+  });
+
+  it("names the supervisor death when the fleet dies before its first worker", async () => {
+    const { deps } = harness({ observations: [[]], livePids: [SUPERVISOR_PID] });
+    // Alive for the supervisor_live check, dead on the next poll.
+    let probes = 0;
+    deps.isLive = (pid) => pid === SUPERVISOR_PID && probes++ < 1;
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.inertStep).toBe("worker_spawn");
+    expect(result.summary).toContain("died before any worker appeared");
+  });
+
+  it("tears the fleet down even when the lane went inert", async () => {
+    const { deps, calls } = harness({ observations: [[]] });
+
+    await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(calls.map((call) => call.tool)).toContain("fleet_stop");
+  });
+});
+
+describe("MCP lane canary — the other inert steps", () => {
+  it("fails at connect when the server is not the castle tool surface", async () => {
+    const { deps } = harness({ tools: ["queue_status"] });
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.inertStep).toBe("connect");
+    expect(result.summary).toContain("fleet_create, fleet_status, fleet_stop");
+    expect(result.steps.every((step) => step.verdict !== "ok")).toBe(true);
+  });
+
+  it("fails at fleet_create when the tool throws over the transport", async () => {
+    const { deps } = harness();
+    deps.callTool = vi.fn(async () => {
+      throw new Error("MCP error -32603: registry write failed");
+    });
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.inertStep).toBe("fleet_create");
+    expect(result.summary).toContain("registry write failed");
+  });
+
+  it("fails at fleet_create when no supervisor pid comes back", async () => {
+    const { deps } = harness({ create: { status: "launched" } });
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.inertStep).toBe("fleet_create");
+    expect(result.summary).toContain("no supervisor pid");
+  });
+
+  it("fails at supervisor_live when the returned pid names no process", async () => {
+    const { deps } = harness({ livePids: [WORKER_PID] });
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.inertStep).toBe("supervisor_live");
+    expect(result.summary).toContain("no such process is alive");
+  });
+
+  it("fails at fleet_status when the reader cannot see its own live worker", async () => {
+    const { deps } = harness({
+      status: {
+        supervisor: { pid: SUPERVISOR_PID, alive: true },
+        slots: { busy: 0, free: 1, total: 1, parked: 0 },
+      },
+    });
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.inertStep).toBe("fleet_status");
+    expect(result.summary).toContain("slots.busy=0");
+  });
+
+  it("fails at fleet_status when reader and writer disagree about liveness", async () => {
+    const { deps } = harness({
+      status: { supervisor: { pid: SUPERVISOR_PID, alive: false }, slots: { busy: 1 } },
+    });
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.inertStep).toBe("fleet_status");
+    expect(result.summary).toContain("reader and writer disagree");
+  });
+
+  it("fails at fleet_stop when the canonical stop leaves the supervisor alive", async () => {
+    const { deps } = harness({ diesOnStop: [WORKER_PID] });
+
+    const result = await runMcpLaneCanary(deps, {
+      ...OPTIONS,
+      teardownDeadlineMs: 100,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.inertStep).toBe("fleet_stop");
+    expect(result.summary).toContain(`supervisor ${SUPERVISOR_PID}`);
+    expect(result.summary).toContain("survived");
+  });
+
+  it("fails at fleet_stop when the stop no-ops", async () => {
+    const { deps } = harness({ stop: { status: "timeout", pid: SUPERVISOR_PID } });
+
+    const result = await runMcpLaneCanary(deps, { ...OPTIONS, teardownDeadlineMs: 100 });
+
+    expect(result.inertStep).toBe("fleet_stop");
+    expect(result.summary).toContain("no-opped");
+  });
+});
+
+describe("MCP lane canary target resolution", () => {
+  // The canary is worthless against a source tree — it must launch the SHIPPED
+  // bundle, which is the artifact #2677 lived in.
+  it("canaries the running castle-mcp bundle itself", () => {
+    expect(resolveShippedMcpEntry("/opt/red/dist/castle-mcp.bundle.min.mjs")).toBe(
+      "/opt/red/dist/castle-mcp.bundle.min.mjs",
+    );
+    expect(resolveShippedMcpEntry("/opt/red/dist/castle-mcp-2.90.0.bundle.min.mjs")).toBe(
+      "/opt/red/dist/castle-mcp-2.90.0.bundle.min.mjs",
+    );
+  });
+
+  it("resolves the castle-mcp sibling when invoked from a dev bundle", () => {
+    expect(resolveShippedMcpEntry("/opt/red/dist/dev.bundle.min.mjs")).toBe(
+      "/opt/red/dist/castle-mcp.bundle.min.mjs",
+    );
+    expect(resolveShippedMcpEntry("/opt/red/dist/dev-2.90.0.bundle.min.mjs")).toBe(
+      "/opt/red/dist/castle-mcp-2.90.0.bundle.min.mjs",
+    );
+  });
+
+  it("parses the probe's tuning flags and refuses unknown ones", () => {
+    const parsed = parseMcpLaneCanaryArgs(
+      ["--fleet", "probe", "--runner", "codex", "--worker-deadline-ms", "9000"],
+      "/scratch",
+    );
+
+    expect(parsed).toMatchObject({ fleet: "probe", runner: "codex", workerDeadlineMs: 9_000 });
+    expect(parsed.root).toBe("/scratch");
+    expect(() => parseMcpLaneCanaryArgs(["--nope"], "/scratch")).toThrow(/unknown flag/);
+    expect(() => parseMcpLaneCanaryArgs(["--fleet"], "/scratch")).toThrow(/requires a value/);
+  });
+});
+
+describe("MCP lane canary report", () => {
+  it("renders the walk as TOON with the inert step addressable", async () => {
+    const { deps } = harness({ observations: [[]] });
+
+    const rendered = renderMcpLaneCanaryToon(await runMcpLaneCanary(deps, OPTIONS));
+    const decoded = decode(rendered) as {
+      ok: boolean;
+      inert_step: string;
+      steps: { step: string; verdict: string }[];
+    };
+
+    expect(rendered).not.toContain("{\n");
+    expect(decoded.ok).toBe(false);
+    expect(decoded.inert_step).toBe("worker_spawn");
+    expect(decoded.steps).toHaveLength(MCP_LANE_CANARY_STEPS.length);
+  });
+});

--- a/apps/dev/tests/mcp-server-routing.test.ts
+++ b/apps/dev/tests/mcp-server-routing.test.ts
@@ -45,6 +45,26 @@ describe("dev:afk MCP entrypoint routing", () => {
     },
   );
 
+  // #2706: the lane's canary ships in THIS bundle, so the unroutable-subcommand
+  // guard must let it through instead of refusing it like a worker subcommand.
+  it("delegates __mcp-canary to the lane canary rather than refusing it", async () => {
+    const canary = vi.fn(async () => 0);
+    const connect = vi.fn(async () => undefined);
+
+    await expect(
+      main(["__mcp-canary", "--fleet", "canary"], {
+        supervise: async () => 0,
+        startCurator: async () => undefined,
+        startMergeDriver: async () => undefined,
+        connect,
+        canary,
+      }),
+    ).resolves.toBe(0);
+
+    expect(canary).toHaveBeenCalledWith(["--fleet", "canary"]);
+    expect(connect).not.toHaveBeenCalled();
+  });
+
   it("starts the issue curator in the castle resident before opening stdio", async () => {
     const calls: string[] = [];
 

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -63,6 +63,17 @@ stamped for another fleet or unstamped standalone workers. Use
 not in `fleet_list` — it persists the profile in-place so `fleet_edit` works
 immediately after.
 
+**The lane carries its own canary.** `fleet_create` once spawned every slot
+against a bundle that cannot route `run`, so a fleet created through this
+interface drained zero issues while the CLI lane kept working and no surface
+reported the difference (#2677). Run
+`castle-mcp __mcp-canary --root <scratch-repo>` to walk the shipped lane end to
+end — `fleet_create` → a slot that spawns a real worker → `fleet_status` →
+`fleet_stop`. It exits non-zero naming the step that went inert, and it treats a
+returned supervisor pid as proof of nothing: only a worker directory holding a
+live `worker.pid` counts as drainage. CI runs the same walk on every PR against
+two bundles that differ solely in whether the slot entry routes `run`.
+
 ### Worker — one worker's lifecycle
 
 | Tool | Mode | What it does |
@@ -225,6 +236,8 @@ the comment is on a pull request.
 ## Refs
 
 - ADR 0120 — red-castle is the AFK MCP; CLI and skills are clients.
+- ADR 0128 §7 — the CLI is a thin client of the same core, so the MCP lane
+  carries a canary that exercises the shipped path end to end and fails loudly.
 - ADR 0113 — castle owns the truth, dev owns the host boundary.
 - [`SKILL.md`](./SKILL.md), [`fleet.md`](./fleet.md), [`monitor.md`](./monitor.md) — the `/afk` clients.
 - [`../go/SKILL.md`](../go/SKILL.md) — the `/go` client.

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -63,6 +63,17 @@ stamped for another fleet or unstamped standalone workers. Use
 not in `fleet_list` — it persists the profile in-place so `fleet_edit` works
 immediately after.
 
+**The lane carries its own canary.** `fleet_create` once spawned every slot
+against a bundle that cannot route `run`, so a fleet created through this
+interface drained zero issues while the CLI lane kept working and no surface
+reported the difference (#2677). Run
+`castle-mcp __mcp-canary --root <scratch-repo>` to walk the shipped lane end to
+end — `fleet_create` → a slot that spawns a real worker → `fleet_status` →
+`fleet_stop`. It exits non-zero naming the step that went inert, and it treats a
+returned supervisor pid as proof of nothing: only a worker directory holding a
+live `worker.pid` counts as drainage. CI runs the same walk on every PR against
+two bundles that differ solely in whether the slot entry routes `run`.
+
 ### Worker — one worker's lifecycle
 
 | Tool | Mode | What it does |
@@ -225,6 +236,8 @@ the comment is on a pull request.
 ## Refs
 
 - ADR 0120 — red-castle is the AFK MCP; CLI and skills are clients.
+- ADR 0128 §7 — the CLI is a thin client of the same core, so the MCP lane
+  carries a canary that exercises the shipped path end to end and fails loudly.
 - ADR 0113 — castle owns the truth, dev owns the host boundary.
 - [`SKILL.md`](./SKILL.md), [`fleet.md`](./fleet.md), [`monitor.md`](./monitor.md) — the `/afk` clients.
 - [`../go/SKILL.md`](../go/SKILL.md) — the `/go` client.


### PR DESCRIPTION
Automated AFK landing for #2706. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2706

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787852893&installation_model_id=20659&pr_number=2717&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2717&signature=5f45179bb4fda9526e344268720ade98734362f652bc45cc5b0720a468d06a79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->