### PR TITLE
fix: #2867 A transient download failure in CI setup fails the whole job with no retry

### DIFF
--- a/.github/actions/install-red-binary/action.yml
+++ b/.github/actions/install-red-binary/action.yml
@@ -27,36 +27,31 @@ runs:
       run: |
         set -euo pipefail
 
+        # Same retrying fetcher the workflows use (#2867). curl's own --retry,
+        # which this used to carry, does not reschedule a 403 — and a blipping
+        # 403 from the Releases API is exactly how this fetch fails.
+        fetch="$GITHUB_ACTION_PATH/../../../scripts/ci-fetch-with-retry.sh"
+
         curl_auth=()
         if [ -n "${RED_GITHUB_TOKEN:-}" ]; then
           curl_auth=(-H "Authorization: Bearer ${RED_GITHUB_TOKEN}")
         fi
 
-        curl_json() {
-          curl -fsSL \
-            --retry 3 \
-            --retry-connrefused \
-            --retry-delay 2 \
-            --max-time 60 \
+        fetch_json() {
+          CI_FETCH_MAX_TIME_S=60 "$fetch" "$1" "$2" \
             "${curl_auth[@]}" \
-            -H "Accept: application/vnd.github+json" \
-            "$@"
+            -H "Accept: application/vnd.github+json"
         }
 
-        curl_asset() {
-          curl -fsSL \
-            --retry 3 \
-            --retry-connrefused \
-            --retry-delay 2 \
-            --max-time 120 \
+        fetch_asset() {
+          CI_FETCH_MAX_TIME_S=120 "$fetch" "$1" "$2" \
             "${curl_auth[@]}" \
-            -H "Accept: application/octet-stream" \
-            "$@"
+            -H "Accept: application/octet-stream"
         }
 
         release_json="$RUNNER_TEMP/red-release.json"
-        curl_json "https://api.github.com/repos/reddb-io/reddb/releases/tags/${RED_VERSION}" \
-          -o "$release_json"
+        fetch_json "https://api.github.com/repos/reddb-io/reddb/releases/tags/${RED_VERSION}" \
+          "$release_json"
 
         asset_id="$(
           node -e 'const fs = require("node:fs"); const name = process.argv[1]; const release = JSON.parse(fs.readFileSync(0, "utf8")); const asset = release.assets.find((entry) => entry.name === name); if (!asset) throw new Error(`${name} release asset not found`); console.log(asset.id);' \
@@ -74,10 +69,10 @@ runs:
 
         red_bin="$RUNNER_TEMP/red"
         checksum_file="$RUNNER_TEMP/red.sha256"
-        curl_asset "https://api.github.com/repos/reddb-io/reddb/releases/assets/${asset_id}" \
-          -o "$red_bin"
-        curl_asset "https://api.github.com/repos/reddb-io/reddb/releases/assets/${checksum_asset_id}" \
-          -o "$checksum_file"
+        fetch_asset "https://api.github.com/repos/reddb-io/reddb/releases/assets/${asset_id}" \
+          "$red_bin"
+        fetch_asset "https://api.github.com/repos/reddb-io/reddb/releases/assets/${checksum_asset_id}" \
+          "$checksum_file"
 
         expected="$(awk '{print $1}' "$checksum_file")"
         actual="$(sha256sum "$red_bin" | awk '{print $1}')"

--- a/.github/workflows/red-rsp-benchmark-ci.yml
+++ b/.github/workflows/red-rsp-benchmark-ci.yml
@@ -32,13 +32,15 @@ jobs:
           TQ_VERSION: v0.3.0
           GH_TOKEN: ${{ github.token }}
         run: |
-          curl --fail --silent --show-error \
-            --retry 1 --retry-delay 2 --retry-connrefused \
+          set -euo pipefail
+          installer="$RUNNER_TEMP/tq-install.sh"
+          scripts/ci-fetch-with-retry.sh \
+            "https://api.github.com/repos/reddb-io/toon/contents/install.sh?ref=${TQ_VERSION}" \
+            "$installer" \
             -H "Accept: application/vnd.github.raw+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/reddb-io/toon/contents/install.sh?ref=${TQ_VERSION}" |
-            sh
+            -H "X-GitHub-Api-Version: 2022-11-28"
+          sh "$installer"
 
       - name: Install workspace dependencies
         env:

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -209,13 +209,15 @@ jobs:
           TQ_VERSION: v0.3.0
           GH_TOKEN: ${{ github.token }}
         run: |
-          curl --fail --silent --show-error \
-            --retry 1 --retry-delay 2 --retry-connrefused \
+          set -euo pipefail
+          installer="$RUNNER_TEMP/tq-install.sh"
+          scripts/ci-fetch-with-retry.sh \
+            "https://api.github.com/repos/reddb-io/toon/contents/install.sh?ref=${TQ_VERSION}" \
+            "$installer" \
             -H "Accept: application/vnd.github.raw+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/reddb-io/toon/contents/install.sh?ref=${TQ_VERSION}" |
-            sh
+            -H "X-GitHub-Api-Version: 2022-11-28"
+          sh "$installer"
 
       - name: Install workspace dependencies
         if: env.RUN_ANY == 'true'

--- a/apps/dev/tests/ci-fetch-retry.test.ts
+++ b/apps/dev/tests/ci-fetch-retry.test.ts
@@ -1,0 +1,183 @@
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+const SCRIPT = join(ROOT, "scripts/ci-fetch-with-retry.sh");
+
+type Run = { code: number; stderr: string };
+
+/**
+ * Runs the fetcher with a tight retry budget so a test never pays the real
+ * CI backoff. The defaults live in the script; only the pacing is overridden.
+ */
+async function fetchWithRetry(args: string[], attempts = 3): Promise<Run> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(SCRIPT, args, {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        CI_FETCH_ATTEMPTS: String(attempts),
+        CI_FETCH_INITIAL_DELAY_S: "0",
+        CI_FETCH_MAX_TIME_S: "10",
+      },
+    });
+
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? -1, stderr }));
+  });
+}
+
+async function readWorkflow(name: string): Promise<string> {
+  return readFile(join(ROOT, ".github/workflows", name), "utf8");
+}
+
+function stepBody(workflow: string, name: string): string {
+  const marker = `      - name: ${name}\n`;
+  const start = workflow.indexOf(marker);
+  expect(start, `missing workflow step: ${name}`).toBeGreaterThanOrEqual(0);
+
+  const next = workflow.indexOf("\n      - name: ", start + marker.length);
+  return workflow.slice(start, next === -1 ? workflow.length : next);
+}
+
+const servers: Server[] = [];
+const tempDirs: string[] = [];
+
+async function serve(handler: (hits: number) => { status: number; body: string }): Promise<string> {
+  let hits = 0;
+  const server = createServer((_req, res) => {
+    hits += 1;
+    const { status, body } = handler(hits);
+    res.writeHead(status, { "content-type": "text/plain" });
+    res.end(body);
+  });
+  servers.push(server);
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (typeof address === "string" || address === null) throw new Error("no port");
+  return `http://127.0.0.1:${address.port}/install.sh`;
+}
+
+async function outputPath(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "ci-fetch-"));
+  tempDirs.push(dir);
+  return join(dir, "downloaded");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+  );
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("ci-fetch-with-retry", () => {
+  it("retries a 403 and succeeds, because curl's own --retry never covers 403", async () => {
+    // The exact outage this exists for: a single transient
+    // `curl: (22) The requested URL returned error: 403` failed a whole job.
+    // curl --retry only reschedules 408/429/5xx, so the blip was never retried.
+    const url = await serve((hits) =>
+      hits < 3 ? { status: 403, body: "rate limited" } : { status: 200, body: "#!/bin/sh\necho ok\n" },
+    );
+    const output = await outputPath();
+
+    const run = await fetchWithRetry([url, output]);
+
+    expect(run.code, run.stderr).toBe(0);
+    expect(await readFile(output, "utf8")).toContain("echo ok");
+  });
+
+  it("names the URL and the HTTP status when every attempt is refused", async () => {
+    const url = await serve(() => ({ status: 403, body: "forbidden" }));
+    const output = await outputPath();
+
+    const run = await fetchWithRetry([url, output]);
+
+    expect(run.code).toBe(1);
+    expect(run.stderr).toContain(url);
+    expect(run.stderr).toContain("403");
+    // "wrong", not "unreachable": the server answered.
+    expect(run.stderr).toContain("answered with HTTP 403");
+  });
+
+  it("reports an unreachable host as unreachable rather than as a status", async () => {
+    // Nothing is listening on this port, so there is no HTTP status at all.
+    const output = await outputPath();
+
+    const run = await fetchWithRetry(["http://127.0.0.1:1/install.sh", output]);
+
+    expect(run.code).toBe(1);
+    expect(run.stderr).toContain("unreachable");
+    expect(run.stderr).not.toContain("answered with HTTP");
+  });
+
+  it("leaves no partial body behind when the fetch fails", async () => {
+    const url = await serve(() => ({ status: 500, body: "half a script" }));
+    const output = await outputPath();
+
+    const run = await fetchWithRetry([url, output]);
+
+    expect(run.code).toBe(1);
+    expect(existsSync(output)).toBe(false);
+  });
+
+  it("makes every attempt, so a late recovery still lands", async () => {
+    const url = await serve((hits) => (hits < 5 ? { status: 502, body: "" } : { status: 200, body: "late" }));
+    const output = await outputPath();
+
+    const run = await fetchWithRetry([url, output], 5);
+
+    expect(run.code, run.stderr).toBe(0);
+    expect(await readFile(output, "utf8")).toBe("late");
+  });
+});
+
+describe("CI setup network fetches", () => {
+  it("routes the workspace-CI tq install through the shared fetcher", async () => {
+    const step = stepBody(await readWorkflow("red-workspace-ci.yml"), "Install pinned tq");
+
+    expect(step).toContain("scripts/ci-fetch-with-retry.sh");
+    // Piping the installer straight into `sh` would execute a partial body and
+    // make the retry meaningless — download first, then run.
+    expect(step).not.toMatch(/\|\s*\n?\s*sh$/m);
+    expect(step).not.toContain("curl ");
+  });
+
+  it("routes the benchmark-CI tq install through the shared fetcher", async () => {
+    const step = stepBody(await readWorkflow("red-rsp-benchmark-ci.yml"), "Install pinned tq");
+
+    expect(step).toContain("scripts/ci-fetch-with-retry.sh");
+    expect(step).not.toContain("curl ");
+  });
+
+  it("routes the red binary install through the shared fetcher too, not a special case", async () => {
+    const action = await readFile(join(ROOT, ".github/actions/install-red-binary/action.yml"), "utf8");
+
+    expect(action).toContain("ci-fetch-with-retry.sh");
+    expect(action).not.toContain("curl -fsSL");
+  });
+
+  it("leaves no un-retried curl anywhere in CI setup", async () => {
+    const surfaces = [
+      ".github/workflows/red-workspace-ci.yml",
+      ".github/workflows/red-rsp-benchmark-ci.yml",
+      ".github/actions/install-red-binary/action.yml",
+    ];
+
+    for (const surface of surfaces) {
+      const body = await readFile(join(ROOT, surface), "utf8");
+      expect(body, `${surface} still fetches with a bare curl`).not.toMatch(/^\s*curl\b/m);
+    }
+  });
+});

