### PR TITLE
fix: #2762 cone-scoped worker gates skip the repo-wide TOON ratchet, so the same failure lands in CI three times in an hour

### DIFF
--- a/.changeset/cone-gate-repo-invariants.md
+++ b/.changeset/cone-gate-repo-invariants.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The AFK gate now runs the repo-wide invariant suites in every cone-scoped run (#2762). A worker that changed one package validated only that package's cone, so a ratchet that constrains the whole repo but lives in a single package — the TOON JSON file-I/O allowlist in `apps/dev` — never ran in the loop where the agent could still satisfy it; it first fired in root CI, after the correction budget was spent, which is how the same assertion failed three PRs in one hour. The suites are declared in `apps/dev/src/core/repo-invariants.ts` and run after the scoped checks whenever the cone does not already cover them, via `pnpm -C apps/dev test:invariants`. A missing script emits a visible `skipped` record rather than a silent drop, a repo without the owning package stays silent, and the baseline probe re-runs the invariant script itself instead of the owning package's full suite. The ratchet's own failure is now actionable: it names each offending path, the allowlist file that classifies it, and the recurring cause — a `*.toon` path written with `JSON.stringify`, which the decoder tolerates at runtime and policy does not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,13 @@ Use `rsp wait` as the standard waiting primitive for PR checks, GitHub Actions r
 
 Use raw commands when exact stdout/stderr is the behavior under test, when a wrapper does not support the command shape, or when resolving low-level git conflicts where every byte matters. In repos whose `.red/config.yaml` sets `rsp.enabled: true`, the pre-exec hook may rewrite simple supported commands to their `rsp` wrappers; absent that opt-in, call `rsp` explicitly. The ambient host instructions that replace legacy per-host terminal guidance are tracked in #1415 and should ship from the generated `apps/rsp/generated/AMBIENT-SKILL.md` surface.
 
+## Repo-wide invariants
+
+Some constraints span the whole repo but live in one package. They run in **every** gate run — including a cone-scoped one that touched a single package — via `pnpm -C apps/dev test:invariants`. The declared list is `apps/dev/src/core/repo-invariants.ts`; adding one is a single entry there plus the script it names.
+
+- **Write a `*.toon` file with the TOON encoder, never `JSON.stringify`.** The decoder sniffs JSON-or-TOON and accepts both, so a JSON-written `.toon` looks correct locally and is wrong by policy.
+- **New JSON file I/O under `apps/` or `packages/` must be fixed or classified.** The ratchet (`apps/dev/tests/toon-json-guard.test.ts`) names the offending path and the allowlist file, `.red/contracts/toon-json-file-io-allowlist.json`, when it fails. An `external` entry is a permanent exception and needs a one-line reason.
+
 ## Change report vs upstream
 
 **Whenever you modify, add, or remove a skill that came from `mattpocock/skills`, record it in `CHANGES.md`**.

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -13,7 +13,8 @@
     "bundle:red-fetch": "esbuild ../../packages/shared/entrypoint-cli.ts --bundle --minify --platform=node --format=esm --target=node22 --define:__ENTRYPOINT_ROLE__='\"fetch\"' --outfile=../../plugins/dev/hooks/red-fetch.mjs --banner:js=\"import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",
     "bundle:entrypoint": "esbuild ../../packages/shared/entrypoint-cli.ts --bundle --minify --platform=node --format=esm --target=node22 --define:__ENTRYPOINT_ROLE__='\"run:dev\"' --outfile=../../plugins/dev/skills/engineering/afk/bin/afk.mjs --banner:js=\"import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",
     "build": "pnpm run bundle && pnpm run bundle:mcp && pnpm run bundle:red-fetch && pnpm run bundle:entrypoint",
-    "test": "NODE_OPTIONS=--max-old-space-size=3072 vitest run"
+    "test": "NODE_OPTIONS=--max-old-space-size=3072 vitest run",
+    "test:invariants": "NODE_OPTIONS=--max-old-space-size=3072 vitest run tests/toon-json-guard.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "catalog:",

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -30,6 +30,7 @@ import {
   type QuarantineEntry,
 } from "./quarantine.js";
 
+import { pendingInvariantSuites } from "./repo-invariants.js";
 import { type ValidationScope } from "./validation-scope.js";
 
 /** Result of a single executed command. Mirrors a child-process completion. */
@@ -488,6 +489,13 @@ export interface FeedbackCheck {
   label: string;
   /** Real package scope (repo-relative dir, `"."` for root, `""` for no-package). Used by the baseline probe. */
   scope: string;
+  /**
+   * The package script actually executed, when it differs from `script` — the
+   * repo-wide invariant suites run a dedicated script (`test:invariants`) while
+   * still classifying as a `test` check. The baseline probe must re-run THIS
+   * script, not the package's full `test`.
+   */
+  runScript?: string;
   status: ValidationStatus;
   record: ValidationRecord;
 }
@@ -587,6 +595,8 @@ export interface BaselineCheckRef {
   name: string;
   script: FeedbackScript;
   scope: string;
+  /** The script to actually execute, when it differs from `script` (see {@link FeedbackCheck.runScript}). */
+  runScript?: string;
 }
 
 export interface BaselineFailureEvidence {
@@ -667,10 +677,11 @@ async function runChecksForBaseline(
   env: NodeJS.ProcessEnv,
 ): Promise<Map<string, BaselineCheckResult>> {
   const out = new Map<string, BaselineCheckResult>();
-  for (const { name, script, scope } of refs) {
-    if (!layout.hasScript(scope, script)) continue;
+  for (const { name, script, scope, runScript } of refs) {
+    const command = runScript ?? script;
+    if (!layout.hasScript(scope, command)) continue;
     const dir = scopeDir(baselineWorktree, scope);
-    const result = await exec(["pnpm", "-C", dir, script], { env });
+    const result = await exec(["pnpm", "-C", dir, command], { env });
     if (result.code === 0) {
       out.set(name, { status: "passed" });
       continue;
@@ -872,12 +883,50 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     push({ name, script: "typecheck", label, scope, status, record });
   }
 
+  // Repo-wide invariant suites (#2762). A cone-scoped run validates the changed
+  // packages only, so an invariant that spans the repo but lives in ONE package
+  // (the TOON JSON file-I/O ratchet in apps/dev) never runs in the loop where the
+  // agent could still satisfy it — it first fires in root CI, after the worker
+  // reported DONE. Run every declared suite the cone does not already cover, and
+  // emit a visible `skipped` record when the script is absent rather than
+  // silently dropping the invariant.
+  for (const suite of pendingInvariantSuites(scopes)) {
+    const name = suite.name;
+    const label = scopeLabel(suite.scope);
+    // The owning package is absent → this repo does not carry the invariant at
+    // all (the gate also runs against consumer repos). Nothing to say.
+    if (!layout.hasPackage(suite.scope)) continue;
+    if (!layout.hasScript(suite.scope, suite.script)) {
+      const record = buildValidationRecord({
+        name,
+        status: "skipped",
+        summary: `invariant suite script missing (${suite.scope} has no \`${suite.script}\`)`,
+      });
+      push({ name, script: "test", label, scope: suite.scope, status: "skipped", record });
+      continue;
+    }
+    const dir = scopeDir(worktree, suite.scope);
+    const command = `pnpm -C ${dir} ${suite.script}`;
+    const start = now();
+    const result = await exec(["pnpm", "-C", dir, suite.script], { env: subprocessEnv });
+    const durationMs = now() - start;
+    const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
+    if (status === "failed") failed = true;
+    const output = joinCommandOutput(result.stdout, result.stderr);
+    const summary =
+      status === "failed"
+        ? `repo-wide invariant — ${suite.why}: ${outputSummary(status, output)}`.slice(0, 1000)
+        : outputSummary(status, output);
+    const record = buildValidationRecord({ name, status, command, exitCode: result.code, durationMs, summary });
+    push({ name, script: "test", label, scope: suite.scope, runScript: suite.script, status, record });
+  }
+
   // AFK runner improvement: baseline probe for pre-existing failures. Only
   // triggered when the gate failed AND a baseline worktree was supplied.
   if (failed && baselineWorktree) {
     const failing = checks
       .filter((c) => c.status === "failed")
-      .map((c) => ({ name: c.name, script: c.script, scope: c.scope }));
+      .map((c) => ({ name: c.name, script: c.script, scope: c.scope, runScript: c.runScript }));
     const baselineResults = await runChecksForBaseline(exec, baselineWorktree, failing, layout, now, subprocessEnv);
     const baselineFailing = [...baselineResults.entries()]
       .filter(([, result]) => result.status === "failed")

--- a/apps/dev/src/core/repo-invariants.ts
+++ b/apps/dev/src/core/repo-invariants.ts
@@ -1,0 +1,68 @@
+// repo-invariants — repo-wide invariant suites that every gate run must include,
+// no matter how narrow the cone (issue #2762).
+//
+// A cone-scoped gate runs the test/typecheck/lint/build of the changed packages
+// and their dependents. That is correct for package-local behavior and WRONG for
+// a repo-wide invariant: the TOON JSON file-I/O ratchet lives in `apps/dev` but
+// constrains every file under `apps/` and `packages/`. A worker that edits only
+// `apps/rsp` validates green, reports DONE, and the ratchet first fires in root
+// CI — after the correction budget is spent. The invariant was enforced outside
+// the only loop that could still satisfy it.
+//
+// The fix is a small, declared list: suites that run in EVERY gate run whose cone
+// does not already cover them. Adding an invariant is a one-entry change here
+// plus the package script it names.
+
+/** One repo-wide invariant suite: a package script that constrains the whole repo. */
+export interface RepoInvariantSuite {
+  /** Canonical check name, surfaced in the sidecar record (`invariants:<slug>`). */
+  name: string;
+  /** Repo-relative dir of the package that owns the suite (never `"."`). */
+  scope: string;
+  /** The package script that runs ONLY the invariant suites (not the full suite). */
+  script: string;
+  /** One line on what the suite enforces — read by a human triaging a park. */
+  why: string;
+}
+
+/**
+ * The declared repo-wide invariant suites. Keep this list SHORT and CHEAP: every
+ * entry runs on every cone-scoped gate run, so a slow suite taxes every landing.
+ * A suite belongs here only when it enforces a constraint that spans packages.
+ */
+export const REPO_INVARIANT_SUITES: readonly RepoInvariantSuite[] = [
+  {
+    name: "invariants:toon-json-io",
+    scope: "apps/dev",
+    script: "test:invariants",
+    why: "the TOON JSON file-I/O ratchet constrains every file under apps/ and packages/, but its suite lives in apps/dev",
+  },
+];
+
+/**
+ * True when `scopes` already runs `suite` as part of the ordinary scoped loop —
+ * either the whole-workspace scope (`"."`, which runs the workspace-wide turbo
+ * commands) or the suite's own package is in the cone (its `test` script covers
+ * the invariant suite too). PURE.
+ */
+export function scopesCoverInvariantSuite(
+  scopes: readonly string[],
+  suite: RepoInvariantSuite,
+): boolean {
+  return scopes.includes(".") || scopes.includes(suite.scope);
+}
+
+/**
+ * The invariant suites a cone-scoped run must add on top of its scoped checks —
+ * every declared suite the cone does not already cover. PURE.
+ *
+ * An empty `scopes` (a repo with no package.json anywhere) yields no suites: a
+ * no-package repo has no script to run.
+ */
+export function pendingInvariantSuites(
+  scopes: readonly string[],
+  suites: readonly RepoInvariantSuite[] = REPO_INVARIANT_SUITES,
+): RepoInvariantSuite[] {
+  if (scopes.length === 0) return [];
+  return suites.filter((suite) => !scopesCoverInvariantSuite(scopes, suite));
+}

--- a/apps/dev/src/core/toon-json-guard.ts
+++ b/apps/dev/src/core/toon-json-guard.ts
@@ -133,6 +133,26 @@ export function formatToonJsonGuardViolations(report: ToonJsonGuardReport): stri
   return violations;
 }
 
+/**
+ * The failure message the ratchet assertion carries (issue #2762). A bare
+ * `expect(violations).toEqual([])` prints `expected [ Array(1) ] to deeply equal
+ * []` — the diff names neither the offending path nor what to do about it, so a
+ * worker reading its own gate output learns only that something broke. This
+ * spells out each violation, the allowlist file that classifies it, and the
+ * `.toon`-written-as-JSON shape that is the recurring cause. PURE.
+ */
+export function formatToonJsonGuardFailureMessage(violations: readonly string[]): string {
+  if (violations.length === 0) return "";
+  const plural = violations.length === 1 ? "site" : "sites";
+  return [
+    `TOON JSON file-I/O ratchet: ${violations.length} unresolved ${plural}.`,
+    ...violations.map((violation) => `  - ${violation}`),
+    `Fix each site (write TOON via @reddb-io/toon) or classify it in ${ALLOWLIST_PATH}.`,
+    "A `*.toon` path written with JSON.stringify is a violation even though the decoder" +
+      " sniffs JSON-or-TOON and accepts it at runtime — it looks correct locally and is wrong by policy.",
+  ].join("\n");
+}
+
 export function readToonJsonAllowlist(root: string): ToonJsonAllowlistEntry[] {
   const allowlistPath = join(root, ALLOWLIST_PATH);
   if (!existsSync(allowlistPath)) return [];

--- a/apps/dev/tests/repo-invariants.test.ts
+++ b/apps/dev/tests/repo-invariants.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import {
+  runFeedback,
+  type Exec,
+  type ExecResult,
+  type PackageLayout,
+} from "../src/core/feedback.js";
+import {
+  pendingInvariantSuites,
+  REPO_INVARIANT_SUITES,
+  scopesCoverInvariantSuite,
+} from "../src/core/repo-invariants.js";
+import {
+  collectToonJsonIoFindingsFromFiles,
+  formatToonJsonGuardFailureMessage,
+  formatToonJsonGuardViolations,
+} from "../src/core/toon-json-guard.js";
+import {
+  computeValidationScope,
+  scopesForValidationScope,
+  type WorkspaceGraph,
+} from "../src/core/validation-scope.js";
+
+const INVARIANT = REPO_INVARIANT_SUITES[0]!;
+
+/** The live workspace shape the gate sees: apps/rsp is a leaf, apps/dev owns the ratchet. */
+const GRAPH: WorkspaceGraph = {
+  packages: [
+    { dir: "apps/dev", dependsOn: ["packages/shared"] },
+    { dir: "apps/rsp", dependsOn: [] },
+    { dir: "packages/shared", dependsOn: [] },
+  ],
+};
+
+function fakeLayout(input: {
+  packages: readonly string[];
+  scripts?: Record<string, readonly string[]>;
+}): PackageLayout {
+  const packages = new Set(input.packages);
+  const scripts = input.scripts ?? {};
+  return {
+    hasPackage: (scope) => packages.has(scope),
+    hasScript: (scope, script) => (scripts[scope] ?? []).includes(script),
+  };
+}
+
+function fakeExec(
+  rules: Array<{ match: (argv: string[]) => boolean; result: Partial<ExecResult> }> = [],
+): { exec: Exec; calls: string[][] } {
+  const calls: string[][] = [];
+  const exec: Exec = async (argv) => {
+    calls.push(argv);
+    for (const rule of rules) {
+      if (rule.match(argv)) return { code: 0, stdout: "", stderr: "", ...rule.result };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  return { exec, calls };
+}
+
+const clock = (step = 5): (() => number) => {
+  let t = 0;
+  return () => (t += step);
+};
+
+const joined = (calls: string[][]): string[] => calls.map((c) => c.join(" "));
+
+/** The live layout: every package declares the four scripts; apps/dev also owns the invariant script. */
+const LIVE_LAYOUT = fakeLayout({
+  packages: [".", "apps/dev", "apps/rsp", "packages/shared"],
+  scripts: {
+    ".": ["test", "typecheck", "lint", "build"],
+    "apps/dev": ["test", "typecheck", "build", INVARIANT.script],
+    "apps/rsp": ["test", "typecheck", "build"],
+    "packages/shared": ["test", "typecheck", "build"],
+  },
+});
+
+describe("pendingInvariantSuites", () => {
+  it("is pending for a cone that excludes the owning package", () => {
+    expect(pendingInvariantSuites(["apps/rsp"])).toEqual([INVARIANT]);
+  });
+
+  it("is already covered when the cone contains the owning package or the whole workspace", () => {
+    expect(scopesCoverInvariantSuite(["apps/dev", "apps/rsp"], INVARIANT)).toBe(true);
+    expect(scopesCoverInvariantSuite(["."], INVARIANT)).toBe(true);
+    expect(pendingInvariantSuites(["apps/dev"])).toEqual([]);
+    expect(pendingInvariantSuites(["."])).toEqual([]);
+  });
+
+  it("has nothing to run in a repo with no packages", () => {
+    expect(pendingInvariantSuites([])).toEqual([]);
+  });
+
+  it("stays silent in a repo that does not carry the owning package", async () => {
+    const layout = fakeLayout({
+      packages: [".", "src"],
+      scripts: { ".": ["test"], src: ["test"] },
+    });
+    const { exec } = fakeExec();
+    const result = await runFeedback(exec, {
+      worktree: "/wt",
+      scopes: ["src"],
+      layout,
+      now: clock(),
+    });
+
+    expect(result.checks.map((c) => c.name)).not.toContain(INVARIANT.name);
+  });
+});
+
+describe("cone-scoped gate runs the repo-wide invariant suites (#2762)", () => {
+  it("runs the ratchet for a single-package cone that does not include apps/dev", async () => {
+    const scope = computeValidationScope(["apps/rsp/src/proxy.ts"], LIVE_LAYOUT, GRAPH);
+    const scopes = scopesForValidationScope(scope);
+    expect(scopes).toEqual(["apps/rsp"]); // the cone genuinely excludes apps/dev
+
+    const { exec, calls } = fakeExec();
+    const result = await runFeedback(exec, {
+      worktree: "/wt",
+      scopes,
+      layout: LIVE_LAYOUT,
+      now: clock(),
+    });
+
+    expect(joined(calls)).toContain(`pnpm -C /wt/${INVARIANT.scope} ${INVARIANT.script}`);
+    expect(result.checks.map((c) => c.name)).toContain(INVARIANT.name);
+    expect(result.ok).toBe(true);
+  });
+
+  it("does not run the invariant script twice when the cone already covers its package", async () => {
+    const { exec, calls } = fakeExec();
+    await runFeedback(exec, {
+      worktree: "/wt",
+      scopes: ["apps/dev"],
+      layout: LIVE_LAYOUT,
+      now: clock(),
+    });
+
+    expect(joined(calls)).not.toContain(`pnpm -C /wt/${INVARIANT.scope} ${INVARIANT.script}`);
+  });
+
+  it("records a visible skip — never a silent drop — when the invariant script is missing", async () => {
+    const layout = fakeLayout({
+      packages: [".", "apps/dev", "apps/rsp"],
+      scripts: { ".": ["typecheck"], "apps/dev": ["test"], "apps/rsp": ["test"] },
+    });
+    const { exec } = fakeExec();
+    const result = await runFeedback(exec, {
+      worktree: "/wt",
+      scopes: ["apps/rsp"],
+      layout,
+      now: clock(),
+    });
+
+    const check = result.checks.find((c) => c.name === INVARIANT.name);
+    expect(check?.status).toBe("skipped");
+    expect(check?.record.summary).toContain(INVARIANT.script);
+  });
+});
+
+describe("the failing shape reaches the worker's own gate, not just root CI (#2762)", () => {
+  it("fails a cone-scoped apps/rsp gate on a new `.toon` write built with JSON.stringify", async () => {
+    // The real guard, on the real shape: a `.toon` path written with
+    // JSON.stringify. The runtime decoder sniffs JSON-or-TOON and accepts it,
+    // so nothing in apps/rsp's own suite would ever notice.
+    const source = `
+      import { writeFileSync } from "node:fs";
+      import { join } from "node:path";
+
+      export function persistLedger(root: string, ledger: unknown) {
+        writeFileSync(join(root, "overhead.toon"), JSON.stringify(ledger), "utf8");
+      }
+    `;
+    const findings = collectToonJsonIoFindingsFromFiles([
+      { relativePath: "apps/rsp/src/overhead-ledger.ts", sourceText: source },
+    ]);
+    const guardOutput = formatToonJsonGuardFailureMessage(
+      formatToonJsonGuardViolations({ findings, allowlist: [] }),
+    );
+    expect(guardOutput).toContain("apps/rsp/src/overhead-ledger.ts");
+
+    const scopes = scopesForValidationScope(
+      computeValidationScope(["apps/rsp/src/overhead-ledger.ts"], LIVE_LAYOUT, GRAPH),
+    );
+    const { exec } = fakeExec([
+      {
+        // Only the invariant suite is red — apps/rsp's own suite is green, which
+        // is exactly the state that shipped the same failure to CI three times.
+        match: (argv) => argv.includes(INVARIANT.script),
+        result: { code: 1, stdout: `FAIL tests/toon-json-guard.test.ts\n${guardOutput}` },
+      },
+    ]);
+
+    const result = await runFeedback(exec, {
+      worktree: "/wt",
+      scopes,
+      layout: LIVE_LAYOUT,
+      now: clock(),
+    });
+
+    expect(result.ok).toBe(false);
+    const check = result.checks.find((c) => c.name === INVARIANT.name);
+    expect(check?.status).toBe("failed");
+    // The park/sidecar summary names the offending path and the allowlist file.
+    expect(check?.record.summary).toContain("repo-wide invariant");
+    expect(check?.record.summary).toContain("apps/rsp/src/overhead-ledger.ts");
+  });
+
+  it("re-runs the invariant script — not the owning package's full suite — on the baseline probe", async () => {
+    const scopes = ["apps/rsp"];
+    const { exec, calls } = fakeExec([
+      { match: (argv) => argv.includes(INVARIANT.script), result: { code: 1, stdout: "violation" } },
+    ]);
+
+    await runFeedback(exec, {
+      worktree: "/wt",
+      scopes,
+      layout: LIVE_LAYOUT,
+      now: clock(),
+      baselineWorktree: "/base",
+    });
+
+    expect(joined(calls)).toContain(`pnpm -C /base/${INVARIANT.scope} ${INVARIANT.script}`);
+    expect(joined(calls)).not.toContain(`pnpm -C /base/${INVARIANT.scope} test`);
+  });
+});

--- a/apps/dev/tests/toon-json-guard.test.ts
+++ b/apps/dev/tests/toon-json-guard.test.ts
@@ -4,9 +4,11 @@ import { describe, expect, it } from "vitest";
 import {
   collectToonJsonGuardReport,
   collectToonJsonIoFindingsFromFiles,
+  formatToonJsonGuardFailureMessage,
   formatToonJsonGuardViolations,
   type ToonJsonAllowlistEntry,
 } from "../src/core/toon-json-guard.js";
+import { ALLOWLIST_PATH } from "../src/core/shared-gate.js";
 
 const ROOT = join(import.meta.dirname, "..", "..", "..");
 const DEV_SRC = join(import.meta.dirname, "..", "src");
@@ -14,8 +16,38 @@ const DEV_SRC = join(import.meta.dirname, "..", "src");
 describe("toon JSON file I/O guard", () => {
   it("ratchets the live apps/packages JSON file I/O allowlist", async () => {
     const report = await collectToonJsonGuardReport(ROOT);
+    const violations = formatToonJsonGuardViolations(report);
 
-    expect(formatToonJsonGuardViolations(report)).toEqual([]);
+    // The message is the point: a bare array diff tells a worker nothing it can
+    // act on, so carry the offending paths + the allowlist file into the failure.
+    expect(violations, formatToonJsonGuardFailureMessage(violations)).toEqual([]);
+  });
+
+  it("names the offending path and the allowlist file in the failure message", () => {
+    // The exact recurring shape (#2762): a `.toon` file written with
+    // JSON.stringify. The runtime decoder sniffs JSON-or-TOON and accepts it,
+    // so it looks correct locally and is wrong by policy.
+    const source = `
+      import { writeFileSync } from "node:fs";
+      import { join } from "node:path";
+
+      export function persistLedger(root: string, ledger: unknown) {
+        writeFileSync(join(root, "ledger.toon"), JSON.stringify(ledger), "utf8");
+      }
+    `;
+    const findings = collectToonJsonIoFindingsFromFiles([
+      { relativePath: "apps/rsp/src/ledger.ts", sourceText: source },
+    ]);
+    expect(findings).toHaveLength(1);
+
+    const message = formatToonJsonGuardFailureMessage(
+      formatToonJsonGuardViolations({ findings, allowlist: [] }),
+    );
+
+    expect(message).toContain("apps/rsp/src/ledger.ts");
+    expect(message).toContain(ALLOWLIST_PATH);
+    expect(message).toContain("JSON.stringify");
+    expect(formatToonJsonGuardFailureMessage([])).toBe("");
   });
 
   it("rejects a new stack-owned JSON.stringify file write until allowlisted", () => {


### PR DESCRIPTION
Automated AFK landing for #2762. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2762

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787878537&installation_model_id=20659&pr_number=2764&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2764&signature=4399a5b75ad53e6140522e47fb69c4d0fe646219f76b9a82b80b93e2a7c90a6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->