### PR TITLE
chore: #2792 Statusline string tool, /red-statusline modes and its config block

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -26,9 +26,11 @@ of it.
 | Which session a daemon serves | `src/paths.ts` — session key, socket, lock, lease |
 | Who owns the session across restarts | `src/session-lease.ts` — pid + start time, TOON on disk |
 | Who owns the socket right now | `src/daemon.ts` — exclusive bind |
-| The frozen wire contract | `src/protocol.ts` — `ping`, `host-state`, `statusline-payload`, `worker-start`, `worker-command`, `shutdown` |
+| The frozen wire contract | `src/protocol.ts` — `ping`, `host-state`, `statusline-payload`, `statusline-string`, `worker-start`, `worker-command`, `shutdown` |
 | Who may read and who may write | `src/session-reach.ts` — read the host, write the project |
 | What this machine is doing, in one document | `src/statusline-payload.ts` — Workers, projects, vitals, budgets, staleness |
+| That same answer, as a finished line | `src/statusline-render.ts` — modes, degradation, width; a pure function of the payload |
+| The declared defaults and the flag above them | `src/statusline-config.ts` — `plugins.dev.statusline.*`, resolved client-side |
 | Where a Worker's resources are charged | `src/worker-placement.ts` — pure planner over injected probes |
 | Birth itself | `src/worker-launch.ts` — plan, spawn once, report the downgrade |
 | The host-wide read | `src/host-state.ts` — total shape, Workers plus the budget total |
@@ -85,6 +87,28 @@ of it.
   answers about the same instant. A tick that failed to read the host ages the
   payload instead of refreshing it, and an unmeasured Worker is `null` and named,
   never a zero that reads as idle.
+- **The string is a pure function of the payload.** Two surfaces exist because a
+  host wants a line and a UI wants structure; purity is what stops them becoming
+  two answers. The daemon renders the string from the very payload the other op
+  returns, and a test proves the daemon's line equals `renderRedskilledStatusline`
+  over the payload read beside it — so **no agent host renders anything**: it runs
+  `redskilled statusline` and prints what comes back.
+- **The default mode is the local project; `global` is the whole machine.** The
+  common case is one operator in one repository, so the quiet default lists only
+  that project's Workers. `global` lists every project's and names the owner of
+  each — an anonymous Worker on a busy machine is what the mode exists to fix.
+- **A crowded machine degrades, it never overflows.** When the Workers do not fit
+  the count budget or the width, the line drops to one entry per project; when
+  the projects do not fit either, it drops to the host total. Detail is lost on
+  purpose and the loss is stated (`detail`, `degraded`) rather than left to be
+  detected by re-parsing the line. The full picture stays with the dashboard and
+  the monitor.
+- **Defaults are declared once, in `plugins.dev.statusline.*`.** `mode`,
+  `max_workers`, `max_projects` and `max_width`; a flag beats config, config
+  beats the built-in. Config is read **client-side** — the daemon may not know
+  what a `.red/config.yaml` is — so only decided values cross the socket. A
+  malformed value is named on stderr and ignored, never fatal: this line renders
+  on every turn, and a blank statusline is the harder failure to diagnose.
 - **An unisolated launch is never silent.** When the host affords no transient
   unit the Worker still starts, and the reply — and the host-state record it
   keeps for its whole life — carries a warning naming what was lost. A declared
@@ -96,4 +120,10 @@ of it.
 pnpm -C apps/redskilled test        # the focused suite
 pnpm -C apps/redskilled typecheck
 pnpm -C apps/redskilled serve       # run the daemon on this session's socket
