### PR TITLE
chore: #2781 Windows placement backend through Job Objects

### DIFF
--- a/apps/redskilled/native/binding.gyp
+++ b/apps/redskilled/native/binding.gyp
@@ -1,0 +1,27 @@
+{
+  "comment": [
+    "The Job Object addon's build description (#2781, mechanism decided on #2780).",
+    "It lives under native/ rather than at the package root DELIBERATELY: a root",
+    "binding.gyp makes every install of this workspace try to compile an addon,",
+    "and this package ships as pure JavaScript on Linux and macOS, where the",
+    "addon does not even exist. Build it explicitly with `pnpm build:native`,",
+    "which is the node-gyp fallback the loader looks for when no prebuild",
+    "matches the host."
+  ],
+  "targets": [
+    {
+      "target_name": "redskilled-job-object",
+      "sources": [],
+      "conditions": [
+        [
+          "OS==\"win\"",
+          {
+            "sources": ["job-object.cc"],
+            "libraries": ["-lkernel32.lib"],
+            "defines": ["NAPI_VERSION=8", "UNICODE", "_UNICODE"]
+          }
+        ]
+      ]
+    }
+  ]
+}

--- a/apps/redskilled/native/job-object.cc
+++ b/apps/redskilled/native/job-object.cc
@@ -1,0 +1,214 @@
+/*
+ * job-object — the native reach the Windows placement backend is built on.
+ *
+ * Node reaches no part of the Job Object API on its own, and #2780 decided the
+ * mechanism: an N-API addon loaded in-process, not a helper binary. This is that
+ * addon, and it is deliberately the smallest surface that can carry the
+ * decision — create a job with limits, put a process inside it, close it.
+ *
+ * **Written against the C Node-API, with no dependency.** Node-API's ABI is
+ * stable across Node majors, so an artifact built once keeps loading; using the
+ * C headers rather than `node-addon-api` keeps the build free of a node_modules
+ * dependency, which is what lets a prebuild be a single file with nothing behind
+ * it.
+ *
+ * **Kill-on-close is not a parameter.** It is set on every job this addon
+ * creates, because it is the property that makes a Worker unable to outlive the
+ * job that owns it. The consequence is explicit: the handle's lifetime IS the
+ * Worker's lifetime, so the daemon holds it for the Worker's life and closing it
+ * (or dropping it) ends the Worker.
+ *
+ * Every failure is thrown with the Win32 error code that caused it. A caller
+ * that could only see "it did not work" would degrade to the sampling floor
+ * without being able to say why, which is the silent downgrade the whole backend
+ * is shaped to avoid.
+ */
+#include <node_api.h>
+
+#include <windows.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+struct JobObjectHolder {
+  HANDLE handle;
+};
+
+void ThrowWin32(napi_env env, const char* what, DWORD code) {
+  std::string message = std::string(what) + " failed with Win32 error " + std::to_string(code);
+  napi_throw_error(env, nullptr, message.c_str());
+}
+
+bool ReadOptionalNumber(napi_env env, napi_value object, const char* key, double* out) {
+  napi_value value;
+  if (napi_get_named_property(env, object, key, &value) != napi_ok) return false;
+  napi_valuetype type;
+  if (napi_typeof(env, value, &type) != napi_ok) return false;
+  if (type != napi_number) return false;
+  return napi_get_value_double(env, value, out) == napi_ok;
+}
+
+/** Read a JS string as UTF-16, which is what every `W` entry point wants. */
+bool ReadUtf16(napi_env env, napi_value value, std::wstring* out) {
+  size_t length = 0;
+  if (napi_get_value_string_utf16(env, value, nullptr, 0, &length) != napi_ok) return false;
+  std::vector<char16_t> buffer(length + 1, 0);
+  if (napi_get_value_string_utf16(env, value, buffer.data(), buffer.size(), &length) != napi_ok) return false;
+  out->assign(reinterpret_cast<const wchar_t*>(buffer.data()), length);
+  return true;
+}
+
+JobObjectHolder* Unwrap(napi_env env, napi_callback_info info, napi_value* argv, size_t* argc) {
+  napi_value self;
+  void* data = nullptr;
+  if (napi_get_cb_info(env, info, argc, argv, &self, nullptr) != napi_ok) return nullptr;
+  if (napi_unwrap(env, self, &data) != napi_ok) return nullptr;
+  return static_cast<JobObjectHolder*>(data);
+}
+
+/** `assign(pid)` — put a LIVE process under this job's limits. */
+napi_value Assign(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  JobObjectHolder* holder = Unwrap(env, info, argv, &argc);
+  if (holder == nullptr || holder->handle == nullptr) {
+    napi_throw_error(env, nullptr, "this Job Object is already closed, so nothing can be assigned to it");
+    return nullptr;
+  }
+  int32_t pid = 0;
+  if (argc < 1 || napi_get_value_int32(env, argv[0], &pid) != napi_ok || pid <= 0) {
+    napi_throw_error(env, nullptr, "assign(pid) needs a positive process id");
+    return nullptr;
+  }
+
+  // PROCESS_TERMINATE is asked for alongside PROCESS_SET_QUOTA so the job can
+  // enforce, rather than merely observe, the limits it carries.
+  HANDLE process = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, FALSE, static_cast<DWORD>(pid));
+  if (process == nullptr) {
+    ThrowWin32(env, "OpenProcess", GetLastError());
+    return nullptr;
+  }
+  BOOL assigned = AssignProcessToJobObject(holder->handle, process);
+  DWORD code = GetLastError();
+  CloseHandle(process);
+  if (!assigned) {
+    ThrowWin32(env, "AssignProcessToJobObject", code);
+    return nullptr;
+  }
+  return nullptr;
+}
+
+/** `close()` — release the job. With kill-on-close set, this ends what is inside. */
+napi_value Close(napi_env env, napi_callback_info info) {
+  size_t argc = 0;
+  JobObjectHolder* holder = Unwrap(env, info, nullptr, &argc);
+  if (holder != nullptr && holder->handle != nullptr) {
+    CloseHandle(holder->handle);
+    holder->handle = nullptr;
+  }
+  return nullptr;
+}
+
+void FinalizeJob(napi_env env, void* data, void* hint) {
+  (void)env;
+  (void)hint;
+  JobObjectHolder* holder = static_cast<JobObjectHolder*>(data);
+  if (holder == nullptr) return;
+  // Collection closes the handle, which kills the Worker: the handle's lifetime
+  // is the Worker's lifetime, and the daemon is what holds it.
+  if (holder->handle != nullptr) CloseHandle(holder->handle);
+  delete holder;
+}
+
+/** `createJobObject({ name, limits })` — a job carrying the budget, kill-on-close set. */
+napi_value CreateJobObject(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok || argc < 1) {
+    napi_throw_error(env, nullptr, "createJobObject({ name, limits }) needs its request object");
+    return nullptr;
+  }
+
+  napi_value name_value;
+  std::wstring name;
+  if (napi_get_named_property(env, argv[0], "name", &name_value) != napi_ok || !ReadUtf16(env, name_value, &name)) {
+    napi_throw_error(env, nullptr, "createJobObject needs a string name");
+    return nullptr;
+  }
+  napi_value limits;
+  if (napi_get_named_property(env, argv[0], "limits", &limits) != napi_ok) {
+    napi_throw_error(env, nullptr, "createJobObject needs a limits object");
+    return nullptr;
+  }
+
+  HANDLE job = CreateJobObjectW(nullptr, name.c_str());
+  if (job == nullptr) {
+    ThrowWin32(env, "CreateJobObjectW", GetLastError());
+    return nullptr;
+  }
+
+  JOBOBJECT_EXTENDED_LIMIT_INFORMATION extended = {};
+  extended.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+  double memory_bytes = 0;
+  if (ReadOptionalNumber(env, limits, "memory_limit_bytes", &memory_bytes) && memory_bytes > 0) {
+    extended.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_JOB_MEMORY;
+    extended.JobMemoryLimit = static_cast<SIZE_T>(memory_bytes);
+  }
+  if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, &extended, sizeof(extended))) {
+    DWORD code = GetLastError();
+    CloseHandle(job);
+    ThrowWin32(env, "SetInformationJobObject(ExtendedLimitInformation)", code);
+    return nullptr;
+  }
+
+  double cpu_rate_percent = 0;
+  if (ReadOptionalNumber(env, limits, "cpu_rate_percent", &cpu_rate_percent) && cpu_rate_percent > 0) {
+    JOBOBJECT_CPU_RATE_CONTROL_INFORMATION cpu = {};
+    cpu.ControlFlags = JOB_OBJECT_CPU_RATE_CONTROL_ENABLE | JOB_OBJECT_CPU_RATE_CONTROL_HARD_CAP;
+    // The field is in hundredths of a percent.
+    cpu.CpuRate = static_cast<DWORD>(cpu_rate_percent * 100);
+    if (!SetInformationJobObject(job, JobObjectCpuRateControlInformation, &cpu, sizeof(cpu))) {
+      DWORD code = GetLastError();
+      CloseHandle(job);
+      ThrowWin32(env, "SetInformationJobObject(CpuRateControlInformation)", code);
+      return nullptr;
+    }
+  }
+
+  napi_value handle;
+  if (napi_create_object(env, &handle) != napi_ok) {
+    CloseHandle(job);
+    napi_throw_error(env, nullptr, "could not build the Job Object handle object");
+    return nullptr;
+  }
+  napi_set_named_property(env, handle, "name", name_value);
+
+  napi_value assign_fn;
+  napi_value close_fn;
+  napi_create_function(env, "assign", NAPI_AUTO_LENGTH, Assign, nullptr, &assign_fn);
+  napi_create_function(env, "close", NAPI_AUTO_LENGTH, Close, nullptr, &close_fn);
+  napi_set_named_property(env, handle, "assign", assign_fn);
+  napi_set_named_property(env, handle, "close", close_fn);
+
+  JobObjectHolder* holder = new JobObjectHolder{job};
+  if (napi_wrap(env, handle, holder, FinalizeJob, nullptr, nullptr) != napi_ok) {
+    CloseHandle(job);
+    delete holder;
+    napi_throw_error(env, nullptr, "could not attach the Job Object to its handle");
+    return nullptr;
+  }
+  return handle;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_value create_fn;
+  napi_create_function(env, "createJobObject", NAPI_AUTO_LENGTH, CreateJobObject, nullptr, &create_fn);
+  napi_set_named_property(env, exports, "createJobObject", create_fn);
+  return exports;
+}
+
+}  // namespace
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "NODE_OPTIONS=--max-old-space-size=4096 vitest run",
     "build": "pnpm run typecheck",
