### PR TITLE
chore: #2750 CI runs the full workspace suite on every PR, including docs-only changes

### DIFF
--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -11,6 +11,15 @@ name: red-workspace-ci
 # the vitest worker (#446); that loop is fixed, so the suite is now a reliable
 # gate. Scoped to apps/dev — the AFK-critical suite that is verified green here;
 # broadening to the other apps' suites is a follow-up.
+#
+# scope: the heavy jobs are narrowed to the change's affected cone by
+# scripts/ci-affected-scope.mjs, on the same principle the AFK feedback gate
+# already uses (apps/dev/src/core/validation-scope.ts). The narrowing is
+# step-level ON PURPOSE: a trigger-level `paths`/`paths-ignore` filter or a
+# job-level `if:` makes a required check vanish or report "skipped", which leaves
+# branch protection waiting forever on a docs PR. Every job here still runs on
+# every PR and still reports a conclusion; only the work inside it shrinks.
+# An unclassifiable change escalates to the whole workspace (#2750).
 
 on:
   pull_request:
@@ -24,6 +33,43 @@ permissions:
   contents: read
 
 jobs:
+  # Resolve the affected cone once; the heavy jobs read it through `needs`.
+  # A push (main / automation branch) always gets the whole workspace: there is
+  # no pull-request base to diff against and post-merge state must never be
+  # under-validated.
+  scope:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.compute.outputs.mode }}
+      test_packages: ${{ steps.compute.outputs.test_packages }}
+      run_typecheck: ${{ steps.compute.outputs.run_typecheck }}
+      run_manifest_checks: ${{ steps.compute.outputs.run_manifest_checks }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # Full history so the merge-base diff against the PR base resolves.
+          fetch-depth: 0
+
+      - name: Compute affected cone
+        id: compute
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "$EVENT" != "pull_request" ]; then
+            node scripts/ci-affected-scope.mjs --whole-workspace --github-output
+            exit 0
+          fi
+          # Fetching the base branch is what makes the three-dot merge-base diff
+          # possible; if it fails, the scoper sees an empty diff and falls back
+          # to the whole workspace rather than narrowing on an unknown set.
+          git fetch --no-tags --depth=0 origin "$BASE_REF" || true
+          base="$BASE_SHA"
+          if [ -z "$base" ]; then base="origin/$BASE_REF"; fi
+          node scripts/ci-affected-scope.mjs --base "$base" --head HEAD --github-output
+
   workflow-security:
     runs-on: ubuntu-latest
     steps:
@@ -61,19 +107,30 @@ jobs:
       - name: Test marketplace manifest validator
         run: scripts/test-validate-marketplace-manifests.sh
 
+      - name: Test CI affected-scope contract
+        run: scripts/test-ci-affected-scope.sh
+
   typecheck:
     runs-on: ubuntu-latest
+    needs: scope
+    env:
+      # Both step families need install; compute the union once.
+      RUN_ANY: ${{ needs.scope.outputs.run_typecheck == 'true' || needs.scope.outputs.run_manifest_checks == 'true' }}
     steps:
       - name: Checkout
+        if: env.RUN_ANY == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+      - if: env.RUN_ANY == 'true'
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - if: env.RUN_ANY == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
 
       - name: Install workspace dependencies
+        if: env.RUN_ANY == 'true'
         env:
           # This PR gate typechecks/tests apps/dev; it does not execute the
           # @reddb-io/sdk-backed memory/brain runtimes. Skip the SDK postinstall
@@ -82,26 +139,43 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Check generated Codex manifests
+        if: needs.scope.outputs.run_manifest_checks == 'true'
         run: pnpm codex:manifests:check
 
       - name: Check generated Pi manifests
+        if: needs.scope.outputs.run_manifest_checks == 'true'
         run: pnpm pi:manifests:check
 
       - name: Check generated Pi npm packages
+        if: needs.scope.outputs.run_manifest_checks == 'true'
         run: pnpm pi:packages:check
 
       - name: Typecheck workspace (apps + packages, excludes red-castle)
+        if: needs.scope.outputs.run_typecheck == 'true'
         run: pnpm typecheck
+
+      - name: Report narrowed scope
+        if: env.RUN_ANY != 'true'
+        run: echo "No typed or manifest input changed (scope ${{ needs.scope.outputs.mode }}) — nothing to check."
 
   test:
     runs-on: ubuntu-latest
