### PR TITLE
chore: #2724 Failure-signature function: derive a stable key for Re-seed dedupe

### DIFF
--- a/apps/dev/src/core/failure-signature.ts
+++ b/apps/dev/src/core/failure-signature.ts
@@ -1,0 +1,157 @@
+// failure-signature — the stable dedupe key for a Re-seed round (issue #2724,
+// Spec #2723, ADR 0129).
+//
+// A Re-seed re-instructs the implementer in place after a gate stage blocked
+// the work. Two things need to know whether round N failed the same way as
+// round N-1: the dedupe rule (do not spend a round repeating a round) and the
+// tier-escalation trigger (a repeated signature buys a different model tier
+// rather than the same tier again). Both consume ONE key, derived here.
+//
+// The key is a SET identity, not a transcript identity. It is order-independent
+// over the failing check names, the named test identities inside their
+// summaries, and the review findings, because the same failures reported in a
+// different order are the same failure. It deliberately excludes everything
+// volatile — durations, exit codes, the captured output tail — so a rerun of an
+// unchanged branch keys the same, while it includes everything identifying, so
+// a subset of the previous failures is NOT a repeat and gets its own round.
+//
+// IO-free and total: every input is data the caller already observed, malformed
+// sidecar lines are skipped rather than thrown on, and degenerate input yields
+// {@link EMPTY_FAILURE_SIGNATURE} instead of an exception.
+
+import { createHash } from "node:crypto";
+
+import { VALIDATION_SCHEMA, type ValidationRecord } from "./feedback.js";
+
+/**
+ * One review finding as the signature sees it. Structurally the intersection of
+ * `InlineComment` (review.ts) and `AdversarialReviewFinding`
+ * (adversarial-review.ts), so either shape passes without adaptation. Every
+ * field is optional because a signature must never be the thing that throws.
+ */
+export interface FailureSignatureFinding {
+  /** Repo-relative path the finding is anchored to. */
+  readonly path?: string;
+  /** 1-indexed line the finding is anchored to. */
+  readonly line?: number;
+  /** The finding text. Whitespace-normalised and capped before it enters the key. */
+  readonly body?: string;
+  /** True when the finding blocks the round. Absent reads as advisory. */
+  readonly blocking?: boolean;
+}
+
+/** Everything one Re-seed round observed that could define a failure. */
+export interface FailureSignatureInput {
+  /** Raw `red.afk.validation.v1` sidecar lines, exactly as the gate emitted them. */
+  readonly sidecar?: readonly string[];
+  /** The round's review findings, blocking and advisory alike. */
+  readonly findings?: readonly FailureSignatureFinding[];
+}
+
+/**
+ * The key for a round with nothing failing. A stable sentinel rather than an
+ * empty string, so a caller comparing two clean rounds gets a meaningful equal
+ * and a caller logging the key never prints nothing at all.
+ */
+export const EMPTY_FAILURE_SIGNATURE = "v1:none";
+
+/** Key version prefix — bump when the term vocabulary changes meaning. */
+const SIGNATURE_VERSION = "v1";
+
+/** Hex digits of the digest kept. 16 is collision-safe for a per-attempt ledger
+ * and short enough to read in a log line. */
+const DIGEST_LENGTH = 16;
+
+/** Cap on one finding body inside the key. A finding is identified by its
+ * location and its opening claim; a long tail adds churn, not identity. */
+const MAX_BODY_CHARS = 240;
+
+/** The `outputSummary` identity prefix: `failing: a | b — <tail>`. Only the part
+ * before the em-dash names checks; the tail is volatile and dropped. */
+const NAMED_FAILURE_PREFIX = /^failing:\s*(.*?)(?:\s+—\s|$)/;
+
+/** Collapse all whitespace runs to single spaces and trim. */
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+/** Parse one sidecar line into a record, or `undefined` when it is blank,
+ * malformed, not an object, or not a `red.afk.validation.v1` record. */
+function parseRecord(raw: string): ValidationRecord | undefined {
+  if (normalizeWhitespace(raw) === "") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+  const record = parsed as Partial<ValidationRecord>;
+  if (record.schema !== VALIDATION_SCHEMA) return undefined;
+  if (typeof record.name !== "string" || record.name === "") return undefined;
+  return record as ValidationRecord;
+}
+
+/** The named check identities inside a failing check's summary, if it carries
+ * the `failing: …` prefix. Returns `[]` for a summary that only holds a tail. */
+function namedTestIdentities(summary: string | undefined): string[] {
+  if (typeof summary !== "string") return [];
+  const match = NAMED_FAILURE_PREFIX.exec(normalizeWhitespace(summary));
+  if (!match) return [];
+  return match[1]
+    .split("|")
+    .map((identity) => normalizeWhitespace(identity))
+    .filter((identity) => identity !== "");
+}
+
+/** The key term for one review finding. */
+function findingTerm(finding: FailureSignatureFinding): string {
+  const kind = finding.blocking === true ? "blocking" : "advisory";
+  const path = typeof finding.path === "string" ? normalizeWhitespace(finding.path) : "";
+  const line = typeof finding.line === "number" && Number.isFinite(finding.line) ? String(finding.line) : "";
+  const body = typeof finding.body === "string" ? normalizeWhitespace(finding.body).slice(0, MAX_BODY_CHARS) : "";
+  return `review:${kind}:${path}:${line}:${body}`;
+}
+
+/**
+ * The canonical, deduped, sorted terms behind {@link failureSignature}. Exported
+ * because a term list is what a human debugging a dedupe decision actually wants
+ * to read — the digest tells you two rounds differ, the terms tell you how.
+ *
+ * Three term families:
+ * - `check:<name>` — one failing validation check (`test:root`, `lint:apps/dev`).
+ * - `test:<identity>` — one named failure inside a failing check's summary.
+ * - `review:<blocking|advisory>:<path>:<line>:<body>` — one review finding.
+ */
+export function failureSignatureTerms(input: FailureSignatureInput): string[] {
+  const terms = new Set<string>();
+
+  for (const raw of input.sidecar ?? []) {
+    const record = parseRecord(raw);
+    if (!record || record.status !== "failed") continue;
+    terms.add(`check:${normalizeWhitespace(record.name)}`);
+    for (const identity of namedTestIdentities(record.summary)) {
+      terms.add(`test:${identity}`);
+    }
+  }
+
+  for (const finding of input.findings ?? []) {
+    if (finding === null || typeof finding !== "object") continue;
+    terms.add(findingTerm(finding));
+  }
+
+  return [...terms].sort();
+}
+
+/**
+ * The stable failure signature for one Re-seed round: `v1:<16 hex digits>`, or
+ * {@link EMPTY_FAILURE_SIGNATURE} when nothing failed. Equal keys mean the round
+ * failed the same way; unequal keys mean the failure set moved, including when
+ * it merely shrank.
+ */
+export function failureSignature(input: FailureSignatureInput): string {
+  const terms = failureSignatureTerms(input);
+  if (terms.length === 0) return EMPTY_FAILURE_SIGNATURE;
+  const digest = createHash("sha256").update(terms.join("\n")).digest("hex");
+  return `${SIGNATURE_VERSION}:${digest.slice(0, DIGEST_LENGTH)}`;
+}

