### PR TITLE
chore: disable rsp in this repo until its overhead is bounded

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -65,7 +65,7 @@ plugins:
 
 # rsp token-efficiency surface (per-repo opt-in; hook stays inert without enabled: true)
 rsp:
-  enabled: true
+  enabled: false               # maintainer decision 2026-07-28: off in this repo
   ttlDays: 7
   byteBudget: 67108864
   heavyGitByteThreshold: 8192


### PR DESCRIPTION
Maintainer decision 2026-07-28: `rsp.enabled: false` in this repo.

rsp exists to make terminal work cheaper; measured today it was doing the opposite on every command, and none of it surfaced:

- **#2745** — the gh ETag cache reached **10.2 MB** and is read and decoded whole on every `gh` call, with no ceiling, eviction or partitioning (plus three zero-byte `.tmp` orphans since 2026-07-23).
- **#2744** — `rsp wait` returned **success** for a PR at `mergeable: BLOCKED` with zero reported checks, i.e. the one status that proves required checks exist was read as proof that none do.
- **#2736** — the resident auto-spawn re-execs the caller's `argv[1]`, so from a hook context it pays the spawn attempt and never gets a resident (fixed, in main).

Re-enable once **#2746** lands: rsp must measure the overhead it imposes, hold itself to a ceiling, and self-disable loudly when it breaches — today every one of its failure modes is silent by design, so the only way to notice was to suspect it and measure by hand.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787865480&installation_model_id=20659&pr_number=2748&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2748&signature=90dc0fac31d9dc28d4625097192e1a8956d94d18afa3f96ee9ecf7915bc4f37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->