### PR TITLE
fix: #2864 A branch that is merely behind is parked as blocked:merge-conflict

### DIFF
--- a/.changeset/a-behind-branch-is-not-a-conflict.md
+++ b/.changeset/a-behind-branch-is-not-a-conflict.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A branch that is merely behind its base is no longer parked as a merge conflict (#2864). `behind` and `dirty` are different states and GitHub reports them differently, but the no-agent landing lane funnelled every non-infra landing refusal into one park — so a pull request with zero conflicts, zero failing checks and `mergeable=true`, one `gh pr update-branch` from merging, was recorded `blocked:merge-conflict` and a human was sent to resolve something that did not exist. A stale base is the NORMAL condition of a busy lane, since every land moves the base for every other in-flight Worker, so that label was reached often and each time it stranded finished work.
+
+**`blocked:merge-conflict` is now reserved for a branch that genuinely conflicts, and its summary names the conflicting paths.** One router, `routeLandingFailure`, decides the terminal from the refusal that was observed: only a real pre-merge-rebase conflict reaches the conflict park (carrying the paths git reported unmerged, read before the abort clears the index); a merge the forge rejected on a mergeable PR and a CI hold park under `blocked:ci` with the cause the PR itself reported; a failed integrated-tree gate parks under `blocked:validation`; a hook abort under `blocked:policy`; and a land-lock timeout parks nothing at all, because it is a backoff and the branch is left untouched for the next sweep.
+
+The landing itself stops passing three non-conflicts off as conflicts: a base that could not be fetched, a force-with-lease race that outlived its retries, and a pull request that could never be opened are now infra refusals that state which step failed. A merely-behind branch keeps taking the repair it always deserved — one `gh pr update-branch`, then the merge — inside the landing lane rather than parking.

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -362,6 +362,9 @@ export type LandingResult =
       infraReason?: string;
     };
 
+/** Why a landing refused, as one named union the callers can route on (#2864). */
+export type LandingFailureReason = Extract<LandingResult, { ok: false }>["reason"];
+
 export type LandingPostMergeValidation =
   | {
       path: "satisfied-by-ci";
@@ -630,6 +633,21 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
           ...(result.mergeFailure ? { message: result.mergeFailure.summary } : {}),
         };
       }
