### PR TITLE
chore: #2793 --verbose second line, from the heartbeat's opaque last log line

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -26,11 +26,12 @@ of it.
 | Which session a daemon serves | `src/paths.ts` — session key, socket, lock, lease |
 | Who owns the session across restarts | `src/session-lease.ts` — pid + start time, TOON on disk |
 | Who owns the socket right now | `src/daemon.ts` — exclusive bind |
-| The frozen wire contract | `src/protocol.ts` — `ping`, `host-state`, `statusline-payload`, `statusline-string`, `worker-start`, `worker-command`, `shutdown` |
+| The frozen wire contract | `src/protocol.ts` — `ping`, `host-state`, `statusline-payload`, `statusline-string`, `worker-start`, `worker-command`, `worker-heartbeat`, `shutdown` |
 | Who may read and who may write | `src/session-reach.ts` — read the host, write the project |
 | What this machine is doing, in one document | `src/statusline-payload.ts` — Workers, projects, vitals, budgets, staleness |
 | That same answer, as a finished line | `src/statusline-render.ts` — modes, degradation, width; a pure function of the payload |
 | The declared defaults and the flag above them | `src/statusline-config.ts` — `plugins.dev.statusline.*`, resolved client-side |
+| A Worker's last logged line, published not read | `src/worker-log.ts` — the heartbeat's opaque string, and the restart-only recovery |
 | Where a Worker's resources are charged | `src/worker-placement.ts` — pure planner over injected probes |
 | Birth itself | `src/worker-launch.ts` — plan, spawn once, report the downgrade |
 | The host-wide read | `src/host-state.ts` — total shape, Workers plus the budget total |
@@ -103,8 +104,22 @@ of it.
   purpose and the loss is stated (`detail`, `degraded`) rather than left to be
   detected by re-parsing the line. The full picture stays with the dashboard and
   the monitor.
+- **`--verbose` adds a second line per Worker, and the Worker supplies it.** The
+  Worker publishes its last logged line on its heartbeat (`worker-heartbeat`) as an
+  opaque string; the daemon stores and returns it without ever parsing it, so the
+  whole global verbose view is still ONE read and opens no project's files. A
+  statusline that read each Worker's log itself would cost a disk read per Worker
+  per render, cross a project boundary, and hand every surface a private source.
+  A Worker that has logged nothing gets no second line at all.
+- **A restart is the one time the daemon reads a log — from the path it was given.**
+  A daemon that just came back holds Workers it has heard no heartbeat from, so for
+  those it reads once, using the `log_path` the client handed over at spawn and the
+  event lane carried through. A Worker whose client gave no path waits for its next
+  heartbeat; guessing a filename inside its workspace would be the derived layout
+  rule 3 forbids. Recovery is not the normal path, and the payload says which lines
+  came from it (`log.source`).
 - **Defaults are declared once, in `plugins.dev.statusline.*`.** `mode`,
-  `max_workers`, `max_projects` and `max_width`; a flag beats config, config
+  `max_workers`, `max_projects`, `max_width` and `verbose`; a flag beats config, config
   beats the built-in. Config is read **client-side** — the daemon may not know
   what a `.red/config.yaml` is — so only decided values cross the socket. A
   malformed value is named on stderr and ignored, never fatal: this line renders
@@ -126,4 +141,6 @@ pnpm -C apps/redskilled serve       # run the daemon on this session's socket
 redskilled statusline                       # this project's Workers
 redskilled statusline global                # every project's, each showing its owner
 redskilled statusline --max-width 60        # a flag overrides the declared default
