### PR TITLE
fix: #2801 An exhausted GraphQL query returns an empty result that is rendered as fact

### DIFF
--- a/.changeset/an-exhausted-read-is-not-an-empty-result.md
+++ b/.changeset/an-exhausted-read-is-not-an-empty-result.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+An exhausted GitHub read raises instead of rendering as an empty result set (#2801). Every gh JSON read in the dev runtime collapsed failure into absence with `if (r.code !== 0) return []`, and an empty result is a confident, well-formed, wrong answer: a PR listing that never ran came back as "no pull requests are open" while two were open, and reading it at face value supported the conclusion that the work had merged. GraphQL made it worse — an exhausted query can exit 0 with a null-filled `data` block and a `RATE_LIMITED` entry in `errors`, so even the exit code said nothing. The new read boundary (`runtime/gh/read.ts`) decides once for every consumer: a query that could not run raises `GhReadError`, a query that ran returns its rows even when there are none, and the raised failure carries the transient quota classification so the existing bounded wait-and-retry applies rather than a generic failure path. The open-PR and queue counters, the statusline count cache, the deadend audit and the dashboard read through it, so a failed read keeps the last known counts or fails loudly instead of publishing a false zero.

--- a/apps/dev/src/commands/dashboard.ts
+++ b/apps/dev/src/commands/dashboard.ts
@@ -14,6 +14,7 @@ import {
   resolveRepoContext,
 } from "../runtime/wire.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
+import { readGhJsonRows } from "../runtime/gh/read.js";
 import { readAllWorkerStates } from "../core/worker-state-reader.js";
 
 /** Output format. TOON is the default agent-facing wire format (PRD #928 / ADR
@@ -78,19 +79,13 @@ function labelsFrom(raw: unknown): string[] {
   }).filter(Boolean);
 }
 
-function parseJsonArray<T>(raw: string, fallback: T[] = []): T[] {
-  try {
-    const parsed = JSON.parse(raw || "[]");
-    return Array.isArray(parsed) ? parsed as T[] : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-async function ghJson<T>(exec: ExecFn, cwd: string, args: readonly string[]): Promise<T[]> {
-  const out = await exec("gh", args, { cwd, maxBuffer: 32 * 1024 * 1024 });
-  if (out.code !== 0) return [];
-  return parseJsonArray<T>(out.stdout);
+/**
+ * Read one dashboard input. RAISES {@link GhReadError} when the query could not
+ * run: a dashboard built from a failed read would report zero open pull requests
+ * and zero open issues as fact (#2801), so it fails loudly instead.
+ */
+function ghJson<T>(exec: ExecFn, cwd: string, args: readonly string[]): Promise<T[]> {
+  return readGhJsonRows<T>({ cwd, exec }, args, { maxBuffer: 32 * 1024 * 1024 });
 }
 
 function issueFrom(row: unknown): DashboardIssue {

--- a/apps/dev/src/runtime/deadend-audit-report.ts
+++ b/apps/dev/src/runtime/deadend-audit-report.ts
@@ -30,7 +30,8 @@ import {
   listIssueStates,
   type GhContext,
 } from "./gh.js";
-import { runGh, isRecord } from "./gh/common.js";
+import { isRecord } from "./gh/common.js";
+import { readGhJsonRows } from "./gh/read.js";
 import { afkPaths, collectMonitorInputs, resolveRepoContext } from "./wire.js";
 
 function issueStateOf(raw: string): IssueState {
@@ -69,8 +70,13 @@ function rollupIsRed(pr: RollupState): boolean {
   });
 }
 
+/**
+ * The audit's open-PR source. RAISES {@link GhReadError} when the read failed:
+ * an audit that cannot see the open pull requests must say so, never report a
+ * clean board because the query never ran (#2801).
+ */
 async function listOpenAfkPrs(gh: GhContext): Promise<Array<{ number: number; issue: number; red: boolean }>> {
-  const result = await runGh(gh, [
+  const rows = await readGhJsonRows<unknown>(gh, [
     "pr",
     "list",
     "--repo",
@@ -82,14 +88,6 @@ async function listOpenAfkPrs(gh: GhContext): Promise<Array<{ number: number; is
     "--json",
     "number,headRefName,statusCheckRollup",
   ]);
-  if (result.code !== 0) return [];
-  let rows: unknown;
-  try {
-    rows = JSON.parse(result.stdout ?? "[]");
-  } catch {
-    return [];
-  }
-  if (!Array.isArray(rows)) return [];
   const out: Array<{ number: number; issue: number; red: boolean }> = [];
   for (const row of rows) {
     if (!isRecord(row)) continue;

--- a/apps/dev/src/runtime/gh/queue.ts
+++ b/apps/dev/src/runtime/gh/queue.ts
@@ -11,6 +11,7 @@ import type {
 import type { ExecOutput } from "../exec.js";
 import { listCandidates } from "./candidates.js";
 import { apiPath, isRecord, repoArgs, runGh, runRsp, type GhContext } from "./common.js";
+import { readGhGraphql, readGhJsonRows } from "./read.js";
 
 async function countIssues(ctx: GhContext, args: string[]): Promise<number> {
   const r = await runGh(ctx, 
@@ -115,7 +116,12 @@ async function countSearchViaRsp(ctx: GhContext, query: string): Promise<number 
   }
 }
 
-/** Count both statusline queue buckets with one GraphQL search request. */
+/** Count both statusline queue buckets with one GraphQL search request.
+ *
+ * RAISES {@link GhReadError} when the GraphQL read could not run — including the
+ * exit-0 response whose `data` block is null-filled and whose `errors` carry
+ * `RATE_LIMITED`. Zeroes here would read as "the queue is empty", the falsehood
+ * this repo treats as a flow bug to diagnose. */
 export async function countStatuslineQueueCounts(ctx: GhContext): Promise<StatuslineQueueCounts> {
   if (!ctx.repo) return { queue: 0, human: 0, quarantine: 0 };
   const [queue, human, quarantine] = await Promise.all([
@@ -131,7 +137,7 @@ export async function countStatuslineQueueCounts(ctx: GhContext): Promise<Status
       quarantine: search(type: ISSUE, query: $quarantine) { issueCount }
     }
   `;
-  const r = await runGh(ctx, [
+  const data = await readGhGraphql(ctx, [
     "api",
     "graphql",
     "-f",
@@ -143,23 +149,11 @@ export async function countStatuslineQueueCounts(ctx: GhContext): Promise<Status
     "-F",
     `quarantine=${statuslineSearchQuery(ctx.repo, LABEL_QUARANTINE)}`,
   ]);
-  if (r.code !== 0) return { queue: 0, human: 0, quarantine: 0 };
-  try {
-    const parsed = JSON.parse(r.stdout) as {
-      data?: {
-        ready?: { issueCount?: unknown };
-        human?: { issueCount?: unknown };
-        quarantine?: { issueCount?: unknown };
-      };
-    };
-    return {
-      queue: Number(parsed.data?.ready?.issueCount ?? 0),
-      human: Number(parsed.data?.human?.issueCount ?? 0),
-      quarantine: Number(parsed.data?.quarantine?.issueCount ?? 0),
-    };
-  } catch {
-    return { queue: 0, human: 0, quarantine: 0 };
-  }
+  const bucket = (key: string): number => {
+    const node = data[key];
+    return isRecord(node) ? Number(node.issueCount ?? 0) : 0;
+  };
+  return { queue: bucket("ready"), human: bucket("human"), quarantine: bucket("quarantine") };
 }
 
 /** Count issues that carry NO labels (the unlabeled straggler bucket). */
@@ -199,11 +193,14 @@ export function countOpenIssues(ctx: GhContext): Promise<number> {
   return countIssues(ctx, []);
 }
 
-/** Count open pull requests — the repo-global `pr` statusline count. Mirrors
- * {@link countIssues} against `gh pr list`. Returns 0 on any gh/auth/parse
- * failure so the statusline stays fail-open. */
+/** Count open pull requests — the repo-global `pr` statusline count.
+ *
+ * RAISES {@link GhReadError} when the query could not run, because 0 here reads
+ * as "nothing is open" and that is the exact falsehood of #2801. Callers that
+ * must stay fail-open (the statusline refresh) catch the raise and keep their
+ * last known value; a genuinely empty repo still counts 0. */
 export async function countOpenPrs(ctx: GhContext): Promise<number> {
-  const r = await runGh(ctx, [
+  const rows = await readGhJsonRows<unknown>(ctx, [
     "pr",
     "list",
     ...repoArgs(ctx),
@@ -214,25 +211,20 @@ export async function countOpenPrs(ctx: GhContext): Promise<number> {
     "--json",
     "number",
   ]);
-  if (r.code !== 0) return 0;
-  try {
-    const parsed = JSON.parse(r.stdout) as unknown[];
-    return Array.isArray(parsed) ? parsed.length : 0;
-  } catch {
-    return 0;
-  }
+  return rows.length;
 }
 
 /** Count pull requests created on the given local calendar day (YYYY-MM-DD).
  * Uses `--search created:<day>` as a server-side filter then re-filters by
- * local date in JS to absorb UTC/local-timezone boundary drift. Returns 0 on
- * any gh/auth/parse failure so the statusline stays fail-open. The `localDay`
- * parameter defaults to today's local date and is exposed for testing. */
+ * local date in JS to absorb UTC/local-timezone boundary drift. RAISES
+ * {@link GhReadError} on a query that could not run, for the same reason as
+ * {@link countOpenPrs}. The `localDay` parameter defaults to today's local date
+ * and is exposed for testing. */
 export async function countPrsCreatedToday(
   ctx: GhContext,
   localDay = new Date().toLocaleDateString("en-CA"),
 ): Promise<number> {
-  const r = await runGh(ctx, [
+  const rows = await readGhJsonRows<{ createdAt?: unknown }>(ctx, [
     "pr",
     "list",
     ...repoArgs(ctx),
@@ -245,18 +237,11 @@ export async function countPrsCreatedToday(
     "--search",
     `created:${localDay}`,
   ]);
-  if (r.code !== 0) return 0;
-  try {
-    const parsed = JSON.parse(r.stdout) as Array<{ createdAt: string }>;
-    if (!Array.isArray(parsed)) return 0;
-    return parsed.filter(
-      (pr) =>
-        typeof pr.createdAt === "string" &&
-        new Date(pr.createdAt).toLocaleDateString("en-CA") === localDay,
-    ).length;
-  } catch {
-    return 0;
-  }
+  return rows.filter(
+    (pr) =>
+      typeof pr.createdAt === "string" &&
+      new Date(pr.createdAt).toLocaleDateString("en-CA") === localDay,
+  ).length;
 }
 
 /** Count `needs-info` straggler issues. */

--- a/apps/dev/src/runtime/gh/read.ts
+++ b/apps/dev/src/runtime/gh/read.ts
@@ -1,0 +1,255 @@
+// gh/read.ts — the gh JSON read boundary: an ABSENCE of data and a FAILURE to
+// obtain data are different outcomes.
+//
+// **A FAILED QUERY IS NOT AN EMPTY RESULT SET.** Every read in this tree used to
+// collapse the two with `if (r.code !== 0) return []`, and an empty result set is
+// a confident, well-formed, wrong answer: a `gh pr list` that never ran came back
+// as "no pull requests are open" while two were open, and the reader downstream
+// concluded the work had merged (#2801). GraphQL makes it worse — an exhausted
+// query can exit 0 with a null-filled `data` block and a `RATE_LIMITED` entry in
+// `errors`, so even the exit code says nothing.
+//
+// This module is the single place that decides, so a new consumer inherits the
+// distinction instead of the trap. {@link readGhJsonRows} RAISES when the query
+// could not run and returns rows — possibly zero of them — only when it did.
+// {@link tryReadGhJsonRows} offers the same distinction as a discriminated union
+// for callers that must degrade rather than throw. The raised failure carries the
+// quota classification from gh/quota.ts, so the bounded wait-and-retry primitive
+// already wired through `quotaBackoff` applies rather than a generic failure
+// path; this module never retries on its own.
+
+import { execTool, type ExecFn, type ExecOutput } from "../exec.js";
+import { isGhRateLimited, withGhQuotaBackoff, type GhQuotaBackoffOpts } from "./quota.js";
+
+/** Which GitHub API answered (or failed to answer) the read. */
+export type GhReadSurface = "graphql" | "rest";
+
+/**
+ * Why the read produced no usable payload. `quota` is the only TRANSIENT class:
+ * the bounded wait-and-retry primitive can still turn it into a real answer.
+ */
+export type GhReadFailureClass = "quota" | "transport" | "malformed";
+
+/** A read that did not run, or ran and returned something unusable. */
+export interface GhReadFailure {
+  readonly surface: GhReadSurface;
+  readonly classification: GhReadFailureClass;
+  /** True only for quota exhaustion — the class a bounded wait can recover. */
+  readonly transient: boolean;
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly message: string;
+}
+
+/**
+ * The error a raising read throws. Carries the full {@link GhReadFailure} shape
+ * so a consumer can branch on `classification` without re-parsing gh output, and
+ * so a quota failure reaches the shared quota path rather than a generic one.
+ */
+export class GhReadError extends Error implements GhReadFailure {
+  readonly name = "GhReadError";
+  readonly surface: GhReadSurface;
+  readonly classification: GhReadFailureClass;
+  readonly transient: boolean;
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(failure: GhReadFailure) {
+    super(failure.message);
+    this.surface = failure.surface;
+    this.classification = failure.classification;
+    this.transient = failure.transient;
+    this.code = failure.code;
+    this.stdout = failure.stdout;
+    this.stderr = failure.stderr;
+  }
+}
+
+/** Either rows the query really returned, or the failure that prevented them. */
+export type GhReadResult<T> =
+  | { readonly outcome: "rows"; readonly rows: T[] }
+  | { readonly outcome: "failed"; readonly failure: GhReadFailure };
+
+/** Either the record the query really returned, or the failure. */
+export type GhReadRecordResult =
+  | { readonly outcome: "record"; readonly record: Record<string, unknown> }
+  | { readonly outcome: "failed"; readonly failure: GhReadFailure };
+
+/**
+ * The read boundary's slice of {@link GhContext}: a cwd, the injectable exec, and
+ * the optional bounded quota retry. `GhContext` satisfies it structurally, so a
+ * gh helper passes its own ctx straight through.
+ */
+export interface GhReadContext {
+  cwd: string;
+  exec?: ExecFn;
+  quotaBackoff?: GhQuotaBackoffOpts;
+}
+
+export interface GhReadOptions {
+  /** Max captured stdout bytes; raise it for whole-repo listings. */
+  maxBuffer?: number;
+}
+
+/**
+ * True when `failure` is transient GitHub quota exhaustion, so the caller should
+ * wait and retry rather than treat it as a permanent failure. Accepts a
+ * {@link GhReadError}, a bare {@link GhReadFailure}, or anything else (false).
+ */
+export function isGhQuotaExhausted(failure: unknown): boolean {
+  if (!failure || typeof failure !== "object") return false;
+  const rec = failure as Partial<GhReadFailure>;
+  return rec.classification === "quota" && rec.transient === true;
+}
+
+/**
+ * Which API a `gh` argv reads from. `gh api graphql` and every `--json` listing
+ * (`gh issue list`, `gh pr list`, `gh issue view`) are GraphQL; any other
+ * `gh api` path is REST.
+ */
+export function ghReadSurface(args: readonly string[]): GhReadSurface {
+  if (args[0] === "api") return args[1] === "graphql" ? "graphql" : "rest";
+  return "graphql";
+}
+
+function failureFrom(
+  args: readonly string[],
+  out: ExecOutput,
+  message: string,
+  classification?: GhReadFailureClass,
+): GhReadFailure {
+  const resolved = classification ?? (isGhRateLimited(out) ? "quota" : "transport");
+  return {
+    surface: ghReadSurface(args),
+    classification: resolved,
+    transient: resolved === "quota",
+    code: out.code,
+    stdout: out.stdout,
+    stderr: out.stderr,
+    message,
+  };
+}
+
+function readFailed(failure: GhReadFailure): { outcome: "failed"; failure: GhReadFailure } {
+  return { outcome: "failed", failure };
+}
+
+function dispatch(
+  ctx: GhReadContext,
+  args: readonly string[],
+  options?: GhReadOptions,
+): Promise<ExecOutput> {
+  const fn = () =>
+    (ctx.exec ?? execTool)("gh", args, {
+      cwd: ctx.cwd,
+      ...(options?.maxBuffer === undefined ? {} : { maxBuffer: options.maxBuffer }),
+    });
+  // The bounded wait-and-retry is the shared primitive's, never this module's.
+  return ctx.quotaBackoff ? withGhQuotaBackoff(fn, ctx.quotaBackoff) : fn();
+}
+
+function parseRows<T>(args: readonly string[], out: ExecOutput): GhReadResult<T> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(out.stdout.trim() === "" ? "[]" : out.stdout);
+  } catch {
+    return readFailed(failureFrom(args, out, "gh read returned malformed JSON", "malformed"));
+  }
+  if (!Array.isArray(parsed)) {
+    return readFailed(failureFrom(args, out, "gh read returned a non-array payload", "malformed"));
+  }
+  return { outcome: "rows", rows: parsed as T[] };
+}
+
+/**
+ * Read a JSON array from `gh <args>` WITHOUT collapsing failure into emptiness.
+ * `{outcome: "rows", rows: []}` means the query ran and the repo has nothing;
+ * `{outcome: "failed"}` means it never ran. A successful read with empty stdout
+ * counts as zero rows.
+ */
+export async function tryReadGhJsonRows<T>(
+  ctx: GhReadContext,
+  args: readonly string[],
+  options?: GhReadOptions,
+): Promise<GhReadResult<T>> {
+  const out = await dispatch(ctx, args, options);
+  if (out.code !== 0) return readFailed(failureFrom(args, out, "gh read failed"));
+  return parseRows<T>(args, out);
+}
+
+/**
+ * {@link tryReadGhJsonRows}, raising {@link GhReadError} on failure. Use this
+ * where an absence would be read as fact: a caller that cannot handle the
+ * failure must fail loudly rather than report nothing found.
+ */
+export async function readGhJsonRows<T>(
+  ctx: GhReadContext,
+  args: readonly string[],
+  options?: GhReadOptions,
+): Promise<T[]> {
+  const result = await tryReadGhJsonRows<T>(ctx, args, options);
+  if (result.outcome === "failed") throw new GhReadError(result.failure);
+  return result.rows;
+}
+
+function graphqlErrorText(errors: readonly unknown[]): string {
+  return errors
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return String(entry ?? "");
+      const rec = entry as { type?: unknown; message?: unknown };
+      return [rec.type, rec.message].filter(Boolean).map(String).join(": ");
+    })
+    .filter(Boolean)
+    .join("; ");
+}
+
+/**
+ * Read the `data` block of a `gh api graphql` response, treating a non-empty
+ * `errors` array as a FAILURE even though gh exited 0. An exhausted GraphQL
+ * query answers with null-filled data plus a `RATE_LIMITED` error; reading its
+ * `data` at face value is how it renders as "nothing is open".
+ */
+export async function tryReadGhGraphql(
+  ctx: GhReadContext,
+  args: readonly string[],
+  options?: GhReadOptions,
+): Promise<GhReadRecordResult> {
+  const out = await dispatch(ctx, args, options);
+  if (out.code !== 0) return readFailed(failureFrom(args, out, "gh graphql read failed"));
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(out.stdout.trim() === "" ? "{}" : out.stdout);
+  } catch {
+    return readFailed(failureFrom(args, out, "gh graphql read returned malformed JSON", "malformed"));
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return readFailed(failureFrom(args, out, "gh graphql read returned a non-object payload", "malformed"));
+  }
+
+  const payload = parsed as { data?: unknown; errors?: unknown };
+  if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+    const text = graphqlErrorText(payload.errors);
+    // Classify against the SAME rate-limit classifier the exit-code path uses,
+    // so a RATE_LIMITED payload lands on the quota path either way.
+    const classified: ExecOutput = { code: 1, stdout: out.stdout, stderr: text };
+    return readFailed(failureFrom(args, classified, `gh graphql read returned errors: ${text}`));
+  }
+  if (!payload.data || typeof payload.data !== "object" || Array.isArray(payload.data)) {
+    return readFailed(failureFrom(args, out, "gh graphql read returned no data block", "malformed"));
+  }
+  return { outcome: "record", record: payload.data as Record<string, unknown> };
+}
+
+/** {@link tryReadGhGraphql}, raising {@link GhReadError} on failure. */
+export async function readGhGraphql(
+  ctx: GhReadContext,
+  args: readonly string[],
+  options?: GhReadOptions,
+): Promise<Record<string, unknown>> {
+  const result = await tryReadGhGraphql(ctx, args, options);
+  if (result.outcome === "failed") throw new GhReadError(result.failure);
+  return result.record;
+}

--- a/apps/dev/src/runtime/wire/statusline-cache.ts
+++ b/apps/dev/src/runtime/wire/statusline-cache.ts
@@ -6,6 +6,7 @@ import { decode as decodeToon, type JsonValue as ToonValue } from "@reddb-io/too
 import { encodeDevSnapshotToon } from "../../core/toon-snapshot.js";
 import { LABEL_HUMAN, LABEL_QUARANTINE, LABEL_READY } from "../../core/triage-labels.js";
 import * as ghx from "../gh.js";
+import { GhReadError } from "../gh/read.js";
 import { afkPaths, type RepoContext } from "./paths.js";
 import { parsePositive } from "./settings.js";
 
@@ -215,6 +216,13 @@ export async function editLabelsWithStatuslineCache(
   return ok;
 }
 
+/**
+ * Refresh the cached statusline counts, LEAVING THE CACHE UNTOUCHED when the
+ * read failed. A read that could not run yields no counts to write: overwriting
+ * known counts with zeroes would render "the queue is empty" as fact (#2801), so
+ * a {@link GhReadError} skips the write and the previous counts keep serving
+ * until a read succeeds.
+ */
 export async function refreshStatuslineCountCache(
   root: string,
   repo: string = inferGitHubRepoSlug(root),
@@ -222,7 +230,11 @@ export async function refreshStatuslineCountCache(
 ): Promise<void> {
   try {
     const cachePath = statuslineCountCachePath(root);
-    const counts = await ghx.countStatuslineQueueCounts({ cwd: root, repo });
+    const counts = await ghx.countStatuslineQueueCounts({ cwd: root, repo }).catch((error: unknown) => {
+      if (error instanceof GhReadError) return null;
+      throw error;
+    });
+    if (counts === null) return;
     writeStatuslineCacheAtomic(cachePath, { ...counts, ts: Math.floor(Date.now() / 1000) });
   } finally {
     if (lockPath) releaseStatuslineRefreshLock(lockPath);

--- a/apps/dev/tests/gh-read.test.ts
+++ b/apps/dev/tests/gh-read.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import type { ExecFn } from "../src/runtime/exec.js";
+import {
+  GhReadError,
+  isGhQuotaExhausted,
+  readGhGraphql,
+  readGhJsonRows,
+  tryReadGhJsonRows,
+} from "../src/runtime/gh/read.js";
+import { countOpenPrs, countPrsCreatedToday } from "../src/runtime/gh.js";
+
+const RATE_LIMITED_STDERR =
+  "gh: API rate limit exceeded for user ID 1. (HTTP 403)";
+
+const RATE_LIMITED_GRAPHQL = JSON.stringify({
+  data: { repository: null },
+  errors: [{ type: "RATE_LIMITED", message: "API rate limit exceeded" }],
+});
+
+function execReturning(...outputs: Array<{ code: number; stdout: string; stderr?: string }>): {
+  exec: ExecFn;
+  calls: number;
+} {
+  const state = { exec: (() => Promise.resolve({ code: 0, stdout: "", stderr: "" })) as ExecFn, calls: 0 };
+  state.exec = async () => {
+    const out = outputs[Math.min(state.calls, outputs.length - 1)]!;
+    state.calls += 1;
+    return { code: out.code, stdout: out.stdout, stderr: out.stderr ?? "" };
+  };
+  return state as { exec: ExecFn; calls: number };
+}
+
+describe("gh read boundary — a failed query is not an empty result", () => {
+  it("raises on an exhausted GraphQL query instead of returning an empty result set", async () => {
+    const exec: ExecFn = async () => ({ code: 1, stdout: "", stderr: RATE_LIMITED_STDERR });
+
+    await expect(
+      readGhJsonRows({ cwd: "/repo", exec }, ["pr", "list", "--json", "number"]),
+    ).rejects.toBeInstanceOf(GhReadError);
+  });
+
+  it("raises on a GraphQL response whose payload carries RATE_LIMITED errors", async () => {
+    // gh exits 0 and prints a well-formed body: `data` is present but null-filled
+    // and `errors` explains the query never ran. Reading `data` at face value is
+    // exactly how an exhausted query renders as an empty result.
+    const exec: ExecFn = async () => ({ code: 0, stdout: RATE_LIMITED_GRAPHQL, stderr: "" });
+
+    const error = await readGhGraphql({ cwd: "/repo", exec }, ["api", "graphql", "-f", "query=x"]).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(GhReadError);
+    expect((error as GhReadError).classification).toBe("quota");
+    expect((error as GhReadError).surface).toBe("graphql");
+  });
+
+  it("returns a genuinely empty result set as empty, distinguishable from a failure", async () => {
+    const empty = await tryReadGhJsonRows({ cwd: "/repo", exec: async () => ({ code: 0, stdout: "[]", stderr: "" }) }, [
+      "pr",
+      "list",
+      "--json",
+      "number",
+    ]);
+    const failed = await tryReadGhJsonRows(
+      { cwd: "/repo", exec: async () => ({ code: 1, stdout: "", stderr: RATE_LIMITED_STDERR }) },
+      ["pr", "list", "--json", "number"],
+    );
+
+    expect(empty).toEqual({ outcome: "rows", rows: [] });
+    expect(failed.outcome).toBe("failed");
+    // The consumer can branch on the outcome without inspecting exit codes.
+    expect(empty.outcome === "rows" && empty.rows.length === 0).toBe(true);
+    expect(failed.outcome === "failed" && failed.failure.classification).toBe("quota");
+  });
+
+  it("treats an empty stdout on a successful read as zero rows, not a failure", async () => {
+    const rows = await readGhJsonRows({ cwd: "/repo", exec: async () => ({ code: 0, stdout: "", stderr: "" }) }, [
+      "pr",
+      "list",
+      "--json",
+      "number",
+    ]);
+    expect(rows).toEqual([]);
+  });
+
+  it("classifies a malformed payload as a failure rather than an empty result", async () => {
+    const result = await tryReadGhJsonRows(
+      { cwd: "/repo", exec: async () => ({ code: 0, stdout: "not-json", stderr: "" }) },
+      ["pr", "list", "--json", "number"],
+    );
+    expect(result.outcome).toBe("failed");
+    expect(result.outcome === "failed" && result.failure.classification).toBe("malformed");
+  });
+
+  it("labels a REST read as the rest surface and a non-quota failure as transport", async () => {
+    const result = await tryReadGhJsonRows(
+      { cwd: "/repo", exec: async () => ({ code: 1, stdout: "", stderr: "HTTP 404: Not Found" }) },
+      ["api", "repos/o/r/issues"],
+    );
+    expect(result.outcome === "failed" && result.failure.surface).toBe("rest");
+    expect(result.outcome === "failed" && result.failure.classification).toBe("transport");
+    expect(result.outcome === "failed" && result.failure.transient).toBe(false);
+  });
+});
+
+describe("gh read boundary — transient quota classification", () => {
+  it("carries the transient quota classification so the bounded wait-and-retry path applies", async () => {
+    const exec: ExecFn = async () => ({ code: 1, stdout: "", stderr: RATE_LIMITED_STDERR });
+    const waits: number[] = [];
+
+    const error = await readGhJsonRows(
+      {
+        cwd: "/repo",
+        exec,
+        quotaBackoff: {
+          nowMs: () => 0,
+          sleepMs: async () => undefined,
+          onWait: (remainingMs) => waits.push(remainingMs),
+          capMs: 0,
+        },
+      },
+      ["pr", "list", "--json", "number"],
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(GhReadError);
+    expect((error as GhReadError).classification).toBe("quota");
+    expect((error as GhReadError).transient).toBe(true);
+    expect(isGhQuotaExhausted(error)).toBe(true);
+    // The cap was zero, so no local retry ran here: waiting is the shared
+    // primitive's job, never this module's.
+    expect(waits).toEqual([]);
+  });
+
+  it("lets the existing bounded wait-and-retry recover before raising", async () => {
+    const state = execReturning(
+      { code: 1, stdout: "", stderr: RATE_LIMITED_STDERR },
+      { code: 0, stdout: JSON.stringify([{ number: 7 }]), stderr: "" },
+    );
+
+    const rows = await readGhJsonRows<{ number: number }>(
+      {
+        cwd: "/repo",
+        exec: state.exec,
+        quotaBackoff: { nowMs: () => 0, sleepMs: async () => undefined, capMs: 60_000 },
+      },
+      ["pr", "list", "--json", "number"],
+    );
+
+    expect(rows).toEqual([{ number: 7 }]);
+  });
+
+  it("does not classify a plain auth failure as quota exhaustion", async () => {
+    const result = await tryReadGhJsonRows(
+      { cwd: "/repo", exec: async () => ({ code: 1, stdout: "", stderr: "gh: Bad credentials (HTTP 401)" }) },
+      ["pr", "list", "--json", "number"],
+    );
+    expect(result.outcome === "failed" && result.failure.classification).toBe("transport");
+    expect(isGhQuotaExhausted(result.outcome === "failed" ? result.failure : null)).toBe(false);
+  });
+});
+
+describe("open pull-request consumers cannot render an exhausted query as none open", () => {
+  it("countOpenPrs raises on an exhausted query rather than reporting zero open PRs", async () => {
+    const exec: ExecFn = async () => ({ code: 1, stdout: "", stderr: RATE_LIMITED_STDERR });
+
+    const error = await countOpenPrs({ cwd: "/repo", repo: "o/r", exec }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(GhReadError);
+    expect(isGhQuotaExhausted(error)).toBe(true);
+  });
+
+  it("countOpenPrs still reports zero when the repo genuinely has no open PRs", async () => {
+    const exec: ExecFn = async () => ({ code: 0, stdout: "[]", stderr: "" });
+    await expect(countOpenPrs({ cwd: "/repo", repo: "o/r", exec })).resolves.toBe(0);
+  });
+
+  it("countOpenPrs counts the open PRs a successful query returns", async () => {
+    const exec: ExecFn = async () => ({
+      code: 0,
+      stdout: JSON.stringify([{ number: 2801 }, { number: 2830 }]),
+      stderr: "",
+    });
+    await expect(countOpenPrs({ cwd: "/repo", repo: "o/r", exec })).resolves.toBe(2);
+  });
+
+  it("countPrsCreatedToday raises on an exhausted query rather than reporting zero", async () => {
+    const exec: ExecFn = async () => ({ code: 1, stdout: "", stderr: RATE_LIMITED_STDERR });
+    await expect(
+      countPrsCreatedToday({ cwd: "/repo", repo: "o/r", exec }, "2026-07-29"),
+    ).rejects.toBeInstanceOf(GhReadError);
+  });
+});

--- a/apps/dev/tests/gh-statusline-counts.test.ts
+++ b/apps/dev/tests/gh-statusline-counts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { countStatuslineQueueCounts, countPrsCreatedToday } from "../src/runtime/gh.js";
 import type { ExecFn } from "../src/runtime/exec.js";
+import { GhReadError } from "../src/runtime/gh/read.js";
 
 describe("gh statusline counts", () => {
   it("prefers rsp conditional REST search counts when available", async () => {
@@ -65,6 +66,29 @@ describe("gh statusline counts", () => {
     expect(calls[3]!.args).toContain('human=repo:o/r is:issue is:open label:"ready-for-human"');
     expect(calls[3]!.args).toContain('quarantine=repo:o/r is:issue is:open label:"quarantine"');
   });
+  it("raises when the GraphQL payload reports RATE_LIMITED instead of counting zeroes", async () => {
+    // gh exits 0 with a well-formed body: `data` is null-filled and `errors`
+    // says the query never ran. Zero counts here would render an exhausted read
+    // as an empty queue (#2801).
+    const exec: ExecFn = async (tool) =>
+      tool === "rsp"
+        ? { code: 1, stdout: "", stderr: "rsp unavailable" }
+        : {
+            code: 0,
+            stdout: JSON.stringify({
+              data: { ready: null, human: null, quarantine: null },
+              errors: [{ type: "RATE_LIMITED", message: "API rate limit exceeded" }],
+            }),
+            stderr: "",
+          };
+
+    const error = await countStatuslineQueueCounts({ cwd: "/repo", repo: "o/r", exec }).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(GhReadError);
+    expect((error as GhReadError).classification).toBe("quota");
+  });
 });
 
 describe("gh countPrsCreatedToday", () => {
@@ -89,16 +113,28 @@ describe("gh countPrsCreatedToday", () => {
     expect(count).toBeLessThanOrEqual(3);
   });
 
-  it("returns 0 on gh failure", async () => {
+  // A read that never ran is NOT a count of zero: reporting 0 here renders the
+  // failure as fact (#2801). Both cases raise so the caller keeps its last
+  // known value instead of publishing a false zero.
+  it("raises on gh failure rather than reporting 0", async () => {
     const exec: ExecFn = async () => ({ code: 1, stdout: "", stderr: "auth error" });
-    const count = await countPrsCreatedToday({ cwd: "/repo", repo: "o/r", exec }, "2026-07-08");
-    expect(count).toBe(0);
+    await expect(
+      countPrsCreatedToday({ cwd: "/repo", repo: "o/r", exec }, "2026-07-08"),
+    ).rejects.toBeInstanceOf(GhReadError);
   });
 
-  it("returns 0 on invalid JSON response", async () => {
+  it("raises on an invalid JSON response rather than reporting 0", async () => {
     const exec: ExecFn = async () => ({ code: 0, stdout: "not-json", stderr: "" });
-    const count = await countPrsCreatedToday({ cwd: "/repo", repo: "o/r", exec }, "2026-07-08");
-    expect(count).toBe(0);
+    await expect(
+      countPrsCreatedToday({ cwd: "/repo", repo: "o/r", exec }, "2026-07-08"),
+    ).rejects.toBeInstanceOf(GhReadError);
+  });
+
+  it("reports 0 when the query ran and matched no pull requests", async () => {
+    const exec: ExecFn = async () => ({ code: 0, stdout: "[]", stderr: "" });
+    await expect(
+      countPrsCreatedToday({ cwd: "/repo", repo: "o/r", exec }, "2026-07-08"),
+    ).resolves.toBe(0);
   });
 
   it("passes the date as a --search created: filter to gh", async () => {

--- a/apps/dev/tests/wire-statusline.test.ts
+++ b/apps/dev/tests/wire-statusline.test.ts
@@ -29,6 +29,7 @@ import {
   readFleetState,
   readFileSync,
   readToonCache,
+  refreshStatuslineCountCache,
   resolveAttemptProbeArming,
   resolveAttemptHead,
   resolveRunSettings,
@@ -43,6 +44,7 @@ import {
   type ExecOutput,
   withTimeout,
   withFakeGh,
+  withRateLimitedGh,
   writeCastleStateSnapshot,
   writeFileSync,
   writeRenderableAttempt,
@@ -444,6 +446,28 @@ describe("statusline count cache write-through", () => {
   });
 });
 
+describe("refreshStatuslineCountCache — an exhausted read writes nothing (#2801)", () => {
+  it("leaves the known queue counts in place instead of caching zeroes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-counts-"));
+    try {
+      const cachePath = statuslineCountCachePath(root);
+      mkdirSync(dirname(cachePath), { recursive: true });
+      const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 10;
+      writeFileSync(cachePath, encode({ queue: 4, human: 1, quarantine: 0, ts: staleTs }), "utf8");
+
+      await withRateLimitedGh(() => refreshStatuslineCountCache(root, "o/r"));
+
+      expect(readToonCache<{ queue: number; human: number; ts: number }>(cachePath)).toMatchObject({
+        queue: 4,
+        human: 1,
+        ts: staleTs,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("statusline repo slug inference", () => {
   it("parses GitHub ssh and https remotes", () => {
     expect(parseGitHubRepoSlugFromRemoteUrl("git@github.com:reddb-io/red-skills.git")).toBe("reddb-io/red-skills");
@@ -560,6 +584,39 @@ describe("collectStatuslineRepo — cache discipline", () => {
       expect(result.localAdded).toBe(20);
       expect(result.localRemoved).toBe(3);
       expect(readToonCache<{ ts: number }>(cachePath).ts).toBe(freshTs);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("exhausted read: keeps the known open-PR count and never publishes a false zero (#2801)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
+    try {
+      const tmpDir = join(root, ".red", "tmp");
+      mkdirSync(tmpDir, { recursive: true });
+      const cachePath = afkPaths(root).statuslineRepoCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
+
+      const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 10;
+      writeFileSync(
+        cachePath,
+        encode({ baseRef: "origin/main", openPrs: 2, todayPrs: 1, openIssues: 5, ts: staleTs }),
+        "utf8",
+      );
+
+      // The read cannot run, so "0 open pull requests" is not an answer this
+      // surface is allowed to give: it keeps the last known 2 and reports the
+      // staleness instead.
+      const result = await withRateLimitedGh(() =>
+        collectStatuslineRepo({ root, repo: "o/r", remote: "origin" }),
+      );
+
+      expect(result.openPrs).toBe(2);
+      expect(result.cacheAgeS).toBeGreaterThan(0);
+      expect(readToonCache<{ openPrs: number; ts: number }>(cachePath)).toMatchObject({
+        openPrs: 2,
+        ts: staleTs,
+      });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/dev/tests/wire.helpers.ts
+++ b/apps/dev/tests/wire.helpers.ts
@@ -30,6 +30,7 @@ import {
   inferGitHubRepoSlug,
   resolveStatuslineCacheTtl,
   resolveAttemptHead,
+  refreshStatuslineCountCache,
 } from "../src/runtime/wire.js";
 import { runBoot } from "../src/core/boot.js";
 import type { ExecOutput } from "../src/runtime/exec.js";
@@ -58,6 +59,7 @@ export {
   parseGitHubRepoSlugFromRemoteUrl,
   readFleetState,
   readFileSync,
+  refreshStatuslineCountCache,
   resolveAttemptProbeArming,
   resolveAttemptHead,
   resolveRunSettings,
@@ -109,6 +111,31 @@ export function fakeBinDir(): string {
 /** Run `fn` with a fake `gh` binary prepended to PATH, then restore PATH. */
 export async function withFakeGh<T>(fn: () => Promise<T>): Promise<T> {
   const dir = fakeBinDir();
+  const orig = process.env.PATH;
+  process.env.PATH = `${dir}:${orig ?? ""}`;
+  try {
+    return await fn();
+  } finally {
+    process.env.PATH = orig;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Write a fake `gh` script that fails the way an exhausted GitHub quota does:
+ * a 403 rate-limit body on stderr and a non-zero exit. */
+export function rateLimitedBinDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "quota-gh-"));
+  writeFileSync(
+    join(dir, "gh"),
+    "#!/bin/sh\necho 'gh: API rate limit exceeded for user ID 1. (HTTP 403)' 1>&2\nexit 1\n",
+    { mode: 0o755 },
+  );
+  return dir;
+}
+
+/** Run `fn` with a rate-limited fake `gh` on PATH, then restore PATH. */
+export async function withRateLimitedGh<T>(fn: () => Promise<T>): Promise<T> {
+  const dir = rateLimitedBinDir();
   const orig = process.env.PATH;
   process.env.PATH = `${dir}:${orig ?? ""}`;
   try {


### PR DESCRIPTION
Automated AFK landing for #2801. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2801

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787968649&installation_model_id=20659&pr_number=2833&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2833&signature=f6a54e1413b76aefff3c57503ba49a04972a8d4a78ee19e2fb093a669e5e20e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->