### PR TITLE
chore: #2905 A drained project deregisters itself

### DIFF
--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -121,6 +121,7 @@ import {
   type RedskilledQueueDiscovery,
   type RedskilledQueueTransport,
 } from "./queue-discovery.js";
+import { planQueueDrain, type RedskilledQueueDrain } from "./queue-drain.js";
 import { buildStatuslinePayload, type RedskilledStatuslinePayload } from "./statusline-payload.js";
 import {
   REDSKILLED_STATUSLINE_DEFAULTS,
@@ -391,6 +392,13 @@ export interface RedskilledDaemon {
   pollQueueDiscovery(): Promise<RedskilledQueueDiscovery | null>;
   /** The last queue fetch, dated by the poll it came from; `null` before the first. */
   queueDiscovery(): RedskilledQueueDiscovery | null;
+  /**
+   * What that fetch decided about each registration — released, or held and why.
+   *
+   * `null` before the first poll: a daemon that has counted nothing has drained
+   * nothing, which is not the same as having found every queue full.
+   */
+  queueDrain(): RedskilledQueueDrain | null;
   /** Re-probe every re-attached Worker, retiring the ones the host no longer confirms. */
   sweepReattached(): Promise<readonly RedskilledWorkerView[]>;
   /** The Workers this daemon adopted at start rather than birthing itself. */
@@ -545,6 +553,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // two cadences produce two instants, and a document that carried one date for
   // both would age the fast half by the slow half's clock.
   let lastQueue: RedskilledQueueDiscovery | null = null;
+  // What the last queue fetch decided about the registrations it covered, kept so
+  // a project's disappearance from the list carries the sentence that removed it
+  // rather than leaving a caller to guess which of the three outcomes it was.
+  let lastDrain: RedskilledQueueDrain | null = null;
   let idleTimer: NodeJS.Timeout | undefined;
   let sampleTimer: NodeJS.Timeout | undefined;
   let replaceTimer: NodeJS.Timeout | undefined;
@@ -641,7 +653,30 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       now: clock(),
       ...(queueRegistration?.batchSize == null ? {} : { batchSize: queueRegistration.batchSize }),
     });
+    applyQueueDrain(lastQueue);
     return lastQueue;
