### PR TITLE
chore: #2775 Daemon restart re-attaches live Workers and rehydrates from its event lane

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -7,6 +7,8 @@ machine while each project's bundle keeps owning the work.
 The core exists, is reachable, honest about its own life — and **births Workers**:
 a project hands over an argv, a placement target, a budget and two opaque
 strings, and the daemon launches the Worker into a resource unit of its own.
+**A restart costs none of it**: the daemon re-attaches to its live Workers by
+unit name and rehydrates identity and budget from its own append-only event lane.
 
 ## Why its own app
 
@@ -27,7 +29,10 @@ of it.
 | The frozen wire contract | `src/protocol.ts` — `ping`, `host-state`, `worker-start`, `shutdown` |
 | Where a Worker's resources are charged | `src/worker-placement.ts` — pure planner over injected probes |
 | Birth itself | `src/worker-launch.ts` — plan, spawn once, report the downgrade |
-| The host-wide read | `src/host-state.ts` — total shape, empty at this slice |
+| The host-wide read | `src/host-state.ts` — total shape, Workers plus the budget total |
+| What the daemon remembers across a restart | `src/event-lane.ts` — append-only TOONL: birth, death, budget-kill |
+| Finding the Workers a restart left running | `src/reattach.ts` — the unit name first, the pid only as fallback |
+| What the host has been promised | `src/budget-accounting.ts` — pure totals over the Worker set |
 | Reaching (and starting) the daemon | `src/client.ts` — auto-spawn, loser joins the winner |
 
 ## Behaviours worth knowing
@@ -55,6 +60,16 @@ of it.
 - **Placement is decided at launch.** Moving a running process between resource
   groups does not move its existing memory charge, so a Worker born in the
   caller's group stays charged there for life no matter what is done afterwards.
