### PR TITLE
fix: #2747 bug: AFK parks blocked:ci on a green PR while its checks are still pending

### DIFF
--- a/.changeset/ci-verdict-no-verdict-not-blocking.md
+++ b/.changeset/ci-verdict-no-verdict-not-blocking.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A pending CI rollup no longer parks a healthy attempt as `blocked:ci` (#2747). The landing tail classified a `BLOCKED` PR whose required checks had not reported yet as ready to merge — the state every PR passes through in the seconds after it opens — so branch protection rejected the merge and the landing path parked that rejection as `blocked:ci`, converting finished work into HITL backlog on a PR that never carried a failing check. `classifyMergeState` now takes the base branch's required contexts into account: a required check with no verdict in the rollup, an empty rollup, or an unreadable one keeps the attempt waiting inside the tail instead of merging into the hole. Only a check that actually concluded unsuccessfully still classifies as `ci-failed`, and a `BLOCKED` PR whose required checks all reported green still attempts the merge, so the required-review handoff is unchanged.

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -762,12 +762,17 @@ async function requiredCheckContexts(
  *      a benign race → `pending` (re-poll).
  *   6. CLEAN → `merge`.
  *   7. any check still running → `pending`.
- *   8. BLOCKED (no failures/pending) → likely a required REVIEW; attempts merge,
- *      surfacing as `merge-failed` if branch protection requires it → `merge`.
- *   9. UNSTABLE / HAS_HOOKS (mergeable; only non-required checks unsettled) → `merge`.
- *  10. UNKNOWN / DRAFT / empty mergeStateStatus → `pending`.
+ *   8. BLOCKED with a required check that has NOT reported a verdict yet (#2747)
+ *      → `pending`. *No verdict yet* is not *a blocking verdict*: right after a
+ *      PR opens the rollup is still empty, and merging into that hole gets the
+ *      merge REJECTED by branch protection, which the landing path parks as
+ *      `blocked:ci` on a PR that was never red. Re-poll until the checks report.
+ *   9. BLOCKED with every required check reported → likely a required REVIEW;
+ *      attempts merge, surfacing as `merge-failed` if protection requires it → `merge`.
+ *  10. UNSTABLE / HAS_HOOKS (mergeable; only non-required checks unsettled) → `merge`.
+ *  11. UNKNOWN / DRAFT / empty mergeStateStatus → `pending`.
  */
-export function classifyMergeState(view: MergeStateView): MergeReadiness {
+export function classifyMergeState(view: MergeStateView, context: MergeClassifyContext = {}): MergeReadiness {
   const s = up(view.mergeStateStatus);
   const m = up(view.mergeable);
   if (m === "CONFLICTING") return "conflict";
@@ -777,9 +782,40 @@ export function classifyMergeState(view: MergeStateView): MergeReadiness {
   if (s === "BEHIND") return "pending";
   if (s === "CLEAN") return "merge";
   if (view.anyPending) return "pending";
-  if (s === "BLOCKED") return "merge";
+  if (s === "BLOCKED") return blockedWithoutVerdict(view, context) ? "pending" : "merge";
   if (s === "UNSTABLE" || s === "HAS_HOOKS") return "merge";
   return "pending";
+}
+
+/** Extra evidence {@link classifyMergeState} uses to tell *no verdict yet* apart
+ * from *a blocking verdict* on a BLOCKED PR (#2747). */
+export interface MergeClassifyContext {
+  /** Required status-check contexts on the base branch, when they could be read
+   * (empty / absent = unknown, never "there are none"). */
+  requiredChecks?: readonly string[];
+}
+
+/**
+ * True when a BLOCKED rollup has not yet produced a verdict for the checks that
+ * gate the merge — the state that must keep waiting rather than merge-and-park.
+ *
+ * With the required contexts known, a required check missing from EVERY rollup
+ * bucket has simply not been created yet. With them unknown, an explicitly empty
+ * rollup (`checkCount === 0`) is the same "not reported yet" hole; a rollup we
+ * could not count at all (`checkCount` absent) keeps the historical behaviour.
+ */
+function blockedWithoutVerdict(view: MergeStateView, context: MergeClassifyContext): boolean {
+  const required = context.requiredChecks ?? [];
+  if (required.length > 0) {
+    const reported = new Set<string>([
+      ...(view.successfulCheckNames ?? []),
+      ...(view.skippedOrNeutralCheckNames ?? []),
+      ...(view.failedCheckNames ?? []),
+      ...(view.pendingCheckNames ?? []),
+    ]);
+    return required.some((name) => !reported.has(name));
+  }
+  return view.checkCount === 0;
 }
 
 function ciEvidenceFor(
@@ -849,7 +885,7 @@ export async function waitForMergeReadyWithEvidence(
       input.probeTimeoutMs,
     );
     const view = parseMergeStateView(res.stdout);
-    const verdict = classifyMergeState(view);
+    const verdict = classifyMergeState(view, { requiredChecks });
     if (verdict !== "pending") {
       const ciEvidence = ciEvidenceFor(view, verdict, requiredChecks, input.expectedBaseOid);
       return { readiness: verdict, ...(ciEvidence ? { ciEvidence } : {}) };

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -616,6 +616,61 @@ describe("CI-aware merge classification (#812)", () => {
     expect(classifyMergeState(v)).toBe("merge");
   });
 
+  // #2747: *no verdict yet* is not *a blocking verdict*. A BLOCKED PR whose
+  // required checks have not reported must keep waiting; classifying it `merge`
+  // gets the merge rejected by branch protection, and the landing path parks
+  // that rejection as `blocked:ci` on a PR that was never red.
+  describe("BLOCKED with an unreported rollup (#2747)", () => {
+    const required = ["test", "typecheck"];
+
+    it("empty rollup right after the PR opened → pending, NOT merge", () => {
+      expect(classifyMergeState(view("BLOCKED", [], "MERGEABLE"), { requiredChecks: required })).toBe("pending");
+    });
+
+    it("only SOME required checks reported → pending (the rest have no verdict yet)", () => {
+      const v = view("BLOCKED", [{ name: "test", status: "COMPLETED", conclusion: "SUCCESS" }], "MERGEABLE");
+      expect(classifyMergeState(v, { requiredChecks: required })).toBe("pending");
+    });
+
+    it("an unreadable / unavailable rollup → pending, never ci-failed", () => {
+      for (const stdout of ["", "not json", JSON.stringify({ mergeStateStatus: "BLOCKED", mergeable: "MERGEABLE" })]) {
+        expect(classifyMergeState(parseMergeStateView(stdout), { requiredChecks: required })).toBe("pending");
+      }
+    });
+
+    it("empty rollup with the required contexts unknown → still pending", () => {
+      // The protection probe can fail or read [] (ruleset-configured checks); an
+      // explicitly empty rollup is the same "not reported yet" hole either way.
+      expect(classifyMergeState(view("BLOCKED", [], "MERGEABLE"))).toBe("pending");
+    });
+
+    it("every required check reported green → merge (the required-REVIEW case is unchanged)", () => {
+      const v = view("BLOCKED", [
+        { name: "test", status: "COMPLETED", conclusion: "SUCCESS" },
+        { name: "typecheck", status: "COMPLETED", conclusion: "SUCCESS" },
+      ], "MERGEABLE");
+      expect(classifyMergeState(v, { requiredChecks: required })).toBe("merge");
+    });
+
+    it("only a CONCLUDED, unsuccessful required check → ci-failed", () => {
+      const failed = view("BLOCKED", [
+        { name: "test", status: "COMPLETED", conclusion: "SUCCESS" },
+        { name: "typecheck", status: "COMPLETED", conclusion: "FAILURE" },
+      ], "MERGEABLE");
+      expect(classifyMergeState(failed, { requiredChecks: required })).toBe("ci-failed");
+      const running = view("BLOCKED", [
+        { name: "test", status: "COMPLETED", conclusion: "SUCCESS" },
+        { name: "typecheck", status: "IN_PROGRESS" },
+      ], "MERGEABLE");
+      expect(classifyMergeState(running, { requiredChecks: required })).toBe("pending");
+      const queued = view("BLOCKED", [
+        { name: "test", status: "QUEUED" },
+        { name: "typecheck", status: "QUEUED" },
+      ], "MERGEABLE");
+      expect(classifyMergeState(queued, { requiredChecks: required })).toBe("pending");
+    });
+  });
+
   it("UNSTABLE (only non-required checks unsettled) → merge", () => {
     expect(classifyMergeState(view("UNSTABLE"))).toBe("merge");
   });
@@ -864,6 +919,75 @@ describe("landPr CI-aware wiring (#812)", () => {
       ciAwait: { sleep: async () => {}, maxPolls: 2 },
     });
     expect(r).toEqual({ ok: false, prNumber: 5, reason: "ci-pending" });
+  });
+
+  // #2747 reproduction — the observed trace of #2724/PR #2740 and #2725/PR #2742:
+  // the PR opens, the rollup has not reported yet, and the landing tail merges
+  // into that hole. GitHub rejects the merge (branch protection), which the
+  // landing path parks as `blocked:ci` on a PR that never carried a failing check.
+  describe("an unreported rollup right after PR-open (#2747)", () => {
+    const protectionContexts = JSON.stringify(["test", "typecheck"]);
+
+    it("does NOT attempt the merge while the required checks have not reported", async () => {
+      const calls: string[][] = [];
+      const exec: Exec = async (argv) => {
+        calls.push(argv);
+        const cmd = argv.join(" ");
+        if (cmd.includes("pr list")) return { code: 0, stdout: "5\n", stderr: "" };
+        if (cmd.includes("required_status_checks/contexts")) return { code: 0, stdout: protectionContexts, stderr: "" };
+        if (cmd.includes("pr view")) {
+          // checks not created yet: BLOCKED + MERGEABLE + an empty rollup
+          return {
+            code: 0,
+            stdout: JSON.stringify({ mergeStateStatus: "BLOCKED", mergeable: "MERGEABLE", statusCheckRollup: [] }),
+            stderr: "",
+          };
+        }
+        // branch protection rejects a merge attempted before the checks report
+        if (cmd.includes("pr merge")) return { code: 1, stdout: "", stderr: "Protected branch update failed" };
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const r = await landPr(exec, {
+        repo: "o/r", gitRepo: "/repo", remote: "origin", branch: "afk/wX/9-x", target: "main", n: 9, title: "t",
+        ciAwait: { sleep: async () => {}, maxPolls: 2 },
+      });
+      // never `merge-failed` — that is the reason the landing parks as blocked:ci
+      expect(r).toEqual({ ok: false, prNumber: 5, reason: "ci-pending" });
+      expect(calls.some((c) => c.join(" ").includes("pr merge"))).toBe(false);
+    });
+
+    it("keeps waiting inside the tail and lands once the checks report green", async () => {
+      const calls: string[][] = [];
+      let polls = 0;
+      const exec: Exec = async (argv) => {
+        calls.push(argv);
+        const cmd = argv.join(" ");
+        if (cmd.includes("pr list")) return { code: 0, stdout: "5\n", stderr: "" };
+        if (cmd.includes("required_status_checks/contexts")) return { code: 0, stdout: protectionContexts, stderr: "" };
+        if (cmd.includes("pr view") && cmd.includes("mergeStateStatus")) {
+          polls += 1;
+          const stdout = polls === 1
+            ? JSON.stringify({ mergeStateStatus: "BLOCKED", mergeable: "MERGEABLE", statusCheckRollup: [] })
+            : JSON.stringify({
+                mergeStateStatus: "CLEAN",
+                mergeable: "MERGEABLE",
+                statusCheckRollup: [
+                  { name: "test", status: "COMPLETED", conclusion: "SUCCESS" },
+                  { name: "typecheck", status: "COMPLETED", conclusion: "SUCCESS" },
+                ],
+              });
+          return { code: 0, stdout, stderr: "" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const r = await landPr(exec, {
+        repo: "o/r", gitRepo: "/repo", remote: "origin", branch: "afk/wX/9-x", target: "main", n: 9, title: "t",
+        ciAwait: { sleep: async () => {}, maxPolls: 4 },
+      });
+      expect(r.ok).toBe(true);
+      expect(polls).toBe(2);
+      expect(calls.some((c) => c.join(" ").includes("pr merge 5 --merge"))).toBe(true);
+    });
   });
 
   it("returns conflict on DIRTY (real merge conflict, distinct from ci)", async () => {


### PR DESCRIPTION
Automated AFK landing for #2747. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2747

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787869578&installation_model_id=20659&pr_number=2754&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2754&signature=d9db38cb3ac9cd803c5c9475a50de4d1b283b0f225a9bffd13dfaf86f067252d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->