### PR TITLE
chore: #2731 Lazily-minted draft PR and one edited Issue comment carry the trail

### DIFF
--- a/.changeset/reseed-trail-draft-pr-and-one-comment.md
+++ b/.changeset/reseed-trail-draft-pr-and-one-comment.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The Re-seed correction trail became visible without paying a pull request per attempt (#2731, ADR 0129). The first Re-seed of any cause opens a DRAFT pull request carrying the trail; an attempt that never re-seeds opens none and lands exactly as it did before, so a churning fleet no longer burns a CI run to document the majority of attempts that need no documentation. The Issue carries ONE comment upserted in place through the existing edit-comment primitive — five rounds are one notification rather than five — and the draft mirrors that same body plus the `Closes #N` link. Landing reuses the existing draft and marks it ready via `gh pr ready`, which is a no-op on a pull request that was never a draft; opening a second pull request is a defect, not a fallback. Both surfaces are best-effort projections: the Attempt record stays the source of truth, so a forge that refuses a post, a patch, or the draft itself costs fidelity on a projection and never a Re-seed round.

--- a/apps/dev/src/commands/run/ports/gh.ts
+++ b/apps/dev/src/commands/run/ports/gh.ts
@@ -74,6 +74,26 @@ export function buildClaimGhPort(ghCtx: GhContext): NonNullable<ProcessIssueDeps
 }
 
 /**
+ * Re-seed trail port (#2731): ONE Issue comment upserted in place. The post goes
+ * through the numeric-id REST surface because the edit needs that id — `gh issue
+ * comment` does not expose it — and the edit reuses the existing edit-comment
+ * primitive. Both are best-effort: the trail is a projection of the Attempt
+ * record, so a refused post or patch costs fidelity, never a Re-seed round.
+ */
+export function buildReseedTrailPort(ghCtx: GhContext): NonNullable<ProcessIssueDeps["reseedTrailGh"]> {
+  return {
+    postComment: async (issue, body) => {
+      try {
+        return await ghx.postClaimComment(ghCtx, issue, body);
+      } catch {
+        return undefined;
+      }
+    },
+    editComment: (commentId, body) => ghx.editComment(ghCtx, commentId, body),
+  };
+}
+
+/**
  * PR-review ports: the two evidence surfaces that post through `ReviewGh` rather
  * than the plain issue API. Same single context as the issue port.
  */

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -58,7 +58,7 @@ import { deriveActivity } from "./activity.js";
 import { makeImplementerRunAgent } from "./implementer-run-agent.js";
 import { makeAgentConflictResolver, makeMechanicalConflictResolver } from "./reconcile.js";
 import { runLinkedSubagent } from "./linked-subagent.js";
-import { buildClaimGhPort, buildGhPort, buildReviewPorts } from "./ports/gh.js";
+import { buildClaimGhPort, buildGhPort, buildReseedTrailPort, buildReviewPorts } from "./ports/gh.js";
 import { buildGitPorts } from "./ports/git.js";
 import { buildFsPort } from "./ports/fs.js";
 import { buildHooks } from "./ports/hooks.js";
