### PR TITLE
chore: #2777 Uniform floor — sample RSS and terminate over budget, naming the budget

### DIFF
--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -44,6 +44,12 @@ import {
   type RedskilledHostEvent,
 } from "./event-lane.js";
 import { buildHostState, type RedskilledHostState, type RedskilledWorkerView } from "./host-state.js";
+import {
+  evaluateMemoryBudgets,
+  sampleTreeRss,
+  type RedskilledBudgetTermination,
+  type RedskilledMemorySampler,
+} from "./memory-sampler.js";
 import type { RedskilledPaths } from "./paths.js";
 import {
   detectWorkerLiveness,
@@ -69,6 +75,15 @@ import {
 
 /** Default idle window before a Worker-free daemon leaves. */
 export const DEFAULT_REDSKILLED_IDLE_MS = 300_000;
+
+/**
+ * Default window between memory samples.
+ *
+ * A whole-set sample is one pass over the process table, so the interval is
+ * chosen for how fast a runaway must be caught rather than for how many Workers
+ * are running — the cost does not move with the Worker count.
+ */
+export const DEFAULT_REDSKILLED_SAMPLE_MS = 15_000;
 
 /** Raised when another daemon already serves this user session. */
 export class RedskilledAlreadyRunningError extends Error {
@@ -99,6 +114,10 @@ export interface RedskilledDaemonOptions {
   readonly liveness?: RedskilledLivenessProbe;
   /** How the daemon stops a Worker it is reclaiming a budget from. */
   readonly stopWorker?: RedskilledStopProbe;
+  /** How the whole Worker set's tree RSS is read; `/proc` by default. */
+  readonly memorySampler?: RedskilledMemorySampler;
+  /** Window between memory samples; 0 or below leaves the sampler unarmed. */
+  readonly sampleMs?: number;
 }
 
 export interface RedskilledDaemon {
@@ -127,6 +146,14 @@ export interface RedskilledDaemon {
    * out of room must not have to distinguish it from a Worker that finished.
    */
   killWorkerOverBudget(workerId: string, detail: string): Promise<boolean>;
+  /**
+   * Sample the whole Worker set once and terminate everything over its budget.
+   *
+   * The floor every placement backend stands on, exposed so the tick can be
+   * driven by a test as well as by the timer. Returns the terminations it
+   * performed, each naming the budget it enforced.
+   */
+  sampleMemoryBudgets(): Promise<readonly RedskilledBudgetTermination[]>;
   /** Re-probe every re-attached Worker, retiring the ones the host no longer confirms. */
   sweepReattached(): Promise<readonly RedskilledWorkerView[]>;
   /** The Workers this daemon adopted at start rather than birthing itself. */
@@ -176,12 +203,15 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const eventLane = options.eventLane ?? createRedskilledEventLane(paths.eventLanePath);
   const liveness = options.liveness ?? detectWorkerLiveness;
   const stopProbe = options.stopWorker ?? stopWorker;
+  const memorySampler = options.memorySampler ?? sampleTreeRss;
+  const sampleMs = options.sampleMs ?? DEFAULT_REDSKILLED_SAMPLE_MS;
   const workers = new Map<string, RedskilledWorkerView>();
   // Re-attached Workers have no child handle to deliver an exit, so their death
   // is discovered by asking the host rather than by being told.
   const reattached = new Set<string>();
   const activeSockets = new Set<Socket>();
   let idleTimer: NodeJS.Timeout | undefined;
+  let sampleTimer: NodeJS.Timeout | undefined;
   let stopping = false;
   let resolveClosed!: () => void;
   const closed = new Promise<void>((resolve) => {
@@ -297,6 +327,40 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     return true;
   }
 
+  /**
+   * One tick of the floor: sample the whole set, terminate what is over budget.
+   *
+   * The sample is taken ONCE for every Worker the daemon holds, so the tick's
+   * cost is the host's process table rather than the Worker count. An empty set
+   * is not sampled at all — there is nothing to measure and nothing to kill.
+   */
+  async function sampleMemoryBudgets(): Promise<readonly RedskilledBudgetTermination[]> {
+    const live = [...workers.values()];
+    if (live.length === 0) return [];
+    let rss: Awaited<ReturnType<RedskilledMemorySampler>>;
+    try {
+      rss = await memorySampler(live);
+    } catch {
+      // A sampler that could not read the host measured nothing, and a Worker
+      // nothing measured is never killed on suspicion.
+      return [];
+    }
+    const { terminations } = evaluateMemoryBudgets({ workers: live, rss });
+    const done: RedskilledBudgetTermination[] = [];
+    for (const termination of terminations) {
+      if (await killWorkerOverBudget(termination.worker_id, termination.reason)) done.push(termination);
+    }
+    return done;
+  }
+
+  function armSampleTimer(): void {
+    if (stopping || sampleTimer != null || sampleMs <= 0) return;
+    sampleTimer = setInterval(() => {
+      void sampleMemoryBudgets().catch(() => undefined);
+    }, sampleMs);
+    sampleTimer.unref();
+  }
+
   function armIdleTimer(): void {
     if (stopping) return;
     if (idleTimer) clearTimeout(idleTimer);
@@ -325,6 +389,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     if (stopping) return await closed;
     stopping = true;
     if (idleTimer) clearTimeout(idleTimer);
+    if (sampleTimer) clearInterval(sampleTimer);
     // Every event already handed over reaches the lane before the daemon lets go
     // of the session: a birth still in flight would leave the next daemon with a
     // Worker it holds a budget for and no record of.
@@ -395,6 +460,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   armIdleTimer();
+  armSampleTimer();
 
   return {
     socketPath: paths.socketPath,
@@ -405,6 +471,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     admit,
     ceiling: () => ceiling,
     killWorkerOverBudget,
+    sampleMemoryBudgets,
     sweepReattached,
     reattached: () => [...reattached].map((id) => workers.get(id)).filter((w): w is RedskilledWorkerView => w != null),
     flushEvents: () => eventLane.flush(),

--- a/apps/redskilled/src/memory-sampler.ts
+++ b/apps/redskilled/src/memory-sampler.ts
@@ -1,0 +1,288 @@
+/**
+ * memory-sampler — the floor every placement backend stands on.
+ *
+ * **Every backend guarantees the same floor**, so backends differ in the
+ * *quality* of their teeth and never in whether they have any. A cgroup, a Job
+ * Object or an rlimit is an upgrade in precision and latency over this sampler —
+ * never a replacement for it, and never a reason for a host without one to run
+ * a Worker with no ceiling at all.
+ *
+ * **One sample per tick covers the whole set.** The sampler is handed every
+ * Worker at once and answers for all of them, because the accounting cost is a
+ * property of the host's process table rather than of how many Workers happen to
+ * be running: a per-Worker read would make the instrument more expensive exactly
+ * as the machine got busier, which is when it must stay cheap.
+ *
+ * **A budgeted termination names the budget, and is never a stall.** A Worker
+ * killed for memory and a Worker that hung are different facts with different
+ * cures, and conflating them has already cost a debugging session — so the
+ * outcome carries the budget's own name (`MemoryMax`/`MemoryHigh`), the declared
+ * value, the observed RSS, and the workspace whose branch or PR is handed
+ * forward.
+ *
+ * PURE except for {@link sampleTreeRss}, the one function that reads the host.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { parseMemoryBudget } from "./budget-accounting.js";
+import type { RedskilledWorkerView } from "./host-state.js";
+
+/** How the daemon classifies a termination it decided itself. */
+export type RedskilledTerminationClassification = "budget-exceeded";
+
+/**
+ * The classification a budgeted termination is NOT.
+ *
+ * Named here rather than left implicit so the distinction is a value a test can
+ * pin: a stall is silence the daemon gave up waiting on, and a budget kill is a
+ * measurement the daemon acted on.
+ */
+export const REDSKILLED_STALL_CLASSIFICATION = "stalled";
+
+/** Which declared budget the floor enforced. The budget's own name, verbatim. */
+export type RedskilledBudgetName = "MemoryMax" | "MemoryHigh";
+
+/**
+ * One Worker the sampler measured over its budget.
+ *
+ * `stall` is a literal `false` rather than an absent field: a reader that had to
+ * infer "not a stall" from the absence of a flag is a reader that will one day
+ * infer it wrong.
+ */
+export interface RedskilledBudgetTermination {
+  readonly version: 1;
+  readonly worker_id: string;
+  readonly project_label: string;
+  readonly outcome: "terminated-over-memory-budget";
+  readonly classification: RedskilledTerminationClassification;
+  /** Never a stall — the daemon measured this Worker, it did not wait on it. */
+  readonly stall: false;
+  /** The budget that was exceeded, by its own name. */
+  readonly budget_name: RedskilledBudgetName;
+  /** The budget exactly as the client declared it, unparsed. */
+  readonly budget_declared: string;
+  readonly budget_bytes: number;
+  readonly observed_rss_bytes: number;
+  /** The workspace whose branch or PR the client hands forward. */
+  readonly workspace_path: string;
+  /** A whole sentence naming the budget — what an operator reads. */
+  readonly reason: string;
+}
+
+/** A Worker the floor could not enforce, and why — named, never silently skipped. */
+export interface RedskilledUnenforceableBudget {
+  readonly worker_id: string;
+  readonly reason: string;
+}
+
+export interface RedskilledMemoryTickOutcome {
+  readonly terminations: readonly RedskilledBudgetTermination[];
+  readonly unenforceable: readonly RedskilledUnenforceableBudget[];
+}
+
+/**
+ * Tree RSS per Worker, in bytes, keyed by `worker_id`.
+ *
+ * A Worker the sampler could not measure is ABSENT from the map rather than
+ * present as zero: an unmeasured Worker must not read as an idle one.
+ */
+export type RedskilledRssReading = Readonly<Record<string, number>>;
+
+/** Measures the whole Worker set in one call. Injected, so a test needs no process. */
+export type RedskilledMemorySampler = (
+  workers: readonly RedskilledWorkerView[],
+) => RedskilledRssReading | Promise<RedskilledRssReading>;
+
+/**
+ * The budget this Worker's floor enforces, or `null` when there is none to enforce.
+ *
+ * `MemoryMax` wins over `MemoryHigh` for the same reason admission charges
+ * against it: `MemoryHigh` is throttling pressure and `MemoryMax` is the wall, so
+ * a floor that killed at the pressure point would end Workers the kernel was
+ * willing to keep running. PURE.
+ */
+export function resolveEnforcedBudget(
+  worker: RedskilledWorkerView,
+): { readonly name: RedskilledBudgetName; readonly declared: string; readonly bytes: number } | null {
+  const budget = worker.budget ?? {};
+  const candidates: ReadonlyArray<readonly [RedskilledBudgetName, string | undefined]> = [
+    ["MemoryMax", budget.memory_max],
+    ["MemoryHigh", budget.memory_high],
+  ];
+  for (const [name, declared] of candidates) {
+    if (declared == null) continue;
+    const bytes = parseMemoryBudget(declared);
+    if (bytes == null) return null;
+    return { name, declared, bytes };
+  }
+  return null;
+}
+
+/**
+ * Judge one tick's reading against the live Worker set. PURE.
+ *
+ * A Worker is terminated only when the host produced a number that is *above*
+ * its budget: an absent reading, an unparseable budget and a Worker at or under
+ * its ceiling all leave the Worker running. The floor exists to stop a runaway,
+ * and a floor that killed on missing evidence would be a worse failure than the
+ * one it prevents.
+ */
+export function evaluateMemoryBudgets(input: {
+  readonly workers: readonly RedskilledWorkerView[];
+  readonly rss: RedskilledRssReading;
+}): RedskilledMemoryTickOutcome {
+  const terminations: RedskilledBudgetTermination[] = [];
+  const unenforceable: RedskilledUnenforceableBudget[] = [];
+
+  for (const worker of input.workers) {
+    const budget = resolveEnforcedBudget(worker);
+    if (budget == null) {
+      unenforceable.push({
+        worker_id: worker.worker_id,
+        reason: (worker.budget?.memory_max ?? worker.budget?.memory_high) == null
+          ? "this Worker declared no memory budget, so the sampler has no ceiling to enforce"
+          : "this Worker's declared memory budget cannot be reduced to bytes, so the sampler has no ceiling to enforce",
+      });
+      continue;
+    }
+    const observed = input.rss[worker.worker_id];
+    if (typeof observed !== "number" || !Number.isFinite(observed)) {
+      unenforceable.push({
+        worker_id: worker.worker_id,
+        reason: "the host produced no RSS reading for this Worker on this tick, and an unmeasured Worker is never killed on suspicion",
+      });
+      continue;
+    }
+    if (observed <= budget.bytes) continue;
+    terminations.push(buildBudgetTermination(worker, budget, observed));
+  }
+
+  return { terminations, unenforceable };
+}
+
+/** The terminal outcome document for one budgeted termination. PURE. */
+export function buildBudgetTermination(
+  worker: RedskilledWorkerView,
+  budget: { readonly name: RedskilledBudgetName; readonly declared: string; readonly bytes: number },
+  observedRssBytes: number,
+): RedskilledBudgetTermination {
+  const who = `Worker ${JSON.stringify(worker.worker_id)} of project ${JSON.stringify(worker.project_label)}`;
+  return {
+    version: 1,
+    worker_id: worker.worker_id,
+    project_label: worker.project_label,
+    outcome: "terminated-over-memory-budget",
+    classification: "budget-exceeded",
+    stall: false,
+    budget_name: budget.name,
+    budget_declared: budget.declared,
+    budget_bytes: budget.bytes,
+    observed_rss_bytes: observedRssBytes,
+    workspace_path: worker.workspace_path,
+    reason: `redskilled terminated ${who}: its tree RSS of ${observedRssBytes} bytes exceeded its ${budget.name} budget of ` +
+      `${budget.declared} (${budget.bytes} bytes). This is a budget termination, not a stall, and the work in ` +
+      `${JSON.stringify(worker.workspace_path)} is handed forward.`,
+  };
+}
+
+/** The Linux page size the kernel reports RSS in. */
+const PAGE_SIZE_BYTES = 4096;
+
+/**
+ * Read every Worker's tree RSS from `/proc` in ONE pass over the process table.
+ *
+ * The pass is shared: the process table is read once and each Worker's subtree is
+ * summed out of that one snapshot, so a host holding ten Workers pays what a host
+ * holding one pays. A Worker whose pid is gone is absent from the reading rather
+ * than zero, and a platform without `/proc` yields an empty reading — where the
+ * kernel backend enforces, this floor is redundant, and where nothing enforces,
+ * an empty reading is the honest report that nothing was measured.
+ */
+export function sampleTreeRss(
+  workers: readonly RedskilledWorkerView[],
+  options: { readonly procRoot?: string; readonly platform?: NodeJS.Platform } = {},
+): RedskilledRssReading {
+  const platform = options.platform ?? process.platform;
+  const procRoot = options.procRoot ?? "/proc";
+  if (platform !== "linux" && options.procRoot == null) return {};
+  if (workers.length === 0) return {};
+
+  const table = readProcessTable(procRoot);
+  if (table.size === 0) return {};
+
+  const children = new Map<number, number[]>();
+  for (const entry of table.values()) {
+    const siblings = children.get(entry.ppid);
+    if (siblings) siblings.push(entry.pid);
+    else children.set(entry.ppid, [entry.pid]);
+  }
+
+  const reading: Record<string, number> = {};
+  for (const worker of workers) {
+    if (!table.has(worker.pid)) continue;
+    let total = 0;
+    const queue = [worker.pid];
+    const seen = new Set<number>();
+    while (queue.length > 0) {
+      const pid = queue.pop()!;
+      if (seen.has(pid)) continue;
+      seen.add(pid);
+      const entry = table.get(pid);
+      if (!entry) continue;
+      total += entry.rssPages * PAGE_SIZE_BYTES;
+      for (const child of children.get(pid) ?? []) queue.push(child);
+    }
+    reading[worker.worker_id] = total;
+  }
+  return reading;
+}
+
+interface ProcessEntry {
+  readonly pid: number;
+  readonly ppid: number;
+  readonly rssPages: number;
+}
+
+function readProcessTable(procRoot: string): Map<number, ProcessEntry> {
+  const table = new Map<number, ProcessEntry>();
+  let entries: string[];
+  try {
+    entries = readdirSync(procRoot);
+  } catch {
+    return table;
+  }
+  for (const name of entries) {
+    if (!/^\d+$/.test(name)) continue;
+    // A process that exits between the listing and the read is simply absent
+    // from this snapshot; the next tick sees the host as it then is.
+    let raw: string;
+    try {
+      raw = readFileSync(join(procRoot, name, "stat"), "utf8");
+    } catch {
+      continue;
+    }
+    const entry = parseProcStat(raw);
+    if (entry) table.set(entry.pid, entry);
+  }
+  return table;
+}
+
+/**
+ * Parse one `/proc/<pid>/stat` line. PURE.
+ *
+ * The command name is read past rather than split on: it is the process's own
+ * bytes, parentheses and spaces included, so a field split from the left would
+ * mis-index every field after it for a process named `(my prog)`.
+ */
+export function parseProcStat(raw: string): ProcessEntry | null {
+  const close = raw.lastIndexOf(")");
+  if (close < 0) return null;
+  const pid = Number(raw.slice(0, raw.indexOf(" ")));
+  const fields = raw.slice(close + 1).trim().split(/\s+/);
+  // Fields after `comm` are 1-indexed from `state` (field 3), so `ppid` (field 4)
+  // is index 1 and `rss` (field 24) is index 21.
+  const ppid = Number(fields[1]);
+  const rssPages = Number(fields[21]);
+  if (!Number.isSafeInteger(pid) || !Number.isSafeInteger(ppid) || !Number.isFinite(rssPages)) return null;
+  return { pid, ppid, rssPages: Math.max(0, rssPages) };
+}

--- a/apps/redskilled/tests/memory-floor.test.ts
+++ b/apps/redskilled/tests/memory-floor.test.ts
@@ -1,0 +1,247 @@
+// The floor every placement backend stands on: the daemon samples tree RSS once
+// per tick and terminates a Worker over its budget, naming the budget it
+// enforced — and never calling that a stall.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { readRedskilledEvents } from "../src/event-lane.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import {
+  evaluateMemoryBudgets,
+  parseProcStat,
+  REDSKILLED_STALL_CLASSIFICATION,
+  resolveEnforcedBudget,
+  sampleTreeRss,
+} from "../src/memory-sampler.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await scratch("redskilled-floor-");
+  return resolveRedskilledPaths({ env: { REDSKILLED_SESSION: `test:${root}` }, runtimeDir: root });
+}
+
+/** A Worker view with no process behind it — the sampler is injected, not probed. */
+function worker(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorkerView {
+  return {
+    worker_id: "w-1",
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-07-29T00:00:00.000Z",
+    workspace_path: "/tmp/acme/w-1",
+    isolated: true,
+    unit: "red-worker-acme-widgets-w-1.service",
+    budget: { memory_high: "512M" },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("the memory floor", () => {
+  it("terminates a Worker over its budget against a synthetic sampler", async () => {
+    const paths = await sessionPaths();
+    const stopped: string[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      // Unarmed: this test drives the tick itself, so nothing races it.
+      sampleMs: 0,
+      stopWorker: (w) => {
+        stopped.push(w.worker_id);
+        return true;
+      },
+      memorySampler: () => ({ "w-1": 900 * 1024 * 1024 }),
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+
+    const terminations = await daemon.sampleMemoryBudgets();
+
+    expect(terminations).toHaveLength(1);
+    expect(terminations[0]!.worker_id).toBe("w-1");
+    expect(stopped).toEqual(["w-1"]);
+    expect(daemon.workerCount()).toBe(0);
+  });
+
+  it("names the budget that was exceeded in the terminal outcome", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      stopWorker: () => true,
+      memorySampler: () => ({ "w-1": 3 * 1024 ** 3 }),
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker({ budget: { memory_high: "512M", memory_max: "2G" } }));
+
+    const [termination] = await daemon.sampleMemoryBudgets();
+
+    // MemoryMax is the wall, MemoryHigh only pressure: the floor enforces the wall.
+    expect(termination!.budget_name).toBe("MemoryMax");
+    expect(termination!.budget_declared).toBe("2G");
+    expect(termination!.budget_bytes).toBe(2 * 1024 ** 3);
+    expect(termination!.observed_rss_bytes).toBe(3 * 1024 ** 3);
+    expect(termination!.reason).toContain("MemoryMax");
+    expect(termination!.reason).toContain("2G");
+    // The branch or PR is handed forward: the workspace rides on the outcome.
+    expect(termination!.workspace_path).toBe("/tmp/acme/w-1");
+    expect(termination!.reason).toContain("/tmp/acme/w-1");
+  });
+
+  it("records a budget kill as its own event, never as a death", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      stopWorker: () => true,
+      memorySampler: () => ({ "w-1": 900 * 1024 * 1024 }),
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+
+    await daemon.sampleMemoryBudgets();
+    await daemon.flushEvents();
+
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    const kills = events.filter((event) => event.event === "worker-budget-kill");
+    expect(kills).toHaveLength(1);
+    expect(kills[0]!.detail).toContain("MemoryHigh");
+    expect(events.some((event) => event.event === "worker-death")).toBe(false);
+  });
+
+  it("classifies a budgeted termination as budget-exceeded, never as a stall", () => {
+    const { terminations } = evaluateMemoryBudgets({
+      workers: [worker()],
+      rss: { "w-1": 900 * 1024 * 1024 },
+    });
+
+    expect(terminations[0]!.classification).toBe("budget-exceeded");
+    expect(terminations[0]!.classification).not.toBe(REDSKILLED_STALL_CLASSIFICATION);
+    expect(terminations[0]!.outcome).toBe("terminated-over-memory-budget");
+    // A Worker killed for memory and a Worker that hung are different facts.
+    expect(terminations[0]!.stall).toBe(false);
+  });
+
+  it("never terminates a Worker under its budget", async () => {
+    const paths = await sessionPaths();
+    let stops = 0;
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      stopWorker: () => {
+        stops += 1;
+        return true;
+      },
+      // Exactly at the ceiling, and comfortably under it: neither is over.
+      memorySampler: () => ({ "w-1": 512 * 1024 * 1024, "w-2": 1024 }),
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+    daemon.trackWorker(worker({ worker_id: "w-2", pid: 4243 }));
+
+    expect(await daemon.sampleMemoryBudgets()).toEqual([]);
+    expect(stops).toBe(0);
+    expect(daemon.workerCount()).toBe(2);
+  });
+
+  it("costs one sample per tick, whatever the Worker count", async () => {
+    const paths = await sessionPaths();
+    let samples = 0;
+    const sampledSets: number[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      stopWorker: () => true,
+      memorySampler: (workers) => {
+        samples += 1;
+        sampledSets.push(workers.length);
+        return {};
+      },
+    });
+    running.push(daemon);
+    for (let i = 0; i < 5; i++) daemon.trackWorker(worker({ worker_id: `w-${i}`, pid: 5000 + i }));
+
+    await daemon.sampleMemoryBudgets();
+    await daemon.sampleMemoryBudgets();
+
+    expect(samples).toBe(2);
+    // One call per tick, handed the whole set — never one call per Worker.
+    expect(sampledSets).toEqual([5, 5]);
+  });
+
+  it("leaves an unmeasured or unaccountable Worker running, and says why", () => {
+    const outcome = evaluateMemoryBudgets({
+      workers: [
+        worker({ worker_id: "unmeasured" }),
+        worker({ worker_id: "opaque", budget: { memory_high: "infinity" } }),
+        worker({ worker_id: "budgetless", budget: undefined }),
+      ],
+      rss: { opaque: 1024 ** 4, budgetless: 1024 ** 4 },
+    });
+
+    expect(outcome.terminations).toEqual([]);
+    expect(outcome.unenforceable.map((entry) => entry.worker_id).sort())
+      .toEqual(["budgetless", "opaque", "unmeasured"]);
+    expect(outcome.unenforceable.find((e) => e.worker_id === "unmeasured")!.reason).toContain("no RSS reading");
+  });
+
+  it("resolves the enforced budget: MemoryMax over MemoryHigh, and null when opaque", () => {
+    expect(resolveEnforcedBudget(worker({ budget: { memory_high: "512M" } }))).toEqual({
+      name: "MemoryHigh",
+      declared: "512M",
+      bytes: 512 * 1024 * 1024,
+    });
+    expect(resolveEnforcedBudget(worker({ budget: { memory_max: "1G", memory_high: "512M" } }))!.name)
+      .toBe("MemoryMax");
+    expect(resolveEnforcedBudget(worker({ budget: { memory_max: "50%" } }))).toBeNull();
+    expect(resolveEnforcedBudget(worker({ budget: undefined }))).toBeNull();
+  });
+
+  it("reads a whole process tree out of one /proc snapshot", async () => {
+    const procRoot = await scratch("redskilled-proc-");
+    // parent 100 → child 101 → grandchild 102, plus an unrelated 200.
+    const { mkdir, writeFile } = await import("node:fs/promises");
+    const rows: Array<[number, number, number]> = [[100, 1, 10], [101, 100, 20], [102, 101, 30], [200, 1, 999]];
+    for (const [pid, ppid, rssPages] of rows) {
+      await mkdir(join(procRoot, String(pid)), { recursive: true });
+      const trailing = Array.from({ length: 19 }, () => "0").join(" ");
+      await writeFile(
+        join(procRoot, String(pid), "stat"),
+        `${pid} (node (worker)) S ${ppid} ${trailing} ${rssPages} 0\n`,
+        "utf8",
+      );
+    }
+
+    const reading = sampleTreeRss([worker({ worker_id: "tree", pid: 100 })], { procRoot, platform: "linux" });
+
+    expect(reading.tree).toBe((10 + 20 + 30) * 4096);
+  });
+
+  it("reads a process name containing spaces and parentheses without shifting fields", () => {
+    const trailing = Array.from({ length: 19 }, () => "0").join(" ");
+    expect(parseProcStat(`77 (my prog (x)) S 5 ${trailing} 12 0\n`)).toEqual({ pid: 77, ppid: 5, rssPages: 12 });
+  });
+
+  it("measures nothing when the host offers no /proc, rather than reporting zero", () => {
+    expect(sampleTreeRss([worker()], { platform: "darwin" })).toEqual({});
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2777. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2777

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787941304&installation_model_id=20659&pr_number=2813&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2813&signature=6b9f7cd2a3e21db536df6594bba1b1711777f2a4a7cfc5ca7f202a30d75d667d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->