### PR TITLE
fix: #2884 The canary fixture mints a daemon session per run inside the operator's real runtime directory and never reclaims it

### DIFF
--- a/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
@@ -13,6 +13,14 @@
 // pinned to this sandbox; `daemon: "down"` pins a session key nothing is
 // listening on. The two differ in one fact — whether the socket answers — which
 // is exactly the boundary the canary's `daemon_reach` step must see.
+//
+// That daemon lives in a runtime directory the SANDBOX owns (#2884). The session
+// key alone made the socket unique but left it under the operator's real
+// `XDG_RUNTIME_DIR`, so a day of canary runs deposited a thousand dead sessions
+// in the directory the singleton's own arbitration reads from — litter
+// indistinguishable from the one-daemon-per-project failure ADR 0130 exists to
+// prevent. The sandbox therefore pins `XDG_RUNTIME_DIR` too: every process in
+// the lane derives the same runtime dir, and it is a temp dir cleanup removes.
 
 import { build } from "esbuild";
 import { spawn } from "node:child_process";
@@ -20,6 +28,7 @@ import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { terminatePid } from "@reddb-io/shared/resident-core.js";
 import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
 import { sendRedskilledRequest } from "@reddb-io/redskilled/protocol";
 
@@ -35,6 +44,8 @@ export interface CanarySandbox {
   readonly root: string;
   /** The MCP bundle entry the canary launches. */
   readonly mcpEntry: string;
+  /** The runtime root this sandbox owns — every socket, lease and lane is under it. */
+  readonly runtimeRoot: string;
   readonly env: Record<string, string>;
 }
 
