### PR TITLE
chore: #2774 A Worker is born through the daemon, placed in its own transient unit

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -4,8 +4,9 @@ The host-scoped execution daemon of ADR 0130: **one singleton per user session,
 behind a unix socket**, owning Worker processes across every project on the
 machine while each project's bundle keeps owning the work.
 
-This app is the daemon's skeleton — the core exists, is reachable, and is honest
-about its own life. No Worker is born here yet.
+The core exists, is reachable, honest about its own life — and **births Workers**:
+a project hands over an argv, a placement target, a budget and two opaque
+strings, and the daemon launches the Worker into a resource unit of its own.
 
 ## Why its own app
 
@@ -23,7 +24,9 @@ of it.
 | Which session a daemon serves | `src/paths.ts` — session key, socket, lock, lease |
 | Who owns the session across restarts | `src/session-lease.ts` — pid + start time, TOON on disk |
 | Who owns the socket right now | `src/daemon.ts` — exclusive bind |
-| The frozen wire contract | `src/protocol.ts` — `ping`, `host-state`, `shutdown` |
+| The frozen wire contract | `src/protocol.ts` — `ping`, `host-state`, `worker-start`, `shutdown` |
+| Where a Worker's resources are charged | `src/worker-placement.ts` — pure planner over injected probes |
+| Birth itself | `src/worker-launch.ts` — plan, spawn once, report the downgrade |
 | The host-wide read | `src/host-state.ts` — total shape, empty at this slice |
 | Reaching (and starting) the daemon | `src/client.ts` — auto-spawn, loser joins the winner |
 
@@ -42,8 +45,20 @@ of it.
 - **Fail closed.** No daemon, no Worker. A client that cannot reach the daemon
   throws; there is no quiet local fallback, because for a launcher failing open
   costs the machine.
-- **The daemon receives paths, never derives them.** That is what lets one daemon
-  serve checkouts pinned to different bundle versions.
+- **The daemon receives paths, never derives them.** No marker file is looked
+  for, no parent directory walked, no layout assumed. That is what lets one
+  daemon serve checkouts pinned to different bundle versions.
+- **A transient service unit, never a scope.** A scope runs inside the caller's
+  unit and cannot outlive it, so every Worker would die with the daemon that
+  asked for it. A service unit is owned by the init system, which is what later
+  lets the daemon restart without taking every project's work down with it.
+- **Placement is decided at launch.** Moving a running process between resource
+  groups does not move its existing memory charge, so a Worker born in the
+  caller's group stays charged there for life no matter what is done afterwards.
+- **An unisolated launch is never silent.** When the host affords no transient
+  unit the Worker still starts, and the reply — and the host-state record it
+  keeps for its whole life — carries a warning naming what was lost. A declared
+  budget that cannot be enforced says so as its own warning.
 
 ## Commands
 

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -23,7 +23,13 @@ import { tryAcquireExclusiveLock } from "@reddb-io/shared/resident-core.js";
 import { socketAnswers } from "./daemon.js";
 import { isRedskilledHostState, type RedskilledHostState } from "./host-state.js";
 import type { RedskilledPaths } from "./paths.js";
-import { sendRedskilledRequest, type RedskilledRequest } from "./protocol.js";
+import {
+  isRedskilledWorkerStarted,
+  sendRedskilledRequest,
+  type RedskilledRequest,
+  type RedskilledWorkerStarted,
+} from "./protocol.js";
+import type { RedskilledWorkerSpec } from "./worker-launch.js";
 
 /** How long a client waits for a daemon — its own or the race winner's — to answer. */
 export const DEFAULT_REDSKILLED_READY_TIMEOUT_MS = 10_000;
@@ -71,10 +77,22 @@ export async function ensureRedskilledDaemon(
   }
 }
 
