### PR TITLE
feat: every shipped binary can state its own version

### DIFF
--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -21,6 +21,7 @@
     "serve": "tsx src/cli.ts serve"
   },
   "dependencies": {
+    "@reddb-io/build-info": "workspace:*",
     "@reddb-io/shared": "workspace:*",
     "@reddb-io/toon": "catalog:"
   },

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -8,6 +8,7 @@
  * bundle versions. A path it needs is a path it was given.
  */
 import { readFileSync } from "node:fs";
+import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
 import { parseFlags, routeCommand } from "@reddb-io/shared/args.js";
 import { findUp } from "@reddb-io/shared/plugin-gate.js";
 import { declaredProjectNameInConfig } from "@reddb-io/shared/project-identity.js";
@@ -30,6 +31,17 @@ const SERVE_FLAGS = {
 } as const;
 
 export async function runRedskilledCli(argv: readonly string[]): Promise<number> {
+  // Answered before routing, because the daemon's own version is the fact a
+  // skew investigation starts from — and `serve` takes `--daemon-version` from
+  // its caller, so the binary must still be able to state what IT is.
+  if (argv[0] === "--version" || argv[0] === "-v") {
+    const info = readBuildInfo("redskilled");
+    process.stdout.write(
+      argv.includes("--json") ? `${JSON.stringify(info)}\n` : `${renderVersion(info)}\n`,
+    );
+    return 0;
+  }
+
   const { command, args } = routeCommand<"serve" | "host-state" | "statusline">(argv, {
     commands: { serve: {}, "host-state": {}, statusline: {} },
     default: "host-state",

--- a/apps/rsp/src/cli/main.ts
+++ b/apps/rsp/src/cli/main.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { type JsonObject } from "@reddb-io/toon";
 import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
-import { readBuildInfo } from "@reddb-io/build-info";
+import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
 import { renderStructuredError } from "../structured-error.js";
 import {
   isHelpRequest,
@@ -34,6 +34,15 @@ import { LazyRspElisionStore, runColdWrappedCommand } from "./store-lifecycle.js
 
 async function main(argv = process.argv.slice(2)): Promise<number> {
   const buildInfo = readBuildInfo("rsp");
+  // Answered before enablement, config, or the resident: "which build is this?"
+  // must stay answerable in exactly the situation you need to ask it — a
+  // directory that never opted in, a host with no socket, a degraded shell.
+  if (argv[0] === "--version" || argv[0] === "-v") {
+    process.stdout.write(
+      argv.includes("--json") ? `${JSON.stringify(buildInfo)}\n` : `${renderVersion(buildInfo)}\n`,
+    );
+    return 0;
+  }
   if (isHelpRequest(argv)) {
     process.stdout.write(renderCliHelp(argv));
     return 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
 
   apps/redskilled:
     dependencies:
+      '@reddb-io/build-info':
+        specifier: workspace:*
+        version: link:../../packages/build-info
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../../packages/shared

--- a/scripts/bundle-app.mjs
+++ b/scripts/bundle-app.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const args = parseArgs(process.argv.slice(2));
 
@@ -13,7 +14,30 @@ if (!args.entry || !args.outfile || !args.asset) {
 }
 
 const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
-const version = (process.env.RED_BUILD_VERSION || pkg.version || "0.0.0-dev").replace(/^v/, "");
+
+// The product has ONE version anchor — the same `apps/dev/package.json` that
+// scripts/sync-version.mjs calls SOURCE — and every bundle carries it.
+//
+// Reading the *cwd's* package.json instead was wrong for the bundles that ship
+// inside the product without being published on their own: `rsp` sat at 2.23.1
+// and `redskilled` at 0.1.0 while the product was at 2.88.x, so a locally built
+// binary reported a version that corresponded to nothing. A release was correct
+// only because RED_BUILD_VERSION overrode it — the fallback was the lie.
+const PRODUCT_VERSION_ANCHOR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "apps/dev/package.json",
+);
+const anchorVersion = readAnchorVersion(PRODUCT_VERSION_ANCHOR);
+const version = (process.env.RED_BUILD_VERSION || anchorVersion || pkg.version || "0.0.0-dev").replace(/^v/, "");
+
+function readAnchorVersion(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")).version;
+  } catch {
+    return undefined;
+  }
+}
 const gitSha = process.env.RED_BUILD_GIT_SHA || "unknown";
 const buildTime =
   process.env.RED_BUILD_TIME ||


### PR DESCRIPTION
Follow-up to today's version-skew incidents. The daemon relaunch (#2808) and the `fleet_status` report (#2809) both turned on "which version is this?" — and two of the binaries in that conversation could not answer.

**`rsp --version` returned a usage error. `redskilled` had no version surface at all.** `red-skills-dev` has had one all along. Both now accept `--version`/`-v` with optional `--json`, answered *before* enablement, config, or the resident is contacted — a skew investigation happens in a directory that never opted in, or on a host whose socket is gone, and the answer has to survive that.

**The root cause was in the bundler.** `scripts/bundle-app.mjs` stamped `__RED_BUILD_VERSION__` from the **CWD's** `package.json`, so each bundle carried its own package's number:

| bundle | stamped | product |
| --- | --- | --- |
| rsp | 2.23.1 | 2.88.1 |
| redskilled | 0.1.0 | 2.88.1 |

Neither is published on its own — both are `private: true` and ship inside the product bundle — so those numbers described nothing at all. A *release* was correct only because the publish workflow overrides `RED_BUILD_VERSION`; the fallback was the lie, and the fallback is what every local build used. The bundler now reads the same single anchor `scripts/sync-version.mjs` already calls `SOURCE` (`apps/dev/package.json`), and the env override still wins.

`redskilled` also gained the `@reddb-io/build-info` dependency it needed and did not declare.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788006668&installation_model_id=20659&pr_number=2847&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2847&signature=47f480978bf0dceccef37ae963efb680f53195fa5e9dedd8dffabc718a28e020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->