### PR TITLE
fix: #2720 ADR triage flags every record that supersedes another as missing its own successor

### DIFF
--- a/.changeset/adr-triage-supersession-direction.md
+++ b/.changeset/adr-triage-supersession-direction.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+ADR triage now reads supersession by direction, so a record that supersedes another is no longer reported as broken (#2720). `claimsSupersession` matched a bare `supersed` anywhere in the status, which made every healthy successor — `Accepted. Supersedes ADR 0032.` — fail the direction-aware `superseded by` lookup and land in `missing-supersession` with `successor-unnamed`. Acting on that bucket as reported would have written a fabricated `superseded-by:` pointer into nine live records, and the noise buried the two genuine findings. A claim now means only "this record IS superseded": a `superseded by` / `Superseded-by:` pointer, or a terminal `Superseded` standing alone. Pointer parsing reads through the markdown emphasis real headers use (`- **Superseded by**: …`), and a successor that names an issue or PR rather than an ADR stays flagged under its own `successor-not-adr:#N` signal — a decision is superseded only by another decision. Over the repo's own `.red/adr/`, `missing-supersession` drops from 12 findings to the 3 real ones.

--- a/apps/dev/src/core/adr-triage.ts
+++ b/apps/dev/src/core/adr-triage.ts
@@ -136,13 +136,44 @@ const TITLE_STOPWORDS = new Set([
 // signal extraction
 // ---------------------------------------------------------------------------
 
+/**
+ * The phrase that names THIS record's successor — `Superseded by ADR-0112`,
+ * `Superseded-by: 0112`. Direction is the whole point: a status that says the
+ * record *supersedes* something else is the forward end of a chain and reveals
+ * nothing about the record's own fate.
+ */
+const SUPERSEDED_BY = "supersed(?:ed|es)[-\\s]+by\\b";
+
+/** Emphasis and punctuation a real header puts between the phrase and its target — `**Superseded by**: #2417`. */
+const POINTER_GAP = "[\\s*_:\\-]*";
+
+/** A bare terminal `Superseded` — the word standing alone, naming nobody. */
+const TERMINAL_SUPERSEDED = /\bsuperseded\b[*_`)\s]*[.;,]?\s*$/im;
+
 /** `Superseded by ADR-0112` in an ADR's own status — the terminal marker. */
 function supersededBy(record: AdrRecord): string | undefined {
-  return /supersed(?:ed|es)\s+by\s+(?:ADR[-\s]?)?(\d{4})/i.exec(record.status)?.[1];
+  return new RegExp(`${SUPERSEDED_BY}${POINTER_GAP}\\[?\\s*(?:ADR[-\\s]?)?(\\d{4})`, "i").exec(record.status)?.[1];
 }
 
+/**
+ * The successor a pointer names when that successor is not an ADR — an issue,
+ * a PR, or a URL. A decision is only superseded by another decision, so this
+ * counts as debt, never as a resolved supersession.
+ */
+function nonAdrSuccessor(record: AdrRecord): string | undefined {
+  if (supersededBy(record)) return undefined;
+  const token = new RegExp(`${SUPERSEDED_BY}${POINTER_GAP}(#\\d+|https?://\\S+)`, "i").exec(record.status)?.[1];
+  return token?.replace(/[.,;:)\]]+$/, "");
+}
+
+/**
+ * True only when the status says THIS record IS superseded: a `superseded by`
+ * pointer, or a terminal `Superseded` standing alone. Merely naming a record
+ * this one supersedes is what a healthy successor reads like, so it is never a
+ * claim — reading it as one flags every live successor as broken.
+ */
 function claimsSupersession(record: AdrRecord): boolean {
-  return /supersed/i.test(record.status);
+  return new RegExp(SUPERSEDED_BY, "i").test(record.status) || TERMINAL_SUPERSEDED.test(record.status);
 }
 
 function isDeprecated(record: AdrRecord): boolean {
@@ -244,11 +275,14 @@ function classify(record: AdrRecord, context: AdrTriageContext): Classification 
   }
 
   if (!successor && claimsSupersession(record)) {
-    signals.push("successor-unnamed");
+    const nonAdr = nonAdrSuccessor(record);
+    signals.push(nonAdr ? `successor-not-adr:${nonAdr}` : "successor-unnamed");
     return {
       bucket: "missing-supersession",
       signals,
-      reason: "Status claims supersession without naming the successor ADR.",
+      reason: nonAdr
+        ? `Status names ${nonAdr} as successor, which is not an ADR; a decision is superseded only by another decision.`
+        : "Status says this record is superseded without naming the successor ADR.",
     };
   }
 

--- a/apps/dev/tests/adr-triage.test.ts
+++ b/apps/dev/tests/adr-triage.test.ts
@@ -140,6 +140,75 @@ describe("triageAdrs", () => {
     expect(report.entries[0]!.signals).toContain("successor-unnamed");
   });
 
+  it("still flags a bare terminal `superseded` when no record supersedes it either", () => {
+    const context: AdrTriageContext = {
+      adrs: [adr("0020", { status: "Superseded." }), adr("0021", { title: "Unrelated live record" })],
+    };
+    const entry = triageAdrs(context).entries.find((item) => item.number === "0020")!;
+
+    expect(entry.bucket, "a terminal status naming nobody is real debt, not noise").toBe(
+      "missing-supersession",
+    );
+    expect(entry.signals).toContain("successor-unnamed");
+  });
+
+  it("keeps the forward end of a supersession — superseding another record is not debt", () => {
+    const context: AdrTriageContext = {
+      adrs: [
+        adr("0112", { title: "Gated curation model" }),
+        adr("0127", {
+          title: "Totipotent editor",
+          status: "Accepted. Supersedes ADR 0112, whose gated model this record replaces.",
+        }),
+      ],
+    };
+
+    expect(bucketsByNumber(context)["0127"]).toBe("keep");
+  });
+
+  it("never reads a mention of superseding something else as this record's own fate", () => {
+    const forward = [
+      "Accepted. Supersedes ADR 0032.",
+      "accepted.\n\nSupersedes: [ADR 0046](0046-single-global-red-dir.md)",
+      "Accepted. Supersedes the transitional dual-output state of the port.",
+      "Accepted. Refines ADR 0038 (which superseded ADR 0032).",
+    ];
+
+    for (const status of forward) {
+      const report = triageAdrs({ adrs: [adr("0200", { status })] });
+
+      expect(report.entries[0]!.bucket, `forward supersession must not be debt: ${status}`).toBe("keep");
+    }
+  });
+
+  it("buckets a record by whichever successor-pointer spelling its status uses", () => {
+    for (const status of ["Superseded by ADR 0003.", "Superseded by ADR-0003.", "Superseded-by: 0003"]) {
+      const report = triageAdrs({ adrs: [adr("0002", { status }), adr("0003", { title: "Successor" })] });
+      const entry = report.entries.find((item) => item.number === "0002")!;
+
+      expect(entry.bucket, `terminal successor pointer: ${status}`).toBe("archive-candidate");
+      expect(entry.signals).toContain("superseded-by:0003");
+    }
+  });
+
+  it("flags a successor pointer that names an issue instead of an ADR", () => {
+    const context: AdrTriageContext = {
+      adrs: [
+        // The real ADR 0119 header shape: emphasis and a colon between phrase and target.
+        adr("0119", {
+          status: "- **Status**: superseded — the trust stage was removed in #2417\n- **Superseded by**: #2417",
+        }),
+      ],
+    };
+    const entry = triageAdrs(context).entries[0]!;
+
+    expect(
+      entry.bucket,
+      "chosen behaviour: an issue is not a decision record, so a non-ADR successor leaves the chain unresolved and stays flagged",
+    ).toBe("missing-supersession");
+    expect(entry.signals).toContain("successor-not-adr:#2417");
+  });
+
   it("archives a deprecated ADR", () => {
     const context: AdrTriageContext = { adrs: [adr("0021", { status: "Deprecated." })] };
 
@@ -339,6 +408,18 @@ describe("detectAdrInconsistencies", () => {
       "0008",
       "0009",
     ]);
+  });
+
+  it("reports only the superseded end of a supersession, never the successor", () => {
+    const report = detectAdrInconsistencies({
+      adrs: [
+        adr("0112", { title: "Gated curation model" }),
+        adr("0127", { title: "Totipotent editor", status: "Accepted. Supersedes ADR 0112." }),
+      ],
+    });
+    const missing = report.inconsistencies.filter((finding) => finding.kind === "missing-supersession");
+
+    expect(missing.map((finding) => finding.numbers[0])).toEqual(["0112"]);
   });
 
   it("never reports an overlap between terminal records", () => {

--- a/packaging/pi/dev/skills/engineering/adr-editor/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/adr-editor/SKILL.md
@@ -36,6 +36,12 @@ destructive or wide → apply in-session → verify → land**.
   when the session ends, and every archived record must carry a terminal status.
   A `superseded-by:` pointer is required only when a successor exists — a record
   archived for going inert has none, so do not invent one to satisfy the rule.
+- ✅ **Read supersession by direction.** `missing-supersession` means *this*
+  record is superseded and says so badly; a status that names a record this one
+  supersedes is the healthy forward end and is never debt. A successor pointer
+  that names an issue or PR (`Superseded by: #2417`) stays flagged — a decision
+  is superseded only by another decision — so cure it by naming the successor
+  ADR, never by writing a fabricated pointer into a live record.
 - ✅ **Honour `start/ADR-FORMAT.md`.** Sequential four-digit numbering, an H1 that
   reads `# NNNN — Title` and matches its filename, and sections only where they
   earn their place.

--- a/plugins/dev/skills/engineering/adr-editor/SKILL.md
+++ b/plugins/dev/skills/engineering/adr-editor/SKILL.md
@@ -36,6 +36,12 @@ destructive or wide → apply in-session → verify → land**.
   when the session ends, and every archived record must carry a terminal status.
   A `superseded-by:` pointer is required only when a successor exists — a record
   archived for going inert has none, so do not invent one to satisfy the rule.
+- ✅ **Read supersession by direction.** `missing-supersession` means *this*
+  record is superseded and says so badly; a status that names a record this one
+  supersedes is the healthy forward end and is never debt. A successor pointer
+  that names an issue or PR (`Superseded by: #2417`) stays flagged — a decision
+  is superseded only by another decision — so cure it by naming the successor
+  ADR, never by writing a fabricated pointer into a live record.
 - ✅ **Honour `start/ADR-FORMAT.md`.** Sequential four-digit numbering, an H1 that
   reads `# NNNN — Title` and matches its filename, and sections only where they
   earn their place.


### PR DESCRIPTION
Automated AFK landing for #2720. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2720

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787861466&installation_model_id=20659&pr_number=2739&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2739&signature=556cfa2d5af0f1f87eaf7ea9f8b3fbb26aca383aae737aa7921252dcfea9cb3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->