### PR TITLE
chore: #2729 A repeated failure signature escalates the tier instead of repeating it

### DIFF
--- a/.changeset/reseed-repeat-escalates-tier.md
+++ b/.changeset/reseed-repeat-escalates-tier.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A REPEATED failure signature now escalates the model tier instead of spending another round at the one that just failed (#2729, ADR 0129 decision 6). The trigger used to be the failure itself, and only ever for a simple-tier semantic one: the first red feedback gate on a `simple`-classified Ticket bought `complex` whether or not the round had learned anything. It is now the repeat. `decideTierEscalation` compares the round's failure signature (#2724) against the previous round's and escalates one step along `validate → simple → complex → think` only when they are equal — a changed signature, including a failure set that merely shrank, is progress and is re-instructed at the tier that produced it. The ladder terminates rather than saturating: a repeat on the dearest tier has nothing left to buy and falls through to gate correction and, once that is spent, to the uniform park. The escalation draws the `tier` sub-cap, never the gate's, so gate correction keeps its own share while the tier moves.

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -161,6 +161,7 @@ import {
   withoutGateOutstanding,
   withoutReviewOutstanding,
 } from "./reseed-handoff.js";
+import { decideTierEscalation } from "./tier-escalation.js";
 import { failureSignature } from "../failure-signature.js";
 import {
   EMPTY_CORRECTION_LEDGER,
@@ -667,7 +668,16 @@ export async function processIssue(
     driftEligible?: boolean;
     /** Tier escalation only — which tier failed and which one now runs. */
     tiers?: { from: string; to: string };
+    /** The round's failure signature, when the caller already derived it to
+     * decide something (the tier escalation does). Absent, it is derived here
+     * from `sidecar` — one key either way. */
+    signature?: string;
   }
+  /** The failure signature of the round that just failed: the gate's sidecar
+   * plus whatever the review still has outstanding, which is exactly what the
+   * history line's repeat count and the tier escalation both key off. */
+  const roundSignature = (sidecar: readonly string[] | undefined): string =>
+    failureSignature({ sidecar, findings: reseedOutstanding.review?.findings ?? [] });
   /** The single Re-seed request path. Every caller that re-instructs the
    * implementer IN PLACE — same Worker, same Worktree, same branch — comes
    * through here: it checks the ceiling and the cause's sub-cap or reservation,
@@ -696,10 +706,7 @@ export async function processIssue(
     // outstanding rides along untouched.
     reseedOutstanding = noteReseedSignature(
       withGateOutstanding(reseedOutstanding, { gate, validation: req.validation, drift }),
-      failureSignature({
-        sidecar: req.sidecar,
-        findings: reseedOutstanding.review?.findings ?? [],
-      }),
+      req.signature ?? roundSignature(req.sidecar),
     );
     const gateSpend = reseedSpend.gate ?? 0;
     if (req.trigger === "tier-escalation") {
@@ -1134,22 +1141,35 @@ export async function processIssue(
         ? `${formatValidationScope(feedback.validationScope)}\n`
         : "";
       const validationText = `${scopeHeader}${feedback.sidecar.join("\n")}`;
-      // A repeated failure buys a HIGHER tier rather than another round at the
-      // tier that just failed (ADR 0129). It draws the `tier` sub-cap, so gate
-      // correction keeps its own share — the mute this replaced cost a Ticket
-      // its whole gate budget for one tier bump.
-      if (!isInfra && activeTaskClass === "simple") {
+      // A REPEATED failure buys a HIGHER tier rather than another round at the
+      // tier that just failed (ADR 0129 decision 6, #2729). The trigger is the
+      // repeat, not the failure: a round that failed a different way is progress
+      // and is re-instructed at the tier that produced it. It draws the `tier`
+      // sub-cap, so gate correction keeps its own share — the mute this replaced
+      // cost a Ticket its whole gate budget for one tier bump.
+      const roundKey = roundSignature(feedback.sidecar);
+      const escalationDecision = isInfra
+        ? ({ escalate: false, refusal: "no-repeat" } as const)
+        : decideTierEscalation({
+            tier: activeTaskClass,
+            previousSignature: reseedOutstanding.signature,
+            signature: roundKey,
+            budget: reseedBudget,
+            spend: reseedSpend,
+          });
+      if (escalationDecision.escalate) {
         const escalation = await requestReseed({
           trigger: "tier-escalation",
           validation: validationText,
           sidecar: feedback.sidecar,
-          tiers: { from: "simple", to: "complex" },
+          signature: roundKey,
+          tiers: { from: escalationDecision.from, to: escalationDecision.to },
         });
         if (escalation === "hook-aborted") {
           return await abortAfterClaim(deps, input, branch, base, hooksFired, "pre_attempt");
         }
         if (escalation === "granted") {
-          activeTaskClass = "complex";
+          activeTaskClass = escalationDecision.to;
           continue;
         }
       }

--- a/apps/dev/src/core/process-issue/tier-escalation.ts
+++ b/apps/dev/src/core/process-issue/tier-escalation.ts
@@ -1,0 +1,83 @@
+// tier-escalation — a repeated failure signature buys a HIGHER tier rather than
+// another round at the tier that just failed (ADR 0129 decision 6, issue #2729).
+//
+// Repeating the same tier against the same failure is the lowest-yield round
+// available: nothing about the round changed, so nothing about its outcome is
+// expected to. The tier is the one variable that moves the chance of
+// converging, so the repeat is what buys it — and it buys it from the `tier`
+// sub-cap, never the gate's, which is what keeps gate correction whole while the
+// escalation happens (ADR 0129, defect 1).
+//
+// The trigger is a REPEAT, not a failure. The previous round's failure signature
+// (#2724) equal to this round's means the round failed the same way; anything
+// else — a different failure set, or a set that merely shrank — is progress, and
+// progress is re-instructed at the tier that produced it.
+//
+// Pure and total: the caller owns the signatures, the budget, and the tally.
+
+import { AFK_MODEL_TIERS, type AfkModelTier } from "../config.js";
+import { EMPTY_FAILURE_SIGNATURE } from "../failure-signature.js";
+import { reseedDraw, type ReseedBudget, type ReseedSpend } from "./reseed-budget.js";
+
+/** The escalation ladder, `validate → simple → complex → think`. It IS the
+ * model-tier vocabulary in its declared order — a second ordering would be a
+ * second truth about which tier is dearer. */
+export const RESEED_TIER_LADDER: readonly AfkModelTier[] = AFK_MODEL_TIERS;
+
+/** The dearest tier on the ladder. A repeat here has nothing left to buy. */
+export const RESEED_TOP_TIER: AfkModelTier = RESEED_TIER_LADDER[RESEED_TIER_LADDER.length - 1]!;
+
+/** One step up the ladder, or `undefined` at the top. Mirror of
+ * `downgradeAfkModelTier`, and deliberately NOT saturating: the top tier
+ * returning itself would read as a granted escalation that changed nothing. */
+export function escalateAfkModelTier(tier: AfkModelTier): AfkModelTier | undefined {
+  const idx = RESEED_TIER_LADDER.indexOf(tier);
+  if (idx < 0 || idx >= RESEED_TIER_LADDER.length - 1) return undefined;
+  return RESEED_TIER_LADDER[idx + 1]!;
+}
+
+/** Why an escalation was refused. `no-repeat` — the failure moved, so the tier
+ * stays put; `ladder-top` — the repeat is already on the dearest tier, so the
+ * ladder terminates and the caller parks; the remaining three are
+ * {@link reseedDraw}'s own refusals, passed through unchanged so a reader can
+ * tell a budget refusal from a policy one. */
+export type TierEscalationRefusal = "no-repeat" | "ladder-top" | "sub-cap" | "ceiling" | "reservation";
+
+export type TierEscalationDecision =
+  | { readonly escalate: true; readonly from: AfkModelTier; readonly to: AfkModelTier }
+  | { readonly escalate: false; readonly refusal: TierEscalationRefusal };
+
+export interface TierEscalationInput {
+  /** The tier the round that just failed ran on. */
+  readonly tier: AfkModelTier;
+  /** The signature of the PREVIOUS round, or {@link EMPTY_FAILURE_SIGNATURE}
+   * when this is the first round to fail. */
+  readonly previousSignature: string;
+  /** The signature of the round that just failed. */
+  readonly signature: string;
+  readonly budget: ReseedBudget;
+  readonly spend?: ReseedSpend;
+}
+
+/**
+ * Decide whether this round's failure escalates the tier.
+ *
+ * The three refusals are checked in the order a reader would ask them: did the
+ * failure actually repeat, is there a dearer tier to buy, and can the `tier`
+ * sub-cap pay for it. A round with nothing identifiable failing is never a
+ * repeat — an empty signature equal to an empty signature says the two rounds
+ * were both unreadable, not that they failed the same way.
+ */
+export function decideTierEscalation(input: TierEscalationInput): TierEscalationDecision {
+  const signature = input.signature || EMPTY_FAILURE_SIGNATURE;
+  const repeated = signature !== EMPTY_FAILURE_SIGNATURE && signature === input.previousSignature;
+  if (!repeated) return { escalate: false, refusal: "no-repeat" };
+
+  const to = escalateAfkModelTier(input.tier);
+  if (!to) return { escalate: false, refusal: "ladder-top" };
+
+  const draw = reseedDraw(input.budget, "tier", input.spend ?? {});
+  if (!draw.allowed) return { escalate: false, refusal: draw.refusal ?? "sub-cap" };
+
+  return { escalate: true, from: input.tier, to };
+}

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -127,6 +127,11 @@ export interface HarnessOptions {
   /** Scripted per-feedback-gate outcomes. Each feedback run executes the four
    * standard scripts; this controls the aggregate pass/fail for each run. */
   feedbackResults?: boolean[];
+  /** Scripted per-feedback-gate FAILURE SETS: entry `n` names the scripts that
+   * fail on feedback run `n` (`[]` = a green run). Where `feedbackResults` only
+   * says whether a run failed, this says HOW — which is what moves the failure
+   * signature (#2724) between rounds. Takes precedence when both are set. */
+  feedbackFailures?: readonly string[][];
   /** Operator-declared backpressure commands (afk.backpressure, #430). When set,
    * the backpressure gate runs after feedback against the worker branch. */
   backpressureCommands?: string[];
@@ -563,9 +568,15 @@ export function harness(opts: HarnessOptions = {}): {
       }
       const feedbackRun = Math.floor(pnpmCalls / 4);
       pnpmCalls += 1;
-      const ok = opts.feedbackResults
-        ? (opts.feedbackResults[feedbackRun] ?? opts.feedbackResults.at(-1) ?? true)
-        : opts.feedbackOk !== false;
+      const failures = opts.feedbackFailures
+        ? (opts.feedbackFailures[feedbackRun] ?? opts.feedbackFailures.at(-1) ?? [])
+        : undefined;
+      const script = Array.isArray(args) ? String(args[args.length - 1] ?? "") : "";
+      const ok = failures
+        ? !failures.includes(script)
+        : opts.feedbackResults
+          ? (opts.feedbackResults[feedbackRun] ?? opts.feedbackResults.at(-1) ?? true)
+          : opts.feedbackOk !== false;
       return { code: ok ? 0 : 1, stdout: "", stderr: "" };
     },
     layout: {

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -150,11 +150,14 @@ describe("processIssue — feedback fail", () => {
     expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:validation"))).toBe(true);
   });
 
-  it("retries a simple-classified feedback failure once on the complex tier, then lands when green", async () => {
+  it("escalates the tier on a REPEATED failure signature, then lands when green (#2729)", async () => {
     const tiers: Array<{ runner: string; taskClass: string | undefined }> = [];
     const { deps, input, trace } = harness({
       outcome: "done",
-      feedbackResults: [false, true],
+      // Round 1 fails; round 2 fails IDENTICALLY → the repeat buys the tier;
+      // round 3 is green.
+      feedbackResults: [false, false, true],
+      stallConvergenceBudget: 1,
       classifyIssue: async () => "simple",
       resolveTier: (runner, taskClass) => {
         tiers.push({ runner, taskClass });
@@ -164,32 +167,44 @@ describe("processIssue — feedback fail", () => {
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("done");
-    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.runAgentCalls).toHaveLength(3);
     expect(tiers).toEqual([
+      { runner: "claude", taskClass: "simple" },
       { runner: "claude", taskClass: "simple" },
       { runner: "claude", taskClass: "complex" },
     ]);
-    expect(trace.runAgentCalls[0]?.model).toBe("claude-simple-model");
-    expect(trace.runAgentCalls[1]?.model).toBe("claude-complex-model");
-    expect(trace.runAgentCalls[1]?.effort).toBe("medium");
+    // Round 2 repeats the tier because nothing repeated yet; round 3 does not.
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("<afk-gate-correction>");
+    expect(trace.runAgentCalls[2]?.handoffContent).toContain("<tier-escalation>");
+    expect(trace.runAgentCalls[2]?.model).toBe("claude-complex-model");
+    expect(trace.runAgentCalls[2]?.effort).toBe("medium");
     expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+"]);
     expect(trace.closed).toEqual([9]);
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "done" }]);
-    expect(result.hooksFired).toEqual([
-      "pre_worktree",
-      "pre_attempt",
-      "post_attempt",
-      "pre_feedback",
-      "on_baseline_probe", // gate 1 FAILED → the baseline probe ran
-      "post_feedback",
-      "on_feedback_classify", // SEMANTIC → simple→complex retry
-      "pre_attempt", // the complex-tier retry
-      "post_attempt",
-      "pre_feedback",
-      "post_feedback", // gate 2 passed → no baseline probe
-      "pre_merge",
-      "post_merge",
-    ]);
+  });
+
+  it("leaves the tier alone while the failure signature keeps changing (#2729)", async () => {
+    const tiers: Array<{ runner: string; taskClass: string | undefined }> = [];
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      // Four failing checks, then ONE — a different failure set, so a different
+      // signature — then the same one again, which is the repeat.
+      feedbackFailures: [["test", "typecheck", "lint", "build"], ["test"], ["test"], []],
+      stallConvergenceBudget: 2,
+      classifyIssue: async () => "simple",
+      resolveTier: (runner, taskClass) => {
+        tiers.push({ runner, taskClass });
+        return { model: `${runner}-${taskClass}-model`, effort: "high" };
+      },
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(tiers.map((t) => t.taskClass)).toEqual(["simple", "simple", "simple", "complex"]);
+    // The two rounds that follow a CHANGED signature are gate corrections.
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("<afk-gate-correction>");
+    expect(trace.runAgentCalls[2]?.handoffContent).toContain("<afk-gate-correction>");
+    expect(trace.runAgentCalls[3]?.handoffContent).toContain("<tier-escalation>");
   });
 
   it("does not escalate a simple-classified attempt when feedback passes", async () => {
@@ -211,11 +226,12 @@ describe("processIssue — feedback fail", () => {
     expect(trace.runAgentCalls[0]?.model).toBe("claude-simple-model");
   });
 
-  it("bounds simple feedback escalation to one complex retry", async () => {
+  it("bounds the escalation to one tier step, then parks on the repeat it cannot buy past", async () => {
     const tiers: Array<{ runner: string; taskClass: string | undefined }> = [];
     const { deps, input, trace } = harness({
       outcome: "done",
-      feedbackResults: [false, false, true],
+      feedbackResults: [false, false, false, true],
+      stallConvergenceBudget: 1,
       classifyIssue: async () => "simple",
       resolveTier: (runner, taskClass) => {
         tiers.push({ runner, taskClass });
@@ -225,8 +241,11 @@ describe("processIssue — feedback fail", () => {
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("feedback-failed");
-    expect(trace.runAgentCalls).toHaveLength(2);
+    // Gate round, then the escalation the repeat bought — and no third round:
+    // the `tier` sub-cap is one deep and the gate's share is spent.
+    expect(trace.runAgentCalls).toHaveLength(3);
     expect(tiers).toEqual([
+      { runner: "claude", taskClass: "simple" },
       { runner: "claude", taskClass: "simple" },
       { runner: "claude", taskClass: "complex" },
     ]);
@@ -1626,10 +1645,11 @@ describe("processIssue — one Re-seed request path (#2727, ADR 0129)", () => {
   it("still Re-seeds a failing gate after a tier escalation — the escalation no longer mutes it", async () => {
     const { deps, input, trace } = harness({
       outcome: "done",
-      // simple fails → tier escalation; complex fails → gate Re-seed; fails again → park.
-      feedbackResults: [false, false, false],
+      // fails → gate Re-seed; fails identically → tier escalation; fails on the
+      // complex tier with a CHANGED signature → one more gate Re-seed; park.
+      feedbackFailures: [["test"], ["test"], ["lint"], ["lint"]],
       classifyIssue: async () => "simple",
-      stallConvergenceBudget: 1,
+      stallConvergenceBudget: 2,
     });
 
     const result = await processIssue(deps, input);
@@ -1637,10 +1657,15 @@ describe("processIssue — one Re-seed request path (#2727, ADR 0129)", () => {
     expect(result.outcome).toBe("feedback-failed");
     // Before the unified request path the tier escalation set a flag that
     // refused EVERY subsequent gate correction, so this run stopped at 2.
-    expect(trace.runAgentCalls).toHaveLength(3);
-    expect(trace.runAgentCalls[1]?.handoffContent).toContain("<tier-escalation>");
-    expect(trace.runAgentCalls[2]?.handoffContent).toContain("<afk-gate-correction>");
-    expect(reseeds(trace).map((e) => e.payload?.trigger)).toEqual(["tier-escalation", "gate-stage"]);
+    expect(trace.runAgentCalls).toHaveLength(4);
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("<afk-gate-correction>");
+    expect(trace.runAgentCalls[2]?.handoffContent).toContain("<tier-escalation>");
+    expect(trace.runAgentCalls[3]?.handoffContent).toContain("<afk-gate-correction>");
+    expect(reseeds(trace).map((e) => e.payload?.trigger)).toEqual([
+      "gate-stage",
+      "tier-escalation",
+      "gate-stage",
+    ]);
     expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:validation"))).toBe(true);
   });
 

--- a/apps/dev/tests/tier-escalation.test.ts
+++ b/apps/dev/tests/tier-escalation.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  RESEED_TIER_LADDER,
+  RESEED_TOP_TIER,
+  decideTierEscalation,
+  escalateAfkModelTier,
+} from "../src/core/process-issue/tier-escalation.js";
+import {
+  AFK_RESEED_BUDGET,
+  recordReseedDraw,
+  reseedDraw,
+  type ReseedCause,
+  type ReseedSpend,
+} from "../src/core/process-issue/reseed-budget.js";
+import { EMPTY_FAILURE_SIGNATURE, failureSignature } from "../src/core/failure-signature.js";
+import { AFK_MODEL_TIERS } from "../src/core/config.js";
+
+/** Spend `n` rounds on the named causes, so a test reads as a sequence of draws
+ * rather than a hand-written tally. */
+function spend(...draws: readonly ReseedCause[]): ReseedSpend {
+  return draws.reduce<ReseedSpend>((acc, cause) => recordReseedDraw(acc, cause), {});
+}
+
+/** A sidecar line for one failing check, so the tests key off REAL signatures
+ * rather than hand-written digests. */
+function failing(name: string, summary?: string): string {
+  return JSON.stringify({
+    schema: "red.afk.validation.v1",
+    name,
+    status: "failed",
+    ...(summary ? { summary } : {}),
+  });
+}
+
+describe("Re-seed tier ladder (ADR 0129 decision 6)", () => {
+  it("climbs the model-tier vocabulary in its declared order", () => {
+    expect(RESEED_TIER_LADDER).toEqual(AFK_MODEL_TIERS);
+    expect(escalateAfkModelTier("validate")).toBe("simple");
+    expect(escalateAfkModelTier("simple")).toBe("complex");
+    expect(escalateAfkModelTier("complex")).toBe("think");
+  });
+
+  it("terminates at the top tier rather than saturating on it", () => {
+    expect(RESEED_TOP_TIER).toBe("think");
+    expect(escalateAfkModelTier(RESEED_TOP_TIER)).toBeUndefined();
+  });
+});
+
+describe("Re-seed tier escalation — the trigger is a REPEAT (#2729)", () => {
+  it("raises the tier when consecutive rounds carry an identical signature", () => {
+    const signature = failureSignature({ sidecar: [failing("test:apps/dev", "failing: a | b — 2 failed")] });
+
+    expect(
+      decideTierEscalation({
+        tier: "simple",
+        previousSignature: signature,
+        signature,
+        budget: AFK_RESEED_BUDGET,
+      }),
+    ).toEqual({ escalate: true, from: "simple", to: "complex" });
+  });
+
+  it("leaves the tier alone when the signature changed", () => {
+    const previous = failureSignature({ sidecar: [failing("test:apps/dev", "failing: a | b — 2 failed")] });
+    const current = failureSignature({ sidecar: [failing("lint:apps/dev")] });
+
+    expect(previous).not.toBe(current);
+    expect(
+      decideTierEscalation({
+        tier: "simple",
+        previousSignature: previous,
+        signature: current,
+        budget: AFK_RESEED_BUDGET,
+      }),
+    ).toEqual({ escalate: false, refusal: "no-repeat" });
+  });
+
+  it("leaves the tier alone on the first failing round, which repeats nothing", () => {
+    expect(
+      decideTierEscalation({
+        tier: "simple",
+        previousSignature: EMPTY_FAILURE_SIGNATURE,
+        signature: failureSignature({ sidecar: [failing("test:apps/dev")] }),
+        budget: AFK_RESEED_BUDGET,
+      }),
+    ).toEqual({ escalate: false, refusal: "no-repeat" });
+  });
+
+  it("leaves the tier alone when a shrinking failure set only LOOKS like a repeat", () => {
+    const previous = failureSignature({ sidecar: [failing("test:apps/dev"), failing("lint:apps/dev")] });
+    const current = failureSignature({ sidecar: [failing("test:apps/dev")] });
+
+    expect(
+      decideTierEscalation({ tier: "simple", previousSignature: previous, signature: current, budget: AFK_RESEED_BUDGET }),
+    ).toEqual({ escalate: false, refusal: "no-repeat" });
+  });
+
+  it("never reads two unidentifiable rounds as a repeat", () => {
+    expect(
+      decideTierEscalation({
+        tier: "simple",
+        previousSignature: EMPTY_FAILURE_SIGNATURE,
+        signature: EMPTY_FAILURE_SIGNATURE,
+        budget: AFK_RESEED_BUDGET,
+      }),
+    ).toEqual({ escalate: false, refusal: "no-repeat" });
+  });
+});
+
+describe("Re-seed tier escalation — the ladder terminates", () => {
+  it("parks a repeat on the top tier rather than escalating past it", () => {
+    const signature = failureSignature({ sidecar: [failing("test:apps/dev")] });
+
+    expect(
+      decideTierEscalation({
+        tier: RESEED_TOP_TIER,
+        previousSignature: signature,
+        signature,
+        budget: AFK_RESEED_BUDGET,
+      }),
+    ).toEqual({ escalate: false, refusal: "ladder-top" });
+  });
+});
+
+describe("Re-seed tier escalation — it draws the TIER sub-cap", () => {
+  const signature = failureSignature({ sidecar: [failing("test:apps/dev")] });
+  const repeat = (tier: "simple" | "complex", spent: ReseedSpend) =>
+    decideTierEscalation({
+      tier,
+      previousSignature: signature,
+      signature,
+      budget: AFK_RESEED_BUDGET,
+      spend: spent,
+    });
+
+  it("escalates on its own share while gate corrections are already spent", () => {
+    const spent = spend("gate", "gate");
+
+    expect(repeat("simple", spent)).toEqual({ escalate: true, from: "simple", to: "complex" });
+  });
+
+  it("leaves the gate's share whole once the escalation is drawn", () => {
+    const spent = spend("tier");
+
+    expect(spent.gate ?? 0).toBe(0);
+    expect(reseedDraw(AFK_RESEED_BUDGET, "gate", spent).allowed).toBe(true);
+  });
+
+  it("refuses a second escalation on the TIER sub-cap, gate share untouched", () => {
+    const spent = spend("tier");
+
+    expect(repeat("complex", spent)).toEqual({ escalate: false, refusal: "sub-cap" });
+    expect(reseedDraw(AFK_RESEED_BUDGET, "gate", spent).allowed).toBe(true);
+  });
+
+  it("refuses when the only round left is the review's reservation", () => {
+    // Ceiling 4, three gate rounds spent: the tier sub-cap is untouched, but the
+    // single remaining round is held for the review and invisible to the tier.
+    const spent = spend("gate", "gate", "gate");
+
+    expect(AFK_RESEED_BUDGET.subCaps.tier - (spent.tier ?? 0)).toBe(1);
+    expect(repeat("simple", spent)).toEqual({ escalate: false, refusal: "reservation" });
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2729. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2729

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787880675&installation_model_id=20659&pr_number=2765&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2765&signature=21950591ef56b3a06bdab0bd362d2cd358aab896af3aae9f39278c863be62082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->