### PR TITLE
chore: #2910 A machine carrying live per-project runtimes reaches the two-player model

### DIFF
--- a/.red/adr/0130-redskilled-host-scoped-execution-daemon.md
+++ b/.red/adr/0130-redskilled-host-scoped-execution-daemon.md
@@ -502,3 +502,74 @@ inside the Worker, from the project's own config in the workspace it was born
 into — and the one input they take from outside, the runner, is what the launch
 carries. The slot-scoped env is composed per birth, from placeholders, so two
 Workers of one project can never share a retire file or a build directory.
+
+## Amendment 6 — reaching the two-player model is a re-adoption, not an evacuation (#2910)
+
+Amendment 4 names the migration as its harder half: a machine already running
+per-project runtimes has to reach the two-player model without stranding the
+Workers those runtimes are holding. The mechanism is **ADR 0105's boot
+migration** — the same one `core/red-path-migration.ts` and
+`core/castle-cutover-migration.ts` use — planned purely, executed best-effort,
+stamped once, and a no-op the second time.
+
+**Decision: the runtime is stopped, the Workers are kept.** A Worker is an
+init-system unit, so it outlives the process that asked for it, and the daemon
+already re-attaches to it *by unit name*. The previous cutover had to quiesce
+Workers because they were born by a path with no unit to be named by; these were
+born through the daemon and carry one. Stopping them would strand work the model
+can keep, so the migration stops exactly one thing — the removed third player —
+and stops it first, so no demand it decides lands behind the migration.
+
+**What travels, and what stays.** The project's label travels with each live
+Worker, so a re-adopted Worker appears in `host-state` under the repository it
+belongs to rather than under the stated `(unowned)` placeholder. Claims do not
+move: the Worker is still working the Ticket, and releasing a live claim would
+put a second Worker on the same work. A dead Worker's claim, branch and workspace
+stay exactly where they are — the crash reconcile path already returns those
+Tickets, and the migration recovers nothing itself.
+
+**The migration never registers the project.** Registering is the MCP's one
+contribution to this model, and it carries a selector and an argv only the
+project states — a migration that invented either would start Workers on work
+nobody asked for. So the migration runs on the registration path, clears the
+process that would refuse the registration, and leaves the registering to the
+player entitled to make it. It is reported as kept, not as done.
+
+**Idempotent twice over.** The report at `.red/state/castle/two-player.toon` is
+also the gate: a second run reads the stamp and touches nothing. Under it, the
+plan is idempotent on its own — a dead runtime, a Worker the host already holds,
+and a project already registered each produce no action — so a stamp lost to a
+wiped state tier costs a re-run, never a second migration's worth of moves.
+
+**It reports both halves.** Everything moved and everything deliberately left
+behind is named with its reason, including moves the host refused: an operator's
+next step depends on knowing which Worker the host did *not* take.
+
+## Recovering from a bad two-player migration
+
+The way back, for an operator whose machine the migration left confusing. Every
+step is safe to run twice, and none of them touches a Worker's branch, workspace
+or claim.
+
+1. **Read the report first.** `.red/state/castle/two-player.toon` names what was
+   stopped, what was re-adopted, what was registered, and — the field that
+   usually explains the symptom — what the host `failed` to take.
+2. **Ask the host what it holds.** `redskilled host-state` lists the live Workers
+   and their project labels. A Worker running here but absent from that list is
+   the one to act on; a Worker present under `(unowned)` was re-adopted without
+   its label and can be left running while the project registers again.
+3. **Put the project back in the daemon's list.** Re-register from the project's
+   MCP (`project_start`). A registration is a record, not a process, so restating
+   it costs nothing and a duplicate is refused rather than doubled.
+4. **Re-run the migration deliberately.** Remove the stamp
+   (`rm .red/state/castle/two-player.toon`) and launch again with
+   `RED_TWO_PLAYER_CUTOVER=1`. The plan re-derives from what the machine actually
+   carries now, so a move that already succeeded produces no action.
+5. **Decline the era to stand still.** Leaving `RED_TWO_PLAYER_CUTOVER` unset
+   makes the migration inert: it observes nothing and moves nothing, so a machine
+   can be inspected — or left running its Workers — before the cutover is
+   declared again.
+
+**What never appears in this list:** stopping a live Worker, deleting a branch,
+or releasing a claim. Those are the three things the migration itself refuses,
+and a recovery that did them would destroy work the failure did not.

