### PR TITLE
chore: #2725 Re-seed budget: lane-scoped ceiling with a reserved review round (expand)

### DIFF
--- a/apps/dev/src/core/process-issue/reseed-budget.ts
+++ b/apps/dev/src/core/process-issue/reseed-budget.ts
@@ -1,0 +1,162 @@
+// reseed-budget — the lane-scoped Re-seed budget (ADR 0129, Spec #2723).
+//
+// A **Re-seed** re-instructs the implementer in place — same Worker, same
+// Worktree, same branch — after a gate stage blocked the work. The **Re-seed
+// budget** bounds how many such rounds one Attempt may spend: ONE ceiling per
+// lane holding per-cause sub-caps, with the review's round modelled as a
+// RESERVATION the other causes cannot draw from.
+//
+// The reservation is the whole point. Under independent counters, gate churn
+// burns every available round first and a Ticket parks on precisely the round a
+// blocking review finding just asked for — the starvation defect ADR 0129 names.
+// Reserving the review's round makes it unreachable to gate and tier draws even
+// while the ceiling still has room.
+//
+// EXPAND STEP: this module is introduced alongside the existing counters
+// (`resolveStallConvergenceBudget`, `resolveGoVerifyRetries`) and is consumed by
+// nothing yet. The retired stall-convergence key therefore stays live and
+// authoritative here; tombstoning it while the lifecycle still reads it would
+// break config loading, so that lands with the contract slice.
+
+import { LABEL_GO_LANE } from "../go.js";
+
+/** The closed vocabulary of causes that may spend a Re-seed round. The `/go`
+ * lane is NOT a cause — it is a budget profile. */
+export type ReseedCause = "gate" | "tier" | "review";
+
+export const RESEED_CAUSES: readonly ReseedCause[] = ["gate", "tier", "review"];
+
+/** The two rulers. The mechanism is identical across lanes; only the numbers
+ * differ, because the difference between them is economic (a human waits on
+ * `/go`) and not structural. */
+export type ReseedLane = "/afk" | "/go";
+
+export interface ReseedBudget {
+  readonly lane: ReseedLane;
+  /** Total Re-seed rounds this Attempt may spend across ALL causes. */
+  readonly ceiling: number;
+  /** Per-cause ceilings. These may sum ABOVE {@link ceiling} on purpose: they
+   * bound each cause's share, while the ceiling bounds the whole. */
+  readonly subCaps: Readonly<Record<ReseedCause, number>>;
+  /** Rounds held for a cause and unreachable to every other cause. */
+  readonly reserved: Readonly<Record<ReseedCause, number>>;
+}
+
+/** Rounds already spent, per cause. An absent cause has spent none. */
+export type ReseedSpend = Partial<Record<ReseedCause, number>>;
+
+/** Why a draw was refused. `sub-cap` — the cause exhausted its own share;
+ * `reservation` — the ceiling still has room, but every remaining round is held
+ * for another cause; `ceiling` — nothing is left at all. */
+export type ReseedRefusal = "sub-cap" | "reservation" | "ceiling";
+
+export interface ReseedDraw {
+  readonly allowed: boolean;
+  readonly refusal?: ReseedRefusal;
+  /** Rounds this cause could still draw, reservations of others removed. */
+  readonly remaining: number;
+}
+
+/** `/afk` totals 4 — gate ≤ 3, tier ≤ 1, review 1 reserved. */
+export const AFK_RESEED_BUDGET: ReseedBudget = {
+  lane: "/afk",
+  ceiling: 4,
+  subCaps: { gate: 3, tier: 1, review: 1 },
+  reserved: { gate: 0, tier: 0, review: 1 },
+};
+
+/** `/go` totals 2 with no review round: review is not activated on the lane
+ * outside `--mode no-mistakes` (ADR 0110), so reserving one would idle a round a
+ * waiting human is paying for. */
+export const GO_RESEED_BUDGET: ReseedBudget = {
+  lane: "/go",
+  ceiling: 2,
+  subCaps: { gate: 2, tier: 1, review: 0 },
+  reserved: { gate: 0, tier: 0, review: 0 },
+};
+
+/** `/go --mode no-mistakes` widens to 3 SO THE RESERVATION FITS — the lane keeps
+ * its two working rounds and the review's reserved round is added on top rather
+ * than carved out of them. */
+export const GO_NO_MISTAKES_RESEED_BUDGET: ReseedBudget = {
+  lane: "/go",
+  ceiling: 3,
+  subCaps: { gate: 2, tier: 1, review: 1 },
+  reserved: { gate: 0, tier: 0, review: 1 },
+};
+
+export interface ResolveReseedBudgetInput {
+  /** The lane label carried by the Ticket (`lane:go` selects the `/go` ruler). */
+  readonly laneLabel?: string;
+  /** The `/go` dispatch mode; `no-mistakes` widens the ceiling. */
+  readonly runMode?: string;
+}
+
+/** Resolve the lane's Re-seed budget. Anything that is not the `/go` lane is
+ * `/afk`'s ruler, including the scout and manual dispatches, because they run
+ * the same unattended pipeline. */
+export function resolveReseedBudget(input: ResolveReseedBudgetInput): ReseedBudget {
+  if (input.laneLabel !== LABEL_GO_LANE) return AFK_RESEED_BUDGET;
+  return input.runMode === "no-mistakes" ? GO_NO_MISTAKES_RESEED_BUDGET : GO_RESEED_BUDGET;
+}
+
+function spentFor(spend: ReseedSpend, cause: ReseedCause): number {
+  const raw = spend[cause];
+  return typeof raw === "number" && Number.isInteger(raw) && raw > 0 ? raw : 0;
+}
+
+/** Rounds spent across every cause. */
+export function totalReseedSpend(spend: ReseedSpend): number {
+  return RESEED_CAUSES.reduce((sum, cause) => sum + spentFor(spend, cause), 0);
+}
+
+/** Reserved rounds still unclaimed by causes OTHER than `cause`. These sit
+ * inside the ceiling but are invisible to this cause. */
+function reservedElsewhere(budget: ReseedBudget, spend: ReseedSpend, cause: ReseedCause): number {
+  return RESEED_CAUSES.filter((other) => other !== cause).reduce((held, other) => {
+    const unclaimed = (budget.reserved[other] ?? 0) - spentFor(spend, other);
+    return held + Math.max(0, unclaimed);
+  }, 0);
+}
+
+/** Decide whether `cause` may spend one more Re-seed round given what has been
+ * spent already. Three refusals, checked in the order a reader would ask them:
+ * did this cause use up its own share, is anything left at all, and is what is
+ * left held for someone else. */
+export function reseedDraw(budget: ReseedBudget, cause: ReseedCause, spend: ReseedSpend = {}): ReseedDraw {
+  const capLeft = (budget.subCaps[cause] ?? 0) - spentFor(spend, cause);
+  const ceilingLeft = budget.ceiling - totalReseedSpend(spend);
+  const drawable = Math.max(0, Math.min(capLeft, ceilingLeft - reservedElsewhere(budget, spend, cause)));
+  if (capLeft <= 0) return { allowed: false, refusal: "sub-cap", remaining: 0 };
+  if (ceilingLeft <= 0) return { allowed: false, refusal: "ceiling", remaining: 0 };
+  if (drawable <= 0) return { allowed: false, refusal: "reservation", remaining: 0 };
+  return { allowed: true, remaining: drawable };
+}
+
+/** Convenience predicate over {@link reseedDraw}. */
+export function canDrawReseed(budget: ReseedBudget, cause: ReseedCause, spend: ReseedSpend = {}): boolean {
+  return reseedDraw(budget, cause, spend).allowed;
+}
+
+/** Record one drawn round. Pure: the caller owns where the tally lives. */
+export function recordReseedDraw(spend: ReseedSpend, cause: ReseedCause): ReseedSpend {
+  return { ...spend, [cause]: spentFor(spend, cause) + 1 };
+}
+
+/** Static incoherences in a profile — a ceiling that cannot honour its own
+ * reservations, or a reservation larger than the cause's own share. A sub-cap
+ * ABOVE the ceiling is not a defect: the ceiling is what actually binds. */
+export function reseedBudgetDefects(budget: ReseedBudget): readonly string[] {
+  const defects: string[] = [];
+  const reservedTotal = RESEED_CAUSES.reduce((sum, cause) => sum + (budget.reserved[cause] ?? 0), 0);
+  if (reservedTotal > budget.ceiling) {
+    defects.push(`reservations (${reservedTotal}) exceed the ceiling (${budget.ceiling})`);
+  }
+  for (const cause of RESEED_CAUSES) {
+    const reserved = budget.reserved[cause] ?? 0;
+    if (reserved > (budget.subCaps[cause] ?? 0)) {
+      defects.push(`\`${cause}\` reserves ${reserved} beyond its sub-cap of ${budget.subCaps[cause] ?? 0}`);
+    }
+  }
+  return defects;
+}