+      // #2864: a branch that never reached a pull request never conflicted with
+      // anything. Route the two no-merge-attempted modes to `infra` so neither
+      // can land on a conflict terminal by falling through.
+      if (result.reason === "push-failed" || result.reason === "no-pr") {
+        return {
+          ok: false,
+          reason: "infra",
+          locked: input.locked,
+          prNumber: result.prNumber,
+          infraReason:
+            result.reason === "push-failed"
+              ? "the worker branch could not be force-pushed before the pull request was opened; nothing was merged"
+              : "no pull request could be opened or reused for the worker branch; nothing was merged",
+        };
+      }
       return {
         ok: false,
         reason: "land-failed",
@@ -660,8 +678,9 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
     if (r.ok) return mapResult(r);
     // Route the CI-aware failure modes (#812) distinctly. A failed required check
     // or a still-pending PR is NOT a merge conflict — preserve the open PR and hand
-    // it to the `blocked:ci` path rather than the merge-conflict re-run. Everything
-    // else (real conflict / push / no-PR / admin-merge rejection) stays land-failed.
+    // it to the `blocked:ci` path rather than the merge-conflict re-run. A push or
+    // PR-open failure is infra (#2864); only an unmapped merge-step refusal is
+    // left as land-failed.
     // `locked` echoes the session's lock state (#842): the admin-PR path is no
     // longer unlocked-only — lock=X + openPr=true also lands through here.
     return mapResult(r);
@@ -675,8 +694,10 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
  * on the worker branch and {@link preMergeRebase} it onto the fetched base,
  * force-pushing the result. Returns a failing {@link LandingResult} to abort the
  * landing (parked as blocked:merge-conflict via `pr-conflict`) on a real conflict
- * or an exhausted force-with-lease retry; returns an infra failure when the
- * rebase worktree provisioner is absent or cannot create a checkout; returns
+ * or the #2481 stale-branch refusal; returns an infra failure when the rebase
+ * worktree provisioner is absent or cannot create a checkout, when the base
+ * could not be fetched, or when the force-with-lease race outlived its retries
+ * (#2864 — none of those is a conflict); returns
  * `undefined` — "proceed to the admin-merge" — only on completed integration.
  * The worktree is always torn down.
  */
@@ -728,18 +749,33 @@ async function preparePrRebaseWorktree(
       maxAgentResolveAttempts: deps.maxAgentConflictResolveAttempts,
     });
     if (!rebased.ok) {
-      // Real conflict / exhausted force-with-lease retries → park merge-conflict.
-      // A `stale-branch` refusal (#2481) parks through the same route but carries
-      // its own actionable text, so the human sees WHY the landing declined to
-      // replay a fat branch onto a base that moved hours ago.
       await deps.removeRebaseWorktree?.(dir);
+      // #2864: `pr-conflict` — and the `blocked:merge-conflict` park behind it —
+      // is reserved for a branch that GENUINELY conflicts. A real rebase conflict
+      // qualifies and now names its conflicting paths; a `stale-branch` refusal
+      // (#2481) qualifies because its whole finding is that replaying this branch
+      // would conflict commit by commit, and it carries its own actionable text.
+      // A failed fetch and an exhausted force-with-lease race are neither: the
+      // rebase never conflicted, so they route to `infra` with the observed
+      // reason instead of sending a human to resolve a conflict that never was.
+      if (rebased.reason === "conflict" || rebased.reason === "stale-branch") {
+        return {
+          ok: false,
+          result: {
+            ok: false,
+            reason: "pr-conflict",
+            locked: input.locked,
+            ...(rebased.message ? { message: rebased.message } : {}),
+          },
+        };
+      }
       return {
         ok: false,
         result: {
           ok: false,
-          reason: "pr-conflict",
+          reason: "infra",
           locked: input.locked,
-          ...(rebased.reason === "stale-branch" && rebased.message ? { message: rebased.message } : {}),
+          infraReason: rebased.message ?? `the pre-merge rebase failed (${rebased.reason ?? "unexplained"}); nothing was merged`,
         },
       };
     }

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -199,8 +199,47 @@ export interface PreMergeRebaseResult {
   ok: boolean;
   /** Set on `ok:false` — the distinct failure mode. */
   reason?: PreMergeRebaseFailReason;
-  /** Actionable refusal text, set on `stale-branch`. */
+  /** Actionable refusal text, set on `stale-branch` and on `conflict`. */
   message?: string;
+  /**
+   * The paths git reported UNMERGED when the rebase stopped (#2864) — the
+   * EVIDENCE that this refusal really is a conflict, and the list the human
+   * needs. Read before `rebase --abort` clears the index; empty when git could
+   * not answer, which the summary says rather than implying there are none.
+   */
+  conflictPaths?: readonly string[];
+}
+
+/** How many conflicting paths a refusal summary names before it counts the rest. */
+const CONFLICT_PATHS_NAMED = 10;
+
+/** Parse `git diff --name-only --diff-filter=U` stdout into unique paths. */
+export function parseUnmergedPaths(stdout: string): string[] {
+  const seen = new Set<string>();
+  for (const line of stdout.split("\n")) {
+    const path = line.trim();
+    if (path !== "") seen.add(path);
+  }
+  return [...seen];
+}
+
+/**
+ * One line naming a GENUINE conflict and the files it is in (#2864).
+ *
+ * `blocked:merge-conflict` is reserved for a branch that actually conflicts, so
+ * the summary that rides it must name the conflicting paths — a human sent to
+ * "resolve the conflict" with no path was, often as not, sent to resolve a
+ * branch that was merely out of date. An unreadable path list says so instead
+ * of reading as "no files".
+ */
+export function describeRebaseConflict(base: string, paths: readonly string[]): string {
+  if (paths.length === 0) {
+    return `the worker branch conflicts with ${base} (the conflicting paths could not be read)`;
+  }
+  const named = paths.slice(0, CONFLICT_PATHS_NAMED).join(", ");
+  const rest = paths.length - CONFLICT_PATHS_NAMED;
+  const tail = rest > 0 ? `, and ${rest} more` : "";
+  return `the worker branch conflicts with ${base} in ${paths.length} file(s): ${named}${tail}`;
 }
 
 /**
@@ -212,11 +251,16 @@ export interface PreMergeRebaseResult {
  * never touched. Sequence, mirroring the issue spec:
  *   1. `git fetch <remote> <base>`, then short-circuit if `<remote>/<base>` is
  *      already an ancestor of `HEAD`; otherwise `git rebase <remote>/<base>`;
- *   2. on a rebase conflict → `git rebase --abort` → `{ ok:false, conflict }`;
+ *   2. on a rebase conflict → read the unmerged paths → `git rebase --abort` →
+ *      `{ ok:false, conflict, conflictPaths }`;
  *   3. `git push <remote> HEAD:refs/heads/<branch> --force-with-lease`;
  *   4. on a push reject (a landing race), re-fetch + re-rebase the advanced base
  *      and retry up to `maxPushRetries` times; exhausting them → `push-rejected`.
- * Both failure modes map to `blocked:merge-conflict` at the caller.
+ *
+ * Only `conflict` (and the #2481 `stale-branch` refusal, whose whole point is a
+ * doomed replay) maps to `blocked:merge-conflict` at the caller. A failed fetch
+ * and an exhausted force-with-lease race are landing-infrastructure failures on
+ * a branch that never conflicted, and each carries a `message` saying so (#2864).
  */
 export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Promise<PreMergeRebaseResult> {
   const { repo, remote, base, branch } = input;
@@ -282,7 +326,13 @@ export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Pr
   // push-retry loop so a racing base advance is re-integrated before each retry.
   const rebaseOntoBase = async (): Promise<PreMergeRebaseResult & { alreadyIntegrated?: boolean }> => {
     const fetch = await exec(["git", "-C", repo, "fetch", remote, base, "--quiet"]);
-    if (fetch.code !== 0) return { ok: false, reason: "fetch-failed" };
+    if (fetch.code !== 0) {
+      return {
+        ok: false,
+        reason: "fetch-failed",
+        message: `the landing could not fetch ${baseRef} before the pre-merge rebase — no rebase was attempted and nothing was merged`,
+      };
+    }
     const alreadyIntegrated = await exec(["git", "-C", repo, "merge-base", "--is-ancestor", baseRef, "HEAD"]);
     if (alreadyIntegrated.code === 0) return { ok: true, alreadyIntegrated: true };
     await squashOwnHistory();
@@ -303,8 +353,18 @@ export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Pr
           return { ok: true };
         }
       }
+      // Name WHAT conflicts before the abort clears the index (#2864). The park
+      // that consumes this is the one label reserved for a real conflict, so it
+      // carries the evidence rather than an instruction to go looking for it.
+      const unmerged = await exec(["git", "-C", repo, "diff", "--name-only", "--diff-filter=U"]);
+      const conflictPaths = unmerged.code === 0 ? parseUnmergedPaths(unmerged.stdout) : [];
       await exec(["git", "-C", repo, "rebase", "--abort"]);
-      return { ok: false, reason: "conflict" };
+      return {
+        ok: false,
+        reason: "conflict",
+        conflictPaths,
+        message: describeRebaseConflict(baseRef, conflictPaths),
+      };
     }
     return { ok: true };
   };