+    "build:native": "node-gyp rebuild --directory=native",
     "serve": "tsx src/cli.ts serve"
   },
   "dependencies": {

--- a/apps/redskilled/src/job-object.ts
+++ b/apps/redskilled/src/job-object.ts
@@ -1,0 +1,325 @@
+/**
+ * job-object — the Windows placement backend, and the honest edge of its reach.
+ *
+ * **A Job Object is the closest analogue to a Linux resource group that exists
+ * off Linux**: it carries a memory ceiling the kernel enforces, CPU rate
+ * control, and kill-on-close, so Windows gains real teeth instead of only the
+ * daemon's sampling floor (ADR 0130 rule 4).
+ *
+ * **Native reach is an N-API addon, decided on #2780.** Node reaches none of
+ * these APIs on its own. The addon is loaded in-process from a prebuild matching
+ * `<platform>-<arch>`, falling back to a `node-gyp` build output when no
+ * prebuild matches the host. When neither is there the reach is a REFUSAL
+ * CARRYING A REASON rather than a thrown error or a silent `false`: the caller
+ * degrades to the sampling floor and says which of the two it is doing.
+ *
+ * **Kill-on-close is set deliberately, and it is a Windows-only bargain.** On
+ * Linux a Worker is owned by the init system so a restarted daemon re-attaches
+ * by unit name (ADR 0130 rule 5). A Job Object has no such owner — the handle IS
+ * the ownership — so this backend trades re-attach for the guarantee that no
+ * Worker outlives the job that owns it. Leaking Workers on every daemon upgrade
+ * is the failure this repository already pays a floor to avoid.
+ *
+ * PURE except {@link loadJobObjectBinding}, the one function that reads the host,
+ * and even that takes its `require` and its existence check injected — which is
+ * what lets every case here be proven on a machine that is not Windows.
+ */
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import type { RedskilledWorkerView } from "./host-state.js";
+import {
+  resolveEnforcedBudget,
+  type RedskilledBudgetName,
+  type RedskilledTerminationClassification,
+} from "./memory-sampler.js";
+import type { RedskilledWorkerBudget } from "./worker-placement.js";
+
+/** The addon's file name, identical in a prebuild and in a local build. */
+export const JOB_OBJECT_ADDON_BASENAME = "redskilled-job-object.node";
+
+/** `CPUWeight`'s systemd default — the fair share, and the line this backend caps below. */
+export const CPU_WEIGHT_FAIR_SHARE = 100;
+
+/**
+ * The limits one Job Object carries.
+ *
+ * `kill_on_close` is a literal `true` rather than a boolean: it is the property
+ * that makes a Worker unable to outlive its job, so it is not a knob a future
+ * caller can turn off by passing the other value.
+ */
+export interface RedskilledJobLimits {
+  /** `JOB_OBJECT_LIMIT_JOB_MEMORY`, in bytes. Absent when no budget declared one. */
+  readonly memory_limit_bytes?: number;
+  /** The budget's own name, so a limit can always be traced back to what asked for it. */
+  readonly memory_budget_name?: RedskilledBudgetName;
+  /** The budget exactly as the client declared it, unparsed. */
+  readonly memory_budget_declared?: string;
+  /** `JOBOBJECT_CPU_RATE_CONTROL_INFORMATION`, as a percentage of one CPU's cycles. */
+  readonly cpu_rate_percent?: number;
+  /** `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Always set; never optional. */
+  readonly kill_on_close: true;
+  /** Set when a declared budget field could not be carried into the job as asked. */
+  readonly note?: string;
+}
+
+/** One live Job Object. Closing it kills everything inside — that is the point. */
+export interface RedskilledJobObjectHandle {
+  readonly name: string;
+  /** Put a live process under this job's limits. Throws when the host refuses. */
+  assign(pid: number): void;
+  /** Close the job. With kill-on-close set, this ends every Worker inside it. */
+  close(): void;
+}
+
+/** What the N-API addon must export. The daemon knows the addon by this alone. */
+export interface RedskilledJobObjectBinding {
+  createJobObject(request: {
+    readonly name: string;
+    readonly limits: RedskilledJobLimits;
+  }): RedskilledJobObjectHandle;
+}
+
+/**
+ * Whether this host can reach Job Objects, and when it cannot, why.
+ *
+ * The unavailable arm carries a whole sentence rather than a flag, because the
+ * caller's job is to degrade to the sampling floor *explicitly* — and a
+ * degradation nobody can read the cause of is the silent one this shape exists
+ * to prevent.
+ */
+export type RedskilledJobObjectReach =
+  | { readonly available: true; readonly binding: RedskilledJobObjectBinding }
+  | { readonly available: false; readonly reason: string };
+
+/** Reach is unavailable, with the sentence a warning will quote. PURE. */
+export function jobObjectsUnavailable(reason: string): RedskilledJobObjectReach {
+  return { available: false, reason };
+}
+
+/**
+ * Where the addon is looked for, in the order it is looked for. PURE.
+ *
+ * A prebuild for this exact `<platform>-<arch>` first, then the `node-gyp`
+ * output a host that compiled its own would produce. Both are listed in a
+ * failure so an operator reads where to put the artifact, not just that it is
+ * missing.
+ */
+export function jobObjectAddonCandidates(
+  platform: NodeJS.Platform,
+  arch: string,
+  packageRoot: string,
+): readonly string[] {
+  return [
+    join(packageRoot, "prebuilds", `${platform}-${arch}`, JOB_OBJECT_ADDON_BASENAME),
+    join(packageRoot, "native", "build", "Release", JOB_OBJECT_ADDON_BASENAME),
+  ];
+}
+
+export interface LoadJobObjectBindingOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly arch?: string;
+  readonly packageRoot?: string;
+  /** Injected so a non-Windows host can prove every arm of this function. */
+  readonly requireFn?: (path: string) => unknown;
+  readonly exists?: (path: string) => boolean;
+}
+
+/**
+ * Load the Job Object addon, or refuse with a reason.
+ *
+ * The one impure read of the host in this module, and it never throws: a
+ * daemon that crashed because an optional native artifact was missing would be
+ * worse than the unenforced ceiling it was trying to install.
+ */
+export function loadJobObjectBinding(
+  options: LoadJobObjectBindingOptions = {},
+): RedskilledJobObjectReach {
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+  if (platform !== "win32") {
+    return jobObjectsUnavailable(
+      `Job Object placement is the Windows backend (platform=${platform}), so there is no native reach to load here`,
+    );
+  }
+
+  const packageRoot = options.packageRoot ?? defaultPackageRoot();
+  const exists = options.exists ?? existsSync;
+  const candidates = jobObjectAddonCandidates(platform, arch, packageRoot);
+  const found = candidates.find((candidate) => exists(candidate));
+  if (found == null) {
+    return jobObjectsUnavailable(
+      `no Job Object addon was found for ${platform}-${arch} (looked in ${candidates.join(", ")}); ` +
+        "either install the prebuild for this platform and architecture or build the addon locally",
+    );
+  }
+
+  const requireFn = options.requireFn ?? createRequire(import.meta.url);
+  let loaded: unknown;
+  try {
+    loaded = requireFn(found);
+  } catch (err) {
+    return jobObjectsUnavailable(
+      `the Job Object addon at ${found} could not be loaded: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!isJobObjectBinding(loaded)) {
+    return jobObjectsUnavailable(
+      `the Job Object addon at ${found} does not export createJobObject, so it cannot be the native reach`,
+    );
+  }
+  return { available: true, binding: loaded };
+}
+
+function isJobObjectBinding(value: unknown): value is RedskilledJobObjectBinding {
+  return typeof value === "object" && value != null &&
+    typeof (value as { createJobObject?: unknown }).createJobObject === "function";
+}
+
+function defaultPackageRoot(): string {
+  return new URL("..", import.meta.url).pathname;
+}
+
+/**
+ * The job limits one budget asks for. PURE.
+ *
+ * `MemoryMax` wins over `MemoryHigh` for the same reason the sampling floor
+ * enforces it: `MemoryHigh` is throttling pressure and `MemoryMax` is the wall,
+ * and a job whose hard ceiling sat at the pressure point would end Workers the
+ * kernel was willing to keep.
+ *
+ * **CPU rate control is not `CPUWeight`, and this refuses to pretend it is.**
+ * Windows caps an absolute percentage of cycles while `CPUWeight` states a
+ * relative share, so a weight AT OR ABOVE the fair share buys no cap at all —
+ * turning "give this Worker more than its share" into a hard ceiling would
+ * install a limit nobody asked for. Only a deprioritising weight becomes a rate.
+ */
+export function planJobLimits(budget: RedskilledWorkerBudget | undefined): RedskilledJobLimits {
+  const declared = budget ?? {};
+  const notes: string[] = [];
+  const memory = resolveJobMemoryLimit(declared);
+  if (memory == null && (declared.memory_max ?? declared.memory_high) != null) {
+    notes.push("the declared memory budget could not be reduced to bytes, so the job carries no memory ceiling");
+  }
+  let cpuRate: number | undefined;
+  if (declared.cpu_weight != null) {
+    if (declared.cpu_weight < CPU_WEIGHT_FAIR_SHARE) {
+      cpuRate = Math.max(1, Math.min(100, Math.round(declared.cpu_weight)));
+    } else {
+      notes.push(
+        `cpu_weight=${declared.cpu_weight} is at or above the fair share of ${CPU_WEIGHT_FAIR_SHARE}, and Windows CPU ` +
+          "rate control is an absolute cap rather than a share, so no rate limit is set",
+      );
+    }
+  }
+  return {
+    ...(memory != null
+      ? {
+          memory_limit_bytes: memory.bytes,
+          memory_budget_name: memory.name,
+          memory_budget_declared: memory.declared,
+        }
+      : {}),
+    ...(cpuRate != null ? { cpu_rate_percent: cpuRate } : {}),
+    kill_on_close: true,
+    ...(notes.length > 0 ? { note: notes.join("; ") } : {}),
+  };
+}
+
+function resolveJobMemoryLimit(
+  budget: RedskilledWorkerBudget,
+): { readonly name: RedskilledBudgetName; readonly declared: string; readonly bytes: number } | null {
+  // The floor already owns this precedence and its parsing; a second copy here
+  // would be a second answer to "which budget is the wall".
+  return resolveEnforcedBudget({ budget });
+}
+
+/**
+ * Windows exit codes a process shows when the job's memory ceiling stopped it.
+ *
+ * A job memory limit does not shoot the process — it fails its allocations, and
+ * the runtime dies of the failure. These are the NTSTATUS values that arrives as,
+ * named rather than inlined so a reader of an outcome can look them up.
+ */
+export const JOB_MEMORY_EXIT_CODES: Readonly<Record<number, string>> = {
+  0xc0000017: "STATUS_NO_MEMORY",
+  0xc000012d: "STATUS_COMMITMENT_LIMIT",
+  0xc0000409: "STATUS_STACK_BUFFER_OVERRUN",
+};
+
+/**
+ * One Worker the Windows kernel stopped for its job's memory ceiling.
+ *
+ * It shares `outcome`, `classification` and `stall` with the sampling floor's
+ * termination on purpose — the same fact happened, with better teeth — and adds
+ * `enforced_by` so a reader can tell which backend acted without inferring it
+ * from the presence of an RSS number nobody measured.
+ */
+export interface RedskilledJobObjectTermination {
+  readonly version: 1;
+  readonly worker_id: string;
+  readonly project_label: string;
+  readonly outcome: "terminated-over-memory-budget";
+  readonly classification: RedskilledTerminationClassification;
+  /** Never a stall — the kernel refused this Worker's memory, it did not wait on it. */
+  readonly stall: false;
+  readonly enforced_by: "job-object";
+  readonly job_name: string;
+  readonly budget_name: RedskilledBudgetName;
+  readonly budget_declared: string;
+  readonly budget_bytes: number;
+  readonly exit_code: number;
+  readonly exit_status: string;
+  readonly workspace_path: string;
+  /** A whole sentence naming the budget — what an operator reads. */
+  readonly reason: string;
+}
+
+export interface ClassifyJobObjectExitInput {
+  readonly worker: RedskilledWorkerView;
+  readonly jobName: string;
+  readonly limits: RedskilledJobLimits;
+  readonly exitCode: number | null;
+}
+
+/**
+ * Read a Worker's death against the job that held it. PURE.
+ *
+ * Returns `null` for every exit this backend cannot attribute — a clean exit, a
+ * job with no memory ceiling, an unknown status. A backend that claimed every
+ * death as a budget kill would make the outcome worthless exactly where it is
+ * read most: after an incident.
+ */
+export function classifyJobObjectExit(
+  input: ClassifyJobObjectExitInput,
+): RedskilledJobObjectTermination | null {
+  const { worker, limits, exitCode } = input;
+  if (exitCode == null) return null;
+  if (limits.memory_limit_bytes == null || limits.memory_budget_name == null) return null;
+  const status = JOB_MEMORY_EXIT_CODES[exitCode >>> 0];
+  if (status == null) return null;
+
+  const who = `Worker ${JSON.stringify(worker.worker_id)} of project ${JSON.stringify(worker.project_label)}`;
+  const declared = limits.memory_budget_declared ?? String(limits.memory_limit_bytes);
+  return {
+    version: 1,
+    worker_id: worker.worker_id,
+    project_label: worker.project_label,
+    outcome: "terminated-over-memory-budget",
+    classification: "budget-exceeded",
+    stall: false,
+    enforced_by: "job-object",
+    job_name: input.jobName,
+    budget_name: limits.memory_budget_name,
+    budget_declared: declared,
+    budget_bytes: limits.memory_limit_bytes,
+    exit_code: exitCode,
+    exit_status: status,
+    workspace_path: worker.workspace_path,
+    reason:
+      `the Windows kernel terminated ${who}: its Job Object ${JSON.stringify(input.jobName)} enforced the ` +
+      `${limits.memory_budget_name} budget of ${declared} (${limits.memory_limit_bytes} bytes) and the Worker died ` +
+      `with ${status} (0x${(exitCode >>> 0).toString(16)}). This is a budget termination, not a stall, and the work ` +
+      `in ${JSON.stringify(worker.workspace_path)} is handed forward.`,
+  };
+}

--- a/apps/redskilled/src/memory-sampler.ts
+++ b/apps/redskilled/src/memory-sampler.ts
@@ -26,6 +26,7 @@ import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { parseMemoryBudget } from "./budget-accounting.js";
 import type { RedskilledWorkerView } from "./host-state.js";
+import type { RedskilledWorkerBudget } from "./worker-placement.js";
 
 /** How the daemon classifies a termination it decided itself. */
 export type RedskilledTerminationClassification = "budget-exceeded";
@@ -102,7 +103,7 @@ export type RedskilledMemorySampler = (
  * willing to keep running. PURE.
  */
 export function resolveEnforcedBudget(
-  worker: RedskilledWorkerView,
+  worker: { readonly budget?: RedskilledWorkerBudget },
 ): { readonly name: RedskilledBudgetName; readonly declared: string; readonly bytes: number } | null {
   const budget = worker.budget ?? {};
   const candidates: ReadonlyArray<readonly [RedskilledBudgetName, string | undefined]> = [

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -22,6 +22,7 @@ import { randomUUID } from "node:crypto";
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import type { RedskilledAdmissionVerdict } from "./admission.js";
 import type { RedskilledWorkerView } from "./host-state.js";
+import type { RedskilledJobObjectHandle } from "./job-object.js";
 import {
   detectWorkerPlacementProbes,
   placementEnabled,
@@ -79,6 +80,14 @@ export interface LaunchedWorker {
   readonly warnings: readonly string[];
   readonly plan: WorkerPlacementPlan;
   readonly child: ChildProcess;
+  /**
+   * The Job Object holding this Worker, on Windows and only when it was minted.
+   *
+   * It is HELD, not closed: kill-on-close means letting go of this handle ends
+   * the Worker, so the daemon keeps it for the Worker's life and closes it when
+   * the Worker is gone.
+   */
+  readonly job?: RedskilledJobObjectHandle;
 }
 
 export interface LaunchWorkerOptions {
@@ -141,6 +150,7 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
   const env = options.env ?? process.env;
   const clock = options.clock ?? (() => new Date().toISOString());
   const workerId = (spec.worker_id ?? options.workerId ?? randomUUID()).trim() || randomUUID();
+  const probes = options.probes ?? detectWorkerPlacementProbes(env);
   const plan = planWorkerPlacement({
     workerId,
     projectLabel: spec.project_label,
@@ -151,7 +161,7 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     target: spec.placement,
     env: spec.env,
     enabled: options.enabled ?? placementEnabled(env),
-    probes: options.probes ?? detectWorkerPlacementProbes(env),
+    probes,
   });
 
   const spawnFn = options.spawnFn ?? spawn;
@@ -172,23 +182,86 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     throw new RedskilledWorkerSpecError(`redskilled could not spawn ${JSON.stringify(plan.command)} for worker ${workerId}`);
   }
 
+  // The Windows backend isolates AFTER the spawn, because Node offers no way to
+  // start a process already inside a job. The window between the two is bounded
+  // by the sampling floor rather than left unenforced — the same floor that
+  // covers a host with no native reach at all.
+  const placed = plan.job != null ? placeInJobObject(plan, probes, child.pid) : null;
+
   // Observed, not polled — but never a reason to keep the daemon alive on its
   // own, so the handle is unref'd and the exit is still delivered while we live.
   child.once("error", () => undefined);
-  if (options.onExit) child.once("exit", (code, signal) => options.onExit?.(workerId, code, signal));
+  child.once("exit", (code, signal) => {
+    // Closing the job is what releases the kernel object; with kill-on-close set
+    // it also guarantees nothing of this Worker is left behind.
+    try {
+      placed?.job?.close();
+    } catch {
+      // A job the host already tore down is the outcome we wanted anyway.
+    }
+    options.onExit?.(workerId, code, signal);
+  });
   child.unref();
 
-  const warnings = [plan.warning, plan.budgetWarning].filter((warning): warning is string => warning != null);
+  const isolated = plan.job != null ? placed?.job != null : plan.isolated;
+  const warnings = [plan.warning, placed?.warning, plan.budgetWarning].filter(
+    (warning): warning is string => warning != null,
+  );
   const worker: RedskilledWorkerView = {
     worker_id: workerId,
     project_label: spec.project_label,
     pid: child.pid,
     started_at: clock(),
     workspace_path: spec.workspace_path,
-    isolated: plan.isolated,
+    isolated,
     ...(plan.unit != null ? { unit: plan.unit } : {}),
     ...(spec.budget != null ? { budget: spec.budget } : {}),
     warnings,
   };
-  return { worker, admission, warnings, plan, child };
+  return { worker, admission, warnings, plan, child, ...(placed?.job != null ? { job: placed.job } : {}) };
+}
+
+/**
+ * Mint this Worker's Job Object and put the live process inside it.
+ *
+ * Every failure here degrades to the sampling floor EXPLICITLY and none of them
+ * ends the launch: a Worker running under the floor is worse than one running
+ * under the kernel, and far better than one that never started because an
+ * optional native artifact misbehaved. A job that was minted but could not take
+ * the process is closed immediately — an empty job with kill-on-close set is a
+ * handle waiting to kill the wrong thing later.
+ */
+function placeInJobObject(
+  plan: WorkerPlacementPlan,
+  probes: WorkerPlacementProbes,
+  pid: number,
+): { readonly job?: RedskilledJobObjectHandle; readonly warning?: string } {
+  const job = plan.job;
+  if (job == null) return {};
+  const floor = "the Worker is charged to the daemon's own resource group and the daemon's RSS sampling floor is the only remaining ceiling";
+  if (!probes.jobObjects.available) {
+    return { warning: `Job Object placement unavailable: ${probes.jobObjects.reason}. ${floor}` };
+  }
+
+  let handle: RedskilledJobObjectHandle;
+  try {
+    handle = probes.jobObjects.binding.createJobObject({ name: job.name, limits: job.limits });
+  } catch (err) {
+    return { warning: `Job Object ${JSON.stringify(job.name)} could not be created: ${reason(err)}. ${floor}` };
+  }
+  try {
+    handle.assign(pid);
+  } catch (err) {
+    try {
+      handle.close();
+    } catch {
+      // Nothing was ever inside it; a close the host refused changes nothing.
+    }
+    return { warning: `Worker pid ${pid} could not be assigned to Job Object ${JSON.stringify(job.name)}: ${reason(err)}. ${floor}` };
+  }
+  return { job: handle };
+}
+
+function reason(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -19,6 +19,13 @@
  */
 import { existsSync } from "node:fs";
 import { delimiter, join } from "node:path";
+import {
+  jobObjectsUnavailable,
+  loadJobObjectBinding,
+  planJobLimits,
+  type RedskilledJobLimits,
+  type RedskilledJobObjectReach,
+} from "./job-object.js";
 
 /** Env kill-switch: `REDSKILLED_PLACEMENT=off` launches unisolated — loudly. */
 export const REDSKILLED_PLACEMENT_ENV = "REDSKILLED_PLACEMENT";
@@ -33,6 +40,14 @@ export interface WorkerPlacementProbes {
   readonly systemdRun: string | null;
   /** True when a systemd `--user` session is reachable. */
   readonly userSession: boolean;
+  /**
+   * Whether Job Objects are reachable here, and when they are not, why.
+   *
+   * A reason rather than a flag: the Windows backend degrades to the sampling
+   * floor *explicitly*, and a warning that could only say "unavailable" would be
+   * the silent downgrade this field exists to prevent.
+   */
+  readonly jobObjects: RedskilledJobObjectReach;
 }
 
 /**
@@ -43,7 +58,14 @@ export interface WorkerPlacementProbes {
  * an unisolated launch is never silent, however it came to be one.
  */
 export interface RedskilledPlacementTarget {
-  readonly isolation: "transient-unit" | "inherit";
+  /**
+   * `transient-unit` and `job-object` both mean "isolate this Worker"; they name
+   * the backend a client EXPECTS, never one the daemon can be argued into. The
+   * host decides which backend exists, so a client asking for a transient unit
+   * on Windows gets a Job Object rather than a refusal — the answer to "isolate
+   * me" must not depend on the client guessing the platform right.
+   */
+  readonly isolation: "transient-unit" | "job-object" | "inherit";
   readonly unit_prefix?: string;
 }
 
@@ -54,15 +76,33 @@ export interface RedskilledWorkerBudget {
   readonly cpu_weight?: number;
 }
 
+/**
+ * Which backend a plan resolved to.
+ *
+ * `none` is a first-class answer, not an absent one: an unisolated launch is a
+ * decision the host made, and it is read alongside its warning.
+ */
+export type WorkerPlacementBackend = "transient-unit" | "job-object" | "none";
+
+/** The Job Object a Windows plan asks for. The handle itself is minted at launch. */
+export interface WorkerJobObjectPlan {
+  readonly name: string;
+  readonly limits: RedskilledJobLimits;
+}
+
 export interface WorkerPlacementPlan {
-  /** True when the Worker runs inside a transient unit of its own. */
+  /** True when the Worker runs inside a resource group of its own. */
   readonly isolated: boolean;
+  /** The backend that isolated it, or `none`. Always set. */
+  readonly backend: WorkerPlacementBackend;
   readonly command: string;
   readonly args: readonly string[];
   /** The working directory for the spawn itself; unset when the unit carries it. */
   readonly cwd?: string;
-  /** The transient unit name, only when isolated. */
+  /** The transient unit name, only under the `transient-unit` backend. */
   readonly unit?: string;
+  /** The Job Object to mint and assign this Worker to, only under `job-object`. */
+  readonly job?: WorkerJobObjectPlan;
   /**
    * Why isolation was skipped, and what the caller now carries instead. ALWAYS
    * set when `isolated` is false.
@@ -73,19 +113,29 @@ export interface WorkerPlacementPlan {
 }
 
 /**
- * Probe the host for transient-unit support.
+ * Probe the host for the backend it can actually offer.
  *
  * The systemd `--user` session is proven by its private socket under
- * `XDG_RUNTIME_DIR`, so nothing is spawned on the launch path to find out.
+ * `XDG_RUNTIME_DIR`, so nothing is spawned on the launch path to find out; the
+ * Windows arm loads the N-API addon, which is the only way to know whether the
+ * native reach this host was shipped with is really there.
  */
 export function detectWorkerPlacementProbes(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
 ): WorkerPlacementProbes {
-  if (platform !== "linux") return { platform, systemdRun: null, userSession: false };
+  if (platform === "win32") {
+    return { platform, systemdRun: null, userSession: false, jobObjects: loadJobObjectBinding({ platform }) };
+  }
+  const noJobObjects = jobObjectsUnavailable(
+    `Job Object placement is the Windows backend (platform=${platform}), so there is no native reach to load here`,
+  );
+  if (platform !== "linux") {
+    return { platform, systemdRun: null, userSession: false, jobObjects: noJobObjects };
+  }
   const runtimeDir = (env.XDG_RUNTIME_DIR ?? "").trim();
   const userSession = runtimeDir !== "" && existsSync(join(runtimeDir, "systemd", "private"));
-  return { platform, systemdRun: which("systemd-run", env), userSession };
+  return { platform, systemdRun: which("systemd-run", env), userSession, jobObjects: noJobObjects };
 }
 
 /** True unless the env kill-switch declines isolation for this host. */
@@ -101,6 +151,21 @@ export function placementEnabled(env: NodeJS.ProcessEnv = process.env): boolean 
  * Both identifiers are opaque labels the client chose, so they are slugified
  * rather than parsed — the daemon never learns what a project label means.
  */
+/**
+ * The Job Object name: `<prefix>-<project>-<worker>`.
+ *
+ * The same slugified pair as the unit name, without the `.service` suffix — a
+ * Job Object is not a unit and naming it like one would invite a reader to look
+ * for it in `systemctl`.
+ */
+export function workerJobObjectName(
+  projectLabel: string,
+  workerId: string,
+  prefix: string = DEFAULT_WORKER_UNIT_PREFIX,
+): string {
+  return workerUnitName(projectLabel, workerId, prefix).replace(/\.service$/, "");
+}
+
 export function workerUnitName(
   projectLabel: string,
   workerId: string,
@@ -142,6 +207,7 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
 
   const unisolated = (warning: string): WorkerPlacementPlan => ({
     isolated: false,
+    backend: "none",
     command: opts.command,
     args,
     cwd: opts.workspacePath,
@@ -157,6 +223,7 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
   if (opts.enabled === false) {
     return unisolated(`worker isolation disabled by ${REDSKILLED_PLACEMENT_ENV}: the Worker is charged to the daemon's own resource group`);
   }
+  if (opts.probes.platform === "win32") return planJobObjectPlacement(opts, args, declaredBudget, unisolated);
   if (opts.probes.platform !== "linux") {
     return unisolated(`transient-unit placement is the Linux backend (platform=${opts.probes.platform}): the Worker is charged to the daemon's own resource group`);
   }
@@ -186,9 +253,54 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
 
   return {
     isolated: true,
+    backend: "transient-unit",
     unit,
     command: opts.probes.systemdRun,
     args: [...unitArgs, "--", opts.command, ...args],
+  };
+}
+
+/**
+ * The Windows arm: a Job Object carrying the budget, with kill-on-close.
+ *
+ * Unlike the Linux backend, the argv is UNCHANGED — Windows has no launcher to
+ * wrap the command in, so the Worker is spawned normally and assigned to its job
+ * at birth. That is why the plan carries the job as data rather than as
+ * arguments, and why `cwd` stays the daemon's job here: there is no unit to hand
+ * the workspace to.
+ *
+ * With native reach missing the Worker still launches, and the plan says the
+ * sampling floor is now the only ceiling. That degradation is the whole reason
+ * the floor is uniform across backends (ADR 0130 rule 4).
+ */
+function planJobObjectPlacement(
+  opts: PlanWorkerPlacementOptions,
+  args: readonly string[],
+  declaredBudget: boolean,
+  unisolated: (warning: string) => WorkerPlacementPlan,
+): WorkerPlacementPlan {
+  const reach = opts.probes.jobObjects;
+  if (!reach.available) {
+    return unisolated(
+      `Job Object placement unavailable: ${reach.reason}. The Worker is charged to the daemon's own resource group ` +
+        "and the daemon's RSS sampling floor is the only remaining ceiling",
+    );
+  }
+  const limits = planJobLimits(opts.budget);
+  const name = workerJobObjectName(opts.projectLabel, opts.workerId, opts.target?.unit_prefix);
+  return {
+    isolated: true,
+    backend: "job-object",
+    command: opts.command,
+    args: [...args],
+    cwd: opts.workspacePath,
+    job: { name, limits },
+    // A budget the job could not carry is named here for the same reason an
+    // unisolated launch is: the floor still holds it, and nobody should have to
+    // discover that from the absence of a limit.
+    ...(declaredBudget && limits.note != null
+      ? { budgetWarning: `${limits.note}; the daemon's RSS sampling floor is the ceiling for that budget` }
+      : {}),
   };
 }
 

--- a/apps/redskilled/tests/windows-job-object.test.ts
+++ b/apps/redskilled/tests/windows-job-object.test.ts
@@ -1,0 +1,369 @@
+// The Windows placement backend, proven on a host that is not Windows: the
+// planner is pure over injected probes, the native reach is an injected binding,
+// and the one thing that must never happen — a silent degrade — is checked from
+// both ends (no reach at plan time, and a reach that fails at launch time).
+import { describe, expect, it } from "vitest";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import {
+  classifyJobObjectExit,
+  CPU_WEIGHT_FAIR_SHARE,
+  JOB_MEMORY_EXIT_CODES,
+  JOB_OBJECT_ADDON_BASENAME,
+  jobObjectAddonCandidates,
+  loadJobObjectBinding,
+  planJobLimits,
+  type RedskilledJobLimits,
+  type RedskilledJobObjectBinding,
+  type RedskilledJobObjectHandle,
+} from "../src/job-object.js";
+import { launchWorker } from "../src/worker-launch.js";
+import {
+  planWorkerPlacement,
+  workerJobObjectName,
+  type WorkerPlacementProbes,
+} from "../src/worker-placement.js";
+import { evaluateWorkerAdmission, UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+
+interface RecordedJob {
+  readonly name: string;
+  readonly limits: RedskilledJobLimits;
+  readonly assigned: number[];
+  closed: boolean;
+}
+
+/** A binding that records instead of reaching the kernel — the addon's whole surface. */
+function fakeBinding(behaviour: { failCreate?: string; failAssign?: string } = {}): {
+  binding: RedskilledJobObjectBinding;
+  jobs: RecordedJob[];
+} {
+  const jobs: RecordedJob[] = [];
+  const binding: RedskilledJobObjectBinding = {
+    createJobObject: ({ name, limits }) => {
+      if (behaviour.failCreate) throw new Error(behaviour.failCreate);
+      const record: RecordedJob = { name, limits, assigned: [], closed: false };
+      jobs.push(record);
+      const handle: RedskilledJobObjectHandle = {
+        name,
+        assign: (pid) => {
+          if (behaviour.failAssign) throw new Error(behaviour.failAssign);
+          record.assigned.push(pid);
+        },
+        close: () => {
+          record.closed = true;
+        },
+      };
+      return handle;
+    },
+  };
+  return { binding, jobs };
+}
+
+function windowsProbes(reach?: RedskilledJobObjectBinding): WorkerPlacementProbes {
+  return {
+    platform: "win32",
+    systemdRun: null,
+    userSession: false,
+    jobObjects: reach
+      ? { available: true, binding: reach }
+      : { available: false, reason: "no Job Object addon was found for win32-x64" },
+  };
+}
+
+function plan(probes: WorkerPlacementProbes, overrides: Record<string, unknown> = {}) {
+  return planWorkerPlacement({
+    workerId: "wQ9F2",
+    projectLabel: "acme/widgets",
+    workspacePath: "C:\\work\\acme",
+    command: "node.exe",
+    args: ["worker.js", "--issue", "2781"],
+    budget: { memory_max: "4G", cpu_weight: 50 },
+    probes,
+    ...overrides,
+  });
+}
+
+describe("windows placement — the planner resolves a Job Object from probes alone", () => {
+  it("places the Worker in a Job Object of its own, spawning nothing", () => {
+    const { binding } = fakeBinding();
+    const placement = plan(windowsProbes(binding));
+
+    expect(placement.isolated).toBe(true);
+    expect(placement.backend).toBe("job-object");
+    expect(placement.job?.name).toBe("red-worker-acme-widgets-wq9f2");
+    expect(placement.warning).toBeUndefined();
+  });
+
+  it("leaves the argv untouched: Windows has no launcher to wrap the command in", () => {
+    const { binding } = fakeBinding();
+    const placement = plan(windowsProbes(binding));
+
+    expect(placement.command).toBe("node.exe");
+    expect(placement.args).toEqual(["worker.js", "--issue", "2781"]);
+    expect(placement.cwd).toBe("C:\\work\\acme");
+    expect(placement.unit).toBeUndefined();
+  });
+
+  it("carries the memory budget into the job as a byte ceiling, naming the budget", () => {
+    const { binding } = fakeBinding();
+    const limits = plan(windowsProbes(binding)).job?.limits;
+
+    expect(limits?.memory_limit_bytes).toBe(4 * 1024 ** 3);
+    expect(limits?.memory_budget_name).toBe("MemoryMax");
+    expect(limits?.memory_budget_declared).toBe("4G");
+  });
+
+  it("names the Job Object like the unit, without pretending it is one", () => {
+    expect(workerJobObjectName("Acme/Widgets.git", "wQ9F2/2781")).toBe("red-worker-acme-widgets-git-wq9f2-2781");
+    expect(workerJobObjectName("p", "w", "red-gate")).toBe("red-gate-p-w");
+    expect(workerJobObjectName("p", "w").endsWith(".service")).toBe(false);
+  });
+});
+
+describe("windows placement — kill-on-close", () => {
+  it("sets kill-on-close on every job it plans, budget or no budget", () => {
+    const { binding } = fakeBinding();
+    for (const budget of [undefined, {}, { memory_max: "1G" }, { cpu_weight: 10 }]) {
+      expect(plan(windowsProbes(binding), { budget }).job?.limits.kill_on_close).toBe(true);
+    }
+  });
+
+  it("assigns the live Worker to the job it planned, so nothing outlives it", () => {
+    const { binding, jobs } = fakeBinding();
+    const launched = launchWorker({
+      admission: evaluateWorkerAdmission({ ceiling: UNBOUNDED_HOST_CEILING, workers: [] }),
+      spec: {
+        project_label: "acme/widgets",
+        workspace_path: "C:\\work\\acme",
+        command: "node.exe",
+        budget: { memory_max: "2G" },
+      },
+      probes: windowsProbes(binding),
+      spawnFn: () => ({ pid: 7331, once: () => undefined, unref: () => undefined }) as never,
+    });
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]!.limits.kill_on_close).toBe(true);
+    expect(jobs[0]!.assigned).toEqual([7331]);
+    expect(launched.worker.isolated).toBe(true);
+    expect(launched.warnings).toEqual([]);
+    expect(launched.job?.name).toBe(jobs[0]!.name);
+  });
+
+  it("holds the job for the Worker's life and closes it when the Worker is gone", () => {
+    const { binding, jobs } = fakeBinding();
+    const handlers: Array<(code: number | null, signal: null) => void> = [];
+    launchWorker({
+      admission: evaluateWorkerAdmission({ ceiling: UNBOUNDED_HOST_CEILING, workers: [] }),
+      spec: { project_label: "acme", workspace_path: "C:\\work", command: "node.exe" },
+      probes: windowsProbes(binding),
+      spawnFn: () =>
+        ({
+          pid: 4242,
+          once: (event: string, handler: (code: number | null, signal: null) => void) => {
+            if (event === "exit") handlers.push(handler);
+          },
+          unref: () => undefined,
+        }) as never,
+    });
+
+    expect(jobs[0]!.closed).toBe(false);
+    for (const handler of handlers) handler(0, null);
+    expect(jobs[0]!.closed).toBe(true);
+  });
+});
+
+describe("windows placement — a kernel kill names the budget it broke", () => {
+  const worker: RedskilledWorkerView = {
+    worker_id: "w-1",
+    project_label: "acme/widgets",
+    pid: 7331,
+    started_at: "2026-07-29T00:00:00.000Z",
+    workspace_path: "C:\\work\\acme",
+    isolated: true,
+    budget: { memory_max: "2G" },
+    warnings: [],
+  };
+  const limits = planJobLimits(worker.budget);
+
+  it("reads a memory-limit death as a budget termination, not a stall", () => {
+    const outcome = classifyJobObjectExit({
+      worker,
+      jobName: "red-worker-acme-widgets-w-1",
+      limits,
+      exitCode: 0xc0000017,
+    });
+
+    expect(outcome?.outcome).toBe("terminated-over-memory-budget");
+    expect(outcome?.classification).toBe("budget-exceeded");
+    expect(outcome?.stall).toBe(false);
+    expect(outcome?.enforced_by).toBe("job-object");
+    expect(outcome?.budget_name).toBe("MemoryMax");
+    expect(outcome?.budget_declared).toBe("2G");
+    expect(outcome?.budget_bytes).toBe(2 * 1024 ** 3);
+    expect(outcome?.exit_status).toBe("STATUS_NO_MEMORY");
+    expect(outcome?.reason).toContain("MemoryMax budget of 2G");
+    expect(outcome?.reason).toContain("not a stall");
+    expect(outcome?.workspace_path).toBe("C:\\work\\acme");
+    expect(outcome?.reason).toContain(JSON.stringify("C:\\work\\acme"));
+  });
+
+  it("claims every documented job-memory status, and only those", () => {
+    for (const code of Object.keys(JOB_MEMORY_EXIT_CODES).map(Number)) {
+      expect(classifyJobObjectExit({ worker, jobName: "j", limits, exitCode: code })).not.toBeNull();
+    }
+    for (const code of [0, 1, 137, null]) {
+      expect(classifyJobObjectExit({ worker, jobName: "j", limits, exitCode: code })).toBeNull();
+    }
+  });
+
+  it("attributes nothing to a job that carried no memory ceiling", () => {
+    const noCeiling = planJobLimits({ cpu_weight: 10 });
+
+    expect(classifyJobObjectExit({ worker, jobName: "j", limits: noCeiling, exitCode: 0xc0000017 })).toBeNull();
+  });
+});
+
+describe("windows placement — the budget the job cannot carry is named, never assumed", () => {
+  it("caps CPU only for a weight below the fair share, and says why when it does not", () => {
+    expect(planJobLimits({ cpu_weight: 25 }).cpu_rate_percent).toBe(25);
+    expect(planJobLimits({ cpu_weight: CPU_WEIGHT_FAIR_SHARE }).cpu_rate_percent).toBeUndefined();
+    expect(planJobLimits({ cpu_weight: 400 }).note).toMatch(/absolute cap rather than a share/);
+  });
+
+  it("says the memory budget it could not reduce to bytes is now the floor's problem", () => {
+    const { binding } = fakeBinding();
+    const placement = plan(windowsProbes(binding), { budget: { memory_max: "50%" } });
+
+    expect(placement.job?.limits.memory_limit_bytes).toBeUndefined();
+    expect(placement.budgetWarning).toMatch(/sampling floor/);
+  });
+});
+
+describe("windows placement — degrading to the sampling floor is explicit", () => {
+  it("names the missing native reach when the addon is not there", () => {
+    const placement = plan(windowsProbes());
+
+    expect(placement.isolated).toBe(false);
+    expect(placement.backend).toBe("none");
+    expect(placement.job).toBeUndefined();
+    expect(placement.warning).toMatch(/Job Object placement unavailable/);
+    expect(placement.warning).toMatch(/no Job Object addon was found/);
+    expect(placement.warning).toMatch(/sampling floor is the only remaining ceiling/);
+    expect(placement.budgetWarning).toMatch(/cannot enforce it/);
+  });
+
+  it("still launches when the addon refuses to mint the job, and says the floor is the ceiling", () => {
+    const { binding, jobs } = fakeBinding({ failCreate: "ERROR_ACCESS_DENIED" });
+    const launched = launchWorker({
+      admission: evaluateWorkerAdmission({ ceiling: UNBOUNDED_HOST_CEILING, workers: [] }),
+      spec: { project_label: "acme", workspace_path: "C:\\work", command: "node.exe", budget: { memory_max: "1G" } },
+      probes: windowsProbes(binding),
+      spawnFn: () => ({ pid: 4242, once: () => undefined, unref: () => undefined }) as never,
+    });
+
+    expect(jobs).toHaveLength(0);
+    expect(launched.worker.pid).toBe(4242);
+    expect(launched.worker.isolated).toBe(false);
+    expect(launched.job).toBeUndefined();
+    expect(launched.warnings.join(" ")).toMatch(/could not be created: ERROR_ACCESS_DENIED/);
+    expect(launched.warnings.join(" ")).toMatch(/sampling floor/);
+  });
+
+  it("closes a job it could not put the Worker into rather than leaving it armed", () => {
+    const { binding, jobs } = fakeBinding({ failAssign: "ERROR_ACCESS_DENIED" });
+    const launched = launchWorker({
+      admission: evaluateWorkerAdmission({ ceiling: UNBOUNDED_HOST_CEILING, workers: [] }),
+      spec: { project_label: "acme", workspace_path: "C:\\work", command: "node.exe" },
+      probes: windowsProbes(binding),
+      spawnFn: () => ({ pid: 4242, once: () => undefined, unref: () => undefined }) as never,
+    });
+
+    expect(jobs[0]!.closed).toBe(true);
+    expect(launched.worker.isolated).toBe(false);
+    expect(launched.warnings.join(" ")).toMatch(/could not be assigned to Job Object/);
+  });
+
+  it("honours the host kill-switch and an `inherit` client on Windows too", () => {
+    const { binding } = fakeBinding();
+    expect(plan(windowsProbes(binding), { enabled: false }).isolated).toBe(false);
+    expect(plan(windowsProbes(binding), { target: { isolation: "inherit" } }).isolated).toBe(false);
+    expect(plan(windowsProbes(binding), { target: { isolation: "job-object" } }).backend).toBe("job-object");
+    // A client naming the Linux backend still gets isolated: the target says
+    // "isolate me", and the host decides which backend that is.
+    expect(plan(windowsProbes(binding), { target: { isolation: "transient-unit" } }).backend).toBe("job-object");
+  });
+});
+
+describe("windows placement — loading the native reach never throws", () => {
+  const ROOT = "C:\\app\\redskilled";
+
+  it("looks for a prebuild for this platform and architecture, then a local build", () => {
+    expect(jobObjectAddonCandidates("win32", "x64", ROOT)).toEqual([
+      `${ROOT}/prebuilds/win32-x64/${JOB_OBJECT_ADDON_BASENAME}`.replaceAll("/", pathSep()),
+      `${ROOT}/native/build/Release/${JOB_OBJECT_ADDON_BASENAME}`.replaceAll("/", pathSep()),
+    ]);
+  });
+
+  it("refuses with the paths it looked in when no artifact matches the host", () => {
+    const reach = loadJobObjectBinding({ platform: "win32", arch: "arm64", packageRoot: ROOT, exists: () => false });
+
+    expect(reach.available).toBe(false);
+    expect(reach.available === false && reach.reason).toMatch(/win32-arm64/);
+    expect(reach.available === false && reach.reason).toMatch(/prebuilds/);
+  });
+
+  it("refuses rather than throwing when the artifact is there but will not load", () => {
+    const reach = loadJobObjectBinding({
+      platform: "win32",
+      arch: "x64",
+      packageRoot: ROOT,
+      exists: () => true,
+      requireFn: () => {
+        throw new Error("The specified module could not be found.");
+      },
+    });
+
+    expect(reach.available === false && reach.reason).toMatch(/could not be loaded/);
+  });
+
+  it("refuses an artifact that loads but is not the binding", () => {
+    const reach = loadJobObjectBinding({
+      platform: "win32",
+      arch: "x64",
+      packageRoot: ROOT,
+      exists: () => true,
+      requireFn: () => ({ somethingElse: true }),
+    });
+
+    expect(reach.available === false && reach.reason).toMatch(/does not export createJobObject/);
+  });
+
+  it("accepts an artifact that exports createJobObject", () => {
+    const { binding } = fakeBinding();
+    const reach = loadJobObjectBinding({
+      platform: "win32",
+      arch: "x64",
+      packageRoot: ROOT,
+      exists: () => true,
+      requireFn: () => binding,
+    });
+
+    expect(reach.available).toBe(true);
+  });
+
+  it("says off Windows that there is no native reach to load, without reading the disk", () => {
+    for (const platform of ["linux", "darwin"] as const) {
+      const reach = loadJobObjectBinding({
+        platform,
+        exists: () => {
+          throw new Error("the disk must not be read here");
+        },
+      });
+      expect(reach.available === false && reach.reason).toContain(`platform=${platform}`);
+    }
+  });
+});
+
+function pathSep(): string {
+  return process.platform === "win32" ? "\\" : "/";
+}

