### PR TITLE
fix: #2736 rsp resident auto-spawn re-execs the caller's argv[1], so a non-rsp host silently loses elision

### DIFF
--- a/.changeset/rsp-resident-entry-resolution.md
+++ b/.changeset/rsp-resident-entry-resolution.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The resident auto-spawn now resolves the rsp entrypoint explicitly instead of re-executing the caller's `process.argv[1]` (#2736). A host that is not the rsp CLI — the dev bundle, castle-mcp, memory, brain — used to re-exec *itself* with `warm-resident`, an argument only the rsp CLI routes, and because rsp fails open by contract that spawn died in silence: the command still ran, but compression, `el:<id>` handles and telemetry quietly disappeared. Entry resolution walks named candidates in order — an explicit `serverCommand`, `RSP_BIN`, the caller's own entry when it *is* an rsp entry, the rsp bundle beside the host bundle, the plugin-root bundle, the repo `dist/`, the workspace entry, and the bundle cache — and a host with no resolvable entry now emits the named `rsp-resident-entry-unresolved` diagnostic once instead of failing silently. Fail-open is unchanged: after the diagnostic the wrapped command keeps its own stdout, stderr and exit status.

--- a/apps/brain/src/resident-brain.ts
+++ b/apps/brain/src/resident-brain.ts
@@ -54,7 +54,8 @@ function residentConfig(rootDir: string): RspResidentConfig {
     storeUri: sharedStoreUri(rootDir),
     ttlDays: DEFAULT_RSP_TTL_DAYS,
     byteBudget: DEFAULT_RSP_BYTE_BUDGET,
-    serverCommand: process.env.RSP_BIN ?? "rsp",
+    // No `serverCommand`: the client resolves the rsp entry explicitly (#2736).
+    // A bare `rsp` on PATH was a guess that failed silently off the shim.
   };
 }
 

--- a/apps/memory/src/resident-memory.ts
+++ b/apps/memory/src/resident-memory.ts
@@ -48,7 +48,8 @@ export async function residentMemoryRequest(
     storeUri: `file://${resolveSharedStorePath(resolve(rootDir), existsSync)}`,
     ttlDays: DEFAULT_RSP_TTL_DAYS,
     byteBudget: DEFAULT_RSP_BYTE_BUDGET,
-    serverCommand: process.env.RSP_BIN ?? "rsp",
+    // No `serverCommand`: the client resolves the rsp entry explicitly (#2736).
+    // A bare `rsp` on PATH was a guess that failed silently off the shim.
   });
   return await client.request({ op: "memory", action, payload });
 }

--- a/apps/rsp/docs/TROUBLESHOOTING.md
+++ b/apps/rsp/docs/TROUBLESHOOTING.md
@@ -37,6 +37,8 @@ While the resident is down, every surface stays usable because it fails open. Th
 
 An unreachable resident **costs the elision, never the command** — if a command result is lost or an exit status changes, that is a defect to report, not fail-open.
 
+**`rsp-resident-entry-unresolved` means the host cannot find an rsp to spawn.** The auto-spawn resolves the rsp entrypoint explicitly — an explicit `serverCommand`, `RSP_BIN`, the caller's own entry when it *is* an rsp entry, the rsp bundle beside the host bundle, the plugin-root bundle, the repo `dist/`, the workspace entry, then the bundle cache — and says this name once per process when none of them exists (#2736). It is emitted by hosts that are not the rsp CLI (the dev bundle, castle-mcp, memory, brain), and it never blocks the command. Recover by installing the rsp bundle where the host can see it (`/red-setup`) or by setting `RSP_BIN` to the rsp binary.
+
 ### Root fix
 
 `rsp status` should classify absent, stale, and unreachable-but-live in one actionable line so this manual split is unnecessary; the resident-health reporting work is tracked by #1731.

--- a/apps/rsp/src/cli/main.ts
+++ b/apps/rsp/src/cli/main.ts
@@ -215,10 +215,14 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     }));
     return 1;
   }
-  const { residentConfigFor, residentElisionStore } = await import("../resident-store.js");
+  const { residentConfigFor, residentElisionStore, reportResidentEntryDiagnostic } = await import("../resident-store.js");
   const openResidentStore = (ensureResident = true) =>
     Promise.resolve(residentElisionStore(process.cwd(), config, { ensureResident, paths: residentPaths }));