+/**
+ * An op the daemon accepts, minus the id the client mints per call.
+ *
+ * Distributive on purpose: a plain `Omit<RedskilledRequest, "id">` narrows to the
+ * keys every member shares, which would silently drop `worker-start`'s payload.
+ */
+export type RedskilledRequestBody = RedskilledRequest extends infer Member
+  ? Member extends { id: string }
+    ? Omit<Member, "id">
+    : never
+  : never;
+
 /** One request against a running daemon; auto-spawns first. Throws on refusal. */
 export async function requestRedskilled(
   paths: RedskilledPaths,
-  request: Omit<RedskilledRequest, "id">,
+  request: RedskilledRequestBody,
   config: RedskilledClientConfig = {},
 ): Promise<unknown> {
   await ensureRedskilledDaemon(paths, config);
@@ -93,6 +111,25 @@ export async function readRedskilledHostState(
 ): Promise<RedskilledHostState> {
   const value = await requestRedskilled(paths, { op: "host-state" }, config);
   if (!isRedskilledHostState(value)) throw new Error("redskilled daemon returned a malformed host state");
+  return value;
+}
+
+/**
+ * Ask the daemon for a Worker.
+ *
+ * The caller states the argv, the placement target, the budget and its own two
+ * opaque strings; it learns back the pid, the unit and any warning. **A refusal
+ * throws** — fail closed (ADR 0130 rule 6): a client that fell back to spawning
+ * the Worker itself would reinstate exactly the unbudgeted spawn the daemon
+ * exists to prevent.
+ */
+export async function startRedskilledWorker(
+  paths: RedskilledPaths,
+  spec: RedskilledWorkerSpec,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledWorkerStarted> {
+  const value = await requestRedskilled(paths, { op: "worker-start", spec }, config);
+  if (!isRedskilledWorkerStarted(value)) throw new Error("redskilled daemon returned a malformed worker record");
   return value;
 }
 

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -26,6 +26,12 @@ import { buildHostState, type RedskilledHostState, type RedskilledWorkerView } f
 import type { RedskilledPaths } from "./paths.js";
 import { REDSKILLED_PROTOCOL_VERSION, type RedskilledRequest, type RedskilledResponse } from "./protocol.js";
 import {
+  launchWorker,
+  type LaunchWorkerOptions,
+  type LaunchedWorker,
+  type RedskilledWorkerSpec,
+} from "./worker-launch.js";
+import {
   createRedskilledLeaseStore,
   currentProcessOwner,
   type RedskilledLease,
@@ -55,6 +61,8 @@ export interface RedskilledDaemonOptions {
   readonly owner?: RedskilledLeaseOwner;
   readonly leaseStore?: RedskilledLeaseStore;
   readonly clock?: () => string;
+  /** How a Worker is born; injected so a test can birth one without a spawn. */
+  readonly launch?: (options: LaunchWorkerOptions) => LaunchedWorker;
 }
 
 export interface RedskilledDaemon {
@@ -63,6 +71,8 @@ export interface RedskilledDaemon {
   readonly startedAt: string;
   /** Resolves when the daemon has stopped listening and released its lease. */
   readonly closed: Promise<void>;
+  /** Birth a Worker from a spec: plan placement, launch, track, report. */
+  startWorker(spec: RedskilledWorkerSpec): LaunchedWorker;
   /** Record a Worker the daemon believes is alive — the idle gate reads this set. */
   trackWorker(worker: RedskilledWorkerView): void;
   /** Forget a Worker the daemon has observed dying. */
@@ -86,6 +96,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const daemonVersion = options.daemonVersion ?? "0.0.0-dev";
   const idleMs = options.idleMs ?? DEFAULT_REDSKILLED_IDLE_MS;
   const clock = options.clock ?? (() => new Date().toISOString());
+  const launch = options.launch ?? launchWorker;
   const owner = options.owner ?? currentProcessOwner();
   const leaseStore = options.leaseStore ?? createRedskilledLeaseStore(paths.leasePath, {
     sessionKeyHash: paths.sessionKeyHash,
@@ -125,6 +136,27 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       startedAt,
       workers: [...workers.values()],
     });
+  }
+
+  /**
+   * Birth one Worker.
+   *
+   * Tracking happens here rather than in the caller, so the idle gate and the
+   * host state learn about a Worker at the same instant the process exists —
+   * a launch the daemon forgot to track would be an untracked budget.
+   */
+  function startWorker(spec: RedskilledWorkerSpec): LaunchedWorker {
+    const launched = launch({
+      spec,
+      clock,
+      onExit: (workerId) => {
+        workers.delete(workerId);
+        armIdleTimer();
+      },
+    });
+    workers.set(launched.worker.worker_id, launched.worker);
+    armIdleTimer();
+    return launched;
   }
 
   function armIdleTimer(): void {
@@ -187,6 +219,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         };
       }
       if (request.op === "host-state") return { id: request.id, ok: true, value: hostState() };
+      if (request.op === "worker-start") {
+        const launched = startWorker(request.spec);
+        return { id: request.id, ok: true, value: { worker: launched.worker, warnings: launched.warnings } };
+      }
       if (request.op === "shutdown") return { id: request.id, ok: true, value: { stopping: true } };
       const unknown = request as { id?: string; op?: string };
       return { id: unknown.id ?? randomUUID(), ok: false, error: `unsupported redskilled op: ${unknown.op ?? "unknown"}` };
@@ -202,6 +238,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     lease: acquisition.lease,
     startedAt,
     closed,
+    startWorker,
     trackWorker(worker) {
       workers.set(worker.worker_id, worker);
       armIdleTimer();

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -1,24 +1,37 @@
 /**
  * host-state — what the daemon knows about the machine, in one document.
  *
- * At this slice the answer is legitimately **empty**: no Worker is born yet, so
- * `workers` and `projects` are empty arrays. Empty is not the same as absent,
- * and the difference is the point — a client must be able to tell "the daemon is
- * up and nothing is running" from "the daemon did not answer". So the shape is
- * total from the first slice: every field is present, the collections are always
- * arrays, and a reader written today keeps working when the arrays fill.
+ * A client must be able to tell "the daemon is up and nothing is running" from
+ * "the daemon did not answer", so the shape is total: every field is present and
+ * the collections are always arrays, empty included.
  *
  * Read the host, write the project (ADR 0130 rule 9): this document is the read
  * half, and it is host-wide on purpose.
  */
 import { REDSKILLED_PROTOCOL_VERSION } from "./protocol.js";
 
-/** One Worker process, as the daemon sees it. Empty in this slice by construction. */
+/**
+ * One Worker process, as the daemon sees it.
+ *
+ * `project_label` and `workspace_path` are the client's own opaque strings,
+ * echoed back untouched — the daemon stores what it was given and interprets
+ * nothing. `isolated` and `warnings` travel WITH the Worker rather than being
+ * reported once at birth, so a reader of host state can still see that a
+ * long-lived Worker never got a unit of its own.
+ */
 export interface RedskilledWorkerView {
   readonly worker_id: string;
   readonly project_label: string;
   readonly pid: number;
   readonly started_at: string;
+  /** The path the client handed over, used verbatim as the Worker's workspace. */
+  readonly workspace_path: string;
+  /** True when the Worker runs inside a transient unit of its own. */
+  readonly isolated: boolean;
+  /** The transient unit's name, present only when `isolated`. */
+  readonly unit?: string;
+  /** Non-empty whenever the launch was a downgrade; never silently absent. */
+  readonly warnings: readonly string[];
 }
 
 /** One project with at least one Worker on this host. Empty in this slice. */
@@ -66,6 +79,19 @@ export function buildHostState(input: BuildHostStateInput): RedskilledHostState 
       .map(([project_label, worker_count]) => ({ project_label, worker_count }))
       .sort((a, b) => a.project_label.localeCompare(b.project_label)),
   };
+}
+
+/** True when `value` is a complete Worker view — a client's fail-closed check. */
+export function isRedskilledWorkerView(value: unknown): value is RedskilledWorkerView {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const worker = value as Record<string, unknown>;
+  return typeof worker.worker_id === "string" &&
+    typeof worker.project_label === "string" &&
+    Number.isInteger(worker.pid) &&
+    typeof worker.started_at === "string" &&
+    typeof worker.workspace_path === "string" &&
+    typeof worker.isolated === "boolean" &&
+    Array.isArray(worker.warnings);
 }
 
 /** True when `value` is a complete host-state document — a client's fail-closed check. */

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -8,12 +8,16 @@
  * semantics, and an op that needed to know what a Ticket or a Gate is would
  * belong to the per-project bundle instead.
  *
- * This slice ships the two ops a daemon needs to be *reachable and honest about
- * its own life*: `ping` and `host-state`. Worker birth arrives later and widens
- * this union; nothing here presumes its shape.
+ * `ping` and `host-state` make the daemon reachable and honest about its own
+ * life. `worker-start` is the one op that changes the machine, and it stays
+ * inside rule 3 by taking the whole launch as data: an argv, a placement target,
+ * a budget, and two opaque strings — a project label and a workspace path. There
+ * is no repository, ticket or runner in this contract, so there is nothing here
+ * for a version-skewed client to disagree with the daemon about.
  */
 import { sendLineRequest } from "@reddb-io/shared/resident-core.js";
-import type { RedskilledHostState } from "./host-state.js";
+import { isRedskilledWorkerView, type RedskilledHostState, type RedskilledWorkerView } from "./host-state.js";
+import type { RedskilledWorkerSpec } from "./worker-launch.js";
 
 /** The wire version. A daemon states it; a client that cannot read it must not proceed. */
 export const REDSKILLED_PROTOCOL_VERSION = 1;
@@ -21,6 +25,7 @@ export const REDSKILLED_PROTOCOL_VERSION = 1;
 export type RedskilledRequest =
   | { id: string; op: "ping" }
   | { id: string; op: "host-state" }
+  | { id: string; op: "worker-start"; spec: RedskilledWorkerSpec }
   | { id: string; op: "shutdown" };
 
 export type RedskilledResponse =
@@ -32,6 +37,24 @@ export interface RedskilledPong {
   readonly protocol_version: number;
   readonly daemon_version: string;
   readonly pid: number;
+}
+
+/**
+ * The answer to `worker-start`.
+ *
+ * `warnings` is part of the success reply, not an error channel: a Worker that
+ * started without isolation is running and is a downgrade at the same time, and
+ * collapsing that into ok/failed would lose whichever half the reader needed.
+ */
+export interface RedskilledWorkerStarted {
+  readonly worker: RedskilledWorkerView;
+  readonly warnings: readonly string[];
+}
+
+export function isRedskilledWorkerStarted(value: unknown): value is RedskilledWorkerStarted {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const started = value as Record<string, unknown>;
+  return Array.isArray(started.warnings) && isRedskilledWorkerView(started.worker);
 }
 
 export interface RedskilledClientOptions {
@@ -56,4 +79,4 @@ export function isRedskilledPong(value: unknown): value is RedskilledPong {
     Number.isInteger(pong.pid);
 }
 
-export type { RedskilledHostState };
+export type { RedskilledHostState, RedskilledWorkerView, RedskilledWorkerSpec };

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -1,0 +1,149 @@
+/**
+ * worker-launch — birth: a spec in, a live Worker and its warnings out.
+ *
+ * The impure half of placement. It plans (pure, in `worker-placement`), spawns
+ * once, and reports what it actually did — including when what it did was worse
+ * than what was asked for.
+ *
+ * **The spec is data, not a description of a repository.** The daemon receives a
+ * command, a placement target, a budget, a project label and a workspace path,
+ * and it reads none of them for meaning: no marker file is looked for, no parent
+ * directory is walked, no layout is assumed. A path it needs is a path it was
+ * given (ADR 0130 rule 3), which is what lets one daemon serve checkouts pinned
+ * to different bundle versions.
+ */
+import { randomUUID } from "node:crypto";
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import type { RedskilledWorkerView } from "./host-state.js";
+import {
+  detectWorkerPlacementProbes,
+  placementEnabled,
+  planWorkerPlacement,
+  type RedskilledPlacementTarget,
+  type RedskilledWorkerBudget,
+  type WorkerPlacementPlan,
+  type WorkerPlacementProbes,
+} from "./worker-placement.js";
+
+/** What a client hands over to ask for a Worker. Every field is opaque to the daemon. */
+export interface RedskilledWorkerSpec {
+  /** The client's own id for this Worker; the daemon mints one when absent. */
+  readonly worker_id?: string;
+  readonly project_label: string;
+  /** Used verbatim as the Worker's working directory. */
+  readonly workspace_path: string;
+  readonly command: string;
+  readonly args?: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+  readonly placement?: RedskilledPlacementTarget;
+  readonly budget?: RedskilledWorkerBudget;
+}
+
+/** Raised when a spec is not launchable. Fail closed: no Worker, and a reason. */
+export class RedskilledWorkerSpecError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RedskilledWorkerSpecError";
+  }
+}
+
+export interface LaunchedWorker {
+  readonly worker: RedskilledWorkerView;
+  /** The same warnings the view carries, for a caller that reports them once. */
+  readonly warnings: readonly string[];
+  readonly plan: WorkerPlacementPlan;
+  readonly child: ChildProcess;
+}
+
+export interface LaunchWorkerOptions {
+  readonly spec: RedskilledWorkerSpec;
+  readonly probes?: WorkerPlacementProbes;
+  readonly enabled?: boolean;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly clock?: () => string;
+  readonly workerId?: string;
+  readonly spawnFn?: (command: string, args: readonly string[], options: SpawnOptions) => ChildProcess;
+  /** Called when the daemon observes this Worker's process end. */
+  readonly onExit?: (workerId: string, code: number | null, signal: NodeJS.Signals | null) => void;
+}
+
+/** Reject a spec the daemon cannot act on, naming the field rather than the shape. */
+export function assertLaunchableSpec(spec: RedskilledWorkerSpec): void {
+  const required: Array<[string, unknown]> = [
+    ["project_label", spec.project_label],
+    ["workspace_path", spec.workspace_path],
+    ["command", spec.command],
+  ];
+  for (const [field, value] of required) {
+    if (typeof value !== "string" || value.trim() === "") {
+      throw new RedskilledWorkerSpecError(`redskilled worker spec is missing ${field}`);
+    }
+  }
+  if (spec.args != null && !Array.isArray(spec.args)) {
+    throw new RedskilledWorkerSpecError("redskilled worker spec args must be an array");
+  }
+}
+
+/**
+ * Launch one Worker.
+ *
+ * Failure to spawn throws rather than returning a half-Worker: a caller that
+ * could not tell "running" from "never started" would leak the budget.
+ */
+export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
+  const { spec } = options;
+  assertLaunchableSpec(spec);
+
+  const env = options.env ?? process.env;
+  const clock = options.clock ?? (() => new Date().toISOString());
+  const workerId = (spec.worker_id ?? options.workerId ?? randomUUID()).trim() || randomUUID();
+  const plan = planWorkerPlacement({
+    workerId,
+    projectLabel: spec.project_label,
+    workspacePath: spec.workspace_path,
+    command: spec.command,
+    args: spec.args,
+    budget: spec.budget,
+    target: spec.placement,
+    env: spec.env,
+    enabled: options.enabled ?? placementEnabled(env),
+    probes: options.probes ?? detectWorkerPlacementProbes(env),
+  });
+
+  const spawnFn = options.spawnFn ?? spawn;
+  const child = spawnFn(plan.command, plan.args, {
+    // When isolated the unit carries the workspace, so the spawn deliberately
+    // does not: a cwd the daemon cannot chdir into would fail a launch the unit
+    // would have run fine.
+    ...(plan.cwd != null ? { cwd: plan.cwd } : {}),
+    detached: true,
+    stdio: "ignore",
+    // The Worker's own env goes through `--setenv` when isolated; unisolated it
+    // has to be merged here, or the downgrade would silently change behaviour.
+    env: plan.isolated ? { ...env } : { ...env, ...(spec.env ?? {}) },
+  });
+
+  if (child.pid == null) {
+    child.once("error", () => undefined);
+    throw new RedskilledWorkerSpecError(`redskilled could not spawn ${JSON.stringify(plan.command)} for worker ${workerId}`);
+  }
+
+  // Observed, not polled — but never a reason to keep the daemon alive on its
+  // own, so the handle is unref'd and the exit is still delivered while we live.
+  child.once("error", () => undefined);
+  if (options.onExit) child.once("exit", (code, signal) => options.onExit?.(workerId, code, signal));
+  child.unref();
+
+  const warnings = [plan.warning, plan.budgetWarning].filter((warning): warning is string => warning != null);
+  const worker: RedskilledWorkerView = {
+    worker_id: workerId,
+    project_label: spec.project_label,
+    pid: child.pid,
+    started_at: clock(),
+    workspace_path: spec.workspace_path,
+    isolated: plan.isolated,
+    ...(plan.unit != null ? { unit: plan.unit } : {}),
+    warnings,
+  };
+  return { worker, warnings, plan, child };
+}

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -1,0 +1,212 @@
+/**
+ * worker-placement — where a Worker's resources are charged, decided at launch.
+ *
+ * **A transient service unit, never a scope.** A scope runs inside the caller's
+ * own unit and cannot outlive it, so every Worker would die with the daemon that
+ * asked for it — and ADR 0130 rule 5 needs the opposite: units owned by the init
+ * system, so the daemon can restart and re-attach by unit name instead of taking
+ * every project's work down on an upgrade.
+ *
+ * **Placement is decided at launch, not adjusted afterwards**, because moving a
+ * running process between resource groups does not move its existing memory
+ * charge. A Worker born in the caller's group stays charged there for its whole
+ * life no matter what is done to it later.
+ *
+ * The shape follows `fleet-scope` (#2697): this module is PURE planning over
+ * injected probes, and the one impure read of the host lives in
+ * {@link detectWorkerPlacementProbes}. That is what lets the Linux-with-session
+ * and Linux-without-session cases be proven without spawning anything.
+ */
+import { existsSync } from "node:fs";
+import { delimiter, join } from "node:path";
+
+/** Env kill-switch: `REDSKILLED_PLACEMENT=off` launches unisolated — loudly. */
+export const REDSKILLED_PLACEMENT_ENV = "REDSKILLED_PLACEMENT";
+
+/** The unit-name prefix when a client states none. */
+export const DEFAULT_WORKER_UNIT_PREFIX = "red-worker";
+
+export interface WorkerPlacementProbes {
+  /** `process.platform` — transient units are a Linux backend. */
+  readonly platform: NodeJS.Platform;
+  /** `systemd-run` on PATH, or null when the binary is absent. */
+  readonly systemdRun: string | null;
+  /** True when a systemd `--user` session is reachable. */
+  readonly userSession: boolean;
+}
+
+/**
+ * Where the client wants the Worker placed.
+ *
+ * `inherit` is a client saying "charge it to me" out loud. It is a distinct
+ * answer from "isolation was unavailable", and both still carry a warning —
+ * an unisolated launch is never silent, however it came to be one.
+ */
+export interface RedskilledPlacementTarget {
+  readonly isolation: "transient-unit" | "inherit";
+  readonly unit_prefix?: string;
+}
+
+/** The resource budget for one Worker. Every field is optional and opaque. */
+export interface RedskilledWorkerBudget {
+  readonly memory_high?: string;
+  readonly memory_max?: string;
+  readonly cpu_weight?: number;
+}
+
+export interface WorkerPlacementPlan {
+  /** True when the Worker runs inside a transient unit of its own. */
+  readonly isolated: boolean;
+  readonly command: string;
+  readonly args: readonly string[];
+  /** The working directory for the spawn itself; unset when the unit carries it. */
+  readonly cwd?: string;
+  /** The transient unit name, only when isolated. */
+  readonly unit?: string;
+  /**
+   * Why isolation was skipped, and what the caller now carries instead. ALWAYS
+   * set when `isolated` is false.
+   */
+  readonly warning?: string;
+  /** Set when a budget was declared that this placement cannot enforce. */
+  readonly budgetWarning?: string;
+}
+
+/**
+ * Probe the host for transient-unit support.
+ *
+ * The systemd `--user` session is proven by its private socket under
+ * `XDG_RUNTIME_DIR`, so nothing is spawned on the launch path to find out.
+ */
+export function detectWorkerPlacementProbes(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): WorkerPlacementProbes {
+  if (platform !== "linux") return { platform, systemdRun: null, userSession: false };
+  const runtimeDir = (env.XDG_RUNTIME_DIR ?? "").trim();
+  const userSession = runtimeDir !== "" && existsSync(join(runtimeDir, "systemd", "private"));
+  return { platform, systemdRun: which("systemd-run", env), userSession };
+}
+
+/** True unless the env kill-switch declines isolation for this host. */
+export function placementEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const override = (env[REDSKILLED_PLACEMENT_ENV] ?? "").trim().toLowerCase();
+  if (override === "") return true;
+  return !["off", "false", "0", "no"].includes(override);
+}
+
+/**
+ * The transient unit name: `<prefix>-<project>-<worker>.service`.
+ *
+ * Both identifiers are opaque labels the client chose, so they are slugified
+ * rather than parsed — the daemon never learns what a project label means.
+ */
+export function workerUnitName(
+  projectLabel: string,
+  workerId: string,
+  prefix: string = DEFAULT_WORKER_UNIT_PREFIX,
+): string {
+  const head = slug(prefix, "red-worker", 24);
+  return `${head}-${slug(projectLabel, "project", 32)}-${slug(workerId, "worker", 32)}.service`;
+}
+
+export interface PlanWorkerPlacementOptions {
+  readonly workerId: string;
+  readonly projectLabel: string;
+  /** The workspace path, used verbatim — the daemon derives nothing from it. */
+  readonly workspacePath: string;
+  readonly command: string;
+  readonly args?: readonly string[];
+  readonly budget?: RedskilledWorkerBudget;
+  readonly target?: RedskilledPlacementTarget;
+  readonly probes: WorkerPlacementProbes;
+  /** False when the env kill-switch declined isolation host-wide. */
+  readonly enabled?: boolean;
+  /** Extra `KEY=VALUE` environment for the Worker. */
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Plan the launch argv.
+ *
+ * When the host affords it, the Worker runs under a transient
+ * `<prefix>-<project>-<worker>.service` carrying the budget as unit properties.
+ * Otherwise the original argv is returned unchanged WITH a warning — the launch
+ * still happens, but a downgrade is never silent.
+ */
+export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPlacementPlan {
+  const args = [...(opts.args ?? [])];
+  const budget = opts.budget ?? {};
+  const declaredBudget = budget.memory_high != null || budget.memory_max != null || budget.cpu_weight != null;
+  const target = opts.target ?? { isolation: "transient-unit" as const };
+
+  const unisolated = (warning: string): WorkerPlacementPlan => ({
+    isolated: false,
+    command: opts.command,
+    args,
+    cwd: opts.workspacePath,
+    warning,
+    ...(declaredBudget
+      ? { budgetWarning: "a budget was declared but this placement cannot enforce it: the daemon's RSS sampling is the only remaining floor" }
+      : {}),
+  });
+
+  if (target.isolation === "inherit") {
+    return unisolated("placement target is `inherit`: the Worker is charged to the daemon's own resource group, so a memory-pressure kill can land on the daemon and every Worker it holds");
+  }
+  if (opts.enabled === false) {
+    return unisolated(`worker isolation disabled by ${REDSKILLED_PLACEMENT_ENV}: the Worker is charged to the daemon's own resource group`);
+  }
+  if (opts.probes.platform !== "linux") {
+    return unisolated(`transient-unit placement is the Linux backend (platform=${opts.probes.platform}): the Worker is charged to the daemon's own resource group`);
+  }
+  if (!opts.probes.systemdRun) {
+    return unisolated("transient-unit placement unavailable: systemd-run is not on PATH; the Worker is charged to the daemon's own resource group and a memory-pressure kill will hit the whole session");
+  }
+  if (!opts.probes.userSession) {
+    return unisolated("transient-unit placement unavailable: no systemd --user session; the Worker is charged to the daemon's own resource group and a memory-pressure kill will hit the whole session");
+  }
+
+  const unit = workerUnitName(opts.projectLabel, opts.workerId, target.unit_prefix);
+  // `--wait` keeps this process alive for the unit's lifetime so its death is
+  // observed rather than polled; the unit itself stays owned by the init system,
+  // which is what lets a restarted daemon re-attach by name.
+  const unitArgs = [
+    "--user",
+    "--collect",
+    "--quiet",
+    "--wait",
+    `--unit=${unit}`,
+    `--working-directory=${opts.workspacePath}`,
+  ];
+  if (budget.memory_high != null) unitArgs.push(`--property=MemoryHigh=${budget.memory_high}`);
+  if (budget.memory_max != null) unitArgs.push(`--property=MemoryMax=${budget.memory_max}`);
+  if (budget.cpu_weight != null) unitArgs.push(`--property=CPUWeight=${budget.cpu_weight}`);
+  for (const [key, value] of Object.entries(opts.env ?? {})) unitArgs.push(`--setenv=${key}=${value}`);
+
+  return {
+    isolated: true,
+    unit,
+    command: opts.probes.systemdRun,
+    args: [...unitArgs, "--", opts.command, ...args],
+  };
+}
+
+function which(binary: string, env: NodeJS.ProcessEnv): string | null {
+  for (const dir of (env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, binary);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function slug(value: string, fallback: string, max: number): string {
+  const cleaned = (value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, max)
+    .replace(/-+$/g, "");
+  return cleaned || fallback;
+}

--- a/apps/redskilled/tests/host-state.test.ts
+++ b/apps/redskilled/tests/host-state.test.ts
@@ -27,6 +27,20 @@ async function sessionPaths(): Promise<RedskilledPaths> {
   });
 }
 
+/** A tracked Worker view; placement fields are part of the total shape. */
+function view(worker_id: string, project_label: string, pid: number) {
+  return {
+    worker_id,
+    project_label,
+    pid,
+    started_at: "2026-07-29T00:00:00.000Z",
+    workspace_path: `/workspaces/${project_label}`,
+    isolated: true,
+    unit: `red-worker-${project_label}-${worker_id}.service`,
+    warnings: [] as string[],
+  };
+}
+
 describe("redskilled host state", () => {
   it("answers a client over the socket with an empty, well-formed host state", async () => {
     const paths = await sessionPaths();
@@ -59,9 +73,9 @@ describe("redskilled host state", () => {
     const daemon = await startRedskilledDaemon({ paths });
     running.push(daemon);
 
-    daemon.trackWorker({ worker_id: "w1", project_label: "beta", pid: 1, started_at: "2026-07-29T00:00:00.000Z" });
-    daemon.trackWorker({ worker_id: "w2", project_label: "alpha", pid: 2, started_at: "2026-07-29T00:00:01.000Z" });
-    daemon.trackWorker({ worker_id: "w3", project_label: "alpha", pid: 3, started_at: "2026-07-29T00:00:02.000Z" });
+    daemon.trackWorker(view("w1", "beta", 1));
+    daemon.trackWorker(view("w2", "alpha", 2));
+    daemon.trackWorker(view("w3", "alpha", 3));
 
     expect(daemon.hostState().projects).toEqual([
       { project_label: "alpha", worker_count: 2 },

--- a/apps/redskilled/tests/idle-exit.test.ts
+++ b/apps/redskilled/tests/idle-exit.test.ts
@@ -22,7 +22,16 @@ async function sessionPaths(): Promise<RedskilledPaths> {
   return resolveRedskilledPaths({ env: { REDSKILLED_SESSION: `test:${root}` }, runtimeDir: root });
 }
 
-const WORKER = { worker_id: "w-1", project_label: "alpha", pid: 4242, started_at: "2026-07-29T10:00:00.000Z" };
+const WORKER = {
+  worker_id: "w-1",
+  project_label: "alpha",
+  pid: 4242,
+  started_at: "2026-07-29T10:00:00.000Z",
+  workspace_path: "/workspaces/alpha",
+  isolated: true,
+  unit: "red-worker-alpha-w-1.service",
+  warnings: [] as string[],
+};
 
 describe("redskilled idle exit", () => {
   it("exits on idle while it holds no workers", async () => {

--- a/apps/redskilled/tests/worker-birth.test.ts
+++ b/apps/redskilled/tests/worker-birth.test.ts
@@ -1,0 +1,189 @@
+// Birth through the socket: a project asks, the daemon launches, and the host
+// state tells the truth about what it got. The tracer bullet of ADR 0130.
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readRedskilledHostState, startRedskilledWorker } from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { isRedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { launchWorker, RedskilledWorkerSpecError, type RedskilledWorkerSpec } from "../src/worker-launch.js";
+import { detectWorkerPlacementProbes, type WorkerPlacementProbes } from "../src/worker-placement.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await scratch("redskilled-birth-");
+  return resolveRedskilledPaths({ env: { REDSKILLED_SESSION: `test:${root}` }, runtimeDir: root });
+}
+
+/** A Worker that writes proof it ran in the workspace it was handed, then exits. */
+function proofSpec(workspacePath: string, overrides: Partial<RedskilledWorkerSpec> = {}): RedskilledWorkerSpec {
+  return {
+    project_label: "acme/widgets",
+    workspace_path: workspacePath,
+    command: process.execPath,
+    args: ["-e", "require('node:fs').writeFileSync('proof.txt', process.cwd());"],
+    budget: { memory_high: "512M" },
+    ...overrides,
+  };
+}
+
+describe("worker birth through the socket", () => {
+  it("starts a Worker, and it appears in host state with its project label", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000 });
+    running.push(daemon);
+
+    const started = await startRedskilledWorker(paths, proofSpec(workspace), { readyTimeoutMs: 5_000 });
+
+    expect(isRedskilledWorkerView(started.worker)).toBe(true);
+    expect(started.worker.project_label).toBe("acme/widgets");
+    expect(started.worker.pid).toBeGreaterThan(0);
+    expect(started.worker.workspace_path).toBe(workspace);
+
+    const state = await readRedskilledHostState(paths, { readyTimeoutMs: 5_000 });
+    expect(state.workers.map((worker) => worker.worker_id)).toContain(started.worker.worker_id);
+    expect(state.projects).toEqual([{ project_label: "acme/widgets", worker_count: 1 }]);
+  });
+
+  it("runs the Worker in a transient unit of its own, or says why it could not", async () => {
+    // The host decides which branch is reachable here; both are legitimate and
+    // neither may be silent. That is the assertion.
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000 });
+    running.push(daemon);
+
+    const started = await startRedskilledWorker(paths, proofSpec(workspace), { readyTimeoutMs: 5_000 });
+
+    if (started.worker.isolated) {
+      expect(started.worker.unit).toMatch(/^red-worker-acme-widgets-.*\.service$/);
+      expect(started.warnings).toEqual([]);
+    } else {
+      expect(started.worker.unit).toBeUndefined();
+      expect(started.warnings.length).toBeGreaterThan(0);
+      expect(started.warnings.join(" ")).toMatch(/resource group/);
+    }
+    expect(started.worker.warnings).toEqual(started.warnings);
+  });
+
+  it("runs the Worker in the workspace it was handed, verbatim", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000 });
+    running.push(daemon);
+
+    await startRedskilledWorker(paths, proofSpec(workspace), { readyTimeoutMs: 5_000 });
+
+    const proof = join(workspace, "proof.txt");
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      try {
+        expect(await readFile(proof, "utf8")).toBe(workspace);
+        return;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    throw new Error(`the Worker never wrote ${proof}`);
+  });
+
+  it("holds the daemon open while it believes the Worker is alive, and lets go on exit", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000 });
+    running.push(daemon);
+
+    await startRedskilledWorker(
+      paths,
+      proofSpec(workspace, { args: ["-e", "setTimeout(() => {}, 150);"] }),
+      { readyTimeoutMs: 5_000 },
+    );
+
+    expect(daemon.workerCount()).toBe(1);
+    expect(daemon.evaluateIdle()).toBe("held-by-workers");
+
+    for (let attempt = 0; attempt < 100 && daemon.workerCount() > 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    expect(daemon.workerCount()).toBe(0);
+    expect(daemon.hostState().projects).toEqual([]);
+  });
+
+  it("refuses an unlaunchable spec instead of half-starting one", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000 });
+    running.push(daemon);
+
+    await expect(
+      startRedskilledWorker(paths, { ...proofSpec(workspace), project_label: "" }, { readyTimeoutMs: 5_000 }),
+    ).rejects.toThrow(/project_label/);
+    expect(daemon.workerCount()).toBe(0);
+  });
+});
+
+describe("the daemon accepts the workspace path as given", () => {
+  const LINUX_WITH_SESSION: WorkerPlacementProbes = {
+    platform: "linux",
+    systemdRun: "/usr/bin/systemd-run",
+    userSession: true,
+  };
+
+  it("never reads a repository marker to decide where the Worker runs", () => {
+    // A path with no repository under it at all — no .git, no .red, no package
+    // manifest, not even an existing directory. The launch plan must be
+    // identical in shape to one aimed at a real checkout.
+    const spawns: Array<{ command: string; args: readonly string[]; cwd?: string }> = [];
+    const launched = launchWorker({
+      spec: {
+        project_label: "opaque-label",
+        workspace_path: "/definitely/not/a/checkout",
+        command: "/bin/true",
+      },
+      probes: LINUX_WITH_SESSION,
+      spawnFn: (command, args, options) => {
+        spawns.push({ command, args, cwd: options.cwd as string | undefined });
+        return { pid: 4242, once: () => undefined, unref: () => undefined } as never;
+      },
+    });
+
+    expect(launched.worker.workspace_path).toBe("/definitely/not/a/checkout");
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0]!.args).toContain("--working-directory=/definitely/not/a/checkout");
+    expect(spawns[0]!.args.join(" ")).not.toMatch(/\.git|\.red|package\.json|worktree/);
+  });
+
+  it("derives nothing from the host either: probes are all it reads", () => {
+    // `detectWorkerPlacementProbes` is the daemon's ONLY host read on the launch
+    // path, and it looks at the platform, PATH and XDG_RUNTIME_DIR — never at a
+    // directory a client named.
+    const probes = detectWorkerPlacementProbes({ PATH: "", XDG_RUNTIME_DIR: "" }, "linux");
+
+    expect(probes).toEqual({ platform: "linux", systemdRun: null, userSession: false });
+  });
+
+  it("rejects a spec with no workspace at all rather than inventing one", () => {
+    expect(() =>
+      launchWorker({
+        spec: { project_label: "opaque", workspace_path: "  ", command: "/bin/true" },
+        probes: LINUX_WITH_SESSION,
+        spawnFn: () => ({ pid: 1, once: () => undefined, unref: () => undefined }) as never,
+      }),
+    ).toThrow(RedskilledWorkerSpecError);
+  });
+});

