### PR TITLE
chore: #2904 A spent quota is not an empty queue

### DIFF
--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -594,6 +594,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       now: clock(),
       reattachedWorkerIds: [...reattached],
       repositoryActivity: lastActivity,
+      queueDiscovery: lastQueue,
     });
   }
 
@@ -639,6 +640,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       projects,
       transport: queueTransport,
       now: clock(),
+      // The document this fetch replaces: a failed poll must not erase the depth
+      // the poll before it counted, because a consumer holding nothing behaves
+      // exactly like one holding a zero.
+      previous: lastQueue,
       ...(queueRegistration?.batchSize == null ? {} : { batchSize: queueRegistration.batchSize }),
     });
     return lastQueue;

--- a/apps/redskilled/src/queue-discovery.ts
+++ b/apps/redskilled/src/queue-discovery.ts
@@ -69,6 +69,18 @@ export interface RedskilledProjectQueue {
   readonly outcome: RedskilledQueueOutcome;
   /** How many items the selector matched; `null` for every outcome but `counted`. */
   readonly depth: number | null;
+  /**
+   * The last depth this selector actually returned, carried across the failures
+   * that followed it; `null` until it has answered once.
+   *
+   * A failed fetch replaces the stored document, so without this a spent quota
+   * would erase the depth the poll before it counted — and a consumer holding
+   * nothing behaves exactly like a consumer holding a zero, which is the whole
+   * confusion this module exists to refuse.
+   */
+  readonly last_counted_depth: number | null;
+  /** When that depth was counted, so its age is read rather than guessed. */
+  readonly last_counted_at: string | null;
   readonly detail: string;
 }
 
@@ -150,16 +162,27 @@ export function buildQueueDiscoveryQuery(
   return { query, aliases };
 }
 
