### PR TITLE
chore: #2791 Statusline payload tool, served entirely by the daemon

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -26,7 +26,9 @@ of it.
 | Which session a daemon serves | `src/paths.ts` — session key, socket, lock, lease |
 | Who owns the session across restarts | `src/session-lease.ts` — pid + start time, TOON on disk |
 | Who owns the socket right now | `src/daemon.ts` — exclusive bind |
-| The frozen wire contract | `src/protocol.ts` — `ping`, `host-state`, `worker-start`, `shutdown` |
+| The frozen wire contract | `src/protocol.ts` — `ping`, `host-state`, `statusline-payload`, `worker-start`, `worker-command`, `shutdown` |
+| Who may read and who may write | `src/session-reach.ts` — read the host, write the project |
+| What this machine is doing, in one document | `src/statusline-payload.ts` — Workers, projects, vitals, budgets, staleness |
 | Where a Worker's resources are charged | `src/worker-placement.ts` — pure planner over injected probes |
 | Birth itself | `src/worker-launch.ts` — plan, spawn once, report the downgrade |
 | The host-wide read | `src/host-state.ts` — total shape, Workers plus the budget total |
@@ -70,6 +72,19 @@ of it.
 - **A crash costs the event in flight, never the lane.** An unterminated final
   line is read as absent (TOONL's own rule for a truncated open tail) and dropped
   before the next append, so a half-written record can never fuse onto the next.
+- **Reach is asymmetric: read the host, write the project.** A session reads
+  every project's Workers, because diagnosing contention from wherever you happen
+  to be is the problem the daemon exists to solve. Dispatch, stop, recycle and
+  steer are refused into any project but the session's own — these sessions are
+  largely driven by autonomous agents that do not understand a repository they
+  were not started in. A refusal never distinguishes "no such Worker" from "not
+  your Worker", so a session cannot map another project by guessing.
+- **Staleness travels inside the payload.** The daemon measures on its own tick
+  and dates the answer itself, so a consumer renders the age rather than
+  re-deriving it — which is what stops two surfaces from reporting different
+  answers about the same instant. A tick that failed to read the host ages the
+  payload instead of refreshing it, and an unmeasured Worker is `null` and named,
+  never a zero that reads as idle.
 - **An unisolated launch is never silent.** When the host affords no transient
   unit the Worker still starts, and the reply — and the host-state record it
   keeps for its whole life — carries a warning naming what was lost. A declared

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -24,9 +24,14 @@ import { socketAnswers } from "./daemon.js";
 import { isRedskilledHostState, type RedskilledHostState } from "./host-state.js";
 import type { RedskilledPaths } from "./paths.js";
 import {
+  isRedskilledStatuslinePayload,
+  isRedskilledWorkerCommandResult,
   isRedskilledWorkerStarted,
   sendRedskilledRequest,
   type RedskilledRequest,
+  type RedskilledStatuslinePayload,
+  type RedskilledWorkerCommandRequest,
+  type RedskilledWorkerCommandResult,
   type RedskilledWorkerStarted,
 } from "./protocol.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
@@ -64,6 +69,14 @@ export interface RedskilledClientConfig {
   readonly readyTimeoutMs?: number;
   readonly requestTimeoutMs?: number;
   readonly env?: NodeJS.ProcessEnv;
+  /**
+   * The project this session belongs to, stated on every request.
+   *
+   * It costs a reader nothing — a session reads the whole host either way — and
+   * it is what a write is refused against (ADR 0130 rule 9), so stating it once
+   * in the config is how a client stays inside its own repository by default.
+   */
+  readonly sessionProject?: string;
 }
 
 /**
@@ -137,6 +150,52 @@ export async function readRedskilledHostState(
 }
 
 /**
+ * The statusline payload: what this machine is doing, in one read.
+ *
+ * Host-wide from any project, and dated by the daemon rather than by the caller.
+ * **A malformed answer throws** — there is no partial payload to patch up from a
+ * local source, because a consumer holding a private source is exactly the second
+ * authority this document exists to remove.
+ */
+export async function readRedskilledStatuslinePayload(
+  paths: RedskilledPaths,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledStatuslinePayload> {
+  const value = await requestRedskilled(
+    paths,
+    { op: "statusline-payload", ...(config.sessionProject != null ? { session_project: config.sessionProject } : {}) },
+    config,
+  );
+  if (!isRedskilledStatuslinePayload(value)) throw new Error("redskilled daemon returned a malformed statusline payload");
+  return value;
+}
+
+/**
+ * Command one Worker — stop, recycle or steer.
+ *
+ * The command names the session's own project, and the daemon refuses it into
+ * any other one. **A refusal throws**: a caller that read a refusal as a quiet
+ * no-op would retry it forever, and one that could tell a refusal from an unknown
+ * Worker would learn another project's Worker set by asking.
+ */
+export async function commandRedskilledWorker(
+  paths: RedskilledPaths,
+  command: RedskilledWorkerCommandRequest,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledWorkerCommandResult> {
+  const value = await requestRedskilled(
+    paths,
+    {
+      op: "worker-command",
+      command: { ...command, session_project: command.session_project ?? config.sessionProject },
+    },
+    config,
+  );
+  if (!isRedskilledWorkerCommandResult(value)) throw new Error("redskilled daemon returned a malformed command result");
+  return value;
+}
+
+/**
  * Ask the daemon for a Worker.
  *
  * The caller states the argv, the placement target, the budget and its own two
@@ -158,7 +217,14 @@ export async function startRedskilledWorker(
   } catch (err) {
     throw new RedskilledUnreachableError(paths.socketPath, err);
   }
-  const value = await requestRedskilled(paths, { op: "worker-start", spec }, config);
+  // A client that stated no session project is dispatching into itself: the
+  // spec's own label IS the session's project, and the reach rule only ever had
+  // something to refuse when a session named a DIFFERENT one.
+  const value = await requestRedskilled(
+    paths,
+    { op: "worker-start", spec, session_project: config.sessionProject ?? spec.project_label },
+    config,
+  );
   if (!isRedskilledWorkerStarted(value)) throw new Error("redskilled daemon returned a malformed worker record");
   return value;
 }

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -58,7 +58,15 @@ import {
   type RedskilledLivenessProbe,
   type RedskilledStopProbe,
 } from "./reattach.js";
-import { REDSKILLED_PROTOCOL_VERSION, type RedskilledRequest, type RedskilledResponse } from "./protocol.js";
+import {
+  REDSKILLED_PROTOCOL_VERSION,
+  type RedskilledRequest,
+  type RedskilledResponse,
+  type RedskilledWorkerCommandRequest,
+  type RedskilledWorkerCommandResult,
+} from "./protocol.js";
+import { commandOp, evaluateSessionReach, type RedskilledSessionOp } from "./session-reach.js";
+import { buildStatuslinePayload, type RedskilledStatuslinePayload } from "./statusline-payload.js";
 import {
   launchWorker,
   type LaunchWorkerOptions,
@@ -139,6 +147,14 @@ export interface RedskilledDaemon {
   workerCount(): number;
   hostState(): RedskilledHostState;
   /**
+   * The whole machine in one document, dated by the daemon's own last sample.
+   *
+   * A read, never a measurement: sampling on demand would let two surfaces
+   * reading the same instant get two different answers, which is the very split
+   * the payload exists to close. The age of the last tick travels inside it.
+   */
+  statuslinePayload(): RedskilledStatuslinePayload;
+  /**
    * Reclaim a Worker's budget: stop it, record the kill, forget it.
    *
    * A budget kill is its own event rather than a death with a note, because the
@@ -210,6 +226,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // is discovered by asking the host rather than by being told.
   const reattached = new Set<string>();
   const activeSockets = new Set<Socket>();
+  // The last thing the sampler measured, kept so a read is dated rather than
+  // dating itself: staleness belongs to the daemon that took the measurement.
+  let lastReading: Awaited<ReturnType<RedskilledMemorySampler>> = {};
+  let lastSampledAt: string | null = null;
   let idleTimer: NodeJS.Timeout | undefined;
   let sampleTimer: NodeJS.Timeout | undefined;
   let stopping = false;
@@ -227,6 +247,78 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       startedAt,
       workers: [...workers.values()],
     });
+  }
+
+  /**
+   * The host-wide payload, assembled from this daemon's own facts alone.
+   *
+   * Nothing here is read from a second place: the Worker set, the ceiling, the
+   * last RSS reading and the instant it was taken all belong to this process, so
+   * a consumer never holds a private source it could contradict the daemon with.
+   */
+  function statuslinePayload(): RedskilledStatuslinePayload {
+    return buildStatuslinePayload({
+      hostState: hostState(),
+      ceiling,
+      rss: lastReading,
+      sampledAt: lastSampledAt,
+      now: clock(),
+      reattachedWorkerIds: [...reattached],
+    });
+  }
+
+  /**
+   * Decide whether a session may do this, before any mechanism runs.
+   *
+   * Reach is checked FIRST and against the target's project, so a cross-project
+   * command is refused identically whether or not the daemon could have carried
+   * it out — a refusal that leaked "no such Worker" would let a session map
+   * another project's Worker set by guessing at it.
+   */
+  function authorize(op: RedskilledSessionOp, sessionProject: string | undefined, targetProject: string | null) {
+    return evaluateSessionReach({ op, sessionProject: sessionProject ?? null, targetProject });
+  }
+
+  /** Carry out one commanding verb, once reach has permitted it. */
+  async function runWorkerCommand(request: RedskilledWorkerCommandRequest): Promise<RedskilledWorkerCommandResult> {
+    const target = workers.get(request.worker_id);
+    const reach = authorize(commandOp(request.command), request.session_project, target?.project_label ?? null);
+    if (!reach.permitted) throw new Error(reach.reason);
+    if (request.command !== "stop") {
+      // Recycle and steer are work decisions — which Ticket is retried, what a
+      // runner is told — and the daemon carries no castle semantics (ADR 0130
+      // rule 3). Their reach is decided here; their mechanism belongs to the
+      // project's own bundle, on top of stop and birth.
+      throw new Error(
+        `redskilled does not implement ${request.command}: it owns birth, death and limits, and ${request.command} is a work decision the project's own bundle makes on top of them`,
+      );
+    }
+    const stopped = target != null && await stopWorkerNow(target, request.detail ?? "stopped by its own project");
+    return {
+      version: 1,
+      command: request.command,
+      worker_id: request.worker_id,
+      applied: stopped,
+      reach,
+      detail: stopped
+        ? `redskilled stopped Worker ${JSON.stringify(request.worker_id)} of project ${JSON.stringify(target!.project_label)}`
+        : `redskilled holds no live Worker ${JSON.stringify(request.worker_id)} to stop`,
+    };
+  }
+
+  /** Stop one Worker the daemon holds, and record its death. */
+  async function stopWorkerNow(worker: RedskilledWorkerView, detail: string): Promise<boolean> {
+    try {
+      await stopProbe(worker);
+    } catch {
+      // A stop the host refused still ends the daemon's claim: a Worker it keeps
+      // holding a budget for while nothing supervises it is the worse state.
+    }
+    workers.delete(worker.worker_id);
+    reattached.delete(worker.worker_id);
+    record("worker-death", worker, detail);
+    armIdleTimer();
+    return true;
   }
 
   /**
@@ -342,9 +434,12 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       rss = await memorySampler(live);
     } catch {
       // A sampler that could not read the host measured nothing, and a Worker
-      // nothing measured is never killed on suspicion.
+      // nothing measured is never killed on suspicion — nor is the last reading
+      // re-dated, because a failed tick must age the payload rather than refresh it.
       return [];
     }
+    lastReading = rss;
+    lastSampledAt = clock();
     const { terminations } = evaluateMemoryBudgets({ workers: live, rss });
     const done: RedskilledBudgetTermination[] = [];
     for (const termination of terminations) {
@@ -422,13 +517,13 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     armIdleTimer();
     handleSocket(socket, async (request) => {
       armIdleTimer();
-      const response = respond(request);
+      const response = await respond(request);
       writeResponse(socket, response);
       if (request.op === "shutdown") setImmediate(() => void stop());
     });
   });
 
-  function respond(request: RedskilledRequest): RedskilledResponse {
+  async function respond(request: RedskilledRequest): Promise<RedskilledResponse> {
     try {
       if (request.op === "ping") {
         return {
@@ -443,7 +538,18 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         };
       }
       if (request.op === "host-state") return { id: request.id, ok: true, value: hostState() };
+      if (request.op === "statusline-payload") {
+        // A host read, permitted from any project: seeing the machine is the
+        // requirement, and a session that could not would diagnose contention
+        // by leaving the session it is in.
+        return { id: request.id, ok: true, value: statuslinePayload() };
+      }
+      if (request.op === "worker-command") {
+        return { id: request.id, ok: true, value: await runWorkerCommand(request.command) };
+      }
       if (request.op === "worker-start") {
+        const reach = authorize("worker-start", request.session_project, request.spec.project_label);
+        if (!reach.permitted) return { id: request.id, ok: false, error: reach.reason };
         const launched = startWorker(request.spec);
         return {
           id: request.id,
@@ -490,6 +596,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     },
     workerCount: () => workers.size,
     hostState,
+    statuslinePayload,
     evaluateIdle,
     stop,
   };

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -14,19 +14,49 @@
  * a budget, and two opaque strings — a project label and a workspace path. There
  * is no repository, ticket or runner in this contract, so there is nothing here
  * for a version-skewed client to disagree with the daemon about.
+ *
+ * `statusline-payload` is the second read, and it widens nothing the daemon does
+ * not already own: it is the host-wide Worker set the daemon holds anyway, dated
+ * by the daemon's own sampler, so a surface that needs structure never has to
+ * parse a rendered line and never needs a private source. `worker-command`
+ * carries the commanding verbs — stop, recycle, steer — as data rather than as
+ * three ops, so the reach rule is decided once for all of them.
+ *
+ * **Every request may name the project its session belongs to.** That single
+ * opaque string is what makes reach asymmetric (ADR 0130 rule 9): a session reads
+ * the whole host and writes only its own project.
  */
 import { sendLineRequest } from "@reddb-io/shared/resident-core.js";
 import { isRedskilledAdmissionVerdict, type RedskilledAdmissionVerdict } from "./admission.js";
 import { isRedskilledWorkerView, type RedskilledHostState, type RedskilledWorkerView } from "./host-state.js";
+import { isRedskilledReachVerdict, type RedskilledReachVerdict, type RedskilledWorkerCommandName } from "./session-reach.js";
+import { isRedskilledStatuslinePayload, type RedskilledStatuslinePayload } from "./statusline-payload.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
 
 /** The wire version. A daemon states it; a client that cannot read it must not proceed. */
 export const REDSKILLED_PROTOCOL_VERSION = 1;
 
+/**
+ * One commanding verb, aimed at one Worker, from one session.
+ *
+ * `session_project` rides on the command rather than on the connection because
+ * the daemon holds no session state: a client that reconnects per request must
+ * not lose the one fact its reach is decided on.
+ */
+export interface RedskilledWorkerCommandRequest {
+  readonly command: RedskilledWorkerCommandName;
+  readonly worker_id: string;
+  readonly session_project?: string;
+  /** Free-form, opaque to the daemon; recorded with the act, never interpreted. */
+  readonly detail?: string;
+}
+
 export type RedskilledRequest =
   | { id: string; op: "ping" }
   | { id: string; op: "host-state" }
-  | { id: string; op: "worker-start"; spec: RedskilledWorkerSpec }
+  | { id: string; op: "statusline-payload"; session_project?: string }
+  | { id: string; op: "worker-start"; spec: RedskilledWorkerSpec; session_project?: string }
+  | { id: string; op: "worker-command"; command: RedskilledWorkerCommandRequest }
   | { id: string; op: "shutdown" };
 
 export type RedskilledResponse =
@@ -68,6 +98,35 @@ export function isRedskilledWorkerStarted(value: unknown): value is RedskilledWo
     isRedskilledAdmissionVerdict(started.admission);
 }
 
+/**
+ * The answer to a permitted `worker-command`.
+ *
+ * A refusal never arrives here: reach is decided before the mechanism runs, and a
+ * refused command comes back as an error carrying the verdict's own sentence, so
+ * a caller can neither mistake it for a no-op nor learn from it what another
+ * project is running.
+ */
+export interface RedskilledWorkerCommandResult {
+  readonly version: 1;
+  readonly command: RedskilledWorkerCommandName;
+  readonly worker_id: string;
+  /** True when the daemon carried the command out. */
+  readonly applied: boolean;
+  readonly reach: RedskilledReachVerdict;
+  readonly detail: string;
+}
+
+export function isRedskilledWorkerCommandResult(value: unknown): value is RedskilledWorkerCommandResult {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const result = value as Record<string, unknown>;
+  return result.version === 1 &&
+    typeof result.command === "string" &&
+    typeof result.worker_id === "string" &&
+    typeof result.applied === "boolean" &&
+    typeof result.detail === "string" &&
+    isRedskilledReachVerdict(result.reach);
+}
+
 export interface RedskilledClientOptions {
   socketPath: string;
   timeoutMs?: number;
@@ -90,4 +149,15 @@ export function isRedskilledPong(value: unknown): value is RedskilledPong {
     Number.isInteger(pong.pid);
 }
 
-export type { RedskilledAdmissionVerdict, RedskilledHostState, RedskilledWorkerView, RedskilledWorkerSpec };
+/** True when `value` is a complete payload — re-exported so a client checks one surface. */
+export { isRedskilledStatuslinePayload };
+
+export type {
+  RedskilledAdmissionVerdict,
+  RedskilledHostState,
+  RedskilledReachVerdict,
+  RedskilledStatuslinePayload,
+  RedskilledWorkerCommandName,
+  RedskilledWorkerView,
+  RedskilledWorkerSpec,
+};

--- a/apps/redskilled/src/session-reach.ts
+++ b/apps/redskilled/src/session-reach.ts
@@ -1,0 +1,169 @@
+/**
+ * session-reach — read the host, write the project (ADR 0130 rule 9).
+ *
+ * **Reach is asymmetric, and the asymmetry is the point.** Seeing the machine is
+ * a requirement of the problem the daemon exists to solve: an operator diagnosing
+ * contention must be able to read every project's Workers from whichever session
+ * they happen to be in, and two readers of the same instant must not be able to
+ * report different answers. Commanding the machine never was a requirement — and
+ * these sessions are largely driven by autonomous agents that do not understand a
+ * repository they were not started in, so a blast radius wider than the checkout
+ * is a defect waiting for a bad afternoon.
+ *
+ * So every op lands in exactly one of three reaches. A **host-read** is permitted
+ * from anywhere. A **project-write** — dispatch, stop, recycle, steer — is
+ * permitted only into the session's own project. **Daemon-life** is the daemon's
+ * own process rather than any project's Workers, and it is named here rather than
+ * folded into either so that "which ops are project-scoped" stays a closed list.
+ *
+ * **A refusal never says what it is refusing about.** An unknown target is
+ * refused with the same shape as a cross-project one, because a session that
+ * could tell "no such Worker" from "not your Worker" would learn another
+ * project's Worker set by guessing at it.
+ *
+ * This is a blast-radius guard between honest clients on one user's own session
+ * socket, not an authentication boundary: the daemon believes the project a
+ * session states about itself, exactly as it believes every other opaque string
+ * a client hands it (ADR 0130 rule 3).
+ *
+ * PURE: every input is passed in.
+ */
+
+/** Every op the reach model classifies, including the ones no mechanism serves yet. */
+export type RedskilledSessionOp =
+  | "ping"
+  | "host-state"
+  | "statusline-payload"
+  | "shutdown"
+  | "worker-start"
+  | "worker-stop"
+  | "worker-recycle"
+  | "worker-steer";
+
+/** The three reaches. A reader of this type knows the whole model. */
+export type RedskilledReachKind = "host-read" | "project-write" | "daemon-life";
+
+/** The closed classification. Adding an op means deciding its reach here, first. */
+export const REDSKILLED_OP_REACH: Readonly<Record<RedskilledSessionOp, RedskilledReachKind>> = {
+  ping: "host-read",
+  "host-state": "host-read",
+  "statusline-payload": "host-read",
+  shutdown: "daemon-life",
+  "worker-start": "project-write",
+  "worker-stop": "project-write",
+  "worker-recycle": "project-write",
+  "worker-steer": "project-write",
+};
+
+/** The commanding verbs, as a session names them. Each maps onto one write op. */
+export type RedskilledWorkerCommandName = "stop" | "recycle" | "steer";
+
+/** The write op one commanding verb reaches through. PURE. */
+export function commandOp(command: RedskilledWorkerCommandName): RedskilledSessionOp {
+  return `worker-${command}` as RedskilledSessionOp;
+}
+
+export type RedskilledReachVerdictKind =
+  | "permitted-host-read"
+  | "permitted-daemon-life"
+  | "permitted-own-project"
+  | "permitted-unattributed"
+  | "refused-cross-project";
+
+/**
+ * The answer, carrying what it was decided on.
+ *
+ * `reason` is a whole sentence for the same reason an admission refusal is: this
+ * string is what an operator reads when their command did not happen.
+ */
+export interface RedskilledReachVerdict {
+  readonly version: 1;
+  readonly permitted: boolean;
+  readonly verdict: RedskilledReachVerdictKind;
+  readonly op: RedskilledSessionOp;
+  readonly reach: RedskilledReachKind;
+  /** The project the session says it is; `null` when it said nothing. */
+  readonly session_project: string | null;
+  /** The project the op would act on; `null` when there is no such target. */
+  readonly target_project: string | null;
+  readonly reason: string;
+}
+
+export interface EvaluateSessionReachInput {
+  readonly op: RedskilledSessionOp;
+  /** The project the session states about itself; absent means unattributed. */
+  readonly sessionProject?: string | null;
+  /** The project the target Worker belongs to; `null` when the target is unknown. */
+  readonly targetProject?: string | null;
+}
+
+/**
+ * Decide one op's reach.
+ *
+ * An unattributed write — a session that stated no project — is permitted, and
+ * says so in its own verdict: the daemon has nothing to compare against, and
+ * refusing every legacy caller would take the machine down to enforce a guard
+ * that only ever mattered against a session that DID name a different project.
+ * PURE.
+ */
+export function evaluateSessionReach(input: EvaluateSessionReachInput): RedskilledReachVerdict {
+  const reach = REDSKILLED_OP_REACH[input.op] ?? "project-write";
+  const sessionProject = input.sessionProject ?? null;
+  const targetProject = input.targetProject ?? null;
+  const base = { version: 1, op: input.op, reach, session_project: sessionProject, target_project: targetProject } as const;
+
+  if (reach === "host-read") {
+    return {
+      ...base,
+      permitted: true,
+      verdict: "permitted-host-read",
+      reason: `redskilled permitted ${input.op}: a session reads the whole host, whichever project it was started in`,
+    };
+  }
+  if (reach === "daemon-life") {
+    return {
+      ...base,
+      permitted: true,
+      verdict: "permitted-daemon-life",
+      reason: `redskilled permitted ${input.op}: it acts on the daemon's own process, not on any project's Workers`,
+    };
+  }
+  if (sessionProject == null || sessionProject === "") {
+    return {
+      ...base,
+      permitted: true,
+      verdict: "permitted-unattributed",
+      reason: `redskilled permitted ${input.op}: the session named no project of its own, so there is nothing to refuse it against`,
+    };
+  }
+  if (targetProject != null && targetProject === sessionProject) {
+    return {
+      ...base,
+      permitted: true,
+      verdict: "permitted-own-project",
+      reason: `redskilled permitted ${input.op}: the target belongs to project ${JSON.stringify(sessionProject)}, which is this session's own`,
+    };
+  }
+  return {
+    ...base,
+    permitted: false,
+    verdict: "refused-cross-project",
+    reason: `redskilled refused ${input.op} from a session in project ${JSON.stringify(sessionProject)}: ` +
+      `${targetProject == null ? "it names no Worker of that project" : `the target belongs to project ${JSON.stringify(targetProject)}`}. ` +
+      `A session reads the whole host and writes only its own project.`,
+  };
+}
+
+/** True when `value` is a complete reach verdict — a client's fail-closed check. */
+export function isRedskilledReachVerdict(value: unknown): value is RedskilledReachVerdict {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const verdict = value as Record<string, unknown>;
+  return verdict.version === 1 &&
+    typeof verdict.permitted === "boolean" &&
+    typeof verdict.verdict === "string" &&
+    typeof verdict.op === "string" &&
+    typeof verdict.reach === "string" &&
+    (verdict.session_project === null || typeof verdict.session_project === "string") &&
+    (verdict.target_project === null || typeof verdict.target_project === "string") &&
+    typeof verdict.reason === "string";
+}

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -1,0 +1,355 @@
+/**
+ * statusline-payload — one answer to "what is this machine doing".
+ *
+ * **Every fact here originates from the daemon.** It is the only process that
+ * holds the Worker set across projects, so a consumer that kept a private source
+ * — a pid file, its own `/proc` read, a per-repository profile — would be a
+ * second authority on a question that has one answer, and two surfaces would
+ * eventually report different states of the same instant.
+ *
+ * **Staleness travels inside the payload.** The daemon measures on its own tick,
+ * so a read can always land between ticks; a consumer that had to date the answer
+ * itself would need the sample interval, the daemon's clock and the read's own
+ * latency, and would get it subtly wrong in a different way per surface. Here the
+ * age is a field, and rendering it is the whole of a consumer's job.
+ *
+ * **A total shape, and never a zero standing in for an absence.** An unmeasured
+ * Worker carries `null` vitals and is named in `unmeasured_workers`; it never
+ * reads as an idle one, because "nothing measured it" and "it is using nothing"
+ * are opposite facts about a busy machine.
+ *
+ * PURE: the host state, the ceiling, the reading and both instants are inputs.
+ */
+import { measureHostConsumption, type RedskilledHostCeiling, type RedskilledHostConsumption } from "./admission.js";
+import type { RedskilledBudgetAccounting } from "./budget-accounting.js";
+import type { RedskilledHostState, RedskilledWorkerView } from "./host-state.js";
+import { resolveEnforcedBudget, type RedskilledBudgetName, type RedskilledRssReading } from "./memory-sampler.js";
+
+/**
+ * How old a sample may be before the payload calls itself stale.
+ *
+ * Two of the daemon's default sample windows: one missed tick is the jitter of a
+ * busy host, and two is a sampler that stopped — the first must not cry wolf and
+ * the second must not pass for current.
+ */
+export const REDSKILLED_STALENESS_MS = 30_000;
+
+/** What a Worker is doing, as the daemon knows it. */
+export type RedskilledWorkerState = "running" | "reattached";
+
+/**
+ * One Worker's measured consumption, or the honest absence of it.
+ *
+ * `fresh` is stated rather than left to a consumer's subtraction: it is the one
+ * thing every renderer needs and the one thing each would compute differently.
+ */
+export interface RedskilledStatuslineVitals {
+  /** Tree RSS at the last sample, in bytes; `null` when nothing measured it. */
+  readonly rss_bytes: number | null;
+  readonly sampled_at: string | null;
+  readonly age_ms: number | null;
+  /** True when this Worker was measured within the staleness window. */
+  readonly fresh: boolean;
+}
+
+/** What this Worker was promised, and how much of it the daemon has seen it take. */
+export interface RedskilledStatuslineWorkerBudget {
+  /** The budget the floor enforces, by its own name; `null` when there is none. */
+  readonly name: RedskilledBudgetName | null;
+  /** The budget exactly as the client declared it, unparsed. */
+  readonly declared: string | null;
+  readonly bytes: number | null;
+  readonly used_bytes: number | null;
+  /** Observed over declared; `null` whenever either half is missing. */
+  readonly used_fraction: number | null;
+  /** False when no ceiling could be reduced to bytes for this Worker. */
+  readonly enforceable: boolean;
+}
+
+export interface RedskilledStatuslineWorker {
+  readonly worker_id: string;
+  readonly project_label: string;
+  readonly workspace_path: string;
+  readonly pid: number;
+  readonly started_at: string;
+  readonly uptime_ms: number | null;
+  readonly state: RedskilledWorkerState;
+  readonly isolated: boolean;
+  readonly unit: string | null;
+  readonly warnings: readonly string[];
+  readonly vitals: RedskilledStatuslineVitals;
+  readonly budget: RedskilledStatuslineWorkerBudget;
+}
+
+/** One project's share of the machine. */
+export interface RedskilledStatuslineProject {
+  readonly project_label: string;
+  readonly worker_count: number;
+  /** Sum of this project's declared charges, in bytes. */
+  readonly declared_memory_bytes: number;
+  /** Sum of the measured RSS of this project's Workers, in bytes. */
+  readonly observed_rss_bytes: number;
+  readonly measured_worker_count: number;
+}
+
+/** The host aggregate — the numbers an operator feels before an incident. */
+export interface RedskilledStatuslineHost {
+  readonly worker_count: number;
+  readonly project_count: number;
+  readonly ceiling: RedskilledHostCeiling;
+  readonly consumption: RedskilledHostConsumption;
+  readonly budget_accounting: RedskilledBudgetAccounting;
+  /** Sum of every measured Worker's RSS, in bytes. */
+  readonly observed_rss_bytes: number;
+  readonly measured_worker_count: number;
+  /** Declared charge over the memory ceiling; `null` when the ceiling is lifted. */
+  readonly ceiling_used_fraction: number | null;
+}
+
+/** How current this answer is, decided by the daemon and rendered by the consumer. */
+export interface RedskilledStatuslineStaleness {
+  readonly sampled_at: string | null;
+  readonly age_ms: number | null;
+  readonly threshold_ms: number;
+  readonly stale: boolean;
+  readonly measured_worker_count: number;
+  /** Live Workers the last sample did not measure, by id. */
+  readonly unmeasured_workers: readonly string[];
+  readonly reason: string;
+}
+
+/** Which daemon answered, so two answers can be told apart rather than averaged. */
+export interface RedskilledStatuslineDaemon {
+  readonly pid: number;
+  readonly daemon_version: string;
+  readonly protocol_version: number;
+  readonly started_at: string;
+  readonly machine_id_hash: string;
+  readonly session_key_hash: string;
+}
+
+export interface RedskilledStatuslinePayload {
+  readonly version: 1;
+  readonly generated_at: string;
+  readonly daemon: RedskilledStatuslineDaemon;
+  readonly staleness: RedskilledStatuslineStaleness;
+  readonly host: RedskilledStatuslineHost;
+  readonly projects: readonly RedskilledStatuslineProject[];
+  readonly workers: readonly RedskilledStatuslineWorker[];
+}
+
+export interface BuildStatuslinePayloadInput {
+  readonly hostState: RedskilledHostState;
+  readonly ceiling: RedskilledHostCeiling;
+  /** The last reading the daemon took; empty when it has taken none. */
+  readonly rss: RedskilledRssReading;
+  /** When that reading was taken; `null` when nothing has been sampled yet. */
+  readonly sampledAt: string | null;
+  readonly now: string;
+  /** Workers this daemon adopted at start rather than birthing itself, by id. */
+  readonly reattachedWorkerIds?: readonly string[];
+  readonly stalenessMs?: number;
+}
+
+/** The payload document. PURE — every aggregate is derived from the Worker set. */
+export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): RedskilledStatuslinePayload {
+  const threshold = input.stalenessMs ?? REDSKILLED_STALENESS_MS;
+  const nowMs = instant(input.now);
+  const sampledMs = input.sampledAt == null ? null : instant(input.sampledAt);
+  const ageMs = nowMs == null || sampledMs == null ? null : Math.max(0, nowMs - sampledMs);
+  const sampleFresh = ageMs != null && ageMs <= threshold;
+  const reattached = new Set(input.reattachedWorkerIds ?? []);
+
+  const workers = input.hostState.workers.map((worker) =>
+    buildWorker(worker, {
+      rss: input.rss,
+      sampledAt: input.sampledAt,
+      ageMs,
+      sampleFresh,
+      nowMs,
+      state: reattached.has(worker.worker_id) ? "reattached" : "running",
+    })
+  );
+
+  const unmeasured = workers.filter((w) => w.vitals.rss_bytes == null).map((w) => w.worker_id).sort();
+  const measuredCount = workers.length - unmeasured.length;
+  const observed = workers.reduce((total, w) => total + (w.vitals.rss_bytes ?? 0), 0);
+  const consumption = measureHostConsumption(input.hostState.workers);
+
+  return {
+    version: 1,
+    generated_at: input.now,
+    daemon: {
+      pid: input.hostState.pid,
+      daemon_version: input.hostState.daemon_version,
+      protocol_version: input.hostState.protocol_version,
+      started_at: input.hostState.started_at,
+      machine_id_hash: input.hostState.machine_id_hash,
+      session_key_hash: input.hostState.session_key_hash,
+    },
+    staleness: buildStaleness({
+      sampledAt: input.sampledAt,
+      ageMs,
+      threshold,
+      workerCount: workers.length,
+      measuredCount,
+      unmeasured,
+    }),
+    host: {
+      worker_count: workers.length,
+      project_count: input.hostState.projects.length,
+      ceiling: input.ceiling,
+      consumption,
+      budget_accounting: input.hostState.budget_accounting,
+      observed_rss_bytes: observed,
+      measured_worker_count: measuredCount,
+      ceiling_used_fraction: input.ceiling.memory_bytes == null || input.ceiling.memory_bytes <= 0
+        ? null
+        : consumption.memory_bytes / input.ceiling.memory_bytes,
+    },
+    projects: buildProjects(workers),
+    workers,
+  };
+}
+
+function buildWorker(
+  worker: RedskilledWorkerView,
+  ctx: {
+    readonly rss: RedskilledRssReading;
+    readonly sampledAt: string | null;
+    readonly ageMs: number | null;
+    readonly sampleFresh: boolean;
+    readonly nowMs: number | null;
+    readonly state: RedskilledWorkerState;
+  },
+): RedskilledStatuslineWorker {
+  const measured = ctx.rss[worker.worker_id];
+  const rssBytes = typeof measured === "number" && Number.isFinite(measured) ? measured : null;
+  const enforced = resolveEnforcedBudget(worker);
+  const declaredOnly = worker.budget?.memory_max ?? worker.budget?.memory_high ?? null;
+  const startedMs = instant(worker.started_at);
+
+  return {
+    worker_id: worker.worker_id,
+    project_label: worker.project_label,
+    workspace_path: worker.workspace_path,
+    pid: worker.pid,
+    started_at: worker.started_at,
+    uptime_ms: ctx.nowMs == null || startedMs == null ? null : Math.max(0, ctx.nowMs - startedMs),
+    state: ctx.state,
+    isolated: worker.isolated,
+    unit: worker.unit ?? null,
+    warnings: [...worker.warnings],
+    vitals: {
+      rss_bytes: rssBytes,
+      sampled_at: rssBytes == null ? null : ctx.sampledAt,
+      age_ms: rssBytes == null ? null : ctx.ageMs,
+      fresh: rssBytes != null && ctx.sampleFresh,
+    },
+    budget: {
+      name: enforced?.name ?? null,
+      declared: enforced?.declared ?? declaredOnly,
+      bytes: enforced?.bytes ?? null,
+      used_bytes: rssBytes,
+      used_fraction: enforced == null || enforced.bytes <= 0 || rssBytes == null ? null : rssBytes / enforced.bytes,
+      enforceable: enforced != null,
+    },
+  };
+}
+
+function buildProjects(workers: readonly RedskilledStatuslineWorker[]): readonly RedskilledStatuslineProject[] {
+  const byProject = new Map<string, { workers: number; declared: number; observed: number; measured: number }>();
+  for (const worker of workers) {
+    const entry = byProject.get(worker.project_label) ?? { workers: 0, declared: 0, observed: 0, measured: 0 };
+    entry.workers += 1;
+    entry.declared += worker.budget.bytes ?? 0;
+    entry.observed += worker.vitals.rss_bytes ?? 0;
+    entry.measured += worker.vitals.rss_bytes == null ? 0 : 1;
+    byProject.set(worker.project_label, entry);
+  }
+  return [...byProject.entries()]
+    .map(([project_label, entry]) => ({
+      project_label,
+      worker_count: entry.workers,
+      declared_memory_bytes: entry.declared,
+      observed_rss_bytes: entry.observed,
+      measured_worker_count: entry.measured,
+    }))
+    .sort((a, b) => a.project_label.localeCompare(b.project_label));
+}
+
+/**
+ * Date the answer, in a sentence a surface can render unchanged.
+ *
+ * A host holding no Workers is never stale: there is nothing to measure, and
+ * calling that state old would put a warning on every idle machine.
+ */
+function buildStaleness(input: {
+  readonly sampledAt: string | null;
+  readonly ageMs: number | null;
+  readonly threshold: number;
+  readonly workerCount: number;
+  readonly measuredCount: number;
+  readonly unmeasured: readonly string[];
+}): RedskilledStatuslineStaleness {
+  const common = {
+    sampled_at: input.sampledAt,
+    age_ms: input.ageMs,
+    threshold_ms: input.threshold,
+    measured_worker_count: input.measuredCount,
+    unmeasured_workers: input.unmeasured,
+  };
+  if (input.workerCount === 0) {
+    return { ...common, stale: false, reason: "the host holds no Workers, so there is nothing to measure and nothing to age" };
+  }
+  if (input.sampledAt == null || input.ageMs == null) {
+    return {
+      ...common,
+      stale: true,
+      reason: `this answer is stale: the daemon has taken no measurement of its ${input.workerCount} live Worker(s) yet`,
+    };
+  }
+  if (input.ageMs > input.threshold) {
+    return {
+      ...common,
+      stale: true,
+      reason: `this answer is stale: its measurement is ${input.ageMs}ms old, past the ${input.threshold}ms staleness window`,
+    };
+  }
+  return {
+    ...common,
+    stale: false,
+    reason: `measured ${input.ageMs}ms ago, within the ${input.threshold}ms staleness window`,
+  };
+}
+
+/** An ISO instant in milliseconds, or `null` when it is not one. PURE. */
+function instant(value: string): number | null {
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** True when `value` is a complete payload — a client's fail-closed check. */
+export function isRedskilledStatuslinePayload(value: unknown): value is RedskilledStatuslinePayload {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const payload = value as Record<string, unknown>;
+  const daemon = payload.daemon as Record<string, unknown> | undefined;
+  const staleness = payload.staleness as Record<string, unknown> | undefined;
+  const host = payload.host as Record<string, unknown> | undefined;
+  return payload.version === 1 &&
+    typeof payload.generated_at === "string" &&
+    daemon != null && typeof daemon === "object" &&
+    Number.isInteger(daemon.pid) &&
+    typeof daemon.daemon_version === "string" &&
+    typeof daemon.protocol_version === "number" &&
+    staleness != null && typeof staleness === "object" &&
+    typeof staleness.stale === "boolean" &&
+    typeof staleness.threshold_ms === "number" &&
+    Array.isArray(staleness.unmeasured_workers) &&
+    host != null && typeof host === "object" &&
+    Number.isInteger(host.worker_count) &&
+    Number.isInteger(host.project_count) &&
+    typeof host.observed_rss_bytes === "number" &&
+    Array.isArray(payload.projects) &&
+    Array.isArray(payload.workers);
+}

--- a/apps/redskilled/tests/statusline-payload.test.ts
+++ b/apps/redskilled/tests/statusline-payload.test.ts
@@ -1,0 +1,267 @@
+// One payload answers "what is this machine doing", and every fact in it comes
+// from the daemon. Reach is asymmetric: a session reads the whole host and
+// writes only its own project. Staleness travels inside the payload.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import {
+  readRedskilledStatuslinePayload,
+  commandRedskilledWorker,
+  startRedskilledWorker,
+} from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import {
+  buildStatuslinePayload,
+  isRedskilledStatuslinePayload,
+  REDSKILLED_STALENESS_MS,
+} from "../src/statusline-payload.js";
+import { evaluateSessionReach, REDSKILLED_OP_REACH } from "../src/session-reach.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await scratch("redskilled-statusline-");
+  return resolveRedskilledPaths({ env: { REDSKILLED_SESSION: `test:${root}` }, runtimeDir: root });
+}
+
+function worker(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorkerView {
+  return {
+    worker_id: "w-1",
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-07-29T00:00:00.000Z",
+    workspace_path: "/tmp/acme/w-1",
+    isolated: true,
+    unit: "red-worker-acme-widgets-w-1.service",
+    budget: { memory_max: "1G" },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+/** A daemon holding two projects' Workers, with the sampler unarmed. */
+async function twoProjectDaemon(): Promise<{ daemon: RedskilledDaemon; paths: RedskilledPaths }> {
+  const paths = await sessionPaths();
+  const daemon = await startRedskilledDaemon({
+    paths,
+    idleMs: 60_000,
+    sampleMs: 0,
+    ceiling: UNBOUNDED_HOST_CEILING,
+    stopWorker: () => true,
+    memorySampler: () => ({ "w-1": 512 * 1024 * 1024, "w-2": 128 * 1024 * 1024 }),
+  });
+  running.push(daemon);
+  daemon.trackWorker(worker());
+  daemon.trackWorker(worker({
+    worker_id: "w-2",
+    project_label: "acme/gadgets",
+    pid: 4343,
+    workspace_path: "/tmp/acme/w-2",
+    unit: "red-worker-acme-gadgets-w-2.service",
+    budget: { memory_max: "512M" },
+  }));
+  return { daemon, paths };
+}
+
+describe("the statusline payload", () => {
+  it("reports every project's Workers with their owning project, from one read", async () => {
+    const { paths } = await twoProjectDaemon();
+    const payload = await readRedskilledStatuslinePayload(paths, { sessionProject: "acme/widgets" });
+
+    expect(isRedskilledStatuslinePayload(payload)).toBe(true);
+    expect(payload.workers.map((w) => [w.worker_id, w.project_label])).toEqual([
+      ["w-1", "acme/widgets"],
+      ["w-2", "acme/gadgets"],
+    ]);
+    expect(payload.projects.map((p) => p.project_label)).toEqual(["acme/gadgets", "acme/widgets"]);
+    expect(payload.host.worker_count).toBe(2);
+    expect(payload.host.project_count).toBe(2);
+  });
+
+  it("carries each Worker's state, vitals and budget consumption", async () => {
+    const { daemon, paths } = await twoProjectDaemon();
+    await daemon.sampleMemoryBudgets();
+    const payload = await readRedskilledStatuslinePayload(paths, { sessionProject: "acme/widgets" });
+
+    const first = payload.workers.find((w) => w.worker_id === "w-1")!;
+    expect(first.state).toBe("running");
+    expect(first.vitals.rss_bytes).toBe(512 * 1024 * 1024);
+    expect(first.vitals.fresh).toBe(true);
+    expect(first.budget.name).toBe("MemoryMax");
+    expect(first.budget.declared).toBe("1G");
+    expect(first.budget.used_bytes).toBe(512 * 1024 * 1024);
+    expect(first.budget.used_fraction).toBeCloseTo(0.5, 6);
+    expect(payload.host.observed_rss_bytes).toBe(640 * 1024 * 1024);
+  });
+
+  it("carries staleness inside the payload rather than leaving it to be re-derived", () => {
+    const workers = [worker()];
+    const fresh = buildStatuslinePayload({
+      hostState: hostStateOf(workers),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      rss: { "w-1": 128 },
+      sampledAt: "2026-07-29T12:00:00.000Z",
+      now: "2026-07-29T12:00:05.000Z",
+    });
+    expect(fresh.staleness.age_ms).toBe(5_000);
+    expect(fresh.staleness.stale).toBe(false);
+    expect(fresh.staleness.threshold_ms).toBe(REDSKILLED_STALENESS_MS);
+
+    const old = buildStatuslinePayload({
+      hostState: hostStateOf(workers),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      rss: { "w-1": 128 },
+      sampledAt: "2026-07-29T12:00:00.000Z",
+      now: "2026-07-29T12:10:00.000Z",
+    });
+    expect(old.staleness.stale).toBe(true);
+    expect(old.workers[0]!.vitals.fresh).toBe(false);
+    expect(old.staleness.reason).toContain("stale");
+
+    const never = buildStatuslinePayload({
+      hostState: hostStateOf(workers),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      rss: {},
+      sampledAt: null,
+      now: "2026-07-29T12:00:00.000Z",
+    });
+    expect(never.staleness.stale).toBe(true);
+    expect(never.staleness.sampled_at).toBeNull();
+    expect(never.staleness.unmeasured_workers).toEqual(["w-1"]);
+    expect(never.workers[0]!.vitals.rss_bytes).toBeNull();
+    expect(never.workers[0]!.budget.used_fraction).toBeNull();
+  });
+
+  it("is total when the host holds nothing at all", () => {
+    const payload = buildStatuslinePayload({
+      hostState: hostStateOf([]),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      rss: {},
+      sampledAt: null,
+      now: "2026-07-29T12:00:00.000Z",
+    });
+    expect(isRedskilledStatuslinePayload(payload)).toBe(true);
+    expect(payload.workers).toEqual([]);
+    expect(payload.projects).toEqual([]);
+    expect(payload.staleness.stale).toBe(false);
+    expect(payload.host.observed_rss_bytes).toBe(0);
+  });
+
+  it("permits a session to read another project's state", async () => {
+    const { paths } = await twoProjectDaemon();
+    const payload = await readRedskilledStatuslinePayload(paths, { sessionProject: "acme/widgets" });
+    expect(payload.workers.some((w) => w.project_label === "acme/gadgets")).toBe(true);
+
+    for (const op of ["ping", "host-state", "statusline-payload"] as const) {
+      expect(REDSKILLED_OP_REACH[op]).toBe("host-read");
+      const verdict = evaluateSessionReach({ op, sessionProject: "acme/widgets", targetProject: "acme/gadgets" });
+      expect(verdict.permitted).toBe(true);
+      expect(verdict.verdict).toBe("permitted-host-read");
+    }
+  });
+
+  it("refuses to dispatch, stop, recycle or steer into another project", async () => {
+    for (const op of ["worker-start", "worker-stop", "worker-recycle", "worker-steer"] as const) {
+      expect(REDSKILLED_OP_REACH[op]).toBe("project-write");
+      const refused = evaluateSessionReach({ op, sessionProject: "acme/widgets", targetProject: "acme/gadgets" });
+      expect(refused.permitted).toBe(false);
+      expect(refused.verdict).toBe("refused-cross-project");
+      expect(refused.reason).toContain("acme/gadgets");
+
+      const own = evaluateSessionReach({ op, sessionProject: "acme/widgets", targetProject: "acme/widgets" });
+      expect(own.permitted).toBe(true);
+      expect(own.verdict).toBe("permitted-own-project");
+    }
+
+    const { paths } = await twoProjectDaemon();
+    await expect(startRedskilledWorker(
+      paths,
+      { project_label: "acme/gadgets", workspace_path: "/tmp/acme/w-3", command: "true" },
+      { sessionProject: "acme/widgets" },
+    )).rejects.toThrow(/acme\/gadgets/);
+
+    for (const command of ["stop", "recycle", "steer"] as const) {
+      await expect(commandRedskilledWorker(
+        paths,
+        { command, worker_id: "w-2", session_project: "acme/widgets" },
+        {},
+      )).rejects.toThrow(/refus/i);
+    }
+  });
+
+  it("stops a Worker of the session's own project, and never one it cannot see", async () => {
+    const { daemon, paths } = await twoProjectDaemon();
+    const result = await commandRedskilledWorker(
+      paths,
+      { command: "stop", worker_id: "w-1", session_project: "acme/widgets" },
+      {},
+    );
+    expect(result.applied).toBe(true);
+    expect(daemon.workerCount()).toBe(1);
+
+    // An unknown Worker is refused rather than reported as absent: a session must
+    // not learn, from a refusal, what another project is running.
+    await expect(commandRedskilledWorker(
+      paths,
+      { command: "stop", worker_id: "w-404", session_project: "acme/widgets" },
+      {},
+    )).rejects.toThrow(/refus/i);
+  });
+
+  it("holds no private source: a malformed answer throws instead of being patched up", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000, sampleMs: 0 });
+    running.push(daemon);
+
+    expect(isRedskilledStatuslinePayload({ version: 1, workers: [], projects: [] })).toBe(false);
+    expect(isRedskilledStatuslinePayload(null)).toBe(false);
+
+    // The daemon's own numbers are the payload's numbers — nothing is re-derived.
+    const payload = await readRedskilledStatuslinePayload(paths, { sessionProject: "acme/widgets" });
+    expect(payload.daemon.pid).toBe(daemon.hostState().pid);
+    expect(payload.daemon.daemon_version).toBe(daemon.hostState().daemon_version);
+    expect(payload.host.budget_accounting).toEqual(daemon.hostState().budget_accounting);
+  });
+});
+
+function hostStateOf(workers: readonly RedskilledWorkerView[]) {
+  return {
+    version: 1 as const,
+    protocol_version: 1,
+    daemon_version: "0.0.0-test",
+    machine_id_hash: "machine",
+    session_key_hash: "session",
+    pid: 999,
+    started_at: "2026-07-29T11:00:00.000Z",
+    workers,
+    projects: [...new Set(workers.map((w) => w.project_label))].sort().map((project_label) => ({
+      project_label,
+      worker_count: workers.filter((w) => w.project_label === project_label).length,
+    })),
+    budget_accounting: {
+      version: 1 as const,
+      worker_count: workers.length,
+      memory_high_bytes: 0,
+      memory_max_bytes: 0,
+      cpu_weight_total: 0,
+      unaccounted_workers: [],
+      unisolated_workers: [],
+    },
+  };
+}


### PR DESCRIPTION
Automated AFK landing for #2791. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2791

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787942181&installation_model_id=20659&pr_number=2816&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2816&signature=fea3b3fa86e13e4348c831a9377cd64aa3750c37ce7e5ab3f65478e4db82da5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->