### PR TITLE
chore: #2926 A major-version gap is reported, not silently held, so an operator learns a manual restart is required

### DIFF
--- a/.changeset/a-major-version-gap-is-reported-not-silently-held.md
+++ b/.changeset/a-major-version-gap-is-reported-not-silently-held.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A major-version gap is reported rather than silently held (#2926). The daemon's self-replacement resolves the newest version *within the same major*, and holding at a major boundary is correct — a breaking change must not arrive on a machine that is holding Workers just because a background timer noticed it. But the hold was silent, and a daemon on 3.x with 4.0.0 published looked exactly like a daemon that was already current: no skew, no pending action, no reason. An operator who updated the plugin to a new major and watched nothing change had no surface that would tell them why.
+
+**The daemon now states the gap, states that not crossing it is deliberate, and names the step that crosses it.** `upgrade.newest_published_version` carries the newest release whatever its major, beside the in-major answer rather than folded into it — the same rule that keeps `published_version` from ever standing in for `running_version`. `upgrade.major_held` is 1 while a major is being withheld and `upgrade.major_hold` carries the running and held majors, the reason, and the operator's step, addressed to whoever would revive this daemon: re-point and restart the unit under supervision, stop this daemon without one. Both numbers come from ONE registry read, so a release landing mid-check cannot produce a gap that existed at no instant.
+
+**A hold is reported only when one is real.** A daemon that is genuinely current, one merely behind inside its own major, one running a local build, and one whose probe resolved nothing all report no hold — a notice raised off an answer that was never read would make an unreachable registry look like a pending breaking change. In-major adoption is unchanged and still automatic, and the cached-bundle fallback is now capped at the running major too: a host that happens to hold a next-major bundle no longer crosses the boundary because the registry was briefly unreachable.

--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -183,6 +183,18 @@ of it.
   never folded into it, and an unresolvable read stays `published_unknown` rather
   than becoming a match — a manufactured zero skew is exactly how a stale process
   looks current while every Worker halts on the version it claimed to measure.
+- **A major boundary is held, and the hold is said out loud.** The self-replacement
+  only ever resolves inside the running major, because a breaking change must not
+  arrive on a machine that is holding Workers just because a timer noticed it. The
+  hold is reported rather than kept: `upgrade.newest_published_version` names the
+  newest release whatever its major, `upgrade.major_held` is 1 while one is being
+  withheld, and `upgrade.major_hold` carries the reason and the manual step that
+  crosses it — re-pointing the unit under supervision, stopping this daemon
+  without one. A silent hold is indistinguishable from being current, which is how
+  an operator who updated the plugin to a new major and saw nothing change was
+  left with no surface to ask (#2926). A daemon that is genuinely current, one
+  merely behind inside its major, and one whose probe resolved nothing all report
+  no hold at all.
 - **An unisolated launch is never silent.** When the host affords no transient
   unit the Worker still starts, and the reply — and the host-state record it
   keeps for its whole life — carries a warning naming what was lost. A declared

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -135,9 +135,12 @@ import {
   completeRedskilledReplacement,
   DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
   isRedskilledSupervised,
+  planRedskilledMajorHold,
   planRedskilledReplacement,
   prepareRedskilledReplacement,
   probePublishedRedskilledVersion,
+  readPublishedObservation,
+  type RedskilledMajorHold,
   type RedskilledPublishedVersionProbe,
   type RedskilledReplacementDecision,
   type RedskilledReplacementIO,
@@ -468,6 +471,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   let publishedCheckedAt: string | null = null;
   let publishedIsNewer = false;
   let replacementState: "none" | "pending" | "in-progress" = "none";
+  // The world's newest version whatever its major, and the hold it implies. Kept
+  // beside the in-major answer because that one is capped by construction: on its
+  // own it cannot tell a current daemon from one holding at a boundary (#2926).
+  let publishedNewest: string | null = null;
+  let majorHold: RedskilledMajorHold | null = null;
   // The last activity fetch, kept for the same reason the RSS reading is: a read
   // between two polls is dated by the poll it came from, never by the read.
   let lastActivity: RedskilledRepositoryActivity | null = null;
@@ -496,6 +504,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         checkedAt: publishedCheckedAt,
         newer: publishedIsNewer,
         replacement: replacementState,
+        newest: publishedNewest,
+        majorHold,
       },
     });
   }
