### PR TITLE
chore: #2776 Host-wide admission — refuse over the ceiling, refuse when the daemon is gone

### DIFF
--- a/apps/redskilled/src/admission.ts
+++ b/apps/redskilled/src/admission.ts
@@ -1,0 +1,266 @@
+/**
+ * admission — may this host afford one more Worker, right now?
+ *
+ * The defect ADR 0130 exists to fix is a static per-repository answer: every
+ * checkout reads the same host capability profile, concludes the machine affords
+ * N Workers, and spends that budget alone, so three projects on one machine run
+ * 3N. **Admission is a decision over live process state, never over a stored
+ * profile** — the denominator is the Worker set the daemon is holding at this
+ * instant, across every project, which is the one number no per-repository read
+ * can produce.
+ *
+ * The shape follows `evaluateHostGateAdmission` in red-castle deliberately: a
+ * pure function, a boolean, and a named verdict. What is new here is the live
+ * denominator and the fact that the verdict carries the numbers it judged on —
+ * a refusal a caller cannot explain to an operator is a refusal that gets
+ * disabled.
+ *
+ * **A Worker's charge is the largest amount it may take**, `MemoryMax` when it
+ * declares one and `MemoryHigh` otherwise: `MemoryHigh` is throttling pressure,
+ * not a wall, so admitting against it would let the host commit past a ceiling
+ * the kernel is willing to exceed.
+ *
+ * PURE: every input is passed in; {@link resolveHostCeiling} is the one place
+ * that reads the environment, and even that takes the host's memory as an
+ * argument.
+ */
+import { totalmem } from "node:os";
+import { parseMemoryBudget } from "./budget-accounting.js";
+import type { RedskilledWorkerView } from "./host-state.js";
+import type { RedskilledWorkerBudget } from "./worker-placement.js";
+
+/** Env var that states the host-wide memory ceiling; `infinity` lifts it. */
+export const REDSKILLED_MEMORY_CEILING_ENV = "REDSKILLED_MEMORY_CEILING";
+
+/** Env var that states the host-wide Worker count ceiling; `infinity` lifts it. */
+export const REDSKILLED_WORKER_CEILING_ENV = "REDSKILLED_WORKER_CEILING";
+
+/**
+ * The share of host memory Workers may commit when nobody stated a ceiling.
+ *
+ * Short of the whole machine on purpose: the terminal, the editor and the
+ * daemon itself are not Workers, and a ceiling that promised every byte to
+ * Workers would finance exactly the pressure kill it exists to prevent.
+ */
+export const DEFAULT_HOST_MEMORY_CEILING_FRACTION = 0.7;
+
+/** The ceiling the host is admitted against. `null` on a dimension means unbounded. */
+export interface RedskilledHostCeiling {
+  /** Total declared Worker memory this host may commit, in bytes. */
+  readonly memory_bytes: number | null;
+  /** Total live Workers this host may hold, across every project. */
+  readonly worker_count: number | null;
+  /** `declared` when an operator stated it, `host-fraction` when derived. */
+  readonly source: "declared" | "host-fraction";
+}
+
+/** No ceiling at all — an operator's explicit opt-out, and the tests' baseline. */
+export const UNBOUNDED_HOST_CEILING: RedskilledHostCeiling = {
+  memory_bytes: null,
+  worker_count: null,
+  source: "declared",
+};
+
+/** What the host is already committed to, derived from the live Worker set. */
+export interface RedskilledHostConsumption {
+  readonly worker_count: number;
+  /** Sum of the live Workers' charges, in bytes. */
+  readonly memory_bytes: number;
+  /** Live Workers whose declared budget could not be reduced to bytes, by id. */
+  readonly unaccounted_workers: readonly string[];
+}
+
+export type RedskilledAdmissionVerdictKind =
+  | "admitted"
+  | "refused-over-memory-ceiling"
+  | "refused-over-worker-ceiling"
+  | "refused-unaccountable-budget";
+
+/**
+ * The answer, carrying what it was decided on.
+ *
+ * `reason` is a whole sentence rather than a code: this string is what a caller
+ * shows an operator whose Worker did not start, and a refusal nobody can read is
+ * a refusal somebody turns off.
+ */
+export interface RedskilledAdmissionVerdict {
+  readonly version: 1;
+  readonly admitted: boolean;
+  readonly verdict: RedskilledAdmissionVerdictKind;
+  readonly reason: string;
+  readonly ceiling: RedskilledHostCeiling;
+  readonly consumption: RedskilledHostConsumption;
+  /** What this request would add, in bytes; `null` when it declared nothing. */
+  readonly requested_memory_bytes: number | null;
+  /** Where the host would stand had this request been admitted. */
+  readonly projected_worker_count: number;
+  readonly projected_memory_bytes: number;
+}
+
+export interface EvaluateWorkerAdmissionInput {
+  readonly ceiling: RedskilledHostCeiling;
+  /** Every Worker the daemon believes is alive — across every project. */
+  readonly workers: readonly RedskilledWorkerView[];
+  /** The budget the request declared, if any. */
+  readonly budget?: RedskilledWorkerBudget;
+  /** The requesting project's own opaque label, echoed into the reason. */
+  readonly projectLabel?: string;
+}
+
+/**
+ * The bytes one Worker's declared budget commits, or `null` when it is opaque.
+ *
+ * A budget the daemon cannot reduce to bytes is named, never rounded to zero —
+ * the same rule the accounting follows, for the same reason: understating the
+ * host's exposure exactly when it is largest is the failure mode that costs the
+ * machine. PURE.
+ */
+export function budgetMemoryCharge(budget: RedskilledWorkerBudget | undefined): number | null | undefined {
+  const declared = budget?.memory_max ?? budget?.memory_high;
+  if (declared == null) return undefined;
+  return parseMemoryBudget(declared);
+}
+
+/** What the live Worker set already commits. PURE. */
+export function measureHostConsumption(
+  workers: readonly RedskilledWorkerView[],
+): RedskilledHostConsumption {
+  let memory = 0;
+  const unaccounted: string[] = [];
+  for (const worker of workers) {
+    const charge = budgetMemoryCharge(worker.budget);
+    if (charge === null) unaccounted.push(worker.worker_id);
+    else if (charge !== undefined) memory += charge;
+  }
+  return { worker_count: workers.length, memory_bytes: memory, unaccounted_workers: unaccounted.sort() };
+}
+
+/**
+ * Decide one request against the live host.
+ *
+ * Refusal is the answer whenever the host cannot *prove* the request fits: over
+ * the memory ceiling, over the Worker ceiling, or carrying a budget that cannot
+ * be reduced to bytes while a byte ceiling is in force. The third case is a
+ * refusal rather than a guess because a request whose size is unknown is
+ * indistinguishable, to the host, from one that is too large. PURE.
+ */
+export function evaluateWorkerAdmission(input: EvaluateWorkerAdmissionInput): RedskilledAdmissionVerdict {
+  const { ceiling } = input;
+  const consumption = measureHostConsumption(input.workers);
+  const charge = budgetMemoryCharge(input.budget);
+  const requested = charge === undefined ? null : charge;
+  const projectedMemory = consumption.memory_bytes + (charge ?? 0);
+  const projectedWorkers = consumption.worker_count + 1;
+  const who = input.projectLabel != null && input.projectLabel !== ""
+    ? ` for project ${JSON.stringify(input.projectLabel)}`
+    : "";
+  const at = `the host is already holding ${consumption.memory_bytes} bytes across ${consumption.worker_count} Worker(s)`;
+
+  const refuse = (verdict: RedskilledAdmissionVerdictKind, reason: string): RedskilledAdmissionVerdict => ({
+    version: 1,
+    admitted: false,
+    verdict,
+    reason,
+    ceiling,
+    consumption,
+    requested_memory_bytes: requested,
+    projected_worker_count: projectedWorkers,
+    projected_memory_bytes: projectedMemory,
+  });
+
+  if (ceiling.worker_count != null && projectedWorkers > ceiling.worker_count) {
+    return refuse(
+      "refused-over-worker-ceiling",
+      `redskilled refused this Worker${who}: it would be Worker ${projectedWorkers} past a host ceiling of ${ceiling.worker_count} Worker(s), and ${at}`,
+    );
+  }
+  if (ceiling.memory_bytes != null && charge === null) {
+    return refuse(
+      "refused-unaccountable-budget",
+      `redskilled refused this Worker${who}: its declared memory budget cannot be reduced to bytes, so it cannot be proven to fit under the host ceiling of ${ceiling.memory_bytes} bytes, and ${at}`,
+    );
+  }
+  if (ceiling.memory_bytes != null && projectedMemory > ceiling.memory_bytes) {
+    return refuse(
+      "refused-over-memory-ceiling",
+      `redskilled refused this Worker${who}: it would take the host to ${projectedMemory} bytes of declared Worker memory, past the host ceiling of ${ceiling.memory_bytes} bytes, and ${at}`,
+    );
+  }
+
+  return {
+    version: 1,
+    admitted: true,
+    verdict: "admitted",
+    reason: `redskilled admitted this Worker${who}: ${projectedMemory} bytes of declared Worker memory against a host ceiling of ${ceiling.memory_bytes ?? "unbounded"} bytes, and ${at}`,
+    ceiling,
+    consumption,
+    requested_memory_bytes: requested,
+    projected_worker_count: projectedWorkers,
+    projected_memory_bytes: projectedMemory,
+  };
+}
+
+/**
+ * The ceiling this host admits against.
+ *
+ * An operator's declaration wins; absent one, the ceiling is a share of the
+ * machine's own memory, so a host that was never configured still has a real
+ * ceiling instead of an unbounded one. `infinity` (systemd's own word) lifts a
+ * dimension outright, because an operator who means unbounded should be able to
+ * say so rather than have to state a number larger than the machine.
+ */
+export function resolveHostCeiling(
+  env: NodeJS.ProcessEnv = process.env,
+  totalMemoryBytes: number = totalmem(),
+): RedskilledHostCeiling {
+  const declaredMemory = (env[REDSKILLED_MEMORY_CEILING_ENV] ?? "").trim();
+  const declaredWorkers = (env[REDSKILLED_WORKER_CEILING_ENV] ?? "").trim();
+  const workerCount = parseCountCeiling(declaredWorkers);
+
+  if (declaredMemory !== "") {
+    const memory = parseMemoryCeiling(declaredMemory, totalMemoryBytes);
+    if (memory !== undefined) return { memory_bytes: memory, worker_count: workerCount, source: "declared" };
+  }
+  return {
+    memory_bytes: Math.floor(totalMemoryBytes * DEFAULT_HOST_MEMORY_CEILING_FRACTION),
+    worker_count: workerCount,
+    source: declaredWorkers !== "" ? "declared" : "host-fraction",
+  };
+}
+
+/** `infinity` → unbounded, `N%` → a share of the host, otherwise systemd bytes. */
+function parseMemoryCeiling(value: string, totalMemoryBytes: number): number | null | undefined {
+  const lowered = value.toLowerCase();
+  if (["infinity", "none", "off", "unbounded"].includes(lowered)) return null;
+  const percent = /^(\d+(?:\.\d+)?)\s*%$/.exec(value);
+  if (percent) return Math.floor(totalMemoryBytes * (Number(percent[1]) / 100));
+  return parseMemoryBudget(value) ?? undefined;
+}
+
+function parseCountCeiling(value: string): number | null {
+  if (value === "") return null;
+  if (["infinity", "none", "off", "unbounded"].includes(value.toLowerCase())) return null;
+  const count = Number(value);
+  return Number.isSafeInteger(count) && count > 0 ? count : null;
+}
+
+/** True when `value` is a complete verdict — a client's fail-closed check. */
+export function isRedskilledAdmissionVerdict(value: unknown): value is RedskilledAdmissionVerdict {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const verdict = value as Record<string, unknown>;
+  const ceiling = verdict.ceiling as Record<string, unknown> | undefined;
+  const consumption = verdict.consumption as Record<string, unknown> | undefined;
+  return verdict.version === 1 &&
+    typeof verdict.admitted === "boolean" &&
+    typeof verdict.verdict === "string" &&
+    typeof verdict.reason === "string" &&
+    ceiling != null && typeof ceiling === "object" &&
+    (ceiling.memory_bytes === null || typeof ceiling.memory_bytes === "number") &&
+    (ceiling.worker_count === null || typeof ceiling.worker_count === "number") &&
+    consumption != null && typeof consumption === "object" &&
+    Number.isInteger(consumption.worker_count) &&
+    typeof consumption.memory_bytes === "number" &&
+    Array.isArray(consumption.unaccounted_workers) &&
+    Number.isInteger(verdict.projected_worker_count) &&
+    typeof verdict.projected_memory_bytes === "number";
+}

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -34,6 +34,28 @@ import type { RedskilledWorkerSpec } from "./worker-launch.js";
 /** How long a client waits for a daemon — its own or the race winner's — to answer. */
 export const DEFAULT_REDSKILLED_READY_TIMEOUT_MS = 10_000;
 
