### PR TITLE
chore: #2784 The supervisor becomes a demand producer and stops managing slots

### DIFF
--- a/apps/redskilled/src/demand-producer.ts
+++ b/apps/redskilled/src/demand-producer.ts
@@ -1,0 +1,390 @@
+/**
+ * demand-producer — the per-project runtime, after it stopped managing processes.
+ *
+ * ADR 0130 draws one seam: **authority over the process is the daemon's,
+ * authority over the work is the project's.** This module is the project's side
+ * of it. It keeps everything that is knowledge about work — trunk mirror
+ * refresh, queue depth sampling, elastic target resolution, runner directives,
+ * claim reconciliation and lifecycle hooks — and it holds nothing that is
+ * knowledge about processes: no slot table, no growing or shrinking to a target,
+ * no birth, no reaping, no respawn, no half-open probe of its own and no
+ * resource sampling. It says "I want N Workers with this profile" and consumes
+ * what the host grants, **which may be fewer**.
+ *
+ * A smaller grant is an ordinary answer, not an error. The host is the only
+ * authority that can see every project at once, so a producer that treated a
+ * refusal as a fault would be arguing with the one party that knows. It records
+ * the shortfall with the host's own reason and ends the tick — after a refusal
+ * the next request would be asked only to be refused, and asking anyway is how a
+ * client turns a full machine into a busy loop.
+ *
+ * **There is exactly one producer per project.** With Fleet gone there is no
+ * reason for more than one and no way for two to share a budget without an
+ * arbiter, so several selectors are an *ordered priority inside one producer*
+ * rather than several competing loops. The registry refuses a second producer
+ * for a project instead of serialising it, because a second loop is a bug to
+ * surface, never a queue to drain.
+ */
+import type { RedskilledHostEvent } from "./event-lane.js";
+import type { RedskilledWorkerStarted } from "./protocol.js";
+import {
+  isSelectorParked,
+  PROJECT_BREAKER_DEFAULTS,
+  recordWorkerDeath,
+  recordWorkerSurvival,
+  selectorParkReason,
+  type ProjectBreakerConfig,
+  type ProjectBreakerState,
+  type WorkerDeathReport,
+} from "./project-breaker.js";
+import type { RedskilledWorkerSpec } from "./worker-launch.js";
+
+/**
+ * One source of demand — a queue the project draws work from.
+ *
+ * `desired` is how many Workers this selector would take right now; the producer
+ * decides how many of them the project's target can actually afford, and the
+ * host decides how many of *those* the machine can. Three answers, each from the
+ * only party that can give it.
+ */
+export interface DemandSelector {
+  readonly selector_id: string;
+  readonly desired: number;
+  /** Builds the spec for one Worker; the runner directive arrives as data. */
+  readonly spec: (input: { readonly index: number; readonly runner: string | null }) => RedskilledWorkerSpec;
+}
+
+export interface DemandRequest {
+  readonly selector_id: string;
+  readonly index: number;
+  readonly spec: RedskilledWorkerSpec;
+}
+
+export interface SkippedSelector {
+  readonly selector_id: string;
+  readonly reason: string;
+}
+
+export interface DemandPlan {
+  readonly requests: readonly DemandRequest[];
+  readonly skipped: readonly SkippedSelector[];
+}
+
+export interface PlanProjectDemandInput {
+  /** In priority order, highest first. */
+  readonly selectors: readonly DemandSelector[];
+  /** Workers this project already holds on the host. */
+  readonly live: number;
+  /** How many Workers the project wants in total, once elasticity resolved it. */
+  readonly target: number;
+  readonly breaker: ProjectBreakerState;
+  readonly nowMs: number;
+  readonly runner: string | null;
+}
+
+/**
+ * Turn several selectors into one ordered list of requests.
+ *
+ * Priority is an **order over one budget, not a share of it**: the first
+ * selector takes what it wants, and a lower one gets whatever room survives —
+ * possibly none. That is the property a share-based split would lose, and the
+ * reason one producer can serve every selector without them racing. PURE.
+ */
+export function planProjectDemand(input: PlanProjectDemandInput): DemandPlan {
+  const requests: DemandRequest[] = [];
+  const skipped: SkippedSelector[] = [];
+  let room = Math.max(0, input.target - input.live);
+
+  for (const selector of input.selectors) {
+    if (isSelectorParked(input.breaker, selector.selector_id, input.nowMs)) {
+      skipped.push({
+        selector_id: selector.selector_id,
+        reason: selectorParkReason(input.breaker, selector.selector_id, input.nowMs) ??
+          `selector ${JSON.stringify(selector.selector_id)} is parked`,
+      });
+      continue;
+    }
+    for (let index = 0; index < selector.desired && room > 0; index += 1) {
+      requests.push({
+        selector_id: selector.selector_id,
+        index,
+        spec: selector.spec({ index, runner: input.runner }),
+      });
+      room -= 1;
+    }
+  }
+  return { requests, skipped };
+}
+
+/** What the producer tells its host about, in order, as a tick unfolds. */
+export interface DemandLifecycleEvent {
+  readonly event: "worker-granted" | "worker-refused" | "selector-parked" | "tick-complete";
+  readonly project_label: string;
+  readonly selector_id: string | null;
+  readonly worker_id: string | null;
+  readonly detail: string | null;
+}
+
+export interface GrantedWorker {
+  readonly selector_id: string;
+  readonly worker_id: string;
+  readonly pid: number;
+  readonly warnings: readonly string[];
+}
+
+export interface DemandProductionResult {
+  readonly project_label: string;
+  readonly queue_depth: number;
+  readonly target: number;
+  readonly live: number;
+  readonly requested: number;
+  readonly granted: readonly GrantedWorker[];
+  /** Requests the host did not grant. Zero when the machine had the room. */
+  readonly shortfall: number;
+  /** The host's own words for the refusal that ended the tick, if one did. */
+  readonly refusal: string | null;
+  readonly skipped: readonly SkippedSelector[];
+  readonly runner: string | null;
+}
+
+export interface DemandProducerOptions {
+  readonly projectLabel: string;
+  /** In priority order, highest first. */
+  readonly selectors: readonly DemandSelector[];
+  /** Asks the host for one Worker. A refusal throws — the client never spawns. */
+  readonly startWorker: (spec: RedskilledWorkerSpec) => Promise<RedskilledWorkerStarted>;
+  /** How many Workers this project already holds; the host is asked, not guessed. */
+  readonly liveWorkers?: () => Promise<number> | number;
+  readonly refreshTrunkMirror?: () => Promise<void> | void;
+  readonly sampleQueueDepth?: () => Promise<number> | number;
+  readonly resolveElasticTarget?: (queueDepth: number) => Promise<number> | number;
+  readonly resolveRunnerDirective?: () => Promise<string | null> | string | null;
+  /** Reconciles the claims of Workers the host reported dead since the last tick. */
+  readonly reconcileClaims?: (deaths: readonly WorkerDeathReport[]) => Promise<void> | void;
+  readonly onLifecycle?: (event: DemandLifecycleEvent) => Promise<void> | void;
+  readonly breakerConfig?: ProjectBreakerConfig;
+  readonly clock?: () => number;
+}
+
+export interface DemandProducer {
+  readonly projectLabel: string;
+  /** One tick: resolve the demand, ask the host, live with the answer. */
+  produce(): Promise<DemandProductionResult>;
+  /** A death the daemon reported. The project decides what it means. */
+  reportDeath(report: WorkerDeathReport): void;
+  /** A Worker of this selector is working — the half-open circuit closes. */
+  reportSurvival(selectorId: string): void;
+  breakerState(): ProjectBreakerState;
+  /** Releases the project's producer slot; a new producer may then be created. */
+  close(): void;
+}
+
+/** Raised when a project already has a producer — a second loop, not a queue. */
+export class DemandProducerConflictError extends Error {
+  constructor(readonly projectLabel: string) {
+    super(
+      `project ${JSON.stringify(projectLabel)} already has a demand producer; several selectors are an ordered priority inside one producer, never competing loops`,
+    );
+    this.name = "DemandProducerConflictError";
+  }
+}
+
+/** Raised when a tick is asked for while this producer's tick is still running. */
+export class DemandProducerBusyError extends Error {
+  constructor(readonly projectLabel: string) {
+    super(`the demand producer for project ${JSON.stringify(projectLabel)} is already producing a tick`);
+    this.name = "DemandProducerBusyError";
+  }
+}
+
+const producers = new Map<string, DemandProducer>();
+
+/** The one producer for this project. Throws when the project already has one. */
+export function createDemandProducer(options: DemandProducerOptions): DemandProducer {
+  if (producers.has(options.projectLabel)) throw new DemandProducerConflictError(options.projectLabel);
+
+  const clock = options.clock ?? (() => Date.now());
+  const breakerConfig = options.breakerConfig ?? PROJECT_BREAKER_DEFAULTS;
+  let breaker: ProjectBreakerState = {};
+  let pendingDeaths: WorkerDeathReport[] = [];
+  let ticking = false;
+
+  const emit = async (event: DemandLifecycleEvent): Promise<void> => {
+    try {
+      await options.onLifecycle?.(event);
+    } catch {
+      // A hook is a notification, never a veto: a project that stopped
+      // producing because its own hook threw would be down for a reason that
+      // has nothing to do with the work or the host.
+    }
+  };
+
+  const producer: DemandProducer = {
+    projectLabel: options.projectLabel,
+
+    reportDeath(report) {
+      breaker = recordWorkerDeath(breaker, report, breakerConfig);
+      pendingDeaths.push(report);
+    },
+
+    reportSurvival(selectorId) {
+      breaker = recordWorkerSurvival(breaker, selectorId);
+    },
+
+    breakerState() {
+      return breaker;
+    },
+
+    close() {
+      if (producers.get(options.projectLabel) === producer) producers.delete(options.projectLabel);
+    },
+
+    async produce() {
+      if (ticking) throw new DemandProducerBusyError(options.projectLabel);
+      ticking = true;
+      try {
+        await callQuietly(options.refreshTrunkMirror);
+        const deaths = pendingDeaths;
+        pendingDeaths = [];
+        if (deaths.length > 0) await callQuietly(() => options.reconcileClaims?.(deaths));
+
+        const queueDepth = (await options.sampleQueueDepth?.()) ?? 0;
+        const target = (await options.resolveElasticTarget?.(queueDepth)) ?? 0;
+        const runner = (await options.resolveRunnerDirective?.()) ?? null;
+        const live = (await options.liveWorkers?.()) ?? 0;
+
+        const plan = planProjectDemand({
+          selectors: options.selectors,
+          live,
+          target,
+          breaker,
+          nowMs: clock(),
+          runner,
+        });
+        for (const skip of plan.skipped) {
+          await emit({
+            event: "selector-parked",
+            project_label: options.projectLabel,
+            selector_id: skip.selector_id,
+            worker_id: null,
+            detail: skip.reason,
+          });
+        }
+
+        const granted: GrantedWorker[] = [];
+        let refusal: string | null = null;
+        for (const request of plan.requests) {
+          let started: RedskilledWorkerStarted;
+          try {
+            started = await options.startWorker(request.spec);
+          } catch (err) {
+            // The host said no, or said nothing at all. Both mean the same to a
+            // producer — no Worker — and both end the tick.
+            refusal = err instanceof Error ? err.message : String(err);
+            await emit({
+              event: "worker-refused",
+              project_label: options.projectLabel,
+              selector_id: request.selector_id,
+              worker_id: null,
+              detail: refusal,
+            });
+            break;
+          }
+          granted.push({
+            selector_id: request.selector_id,
+            worker_id: started.worker.worker_id,
+            pid: started.worker.pid,
+            warnings: started.warnings,
+          });
+          await emit({
+            event: "worker-granted",
+            project_label: options.projectLabel,
+            selector_id: request.selector_id,
+            worker_id: started.worker.worker_id,
+            detail: started.admission.reason,
+          });
+        }
+
+        const result: DemandProductionResult = {
+          project_label: options.projectLabel,
+          queue_depth: queueDepth,
+          target,
+          live,
+          requested: plan.requests.length,
+          granted,
+          shortfall: plan.requests.length - granted.length,
+          refusal,
+          skipped: plan.skipped,
+          runner,
+        };
+        await emit({
+          event: "tick-complete",
+          project_label: options.projectLabel,
+          selector_id: null,
+          worker_id: null,
+          detail: `granted ${granted.length} of ${plan.requests.length} requested`,
+        });
+        return result;
+      } finally {
+        ticking = false;
+      }
+    },
+  };
+
+  producers.set(options.projectLabel, producer);
+  return producer;
+}
+
+/** The project's producer, if it has one. */
+export function demandProducerFor(projectLabel: string): DemandProducer | undefined {
+  return producers.get(projectLabel);
+}
+
+/** Releases every producer. For a host tearing a session down, and for tests. */
+export function closeAllDemandProducers(): void {
+  producers.clear();
+}
+
+export interface DeathReportContext {
+  readonly selector_id: string;
+  /** The Worker's birth timestamp, as the host reported it. */
+  readonly started_at: string;
+}
+
+/**
+ * Read a death report off the host event the daemon appended.
+ *
+ * The lane already carries the whole fact; what it cannot carry is which
+ * selector's demand produced the Worker, because that is work knowledge and the
+ * daemon holds none. So the project supplies exactly that one field and reads
+ * the rest. PURE.
+ */
+export function deathReportFromHostEvent(
+  event: RedskilledHostEvent,
+  context: DeathReportContext,
+): WorkerDeathReport {
+  const diedAt = Date.parse(event.ts);
+  const bornAt = Date.parse(context.started_at);
+  const atMs = Number.isNaN(diedAt) ? 0 : diedAt;
+  return {
+    worker_id: event.worker_id,
+    selector_id: context.selector_id,
+    kind: event.event === "worker-budget-kill" ? "worker-budget-kill" : "worker-death",
+    lived_ms: Number.isNaN(diedAt) || Number.isNaN(bornAt) ? 0 : Math.max(0, diedAt - bornAt),
+    at_ms: atMs,
+    detail: event.detail,
+  };
+}
+
+async function callQuietly(fn: (() => Promise<unknown> | unknown) | undefined): Promise<void> {
+  if (fn == null) return;
+  try {
+    await fn();
+  } catch {
+    // Work knowledge is best-effort per tick: a mirror that would not refresh
+    // is a stale read, and refusing to produce over it would idle the project
+    // for a fact the next tick is likely to have.
+  }
+}
+
+export type { ProjectBreakerState, WorkerDeathReport };

