### PR TITLE
fix: #2964 Re-seed loop charges infra feedback-worktree failures as semantic gate failures, burning the correction budget

### DIFF
--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -372,7 +372,32 @@ export function formatValidationLine(record: ValidationRecord): string {
  */
 export function isInfraFeedbackFailure(feedback: RunFeedbackResult): boolean {
   if (feedback.ok) return false;
-  for (const check of feedback.checks) {
+  return isInfraValidationFailure(feedback.checks);
+}
+
+/**
+ * The minimum a check has to expose to be classified: its status plus the
+ * `red.afk.validation.v1` record whose `summary` carries the evidence. Both
+ * gates already emit exactly this — feedback's {@link FeedbackCheck} and
+ * backpressure's `BackpressureCheck` — which is what lets ONE classifier serve
+ * both instead of the feedback stage owning a guard the backpressure stage
+ * silently lacked (#2964).
+ */
+export interface ClassifiableCheck {
+  status: ValidationStatus;
+  record: ValidationRecord;
+}
+
+/**
+ * INFRA-vs-SEMANTIC classification over any gate's checks — the stage-agnostic
+ * core of {@link isInfraFeedbackFailure}. An operator-declared backpressure
+ * command that never ran because the feedback worktree failed to materialise is
+ * an infra failure by exactly the same evidence a feedback check is; routing it
+ * as semantic charged three correction rounds against a branch whose gate had
+ * not executed a single byte (#2964).
+ */
+export function isInfraValidationFailure(checks: readonly ClassifiableCheck[]): boolean {
+  for (const check of checks) {
     if (check.status !== "failed") continue;
     const exitCode = check.record.exitCode;
     if (exitCode === 0) continue;

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -34,7 +34,8 @@ import {
   buildValidationRecord,
   formatValidationLine,
   runFeedback,
-  isInfraFeedbackFailure,
+  isInfraValidationFailure,
+  type ClassifiableCheck,
   type Exec as PnpmExec,
   type PackageLayout,
   type RunFeedbackResult,
@@ -870,6 +871,43 @@ export async function processIssue(
     if (!correctionBudgetExhausted(correctionLedger, gateSubCap)) return "";
     return ` Post-DONE gate-correction budget exhausted (${describeCorrectionLedger(correctionLedger, gateSubCap)}).`;
   };
+  /**
+   * Classify a FAILED gate stage as INFRA or SEMANTIC, for EITHER stage (#2964).
+   *
+   * The guard used to live inline in the feedback branch alone, so a backpressure
+   * command that never executed — the feedback worktree failed to materialise and
+   * the executor short-circuited to exit 1 with `durationMs: 0` — was charged as
+   * a semantic failure and re-instructed three times against a gate that had run
+   * nothing. Both stages emit the same `red.afk.validation.v1` records, so both
+   * get the same classifier and the same mutable `on_feedback_classify` hook.
+   *
+   * A hook override is HONOURED and NAMED: the returned `note` states what the
+   * classifier said and what the hook made it, so a reclassification is visible
+   * in the record instead of silently rewriting the routing.
+   */
+  const classifyGateFailure = async (
+    stage: "feedback" | "backpressure",
+    checks: readonly ClassifiableCheck[],
+  ): Promise<{ isInfra: boolean; note: string }> => {
+    const classified = isInfraValidationFailure(checks);
+    const classResult = await fireHookCtx(
+      "on_feedback_classify",
+      hookContext({
+        issue,
+        title: input.title,
+        workspace: branch,
+        class: classified ? "infra" : "semantic",
+      }),
+    );
+    const override = parseFeedbackClass(classResult.context);
+    if (override === null) return { isInfra: classified, note: "" };
+    const isInfra = override === "infra";
+    const note =
+      `🤖 classification override: the \`on_feedback_classify\` hook set the ${stage} ` +
+      `failure to \`${override}\` (the classifier read it as ` +
+      `\`${classified ? "infra" : "semantic"}\`).`;
+    return { isInfra, note };
+  };
   /** What the review stage decided, in the fold's own vocabulary plus what the
    * lifecycle must do next. */
   interface ReviewStageResult {
@@ -1337,17 +1375,13 @@ export async function processIssue(
     );
     if (gateVerdict(gateStages).failedStage === "feedback") {
       await writeValidationSidecar(deps, input.attemptDir, feedback.sidecar);
-      let isInfra = isInfraFeedbackFailure(feedback);
-      const classResult = await fireHookCtx(
-        "on_feedback_classify",
-        hookContext({ issue, title: input.title, workspace: branch, class: isInfra ? "infra" : "semantic" }),
-      );
-      const classOverride = parseFeedbackClass(classResult.context);
-      if (classOverride !== null) isInfra = classOverride === "infra";
+      const classification = await classifyGateFailure("feedback", feedback.checks);
+      const isInfra = classification.isInfra;
       const scopeHeader = feedback.validationScope
         ? `${formatValidationScope(feedback.validationScope)}\n`
         : "";
-      const validationText = `${scopeHeader}${feedback.sidecar.join("\n")}`;
+      const overrideFooter = classification.note === "" ? "" : `\n${classification.note}`;
+      const validationText = `${scopeHeader}${feedback.sidecar.join("\n")}${overrideFooter}`;
       // A REPEATED failure buys a HIGHER tier rather than another round at the
       // tier that just failed (ADR 0129 decision 6, #2729). The trigger is the
       // repeat, not the failure: a round that failed a different way is progress
@@ -1389,6 +1423,7 @@ export async function processIssue(
       } else {
         notes = "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.";
       }
+      if (classification.note !== "") notes += ` ${classification.note}`;
       if (!isInfra && (await reseedAfterGate("gate-stage", "feedback", validationText, feedback.sidecar))) {
         continue;
       }
@@ -1416,14 +1451,27 @@ export async function processIssue(
       gateStages.push({ stage: "backpressure", ok: backpressure.ok });
       if (gateVerdict(gateStages).failedStage === "backpressure") {
         await writeValidationSidecar(deps, input.attemptDir, [...feedback.sidecar, ...backpressure.sidecar]);
-        let bpNotes = "Backpressure validation failed after the feedback gate passed. The worker branch was not merged.";
-        const validationText = backpressure.sidecar.join("\n");
-        if (await reseedAfterGate("gate-stage", "backpressure", validationText, backpressure.sidecar)) {
+        // The backpressure stage is classified exactly like the feedback stage
+        // (#2964). It has to be: `bash scripts/gate.sh` failing at `durationMs:
+        // 0` because the feedback worktree never materialised is an environment
+        // failure, and charging it as semantic re-instructed six green branches
+        // three times each against a gate that never executed.
+        const bpClass = await classifyGateFailure("backpressure", backpressure.checks);
+        const bpInfra = bpClass.isInfra;
+        let bpNotes = bpInfra
+          ? `Backpressure validation failed for an INFRA reason (worktree/submodule/pnpm install/OOM) on branch \`${workerBranch}\` — the recovery policy will retry up to its cap.`
+          : "Backpressure validation failed after the feedback gate passed. The worker branch was not merged.";
+        if (bpClass.note !== "") bpNotes += ` ${bpClass.note}`;
+        const overrideFooter = bpClass.note === "" ? "" : `\n${bpClass.note}`;
+        const validationText = `${backpressure.sidecar.join("\n")}${overrideFooter}`;
+        if (!bpInfra && (await reseedAfterGate("gate-stage", "backpressure", validationText, backpressure.sidecar))) {
           continue;
         }
-        bpNotes += correctionBudgetNote();
-        await parkReseedTrail(validationText);
-        return await terminalFailure(common, "feedback-failed", "feedback", {
+        if (!bpInfra) {
+          bpNotes += correctionBudgetNote();
+          await parkReseedTrail(validationText);
+        }
+        return await terminalFailure(common, bpInfra ? "feedback-failed-infra" : "feedback-failed", "feedback", {
           notes: bpNotes,
           validation: validationText,
         }, { validationSummary: validationText });

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -15,7 +15,12 @@
 //
 // When the worktree cannot be materialised (worktreeAdd failure) or the
 // install fails, the gate fails closed: all validation calls return code 1.
-// A failed setup never silently validates the primary checkout.
+// A failed setup never silently validates the primary checkout. It also NAMES
+// its cause (#2964): the blocked message carries which of lock-wait timeout,
+// `worktree add` failure or `pnpm install` failure fired, plus the underlying
+// stderr, so the validation record it lands in is diagnosable on its own. An
+// infra failure that cannot name its own cause turns every occurrence into a
+// fresh investigation.
 //
 // AFK runner improvement — cross-session worktree cache: by default, a
 // materialised worktree whose branch HEAD matches the live branch's HEAD
@@ -351,6 +356,34 @@ export function makeFeedbackWorktree(
   // worktree looks exactly like a hard failure at the first attempt, and
   // latching it made one collision fail every remaining check of the cycle.
   const setupFailures = new Map<string, number>();
+  // WHY the last materialise failed, per branch (#2964). `materialise()` returns
+  // a bare `null` on three distinct paths — lock-wait timeout, `worktree add`
+  // failure, `pnpm install` failure — and until this map existed the underlying
+  // stderr went only to this process's stderr. The validation record then read
+  // `setup failed … validation blocked` with no cause, so every occurrence in
+  // the field became a fresh investigation that could not even confirm which
+  // path fired. The reason SURVIVES latching (it is never cleared by
+  // `noteSetupFailure`) precisely because the latched calls are the ones a
+  // reader sees in the record.
+  const setupFailureReason = new Map<string, string>();
+
+  /** Cap a captured stderr so one cause line stays a summary, not a log dump. */
+  function briefly(detail: string): string {
+    const flat = detail.replace(/\s+/g, " ").trim();
+    return flat.length > 400 ? `${flat.slice(0, 400)}…` : flat;
+  }
+
+  /**
+   * The blocked-validation message for a branch whose worktree never
+   * materialised. The literal prefix is frozen wire vocabulary — the INFRA
+   * classifier (`isInfraValidationFailure`) matches it as a substring — so the
+   * cause is appended after it rather than woven into it.
+   */
+  function setupFailureMessage(branch: string, suffix = "validation blocked"): string {
+    const reason = setupFailureReason.get(branch);
+    const because = reason ? ` (${reason})` : "";
+    return `feedback worktree setup failed for ${branch}; ${suffix}${because}`;
+  }
 
   async function runValidationCommand(
     run: () => Promise<ExecOutput>,
@@ -377,9 +410,10 @@ export function makeFeedbackWorktree(
    * {@link MAX_SETUP_ATTEMPTS} consecutive failures; before that the next
    * validation call retries the baseline step from scratch.
    */
-  function noteSetupFailure(branch: string): null {
+  function noteSetupFailure(branch: string, reason: string): null {
     const attempts = (setupFailures.get(branch) ?? 0) + 1;
     setupFailures.set(branch, attempts);
+    setupFailureReason.set(branch, reason);
     if (attempts >= MAX_SETUP_ATTEMPTS) resolved.set(branch, null);
     return null;
   }
@@ -444,7 +478,10 @@ export function makeFeedbackWorktree(
         `warn: feedback worktree ${dest} is busy (lock wait timed out); ` +
           `baseline setup for ${branch} will be retried\n`,
       );
-      return noteSetupFailure(branch);
+      return noteSetupFailure(
+        branch,
+        `lock wait timed out after ${WORKTREE_LOCK_WAIT_MS}ms for ${dest}`,
+      );
     }
     try {
       return await materialiseLocked(branch, dest, release !== null);
@@ -493,7 +530,10 @@ export function makeFeedbackWorktree(
         `error: feedback worktree add failed for ${branch}; blocking validation: ` +
           `${added.stderr?.trim() || "no git detail"}\n`,
       );
-      return noteSetupFailure(branch);
+      return noteSetupFailure(
+        branch,
+        `worktree add failed: ${briefly(added.stderr ?? "") || "no git detail"}`,
+      );
     }
     // A freshly added worktree has NO node_modules. Without an install here,
     // the feedback gate's `pnpm -C <dest> test/build` calls fail with
@@ -510,7 +550,11 @@ export function makeFeedbackWorktree(
         `error: feedback worktree install failed for ${branch} (exit ${ins.code}); ` +
           `blocking validation\n${ins.stderr.trim()}\n`,
       );
-      return noteSetupFailure(branch);
+      return noteSetupFailure(
+        branch,
+        `pnpm install --frozen-lockfile failed (exit ${ins.code}): ` +
+          `${briefly(ins.stderr) || "no install detail"}`,
+      );
     }
     // AFK runner improvement (Pattern 2): best-effort rebase onto the session
     // base so a worker test written against a now-moved main validates against
@@ -573,7 +617,7 @@ export function makeFeedbackWorktree(
       const { branch, scope } = splitBranchDir(args[cIdx + 1]!, layout.hasPackage);
       const base = await pathFor(branch);
       if (base === null) {
-        return { code: 1, stdout: "", stderr: `feedback worktree setup failed for ${branch}; validation blocked` };
+        return { code: 1, stdout: "", stderr: setupFailureMessage(branch) };
       }
       const rewritten = scope === "." ? base : join(base, scope);
       const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
@@ -598,7 +642,7 @@ export function makeFeedbackWorktree(
   const backpressure: BackpressureExec = async ({ command, cwd, timeoutMs }) => {
     const dir = await pathFor(cwd);
     if (dir === null) {
-      return { code: 1, stdout: "", stderr: `feedback worktree setup failed for ${cwd}; validation blocked` };
+      return { code: 1, stdout: "", stderr: setupFailureMessage(cwd) };
     }
     const env = buildFeedbackSubprocessEnv(process.env, resourceBudget);
     const r = await runValidationCommand(
@@ -618,7 +662,7 @@ export function makeFeedbackWorktree(
   const postWorkerFormat: PostWorkerFormatExec = async ({ command, cwd, timeoutMs }) => {
     const dir = await pathFor(cwd);
     if (dir === null) {
-      return { code: 1, stdout: "", stderr: `feedback worktree setup failed for ${cwd}; format aborted`, committed: false };
+      return { code: 1, stdout: "", stderr: setupFailureMessage(cwd, "format aborted"), committed: false };
     }
 
     const r = await io.exec("sh", ["-c", command], { cwd: dir, timeoutMs });
@@ -667,6 +711,7 @@ export function makeFeedbackWorktree(
       created.clear();
       resolved.clear();
       setupFailures.clear();
+      setupFailureReason.clear();
     },
   };
 }

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -934,3 +934,94 @@ describe("makeFeedbackWorktree — shared baseline serialization (#2437)", () =>
     expect(shared.calls.filter((c) => c.op === "install")).toHaveLength(1);
   });
 });
+
+// #2964 — `materialise()` returns a bare `null` on three distinct paths, and the
+// blocked message named none of them. A field report on `reddb-io/brand` could
+// not conclude which one fired ("lock contention" was stated as a suspicion
+// precisely because the evidence had been thrown away), so every recurrence was
+// a fresh investigation. Each path now carries its own cause into the message
+// the validation record's `summary` is built from.
+describe("makeFeedbackWorktree setup failure names its cause (#2964)", () => {
+  const BROKEN = "afk/w1/9-x";
+
+  it("names a failed `worktree add`, carrying git's own stderr", async () => {
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async () => ({ ok: false, stderr: "fatal: couldn't find remote ref refs/heads/nope" }),
+      worktreeRemove: async () => {},
+      pnpm: async () => ({ code: 0, stdout: "", stderr: "" }),
+      exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+      branchHead: async () => null,
+      worktreeHead: async () => null,
+      rebase: async () => ({ ok: true }),
+    };
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    const r = await fb.backpressure({ command: "bash scripts/gate.sh", cwd: BROKEN, timeoutMs: 1000 });
+
+    expect(r.code).toBe(1);
+    // The literal the INFRA classifier matches survives verbatim…
+    expect(r.stderr).toContain("feedback worktree setup failed");
+    // …and the cause is appended after it.
+    expect(r.stderr).toContain("worktree add failed");
+    expect(r.stderr).toContain("couldn't find remote ref refs/heads/nope");
+  });
+
+  it("names a failed install, with its exit code and pnpm's stderr", async () => {
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async () => ({ ok: true, stderr: "" }),
+      worktreeRemove: async () => {},
+      pnpm: async () => ({ code: 1, stdout: "", stderr: "ERR_PNPM_OUTDATED_LOCKFILE" }),
+      exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+      branchHead: async () => null,
+      worktreeHead: async () => null,
+      rebase: async () => ({ ok: true }),
+    };
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    const r = await fb.backpressure({ command: "bash scripts/gate.sh", cwd: BROKEN, timeoutMs: 1000 });
+
+    expect(r.stderr).toContain("pnpm install --frozen-lockfile failed (exit 1)");
+    expect(r.stderr).toContain("ERR_PNPM_OUTDATED_LOCKFILE");
+    // Distinguishable from the add path — that is the whole point.
+    expect(r.stderr).not.toContain("worktree add failed");
+  });
+
+  it("names a lock-wait timeout, which no other path can be mistaken for", async () => {
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async () => ({ ok: true, stderr: "" }),
+      worktreeRemove: async () => {},
+      pnpm: async () => ({ code: 0, stdout: "", stderr: "" }),
+      exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+      branchHead: async () => null,
+      worktreeHead: async () => null,
+      rebase: async () => ({ ok: true }),
+      lock: async () => null, // the wait timed out
+    };
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    const r = await fb.backpressure({ command: "bash scripts/gate.sh", cwd: BROKEN, timeoutMs: 1000 });
+
+    expect(r.stderr).toContain("lock wait timed out");
+    expect(r.stderr).not.toContain("worktree add failed");
+    expect(r.stderr).not.toContain("pnpm install");
+  });
+
+  it("keeps the cause on the LATCHED calls — the ones a reader actually sees", async () => {
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async () => ({ ok: false, stderr: "fatal: couldn't find remote ref refs/heads/nope" }),
+      worktreeRemove: async () => {},
+      pnpm: async () => ({ code: 0, stdout: "", stderr: "" }),
+      exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+      branchHead: async () => null,
+      worktreeHead: async () => null,
+      rebase: async () => ({ ok: true }),
+    };
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    // Burn through MAX_SETUP_ATTEMPTS so the branch latches to `resolved -> null`.
+    for (let i = 0; i < 3; i++) await fb.backpressure({ command: "x", cwd: BROKEN, timeoutMs: 1000 });
+    const latched = await fb.backpressure({ command: "x", cwd: BROKEN, timeoutMs: 1000 });
+
+    expect(latched.stderr).toContain("worktree add failed");
+  });
+});

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -145,6 +145,10 @@ export interface HarnessOptions {
   /** When false, the backpressure exec returns a non-zero code (a failing gate).
    * Defaults to passing. Only consulted when `backpressureCommands` is set. */
   backpressureOk?: boolean;
+  /** Stderr the backpressure exec reports on a failing command. Models the
+   * short-circuit the feedback-worktree manager returns when `materialise()`
+   * never produced a checkout — the command itself never ran (#2964). */
+  backpressureStderr?: string;
   locked?: boolean;
   /**
    * Landing-mode flag (#842), decoupled from the lock. Defaults to `!locked` so
@@ -618,8 +622,11 @@ export function harness(opts: HarnessOptions = {}): {
     // failing-command output is captured so the envelope/sidecar carry the tail.
     backpressure: async ({ command }) => ({
       code: opts.backpressureOk === false ? 1 : 0,
-      stdout: opts.backpressureOk === false ? `${command} exploded\nstack trace here\n` : "",
-      stderr: "",
+      stdout:
+        opts.backpressureOk === false && opts.backpressureStderr === undefined
+          ? `${command} exploded\nstack trace here\n`
+          : "",
+      stderr: opts.backpressureOk === false ? (opts.backpressureStderr ?? "") : "",
     }),
     backpressureCommands: opts.backpressureCommands,
     outputShaping: opts.outputShaping,

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -288,6 +288,91 @@ describe("processIssue — backpressure fail (#430)", () => {
     expect(bp.summary).toBe("npm run e2e exploded stack trace here");
   });
 
+  // #2964 — six green branches on `reddb-io/brand` parked `blocked:validation`
+  // carrying `backpressure:bash scripts/gate.sh … durationMs: 0`, and each was
+  // re-instructed three times to repair a gate that never executed a byte. The
+  // report guessed at two candidates inside the FEEDBACK stage's classifier;
+  // neither fired. The cause is that the guard was never wired to the
+  // BACKPRESSURE stage at all — `isInfraFeedbackFailure` was consulted only in
+  // the feedback branch, so a backpressure check short-circuited by a failed
+  // `materialise()` fell straight through to `reseedAfterGate`.
+  const WORKTREE_SETUP_FAILED =
+    "feedback worktree setup failed for afk/w1/9-x; validation blocked " +
+    "(pnpm install --frozen-lockfile failed (exit 1): ERR_PNPM_OUTDATED_LOCKFILE)";
+
+  it("REGRESSION: a backpressure check the worktree setup blocked was charged as semantic", async () => {
+    // The failing fixture. With the guard wired to the feedback stage ONLY, this
+    // spent the whole gate share of the Re-seed budget (a second runAgent) and
+    // parked as `feedback-failed`, exactly as the field report describes.
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      backpressureCommands: ["bash scripts/gate.sh"],
+      backpressureOk: false,
+      backpressureStderr: WORKTREE_SETUP_FAILED,
+      reseedGateBudget: 1,
+    });
+    const result = await processIssue(deps, input);
+
+    // No correction round is charged — the branch is never re-instructed.
+    expect(trace.runAgentCalls).toHaveLength(1);
+    // And it parks under the BOUNDED validation-infra policy, not as a worker-
+    // code failure.
+    expect(result.outcome).toBe("feedback-failed-infra");
+  });
+
+  it("names the materialise() cause in the record, so the three setup paths are distinguishable", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      backpressureCommands: ["bash scripts/gate.sh"],
+      backpressureOk: false,
+      backpressureStderr: WORKTREE_SETUP_FAILED,
+    });
+    await processIssue(deps, input);
+
+    const records = trace.sidecarWrites
+      .at(-1)!
+      .lines.map((l) => JSON.parse(l) as { name: string; summary?: string });
+    const bp = records.find((r) => r.name === "backpressure:bash scripts/gate.sh")!;
+    // Not just "setup failed" — WHICH of lock-wait / worktree-add / install.
+    expect(bp.summary).toContain("pnpm install --frozen-lockfile failed");
+    expect(bp.summary).toContain("ERR_PNPM_OUTDATED_LOCKFILE");
+  });
+
+  it("honours a hook that overrides the backpressure classification, and says so in the record", async () => {
+    // The classifier reads this as INFRA; the hook forces SEMANTIC. The override
+    // wins (the routing charges a correction round again) and is NAMED — the
+    // silent rewrite is what made the original diagnosis a guess.
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      backpressureCommands: ["bash scripts/gate.sh"],
+      backpressureOk: false,
+      backpressureStderr: WORKTREE_SETUP_FAILED,
+      reseedGateBudget: 1,
+    });
+    const customDeps: ProcessIssueDeps = {
+      ...deps,
+      hooks: {
+        ...deps.hooks,
+        config: { "afk.hooks.on_feedback_classify": "cls" },
+        exec: async (command) =>
+          command === "cls"
+            ? { code: 0, stdout: JSON.stringify({ class: "semantic" }) }
+            : { code: 0, stdout: "" },
+      },
+    };
+    const result = await processIssue(customDeps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    const envelope = trace.envelopeBodies.join("\n");
+    expect(envelope).toContain("classification override");
+    expect(envelope).toContain("`on_feedback_classify`");
+    expect(envelope).toContain("`semantic`");
+  });
+
   it("merges + closes when feedback and backpressure both pass, sidecar carrying both", async () => {
     const { deps, input, trace } = harness({
       outcome: "done",


### PR DESCRIPTION
Automated AFK landing for #2964. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2964

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788122653&installation_model_id=20659&pr_number=2967&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2967&signature=e66a7c3966579cacfd8334201d328a921404d26574c1c05e1793ba70162764f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->