+```
+
+```bash
+redskilled statusline                       # this project's Workers
+redskilled statusline global                # every project's, each showing its owner
+redskilled statusline --max-width 60        # a flag overrides the declared default
 ```

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -7,10 +7,17 @@
  * because the moment it does, it stops being servable by checkouts on different
  * bundle versions. A path it needs is a path it was given.
  */
+import { readFileSync } from "node:fs";
 import { parseFlags, routeCommand } from "@reddb-io/shared/args.js";
-import { readRedskilledHostState } from "./client.js";
+import { findUp } from "@reddb-io/shared/plugin-gate.js";
+import { declaredProjectNameInConfig } from "@reddb-io/shared/project-identity.js";
+import { readRedskilledHostState, readRedskilledStatuslineString } from "./client.js";
 import { DEFAULT_REDSKILLED_IDLE_MS, startRedskilledDaemon } from "./daemon.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
+import {
+  parseRedskilledStatuslineFlags,
+  resolveRedskilledStatuslineOptions,
+} from "./statusline-config.js";
 
 const SERVE_FLAGS = {
   socket: { kind: "value", coerce: (raw: string) => raw },
@@ -23,8 +30,8 @@ const SERVE_FLAGS = {
 } as const;
 
 export async function runRedskilledCli(argv: readonly string[]): Promise<number> {
-  const { command, args } = routeCommand<"serve" | "host-state">(argv, {
-    commands: { serve: {}, "host-state": {} },
+  const { command, args } = routeCommand<"serve" | "host-state" | "statusline">(argv, {
+    commands: { serve: {}, "host-state": {}, statusline: {} },
     default: "host-state",
   });
 
@@ -39,9 +46,63 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
     return 0;
   }
 
+  if (command === "statusline") return await runStatusline(args);
+
   const state = await readRedskilledHostState(resolveRedskilledPaths());
   process.stdout.write(`${JSON.stringify(state, null, 2)}\n`);
   return 0;
+}
+
+/**
+ * `redskilled statusline [global] [--flags]` — the whole of an agent host's job.
+ *
+ * The host runs this and prints the one line it writes; it decides nothing about
+ * shape, order, width or degradation, because ADR 0130 rule 10 moves rendering
+ * off every host so that a second host cannot drift from the first. Config is
+ * read HERE, on the client side, and only decided values cross the socket.
+ */
+export async function runStatusline(
+  args: readonly string[],
+  io: {
+    readonly cwd?: string;
+    /** The session's socket; derived from the environment when absent. */
+    readonly paths?: RedskilledPaths;
+    readonly write?: (line: string) => void;
+    readonly warn?: (line: string) => void;
+  } = {},
+): Promise<number> {
+  const write = io.write ?? ((line: string) => process.stdout.write(line));
+  const warn = io.warn ?? ((line: string) => process.stderr.write(line));
+
+  const parsed = parseRedskilledStatuslineFlags(args);
+  const project = readProjectConfig(io.cwd ?? process.cwd());
+  const resolved = resolveRedskilledStatuslineOptions({
+    configText: project.configText,
+    project: project.name,
+    flags: parsed.flags,
+  });
+  for (const warning of [...resolved.warnings, ...parsed.warnings]) {
+    warn(`redskilled statusline: ignoring ${warning.key}=${warning.value} — ${warning.reason}\n`);
+  }
+
+  const render = await readRedskilledStatuslineString(io.paths ?? resolveRedskilledPaths(), resolved.options, {
+    ...(resolved.options.project == null ? {} : { sessionProject: resolved.options.project }),
+  });
+  write(`${render.line}\n`);
+  return 0;
+}
+
+/** The nearest `.red/config.yaml`, and the project name it declares. */
+function readProjectConfig(cwd: string): { configText?: string; name: string | null } {
+  const path = findUp(cwd, ".red/config.yaml");
+  if (path == null) return { name: null };
+  let configText: string;
+  try {
+    configText = readFileSync(path, "utf8");
+  } catch {
+    return { name: null };
+  }
+  return { configText, name: declaredProjectNameInConfig(configText) ?? null };
 }
 
 /**

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -25,15 +25,19 @@ import { isRedskilledHostState, type RedskilledHostState } from "./host-state.js
 import type { RedskilledPaths } from "./paths.js";
 import {
   isRedskilledStatuslinePayload,
+  isRedskilledStatuslineRender,
   isRedskilledWorkerCommandResult,
   isRedskilledWorkerStarted,
   sendRedskilledRequest,
   type RedskilledRequest,
   type RedskilledStatuslinePayload,
+  type RedskilledStatuslineRender,
+  type RedskilledStatuslineRenderRequest,
   type RedskilledWorkerCommandRequest,
   type RedskilledWorkerCommandResult,
   type RedskilledWorkerStarted,
 } from "./protocol.js";
+import type { RedskilledStatuslineOptions } from "./statusline-render.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
 
 /** How long a client waits for a daemon — its own or the race winner's — to answer. */
@@ -168,6 +172,44 @@ export async function readRedskilledStatuslinePayload(
   );
   if (!isRedskilledStatuslinePayload(value)) throw new Error("redskilled daemon returned a malformed statusline payload");
   return value;
+}
+
+/**
+ * The statusline string: the same read, already rendered.
+ *
+ * The caller resolves its own taste first — config then flags — and hands the
+ * decided options over, because the daemon may not read a repository's config
+ * (ADR 0130 rule 3). **An agent host calls this and prints what comes back.**
+ * That is the whole point: a host that rendered the line itself would be the
+ * second renderer whose drift from this one nobody would notice for weeks.
+ */
+export async function readRedskilledStatuslineString(
+  paths: RedskilledPaths,
+  options: RedskilledStatuslineOptions | undefined = undefined,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledStatuslineRender> {
+  const value = await requestRedskilled(
+    paths,
+    {
+      op: "statusline-string",
+      ...(config.sessionProject != null ? { session_project: config.sessionProject } : {}),
+      ...(options == null ? {} : { render: renderRequest(options) }),
+    },
+    config,
+  );
+  if (!isRedskilledStatuslineRender(value)) throw new Error("redskilled daemon returned a malformed statusline render");
+  return value;
+}
+
+/** The wire shape of decided render options. PURE. */
+function renderRequest(options: RedskilledStatuslineOptions): RedskilledStatuslineRenderRequest {
+  return {
+    mode: options.mode,
+    project: options.project,
+    max_workers: options.maxWorkers,
+    max_projects: options.maxProjects,
+    max_width: options.maxWidth,
+  };
 }
 
 /**

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -62,11 +62,17 @@ import {
   REDSKILLED_PROTOCOL_VERSION,
   type RedskilledRequest,
   type RedskilledResponse,
+  type RedskilledStatuslineRenderRequest,
   type RedskilledWorkerCommandRequest,
   type RedskilledWorkerCommandResult,
 } from "./protocol.js";
 import { commandOp, evaluateSessionReach, type RedskilledSessionOp } from "./session-reach.js";
 import { buildStatuslinePayload, type RedskilledStatuslinePayload } from "./statusline-payload.js";
+import {
+  REDSKILLED_STATUSLINE_DEFAULTS,
+  renderRedskilledStatusline,
+  type RedskilledStatuslineRender,
+} from "./statusline-render.js";
 import {
   launchWorker,
   type LaunchWorkerOptions,
@@ -264,6 +270,26 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       sampledAt: lastSampledAt,
       now: clock(),
       reattachedWorkerIds: [...reattached],
+    });
+  }
+
+  /**
+   * The rendered line, from that same payload and from nothing else.
+   *
+   * The request carries taste already settled by the client — mode, project and
+   * the count budgets — because a daemon that resolved a config would have to
+   * know what a `.red/config.yaml` is, and ADR 0130 rule 3 keeps repository
+   * layout out of this process entirely. An absent field takes the shared
+   * default, so a bare read still renders.
+   */
+  function statuslineString(render?: RedskilledStatuslineRenderRequest): RedskilledStatuslineRender {
+    return renderRedskilledStatusline(statuslinePayload(), {
+      ...REDSKILLED_STATUSLINE_DEFAULTS,
+      mode: render?.mode ?? REDSKILLED_STATUSLINE_DEFAULTS.mode,
+      project: render?.project ?? REDSKILLED_STATUSLINE_DEFAULTS.project,
+      maxWorkers: render?.max_workers ?? REDSKILLED_STATUSLINE_DEFAULTS.maxWorkers,
+      maxProjects: render?.max_projects ?? REDSKILLED_STATUSLINE_DEFAULTS.maxProjects,
+      maxWidth: render?.max_width ?? REDSKILLED_STATUSLINE_DEFAULTS.maxWidth,
     });
   }
 
@@ -543,6 +569,12 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         // requirement, and a session that could not would diagnose contention
         // by leaving the session it is in.
         return { id: request.id, ok: true, value: statuslinePayload() };
+      }
+      if (request.op === "statusline-string") {
+        // The same host read, already rendered. The daemon renders it from the
+        // payload the other op returns — one call of a pure function — so the
+        // two surfaces are the same answer twice and never two answers.
+        return { id: request.id, ok: true, value: statuslineString(request.render) };
       }
       if (request.op === "worker-command") {
         return { id: request.id, ok: true, value: await runWorkerCommand(request.command) };

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -18,7 +18,12 @@
  * `statusline-payload` is the second read, and it widens nothing the daemon does
  * not already own: it is the host-wide Worker set the daemon holds anyway, dated
  * by the daemon's own sampler, so a surface that needs structure never has to
- * parse a rendered line and never needs a private source. `worker-command`
+ * parse a rendered line and never needs a private source. `statusline-string` is
+ * the same answer already rendered, and it widens the contract by exactly one
+ * string because the alternative is every agent host reimplementing the line —
+ * which is the drift the pair of ops exists to prevent (ADR 0130 rule 10). The
+ * daemon renders it from the very payload the other op returns, so the two can
+ * disagree only if a pure function is impure. `worker-command`
  * carries the commanding verbs — stop, recycle, steer — as data rather than as
  * three ops, so the reach rule is decided once for all of them.
  *
@@ -31,6 +36,7 @@ import { isRedskilledAdmissionVerdict, type RedskilledAdmissionVerdict } from ".
 import { isRedskilledWorkerView, type RedskilledHostState, type RedskilledWorkerView } from "./host-state.js";
 import { isRedskilledReachVerdict, type RedskilledReachVerdict, type RedskilledWorkerCommandName } from "./session-reach.js";
 import { isRedskilledStatuslinePayload, type RedskilledStatuslinePayload } from "./statusline-payload.js";
+import type { RedskilledStatuslineMode, RedskilledStatuslineRender } from "./statusline-render.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
 
 /** The wire version. A daemon states it; a client that cannot read it must not proceed. */
@@ -51,10 +57,27 @@ export interface RedskilledWorkerCommandRequest {
   readonly detail?: string;
 }
 
+/**
+ * How one statusline read wants to be rendered.
+ *
+ * Every field is optional and every one is a decided value: the client resolves
+ * config and flags before it asks, because the daemon must never learn what a
+ * `.red/config.yaml` is (ADR 0130 rule 3). What travels here is taste already
+ * settled, never a place to go and look it up.
+ */
+export interface RedskilledStatuslineRenderRequest {
+  readonly mode?: RedskilledStatuslineMode;
+  readonly project?: string | null;
+  readonly max_workers?: number;
+  readonly max_projects?: number;
+  readonly max_width?: number;
+}
+
 export type RedskilledRequest =
   | { id: string; op: "ping" }
   | { id: string; op: "host-state" }
   | { id: string; op: "statusline-payload"; session_project?: string }
+  | { id: string; op: "statusline-string"; session_project?: string; render?: RedskilledStatuslineRenderRequest }
   | { id: string; op: "worker-start"; spec: RedskilledWorkerSpec; session_project?: string }
   | { id: string; op: "worker-command"; command: RedskilledWorkerCommandRequest }
   | { id: string; op: "shutdown" };
@@ -149,6 +172,26 @@ export function isRedskilledPong(value: unknown): value is RedskilledPong {
     Number.isInteger(pong.pid);
 }
 
+/**
+ * True when `value` is a rendered statusline.
+ *
+ * The line alone would have been enough to print, and is not enough to trust: a
+ * consumer that could not tell a degraded line from a full one, or a stale one
+ * from a current one, would have to read those facts back out of the text.
+ */
+export function isRedskilledStatuslineRender(value: unknown): value is RedskilledStatuslineRender {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const render = value as Record<string, unknown>;
+  return render.version === 1 &&
+    typeof render.line === "string" &&
+    (render.mode === "local" || render.mode === "global") &&
+    (render.project === null || typeof render.project === "string") &&
+    typeof render.detail === "string" &&
+    typeof render.degraded === "boolean" &&
+    typeof render.stale === "boolean" &&
+    typeof render.generated_at === "string";
+}
+
 /** True when `value` is a complete payload — re-exported so a client checks one surface. */
 export { isRedskilledStatuslinePayload };
 
@@ -156,7 +199,9 @@ export type {
   RedskilledAdmissionVerdict,
   RedskilledHostState,
   RedskilledReachVerdict,
+  RedskilledStatuslineMode,
   RedskilledStatuslinePayload,
+  RedskilledStatuslineRender,
   RedskilledWorkerCommandName,
   RedskilledWorkerView,
   RedskilledWorkerSpec,

--- a/apps/redskilled/src/statusline-config.ts
+++ b/apps/redskilled/src/statusline-config.ts
@@ -1,0 +1,207 @@
+/**
+ * statusline-config — the declared defaults, and the flag that beats them.
+ *
+ * **Every statusline default is declarable in `.red/config.yaml`.** The block is
+ * new rather than migrated: the file has never held a statusline key, so there
+ * is no legacy spelling to keep working and no deprecation to carry.
+ *
+ * **Precedence is one sentence: flag beats config beats built-in.** An operator
+ * declares the taste they hold every day and overrides it for the one read where
+ * they want something else; a config that a flag could not override would make
+ * the declaration a cage rather than a default.
+ *
+ * **A malformed value is ignored and named, never obeyed and never fatal.** This
+ * is the one surface rendered on every turn of every session: a line that
+ * refused to render because `max_width` says `wide` would replace a small
+ * mistake with a blank statusline, which is the harder failure to diagnose.
+ * The warning travels with the resolved options so a caller can surface it once.
+ */
+import { parseFlags } from "@reddb-io/shared/args.js";
+import { flatConfigValue } from "@reddb-io/shared/plugin-gate.js";
+import {
+  REDSKILLED_STATUSLINE_DEFAULTS,
+  type RedskilledStatuslineMode,
+  type RedskilledStatuslineOptions,
+} from "./statusline-render.js";
+
+/**
+ * The canonical config block.
+ *
+ * Statusline behaviour is a dev-plugin surface — `/red-statusline` is a dev
+ * skill — so the block lives under the plugin rather than at the sacred root.
+ */
+export const REDSKILLED_STATUSLINE_CONFIG_PREFIX = "plugins.dev.statusline";
+
+/**
+ * The folded spelling the config loader also accepts.
+ *
+ * `plugins.dev.*` folds to `dev.*` everywhere else in this repository; reading
+ * both here means the statusline block is not the one place where the fold
+ * silently does nothing.
+ */
+export const REDSKILLED_STATUSLINE_CONFIG_FOLD = "dev.statusline";
+
+/** Every option a project may declare. Absent keys keep the built-in default. */
+export interface RedskilledStatuslineConfig {
+  readonly mode?: RedskilledStatuslineMode;
+  readonly maxWorkers?: number;
+  readonly maxProjects?: number;
+  readonly maxWidth?: number;
+}
+
+/** A declared value that could not be honoured, in a sentence a human can act on. */
+export interface RedskilledStatuslineConfigWarning {
+  readonly key: string;
+  readonly value: string;
+  readonly reason: string;
+}
+
+export interface RedskilledStatuslineConfigRead {
+  readonly config: RedskilledStatuslineConfig;
+  readonly warnings: readonly RedskilledStatuslineConfigWarning[];
+}
+
+/** Overrides a caller states explicitly — the flags of one invocation. */
+export interface RedskilledStatuslineFlags {
+  readonly mode?: RedskilledStatuslineMode;
+  readonly project?: string | null;
+  readonly maxWorkers?: number;
+  readonly maxProjects?: number;
+  readonly maxWidth?: number;
+}
+
+export interface ResolveStatuslineOptionsInput {
+  /** The TEXT of a `.red/config.yaml`; absent when the project has none. */
+  readonly configText?: string;
+  readonly flags?: RedskilledStatuslineFlags;
+  /** The project this session belongs to, resolved by its own authority. */
+  readonly project?: string | null;
+}
+
+export interface ResolvedStatuslineOptions {
+  readonly options: RedskilledStatuslineOptions;
+  readonly warnings: readonly RedskilledStatuslineConfigWarning[];
+}
+
+/** Read the statusline block out of a config file's text. PURE. */
+export function readRedskilledStatuslineConfig(text: string): RedskilledStatuslineConfigRead {
+  const warnings: RedskilledStatuslineConfigWarning[] = [];
+  const raw = (leaf: string): { key: string; value: string } | undefined => {
+    for (const prefix of [REDSKILLED_STATUSLINE_CONFIG_PREFIX, REDSKILLED_STATUSLINE_CONFIG_FOLD]) {
+      const key = `${prefix}.${leaf}`;
+      const value = flatConfigValue(text, key)?.trim();
+      if (value != null && value !== "") return { key, value };
+    }
+    return undefined;
+  };
+
+  const mode = raw("mode");
+  const config: {
+    mode?: RedskilledStatuslineMode;
+    maxWorkers?: number;
+    maxProjects?: number;
+    maxWidth?: number;
+  } = {};
+
+  if (mode != null) {
+    if (mode.value === "local" || mode.value === "global") config.mode = mode.value;
+    else warnings.push({ ...mode, reason: "expected `local` or `global`" });
+  }
+  const counts = [
+    { leaf: "max_workers", assign: (n: number) => { config.maxWorkers = n; } },
+    { leaf: "max_projects", assign: (n: number) => { config.maxProjects = n; } },
+    { leaf: "max_width", assign: (n: number) => { config.maxWidth = n; } },
+  ] as const;
+  for (const count of counts) {
+    const declared = raw(count.leaf);
+    if (declared == null) continue;
+    const parsed = Number(declared.value);
+    if (Number.isInteger(parsed) && parsed >= 0) count.assign(parsed);
+    else warnings.push({ ...declared, reason: "expected a whole number of zero or more" });
+  }
+
+  return { config, warnings };
+}
+
+const STATUSLINE_FLAGS = {
+  mode: { kind: "value", coerce: (raw: string) => raw },
+  project: { kind: "value", coerce: (raw: string) => raw },
+  "max-workers": { kind: "value", coerce: (raw: string) => raw },
+  "max-projects": { kind: "value", coerce: (raw: string) => raw },
+  "max-width": { kind: "value", coerce: (raw: string) => raw },
+} as const;
+
+/**
+ * One invocation's flags, from argv.
+ *
+ * `global` is accepted as a bare word because that is how an operator says it —
+ * `/red-statusline global` — and making the short spelling a second-class alias
+ * of `--mode global` would leave the documented invocation unparsed.
+ * An unreadable flag is a warning and a fall-through to the declared default,
+ * for the same reason a malformed config key is.
+ */
+export function parseRedskilledStatuslineFlags(argv: readonly string[]): {
+  readonly flags: RedskilledStatuslineFlags;
+  readonly warnings: readonly RedskilledStatuslineConfigWarning[];
+} {
+  const { values, positionals } = parseFlags(argv, STATUSLINE_FLAGS);
+  const warnings: RedskilledStatuslineConfigWarning[] = [];
+  const flags: {
+    mode?: RedskilledStatuslineMode;
+    project?: string | null;
+    maxWorkers?: number;
+    maxProjects?: number;
+    maxWidth?: number;
+  } = {};
+
+  const declaredMode = values.mode ?? positionals.find((word) => word === "global" || word === "local");
+  if (declaredMode != null) {
+    if (declaredMode === "local" || declaredMode === "global") flags.mode = declaredMode;
+    else warnings.push({ key: "--mode", value: declaredMode, reason: "expected `local` or `global`" });
+  }
+  if (values.project != null) flags.project = values.project;
+
+  const counts = [
+    { flag: "max-workers", assign: (n: number) => { flags.maxWorkers = n; } },
+    { flag: "max-projects", assign: (n: number) => { flags.maxProjects = n; } },
+    { flag: "max-width", assign: (n: number) => { flags.maxWidth = n; } },
+  ] as const;
+  for (const count of counts) {
+    const raw = values[count.flag];
+    if (raw == null) continue;
+    const parsed = Number(raw);
+    if (Number.isInteger(parsed) && parsed >= 0) count.assign(parsed);
+    else warnings.push({ key: `--${count.flag}`, value: raw, reason: "expected a whole number of zero or more" });
+  }
+
+  return { flags, warnings };
+}
+
+/**
+ * The options one render runs under: built-in, then config, then flags.
+ *
+ * The session's project is not a taste and so is not a config key — it is a fact
+ * about where the session is, resolved by the identity authority and handed in.
+ * A flag may still override it, which is how one session inspects another
+ * project's local view without moving.
+ */
+export function resolveRedskilledStatuslineOptions(
+  input: ResolveStatuslineOptionsInput = {},
+): ResolvedStatuslineOptions {
+  const read = input.configText == null
+    ? { config: {}, warnings: [] as readonly RedskilledStatuslineConfigWarning[] }
+    : readRedskilledStatuslineConfig(input.configText);
+  const flags = input.flags ?? {};
+
+  return {
+    options: {
+      ...REDSKILLED_STATUSLINE_DEFAULTS,
+      mode: flags.mode ?? read.config.mode ?? REDSKILLED_STATUSLINE_DEFAULTS.mode,
+      project: flags.project !== undefined ? flags.project : input.project ?? REDSKILLED_STATUSLINE_DEFAULTS.project,
+      maxWorkers: flags.maxWorkers ?? read.config.maxWorkers ?? REDSKILLED_STATUSLINE_DEFAULTS.maxWorkers,
+      maxProjects: flags.maxProjects ?? read.config.maxProjects ?? REDSKILLED_STATUSLINE_DEFAULTS.maxProjects,
+      maxWidth: flags.maxWidth ?? read.config.maxWidth ?? REDSKILLED_STATUSLINE_DEFAULTS.maxWidth,
+    },
+    warnings: read.warnings,
+  };
+}

--- a/apps/redskilled/src/statusline-render.ts
+++ b/apps/redskilled/src/statusline-render.ts
@@ -1,0 +1,292 @@
+/**
+ * statusline-render — the finished line, and nothing behind it.
+ *
+ * **The string is a pure function of the payload.** That purity is the whole
+ * mitigation for having two surfaces at all (ADR 0130 rule 10): a renderer that
+ * could reach for one extra fact — a directory listing, a clock, an environment
+ * variable — would be a second authority on a question the payload already
+ * answers, and the two surfaces would eventually describe different machines.
+ * Everything this function needs is an argument, so a test can prove the string
+ * the daemon serves is the string this function computes from the payload the
+ * daemon serves alongside it.
+ *
+ * **The default mode is quiet: only the local project's Workers.** The common
+ * case is one operator in one repository, and a line that listed every project
+ * by default would make the common case pay for the rare one. `global` lists
+ * every project's Workers and names the owner of each, because an anonymous
+ * Worker on a busy machine is the exact thing the mode exists to fix.
+ *
+ * **A crowded machine degrades to an aggregate rather than overflowing.** The
+ * statusline answers "who is using this machine and how much"; it is not the
+ * dashboard. When the Workers do not fit, the line drops to one entry per
+ * project, and when the projects do not fit it drops to the host total — losing
+ * detail on purpose, never losing the line.
+ */
+import type {
+  RedskilledStatuslinePayload,
+  RedskilledStatuslineProject,
+  RedskilledStatuslineWorker,
+} from "./statusline-payload.js";
+
+/** Which Workers the line is about. */
+export type RedskilledStatuslineMode = "local" | "global";
+
+/** How much detail survived the width and count budgets. */
+export type RedskilledStatuslineDetail = "workers" | "projects" | "host";
+
+export interface RedskilledStatuslineOptions {
+  readonly mode: RedskilledStatuslineMode;
+  /** The project this session belongs to; `null` when it declared none. */
+  readonly project: string | null;
+  /** How many Worker entries may be listed before the line drops to projects. */
+  readonly maxWorkers: number;
+  /** How many project entries may be listed before the line drops to the host. */
+  readonly maxProjects: number;
+  /** The hard ceiling in characters. The line never exceeds it. */
+  readonly maxWidth: number;
+  readonly separator: string;
+}
+
+/**
+ * What was rendered, and at what detail.
+ *
+ * `detail` is stated rather than inferred from the text: a consumer that had to
+ * detect degradation by counting separators would be parsing the rendered line,
+ * which is the failure this whole tool exists to remove.
+ */
+export interface RedskilledStatuslineRender {
+  readonly version: 1;
+  readonly line: string;
+  readonly mode: RedskilledStatuslineMode;
+  readonly project: string | null;
+  readonly detail: RedskilledStatuslineDetail;
+  /** True when the line lost detail to the width or the count budgets. */
+  readonly degraded: boolean;
+  readonly stale: boolean;
+  /** The instant of the payload this line was rendered from. */
+  readonly generated_at: string;
+}
+
+/** The defaults a project overrides in config, and a flag overrides again. */
+export const REDSKILLED_STATUSLINE_DEFAULTS: RedskilledStatuslineOptions = {
+  mode: "local",
+  project: null,
+  maxWorkers: 4,
+  maxProjects: 4,
+  maxWidth: 120,
+  separator: " · ",
+};
+
+/**
+ * The finished statusline. PURE — payload and options in, one line out.
+ *
+ * The line is built at the richest detail the budgets allow and then re-built
+ * one step poorer for as long as it does not fit. Rebuilding rather than
+ * trimming is deliberate: a trimmed line ends mid-fact, and a half-printed
+ * memory figure is worse than an honest aggregate.
+ */
+export function renderRedskilledStatusline(
+  payload: RedskilledStatuslinePayload,
+  options: RedskilledStatuslineOptions = REDSKILLED_STATUSLINE_DEFAULTS,
+): RedskilledStatuslineRender {
+  const workers = selectWorkers(payload, options);
+  const projects = selectProjects(payload, options);
+  const head = renderHead(payload, options, workers);
+
+  const ladder = detailLadder(options, workers, projects);
+  let chosen: { detail: RedskilledStatuslineDetail; line: string } = {
+    detail: "host",
+    line: head,
+  };
+  for (const detail of ladder) {
+    const line = compose(head, body(detail, options, workers, projects), options.separator);
+    chosen = { detail, line };
+    if (width(line) <= options.maxWidth) break;
+  }
+  // Even the host aggregate can outgrow a very narrow line; a clamp is the last
+  // resort and never the normal path, so it keeps the ellipsis visible.
+  const line = clamp(chosen.line, options.maxWidth);
+  // Degradation is measured against the richest detail this payload COULD have
+  // shown, not against the richest one the budgets allowed: a line that dropped
+  // the Workers because `max_workers` said so is degraded in the only sense a
+  // reader cares about — there is more to see than is on the line.
+  const richest: RedskilledStatuslineDetail = workers.length > 0 ? "workers" : "host";
+
+  return {
+    version: 1,
+    line,
+    mode: options.mode,
+    project: options.project,
+    detail: chosen.detail,
+    degraded: chosen.detail !== richest || line !== chosen.line,
+    stale: payload.staleness.stale,
+    generated_at: payload.generated_at,
+  };
+}
+
+/**
+ * The detail levels this render may use, richest first.
+ *
+ * A level whose count budget is already blown is never attempted: the budgets
+ * are the operator's declared taste, and honouring them only when the line
+ * happens to be long would make the setting mean nothing on a wide terminal.
+ */
+function detailLadder(
+  options: RedskilledStatuslineOptions,
+  workers: readonly RedskilledStatuslineWorker[],
+  projects: readonly RedskilledStatuslineProject[],
+): readonly RedskilledStatuslineDetail[] {
+  const ladder: RedskilledStatuslineDetail[] = [];
+  if (workers.length > 0 && workers.length <= options.maxWorkers) ladder.push("workers");
+  // The local mode holds one project by construction, so a per-project line
+  // would repeat the head verbatim. Only `global` has an aggregate worth a step.
+  if (options.mode === "global" && projects.length > 0 && projects.length <= options.maxProjects) {
+    ladder.push("projects");
+  }
+  ladder.push("host");
+  return ladder;
+}
+
+function body(
+  detail: RedskilledStatuslineDetail,
+  options: RedskilledStatuslineOptions,
+  workers: readonly RedskilledStatuslineWorker[],
+  projects: readonly RedskilledStatuslineProject[],
+): readonly string[] {
+  if (detail === "workers") return workers.map((worker) => renderWorker(worker, options));
+  if (detail === "projects") return projects.map(renderProject);
+  return [];
+}
+
+/**
+ * The Workers this line is about.
+ *
+ * The default mode keeps the session inside its own repository; a session that
+ * declared no project has nothing to filter on, and rather than guess it shows
+ * none — the head still carries the host total, so the line stays truthful.
+ */
+function selectWorkers(
+  payload: RedskilledStatuslinePayload,
+  options: RedskilledStatuslineOptions,
+): readonly RedskilledStatuslineWorker[] {
+  if (options.mode === "global") return payload.workers;
+  if (options.project == null) return [];
+  return payload.workers.filter((worker) => worker.project_label === options.project);
+}
+
+function selectProjects(
+  payload: RedskilledStatuslinePayload,
+  options: RedskilledStatuslineOptions,
+): readonly RedskilledStatuslineProject[] {
+  if (options.mode === "global") return payload.projects;
+  return payload.projects.filter((project) => project.project_label === options.project);
+}
+
+/**
+ * The head — the one part of the line that never degrades.
+ *
+ * Whatever else is dropped, "how much of this machine is in use" survives,
+ * because that is the question the statusline exists to answer.
+ */
+function renderHead(
+  payload: RedskilledStatuslinePayload,
+  options: RedskilledStatuslineOptions,
+  workers: readonly RedskilledStatuslineWorker[],
+): string {
+  const parts: string[] = [];
+  if (options.mode === "global") {
+    parts.push(`host ${payload.host.worker_count}w/${payload.host.project_count}p`);
+  } else {
+    parts.push(`${options.project ?? "project unknown"} ${workers.length}w`);
+  }
+  parts.push(memoryFigure(payload, options));
+  if (options.mode === "local" && workers.length === 0) parts.push("idle");
+  if (payload.staleness.stale) parts.push(stalenessMark(payload));
+  return parts.join(" ");
+}
+
+/**
+ * Observed memory over the host ceiling, or observed alone when it is lifted.
+ *
+ * The local mode reports its own project's share, because an operator reading a
+ * quiet line wants to know what *their* repository is spending; the host figure
+ * is one mode away.
+ */
+function memoryFigure(payload: RedskilledStatuslinePayload, options: RedskilledStatuslineOptions): string {
+  const observed = options.mode === "global"
+    ? payload.host.observed_rss_bytes
+    : payload.projects
+      .filter((project) => project.project_label === options.project)
+      .reduce((total, project) => total + project.observed_rss_bytes, 0);
+  const ceiling = payload.host.ceiling.memory_bytes;
+  if (options.mode === "global" && ceiling != null && ceiling > 0) {
+    return `${formatBytes(observed)}/${formatBytes(ceiling)}`;
+  }
+  return formatBytes(observed);
+}
+
+/** How old the answer is, in the shortest sentence that stays honest. */
+function stalenessMark(payload: RedskilledStatuslinePayload): string {
+  const age = payload.staleness.age_ms;
+  return age == null ? "!unmeasured" : `!stale ${Math.round(age / 1000)}s`;
+}
+
+/**
+ * One Worker. In `global`, the owning project rides on the entry itself.
+ *
+ * A separate "these belong to acme/widgets" grouping was rejected: the line has
+ * no vertical dimension to group in, so the owner has to travel with the Worker
+ * or it is not shown at all.
+ */
+function renderWorker(worker: RedskilledStatuslineWorker, options: RedskilledStatuslineOptions): string {
+  const name = options.mode === "global" ? `${worker.project_label}:${worker.worker_id}` : worker.worker_id;
+  const used = worker.vitals.rss_bytes;
+  // An unmeasured Worker says so. A zero here would read as an idle Worker, and
+  // "nothing measured it" and "it is using nothing" are opposite facts.
+  const usage = used == null
+    ? "?"
+    : worker.budget.bytes == null
+      ? formatBytes(used)
+      : `${formatBytes(used)}/${formatBytes(worker.budget.bytes)}`;
+  return `${name} ${usage}`;
+}
+
+function renderProject(project: RedskilledStatuslineProject): string {
+  return `${project.project_label} ${project.worker_count}w ${formatBytes(project.observed_rss_bytes)}`;
+}
+
+function compose(head: string, body: readonly string[], separator: string): string {
+  return [head, ...body].join(separator);
+}
+
+/** The visible width. One character is one column here — the line carries no ANSI. */
+function width(line: string): number {
+  return [...line].length;
+}
+
+function clamp(line: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  const chars = [...line];
+  if (chars.length <= maxWidth) return line;
+  if (maxWidth === 1) return "…";
+  return `${chars.slice(0, maxWidth - 1).join("")}…`;
+}
+
+/**
+ * Bytes at statusline resolution: three significant characters, never more.
+ *
+ * Exactness is the payload's job. A line that read `1.234567G` would spend the
+ * width it does not have on precision nobody acts on.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0B";
+  const units = ["B", "K", "M", "G", "T"] as const;
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  const rendered = value >= 100 || unit === 0 ? Math.round(value).toString() : value.toFixed(1).replace(/\.0$/, "");
+  return `${rendered}${units[unit]}`;
+}

--- a/apps/redskilled/tests/statusline-string.test.ts
+++ b/apps/redskilled/tests/statusline-string.test.ts
@@ -1,0 +1,360 @@
+// The rendered statusline lives on the tool surface, so no agent host renders
+// it. The string is a pure function of the payload — proven here rather than
+// left to discipline — the default mode is the local project's Workers, `global`
+// names the owner of each, a crowded machine degrades to an aggregate instead of
+// overflowing, and every default is declarable in config with a flag above it.
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { runStatusline } from "../src/cli.js";
+import { readRedskilledStatuslinePayload, readRedskilledStatuslineString } from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { buildHostState, type RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { isRedskilledStatuslineRender } from "../src/protocol.js";
+import {
+  parseRedskilledStatuslineFlags,
+  readRedskilledStatuslineConfig,
+  resolveRedskilledStatuslineOptions,
+} from "../src/statusline-config.js";
+import {
+  REDSKILLED_STATUSLINE_DEFAULTS,
+  renderRedskilledStatusline,
+  type RedskilledStatuslineOptions,
+} from "../src/statusline-render.js";
+import type { RedskilledStatuslinePayload } from "../src/statusline-payload.js";
+import { buildStatuslinePayload } from "../src/statusline-payload.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await scratch("redskilled-statusline-string-");
+  return resolveRedskilledPaths({ env: { REDSKILLED_SESSION: `test:${root}` }, runtimeDir: root });
+}
+
+function worker(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorkerView {
+  return {
+    worker_id: "w-1",
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-07-29T00:00:00.000Z",
+    workspace_path: "/tmp/acme/w-1",
+    isolated: true,
+    unit: "red-worker-acme-widgets-w-1.service",
+    budget: { memory_max: "1G" },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+const MB = 1024 * 1024;
+
+/** A payload built the way the daemon builds it, from a fixed instant. */
+function payloadOf(
+  workers: readonly RedskilledWorkerView[],
+  rss: Record<string, number> = {},
+  overrides: { sampledAt?: string | null; now?: string } = {},
+): RedskilledStatuslinePayload {
+  return buildStatuslinePayload({
+    hostState: buildHostState({
+      daemonVersion: "0.1.0",
+      machineIdHash: "mach",
+      sessionKeyHash: "sess",
+      pid: 99,
+      startedAt: "2026-07-29T00:00:00.000Z",
+      workers,
+    }),
+    ceiling: UNBOUNDED_HOST_CEILING,
+    rss,
+    sampledAt: overrides.sampledAt === undefined ? "2026-07-29T01:00:00.000Z" : overrides.sampledAt,
+    now: overrides.now ?? "2026-07-29T01:00:05.000Z",
+  });
+}
+
+function options(overrides: Partial<RedskilledStatuslineOptions> = {}): RedskilledStatuslineOptions {
+  return { ...REDSKILLED_STATUSLINE_DEFAULTS, ...overrides };
+}
+
+/** Many projects, each with one Worker, so the global view has to give up detail. */
+function crowdedWorkers(projects: number): RedskilledWorkerView[] {
+  return Array.from({ length: projects }, (_, index) =>
+    worker({
+      worker_id: `w-${index}`,
+      project_label: `acme/project-with-a-long-name-${index}`,
+      pid: 5000 + index,
+      workspace_path: `/tmp/acme/w-${index}`,
+      unit: `red-worker-${index}.service`,
+    }));
+}
+
+describe("the rendered statusline", () => {
+  it("is a pure function of the payload — the daemon's string is this renderer's string", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      stopWorker: () => true,
+      // A frozen clock so the two reads describe the same instant: purity is the
+      // claim under test, and a moving clock would test the clock instead.
+      clock: () => "2026-07-29T01:00:05.000Z",
+      memorySampler: () => ({ "w-1": 512 * MB, "w-2": 128 * MB }),
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+    daemon.trackWorker(worker({
+      worker_id: "w-2",
+      project_label: "acme/gadgets",
+      pid: 4343,
+      workspace_path: "/tmp/acme/w-2",
+      unit: "red-worker-acme-gadgets-w-2.service",
+      budget: { memory_max: "512M" },
+    }));
+
+    const asked = options({ mode: "global", project: "acme/widgets" });
+    const payload = await readRedskilledStatuslinePayload(paths, { sessionProject: "acme/widgets" });
+    const render = await readRedskilledStatuslineString(paths, asked, { sessionProject: "acme/widgets" });
+
+    expect(isRedskilledStatuslineRender(render)).toBe(true);
+    expect(render.line).toBe(renderRedskilledStatusline(payload, asked).line);
+    expect(render.generated_at).toBe(payload.generated_at);
+  });
+
+  it("defaults to the local project's Workers and names no other project", () => {
+    const payload = payloadOf(
+      [worker(), worker({ worker_id: "w-2", project_label: "acme/gadgets", pid: 43 })],
+      { "w-1": 512 * MB, "w-2": 128 * MB },
+    );
+
+    const render = renderRedskilledStatusline(payload, options({ project: "acme/widgets" }));
+
+    expect(render.mode).toBe("local");
+    expect(render.line).toContain("acme/widgets 1w");
+    expect(render.line).toContain("w-1 512M/1G");
+    expect(render.line).not.toContain("w-2");
+    expect(render.line).not.toContain("acme/gadgets");
+  });
+
+  it("lists every project's Workers in `global`, each showing its owner", () => {
+    const payload = payloadOf(
+      [worker(), worker({ worker_id: "w-2", project_label: "acme/gadgets", pid: 43, budget: { memory_max: "512M" } })],
+      { "w-1": 512 * MB, "w-2": 128 * MB },
+    );
+
+    const render = renderRedskilledStatusline(payload, options({ mode: "global", project: "acme/widgets" }));
+
+    expect(render.detail).toBe("workers");
+    expect(render.line).toContain("host 2w/2p");
+    expect(render.line).toContain("acme/widgets:w-1 512M/1G");
+    expect(render.line).toContain("acme/gadgets:w-2 128M/512M");
+  });
+
+  it("degrades a crowded global view to an aggregate and never overflows the line", () => {
+    const workers = crowdedWorkers(6);
+    const payload = payloadOf(workers, Object.fromEntries(workers.map((w) => [w.worker_id, 256 * MB])));
+
+    const perProject = renderRedskilledStatusline(
+      payload,
+      options({ mode: "global", maxWorkers: 3, maxProjects: 6, maxWidth: 400 }),
+    );
+    expect(perProject.detail).toBe("projects");
+    expect(perProject.degraded).toBe(true);
+    expect(perProject.line).toContain("acme/project-with-a-long-name-0 1w 256M");
+    expect(perProject.line).not.toContain(":w-0");
+
+    // Narrow enough that even the per-project aggregate cannot fit: the line
+    // drops to the host total rather than printing half a project.
+    const hostOnly = renderRedskilledStatusline(
+      payload,
+      options({ mode: "global", maxWorkers: 3, maxProjects: 6, maxWidth: 40 }),
+    );
+    expect(hostOnly.detail).toBe("host");
+    expect(hostOnly.line).toBe("host 6w/6p 1.5G");
+    expect([...hostOnly.line].length).toBeLessThanOrEqual(40);
+  });
+
+  it("never exceeds the declared width, at any width", () => {
+    const workers = crowdedWorkers(9);
+    const payload = payloadOf(workers, Object.fromEntries(workers.map((w) => [w.worker_id, 128 * MB])));
+
+    for (const maxWidth of [5, 12, 40, 80, 200]) {
+      for (const mode of ["local", "global"] as const) {
+        const render = renderRedskilledStatusline(
+          payload,
+          options({ mode, project: workers[0].project_label, maxWidth, maxProjects: 9, maxWorkers: 9 }),
+        );
+        expect([...render.line].length).toBeLessThanOrEqual(maxWidth);
+      }
+    }
+  });
+
+  it("says a Worker is unmeasured rather than showing it as idle", () => {
+    const payload = payloadOf([worker()], {});
+    const render = renderRedskilledStatusline(payload, options({ project: "acme/widgets" }));
+    expect(render.line).toContain("w-1 ?");
+    expect(render.line).not.toContain("w-1 0B");
+  });
+
+  it("marks a stale answer, and calls an idle host neither stale nor busy", () => {
+    const stale = payloadOf([worker()], { "w-1": 64 * MB }, { now: "2026-07-29T01:01:00.000Z" });
+    expect(renderRedskilledStatusline(stale, options({ project: "acme/widgets" })).stale).toBe(true);
+    expect(renderRedskilledStatusline(stale, options({ project: "acme/widgets" })).line).toContain("!stale 60s");
+
+    const idle = payloadOf([], {}, { sampledAt: null });
+    const render = renderRedskilledStatusline(idle, options({ project: "acme/widgets" }));
+    expect(render.stale).toBe(false);
+    expect(render.line).toBe("acme/widgets 0w 0B idle");
+  });
+});
+
+describe("the statusline config block", () => {
+  const config = [
+    "plugins:",
+    "  dev:",
+    "    statusline:",
+    "      mode: global",
+    "      max_workers: 2",
+    "      max_projects: 7",
+    "      max_width: 90",
+  ].join("\n");
+
+  it("honours declared defaults with no flags passed", () => {
+    const resolved = resolveRedskilledStatuslineOptions({ configText: config, project: "acme/widgets" });
+
+    expect(resolved.options).toMatchObject({
+      mode: "global",
+      project: "acme/widgets",
+      maxWorkers: 2,
+      maxProjects: 7,
+      maxWidth: 90,
+    });
+    expect(resolved.warnings).toEqual([]);
+  });
+
+  it("lets a flag override the config", () => {
+    const { flags } = parseRedskilledStatuslineFlags(["local", "--max-width", "60"]);
+    const resolved = resolveRedskilledStatuslineOptions({ configText: config, project: "acme/widgets", flags });
+
+    expect(resolved.options.mode).toBe("local");
+    expect(resolved.options.maxWidth).toBe(60);
+    // Untouched keys keep the declared value rather than reverting to built-ins.
+    expect(resolved.options.maxWorkers).toBe(2);
+  });
+
+  it("reads the folded `dev.statusline.*` spelling too", () => {
+    const folded = ["dev:", "  statusline:", "    mode: global"].join("\n");
+    expect(readRedskilledStatuslineConfig(folded).config.mode).toBe("global");
+  });
+
+  it("ignores and names a malformed value instead of refusing to render", () => {
+    const broken = ["plugins:", "  dev:", "    statusline:", "      mode: sideways", "      max_width: wide"].join("\n");
+    const resolved = resolveRedskilledStatuslineOptions({ configText: broken, project: "acme/widgets" });
+
+    expect(resolved.options.mode).toBe(REDSKILLED_STATUSLINE_DEFAULTS.mode);
+    expect(resolved.options.maxWidth).toBe(REDSKILLED_STATUSLINE_DEFAULTS.maxWidth);
+    expect(resolved.warnings.map((w) => w.reason)).toEqual([
+      "expected `local` or `global`",
+      "expected a whole number of zero or more",
+    ]);
+  });
+
+  it("takes no flags at all and still resolves the built-in defaults", () => {
+    expect(resolveRedskilledStatuslineOptions().options).toEqual(REDSKILLED_STATUSLINE_DEFAULTS);
+  });
+});
+
+describe("one renderer, machine-wide", () => {
+  // Sources that may legitimately touch the payload: the renderer itself, the
+  // daemon that serves both surfaces, the wire contract, the client, and tests.
+  const PAYLOAD_CONSUMERS = new Set([
+    "apps/redskilled/src/statusline-render.ts",
+    "apps/redskilled/src/statusline-payload.ts",
+    "apps/redskilled/src/daemon.ts",
+    "apps/redskilled/src/protocol.ts",
+    "apps/redskilled/src/client.ts",
+  ]);
+
+  it("keeps every other surface — every agent host included — on the string", () => {
+    const root = join(import.meta.dirname, "..", "..", "..");
+    const offenders: string[] = [];
+
+    for (const area of ["apps", "packages", "plugins"]) {
+      const dir = join(root, area);
+      if (!existsSync(dir)) continue;
+      for (const entry of readdirSync(dir, { recursive: true, encoding: "utf8" })) {
+        const rel = `${area}/${entry.split(sep).join("/")}`;
+        if (!/\.(ts|mts|mjs|js)$/.test(rel)) continue;
+        if (rel.includes("/node_modules/") || rel.includes("/dist/") || rel.includes("/tests/")) continue;
+        if (PAYLOAD_CONSUMERS.has(rel)) continue;
+        const file = join(root, rel);
+        if (!statSync(file).isFile()) continue;
+        // The MODULE, not the op name: `"statusline-payload"` as a wire verb is
+        // a string every reach table may hold; importing the module is what
+        // gives a surface the structure to render from.
+        if (/statusline-payload\.js/.test(readFileSync(file, "utf8"))) offenders.push(rel);
+      }
+    }
+
+    // A surface importing the payload is a surface that can build its own line;
+    // the tool returns a finished string precisely so none of them needs to.
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("the host's whole job", () => {
+  it("is one command that prints the daemon's line, config-resolved on the client side", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      stopWorker: () => true,
+      clock: () => "2026-07-29T01:00:05.000Z",
+      memorySampler: () => ({ "w-1": 512 * MB }),
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+    await daemon.sampleMemoryBudgets();
+
+    const cwd = await scratch("redskilled-statusline-project-");
+    await mkdir(join(cwd, ".red"), { recursive: true });
+    await writeFile(
+      join(cwd, ".red", "config.yaml"),
+      ["project:", "  name: acme/widgets", "plugins:", "  dev:", "    statusline:", "      mode: global", ""].join("\n"),
+      "utf8",
+    );
+
+    const written: string[] = [];
+    const code = await runStatusline([], {
+      cwd,
+      paths,
+      write: (line) => written.push(line),
+      warn: () => undefined,
+    });
+
+    expect(code).toBe(0);
+    expect(written).toHaveLength(1);
+    // The config declared `global`; the host passed no flag and still gets it,
+    // and the owning project rides on the Worker.
+    expect(written[0]).toContain("host 1w/1p");
+    expect(written[0]).toContain("acme/widgets:w-1 512M/1G");
+    expect(written[0].endsWith("\n")).toBe(true);
+  });
+});

--- a/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -191,3 +191,31 @@ and idempotent; disable it by removing the second `SessionStart` entry in
 ## OpenCode Adapter
 
 Nothing to install: OpenCode is an AFK API-auth runner lane (`--runner opencode`), not an interactive host UI, so it has no footer/statusline adapter — observe it through `/afk monitor`, `/afk dashboard`, and Actions output like any other runner.
+
+## Worker Statusline Modes And Config
+
+**The Worker line comes from the daemon finished; no host renders it.** `redskilled` serves two ops over one socket — `statusline-payload` for a surface that needs structure, `statusline-string` for one that needs a line — and the string is a **pure function of the payload**, proven by test rather than by discipline. ADR 0130 rule 10 moved rendering here precisely so Claude Code, Codex and OpenCode print identical lines without any of them reimplementing anything.
+
+| Invocation | What it lists |
+| --- | --- |
+| `redskilled statusline` | the local project's Workers only — the quiet default |
+| `redskilled statusline global` | every project's Workers, each entry naming its owning project |
+| `redskilled statusline --max-width 60` | the same, under a narrower line |
+
+**A crowded machine degrades rather than overflowing.** Too many Workers for the count budget or the width drops the line to one entry per project; too many projects drops it to the host total (`host 6w/6p 1.5G`). The statusline answers "who is using this machine and how much" — the full picture stays with `/afk dashboard` and `/afk monitor`.
+
+### The config block
+
+Declare the defaults once under `plugins.dev.statusline.*` (the folded `dev.statusline.*` spelling is read too). Precedence is one sentence: **flag beats config beats built-in.**
+
+```yaml
+plugins:
+  dev:
+    statusline:
+      mode: local          # `local` (default) or `global`
+      max_workers: 4       # Worker entries before the line drops to projects
+      max_projects: 4      # project entries before the line drops to the host total
+      max_width: 120       # hard ceiling in characters; the line never exceeds it
+```
+
+Config is read **client-side** and only decided values cross the socket — the daemon must never learn what a `.red/config.yaml` is (ADR 0130 rule 3). A malformed value is named on stderr and ignored: this line renders on every turn, and a blank statusline is the harder failure to diagnose than a wrong `max_width`.

--- a/packaging/pi/dev/skills/engineering/red-statusline/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/red-statusline/SKILL.md
@@ -35,7 +35,13 @@ disable-model-invocation: true
 
 **Install nothing.** OpenCode is a runner lane, not an interactive host UI with a footer adapter. Point the user to `/afk monitor`, `/afk dashboard`, and Actions output. The full note is in [HOST-NOTES.md](HOST-NOTES.md#opencode-adapter).
 
-## 5. Finish
+## 5. Report The Worker Modes
+
+**Never render the Worker line yourself.** The daemon serves it finished — `redskilled statusline` prints the local project's Workers, `redskilled statusline global` prints every project's and names the owner of each. A host that formatted its own line would be the second renderer that drifts from the first (ADR 0130 rule 10).
+
+**State the mode and the declared defaults, do not guess them.** Read `plugins.dev.statusline.*` from `.red/config.yaml` and report what it declares; the keys are in [HOST-NOTES.md](HOST-NOTES.md#worker-statusline-modes-and-config).
+
+## 6. Finish
 
 Tell the user which host branch you used, what changed or why nothing changed, and how to observe live AFK state.
 
@@ -49,6 +55,7 @@ Tell the user which host branch you used, what changed or why nothing changed, a
 - **Claude Code command-backed adapter:** [HOST-NOTES.md](HOST-NOTES.md#claude-code-adapter-recipe).
 - **Codex native footer adapter:** [HOST-NOTES.md](HOST-NOTES.md#codex-adapter-recipe).
 - **OpenCode no-install note:** [HOST-NOTES.md](HOST-NOTES.md#opencode-adapter).
+- **Worker modes and the config block:** [HOST-NOTES.md](HOST-NOTES.md#worker-statusline-modes-and-config).
 
 ## Invocation Notes
 

--- a/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -191,3 +191,31 @@ and idempotent; disable it by removing the second `SessionStart` entry in
 ## OpenCode Adapter
 
 Nothing to install: OpenCode is an AFK API-auth runner lane (`--runner opencode`), not an interactive host UI, so it has no footer/statusline adapter — observe it through `/afk monitor`, `/afk dashboard`, and Actions output like any other runner.
+
+## Worker Statusline Modes And Config
+
+**The Worker line comes from the daemon finished; no host renders it.** `redskilled` serves two ops over one socket — `statusline-payload` for a surface that needs structure, `statusline-string` for one that needs a line — and the string is a **pure function of the payload**, proven by test rather than by discipline. ADR 0130 rule 10 moved rendering here precisely so Claude Code, Codex and OpenCode print identical lines without any of them reimplementing anything.
+
+| Invocation | What it lists |
+| --- | --- |
+| `redskilled statusline` | the local project's Workers only — the quiet default |
+| `redskilled statusline global` | every project's Workers, each entry naming its owning project |
+| `redskilled statusline --max-width 60` | the same, under a narrower line |
+
+**A crowded machine degrades rather than overflowing.** Too many Workers for the count budget or the width drops the line to one entry per project; too many projects drops it to the host total (`host 6w/6p 1.5G`). The statusline answers "who is using this machine and how much" — the full picture stays with `/afk dashboard` and `/afk monitor`.
+
+### The config block
+
+Declare the defaults once under `plugins.dev.statusline.*` (the folded `dev.statusline.*` spelling is read too). Precedence is one sentence: **flag beats config beats built-in.**
+
+```yaml
+plugins:
+  dev:
+    statusline:
+      mode: local          # `local` (default) or `global`
+      max_workers: 4       # Worker entries before the line drops to projects
+      max_projects: 4      # project entries before the line drops to the host total
+      max_width: 120       # hard ceiling in characters; the line never exceeds it
+```
+
+Config is read **client-side** and only decided values cross the socket — the daemon must never learn what a `.red/config.yaml` is (ADR 0130 rule 3). A malformed value is named on stderr and ignored: this line renders on every turn, and a blank statusline is the harder failure to diagnose than a wrong `max_width`.

--- a/plugins/dev/skills/engineering/red-statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/red-statusline/SKILL.md
@@ -35,7 +35,13 @@ disable-model-invocation: true
 
 **Install nothing.** OpenCode is a runner lane, not an interactive host UI with a footer adapter. Point the user to `/afk monitor`, `/afk dashboard`, and Actions output. The full note is in [HOST-NOTES.md](HOST-NOTES.md#opencode-adapter).
 
-## 5. Finish
+## 5. Report The Worker Modes
+
+**Never render the Worker line yourself.** The daemon serves it finished — `redskilled statusline` prints the local project's Workers, `redskilled statusline global` prints every project's and names the owner of each. A host that formatted its own line would be the second renderer that drifts from the first (ADR 0130 rule 10).
+
+**State the mode and the declared defaults, do not guess them.** Read `plugins.dev.statusline.*` from `.red/config.yaml` and report what it declares; the keys are in [HOST-NOTES.md](HOST-NOTES.md#worker-statusline-modes-and-config).
+
+## 6. Finish
 
 Tell the user which host branch you used, what changed or why nothing changed, and how to observe live AFK state.
 
@@ -49,6 +55,7 @@ Tell the user which host branch you used, what changed or why nothing changed, a
 - **Claude Code command-backed adapter:** [HOST-NOTES.md](HOST-NOTES.md#claude-code-adapter-recipe).
 - **Codex native footer adapter:** [HOST-NOTES.md](HOST-NOTES.md#codex-adapter-recipe).
 - **OpenCode no-install note:** [HOST-NOTES.md](HOST-NOTES.md#opencode-adapter).
+- **Worker modes and the config block:** [HOST-NOTES.md](HOST-NOTES.md#worker-statusline-modes-and-config).
 
 ## Invocation Notes
 


### PR DESCRIPTION
Automated AFK landing for #2792. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2792

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787943476&installation_model_id=20659&pr_number=2819&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2819&signature=09843b448559d8657fd1593423da5f00bce8b3f5c7ea3469cb6eb7e510e2efa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->