### PR TITLE
chore: enforce and document the Gemini manifest surface

### DIFF
--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -142,6 +142,10 @@ jobs:
         if: needs.scope.outputs.run_manifest_checks == 'true'
         run: pnpm codex:manifests:check
 
+      - name: Check generated Gemini manifests
+        if: needs.scope.outputs.run_manifest_checks == 'true'
+        run: pnpm gemini:manifests:check
+
       - name: Check generated Pi manifests
         if: needs.scope.outputs.run_manifest_checks == 'true'
         run: pnpm pi:manifests:check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ red-skills/                         ← repo root + marketplace
 │   └── marketplace.json            ← marketplace manifest, lists every plugin
 ├── .agents/
 │   └── plugins/marketplace.json    ← Codex marketplace manifest
+├── .gemini-plugin/
+│   └── marketplace.json            ← Gemini CLI marketplace manifest
 ├── .red/
 │   ├── CONTEXT.md                  ← compatibility pointer; start at CONTEXT-MAP.md
 │   ├── CONTEXT-MAP.md              ← multi-context glossary entry point
@@ -40,6 +42,7 @@ red-skills/                         ← repo root + marketplace
     ├── dev/                        ← shipped `dev` plugin definition
     │   ├── .claude-plugin/plugin.json
     │   ├── .codex-plugin/plugin.json
+    │   ├── .gemini-plugin/plugin.json
     │   └── skills/
     │       ├── engineering/        ← day-to-day code work
     │       ├── knowledge/          ← knowledge accumulation and curation (LLM Wiki pattern)
@@ -60,10 +63,13 @@ repo root — with shared dependency versions consolidated into a pnpm `catalog:
 
 Future plugins (e.g. `data`, `ops`) live as additional siblings under
 `plugins/` with their own `.claude-plugin/plugin.json`, generated
-`.codex-plugin/plugin.json`, and their own `skills/` tree. Each plugin appears
-as a separate entry in the Claude marketplace manifest; the Codex marketplace
-manifest is generated from it. Any runtime code for a plugin lives under
-`apps/<plugin>/`.
+`.codex-plugin/plugin.json` and `.gemini-plugin/plugin.json`, and their own
+`skills/` tree. **The Claude-side manifest is the source; Codex and Gemini are
+projections of it.** Each plugin appears as a separate entry in the Claude
+marketplace manifest, and the Codex and Gemini marketplace manifests are
+generated from it — which is why the marketplace validation asserts that all
+three list exactly the same plugin names. Any runtime code for a plugin lives
+under `apps/<plugin>/`.
 
 `personal/` and `deprecated/` were removed from upstream and **must not be recreated**.
 


### PR DESCRIPTION
Completes the Gemini CLI integration landed in #2840. Two gaps, one of them load-bearing.

**CI never checked the Gemini manifests.** The generator ships a `--check` mode and CLAUDE.md rule 2 tells readers the manifests are generated artifacts, but the workspace CI only ran `codex:manifests:check` and `pi:manifests:check`. A generated artifact nobody verifies is a file that drifts silently — and it would drift into a *published* marketplace manifest. The check now runs alongside the other two.

**The structure diagram never mentioned the surface.** No `.gemini-plugin/` at the root or under a plugin, so a reader had no way to learn it exists. Both added.

The 'future plugins' paragraph now also states the relationship the marketplace validation already enforces but nobody had written down: the Claude-side manifest is the source, Codex and Gemini are projections of it, and all three must list exactly the same plugin names.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787980553&installation_model_id=20659&pr_number=2841&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2841&signature=edf8c970d2159eaf0e12cace2399e23680fc57f39bbca5361710f73f9dcdc083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->