@@ -922,16 +932,23 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
    * A probe that throws leaves the answer UNKNOWN rather than asserting the
    * running version: an unresolvable read must not manufacture the match that
    * makes a superseded daemon look current (#2809).
+   *
+   * The major beyond this one is RECORDED and never acted on: adopting it would
+   * be a breaking change arriving on a timer, and staying quiet about it is how a
+   * held daemon becomes indistinguishable from a current one (#2926).
    */
   async function observePublishedVersion(): Promise<RedskilledReplacementDecision> {
-    let observed: string | null;
+    let observation: { version: string | null; newest?: string | null };
     try {
-      observed = await publishedProbe(daemonVersion);
+      observation = readPublishedObservation(await publishedProbe(daemonVersion));
     } catch {
-      observed = null;
+      observation = { version: null, newest: null };
     }
+    const observed = observation.version;
     publishedVersion = observed;
+    publishedNewest = observation.newest ?? null;
     publishedCheckedAt = clock();
+    majorHold = planRedskilledMajorHold({ running: daemonVersion, newest: publishedNewest, supervised });
     const decision = planRedskilledReplacement({ running: daemonVersion, published: observed, supervised });
     publishedIsNewer = decision.act === "replace";
     // An in-progress handover is never talked back down: the socket and the lease

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -19,6 +19,7 @@ import {
   type RedskilledProjectRegistration,
 } from "./project-registration.js";
 import { REDSKILLED_PROTOCOL_VERSION } from "./protocol.js";
+import type { RedskilledMajorHold } from "./self-replace.js";
 import type { RedskilledWorkerBudget } from "./worker-placement.js";
 
 /**
@@ -99,11 +100,17 @@ export interface RedskilledProjectView {
  * world. Folding the second into the first is how a stale process reports a
  * confident zero skew while every Worker halts on the version it claimed to
  * measure (#2809), so the daemon states both and compares them out loud.
+ *
+ * A third number joins them for the same reason: `published_version` is capped at
+ * the running major, so on its own it cannot distinguish a current daemon from
+ * one holding at a major boundary. `newest_published_version` is that horizon,
+ * and `major_hold` is the daemon saying out loud that not crossing it is a
+ * decision (#2926).
  */
 export interface RedskilledUpgradeState {
   /** Identical to `daemon_version`, from the same value — never re-derived. */
   readonly running_version: string;
-  /** The published version last resolved; null when it never was. */
+  /** The newest IN-MAJOR published version last resolved; null when it never was. */
   readonly published_version: string | null;
   /** 1 when the published answer could not be resolved at all. */
   readonly published_unknown: number;
@@ -113,6 +120,12 @@ export interface RedskilledUpgradeState {
   readonly replacement: "none" | "pending" | "in-progress";
   /** When the published answer was last observed; null when it never was. */
   readonly checked_at: string | null;
+  /** The newest version published across every major; null when unresolved. */
+  readonly newest_published_version: string | null;
+  /** 1 when a newer major exists and this daemon is deliberately not on it. */
+  readonly major_held: number;
+  /** The held major with its reason and the operator's step; null when none. */
+  readonly major_hold: RedskilledMajorHold | null;
 }
 
 export interface RedskilledHostState {
@@ -167,6 +180,10 @@ export interface BuildHostStateInput {
     /** Whether the observed version supersedes the running one — the daemon decides. */
     readonly newer?: boolean;
     readonly replacement?: RedskilledUpgradeState["replacement"];
+    /** The newest version resolved across every major; absent leaves it unknown. */
+    readonly newest?: string | null;
+    /** The major this daemon is holding at — the daemon decides, this echoes it. */
+    readonly majorHold?: RedskilledMajorHold | null;
   };
 }
 
@@ -206,6 +223,7 @@ export function buildHostState(input: BuildHostStateInput): RedskilledHostState 
 export function buildUpgradeState(input: BuildHostStateInput): RedskilledUpgradeState {
   const running = input.daemonVersion;
   const published = input.published?.version ?? null;
+  const hold = input.published?.majorHold ?? null;
   return {
     running_version: running,
     published_version: published,
@@ -213,6 +231,9 @@ export function buildUpgradeState(input: BuildHostStateInput): RedskilledUpgrade
     newer_published: Number(input.published?.newer === true),
     replacement: input.published?.replacement ?? "none",
     checked_at: input.published?.checkedAt ?? null,
+    newest_published_version: input.published?.newest ?? null,
+    major_held: Number(hold !== null),
+    major_hold: hold,
   };
 }
 
@@ -279,5 +300,29 @@ export function isRedskilledUpgradeState(value: unknown): value is RedskilledUpg
     typeof upgrade.published_unknown === "number" &&
     typeof upgrade.newer_published === "number" &&
     (upgrade.replacement === "none" || upgrade.replacement === "pending" || upgrade.replacement === "in-progress") &&
-    (upgrade.checked_at === null || typeof upgrade.checked_at === "string");
+    (upgrade.checked_at === null || typeof upgrade.checked_at === "string") &&
+    // Checked only when present, exactly as the block itself is on the document:
+    // a daemon from a bundle that predates the major-hold report still answers
+    // completely, while a block that IS there and is the wrong shape fails closed.
+    (upgrade.newest_published_version === undefined ||
+      upgrade.newest_published_version === null ||
+      typeof upgrade.newest_published_version === "string") &&
+    (upgrade.major_held === undefined || typeof upgrade.major_held === "number") &&
+    (upgrade.major_hold === undefined ||
+      upgrade.major_hold === null ||
+      isRedskilledMajorHold(upgrade.major_hold));
+}
+
+/** True when `value` is a complete major-hold report — a client's fail-closed check. */
+export function isRedskilledMajorHold(value: unknown): value is RedskilledMajorHold {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const hold = value as Record<string, unknown>;
+  return typeof hold.version === "string" &&
+    Number.isInteger(hold.running_major) &&
+    Number.isInteger(hold.held_major) &&
+    typeof hold.reason === "string" &&
+    // The step is the whole point of the report: a hold that named no way across
+    // would be the silent hold again, wearing a field name.
+    typeof hold.action === "string" &&
+    hold.action.trim() !== "";
 }

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -26,12 +26,21 @@
  * point on the published lane, so comparing it to a release is meaningless and
  * acting on the comparison would take a developer's own daemon away mid-session.
  *
+ * **A major boundary is held, and the hold is SAID.** A breaking change must not
+ * arrive on a machine because a background timer noticed it, so the resolver only
+ * ever adopts inside the running major — but a silent hold is indistinguishable
+ * from being current, and an operator who updated the plugin to a new major and
+ * saw nothing change had no surface that would tell them why (#2926). The daemon
+ * therefore reports the newest published version *whatever its major*, states
+ * that not adopting it is deliberate, and names the step that crosses it. A
+ * refusal that is stated is a decision; a refusal that is silent is a bug.
+ *
  * PURE apart from the injected spawn, exit and existence lookups.
  */
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fetchNewestSameMajor } from "@reddb-io/shared/bundle-fetch.js";
+import { fetchPublishedVersionHorizon } from "@reddb-io/shared/bundle-fetch.js";
 import { compareSemver, parseSemver } from "@reddb-io/shared/self-update.js";
 import {
   redskilledBundleCacheRoot,
@@ -58,8 +67,109 @@ export const REDSKILLED_REPLACEMENT_ENTRY_UNRESOLVED = "redskilled-replacement-e
 /** Env var that turns the registry read off, leaving local evidence only. */
 export const REDSKILLED_NO_REGISTRY_PROBE_ENV = "REDSKILLED_NO_REGISTRY_PROBE";
 
-/** Answers "what version is published?" — null when it cannot be resolved. */
-export type RedskilledPublishedVersionProbe = (running: string) => Promise<string | null>;
+/**
+ * What one probe resolved about the published world.
+ *
+ * Two numbers rather than one: `version` is the newest release this daemon may
+ * ADOPT — same major, by construction — while `newest` is the newest release
+ * that EXISTS. Folding them together would either adopt a major on a timer or
+ * hide one, and both are the failure this module reports its way out of.
+ */
+export interface RedskilledPublishedObservation {
+  /** The newest in-major version; null when it could not be resolved. */
+  readonly version: string | null;
+  /** The newest version published at all; null when it could not be resolved. */
+  readonly newest?: string | null;
+}
+
+/**
+ * Answers "what is published?" — an unresolvable answer is null, never a match.
+ *
+ * A bare version is accepted and read as the in-major answer alone: a probe that
+ * only ever knew one number leaves the major horizon UNKNOWN rather than having
+ * its single answer promoted into a claim about every major.
+ */
+export type RedskilledPublishedVersionProbe = (
+  running: string,
+) => Promise<string | null | RedskilledPublishedObservation>;
+
+/** Read a probe's answer as an observation. PURE. */
+export function readPublishedObservation(
+  answer: string | null | RedskilledPublishedObservation,
+): RedskilledPublishedObservation {
+  if (answer === null || typeof answer === "string") return { version: answer, newest: null };
+  return { version: answer.version, newest: answer.newest ?? null };
+}
+
+/**
+ * A published major this daemon deliberately will not adopt, and the way across.
+ *
+ * `reason` and `action` are sentences rather than codes because this block exists
+ * to be READ: the operator it is written for has already updated something and
+ * watched nothing happen, and a surface that answered them with `major_held: 1`
+ * would leave them exactly where the silent hold did.
+ */
+export interface RedskilledMajorHold {
+  /** The newest published version, which lives beyond the running major. */
+  readonly version: string;
+  readonly running_major: number;
+  readonly held_major: number;
+  /** Why this daemon is not on it — stated so it does not read as a fault. */
+  readonly reason: string;
+  /** The manual step that crosses the boundary. */
+  readonly action: string;
+}
+
+export interface PlanRedskilledMajorHoldInput {
+  /** The version this process is RUNNING — never the one it resolved. */
+  readonly running: string;
+  /** The newest version published at all; null or unknown holds nothing. */
+  readonly newest: string | null | undefined;
+  /** True when a unit will revive this process — it decides the operator's step. */
+  readonly supervised: boolean;
+}
+
+/**
+ * Decide whether a major is being held, and say so. PURE.
+ *
+ * Null is "nothing is being withheld", and it is the answer for a daemon that is
+ * current, one merely behind inside its major, and one whose probe resolved
+ * nothing — a hold reported off an answer that was never read would make an
+ * unreachable registry look like a pending breaking change.
+ */
+export function planRedskilledMajorHold(input: PlanRedskilledMajorHoldInput): RedskilledMajorHold | null {
+  const running = input.running.trim();
+  if (isLocalRedskilledBuild(running)) return null;
+  const newest = input.newest?.trim() ?? "";
+  const held = parseSemver(newest);
+  const now = parseSemver(running);
+  if (held === null || now === null || held.major <= now.major) return null;
+  return {
+    version: newest,
+    running_major: now.major,
+    held_major: held.major,
+    reason:
+      `redskilled ${newest} is published and this daemon runs ${running}; a major version is ` +
+      `deliberately never adopted by the background check, because a breaking change must not ` +
+      `arrive on a machine that is holding Workers`,
+    action: majorHoldAction(held.major, input.supervised),
+  };
+}
+
+/**
+ * The step, addressed to whoever would revive this daemon.
+ *
+ * Under a unit the `ExecStart` is what has to move — a bare restart would revive
+ * the same argv and the same major — so re-installing it is named first. With no
+ * unit nothing revives this process at all, and stopping it is the whole step:
+ * the next client start resolves the bundle the machine now holds.
+ */
+function majorHoldAction(heldMajor: number, supervised: boolean): string {
+  const install = `install the ${heldMajor}.x bundle (update this machine's plugin pin), then `;
+  return supervised
+    ? `${install}re-point the unit and restart it: redskilled unit install && systemctl --user restart redskilled.service`
+    : `${install}stop this daemon — the next client start resolves the newly installed bundle`;
+}
 
 /** Who carries out the swap: the supervisor that will revive us, or ourselves. */
 export type RedskilledReplacementVia = "supervisor-exit" | "self-spawn";
@@ -279,20 +389,27 @@ function defaultExit(code: number): void {
  * only consulted when the registry could not be read at all. Never substitutes
  * the running version for the published one — an unresolvable answer stays null,
  * because a manufactured match is what makes a stale daemon look current.
+ *
+ * The adoptable answer is capped at the running major on EVERY path, the cache
+ * included: a host that happens to hold a next-major bundle must not cross the
+ * boundary just because the registry was unreachable that minute — that is the
+ * timer-driven breaking change the hold exists to refuse. The cached bundle still
+ * counts towards `newest`, so the gap is reported rather than acted on.
  */
 export async function probePublishedRedskilledVersion(
   running: string,
   env: NodeJS.ProcessEnv = process.env,
   fetchText: (url: string) => Promise<string> = defaultFetchText,
-): Promise<string | null> {
-  const cached = newestCachedRedskilledVersion(env);
-  if (env[REDSKILLED_NO_REGISTRY_PROBE_ENV] === "1") return cached;
+): Promise<RedskilledPublishedObservation> {
+  const cachedNewest = newestCachedRedskilledVersion(env);
+  const cachedInMajor = newestCachedRedskilledVersionInMajor(running, env);
+  if (env[REDSKILLED_NO_REGISTRY_PROBE_ENV] === "1") return { version: cachedInMajor, newest: cachedNewest };
   const floor = parseSemver(running) === null ? "0.0.0" : running;
   try {
-    const newest = await fetchNewestSameMajor({ fetchText }, floor);
-    return newest ?? cached;
+    const horizon = await fetchPublishedVersionHorizon({ fetchText }, floor);
+    return { version: horizon.sameMajor ?? cachedInMajor, newest: horizon.newest ?? cachedNewest };
   } catch {
-    return cached;
+    return { version: cachedInMajor, newest: cachedNewest };
   }
 }
 
@@ -301,10 +418,37 @@ export function newestCachedRedskilledVersion(
   env: NodeJS.ProcessEnv = process.env,
   listDir: (path: string) => readonly string[] = listDirSafe,
 ): string | null {
-  let best: string | null = null;
+  return newestCached(cachedRedskilledVersions(env, listDir));
+}
+
+/** The newest cached bundle inside `running`'s major — the only one adoptable. */
+export function newestCachedRedskilledVersionInMajor(
+  running: string,
+  env: NodeJS.ProcessEnv = process.env,
+  listDir: (path: string) => readonly string[] = listDirSafe,
+): string | null {
+  const major = parseSemver(running.trim())?.major;
+  if (major === undefined) return null;
+  return newestCached(cachedRedskilledVersions(env, listDir).filter((v) => parseSemver(v)?.major === major));
+}
+
+/** Every version this host holds a redskilled bundle for, unordered. */
+function cachedRedskilledVersions(
+  env: NodeJS.ProcessEnv,
+  listDir: (path: string) => readonly string[],
+): readonly string[] {
+  const versions: string[] = [];
   for (const name of listDir(redskilledBundleCacheRoot(env))) {
     const version = /^redskilled-(.+)\.bundle\.min\.mjs$/.exec(name)?.[1];
     if (!version || parseSemver(version) === null) continue;
+    versions.push(version);
+  }
+  return versions;
+}
+
+function newestCached(versions: readonly string[]): string | null {
+  let best: string | null = null;
+  for (const version of versions) {
     if (best === null || compareSemver(version, best) > 0) best = version;
   }
   return best;

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -29,6 +29,7 @@ import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { sendRedskilledRequest } from "../src/protocol.js";
 import {
   isLocalRedskilledBuild,
+  planRedskilledMajorHold,
   planRedskilledReplacement,
   REDSKILLED_REPLACE_EXIT_CODE,
   RedskilledReplacementEntryError,
@@ -173,6 +174,113 @@ describe("the replacement decision", () => {
     });
     expect(isLocalRedskilledBuild("2.0.0-rc.1")).toBe(true);
     expect(isLocalRedskilledBuild("2.0.0")).toBe(false);
+  });
+});
+
+describe("a published major the daemon will not adopt", () => {
+  it("names the gap, says the refusal is deliberate, and names the manual step", () => {
+    const hold = planRedskilledMajorHold({ running: RUNNING_VERSION, newest: "2.0.0", supervised: false });
+
+    expect(hold).not.toBeNull();
+    expect(hold?.version).toBe("2.0.0");
+    expect(hold?.running_major).toBe(1);
+    expect(hold?.held_major).toBe(2);
+    // A refusal that is stated is a decision; one that is silent is a bug.
+    expect(hold?.reason).toContain("deliberately");
+    expect(hold?.reason).toContain("2.0.0");
+    expect(hold?.action).not.toBe("");
+  });
+
+  it("names a step whoever would revive this daemon can actually take", () => {
+    const supervised = planRedskilledMajorHold({ running: RUNNING_VERSION, newest: "2.0.0", supervised: true });
+    const alone = planRedskilledMajorHold({ running: RUNNING_VERSION, newest: "2.0.0", supervised: false });
+
+    // Under a unit the ExecStart is what has to move, so the step says so;
+    // without one, nothing revives this process and stopping it is the step.
+    expect(supervised?.action).toContain("redskilled unit install");
+    expect(supervised?.action).toContain("systemctl --user restart");
+    expect(alone?.action).toContain("stop this daemon");
+    expect(alone?.action).not.toContain("systemctl");
+  });
+
+  it("holds nothing for a daemon that is current, inside its major, or a local build", () => {
+    const base = { running: RUNNING_VERSION, supervised: false } as const;
+
+    // Genuinely current: nothing is being withheld, so nothing is reported.
+    expect(planRedskilledMajorHold({ ...base, newest: RUNNING_VERSION })).toBeNull();
+    // Inside the major the timer adopts it, so there is no hold to report.
+    expect(planRedskilledMajorHold({ ...base, newest: PUBLISHED_VERSION })).toBeNull();
+    expect(planRedskilledMajorHold({ ...base, newest: null })).toBeNull();
+    expect(planRedskilledMajorHold({ ...base, newest: "not-a-version" })).toBeNull();
+    // A source checkout is not a point on the published lane at all.
+    expect(planRedskilledMajorHold({ running: "0.0.0-dev", newest: "9.9.9", supervised: false })).toBeNull();
+  });
+
+  it("reports the gap beside the running version, and still adopts inside the major", async () => {
+    const { paths, env } = await session();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      replaceCheckMs: 0,
+      daemonVersion: RUNNING_VERSION,
+      publishedVersion: async () => ({ version: PUBLISHED_VERSION, newest: "2.0.0" }),
+      replacementIO: { env },
+    });
+    running.push(daemon);
+
+    // The major boundary changes nothing about in-major adoption.
+    expect(await daemon.observePublishedVersion()).toMatchObject({ act: "replace", to: PUBLISHED_VERSION });
+
+    const upgrade = daemon.hostState().upgrade;
+    expect(upgrade.running_version).toBe(RUNNING_VERSION);
+    expect(upgrade.published_version).toBe(PUBLISHED_VERSION);
+    expect(upgrade.newest_published_version).toBe("2.0.0");
+    expect(upgrade.major_held).toBe(1);
+    expect(upgrade.major_hold?.held_major).toBe(2);
+    expect(upgrade.major_hold?.version).toBe("2.0.0");
+    expect(upgrade.major_hold?.action).toContain("stop this daemon");
+  });
+
+  it("reports no hold at all on a daemon that is genuinely current", async () => {
+    const { paths, env } = await session();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      replaceCheckMs: 0,
+      daemonVersion: RUNNING_VERSION,
+      publishedVersion: async () => ({ version: RUNNING_VERSION, newest: RUNNING_VERSION }),
+      replacementIO: { env },
+    });
+    running.push(daemon);
+
+    expect(await daemon.observePublishedVersion()).toEqual({ act: "hold", reason: "no-newer-version" });
+
+    const upgrade = daemon.hostState().upgrade;
+    expect(upgrade.newest_published_version).toBe(RUNNING_VERSION);
+    expect(upgrade.major_held).toBe(0);
+    expect(upgrade.major_hold).toBeNull();
+  });
+
+  it("holds nothing it never resolved: an unreadable registry states no major gap", async () => {
+    const { paths, env } = await session();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      replaceCheckMs: 0,
+      daemonVersion: RUNNING_VERSION,
+      publishedVersion: async () => {
+        throw new Error("the registry is unreachable");
+      },
+      replacementIO: { env },
+    });
+    running.push(daemon);
+
+    expect(await daemon.observePublishedVersion()).toEqual({ act: "hold", reason: "published-unknown" });
+
+    const upgrade = daemon.hostState().upgrade;
+    expect(upgrade.newest_published_version).toBeNull();
+    expect(upgrade.major_held).toBe(0);
+    expect(upgrade.major_hold).toBeNull();
   });
 });
 