@@ -324,7 +384,13 @@ export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Pr
       if (!again.ok) return again;
     }
   }
-  return { ok: false, reason: "push-rejected" };
+  return {
+    ok: false,
+    reason: "push-rejected",
+    message:
+      `the rebased worker branch could not be force-pushed to ${remote} after ${maxRetries + 1} attempts ` +
+      `(--force-with-lease kept losing the race for ${branch}) — the rebase itself never conflicted and nothing was merged`,
+  };
 }
 
 /** Inputs for the LOCKED landing path, {@link landMerge}. */

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -48,7 +48,7 @@ import type {
   PackageLayout,
   RunFeedbackResult,
 } from "./feedback.js";
-import type { doLanding, LandingPostMergeValidation } from "./landing.js";
+import type { doLanding, LandingFailureReason, LandingPostMergeValidation } from "./landing.js";
 import { type CiAwaitInput, type ConflictResolver, type Exec as MergeExec, type WaitForReviewInput } from "./merge.js";
 import type { deleteRemote, pushAttempt, GitExec } from "./remote-branch.js";
 import { type LandLock } from "./land-lock.js";
@@ -320,7 +320,75 @@ export interface ReconcileInput {
 
 // ---------- result ----------
 
-export type ReconcileSkipReason = "not-mechanical" | "active-blocker" | "no-commits" | "branch-absent" | "already-closed";
+export type ReconcileSkipReason =
+  | "not-mechanical"
+  | "active-blocker"
+  | "no-commits"
+  | "branch-absent"
+  | "already-closed"
+  /** Another worker held the land-lock past the wait timeout — a BACKOFF, so the
+   * branch is left exactly as it was for the next sweep (#2864). */
+  | "land-lock-timeout";
+
+/** The reasons a reconcile park records, one per landing refusal class (#2864). */
+export type ReconcileParkReason =
+  | "feedback-failed"
+  | "feedback-failed-infra"
+  | "merge-conflict"
+  | "ci-failed"
+  | "ci-pending"
+  | "hook-aborted"
+  | "trunk-diverged"
+  | "infra";
+
+/**
+ * Route a LANDING refusal to the terminal that names it (#2864).
+ *
+ * The reconcile lane used to funnel every non-infra landing failure into
+ * `parkMergeConflict`, so a PR that was merely BEHIND its base — zero conflicts,
+ * zero failing checks, `mergeable=true`, one `gh pr update-branch` from
+ * merging — was parked `blocked:merge-conflict` and a human was sent to resolve
+ * a conflict that did not exist. `behind` and `dirty` are different states and
+ * the forge reports them differently, so the park must be too:
+ *
+ *   - `pr-conflict`        → `merge-conflict`. The ONLY route to that label: the
+ *                            rebase genuinely conflicted (and names its paths).
+ *   - `ci-failed` /
+ *     `pr-merge-failed`    → `ci-failed`. A merge the forge REJECTED on a
+ *                            mergeable PR — a stale base, a red required check,
+ *                            an unsatisfied protection rule. The landing already
+ *                            re-read the PR and repaired the one cause it owns
+ *                            (an out-of-date branch, #2807); what reaches here is
+ *                            the refusal the PR itself explained.
+ *   - `ci-pending`         → `ci-pending`. Checks still running on an intact PR.
+ *   - `post-merge-gate`    → `feedback-failed`. The integrated tree failed the
+ *                            gate; the rebase before it succeeded (#2339).
+ *   - `pre_merge-abort`    → `hook-aborted`. A hook, not a conflict.
+ *   - `trunk-diverged`     → `trunk-diverged`.
+ *   - `land-lock-timeout`  → null. A backoff: nothing to park.
+ *   - everything else      → `infra`, carrying the observed reason verbatim.
+ */
+export function routeLandingFailure(reason: LandingFailureReason): ReconcileParkReason | null {
+  switch (reason) {
+    case "pr-conflict":
+      return "merge-conflict";
+    case "ci-failed":
+    case "pr-merge-failed":
+      return "ci-failed";
+    case "ci-pending":
+      return "ci-pending";
+    case "post-merge-gate":
+      return "feedback-failed";
+    case "pre_merge-abort":
+      return "hook-aborted";
+    case "trunk-diverged":
+      return "trunk-diverged";
+    case "land-lock-timeout":
+      return null;
+    default:
+      return "infra";
+  }
+}
 
 export type ReconcileResult =
   | { outcome: "landed"; mergeSha: string; locked: boolean; posted: boolean }
@@ -331,7 +399,9 @@ export type ReconcileResult =
       // that the `validation-infra` recovery policy re-queues (or escalates
       // when the cap is exhausted). The original `feedback-failed` keeps its
       // semantic meaning (the worker's code really has a problem, page human).
-      reason: "feedback-failed" | "feedback-failed-infra" | "merge-conflict" | "infra";
+      // The landing refusals each park under their own reason (#2864), so
+      // `merge-conflict` names a branch that really conflicts and nothing else.
+      reason: ReconcileParkReason;
       posted: boolean;
     }
   | { outcome: "skipped"; reason: ReconcileSkipReason };