--- a/apps/dev/tests/failure-signature.test.ts
+++ b/apps/dev/tests/failure-signature.test.ts
@@ -1,0 +1,186 @@
+// failure-signature — the pure Re-seed dedupe key (issue #2724, Spec #2723).
+//
+// Acceptance criteria under test:
+// 1. Two sidecars listing the same failing checks in a different order produce
+//    equal keys.
+// 2. A partially-overlapping failure set produces a DIFFERENT key — a subset is
+//    not a repeat.
+// 3. Review findings contribute, so a gate-clean/review-blocking round is
+//    distinguishable from a gate-failing one.
+// 4. An empty sidecar with no findings produces a stable sentinel rather than
+//    throwing.
+import { describe, expect, it } from "vitest";
+import {
+  EMPTY_FAILURE_SIGNATURE,
+  failureSignature,
+  failureSignatureTerms,
+  type FailureSignatureFinding,
+} from "../src/core/failure-signature.js";
+import { VALIDATION_SCHEMA, type ValidationRecord } from "../src/core/feedback.js";
+
+function line(over: Partial<ValidationRecord> & Pick<ValidationRecord, "name">): string {
+  const record: ValidationRecord = {
+    schema: VALIDATION_SCHEMA,
+    status: "failed",
+    ...over,
+  };
+  return JSON.stringify(record);
+}
+
+const TEST_ROOT_FAILED = line({
+  name: "test:root",
+  command: "pnpm -C . test",
+  exitCode: 1,
+  summary: "failing: FAIL tests/a.test.ts > widget renders — Tests 1 failed | 40 passed",
+});
+const LINT_DEV_FAILED = line({ name: "lint:apps/dev", exitCode: 1, summary: "command exited non-zero" });
+const BUILD_DEV_FAILED = line({ name: "build:apps/dev", exitCode: 1, summary: "command exited non-zero" });
+const TYPECHECK_PASSED = line({ name: "typecheck:workspace", status: "passed", summary: "command exited 0" });
+
+function finding(over: Partial<FailureSignatureFinding> = {}): FailureSignatureFinding {
+  return {
+    path: "apps/dev/src/core/lifecycle.ts",
+    line: 42,
+    body: "This swallows the error instead of surfacing it.",
+    blocking: true,
+    ...over,
+  };
+}
+
+describe("failureSignature — order independence", () => {
+  it("gives the same key for the same failing checks listed in a different order", () => {
+    const forward = failureSignature({ sidecar: [TEST_ROOT_FAILED, LINT_DEV_FAILED, BUILD_DEV_FAILED] });
+    const reversed = failureSignature({ sidecar: [BUILD_DEV_FAILED, LINT_DEV_FAILED, TEST_ROOT_FAILED] });
+
+    expect(forward).toBe(reversed);
+    expect(forward).not.toBe(EMPTY_FAILURE_SIGNATURE);
+  });
+
+  it("gives the same key for the same review findings reported in a different order", () => {
+    const a = finding({ path: "a.ts", line: 1, body: "one" });
+    const b = finding({ path: "b.ts", line: 2, body: "two" });
+
+    expect(failureSignature({ findings: [a, b] })).toBe(failureSignature({ findings: [b, a] }));
+  });
+
+  it("ignores duplicate records, so a repeated failure is not a different failure", () => {
+    expect(failureSignature({ sidecar: [TEST_ROOT_FAILED, TEST_ROOT_FAILED] })).toBe(
+      failureSignature({ sidecar: [TEST_ROOT_FAILED] }),
+    );
+  });
+});
+
+describe("failureSignature — set identity", () => {
+  it("gives a different key for a partially-overlapping failure set", () => {
+    const both = failureSignature({ sidecar: [TEST_ROOT_FAILED, LINT_DEV_FAILED] });
+    const subset = failureSignature({ sidecar: [TEST_ROOT_FAILED] });
+    const superset = failureSignature({ sidecar: [TEST_ROOT_FAILED, LINT_DEV_FAILED, BUILD_DEV_FAILED] });
+
+    expect(both).not.toBe(subset);
+    expect(both).not.toBe(superset);
+    expect(subset).not.toBe(superset);
+  });
+
+  it("keys on the named test identities, not on the volatile output tail", () => {
+    const named = "failing: FAIL tests/a.test.ts > widget renders";
+    const runOne = line({ name: "test:root", summary: `${named} — Tests 1 failed | 40 passed in 12.01s` });
+    const runTwo = line({ name: "test:root", summary: `${named} — Tests 1 failed | 40 passed in 9.44s` });
+
+    expect(failureSignature({ sidecar: [runOne] })).toBe(failureSignature({ sidecar: [runTwo] }));
+  });
+
+  it("distinguishes the same check failing on different tests", () => {
+    const widget = line({ name: "test:root", summary: "failing: FAIL tests/a.test.ts > widget renders — tail" });
+    const gadget = line({ name: "test:root", summary: "failing: FAIL tests/a.test.ts > gadget renders — tail" });
+
+    expect(failureSignature({ sidecar: [widget] })).not.toBe(failureSignature({ sidecar: [gadget] }));
+  });
+
+  it("ignores passed and skipped records — only failures define the signature", () => {
+    const skipped = line({ name: "lint:apps/dev", status: "skipped", summary: "no lint script" });
+
+    expect(failureSignature({ sidecar: [TEST_ROOT_FAILED, TYPECHECK_PASSED, skipped] })).toBe(
+      failureSignature({ sidecar: [TEST_ROOT_FAILED] }),
+    );
+  });
+});
+
+describe("failureSignature — review findings", () => {
+  it("distinguishes a gate-clean/review-blocking round from a gate-failing one", () => {
+    const reviewOnly = failureSignature({ sidecar: [TYPECHECK_PASSED], findings: [finding()] });
+    const gateOnly = failureSignature({ sidecar: [TEST_ROOT_FAILED] });
+
+    expect(reviewOnly).not.toBe(gateOnly);
+    expect(reviewOnly).not.toBe(EMPTY_FAILURE_SIGNATURE);
+  });
+
+  it("changes the key when a finding is added to an otherwise identical gate failure", () => {
+    const withoutReview = failureSignature({ sidecar: [TEST_ROOT_FAILED] });
+    const withReview = failureSignature({ sidecar: [TEST_ROOT_FAILED], findings: [finding()] });
+
+    expect(withReview).not.toBe(withoutReview);
+  });
+
+  it("separates a blocking finding from an advisory one at the same location", () => {
+    const blocking = failureSignature({ findings: [finding({ blocking: true })] });
+    const advisory = failureSignature({ findings: [finding({ blocking: false })] });
+
+    expect(blocking).not.toBe(advisory);
+  });
+
+  it("keys a finding on its location and normalised body", () => {
+    const spaced = finding({ body: "  This  swallows\n the error.  " });
+    const tight = finding({ body: "This swallows the error." });
+    const moved = finding({ body: "This swallows the error.", line: 43 });
+
+    expect(failureSignature({ findings: [spaced] })).toBe(failureSignature({ findings: [tight] }));
+    expect(failureSignature({ findings: [moved] })).not.toBe(failureSignature({ findings: [tight] }));
+  });
+});
+
+describe("failureSignature — degenerate input", () => {
+  it("returns the stable sentinel for an empty sidecar and no findings", () => {
+    expect(failureSignature({})).toBe(EMPTY_FAILURE_SIGNATURE);
+    expect(failureSignature({ sidecar: [], findings: [] })).toBe(EMPTY_FAILURE_SIGNATURE);
+    expect(failureSignature({ sidecar: ["", "   "] })).toBe(EMPTY_FAILURE_SIGNATURE);
+    expect(failureSignature({ sidecar: [TYPECHECK_PASSED] })).toBe(EMPTY_FAILURE_SIGNATURE);
+  });
+
+  it("never throws on malformed, non-object, or foreign sidecar lines", () => {
+    expect(failureSignature({ sidecar: ["{not json", "[]", "null", "42", '{"status":"failed"}'] })).toBe(
+      EMPTY_FAILURE_SIGNATURE,
+    );
+    expect(failureSignature({ sidecar: ["{not json", TEST_ROOT_FAILED] })).toBe(
+      failureSignature({ sidecar: [TEST_ROOT_FAILED] }),
+    );
+  });
+
+  it("tolerates findings missing every optional field", () => {
+    expect(() => failureSignature({ findings: [{} as FailureSignatureFinding] })).not.toThrow();
+    expect(failureSignature({ findings: [{} as FailureSignatureFinding] })).not.toBe(EMPTY_FAILURE_SIGNATURE);
+  });
+
+  it("is deterministic across calls", () => {
+    const input = { sidecar: [TEST_ROOT_FAILED, LINT_DEV_FAILED], findings: [finding()] };
+    expect(failureSignature(input)).toBe(failureSignature(input));
+  });
+});
+
+describe("failureSignatureTerms", () => {
+  it("exposes the canonical sorted terms behind the key", () => {
+    const terms = failureSignatureTerms({
+      sidecar: [LINT_DEV_FAILED, TEST_ROOT_FAILED],
+      findings: [finding({ path: "z.ts", line: 9, body: "nope" })],
+    });
+
+    expect(terms).toEqual([...terms].sort());
+    expect(terms).toContain("check:lint:apps/dev");
+    expect(terms).toContain("check:test:root");
+    expect(terms).toContain("test:FAIL tests/a.test.ts > widget renders");
+    expect(terms).toContain("review:blocking:z.ts:9:nope");
+  });
+
+  it("is empty for degenerate input", () => {
+    expect(failureSignatureTerms({})).toEqual([]);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2724. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2724

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787862325&installation_model_id=20659&pr_number=2740&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2740&signature=ad048343c048f268b7939678a88ccda208189debdfbc7951e2ca4fb7444b29d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->