### PR TITLE
chore: #2732 A parked Re-seed leaves its draft PR open and marked

### DIFF
--- a/.changeset/reseed-park-leaves-the-draft-open.md
+++ b/.changeset/reseed-park-leaves-the-draft-open.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A Re-seed budget exhausted with work still outstanding now parks WITHOUT closing its draft pull request (#2732, ADR 0129). A validation park is precisely the moment a human needs the diff open, so the draft is left standing and marked with the same `blocked:validation` label the Ticket carries — parked work and live work separate in one query instead of a join across two vocabularies. Both projections are sealed on the way out through one path: the trail's Issue comment is edited in place a final time and the draft's body is mirrored onto it, each carrying the rounds already spent plus the evidence that ended the budget, so the human queue starts from the diagnosis rather than from a search. Exhaustion parks identically whatever exhausted it — gate churn and a surviving blocking review finding take the same exit — and an attempt that never re-seeded has no trail to seal and parks exactly as it did before.

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -1468,6 +1468,15 @@ export async function editPrBody(exec: Exec, repo: string, prNumber: number, bod
   return r.code === 0;
 }
 
+/** Add ONE label to an open pull request (#2732). Best-effort like
+ * {@link editPrBody}: the label is what makes a parked draft and its parked
+ * Issue answer the same query, and a forge that refuses it costs that query a
+ * row, never the park. */
+export async function labelPr(exec: Exec, repo: string, prNumber: number, label: string): Promise<boolean> {
+  const r = await exec(["gh", "-R", repo, "pr", "edit", String(prNumber), "--add-label", label]);
+  return r.code === 0;
+}
+
 /** Inputs for the review-gate PR handoff, {@link openReviewPr}. */
 export interface OpenReviewPrInput {
   /** `owner/repo` slug passed to `gh -R`. */

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -712,6 +712,19 @@ export async function processIssue(
       // observability only.
     }
   };
+  /** The ONE exit an exhausted Re-seed budget takes (#2732), whatever cause
+   * exhausted it: seal both projections on the same `blocked:validation` state
+   * and the same evidence, and leave the draft OPEN — a validation park is
+   * precisely when a human needs the diff. An attempt that never re-seeded has
+   * no trail and therefore nothing to seal: it parks as it always did. */
+  const parkReseedTrail = async (evidence: string): Promise<void> => {
+    if (!trail) return;
+    try {
+      await trail.park({ evidence });
+    } catch {
+      // observability only.
+    }
+  };
   /** The single Re-seed request path. Every caller that re-instructs the
    * implementer IN PLACE — same Worker, same Worktree, same branch — comes
    * through here: it checks the ceiling and the cause's sub-cap or reservation,
@@ -1344,7 +1357,10 @@ export async function processIssue(
       if (!isInfra && (await reseedAfterGate("gate-stage", "feedback", validationText, feedback.sidecar))) {
         continue;
       }
-      if (!isInfra) notes += correctionBudgetNote();
+      if (!isInfra) {
+        notes += correctionBudgetNote();
+        await parkReseedTrail(validationText);
+      }
       return await terminalFailure(common, outcome, "feedback", {
         notes,
         validation: validationText,
@@ -1371,6 +1387,7 @@ export async function processIssue(
           continue;
         }
         bpNotes += correctionBudgetNote();
+        await parkReseedTrail(validationText);
         return await terminalFailure(common, "feedback-failed", "feedback", {
           notes: bpNotes,
           validation: validationText,
@@ -1391,6 +1408,7 @@ export async function processIssue(
     if (review.next === "park") {
       const validation = review.validation ?? "Blocking review findings remain.";
       await writeValidationSidecar(deps, input.attemptDir, [...validationSidecar, validation]);
+      await parkReseedTrail(validation);
       return await terminalFailure(
         common,
         "feedback-failed",

--- a/apps/dev/src/core/process-issue/reseed-trail.ts
+++ b/apps/dev/src/core/process-issue/reseed-trail.ts
@@ -12,14 +12,22 @@
 // on a projection and never the round: every call here is best-effort and the
 // publisher retries the missing half on the next round.
 
-import { openDraftPr, editPrBody, type Exec as MergeExec } from "../merge.js";
+import { openDraftPr, editPrBody, labelPr, type Exec as MergeExec } from "../merge.js";
 import { pushAttempt, type GitExec } from "../remote-branch.js";
+import { LABEL_VALIDATION } from "../triage-labels.js";
 import type { ReseedCause, ReseedTrigger } from "./reseed-budget.js";
 
 /** The marker that makes the comment findable for the in-place edit. Carries the
  * issue so a comment posted on the wrong Ticket can never be mistaken for it. */
 export function reseedTrailMarker(issue: number): string {
   return `<!-- afk:reseed-trail v1 issue=${issue} -->`;
+}
+
+/** The park marker both surfaces carry (#2732). It names `blocked:validation` —
+ * the SAME state the Ticket's label carries — so one query over the marker
+ * separates parked work from live work without joining two vocabularies. */
+export function reseedParkMarker(issue: number): string {
+  return `<!-- afk:reseed-park v1 issue=${issue} blocked=${LABEL_VALIDATION} -->`;
 }
 
 /** One round on the trail. `note` is the same line the iteration log carries, so
@@ -31,12 +39,24 @@ export interface ReseedTrailRound {
   readonly note: string;
 }
 
+/** The exhaustion that ended the Attempt (#2732). One shape for every cause: a
+ * budget spent on gate churn and a budget spent on a blocking review finding
+ * park through the same rendering, because a human reading the park needs the
+ * evidence and the open diff either way. */
+export interface ReseedTrailPark {
+  /** Whatever the exhausted round left red — the gate tail or the blocker
+   * summary — verbatim, so the park needs no re-run to be diagnosed. */
+  readonly evidence: string;
+}
+
 export interface ReseedTrailView {
   readonly issue: number;
   readonly branch: string;
   readonly lane: string;
   readonly ceiling: number;
   readonly rounds: readonly ReseedTrailRound[];
+  /** Present once the budget is exhausted with work still outstanding. */
+  readonly park?: ReseedTrailPark;
 }
 
 /** Render the trail. Pure, and the SAME body reaches both surfaces — the draft
@@ -59,6 +79,21 @@ export function renderReseedTrail(view: ReseedTrailView): string {
     "",
     "The Attempt record is the source of truth; this is a derived projection.",
   );
+  if (view.park) {
+    lines.push(
+      "",
+      reseedParkMarker(view.issue),
+      `🛑 **Parked — \`${LABEL_VALIDATION}\`.** The Re-seed budget is exhausted with work still`,
+      "outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is",
+      "precisely the moment the diff must be readable.",
+      "",
+      "**Evidence at park time**",
+      "",
+      "```",
+      view.park.evidence.trim(),
+      "```",
+    );
+  }
   return lines.join("\n");
 }
 
@@ -91,6 +126,9 @@ export interface ReseedTrailContext {
 export interface ReseedTrail {
   /** Record one round and upsert both projections. */
   publish(round: ReseedTrailRound): Promise<void>;
+  /** Seal both projections on the exhausted budget: the draft stays OPEN and
+   * both surfaces carry the same `blocked:validation` state and evidence. */
+  park(park: ReseedTrailPark): Promise<void>;
   /** The draft's number once minted, for the landing that reuses it. */
   prNumber(): number | undefined;
 }