+redskilled statusline global --verbose      # each Worker plus the last line it logged
+redskilled statusline --no-verbose          # one read without the second lines
 ```

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -54,7 +54,8 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
 }
 
 /**
- * `redskilled statusline [global] [--flags]` — the whole of an agent host's job.
+ * `redskilled statusline [global] [--verbose] [--flags]` — the whole of an agent
+ * host's job.
  *
  * The host runs this and prints the one line it writes; it decides nothing about
  * shape, order, width or degradation, because ADR 0130 rule 10 moves rendering
@@ -88,7 +89,10 @@ export async function runStatusline(
   const render = await readRedskilledStatuslineString(io.paths ?? resolveRedskilledPaths(), resolved.options, {
     ...(resolved.options.project == null ? {} : { sessionProject: resolved.options.project }),
   });
-  write(`${render.line}\n`);
+  // Every line the daemon rendered, in order — one write, whatever the taste.
+  // With `--verbose` that is the Worker line plus a second line per Worker; the
+  // host still decides nothing about shape (ADR 0130 rule 10).
+  write(`${render.lines.join("\n")}\n`);
   return 0;
 }
 

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -27,6 +27,7 @@ import {
   isRedskilledStatuslinePayload,
   isRedskilledStatuslineRender,
   isRedskilledWorkerCommandResult,
+  isRedskilledWorkerHeartbeatAck,
   isRedskilledWorkerStarted,
   sendRedskilledRequest,
   type RedskilledRequest,
@@ -35,9 +36,11 @@ import {
   type RedskilledStatuslineRenderRequest,
   type RedskilledWorkerCommandRequest,
   type RedskilledWorkerCommandResult,
+  type RedskilledWorkerHeartbeatAck,
   type RedskilledWorkerStarted,
 } from "./protocol.js";
 import type { RedskilledStatuslineOptions } from "./statusline-render.js";
+import { clampPublishedLogLine } from "./worker-log.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
 
 /** How long a client waits for a daemon — its own or the race winner's — to answer. */
@@ -209,7 +212,41 @@ function renderRequest(options: RedskilledStatuslineOptions): RedskilledStatusli
     max_workers: options.maxWorkers,
     max_projects: options.maxProjects,
     max_width: options.maxWidth,
+    verbose: options.verbose,
   };
+}
+
+/**
+ * Publish one Worker's last logged line — the verbose statusline's whole supply.
+ *
+ * The Worker's own project publishes it, on the heartbeat it already sends, and
+ * the daemon stores the string without reading it. **Clamping happens here, on the
+ * publisher's side**: the daemon shortening a line would be the daemon touching
+ * content, and a runaway log line must not make a heartbeat expensive.
+ *
+ * A refusal throws, exactly as a command's does; an ack that says `accepted:
+ * false` is the benign race where the daemon had already let the Worker go.
+ */
+export async function publishRedskilledWorkerLogLine(
+  paths: RedskilledPaths,
+  heartbeat: { readonly worker_id: string; readonly line: string; readonly session_project?: string },
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledWorkerHeartbeatAck> {
+  const sessionProject = heartbeat.session_project ?? config.sessionProject;
+  const value = await requestRedskilled(
+    paths,
+    {
+      op: "worker-heartbeat",
+      heartbeat: {
+        worker_id: heartbeat.worker_id,
+        last_log_line: clampPublishedLogLine(heartbeat.line),
+        ...(sessionProject == null ? {} : { session_project: sessionProject }),
+      },
+    },
+    config,
+  );
+  if (!isRedskilledWorkerHeartbeatAck(value)) throw new Error("redskilled daemon returned a malformed heartbeat ack");
+  return value;
 }
 
 /**

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -65,6 +65,8 @@ import {
   type RedskilledStatuslineRenderRequest,
   type RedskilledWorkerCommandRequest,
   type RedskilledWorkerCommandResult,
+  type RedskilledWorkerHeartbeatAck,
+  type RedskilledWorkerHeartbeatRequest,
 } from "./protocol.js";
 import { commandOp, evaluateSessionReach, type RedskilledSessionOp } from "./session-reach.js";
 import { buildStatuslinePayload, type RedskilledStatuslinePayload } from "./statusline-payload.js";
@@ -79,6 +81,11 @@ import {
   type LaunchedWorker,
   type RedskilledWorkerSpec,
 } from "./worker-launch.js";
+import {
+  readLastLogLine,
+  type RedskilledLogTailProbe,
+  type RedskilledWorkerLogLine,
+} from "./worker-log.js";
 import {
   createRedskilledLeaseStore,
   currentProcessOwner,
@@ -132,6 +139,14 @@ export interface RedskilledDaemonOptions {
   readonly memorySampler?: RedskilledMemorySampler;
   /** Window between memory samples; 0 or below leaves the sampler unarmed. */
   readonly sampleMs?: number;
+  /**
+   * How the daemon recovers a Worker's last logged line after a restart.
+   *
+   * Injected so a test can prove the read happens exactly once, on exactly the
+   * path the client gave. It is never used on the normal path: a live Worker's
+   * line arrives on its own heartbeat.
+   */
+  readonly readLogTail?: RedskilledLogTailProbe;
 }
 
 export interface RedskilledDaemon {
@@ -176,6 +191,15 @@ export interface RedskilledDaemon {
    * performed, each naming the budget it enforced.
    */
   sampleMemoryBudgets(): Promise<readonly RedskilledBudgetTermination[]>;
+  /**
+   * Store one Worker's last logged line, exactly as it was published.
+   *
+   * The daemon widens by one string and learns nothing: it does not parse the
+   * line, does not date it from its content, and does not know which file it came
+   * out of. That ignorance is what keeps the verbose statusline a single read
+   * instead of a disk read per Worker per render.
+   */
+  publishWorkerHeartbeat(request: RedskilledWorkerHeartbeatRequest): RedskilledWorkerHeartbeatAck;
   /** Re-probe every re-attached Worker, retiring the ones the host no longer confirms. */
   sweepReattached(): Promise<readonly RedskilledWorkerView[]>;
   /** The Workers this daemon adopted at start rather than birthing itself. */
@@ -226,11 +250,16 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const liveness = options.liveness ?? detectWorkerLiveness;
   const stopProbe = options.stopWorker ?? stopWorker;
   const memorySampler = options.memorySampler ?? sampleTreeRss;
+  const readLogTail = options.readLogTail ?? readLastLogLine;
   const sampleMs = options.sampleMs ?? DEFAULT_REDSKILLED_SAMPLE_MS;
   const workers = new Map<string, RedskilledWorkerView>();
   // Re-attached Workers have no child handle to deliver an exit, so their death
   // is discovered by asking the host rather than by being told.
   const reattached = new Set<string>();
+  // The last line each Worker published, by Worker id. Held in memory only: it is
+  // a live progress note, and a durable copy would be a third authority on a
+  // Worker's story next to the tracker and git (ADR 0130).
+  const logLines = new Map<string, RedskilledWorkerLogLine>();
   const activeSockets = new Set<Socket>();
   // The last thing the sampler measured, kept so a read is dated rather than
   // dating itself: staleness belongs to the daemon that took the measurement.
@@ -268,6 +297,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       ceiling,
       rss: lastReading,
       sampledAt: lastSampledAt,
+      logLines: Object.fromEntries(logLines),
       now: clock(),
       reattachedWorkerIds: [...reattached],
     });
@@ -290,6 +320,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       maxWorkers: render?.max_workers ?? REDSKILLED_STATUSLINE_DEFAULTS.maxWorkers,
       maxProjects: render?.max_projects ?? REDSKILLED_STATUSLINE_DEFAULTS.maxProjects,
       maxWidth: render?.max_width ?? REDSKILLED_STATUSLINE_DEFAULTS.maxWidth,
+      verbose: render?.verbose ?? REDSKILLED_STATUSLINE_DEFAULTS.verbose,
     });
   }
 
@@ -332,6 +363,57 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     };
   }
 
+  /**
+   * Drop every belief about one Worker at once.
+   *
+   * One function rather than three deletes at each site: a Worker forgotten from
+   * the live set but left in the log-line map would keep a dead Worker's progress
+   * note alive and leak a little memory per death.
+   */
+  function forgetWorker(workerId: string): void {
+    workers.delete(workerId);
+    reattached.delete(workerId);
+    logLines.delete(workerId);
+  }
+
+  /**
+   * Record one heartbeat's line, once reach has permitted it.
+   *
+   * Reach is checked against the TARGET's project, exactly as a command is, so a
+   * session cannot publish a line into another project's statusline. A refusal
+   * throws and stores nothing.
+   */
+  function publishWorkerHeartbeat(request: RedskilledWorkerHeartbeatRequest): RedskilledWorkerHeartbeatAck {
+    const target = workers.get(request.worker_id);
+    const reach = authorize("worker-heartbeat", request.session_project, target?.project_label ?? null);
+    if (!reach.permitted) throw new Error(reach.reason);
+    if (typeof request.last_log_line !== "string") {
+      // The shape, not the content: the daemon must know it holds a string, and
+      // that is the last thing it ever asks about this value.
+      throw new Error("redskilled worker heartbeat last_log_line must be a string");
+    }
+    if (target == null) {
+      return {
+        version: 1,
+        worker_id: request.worker_id,
+        accepted: false,
+        reach,
+        published_at: null,
+        detail: `redskilled holds no live Worker ${JSON.stringify(request.worker_id)} to publish a line for`,
+      };
+    }
+    const publishedAt = clock();
+    logLines.set(request.worker_id, { line: request.last_log_line, published_at: publishedAt, source: "heartbeat" });
+    return {
+      version: 1,
+      worker_id: request.worker_id,
+      accepted: true,
+      reach,
+      published_at: publishedAt,
+      detail: `redskilled stored a line for Worker ${JSON.stringify(request.worker_id)} without reading it`,
+    };
+  }
+
   /** Stop one Worker the daemon holds, and record its death. */
   async function stopWorkerNow(worker: RedskilledWorkerView, detail: string): Promise<boolean> {
     try {
@@ -340,8 +422,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       // A stop the host refused still ends the daemon's claim: a Worker it keeps
       // holding a budget for while nothing supervises it is the worse state.
     }
-    workers.delete(worker.worker_id);
-    reattached.delete(worker.worker_id);
+    forgetWorker(worker.worker_id);
     record("worker-death", worker, detail);
     armIdleTimer();
     return true;
@@ -380,8 +461,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       clock,
       onExit: (workerId, code, signal) => {
         const worker = workers.get(workerId);
-        workers.delete(workerId);
-        reattached.delete(workerId);
+        forgetWorker(workerId);
         if (worker) record("worker-death", worker, `exit code=${code ?? "null"} signal=${signal ?? "null"}`);
         armIdleTimer();
       },
@@ -420,8 +500,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     if (adopted.length === 0) return [];
     const { dead } = await reattachWorkers(adopted, liveness);
     for (const worker of dead) {
-      workers.delete(worker.worker_id);
-      reattached.delete(worker.worker_id);
+      forgetWorker(worker.worker_id);
       record("worker-death", worker, "the host no longer confirms this Worker");
     }
     if (dead.length > 0) armIdleTimer();
@@ -438,8 +517,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       // daemon's claim on the budget, and a silent failure would leave the
       // accounting holding room for a Worker nobody is tracking any more.
     }
-    workers.delete(workerId);
-    reattached.delete(workerId);
+    forgetWorker(workerId);
     record("worker-budget-kill", worker, detail);
     armIdleTimer();
     return true;
@@ -536,6 +614,18 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   for (const worker of reattachment.dead) {
     record("worker-death", worker, "the Worker ended while no daemon was watching");
   }
+  // The bounded exception. A daemon that has just come back holds Workers it has
+  // never heard a heartbeat from, so for those — and only those — it reads the log
+  // ONCE, from the path the client GAVE at spawn and carried on the event lane. A
+  // Worker whose client gave no path stays without a line until it publishes one;
+  // guessing a filename inside its workspace would be the derived layout ADR 0130
+  // rule 3 forbids. Recovery is not the normal path.
+  for (const worker of reattachment.alive) {
+    if (worker.log_path == null || logLines.has(worker.worker_id)) continue;
+    const recovered = await readLogTail(worker.log_path).catch(() => null);
+    if (recovered == null || recovered.trim() === "") continue;
+    logLines.set(worker.worker_id, { line: recovered, published_at: clock(), source: "rehydrated" });
+  }
 
   server.on("connection", (socket) => {
     activeSockets.add(socket);
@@ -576,6 +666,9 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         // two surfaces are the same answer twice and never two answers.
         return { id: request.id, ok: true, value: statuslineString(request.render) };
       }
+      if (request.op === "worker-heartbeat") {
+        return { id: request.id, ok: true, value: publishWorkerHeartbeat(request.heartbeat) };
+      }
       if (request.op === "worker-command") {
         return { id: request.id, ok: true, value: await runWorkerCommand(request.command) };
       }
@@ -611,6 +704,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     killWorkerOverBudget,
     sampleMemoryBudgets,
     sweepReattached,
+    publishWorkerHeartbeat,
     reattached: () => [...reattached].map((id) => workers.get(id)).filter((w): w is RedskilledWorkerView => w != null),
     flushEvents: () => eventLane.flush(),
     trackWorker(worker) {
@@ -622,6 +716,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       const worker = workers.get(workerId);
       const removed = workers.delete(workerId);
       reattached.delete(workerId);
+      logLines.delete(workerId);
       if (worker) record("worker-death", worker, "released by the daemon");
       armIdleTimer();
       return removed;

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -49,6 +49,8 @@ export interface RedskilledHostEvent {
   readonly project_label: string;
   readonly pid: number;
   readonly workspace_path: string;
+  /** The log path the client gave at spawn, so a restart can recover a heartbeat. */
+  readonly log_path: string | null;
   readonly isolated: boolean;
   /** The transient unit name — the handle a restarted daemon re-attaches by. */
   readonly unit: string | null;
@@ -80,6 +82,7 @@ export function buildHostEvent(input: RecordEventInput): RedskilledHostEvent {
     project_label: input.worker.project_label,
     pid: input.worker.pid,
     workspace_path: input.worker.workspace_path,
+    log_path: input.worker.log_path ?? null,
     isolated: input.worker.isolated,
     unit: input.worker.unit ?? null,
     memory_high: budget.memory_high ?? null,
@@ -244,6 +247,7 @@ export function toWorkerView(event: RedskilledHostEvent): RedskilledWorkerView {
     pid: event.pid,
     started_at: event.ts,
     workspace_path: event.workspace_path,
+    ...(event.log_path != null ? { log_path: event.log_path } : {}),
     isolated: event.isolated,
     ...(event.unit != null ? { unit: event.unit } : {}),
     ...(Object.keys(budget).length > 0 ? { budget } : {}),
@@ -271,6 +275,7 @@ function fromRow(record: ToonlRecord): RedskilledHostEvent {
     project_label: text(record.project_label) ?? "",
     pid: Number(record.pid ?? 0),
     workspace_path: text(record.workspace_path) ?? "",
+    log_path: text(record.log_path),
     isolated: record.isolated === true || record.isolated === "true",
     unit: text(record.unit),
     memory_high: text(record.memory_high),

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -32,6 +32,14 @@ export interface RedskilledWorkerView {
   readonly started_at: string;
   /** The path the client handed over, used verbatim as the Worker's workspace. */
   readonly workspace_path: string;
+  /**
+   * Where this Worker's log is, when the client said so at spawn.
+   *
+   * Given, never derived: the daemon reads it only to rehydrate a Worker it holds
+   * no heartbeat for after a restart, and a daemon that guessed a filename inside
+   * the workspace would have learned a repository's layout (ADR 0130 rule 3).
+   */
+  readonly log_path?: string;
   /** True when the Worker runs inside a transient unit of its own. */
   readonly isolated: boolean;
   /** The transient unit's name, present only when `isolated`. */

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -23,7 +23,11 @@
  * string because the alternative is every agent host reimplementing the line —
  * which is the drift the pair of ops exists to prevent (ADR 0130 rule 10). The
  * daemon renders it from the very payload the other op returns, so the two can
- * disagree only if a pure function is impure. `worker-command`
+ * disagree only if a pure function is impure. `worker-heartbeat` widens it by one
+ * more string, in the one direction the daemon has no other way to learn: the
+ * Worker's own last logged line. It is stored and echoed, never parsed — transport
+ * is not semantics — which is what keeps the verbose statusline one read and keeps
+ * the daemon ignorant of where a project's logs live. `worker-command`
  * carries the commanding verbs — stop, recycle, steer — as data rather than as
  * three ops, so the reach rule is decided once for all of them.
  *
@@ -71,6 +75,23 @@ export interface RedskilledStatuslineRenderRequest {
   readonly max_workers?: number;
   readonly max_projects?: number;
   readonly max_width?: number;
+  /** Ask for the second line per Worker: the last line each one logged. */
+  readonly verbose?: boolean;
+}
+
+/**
+ * One Worker publishing its own last logged line.
+ *
+ * `last_log_line` is opaque: the daemon checks that it is a string and stores it,
+ * and nothing in this process ever reads it for meaning. The alternative — a
+ * statusline reading each Worker's log itself — would cost a disk read per Worker
+ * per render, cross a project boundary, and give every surface a private source
+ * to contradict the daemon with.
+ */
+export interface RedskilledWorkerHeartbeatRequest {
+  readonly worker_id: string;
+  readonly last_log_line: string;
+  readonly session_project?: string;
 }
 
 export type RedskilledRequest =
@@ -80,6 +101,7 @@ export type RedskilledRequest =
   | { id: string; op: "statusline-string"; session_project?: string; render?: RedskilledStatuslineRenderRequest }
   | { id: string; op: "worker-start"; spec: RedskilledWorkerSpec; session_project?: string }
   | { id: string; op: "worker-command"; command: RedskilledWorkerCommandRequest }
+  | { id: string; op: "worker-heartbeat"; heartbeat: RedskilledWorkerHeartbeatRequest }
   | { id: string; op: "shutdown" };
 
 export type RedskilledResponse =
@@ -150,6 +172,34 @@ export function isRedskilledWorkerCommandResult(value: unknown): value is Redski
     isRedskilledReachVerdict(result.reach);
 }
 
+/**
+ * The answer to a permitted heartbeat.
+ *
+ * `accepted` is false — not an error — when the daemon holds no such live Worker:
+ * a Worker whose death the daemon observed a moment before its last heartbeat
+ * landed is a race, not a fault, and a publisher must not treat it as one.
+ */
+export interface RedskilledWorkerHeartbeatAck {
+  readonly version: 1;
+  readonly worker_id: string;
+  readonly accepted: boolean;
+  readonly reach: RedskilledReachVerdict;
+  /** When the daemon recorded the line; `null` when it recorded nothing. */
+  readonly published_at: string | null;
+  readonly detail: string;
+}
+
+export function isRedskilledWorkerHeartbeatAck(value: unknown): value is RedskilledWorkerHeartbeatAck {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const ack = value as Record<string, unknown>;
+  return ack.version === 1 &&
+    typeof ack.worker_id === "string" &&
+    typeof ack.accepted === "boolean" &&
+    typeof ack.detail === "string" &&
+    (ack.published_at === null || typeof ack.published_at === "string") &&
+    isRedskilledReachVerdict(ack.reach);
+}
+
 export interface RedskilledClientOptions {
   socketPath: string;
   timeoutMs?: number;
@@ -184,6 +234,9 @@ export function isRedskilledStatuslineRender(value: unknown): value is Redskille
   const render = value as Record<string, unknown>;
   return render.version === 1 &&
     typeof render.line === "string" &&
+    Array.isArray(render.lines) &&
+    render.lines.every((line) => typeof line === "string") &&
+    typeof render.verbose === "boolean" &&
     (render.mode === "local" || render.mode === "global") &&
     (render.project === null || typeof render.project === "string") &&
     typeof render.detail === "string" &&

--- a/apps/redskilled/src/session-reach.ts
+++ b/apps/redskilled/src/session-reach.ts
@@ -38,7 +38,8 @@ export type RedskilledSessionOp =
   | "worker-start"
   | "worker-stop"
   | "worker-recycle"
-  | "worker-steer";
+  | "worker-steer"
+  | "worker-heartbeat";
 
 /** The three reaches. A reader of this type knows the whole model. */
 export type RedskilledReachKind = "host-read" | "project-write" | "daemon-life";
@@ -53,6 +54,11 @@ export const REDSKILLED_OP_REACH: Readonly<Record<RedskilledSessionOp, Redskille
   "worker-stop": "project-write",
   "worker-recycle": "project-write",
   "worker-steer": "project-write",
+  // A heartbeat is a Worker telling the daemon about itself, so it lands where
+  // every other statement about a Worker lands: inside its own project. A
+  // cross-project publish would let one session write a line another session's
+  // statusline then shows as that project's own.
+  "worker-heartbeat": "project-write",
 };
 
 /** The commanding verbs, as a session names them. Each maps onto one write op. */

--- a/apps/redskilled/src/statusline-config.ts
+++ b/apps/redskilled/src/statusline-config.ts
@@ -1,7 +1,8 @@
 /**
  * statusline-config — the declared defaults, and the flag that beats them.
  *
- * **Every statusline default is declarable in `.red/config.yaml`.** The block is
+ * **Every statusline default is declarable in `.red/config.yaml`** — the modes,
+ * the count budgets, the width and `verbose`. The block is
  * new rather than migrated: the file has never held a statusline key, so there
  * is no legacy spelling to keep working and no deprecation to carry.
  *
@@ -47,6 +48,7 @@ export interface RedskilledStatuslineConfig {
   readonly maxWorkers?: number;
   readonly maxProjects?: number;
   readonly maxWidth?: number;
+  readonly verbose?: boolean;
 }
 
 /** A declared value that could not be honoured, in a sentence a human can act on. */
@@ -68,6 +70,7 @@ export interface RedskilledStatuslineFlags {
   readonly maxWorkers?: number;
   readonly maxProjects?: number;
   readonly maxWidth?: number;
+  readonly verbose?: boolean;
 }
 
 export interface ResolveStatuslineOptionsInput {
@@ -101,6 +104,7 @@ export function readRedskilledStatuslineConfig(text: string): RedskilledStatusli
     maxWorkers?: number;
     maxProjects?: number;
     maxWidth?: number;
+    verbose?: boolean;
   } = {};
 
   if (mode != null) {
@@ -120,11 +124,18 @@ export function readRedskilledStatuslineConfig(text: string): RedskilledStatusli
     else warnings.push({ ...declared, reason: "expected a whole number of zero or more" });
   }
 
+  const verbose = raw("verbose");
+  if (verbose != null) {
+    if (verbose.value === "true" || verbose.value === "false") config.verbose = verbose.value === "true";
+    else warnings.push({ ...verbose, reason: "expected `true` or `false`" });
+  }
+
   return { config, warnings };
 }
 
 const STATUSLINE_FLAGS = {
   mode: { kind: "value", coerce: (raw: string) => raw },
+  verbose: { kind: "boolean" },
   project: { kind: "value", coerce: (raw: string) => raw },
   "max-workers": { kind: "value", coerce: (raw: string) => raw },
   "max-projects": { kind: "value", coerce: (raw: string) => raw },
@@ -152,6 +163,7 @@ export function parseRedskilledStatuslineFlags(argv: readonly string[]): {
     maxWorkers?: number;
     maxProjects?: number;
     maxWidth?: number;
+    verbose?: boolean;
   } = {};
 
   const declaredMode = values.mode ?? positionals.find((word) => word === "global" || word === "local");
@@ -160,6 +172,9 @@ export function parseRedskilledStatuslineFlags(argv: readonly string[]): {
     else warnings.push({ key: "--mode", value: declaredMode, reason: "expected `local` or `global`" });
   }
   if (values.project != null) flags.project = values.project;
+  // `--no-verbose` is a stated `false`, not an absent flag: an operator who
+  // declared `verbose: true` in config needs one read without it.
+  if (values.verbose !== undefined) flags.verbose = values.verbose === true;
 
   const counts = [
     { flag: "max-workers", assign: (n: number) => { flags.maxWorkers = n; } },
@@ -201,6 +216,7 @@ export function resolveRedskilledStatuslineOptions(
       maxWorkers: flags.maxWorkers ?? read.config.maxWorkers ?? REDSKILLED_STATUSLINE_DEFAULTS.maxWorkers,
       maxProjects: flags.maxProjects ?? read.config.maxProjects ?? REDSKILLED_STATUSLINE_DEFAULTS.maxProjects,
       maxWidth: flags.maxWidth ?? read.config.maxWidth ?? REDSKILLED_STATUSLINE_DEFAULTS.maxWidth,
+      verbose: flags.verbose ?? read.config.verbose ?? REDSKILLED_STATUSLINE_DEFAULTS.verbose,
     },
     warnings: read.warnings,
   };

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -24,6 +24,7 @@ import { measureHostConsumption, type RedskilledHostCeiling, type RedskilledHost
 import type { RedskilledBudgetAccounting } from "./budget-accounting.js";
 import type { RedskilledHostState, RedskilledWorkerView } from "./host-state.js";
 import { resolveEnforcedBudget, type RedskilledBudgetName, type RedskilledRssReading } from "./memory-sampler.js";
+import type { RedskilledWorkerLogLine } from "./worker-log.js";
 
 /**
  * How old a sample may be before the payload calls itself stale.
@@ -66,6 +67,22 @@ export interface RedskilledStatuslineWorkerBudget {
   readonly enforceable: boolean;
 }
 
+/**
+ * The last line this Worker logged, as the daemon received it.
+ *
+ * It rides on the payload because that is what makes the verbose view ONE read:
+ * a consumer that had to open each Worker's log would pay a disk read per Worker
+ * per render and would cross a project boundary to do it. `last_line` is `null`
+ * for a Worker that has published nothing — never `""`, because a consumer
+ * printing an empty second line is the broken render this field exists to avoid.
+ */
+export interface RedskilledStatuslineWorkerLog {
+  readonly last_line: string | null;
+  readonly published_at: string | null;
+  /** How the daemon came by the line; `null` when it has none. */
+  readonly source: "heartbeat" | "rehydrated" | null;
+}
+
 export interface RedskilledStatuslineWorker {
   readonly worker_id: string;
   readonly project_label: string;
@@ -79,6 +96,7 @@ export interface RedskilledStatuslineWorker {
   readonly warnings: readonly string[];
   readonly vitals: RedskilledStatuslineVitals;
   readonly budget: RedskilledStatuslineWorkerBudget;
+  readonly log: RedskilledStatuslineWorkerLog;
 }
 
 /** One project's share of the machine. */
@@ -145,6 +163,13 @@ export interface BuildStatuslinePayloadInput {
   readonly rss: RedskilledRssReading;
   /** When that reading was taken; `null` when nothing has been sampled yet. */
   readonly sampledAt: string | null;
+  /**
+   * The last line each Worker published, by Worker id.
+   *
+   * Passed in rather than read here: the lines belong to the daemon that received
+   * the heartbeats, and this document stays a pure function of its inputs.
+   */
+  readonly logLines?: Readonly<Record<string, RedskilledWorkerLogLine>>;
   readonly now: string;
   /** Workers this daemon adopted at start rather than birthing itself, by id. */
   readonly reattachedWorkerIds?: readonly string[];
@@ -167,6 +192,7 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
       ageMs,
       sampleFresh,
       nowMs,
+      log: input.logLines?.[worker.worker_id],
       state: reattached.has(worker.worker_id) ? "reattached" : "running",
     })
   );
@@ -220,6 +246,8 @@ function buildWorker(
     readonly ageMs: number | null;
     readonly sampleFresh: boolean;
     readonly nowMs: number | null;
+    /** What this Worker published, when it has published anything. */
+    readonly log?: RedskilledWorkerLogLine;
     readonly state: RedskilledWorkerState;
   },
 ): RedskilledStatuslineWorker {
@@ -254,7 +282,21 @@ function buildWorker(
       used_fraction: enforced == null || enforced.bytes <= 0 || rssBytes == null ? null : rssBytes / enforced.bytes,
       enforceable: enforced != null,
     },
+    log: workerLog(ctx.log),
   };
+}
+
+/**
+ * The published line, echoed and never parsed. PURE.
+ *
+ * The one judgement made about the content is whether there is any: a line of
+ * spaces is the same absence as no line at all, and reporting it as present
+ * would hand every consumer a blank second line to render.
+ */
+function workerLog(log: RedskilledWorkerLogLine | undefined): RedskilledStatuslineWorkerLog {
+  const absent = { last_line: null, published_at: null, source: null } as const;
+  if (log == null || log.line.trim() === "") return absent;
+  return { last_line: log.line, published_at: log.published_at, source: log.source };
 }
 
 function buildProjects(workers: readonly RedskilledStatuslineWorker[]): readonly RedskilledStatuslineProject[] {

--- a/apps/redskilled/src/statusline-render.ts
+++ b/apps/redskilled/src/statusline-render.ts
@@ -16,6 +16,15 @@
  * every project's Workers and names the owner of each, because an anonymous
  * Worker on a busy machine is the exact thing the mode exists to fix.
  *
+ * **`verbose` gives each listed Worker a second line: the last line it logged.**
+ * That line arrives inside the payload, published by the Worker on its heartbeat,
+ * so a verbose global view still costs ONE read and opens no project's files. The
+ * renderer treats it as text to fit on a line and never as a fact to interpret:
+ * whitespace is collapsed so one Worker cannot break the line contract, and the
+ * width clamp is the same one every other line answers to. A Worker that has
+ * logged nothing gets no second line at all — a blank one would be a render
+ * defect wearing the shape of information.
+ *
  * **A crowded machine degrades to an aggregate rather than overflowing.** The
  * statusline answers "who is using this machine and how much"; it is not the
  * dashboard. When the Workers do not fit, the line drops to one entry per
@@ -45,6 +54,8 @@ export interface RedskilledStatuslineOptions {
   /** The hard ceiling in characters. The line never exceeds it. */
   readonly maxWidth: number;
   readonly separator: string;
+  /** Give each listed Worker a second line carrying its last logged line. */
+  readonly verbose: boolean;
 }
 
 /**
@@ -56,7 +67,17 @@ export interface RedskilledStatuslineOptions {
  */
 export interface RedskilledStatuslineRender {
   readonly version: 1;
+  /** The statusline itself — the first line, and the only one when quiet. */
   readonly line: string;
+  /**
+   * Every line to print, `line` first.
+   *
+   * A list rather than one string with newlines in it: a host that had to split
+   * on `\n` to know how many rows to reserve would be parsing the render, which
+   * is the one thing this surface exists to spare it.
+   */
+  readonly lines: readonly string[];
+  readonly verbose: boolean;
   readonly mode: RedskilledStatuslineMode;
   readonly project: string | null;
   readonly detail: RedskilledStatuslineDetail;
@@ -75,6 +96,7 @@ export const REDSKILLED_STATUSLINE_DEFAULTS: RedskilledStatuslineOptions = {
   maxProjects: 4,
   maxWidth: 120,
   separator: " · ",
+  verbose: false,
 };
 
 /**
@@ -106,6 +128,12 @@ export function renderRedskilledStatusline(
   // Even the host aggregate can outgrow a very narrow line; a clamp is the last
   // resort and never the normal path, so it keeps the ellipsis visible.
   const line = clamp(chosen.line, options.maxWidth);
+  // Second lines belong to Worker entries, so they exist only while the line is
+  // still listing Workers: annotating an aggregate would attach a Worker's log to
+  // a row that names a project.
+  const extra = options.verbose && chosen.detail === "workers"
+    ? workerLogLines(workers, options)
+    : [];
   // Degradation is measured against the richest detail this payload COULD have
   // shown, not against the richest one the budgets allowed: a line that dropped
   // the Workers because `max_workers` said so is degraded in the only sense a
@@ -115,6 +143,8 @@ export function renderRedskilledStatusline(
   return {
     version: 1,
     line,
+    lines: [line, ...extra],
+    verbose: options.verbose,
     mode: options.mode,
     project: options.project,
     detail: chosen.detail,
@@ -239,7 +269,7 @@ function stalenessMark(payload: RedskilledStatuslinePayload): string {
  * or it is not shown at all.
  */
 function renderWorker(worker: RedskilledStatuslineWorker, options: RedskilledStatuslineOptions): string {
-  const name = options.mode === "global" ? `${worker.project_label}:${worker.worker_id}` : worker.worker_id;
+  const name = workerName(worker, options);
   const used = worker.vitals.rss_bytes;
   // An unmeasured Worker says so. A zero here would read as an idle Worker, and
   // "nothing measured it" and "it is using nothing" are opposite facts.
@@ -249,6 +279,51 @@ function renderWorker(worker: RedskilledStatuslineWorker, options: RedskilledSta
       ? formatBytes(used)
       : `${formatBytes(used)}/${formatBytes(worker.budget.bytes)}`;
   return `${name} ${usage}`;
+}
+
+/**
+ * One second line per Worker that has actually logged something.
+ *
+ * The Worker is named again rather than left to position: the lines are printed
+ * under a first line whose entries may have been reordered or clamped away, and
+ * an unlabelled log line would belong to whichever Worker the reader guessed.
+ */
+function workerLogLines(
+  workers: readonly RedskilledStatuslineWorker[],
+  options: RedskilledStatuslineOptions,
+): readonly string[] {
+  const lines: string[] = [];
+  for (const worker of workers) {
+    const logged = flatten(worker.log.last_line);
+    if (logged == null) continue;
+    lines.push(clamp(`  ${LOG_LINE_MARK} ${workerName(worker, options)}: ${logged}`, options.maxWidth));
+  }
+  return lines;
+}
+
+/** The mark that says "this line belongs to the entry above it". */
+const LOG_LINE_MARK = "↳";
+
+/**
+ * A published line reduced to something that fits on one row. PURE.
+ *
+ * Whitespace — a newline included — is collapsed rather than escaped, and control
+ * characters are dropped: the daemon stored the string a Worker published
+ * verbatim, and this is the last moment before it becomes a terminal's line.
+ * Returns `null` when nothing survives, which is the same absence as no publish.
+ */
+function flatten(line: string | null): string | null {
+  if (line == null) return null;
+  const collapsed = line
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return collapsed === "" ? null : collapsed;
+}
+
+/** How one Worker is named on this line: owner-qualified in `global`. PURE. */
+function workerName(worker: RedskilledStatuslineWorker, options: RedskilledStatuslineOptions): string {
+  return options.mode === "global" ? `${worker.project_label}:${worker.worker_id}` : worker.worker_id;
 }
 
 function renderProject(project: RedskilledStatuslineProject): string {

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -40,6 +40,14 @@ export interface RedskilledWorkerSpec {
   readonly project_label: string;
   /** Used verbatim as the Worker's working directory. */
   readonly workspace_path: string;
+  /**
+   * Where this Worker will write its log, if the client wants it recoverable.
+   *
+   * Optional, and opaque: the daemon opens it only to rehydrate a heartbeat it
+   * lost to a restart. A client that gives none keeps the whole mechanism on the
+   * heartbeat, which is the normal path anyway.
+   */
+  readonly log_path?: string;
   readonly command: string;
   readonly args?: readonly string[];
   readonly env?: Readonly<Record<string, string>>;
@@ -213,6 +221,7 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     pid: child.pid,
     started_at: clock(),
     workspace_path: spec.workspace_path,
+    ...(spec.log_path != null ? { log_path: spec.log_path } : {}),
     isolated,
     ...(plan.unit != null ? { unit: plan.unit } : {}),
     ...(spec.budget != null ? { budget: spec.budget } : {}),

--- a/apps/redskilled/src/worker-log.ts
+++ b/apps/redskilled/src/worker-log.ts
@@ -1,0 +1,116 @@
+/**
+ * worker-log — the last line a Worker logged, as a published string.
+ *
+ * **The Worker publishes; the daemon stores.** The line travels on the Worker's
+ * heartbeat and the daemon never reads it for meaning — no level is parsed, no
+ * progress is inferred, no field is extracted. That is what keeps the global
+ * verbose view to ONE read: the line is already in the payload, so a statusline
+ * never opens a log, and the daemon never learns what a repository's log layout
+ * is (ADR 0130 rule 3).
+ *
+ * The rejected alternative looks easier and is worse: a statusline that read each
+ * Worker's log file directly would cost a disk read per Worker per render, cross a
+ * project boundary on every tick, and reintroduce exactly the private source the
+ * single-anchor rule forbids — a second authority on a question the payload
+ * already answers.
+ *
+ * **One bounded exception: a restart.** A daemon that has just come back holds
+ * Workers it has never heard a heartbeat from, and for those it may read the log
+ * ONCE — from the path it was GIVEN at spawn, never from a path it derives. A
+ * Worker whose client gave no log path simply has no line until it publishes one;
+ * guessing a filename inside its workspace would be the derived layout this whole
+ * design refuses.
+ */
+import { open, stat } from "node:fs/promises";
+
+/**
+ * One Worker's last logged line, and where the daemon got it.
+ *
+ * `source` is stated rather than inferred: a line recovered from disk after a
+ * restart is a bounded exception, and a reader that could not tell it from a
+ * published one would not be able to see the exception happening.
+ */
+export interface RedskilledWorkerLogLine {
+  /** Exactly what was published, unparsed and unclamped by the daemon. */
+  readonly line: string;
+  readonly published_at: string;
+  readonly source: "heartbeat" | "rehydrated";
+}
+
+/** How the daemon recovers a line after a restart; injected so a test can refuse it. */
+export type RedskilledLogTailProbe = (path: string) => Promise<string | null>;
+
+/**
+ * How much of a log's tail one recovery read may look at.
+ *
+ * A window rather than the whole file: the answer is one line, and a Worker's log
+ * can be hundreds of megabytes by the time a daemon restarts.
+ */
+export const REDSKILLED_LOG_TAIL_BYTES = 16 * 1024;
+
+/**
+ * How long a published line may be on the wire.
+ *
+ * Clamped by the PUBLISHER, never by the daemon: the daemon storing a string it
+ * shortened would be the daemon interpreting content, and the statusline clamps
+ * to the terminal's width anyway. This bound exists so a runaway log line cannot
+ * make a heartbeat expensive.
+ */
+export const REDSKILLED_LOG_LINE_MAX = 500;
+
+/**
+ * The last non-empty line of the file at `path`, or `null`.
+ *
+ * `null` covers every way this can come up empty — no such file, no permission,
+ * nothing but blank lines — because they all mean the same thing to the caller:
+ * this Worker has no line to show yet.
+ */
+export async function readLastLogLine(
+  path: string,
+  tailBytes: number = REDSKILLED_LOG_TAIL_BYTES,
+): Promise<string | null> {
+  let size: number;
+  try {
+    size = (await stat(path)).size;
+  } catch {
+    return null;
+  }
+  if (size <= 0) return null;
+
+  const length = Math.min(tailBytes, size);
+  let raw: string;
+  try {
+    const handle = await open(path, "r");
+    try {
+      const chunk = Buffer.alloc(length);
+      await handle.read(chunk, 0, length, size - length);
+      raw = chunk.toString("utf8");
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return null;
+  }
+  return lastNonEmptyLine(raw);
+}
+
+/**
+ * The last line of `raw` that carries anything. PURE.
+ *
+ * A trailing newline is a log at rest, not an empty last line, so it is skipped
+ * rather than reported as a blank the statusline would then have to hide.
+ */
+export function lastNonEmptyLine(raw: string): string | null {
+  const lines = raw.split("\n");
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]!.replace(/\r$/, "");
+    if (line.trim() !== "") return line;
+  }
+  return null;
+}
+
+/** A line trimmed to what a heartbeat may carry. PURE — publisher-side only. */
+export function clampPublishedLogLine(line: string, max: number = REDSKILLED_LOG_LINE_MAX): string {
+  const chars = [...line];
+  return chars.length <= max ? line : chars.slice(0, max).join("");
+}

--- a/apps/redskilled/tests/daemon-restart.test.ts
+++ b/apps/redskilled/tests/daemon-restart.test.ts
@@ -364,6 +364,7 @@ function laneEvent(event: RedskilledHostEvent["event"], workerId: string): Redsk
     project_label: "acme/widgets",
     pid: 4242,
     workspace_path: "/tmp/ws",
+    log_path: null,
     isolated: true,
     unit: `red-worker-${workerId}.service`,
     memory_high: "512M",

--- a/apps/redskilled/tests/demand-producer.test.ts
+++ b/apps/redskilled/tests/demand-producer.test.ts
@@ -473,6 +473,7 @@ describe("a death reported by the daemon drives the project's breaker", () => {
       project_label: "acme/widgets",
       pid: 4242,
       workspace_path: "/tmp/acme/w-1",
+      log_path: null,
       isolated: true,
       unit: "redskilled-w-1.service",
       memory_high: null,

--- a/apps/redskilled/tests/statusline-verbose.test.ts
+++ b/apps/redskilled/tests/statusline-verbose.test.ts
@@ -1,0 +1,383 @@
+// The verbose statusline gives each Worker a second line carrying the last line
+// it logged. The mechanism is the claim under test: the Worker PUBLISHES that
+// line on its heartbeat as an opaque string, the daemon stores and returns it
+// without ever interpreting it, and one read renders the whole global view — so
+// no render ever opens another project's files. The one bounded exception is a
+// restart, where the daemon rehydrates from the log path it was GIVEN at spawn.
+import { readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { runStatusline } from "../src/cli.js";
+import {
+  publishRedskilledWorkerLogLine,
+  readRedskilledStatuslinePayload,
+  readRedskilledStatuslineString,
+} from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { buildHostState, type RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { isRedskilledStatuslineRender } from "../src/protocol.js";
+import {
+  parseRedskilledStatuslineFlags,
+  readRedskilledStatuslineConfig,
+  resolveRedskilledStatuslineOptions,
+} from "../src/statusline-config.js";
+import {
+  REDSKILLED_STATUSLINE_DEFAULTS,
+  renderRedskilledStatusline,
+  type RedskilledStatuslineOptions,
+} from "../src/statusline-render.js";
+import { buildStatuslinePayload, type RedskilledStatuslinePayload } from "../src/statusline-payload.js";
+import type { RedskilledWorkerLogLine } from "../src/worker-log.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await scratch("redskilled-statusline-verbose-");
+  return resolveRedskilledPaths({ env: { REDSKILLED_SESSION: `test:${root}` }, runtimeDir: root });
+}
+
+function worker(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorkerView {
+  return {
+    worker_id: "w-1",
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-07-29T00:00:00.000Z",
+    workspace_path: "/tmp/acme/w-1",
+    isolated: true,
+    unit: "red-worker-acme-widgets-w-1.service",
+    budget: { memory_max: "1G" },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+const MB = 1024 * 1024;
+
+function payloadOf(
+  workers: readonly RedskilledWorkerView[],
+  rss: Record<string, number> = {},
+  logLines: Record<string, RedskilledWorkerLogLine> = {},
+): RedskilledStatuslinePayload {
+  return buildStatuslinePayload({
+    hostState: buildHostState({
+      daemonVersion: "0.1.0",
+      machineIdHash: "mach",
+      sessionKeyHash: "sess",
+      pid: 99,
+      startedAt: "2026-07-29T00:00:00.000Z",
+      workers,
+    }),
+    ceiling: UNBOUNDED_HOST_CEILING,
+    rss,
+    logLines,
+    sampledAt: "2026-07-29T01:00:00.000Z",
+    now: "2026-07-29T01:00:05.000Z",
+  });
+}
+
+function published(line: string): RedskilledWorkerLogLine {
+  return { line, published_at: "2026-07-29T01:00:04.000Z", source: "heartbeat" };
+}
+
+function options(overrides: Partial<RedskilledStatuslineOptions> = {}): RedskilledStatuslineOptions {
+  return { ...REDSKILLED_STATUSLINE_DEFAULTS, ...overrides };
+}
+
+describe("the verbose statusline", () => {
+  it("gives each Worker a second line in the local mode", () => {
+    const payload = payloadOf(
+      [worker(), worker({ worker_id: "w-2", pid: 43, workspace_path: "/tmp/acme/w-2" })],
+      { "w-1": 512 * MB, "w-2": 128 * MB },
+      { "w-1": published("running the gate: 41 files"), "w-2": published("waiting on PR checks") },
+    );
+
+    const render = renderRedskilledStatusline(payload, options({ project: "acme/widgets", verbose: true }));
+
+    expect(render.verbose).toBe(true);
+    expect(render.lines).toHaveLength(3);
+    expect(render.lines[0]).toBe(render.line);
+    expect(render.lines[1]).toContain("w-1");
+    expect(render.lines[1]).toContain("running the gate: 41 files");
+    expect(render.lines[2]).toContain("waiting on PR checks");
+  });
+
+  it("gives each Worker a second line in the global mode, still naming its owner", () => {
+    const payload = payloadOf(
+      [worker(), worker({ worker_id: "w-2", project_label: "acme/gadgets", pid: 43 })],
+      { "w-1": 512 * MB, "w-2": 128 * MB },
+      { "w-1": published("gate green"), "w-2": published("rebasing onto main") },
+    );
+
+    const render = renderRedskilledStatusline(
+      payload,
+      options({ mode: "global", project: "acme/widgets", verbose: true }),
+    );
+
+    expect(render.detail).toBe("workers");
+    expect(render.lines).toHaveLength(3);
+    expect(render.lines[1]).toContain("acme/widgets:w-1");
+    expect(render.lines[1]).toContain("gate green");
+    expect(render.lines[2]).toContain("acme/gadgets:w-2");
+    expect(render.lines[2]).toContain("rebasing onto main");
+  });
+
+  it("renders no empty or broken second line for a Worker that has logged nothing", () => {
+    const payload = payloadOf(
+      [worker(), worker({ worker_id: "w-2", pid: 43 })],
+      { "w-1": 512 * MB, "w-2": 128 * MB },
+      // `w-2` published nothing; `w-1` published only whitespace, which is the
+      // same absence wearing a different disguise.
+      { "w-1": published("   ") },
+    );
+
+    const render = renderRedskilledStatusline(payload, options({ project: "acme/widgets", verbose: true }));
+
+    expect(render.lines).toHaveLength(1);
+    expect(render.lines[0]).toBe(render.line);
+    for (const line of render.lines) expect(line.trim()).not.toBe("");
+  });
+
+  it("keeps a published newline out of the line contract and honours the width", () => {
+    const payload = payloadOf(
+      [worker()],
+      { "w-1": 512 * MB },
+      { "w-1": published("first\nsecond\tthird   fourth fifth sixth seventh eighth") },
+    );
+
+    const render = renderRedskilledStatusline(
+      payload,
+      // Wide enough for the Worker entry, far too narrow for the published line:
+      // the second line answers to the same clamp as the first.
+      options({ project: "acme/widgets", verbose: true, maxWidth: 34 }),
+    );
+
+    expect(render.lines).toHaveLength(2);
+    for (const line of render.lines) {
+      expect(line).not.toContain("\n");
+      expect([...line].length).toBeLessThanOrEqual(34);
+    }
+    // Collapsed, not re-interpreted: the words survive in the order published.
+    expect(render.lines[1]).toContain("first second");
+    expect(render.lines[1].endsWith("…")).toBe(true);
+  });
+
+  it("annotates nothing once the line has degraded past the Workers", () => {
+    const workers = Array.from({ length: 6 }, (_, index) =>
+      worker({ worker_id: `w-${index}`, project_label: `acme/project-${index}`, pid: 5000 + index }));
+    const payload = payloadOf(
+      workers,
+      Object.fromEntries(workers.map((w) => [w.worker_id, 256 * MB])),
+      Object.fromEntries(workers.map((w) => [w.worker_id, published(`working on ${w.worker_id}`)])),
+    );
+
+    const render = renderRedskilledStatusline(
+      payload,
+      options({ mode: "global", verbose: true, maxWorkers: 3, maxProjects: 6, maxWidth: 400 }),
+    );
+
+    // A second line belongs to a Worker entry; with no Worker entries on the
+    // line there is nothing for one to be the second line OF.
+    expect(render.detail).toBe("projects");
+    expect(render.lines).toHaveLength(1);
+  });
+});
+
+describe("the line the Worker publishes", () => {
+  it("arrives through the heartbeat and comes back byte-identical", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      stopWorker: () => true,
+      clock: () => "2026-07-29T01:00:05.000Z",
+      memorySampler: () => ({ "w-1": 512 * MB }),
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+
+    // Content the daemon must not read for meaning: another surface's syntax, a
+    // key/value pair, a level marker. It stores a string and returns a string.
+    const opaque = 'host 9w/9p [error] {"detail":"nope"} · stale 60s';
+    const ack = await publishRedskilledWorkerLogLine(
+      paths,
+      { worker_id: "w-1", line: opaque },
+      { sessionProject: "acme/widgets" },
+    );
+    expect(ack.accepted).toBe(true);
+
+    const payload = await readRedskilledStatuslinePayload(paths, { sessionProject: "acme/widgets" });
+    expect(payload.workers[0]?.log.last_line).toBe(opaque);
+    expect(payload.workers[0]?.log.source).toBe("heartbeat");
+
+    const asked = options({ project: "acme/widgets", verbose: true, maxWidth: 400 });
+    const render = await readRedskilledStatuslineString(paths, asked, { sessionProject: "acme/widgets" });
+    expect(isRedskilledStatuslineRender(render)).toBe(true);
+    expect(render.lines).toEqual(renderRedskilledStatusline(payload, asked).lines);
+    expect(render.lines[1]).toContain(opaque);
+  });
+
+  it("is refused from a session in another project, and never stored", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      stopWorker: () => true,
+      clock: () => "2026-07-29T01:00:05.000Z",
+      memorySampler: () => ({}),
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+
+    await expect(
+      publishRedskilledWorkerLogLine(paths, { worker_id: "w-1", line: "not mine to say" }, {
+        sessionProject: "acme/gadgets",
+      }),
+    ).rejects.toThrow(/refused/);
+
+    const payload = await readRedskilledStatuslinePayload(paths, { sessionProject: "acme/widgets" });
+    expect(payload.workers[0]?.log.last_line).toBeNull();
+  });
+
+  it("renders the whole global view from that one read, opening no project's files", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      stopWorker: () => true,
+      clock: () => "2026-07-29T01:00:05.000Z",
+      memorySampler: () => ({ "w-1": 512 * MB, "w-2": 128 * MB }),
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+    daemon.trackWorker(worker({ worker_id: "w-2", project_label: "acme/gadgets", pid: 43 }));
+    for (const [id, project] of [["w-1", "acme/widgets"], ["w-2", "acme/gadgets"]] as const) {
+      await publishRedskilledWorkerLogLine(paths, { worker_id: id, line: `busy in ${project}` }, {
+        sessionProject: project,
+      });
+    }
+
+    const cwd = await scratch("redskilled-verbose-project-");
+    await mkdir(join(cwd, ".red"), { recursive: true });
+    await writeFile(
+      join(cwd, ".red", "config.yaml"),
+      ["project:", "  name: acme/widgets", ""].join("\n"),
+      "utf8",
+    );
+
+    const written: string[] = [];
+    const code = await runStatusline(["global", "--verbose", "--max-width", "400"], {
+      cwd,
+      paths,
+      write: (line) => written.push(line),
+      warn: () => undefined,
+    });
+
+    // One write, one read: both projects' second lines are already in the single
+    // payload the daemon served, so nothing has to go looking for a log.
+    expect(code).toBe(0);
+    expect(written).toHaveLength(1);
+    const lines = written[0].trimEnd().split("\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toContain("busy in acme/widgets");
+    expect(lines[2]).toContain("busy in acme/gadgets");
+
+    // The renderer could not open a foreign project's log even if it wanted to:
+    // it is a pure function of the payload and reaches no filesystem at all.
+    const source = readFileSync(join(import.meta.dirname, "..", "src", "statusline-render.ts"), "utf8");
+    expect(source).not.toMatch(/from "node:fs/);
+  });
+});
+
+describe("a restart with no information", () => {
+  it("rehydrates from the log path it was given, and never from a derived layout", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-verbose-workspace-");
+    const given = join(workspace, "given.log");
+    await writeFile(given, "earlier line\nthe last line it logged\n", "utf8");
+    // A file a layout-guessing daemon would find inside the workspace. Reading it
+    // would be the private source the single-anchor rule forbids.
+    await writeFile(join(workspace, "worker.log"), "a layout the daemon must not assume\n", "utf8");
+
+    const first = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      stopWorker: () => true,
+      clock: () => "2026-07-29T01:00:05.000Z",
+      memorySampler: () => ({}),
+    });
+    first.trackWorker(worker({ workspace_path: workspace, log_path: given }));
+    first.trackWorker(worker({ worker_id: "w-2", pid: 43, workspace_path: workspace }));
+    await first.flushEvents();
+    await first.stop();
+
+    const second = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      stopWorker: () => true,
+      clock: () => "2026-07-29T01:05:00.000Z",
+      memorySampler: () => ({}),
+      // The host still confirms both Workers, so the daemon holds two Workers it
+      // has never heard a heartbeat from — the one state that permits a read.
+      liveness: () => true,
+    });
+    running.push(second);
+
+    const payload = second.statuslinePayload();
+    const rehydrated = payload.workers.find((w) => w.worker_id === "w-1");
+    const unknown = payload.workers.find((w) => w.worker_id === "w-2");
+
+    expect(rehydrated?.log.last_line).toBe("the last line it logged");
+    expect(rehydrated?.log.source).toBe("rehydrated");
+    // No log path was given for `w-2`, so there is no path to read — a daemon
+    // that guessed `workspace/worker.log` would have found one.
+    expect(unknown?.log.last_line).toBeNull();
+    expect(JSON.stringify(payload)).not.toContain("a layout the daemon must not assume");
+  });
+});
+
+describe("the verbose taste", () => {
+  it("is declarable in config and overridable by a flag", () => {
+    const config = ["plugins:", "  dev:", "    statusline:", "      verbose: true"].join("\n");
+    expect(readRedskilledStatuslineConfig(config).config.verbose).toBe(true);
+    expect(resolveRedskilledStatuslineOptions({ configText: config }).options.verbose).toBe(true);
+
+    const { flags } = parseRedskilledStatuslineFlags(["--no-verbose"]);
+    expect(resolveRedskilledStatuslineOptions({ configText: config, flags }).options.verbose).toBe(false);
+    expect(parseRedskilledStatuslineFlags(["--verbose"]).flags.verbose).toBe(true);
+    expect(REDSKILLED_STATUSLINE_DEFAULTS.verbose).toBe(false);
+  });
+
+  it("ignores and names a malformed declaration instead of refusing to render", () => {
+    const broken = ["plugins:", "  dev:", "    statusline:", "      verbose: loud"].join("\n");
+    const resolved = resolveRedskilledStatuslineOptions({ configText: broken });
+
+    expect(resolved.options.verbose).toBe(false);
+    expect(resolved.warnings.map((w) => w.reason)).toEqual(["expected `true` or `false`"]);
+  });
+});

--- a/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -201,6 +201,10 @@ Nothing to install: OpenCode is an AFK API-auth runner lane (`--runner opencode`
 | `redskilled statusline` | the local project's Workers only — the quiet default |
 | `redskilled statusline global` | every project's Workers, each entry naming its owning project |
 | `redskilled statusline --max-width 60` | the same, under a narrower line |
+| `redskilled statusline --verbose` | each listed Worker plus a second line: the last line it logged |
+| `redskilled statusline global --verbose` | the same, machine-wide, each second line naming its Worker's owner |
+
+**The second line comes from the Worker, never from its log file.** With `--verbose` each listed Worker gets one extra line carrying the last line it logged. The Worker **publishes** that line on its heartbeat and the daemon stores it as an opaque string — so a verbose global view is still one read and opens no other project's files. A statusline that read each Worker's log directly would cost a disk read per Worker per render and cross a project boundary on every tick. A Worker that has logged nothing renders no second line, and the annotation disappears entirely once the line degrades past the Worker entries — a second line belongs to a Worker entry, and an aggregate row has no Worker to be the second line of.
 
 **A crowded machine degrades rather than overflowing.** Too many Workers for the count budget or the width drops the line to one entry per project; too many projects drops it to the host total (`host 6w/6p 1.5G`). The statusline answers "who is using this machine and how much" — the full picture stays with `/afk dashboard` and `/afk monitor`.
 
@@ -216,6 +220,7 @@ plugins:
       max_workers: 4       # Worker entries before the line drops to projects
       max_projects: 4      # project entries before the line drops to the host total
       max_width: 120       # hard ceiling in characters; the line never exceeds it
+      verbose: false       # `true` gives each Worker a second line: its last logged line
 ```
 
 Config is read **client-side** and only decided values cross the socket — the daemon must never learn what a `.red/config.yaml` is (ADR 0130 rule 3). A malformed value is named on stderr and ignored: this line renders on every turn, and a blank statusline is the harder failure to diagnose than a wrong `max_width`.

