### PR TITLE
fix: green main — allowlist the overhead ledger's legacy JSON decode

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -162,6 +162,11 @@
    "classification": "external",
    "reason": "TOON migration accepts legacy JSON inputs.",
    "moveKey": "e57f5cae7679"
+  },
+  {
+   "id": "apps/rsp/src/overhead-budget.ts#json-parse-file-read#e1e4e966b7a7",
+   "classification": "migrate",
+   "reason": "Overhead ledger decoder accepts legacy JSON while TOON ledgers roll out; every write already emits TOON."
   }
  ]
 }


### PR DESCRIPTION
## main is red

Since `dafeb3925` (the merge of #2758), every workspace CI run fails:

```
toon JSON file I/O guard > ratchets the live apps/packages JSON file I/O allowlist
AssertionError: expected [ Array(1) ] to deeply equal []
+ "unallowlisted json-parse-file-read apps/rsp/src/overhead-budget.ts#json-parse-file-read#e1e4e966b7a7
   at apps/rsp/src/overhead-budget.ts:408:12 JSON.parse(raw)"
```

I merged #2758, so this is mine to clear. Reproduced locally against `origin/main` before and after the fix.

## Why four PRs looked broken and were not

`#2756`, `#2759`, `#2760` and `#2761` each failed on this identical assertion. They were **not** four independent worker mistakes — every branch built on the red main inherits the failure regardless of its own diff. Worth stating plainly, because the obvious reading was "the workers keep breaking the TOON rule".

## The fix

`decodeLedger` (`apps/rsp/src/overhead-budget.ts:406-412`) tries `JSON.parse` and falls back to `decode`, so an overhead ledger written by an older build still loads. That is the legitimate legacy-read shape the allowlist exists for — and the ledger's **write** path already emits TOON (`encode(...)` at `:401`), so the mandate holds for everything produced from now on.

Allowlisted with `classification: migrate` and that reason. `pnpm -C apps/dev exec vitest run tests/toon-json-guard.test.ts` → 4/4 green.

## Related

`#2762` covers why this class reaches CI at all: a worker's cone-scoped gate never runs the repo-wide ratchet, so the constraint fires only after the correction budget is spent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787876477&installation_model_id=20659&pr_number=2763&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2763&signature=92f46570d29e610240bbf717ab3c942ac1b6ba39710bd61612ed882e5418d673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->