@@ -117,44 +155,71 @@ export function createReseedTrail(deps: ReseedTrailDeps, ctx: ReseedTrailContext
     return pushed;
   };
 
-  const publish = async (round: ReseedTrailRound): Promise<void> => {
-    rounds.push(round);
-    const body = renderReseedTrail({
+  const render = (park?: ReseedTrailPark): string =>
+    renderReseedTrail({
       issue: ctx.issue,
       branch: ctx.branch,
       lane: ctx.lane,
       ceiling: ctx.ceiling,
       rounds,
+      park,
     });
 
-    // 1. ONE Issue comment: posted on the first round, edited in place on every
-    // round after it, so five rounds are one notification rather than five.
-    if (deps.gh) {
-      if (commentId === undefined) commentId = await deps.gh.postComment(ctx.issue, body);
-      else await deps.gh.editComment(commentId, body);
-    }
-
-    // 2. The draft, minted lazily on the first round and mirrored thereafter.
-    if (prNumber === undefined) {
-      if (!(await ensurePushed())) return;
-      prNumber = await openDraftPr(deps.mergeExec, {
-        repo: ctx.repo,
-        branch: ctx.branch,
-        target: ctx.base,
-        n: ctx.issue,
-        title: ctx.title,
-        body: draftBody(ctx.issue, body),
-      });
-      if (prNumber !== undefined) {
-        deps.appendIterLog(
-          `🤖 ${ctx.lane}: first Re-seed — opened draft PR #${prNumber} carrying the correction trail.`,
-        );
-        deps.recordWorkerEvent?.("worker.reseed_draft_opened", { pr: prNumber, round: round.round });
-      }
-      return;
-    }
-    await editPrBody(deps.mergeExec, ctx.repo, prNumber, draftBody(ctx.issue, body));
+  /** ONE Issue comment: posted the first time the trail says anything, edited in
+   * place every time after, so five rounds and a park are one notification
+   * rather than six. */
+  const upsertComment = async (body: string): Promise<void> => {
+    if (!deps.gh) return;
+    if (commentId === undefined) commentId = await deps.gh.postComment(ctx.issue, body);
+    else await deps.gh.editComment(commentId, body);
   };
 
-  return { publish, prNumber: () => prNumber };
+  /** The draft, minted lazily on the first round and mirrored thereafter.
+   * Returns whether a pull request carries the body — the park needs to know,
+   * because a draft the forge refused cannot be labelled. */
+  const upsertDraft = async (body: string, round?: number): Promise<boolean> => {
+    if (prNumber !== undefined) {
+      await editPrBody(deps.mergeExec, ctx.repo, prNumber, draftBody(ctx.issue, body));
+      return true;
+    }
+    if (!(await ensurePushed())) return false;
+    prNumber = await openDraftPr(deps.mergeExec, {
+      repo: ctx.repo,
+      branch: ctx.branch,
+      target: ctx.base,
+      n: ctx.issue,
+      title: ctx.title,
+      body: draftBody(ctx.issue, body),
+    });
+    if (prNumber === undefined) return false;
+    deps.appendIterLog(
+      `🤖 ${ctx.lane}: first Re-seed — opened draft PR #${prNumber} carrying the correction trail.`,
+    );
+    deps.recordWorkerEvent?.("worker.reseed_draft_opened", { pr: prNumber, round });
+    return true;
+  };
+
+  const publish = async (round: ReseedTrailRound): Promise<void> => {
+    rounds.push(round);
+    const body = render();
+    await upsertComment(body);
+    await upsertDraft(body, round.round);
+  };
+
+  /** The exhausted budget's last act, and deliberately NOT a close: a validation
+   * park is exactly when a human needs the diff open, so the draft is left
+   * standing and marked `blocked:validation` — the same state the Ticket
+   * carries, which is what makes one query answer for both surfaces. */
+  const park = async (parked: ReseedTrailPark): Promise<void> => {
+    const body = render(parked);
+    await upsertComment(body);
+    if (!(await upsertDraft(body))) return;
+    await labelPr(deps.mergeExec, ctx.repo, prNumber!, LABEL_VALIDATION);
+    deps.appendIterLog(
+      `🤖 ${ctx.lane}: Re-seed budget exhausted — draft PR #${prNumber} left open and marked \`${LABEL_VALIDATION}\`.`,
+    );
+    deps.recordWorkerEvent?.("worker.reseed_parked", { pr: prNumber, rounds: rounds.length });
+  };
+
+  return { publish, park, prNumber: () => prNumber };
 }

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -13,6 +13,7 @@ import {
   upsertCurrentBlocker,
 } from "./process-issue.test-helpers.js";
 import type { AttemptProgressInfo, ConfigValues, ProcessIssueDeps } from "./process-issue.test-helpers.js";
+import { reseedParkMarker } from "../src/core/process-issue/reseed-trail.js";
 import { vi } from "vitest";
 describe("processIssue — DONE + green + merged (unlocked, admin-PR landing)", () => {
   describe("landing.wait slot release (#2427)", () => {
@@ -1835,5 +1836,137 @@ describe("processIssue — the Re-seed trail's two derived surfaces (#2731)", ()
     expect(trace.trailCommentEdits[0]?.body).toContain("2/4");
     // Still one pull request, still a draft.
     expect(prCreates(trace)).toHaveLength(1);
+  });
+});
+
+describe("processIssue — an exhausted Re-seed budget parks with the draft open (#2732)", () => {
+  const prCalls = (trace: { mergeCalls: string[][] }, verb: string): string[][] =>
+    trace.mergeCalls.filter((argv) => argv.includes("pr") && argv.includes(verb));
+  /** Every `gh pr edit --add-label` applied to the draft. */
+  const prLabels = (trace: { mergeCalls: string[][] }): string[] =>
+    prCalls(trace, "edit")
+      .filter((argv) => argv.includes("--add-label"))
+      .map((argv) => argv[argv.indexOf("--add-label") + 1] ?? "");
+  /** The LAST body written onto the draft — the park's own. */
+  const lastPrBody = (trace: { mergeCalls: string[][] }): string => {
+    const bodies = trace.mergeCalls
+      .filter((argv) => argv.includes("--body"))
+      .map((argv) => argv[argv.indexOf("--body") + 1] ?? "");
+    return bodies.at(-1) ?? "";
+  };
+  /** The LAST body written onto the trail's Issue comment. */
+  const lastIssueBody = (trace: {
+    trailComments: Array<{ body: string }>;
+    trailCommentEdits: Array<{ body: string }>;
+  }): string => trace.trailCommentEdits.at(-1)?.body ?? trace.trailComments.at(-1)?.body ?? "";
+
+  /** A budget exhausted by GATE churn: one correction round, then the same red
+   * gate again with nothing left to draw. */
+  const gateExhaustion = () =>
+    harness({
+      outcome: "done",
+      feedbackResults: [false, false],
+      stallConvergenceBudget: 1,
+    });
+
+  /** A budget exhausted by the RESERVED review round: a blocking finding draws
+   * it, and the finding survives the correction. */
+  const reviewExhaustion = () => {
+    const blocking = {
+      summary: "Blocking acceptance gaps remain.",
+      findings: [
+        {
+          path: "packages/x/src/a.ts",
+          line: 1,
+          body: "The implementation still omits the required audit trail.",
+          blocking: true,
+        },
+      ],
+    };
+    return harness({
+      outcomes: ["done", "done"],
+      feedbackOk: true,
+      locked: false,
+      adversarialReview: { enabled: true, maxIterations: 1, reviewerCount: 1, quorum: "any" },
+      adversarialFindingsSequence: [blocking, blocking],
+    });
+  };
+
+  it("leaves the draft pull request OPEN — a validation park is when the diff is needed", async () => {
+    const { deps, input, trace } = gateExhaustion();
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    // The draft was minted by the first Re-seed and never closed on the way out.
+    expect(prCalls(trace, "create")).toHaveLength(1);
+    expect(prCalls(trace, "close")).toEqual([]);
+    expect(prCalls(trace, "merge")).toEqual([]);
+  });
+
+  it("marks the parked draft with the same blocked-validation label the Ticket carries", async () => {
+    const { deps, input, trace } = gateExhaustion();
+    await processIssue(deps, input);
+
+    expect(prLabels(trace)).toContain("blocked:validation");
+    // The Ticket parks with the very same label — one query answers for both.
+    expect(
+      trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:validation")),
+    ).toBe(true);
+    expect(lastPrBody(trace)).toContain(reseedParkMarker(9));
+  });
+
+  it("puts the accumulated evidence on BOTH the Issue and the pull request at park time", async () => {
+    const { deps, input, trace } = gateExhaustion();
+    await processIssue(deps, input);
+
+    for (const body of [lastIssueBody(trace), lastPrBody(trace)]) {
+      expect(body).toContain(reseedParkMarker(9));
+      // The rounds already spent…
+      expect(body).toContain("Re-seed trail");
+      expect(body).toContain("machine gate failed after DONE");
+      // …and the evidence that ended the budget.
+      expect(body).toContain("Evidence at park time");
+      expect(body).toContain('"status":"failed"');
+    }
+    // Still ONE comment: the park edits the trail rather than notifying again.
+    expect(trace.trailComments).toHaveLength(1);
+  });
+
+  it("parks identically whatever cause exhausted the budget", async () => {
+    const gate = gateExhaustion();
+    const review = reviewExhaustion();
+    const gateResult = await processIssue(gate.deps, gate.input);
+    const reviewResult = await processIssue(review.deps, review.input);
+
+    expect(gateResult.outcome).toBe("feedback-failed");
+    expect(reviewResult.outcome).toBe("feedback-failed");
+    for (const trace of [gate.trace, review.trace]) {
+      expect(prCalls(trace, "create")).toHaveLength(1);
+      expect(prCalls(trace, "close")).toEqual([]);
+      expect(prLabels(trace)).toContain("blocked:validation");
+      expect(lastPrBody(trace)).toContain(reseedParkMarker(9));
+      expect(lastIssueBody(trace)).toContain(reseedParkMarker(9));
+      expect(lastPrBody(trace)).toContain("Evidence at park time");
+      expect(lastIssueBody(trace)).toContain("Evidence at park time");
+    }
+    // The evidence itself is the one thing that differs: each cause carries what
+    // IT left red.
+    expect(lastIssueBody(review.trace)).toContain("The implementation still omits the required audit trail.");
+  });
+
+  it("parks with no draft to seal when the attempt never re-seeded", async () => {
+    // Budget 0: the first red gate has nothing to draw, so no round is ever
+    // published and no pull request is minted. The park is the Ticket's alone.
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackResults: [false],
+      stallConvergenceBudget: 0,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(prCalls(trace, "create")).toEqual([]);
+    expect(prLabels(trace)).toEqual([]);
+    expect(trace.trailComments).toEqual([]);
   });
 });

--- a/apps/dev/tests/reseed-trail.test.ts
+++ b/apps/dev/tests/reseed-trail.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   renderReseedTrail,
+  reseedParkMarker,
   reseedTrailMarker,
 } from "../src/core/process-issue/reseed-trail.js";
 
@@ -32,6 +33,26 @@ describe("renderReseedTrail (#2731)", () => {
 
   it("names the Attempt record as the source of truth, not itself", () => {
     expect(renderReseedTrail(view)).toContain("derived projection");
+  });
+
+  it("says nothing about a park while the budget still has rounds (#2732)", () => {
+    const body = renderReseedTrail(view);
+    expect(body).not.toContain(reseedParkMarker(9));
+    expect(body).not.toContain("blocked:validation");
+  });
+
+  it("carries the blocked-validation marker and the evidence once parked (#2732)", () => {
+    const body = renderReseedTrail({
+      ...view,
+      park: { evidence: '{"check":"test","status":"failed"}' },
+    });
+    expect(body).toContain(reseedParkMarker(9));
+    expect(reseedParkMarker(9)).toContain("blocked:validation");
+    expect(body).toContain('{"check":"test","status":"failed"}');
+    // The rounds already spent stay on the park: the human reads the whole
+    // correction history and the evidence that ended it in one place.
+    expect(body).toContain("feedback machine gate failed");
+    expect(body).toContain("blocking finding");
   });
 
   it("escapes a pipe in a note so one round cannot break the table", () => {


### PR DESCRIPTION
Automated AFK landing for #2732. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2732

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787885868&installation_model_id=20659&pr_number=2769&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2769&signature=cf13dd5111b9e5cfce402d0a74221e6392d984b418b71f08aeb52835d299289b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->