### PR TITLE
chore: #2785 /go takes the next slot without killing a live Worker

### DIFF
--- a/apps/redskilled/src/demand-producer.ts
+++ b/apps/redskilled/src/demand-producer.ts
@@ -26,6 +26,16 @@
  * surface, never a queue to drain.
  */
 import type { RedskilledHostEvent } from "./event-lane.js";
+import {
+  expireLapsedReservations,
+  heldBackReason,
+  INTERACTIVE_RESERVATION_TTL_MS,
+  NO_INTERACTIVE_RESERVATIONS,
+  releaseInteractiveSlot,
+  reserveInteractiveSlot,
+  reservedSlotCount,
+  type InteractiveReservationState,
+} from "./interactive-reservation.js";
 import type { RedskilledWorkerStarted } from "./protocol.js";
 import {
   isSelectorParked,
@@ -50,6 +60,12 @@ import type { RedskilledWorkerSpec } from "./worker-launch.js";
 export interface DemandSelector {
   readonly selector_id: string;
   readonly desired: number;
+  /**
+   * Whether this selector carries interactive work. An interactive selector may
+   * spend a slot reserved for it; an autonomous one is held back from it, which
+   * is the whole of soft preemption — see `interactive-reservation.ts`.
+   */
+  readonly interactive?: boolean;
   /** Builds the spec for one Worker; the runner directive arrives as data. */
   readonly spec: (input: { readonly index: number; readonly runner: string | null }) => RedskilledWorkerSpec;
 }
@@ -68,6 +84,8 @@ export interface SkippedSelector {
 export interface DemandPlan {
   readonly requests: readonly DemandRequest[];
   readonly skipped: readonly SkippedSelector[];
+  /** Autonomous selectors that had room but yielded it to a reservation. */
+  readonly held_back: readonly SkippedSelector[];
 }
 
 export interface PlanProjectDemandInput {
@@ -80,6 +98,8 @@ export interface PlanProjectDemandInput {
   readonly breaker: ProjectBreakerState;
   readonly nowMs: number;
   readonly runner: string | null;
+  /** Slots claimed by interactive dispatches; withheld from autonomous demand. */
+  readonly reserved?: number;
 }
 
 /**
@@ -89,11 +109,17 @@ export interface PlanProjectDemandInput {
  * selector takes what it wants, and a lower one gets whatever room survives —
  * possibly none. That is the property a share-based split would lose, and the
  * reason one producer can serve every selector without them racing. PURE.
+ *
+ * A reservation narrows that budget for autonomous selectors only, so the next
+ * slot the machine frees goes to the interactive dispatch. **Nothing here can
+ * end a Worker**: the planner's only output is births it declines to ask for.
  */
 export function planProjectDemand(input: PlanProjectDemandInput): DemandPlan {
   const requests: DemandRequest[] = [];
   const skipped: SkippedSelector[] = [];
+  const heldBack: SkippedSelector[] = [];
   let room = Math.max(0, input.target - input.live);
+  let reserved = Math.max(0, input.reserved ?? 0);
 
   for (const selector of input.selectors) {
     if (isSelectorParked(input.breaker, selector.selector_id, input.nowMs)) {
@@ -104,21 +130,37 @@ export function planProjectDemand(input: PlanProjectDemandInput): DemandPlan {
       });
       continue;
     }
-    for (let index = 0; index < selector.desired && room > 0; index += 1) {
+    const interactive = selector.interactive === true;
+    let taken = 0;
+    for (let index = 0; index < selector.desired; index += 1) {
+      // An autonomous selector may only spend room that no reservation claims.
+      const affordable = interactive ? room : room - reserved;
+      if (affordable <= 0) break;
       requests.push({
         selector_id: selector.selector_id,
         index,
         spec: selector.spec({ index, runner: input.runner }),
       });
       room -= 1;
+      taken += 1;
+      // The interactive dispatch spends the slot that was being kept for it.
+      if (interactive && reserved > 0) reserved -= 1;
+    }
+    if (!interactive && taken < selector.desired && reserved > 0 && room > 0) {
+      heldBack.push({ selector_id: selector.selector_id, reason: heldBackReason(reserved) });
     }
   }
-  return { requests, skipped };
+  return { requests, skipped, held_back: heldBack };
 }
 
 /** What the producer tells its host about, in order, as a tick unfolds. */
 export interface DemandLifecycleEvent {
-  readonly event: "worker-granted" | "worker-refused" | "selector-parked" | "tick-complete";
+  readonly event:
+    | "worker-granted"
+    | "worker-refused"
+    | "selector-parked"
+    | "selector-held-back"
+    | "tick-complete";
   readonly project_label: string;
   readonly selector_id: string | null;
   readonly worker_id: string | null;
@@ -144,6 +186,9 @@ export interface DemandProductionResult {
   /** The host's own words for the refusal that ended the tick, if one did. */
   readonly refusal: string | null;
   readonly skipped: readonly SkippedSelector[];
+  readonly held_back: readonly SkippedSelector[];
+  /** Slots this tick kept for interactive dispatches, after lapses were dropped. */
+  readonly reserved: number;
   readonly runner: string | null;
 }
 
@@ -163,6 +208,8 @@ export interface DemandProducerOptions {
   readonly reconcileClaims?: (deaths: readonly WorkerDeathReport[]) => Promise<void> | void;
   readonly onLifecycle?: (event: DemandLifecycleEvent) => Promise<void> | void;
   readonly breakerConfig?: ProjectBreakerConfig;
+  /** How long an unwithdrawn interactive reservation survives. */
+  readonly reservationTtlMs?: number;
   readonly clock?: () => number;
 }
 
@@ -174,6 +221,15 @@ export interface DemandProducer {
   reportDeath(report: WorkerDeathReport): void;
   /** A Worker of this selector is working — the half-open circuit closes. */
   reportSurvival(selectorId: string): void;
+  /**
+   * Claim the next slot for an interactive dispatch. Autonomous demand is held
+   * back from that slot; **no live Worker is terminated to free it**.
+   */
+  reserveInteractive(input: { readonly reservation_id: string; readonly reason?: string | null }): void;
+  /** Withdraw a claim, so a slot cannot be held past the request that wanted it. */
+  releaseInteractive(reservationId: string): void;
+  /** The claims still standing, lapsed ones already dropped. */
+  reservations(): InteractiveReservationState;
   breakerState(): ProjectBreakerState;
   /** Releases the project's producer slot; a new producer may then be created. */
   close(): void;
@@ -205,7 +261,9 @@ export function createDemandProducer(options: DemandProducerOptions): DemandProd
 
   const clock = options.clock ?? (() => Date.now());
   const breakerConfig = options.breakerConfig ?? PROJECT_BREAKER_DEFAULTS;
+  const reservationTtlMs = options.reservationTtlMs ?? INTERACTIVE_RESERVATION_TTL_MS;
   let breaker: ProjectBreakerState = {};
+  let reserved: InteractiveReservationState = NO_INTERACTIVE_RESERVATIONS;
   let pendingDeaths: WorkerDeathReport[] = [];
   let ticking = false;
 
@@ -231,6 +289,23 @@ export function createDemandProducer(options: DemandProducerOptions): DemandProd
       breaker = recordWorkerSurvival(breaker, selectorId);
     },
 
+    reserveInteractive(input) {
+      reserved = reserveInteractiveSlot(reserved, {
+        reservation_id: input.reservation_id,
+        at_ms: clock(),
+        reason: input.reason ?? null,
+      });
+    },
+
+    releaseInteractive(reservationId) {
+      reserved = releaseInteractiveSlot(reserved, reservationId);
+    },
+
+    reservations() {
+      reserved = expireLapsedReservations(reserved, clock(), reservationTtlMs);
+      return reserved;
+    },
+
     breakerState() {
       return breaker;
     },
@@ -253,13 +328,18 @@ export function createDemandProducer(options: DemandProducerOptions): DemandProd
         const runner = (await options.resolveRunnerDirective?.()) ?? null;
         const live = (await options.liveWorkers?.()) ?? 0;
 
+        const nowMs = clock();
+        reserved = expireLapsedReservations(reserved, nowMs, reservationTtlMs);
+        const reservedSlots = reservedSlotCount(reserved, nowMs, reservationTtlMs);
+
         const plan = planProjectDemand({
           selectors: options.selectors,
           live,
           target,
           breaker,
-          nowMs: clock(),
+          nowMs,
           runner,
+          reserved: reservedSlots,
         });
         for (const skip of plan.skipped) {
           await emit({
@@ -268,6 +348,15 @@ export function createDemandProducer(options: DemandProducerOptions): DemandProd
             selector_id: skip.selector_id,
             worker_id: null,
             detail: skip.reason,
+          });
+        }
+        for (const held of plan.held_back) {
+          await emit({
+            event: "selector-held-back",
+            project_label: options.projectLabel,
+            selector_id: held.selector_id,
+            worker_id: null,
+            detail: held.reason,
           });
         }
 
@@ -315,6 +404,8 @@ export function createDemandProducer(options: DemandProducerOptions): DemandProd
           shortfall: plan.requests.length - granted.length,
           refusal,
           skipped: plan.skipped,
+          held_back: plan.held_back,
+          reserved: reservedSlots,
           runner,
         };
         await emit({
@@ -387,4 +478,4 @@ async function callQuietly(fn: (() => Promise<unknown> | unknown) | undefined): 
   }
 }
 
-export type { ProjectBreakerState, WorkerDeathReport };
+export type { InteractiveReservationState, ProjectBreakerState, WorkerDeathReport };

--- a/apps/redskilled/src/interactive-reservation.ts
+++ b/apps/redskilled/src/interactive-reservation.ts
@@ -1,0 +1,123 @@
+/**
+ * interactive-reservation — how a one-off dispatch takes the next slot without
+ * killing anything.
+ *
+ * A ticket-slicing run can queue days of autonomous work, so an interactive
+ * request that waits behind it waits for days. The cure is **soft preemption**:
+ * the project reserves the next slot by *declining to admit the next queued
+ * birth* — it holds room back from autonomous demand and lets the interactive
+ * selector take the slot the next natural death frees. Nothing in flight is lost
+ * to impatience, and the cost is bounded to one Worker's remaining run.
+ *
+ * There is deliberately no kill path here, and none anywhere on the producer's
+ * side: **a reservation removes future births, never present Workers.** A
+ * reservation that could terminate a live Worker would trade a bounded wait for
+ * an unbounded loss of work, which is the opposite of the bargain.
+ *
+ * The policy lives in the project because deciding whose work matters is
+ * repository knowledge and the daemon holds none (ADR 0130). The daemon sees
+ * only that fewer Workers were asked for this tick.
+ *
+ * Every function here is PURE: state in, state out.
+ */
+
+/** One outstanding claim on the next free slot. */
+export interface InteractiveReservation {
+  readonly reservation_id: string;
+  /** When the claim was first made. A renewal does not move it — see below. */
+  readonly reserved_at_ms: number;
+  readonly reason: string | null;
+}
+
+export interface InteractiveReservationState {
+  readonly reservations: readonly InteractiveReservation[];
+}
+
+/**
+ * How long an unclaimed reservation survives before it lapses.
+ *
+ * A withdrawal is the intended release, but a caller that dies mid-request
+ * never withdraws, so the hold also expires on its own. Without the lapse a
+ * crashed client would keep a slot empty for as long as the project runs.
+ */
+export const INTERACTIVE_RESERVATION_TTL_MS = 5 * 60_000;
+
+export const NO_INTERACTIVE_RESERVATIONS: InteractiveReservationState = { reservations: [] };
+
+/**
+ * Claim the next free slot for an interactive dispatch.
+ *
+ * Re-reserving an id already held is idempotent and **keeps the original
+ * timestamp**: a client that renewed on a timer could otherwise hold a slot
+ * forever, which is exactly the indefinite hold the lapse exists to prevent.
+ */
+export function reserveInteractiveSlot(
+  state: InteractiveReservationState,
+  input: { readonly reservation_id: string; readonly at_ms: number; readonly reason?: string | null },
+): InteractiveReservationState {
+  if (state.reservations.some((held) => held.reservation_id === input.reservation_id)) return state;
+  return {
+    reservations: [
+      ...state.reservations,
+      {
+        reservation_id: input.reservation_id,
+        reserved_at_ms: input.at_ms,
+        reason: input.reason ?? null,
+      },
+    ],
+  };
+}
+
+/**
+ * Withdraw a claim — the request was served, cancelled, or abandoned.
+ *
+ * Releasing an id that is not held is not an error: a withdrawal races the
+ * lapse, and a caller that had to know which of the two won would have to hold
+ * the producer's clock.
+ */
+export function releaseInteractiveSlot(
+  state: InteractiveReservationState,
+  reservationId: string,
+): InteractiveReservationState {
+  const kept = state.reservations.filter((held) => held.reservation_id !== reservationId);
+  return kept.length === state.reservations.length ? state : { reservations: kept };
+}
+
+/** Drop every reservation whose hold has run out. */
+export function expireLapsedReservations(
+  state: InteractiveReservationState,
+  nowMs: number,
+  ttlMs: number = INTERACTIVE_RESERVATION_TTL_MS,
+): InteractiveReservationState {
+  const kept = state.reservations.filter((held) => !hasLapsed(held, nowMs, ttlMs));
+  return kept.length === state.reservations.length ? state : { reservations: kept };
+}
+
+/** How many slots are held back from autonomous demand right now. */
+export function reservedSlotCount(
+  state: InteractiveReservationState,
+  nowMs: number,
+  ttlMs: number = INTERACTIVE_RESERVATION_TTL_MS,
+): number {
+  return state.reservations.filter((held) => !hasLapsed(held, nowMs, ttlMs)).length;
+}
+
+/** Whether this specific claim is still standing. */
+export function isReservationHeld(
+  state: InteractiveReservationState,
+  reservationId: string,
+  nowMs: number,
+  ttlMs: number = INTERACTIVE_RESERVATION_TTL_MS,
+): boolean {
+  const held = state.reservations.find((entry) => entry.reservation_id === reservationId);
+  return held != null && !hasLapsed(held, nowMs, ttlMs);
+}
+
+/** The words a held-back selector is skipped with, for the lifecycle lane. */
+export function heldBackReason(reserved: number): string {
+  return `${reserved} slot(s) held back for an interactive dispatch; no live Worker was terminated to make room`;
+}
+
+function hasLapsed(held: InteractiveReservation, nowMs: number, ttlMs: number): boolean {
+  return nowMs - held.reserved_at_ms >= ttlMs;
+}

--- a/apps/redskilled/tests/interactive-reservation.test.ts
+++ b/apps/redskilled/tests/interactive-reservation.test.ts
@@ -1,0 +1,319 @@
+// Interactive work stops queueing behind autonomous work — and it buys that
+// with a held-back birth, never with a killed Worker. These tests pin both
+// halves: the interactive dispatch is served ahead of a full queue, and nothing
+// in flight is terminated to make room for it.
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  closeAllDemandProducers,
+  createDemandProducer,
+  planProjectDemand,
+  type DemandSelector,
+} from "../src/demand-producer.js";
+import {
+  expireLapsedReservations,
+  INTERACTIVE_RESERVATION_TTL_MS,
+  isReservationHeld,
+  NO_INTERACTIVE_RESERVATIONS,
+  releaseInteractiveSlot,
+  reservedSlotCount,
+  reserveInteractiveSlot,
+} from "../src/interactive-reservation.js";
+import type { RedskilledAdmissionVerdict } from "../src/admission.js";
+import type { RedskilledWorkerSpec } from "../src/worker-launch.js";
+import type { RedskilledWorkerStarted } from "../src/protocol.js";
+
+afterEach(() => {
+  closeAllDemandProducers();
+});
+
+function selector(id: string, desired: number, interactive = false): DemandSelector {
+  return {
+    selector_id: id,
+    desired,
+    interactive,
+    spec: ({ index }) => ({
+      project_label: "acme/widgets",
+      workspace_path: `/tmp/acme/${id}-${index}`,
+      command: "/bin/true",
+      args: [],
+    }),
+  };
+}
+
+const ADMITTED: RedskilledAdmissionVerdict = {
+  version: 1,
+  admitted: true,
+  verdict: "admitted",
+  reason: "redskilled admitted this Worker",
+  ceiling: { memory_bytes: null, worker_count: null, source: "declared" },
+  consumption: { worker_count: 0, memory_bytes: 0, unaccounted_workers: [] },
+  requested_memory_bytes: null,
+  projected_worker_count: 1,
+  projected_memory_bytes: 0,
+};
+
+/** A host that grants everything it is asked for, and records what that was. */
+function generousHost(): {
+  start: (spec: RedskilledWorkerSpec) => Promise<RedskilledWorkerStarted>;
+  seen: RedskilledWorkerSpec[];
+} {
+  const seen: RedskilledWorkerSpec[] = [];
+  let served = 0;
+  return {
+    seen,
+    start: async (spec) => {
+      seen.push(spec);
+      served += 1;
+      return {
+        worker: {
+          worker_id: `w-${served}`,
+          project_label: spec.project_label,
+          pid: 1000 + served,
+          started_at: new Date(served * 1000).toISOString(),
+          workspace_path: spec.workspace_path,
+        },
+        admission: ADMITTED,
+        warnings: [],
+      } as unknown as RedskilledWorkerStarted;
+    },
+  };
+}
+
+describe("interactive reservation state", () => {
+  it("holds a slot until the request is withdrawn", () => {
+    let state = reserveInteractiveSlot(NO_INTERACTIVE_RESERVATIONS, { reservation_id: "go-1", at_ms: 0 });
+    expect(reservedSlotCount(state, 0)).toBe(1);
+    expect(isReservationHeld(state, "go-1", 0)).toBe(true);
+
+    state = releaseInteractiveSlot(state, "go-1");
+    expect(reservedSlotCount(state, 0)).toBe(0);
+    expect(isReservationHeld(state, "go-1", 0)).toBe(false);
+  });
+
+  it("is idempotent and does not let a renewal extend the hold", () => {
+    const first = reserveInteractiveSlot(NO_INTERACTIVE_RESERVATIONS, { reservation_id: "go-1", at_ms: 0 });
+    const renewed = reserveInteractiveSlot(first, { reservation_id: "go-1", at_ms: 4_000 });
+    expect(renewed).toBe(first);
+    expect(reservedSlotCount(renewed, INTERACTIVE_RESERVATION_TTL_MS)).toBe(0);
+  });
+
+  it("lapses a hold whose caller never came back, so a slot is never held forever", () => {
+    const state = reserveInteractiveSlot(NO_INTERACTIVE_RESERVATIONS, { reservation_id: "go-1", at_ms: 0 });
+    expect(reservedSlotCount(state, INTERACTIVE_RESERVATION_TTL_MS - 1)).toBe(1);
+    expect(reservedSlotCount(state, INTERACTIVE_RESERVATION_TTL_MS)).toBe(0);
+    expect(expireLapsedReservations(state, INTERACTIVE_RESERVATION_TTL_MS).reservations).toEqual([]);
+  });
+
+  it("treats withdrawing an unheld id as a no-op, because withdrawal races the lapse", () => {
+    expect(releaseInteractiveSlot(NO_INTERACTIVE_RESERVATIONS, "never-held")).toBe(NO_INTERACTIVE_RESERVATIONS);
+  });
+});
+
+describe("planning under a reservation", () => {
+  it("withholds the last slot from autonomous demand", () => {
+    const plan = planProjectDemand({
+      selectors: [selector("afk", 4)],
+      live: 2,
+      target: 3,
+      breaker: {},
+      nowMs: 0,
+      runner: null,
+      reserved: 1,
+    });
+    expect(plan.requests).toHaveLength(0);
+    expect(plan.held_back.map((held) => held.selector_id)).toEqual(["afk"]);
+    expect(plan.held_back[0]?.reason).toContain("no live Worker was terminated");
+  });
+
+  it("serves the interactive dispatch out of the slot it reserved", () => {
+    const plan = planProjectDemand({
+      selectors: [selector("go", 1, true), selector("afk", 4)],
+      live: 2,
+      target: 3,
+      breaker: {},
+      nowMs: 0,
+      runner: null,
+      reserved: 1,
+    });
+    expect(plan.requests.map((request) => request.selector_id)).toEqual(["go"]);
+    // The reservation was spent, not double-counted: with no room left there is
+    // nothing to hold back and nothing to report.
+    expect(plan.held_back).toEqual([]);
+  });
+
+  it("leaves autonomous demand whole once the reservation is withdrawn", () => {
+    const plan = planProjectDemand({
+      selectors: [selector("afk", 4)],
+      live: 0,
+      target: 3,
+      breaker: {},
+      nowMs: 0,
+      runner: null,
+      reserved: 0,
+    });
+    expect(plan.requests).toHaveLength(3);
+    expect(plan.held_back).toEqual([]);
+  });
+
+  it("holds back only the reserved slots, not the whole budget", () => {
+    const plan = planProjectDemand({
+      selectors: [selector("afk", 4)],
+      live: 0,
+      target: 3,
+      breaker: {},
+      nowMs: 0,
+      runner: null,
+      reserved: 1,
+    });
+    expect(plan.requests.map((request) => request.index)).toEqual([0, 1]);
+    expect(plan.held_back.map((held) => held.selector_id)).toEqual(["afk"]);
+  });
+
+  it("never asks for a negative number of Workers when the reservation exceeds the room", () => {
+    const plan = planProjectDemand({
+      selectors: [selector("afk", 4)],
+      live: 3,
+      target: 3,
+      breaker: {},
+      nowMs: 0,
+      runner: null,
+      reserved: 5,
+    });
+    expect(plan.requests).toEqual([]);
+  });
+});
+
+describe("a producer serving an interactive dispatch", () => {
+  it("gives the next free slot to the interactive selector, ahead of the queue", async () => {
+    const host = generousHost();
+    let live = 3;
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("go", 1, true), selector("afk", 10)],
+      startWorker: host.start,
+      liveWorkers: () => live,
+      resolveElasticTarget: () => 3,
+      clock: () => 0,
+    });
+
+    // A full machine with days of queued autonomous work.
+    producer.reserveInteractive({ reservation_id: "go-1", reason: "one-off dispatch" });
+    const full = await producer.produce();
+    expect(full.granted).toEqual([]);
+    expect(full.reserved).toBe(1);
+    expect(host.seen).toHaveLength(0);
+
+    // A Worker finishes on its own; the freed slot goes to the interactive work.
+    live = 2;
+    const served = await producer.produce();
+    expect(served.granted.map((worker) => worker.selector_id)).toEqual(["go"]);
+    expect(host.seen).toHaveLength(1);
+  });
+
+  it("returns the slot to autonomous demand when the request is withdrawn", async () => {
+    const host = generousHost();
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("afk", 10)],
+      startWorker: host.start,
+      liveWorkers: () => 2,
+      resolveElasticTarget: () => 3,
+      clock: () => 0,
+    });
+
+    producer.reserveInteractive({ reservation_id: "go-1" });
+    expect((await producer.produce()).granted).toEqual([]);
+
+    producer.releaseInteractive("go-1");
+    const after = await producer.produce();
+    expect(after.reserved).toBe(0);
+    expect(after.granted.map((worker) => worker.selector_id)).toEqual(["afk"]);
+  });
+
+  it("releases a hold whose caller never withdrew, so the queue always resumes", async () => {
+    const host = generousHost();
+    let nowMs = 0;
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("afk", 10)],
+      startWorker: host.start,
+      liveWorkers: () => 2,
+      resolveElasticTarget: () => 3,
+      reservationTtlMs: 60_000,
+      clock: () => nowMs,
+    });
+
+    producer.reserveInteractive({ reservation_id: "go-1" });
+    expect((await producer.produce()).granted).toEqual([]);
+
+    nowMs = 60_000;
+    const after = await producer.produce();
+    expect(after.reserved).toBe(0);
+    expect(after.granted.map((worker) => worker.selector_id)).toEqual(["afk"]);
+    expect(producer.reservations().reservations).toEqual([]);
+  });
+
+  it("tells its host which selector yielded the slot and why", async () => {
+    const host = generousHost();
+    const events: string[] = [];
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("afk", 10)],
+      startWorker: host.start,
+      liveWorkers: () => 1,
+      resolveElasticTarget: () => 3,
+      onLifecycle: (event) => {
+        if (event.event === "selector-held-back") events.push(`${event.selector_id}: ${event.detail}`);
+      },
+      clock: () => 0,
+    });
+
+    producer.reserveInteractive({ reservation_id: "go-1" });
+    await producer.produce();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toContain("afk: 1 slot(s) held back for an interactive dispatch");
+  });
+});
+
+describe("soft preemption is soft, and the policy is the project's", () => {
+  const producerSource = readFileSync(new URL("../src/demand-producer.ts", import.meta.url), "utf8");
+  const reservationSource = readFileSync(new URL("../src/interactive-reservation.ts", import.meta.url), "utf8");
+
+  it("gives the project no way to terminate a live Worker for a reservation", () => {
+    // The producer's only host seam is `startWorker`. A stop/kill/signal seam
+    // would let impatience destroy work in flight, which is the exact bargain
+    // soft preemption refuses.
+    for (const source of [producerSource, reservationSource]) {
+      const code = source.replace(/\/\*\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+      expect(code).not.toMatch(/stopWorker|killWorker|terminateWorker|SIGTERM|SIGKILL|process\.kill/);
+    }
+  });
+
+  it("does not shrink the live Worker count when a reservation is taken", async () => {
+    const host = generousHost();
+    const producer = createDemandProducer({
+      projectLabel: "acme/widgets",
+      selectors: [selector("afk", 10)],
+      startWorker: host.start,
+      liveWorkers: () => 3,
+      resolveElasticTarget: () => 3,
+      clock: () => 0,
+    });
+
+    producer.reserveInteractive({ reservation_id: "go-1" });
+    const result = await producer.produce();
+    expect(result.live).toBe(3);
+    expect(result.granted).toEqual([]);
+    expect(result.requested).toBe(0);
+    // The host was never contacted at all: the reservation is an unasked birth.
+    expect(host.seen).toEqual([]);
+  });
+
+  it("keeps every word of the priority policy out of the daemon", () => {
+    for (const file of ["daemon.ts", "admission.ts", "worker-launch.ts", "protocol.ts", "client.ts"]) {
+      const source = readFileSync(new URL(`../src/${file}`, import.meta.url), "utf8");
+      expect(source, `${file} must hold no priority policy`).not.toMatch(/interactive|reserv/i);
+    }
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2785. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2785

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787943382&installation_model_id=20659&pr_number=2818&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2818&signature=1ad22273b4ecfd83aa6f979d3ec7c1161a4fc8dc03ea5af473189910b300aac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->