### PR TITLE
fix: #2865 A dispatched worker does not adopt prior work on its issue's branch, so finished work is silently redone

### DIFF
--- a/.changeset/a-worker-adopts-the-work-its-issue-already-has.md
+++ b/.changeset/a-worker-adopts-the-work-its-issue-already-has.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A dispatched Worker decides its issue's branch on what the branch holds, not on what it is called (#2865). Branch-resume already discovered `afk/<issue>-*` by name and skipped `prepareFreshWorkerBranch` when it matched — but the name is not evidence. Worktree creation pushes the deterministic ref before the agent writes a line, so a dead Worker's nine committed slices and an empty placeholder read identically, and the branch a Worker declines to adopt is the branch `prepareFreshWorkerBranch` deletes from origin. The lifecycle now asks git how many commits the candidate carries ahead of the base before it decides: a proven-empty ref is prepared fresh, and a ref carrying work is continued.
+
+**An unread branch is adopted, never assumed empty.** `branchCommitsAhead` returns `undefined` — not zero — when it cannot resolve the tip or the base, and a throwing probe degrades the same way, because a count the engine merely failed to read must not look like a branch with nothing to lose. The one path that still discards work is the one a human asked for: an explicit restart directive in the thread.
+
+**Committed work that reached origin is no longer invisible.** Two facts the engine used to keep to itself are now recorded on the issue: the reason a refusal refused, and the existence of a branch that carries commits no pull request mentions — the exact shape in which #2851's finished 1553-line slice sat on origin while the issue read as in-progress. The attempt-PR census already names an adopted branch that has a PR, so that case stays silent rather than doubling the comment.