+/** What a previous fetch already knew, so a failure loses no fact it held. */
+export interface QueueDiscoveryHistory {
+  /** The instant this answer belongs to; dates a fresh count. */
+  readonly now?: string | null;
+  /** The projects of the last fetch, whatever its outcomes were. */
+  readonly previous?: readonly RedskilledProjectQueue[];
+}
+
 /**
  * Turn one answer into one document. PURE.
  *
  * Each project is judged on its own alias: a selector the token cannot resolve
  * fails alone while its neighbours still count, because one refused query is a
- * fact about that project and not about the host.
+ * fact about that project and not about the host. A project that fails inherits
+ * the last depth it counted — inheriting a NEIGHBOUR's would be the same lie in
+ * the other direction, so the carry is keyed by project label and nothing else.
  */
 export function parseQueueDiscoveryResponse(
   operation: RedskilledQueueOperation,
   payload: unknown,
+  history: QueueDiscoveryHistory = {},
 ): { readonly projects: readonly RedskilledProjectQueue[]; readonly rate_limit: RedskilledQueueRateLimit } {
   const root = asRecord(payload);
   const data = asRecord(root.data);
@@ -167,12 +190,15 @@ export function parseQueueDiscoveryResponse(
   const rateLimit = readRateLimit(data.rateLimit, errors);
 
   const projects = operation.aliases.map(({ alias, project }): RedskilledProjectQueue => {
+    const held = heldCount(history, project.project_label);
     const depth = issueCount(data[alias]);
     if (depth != null) {
       return {
         project_label: project.project_label,
         outcome: "counted",
         depth,
+        last_counted_depth: depth,
+        last_counted_at: history.now ?? null,
         detail: `project ${JSON.stringify(project.project_label)} has ${depth} item(s) matching its selector`,
       };
     }
@@ -182,6 +208,7 @@ export function parseQueueDiscoveryResponse(
         project_label: project.project_label,
         outcome: "rate-limited",
         depth: null,
+        ...held,
         detail:
           `the host token's quota was spent before project ${JSON.stringify(project.project_label)} answered, so this ` +
           `queue has no depth rather than a depth of zero` +
@@ -192,6 +219,7 @@ export function parseQueueDiscoveryResponse(
       project_label: project.project_label,
       outcome: "unreachable",
       depth: null,
+      ...held,
       detail:
         `project ${JSON.stringify(project.project_label)} could not be counted with the host token: ` +
         `${stringValue(aliasError?.message) || "the query returned no count for this selector"}`,
@@ -222,6 +250,13 @@ export interface FetchQueueDiscoveryInput {
   readonly transport: RedskilledQueueTransport;
   readonly now: string;
   readonly batchSize?: number;
+  /**
+   * The document this fetch replaces, so a failure keeps what the last one knew.
+   *
+   * Optional and never required: a first fetch has no history, and a caller that
+   * forgets to pass one gets honest nulls rather than a wrong number.
+   */
+  readonly previous?: RedskilledQueueDiscovery | null;
 }
 
 /**
@@ -239,12 +274,13 @@ export async function fetchQueueDiscovery(input: FetchQueueDiscoveryInput): Prom
   const batches = planQueueDiscoveryBatches(input.projects, batchSize);
 
   const projects: RedskilledProjectQueue[] = [];
+  const history: QueueDiscoveryHistory = { now: input.now, previous: input.previous?.projects ?? [] };
   let rateLimit: RedskilledQueueRateLimit = { remaining: null, reset_at: null, exhausted: false };
   for (const batch of batches) {
     const operation = buildQueueDiscoveryQuery(batch, { batchSize });
     try {
       const payload = await input.transport(operation.query);
-      const parsed = parseQueueDiscoveryResponse(operation, payload);
+      const parsed = parseQueueDiscoveryResponse(operation, payload, history);
       projects.push(...parsed.projects);
       rateLimit = mergeRateLimit(rateLimit, parsed.rate_limit);
     } catch (err) {
@@ -256,6 +292,7 @@ export async function fetchQueueDiscovery(input: FetchQueueDiscoveryInput): Prom
           project_label: project.project_label,
           outcome: rateLimited ? "rate-limited" : "unreachable",
           depth: null,
+          ...heldCount(history, project.project_label),
           detail: `the queue fetch failed before project ${JSON.stringify(project.project_label)} answered: ${reason}`,
         });
       }
@@ -278,6 +315,15 @@ export interface RedskilledQueueView extends RedskilledProjectQueue {
   readonly fetched_at: string;
   readonly age_ms: number | null;
   readonly stale: boolean;
+  /**
+   * How old the last SUCCESSFUL count is, which is not how old the fetch is.
+   *
+   * A poll that came back rate-limited is current and knows nothing; the depth a
+   * consumer would act on came from an earlier one, and this is the only number
+   * that says whether it is still worth acting on. `null` when the selector has
+   * never answered.
+   */
+  readonly last_counted_age_ms: number | null;
 }
 
 export interface RedskilledQueueReport {
@@ -336,6 +382,7 @@ export function buildQueueReport(input: {
       fetched_at: discovery.fetched_at,
       age_ms: ageMs,
       stale,
+      last_counted_age_ms: countedAge(nowMs, project.last_counted_at),
     })),
     reason: discovery.projects.length === 0
       ? "the daemon polls no selector, so there are no queue depths to age"
@@ -384,6 +431,30 @@ function assertQueueProjects(projects: readonly RedskilledProjectSelector[]): vo
     }
     seen.add(project.project_label);
   }
+}
+
+/**
+ * What this project last counted, by label. PURE.
+ *
+ * Absent history is nulls rather than a zero: a selector that has never answered
+ * has no depth to hold, and inventing one would be the confusion in miniature.
+ */
+function heldCount(
+  history: QueueDiscoveryHistory,
+  projectLabel: string,
+): { readonly last_counted_depth: number | null; readonly last_counted_at: string | null } {
+  const held = history.previous?.find((candidate) => candidate.project_label === projectLabel);
+  return {
+    last_counted_depth: held?.last_counted_depth ?? null,
+    last_counted_at: held?.last_counted_at ?? null,
+  };
+}
+
+/** Milliseconds since the last successful count, or `null` when there is none. */
+function countedAge(nowMs: number, countedAt: string | null): number | null {
+  if (countedAt == null || !Number.isFinite(nowMs)) return null;
+  const countedMs = Date.parse(countedAt);
+  return Number.isFinite(countedMs) ? Math.max(0, nowMs - countedMs) : null;
 }
 
 function mergeRateLimit(held: RedskilledQueueRateLimit, next: RedskilledQueueRateLimit): RedskilledQueueRateLimit {

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -30,6 +30,12 @@ import {
   type RedskilledActivityReport,
   type RedskilledRepositoryActivity,
 } from "./repository-activity.js";
+import {
+  buildQueueReport,
+  isRedskilledQueueReport,
+  type RedskilledQueueDiscovery,
+  type RedskilledQueueReport,
+} from "./queue-discovery.js";
 import type { RedskilledWorkerLogLine } from "./worker-log.js";
 
 /**
@@ -184,6 +190,17 @@ export interface RedskilledStatuslinePayload {
    * interval, and one number ageing does not make the other one old.
    */
   readonly repository_activity: RedskilledActivityReport;
+  /**
+   * Each registered project's queue depth, and the outcome that produced it.
+   *
+   * **A spent quota is not an empty queue.** The fetch has three outcomes and
+   * only `counted` is ever a number, so a consumer deciding whether to ask for a
+   * Worker reads the outcome before the depth: a project that could not be
+   * reached and a project whose quota ran out both carry `null`, and a queue that
+   * has genuinely drained carries a zero. Reading the first two as the third is
+   * how one exhausted token stops a whole host that still has work.
+   */
+  readonly queue: RedskilledQueueReport;
 }
 
 export interface BuildStatuslinePayloadInput {
@@ -213,6 +230,15 @@ export interface BuildStatuslinePayloadInput {
    */
   readonly repositoryActivity?: RedskilledRepositoryActivity | null;
   readonly activityStalenessMs?: number;
+  /**
+   * The last queue fetch, or `null` when the daemon polls no selector.
+   *
+   * Passed in for the reason the activity counts are: the depths belong to the
+   * daemon that spent the request for them, and this document stays a pure
+   * function of its inputs.
+   */
+  readonly queueDiscovery?: RedskilledQueueDiscovery | null;
+  readonly queueStalenessMs?: number;
 }
 
 /** The payload document. PURE — every aggregate is derived from the Worker set. */
@@ -279,6 +305,11 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
       activity: input.repositoryActivity ?? null,
       now: input.now,
       stalenessMs: input.activityStalenessMs,
+    }),
+    queue: buildQueueReport({
+      discovery: input.queueDiscovery ?? null,
+      now: input.now,
+      stalenessMs: input.queueStalenessMs,
     }),
   };
 }