@@ -109,6 +120,10 @@ export async function createCanarySandbox(
   // about this sandbox rather than about whatever the developer happens to be
   // running, and an `up` sandbox can never be served by a stranger's daemon.
   sessions += 1;
+  // And a runtime root this sandbox owns, so that uniqueness lands in a
+  // directory cleanup can take back rather than in the operator's live one.
+  const runtimeRoot = await mkdtemp(join(tmpdir(), "mcp-canary-run-"));
+  sandboxes.push(runtimeRoot);
   const env: Record<string, string> = {
     ...(process.env as Record<string, string>),
     // The harness runs many times in CI; a transient cgroup scope per launch
@@ -116,10 +131,27 @@ export async function createCanarySandbox(
     RED_AFK_FLEET_SCOPE: "off",
     RED_AFK_TARGET: "1",
     REDSKILLED_SESSION: `mcp-canary-${process.pid}-${sessions}`,
+    // Every process in the lane derives its runtime dir from this one variable,
+    // so pinning it here is what makes the isolation reach the daemon the MCP
+    // bundle spawns rather than only the one this file starts. It also takes
+    // systemd user-session placement out of the picture, which is the same
+    // opt-out the scope line above already declares.
+    XDG_RUNTIME_DIR: runtimeRoot,
   };
+
+  // Loud, not hopeful: `runtimeSocketDir` silently falls back to `tmpdir()` when
+  // the derived socket path would exceed `sun_path`, and a silent fallback is
+  // exactly how this litter reached the operator's directory in the first place.
+  const derived = resolveRedskilledPaths({ env }).runtimeDir;
+  if (!derived.startsWith(`${runtimeRoot}/`)) {
+    throw new Error(
+      `canary sandbox runtime dir escaped its own root: ${derived} is not under ${runtimeRoot}`,
+    );
+  }
+
   if (daemon === "up") await startCanaryDaemon(built.redskilled, env);
 
-  return { root, mcpEntry, env };
+  return { root, mcpEntry, runtimeRoot, env };
 }
 
 /** Start the real daemon on this sandbox's session socket and wait for it to
@@ -169,15 +201,18 @@ async function pings(socketPath: string): Promise<boolean> {
   }
 }
 
+/**
+ * Take back everything a run created: the daemons, the scratch repos, and the
+ * runtime roots those daemons wrote into.
+ *
+ * The daemons go FIRST and are waited on, because a daemon still alive when its
+ * directory is removed writes the lease back and leaves the very corpse this
+ * cleanup exists to prevent. Callers run it from `afterAll`, so a walk that
+ * fails mid-way is cleaned up on exactly the same path as one that passes.
+ */
 export async function cleanupCanarySandboxes(): Promise<void> {
   bundles = undefined;
-  for (const pid of daemonPids.splice(0)) {
-    try {
-      process.kill(pid, "SIGTERM");
-    } catch {
-      // Already gone; a daemon that exited on its own needs no help.
-    }
-  }
+  await Promise.all(daemonPids.splice(0).map((pid) => terminatePid(pid, 2_000)));
   await Promise.all(
     sandboxes.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
   );

--- a/apps/dev/tests/mcp-lane-canary-e2e.test.ts
+++ b/apps/dev/tests/mcp-lane-canary-e2e.test.ts
@@ -12,10 +12,12 @@
 // case is an assertion, not a smoke test.
 
 import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
 import { decode } from "@reddb-io/toon";
+import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
 import { runMcpLaneCanary } from "../src/core/mcp-lane-canary.js";
 import {
   connectMcpLaneCanary,
@@ -203,6 +205,59 @@ describe("the shipped castle-mcp bundle carries the canary", () => {
       const report = decode(stdout.trim()) as { ok: boolean; inert_step?: string };
       expect(report.inert_step).toBeUndefined();
       expect(report.ok).toBe(true);
+    },
+    TIMEOUT,
+  );
+});
+
+// Deliberately LAST in the file: the closing case runs the harness's own
+// cleanup, which drops the shared bundle cache every earlier test reuses.
+describe("the canary's daemon lives in a runtime directory the sandbox owns (#2884)", () => {
+  it(
+    "writes its socket, lease and lane outside the operator's runtime directory",
+    async () => {
+      const sandbox = await createCanarySandbox("healthy");
+      const paths = resolveRedskilledPaths({ env: sandbox.env });
+
+      // The daemon really ran, and really ran HERE — an isolation claim that
+      // held only because nothing was started would prove nothing.
+      expect(paths.runtimeDir.startsWith(`${sandbox.runtimeRoot}/`)).toBe(true);
+      expect(existsSync(paths.socketPath)).toBe(true);
+      expect(existsSync(paths.leasePath)).toBe(true);
+
+      // The path this sandbox WOULD have used before the fix: same session key,
+      // the operator's real environment. Nothing may exist there. This is a pure
+      // function of the session key, so it names the one directory this sandbox
+      // could have littered rather than diffing a directory other tests share.
+      const strayed = resolveRedskilledPaths({
+        env: { ...process.env, REDSKILLED_SESSION: sandbox.env.REDSKILLED_SESSION },
+      });
+      expect(strayed.runtimeDir).not.toBe(paths.runtimeDir);
+      expect(existsSync(strayed.runtimeDir)).toBe(false);
+
+      // The isolation the fixture depends on survives the move: two sandboxes
+      // still land on two runtime directories, so an `up` sandbox can never be
+      // served by another sandbox's daemon.
+      const other = await createCanarySandbox("healthy", "down");
+      expect(resolveRedskilledPaths({ env: other.env }).runtimeDir).not.toBe(paths.runtimeDir);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "leaves no runtime directory behind when a walk fails mid-way",
+    async () => {
+      const sandbox = await createCanarySandbox("healthy");
+      const paths = resolveRedskilledPaths({ env: sandbox.env });
+      expect(existsSync(paths.socketPath)).toBe(true);
+
+      // A walk that throws never reaches its own teardown; the harness's
+      // `afterAll` is the only thing that runs, so that is what is exercised.
+      await cleanupCanarySandboxes();
+
+      expect(existsSync(sandbox.runtimeRoot)).toBe(false);
+      expect(existsSync(sandbox.root)).toBe(false);
+      expect(existsSync(paths.runtimeDir)).toBe(false);
     },
     TIMEOUT,
   );

--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -43,6 +43,7 @@ of it.
 | Reviving a daemon nobody asked for | `src/supervision.ts` — the optional user unit, `Restart=on-failure` |
 | Becoming the version that is published | `src/self-replace.ts` — decide, find the successor, hand the session over |
 | The home, and the route to a reachable daemon | `src/provision.ts` — the ONE creator of `~/.red/redskilled/`, the pure provisioning audit, and the optional user unit |
+| Clearing the sessions that died | `src/reclaim.ts` — the lease decides, another tool's directory is left alone |
 
 ## Behaviours worth knowing
 
@@ -216,3 +217,32 @@ redskilled unit status                      # is a supervisor installed? (absent
 redskilled unit install                     # write the user unit and enable it now
 redskilled unit uninstall                   # remove it; auto-spawn stays the floor
 ```
+
+```bash
+redskilled reclaim --dry-run                # what a sweep would take, and why
+redskilled reclaim                          # remove the runtime dirs whose owner is gone
+redskilled reclaim --grace-ms 60000         # how old a lease-less dir must be to count
+```
+
+## Reclaiming dead sessions
+
+A daemon that crashes leaves its runtime directory behind: a socket nothing
+listens on, a lease naming a pid that died, an event lane nobody will rehydrate.
+`redskilled reclaim` sweeps both runtime parents — the `XDG_RUNTIME_DIR` one and
+the `tmpdir()` fallback — and reports every directory it looked at.
+
+- **The lease decides, not the directory.** A dead pid in a lease is proof the
+  holder is gone; nothing else on disk proves anything. A lease naming a live
+  pid keeps its directory whatever else it contains.
+- **A directory with no lease is only a corpse once it is stale.** A daemon
+  mid-spawn has made its directory but not yet won its lease, so a lease-less
+  directory younger than the grace window is reported `young` and kept — as is
+  one whose socket still answers.
+- **The runtime parent is shared, so foreignness is judged by name.** `rsp`'s
+  resident sockets live under the same `red-skills/` parent. Only `redskilled.*`
+  files are this sweep's business; a directory holding anything else is reported
+  `foreign` and left alone.
+- **The report is the point.** An operator reaching for this is usually
+  mid-diagnosis — "which of these is a live daemon" is the question — so the
+  sweep names every directory and its reason, and `--dry-run` is that same report
+  with nothing removed.

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -13,6 +13,7 @@
     "./paths": "./src/paths.ts",
     "./project-breaker": "./src/project-breaker.ts",
     "./protocol": "./src/protocol.ts",
+    "./reclaim": "./src/reclaim.ts",
     "./provision": "./src/provision.ts",
     "./statusline-payload": "./src/statusline-payload.ts",
     "./worker-launch": "./src/worker-launch.ts"

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -30,6 +30,10 @@ import {
   renderRedskilledUserUnit,
 } from "./provision.js";
 import { DEFAULT_REDSKILLED_IDLE_MS, startRedskilledDaemon } from "./daemon.js";
+import {
+  reclaimRedskilledRuntimeDirs,
+  type RedskilledReclaimOptions,
+} from "./reclaim.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
 import {
   parseRedskilledStatuslineFlags,
@@ -66,9 +70,9 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
   }
 
   const { command, args } = routeCommand<
-    "serve" | "host-state" | "statusline" | "unit" | "provision"
+    "serve" | "host-state" | "statusline" | "unit" | "provision" | "reclaim"
   >(argv, {
-    commands: { serve: {}, "host-state": {}, statusline: {}, unit: {}, provision: {} },
+    commands: { serve: {}, "host-state": {}, statusline: {}, unit: {}, provision: {}, reclaim: {} },
     default: "host-state",
   });
 
@@ -90,6 +94,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
   if (command === "unit") return await runUnit(args);
 
   if (command === "provision") return await runProvision(args);
+  if (command === "reclaim") return await runReclaim(args);
 
   const state = await readRedskilledHostState(resolveRedskilledPaths());
   process.stdout.write(`${JSON.stringify(state, null, 2)}\n`);
@@ -252,6 +257,51 @@ export async function runProvision(
     fixes: report.findings.map((finding) => ({ check: finding.check, fix: finding.fix })),
   })}\n`);
   return report.verdict === "ok" ? 0 : 1;
+}
+
+const RECLAIM_FLAGS = {
+  "dry-run": { kind: "boolean" },
+  "grace-ms": { kind: "value", coerce: (raw: string) => Number(raw) },
+} as const;
+
+/**
+ * `redskilled reclaim [--dry-run] [--grace-ms N]` — a host that already
+ * accumulated dead sessions, cleared without hand-deleting paths.
+ *
+ * It reports every directory it looked at and why it kept or removed it, because
+ * the operator reaching for this command is usually mid-diagnosis: "which of
+ * these is a live daemon" is the question, and a sweep that answered it only by
+ * changing the filesystem underneath them would destroy the evidence it was
+ * called to explain. `--dry-run` is that same report with nothing removed.
+ */
+export async function runReclaim(
+  args: readonly string[],
+  io: {
+    readonly write?: (text: string) => void;
+    readonly options?: RedskilledReclaimOptions;
+  } = {},
+): Promise<number> {
+  const write = io.write ?? ((text: string) => process.stdout.write(text));
+  const { values } = parseFlags(args, RECLAIM_FLAGS);
+  const report = await reclaimRedskilledRuntimeDirs({
+    ...(io.options ?? {}),
+    dryRun: values["dry-run"] === true,
+    ...(Number.isFinite(values["grace-ms"]) ? { graceMs: values["grace-ms"] as number } : {}),
+  });
+  write(`${encodeToon({
+    roots: [...report.roots],
+    scanned: report.scanned,
+    reclaimed: report.reclaimed,
+    dry_run: report.dryRun,
+    entries: report.entries.map((entry) => ({
+      dir: entry.dir,
+      verdict: entry.verdict,
+      reason: entry.reason,
+      removed: [...entry.removed],
+    })),
+  })}\n`);
+  // A failure to read or remove is the one thing an operator must not miss.
+  return report.entries.some((entry) => entry.verdict === "failed") ? 1 : 0;
 }
 
 function configHome(): string {

--- a/apps/redskilled/src/reclaim.ts
+++ b/apps/redskilled/src/reclaim.ts
@@ -1,0 +1,227 @@
+/**
+ * reclaim — clear the corpses out of a session runtime root.
+ *
+ * A daemon that crashes, or a harness that pinned its own session key, leaves a
+ * runtime directory behind: a socket nothing listens on, a lease naming a pid
+ * that died, an event lane nobody will rehydrate. The lease is the singleton's
+ * own arbitration record, so a directory full of dead ones is not merely untidy
+ * — it is noise inside the exact surface arbitration reads from, and it reads to
+ * a human counting sockets as one-daemon-per-something, which is the failure
+ * ADR 0130 exists to prevent. An artifact that imitates a design failure costs
+ * more than one that is simply messy.
+ *
+ * **The lease decides, not the directory.** A dead pid in a lease is proof the
+ * holder is gone; nothing else on disk proves anything. So a directory whose
+ * lease names a live pid is kept whatever else it contains, and a directory with
+ * no lease is only a corpse once it has aged past `graceMs` — a daemon that is
+ * mid-spawn has made its directory but not yet won its lease, and reclaiming
+ * that one would race a healthy start.
+ *
+ * **The runtime root is shared, so foreignness is judged by name.** `rsp`'s
+ * resident sockets live under the same `red-skills/` parent (one hashed
+ * directory per scope), and a sweep that deleted by location rather than by
+ * content would take another tool's live socket with it. Only files named
+ * `redskilled.*` are this module's business; a directory holding anything else
+ * is reported `foreign` and left alone.
+ */
+import { readdir, rm, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { isPidAlive as defaultIsPidAlive, runtimeSocketDir } from "@reddb-io/shared/resident-core.js";
+import { REDSKILLED_SOCKET_FILE } from "./paths.js";
+import { readRedskilledLeaseFile } from "./session-lease.js";
+import { sendRedskilledRequest } from "./protocol.js";
+
+/** A directory with no lease is only a corpse once it is this old. */
+export const REDSKILLED_RECLAIM_GRACE_MS = 5 * 60_000;
+
+/** File name prefix that marks a runtime directory as this daemon's. */
+const REDSKILLED_FILE_PREFIX = "redskilled.";
+
+/** What the sweep decided about one directory. */
+export type RedskilledReclaimVerdict = "reclaimed" | "live" | "young" | "foreign" | "failed";
+
+export interface RedskilledReclaimEntry {
+  readonly dir: string;
+  readonly verdict: RedskilledReclaimVerdict;
+  /** Why, in operator words — the report is the whole point of reclaiming. */
+  readonly reason: string;
+  /** The file names that went with the directory, so the report says what was lost. */
+  readonly removed: readonly string[];
+}
+
+export interface RedskilledReclaimReport {
+  readonly roots: readonly string[];
+  readonly scanned: number;
+  readonly reclaimed: number;
+  readonly dryRun: boolean;
+  readonly entries: readonly RedskilledReclaimEntry[];
+}
+
+export interface RedskilledReclaimOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly uid?: number | string;
+  /** Directories to sweep; derived from the environment when absent. */
+  readonly roots?: readonly string[];
+  readonly graceMs?: number;
+  /** Report what would go, remove nothing. */
+  readonly dryRun?: boolean;
+  readonly now?: () => number;
+  readonly isPidAlive?: (pid: number) => boolean | Promise<boolean>;
+  /** Whether a socket answers; only ever asked of a directory with no lease. */
+  readonly answers?: (socketPath: string) => Promise<boolean>;
+}
+
+/**
+ * The parent directories session runtime dirs are minted under.
+ *
+ * Derived by asking {@link runtimeSocketDir} rather than by rebuilding its
+ * layout, so the sweep cannot drift from the minting. Both candidates are
+ * returned — the `XDG_RUNTIME_DIR` one and the `tmpdir()` fallback — because a
+ * host that lost or gained XDG between runs has litter in both.
+ */
+export function redskilledRuntimeRoots(options: RedskilledReclaimOptions = {}): readonly string[] {
+  const env = options.env ?? process.env;
+  const probe = (candidate: NodeJS.ProcessEnv): string =>
+    dirname(runtimeSocketDir({
+      key: "redskilled:reclaim-probe",
+      socketFileName: REDSKILLED_SOCKET_FILE,
+      env: candidate,
+      ...(options.uid === undefined ? {} : { uid: options.uid }),
+    }));
+
+  const { XDG_RUNTIME_DIR: _xdg, ...withoutXdg } = env;
+  const roots = [probe(env), probe(withoutXdg)];
+  return [...new Set(roots)];
+}
+
+/**
+ * Sweep every runtime root and remove the directories whose owner is gone.
+ *
+ * Never throws on a directory it cannot read: an unreadable entry is reported
+ * `failed` and the sweep continues, because one bad permission must not leave
+ * the other thousand corpses in place.
+ */
+export async function reclaimRedskilledRuntimeDirs(
+  options: RedskilledReclaimOptions = {},
+): Promise<RedskilledReclaimReport> {
+  const roots = options.roots ?? redskilledRuntimeRoots(options);
+  const graceMs = options.graceMs ?? REDSKILLED_RECLAIM_GRACE_MS;
+  const now = options.now ?? Date.now;
+  const pidAlive = options.isPidAlive ?? defaultIsPidAlive;
+  const answers = options.answers ?? socketAnswers;
+  const dryRun = options.dryRun === true;
+
+  const entries: RedskilledReclaimEntry[] = [];
+  for (const root of roots) {
+    let children: string[];
+    try {
+      children = (await readdir(root, { withFileTypes: true }))
+        .filter((child) => child.isDirectory())
+        .map((child) => child.name);
+    } catch {
+      // A root that does not exist is a host that never littered, not an error.
+      continue;
+    }
+    for (const child of children.sort()) {
+      entries.push(await judge(join(root, child), { graceMs, now, pidAlive, answers, dryRun }));
+    }
+  }
+
+  return {
+    roots,
+    scanned: entries.length,
+    reclaimed: entries.filter((entry) => entry.verdict === "reclaimed").length,
+    dryRun,
+    entries,
+  };
+}
+
+interface JudgeDeps {
+  readonly graceMs: number;
+  readonly now: () => number;
+  readonly pidAlive: (pid: number) => boolean | Promise<boolean>;
+  readonly answers: (socketPath: string) => Promise<boolean>;
+  readonly dryRun: boolean;
+}
+
+async function judge(dir: string, deps: JudgeDeps): Promise<RedskilledReclaimEntry> {
+  let names: string[];
+  try {
+    names = (await readdir(dir)).sort();
+  } catch (error) {
+    return { dir, verdict: "failed", reason: describe(error), removed: [] };
+  }
+
+  const ours = names.filter((name) => name.startsWith(REDSKILLED_FILE_PREFIX));
+  if (names.length > 0 && ours.length === 0) {
+    return { dir, verdict: "foreign", reason: "holds no redskilled files", removed: [] };
+  }
+
+  const lease = await readLease(join(dir, "redskilled.lease.toon"));
+  if (lease !== undefined) {
+    if (await deps.pidAlive(lease.pid)) {
+      return { dir, verdict: "live", reason: `lease pid ${lease.pid} is alive`, removed: [] };
+    }
+    return await reclaim(dir, names, `lease pid ${lease.pid} is dead`, deps);
+  }
+
+  // No lease. A socket that still answers outranks the missing record — the
+  // holder is demonstrably there, whatever the directory says about it.
+  if (names.includes(REDSKILLED_SOCKET_FILE) && await deps.answers(join(dir, REDSKILLED_SOCKET_FILE))) {
+    return { dir, verdict: "live", reason: "socket answers with no lease", removed: [] };
+  }
+
+  const age = await ageMs(dir, deps.now);
+  if (age !== undefined && age < deps.graceMs) {
+    return { dir, verdict: "young", reason: `no lease, modified ${Math.round(age / 1000)}s ago`, removed: [] };
+  }
+  return await reclaim(dir, names, names.length === 0 ? "empty and stale" : "no lease and stale", deps);
+}
+
+async function reclaim(
+  dir: string,
+  names: readonly string[],
+  reason: string,
+  deps: JudgeDeps,
+): Promise<RedskilledReclaimEntry> {
+  if (deps.dryRun) return { dir, verdict: "reclaimed", reason: `${reason} (dry run)`, removed: names };
+  try {
+    await rm(dir, { recursive: true, force: true });
+  } catch (error) {
+    return { dir, verdict: "failed", reason: describe(error), removed: [] };
+  }
+  return { dir, verdict: "reclaimed", reason, removed: names };
+}
+
+async function readLease(leasePath: string) {
+  try {
+    return await readRedskilledLeaseFile(leasePath);
+  } catch {
+    // Bytes nobody can interpret name no owner, so they protect nothing.
+    return undefined;
+  }
+}
+
+async function ageMs(dir: string, now: () => number): Promise<number | undefined> {
+  try {
+    return Math.max(0, now() - (await stat(dir)).mtimeMs);
+  } catch {
+    return undefined;
+  }
+}
+
+async function socketAnswers(socketPath: string): Promise<boolean> {
+  try {
+    const response = await sendRedskilledRequest(
+      { socketPath, timeoutMs: 250 },
+      { id: `redskilled-reclaim-${process.pid}`, op: "ping" },
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/redskilled/src/session-lease.ts
+++ b/apps/redskilled/src/session-lease.ts
@@ -67,6 +67,29 @@ export interface RedskilledLeaseStore {
   release(owner: RedskilledLeaseOwner): Promise<boolean>;
 }
 
+/**
+ * Read a lease record off disk without acquiring anything.
+ *
+ * A reader that only wants to know who holds a session — `reclaim`, a doctor,
+ * a bug report — must not have to mint the labels an acquirer needs, because
+ * inventing labels to read a record is how a reader ends up writing one.
+ * Absent or unreadable reads as `undefined`, never as a throw: the whole point
+ * of looking is that the record may be missing or corrupt.
+ */
+export async function readRedskilledLeaseFile(
+  leasePath: string,
+): Promise<RedskilledLease | undefined> {
+  let raw: string;
+  try {
+    raw = await readFile(leasePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  const parsed = parseSnapshot(raw);
+  return isLease(parsed) ? parsed : undefined;
+}
+
 let cachedProcessOwner: RedskilledLeaseOwner | undefined;
 
 /**
@@ -92,15 +115,7 @@ export function createRedskilledLeaseStore(
   const pidAlive = options.isPidAlive ?? isPidAlive;
 
   async function readLease(): Promise<RedskilledLease | undefined> {
-    let raw: string;
-    try {
-      raw = await readFile(leasePath, "utf8");
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-      throw error;
-    }
-    const parsed = parseSnapshot(raw);
-    return isLease(parsed) ? parsed : undefined;
+    return await readRedskilledLeaseFile(leasePath);
   }
 
   async function replace(lease: RedskilledLease): Promise<void> {

--- a/apps/redskilled/tests/reclaim.test.ts
+++ b/apps/redskilled/tests/reclaim.test.ts
@@ -1,0 +1,226 @@
+// A host that already accumulated dead sessions, cleared without hand-deleting
+// paths (#2884).
+//
+// The sweep's whole value is that an operator can trust it mid-diagnosis, so the
+// assertions are about what it REFUSES to take as much as what it removes: a
+// live lease, another tool's directory under the same shared parent, and a
+// directory too young to have won its lease yet all survive.
+import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { encode } from "@reddb-io/toon";
+import { runReclaim } from "../src/cli.js";
+import {
+  reclaimRedskilledRuntimeDirs,
+  redskilledRuntimeRoots,
+} from "../src/reclaim.js";
+
+const roots: string[] = [];
+const NOW = Date.parse("2026-07-30T12:00:00.000Z");
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function runtimeRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-reclaim-"));
+  roots.push(root);
+  return root;
+}
+
+/** One runtime directory holding a lease that names `pid`. */
+async function session(root: string, name: string, pid: number | null): Promise<string> {
+  const dir = join(root, name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "redskilled.sock"), "", "utf8");
+  if (pid !== null) {
+    await writeFile(
+      join(dir, "redskilled.lease.toon"),
+      `${encode({
+        version: 1,
+        pid,
+        start_time: "2026-07-30T11:00:00.000Z",
+        session_key_hash: "aaaaaaaaaaaa",
+        machine_id_hash: "bbbbbbbbbbbb",
+        socket_path: join(dir, "redskilled.sock"),
+        acquired_at: "2026-07-30T11:00:00.000Z",
+        renewed_at: "2026-07-30T11:30:00.000Z",
+      }, { keyedMapCollapse: true })}\n`,
+      "utf8",
+    );
+  }
+  return dir;
+}
+
+/** Age a directory past the grace window by moving its mtime back. */
+async function age(dir: string, ms: number): Promise<void> {
+  const when = new Date(NOW - ms);
+  const current = await stat(dir);
+  await utimes(dir, current.atime, when);
+}
+
+function sweep(root: string, overrides: Record<string, unknown> = {}) {
+  return reclaimRedskilledRuntimeDirs({
+    roots: [root],
+    now: () => NOW,
+    // Only the pids this test names are alive; the OS's real table would make
+    // the outcome depend on whatever else the machine is running.
+    isPidAlive: (pid) => pid === 1234,
+    answers: async () => false,
+    ...overrides,
+  });
+}
+
+describe("reclaiming dead session runtime directories", () => {
+  it("removes a directory whose lease names a dead pid, and reports what went", async () => {
+    const root = await runtimeRoot();
+    const dead = await session(root, "deadbeef", 999_001);
+
+    const report = await sweep(root);
+
+    expect(report.reclaimed).toBe(1);
+    const entry = report.entries.find((row) => row.dir === dead);
+    expect(entry?.verdict).toBe("reclaimed");
+    expect(entry?.reason).toContain("999001");
+    expect(entry?.reason).toContain("dead");
+    // Named, not counted: the operator must be able to see the lease and the
+    // socket left with it rather than trust a number.
+    expect(entry?.removed).toEqual(["redskilled.lease.toon", "redskilled.sock"]);
+    expect(existsSync(dead)).toBe(false);
+  });
+
+  it("keeps a directory whose lease names a live pid", async () => {
+    const root = await runtimeRoot();
+    const live = await session(root, "livelease", 1234);
+
+    const report = await sweep(root);
+
+    expect(report.reclaimed).toBe(0);
+    expect(report.entries.find((row) => row.dir === live)?.verdict).toBe("live");
+    expect(existsSync(live)).toBe(true);
+  });
+
+  it("keeps another tool's directory sharing the same runtime parent", async () => {
+    // `rsp`'s resident sockets land under the same `red-skills/` parent, one
+    // hashed directory per scope. A sweep that deleted by location would take a
+    // live socket belonging to a different tool.
+    const root = await runtimeRoot();
+    const foreign = join(root, "rsp-resident");
+    await mkdir(foreign, { recursive: true });
+    await writeFile(join(foreign, "rsp.sock"), "", "utf8");
+    await age(foreign, 60 * 60_000);
+
+    const report = await sweep(root);
+
+    expect(report.entries.find((row) => row.dir === foreign)?.verdict).toBe("foreign");
+    expect(existsSync(foreign)).toBe(true);
+  });
+
+  it("keeps a lease-less directory that is still young, and takes it once stale", async () => {
+    // A daemon mid-spawn has made its directory but not yet won its lease.
+    const root = await runtimeRoot();
+    const young = await session(root, "midspawn", null);
+
+    const first = await sweep(root);
+    expect(first.entries.find((row) => row.dir === young)?.verdict).toBe("young");
+    expect(existsSync(young)).toBe(true);
+
+    await age(young, 60 * 60_000);
+    const second = await sweep(root);
+    expect(second.entries.find((row) => row.dir === young)?.verdict).toBe("reclaimed");
+    expect(existsSync(young)).toBe(false);
+  });
+
+  it("keeps a lease-less directory whose socket still answers", async () => {
+    const root = await runtimeRoot();
+    const answering = await session(root, "answering", null);
+    await age(answering, 60 * 60_000);
+
+    const report = await sweep(root, { answers: async () => true });
+
+    expect(report.entries.find((row) => row.dir === answering)?.verdict).toBe("live");
+    expect(existsSync(answering)).toBe(true);
+  });
+
+  it("removes the empty directories a start that never got anywhere left behind", async () => {
+    const root = await runtimeRoot();
+    const empty = join(root, "emptyshell");
+    await mkdir(empty, { recursive: true });
+    await age(empty, 60 * 60_000);
+
+    const report = await sweep(root);
+
+    expect(report.entries.find((row) => row.dir === empty)?.reason).toContain("empty");
+    expect(existsSync(empty)).toBe(false);
+  });
+
+  it("removes nothing on a dry run, and still says what it would take", async () => {
+    const root = await runtimeRoot();
+    const dead = await session(root, "deadbeef", 999_001);
+
+    const report = await sweep(root, { dryRun: true });
+
+    expect(report.dryRun).toBe(true);
+    expect(report.reclaimed).toBe(1);
+    expect(report.entries.find((row) => row.dir === dead)?.reason).toContain("dry run");
+    expect(existsSync(dead)).toBe(true);
+  });
+
+  it("reads a missing root as a host that never littered", async () => {
+    const report = await reclaimRedskilledRuntimeDirs({
+      roots: [join(tmpdir(), "redskilled-reclaim-absent-root")],
+    });
+    expect(report.scanned).toBe(0);
+    expect(report.reclaimed).toBe(0);
+  });
+});
+
+describe("the roots a sweep looks in", () => {
+  it("covers both the XDG parent and the tmpdir fallback", () => {
+    const found = redskilledRuntimeRoots({ env: { XDG_RUNTIME_DIR: "/run/user/4242" }, uid: 4242 });
+    expect(found).toContain("/run/user/4242/red-skills");
+    expect(found).toContain(join(tmpdir(), "red-skills-4242"));
+  });
+
+  it("does not repeat a root when there is no XDG runtime dir", () => {
+    const found = redskilledRuntimeRoots({ env: {}, uid: 4242 });
+    expect(found).toEqual([join(tmpdir(), "red-skills-4242")]);
+  });
+});
+
+describe("`redskilled reclaim`", () => {
+  it("prints the sweep as TOON and exits 0", async () => {
+    const root = await runtimeRoot();
+    await session(root, "deadbeef", 999_001);
+    let out = "";
+
+    const code = await runReclaim([], {
+      write: (text) => {
+        out += text;
+      },
+      options: { roots: [root], now: () => NOW, isPidAlive: () => false, answers: async () => false },
+    });
+
+    expect(code).toBe(0);
+    expect(out).toContain("reclaimed");
+    expect(out).toContain("deadbeef");
+  });
+
+  it("honours `--dry-run`", async () => {
+    const root = await runtimeRoot();
+    const dead = await session(root, "deadbeef", 999_001);
+    let out = "";
+
+    await runReclaim(["--dry-run"], {
+      write: (text) => {
+        out += text;
+      },
+      options: { roots: [root], now: () => NOW, isPidAlive: () => false, answers: async () => false },
+    });
+
+    expect(out).toContain("dry run");
+    expect(existsSync(dead)).toBe(true);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2884. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2884

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788038246&installation_model_id=20659&pr_number=2890&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2890&signature=021ae1de2d39d0f6aa18d61903f8c541bf1fec4eb1662b27d92161b44c50d6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->