### PR TITLE
merge: #2783 The Worker state file becomes TOON/TOONL

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -50,7 +50,7 @@ import {
 } from "../../core/process-safety.js";
 import { dirname, join } from "node:path";
 import { workerIdentity } from "../../core/host-identity.js";
-import { initStateSync, readPidStartTime, updateState, writeIdentitySync } from "../../core/state.js";
+import { initStateSync, readPidStartTime, updateState, workerStatePath, writeIdentitySync } from "../../core/state.js";
 import { createCastleWorkerLaneBridge } from "../../core/castle-worker-lane-bridge.js";
 import { HOST_CONFIG_EXIT_CODE } from "../../core/worker-outcome.js";
 
@@ -323,7 +323,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         await fsx.removeDir(pi.attemptDir).catch(() => {});
         return result;
       }
-      const sp = join(pi.attemptDir, "afk.state.toon");
+      const sp = workerStatePath(pi.attemptDir);
       if (await fsx.pathExists(sp)) {
         await updateState(sp, { pid: 0 }, { allowPidReset: true }).catch(() => {});
         await castleBridge.snapshot().catch(() => {});
@@ -392,7 +392,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       // vitals but NO identity (rendered as a pid-0 `?`/idle ghost in monitor /
       // statusline). Seeding synchronously guarantees the identity exists before
       // any updateState runs, so every later read preserves it.
-      const statePath = join(attemptDir, "afk.state.toon");
+      const statePath = workerStatePath(attemptDir);
       const startedAt = new Date().toISOString();
       try {
         initStateSync(statePath, {

--- a/apps/dev/src/commands/run/implementer-run-agent.ts
+++ b/apps/dev/src/commands/run/implementer-run-agent.ts
@@ -4,7 +4,7 @@ import type { CastleWorkerLaneBridge } from "../../core/castle-worker-lane-bridg
 import type { ConfigValues } from "../../core/config.js";
 import { getConfig } from "../../core/config.js";
 import type { LaneIdleStallConfig } from "../../core/lane-idle-reaper.js";
-import { updateState } from "../../core/state.js";
+import { updateState, workerStatePath } from "../../core/state.js";
 import {
   prepareImplementerEnvironment,
   type ImplementerPluginRoots,
@@ -82,7 +82,7 @@ export function makeImplementerRunAgent(
           environment.recordRunnerStartup(
             Math.max(0, Math.round(performance.now() - launchStarted)),
           );
-          void updateState(join(attemptDir, "afk.state.toon"), {
+          void updateState(workerStatePath(attemptDir), {
             "current.implementer_runner_startup_before_ms":
               environment.metrics.runner_startup_ms.before,
             "current.implementer_runner_startup_after_ms":

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -45,7 +45,7 @@ import { deathCauseForRecoveredWorker } from "../../core/process-safety.js";
 import { join } from "node:path";
 import { hostFingerprintPrefix } from "../../core/host-identity.js";
 import { appendAgentRecord, appendRecordToonlTaggedRow } from "../../core/jsonl-log.js";
-import { updateState } from "../../core/state.js";
+import { updateState, workerStatePath } from "../../core/state.js";
 import { buildProgressHeartbeat, formatIterationMarker } from "../../core/heartbeat.js";
 import { resolveAttemptLoc, locMemoPath } from "../../core/loc-memo.js";
 import { createActivityMeter } from "../../core/activity-meter.js";
@@ -556,7 +556,7 @@ export function buildProcessDeps({
         if (lastIter > 0) emit(formatIterationMarker(lastIter, "ended", iterMax), "ended", lastIter);
         lastIter = event.iteration;
         emit(formatIterationMarker(lastIter, "started", iterMax), "started", lastIter);
-        void updateState(join(dir0, "afk.state.toon"), { "current.iteration": String(lastIter) }).catch(() => {});
+        void updateState(workerStatePath(dir0), { "current.iteration": String(lastIter) }).catch(() => {});
       }
       const msg =
         event.type === "text"
@@ -621,7 +621,7 @@ export function buildProcessDeps({
             }
           : {};
       if (activity || discrete) {
-        void updateState(join(current.attemptDir, "afk.state.toon"), {
+        void updateState(workerStatePath(current.attemptDir), {
           ...(activity ? { "current.activity": activity, "current.last_stream_line": msg.slice(0, 200) } : {}),
           // Any inner-agent stream activity means we are in the macro `coding`
           // phase (collapses explore/impl/tests/commit — the fine activity lives in
@@ -729,7 +729,7 @@ export function buildProcessDeps({
           fields: { extra: hb.extra },
         }).catch(() => {});
         await fsx.appendLine(join(current.attemptDir, "afk.log"), `[heartbeat] ${hb.msg}`);
-        await updateState(join(current.attemptDir, "afk.state.toon"), {
+        await updateState(workerStatePath(current.attemptDir), {
           ...hb.statePatch,
           "current.loc_peak_added": peakLocAdded,
           "current.loc_peak_removed": peakLocRemoved,
@@ -781,7 +781,7 @@ export function buildProcessDeps({
     // signal must never fail the run.
     markPhase: (phase) => {
       void (async () => {
-        await updateState(join(current.attemptDir, "afk.state.toon"), {
+        await updateState(workerStatePath(current.attemptDir), {
           "current.phase": phase,
         }).catch(() => {});
         await castleBridge.snapshot().catch(() => {});
@@ -789,7 +789,7 @@ export function buildProcessDeps({
     },
     markState: (patch) => {
       void (async () => {
-        await updateState(join(current.attemptDir, "afk.state.toon"), patch).catch(() => {});
+        await updateState(workerStatePath(current.attemptDir), patch).catch(() => {});
         await castleBridge.snapshot().catch(() => {});
       })();
     },

--- a/apps/dev/src/commands/run/state.ts
+++ b/apps/dev/src/commands/run/state.ts
@@ -6,7 +6,7 @@ import { parseHistoryLines, requeueOrdinal } from "../../core/history.js";
 import { existsSync, readFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
-import { initStateSync, writeIdentitySync } from "../../core/state.js";
+import { initStateSync, workerStatePath, writeIdentitySync } from "../../core/state.js";
 import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../../core/toon-snapshot.js";
 import type { LocMemo } from "../../core/loc-memo.js";
 import { LivenessLane, LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
@@ -32,7 +32,7 @@ export interface BootWorkerStateInput {
  */
 export async function initBootWorkerState(input: BootWorkerStateInput): Promise<string> {
   const attemptDir = join(workerDirPath(input.tmpDir, input.workerId), "boot");
-  const statePath = join(attemptDir, "afk.state.toon");
+  const statePath = workerStatePath(attemptDir);
   const nowMs = input.nowMs ?? (() => Date.now());
   const startedAt = new Date(nowMs()).toISOString();
   initStateSync(statePath, {

--- a/apps/dev/src/core/adopt-presence.ts
+++ b/apps/dev/src/core/adopt-presence.ts
@@ -16,8 +16,8 @@
 // zero disk. No reader changes — the reader already unions every worker-lane
 // namespace and reads `origin` off the state (issue #1306).
 
-import { join } from "node:path";
 import { buildWorkerAttemptPath } from "./worker-paths.js";
+import { workerStatePath } from "./state.js";
 
 /** Spawn-time provenance stamped on an adopt-landing presence row, distinct from
  * `afk` / `go` / `urgent` so the monitor/statusline render its per-source count
@@ -105,7 +105,7 @@ export async function withAdoptPresence<T>(
     params.issue,
     REQUEUE_ADOPT_ATTEMPT,
   );
-  const statePath = join(attemptDir, "afk.state.toon");
+  const statePath = workerStatePath(attemptDir);
   io.seed({
     statePath,
     attemptDir,

--- a/apps/dev/src/core/castle-worker-lane-bridge.ts
+++ b/apps/dev/src/core/castle-worker-lane-bridge.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   createCastleLaneWriters,
@@ -9,7 +8,8 @@ import {
   type CastleStateSnapshot,
 } from "@reddb-io/red-castle/engine";
 import { LivenessLane, LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
-import { parseStateDocument } from "./state.js";
+import { workerStatePath } from "./state.js";
+import { readWorkerStateDocument } from "./worker-state-reader.js";
 import type { AfkState } from "../types/state.js";
 
 export type WorkerLifecycleKind =
@@ -75,11 +75,7 @@ function snapshotFromState(
 
 function readAttemptState(attemptDir: string): AfkState | null {
   if (!attemptDir) return null;
-  try {
-    return parseStateDocument(readFileSync(join(attemptDir, "afk.state.toon"), "utf8"));
-  } catch {
-    return null;
-  }
+  return readWorkerStateDocument(workerStatePath(attemptDir));
 }
 
 export function createCastleWorkerLaneBridge(

--- a/apps/dev/src/core/output-shaping-report.ts
+++ b/apps/dev/src/core/output-shaping-report.ts
@@ -1,7 +1,8 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { encode as encodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
-import { parseStateDocument } from "./state.js";
+import { WORKER_STATE_FILENAME } from "./state.js";
+import { readWorkerStateDocument } from "./worker-state-reader.js";
 import type { OutputShapingVariant } from "./output-shaping.js";
 
 export interface OutputShapingSample {
@@ -31,18 +32,16 @@ export function collectOutputShapingSamples(tmpDir: string): OutputShapingSample
   const states = listStateFiles(join(tmpDir, "workers"));
   const samples: OutputShapingSample[] = [];
   for (const path of states) {
-    try {
-      const state = parseStateDocument(readFileSync(path, "utf8"));
-      const variant = state.current.output_shaping_variant;
-      if (variant !== "steered" && variant !== "holdout") continue;
-      samples.push({
-        issue: state.current.number,
-        variant,
-        output_tokens: state.current.output_tokens ?? 0,
-      });
-    } catch {
-      // Ignore unreadable or malformed historical state files.
-    }
+    // Unreadable or malformed historical state files read as null and are skipped.
+    const state = readWorkerStateDocument(path);
+    if (state === null) continue;
+    const variant = state.current.output_shaping_variant;
+    if (variant !== "steered" && variant !== "holdout") continue;
+    samples.push({
+      issue: state.current.number,
+      variant,
+      output_tokens: state.current.output_tokens ?? 0,
+    });
   }
   return samples;
 }
@@ -58,7 +57,7 @@ function listStateFiles(dir: string): string[] {
   for (const entry of entries) {
     const path = join(dir, entry.name);
     if (entry.isDirectory()) files.push(...listStateFiles(path));
-    else if (entry.isFile() && entry.name === "afk.state.toon") files.push(path);
+    else if (entry.isFile() && entry.name === WORKER_STATE_FILENAME) files.push(path);
   }
   return files;
 }

--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -11,6 +11,19 @@ export function defaultState(): AfkState {
 }
 
 /**
+ * Filename of the Worker state document inside a Worker workspace. Named ONCE
+ * here so no consumer re-spells it: the document is TOON on disk (written by
+ * {@link writeStateAtomic} / {@link initStateSync} through the TOON encoder,
+ * never a JSON serializer) and read back through the sniffing decoder.
+ */
+export const WORKER_STATE_FILENAME = "afk.state.toon";
+
+/** Path of the Worker state document inside a Worker workspace dir. */
+export function workerStatePath(workspaceDir: string): string {
+  return join(workspaceDir, WORKER_STATE_FILENAME);
+}
+
+/**
  * The write-once identity sidecar filename in an attempt dir (issue #1219). The
  * filename is retained across the TOON migration (wave-1 in-place convention):
  * the content flips from raw JSON to TOON but the `.json` name stays, and the

--- a/apps/dev/src/core/worker-state-reader.ts
+++ b/apps/dev/src/core/worker-state-reader.ts
@@ -261,6 +261,27 @@ function verdictToLiveness(v: LivenessVerdict): WorkerLivenessVerdict {
 }
 
 /**
+ * Read ONE Worker state document into its parsed {@link AfkState}, or `null`
+ * when the file is missing, unreadable, or fails the schema. This is the seam
+ * every consumer that only wants the document — not the liveness-tagged record
+ * {@link readWorkerState} builds — routes through, so the read/decode pair is
+ * spelled exactly once: no consumer reads the bytes and parses them privately.
+ */
+export function readWorkerStateDocument(path: string): AfkState | null {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    return parseStateDocument(text);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Read and normalize ONE `afk.state.toon`. Synchronous so the supervisor reaper
  * can call it inside its sync closures. Returns `null` when the file is missing,
  * unreadable, not valid JSON, or fails the schema — the safe value every caller
@@ -270,18 +291,9 @@ function verdictToLiveness(v: LivenessVerdict): WorkerLivenessVerdict {
  * path.
  */
 export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): WorkerStateRecord | null {
-  let text: string;
-  try {
-    text = readFileSync(path, "utf8");
-  } catch {
-    return null;
-  }
-  let state: AfkState;
-  try {
-    state = parseStateDocument(text);
-  } catch {
-    return null;
-  }
+  const parsed = readWorkerStateDocument(path);
+  if (parsed === null) return null;
+  const state: AfkState = parsed;
   const nowMs = opts.nowMs ?? Date.now();
 
   // Liveness lane recency — injected directly in tests, read from disk otherwise.

--- a/apps/dev/src/runtime/fs.ts
+++ b/apps/dev/src/runtime/fs.ts
@@ -21,7 +21,7 @@ import { dirname, join, normalize, sep } from "node:path";
 import type { FailureMarkers } from "../core/envelope-emit.js";
 import { ENVELOPE_REF_FILE, FAILURE_REASON_FILE } from "../core/prev-failure.js";
 import type { OrphanDir, StaleClaimDir } from "../core/boot.js";
-import { readState, updateState } from "../core/state.js";
+import { readState, updateState, workerStatePath } from "../core/state.js";
 import { allWorkersRoots } from "../core/worker-paths.js";
 
 export async function ensureDir(path: string): Promise<void> {
@@ -200,7 +200,7 @@ export async function globWorkerStates(workersRoot: string): Promise<string[]> {
       continue;
     }
     for (const attempt of attempts) {
-      const stateFile = join(workerPath, attempt, "afk.state.toon");
+      const stateFile = workerStatePath(join(workerPath, attempt));
       if (await pathExists(stateFile)) out.push(stateFile);
     }
   }
@@ -231,14 +231,14 @@ export async function writeFailureMarkers(attemptDir: string, markers: FailureMa
 /** Persist the `envelope.posted` signal into the iteration state file. Best
  * effort: a malformed/absent state file degrades to writing a minimal object. */
 export async function writeEnvelopePosted(attemptDir: string, posted: boolean): Promise<void> {
-  await updateState(join(attemptDir, "afk.state.toon"), { "envelope.posted": posted });
+  await updateState(workerStatePath(attemptDir), { "envelope.posted": posted });
 }
 
 /** Read the `envelope.posted` flag from an attempt state file (false when
  * absent/malformed). */
 export async function readEnvelopePosted(attemptDir: string): Promise<boolean> {
   try {
-    return (await readState(join(attemptDir, "afk.state.toon"))).envelope.posted === true;
+    return (await readState(workerStatePath(attemptDir))).envelope.posted === true;
   } catch {
     return false;
   }

--- a/apps/dev/src/runtime/state-watch.ts
+++ b/apps/dev/src/runtime/state-watch.ts
@@ -13,12 +13,13 @@
 
 import { watch, type FSWatcher } from "node:fs";
 import type { WakeSource } from "../core/event-wake.js";
+import { WORKER_STATE_FILENAME } from "../core/state.js";
 
 /** The worker state file every worker rewrites on each state transition. A watch
  * event naming this file is a genuine state change worth waking the supervisor
  * for; events on the noisier log/firehose siblings are ignored so a `tail -f`
  * churn does not wake the loop. */
-const STATE_FILENAME = "afk.state.toon";
+const STATE_FILENAME = WORKER_STATE_FILENAME;
 
 /**
  * Build the supervisor's worker-state-change {@link WakeSource} over a recursive

--- a/apps/dev/src/runtime/supervisor-fs.ts
+++ b/apps/dev/src/runtime/supervisor-fs.ts
@@ -23,6 +23,7 @@ import {
   workerDir,
 } from "../core/worker-paths.js";
 import { readWorkerState } from "../core/worker-state-reader.js";
+import { workerStatePath } from "../core/state.js";
 import {
   evaluateLiveness,
   resolveLivenessCrossCheckArming,
@@ -128,7 +129,7 @@ export function sumWorkerCostUsd(tmpDir: string): number {
       continue;
     }
     for (const attempt of attempts) {
-      const rec = readWorkerState(join(wdir, attempt, "afk.state.toon"));
+      const rec = readWorkerState(workerStatePath(join(wdir, attempt)));
       if (rec === null) continue;
       const cost = rec.state.current.cost_usd;
       if (Number.isFinite(cost) && cost > 0) total += cost;
@@ -142,7 +143,7 @@ export function sumWorkerCostUsd(tmpDir: string): number {
  * (core/worker-state-reader) so the schema + legacy-key shim apply — no private
  * JSON.parse. */
 export function iterDirIssueNumber(dir: string): number | null {
-  const rec = readWorkerState(join(dir, "afk.state.toon"));
+  const rec = readWorkerState(workerStatePath(dir));
   const n = rec?.state.current.number;
   return typeof n === "number" && Number.isInteger(n) ? n : null;
 }
@@ -239,7 +240,7 @@ export function workerLivenessFor(
   let agentPid = 0;
   let issueClaimedAtMs: number | undefined;
   try {
-    const rec = readWorkerState(join(dir, "afk.state.toon"));
+    const rec = readWorkerState(workerStatePath(dir));
     if (rec !== null) {
       agentPid = rec.state.pid;
       const raw = rec.state.current.started_at || rec.state.started_at;
@@ -306,7 +307,7 @@ export function resolveIterDirInfo(
   let costUsd: number | undefined;
   // Single owner (core/worker-state-reader): null when the dir has no/malformed
   // state, in which case issue/worker stay empty and teardown still proceeds.
-  const rec = readWorkerState(join(dir, "afk.state.toon"));
+  const rec = readWorkerState(workerStatePath(dir));
   if (rec !== null) {
     const n = rec.state.current.number;
     if (typeof n === "number" && Number.isInteger(n)) issue = n;

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -12,6 +12,7 @@ import type { AttemptDir } from "../../core/reclaim.js";
 import { LABEL_HUMAN, LABEL_READY, LABEL_RUNNING } from "../../core/triage-labels.js";
 import { allWorkersRoots, parseReapableWorkerPath } from "../../core/worker-paths.js";
 import { parseClaimRecords } from "../../core/claim.js";
+import { workerStatePath } from "../../core/state.js";
 import {
   collectFleetTruthProbeInput,
   HOST_PREREQUISITE_COMMANDS,
@@ -54,7 +55,7 @@ export async function collectBootOptions(
     // Cap-pass liveness keeps the pid-identity verdict (a live attempt is
     // excluded from the cap even when briefly quiet), read through the single
     // owner so the schema + legacy-key shim apply here too.
-    const live = readWorkerState(join(o.path, "afk.state.toon"))?.live ?? false;
+    const live = readWorkerState(workerStatePath(o.path))?.live ?? false;
     const mtimeS = nowS - o.ageS;
     const list = byIssue.get(parsed.issue) ?? [];
     list.push({ path: o.path, mtimeS, live });

--- a/apps/dev/src/runtime/wire/settings.ts
+++ b/apps/dev/src/runtime/wire/settings.ts
@@ -8,6 +8,7 @@ import { resolveLaneIdleStallConfig, type LaneIdleStallConfig } from "../../core
 import { resolveSandboxImageName } from "../../core/execution/sandbox-image.js";
 import { inspectProcessTreeNative } from "../proc-tree.js";
 import { readWorkerState } from "../../core/worker-state-reader.js";
+import { workerStatePath } from "../../core/state.js";
 import {
   evaluateLiveness,
   resolveLivenessCrossCheckArming,
@@ -174,7 +175,7 @@ export function agentLivenessVerdictSync(
   // leaves it undefined, which disables the ceiling rather than guessing an age.
   let issueClaimedAtMs: number | undefined;
   try {
-    const rec = readWorkerState(join(attemptDir, "afk.state.toon"));
+    const rec = readWorkerState(workerStatePath(attemptDir));
     const raw = rec === null ? "" : rec.state.current.started_at || rec.state.started_at;
     const parsed = raw ? Date.parse(raw) : Number.NaN;
     if (!Number.isNaN(parsed)) issueClaimedAtMs = parsed;

--- a/apps/dev/tests/worker-state-reader.test.ts
+++ b/apps/dev/tests/worker-state-reader.test.ts
@@ -1,10 +1,17 @@
 import { mkdtemp, mkdir, utimes, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { decode, encode } from "@reddb-io/toon";
-import { readWorkerState, readWorkerStates, readAllWorkerStates, isRenderableLive } from "../src/core/worker-state-reader.js";
-import { initStateSync } from "../src/core/state.js";
+import {
+  readWorkerState,
+  readWorkerStateDocument,
+  readWorkerStates,
+  readAllWorkerStates,
+  isRenderableLive,
+} from "../src/core/worker-state-reader.js";
+import { initStateSync, WORKER_STATE_FILENAME, workerStatePath } from "../src/core/state.js";
 import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 
 const NOW = Date.UTC(2026, 5, 22, 12, 0, 0);
@@ -436,5 +443,45 @@ describe("worker-state-reader", () => {
       const dead = readWorkerState(deadPath, { nowMs: NOW, laneRecencyMs: LANE_STALE_MS, kill: () => false });
       expect(dead!.renderableLive).toBe(false);
     });
+  });
+});
+
+describe("readWorkerStateDocument", () => {
+  it("names the Worker state file once, for every consumer", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "wsd-name-"));
+    expect(WORKER_STATE_FILENAME).toBe("afk.state.toon");
+    expect(workerStatePath(dir)).toBe(join(dir, WORKER_STATE_FILENAME));
+  });
+
+  it("reads a TOON document through the single owning parse path", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "wsd-toon-"));
+    const path = workerStatePath(dir);
+    initStateSync(path, { worker_id: "wZZZZ", pid: 77, "current.number": 2783 });
+
+    const state = readWorkerStateDocument(path);
+    expect(state?.worker_id).toBe("wZZZZ");
+    expect(state?.current.number).toBe(2783);
+    // The on-disk document is TOON, never a JSON serialization.
+    const text = readFileSync(path, "utf8");
+    expect(() => JSON.parse(text)).toThrow();
+    expect(decode(text)).toMatchObject({ worker_id: "wZZZZ" });
+  });
+
+  it("still reads a pre-migration JSON document", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "wsd-json-"));
+    const path = workerStatePath(dir);
+    await writeFile(path, JSON.stringify({ worker_id: "wLEGACY", current: { number: 7 } }), "utf8");
+
+    const state = readWorkerStateDocument(path);
+    expect(state?.worker_id).toBe("wLEGACY");
+    expect(state?.current.number).toBe(7);
+  });
+
+  it("returns null for a missing or malformed document", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "wsd-bad-"));
+    expect(readWorkerStateDocument(workerStatePath(dir))).toBeNull();
+    const path = join(dir, "broken.toon");
+    await writeFile(path, "{ not: valid", "utf8");
+    expect(readWorkerStateDocument(path)).toBeNull();
   });
 });


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=2783 -->
🤖 **Re-seed trail** — #2783 on `afk/2783-the-worker-state-file-becomes-toon-toonl`, lane `/afk`.

Rounds spent: 1/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |

The Attempt record is the source of truth; this is a derived projection.

Closes #2783

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787935226&installation_model_id=20659&pr_number=2798&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2798&signature=65cce9f7bd7270570777aa25742c08054032013d3512ddee4cf5c7874eee8bb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->