### PR TITLE
chore: #2959 /red-setup reports a running redskilled instead of asking about it again

### DIFF
--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -26,6 +26,7 @@ import {
 import { isResolvedRedskilledEntry } from "./daemon-entry.js";
 import {
   auditRedskilledProvisioning,
+  describeRedskilledPresence,
   installRedskilledUserUnit,
   provisionRedskilledHome,
   readRedskilledProvisionFacts,
@@ -122,7 +123,9 @@ with no unit is a supported configuration (ADR 0130 rule 7). Defaults to status.
   provision: `Usage: redskilled provision [--check] [--no-start] [--install-unit]
 
 Makes a machine with no prior state ready, and prints the audit. Idempotent: a
-second run creates nothing and reports the same verdicts.
+second run creates nothing and reports the same verdicts. Every run opens with a
+presence — running, partial or absent — so a machine that is already done says so
+instead of looking like a fresh install.
 
   --check         read-only; creates and starts nothing
   --no-start      provision the home without starting the daemon
@@ -503,7 +506,14 @@ export async function runProvision(
     : undefined;
 
   const report = auditRedskilledProvisioning(facts);
+  // Presence leads the output because it is the question the operator re-running
+  // setup actually has — "is this machine already done?" — and a report that
+  // opened with four check rows made them derive the answer from the evidence.
+  const presence = describeRedskilledPresence(facts);
   write(`${encodeToon({
+    presence: presence.presence,
+    summary: presence.headline,
+    ...(presence.daemon == null ? {} : { daemon: { version: presence.daemon.version, pid: presence.daemon.pid } }),
     verdict: report.verdict,
     home: home == null
       ? { path: facts.homePath, created: false, tightened: false }

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -112,7 +112,9 @@ import {
   type RedskilledUnitPidProbe,
 } from "./reattach.js";
 import {
+  isRedskilledPong,
   REDSKILLED_PROTOCOL_VERSION,
+  type RedskilledDaemonIdentity,
   type RedskilledRequest,
   type RedskilledResponse,
   type RedskilledStatuslineRenderRequest,
@@ -1765,18 +1767,46 @@ async function bindExclusive(socketPath: string): Promise<Server> {
   throw new RedskilledAlreadyRunningError(socketPath);
 }
 
-/** True when something on the other end of `socketPath` answers a ping. */
-export async function socketAnswers(socketPath: string, timeoutMs = 250): Promise<boolean> {
+/**
+ * Who is answering on `socketPath` — version and pid — or `undefined` for nobody.
+ *
+ * It is the ping and nothing more: **a probe that auto-spawned would answer its
+ * own question**, and a report of a daemon the report started tells an operator
+ * nothing about the machine they walked up to. A daemon too old to name itself
+ * still counts as reachable; the identity is what may be missing, never the
+ * reach.
+ */
+export async function probeRedskilledDaemon(
+  socketPath: string,
+  timeoutMs = 250,
+): Promise<RedskilledDaemonProbe> {
   try {
     const response = await sendLineRequest<RedskilledRequest, RedskilledResponse>(
       { socketPath, timeoutMs },
       { id: randomUUID(), op: "ping" },
       "redskilled daemon",
     );
-    return response.ok === true;
+    if (response.ok !== true) return { reachable: false };
+    // Reach and identity are separate answers on purpose: a daemon from before
+    // the pong carried a version is still up, and reporting it as absent would
+    // be the one lie this probe exists to prevent.
+    return isRedskilledPong(response.value)
+      ? { reachable: true, identity: { version: response.value.daemon_version, pid: response.value.pid } }
+      : { reachable: true };
   } catch {
-    return false;
+    return { reachable: false };
   }
+}
+
+/** What a ping learned: whether anyone is there, and who, when they said. */
+export interface RedskilledDaemonProbe {
+  readonly reachable: boolean;
+  readonly identity?: RedskilledDaemonIdentity;
+}
+
+/** True when something on the other end of `socketPath` answers a ping. */
+export async function socketAnswers(socketPath: string, timeoutMs = 250): Promise<boolean> {
+  return (await probeRedskilledDaemon(socketPath, timeoutMs)).reachable;
 }
 
 /**

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -155,6 +155,18 @@ export type RedskilledResponse =
   | { id: string; ok: true; value: unknown }
   | { id: string; ok: false; error: string };
 
+/**
+ * A daemon named by its own ping — the version it runs and the pid running it.
+ *
+ * It is a projection of {@link RedskilledPong}, not a second source: every
+ * surface that reports "this machine has a daemon" reads the same two fields off
+ * the same answer, so a report cannot disagree with the socket it read.
+ */
+export interface RedskilledDaemonIdentity {
+  readonly version: string;
+  readonly pid: number;
+}
+
 export interface RedskilledPong {
   readonly pong: true;
   readonly protocol_version: number;

--- a/apps/redskilled/src/provision.ts
+++ b/apps/redskilled/src/provision.ts
@@ -23,7 +23,8 @@ import { chmod, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { REDSKILLED_HOME_MODE, redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
-import { socketAnswers } from "./daemon.js";
+import { probeRedskilledDaemon } from "./daemon.js";
+import type { RedskilledDaemonIdentity } from "./protocol.js";
 import {
   isResolvedRedskilledEntry,
   resolveRedskilledEntry,
@@ -94,6 +95,8 @@ export interface RedskilledProvisionFacts {
   readonly socketPath: string;
   /** Whether a daemon answered a ping. Probed WITHOUT spawning one. */
   readonly reachable: boolean;
+  /** Who answered, when the pong named itself. Absent is not unreachable. */
+  readonly daemon?: RedskilledDaemonIdentity | undefined;
   readonly supervisorUnit: RedskilledSupervisorUnitState;
 }
 
@@ -134,6 +137,79 @@ export function auditRedskilledProvisioning(facts: RedskilledProvisionFacts): Re
       ? "degraded"
       : "ok";
   return { verdict, rows, findings };
+}
+
+/** Three states a machine can be in when setup walks up to it. */
+export type RedskilledPresence = "running" | "partial" | "absent";
+
+export interface RedskilledPresenceReport {
+  readonly presence: RedskilledPresence;
+  /** One sentence an operator can read without knowing the check vocabulary. */
+  readonly headline: string;
+  /** The headline's supporting rows, already indented for printing under it. */
+  readonly lines: readonly string[];
+  /** Who answered, when the daemon named itself. */
+  readonly daemon?: RedskilledDaemonIdentity | undefined;
+  /**
+   * Whether setup still owes the operator the daemon interview.
+   *
+   * False ONLY when a daemon answers: everything the interview would ask has
+   * already been answered by the machine itself, and asking again is how an
+   * operator loses the ability to tell a working host from an unconfigured one.
+   */
+  readonly reinterview: boolean;
+}
+
+/**
+ * What this machine already is, in one verdict. PURE.
+ *
+ * **Reach is the live fact and it decides.** A daemon that answers is running
+ * whatever the home looks like — the home is a precondition for starting one, and
+ * a machine that is past that point is not made un-started by drift behind it.
+ * Absent reach, prior state is what separates a half-provisioned host from a bare
+ * one, and the middle state is REPORTED as the middle state: an operator told
+ * "not provisioned" about a machine that already has a home goes looking for the
+ * wrong thing, and one told "running" about a daemon that never answers goes
+ * looking for nothing at all.
+ *
+ * Silence is not a report. Every state prints its evidence, because a step that
+ * says nothing is indistinguishable from a step that did nothing.
+ */
+export function describeRedskilledPresence(facts: RedskilledProvisionFacts): RedskilledPresenceReport {
+  const home = homeRow(facts);
+  const homeLine = `  home    ${home.evidence}`;
+  const socketLine = `  socket  ${facts.socketPath}`;
+  if (facts.reachable) {
+    const named = facts.daemon == null
+      ? "version unnamed by this daemon"
+      : `${facts.daemon.version}, pid ${facts.daemon.pid}`;
+    return {
+      presence: "running",
+      headline: `redskilled detected and running — ${named}`,
+      // A drifted home rides along rather than demoting the verdict: the daemon
+      // is up AND something behind it wants narrowing, and collapsing the two
+      // would hide whichever half the operator needed.
+      lines: [socketLine, "  reach   ok", ...(home.verdict === "ok" ? [] : [homeLine])],
+      ...(facts.daemon == null ? {} : { daemon: facts.daemon }),
+      reinterview: false,
+    };
+  }
+  const lines = [homeLine, socketLine, `  reach   ${reachRow(facts).evidence}`];
+  if (facts.homePresent || isResolvedRedskilledEntry(facts.entry)) {
+    const half = facts.homePresent ? "home present" : "bundle present";
+    return {
+      presence: "partial",
+      headline: `redskilled partially provisioned — ${half}, no daemon answering on the socket`,
+      lines,
+      reinterview: true,
+    };
+  }
+  return {
+    presence: "absent",
+    headline: "redskilled not provisioned on this host — no home, no daemon",
+    lines,
+    reinterview: true,
+  };
 }
 
 function homeRow(facts: RedskilledProvisionFacts): RedskilledProvisionRow {
@@ -235,9 +311,9 @@ export async function readRedskilledProvisionFacts(
   const homeDir = options.homeDir ?? homedir();
   const paths = options.paths ?? resolveRedskilledPaths({ env });
   const homePath = redskilledHomeDir(homeDir);
-  const [homeMode, reachable] = await Promise.all([
+  const [homeMode, probe] = await Promise.all([
     modeOf(homePath),
-    socketAnswers(paths.socketPath),
+    probeRedskilledDaemon(paths.socketPath),
   ]);
   return {
     homePath,
@@ -245,7 +321,8 @@ export async function readRedskilledProvisionFacts(
     homeMode,
     entry: resolveRedskilledEntry(options.entryOverride ?? {}, { env, ...options.entryLookup }),
     socketPath: paths.socketPath,
-    reachable,
+    reachable: probe.reachable,
+    ...(probe.identity == null ? {} : { daemon: probe.identity }),
     supervisorUnit: await readSupervisorUnitState(configHomeOf(options, env, homeDir), env),
   };
 }

--- a/apps/redskilled/tests/provision-presence.test.ts
+++ b/apps/redskilled/tests/provision-presence.test.ts
@@ -1,0 +1,200 @@
+// Presence: what `/red-setup` sees when it walks up to a machine that may
+// already be provisioned.
+//
+// Setup has always had the facts and never said them, so re-running it on a
+// working host asked the same questions as a fresh install. Three states have to
+// be distinguishable — a daemon that answers, a half-provisioned host, and a
+// machine with nothing on it — and the middle one must not collapse into either
+// extreme. The detection is READ-ONLY: it observes a daemon, it never starts one
+// as a side effect of looking.
+import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { REDSKILLED_HOME_MODE, redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { runProvision } from "../src/cli.js";
+import {
+  describeRedskilledPresence,
+  readRedskilledProvisionFacts,
+  type RedskilledProvisionFacts,
+} from "../src/provision.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function root(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(dir);
+  return dir;
+}
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const dir = await root("redskilled-presence-");
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${dir}`, REDSKILLED_MACHINE_DIR: dir },
+    runtimeDir: dir,
+  });
+}
+
+/** Healthy facts; each test spoils exactly the one thing it is about. */
+function facts(overrides: Partial<RedskilledProvisionFacts> = {}): RedskilledProvisionFacts {
+  return {
+    homePath: "/home/dev/.red/redskilled",
+    homePresent: true,
+    homeMode: REDSKILLED_HOME_MODE,
+    entry: { command: "/usr/bin/node", args: ["/bundles/redskilled.bundle.min.mjs"], source: "bundle-cache" },
+    socketPath: "/run/user/1000/red-skills/redskilled.sock",
+    reachable: true,
+    daemon: { version: "3.0.4", pid: 533336 },
+    supervisorUnit: "absent",
+    ...overrides,
+  };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("presence of a daemon already running", () => {
+  it("reports version, pid and socket rather than asking again", () => {
+    const report = describeRedskilledPresence(facts());
+
+    expect(report.presence).toBe("running");
+    expect(report.headline).toBe("redskilled detected and running — 3.0.4, pid 533336");
+    expect(report.lines).toContain("  socket  /run/user/1000/red-skills/redskilled.sock");
+    expect(report.lines).toContain("  reach   ok");
+    // The whole point of the slice: setup has its answer and must not re-ask.
+    expect(report.reinterview).toBe(false);
+  });
+
+  it("still reports a running daemon that cannot name its own version", () => {
+    const report = describeRedskilledPresence(facts({ daemon: undefined }));
+
+    expect(report.presence).toBe("running");
+    expect(report.headline).toContain("detected and running");
+    expect(report.reinterview).toBe(false);
+  });
+
+  it("names a home that drifted wider, without demoting a daemon that answers", () => {
+    const report = describeRedskilledPresence(facts({ homeMode: 0o755 }));
+
+    expect(report.presence).toBe("running");
+    expect(report.lines.join("\n")).toContain("/home/dev/.red/redskilled");
+  });
+});
+
+describe("presence of a host that is only half there", () => {
+  it("reports home-present-daemon-unreachable as exactly that, not as either extreme", () => {
+    const report = describeRedskilledPresence(facts({ reachable: false, daemon: undefined }));
+
+    expect(report.presence).toBe("partial");
+    expect(report.headline).toContain("home present");
+    expect(report.headline).toContain("no daemon");
+    // Half a host still owes the operator the rest of the interview.
+    expect(report.reinterview).toBe(true);
+    expect(report.lines.join("\n")).toContain("/home/dev/.red/redskilled");
+  });
+
+  it("counts a reachable daemon with no home as running, because reach is the live fact", () => {
+    expect(describeRedskilledPresence(facts({ homePresent: false, homeMode: undefined })).presence).toBe("running");
+  });
+});
+
+describe("presence of a machine with nothing on it", () => {
+  it("walks the full path when neither the home nor a daemon is there", () => {
+    const report = describeRedskilledPresence(facts({
+      homePresent: false,
+      homeMode: undefined,
+      reachable: false,
+      daemon: undefined,
+      entry: { searched: ["/home/dev/.cache/red-skills/bundles"], diagnostic: "redskilled-daemon-entry-unresolved" },
+    }));
+
+    expect(report.presence).toBe("absent");
+    expect(report.reinterview).toBe(true);
+    expect(report.headline).toContain("not provisioned");
+  });
+});
+
+describe("detection observes and never provisions", () => {
+  it("reads a live daemon's version and pid off a ping", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({ paths, daemonVersion: "9.9.9-test" });
+    running.push(daemon);
+
+    const home = await root("redskilled-presence-home-");
+    const observed = await readRedskilledProvisionFacts({ paths, homeDir: home, configHome: join(home, ".config") });
+
+    expect(observed.reachable).toBe(true);
+    expect(observed.daemon).toEqual({ version: "9.9.9-test", pid: process.pid });
+    expect(describeRedskilledPresence(observed).presence).toBe("running");
+    // Looking created nothing: the home is still the daemon's to create.
+    expect(await exists(redskilledHomeDir(home))).toBe(false);
+  });
+
+  it("starts no daemon on a session nobody is serving", async () => {
+    const paths = await sessionPaths();
+    const home = await root("redskilled-presence-cold-");
+
+    const observed = await readRedskilledProvisionFacts({ paths, homeDir: home, configHome: join(home, ".config") });
+
+    expect(observed.reachable).toBe(false);
+    expect(observed.daemon).toBeUndefined();
+    expect(await exists(paths.socketPath)).toBe(false);
+    expect(await exists(redskilledHomeDir(home))).toBe(false);
+  });
+
+  it("`provision --check` prints the presence and leaves the machine as it found it", async () => {
+    const paths = await sessionPaths();
+    const home = await root("redskilled-presence-check-");
+    let out = "";
+
+    const code = await runProvision(["--check"], {
+      write: (text) => {
+        out += text;
+      },
+      paths,
+      homeDir: home,
+      configHome: join(home, ".config"),
+    });
+
+    expect(code).toBe(1);
+    expect(out).toContain("presence: absent");
+    expect(await exists(redskilledHomeDir(home))).toBe(false);
+    expect(await exists(paths.socketPath)).toBe(false);
+  });
+
+  it("`provision --check` names the daemon it found, without starting one", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({ paths, daemonVersion: "9.9.9-test" });
+    running.push(daemon);
+    const home = await root("redskilled-presence-live-");
+    let out = "";
+
+    await runProvision(["--check"], {
+      write: (text) => {
+        out += text;
+      },
+      paths,
+      homeDir: home,
+      configHome: join(home, ".config"),
+    });
+
+    expect(out).toContain("presence: running");
+    expect(out).toContain("9.9.9-test");
+    expect(out).toContain(String(process.pid));
+    expect(await readdir(redskilledHomeDir(home)).catch(() => undefined)).toBeUndefined();
+  });
+});

--- a/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -166,6 +166,18 @@ The installed version must be `0.3.0`. Record the same pin in `.red/config.yaml`
 
 > Explainer: `redskilled` is the host-scoped execution daemon (ADR 0130): exactly one singleton per machine, behind a unix socket, owning Worker processes across every project on this machine while each project's bundle keeps owning the work. It is what makes "what is this machine currently doing" answerable, and it fails closed — no daemon, no Worker. A daemon starts on first use, but three things must exist before it can: its host-scoped home, a published bundle to run, and a socket that answers.
 
+**Ask the machine before you ask the user.** Open E3 with the read-only probe and let its `presence` decide the section:
+
+```bash
+redskilled provision --check      # presence: running | partial | absent
+```
+
+- **`presence: running`** — a daemon is up. **Report it and move on**; do not re-interview what the machine already answered. Print the `summary` line and its evidence verbatim, e.g. `redskilled detected and running — 3.0.4, pid 533336`, then the socket and the reach row. Silence is not an option: an operator running setup on a working machine wants confirmation, and a step that says nothing is indistinguishable from a step that did nothing. Re-run `redskilled provision` only if the operator asks for it, or if a check row below `presence` is non-`ok`.
+- **`presence: partial`** — half a host: the home (or the bundle) is there and no daemon answers on the socket. **Report it as exactly that** — neither "already set up" nor "nothing here" — and walk the rest of the section to close the missing half.
+- **`presence: absent`** — nothing is provisioned. Walk the full path below.
+
+`--check` observes and never provisions: it creates no home and starts no daemon, so the presence it reports is the machine you walked up to and not one the report brought into being.
+
 **The home is the daemon's, not this skill's.** `~/.red/redskilled/` is operator-scoped and lives outside every checkout, so it is *not* the `.red/` this skill has sole authority over. Its one owner is `provisionRedskilledHome` in `apps/redskilled/src/provision.ts` (ADR 0130 Amendment 1) — never `mkdir` it here, and never treat a repo's ADR 0067 authority as covering it. Setup provisions it by **calling** its owner:
 
 ```bash
@@ -180,7 +192,7 @@ That one command creates the home owner-only (`0700`), starts the daemon through
 Verify afterwards:
 
 ```bash
-redskilled provision --check      # verdict: ok
+redskilled provision --check      # presence: running, verdict: ok
 redskilled host-state             # the machine's Workers, from the daemon itself
 ```
 

--- a/packaging/pi/dev/skills/engineering/red-setup/REFERENCE.md
+++ b/packaging/pi/dev/skills/engineering/red-setup/REFERENCE.md
@@ -33,5 +33,5 @@ Look at the current repo to understand its starting state. Read whatever exists;
 - `.red/agents/` — does this skill's prior output already exist?
 - `.red/config.yaml` — does it exist? Which plugins are already enabled (`plugins.<name>.enabled: true`)? Is the canonical `plugins.dev.lock.primary-branch` flag already set? Is `command_guard` already configured, and under which scopes (`global`, `main`, `worktree`, or legacy `deny`)?
 - `tq --version` and `.red/config.yaml` `host_binaries.tq.version` — is the required host binary present and pinned to `0.3.0`?
-- `redskilled provision --check` — is the daemon provisioned on this host, and if not, which of `home` / `daemon-entry` / `reach` is missing? (Read-only: it creates nothing and starts nothing.)
+- `redskilled provision --check` — what is this machine's `presence` (`running` / `partial` / `absent`), and when it is not `running`, which of `home` / `daemon-entry` / `reach` is missing? A `running` presence names the daemon's version, pid and socket, and Section E3 reports it instead of re-asking. (Read-only: it creates nothing and starts nothing.)
 - `AGENTS.md` and `CLAUDE.md` — does either already have a `## Development workflow` section?

--- a/packaging/pi/dev/skills/engineering/red-setup/WRITE-CONTRACT.md
+++ b/packaging/pi/dev/skills/engineering/red-setup/WRITE-CONTRACT.md
@@ -106,10 +106,11 @@ Install and record required host binaries (Section E2):
 
 For Section E3, provision the execution daemon:
 
-1. Run `redskilled provision`. It creates the host-scoped home, starts the daemon, and prints the audit. **Never `mkdir ~/.red/redskilled/` here** — the home belongs to `redskilled` (ADR 0130 Amendment 1) and this skill's `.red/` authority is repository-scoped. Re-running is a no-op, so run it on every pass.
-2. If the verdict is not `ok`, print the per-check fix the command already named and stop rather than improvising one. A `daemon-entry` finding is a missing published bundle, cured by warming the bundle for this host and re-running — never by pointing the daemon at a caller's own entry.
-3. Only if the user accepted the optional supervising unit, run `redskilled provision --install-unit` and then tell them the `systemctl --user` commands. The installer writes the unit only when absent; per the no-clobber rule, an existing `redskilled.service` is left exactly as the operator has it.
-4. Do not write anything about the daemon into `.red/config.yaml` — the daemon reads no repository config (ADR 0130 rule 3).
+1. Run `redskilled provision --check` first and report its `presence`. On `running`, print the summary line — version, pid, socket — and skip steps 2 and 3 unless a check row is non-`ok`: the machine has already answered, and re-asking makes a working host indistinguishable from an unconfigured one. On `partial`, say which half is there before curing the other. On `absent`, continue.
+2. Run `redskilled provision`. It creates the host-scoped home, starts the daemon, and prints the audit. **Never `mkdir ~/.red/redskilled/` here** — the home belongs to `redskilled` (ADR 0130 Amendment 1) and this skill's `.red/` authority is repository-scoped. Re-running is a no-op, so run it on every pass.
+3. If the verdict is not `ok`, print the per-check fix the command already named and stop rather than improvising one. A `daemon-entry` finding is a missing published bundle, cured by warming the bundle for this host and re-running — never by pointing the daemon at a caller's own entry.
+4. Only if the user accepted the optional supervising unit, run `redskilled provision --install-unit` and then tell them the `systemctl --user` commands. The installer writes the unit only when absent; per the no-clobber rule, an existing `redskilled.service` is left exactly as the operator has it.
+5. Do not write anything about the daemon into `.red/config.yaml` — the daemon reads no repository config (ADR 0130 rule 3).
 
 If the user accepted Section H, activate the development workflow:
 

--- a/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -166,6 +166,18 @@ The installed version must be `0.3.0`. Record the same pin in `.red/config.yaml`
 
 > Explainer: `redskilled` is the host-scoped execution daemon (ADR 0130): exactly one singleton per machine, behind a unix socket, owning Worker processes across every project on this machine while each project's bundle keeps owning the work. It is what makes "what is this machine currently doing" answerable, and it fails closed — no daemon, no Worker. A daemon starts on first use, but three things must exist before it can: its host-scoped home, a published bundle to run, and a socket that answers.
 
+**Ask the machine before you ask the user.** Open E3 with the read-only probe and let its `presence` decide the section:
+
+```bash
+redskilled provision --check      # presence: running | partial | absent
+```
+
+- **`presence: running`** — a daemon is up. **Report it and move on**; do not re-interview what the machine already answered. Print the `summary` line and its evidence verbatim, e.g. `redskilled detected and running — 3.0.4, pid 533336`, then the socket and the reach row. Silence is not an option: an operator running setup on a working machine wants confirmation, and a step that says nothing is indistinguishable from a step that did nothing. Re-run `redskilled provision` only if the operator asks for it, or if a check row below `presence` is non-`ok`.
+- **`presence: partial`** — half a host: the home (or the bundle) is there and no daemon answers on the socket. **Report it as exactly that** — neither "already set up" nor "nothing here" — and walk the rest of the section to close the missing half.
+- **`presence: absent`** — nothing is provisioned. Walk the full path below.
+
+`--check` observes and never provisions: it creates no home and starts no daemon, so the presence it reports is the machine you walked up to and not one the report brought into being.
+
 **The home is the daemon's, not this skill's.** `~/.red/redskilled/` is operator-scoped and lives outside every checkout, so it is *not* the `.red/` this skill has sole authority over. Its one owner is `provisionRedskilledHome` in `apps/redskilled/src/provision.ts` (ADR 0130 Amendment 1) — never `mkdir` it here, and never treat a repo's ADR 0067 authority as covering it. Setup provisions it by **calling** its owner:
 
 ```bash
@@ -180,7 +192,7 @@ That one command creates the home owner-only (`0700`), starts the daemon through
 Verify afterwards:
 
 ```bash
-redskilled provision --check      # verdict: ok
+redskilled provision --check      # presence: running, verdict: ok
 redskilled host-state             # the machine's Workers, from the daemon itself
 ```
 

--- a/plugins/dev/skills/engineering/red-setup/REFERENCE.md
+++ b/plugins/dev/skills/engineering/red-setup/REFERENCE.md
@@ -33,5 +33,5 @@ Look at the current repo to understand its starting state. Read whatever exists;
 - `.red/agents/` — does this skill's prior output already exist?
 - `.red/config.yaml` — does it exist? Which plugins are already enabled (`plugins.<name>.enabled: true`)? Is the canonical `plugins.dev.lock.primary-branch` flag already set? Is `command_guard` already configured, and under which scopes (`global`, `main`, `worktree`, or legacy `deny`)?
 - `tq --version` and `.red/config.yaml` `host_binaries.tq.version` — is the required host binary present and pinned to `0.3.0`?
-- `redskilled provision --check` — is the daemon provisioned on this host, and if not, which of `home` / `daemon-entry` / `reach` is missing? (Read-only: it creates nothing and starts nothing.)
+- `redskilled provision --check` — what is this machine's `presence` (`running` / `partial` / `absent`), and when it is not `running`, which of `home` / `daemon-entry` / `reach` is missing? A `running` presence names the daemon's version, pid and socket, and Section E3 reports it instead of re-asking. (Read-only: it creates nothing and starts nothing.)
 - `AGENTS.md` and `CLAUDE.md` — does either already have a `## Development workflow` section?

--- a/plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md
+++ b/plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md
@@ -106,10 +106,11 @@ Install and record required host binaries (Section E2):
 
 For Section E3, provision the execution daemon:
 
-1. Run `redskilled provision`. It creates the host-scoped home, starts the daemon, and prints the audit. **Never `mkdir ~/.red/redskilled/` here** — the home belongs to `redskilled` (ADR 0130 Amendment 1) and this skill's `.red/` authority is repository-scoped. Re-running is a no-op, so run it on every pass.
-2. If the verdict is not `ok`, print the per-check fix the command already named and stop rather than improvising one. A `daemon-entry` finding is a missing published bundle, cured by warming the bundle for this host and re-running — never by pointing the daemon at a caller's own entry.
-3. Only if the user accepted the optional supervising unit, run `redskilled provision --install-unit` and then tell them the `systemctl --user` commands. The installer writes the unit only when absent; per the no-clobber rule, an existing `redskilled.service` is left exactly as the operator has it.
-4. Do not write anything about the daemon into `.red/config.yaml` — the daemon reads no repository config (ADR 0130 rule 3).
+1. Run `redskilled provision --check` first and report its `presence`. On `running`, print the summary line — version, pid, socket — and skip steps 2 and 3 unless a check row is non-`ok`: the machine has already answered, and re-asking makes a working host indistinguishable from an unconfigured one. On `partial`, say which half is there before curing the other. On `absent`, continue.
+2. Run `redskilled provision`. It creates the host-scoped home, starts the daemon, and prints the audit. **Never `mkdir ~/.red/redskilled/` here** — the home belongs to `redskilled` (ADR 0130 Amendment 1) and this skill's `.red/` authority is repository-scoped. Re-running is a no-op, so run it on every pass.
+3. If the verdict is not `ok`, print the per-check fix the command already named and stop rather than improvising one. A `daemon-entry` finding is a missing published bundle, cured by warming the bundle for this host and re-running — never by pointing the daemon at a caller's own entry.
+4. Only if the user accepted the optional supervising unit, run `redskilled provision --install-unit` and then tell them the `systemctl --user` commands. The installer writes the unit only when absent; per the no-clobber rule, an existing `redskilled.service` is left exactly as the operator has it.
+5. Do not write anything about the daemon into `.red/config.yaml` — the daemon reads no repository config (ADR 0130 rule 3).
 
 If the user accepted Section H, activate the development workflow:
 


### PR DESCRIPTION
Automated AFK landing for #2959. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2959

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788113960&installation_model_id=20659&pr_number=2963&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2963&signature=55817bcd2e5c4c5a67561e42c704b266fdb48b9d620293fff4943f576adfb968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->