### PR TITLE
chore: #2790 Janitor reclaim re-anchored onto the daemon's process truth

### DIFF
--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -140,6 +140,7 @@ function renderHuman(
   const expired = flattenExpired(report).map((path) => rel(root, path));
   const workers = report.staleWorkers.reclaim.map((entry) => rel(root, entry.path));
   const unknown = report.plan.unknownTmpRoots.map((name) => `.red/tmp/${name}`);
+  const reclaimPlan = report.workerReclaim;
   const lines = [
     "red-doctor host toolchain",
     ...hostReport.rows.map((row) => `  ${row.verdict === "ok" ? "✅" : "❌"} ${row.tool} ${row.version} (required ${row.required}; manager ${row.manager})`),
@@ -181,6 +182,15 @@ function renderHuman(
     ...workers.map((path) => `  ${path}`),
     `unknown tmp roots: ${unknown.length}`,
     ...unknown.map((path) => `  ${path}`),
+    // The daemon-keyed view (Spec #2772 US 46). `dropped` is printed in full: a
+    // plan that quietly held artifacts back would read here as a clean sweep.
+    `worker artifacts considered: ${reclaimPlan.totals.considered}`,
+    `worker artifacts reclaimable: ${reclaimPlan.totals.reclaim}`,
+    `worker artifacts retained: ${reclaimPlan.totals.retain}`,
+    `worker artifacts dropped: ${reclaimPlan.dropped.length}${reclaimPlan.truncated ? " (truncated)" : ""}`,
+    ...reclaimPlan.dropped.map(
+      (drop) => `  ${drop.reason} ${drop.path ? rel(root, drop.path) : (drop.worker_id ?? "")}: ${drop.detail}`,
+    ),
     "",
     "red-doctor deadend audit",
     `deadends: ${deadendReport.total}`,
@@ -195,6 +205,8 @@ function renderHuman(
       `applied unknown tmp roots: ${applied.unknownTmpRoots.length}`,
       `protected live workers: ${applied.protectedLiveWorkers.length}`,
       `protected live feedback worktrees: ${applied.protectedLiveFeedback.length}`,
+      `applied worker workspaces: ${applied.workerWorkspaces.length}`,
+      `protected live workspaces: ${applied.protectedLiveWorkspaces.length}`,
       `refused outside tmp: ${applied.refusedOutsideTmp.length}`,
       ...applied.removals.map(
         (removal) => `  remove=${rel(root, removal.path)} liveness=${removal.livenessVerdict}`,
@@ -251,6 +263,15 @@ function renderToon(
       expiredLanes: flattenExpired(report).map((path) => rel(root, path)),
       staleWorkers: report.staleWorkers.reclaim.map((entry) => rel(root, entry.path)),
       unknownTmpRoots: report.plan.unknownTmpRoots.map((name) => `.red/tmp/${name}`),
+      workerReclaim: {
+        ...report.workerReclaim.totals,
+        truncated: report.workerReclaim.truncated,
+        dropped: report.workerReclaim.dropped.map((drop) => ({
+          reason: drop.reason,
+          path: drop.path ? rel(root, drop.path) : "",
+          detail: drop.detail,
+        })),
+      },
     },
     appliedFixes: probeFixes.map((fix) => ({
       probeId: fix.probeId,
@@ -303,6 +324,8 @@ function renderToon(
           unknownTmpRoots: applied.unknownTmpRoots.map((path) => rel(root, path)),
           protectedLiveWorkers: applied.protectedLiveWorkers.map((path) => rel(root, path)),
           protectedLiveFeedback: applied.protectedLiveFeedback.map((path) => rel(root, path)),
+          workerWorkspaces: applied.workerWorkspaces.map((path) => rel(root, path)),
+          protectedLiveWorkspaces: applied.protectedLiveWorkspaces.map((path) => rel(root, path)),
           refusedOutsideTmp: applied.refusedOutsideTmp.map((path) => rel(root, path)),
           removals: applied.removals.map((removal) => ({
             path: rel(root, removal.path),

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -85,8 +85,9 @@ import {
   type QueueVisibilityProbeData,
 } from "./operational-probes.js";
 import { runHostPrerequisiteProbe } from "./operational-probes/host-prerequisites.js";
-import { removableUnknownTmpRoots } from "./tmp-janitor.js";
+import { pathIsInsideTmp, removableUnknownTmpRoots } from "./tmp-janitor.js";
 import type { TmpJanitorPlan, WorkerDirJanitorPlan } from "./tmp-janitor.js";
+import type { WorkerProcessVerdict, WorkerReclaimPlan } from "./worker-reclaim.js";
 import { LABEL_HUMAN, LABEL_QUARANTINE, LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
 import { isRefused, planTransition, type StateTransition } from "./state-transition.js";
 
@@ -228,8 +229,19 @@ export interface BootFs {
   writeWorkerPid(pidFile: string, pid: number): Promise<void>;
   /** rm -rf an orphaned attempt dir. */
   removeDir(path: string): Promise<void>;
-  /** Final worker.pid liveness guard before removing a whole worker dir. */
-  workerPidLive?(workerDir: string): Promise<boolean>;
+  /**
+   * The DAEMON's verdict on the Worker that owns a dir, re-read immediately
+   * before removal (Spec #2772 US 46): a Worker may have been born since the
+   * plan was built. Only `dead` releases bytes — `unknown`, an unwired probe, or
+   * a throwing one all spare the dir, because a reader that could not reach the
+   * authority must never report a running Worker as gone (#2679).
+   */
+  workerLivenessVerdict?(workerDir: string): Promise<WorkerProcessVerdict>;
+  /**
+   * The same question about one WORKSPACE path, so the record-free reclaim pass
+   * re-authorises each removal against a current answer.
+   */
+  workerWorkspaceLivenessVerdict?(path: string): Promise<WorkerProcessVerdict>;
   /** Fresh owner-liveness verdict before removing a feedback worktree. */
   feedbackWorktreeLiveness?(
     path: string,
@@ -711,12 +723,16 @@ export interface BootOptions {
    * stale `needs-slicing` label once at least one slice exists. */
   specSubIssueCandidates?: readonly SpecSubIssueCandidate[];
   /** ADR 0098 tmp janitor plan: expired named lanes, audited unknown root entries,
-   * and stale worker dirs whose worker.pid was already observed dead and whose
-   * represented issues are closed. */
+   * and stale worker dirs the DAEMON already called dead and whose represented
+   * issues are closed. */
   tmpJanitor?: {
     plan: TmpJanitorPlan;
     staleWorkers: WorkerDirJanitorPlan;
     orphanTestRunners?: readonly OrphanTestRunnerSweepEntry[];
+    /** The daemon-keyed reclaim plan (Spec #2772 US 46). Absent means the caller
+     * had no daemon answer to plan against, so the sweep reclaims nothing on its
+     * behalf. */
+    workerReclaim?: WorkerReclaimPlan;
   };
   /**
    * Skip every shared boot sweep (#623). When true, `runBoot` runs precheck +
@@ -799,6 +815,10 @@ export interface TmpJanitorSweepResult {
   protectedLiveWorkers: string[];
   protectedLiveFeedback: string[];
   orphanTestRunners: Array<{ pid: number; pgid: number }>;
+  /** Workspaces removed because the daemon called their Worker gone. */
+  workerWorkspaces: string[];
+  /** Workspaces spared because the daemon did not call their Worker gone. */
+  protectedLiveWorkspaces: string[];
   /** Paths a plan named outside this tmp tier: reported, never removed. */
   refusedOutsideTmp: string[];
   removals: Array<{
@@ -1012,10 +1032,35 @@ async function runTmpJanitorSweep(
     protectedLiveWorkers: [],
     protectedLiveFeedback: [],
     orphanTestRunners: [],
+    workerWorkspaces: [],
+    protectedLiveWorkspaces: [],
     refusedOutsideTmp: [],
     removals: [],
   };
   if (!sweep) return result;
+
+  // The daemon-keyed pass runs FIRST and is the authority (Spec #2772 US 46): a
+  // workspace goes because the daemon says the Worker that owns it is gone. The
+  // passes below only ever narrow what it already decided.
+  for (const verdict of sweep.workerReclaim?.reclaim ?? []) {
+    // A reclaimable artifact with no path has no bytes here to remove.
+    if (verdict.artifact.path === undefined) continue;
+    const path = verdict.artifact.path;
+    if (!pathIsInsideTmp(options.bootstrap.tmpDir, path)) {
+      result.refusedOutsideTmp.push(path);
+      continue;
+    }
+    // Fail CLOSED: an unanswerable — or unwired — liveness probe spares the
+    // workspace. The opposite default deleted a live lane once already (#2679).
+    const live = await deps.fs.workerWorkspaceLivenessVerdict?.(path).catch(() => "unknown" as const);
+    if (live !== "dead") {
+      result.protectedLiveWorkspaces.push(path);
+      continue;
+    }
+    await deps.fs.removeDir(path);
+    result.removals.push({ path, livenessVerdict: "worker-dead" });
+    result.workerWorkspaces.push(path);
+  }
 
   const expired = [
     ...sweep.plan.logs.reclaim,
@@ -1044,8 +1089,8 @@ async function runTmpJanitorSweep(
   }
 
   for (const worker of sweep.staleWorkers.reclaim) {
-    const live = await deps.fs.workerPidLive?.(worker.path).catch(() => true);
-    if (live !== false) {
+    const live = await deps.fs.workerLivenessVerdict?.(worker.path).catch(() => "unknown" as const);
+    if (live !== "dead") {
       result.protectedLiveWorkers.push(worker.path);
       continue;
     }

--- a/apps/dev/src/core/reclaim.ts
+++ b/apps/dev/src/core/reclaim.ts
@@ -11,6 +11,7 @@
 // shared worker-paths.ts parser so the nested layout stays single-sourced.
 
 import { parseReapableWorkerPath } from "./worker-paths.js";
+import type { WorkerProcessVerdict } from "./worker-reclaim.js";
 import { LABEL_HUMAN, LABEL_RUNNING } from "./triage-labels.js";
 
 /** Orphan TTLs (afk.sh TTL_LONG / TTL_SHORT). */
@@ -166,18 +167,19 @@ export function planAttemptCap(
 // ---------- liveness-gated reclaim (issue #1219) ----------
 
 /** One dead-worker candidate for the read-time liveness reclaim. The caller has
- * already resolved the OWNING worker's `worker.pid` liveness and the issue's
+ * already asked the DAEMON about the OWNING Worker and resolved the issue's
  * preservation state. */
 export interface LivenessReclaimInput {
   /** Absolute attempt dir path (`.../workers/{wid}/{N}-a{n}`). */
   attemptDir: string;
   /** Absolute path of the attempt's heavy `worktree/`. */
   worktreePath: string;
-  /** Whether the OWNING worker's `worker.pid` still resolves to a live process.
-   * Keyed on the per-WORKER pid (shared across a worker's attempts), NOT the
-   * per-attempt `state.pid`: a worker live on a later attempt keeps ALL its
-   * attempt dirs. */
-  workerPidAlive: boolean;
+  /** The DAEMON's verdict on the OWNING Worker (Spec #2772 US 46). Keyed on the
+   * per-WORKER identity, shared across its attempt dirs, so a Worker still
+   * running keeps ALL of them. Only `dead` releases bytes: `unknown` — an
+   * unreachable or stale daemon — spares the dir, because a reader that could
+   * not reach the authority must never report a running Worker as gone (#2679). */
+  liveness: WorkerProcessVerdict;
   /** Whether the issue is in a post-mortem preservation state (`blocked:*` /
    * `ready-for-human`, existing #256/#257 policy) — its JSONL/handoff is kept. */
   preserved: boolean;
@@ -197,8 +199,8 @@ export interface LivenessReclaimAction {
 
 /**
  * Plan the read-time liveness-gated reclaim (issue #1219). PURE — no I/O; the
- * caller resolves `workerPidAlive` and `preserved`.
- *   - A live worker's dir (workerPidAlive) is NEVER touched.
+ * caller resolves `liveness` and `preserved`.
+ *   - A dir whose Worker the daemon has not called dead is NEVER touched.
  *   - A dead worker's `worktree/` is ALWAYS removed (disposable heavy dir).
  *   - A dead worker's whole attempt dir is reclaimed UNLESS the issue is
  *     preserved (blocked:* / ready-for-human), in which case the JSONL/handoff
@@ -211,7 +213,7 @@ export function planLivenessReclaim(
 ): LivenessReclaimAction[] {
   const out: LivenessReclaimAction[] = [];
   for (const i of inputs) {
-    if (i.workerPidAlive) continue;
+    if (i.liveness !== "dead") continue;
     out.push({
       attemptDir: i.attemptDir,
       worktreePath: i.worktreePath,

--- a/apps/dev/src/core/tmp-janitor.ts
+++ b/apps/dev/src/core/tmp-janitor.ts
@@ -20,6 +20,7 @@
 // janitor never deletes outside its known lanes.
 
 import { isAbsolute, relative, resolve, sep } from "node:path";
+import type { WorkerProcessVerdict } from "./worker-reclaim.js";
 
 /**
  * Whether a path lies strictly inside a tmp tier. An ATTEMPT RECORD may name any
@@ -298,7 +299,13 @@ export interface WorkerDirIssueState {
 
 export interface WorkerDirJanitorEntry {
   path: string;
-  workerPidLive: boolean;
+  /**
+   * The DAEMON's verdict on the Worker that owns this dir (Spec #2772 US 46).
+   * `unknown` — an unreachable or stale daemon — is not `dead`, so it spares the
+   * dir: a reader that could not reach the authority must never report a running
+   * Worker as gone, which is how a janitor came to delete a live lane (#2679).
+   */
+  liveness: WorkerProcessVerdict;
   issues: readonly WorkerDirIssueState[];
 }
 
@@ -307,21 +314,21 @@ export interface WorkerDirJanitorPlan {
   spare: WorkerDirJanitorEntry[];
 }
 
-/** Plan dead-worker-dir cleanup. A worker dir is reclaimable only when its
- * worker.pid is not live, it represents at least one issue, and every issue it
- * represents is known closed.
+/** Plan dead-worker-dir cleanup. A worker dir is reclaimable only when the
+ * DAEMON calls its Worker dead, it represents at least one issue, and every
+ * issue it represents is known closed.
  *
- * The removed liveness VETO — the one an open record used to cast, sparing a
- * worker whose pid file was missing — re-anchors onto the daemon in #2790, which
- * owns process death by construction. Nothing here may grow a pid-file rule of
- * its own in the meantime: keying reclaim on a missing pid file is what deleted
- * a live lane and kept the dead ones (#2679). */
+ * The liveness question is asked of the daemon, which owns process death by
+ * construction, and never of a pid file (Spec #2772 US 46): keying reclaim on a
+ * missing pid file is what deleted a live lane and kept the dead ones (#2679).
+ * A missing pid file is therefore not even an input here — only the daemon's own
+ * fresh answer can release a dir. */
 export function planWorkerDirJanitor(entries: readonly WorkerDirJanitorEntry[]): WorkerDirJanitorPlan {
   const reclaim: WorkerDirJanitorEntry[] = [];
   const spare: WorkerDirJanitorEntry[] = [];
   for (const entry of entries) {
     const issues = entry.issues;
-    if (!entry.workerPidLive && issues.length > 0 && issues.every((issue) => issue.state === "CLOSED")) {
+    if (entry.liveness === "dead" && issues.length > 0 && issues.every((issue) => issue.state === "CLOSED")) {
       reclaim.push(entry);
     } else {
       spare.push(entry);

--- a/apps/dev/src/core/worker-reclaim.ts
+++ b/apps/dev/src/core/worker-reclaim.ts
@@ -1,0 +1,365 @@
+// worker-reclaim.ts — the janitor's reclaim rule, anchored on the DAEMON's
+// process truth (Spec #2772 US 46, ADR 0130).
+//
+// ONE RULE, STATED ONCE: an artifact is reclaimable when the daemon says the
+// Worker that owns it is gone, and never because a pid file happens to be
+// missing. Nothing in this module reads a pid, a pid file, or an mtime, because
+// keying on those produced the exact inversion they were meant to prevent — the
+// live supervisor's lane was deleted while the dead ones survived (#2679).
+//
+// The record that used to answer this question is extinct (Spec #2772). The
+// daemon is the stronger authority that replaces it: it owns birth and death by
+// construction, so it cannot be out of date about a process it holds.
+//
+// THREE VERDICTS, NOT TWO, and the third is the load-bearing one:
+//
+//   alive    — the daemon names this Worker. NOTHING it owns is reclaimable.
+//   unknown  — the daemon did not answer, its answer is stale, or something
+//              else can still see the Worker running. Retained, because "I could
+//              not reach the authority" is not evidence of death.
+//   dead     — the daemon answered, its answer is current, and it does not name
+//              this Worker. Only here may bytes go.
+//
+// What a dead Worker leaves behind splits by COST, which is what decides whether
+// it is kept:
+//
+//   workspace — expensive and regenerable (the 2.3 GB that fills a disk). Goes.
+//   evidence  — cheap and irreplaceable: the material a human reads to rescue
+//               orphaned work (#2701). Stays.
+//   pointer   — a branch, PR or commit: named elsewhere, no bytes here.
+//   unknown   — an unrecognised kind: retained and REPORTED, never guessed at.
+//
+// Two artifact-level overrides win over a dead Worker's release: `reclaimable:
+// false` pins an artifact the rule would otherwise reclaim, and `reclaim_after`
+// holds one until that instant has passed.
+//
+// And one discipline over all of it: A SILENT TRUNCATION IS A FAILURE. Every
+// artifact considered lands in exactly one of `reclaim`, `retain`, or `dropped`,
+// and `totals` states the identity so a caller can assert it.
+
+/**
+ * The daemon's verdict on one Worker's PROCESS, in the vocabulary the liveness
+ * anchor publishes. Restated here so this planner stays pure: it consumes the
+ * verdict, it never resolves one.
+ */
+export type WorkerProcessVerdict = "alive" | "dead" | "unknown";
+
+/** What an artifact costs to keep, which is what decides whether it is kept. */
+export type WorkerArtifactClass = "workspace" | "evidence" | "pointer" | "unknown";
+
+/** Expensive and regenerable: the bytes that fill a disk. */
+export const WORKER_WORKSPACE_ARTIFACT_KINDS = [
+  "worktree",
+  "workspace",
+  "node_modules",
+  "checkout",
+  "build-cache",
+  "sandbox",
+] as const;
+
+/** Cheap and irreplaceable: the material a rescue reads after the Worker died. */
+export const WORKER_EVIDENCE_ARTIFACT_KINDS = [
+  "log",
+  "diagnostic",
+  "envelope",
+  "transcript",
+  "patch",
+  "handoff",
+  "report",
+] as const;
+
+/** Named elsewhere, so there are no bytes here to reclaim. */
+export const WORKER_POINTER_ARTIFACT_KINDS = [
+  "branch",
+  "pr",
+  "commit",
+  "tag",
+  "issue",
+] as const;
+
+const CLASS_BY_KIND = new Map<string, WorkerArtifactClass>([
+  ...WORKER_WORKSPACE_ARTIFACT_KINDS.map((kind) => [kind, "workspace"] as const),
+  ...WORKER_EVIDENCE_ARTIFACT_KINDS.map((kind) => [kind, "evidence"] as const),
+  ...WORKER_POINTER_ARTIFACT_KINDS.map((kind) => [kind, "pointer"] as const),
+]);
+
+/** Classify one artifact kind. An unrecognised kind is `unknown` on purpose:
+ * the janitor retains and REPORTS what it cannot classify, never guesses. */
+export function classifyWorkerArtifact(kind: string): WorkerArtifactClass {
+  return CLASS_BY_KIND.get(kind) ?? "unknown";
+}
+
+/** One thing a Worker left on disk, attributed to the Worker that owns it. */
+export interface WorkerArtifact {
+  /** The Worker whose process liveness releases (or holds) these bytes. */
+  worker_id: string;
+  /** What the artifact is, which decides its retention class. */
+  kind: string;
+  /** Absolute path, when the artifact has bytes at all. */
+  path?: string;
+  /** `false` PINS the artifact: a dead Worker does not release it. */
+  reclaimable?: boolean;
+  /** An ISO instant before which the artifact is HELD whatever else says. */
+  reclaim_after?: string;
+  /** Why it is pinned, carried into the retain verdict's reason. */
+  reason?: string;
+}
+
+export type WorkerReclaimVerdictKind =
+  /** The daemon names this Worker — the veto that outranks everything else. */
+  | "worker-live"
+  /** The daemon did not answer, or its answer is stale. Never a death. */
+  | "liveness-unknown"
+  /** The artifact pins itself: `reclaimable: false`. */
+  | "pinned"
+  /** `reclaim_after` has not passed yet (or does not parse). */
+  | "grace-period"
+  /** A branch, PR, or commit: named elsewhere, no bytes to reclaim. */
+  | "pointer-retained"
+  /** An unrecognised kind: retained and reported, never guessed at. */
+  | "unclassified"
+  /** Cheap evidence of a dead Worker — the rescue material. */
+  | "evidence-retained"
+  /** Expensive, regenerable workspace of a Worker the daemon calls gone. */
+  | "workspace-reclaimable";
+
+/** One artifact, one verdict, one reason. */
+export interface WorkerArtifactVerdict {
+  worker_id: string;
+  artifact: WorkerArtifact;
+  class: WorkerArtifactClass;
+  /** The daemon's verdict on the owning Worker, carried so a reader never
+   * re-derives it from a second source. */
+  liveness: WorkerProcessVerdict;
+  reclaim: boolean;
+  verdict: WorkerReclaimVerdictKind;
+  reason: string;
+}
+
+/** One Worker's share of the plan. */
+export interface WorkerRetention {
+  worker_id: string;
+  liveness: WorkerProcessVerdict;
+  reclaim: WorkerArtifactVerdict[];
+  retain: WorkerArtifactVerdict[];
+}
+
+export const WORKER_RECLAIM_LIMIT_REASON = "limit" as const;
+
+export type WorkerReclaimDropReason = "limit" | "no-worker";
+
+/** Something the planner did NOT plan, and why. Never omitted silently. */
+export interface WorkerReclaimDrop {
+  reason: WorkerReclaimDropReason;
+  detail: string;
+  path?: string;
+  worker_id?: string;
+}
+
+export interface WorkerReclaimTotals {
+  considered: number;
+  reclaim: number;
+  retain: number;
+  dropped: number;
+}
+
+export interface WorkerReclaimPlan {
+  workers: WorkerRetention[];
+  reclaim: WorkerArtifactVerdict[];
+  retain: WorkerArtifactVerdict[];
+  dropped: WorkerReclaimDrop[];
+  /** True when a cap held reclaimable artifacts back. They are in `dropped`. */
+  truncated: boolean;
+  totals: WorkerReclaimTotals;
+}
+
+export interface WorkerReclaimOptions {
+  /** The daemon's verdict per Worker. Injected, so this planner stays pure and
+   * so no fallback source can sneak in behind it. */
+  liveness: (workerId: string) => WorkerProcessVerdict;
+  /** The instant `reclaim_after` is measured against. Injected, so this is pure. */
+  nowIso?: string;
+  /** Cap on reclaim actions per sweep. Everything past it is REPORTED, not
+   * dropped quietly. */
+  limit?: number;
+  /** Paths seen on disk. Any the artifacts do not account for is reported and
+   * left alone. */
+  observedPaths?: readonly string[];
+}
+
+const NO_WORKER_DETAIL =
+  "no Worker accounts for this path; the janitor leaves it alone";
+
+function graceHasPassed(reclaimAfter: string, nowIso: string): boolean {
+  const after = Date.parse(reclaimAfter);
+  const now = Date.parse(nowIso);
+  // An unparsable grace is treated as still running: the janitor holds bytes it
+  // cannot reason about rather than deleting them.
+  if (Number.isNaN(after) || Number.isNaN(now)) return false;
+  return now >= after;
+}
+
+/**
+ * Every path a LIVE Worker owns. A path can be attributed to more than one
+ * Worker — a retry reuses the workspace a previous try left (ADR 0103) — so the
+ * dead one's release must not offer up bytes the running one is still writing.
+ * Liveness wins at PATH granularity, not just at Worker granularity.
+ */
+function pathsOwnedByLiveWorkers(
+  artifacts: readonly WorkerArtifact[],
+  liveness: (workerId: string) => WorkerProcessVerdict,
+): Set<string> {
+  const owned = new Set<string>();
+  for (const artifact of artifacts) {
+    if (artifact.path === undefined) continue;
+    if (liveness(artifact.worker_id) === "dead") continue;
+    owned.add(artifact.path);
+  }
+  return owned;
+}
+
+function judge(
+  artifact: WorkerArtifact,
+  verdict: WorkerProcessVerdict,
+  nowIso: string,
+  liveOwned: ReadonlySet<string>,
+): WorkerArtifactVerdict {
+  const cls = classifyWorkerArtifact(artifact.kind);
+  const base = {
+    worker_id: artifact.worker_id,
+    artifact,
+    class: cls,
+    liveness: verdict,
+  } as const;
+  const retain = (
+    kind: WorkerReclaimVerdictKind,
+    reason: string,
+  ): WorkerArtifactVerdict => ({ ...base, reclaim: false, verdict: kind, reason });
+  const reclaim = (
+    kind: WorkerReclaimVerdictKind,
+    reason: string,
+  ): WorkerArtifactVerdict => ({ ...base, reclaim: true, verdict: kind, reason });
+
+  if (verdict === "alive") {
+    return retain(
+      "worker-live",
+      "the daemon names this Worker, so nothing it owns is reclaimable",
+    );
+  }
+  if (verdict === "unknown") {
+    return retain(
+      "liveness-unknown",
+      "the daemon did not answer for this Worker, and an unanswered question is not a death",
+    );
+  }
+  if (artifact.path !== undefined && liveOwned.has(artifact.path)) {
+    return retain(
+      "worker-live",
+      "a Worker the daemon has not called dead owns this path; this Worker's death does not release it",
+    );
+  }
+  if (artifact.reclaimable === false) {
+    return retain("pinned", artifact.reason ?? "this artifact is pinned as not reclaimable");
+  }
+  if (artifact.reclaim_after && !graceHasPassed(artifact.reclaim_after, nowIso)) {
+    return retain("grace-period", `held until reclaim_after ${artifact.reclaim_after}`);
+  }
+  if (cls === "pointer") {
+    return retain(
+      "pointer-retained",
+      `a ${artifact.kind} pointer is named by the tracker and git, not stored here`,
+    );
+  }
+  if (cls === "unknown") {
+    return retain(
+      "unclassified",
+      `artifact kind ${JSON.stringify(artifact.kind)} is not a known retention class`,
+    );
+  }
+  if (cls === "evidence") {
+    return retain(
+      "evidence-retained",
+      "the Worker is gone, so its cheap evidence is the material a rescue reads",
+    );
+  }
+  return reclaim(
+    "workspace-reclaimable",
+    "the daemon calls this Worker gone, and its workspace is expensive and regenerable",
+  );
+}
+
+/**
+ * Plan the reclaim for a set of Worker artifacts against the daemon's verdicts.
+ *
+ * The plan is total: every artifact — plus every observed path no Worker
+ * accounts for — appears exactly once across `reclaim`, `retain`, and `dropped`,
+ * and `totals` states that identity.
+ */
+export function planWorkerReclaim(
+  artifacts: readonly WorkerArtifact[],
+  options: WorkerReclaimOptions,
+): WorkerReclaimPlan {
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const workers = new Map<string, WorkerRetention>();
+  const reclaim: WorkerArtifactVerdict[] = [];
+  const retain: WorkerArtifactVerdict[] = [];
+  const dropped: WorkerReclaimDrop[] = [];
+  const accounted = new Set<string>();
+  // Counted from the INPUT, never from the output arrays, so the accounting
+  // identity in `totals` is a real assertion rather than a tautology.
+  let considered = 0;
+  const liveOwned = pathsOwnedByLiveWorkers(artifacts, options.liveness);
+
+  for (const artifact of artifacts) {
+    considered += 1;
+    if (artifact.path !== undefined) accounted.add(artifact.path);
+    const liveness = options.liveness(artifact.worker_id);
+    let worker = workers.get(artifact.worker_id);
+    if (worker === undefined) {
+      worker = { worker_id: artifact.worker_id, liveness, reclaim: [], retain: [] };
+      workers.set(artifact.worker_id, worker);
+    }
+    const verdict = judge(artifact, liveness, nowIso, liveOwned);
+    if (!verdict.reclaim) {
+      retain.push(verdict);
+      worker.retain.push(verdict);
+      continue;
+    }
+    // The cap is applied here so a held-back artifact is REPORTED as a drop
+    // rather than quietly re-labelled as retained — a caller reading `retain`
+    // must never be told an artifact was kept on purpose when it was really
+    // just past the cap.
+    if (options.limit !== undefined && reclaim.length >= options.limit) {
+      dropped.push({
+        reason: WORKER_RECLAIM_LIMIT_REASON,
+        detail: `reclaim limit ${options.limit} reached; this artifact was not planned`,
+        worker_id: artifact.worker_id,
+        ...(artifact.path === undefined ? {} : { path: artifact.path }),
+      });
+      continue;
+    }
+    reclaim.push(verdict);
+    worker.reclaim.push(verdict);
+  }
+
+  for (const path of options.observedPaths ?? []) {
+    if (accounted.has(path)) continue;
+    accounted.add(path);
+    considered += 1;
+    dropped.push({ reason: "no-worker", path, detail: NO_WORKER_DETAIL });
+  }
+
+  return {
+    workers: [...workers.values()],
+    reclaim,
+    retain,
+    dropped,
+    truncated: dropped.some((drop) => drop.reason === WORKER_RECLAIM_LIMIT_REASON),
+    totals: {
+      considered,
+      reclaim: reclaim.length,
+      retain: retain.length,
+      dropped: dropped.length,
+    },
+  };
+}

--- a/apps/dev/src/runtime/tmp-janitor.ts
+++ b/apps/dev/src/runtime/tmp-janitor.ts
@@ -1,7 +1,8 @@
 import { readdir, readlink, rm, stat, readFile } from "node:fs/promises";
-import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
   isLegacySlotLogName,
+  pathIsInsideTmp,
   planTmpJanitor,
   planWorkerDirJanitor,
   planSupervisorLaneJanitor,
@@ -17,10 +18,22 @@ import {
   type SupervisorLaneEntry,
   type SupervisorLanePlan,
 } from "../core/tmp-janitor.js";
+import {
+  planWorkerReclaim,
+  type WorkerArtifact,
+  type WorkerProcessVerdict,
+  type WorkerReclaimPlan,
+} from "../core/worker-reclaim.js";
 import { decodeDevSnapshotSniff } from "../core/toon-snapshot.js";
 import { allWorkersRoots, parseReapableWorkerPath } from "../core/worker-paths.js";
 import { execTool } from "./exec.js";
 import { killTreeAndWait } from "./kill-tree.js";
+import {
+  readDaemonWorkerSet,
+  resolveWorkerLiveness,
+  type DaemonWorkerSet,
+  type DaemonWorkerSetReader,
+} from "./liveness-anchor.js";
 
 export const ORPHAN_TEST_RUNNER_MIN_AGE_S = 300;
 
@@ -83,6 +96,13 @@ export type IssueStateLookup = (issue: number) => "OPEN" | "CLOSED" | "UNKNOWN";
 
 export interface TmpJanitorReport {
   plan: TmpJanitorPlan;
+  /**
+   * The daemon-keyed reclaim plan (Spec #2772 US 46): what the daemon's process
+   * truth says about the artifacts each Worker left, plus every observed path no
+   * Worker accounts for. This is the authority; the lanes below only ever narrow
+   * it, never widen it.
+   */
+  workerReclaim: WorkerReclaimPlan;
   staleWorkers: ReturnType<typeof planWorkerDirJanitor>;
   /** Supervisor fleet dirs partitioned by pid liveness. Live dirs are spared;
    * dead dirs are eligible for removal. */
@@ -110,6 +130,10 @@ export interface TmpJanitorApplyResult {
   orphanFeedback: string[];
   /** Confirmed orphan runner processes reaped by process-group ID. */
   orphanTestRunners: Array<{ pid: number; pgid: number }>;
+  /** Workspaces removed because the daemon called their Worker gone. */
+  workerWorkspaces: string[];
+  /** Workspaces spared because the daemon did not call their Worker gone. */
+  protectedLiveWorkspaces: string[];
   /** Paths a plan named outside this tmp tier: reported, never removed. */
   refusedOutsideTmp: string[];
   /** Every destructive action, including the liveness verdict authorising it. */
@@ -175,9 +199,103 @@ async function readText(path: string): Promise<string | null> {
   }
 }
 
+// ---------- the daemon is the reclaim authority (Spec #2772 US 46) ----------
+
+/**
+ * Ask the daemon about one Worker, and NOTHING else.
+ *
+ * `evidenceOfLife` is the one contribution a caller may make, and it is one-way:
+ * it can WITHHOLD a death claim, never manufacture a life. That is what keeps a
+ * `worker.pid` file out of reclaim eligibility while a Worker the project
+ * launched itself — one the daemon never birthed and so cannot vouch for — still
+ * survives the sweep.
+ */
+export type WorkerLivenessLookup = (
+  workerId: string,
+  evidenceOfLife?: boolean,
+) => WorkerProcessVerdict;
+
+function livenessLookup(hostAnswer: DaemonWorkerSet | null): WorkerLivenessLookup {
+  return (workerId, evidenceOfLife = false) =>
+    resolveWorkerLiveness(hostAnswer, workerId, { evidenceOfLife }).verdict;
+}
+
+/** One daemon read, or null when it did not answer. Every Worker in the sweep is
+ * judged against THIS answer, so two lanes of one sweep cannot disagree. */
+async function readDaemon(read: DaemonWorkerSetReader): Promise<DaemonWorkerSet | null> {
+  try {
+    return await read();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Which Workers something OTHER than the daemon can still see running.
+ *
+ * Read once and applied to every lane of the sweep, so a Worker cannot be
+ * `unknown` to one lane and `dead` to the next — the disagreement that lets one
+ * pass spare a workspace while another deletes it.
+ */
+async function collectWorkerEvidence(tmpDir: string): Promise<Set<string>> {
+  const evidence = new Set<string>();
+  for (const workersRoot of allWorkersRoots(tmpDir)) {
+    for (const worker of await listNames(workersRoot)) {
+      if (pidAlive(await readText(join(workersRoot, worker, "worker.pid")))) evidence.add(worker);
+    }
+  }
+  return evidence;
+}
+
+/** The sweep's ONE liveness question, with the host's evidence already folded in. */
+function sweepLiveness(
+  hostAnswer: DaemonWorkerSet | null,
+  evidence: ReadonlySet<string>,
+): WorkerLivenessLookup {
+  const ask = livenessLookup(hostAnswer);
+  return (workerId, extraEvidence = false) =>
+    ask(workerId, evidence.has(workerId) || extraEvidence);
+}
+
+/**
+ * Every artifact the Worker lanes hold, attributed to its owning Worker.
+ *
+ * The workspace path is DERIVED from the Worker's identity (ADR 0103/0105) — it
+ * is a pure function of `workers/{id}/{issue}/worktree` — and the daemon still
+ * decides whether the bytes go.
+ */
+async function collectWorkerArtifacts(tmpDir: string): Promise<{
+  artifacts: WorkerArtifact[];
+  observedPaths: string[];
+}> {
+  const artifacts: WorkerArtifact[] = [];
+  const observedPaths: string[] = [];
+  for (const workersRoot of allWorkersRoots(tmpDir)) {
+    for (const worker of await listNames(workersRoot)) {
+      for (const issue of await listNames(join(workersRoot, worker))) {
+        const issueDir = join(workersRoot, worker, issue);
+        const worktree = join(issueDir, "worktree");
+        try {
+          if (!(await stat(worktree)).isDirectory()) continue;
+        } catch {
+          continue; // No workspace under this Worker's issue dir.
+        }
+        observedPaths.push(worktree);
+        artifacts.push({ worker_id: worker, kind: "worktree", path: worktree });
+        const log = join(issueDir, "worker.log.toonl");
+        if (await readText(log) !== null) {
+          artifacts.push({ worker_id: worker, kind: "log", path: log });
+        }
+      }
+    }
+  }
+  return { artifacts, observedPaths };
+}
+
 async function collectWorkerEntries(
   tmpDir: string,
   lookup: IssueStateLookup,
+  liveness: WorkerLivenessLookup,
 ): Promise<WorkerDirJanitorEntry[]> {
   const out: WorkerDirJanitorEntry[] = [];
   for (const workersRoot of allWorkersRoots(tmpDir)) {
@@ -190,7 +308,7 @@ async function collectWorkerEntries(
       } catch {
         continue;
       }
-      const workerPidLive = pidAlive(await readText(join(workerPath, "worker.pid")));
+      const verdict = liveness(worker);
       const issues = new Map<number, "OPEN" | "CLOSED" | "UNKNOWN">();
       for (const child of await listNames(workerPath)) {
         const childPath = join(workerPath, child);
@@ -207,7 +325,7 @@ async function collectWorkerEntries(
       }
       out.push({
         path: workerPath,
-        workerPidLive,
+        liveness: verdict,
         issues: [...issues].map(([issue, state]) => ({ issue, state })),
       });
     }
@@ -282,24 +400,24 @@ async function collectSupervisorEntries(tmpDir: string): Promise<SupervisorLaneE
 }
 
 /**
- * Build the live-worker PID index: a map from worker ID to liveness so the
- * orphan feedback sweep can decide per-entry without re-reading PID files.
- * Returns null when any worker is alive (signals that the shared baseline
- * worktree is in use and must be spared).
+ * Build the surviving-Worker index the orphan feedback sweep decides against.
+ *
+ * A Worker is in the set unless the DAEMON called it dead: `alive` and `unknown`
+ * both survive, because only a fresh daemon answer may release bytes. `anyAlive`
+ * reports whether any Worker survived at all, which is what the shared baseline
+ * worktree (owned by no single Worker) is judged against.
  */
-async function buildWorkerLivenessIndex(tmpDir: string): Promise<{ liveWorkers: Set<string>; anyAlive: boolean }> {
+async function buildWorkerLivenessIndex(
+  tmpDir: string,
+  liveness: WorkerLivenessLookup,
+): Promise<{ liveWorkers: Set<string>; anyAlive: boolean }> {
   const liveWorkers = new Set<string>();
-  let anyAlive = false;
   for (const workersRoot of allWorkersRoots(tmpDir)) {
     for (const workerDir of await listNames(workersRoot)) {
-      const pidFile = join(workersRoot, workerDir, "worker.pid");
-      if (pidAlive(await readText(pidFile))) {
-        liveWorkers.add(workerDir);
-        anyAlive = true;
-      }
+      if (liveness(workerDir) !== "dead") liveWorkers.add(workerDir);
     }
   }
-  return { liveWorkers, anyAlive };
+  return { liveWorkers, anyAlive: liveWorkers.size > 0 };
 }
 
 function feedbackIssueFromBasename(name: string): number | null {
@@ -307,19 +425,22 @@ function feedbackIssueFromBasename(name: string): number | null {
   return match?.[1] ? Number(match[1]) : null;
 }
 
+/** Whether the issue's claim lock still names a running process. Evidence of
+ * life only: a live claim WITHHOLDS a death claim about a resumed branch's
+ * Worker, and can never assert one. */
 async function feedbackClaimIsLive(tmpDir: string, name: string): Promise<boolean> {
   const issue = feedbackIssueFromBasename(name);
   if (issue === null) return false;
   return pidAlive(await readText(join(tmpDir, "claims", String(issue), "pid")));
 }
 
-async function collectOrphanFeedbackEntries(tmpDir: string): Promise<{
+async function collectOrphanFeedbackEntries(tmpDir: string, liveness: WorkerLivenessLookup): Promise<{
   entries: OrphanFeedbackEntry[];
   anyWorkerAlive: boolean;
 }> {
   const feedbackDir = join(tmpDir, "worktrees", "feedback");
   const names = await listNames(feedbackDir);
-  const { liveWorkers, anyAlive } = await buildWorkerLivenessIndex(tmpDir);
+  const { liveWorkers, anyAlive } = await buildWorkerLivenessIndex(tmpDir, liveness);
   const entries: OrphanFeedbackEntry[] = [];
   for (const name of names) {
     const path = join(feedbackDir, name);
@@ -333,10 +454,12 @@ async function collectOrphanFeedbackEntries(tmpDir: string): Promise<{
     const workerSlug = parseFeedbackWorktreeWorkerSlug(name);
     let ownerAlive: boolean | null;
     if (workerSlug !== null) {
-      // A re-claim may resume an old worker's branch, so the branch slug is not
-      // always the current process owner. The active issue claim is an equal
-      // liveness anchor and must spare that resumed workspace.
-      ownerAlive = liveWorkers.has(workerSlug) || await feedbackClaimIsLive(tmpDir, name);
+      // The daemon answers for the owning Worker; a re-claim that resumed an old
+      // Worker's branch contributes its live claim as EVIDENCE, which withholds
+      // the death claim without ever asserting a life of its own.
+      ownerAlive =
+        liveWorkers.has(workerSlug) ||
+        liveness(workerSlug, await feedbackClaimIsLive(tmpDir, name)) !== "dead";
     } else {
       // Non-afk entry (e.g. 'main'): liveness is inferred from anyAlive
       ownerAlive = null;
@@ -349,14 +472,16 @@ async function collectOrphanFeedbackEntries(tmpDir: string): Promise<{
 async function feedbackRemovalVerdict(
   tmpDir: string,
   path: string,
+  liveness: WorkerLivenessLookup,
 ): Promise<
   | { safe: false; verdict: "owner-live" }
   | { safe: true; verdict: "owner-dead" | "no-live-workers" }
 > {
   const workerSlug = parseFeedbackWorktreeWorkerSlug(basename(path));
-  const { liveWorkers, anyAlive } = await buildWorkerLivenessIndex(tmpDir);
+  const { liveWorkers, anyAlive } = await buildWorkerLivenessIndex(tmpDir, liveness);
   if (workerSlug !== null) {
-    return liveWorkers.has(workerSlug) || await feedbackClaimIsLive(tmpDir, basename(path))
+    const evidence = await feedbackClaimIsLive(tmpDir, basename(path));
+    return liveWorkers.has(workerSlug) || liveness(workerSlug, evidence) !== "dead"
       ? { safe: false, verdict: "owner-live" }
       : { safe: true, verdict: "owner-dead" };
   }
@@ -365,11 +490,29 @@ async function feedbackRemovalVerdict(
     : { safe: true, verdict: "no-live-workers" };
 }
 
+/** How this sweep reaches the daemon. Injected so a caller can hand the sweep a
+ * host answer it already holds, and so the read is testable at the seam the
+ * shipped path uses. */
+export interface TmpJanitorSources {
+  daemon?: DaemonWorkerSetReader;
+}
+
 export async function collectTmpJanitorReport(
   tmpDir: string,
   nowS: number,
   lookup: IssueStateLookup,
+  sources: TmpJanitorSources = {},
 ): Promise<TmpJanitorReport> {
+  const liveness = sweepLiveness(
+    await readDaemon(sources.daemon ?? readDaemonWorkerSet),
+    await collectWorkerEvidence(tmpDir),
+  );
+  const workerArtifacts = await collectWorkerArtifacts(tmpDir);
+  const workerReclaim = planWorkerReclaim(workerArtifacts.artifacts, {
+    liveness: (workerId) => liveness(workerId),
+    nowIso: new Date(nowS * 1000).toISOString(),
+    observedPaths: workerArtifacts.observedPaths,
+  });
   const [tmpRootNames, tmpRootEntries, logEntries, scratchEntries, diagnosticsEntries, feedbackEntries, workers, orphanFeedbackData, supervisorEntries] =
     await Promise.all([
       listNames(tmpDir),
@@ -378,8 +521,8 @@ export async function collectTmpJanitorReport(
       listEntries(join(tmpDir, "scratch")),
       listEntries(join(tmpDir, "diagnostics")),
       listEntries(join(tmpDir, "worktrees", "feedback")),
-      collectWorkerEntries(tmpDir, lookup),
-      collectOrphanFeedbackEntries(tmpDir),
+      collectWorkerEntries(tmpDir, lookup, liveness),
+      collectOrphanFeedbackEntries(tmpDir, liveness),
       collectSupervisorEntries(tmpDir),
     ]);
   const legacySlotLogEntries = tmpRootEntries.filter((entry) => isLegacySlotLogName(basename(entry.path)));
@@ -399,6 +542,7 @@ export async function collectTmpJanitorReport(
       legacySlotLogEntries,
       tmpRootNames,
     }),
+    workerReclaim,
     staleWorkers: planWorkerDirJanitor(workers),
     staleSupervisors: planSupervisorLaneJanitor(supervisorEntries),
     orphanFeedback,
@@ -409,12 +553,19 @@ export async function collectTmpJanitorReport(
 export async function applyTmpJanitorReport(
   tmpDir: string,
   report: TmpJanitorReport,
-  options: {
+  options: TmpJanitorSources & {
     worktreePrune?: () => Promise<void>;
     reapProcessGroup?: (pgid: number) => Promise<boolean>;
     log?: (line: string) => void;
   } = {},
 ): Promise<TmpJanitorApplyResult> {
+  // The daemon is RE-READ here, not carried from the plan: a Worker may have
+  // been born between collect and apply, and the plan is history the moment it
+  // is built. A removal is authorised by a CURRENT answer or not at all.
+  const liveness = sweepLiveness(
+    await readDaemon(options.daemon ?? readDaemonWorkerSet),
+    await collectWorkerEvidence(tmpDir),
+  );
   const expired = [
     ...report.plan.logs.reclaim,
     ...report.plan.scratch.reclaim,
@@ -432,6 +583,8 @@ export async function applyTmpJanitorReport(
     protectedLiveFeedback: [],
     orphanFeedback: [],
     orphanTestRunners: [],
+    workerWorkspaces: [],
+    protectedLiveWorkspaces: [],
     refusedOutsideTmp: [],
     removals: [],
   };
@@ -446,14 +599,14 @@ export async function applyTmpJanitorReport(
 
   for (const entry of expired) {
     if (dirname(entry.path) === feedbackDir) {
-      const liveness = await feedbackRemovalVerdict(tmpDir, entry.path);
-      if (!liveness.safe) {
+      const owner = await feedbackRemovalVerdict(tmpDir, entry.path, liveness);
+      if (!owner.safe) {
         protectFeedback(entry.path);
         continue;
       }
       await rm(entry.path, { recursive: true, force: true });
       removedFeedback.add(entry.path);
-      result.removals.push({ path: entry.path, livenessVerdict: liveness.verdict });
+      result.removals.push({ path: entry.path, livenessVerdict: owner.verdict });
       result.expiredLanes.push(entry.path);
       continue;
     }
@@ -462,8 +615,27 @@ export async function applyTmpJanitorReport(
     result.expiredLanes.push(entry.path);
   }
 
+  // The daemon-keyed pass runs FIRST: it is the authority, and the lanes below
+  // only narrow what it already decided. Every removal is re-authorised against
+  // the answer read at the top of this function.
+  for (const verdict of report.workerReclaim.reclaim) {
+    const path = verdict.artifact.path;
+    if (path === undefined) continue; // No bytes here to remove.
+    if (!pathIsInsideTmp(tmpDir, path)) {
+      result.refusedOutsideTmp.push(path);
+      continue;
+    }
+    if (liveness(verdict.worker_id) !== "dead") {
+      result.protectedLiveWorkspaces.push(path);
+      continue;
+    }
+    await rm(path, { recursive: true, force: true });
+    result.removals.push({ path, livenessVerdict: "worker-dead" });
+    result.workerWorkspaces.push(path);
+  }
+
   for (const worker of report.staleWorkers.reclaim) {
-    if (pidAlive(await readText(join(worker.path, "worker.pid")))) {
+    if (liveness(basename(worker.path)) !== "dead") {
       result.protectedLiveWorkers.push(worker.path);
       continue;
     }
@@ -498,15 +670,15 @@ export async function applyTmpJanitorReport(
   }
 
   for (const entry of report.orphanFeedback.reclaim) {
-    const liveness = await feedbackRemovalVerdict(tmpDir, entry.path);
-    if (!liveness.safe) {
+    const owner = await feedbackRemovalVerdict(tmpDir, entry.path, liveness);
+    if (!owner.safe) {
       protectFeedback(entry.path);
       continue;
     }
     if (!removedFeedback.has(entry.path)) {
       await rm(entry.path, { recursive: true, force: true });
       removedFeedback.add(entry.path);
-      result.removals.push({ path: entry.path, livenessVerdict: liveness.verdict });
+      result.removals.push({ path: entry.path, livenessVerdict: owner.verdict });
     }
     result.orphanFeedback.push(entry.path);
   }
@@ -535,18 +707,52 @@ export async function applyTmpJanitorReport(
   return result;
 }
 
+/** The Worker a Worker-lane path belongs to, or null when no lane owns it.
+ * Pure path arithmetic over the ADR 0103/0105 layout — it asks nothing about
+ * processes, which is exactly why the answer it feeds must come from the daemon. */
+export function workerIdForTmpPath(tmpDir: string, path: string): string | null {
+  const resolved = resolve(path);
+  for (const workersRoot of allWorkersRoots(tmpDir)) {
+    const rel = relative(resolve(workersRoot), resolved);
+    if (rel === "" || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) continue;
+    return rel.split(sep)[0] ?? null;
+  }
+  return null;
+}
+
+/**
+ * The daemon's CURRENT verdict on the Worker that owns one tmp path.
+ *
+ * This is the guard an apply pass calls immediately before removing: a Worker
+ * may have been born since the plan was built. A path no Worker lane owns
+ * answers `unknown`, which spares it.
+ */
+export async function readWorkerLivenessForTmpPath(
+  tmpDir: string,
+  path: string,
+  sources: TmpJanitorSources = {},
+): Promise<WorkerProcessVerdict> {
+  const workerId = workerIdForTmpPath(tmpDir, path);
+  if (workerId === null) return "unknown";
+  const liveness = sweepLiveness(
+    await readDaemon(sources.daemon ?? readDaemonWorkerSet),
+    await collectWorkerEvidence(tmpDir),
+  );
+  return liveness(workerId);
+}
+
 export async function runTmpJanitor(
   tmpDir: string,
   nowS: number,
   lookup: IssueStateLookup,
-  options: {
+  options: TmpJanitorSources & {
     fix?: boolean;
     worktreePrune?: () => Promise<void>;
     reapProcessGroup?: (pgid: number) => Promise<boolean>;
     log?: (line: string) => void;
   } = {},
 ): Promise<TmpJanitorRunResult> {
-  const report = await collectTmpJanitorReport(tmpDir, nowS, lookup);
+  const report = await collectTmpJanitorReport(tmpDir, nowS, lookup, options);
   if (!options.fix) return report;
   return { ...report, applied: await applyTmpJanitorReport(tmpDir, report, options) };
 }

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -26,7 +26,7 @@ import { liveIssueFromBranch, type IssueMeta } from "../../core/branch-cleanup.j
 import { readWorkerState } from "../../core/worker-state-reader.js";
 import { isLivePid, killTreeAndWait } from "../kill-tree.js";
 import { execTool, type ExecFn } from "../exec.js";
-import { collectTmpJanitorReport } from "../tmp-janitor.js";
+import { collectTmpJanitorReport, readWorkerLivenessForTmpPath } from "../tmp-janitor.js";
 import { issueMeta, type GhContext, type IssueStateRow } from "../gh.js";
 import * as ghx from "../gh.js";
 import * as gitx from "../git.js";
@@ -447,12 +447,10 @@ export async function buildBootDeps(
       ensureGitignoreLine: fsx.ensureGitignoreLine,
       writeWorkerPid: fsx.writeWorkerPid,
       removeDir: fsx.removeDir,
-      workerPidLive: async (workerDir) => {
-        const raw = await fsx.readText(join(workerDir, "worker.pid"));
-        if (raw === null) return false;
-        const pid = Number(raw.trim());
-        return Number.isInteger(pid) && pid > 0 && isLivePid(pid);
-      },
+      // Both guards ask the DAEMON, which owns process death by construction,
+      // and never a pid file (Spec #2772 US 46).
+      workerLivenessVerdict: (workerDir) => readWorkerLivenessForTmpPath(paths.tmpDir, workerDir),
+      workerWorkspaceLivenessVerdict: (path) => readWorkerLivenessForTmpPath(paths.tmpDir, path),
       feedbackWorktreeLiveness: async (path) => {
         // Re-collect immediately before deletion: the boot plan may have been
         // built before another fleet spawned the feedback worktree's owner.

--- a/apps/dev/src/runtime/wire/monitor.ts
+++ b/apps/dev/src/runtime/wire/monitor.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { readDevBundleCacheState } from "../../core/bundle-version.js";
 import { decodeDevSnapshotSniff } from "../../core/toon-snapshot.js";
@@ -9,6 +9,8 @@ import {
   type WorkerStateRecord,
 } from "../../core/worker-state-reader.js";
 import { planLivenessReclaim, type LivenessReclaimInput } from "../../core/reclaim.js";
+import type { WorkerProcessVerdict } from "../../core/worker-reclaim.js";
+import { readWorkerLivenessForTmpPath } from "../tmp-janitor.js";
 import { readHistoryRecords, type HistoryRecord } from "../../core/history.js";
 import { LABEL_HUMAN } from "../../core/triage-labels.js";
 import {
@@ -177,10 +179,11 @@ export async function readFleetState(path: string): Promise<FleetState | null> {
 
 /** Injected seams for {@link reclaimDeadWorkers} (real defaults wire gh/git/fs). */
 export interface DeadWorkerSweepDeps {
-  /** Raw `worker.pid` text for a worker dir. Default reads `{workerDir}/worker.pid`. */
-  readWorkerPid?: (workerDir: string) => string | null;
-  /** `kill -0` liveness probe. Default `process.kill(pid, 0)`. */
-  killAlive?: (pid: number) => boolean;
+  /** The DAEMON's verdict on the Worker owning a dir (Spec #2772 US 46). Default
+   * asks the daemon through the single liveness anchor; there is deliberately no
+   * pid-file seam here, because keying reclaim on a pid file is what deleted a
+   * live lane and kept the dead ones (#2679). */
+  workerLiveness?: (workerDir: string) => Promise<WorkerProcessVerdict>;
   /** Whether an issue is in a post-mortem preservation state (blocked:* /
    * ready-for-human). Default `gh issue view --json labels`. Returns `true`
    * (conservative — keep the JSONL) whenever it cannot resolve. */
@@ -201,9 +204,9 @@ export interface DeadWorkerSweepDeps {
  * scout-workers) since it consumes {@link readAllWorkerStates} records.
  *
  * Safety rules (see {@link planLivenessReclaim}):
- *   - NEVER touch a live worker's dir — keyed on the OWNING worker's `worker.pid`
- *     (shared across a worker's attempts), so a worker live on a later attempt
- *     keeps ALL its dirs.
+ *   - NEVER touch a dir whose OWNING Worker the daemon has not called dead — the
+ *     verdict is per-Worker (shared across its attempts), so a Worker live on a
+ *     later attempt keeps ALL its dirs.
  *   - A dead worker's disposable `worktree/` is ALWAYS removed.
  *   - The whole attempt dir is reclaimed UNLESS the issue is preserved
  *     (blocked:* / ready-for-human), where the JSONL/handoff stay for post-mortem.
@@ -218,25 +221,10 @@ export async function reclaimDeadWorkers(
   deps: DeadWorkerSweepDeps = {},
 ): Promise<string[]> {
   const exists = deps.exists ?? ((p: string) => existsSync(p));
-  const readWorkerPid =
-    deps.readWorkerPid ??
-    ((workerDir: string): string | null => {
-      try {
-        return readFileSync(join(workerDir, "worker.pid"), "utf8");
-      } catch {
-        return null;
-      }
-    });
-  const killAlive =
-    deps.killAlive ??
-    ((pid: number): boolean => {
-      try {
-        process.kill(pid, 0);
-        return true;
-      } catch {
-        return false;
-      }
-    });
+  const workerLiveness =
+    deps.workerLiveness ??
+    ((workerDir: string): Promise<WorkerProcessVerdict> =>
+      readWorkerLivenessForTmpPath(afkPaths(root).tmpDir, workerDir));
   const isPreserved =
     deps.isPreserved ??
     (async (issue: number): Promise<boolean> => {
@@ -256,19 +244,15 @@ export async function reclaimDeadWorkers(
     });
   const removeDir = deps.removeDir ?? ((dir: string) => fsx.removeDir(dir));
 
-  // Per-worker `worker.pid` liveness, memoized so a worker's several attempt dirs
-  // resolve it once.
-  const workerAliveCache = new Map<string, boolean>();
-  const workerPidAlive = (workerDir: string): boolean => {
-    const cached = workerAliveCache.get(workerDir);
+  // The daemon's verdict per Worker, memoized so a Worker's several attempt dirs
+  // ask once. An unreachable daemon answers `unknown`, which spares the dir.
+  const verdictCache = new Map<string, WorkerProcessVerdict>();
+  const workerVerdict = async (workerDir: string): Promise<WorkerProcessVerdict> => {
+    const cached = verdictCache.get(workerDir);
     if (cached !== undefined) return cached;
-    const raw = readWorkerPid(workerDir);
-    const pid = raw ? parseInt(raw.trim(), 10) : NaN;
-    // Absent/unparseable worker.pid → treat as ALIVE (never reclaim a dir we
-    // cannot prove belongs to a dead worker).
-    const alive = Number.isFinite(pid) && pid > 0 ? killAlive(pid) : true;
-    workerAliveCache.set(workerDir, alive);
-    return alive;
+    const verdict = await workerLiveness(workerDir).catch((): WorkerProcessVerdict => "unknown");
+    verdictCache.set(workerDir, verdict);
+    return verdict;
   };
 
   // Build the pure planner inputs, resolving preservation only for dead workers.
@@ -276,9 +260,9 @@ export async function reclaimDeadWorkers(
   for (const rec of records) {
     const attemptDir = dirname(rec.path);
     const workerDir = dirname(attemptDir);
-    // A renderable-live record (or a worker still live on any attempt) is never
-    // a reclaim candidate.
-    const alive = rec.renderableLive || workerPidAlive(workerDir);
+    // A renderable-live record is EVIDENCE the Worker still runs: it withholds
+    // the death claim, and never asserts a life the daemon did not.
+    const liveness = rec.renderableLive ? "unknown" : await workerVerdict(workerDir);
     const num = rec.state.current.number;
     const issue = typeof num === "number" ? num : Number.parseInt(String(num), 10);
     const preserved =
@@ -288,7 +272,7 @@ export async function reclaimDeadWorkers(
       // Current workers use the conventional direct child. During rollout,
       // hygiene may still discover a legacy nested worktree for removal only.
       worktreePath: reapableWorktreeUnder(attemptDir) ?? join(attemptDir, "worktree"),
-      workerPidAlive: alive,
+      liveness,
       preserved,
     });
   }

--- a/apps/dev/tests/boot-cleanup.test.ts
+++ b/apps/dev/tests/boot-cleanup.test.ts
@@ -40,7 +40,7 @@ describe("runBoot tmp janitor", () => {
   });
 
   it("reclaims expired named lanes, closed-issue dead workers, and audited unknown tmp roots", async () => {
-    const { deps, fsCalls } = makeDeps({ workerPidLive: async () => false });
+    const { deps, fsCalls } = makeDeps({ workerLivenessVerdict: async () => "dead" });
     const result = await runBoot(
       deps,
       options({
@@ -57,7 +57,7 @@ describe("runBoot tmp janitor", () => {
             reclaim: [
               {
                 path: "/p/.red/tmp/workers/wOLD",
-                workerPidLive: false,
+                liveness: "dead",
                 issues: [{ issue: 9, state: "CLOSED" }],
               },
             ],
@@ -80,6 +80,8 @@ describe("runBoot tmp janitor", () => {
       protectedLiveWorkers: [],
       protectedLiveFeedback: [],
       orphanTestRunners: [],
+      workerWorkspaces: [],
+      protectedLiveWorkspaces: [],
       refusedOutsideTmp: [],
       removals: [
         { path: "/p/.red/tmp/logs/old", livenessVerdict: "not-worker-workspace" },
@@ -116,8 +118,8 @@ describe("runBoot tmp janitor", () => {
     expect(result.tmpJanitor?.removals.map((r) => r.path)).not.toContain("/p/.red/tmp/supervisors");
   });
 
-  it("rechecks worker.pid before removing a stale worker dir and protects live anchors", async () => {
-    const { deps, fsCalls } = makeDeps({ workerPidLive: async () => true });
+  it("re-asks the daemon before removing a stale worker dir and protects a live Worker", async () => {
+    const { deps, fsCalls } = makeDeps({ workerLivenessVerdict: async () => "alive" });
     const result = await runBoot(
       deps,
       options({
@@ -134,7 +136,7 @@ describe("runBoot tmp janitor", () => {
             reclaim: [
               {
                 path: "/p/.red/tmp/workers/wLIVE",
-                workerPidLive: false,
+                liveness: "dead",
                 issues: [{ issue: 9, state: "CLOSED" }],
               },
             ],

--- a/apps/dev/tests/boot.helpers.ts
+++ b/apps/dev/tests/boot.helpers.ts
@@ -51,7 +51,8 @@ export function makeDeps(over: Partial<{
   straggler: BootDeps["lookups"]["straggler"];
   claimHolderAlive: BootDeps["lookups"]["claimHolderAlive"];
   claimedIssues: BootDeps["lookups"]["claimedIssues"];
-  workerPidLive: BootDeps["fs"]["workerPidLive"];
+  workerLivenessVerdict: BootDeps["fs"]["workerLivenessVerdict"];
+  workerWorkspaceLivenessVerdict: BootDeps["fs"]["workerWorkspaceLivenessVerdict"];
   viewLabels: (issue: number) => Promise<string[]>;
   env: Record<string, string | undefined>;
   config: Record<string, string | undefined>;
@@ -96,11 +97,19 @@ export function makeDeps(over: Partial<{
         calls.push(`fs.removeDir:${p}`);
         fsCalls.removeDir.push(p);
       },
-      ...(over.workerPidLive
+      ...(over.workerLivenessVerdict
         ? {
-            async workerPidLive(workerDir: string) {
-              calls.push(`fs.workerPidLive:${workerDir}`);
-              return over.workerPidLive!(workerDir);
+            async workerLivenessVerdict(workerDir: string) {
+              calls.push(`fs.workerLivenessVerdict:${workerDir}`);
+              return over.workerLivenessVerdict!(workerDir);
+            },
+          }
+        : {}),
+      ...(over.workerWorkspaceLivenessVerdict
+        ? {
+            async workerWorkspaceLivenessVerdict(path: string) {
+              calls.push(`fs.workerWorkspaceLivenessVerdict:${path}`);
+              return over.workerWorkspaceLivenessVerdict!(path);
             },
           }
         : {}),

--- a/apps/dev/tests/reclaim.test.ts
+++ b/apps/dev/tests/reclaim.test.ts
@@ -202,31 +202,35 @@ describe("planLivenessReclaim (issue #1219)", () => {
   const input = (over: Partial<LivenessReclaimInput>): LivenessReclaimInput => ({
     attemptDir: "/r/.red/tmp/workers/wA/5-a1",
     worktreePath: "/r/.red/tmp/workers/wA/5-a1/worktree",
-    workerPidAlive: false,
+    liveness: "dead",
     preserved: false,
     ...over,
   });
 
+  it("never touches a dir the daemon has not called dead", () => {
+    expect(planLivenessReclaim([input({ liveness: "unknown" })])).toEqual([]);
+  });
+
   it("never touches a live worker's dir", () => {
-    expect(planLivenessReclaim([input({ workerPidAlive: true })])).toEqual([]);
+    expect(planLivenessReclaim([input({ liveness: "alive" })])).toEqual([]);
   });
 
   it("reclaims a dead, non-preserved worker's whole dir (worktree + dir)", () => {
-    const [action] = planLivenessReclaim([input({ workerPidAlive: false, preserved: false })]);
+    const [action] = planLivenessReclaim([input({ liveness: "dead", preserved: false })]);
     expect(action.removeWorktree).toBe(true);
     expect(action.reclaimDir).toBe(true);
   });
 
   it("removes only the worktree of a dead but preserved worker (keeps JSONL/handoff)", () => {
-    const [action] = planLivenessReclaim([input({ workerPidAlive: false, preserved: true })]);
+    const [action] = planLivenessReclaim([input({ liveness: "dead", preserved: true })]);
     expect(action.removeWorktree).toBe(true);
     expect(action.reclaimDir).toBe(false);
   });
 
   it("keeps a live worker's dir while reclaiming a sibling dead worker", () => {
     const actions = planLivenessReclaim([
-      input({ attemptDir: "/r/.red/tmp/workers/wLIVE/5-a1", workerPidAlive: true }),
-      input({ attemptDir: "/r/.red/tmp/go-workers/wDEAD/6-a1", workerPidAlive: false, preserved: false }),
+      input({ attemptDir: "/r/.red/tmp/workers/wLIVE/5-a1", liveness: "alive" }),
+      input({ attemptDir: "/r/.red/tmp/go-workers/wDEAD/6-a1", liveness: "dead", preserved: false }),
     ]);
     expect(actions.map((a) => a.attemptDir)).toEqual(["/r/.red/tmp/go-workers/wDEAD/6-a1"]);
   });

--- a/apps/dev/tests/red-doctor-command.test.ts
+++ b/apps/dev/tests/red-doctor-command.test.ts
@@ -35,6 +35,8 @@ vi.mock("../src/runtime/tmp-janitor.js", () => ({
     unknownTmpRoots: [],
     protectedLiveWorkers: [],
     protectedLiveFeedback: [],
+    workerWorkspaces: [],
+    protectedLiveWorkspaces: [],
     refusedOutsideTmp: [],
     removals: [],
   })),
@@ -48,6 +50,14 @@ vi.mock("../src/runtime/tmp-janitor.js", () => ({
       unknownTmpRoots: [],
     },
     staleWorkers: { reclaim: [] },
+    workerReclaim: {
+      workers: [],
+      reclaim: [],
+      retain: [],
+      dropped: [],
+      truncated: false,
+      totals: { considered: 0, reclaim: 0, retain: 0, dropped: 0 },
+    },
   })),
 }));
 

--- a/apps/dev/tests/supervise-passthrough.test.ts
+++ b/apps/dev/tests/supervise-passthrough.test.ts
@@ -198,6 +198,8 @@ describe("formatBootSweepResult — supervisor boot log shape (#623)", () => {
         orphanTestRunners: [],
         protectedLiveWorkers: [],
         protectedLiveFeedback: [],
+        workerWorkspaces: [],
+        protectedLiveWorkspaces: [],
         refusedOutsideTmp: [],
         removals: [
           {

--- a/apps/dev/tests/tmp-janitor-daemon-reclaim.test.ts
+++ b/apps/dev/tests/tmp-janitor-daemon-reclaim.test.ts
@@ -1,0 +1,288 @@
+// tmp-janitor-daemon-reclaim.test.ts — the janitor reclaims on the DAEMON's
+// process truth, not on a missing pid file (Spec #2772 US 46, ADR 0130).
+//
+// Every tree below is built the way the failure that motivated this was shaped
+// (#2679): the live lanes carry NO pid file at all, and the dead ones do. A
+// janitor keyed on pid files gets each of these exactly backwards.
+
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  planWorkerReclaim,
+  type WorkerArtifact,
+  type WorkerProcessVerdict,
+} from "../src/core/worker-reclaim.js";
+import {
+  applyTmpJanitorReport,
+  collectTmpJanitorReport,
+  runTmpJanitor,
+} from "../src/runtime/tmp-janitor.js";
+import type { DaemonWorkerSetReader } from "../src/runtime/liveness-anchor.js";
+
+const NOW = 1_800_000_000;
+const NOW_ISO = new Date(NOW * 1000).toISOString();
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "red-skills-daemon-janitor-"));
+  roots.push(root);
+  return root;
+}
+
+/** A fresh daemon answer naming exactly these Workers. */
+function daemonNaming(...workerIds: readonly string[]): DaemonWorkerSetReader {
+  return async () => ({
+    staleness: { stale: false, age_ms: 120, threshold_ms: 90_000, reason: "measured 120ms ago" },
+    workers: workerIds.map((worker_id, index) => ({
+      worker_id,
+      project_label: "red-skills",
+      pid: 4_000 + index,
+    })),
+  });
+}
+
+/** A daemon that answered, but about a measurement too old to act on. */
+const staleDaemon: DaemonWorkerSetReader = async () => ({
+  staleness: { stale: true, age_ms: 900_000, threshold_ms: 90_000, reason: "this answer is stale" },
+  workers: [],
+});
+
+/** A daemon that did not answer at all. */
+const noDaemon: DaemonWorkerSetReader = async () => null;
+
+/** A Worker workspace with a git worktree and a log beside it, and no pid file. */
+async function workspace(tmp: string, worker: string, issue: number): Promise<{
+  worktree: string;
+  log: string;
+}> {
+  const issueDir = join(tmp, "workers", worker, String(issue));
+  const worktree = join(issueDir, "worktree");
+  await mkdir(join(worktree, "node_modules"), { recursive: true });
+  const log = join(issueDir, "worker.log.toonl");
+  await writeFile(log, "", "utf8");
+  return { worktree, log };
+}
+
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(() => true, () => false);
+}
+
+describe("the janitor reclaims on the daemon's process truth", () => {
+  it("spares a live Worker's workspace with no pid file anywhere on the tree", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const { worktree } = await workspace(tmp, "wLIVE", 2790);
+
+    // Issues CLOSED so the issue rule cannot claim the credit: whatever survives
+    // here survives because the daemon said so.
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "CLOSED", {
+      daemon: daemonNaming("wLIVE"),
+    });
+
+    expect(report.workerReclaim.reclaim).toEqual([]);
+    expect(report.workerReclaim.retain.map((verdict) => verdict.verdict)).toEqual([
+      "worker-live",
+      "worker-live",
+    ]);
+    expect(report.staleWorkers.reclaim).toEqual([]);
+
+    const applied = await applyTmpJanitorReport(tmp, report, { daemon: daemonNaming("wLIVE") });
+    expect(applied.workerWorkspaces).toEqual([]);
+    expect(await exists(worktree)).toBe(true);
+  });
+
+  it("reclaims a dead Worker's workspace and keeps the evidence beside it", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const { worktree, log } = await workspace(tmp, "wDONE", 2789);
+
+    // Issue OPEN, so the whole-dir rule stays out of it: the workspace goes
+    // because the daemon does not name its Worker, with nothing else to help.
+    const result = await runTmpJanitor(tmp, NOW, () => "OPEN", {
+      fix: true,
+      daemon: daemonNaming("wOTHER"),
+    });
+
+    expect(result.applied?.workerWorkspaces).toEqual([worktree]);
+    expect(await exists(worktree)).toBe(false);
+    expect(await exists(log)).toBe(true);
+  });
+
+  it("never reclaims through a pid file: an unanswered daemon spares everything", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const { worktree } = await workspace(tmp, "wGHOST", 2790);
+    // A DEAD pid file — the exact input the predecessor read as permission.
+    await writeFile(join(tmp, "workers", "wGHOST", "worker.pid"), "999999999", "utf8");
+
+    for (const daemon of [noDaemon, staleDaemon]) {
+      const result = await runTmpJanitor(tmp, NOW, () => "CLOSED", { fix: true, daemon });
+
+      expect(result.workerReclaim.reclaim).toEqual([]);
+      expect(result.workerReclaim.retain.map((verdict) => verdict.verdict)).toContain(
+        "liveness-unknown",
+      );
+      expect(result.staleWorkers.reclaim).toEqual([]);
+      expect(result.applied?.workerWorkspaces).toEqual([]);
+      expect(await exists(worktree)).toBe(true);
+    }
+  });
+
+  it("re-reads the daemon at apply time so a Worker born mid-sweep survives", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const { worktree } = await workspace(tmp, "wRETRY", 2790);
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "OPEN", {
+      daemon: daemonNaming(),
+    });
+    expect(report.workerReclaim.reclaim.map((verdict) => verdict.artifact.path)).toEqual([worktree]);
+
+    const applied = await applyTmpJanitorReport(tmp, report, { daemon: daemonNaming("wRETRY") });
+    expect(applied.workerWorkspaces).toEqual([]);
+    expect(applied.protectedLiveWorkspaces).toEqual([worktree]);
+    expect(await exists(worktree)).toBe(true);
+  });
+
+  it("refuses a plan-named path outside the tmp tier and reports the refusal", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const outside = join(root, "precious");
+    await mkdir(outside, { recursive: true });
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "OPEN", { daemon: daemonNaming() });
+    // A plan from an older bundle, or a hand-built one, may name any path at all.
+    report.workerReclaim.reclaim.push({
+      worker_id: "wODD",
+      artifact: { worker_id: "wODD", kind: "worktree", path: outside },
+      class: "workspace",
+      liveness: "dead",
+      reclaim: true,
+      verdict: "workspace-reclaimable",
+      reason: "test-built plan",
+    });
+
+    const applied = await applyTmpJanitorReport(tmp, report, { daemon: daemonNaming() });
+
+    expect(applied.refusedOutsideTmp).toEqual([outside]);
+    expect(applied.workerWorkspaces).toEqual([]);
+    expect(await exists(outside)).toBe(true);
+  });
+
+  it("plans nothing from a lane that does not exist yet", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    await mkdir(join(tmp, "workers"), { recursive: true });
+
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "OPEN", { daemon: daemonNaming() });
+
+    expect(report.workerReclaim.totals).toEqual({
+      considered: 0,
+      reclaim: 0,
+      retain: 0,
+      dropped: 0,
+    });
+  });
+});
+
+describe("the reclaim planner stays total", () => {
+  const dead = (): WorkerProcessVerdict => "dead";
+  const artifact = (over: Partial<WorkerArtifact> = {}): WorkerArtifact => ({
+    worker_id: "wDEAD",
+    kind: "worktree",
+    path: "/red/tmp/workers/wDEAD/1/worktree",
+    ...over,
+  });
+
+  it("accounts for every artifact exactly once, and states the identity", () => {
+    const plan = planWorkerReclaim(
+      [
+        artifact(),
+        artifact({ kind: "log", path: "/red/tmp/workers/wDEAD/1/worker.log.toonl" }),
+        artifact({ kind: "branch", path: undefined }),
+        artifact({ kind: "moonbeam", path: "/red/tmp/workers/wDEAD/1/moonbeam" }),
+      ],
+      { liveness: dead, nowIso: NOW_ISO, observedPaths: ["/red/tmp/workers/wSTRAY/9/worktree"] },
+    );
+
+    expect(plan.totals).toEqual({ considered: 5, reclaim: 1, retain: 3, dropped: 1 });
+    expect(plan.totals.reclaim + plan.totals.retain + plan.totals.dropped).toBe(
+      plan.totals.considered,
+    );
+    expect(plan.retain.map((verdict) => verdict.verdict)).toEqual([
+      "evidence-retained",
+      "pointer-retained",
+      "unclassified",
+    ]);
+  });
+
+  it("reports a path no Worker accounts for instead of touching it", () => {
+    const stray = "/red/tmp/workers/wSTRAY/9/worktree";
+    const plan = planWorkerReclaim([], {
+      liveness: dead,
+      nowIso: NOW_ISO,
+      observedPaths: [stray],
+    });
+
+    expect(plan.reclaim).toEqual([]);
+    expect(plan.dropped).toEqual([
+      {
+        reason: "no-worker",
+        path: stray,
+        detail: "no Worker accounts for this path; the janitor leaves it alone",
+      },
+    ]);
+  });
+
+  it("reports a capped artifact as dropped rather than truncating it away", () => {
+    const plan = planWorkerReclaim(
+      [artifact(), artifact({ path: "/red/tmp/workers/wDEAD/2/worktree" })],
+      { liveness: dead, nowIso: NOW_ISO, limit: 1 },
+    );
+
+    expect(plan.truncated).toBe(true);
+    expect(plan.totals).toEqual({ considered: 2, reclaim: 1, retain: 0, dropped: 1 });
+    expect(plan.dropped[0]).toMatchObject({ reason: "limit", path: "/red/tmp/workers/wDEAD/2/worktree" });
+  });
+
+  it("honours a pinned artifact and a hold-until instant over a dead Worker", () => {
+    const pinned = planWorkerReclaim([artifact({ reclaimable: false, reason: "under post-mortem" })], {
+      liveness: dead,
+      nowIso: NOW_ISO,
+    });
+    const held = planWorkerReclaim(
+      [artifact({ reclaim_after: new Date((NOW + 3_600) * 1000).toISOString() })],
+      { liveness: dead, nowIso: NOW_ISO },
+    );
+    const released = planWorkerReclaim(
+      [artifact({ reclaim_after: new Date((NOW - 3_600) * 1000).toISOString() })],
+      { liveness: dead, nowIso: NOW_ISO },
+    );
+
+    expect(pinned.reclaim).toEqual([]);
+    expect(pinned.retain[0]).toMatchObject({ verdict: "pinned", reason: "under post-mortem" });
+    expect(held.reclaim).toEqual([]);
+    expect(held.retain[0]?.verdict).toBe("grace-period");
+    expect(released.reclaim.map((verdict) => verdict.verdict)).toEqual(["workspace-reclaimable"]);
+  });
+
+  it("lets a Worker the daemon has not called dead hold a path a dead one also names", () => {
+    const shared = "/red/tmp/workers/wSHARED/1/worktree";
+    const plan = planWorkerReclaim(
+      [
+        { worker_id: "wDEAD", kind: "worktree", path: shared },
+        { worker_id: "wLIVE", kind: "worktree", path: shared },
+      ],
+      { liveness: (workerId) => (workerId === "wLIVE" ? "alive" : "dead"), nowIso: NOW_ISO },
+    );
+
+    expect(plan.reclaim).toEqual([]);
+    expect(plan.retain.map((verdict) => verdict.verdict)).toEqual(["worker-live", "worker-live"]);
+  });
+});

--- a/apps/dev/tests/tmp-janitor-runtime.test.ts
+++ b/apps/dev/tests/tmp-janitor-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   runTmpJanitor,
   selectOrphanTestRunners,
 } from "../src/runtime/tmp-janitor.js";
+import type { DaemonWorkerSetReader } from "../src/runtime/liveness-anchor.js";
 import { KNOWN_TMP_LANES, LOGS_TTL_S, SCRATCH_TTL_S } from "../src/core/tmp-janitor.js";
 import { encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
 import { discoverLiveSupervisorPid } from "../src/runtime/supervisor-state.js";
@@ -27,6 +28,22 @@ function fleetSnapshot(pid: number): string {
     slots: { busy: 0, free: 1, total: 1, parked: 0 },
     slot_pids: [],
     spawns_this_tick: 0,
+  });
+}
+
+/**
+ * The daemon's answer, fresh, naming exactly these Workers. Every liveness
+ * assertion below hands one in: reclaim is authorised by THIS answer, never by
+ * whatever pid files happen to be on disk.
+ */
+function daemonNaming(...workerIds: readonly string[]): DaemonWorkerSetReader {
+  return async () => ({
+    staleness: { stale: false, age_ms: 120, threshold_ms: 90_000, reason: "measured 120ms ago" },
+    workers: workerIds.map((worker_id, index) => ({
+      worker_id,
+      project_label: "red-skills",
+      pid: 4_000 + index,
+    })),
   });
 }
 
@@ -93,38 +110,39 @@ describe("tmp janitor runtime", () => {
     await mkdir(join(tmp, "work-old"), { recursive: true });
     await mkdir(join(tmp, "workers", "wOLD", "1961-a1"), { recursive: true });
     await writeFile(join(tmp, "afk-supervisor-slot-0.log"), "legacy slot log\n", "utf8");
-    await writeFile(join(tmp, "workers", "wOLD", "worker.pid"), "999999999", "utf8");
     await utimes(join(tmp, "scratch", "old"), NOW - SCRATCH_TTL_S - 10, NOW - SCRATCH_TTL_S - 10);
     await utimes(join(tmp, "afk-supervisor-slot-0.log"), NOW - LOGS_TTL_S - 10, NOW - LOGS_TTL_S - 10);
 
-    const report = await collectTmpJanitorReport(tmp, NOW, (issue) => issue === 1961 ? "CLOSED" : "UNKNOWN");
+    const daemon = daemonNaming();
+    const report = await collectTmpJanitorReport(tmp, NOW, (issue) => issue === 1961 ? "CLOSED" : "UNKNOWN", { daemon });
 
     expect(report.plan.scratch.reclaim.map((entry) => entry.path)).toEqual([join(tmp, "scratch", "old")]);
     expect(report.plan.legacySlotLogs.reclaim.map((entry) => entry.path)).toEqual([join(tmp, "afk-supervisor-slot-0.log")]);
     expect(report.plan.unknownTmpRoots).toEqual(["work-old"]);
     expect(report.staleWorkers.reclaim.map((entry) => entry.path)).toEqual([join(tmp, "workers", "wOLD")]);
 
-    const applied = await applyTmpJanitorReport(tmp, report);
+    const applied = await applyTmpJanitorReport(tmp, report, { daemon });
     expect(applied.expiredLanes).toEqual([join(tmp, "scratch", "old"), join(tmp, "afk-supervisor-slot-0.log")]);
     expect(applied.staleWorkers).toEqual([join(tmp, "workers", "wOLD")]);
     expect(applied.unknownTmpRoots).toEqual([join(tmp, "work-old")]);
     expect(await readdir(tmp)).toEqual(["scratch", "workers"]);
   });
 
-  it("rechecks worker.pid during fix and refuses to delete a now-live worker anchor", async () => {
+  it("re-asks the daemon during fix and refuses to delete a Worker it now names", async () => {
     const root = await tempRoot();
     const tmp = join(root, ".red", "tmp");
     const worker = join(tmp, "workers", "wLIVE");
+    // No pid file anywhere on this tree: the whole verdict comes from the daemon.
     await mkdir(join(worker, "1961-a1"), { recursive: true });
-    await writeFile(join(worker, "worker.pid"), "999999999", "utf8");
 
-    const report = await collectTmpJanitorReport(tmp, NOW, () => "CLOSED");
-    await writeFile(join(worker, "worker.pid"), String(process.pid), "utf8");
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "CLOSED", { daemon: daemonNaming() });
+    expect(report.staleWorkers.reclaim.map((entry) => entry.path)).toEqual([worker]);
 
-    const applied = await applyTmpJanitorReport(tmp, report);
+    // The Worker was born between collect and apply.
+    const applied = await applyTmpJanitorReport(tmp, report, { daemon: daemonNaming("wLIVE") });
     expect(applied.staleWorkers).toEqual([]);
     expect(applied.protectedLiveWorkers).toEqual([worker]);
-    expect(await readdir(worker)).toEqual(["1961-a1", "worker.pid"]);
+    expect(await readdir(worker)).toEqual(["1961-a1"]);
   });
 
   it("never TTL-reclaims a feedback worktree owned by a live worker", async () => {
@@ -138,11 +156,11 @@ describe("tmp janitor runtime", () => {
     await writeFile(join(feedback, "node_modules", "tinypool", "dist", "entry", "process.js"), "export {};\n", "utf8");
     await utimes(feedback, 1, 1);
 
-    const report = await collectTmpJanitorReport(tmp, NOW, () => "OPEN");
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "OPEN", { daemon: daemonNaming() });
 
     expect(report.plan.feedbackWorktrees.reclaim).toEqual([]);
     expect(report.orphanFeedback.reclaim).toEqual([]);
-    const applied = await applyTmpJanitorReport(tmp, report);
+    const applied = await applyTmpJanitorReport(tmp, report, { daemon: daemonNaming() });
     await expect(access(join(feedback, "node_modules", "tinypool", "dist", "entry", "process.js"))).resolves.toBeUndefined();
     expect(applied.protectedLiveFeedback).toEqual([feedback]);
   });
@@ -157,10 +175,10 @@ describe("tmp janitor runtime", () => {
     await writeFile(join(worker, "worker.pid"), "999999999", "utf8");
     await utimes(feedback, 1, 1);
 
-    const report = await collectTmpJanitorReport(tmp, NOW, () => "CLOSED");
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "CLOSED", { daemon: daemonNaming() });
     await writeFile(join(worker, "worker.pid"), String(process.pid), "utf8");
 
-    const applied = await applyTmpJanitorReport(tmp, report);
+    const applied = await applyTmpJanitorReport(tmp, report, { daemon: daemonNaming() });
     await expect(access(feedback)).resolves.toBeUndefined();
     expect(applied.protectedLiveFeedback).toEqual([feedback]);
     expect(applied.removals).not.toContainEqual(expect.objectContaining({ path: feedback }));
@@ -178,11 +196,11 @@ describe("tmp janitor runtime", () => {
     await writeFile(join(tmp, "claims", "2450", "pid"), String(process.pid), "utf8");
     await utimes(feedback, 1, 1);
 
-    const report = await collectTmpJanitorReport(tmp, NOW, () => "OPEN");
+    const report = await collectTmpJanitorReport(tmp, NOW, () => "OPEN", { daemon: daemonNaming() });
     expect(report.plan.feedbackWorktrees.reclaim).toEqual([]);
     expect(report.orphanFeedback.reclaim).toEqual([]);
 
-    const applied = await applyTmpJanitorReport(tmp, report);
+    const applied = await applyTmpJanitorReport(tmp, report, { daemon: daemonNaming() });
     await expect(access(feedback)).resolves.toBeUndefined();
     expect(applied.protectedLiveFeedback).toEqual([feedback]);
   });

--- a/apps/dev/tests/tmp-janitor.test.ts
+++ b/apps/dev/tests/tmp-janitor.test.ts
@@ -294,7 +294,7 @@ describe("planWorkerDirJanitor", () => {
   function worker(over: Partial<WorkerDirJanitorEntry>): WorkerDirJanitorEntry {
     return {
       path: "/red/tmp/workers/w1",
-      workerPidLive: false,
+      liveness: "dead",
       issues: [{ issue: 1, state: "CLOSED" }],
       ...over,
     };
@@ -305,8 +305,15 @@ describe("planWorkerDirJanitor", () => {
     expect(planWorkerDirJanitor([entry])).toEqual({ reclaim: [entry], spare: [] });
   });
 
-  it("spares worker dirs with a live worker.pid", () => {
-    const entry = worker({ workerPidLive: true });
+  it("spares worker dirs the daemon calls alive", () => {
+    const entry = worker({ liveness: "alive" });
+    expect(planWorkerDirJanitor([entry])).toEqual({ reclaim: [], spare: [entry] });
+  });
+
+  it("spares a worker dir the daemon could not answer for, closed issues and all", () => {
+    // The pid-keyed predecessor read a missing pid file as death and reclaimed
+    // exactly this dir. An unreachable authority is not evidence (#2679).
+    const entry = worker({ liveness: "unknown" });
     expect(planWorkerDirJanitor([entry])).toEqual({ reclaim: [], spare: [entry] });
   });
 

--- a/apps/dev/tests/wire-reclaim.test.ts
+++ b/apps/dev/tests/wire-reclaim.test.ts
@@ -41,9 +41,8 @@ function harness(over: Partial<DeadWorkerSweepDeps> = {}): {
   const removedWorktrees: string[] = [];
   const removedDirs: string[] = [];
   const deps: DeadWorkerSweepDeps = {
-    // worker.pid text: default all dead unless overridden.
-    readWorkerPid: () => "9999",
-    killAlive: () => false,
+    // The daemon's verdict: dead unless a test overrides it.
+    workerLiveness: async () => "dead",
     isPreserved: async () => false,
     exists: () => true,
     removeWorktree: async (p) => {
@@ -68,8 +67,8 @@ describe("reclaimDeadWorkers (issue #1219)", () => {
     expect(reclaimed).toEqual(["/r/.red/tmp/workers/wDEAD/5-a1"]);
   });
 
-  it("NEVER touches a live worker's dir (worker.pid alive)", async () => {
-    const { deps, removedWorktrees, removedDirs } = harness({ killAlive: () => true });
+  it("NEVER touches a dir whose Worker the daemon names", async () => {
+    const { deps, removedWorktrees, removedDirs } = harness({ workerLiveness: async () => "alive" });
     const reclaimed = await reclaimDeadWorkers(ROOT, [record(ROOT, "wLIVE", 5, true)], "", deps);
     expect(removedWorktrees).toEqual([]);
     expect(removedDirs).toEqual([]);
@@ -85,11 +84,10 @@ describe("reclaimDeadWorkers (issue #1219)", () => {
   });
 
   it("reclaims a dead worker while preserving a live sibling in the same sweep", async () => {
-    // wLIVE alive, wDEAD dead — keyed on the per-worker worker.pid.
+    // wLIVE alive, wDEAD dead — the verdict is per-Worker, from the daemon.
     const alive = new Set(["/r/.red/tmp/workers/wLIVE"]);
     const { deps, removedDirs } = harness({
-      readWorkerPid: (workerDir) => (alive.has(workerDir) ? "111" : "222"),
-      killAlive: (pid) => pid === 111,
+      workerLiveness: async (workerDir) => (alive.has(workerDir) ? "alive" : "dead"),
     });
     const reclaimed = await reclaimDeadWorkers(
       ROOT,
@@ -99,6 +97,16 @@ describe("reclaimDeadWorkers (issue #1219)", () => {
     );
     expect(removedDirs).toEqual(["/r/.red/tmp/workers/wDEAD/6-a1"]);
     expect(reclaimed).toEqual(["/r/.red/tmp/workers/wDEAD/6-a1"]);
+  });
+
+  it("spares every dir when the daemon does not answer", async () => {
+    const { deps, removedWorktrees, removedDirs } = harness({
+      workerLiveness: async () => "unknown",
+    });
+    const reclaimed = await reclaimDeadWorkers(ROOT, [record(ROOT, "wGHOST", 5, false)], "", deps);
+    expect(removedWorktrees).toEqual([]);
+    expect(removedDirs).toEqual([]);
+    expect(reclaimed).toEqual([]);
   });
 
   it("skips the worktree removal when it does not exist, still reclaims the dir", async () => {


### PR DESCRIPTION
Automated AFK landing for #2790. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2790

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787960952&installation_model_id=20659&pr_number=2827&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2827&signature=407c3b6db405101d9d0eaf6e2a62bf24fb3d57fb76d07f9b82e65acdecf572d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->