--- a/apps/dev/tests/reseed-budget.test.ts
+++ b/apps/dev/tests/reseed-budget.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  AFK_RESEED_BUDGET,
+  GO_NO_MISTAKES_RESEED_BUDGET,
+  GO_RESEED_BUDGET,
+  RESEED_CAUSES,
+  canDrawReseed,
+  recordReseedDraw,
+  reseedBudgetDefects,
+  reseedDraw,
+  resolveReseedBudget,
+  totalReseedSpend,
+  type ReseedBudget,
+  type ReseedCause,
+  type ReseedSpend,
+} from "../src/core/process-issue/reseed-budget.js";
+import { auditConfigLoad, CONFIG_DEFAULTS, DELETED_CONFIG_KEYS, getConfig } from "../src/core/config.js";
+import { LABEL_GO_LANE } from "../src/core/triage-labels.js";
+
+/** Spend `n` rounds on one cause, so the tests read as a sequence of draws
+ * rather than as a hand-written tally. */
+function spend(...draws: readonly ReseedCause[]): ReseedSpend {
+  return draws.reduce<ReseedSpend>((acc, cause) => recordReseedDraw(acc, cause), {});
+}
+
+describe("Re-seed budget — lane resolution (ADR 0129)", () => {
+  it("resolves the `/afk` ceiling of 4 with the review round reserved", () => {
+    const budget = resolveReseedBudget({});
+
+    expect(budget).toBe(AFK_RESEED_BUDGET);
+    expect(budget.lane).toBe("/afk");
+    expect(budget.ceiling).toBe(4);
+    expect(budget.subCaps).toEqual({ gate: 3, tier: 1, review: 1 });
+    expect(budget.reserved.review).toBe(1);
+    expect(budget.reserved.gate).toBe(0);
+    expect(budget.reserved.tier).toBe(0);
+  });
+
+  it("keeps every non-`/go` lane on the `/afk` ruler", () => {
+    expect(resolveReseedBudget({ laneLabel: "lane:scout" })).toBe(AFK_RESEED_BUDGET);
+    expect(resolveReseedBudget({ laneLabel: undefined, runMode: "no-mistakes" })).toBe(AFK_RESEED_BUDGET);
+  });
+
+  it("resolves `/go` to 2, widening to 3 under `--mode no-mistakes` so the reservation fits", () => {
+    const plain = resolveReseedBudget({ laneLabel: LABEL_GO_LANE });
+    expect(plain).toBe(GO_RESEED_BUDGET);
+    expect(plain.ceiling).toBe(2);
+    expect(plain.reserved.review).toBe(0);
+
+    const hardened = resolveReseedBudget({ laneLabel: LABEL_GO_LANE, runMode: "no-mistakes" });
+    expect(hardened).toBe(GO_NO_MISTAKES_RESEED_BUDGET);
+    expect(hardened.ceiling).toBe(3);
+    expect(hardened.reserved.review).toBe(1);
+    // The widening ADDS the reserved round rather than carving it out of the
+    // lane's two working rounds.
+    expect(hardened.ceiling - hardened.reserved.review).toBe(plain.ceiling);
+  });
+
+  it("leaves `/go`'s other dispatch modes on the narrow ruler", () => {
+    expect(resolveReseedBudget({ laneLabel: LABEL_GO_LANE, runMode: "direct-PR" })).toBe(GO_RESEED_BUDGET);
+    expect(resolveReseedBudget({ laneLabel: LABEL_GO_LANE, runMode: "local-only" })).toBe(GO_RESEED_BUDGET);
+  });
+});
+
+describe("Re-seed budget — the review reservation", () => {
+  it("refuses a non-review cause the reserved round even when the ceiling has room", () => {
+    const gateChurn = spend("gate", "gate", "gate");
+    expect(totalReseedSpend(gateChurn)).toBe(3);
+    // The ceiling is 4: a round is genuinely left, and it is NOT drawable.
+    expect(AFK_RESEED_BUDGET.ceiling - totalReseedSpend(gateChurn)).toBe(1);
+
+    const tier = reseedDraw(AFK_RESEED_BUDGET, "tier", gateChurn);
+    expect(tier.allowed).toBe(false);
+    expect(tier.refusal).toBe("reservation");
+  });
+
+  it("still fires the review round after gate churn exhausted its sub-cap", () => {
+    const gateChurn = spend("gate", "gate", "gate");
+    expect(canDrawReseed(AFK_RESEED_BUDGET, "gate", gateChurn)).toBe(false);
+    expect(reseedDraw(AFK_RESEED_BUDGET, "gate", gateChurn).refusal).toBe("sub-cap");
+    expect(canDrawReseed(AFK_RESEED_BUDGET, "review", gateChurn)).toBe(true);
+  });
+
+  it("frees the reserved round to nobody once review has spent it", () => {
+    const drained = spend("gate", "gate", "gate", "review");
+    expect(totalReseedSpend(drained)).toBe(AFK_RESEED_BUDGET.ceiling);
+    expect(reseedDraw(AFK_RESEED_BUDGET, "tier", drained).refusal).toBe("ceiling");
+    expect(reseedDraw(AFK_RESEED_BUDGET, "review", drained).refusal).toBe("sub-cap");
+  });
+
+  it("does not reserve anything on the plain `/go` lane, which runs no review", () => {
+    const oneGate = spend("gate");
+    expect(canDrawReseed(GO_RESEED_BUDGET, "tier", oneGate)).toBe(true);
+    expect(canDrawReseed(GO_RESEED_BUDGET, "review", oneGate)).toBe(false);
+  });
+
+  it("reserves the review round on `/go --mode no-mistakes` too", () => {
+    const goChurn = spend("gate", "gate");
+    expect(reseedDraw(GO_NO_MISTAKES_RESEED_BUDGET, "tier", goChurn).refusal).toBe("reservation");
+    expect(canDrawReseed(GO_NO_MISTAKES_RESEED_BUDGET, "review", goChurn)).toBe(true);
+  });
+});
+
+describe("Re-seed budget — the ceiling binds the sub-caps", () => {
+  it("stops the sub-caps drawing more rounds than the ceiling, whatever the mix", () => {
+    for (const budget of [AFK_RESEED_BUDGET, GO_RESEED_BUDGET, GO_NO_MISTAKES_RESEED_BUDGET]) {
+      const declared = RESEED_CAUSES.reduce((sum, cause) => sum + budget.subCaps[cause], 0);
+      let tally: ReseedSpend = {};
+      let drawn = 0;
+      // Draw greedily, forever, in every cause order — the ceiling is the only
+      // thing that can end the loop.
+      while (RESEED_CAUSES.some((cause) => canDrawReseed(budget, cause, tally))) {
+        const cause = RESEED_CAUSES.find((c) => canDrawReseed(budget, c, tally))!;
+        tally = recordReseedDraw(tally, cause);
+        drawn += 1;
+        expect(drawn).toBeLessThanOrEqual(budget.ceiling);
+      }
+      expect(drawn).toBe(budget.ceiling);
+      expect(totalReseedSpend(tally)).toBeLessThanOrEqual(budget.ceiling);
+      // The declared shares deliberately sum ABOVE the ceiling on the lanes that
+      // reserve a review round; the ceiling is what actually binds.
+      expect(declared).toBeGreaterThanOrEqual(budget.ceiling);
+    }
+  });
+
+  it("names `ceiling` — not `sub-cap` — when the whole budget is gone", () => {
+    const drained = spend("gate", "gate", "review");
+    expect(totalReseedSpend(drained)).toBe(GO_NO_MISTAKES_RESEED_BUDGET.ceiling);
+    expect(reseedDraw(GO_NO_MISTAKES_RESEED_BUDGET, "tier", drained).refusal).toBe("ceiling");
+  });
+
+  it("reports every shipped profile as coherent", () => {
+    for (const budget of [AFK_RESEED_BUDGET, GO_RESEED_BUDGET, GO_NO_MISTAKES_RESEED_BUDGET]) {
+      expect(reseedBudgetDefects(budget)).toEqual([]);
+    }
+  });
+
+  it("names a profile whose reservations cannot fit under its ceiling", () => {
+    const incoherent: ReseedBudget = {
+      lane: "/go",
+      ceiling: 1,
+      subCaps: { gate: 1, tier: 1, review: 1 },
+      reserved: { gate: 1, tier: 0, review: 1 },
+    };
+    expect(reseedBudgetDefects(incoherent)).toEqual(["reservations (2) exceed the ceiling (1)"]);
+  });
+
+  it("names a reservation larger than the cause's own share", () => {
+    const incoherent: ReseedBudget = {
+      lane: "/afk",
+      ceiling: 4,
+      subCaps: { gate: 3, tier: 1, review: 0 },
+      reserved: { gate: 0, tier: 0, review: 1 },
+    };
+    expect(reseedBudgetDefects(incoherent)).toEqual(["`review` reserves 1 beyond its sub-cap of 0"]);
+  });
+});
+
+describe("Re-seed budget — the retired key is still live in this slice", () => {
+  const OPTED_IN_WITH_STALL =
+    "plugins:\n  dev:\n    enabled: true\n    afk:\n      stallConvergenceBudget: 5\n";
+
+  it("still resolves the stall-convergence key and does not report it as retired", () => {
+    const warnings: string[] = [];
+    const audit = auditConfigLoad("/x/.red/config.yaml", {
+      read: () => OPTED_IN_WITH_STALL,
+      warn: (m) => warnings.push(m),
+    });
+
+    expect(audit.retiredKeys).toEqual([]);
+    expect(warnings.join("\n")).not.toContain("RETIRED");
+    expect(getConfig(audit.values, "afk.stallConvergenceBudget")).toBe("5");
+    expect(DELETED_CONFIG_KEYS.has("afk.stallConvergenceBudget")).toBe(false);
+    expect(DELETED_CONFIG_KEYS.has("plugins.dev.afk.stallConvergenceBudget")).toBe(false);
+    expect(CONFIG_DEFAULTS["afk.stallConvergenceBudget"]).toBe("3");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2725. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2725

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787863889&installation_model_id=20659&pr_number=2742&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2742&signature=d3753b8d50118025de0960370bd96a93347815f6f917296c436b132f1764a393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->