### PR TITLE
chore: #2778 Project identity resolves once, and project.name becomes a sanctioned root key

### DIFF
--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -333,6 +333,25 @@ export const DELETED_CONFIG_KEYS: ReadonlySet<string> = new Set([
  */
 export const PLUGIN_ENABLED_KEY = "plugins.dev.enabled";
 
+/**
+ * Root keys the contract SANCTIONS. Every other root-level accessor spelling is
+ * off-contract and warns (see {@link rootAccessorConfigCollisions}).
+ *
+ * `project.name` is the first entry and one of the few cases where the config
+ * root is right rather than a leak: project identity is shared by the dev,
+ * memory and brain plugins in one repository, so it belongs to none of them and
+ * cannot live under `plugins.<name>.*`. The canonical reader is
+ * `declaredProjectNameInConfig` in `packages/shared/project-identity.ts`, which
+ * is deliberately gate-independent — a memory-only repository declares its
+ * identity the same way a dev one does.
+ *
+ * To sanction a root key: add it here and record the sanction in the ADR that
+ * grants it.
+ */
+export const SANCTIONED_ROOT_CONFIG_KEYS: ReadonlySet<string> = new Set([
+  "project.name",
+]);
+
 export const AFK_MODEL_TIERS = ["validate", "simple", "complex", "think"] as const;
 export type AfkModelTier = (typeof AFK_MODEL_TIERS)[number];
 
@@ -688,6 +707,7 @@ function configParseFailure(err: unknown): ConfigParseFailure {
 
 export function rootAccessorConfigCollisions(values: ConfigValues): RootAccessorConfigCollision[] {
   return Object.keys(values)
+    .filter((key) => !SANCTIONED_ROOT_CONFIG_KEYS.has(key))
     .filter((key) => key.startsWith("dev.") || key.startsWith("afk."))
     .sort()
     .map((key) => ({

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -18,7 +18,9 @@ import {
   resolveCiTimeoutSeconds,
   DEFAULT_MERGE_CI_TIMEOUT_S,
   rootDevConfigCollisionsFromText,
+  SANCTIONED_ROOT_CONFIG_KEYS,
 } from "../src/core/config.js";
+import { PROJECT_NAME_CONFIG_KEY } from "@reddb-io/shared/project-identity.js";
 import {
   aggregateAdversarialReviewFindings,
   decideAdversarialReview,
@@ -150,6 +152,40 @@ describe("config — retired-key tombstone (ADR 0117)", () => {
     for (const key of DELETED_CONFIG_KEYS) {
       expect(Object.prototype.hasOwnProperty.call(CONFIG_DEFAULTS, key)).toBe(false);
     }
+  });
+});
+
+describe("config — sanctioned root keys", () => {
+  const OPT_IN = "plugins:\n  dev:\n    enabled: true\n";
+
+  it("`project.name` at the root is sanctioned — no off-contract warning", () => {
+    const warnings: string[] = [];
+    const audit = auditConfigLoad("/x/.red/config.yaml", {
+      read: () => `project:\n  name: Red Skills\n${OPT_IN}`,
+      warn: (m) => warnings.push(m),
+    });
+    expect(audit.rootAccessorCollisions).toEqual([]);
+    expect(warnings.join("\n")).not.toContain("off-contract");
+    expect(getConfig(audit.values, "project.name")).toBe("Red Skills");
+  });
+
+  it("an unsanctioned root key is still off-contract", () => {
+    const warnings: string[] = [];
+    const audit = auditConfigLoad("/x/.red/config.yaml", {
+      read: () => `dev:\n  trunk: main\n${OPT_IN}`,
+      warn: (m) => warnings.push(m),
+    });
+    expect(audit.rootAccessorCollisions.map((c) => c.key)).toEqual(["dev.trunk"]);
+    expect(warnings.join("\n")).toContain("off-contract");
+  });
+
+  it("the sanction is per-key, not per-namespace — `project.other` is not sanctioned into existence", () => {
+    expect(SANCTIONED_ROOT_CONFIG_KEYS.has("project.name")).toBe(true);
+    expect(SANCTIONED_ROOT_CONFIG_KEYS.has("project.other")).toBe(false);
+  });
+
+  it("the sanctioned key matches the shared reader's key", () => {
+    expect(SANCTIONED_ROOT_CONFIG_KEYS.has(PROJECT_NAME_CONFIG_KEY)).toBe(true);
   });
 });
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,6 +18,7 @@
     "./toon-migration.js": "./toon-migration.ts",
     "./log.js": "./log.ts",
     "./plugin-gate.js": "./plugin-gate.ts",
+    "./project-identity.js": "./project-identity.ts",
     "./red-paths.js": "./red-paths.ts",
     "./repo-root.js": "./repo-root.ts",
     "./outcome-event.js": "./outcome-event.ts",

--- a/packages/shared/project-identity.test.ts
+++ b/packages/shared/project-identity.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  declaredProjectNameInConfig,
+  PROJECT_NAME_CONFIG_KEY,
+  resolveProjectIdentity,
+  type ProjectIdentityInput,
+} from "./project-identity.js";
+
+/**
+ * Table-driven and filesystem-free by contract: every case is a literal input
+ * record, so the resolver is proven pure over its inputs rather than over a
+ * checkout that happens to exist on the machine running the suite.
+ */
+
+const MAIN: ProjectIdentityInput = {
+  checkoutPath: "/home/dev/code/red-skills",
+  gitCommonDir: "/home/dev/code/red-skills/.git",
+  remoteUrl: "git@github.com:reddb-io/red-skills.git",
+};
+
+const CLONE: ProjectIdentityInput = {
+  checkoutPath: "/home/dev/other/red-skills",
+  gitCommonDir: "/home/dev/other/red-skills/.git",
+  remoteUrl: "git@github.com:reddb-io/red-skills.git",
+};
+
+const WORKTREE: ProjectIdentityInput = {
+  checkoutPath: "/home/dev/code/red-skills/.red/tmp/workers/w1/2778/worktree",
+  gitCommonDir: "/home/dev/code/red-skills/.git",
+  remoteUrl: "git@github.com:reddb-io/red-skills.git",
+};
+
+describe("resolveProjectIdentity — name resolution order", () => {
+  const cases: { readonly label: string; readonly input: ProjectIdentityInput; readonly name: string; readonly source: string }[] = [
+    {
+      label: "a declared name wins over the remote",
+      input: { ...MAIN, declaredName: "Red Skills" },
+      name: "Red Skills",
+      source: "declared",
+    },
+    {
+      label: "a blank declared name is not a declaration",
+      input: { ...MAIN, declaredName: "   " },
+      name: "reddb-io/red-skills",
+      source: "remote",
+    },
+    {
+      label: "the remote wins over the basename",
+      input: MAIN,
+      name: "reddb-io/red-skills",
+      source: "remote",
+    },
+    {
+      label: "no remote and no declared name falls back to the checkout basename",
+      input: { checkoutPath: "/home/dev/code/scratch-repo", gitCommonDir: "/home/dev/code/scratch-repo/.git" },
+      name: "scratch-repo",
+      source: "basename",
+    },
+    {
+      label: "the basename fallback names the main checkout, not the worktree directory",
+      input: { checkoutPath: "/home/dev/code/red-skills/.red/tmp/workers/w1/2778/worktree", gitCommonDir: "/home/dev/code/red-skills/.git" },
+      name: "red-skills",
+      source: "basename",
+    },
+    {
+      label: "outside a git checkout the basename of the path is used",
+      input: { checkoutPath: "/home/dev/code/loose-dir" },
+      name: "loose-dir",
+      source: "basename",
+    },
+    {
+      label: "an https remote resolves owner/repo",
+      input: { ...MAIN, remoteUrl: "https://github.com/reddb-io/red-skills.git" },
+      name: "reddb-io/red-skills",
+      source: "remote",
+    },
+    {
+      label: "an ssh:// remote resolves owner/repo",
+      input: { ...MAIN, remoteUrl: "ssh://git@github.com:22/reddb-io/red-skills.git" },
+      name: "reddb-io/red-skills",
+      source: "remote",
+    },
+    {
+      label: "a nested group remote keeps the last two segments",
+      input: { ...MAIN, remoteUrl: "https://gitlab.com/group/sub/red-skills.git" },
+      name: "sub/red-skills",
+      source: "remote",
+    },
+    {
+      label: "a single-segment remote resolves the repo name alone",
+      input: { ...MAIN, remoteUrl: "https://example.com/red-skills.git" },
+      name: "red-skills",
+      source: "remote",
+    },
+    {
+      label: "an unparseable remote falls through to the basename",
+      input: { ...MAIN, remoteUrl: "not a url" },
+      name: "red-skills",
+      source: "basename",
+    },
+  ];
+
+  for (const testCase of cases) {
+    it(testCase.label, () => {
+      const identity = resolveProjectIdentity(testCase.input);
+      expect(identity.name).toBe(testCase.name);
+      expect(identity.source).toBe(testCase.source);
+    });
+  }
+});
+
+describe("resolveProjectIdentity — slug", () => {
+  it("always carries a short hash, with no collision needed to earn it", () => {
+    const identity = resolveProjectIdentity(MAIN);
+    expect(identity.slug).toMatch(/^reddb-io--red-skills-[0-9a-f]{8}$/);
+    expect(identity.hash).toMatch(/^[0-9a-f]{8}$/);
+    expect(identity.slug.endsWith(identity.hash)).toBe(true);
+  });
+
+  it("gives two independent clones of one repository different slugs", () => {
+    const main = resolveProjectIdentity(MAIN);
+    const clone = resolveProjectIdentity(CLONE);
+    expect(main.name).toBe(clone.name);
+    expect(main.slug).not.toBe(clone.slug);
+  });
+
+  it("collapses a worktree onto the project its main checkout owns", () => {
+    expect(resolveProjectIdentity(WORKTREE).slug).toBe(resolveProjectIdentity(MAIN).slug);
+  });
+
+  it("ignores a trailing separator on the git common directory", () => {
+    const trailing = resolveProjectIdentity({ ...MAIN, gitCommonDir: "/home/dev/code/red-skills/.git/" });
+    expect(trailing.slug).toBe(resolveProjectIdentity(MAIN).slug);
+  });
+
+  it("hashes the checkout path when there is no git common directory", () => {
+    const a = resolveProjectIdentity({ checkoutPath: "/home/dev/a/loose" });
+    const b = resolveProjectIdentity({ checkoutPath: "/home/dev/b/loose" });
+    expect(a.name).toBe(b.name);
+    expect(a.slug).not.toBe(b.slug);
+  });
+
+  const slugCases: { readonly label: string; readonly declaredName: string; readonly slugBase: string }[] = [
+    { label: "lowercases and hyphenates a display name", declaredName: "Red Skills", slugBase: "red-skills" },
+    { label: "maps a path separator to a double hyphen", declaredName: "reddb-io/red-skills", slugBase: "reddb-io--red-skills" },
+    { label: "collapses runs of punctuation inside a segment", declaredName: "red__.. skills", slugBase: "red-skills" },
+    { label: "trims leading and trailing separators", declaredName: " -Red Skills- ", slugBase: "red-skills" },
+    { label: "drops empty path segments", declaredName: "owner//repo", slugBase: "owner--repo" },
+    { label: "falls back to `project` when nothing survives slugification", declaredName: "!!!", slugBase: "project" },
+    { label: "keeps digits", declaredName: "Repo 2778", slugBase: "repo-2778" },
+  ];
+
+  for (const testCase of slugCases) {
+    it(testCase.label, () => {
+      const identity = resolveProjectIdentity({ ...MAIN, declaredName: testCase.declaredName });
+      expect(identity.slug).toBe(`${testCase.slugBase}-${identity.hash}`);
+    });
+  }
+});
+
+describe("declaredProjectNameInConfig", () => {
+  it("names the sanctioned root key", () => {
+    expect(PROJECT_NAME_CONFIG_KEY).toBe("project.name");
+  });
+
+  it("reads a root-level project.name", () => {
+    expect(declaredProjectNameInConfig("project:\n  name: Red Skills\n")).toBe("Red Skills");
+  });
+
+  it("reads it without any plugin being enabled", () => {
+    expect(declaredProjectNameInConfig("project:\n  name: Red Skills\nplugins:\n  dev:\n    enabled: false\n"))
+      .toBe("Red Skills");
+  });
+
+  it("is undefined when absent", () => {
+    expect(declaredProjectNameInConfig("plugins:\n  dev:\n    enabled: true\n")).toBeUndefined();
+  });
+
+  it("is undefined when the key carries no value", () => {
+    expect(declaredProjectNameInConfig("project:\n  name:\n")).toBeUndefined();
+  });
+});
+
+describe("resolveProjectIdentity — purity", () => {
+  it("returns the same identity for the same inputs", () => {
+    expect(resolveProjectIdentity(MAIN)).toEqual(resolveProjectIdentity({ ...MAIN }));
+  });
+
+  it("does not mutate its input", () => {
+    const input = { ...MAIN };
+    resolveProjectIdentity(input);
+    expect(input).toEqual(MAIN);
+  });
+});

--- a/packages/shared/project-identity.ts
+++ b/packages/shared/project-identity.ts
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto";
+import { flatConfigValue } from "./plugin-gate.js";
+
+/**
+ * project-identity.ts — one identity per project, resolved once (Spec #2772).
+ *
+ * A project has two names and they are not the same thing:
+ *   - `name` is what a human reads. It resolves from a declared `project.name`,
+ *     then the git remote's `owner/repo`, then the checkout basename.
+ *   - `slug` is what the filesystem uses. It is the slugified name plus a short
+ *     hash of the absolute git common directory, ALWAYS present.
+ *
+ * The hash is unconditional on purpose. Detecting a collision first is racy —
+ * two clients may not see each other's directories at the same instant, so a
+ * collision-only suffix fails in exactly the case it exists for.
+ *
+ * Hashing the git *common* directory rather than the checkout has a second
+ * effect that is wanted, not incidental: every worktree of a repository collapses
+ * onto the project its main checkout owns, which is the correct owner for a
+ * Worker running inside one.
+ *
+ * A generated `project.id` written back into config was considered and rejected:
+ * the config file is versioned, so a clone would inherit the id and recreate the
+ * very collision it was meant to prevent.
+ *
+ * The resolver is PURE over its inputs — it reads no filesystem, no environment
+ * and no git process. Callers collect `remoteUrl` and `gitCommonDir` and hand
+ * them in, so the decision itself stays testable as a table.
+ */
+
+/**
+ * The sanctioned root-level config key holding the declared display name.
+ *
+ * The config ROOT is right here rather than a leak: identity is shared by the
+ * dev, memory and brain plugins in one repository, so it belongs to none of
+ * them. Because the loader treats an unsanctioned root key as off-contract, the
+ * sanction is explicit — see `SANCTIONED_ROOT_CONFIG_KEYS` in
+ * `apps/dev/src/core/config.ts`.
+ */
+export const PROJECT_NAME_CONFIG_KEY = "project.name";
+
+/**
+ * Read the declared `project.name` from the TEXT of a `.red/config.yaml`.
+ *
+ * Deliberately independent of any plugin's activation gate: a memory-only or
+ * brain-only repository declares its identity the same way a dev one does.
+ * Returns `undefined` when the key is absent or blank.
+ */
+export function declaredProjectNameInConfig(text: string): string | undefined {
+  const value = flatConfigValue(text, PROJECT_NAME_CONFIG_KEY)?.trim();
+  return value === undefined || value === "" ? undefined : value;
+}
+
+/** Where the resolved display name came from. */
+export type ProjectNameSource = "declared" | "remote" | "basename";
+
+export interface ProjectIdentityInput {
+  /** Absolute path of the checkout being resolved — a main checkout or a worktree. */
+  readonly checkoutPath: string;
+  /**
+   * Absolute path of the git common directory (`git rev-parse --git-common-dir`).
+   * A worktree reports its MAIN checkout's `.git`, which is what collapses the
+   * worktree onto its owning project. Absent outside a git checkout.
+   */
+  readonly gitCommonDir?: string;
+  /** The `origin` remote URL, when the checkout has one. */
+  readonly remoteUrl?: string;
+  /** A declared root-level `project.name` from `.red/config.yaml`, when set. */
+  readonly declaredName?: string;
+}
+
+export interface ProjectIdentity {
+  /** The display name — declared, else `owner/repo`, else the checkout basename. */
+  readonly name: string;
+  /** The filesystem slug — `<slugified-name>-<hash>`, the hash always present. */
+  readonly slug: string;
+  /** The short hash of the git common directory (or the checkout path without one). */
+  readonly hash: string;
+  /** Which rung of the resolution order produced {@link name}. */
+  readonly source: ProjectNameSource;
+}
+
+/** Hash width. Eight hex characters keep the slug readable while leaving ~4e9
+ * values — far past the number of checkouts one machine will ever hold. */
+const HASH_LENGTH = 8;
+
+/** The slug when a name slugifies to nothing at all (e.g. `!!!`). */
+const SLUG_FALLBACK = "project";
+
+export function resolveProjectIdentity(input: ProjectIdentityInput): ProjectIdentity {
+  const commonDir = normalizeDir(input.gitCommonDir);
+  const declared = (input.declaredName ?? "").trim();
+
+  const resolved = declared !== ""
+    ? { name: declared, source: "declared" as const }
+    : remoteName(input.remoteUrl) ?? { name: checkoutName(input.checkoutPath, commonDir), source: "basename" as const };
+
+  const hash = shortHash(commonDir ?? normalizePath(input.checkoutPath));
+  return { name: resolved.name, slug: `${slugify(resolved.name)}-${hash}`, hash, source: resolved.source };
+}
+
+/** `owner/repo` from a remote URL, in every spelling git accepts: scp-style
+ * (`git@host:owner/repo.git`), `https://`, and `ssh://` with an optional port.
+ * Nested groups keep the last two segments, which is the pair that identifies
+ * the repository to a human. */
+function remoteName(remoteUrl: string | undefined): { name: string; source: ProjectNameSource } | undefined {
+  const raw = (remoteUrl ?? "").trim();
+  if (raw === "") return undefined;
+
+  const withoutScheme = raw.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, "");
+  // scp-style `host:owner/repo` — the colon is a path separator, not a port.
+  const scp = /^[^/]*?:(?!\d)(.+)$/.exec(withoutScheme);
+  const afterHost = scp ? scp[1]! : withoutScheme.replace(/^[^/]*/, "");
+
+  const segments = afterHost
+    .replace(/\.git$/, "")
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment !== "");
+  if (segments.length === 0) return undefined;
+
+  const name = segments.slice(-2).join("/");
+  return { name, source: "remote" };
+}
+
+/** The basename fallback. Prefer the MAIN checkout's directory name (the parent
+ * of the git common directory) so a worktree does not report itself — a worktree
+ * is not a separate project. */
+function checkoutName(checkoutPath: string, commonDir: string | undefined): string {
+  const fromCommonDir = commonDir === undefined ? "" : baseName(parentName(commonDir));
+  if (fromCommonDir !== "") return fromCommonDir;
+  const fromCheckout = baseName(normalizePath(checkoutPath));
+  return fromCheckout === "" ? SLUG_FALLBACK : fromCheckout;
+}
+
+/** Lowercase, path separators become `--`, every other run of non-alphanumerics
+ * becomes a single `-`. `reddb-io/red-skills` → `reddb-io--red-skills`. */
+function slugify(name: string): string {
+  const segments = name
+    .split("/")
+    .map((segment) => segment.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, ""))
+    .filter((segment) => segment !== "");
+  const slug = segments.join("--");
+  return slug === "" ? SLUG_FALLBACK : slug;
+}
+
+function shortHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, HASH_LENGTH);
+}
+
+function normalizeDir(dir: string | undefined): string | undefined {
+  const normalized = normalizePath(dir ?? "");
+  return normalized === "" ? undefined : normalized;
+}
+
+/** Backslashes fold to `/` and a trailing separator is dropped, so the same
+ * directory spelled two ways hashes to one value. Deliberately NOT `path.resolve`:
+ * resolving would consult `process.cwd()` and break purity. */
+function normalizePath(value: string): string {
+  const unified = value.trim().replace(/\\/g, "/");
+  return unified.length > 1 ? unified.replace(/\/+$/, "") : unified;
+}
+
+function baseName(value: string): string {
+  const segments = value.split("/").filter((segment) => segment !== "");
+  return segments[segments.length - 1] ?? "";
+}
+
+function parentName(value: string): string {
+  const segments = value.split("/").filter((segment) => segment !== "");
+  return segments.slice(0, -1).join("/");
+}


### PR DESCRIPTION
Automated AFK landing for #2778. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2778

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787934202&installation_model_id=20659&pr_number=2797&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2797&signature=3f1845b0993754714b7ffd15b6c9ee792e60532381c3be948586544e139e48f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->