--- a/scripts/ci-fetch-with-retry.sh
+++ b/scripts/ci-fetch-with-retry.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Fetch one URL to a file with bounded exponential backoff — the single path
+# every network fetch in CI setup goes through (#2867).
+#
+# The outage this pins: the `Install pinned tq` step fetched its installer with
+# `curl --fail --retry 1` and a transient
+# `curl: (22) The requested URL returned error: 403` failed the entire test job.
+# The other seven checks were green; nothing about the change was wrong. The
+# `--retry` flag was already there and bought nothing, because curl only
+# reschedules its own fixed set of transient statuses (408, 429, 5xx) — a 403
+# from an API edge is not on that list and is never retried. Passing
+# `--retry-all-errors` would fix that one flag in that one step; a shared script
+# fixes it everywhere and keeps the next fetch from being special-cased too.
+#
+# A failure after the whole budget names the URL and the observed HTTP status,
+# so the log distinguishes "unreachable" (no status was ever observed) from
+# "wrong" (the server answered, and answered 4xx). That distinction is what a
+# human reads to tell an infrastructure blip from a real defect.
+#
+# Usage: ci-fetch-with-retry.sh <url> <output-path> [extra curl args...]
+#
+# Knobs (env, defaults tuned for CI; tests tighten the pacing):
+#   CI_FETCH_ATTEMPTS         total attempts, including the first  (default 5)
+#   CI_FETCH_INITIAL_DELAY_S  first backoff, doubled each retry    (default 2)
+#   CI_FETCH_MAX_TIME_S       per-attempt curl timeout             (default 120)
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: ci-fetch-with-retry.sh <url> <output-path> [curl args...]" >&2
+  exit 2
+fi
+
+url="$1"
+output="$2"
+shift 2
+
+attempts="${CI_FETCH_ATTEMPTS:-5}"
+delay="${CI_FETCH_INITIAL_DELAY_S:-2}"
+max_time="${CI_FETCH_MAX_TIME_S:-120}"
+
+status="000"
+attempt=1
+
+while [ "$attempt" -le "$attempts" ]; do
+  set +e
+  status="$(
+    curl --silent --show-error --location \
+      --max-time "$max_time" \
+      --output "$output" \
+      --write-out '%{http_code}' \
+      "$@" \
+      "$url"
+  )"
+  curl_exit=$?
+  set -e
+
+  # A hard curl failure can leave the status unwritten; treat it as "no answer".
+  case "$status" in
+    ''|*[!0-9]*) status="000" ;;
+  esac
+
+  if [ "$curl_exit" -eq 0 ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+    exit 0
+  fi
+
+  # Never leave a partial or error body where a caller would execute it.
+  rm -f "$output"
+
+  echo "fetch attempt ${attempt}/${attempts} failed: status=${status} curl_exit=${curl_exit} url=${url}" >&2
+
+  if [ "$attempt" -lt "$attempts" ]; then
+    if [ "$delay" -gt 0 ]; then
+      echo "  retrying in ${delay}s" >&2
+      sleep "$delay"
+    fi
+    delay=$((delay * 2))
+  fi
+
+  attempt=$((attempt + 1))
+done
+
+echo "fetch failed after ${attempts} attempts: ${url}" >&2
+if [ "$status" = "000" ]; then
+  echo "  the host was unreachable — no HTTP status was ever observed" >&2
+else
+  echo "  the server answered with HTTP ${status} on the last attempt" >&2
+fi
+exit 1


### PR DESCRIPTION
Automated AFK landing for #2867. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2867

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788024282&installation_model_id=20659&pr_number=2871&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2871&signature=a99ec93303f20a8ed8920f07b6b359a4b7b61b32824fe58a674222db5cf64a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->