### PR TITLE
chore: #2875 opencode-host parses arguments through the shared contract

### DIFF
--- a/.changeset/opencode-host-parses-through-the-shared-contract.md
+++ b/.changeset/opencode-host-parses-through-the-shared-contract.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+`opencode-host` parses its arguments through the shared contract, and answers `--version` (#2875). The binary carried its own `parseArgs` — a hand-rolled walk over argv — and exposed no version surface at all, despite importing the version helper for the header it stamps into the generated `opencode.json`. Every hand-rolled parser has its own answer to the questions a parser must answer: what counts as a flag, what happens to an unknown one, whether `-v` is version or verbose, whether the command may be omitted. Those answers differed per binary, which is why `--version` existed on some shipped binaries and not others — nothing guaranteed it, so each author decided separately.
+
+**Routing and flags now go through `@reddb-io/shared/args`, and the accepted surface is declared rather than walked.** `src/cli-args.ts` states the schema; `routeCommand` peels the (optional) `generate` verb and rejects a typo'd one; `parseFlags` handles `--flag`, `--flag=value`, `-f value`, `--no-slice-2` negation, and repeated `--plugin` accumulation the same way every other RedSkills binary does. `--version`/`-v` print the build version and `--json` prints the structured build info, answered before the config is read, before the ADR 0067 opt-in gate is consulted, and before any plugin is discovered — because "which build is this?" is asked exactly when a directory is unconfigured or its gate is closed. `--help`/`-h` print usage from the same declaration.
+
+The contract itself grew the strictness the binaries needed: `parseFlags(argv, schema, { unknownFlags: "error" })` throws `UnknownFlagError` naming the offending flag and listing the declared ones. The default stays permissive, so existing callers are unchanged; opencode-host opts in and a typo'd flag now exits 2 with `unknown flag '--bogus'` instead of being silently swallowed into a default the caller believed they had overridden.

--- a/apps/opencode-host/README.md
+++ b/apps/opencode-host/README.md
@@ -56,7 +56,18 @@ pnpm --filter @reddb-io/red-skills generate -- --with-slice-2 --copy
 # Bundled form (release asset)
 pnpm --filter @reddb-io/red-skills bundle
 node ./dist/opencode-host.bundle.min.mjs --with-slice-2 --plugins-root ./plugins
+
+# Which build is answering?
+node ./dist/opencode-host.bundle.min.mjs --version         # opencode-host <version> <sha>
+node ./dist/opencode-host.bundle.min.mjs --version --json  # the structured build info
+node ./dist/opencode-host.bundle.min.mjs --help
 ```
+
+Commands and flags are routed by the shared arg contract
+(`@reddb-io/shared/args`, ADR 0114): `generate` is the default command, `-v` is
+version (never verbose), and a flag the schema does not declare fails with exit
+2 and a message naming it. The accepted surface is declared in
+`src/cli-args.ts`.
 
 ## Universal install (recommended)
 

--- a/apps/opencode-host/src/cli-args.ts
+++ b/apps/opencode-host/src/cli-args.ts
@@ -1,0 +1,156 @@
+/**
+ * cli-args — opencode-host's argument surface, stated as a schema the shared
+ * contract parses (ADR 0114) instead of as a walk over argv.
+ *
+ * The questions a parser must answer — what counts as a flag, what happens to
+ * an unknown one, whether `-v` is version or verbose, whether the command may
+ * be omitted — are answered once in `@reddb-io/shared/args`, so every RedSkills
+ * binary answers them the same way. This module only declares what
+ * opencode-host accepts and maps the parsed values onto its options.
+ */
+import {
+  parseFlags,
+  routeCommand,
+  UnknownCommandError,
+  type FlagSchema,
+} from "@reddb-io/shared/args.js";
+
+/** The command set. `generate` is the only verb, and the default one. */
+export type OpencodeHostCommand = "generate";
+
+const FLAGS = {
+  config: { kind: "value", aliases: ["c"], coerce: (raw: string) => raw },
+  out: { kind: "value", aliases: ["o"], coerce: (raw: string) => raw },
+  "out-dir": { kind: "value", aliases: ["d"], coerce: (raw: string) => raw },
+  "plugins-root": { kind: "value", aliases: ["p"], coerce: (raw: string) => raw },
+  plugin: { kind: "value", type: "array", coerce: (raw: string) => raw },
+  // Negation is the contract's (`--no-slice-2`); `--with-slice-2` stays as the
+  // spelling earlier callers used.
+  "slice-2": { kind: "boolean", aliases: ["with-slice-2"] },
+  copy: { kind: "boolean" },
+  print: { kind: "boolean" },
+  help: { kind: "boolean", aliases: ["h"] },
+  version: { kind: "boolean", aliases: ["v"] },
+  json: { kind: "boolean" },
+} satisfies FlagSchema;
+
+export interface OpencodeHostArgs {
+  command: OpencodeHostCommand;
+  configPath: string;
+  /** Slice 1: write the provider block to this file path. */
+  outPath: string;
+  /** Slice 2: write the dist tree under this directory. */
+  outDir: string;
+  pluginsRoot: string;
+  showHelp: boolean;
+  showVersion: boolean;
+  /** `--json`: print the structured build info instead of the version line. */
+  versionJson: boolean;
+  /** `--print`: write the Slice 1 JSON to stdout instead of a file. */
+  printJson: boolean;
+  copySkills: boolean;
+  pluginFilter: string[] | null;
+  slice2: boolean;
+}
+
+/** A usage failure: the caller wrote something the schema does not accept. */
+export class OpencodeHostUsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OpencodeHostUsageError";
+  }
+}
+
+/**
+ * True when argv leads with a version token.
+ *
+ * Checked before routing so "which build is this?" stays answerable in exactly
+ * the situation you need to ask it — a directory that never opted in, a config
+ * that cannot be read, a tree with no plugins.
+ */
+export function isVersionRequest(argv: readonly string[]): boolean {
+  return argv[0] === "--version" || argv[0] === "-v";
+}
+
+/** Parse `argv` into the options `generate` runs on, or throw a usage error. */
+export function parseOpencodeHostArgs(argv: readonly string[]): OpencodeHostArgs {
+  let routed;
+  try {
+    routed = routeCommand<OpencodeHostCommand>(argv, {
+      commands: { generate: {} },
+      default: "generate",
+      errorOnUnknownCommand: true,
+    });
+  } catch (err) {
+    if (err instanceof UnknownCommandError) throw new OpencodeHostUsageError(err.message);
+    throw err;
+  }
+
+  let parsed;
+  try {
+    parsed = parseFlags(routed.args, FLAGS, { unknownFlags: "error" });
+  } catch (err) {
+    throw new OpencodeHostUsageError((err as Error).message);
+  }
+
+  const stray = parsed.positionals[0];
+  if (stray !== undefined) {
+    throw new OpencodeHostUsageError(`unexpected argument '${stray}'`);
+  }
+
+  const { values } = parsed;
+  return {
+    command: routed.command,
+    configPath: values.config ?? "./.red/config.yaml",
+    outPath: values.out ?? "./opencode.json",
+    outDir: values["out-dir"] ?? "./dist/opencode",
+    pluginsRoot: values["plugins-root"] ?? "./plugins",
+    showHelp: values.help ?? false,
+    showVersion: values.version ?? false,
+    versionJson: values.json ?? false,
+    printJson: values.print ?? false,
+    copySkills: values.copy ?? false,
+    pluginFilter: values.plugin ?? null,
+    slice2: values["slice-2"] ?? true,
+  };
+}
+
+/** The usage text, kept next to the schema it describes. */
+export function renderHelp(): string {
+  return `opencode-host generate — emit the opencode-host runtime tree
+
+Slice 1: opencode.json (provider block) at <out>
+Slice 2: dist tree at <out-dir>/<plugin>/{opencode.json, .opencode/...}
+
+Usage:
+  opencode-host [generate] [--config <path>] [--out <path>] [--out-dir <path>] [--plugins-root <path>] [--plugin <name>] [--copy] [--print] [--no-slice-2]
+  opencode-host --version [--json]
+  opencode-host --help
+
+Options:
+  -c, --config <path>        path to .red/config.yaml (default: ./.red/config.yaml)
+  -o, --out <path>           Slice 1: path to write opencode.json (default: ./opencode.json)
+  -d, --out-dir <path>       Slice 2: dist root (default: ./dist/opencode)
+  -p, --plugins-root <path>  path to the plugins/ tree (default: ./plugins)
+      --plugin <name>        emit only this plugin (repeatable; Slice 2 only)
+      --copy                 copy SKILL.md instead of symlinking
+      --with-slice-2         emit the Slice 2 dist tree (default; kept for compatibility)
+      --no-slice-2           opt out of the Slice 2 dist tree
+      --print                print Slice 1 JSON to stdout (Slice 2 not written)
+  -v, --version              print the build version (--json for the build info)
+      --json                 with --version: print the structured build info
+  -h, --help                 show this help
+
+Exit codes:
+  0  wrote (or printed) successfully
+  1  read/write failure or opt-in gate closed (plugins.dev.enabled: true missing)
+  2  usage error
+
+Notes:
+  - The ADR 0067 strict opt-in gate applies: plugins.dev.enabled: true must be set.
+  - Slice 1 (--out) is unaffected by --plugin/--no-slice-2; it is the standalone
+    provider-block JSON file.
+  - Planner errors (bad name, missing frontmatter) are reported on stderr but
+    do NOT fail the build. The events the generator can map are emitted.
+`;
+}

--- a/apps/opencode-host/src/generate.ts
+++ b/apps/opencode-host/src/generate.ts
@@ -11,6 +11,9 @@
  *   pnpm --filter @reddb-io/red-skills generate
  *   pnpm --filter @reddb-io/red-skills generate -- --config ./.red/config.yaml --out ./dist/opencode
  *
+ * Arguments are routed and parsed by the shared contract (ADR 0114); the
+ * accepted surface is declared in `cli-args.ts`.
+ *
  * Behaviour:
  *   - reads `<config>` (default `./.red/config.yaml`),
  *   - checks the ADR 0067 strict opt-in gate (`plugins.dev.enabled: true`),
@@ -26,6 +29,13 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
+import {
+  isVersionRequest,
+  OpencodeHostUsageError,
+  parseOpencodeHostArgs,
+  renderHelp,
+  type OpencodeHostArgs,
+} from "./cli-args.js";
 import {
   buildProviderBlock,
   isDevPluginEnabled,
@@ -68,125 +78,38 @@ function mcpPlansToObject(plans: McpPlan[]): Record<string, McpEntry> {
   return out;
 }
 
-interface CliArgs {
-  configPath: string;
-  /** Slice 1: write the provider block to this file path. */
-  outPath: string;
-  /** Slice 2: write the dist tree under this directory. */
-  outDir: string;
-  pluginsRoot: string;
-  showHelp: boolean;
-  printJson: boolean;
-  copySkills: boolean;
-  pluginFilter: string[] | null;
-  slice2: boolean;
+/** Print the build version — the answer this binary owes before anything else. */
+function writeVersion(asJson: boolean): void {
+  const info = readBuildInfo("opencode-host");
+  process.stdout.write(asJson ? `${JSON.stringify(info)}\n` : `${renderVersion(info)}\n`);
 }
-
-function parseArgs(argv: ReadonlyArray<string>): CliArgs {
-  const args: CliArgs = {
-    configPath: "./.red/config.yaml",
-    outPath: "./opencode.json",
-    outDir: "./dist/opencode",
-    pluginsRoot: "./plugins",
-    showHelp: false,
-    printJson: false,
-    copySkills: false,
-    pluginFilter: null,
-    slice2: true,
-  };
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg === "--config" || arg === "-c") {
-      const next = argv[++i];
-      if (typeof next !== "string" || next.length === 0) {
-        process.stderr.write("opencode-host: --config requires a path\n");
-        process.exit(2);
-      }
-      args.configPath = next;
-    } else if (arg === "--out" || arg === "-o") {
-      const next = argv[++i];
-      if (typeof next !== "string" || next.length === 0) {
-        process.stderr.write("opencode-host: --out requires a path\n");
-        process.exit(2);
-      }
-      args.outPath = next;
-    } else if (arg === "--out-dir" || arg === "-d") {
-      const next = argv[++i];
-      if (typeof next !== "string" || next.length === 0) {
-        process.stderr.write("opencode-host: --out-dir requires a path\n");
-        process.exit(2);
-      }
-      args.outDir = next;
-    } else if (arg === "--plugins-root" || arg === "-p") {
-      const next = argv[++i];
-      if (typeof next !== "string" || next.length === 0) {
-        process.stderr.write("opencode-host: --plugins-root requires a path\n");
-        process.exit(2);
-      }
-      args.pluginsRoot = next;
-    } else if (arg === "--plugin") {
-      const next = argv[++i];
-      if (typeof next !== "string" || next.length === 0) {
-        process.stderr.write("opencode-host: --plugin requires a name\n");
-        process.exit(2);
-      }
-      args.pluginFilter = [...(args.pluginFilter ?? []), next];
-    } else if (arg === "--with-slice-2" || arg === "--slice-2") {
-      args.slice2 = true;
-    } else if (arg === "--no-slice-2") {
-      args.slice2 = false;
-    } else if (arg === "--copy") {
-      args.copySkills = true;
-    } else if (arg === "--help" || arg === "-h") {
-      args.showHelp = true;
-    } else if (arg === "--print") {
-      args.printJson = true;
-    } else {
-      process.stderr.write(`opencode-host: unknown arg ${arg}\n`);
-      process.exit(2);
-    }
-  }
-  return args;
-}
-
-const HELP = `opencode-host generate — emit the opencode-host runtime tree
-
-Slice 1: opencode.json (provider block) at <out>
-Slice 2: dist tree at <out-dir>/<plugin>/{opencode.json, .opencode/...}
-
-Usage:
-  opencode-host generate [--config <path>] [--out <path>] [--out-dir <path>] [--plugins-root <path>] [--plugin <name>] [--copy] [--print] [--no-slice-2]
-  opencode-host generate --help
-
-Options:
-  -c, --config <path>        path to .red/config.yaml (default: ./.red/config.yaml)
-  -o, --out <path>           Slice 1: path to write opencode.json (default: ./opencode.json)
-  -d, --out-dir <path>       Slice 2: dist root (default: ./dist/opencode)
-  -p, --plugins-root <path>  path to the plugins/ tree (default: ./plugins)
-      --plugin <name>        emit only this plugin (repeatable; Slice 2 only)
-      --copy                 copy SKILL.md instead of symlinking
-      --with-slice-2         emit the Slice 2 dist tree (default; kept for compatibility)
-      --no-slice-2           opt out of the Slice 2 dist tree
-  --print                    print Slice 1 JSON to stdout (Slice 2 not written)
-  -h, --help                 show this help
-
-Exit codes:
-  0  wrote (or printed) successfully
-  1  read/write failure or opt-in gate closed (plugins.dev.enabled: true missing)
-  2  usage error
-
-Notes:
-  - The ADR 0067 strict opt-in gate applies: plugins.dev.enabled: true must be set.
-  - Slice 1 (--out) is unaffected by --plugin/--no-slice-2; it is the standalone
-    provider-block JSON file.
-  - Planner errors (bad name, missing frontmatter) are reported on stderr but
-    do NOT fail the build. The events the generator can map are emitted.
-`;
 
 function main(argv: ReadonlyArray<string>): void {
-  const args = parseArgs(argv);
+  // Answered before config, the opt-in gate, or any plugin discovery: "which
+  // build is this?" must stay answerable in exactly the situation you need to
+  // ask it — an unconfigured directory, a closed gate, an empty plugins tree.
+  if (isVersionRequest(argv)) {
+    writeVersion(argv.includes("--json"));
+    return;
+  }
+
+  let args: OpencodeHostArgs;
+  try {
+    args = parseOpencodeHostArgs(argv);
+  } catch (err) {
+    if (err instanceof OpencodeHostUsageError) {
+      process.stderr.write(`opencode-host: ${err.message}\n`);
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  if (args.showVersion) {
+    writeVersion(args.versionJson);
+    return;
+  }
   if (args.showHelp) {
-    process.stdout.write(HELP);
+    process.stdout.write(renderHelp());
     return;
   }
 

--- a/apps/opencode-host/tests/cli-args.test.ts
+++ b/apps/opencode-host/tests/cli-args.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for `cli-args.ts` — opencode-host's argument surface stated as a
+ * schema over the shared contract (ADR 0114). The CLI smoke suite spawns the
+ * binary; this suite pins the parsing answers themselves, which is where a
+ * hand-rolled parser used to differ per binary.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  OpencodeHostUsageError,
+  isVersionRequest,
+  parseOpencodeHostArgs,
+  renderHelp,
+} from "../src/cli-args.js";
+
+describe("parseOpencodeHostArgs", () => {
+  it("defaults every path when argv is empty", () => {
+    expect(parseOpencodeHostArgs([])).toEqual({
+      command: "generate",
+      configPath: "./.red/config.yaml",
+      outPath: "./opencode.json",
+      outDir: "./dist/opencode",
+      pluginsRoot: "./plugins",
+      showHelp: false,
+      showVersion: false,
+      versionJson: false,
+      printJson: false,
+      copySkills: false,
+      pluginFilter: null,
+      slice2: true,
+    });
+  });
+
+  it("routes the explicit `generate` command and still parses its flags", () => {
+    const args = parseOpencodeHostArgs(["generate", "--config", "a.yaml"]);
+    expect(args.command).toBe("generate");
+    expect(args.configPath).toBe("a.yaml");
+  });
+
+  it("routes a flag-led invocation to the default command without dropping flags", () => {
+    expect(parseOpencodeHostArgs(["--config", "a.yaml"]).configPath).toBe("a.yaml");
+  });
+
+  it("accepts long, short, and inline spellings of the same flag", () => {
+    expect(parseOpencodeHostArgs(["--config", "a.yaml"]).configPath).toBe("a.yaml");
+    expect(parseOpencodeHostArgs(["-c", "a.yaml"]).configPath).toBe("a.yaml");
+    expect(parseOpencodeHostArgs(["--config=a.yaml"]).configPath).toBe("a.yaml");
+  });
+
+  it("maps the remaining path flags onto their fields", () => {
+    const args = parseOpencodeHostArgs([
+      "--out",
+      "o.json",
+      "-d",
+      "dist/x",
+      "--plugins-root",
+      "p",
+      "--copy",
+      "--print",
+    ]);
+    expect(args.outPath).toBe("o.json");
+    expect(args.outDir).toBe("dist/x");
+    expect(args.pluginsRoot).toBe("p");
+    expect(args.copySkills).toBe(true);
+    expect(args.printJson).toBe(true);
+  });
+
+  it("accumulates repeated --plugin occurrences in order", () => {
+    expect(parseOpencodeHostArgs(["--plugin", "dev", "--plugin", "memory"]).pluginFilter).toEqual([
+      "dev",
+      "memory",
+    ]);
+  });
+
+  it("keeps Slice 2 on by default, off under --no-slice-2, on under the compatibility spellings", () => {
+    expect(parseOpencodeHostArgs([]).slice2).toBe(true);
+    expect(parseOpencodeHostArgs(["--no-slice-2"]).slice2).toBe(false);
+    expect(parseOpencodeHostArgs(["--slice-2"]).slice2).toBe(true);
+    expect(parseOpencodeHostArgs(["--with-slice-2"]).slice2).toBe(true);
+  });
+
+  it("reads --help/-h and --version/-v/--json off the schema", () => {
+    expect(parseOpencodeHostArgs(["--help"]).showHelp).toBe(true);
+    expect(parseOpencodeHostArgs(["-h"]).showHelp).toBe(true);
+    expect(parseOpencodeHostArgs(["--version"]).showVersion).toBe(true);
+    expect(parseOpencodeHostArgs(["-v"]).showVersion).toBe(true);
+    expect(parseOpencodeHostArgs(["--version", "--json"]).versionJson).toBe(true);
+    expect(parseOpencodeHostArgs(["--config", "a.yaml", "--version"]).showVersion).toBe(true);
+  });
+
+  it("fails with a message naming the unknown flag", () => {
+    expect(() => parseOpencodeHostArgs(["--bogus"])).toThrow(OpencodeHostUsageError);
+    expect(() => parseOpencodeHostArgs(["--bogus"])).toThrow(/unknown flag '--bogus'/);
+    expect(() => parseOpencodeHostArgs(["-z"])).toThrow(/unknown flag '-z'/);
+  });
+
+  it("fails when a value flag is missing its value", () => {
+    expect(() => parseOpencodeHostArgs(["--config"])).toThrow(OpencodeHostUsageError);
+    expect(() => parseOpencodeHostArgs(["--config"])).toThrow(/--config requires a value/);
+  });
+
+  it("fails on an unknown command rather than treating it as a flagless default", () => {
+    expect(() => parseOpencodeHostArgs(["emitt"])).toThrow(/unknown command 'emitt'/);
+  });
+
+  it("fails on a stray positional after the command", () => {
+    expect(() => parseOpencodeHostArgs(["generate", "stray"])).toThrow(/unexpected argument 'stray'/);
+  });
+});
+
+describe("isVersionRequest", () => {
+  it("recognises the leading version tokens only", () => {
+    expect(isVersionRequest(["--version"])).toBe(true);
+    expect(isVersionRequest(["-v", "--json"])).toBe(true);
+    expect(isVersionRequest(["--config", "a.yaml"])).toBe(false);
+    expect(isVersionRequest([])).toBe(false);
+  });
+});
+
+describe("renderHelp", () => {
+  it("documents every declared flag", () => {
+    const help = renderHelp();
+    for (const flag of [
+      "--config",
+      "--out",
+      "--out-dir",
+      "--plugins-root",
+      "--plugin",
+      "--copy",
+      "--print",
+      "--no-slice-2",
+      "--version",
+      "--json",
+      "--help",
+    ]) {
+      expect(help).toContain(flag);
+    }
+  });
+});

--- a/apps/opencode-host/tests/generate-cli.test.ts
+++ b/apps/opencode-host/tests/generate-cli.test.ts
@@ -90,13 +90,39 @@ describe("opencode-host generate (CLI smoke)", () => {
     expect(r.stdout).toContain("--config");
   });
 
-  it("rejects unknown args with exit 2", () => {
+  it("rejects unknown args with exit 2 and names the flag", () => {
     const r = runGenerate(["--bogus"], {});
     // pnpm propagates the child exit code as 1 when non-zero (a quirk of
     // pnpm's recursive exec wrapper), so we accept either the documented
     // 2 or pnpm's 1. The contract under test is "non-zero + clear stderr".
     expect([1, 2]).toContain(r.status);
-    expect(r.stderr).toMatch(/unknown arg/);
+    expect(r.stderr).toMatch(/unknown flag '--bogus'/);
+  });
+
+  it("prints the build version on --version and -v", () => {
+    for (const flag of ["--version", "-v"]) {
+      const r = runGenerate([flag], {});
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/^opencode-host \S+ \S+\n$/);
+    }
+  });
+
+  it("prints the structured build info on --version --json", () => {
+    const r = runGenerate(["--version", "--json"], {});
+    expect(r.status).toBe(0);
+    const info = JSON.parse(r.stdout) as { app: string; version: string; gitSha: string };
+    expect(info.app).toBe("opencode-host");
+    expect(typeof info.version).toBe("string");
+    expect(typeof info.gitSha).toBe("string");
+  });
+
+  it("answers --version without reading a config or opening the gate", () => {
+    // No --config exists at this path and the CWD's gate is irrelevant: the
+    // version answer must come before either is touched.
+    const r = runGenerate(["--version", "--config", "/nonexistent/config.yaml"], {});
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/^opencode-host /);
+    expect(r.stderr).not.toMatch(/could not read config/);
   });
 
   it("refuses to emit when the dev plugin is not enabled (ADR 0067)", () => {

--- a/packages/shared/args.test.ts
+++ b/packages/shared/args.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { parseFlags, parseLooseArgs, routeCommand, UnknownCommandError, type FlagSchema, type RouterSchema } from "./args.js";
+import {
+  parseFlags,
+  parseLooseArgs,
+  routeCommand,
+  UnknownCommandError,
+  UnknownFlagError,
+  type FlagSchema,
+  type RouterSchema,
+} from "./args.js";
 
 const SCHEMA = {
   prd: { kind: "value", coerce: (raw: string) => Number(raw) },
@@ -115,6 +123,46 @@ describe("parseFlags", () => {
 
   it("accepts a negative number as a value", () => {
     expect(parseFlags(["-n", "-5"], SCHEMA).values.n).toBe(-5);
+  });
+
+  it("names the offending flag when the caller opts into strict unknown handling", () => {
+    expect(() => parseFlags(["--once", "--bogus"], SCHEMA, { unknownFlags: "error" })).toThrow(
+      UnknownFlagError,
+    );
+    expect(() => parseFlags(["--once", "--bogus"], SCHEMA, { unknownFlags: "error" })).toThrow(
+      /unknown flag '--bogus'/,
+    );
+  });
+
+  it("names a short unknown flag with a single dash", () => {
+    expect(() => parseFlags(["-z"], SCHEMA, { unknownFlags: "error" })).toThrow(/unknown flag '-z'/);
+  });
+
+  it("lists the declared flags alongside the unknown one", () => {
+    try {
+      parseFlags(["--bogus"], REPEATED_SCHEMA, { unknownFlags: "error" });
+      expect.unreachable("expected UnknownFlagError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnknownFlagError);
+      expect((err as UnknownFlagError).flag).toBe("--bogus");
+      expect((err as UnknownFlagError).known).toEqual(["--change"]);
+    }
+  });
+
+  it("accepts declared aliases and negated booleans under strict handling", () => {
+    const schema = {
+      "slice-2": { kind: "boolean", aliases: ["with-slice-2"] },
+      config: { kind: "value", aliases: ["c"], coerce: (raw: string) => raw },
+    } satisfies FlagSchema;
+    expect(parseFlags(["--no-slice-2", "-c", "x"], schema, { unknownFlags: "error" }).values).toEqual({
+      "slice-2": false,
+      config: "x",
+    });
+    expect(parseFlags(["--with-slice-2"], schema, { unknownFlags: "error" }).values["slice-2"]).toBe(true);
+  });
+
+  it("still ignores unknown flags by default", () => {
+    expect(parseFlags(["--bogus", "--once"], SCHEMA).values.once).toBe(true);
   });
 });
 

--- a/packages/shared/args.ts
+++ b/packages/shared/args.ts
@@ -63,6 +63,32 @@ export interface ParseFlagsResult<Schema extends FlagSchema> {
   positionals: string[];
 }
 
+/** How `parseFlags` answers a flag the schema never declared. */
+export interface ParseFlagsOptions {
+  /**
+   * `"ignore"` (default) leaves undeclared flags alone for the caller to handle
+   * elsewhere; `"error"` throws {@link UnknownFlagError} naming the first one.
+   */
+  unknownFlags?: "ignore" | "error";
+}
+
+/**
+ * Raised by {@link parseFlags} under `unknownFlags: "error"` when argv carries a
+ * flag the schema never declared — e.g. `--bogus`. Naming the flag is the point:
+ * a binary that silently swallows a typo'd flag runs with a default the caller
+ * believed they had overridden.
+ */
+export class UnknownFlagError extends Error {
+  readonly flag: string;
+  readonly known: readonly string[];
+  constructor(flag: string, known: readonly string[]) {
+    super(`unknown flag '${flag}'; expected one of: ${known.join(", ")}`);
+    this.name = "UnknownFlagError";
+    this.flag = flag;
+    this.known = known;
+  }
+}
+
 export interface LooseParsedArgs {
   command: string | undefined;
   positional: string[];
@@ -130,11 +156,14 @@ function collectArrayValues(argv: readonly string[], schema: FlagSchema): Map<st
  *
  * Last occurrence wins unless a value flag opts into `type: "array"`, which
  * accumulates occurrences in input order. Unknown flags are ignored (left for
- * the caller to handle elsewhere), matching the permissive scan dev relied on.
+ * the caller to handle elsewhere), matching the permissive scan dev relied on;
+ * pass `{ unknownFlags: "error" }` to have the contract throw
+ * {@link UnknownFlagError} naming the offending flag instead.
  */
 export function parseFlags<Schema extends FlagSchema>(
   argv: readonly string[],
   schema: Schema,
+  options: ParseFlagsOptions = {},
 ): ParseFlagsResult<Schema> {
   const parser = createParser({
     options: buildParserOptions(schema),
@@ -150,6 +179,20 @@ export function parseFlags<Schema extends FlagSchema>(
   }
 
   if (parsed.errors.length > 0) throw new Error(parsed.errors[0]);
+
+  if (options.unknownFlags === "error") {
+    // The parser normalises aliases and `--no-x` negation onto the canonical
+    // name, so anything left in `options` that the schema never declared is a
+    // flag nobody defined — report it in the spelling the caller can retype.
+    const declared = new Set(Object.keys(schema));
+    for (const name of Object.keys(parsed.options)) {
+      if (declared.has(name)) continue;
+      throw new UnknownFlagError(
+        name.length === 1 ? `-${name}` : `--${name}`,
+        Object.keys(schema).map((flag) => (flag.length === 1 ? `-${flag}` : `--${flag}`)),
+      );
+    }
+  }
 
   for (const [name, spec] of Object.entries(schema)) {
     const raw = parsed.options[name];


### PR DESCRIPTION
Automated AFK landing for #2875. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2875

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788030691&installation_model_id=20659&pr_number=2879&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2879&signature=fbe1f7b294524adc6bac347dfb7de50f4694dccf676434e8631d2a37eddc75a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->