--- a/apps/dev/src/commands/run/ports/lookups.ts
+++ b/apps/dev/src/commands/run/ports/lookups.ts
@@ -106,6 +106,10 @@ export function buildLookups({
     // Branch-resume discovery (issue #2397): list all remote afk/* refs so the
     // lifecycle can detect a prior pushed branch and resume instead of rebuilding.
     discoverBranches: () => gitx.listRemoteBranches(gitCtx, "afk/"),
+    // Adoption evidence (#2865): a discovered branch is only prior work if it
+    // carries commits the base does not. Without this the lifecycle cannot tell
+    // finished work from the empty ref worktree creation pushes.
+    branchCommitsAhead: (branch, base) => gitx.branchCommitsAhead(gitCtx, branch, base),
     // Attempt-adoption sanity check (#2416): one cheap open-PR census before
     // any agent run. The lifecycle owns exact body/head matching and adoption.
     discoverOpenPullRequests: async () => {

--- a/apps/dev/src/core/branch-resume.ts
+++ b/apps/dev/src/core/branch-resume.ts
@@ -62,6 +62,76 @@ export function discoverResumableBranch(refs: readonly BranchRef[], issue: numbe
 }
 
 /**
+ * What a dispatched Worker decided about the branch its issue already has
+ * (#2865). `none` means there was nothing to adopt; `refused` means work exists
+ * and the Worker deliberately left it, which is a fact the issue must carry.
+ */
+export type BranchAdoption =
+  | { kind: "adopt"; branch: string; commitsAhead: number | undefined; hasOpenPullRequest: boolean }
+  | { kind: "refused"; branch: string; commitsAhead: number | undefined; reason: string }
+  | { kind: "none" };
+
+const RESTART_REFUSAL_REASON = "a human directive in the thread asked for a restart";
+
+/**
+ * Decide whether a dispatched Worker adopts the branch its issue already has.
+ *
+ * The commit count is the evidence, not the branch name: worktree creation
+ * pushes the deterministic `afk/<issue>-<slug>` ref before the agent writes a
+ * line, so a name match alone cannot tell a dead Worker's finished work from an
+ * empty placeholder. A count of `undefined` means the probe could not tell —
+ * and an unread branch is adopted, never assumed empty, because the branch a
+ * Worker declines to adopt is the branch `prepareFreshWorkerBranch` deletes.
+ */
+export function decideBranchAdoption(input: {
+  candidate: { branch: string } | null;
+  commitsAhead: number | undefined;
+  explicitRestart: boolean;
+  hasOpenPullRequest: boolean;
+}): BranchAdoption {
+  const { candidate, commitsAhead, explicitRestart, hasOpenPullRequest } = input;
+  if (!candidate) return { kind: "none" };
+  // A branch proven empty carries no work to lose, so declining it is not a
+  // refusal worth announcing — it is the ordinary first dispatch.
+  if (commitsAhead === 0) return { kind: "none" };
+  if (explicitRestart) {
+    return { kind: "refused", branch: candidate.branch, commitsAhead, reason: RESTART_REFUSAL_REASON };
+  }
+  return { kind: "adopt", branch: candidate.branch, commitsAhead, hasOpenPullRequest };
+}
+
+function describeCommits(commitsAhead: number | undefined): string {
+  if (commitsAhead === undefined) return "an unknown number of commits";
+  return `${commitsAhead} commit${commitsAhead === 1 ? "" : "s"}`;
+}
+
+/**
+ * The issue comment an adoption decision owes the record, or `null` when the
+ * decision needs no announcement (#2865).
+ *
+ * Two things are never left unsaid: a refusal (the reason belongs on the issue,
+ * not only in a Worker's log), and pushed work that no pull request mentions —
+ * the exact shape in which a dead Worker's finished slice goes invisible. An
+ * adopted branch that already has an open PR is silent here because the
+ * attempt-PR census comment already names it.
+ */
+export function formatAdoptionNotice(decision: BranchAdoption, issue: number): string | null {
+  if (decision.kind === "none") return null;
+  const commits = describeCommits(decision.commitsAhead);
+  if (decision.kind === "refused") {
+    return (
+      `🤖 /afk #${issue}: branch \`${decision.branch}\` carries ${commits} ahead of the base and was NOT adopted — ` +
+      `${decision.reason}. The commits stay on the branch until someone takes them.`
+    );
+  }
+  if (decision.hasOpenPullRequest) return null;
+  return (
+    `🤖 /afk #${issue}: branch \`${decision.branch}\` carries ${commits} ahead of the base and has no open pull request. ` +
+    `Adopting it — this Worker continues that branch instead of starting over.`
+  );
+}
+
+/**
  * Extract the `prev-failure-reason:` value from a prior-attempt-context block.
  * Returns undefined when the marker is absent or the context is empty.
  */

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -9,8 +9,10 @@ import {
 import { buildHandoff, buildHumanGuidance, exitProtocolFor, type HandoffComment } from "../handoff.js";
 import {
   buildResumeInstruction,
+  decideBranchAdoption,
   discoverResumableBranch,
   extractFailureReason,
+  formatAdoptionNotice,
   isExplicitRestartRequested,
   isGateGreenBranch,
   pullRequestMatchesAttempt,
@@ -420,11 +422,34 @@ export async function processIssue(
   const allBranches = await deps.lookups.discoverBranches?.() ?? [];
   const humanGuidanceForResume = buildHumanGuidance(comments);
   const explicitRestart = isExplicitRestartRequested(humanGuidanceForResume);
+  const candidateBranch = discoverResumableBranch(allBranches, issue);
+  // Issue #2865 — ask git what the branch HOLDS before deciding its fate. The
+  // ref name is not evidence: worktree creation pushes `afk/<issue>-<slug>`
+  // before the agent writes a line, so a dead Worker's nine committed slices and
+  // an empty placeholder read identically by name. Whatever this Worker declines
+  // to adopt, `prepareFreshWorkerBranch` deletes from origin.
+  const candidateCommitsAhead = candidateBranch
+    ? await deps.lookups.branchCommitsAhead?.(candidateBranch.branch, base).catch(() => undefined)
+    : undefined;
+  const adoption = decideBranchAdoption({
+    candidate: candidateBranch,
+    commitsAhead: candidateCommitsAhead,
+    explicitRestart,
+    hasOpenPullRequest: matchingPullRequests.length > 0,
+  });
+  // Committed work is never invisible: a refusal states its reason on the issue,
+  // and a branch carrying commits that no pull request mentions is named rather
+  // than silently orphaned.
+  const adoptionNotice = formatAdoptionNotice(adoption, issue);
+  if (adoptionNotice) {
+    await deps.gh.comment(issue, adoptionNotice);
+    deps.appendIterLog(adoptionNotice);
+  }
   const resumableBranch = adoptedPullRequest
     ? { branch: adoptedPullRequest.headRefName }
-    : explicitRestart
-      ? null
-      : discoverResumableBranch(allBranches, issue);
+    : adoption.kind === "adopt"
+      ? candidateBranch
+      : null;
   const failureReason = extractFailureReason(prevFailureContext);
   const resumeIsGateGreen = adoptedPullRequest !== null ||
     (resumableBranch !== null && isGateGreenBranch(failureReason));

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -209,6 +209,14 @@ export interface ProcessLookups {
   /** Discover all remote afk/* branches (issue #2397). Used to detect a prior
    * pushed attempt so re-claim can resume instead of rebuilding from scratch. */
   discoverBranches?(): Promise<BranchRef[]>;
+  /**
+   * How many commits a discovered branch carries ahead of `base` (#2865) — the
+   * evidence that separates a dead Worker's finished work from the empty ref
+   * worktree creation pushes. Optional, and `undefined` means "could not tell":
+   * an unread branch is adopted rather than reset, because the branch a Worker
+   * declines to adopt is the branch it deletes.
+   */
+  branchCommitsAhead?(branch: string, base: string): Promise<number | undefined>;
   /** List open PRs that may already carry this issue's work. The lifecycle
    * applies its own body/head match before adopting one. */
   discoverOpenPullRequests?(issue: number): Promise<AttemptPullRequest[]>;

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -472,6 +472,43 @@ export async function branchMergedInto(ctx: GitContext, branch: string, base: st
   return r.code === 0;
 }
 
+/**
+ * How many commits `<branch>` carries ahead of `<base>` — the evidence a
+ * dispatched Worker needs before it decides whether a prior branch holds
+ * finished work (#2865). The branch name cannot answer this: worktree creation
+ * pushes `afk/<issue>-<slug>` before the agent writes a line, so a name match
+ * alone reads the same for nine committed slices and for an empty placeholder.
+ *
+ * The tip is read from the local ref first, then `origin/<branch>`, fetching
+ * once when neither is present. `undefined` means "could not tell" and is never
+ * collapsed to zero: the caller deletes the branches it reads as empty, so a
+ * branch this probe merely failed to see must not look like one with no work.
+ */
+export async function branchCommitsAhead(
+  ctx: GitContext,
+  branch: string,
+  base: string,
+): Promise<number | undefined> {
+  if (!branch || !base) return undefined;
+  let head = await branchHead(ctx, branch);
+  if (!head) {
+    const remoteRef = `refs/remotes/origin/${branch}`;
+    let r = await runGit(ctx, ["rev-parse", "--verify", "--quiet", remoteRef]);
+    if (r.code !== 0 || r.stdout.trim() === "") {
+      await fetchBranch(ctx, branch);
+      r = await runGit(ctx, ["rev-parse", "--verify", "--quiet", remoteRef]);
+    }
+    head = r.code === 0 && r.stdout.trim() !== "" ? r.stdout.trim() : undefined;
+  }
+  if (!head) return undefined;
+  const baseTip = (await revParse(ctx, base)) ?? (await revParse(ctx, `origin/${base}`));
+  if (!baseTip) return undefined;
+  const count = await runGit(ctx, ["rev-list", "--count", `${baseTip}..${head}`]);
+  if (count.code !== 0) return undefined;
+  const n = Number(count.stdout.trim());
+  return Number.isInteger(n) && n >= 0 ? n : undefined;
+}
+
 /** Changed files of <branch> vs <base> (git diff --name-only base...branch). */
 export async function changedFiles(ctx: GitContext, branch: string, base: string): Promise<string[]> {
   const r = await runGit(ctx, ["diff", "--name-only", `${base}...${branch}`]);

--- a/apps/dev/tests/branch-resume.test.ts
+++ b/apps/dev/tests/branch-resume.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildResumeInstruction,
+  decideBranchAdoption,
   discoverResumableBranch,
   extractFailureReason,
+  formatAdoptionNotice,
   isExplicitRestartRequested,
   isGateGreenBranch,
 } from "../src/core/branch-resume.js";
@@ -191,5 +193,129 @@ describe("buildResumeInstruction", () => {
     expect(text).toContain("git fetch origin develop");
     expect(text).toContain("git rebase origin/develop");
     expect(text).toContain("origin/develop..HEAD");
+  });
+});
+
+// Refs #2865
+
+describe("decideBranchAdoption", () => {
+  const CANDIDATE: BranchRef = { branch: "afk/9-fix-the-thing", commitS: 1000 };
+
+  it("returns none when no branch for the issue exists", () => {
+    expect(
+      decideBranchAdoption({
+        candidate: null,
+        commitsAhead: undefined,
+        explicitRestart: false,
+        hasOpenPullRequest: false,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("returns none for a branch that carries no commits ahead of the base", () => {
+    // Worktree creation pushes the deterministic ref before the agent writes a
+    // line, so a name match alone is not evidence of work.
+    expect(
+      decideBranchAdoption({
+        candidate: CANDIDATE,
+        commitsAhead: 0,
+        explicitRestart: false,
+        hasOpenPullRequest: false,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("adopts a branch that carries commits ahead of the base", () => {
+    expect(
+      decideBranchAdoption({
+        candidate: CANDIDATE,
+        commitsAhead: 9,
+        explicitRestart: false,
+        hasOpenPullRequest: false,
+      }),
+    ).toEqual({
+      kind: "adopt",
+      branch: CANDIDATE.branch,
+      commitsAhead: 9,
+      hasOpenPullRequest: false,
+    });
+  });
+
+  it("adopts when the commit count is unknown — an unread branch is never assumed empty", () => {
+    const decision = decideBranchAdoption({
+      candidate: CANDIDATE,
+      commitsAhead: undefined,
+      explicitRestart: false,
+      hasOpenPullRequest: false,
+    });
+    expect(decision.kind).toBe("adopt");
+  });
+
+  it("refuses with a stated reason when a human directive asked for a restart", () => {
+    const decision = decideBranchAdoption({
+      candidate: CANDIDATE,
+      commitsAhead: 9,
+      explicitRestart: true,
+      hasOpenPullRequest: false,
+    });
+    expect(decision.kind).toBe("refused");
+    if (decision.kind !== "refused") throw new Error("unreachable");
+    expect(decision.branch).toBe(CANDIDATE.branch);
+    expect(decision.commitsAhead).toBe(9);
+    expect(decision.reason).toMatch(/restart/i);
+  });
+
+  it("does not announce a refusal for an empty branch a restart would discard", () => {
+    expect(
+      decideBranchAdoption({
+        candidate: CANDIDATE,
+        commitsAhead: 0,
+        explicitRestart: true,
+        hasOpenPullRequest: false,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+});
+
+describe("formatAdoptionNotice", () => {
+  it("surfaces a branch that carries commits and has no open pull request", () => {
+    const notice = formatAdoptionNotice(
+      { kind: "adopt", branch: "afk/9-fix-the-thing", commitsAhead: 9, hasOpenPullRequest: false },
+      9,
+    );
+    expect(notice).toContain("afk/9-fix-the-thing");
+    expect(notice).toContain("9 commits");
+    expect(notice).toContain("no open pull request");
+  });
+
+  it("stays silent when an open pull request already surfaces the work", () => {
+    expect(
+      formatAdoptionNotice(
+        { kind: "adopt", branch: "afk/9-fix-the-thing", commitsAhead: 9, hasOpenPullRequest: true },
+        9,
+      ),
+    ).toBeNull();
+  });
+
+  it("records the reason adoption was refused", () => {
+    const notice = formatAdoptionNotice(
+      { kind: "refused", branch: "afk/9-fix-the-thing", commitsAhead: 9, reason: "a human directive asked for a restart" },
+      9,
+    );
+    expect(notice).toContain("afk/9-fix-the-thing");
+    expect(notice).toContain("a human directive asked for a restart");
+    expect(notice).toContain("9 commits");
+  });
+
+  it("says nothing when there was no branch to decide about", () => {
+    expect(formatAdoptionNotice({ kind: "none" }, 9)).toBeNull();
+  });
+
+  it("names an unknown commit count as unknown rather than as zero", () => {
+    const notice = formatAdoptionNotice(
+      { kind: "adopt", branch: "afk/9-fix-the-thing", commitsAhead: undefined, hasOpenPullRequest: false },
+      9,
+    );
+    expect(notice).toContain("an unknown number of commits");
   });
 });

--- a/apps/dev/tests/process-issue-resume.test.ts
+++ b/apps/dev/tests/process-issue-resume.test.ts
@@ -250,3 +250,79 @@ describe("branch-resume: existing open PR adoption (issue #2416)", () => {
     )).toBe(true);
   });
 });
+
+describe("branch adoption is decided on commits, not on the ref name (issue #2865)", () => {
+  /** The empty ref every worktree creation pushes before the agent writes a line. */
+  const EMPTY_REFS: BranchRef[] = [{ branch: "afk/9-fix-the-thing", commitS: 9000 }];
+
+  it("prepares a fresh branch when the matching ref carries no commits ahead of the base", async () => {
+    const { deps, input, trace } = harness({});
+    deps.lookups.discoverBranches = async () => EMPTY_REFS;
+    Object.assign(deps.lookups, { branchCommitsAhead: async () => 0 });
+
+    await import("../src/core/process-issue.js").then((m) => m.processIssue(deps, input));
+
+    expect(trace.freshWorkerBranchCalls).toHaveLength(1);
+    expect(trace.handoffs[0]?.content ?? "").not.toContain("<resume-from-branch>");
+  });
+
+  it("surfaces a branch that carries commits and has no open pull request", async () => {
+    const { deps, input, trace } = harness({});
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+    Object.assign(deps.lookups, { branchCommitsAhead: async () => 9 });
+
+    await import("../src/core/process-issue.js").then((m) => m.processIssue(deps, input));
+
+    expect(trace.comments.some((c) =>
+      c.body.includes(PRIOR_BRANCH) && c.body.includes("9 commits") &&
+      c.body.includes("no open pull request")
+    )).toBe(true);
+    expect(trace.freshWorkerBranchCalls).toHaveLength(0);
+    expect(trace.handoffs[0]?.content ?? "").toContain("<resume-from-branch>");
+  });
+
+  it("records on the issue why a restart refused a branch that carries work", async () => {
+    const { deps, input, trace } = harness({});
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+    Object.assign(deps.lookups, { branchCommitsAhead: async () => 9 });
+    deps.lookups.comments = async () => [
+      {
+        body: "<details data-kind=\"directive\">\n<summary>directive</summary>\nPlease restart from scratch.\n</details>",
+        author: "maintainer",
+        sourceTrust: "trusted" as const,
+      },
+    ];
+
+    await import("../src/core/process-issue.js").then((m) => m.processIssue(deps, input));
+
+    expect(trace.comments.some((c) =>
+      c.body.includes(PRIOR_BRANCH) && c.body.includes("NOT adopted") && c.body.includes("restart")
+    )).toBe(true);
+    expect(trace.freshWorkerBranchCalls).toHaveLength(1);
+  });
+
+  it("adopts rather than resets when the commit count cannot be read", async () => {
+    const { deps, input, trace } = harness({});
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+    Object.assign(deps.lookups, { branchCommitsAhead: async () => undefined });
+
+    await import("../src/core/process-issue.js").then((m) => m.processIssue(deps, input));
+
+    expect(trace.freshWorkerBranchCalls).toHaveLength(0);
+    expect(trace.handoffs[0]?.content ?? "").toContain("<resume-from-branch>");
+  });
+
+  it("adopts rather than resets when the commit probe throws", async () => {
+    const { deps, input, trace } = harness({});
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+    Object.assign(deps.lookups, {
+      branchCommitsAhead: async () => {
+        throw new Error("ls-remote unreachable");
+      },
+    });
+
+    await import("../src/core/process-issue.js").then((m) => m.processIssue(deps, input));
+
+    expect(trace.freshWorkerBranchCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2865. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2865

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788022554&installation_model_id=20659&pr_number=2869&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2869&signature=7b155f91063ad3df71edb8795210ccc8bfc202f4c3e720d7a5da87d44ba98cbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->