--- a/apps/redskilled/src/project-breaker.ts
+++ b/apps/redskilled/src/project-breaker.ts
@@ -1,0 +1,157 @@
+/**
+ * project-breaker — the project's half of the circuit, driven by the host's deaths.
+ *
+ * The breaker is the clearest proof the seam sits in the right place: **the
+ * daemon reports that a Worker died, and the project decides whether repeated
+ * deaths park the work.** Neither half needs to know the other's business — a
+ * death is a fact about a process, and parking a selector is a decision about
+ * work, so the fact crosses the socket and the policy never does.
+ *
+ * The state machine is the one the fleet's slot circuit ran, minus the slot:
+ *
+ *   closed     — the selector is asked for Workers normally
+ *   open       — K consecutive fast deaths tripped it; it waits out a cooldown
+ *   half-open   — the cooldown elapsed, so the next request is a probe
+ *
+ * A probe that fast-dies re-parks with the cooldown doubled; a Worker that
+ * *lived* closes the circuit outright. There is no half-open flag to store,
+ * because "the cooldown elapsed and the selector has not been closed yet" is
+ * already the whole of half-open, and a stored flag would be a second copy of a
+ * fact the clock already holds.
+ *
+ * PURE: every function here takes its clock as an argument and returns new
+ * state. Nothing in this file reads a process, a file or the environment.
+ */
+
+/** What the daemon reported, reduced to what the decision needs. */
+export interface WorkerDeathReport {
+  readonly worker_id: string;
+  /** The selector whose demand produced this Worker — the breaker's unit. */
+  readonly selector_id: string;
+  /** Which host fact this was: an ordinary death, or a budget-driven kill. */
+  readonly kind: "worker-death" | "worker-budget-kill";
+  /** How long the Worker lived, in milliseconds. */
+  readonly lived_ms: number;
+  /** When the death was observed, in epoch milliseconds. */
+  readonly at_ms: number;
+  /** The host's own words for why — an exit status, a signal, a budget. */
+  readonly detail: string | null;
+}
+
+export interface ProjectBreakerConfig {
+  /** A Worker that died sooner than this never got to work; it died on birth. */
+  readonly fastDeathMs: number;
+  /** Consecutive fast deaths that park a selector. */
+  readonly deathsToPark: number;
+  readonly cooldownBaseMs: number;
+  readonly cooldownCapMs: number;
+}
+
+export const PROJECT_BREAKER_DEFAULTS: ProjectBreakerConfig = {
+  fastDeathMs: 60_000,
+  deathsToPark: 3,
+  cooldownBaseMs: 60_000,
+  cooldownCapMs: 3_600_000,
+};
+
+/** One selector's circuit. `parked_until_ms` of 0 means closed. */
+export interface SelectorBreaker {
+  readonly selector_id: string;
+  readonly consecutive_fast_deaths: number;
+  readonly parked_until_ms: number;
+  readonly backoff_step: number;
+  /** Why it was last parked, in the host's words. `null` while closed. */
+  readonly last_reason: string | null;
+}
+
+/** Every selector the project has an opinion about, by selector id. */
+export type ProjectBreakerState = Readonly<Record<string, SelectorBreaker>>;
+
+/** A selector nothing has tripped. PURE. */
+export function closedBreaker(selectorId: string): SelectorBreaker {
+  return {
+    selector_id: selectorId,
+    consecutive_fast_deaths: 0,
+    parked_until_ms: 0,
+    backoff_step: 0,
+    last_reason: null,
+  };
+}
+
+/** The cooldown for backoff step N: `base × 2^step`, capped. PURE. */
+export function breakerCooldownMs(step: number, config: ProjectBreakerConfig = PROJECT_BREAKER_DEFAULTS): number {
+  return Math.min(config.cooldownBaseMs * 2 ** step, config.cooldownCapMs);
+}
+
+/** True while this selector must not be asked for Workers. PURE. */
+export function isSelectorParked(state: ProjectBreakerState, selectorId: string, nowMs: number): boolean {
+  const breaker = state[selectorId];
+  return breaker != null && breaker.parked_until_ms > nowMs;
+}
+
+/** Why the selector is parked, or `null` when it is not. PURE. */
+export function selectorParkReason(
+  state: ProjectBreakerState,
+  selectorId: string,
+  nowMs: number,
+): string | null {
+  if (!isSelectorParked(state, selectorId, nowMs)) return null;
+  return state[selectorId]?.last_reason ?? null;
+}
+
+/**
+ * Fold one reported death into the project's decision.
+ *
+ * A death that is *not* fast closes the circuit: the Worker lived long enough to
+ * have done work, so whatever tripped the selector is over, and carrying the
+ * count forward would park a selector for deaths that had nothing to do with
+ * each other. A fast death while the circuit is already backed off re-parks
+ * immediately, without waiting for K again — that death **was** the probe, and
+ * demanding another K would spend the failure budget over and over. PURE.
+ */
+export function recordWorkerDeath(
+  state: ProjectBreakerState,
+  report: WorkerDeathReport,
+  config: ProjectBreakerConfig = PROJECT_BREAKER_DEFAULTS,
+): ProjectBreakerState {
+  const previous = state[report.selector_id] ?? closedBreaker(report.selector_id);
+  if (report.lived_ms >= config.fastDeathMs) {
+    return { ...state, [report.selector_id]: closedBreaker(report.selector_id) };
+  }
+
+  const fastDeaths = previous.consecutive_fast_deaths + 1;
+  const probing = previous.backoff_step > 0;
+  if (!probing && fastDeaths < config.deathsToPark) {
+    return {
+      ...state,
+      [report.selector_id]: { ...previous, consecutive_fast_deaths: fastDeaths },
+    };
+  }
+
+  const cooldown = breakerCooldownMs(previous.backoff_step, config);
+  const cause = report.detail ?? report.kind;
+  return {
+    ...state,
+    [report.selector_id]: {
+      selector_id: report.selector_id,
+      consecutive_fast_deaths: 0,
+      parked_until_ms: report.at_ms + cooldown,
+      backoff_step: previous.backoff_step + 1,
+      last_reason: probing
+        ? `selector ${JSON.stringify(report.selector_id)} is parked for ${cooldown}ms: its probe Worker died in ${report.lived_ms}ms (${cause})`
+        : `selector ${JSON.stringify(report.selector_id)} is parked for ${cooldown}ms after ${fastDeaths} fast deaths, the last of them ${cause}`,
+    },
+  };
+}
+
+/**
+ * Close the circuit because a Worker of this selector is working.
+ *
+ * The half-open → closed edge. It is a separate report rather than an inference
+ * from the next tick, because "no death arrived" is also what a selector nobody
+ * asked for looks like, and closing on that would unpark a circuit no probe ever
+ * tested. PURE.
+ */
+export function recordWorkerSurvival(state: ProjectBreakerState, selectorId: string): ProjectBreakerState {
+  return { ...state, [selectorId]: closedBreaker(selectorId) };
+}

