### PR TITLE
fix: the Gemini changeset names a package that exists

### DIFF
--- a/.changeset/gemini-cli-integration.md
+++ b/.changeset/gemini-cli-integration.md
@@ -1,5 +1,5 @@
 ---
-"red-skills": minor
+"@reddb-io/red-skills": minor
 ---
 
-Added native support for the Gemini CLI by generating `.gemini-plugin` metadata from the Claude source-of-truth.
+Generate `.gemini-plugin` manifests so RedSkills installs in Gemini CLI, projected from the Claude-side manifest that remains the source of truth.


### PR DESCRIPTION
**Every release has been failing since 12:25 today.** Three consecutive `red-release` runs died at the version job with:

```
Error: Found changeset gemini-cli-integration for package red-skills
which is not in the workspace
```

The changeset said `"red-skills"`; every other changeset in the repo says `"@reddb-io/red-skills"`. The scope was missing, the package does not exist, and `changeset version` aborts the **entire** release plan on one unknown package rather than skipping it — so 2.88.1 never published and the merged work piled up behind a silent gate.

The bad name arrived with a copied diff instead of being written against this workspace. `npx changeset status` now resolves the plan cleanly at minor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788008067&installation_model_id=20659&pr_number=2848&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2848&signature=22302dd4ff44649fc5459008f342608c773a7fa879f8ec8017ea833f1304d47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->