+    needs: scope
+    env:
+      # JSON array of every package in the affected cone; each step below asks
+      # whether its own package is in it.
+      PACKAGES: ${{ needs.scope.outputs.test_packages }}
+      RUN_ANY: ${{ needs.scope.outputs.test_packages != '[]' }}
     steps:
       - name: Checkout
+        if: env.RUN_ANY == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+      - if: env.RUN_ANY == 'true'
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - if: env.RUN_ANY == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
 
@@ -110,6 +184,7 @@ jobs:
       # binary must exist here exactly as it does on dev machines (/red-setup)
       # and in red-rsp-benchmark-ci.yml. Same pinned installer, no fallback.
       - name: Install pinned tq
+        if: contains(fromJSON(env.PACKAGES), 'apps/dev')
         env:
           TQ_VERSION: v0.3.0
           GH_TOKEN: ${{ github.token }}
@@ -123,6 +198,7 @@ jobs:
             sh
 
       - name: Install workspace dependencies
+        if: env.RUN_ANY == 'true'
         env:
           # This PR gate typechecks/tests apps/dev; it does not execute the
           # @reddb-io/sdk-backed memory/brain runtimes. Skip the SDK postinstall
@@ -131,6 +207,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Test apps/dev (includes packages/shared)
+        if: contains(fromJSON(env.PACKAGES), 'apps/dev')
         run: pnpm -C apps/dev test
 
       # The engine's own suite carries the castle-tree transition-API contract
@@ -138,10 +215,17 @@ jobs:
       # this step that lint would never run and a raw state-role writer could
       # reach main unseen.
       - name: Test packages/red-castle
+        if: contains(fromJSON(env.PACKAGES), 'packages/red-castle')
         run: pnpm -C packages/red-castle test
 
       - name: Test apps/opencode-host
+        if: contains(fromJSON(env.PACKAGES), 'apps/opencode-host')
         run: pnpm -C apps/opencode-host test
 
       - name: Test apps/afk-container
+        if: contains(fromJSON(env.PACKAGES), 'apps/afk-container')
         run: pnpm -C apps/afk-container test
+
+      - name: Report narrowed scope
+        if: env.RUN_ANY != 'true'
+        run: echo "No package is in the affected cone (scope ${{ needs.scope.outputs.mode }}) — no suite to run."

