### PR TITLE
chore: #2906 A registration outlives its session and expires

### DIFF
--- a/.changeset/a-registration-outlives-its-session-and-expires.md
+++ b/.changeset/a-registration-outlives-its-session-and-expires.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A registration now **outlives the session that made it, and lapses once nothing renews it** (#2906). Both halves are load-bearing and pull against each other: `/afk` has to keep draining after the operator closes the terminal — that was the entire reason a detached per-project process existed before ADR 0130 Amendment 3 — while a registration that never lapsed would make a closed laptop poll a repository forever. So the daemon keeps polling a registration nobody is renewing right up to its deadline, and stops at it: a lapsed project is absent from the very next queue fetch, absent from `host-state`, and no longer holds the daemon awake.
+
+The daemon gained one op, `project-renew`, a project-write like every other statement about a project — a session that could renew another project's registration could keep a drain nobody is watching running past the deadline that exists to end it. It widens the frozen contract by nothing: it names a project the daemon already keys registrations by and carries no field a client must state, because a renewal is a session saying "I am still here" rather than a second chance to restate what it wants. **A renewal never mints a record.** The selector, the argv and the target are deliberately kept nowhere else, so a lapsed registration is refused with the sentence that says to register again.
+
+`host-state` now reports, per registration, whether a session is still renewing it — `renewing` — or whether it is `running-on` after its session ended. The verdict is derived at the instant of the read and never stored, because it is a fact about silence rather than about the record: the daemon holds no connection to a session, so a closed terminal is something it learns by hearing nothing for longer than the half-life a lease states its own cadence at. An operator can now tell a drain that outlived its terminal from one being watched.

--- a/apps/dev/src/runtime/redskilled-birth.ts
+++ b/apps/dev/src/runtime/redskilled-birth.ts
@@ -25,6 +25,7 @@ import {
   deregisterRedskilledProject,
   ensureRedskilledDaemon,
   registerRedskilledProject,
+  renewRedskilledProject,
   readRedskilledHostState,
   startRedskilledWorker,
   type RedskilledClientConfig,
@@ -105,6 +106,16 @@ export interface RedskilledBirthPort {
    */
   register(request: ProjectRegistrationRequest): Promise<RedskilledProjectRegistration>;
   /**
+   * Say this session is still here, so the registration keeps standing.
+   *
+   * The registration outlives this session on purpose — a drain has to survive
+   * the operator closing the terminal — and the renewal is the only reason it
+   * does not outlive it forever. A refusal throws, including the one that says
+   * the record lapsed: a session that read that as renewed would keep renewing
+   * nothing while its work sat undrained, and its next move is to register again.
+   */
+  renew(): Promise<RedskilledProjectRegistration>;
+  /**
    * Take this project's presence back. Reports whether a record stood.
    *
    * `false` is an answer, not a fault: work stops from two directions — an
@@ -175,6 +186,11 @@ export function createRedskilledBirthPort(options: CreateRedskilledBirthOptions)
         config,
       );
       return registered.registration;
+    },
+
+    async renew() {
+      const renewed = await renewRedskilledProject(paths, { project_label: projectLabel }, config);
+      return renewed.registration;
     },
 
     async deregister() {

--- a/apps/dev/tests/redskilled-birth.test.ts
+++ b/apps/dev/tests/redskilled-birth.test.ts
@@ -155,6 +155,41 @@ describe("a project's Worker is born by the daemon", () => {
   });
 });
 
+describe("a project's registration outlives the session that made it", () => {
+  it("renews while the session lives, and is refused once the record has lapsed", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("dev-birth-registration-");
+    let ms = Date.parse("2026-07-31T12:00:00.000Z");
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      clock: () => new Date(ms).toISOString(),
+    });
+    running.push(daemon);
+
+    const port = createRedskilledBirthPort({ root: workspace, projectLabel: "acme/widgets", paths });
+    const registered = await port.register({
+      selector: "is:open label:ready-for-agent",
+      argv: ["red-skills-dev", "__work"],
+      target: 2,
+      renew_within_ms: 60_000,
+    });
+    expect(registered.renewals).toBe(0);
+
+    // The session is still here, so it says so — and the record's deadline moves.
+    ms += 30_000;
+    const renewed = await port.renew();
+    expect(renewed.renewals).toBe(1);
+    expect(Date.parse(renewed.renew_by)).toBeGreaterThan(Date.parse(registered.renew_by));
+
+    // The session ends here. One window of silence later the record is gone, and
+    // renewing it is refused rather than quietly minting an argv nobody restated.
+    ms += 60_000;
+    await expect(port.renew()).rejects.toThrow(/acme\/widgets/);
+    expect(daemon.hostState().registrations).toEqual([]);
+  });
+});
+
 describe("the project's identity and its advice", () => {
   it("resolves a label for a checkout with no git, no remote and no declared name", async () => {
     const root = await scratch("dev-birth-label-");

--- a/apps/dev/tests/supervise-slot-entry.test.ts
+++ b/apps/dev/tests/supervise-slot-entry.test.ts
@@ -39,6 +39,9 @@ function recordingHost(): RedskilledBirthPort {
     register: async () => {
       throw new Error("no project registers itself in a slot-argv test");
     },
+    renew: async () => {
+      throw new Error("no project renews a registration in a slot-argv test");
+    },
     deregister: async () => false,
     liveWorkers: async () => asked.length,
     drainEvents: async () => [],

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -34,6 +34,7 @@ import type { RedskilledProjectRegistrationRequest } from "./project-registratio
 import {
   isRedskilledProjectDeregistered,
   isRedskilledProjectRegistered,
+  isRedskilledProjectRenewed,
   isRedskilledStatuslinePayload,
   isRedskilledStatuslineRender,
   isRedskilledWorkerCommandResult,
@@ -42,6 +43,7 @@ import {
   sendRedskilledRequest,
   type RedskilledProjectDeregistered,
   type RedskilledProjectRegistered,
+  type RedskilledProjectRenewed,
   type RedskilledRequest,
   type RedskilledStatuslinePayload,
   type RedskilledStatuslineRender,
@@ -399,6 +401,36 @@ export async function registerRedskilledProject(
     config,
   );
   if (!isRedskilledProjectRegistered(value)) throw new Error("redskilled daemon returned a malformed registration");
+  return value;
+}
+
+/**
+ * Say this project's session is still here, so its registration keeps standing.
+ *
+ * **The registration outlives the session, and the renewal is why it does not
+ * outlive it forever.** A drain keeps being polled after the operator closes the
+ * terminal, all the way to the deadline the last renewal set; a laptop that closed
+ * mid-tick stops being a registered project one window later instead of polling a
+ * repository for the rest of the afternoon. **A refusal throws**, including the
+ * one that says the daemon holds no such registration: a client that read a lapsed
+ * record as renewed would keep renewing nothing while its work sat undrained.
+ */
+export async function renewRedskilledProject(
+  paths: RedskilledPaths,
+  request: { project_label: string; renew_within_ms?: number },
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledProjectRenewed> {
+  const value = await requestRedskilled(
+    paths,
+    {
+      op: "project-renew",
+      project_label: request.project_label,
+      ...(request.renew_within_ms == null ? {} : { renew_within_ms: request.renew_within_ms }),
+      session_project: config.sessionProject ?? request.project_label,
+    },
+    config,
+  );
+  if (!isRedskilledProjectRenewed(value)) throw new Error("redskilled daemon returned a malformed renewal");
   return value;
 }
 

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -77,6 +77,9 @@ import {
 import type { RedskilledPaths } from "./paths.js";
 import {
   buildProjectRegistration,
+  renewProjectRegistration,
+  RedskilledProjectUnregisteredError,
+  sweepLapsedRegistrations,
   type RedskilledProjectRegistration,
   type RedskilledProjectRegistrationRequest,
 } from "./project-registration.js";
@@ -102,6 +105,7 @@ import {
   type RedskilledWorkerCommandRequest,
   type RedskilledProjectDeregistered,
   type RedskilledProjectRegistered,
+  type RedskilledProjectRenewed,
   type RedskilledWorkerCommandResult,
   type RedskilledWorkerHeartbeatAck,
   type RedskilledWorkerHeartbeatRequest,
@@ -335,7 +339,19 @@ export interface RedskilledDaemon {
    * and the session that ends — so the second one must read as done, not failed.
    */
   deregisterProject(projectLabel: string, sessionProject?: string): RedskilledProjectDeregistered;
-  /** The registrations this daemon holds, ordered by project label. */
+  /**
+   * Push a project's registration out to a new deadline, because its session lives.
+   *
+   * Renewal is the ONLY thing that keeps a registration standing, and its absence
+   * is the only thing that ends one on its own: the daemon holds no connection to
+   * a session — every request arrives on its own socket — so a closed terminal is
+   * something it learns by not being told anything for a window.
+   */
+  renewProject(
+    projectLabel: string,
+    options?: { readonly sessionProject?: string; readonly renewWithinMs?: number },
+  ): RedskilledProjectRenewed;
+  /** The registrations this daemon holds, ordered by project label; lapsed ones swept. */
   registrations(): readonly RedskilledProjectRegistration[];
   hostState(): RedskilledHostState;
   /**
@@ -398,7 +414,7 @@ export interface RedskilledDaemon {
   /** Resolves once every event handed to the lane has reached disk. */
   flushEvents(): Promise<void>;
   /** Force the idle check to run now — the timer's body, exposed for tests. */
-  evaluateIdle(): "exited" | "held-by-workers";
+  evaluateIdle(): "exited" | "held-by-workers" | "held-by-registrations";
   /**
    * Resolve the published version and decide, WITHOUT acting on the decision.
    *
@@ -556,8 +572,26 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     resolveClosed = resolve;
   });
 
+  /**
+   * Drop every registration whose deadline has passed, and say which those were.
+   *
+   * Called from each surface that reads the set rather than from a timer of its
+   * own: a lapse is only ever observable at a read, and a timer would have to keep
+   * this process awake to enforce a deadline whose whole purpose is to let it
+   * sleep. A registration therefore stops being polled, stops being reported and
+   * stops holding the daemon alive at the same instant — the first read past it.
+   */
+  function expireLapsedRegistrations(nowMs: number): readonly RedskilledProjectRegistration[] {
+    const swept = sweepLapsedRegistrations(registrations.values(), nowMs);
+    for (const lapsed of swept.lapsed) registrations.delete(lapsed.project_label);
+    return swept.lapsed;
+  }
+
   function hostState(): RedskilledHostState {
+    const now = clock();
+    expireLapsedRegistrations(Date.parse(now));
     return buildHostState({
+      now,
       daemonVersion,
       machineIdHash: paths.machineIdHash,
       sessionKeyHash: paths.sessionKeyHash,
@@ -629,6 +663,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
    */
   async function pollQueueDiscovery(): Promise<RedskilledQueueDiscovery | null> {
     if (queueTransport == null) return null;
+    const now = clock();
+    // Swept before the set is snapshotted, so a lapsed project is absent from the
+    // very poll that would otherwise have asked the tracker about it again.
+    expireLapsedRegistrations(Date.parse(now));
     const projects = [...registrations.values()]
       .map((registration) => ({ project_label: registration.project_label, selector: registration.selector }))
       // By label, like every other list the daemon reports: the order a client
@@ -638,7 +676,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     lastQueue = await fetchQueueDiscovery({
       projects,
       transport: queueTransport,
-      now: clock(),
+      now,
       ...(queueRegistration?.batchSize == null ? {} : { batchSize: queueRegistration.batchSize }),
     });
     return lastQueue;
@@ -830,11 +868,19 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   ): RedskilledProjectRegistered {
     const reach = authorize("project-register", sessionProject, request.project_label);
     if (!reach.permitted) throw new Error(reach.reason);
+    const now = clock();
+    // Swept first, so a project whose last session died is refused nothing: the
+    // record it would collide with is one no session has renewed past its deadline.
+    expireLapsedRegistrations(Date.parse(now));
     const registration = buildProjectRegistration(request, {
-      now: clock(),
+      now,
       held: registrations.get(request.project_label),
     });
     registrations.set(registration.project_label, registration);
+    // A registration holds the daemon awake, exactly as a Worker does: a drain the
+    // operator walked away from must outlive the terminal, and a daemon that idled
+    // out under a standing registration would take the promise with it.
+    armIdleTimer();
     return {
       version: 1,
       registration,
@@ -842,6 +888,41 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       detail:
         `redskilled holds a registration for project ${JSON.stringify(registration.project_label)} at a target of ` +
         `${registration.target} until ${registration.renew_by}, and has read neither its selector nor its argv`,
+    };
+  }
+
+  /**
+   * Keep one project's registration standing, once reach has permitted it.
+   *
+   * Reach is checked against the project being renewed — its own label, exactly as
+   * at registration. A renewal for a record the daemon is not holding is REFUSED
+   * rather than minted: the selector, the argv and the target were deliberately
+   * not kept anywhere else, so a renewal that created a registration would be
+   * inventing the very strings ADR 0130 rule 3 forbids this process to author.
+   */
+  function renewProject(
+    projectLabel: string,
+    options: { readonly sessionProject?: string; readonly renewWithinMs?: number } = {},
+  ): RedskilledProjectRenewed {
+    const reach = authorize("project-renew", options.sessionProject, projectLabel);
+    if (!reach.permitted) throw new Error(reach.reason);
+    const now = clock();
+    expireLapsedRegistrations(Date.parse(now));
+    const held = registrations.get(projectLabel);
+    if (held == null) throw new RedskilledProjectUnregisteredError(projectLabel);
+    const registration = renewProjectRegistration(held, {
+      now,
+      ...(options.renewWithinMs == null ? {} : { renew_within_ms: options.renewWithinMs }),
+    });
+    registrations.set(registration.project_label, registration);
+    armIdleTimer();
+    return {
+      version: 1,
+      registration,
+      reach,
+      detail:
+        `redskilled renewed the registration for project ${JSON.stringify(registration.project_label)}, which now ` +
+        `stands until ${registration.renew_by} after renewal ${registration.renewals}`,
     };
   }
 
@@ -1161,12 +1242,22 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     idleTimer.unref();
   }
 
-  function evaluateIdle(): "exited" | "held-by-workers" {
+  function evaluateIdle(): "exited" | "held-by-workers" | "held-by-registrations" {
     // The rule that will matter once Workers exist, in place from the start: a
     // daemon that believes it holds live Workers rearms instead of exiting.
     if (workers.size > 0) {
       armIdleTimer();
       return "held-by-workers";
+    }
+    // A standing registration holds the daemon just as a Worker does, and holds it
+    // for the state a Worker cannot: a project between Workers is a project the
+    // host must still be awake to poll for. The deadline is what keeps this from
+    // being "awake forever" — a registration nobody renews lapses in the sweep
+    // above, and the very next tick finds nothing holding anything.
+    expireLapsedRegistrations(Date.parse(clock()));
+    if (registrations.size > 0) {
+      armIdleTimer();
+      return "held-by-registrations";
     }
     void stop();
     return "exited";
@@ -1289,6 +1380,16 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       if (request.op === "project-register") {
         return { id: request.id, ok: true, value: registerProject(request.registration, request.session_project) };
       }
+      if (request.op === "project-renew") {
+        return {
+          id: request.id,
+          ok: true,
+          value: renewProject(request.project_label, {
+            ...(request.session_project == null ? {} : { sessionProject: request.session_project }),
+            ...(request.renew_within_ms == null ? {} : { renewWithinMs: request.renew_within_ms }),
+          }),
+        };
+      }
       if (request.op === "project-deregister") {
         return { id: request.id, ok: true, value: deregisterProject(request.project_label, request.session_project) };
       }
@@ -1358,6 +1459,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     },
     workerCount: () => workers.size,
     registerProject,
+    renewProject,
     deregisterProject,
     registrations: () => hostState().registrations ?? [],
     hostState,

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -16,7 +16,9 @@ import {
 import { isRedskilledScopeState, type RedskilledScopeState } from "./machine-scope.js";
 import {
   isRedskilledProjectRegistration,
+  registrationRenewalStatus,
   type RedskilledProjectRegistration,
+  type RedskilledRenewalStatus,
 } from "./project-registration.js";
 import { REDSKILLED_PROTOCOL_VERSION } from "./protocol.js";
 import type { RedskilledMajorHold } from "./self-replace.js";
@@ -128,6 +130,20 @@ export interface RedskilledUpgradeState {
   readonly major_hold: RedskilledMajorHold | null;
 }
 
+/**
+ * One registration as the host reports it: the record, plus how it is being held.
+ *
+ * `renewal` is DERIVED at the instant of the read and never stored, because it is
+ * a fact about silence rather than a fact about the record: the same registration
+ * is `renewing` a second after its session spoke and `running-on` a minute later,
+ * with nothing about it having changed. A stored copy would be a second answer
+ * waiting to disagree with the clock.
+ */
+export interface RedskilledRegistrationView extends RedskilledProjectRegistration {
+  /** Whether a session is still renewing this; absent when the read stated no instant. */
+  readonly renewal?: RedskilledRenewalStatus;
+}
+
 export interface RedskilledHostState {
   readonly version: 1;
   readonly protocol_version: number;
@@ -155,7 +171,7 @@ export interface RedskilledHostState {
    * with a registration and no Worker is real, and so is a Worker whose project
    * registered nothing — collapsing them would make each one unsayable.
    */
-  readonly registrations?: readonly RedskilledProjectRegistration[];
+  readonly registrations?: readonly RedskilledRegistrationView[];
   /** What the daemon has promised the machine, derived from `workers`. */
   readonly budget_accounting: RedskilledBudgetAccounting;
   /** Running version against published version, and what is being done about it. */
@@ -173,6 +189,15 @@ export interface BuildHostStateInput {
   readonly workers?: readonly RedskilledWorkerView[];
   /** The registrations the daemon holds; absent is a host with none, not an error. */
   readonly registrations?: readonly RedskilledProjectRegistration[];
+  /**
+   * The instant the document is dated at, for judging renewal against.
+   *
+   * Optional, and its absence is honest rather than defaulted: a caller that
+   * states no instant gets each registration reported without a renewal verdict,
+   * because a judgement made up from the daemon's start time would call a
+   * registration nobody has renewed in an hour `renewing`.
+   */
+  readonly now?: string;
   /** The version observation; a daemon that never checked reports unknown. */
   readonly published?: {
     readonly version: string | null;
@@ -207,10 +232,26 @@ export function buildHostState(input: BuildHostStateInput): RedskilledHostState 
       .sort((a, b) => a.project_label.localeCompare(b.project_label)),
     // Ordered by the one field the daemon is allowed to read. A document ordered
     // by anything a selector says would be the daemon having read one.
-    registrations: [...(input.registrations ?? [])].sort((a, b) => a.project_label.localeCompare(b.project_label)),
+    registrations: buildRegistrationViews(input),
     budget_accounting: buildBudgetAccounting(workers),
     upgrade: buildUpgradeState(input),
   };
+}
+
+/**
+ * The registration block: every record, each judged against the read's instant. PURE.
+ *
+ * Ordered by the one field the daemon is allowed to read. A document ordered by
+ * anything a selector says would be the daemon having read one.
+ */
+function buildRegistrationViews(input: BuildHostStateInput): readonly RedskilledRegistrationView[] {
+  const nowMs = input.now == null ? Number.NaN : Date.parse(input.now);
+  const judged = Number.isFinite(nowMs);
+  return [...(input.registrations ?? [])]
+    .map((registration) =>
+      judged ? { ...registration, renewal: registrationRenewalStatus(registration, nowMs) } : registration,
+    )
+    .sort((a, b) => a.project_label.localeCompare(b.project_label));
 }
 
 /**

--- a/apps/redskilled/src/project-registration.ts
+++ b/apps/redskilled/src/project-registration.ts
@@ -40,6 +40,27 @@
 export const REDSKILLED_REGISTRATION_TTL_MS = 300_000;
 
 /**
+ * The fraction of its window a session is expected to renew inside.
+ *
+ * **A lease's half-life is the only cadence a deadline states on its own.** The
+ * daemon holds no connection to the session — every request arrives on its own
+ * socket — so the one thing it can tell a live session from a closed terminal by
+ * is silence, and silence is only readable against an expected rhythm. Renewing
+ * at the half-life leaves a whole half-window of slack for a slow tick, and going
+ * quiet past it is what "nothing is renewing this any more" looks like from here.
+ */
+export const REDSKILLED_RENEWAL_CADENCE = 0.5;
+
+/**
+ * Whether a session is still renewing a registration, or it is running on alone.
+ *
+ * Both states are POLLED — a drain must outlive the terminal that started it —
+ * and that is exactly why they have to be distinguishable: an operator reading
+ * `running-on` is reading work nobody is watching, on a deadline it will lapse at.
+ */
+export type RedskilledRenewalStatus = "renewing" | "running-on";
+
+/**
  * One project asking to be held, as it states itself.
  *
  * The deadline arrives as a WINDOW rather than as an instant, and the daemon
@@ -70,8 +91,18 @@ export interface RedskilledProjectRegistration {
   /** The daemon's own clock, at the instant it accepted this registration. */
   readonly registered_at: string;
   readonly renew_within_ms: number;
-  /** When this registration lapses unless renewed — `registered_at` plus the window. */
+  /** When this registration lapses unless renewed — the last renewal plus the window. */
   readonly renew_by: string;
+  /**
+   * The last instant a session was heard from about this registration.
+   *
+   * The registration itself counts as the first: a record the daemon accepted a
+   * second ago is being renewed by definition, and dating it from a renewal that
+   * has not happened yet would report every new registration as abandoned.
+   */
+  readonly renewed_at: string;
+  /** How many renewals the daemon has accepted; 0 for a registration never renewed. */
+  readonly renewals: number;
 }
 
 /**
@@ -160,7 +191,122 @@ export function buildProjectRegistration(
     registered_at: new Date(nowMs).toISOString(),
     renew_within_ms: renewWithinMs,
     renew_by: new Date(nowMs + renewWithinMs).toISOString(),
+    renewed_at: new Date(nowMs).toISOString(),
+    renewals: 0,
   };
+}
+
+/**
+ * Raised when a project asks to renew a registration the daemon is not holding.
+ *
+ * **A renewal is never a registration.** A client whose record lapsed while its
+ * session was blocked must re-register — stating its selector, its argv and its
+ * target again — because the daemon deliberately kept none of them, and a renewal
+ * that quietly minted a record would resurrect an argv nobody restated.
+ */
+export class RedskilledProjectUnregisteredError extends Error {
+  constructor(readonly projectLabel: string) {
+    super(
+      `redskilled holds no registration for project ${JSON.stringify(projectLabel)} to renew: it lapsed or was never ` +
+        `held, and a renewal never mints a record — register again, stating the selector, the argv and the target`,
+    );
+    this.name = "RedskilledProjectUnregisteredError";
+  }
+}
+
+export interface RenewProjectRegistrationOptions {
+  /** The daemon's clock, as an instant it can parse. */
+  readonly now: string;
+  /** A restated window; the one the registration already stands on when absent. */
+  readonly renew_within_ms?: number;
+}
+
+/**
+ * Push one registration's deadline out. PURE.
+ *
+ * Everything the project said about its work is carried over untouched — the
+ * selector, the argv, the target and the instant it first registered — because a
+ * renewal is a session saying "I am still here", never a second chance to restate
+ * what it wants. The only fields that move are the ones about time.
+ */
+export function renewProjectRegistration(
+  held: RedskilledProjectRegistration,
+  options: RenewProjectRegistrationOptions,
+): RedskilledProjectRegistration {
+  const nowMs = Date.parse(options.now);
+  if (!Number.isFinite(nowMs)) {
+    throw new Error(`redskilled needs an instant to date a renewal, not ${JSON.stringify(options.now)}`);
+  }
+  const renewWithinMs = options.renew_within_ms ?? held.renew_within_ms;
+  if (!Number.isFinite(renewWithinMs) || renewWithinMs <= 0) {
+    throw new Error(
+      `redskilled needs a positive renewal window to renew project ${JSON.stringify(held.project_label)}, not ` +
+        `${JSON.stringify(options.renew_within_ms)}`,
+    );
+  }
+  return {
+    ...held,
+    renew_within_ms: renewWithinMs,
+    renewed_at: new Date(nowMs).toISOString(),
+    // Dated from the renewal rather than from the registration: a deadline that
+    // kept counting from the first record would lapse a session that renewed on
+    // time, which is the one thing renewing is for.
+    renew_by: new Date(nowMs + renewWithinMs).toISOString(),
+    renewals: held.renewals + 1,
+  };
+}
+
+/** True once a registration's deadline has passed with nothing renewing it. PURE. */
+export function hasRegistrationLapsed(registration: RedskilledProjectRegistration, nowMs: number): boolean {
+  const renewBy = Date.parse(registration.renew_by);
+  // An undatable deadline is not a lapse: dropping a record because its own
+  // timestamp is unreadable would stop work over a field nobody meant to act on.
+  if (!Number.isFinite(renewBy)) return false;
+  return nowMs >= renewBy;
+}
+
+/**
+ * Whether a session is still renewing this registration, at one instant. PURE.
+ *
+ * Read off silence and nothing else: the daemon has no session to ask, so the
+ * question it can answer is "have I heard about this within the cadence a session
+ * renews at", and the answer past that is `running-on` — still held, still polled,
+ * on its way to a deadline.
+ */
+export function registrationRenewalStatus(
+  registration: RedskilledProjectRegistration,
+  nowMs: number,
+): RedskilledRenewalStatus {
+  // The fallback is for a record from a daemon older than renewal, which dates
+  // itself by the only instant it carries: the one it was registered at.
+  const heardAt = Date.parse(registration.renewed_at ?? registration.registered_at);
+  if (!Number.isFinite(heardAt)) return "running-on";
+  return nowMs - heardAt <= registration.renew_within_ms * REDSKILLED_RENEWAL_CADENCE ? "renewing" : "running-on";
+}
+
+/** What one sweep of a registration set decided, at one instant. */
+export interface LapsedRegistrationSweep {
+  readonly standing: readonly RedskilledProjectRegistration[];
+  readonly lapsed: readonly RedskilledProjectRegistration[];
+}
+
+/**
+ * Split a registration set into the ones still standing and the ones that lapsed. PURE.
+ *
+ * Both halves are returned because the lapse is a fact somebody has to be told:
+ * a caller that only received the survivors could drop a project's work without
+ * ever being able to say which project stopped, or when.
+ */
+export function sweepLapsedRegistrations(
+  registrations: Iterable<RedskilledProjectRegistration>,
+  nowMs: number,
+): LapsedRegistrationSweep {
+  const standing: RedskilledProjectRegistration[] = [];
+  const lapsed: RedskilledProjectRegistration[] = [];
+  for (const registration of registrations) {
+    (hasRegistrationLapsed(registration, nowMs) ? lapsed : standing).push(registration);
+  }
+  return { standing, lapsed };
 }
 
 /** True when `value` is a complete registration — a client's fail-closed check. */
@@ -175,7 +321,13 @@ export function isRedskilledProjectRegistration(value: unknown): value is Redski
     Number.isInteger(registration.target) &&
     typeof registration.registered_at === "string" &&
     typeof registration.renew_within_ms === "number" &&
-    typeof registration.renew_by === "string";
+    typeof registration.renew_by === "string" &&
+    // Checked only when present, exactly as the host state's own optional blocks
+    // are: one daemon serves checkouts pinned to different bundle versions, so a
+    // record from a daemon older than renewal must still read as complete — while
+    // a field that IS there and is the wrong shape still fails closed.
+    (registration.renewed_at === undefined || typeof registration.renewed_at === "string") &&
+    (registration.renewals === undefined || Number.isInteger(registration.renewals));
 }
 
 function requireText(value: unknown, what: string): string {

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -38,7 +38,10 @@
  * The daemon still does not know what an Issue, a label, a Spec, a gate or a
  * Landing is, which is what keeps this a frozen surface rather than a growing one.
  * `project-deregister` widens it by nothing at all: it names a project the daemon
- * already keys registrations by, and takes the record back out.
+ * already keys registrations by, and takes the record back out. `project-renew`
+ * widens it by less than nothing: it names that same project and carries no new
+ * field a client is obliged to state, because a renewal is a session saying "I am
+ * still here" rather than a second chance to restate what it wants.
  *
  * **Every request may name the project its session belongs to.** That single
  * opaque string is what makes reach asymmetric (ADR 0130 rule 9): a session reads
@@ -117,6 +120,7 @@ export type RedskilledRequest =
   | { id: string; op: "worker-command"; command: RedskilledWorkerCommandRequest }
   | { id: string; op: "worker-heartbeat"; heartbeat: RedskilledWorkerHeartbeatRequest }
   | { id: string; op: "project-register"; registration: RedskilledProjectRegistrationRequest; session_project?: string }
+  | { id: string; op: "project-renew"; project_label: string; renew_within_ms?: number; session_project?: string }
   | { id: string; op: "project-deregister"; project_label: string; session_project?: string }
   | { id: string; op: "shutdown" };
 
@@ -237,6 +241,30 @@ export function isRedskilledProjectRegistered(value: unknown): value is Redskill
     typeof registered.detail === "string" &&
     isRedskilledProjectRegistration(registered.registration) &&
     isRedskilledReachVerdict(registered.reach);
+}
+
+/**
+ * The answer to an accepted `project-renew`.
+ *
+ * The whole renewed record travels back rather than the new deadline alone: a
+ * session renewing is precisely the moment it should be able to see the record
+ * the host is holding for it, and one that received only a timestamp would have
+ * to ask a second question to check the host still holds what it thinks it does.
+ */
+export interface RedskilledProjectRenewed {
+  readonly version: 1;
+  readonly registration: RedskilledProjectRegistration;
+  readonly reach: RedskilledReachVerdict;
+  readonly detail: string;
+}
+
+export function isRedskilledProjectRenewed(value: unknown): value is RedskilledProjectRenewed {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const renewed = value as Record<string, unknown>;
+  return renewed.version === 1 &&
+    typeof renewed.detail === "string" &&
+    isRedskilledProjectRegistration(renewed.registration) &&
+    isRedskilledReachVerdict(renewed.reach);
 }
 
 /**

--- a/apps/redskilled/src/session-reach.ts
+++ b/apps/redskilled/src/session-reach.ts
@@ -41,6 +41,7 @@ export type RedskilledSessionOp =
   | "worker-steer"
   | "worker-heartbeat"
   | "project-register"
+  | "project-renew"
   | "project-deregister";
 
 /** The three reaches. A reader of this type knows the whole model. */
@@ -66,6 +67,10 @@ export const REDSKILLED_OP_REACH: Readonly<Record<RedskilledSessionOp, Redskille
   // that project. A cross-project registration would let one session commit
   // another project's name to an argv it never chose.
   "project-register": "project-write",
+  // Keeping one alive lands where taking it did, and for a sharper reason: a
+  // session that could renew another project's registration could keep a drain
+  // nobody is watching running past the deadline that exists to end it.
+  "project-renew": "project-write",
   // Releasing one lands exactly where taking it did: a session that could release
   // another project's registration could stop its work from outside it.
   "project-deregister": "project-write",

--- a/apps/redskilled/tests/registration-renewal.test.ts
+++ b/apps/redskilled/tests/registration-renewal.test.ts
@@ -1,0 +1,353 @@
+// A registration outlives the session that created it, and lapses once nothing
+// renews it. Both halves are load-bearing and pull against each other: the drain
+// has to survive the operator closing the terminal, and a closed laptop must not
+// poll a repository forever. What is proven here is that a registration nobody
+// renews keeps being polled right up to its deadline and stops at it, that a
+// renewed one never reaches a deadline at all, and that `host-state` says which
+// of the two an operator is looking at.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import {
+  registerRedskilledProject,
+  renewRedskilledProject,
+  readRedskilledHostState,
+} from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import {
+  buildProjectRegistration,
+  hasRegistrationLapsed,
+  REDSKILLED_RENEWAL_CADENCE,
+  registrationRenewalStatus,
+  renewProjectRegistration,
+  RedskilledProjectUnregisteredError,
+  sweepLapsedRegistrations,
+  type RedskilledProjectRegistrationRequest,
+} from "../src/project-registration.js";
+import { evaluateSessionReach, REDSKILLED_OP_REACH } from "../src/session-reach.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+const T0 = "2026-07-31T12:00:00.000Z";
+const WINDOW_MS = 60_000;
+
+function request(
+  overrides: Partial<RedskilledProjectRegistrationRequest> = {},
+): RedskilledProjectRegistrationRequest {
+  return {
+    project_label: "acme/widgets",
+    selector: "is:open label:ready-for-agent",
+    argv: ["red-skills-dev", "__work"],
+    target: 3,
+    renew_within_ms: WINDOW_MS,
+    ...overrides,
+  };
+}
+
+/** A clock a test moves by hand, so a deadline is reached without waiting for one. */
+function testClock(start = T0) {
+  let ms = Date.parse(start);
+  return {
+    now: () => new Date(ms).toISOString(),
+    advance(by: number) {
+      ms += by;
+    },
+  };
+}
+
+describe("a registration outlives its session", () => {
+  it("keeps polling a registration nobody is renewing, all the way to its deadline", async () => {
+    const clock = testClock();
+    const queried: string[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      clock: clock.now,
+      queueDiscovery: {
+        intervalMs: 0,
+        transport: async (query) => {
+          queried.push(query);
+          return { data: { q0: { issueCount: 4 } } };
+        },
+      },
+    });
+    running.push(daemon);
+
+    daemon.registerProject(request());
+    // The session ends here. Nothing renews the registration from this point on,
+    // and the drain must carry on regardless — that is the whole promise the
+    // detached per-project process used to keep.
+    clock.advance(WINDOW_MS - 1);
+
+    const polled = await daemon.pollQueueDiscovery();
+    expect(polled?.projects.map((entry) => entry.project_label)).toEqual(["acme/widgets"]);
+    expect(queried).toHaveLength(1);
+    expect(daemon.hostState().registrations).toHaveLength(1);
+  });
+
+  it("lapses at the stated interval and stops being polled", async () => {
+    const clock = testClock();
+    const queried: string[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      clock: clock.now,
+      queueDiscovery: {
+        intervalMs: 0,
+        transport: async (query) => {
+          queried.push(query);
+          return { data: { q0: { issueCount: 4 } } };
+        },
+      },
+    });
+    running.push(daemon);
+
+    daemon.registerProject(request());
+    clock.advance(WINDOW_MS);
+
+    // A lapsed registration is not a project with an empty queue: it is a project
+    // the host no longer asks the tracker about at all.
+    expect(await daemon.pollQueueDiscovery()).toBeNull();
+    expect(queried).toEqual([]);
+    expect(daemon.hostState().registrations).toEqual([]);
+  });
+
+  it("never lapses while a session renews it, however many windows pass", async () => {
+    const clock = testClock();
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      clock: clock.now,
+    });
+    running.push(daemon);
+
+    await registerRedskilledProject(paths, request(), { sessionProject: "acme/widgets" });
+    for (let tick = 0; tick < 10; tick += 1) {
+      // Renewed at the half-life, which is the cadence the deadline states.
+      clock.advance(WINDOW_MS * REDSKILLED_RENEWAL_CADENCE);
+      const renewed = await renewRedskilledProject(paths, { project_label: "acme/widgets" }, {
+        sessionProject: "acme/widgets",
+      });
+      expect(renewed.registration.renewals).toBe(tick + 1);
+      expect(daemon.hostState().registrations).toHaveLength(1);
+    }
+
+    // Ten windows on, and everything the project stated about its work is the
+    // record it registered with: a renewal moves the deadline and nothing else.
+    const held = daemon.hostState().registrations![0]!;
+    expect(held.registered_at).toBe(T0);
+    expect(held.selector).toBe("is:open label:ready-for-agent");
+    expect(held.argv).toEqual(["red-skills-dev", "__work"]);
+    expect(held.target).toBe(3);
+  });
+
+  it("holds the daemon awake while a registration stands, and lets go when it lapses", async () => {
+    const clock = testClock();
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      clock: clock.now,
+    });
+    running.push(daemon);
+
+    daemon.registerProject(request());
+    // No Worker is running: a project between Workers is exactly the state the
+    // host has to stay awake for, and a daemon that idled out under it would end
+    // the drain the operator walked away from.
+    expect(daemon.workerCount()).toBe(0);
+    expect(daemon.evaluateIdle()).toBe("held-by-registrations");
+
+    clock.advance(WINDOW_MS);
+    expect(daemon.evaluateIdle()).toBe("exited");
+  });
+});
+
+describe("host state says whether a registration is still being renewed", () => {
+  it("reports a renewing session, then the drain that outlived it", async () => {
+    const clock = testClock();
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      clock: clock.now,
+    });
+    running.push(daemon);
+
+    await registerRedskilledProject(paths, request(), { sessionProject: "acme/widgets" });
+    expect((await readRedskilledHostState(paths)).registrations![0]!.renewal).toBe("renewing");
+
+    // Still inside the cadence: a session that renews at the half-life has not
+    // gone quiet yet, and calling it abandoned here would be calling every
+    // healthy session abandoned between two ticks.
+    clock.advance(WINDOW_MS * REDSKILLED_RENEWAL_CADENCE);
+    expect(daemon.hostState().registrations![0]!.renewal).toBe("renewing");
+
+    // Past it, with nothing heard: the registration is still held and still
+    // polled, and an operator can now see that nobody is watching it.
+    clock.advance(1);
+    const outlived = daemon.hostState().registrations![0]!;
+    expect(outlived.renewal).toBe("running-on");
+    expect(outlived.project_label).toBe("acme/widgets");
+
+    // A renewal puts it back — the verdict is about silence, not about age.
+    await renewRedskilledProject(paths, { project_label: "acme/widgets" }, { sessionProject: "acme/widgets" });
+    expect(daemon.hostState().registrations![0]!.renewal).toBe("renewing");
+  });
+
+  it("states no renewal verdict when the read states no instant to judge against", () => {
+    const registration = buildProjectRegistration(request(), { now: T0 });
+    // A judgement invented from the daemon's start time would report a
+    // registration nobody has renewed in an hour as being renewed.
+    expect(registrationRenewalStatus(registration, Date.parse(T0))).toBe("renewing");
+    expect(registrationRenewalStatus(registration, Date.parse(T0) + WINDOW_MS)).toBe("running-on");
+  });
+});
+
+describe("renewing a registration the daemon does not hold", () => {
+  it("refuses rather than minting one, because the strings were never kept", async () => {
+    const clock = testClock();
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      clock: clock.now,
+    });
+    running.push(daemon);
+
+    await expect(
+      renewRedskilledProject(paths, { project_label: "acme/widgets" }, { sessionProject: "acme/widgets" }),
+    ).rejects.toThrow(/acme\/widgets/);
+
+    daemon.registerProject(request());
+    clock.advance(WINDOW_MS);
+    // A lapsed record renews into the same refusal as one that never existed: the
+    // client's next move is to register again, stating its selector and argv.
+    expect(() => daemon.renewProject("acme/widgets")).toThrow(RedskilledProjectUnregisteredError);
+    expect(daemon.hostState().registrations).toEqual([]);
+  });
+
+  it("renews into the session's own project and refuses another one", async () => {
+    expect(REDSKILLED_OP_REACH["project-renew"]).toBe("project-write");
+    const refused = evaluateSessionReach({
+      op: "project-renew",
+      sessionProject: "acme/widgets",
+      targetProject: "acme/gadgets",
+    });
+    expect(refused.permitted).toBe(false);
+    expect(refused.verdict).toBe("refused-cross-project");
+
+    const clock = testClock();
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      clock: clock.now,
+    });
+    running.push(daemon);
+
+    daemon.registerProject(request({ project_label: "acme/gadgets" }));
+    await expect(
+      renewRedskilledProject(paths, { project_label: "acme/gadgets" }, { sessionProject: "acme/widgets" }),
+    ).rejects.toThrow(/acme\/gadgets/);
+    // Refused, and the deadline it aimed at is exactly where it was.
+    expect(daemon.hostState().registrations![0]!.renewals).toBe(0);
+  });
+
+  it("registers again after a lapse, because the record it would collide with is gone", async () => {
+    const clock = testClock();
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      clock: clock.now,
+    });
+    running.push(daemon);
+
+    await registerRedskilledProject(paths, request(), { sessionProject: "acme/widgets" });
+    clock.advance(WINDOW_MS);
+    const again = await registerRedskilledProject(paths, request({ target: 9 }), {
+      sessionProject: "acme/widgets",
+    });
+    expect(again.registration.target).toBe(9);
+    expect(again.registration.renewals).toBe(0);
+  });
+});
+
+describe("the renewal arithmetic itself", () => {
+  it("dates the deadline from the renewal, never from the registration", () => {
+    const held = buildProjectRegistration(request(), { now: T0 });
+    expect(held.renewed_at).toBe(T0);
+    expect(held.renewals).toBe(0);
+
+    const at = new Date(Date.parse(T0) + 30_000).toISOString();
+    const renewed = renewProjectRegistration(held, { now: at });
+    expect(renewed.renewed_at).toBe(at);
+    expect(renewed.renew_by).toBe(new Date(Date.parse(at) + WINDOW_MS).toISOString());
+    // Everything about the work is carried over untouched.
+    expect({ ...renewed, renewed_at: "", renew_by: "", renewals: 0 }).toEqual({
+      ...held,
+      renewed_at: "",
+      renew_by: "",
+      renewals: 0,
+    });
+  });
+
+  it("restates the window when a session asks for a different one", () => {
+    const held = buildProjectRegistration(request(), { now: T0 });
+    const renewed = renewProjectRegistration(held, { now: T0, renew_within_ms: 5_000 });
+    expect(renewed.renew_within_ms).toBe(5_000);
+    expect(renewed.renew_by).toBe(new Date(Date.parse(T0) + 5_000).toISOString());
+    expect(() => renewProjectRegistration(held, { now: T0, renew_within_ms: 0 })).toThrow(/renewal window/);
+    expect(() => renewProjectRegistration(held, { now: "not an instant" })).toThrow(/instant/);
+  });
+
+  it("lapses at the deadline and not a millisecond before it", () => {
+    const held = buildProjectRegistration(request(), { now: T0 });
+    const deadline = Date.parse(held.renew_by);
+    expect(hasRegistrationLapsed(held, deadline - 1)).toBe(false);
+    expect(hasRegistrationLapsed(held, deadline)).toBe(true);
+    // An undatable deadline stops nothing: dropping a record over a timestamp
+    // nobody can read would stop work for a reason no operator ever stated.
+    expect(hasRegistrationLapsed({ ...held, renew_by: "whenever" }, deadline)).toBe(false);
+  });
+
+  it("splits a set into what still stands and what lapsed, naming both", () => {
+    const standing = buildProjectRegistration(request({ project_label: "a/one" }), { now: T0 });
+    const lapsing = buildProjectRegistration(
+      request({ project_label: "b/two", renew_within_ms: 1_000 }),
+      { now: T0 },
+    );
+    const swept = sweepLapsedRegistrations([standing, lapsing], Date.parse(T0) + 30_000);
+    expect(swept.standing.map((held) => held.project_label)).toEqual(["a/one"]);
+    // The lapse is returned rather than silently dropped: a caller that only got
+    // the survivors could not say which project stopped, or when.
+    expect(swept.lapsed.map((held) => held.project_label)).toEqual(["b/two"]);
+  });
+});