+  }
+
+  /**
+   * Release every project this poll found genuinely drained.
+   *
+   * The registration set is re-read HERE rather than reused from before the
+   * request, so a project that registered while the answer was in flight cannot
+   * be judged by a poll that never named it. The plan is the whole decision — a
+   * counted zero and nothing else — and this function only applies it.
+   */
+  function applyQueueDrain(discovery: RedskilledQueueDiscovery): void {
+    const plan = planQueueDrain({
+      discovery,
+      registered: [...registrations.keys()],
+      busyProjects: [...workers.values()].map((worker) => worker.project_label),
+      now: clock(),
+    });
+    for (const projectLabel of plan.deregistered) registrations.delete(projectLabel);
+    lastDrain = plan;
+    // A host that just let go of its last registration may now have nothing to
+    // hold it open, exactly as a Worker's death does.
+    if (plan.deregistered.length > 0) armIdleTimer();
   }
 
   /**
@@ -1338,6 +1373,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     pollRepositoryActivity,
     pollQueueDiscovery,
     queueDiscovery: () => lastQueue,
+    queueDrain: () => lastDrain,
     sweepReattached,
     publishWorkerHeartbeat,
     reattached: () => [...reattached].map((id) => workers.get(id)).filter((w): w is RedskilledWorkerView => w != null),

--- a/apps/redskilled/src/queue-drain.ts
+++ b/apps/redskilled/src/queue-drain.ts
@@ -1,0 +1,123 @@
+/**
+ * queue-drain — a project whose queue has run out leaves the daemon's list.
+ *
+ * ADR 0130 Amendment 3: **the list of active projects lives in the daemon and
+ * leaves it when the issues run out.** A registration whose selector matches
+ * nothing is a query re-asked every window to re-learn a fact that has not
+ * changed — the standing cost the batched poll exists to remove, and the one
+ * shape of it batching alone cannot remove.
+ *
+ * **Only a counted zero drains a project.** The three outcomes a queue read can
+ * have are three different facts, and exactly one of them is an empty queue: a
+ * spent quota and a selector the token could not resolve each carry no depth at
+ * all, so a project behind either stays registered and is asked again. Treating
+ * them as zeros would retire a project that still had work — the reason this
+ * slice lands after the three-outcome one rather than beside it.
+ *
+ * **A project this poll never asked about is held, not judged.** A registration
+ * that arrived mid-flight is absent from an answer that never named it, and
+ * absence is not emptiness.
+ *
+ * **A live Worker is remaining work.** A project whose last item is being worked
+ * right now reads zero while the Worker still runs, so a project holding one is
+ * kept: deregistering it would drop the registration out from under the process
+ * it was made for, and the empty read repeats one window after the Worker dies.
+ *
+ * **Nothing here reads a selector.** The decision turns on an outcome, an integer
+ * and a project label — the daemon still does not know what an Issue is (rule 3).
+ *
+ * PURE: every input is passed in, the clock included.
+ */
+
+import type { RedskilledQueueDiscovery } from "./queue-discovery.js";
+
+/** What the daemon decided about one registered project, and why. */
+export interface RedskilledDrainDecision {
+  readonly project_label: string;
+  readonly deregistered: boolean;
+  readonly reason: string;
+}
+
+export interface RedskilledQueueDrain {
+  readonly version: 1;
+  readonly decided_at: string;
+  /** The projects to release, by label, ordered — a caller applies them verbatim. */
+  readonly deregistered: readonly string[];
+  /** One decision per registered project, held ones included, ordered by label. */
+  readonly decisions: readonly RedskilledDrainDecision[];
+}
+
+export interface PlanQueueDrainInput {
+  /** The poll that just answered; `null` before the first one, which drains nothing. */
+  readonly discovery: RedskilledQueueDiscovery | null;
+  /** The projects the daemon holds a registration for right now. */
+  readonly registered: readonly string[];
+  /** The projects with a Worker alive; theirs is work a zero cannot see. */
+  readonly busyProjects?: readonly string[];
+  /** The daemon's own clock, so the decision is dated by the daemon that made it. */
+  readonly now: string;
+}
+
+/**
+ * Decide which registered projects have drained. PURE.
+ *
+ * The registered set is the subject rather than the answer's project list, so a
+ * project the poll skipped is still accounted for — held, with the reason it was
+ * held — instead of quietly falling out of a document that claims to cover the
+ * whole list.
+ */
+export function planQueueDrain(input: PlanQueueDrainInput): RedskilledQueueDrain {
+  const counted = new Map((input.discovery?.projects ?? []).map((project) => [project.project_label, project]));
+  const busy = new Set(input.busyProjects ?? []);
+  const decisions = [...input.registered]
+    .sort((left, right) => left.localeCompare(right))
+    .map((projectLabel): RedskilledDrainDecision => decide(projectLabel, counted.get(projectLabel), busy));
+
+  return {
+    version: 1,
+    decided_at: input.now,
+    deregistered: decisions.filter((decision) => decision.deregistered).map((decision) => decision.project_label),
+    decisions,
+  };
+}
+
+function decide(
+  projectLabel: string,
+  read: RedskilledQueueDiscovery["projects"][number] | undefined,
+  busy: ReadonlySet<string>,
+): RedskilledDrainDecision {
+  const held = (reason: string): RedskilledDrainDecision => ({ project_label: projectLabel, deregistered: false, reason });
+  const named = JSON.stringify(projectLabel);
+
+  if (read == null) {
+    return held(`this poll never asked about project ${named}, and an absent answer is not an empty queue`);
+  }
+  if (read.outcome === "rate-limited") {
+    return held(
+      `the host token's quota was spent before project ${named} answered, so this queue has no depth rather than a ` +
+        `depth of zero and the registration stands`,
+    );
+  }
+  if (read.outcome !== "counted" || read.depth == null) {
+    return held(
+      `project ${named} could not be reached with the host token, so it carries no depth to drain on and stays ` +
+        `registered until one answers`,
+    );
+  }
+  if (read.depth > 0) {
+    return held(`project ${named} still has ${read.depth} item(s) matching its selector`);
+  }
+  if (busy.has(projectLabel)) {
+    return held(
+      `project ${named} counted zero while a Worker of its own is still alive, and that Worker is the work the count ` +
+        `cannot see`,
+    );
+  }
+  return {
+    project_label: projectLabel,
+    deregistered: true,
+    reason:
+      `project ${named} counted zero items with the host token answering, so its queue has genuinely drained and the ` +
+      `daemon stops polling a selector that names no work`,
+  };
+}

