### PR TITLE
fix: #2866 Worktrees and branches accumulate without reclaim

### DIFF
--- a/.changeset/worktrees-and-branches-are-reclaimed.md
+++ b/.changeset/worktrees-and-branches-are-reclaimed.md
@@ -1,0 +1,13 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Worktrees and branches are reclaimed instead of accumulating (#2866). A single working period produced 27 worktrees and 75 local branches, and a manual sweep back down to 17 and 20 was undone within hours. Two separate halves were missing, and each one alone made the other look like it was working.
+
+**The worktree half was only half a reclaim.** The daemon-keyed rule from #2790 correctly condemned a dead Worker's workspace and correctly removed its bytes — and then asked git nothing. Git's registry kept pointing at the deleted path, which is the trap the issue describes: a stale registration blocks the next worktree created there and can hold a lock a later gate run trips over. The prune existed but was reached only by the feedback lane, in a code path (`runtime/tmp-janitor.ts`) that the shipped boot does not use — boot performs its own removals through the fs deps. So in production nothing ever pruned. Every lane that can delete a registered worktree now counts toward one prune at the end of the sweep, in `runtime/tmp-janitor.ts` and in boot's own `runTmpJanitorSweep`, and `/red-doctor --fix` wires it too. Feedback worktrees are counted apart from `expiredLanes`, which also holds logs and scratch: only a removed worktree leaves a registration behind.
+
+**The branch half decided on the wrong fact.** The local reaper reaped when the ISSUE was closed, so a slice whose PR merged while its issue stayed open — the single most common shape in the queue — was never eligible at all. `core/branch-reclaim.ts` is the new planner, shaped like `worker-reclaim.ts`: one verdict per candidate, a reason on each, and an accounting identity in `totals`. It decides on LANDED-ness, the merge-base fact read against the trunk's remote ref (a stale local trunk under-reports, and under-reporting only ever spares), with the tracker's closed-issue verdict kept as a weaker second route.
+
+**And the refusal is stated by name.** A hand sweep of "merged" branches deleted `red-trunk`, the fleet's trunk mirror, because it is merged into the trunk BY CONSTRUCTION and so every merged-ness test on earth condemns it. `INFRASTRUCTURE_BRANCHES` names it, and that refusal is checked before any merged-ness reasoning can reach it — along with the configured trunk itself, a branch a worktree still holds, and a branch in a namespace no Worker lane owns, which the planner spares rather than guessing at.
+
+The spares are reported everywhere the reclaim runs — the boot sweep line now carries `spared=`, `reap` prints a reason per spared branch, and the `reap` MCP tool returns `local_spared` — because a reclaim that only ever prints its deletions cannot be audited for what it refused.

--- a/apps/dev/src/commands/reap.ts
+++ b/apps/dev/src/commands/reap.ts
@@ -3,12 +3,18 @@ import {
   planLiveBranchCleanup,
   planLocalBranchCleanup,
 } from "../core/branch-cleanup.js";
+import { planBranchReclaim } from "../core/branch-reclaim.js";
 import { collectReapInputs, resolveRepoContext } from "../runtime/wire.js";
 
 /**
  * `reap` — native branch reaper. Lists remote/local afk/* refs, classifies
  * each via the pure branch-cleanup planners against the pre-resolved gh
  * issue-state cache, prints the count lines, and deletes per plan. No bash.
+ *
+ * The LOCAL pass runs through the branch reclaim (#2866), which decides on the
+ * landed fact and refuses infrastructure refs by name, and it prints what it
+ * spared as well as what it deleted — an operator reading this must be able to
+ * see that `red-trunk` was kept on purpose rather than missed by accident.
  */
 export async function reapCommand(
   _args: string[],
@@ -20,21 +26,37 @@ export async function reapCommand(
   const nowS = Math.floor(Date.now() / 1000);
 
   const remoteLivePlan = planLiveBranchCleanup(inputs.remoteLiveRefs, inputs.lookup, nowS);
-  const localLivePlan = planLocalBranchCleanup(inputs.localLiveRefs, inputs.lookup, nowS);
-
   const remoteLiveReap = branchesToReap(remoteLivePlan);
-  const localLiveReap = branchesToReap(localLivePlan);
+
+  const issueClosed = new Set(
+    branchesToReap(planLocalBranchCleanup(inputs.localLiveRefs, inputs.lookup, nowS))
+      .map((d) => d.branch),
+  );
+  const landed = new Set(inputs.landedLocalBranches);
+  const localPlan = planBranchReclaim(
+    inputs.localLiveRefs.map((ref) => ({
+      branch: ref.branch,
+      landed: landed.has(ref.branch),
+      issueClosed: issueClosed.has(ref.branch),
+    })),
+    { trunk: inputs.trunk },
+  );
 
   stdout.write(`reap: afk/* remote live: ${inputs.remoteLiveRefs.length} found, ${remoteLiveReap.length} to reap\n`);
-  stdout.write(`reap: afk/* local live: ${inputs.localLiveRefs.length} found, ${localLiveReap.length} to reap\n`);
+  stdout.write(
+    `reap: afk/* local live: ${localPlan.totals.considered} found, ${localPlan.totals.reclaim} to reap, ${localPlan.totals.spare} spared\n`,
+  );
 
   for (const d of remoteLiveReap) {
     await inputs.deleteRemote(d.branch);
     stdout.write(`reaped (remote live): ${d.branch}\n`);
   }
-  for (const d of localLiveReap) {
+  for (const d of localPlan.reclaim) {
     await inputs.deleteLocal(d.branch);
-    stdout.write(`reaped (local live): ${d.branch}\n`);
+    stdout.write(`reaped (local live): ${d.branch} — ${d.reason}\n`);
+  }
+  for (const d of localPlan.spare) {
+    stdout.write(`spared (local live): ${d.branch} — ${d.reason}\n`);
   }
 
   return 0;

--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -457,7 +457,13 @@ export async function redDoctorCommand(args: readonly string[], cwd = process.cw
         installTq: () => execTool("sh", ["-c", tqInstallRecipe()], { cwd: ctx.root }),
       },
     );
-    const applied = flags.fix ? await applyTmpJanitorReport(paths.tmpDir, report) : undefined;
+    // `worktreePrune` is wired so a doctor that removes a worktree's bytes also
+    // drops git's registration of it — half a reclaim leaves the trap (#2866).
+    const applied = flags.fix
+      ? await applyTmpJanitorReport(paths.tmpDir, report, {
+          worktreePrune: () => gitx.worktreePrune({ cwd: ctx.root }),
+        })
+      : undefined;
     // Detection only — /red-doctor consumes the same read-only deadend audit
     // the `deadend_audit` MCP tool serves; it renders findings and never mutates.
     // A gather failure degrades to an empty section, never a failed doctor.

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -476,7 +476,9 @@ export function formatBootSweepResult(result: BootResult): string {
     "boot sweeps complete: " +
     `orphans removed=${oc?.removed.length ?? 0} restored=${oc?.restored.length ?? 0} kept=${oc?.kept.length ?? 0}` +
     ` | attempt-cap reclaimed=${ac?.reclaimed.length ?? 0}` +
-    ` | branches remote=${bc?.remoteLiveReaped.length ?? 0} local=${bc?.localLiveReaped.length ?? 0}` +
+    // `spared` is reported beside `local` on purpose (#2866): a reclaim that
+    // only ever prints its deletions cannot be audited for what it refused.
+    ` | branches remote=${bc?.remoteLiveReaped.length ?? 0} local=${bc?.localLiveReaped.length ?? 0} spared=${bc?.localSpared?.length ?? 0}` +
     ` | tmp-janitor expired=${tj?.expiredLanes.length ?? 0} workers=${tj?.staleWorkers.length ?? 0} orphan-runners=${tj?.orphanTestRunners?.length ?? 0} unknown=${tj?.unknownTmpRoots.length ?? 0} protected=${(tj?.protectedLiveWorkers.length ?? 0) + (tj?.protectedLiveFeedback.length ?? 0)}` +
     janitorRemovalLog +
     ` | docs-sweep ${ds?.action ?? "clean"} files=${ds?.files.length ?? 0}` +

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -33,6 +33,10 @@ import {
   type IssueLookup,
 } from "./branch-cleanup.js";
 import {
+  planBranchReclaim,
+  type BranchReclaimVerdict,
+} from "./branch-reclaim.js";
+import {
   executeMixedBlockedNormalize,
   executeUnblockSweep,
   planReconcileSweep,
@@ -287,6 +291,9 @@ export interface BootGit {
   deleteRemoteBranch(branch: string): Promise<void>;
   /** Delete a local branch (git branch -D <branch>). */
   deleteLocalBranch(branch: string): Promise<void>;
+  /** Drop git's registrations of worktrees whose bytes are gone (#2866).
+   * Optional: a caller that does not wire it simply leaves the registry alone. */
+  worktreePrune?(): Promise<void>;
 }
 
 /** Injected lookups the deciders need. Each mirrors a `gh issue view`/`gh issue
@@ -678,6 +685,12 @@ export interface AttemptCapInput {
 export interface BranchCleanupInput {
   remoteLiveRefs: readonly BranchRef[];
   localLiveRefs: readonly BranchRef[];
+  /** Local branches the trunk already carries — the LANDED fact the reclaim
+   * decides on (#2866). Absent leaves the reclaim on the tracker's weaker
+   * verdict alone, which is the pre-#2866 behaviour. */
+  landedLocalBranches?: readonly string[];
+  /** The repo's configured trunk, so the reclaim can spare it by name. */
+  trunk?: string;
 }
 
 /** A `.red/tmp/claims/<N>/` lock dir whose recorded pid the caller already
@@ -766,6 +779,10 @@ export interface AttemptCapResult {
 export interface BranchCleanupResult {
   remoteLiveReaped: string[];
   localLiveReaped: string[];
+  /** Local branches the reclaim deliberately KEPT, each with the reason (#2866).
+   * Reported rather than dropped, because the spares — `red-trunk` above all —
+   * are the half of this sweep that a silent pass gets catastrophically wrong. */
+  localSpared?: BranchReclaimVerdict[];
 }
 
 export interface UnblockSweepResult {
@@ -1070,6 +1087,9 @@ async function runTmpJanitorSweep(
     ...sweep.plan.legacySlotLogs.reclaim,
   ];
   const feedbackPaths = new Set(sweep.plan.feedbackWorktrees.reclaim.map((entry) => entry.path));
+  // Counted apart from `expiredLanes`, which also holds logs and scratch: only a
+  // removed WORKTREE leaves a git registration behind to prune (#2866).
+  let removedFeedbackWorktrees = 0;
   for (const entry of expired) {
     if (feedbackPaths.has(entry.path)) {
       const verdict = await deps.fs.feedbackWorktreeLiveness?.(entry.path).catch(() => "owner-live" as const)
@@ -1079,6 +1099,7 @@ async function runTmpJanitorSweep(
         continue;
       }
       await deps.fs.removeDir(entry.path);
+      removedFeedbackWorktrees += 1;
       result.removals.push({ path: entry.path, livenessVerdict: verdict });
       result.expiredLanes.push(entry.path);
       continue;
@@ -1121,6 +1142,15 @@ async function runTmpJanitorSweep(
     deps.log?.(
       `tmp-janitor reaped orphan test runner pid=${orphan.pid} pgid=${orphan.pgid} cwd=${relative(options.bootstrap.tmpDir, orphan.cwd)} command=${orphan.command}`,
     );
+  }
+
+  // Deleting a registered worktree's bytes leaves git still pointing at the
+  // path, which blocks the next worktree created there (#2866). Every lane above
+  // that can delete one is counted; prune once, at the end, for all of them.
+  const removedWorktrees =
+    result.workerWorkspaces.length + result.staleWorkers.length + removedFeedbackWorktrees;
+  if (removedWorktrees > 0 && deps.git.worktreePrune) {
+    await deps.git.worktreePrune().catch(() => {});
   }
 
   return result;
@@ -1394,18 +1424,31 @@ async function runBranchCleanup(
     remoteLiveReaped.push(d.branch);
   }
 
+  // The local pass reclaims on LANDED-ness, with the tracker's closed-issue
+  // verdict folded in as the weaker second route (#2866). The reclaim planner is
+  // the authority over both: it alone may spare `red-trunk` and the trunk.
   const localLivePlan = planLocalBranchCleanup(
     input.localLiveRefs,
     deps.lookups.branchIssue,
     deps.nowS,
   );
+  const issueClosed = new Set(branchesToReap(localLivePlan).map((d) => d.branch));
+  const landed = new Set(input.landedLocalBranches ?? []);
+  const localPlan = planBranchReclaim(
+    input.localLiveRefs.map((ref) => ({
+      branch: ref.branch,
+      landed: landed.has(ref.branch),
+      issueClosed: issueClosed.has(ref.branch),
+    })),
+    { trunk: input.trunk },
+  );
   const localLiveReaped: string[] = [];
-  for (const d of branchesToReap(localLivePlan)) {
+  for (const d of localPlan.reclaim) {
     await deps.git.deleteLocalBranch(d.branch);
     localLiveReaped.push(d.branch);
   }
 
-  return { remoteLiveReaped, localLiveReaped };
+  return { remoteLiveReaped, localLiveReaped, localSpared: localPlan.spare };
 }
 
 /** Step 6: planUnblockSweep, then promote each planned issue (remove its holding

--- a/apps/dev/src/core/branch-reclaim.ts
+++ b/apps/dev/src/core/branch-reclaim.ts
@@ -1,0 +1,192 @@
+// branch-reclaim.ts — which LOCAL branches a reclaim may delete, and which it
+// must name and spare (#2866).
+//
+// This is the branch half of the reclaim whose workspace half lives in
+// worker-reclaim.ts, and it is deliberately shaped the same way: a PURE planner
+// that consumes already-resolved facts, gives every candidate exactly one
+// verdict with a reason, and states the accounting identity in `totals` so a
+// caller can assert nothing fell out silently.
+//
+// ONE RULE, STATED ONCE: a branch is reclaimable when its work has LANDED and
+// nothing else claims it. "Landed" is the merge-base fact — the trunk already
+// carries the commits — not "the issue is closed", because a slice whose PR
+// merged while its issue stayed open is exactly the branch that accumulates.
+// The tracker's verdict is kept as a second, weaker route: an issue that is over
+// releases its branch even when merged-ness could not be resolved.
+//
+// AND ONE PROHIBITION THAT OUTRANKS THE RULE: an infrastructure ref is never
+// eligible, however merged it looks. `red-trunk` is the fleet's trunk mirror; it
+// is merged into the trunk BY CONSTRUCTION, so every merged-ness test on earth
+// says delete it, and deleting it breaks every landing until someone notices. A
+// hand sweep made exactly that mistake. The refusal is therefore stated by NAME
+// here rather than derived, so no future merged-ness refinement can reason its
+// way past it.
+//
+// The spares are as load-bearing as the deletions, which is why they are
+// returned rather than dropped: `checked-out` (a worktree holds it — including
+// the live Worker still writing to it), `unrecognised` (no Worker lane owns this
+// namespace, so the planner does not guess), and `unlanded` (the work is still
+// only on this branch — deleting it is data loss, not hygiene).
+
+import { liveIssueFromBranch } from "./branch-cleanup.js";
+
+/**
+ * Refs the reclaim names and refuses, whatever else is true of them.
+ *
+ * `red-trunk` is the fleet-owned mirror of `origin/<trunk>` that landings
+ * promote (see core/merge.ts). It holds no unique commits, which is precisely
+ * why a merged-ness sweep condemns it.
+ */
+export const INFRASTRUCTURE_BRANCHES = ["red-trunk"] as const;
+
+/** One local branch, with the facts a caller has already resolved about it. */
+export interface BranchReclaimCandidate {
+  /** The bare ref name, e.g. `afk/2866-slug`. */
+  branch: string;
+  /** True when the trunk already carries this branch's commits. */
+  landed?: boolean;
+  /** True when a worktree — live Worker or not — has this branch checked out. */
+  checkedOut?: boolean;
+  /** True when the tracker says the branch's issue is over. */
+  issueClosed?: boolean;
+}
+
+export type BranchReclaimVerdictKind =
+  /** Named in `INFRASTRUCTURE_BRANCHES`: the refusal that outranks everything. */
+  | "infrastructure"
+  /** The configured trunk itself, whatever it is named. */
+  | "trunk"
+  /** A worktree holds it; git would refuse, and so does the planner. */
+  | "checked-out"
+  /** No Worker lane owns this namespace, so the planner does not guess. */
+  | "unrecognised"
+  /** A repeated candidate: already decided once, reported rather than re-planned. */
+  | "already-planned"
+  /** The work exists only here. Deleting it is data loss, not hygiene. */
+  | "unlanded"
+  /** The trunk already carries the commits. */
+  | "landed"
+  /** The tracker says the work is over, so the branch is residue. */
+  | "issue-closed";
+
+/** One branch, one verdict, one reason. */
+export interface BranchReclaimVerdict {
+  branch: string;
+  reclaim: boolean;
+  verdict: BranchReclaimVerdictKind;
+  reason: string;
+}
+
+export interface BranchReclaimTotals {
+  considered: number;
+  reclaim: number;
+  spare: number;
+}
+
+export interface BranchReclaimPlan {
+  /** Branches to delete, in input order. */
+  reclaim: BranchReclaimVerdict[];
+  /** Branches deliberately kept, each with the reason it was kept. */
+  spare: BranchReclaimVerdict[];
+  totals: BranchReclaimTotals;
+}
+
+export interface BranchReclaimOptions {
+  /** The repo's configured trunk (`main`, `develop`, …). Never eligible. */
+  trunk?: string;
+  /** Extra refs to treat as infrastructure, added to the named list. */
+  infrastructure?: readonly string[];
+}
+
+/** True when this branch is one the reclaim refuses by name. */
+export function isInfrastructureBranch(
+  branch: string,
+  extra: readonly string[] = [],
+): boolean {
+  return (INFRASTRUCTURE_BRANCHES as readonly string[]).includes(branch) || extra.includes(branch);
+}
+
+function judge(
+  candidate: BranchReclaimCandidate,
+  options: BranchReclaimOptions,
+): BranchReclaimVerdict {
+  const branch = candidate.branch;
+  const spare = (verdict: BranchReclaimVerdictKind, reason: string): BranchReclaimVerdict => ({
+    branch,
+    reclaim: false,
+    verdict,
+    reason,
+  });
+  const reclaim = (verdict: BranchReclaimVerdictKind, reason: string): BranchReclaimVerdict => ({
+    branch,
+    reclaim: true,
+    verdict,
+    reason,
+  });
+
+  if (isInfrastructureBranch(branch, options.infrastructure ?? [])) {
+    return spare(
+      "infrastructure",
+      `${branch} is an infrastructure ref: it is merged by construction and the fleet needs it`,
+    );
+  }
+  if (options.trunk !== undefined && branch === options.trunk) {
+    return spare("trunk", `${branch} is the configured trunk`);
+  }
+  if (candidate.checkedOut === true) {
+    return spare("checked-out", "a worktree has this branch checked out");
+  }
+  if (liveIssueFromBranch(branch) === null) {
+    return spare(
+      "unrecognised",
+      "no Worker lane owns this branch namespace, so the reclaim leaves it alone",
+    );
+  }
+  if (candidate.landed === true) {
+    return reclaim("landed", "the trunk already carries this branch's commits");
+  }
+  if (candidate.issueClosed === true) {
+    return reclaim("issue-closed", "the tracker says this branch's issue is over");
+  }
+  return spare("unlanded", "this branch's work has not landed, so its commits exist only here");
+}
+
+/**
+ * Plan the local branch reclaim.
+ *
+ * The plan is total: every candidate appears exactly once across `reclaim` and
+ * `spare`, and `totals` states that identity. A branch offered twice is decided
+ * once and the repeat is reported as `already-planned`, never dropped.
+ */
+export function planBranchReclaim(
+  candidates: readonly BranchReclaimCandidate[],
+  options: BranchReclaimOptions = {},
+): BranchReclaimPlan {
+  const reclaim: BranchReclaimVerdict[] = [];
+  const spare: BranchReclaimVerdict[] = [];
+  const seen = new Set<string>();
+  let considered = 0;
+
+  for (const candidate of candidates) {
+    considered += 1;
+    if (seen.has(candidate.branch)) {
+      spare.push({
+        branch: candidate.branch,
+        reclaim: false,
+        verdict: "already-planned",
+        reason: "this branch was already decided earlier in the same plan",
+      });
+      continue;
+    }
+    seen.add(candidate.branch);
+    const verdict = judge(candidate, options);
+    if (verdict.reclaim) reclaim.push(verdict);
+    else spare.push(verdict);
+  }
+
+  return {
+    reclaim,
+    spare,
+    totals: { considered, reclaim: reclaim.length, spare: spare.length },
+  };
+}

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -122,6 +122,7 @@ import {
   planLiveBranchCleanup,
   planLocalBranchCleanup,
 } from "./core/branch-cleanup.js";
+import { planBranchReclaim } from "./core/branch-reclaim.js";
 import { executeUnblockSweep } from "./core/boot-sweep.js";
 import { collectReapInputs } from "./runtime/wire/reap.js";
 import { collectActivityReview } from "./commands/activity-review.js";
@@ -478,13 +479,24 @@ export function createDefaultDevAfkMcpOperations(
         inputs.lookup,
         nowS,
       );
-      const localPlan = planLocalBranchCleanup(
-        inputs.localLiveRefs,
-        inputs.lookup,
-        nowS,
+      // The local pass runs the one reclaim (#2866): it decides on the landed
+      // fact and refuses infrastructure refs by name, and it reports its spares
+      // so a caller of this tool sees what was kept on purpose.
+      const issueClosed = new Set(
+        branchesToReap(planLocalBranchCleanup(inputs.localLiveRefs, inputs.lookup, nowS))
+          .map((item) => item.branch),
+      );
+      const landed = new Set(inputs.landedLocalBranches);
+      const localPlan = planBranchReclaim(
+        inputs.localLiveRefs.map((ref) => ({
+          branch: ref.branch,
+          landed: landed.has(ref.branch),
+          issueClosed: issueClosed.has(ref.branch),
+        })),
+        { trunk: inputs.trunk },
       );
       const remoteReaped = branchesToReap(remotePlan).map((item) => item.branch);
-      const localReaped = branchesToReap(localPlan).map((item) => item.branch);
+      const localReaped = localPlan.reclaim.map((item) => item.branch);
       for (const branch of remoteReaped) await inputs.deleteRemote(branch);
       for (const branch of localReaped) await inputs.deleteLocal(branch);
       return {
@@ -492,6 +504,11 @@ export function createDefaultDevAfkMcpOperations(
         local_found: inputs.localLiveRefs.length,
         remote_reaped: remoteReaped,
         local_reaped: localReaped,
+        local_spared: localPlan.spare.map((item) => ({
+          branch: item.branch,
+          verdict: item.verdict,
+          reason: item.reason,
+        })),
       };
     },
     async unblockSweep() {

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -737,6 +737,33 @@ export async function listLocalBranches(ctx: GitContext, pattern: string): Promi
   return r.stdout.split("\n").map((l) => l.trim()).filter(Boolean);
 }
 
+/**
+ * Local branches matching a glob whose commits `base` ALREADY CARRIES — the
+ * landed fact the branch reclaim decides on (#2866).
+ *
+ * `base` should be the trunk's remote ref (`origin/<trunk>`), because a stale
+ * local trunk under-reports what has landed. Under-reporting is the safe
+ * direction and is why a git failure returns nothing: a base git cannot resolve
+ * spares every branch rather than condemning them all.
+ */
+export async function listMergedLocalBranches(
+  ctx: GitContext,
+  pattern: string,
+  base: string,
+): Promise<string[]> {
+  if (!base) return [];
+  const r = await runGit(ctx, [
+    "branch",
+    "--list",
+    pattern,
+    "--merged",
+    base,
+    "--format=%(refname:short)",
+  ]);
+  if (r.code !== 0) return [];
+  return r.stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+}
+
 /** Local branches currently checked out (to exclude from the local reaper). */
 export async function checkedOutBranches(ctx: GitContext): Promise<Set<string>> {
   const out = new Set<string>();

--- a/apps/dev/src/runtime/tmp-janitor.ts
+++ b/apps/dev/src/runtime/tmp-janitor.ts
@@ -683,9 +683,16 @@ export async function applyTmpJanitorReport(
     result.orphanFeedback.push(entry.path);
   }
 
-  // After removing orphaned feedback worktrees, ask git to prune its own
-  // internal registry so stale worktree entries do not accumulate there either.
-  if (result.orphanFeedback.length > 0 && options.worktreePrune) {
+  // Removing the BYTES of a registered git worktree is only half the reclaim:
+  // git's own registry still points at the deleted path, and a registration
+  // nothing cleaned up is the trap this sweep exists to remove — it blocks a new
+  // worktree at that path and can hold a lock a later gate run trips over
+  // (#2866). Every lane that can delete a worktree is counted, not just the
+  // feedback lane that used to be counted alone: a Worker's workspace is a
+  // registered worktree exactly as much as a feedback lane is.
+  const removedWorktrees =
+    removedFeedback.size + result.workerWorkspaces.length + result.staleWorkers.length;
+  if (removedWorktrees > 0 && options.worktreePrune) {
     await options.worktreePrune().catch(() => {});
   }
 

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -71,6 +71,7 @@ export async function collectBootOptions(
     remoteLiveRefs,
     localAll,
     checkedOut,
+    landedLocalBranches,
     unblockCandidates,
     staleClaimDirs,
     legacyWorkDirs,
@@ -82,6 +83,9 @@ export async function collectBootOptions(
       gitx.listRemoteBranches(gitCtx, "afk/"),
       gitx.listLocalBranches(gitCtx, "afk/*"),
       gitx.checkedOutBranches(gitCtx),
+      // Read against the trunk's REMOTE ref: a stale local trunk under-reports
+      // what has landed, and under-reporting only ever spares (#2866).
+      gitx.listMergedLocalBranches(gitCtx, "afk/*", `origin/${facts.configuredTrunk ?? DEFAULT_BRANCH}`),
       ghx.listUnblockCandidates(ghCtx),
       fsx.listStaleClaimDirs(paths.tmpDir),
       fsx.listLegacyWorkDirs(paths.tmpDir),
@@ -100,7 +104,12 @@ export async function collectBootOptions(
     bootstrap,
     orphans: orphans as readonly OrphanDir[],
     attemptCap: { byIssue },
-    branches: { remoteLiveRefs, localLiveRefs },
+    branches: {
+      remoteLiveRefs,
+      localLiveRefs,
+      landedLocalBranches,
+      trunk: facts.configuredTrunk ?? DEFAULT_BRANCH,
+    },
     unblockCandidates,
     staleClaimDirs,
     legacyWorkDirs,
@@ -509,6 +518,7 @@ export async function buildBootDeps(
       deleteLocalBranch: async (branch) => {
         await gitx.deleteLocalBranch(gitCtx, branch);
       },
+      worktreePrune: () => gitx.worktreePrune(gitCtx),
     },
     log,
     fastForwardLocalBase: ({ remote, target }) =>

--- a/apps/dev/src/runtime/wire/reap.ts
+++ b/apps/dev/src/runtime/wire/reap.ts
@@ -1,5 +1,7 @@
 import type { BranchRef, IssueMeta } from "../../core/branch-cleanup.js";
 import { liveIssueFromBranch } from "../../core/branch-cleanup.js";
+import { getConfig, loadConfig } from "../../core/config.js";
+import { DEFAULT_BRANCH } from "../../core/pin-reader.js";
 import { issueMeta, listIssueStates, type GhContext } from "../gh.js";
 import * as gitx from "../git.js";
 import { type RepoContext } from "./paths.js";
@@ -7,6 +9,10 @@ import { type RepoContext } from "./paths.js";
 export interface ReapInputs {
   remoteLiveRefs: BranchRef[];
   localLiveRefs: BranchRef[];
+  /** Local branches the trunk already carries — the landed fact (#2866). */
+  landedLocalBranches: string[];
+  /** The repo's configured trunk, so the reclaim can spare it by name. */
+  trunk: string;
   /** Synchronous issue-state lookup (pre-resolved gh metadata cache). */
   lookup: (issue: number) => IssueMeta | null | undefined;
   /** git deletion closures bound to the repo. */
@@ -29,6 +35,14 @@ export async function collectReapInputs(ctx: RepoContext): Promise<ReapInputs> {
   const localLiveRefs: BranchRef[] = localAll
     .filter((b) => !checkedOut.has(b))
     .map((b) => ({ branch: b }));
+  const trunk = getConfig(await loadConfig(ctx.root), "dev.trunk") || DEFAULT_BRANCH;
+  // Against the trunk's REMOTE ref: a stale local trunk under-reports what has
+  // landed, and under-reporting only ever spares (#2866).
+  const landedLocalBranches = await gitx.listMergedLocalBranches(
+    gitCtx,
+    "afk/*",
+    `${ctx.remote}/${trunk}`,
+  );
 
   // Pre-resolve every issue referenced across the live branch sets.
   const issues = new Set<number>();
@@ -50,6 +64,8 @@ export async function collectReapInputs(ctx: RepoContext): Promise<ReapInputs> {
   return {
     remoteLiveRefs,
     localLiveRefs,
+    landedLocalBranches,
+    trunk,
     lookup: (issue) => cache.get(issue),
     deleteRemote: (branch) => gitx.deleteRemoteBranch(gitCtx, branch),
     deleteLocal: async (branch) => {

--- a/apps/dev/tests/boot-cleanup.test.ts
+++ b/apps/dev/tests/boot-cleanup.test.ts
@@ -14,6 +14,33 @@ import {
   type UnblockCandidate,
 } from "./boot.helpers.js";
 import { KNOWN_TMP_LANES } from "../src/core/tmp-janitor.js";
+import type { WorkerArtifactVerdict } from "../src/core/worker-reclaim.js";
+
+type JanitorSweep = NonNullable<NonNullable<Parameters<typeof options>[0]>["tmpJanitor"]>;
+
+function emptyJanitorPlan(): JanitorSweep["plan"] {
+  return {
+    logs: { reclaim: [], spare: [] },
+    scratch: { reclaim: [], spare: [] },
+    diagnostics: { reclaim: [], spare: [] },
+    feedbackWorktrees: { reclaim: [], spare: [] },
+    legacySlotLogs: { reclaim: [], spare: [] },
+    unknownTmpRoots: [],
+  };
+}
+
+/** One dead Worker's workspace, already condemned by the daemon-keyed planner. */
+function workspaceVerdict(workerId: string, path: string): WorkerArtifactVerdict {
+  return {
+    worker_id: workerId,
+    artifact: { worker_id: workerId, kind: "worktree", path },
+    class: "workspace",
+    liveness: "dead",
+    reclaim: true,
+    verdict: "workspace-reclaimable",
+    reason: "the daemon calls this Worker gone",
+  };
+}
 
 describe("runBoot tmp janitor", () => {
   it("reaps orphan test-runner groups and records an audit row", async () => {
@@ -90,6 +117,49 @@ describe("runBoot tmp janitor", () => {
         { path: "/p/.red/tmp/work-old", livenessVerdict: "not-worker-workspace" },
       ],
     });
+  });
+
+  // #2866: removing a worktree's bytes leaves git still registering the path,
+  // which is what blocked a gate worktree from being created there.
+  it("prunes git's worktree registry after reclaiming a dead Worker's workspace", async () => {
+    const { deps, gitCalls } = makeDeps({ workerWorkspaceLivenessVerdict: async () => "dead" });
+    await runBoot(
+      deps,
+      options({
+        tmpJanitor: {
+          plan: emptyJanitorPlan(),
+          staleWorkers: { reclaim: [], spare: [] },
+          workerReclaim: {
+            workers: [],
+            reclaim: [
+              workspaceVerdict("wDEAD", "/p/.red/tmp/workers/wDEAD/2866/worktree"),
+            ],
+            retain: [],
+            dropped: [],
+            truncated: false,
+            totals: { considered: 1, reclaim: 1, retain: 0, dropped: 0 },
+          },
+        },
+      }),
+    );
+    expect(gitCalls.worktreePrune).toBe(1);
+  });
+
+  it("does not prune when only logs and scratch expired", async () => {
+    const { deps, gitCalls } = makeDeps();
+    await runBoot(
+      deps,
+      options({
+        tmpJanitor: {
+          plan: {
+            ...emptyJanitorPlan(),
+            logs: { reclaim: [{ path: "/p/.red/tmp/logs/old", mtimeS: NOW - 99 }], spare: [] },
+          },
+          staleWorkers: { reclaim: [], spare: [] },
+        },
+      }),
+    );
+    expect(gitCalls.worktreePrune).toBe(0);
   });
 
   it("refuses to remove a registered lane named as an unknown tmp root (#2679)", async () => {
@@ -417,10 +487,60 @@ describe("runBoot branch cleanup deletes the planned refs", () => {
     );
     expect(gitCalls.deleteRemote).toEqual(["afk/wAAA/9-slug"]);
     expect(gitCalls.deleteLocal).toEqual(["afk/wAAA/9-local"]);
-    expect(r.branchCleanup).toEqual({
-      remoteLiveReaped: ["afk/wAAA/9-slug"],
-      localLiveReaped: ["afk/wAAA/9-local"],
-    });
+    expect(r.branchCleanup?.remoteLiveReaped).toEqual(["afk/wAAA/9-slug"]);
+    expect(r.branchCleanup?.localLiveReaped).toEqual(["afk/wAAA/9-local"]);
+    expect(r.branchCleanup?.localSpared).toEqual([]);
+  });
+
+  // #2866: a branch whose PR merged while its issue stayed open is exactly the
+  // branch that accumulated 75-deep. Landing is the merge-base fact, so the
+  // reclaim must not wait for the tracker to catch up.
+  it("reaps a landed local branch even while its issue is still open", async () => {
+    const { deps, gitCalls } = makeDeps({ branchIssue: () => ({ state: "OPEN" } as IssueMeta) });
+    const localLiveRefs: BranchRef[] = [
+      { branch: "afk/wAAA/9-landed" },
+      { branch: "afk/wAAA/3-in-flight" },
+    ];
+    const r = await runBoot(
+      deps,
+      options({
+        branches: {
+          remoteLiveRefs: [],
+          localLiveRefs,
+          landedLocalBranches: ["afk/wAAA/9-landed"],
+          trunk: "main",
+        },
+      }),
+    );
+    expect(gitCalls.deleteLocal).toEqual(["afk/wAAA/9-landed"]);
+    expect(r.branchCleanup?.localSpared?.map((s) => [s.branch, s.verdict])).toEqual([
+      ["afk/wAAA/3-in-flight", "unlanded"],
+    ]);
+  });
+
+  it("never deletes red-trunk or the trunk, however landed they look", async () => {
+    const { deps, gitCalls } = makeDeps({ branchIssue: () => ({ state: "CLOSED", closedAt: "2000-01-01T00:00:00Z" } as IssueMeta) });
+    const localLiveRefs: BranchRef[] = [
+      { branch: "red-trunk" },
+      { branch: "main" },
+      { branch: "afk/wAAA/9-landed" },
+    ];
+    const r = await runBoot(
+      deps,
+      options({
+        branches: {
+          remoteLiveRefs: [],
+          localLiveRefs,
+          landedLocalBranches: ["red-trunk", "main", "afk/wAAA/9-landed"],
+          trunk: "main",
+        },
+      }),
+    );
+    expect(gitCalls.deleteLocal).toEqual(["afk/wAAA/9-landed"]);
+    expect(r.branchCleanup?.localSpared?.map((s) => [s.branch, s.verdict])).toEqual([
+      ["red-trunk", "infrastructure"],
+      ["main", "trunk"],
+    ]);
   });
 });
 

--- a/apps/dev/tests/boot.helpers.ts
+++ b/apps/dev/tests/boot.helpers.ts
@@ -77,6 +77,7 @@ export function makeDeps(over: Partial<{
   const gitCalls = {
     deleteRemote: [] as string[],
     deleteLocal: [] as string[],
+    worktreePrune: 0,
   };
 
   const deps: BootDeps = {
@@ -141,6 +142,10 @@ export function makeDeps(over: Partial<{
       async deleteLocalBranch(branch) {
         calls.push(`git.deleteLocal:${branch}`);
         gitCalls.deleteLocal.push(branch);
+      },
+      async worktreePrune() {
+        calls.push("git.worktreePrune");
+        gitCalls.worktreePrune += 1;
       },
     },
     ...(over.log ? { log: over.log } : {}),

--- a/apps/dev/tests/branch-reclaim.test.ts
+++ b/apps/dev/tests/branch-reclaim.test.ts
@@ -1,0 +1,119 @@
+// branch-reclaim.test.ts — local branches are reclaimed when their work has
+// LANDED, and infrastructure refs are named and never eligible (#2866).
+//
+// The incident this encodes: a hand sweep of "merged" branches deleted
+// `red-trunk`, the fleet's trunk mirror, because to a merged-ness test it looks
+// exactly like an ordinary merged branch. Every test below asks the planner the
+// question that sweep asked, and demands the answer that sweep got wrong.
+
+import { describe, expect, it } from "vitest";
+import {
+  INFRASTRUCTURE_BRANCHES,
+  planBranchReclaim,
+  type BranchReclaimCandidate,
+} from "../src/core/branch-reclaim.js";
+
+function verdictFor(
+  plan: ReturnType<typeof planBranchReclaim>,
+  branch: string,
+): { reclaim: boolean; verdict: string; reason: string } {
+  const found = [...plan.reclaim, ...plan.spare].find((entry) => entry.branch === branch);
+  if (found === undefined) throw new Error(`no verdict for ${branch}`);
+  return { reclaim: found.reclaim, verdict: found.verdict, reason: found.reason };
+}
+
+const landed: BranchReclaimCandidate = { branch: "afk/2100-landed-slice", landed: true };
+
+describe("infrastructure refs are named and never eligible", () => {
+  it("names red-trunk", () => {
+    expect(INFRASTRUCTURE_BRANCHES).toContain("red-trunk");
+  });
+
+  it("spares red-trunk even when it is fully merged into the trunk", () => {
+    const plan = planBranchReclaim([{ branch: "red-trunk", landed: true }], { trunk: "main" });
+    expect(verdictFor(plan, "red-trunk").reclaim).toBe(false);
+    expect(verdictFor(plan, "red-trunk").verdict).toBe("infrastructure");
+    expect(plan.reclaim).toEqual([]);
+  });
+
+  it("spares the configured trunk itself, whatever it is named", () => {
+    const plan = planBranchReclaim([{ branch: "develop", landed: true }], { trunk: "develop" });
+    expect(verdictFor(plan, "develop").verdict).toBe("trunk");
+    expect(plan.reclaim).toEqual([]);
+  });
+
+  it("spares a branch outside any Worker namespace rather than guessing", () => {
+    const plan = planBranchReclaim([{ branch: "release/v2", landed: true }], { trunk: "main" });
+    expect(verdictFor(plan, "release/v2").verdict).toBe("unrecognised");
+    expect(plan.reclaim).toEqual([]);
+  });
+});
+
+describe("a Worker branch whose work has landed is reclaimed", () => {
+  it("reclaims a landed branch even while its issue is still open", () => {
+    const plan = planBranchReclaim([{ ...landed, issueClosed: false }], { trunk: "main" });
+    expect(verdictFor(plan, landed.branch).reclaim).toBe(true);
+    expect(verdictFor(plan, landed.branch).verdict).toBe("landed");
+  });
+
+  it("reclaims a branch whose issue is closed even when merged-ness is unknown", () => {
+    const plan = planBranchReclaim(
+      [{ branch: "afk/2101-closed-slice", issueClosed: true }],
+      { trunk: "main" },
+    );
+    expect(verdictFor(plan, "afk/2101-closed-slice").verdict).toBe("issue-closed");
+  });
+
+  it("spares a Worker branch whose work has not landed", () => {
+    const plan = planBranchReclaim([{ branch: "afk/2102-in-flight" }], { trunk: "main" });
+    expect(verdictFor(plan, "afk/2102-in-flight").reclaim).toBe(false);
+    expect(verdictFor(plan, "afk/2102-in-flight").verdict).toBe("unlanded");
+  });
+
+  it("spares a landed branch a worktree still holds", () => {
+    const plan = planBranchReclaim([{ ...landed, checkedOut: true }], { trunk: "main" });
+    expect(verdictFor(plan, landed.branch).reclaim).toBe(false);
+    expect(verdictFor(plan, landed.branch).verdict).toBe("checked-out");
+  });
+
+  it("spares a legacy per-worker branch that has not landed", () => {
+    const plan = planBranchReclaim([{ branch: "afk/wZK2Z/2103-legacy" }], { trunk: "main" });
+    expect(verdictFor(plan, "afk/wZK2Z/2103-legacy").verdict).toBe("unlanded");
+  });
+});
+
+describe("the plan reports what it removed and what it deliberately spared", () => {
+  it("accounts for every candidate exactly once", () => {
+    const candidates: BranchReclaimCandidate[] = [
+      { branch: "red-trunk", landed: true },
+      { branch: "main", landed: true },
+      { branch: "afk/2100-landed-slice", landed: true },
+      { branch: "afk/2102-in-flight" },
+      { branch: "release/v2", landed: true },
+    ];
+    const plan = planBranchReclaim(candidates, { trunk: "main" });
+    expect(plan.totals.considered).toBe(candidates.length);
+    expect(plan.totals.reclaim + plan.totals.spare).toBe(candidates.length);
+    expect(plan.totals.reclaim).toBe(plan.reclaim.length);
+    expect(plan.totals.spare).toBe(plan.spare.length);
+  });
+
+  it("carries a reason on every spare, so a reader never has to guess", () => {
+    const plan = planBranchReclaim(
+      [
+        { branch: "red-trunk", landed: true },
+        { branch: "afk/2102-in-flight" },
+      ],
+      { trunk: "main" },
+    );
+    for (const spared of plan.spare) expect(spared.reason).not.toBe("");
+  });
+
+  it("never reclaims the same branch twice, and says why the repeat was spared", () => {
+    const plan = planBranchReclaim([landed, landed], { trunk: "main" });
+    expect(plan.reclaim.map((entry) => entry.branch)).toEqual([landed.branch]);
+    expect(plan.spare.map((entry) => entry.verdict)).toEqual(["already-planned"]);
+    expect(plan.totals.considered).toBe(2);
+    expect(plan.totals.reclaim + plan.totals.spare).toBe(2);
+  });
+});

--- a/apps/dev/tests/runtime-git-branch.test.ts
+++ b/apps/dev/tests/runtime-git-branch.test.ts
@@ -15,6 +15,7 @@ import {
   worktreePathUnder,
   unquotePorcelainPath,
   listRemoteBranches,
+  listMergedLocalBranches,
 } from "../src/runtime/git.js";
 import type { GitContext } from "../src/runtime/git.js";
 import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
@@ -400,5 +401,35 @@ describe("exit-time salvage surface (ADR 0103)", () => {
     const gitModule = await import("../src/runtime/git.js");
     expect(Object.keys(gitModule)).not.toContain("salvageUncommitted");
     expect(Object.keys(gitModule)).not.toContain("pushBranch");
+  });
+});
+
+describe("listMergedLocalBranches reads the landed fact (#2866)", () => {
+  it("asks git which matching branches the base already carries", async () => {
+    const { exec, calls } = recordingExec(() => ok("afk/9-landed\nafk/3-also-landed\n"));
+    const ctx: GitContext = { cwd: "/repo", exec };
+    const merged = await listMergedLocalBranches(ctx, "afk/*", "origin/main");
+    expect(merged).toEqual(["afk/9-landed", "afk/3-also-landed"]);
+    expect(calls[0]).toEqual([
+      "git",
+      "branch",
+      "--list",
+      "afk/*",
+      "--merged",
+      "origin/main",
+      "--format=%(refname:short)",
+    ]);
+  });
+
+  it("reports NOTHING landed when git cannot resolve the base", async () => {
+    // Under-reporting spares every branch; over-reporting deletes unlanded work.
+    const { exec } = recordingExec(() => fail());
+    expect(await listMergedLocalBranches({ cwd: "/repo", exec }, "afk/*", "origin/main")).toEqual([]);
+  });
+
+  it("asks git nothing at all when no base was resolved", async () => {
+    const { exec, calls } = recordingExec(() => ok("afk/9-landed\n"));
+    expect(await listMergedLocalBranches({ cwd: "/repo", exec }, "afk/*", "")).toEqual([]);
+    expect(calls).toEqual([]);
   });
 });

--- a/apps/dev/tests/supervise-passthrough.test.ts
+++ b/apps/dev/tests/supervise-passthrough.test.ts
@@ -164,13 +164,21 @@ describe("formatBootSweepResult — supervisor boot log shape (#623)", () => {
       bootstrap: { ok: true },
       orphanCleanup: { removed: ["a", "b"], restored: [7], kept: ["c"], legacyWiped: [], claimsReleased: [] },
       attemptCap: { reclaimed: ["x"] },
-      branchCleanup: { remoteLiveReaped: [], localLiveReaped: ["l1", "l2"] },
+      branchCleanup: {
+        remoteLiveReaped: [],
+        localLiveReaped: ["l1", "l2"],
+        localSpared: [
+          // #2866: the spare is reported, so an operator can see the trunk
+          // mirror was kept on purpose rather than missed by accident.
+          { branch: "red-trunk", reclaim: false, verdict: "infrastructure", reason: "infrastructure ref" },
+        ],
+      },
       unblockSweep: { promoted: [9] },
       straggler: { counts: { unlabeled: 2, needsTriage: 1, needsInfo: 0 }, warn: true },
     };
     expect(formatBootSweepResult(result)).toBe(
       "boot sweeps complete: orphans removed=2 restored=1 kept=1 | attempt-cap reclaimed=1 | " +
-        "branches remote=0 local=2 | tmp-janitor expired=0 workers=0 orphan-runners=0 unknown=0 protected=0 | " +
+        "branches remote=0 local=2 spared=1 | tmp-janitor expired=0 workers=0 orphan-runners=0 unknown=0 protected=0 | " +
         "docs-sweep clean files=0 | unblocked=1 | stragglers unlabeled=2 triage=1 info=0",
     );
   });

--- a/apps/dev/tests/tmp-janitor-daemon-reclaim.test.ts
+++ b/apps/dev/tests/tmp-janitor-daemon-reclaim.test.ts
@@ -286,3 +286,42 @@ describe("the reclaim planner stays total", () => {
     expect(plan.retain.map((verdict) => verdict.verdict)).toEqual(["worker-live", "worker-live"]);
   });
 });
+
+describe("reclaiming a worktree also drops git's registration of it (#2866)", () => {
+  it("prunes after removing a dead Worker's workspace", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const { worktree } = await workspace(tmp, "wDONE", 2866);
+    let pruned = 0;
+
+    const result = await runTmpJanitor(tmp, NOW, () => "OPEN", {
+      fix: true,
+      daemon: daemonNaming("wOTHER"),
+      worktreePrune: async () => {
+        pruned += 1;
+      },
+    });
+
+    expect(result.applied?.workerWorkspaces).toEqual([worktree]);
+    // Without this, git keeps pointing at a path that no longer exists — the
+    // stale registration that blocked a gate worktree from being created.
+    expect(pruned).toBe(1);
+  });
+
+  it("does not prune when nothing was removed", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    await workspace(tmp, "wLIVE", 2866);
+    let pruned = 0;
+
+    await runTmpJanitor(tmp, NOW, () => "OPEN", {
+      fix: true,
+      daemon: daemonNaming("wLIVE"),
+      worktreePrune: async () => {
+        pruned += 1;
+      },
+    });
+
+    expect(pruned).toBe(0);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2866. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2866

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788023918&installation_model_id=20659&pr_number=2870&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2870&signature=a1fc0f28db39266068f6ab1323df81cae9426f64c413714f653a99e4ae2b1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->