--- a/apps/redskilled/tests/statusline-payload.test.ts
+++ b/apps/redskilled/tests/statusline-payload.test.ts
@@ -270,6 +270,9 @@ function hostStateOf(workers: readonly RedskilledWorkerView[]) {
       newer_published: 0,
       replacement: "none" as const,
       checked_at: null,
+      newest_published_version: null,
+      major_held: 0,
+      major_hold: null,
     },
   };
 }

--- a/packages/shared/bundle-fetch.test.ts
+++ b/packages/shared/bundle-fetch.test.ts
@@ -10,6 +10,8 @@ import {
   companionBundlePlugins,
   ensureBundle,
   fetchNewestSameMajor,
+  fetchPublishedVersionHorizon,
+  newestPublished,
   newestSameMajor,
   npmPackageSpec,
   packagedBundleName,
@@ -293,6 +295,26 @@ describe("registry version discovery", () => {
     expect(newest).toBe("1.146.0");
     expect(fetches).toEqual([url]);
     expect(fetches.every((u) => !u.includes("releases/download"))).toBe(true);
+  });
+
+  it("picks the newest version published at ALL, ignoring prereleases", () => {
+    expect(newestPublished(parseRegistryVersions(metadata))).toBe("2.0.0");
+    // A prerelease is not a major an operator is asked to cross to.
+    expect(newestPublished(["1.0.0", "2.0.0-rc.1"])).toBe("1.0.0");
+    expect(newestPublished([])).toBeNull();
+  });
+
+  it("answers both version questions from ONE registry read", async () => {
+    const url = registryPackageUrl();
+    const { io, fetches } = makeIO({ registry: { [url]: metadata } });
+
+    // Two answers that must describe the same instant: a second read could see a
+    // release land between them and report a gap that never existed.
+    expect(await fetchPublishedVersionHorizon(io, "1.140.0")).toEqual({
+      sameMajor: "1.146.0",
+      newest: "2.0.0",
+    });
+    expect(fetches).toEqual([url]);
   });
 });
 