+- **A restart re-attaches, it does not restart the work.** The daemon replays its
+  event lane, asks the host about each Worker by unit name, adopts the ones still
+  running and records the deaths of the ones that ended while nobody was
+  watching. A pid is only consulted for a Worker that never got a unit.
+- **Three facts on the lane, and no per-Worker durable record.** Birth, death and
+  budget-kill are the daemon's own — issue-to-PR belongs to the tracker and
+  branch-to-commits to git, and a third copy of those would only drift.
+- **A crash costs the event in flight, never the lane.** An unterminated final
+  line is read as absent (TOONL's own rule for a truncated open tail) and dropped
+  before the next append, so a half-written record can never fuse onto the next.
 - **An unisolated launch is never silent.** When the host affords no transient
   unit the Worker still starts, and the reply — and the host-state record it
   keeps for its whole life — carries a warning naming what was lost. A declared

--- a/apps/redskilled/src/budget-accounting.ts
+++ b/apps/redskilled/src/budget-accounting.ts
@@ -1,0 +1,108 @@
+/**
+ * budget-accounting — what the daemon has promised the machine, in one total.
+ *
+ * The daemon exists so the memory a host spends on Workers is decided once,
+ * host-wide, instead of once per project. That promise is only as good as the
+ * daemon's ability to state it, so the accounting is a first-class document
+ * rather than a number a caller re-derives — and it is derived from the Worker
+ * set alone, which is what makes "the accounting after a restart matches the
+ * accounting before it" a property of rehydration rather than of a second
+ * durable copy.
+ *
+ * **A budget that cannot be reduced to bytes is named, never rounded to zero.**
+ * `MemoryHigh` accepts forms the daemon does not model (a percentage of the
+ * host, `infinity`), and quietly counting those as nothing would understate the
+ * host's exposure exactly when it is largest.
+ *
+ * PURE: every input is a Worker view.
+ */
+import type { RedskilledWorkerView } from "./host-state.js";
+
+export interface RedskilledBudgetAccounting {
+  readonly version: 1;
+  readonly worker_count: number;
+  /** Sum of the declared `MemoryHigh` budgets, in bytes. */
+  readonly memory_high_bytes: number;
+  /** Sum of the declared `MemoryMax` budgets, in bytes. */
+  readonly memory_max_bytes: number;
+  /** Sum of the declared CPU weights — a share, reported as declared. */
+  readonly cpu_weight_total: number;
+  /** Workers whose declared budget could not be reduced to bytes, by id. */
+  readonly unaccounted_workers: readonly string[];
+  /** Workers with no unit of their own; their charge lands on the daemon. */
+  readonly unisolated_workers: readonly string[];
+}
+
+/** The empty accounting — a daemon holding nothing still states a total. */
+export const EMPTY_BUDGET_ACCOUNTING: RedskilledBudgetAccounting = {
+  version: 1,
+  worker_count: 0,
+  memory_high_bytes: 0,
+  memory_max_bytes: 0,
+  cpu_weight_total: 0,
+  unaccounted_workers: [],
+  unisolated_workers: [],
+};
+
+/** Total the declared budgets of a Worker set. PURE. */
+export function buildBudgetAccounting(workers: readonly RedskilledWorkerView[]): RedskilledBudgetAccounting {
+  let memoryHigh = 0;
+  let memoryMax = 0;
+  let cpuWeight = 0;
+  const unaccounted: string[] = [];
+  const unisolated: string[] = [];
+
+  for (const worker of workers) {
+    const budget = worker.budget ?? {};
+    let opaque = false;
+    for (const [declared, add] of [
+      [budget.memory_high, (bytes: number) => (memoryHigh += bytes)],
+      [budget.memory_max, (bytes: number) => (memoryMax += bytes)],
+    ] as const) {
+      if (declared == null) continue;
+      const bytes = parseMemoryBudget(declared);
+      if (bytes == null) opaque = true;
+      else add(bytes);
+    }
+    if (budget.cpu_weight != null) cpuWeight += budget.cpu_weight;
+    if (opaque) unaccounted.push(worker.worker_id);
+    if (!worker.isolated) unisolated.push(worker.worker_id);
+  }
+
+  return {
+    version: 1,
+    worker_count: workers.length,
+    memory_high_bytes: memoryHigh,
+    memory_max_bytes: memoryMax,
+    cpu_weight_total: cpuWeight,
+    unaccounted_workers: unaccounted.sort(),
+    unisolated_workers: unisolated.sort(),
+  };
+}
+
+/**
+ * A systemd memory value in bytes, or `null` when it is not a byte quantity.
+ *
+ * The suffixes are systemd's own (`K`/`M`/`G`/`T`, base 1024, optional `B`).
+ * `infinity`, a percentage and anything unrecognised return `null` rather than a
+ * guess: the caller reports those Workers by name.
+ */
+export function parseMemoryBudget(value: string): number | null {
+  const match = /^\s*(\d+(?:\.\d+)?)\s*([KMGT]?)(?:B)?\s*$/i.exec(value);
+  if (!match) return null;
+  const scale = { "": 1, k: 1024, m: 1024 ** 2, g: 1024 ** 3, t: 1024 ** 4 }[match[2]!.toLowerCase()]!;
+  return Math.round(Number(match[1]) * scale);
+}
+
+/** True when `value` is a complete accounting document — a client's fail-closed check. */
+export function isRedskilledBudgetAccounting(value: unknown): value is RedskilledBudgetAccounting {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const accounting = value as Record<string, unknown>;
+  return accounting.version === 1 &&
+    Number.isInteger(accounting.worker_count) &&
+    typeof accounting.memory_high_bytes === "number" &&
+    typeof accounting.memory_max_bytes === "number" &&
+    typeof accounting.cpu_weight_total === "number" &&
+    Array.isArray(accounting.unaccounted_workers) &&
+    Array.isArray(accounting.unisolated_workers);
+}

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -15,6 +15,7 @@ import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
 const SERVE_FLAGS = {
   socket: { kind: "value", coerce: (raw: string) => raw },
   lease: { kind: "value", coerce: (raw: string) => raw },
+  events: { kind: "value", coerce: (raw: string) => raw },
   "session-key-hash": { kind: "value", coerce: (raw: string) => raw },
   "machine-id-hash": { kind: "value", coerce: (raw: string) => raw },
   "idle-ms": { kind: "value", coerce: (raw: string) => Number(raw) },
@@ -52,6 +53,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
 function servePaths(values: {
   socket?: string;
   lease?: string;
+  events?: string;
   "session-key-hash"?: string;
   "machine-id-hash"?: string;
 }): RedskilledPaths {
@@ -60,6 +62,7 @@ function servePaths(values: {
     ...derived,
     socketPath: values.socket ?? derived.socketPath,
     leasePath: values.lease ?? derived.leasePath,
+    eventLanePath: values.events ?? derived.eventLanePath,
     sessionKeyHash: values["session-key-hash"] ?? derived.sessionKeyHash,
     machineIdHash: values["machine-id-hash"] ?? derived.machineIdHash,
   };

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -151,6 +151,8 @@ function spawnDaemon(paths: RedskilledPaths, config: RedskilledClientConfig): vo
     paths.socketPath,
     "--lease",
     paths.leasePath,
+    "--events",
+    paths.eventLanePath,
     "--session-key-hash",
     paths.sessionKeyHash,
     "--machine-id-hash",

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -16,14 +16,36 @@
  * every fire the daemon re-reads its own Worker set and rearms instead of
  * exiting if it is non-empty. Leaving by boredom would abandon a budget nobody
  * else is tracking.
+ *
+ * **A restart costs no work, and no accounting.** Workers are init-system units,
+ * so a starting daemon does not find an empty world — it replays its own
+ * append-only event lane, re-attaches to every Worker the host still confirms by
+ * unit name, and records the deaths of the ones that ended while nobody was
+ * watching. Identity and budget come back from the lane rather than from a
+ * per-Worker durable record, because the two authorities that already hold the
+ * rest of a Worker's story — the tracker and git — would only be contradicted by
+ * a third copy.
  */
 import { randomUUID } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
 import { createServer, type Server, type Socket } from "node:net";
 import { dirname } from "node:path";
 import { sendLineRequest } from "@reddb-io/shared/resident-core.js";
+import {
+  createRedskilledEventLane,
+  rehydrateWorkers,
+  type RedskilledEventLane,
+  type RedskilledHostEvent,
+} from "./event-lane.js";
 import { buildHostState, type RedskilledHostState, type RedskilledWorkerView } from "./host-state.js";
 import type { RedskilledPaths } from "./paths.js";
+import {
+  detectWorkerLiveness,
+  reattachWorkers,
+  stopWorker,
+  type RedskilledLivenessProbe,
+  type RedskilledStopProbe,
+} from "./reattach.js";
 import { REDSKILLED_PROTOCOL_VERSION, type RedskilledRequest, type RedskilledResponse } from "./protocol.js";
 import {
   launchWorker,
@@ -63,6 +85,12 @@ export interface RedskilledDaemonOptions {
   readonly clock?: () => string;
   /** How a Worker is born; injected so a test can birth one without a spawn. */
   readonly launch?: (options: LaunchWorkerOptions) => LaunchedWorker;
+  /** The append-only host event lane; defaults to this session's own. */
+  readonly eventLane?: RedskilledEventLane;
+  /** How the daemon asks whether a re-attached Worker is still running. */
+  readonly liveness?: RedskilledLivenessProbe;
+  /** How the daemon stops a Worker it is reclaiming a budget from. */
+  readonly stopWorker?: RedskilledStopProbe;
 }
 
 export interface RedskilledDaemon {
@@ -79,6 +107,20 @@ export interface RedskilledDaemon {
   releaseWorker(workerId: string): boolean;
   workerCount(): number;
   hostState(): RedskilledHostState;
+  /**
+   * Reclaim a Worker's budget: stop it, record the kill, forget it.
+   *
+   * A budget kill is its own event rather than a death with a note, because the
+   * two answer different questions — a reader counting how often the host ran
+   * out of room must not have to distinguish it from a Worker that finished.
+   */
+  killWorkerOverBudget(workerId: string, detail: string): Promise<boolean>;
+  /** Re-probe every re-attached Worker, retiring the ones the host no longer confirms. */
+  sweepReattached(): Promise<readonly RedskilledWorkerView[]>;
+  /** The Workers this daemon adopted at start rather than birthing itself. */
+  reattached(): readonly RedskilledWorkerView[];
+  /** Resolves once every event handed to the lane has reached disk. */
+  flushEvents(): Promise<void>;
   /** Force the idle check to run now — the timer's body, exposed for tests. */
   evaluateIdle(): "exited" | "held-by-workers";
   stop(): Promise<void>;
@@ -118,7 +160,13 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   const startedAt = clock();
+  const eventLane = options.eventLane ?? createRedskilledEventLane(paths.eventLanePath);
+  const liveness = options.liveness ?? detectWorkerLiveness;
+  const stopProbe = options.stopWorker ?? stopWorker;
   const workers = new Map<string, RedskilledWorkerView>();
+  // Re-attached Workers have no child handle to deliver an exit, so their death
+  // is discovered by asking the host rather than by being told.
+  const reattached = new Set<string>();
   const activeSockets = new Set<Socket>();
   let idleTimer: NodeJS.Timeout | undefined;
   let stopping = false;
@@ -149,21 +197,82 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     const launched = launch({
       spec,
       clock,
-      onExit: (workerId) => {
+      onExit: (workerId, code, signal) => {
+        const worker = workers.get(workerId);
         workers.delete(workerId);
+        reattached.delete(workerId);
+        if (worker) record("worker-death", worker, `exit code=${code ?? "null"} signal=${signal ?? "null"}`);
         armIdleTimer();
       },
     });
     workers.set(launched.worker.worker_id, launched.worker);
+    record("worker-birth", launched.worker, null);
     armIdleTimer();
     return launched;
+  }
+
+  /**
+   * Append one event, without making the caller wait for the disk.
+   *
+   * The lane serialises its own appends, so ordering survives the fire-and-
+   * forget; what a failed write must not do is take down the daemon that still
+   * holds the live Worker the event was about.
+   */
+  function record(
+    event: RedskilledHostEvent["event"],
+    worker: RedskilledWorkerView,
+    detail: string | null,
+  ): void {
+    // A stopped daemon writes nothing. Its beliefs about who is alive stopped
+    // being authoritative when it let go of the session, and the next daemon
+    // re-derives every one of them by asking the host directly.
+    if (stopping) return;
+    void eventLane.record({ event, worker, ts: clock(), detail }).catch(() => undefined);
+  }
+
+  /**
+   * Ask the host about every re-attached Worker, and retire the ones it no
+   * longer confirms. Returns the Workers that were retired.
+   */
+  async function sweepReattached(): Promise<readonly RedskilledWorkerView[]> {
+    const adopted = [...reattached].map((id) => workers.get(id)).filter((w): w is RedskilledWorkerView => w != null);
+    if (adopted.length === 0) return [];
+    const { dead } = await reattachWorkers(adopted, liveness);
+    for (const worker of dead) {
+      workers.delete(worker.worker_id);
+      reattached.delete(worker.worker_id);
+      record("worker-death", worker, "the host no longer confirms this Worker");
+    }
+    if (dead.length > 0) armIdleTimer();
+    return dead;
+  }
+
+  async function killWorkerOverBudget(workerId: string, detail: string): Promise<boolean> {
+    const worker = workers.get(workerId);
+    if (!worker) return false;
+    try {
+      await stopProbe(worker);
+    } catch {
+      // The kill is recorded either way: a stop the host refused still ends the
+      // daemon's claim on the budget, and a silent failure would leave the
+      // accounting holding room for a Worker nobody is tracking any more.
+    }
+    workers.delete(workerId);
+    reattached.delete(workerId);
+    record("worker-budget-kill", worker, detail);
+    armIdleTimer();
+    return true;
   }
 
   function armIdleTimer(): void {
     if (stopping) return;
     if (idleTimer) clearTimeout(idleTimer);
     idleTimer = setTimeout(() => {
-      evaluateIdle();
+      // Sweep before deciding: a daemon that exited on a stale belief in a
+      // re-attached Worker would hold this session's socket for nothing.
+      void sweepReattached()
+        .catch(() => undefined)
+        .then(() => evaluateIdle());
     }, idleMs);
     idleTimer.unref();
   }
@@ -183,6 +292,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     if (stopping) return await closed;
     stopping = true;
     if (idleTimer) clearTimeout(idleTimer);
+    // Every event already handed over reaches the lane before the daemon lets go
+    // of the session: a birth still in flight would leave the next daemon with a
+    // Worker it holds a budget for and no record of.
+    await eventLane.flush().catch(() => undefined);
     server.close();
     for (const socket of activeSockets) socket.destroy();
     await new Promise<void>((resolve) => server.once("close", () => resolve()));
@@ -190,6 +303,19 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     await leaseStore.release(owner).catch(() => undefined);
     resolveClosed();
     return await closed;
+  }
+
+  // Rehydrate BEFORE the socket starts answering: a client that read host state
+  // in the window between binding and replay would be told this session holds
+  // nothing, and would then birth a second Worker for work already running.
+  const replayed = rehydrateWorkers(await eventLane.read().catch(() => []));
+  const reattachment = await reattachWorkers(replayed, liveness);
+  for (const worker of reattachment.alive) {
+    workers.set(worker.worker_id, worker);
+    reattached.add(worker.worker_id);
+  }
+  for (const worker of reattachment.dead) {
+    record("worker-death", worker, "the Worker ended while no daemon was watching");
   }
 
   server.on("connection", (socket) => {
@@ -239,12 +365,20 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     startedAt,
     closed,
     startWorker,
+    killWorkerOverBudget,
+    sweepReattached,
+    reattached: () => [...reattached].map((id) => workers.get(id)).filter((w): w is RedskilledWorkerView => w != null),
+    flushEvents: () => eventLane.flush(),
     trackWorker(worker) {
       workers.set(worker.worker_id, worker);
+      record("worker-birth", worker, null);
       armIdleTimer();
     },
     releaseWorker(workerId) {
+      const worker = workers.get(workerId);
       const removed = workers.delete(workerId);
+      reattached.delete(workerId);
+      if (worker) record("worker-death", worker, "released by the daemon");
       armIdleTimer();
       return removed;
     },

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -1,0 +1,286 @@
+/**
+ * event-lane — the daemon's own append-only memory of the Workers it birthed.
+ *
+ * **One lane, three facts: birth, death, and a budget-driven kill.** ADR 0130
+ * gives the daemon exactly one thing no other authority holds — Worker-to-process
+ * — and this lane is the durable form of it. The tracker already owns
+ * issue-to-PR and git already owns branch-to-commits, so a per-Worker durable
+ * record would be a third copy of facts two authorities already keep, and the
+ * only thing a third copy reliably does is drift.
+ *
+ * **Append-only, never rewritten.** A restarted daemon rehydrates by replaying
+ * the lane, so a writer that rewrote a record would be editing the past out from
+ * under a reader mid-replay. Every event is a whole line appended in one call.
+ *
+ * **A crash mid-append costs the tail, never the lane.** The writer's process can
+ * die between the `write` and the newline, which leaves a half-encoded row on
+ * disk. The reader therefore treats an unterminated final line as absent —
+ * TOONL's own rule that a crash-truncated open tail is unverified rather than
+ * corrupt — instead of failing the whole replay over the one event that was
+ * still in flight.
+ *
+ * TOONL on disk via the TOON encoder (repo mandate). The shape is fixed and
+ * total — every field present on every event, `null` where it does not apply —
+ * so one segment header covers a whole writer's session and a reader never
+ * special-cases an event kind's row.
+ */
+import { appendFile, mkdir, open, readFile, stat, truncate } from "node:fs/promises";
+import { dirname } from "node:path";
+import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
+import type { RedskilledWorkerView } from "./host-state.js";
+import type { RedskilledWorkerBudget } from "./worker-placement.js";
+
+/** The three facts the lane carries. Nothing else is a host event. */
+export type RedskilledEventKind = "worker-birth" | "worker-death" | "worker-budget-kill";
+
+/**
+ * One host event, flat and total.
+ *
+ * The Worker's identity fields ride on the death and kill events too, not just
+ * on birth: a reader that had to join a death back to its birth to learn the
+ * project label would be unable to report anything from a lane whose head was
+ * rotated away.
+ */
+export interface RedskilledHostEvent {
+  readonly version: 1;
+  readonly ts: string;
+  readonly event: RedskilledEventKind;
+  readonly worker_id: string;
+  readonly project_label: string;
+  readonly pid: number;
+  readonly workspace_path: string;
+  readonly isolated: boolean;
+  /** The transient unit name — the handle a restarted daemon re-attaches by. */
+  readonly unit: string | null;
+  readonly memory_high: string | null;
+  readonly memory_max: string | null;
+  readonly cpu_weight: number | null;
+  /** Why, for a death or a kill: an exit status, a signal, a budget verdict. */
+  readonly detail: string | null;
+}
+
+/** The lane file's name inside the session runtime directory. */
+export const REDSKILLED_EVENT_LANE_FILE = "redskilled.events.toonl";
+
+export interface RecordEventInput {
+  readonly event: RedskilledEventKind;
+  readonly worker: RedskilledWorkerView;
+  readonly ts: string;
+  readonly detail?: string | null;
+}
+
+/** Build one event from a Worker view. PURE. */
+export function buildHostEvent(input: RecordEventInput): RedskilledHostEvent {
+  const budget = input.worker.budget ?? {};
+  return {
+    version: 1,
+    ts: input.ts,
+    event: input.event,
+    worker_id: input.worker.worker_id,
+    project_label: input.worker.project_label,
+    pid: input.worker.pid,
+    workspace_path: input.worker.workspace_path,
+    isolated: input.worker.isolated,
+    unit: input.worker.unit ?? null,
+    memory_high: budget.memory_high ?? null,
+    memory_max: budget.memory_max ?? null,
+    cpu_weight: budget.cpu_weight ?? null,
+    detail: input.detail ?? null,
+  };
+}
+
+/**
+ * An open lane writer.
+ *
+ * The emitter is held per writer rather than per call so a session's events
+ * share one segment header. A fresh process starts a fresh emitter and therefore
+ * re-declares the header, which is a segment rotation the reader already
+ * follows — the alternative, reading the file's tail to recover the previous
+ * writer's header, would make every append depend on bytes a crash may have cut.
+ */
+export interface RedskilledEventLane {
+  readonly path: string;
+  /** Append one event; resolves once the bytes are on the lane. */
+  record(input: RecordEventInput): Promise<RedskilledHostEvent>;
+  /** Every event on the lane, oldest first, tolerating a truncated tail. */
+  read(): Promise<RedskilledHostEvent[]>;
+  /** Resolves once every append handed over so far has reached the lane. */
+  flush(): Promise<void>;
+}
+
+export function createRedskilledEventLane(path: string): RedskilledEventLane {
+  const emitter = encodeLines({ trailer: false });
+  // Appends are serialised through one chain: two concurrent `appendFile` calls
+  // could interleave a header and a row, and a header the reader sees mid-row is
+  // exactly the corruption this lane promises not to produce.
+  let tail: Promise<unknown> = Promise.resolve();
+
+  return {
+    path,
+    async record(input) {
+      const event = buildHostEvent(input);
+      const write = tail.then(async () => {
+        await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+        await dropIncompleteTail(path);
+        await appendFile(path, emitter.push(toRow(event)), { encoding: "utf8", mode: 0o600 });
+      });
+      tail = write.catch(() => undefined);
+      await write;
+      return event;
+    },
+    read: () => readRedskilledEvents(path),
+    flush: async () => {
+      await tail;
+    },
+  };
+}
+
+/**
+ * Cut a crash's half-written last line off the lane, before every append.
+ *
+ * Before EVERY append rather than once per writer: the check costs a stat and a
+ * single byte, and "the file always ends on a line boundary" is a property worth
+ * more than that — a writer that only checked at startup would fuse its rows
+ * onto a tail that anything else truncated later.
+ *
+ * This is not a rewrite of the lane and it is not in tension with append-only:
+ * the bytes it drops were never a record, only the beginning of one nobody
+ * finished. Leaving them would be far worse than dropping them — the next append
+ * would fuse onto the unterminated line and turn one lost event into a line no
+ * reader can decode, which is a corruption that outlives the crash.
+ */
+async function dropIncompleteTail(path: string): Promise<void> {
+  let size: number;
+  try {
+    size = (await stat(path)).size;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  if (size === 0) return;
+
+  // Read backwards a window at a time: a lane is small in practice, and reading
+  // the whole file to inspect its last byte would make every daemon start pay
+  // for the session's entire history.
+  const window = 64 * 1024;
+  const handle = await open(path, "r");
+  try {
+    const last = Buffer.alloc(1);
+    await handle.read(last, 0, 1, size - 1);
+    if (last[0] === 0x0a) return;
+    for (let end = size; end > 0; end -= window) {
+      const length = Math.min(window, end);
+      const chunk = Buffer.alloc(length);
+      await handle.read(chunk, 0, length, end - length);
+      const newline = chunk.lastIndexOf(0x0a);
+      if (newline >= 0) {
+        await truncate(path, end - length + newline + 1);
+        return;
+      }
+    }
+    // Not one complete line in the whole file: the crash took everything.
+    await truncate(path, 0);
+  } finally {
+    await handle.close();
+  }
+}
+
+/** Every event on the lane at `path`; an absent lane is an empty history. */
+export async function readRedskilledEvents(path: string): Promise<RedskilledHostEvent[]> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  return parseEventLane(raw);
+}
+
+/**
+ * Decode a lane's text into events, dropping a crash-truncated tail. PURE.
+ *
+ * Only a line the writer never terminated is dropped, and only from the end: a
+ * reader that skipped every line it could not decode would silently swallow a
+ * genuine format bug in the middle of the lane as if it were a crash.
+ */
+export function parseEventLane(raw: string): RedskilledHostEvent[] {
+  const lines = raw.split("\n");
+  // `split` leaves a trailing "" for a newline-terminated file; anything else in
+  // that slot is the half-written line a crash left behind.
+  lines.pop();
+  if (lines.length === 0) return [];
+  const records = parseRecords(`${lines.join("\n")}\n`);
+  return records.filter(isHostEventRecord).map(fromRow);
+}
+
+/**
+ * Replay events into the Workers the daemon should still believe are alive.
+ *
+ * Last event per Worker wins: a birth admits it, a death or a budget kill
+ * retires it. Ordering is the lane's own, which is the order the daemon observed
+ * the facts in — a timestamp comparison would let a clock adjustment resurrect a
+ * Worker the daemon watched die. PURE.
+ */
+export function rehydrateWorkers(events: readonly RedskilledHostEvent[]): RedskilledWorkerView[] {
+  const alive = new Map<string, RedskilledWorkerView>();
+  for (const event of events) {
+    if (event.event === "worker-birth") alive.set(event.worker_id, toWorkerView(event));
+    else alive.delete(event.worker_id);
+  }
+  return [...alive.values()];
+}
+
+/** The Worker view an event describes. PURE. */
+export function toWorkerView(event: RedskilledHostEvent): RedskilledWorkerView {
+  const budget: RedskilledWorkerBudget = {
+    ...(event.memory_high != null ? { memory_high: event.memory_high } : {}),
+    ...(event.memory_max != null ? { memory_max: event.memory_max } : {}),
+    ...(event.cpu_weight != null ? { cpu_weight: event.cpu_weight } : {}),
+  };
+  return {
+    worker_id: event.worker_id,
+    project_label: event.project_label,
+    pid: event.pid,
+    started_at: event.ts,
+    workspace_path: event.workspace_path,
+    isolated: event.isolated,
+    ...(event.unit != null ? { unit: event.unit } : {}),
+    ...(Object.keys(budget).length > 0 ? { budget } : {}),
+    warnings: [],
+  };
+}
+
+function toRow(event: RedskilledHostEvent): ToonlRecord {
+  return { ...event };
+}
+
+function isHostEventRecord(record: ToonlRecord): boolean {
+  return record.version === 1 &&
+    typeof record.ts === "string" &&
+    typeof record.worker_id === "string" &&
+    (record.event === "worker-birth" || record.event === "worker-death" || record.event === "worker-budget-kill");
+}
+
+function fromRow(record: ToonlRecord): RedskilledHostEvent {
+  return {
+    version: 1,
+    ts: String(record.ts),
+    event: record.event as RedskilledEventKind,
+    worker_id: String(record.worker_id),
+    project_label: text(record.project_label) ?? "",
+    pid: Number(record.pid ?? 0),
+    workspace_path: text(record.workspace_path) ?? "",
+    isolated: record.isolated === true || record.isolated === "true",
+    unit: text(record.unit),
+    memory_high: text(record.memory_high),
+    memory_max: text(record.memory_max),
+    cpu_weight: record.cpu_weight == null || record.cpu_weight === "" ? null : Number(record.cpu_weight),
+    detail: text(record.detail),
+  };
+}
+
+function text(value: ToonlRecord[string]): string | null {
+  if (value == null || value === "") return null;
+  return String(value);
+}

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -8,7 +8,13 @@
  * Read the host, write the project (ADR 0130 rule 9): this document is the read
  * half, and it is host-wide on purpose.
  */
+import {
+  buildBudgetAccounting,
+  isRedskilledBudgetAccounting,
+  type RedskilledBudgetAccounting,
+} from "./budget-accounting.js";
 import { REDSKILLED_PROTOCOL_VERSION } from "./protocol.js";
+import type { RedskilledWorkerBudget } from "./worker-placement.js";
 
 /**
  * One Worker process, as the daemon sees it.
@@ -30,6 +36,14 @@ export interface RedskilledWorkerView {
   readonly isolated: boolean;
   /** The transient unit's name, present only when `isolated`. */
   readonly unit?: string;
+  /**
+   * The budget this Worker was born under, carried for its whole life.
+   *
+   * It travels WITH the Worker because the host-wide accounting is derived from
+   * the Worker set: a budget known only at launch would be a number the daemon
+   * could state once and never again after a restart.
+   */
+  readonly budget?: RedskilledWorkerBudget;
   /** Non-empty whenever the launch was a downgrade; never silently absent. */
   readonly warnings: readonly string[];
 }
@@ -50,6 +64,8 @@ export interface RedskilledHostState {
   readonly started_at: string;
   readonly workers: readonly RedskilledWorkerView[];
   readonly projects: readonly RedskilledProjectView[];
+  /** What the daemon has promised the machine, derived from `workers`. */
+  readonly budget_accounting: RedskilledBudgetAccounting;
 }
 
 export interface BuildHostStateInput {
@@ -78,6 +94,7 @@ export function buildHostState(input: BuildHostStateInput): RedskilledHostState 
     projects: [...counts.entries()]
       .map(([project_label, worker_count]) => ({ project_label, worker_count }))
       .sort((a, b) => a.project_label.localeCompare(b.project_label)),
+    budget_accounting: buildBudgetAccounting(workers),
   };
 }
 
@@ -106,5 +123,6 @@ export function isRedskilledHostState(value: unknown): value is RedskilledHostSt
     Number.isInteger(state.pid) &&
     typeof state.started_at === "string" &&
     Array.isArray(state.workers) &&
-    Array.isArray(state.projects);
+    Array.isArray(state.projects) &&
+    isRedskilledBudgetAccounting(state.budget_accounting);
 }

--- a/apps/redskilled/src/paths.ts
+++ b/apps/redskilled/src/paths.ts
@@ -16,6 +16,7 @@ import { createHash } from "node:crypto";
 import { hostname } from "node:os";
 import { join } from "node:path";
 import { runtimeSocketDir } from "@reddb-io/shared/resident-core.js";
+import { REDSKILLED_EVENT_LANE_FILE } from "./event-lane.js";
 
 /** The socket file name; also the length the runtime dir must accommodate. */
 export const REDSKILLED_SOCKET_FILE = "redskilled.sock";
@@ -34,6 +35,8 @@ export interface RedskilledPaths {
   readonly socketPath: string;
   readonly lockPath: string;
   readonly leasePath: string;
+  /** The append-only host event lane the daemon rehydrates itself from. */
+  readonly eventLanePath: string;
 }
 
 export interface ResolveRedskilledPathsOptions {
@@ -88,6 +91,7 @@ export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = 
     socketPath: join(runtimeDir, REDSKILLED_SOCKET_FILE),
     lockPath: join(runtimeDir, "redskilled.spawn.lock"),
     leasePath: join(runtimeDir, "redskilled.lease.toon"),
+    eventLanePath: join(runtimeDir, REDSKILLED_EVENT_LANE_FILE),
   };
 }
 

--- a/apps/redskilled/src/reattach.ts
+++ b/apps/redskilled/src/reattach.ts
@@ -1,0 +1,95 @@
+/**
+ * reattach — how a restarted daemon finds the Workers it left running.
+ *
+ * **A Worker is an init-system unit, not a daemon child.** That is the whole
+ * reason a restart costs nothing: the unit's owner is the init system, so the
+ * daemon that asked for it can die, be upgraded and come back, and the Worker
+ * never notices. What the new daemon has to do is the inverse of birth — take
+ * the handle the lane recorded and ask the host whether it still names something
+ * alive.
+ *
+ * **The handle is the unit name, and the pid is only the fallback.** A pid is
+ * not an identity: the OS reuses it, so a restarted daemon that re-attached by
+ * pid alone would sooner or later adopt a stranger's process and hold a budget
+ * for work nobody is doing. A unit name is unique for as long as the unit
+ * exists, which is exactly the window re-attachment cares about. Only an
+ * unisolated Worker — one that never got a unit, and whose launch said so out
+ * loud — falls back to its pid.
+ *
+ * The probes are injected, so both branches are provable without systemd.
+ */
+import { spawnSync } from "node:child_process";
+import { isPidAlive } from "@reddb-io/shared/resident-core.js";
+import type { RedskilledWorkerView } from "./host-state.js";
+
+/** Answers "is this Worker still running?" for one Worker. */
+export type RedskilledLivenessProbe = (worker: RedskilledWorkerView) => boolean | Promise<boolean>;
+
+/** Stops one Worker; returns whether the host accepted the stop. */
+export type RedskilledStopProbe = (worker: RedskilledWorkerView) => boolean | Promise<boolean>;
+
+export interface ReattachOutcome {
+  /** Workers the host still confirms; the restarted daemon adopts these. */
+  readonly alive: readonly RedskilledWorkerView[];
+  /** Workers that died while no daemon was watching; their deaths are recorded. */
+  readonly dead: readonly RedskilledWorkerView[];
+}
+
+/**
+ * Sort a rehydrated Worker set into the ones still running and the ones gone.
+ *
+ * A probe that throws counts the Worker as dead. The alternative — treating an
+ * unanswerable probe as alive — would hold a budget forever on the first
+ * transient failure, and a Worker wrongly declared dead is re-observable the
+ * moment the host answers again, while a budget wrongly held is not.
+ */
+export async function reattachWorkers(
+  workers: readonly RedskilledWorkerView[],
+  probe: RedskilledLivenessProbe,
+): Promise<ReattachOutcome> {
+  const alive: RedskilledWorkerView[] = [];
+  const dead: RedskilledWorkerView[] = [];
+  for (const worker of workers) {
+    let live = false;
+    try {
+      live = (await probe(worker)) === true;
+    } catch {
+      live = false;
+    }
+    (live ? alive : dead).push(worker);
+  }
+  return { alive, dead };
+}
+
+/** The default probe: the unit when there is one, the pid when there is not. */
+export function detectWorkerLiveness(worker: RedskilledWorkerView): boolean {
+  if (worker.unit != null && worker.unit !== "") return isUnitActive(worker.unit);
+  return isPidAlive(worker.pid);
+}
+
+/** True when systemd reports `unit` in a running state for this user session. */
+export function isUnitActive(unit: string): boolean {
+  const probe = spawnSync("systemctl", ["--user", "is-active", "--quiet", unit], { stdio: "ignore" });
+  if (probe.error != null) return false;
+  return probe.status === 0;
+}
+
+/**
+ * Stop one Worker: the unit by name, or the process by pid.
+ *
+ * Stopping the unit rather than the pid is what makes the kill total — a Worker
+ * that forked children would otherwise leave them behind, still charged to the
+ * budget the daemon just decided to reclaim.
+ */
+export function stopWorker(worker: RedskilledWorkerView): boolean {
+  if (worker.unit != null && worker.unit !== "") {
+    const stop = spawnSync("systemctl", ["--user", "stop", worker.unit], { stdio: "ignore" });
+    return stop.error == null && stop.status === 0;
+  }
+  try {
+    process.kill(worker.pid, "SIGTERM");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -143,6 +143,7 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     workspace_path: spec.workspace_path,
     isolated: plan.isolated,
     ...(plan.unit != null ? { unit: plan.unit } : {}),
+    ...(spec.budget != null ? { budget: spec.budget } : {}),
     warnings,
   };
   return { worker, warnings, plan, child };

--- a/apps/redskilled/tests/daemon-restart.test.ts
+++ b/apps/redskilled/tests/daemon-restart.test.ts
@@ -1,0 +1,374 @@
+// A restart costs nothing: the Workers keep running, the daemon finds them
+// again by unit name, and the budget it reports afterwards is the budget it
+// reported before. The lane is the only thing that carries that across the gap.
+import { appendFile, mkdtemp, readFile, rm, truncate, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseRecords } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildBudgetAccounting, parseMemoryBudget } from "../src/budget-accounting.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import {
+  createRedskilledEventLane,
+  parseEventLane,
+  readRedskilledEvents,
+  rehydrateWorkers,
+  type RedskilledHostEvent,
+} from "../src/event-lane.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import type { RedskilledWorkerSpec } from "../src/worker-launch.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+const spawnedPids: number[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const pid of spawnedPids.splice(0)) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {}
+  }
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await scratch("redskilled-restart-");
+  return resolveRedskilledPaths({ env: { REDSKILLED_SESSION: `test:${root}` }, runtimeDir: root });
+}
+
+/** A Worker that outlives the daemon that birthed it — the whole point of the slice. */
+function longLivedSpec(workspacePath: string, overrides: Partial<RedskilledWorkerSpec> = {}): RedskilledWorkerSpec {
+  return {
+    project_label: "acme/widgets",
+    workspace_path: workspacePath,
+    command: process.execPath,
+    args: ["-e", "setTimeout(() => {}, 30000);"],
+    budget: { memory_high: "512M", memory_max: "1G", cpu_weight: 100 },
+    ...overrides,
+  };
+}
+
+/** Liveness by pid: the host under test may have no systemd --user session. */
+function pidLiveness(worker: RedskilledWorkerView): boolean {
+  try {
+    process.kill(worker.pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function workerView(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorkerView {
+  return {
+    worker_id: "w-fixture",
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-07-29T00:00:00.000Z",
+    workspace_path: "/tmp/workspace",
+    isolated: true,
+    unit: "red-worker-acme-widgets-w-fixture.service",
+    budget: { memory_high: "512M" },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("a daemon restart re-attaches to its live Workers", () => {
+  it("leaves them running and reports them with their original project labels", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const first = await startRedskilledDaemon({ paths, idleMs: 60_000, liveness: pidLiveness });
+    running.push(first);
+
+    const started = first.startWorker(longLivedSpec(workspace));
+    spawnedPids.push(started.worker.pid);
+    await first.flushEvents();
+    await first.stop();
+
+    // The Worker outlived the daemon: that is what makes re-attachment a thing
+    // to do rather than a thing to mourn.
+    expect(pidLiveness(started.worker)).toBe(true);
+
+    const second = await startRedskilledDaemon({ paths, idleMs: 60_000, liveness: pidLiveness });
+    running.push(second);
+
+    const state = second.hostState();
+    expect(state.workers.map((worker) => worker.worker_id)).toEqual([started.worker.worker_id]);
+    expect(state.workers[0]!.project_label).toBe("acme/widgets");
+    expect(state.workers[0]!.workspace_path).toBe(workspace);
+    expect(state.projects).toEqual([{ project_label: "acme/widgets", worker_count: 1 }]);
+    expect(second.reattached().map((worker) => worker.worker_id)).toEqual([started.worker.worker_id]);
+  });
+
+  it("re-attaches by unit name, never by pid, whenever the Worker has a unit", async () => {
+    const paths = await sessionPaths();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    const unitWorker = workerView({ worker_id: "w-unit", pid: 1 });
+    await lane.record({ event: "worker-birth", worker: unitWorker, ts: "2026-07-29T00:00:00.000Z" });
+
+    // The probe answers on the unit and refuses the pid; a daemon that fell back
+    // to the pid would adopt whatever process now wears the number 1.
+    const asked: string[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      liveness: (worker) => {
+        asked.push(worker.unit ?? `pid:${worker.pid}`);
+        return worker.unit === unitWorker.unit;
+      },
+    });
+    running.push(daemon);
+
+    expect(asked).toEqual([unitWorker.unit]);
+    expect(daemon.workerCount()).toBe(1);
+    expect(daemon.hostState().workers[0]!.unit).toBe(unitWorker.unit);
+  });
+
+  it("records the death of a Worker that ended while no daemon was watching", async () => {
+    const paths = await sessionPaths();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    await lane.record({ event: "worker-birth", worker: workerView({ worker_id: "w-gone" }), ts: "2026-07-29T00:00:00.000Z" });
+
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000, liveness: () => false });
+    running.push(daemon);
+    await daemon.flushEvents();
+
+    expect(daemon.workerCount()).toBe(0);
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.map((event) => event.event)).toEqual(["worker-birth", "worker-death"]);
+    expect(events[1]!.worker_id).toBe("w-gone");
+    expect(events[1]!.detail).toMatch(/no daemon was watching/);
+  });
+});
+
+describe("budget accounting survives the restart", () => {
+  it("reports the same totals after the restart as before it", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const first = await startRedskilledDaemon({ paths, idleMs: 60_000, liveness: pidLiveness });
+    running.push(first);
+
+    const started = first.startWorker(longLivedSpec(workspace));
+    spawnedPids.push(started.worker.pid);
+    await first.flushEvents();
+    const before = first.hostState().budget_accounting;
+    await first.stop();
+
+    const second = await startRedskilledDaemon({ paths, idleMs: 60_000, liveness: pidLiveness });
+    running.push(second);
+
+    expect(second.hostState().budget_accounting).toEqual(before);
+    expect(before.worker_count).toBe(1);
+    expect(before.memory_high_bytes).toBe(512 * 1024 * 1024);
+    expect(before.memory_max_bytes).toBe(1024 * 1024 * 1024);
+    expect(before.cpu_weight_total).toBe(100);
+  });
+
+  it("names a budget it cannot reduce to bytes instead of counting it as nothing", () => {
+    const accounting = buildBudgetAccounting([
+      workerView({ worker_id: "w-bytes", budget: { memory_high: "512M" } }),
+      workerView({ worker_id: "w-percent", budget: { memory_high: "40%" } }),
+      workerView({ worker_id: "w-loose", isolated: false, budget: undefined }),
+    ]);
+
+    expect(accounting.memory_high_bytes).toBe(512 * 1024 * 1024);
+    expect(accounting.unaccounted_workers).toEqual(["w-percent"]);
+    expect(accounting.unisolated_workers).toEqual(["w-loose"]);
+    expect(parseMemoryBudget("1.5G")).toBe(Math.round(1.5 * 1024 ** 3));
+    expect(parseMemoryBudget("2048")).toBe(2048);
+    expect(parseMemoryBudget("infinity")).toBeNull();
+  });
+});
+
+describe("the host event lane", () => {
+  it("records birth, death and budget-kill, and nothing else", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      liveness: pidLiveness,
+      stopWorker: () => true,
+    });
+    running.push(daemon);
+
+    const born = daemon.startWorker(longLivedSpec(workspace));
+    spawnedPids.push(born.worker.pid);
+    const killed = daemon.startWorker(longLivedSpec(workspace, { project_label: "acme/gadgets" }));
+    spawnedPids.push(killed.worker.pid);
+
+    await daemon.killWorkerOverBudget(killed.worker.worker_id, "host memory high-water mark exceeded");
+    await daemon.flushEvents();
+
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.map((event) => event.event)).toEqual(["worker-birth", "worker-birth", "worker-budget-kill"]);
+    const kill = events[2]!;
+    expect(kill.worker_id).toBe(killed.worker.worker_id);
+    expect(kill.project_label).toBe("acme/gadgets");
+    expect(kill.detail).toBe("host memory high-water mark exceeded");
+    expect(daemon.hostState().budget_accounting.worker_count).toBe(1);
+  });
+
+  it("only ever appends: earlier bytes are never rewritten", async () => {
+    const paths = await sessionPaths();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+
+    await lane.record({ event: "worker-birth", worker: workerView({ worker_id: "w-1" }), ts: "2026-07-29T00:00:00.000Z" });
+    const afterFirst = await readFile(paths.eventLanePath, "utf8");
+    await lane.record({ event: "worker-death", worker: workerView({ worker_id: "w-1" }), ts: "2026-07-29T00:00:01.000Z", detail: "exit code=0" });
+    const afterSecond = await readFile(paths.eventLanePath, "utf8");
+
+    expect(afterSecond.startsWith(afterFirst)).toBe(true);
+    expect(afterSecond.length).toBeGreaterThan(afterFirst.length);
+  });
+
+  it("is written with the TOON encoder as TOONL, not as JSON", async () => {
+    const paths = await sessionPaths();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    await lane.record({ event: "worker-birth", worker: workerView({ worker_id: "w-toon" }), ts: "2026-07-29T00:00:00.000Z" });
+
+    const text = await readFile(paths.eventLanePath, "utf8");
+    const [header, row] = text.split("\n");
+
+    // A TOONL segment header declares the schema once; the row is positional.
+    expect(header).toMatch(/^\[\]\{[a-z_,]+\}:$/);
+    expect(header).toContain("worker_id");
+    expect(row?.startsWith("{")).toBe(false);
+    expect(parseRecords(text)[0]).toMatchObject({ event: "worker-birth", worker_id: "w-toon" });
+  });
+
+  it("stays readable after a writer crashed mid-append", async () => {
+    const paths = await sessionPaths();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    await lane.record({ event: "worker-birth", worker: workerView({ worker_id: "w-1" }), ts: "2026-07-29T00:00:00.000Z" });
+    await lane.record({ event: "worker-birth", worker: workerView({ worker_id: "w-2", pid: 4243 }), ts: "2026-07-29T00:00:01.000Z" });
+
+    // Cut the last row in half — a writer that died between the bytes and the
+    // newline. The complete events before it must survive intact.
+    const whole = await readFile(paths.eventLanePath, "utf8");
+    await truncate(paths.eventLanePath, whole.lastIndexOf("\n") - 5);
+
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.map((event) => event.worker_id)).toEqual(["w-1"]);
+
+    // And the lane is still writable: the next append lands after the ruins.
+    await lane.record({ event: "worker-birth", worker: workerView({ worker_id: "w-3", pid: 4244 }), ts: "2026-07-29T00:00:02.000Z" });
+    const recovered = await readRedskilledEvents(paths.eventLanePath);
+    expect(recovered.map((event) => event.worker_id)).toEqual(["w-1", "w-3"]);
+  });
+
+  it("rehydrates the daemon from a lane whose tail a crash truncated", async () => {
+    const paths = await sessionPaths();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    await lane.record({ event: "worker-birth", worker: workerView({ worker_id: "w-live" }), ts: "2026-07-29T00:00:00.000Z" });
+    await lane.record({ event: "worker-death", worker: workerView({ worker_id: "w-live" }), ts: "2026-07-29T00:00:01.000Z" });
+    const whole = await readFile(paths.eventLanePath, "utf8");
+    // The death was the record still in flight, so the Worker is believed alive.
+    await truncate(paths.eventLanePath, whole.lastIndexOf("\n") - 3);
+
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000, liveness: () => true });
+    running.push(daemon);
+
+    expect(daemon.hostState().workers.map((worker) => worker.worker_id)).toEqual(["w-live"]);
+  });
+
+  it("keeps a half-written trailing line out, and a malformed middle line in view", async () => {
+    // Only an unterminated FINAL line is a crash. A broken line in the middle is
+    // a format bug, and swallowing it would hide the very thing that needs fixing.
+    const lane = createRedskilledEventLane(join(await scratch("redskilled-lane-"), "lane.toonl"));
+    await lane.record({ event: "worker-birth", worker: workerView({ worker_id: "w-1" }), ts: "2026-07-29T00:00:00.000Z" });
+    const whole = await readFile(lane.path, "utf8");
+
+    expect(parseEventLane(`${whole}birth,w-2,`)).toHaveLength(1);
+    expect(() => parseEventLane(`${whole}birth,w-2,\nfine\n`)).toThrow();
+    expect(parseEventLane("")).toEqual([]);
+  });
+
+  it("replays into the Workers still alive, last event per Worker winning", () => {
+    const events: RedskilledHostEvent[] = [
+      laneEvent("worker-birth", "w-1"),
+      laneEvent("worker-birth", "w-2"),
+      laneEvent("worker-death", "w-1"),
+      laneEvent("worker-birth", "w-3"),
+      laneEvent("worker-budget-kill", "w-3"),
+      laneEvent("worker-birth", "w-1"),
+    ];
+
+    expect(rehydrateWorkers(events).map((worker) => worker.worker_id)).toEqual(["w-2", "w-1"]);
+  });
+});
+
+describe("a sweep retires a re-attached Worker the host stopped confirming", () => {
+  it("forgets it and records its death", async () => {
+    const paths = await sessionPaths();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    await lane.record({ event: "worker-birth", worker: workerView({ worker_id: "w-fading" }), ts: "2026-07-29T00:00:00.000Z" });
+
+    let alive = true;
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000, liveness: () => alive });
+    running.push(daemon);
+    expect(daemon.workerCount()).toBe(1);
+
+    alive = false;
+    const retired = await daemon.sweepReattached();
+    await daemon.flushEvents();
+
+    expect(retired.map((worker) => worker.worker_id)).toEqual(["w-fading"]);
+    expect(daemon.workerCount()).toBe(0);
+    expect(daemon.evaluateIdle()).toBe("exited");
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.at(-1)!.event).toBe("worker-death");
+  });
+});
+
+describe("a lane written by an older bundle", () => {
+  it("is read through, and appended to, without a rewrite", async () => {
+    const root = await scratch("redskilled-legacy-");
+    const path = join(root, "lane.toonl");
+    // A whole segment written by a previous process, header and all.
+    await writeFile(
+      path,
+      "[]{version,ts,event,worker_id,project_label,pid,workspace_path,isolated,unit,memory_high,memory_max,cpu_weight,detail}:\n" +
+        "1,2026-07-29T00:00:00.000Z,worker-birth,w-old,acme/widgets,4242,/tmp/ws,true,red-worker-old.service,512M,,,\n",
+      "utf8",
+    );
+    await appendFile(path, "", "utf8");
+
+    const events = await readRedskilledEvents(path);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.worker_id).toBe("w-old");
+    expect(events[0]!.memory_high).toBe("512M");
+    expect(events[0]!.cpu_weight).toBeNull();
+
+    const lane = createRedskilledEventLane(path);
+    await lane.record({ event: "worker-death", worker: workerView({ worker_id: "w-old" }), ts: "2026-07-29T00:00:01.000Z" });
+    expect((await readRedskilledEvents(path)).map((event) => event.event)).toEqual(["worker-birth", "worker-death"]);
+    expect(rehydrateWorkers(await readRedskilledEvents(path))).toEqual([]);
+  });
+});
+
+function laneEvent(event: RedskilledHostEvent["event"], workerId: string): RedskilledHostEvent {
+  return {
+    version: 1,
+    ts: "2026-07-29T00:00:00.000Z",
+    event,
+    worker_id: workerId,
+    project_label: "acme/widgets",
+    pid: 4242,
+    workspace_path: "/tmp/ws",
+    isolated: true,
+    unit: `red-worker-${workerId}.service`,
+    memory_high: "512M",
+    memory_max: null,
+    cpu_weight: null,
+    detail: null,
+  };
+}


### PR DESCRIPTION
Automated AFK landing for #2775. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2775

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787939260&installation_model_id=20659&pr_number=2806&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2806&signature=17e3f249310d50b044ed031f5e49aca7248b149e3042aa315d61073f1974a205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->