--- a/apps/redskilled/tests/statusline-local-project.test.ts
+++ b/apps/redskilled/tests/statusline-local-project.test.ts
@@ -174,6 +174,8 @@ describe("`project unknown`", () => {
           registered_at: "2026-07-29T00:00:00.000Z",
           renew_within_ms: 60_000,
           renew_by: "2026-07-29T00:01:00.000Z",
+          renewed_at: "2026-07-29T00:00:00.000Z",
+          renewals: 0,
         })),
       }),
       ceiling: UNBOUNDED_HOST_CEILING,

--- a/apps/redskilled/tests/statusline-string.test.ts
+++ b/apps/redskilled/tests/statusline-string.test.ts
@@ -76,6 +76,8 @@ function registrationOf(project_label: string) {
     registered_at: "2026-07-29T00:00:00.000Z",
     renew_within_ms: 60_000,
     renew_by: "2026-07-29T00:01:00.000Z",
+    renewed_at: "2026-07-29T00:00:00.000Z",
+    renewals: 0,
   };
 }
 


### PR DESCRIPTION
Automated AFK landing for #2906. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2906

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788092315&installation_model_id=20659&pr_number=2945&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2945&signature=070b6ea16c064338243ec9d59fbf403944f25064320bff2fe85cf091b91975a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->