### PR TITLE
fix: #2745 rsp gh ETag cache grows unbounded and is read whole on every gh call (10 MB measured)

### DIFF
--- a/apps/rsp/docs/TROUBLESHOOTING.md
+++ b/apps/rsp/docs/TROUBLESHOOTING.md
@@ -120,3 +120,28 @@ If logical retained bytes are below budget but the file keeps growing, capture t
 ### Root fix
 
 This manual bound check is a stopgap for #1704. The root fix is the physical-cap contract: store compaction or rotation must enforce the on-disk ceiling, not only logical expiry.
+
+## gh ETag cache growth
+
+### Symptom
+
+`gh` calls routed through rsp get slower as the repo ages, with no change at the call site.
+
+### Confirm
+
+The ETag lane is `.red/state/rsp/gh-etag/`, one file per request key:
+
+```bash
+du -sb .red/state/rsp/gh-etag
+find .red/state/rsp -name '*.tmp'
+```
+
+A lookup reads exactly one entry file, so lane size must not affect per-call cost. A pre-partition monolith (`gh-etag-cache.toon` or `gh-etag-cache.json`) is folded into partitions on the next lookup and then removed; seeing one linger means no `gh` call has run since.
+
+### Recover
+
+Lower the ceiling with `rsp.ghEtagCacheByteBudget` in `.red/config.yaml` (or `RSP_GH_ETAG_CACHE_BYTE_BUDGET`); the next cache write evicts oldest-first down to it. Deleting the lane outright is safe — it costs one non-conditional fetch per dropped entry.
+
+### Root fix
+
+Shipped with #2745: the lane is partitioned by request key, bounded by a configured byte ceiling, and sweeps its own orphan `.tmp` files on every write.

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -17,6 +17,8 @@ export const DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS = 2_000;
 export const DEFAULT_RSP_IDLE_MS = 5 * 60_000;
 export const MIN_RSP_IDLE_MS = 5_000;
 export const DEFAULT_RSP_MEASUREMENT_HOLDOUT_SHARE = 0;
+/** Ceiling for the partitioned `gh` ETag lane; entries above it are evicted oldest-first. */
+export const DEFAULT_RSP_GH_ETAG_CACHE_BYTE_BUDGET = 4 * 1024 * 1024;
 
 export interface RspRuntimeConfig {
   enabled: boolean;
@@ -96,6 +98,18 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
     heavyGitByteThreshold,
     measurementHoldoutShare,
   };