+/**
+ * Raised when no daemon could be reached, so nothing was born.
+ *
+ * A distinct type because the two refusals a caller can get mean opposite
+ * things: an admission refusal is the host saying "not this Worker, not now",
+ * while this one is the host saying nothing at all. Both end in no Worker — the
+ * fail-closed rule (ADR 0130 rule 6) — and only one of them is a fault.
+ */
+export class RedskilledUnreachableError extends Error {
+  constructor(
+    readonly socketPath: string,
+    override readonly cause: unknown,
+  ) {
+    super(
+      `redskilled daemon is unreachable on ${JSON.stringify(socketPath)}, so no Worker was started: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    );
+    this.name = "RedskilledUnreachableError";
+  }
+}
+
 export interface RedskilledClientConfig {
   /** The command that runs the daemon; defaults to this bundle's own entry. */
   readonly serverCommand?: string;
@@ -128,6 +150,14 @@ export async function startRedskilledWorker(
   spec: RedskilledWorkerSpec,
   config: RedskilledClientConfig = {},
 ): Promise<RedskilledWorkerStarted> {
+  // Reaching the daemon is its own step so its failure is its own error: a
+  // caller must be able to tell "the host refused this Worker" from "there was
+  // no host to ask", and neither may end in a Worker.
+  try {
+    await ensureRedskilledDaemon(paths, config);
+  } catch (err) {
+    throw new RedskilledUnreachableError(paths.socketPath, err);
+  }
   const value = await requestRedskilled(paths, { op: "worker-start", spec }, config);
   if (!isRedskilledWorkerStarted(value)) throw new Error("redskilled daemon returned a malformed worker record");
   return value;

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -32,6 +32,12 @@ import { createServer, type Server, type Socket } from "node:net";
 import { dirname } from "node:path";
 import { sendLineRequest } from "@reddb-io/shared/resident-core.js";
 import {
+  evaluateWorkerAdmission,
+  resolveHostCeiling,
+  type RedskilledAdmissionVerdict,
+  type RedskilledHostCeiling,
+} from "./admission.js";
+import {
   createRedskilledEventLane,
   rehydrateWorkers,
   type RedskilledEventLane,
@@ -80,6 +86,8 @@ export interface RedskilledDaemonOptions {
   readonly paths: RedskilledPaths;
   readonly daemonVersion?: string;
   readonly idleMs?: number;
+  /** The host-wide ceiling admission is decided against; the host's own by default. */
+  readonly ceiling?: RedskilledHostCeiling;
   readonly owner?: RedskilledLeaseOwner;
   readonly leaseStore?: RedskilledLeaseStore;
   readonly clock?: () => string;
@@ -99,8 +107,12 @@ export interface RedskilledDaemon {
   readonly startedAt: string;
   /** Resolves when the daemon has stopped listening and released its lease. */
   readonly closed: Promise<void>;
-  /** Birth a Worker from a spec: plan placement, launch, track, report. */
+  /** Birth a Worker from a spec: admit, plan placement, launch, track, report. */
   startWorker(spec: RedskilledWorkerSpec): LaunchedWorker;
+  /** Judge a spec against the live host without birthing anything. */
+  admit(spec: RedskilledWorkerSpec): RedskilledAdmissionVerdict;
+  /** The ceiling this daemon admits against. */
+  ceiling(): RedskilledHostCeiling;
   /** Record a Worker the daemon believes is alive — the idle gate reads this set. */
   trackWorker(worker: RedskilledWorkerView): void;
   /** Forget a Worker the daemon has observed dying. */
@@ -139,6 +151,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const idleMs = options.idleMs ?? DEFAULT_REDSKILLED_IDLE_MS;
   const clock = options.clock ?? (() => new Date().toISOString());
   const launch = options.launch ?? launchWorker;
+  const ceiling = options.ceiling ?? resolveHostCeiling();
   const owner = options.owner ?? currentProcessOwner();
   const leaseStore = options.leaseStore ?? createRedskilledLeaseStore(paths.leasePath, {
     sessionKeyHash: paths.sessionKeyHash,
@@ -187,7 +200,26 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   /**
+   * Judge one request against the Workers this daemon is holding right now.
+   *
+   * The denominator is live process state across every project, which is the
+   * whole point: a per-repository profile would let each checkout conclude the
+   * machine affords N Workers and spend that budget alone.
+   */
+  function admit(spec: RedskilledWorkerSpec): RedskilledAdmissionVerdict {
+    return evaluateWorkerAdmission({
+      ceiling,
+      workers: [...workers.values()],
+      budget: spec.budget,
+      projectLabel: spec.project_label,
+    });
+  }
+
+  /**
    * Birth one Worker.
+   *
+   * Admission comes first and the verdict travels into the launch, so a refusal
+   * is a Worker that never existed rather than one killed after the fact.
    *
    * Tracking happens here rather than in the caller, so the idle gate and the
    * host state learn about a Worker at the same instant the process exists —
@@ -196,6 +228,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   function startWorker(spec: RedskilledWorkerSpec): LaunchedWorker {
     const launched = launch({
       spec,
+      admission: admit(spec),
       clock,
       onExit: (workerId, code, signal) => {
         const worker = workers.get(workerId);
@@ -347,7 +380,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       if (request.op === "host-state") return { id: request.id, ok: true, value: hostState() };
       if (request.op === "worker-start") {
         const launched = startWorker(request.spec);
-        return { id: request.id, ok: true, value: { worker: launched.worker, warnings: launched.warnings } };
+        return {
+          id: request.id,
+          ok: true,
+          value: { worker: launched.worker, admission: launched.admission, warnings: launched.warnings },
+        };
       }
       if (request.op === "shutdown") return { id: request.id, ok: true, value: { stopping: true } };
       const unknown = request as { id?: string; op?: string };
@@ -365,6 +402,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     startedAt,
     closed,
     startWorker,
+    admit,
+    ceiling: () => ceiling,
     killWorkerOverBudget,
     sweepReattached,
     reattached: () => [...reattached].map((id) => workers.get(id)).filter((w): w is RedskilledWorkerView => w != null),

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -16,6 +16,7 @@
  * for a version-skewed client to disagree with the daemon about.
  */
 import { sendLineRequest } from "@reddb-io/shared/resident-core.js";
+import { isRedskilledAdmissionVerdict, type RedskilledAdmissionVerdict } from "./admission.js";
 import { isRedskilledWorkerView, type RedskilledHostState, type RedskilledWorkerView } from "./host-state.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
 
@@ -48,13 +49,23 @@ export interface RedskilledPong {
  */
 export interface RedskilledWorkerStarted {
   readonly worker: RedskilledWorkerView;
+  /**
+   * The host-wide verdict that allowed this birth.
+   *
+   * It rides on the success reply, not only on a refusal: a caller that can read
+   * the ceiling and the machine's current consumption off its own admitted
+   * request never has to ask a second question to know how much room is left.
+   */
+  readonly admission: RedskilledAdmissionVerdict;
   readonly warnings: readonly string[];
 }
 
 export function isRedskilledWorkerStarted(value: unknown): value is RedskilledWorkerStarted {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const started = value as Record<string, unknown>;
-  return Array.isArray(started.warnings) && isRedskilledWorkerView(started.worker);
+  return Array.isArray(started.warnings) &&
+    isRedskilledWorkerView(started.worker) &&
+    isRedskilledAdmissionVerdict(started.admission);
 }
 
 export interface RedskilledClientOptions {
@@ -79,4 +90,4 @@ export function isRedskilledPong(value: unknown): value is RedskilledPong {
     Number.isInteger(pong.pid);
 }
 
-export type { RedskilledHostState, RedskilledWorkerView, RedskilledWorkerSpec };
+export type { RedskilledAdmissionVerdict, RedskilledHostState, RedskilledWorkerView, RedskilledWorkerSpec };

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -11,9 +11,16 @@
  * directory is walked, no layout is assumed. A path it needs is a path it was
  * given (ADR 0130 rule 3), which is what lets one daemon serve checkouts pinned
  * to different bundle versions.
+ *
+ * **A birth carries the verdict that allowed it.** The host-wide admission
+ * verdict is a required launch input rather than a check the caller is trusted
+ * to have run first, so "no code path spawns a Worker without an admission
+ * verdict" is a property of this function instead of a convention every future
+ * call site has to remember.
  */
 import { randomUUID } from "node:crypto";
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import type { RedskilledAdmissionVerdict } from "./admission.js";
 import type { RedskilledWorkerView } from "./host-state.js";
 import {
   detectWorkerPlacementProbes,
@@ -47,8 +54,27 @@ export class RedskilledWorkerSpecError extends Error {
   }
 }
 
+/**
+ * Raised when a launch was attempted without a verdict admitting it.
+ *
+ * Its own type, not a spec error: a spec the daemon cannot act on is the
+ * client's mistake, while a birth attempted past the host's answer is the
+ * daemon's, and an operator reading a refusal needs to know which happened.
+ */
+export class RedskilledAdmissionError extends Error {
+  constructor(
+    message: string,
+    readonly admission?: RedskilledAdmissionVerdict,
+  ) {
+    super(message);
+    this.name = "RedskilledAdmissionError";
+  }
+}
+
 export interface LaunchedWorker {
   readonly worker: RedskilledWorkerView;
+  /** The verdict that allowed this birth, carried into the caller's reply. */
+  readonly admission: RedskilledAdmissionVerdict;
   /** The same warnings the view carries, for a caller that reports them once. */
   readonly warnings: readonly string[];
   readonly plan: WorkerPlacementPlan;
@@ -57,6 +83,8 @@ export interface LaunchedWorker {
 
 export interface LaunchWorkerOptions {
   readonly spec: RedskilledWorkerSpec;
+  /** The host-wide verdict admitting this birth. Required: no verdict, no Worker. */
+  readonly admission: RedskilledAdmissionVerdict;
   readonly probes?: WorkerPlacementProbes;
   readonly enabled?: boolean;
   readonly env?: NodeJS.ProcessEnv;
@@ -85,13 +113,29 @@ export function assertLaunchableSpec(spec: RedskilledWorkerSpec): void {
 }
 
 /**
+ * Refuse a birth no verdict admitted — including the birth nobody judged at all.
+ *
+ * An absent verdict is treated exactly like a refusal, because the two mean the
+ * same thing to the host: nothing proved this Worker fits.
+ */
+export function assertAdmitted(admission: RedskilledAdmissionVerdict | undefined): void {
+  if (admission == null) {
+    throw new RedskilledAdmissionError(
+      "redskilled refused this Worker: no host admission verdict was handed over, and an unjudged birth is an unbudgeted one",
+    );
+  }
+  if (!admission.admitted) throw new RedskilledAdmissionError(admission.reason, admission);
+}
+
+/**
  * Launch one Worker.
  *
  * Failure to spawn throws rather than returning a half-Worker: a caller that
  * could not tell "running" from "never started" would leak the budget.
  */
 export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
-  const { spec } = options;
+  const { spec, admission } = options;
+  assertAdmitted(admission);
   assertLaunchableSpec(spec);
 
   const env = options.env ?? process.env;
@@ -146,5 +190,5 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     ...(spec.budget != null ? { budget: spec.budget } : {}),
     warnings,
   };
-  return { worker, warnings, plan, child };
+  return { worker, admission, warnings, plan, child };
 }

--- a/apps/redskilled/tests/host-admission.test.ts
+++ b/apps/redskilled/tests/host-admission.test.ts
@@ -1,0 +1,276 @@
+// Host-wide admission: the budget is spent once, by the host, over live process
+// state — and when the daemon is not there to say so, nothing is born at all.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  evaluateWorkerAdmission,
+  measureHostConsumption,
+  resolveHostCeiling,
+  UNBOUNDED_HOST_CEILING,
+  type RedskilledHostCeiling,
+} from "../src/admission.js";
+import { RedskilledUnreachableError, startRedskilledWorker } from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { launchWorker, RedskilledAdmissionError, type RedskilledWorkerSpec } from "../src/worker-launch.js";
+
+const GIB = 1024 ** 3;
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await scratch("redskilled-admission-");
+  return resolveRedskilledPaths({ env: { REDSKILLED_SESSION: `test:${root}` }, runtimeDir: root });
+}
+
+/** A Worker that outlives the next request, so the second project sees it alive. */
+function projectSpec(
+  projectLabel: string,
+  workspacePath: string,
+  memory: string,
+): RedskilledWorkerSpec {
+  return {
+    project_label: projectLabel,
+    workspace_path: workspacePath,
+    command: process.execPath,
+    args: ["-e", "setTimeout(() => {}, 5000);"],
+    budget: { memory_high: memory },
+  };
+}
+
+function workerView(id: string, memory?: string): RedskilledWorkerView {
+  return {
+    worker_id: id,
+    project_label: "acme/widgets",
+    pid: 1234,
+    started_at: "2026-07-29T00:00:00.000Z",
+    workspace_path: "/tmp/workspace",
+    isolated: true,
+    ...(memory != null ? { budget: { memory_high: memory } } : {}),
+    warnings: [],
+  };
+}
+
+describe("two projects spend one host budget", () => {
+  it("refuses the second project's Worker, which fits alone and not alongside the first", async () => {
+    // The defect in one fixture: each project asks for 5 GiB against an 8 GiB
+    // host. Alone, either is affordable. Together they are not, and only a host-
+    // wide denominator can tell — a per-repository profile admits both.
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const ceiling: RedskilledHostCeiling = { memory_bytes: 8 * GIB, worker_count: null, source: "declared" };
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000, ceiling });
+    running.push(daemon);
+
+    const first = await startRedskilledWorker(
+      paths,
+      projectSpec("acme/widgets", workspace, "5G"),
+      { readyTimeoutMs: 5_000 },
+    );
+    expect(first.admission.admitted).toBe(true);
+
+    await expect(
+      startRedskilledWorker(paths, projectSpec("globex/gizmos", workspace, "5G"), { readyTimeoutMs: 5_000 }),
+    ).rejects.toThrow(/refused/i);
+
+    // Refused means not born: the host still holds exactly the first project's
+    // Worker, and the second project's label never reaches host state.
+    const state = daemon.hostState();
+    expect(state.workers).toHaveLength(1);
+    expect(state.projects.map((project) => project.project_label)).toEqual(["acme/widgets"]);
+  });
+
+  it("names the ceiling and the current consumption in the refusal", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const ceiling: RedskilledHostCeiling = { memory_bytes: 8 * GIB, worker_count: null, source: "declared" };
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000, ceiling });
+    running.push(daemon);
+
+    await startRedskilledWorker(paths, projectSpec("acme/widgets", workspace, "5G"), { readyTimeoutMs: 5_000 });
+    const refusal = await startRedskilledWorker(
+      paths,
+      projectSpec("globex/gizmos", workspace, "5G"),
+      { readyTimeoutMs: 5_000 },
+    ).catch((error: unknown) => (error instanceof Error ? error.message : String(error)));
+
+    expect(refusal).toContain(String(8 * GIB));
+    expect(refusal).toContain(String(5 * GIB));
+    expect(refusal).toContain("globex/gizmos");
+  });
+
+  it("admits a Worker under the ceiling, with a verdict naming the ceiling and the consumption", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const ceiling: RedskilledHostCeiling = { memory_bytes: 8 * GIB, worker_count: null, source: "declared" };
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000, ceiling });
+    running.push(daemon);
+
+    const started = await startRedskilledWorker(
+      paths,
+      projectSpec("acme/widgets", workspace, "1G"),
+      { readyTimeoutMs: 5_000 },
+    );
+
+    expect(started.admission.verdict).toBe("admitted");
+    expect(started.admission.ceiling.memory_bytes).toBe(8 * GIB);
+    expect(started.admission.consumption).toEqual({
+      worker_count: 0,
+      memory_bytes: 0,
+      unaccounted_workers: [],
+    });
+    expect(started.admission.projected_memory_bytes).toBe(GIB);
+    expect(started.admission.reason).toContain(String(8 * GIB));
+  });
+});
+
+describe("no daemon, no Worker", () => {
+  it("refuses the spawn when the daemon is unreachable, and says so", async () => {
+    // The daemon "starts" by exiting immediately, so the socket never answers.
+    // Failing open here would reinstate the very unbudgeted spawn this Spec
+    // exists to prevent, and would do it silently.
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+
+    const refusal = startRedskilledWorker(paths, projectSpec("acme/widgets", workspace, "1G"), {
+      serverCommand: process.execPath,
+      serverArgs: ["-e", "process.exit(0);"],
+      readyTimeoutMs: 500,
+    });
+
+    await expect(refusal).rejects.toThrow(RedskilledUnreachableError);
+    await expect(refusal).rejects.toThrow(/no Worker was started/i);
+  });
+});
+
+describe("no code path spawns a Worker without an admission verdict", () => {
+  it("refuses to launch when no verdict was handed over", () => {
+    const spawns: string[] = [];
+    expect(() =>
+      launchWorker({
+        spec: { project_label: "acme/widgets", workspace_path: "/tmp/workspace", command: "/bin/true" },
+        admission: undefined as never,
+        spawnFn: (command) => {
+          spawns.push(command);
+          return { pid: 1, once: () => undefined, unref: () => undefined } as never;
+        },
+      }),
+    ).toThrow(RedskilledAdmissionError);
+    expect(spawns).toEqual([]);
+  });
+
+  it("refuses to launch on a verdict that refused", () => {
+    const refused = evaluateWorkerAdmission({
+      ceiling: { memory_bytes: GIB, worker_count: null, source: "declared" },
+      workers: [workerView("held", "1G")],
+      budget: { memory_high: "1G" },
+      projectLabel: "acme/widgets",
+    });
+    const spawns: string[] = [];
+
+    expect(() =>
+      launchWorker({
+        spec: { project_label: "acme/widgets", workspace_path: "/tmp/workspace", command: "/bin/true" },
+        admission: refused,
+        spawnFn: (command) => {
+          spawns.push(command);
+          return { pid: 1, once: () => undefined, unref: () => undefined } as never;
+        },
+      }),
+    ).toThrow(RedskilledAdmissionError);
+    expect(spawns).toEqual([]);
+  });
+});
+
+describe("the verdict is decided over live process state", () => {
+  it("measures consumption from the Worker set, naming budgets it cannot reduce to bytes", () => {
+    const consumption = measureHostConsumption([
+      workerView("a", "2G"),
+      workerView("b"),
+      workerView("c", "60%"),
+    ]);
+
+    expect(consumption).toEqual({
+      worker_count: 3,
+      memory_bytes: 2 * GIB,
+      unaccounted_workers: ["c"],
+    });
+  });
+
+  it("refuses a request whose own budget cannot be proven to fit", () => {
+    const verdict = evaluateWorkerAdmission({
+      ceiling: { memory_bytes: 8 * GIB, worker_count: null, source: "declared" },
+      workers: [],
+      budget: { memory_max: "infinity" },
+    });
+
+    expect(verdict.verdict).toBe("refused-unaccountable-budget");
+    expect(verdict.admitted).toBe(false);
+  });
+
+  it("charges a Worker its hard limit when it declares one", () => {
+    const verdict = evaluateWorkerAdmission({
+      ceiling: { memory_bytes: 4 * GIB, worker_count: null, source: "declared" },
+      workers: [],
+      budget: { memory_high: "1G", memory_max: "6G" },
+    });
+
+    expect(verdict.verdict).toBe("refused-over-memory-ceiling");
+    expect(verdict.requested_memory_bytes).toBe(6 * GIB);
+  });
+
+  it("refuses over a Worker-count ceiling, whichever projects the Workers belong to", () => {
+    const verdict = evaluateWorkerAdmission({
+      ceiling: { memory_bytes: null, worker_count: 2, source: "declared" },
+      workers: [workerView("a", "1G"), workerView("b", "1G")],
+      budget: { memory_high: "1G" },
+    });
+
+    expect(verdict.verdict).toBe("refused-over-worker-ceiling");
+    expect(verdict.projected_worker_count).toBe(3);
+  });
+
+  it("admits everything under an unbounded ceiling — the operator's explicit opt-out", () => {
+    const verdict = evaluateWorkerAdmission({
+      ceiling: UNBOUNDED_HOST_CEILING,
+      workers: [workerView("a", "512G")],
+      budget: { memory_max: "infinity" },
+    });
+
+    expect(verdict.admitted).toBe(true);
+  });
+});
+
+describe("the ceiling a host admits against", () => {
+  it("takes an operator's declaration over the derived share", () => {
+    expect(resolveHostCeiling({ REDSKILLED_MEMORY_CEILING: "6G", REDSKILLED_WORKER_CEILING: "4" }, 16 * GIB))
+      .toEqual({ memory_bytes: 6 * GIB, worker_count: 4, source: "declared" });
+  });
+
+  it("reads a percentage of the host, and `infinity` as no ceiling at all", () => {
+    expect(resolveHostCeiling({ REDSKILLED_MEMORY_CEILING: "50%" }, 16 * GIB).memory_bytes).toBe(8 * GIB);
+    expect(resolveHostCeiling({ REDSKILLED_MEMORY_CEILING: "infinity" }, 16 * GIB).memory_bytes).toBeNull();
+  });
+
+  it("still holds a real ceiling on a host nobody configured", () => {
+    const ceiling = resolveHostCeiling({}, 16 * GIB);
+
+    expect(ceiling.source).toBe("host-fraction");
+    expect(ceiling.memory_bytes).toBeLessThan(16 * GIB);
+    expect(ceiling.memory_bytes).toBeGreaterThan(0);
+  });
+});

--- a/apps/redskilled/tests/worker-birth.test.ts
+++ b/apps/redskilled/tests/worker-birth.test.ts
@@ -8,6 +8,7 @@ import { readRedskilledHostState, startRedskilledWorker } from "../src/client.js
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { isRedskilledWorkerView } from "../src/host-state.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { evaluateWorkerAdmission, UNBOUNDED_HOST_CEILING } from "../src/admission.js";
 import { launchWorker, RedskilledWorkerSpecError, type RedskilledWorkerSpec } from "../src/worker-launch.js";
 import { detectWorkerPlacementProbes, type WorkerPlacementProbes } from "../src/worker-placement.js";
 
@@ -138,6 +139,9 @@ describe("worker birth through the socket", () => {
 });
 
 describe("the daemon accepts the workspace path as given", () => {
+  // Placement is what these cases are about, so admission is held constant: an
+  // unbounded ceiling is the operator's own opt-out, not a test-only bypass.
+  const ADMITTED = evaluateWorkerAdmission({ ceiling: UNBOUNDED_HOST_CEILING, workers: [] });
   const LINUX_WITH_SESSION: WorkerPlacementProbes = {
     platform: "linux",
     systemdRun: "/usr/bin/systemd-run",
@@ -150,6 +154,7 @@ describe("the daemon accepts the workspace path as given", () => {
     // identical in shape to one aimed at a real checkout.
     const spawns: Array<{ command: string; args: readonly string[]; cwd?: string }> = [];
     const launched = launchWorker({
+      admission: ADMITTED,
       spec: {
         project_label: "opaque-label",
         workspace_path: "/definitely/not/a/checkout",
@@ -180,6 +185,7 @@ describe("the daemon accepts the workspace path as given", () => {
   it("rejects a spec with no workspace at all rather than inventing one", () => {
     expect(() =>
       launchWorker({
+        admission: ADMITTED,
         spec: { project_label: "opaque", workspace_path: "  ", command: "/bin/true" },
         probes: LINUX_WITH_SESSION,
         spawnFn: () => ({ pid: 1, once: () => undefined, unref: () => undefined }) as never,


### PR DESCRIPTION
Automated AFK landing for #2776. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2776

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787940625&installation_model_id=20659&pr_number=2812&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2812&signature=27c3cd9687cd88f846c9445627c3c9d420be5bb16b4fc31ecbd813ef6ea50d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->