### PR TITLE
chore: #2782 macOS placement backend through rlimits and priority

### DIFF
--- a/apps/redskilled/src/memory-sampler.ts
+++ b/apps/redskilled/src/memory-sampler.ts
@@ -22,6 +22,7 @@
  *
  * PURE except for {@link sampleTreeRss}, the one function that reads the host.
  */
+import { execFileSync } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { parseMemoryBudget } from "./budget-accounting.js";
@@ -190,25 +191,33 @@ export function buildBudgetTermination(
 const PAGE_SIZE_BYTES = 4096;
 
 /**
- * Read every Worker's tree RSS from `/proc` in ONE pass over the process table.
+ * Read every Worker's tree RSS in ONE pass over the host's process table.
  *
  * The pass is shared: the process table is read once and each Worker's subtree is
  * summed out of that one snapshot, so a host holding ten Workers pays what a host
  * holding one pays. A Worker whose pid is gone is absent from the reading rather
- * than zero, and a platform without `/proc` yields an empty reading — where the
- * kernel backend enforces, this floor is redundant, and where nothing enforces,
- * an empty reading is the honest report that nothing was measured.
+ * than zero.
+ *
+ * **The source of the table is the platform's, and only the source differs.**
+ * Linux reads `/proc`; macOS reads `ps`, because it has no `/proc` and IS the
+ * platform where this floor is the memory ceiling rather than a redundant second
+ * one — a macOS sampler that returned nothing would leave the only backend
+ * without kernel teeth with no teeth at all. A host whose table cannot be read
+ * yields an empty reading, which is the honest report that nothing was measured.
  */
 export function sampleTreeRss(
   workers: readonly RedskilledWorkerView[],
-  options: { readonly procRoot?: string; readonly platform?: NodeJS.Platform } = {},
+  options: {
+    readonly procRoot?: string;
+    readonly platform?: NodeJS.Platform;
+    /** Injected `ps` output, so the macOS arm is provable off a Mac. */
+    readonly psTable?: () => string;
+  } = {},
 ): RedskilledRssReading {
   const platform = options.platform ?? process.platform;
-  const procRoot = options.procRoot ?? "/proc";
-  if (platform !== "linux" && options.procRoot == null) return {};
   if (workers.length === 0) return {};
 
-  const table = readProcessTable(procRoot);
+  const table = readHostProcessTable(platform, options);
   if (table.size === 0) return {};
 
   const children = new Map<number, number[]>();
@@ -230,7 +239,7 @@ export function sampleTreeRss(
       seen.add(pid);
       const entry = table.get(pid);
       if (!entry) continue;
-      total += entry.rssPages * PAGE_SIZE_BYTES;
+      total += entry.rssBytes;
       for (const child of children.get(pid) ?? []) queue.push(child);
     }
     reading[worker.worker_id] = total;
@@ -238,14 +247,79 @@ export function sampleTreeRss(
   return reading;
 }
 
+/** One `/proc` row, in the kernel's own units. */
 interface ProcessEntry {
   readonly pid: number;
   readonly ppid: number;
   readonly rssPages: number;
 }
 
-function readProcessTable(procRoot: string): Map<number, ProcessEntry> {
-  const table = new Map<number, ProcessEntry>();
+/**
+ * One row of the host's process table, in bytes.
+ *
+ * Bytes rather than each source's own unit — pages on Linux, KiB from `ps` —
+ * because the summation above must not have to know which platform produced the
+ * row it is adding.
+ */
+interface HostProcessEntry {
+  readonly pid: number;
+  readonly ppid: number;
+  readonly rssBytes: number;
+}
+
+/**
+ * The host's process table, from whichever source this platform has.
+ *
+ * An injected `procRoot` or `psTable` picks the arm regardless of platform, so
+ * each source is provable on a machine that is not the one it belongs to.
+ */
+function readHostProcessTable(
+  platform: NodeJS.Platform,
+  options: { readonly procRoot?: string; readonly psTable?: () => string },
+): Map<number, HostProcessEntry> {
+  if (options.procRoot != null || platform === "linux") return readProcessTable(options.procRoot ?? "/proc");
+  if (options.psTable != null || platform === "darwin") return parsePsTable(readPsTable(options.psTable));
+  return new Map();
+}
+
+/** `ps` in one call, or the empty string — an unreadable table is never a crash. */
+function readPsTable(injected?: () => string): string {
+  try {
+    return (injected ?? runPs)();
+  } catch {
+    return "";
+  }
+}
+
+function runPs(): string {
+  return execFileSync("ps", ["-axo", "pid=,ppid=,rss="], { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 });
+}
+
+/** How `ps` reports RSS on macOS. */
+const PS_RSS_UNIT_BYTES = 1024;
+
+/**
+ * Parse `ps -axo pid=,ppid=,rss=` output into the host process table. PURE.
+ *
+ * Every line that is not three numbers is skipped rather than guessed at: a
+ * header a future `ps` decides to print, or a truncated final line, must cost a
+ * row and never a wrong parent — a mis-parsed ppid would attribute a stranger's
+ * memory to a Worker and terminate it for someone else's leak.
+ */
+export function parsePsTable(raw: string): Map<number, HostProcessEntry> {
+  const table = new Map<number, HostProcessEntry>();
+  for (const line of raw.split("\n")) {
+    const fields = line.trim().split(/\s+/);
+    if (fields.length !== 3) continue;
+    const [pid, ppid, rssKib] = fields.map(Number);
+    if (![pid, ppid, rssKib].every((value) => value != null && Number.isSafeInteger(value) && value >= 0)) continue;
+    table.set(pid!, { pid: pid!, ppid: ppid!, rssBytes: rssKib! * PS_RSS_UNIT_BYTES });
+  }
+  return table;
+}
+
+function readProcessTable(procRoot: string): Map<number, HostProcessEntry> {
+  const table = new Map<number, HostProcessEntry>();
   let entries: string[];
   try {
     entries = readdirSync(procRoot);
@@ -263,7 +337,7 @@ function readProcessTable(procRoot: string): Map<number, ProcessEntry> {
       continue;
     }
     const entry = parseProcStat(raw);
-    if (entry) table.set(entry.pid, entry);
+    if (entry) table.set(entry.pid, { pid: entry.pid, ppid: entry.ppid, rssBytes: entry.rssPages * PAGE_SIZE_BYTES });
   }
   return table;
 }

--- a/apps/redskilled/src/posix-limits.ts
+++ b/apps/redskilled/src/posix-limits.ts
@@ -1,0 +1,218 @@
+/**
+ * posix-limits — the macOS placement backend, and the ceiling it refuses to claim.
+ *
+ * **macOS has no resource-group equivalent, and this backend does not pretend
+ * otherwise.** Linux gets a cgroup through a transient unit and Windows gets a
+ * Job Object; both carry a memory ceiling the kernel enforces. macOS offers
+ * POSIX rlimits and priority, and the rlimit that looks like a memory ceiling —
+ * `RLIMIT_AS` — bounds ADDRESS SPACE rather than resident memory. A runtime that
+ * reserves address space it never faults in would die under a limit it never
+ * used, so setting one would trade a real ceiling for a lie about a fake one.
+ * The daemon's RSS sampling floor stays the memory ceiling that actually holds
+ * here (ADR 0130 rule 4), and every sentence this module produces says so.
+ *
+ * **What it genuinely adds is priority.** A Worker that runs at a positive nice
+ * yields to the operator's interactive work, which is the difference between a
+ * busy machine and an unusable one — a real tooth, just not the memory one.
+ *
+ * **An rlimit is set only where it behaves predictably.** `ulimit -u` and
+ * `ulimit -t` are carried when a client declares them and dropped, by name, when
+ * the declared value cannot become one — never silently rounded into something
+ * nobody asked for.
+ *
+ * PURE, entirely: the host is read in `worker-placement`'s probe and nowhere here,
+ * which is what lets every case be proven on a machine that is not a Mac.
+ */
+import { CPU_WEIGHT_FAIR_SHARE } from "./job-object.js";
+import type { RedskilledWorkerBudget } from "./worker-placement.js";
+
+/**
+ * The nice a Worker runs at when nothing asked for more.
+ *
+ * Positive by default rather than on request: yielding to interactive work is
+ * the reason this backend exists, so it is the behaviour a client gets without
+ * having to know the platform it landed on.
+ */
+export const WORKER_YIELD_NICE = 5;
+
+/** The kernel's highest nice — the most a process can yield. */
+export const MAX_POSIX_NICE = 19;
+
+/**
+ * Whether this host can wrap a launch in POSIX limits, and when it cannot, why.
+ *
+ * `nice` is a nullable PATH answer INSIDE the available arm rather than a second
+ * unavailable reason: a host with a shell and no `nice` still gets its rlimits,
+ * and only loses the priority half — a degradation worth naming, not one worth
+ * refusing the whole backend over.
+ */
+export type RedskilledPosixReach =
+  | { readonly available: true; readonly shell: string; readonly nice: string | null }
+  | { readonly available: false; readonly reason: string };
+
+/** POSIX reach is unavailable, with the sentence a warning will quote. PURE. */
+export function posixLimitsUnavailable(reason: string): RedskilledPosixReach {
+  return { available: false, reason };
+}
+
+/**
+ * The limits one Worker's shell applies to itself before it execs.
+ *
+ * `memory_ceiling` is a literal `"sampling-floor"` rather than an optional
+ * number: it is not a value this backend could one day fill in, it is the
+ * statement that the ceiling lives somewhere else — and a reader who had to
+ * infer that from an absent field is a reader who will infer it wrong.
+ */
+export interface RedskilledPosixLimits {
+  /** The nice the Worker runs at. Absent only when the host has no `nice`. */
+  readonly nice?: number;
+  /** `RLIMIT_NPROC`, via `ulimit -u`. Set only when a client declared one. */
+  readonly max_processes?: number;
+  /** `RLIMIT_CPU` in seconds, via `ulimit -t`. Set only when a client declared one. */
+  readonly cpu_seconds?: number;
+  /** Always the floor: macOS has no per-process resident-memory ceiling to set. */
+  readonly memory_ceiling: "sampling-floor";
+  /** Why there is no memory rlimit — quoted into the launch's warning. */
+  readonly memory_ceiling_reason: string;
+  /** Set when something declared could not be carried, naming the field. */
+  readonly note?: string;
+}
+
+/** The sentence every macOS launch carries about its missing memory ceiling. */
+export const POSIX_MEMORY_CEILING_REASON =
+  "an address-space rlimit is not a resident-memory ceiling: a runtime that reserves address space it never faults in " +
+  "would die under a limit it never used, so no memory rlimit is set and the daemon's RSS sampling floor is the ceiling " +
+  "that actually holds";
+
+/**
+ * The limits a budget asks for on this host. PURE.
+ *
+ * A weight BELOW the fair share deepens the yield proportionally; a weight at or
+ * above it buys nothing, because raising a process's priority needs privilege
+ * the daemon does not have and must not claim. That asymmetry is the same one
+ * the Windows backend refuses to smooth over — a client asking for more than its
+ * share gets the default and a sentence, never an invented limit.
+ */
+export function planPosixLimits(
+  budget: RedskilledWorkerBudget | undefined,
+  reach: { readonly canRenice: boolean },
+): RedskilledPosixLimits {
+  const declared = budget ?? {};
+  const notes: string[] = [];
+
+  let nice: number | undefined;
+  if (!reach.canRenice) {
+    notes.push("nice is not on this host, so no priority control was applied and the Worker competes with interactive work");
+  } else if (declared.cpu_weight == null) {
+    nice = WORKER_YIELD_NICE;
+  } else if (declared.cpu_weight < CPU_WEIGHT_FAIR_SHARE) {
+    const scaled = Math.round((MAX_POSIX_NICE * (CPU_WEIGHT_FAIR_SHARE - declared.cpu_weight)) / CPU_WEIGHT_FAIR_SHARE);
+    nice = Math.min(MAX_POSIX_NICE, Math.max(WORKER_YIELD_NICE, scaled));
+  } else {
+    nice = WORKER_YIELD_NICE;
+    notes.push(
+      `cpu_weight=${declared.cpu_weight} is at or above the fair share of ${CPU_WEIGHT_FAIR_SHARE}, and raising a ` +
+        `process's priority requires privilege this daemon does not have, so the Worker keeps the default yield of nice ` +
+        `${WORKER_YIELD_NICE}`,
+    );
+  }
+
+  const maxProcesses = positiveInteger(declared.max_processes);
+  if (maxProcesses == null && declared.max_processes != null) {
+    notes.push(`max_processes=${declared.max_processes} is not a positive whole number, so no ulimit -u is set`);
+  }
+  const cpuSeconds = positiveInteger(declared.cpu_seconds);
+  if (cpuSeconds == null && declared.cpu_seconds != null) {
+    notes.push(`cpu_seconds=${declared.cpu_seconds} is not a positive whole number, so no ulimit -t is set`);
+  }
+
+  return {
+    ...(nice != null ? { nice } : {}),
+    ...(maxProcesses != null ? { max_processes: maxProcesses } : {}),
+    ...(cpuSeconds != null ? { cpu_seconds: cpuSeconds } : {}),
+    memory_ceiling: "sampling-floor",
+    memory_ceiling_reason: POSIX_MEMORY_CEILING_REASON,
+    ...(notes.length > 0 ? { note: notes.join("; ") } : {}),
+  };
+}
+
+/**
+ * The shell argv that applies these limits and then becomes the Worker. PURE.
+ *
+ * The command and its arguments ride as `"$0"` and `"$@"` rather than being
+ * interpolated into the script, so a workspace, a flag or a path containing
+ * spaces or quotes is passed through byte-for-byte — a launcher that quoted its
+ * own payload into a script would be one argument away from running something
+ * else. `exec` is what makes the shell disappear: the Worker keeps the pid the
+ * daemon sampled and there is no extra process between it and its limits.
+ */
+export function posixLimitsShellArgv(input: {
+  readonly limits: RedskilledPosixLimits;
+  readonly nice: string | null;
+  readonly command: string;
+  readonly args: readonly string[];
+}): readonly string[] {
+  const { limits } = input;
+  const lines: string[] = [];
+  // A ulimit the host refuses (a hard limit already lower) prints and continues:
+  // a Worker that never started because it could not lower a soft limit would be
+  // a worse outcome than one running under the limit it inherited.
+  if (limits.max_processes != null) lines.push(`ulimit -u ${limits.max_processes}`);
+  if (limits.cpu_seconds != null) lines.push(`ulimit -t ${limits.cpu_seconds}`);
+  lines.push(
+    limits.nice != null && input.nice != null
+      ? `exec ${quote(input.nice)} -n ${limits.nice} "$0" "$@"`
+      : 'exec "$0" "$@"',
+  );
+  return ["-c", lines.join("\n"), input.command, ...input.args];
+}
+
+/**
+ * The whole sentence a macOS launch carries. PURE.
+ *
+ * It states the teeth AND the missing one in the same breath, because this
+ * placement is a downgrade and an upgrade at once: an operator reading only
+ * "unisolated" would miss the priority, and one reading only "nice 5" would
+ * think the memory budget had a kernel behind it.
+ */
+export function describePosixPlacement(limits: RedskilledPosixLimits): string {
+  const applied: string[] = [];
+  if (limits.nice != null) applied.push(`the Worker runs at nice ${limits.nice} so it yields to interactive work`);
+  else applied.push("no priority control was applied");
+  if (limits.max_processes != null) applied.push(`its processes are capped at ${limits.max_processes}`);
+  if (limits.cpu_seconds != null) applied.push(`its CPU time is capped at ${limits.cpu_seconds} seconds`);
+  return (
+    `macOS placement applied POSIX limits: ${applied.join(", ")}. macOS has no resource-group equivalent, so the ` +
+    `Worker is charged to the daemon's own resource group, and ${limits.memory_ceiling_reason}` +
+    (limits.note != null ? ` (${limits.note})` : "")
+  );
+}
+
+/**
+ * Name the POSIX-only budget fields a non-POSIX backend cannot carry. PURE.
+ *
+ * Returns `null` when there is nothing to say. A declared limit that quietly
+ * did nothing is the failure this repository already pays warnings to avoid, so
+ * the fields are named on the backends that ignore them rather than only
+ * honoured on the one that does not.
+ */
+export function unenforcedPosixBudgetFields(budget: RedskilledWorkerBudget | undefined): string | null {
+  const declared = budget ?? {};
+  const fields = [
+    declared.max_processes != null ? "max_processes" : null,
+    declared.cpu_seconds != null ? "cpu_seconds" : null,
+  ].filter((field): field is string => field != null);
+  if (fields.length === 0) return null;
+  return `${fields.join(" and ")} ${fields.length === 1 ? "is a POSIX rlimit" : "are POSIX rlimits"} honoured only by the macOS placement backend, so this placement carries no equivalent`;
+}
+
+function positiveInteger(value: number | undefined): number | undefined {
+  if (value == null) return undefined;
+  if (!Number.isSafeInteger(value) || value <= 0) return undefined;
+  return value;
+}
+
+/** Single-quote a path for `sh`, so a host-supplied path is a word and not a script. */
+function quote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -26,6 +26,15 @@ import {
   type RedskilledJobLimits,
   type RedskilledJobObjectReach,
 } from "./job-object.js";
+import {
+  describePosixPlacement,
+  planPosixLimits,
+  posixLimitsShellArgv,
+  posixLimitsUnavailable,
+  unenforcedPosixBudgetFields,
+  type RedskilledPosixLimits,
+  type RedskilledPosixReach,
+} from "./posix-limits.js";
 
 /** Env kill-switch: `REDSKILLED_PLACEMENT=off` launches unisolated — loudly. */
 export const REDSKILLED_PLACEMENT_ENV = "REDSKILLED_PLACEMENT";
@@ -48,7 +57,19 @@ export interface WorkerPlacementProbes {
    * the silent downgrade this field exists to prevent.
    */
   readonly jobObjects: RedskilledJobObjectReach;
+  /**
+   * Whether POSIX rlimits and priority are reachable here, and when not, why.
+   *
+   * The macOS arm of the same shape `jobObjects` has, for the same reason: this
+   * backend is the one that adds real teeth without adding a memory ceiling, so
+   * a host that cannot even reach it must degrade with a sentence rather than a
+   * flag.
+   */
+  readonly posix: RedskilledPosixReach;
 }
+
+/** The POSIX shell a macOS launch wraps itself in. Present on every Unix host. */
+export const POSIX_SHELL_PATH = "/bin/sh";
 
 /**
  * Where the client wants the Worker placed.
@@ -65,7 +86,7 @@ export interface RedskilledPlacementTarget {
    * on Windows gets a Job Object rather than a refusal — the answer to "isolate
    * me" must not depend on the client guessing the platform right.
    */
-  readonly isolation: "transient-unit" | "job-object" | "inherit";
+  readonly isolation: "transient-unit" | "job-object" | "posix-limits" | "inherit";
   readonly unit_prefix?: string;
 }
 
@@ -74,6 +95,14 @@ export interface RedskilledWorkerBudget {
   readonly memory_high?: string;
   readonly memory_max?: string;
   readonly cpu_weight?: number;
+  /**
+   * `RLIMIT_NPROC`, honoured by the macOS backend and named as unenforced by the
+   * others — a declared limit that quietly did nothing is the failure every
+   * warning in this module exists to prevent.
+   */
+  readonly max_processes?: number;
+  /** `RLIMIT_CPU` in seconds, on the same terms as {@link max_processes}. */
+  readonly cpu_seconds?: number;
 }
 
 /**
@@ -82,7 +111,7 @@ export interface RedskilledWorkerBudget {
  * `none` is a first-class answer, not an absent one: an unisolated launch is a
  * decision the host made, and it is read alongside its warning.
  */
-export type WorkerPlacementBackend = "transient-unit" | "job-object" | "none";
+export type WorkerPlacementBackend = "transient-unit" | "job-object" | "posix-limits" | "none";
 
 /** The Job Object a Windows plan asks for. The handle itself is minted at launch. */
 export interface WorkerJobObjectPlan {
@@ -91,9 +120,16 @@ export interface WorkerJobObjectPlan {
 }
 
 export interface WorkerPlacementPlan {
-  /** True when the Worker runs inside a resource group of its own. */
+  /**
+   * True when the Worker runs inside a resource group of its own.
+   *
+   * `posix-limits` is deliberately NOT isolated: macOS has no resource group to
+   * put a Worker in, so its memory charge lands on the daemon exactly as an
+   * unisolated launch's does — and the host-wide accounting must keep counting it
+   * that way, however many rlimits the launch also carries.
+   */
   readonly isolated: boolean;
-  /** The backend that isolated it, or `none`. Always set. */
+  /** The backend that placed it, or `none`. Always set. */
   readonly backend: WorkerPlacementBackend;
   readonly command: string;
   readonly args: readonly string[];
@@ -103,6 +139,8 @@ export interface WorkerPlacementPlan {
   readonly unit?: string;
   /** The Job Object to mint and assign this Worker to, only under `job-object`. */
   readonly job?: WorkerJobObjectPlan;
+  /** The rlimits and priority the launch applies to itself, only under `posix-limits`. */
+  readonly posix?: RedskilledPosixLimits;
   /**
    * Why isolation was skipped, and what the caller now carries instead. ALWAYS
    * set when `isolated` is false.
@@ -124,18 +162,52 @@ export function detectWorkerPlacementProbes(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
 ): WorkerPlacementProbes {
+  const noPosix = posixLimitsUnavailable(
+    `POSIX rlimit and priority placement is the macOS backend (platform=${platform})`,
+  );
   if (platform === "win32") {
-    return { platform, systemdRun: null, userSession: false, jobObjects: loadJobObjectBinding({ platform }) };
+    return {
+      platform,
+      systemdRun: null,
+      userSession: false,
+      jobObjects: loadJobObjectBinding({ platform }),
+      posix: noPosix,
+    };
   }
   const noJobObjects = jobObjectsUnavailable(
     `Job Object placement is the Windows backend (platform=${platform}), so there is no native reach to load here`,
   );
+  if (platform === "darwin") {
+    return { platform, systemdRun: null, userSession: false, jobObjects: noJobObjects, posix: detectPosixReach(env) };
+  }
   if (platform !== "linux") {
-    return { platform, systemdRun: null, userSession: false, jobObjects: noJobObjects };
+    return { platform, systemdRun: null, userSession: false, jobObjects: noJobObjects, posix: noPosix };
   }
   const runtimeDir = (env.XDG_RUNTIME_DIR ?? "").trim();
   const userSession = runtimeDir !== "" && existsSync(join(runtimeDir, "systemd", "private"));
-  return { platform, systemdRun: which("systemd-run", env), userSession, jobObjects: noJobObjects };
+  return {
+    platform,
+    systemdRun: which("systemd-run", env),
+    userSession,
+    jobObjects: noJobObjects,
+    posix: noPosix,
+  };
+}
+
+/**
+ * Whether this host can wrap a launch in `sh` and, separately, in `nice`.
+ *
+ * The shell is checked on disk rather than looked up on PATH, because it is the
+ * process the daemon is about to exec by absolute path — a `sh` that exists only
+ * on a PATH the Worker will not inherit is not the one that would run.
+ */
+function detectPosixReach(env: NodeJS.ProcessEnv): RedskilledPosixReach {
+  if (!existsSync(POSIX_SHELL_PATH)) {
+    return posixLimitsUnavailable(
+      `no POSIX shell was found at ${POSIX_SHELL_PATH}, so there is nothing to apply rlimits or priority in`,
+    );
+  }
+  return { available: true, shell: POSIX_SHELL_PATH, nice: which("nice", env) };
 }
 
 /** True unless the env kill-switch declines isolation for this host. */
@@ -224,6 +296,7 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
     return unisolated(`worker isolation disabled by ${REDSKILLED_PLACEMENT_ENV}: the Worker is charged to the daemon's own resource group`);
   }
   if (opts.probes.platform === "win32") return planJobObjectPlacement(opts, args, declaredBudget, unisolated);
+  if (opts.probes.platform === "darwin") return planPosixLimitsPlacement(opts, args, unisolated);
   if (opts.probes.platform !== "linux") {
     return unisolated(`transient-unit placement is the Linux backend (platform=${opts.probes.platform}): the Worker is charged to the daemon's own resource group`);
   }
@@ -251,12 +324,63 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
   if (budget.cpu_weight != null) unitArgs.push(`--property=CPUWeight=${budget.cpu_weight}`);
   for (const [key, value] of Object.entries(opts.env ?? {})) unitArgs.push(`--setenv=${key}=${value}`);
 
+  const unenforced = unenforcedPosixBudgetFields(opts.budget);
   return {
     isolated: true,
     backend: "transient-unit",
     unit,
     command: opts.probes.systemdRun,
     args: [...unitArgs, "--", opts.command, ...args],
+    ...(unenforced != null ? { budgetWarning: unenforced } : {}),
+  };
+}
+
+/**
+ * The macOS arm: rlimits and priority, with the floor left as the memory ceiling.
+ *
+ * Unlike both other backends this one returns `isolated: false` while still
+ * having done real work. That is the honesty the platform forces: the limits are
+ * genuine and the resource group does not exist, so the launch is a placement
+ * and an unisolated charge at the same time — and the accounting that decides
+ * how much of the machine is spoken for must read the second fact, not the first.
+ *
+ * With no shell to wrap the launch in, nothing is applied and the plan degrades
+ * to the plain argv with the same sentence any unisolated launch carries.
+ */
+function planPosixLimitsPlacement(
+  opts: PlanWorkerPlacementOptions,
+  args: readonly string[],
+  unisolated: (warning: string) => WorkerPlacementPlan,
+): WorkerPlacementPlan {
+  const reach = opts.probes.posix;
+  if (!reach.available) {
+    return unisolated(
+      `POSIX limit placement unavailable: ${reach.reason}. The Worker is charged to the daemon's own resource group ` +
+        "and the daemon's RSS sampling floor is the only remaining ceiling",
+    );
+  }
+
+  const limits = planPosixLimits(opts.budget, { canRenice: reach.nice != null });
+  const budget = opts.budget ?? {};
+  const declaredMemory = budget.memory_high != null || budget.memory_max != null;
+  return {
+    isolated: false,
+    backend: "posix-limits",
+    command: reach.shell,
+    args: posixLimitsShellArgv({ limits, nice: reach.nice, command: opts.command, args }),
+    cwd: opts.workspacePath,
+    posix: limits,
+    warning: describePosixPlacement(limits),
+    // Named for the same reason the Windows note is: the budget still holds, it
+    // just holds one layer down, and nobody should have to discover that from
+    // the absence of a limit.
+    ...(declaredMemory
+      ? {
+          budgetWarning:
+            `the declared memory budget is enforced by the daemon's RSS sampling floor rather than by the kernel: ` +
+            limits.memory_ceiling_reason,
+        }
+      : {}),
   };
 }
 
@@ -298,10 +422,16 @@ function planJobObjectPlacement(
     // A budget the job could not carry is named here for the same reason an
     // unisolated launch is: the floor still holds it, and nobody should have to
     // discover that from the absence of a limit.
-    ...(declaredBudget && limits.note != null
-      ? { budgetWarning: `${limits.note}; the daemon's RSS sampling floor is the ceiling for that budget` }
-      : {}),
+    ...(budgetWarningFor(declaredBudget && limits.note != null
+      ? `${limits.note}; the daemon's RSS sampling floor is the ceiling for that budget`
+      : null, unenforcedPosixBudgetFields(opts.budget))),
   };
+}
+
+/** Join what a placement could not carry into one warning, or into none. PURE. */
+function budgetWarningFor(...notes: ReadonlyArray<string | null>): { budgetWarning?: string } {
+  const said = notes.filter((note): note is string => note != null && note !== "");
+  return said.length > 0 ? { budgetWarning: said.join("; ") } : {};
 }
 
 function which(binary: string, env: NodeJS.ProcessEnv): string | null {

--- a/apps/redskilled/tests/macos-posix-limits.test.ts
+++ b/apps/redskilled/tests/macos-posix-limits.test.ts
@@ -1,0 +1,277 @@
+// The macOS placement backend, proven from injected probes with nothing spawned
+// and nothing reniced. The cases that matter here are the ones about HONESTY:
+// macOS has no resource-group equivalent, so this backend must add the priority
+// and rlimit teeth it really has WITHOUT claiming a kernel memory ceiling it
+// cannot deliver — the sampling floor stays the ceiling that actually holds.
+import { describe, expect, it } from "vitest";
+import { evaluateWorkerAdmission, UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import {
+  evaluateMemoryBudgets,
+  parsePsTable,
+  sampleTreeRss,
+} from "../src/memory-sampler.js";
+import {
+  MAX_POSIX_NICE,
+  planPosixLimits,
+  WORKER_YIELD_NICE,
+} from "../src/posix-limits.js";
+import { launchWorker } from "../src/worker-launch.js";
+import {
+  detectWorkerPlacementProbes,
+  planWorkerPlacement,
+  type WorkerPlacementProbes,
+} from "../src/worker-placement.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+
+const NO_JOB_OBJECTS = { available: false, reason: "Job Object placement is the Windows backend (platform=darwin)" } as const;
+
+const DARWIN: WorkerPlacementProbes = {
+  platform: "darwin",
+  systemdRun: null,
+  userSession: false,
+  jobObjects: NO_JOB_OBJECTS,
+  posix: { available: true, shell: "/bin/sh", nice: "/usr/bin/nice" },
+};
+const DARWIN_WITHOUT_NICE: WorkerPlacementProbes = {
+  ...DARWIN,
+  posix: { available: true, shell: "/bin/sh", nice: null },
+};
+const DARWIN_WITHOUT_SHELL: WorkerPlacementProbes = {
+  ...DARWIN,
+  posix: { available: false, reason: "no POSIX shell was found at /bin/sh" },
+};
+const LINUX: WorkerPlacementProbes = {
+  platform: "linux",
+  systemdRun: "/usr/bin/systemd-run",
+  userSession: true,
+  jobObjects: { available: false, reason: "Job Object placement is the Windows backend (platform=linux)" },
+  posix: { available: false, reason: "POSIX rlimit placement is the macOS backend (platform=linux)" },
+};
+
+function plan(probes: WorkerPlacementProbes, overrides: Record<string, unknown> = {}) {
+  return planWorkerPlacement({
+    workerId: "wQ9F2",
+    projectLabel: "acme/widgets",
+    workspacePath: "/given/workspace",
+    command: "/usr/bin/node",
+    args: ["worker.js", "--issue", "2782"],
+    budget: { memory_max: "4G", cpu_weight: 50 },
+    probes,
+    ...overrides,
+  });
+}
+
+function worker(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorkerView {
+  return {
+    worker_id: "wQ9F2",
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-07-29T00:00:00.000Z",
+    workspace_path: "/given/workspace",
+    isolated: false,
+    budget: { memory_max: "4G" },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("macOS placement — resolved from probes, with nothing spawned", () => {
+  it("wraps the argv in a POSIX shell that applies the limits and execs the command", () => {
+    const placement = plan(DARWIN);
+
+    expect(placement.backend).toBe("posix-limits");
+    expect(placement.command).toBe("/bin/sh");
+    expect(placement.args.slice(-4)).toEqual(["/usr/bin/node", "worker.js", "--issue", "2782"]);
+    expect(placement.args[0]).toBe("-c");
+    expect(placement.args[1]).toMatch(/exec '\/usr\/bin\/nice' -n \d+ "\$0" "\$@"/);
+    expect(placement.cwd).toBe("/given/workspace");
+  });
+
+  it("reads the host once, in the probe, and never on the planning path", () => {
+    const probes = detectWorkerPlacementProbes({ PATH: "" }, "darwin");
+
+    expect(probes.platform).toBe("darwin");
+    expect(probes.systemdRun).toBeNull();
+    expect(probes.jobObjects.available).toBe(false);
+    // `nice` is absent from an empty PATH; the shell is the one path this probe
+    // checks on disk, so the reach answer is a fact about the host, not a guess.
+    expect(probes.posix.available ? probes.posix.nice : null).toBeNull();
+  });
+
+  it("charges the Worker to the daemon's group and says so — macOS has no resource group to give it", () => {
+    const placement = plan(DARWIN);
+
+    expect(placement.isolated).toBe(false);
+    expect(placement.warning).toMatch(/no resource-group equivalent/);
+    expect(placement.unit).toBeUndefined();
+    expect(placement.job).toBeUndefined();
+  });
+});
+
+describe("macOS placement — the memory ceiling it refuses to claim", () => {
+  it("sets no memory rlimit at all: an address-space limit is not a resident ceiling", () => {
+    const placement = plan(DARWIN, { budget: { memory_max: "4G", memory_high: "3G" } });
+    const script = placement.args[1] ?? "";
+
+    expect(script).not.toMatch(/ulimit -[vmd]/);
+    expect(placement.posix?.memory_ceiling).toBe("sampling-floor");
+    expect(placement.posix?.memory_ceiling_reason).toMatch(/address-space/);
+  });
+
+  it("names the sampling floor as the enforcer of a declared memory budget", () => {
+    expect(plan(DARWIN).budgetWarning).toMatch(/RSS sampling floor/);
+    expect(plan(DARWIN, { budget: { cpu_weight: 50 } }).budgetWarning).toBeUndefined();
+  });
+
+  it("measures RSS on macOS from the process table `ps` reports, so the floor has a number to act on", () => {
+    const ps = [
+      "  100     1  1048576",
+      "  200   100  2097152",
+      "  300   999    65536",
+    ].join("\n");
+    const reading = sampleTreeRss([worker({ pid: 100 })], { platform: "darwin", psTable: () => ps });
+
+    // KiB from `ps`, bytes in the reading — the child is summed, the stranger is not.
+    expect(reading).toEqual({ wQ9F2: (1048576 + 2097152) * 1024 });
+  });
+
+  it("reports nothing rather than zero when the host process table cannot be read", () => {
+    const reading = sampleTreeRss([worker({ pid: 100 })], {
+      platform: "darwin",
+      psTable: () => {
+        throw new Error("ps: command not found");
+      },
+    });
+
+    expect(reading).toEqual({});
+  });
+
+  it("parses `ps` output and ignores every line that is not a process row", () => {
+    const table = parsePsTable("  PID  PPID   RSS\n 12 1 2048\nnonsense\n");
+
+    expect(table.get(12)).toEqual({ pid: 12, ppid: 1, rssBytes: 2048 * 1024 });
+    expect(table.size).toBe(1);
+  });
+});
+
+describe("macOS placement — the uniform floor", () => {
+  it("terminates an over-budget Worker identically on macOS and on Linux", () => {
+    const over = { wQ9F2: 5 * 1024 ** 3 };
+    const outcome = evaluateMemoryBudgets({ workers: [worker()], rss: over });
+
+    // The floor is a pure judgement over a reading and a budget: the platform is
+    // not one of its inputs, which IS the uniformity this asserts.
+    expect(outcome.terminations).toHaveLength(1);
+    expect(outcome.terminations[0]).toMatchObject({
+      outcome: "terminated-over-memory-budget",
+      classification: "budget-exceeded",
+      stall: false,
+      budget_name: "MemoryMax",
+      budget_declared: "4G",
+    });
+
+    const darwinPlanned = plan(DARWIN);
+    const linuxPlanned = plan(LINUX);
+    expect(darwinPlanned.backend).not.toBe(linuxPlanned.backend);
+    // Different teeth, same floor: neither backend changes what the sampler
+    // decides about the very same Worker.
+    expect(evaluateMemoryBudgets({ workers: [worker()], rss: over }).terminations[0]?.reason).toBe(
+      outcome.terminations[0]?.reason,
+    );
+  });
+
+  it("leaves an under-budget Worker alone on macOS exactly as on Linux", () => {
+    const outcome = evaluateMemoryBudgets({ workers: [worker()], rss: { wQ9F2: 1024 ** 3 } });
+
+    expect(outcome.terminations).toEqual([]);
+  });
+});
+
+describe("macOS placement — priority control, the tooth this backend really has", () => {
+  it("yields to interactive work by default", () => {
+    const placement = plan(DARWIN, { budget: undefined });
+
+    expect(placement.posix?.nice).toBe(WORKER_YIELD_NICE);
+    expect(placement.args[1]).toContain(`-n ${WORKER_YIELD_NICE}`);
+  });
+
+  it("yields further when the client declared a deprioritising weight", () => {
+    expect(planPosixLimits({ cpu_weight: 10 }, { canRenice: true }).nice).toBe(17);
+    expect(planPosixLimits({ cpu_weight: 50 }, { canRenice: true }).nice).toBe(10);
+    expect(planPosixLimits({ cpu_weight: 1 }, { canRenice: true }).nice).toBeLessThanOrEqual(MAX_POSIX_NICE);
+  });
+
+  it("refuses to raise priority for a weight at or above the fair share, and says why", () => {
+    const limits = planPosixLimits({ cpu_weight: 200 }, { canRenice: true });
+
+    expect(limits.nice).toBe(WORKER_YIELD_NICE);
+    expect(limits.note).toMatch(/privilege/);
+  });
+
+  it("applies no priority when `nice` is not on the host, rather than pretending it did", () => {
+    const placement = plan(DARWIN_WITHOUT_NICE);
+
+    expect(placement.posix?.nice).toBeUndefined();
+    expect(placement.args[1]).toContain('exec "$0" "$@"');
+    expect(placement.warning).toMatch(/no priority control/);
+  });
+
+  it("carries the applied priority into the warning, so it is observable for the Worker's life", () => {
+    const spawns: Array<{ command: string; args: readonly string[] }> = [];
+    const launched = launchWorker({
+      admission: evaluateWorkerAdmission({ ceiling: UNBOUNDED_HOST_CEILING, workers: [] }),
+      spec: {
+        project_label: "acme/widgets",
+        workspace_path: "/given/workspace",
+        command: "/usr/bin/node",
+        args: ["worker.js"],
+        budget: { memory_max: "4G" },
+      },
+      probes: DARWIN,
+      spawnFn: (command, args) => {
+        spawns.push({ command, args });
+        return { pid: 4242, once: () => undefined, unref: () => undefined } as never;
+      },
+    });
+
+    expect(spawns[0]?.command).toBe("/bin/sh");
+    expect(spawns[0]?.args[1]).toContain(`-n ${WORKER_YIELD_NICE}`);
+    expect(launched.worker.isolated).toBe(false);
+    expect(launched.worker.warnings.join(" ")).toContain(`nice ${WORKER_YIELD_NICE}`);
+  });
+});
+
+describe("macOS placement — the rlimits it will and will not set", () => {
+  it("carries a declared process-count and CPU-time budget into the shell's rlimits", () => {
+    const placement = plan(DARWIN, { budget: { max_processes: 256, cpu_seconds: 3600 } });
+
+    expect(placement.args[1]).toContain("ulimit -u 256");
+    expect(placement.args[1]).toContain("ulimit -t 3600");
+    expect(placement.posix).toMatchObject({ max_processes: 256, cpu_seconds: 3600 });
+  });
+
+  it("sets no rlimit for a value it cannot carry, and names the one it dropped", () => {
+    const limits = planPosixLimits({ max_processes: 0, cpu_seconds: -1 }, { canRenice: true });
+
+    expect(limits.max_processes).toBeUndefined();
+    expect(limits.cpu_seconds).toBeUndefined();
+    expect(limits.note).toMatch(/max_processes/);
+    expect(limits.note).toMatch(/cpu_seconds/);
+  });
+
+  it("names POSIX-only budget fields as unenforced on a backend that has no equivalent", () => {
+    const linux = plan(LINUX, { budget: { memory_max: "4G", max_processes: 256 } });
+
+    expect(linux.backend).toBe("transient-unit");
+    expect(linux.budgetWarning).toMatch(/max_processes/);
+  });
+
+  it("degrades to an unwrapped launch when the host has no POSIX shell to wrap it in", () => {
+    const placement = plan(DARWIN_WITHOUT_SHELL);
+
+    expect(placement.backend).toBe("none");
+    expect(placement.command).toBe("/usr/bin/node");
+    expect(placement.warning).toMatch(/no POSIX shell/);
+    expect(placement.budgetWarning).toMatch(/cannot enforce it/);
+  });
+});

--- a/apps/redskilled/tests/memory-floor.test.ts
+++ b/apps/redskilled/tests/memory-floor.test.ts
@@ -241,7 +241,19 @@ describe("the memory floor", () => {
     expect(parseProcStat(`77 (my prog (x)) S 5 ${trailing} 12 0\n`)).toEqual({ pid: 77, ppid: 5, rssPages: 12 });
   });
 
-  it("measures nothing when the host offers no /proc, rather than reporting zero", () => {
-    expect(sampleTreeRss([worker()], { platform: "darwin" })).toEqual({});
+  it("measures a host with no /proc from its own process table instead of giving up", () => {
+    // macOS is the platform where this floor IS the memory ceiling, so an empty
+    // reading there would leave the only backend without kernel teeth unmeasured.
+    const reading = sampleTreeRss([worker({ worker_id: "tree", pid: 100 })], {
+      platform: "darwin",
+      psTable: () => " 100 1 4096\n 200 100 2048\n",
+    });
+
+    expect(reading.tree).toBe((4096 + 2048) * 1024);
+  });
+
+  it("measures nothing when no process table can be read at all, rather than reporting zero", () => {
+    expect(sampleTreeRss([worker()], { platform: "aix" })).toEqual({});
+    expect(sampleTreeRss([worker()], { platform: "darwin", psTable: () => "" })).toEqual({});
   });
 });

--- a/apps/redskilled/tests/windows-job-object.test.ts
+++ b/apps/redskilled/tests/windows-job-object.test.ts
@@ -66,6 +66,7 @@ function windowsProbes(reach?: RedskilledJobObjectBinding): WorkerPlacementProbe
     jobObjects: reach
       ? { available: true, binding: reach }
       : { available: false, reason: "no Job Object addon was found for win32-x64" },
+    posix: { available: false, reason: "POSIX rlimit and priority placement is the macOS backend (platform=win32)" },
   };
 }
 

--- a/apps/redskilled/tests/worker-birth.test.ts
+++ b/apps/redskilled/tests/worker-birth.test.ts
@@ -147,6 +147,7 @@ describe("the daemon accepts the workspace path as given", () => {
     systemdRun: "/usr/bin/systemd-run",
     userSession: true,
     jobObjects: { available: false, reason: "not Windows" },
+    posix: { available: false, reason: "not macOS" },
   };
 
   it("never reads a repository marker to decide where the Worker runs", () => {
@@ -185,6 +186,7 @@ describe("the daemon accepts the workspace path as given", () => {
       systemdRun: null,
       userSession: false,
       jobObjects: { available: false, reason: expect.stringContaining("Windows backend") },
+      posix: { available: false, reason: expect.stringContaining("macOS backend") },
     });
   });
 

--- a/apps/redskilled/tests/worker-placement.test.ts
+++ b/apps/redskilled/tests/worker-placement.test.ts
@@ -14,29 +14,38 @@ import {
 
 const NO_JOB_OBJECTS = { available: false, reason: "Job Object placement is the Windows backend (platform=linux)" } as const;
 
+const NO_POSIX = { available: false, reason: "POSIX rlimit and priority placement is the macOS backend (platform=linux)" } as const;
+
 const LINUX_WITH_SESSION: WorkerPlacementProbes = {
   platform: "linux",
   systemdRun: "/usr/bin/systemd-run",
   userSession: true,
   jobObjects: NO_JOB_OBJECTS,
+  posix: NO_POSIX,
 };
 const LINUX_WITHOUT_SESSION: WorkerPlacementProbes = {
   platform: "linux",
   systemdRun: "/usr/bin/systemd-run",
   userSession: false,
   jobObjects: NO_JOB_OBJECTS,
+  posix: NO_POSIX,
 };
 const LINUX_WITHOUT_SYSTEMD: WorkerPlacementProbes = {
   platform: "linux",
   systemdRun: null,
   userSession: false,
   jobObjects: NO_JOB_OBJECTS,
+  posix: NO_POSIX,
 };
-const DARWIN: WorkerPlacementProbes = {
-  platform: "darwin",
+// An OS with neither backend: the case that proves an unknown platform still
+// launches and still says what it gave up. macOS has its own backend now, so it
+// is no longer the example of a host with nothing.
+const UNKNOWN_PLATFORM: WorkerPlacementProbes = {
+  platform: "aix",
   systemdRun: null,
   userSession: false,
-  jobObjects: { available: false, reason: "Job Object placement is the Windows backend (platform=darwin)" },
+  jobObjects: { available: false, reason: "Job Object placement is the Windows backend (platform=aix)" },
+  posix: { available: false, reason: "POSIX rlimit and priority placement is the macOS backend (platform=aix)" },
 };
 
 function plan(probes: WorkerPlacementProbes, overrides: Record<string, unknown> = {}) {
@@ -124,11 +133,11 @@ describe("worker placement — Linux without a user session", () => {
 });
 
 describe("worker placement — every unisolated launch carries a warning", () => {
-  it("warns off Linux, where the transient-unit backend does not exist", () => {
-    const placement = plan(DARWIN);
+  it("warns on a platform with no backend at all", () => {
+    const placement = plan(UNKNOWN_PLATFORM);
 
     expect(placement.isolated).toBe(false);
-    expect(placement.warning).toMatch(/platform=darwin/);
+    expect(placement.warning).toMatch(/platform=aix/);
   });
 
   it("warns when the host kill-switch declined isolation", () => {
@@ -146,7 +155,7 @@ describe("worker placement — every unisolated launch carries a warning", () =>
   });
 
   it("leaves no unisolated plan without a warning, over every probe combination", () => {
-    for (const probes of [LINUX_WITH_SESSION, LINUX_WITHOUT_SESSION, LINUX_WITHOUT_SYSTEMD, DARWIN]) {
+    for (const probes of [LINUX_WITH_SESSION, LINUX_WITHOUT_SESSION, LINUX_WITHOUT_SYSTEMD, UNKNOWN_PLATFORM]) {
       for (const enabled of [true, false]) {
         for (const isolation of ["transient-unit", "inherit"] as const) {
           const placement = plan(probes, { enabled, target: { isolation } });


### PR DESCRIPTION
Automated AFK landing for #2782. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2782

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787943656&installation_model_id=20659&pr_number=2820&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2820&signature=d25a543856f2e75769ea725287c4572f1b266379630114612187a524c2e99005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->