-  const warmResidentStore = () => ensureResidentServer(residentPaths, residentConfigFor(config, buildInfo.version));
+  // A warm that cannot find an rsp entry is the silent-elision-loss failure
+  // (#2736): it names itself once, then the command runs on regardless.
+  const warmResidentStore = () =>
+    ensureResidentServer(residentPaths, residentConfigFor(config, buildInfo.version))
+      .catch((err: unknown) => void reportResidentEntryDiagnostic(err));
   // Reads go through the resident too: one core owns the store, so `show` and
   // `gains` ask it rather than opening a second handle on the same file.
   const openReadStore = () => openResidentStore();

--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -12,6 +12,7 @@ import {
   kickResidentServer,
   resolveResidentPaths,
 } from "./resident-client.js";
+import { reportResidentEntryDiagnostic } from "./resident-store.js";
 import { resolveRspInvocationPrefix } from "./rsp-cli.js";
 import {
   appendTelemetryEvent,
@@ -427,7 +428,13 @@ function debugHookException(hook: string, err: unknown): void {
   process.stderr.write(`rsp hook ${hook}: exception ${errorLabel(err)}\n`);
 }
 
+/**
+ * A wake that failed is debug-only noise — except when the host cannot resolve
+ * an rsp entry at all. That one always says its name (#2736), and the command
+ * still runs raw.
+ */
 function debugHookWakeFailure(err: unknown): void {
+  if (reportResidentEntryDiagnostic(err)) return;
   if (process.env.RSP_DEBUG !== "1") return;
   process.stderr.write(`rsp hook pre-exec: resident-wake-failed ${errorLabel(err)}\n`);
 }

--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -13,6 +13,9 @@ import { sendResidentRequest } from "./resident-protocol.js";
 import {
   ensureResidentServer,
   kickResidentServer,
+  resolveRspEntry,
+  RspResidentEntryError,
+  RSP_ENTRY_UNRESOLVED,
   pingResident,
   readResidentRegistry,
   removeResidentRegistry,
@@ -35,6 +38,9 @@ export interface ResidentResponseMetrics {
 export {
   ensureResidentServer,
   kickResidentServer,
+  resolveRspEntry,
+  RspResidentEntryError,
+  RSP_ENTRY_UNRESOLVED,
   pingResident,
   readResidentRegistry,
   removeResidentRegistry,

--- a/apps/rsp/src/resident-store.ts
+++ b/apps/rsp/src/resident-store.ts
@@ -12,7 +12,12 @@
  */
 import { readBuildInfo } from "@reddb-io/build-info";
 import type { RspRuntimeConfig } from "./config.js";
-import { ResidentRspElisionStore, resolveResidentPaths, type RspResidentPaths } from "./resident-client.js";
+import {
+  ResidentRspElisionStore,
+  resolveResidentPaths,
+  RSP_ENTRY_UNRESOLVED,
+  type RspResidentPaths,
+} from "./resident-client.js";
 import type { RspResidentConfig } from "./resident-protocol.js";
 
 export interface ResidentElisionStoreOptions {
@@ -50,4 +55,29 @@ export function residentElisionStore(
     residentConfigFor(config, readBuildInfo("rsp").version),
     { ensureResident: opts.ensureResident },
   );
+}
+
+let entryDiagnosticReported = false;
+
+/**
+ * Say the one failure that used to be silent.
+ *
+ * An ordinary failed wake stays debug-only noise, but a host with no resolvable
+ * rsp entry loses elision, handles and telemetry for every command it will ever
+ * run (#2736). That one names itself on stderr, once per process, and the
+ * command still runs — fail-open is the contract, silence never was.
+ *
+ * Returns whether the error was that diagnostic, so a caller can stop there.
+ */
+export function reportResidentEntryDiagnostic(err: unknown): boolean {
+  if (!isResidentEntryUnresolved(err)) return false;
+  if (entryDiagnosticReported) return true;
+  entryDiagnosticReported = true;
+  process.stderr.write(`rsp: ${RSP_ENTRY_UNRESOLVED} — elision is off until an rsp entry is installed\n`);
+  if (process.env.RSP_DEBUG === "1" && err instanceof Error) process.stderr.write(`${err.message}\n`);
+  return true;
+}
+
+export function isResidentEntryUnresolved(err: unknown): boolean {
+  return typeof err === "object" && err !== null && (err as { code?: string }).code === RSP_ENTRY_UNRESOLVED;
 }

--- a/apps/rsp/tests/resident-entry.test.ts
+++ b/apps/rsp/tests/resident-entry.test.ts
@@ -1,0 +1,225 @@
+// #2736 — the resident auto-spawn must target the rsp entry, never the caller's
+// own argv[1]. A dev-bundle or castle-mcp host that re-execs itself with
+// `warm-resident` loses elision in silence, because rsp fails open by contract.
+import { spawnSync } from "node:child_process";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ensureResidentServer,
+  resolveResidentPaths,
+  resolveRspEntry,
+  RSP_ENTRY_UNRESOLVED,
+} from "../src/resident-client.js";
+import { hookDecisionFromClaudePreExecJson, formatHookDecision } from "../src/intercept.js";
+import { cli, commitMany, enableRsp, initGitRepo, tempRoot, tsxLoader } from "./cli.helpers.js";
+
+/** Every ambient escape hatch cleared, so a lookup only sees what the test plants. */
+function bareEnv(cacheRoot: string): NodeJS.ProcessEnv {
+  return { RED_SKILLS_CACHE_DIR: cacheRoot };
+}
+
+/** Run `body` with the ambient rsp-entry env vars removed from this process. */
+async function withoutAmbientEntry<T>(cacheRoot: string, body: () => Promise<T>): Promise<T> {
+  const names = [
+    "RSP_BIN",
+    "RED_SKILLS_CACHE_DIR",
+    "RED_SKILLS_DEV_PLUGIN_ROOT",
+    "CLAUDE_PLUGIN_ROOT",
+    "CODEX_PLUGIN_ROOT",
+    "OPENCODE_PLUGIN_ROOT",
+  ];
+  const saved = new Map(names.map((name) => [name, process.env[name]]));
+  for (const name of names) delete process.env[name];
+  process.env.RED_SKILLS_CACHE_DIR = cacheRoot;
+  try {
+    return await body();
+  } finally {
+    for (const [name, value] of saved) {
+      if (value == null) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}
+
+describe("resident spawn target (#2736)", () => {
+  it("targets the rsp bundle when the caller's argv[1] is a foreign bundle", async () => {
+    const root = await tempRoot();
+    const dist = join(root, "dist");
+    await mkdir(dist, { recursive: true });
+    await writeFile(join(dist, "rsp.bundle.min.mjs"), "// rsp\n");
+    // The dev plugin bundle: a host that does not route `warm-resident`.
+    const callerEntry = join(dist, "dev.bundle.min.mjs");
+    await writeFile(callerEntry, "// dev\n");
+
+    const entry = resolveRspEntry({}, {
+      rootDir: root,
+      callerEntry,
+      env: bareEnv(join(root, "cache")),
+    });
+
+    expect(entry).toMatchObject({ command: process.execPath, source: "caller-sibling-bundle" });
+    expect("args" in entry && entry.args.at(-1)).toBe(join(dist, "rsp.bundle.min.mjs"));
+  });
+
+  it("targets the cache-keyed rsp bundle beside a cache-keyed host bundle", async () => {
+    const root = await tempRoot();
+    const cache = join(root, "cache");
+    await mkdir(cache, { recursive: true });
+    await writeFile(join(cache, "rsp-2.87.5.bundle.min.mjs"), "// rsp\n");
+    const callerEntry = join(cache, "dev-2.87.5.bundle.min.mjs");
+    await writeFile(callerEntry, "// dev\n");
+
+    const entry = resolveRspEntry({}, { callerEntry, env: bareEnv(join(root, "empty")) });
+
+    expect("args" in entry && entry.args.at(-1)).toBe(join(cache, "rsp-2.87.5.bundle.min.mjs"));
+  });
+
+  it("targets the plugin-root rsp bundle when a castle-mcp-shaped host asks", async () => {
+    const root = await tempRoot();
+    const pluginRoot = join(root, "plugins", "dev");
+    await mkdir(join(pluginRoot, "dist"), { recursive: true });
+    await writeFile(join(pluginRoot, "dist", "rsp.bundle.min.mjs"), "// rsp\n");
+
+    const entry = resolveRspEntry({}, {
+      callerEntry: join(root, "somewhere", "castle-mcp.bundle.min.mjs"),
+      env: { ...bareEnv(join(root, "empty")), CLAUDE_PLUGIN_ROOT: pluginRoot },
+    });
+
+    expect(entry).toMatchObject({ source: "plugin-root-bundle" });
+    expect("args" in entry && entry.args.at(-1)).toBe(join(pluginRoot, "dist", "rsp.bundle.min.mjs"));
+  });
+
+  it("re-execs the caller when the caller IS the rsp entry", async () => {
+    const root = await tempRoot();
+    const callerEntry = join(root, "apps", "rsp", "src", "cli.ts");
+
+    const entry = resolveRspEntry({}, { callerEntry, env: bareEnv(join(root, "empty")) });
+
+    expect(entry).toMatchObject({ source: "caller-entry" });
+    expect("args" in entry && entry.args.at(-1)).toBe(callerEntry);
+  });
+
+  it("lets an explicit serverCommand win over the resolver", async () => {
+    const root = await tempRoot();
+    const dist = join(root, "dist");
+    await mkdir(dist, { recursive: true });
+    await writeFile(join(dist, "rsp.bundle.min.mjs"), "// rsp\n");
+
+    const entry = resolveRspEntry(
+      { serverCommand: "/opt/custom/rsp", serverArgs: ["--flag"] },
+      { rootDir: root, callerEntry: join(dist, "dev.bundle.min.mjs"), env: bareEnv(join(root, "cache")) },
+    );
+
+    expect(entry).toEqual({ command: "/opt/custom/rsp", args: ["--flag"], source: "server-command" });
+  });
+
+  it("names the diagnostic when no rsp entry exists instead of spawning a host that ignores warm-resident", async () => {
+    const root = await tempRoot();
+    const callerEntry = join(root, "dist", "dev.bundle.min.mjs");
+
+    const entry = resolveRspEntry({}, { rootDir: root, callerEntry, env: bareEnv(join(root, "empty")) });
+
+    expect(entry).toMatchObject({ diagnostic: RSP_ENTRY_UNRESOLVED, callerEntry });
+    expect("searched" in entry && entry.searched.length).toBeGreaterThan(0);
+    // The foreign host is never proposed as the spawn target.
+    expect("searched" in entry && entry.searched).not.toContain(callerEntry);
+  });
+
+  it("rejects an auto-spawn with the named diagnostic rather than starting the wrong process", async () => {
+    const root = await tempRoot();
+    const paths = resolveResidentPaths(root);
+
+    await withoutAmbientEntry(join(root, "empty-cache"), async () => {
+      await expect(ensureResidentServer(paths, {
+        storeUri: `file://${join(root, ".red", "tmp", "red-skills.rdb")}`,
+        ttlDays: 7,
+        byteBudget: 1024,
+      })).rejects.toThrow(new RegExp(RSP_ENTRY_UNRESOLVED));
+    });
+  });
+
+  it("says the diagnostic out loud on the hook path and still rewrites the command", async () => {
+    const root = await tempRoot();
+    await enableRsp(root);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const decision = await hookDecisionFromClaudePreExecJson(
+        JSON.stringify({ cwd: root, tool_input: { command: "git status" } }),
+        {
+          cwd: root,
+          isEnabled: () => true,
+          wakeResident: () => {
+            throw Object.assign(new Error("no rsp entry"), { code: RSP_ENTRY_UNRESOLVED });
+          },
+          rspInvocationPrefix: ["rsp"],
+        },
+      );
+
+      expect(decision.kind).toBe("rewrite");
+      expect(formatHookDecision(decision).status).toBe(0);
+      expect(stderr.mock.calls.map(([chunk]) => String(chunk)).join("")).toContain(RSP_ENTRY_UNRESOLVED);
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  it("names the diagnostic on a foreign host and keeps the wrapped command's stdout, stderr and status", async () => {
+    const root = await initGitRepo();
+    expect(spawnSync(process.execPath, ["--import", tsxLoader, cli, "setup"], {
+      cwd: root,
+      encoding: "utf8",
+    }).status).toBe(0);
+    await commitMany(root, 1);
+
+    // A host that is not the rsp CLI: its own argv[1] never routes `warm-resident`.
+    const host = join(root, "foreign-host.mjs");
+    await writeFile(
+      host,
+      `import { main } from ${JSON.stringify(pathToFileURL(join(import.meta.dirname, "..", "src", "cli", "main.ts")).href)};\n` +
+        "process.exit(await main(process.argv.slice(2)));\n",
+    );
+    const emptyCache = join(root, "empty-cache");
+    await mkdir(emptyCache, { recursive: true });
+
+    const env: NodeJS.ProcessEnv = { ...process.env, RED_SKILLS_CACHE_DIR: emptyCache };
+    for (const name of [
+      "RSP_BIN",
+      "RSP_DEBUG",
+      "RED_SKILLS_DEV_PLUGIN_ROOT",
+      "CLAUDE_PLUGIN_ROOT",
+      "CODEX_PLUGIN_ROOT",
+      "OPENCODE_PLUGIN_ROOT",
+    ]) delete env[name];
+    const onHost = (args: string[], input?: string) =>
+      spawnSync(process.execPath, ["--import", tsxLoader, host, ...args], {
+        cwd: root,
+        env,
+        encoding: "utf8",
+        ...(input ? { input } : {}),
+      });
+
+    // The hook awaits its wake, so the failure says its name instead of losing
+    // elision in silence — and it still allows the command through.
+    const hook = onHost(
+      ["hook", "claude-pre-exec"],
+      JSON.stringify({ cwd: root, tool_input: { command: "git status" } }),
+    );
+    expect(hook.stderr).toContain(RSP_ENTRY_UNRESOLVED);
+    expect(hook.status).toBe(0);
+    expect(hook.stdout).toContain("updatedInput");
+
+    // Fail-open holds after the diagnostic: the wrapped command still ran …
+    const log = onHost(["git", "log"]);
+    expect(log.status).toBe(0);
+    expect(log.stdout).toContain("commit 1");
+
+    // … and a failing command keeps its own raw stderr and non-zero exit.
+    const failed = onHost(["git", "diff", "bogus-ref"]);
+    expect(failed.status).not.toBe(0);
+    expect(failed.stderr).toContain("fatal: ambiguous argument 'bogus-ref'");
+
+    await rm(host, { force: true });
+  }, 60_000);
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,7 +22,8 @@
     "./repo-root.js": "./repo-root.ts",
     "./outcome-event.js": "./outcome-event.ts",
     "./resident-client.js": "./resident-client.ts",
-    "./resident-protocol.js": "./resident-protocol.ts"
+    "./resident-protocol.js": "./resident-protocol.ts",
+    "./rsp-entry.js": "./rsp-entry.ts"
   },
   "dependencies": {
     "@reddb-io/toon": "catalog:",

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -10,6 +10,7 @@ import { decode, encode, type JsonObject } from "@reddb-io/toon";
 import { rspStateDir } from "./red-paths.js";
 import type { RspResidentConfig, RspResidentRequest } from "./resident-protocol.js";
 import { sendResidentRequest } from "./resident-protocol.js";
+import { requireRspEntry } from "./rsp-entry.js";
 
 export interface RspResidentPaths {
   rootDir: string;
@@ -65,10 +66,14 @@ export function resolveResidentPaths(cwd: string): RspResidentPaths {
   };
 }
 
+export { RspResidentEntryError, RSP_ENTRY_UNRESOLVED, resolveRspEntry } from "./rsp-entry.js";
+
 /**
  * Generic client for the resident rsp server. Consumers outside the rsp app
- * (memory today, brain next) set `config.serverCommand` so an auto-start
- * spawns the rsp binary rather than re-executing the caller's own entrypoint.
+ * (memory, brain, the dev bundle, castle-mcp) need no extra wiring: an
+ * auto-start resolves the rsp entry explicitly (`rsp-entry.ts`) rather than
+ * re-executing the caller's own entrypoint. `config.serverCommand` stays the
+ * override for a host that knows better.
  */
 export class ResidentRspClient {
   constructor(
@@ -139,7 +144,7 @@ export async function kickResidentServer(paths: RspResidentPaths, config: RspRes
   if (!lock) return false;
   await lock.close();
 
-  const [command, prefix] = spawnTarget(config);
+  const [command, prefix] = spawnTarget(paths, config);
   const child = spawn(command, [
     ...prefix,
     "warm-resident",
@@ -311,7 +316,7 @@ async function tryAcquireLock(lockPath: string) {
 }
 
 function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): ResidentSpawn {
-  const [command, prefix] = spawnTarget(config);
+  const [command, prefix] = spawnTarget(paths, config);
   const captureDiagnostics = process.env.RSP_DEBUG === "1";
   let spawnError: Error | undefined;
   let stderrTail = "";
@@ -462,10 +467,16 @@ async function isStorePathMissing(storeUri: string): Promise<boolean> {
   }
 }
 
-function spawnTarget(config: RspResidentConfig): [string, string[]] {
-  if (config.serverCommand) return [config.serverCommand, config.serverArgs ?? []];
-  const entry = process.argv[1] ? resolve(process.argv[1]) : fileURLToPath(import.meta.url);
-  return [process.execPath, [...process.execArgv, entry]];
+/**
+ * The rsp entry, resolved explicitly — never inferred from the caller's argv.
+ *
+ * Throws {@link RspResidentEntryError} when no rsp entry exists on this host, so
+ * a foreign bundle gets a named diagnostic instead of re-executing itself with
+ * an argument it does not route (#2736).
+ */
+function spawnTarget(paths: RspResidentPaths, config: RspResidentConfig): [string, string[]] {
+  const entry = requireRspEntry(config, { rootDir: paths.rootDir });
+  return [entry.command, entry.args];
 }
 
 function resolveRuntimeSocketDir(rootDir: string): string {

--- a/packages/shared/rsp-entry.ts
+++ b/packages/shared/rsp-entry.ts
@@ -1,0 +1,235 @@
+/**
+ * rsp-entry.ts — where the resident's own executable lives, resolved explicitly.
+ *
+ * The resident auto-spawn used to infer its target from `process.argv[1]`, so a
+ * host that is not the rsp CLI (the dev bundle, castle-mcp, memory, brain)
+ * re-executed *itself* with `warm-resident` — an argument only the rsp CLI
+ * routes. rsp fails open by contract, so that spawn died in silence and the
+ * surface quietly lost elision, handles and telemetry (#2736, same defect class
+ * as #2677: never infer the executable from the caller's argv).
+ *
+ * This module resolves the rsp entry from named candidates instead, and when no
+ * candidate exists it says so — {@link RspResidentEntryError}, a named
+ * diagnostic on the degradation path — rather than spawning something that
+ * ignores `warm-resident`.
+ */
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+
+/** The named diagnostic a host emits when no rsp entry can be resolved. */
+export const RSP_ENTRY_UNRESOLVED = "rsp-resident-entry-unresolved";
+
+/** Which candidate produced the entry — carried for diagnosis, never for logic. */
+export type RspEntrySource =
+  | "server-command"
+  | "env-rsp-bin"
+  | "caller-entry"
+  | "caller-sibling-bundle"
+  | "plugin-root-bundle"
+  | "repo-bundle"
+  | "workspace-entry"
+  | "node-modules-entry"
+  | "bundle-cache";
+
+export interface ResolvedRspEntry {
+  command: string;
+  args: string[];
+  source: RspEntrySource;
+}
+
+export interface UnresolvedRspEntry {
+  diagnostic: typeof RSP_ENTRY_UNRESOLVED;
+  /** Every path that was probed, in order — the message a human needs. */
+  searched: string[];
+  /** The caller's own entrypoint, named so the log shows the foreign host. */
+  callerEntry?: string;
+}
+
+export type RspEntryResolution = ResolvedRspEntry | UnresolvedRspEntry;
+
+export function isResolvedRspEntry(resolution: RspEntryResolution): resolution is ResolvedRspEntry {
+  return "command" in resolution;
+}
+
+/** Injected environment. Every field defaults to this process, so tests can pose as a foreign host. */
+export interface RspEntryLookup {
+  /** Repo root of the resident being started — the workspace/bundle candidates hang off it. */
+  rootDir?: string;
+  /** The caller's own entrypoint (`process.argv[1]` by default). */
+  callerEntry?: string;
+  execPath?: string;
+  execArgv?: readonly string[];
+  env?: NodeJS.ProcessEnv;
+  exists?: (path: string) => boolean;
+  listDir?: (path: string) => string[];
+}
+
+/** An explicit `serverCommand` always wins; the resolver is the fallback, not the override. */
+export interface RspEntryOverride {
+  serverCommand?: string;
+  serverArgs?: string[];
+}
+
+/** Thrown by the spawn path so an unresolvable entry is loud in logs and still fails open. */
+export class RspResidentEntryError extends Error {
+  readonly code = RSP_ENTRY_UNRESOLVED;
+  readonly searched: string[];
+  readonly callerEntry?: string;
+
+  constructor(unresolved: UnresolvedRspEntry) {
+    super(
+      `${RSP_ENTRY_UNRESOLVED}: no rsp entrypoint found for the resident auto-spawn` +
+        `${unresolved.callerEntry ? ` (caller entry: ${unresolved.callerEntry})` : ""}` +
+        `\nsearched:\n${unresolved.searched.map((path) => `  ${path}`).join("\n")}`,
+    );
+    this.name = "RspResidentEntryError";
+    this.searched = unresolved.searched;
+    this.callerEntry = unresolved.callerEntry;
+  }
+}
+
+const RSP_BUNDLE = "rsp.bundle.min.mjs";
+const VERSIONED_BUNDLE = /^([a-z0-9-]+)-(.+)\.bundle\.min\.mjs$/;
+const RSP_VERSIONED_BUNDLE = /^rsp-(.+)\.bundle\.min\.mjs$/;
+const PLUGIN_ROOT_VARS = [
+  "RED_SKILLS_DEV_PLUGIN_ROOT",
+  "CLAUDE_PLUGIN_ROOT",
+  "CODEX_PLUGIN_ROOT",
+  "OPENCODE_PLUGIN_ROOT",
+] as const;
+
+/**
+ * Resolve the command that understands `warm-resident` / `server`.
+ *
+ * Order is explicit-before-inferred: the caller's override, then `RSP_BIN`, then
+ * the caller's entry *only when it is itself an rsp entry*, then the bundles
+ * that ship beside a host (plugin root, repo `dist/`, workspace, bundle cache).
+ */
+export function resolveRspEntry(
+  override: RspEntryOverride = {},
+  lookup: RspEntryLookup = {},
+): RspEntryResolution {
+  if (override.serverCommand) {
+    return { command: override.serverCommand, args: override.serverArgs ?? [], source: "server-command" };
+  }
+  const env = lookup.env ?? process.env;
+  const exists = lookup.exists ?? existsSync;
+  const execPath = lookup.execPath ?? process.execPath;
+  const execArgv = lookup.execArgv ?? process.execArgv;
+  const callerEntry = lookup.callerEntry === undefined ? process.argv[1] : lookup.callerEntry;
+  const node = (entry: string, source: RspEntrySource): ResolvedRspEntry =>
+    ({ command: execPath, args: [...execArgv, entry], source });
+
+  if (env.RSP_BIN) return { command: env.RSP_BIN, args: [], source: "env-rsp-bin" };
+
+  if (callerEntry && isRspEntryPath(callerEntry)) return node(resolve(callerEntry), "caller-entry");
+
+  const searched: string[] = [];
+  for (const [path, source] of entryCandidates(callerEntry, lookup.rootDir, env, lookup.listDir ?? listDirSafe)) {
+    searched.push(path);
+    if (exists(path)) return node(path, source);
+  }
+  return { diagnostic: RSP_ENTRY_UNRESOLVED, searched, ...(callerEntry ? { callerEntry: resolve(callerEntry) } : {}) };
+}
+
+/** Resolve or throw — the shape the spawn path wants. */
+export function requireRspEntry(override: RspEntryOverride = {}, lookup: RspEntryLookup = {}): ResolvedRspEntry {
+  const resolution = resolveRspEntry(override, lookup);
+  if (isResolvedRspEntry(resolution)) return resolution;
+  throw new RspResidentEntryError(resolution);
+}
+
+/**
+ * Does this path route `warm-resident` itself?
+ *
+ * True for the rsp bundle in any of its names, and for `cli.js` / `cli.ts`
+ * inside an `rsp` package (`apps/rsp/src/cli.ts`, `@reddb-io/rsp/dist/cli.js`),
+ * and for the packaged `bin/rsp*` shim that execs the bundle.
+ */
+export function isRspEntryPath(path: string): boolean {
+  const name = basename(path);
+  if (name === RSP_BUNDLE || RSP_VERSIONED_BUNDLE.test(name)) return true;
+  if (name === "rsp" || name === "rsp.mjs" || name === "rsp.js") return true;
+  if (name !== "cli.js" && name !== "cli.mjs" && name !== "cli.ts") return false;
+  return hasRspPackageAncestor(resolve(path));
+}
+
+function hasRspPackageAncestor(entry: string): boolean {
+  let dir = dirname(entry);
+  for (let i = 0; i < 4; i++) {
+    if (basename(dir) === "rsp") return true;
+    const parent = dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
+  }
+  return false;
+}
+
+function* entryCandidates(
+  callerEntry: string | undefined,
+  rootDir: string | undefined,
+  env: NodeJS.ProcessEnv,
+  listDir: (path: string) => string[],
+): Generator<[string, RspEntrySource]> {
+  if (callerEntry) {
+    // A host bundle and the rsp bundle are published side by side, both as
+    // `dist/<plugin>.bundle.min.mjs` and as cache-keyed `<plugin>-<key>...`.
+    const dir = dirname(resolve(callerEntry));
+    yield [join(dir, RSP_BUNDLE), "caller-sibling-bundle"];
+    const versioned = VERSIONED_BUNDLE.exec(basename(callerEntry));
+    if (versioned) yield [join(dir, `rsp-${versioned[2]}.bundle.min.mjs`), "caller-sibling-bundle"];
+    yield [join(dir, "..", "dist", RSP_BUNDLE), "caller-sibling-bundle"];
+  }
+  for (const variable of PLUGIN_ROOT_VARS) {
+    const root = env[variable];
+    if (!root) continue;
+    yield [join(root, "dist", RSP_BUNDLE), "plugin-root-bundle"];
+    yield [join(root, "..", "..", "dist", RSP_BUNDLE), "plugin-root-bundle"];
+  }
+  if (rootDir) {
+    yield [join(rootDir, "dist", RSP_BUNDLE), "repo-bundle"];
+    yield [join(rootDir, "apps", "rsp", "dist", "cli.js"), "workspace-entry"];
+    yield [join(rootDir, "node_modules", "@reddb-io", "rsp", "dist", "cli.js"), "node-modules-entry"];
+  }
+  const cacheRoot = bundleCacheRoot(env);
+  yield [join(cacheRoot, RSP_BUNDLE), "bundle-cache"];
+  for (const name of cachedRspBundles(cacheRoot, listDir)) yield [join(cacheRoot, name), "bundle-cache"];
+}
+
+function bundleCacheRoot(env: NodeJS.ProcessEnv): string {
+  if (env.RED_SKILLS_CACHE_DIR) return env.RED_SKILLS_CACHE_DIR;
+  const xdg = env.XDG_CACHE_HOME || join(env.HOME || homedir(), ".cache");
+  return join(xdg, "red-skills", "bundles");
+}
+
+/** Cache-keyed bundles, newest key first — `canary` sorts last, it is not a version. */
+function cachedRspBundles(cacheRoot: string, listDir: (path: string) => string[]): string[] {
+  return listDir(cacheRoot)
+    .filter((name) => RSP_VERSIONED_BUNDLE.test(name))
+    .sort((a, b) => compareBundleKeys(bundleKey(b), bundleKey(a)));
+}
+
+function bundleKey(name: string): string {
+  return RSP_VERSIONED_BUNDLE.exec(name)?.[1] ?? "";
+}
+
+function compareBundleKeys(a: string, b: string): number {
+  const parse = (key: string) => key.split(".").map((part) => Number.parseInt(part, 10));
+  const [pa, pb] = [parse(a), parse(b)];
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const [x, y] = [pa[i], pb[i]];
+    if (Number.isNaN(x) || x === undefined) return Number.isNaN(y) || y === undefined ? a.localeCompare(b) : -1;
+    if (Number.isNaN(y) || y === undefined) return 1;
+    if (x !== y) return x - y;
+  }
+  return 0;
+}
+
+function listDirSafe(path: string): string[] {
+  try {
+    return readdirSync(path);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
Automated AFK landing for #2736. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2736

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787862954&installation_model_id=20659&pr_number=2741&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2741&signature=13c5168eabb9f08ee4d3516dfc6751a9ee37060eb8982324bc15717a8f169763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->