### PR TITLE
fix: #2807 A merge rejected for an out-of-date branch is recorded as blocked:ci, stranding a green PR and stopping the lane

### DIFF
--- a/.changeset/merge-rejection-reads-its-reason.md
+++ b/.changeset/merge-rejection-reads-its-reason.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A merge rejected for an out-of-date branch is repaired in the landing lane instead of parked as `blocked:ci` (#2807). Every `gh pr merge` refusal was recorded as "usually because branch protection or CI is not satisfied" — a guess, and the wrong one on two green, `mergeable=true`, `CLEAN` PRs whose only defect was that `<base>` had advanced between the readiness poll and the merge call. The `next:` step then sent a human to fix a failing required check that did not exist, while the issue parked `ready-for-human` and stopped every dependent below it. The landing now reads the PR back after a rejection and classifies the OBSERVED cause: an out-of-date branch is updated (`gh pr update-branch`) and re-merged — bounded to two rounds, re-waiting for green when the landing is CI-aware — which is exactly what a human does. A failing check, a conflict, an unreported rollup, and a protection rule that is not a check are each named verbatim in the terminal note, and the recorded `next:` points at that observed reason rather than asserting a check that may well be green.

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -607,7 +607,15 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
       }
       if (result.reason === "conflict") return { ok: false, reason: "pr-conflict", locked: input.locked, prNumber: result.prNumber };
       if (result.reason === "merge-failed" && result.prNumber !== undefined) {
-        return { ok: false, reason: "pr-merge-failed", locked: input.locked, prNumber: result.prNumber };
+        return {
+          ok: false,
+          reason: "pr-merge-failed",
+          locked: input.locked,
+          prNumber: result.prNumber,
+          // #2807: carry the OBSERVED rejection cause so the terminal names what
+          // the PR reported instead of guessing at branch protection.
+          ...(result.mergeFailure ? { message: result.mergeFailure.summary } : {}),
+        };
       }
       return {
         ok: false,

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -787,6 +787,106 @@ export function classifyMergeState(view: MergeStateView, context: MergeClassifyC
   return "pending";
 }
 
+/** Why the forge refused a `gh pr merge`, READ BACK from the PR instead of
+ * guessed (#2807). */
+export type MergeRejectionCause =
+  /** Out of date vs base; branch protection requires branches to be up to date.
+   * The one cause the landing repairs itself: update the branch and merge. */
+  | "stale-branch"
+  | "ci-failed"
+  | "conflict"
+  /** BLOCKED with every check reported — an unsatisfied protection rule that is
+   * not a check (a required review, a code-owner gate, …). */
+  | "protection-blocked"
+  | "checks-pending"
+  /** The rejection is real but the PR state does not explain it (or could not be
+   * re-read). Named as unexplained rather than attributed to a probable cause. */
+  | "unknown";
+
+export interface MergeRejectionDiagnosis {
+  cause: MergeRejectionCause;
+  /** One line naming the OBSERVED state. Never says "usually" / "probably": the
+   * landing records what the PR reported, so no human is sent to fix a failing
+   * check that does not exist. */
+  summary: string;
+  /** True when the landing can clear it without a human. */
+  retryable: boolean;
+}
+
+function mergeStateEvidence(view: MergeStateView): string {
+  const state = up(view.mergeStateStatus) || "unreadable";
+  const mergeable = up(view.mergeable) || "unreadable";
+  return `mergeStateStatus=${state} mergeable=${mergeable}`;
+}
+
+/**
+ * Classify a merge rejection from the PR state observed AFTER it (#2807).
+ *
+ * The landing used to record every `gh pr merge` failure as "usually because
+ * branch protection or CI is not satisfied" and park `blocked:ci`. Observed
+ * twice in 40 minutes on PRs whose every required check was green and that were
+ * `mergeable=true` / `CLEAN`: `<base>` had simply advanced between the readiness
+ * poll and the merge call, so protection's *require branches to be up to date*
+ * declined it. A stale base is the NORMAL condition of a busy lane — every land
+ * moves `<base>` for every other in-flight worker — so it must be repaired in
+ * the landing lane, not parked with an instruction naming a check that never
+ * failed.
+ */
+export function diagnoseMergeRejection(view: MergeStateView): MergeRejectionDiagnosis {
+  const s = up(view.mergeStateStatus);
+  const m = up(view.mergeable);
+  if (m === "CONFLICTING" || s === "DIRTY") {
+    return {
+      cause: "conflict",
+      retryable: false,
+      summary: `the PR conflicts with its base (${mergeStateEvidence(view)})`,
+    };
+  }
+  if (view.anyFailed) {
+    const failed = (view.failedCheckNames ?? []).filter((name) => name !== "").join(", ");
+    return {
+      cause: "ci-failed",
+      retryable: false,
+      summary: failed
+        ? `a status check failed on the PR: ${failed}`
+        : `a status check failed on the PR (${mergeStateEvidence(view)})`,
+    };
+  }
+  if (s === "BEHIND") {
+    return {
+      cause: "stale-branch",
+      retryable: true,
+      summary:
+        `the PR branch is out of date with its base (${mergeStateEvidence(view)}) — no check failed; ` +
+        `branch protection requires branches to be up to date before merging`,
+    };
+  }
+  if (view.anyPending) {
+    const pending = (view.pendingCheckNames ?? []).filter((name) => name !== "").join(", ");
+    return {
+      cause: "checks-pending",
+      retryable: false,
+      summary: pending
+        ? `a status check has not reported a verdict yet: ${pending}`
+        : `a status check has not reported a verdict yet (${mergeStateEvidence(view)})`,
+    };
+  }
+  if (s === "BLOCKED") {
+    return {
+      cause: "protection-blocked",
+      retryable: false,
+      summary:
+        `branch protection blocks the PR with every check reported and none failing ` +
+        `(${mergeStateEvidence(view)}) — an unsatisfied non-check rule such as a required review`,
+    };
+  }
+  return {
+    cause: "unknown",
+    retryable: false,
+    summary: `the forge rejected the merge and the PR state does not explain it (${mergeStateEvidence(view)})`,
+  };
+}
+
 /** Extra evidence {@link classifyMergeState} uses to tell *no verdict yet* apart
  * from *a blocking verdict* on a BLOCKED PR (#2747). */
 export interface MergeClassifyContext {
@@ -993,6 +1093,10 @@ export interface LandPrResult {
   ciEvidence?: CiGreenEvidence;
   /** Set on `ok:false` — the distinct failure mode (#812). */
   reason?: LandPrFailReason;
+  /** Set on `reason: "merge-failed"` — the OBSERVED rejection cause and the one
+   * line describing it, read back from the PR (#2807). The caller records this
+   * verbatim instead of guessing at branch protection. */
+  mergeFailure?: MergeRejectionDiagnosis;
   /** Remaining landing tail when `releaseAt` stopped before the merge. */
   deferred?: {
     prNumber: number;
@@ -1006,6 +1110,77 @@ export interface LandPrResult {
 }
 
 const PR_BODY_PREFIX = "Automated AFK landing for #";
+
+/** How many times a rejected merge is repaired by updating the branch before the
+ * landing gives up. A busy lane can move `<base>` again during the retry, so one
+ * spare round absorbs a second land landing underneath this one; beyond that the
+ * loop would just chase the trunk. */
+const STALE_BRANCH_MERGE_ROUNDS = 2;
+
+async function readMergeStateView(exec: Exec, repo: string, prNumber: number): Promise<MergeStateView> {
+  const res = await exec([
+    "gh", "-R", repo, "pr", "view", String(prNumber), "--json", "mergeStateStatus,mergeable,baseRefOid,headRefOid,statusCheckRollup",
+  ]);
+  if (res.code !== 0) return emptyMergeStateView();
+  return parseMergeStateView(res.stdout);
+}
+
+/**
+ * Run the merge; on rejection, read the PR back and repair the one cause the
+ * landing owns — an out-of-date branch (#2807).
+ *
+ * Returns `undefined` once the merge succeeds, or the failing {@link LandPrResult}
+ * carrying the OBSERVED cause. A stale branch is updated (`gh pr update-branch`,
+ * exactly what a human does) and, when CI-aware, re-waited to green before the
+ * next merge, so a base that moved mid-landing never parks a green PR. Every
+ * other cause is returned unretried: a failing check, a conflict, or a review
+ * gate is genuinely refusable and no amount of retrying clears it.
+ */
+async function mergeWithStaleBranchRecovery(
+  exec: Exec,
+  input: {
+    repo: string;
+    gitRepo: string;
+    remote: string;
+    target: string;
+    prNumber: number;
+    mergeArgs: string[];
+    ciAwait?: CiAwaitInput;
+  },
+): Promise<LandPrResult | undefined> {
+  const { repo, prNumber, mergeArgs, ciAwait } = input;
+  for (let round = 0; ; round += 1) {
+    const merge = await exec(mergeArgs);
+    if (merge.code === 0) return undefined;
+    const diagnosis = diagnoseMergeRejection(await readMergeStateView(exec, repo, prNumber));
+    if (!diagnosis.retryable || round >= STALE_BRANCH_MERGE_ROUNDS) {
+      return { ok: false, prNumber, reason: "merge-failed", mergeFailure: diagnosis };
+    }
+    const updated = await exec(["gh", "-R", repo, "pr", "update-branch", String(prNumber)]);
+    if (updated.code !== 0) {
+      return {
+        ok: false,
+        prNumber,
+        reason: "merge-failed",
+        mergeFailure: {
+          ...diagnosis,
+          retryable: false,
+          summary: `${diagnosis.summary}; updating the branch from its base failed`,
+        },
+      };
+    }
+    if (!ciAwait) continue;
+    // The updated head is a new commit: its required checks must report again
+    // before protection will accept the merge.
+    const ready = await waitForMergeReadyWithEvidence(exec, repo, prNumber, {
+      ...ciAwait,
+      baseBranch: ciAwait.baseBranch ?? input.target,
+    });
+    if (ready.readiness === "conflict") return { ok: false, prNumber, reason: "conflict" };
+    if (ready.readiness === "ci-failed") return { ok: false, prNumber, reason: "ci-failed" };
+    if (ready.readiness === "pending") return { ok: false, prNumber, reason: "ci-pending" };
+  }
+}
 
 /**
  * Best-effort, non-destructive fast-forward of the primary checkout's local
@@ -1289,8 +1464,16 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
     const mergeArgs = ["gh", "-R", repo, "pr", "merge", String(prNumber), "--merge"];
     if (mergeQueue) mergeArgs.push("--auto");
     if (mergeTitle) mergeArgs.push("--subject", mergeTitle);
-    const merge = await exec(mergeArgs);
-    if (merge.code !== 0) return { ok: false, prNumber, reason: "merge-failed" };
+    const rejected = await mergeWithStaleBranchRecovery(exec, {
+      repo,
+      gitRepo,
+      remote,
+      target,
+      prNumber,
+      mergeArgs,
+      ...(ciAwait ? { ciAwait } : {}),
+    });
+    if (rejected) return rejected;
 
     if (mergeQueue) return { ok: true, prNumber };
 

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -180,6 +180,15 @@ import {
 } from "../stale-base-drift.js";
 import { abortAfterClaim, claimLost, emitBackpressureReview, emitDone, handoffForManualLanding, handoffForReview, hookContext, isRunnerRecoverableOutcome, landLockBackoff, mergeFailed, ciBlocked, prLandingBlocked, trunkDivergedBlocked, onErrorContext, parseHookEnv, postAttemptContext, recordOutcomeBestEffort, releaseOwnedClaim, runCascadeRebase, runCloseCascade, runnerRecoverable, terminalFailure, writeValidationSidecar, type StageCommon } from "./terminal.js";
 
+/** Recorded when the forge refused the merge and the PR state did not explain it
+ * (#2807). It says the cause is unknown rather than inventing a probable one. */
+const MERGE_REJECTION_UNEXPLAINED =
+  "the open PR merge was rejected by GitHub and the PR state did not explain the refusal";
+/** The `next:` step for a rejected merge. It points at the recorded reason
+ * instead of asserting a failing required check that may well be green (#2807). */
+const MERGE_REJECTION_NEXT =
+  "Read the recorded rejection reason above, clear it on the open PR, then merge it (no full agent re-run needed).";
+
 function setupFailureExcerpt(log: string | null | undefined): string | undefined {
   const lines = (log ?? "")
     .split("\n")
@@ -1637,8 +1646,9 @@ export async function processIssue(
             "ci-failed",
             completed.prNumber,
             completed.reason === "pr-merge-failed"
-              ? "the observer's merge was rejected by GitHub"
+              ? completed.message ?? MERGE_REJECTION_UNEXPLAINED
               : `the observer could not finish the landing tail (${completed.reason})`,
+            completed.reason === "pr-merge-failed" ? MERGE_REJECTION_NEXT : undefined,
           );
         })
         .catch((error) => {
@@ -1711,11 +1721,16 @@ export async function processIssue(
       );
     }
     if (landing.reason === "pr-merge-failed") {
+      // #2807: the landing already re-read the PR and repaired the one cause it
+      // owns (an out-of-date branch). What survives to here is a refusal the PR
+      // itself explained, so the note carries that observed reason verbatim —
+      // never a probable one, and never a `next:` naming a check that is green.
       return await prLandingBlocked(
         common,
         "ci-failed",
         landing.prNumber,
-        `the open PR merge was rejected by GitHub, usually because branch protection or CI is not satisfied`,
+        landing.message ?? MERGE_REJECTION_UNEXPLAINED,
+        MERGE_REJECTION_NEXT,
       );
     }
     if (landing.reason === "post-merge-gate") {

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -532,11 +532,20 @@ export async function prLandingBlocked(
   outcome: "ci-failed" | "merge-conflict",
   prNumber: number | undefined,
   reason: string,
+  /** Replaces the outcome's default `next:` step. A merge REJECTION routes
+   * through the `ci-failed` outcome without a verified failing check, so it must
+   * not inherit "fix the failing required check" (#2807). */
+  nextStep?: string,
 ): Promise<ProcessIssueResult> {
   const { deps, input } = c;
   const prRef = prNumber !== undefined ? `PR #${prNumber}` : "the open PR";
   await routeRecovery(deps, input.issue, outcome, recoveryOrdinalFor(input), { forceDecision: "escalate" });
-  await writeCurrentBlockerBestEffort(deps, input, blockerForFailure(outcome, { log: `${prRef}: ${reason}` }));
+  const blocker = blockerForFailure(outcome, { log: `${prRef}: ${reason}` });
+  await writeCurrentBlockerBestEffort(
+    deps,
+    input,
+    blocker && nextStep ? { ...blocker, next: nextStep } : blocker,
+  );
   const section = outcome === "merge-conflict" ? "merge-conflict" : "ci";
   const posted = await emitFailure(c, envelopeStatusFor(outcome), section, {
     log:

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -446,7 +446,15 @@ describe("doLanding — CI-aware merge (#812)", () => {
   it("a rejected admin merge after PR creation preserves the PR instead of collapsing to generic land-failed", async () => {
     const h = harness({ locked: false, prMergeCode: 1 });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "pr-merge-failed", locked: false, prNumber: 42 });
+    // #2807: the refusal carries the OBSERVED PR state, never a guessed cause.
+    expect(r).toEqual({
+      ok: false,
+      reason: "pr-merge-failed",
+      locked: false,
+      prNumber: 42,
+      message: "the forge rejected the merge and the PR state does not explain it (mergeStateStatus=CLEAN mergeable=MERGEABLE)",
+    });
+    expect((r as { message?: string }).message).not.toMatch(/usually|probably/i);
   });
 });
 

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -10,6 +10,7 @@ import {
   buildConflictPrompt,
   waitForReviewCheck,
   classifyMergeState,
+  diagnoseMergeRejection,
   parseMergeStateView,
   waitForMergeReady,
   waitForMergeReadyWithEvidence,
@@ -727,6 +728,37 @@ describe("CI-aware merge classification (#812)", () => {
   });
 });
 
+describe("diagnoseMergeRejection (#2807)", () => {
+  const view = (mergeStateStatus: string, rollup: unknown[] = [], mergeable = "MERGEABLE") =>
+    parseMergeStateView(JSON.stringify({ mergeStateStatus, mergeable, statusCheckRollup: rollup }));
+  const greenRollup = [{ name: "test", status: "COMPLETED", conclusion: "SUCCESS" }];
+
+  it("BEHIND with green checks → a retryable stale branch, never a CI failure", () => {
+    const d = diagnoseMergeRejection(view("BEHIND", greenRollup));
+    expect(d.cause).toBe("stale-branch");
+    expect(d.retryable).toBe(true);
+    expect(d.summary).toContain("out of date");
+  });
+
+  it("a failed check → ci-failed, naming the check", () => {
+    const d = diagnoseMergeRejection(view("BLOCKED", [{ name: "test", status: "COMPLETED", conclusion: "FAILURE" }]));
+    expect(d.cause).toBe("ci-failed");
+    expect(d.retryable).toBe(false);
+    expect(d.summary).toContain("test");
+  });
+
+  it("CONFLICTING → conflict", () => {
+    expect(diagnoseMergeRejection(view("DIRTY", [], "CONFLICTING")).cause).toBe("conflict");
+  });
+
+  it("an unreadable state is reported as unexplained, not attributed to a probable cause", () => {
+    const d = diagnoseMergeRejection(parseMergeStateView(""));
+    expect(d.cause).toBe("unknown");
+    expect(d.retryable).toBe(false);
+    expect(d.summary).not.toMatch(/usually|probably/i);
+  });
+});
+
 describe("waitForMergeReady (#812 poll loop)", () => {
   function pollExec(views: string[]): { exec: Exec; calls: string[][] } {
     const calls: string[][] = [];
@@ -1004,6 +1036,116 @@ describe("landPr CI-aware wiring (#812)", () => {
       ciAwait: { sleep: async () => {} },
     });
     expect(r).toEqual({ ok: false, prNumber: 5, reason: "conflict" });
+  });
+
+  // #2807 reproduction — the observed trace of #2774/PR #2803 and #2775/PR #2806:
+  // every required check green and `mergeable=true`, but `<base>` advanced between
+  // the readiness poll and the merge call, so protection's "require branches to be
+  // up to date" declined it. The landing recorded a guessed `blocked:ci` and told a
+  // human to fix a check that was not failing.
+  describe("a merge rejected for an out-of-date branch (#2807)", () => {
+    const green = [
+      { name: "test", status: "COMPLETED", conclusion: "SUCCESS" },
+      { name: "typecheck", status: "COMPLETED", conclusion: "SUCCESS" },
+    ];
+
+    it("updates the branch and merges instead of parking a green PR", async () => {
+      const calls: string[][] = [];
+      let merges = 0;
+      let updated = false;
+      const exec: Exec = async (argv) => {
+        calls.push(argv);
+        const cmd = argv.join(" ");
+        if (cmd.includes("pr list")) return { code: 0, stdout: "5\n", stderr: "" };
+        if (cmd.includes("pr view") && cmd.includes("mergeStateStatus")) {
+          // CLEAN at the readiness poll, BEHIND once the base moves under the
+          // merge, CLEAN again after the branch is updated. Green throughout.
+          const behind = merges > 0 && !updated;
+          return {
+            code: 0,
+            stdout: JSON.stringify({
+              mergeStateStatus: behind ? "BEHIND" : "CLEAN",
+              mergeable: "MERGEABLE",
+              statusCheckRollup: green,
+            }),
+            stderr: "",
+          };
+        }
+        if (cmd.includes("pr update-branch")) {
+          updated = true;
+          return { code: 0, stdout: "", stderr: "" };
+        }
+        if (cmd.includes("pr merge")) {
+          merges += 1;
+          // the base moved under the first merge; the second lands
+          return updated ? { code: 0, stdout: "", stderr: "" } : { code: 1, stdout: "", stderr: "Protected branch update failed" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const r = await landPr(exec, {
+        repo: "o/r", gitRepo: "/repo", remote: "origin", branch: "afk/wX/9-x", target: "main", n: 9, title: "t",
+        ciAwait: { sleep: async () => {}, maxPolls: 3 },
+      });
+      expect(r.ok).toBe(true);
+      expect(merges).toBe(2);
+      expect(calls.some((c) => c.join(" ").includes("pr update-branch 5"))).toBe(true);
+    });
+
+    it("names the OBSERVED cause when the rejection is not a stale branch", async () => {
+      const exec: Exec = async (argv) => {
+        const cmd = argv.join(" ");
+        if (cmd.includes("pr list")) return { code: 0, stdout: "5\n", stderr: "" };
+        if (cmd.includes("pr view") && cmd.includes("mergeStateStatus")) {
+          return {
+            code: 0,
+            stdout: JSON.stringify({ mergeStateStatus: "BLOCKED", mergeable: "MERGEABLE", statusCheckRollup: green }),
+            stderr: "",
+          };
+        }
+        if (cmd.includes("pr merge")) return { code: 1, stdout: "", stderr: "Protected branch update failed" };
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const r = await landPr(exec, {
+        repo: "o/r", gitRepo: "/repo", remote: "origin", branch: "afk/wX/9-x", target: "main", n: 9, title: "t",
+      });
+      expect(r.ok).toBe(false);
+      expect(r.reason).toBe("merge-failed");
+      expect(r.mergeFailure?.cause).toBe("protection-blocked");
+      expect(r.mergeFailure?.summary ?? "").not.toMatch(/usually|probably/i);
+    });
+
+    it("gives up after a bounded number of update-and-retry rounds", async () => {
+      let merges = 0;
+      let updates = 0;
+      const exec: Exec = async (argv) => {
+        const cmd = argv.join(" ");
+        if (cmd.includes("pr list")) return { code: 0, stdout: "5\n", stderr: "" };
+        if (cmd.includes("pr view") && cmd.includes("mergeStateStatus")) {
+          // a lane so busy the branch is BEHIND again on every look
+          return {
+            code: 0,
+            stdout: JSON.stringify({ mergeStateStatus: "BEHIND", mergeable: "MERGEABLE", statusCheckRollup: green }),
+            stderr: "",
+          };
+        }
+        if (cmd.includes("pr update-branch")) {
+          updates += 1;
+          return { code: 0, stdout: "", stderr: "" };
+        }
+        if (cmd.includes("pr merge")) {
+          merges += 1;
+          return { code: 1, stdout: "", stderr: "Protected branch update failed" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const r = await landPr(exec, {
+        repo: "o/r", gitRepo: "/repo", remote: "origin", branch: "afk/wX/9-x", target: "main", n: 9, title: "t",
+      });
+      expect(r.reason).toBe("merge-failed");
+      expect(r.mergeFailure?.cause).toBe("stale-branch");
+      expect(updates).toBe(2);
+      expect(merges).toBe(3);
+    });
   });
 
   it("does NOT poll merge state by default (ciAwait absent)", async () => {

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -439,6 +439,21 @@ describe("processIssue — CI-aware unlocked landing (#812)", () => {
     expect(trace.runAgentCalls.length).toBe(1);
     expect(trace.released).toEqual([9]);
   });
+
+  it("a rejected merge records the OBSERVED reason and never sends a human after an unverified failing check (#2807)", async () => {
+    // Field trace: PRs #2803 / #2806 were green, mergeable, and CLEAN; the base
+    // had merely advanced. The blocker still read "usually because branch
+    // protection or CI is not satisfied" and told a human to fix a check that
+    // did not exist.
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true, locked: false, prMergeCode: 1 });
+    await processIssue(deps, input);
+
+    const written = [...trace.bodyEdits.map((e) => e.body), ...trace.comments.map((c) => c.body)].join("\n");
+    expect(written).not.toMatch(/usually|probably/i);
+    expect(written).not.toContain("Fix the failing required check");
+    const blocker = trace.bodyEdits.at(-1)?.body ?? "";
+    expect(blocker).toContain("Read the recorded rejection reason");
+  });
 });
 
 


### PR DESCRIPTION
Automated AFK landing for #2807. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2807

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787944874&installation_model_id=20659&pr_number=2821&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2821&signature=fb921072356cfc9feefc1fb4a0861db9867bebc7e63914782658ac94a325e7c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->