### PR TITLE
fix: #2925 The per-project producer resolves its bundle once at launch and never re-checks, so it strands on every release

### DIFF
--- a/.changeset/the-producer-re-checks-its-own-bundle.md
+++ b/.changeset/the-producer-re-checks-its-own-bundle.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The per-project producer now re-checks the published version and hands over to a newer bundle instead of stranding on the one it resolved at launch (#2925). It resolved a bundle once, at boot, from the local ladder, and never asked again — so `project_start` went on reporting `bundle_version: 3.0.3` while npm already served 3.0.4, every Worker born after the release boot-halted on skew, and the producer kept ticking and reporting itself healthy. Over one session that stranded a dispatch twice and left four `ready-for-agent` issues unworked with free slots available.
+
+**The component that decides when Workers are born must not strand.** The daemon already answered this for itself — it probes every 15 minutes and comes back on the new bundle — and the producer now asks the same question on the same cadence (`RED_AFK_REPLACE_CHECK_MS`; `0` turns it off), under the same four rules. A replacement is a restart, not an evacuation: the live Workers are the daemon's units, so the successor adopts them by pid and nothing is stopped, drained or re-queued. The version reported is always the version RUNNING — the published answer is carried beside it, never folded into it (#2809). A local build replaces itself with nothing. And a major boundary is never crossed on a background timer.
+
+The successor is **pinned** to the version that was decided, not resolved afresh — an entry that landed on any other version would let the skew survive the very restart it exists to end — and it is prepared before anything is given up: a published version this host can run from nowhere is not an adoptable answer, so the producer keeps working rather than releasing its identity to a successor that cannot start.

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -42,7 +42,16 @@ import { formatPreconditionFailure, runBoot, type BootResult, type BootstrapInpu
 import { inspectProcessTreeNative, sampleTreeRssMbNative } from "../runtime/proc-tree.js";
 import { refuseRemovedFleetFlag } from "../core/removed-fleet-flag.js";
 import { SUPERVISOR_LANE_ENV } from "../core/supervisor-lane.js";
-import { resolveDevScriptPath } from "../runtime/supervisor-spawn.js";
+import { resolveDevScriptPath, spawnSupervisor } from "../runtime/supervisor-spawn.js";
+import { resolveSupervisorEntry } from "../runtime/supervisor-entry.js";
+import { compareSemver } from "../core/bundle-version.js";
+import { refreshPublishedBundleVersion } from "../core/published-version.js";
+import {
+  createProducerReplacementWatch,
+  handOverProducer,
+  producerReplaceCheckMs,
+  type ProducerSlotPid,
+} from "../core/producer-self-replace.js";
 import {
   createRedskilledBirthPort,
   redskilledUnreachableAdvice,
@@ -1193,7 +1202,65 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   process.once("exit", onProcessExit);
   process.once("uncaughtExceptionMonitor", onUncaughtException);
 
-  const stopRequested = (): boolean => existsSync(stopFile);
+  // ---- the producer re-checks its own bundle (#2925) -----------------------
+  // Resolving a bundle once at launch is what stranded this process on every
+  // release: `project_start` went on reporting 3.0.3 while npm served 3.0.4, and
+  // every Worker born afterwards boot-halted on skew while the producer reported
+  // itself healthy. The daemon already answers this for itself; the cadence and
+  // the four rules are deliberately its own (`producer-self-replace.ts`).
+  const runningVersion = readBuildInfo("dev").version;
+  const laneLog = (line: string): void => {
+    try {
+      process.stderr.write(`${line}\n`);
+    } catch {
+      // a closed stderr never costs the handover.
+    }
+    void exitWriter
+      .append({ kind: "supervisor.message", supervisor_id: supervisorId, payload: { message: line } })
+      .catch(() => undefined);
+  };
+  const replaceWatch = createProducerReplacementWatch({
+    running: runningVersion,
+    // One registry read per check, recorded so every passive surface replays it
+    // instead of deriving its own answer (#2809). A published version this host
+    // cannot RUN is not an adoptable answer: resolving the successor's entry here
+    // is what keeps preparation ahead of anything being given up.
+    probePublished: async () => {
+      const observed = await refreshPublishedBundleVersion(runningVersion, process.env);
+      const published = observed.version;
+      if (!published || compareSemver(published, runningVersion) <= 0) return published;
+      try {
+        resolveSupervisorEntry({ installedVersion: runningVersion, resolvePublished: () => published });
+      } catch (err) {
+        laneLog(
+          `producer self-replace deferred: the published bundle ${published} runs from nowhere on this host ` +
+            `(${err instanceof Error ? err.message : String(err)})`,
+        );
+        return null;
+      }
+      return published;
+    },
+  });
+  const replaceCheckMs = producerReplaceCheckMs(process.env);
+  const replaceTimer =
+    replaceCheckMs > 0
+      ? setInterval(() => {
+          void replaceWatch
+            .tick()
+            .then((decision) => {
+              if (decision.act === "replace") {
+                laneLog(
+                  `producer self-replace decided: ${runningVersion} is superseded by ${decision.to}; ` +
+                    `stopping the tick loop to hand over`,
+                );
+              }
+            })
+            .catch(() => undefined);
+        }, replaceCheckMs)
+      : undefined;
+  replaceTimer?.unref();
+
+  const stopRequested = (): boolean => existsSync(stopFile) || replaceWatch.decided() !== null;
   let state: SupervisorState | undefined;
   let deps: SupervisorDeps | undefined;
   let shuttingDown = false;
@@ -1249,7 +1316,50 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
     );
     await runSupervisor(state, deps, config, stopRequested);
     completed = true;
-    await exitRecorder.record(stopRequested() ? "explicit-stop" : "completed");
+    const replacement = replaceWatch.decided();
+    if (replacement === null) {
+      await exitRecorder.record(existsSync(stopFile) ? "explicit-stop" : "completed");
+      return 0;
+    }
+
+    // The tick loop stopped because a newer bundle is published, not because
+    // anyone asked this project to stop. The live Workers are the daemon's units
+    // and outlive this process, so they are handed to the successor by pid rather
+    // than terminated; the control files this process owns are given up first,
+    // because one producer per project is enforced by exactly that identity.
+    const liveSlotPids: ProducerSlotPid[] = state.slots.flatMap((slot, index) =>
+      slot.pid !== null && isAlive(slot.pid) ? [{ slot: index, pid: slot.pid }] : [],
+    );
+    await exitRecorder.record("self-replace", { from: runningVersion, to: replacement.to });
+    const handover = await handOverProducer(
+      { to: replacement.to, target: state.slots.length, adoptSlotPids: liveSlotPids },
+      {
+        release: () => {
+          // Do NOT let the finally block remove these again: from here on they
+          // belong to whoever wins the identity next.
+          completed = false;
+          rmSync(pidFile, { force: true });
+          rmSync(paths.supervisorPidStartPath, { force: true });
+          rmSync(stopFile, { force: true });
+        },
+        spawn: (input) =>
+          spawnSupervisor({
+            root,
+            target: input.target,
+            runner: config.runner,
+            base: trunk,
+            passthrough: slotArgs,
+            adoptSlotPids: input.adoptSlotPids,
+            // The successor is PINNED to the decided version: an entry resolved
+            // afresh could land on any other one, and the skew would survive the
+            // restart it exists to end.
+            entry: { installedVersion: runningVersion, resolvePublished: () => input.to },
+            onNotice: laneLog,
+          }),
+        log: laneLog,
+      },
+    );
+    return handover.ok ? 0 : 1;
   } catch (error) {
     await exitRecorder.record("exception", {
       name: error instanceof Error ? error.name : "Error",
@@ -1257,6 +1367,7 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
     });
     throw error;
   } finally {
+    if (replaceTimer !== undefined) clearInterval(replaceTimer);
     process.removeListener("exit", onProcessExit);
     process.removeListener("uncaughtExceptionMonitor", onUncaughtException);
     process.removeListener("SIGTERM", onSigterm);

--- a/apps/dev/src/core/producer-self-replace.ts
+++ b/apps/dev/src/core/producer-self-replace.ts
@@ -1,0 +1,215 @@
+/**
+ * producer-self-replace — how a per-project producer on a superseded bundle
+ * becomes one on the current.
+ *
+ * The daemon already answered this for itself (`redskilled/self-replace.ts`): it
+ * probes the published version on an interval and comes back on the new bundle,
+ * because a long-running process on a superseded bundle killed 21 Workers in 20
+ * minutes. The per-project producer had no equivalent — it resolved a bundle once
+ * at launch and never asked again — so every release stranded it: `project_start`
+ * reported `bundle_version: 3.0.3` while npm already served 3.0.4, every Worker
+ * born afterwards boot-halted on skew, and the producer went on reporting itself
+ * healthy (#2925). Restarting by hand is not the cure: three releases landed
+ * inside one hour, faster than an operator can chase.
+ *
+ * Four rules decide this module, and they are the daemon's rules deliberately.
+ *
+ * **A replacement is a restart, not an evacuation.** Workers are born by the host
+ * daemon (ADR 0130) and outlive the producer that asked for them; the successor
+ * adopts them by pid. Nothing is stopped, drained or re-queued.
+ *
+ * **The version a producer reports is the version it RUNS, always.** The published
+ * answer is carried beside it, never folded into it — substituting the resolved
+ * version for the running one is exactly how a stale process reports a healthy
+ * zero skew while every Worker boot-halts (#2809). This module *decides*; it
+ * never renames what is running.
+ *
+ * **A local build replaces itself with nothing.** A source checkout is not a
+ * point on the published lane, so comparing it to a release is meaningless and
+ * acting on the comparison would take a developer's own producer away
+ * mid-session.
+ *
+ * **A major boundary is held.** A breaking change must not arrive on a machine
+ * because a background timer noticed it, so the decision only ever adopts inside
+ * the running major.
+ *
+ * PURE — the probe is injected, and nothing here reads a clock, a socket or a
+ * file.
+ */
+import { compareSemver, semverParts } from "./bundle-version.js";
+
+/** How long the producer waits between published-version checks — the daemon's cadence. */
+export const DEFAULT_PRODUCER_REPLACE_CHECK_MS = 900_000;
+
+/** Operator override for the cadence; `0` turns the check off entirely. */
+export const PRODUCER_REPLACE_CHECK_ENV = "RED_AFK_REPLACE_CHECK_MS";
+
+export type ProducerReplacementHoldReason =
+  | "local-build"
+  | "published-unknown"
+  | "no-newer-version"
+  | "major-held";
+
+/** The decision itself, and the version it names — never the version being run. */
+export type ProducerReplacement = { readonly act: "replace"; readonly to: string };
+
+export type ProducerReplacementDecision =
+  | { readonly act: "hold"; readonly reason: ProducerReplacementHoldReason }
+  | ProducerReplacement;
+
+export interface PlanProducerReplacementInput {
+  /** The version this process is RUNNING — never the one it resolved. */
+  readonly running: string;
+  /** The published answer; null or unparseable is unknown, never a match. */
+  readonly published: string | null | undefined;
+}
+
+/** Decide whether this producer should hand over to a newer bundle. PURE. */
+export function planProducerReplacement(
+  input: PlanProducerReplacementInput,
+): ProducerReplacementDecision {
+  const running = input.running.trim();
+  if (isLocalProducerBuild(running)) return { act: "hold", reason: "local-build" };
+  const published = (input.published ?? "").trim();
+  const parsed = semverParts(published);
+  if (!published || parsed === null) return { act: "hold", reason: "published-unknown" };
+  if (compareSemver(published, running) <= 0) return { act: "hold", reason: "no-newer-version" };
+  // A newer MAJOR is reported by the surfaces and adopted by nobody on a timer.
+  if (parsed[0] !== semverParts(running)?.[0]) return { act: "hold", reason: "major-held" };
+  return { act: "replace", to: published };
+}
+
+/**
+ * A prerelease, a build-metadata version or anything unparseable is a local
+ * build: it is the intended runtime for whoever started it, and no release
+ * supersedes it. Matches `isLocalDevBuild`'s rule for the launch path, plus the
+ * daemon's reading of an unparseable version as local.
+ */
+export function isLocalProducerBuild(version: string): boolean {
+  const trimmed = version.trim();
+  if (semverParts(trimmed) === null) return true;
+  return /^\d+\.\d+\.\d+[-+]/.test(trimmed);
+}
+
+/** The configured cadence between checks, in milliseconds. PURE. */
+export function producerReplaceCheckMs(env: NodeJS.ProcessEnv): number {
+  const raw = (env[PRODUCER_REPLACE_CHECK_ENV] ?? "").trim();
+  if (!raw) return DEFAULT_PRODUCER_REPLACE_CHECK_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_PRODUCER_REPLACE_CHECK_MS;
+  return Math.floor(parsed);
+}
+
+export interface ProducerReplacementWatchInput {
+  /** The version this process is RUNNING. */
+  readonly running: string;
+  /** One published-version read; a throw is read as unknown, never as a match. */
+  readonly probePublished: () => Promise<string | null | undefined>;
+}
+
+/**
+ * The standing question "has the published version moved?", asked one tick at a
+ * time.
+ *
+ * A decision, once made, is BINDING: the producer stops feeding new Workers on
+ * the strength of it, so letting a later flapping answer unmake it would leave a
+ * producer that had already announced a handover serving the old bundle again.
+ * A local build never even probes — asking would spend a registry read on a
+ * comparison whose answer can only be "hold".
+ */
+export interface ProducerReplacementWatch {
+  /** Ask once. Returns this tick's decision, binding or not. */
+  tick(): Promise<ProducerReplacementDecision>;
+  /** The binding decision, or null while none has been made. */
+  decided(): ProducerReplacement | null;
+}
+
+export function createProducerReplacementWatch(
+  input: ProducerReplacementWatchInput,
+): ProducerReplacementWatch {
+  let decision: ProducerReplacement | null = null;
+  const local = isLocalProducerBuild(input.running);
+  return {
+    async tick(): Promise<ProducerReplacementDecision> {
+      if (decision !== null) return decision;
+      if (local) return { act: "hold", reason: "local-build" };
+      let published: string | null | undefined;
+      try {
+        published = await input.probePublished();
+      } catch {
+        // An unreachable registry costs the check, never the producer: unknown
+        // stays unknown, and the next tick asks again.
+        published = null;
+      }
+      const planned = planProducerReplacement({ running: input.running, published });
+      if (planned.act === "replace") decision = planned;
+      return planned;
+    },
+    decided: () => decision,
+  };
+}
+
+/** A live Worker the successor inherits, by the slot it occupies. */
+export interface ProducerSlotPid {
+  readonly slot: number;
+  readonly pid: number;
+}
+
+/** Everything the successor needs to continue this producer's work. */
+export interface ProducerHandover {
+  /** The version the successor must run — pinned, so the skew cannot survive it. */
+  readonly to: string;
+  readonly target: number;
+  /** Live Workers, handed over rather than stopped: they outlive this process. */
+  readonly adoptSlotPids: readonly ProducerSlotPid[];
+}
+
+export interface ProducerHandoverIO {
+  /** Give up this producer's pid identity so the successor can take it. */
+  release(): Promise<void> | void;
+  /** Start the successor at the pinned version; null when it never came up. */
+  spawn(handover: ProducerHandover): Promise<number | null>;
+  log(line: string): void;
+}
+
+export interface ProducerHandoverResult {
+  readonly ok: boolean;
+  readonly pid: number | null;
+  /** Present only on failure — the reason, in the words an operator needs. */
+  readonly error?: string;
+}
+
+/**
+ * Complete one handover, on a producer that has ALREADY stopped its tick loop.
+ *
+ * The order is not negotiable: this process releases its pid identity FIRST and
+ * only then starts a successor — one supervisor per project is enforced by that
+ * identity, so a successor racing a live holder is refused on the spot and the
+ * project is left on the old bundle by a producer that believed it had handed
+ * over. The live Workers are carried across rather than stopped, because they
+ * are the daemon's units and outlive whoever asked for them.
+ */
+export async function handOverProducer(
+  handover: ProducerHandover,
+  io: ProducerHandoverIO,
+): Promise<ProducerHandoverResult> {
+  io.log(
+    `producer self-replace: handing over to ${handover.to} ` +
+      `(target=${handover.target}, live workers adopted=${handover.adoptSlotPids.length})`,
+  );
+  await io.release();
+  try {
+    const pid = await io.spawn(handover);
+    if (pid === null) {
+      const error = `the successor at ${handover.to} published no pid within the boot window`;
+      io.log(`producer self-replace failed: ${error}`);
+      return { ok: false, pid: null, error };
+    }
+    io.log(`producer self-replace: ${handover.to} is live (pid=${pid})`);
+    return { ok: true, pid };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    io.log(`producer self-replace failed: ${error}`);
+    return { ok: false, pid: null, error };
+  }
+}

--- a/apps/dev/src/core/supervisor-exit.ts
+++ b/apps/dev/src/core/supervisor-exit.ts
@@ -5,6 +5,9 @@ export type SupervisorExitReason =
   | "exception"
   | "explicit-stop"
   | "completed"
+  /** The tick loop stopped so a successor on a newer published bundle can take
+   * over (#2925) — a restart, not a stop: the live Workers are handed across. */
+  | "self-replace"
   | "process-exit";
 
 type SupervisorExitRecord = Omit<CastleLaneRecord, "at">;

--- a/apps/dev/tests/producer-self-replace.test.ts
+++ b/apps/dev/tests/producer-self-replace.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+  createProducerReplacementWatch,
+  DEFAULT_PRODUCER_REPLACE_CHECK_MS,
+  handOverProducer,
+  isLocalProducerBuild,
+  planProducerReplacement,
+  producerReplaceCheckMs,
+  type ProducerHandover,
+} from "../src/core/producer-self-replace.js";
+
+describe("planProducerReplacement", () => {
+  it("adopts a newer published version inside the running major", () => {
+    expect(planProducerReplacement({ running: "3.0.3", published: "3.0.4" })).toEqual({
+      act: "replace",
+      to: "3.0.4",
+    });
+  });
+
+  it("holds when the published version is the running one", () => {
+    expect(planProducerReplacement({ running: "3.0.4", published: "3.0.4" })).toEqual({
+      act: "hold",
+      reason: "no-newer-version",
+    });
+  });
+
+  it("holds when the published version is older than the running one", () => {
+    expect(planProducerReplacement({ running: "3.0.4", published: "3.0.3" })).toEqual({
+      act: "hold",
+      reason: "no-newer-version",
+    });
+  });
+
+  it("holds when the published version could not be resolved", () => {
+    expect(planProducerReplacement({ running: "3.0.3", published: null })).toEqual({
+      act: "hold",
+      reason: "published-unknown",
+    });
+    expect(planProducerReplacement({ running: "3.0.3", published: "not-a-version" })).toEqual({
+      act: "hold",
+      reason: "published-unknown",
+    });
+  });
+
+  it("never replaces a local build, however far ahead the registry is", () => {
+    expect(planProducerReplacement({ running: "0.0.0-dev", published: "9.9.9" })).toEqual({
+      act: "hold",
+      reason: "local-build",
+    });
+    expect(planProducerReplacement({ running: "3.0.3+local", published: "3.0.4" })).toEqual({
+      act: "hold",
+      reason: "local-build",
+    });
+  });
+
+  it("holds a major boundary rather than crossing it on a timer", () => {
+    expect(planProducerReplacement({ running: "3.0.3", published: "4.0.0" })).toEqual({
+      act: "hold",
+      reason: "major-held",
+    });
+  });
+});
+
+describe("isLocalProducerBuild", () => {
+  it("reads a prerelease, a build-metadata version and anything unparseable as local", () => {
+    expect(isLocalProducerBuild("0.0.0-dev")).toBe(true);
+    expect(isLocalProducerBuild("3.0.3+local")).toBe(true);
+    expect(isLocalProducerBuild("")).toBe(true);
+    expect(isLocalProducerBuild("3.0.3")).toBe(false);
+  });
+});
+
+describe("producerReplaceCheckMs", () => {
+  it("defaults to the daemon's cadence and accepts an operator override", () => {
+    expect(producerReplaceCheckMs({})).toBe(DEFAULT_PRODUCER_REPLACE_CHECK_MS);
+    expect(producerReplaceCheckMs({ RED_AFK_REPLACE_CHECK_MS: "60000" })).toBe(60_000);
+    expect(producerReplaceCheckMs({ RED_AFK_REPLACE_CHECK_MS: "0" })).toBe(0);
+    expect(producerReplaceCheckMs({ RED_AFK_REPLACE_CHECK_MS: "junk" })).toBe(
+      DEFAULT_PRODUCER_REPLACE_CHECK_MS,
+    );
+  });
+});
+
+describe("createProducerReplacementWatch", () => {
+  it("reproduces the observed case: a producer on 3.0.3 adopts the published 3.0.4", async () => {
+    // The fixture the issue describes: the producer resolved 3.0.3 at launch while
+    // npm already served 3.0.4, and the skew stood indefinitely because nothing
+    // asked again. One tick of the watch is the whole cure.
+    const published = ["3.0.3", "3.0.3", "3.0.4"];
+    let probes = 0;
+    const watch = createProducerReplacementWatch({
+      running: "3.0.3",
+      probePublished: async () => published[Math.min(probes++, published.length - 1)] ?? null,
+    });
+
+    expect(await watch.tick()).toEqual({ act: "hold", reason: "no-newer-version" });
+    expect(watch.decided()).toBeNull();
+    await watch.tick();
+    expect(watch.decided()).toBeNull();
+
+    expect(await watch.tick()).toEqual({ act: "replace", to: "3.0.4" });
+    expect(watch.decided()).toEqual({ act: "replace", to: "3.0.4" });
+    expect(probes).toBe(3);
+  });
+
+  it("keeps the first decision once made, so a flapping registry cannot unmake it", async () => {
+    const answers = ["3.0.4", "3.0.3"];
+    let probes = 0;
+    const watch = createProducerReplacementWatch({
+      running: "3.0.3",
+      probePublished: async () => answers[probes++] ?? null,
+    });
+
+    await watch.tick();
+    expect(watch.decided()).toEqual({ act: "replace", to: "3.0.4" });
+    expect(await watch.tick()).toEqual({ act: "replace", to: "3.0.4" });
+    expect(watch.decided()).toEqual({ act: "replace", to: "3.0.4" });
+    // Nothing was probed again after the decision: the answer is already binding.
+    expect(probes).toBe(1);
+  });
+
+  it("treats a failing probe as unknown, never as a match", async () => {
+    const watch = createProducerReplacementWatch({
+      running: "3.0.3",
+      probePublished: async () => {
+        throw new Error("registry unreachable");
+      },
+    });
+    expect(await watch.tick()).toEqual({ act: "hold", reason: "published-unknown" });
+    expect(watch.decided()).toBeNull();
+  });
+
+  it("never probes at all for a local build", async () => {
+    let probes = 0;
+    const watch = createProducerReplacementWatch({
+      running: "0.0.0-dev",
+      probePublished: async () => {
+        probes += 1;
+        return "9.9.9";
+      },
+    });
+    expect(await watch.tick()).toEqual({ act: "hold", reason: "local-build" });
+    expect(probes).toBe(0);
+    expect(watch.decided()).toBeNull();
+  });
+});
+
+describe("handOverProducer", () => {
+  const handover: ProducerHandover = {
+    to: "3.0.4",
+    target: 3,
+    adoptSlotPids: [
+      { slot: 0, pid: 4242 },
+      { slot: 2, pid: 4343 },
+    ],
+  };
+
+  it("releases the pid identity BEFORE the successor is started", async () => {
+    const order: string[] = [];
+    const result = await handOverProducer(handover, {
+      release: () => {
+        order.push("release");
+      },
+      spawn: async () => {
+        order.push("spawn");
+        return 99;
+      },
+      log: () => undefined,
+    });
+
+    expect(order).toEqual(["release", "spawn"]);
+    expect(result).toEqual({ ok: true, pid: 99 });
+  });
+
+  it("hands the live workers to the successor instead of stopping them", async () => {
+    let seen: ProducerHandover | undefined;
+    await handOverProducer(handover, {
+      release: () => undefined,
+      spawn: async (input) => {
+        seen = input;
+        return 99;
+      },
+      log: () => undefined,
+    });
+
+    expect(seen?.adoptSlotPids).toEqual([
+      { slot: 0, pid: 4242 },
+      { slot: 2, pid: 4343 },
+    ]);
+    expect(seen?.to).toBe("3.0.4");
+    expect(seen?.target).toBe(3);
+  });
+
+  it("reports a successor that never came up, loudly", async () => {
+    const lines: string[] = [];
+    const result = await handOverProducer(handover, {
+      release: () => undefined,
+      spawn: async () => null,
+      log: (line) => lines.push(line),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("3.0.4");
+    expect(lines.some((line) => line.includes("producer self-replace failed"))).toBe(true);
+  });
+
+  it("reports a successor that refused to start, loudly", async () => {
+    const lines: string[] = [];
+    const result = await handOverProducer(handover, {
+      release: () => undefined,
+      spawn: async () => {
+        throw new Error("redskilled unreachable");
+      },
+      log: (line) => lines.push(line),
+    });
+
+    expect(result).toEqual({ ok: false, pid: null, error: "redskilled unreachable" });
+    expect(lines.some((line) => line.includes("redskilled unreachable"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2925. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2925

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788088895&installation_model_id=20659&pr_number=2943&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2943&signature=305755990039f88d7e6198bd8c13bebf79c0c84406733b30020eced85f22af0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->