--- a/scripts/ci-affected-scope.mjs
+++ b/scripts/ci-affected-scope.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+// ci-affected-scope — compute the CI gate's affected cone from a changed-file set.
+//
+// The AFK feedback gate already scopes validation to the dependency cone of a
+// change (apps/dev/src/core/validation-scope.ts). CI had no equivalent, so the
+// same narrow diff was cheap when a worker validated it and a full-workspace
+// run when GitHub did. This script gives red-workspace-ci.yml the same cone, on
+// the same principle: touched packages plus every package that transitively
+// depends on them.
+//
+// Two rules keep the narrowing honest:
+//
+//   1. Unclassifiable wins the whole workspace. Every path is matched against an
+//      explicit table; a path that matches nothing escalates to the full suite,
+//      because a wrongly-skipped test costs far more than a needlessly-run one.
+//   2. Docs are not inert here. This repo's apps/dev suite asserts the content of
+//      `.red/**` and `plugins/**` (the *-docs.test.ts contracts, ADR governance,
+//      pi package payloads), so a docs-only change still runs apps/dev — it just
+//      stops paying for typecheck and for every unrelated package's suite.
+//
+// Usage:
+//   node scripts/ci-affected-scope.mjs --files-stdin [--github-output]
+//   node scripts/ci-affected-scope.mjs --base <ref> --head <ref> [--github-output]
+//   node scripts/ci-affected-scope.mjs --whole-workspace [--github-output]
+//
+// Prints the scope as JSON on stdout. With --github-output it also appends
+// `mode`, `trigger`, `test_packages` (JSON array), `run_typecheck` and
+// `run_manifest_checks` to $GITHUB_OUTPUT.
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+// ---------- workspace graph ----------
+
+/** Workspace package globs, mirroring pnpm-workspace.yaml's `packages:` list. */
+const PACKAGE_ROOTS = ['apps', 'packages'];
+
+/** @returns {{dir: string, name: string, dependsOn: string[]}[]} */
+function readWorkspaceGraph(repoRoot) {
+  const manifests = [];
+  for (const root of PACKAGE_ROOTS) {
+    let entries;
+    try {
+      entries = readdirSync(join(repoRoot, root), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const dir = `${root}/${entry.name}`;
+      let pkg;
+      try {
+        pkg = JSON.parse(readFileSync(join(repoRoot, dir, 'package.json'), 'utf8'));
+      } catch {
+        continue;
+      }
+      manifests.push({ dir, pkg });
+    }
+  }
+
+  const dirByName = new Map(manifests.map(({ dir, pkg }) => [pkg.name, dir]));
+  return manifests.map(({ dir, pkg }) => {
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies, ...pkg.peerDependencies };
+    const dependsOn = Object.entries(deps)
+      .filter(([name, range]) =>
+        typeof range === 'string' && range.startsWith('workspace:') && dirByName.has(name))
+      .map(([name]) => dirByName.get(name));
+    return { dir, name: pkg.name, dependsOn: [...new Set(dependsOn)].sort() };
+  });
+}
+
+/** Touched dirs → touched dirs plus every transitive dependent, byte-sorted. */
+function expandToCone(touchedDirs, graph) {
+  const reverseDeps = new Map();
+  for (const pkg of graph) {
+    for (const dep of pkg.dependsOn) {
+      if (!reverseDeps.has(dep)) reverseDeps.set(dep, []);
+      reverseDeps.get(dep).push(pkg.dir);
+    }
+  }
+
+  const cone = new Set(touchedDirs);
+  const queue = [...touchedDirs];
+  while (queue.length > 0) {
+    const dir = queue.shift();
+    for (const dependent of reverseDeps.get(dir) ?? []) {
+      if (cone.has(dependent)) continue;
+      cone.add(dependent);
+      queue.push(dependent);
+    }
+  }
+  return [...cone].sort();
+}
+
+// ---------- path classification ----------
+
+/**
+ * Doc lanes that no suite reads. Keep this list short and provable: anything
+ * added here is a promise that no test asserts the file's content.
+ */
+const INERT_PREFIXES = ['.red/researches/', '.red/tmp/', '.changeset/'];
+
+/**
+ * Doc lanes whose content apps/dev's suite asserts — the *-docs.test.ts
+ * contracts, ADR governance, the skill/manifest audits. A change here runs
+ * apps/dev's tests but affects no type.
+ */
+const DOC_PREFIXES = ['.red/'];
+
+/**
+ * Doc lanes that are ALSO inputs to generated artifacts (Codex/Pi manifests,
+ * Pi package payloads), so they additionally re-run the manifest checks.
+ */
+const MANIFEST_INPUT_PREFIXES = ['plugins/', '.claude-plugin/', '.agents/', 'packaging/pi/'];
+
+/** Root-level docs that the suite reads (README/CLAUDE/CHANGES are asserted). */
+const ROOT_DOC_FILES = new Set(['README.md', 'CLAUDE.md', 'CHANGES.md', 'NOTICE', 'LICENSE']);
+
+/** Source-file extensions — anything else inside a package is docs/fixtures. */
+const TYPED_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.mjs', '.cjs', '.json'];
+
+function stripDotSlash(file) {
+  return file.startsWith('./') ? file.slice(2) : file;
+}
+
+function packageDirFor(file, graph) {
+  // Longest-prefix match, so packages/red-castle wins over a shorter sibling.
+  let best;
+  for (const pkg of graph) {
+    if (!file.startsWith(`${pkg.dir}/`)) continue;
+    if (best === undefined || pkg.dir.length > best.length) best = pkg.dir;
+  }
+  return best;
+}
+
+/**
+ * Classify one changed path.
+ * @returns {{kind: 'whole'} | {kind: 'inert'} | {kind: 'scoped', packages: string[], typecheck: boolean, manifests: boolean}}
+ */
+function classify(file, graph) {
+  const clean = stripDotSlash(file);
+
+  // `.red/` docs that the ADR/pi payload builders read are manifest inputs too.
+  if (clean.startsWith('.red/adr/')) {
+    return { kind: 'scoped', packages: ['apps/dev'], typecheck: false, manifests: true };
+  }
+  if (INERT_PREFIXES.some((p) => clean.startsWith(p))) return { kind: 'inert' };
+  if (MANIFEST_INPUT_PREFIXES.some((p) => clean.startsWith(p))) {
+    return { kind: 'scoped', packages: ['apps/dev'], typecheck: false, manifests: true };
+  }
+  if (DOC_PREFIXES.some((p) => clean.startsWith(p))) {
+    // `.red/config.yaml` is repo configuration the runtimes read, not prose —
+    // it does not get the docs discount.
+    if (clean === '.red/config.yaml') return { kind: 'whole' };
+    return { kind: 'scoped', packages: ['apps/dev'], typecheck: false, manifests: false };
+  }
+
+  if (!clean.includes('/')) {
+    if (ROOT_DOC_FILES.has(clean)) {
+      return { kind: 'scoped', packages: ['apps/dev'], typecheck: false, manifests: false };
+    }
+    // Every other root file (package.json, lockfile, turbo.json, tsconfig, …)
+    // has global blast radius.
+    return { kind: 'whole' };
+  }
+
+  const dir = packageDirFor(clean, graph);
+  if (dir !== undefined) {
+    // A package's own manifest can change its build/test wiring, and apps/*
+    // versions feed the generated Pi packages.
+    const isManifest = clean === `${dir}/package.json`;
+    const typecheck = TYPED_EXTENSIONS.some((ext) => clean.endsWith(ext));
+    return { kind: 'scoped', packages: [dir], typecheck, manifests: isManifest };
+  }
+
+  // scripts/**, .github/**, dist/**, anything unrecognised: unclassifiable.
+  return { kind: 'whole' };
+}
+
+// ---------- scope computation ----------
+
+export function computeCiScope(changedFiles, graph) {
+  const files = changedFiles.map(stripDotSlash).filter((f) => f !== '');
+  const allPackages = graph.map((p) => p.dir).sort();
+
+  const whole = (trigger) => ({
+    mode: 'whole-workspace',
+    trigger,
+    testPackages: allPackages,
+    triggerPackages: allPackages,
+    runTypecheck: true,
+    runManifestChecks: true,
+  });
+
+  // No files means the diff could not be established — fall back, never narrow
+  // on an unknown change set.
+  if (files.length === 0) return whole('(no changed files resolved)');
+
+  const touched = new Set();
+  let typecheck = false;
+  let manifests = false;
+  for (const file of files) {
+    const verdict = classify(file, graph);
+    if (verdict.kind === 'whole') return whole(file);
+    if (verdict.kind === 'inert') continue;
+    for (const pkg of verdict.packages) touched.add(pkg);
+    typecheck ||= verdict.typecheck;
+    manifests ||= verdict.manifests;
+  }
+
+  const triggerPackages = [...touched].sort();
+  return {
+    mode: 'cone',
+    trigger: null,
+    testPackages: expandToCone(triggerPackages, graph),
+    triggerPackages,
+    runTypecheck: typecheck,
+    runManifestChecks: manifests,
+  };
+}
+
+// ---------- CLI ----------
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function changedFilesFromGit(base, head) {
+  const range = `${base}...${head}`;
+  const out = execFileSync('git', ['diff', '--name-only', range], { encoding: 'utf8' });
+  return out.split('\n');
+}
+
+function main(argv) {
+  const repoRoot = process.cwd();
+  const graph = readWorkspaceGraph(repoRoot);
+
+  const has = (flag) => argv.includes(flag);
+  const value = (flag) => {
+    const i = argv.indexOf(flag);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+
+  let changedFiles;
+  if (has('--whole-workspace')) {
+    changedFiles = [];
+  } else if (has('--files-stdin')) {
+    changedFiles = readStdin().split('\n');
+  } else if (has('--base')) {
+    try {
+      changedFiles = changedFilesFromGit(value('--base'), value('--head') ?? 'HEAD');
+    } catch (err) {
+      // A diff we cannot compute is an unknown change set: run everything.
+      process.stderr.write(`ci-affected-scope: git diff failed (${err.message})\n`);
+      changedFiles = [];
+    }
+  } else {
+    process.stderr.write('ci-affected-scope: pass --files-stdin, --base <ref>, or --whole-workspace\n');
+    process.exit(2);
+  }
+
+  const scope = computeCiScope(changedFiles, graph);
+  process.stdout.write(`${JSON.stringify(scope, null, 2)}\n`);
+
+  if (has('--github-output') && process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      [
+        `mode=${scope.mode}`,
+        `trigger=${scope.trigger ?? ''}`,
+        `test_packages=${JSON.stringify(scope.testPackages)}`,
+        `run_typecheck=${scope.runTypecheck}`,
+        `run_manifest_checks=${scope.runManifestChecks}`,
+        '',
+      ].join('\n'),
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main(process.argv.slice(2));

--- a/scripts/test-ci-affected-scope.sh
+++ b/scripts/test-ci-affected-scope.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Contract for the CI affected-cone scoper (scripts/ci-affected-scope.mjs) and
+# for the way red-workspace-ci.yml consumes it.
+#
+# Two things must hold together: the scoper must narrow correctly (and fall back
+# to the whole workspace whenever it cannot classify a path), and the workflow
+# must keep every required check reporting a conclusion — narrowing happens at
+# step level, never by removing a job from the event.
+
+set -euo pipefail
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'PASS: %s\n' "$1"
+}
+
+scope_of() {
+  # usage: scope_of <newline-separated changed files>
+  printf '%s\n' "$1" | node scripts/ci-affected-scope.mjs --files-stdin
+}
+
+assert_field() {
+  # usage: assert_field <json> <node expression over `s`> <expected> <label>
+  local json="$1" expr="$2" expected="$3" label="$4"
+  local actual
+  actual="$(JSON="$json" node --input-type=module -e "
+    const s = JSON.parse(process.env.JSON);
+    const value = ($expr);
+    console.log(Array.isArray(value) ? value.join(',') : String(value));
+  ")"
+  [ "$actual" = "$expected" ] || fail "$label — expected '$expected', got '$actual'"
+  pass "$label"
+}
+
+# ---------- docs-only changes ----------
+
+docs="$(scope_of '.red/adr/0130-example.md
+.red/contexts/dev/CONTEXT.md')"
+
+assert_field "$docs" "s.mode" "cone" "docs-only change stays in cone mode"
+assert_field "$docs" "s.runTypecheck" "false" "docs-only change does not typecheck"
+assert_field "$docs" "s.testPackages" "apps/dev" "docs-only change tests only apps/dev (the doc-contract suite)"
+
+researches="$(scope_of '.red/researches/notes.md')"
+assert_field "$researches" "s.testPackages.length" "0" "untested doc lane runs no package tests"
+assert_field "$researches" "s.runTypecheck" "false" "untested doc lane does not typecheck"
+
+# ---------- single-package changes ----------
+
+leaf="$(scope_of 'apps/afk-container/src/entry.ts')"
+assert_field "$leaf" "s.mode" "cone" "leaf-package change stays in cone mode"
+assert_field "$leaf" "s.testPackages" "apps/afk-container" "leaf-package change tests only that package"
+assert_field "$leaf" "s.runTypecheck" "true" "source change typechecks"
+
+# ---------- shared-package changes fan out to dependents ----------
+
+shared="$(scope_of 'packages/shared/src/args.ts')"
+assert_field "$shared" "s.mode" "cone" "shared-package change stays in cone mode"
+assert_field "$shared" "s.testPackages.includes('packages/shared')" "true" "shared cone includes the touched package"
+assert_field "$shared" "s.testPackages.includes('apps/dev')" "true" "shared cone includes apps/dev (a dependent)"
+assert_field "$shared" "s.testPackages.includes('apps/opencode-host')" "true" "shared cone includes apps/opencode-host (a dependent)"
+assert_field "$shared" "s.testPackages.includes('apps/afk-container')" "false" "shared cone excludes an unrelated package"
+
+# ---------- unclassifiable / global-blast-radius changes ----------
+
+for global_path in \
+  ".github/workflows/red-workspace-ci.yml" \
+  "pnpm-lock.yaml" \
+  "package.json" \
+  "turbo.json" \
+  "scripts/ci-affected-scope.mjs" \
+  "some/unknown/place.txt"; do
+  out="$(scope_of "$global_path")"
+  assert_field "$out" "s.mode" "whole-workspace" "'$global_path' falls back to the whole workspace"
+  assert_field "$out" "s.runTypecheck" "true" "'$global_path' typechecks"
+done
+
+whole="$(scope_of 'pnpm-lock.yaml')"
+assert_field "$whole" "s.testPackages.includes('apps/dev')" "true" "whole-workspace mode lists every tested package (apps/dev)"
+assert_field "$whole" "s.testPackages.includes('packages/red-castle')" "true" "whole-workspace mode lists every tested package (red-castle)"
+
+empty="$(scope_of '')"
+assert_field "$empty" "s.mode" "whole-workspace" "an empty changed-file set falls back to the whole workspace"
+
+# ---------- generated-manifest inputs ----------
+
+plugin="$(scope_of 'plugins/dev/skills/engineering/red-setup/SKILL.md')"
+assert_field "$plugin" "s.runManifestChecks" "true" "a plugin doc change re-checks the generated manifests"
+assert_field "$plugin" "s.runTypecheck" "false" "a plugin doc change does not typecheck"
+assert_field "$plugin" "s.testPackages" "apps/dev" "a plugin doc change tests apps/dev"
+
+leaf_manifests="$(scope_of 'apps/afk-container/src/entry.ts')"
+assert_field "$leaf_manifests" "s.runManifestChecks" "false" "an unrelated source change skips the manifest checks"
+
+# ---------- GitHub Actions output rendering ----------
+
+gh_out="$(mktemp)"
+trap 'rm -f "$gh_out"' EXIT
+printf 'apps/afk-container/src/entry.ts\n' |
+  GITHUB_OUTPUT="$gh_out" node scripts/ci-affected-scope.mjs --files-stdin --github-output >/dev/null
+grep -q '^mode=cone$' "$gh_out" || fail "--github-output must write mode="
+grep -q '^run_typecheck=true$' "$gh_out" || fail "--github-output must write run_typecheck="
+grep -q '^test_packages=\["apps/afk-container"\]$' "$gh_out" ||
+  fail "--github-output must write test_packages= as a JSON array (fromJSON-consumable)"
+pass "--github-output emits GitHub-Actions-consumable outputs"
+
+# ---------- workflow wiring: required checks must always report ----------
+
+workflow=".github/workflows/red-workspace-ci.yml"
+test -f "$workflow" || fail "$workflow is required"
+
+node --input-type=module <<'NODE'
+import { readFileSync } from 'node:fs';
+
+const text = readFileSync('.github/workflows/red-workspace-ci.yml', 'utf8');
+const need = (ok, msg) => {
+  if (!ok) {
+    console.error(`FAIL: ${msg}`);
+    process.exit(1);
+  }
+  console.log(`PASS: ${msg}`);
+};
+
+// Trigger-level path filtering removes the check from the PR entirely, which
+// leaves branch protection waiting forever for a conclusion that never arrives.
+// Narrowing must happen inside the jobs, at step level.
+const trigger = text.slice(0, text.indexOf('\njobs:'));
+need(!/^\s*paths(-ignore)?:/m.test(trigger),
+  'red-workspace-ci does not filter its triggers by path');
+
+need(/^\s{2}scope:/m.test(text), 'red-workspace-ci defines a scope job');
+need(/ci-affected-scope\.mjs/.test(text), 'the scope job runs the affected-cone scoper');
+
+for (const job of ['typecheck', 'test']) {
+  const start = text.indexOf(`\n  ${job}:`);
+  need(start !== -1, `red-workspace-ci still defines the ${job} job`);
+  const rest = text.slice(start + 1);
+  const end = rest.search(/\n {2}[a-z][a-z0-9-]*:\n/);
+  const body = end === -1 ? rest : rest.slice(0, end);
+  need(/needs:\s*(scope|\[[^\]]*scope)/.test(body), `${job} consumes the scope job`);
+  need(/if:\s/.test(body), `${job} narrows its work with step-level conditions`);
+  // A job-level `if:` would report as "skipped", which branch protection treats
+  // as a missing conclusion for a required check.
+  need(!/^ {4}if:/m.test(body), `${job} has no job-level if (it must always report)`);
+}
+NODE
+
+printf '\nAll CI affected-scope contract checks passed.\n'


### PR DESCRIPTION
Automated AFK landing for #2750. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2750

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787872526&installation_model_id=20659&pr_number=2757&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2757&signature=00f59a40a153a33c65c410655fe40bfb1ac091ee41a885a54afc3430a1f9f506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->