### PR TITLE
chore: #2946 redskilled CLI output is TOON, not JSON

### DIFF
--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -6,10 +6,16 @@
  * that a contract, not a style: the daemon must never learn repository layout,
  * because the moment it does, it stops being servable by checkouts on different
  * bundle versions. A path it needs is a path it was given.
+ *
+ * **Every command writes TOON** (#2946). The reader of this stdout is an agent,
+ * and the daemon already speaks TOON everywhere else it writes — the event lane
+ * is `.toonl`, the lease is `.toon`. The two exceptions are opt-outs rather than
+ * omissions: `--version --json` is a caller ASKING for JSON, and an error that
+ * quotes a path is quoting a string for legibility, not encoding a payload.
  */
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { encode as encodeToon } from "@reddb-io/toon";
+import { encode as encodeToon, type JsonValue } from "@reddb-io/toon";
 import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
 import { parseFlags, routeCommand } from "@reddb-io/shared/args.js";
 import {
@@ -62,7 +68,7 @@ import {
 export const REDSKILLED_USAGE = `Usage: redskilled <command> [options]
 
 Commands:
-  host-state (default)  print the host's state as JSON
+  host-state (default)  print the host's state as TOON
   serve                 run the daemon in this process
   statusline [global]   render one agent-host status line
   unit                  install | uninstall | status — the optional supervisor
@@ -91,7 +97,7 @@ Runs the daemon in this process. Every path is a flag and none is derived
 `,
   "host-state": `Usage: redskilled host-state
 
-Prints the host's state as JSON. Contacts the running daemon; the default
+Prints the host's state as TOON. Contacts the running daemon; the default
 command when none is named.
 `,
   statusline: `Usage: redskilled statusline [global] [--verbose] [flags]
@@ -133,6 +139,19 @@ Reports every session runtime dir it looked at and why it kept or removed it.
   --grace-ms <n>   how long a dir must be idle before it is reclaimed
 `,
 } as const satisfies Record<string, string>;
+
+/**
+ * One DECLARED record, printed as TOON.
+ *
+ * The cast is the same one `session-lease` and `machine-scope` make: these shapes
+ * are JSON-safe by construction — they either crossed the socket as JSON or were
+ * built here — but an `interface` declares no index signature, so the encoder's
+ * `JsonValue` cannot see that. The commands that hand-shape an object literal at
+ * the emit point need no helper; they already have the type.
+ */
+function toonDocument(document: unknown): string {
+  return `${encodeToon(document as JsonValue)}\n`;
+}
 
 /** The three spellings of "tell me what this does", asked of the top level. */
 function isHelpToken(token: string | undefined): boolean {
@@ -218,7 +237,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
   if (command === "reclaim") return await runReclaim(args);
 
   const state = await readRedskilledHostState(resolveRedskilledPaths());
-  process.stdout.write(`${JSON.stringify(state, null, 2)}\n`);
+  process.stdout.write(toonDocument(state));
   return 0;
 }
 
@@ -307,18 +326,20 @@ export async function runUnit(
   const action = args[0] ?? "status";
 
   if (action === "status") {
-    write(`${JSON.stringify(readRedskilledUnitStatus(io.unitIO ?? {}), null, 2)}\n`);
+    write(toonDocument(readRedskilledUnitStatus(io.unitIO ?? {})));
     return 0;
   }
   if (action === "install") {
     const installed = await installRedskilledUnit(planRedskilledUnit(paths), io.unitIO ?? {});
-    write(`${JSON.stringify(installed, null, 2)}\n`);
+    write(toonDocument(installed));
     return installed.installed ? 0 : 1;
   }
   if (action === "uninstall") {
-    write(`${JSON.stringify(await uninstallRedskilledUnit(io.unitIO ?? {}), null, 2)}\n`);
+    write(toonDocument(await uninstallRedskilledUnit(io.unitIO ?? {})));
     return 0;
   }
+  // Quoting the word back at its author is legibility, not encoding: without the
+  // quotes, `redskilled unit ""` would report an error naming nothing at all.
   throw new Error(`unsupported redskilled unit action ${JSON.stringify(action)}: expected install, uninstall or status`);
 }
 

--- a/apps/redskilled/tests/cli-toon-output.test.ts
+++ b/apps/redskilled/tests/cli-toon-output.test.ts
@@ -19,7 +19,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { encode as encodeToon } from "@reddb-io/toon";
+import { encode as encodeToon, type JsonValue } from "@reddb-io/toon";
 import { readBuildInfo } from "@reddb-io/build-info";
 
 const HOST_STATE = {
@@ -108,7 +108,7 @@ async function unitFixture() {
 
 /** The whole assertion, in one place: this is TOON and it is not JSON. */
 function expectToon(out: string, payload: unknown): void {
-  expect(out).toBe(`${encodeToon(payload)}\n`);
+  expect(out).toBe(`${encodeToon(payload as JsonValue)}\n`);
   expect(() => JSON.parse(out) as unknown).toThrow();
 }
 
@@ -118,11 +118,13 @@ describe("`redskilled host-state`", () => {
 
     expect(code).toBe(0);
     expectToon(printed, HOST_STATE);
-    // The shape a reader recognises, stated rather than left to the encoder: keys
-    // at column zero and a `workers[1]:` table head, not a brace in sight.
+    // The marks a reader recognises, stated rather than left to the encoder: an
+    // unquoted key at column zero and a tabular header, neither of which JSON can
+    // spell. `{` alone would be the wrong tell — TOON writes its field list in
+    // braces, so banning the character would fail on correct output.
     expect(printed.startsWith("version: 1\n")).toBe(true);
-    expect(printed).toContain("workers[1]");
-    expect(printed).not.toContain("{");
+    expect(printed).toContain("projects[1]{project_label,workers}:");
+    expect(printed).not.toContain('"version": 1');
   });
 });
 
@@ -174,7 +176,7 @@ describe("`redskilled unit`", () => {
     expect(out).toContain("steps[3]");
     expect(out).toContain("- step: write-unit");
     expect(out).toContain("- step: enable");
-    expect(out).not.toContain("{");
+    expect(out).not.toContain('"step": ');
   });
 
   it("prints `uninstall` as TOON", async () => {
@@ -190,7 +192,7 @@ describe("`redskilled unit`", () => {
     expect(out).toContain("installed: false");
     expect(out).toContain("- step: disable");
     expect(out).toContain("- step: remove-unit");
-    expect(out).not.toContain("{");
+    expect(out).not.toContain('"step": ');
   });
 
   it("keeps quoting the action it was given in the error it throws", async () => {

--- a/apps/redskilled/tests/cli-toon-output.test.ts
+++ b/apps/redskilled/tests/cli-toon-output.test.ts
@@ -1,0 +1,222 @@
+/**
+ * The CLI's agent-facing stdout is TOON, not JSON (#2946).
+ *
+ * The daemon already speaks TOON everywhere it writes to disk — the event lane is
+ * `.toonl`, the lease is `.toon` — and `stop`, `provision` and `reclaim` print it.
+ * `host-state` and the three `unit` actions were the last surfaces still emitting
+ * `JSON.stringify(..., null, 2)`, which is exactly the shape the mandate exists to
+ * remove from an agent's context.
+ *
+ * **Each surface is pinned to its encoding, not merely to parsing.** A test that
+ * only asserted "the output parses" would pass on JSON forever, because JSON is
+ * also a document one can read; so every case compares against `encode(...)` byte
+ * for byte AND asserts `JSON.parse` refuses it. The two escape hatches are pinned
+ * the same way in the other direction: `--version --json` is a stated JSON opt-out
+ * and stays JSON, and an error that quotes a path is quoting a string for
+ * legibility rather than encoding a payload, so it keeps its quotes.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { encode as encodeToon } from "@reddb-io/toon";
+import { readBuildInfo } from "@reddb-io/build-info";
+
+const HOST_STATE = {
+  version: 1,
+  protocol_version: 1,
+  daemon_version: "3.0.4",
+  machine_id_hash: "abcd1234",
+  session_key_hash: "beef5678",
+  pid: 4242,
+  started_at: "2026-07-31T10:00:00.000Z",
+  workers: [
+    {
+      worker_id: "w-1",
+      project_label: "alpha",
+      pid: 4343,
+      started_at: "2026-07-31T10:01:00.000Z",
+      workspace_path: "/workspaces/alpha",
+      isolated: true,
+      warnings: [] as string[],
+    },
+  ],
+  projects: [{ project_label: "alpha", workers: 1 }],
+  budget_accounting: { promised_workers: 1 },
+  upgrade: { running_version: "3.0.4", state: "current" },
+};
+
+vi.mock("../src/client.js", async (importActual) => {
+  const actual = await importActual<typeof import("../src/client.js")>();
+  return { ...actual, readRedskilledHostState: async () => HOST_STATE };
+});
+
+const { runRedskilledCli, runUnit } = await import("../src/cli.js");
+const { resolveRedskilledPaths } = await import("../src/paths.js");
+
+const roots: string[] = [];
+let printed: string;
+const restore = new Map<string, string | undefined>();
+
+function setEnv(key: string, value: string): void {
+  if (!restore.has(key)) restore.set(key, process.env[key]);
+  process.env[key] = value;
+}
+
+beforeEach(() => {
+  printed = "";
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    printed += String(chunk);
+    return true;
+  });
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const [key, value] of restore) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  restore.clear();
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-toon-"));
+  roots.push(root);
+  return root;
+}
+
+/** The unit surfaces, on a machine with no systemd and no bundle on disk. */
+async function unitFixture() {
+  const root = await sessionRoot();
+  setEnv("XDG_CONFIG_HOME", join(root, "config"));
+  setEnv("REDSKILLED_BIN", join(root, "redskilled.bundle.min.mjs"));
+  return {
+    paths: resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    }),
+    unitIO: {
+      writeFile: async () => undefined,
+      removeFile: async () => undefined,
+      exists: () => true,
+      run: () => ({ status: 0, stdout: "", stderr: "" }),
+    },
+  };
+}
+
+/** The whole assertion, in one place: this is TOON and it is not JSON. */
+function expectToon(out: string, payload: unknown): void {
+  expect(out).toBe(`${encodeToon(payload)}\n`);
+  expect(() => JSON.parse(out) as unknown).toThrow();
+}
+
+describe("`redskilled host-state`", () => {
+  it("prints the host's state as TOON", async () => {
+    const code = await runRedskilledCli([]);
+
+    expect(code).toBe(0);
+    expectToon(printed, HOST_STATE);
+    // The shape a reader recognises, stated rather than left to the encoder: keys
+    // at column zero and a `workers[1]:` table head, not a brace in sight.
+    expect(printed.startsWith("version: 1\n")).toBe(true);
+    expect(printed).toContain("workers[1]");
+    expect(printed).not.toContain("{");
+  });
+});
+
+describe("`redskilled unit`", () => {
+  it("prints `status` as TOON", async () => {
+    const { paths, unitIO } = await unitFixture();
+    let out = "";
+
+    const code = await runUnit(["status"], { paths, unitIO, write: (text) => {
+      out += text;
+    } });
+
+    expect(code).toBe(0);
+    expectToon(out, {
+      unitName: "redskilled.service",
+      unitPath: join(process.env.XDG_CONFIG_HOME!, "systemd", "user", "redskilled.service"),
+      installed: true,
+      enabled: true,
+      active: true,
+      floor: "auto-spawn",
+    });
+    expect(out).toContain("floor: auto-spawn");
+  });
+
+  it("defaults to `status`, still as TOON", async () => {
+    const { paths, unitIO } = await unitFixture();
+    let out = "";
+
+    await runUnit([], { paths, unitIO, write: (text) => {
+      out += text;
+    } });
+
+    expect(out.startsWith("unitName: redskilled.service\n")).toBe(true);
+    expect(() => JSON.parse(out) as unknown).toThrow();
+  });
+
+  it("prints `install` as TOON, steps and all", async () => {
+    const { paths, unitIO } = await unitFixture();
+    let out = "";
+
+    const code = await runUnit(["install"], { paths, unitIO, write: (text) => {
+      out += text;
+    } });
+
+    expect(code).toBe(0);
+    expect(() => JSON.parse(out) as unknown).toThrow();
+    expect(out).toContain("installed: true");
+    // The step list is the part a JSON emitter would have spelled with braces.
+    expect(out).toContain("steps[3]");
+    expect(out).toContain("- step: write-unit");
+    expect(out).toContain("- step: enable");
+    expect(out).not.toContain("{");
+  });
+
+  it("prints `uninstall` as TOON", async () => {
+    const { paths, unitIO } = await unitFixture();
+    let out = "";
+
+    const code = await runUnit(["uninstall"], { paths, unitIO, write: (text) => {
+      out += text;
+    } });
+
+    expect(code).toBe(0);
+    expect(() => JSON.parse(out) as unknown).toThrow();
+    expect(out).toContain("installed: false");
+    expect(out).toContain("- step: disable");
+    expect(out).toContain("- step: remove-unit");
+    expect(out).not.toContain("{");
+  });
+
+  it("keeps quoting the action it was given in the error it throws", async () => {
+    const { paths, unitIO } = await unitFixture();
+
+    // Quoting a bad word back at its author is legibility, not encoding: without
+    // the quotes, `redskilled unit ""` reports an error naming nothing at all.
+    await expect(runUnit(["bogus"], { paths, unitIO })).rejects.toThrow(
+      'unsupported redskilled unit action "bogus": expected install, uninstall or status',
+    );
+  });
+});
+
+describe("`redskilled --version`", () => {
+  it("keeps `--json` JSON — the stated opt-out the mandate does not govern", async () => {
+    const code = await runRedskilledCli(["--version", "--json"]);
+
+    expect(code).toBe(0);
+    expect(printed).toBe(`${JSON.stringify(readBuildInfo("redskilled"))}\n`);
+    expect(JSON.parse(printed) as { version: string }).toHaveProperty("version");
+  });
+
+  it("still prints the human stamp without `--json`", async () => {
+    const code = await runRedskilledCli(["--version"]);
+
+    expect(code).toBe(0);
+    expect(printed).not.toContain("{");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2946. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2946

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788097649&installation_model_id=20659&pr_number=2950&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2950&signature=84ca5722fa467348bdef757f0caa0cbe11bb5b3819f86d1d17d82ca95d2979f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->