### PR TITLE
chore: #2726 Gate fold gains its third stage: review joins the stage order (expand)

### DIFF
--- a/.changeset/gate-stage-order-review.md
+++ b/.changeset/gate-stage-order-review.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+`review` joins the gate's stage order as its third stage, after feedback and backpressure (#2726). This is vocabulary: a stage absent from the fold cannot block, so nothing changes behaviourally until a producer pushes a review outcome. What it buys is that the two properties a diff review needs — running only once the earlier, cheaper stages are green, and degrading instead of failing the attempt when it cannot run — are now native fold behaviour (the short-circuit on the earliest blocker, and the `skipped` outcome that never blocks) rather than machinery reimplemented beside the gate. The dev glossary's `Gate stage order` term is updated to the current order and drops the `trust` stage that went with the sensitive-path removal in #2417.

--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -203,7 +203,7 @@ An entry in `DELETED_CONFIG_KEYS` naming a config key that USED to mean somethin
 _Avoid_: deprecated key (a tombstoned key does not still work), unknown key
 
 **Gate stage order**:
-The gate's stages in cheap → expensive order — trust, feedback, backpressure (ADR 0119). `gateVerdict` folds stage outcomes into one `ok` naming the earliest blocker, so a diff that can never auto-land is refused before the package suite runs.
+The gate's stages in cheap → expensive order — feedback, backpressure, review (ADR 0119; the `trust` stage went with the sensitive-path removal in #2417). `gateVerdict` folds stage outcomes into one `ok` naming the earliest blocker, so a later stage never runs once an earlier one blocked, and a stage with nothing to run is skipped rather than failed.
 _Avoid_: validation order (the gate stages are not the suite's internal order), pipeline stage
 
 **State tier**:

--- a/apps/dev/src/core/shared-gate.ts
+++ b/apps/dev/src/core/shared-gate.ts
@@ -175,9 +175,12 @@ export function allowlistExternalWidened(oldContent: string, newContent: string)
  * The gate's stages, in CHEAP → EXPENSIVE order.
  *
  * `feedback` is the package test/typecheck/lint suite; `backpressure` is the
- * operator's extra commands. Later stages do not run once an earlier one blocks.
+ * operator's extra commands; `review` is the diff review, last because it is
+ * the most expensive. Later stages do not run once an earlier one blocks, and a
+ * stage with nothing to run is skipped rather than failed — so a review that
+ * cannot run degrades the gate instead of blocking the attempt.
  */
-export const GATE_STAGE_ORDER = ["feedback", "backpressure"] as const;
+export const GATE_STAGE_ORDER = ["feedback", "backpressure", "review"] as const;
 
 export type GateStage = (typeof GATE_STAGE_ORDER)[number];
 

--- a/apps/dev/tests/shared-gate.test.ts
+++ b/apps/dev/tests/shared-gate.test.ts
@@ -138,7 +138,7 @@ describe("default = intent boundary", () => {
 
 describe("gateVerdict — one verdict, cheap stage first", () => {
   it("orders the stages cheap → expensive", () => {
-    expect(GATE_STAGE_ORDER).toEqual(["feedback", "backpressure"]);
+    expect(GATE_STAGE_ORDER).toEqual(["feedback", "backpressure", "review"]);
   });
 
   it("is green when every stage passed", () => {
@@ -171,5 +171,34 @@ describe("gateVerdict — one verdict, cheap stage first", () => {
   it("folds the stages run so far — a partial gate is still one verdict", () => {
     expect(gateVerdict([{ stage: "feedback", ok: true }])).toEqual({ ok: true });
     expect(gateVerdict([]).ok).toBe(true);
+  });
+
+  it("names review as the failed stage when the review blocks", () => {
+    const verdict = gateVerdict([
+      { stage: "feedback", ok: true },
+      { stage: "backpressure", ok: true },
+      { stage: "review", ok: false },
+    ]);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failedStage).toBe("review");
+  });
+
+  it("a review marked skipped never blocks — it degrades, it does not fail", () => {
+    expect(
+      gateVerdict([
+        { stage: "feedback", ok: true },
+        { stage: "backpressure", ok: true },
+        { stage: "review", ok: false, skipped: true },
+      ]),
+    ).toEqual({ ok: true });
+  });
+
+  it("does not consult review once an earlier stage blocked", () => {
+    const verdict = gateVerdict([
+      { stage: "review", ok: false },
+      { stage: "backpressure", ok: false },
+      { stage: "feedback", ok: false },
+    ]);
+    expect(verdict.failedStage).toBe("feedback");
   });
 });


### PR DESCRIPTION
Automated AFK landing for #2726. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2726

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787864863&installation_model_id=20659&pr_number=2743&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2743&signature=959dc50d0c9ca6410b4531ebc8e7aebc153dc1f3c40cb83839ddf9bdcf09916c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->