--- a/apps/redskilled/tests/worker-birth.test.ts
+++ b/apps/redskilled/tests/worker-birth.test.ts
@@ -146,6 +146,7 @@ describe("the daemon accepts the workspace path as given", () => {
     platform: "linux",
     systemdRun: "/usr/bin/systemd-run",
     userSession: true,
+    jobObjects: { available: false, reason: "not Windows" },
   };
 
   it("never reads a repository marker to decide where the Worker runs", () => {
@@ -179,7 +180,12 @@ describe("the daemon accepts the workspace path as given", () => {
     // directory a client named.
     const probes = detectWorkerPlacementProbes({ PATH: "", XDG_RUNTIME_DIR: "" }, "linux");
 
-    expect(probes).toEqual({ platform: "linux", systemdRun: null, userSession: false });
+    expect(probes).toEqual({
+      platform: "linux",
+      systemdRun: null,
+      userSession: false,
+      jobObjects: { available: false, reason: expect.stringContaining("Windows backend") },
+    });
   });
 
   it("rejects a spec with no workspace at all rather than inventing one", () => {

--- a/apps/redskilled/tests/worker-placement.test.ts
+++ b/apps/redskilled/tests/worker-placement.test.ts
@@ -12,22 +12,32 @@ import {
   type WorkerPlacementProbes,
 } from "../src/worker-placement.js";
 
+const NO_JOB_OBJECTS = { available: false, reason: "Job Object placement is the Windows backend (platform=linux)" } as const;
+
 const LINUX_WITH_SESSION: WorkerPlacementProbes = {
   platform: "linux",
   systemdRun: "/usr/bin/systemd-run",
   userSession: true,
+  jobObjects: NO_JOB_OBJECTS,
 };
 const LINUX_WITHOUT_SESSION: WorkerPlacementProbes = {
   platform: "linux",
   systemdRun: "/usr/bin/systemd-run",
   userSession: false,
+  jobObjects: NO_JOB_OBJECTS,
 };
 const LINUX_WITHOUT_SYSTEMD: WorkerPlacementProbes = {
   platform: "linux",
   systemdRun: null,
   userSession: false,
+  jobObjects: NO_JOB_OBJECTS,
 };
-const DARWIN: WorkerPlacementProbes = { platform: "darwin", systemdRun: null, userSession: false };
+const DARWIN: WorkerPlacementProbes = {
+  platform: "darwin",
+  systemdRun: null,
+  userSession: false,
+  jobObjects: { available: false, reason: "Job Object placement is the Windows backend (platform=darwin)" },
+};
 
 function plan(probes: WorkerPlacementProbes, overrides: Record<string, unknown> = {}) {
   return planWorkerPlacement({


### PR DESCRIPTION
Automated AFK landing for #2781. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2781

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787942218&installation_model_id=20659&pr_number=2817&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2817&signature=0754f3477988bd3f7e0b87057f07e065557b9e3dcac350302c71e21085b40ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->