@@ -464,5 +495,9 @@ export function isRedskilledStatuslinePayload(value: unknown): value is Redskill
     // poller answers a newer client's read, and rejecting its whole payload over
     // a field this consumer did not ask for would lose the Worker set — the very
     // version skew one host-scoped daemon exists to stop managing (ADR 0130).
-    (payload.repository_activity === undefined || isRedskilledActivityReport(payload.repository_activity));
+    (payload.repository_activity === undefined || isRedskilledActivityReport(payload.repository_activity)) &&
+    // Same posture for the queue: a daemon older than the queue poller answers a
+    // newer client's read, and losing the Worker set over a missing field would
+    // be the version skew one host-scoped daemon exists to stop managing.
+    (payload.queue === undefined || isRedskilledQueueReport(payload.queue));
 }

--- a/apps/redskilled/tests/queue-spent-quota.test.ts
+++ b/apps/redskilled/tests/queue-spent-quota.test.ts
@@ -1,0 +1,209 @@
+// A spent quota is not an empty queue (issue #2904). A queue fetch has three
+// distinguishable outcomes — unreachable, rate-limited, counted — and only the
+// last of them is ever a number. This file holds the fixtures for the half a
+// consumer reads: the outcomes ride on the statusline payload, the last depth a
+// selector actually returned survives the failure that followed it with its own
+// age, and one project's refused query leaves its neighbours' depths alone.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import {
+  buildQueueReport,
+  fetchQueueDiscovery,
+  type RedskilledProjectSelector,
+} from "../src/queue-discovery.js";
+import { buildStatuslinePayload, isRedskilledStatuslinePayload } from "../src/statusline-payload.js";
+import { buildHostState } from "../src/host-state.js";
+
+const NOW = "2026-07-31T12:00:00.000Z";
+const LATER = "2026-07-31T12:00:20.000Z";
+
+function selector(index: number): RedskilledProjectSelector {
+  return { project_label: `acme/p${index}`, selector: `repo:acme/p${index} label:ready-for-agent` };
+}
+
+/** The answer a token with nothing left gives: a rate limit, and no counts. */
+const SPENT = {
+  data: { rateLimit: { remaining: 0, resetAt: "2026-07-31T13:00:00.000Z" } },
+  errors: [{ type: "RATE_LIMITED", message: "API rate limit exceeded" }],
+};
+
+function counted(depths: readonly number[]) {
+  const data: Record<string, unknown> = { rateLimit: { remaining: 4900, resetAt: "2026-07-31T13:00:00.000Z" } };
+  depths.forEach((depth, index) => {
+    data[`q${index}`] = { issueCount: depth };
+  });
+  return { data };
+}
+
+describe("the last depth a selector returned outlives the failure after it", () => {
+  it("carries the previous count and its own instant through a spent quota", async () => {
+    const first = await fetchQueueDiscovery({
+      projects: [selector(0)],
+      now: NOW,
+      transport: async () => counted([6]),
+    });
+    const second = await fetchQueueDiscovery({
+      projects: [selector(0)],
+      now: LATER,
+      previous: first,
+      transport: async () => SPENT,
+    });
+
+    // The fetch that failed reports a failure, not a drained queue...
+    expect(second.projects[0]).toMatchObject({ outcome: "rate-limited", depth: null });
+    // ...and still says what the last successful read saw, and when.
+    expect(second.projects[0]!.last_counted_depth).toBe(6);
+    expect(second.projects[0]!.last_counted_at).toBe(NOW);
+  });
+
+  it("ages the last successful read separately from the failed poll that replaced it", async () => {
+    const first = await fetchQueueDiscovery({ projects: [selector(0)], now: NOW, transport: async () => counted([6]) });
+    const second = await fetchQueueDiscovery({
+      projects: [selector(0)],
+      now: LATER,
+      previous: first,
+      transport: async () => SPENT,
+    });
+    const report = buildQueueReport({ discovery: second, now: LATER });
+
+    expect(report.age_ms).toBe(0);
+    // 20s between the counted poll and now — the number a consumer needs to
+    // decide whether the held depth is still worth acting on.
+    expect(report.projects[0]!.last_counted_age_ms).toBe(20_000);
+  });
+
+  it("holds no phantom count for a selector that has never answered", async () => {
+    const discovery = await fetchQueueDiscovery({ projects: [selector(0)], now: NOW, transport: async () => SPENT });
+    const report = buildQueueReport({ discovery, now: NOW });
+
+    expect(report.projects[0]!.last_counted_depth).toBeNull();
+    expect(report.projects[0]!.last_counted_at).toBeNull();
+    expect(report.projects[0]!.last_counted_age_ms).toBeNull();
+  });
+
+  it("does not let one project's failure overwrite another project's count", async () => {
+    const first = await fetchQueueDiscovery({
+      projects: [selector(0), selector(1)],
+      now: NOW,
+      transport: async () => counted([6, 9]),
+    });
+    const second = await fetchQueueDiscovery({
+      projects: [selector(0), selector(1)],
+      now: LATER,
+      previous: first,
+      transport: async () => ({
+        data: { rateLimit: { remaining: 4900, resetAt: null }, q1: { issueCount: 4 } },
+        errors: [{ path: ["q0"], message: "Could not resolve to a Repository" }],
+      }),
+    });
+
+    expect(second.projects[0]).toMatchObject({ outcome: "unreachable", depth: null, last_counted_depth: 6 });
+    expect(second.projects[1]).toMatchObject({ outcome: "counted", depth: 4, last_counted_depth: 4 });
+    expect(second.projects[1]!.last_counted_at).toBe(LATER);
+  });
+});
+
+describe("the three outcomes ride on the payload a consumer reads", () => {
+  function payload(discovery: Parameters<typeof buildQueueReport>[0]["discovery"], now: string) {
+    return buildStatuslinePayload({
+      hostState: buildHostState({
+        daemonVersion: "0.0.0-test",
+        machineIdHash: "hash",
+        sessionKeyHash: "session",
+        pid: 4242,
+        startedAt: NOW,
+        workers: [],
+        registrations: [],
+      }),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      rss: {},
+      sampledAt: null,
+      now,
+      queueDiscovery: discovery,
+    });
+  }
+
+  it("names a spent quota on the payload rather than reporting no work", async () => {
+    const discovery = await fetchQueueDiscovery({ projects: [selector(0)], now: NOW, transport: async () => SPENT });
+    const built = payload(discovery, NOW);
+
+    expect(isRedskilledStatuslinePayload(built)).toBe(true);
+    expect(built.queue.projects[0]!.outcome).toBe("rate-limited");
+    expect(built.queue.projects[0]!.depth).toBeNull();
+    expect(built.queue.rate_limit.exhausted).toBe(true);
+    expect(built.queue.projects[0]!.detail).toContain("quota");
+  });
+
+  it("tells an unreachable project, a rate-limited one and a drained one apart", async () => {
+    const discovery = await fetchQueueDiscovery({
+      projects: [selector(0), selector(1)],
+      now: NOW,
+      transport: async () => ({
+        data: { rateLimit: { remaining: 4900, resetAt: null }, q1: { issueCount: 0 } },
+        errors: [{ path: ["q0"], message: "Could not resolve to a Repository" }],
+      }),
+    });
+    const built = payload(discovery, NOW);
+
+    expect(built.queue.projects.map((entry) => entry.outcome)).toEqual(["unreachable", "counted"]);
+    expect(built.queue.projects.map((entry) => entry.depth)).toEqual([null, 0]);
+  });
+
+  it("carries an honest absence when the daemon polls no selector at all", () => {
+    const built = payload(null, NOW);
+
+    expect(built.queue.projects).toEqual([]);
+    expect(built.queue.fetched_at).toBeNull();
+    expect(built.queue.stale).toBe(false);
+  });
+});
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-quota-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+describe("the daemon publishes the queue outcome it last observed", () => {
+  it("reports a spent quota on the payload, with the depth the previous poll held", async () => {
+    const answers: unknown[] = [counted([3]), SPENT];
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      queueDiscovery: { intervalMs: 0, transport: async () => answers.shift() ?? SPENT },
+    });
+    running.push(daemon);
+    daemon.registerProject({
+      project_label: "acme/p0",
+      selector: "repo:acme/p0 label:ready-for-agent",
+      argv: ["red-skills-dev", "work"],
+      target: 1,
+    });
+
+    await daemon.pollQueueDiscovery();
+    const first = daemon.statuslinePayload();
+    expect(first.queue.projects[0]).toMatchObject({ outcome: "counted", depth: 3 });
+
+    await daemon.pollQueueDiscovery();
+    const second = daemon.statuslinePayload();
+    expect(second.queue.projects[0]).toMatchObject({ outcome: "rate-limited", depth: null, last_counted_depth: 3 });
+    expect(second.queue.rate_limit.exhausted).toBe(true);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2904. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2904

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788086286&installation_model_id=20659&pr_number=2940&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2940&signature=c32b94ba442198f095c53b4cb670c246507334f70568d4b41eba3c114fad75ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->