--- a/apps/redskilled/tests/worker-placement.test.ts
+++ b/apps/redskilled/tests/worker-placement.test.ts
@@ -1,0 +1,163 @@
+// The placement planner, proven from injected probes with nothing spawned.
+// Both Linux cases matter and they matter differently: with a user session the
+// Worker gets a transient SERVICE unit (never a scope — a scope dies with the
+// caller), and without one the launch still happens but says so out loud.
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKER_UNIT_PREFIX,
+  placementEnabled,
+  planWorkerPlacement,
+  REDSKILLED_PLACEMENT_ENV,
+  workerUnitName,
+  type WorkerPlacementProbes,
+} from "../src/worker-placement.js";
+
+const LINUX_WITH_SESSION: WorkerPlacementProbes = {
+  platform: "linux",
+  systemdRun: "/usr/bin/systemd-run",
+  userSession: true,
+};
+const LINUX_WITHOUT_SESSION: WorkerPlacementProbes = {
+  platform: "linux",
+  systemdRun: "/usr/bin/systemd-run",
+  userSession: false,
+};
+const LINUX_WITHOUT_SYSTEMD: WorkerPlacementProbes = {
+  platform: "linux",
+  systemdRun: null,
+  userSession: false,
+};
+const DARWIN: WorkerPlacementProbes = { platform: "darwin", systemdRun: null, userSession: false };
+
+function plan(probes: WorkerPlacementProbes, overrides: Record<string, unknown> = {}) {
+  return planWorkerPlacement({
+    workerId: "wQ9F2",
+    projectLabel: "acme/widgets",
+    workspacePath: "/given/workspace",
+    command: "/usr/bin/node",
+    args: ["worker.js", "--issue", "2774"],
+    budget: { memory_high: "3G", memory_max: "4G", cpu_weight: 200 },
+    probes,
+    ...overrides,
+  });
+}
+
+describe("worker placement — Linux with a user session", () => {
+  it("places the Worker in a transient service unit of its own", () => {
+    const placement = plan(LINUX_WITH_SESSION);
+
+    expect(placement.isolated).toBe(true);
+    expect(placement.command).toBe("/usr/bin/systemd-run");
+    expect(placement.unit).toBe("red-worker-acme-widgets-wq9f2.service");
+    expect(placement.args).toContain("--user");
+    expect(placement.args).toContain(`--unit=${placement.unit}`);
+    expect(placement.warning).toBeUndefined();
+  });
+
+  it("asks for a service unit, never a scope — a scope cannot outlive the daemon", () => {
+    const placement = plan(LINUX_WITH_SESSION);
+
+    expect(placement.args).not.toContain("--scope");
+    expect(placement.unit?.endsWith(".service")).toBe(true);
+  });
+
+  it("carries the budget as unit properties and the argv after the separator", () => {
+    const placement = plan(LINUX_WITH_SESSION);
+    const separator = placement.args.indexOf("--");
+
+    expect(placement.args.slice(0, separator)).toEqual(
+      expect.arrayContaining(["--property=MemoryHigh=3G", "--property=MemoryMax=4G", "--property=CPUWeight=200"]),
+    );
+    expect(placement.args.slice(separator + 1)).toEqual([
+      "/usr/bin/node",
+      "worker.js",
+      "--issue",
+      "2774",
+    ]);
+    expect(placement.budgetWarning).toBeUndefined();
+  });
+
+  it("hands the workspace path to the unit verbatim", () => {
+    const placement = plan(LINUX_WITH_SESSION, { workspacePath: "/nowhere/near/a/repo/x y" });
+
+    expect(placement.args).toContain("--working-directory=/nowhere/near/a/repo/x y");
+    expect(placement.args.filter((arg) => arg.startsWith("--working-directory="))).toHaveLength(1);
+  });
+
+  it("passes the Worker's environment through the unit, not through the daemon's", () => {
+    const placement = plan(LINUX_WITH_SESSION, { env: { RED_WORKER: "1" } });
+
+    expect(placement.args).toContain("--setenv=RED_WORKER=1");
+  });
+});
+
+describe("worker placement — Linux without a user session", () => {
+  it("still launches, and never silently: the warning names the cost", () => {
+    const placement = plan(LINUX_WITHOUT_SESSION);
+
+    expect(placement.isolated).toBe(false);
+    expect(placement.command).toBe("/usr/bin/node");
+    expect(placement.args).toEqual(["worker.js", "--issue", "2774"]);
+    expect(placement.cwd).toBe("/given/workspace");
+    expect(placement.unit).toBeUndefined();
+    expect(placement.warning).toMatch(/no systemd --user session/);
+  });
+
+  it("says the declared budget is now unenforceable rather than pretending it holds", () => {
+    expect(plan(LINUX_WITHOUT_SESSION).budgetWarning).toMatch(/cannot enforce it/);
+    expect(plan(LINUX_WITHOUT_SESSION, { budget: undefined }).budgetWarning).toBeUndefined();
+  });
+
+  it("warns about the missing binary when systemd-run is not on PATH", () => {
+    expect(plan(LINUX_WITHOUT_SYSTEMD).warning).toMatch(/systemd-run is not on PATH/);
+  });
+});
+
+describe("worker placement — every unisolated launch carries a warning", () => {
+  it("warns off Linux, where the transient-unit backend does not exist", () => {
+    const placement = plan(DARWIN);
+
+    expect(placement.isolated).toBe(false);
+    expect(placement.warning).toMatch(/platform=darwin/);
+  });
+
+  it("warns when the host kill-switch declined isolation", () => {
+    const placement = plan(LINUX_WITH_SESSION, { enabled: false });
+
+    expect(placement.isolated).toBe(false);
+    expect(placement.warning).toContain(REDSKILLED_PLACEMENT_ENV);
+  });
+
+  it("warns even when the client asked for `inherit` out loud", () => {
+    const placement = plan(LINUX_WITH_SESSION, { target: { isolation: "inherit" } });
+
+    expect(placement.isolated).toBe(false);
+    expect(placement.warning).toMatch(/inherit/);
+  });
+
+  it("leaves no unisolated plan without a warning, over every probe combination", () => {
+    for (const probes of [LINUX_WITH_SESSION, LINUX_WITHOUT_SESSION, LINUX_WITHOUT_SYSTEMD, DARWIN]) {
+      for (const enabled of [true, false]) {
+        for (const isolation of ["transient-unit", "inherit"] as const) {
+          const placement = plan(probes, { enabled, target: { isolation } });
+          expect(placement.isolated ? placement.warning === undefined : (placement.warning ?? "").length > 0).toBe(true);
+        }
+      }
+    }
+  });
+});
+
+describe("worker placement — naming and the kill-switch", () => {
+  it("slugifies both opaque labels instead of parsing them", () => {
+    expect(workerUnitName("Acme/Widgets.git", "wQ9F2/2774")).toBe("red-worker-acme-widgets-git-wq9f2-2774.service");
+    expect(workerUnitName("", "")).toBe(`${DEFAULT_WORKER_UNIT_PREFIX}-project-worker.service`);
+    expect(workerUnitName("p", "w", "red-gate")).toBe("red-gate-p-w.service");
+  });
+
+  it("reads the kill-switch off the environment, defaulting to enabled", () => {
+    expect(placementEnabled({})).toBe(true);
+    expect(placementEnabled({ [REDSKILLED_PLACEMENT_ENV]: "off" })).toBe(false);
+    expect(placementEnabled({ [REDSKILLED_PLACEMENT_ENV]: "0" })).toBe(false);
+    expect(placementEnabled({ [REDSKILLED_PLACEMENT_ENV]: "on" })).toBe(true);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2774. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2774

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787937649&installation_model_id=20659&pr_number=2803&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2803&signature=323dd27bc44be7e0205b1713186567bf0b1605d3b4d666cbe4f0bac0f521b9c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->