### PR TITLE
chore: minor changeset for the demand-loop release

### DIFF
--- a/.changeset/daemon-owns-the-demand-loop.md
+++ b/.changeset/daemon-owns-the-demand-loop.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/red-skills": minor
+---
+
+**The daemon owns the demand loop: two players, one poller.**
+
+A project no longer runs a process of its own. Its MCP **registers** — repository identity, an opaque selector, an opaque argv, a workspace path, a target — and the daemon polls the issue tracker for **every** registered project in a single aliased request, then decides when to ask for the next Worker. Cost is flat in the number of projects instead of linear in it, which is the whole point: GitHub quota is per token, so N pollers on one credential spend N times for the same answer.
+
+A registration outlives the session that created it, so a drain keeps going after the terminal closes, and lapses when nothing renews it, so a closed laptop stops polling. A project whose queue genuinely empties leaves the list — and *genuinely* is load-bearing: a rate-limited fetch, an unreachable repository and an empty queue are now three distinguishable outcomes, because reporting a spent quota as "no work" is what once parked a fleet's slots for an hour while the tracker held four ready issues.
+
+**Rule 3 survived the move.** The daemon matches a query to a result and starts a process with the argv it was handed. It still does not know what an Issue, a label, a Spec, a gate or a Landing *is*.
+
+**A Worker's runner, model and effort stay decided per birth.** A runner is chosen when a Worker is born and swaps at runtime when one degrades mid-drain; model and effort resolve per tier, per run. A registration carrying one frozen argv could not have expressed that, and the change that removes the composing site was held until this was answered.
+
+Also in this release: the daemon's wire and CLI speak TOON rather than JSON, and the ratchet that keeps the repository on TOON gained a second dimension so the next socket cannot be born JSON the way this one was; a pull request a Worker opens is born integrated with its base, so a conflict surfaces while the Worker is still alive to resolve it; an operator's installed plugin counts as evidence when resolving the published version; and a major-version gap is reported rather than silently held.


### PR DESCRIPTION
Spec #2900 delivered all 11 slices, so this release is a **minor**, not the patch the pending changesets alone would compute.

The changeset describes the release by what it changes for an operator: a project no longer runs a process of its own, the daemon polls every registered project in one request, and a registration outlives its session while lapsing when nothing renews it.

Merging this makes the release bot recompute the Version PR (#2932) from 3.0.5 to **3.1.0**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788110605&installation_model_id=20659&pr_number=2957&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2957&signature=47046d4aae3a9f78c746b77ee0b4095f79cda2db4a28a0001c18d03e6cc29e42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->