--- a/apps/dev/src/core/two-player-migration.ts
+++ b/apps/dev/src/core/two-player-migration.ts
@@ -1,0 +1,281 @@
+// core/two-player-migration.ts — the ONE-TIME, idempotent boot migration that
+// carries a machine already running per-project runtimes into the two-player
+// model of ADR 0130 Amendment 4: the project's MCP registers, the daemon polls.
+//
+// Pure: this module observes nothing and touches nothing. It receives a snapshot
+// of what the machine carries and returns the plan, which is what makes every
+// rule below provable without a live runtime, a real workspace or a running
+// daemon (runtime/two-player-migration.ts does the IO).
+//
+// **The mechanism is ADR 0105's boot migration, not a third one.** A state-tier
+// move has a precedent twice over here — `core/red-path-migration.ts` and
+// `core/castle-cutover-migration.ts` — so this record follows it: plan purely,
+// execute best-effort at boot, never overwrite, and be a pure no-op the second
+// time.
+//
+// **This is a re-adoption, not an evacuation.** That is the one way it differs
+// from the ADR 0130 cutover it follows. A Worker is an init-system unit, so it
+// outlives the runtime that asked for it, and the daemon already re-attaches to
+// it by unit name. The previous cutover had to quiesce Workers because they were
+// born by a path with no unit to be named by; these Workers were born through the
+// daemon and carry one, so stopping them would strand work the model can keep.
+//
+// The five rules that decide everything:
+//
+// 1. **A live per-project runtime is stopped, and stopped first.** It is the
+//    third player Amendment 4 removes — a process that keeps asking for Workers
+//    on a loop the daemon now owns. Stopping it first means nothing it decides
+//    can land behind the migration.
+//
+// 2. **A live Worker is re-adopted, never stopped.** It survives its parent by
+//    construction, and the daemon's reattach path names it by unit. Stranding one
+//    is the exact failure this migration exists to prevent.
+//
+// 3. **Re-adoption carries the project label.** A Worker the host holds under a
+//    stated placeholder is one an operator cannot route back to a repository, so
+//    the label the stopped runtime owned travels with the Worker into host state.
+//
+// 4. **A claim is never released.** The Worker still holds it and is still
+//    working, so returning the Ticket to the queue would put two Workers on one
+//    piece of work. A DEAD Worker's claim is the crash reconcile path's, exactly
+//    as before — the migration discards nothing and recovers nothing itself.
+//
+// 5. **The migration never registers the project.** Registering is the MCP's
+//    one contribution to the two-player model, and it carries a selector and an
+//    argv only the project states — a migration that invented either would start
+//    Workers on work nobody asked for. So the migration removes the process that
+//    would refuse the registration and names the registration as the caller's
+//    next move. That is also what makes the plan idempotent independently of the
+//    stamp: a machine already in the two-player model produces no action at all.
+
+/** Contract id stamped on the migration report. */
+export const TWO_PLAYER_CONTRACT = "red.castle.two-player.v1";
+
+/** Env var an operator sets to declare the two-player era in effect on this host. */
+export const TWO_PLAYER_ENV = "RED_TWO_PLAYER_CUTOVER";
+
+/**
+ * Where an operator goes when the migration misbehaves.
+ *
+ * Named in the boot summary AND stamped in the report, because the moment the
+ * path is needed is the moment the machine is confusing: an operator reading a
+ * one-line notice must not have to find out where the way back is written.
+ */
+export const TWO_PLAYER_RECOVERY_DOC =
+  ".red/adr/0130-redskilled-host-scoped-execution-daemon.md#recovering-from-a-bad-two-player-migration";
+
+/** The per-project runtime, as the migration finds it. */
+export interface TwoPlayerRuntimeObservation {
+  pid: number;
+  /** Identity-verified liveness, never bare pid existence. */
+  live: boolean;
+}
+
+/** One Worker the machine carries into the two-player model. */
+export interface TwoPlayerWorkerObservation {
+  workerId: string;
+  /** The Ticket the Worker claimed, or null when it died before claiming. */
+  issue: number | null;
+  pid: number | null;
+  live: boolean;
+  /** The init-system unit the Worker was placed in at birth, when it has one. */
+  unit?: string;
+  /** Absolute workspace path (`.red/tmp/workers/<id>`). */
+  workspace: string;
+  /** Whether the daemon already carries this Worker in `host-state`. */
+  heldByHost: boolean;
+}
+
+/** Everything the migration needs to decide, gathered once. */
+export interface TwoPlayerObservation {
+  /** The one opaque string the daemon keys this project by. */
+  projectLabel: string;
+  runtime: TwoPlayerRuntimeObservation | null;
+  workers: readonly TwoPlayerWorkerObservation[];
+  /** Whether the daemon already holds a registration for this project. */
+  registered: boolean;
+}
+
+export type TwoPlayerActionKind = "stop-runtime" | "readopt-worker";
+
+/** One thing the migration moves, with the reason it moved it. */
+export interface TwoPlayerAction {
+  kind: TwoPlayerActionKind;
+  /** Human-readable identity of the thing acted on. */
+  subject: string;
+  reason: string;
+  pid?: number;
+  workerId?: string;
+  projectLabel?: string;
+  issue?: number | null;
+  unit?: string;
+}
+
+/** One thing the migration deliberately leaves behind, with the reason. */
+export interface TwoPlayerRetention {
+  subject: string;
+  reason: string;
+}
+
+export interface TwoPlayerPlan {
+  actions: readonly TwoPlayerAction[];
+  kept: readonly TwoPlayerRetention[];
+}
+
+/** The frozen reason strings — the report, the log line and the tests share them. */
+export const TWO_PLAYER_REASONS = {
+  runtimeStopped:
+    "the per-project runtime is the third player ADR 0130 Amendment 4 removes; it is stopped first so no demand it decides can land behind the migration",
+  runtimeAlreadyGone:
+    "the runtime is already dead, so the machine has one fewer player to remove and nothing to stop",
+  workerReadopted:
+    "an init-system unit that outlives the runtime that asked for it, so the daemon re-attaches to it by unit name and holds it under this project's label — stopping it would strand work in flight",
+  workerAlreadyHeld:
+    "already carried in host state under its project label — the migration has nothing to move",
+  workerDead:
+    "already dead; its workspace, branch and claim are the crash reconcile path's to recover, not the migration's to discard",
+  claimKept:
+    "the Worker survives the migration and is still working the Ticket, so releasing its claim would put a second Worker on the same work",
+  workspaceKept:
+    "the workspace and its branch hold committed and uncommitted work git owns; reclaiming disk is never worth discarding a Worker's output",
+  projectRegistrationIsCallers:
+    "a registration carries a selector and an argv only the project states, so the migration clears the process that would refuse it and leaves the registering to the MCP — the one player entitled to make it",
+  projectAlreadyRegistered:
+    "the daemon already holds this project, so the machine is already in the two-player model",
+} as const;
+
+/**
+ * The plan for one machine's pre-migration state.
+ *
+ * Order is load-bearing: the runtime is stopped before any Worker is re-adopted,
+ * because a live runtime answers a Worker's death by asking for a replacement —
+ * through the very loop the two-player model moved into the daemon.
+ */
+export function planTwoPlayerMigration(observation: TwoPlayerObservation): TwoPlayerPlan {
+  const actions: TwoPlayerAction[] = [];
+  const kept: TwoPlayerRetention[] = [];
+
+  const runtime = observation.runtime;
+  if (runtime !== null) {
+    if (runtime.live) {
+      actions.push({
+        kind: "stop-runtime",
+        subject: `project runtime pid ${runtime.pid}`,
+        reason: TWO_PLAYER_REASONS.runtimeStopped,
+        pid: runtime.pid,
+      });
+    } else {
+      kept.push({
+        subject: `project runtime pid ${runtime.pid}`,
+        reason: TWO_PLAYER_REASONS.runtimeAlreadyGone,
+      });
+    }
+  }
+
+  for (const worker of observation.workers) {
+    const subject = worker.issue === null ? worker.workerId : `${worker.workerId} (#${worker.issue})`;
+    if (!worker.live) {
+      kept.push({ subject, reason: TWO_PLAYER_REASONS.workerDead });
+      continue;
+    }
+    kept.push({ subject: `${subject} claim`, reason: TWO_PLAYER_REASONS.claimKept });
+    kept.push({ subject: `${subject} workspace`, reason: TWO_PLAYER_REASONS.workspaceKept });
+    if (worker.heldByHost) {
+      kept.push({ subject, reason: TWO_PLAYER_REASONS.workerAlreadyHeld });
+      continue;
+    }
+    actions.push({
+      kind: "readopt-worker",
+      subject,
+      reason: TWO_PLAYER_REASONS.workerReadopted,
+      workerId: worker.workerId,
+      projectLabel: observation.projectLabel,
+      issue: worker.issue,
+      ...(worker.unit !== undefined ? { unit: worker.unit } : {}),
+    });
+  }
+
+  kept.push({
+    subject: observation.projectLabel,
+    reason: observation.registered
+      ? TWO_PLAYER_REASONS.projectAlreadyRegistered
+      : TWO_PLAYER_REASONS.projectRegistrationIsCallers,
+  });
+
+  return { actions, kept };
+}
+
+/** One line an operator can read at boot: what moved, what stayed, where to go. */
+export function summarizeTwoPlayerMigration(plan: TwoPlayerPlan): string {
+  const stopped = plan.actions.filter((action) => action.kind === "stop-runtime").length;
+  const readopted = plan.actions.filter((action) => action.kind === "readopt-worker").length;
+  return (
+    `two-player migration: ${stopped} project runtime stopped, ${readopted} worker(s) re-adopted, ` +
+    `${plan.kept.length} artifact(s) left in place — recovery: ${TWO_PLAYER_RECOVERY_DOC}`
+  );
+}
+
+/** What the executor actually managed to do, fed back into the report. */
+export interface TwoPlayerExecution {
+  stopped: readonly string[];
+  readopted: readonly string[];
+  /** Actions the host refused; they stay in the report rather than vanishing. */
+  failed: readonly string[];
+}
+
+/** The stamped, TOON-encodable migration report. */
+export interface TwoPlayerReport {
+  contract: typeof TWO_PLAYER_CONTRACT;
+  at: string;
+  /** Where an operator goes when this report describes something wrong. */
+  recovery: typeof TWO_PLAYER_RECOVERY_DOC;
+  moved: {
+    stopped: string[];
+    readopted: string[];
+    failed: string[];
+  };
+  kept: { subject: string; reason: string }[];
+  reasons: { subject: string; kind: TwoPlayerActionKind; reason: string }[];
+}
+
+/** Shape the report the migration stamps once, naming both halves of the move. */
+export function buildTwoPlayerReport(
+  plan: TwoPlayerPlan,
+  execution: TwoPlayerExecution,
+  at: string,
+): TwoPlayerReport {
+  return {
+    contract: TWO_PLAYER_CONTRACT,
+    at,
+    recovery: TWO_PLAYER_RECOVERY_DOC,
+    moved: {
+      stopped: [...execution.stopped],
+      readopted: [...execution.readopted],
+      failed: [...execution.failed],
+    },
+    kept: plan.kept.map((entry) => ({ subject: entry.subject, reason: entry.reason })),
+    reasons: plan.actions.map((action) => ({
+      subject: action.subject,
+      kind: action.kind,
+      reason: action.reason,
+    })),
+  };
+}
+
+/**
+ * Whether the two-player era is in effect for this launch.
+ *
+ * Explicit rather than inferred, for the same reason the previous cutover was:
+ * the caller that registers instead of launching a runtime passes `true`, and an
+ * operator can declare it with `RED_TWO_PLAYER_CUTOVER=1`. Inferring it from a
+ * reachable daemon would stop a healthy per-project runtime the first time the
+ * daemon happened to be up for some other project.
+ */
+export function resolveTwoPlayerActive(
+  env: Record<string, string | undefined>,
+  explicit?: boolean,
+): boolean {
+  if (explicit !== undefined) return explicit;
+  const raw = env[TWO_PLAYER_ENV]?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -66,6 +66,7 @@ import {
   createRedskilledBirthPort,
   redskilledRegistrationRefusal,
 } from "./runtime/redskilled-birth.js";
+import { migrateToTwoPlayer } from "./runtime/two-player-migration.js";
 import {
   publishWorkerLiveness,
   readDaemonWorkerSet,
@@ -944,6 +945,25 @@ async function projectStart(root: string, rawInput: ProjectStartInput) {
   // A project already registered is refused by the DAEMON, which is the one
   // party that can see the record — a pre-check of our own would be a second
   // opinion racing the authority (ADR 0130 Amendment 4).
+  const port = createRedskilledBirthPort({ root });
+  // ADR 0130 Amendment 6 (#2910): registering is the boundary between a machine
+  // that still carries a per-project runtime and one in the two-player model, so
+  // the one-time carry-across runs exactly here — before anything this project
+  // registers, which is the very thing a leftover runtime would collide with.
+  // Stamped, idempotent, and INERT until an operator declares the era with
+  // `RED_TWO_PLAYER_CUTOVER=1`: an undeclared era must never stop a runtime the
+  // operator is still relying on.
+  await migrateToTwoPlayer(root, {
+    deps: {
+      projectLabel: () => port.projectLabel,
+      // The host's own answer to "which Workers are mine", so a Worker it already
+      // holds is never re-adopted and a Worker it does not hold is named rather
+      // than assumed — re-adoption is confirmed against host state, never claimed.
+      hostWorkers: async () =>
+        new Map((await port.workerIds()).map((workerId) => [workerId, port.projectLabel])),
+      readopt: async (workerId) => (await port.workerIds()).includes(workerId),
+    },
+  }).catch(() => undefined);
   const selector = encodeRegistrationSelector(input.selector);
   // What runs when a Worker is born for this project — resolved from the
   // PUBLISHED bundle rather than from this process's own entry (#2808), so a
@@ -958,7 +978,6 @@ async function projectStart(root: string, rawInput: ProjectStartInput) {
     ...(input.selector ? ["--selector", JSON.stringify(input.selector)] : []),
   ];
 
-  const port = createRedskilledBirthPort({ root });
   let registered;
   try {
     await port.reach();

--- a/apps/dev/src/runtime/two-player-migration.ts
+++ b/apps/dev/src/runtime/two-player-migration.ts
@@ -1,0 +1,268 @@
+// runtime/two-player-migration.ts — the real-fs/real-process executor behind the
+// ADR 0130 Amendment 4 migration (core/two-player-migration.ts owns the pure plan
+// and every rule it encodes).
+//
+// Run-once through a STAMP, idempotent by construction: the report the migration
+// writes to `.red/state/castle/two-player.toon` is also its gate, so a second run
+// reads the stamp and returns `already-migrated` having touched nothing.
+//
+// Best-effort throughout, like the two boot migrations it follows: a launch must
+// never fail because a stop, a re-adoption or a registration was refused. A
+// refused move is NAMED in the report's `failed` list rather than silently
+// dropped, because the operator's next move — and the way back, which the report
+// carries — depends on knowing which Worker the host did not take.
+import { readFile, readdir, mkdir, rename, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  afkStateDir,
+  goWorkersDir,
+  scoutWorkersDir,
+  tmpDir,
+  workersDir,
+} from "@reddb-io/shared/red-paths.js";
+import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
+import {
+  buildTwoPlayerReport,
+  planTwoPlayerMigration,
+  resolveTwoPlayerActive,
+  summarizeTwoPlayerMigration,
+  type TwoPlayerObservation,
+  type TwoPlayerPlan,
+  type TwoPlayerReport,
+  type TwoPlayerWorkerObservation,
+} from "../core/two-player-migration.js";
+import { isLivePid as defaultIsLivePid, killTreeAndWait } from "./kill-tree.js";
+import { resolveProjectLabel } from "./redskilled-birth.js";
+
+/** Where the one-time report is stamped; its presence is the run-once gate. */
+export function twoPlayerReportPath(root: string): string {
+  return join(afkStateDir(root), "two-player.toon");
+}
+
+/** Every side effect the migration performs, injected so tests need no host. */
+export interface TwoPlayerMigrationDeps {
+  isLivePid(pid: number): boolean;
+  /** SIGTERM → grace → SIGKILL, confirming the tree is gone. */
+  stopTree(pid: number): Promise<boolean>;
+  /** The one opaque string the daemon keys this project by. */
+  projectLabel(root: string): string;
+  /** Workers the daemon already holds, as `worker id → project label`. */
+  hostWorkers(): Promise<ReadonlyMap<string, string>>;
+  /** Whether the daemon already holds a registration for this project. */
+  isRegistered(projectLabel: string): Promise<boolean>;
+  /**
+   * Ask the host to hold a live Worker under this project's label.
+   *
+   * The default is the daemon's own unit sweep, which needs no help: a Worker
+   * that is an active unit is re-attached when the daemon next reads the host,
+   * so re-adoption here is a CONFIRMATION that host state carries it, not a
+   * second adoption mechanism competing with `redskilled/reattach.ts`.
+   */
+  readopt(workerId: string, projectLabel: string): Promise<boolean>;
+  now(): Date;
+  /** Where the one-line summary goes. Never silent, never fatal. */
+  notice(message: string): void;
+}
+
+export interface MigrateToTwoPlayerOptions {
+  /**
+   * Whether this launch registers instead of starting a per-project runtime. The
+   * caller that owns registration passes it; absent, `RED_TWO_PLAYER_CUTOVER`
+   * decides, and the default is off — an undeclared era must never stop a healthy
+   * per-project runtime.
+   */
+  active?: boolean;
+  env?: Record<string, string | undefined>;
+  deps?: Partial<TwoPlayerMigrationDeps>;
+}
+
+export type TwoPlayerStatus = "migrated" | "already-migrated" | "inactive";
+
+export interface TwoPlayerResult {
+  status: TwoPlayerStatus;
+  plan: TwoPlayerPlan;
+  report: TwoPlayerReport | null;
+  reportPath: string;
+}
+
+const EMPTY_PLAN: TwoPlayerPlan = { actions: [], kept: [] };
+
+function defaultDeps(): TwoPlayerMigrationDeps {
+  return {
+    isLivePid: defaultIsLivePid,
+    stopTree: (pid) => killTreeAndWait(pid),
+    projectLabel: (root) => resolveProjectLabel(root),
+    hostWorkers: async () => new Map<string, string>(),
+    isRegistered: async () => false,
+    // A Worker that is an active unit is the daemon's to re-attach to, so the
+    // default confirms rather than adopts: the host either already carries it —
+    // in which case the plan never asked — or it will on its next sweep.
+    readopt: async () => true,
+    now: () => new Date(),
+    notice: (message) => {
+      try {
+        process.stderr.write(`${message}\n`);
+      } catch {
+        // a closed stderr never blocks a launch
+      }
+    },
+  };
+}
+
+async function readWorkerPid(pidFile: string): Promise<number | null> {
+  try {
+    const raw = (await readFile(pidFile, "utf8")).trim();
+    if (!/^\d+$/.test(raw)) return null;
+    const pid = Number(raw);
+    return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readClaimedIssue(workspace: string): Promise<number | null> {
+  let entries: string[] = [];
+  try {
+    entries = await readdir(workspace);
+  } catch {
+    return null;
+  }
+  const issues = entries
+    .map((entry) => /^([1-9][0-9]*)$/.exec(entry)?.[1])
+    .filter((value): value is string => value !== undefined)
+    .map(Number)
+    .sort((a, b) => a - b);
+  return issues.length > 0 ? (issues[0] as number) : null;
+}
+
+/** The live pid of this project's own runtime, when it still has one. */
+async function readProjectRuntimePid(root: string): Promise<number | null> {
+  const lane = join(tmpDir(root), "supervisors", "default");
+  let entries: string[] = [];
+  try {
+    entries = await readdir(lane);
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".pid")) continue;
+    const pid = await readWorkerPid(join(lane, entry));
+    if (pid !== null) return pid;
+  }
+  return null;
+}
+
+/** Every Worker workspace on disk, across all still-readable worker lanes. */
+async function observeWorkers(
+  root: string,
+  deps: TwoPlayerMigrationDeps,
+): Promise<TwoPlayerWorkerObservation[]> {
+  const held = await deps.hostWorkers().catch(() => new Map<string, string>());
+  const observed: TwoPlayerWorkerObservation[] = [];
+  for (const lane of [workersDir(root), goWorkersDir(root), scoutWorkersDir(root)]) {
+    let ids: string[] = [];
+    try {
+      ids = await readdir(lane);
+    } catch {
+      continue;
+    }
+    for (const workerId of ids) {
+      if (!/^[A-Za-z0-9_-]+$/.test(workerId)) continue;
+      const workspace = join(lane, workerId);
+      const pid = await readWorkerPid(join(workspace, "worker.pid"));
+      observed.push({
+        workerId,
+        issue: await readClaimedIssue(workspace),
+        pid,
+        live: pid !== null && deps.isLivePid(pid),
+        workspace,
+        heldByHost: held.has(workerId),
+      });
+    }
+  }
+  return observed;
+}
+
+/** Gather the machine's pre-migration state. Read-only; decides nothing. */
+export async function observeTwoPlayerMigration(
+  root: string,
+  deps: TwoPlayerMigrationDeps,
+): Promise<TwoPlayerObservation> {
+  const projectLabel = deps.projectLabel(root);
+  const pid = await readProjectRuntimePid(root).catch(() => null);
+  return {
+    projectLabel,
+    runtime: pid === null ? null : { pid, live: deps.isLivePid(pid) },
+    workers: await observeWorkers(root, deps),
+    registered: await deps.isRegistered(projectLabel).catch(() => false),
+  };
+}
+
+async function writeReport(path: string, report: TwoPlayerReport): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp.${process.pid}`;
+  await writeFile(tmp, `${encodeDevSnapshotToon(report as unknown as never)}\n`, "utf8");
+  await rename(tmp, path);
+}
+
+/**
+ * Carry one project's live pre-migration state into the two-player model, once.
+ *
+ * Returns `inactive` when this launch is not yet the two-player era,
+ * `already-migrated` when the stamp is present, and `migrated` — with the full
+ * report — the single time it actually moves anything. Never throws.
+ */
+export async function migrateToTwoPlayer(
+  root: string,
+  options: MigrateToTwoPlayerOptions = {},
+): Promise<TwoPlayerResult> {
+  const reportPath = twoPlayerReportPath(root);
+  const deps: TwoPlayerMigrationDeps = { ...defaultDeps(), ...options.deps };
+  const env = options.env ?? process.env;
+
+  if (!resolveTwoPlayerActive(env, options.active)) {
+    return { status: "inactive", plan: EMPTY_PLAN, report: null, reportPath };
+  }
+  if (existsSync(reportPath)) {
+    return { status: "already-migrated", plan: EMPTY_PLAN, report: null, reportPath };
+  }
+
+  const observation = await observeTwoPlayerMigration(root, deps);
+  const plan = planTwoPlayerMigration(observation);
+
+  const stopped: string[] = [];
+  const readopted: string[] = [];
+  const failed: string[] = [];
+
+  for (const action of plan.actions) {
+    let ok = false;
+    try {
+      if (action.kind === "stop-runtime") {
+        ok = (await deps.stopTree(action.pid as number)) !== false;
+        if (ok) stopped.push(action.subject);
+      } else {
+        // Never a stop: the Worker outlives the runtime that asked for it, and
+        // this move only asks the host to hold it under a named project.
+        ok = (await deps.readopt(action.workerId as string, action.projectLabel as string)) !== false;
+        if (ok) readopted.push(action.subject);
+      }
+    } catch {
+      ok = false;
+    }
+    if (!ok) failed.push(action.subject);
+  }
+
+  const report = buildTwoPlayerReport(plan, { stopped, readopted, failed }, deps.now().toISOString());
+  try {
+    await writeReport(reportPath, report);
+  } catch {
+    // A report that could not be stamped leaves the migration to the next launch,
+    // which is the safe direction: every move it makes is idempotent on its own,
+    // and skipping the migration entirely would leave the removed player running.
+  }
+  deps.notice(summarizeTwoPlayerMigration(plan));
+  return { status: "migrated", plan, report, reportPath };
+}
+
+export { TWO_PLAYER_CONTRACT, TWO_PLAYER_RECOVERY_DOC } from "../core/two-player-migration.js";

--- a/apps/dev/tests/two-player-migration-runtime.test.ts
+++ b/apps/dev/tests/two-player-migration-runtime.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { decode } from "@reddb-io/toon";
+import { afkStateDir, tmpDir, workersDir } from "@reddb-io/shared/red-paths.js";
+import {
+  migrateToTwoPlayer,
+  twoPlayerReportPath,
+  type TwoPlayerMigrationDeps,
+} from "../src/runtime/two-player-migration.js";
+import { TWO_PLAYER_CONTRACT, TWO_PLAYER_RECOVERY_DOC } from "../src/core/two-player-migration.js";
+
+async function freshRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "two-player-"));
+  await mkdir(tmpDir(root), { recursive: true });
+  await mkdir(afkStateDir(root), { recursive: true });
+  return root;
+}
+
+async function seedWorker(root: string, workerId: string, issue: number, pid: number): Promise<void> {
+  const workspace = join(workersDir(root), workerId);
+  await mkdir(join(workspace, String(issue)), { recursive: true });
+  await writeFile(join(workspace, "worker.pid"), `${pid}\n`, "utf8");
+}
+
+async function seedRuntime(root: string, pid: number): Promise<void> {
+  const dir = join(tmpDir(root), "supervisors", "default");
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "afk-supervisor.pid"), `${pid}\n`, "utf8");
+}
+
+interface Recorder {
+  stopped: number[];
+  notices: string[];
+  deps: Partial<TwoPlayerMigrationDeps>;
+}
+
+function recorder(overrides: Partial<TwoPlayerMigrationDeps> = {}): Recorder {
+  const stopped: number[] = [];
+  const notices: string[] = [];
+  return {
+    stopped,
+    notices,
+    deps: {
+      isLivePid: () => true,
+      stopTree: async (pid) => {
+        stopped.push(pid);
+        return true;
+      },
+      projectLabel: () => "red-skills",
+      hostWorkers: async () => new Map<string, string>(),
+      isRegistered: async () => false,
+      now: () => new Date("2026-07-31T12:00:00.000Z"),
+      notice: (message) => notices.push(message),
+      ...overrides,
+    },
+  };
+}
+
+describe("migrateToTwoPlayer", () => {
+  it("stays inert until the two-player era is declared", async () => {
+    const root = await freshRoot();
+    await seedRuntime(root, 900);
+    const rec = recorder();
+    const result = await migrateToTwoPlayer(root, { env: {}, deps: rec.deps });
+    expect(result.status).toBe("inactive");
+    expect(rec.stopped).toEqual([]);
+  });
+
+  it("stops the per-project runtime and leaves the live Worker running", async () => {
+    const root = await freshRoot();
+    await seedRuntime(root, 900);
+    await seedWorker(root, "wAAAA", 42, 111);
+    const rec = recorder();
+    const result = await migrateToTwoPlayer(root, { active: true, deps: rec.deps });
+    expect(result.status).toBe("migrated");
+    expect(rec.stopped).toEqual([900]);
+    expect(rec.stopped).not.toContain(111);
+  });
+
+  it("re-adopts a live Worker under this project's label, proven by host state", async () => {
+    const root = await freshRoot();
+    await seedWorker(root, "wAAAA", 42, 111);
+    const adopted = new Map<string, string>();
+    const rec = recorder({
+      hostWorkers: async () => new Map(adopted),
+      readopt: async (workerId, label) => {
+        adopted.set(workerId, label);
+        return true;
+      },
+    });
+    const result = await migrateToTwoPlayer(root, { active: true, deps: rec.deps });
+    expect(result.report?.moved.readopted).toEqual(["wAAAA (#42)"]);
+    expect(adopted.get("wAAAA")).toBe("red-skills");
+  });
+
+  it("names a Worker the host would not re-adopt instead of dropping it", async () => {
+    const root = await freshRoot();
+    await seedWorker(root, "wAAAA", 42, 111);
+    const rec = recorder({ readopt: async () => false });
+    const result = await migrateToTwoPlayer(root, { active: true, deps: rec.deps });
+    expect(result.report?.moved.failed).toEqual(["wAAAA (#42)"]);
+    expect(result.report?.moved.readopted).toEqual([]);
+  });
+
+  it("leaves the registration to the MCP and says so in the report", async () => {
+    const root = await freshRoot();
+    await seedRuntime(root, 900);
+    const rec = recorder();
+    const result = await migrateToTwoPlayer(root, { active: true, deps: rec.deps });
+    expect(result.plan.actions.map((action) => action.kind)).toEqual(["stop-runtime"]);
+    expect(result.report?.kept.map((entry) => entry.subject)).toContain("red-skills");
+  });
+
+  it("reports what it moved and what it left behind, with the way back", async () => {
+    const root = await freshRoot();
+    await seedRuntime(root, 900);
+    await seedWorker(root, "wAAAA", 42, 111);
+    const rec = recorder({ readopt: async () => true });
+    const result = await migrateToTwoPlayer(root, { active: true, deps: rec.deps });
+    const raw = await readFile(twoPlayerReportPath(root), "utf8");
+    const stamped = decode(raw) as { contract: string; recovery: string };
+    expect(stamped.contract).toBe(TWO_PLAYER_CONTRACT);
+    expect(stamped.recovery).toBe(TWO_PLAYER_RECOVERY_DOC);
+    expect(result.report?.moved.stopped).toEqual(["project runtime pid 900"]);
+    expect(result.report?.kept.length).toBeGreaterThan(0);
+    expect(rec.notices.join("\n")).toContain(TWO_PLAYER_RECOVERY_DOC);
+  });
+
+  it("changes nothing the second time it runs", async () => {
+    const root = await freshRoot();
+    await seedRuntime(root, 900);
+    await seedWorker(root, "wAAAA", 42, 111);
+    const first = recorder({ readopt: async () => true });
+    await migrateToTwoPlayer(root, { active: true, deps: first.deps });
+    const before = await readFile(twoPlayerReportPath(root), "utf8");
+
+    const second = recorder({ readopt: async () => true });
+    const result = await migrateToTwoPlayer(root, { active: true, deps: second.deps });
+    expect(result.status).toBe("already-migrated");
+    expect(second.stopped).toEqual([]);
+    expect(result.plan.actions).toEqual([]);
+    expect(await readFile(twoPlayerReportPath(root), "utf8")).toBe(before);
+  });
+
+  it("never fails a launch when the host refuses every move", async () => {
+    const root = await freshRoot();
+    await seedRuntime(root, 900);
+    const rec = recorder({
+      stopTree: async () => {
+        throw new Error("refused");
+      },
+    });
+    const result = await migrateToTwoPlayer(root, { active: true, deps: rec.deps });
+    expect(result.status).toBe("migrated");
+    expect(result.report?.moved.failed).toEqual(["project runtime pid 900"]);
+  });
+});
+
+describe("the documented way back", () => {
+  it("is written where the report and the boot notice point", async () => {
+    const [file] = TWO_PLAYER_RECOVERY_DOC.split("#");
+    const doc = await readFile(join(process.cwd(), "..", "..", file as string), "utf8");
+    expect(doc).toContain("## Recovering from a bad two-player migration");
+    expect(doc).toContain("RED_TWO_PLAYER_CUTOVER");
+    expect(doc).toContain("two-player.toon");
+  });
+});

--- a/apps/dev/tests/two-player-migration.test.ts
+++ b/apps/dev/tests/two-player-migration.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  TWO_PLAYER_CONTRACT,
+  TWO_PLAYER_REASONS,
+  TWO_PLAYER_RECOVERY_DOC,
+  buildTwoPlayerReport,
+  planTwoPlayerMigration,
+  resolveTwoPlayerActive,
+  summarizeTwoPlayerMigration,
+  type TwoPlayerObservation,
+  type TwoPlayerWorkerObservation,
+} from "../src/core/two-player-migration.js";
+
+function worker(overrides: Partial<TwoPlayerWorkerObservation> = {}): TwoPlayerWorkerObservation {
+  return {
+    workerId: "wAAAA",
+    issue: 42,
+    pid: 111,
+    live: true,
+    unit: "red-worker-wAAAA.service",
+    workspace: "/repo/.red/tmp/workers/wAAAA",
+    heldByHost: false,
+    ...overrides,
+  };
+}
+
+function observation(overrides: Partial<TwoPlayerObservation> = {}): TwoPlayerObservation {
+  return {
+    projectLabel: "red-skills",
+    runtime: null,
+    workers: [],
+    registered: false,
+    ...overrides,
+  };
+}
+
+describe("planTwoPlayerMigration", () => {
+  it("stops the live per-project runtime before touching anything else", () => {
+    const plan = planTwoPlayerMigration(
+      observation({ runtime: { pid: 900, live: true }, workers: [worker()] }),
+    );
+    expect(plan.actions[0]).toMatchObject({ kind: "stop-runtime", pid: 900 });
+  });
+
+  it("ignores a runtime whose pid is no longer live", () => {
+    const plan = planTwoPlayerMigration(observation({ runtime: { pid: 900, live: false } }));
+    expect(plan.actions.filter((action) => action.kind === "stop-runtime")).toEqual([]);
+    expect(plan.kept).toContainEqual({
+      subject: "project runtime pid 900",
+      reason: TWO_PLAYER_REASONS.runtimeAlreadyGone,
+    });
+  });
+
+  it("re-adopts a live Worker instead of stopping it", () => {
+    const plan = planTwoPlayerMigration(observation({ workers: [worker()] }));
+    expect(plan.actions).toContainEqual({
+      kind: "readopt-worker",
+      subject: "wAAAA (#42)",
+      reason: TWO_PLAYER_REASONS.workerReadopted,
+      workerId: "wAAAA",
+      projectLabel: "red-skills",
+      issue: 42,
+      unit: "red-worker-wAAAA.service",
+    });
+    expect(plan.actions.map((action) => action.kind)).not.toContain("quiesce-worker");
+  });
+
+  it("keeps a live Worker's claim, branch and workspace exactly where they are", () => {
+    const plan = planTwoPlayerMigration(observation({ workers: [worker()] }));
+    expect(plan.kept).toContainEqual({
+      subject: "wAAAA (#42) claim",
+      reason: TWO_PLAYER_REASONS.claimKept,
+    });
+  });
+
+  it("has nothing to move for a Worker the host already holds", () => {
+    const plan = planTwoPlayerMigration(observation({ workers: [worker({ heldByHost: true })] }));
+    expect(plan.actions.filter((action) => action.kind === "readopt-worker")).toEqual([]);
+    expect(plan.kept).toContainEqual({
+      subject: "wAAAA (#42)",
+      reason: TWO_PLAYER_REASONS.workerAlreadyHeld,
+    });
+  });
+
+  it("leaves a dead Worker to the crash reconcile path", () => {
+    const plan = planTwoPlayerMigration(observation({ workers: [worker({ live: false })] }));
+    expect(plan.actions.filter((action) => action.kind === "readopt-worker")).toEqual([]);
+    expect(plan.kept).toContainEqual({
+      subject: "wAAAA (#42)",
+      reason: TWO_PLAYER_REASONS.workerDead,
+    });
+  });
+
+  it("never registers the project itself — that is the MCP's move to make", () => {
+    const plan = planTwoPlayerMigration(observation({ runtime: { pid: 900, live: true } }));
+    expect(plan.actions.map((action) => action.kind)).toEqual(["stop-runtime"]);
+    expect(plan.kept).toContainEqual({
+      subject: "red-skills",
+      reason: TWO_PLAYER_REASONS.projectRegistrationIsCallers,
+    });
+  });
+
+  it("says so when the daemon already holds the project", () => {
+    const plan = planTwoPlayerMigration(observation({ registered: true }));
+    expect(plan.actions).toEqual([]);
+    expect(plan.kept).toContainEqual({
+      subject: "red-skills",
+      reason: TWO_PLAYER_REASONS.projectAlreadyRegistered,
+    });
+  });
+
+  it("is a no-op on a machine that already reached the two-player model", () => {
+    const plan = planTwoPlayerMigration(
+      observation({ registered: true, workers: [worker({ heldByHost: true })] }),
+    );
+    expect(plan.actions).toEqual([]);
+  });
+});
+
+describe("summarizeTwoPlayerMigration", () => {
+  it("names what moved, what stayed, and where to go when it misbehaved", () => {
+    const plan = planTwoPlayerMigration(
+      observation({ runtime: { pid: 900, live: true }, workers: [worker()] }),
+    );
+    const summary = summarizeTwoPlayerMigration(plan);
+    expect(summary).toContain("1 project runtime stopped");
+    expect(summary).toContain("1 worker(s) re-adopted");
+    expect(summary).toContain("left in place");
+    expect(summary).toContain(TWO_PLAYER_RECOVERY_DOC);
+  });
+});
+
+describe("buildTwoPlayerReport", () => {
+  it("stamps both halves of the move, including what the host refused", () => {
+    const plan = planTwoPlayerMigration(
+      observation({ runtime: { pid: 900, live: true }, workers: [worker()] }),
+    );
+    const report = buildTwoPlayerReport(
+      plan,
+      { stopped: ["project runtime pid 900"], readopted: [], failed: ["wAAAA (#42)"] },
+      "2026-07-31T00:00:00.000Z",
+    );
+    expect(report.contract).toBe(TWO_PLAYER_CONTRACT);
+    expect(report.recovery).toBe(TWO_PLAYER_RECOVERY_DOC);
+    expect(report.moved.stopped).toEqual(["project runtime pid 900"]);
+    expect(report.moved.failed).toEqual(["wAAAA (#42)"]);
+    expect(report.kept.length).toBeGreaterThan(0);
+  });
+});
+
+describe("resolveTwoPlayerActive", () => {
+  it("prefers the caller's explicit statement over the environment", () => {
+    expect(resolveTwoPlayerActive({ RED_TWO_PLAYER_CUTOVER: "1" }, false)).toBe(false);
+    expect(resolveTwoPlayerActive({}, true)).toBe(true);
+  });
+
+  it("is off unless an operator declares the era", () => {
+    expect(resolveTwoPlayerActive({})).toBe(false);
+    expect(resolveTwoPlayerActive({ RED_TWO_PLAYER_CUTOVER: "yes" })).toBe(true);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2910. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2910

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788107974&installation_model_id=20659&pr_number=2956&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2956&signature=5642165ded7e8209e2edce4b825ce2b74d1b14e91613e7f3e2894eb719313193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->