@@ -546,9 +616,17 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
         startedEpoch,
       );
     }
-    // The land path's own gates (drift-guard + integrate/rebase) rejected the
-    // branch — park it as a merge conflict, exactly like the DONE path does.
-    return await parkMergeConflict(deps, input, landing.reason, startedEpoch);
+    // #2864: park under the terminal the REFUSAL names, never a blanket
+    // merge-conflict. A land-lock timeout is a backoff — leave the branch as it
+    // is and let the next sweep take it.
+    const parkReason = routeLandingFailure(landing.reason);
+    if (parkReason === null) {
+      deps.appendIterLog(
+        `🤖 /afk reconcile #${issue}: skipped (land-lock-timeout) — another worker holds the land-lock; \`${branch}\` is untouched for the next sweep.`,
+      );
+      return { outcome: "skipped", reason: "land-lock-timeout" };
+    }
+    return await parkLandingRefusal(deps, input, parkReason, landing.message, startedEpoch);
   }
 
   if (landing.postMergeValidation) {
@@ -749,30 +827,65 @@ async function parkInfraLanding(
   return { outcome: "parked", reason: "infra", posted };
 }
 
-/** The land path rejected the branch (integrate/rebase/drift) → park as a merge
- * conflict, mirroring the DONE path's merge-failed terminal. */
-async function parkMergeConflict(
+/**
+ * The one line a landing refusal records, per park reason (#2864). It states
+ * what was OBSERVED — never a probable cause — because the note is the whole
+ * brief the next human reads. `observed` is the landing's own message when it
+ * carried one (the conflicting paths, the forge's rejection cause); absent, the
+ * line still says which refusal happened rather than falling back to a conflict.
+ */
+export function landingRefusalSummary(reason: ReconcileParkReason, observed?: string): string {
+  const detail = observed && observed.trim() !== "" ? observed.trim() : undefined;
+  switch (reason) {
+    case "merge-conflict":
+      return detail ?? "the worker branch conflicts with its base and could not be rebased for the landing";
+    case "ci-failed":
+      return detail ?? "the forge rejected the merge on the open PR and the PR state did not explain it";
+    case "ci-pending":
+      return detail ?? "required status checks had not reported a verdict on the open PR";
+    case "feedback-failed":
+      return "the post-merge integration gate failed on the rebased tree; nothing was merged";
+    case "hook-aborted":
+      return detail ?? "a pre_merge hook aborted the landing before anything merged";
+    case "trunk-diverged":
+      return detail ?? "the local trunk has diverged from its remote, so the landing refused to merge";
+    case "feedback-failed-infra":
+    case "infra":
+      return detail ?? "the landing failed before anything merged";
+  }
+}
+
+/**
+ * The land path refused the validated branch → park under the terminal that
+ * NAMES the refusal (#2864).
+ *
+ * Every non-infra refusal used to park `blocked:merge-conflict`, so a branch
+ * that was merely behind its base sent a human to resolve a conflict that did
+ * not exist. The composer owns the typed label + envelope status; reconcile
+ * ALWAYS parks a failed land to a human here (the land path already exhausted
+ * its own gates), so it uses the typed label and status but not the composer's
+ * retry-vs-escalate decision.
+ */
+async function parkLandingRefusal(
   deps: ReconcileDeps,
   input: ReconcileInput,
-  reason: string,
+  reason: ReconcileParkReason,
+  observed: string | undefined,
   startedEpoch: number,
 ): Promise<ReconcileResult> {
   const { issue, labels } = input;
-  // The composer owns the typed blocked label + envelope status. reconcile ALWAYS
-  // parks a failed land to a human here (the land path already exhausted its own
-  // gates), so it uses the typed label + status but not the composer's
-  // retry-vs-escalate decision.
-  const disp = dispose("merge-conflict", input.attempt, deps.recoveryEnv ?? {});
-  const typed = disp.typedLabel!;
-  await deps.gh.ensureLabel(typed);
+  const summary = landingRefusalSummary(reason, observed);
+  const disp = dispose(reason, input.attempt, deps.recoveryEnv ?? {});
+  const typed = disp.typedLabel;
+  if (typed) await deps.gh.ensureLabel(typed);
   await applyReconcileTransition(deps, issue, labels, parkOrHuman(typed));
   const posted = await emitFailure(deps, input, disp.envelopeStatus, startedEpoch, {
-    log: `reconcile land failed: ${reason}`,
+    log: `reconcile land failed (${reason}): ${summary}`,
   });
   deps.appendIterLog(
-    `🤖 /afk reconcile #${issue}: \`${input.branch}\` validated green but the land failed (${reason}) — parked to ready-for-human.`,
+    `🤖 /afk reconcile #${issue}: \`${input.branch}\` validated green but the land was refused — ${summary} — parked to ready-for-human as ${typed ?? reason}.`,
   );
-  return { outcome: "parked", reason: "merge-conflict", posted };
+  return { outcome: "parked", reason, posted };
 }
 
 /**

--- a/apps/dev/tests/landing-conflict-resolution.test.ts
+++ b/apps/dev/tests/landing-conflict-resolution.test.ts
@@ -66,7 +66,7 @@ describe("doLanding — first-attempt mechanical conflict resolution (#2072)", (
 
     const r = await doLanding(h.deps, h.input, h.hooks);
 
-    expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
+    expect(r).toMatchObject({ ok: false, reason: "pr-conflict", locked: false });
     expect(h.mechanicalResolverDirs).toEqual([RWT]);
     expect(h.agentResolverDirs).toEqual([]);
     expect(h.postMergeGateDirs).toEqual([]);
@@ -169,7 +169,7 @@ describe("doLanding — agent-tier semantic conflict resolution (#2075)", () => 
 
     const r = await doLanding(h.deps, h.input, h.hooks);
 
-    expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
+    expect(r).toMatchObject({ ok: false, reason: "pr-conflict", locked: false });
     expect(h.mechanicalResolverDirs).toEqual([RWT]);
     expect(h.agentResolverDirs).toEqual([RWT, RWT]);
     expect(h.postMergeGateDirs).toEqual([]);

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -314,8 +314,10 @@ describe("doLanding — locked conflict self-resolve", () => {
       return { code: 0, stdout: "", stderr: "" };
     };
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toMatchObject({ ok: false, reason: "land-failed", locked: false });
-    expect((r as { message?: string }).message).toContain("merge step");
+    // #2864: a branch that never reached a PR never conflicted — the refusal is
+    // infra and says which step failed, so no conflict terminal can claim it.
+    expect(r).toMatchObject({ ok: false, reason: "infra", locked: false });
+    expect((r as { infraReason?: string }).infraReason).toContain("no pull request could be opened");
   });
 });
 
@@ -490,8 +492,10 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
   it("a real rebase conflict aborts and parks blocked:merge-conflict (never admin-merges)", async () => {
     const h = harness({ locked: false, rebaseWorktree: true, rebaseCode: 1 });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    // pr-conflict routes to blocked:merge-conflict at the caller (existing behaviour).
-    expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
+    // pr-conflict routes to blocked:merge-conflict at the caller (existing behaviour),
+    // and #2864 makes it carry the conflicting paths so the park names them.
+    expect(r).toMatchObject({ ok: false, reason: "pr-conflict", locked: false });
+    expect((r as { message?: string }).message).toContain("conflicts with origin/main in 1 file(s): src/x.ts");
     const j = joined(h.mergeCalls);
     expect(j).toContain(`git -C ${RWT} rebase --abort`);
     // Never force-pushed, never admin-merged, post_merge never fired.
@@ -524,10 +528,13 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
     expect(joined(h.mergeCalls)).toContain(`git -C ${RWT} rebase origin/main`);
   });
 
-  it("force-with-lease rejected on every attempt → parks blocked:merge-conflict after the bounded retry", async () => {
+  it("#2864: force-with-lease rejected on every attempt is INFRA, not a conflict", async () => {
     const h = harness({ locked: false, rebaseWorktree: true, rebasePushCode: 1 });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
+    // The rebase itself completed cleanly — a lost push race is a landing-race
+    // failure, so it must never reach the merge-conflict park.
+    expect(r).toMatchObject({ ok: false, reason: "infra", locked: false });
+    expect((r as { infraReason?: string }).infraReason).toContain("could not be force-pushed");
     const j = joined(h.mergeCalls);
     // Three force-with-lease pushes (1 + 2 retries) then gives up — never merges.
     const pushes = j.filter((c) => c.includes("--force-with-lease")).length;
@@ -902,7 +909,7 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
   it("PR rebase conflict → gate is never called (gate only runs on successful rebase)", async () => {
     const h = harness({ locked: false, openPr: true, postMergeGate: true, rebaseCode: 1 });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
+    expect(r).toMatchObject({ ok: false, reason: "pr-conflict", locked: false });
     expect(h.postMergeGateDirs).toEqual([]);
   });
 });

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -10,7 +10,9 @@ import {
   buildConflictPrompt,
   waitForReviewCheck,
   classifyMergeState,
+  describeRebaseConflict,
   diagnoseMergeRejection,
+  parseUnmergedPaths,
   parseMergeStateView,
   waitForMergeReady,
   waitForMergeReadyWithEvidence,
@@ -1420,7 +1422,9 @@ describe("preMergeRebase (#1006)", () => {
       { match: (a) => a.includes("fetch"), result: { code: 1 } },
     ]);
     const r = await preMergeRebase(exec, base);
-    expect(r).toEqual({ ok: false, reason: "fetch-failed" });
+    // #2864: the refusal says a fetch failed, so no caller can read it as a conflict.
+    expect(r).toMatchObject({ ok: false, reason: "fetch-failed" });
+    expect(r.message).toContain("could not fetch origin/main");
     expect(joined(calls).some((c) => c.includes("rebase"))).toBe(false);
   });
 
@@ -1430,7 +1434,7 @@ describe("preMergeRebase (#1006)", () => {
       { match: (a) => a.join(" ") === "git -C /wt rebase origin/main", result: { code: 1 } },
     ]);
     const r = await preMergeRebase(exec, base);
-    expect(r).toEqual({ ok: false, reason: "conflict" });
+    expect(r).toMatchObject({ ok: false, reason: "conflict" });
     const j = joined(calls);
     expect(j).toContain("git -C /wt rebase --abort");
     expect(j.some((c) => c.includes("push"))).toBe(false);
@@ -1463,7 +1467,7 @@ describe("preMergeRebase (#1006)", () => {
       { match: (a) => a.join(" ") === "git -C /wt rebase origin/main", result: { code: 1 } },
     ]);
     const r = await preMergeRebase(exec, { ...base, resolveMechanical: async () => false });
-    expect(r).toEqual({ ok: false, reason: "conflict" });
+    expect(r).toMatchObject({ ok: false, reason: "conflict" });
     const j = joined(calls);
     expect(j).toContain("git -C /wt rebase --abort");
     expect(j.some((c) => c.includes("push"))).toBe(false);
@@ -1505,7 +1509,9 @@ describe("preMergeRebase (#1006)", () => {
       return { code: 0, stdout: "", stderr: "" };
     };
     const r = await preMergeRebase(exec, { ...base, maxPushRetries: 2 });
-    expect(r).toEqual({ ok: false, reason: "push-rejected" });
+    // #2864: an exhausted force-with-lease race says the rebase never conflicted.
+    expect(r).toMatchObject({ ok: false, reason: "push-rejected" });
+    expect(r.message).toContain("never conflicted");
     expect(pushes).toBe(3);
   });
 
@@ -1523,6 +1529,55 @@ describe("preMergeRebase (#1006)", () => {
       return { code: 0, stdout: "", stderr: "" };
     };
     const r = await preMergeRebase(exec, base);
-    expect(r).toEqual({ ok: false, reason: "conflict" });
+    expect(r).toMatchObject({ ok: false, reason: "conflict" });
+  });
+
+  // #2864: `blocked:merge-conflict` is reserved for a branch that genuinely
+  // conflicts, so the refusal that reaches that label must carry the evidence —
+  // the paths git reported unmerged, read BEFORE the abort clears the index.
+  it("a rebase conflict names the conflicting paths, read before the abort", async () => {
+    const { exec, calls } = fakeExec([
+      needsRebase,
+      { match: (a) => a.join(" ") === "git -C /wt rebase origin/main", result: { code: 1 } },
+      {
+        match: (a) => a.includes("--diff-filter=U"),
+        result: { code: 0, stdout: "src/a.ts\nsrc/b.ts\n" },
+      },
+    ]);
+    const r = await preMergeRebase(exec, base);
+    expect(r.reason).toBe("conflict");
+    expect(r.conflictPaths).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(r.message).toBe("the worker branch conflicts with origin/main in 2 file(s): src/a.ts, src/b.ts");
+    const j = joined(calls);
+    const unmergedIdx = j.findIndex((c) => c.includes("--diff-filter=U"));
+    const abortIdx = j.findIndex((c) => c.includes("rebase --abort"));
+    expect(unmergedIdx).toBeGreaterThanOrEqual(0);
+    expect(abortIdx).toBeGreaterThan(unmergedIdx);
+  });
+
+  it("an unreadable unmerged-path list SAYS so rather than implying there are none (#2864)", async () => {
+    const { exec } = fakeExec([
+      needsRebase,
+      { match: (a) => a.join(" ") === "git -C /wt rebase origin/main", result: { code: 1 } },
+      { match: (a) => a.includes("--diff-filter=U"), result: { code: 128, stdout: "" } },
+    ]);
+    const r = await preMergeRebase(exec, base);
+    expect(r.conflictPaths).toEqual([]);
+    expect(r.message).toBe("the worker branch conflicts with origin/main (the conflicting paths could not be read)");
+  });
+});
+
+describe("describeRebaseConflict / parseUnmergedPaths (#2864)", () => {
+  it("parses, de-duplicates and trims the unmerged path list", () => {
+    expect(parseUnmergedPaths("a.ts\n\n b.ts \na.ts\n")).toEqual(["a.ts", "b.ts"]);
+    expect(parseUnmergedPaths("")).toEqual([]);
+  });
+
+  it("names up to ten paths, then counts the rest", () => {
+    const paths = Array.from({ length: 12 }, (_, i) => `f${i}.ts`);
+    const summary = describeRebaseConflict("origin/main", paths);
+    expect(summary).toContain("in 12 file(s): f0.ts");
+    expect(summary).toContain("f9.ts, and 2 more");
+    expect(summary).not.toContain("f10.ts,");
   });
 });

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  landingRefusalSummary,
   mechanicalDisqualifier,
   reconcile,
+  routeLandingFailure,
   type ReconcileDeps,
   type ReconcileInput,
 } from "../src/core/reconcile.js";
@@ -55,6 +57,17 @@ interface HarnessOptions {
   locked?: boolean;
   /** When true, the unlocked `gh pr merge` returns non-zero (land fails). */
   landFail?: boolean;
+  /**
+   * #2864: the PR is merely BEHIND its base — zero conflicts, zero failing
+   * checks, `mergeable=true`. The first `gh pr merge` is rejected; a single
+   * `gh pr update-branch` makes it CLEAN and the retry merges.
+   */
+  behindBase?: boolean;
+  /**
+   * #2864: the pre-merge rebase hits a GENUINE conflict in these paths (the
+   * only state that may reach `blocked:merge-conflict`).
+   */
+  rebaseConflict?: string[];
   /** Close-cascade fixture: open dependents returned by gh.listByLabel(req:N). */
   dependentsByLabel?: Record<string, { number: number; labels: string[] }[]>;
   closedIssues?: number[];
@@ -86,6 +99,9 @@ function harness(opts: HarnessOptions = {}): {
     pnpmArgs: [],
     changedFileCalls: [],
   };
+
+  /** #2864: flipped by the landing's `gh pr update-branch` repair. */
+  let branchUpdated = false;
 
   const deps: ReconcileDeps = {
     ...HOST_RECONCILE_PORTS,
@@ -146,6 +162,36 @@ function harness(opts: HarnessOptions = {}): {
     mergeExec: async (argv) => {
       trace.mergeCalls.push(argv);
       const j = argv.join(" ");
+      // #2864 fixtures: a genuinely conflicting rebase, and a merely-behind PR
+      // the landing repairs with `gh pr update-branch`.
+      if (opts.rebaseConflict) {
+        if (j.includes("merge-base --is-ancestor")) return { code: 1, stdout: "", stderr: "" };
+        if (j === "git -C /rwt rebase origin/main") return { code: 1, stdout: "", stderr: "CONFLICT" };
+        if (j.includes("--diff-filter=U")) {
+          return { code: 0, stdout: `${opts.rebaseConflict.join("\n")}\n`, stderr: "" };
+        }
+      }
+      if (opts.behindBase) {
+        if (j.includes("pr update-branch")) {
+          branchUpdated = true;
+          return { code: 0, stdout: "", stderr: "" };
+        }
+        if (j.includes("pr merge") && !branchUpdated) {
+          return { code: 1, stdout: "", stderr: "Base branch was modified. Review and try the merge again." };
+        }
+        if (j.includes("pr view") && j.includes("mergeStateStatus")) {
+          return {
+            code: 0,
+            stdout: JSON.stringify({
+              mergeStateStatus: branchUpdated ? "CLEAN" : "BEHIND",
+              mergeable: "MERGEABLE",
+              baseRefOid: "0r1g1nsha",
+              statusCheckRollup: [{ name: "ci", conclusion: "SUCCESS" }],
+            }),
+            stderr: "",
+          };
+        }
+      }
       if (j === "git -C /repo fetch origin afk/wAAAA/9-fix-the-thing --quiet") {
         return { code: 0, stdout: "", stderr: "" };
       }
@@ -340,18 +386,22 @@ describe("reconcile — green → land", () => {
     expect(trace.sidecarWrites.at(-1)?.lines.some((line) => line.includes("post-merge:local-rerun"))).toBe(true);
   });
 
-  it("parks a trusted merge-conflict reland when the in-lock integrated-tree gate fails", async () => {
+  it("parks a trusted reland as VALIDATION when the in-lock integrated-tree gate fails (#2864)", async () => {
     const { deps, input, trace } = harness({
       labels: ["ready-for-human", "blocked:merge-conflict", "priority:high"],
       postMergeFeedbackOk: false,
     });
     const result = await reconcile(deps, { ...input, trustPriorValidation: true });
 
-    expect(result).toEqual({ outcome: "parked", reason: "merge-conflict", posted: true });
+    // The rebase that precedes the gate SUCCEEDED — nothing conflicted, so the
+    // park names the gate that failed instead of re-asserting a conflict.
+    expect(result).toEqual({ outcome: "parked", reason: "feedback-failed", posted: true });
     expect(trace.pnpmCalls).toBe(8);
     expect(trace.closed).toEqual([]);
     expect(trace.deletedRemote).toEqual([]);
-    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "merge-conflict" }]);
+    expect(trace.ensuredLabels).toContain("blocked:validation");
+    expect(trace.labelEdits.at(-1)!.add).toContain("blocked:validation");
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
   });
 
   it("lands a PARKED issue, shedding ready-for-human + the mechanical blocked label", async () => {
@@ -405,8 +455,11 @@ describe("reconcile — red → park", () => {
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
   });
 
-  it("parks as a merge-conflict when the land path rejects the green branch", async () => {
-    const { deps, input, trace } = harness({ feedbackOk: true, landFail: true });
+  it("parks as a merge-conflict when the rebase GENUINELY conflicts, naming the paths (#2864)", async () => {
+    const { deps, input, trace } = harness({
+      feedbackOk: true,
+      rebaseConflict: ["src/a.ts", "src/b.ts"],
+    });
     const result = await reconcile(deps, input);
 
     expect(result.outcome).toBe("parked");
@@ -417,6 +470,40 @@ describe("reconcile — red → park", () => {
     expect(park.add).toContain("ready-for-human");
     expect(park.add).toContain("blocked:merge-conflict");
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "merge-conflict" }]);
+    // The summary names WHAT conflicts, so no human hunts for a phantom.
+    expect(trace.iterLogs.some((line) => line.includes("in 2 file(s): src/a.ts, src/b.ts"))).toBe(true);
+  });
+
+  // #2864 — the defect: a rejected merge on a PR with zero conflicts and zero
+  // failing checks was parked `blocked:merge-conflict`, sending a human to
+  // resolve something that did not exist.
+  it("parks a REJECTED merge on a mergeable PR as blocked:ci, never merge-conflict (#2864)", async () => {
+    const { deps, input, trace } = harness({ feedbackOk: true, landFail: true });
+    const result = await reconcile(deps, input);
+
+    expect(result.outcome).toBe("parked");
+    if (result.outcome === "parked") expect(result.reason).toBe("ci-failed");
+    expect(trace.closed).toEqual([]);
+    expect(trace.ensuredLabels).not.toContain("blocked:merge-conflict");
+    expect(trace.ensuredLabels).toContain("blocked:ci");
+    const park = trace.labelEdits.at(-1)!;
+    expect(park.add).toContain("ready-for-human");
+    expect(park.add).toContain("blocked:ci");
+    expect(park.add).not.toContain("blocked:merge-conflict");
+    // Never a `merge-conflict` envelope on a PR that never conflicted.
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+  });
+
+  it("updates a merely-BEHIND branch and lands it instead of parking (#2864)", async () => {
+    const { deps, input, trace } = harness({ feedbackOk: true, behindBase: true });
+    const result = await reconcile(deps, input);
+
+    // One `gh pr update-branch` — exactly what a human does — then it merges.
+    expect(result.outcome).toBe("landed");
+    expect(trace.mergeCalls.some((c) => c.join(" ").includes("pr update-branch"))).toBe(true);
+    expect(trace.closed).toEqual([9]);
+    expect(trace.ensuredLabels).not.toContain("blocked:merge-conflict");
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "done" }]);
   });
 });
 
@@ -610,5 +697,56 @@ describe("reconcile — pre-fetch safety push (ADR 0103)", () => {
     expect(barePushes.length).toBeGreaterThanOrEqual(1);
     expect(trace.iterLogs.some((l) => l.includes("exit barrier"))).toBe(false);
     expect(trace.iterLogs.some((l) => l.includes("uncommitted file(s)"))).toBe(false);
+  });
+});
+
+// #2864: `blocked:merge-conflict` is reserved for a branch that GENUINELY
+// conflicts. This table is the whole contract — exactly one landing refusal
+// reaches that label, and every other refusal names itself.
+describe("routeLandingFailure — one landing refusal, one terminal (#2864)", () => {
+  it("routes each refusal to the terminal that names it", () => {
+    expect(routeLandingFailure("pr-conflict")).toBe("merge-conflict");
+    expect(routeLandingFailure("ci-failed")).toBe("ci-failed");
+    expect(routeLandingFailure("pr-merge-failed")).toBe("ci-failed");
+    expect(routeLandingFailure("ci-pending")).toBe("ci-pending");
+    expect(routeLandingFailure("post-merge-gate")).toBe("feedback-failed");
+    expect(routeLandingFailure("pre_merge-abort")).toBe("hook-aborted");
+    expect(routeLandingFailure("trunk-diverged")).toBe("trunk-diverged");
+    expect(routeLandingFailure("land-failed")).toBe("infra");
+    expect(routeLandingFailure("pr-resolved-abort")).toBe("infra");
+    expect(routeLandingFailure("infra")).toBe("infra");
+  });
+
+  it("reaches merge-conflict from `pr-conflict` and from nothing else", () => {
+    const reasons = [
+      "pre_merge-abort",
+      "integrate-failed",
+      "land-failed",
+      "ci-failed",
+      "ci-pending",
+      "pr-conflict",
+      "pr-merge-failed",
+      "infra",
+      "pr-resolved-abort",
+      "trunk-diverged",
+      "post-merge-gate",
+      "land-lock-timeout",
+    ] as const;
+    const conflictRoutes = reasons.filter((r) => routeLandingFailure(r) === "merge-conflict");
+    expect(conflictRoutes).toEqual(["pr-conflict"]);
+  });
+
+  it("a land-lock timeout is a BACKOFF, so it parks nothing", () => {
+    expect(routeLandingFailure("land-lock-timeout")).toBeNull();
+  });
+
+  it("every summary states what was observed, and never invents a conflict", () => {
+    expect(landingRefusalSummary("merge-conflict", "conflicts with origin/main in 1 file(s): a.ts"))
+      .toBe("conflicts with origin/main in 1 file(s): a.ts");
+    expect(landingRefusalSummary("ci-failed")).toContain("rejected the merge");
+    expect(landingRefusalSummary("ci-failed")).not.toContain("conflict");
+    expect(landingRefusalSummary("ci-pending")).not.toContain("conflict");
+    expect(landingRefusalSummary("feedback-failed", "ignored")).toContain("post-merge integration gate");
+    expect(landingRefusalSummary("infra")).not.toContain("conflict");
   });
 });

