### PR TITLE
chore: changeset for the first redskilled slices (minor)

### DIFF
--- a/.changeset/redskilled-first-slices.md
+++ b/.changeset/redskilled-first-slices.md
@@ -1,0 +1,12 @@
+---
+"@reddb-io/dev": minor
+---
+
+First slices of the `redskilled` host-scoped execution daemon (Spec #2772, ADR 0130).
+
+Every fleet is scoped to one directory, which is right for work and wrong for resources: each checkout reads the same host capability profile, concludes the machine affords N workers, and spends that budget alone. These slices lay the foundation for one daemon that owns Worker processes across every project on a machine, while each project's bundle keeps owning the work.
+
+- **`redskilled` skeleton** (#2773) — a user-session singleton reachable over a unix socket, with lease ownership, auto-spawn, and an idle rule that never exits while a Worker is alive.
+- **A Worker is born through the daemon** (#2774) — the daemon plans placement from injected probes and launches the Worker into a transient service unit of its own, so the resource charge lands at birth rather than being reassigned later.
+- **Project identity resolves once** (#2778) — a declared `project.name` wins, then the git remote, then the checkout basename; the filesystem slug always carries a short hash of the git common directory, which makes a collision between independent clones impossible by construction while collapsing a repository's worktrees onto the project they belong to.
+- **The Worker state file becomes TOON/TOONL** (#2783) — the state file stops violating the repository's own encoder mandate, and its entry leaves the JSON file-I/O allowlist.


### PR DESCRIPTION
Adds the changeset that releases the first four slices of Spec #2772 as a **minor** bump (2.87.7 → 2.88.0).

Landed in this range:

- #2773 `redskilled` skeleton — user-session singleton behind a unix socket
- #2774 A Worker is born through the daemon, placed in its own transient unit
- #2778 Project identity resolves once, and `project.name` becomes a sanctioned root key
- #2783 The Worker state file becomes TOON/TOONL

Minor rather than patch because these add a new runtime surface rather than fixing behaviour. The `fixed` group in the changesets config bumps the published packages together.

Merging this opens the Version PR; merging that one publishes.

**Operational note:** publishing will make every Worker in a running fleet boot-halt on version skew until the fleet is relaunched on the new version. Relaunch immediately after the release lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787938440&installation_model_id=20659&pr_number=2804&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2804&signature=8ea3aa8569a76a91a124c17b106c8592a4ae250e9a496d30c650b62655e27f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->