--- a/packaging/pi/dev/skills/engineering/red-statusline/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/red-statusline/SKILL.md
@@ -37,7 +37,7 @@ disable-model-invocation: true
 
 ## 5. Report The Worker Modes
 
-**Never render the Worker line yourself.** The daemon serves it finished — `redskilled statusline` prints the local project's Workers, `redskilled statusline global` prints every project's and names the owner of each. A host that formatted its own line would be the second renderer that drifts from the first (ADR 0130 rule 10).
+**Never render the Worker line yourself.** The daemon serves it finished — `redskilled statusline` prints the local project's Workers, `redskilled statusline global` prints every project's and names the owner of each, and `--verbose` adds one second line per Worker carrying the last line that Worker logged. A host that formatted its own line would be the second renderer that drifts from the first (ADR 0130 rule 10).
 
 **State the mode and the declared defaults, do not guess them.** Read `plugins.dev.statusline.*` from `.red/config.yaml` and report what it declares; the keys are in [HOST-NOTES.md](HOST-NOTES.md#worker-statusline-modes-and-config).
 

--- a/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -201,6 +201,10 @@ Nothing to install: OpenCode is an AFK API-auth runner lane (`--runner opencode`
 | `redskilled statusline` | the local project's Workers only — the quiet default |
 | `redskilled statusline global` | every project's Workers, each entry naming its owning project |
 | `redskilled statusline --max-width 60` | the same, under a narrower line |
+| `redskilled statusline --verbose` | each listed Worker plus a second line: the last line it logged |
+| `redskilled statusline global --verbose` | the same, machine-wide, each second line naming its Worker's owner |
+
+**The second line comes from the Worker, never from its log file.** With `--verbose` each listed Worker gets one extra line carrying the last line it logged. The Worker **publishes** that line on its heartbeat and the daemon stores it as an opaque string — so a verbose global view is still one read and opens no other project's files. A statusline that read each Worker's log directly would cost a disk read per Worker per render and cross a project boundary on every tick. A Worker that has logged nothing renders no second line, and the annotation disappears entirely once the line degrades past the Worker entries — a second line belongs to a Worker entry, and an aggregate row has no Worker to be the second line of.
 
 **A crowded machine degrades rather than overflowing.** Too many Workers for the count budget or the width drops the line to one entry per project; too many projects drops it to the host total (`host 6w/6p 1.5G`). The statusline answers "who is using this machine and how much" — the full picture stays with `/afk dashboard` and `/afk monitor`.
 
@@ -216,6 +220,7 @@ plugins:
       max_workers: 4       # Worker entries before the line drops to projects
       max_projects: 4      # project entries before the line drops to the host total
       max_width: 120       # hard ceiling in characters; the line never exceeds it
+      verbose: false       # `true` gives each Worker a second line: its last logged line
 ```
 
 Config is read **client-side** and only decided values cross the socket — the daemon must never learn what a `.red/config.yaml` is (ADR 0130 rule 3). A malformed value is named on stderr and ignored: this line renders on every turn, and a blank statusline is the harder failure to diagnose than a wrong `max_width`.

--- a/plugins/dev/skills/engineering/red-statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/red-statusline/SKILL.md
@@ -37,7 +37,7 @@ disable-model-invocation: true
 
 ## 5. Report The Worker Modes
 
-**Never render the Worker line yourself.** The daemon serves it finished — `redskilled statusline` prints the local project's Workers, `redskilled statusline global` prints every project's and names the owner of each. A host that formatted its own line would be the second renderer that drifts from the first (ADR 0130 rule 10).
+**Never render the Worker line yourself.** The daemon serves it finished — `redskilled statusline` prints the local project's Workers, `redskilled statusline global` prints every project's and names the owner of each, and `--verbose` adds one second line per Worker carrying the last line that Worker logged. A host that formatted its own line would be the second renderer that drifts from the first (ADR 0130 rule 10).
 
 **State the mode and the declared defaults, do not guess them.** Read `plugins.dev.statusline.*` from `.red/config.yaml` and report what it declares; the keys are in [HOST-NOTES.md](HOST-NOTES.md#worker-statusline-modes-and-config).
 


### PR DESCRIPTION
Automated AFK landing for #2793. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2793

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787969884&installation_model_id=20659&pr_number=2834&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2834&signature=11c76e904ea65332afb85b88da2757b39c48682f5df9bf8e8cf6d7f183fb1a73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->