--- a/apps/redskilled/tests/demand-producer.test.ts
+++ b/apps/redskilled/tests/demand-producer.test.ts
@@ -1,0 +1,516 @@
+// The per-project runtime is a producer of demand, not a manager of processes:
+// it asks for N Workers, lives with being granted fewer, serves several
+// selectors from one ordered priority, and owns the breaker the daemon's death
+// reports drive.
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  closeAllDemandProducers,
+  createDemandProducer,
+  DemandProducerBusyError,
+  DemandProducerConflictError,
+  deathReportFromHostEvent,
+  planProjectDemand,
+  type DemandSelector,
+} from "../src/demand-producer.js";
+import {
+  breakerCooldownMs,
+  closedBreaker,
+  isSelectorParked,
+  PROJECT_BREAKER_DEFAULTS,
+  recordWorkerDeath,
+  recordWorkerSurvival,
+  selectorParkReason,
+  type ProjectBreakerState,
+} from "../src/project-breaker.js";
+import type { RedskilledAdmissionVerdict } from "../src/admission.js";
+import type { RedskilledHostEvent } from "../src/event-lane.js";
+import { RedskilledAdmissionError, type RedskilledWorkerSpec } from "../src/worker-launch.js";
+import type { RedskilledWorkerStarted } from "../src/protocol.js";
+
+afterEach(() => {
+  closeAllDemandProducers();
+});
+
+function selector(id: string, desired: number): DemandSelector {
+  return {
+    selector_id: id,
+    desired,
+    spec: ({ index, runner }) => ({
+      project_label: "acme/widgets",
+      workspace_path: `/tmp/acme/${id}-${index}`,
+      command: "/bin/true",
+      args: runner == null ? [] : ["--runner", runner],
+    }),
+  };
+}
+
+const ADMITTED: RedskilledAdmissionVerdict = {
+  version: 1,
+  admitted: true,
+  verdict: "admitted",
+  reason: "redskilled admitted this Worker",
+  ceiling: { memory_bytes: null, worker_count: null, source: "declared" },
+  consumption: { worker_count: 0, memory_bytes: 0, unaccounted_workers: [] },
+  requested_memory_bytes: null,
+  projected_worker_count: 1,
+  projected_memory_bytes: 0,
+};
+
+/** A daemon that grants the first `grants` requests and refuses the rest. */
+function grantingDaemon(grants: number): {
+  start: (spec: RedskilledWorkerSpec) => Promise<RedskilledWorkerStarted>;
+  seen: RedskilledWorkerSpec[];
+} {
+  const seen: RedskilledWorkerSpec[] = [];
+  let served = 0;
+  return {
+    seen,
+    start: async (spec) => {
+      seen.push(spec);
+      if (served >= grants) {
+        throw new RedskilledAdmissionError(
+          "redskilled refused this Worker: it would be Worker 4 past a host ceiling of 3 Worker(s)",
+        );
+      }
+      served += 1;
+      return {
+        worker: {
+          worker_id: `w-${served}`,
+          project_label: spec.project_label,
+          pid: 1000 + served,
+          started_at: "2026-07-29T00:00:00.000Z",
+          workspace_path: spec.workspace_path,
+          isolated: true,
+          warnings: [],
+        },
+        admission: ADMITTED,
+        warnings: [],
+      };
+    },
+  };
+}
+
+describe("planProjectDemand", () => {
+  it("serves several selectors from one ordered priority, highest first", () => {
+    const plan = planProjectDemand({
+      selectors: [selector("blocked-repair", 1), selector("ready-for-agent", 3), selector("go", 2)],
+      live: 0,
+      target: 3,
+      breaker: {},
+      nowMs: 0,
+      runner: "claude",
+    });
+    expect(plan.requests.map((request) => request.selector_id)).toEqual([
+      "blocked-repair",
+      "ready-for-agent",
+      "ready-for-agent",
+    ]);
+    // The lowest-priority selector wanted two and got none: priority is an
+    // order over one budget, not a share of it.
+    expect(plan.requests).toHaveLength(3);
+  });
+
+  it("asks for nothing beyond the room left by the Workers already live", () => {
+    const plan = planProjectDemand({
+      selectors: [selector("ready-for-agent", 5)],
+      live: 3,
+      target: 4,
+      breaker: {},
+      nowMs: 0,
+      runner: null,
+    });
+    expect(plan.requests).toHaveLength(1);
+  });
+
+  it("skips a parked selector and names why, without skipping the ones behind it", () => {
+    let breaker: ProjectBreakerState = {};
+    for (let i = 0; i < PROJECT_BREAKER_DEFAULTS.deathsToPark; i += 1) {
+      breaker = recordWorkerDeath(breaker, {
+        worker_id: `w-${i}`,
+        selector_id: "ready-for-agent",
+        kind: "worker-death",
+        lived_ms: 900,
+        at_ms: 10_000,
+        detail: "exit 1",
+      });
+    }
+    const plan = planProjectDemand({
+      selectors: [selector("ready-for-agent", 2), selector("go", 1)],
+      live: 0,
+      target: 3,
+      breaker,
+      nowMs: 10_000,
+      runner: null,
+    });
+    expect(plan.requests.map((request) => request.selector_id)).toEqual(["go"]);
+    expect(plan.skipped).toHaveLength(1);
+    expect(plan.skipped[0]?.selector_id).toBe("ready-for-agent");
+    expect(plan.skipped[0]?.reason).toMatch(/parked/i);
+  });
+
+  it("passes the runner directive into every spec it builds", () => {
+    const plan = planProjectDemand({
+      selectors: [selector("ready-for-agent", 2)],
+      live: 0,
+      target: 2,
+      breaker: {},
+      nowMs: 0,
+      runner: "codex",
+    });
+    expect(plan.requests.map((request) => request.spec.args)).toEqual([
+      ["--runner", "codex"],
+      ["--runner", "codex"],
+    ]);
+  });
+});
+
+describe("the producer requests Workers and lives with a smaller grant", () => {
+  it("reports the shortfall and the host's reason when granted fewer than asked", async () => {
+    const daemon = grantingDaemon(2);
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("ready-for-agent", 4)],
+      startWorker: daemon.start,
+      sampleQueueDepth: () => 9,
+      resolveElasticTarget: () => 4,
+      clock: () => 0,
+    });
+
+    const result = await producer.produce();
+
+    expect(result.requested).toBe(4);
+    expect(result.granted).toHaveLength(2);
+    expect(result.shortfall).toBe(2);
+    expect(result.refusal).toMatch(/past a host ceiling/);
+    // A refusal ends the tick: the host just said it is full, so the remaining
+    // requests would be asked only to be refused.
+    expect(daemon.seen).toHaveLength(3);
+  });
+
+  it("grants everything asked for when the host has the room", async () => {
+    const daemon = grantingDaemon(10);
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("ready-for-agent", 2)],
+      startWorker: daemon.start,
+      resolveElasticTarget: () => 2,
+    });
+
+    const result = await producer.produce();
+
+    expect(result.granted).toHaveLength(2);
+    expect(result.shortfall).toBe(0);
+    expect(result.refusal).toBeNull();
+  });
+
+  it("keeps the work knowledge: mirror, queue depth, target, runner, claims and hooks", async () => {
+    const daemon = grantingDaemon(1);
+    const order: string[] = [];
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("ready-for-agent", 1)],
+      startWorker: daemon.start,
+      refreshTrunkMirror: () => {
+        order.push("mirror");
+      },
+      reconcileClaims: (deaths) => {
+        order.push(`claims:${deaths.length}`);
+      },
+      sampleQueueDepth: () => {
+        order.push("queue");
+        return 7;
+      },
+      resolveElasticTarget: (depth) => {
+        order.push(`target:${depth}`);
+        return 1;
+      },
+      resolveRunnerDirective: () => {
+        order.push("runner");
+        return "codex";
+      },
+      onLifecycle: (event) => {
+        order.push(`hook:${event.event}`);
+      },
+    });
+
+    producer.reportDeath({
+      worker_id: "w-old",
+      selector_id: "ready-for-agent",
+      kind: "worker-death",
+      lived_ms: 600_000,
+      at_ms: 1,
+      detail: "exit 0",
+    });
+    const result = await producer.produce();
+
+    expect(order).toEqual([
+      "mirror",
+      "claims:1",
+      "queue",
+      "target:7",
+      "runner",
+      "hook:worker-granted",
+      "hook:tick-complete",
+    ]);
+    expect(result.queue_depth).toBe(7);
+    expect(result.runner).toBe("codex");
+    expect(daemon.seen[0]?.args).toEqual(["--runner", "codex"]);
+  });
+
+  it("fails closed on an unreachable host: nothing granted, and the reason kept", async () => {
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("ready-for-agent", 2)],
+      startWorker: async () => {
+        throw new Error("redskilled daemon is unreachable, so no Worker was started");
+      },
+      resolveElasticTarget: () => 2,
+    });
+
+    const result = await producer.produce();
+
+    expect(result.granted).toEqual([]);
+    expect(result.shortfall).toBe(2);
+    expect(result.refusal).toMatch(/unreachable/);
+  });
+});
+
+describe("exactly one producer per project", () => {
+  it("refuses a second producer for the same project rather than racing it", () => {
+    createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("ready-for-agent", 1)],
+      startWorker: grantingDaemon(1).start,
+    });
+    expect(() =>
+      createDemandProducer({
+        projectLabel: "acme/widgets",
+        selectors: [selector("go", 1)],
+        startWorker: grantingDaemon(1).start,
+      }),
+    ).toThrow(DemandProducerConflictError);
+  });
+
+  it("admits a second producer once the first one is closed", () => {
+    const first = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("ready-for-agent", 1)],
+      startWorker: grantingDaemon(1).start,
+    });
+    first.close();
+    expect(() =>
+      createDemandProducer({
+        projectLabel: "acme/widgets",
+        selectors: [selector("go", 1)],
+        startWorker: grantingDaemon(1).start,
+      }),
+    ).not.toThrow();
+  });
+
+  it("lets a different project have its own producer", () => {
+    createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("ready-for-agent", 1)],
+      startWorker: grantingDaemon(1).start,
+    });
+    expect(() =>
+      createDemandProducer({
+        projectLabel: "acme/gadgets",
+        selectors: [selector("ready-for-agent", 1)],
+        startWorker: grantingDaemon(1).start,
+      }),
+    ).not.toThrow();
+  });
+
+  it("refuses a tick that overlaps the tick already in flight", async () => {
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const daemon = grantingDaemon(2);
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("ready-for-agent", 1)],
+      startWorker: async (spec) => {
+        await gate;
+        return await daemon.start(spec);
+      },
+      resolveElasticTarget: () => 1,
+    });
+
+    const inFlight = producer.produce();
+    await expect(producer.produce()).rejects.toBeInstanceOf(DemandProducerBusyError);
+    release();
+    await expect(inFlight).resolves.toMatchObject({ shortfall: 0 });
+  });
+});
+
+describe("a death reported by the daemon drives the project's breaker", () => {
+  it("parks the selector after repeated fast deaths, and reopens after the cooldown", () => {
+    const config = PROJECT_BREAKER_DEFAULTS;
+    let breaker: ProjectBreakerState = {};
+    for (let i = 0; i < config.deathsToPark; i += 1) {
+      breaker = recordWorkerDeath(breaker, {
+        worker_id: `w-${i}`,
+        selector_id: "ready-for-agent",
+        kind: "worker-death",
+        lived_ms: 500,
+        at_ms: 1_000,
+        detail: "exit 1",
+      });
+    }
+    expect(isSelectorParked(breaker, "ready-for-agent", 1_000)).toBe(true);
+    expect(selectorParkReason(breaker, "ready-for-agent", 1_000)).toMatch(/3 fast deaths/);
+    expect(isSelectorParked(breaker, "ready-for-agent", 1_000 + config.cooldownBaseMs)).toBe(false);
+  });
+
+  it("re-parks a probe that fast-dies, with the cooldown doubled", () => {
+    const config = PROJECT_BREAKER_DEFAULTS;
+    let breaker: ProjectBreakerState = {};
+    for (let i = 0; i < config.deathsToPark; i += 1) {
+      breaker = recordWorkerDeath(breaker, {
+        worker_id: `w-${i}`,
+        selector_id: "go",
+        kind: "worker-death",
+        lived_ms: 500,
+        at_ms: 0,
+        detail: "exit 1",
+      });
+    }
+    const probeAt = config.cooldownBaseMs;
+    breaker = recordWorkerDeath(breaker, {
+      worker_id: "probe",
+      selector_id: "go",
+      kind: "worker-death",
+      lived_ms: 500,
+      at_ms: probeAt,
+      detail: "exit 1",
+    });
+    expect(isSelectorParked(breaker, "go", probeAt + config.cooldownBaseMs)).toBe(true);
+    expect(isSelectorParked(breaker, "go", probeAt + breakerCooldownMs(1, config))).toBe(false);
+  });
+
+  it("closes the circuit on a Worker that lived, and on a survival report", () => {
+    let breaker: ProjectBreakerState = {};
+    breaker = recordWorkerDeath(breaker, {
+      worker_id: "w-1",
+      selector_id: "go",
+      kind: "worker-death",
+      lived_ms: 500,
+      at_ms: 0,
+      detail: "exit 1",
+    });
+    breaker = recordWorkerDeath(breaker, {
+      worker_id: "w-2",
+      selector_id: "go",
+      kind: "worker-death",
+      lived_ms: PROJECT_BREAKER_DEFAULTS.fastDeathMs + 1,
+      at_ms: 1,
+      detail: "exit 0",
+    });
+    expect(breaker.go?.consecutive_fast_deaths).toBe(0);
+    expect(isSelectorParked(breaker, "go", 1)).toBe(false);
+
+    breaker = recordWorkerDeath(breaker, {
+      worker_id: "w-3",
+      selector_id: "go",
+      kind: "worker-death",
+      lived_ms: 10,
+      at_ms: 2,
+      detail: "exit 1",
+    });
+    expect(recordWorkerSurvival(breaker, "go").go).toEqual(closedBreaker("go"));
+  });
+
+  it("counts a budget kill the host reported, naming it as the cause", () => {
+    let breaker: ProjectBreakerState = {};
+    for (let i = 0; i < PROJECT_BREAKER_DEFAULTS.deathsToPark; i += 1) {
+      breaker = recordWorkerDeath(breaker, {
+        worker_id: `w-${i}`,
+        selector_id: "go",
+        kind: "worker-budget-kill",
+        lived_ms: 400,
+        at_ms: 0,
+        detail: "MemoryMax=2G exceeded",
+      });
+    }
+    expect(selectorParkReason(breaker, "go", 0)).toMatch(/MemoryMax=2G exceeded/);
+  });
+
+  it("drives the producer's own breaker from a death the daemon reported", async () => {
+    const daemon = grantingDaemon(10);
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("ready-for-agent", 1), selector("go", 1)],
+      startWorker: daemon.start,
+      resolveElasticTarget: () => 2,
+      clock: () => 0,
+    });
+
+    for (let i = 0; i < PROJECT_BREAKER_DEFAULTS.deathsToPark; i += 1) {
+      producer.reportDeath({
+        worker_id: `w-${i}`,
+        selector_id: "ready-for-agent",
+        kind: "worker-death",
+        lived_ms: 300,
+        at_ms: 0,
+        detail: "exit 1",
+      });
+    }
+    const result = await producer.produce();
+
+    expect(result.granted.map((grant) => grant.selector_id)).toEqual(["go"]);
+    expect(result.skipped.map((skip) => skip.selector_id)).toEqual(["ready-for-agent"]);
+  });
+
+  it("reads a death report straight off the host event the daemon appended", () => {
+    const event: RedskilledHostEvent = {
+      version: 1,
+      ts: "2026-07-29T00:00:10.000Z",
+      event: "worker-death",
+      worker_id: "w-1",
+      project_label: "acme/widgets",
+      pid: 4242,
+      workspace_path: "/tmp/acme/w-1",
+      isolated: true,
+      unit: "redskilled-w-1.service",
+      memory_high: null,
+      memory_max: null,
+      cpu_weight: null,
+      detail: "exit 1",
+    };
+    expect(
+      deathReportFromHostEvent(event, { selector_id: "ready-for-agent", started_at: "2026-07-29T00:00:00.000Z" }),
+    ).toEqual({
+      worker_id: "w-1",
+      selector_id: "ready-for-agent",
+      kind: "worker-death",
+      lived_ms: 10_000,
+      at_ms: Date.parse("2026-07-29T00:00:10.000Z"),
+      detail: "exit 1",
+    });
+  });
+});
+
+describe("the seam holds in both directions", () => {
+  it("leaves no slot, spawn, reap or respawn path in the per-project producer", () => {
+    for (const file of ["demand-producer.ts", "project-breaker.ts"]) {
+      const source = readFileSync(new URL(`../src/${file}`, import.meta.url), "utf8");
+      const code = source.replace(/\/\*\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+      expect(code, `${file} must hold no process management`).not.toMatch(
+        /\bslots?\b|\bspawn\w*\(|\brespawn|\breap\b|\bkillTree\b|\bprocess\.kill\b|child_process/i,
+      );
+    }
+  });
+
+  it("keeps every breaker policy out of the daemon's half", () => {
+    for (const file of ["daemon.ts", "protocol.ts", "host-state.ts", "admission.ts", "event-lane.ts"]) {
+      const source = readFileSync(new URL(`../src/${file}`, import.meta.url), "utf8");
+      const code = source.replace(/\/\*\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+      expect(code, `${file} must hold no circuit-breaker policy`).not.toMatch(
+        /breaker|half.?open|cooldown|\bparked?\b|backoff/i,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2784. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2784

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787942132&installation_model_id=20659&pr_number=2815&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2815&signature=7de7bb1ae3a6238dc1d5ae7f7f9a22222e6b0d9123bffaca12a51d38d497472e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->