+}
+
+/**
+ * Byte ceiling for the `gh` ETag cache lane, resolved on its own so the cache
+ * never has to build the full runtime config on a hot lookup path.
+ */
+export function resolveGhEtagCacheByteBudget(cwd: string, env: NodeJS.ProcessEnv): number {
+  const fromEnv = numericEnv(env.RSP_GH_ETAG_CACHE_BYTE_BUDGET);
+  if (fromEnv !== undefined) return positiveNumber(fromEnv, DEFAULT_RSP_GH_ETAG_CACHE_BYTE_BUDGET);
+  const configPath = findUp(resolve(cwd), join(".red", "config.yaml"));
+  const yaml = configPath ? readFileSync(configPath, "utf8") : "";
+  return positiveNumber(readNumericYamlPath(yaml, "rsp.ghEtagCacheByteBudget"), DEFAULT_RSP_GH_ETAG_CACHE_BYTE_BUDGET);
 }
 
 function readNumericYamlPath(yaml: string, dottedPath: string): number | undefined {

--- a/apps/rsp/src/gh-conditional.ts
+++ b/apps/rsp/src/gh-conditional.ts
@@ -1,9 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
-import { rspStateDir } from "@reddb-io/shared/red-paths.js";
-import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { readGhEtagEntry, writeGhEtagEntry } from "./gh-etag-cache.js";
 import { appendTelemetryEvent, RSP_DECISIONS_COLLECTION } from "./telemetry.js";
 
 export interface GhConditionalRequest {
@@ -29,29 +26,12 @@ export interface GhConditionalResult {
   quotaFree: boolean;
 }
 
-interface GhEtagCacheDocument {
-  version: 1;
-  entries: Record<string, GhEtagCacheEntry>;
-}
-
-interface GhEtagCacheEntry {
-  key: string;
-  request: string;
-  etag: string;
-  body: string;
-  updated_at: string;
-}
-
-const CACHE_FILE = "gh-etag-cache.toon";
-const LEGACY_CACHE_FILE = "gh-etag-cache.json";
-
 export async function readGhConditionalJson(request: GhConditionalRequest): Promise<GhConditionalResult> {
   const cwd = request.cwd ?? process.cwd();
   const telemetryRoot = request.telemetryRoot ?? cwd;
   const identity = requestIdentity(request.path, request.params);
   const key = cacheKey(identity);
-  const cache = await readCache(telemetryRoot);
-  const cached = cache.entries[key];
+  const cached = await readGhEtagEntry(telemetryRoot, key);
   const args = ["api", "--include", "--method", "GET", request.path];
   for (const [name, value] of sortedParams(request.params)) {
     args.push("-f", `${name}=${String(value)}`);
@@ -75,14 +55,17 @@ export async function readGhConditionalJson(request: GhConditionalRequest): Prom
   if (parsed.statusCode >= 200 && parsed.statusCode < 300) {
     const etag = parsed.headers.get("etag");
     if (etag) {
-      cache.entries[key] = {
-        key,
-        request: identity,
-        etag,
-        body: parsed.body,
-        updated_at: new Date().toISOString(),
-      };
-      await writeCache(telemetryRoot, cache);
+      await writeGhEtagEntry(
+        telemetryRoot,
+        {
+          key,
+          request: identity,
+          etag,
+          body: parsed.body,
+          updated_at: new Date().toISOString(),
+        },
+        { env: request.env },
+      );
     }
     await recordConditionalTelemetry(telemetryRoot, request.command ?? `gh api ${request.path}`, false);
     return {
@@ -184,40 +167,6 @@ function parseIncludedResponse(raw: string): { statusCode: number; headers: Map<
   };
 }
 
-async function readCache(root: string): Promise<GhEtagCacheDocument> {
-  for (const path of [cachePath(root), legacyCachePath(root)]) {
-    try {
-      const parsed = decodeCacheDocument(await readFile(path, "utf8"));
-      if (isCacheDocument(parsed)) return parsed;
-    } catch {}
-  }
-  return { version: 1, entries: {} };
-}
-
-async function writeCache(root: string, cache: GhEtagCacheDocument): Promise<void> {
-  const path = cachePath(root);
-  await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
-  await writeFile(tmp, `${encode(cache as unknown as JsonValue)}\n`, { encoding: "utf8", mode: 0o600 });
-  await rename(tmp, path);
-}
-
-function cachePath(root: string): string {
-  return join(rspStateDir(root), CACHE_FILE);
-}
-
-function legacyCachePath(root: string): string {
-  return join(rspStateDir(root), LEGACY_CACHE_FILE);
-}
-
-function decodeCacheDocument(raw: string): unknown {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return decode(raw);
-  }
-}
-
 async function recordConditionalTelemetry(root: string, command: string, quotaFree: boolean): Promise<void> {
   await appendTelemetryEvent(root, {
     collection: RSP_DECISIONS_COLLECTION,
@@ -232,22 +181,3 @@ async function recordConditionalTelemetry(root: string, command: string, quotaFr
   });
 }
 
-function isCacheDocument(value: unknown): value is GhEtagCacheDocument {
-  return isRecord(value) &&
-    value.version === 1 &&
-    isRecord(value.entries) &&
-    Object.values(value.entries).every(isCacheEntry);
-}
-
-function isCacheEntry(value: unknown): value is GhEtagCacheEntry {
-  return isRecord(value) &&
-    typeof value.key === "string" &&
-    typeof value.request === "string" &&
-    typeof value.etag === "string" &&
-    typeof value.body === "string" &&
-    typeof value.updated_at === "string";
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}

--- a/apps/rsp/src/gh-etag-cache.ts
+++ b/apps/rsp/src/gh-etag-cache.ts
@@ -1,0 +1,242 @@
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { rspStateDir } from "@reddb-io/shared/red-paths.js";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { resolveGhEtagCacheByteBudget } from "./config.js";
+
+/**
+ * Partitioned on-disk store for `gh` conditional-request ETags.
+ *
+ * One entry per file, addressed by its request key, so a lookup costs one small
+ * read no matter how many entries the lane holds. The predecessor kept every
+ * entry in a single document and read it whole on every `gh` call, which grew
+ * to ~10 MB of read-decode-rewrite per invocation on a busy repo.
+ */
+export interface GhEtagCacheEntry {
+  key: string;
+  request: string;
+  etag: string;
+  body: string;
+  updated_at: string;
+}
+
+export interface GhEtagCacheSweepOptions {
+  /** Byte ceiling for the whole lane; entries are evicted oldest-first above it. */
+  maxBytes?: number;
+  /**
+   * How long an unclaimed `.tmp` may survive before the sweep reclaims it. The
+   * grace exists so a concurrent writer's in-flight temp is never deleted out
+   * from under it; tests pass 0 to sweep synchronously.
+   */
+  tmpGraceMs?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface GhEtagCacheSweepResult {
+  bytes: number;
+  entries: number;
+  evicted: number;
+  reclaimedTmp: number;
+}
+
+const CACHE_DIR = "gh-etag";
+const ENTRY_SUFFIX = ".toon";
+const LEGACY_CACHE_FILES = ["gh-etag-cache.toon", "gh-etag-cache.json"] as const;
+const LEGACY_TMP_PREFIX = "gh-etag-cache.";
+const DEFAULT_TMP_GRACE_MS = 5 * 60_000;
+
+let readBytes = 0;
+let readFiles = 0;
+
+/** Bytes and files this process has read from the cache — the lookup-cost probe. */
+export function ghEtagCacheReadStats(): { bytes: number; files: number } {
+  return { bytes: readBytes, files: readFiles };
+}
+
+export function resetGhEtagCacheReadStats(): void {
+  readBytes = 0;
+  readFiles = 0;
+}
+
+export function ghEtagCacheDir(root: string): string {
+  return join(rspStateDir(root), CACHE_DIR);
+}
+
+export function ghEtagEntryPath(root: string, key: string): string {
+  return join(ghEtagCacheDir(root), key.slice(0, 2), `${key}${ENTRY_SUFFIX}`);
+}
+
+/** Reads exactly one entry file; unknown keys cost one failed open, not a scan. */
+export async function readGhEtagEntry(root: string, key: string): Promise<GhEtagCacheEntry | null> {
+  await migrateLegacyGhEtagCache(root);
+  try {
+    const raw = await readFile(ghEtagEntryPath(root, key), "utf8");
+    readBytes += Buffer.byteLength(raw);
+    readFiles += 1;
+    const parsed = decodeEntry(raw);
+    return isCacheEntry(parsed) && parsed.key === key ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeGhEtagEntry(
+  root: string,
+  entry: GhEtagCacheEntry,
+  options: GhEtagCacheSweepOptions = {},
+): Promise<void> {
+  const path = ghEtagEntryPath(root, entry.key);
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${counterToken()}.tmp`;
+  try {
+    await writeFile(tmp, `${encode(entry as unknown as JsonValue)}\n`, { encoding: "utf8", mode: 0o600 });
+    await rename(tmp, path);
+  } catch (error) {
+    await rm(tmp, { force: true });
+    throw error;
+  }
+  await sweepGhEtagCache(root, options);
+}
+
+/**
+ * Enforces the byte ceiling and reclaims orphan `.tmp` files in one pass.
+ *
+ * Only directory metadata is consulted — sizes and mtimes — so bounding the
+ * lane never pays the cost of reading the bodies it may be about to delete.
+ */
+export async function sweepGhEtagCache(
+  root: string,
+  options: GhEtagCacheSweepOptions = {},
+): Promise<GhEtagCacheSweepResult> {
+  const maxBytes = options.maxBytes ?? resolveGhEtagCacheByteBudget(root, options.env ?? process.env);
+  const graceMs = options.tmpGraceMs ?? DEFAULT_TMP_GRACE_MS;
+  const now = Date.now();
+  const dir = ghEtagCacheDir(root);
+  const result: GhEtagCacheSweepResult = { bytes: 0, entries: 0, evicted: 0, reclaimedTmp: 0 };
+  const live: Array<{ path: string; size: number; mtimeMs: number }> = [];
+
+  for (const path of await listFiles(dir)) {
+    const info = await statOrNull(path);
+    if (!info) continue;
+    if (path.endsWith(".tmp")) {
+      if (now - info.mtimeMs >= graceMs) {
+        await rm(path, { force: true });
+        result.reclaimedTmp += 1;
+      }
+      continue;
+    }
+    if (!path.endsWith(ENTRY_SUFFIX)) continue;
+    live.push({ path, size: info.size, mtimeMs: info.mtimeMs });
+    result.bytes += info.size;
+  }
+
+  // Orphans from the pre-partition writer sat directly in the state dir.
+  for (const path of await listFiles(rspStateDir(root), false)) {
+    const name = path.slice(path.lastIndexOf("/") + 1);
+    if (!name.startsWith(LEGACY_TMP_PREFIX) || !name.endsWith(".tmp")) continue;
+    const info = await statOrNull(path);
+    if (!info || now - info.mtimeMs < graceMs) continue;
+    await rm(path, { force: true });
+    result.reclaimedTmp += 1;
+  }
+
+  live.sort((a, b) => a.mtimeMs - b.mtimeMs || a.path.localeCompare(b.path));
+  let index = 0;
+  while (result.bytes > maxBytes && index < live.length) {
+    const victim = live[index++]!;
+    await rm(victim.path, { force: true });
+    result.bytes -= victim.size;
+    result.evicted += 1;
+  }
+  result.entries = live.length - result.evicted;
+  return result;
+}
+
+/**
+ * Folds a pre-partition monolith into per-key entries exactly once. The whole
+ * document is read here and nowhere else, and the legacy file is removed so the
+ * cost is paid at most once per repo.
+ */
+export async function migrateLegacyGhEtagCache(root: string): Promise<number> {
+  let migrated = 0;
+  for (const file of LEGACY_CACHE_FILES) {
+    const path = join(rspStateDir(root), file);
+    let raw: string;
+    try {
+      raw = await readFile(path, "utf8");
+    } catch {
+      continue;
+    }
+    const parsed = decodeEntry(raw);
+    const entries = isRecord(parsed) && isRecord(parsed.entries) ? Object.values(parsed.entries) : [];
+    for (const entry of entries) {
+      if (!isCacheEntry(entry)) continue;
+      const target = ghEtagEntryPath(root, entry.key);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, `${encode(entry as unknown as JsonValue)}\n`, { encoding: "utf8", mode: 0o600 });
+      migrated += 1;
+    }
+    await rm(path, { force: true });
+  }
+  return migrated;
+}
+
+let tmpCounter = 0;
+
+function counterToken(): string {
+  tmpCounter += 1;
+  return `${Date.now().toString(36)}${tmpCounter.toString(36)}`;
+}
+
+async function listFiles(dir: string, recursive = true): Promise<string[]> {
+  let dirents;
+  try {
+    dirents = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const files: string[] = [];
+  for (const dirent of dirents) {
+    const path = join(dir, dirent.name);
+    if (dirent.isDirectory()) {
+      if (recursive) files.push(...(await listFiles(path)));
+      continue;
+    }
+    files.push(path);
+  }
+  return files;
+}
+
+async function statOrNull(path: string): Promise<{ size: number; mtimeMs: number } | null> {
+  try {
+    const info = await stat(path);
+    return { size: info.size, mtimeMs: info.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+function decodeEntry(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    try {
+      return decode(raw);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function isCacheEntry(value: unknown): value is GhEtagCacheEntry {
+  return isRecord(value) &&
+    typeof value.key === "string" &&
+    typeof value.request === "string" &&
+    typeof value.etag === "string" &&
+    typeof value.body === "string" &&
+    typeof value.updated_at === "string";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/rsp/tests/gh-conditional.test.ts
+++ b/apps/rsp/tests/gh-conditional.test.ts
@@ -1,9 +1,10 @@
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { decode } from "@reddb-io/toon";
 import { readGhConditionalJson } from "../src/gh-conditional.js";
+import { ghEtagCacheDir } from "../src/gh-etag-cache.js";
 import { telemetrySpoolPath } from "../src/telemetry.js";
 
 const roots: string[] = [];
@@ -50,9 +51,12 @@ describe("gh conditional requests", () => {
     expect(second).toMatchObject({ status: 0, quotaFree: true });
     expect(second.stdout).toBe("{\"number\":1975,\"state\":\"OPEN\"}\n");
     expect(await readFile(countFile, "utf8")).toBe("2");
-    const cacheRaw = await readFile(join(root, ".red", "state", "rsp", "gh-etag-cache.toon"), "utf8");
+    const entries = await readdir(ghEtagCacheDir(root), { recursive: true, withFileTypes: true });
+    const files = entries.filter((entry) => entry.isFile());
+    expect(files).toHaveLength(1);
+    const cacheRaw = await readFile(join(files[0]!.parentPath, files[0]!.name), "utf8");
     expect(() => JSON.parse(cacheRaw)).toThrow();
-    expect(decode(cacheRaw)).toMatchObject({ version: 1 });
+    expect(decode(cacheRaw)).toMatchObject({ etag: "rsp-test-etag" });
     await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toContain("quota_free");
   });
 });

--- a/apps/rsp/tests/gh-etag-cache.test.ts
+++ b/apps/rsp/tests/gh-etag-cache.test.ts
@@ -1,0 +1,200 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { encode, type JsonValue } from "@reddb-io/toon";
+import {
+  ghEtagCacheDir,
+  ghEtagCacheReadStats,
+  ghEtagEntryPath,
+  migrateLegacyGhEtagCache,
+  readGhEtagEntry,
+  resetGhEtagCacheReadStats,
+  sweepGhEtagCache,
+  writeGhEtagEntry,
+  type GhEtagCacheEntry,
+} from "../src/gh-etag-cache.js";
+
+const roots: string[] = [];
+const HUGE_BUDGET = 64 * 1024 * 1024;
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-gh-etag-"));
+  roots.push(root);
+  await mkdir(join(root, ".red", "state", "rsp"), { recursive: true });
+  return root;
+}
+
+function entry(index: number, bodyBytes = 512): GhEtagCacheEntry {
+  const key = `${index.toString(16).padStart(4, "0")}`.repeat(16);
+  return {
+    key,
+    request: JSON.stringify({ method: "GET", path: `repos/owner/repo/issues/${index}`, params: [] }),
+    etag: `etag-${index}`,
+    body: "b".repeat(bodyBytes),
+    updated_at: new Date(1_700_000_000_000 + index * 1000).toISOString(),
+  };
+}
+
+async function seed(root: string, count: number, bodyBytes = 512): Promise<GhEtagCacheEntry[]> {
+  const seeded: GhEtagCacheEntry[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const value = entry(index, bodyBytes);
+    await writeGhEtagEntry(root, value, { maxBytes: HUGE_BUDGET, tmpGraceMs: HUGE_BUDGET });
+    seeded.push(value);
+  }
+  return seeded;
+}
+
+async function cacheFiles(root: string): Promise<string[]> {
+  try {
+    const dirents = await readdir(ghEtagCacheDir(root), { recursive: true, withFileTypes: true });
+    return dirents.filter((dirent) => dirent.isFile()).map((dirent) => join(dirent.parentPath, dirent.name));
+  } catch {
+    return [];
+  }
+}
+
+beforeEach(() => {
+  resetGhEtagCacheReadStats();
+});
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("gh etag cache partitioning", () => {
+  it("reads exactly one entry file per lookup, never the whole lane", async () => {
+    const root = await tempRoot();
+    const seeded = await seed(root, 40);
+
+    resetGhEtagCacheReadStats();
+    const found = await readGhEtagEntry(root, seeded[7]!.key);
+
+    expect(found?.etag).toBe("etag-7");
+    const stats = ghEtagCacheReadStats();
+    expect(stats.files).toBe(1);
+    const entrySize = (await stat(ghEtagEntryPath(root, seeded[7]!.key))).size;
+    expect(stats.bytes).toBe(entrySize);
+  });
+
+  it("keeps lookup cost independent of total cache size", async () => {
+    const small = await tempRoot();
+    const large = await tempRoot();
+    const smallSeeded = await seed(small, 4);
+    const largeSeeded = await seed(large, 200);
+
+    resetGhEtagCacheReadStats();
+    await readGhEtagEntry(small, smallSeeded[1]!.key);
+    const smallBytes = ghEtagCacheReadStats().bytes;
+
+    resetGhEtagCacheReadStats();
+    await readGhEtagEntry(large, largeSeeded[1]!.key);
+    const largeBytes = ghEtagCacheReadStats().bytes;
+
+    // 50x the entries must not cost 50x the read: one entry is one entry.
+    expect(largeBytes).toBe(smallBytes);
+    const laneBytes = (await Promise.all((await cacheFiles(large)).map(async (path) => (await stat(path)).size)))
+      .reduce((total, size) => total + size, 0);
+    expect(largeBytes).toBeLessThan(laneBytes / 50);
+  });
+
+  it("misses cost one failed open rather than a scan", async () => {
+    const root = await tempRoot();
+    await seed(root, 20);
+
+    resetGhEtagCacheReadStats();
+    expect(await readGhEtagEntry(root, "f".repeat(64))).toBeNull();
+    expect(ghEtagCacheReadStats()).toEqual({ bytes: 0, files: 0 });
+  });
+});
+
+describe("gh etag cache ceiling", () => {
+  it("evicts oldest-first once the configured byte ceiling is exceeded", async () => {
+    const root = await tempRoot();
+    const seeded = await seed(root, 10, 1024);
+    const sizes = await Promise.all(seeded.map(async (value) => (await stat(ghEtagEntryPath(root, value.key))).size));
+    const perEntry = sizes[0]!;
+
+    const result = await sweepGhEtagCache(root, { maxBytes: perEntry * 4, tmpGraceMs: HUGE_BUDGET });
+
+    expect(result.evicted).toBe(6);
+    expect(result.bytes).toBeLessThanOrEqual(perEntry * 4);
+    expect(await readGhEtagEntry(root, seeded[0]!.key)).toBeNull();
+    expect(await readGhEtagEntry(root, seeded[9]!.key)).not.toBeNull();
+  });
+
+  it("bounds the lane on write without a caller-supplied ceiling", async () => {
+    const root = await tempRoot();
+    for (let index = 0; index < 12; index += 1) {
+      await writeGhEtagEntry(root, entry(index, 1024), { maxBytes: 3 * 1024, tmpGraceMs: HUGE_BUDGET });
+    }
+    const files = await cacheFiles(root);
+    const total = (await Promise.all(files.map(async (path) => (await stat(path)).size)))
+      .reduce((sum, size) => sum + size, 0);
+    expect(total).toBeLessThanOrEqual(3 * 1024);
+  });
+
+  it("reads the ceiling from the repo config", async () => {
+    const root = await tempRoot();
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  ghEtagCacheByteBudget: 2048\n", "utf8");
+    for (let index = 0; index < 8; index += 1) {
+      await writeGhEtagEntry(root, entry(index, 1024), { tmpGraceMs: HUGE_BUDGET, env: {} });
+    }
+    const files = await cacheFiles(root);
+    const total = (await Promise.all(files.map(async (path) => (await stat(path)).size)))
+      .reduce((sum, size) => sum + size, 0);
+    expect(total).toBeLessThanOrEqual(2048);
+  });
+});
+
+describe("gh etag cache tmp reclamation", () => {
+  it("leaves no .tmp behind from an interrupted write after the next lane sweep", async () => {
+    const root = await tempRoot();
+    await seed(root, 2);
+    const orphanInLane = join(ghEtagCacheDir(root), "aa", "aa-interrupted.toon.4242.1.tmp");
+    const orphanInStateDir = join(root, ".red", "state", "rsp", "gh-etag-cache.toon.4242.1.tmp");
+    await mkdir(join(ghEtagCacheDir(root), "aa"), { recursive: true });
+    await writeFile(orphanInLane, "", "utf8");
+    await writeFile(orphanInStateDir, "", "utf8");
+
+    const result = await sweepGhEtagCache(root, { maxBytes: HUGE_BUDGET, tmpGraceMs: 0 });
+
+    expect(result.reclaimedTmp).toBe(2);
+    expect((await cacheFiles(root)).some((path) => path.endsWith(".tmp"))).toBe(false);
+    await expect(stat(orphanInStateDir)).rejects.toThrow();
+  });
+
+  it("spares a temp still inside its grace window", async () => {
+    const root = await tempRoot();
+    await mkdir(join(ghEtagCacheDir(root), "aa"), { recursive: true });
+    const inflight = join(ghEtagCacheDir(root), "aa", "aa-inflight.toon.4242.1.tmp");
+    await writeFile(inflight, "", "utf8");
+
+    const result = await sweepGhEtagCache(root, { maxBytes: HUGE_BUDGET, tmpGraceMs: 60_000 });
+
+    expect(result.reclaimedTmp).toBe(0);
+    await expect(stat(inflight)).resolves.toBeTruthy();
+  });
+});
+
+describe("gh etag cache legacy migration", () => {
+  it("folds a monolithic cache document into partitions exactly once", async () => {
+    const root = await tempRoot();
+    const legacyPath = join(root, ".red", "state", "rsp", "gh-etag-cache.toon");
+    const entries = [entry(1), entry(2)];
+    const document = {
+      version: 1,
+      entries: Object.fromEntries(entries.map((value) => [value.key, value])),
+    };
+    await writeFile(legacyPath, `${encode(document as unknown as JsonValue)}\n`, "utf8");
+
+    resetGhEtagCacheReadStats();
+    const found = await readGhEtagEntry(root, entries[1]!.key);
+
+    expect(found?.etag).toBe("etag-2");
+    await expect(stat(legacyPath)).rejects.toThrow();
+    expect(await migrateLegacyGhEtagCache(root)).toBe(0);
+    await expect(readFile(ghEtagEntryPath(root, entries[0]!.key), "utf8")).resolves.toContain("etag-1");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2745. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2745

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787871012&installation_model_id=20659&pr_number=2756&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2756&signature=531a3f3f66047f99e92c435ed010c54d31cc73d5002b6df825d5a092a5ff6f02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->