### PR TITLE
fix: #2863 A changeset naming a package outside the workspace blocks every release, and nothing catches it at PR time

### DIFF
--- a/.changeset/a-changeset-is-resolved-while-the-pr-is-open.md
+++ b/.changeset/a-changeset-is-resolved-while-the-pr-is-open.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A changeset that cannot resolve now fails its own PR instead of the next release (#2863). `changeset version` does not skip a file naming a package outside the workspace — it throws and abandons the whole release plan, so one file saying `"red-skills"` where every other one says `"@reddb-io/red-skills"` failed three consecutive release runs, left npm on the previous version, and reported nothing until someone opened the job log. `scripts/validate-changesets.mjs` resolves every pending changeset against the `pnpm-workspace.yaml` globs with no dependency on an installed `@changesets/cli`, names the offending file, the unknown package and the scoped name the author meant, and passes a repository with no pending changesets. It runs in `workflow-security` on purpose: `.changeset/` is inert to the affected-cone scoper, so a changeset-only PR narrows every other job away and that is exactly the PR carrying the defect.

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -98,6 +98,17 @@ jobs:
       - name: Test version sync contract
         run: scripts/test-version-sync-contract.sh
 
+      # ADR 0121: a changeset that cannot resolve does not get skipped — it
+      # throws and abandons the whole release plan, so one bad file fails every
+      # release after it (#2863). This job is the only one a changeset-only PR
+      # reaches: `.changeset/` is INERT to scripts/ci-affected-scope.mjs, so the
+      # test and typecheck jobs narrow themselves away on exactly that PR.
+      - name: Validate pending changesets resolve against the workspace
+        run: node scripts/validate-changesets.mjs
+
+      - name: Test changeset validation contract
+        run: scripts/test-validate-changesets.sh
+
       - name: Test red-castle vendor contract
         run: scripts/test-red-castle-vendor-contract.sh
 

--- a/scripts/test-validate-changesets.sh
+++ b/scripts/test-validate-changesets.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Contract tests for scripts/validate-changesets.mjs — the PR-time check that a
+# pending changeset actually resolves against this workspace (#2863).
+#
+# The outage this pins: one changeset said `"red-skills"` (the ROOT manifest's
+# name, which is not a workspace package) where every other one says
+# `"@reddb-io/red-skills"`. `changeset version` does not skip a bad file — it
+# throws and abandons the whole release plan, so three consecutive red-release
+# runs failed at the version job and npm stayed on the previous version. Nothing
+# ran `changeset status` while the PR was open, so the defect was only
+# detectable after merge, at the one moment it was most expensive.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+SCRIPT="$ROOT/scripts/validate-changesets.mjs"
+failures=0
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; failures=$((failures + 1)); }
+pass() { printf 'PASS: %s\n' "$*"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A throwaway workspace with the same shape as this repo: two package roots, a
+# scoped package name, and a root manifest whose name is NOT a workspace member.
+new_fixture() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir/.changeset" "$dir/apps/dev" "$dir/apps/bundle" "$dir/packages/shared"
+  cat > "$dir/pnpm-workspace.yaml" <<'YAML'
+packages:
+  - "apps/*"
+  - "packages/*"
+
+catalog:
+  typescript: ^5.6.0
+YAML
+  printf '{"name":"red-skills","private":true}\n' > "$dir/package.json"
+  printf '{"name":"@reddb-io/dev"}\n' > "$dir/apps/dev/package.json"
+  printf '{"name":"@reddb-io/red-skills"}\n' > "$dir/apps/bundle/package.json"
+  printf '{"name":"@reddb-io/shared"}\n' > "$dir/packages/shared/package.json"
+  printf 'Changesets live here.\n' > "$dir/.changeset/README.md"
+  printf '{"baseBranch":"main"}\n' > "$dir/.changeset/config.json"
+  printf '%s' "$dir"
+}
+
+changeset() { # <fixture-dir> <name> <frontmatter-body>
+  { printf -- '---\n%s\n---\n\nA summary line.\n' "$3"; } > "$1/.changeset/$2.md"
+}
+
+run_on() { # <fixture-dir> -> stdout+stderr, exit code preserved by caller
+  node "$SCRIPT" --root "$1" 2>&1
+}
+
+# --- the committed checkout resolves ---------------------------------------
+
+if node "$SCRIPT" >/dev/null 2>&1; then
+  pass "every changeset committed in this checkout resolves against the workspace"
+else
+  fail "this checkout carries a changeset that cannot resolve — the release would abort"
+  node "$SCRIPT" || true
+fi
+
+# --- a valid changeset passes ----------------------------------------------
+
+good="$(new_fixture good)"
+changeset "$good" "a-real-slice" '"@reddb-io/dev": patch'
+if node "$SCRIPT" --root "$good" >/dev/null 2>&1; then
+  pass "a changeset naming a workspace package passes"
+else
+  fail "a valid changeset must pass"
+  run_on "$good" || true
+fi
+
+# Several packages and every accepted bump, in one file.
+changeset "$good" "a-wide-slice" '"@reddb-io/dev": minor
+"@reddb-io/shared": none'
+if node "$SCRIPT" --root "$good" >/dev/null 2>&1; then
+  pass "a multi-package changeset with major/minor/patch/none bumps passes"
+else
+  fail "every bump changesets accepts (including \`none\`) must pass"
+  run_on "$good" || true
+fi
+
+# An empty frontmatter block is a valid changeset that releases nothing.
+changeset "$good" "an-empty-one" ''
+if node "$SCRIPT" --root "$good" >/dev/null 2>&1; then
+  pass "a changeset with an empty frontmatter block passes"
+else
+  fail "an empty changeset releases nothing and must not be rejected"
+  run_on "$good" || true
+fi
+
+# --- an unknown package name fails -----------------------------------------
+
+bad="$(new_fixture bad)"
+changeset "$bad" "names-a-stranger" '"@reddb-io/nowhere": patch'
+if node "$SCRIPT" --root "$bad" >/dev/null 2>&1; then
+  fail "a changeset naming a package outside the workspace must exit non-zero"
+else
+  pass "a changeset naming a package outside the workspace exits non-zero"
+fi
+
+out="$(run_on "$bad" || true)"
+if grep -qF 'names-a-stranger.md' <<<"$out"; then
+  pass "the failure names the offending changeset file"
+else
+  fail "the failure must name the offending file"
+  printf '%s\n' "$out" >&2
+fi
+if grep -qF '@reddb-io/nowhere' <<<"$out"; then
+  pass "the failure names the unknown package"
+else
+  fail "the failure must name the unknown package"
+  printf '%s\n' "$out" >&2
+fi
+
+# --- the exact outage: the ROOT manifest's name is not a workspace package ---
+
+incident="$(new_fixture incident)"
+changeset "$incident" "gemini-cli-integration" '"red-skills": minor'
+if node "$SCRIPT" --root "$incident" >/dev/null 2>&1; then
+  fail "the root manifest's name is not a workspace package — it must be rejected"
+else
+  pass "the root manifest's name is rejected exactly as \`changeset version\` rejects it"
+fi
+
+out="$(run_on "$incident" || true)"
+if grep -qF 'did you mean "@reddb-io/red-skills"' <<<"$out"; then
+  pass "the failure points at the scoped workspace name the author meant"
+else
+  fail "an unknown name matching exactly one scoped package must suggest that package"
+  printf '%s\n' "$out" >&2
+fi
+
+# Ambiguity must not become a confident wrong answer.
+ambiguous="$(new_fixture ambiguous)"
+printf '{"name":"@other/dev"}\n' > "$ambiguous/packages/shared/package.json"
+changeset "$ambiguous" "ambiguous-suffix" '"dev": patch'
+if grep -qF 'did you mean' <<<"$(run_on "$ambiguous" || true)"; then
+  fail "two packages ending in /dev must yield no suggestion, not a guess"
+else
+  pass "an ambiguous suffix yields no suggestion rather than a wrong one"
+fi
+
+# --- an unrecognized bump fails --------------------------------------------
+
+bump="$(new_fixture bump)"
+changeset "$bump" "typoed-bump" '"@reddb-io/dev": pathc'
+if node "$SCRIPT" --root "$bump" >/dev/null 2>&1; then
+  fail "an unrecognized bump aborts the same release plan and must be rejected"
+else
+  pass "an unrecognized bump is rejected"
+fi
+if grep -qF 'pathc' <<<"$(run_on "$bump" || true)"; then
+  pass "the failure names the unrecognized bump"
+else
+  fail "the failure must name the unrecognized bump"
+fi
+
+# --- no pending changesets passes, it does not error ------------------------
+
+empty="$(new_fixture empty)"
+if node "$SCRIPT" --root "$empty" >/dev/null 2>&1; then
+  pass "a repository whose .changeset holds only README/config passes"
+else
+  fail "no pending changesets must pass, not error"
+  run_on "$empty" || true
+fi
+
+none="$(new_fixture none)"
+rm -rf "$none/.changeset"
+if node "$SCRIPT" --root "$none" >/dev/null 2>&1; then
+  pass "a repository with no .changeset directory at all passes"
+else
+  fail "a repository with no .changeset directory must pass, not error"
+  run_on "$none" || true
+fi
+
+# --- the check is wired into the PR gate ------------------------------------
+#
+# `.changeset/` is classified INERT by scripts/ci-affected-scope.mjs, so a
+# changeset-only PR runs neither the test nor the typecheck job. The check has to
+# live in a job that runs unconditionally or it would never see the PR that
+# carries the defect.
+
+CI=".github/workflows/red-workspace-ci.yml"
+
+# The body of the one job that runs unconditionally, so "wired in" means wired
+# into a job the narrowing cannot skip — not merely present somewhere in the file.
+unconditional_job="$(awk '
+  /^  workflow-security:$/ { injob = 1; next }
+  /^  [A-Za-z0-9_-]+:$/    { injob = 0 }
+  injob                    { print }
+' "$CI")"
+
+if grep -qF 'node scripts/validate-changesets.mjs' <<<"$unconditional_job"; then
+  pass "workflow-security runs the changeset validator — no affected-cone narrowing can skip it"
+else
+  fail "$CI must run \`node scripts/validate-changesets.mjs\` inside workflow-security"
+fi
+if grep -qF 'scripts/test-validate-changesets.sh' <<<"$unconditional_job"; then
+  pass "workflow-security runs this contract test"
+else
+  fail "$CI must run scripts/test-validate-changesets.sh inside workflow-security"
+fi
+
+if (( failures > 0 )); then
+  printf '\n%d failure(s)\n' "$failures" >&2
+  exit 1
+fi
+
+printf '\nchangeset validation contract ok\n'