--- a/apps/dev/tests/state-transition-site-deltas.test.ts
+++ b/apps/dev/tests/state-transition-site-deltas.test.ts
@@ -21,6 +21,7 @@ import { lifecycleTransitionFor } from "../src/core/process-issue/recovery.js";
 import { dispose } from "../src/core/disposition.js";
 import type { StateTransition } from "../src/core/state-transition.js";
 import {
+  LABEL_CI,
   LABEL_CRASHED,
   LABEL_DEPENDENCY,
   LABEL_HUMAN,
@@ -77,11 +78,20 @@ const SITES: SiteDelta[] = [
     add: [LABEL_HUMAN, LABEL_INFRA],
   },
   {
-    site: "core/reconcile.ts:parkMergeConflict",
+    // #2864: the merge-conflict park is now ONE route of parkLandingRefusal —
+    // the one a genuinely conflicting branch reaches.
+    site: "core/reconcile.ts:parkLandingRefusal (merge-conflict)",
     current: [LABEL_RUNNING],
     transition: parkOrHuman(LABEL_MERGE_CONFLICT),
     remove: [LABEL_RUNNING],
     add: [LABEL_HUMAN, LABEL_MERGE_CONFLICT],
+  },
+  {
+    site: "core/reconcile.ts:parkLandingRefusal (ci-failed — a rejected merge on a mergeable PR)",
+    current: [LABEL_RUNNING],
+    transition: parkOrHuman(LABEL_CI),
+    remove: [LABEL_RUNNING],
+    add: [LABEL_HUMAN, LABEL_CI],
   },
   {
     site: "core/reconcile.ts:runCloseCascade (mirror of the DONE-path promote)",


### PR DESCRIPTION
Automated AFK landing for #2864. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2864

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788025712&installation_model_id=20659&pr_number=2872&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2872&signature=ac1920f7a306501ee6a883bc4ddd310be090eda23d625677caec108168184e45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->