--- a/apps/redskilled/tests/queue-drain.test.ts
+++ b/apps/redskilled/tests/queue-drain.test.ts
@@ -1,0 +1,184 @@
+// A project whose queue is GENUINELY empty leaves the daemon's list (ADR 0130
+// Amendment 3, issue #2905): an empty selector polled forever is the standing
+// cost the batching Spec exists to remove. Only a counted zero deregisters — a
+// spent quota and an unreachable selector carry no depth, so a project behind
+// either of them stays registered and keeps being asked.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { planQueueDrain } from "../src/queue-drain.js";
+import type { RedskilledQueueDiscovery, RedskilledProjectQueue } from "../src/queue-discovery.js";
+
+const NOW = "2026-07-31T12:00:00.000Z";
+
+function discovery(projects: readonly RedskilledProjectQueue[]): RedskilledQueueDiscovery {
+  return {
+    version: 1,
+    fetched_at: NOW,
+    request_count: 1,
+    project_count: projects.length,
+    batch_size: 50,
+    rate_limit: { remaining: 4900, reset_at: null, exhausted: false },
+    projects,
+  };
+}
+
+function counted(label: string, depth: number): RedskilledProjectQueue {
+  return { project_label: label, outcome: "counted", depth, detail: `${label} has ${depth} item(s)` };
+}
+
+function failed(label: string, outcome: "unreachable" | "rate-limited"): RedskilledProjectQueue {
+  return { project_label: label, outcome, depth: null, detail: `${label} carries no depth` };
+}
+
+describe("only a counted zero drains a project", () => {
+  it("deregisters the genuinely empty queue and holds every project that still has work", () => {
+    const plan = planQueueDrain({
+      discovery: discovery([counted("acme/empty", 0), counted("acme/busy", 3)]),
+      registered: ["acme/busy", "acme/empty"],
+      now: NOW,
+    });
+
+    expect(plan.deregistered).toEqual(["acme/empty"]);
+    expect(plan.decisions.map((decision) => decision.project_label)).toEqual(["acme/busy", "acme/empty"]);
+    expect(plan.decisions.find((d) => d.project_label === "acme/busy")!.deregistered).toBe(false);
+  });
+
+  it("never mistakes a spent quota or an unreachable selector for a drained queue", () => {
+    const plan = planQueueDrain({
+      discovery: discovery([failed("acme/spent", "rate-limited"), failed("acme/lost", "unreachable")]),
+      registered: ["acme/lost", "acme/spent"],
+      now: NOW,
+    });
+
+    expect(plan.deregistered).toEqual([]);
+    for (const decision of plan.decisions) {
+      expect(decision.deregistered).toBe(false);
+      expect(decision.reason).toMatch(/no depth|quota|reach/i);
+    }
+  });
+
+  it("holds a project this poll never asked about, and every project when nothing was polled", () => {
+    const midFlight = planQueueDrain({
+      discovery: discovery([counted("acme/empty", 0)]),
+      registered: ["acme/empty", "acme/fresh"],
+      now: NOW,
+    });
+    expect(midFlight.deregistered).toEqual(["acme/empty"]);
+    expect(midFlight.decisions.find((d) => d.project_label === "acme/fresh")!.deregistered).toBe(false);
+
+    expect(planQueueDrain({ discovery: null, registered: ["acme/empty"], now: NOW }).deregistered).toEqual([]);
+  });
+
+  it("keeps a drained project whose Worker is still alive, because that Worker is its remaining work", () => {
+    const plan = planQueueDrain({
+      discovery: discovery([counted("acme/empty", 0)]),
+      registered: ["acme/empty"],
+      busyProjects: ["acme/empty"],
+      now: NOW,
+    });
+
+    expect(plan.deregistered).toEqual([]);
+    expect(plan.decisions[0]!.reason).toMatch(/Worker/);
+  });
+});
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-drain-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+function registration(index: number) {
+  return {
+    project_label: `acme/p${index}`,
+    selector: `repo:acme/p${index} label:ready-for-agent`,
+    argv: ["red-skills-dev", "work"],
+    target: 1,
+  };
+}
+
+/** One tracker answer: a depth per alias, in the order the batch was built. */
+function answer(depths: readonly (number | null)[]) {
+  const data: Record<string, unknown> = { rateLimit: { remaining: 4900, resetAt: null } };
+  depths.forEach((depth, index) => {
+    if (depth != null) data[`q${index}`] = { issueCount: depth };
+  });
+  return { data };
+}
+
+describe("a drained project leaves the daemon's list", () => {
+  it("drops the drained project from host-state, stops asking about it, and takes it back later", async () => {
+    const queries: string[] = [];
+    let call = 0;
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      queueDiscovery: {
+        intervalMs: 0,
+        transport: async (query) => {
+          queries.push(query);
+          call += 1;
+          // First poll: p0 has drained, p1 still has work. Later polls answer
+          // one depth per alias for whatever is still registered.
+          if (call === 1) return answer([0, 4]);
+          return answer(Array.from({ length: query.match(/q\d+: search/g)?.length ?? 0 }, () => 4));
+        },
+      },
+    });
+    running.push(daemon);
+
+    daemon.registerProject(registration(0));
+    daemon.registerProject(registration(1));
+    await daemon.pollQueueDiscovery();
+
+    expect(daemon.registrations().map((entry) => entry.project_label)).toEqual(["acme/p1"]);
+    expect(daemon.hostState().registrations!.map((entry) => entry.project_label)).toEqual(["acme/p1"]);
+
+    // Not in the next aliased request: the drained selector is gone from the query.
+    await daemon.pollQueueDiscovery();
+    expect(queries[1]).not.toContain("acme/p0");
+    expect(queries[1]).toContain("acme/p1");
+
+    // Re-registering a drained project is a fresh registration, not a duplicate.
+    expect(() => daemon.registerProject(registration(0))).not.toThrow();
+    expect(daemon.registrations().map((entry) => entry.project_label)).toEqual(["acme/p0", "acme/p1"]);
+  });
+
+  it("keeps a project the fetch could not count, so a spent quota never retires live work", async () => {
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      queueDiscovery: {
+        intervalMs: 0,
+        transport: async () => {
+          throw new Error("API rate limit exceeded");
+        },
+      },
+    });
+    running.push(daemon);
+
+    daemon.registerProject(registration(0));
+    const fetched = await daemon.pollQueueDiscovery();
+
+    expect(fetched!.projects[0]!.outcome).toBe("rate-limited");
+    expect(daemon.registrations().map((entry) => entry.project_label)).toEqual(["acme/p0"]);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2905. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2905

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788090479&installation_model_id=20659&pr_number=2944&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2944&signature=3d8829940120cfab9ed460d032ca590c7a36447757afd8d88519e96e3ac4f2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->