### PR TITLE
chore: #2733 Contract: remove the adversarial-correction reason, old counters, and tombstone the retired key

### DIFF
--- a/.changeset/reseed-retires-the-convergence-counter.md
+++ b/.changeset/reseed-retires-the-convergence-counter.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The superseded correction vocabulary is deleted now that every call site draws from the one Re-seed budget (#2733, ADR 0129). `afk.stallConvergenceBudget` — the standalone post-DONE gate counter that stood beside the lane budget instead of inside it — carries an ADR 0117 tombstone in both spellings, so a repo that still sets it is warned `RETIRED` rather than left believing it tunes anything; its reader (`resolveStallConvergenceBudget`, `RED_AFK_STALL_CONVERGENCE_BUDGET`) is gone with it. The replacement is `dev.reseed.afk.gate_budget` (default 3, env `RED_RESEED_GATE_BUDGET`), which caps only the GATE's share of the budget: the ceiling and the review's reserved round belong to the lane profile, so a raised setting can neither buy an unbounded run nor consume the round a blocking review finding is entitled to. The `adversarial-correction` landing reason stays gone with a guard that fails if any shipped source reintroduces it — every non-ok landing outcome is now an actual landing failure.

--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -38,12 +38,11 @@ plugins:
             model: gpt-5.6-sol   # design/routing — grouped with coding
             effort: high
     # Adversarial review (ADR 0110, Spec #2205 — all slices landed 2026-07-19).
-    # Folds to `review.*`. Bounded by design at this setting:
-    #   decideAdversarialReview -> no blocking findings = "pass";
-    #   blocking + iteration <= cap = "correct" (one re-seed);
-    #   exhausted + cap < 2 = "pass". With max_iterations 1 it can NEVER park,
-    #   so the worst case is one extra correction round and the PR still lands.
-    #   Raising max_iterations to 2+ enables parking to ready-for-human.
+    # Folds to `review.*`. Review is the gate fold's third stage (ADR 0129): a
+    # blocking finding draws the RESERVED review round of the Re-seed budget, and
+    # exhaustion parks `ready-for-human` + `blocked:validation` uniformly — the
+    # old `cap < 2` cliff that landed known blocking findings is gone.
+    # `max_iterations` now bounds only the reviewer agent's own loop.
     review:
       # Maintainer decision 2026-07-22: review OFF in this repo — the extra
       # bounded round was still costing wall-clock on every landing during the

--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -147,7 +147,7 @@ Re-instructing the implementer **in place** — same **Worker**, same **Worktree
 _Avoid_: attempt (an Attempt is one Worker × one Ticket × one try; a Re-seed happens inside one), retry, attempt ordinal (retired by ADR 0103), correction retry
 
 **Re-seed budget**:
-The bound on how many **Re-seed** rounds one **Attempt** may spend. A single ceiling per lane holds sub-caps per cause — a failing gate stage, a repeated failure signature escalating the tier, a blocking review finding — and the review's round is a **reservation**, not a quota, so gate churn cannot consume it. Exhaustion with anything still outstanding parks `ready-for-human` + `blocked:validation`, uniformly and regardless of cause; landing with a known blocking finding is not reachable by config value.
+The bound on how many **Re-seed** rounds one **Attempt** may spend. A single ceiling per lane holds sub-caps per cause — a failing gate stage, a repeated failure signature escalating the tier, a blocking review finding — and the review's round is a **reservation**, not a quota, so gate churn cannot consume it. Exhaustion with anything still outstanding parks `ready-for-human` + `blocked:validation`, uniformly and regardless of cause; landing with a known blocking finding is not reachable by config value. An operator tunes only the gate's share (`dev.reseed.afk.gate_budget`); the ceiling and the reservation belong to the lane, so a raised setting can neither buy an unbounded run nor starve the review's round.
 _Avoid_: correction budget, convergence budget, stall convergence budget (the `afk.stallConvergenceBudget` key names the retired shape), heal ledger (that is the per-Ticket repair history, a different object), attempt ledger
 
 **Worker kind**:

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -305,8 +305,8 @@ export function buildProcessDeps({
     adversarialReview,
     extractAdversarialReview,
     goVerifyRetries,
-    stallConvergenceBudget: (() => {
-      const raw = getConfig(config, "afk.stallConvergenceBudget");
+    reseedGateBudget: (() => {
+      const raw = getConfig(config, "dev.reseed.afk.gate_budget");
       const parsed = raw === undefined ? NaN : Number(raw);
       return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
     })(),

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -255,13 +255,14 @@ export const CONFIG_DEFAULTS = {
   "afk.validation.node_max_old_space_mb": "2048",
   "afk.validation.vitest_max_workers": "1",
   "afk.validation.heavy_available_memory_mb": "4096",
-  // Post-DONE gate-correction convergence budget (#2285). After an inner agent
-  // emits DONE, if the feedback/backpressure gate still fails the worker re-seeds
-  // the agent with a bounded correction handoff instead of immediately parking.
-  // This cap limits consecutive failed gate cycles on one issue before the engine
-  // stops re-seeding and deterministically parks ready-for-human + blocked:validation
-  // with the last failing validation tail. Override with RED_AFK_STALL_CONVERGENCE_BUDGET.
-  "afk.stallConvergenceBudget": "3",
+  // The `/afk` lane's GATE share of the Re-seed budget (ADR 0129, #2733), the
+  // lane-scoped replacement for the retired `afk.stallConvergenceBudget`. It caps
+  // only how many Re-seed rounds a red post-DONE gate may claim; the lane owns
+  // the ceiling and the review's reserved round, so raising this can never eat
+  // the round a blocking review finding is entitled to. Exhaustion parks
+  // ready-for-human + blocked:validation with the last failing validation tail.
+  // Override with RED_RESEED_GATE_BUDGET.
+  "dev.reseed.afk.gate_budget": "3",
   // Spec cascade rebase (issue #1007). After a successful DONE landing, rebase
   // every open sibling branch (same spec:N, not held by a live worker) onto the
   // new base HEAD so the next worker to pick up a sibling starts from a
@@ -309,12 +310,19 @@ export type ConfigKey = keyof typeof CONFIG_DEFAULTS;
  * `afk.attempt_timeout` was the wall-clock attempt cap, retired when the
  * commit-anchored progress guard replaced it (ADR 0044/0045).
  *
+ * `afk.stallConvergenceBudget` was the standalone post-DONE gate-correction
+ * counter, retired when the four correction loops unified into one Re-seed with
+ * a lane-scoped budget (ADR 0129). Its replacement is
+ * `dev.reseed.afk.gate_budget`, which caps only the gate's SHARE of that budget.
+ *
  * To retire a key: delete its reader, add BOTH spellings here, and record the
  * removal in the ADR that retires it.
  */
 export const DELETED_CONFIG_KEYS: ReadonlySet<string> = new Set([
   "afk.attempt_timeout",
   "plugins.dev.afk.attempt_timeout",
+  "afk.stallConvergenceBudget",
+  "plugins.dev.afk.stallConvergenceBudget",
 ]);
 
 /**

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -140,7 +140,7 @@ import {
 } from "../adversarial-review.js";
 import type { ProcessIssueDeps, ProcessIssueInput, ProcessIssueResult, WorkerBaseResolution, ProcessOutcome } from "./types.js";
 import { baseResolutionStatePatch, formatBaseResolution, isMergeConflictRetry, markTerminalState, recoveryOrdinalFor, remoteTrackingBaseRef, resolveSpawnTier } from "./types.js";
-import { MECHANICAL_BLOCKER_KINDS, blockedLabelsIn, editIssueLifecycleLabels, formatNoSourceChangeWarning, hasLikelySourceChanges, parseFeedbackClass, refuseNoSandboxForUntrustedAuthor, resolveGoVerifyRetries, resolveStallConvergenceBudget, resolveStaleBaseDriftCap, resolveUntrustedAuthorSandbox, scoutCapturedDone, scoutReportFrom } from "./recovery.js";
+import { MECHANICAL_BLOCKER_KINDS, blockedLabelsIn, editIssueLifecycleLabels, formatNoSourceChangeWarning, hasLikelySourceChanges, parseFeedbackClass, refuseNoSandboxForUntrustedAuthor, resolveGoVerifyRetries, resolveReseedGateBudget, resolveStaleBaseDriftCap, resolveUntrustedAuthorSandbox, scoutCapturedDone, scoutReportFrom } from "./recovery.js";
 import type { ReseedSpend, ReseedTrigger } from "./reseed-budget.js";
 import {
   recordReseedDraw,
@@ -611,7 +611,7 @@ export async function processIssue(
     if (attribution.cause !== "stale-base-drift" || !movement) return { attribution };
     return { attribution, drift: { base, movement, attribution } };
   };
-  const stallConvergenceCap = resolveStallConvergenceBudget(deps);
+  const afkGateCap = resolveReseedGateBudget(deps);
   const isGoLane = input.laneLabel === LABEL_GO_LANE;
   const reseedLane: "/go" | "/afk" = isGoLane ? "/go" : "/afk";
   // ONE budget for every Re-seed this Attempt may spend (ADR 0129): the lane
@@ -620,7 +620,7 @@ export async function processIssue(
   // its own round instead of muting gate correction outright.
   const reseedBudget = withGateSubCap(
     resolveReseedBudget({ laneLabel: input.laneLabel, runMode: input.runMode }),
-    isGoLane ? goVerifyRetryCap : stallConvergenceCap,
+    isGoLane ? goVerifyRetryCap : afkGateCap,
   );
   let reseedSpend: ReseedSpend = {};
   const gateSubCap = reseedBudget.subCaps.gate;

--- a/apps/dev/src/core/process-issue/recovery.ts
+++ b/apps/dev/src/core/process-issue/recovery.ts
@@ -303,19 +303,27 @@ export function resolveGoVerifyRetries(deps: ProcessIssueDeps): number {
 export function resolveStaleBaseDriftCap(deps: ProcessIssueDeps): number {
   return resolveStaleBaseDriftCorrections(deps.recoveryEnv?.[STALE_BASE_DRIFT_CORRECTIONS_ENV]);
 }
-export const DEFAULT_STALL_CONVERGENCE_BUDGET = 0;
-export function resolveStallConvergenceBudget(deps: ProcessIssueDeps): number {
-  const raw = deps.recoveryEnv?.RED_AFK_STALL_CONVERGENCE_BUDGET;
+/** No caller-supplied share means NO gate Re-seed. The shipped default lives in
+ * `dev.reseed.afk.gate_budget` and reaches here through the run deps, so an
+ * embedder that wires nothing gets the conservative behaviour rather than a
+ * budget it never asked for. */
+export const DEFAULT_RESEED_GATE_BUDGET = 0;
+/** The `/afk` lane's GATE share of the Re-seed budget (ADR 0129). It bounds one
+ * cause, not the lane: the ceiling and the review's reserved round belong to the
+ * lane profile, which is why this folds in through `withGateSubCap` instead of
+ * standing on its own the way the retired stall-convergence counter did. */
+export function resolveReseedGateBudget(deps: ProcessIssueDeps): number {
+  const raw = deps.recoveryEnv?.RED_RESEED_GATE_BUDGET;
   const parsed = raw === undefined ? NaN : Number(raw);
   if (Number.isInteger(parsed) && parsed >= 0) return parsed;
   if (
-    deps.stallConvergenceBudget !== undefined &&
-    Number.isInteger(deps.stallConvergenceBudget) &&
-    deps.stallConvergenceBudget >= 0
+    deps.reseedGateBudget !== undefined &&
+    Number.isInteger(deps.reseedGateBudget) &&
+    deps.reseedGateBudget >= 0
   ) {
-    return deps.stallConvergenceBudget;
+    return deps.reseedGateBudget;
   }
-  return DEFAULT_STALL_CONVERGENCE_BUDGET;
+  return DEFAULT_RESEED_GATE_BUDGET;
 }
 // The gate and tier-escalation correction handoffs are no longer built here.
 // Each of the three appenders that lived at this spot rebuilt from the ORIGINAL

--- a/apps/dev/src/core/process-issue/reseed-budget.ts
+++ b/apps/dev/src/core/process-issue/reseed-budget.ts
@@ -12,13 +12,11 @@
 // Reserving the review's round makes it unreachable to gate and tier draws even
 // while the ceiling still has room.
 //
-// EXPAND STEP: the lifecycle's single `requestReseed` request path now draws
-// from this budget, but the operator-facing counters
-// (`resolveStallConvergenceBudget`, `resolveGoVerifyRetries`) still supply the
-// gate sub-cap through {@link withGateSubCap}. The retired stall-convergence key
-// therefore stays live and authoritative here; tombstoning it while the
-// lifecycle still reads it would break config loading, so that lands with the
-// contract slice.
+// The standalone stall-convergence counter is GONE (#2733): its key carries an
+// ADR 0117 tombstone and its replacement, `dev.reseed.afk.gate_budget`, folds in
+// through {@link withGateSubCap} as one cause's SHARE of this budget. The lane
+// keeps the ceiling and the review's reservation, so no operator setting can buy
+// an unbounded run or starve the review's round.
 
 import { LABEL_GO_LANE } from "../go.js";
 

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -277,7 +277,9 @@ export interface ProcessIssueDeps {
   outputShaping?: OutputShapingConfig;
   postBackpressureReview?: (pr: number, body: string) => Promise<void>;
   goVerifyRetries?: number;
-  stallConvergenceBudget?: number;
+  /** The `/afk` lane's gate share of the Re-seed budget (ADR 0129), from
+   * `dev.reseed.afk.gate_budget`. */
+  reseedGateBudget?: number;
   postWorkerFormat?: PostWorkerFormatExec;
   postWorkerFormatCommands?: readonly string[];
   runAgent(input: RunAgentInput): Promise<RunAgentResult>;

--- a/apps/dev/src/core/stale-base-drift.ts
+++ b/apps/dev/src/core/stale-base-drift.ts
@@ -1,8 +1,9 @@
 // stale-base-drift — CAUSE-AWARE accounting for post-DONE machine-gate failures
 // (issue #2711).
 //
-// The post-DONE correction budget (`RED_GO_VERIFY_RETRIES` for `/go`,
-// `RED_AFK_STALL_CONVERGENCE_BUDGET` for `/afk`) used to count ATTEMPTS, not
+// The post-DONE correction budget — the gate share of the Re-seed budget
+// (`RED_GO_VERIFY_RETRIES` for `/go`, `RED_RESEED_GATE_BUDGET` for `/afk`) — used
+// to count ATTEMPTS, not
 // CAUSES. That is the whole defect: the gate runs in a feedback worktree rebased
 // onto the live base, so when the base moves under a run — most sharply on a
 // `chore(release): version packages` bump, which rewrites every generated

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -1,5 +1,9 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_BRANCH_TIP, RWT, WT, doLanding, harness, joined, type Harness } from "./landing.test-support.js";
+
+const DEV_SRC = join(import.meta.dirname, "..", "src");
 
 describe("doLanding — happy paths", () => {
   it("unlocked → pushes, fires both hooks, lands via admin PR", async () => {
@@ -887,5 +891,35 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
     expect(h.postMergeGateDirs).toEqual([]);
+  });
+});
+
+describe("landing outcomes — every non-ok reason is a landing failure (ADR 0129)", () => {
+  // The `adversarial-correction` reason was the ONE non-ok landing outcome that
+  // was not a landing failure: review ran after the merge decision and aborted
+  // it to send the work back to the implementer. Review is the gate fold's third
+  // stage now (#2730), so the reason has no producer left — and a string scan is
+  // the only check that also catches a re-introduction in a comment, a log line,
+  // or a test fixture that would quietly resurrect the vocabulary.
+  it("no shipped dev source mentions the adversarial-correction landing reason", () => {
+    const offenders: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (!entry.name.endsWith(".ts")) continue;
+        if (readFileSync(full, "utf8").includes("adversarial-correction")) {
+          offenders.push(relative(DEV_SRC, full));
+        }
+      }
+    };
+    walk(DEV_SRC);
+
+    expect(offenders, `retired landing reason \`adversarial-correction\` found in: ${offenders.join(", ")}`).toEqual(
+      [],
+    );
   });
 });

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -1190,7 +1190,7 @@ describe("processIssue — review is the gate fold's third stage (#2730)", () =>
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackOk: false,
-      stallConvergenceBudget: 0,
+      reseedGateBudget: 0,
       locked: false,
       adversarialReview: { enabled: true, maxIterations: 1, reviewerCount: 1, quorum: "any" },
       adversarialFindings: { summary: "Never asked.", findings: [] },
@@ -1276,7 +1276,7 @@ describe("processIssue — review is the gate fold's third stage (#2730)", () =>
     const { deps, input, trace } = harness({
       outcomes: ["done", "done", "done"],
       feedbackResults: [true, false, false],
-      stallConvergenceBudget: 2,
+      reseedGateBudget: 2,
       locked: false,
       adversarialReview: { enabled: true, maxIterations: 1, reviewerCount: 1, quorum: "any" },
       adversarialFindingsSequence: [
@@ -1449,7 +1449,7 @@ describe("processIssue — review is the gate fold's third stage (#2730)", () =>
       outcomes: ["done", "done", "done", "done", "done"],
       // Three red gate rounds, then a green one the review gets to see.
       feedbackResults: [false, false, false, true, true],
-      stallConvergenceBudget: 3,
+      reseedGateBudget: 3,
       locked: false,
       adversarialReview: { enabled: true, maxIterations: 1, reviewerCount: 1, quorum: "any" },
       adversarialFindingsSequence: [
@@ -1786,7 +1786,7 @@ describe("processIssue — the Re-seed trail's two derived surfaces (#2731)", ()
       outcome: "done",
       // One red gate, then green: one Re-seed, then landing.
       feedbackResults: [false, true],
-      stallConvergenceBudget: 2,
+      reseedGateBudget: 2,
     });
     const result = await processIssue(deps, input);
 
@@ -1805,7 +1805,7 @@ describe("processIssue — the Re-seed trail's two derived surfaces (#2731)", ()
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackResults: [false, true],
-      stallConvergenceBudget: 2,
+      reseedGateBudget: 2,
     });
     const result = await processIssue(deps, input);
 
@@ -1821,7 +1821,7 @@ describe("processIssue — the Re-seed trail's two derived surfaces (#2731)", ()
       outcome: "done",
       // Two red gates, then green: two Re-seed rounds on one comment.
       feedbackResults: [false, false, true],
-      stallConvergenceBudget: 3,
+      reseedGateBudget: 3,
     });
     const result = await processIssue(deps, input);
 
@@ -1866,7 +1866,7 @@ describe("processIssue — an exhausted Re-seed budget parks with the draft open
     harness({
       outcome: "done",
       feedbackResults: [false, false],
-      stallConvergenceBudget: 1,
+      reseedGateBudget: 1,
     });
 
   /** A budget exhausted by the RESERVED review round: a blocking finding draws
@@ -1960,7 +1960,7 @@ describe("processIssue — an exhausted Re-seed budget parks with the draft open
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackResults: [false],
-      stallConvergenceBudget: 0,
+      reseedGateBudget: 0,
     });
     const result = await processIssue(deps, input);
 

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -235,7 +235,7 @@ export interface HarnessOptions {
   /** /go post-DONE machine-gate retry cap injected by run.ts. */
   goVerifyRetries?: number;
   /** /afk post-DONE gate-correction convergence budget (#2285). */
-  stallConvergenceBudget?: number;
+  reseedGateBudget?: number;
   /** When set, register the Brain outcome-event sink. "throw"/"hang" model Brain down/slow. */
   recordOutcomeEvent?: "ok" | "throw" | "hang";
   /** When false, omit the optional fs.writeValidationSidecar port (older-caller
@@ -653,7 +653,7 @@ export function harness(opts: HarnessOptions = {}): {
         }
       : undefined,
     goVerifyRetries: opts.goVerifyRetries,
-    stallConvergenceBudget: opts.stallConvergenceBudget,
+    reseedGateBudget: opts.reseedGateBudget,
     sandboxMode: opts.sandboxMode ?? "none",
     sandboxAvailable: async (mode) => (opts.availableSandboxes ?? ["docker", "podman"]).includes(mode),
     sandboxImage: opts.sandboxImage,

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -157,7 +157,7 @@ describe("processIssue — feedback fail", () => {
       // Round 1 fails; round 2 fails IDENTICALLY → the repeat buys the tier;
       // round 3 is green.
       feedbackResults: [false, false, true],
-      stallConvergenceBudget: 1,
+      reseedGateBudget: 1,
       classifyIssue: async () => "simple",
       resolveTier: (runner, taskClass) => {
         tiers.push({ runner, taskClass });
@@ -190,7 +190,7 @@ describe("processIssue — feedback fail", () => {
       // Four failing checks, then ONE — a different failure set, so a different
       // signature — then the same one again, which is the repeat.
       feedbackFailures: [["test", "typecheck", "lint", "build"], ["test"], ["test"], []],
-      stallConvergenceBudget: 2,
+      reseedGateBudget: 2,
       classifyIssue: async () => "simple",
       resolveTier: (runner, taskClass) => {
         tiers.push({ runner, taskClass });
@@ -231,7 +231,7 @@ describe("processIssue — feedback fail", () => {
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackResults: [false, false, false, true],
-      stallConvergenceBudget: 1,
+      reseedGateBudget: 1,
       classifyIssue: async () => "simple",
       resolveTier: (runner, taskClass) => {
         tiers.push({ runner, taskClass });
@@ -1326,12 +1326,12 @@ describe("processIssue — merge-conflict one-shot self-resolve (gap 3)", () => 
 });
 
 describe("processIssue — /afk post-DONE gate-correction convergence (#2285)", () => {
-  it("retries an empty-diff DONE up to stallConvergenceBudget, then parks with convergence note", async () => {
+  it("retries an empty-diff DONE up to the gate share of the Re-seed budget, then parks with convergence note", async () => {
     const { deps, input, trace } = harness({
       outcome: "done",
       changedFilesSequence: [[], []],
       feedbackOk: true,
-      stallConvergenceBudget: 1,
+      reseedGateBudget: 1,
     });
     const result = await processIssue(deps, input);
 
@@ -1349,7 +1349,7 @@ describe("processIssue — /afk post-DONE gate-correction convergence (#2285)", 
       outcome: "done",
       changedFilesSequence: [[], ["packages/x/src/a.ts"]],
       feedbackOk: true,
-      stallConvergenceBudget: 1,
+      reseedGateBudget: 1,
     });
     const result = await processIssue(deps, input);
 
@@ -1360,11 +1360,11 @@ describe("processIssue — /afk post-DONE gate-correction convergence (#2285)", 
     expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(false);
   });
 
-  it("retries a red feedback gate up to stallConvergenceBudget, then parks; handoff carries <afk-gate-correction>", async () => {
+  it("retries a red feedback gate up to the gate share of the Re-seed budget, then parks; handoff carries <afk-gate-correction>", async () => {
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackResults: [false, false],
-      stallConvergenceBudget: 1,
+      reseedGateBudget: 1,
     });
     const result = await processIssue(deps, input);
 
@@ -1382,7 +1382,7 @@ describe("processIssue — /afk post-DONE gate-correction convergence (#2285)", 
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackResults: [false, true],
-      stallConvergenceBudget: 2,
+      reseedGateBudget: 2,
     });
     const result = await processIssue(deps, input);
 
@@ -1392,13 +1392,13 @@ describe("processIssue — /afk post-DONE gate-correction convergence (#2285)", 
     expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(false);
   });
 
-  it("retries a red backpressure gate up to stallConvergenceBudget, then parks", async () => {
+  it("retries a red backpressure gate up to the gate share of the Re-seed budget, then parks", async () => {
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackOk: true,
       backpressureCommands: ["npm run e2e"],
       backpressureOk: false,
-      stallConvergenceBudget: 1,
+      reseedGateBudget: 1,
     });
     const result = await processIssue(deps, input);
 
@@ -1411,18 +1411,18 @@ describe("processIssue — /afk post-DONE gate-correction convergence (#2285)", 
     expect(trace.closed).toEqual([]);
   });
 
-  it("go lane ignores stallConvergenceBudget — retryAfkMachineGate is a no-op for lane:go", async () => {
+  it("go lane ignores the `/afk` gate share — retryAfkMachineGate is a no-op for lane:go", async () => {
     const { deps, input, trace } = harness({
       labels: ["lane:go"],
       laneLabel: "lane:go",
       outcome: "done",
       feedbackResults: [false],
       recoveryEnv: { RED_GO_VERIFY_RETRIES: "0" },
-      stallConvergenceBudget: 99,
+      reseedGateBudget: 99,
     });
     const result = await processIssue(deps, input);
 
-    // go lane with cap=0 parks on first failure; stallConvergenceBudget has no effect
+    // go lane with cap=0 parks on first failure; the /afk gate share has no effect
     expect(result.outcome).toBe("feedback-failed");
     expect(trace.runAgentCalls).toHaveLength(1);
     expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(true);
@@ -1649,7 +1649,7 @@ describe("processIssue — one Re-seed request path (#2727, ADR 0129)", () => {
       // complex tier with a CHANGED signature → one more gate Re-seed; park.
       feedbackFailures: [["test"], ["test"], ["lint"], ["lint"]],
       classifyIssue: async () => "simple",
-      stallConvergenceBudget: 2,
+      reseedGateBudget: 2,
     });
 
     const result = await processIssue(deps, input);
@@ -1676,7 +1676,7 @@ describe("processIssue — one Re-seed request path (#2727, ADR 0129)", () => {
       classifyIssue: async () => "simple",
       // A gate sub-cap far above the lane ceiling: the ceiling is what binds,
       // and the review's reserved round stays unreachable to gate and tier.
-      stallConvergenceBudget: 9,
+      reseedGateBudget: 9,
     });
 
     const result = await processIssue(deps, input);
@@ -1694,7 +1694,7 @@ describe("processIssue — one Re-seed request path (#2727, ADR 0129)", () => {
       // An empty-diff DONE first, then a red gate on the round that produced one.
       changedFilesSequence: [[], ["packages/x/src/a.ts"], ["packages/x/src/a.ts"]],
       feedbackResults: [false, false],
-      stallConvergenceBudget: 2,
+      reseedGateBudget: 2,
     });
 
     const result = await processIssue(deps, input);

--- a/apps/dev/tests/reseed-budget.test.ts
+++ b/apps/dev/tests/reseed-budget.test.ts
@@ -156,22 +156,51 @@ describe("Re-seed budget — the ceiling binds the sub-caps", () => {
   });
 });
 
-describe("Re-seed budget — the retired key is still live in this slice", () => {
+describe("Re-seed budget — the retired stall-convergence key (ADR 0117 tombstone)", () => {
   const OPTED_IN_WITH_STALL =
     "plugins:\n  dev:\n    enabled: true\n    afk:\n      stallConvergenceBudget: 5\n";
 
-  it("still resolves the stall-convergence key and does not report it as retired", () => {
+  it("reports the stall-convergence key as retired and never reads it back", () => {
     const warnings: string[] = [];
     const audit = auditConfigLoad("/x/.red/config.yaml", {
       read: () => OPTED_IN_WITH_STALL,
       warn: (m) => warnings.push(m),
     });
 
+    expect(audit.retiredKeys).toEqual(["plugins.dev.afk.stallConvergenceBudget"]);
+    expect(warnings.join("\n")).toContain("RETIRED");
+    expect(getConfig(audit.values, "afk.stallConvergenceBudget")).toBe("");
+  });
+
+  it("tombstones the legacy top-level spelling too", () => {
+    const audit = auditConfigLoad("/x/.red/config.yaml", {
+      read: () => "plugins:\n  dev:\n    enabled: true\nafk:\n  stallConvergenceBudget: 5\n",
+      warn: () => {},
+    });
+
+    expect(audit.retiredKeys).toEqual(["afk.stallConvergenceBudget"]);
+    expect(getConfig(audit.values, "afk.stallConvergenceBudget")).toBe("");
+  });
+
+  it("both spellings are tombstoned and neither keeps a live default", () => {
+    for (const key of ["afk.stallConvergenceBudget", "plugins.dev.afk.stallConvergenceBudget"]) {
+      expect(DELETED_CONFIG_KEYS.has(key)).toBe(true);
+      expect(Object.prototype.hasOwnProperty.call(CONFIG_DEFAULTS, key)).toBe(false);
+    }
+  });
+
+  it("the lane-scoped replacement carries the `/afk` gate sub-cap as its default", () => {
+    expect(CONFIG_DEFAULTS["dev.reseed.afk.gate_budget"]).toBe(String(AFK_RESEED_BUDGET.subCaps.gate));
+  });
+
+  it("resolves the replacement key from an opted-in file", () => {
+    const audit = auditConfigLoad("/x/.red/config.yaml", {
+      read: () =>
+        "plugins:\n  dev:\n    enabled: true\n    reseed:\n      afk:\n        gate_budget: 5\n",
+      warn: () => {},
+    });
+
     expect(audit.retiredKeys).toEqual([]);
-    expect(warnings.join("\n")).not.toContain("RETIRED");
-    expect(getConfig(audit.values, "afk.stallConvergenceBudget")).toBe("5");
-    expect(DELETED_CONFIG_KEYS.has("afk.stallConvergenceBudget")).toBe(false);
-    expect(DELETED_CONFIG_KEYS.has("plugins.dev.afk.stallConvergenceBudget")).toBe(false);
-    expect(CONFIG_DEFAULTS["afk.stallConvergenceBudget"]).toBe("3");
+    expect(getConfig(audit.values, "dev.reseed.afk.gate_budget")).toBe("5");
   });
 });


### PR DESCRIPTION
Automated AFK landing for #2733. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2733

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787888240&installation_model_id=20659&pr_number=2770&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2770&signature=4a1741a34da9056aeca5b151ebc2138e50245b31579684ed456331eebbf1db93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->