--- a/packages/shared/bundle-fetch.ts
+++ b/packages/shared/bundle-fetch.ts
@@ -248,6 +248,39 @@ export async function fetchNewestSameMajor(
   return newestSameMajor(parseRegistryVersions(text), installed);
 }
 
+/**
+ * The two version questions one registry read answers.
+ *
+ * They travel together because a caller that asked twice could see a release
+ * land between the reads and report a major gap that existed at no instant.
+ */
+export interface PublishedVersionHorizon {
+  /** Newest version sharing the installed major — the only in-range candidate. */
+  readonly sameMajor: string | null;
+  /** Newest version published at all, across every major. */
+  readonly newest: string | null;
+}
+
+/**
+ * Both answers, from ONE registry read: what may be adopted in range, and what
+ * exists beyond it. A consumer that must *report* a major boundary rather than
+ * cross it needs the second number, and it is not derivable from the first.
+ */
+export async function fetchPublishedVersionHorizon(
+  io: Pick<BundleIO, "fetchText">,
+  installed: string,
+  pkg: string = NPM_PACKAGE,
+): Promise<PublishedVersionHorizon> {
+  let text: string;
+  try {
+    text = await io.fetchText(registryPackageUrl(pkg));
+  } catch (err) {
+    throw classifyMaterializeError(err, pkg);
+  }
+  const versions = parseRegistryVersions(text);
+  return { sameMajor: newestSameMajor(versions, installed), newest: newestPublished(versions) };
+}
+
 /** Parse the published-version list out of registry package metadata JSON. */
 export function parseRegistryVersions(text: string): string[] {
   let parsed: unknown;
@@ -289,6 +322,24 @@ export function newestSameMajor(
   for (const v of versions) {
     if (majorOf(v) !== target) continue;
     if (best === null || compareVersion(v, best) > 0) best = v;
+  }
+  return best;
+}
+
+/**
+ * Newest STABLE version from a list, whatever its major, or null.
+ *
+ * Prereleases are skipped: they are published, but they are not a release an
+ * operator is asked to move a machine onto, and announcing `4.0.0-rc.1` as the
+ * major beyond a 3.x install would put a standing notice on every host for as
+ * long as a release candidate exists.
+ */
+export function newestPublished(versions: readonly string[]): string | null {
+  let best: string | null = null;
+  for (const v of versions) {
+    const trimmed = String(v).trim();
+    if (majorOf(trimmed) === null || /^\d+\.\d+\.\d+[-+]/.test(trimmed)) continue;
+    if (best === null || compareVersion(trimmed, best) > 0) best = trimmed;
   }
   return best;
 }

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -57,6 +57,8 @@ export {
   bundleFileName,
   ensureBundle,
   fetchNewestSameMajor,
+  fetchPublishedVersionHorizon,
+  newestPublished,
   newestSameMajor,
   npmPackageSpec,
   packagedBundleName,
@@ -68,6 +70,7 @@ export {
   type BundleIO,
   type BundleFetchFailure,
   type EnsureBundleInput,
+  type PublishedVersionHorizon,
   type ResolveBundleInput,
 } from "./bundle-fetch.js";
 export {


### PR DESCRIPTION
Automated AFK landing for #2926. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2926

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788070253&installation_model_id=20659&pr_number=2935&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2935&signature=6baee25889b851304d4ad9d4a82734fc742065f6d0c56c23b0c25da5b9a6bebd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->