### PR TITLE
fix: the daemon entry fetches its bundle when no local path has one

### DIFF
--- a/.changeset/redskilled-entry-fetch.md
+++ b/.changeset/redskilled-entry-fetch.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A host that has never cached the `redskilled` bundle now fetches one instead of dead-ending. The daemon entry resolver walked local paths only — a pinned env var, the caller's entry, a sibling bundle, the bundle cache — and every one must already exist, so on a fresh machine there was nothing to auto-spawn and rule 7's "a daemon starts on first use" quietly did not hold. `/red-setup` then answered by telling the operator to run `redskilled provision`, the binary that only exists after the thing it is meant to install: the instruction pointed at its own precondition. The resolver gains the missing rung, the same `ensureBundle` the dev launcher already uses. A local entry still wins, so a checkout never loses to a published bundle; the fetch is cache-first, so a warm host pays nothing; and a fetch that cannot run leaves the original diagnostic intact, because "here is every path I looked at" helps an operator more than "npm failed".

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -22,10 +22,10 @@ import { dirname } from "node:path";
 import { isPidAlive, tryAcquireExclusiveLock } from "@reddb-io/shared/resident-core.js";
 import {
   redskilledServeArgv,
-  requireRedskilledEntry,
   type RedskilledEntryLookup,
   type ResolvedRedskilledEntry,
 } from "./daemon-entry.js";
+import { requireRedskilledEntryWithFetch } from "./entry-fetch.js";
 import { socketAnswers } from "./daemon.js";
 import { buildRedskilledNotRunningStop, type RedskilledDaemonStopped } from "./daemon-stop.js";
 import { isRedskilledHostState, type RedskilledHostState } from "./host-state.js";
@@ -183,7 +183,7 @@ async function reachRedskilledDaemon(
     // winner may already have bound, and spawning on top of it is the very
     // second daemon the lock exists to prevent.
     if (await socketAnswers(paths.socketPath)) return "already-running";
-    const spawned = spawnDaemon(paths, config);
+    const spawned = await spawnDaemon(paths, config);
     await waitForDaemon(paths, config, spawned);
     return "spawned";
   } finally {
@@ -599,12 +599,15 @@ async function waitForDaemon(
   }
 }
 