@@ -267,6 +267,8 @@ export function buildProcessDeps({
   return {
     gh: buildGhPort(ghCtx),
     claimGh: buildClaimGhPort(ghCtx),
+    // The Re-seed trail's Issue half (#2731): one comment, edited in place.
+    reseedTrailGh: buildReseedTrailPort(ghCtx),
     // Cross-host stale-claim recovery (#627, ADR 0066): a claim whose owner
     // stopped refreshing past `cadence × (tolerance + 1)` is presumed dead and
     // released by this sweep. The clock is sampled once per issue at deps build;

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -1381,27 +1381,91 @@ async function ensurePr(
 ): Promise<number | undefined> {
   const { repo, branch, target, n, title } = input;
   const prTitle = input.mergeTitle ?? `merge: #${n} ${title}`;
-  let prNumber = await listOpenPr(exec, repo, branch, target);
-  if (prNumber === undefined) {
-    const create = await exec([
-      "gh",
-      "-R",
-      repo,
-      "pr",
-      "create",
-      "--base",
-      target,
-      "--head",
-      branch,
-      "--title",
-      scrubOutbound(prTitle),
-      "--body",
-      scrubOutbound(`${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.\n\nCloses #${n}`),
-    ]);
-    if (create.code !== 0) return undefined;
-    prNumber = await listOpenPr(exec, repo, branch, target);
+  const existing = await listOpenPr(exec, repo, branch, target);
+  if (existing !== undefined) {
+    // A REUSED pull request may be the draft the first Re-seed minted (#2731),
+    // and landing is precisely the moment it stops being a draft. `gh pr ready`
+    // is a no-op on a PR that is already ready, so mark unconditionally rather
+    // than paying a state read to decide. Best-effort: a forge that refuses the
+    // flip must not abort a landing that is otherwise green.
+    await exec(["gh", "-R", repo, "pr", "ready", String(existing)]);
+    return existing;
   }
-  return prNumber;
+  const create = await exec([
+    "gh",
+    "-R",
+    repo,
+    "pr",
+    "create",
+    "--base",
+    target,
+    "--head",
+    branch,
+    "--title",
+    scrubOutbound(prTitle),
+    "--body",
+    scrubOutbound(`${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.\n\nCloses #${n}`),
+  ]);
+  if (create.code !== 0) return undefined;
+  return await listOpenPr(exec, repo, branch, target);
+}
+
+/** Inputs for the lazily-minted draft pull request, {@link openDraftPr}. */
+export interface OpenDraftPrInput {
+  /** `owner/repo` slug passed to `gh -R`. */
+  repo: string;
+  /** Attempt branch (PR head, already pushed to the remote). */
+  branch: string;
+  /** Pinned target branch (PR base). */
+  target: string;
+  /** Issue number, for the PR title and the `Closes #N` auto-close link. */
+  n: number;
+  /** Issue title, for the PR title. */
+  title: string;
+  /** The trail body the draft mirrors. */
+  body: string;
+}
+
+/**
+ * Mint the DRAFT pull request that carries the correction trail (ADR 0129,
+ * #2731). Opened lazily at the first Re-seed of any cause: an attempt that never
+ * re-seeds pays no pull request and no CI run, which is the whole reason the
+ * mint is lazy rather than fired at the first commit.
+ *
+ * Idempotent by the same rule {@link ensurePr} uses — an open PR for this
+ * head/base IS the draft, whether this worker minted it or a predecessor did.
+ * Landing then reuses it and marks it ready; opening a second is a defect.
+ */
+export async function openDraftPr(exec: Exec, input: OpenDraftPrInput): Promise<number | undefined> {
+  const { repo, branch, target, n, title, body } = input;
+  const existing = await listOpenPr(exec, repo, branch, target);
+  if (existing !== undefined) return existing;
+  const create = await exec([
+    "gh",
+    "-R",
+    repo,
+    "pr",
+    "create",
+    "--draft",
+    "--base",
+    target,
+    "--head",
+    branch,
+    "--title",
+    scrubOutbound(`merge: #${n} ${title}`),
+    "--body",
+    scrubOutbound(body),
+  ]);
+  if (create.code !== 0) return undefined;
+  return await listOpenPr(exec, repo, branch, target);
+}
+
+/** Mirror the trail body onto the draft (#2731). Best-effort: the Issue comment
+ * and the Attempt record already carry the trail, so a failed mirror costs
+ * fidelity on a projection, never the round. */
+export async function editPrBody(exec: Exec, repo: string, prNumber: number, body: string): Promise<boolean> {
+  const r = await exec(["gh", "-R", repo, "pr", "edit", String(prNumber), "--body", scrubOutbound(body)]);
+  return r.code === 0;
 }
 
 /** Inputs for the review-gate PR handoff, {@link openReviewPr}. */

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -150,6 +150,8 @@ import {
   totalReseedSpend,
   withGateSubCap,
 } from "./reseed-budget.js";
+import type { ReseedTrail, ReseedTrailRound } from "./reseed-trail.js";
+import { createReseedTrail } from "./reseed-trail.js";
 import type { ReseedOutstanding, ReseedSectionTag } from "./reseed-handoff.js";
 import {
   EMPTY_RESEED_OUTSTANDING,
@@ -677,6 +679,39 @@ export async function processIssue(
    * history line's repeat count and the tier escalation both key off. */
   const roundSignature = (sidecar: readonly string[] | undefined): string =>
     failureSignature({ sidecar, findings: reseedOutstanding.review?.findings ?? [] });
+  /** The trail's two derived surfaces (#2731), built on the FIRST Re-seed and
+   * not before: an attempt that never re-seeds opens no pull request and posts
+   * no comment, which is the whole point of minting the draft lazily. The build
+   * is deferred to first use so it pins the branch the agent actually ran on. */
+  let trail: ReseedTrail | undefined;
+  const publishReseedTrail = async (round: ReseedTrailRound): Promise<void> => {
+    trail ??= createReseedTrail(
+      {
+        gh: deps.reseedTrailGh,
+        mergeExec: deps.mergeExec,
+        remoteGit: deps.remoteGit,
+        appendIterLog: deps.appendIterLog,
+        recordWorkerEvent: deps.recordWorkerEvent,
+      },
+      {
+        issue,
+        repo: input.repo,
+        repoDir: input.repoDir,
+        branch: workerBranch,
+        base,
+        title: input.title,
+        lane: reseedLane,
+        ceiling: reseedBudget.ceiling,
+      },
+    );
+    // Best-effort by contract: the Attempt record already holds the round, so a
+    // forge that refuses a projection must never fail the Re-seed itself.
+    try {
+      await trail.publish(round);
+    } catch {
+      // observability only.
+    }
+  };
   /** The single Re-seed request path. Every caller that re-instructs the
    * implementer IN PLACE — same Worker, same Worktree, same branch — comes
    * through here: it checks the ceiling and the cause's sub-cap or reservation,
@@ -711,16 +746,19 @@ export async function processIssue(
       req.signature ?? roundSignature(req.sidecar),
     );
     const gateSpend = reseedSpend.gate ?? 0;
+    /** The round's one-line account. It reaches the iteration log AND the trail's
+     * two projections, so the surfaces cannot disagree about what the round was
+     * asked to fix. */
+    let note: string;
     if (req.trigger === "review-finding") {
       const reviewSpend = reseedSpend.review ?? 0;
       currentHandoff = composeReseed(
         "adversarial-review-correction",
         reviewReseedDirectives({ retry: reviewSpend, cap: reseedBudget.subCaps.review }),
       );
-      deps.appendIterLog(
+      note =
         `🤖 ${reseedLane}: adversarial review found blocking issue(s); ` +
-          `correction retry ${reviewSpend}/${reseedBudget.subCaps.review}.`,
-      );
+        `correction retry ${reviewSpend}/${reseedBudget.subCaps.review}.`;
     } else if (req.trigger === "tier-escalation") {
       currentHandoff = composeReseed(
         "tier-escalation",
@@ -732,23 +770,22 @@ export async function processIssue(
         }),
         req.tiers?.to,
       );
-      deps.appendIterLog(
+      note =
         `🤖 ${reseedLane}: ${req.tiers?.from ?? ""}-tier feedback failed for #${issue}; ` +
-          `re-seeding on the ${req.tiers?.to ?? ""} tier before terminal validation routing.`,
-      );
+        `re-seeding on the ${req.tiers?.to ?? ""} tier before terminal validation routing.`;
     } else {
       currentHandoff = composeReseed(
         isGoLane ? "go-machine-gate-retry" : "afk-gate-correction",
         gateReseedDirectives({ gate, retry: gateSpend, cap: gateSubCap, drift }),
       );
-      deps.appendIterLog(
-        drift
-          ? `🤖 ${reseedLane}: ${gate} machine gate failed after DONE, but ${attribution?.reason}; ` +
-            `granting a free stale-base correction (${correctionLedger.refunded}/${staleBaseDriftCap}), ` +
-            `budget untouched at ${gateSpend}/${gateSubCap}.`
-          : `🤖 ${reseedLane}: ${gate} machine gate failed after DONE; correction retry ${gateSpend}/${gateSubCap}.`,
-      );
+      note = drift
+        ? `🤖 ${reseedLane}: ${gate} machine gate failed after DONE, but ${attribution?.reason}; ` +
+          `granting a free stale-base correction (${correctionLedger.refunded}/${staleBaseDriftCap}), ` +
+          `budget untouched at ${gateSpend}/${gateSubCap}.`
+        : `🤖 ${reseedLane}: ${gate} machine gate failed after DONE; correction retry ${gateSpend}/${gateSubCap}.`;
     }
+    deps.appendIterLog(note);
+    await publishReseedTrail({ round: reseedRound, trigger: req.trigger, cause, note });
     deps.recordWorkerEvent?.("worker.reseeded", {
       trigger: req.trigger,
       cause,

--- a/apps/dev/src/core/process-issue/reseed-trail.ts
+++ b/apps/dev/src/core/process-issue/reseed-trail.ts
@@ -1,0 +1,160 @@
+// reseed-trail — the Re-seed's two DERIVED surfaces (ADR 0129, Spec #2723,
+// issue #2731): a lazily-minted draft pull request and ONE Issue comment
+// upserted in place.
+//
+// The trail becomes visible without paying a pull request per attempt. The first
+// Re-seed of any cause opens the draft; an attempt that never re-seeds opens
+// none and lands exactly as it always did. Landing reuses that draft and marks
+// it ready — opening a second pull request is a defect, not a fallback.
+//
+// Both surfaces are PROJECTIONS. The Attempt record is the source of truth, so a
+// failed post, a failed edit, or a forge that refuses the draft costs fidelity
+// on a projection and never the round: every call here is best-effort and the
+// publisher retries the missing half on the next round.
+
+import { openDraftPr, editPrBody, type Exec as MergeExec } from "../merge.js";
+import { pushAttempt, type GitExec } from "../remote-branch.js";
+import type { ReseedCause, ReseedTrigger } from "./reseed-budget.js";
+
+/** The marker that makes the comment findable for the in-place edit. Carries the
+ * issue so a comment posted on the wrong Ticket can never be mistaken for it. */
+export function reseedTrailMarker(issue: number): string {
+  return `<!-- afk:reseed-trail v1 issue=${issue} -->`;
+}
+
+/** One round on the trail. `note` is the same line the iteration log carries, so
+ * the two surfaces cannot disagree about what a round was asked to fix. */
+export interface ReseedTrailRound {
+  readonly round: number;
+  readonly trigger: ReseedTrigger;
+  readonly cause: ReseedCause;
+  readonly note: string;
+}
+
+export interface ReseedTrailView {
+  readonly issue: number;
+  readonly branch: string;
+  readonly lane: string;
+  readonly ceiling: number;
+  readonly rounds: readonly ReseedTrailRound[];
+}
+
+/** Render the trail. Pure, and the SAME body reaches both surfaces — the draft
+ * mirrors the comment rather than maintaining a second narrative. */
+export function renderReseedTrail(view: ReseedTrailView): string {
+  const lines = [
+    reseedTrailMarker(view.issue),
+    `🤖 **Re-seed trail** — #${view.issue} on \`${view.branch}\`, lane \`${view.lane}\`.`,
+    "",
+    `Rounds spent: ${view.rounds.length}/${view.ceiling}. A Re-seed re-instructs the implementer in place —`,
+    "same Worker, same Worktree, same branch — after a gate stage blocked the work.",
+    "",
+    "| round | trigger | what it was asked to fix |",
+    "| --- | --- | --- |",
+  ];
+  for (const r of view.rounds) {
+    lines.push(`| ${r.round}/${view.ceiling} | \`${r.trigger}\` (${r.cause}) | ${r.note.replace(/\|/g, "\\|")} |`);
+  }
+  lines.push(
+    "",
+    "The Attempt record is the source of truth; this is a derived projection.",
+  );
+  return lines.join("\n");
+}
+
+/** The Issue half of the trail. Posting returns the comment's numeric id, which
+ * is what makes the SECOND round an edit rather than another notification. */
+export interface ReseedTrailGh {
+  postComment(issue: number, body: string): Promise<number | undefined>;
+  editComment(commentId: number, body: string): Promise<boolean>;
+}
+
+export interface ReseedTrailDeps {
+  gh?: ReseedTrailGh;
+  mergeExec: MergeExec;
+  remoteGit: GitExec;
+  appendIterLog(line: string): void;
+  recordWorkerEvent?(kind: `worker.${string}`, payload?: Record<string, unknown>): void;
+}
+
+export interface ReseedTrailContext {
+  readonly issue: number;
+  readonly repo: string;
+  readonly repoDir: string;
+  readonly branch: string;
+  readonly base: string;
+  readonly title: string;
+  readonly lane: string;
+  readonly ceiling: number;
+}
+
+export interface ReseedTrail {
+  /** Record one round and upsert both projections. */
+  publish(round: ReseedTrailRound): Promise<void>;
+  /** The draft's number once minted, for the landing that reuses it. */
+  prNumber(): number | undefined;
+}
+
+/** The draft's body: the trail plus the auto-close link, so the pull request
+ * landing reuses carries the same issue linkage {@link ensurePr} would have
+ * given it had it been opened at landing time. */
+function draftBody(issue: number, trail: string): string {
+  return `${trail}\n\nCloses #${issue}`;
+}
+
+export function createReseedTrail(deps: ReseedTrailDeps, ctx: ReseedTrailContext): ReseedTrail {
+  const rounds: ReseedTrailRound[] = [];
+  let commentId: number | undefined;
+  let prNumber: number | undefined;
+  let pushed = false;
+
+  /** The branch must be on the remote before a pull request can name it as head.
+   * Pushed ONCE per attempt: later rounds ride the post-commit hook and the
+   * landing's own force-push. */
+  const ensurePushed = async (): Promise<boolean> => {
+    if (pushed) return true;
+    pushed = (await pushAttempt(deps.remoteGit, ctx.repoDir, ctx.branch, ctx.branch)).ok;
+    return pushed;
+  };
+
+  const publish = async (round: ReseedTrailRound): Promise<void> => {
+    rounds.push(round);
+    const body = renderReseedTrail({
+      issue: ctx.issue,
+      branch: ctx.branch,
+      lane: ctx.lane,
+      ceiling: ctx.ceiling,
+      rounds,
+    });
+
+    // 1. ONE Issue comment: posted on the first round, edited in place on every
+    // round after it, so five rounds are one notification rather than five.
+    if (deps.gh) {
+      if (commentId === undefined) commentId = await deps.gh.postComment(ctx.issue, body);
+      else await deps.gh.editComment(commentId, body);
+    }
+
+    // 2. The draft, minted lazily on the first round and mirrored thereafter.
+    if (prNumber === undefined) {
+      if (!(await ensurePushed())) return;
+      prNumber = await openDraftPr(deps.mergeExec, {
+        repo: ctx.repo,
+        branch: ctx.branch,
+        target: ctx.base,
+        n: ctx.issue,
+        title: ctx.title,
+        body: draftBody(ctx.issue, body),
+      });
+      if (prNumber !== undefined) {
+        deps.appendIterLog(
+          `🤖 ${ctx.lane}: first Re-seed — opened draft PR #${prNumber} carrying the correction trail.`,
+        );
+        deps.recordWorkerEvent?.("worker.reseed_draft_opened", { pr: prNumber, round: round.round });
+      }
+      return;
+    }
+    await editPrBody(deps.mergeExec, ctx.repo, prNumber, draftBody(ctx.issue, body));
+  };
+
+  return { publish, prNumber: () => prNumber };
+}

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -98,6 +98,7 @@ import {
   type IssueClassificationMetadata,
   type ReviewGateConfig,
 } from "../issue-classifier.js";
+import type { ReseedTrailGh } from "./reseed-trail.js";
 import type { AttemptStatus } from "../envelope.js";
 import type { Runner } from "../../types/runner.js";
 import { runnerSupportsStructuredOutput, toAgentRunner } from "../runner-spec.js";
@@ -340,6 +341,11 @@ export interface ProcessIssueDeps {
     body: string;
     findings: AdversarialReviewFindings;
   }): Promise<void>;
+  /** The Issue half of the Re-seed trail (#2731): ONE comment upserted in place
+   * through the existing edit-comment primitive, so repeated rounds edit rather
+   * than append. Absent, the trail keeps its draft pull request and drops the
+   * comment — both are derived projections of the Attempt record. */
+  reseedTrailGh?: ReseedTrailGh;
   envelope: EmitEnvelopeDeps;
   nowEpoch(): number;
   nowIso(): string;

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -1763,3 +1763,77 @@ describe("processIssue — land-lock timeout self-requeue (#2596)", () => {
     expect(trace.postedEnvelopes).toEqual([]);
   });
 });
+
+describe("processIssue — the Re-seed trail's two derived surfaces (#2731)", () => {
+  const prCreates = (trace: { mergeCalls: string[][] }): string[][] =>
+    trace.mergeCalls.filter((argv) => argv.includes("pr") && argv.includes("create"));
+
+  it("opens NO pull request before landing when the attempt never re-seeds", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    // Exactly one create, and it is the landing's own — no draft, no trail.
+    expect(prCreates(trace)).toHaveLength(1);
+    expect(prCreates(trace)[0]).not.toContain("--draft");
+    expect(trace.trailComments).toEqual([]);
+    expect(trace.trailCommentEdits).toEqual([]);
+  });
+
+  it("mints exactly one DRAFT pull request on the first Re-seed", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      // One red gate, then green: one Re-seed, then landing.
+      feedbackResults: [false, true],
+      stallConvergenceBudget: 2,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    const creates = prCreates(trace);
+    expect(creates).toHaveLength(1);
+    expect(creates[0]).toContain("--draft");
+    // The draft body mirrors the trail and keeps the auto-close link.
+    const body = creates[0]![creates[0]!.indexOf("--body") + 1] ?? "";
+    expect(body).toContain("Re-seed trail");
+    expect(body).toContain("Closes #9");
+  });
+
+  it("lands by reusing that draft and marking it ready, never opening a second", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackResults: [false, true],
+      stallConvergenceBudget: 2,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(prCreates(trace)).toHaveLength(1);
+    const joined = trace.mergeCalls.map((argv) => argv.join(" "));
+    expect(joined.some((c) => c.includes("pr ready 42"))).toBe(true);
+    expect(joined.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+  });
+
+  it("edits ONE Issue comment across repeated rounds instead of appending new ones", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      // Two red gates, then green: two Re-seed rounds on one comment.
+      feedbackResults: [false, false, true],
+      stallConvergenceBudget: 3,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(3);
+    expect(trace.trailComments).toHaveLength(1);
+    expect(trace.trailCommentEdits).toHaveLength(1);
+    expect(trace.trailCommentEdits[0]?.commentId).toBe(trace.trailComments[0]?.id);
+    // The edit carries BOTH rounds; the original post carried only the first.
+    expect(trace.trailComments[0]?.body).toContain("1/4");
+    expect(trace.trailComments[0]?.body).not.toContain("2/4");
+    expect(trace.trailCommentEdits[0]?.body).toContain("2/4");
+    // Still one pull request, still a draft.
+    expect(prCreates(trace)).toHaveLength(1);
+  });
+});

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -57,6 +57,10 @@ export interface Trace {
   sidecarWrites: Array<{ path: string; lines: string[] }>;
   /** Non-blocking backpressure evidence reviews posted via the #1279 seam. */
   backpressureReviews: Array<{ pr: number; body: string }>;
+  /** Re-seed trail comments POSTED on the issue, with their assigned ids (#2731). */
+  trailComments: Array<{ issue: number; body: string; id: number }>;
+  /** Re-seed trail comments EDITED in place — one entry per round after the first. */
+  trailCommentEdits: Array<{ commentId: number; body: string }>;
   /** Review verdicts posted by the gate fold's third stage, pre-PR (#2730). */
   adversarialReviews: Array<{ issue: number; body: string; findings: AdversarialReviewFindings }>;
   adversarialReviewContexts: Array<{
@@ -309,6 +313,8 @@ export function harness(opts: HarnessOptions = {}): {
     ensuredLabels: [],
     sidecarWrites: [],
     backpressureReviews: [],
+    trailComments: [],
+    trailCommentEdits: [],
     adversarialReviews: [],
     adversarialReviewContexts: [],
     worktreeDiffCalls: [],
@@ -331,6 +337,9 @@ export function harness(opts: HarnessOptions = {}): {
   // Flipped true once the conflict resolver dispatch runs; the mergeExec
   // verification reads above key off it to model "the agent resolved the merge".
   let mergeResolved = false;
+  // Whether a pull request exists for the attempt branch. Landing opens one when
+  // no Re-seed minted a draft first; both go through `gh pr create`.
+  let prOpen = false;
   let pnpmCalls = 0;
   let changedFilesCalls = 0;
 
@@ -472,6 +481,18 @@ export function harness(opts: HarnessOptions = {}): {
         return true;
       },
     },
+    // The Re-seed trail's Issue half (#2731): one comment, then edits in place.
+    reseedTrailGh: {
+      async postComment(issue, body) {
+        const id = 7000 + trace.trailComments.length;
+        trace.trailComments.push({ issue, body, id });
+        return id;
+      },
+      async editComment(commentId, body) {
+        trace.trailCommentEdits.push({ commentId, body });
+        return true;
+      },
+    },
     mergeExec: async (argv) => {
       trace.mergeCalls.push([...argv]);
       const j = argv.join(" ");
@@ -487,10 +508,15 @@ export function harness(opts: HarnessOptions = {}): {
       if (j.includes("merge-base --is-ancestor origin/")) {
         return { code: 1, stdout: "", stderr: "" };
       }
-      // landPr reuses an open PR via `gh pr list`; reply with a number so it
-      // resolves without a create round-trip.
+      // `gh pr list` is the ONE reuse probe every PR path shares (#2731): it
+      // answers empty until a PR has actually been created, so a test can tell
+      // a lazily-minted draft from a landing that opened its own.
+      if (argv.includes("pr") && argv.includes("create")) {
+        prOpen = true;
+        return { code: 0, stdout: "", stderr: "" };
+      }
       if (argv.includes("pr") && argv.includes("list")) {
-        return { code: 0, stdout: "42\n", stderr: "" };
+        return { code: 0, stdout: prOpen ? "42\n" : "", stderr: "" };
       }
       if (argv.includes("pr") && argv.includes("diff")) {
         return {

--- a/apps/dev/tests/reseed-trail.test.ts
+++ b/apps/dev/tests/reseed-trail.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderReseedTrail,
+  reseedTrailMarker,
+} from "../src/core/process-issue/reseed-trail.js";
+
+describe("renderReseedTrail (#2731)", () => {
+  const view = {
+    issue: 9,
+    branch: "afk/9-thing",
+    lane: "/afk",
+    ceiling: 4,
+    rounds: [
+      { round: 1, trigger: "gate-stage" as const, cause: "gate" as const, note: "feedback machine gate failed" },
+      { round: 2, trigger: "review-finding" as const, cause: "review" as const, note: "blocking finding" },
+    ],
+  };
+
+  it("carries the issue-scoped marker that makes the comment upsertable", () => {
+    expect(renderReseedTrail(view)).toContain(reseedTrailMarker(9));
+    expect(reseedTrailMarker(9)).not.toBe(reseedTrailMarker(10));
+  });
+
+  it("renders every round with its trigger, cause, and note", () => {
+    const body = renderReseedTrail(view);
+    expect(body).toContain("gate-stage");
+    expect(body).toContain("feedback machine gate failed");
+    expect(body).toContain("review-finding");
+    expect(body).toContain("blocking finding");
+    expect(body).toContain("2/4");
+  });
+
+  it("names the Attempt record as the source of truth, not itself", () => {
+    expect(renderReseedTrail(view)).toContain("derived projection");
+  });
+
+  it("escapes a pipe in a note so one round cannot break the table", () => {
+    const body = renderReseedTrail({
+      ...view,
+      rounds: [{ round: 1, trigger: "gate-stage", cause: "gate", note: "pnpm a | pnpm b failed" }],
+    });
+    expect(body).toContain("pnpm a \\| pnpm b failed");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2731. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2731

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787884328&installation_model_id=20659&pr_number=2768&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2768&signature=647121585942ddca8a42e03f30c97966012480e3b9e4fb0c9ca82e1ed2cb257a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->