### PR TITLE
ci: report required checks to the merge queue

### DIFF
--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -23,6 +23,12 @@ name: red-workspace-ci
 
 on:
   pull_request:
+  # A merge queue tests each candidate on a temporary `gh-readonly-queue/*` branch
+  # and reports through the `merge_group` event. Without this trigger the required
+  # checks never report for a queued entry, so the queue accepts pull requests and
+  # then holds them forever — which is exactly what it did on 2026-07-31, with
+  # three entries queued and no run against any queue branch.
+  merge_group:
   push:
     # automation/toon-bump is written with GITHUB_TOKEN, whose events never
     # trigger pull_request workflows. The Version Packages PR uses RELEASE_PAT


### PR DESCRIPTION
The merge queue is enabled but nothing reports to it.

A queue tests each candidate on a temporary `gh-readonly-queue/*` branch and reports through the **`merge_group`** event. `red-workspace-ci` — the workflow that emits the two required checks, `test` and `typecheck` — listens only to `pull_request` and `push`. So a queued entry never receives its required checks and the queue holds it indefinitely.

Observed today: PRs #2931, #2933 and #2934 all report `already queued to merge`, and there is **no workflow run against any queue branch**.

The `scope` job already falls back to `--whole-workspace` for any non-`pull_request` event, so a `merge_group` run is correct — just unscoped, which is the safe direction.

**This PR cannot go through the queue it repairs.** It needs a direct merge, or the queue requirement lifted for the one merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788085399&installation_model_id=20659&pr_number=2939&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2939&signature=3154ac1da5e752c669cbb7471b2723e55a4df2eef6a1d59395d18c8a6eedf7f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->