### PR TITLE
fix: #2714 bug: fleet stop is blind to a live supervisor, and the MCP self-heals one it cannot stop

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -26,6 +26,7 @@ import { spawnSupervisorWatchdog } from "../runtime/supervisor-watchdog-spawn.js
 import { isLivePid, killTreeAndWait } from "../runtime/kill-tree.js";
 import {
   publishSupervisorLiveness,
+  readRecordedLiveSupervisorPid,
   readSupervisorLiveness,
   readWatchdogLiveness,
   reapStaleSupervisorState,
@@ -318,8 +319,23 @@ export async function stopFleet(
   };
   // The single anchor names the supervisor to stop. `status: none` is now only
   // reachable when NO anchor names one — never while a lane is visibly ticking.
-  const liveSupervisor = await readSupervisorLiveness(stateAfk, { fleet: paths.fleet });
-  if (!liveSupervisor.alive) {
+  //
+  // `--force` alone may then fall back to a recorded pid that is merely alive
+  // (#2714). A hard teardown must never be blocked by a missing start pin — that
+  // is the state in which stop reported "no fleet running" about a supervisor the
+  // operator could see and had to kill by hand.
+  const liveness = await readSupervisorLiveness(stateAfk, { fleet: paths.fleet });
+  const recorded =
+    !liveness.alive && options.force
+      ? await readRecordedLiveSupervisorPid(stateAfk, isLivePid)
+      : null;
+  const liveSupervisor: { pid: number; anchor: "pid-file" | "fleet-state" } | null =
+    liveness.alive
+      ? { pid: liveness.pid, anchor: liveness.anchor }
+      : recorded !== null
+        ? { pid: recorded.pid, anchor: recorded.source }
+        : null;
+  if (liveSupervisor === null) {
     const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
     if (supervisor.status === "stale" && supervisor.pid !== undefined) {
       stdout.write(`no fleet running (reason=dead supervisor pid; stale files cleaned).\n`);

--- a/apps/dev/src/commands/supervisor-watchdog.ts
+++ b/apps/dev/src/commands/supervisor-watchdog.ts
@@ -134,6 +134,10 @@ export async function supervisorWatchdogCommand(
           !(await io.isRecoveryPending?.())
         ) stopping = true;
         if (result.crashLoopSuppressed) stopping = true;
+        // A stop that landed mid-pass is observed by runWatchdog itself (#2714);
+        // retire on it here too, so the loop does not keep an armed healer alive
+        // behind a fleet the operator already stopped.
+        if (result.stopRequested) stopping = true;
       },
     });
   } finally {

--- a/apps/dev/src/core/watchdog.ts
+++ b/apps/dev/src/core/watchdog.ts
@@ -67,6 +67,14 @@ export interface WatchdogIO {
    * being removed between teardown and a successful replacement boot. */
   isRecoveryPending?(): Promise<boolean>;
   setRecoveryPending?(pending: boolean): Promise<void>;
+  /**
+   * True once an explicit `fleet stop` has been requested for this fleet (#2714).
+   * Read at the single decision point every recovery path passes through, so a
+   * stop landing mid-pass still cannot be undone by a relaunch already in flight.
+   * Best-effort: an unreadable sentinel reads as "no stop requested", which only
+   * restores the pre-#2714 behaviour. Absent → the guard is inert (back-compat).
+   */
+  isStopRequested?(): Promise<boolean>;
   /** Loud, structured progress line (best-effort). */
   log(line: string): void;
 }
@@ -165,6 +173,10 @@ export interface WatchdogResult {
   /** True when the crashloop circuit breaker (#2527) is open, so the net refused
    * to respawn into a configuration proven to kill every boot identically. */
   bootBreakerSuppressed?: boolean;
+  /** True when this pass refused to recover because an explicit `fleet stop` was
+   * requested (#2714). A stop is terminal: the surface that owns teardown also
+   * owns the decision to run again. */
+  stopRequested?: boolean;
 }
 
 export interface SupervisorWatchdogLoopOptions {
@@ -274,6 +286,25 @@ export async function runWatchdog(
   if (health === "healthy") {
     if (await io.isRecoveryPending?.()) await io.setRecoveryPending?.(false);
     return base;
+  }
+
+  // An explicit stop is TERMINAL (#2714). One guard for every recovery path
+  // below, read here rather than per-path, so no route — quiescent teardown,
+  // pending-recovery retry, or the dead-supervisor net — can resurrect a fleet
+  // the operator just stopped. Without it a stop and a self-heal fight: the
+  // healer respawns what the stop cannot then see, and the fleet is unkillable.
+  let stopRequested = false;
+  try {
+    stopRequested = (await io.isStopRequested?.()) === true;
+  } catch {
+    // best-effort: an unreadable sentinel must not disarm recovery entirely.
+  }
+  if (stopRequested) {
+    io.log(
+      `watchdog: fleet stop requested — NOT recovering supervisor pid=${liveness.pid ?? "?"} ` +
+        `(health=${health}). Relaunch the fleet explicitly to resume.`,
+    );
+    return { ...base, stopRequested: true };
   }
 
   if (health === "absent") {

--- a/apps/dev/src/runtime/liveness-anchor.ts
+++ b/apps/dev/src/runtime/liveness-anchor.ts
@@ -40,6 +40,10 @@ import {
 // reader never has to reach into `supervisor-state.js` for it and re-open the
 // private-source door the ratchet closes.
 export { reapStaleSupervisorState } from "./supervisor-state.js";
+// The forced-teardown identity (#2714) is the one reader allowed to accept a pid
+// without its process-start proof. It travels through the anchor too, so
+// `fleet_stop` keeps ONE liveness import and the ratchet stays closed.
+export { readRecordedLiveSupervisorPid } from "./supervisor-state.js";
 export type { SupervisorStateReapResult, SupervisorPidDiscovery } from "./supervisor-state.js";
 
 /** Which anchor named the supervisor. `none` when no anchor named a live one. */

--- a/apps/dev/src/runtime/supervisor-state.ts
+++ b/apps/dev/src/runtime/supervisor-state.ts
@@ -186,6 +186,36 @@ export async function discoverLiveSupervisorPid(
   return null;
 }
 
+/**
+ * The last-resort identity for a FORCED teardown (#2714): any supervisor pid
+ * this lane recorded that is still alive, accepted WITHOUT the process-start
+ * proof {@link discoverLiveSupervisorPid} demands. A lock that lost its start
+ * sidecar, or a snapshot too old to vouch for itself, is exactly the state in
+ * which strict discovery answers "no fleet running" about a process the operator
+ * can see — and then has to kill by pid. `--force` is the operator's explicit
+ * "I accept the weaker proof"; every other caller must keep the strict reader,
+ * because an unpinned pid cannot rule out reuse by an unrelated process.
+ */
+export async function readRecordedLiveSupervisorPid(
+  supervisorRuntimeDir: string,
+  isLivePid: (pid: number) => boolean = defaultIsLivePid,
+): Promise<SupervisorPidDiscovery | null> {
+  const pidFile = join(supervisorRuntimeDir, "afk-supervisor.pid");
+  const pid = await readSupervisorPid(pidFile);
+  if (pid !== null && isLivePid(pid)) {
+    return { pid, source: "pid-file", path: pidFile };
+  }
+  const anchor = await readFleetStateAnchor(supervisorRuntimeDir);
+  if (anchor !== null && isLivePid(anchor.pid)) {
+    return {
+      pid: anchor.pid,
+      source: "fleet-state",
+      path: join(supervisorRuntimeDir, "state.toon"),
+    };
+  }
+  return null;
+}
+
 async function exists(path: string): Promise<boolean> {
   try {
     await access(path, constants.F_OK);

--- a/apps/dev/src/runtime/watchdog-io.ts
+++ b/apps/dev/src/runtime/watchdog-io.ts
@@ -219,6 +219,11 @@ export function buildWatchdogIO(
       }
     },
 
+    // The very sentinel `fleet stop` publishes before it inspects any process
+    // (#2714) — one file, written by the stop path and read by the healer, so
+    // the two surfaces can never disagree about whether a stop is in force.
+    isStopRequested: async () => fileExists(stopFile),
+
     isRecoveryPending: async () => fileExists(paths.supervisorRecoveryPath),
 
     setRecoveryPending: async (pending) => {

--- a/apps/dev/tests/fleet-stop-self-heal.test.ts
+++ b/apps/dev/tests/fleet-stop-self-heal.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Stop and self-heal must agree about which supervisor exists (#2714).
+ *
+ * The reported loop: `fleet stop` answered `status: none` on a live fleet, and
+ * ~90s after the operator killed the supervisor by hand a fresh one appeared,
+ * spawned by the self-heal path — a stop the healer could undo. #2698 gave every
+ * management reader one identity anchor; what was still unpinned is the
+ * interaction:
+ *
+ *   1. an explicit stop is terminal — the watchdog never resurrects a fleet
+ *      whose stop was requested, on ANY of its recovery paths;
+ *   2. `fleet_stop` names the pid and fleet it stopped whenever the recorded
+ *      supervisor pid is alive, instead of reporting `none`;
+ *   3. `--force` still finds the recorded pid when the strict identity anchor is
+ *      unreadable, so a hard teardown is never blocked by a missing start pin;
+ *   4. a supervisor the self-heal spawns is discoverable through the same anchor
+ *      `fleet_stop` reads, so create and stop cannot disagree.
+ */
+import { mkdirSync, mkdtempSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const LIVE_PID = 515_151;
+const SPAWNED_PID = 626_262;
+const DEAD_PID = 999_999_999;
+
+vi.mock("../src/runtime/kill-tree.js", () => ({
+  isLivePid: (pid: number) => pid === LIVE_PID || pid === SPAWNED_PID,
+  killTreeAndWait: vi.fn(async () => true),
+}));
+
+vi.mock("../src/core/state.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/core/state.js")>();
+  return {
+    ...actual,
+    readPidStartTime: (pid: number) =>
+      pid === LIVE_PID || pid === SPAWNED_PID ? `start-${pid}` : null,
+  };
+});
+
+// The self-heal spawn is modeled, not executed: the assertion is about which
+// anchors a spawned supervisor publishes, not about launching a real process.
+vi.mock("../src/runtime/supervisor-spawn.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/runtime/supervisor-spawn.js")>();
+  return {
+    ...actual,
+    spawnSupervisor: vi.fn(async () => SPAWNED_PID),
+    stampFreshFleetHeartbeat: vi.fn(() => {}),
+  };
+});
+
+import { stopFleet } from "../src/commands/fleet.js";
+import { runWatchdog, type WatchdogIO } from "../src/core/watchdog.js";
+import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
+import { createCastleMcpDependencies } from "../src/mcp-adapter.js";
+import { discoverLiveSupervisorPid } from "../src/runtime/supervisor-state.js";
+import { spawnSupervisor } from "../src/runtime/supervisor-spawn.js";
+import { buildWatchdogIO } from "../src/runtime/watchdog-io.js";
+import { afkPaths } from "../src/runtime/wire.js";
+
+const NOW = 1_700_000_000;
+const STALE = 300;
+const PROGRESS_STALE = 900;
+
+function scratch(): string {
+  return mkdtempSync(join(tmpdir(), "afk-stop-selfheal-"));
+}
+
+function sink(): NodeJS.WritableStream {
+  return { write: () => true } as unknown as NodeJS.WritableStream;
+}
+
+/** A heartbeat snapshot in the shape the supervisor writes every tick. */
+function fleetSnapshot(options: { pid?: number; startTime?: string | null; ageS?: number } = {}): string {
+  const pid = options.pid ?? LIVE_PID;
+  const epoch = Math.floor(Date.now() / 1_000) - (options.ageS ?? 5);
+  const startTime = options.startTime === undefined ? `start-${pid}` : options.startTime;
+  return encodeDevSnapshotToon({
+    ts: new Date(epoch * 1_000).toISOString(),
+    epoch,
+    runner: "claude",
+    target: 2,
+    pid,
+    ...(startTime !== null ? { pid_start_time: startTime } : {}),
+    ready_for_agent: 3,
+    slots: { busy: 1, free: 1, total: 2, parked: 0 },
+    slot_pids: [],
+    spawns_this_tick: 0,
+    churn: { deaths: 0, respawns: 0, window_s: 300 },
+  });
+}
+
+function lane(root: string, fleet?: string): ReturnType<typeof afkPaths> {
+  const paths = afkPaths(root, fleet);
+  mkdirSync(paths.supervisorRuntimeDir, { recursive: true });
+  return paths;
+}
+
+interface StubOverrides {
+  pid: number | null;
+  pidAlive: boolean;
+  lastHeartbeatEpoch?: number | null;
+  stopRequested: boolean;
+  recoveryPending?: boolean;
+  readyForAgent?: number;
+}
+
+/** A watchdog IO stub whose every recovery seam is observable. */
+function stubIo(over: StubOverrides) {
+  const calls = {
+    killTree: vi.fn(async () => {}),
+    killWorkers: vi.fn(async () => ({ killed: 0, survivors: [] as number[] })),
+    clearControlFiles: vi.fn(async () => {}),
+    reconcile: vi.fn(async () => {}),
+    relaunch: vi.fn(async () => true),
+    isStopRequested: vi.fn(async () => over.stopRequested),
+    log: vi.fn(),
+  };
+  const io = {
+    now: () => NOW,
+    liveness: async () => ({
+      pid: over.pid,
+      pidAlive: over.pidAlive,
+      lastHeartbeatEpoch: over.lastHeartbeatEpoch ?? null,
+      lastProgressEpoch: null,
+      slotsBusy: 0,
+    }),
+    ...calls,
+    // The legacy dead-path signal deliberately reports NO stop here, so the test
+    // proves the new fleet-wide guard is what refuses the resurrection.
+    deadSupervisorSignals: async () => ({
+      readyForAgent: over.readyForAgent ?? 5,
+      target: 2,
+      liveWorkers: 0,
+      stopRequested: false,
+    }),
+    readRestartLedger: async () => [],
+    writeRestartLedger: async () => {},
+    isRecoveryPending: async () => over.recoveryPending === true,
+    setRecoveryPending: async () => {},
+  } as unknown as WatchdogIO;
+  return { io, calls };
+}
+
+describe("an explicit stop is terminal for the self-heal (#2714)", () => {
+  it("does not relaunch a QUIESCENT supervisor whose stop was requested", async () => {
+    const { io, calls } = stubIo({
+      pid: LIVE_PID,
+      pidAlive: true,
+      lastHeartbeatEpoch: NOW - 9_999,
+      stopRequested: true,
+    });
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE);
+
+    expect(result.stopRequested).toBe(true);
+    expect(result.recovered).toBe(false);
+    // Not merely "no relaunch": the stop path owns teardown, so the watchdog
+    // must not race it by killing the tree it is already draining.
+    expect(calls.relaunch).not.toHaveBeenCalled();
+    expect(calls.killTree).not.toHaveBeenCalled();
+    expect(calls.killWorkers).not.toHaveBeenCalled();
+    expect(calls.clearControlFiles).not.toHaveBeenCalled();
+  });
+
+  it("does not respawn a DEAD supervisor stranding work when the stop was requested", async () => {
+    const { io, calls } = stubIo({
+      pid: DEAD_PID,
+      pidAlive: false,
+      stopRequested: true,
+      readyForAgent: 12,
+    });
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE);
+
+    expect(result.stopRequested).toBe(true);
+    expect(result.respawnedDeadSupervisor).toBe(false);
+    expect(calls.relaunch).not.toHaveBeenCalled();
+  });
+
+  it("does not complete a pending quiescent recovery once the stop was requested", async () => {
+    // The exact resurrection window from the report: a recovery armed before the
+    // operator stopped, whose identity is already gone.
+    const { io, calls } = stubIo({
+      pid: null,
+      pidAlive: false,
+      stopRequested: true,
+      recoveryPending: true,
+    });
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE);
+
+    expect(result.stopRequested).toBe(true);
+    expect(result.recovered).toBe(false);
+    expect(calls.relaunch).not.toHaveBeenCalled();
+  });
+
+  it("still recovers a quiescent supervisor when no stop was requested", async () => {
+    const { io, calls } = stubIo({
+      pid: LIVE_PID,
+      pidAlive: true,
+      lastHeartbeatEpoch: NOW - 9_999,
+      stopRequested: false,
+    });
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE);
+
+    expect(result.recovered).toBe(true);
+    expect(result.stopRequested ?? false).toBe(false);
+    expect(calls.relaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads the stop sentinel the stop path writes, through the real IO", async () => {
+    const root = scratch();
+    try {
+      const paths = lane(root);
+      const io = buildWatchdogIO(root, sink(), "default");
+      expect(await io.isStopRequested?.()).toBe(false);
+      writeFileSync(paths.supervisorStopPath, "", "utf8");
+      expect(await io.isStopRequested?.()).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("fleet_stop names what it stopped (#2714)", () => {
+  it("reports the live recorded pid and fleet instead of status none", async () => {
+    const root = scratch();
+    try {
+      const paths = lane(root);
+      writeFileSync(paths.supervisorPidPath, String(LIVE_PID), "utf8");
+      writeFileSync(paths.supervisorPidStartPath, `start-${LIVE_PID}`, "utf8");
+      writeFileSync(paths.fleetStatePath, fleetSnapshot(), "utf8");
+
+      const result = (await createCastleMcpDependencies(root).fleetStop({
+        name: "default",
+        force: true,
+      })) as { fleet: string; status: string; pid?: number };
+
+      expect(result.status).toBe("stopped");
+      expect(result.pid).toBe(LIVE_PID);
+      expect(result.fleet).toBe("default");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("forced stop falls back to the recorded pid (#2714)", () => {
+  it("stops the recorded live pid when the strict identity anchor is unreadable", async () => {
+    const root = scratch();
+    try {
+      // The pid lock lost its start sidecar and the snapshot is undecodable —
+      // strict discovery can prove nothing, but the recorded pid is alive.
+      const paths = lane(root);
+      writeFileSync(paths.supervisorPidPath, String(LIVE_PID), "utf8");
+      writeFileSync(paths.fleetStatePath, "}{ not a snapshot", "utf8");
+
+      expect(await discoverLiveSupervisorPid(paths.supervisorRuntimeDir)).toBeNull();
+
+      const result = await stopFleet(root, sink(), "default", { force: true });
+
+      expect(result).toMatchObject({ status: "stopped", pid: LIVE_PID });
+      expect(existsSync(paths.supervisorPidPath)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the graceful stop strict — no unproven pid is signaled without --force", async () => {
+    const root = scratch();
+    try {
+      const paths = lane(root);
+      writeFileSync(paths.supervisorPidPath, String(LIVE_PID), "utf8");
+      writeFileSync(paths.fleetStatePath, "}{ not a snapshot", "utf8");
+
+      const result = await stopFleet(root, sink(), "default");
+
+      expect(result.status).not.toBe("stopped");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not fall back to a recorded pid that is dead", async () => {
+    const root = scratch();
+    try {
+      const paths = lane(root);
+      writeFileSync(paths.supervisorPidPath, String(DEAD_PID), "utf8");
+
+      const result = await stopFleet(root, sink(), "default", { force: true });
+
+      expect(result.status).not.toBe("stopped");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("the self-heal publishes the anchor fleet_stop reads (#2714)", () => {
+  it("only reports a relaunch once discovery resolves the spawned supervisor", async () => {
+    const root = scratch();
+    try {
+      const paths = lane(root);
+      writeFileSync(paths.fleetStatePath, fleetSnapshot(), "utf8");
+      // The modeled spawn publishes the boot lock exactly as the real one does.
+      vi.mocked(spawnSupervisor).mockImplementation(async () => {
+        writeFileSync(paths.supervisorPidPath, String(SPAWNED_PID), "utf8");
+        writeFileSync(paths.supervisorPidStartPath, `start-${SPAWNED_PID}`, "utf8");
+        return SPAWNED_PID;
+      });
+
+      const io = buildWatchdogIO(root, sink(), "default");
+      await io.liveness();
+
+      expect(await io.relaunch()).toBe(true);
+      // Same anchor, same pid: fleet_stop can see what the self-heal created.
+      const discovered = await discoverLiveSupervisorPid(paths.supervisorRuntimeDir);
+      expect(discovered).toMatchObject({ pid: SPAWNED_PID, source: "pid-file" });
+      expect(Number(readFileSync(paths.supervisorPidPath, "utf8").trim())).toBe(SPAWNED_PID);
+    } finally {
+      vi.mocked(spawnSupervisor).mockReset();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to report a relaunch whose supervisor publishes no discoverable anchor", async () => {
+    const root = scratch();
+    try {
+      const paths = lane(root);
+      // A dead-pid snapshot: no anchor in the lane can vouch for anybody, so the
+      // only thing that could make discovery answer is the spawn itself.
+      writeFileSync(paths.fleetStatePath, fleetSnapshot({ pid: DEAD_PID }), "utf8");
+      vi.mocked(spawnSupervisor).mockImplementation(async () => SPAWNED_PID);
+
+      const io = buildWatchdogIO(root, sink(), "default");
+      await io.liveness();
+
+      expect(await io.relaunch()).toBe(false);
+      expect(await discoverLiveSupervisorPid(paths.supervisorRuntimeDir)).toBeNull();
+    } finally {
+      vi.mocked(spawnSupervisor).mockReset();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2714. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2714

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787859964&installation_model_id=20659&pr_number=2737&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2737&signature=46de9f53f02e6a6a866982ff21ef7877a3df0cff9a4b6467e8a45cf41ca58e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->