### PR TITLE
fix: #2749 bug: a park role survives on a closed issue when parked work lands anyway

### DIFF
--- a/.changeset/closed-issue-sheds-park-role.md
+++ b/.changeset/closed-issue-sheds-park-role.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A park no longer survives on a closed issue (#2749). A park was treated as terminal, but it is not: parked work still lands — by a human merge of its PR, by a later retake, by an adopt-branch landing — and when GitHub's own PR-closes-issue mechanism performs the close, no engine path was watching to reconcile what the park left behind, so delivered slices stayed closed wearing `ready-for-human` + `blocked:ci` and any audit of label history read them as human-escalated. Closing is now a first-class `close` transition in the ADR 0122 API: it targets no state role at all, so the planner strips every role, the `running` projection, the blocked reasons, and the `req:*` edges in one proven-coherent mutation, while permanent markers such as the Spec child label, `type:*`, and `priority:*` ride through untouched. The `hitl_resolve` close decision routes through it before closing, and the ADR 0122 curator reconciles closes that originated outside the engine — one bounded `label:"a","b"` search per sweep over closed issues still carrying a state role, never a per-label loop.

--- a/apps/dev/src/core/hitl-resolve.ts
+++ b/apps/dev/src/core/hitl-resolve.ts
@@ -44,6 +44,17 @@ export async function resolveHitlDecision(
   actions.push("rationale comment posted");
 
   if (input.decision === "close") {
+    // Closing is a TRANSITION, not just a tracker verb (#2749): the park role
+    // that brought the issue to HITL must not outlive the decision that ends
+    // it, or the audit reads a resolved issue as still human-escalated. The
+    // labels go first — a close that fails leaves an open, coherent issue,
+    // where the reverse would leave a closed one nobody re-reconciles.
+    const closing = await deps.viewLabels(input.issue);
+    const plan = planTransition(closing, { kind: "close" });
+    if (!isRefused(plan) && (plan.add.length > 0 || plan.remove.length > 0)) {
+      await deps.editLabels(input.issue, [...plan.remove], [...plan.add]);
+      actions.push(`close labels reconciled (-${plan.remove.join(",") || "∅"})`);
+    }
     await deps.closeIssue(input.issue);
     actions.push("issue closed");
     return { issue: input.issue, decision: input.decision, actions };

--- a/apps/dev/tests/hitl-resolve.test.ts
+++ b/apps/dev/tests/hitl-resolve.test.ts
@@ -100,15 +100,35 @@ describe("hitl_resolve decisions (#2369)", () => {
     expect(result.actions.some((a) => a.includes("rationale comment posted"))).toBe(true);
   });
 
-  it("close: closes with the rationale on record and touches nothing else", async () => {
-    const deps = makeDeps(["ready-for-human"]);
+  it("close: strips the park role BEFORE closing, keeping permanent markers (#2749)", async () => {
+    const deps = makeDeps(["ready-for-human", "blocked:ci", "spec:2723", "type:task"]);
 
-    await resolveHitlDecision(deps, { issue: 10, decision: "close", rationale: "superseded by #2523" });
+    const result = await resolveHitlDecision(deps, {
+      issue: 10,
+      decision: "close",
+      rationale: "superseded by #2523",
+    });
 
     expect(deps.closeIssue).toHaveBeenCalledWith(10);
     expect(deps.comment).toHaveBeenCalledTimes(1);
-    expect(deps.editLabels).not.toHaveBeenCalled();
     expect(deps.releaseClaims).not.toHaveBeenCalled();
+    expect(deps.editLabels).toHaveBeenCalledTimes(1);
+    const [, remove, add] = deps.editLabels.mock.calls[0]!;
+    expect(new Set(remove as string[])).toEqual(new Set(["ready-for-human", "blocked:ci"]));
+    expect(add).toEqual([]);
+    expect(deps.editLabels.mock.invocationCallOrder[0]!).toBeLessThan(
+      deps.closeIssue.mock.invocationCallOrder[0]!,
+    );
+    expect(result.actions.some((a) => a.includes("close labels reconciled"))).toBe(true);
+  });
+
+  it("close: writes no label edit when the issue carries no state to shed", async () => {
+    const deps = makeDeps(["spec:2723", "type:task"]);
+
+    await resolveHitlDecision(deps, { issue: 11, decision: "close", rationale: "duplicate" });
+
+    expect(deps.closeIssue).toHaveBeenCalledWith(11);
+    expect(deps.editLabels).not.toHaveBeenCalled();
   });
 
   it("requeue: clears an active body blocker of any kind (runner) and archives the rationale (#2597)", async () => {

--- a/apps/dev/tests/state-transition.test.ts
+++ b/apps/dev/tests/state-transition.test.ts
@@ -87,6 +87,23 @@ describe("planTransition", () => {
     expect(stateRolesOf([...result])).toEqual(["ready-for-agent"]);
   });
 
+  // #2749 — a park is not terminal. The live shape: #2724/#2725 landed anyway
+  // and GitHub's PR-closes-issue closed them still wearing ready-for-human +
+  // blocked:ci, recording two delivered slices as human-escalated.
+  it("close: no park role survives, and the Spec child label is untouched", () => {
+    const current = ["ready-for-human", "blocked:ci", "running", "spec:2723", "priority:high"];
+    const p = plan(current, { kind: "close" });
+    expect(p.add).toEqual([]);
+    expect(new Set(p.remove)).toEqual(new Set(["ready-for-human", "blocked:ci", "running"]));
+    const after = current.filter((l) => !p.remove.includes(l));
+    expect(stateRolesOf(after)).toEqual([]);
+    expect(after).toEqual(["spec:2723", "priority:high"]);
+  });
+
+  it("close: refuses nothing and adds nothing on an already-clean issue", () => {
+    expect(plan(["type:task"], { kind: "close" })).toEqual({ add: [], remove: [] });
+  });
+
   it("human: plain human gate keeps no blocked modifiers", () => {
     const p = plan(["ready-for-agent", "blocked:validation"], { kind: "human" });
     expect(p.add).toEqual(["ready-for-human"]);

--- a/packages/red-castle/src/engine/issue-state-curator.test.ts
+++ b/packages/red-castle/src/engine/issue-state-curator.test.ts
@@ -84,7 +84,7 @@ describe("castle issue-state curator", () => {
 
     const result = await runIssueStateCurator({ tracker: h.tracker, store, labels, nowMs: Date.UTC(2026, 6, 23) });
 
-    expect(result).toEqual({ checked: 1, released: [11], parked: [] });
+    expect(result).toEqual({ checked: 1, released: [11], parked: [], reconciled: [] });
     expect(h.edits).toEqual([{ remove: ["quarantine"], add: ["ready-for-agent"] }]);
     expect(h.bodies[0]).toContain("<!-- afk:quarantine-release v1 issue=#11 -->");
     expect(h.bodies[0]).toContain("auto-released after coherence was restored");
@@ -99,9 +99,9 @@ describe("castle issue-state curator", () => {
     const second = await runIssueStateCurator({ tracker: h.tracker, store, labels, nowMs: 2_000 });
     const third = await runIssueStateCurator({ tracker: h.tracker, store, labels, nowMs: 3_000 });
 
-    expect(first).toEqual({ checked: 1, released: [], parked: [] });
-    expect(second).toEqual({ checked: 1, released: [], parked: [] });
-    expect(third).toEqual({ checked: 1, released: [], parked: [12] });
+    expect(first).toEqual({ checked: 1, released: [], parked: [], reconciled: [] });
+    expect(second).toEqual({ checked: 1, released: [], parked: [], reconciled: [] });
+    expect(third).toEqual({ checked: 1, released: [], parked: [12], reconciled: [] });
     // The pre-transition writer emitted a fixed `[quarantine, ready-for-agent]`
     // removal; `ready-for-agent` is absent here, so dropping it from the delta
     // is the same tracker outcome with one less no-op label (#2666).
@@ -128,8 +128,168 @@ describe("castle issue-state curator", () => {
 
     const result = await runIssueStateCurator({ tracker, store, labels, nowMs: 1_000 });
 
-    expect(result).toEqual({ checked: 2, released: [2], parked: [] });
+    expect(result).toEqual({ checked: 2, released: [2], parked: [], reconciled: [] });
     expect(tracker.editIssueLabels).toHaveBeenCalledTimes(2);
+  });
+});
+
+// #2749 — a park is treated as terminal, but it is not. A parked issue can
+// still land, and when GitHub's own PR-closes-issue mechanism performs the
+// close on a human merge, NO engine close path runs: the park role survives on
+// the closed issue and the audit reads a delivered slice as human-escalated.
+describe("closed-issue state reconcile (#2749)", () => {
+  /** A tracker with nothing quarantined and `closed` sitting in the tracker's
+   * closed set — i.e. every close here originated OUTSIDE the engine. */
+  function closedHarness(closed: TrackerIssue[]) {
+    const edits: Array<{ issue: number; remove: readonly string[]; add: readonly string[] }> = [];
+    const searches: Array<{ labels: readonly string[]; limit: number }> = [];
+    const tracker: TrackerPort = {
+      listOpenIssuesByLabel: async () => [],
+      listClosedIssuesByAnyLabel: async (names, limit) => {
+        searches.push({ labels: names, limit });
+        return closed.filter((issue) => issue.labels.some((label) => names.includes(label)));
+      },
+      isIssueClosed: async () => true,
+      editIssueLabels: async (issue, mutation) => {
+        edits.push({ issue, ...mutation });
+      },
+      editIssueBody: async () => undefined,
+      commentOnIssue: async () => undefined,
+      closeIssue: async () => undefined,
+    };
+    return { tracker, edits, searches };
+  }
+
+  it("strips the park role from an issue closed outside the engine", async () => {
+    const h = closedHarness([
+      { number: 2724, labels: ["ready-for-human", "blocked:ci", "spec:2723"], body: "" },
+      { number: 2725, labels: ["ready-for-human", "blocked:ci", "spec:2723"], body: "" },
+    ]);
+
+    const result = await runIssueStateCurator({
+      tracker: h.tracker,
+      store: memoryStore(),
+      labels,
+      nowMs: 1_000,
+    });
+
+    expect(result.reconciled).toEqual([2724, 2725]);
+    for (const edit of h.edits) {
+      expect(new Set(edit.remove)).toEqual(new Set(["ready-for-human", "blocked:ci"]));
+      expect(edit.add).toEqual([]);
+    }
+  });
+
+  it("keeps the Spec child label and every other permanent marker", async () => {
+    const h = closedHarness([
+      {
+        number: 2724,
+        labels: ["ready-for-human", "blocked:ci", "spec:2723", "type:task", "priority:high"],
+        body: "",
+      },
+    ]);
+
+    await runIssueStateCurator({ tracker: h.tracker, store: memoryStore(), labels, nowMs: 1_000 });
+
+    const removed = new Set(h.edits[0]!.remove);
+    expect(removed.has("spec:2723")).toBe(false);
+    expect(removed.has("type:task")).toBe(false);
+    expect(removed.has("priority:high")).toBe(false);
+  });
+
+  it("reads every state role in ONE bounded search, never a per-label loop", async () => {
+    const h = closedHarness([]);
+
+    await runIssueStateCurator({
+      tracker: h.tracker,
+      store: memoryStore(),
+      labels,
+      nowMs: 1_000,
+      closedReconcileLimit: 7,
+    });
+
+    expect(h.searches).toEqual([
+      {
+        labels: [
+          "ready-for-agent",
+          "ready-for-human",
+          "needs-triage",
+          "needs-info",
+          "quarantine",
+          "blocked:dependency",
+        ],
+        limit: 7,
+      },
+    ]);
+  });
+
+  it("writes nothing for a closed issue that already carries no state", async () => {
+    const h = closedHarness([{ number: 40, labels: ["ready-for-human"], body: "" }]);
+    // The search is label-driven, so a clean issue never lists; assert the
+    // planner's no-op guard directly by handing back one anyway.
+    h.tracker.listClosedIssuesByAnyLabel = async () => [
+      { number: 41, labels: ["spec:2723"], body: "" },
+    ];
+
+    const result = await runIssueStateCurator({
+      tracker: h.tracker,
+      store: memoryStore(),
+      labels,
+      nowMs: 1_000,
+    });
+
+    expect(result.reconciled).toEqual([]);
+    expect(h.edits).toEqual([]);
+  });
+
+  it("no-ops when the tracker adapter cannot list closed issues", async () => {
+    const tracker: TrackerPort = {
+      listOpenIssuesByLabel: async () => [],
+      isIssueClosed: async () => true,
+      editIssueLabels: vi.fn(async () => undefined),
+      commentOnIssue: async () => undefined,
+      closeIssue: async () => undefined,
+    };
+
+    const result = await runIssueStateCurator({ tracker, store: memoryStore(), labels, nowMs: 1 });
+
+    expect(result.reconciled).toEqual([]);
+    expect(tracker.editIssueLabels).not.toHaveBeenCalled();
+  });
+
+  it("keeps a read fault issue-local: the quarantine sweep still reports", async () => {
+    const h = closedHarness([]);
+    h.tracker.listClosedIssuesByAnyLabel = async () => {
+      throw new Error("tracker search unavailable");
+    };
+
+    const result = await runIssueStateCurator({
+      tracker: h.tracker,
+      store: memoryStore(),
+      labels,
+      nowMs: 1_000,
+    });
+
+    expect(result).toEqual({ checked: 0, released: [], parked: [], reconciled: [] });
+  });
+
+  it("keeps one unwritable issue from stopping the rest of the batch", async () => {
+    const h = closedHarness([
+      { number: 50, labels: ["ready-for-human"], body: "" },
+      { number: 51, labels: ["ready-for-human"], body: "" },
+    ]);
+    h.tracker.editIssueLabels = async (issue) => {
+      if (issue === 50) throw new Error("one issue is unwritable");
+    };
+
+    const result = await runIssueStateCurator({
+      tracker: h.tracker,
+      store: memoryStore(),
+      labels,
+      nowMs: 1_000,
+    });
+
+    expect(result.reconciled).toEqual([51]);
   });
 });
 
@@ -178,7 +338,7 @@ describe("curator label deltas are byte-identical to the pre-transition writer",
       labels,
       nowMs: 1_000,
     });
-    expect(result).toEqual({ checked: 1, released: [], parked: [] });
+    expect(result).toEqual({ checked: 1, released: [], parked: [], reconciled: [] });
     expect(h.edits).toEqual([]);
   });
 

--- a/packages/red-castle/src/engine/issue-state-curator.ts
+++ b/packages/red-castle/src/engine/issue-state-curator.ts
@@ -2,10 +2,21 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
 import type { EnginePaths } from "./paths.js";
-import { isRefused, planTransition, type StateTransitionLabels } from "./state-transition.js";
+import {
+  isRefused,
+  planTransition,
+  stateRoleLabels,
+  type StateTransitionLabels,
+} from "./state-transition.js";
 import type { TrackerIssue, TrackerPort } from "./tracker/port.js";
 
 export const ISSUE_CURATOR_RECHECK_LIMIT = 3;
+
+/** How many closed issues one sweep reconciles. The set is self-draining — a
+ * reconciled issue no longer carries a state role, so it never lists again —
+ * and the sweep repeats, so a bounded batch costs a bounded number of tracker
+ * writes per pass without leaving residue behind permanently. */
+export const ISSUE_CURATOR_CLOSED_RECONCILE_LIMIT = 25;
 
 export interface IssueCuratorFailureRecord {
   readonly count: number;
@@ -29,12 +40,17 @@ export interface IssueStateCuratorInput {
   readonly labels: StateTransitionLabels;
   readonly nowMs?: number;
   readonly recheckLimit?: number;
+  /** Closed issues reconciled per sweep; see
+   * {@link ISSUE_CURATOR_CLOSED_RECONCILE_LIMIT}. */
+  readonly closedReconcileLimit?: number;
 }
 
 export interface IssueStateCuratorResult {
   readonly checked: number;
   readonly released: number[];
   readonly parked: number[];
+  /** Closed issues whose surviving engine state was stripped (#2749). */
+  readonly reconciled: number[];
 }
 
 /** The lifecycle labels that must not coexist with `quarantine`. Sourced from
@@ -125,6 +141,50 @@ export function createFileIssueCuratorStore(paths: EnginePaths): IssueCuratorSto
   };
 }
 
+/**
+ * Strip the engine state a CLOSED issue has no business carrying (#2749).
+ *
+ * A park is not terminal: parked work still lands — by a human merge of its PR,
+ * by a later retake, by an adopt-branch landing — and when GitHub's own
+ * PR-closes-issue mechanism performs the close, no engine code path is watching
+ * to reconcile what the park left behind. The result is a closed issue recorded
+ * as human-escalated forever, which is exactly the one-state-role violation
+ * ADR 0122 rule 5 exists to make unconstructible. The DECISION is this sweep's;
+ * the WRITE is the transition API's, so permanent markers (`spec:N`, `type:*`,
+ * `priority:*`) are untouched by construction — the `close` plan names only
+ * state roles, `running`, blocked reasons, and `req:*` edges.
+ */
+async function reconcileClosedIssues(
+  input: IssueStateCuratorInput,
+  limit: number,
+): Promise<number[]> {
+  const list = input.tracker.listClosedIssuesByAnyLabel;
+  if (!list) return [];
+  let closed: TrackerIssue[];
+  try {
+    closed = await list.call(input.tracker, stateRoleLabels(input.labels), limit);
+  } catch {
+    // A tracker read fault costs this pass, never the sweep; the next one retries.
+    return [];
+  }
+
+  const reconciled: number[] = [];
+  for (const issue of closed) {
+    const plan = planTransition(issue.labels, { kind: "close" }, input.labels);
+    if (isRefused(plan) || (plan.remove.length === 0 && plan.add.length === 0)) continue;
+    try {
+      await input.tracker.editIssueLabels(issue.number, {
+        remove: [...plan.remove],
+        add: [...plan.add],
+      });
+      reconciled.push(issue.number);
+    } catch {
+      // One unwritable issue keeps its residue; the next sweep retries it.
+    }
+  }
+  return reconciled;
+}
+
 export async function runIssueStateCurator(
   input: IssueStateCuratorInput,
 ): Promise<IssueStateCuratorResult> {
@@ -182,6 +242,13 @@ export async function runIssueStateCurator(
     }
   }
 
+  const reconciled = await reconcileClosedIssues(
+    input,
+    input.closedReconcileLimit ?? ISSUE_CURATOR_CLOSED_RECONCILE_LIMIT,
+  );
+  // A closed issue is done being judged: its re-check counter is dead weight.
+  for (const issue of reconciled) delete failedChecks[String(issue)];
+
   await input.store.write({ version: 1, failedChecks });
-  return { checked: issues.length, released, parked };
+  return { checked: issues.length, released, parked, reconciled };
 }

--- a/packages/red-castle/src/engine/state-transition.test.ts
+++ b/packages/red-castle/src/engine/state-transition.test.ts
@@ -85,6 +85,30 @@ describe("planTransition", () => {
     expect(p.appendBody).toBe("two state roles");
   });
 
+  // #2749 — a park is not terminal. Parked work still lands (human merge,
+  // retake, adopt-branch landing) and the close must not preserve the park.
+  it("close: leaves ZERO state roles and keeps the permanent markers", () => {
+    // The live #2724/#2725 shape: delivered slices closed by GitHub's own
+    // PR-closes-issue on a human merge, still wearing their park.
+    const current = ["ready-for-human", "blocked:ci", "running", "spec:2723", "type:task"];
+    const p = plan(current, { kind: "close" });
+    expect(p.add).toEqual([]);
+    expect(new Set(p.remove)).toEqual(new Set(["ready-for-human", "blocked:ci", "running"]));
+    const after = current.filter((l) => !p.remove.includes(l));
+    expect(stateRolesOf(after, labels)).toEqual([]);
+    expect(after).toEqual(["spec:2723", "type:task"]);
+  });
+
+  it("close: consumes dependency edges alongside the wait state", () => {
+    const p = plan(["blocked:dependency", "req:12", "req:3"], { kind: "close" });
+    expect(p.add).toEqual([]);
+    expect(p.remove).toEqual(["blocked:dependency", "req:3", "req:12"]);
+  });
+
+  it("close: is a no-op mutation on an issue that carries no state", () => {
+    expect(plan(["spec:2723", "type:task"], { kind: "close" })).toEqual({ add: [], remove: [] });
+  });
+
   it("honours a host vocabulary that differs from the defaults", () => {
     const custom: StateTransitionLabels = { ...labels, ready: "queued", reqPrefix: "needs#" };
     const p = planTransition(["queued", "needs#5"], { kind: "promote" }, custom);

--- a/packages/red-castle/src/engine/state-transition.ts
+++ b/packages/red-castle/src/engine/state-transition.ts
@@ -73,7 +73,14 @@ export type StateTransition =
   /** Back to the triage queue — the state a fresh or bounced issue sits in. */
   | { kind: "triage" }
   /** Close-cascade promotion: consume the `req:*` edges and re-queue. */
-  | { kind: "promote" };
+  | { kind: "promote" }
+  /** Terminal: the issue is closed, so it carries NO state role at all. Every
+   * role, the `running` projection, the blocked-reason modifiers, and the
+   * `req:*` edges go; permanent markers (`spec:N`, `type:*`, `priority:*`)
+   * stay. A park is not terminal — parked work still lands, by a human merge,
+   * a retake, or an adopt-branch landing — and the state the park left behind
+   * must not outlive the close (#2749). */
+  | { kind: "close" };
 
 export interface TransitionPlan {
   readonly add: readonly string[];
@@ -102,8 +109,12 @@ export function stateRolesOf(
   return stateRoleLabels(labels).filter((role) => current.includes(role));
 }
 
-function targetRole(t: StateTransition, labels: StateTransitionLabels): string {
+/** The single role the transition targets, or `null` for the terminal `close`
+ * transition — the one state an issue reaches by carrying no role at all. */
+function targetRole(t: StateTransition, labels: StateTransitionLabels): string | null {
   switch (t.kind) {
+    case "close":
+      return null;
     case "queue":
     case "promote":
       return labels.ready;
@@ -119,6 +130,16 @@ function targetRole(t: StateTransition, labels: StateTransitionLabels): string {
     case "triage":
       return labels.needsTriage;
   }
+}
+
+/** Dependency edges in numeric issue order, so the emitted mutation is
+ * deterministic regardless of the tracker's label listing order. */
+function sortedReqLabels(
+  reqLabels: readonly string[],
+  labels: StateTransitionLabels,
+): string[] {
+  const byIssue = (l: string): number => Number(l.slice(labels.reqPrefix.length)) || 0;
+  return [...reqLabels].sort((a, b) => byIssue(a) - byIssue(b));
 }
 
 /**
@@ -155,12 +176,13 @@ export function planTransition(
   const add = new Set<string>();
   const remove = new Set<string>();
 
-  // Every other state role present goes; the target role arrives.
+  // Every other state role present goes; the target role arrives. `close`
+  // targets no role, so every role present goes and nothing arrives.
   for (const role of stateRoleLabels(labels)) {
     if (role === target) continue;
     if (current.includes(role)) remove.add(role);
   }
-  if (!current.includes(target)) add.add(target);
+  if (target !== null && !current.includes(target)) add.add(target);
 
   // Leaving execution: `running` never survives a state transition.
   if (current.includes(labels.running)) remove.add(labels.running);
@@ -181,28 +203,31 @@ export function planTransition(
         if (!current.includes(label)) add.add(label);
       }
       break;
-    case "promote": {
+    case "promote":
+    case "close":
+      // Both consume the dependency edges: `promote` because the blockers
+      // closed, `close` because a closed issue holds no engine state at all.
       for (const l of blockedPresent) remove.add(l);
-      // Numeric req order keeps the emitted mutation deterministic regardless
-      // of the tracker's label listing order.
-      const byIssue = (l: string): number => Number(l.slice(labels.reqPrefix.length)) || 0;
-      for (const l of [...reqLabels].sort((a, b) => byIssue(a) - byIssue(b))) remove.add(l);
+      for (const l of sortedReqLabels(reqLabels, labels)) remove.add(l);
       break;
-    }
     default:
       for (const l of blockedPresent) remove.add(l);
       break;
   }
 
-  // Invariant proof: replay the mutation and demand exactly one state role.
+  // Invariant proof: replay the mutation and demand exactly one state role —
+  // or, for the terminal `close`, exactly none.
+  const expectedRoles = transition.kind === "close" ? 0 : 1;
   const result = new Set(current);
   for (const l of remove) result.delete(l);
   for (const l of add) result.add(l);
   const roles = stateRolesOf([...result], labels);
-  if (roles.length !== 1) {
+  if (roles.length !== expectedRoles) {
     return {
       refused: true,
-      reason: `transition would leave ${roles.length} state roles (${roles.join(", ") || "none"})`,
+      reason:
+        `transition would leave ${roles.length} state roles ` +
+        `(${roles.join(", ") || "none"}), expected ${expectedRoles}`,
     };
   }
 

--- a/packages/red-castle/src/engine/tracker/github/adapter.test.ts
+++ b/packages/red-castle/src/engine/tracker/github/adapter.test.ts
@@ -173,4 +173,52 @@ describe("GitHub tracker adapter", () => {
       ],
     ]);
   });
+
+  // #2749 — the external-close reconcile read. Repeated `--label` flags are
+  // ANDed by gh, so every state role must ride ONE `label:"a","b"` search
+  // qualifier: a per-label loop on a timer-driven sweep is a flow bug.
+  it("reads closed issues for any state role in one bounded search", async () => {
+    const calls: string[][] = [];
+    const gh: GhExec = async (args) => {
+      calls.push([...args]);
+      return JSON.stringify([
+        { number: 2724, body: "B", labels: [{ name: "ready-for-human" }, { name: "spec:2723" }] },
+      ]);
+    };
+    const tracker = createGitHubTrackerAdapter({ gh, repo: "owner/repo" });
+
+    await expect(
+      tracker.listClosedIssuesByAnyLabel?.(["ready-for-human", "blocked:dependency"], 25),
+    ).resolves.toEqual([{ number: 2724, body: "B", labels: ["ready-for-human", "spec:2723"] }]);
+
+    expect(calls).toEqual([
+      [
+        "issue",
+        "list",
+        "--state",
+        "closed",
+        "--search",
+        'label:"ready-for-human","blocked:dependency"',
+        "--json",
+        "number,body,labels",
+        "--limit",
+        "25",
+        "--repo",
+        "owner/repo",
+      ],
+    ]);
+  });
+
+  it("skips the tracker call entirely for an empty label set", async () => {
+    const calls: string[][] = [];
+    const tracker = createGitHubTrackerAdapter({
+      gh: async (args) => {
+        calls.push([...args]);
+        return "";
+      },
+    });
+
+    await expect(tracker.listClosedIssuesByAnyLabel?.([], 25)).resolves.toEqual([]);
+    expect(calls).toEqual([]);
+  });
 });

--- a/packages/red-castle/src/engine/tracker/github/adapter.ts
+++ b/packages/red-castle/src/engine/tracker/github/adapter.ts
@@ -96,6 +96,27 @@ export function createGitHubTrackerAdapter(
       );
       return parseIssueList(stdout);
     },
+    async listClosedIssuesByAnyLabel(labelNames, limit) {
+      if (labelNames.length === 0) return [];
+      // ONE search request covers every role: repeated `--label` flags are ANDed
+      // by gh, while a single `label:"a","b"` search qualifier is the OR this
+      // read needs (#2749). Never a per-label loop — the sweep runs on a timer.
+      const stdout = await gh(
+        withRepo([
+          "issue",
+          "list",
+          "--state",
+          "closed",
+          "--search",
+          `label:${labelNames.map((name) => `"${name}"`).join(",")}`,
+          "--json",
+          "number,body,labels",
+          "--limit",
+          String(limit),
+        ]),
+      );
+      return parseIssueList(stdout);
+    },
     async isIssueClosed(issue) {
       const stdout = await gh(
         withRepo(["issue", "view", String(issue), "--json", "state"]),

--- a/packages/red-castle/src/engine/tracker/port.ts
+++ b/packages/red-castle/src/engine/tracker/port.ts
@@ -47,6 +47,16 @@ export interface TrackerClaimDecision {
 export interface TrackerPort {
   createIssue?(spec: TrackerIssueCreateSpec): Promise<number>;
   listOpenIssuesByLabel(label: string): Promise<TrackerIssue[]>;
+  /** CLOSED issues carrying ANY of `labels`, at most `limit` of them — the
+   * external-close reconcile lane (#2749). A close performed outside the
+   * engine (GitHub's own PR-closes-issue on a human merge) leaves whatever
+   * state the issue was in; this read is how the curator finds it. Optional so
+   * read-only and legacy adapters keep working — the reconcile pass no-ops when
+   * the adapter omits it. */
+  listClosedIssuesByAnyLabel?(
+    labels: readonly string[],
+    limit: number,
+  ): Promise<TrackerIssue[]>;
   isIssueClosed(issue: number): Promise<boolean>;
   editIssueLabels(issue: number, mutation: TrackerLabelMutation): Promise<void>;
   /** Replace an issue body while preserving the tracker abstraction. Optional


### PR DESCRIPTION
Automated AFK landing for #2749. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2749

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787875558&installation_model_id=20659&pr_number=2761&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2761&signature=9641bd053afb010e58477300db59ed64e1c82aa005ada8f29302454f7e97caf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->