-function spawnDaemon(paths: RedskilledPaths, config: RedskilledClientConfig): SpawnedDaemon {
+async function spawnDaemon(paths: RedskilledPaths, config: RedskilledClientConfig): Promise<SpawnedDaemon> {
   // Resolved before anything is launched: a missing bundle must be a named error
   // (ADR 0130 rule 6), never a process started from whatever the caller happens
   // to be running.
   const stated = config.serverCommand ?? (config.serverArgs != null ? process.execPath : undefined);
-  const entry = requireRedskilledEntry(
+  // A host that has never cached the bundle has no local path to resolve, so the
+  // fetch rung runs BEFORE the fail-closed raise. Local always wins: a checkout's
+  // own entry must never lose to a published one (#2961).
+  const entry = await requireRedskilledEntryWithFetch(
     { ...(stated != null ? { serverCommand: stated } : {}), serverArgs: config.serverArgs },
     config.entryLookup ?? {},
   );

--- a/apps/redskilled/src/entry-fetch.ts
+++ b/apps/redskilled/src/entry-fetch.ts
@@ -1,0 +1,140 @@
+/**
+ * entry-fetch — the rung the daemon entry resolver was missing.
+ *
+ * `resolveRedskilledEntry` walks local paths and nothing else: a pinned env var,
+ * the caller's own entry, a sibling bundle, the bundle cache. Every one of them
+ * must already exist. On a host that has never cached a `redskilled` bundle
+ * there is therefore nothing to auto-spawn, and rule 7's "a daemon starts on
+ * first use" quietly does not hold.
+ *
+ * **The dead end that made it visible.** `/red-setup` reports the daemon absent
+ * and tells the operator to run `redskilled provision` — a binary that only
+ * exists after the thing it is supposed to install. The instruction points at
+ * its own precondition, so an operator on a fresh machine has no move.
+ *
+ * The fix is one rung, not a new mechanism: when every local path misses, fetch
+ * the published bundle the way the dev launcher already does, then resolve
+ * again. `ensureBundle` is cache-first, so a warm host pays nothing and this
+ * path is reached only by the host that would otherwise have failed.
+ *
+ * **Fetching stays the LAST resort.** A local entry always wins — a developer
+ * running from a checkout must not have a published bundle silently preferred
+ * over the code in front of them.
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { ensureBundle, NPM_PACKAGE, type BundleIO } from "@reddb-io/shared/bundle-fetch.js";
+import {
+  isResolvedRedskilledEntry,
+  resolveRedskilledEntry,
+  type RedskilledEntryLookup,
+  type RedskilledEntryOverride,
+  type ResolvedRedskilledEntry,
+  type RedskilledEntryResolution,
+} from "./daemon-entry.js";
+
+/**
+ * The npm-backed IO, built HERE rather than imported from the launcher.
+ *
+ * `entrypoint-cli` owns an equivalent, but it is a CLI entry: importing it drags
+ * a module that runs and exits into the daemon bundle, so the shipped artifact
+ * stopped serving. Forty lines of duplication beats a bundle that terminates.
+ */
+const npmBundleIO: BundleIO = {
+  async materialize(spec, stagingDir) {
+    await mkdir(stagingDir, { recursive: true });
+    const res = spawnSync(
+      "npm",
+      ["install", spec, "--prefix", stagingDir, "--no-save", "--no-audit", "--no-fund", "--ignore-scripts", "--loglevel=error"],
+      { stdio: ["ignore", "ignore", "pipe"], encoding: "utf8" },
+    );
+    if (res.error) throw res.error;
+    if (res.status !== 0) throw new Error(`npm install ${spec} -> ${res.status}: ${(res.stderr || "").trim()}`);
+    return join(stagingDir, "node_modules", ...NPM_PACKAGE.split("/"));
+  },
+  async readFile(path) {
+    return new Uint8Array(await readFile(path));
+  },
+  async writeFile(path, bytes) {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, bytes);
+  },
+  async exists(path) {
+    return existsSync(path);
+  },
+  sha256(bytes) {
+    return createHash("sha256").update(bytes).digest("hex");
+  },
+  async fetchText(url) {
+    const res = await fetch(url, { redirect: "follow" });
+    if (!res.ok) throw new Error(`GET ${url} -> ${res.status}`);
+    return await res.text();
+  },
+};
+
+/** The plugin name the published bundle is filed under. */
+export const REDSKILLED_BUNDLE_PLUGIN = "redskilled";
+
+export interface RedskilledEntryFetchIO {
+  /** Injected so the fetch is provable without a registry. */
+  readonly bundleIO?: BundleIO;
+  /** Which published version to materialise. Absent = the newest stable. */
+  readonly version?: string;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+/** Where bundles are cached, matching the resolver's own candidate root. */
+export function redskilledBundleCacheDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.RED_SKILLS_CACHE_DIR) return env.RED_SKILLS_CACHE_DIR;
+  const xdg = env.XDG_CACHE_HOME || join(env.HOME || homedir(), ".cache");
+  return join(xdg, "red-skills", "bundles");
+}
+
+/**
+ * Resolve the daemon entry, fetching the published bundle only if no local path
+ * has one. Returns the unresolved resolution when the fetch cannot help, so the
+ * caller still raises the same fail-closed error with the same diagnostic.
+ */
+export async function ensureRedskilledEntry(
+  override: RedskilledEntryOverride = {},
+  lookup: RedskilledEntryLookup = {},
+  io: RedskilledEntryFetchIO = {},
+): Promise<RedskilledEntryResolution> {
+  const local = resolveRedskilledEntry(override, lookup);
+  if (isResolvedRedskilledEntry(local)) return local;
+
+  const env = io.env ?? lookup.env ?? process.env;
+  try {
+    await ensureBundle(io.bundleIO ?? npmBundleIO, {
+      plugin: REDSKILLED_BUNDLE_PLUGIN,
+      version: io.version ?? "",
+      cacheDir: redskilledBundleCacheDir(env),
+    });
+  } catch {
+    // A fetch that cannot run leaves the original unresolved answer intact: the
+    // caller's error already names every path it looked at, which is the more
+    // useful diagnostic than "npm failed".
+    return local;
+  }
+
+  // Re-walk rather than trusting the fetch's return path, so the entry a caller
+  // gets is one this resolver would have found on its own next boot.
+  return resolveRedskilledEntry(override, lookup);
+}
+
+/** Resolve-or-throw, with the fetch rung. The shape the spawn path wants. */
+export async function requireRedskilledEntryWithFetch(
+  override: RedskilledEntryOverride = {},
+  lookup: RedskilledEntryLookup = {},
+  io: RedskilledEntryFetchIO = {},
+): Promise<ResolvedRedskilledEntry> {
+  const resolution = await ensureRedskilledEntry(override, lookup, io);
+  if (isResolvedRedskilledEntry(resolution)) return resolution;
+  const { RedskilledDaemonEntryError } = await import("./daemon-entry.js");
+  throw new RedskilledDaemonEntryError(resolution);
+}

--- a/apps/redskilled/tests/entry-fetch.test.ts
+++ b/apps/redskilled/tests/entry-fetch.test.ts
@@ -1,0 +1,145 @@
+// A host that has never cached the bundle had nothing to auto-spawn: the entry
+// resolver walked local paths only, so rule 7's "a daemon starts on first use"
+// did not hold there — and `/red-setup` answered by telling the operator to run
+// `redskilled provision`, the binary that does not exist yet (#2961).
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { isResolvedRedskilledEntry, REDSKILLED_BUNDLE_ASSET } from "../src/daemon-entry.js";
+import { ensureRedskilledEntry, redskilledBundleCacheDir } from "../src/entry-fetch.js";
+import type { BundleIO } from "@reddb-io/shared/bundle-fetch.js";
+
+async function bareHost(): Promise<{ env: NodeJS.ProcessEnv; cacheDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-entry-fetch-"));
+  const cacheDir = join(root, "bundles");
+  await mkdir(cacheDir, { recursive: true });
+  // No RED_SKILLS_* plugin roots, no repo, no cached bundle: the shape of a
+  // machine that has never run any of this.
+  return { env: { HOME: root, RED_SKILLS_CACHE_DIR: cacheDir }, cacheDir };
+}
+
+/** A fetch that lands the bundle where the resolver already looks.
+ *
+ * `exists` reports FALSE until `materialize` has run, because `ensureBundle` is
+ * cache-first: an IO that claims the bundle is already there short-circuits the
+ * fetch, and the test would pass while proving nothing. */
+function fetchingIO(cacheDir: string, onFetch: () => void): BundleIO {
+  let landed = false;
+  return {
+    async materialize() {
+      onFetch();
+      landed = true;
+      await writeFile(join(cacheDir, REDSKILLED_BUNDLE_ASSET), "// bundle\n", "utf8");
+      return cacheDir;
+    },
+    async readFile() {
+      return new Uint8Array(Buffer.from("// bundle\n", "utf8"));
+    },
+    async writeFile(path, bytes) {
+      await writeFile(path, Buffer.from(bytes));
+    },
+    async exists() {
+      return landed;
+    },
+    sha256() {
+      return "";
+    },
+    async fetchText() {
+      return "";
+    },
+  };
+}
+
+describe("the daemon entry resolves on a host that has never cached a bundle", () => {
+  it("is unresolved without the fetch rung — the state that dead-ended /red-setup", async () => {
+    const { env } = await bareHost();
+    // No fetch offered: this is the behaviour that shipped, reproduced.
+    const resolution = await ensureRedskilledEntry(
+      {},
+      { env },
+      {
+        env,
+        bundleIO: {
+          async materialize() {
+            throw new Error("registry unreachable");
+          },
+          async readFile() {
+            return new Uint8Array();
+          },
+          async writeFile() {},
+          async exists() {
+            return false;
+          },
+          sha256() {
+            return "";
+          },
+          async fetchText() {
+            return "";
+          },
+        },
+      },
+    );
+    expect(isResolvedRedskilledEntry(resolution)).toBe(false);
+  });
+
+  it("fetches the published bundle and then resolves", async () => {
+    const { env, cacheDir } = await bareHost();
+    let fetched = 0;
+    const resolution = await ensureRedskilledEntry({}, { env }, { env, bundleIO: fetchingIO(cacheDir, () => { fetched += 1; }) });
+
+    expect(fetched).toBe(1);
+    expect(isResolvedRedskilledEntry(resolution)).toBe(true);
+  });
+
+  it("prefers a local entry and never fetches over it", async () => {
+    const { env, cacheDir } = await bareHost();
+    // A checkout's own bundle must win: a developer running from source must not
+    // silently get the published one instead of the code in front of them.
+    const local = join(cacheDir, REDSKILLED_BUNDLE_ASSET);
+    await writeFile(local, "// local bundle\n", "utf8");
+
+    let fetched = 0;
+    const resolution = await ensureRedskilledEntry({}, { env }, { env, bundleIO: fetchingIO(cacheDir, () => { fetched += 1; }) });
+
+    expect(fetched).toBe(0);
+    expect(isResolvedRedskilledEntry(resolution)).toBe(true);
+  });
+
+  it("keeps the caller's diagnostic when the fetch itself cannot run", async () => {
+    const { env } = await bareHost();
+    const resolution = await ensureRedskilledEntry(
+      {},
+      { env },
+      {
+        env,
+        bundleIO: {
+          async materialize() {
+            throw new Error("offline");
+          },
+          async readFile() {
+            return new Uint8Array();
+          },
+          async writeFile() {},
+          async exists() {
+            return false;
+          },
+          sha256() {
+            return "";
+          },
+          async fetchText() {
+            return "";
+          },
+        },
+      },
+    );
+    // Unresolved, and still carrying the resolver's own account of where it
+    // looked — more useful to an operator than "npm failed".
+    expect(isResolvedRedskilledEntry(resolution)).toBe(false);
+  });
+
+  it("caches into the directory the resolver already searches", async () => {
+    const { env, cacheDir } = await bareHost();
+    expect(redskilledBundleCacheDir(env)).toBe(cacheDir);
+  });
+});


### PR DESCRIPTION
This is why `/red-setup` reports `redskilled is not installed on this host` in every other repository.

`resolveRedskilledEntry` walks local paths and nothing else — a pinned env var, the caller's own entry, a sibling bundle, the bundle cache. **Every one must already exist.** A host that has never cached the bundle therefore has nothing to auto-spawn, and ADR 0130 rule 7 — *a daemon starts on first use* — quietly does not hold there.

The setup path then closes the loop the wrong way: it tells the operator to run `redskilled provision`, which is the binary that only exists after the thing it is supposed to install. **The instruction points at its own precondition**, so an operator on a fresh machine has no move at all.

The fix is one rung, not a new mechanism: when every local path misses, fetch the published bundle with the same `ensureBundle` the dev launcher already uses, then resolve again.

- **A local entry always wins.** A developer running from a checkout must never silently get a published bundle instead of the code in front of them — tested.
- **Cache-first**, so a warm host pays nothing and this path is only reached by the host that would otherwise have failed.
- **A fetch that cannot run keeps the original diagnostic** — the resolver's own list of every path it looked at is more useful than `npm failed`.

The bundle IO is built in this module rather than imported from `entrypoint-cli`. That module is a CLI entry: importing it dragged something that *runs and exits* into the daemon bundle, and `shipped-artifact.test.ts` caught it — the artifact exited instead of serving. Forty lines of duplication beats a bundle that terminates.

408 tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788114620&installation_model_id=20659&pr_number=2965&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2965&signature=62eb0076ab6ac61ad181b175fe545e09f5744bf48d93afd551f3e0affc03d588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->