### PR TITLE
merge: #2968 The daemon idle-exits at 5 minutes but checks for a newer version at 15, so self-replacement can never fire on a quiet host

### DIFF
--- a/.changeset/redskilled-idle-boundary-replace.md
+++ b/.changeset/redskilled-idle-boundary-replace.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The `redskilled` daemon now asks whether it is superseded on its way out, so self-replacement can fire on a quiet host. Two constants disagreed: the daemon idle-exits at five minutes and checked for a newer version at fifteen, so a Worker-free daemon left three times over before the timer's first tick and the upgrade path shipped unable to run anywhere except on a machine busy for a quarter of an hour straight. The failure hid itself — a daemon born after a release reports the right version without ever having upgraded — while every release published under a running host cost a hand-written pinned dispatch. The idle exit is now the check a quiet host reaches: one registry read at the boundary, skipped entirely on a local build, and a replacement there is a restart the live Workers do not notice. The interval stays what it always was, the busy daemon's check, and both declarations now state the relationship rather than encoding it. The published-version read also gained a deadline, because an exit that waits on a registry must be able to stop waiting.

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -159,6 +159,7 @@ import {
 import {
   completeRedskilledReplacement,
   DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
+  isLocalRedskilledBuild,
   isRedskilledSupervised,
   planRedskilledMajorHold,
   planRedskilledReplacement,
@@ -166,6 +167,7 @@ import {
   probePublishedRedskilledVersion,
   readPublishedObservation,
   type RedskilledMajorHold,
+  type RedskilledPublishedObservation,
   type RedskilledPublishedVersionProbe,
   type RedskilledReplacementDecision,
   type RedskilledReplacementIO,
@@ -178,8 +180,29 @@ import {
   type RedskilledLeaseStore,
 } from "./session-lease.js";
 
-/** Default idle window before a Worker-free daemon leaves. */
+/**
+ * Default idle window before a Worker-free daemon leaves.
+ *
+ * **Shorter than `DEFAULT_REDSKILLED_REPLACE_CHECK_MS` (fifteen minutes), which
+ * is why the idle exit asks about the published version on its way out.** A quiet
+ * host's daemon leaves three times over before that interval's first tick, so an
+ * upgrade that only ever rode the timer could not fire here at all (#2968) — and
+ * the failure hid itself, because a daemon born after a release reports the right
+ * version without ever having upgraded. `leaveIdleSession` is the coupling; these
+ * two numbers may move freely, in either direction, without reintroducing it.
+ */
 export const DEFAULT_REDSKILLED_IDLE_MS = 300_000;
+
+/**
+ * How long a published-version read may take before it counts as unresolved.
+ *
+ * A bound rather than a preference: the shipped probe is a `fetch` with no
+ * timeout of its own, and the idle exit now waits on one — a registry that
+ * accepts the connection and never answers would otherwise strand a daemon that
+ * had already decided to leave, holding the session for a host that wanted none.
+ * A read that runs out of time is UNKNOWN, which is the answer that holds.
+ */
+export const DEFAULT_REDSKILLED_PUBLISHED_PROBE_TIMEOUT_MS = 10_000;
 
 /**
  * Default window between memory samples.
@@ -254,6 +277,14 @@ export interface RedskilledDaemonOptions {
   readonly publishedVersion?: RedskilledPublishedVersionProbe;
   /** Window between published-version checks; 0 or below leaves the watch unarmed. */
   readonly replaceCheckMs?: number;
+  /**
+   * How long one published-version read may take before it counts as unresolved.
+   *
+   * Injected so the bound itself is provable: an idle exit that waits on a read
+   * has to be able to stop waiting, and a test that could not shorten the
+   * deadline would have to spend it.
+   */
+  readonly publishedProbeTimeoutMs?: number;
   /** True when a unit will revive this process, so replacing means exiting. */
   readonly supervised?: boolean;
   /** How the successor is found and started; the real handover by default. */
@@ -454,7 +485,13 @@ export interface RedskilledDaemon {
   reattached(): readonly RedskilledWorkerView[];
   /** Resolves once every event handed to the lane has reached disk. */
   flushEvents(): Promise<void>;
-  /** Force the idle check to run now — the timer's body, exposed for tests. */
+  /**
+   * Force the idle check to run now — the timer's body, exposed for tests.
+   *
+   * `"exited"` is the DECISION to give the session up, not a completed exit: a
+   * daemon on its way out first asks whether it should come back newer instead
+   * (#2968), so the leaving finishes on `closed` rather than on this return.
+   */
   evaluateIdle(): "exited" | "held-by-workers" | "held-by-registrations";
   /**
    * Resolve the published version and decide, WITHOUT acting on the decision.
@@ -584,6 +621,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const sampleMs = options.sampleMs ?? DEFAULT_REDSKILLED_SAMPLE_MS;
   const publishedProbe = options.publishedVersion ?? ((running: string) => probePublishedRedskilledVersion(running));
   const replaceCheckMs = options.replaceCheckMs ?? DEFAULT_REDSKILLED_REPLACE_CHECK_MS;
+  const publishedProbeTimeoutMs = options.publishedProbeTimeoutMs ?? DEFAULT_REDSKILLED_PUBLISHED_PROBE_TIMEOUT_MS;
   const supervised = options.supervised ?? isRedskilledSupervised();
   const replacementIO = options.replacementIO ?? {};
   const activityRegistration = options.repositoryActivity;
@@ -1319,13 +1357,39 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
    * be a breaking change arriving on a timer, and staying quiet about it is how a
    * held daemon becomes indistinguishable from a current one (#2926).
    */
-  async function observePublishedVersion(): Promise<RedskilledReplacementDecision> {
-    let observation: { version: string | null; newest?: string | null };
+  /**
+   * One read of the published world, bounded — a throw and a silence both answer
+   * `null`.
+   *
+   * The two failures are the same fact: nothing was resolved. Distinguishing them
+   * would only tempt a caller into treating a slow registry as evidence, and the
+   * deadline exists because the idle exit WAITS on this answer — an unbounded read
+   * would hold a daemon that had already decided to leave.
+   */
+  async function askWhatIsPublished(): Promise<string | null | RedskilledPublishedObservation> {
     try {
-      observation = readPublishedObservation(await publishedProbe(daemonVersion));
+      if (publishedProbeTimeoutMs <= 0) return await publishedProbe(daemonVersion);
+      return await new Promise((resolve) => {
+        const deadline = setTimeout(() => resolve(null), publishedProbeTimeoutMs);
+        deadline.unref();
+        publishedProbe(daemonVersion).then(
+          (answer) => {
+            clearTimeout(deadline);
+            resolve(answer);
+          },
+          () => {
+            clearTimeout(deadline);
+            resolve(null);
+          },
+        );
+      });
     } catch {
-      observation = { version: null, newest: null };
+      return null;
     }
+  }
+
+  async function observePublishedVersion(): Promise<RedskilledReplacementDecision> {
+    const observation = readPublishedObservation(await askWhatIsPublished());
     const observed = observation.version;
     publishedVersion = observed;
     publishedNewest = observation.newest ?? null;
@@ -1458,8 +1522,42 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       armIdleTimer();
       return "held-by-registrations";
     }
-    void stop({ reason: "idle" });
+    void leaveIdleSession();
     return "exited";
+  }
+
+  /**
+   * Leave — as a newer daemon when one is published, or for good.
+   *
+   * **The idle boundary is where a quiet host's daemon asks, because it is the
+   * only moment it ever reaches.** The check interval is three times the idle
+   * window, so this process exits three times over before the timer's first tick;
+   * self-replacement shipped unable to fire here at all (#2968). It is also the
+   * safest instant to ask: nothing is waiting on this socket, and the alternative
+   * already on the table was going away entirely — so an upgrade that fails costs
+   * only the upgrade.
+   *
+   * ONE read, and only when it can decide something. A local build is not a point
+   * on the published lane, so it leaves exactly as it did before, without asking —
+   * which is also why a developer's own daemon never spends a registry read to be
+   * told what it already knows.
+   */
+  async function leaveIdleSession(): Promise<void> {
+    if (!isLocalRedskilledBuild(daemonVersion)) {
+      // A replacement stops this daemon itself, and by a different name: the
+      // successor is what takes the session, so there is no idle exit to make.
+      const decision = await checkForReplacement().catch(() => null);
+      if (decision?.act === "replace") return;
+      if (leaving || stopping) return;
+      // A Worker or a registration that arrived while the registry was being read
+      // holds this daemon exactly as it would have a moment earlier — the read is
+      // a window the instantaneous decision never had.
+      if (workers.size > 0 || registrations.size > 0) {
+        armIdleTimer();
+        return;
+      }
+    }
+    await stop({ reason: "idle" });
   }
 
   /**

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -58,7 +58,20 @@ import { REDSKILLED_SUPERVISED_ENV } from "./supervision.js";
  */
 export const REDSKILLED_REPLACE_EXIT_CODE = 75;
 
-/** How long the daemon waits between published-version checks. */
+/**
+ * How long the daemon waits between published-version checks.
+ *
+ * **This is the BUSY daemon's check, and it is deliberately longer than the idle
+ * window** (`DEFAULT_REDSKILLED_IDLE_MS`, five minutes, in `daemon.ts`). A probe
+ * costs a read of a registry every project on the host shares, so paying it every
+ * few minutes on a quiet machine buys nothing — but a daemon that leaves at five
+ * minutes reaches a fifteen-minute timer never, and shipped alone this interval
+ * made self-replacement unreachable on exactly the hosts where nobody would
+ * notice (#2968). The two numbers are coupled by `leaveIdleSession` in
+ * `daemon.ts`, which asks once at the idle boundary, and not by their ratio:
+ * whoever moves either one changes how often a LIVE daemon looks, never whether
+ * an idle one looks at all.
+ */
 export const DEFAULT_REDSKILLED_REPLACE_CHECK_MS = 900_000;
 
 /** The named diagnostic a replacement emits when the new bundle is unreachable. */

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -14,7 +14,10 @@
 //   3. the swap is a RESTART, not an evacuation: the live Worker survives it and
 //      the new process re-adopts it;
 //   4. the daemon never reports a version it is not running — the published
-//      answer travels beside the running one, never inside it.
+//      answer travels beside the running one, never inside it;
+//   5. the check is REACHABLE — a quiet host's daemon leaves at its idle window,
+//      long before the check interval, so the boundary it leaves through is where
+//      it asks (#2968).
 import { spawn, type ChildProcess } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -28,6 +31,7 @@ import type { RedskilledWorkerView } from "../src/host-state.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { sendRedskilledRequest } from "../src/protocol.js";
 import {
+  DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
   isLocalRedskilledBuild,
   planRedskilledMajorHold,
   planRedskilledReplacement,
@@ -475,5 +479,166 @@ describe("an unsupervised daemon replaces itself", () => {
 
     expect(daemon.reattached().map((view) => view.worker_id)).toEqual(["w-lane"]);
     expect(daemon.hostState().budget_accounting.worker_count).toBe(1);
+  });
+});
+
+// The idle window is five minutes and the check interval is fifteen, so a daemon
+// on a quiet host exits three times over before its first tick: shipped as it
+// was, self-replacement could not fire there once (#2968). The cure is a check at
+// the boundary the idle exit creates — the instant when nothing is waiting on
+// this socket and the alternative on the table was going away entirely.
+describe("the idle boundary, the only check a quiet host ever reaches", () => {
+  it("replaces itself on the way out, on an interval that would never have fired", async () => {
+    const { paths, env, publishedBundle } = await session();
+    const spawns: string[][] = [];
+    let probes = 0;
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 20,
+      // The SHIPPED interval, orders of magnitude past this idle window: whatever
+      // replaces this daemon was decided at the boundary, by nothing else.
+      replaceCheckMs: DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
+      daemonVersion: RUNNING_VERSION,
+      publishedVersion: async () => {
+        probes += 1;
+        return PUBLISHED_VERSION;
+      },
+      replacementIO: { env, spawnSuccessor: (entry, argv) => spawns.push([entry.command, ...argv]) },
+    });
+    running.push(daemon);
+
+    await daemon.closed;
+    expect(await until(async () => spawns.length > 0, 5_000)).toBe(true);
+
+    // One read, at the boundary, and the successor runs the published version.
+    expect(probes).toBe(1);
+    expect(spawns[0]).toContain(publishedBundle);
+    expect(daemon.hostState().upgrade.replacement).toBe("in-progress");
+    // It let go first, so the successor can take the session.
+    expect(await socketAnswers(paths.socketPath)).toBe(false);
+  });
+
+  it("exits as it always did when it is current, having asked exactly once", async () => {
+    const { paths, env } = await session();
+    const spawns: string[] = [];
+    let probes = 0;
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 20,
+      replaceCheckMs: DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
+      daemonVersion: RUNNING_VERSION,
+      publishedVersion: async () => {
+        probes += 1;
+        return RUNNING_VERSION;
+      },
+      replacementIO: { env, spawnSuccessor: (entry) => spawns.push(entry.command) },
+    });
+    running.push(daemon);
+
+    await daemon.closed;
+
+    // The read is spent once, on the way out — never per tick.
+    expect(probes).toBe(1);
+    expect(spawns).toEqual([]);
+    expect(await socketAnswers(paths.socketPath)).toBe(false);
+  });
+
+  it("asks nothing at all on a local build, which no release supersedes", async () => {
+    const { paths, env } = await session();
+    let probes = 0;
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 20,
+      replaceCheckMs: DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
+      daemonVersion: "0.0.0-dev",
+      publishedVersion: async () => {
+        probes += 1;
+        return "9.9.9";
+      },
+      replacementIO: { env },
+    });
+    running.push(daemon);
+
+    await daemon.closed;
+
+    // A source checkout is not a point on the published lane, so the read would
+    // decide nothing and is not spent.
+    expect(probes).toBe(0);
+    expect(await socketAnswers(paths.socketPath)).toBe(false);
+  });
+
+  it("spends no read while Workers hold it — the boundary is an exit, not a tick", async () => {
+    const { paths, env } = await session();
+    let probes = 0;
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 20,
+      replaceCheckMs: DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
+      daemonVersion: RUNNING_VERSION,
+      liveness: () => true,
+      publishedVersion: async () => {
+        probes += 1;
+        return RUNNING_VERSION;
+      },
+      replacementIO: { env },
+    });
+    running.push(daemon);
+    daemon.trackWorker({
+      worker_id: "w-holder",
+      project_label: "acme/widgets",
+      pid: process.pid,
+      started_at: "2026-07-30T00:00:00.000Z",
+      workspace_path: "/tmp/workspace",
+      isolated: false,
+      warnings: [],
+    });
+
+    expect(daemon.evaluateIdle()).toBe("held-by-workers");
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(probes).toBe(0);
+    expect(await socketAnswers(paths.socketPath)).toBe(true);
+  });
+
+  it("loses the upgrade and not the exit when the published bundle is unreachable", async () => {
+    const { paths } = await session();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 20,
+      replaceCheckMs: DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
+      daemonVersion: RUNNING_VERSION,
+      publishedVersion: async () => "3.0.0",
+      // No cache, no dispatch: the successor cannot be found at all.
+      replacementIO: {
+        env: { RED_SKILLS_CACHE_DIR: join(paths.runtimeDir, "empty"), RED_SKILLS_NO_PINNED_DISPATCH: "1" },
+      },
+    });
+    running.push(daemon);
+
+    // The daemon was leaving either way; the failed handover does not strand it.
+    await daemon.closed;
+    expect(await socketAnswers(paths.socketPath)).toBe(false);
+  });
+
+  it("leaves on time when the registry never answers, rather than hanging on the read", async () => {
+    const { paths, env } = await session();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 20,
+      replaceCheckMs: DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
+      publishedProbeTimeoutMs: 50,
+      daemonVersion: RUNNING_VERSION,
+      // A read that resolves never — the shipped one has no timeout of its own.
+      publishedVersion: () => new Promise(() => undefined),
+      replacementIO: { env },
+    });
+    running.push(daemon);
+
+    await daemon.closed;
+
+    // Unresolved stays unresolved: an unanswered read is never a match.
+    expect(daemon.hostState().upgrade.published_unknown).toBe(1);
+    expect(daemon.hostState().upgrade.running_version).toBe(RUNNING_VERSION);
+    expect(await socketAnswers(paths.socketPath)).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=2968 -->
🤖 **Re-seed trail** — #2968 on `afk/2968-the-daemon-idle-exits-at-5-minutes-but-c`, lane `/afk`.

Rounds spent: 1/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

Closes #2968

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788125900&installation_model_id=20659&pr_number=2969&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2969&signature=05d156761b4fad1f598c6bd04a6a327f15c2d2200bc1b18ed0ffc3fad20b14eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->