--- a/scripts/validate-changesets.mjs
+++ b/scripts/validate-changesets.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// validate-changesets — every pending changeset must resolve against this
+// workspace, checked while the PR is open (#2863).
+//
+// `changeset version` does not skip a changeset it cannot resolve. It throws,
+// and the whole release plan dies with it. One file saying `"red-skills"` (the
+// ROOT manifest's name, which is not a workspace package) where every other one
+// says `"@reddb-io/red-skills"` failed three consecutive release runs over half
+// an hour, left npm on the previous version, and reported nothing until someone
+// opened the job log.
+//
+// Nothing caught it earlier because nothing validated a changeset at PR time —
+// `test`, `typecheck`, the scope check and the marketplace validation all pass a
+// bad changeset, since none of them resolve the release plan. This script does,
+// with no dependency on an installed `@changesets/cli`, so it can run in the
+// unconditional workflow-security job: `.changeset/` is INERT to
+// scripts/ci-affected-scope.mjs, so a changeset-only PR runs no other heavy job.
+//
+// Usage:
+//   node scripts/validate-changesets.mjs              # this repo
+//   node scripts/validate-changesets.mjs --root DIR   # another checkout
+//
+// Exits 0 when every changeset resolves — including when there are none at all.
+// Exits 1 naming each offending file, the unknown package, and the workspace
+// name the author most likely meant.
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** The bumps `@changesets/types` accepts. Anything else aborts the plan too. */
+const VERSION_TYPES = new Set(["major", "minor", "patch", "none"]);
+
+// ---------- workspace ----------
+
+/**
+ * The `packages:` globs from pnpm-workspace.yaml. Read rather than mirrored, so
+ * a new package root cannot silently fall outside this check.
+ */
+function readWorkspaceGlobs(root) {
+  const file = join(root, "pnpm-workspace.yaml");
+  if (!existsSync(file)) return [];
+  const globs = [];
+  let inPackages = false;
+  for (const line of readFileSync(file, "utf8").split("\n")) {
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (!inPackages) continue;
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+    const item = /^\s*-\s*(.+?)\s*$/.exec(line);
+    if (!item) break; // the next top-level key ends the list
+    globs.push(unquote(item[1]));
+  }
+  return globs;
+}
+
+function unquote(value) {
+  const quoted = /^(["'])(.*)\1$/.exec(value);
+  if (quoted) return quoted[2];
+  return value.replace(/\s+#.*$/, "").trim();
+}
+
+/**
+ * Workspace package names, resolved from the globs. Only the two shapes this
+ * repo uses are supported — a literal directory and a `<prefix>/*` fan-out; an
+ * unsupported pattern throws rather than narrowing the check silently.
+ *
+ * The ROOT manifest is deliberately absent: `changeset version` resolves against
+ * the glob-matched packages, so the root's own name is exactly the name that
+ * broke the release.
+ */
+function readWorkspacePackageNames(root) {
+  const names = new Set();
+  for (const glob of readWorkspaceGlobs(root)) {
+    if (glob.includes("!")) throw new Error(`unsupported workspace pattern: ${glob}`);
+    const star = glob.indexOf("*");
+    if (star === -1) {
+      addPackageName(names, join(root, glob));
+      continue;
+    }
+    if (!glob.endsWith("/*") || glob.slice(0, -2).includes("*")) {
+      throw new Error(`unsupported workspace pattern: ${glob}`);
+    }
+    const parent = join(root, glob.slice(0, -2));
+    let entries;
+    try {
+      entries = readdirSync(parent, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) addPackageName(names, join(parent, entry.name));
+    }
+  }
+  return names;
+}
+
+function addPackageName(names, dir) {
+  try {
+    const name = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")).name;
+    if (typeof name === "string" && name !== "") names.add(name);
+  } catch {
+    // Not a package directory; the workspace ignores it and so do we.
+  }
+}
+
+// ---------- changesets ----------
+
+/** The pending changeset files, exactly the set `@changesets/read` picks up. */
+function readChangesetFiles(root) {
+  const dir = join(root, ".changeset");
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return []; // no .changeset at all — nothing pending, nothing to resolve
+  }
+  return entries
+    .filter((file) => file.endsWith(".md") && file !== "README.md" && !file.startsWith("."))
+    .sort();
+}
+
+/**
+ * The `name: bump` pairs in a changeset's frontmatter, with the line each sits
+ * on so a failure can point at it. An empty frontmatter block is a valid
+ * changeset that releases nothing, and yields no pairs.
+ *
+ * @returns {{releases: {name: string, bump: string, line: number}[]} | {error: string}}
+ */
+function parseFrontmatter(source) {
+  const lines = source.split("\n");
+  if (lines[0]?.trim() !== "---") {
+    return { error: "no `---` frontmatter block — `changeset version` cannot read this file" };
+  }
+  const end = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+  if (end === -1) return { error: "the `---` frontmatter block is never closed" };
+
+  const releases = [];
+  for (let index = 1; index < end; index += 1) {
+    const line = lines[index];
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+    const pair = /^\s*(?:"([^"]+)"|'([^']+)'|([^:]+?))\s*:\s*(.+?)\s*$/.exec(line);
+    if (!pair) return { error: `frontmatter line ${index + 1} is not a \`"package": bump\` pair` };
+    releases.push({
+      name: pair[1] ?? pair[2] ?? pair[3],
+      bump: unquote(pair[4]),
+      line: index + 1,
+    });
+  }
+  return { releases };
+}
+
+/**
+ * The workspace name an unknown name most likely meant: the single package whose
+ * scoped name ends with `/<unknown>`. Ambiguity yields nothing rather than a
+ * guess that sends the author to the wrong package.
+ */
+function suggestionFor(unknown, workspaceNames) {
+  const matches = [...workspaceNames].filter((name) => name.endsWith(`/${unknown}`));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+// ---------- run ----------
+
+export function run(argv = [], { root = REPO_ROOT, log = console.log, error = console.error } = {}) {
+  let target = root;
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--root") target = resolve(argv[++i] ?? "");
+    else if (argv[i].startsWith("--root=")) target = resolve(argv[i].slice("--root=".length));
+    else throw new Error(`unknown argument: ${argv[i]}`);
+  }
+
+  const files = readChangesetFiles(target);
+  if (files.length === 0) {
+    log("changesets ok — no pending changeset to resolve");
+    return 0;
+  }
+
+  const workspaceNames = readWorkspacePackageNames(target);
+  const problems = [];
+
+  for (const file of files) {
+    const relative = `.changeset/${file}`;
+    const parsed = parseFrontmatter(readFileSync(join(target, ".changeset", file), "utf8"));
+    if (parsed.error) {
+      problems.push({ file: relative, line: 1, message: parsed.error });
+      continue;
+    }
+    for (const release of parsed.releases) {
+      if (!workspaceNames.has(release.name)) {
+        const suggestion = suggestionFor(release.name, workspaceNames);
+        problems.push({
+          file: relative,
+          line: release.line,
+          message:
+            `"${release.name}" is not a package in this workspace, so \`changeset version\` ` +
+            `throws and abandons the WHOLE release plan` +
+            (suggestion ? ` — did you mean "${suggestion}"?` : ""),
+        });
+      }
+      if (!VERSION_TYPES.has(release.bump)) {
+        problems.push({
+          file: relative,
+          line: release.line,
+          message:
+            `"${release.bump}" is not a release type, so \`changeset version\` throws and ` +
+            `abandons the WHOLE release plan — use ${[...VERSION_TYPES].join(", ")}`,
+        });
+      }
+    }
+  }
+
+  if (problems.length === 0) {
+    log(`changesets ok — ${files.length} pending changeset(s) resolve against the workspace`);
+    return 0;
+  }
+
+  for (const problem of problems) {
+    error(`::error file=${problem.file},line=${problem.line}::${problem.file}: ${problem.message}`);
+  }
+  error(
+    `${problems.length} changeset problem(s). Fix them here: after merge this fails every ` +
+      `release run, not just this PR.`,
+  );
+  return 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    process.exit(run(process.argv.slice(2)));
+  } catch (err) {
+    console.error(`::error::${err.message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
Automated AFK landing for #2863. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2863

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788021368&installation_model_id=20659&pr_number=2868&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2868&signature=ce30c034bb89fc9f34c3d9e86c19511fa9b65be8471c28ac5293197673cc4372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->