### PR TITLE
fix: #2966 (branch had 23 commits and no PR)

### DIFF
--- a/.changeset/a-human-only-type-is-never-promoted-into-the-queue.md
+++ b/.changeset/a-human-only-type-is-never-promoted-into-the-queue.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+An unblocked dependent carrying a **HUMAN-ONLY type** is now promoted to `ready-for-human` instead of the autonomous queue (#2966). The unblock sweep and the close cascade read exactly two things about a dependent — its `blocked:dependency` label and its `req:*` edges — and promoted every all-blockers-closed one to `ready-for-agent`. Nothing looked at what kind of Ticket it was, so closing two decision tickets handed four human decisions to agents, and an operator reading `queue_status` saw a healthy queue. On a decision-shaped map most dependents of a decision ticket are themselves decisions: this fired on the normal path, and would fire again on every resolution after.
+
+The lane now follows the dependent's own type. `afk.labels.hitl_types` declares which type labels this repo treats as human-only, and **the names come from that list, never from a built-in one** — a repo whose decision tickets are called something else declares its own and inherits the same protection. The routing lives in the transition planner's `promote`, so every promote path inherits it at once: the boot and periodic unblock sweeps, the event-driven close cascade, the reconcile lane, and the castle's own tracker cascade. The `req:*` edges are consumed either way — the dependency wait genuinely ended; what the blockers closing means is that the *human* may now act, not that an agent may act for them.
+
+The promotion is no longer silent either: the audit comment names the lane it routed to and the type that chose it, so a human can tell a sweep promotion from a hand-set label. A repo that declares no HUMAN-ONLY type is unchanged down to the comment text.

--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -45,7 +45,7 @@ import { pathExists, removeDir } from "../runtime/fs.js";
 import { afkPaths, editLabelsWithStatuslineCache, resolveRepoSlug, statuslineCountCachePath } from "../runtime/wire.js";
 import { branchLockPath, isLocked, readLockedBranch } from "../runtime/lock.js";
 import { resolveBase } from "../core/base-resolver.js";
-import { getConfig, loadConfig, readValidationResourceBudget } from "../core/config.js";
+import { getConfig, loadConfig, readHitlTypeLabels, readValidationResourceBudget } from "../core/config.js";
 import * as ghx from "../runtime/gh.js";
 import * as gitx from "../runtime/git.js";
 import type { GhContext } from "../runtime/gh.js";
@@ -403,6 +403,7 @@ async function runAdoptLanding(
 
     const reconcileDeps: ReconcileDeps = {
       ...HOST_RECONCILE_PORTS,
+      hitlTypes: readHitlTypeLabels(config),
       gh: {
         editLabels: async (n, remove, add) => {
           return editLabelsWithStatuslineCache(

--- a/apps/dev/src/commands/run/reconcile.ts
+++ b/apps/dev/src/commands/run/reconcile.ts
@@ -20,7 +20,7 @@ import * as fsx from "../../runtime/fs.js";
 import type { GhContext } from "../../runtime/gh.js";
 import type { GitContext } from "../../runtime/git.js";
 import { execTool, type ExecFn } from "../../runtime/exec.js";
-import { getConfig, loadConfig, readValidationResourceBudget, resolveTier } from "../../core/config.js";
+import { getConfig, loadConfig, readHitlTypeLabels, readValidationResourceBudget, resolveTier } from "../../core/config.js";
 import { LABEL_MERGE_CONFLICT } from "../../core/triage-labels.js";
 import { createFsIssueLeaseStore } from "@reddb-io/red-castle/engine";
 import { readFile } from "node:fs/promises";
@@ -183,6 +183,7 @@ export function makeBootReconcileRunner(
     }
     const reconcileDeps: ReconcileDeps = {
       ...HOST_RECONCILE_PORTS,
+      hitlTypes: readHitlTypeLabels(reconcileConfig),
       gh: {
         editLabels: async (issue, remove, add) => {
           await ghx.editLabels(ghCtx, issue, remove, add);

--- a/apps/dev/src/core/boot-sweep.ts
+++ b/apps/dev/src/core/boot-sweep.ts
@@ -27,7 +27,7 @@
 /** The literal `## Blocked by` heading line, allowing only trailing whitespace.
  * Mirrors awk `/^## Blocked by[[:space:]]*$/`. */
 import { LABEL_STALLED, LABEL_CRASHED, LABEL_MERGE_CONFLICT, LABEL_DEPENDENCY, LABEL_READY, LABEL_RUNNING, LABEL_HUMAN } from "./triage-labels.js";
-import { isRefused, planTransition } from "./state-transition.js";
+import { hostHitlTypesIn, isRefused, planTransition } from "./state-transition.js";
 import {
   renderIssueReferenceList,
   resolveIssueReferences,
@@ -142,31 +142,68 @@ export interface DependentIssue {
   number: number;
   /** One entry per `req:<n>` label, with `n` resolved to its closed-state. */
   reqs: { n: number; closed: boolean }[];
+  /** Full label set, read to decide the promotion LANE (#2966). Optional for
+   * back-compat with callers that only resolved the dependency edges. */
+  labels?: string[];
+}
+
+/** Which queue a promotion routes to: the autonomous `ready-for-agent` pool, or
+ * the `ready-for-human` park a HUMAN-ONLY type demands (#2966). */
+export type PromotionLane = "agent" | "human";
+
+/**
+ * The lane sentence appended to a promotion's audit comment, so a human reading
+ * the Ticket can tell a sweep promotion from a hand-set label AND see why it
+ * landed where it did. Empty when the repo declares no HUMAN-ONLY type — there
+ * is no routing decision to explain, and such a repo's comments stay exactly as
+ * they were before this rule existed. Pure.
+ */
+export function promotionLaneNote(
+  lane: PromotionLane,
+  carried: readonly string[],
+  declared: readonly string[],
+): string {
+  if (declared.length === 0) return "";
+  if (lane === "human") {
+    return (
+      ` Routed to \`${LABEL_HUMAN}\`: this Ticket carries ${carried.join(", ")}, declared` +
+      ` HUMAN-ONLY in this repo's label vocabulary — a human owns the next move, and the` +
+      ` agent never stands in for their side of it.`
+    );
+  }
+  return ` Routed to \`${LABEL_READY}\`: this Ticket carries no HUMAN-ONLY type.`;
 }
 
 /**
  * Plan the event-driven close cascade triggered when `closedIssue` closes. For
  * each dependent issue carrying `req:closedIssue` (and possibly other `req:*`
- * deps), promote it to `ready-for-agent` IFF EVERY one of its `req:*` deps is
- * now CLOSED (and it has ≥1 dep) — the same all-closed semantics as
- * `shouldPromote`. The audit comment names every now-satisfied dep in ascending
- * order. `refs` holds the dep ids as `#N` strings for parity with the sweep's
- * PromotionPlan. Pure — closed-states are resolved by the caller.
+ * deps), promote it IFF EVERY one of its `req:*` deps is now CLOSED (and it has
+ * ≥1 dep) — the same all-closed semantics as `shouldPromote`. The LANE follows
+ * the dependent's type: a Ticket carrying one of `hitlTypes` routes to
+ * `ready-for-human`, everything else to `ready-for-agent` (#2966). The audit
+ * comment names every now-satisfied dep in ascending order. `refs` holds the dep
+ * ids as `#N` strings for parity with the sweep's PromotionPlan. Pure —
+ * closed-states are resolved by the caller.
  */
 export function planCloseCascade(
   closedIssue: number,
   dependents: readonly DependentIssue[],
+  hitlTypes: readonly string[] = [],
 ): PromotionPlan[] {
   const plans: PromotionPlan[] = [];
   for (const dep of dependents) {
     const states: BlockerState[] = dep.reqs.map((r) => (r.closed ? "CLOSED" : "open-or-unknown"));
     if (!shouldPromote(states)) continue;
     const reqs = dep.reqs.map((r) => r.n).sort((a, b) => a - b);
+    const carried = hostHitlTypesIn(dep.labels ?? [], hitlTypes);
+    const lane: PromotionLane = carried.length > 0 ? "human" : "agent";
     plans.push({
       number: dep.number,
       refs: reqs.map((n) => `#${n}`),
       reqLabels: reqs.map((n) => `req:${n}`),
-      comment: cascadeAuditComment(reqs),
+      comment: cascadeAuditComment(reqs) + promotionLaneNote(lane, carried, hitlTypes),
+      lane,
+      hitlTypes: carried,
     });
   }
   return plans;
@@ -201,6 +238,12 @@ export interface PromotionPlan {
   reqLabels: string[];
   /** The audit comment to post on promotion. */
   comment: string;
+  /** Which queue this promotion routes to (#2966). `human` whenever the Ticket
+   * carries a type the repo's vocabulary declares HUMAN-ONLY. */
+  lane: PromotionLane;
+  /** The declared HUMAN-ONLY type labels the Ticket carries — the reason the
+   * lane is `human`, named in the audit comment. Empty for the agent lane. */
+  hitlTypes: string[];
 }
 
 /**
@@ -220,6 +263,7 @@ export interface PromotionPlan {
 export async function planUnblockSweep(
   candidates: readonly UnblockCandidate[],
   fetchBlockerState: BlockerStateLookup,
+  hitlTypes: readonly string[] = [],
 ): Promise<PromotionPlan[]> {
   const plans: PromotionPlan[] = [];
   for (const candidate of candidates) {
@@ -227,6 +271,10 @@ export async function planUnblockSweep(
     if (!labels.includes(LABEL_DEPENDENCY)) continue;
 
     const reqIds = parseReqLabels(labels);
+    // The LANE is the candidate's own type, not the sweep's default (#2966):
+    // blockers closing frees a HUMAN-ONLY Ticket for its human, never for an agent.
+    const carried = hostHitlTypesIn(labels, hitlTypes);
+    const lane: PromotionLane = carried.length > 0 ? "human" : "agent";
 
     // Prefer the structured req:* dependency labels when present.
     if (reqIds.length > 0) {
@@ -240,7 +288,9 @@ export async function planUnblockSweep(
           number: candidate.number,
           refs: reqIds.map((n) => `#${n}`),
           reqLabels: reqIds.map((n) => `req:${n}`),
-          comment: cascadeAuditComment(reqIds),
+          comment: cascadeAuditComment(reqIds) + promotionLaneNote(lane, carried, hitlTypes),
+          lane,
+          hitlTypes: carried,
         });
       }
       continue;
@@ -259,7 +309,14 @@ export async function planUnblockSweep(
     }
 
     if (shouldPromote(states)) {
-      plans.push({ number: candidate.number, refs, reqLabels: [], comment: auditComment(refs) });
+      plans.push({
+        number: candidate.number,
+        refs,
+        reqLabels: [],
+        comment: auditComment(refs) + promotionLaneNote(lane, carried, hitlTypes),
+        lane,
+        hitlTypes: carried,
+      });
     }
   }
   return plans;
@@ -295,8 +352,9 @@ export async function executeUnblockSweep(
   candidates: readonly UnblockCandidate[],
   fetchBlockerState: BlockerStateLookup,
   gh: UnblockSweepGh,
+  hitlTypes: readonly string[] = [],
 ): Promise<number[]> {
-  const plans = await planUnblockSweep(candidates, fetchBlockerState);
+  const plans = await planUnblockSweep(candidates, fetchBlockerState, hitlTypes);
   // Resolve each promoted issue's holding label from its candidate label set.
   const labelsByIssue = new Map<number, string[]>();
   for (const c of candidates) labelsByIssue.set(c.number, c.labels ?? []);
@@ -307,18 +365,23 @@ export async function executeUnblockSweep(
     // labels were listed: one atomic edit that consumes every req:* edge and
     // provably leaves exactly one state role. The legacy edit survives only for
     // a label-less candidate (degraded listing), where no plan can be proven.
-    const plan = held.length > 0 ? planTransition(held, { kind: "promote" }) : undefined;
+    const plan = held.length > 0 ? planTransition(held, { kind: "promote" }, hitlTypes) : undefined;
     if (plan && !isRefused(plan)) {
       await gh.editLabels(p.number, [...plan.remove], [...plan.add]);
     } else if (plan && isRefused(plan)) {
       continue;
     } else {
       const remove = held.includes(LABEL_DEPENDENCY) ? LABEL_DEPENDENCY : LABEL_HUMAN;
-      await gh.editLabels(p.number, [remove, ...p.reqLabels], [LABEL_READY]);
+      await gh.editLabels(
+        p.number,
+        [remove, ...p.reqLabels],
+        [p.lane === "human" ? LABEL_HUMAN : LABEL_READY],
+      );
     }
     const reqs = p.refs.map(refToNumber).filter((n): n is number => n !== null);
     const comment = p.reqLabels.length > 0 && reqs.length > 0
-      ? await cascadeAuditCommentFor(reqs, gh.issueReference)
+      ? (await cascadeAuditCommentFor(reqs, gh.issueReference)) +
+        promotionLaneNote(p.lane, p.hitlTypes, hitlTypes)
       : p.comment;
     await gh.comment(p.number, comment);
     promoted.push(p.number);

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -93,6 +93,7 @@ import { pathIsInsideTmp, removableUnknownTmpRoots } from "./tmp-janitor.js";
 import type { TmpJanitorPlan, WorkerDirJanitorPlan } from "./tmp-janitor.js";
 import type { WorkerProcessVerdict, WorkerReclaimPlan } from "./worker-reclaim.js";
 import { LABEL_HUMAN, LABEL_QUARANTINE, LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
+import { readHitlTypeLabels } from "./config.js";
 import { isRefused, planTransition, type StateTransition } from "./state-transition.js";
 
 // ---------- precheck (hard preconditions) ----------
@@ -1460,7 +1461,14 @@ async function runUnblockSweep(
 ): Promise<UnblockSweepResult> {
   // Delegate to the shared sweep core so the boot-time safety net and the
   // periodic supervisor sweep (#844) promote through exactly one code path.
-  const promoted = await executeUnblockSweep(candidates, deps.lookups.blockerState, deps.gh);
+  // The repo's own vocabulary decides the LANE (#2966): a dependent carrying a
+  // declared HUMAN-ONLY type parks for its human instead of joining the queue.
+  const promoted = await executeUnblockSweep(
+    candidates,
+    deps.lookups.blockerState,
+    deps.gh,
+    readHitlTypeLabels(deps.config ?? {}),
+  );
   return { promoted };
 }
 

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -985,6 +985,36 @@ export function readBackpressure(values: ConfigValues): string[] {
 }
 
 /**
+ * Read the TYPE labels this repo's installed vocabulary declares HUMAN-ONLY
+ * (`afk.labels.hitl_types`, #2966). A Ticket carrying one resolves only through
+ * a live exchange with a human, so an unblock sweep or close cascade routes it
+ * to `ready-for-human` instead of the executable queue. The list form
+ *
+ *   afk:
+ *     labels:
+ *       hitl_types:
+ *         - wayfinder:grilling
+ *         - wayfinder:prototype
+ *
+ * materialises as the indexed keys `afk.labels.hitl_types.0`, … which this reads
+ * back in order until the first gap; the namespaced `plugins.dev.*` location
+ * folds down in {@link loadConfig} (ADR 0042). A single-line scalar is accepted
+ * as a one-label list. Absent/empty → `[]`, and a repo that declares none keeps
+ * the pre-#2966 behaviour exactly — every promotion goes to the agent lane.
+ */
+export function readHitlTypeLabels(values: Record<string, string | undefined>): string[] {
+  const indexed: string[] = [];
+  for (let i = 0; ; i++) {
+    const v = values[`afk.labels.hitl_types.${i}`];
+    if (v === undefined) break;
+    if (v.trim() !== "") indexed.push(v.trim());
+  }
+  if (indexed.length > 0) return indexed;
+  const scalar = values["afk.labels.hitl_types"];
+  return scalar && scalar.trim() !== "" ? [scalar.trim()] : [];
+}
+
+/**
  * Read the operator-declared post-attempt-format command list
  * (`afk.post_attempt_format`), in declaration order (#1015). The list form
  *

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -66,7 +66,7 @@ import {
 } from "../worker-outcome.js";
 import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookName } from "../hook-config.js";
 import { formatStartedMarker } from "../heartbeat.js";
-import { cascadeAuditCommentFor, parseReqLabels, planCloseCascade, type DependentIssue } from "../boot-sweep.js";
+import { cascadeAuditCommentFor, parseReqLabels, planCloseCascade, promotionLaneNote, type DependentIssue } from "../boot-sweep.js";
 import { isRefused, parkOrHuman, planTransition, transitionLabels } from "../state-transition.js";
 import { deriveOutcomeRecord } from "../outcome-record.js";
 import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
@@ -81,7 +81,7 @@ import {
   type RepoVisibility,
   type ActorTrustSignals,
 } from "../trust-gate.js";
-import { getConfig } from "../config.js";
+import { getConfig, readHitlTypeLabels } from "../config.js";
 import type { AfkModelTier, ConfigValues } from "../config.js";
 import { runNotesLoop, notesPath, type NotesLoopConfig } from "../notes-loop.js";
 import {
@@ -846,13 +846,17 @@ export async function runCloseCascade(deps: ProcessIssueDeps, closedIssue: numbe
       dependents.push({ number: dep.number, reqs });
     }
     const labelsByNumber = new Map(dependentsRaw.map((dep) => [dep.number, dep.labels]));
-    const plans = planCloseCascade(closedIssue, dependents);
+    for (const dep of dependents) dep.labels = labelsByNumber.get(dep.number);
+    // A dependent carrying a type this repo declares HUMAN-ONLY parks for its
+    // human instead of joining the autonomous queue (#2966).
+    const hitlTypes = readHitlTypeLabels(deps.hooks.config);
+    const plans = planCloseCascade(closedIssue, dependents, hitlTypes);
     for (const p of plans) {
       // Promote through the ADR 0122 transition API (#2528): one atomic edit
       // that consumes every req:* edge and provably leaves exactly one state
       // role, so a cascade can never stack ready-for-agent onto a park.
       const current = labelsByNumber.get(p.number);
-      const plan = current ? planTransition(current, { kind: "promote" }) : undefined;
+      const plan = current ? planTransition(current, { kind: "promote" }, hitlTypes) : undefined;
       if (plan && !isRefused(plan)) {
         await deps.gh.editLabels(p.number, [...plan.remove], [...plan.add]);
       } else {
@@ -860,10 +864,18 @@ export async function runCloseCascade(deps: ProcessIssueDeps, closedIssue: numbe
           deps.appendIterLog(`🤖 close-cascade promote refused for #${p.number}: ${plan.reason}`);
           continue;
         }
-        await deps.gh.editLabels(p.number, [LABEL_DEPENDENCY, ...p.reqLabels], [LABEL_READY]);
+        await deps.gh.editLabels(
+          p.number,
+          [LABEL_DEPENDENCY, ...p.reqLabels],
+          [p.lane === "human" ? LABEL_HUMAN : LABEL_READY],
+        );
       }
       const reqs = p.refs.map((ref) => Number(ref.slice(1))).filter((n) => Number.isFinite(n));
-      await deps.gh.comment(p.number, await cascadeAuditCommentFor(reqs, deps.gh.issueReference));
+      await deps.gh.comment(
+        p.number,
+        (await cascadeAuditCommentFor(reqs, deps.gh.issueReference)) +
+          promotionLaneNote(p.lane, p.hitlTypes, hitlTypes),
+      );
     }
   } catch (err) {
     deps.appendIterLog(

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -54,7 +54,7 @@ import type { deleteRemote, pushAttempt, GitExec } from "./remote-branch.js";
 import { type LandLock } from "./land-lock.js";
 import type { emitEnvelope, EmitEnvelopeDeps } from "./envelope-emit.js";
 import { parseCurrentBlocker } from "./blocker-state.js";
-import { cascadeAuditCommentFor, parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
+import { cascadeAuditCommentFor, parseReqLabels, planCloseCascade, promotionLaneNote, type DependentIssue } from "./boot-sweep.js";
 import { type RecoveryEnv } from "./recovery.js";
 import { dispose } from "./disposition.js";
 import { parkOrHuman, transitionLabels, type StateTransition } from "./state-transition.js";
@@ -195,6 +195,10 @@ export interface ReconcileDeps {
   remoteBranch: ReconcileRemoteBranchPort;
   /** The triage-label vocabulary, injected as config (castle convention). */
   labels: TriageLabelConfig;
+  /** The TYPE labels this repo declares HUMAN-ONLY (`afk.labels.hitl_types`,
+   * #2966). A close cascade routes a dependent carrying one to the human lane.
+   * Absent → none declared, and every promotion keeps the agent lane. */
+  hitlTypes?: readonly string[];
   /** git executor for merge.ts (integrateOrigin / landMerge / landPr). */
   mergeExec: MergeExec;
   /** git executor for remote-branch.ts (pushAttempt / deleteRemote). */
@@ -908,11 +912,13 @@ async function applyReconcileTransition(
   issue: number,
   labels: string[],
   transition: StateTransition,
+  hitlTypes: readonly string[] = [],
 ): Promise<boolean> {
   const result = await transitionLabels(
     (remove, add) => deps.gh.editLabels(issue, remove, add),
     labels,
     transition,
+    hitlTypes,
   );
   if (result.applied) return result.ok;
   deps.appendIterLog(
@@ -1035,15 +1041,24 @@ async function runCloseCascade(deps: ReconcileDeps, closedIssue: number): Promis
     // and lands on `ready-for-agent` in ONE proven edit (#2663). The planner
     // needs the dependent's CURRENT labels, which the listing already carried.
     const labelsOf = new Map(dependentsRaw.map((d) => [d.number, d.labels]));
-    for (const p of planCloseCascade(closedIssue, dependents)) {
+    for (const dep of dependents) dep.labels = labelsOf.get(dep.number);
+    // The dependent's own type decides the lane (#2966): a HUMAN-ONLY Ticket
+    // parks for its human rather than rejoining the autonomous queue.
+    const hitlTypes = deps.hitlTypes ?? [];
+    for (const p of planCloseCascade(closedIssue, dependents, hitlTypes)) {
       await applyReconcileTransition(
         deps,
         p.number,
         labelsOf.get(p.number) ?? [deps.labels.dependency, ...p.reqLabels],
         { kind: "promote" },
+        hitlTypes,
       );
       const reqs = p.refs.map((ref) => Number(ref.slice(1))).filter((n) => Number.isFinite(n));
-      await deps.gh.comment(p.number, await cascadeAuditCommentFor(reqs, deps.gh.issueReference));
+      await deps.gh.comment(
+        p.number,
+        (await cascadeAuditCommentFor(reqs, deps.gh.issueReference)) +
+          promotionLaneNote(p.lane, p.hitlTypes, hitlTypes),
+      );
     }
   } catch (err) {
     deps.appendIterLog(

--- a/apps/dev/src/core/state-transition.ts
+++ b/apps/dev/src/core/state-transition.ts
@@ -16,6 +16,7 @@
 // that engine code routes through this API.
 
 import {
+  hitlTypesIn,
   isRefused,
   planTransition as planTransitionWithLabels,
   stateRoleLabels,
@@ -79,8 +80,27 @@ export function stateRolesOf(labels: readonly string[]): string[] {
 export function planTransition(
   current: readonly string[],
   transition: StateTransition,
+  hitlTypes: readonly string[] = [],
 ): TransitionPlan | RefusedTransition {
-  return planTransitionWithLabels(current, transition, HOST_STATE_TRANSITION_LABELS);
+  return planTransitionWithLabels(current, transition, hostLabels(hitlTypes));
+}
+
+/** The host vocabulary with this repo's declared HUMAN-ONLY type labels folded
+ * in (#2966). The spellings are constants; the HITL types are per-repo config,
+ * so they arrive at the call site rather than at module load. */
+function hostLabels(hitlTypes: readonly string[]): StateTransitionLabels {
+  return hitlTypes.length === 0
+    ? HOST_STATE_TRANSITION_LABELS
+    : { ...HOST_STATE_TRANSITION_LABELS, hitlTypes };
+}
+
+/** The declared HUMAN-ONLY type labels `current` carries (empty when the repo
+ * declares none). Callers use it to explain the lane in their audit comment. */
+export function hostHitlTypesIn(
+  current: readonly string[],
+  hitlTypes: readonly string[],
+): string[] {
+  return hitlTypesIn(current, hostLabels(hitlTypes));
 }
 
 /**
@@ -120,8 +140,9 @@ export async function transitionLabels(
   edit: (remove: string[], add: string[]) => Promise<unknown>,
   current: readonly string[],
   transition: StateTransition,
+  hitlTypes: readonly string[] = [],
 ): Promise<TransitionLabelsResult> {
-  const plan = planTransition(current, transition);
+  const plan = planTransition(current, transition, hitlTypes);
   if (isRefused(plan)) return { applied: false, ...plan };
   const result = await edit([...plan.remove], [...plan.add]);
   return { applied: true, ok: result !== false, plan };

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -97,6 +97,7 @@ import {
   getConfig,
   loadConfig,
   readBackpressure,
+  readHitlTypeLabels,
   readValidationResourceBudget,
 } from "./core/config.js";
 import * as gitx from "./runtime/git.js";
@@ -510,6 +511,11 @@ export function createDefaultDevAfkMcpOperations(
       const context = await resolveRepoContext(root);
       const gh = { cwd: context.root, repo: context.repo };
       const candidates = await ghx.listUnblockCandidates(gh);
+      // The lane comes from THIS repo's installed vocabulary (#2966), so a
+      // HUMAN-ONLY dependent parks for its human instead of joining the queue.
+      const hitlTypes = readHitlTypeLabels(
+        loadConfig(afkPaths(root).configPath, { warn: () => undefined }),
+      );
       const promoted = await executeUnblockSweep(
         candidates,
         async (issue) => ((await ghx.issueClosed(gh, issue)) ? "CLOSED" : "OPEN"),
@@ -520,6 +526,7 @@ export function createDefaultDevAfkMcpOperations(
           comment: (issue, body) => ghx.comment(gh, issue, body),
           issueReference: (issue) => ghx.issueReference(gh, issue),
         },
+        hitlTypes,
       );
       return { promoted };
     },
@@ -631,22 +638,29 @@ export function createDefaultDevAfkMcpOperations(
         if (!reqs.includes(input.issue)) continue;
         dependents.push({
           number,
+          labels: row.labels,
           reqs: reqs.map((n) => ({
             n,
             closed: (states.get(n)?.state ?? "").toUpperCase() === "CLOSED",
           })),
         });
       }
+      // An operator reading this projection must see WHERE each promotion would
+      // land, not just that it would happen (#2966).
+      const hitlTypes = readHitlTypeLabels(
+        loadConfig(afkPaths(root).configPath, { warn: () => undefined }),
+      );
       return {
         issue: input.issue,
         dependents: dependents.map((dependent) => ({
           number: dependent.number,
           reqs: dependent.reqs,
         })),
-        promotable: planCloseCascade(input.issue, dependents).map((plan) => ({
+        promotable: planCloseCascade(input.issue, dependents, hitlTypes).map((plan) => ({
           number: plan.number,
           refs: plan.refs,
           req_labels: plan.reqLabels,
+          lane: plan.lane,
         })),
       };
     },

--- a/apps/dev/tests/boot-sweep.test.ts
+++ b/apps/dev/tests/boot-sweep.test.ts
@@ -118,7 +118,7 @@ describe("planCloseCascade", () => {
       { number: 20, reqs: [{ n: 9, closed: true }] },
     ];
     expect(planCloseCascade(9, deps)).toEqual([
-      { number: 20, refs: ["#9"], reqLabels: ["req:9"], comment: "🤖 /afk unblocked: all dependencies closed (#9)." },
+      { number: 20, refs: ["#9"], reqLabels: ["req:9"], comment: "🤖 /afk unblocked: all dependencies closed (#9).", lane: "agent", hitlTypes: [] },
     ]);
   });
 
@@ -139,7 +139,7 @@ describe("planCloseCascade", () => {
       { number: 30, reqs: [{ n: 9, closed: true }, { n: 8, closed: true }] },
     ];
     expect(planCloseCascade(9, deps)).toEqual([
-      { number: 30, refs: ["#8", "#9"], reqLabels: ["req:8", "req:9"], comment: "🤖 /afk unblocked: all dependencies closed (#8, #9)." },
+      { number: 30, refs: ["#8", "#9"], reqLabels: ["req:8", "req:9"], comment: "🤖 /afk unblocked: all dependencies closed (#8, #9).", lane: "agent", hitlTypes: [] },
     ]);
   });
 
@@ -207,6 +207,8 @@ describe("planUnblockSweep", () => {
         refs: ["#1", "#2"],
         reqLabels: [],
         comment: "🤖 /afk promoted to ready-for-agent: all blockers closed (#1, #2).",
+        lane: "agent",
+        hitlTypes: [],
       },
     ]);
     expect(lookup.calls).toEqual([1, 2]);
@@ -266,6 +268,8 @@ describe("planUnblockSweep", () => {
         refs: ["#101", "#102"],
         reqLabels: ["req:101", "req:102"],
         comment: "🤖 /afk unblocked: all dependencies closed (#101, #102).",
+        lane: "agent",
+        hitlTypes: [],
       },
     ]);
     // The body ref (#999) was never consulted — only the req:* deps.
@@ -292,6 +296,8 @@ describe("planUnblockSweep", () => {
         refs: ["#1"],
         reqLabels: [],
         comment: "🤖 /afk promoted to ready-for-agent: all blockers closed (#1).",
+        lane: "agent",
+        hitlTypes: [],
       },
     ]);
   });
@@ -412,6 +418,131 @@ describe("executeUnblockSweep", () => {
 
     expect(promoted).toEqual([7]);
     expect(rec.edits.map((e) => e.issue)).toEqual([7]);
+  });
+});
+
+// #2966: the sweep promoted EVERY unblocked dependent into the autonomous queue,
+// so closing a decision Ticket handed the human's own decisions to an agent. The
+// HUMAN-ONLY types are read from the repo's installed label vocabulary
+// (`afk.labels.hitl_types`) — never from a hard-coded `wayfinder:*` list.
+describe("executeUnblockSweep — HUMAN-ONLY type routing", () => {
+  const lookupFor = (states: Record<number, string | undefined>) => async (n: number) => states[n];
+  const HITL_TYPES = ["wayfinder:grilling", "wayfinder:prototype"];
+
+  function recordingGh() {
+    const edits: Array<{ issue: number; remove: string[]; add: string[] }> = [];
+    const comments: Array<{ issue: number; body: string }> = [];
+    return {
+      edits,
+      comments,
+      gh: {
+        editLabels: async (issue: number, remove: string[], add: string[]) => {
+          edits.push({ issue, remove, add });
+        },
+        comment: async (issue: number, body: string) => {
+          comments.push({ issue, body });
+        },
+      },
+    };
+  }
+
+  it("routes a dependent carrying a declared HUMAN-ONLY type to ready-for-human", async () => {
+    const candidates: UnblockCandidate[] = [
+      { number: 12, labels: ["blocked:dependency", "req:8", "wayfinder:grilling"], body: "" },
+    ];
+    const rec = recordingGh();
+    const promoted = await executeUnblockSweep(
+      candidates,
+      lookupFor({ 8: "CLOSED" }),
+      rec.gh,
+      HITL_TYPES,
+    );
+
+    expect(promoted).toEqual([12]);
+    expect(rec.edits).toEqual([
+      { issue: 12, remove: ["blocked:dependency", "req:8"], add: ["ready-for-human"] },
+    ]);
+    expect(rec.comments[0]!.body).toContain("all dependencies closed (#8)");
+    expect(rec.comments[0]!.body).toContain("`ready-for-human`");
+    expect(rec.comments[0]!.body).toContain("wayfinder:grilling");
+  });
+
+  it("still routes a dependent with no HUMAN-ONLY type to ready-for-agent", async () => {
+    const candidates: UnblockCandidate[] = [
+      { number: 13, labels: ["blocked:dependency", "req:8", "wayfinder:task"], body: "" },
+    ];
+    const rec = recordingGh();
+    const promoted = await executeUnblockSweep(
+      candidates,
+      lookupFor({ 8: "CLOSED" }),
+      rec.gh,
+      HITL_TYPES,
+    );
+
+    expect(promoted).toEqual([13]);
+    expect(rec.edits).toEqual([
+      { issue: 13, remove: ["blocked:dependency", "req:8"], add: ["ready-for-agent"] },
+    ]);
+    expect(rec.comments[0]!.body).toContain("`ready-for-agent`");
+  });
+
+  it("leaves a repo that declares no HUMAN-ONLY type byte-identical to before", async () => {
+    const candidates: UnblockCandidate[] = [
+      { number: 12, labels: ["blocked:dependency", "req:8", "wayfinder:grilling"], body: "" },
+    ];
+    const rec = recordingGh();
+    await executeUnblockSweep(candidates, lookupFor({ 8: "CLOSED" }), rec.gh, []);
+
+    expect(rec.edits).toEqual([
+      { issue: 12, remove: ["blocked:dependency", "req:8"], add: ["ready-for-agent"] },
+    ]);
+    expect(rec.comments).toEqual([
+      { issue: 12, body: "🤖 /afk unblocked: all dependencies closed (#8)." },
+    ]);
+  });
+
+  it("names every HUMAN-ONLY type the dependent carries", async () => {
+    const candidates: UnblockCandidate[] = [
+      {
+        number: 14,
+        labels: ["blocked:dependency", "req:8", "wayfinder:grilling", "wayfinder:prototype"],
+        body: "",
+      },
+    ];
+    const rec = recordingGh();
+    await executeUnblockSweep(candidates, lookupFor({ 8: "CLOSED" }), rec.gh, HITL_TYPES);
+
+    expect(rec.comments[0]!.body).toContain("wayfinder:grilling, wayfinder:prototype");
+  });
+
+  it("routes the legacy `## Blocked by` promotion by the same rule", async () => {
+    const candidates: UnblockCandidate[] = [
+      {
+        number: 15,
+        labels: ["blocked:dependency", "wayfinder:prototype"],
+        body: "## Blocked by\n- [x] #8\n",
+      },
+    ];
+    const rec = recordingGh();
+    await executeUnblockSweep(candidates, lookupFor({ 8: "CLOSED" }), rec.gh, HITL_TYPES);
+
+    expect(rec.edits).toEqual([
+      { issue: 15, remove: ["blocked:dependency"], add: ["ready-for-human"] },
+    ]);
+  });
+
+  it("plans the lane so a close cascade routes a HUMAN-ONLY dependent too", () => {
+    const dependents: DependentIssue[] = [
+      { number: 12, labels: ["blocked:dependency", "req:8", "wayfinder:grilling"], reqs: [{ n: 8, closed: true }] },
+      { number: 13, labels: ["blocked:dependency", "req:8"], reqs: [{ n: 8, closed: true }] },
+    ];
+    const plans = planCloseCascade(8, dependents, HITL_TYPES);
+
+    expect(plans.map((p) => [p.number, p.lane])).toEqual([
+      [12, "human"],
+      [13, "agent"],
+    ]);
+    expect(plans[0]!.hitlTypes).toEqual(["wayfinder:grilling"]);
   });
 });
 

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -12,6 +12,7 @@ import {
   MalformedConfigError,
   parseConfigYaml,
   readBackpressure,
+  readHitlTypeLabels,
   readValidationResourceBudget,
   downgradeAfkModelTier,
   resolveTier,
@@ -799,6 +800,24 @@ describe("config — block sequences (afk.backpressure, #430)", () => {
   it("readBackpressure returns [] when absent (the gate is a no-op)", () => {
     const values = loadConfig("/x/.red/config.yaml", { ignoreActivationGate: true, read: () => "afk:\n  default_runner: codex\n" });
     expect(readBackpressure(values)).toEqual([]);
+  });
+
+  it("readHitlTypeLabels reads the declared HUMAN-ONLY types in order", () => {
+    const text =
+      "plugins:\n  dev:\n    afk:\n      labels:\n        hitl_types:\n          - wayfinder:grilling\n          - wayfinder:prototype\n";
+    const values = loadConfig("/x/.red/config.yaml", { ignoreActivationGate: true, read: () => text });
+    expect(readHitlTypeLabels(values)).toEqual(["wayfinder:grilling", "wayfinder:prototype"]);
+  });
+
+  it("readHitlTypeLabels accepts a single-line scalar as a one-label list", () => {
+    const text = "afk:\n  labels:\n    hitl_types: wayfinder:grilling\n";
+    const values = loadConfig("/x/.red/config.yaml", { ignoreActivationGate: true, read: () => text });
+    expect(readHitlTypeLabels(values)).toEqual(["wayfinder:grilling"]);
+  });
+
+  it("readHitlTypeLabels returns [] when the repo declares no HUMAN-ONLY type", () => {
+    const values = loadConfig("/x/.red/config.yaml", { ignoreActivationGate: true, read: () => "afk:\n  default_runner: codex\n" });
+    expect(readHitlTypeLabels(values)).toEqual([]);
   });
 });
 

--- a/apps/dev/tests/label-vocabulary-docs.test.ts
+++ b/apps/dev/tests/label-vocabulary-docs.test.ts
@@ -381,6 +381,25 @@ describe("wayfinder docs", () => {
     }
   });
 
+  // #2966: the unblock sweep queued HITL tickets for agents because nothing
+  // told it which types are human-only. The declaration is per-repo config, so
+  // the docs that teach it are the only thing standing between a consumer repo
+  // and the same defect.
+  it("teaches the HUMAN-ONLY type declaration in every doc a consumer installs", async () => {
+    const skill = await readRepoFile("plugins/dev/skills/engineering/wayfinder/SKILL.md");
+    const labels = await readRepoFile("plugins/dev/skills/engineering/red-setup/triage-labels.md");
+    const config = await readRepoFile("plugins/dev/skills/engineering/afk/docs/CONFIG.md");
+    const operations = await readRepoFile("plugins/dev/skills/engineering/afk/docs/OPERATIONS.md");
+
+    for (const doc of [skill, labels, config, operations]) {
+      expect(doc).toContain("hitl_types");
+    }
+    expect(labels).toContain("ready-for-human");
+    expect(config).toContain("ready-for-human");
+    // The whole point of the key: the names are the repo's, not ours.
+    expect(config).toContain("never from a built-in one");
+  });
+
   it("pins the fidelity-restoration directives from upstream v1.1.0", async () => {
     const skill = await readRepoFile("plugins/dev/skills/engineering/wayfinder/SKILL.md");
 

--- a/apps/dev/tests/state-transition-contract.test.ts
+++ b/apps/dev/tests/state-transition-contract.test.ts
@@ -131,12 +131,12 @@ const ALLOWLIST = new Map<string, string>([
   // never listed, or claim / PR / maintainer-command vocabulary that is not an
   // issue STATE transition at all.
   [
-    "apps/dev/src/core/boot-sweep.ts :: await gh.editLabels(p.number, [remove, ...p.reqLabels], [LABEL_READY]);",
-    "unblock-sweep fallback when the candidate's labels were not listed (#2528)",
+    'apps/dev/src/core/boot-sweep.ts :: await gh.editLabels( p.number, [remove, ...p.reqLabels], [p.lane === "human" ? LABEL_HUMAN : LABEL_READY], );',
+    "unblock-sweep fallback when the candidate's labels were not listed (#2528); the lane still follows the planned HUMAN-ONLY routing (#2966)",
   ],
   [
-    "apps/dev/src/core/process-issue/terminal.ts :: await deps.gh.editLabels(p.number, [LABEL_DEPENDENCY, ...p.reqLabels], [LABEL_READY]);",
-    "close-cascade fallback when the dependent's labels were not listed (#2528)",
+    'apps/dev/src/core/process-issue/terminal.ts :: await deps.gh.editLabels( p.number, [LABEL_DEPENDENCY, ...p.reqLabels], [p.lane === "human" ? LABEL_HUMAN : LABEL_READY], );',
+    "close-cascade fallback when the dependent's labels were not listed (#2528); the lane still follows the planned HUMAN-ONLY routing (#2966)",
   ],
   // --- claim machinery: ready<->running swaps are claims, not state transitions ---
   [

--- a/apps/dev/tests/tsconfig-import-hygiene.test.ts
+++ b/apps/dev/tests/tsconfig-import-hygiene.test.ts
@@ -23,7 +23,7 @@ const DEV_UNUSED_IMPORT_DEBT: Record<string, number> = {
   "src/core/dashboard.ts": 1,
   "src/core/process-issue/lifecycle.ts": 61,
   "src/core/process-issue/recovery.ts": 92,
-  "src/core/process-issue/terminal.ts": 76,
+  "src/core/process-issue/terminal.ts": 75,
   "src/core/process-issue/types.ts": 72,
   "src/core/review-extract.ts": 1,
   "src/core/session.ts": 3,

--- a/packages/red-castle/src/engine/config.test.ts
+++ b/packages/red-castle/src/engine/config.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   loadEngineConfig,
   parseEngineConfigYaml,
+  readEngineHitlTypeLabels,
   readEngineLabelVocabulary,
   readEngineBackpressure,
 } from "./config.js";
@@ -151,6 +152,58 @@ describe("engine config reader", () => {
       dependencyBlocked: "wait:dependency",
       blockedPrefix: "blocked:",
       reqPrefix: "depends-on:",
+      hitlTypes: [],
     });
+  });
+
+  it("reads the declared HUMAN-ONLY type labels as a list", () => {
+    const redRoot = redRootWithConfig(
+      [
+        "plugins:",
+        "  dev:",
+        "    enabled: true",
+        "    afk:",
+        "      labels:",
+        "        hitl_types:",
+        "          - wayfinder:grilling",
+        "          - wayfinder:prototype",
+        "",
+      ].join("\n"),
+    );
+
+    const cfg = loadEngineConfig(redRoot, { env: {} });
+
+    expect(readEngineHitlTypeLabels(cfg)).toEqual([
+      "wayfinder:grilling",
+      "wayfinder:prototype",
+    ]);
+    expect(readEngineLabelVocabulary(cfg).hitlTypes).toEqual([
+      "wayfinder:grilling",
+      "wayfinder:prototype",
+    ]);
+  });
+
+  it("accepts a single HUMAN-ONLY type written as a scalar", () => {
+    const redRoot = redRootWithConfig(
+      [
+        "plugins:",
+        "  dev:",
+        "    enabled: true",
+        "    afk:",
+        "      labels:",
+        "        hitl_types: wayfinder:grilling",
+        "",
+      ].join("\n"),
+    );
+
+    expect(readEngineHitlTypeLabels(loadEngineConfig(redRoot, { env: {} }))).toEqual([
+      "wayfinder:grilling",
+    ]);
+  });
+
+  it("declares no HUMAN-ONLY type when the repo never opted in", () => {
+    const redRoot = redRootWithConfig("plugins:\n  dev:\n    enabled: true\n");
+
+    expect(readEngineHitlTypeLabels(loadEngineConfig(redRoot, { env: {} }))).toEqual([]);
   });
 });

--- a/packages/red-castle/src/engine/config.ts
+++ b/packages/red-castle/src/engine/config.ts
@@ -261,8 +261,29 @@ export function readEngineBackpressure(config: EngineConfig): string[] {
   return scalar && scalar.trim() !== "" ? [scalar] : [];
 }
 
+/**
+ * The TYPE labels this repo declares HUMAN-ONLY (`afk.labels.hitl_types`), as a
+ * YAML list or a single scalar. A dependent carrying one is promoted to the
+ * human lane instead of the executable queue (red-skills #2966). A repo that
+ * declares none gets `[]` — the reason an existing repo's promotions are
+ * unchanged by this key's arrival.
+ */
+export function readEngineHitlTypeLabels(config: EngineConfig): string[] {
+  const indexed: string[] = [];
+  for (let i = 0; ; i++) {
+    const value = config.values[`afk.labels.hitl_types.${i}`];
+    if (value === undefined) break;
+    if (value.trim() !== "") indexed.push(value.trim());
+  }
+  if (indexed.length > 0) return indexed;
+
+  const scalar = config.values["afk.labels.hitl_types"];
+  return scalar && scalar.trim() !== "" ? [scalar.trim()] : [];
+}
+
 export function readEngineLabelVocabulary(config: EngineConfig): EngineLabelVocabulary {
   return {
+    hitlTypes: readEngineHitlTypeLabels(config),
     ready: config.get("afk.labels.ready"),
     running: config.get("afk.labels.running"),
     human: config.get("afk.labels.human"),

--- a/packages/red-castle/src/engine/state-transition.test.ts
+++ b/packages/red-castle/src/engine/state-transition.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   applyTransition,
+  hitlTypesIn,
   isRefused,
   planTransition,
   stateRoleLabels,
@@ -46,6 +47,47 @@ describe("planTransition", () => {
     const p = plan(["blocked:dependency", "req:12", "req:3"], { kind: "promote" });
     expect(p.add).toEqual(["ready-for-agent"]);
     expect(p.remove).toEqual(["blocked:dependency", "req:3", "req:12"]);
+  });
+
+  it("promote: routes a HITL-typed dependent to the human lane, edges still consumed", () => {
+    const hitl: StateTransitionLabels = { ...labels, hitlTypes: ["wayfinder:grilling"] };
+    const p = planTransition(
+      ["blocked:dependency", "req:8", "req:9", "wayfinder:grilling"],
+      { kind: "promote" },
+      hitl,
+    );
+    if (isRefused(p)) throw new Error(`unexpected refusal: ${p.reason}`);
+    expect(p.add).toEqual(["ready-for-human"]);
+    expect(p.remove).toEqual(["blocked:dependency", "req:8", "req:9"]);
+  });
+
+  it("promote: a vocabulary declaring no HITL type re-queues the same dependent", () => {
+    const p = plan(["blocked:dependency", "req:8", "wayfinder:grilling"], { kind: "promote" });
+    expect(p.add).toEqual(["ready-for-agent"]);
+    expect(p.remove).toEqual(["blocked:dependency", "req:8"]);
+  });
+
+  it("promote: a dependent outside the HITL vocabulary still re-queues", () => {
+    const hitl: StateTransitionLabels = { ...labels, hitlTypes: ["wayfinder:grilling"] };
+    const p = planTransition(
+      ["blocked:dependency", "req:8", "wayfinder:task"],
+      { kind: "promote" },
+      hitl,
+    );
+    if (isRefused(p)) throw new Error(`unexpected refusal: ${p.reason}`);
+    expect(p.add).toEqual(["ready-for-agent"]);
+  });
+
+  it("hitlTypesIn: names the declared human-only types the label set carries", () => {
+    const hitl: StateTransitionLabels = {
+      ...labels,
+      hitlTypes: ["wayfinder:grilling", "wayfinder:prototype"],
+    };
+    expect(hitlTypesIn(["bug", "wayfinder:prototype", "req:3"], hitl)).toEqual([
+      "wayfinder:prototype",
+    ]);
+    expect(hitlTypesIn(["bug"], hitl)).toEqual([]);
+    expect(hitlTypesIn(["wayfinder:prototype"], labels)).toEqual([]);
   });
 
   it("park: swaps the blocked reason without stacking a second one", () => {

--- a/packages/red-castle/src/engine/state-transition.ts
+++ b/packages/red-castle/src/engine/state-transition.ts
@@ -38,6 +38,27 @@ export interface StateTransitionLabels {
   readonly blockedPrefix: string;
   /** The prefix of a dependency edge label (`req:{issue}`). */
   readonly reqPrefix: string;
+  /**
+   * The TYPE labels this repo's vocabulary declares HUMAN-ONLY (red-skills
+   * #2966). A ticket carrying one resolves only through a live exchange with a
+   * human, so a `promote` routes it to {@link human} instead of the executable
+   * queue — the blockers closing means the human may now act, never that an
+   * agent may act for them. A vocabulary that declares none (the default) leaves
+   * every promotion in the autonomous lane, exactly as before.
+   */
+  readonly hitlTypes?: readonly string[];
+}
+
+/**
+ * The declared HUMAN-ONLY type labels `current` carries, in vocabulary order.
+ * Empty when the repo declares no HITL type — the reason a repo that never
+ * opted in keeps its previous behaviour. Pure.
+ */
+export function hitlTypesIn(
+  current: readonly string[],
+  labels: StateTransitionLabels,
+): string[] {
+  return (labels.hitlTypes ?? []).filter((type) => current.includes(type));
 }
 
 /** Every label that counts as a STATE ROLE, in the deterministic order the
@@ -110,13 +131,24 @@ export function stateRolesOf(
 }
 
 /** The single role the transition targets, or `null` for the terminal `close`
- * transition — the one state an issue reaches by carrying no role at all. */
-function targetRole(t: StateTransition, labels: StateTransitionLabels): string | null {
+ * transition — the one state an issue reaches by carrying no role at all.
+ *
+ * `promote` is the one transition whose target depends on the ISSUE and not
+ * only on the request: a dependent carrying a declared HUMAN-ONLY type lands in
+ * the human lane. The edges are consumed either way — the dependency wait is
+ * genuinely over; only who acts next differs.
+ */
+function targetRole(
+  t: StateTransition,
+  labels: StateTransitionLabels,
+  current: readonly string[],
+): string | null {
   switch (t.kind) {
     case "close":
       return null;
-    case "queue":
     case "promote":
+      return hitlTypesIn(current, labels).length > 0 ? labels.human : labels.ready;
+    case "queue":
       return labels.ready;
     case "park":
     case "human":
@@ -172,7 +204,7 @@ export function planTransition(
     };
   }
 
-  const target = targetRole(transition, labels);
+  const target = targetRole(transition, labels, current);
   const add = new Set<string>();
   const remove = new Set<string>();
 

--- a/packages/red-castle/src/engine/tracker/dependencies.test.ts
+++ b/packages/red-castle/src/engine/tracker/dependencies.test.ts
@@ -186,6 +186,37 @@ describe("tracker unblock sweep", () => {
       },
     ]);
   });
+
+  it("routes a dependent carrying a declared HUMAN-ONLY type to the human lane", async () => {
+    const tracker = fakeTracker({
+      issues: new Map([
+        [7, { body: "", labels: [], closed: true }],
+        [
+          20,
+          {
+            body: "",
+            labels: ["wait:dependency", "depends-on:7", "wayfinder:grilling"],
+            closed: false,
+          },
+        ],
+      ]),
+      labelIndex: new Map([["wait:dependency", [20]]]),
+    });
+
+    await expect(
+      executeUnblockSweep({
+        tracker,
+        labels: { ...labels, hitlTypes: ["wayfinder:grilling"] },
+      }),
+    ).resolves.toEqual([20]);
+    expect(tracker.edits).toEqual([
+      {
+        issue: 20,
+        remove: ["wait:dependency", "depends-on:7"],
+        add: ["queue:human"],
+      },
+    ]);
+  });
 });
 
 // The promotion WRITE moved to planTransition in #2666. These rows pin the

--- a/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
@@ -157,6 +157,22 @@ afk:
 
 **This is how maintainers tell an inner agent the exact gate it must satisfy — without ad-hoc `-r` retry guidance.** When `afk.backpressure` is set, every inner-agent handoff carries a `<merge-gate>` section listing the configured commands verbatim, and the agent's exit-protocol completion contract instructs it to run and pass those commands *before* emitting `<promise>DONE</promise>` (issue #849). The contract distinguishes two kinds of check: the **touched-package confidence checks** the agent runs while developing (the package's own `test`/`typecheck`/`lint`/`build`) versus the **binding merge gate** the orchestrator enforces after DONE (these backpressure commands plus `drift-guard`). So for repos with a broader gate than any single touched package — `cargo fmt --all -- --check`, a workspace-wide `cargo clippy`, an integration smoke — declare it once under `afk.backpressure` and the agent sees and satisfies it on the first attempt instead of bouncing as `blocked:validation`. On an automatic re-queue, the prior failure's summary remains visible through `<prev-failure-context>`, so the next agent can target the real blocker. The agent is told **not** to re-run an unbounded full repository suite after its final commit; the listed gate commands are the contract.
 
+### HUMAN-ONLY ticket types
+
+`afk.labels.hitl_types` is the list of TYPE labels this repo declares human-only. **A dependent carrying one is promoted to `ready-for-human`, never into the autonomous queue** (issue #2966): its blockers closing means the *human* may now act, not that an agent may act for them. Both promote paths honour it — the boot/periodic unblock sweep and the event-driven close cascade — and the `req:*` edges are consumed either way, so the dependency wait genuinely ends; only the lane differs.
+
+```yaml
+plugins:
+  dev:
+    afk:
+      labels:
+        hitl_types:
+          - wayfinder:grilling
+          - wayfinder:prototype
+```
+
+The audit comment then names the lane and the type that chose it, so an operator reading the Ticket can tell a sweep promotion from a hand-set label. **The names come from this list, never from a built-in one** — a repo whose decision tickets are called something else declares its own and inherits the same protection. An absent or empty list is today's behaviour exactly: every unblocked dependent reaches `ready-for-agent`, with the pre-existing comment text unchanged. A single-line scalar is accepted as a one-label list, and the namespaced `plugins.dev.afk.labels.hitl_types` location folds down like every other key (ADR 0042).
+
 ### Merge-gate policy
 
 The unlocked admin-merge (`gh pr merge --admin --merge`, ADR 0030) **ignores advisory review checks by default** — this is intentional, not an oversight. The binding gates on a landing are:

--- a/packaging/pi/dev/skills/engineering/afk/docs/OPERATIONS.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/OPERATIONS.md
@@ -148,7 +148,7 @@ Dependencies are first-class **`req:N` edge labels** (one per blocker), and a de
 
 1. `gh issue list --label req:N --state open --json number,labels`.
 2. For each dependent, read its `req:*` labels and resolve each referenced issue's state (the just-closed #N is known closed; others via a cached lookup).
-3. When **every** `req:*` of a dependent is now closed: `gh issue edit --remove-label blocked:dependency --add-label ready-for-agent` + post `🤖 /afk unblocked: all dependencies closed (#…)`.
+3. When **every** `req:*` of a dependent is now closed: `gh issue edit --remove-label blocked:dependency --add-label ready-for-agent` + post `🤖 /afk unblocked: all dependencies closed (#…)`. **The lane follows the dependent's TYPE**: one carrying a label declared under `afk.labels.hitl_types` gets `ready-for-human` instead, because its blockers closing frees the *human* to act, not an agent (#2966).
 
 Best-effort: a `gh` failure here logs a `warn:` and never fails the close — the boot sweep below catches anything the cascade missed.
 
@@ -157,7 +157,7 @@ Best-effort: a `gh` failure here logs a `warn:` and never fails the close — th
 1. `gh issue list` for open `blocked:dependency` issues with `number,labels,body`.
 2. Deps come from the `req:*` labels (the source of truth); for pre-`req:N` issues with no such label, fall back to extracting `#N` refs under the literal `## Blocked by` body heading (`- [ ] #N`) only when the issue is still labelled `blocked:dependency`.
 3. Resolve each dep via `gh issue view <N> --json state`; promote only when **every** dep is `CLOSED`.
-4. On promotion: remove the holding label (`blocked:dependency`), add `ready-for-agent`, post the audit comment, and log `unblocked N issue(s): #A #B`.
+4. On promotion: remove the holding label (`blocked:dependency`), add `ready-for-agent` — or `ready-for-human` when the dependent carries a HUMAN-ONLY type (`afk.labels.hitl_types`, see [CONFIG.md](./CONFIG.md)) — post the audit comment, and log `unblocked N issue(s): #A #B`. The comment names the lane it routed to and why, so a human can tell a sweep promotion from a hand-set label.
 
 `ready-for-human` is a human gate, not dependency-wait. The boot sweep must not promote it from a legacy `## Blocked by` body parse, because a closed blocker can still encode a failed measurement or a no-go decision. `blocked:dependency` issues do not have that ambiguity: the label *means* dependency-wait, which is the whole point of separating it from `ready-for-human`.
 

--- a/packaging/pi/dev/skills/engineering/red-setup/triage-labels.md
+++ b/packaging/pi/dev/skills/engineering/red-setup/triage-labels.md
@@ -101,6 +101,22 @@ The issue body contains a complete `## Agent brief` section (see `triage/AGENT-B
 ### `ready-for-human`
 The issue requires human decision or resolution before it can proceed or be delegated. Two sources: `/triage` decides it during evaluation (e.g. architectural call, design review needed), or `/afk` promotes it from `running` after a blocker (inner agent gave up, merge conflict couldn't be auto-resolved, both runners exhausted). When `/afk` promotes, the worktree is **preserved at the moment of blocker** so the human can inspect or resolve the blocker in place.
 
+### HUMAN-ONLY types (`afk.labels.hitl_types`)
+
+**A type can be declared human-only, and the dependency machinery then routes it to `ready-for-human` instead of the queue.** A Ticket of such a type resolves only through a live exchange with a human — an agent answering its own grilling questions has broken exactly the thing the type exists to protect. List those type labels in `.red/config.yaml`:
+
+```yaml
+plugins:
+  dev:
+    afk:
+      labels:
+        hitl_types:
+          - wayfinder:grilling
+          - wayfinder:prototype
+```
+
+When the last `req:N` blocker of a dependent carrying one of these labels closes, the unblock sweep and the close cascade promote it to **`ready-for-human`** (edges consumed, `blocked:dependency` shed) rather than `ready-for-agent`, and the audit comment names the lane and the type that chose it. **Declare your own repo's names here — the routing reads this list, never a built-in `wayfinder:*` list**, so a repo whose decision tickets are called something else inherits the same protection. A repo that declares none behaves exactly as before: every unblocked dependent goes to `ready-for-agent`.
+
 ### `quarantine`
 An issue-local safety hold for mechanically detected queue incoherence (ADR 0122). The probe removes `ready-for-agent`, adds `quarantine`, and appends its diagnosis to the issue body; healthy sibling issues continue through the same boot. The castle resident curator periodically re-runs the coherence check. It removes `quarantine` and restores `ready-for-agent` when the defect dissolves, or replaces `quarantine` with `ready-for-human` after three failed re-checks so `/hitl` owns the judgment. The per-issue heal ledger uses the same hold instead of applying a third heal within 24 hours.
 
@@ -140,8 +156,8 @@ These exist for filtering and don't drive lifecycle transitions:
 | `spec:{N}`      | Issue belongs to Spec #N                         | `/to-tickets` when splitting a Spec |
 | `wayfinder:map` | Planning map Ticket for work too large for one agent session. Carries `## Destination`, `## Not yet specified`, and `## Out of scope`; the map is an index, not a store. | `/wayfinder` |
 | `wayfinder:research` | Wayfinder child type for AFK-typed research scoped to one session. Unblocked children use `ready-for-agent`; blocked children use `blocked:dependency` plus `req:N`. | `/wayfinder` |
-| `wayfinder:grilling` | Wayfinder child type for HITL-typed decision work routed to a `/start` session and claimed by assignment. | `/wayfinder` |
-| `wayfinder:prototype` | Wayfinder child type for HITL-typed design or logic exploration routed to a `/prototype` session and claimed by assignment. | `/wayfinder` |
+| `wayfinder:grilling` | Wayfinder child type for HITL-typed decision work routed to a `/start` session and claimed by assignment. Declare it under `afk.labels.hitl_types` so an unblocked grilling Ticket parks for its human instead of joining the agent queue. | `/wayfinder` |
+| `wayfinder:prototype` | Wayfinder child type for HITL-typed design or logic exploration routed to a `/prototype` session and claimed by assignment. Declare it under `afk.labels.hitl_types` alongside `wayfinder:grilling`. | `/wayfinder` |
 | `wayfinder:task` | Wayfinder child type for AFK-typed implementation/docs work scoped to one session. Unblocked children use `ready-for-agent`; blocked children use `blocked:dependency` plus `req:N`. | `/wayfinder` |
 | `runner-error` | `/afk` fleet supervisor parked a slot after fast-death streak; affected issues were restored to `ready-for-agent` after the runner was discarded | `/afk` fleet supervisor on circuit trip |
 | `landing:manual` | Per-issue **manual-landing** mode (#1049): on a `ready-for-agent` issue, `/afk` runs the full pipeline + opens the PR, then **holds for a human's merge click** (parks `ready-for-human`, never auto-merges, never re-runs the agent). The issue auto-closes on PR merge via `Closes #N`. Lets agent-codable slices that must not be auto-merged stay in the autonomous lane instead of being hand-dispatched via `/go`. | `/triage` at brief time, or `/hitl`'s **delegable-manual-landing** disposition |

--- a/packaging/pi/dev/skills/engineering/wayfinder/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/wayfinder/SKILL.md
@@ -74,6 +74,8 @@ The answer isn't part of the body — it's recorded on resolution (see [Work thr
 
 Every ticket is either **HITL** — human in the loop, worked *with* a human who speaks for themselves — or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this).
 
+**Declare the HITL types to the tracker, or the dependency machinery will queue them for an agent.** On a decision-shaped map most dependents of a decision ticket are themselves grilling or prototype, so every resolution would push human decisions into the autonomous lane (#2966). List them once in `.red/config.yaml` under `plugins.dev.afk.labels.hitl_types` — `wayfinder:grilling` and `wayfinder:prototype` for this skill's vocabulary — and an unblocked HITL child parks `ready-for-human` instead. See [triage-labels.md](../red-setup/triage-labels.md) *HUMAN-ONLY types*.
+
 - **Research** (AFK): Reading documentation, third-party APIs, or local resources like knowledge bases to surface a fact a decision waits on. Resolved by a `/research` **subagent**. Use when knowledge outside the current working directory is required.
 - **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
 - **Grilling** (HITL): Conversation via the /start skills, one question at a time. The default case.

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -157,6 +157,22 @@ afk:
 
 **This is how maintainers tell an inner agent the exact gate it must satisfy — without ad-hoc `-r` retry guidance.** When `afk.backpressure` is set, every inner-agent handoff carries a `<merge-gate>` section listing the configured commands verbatim, and the agent's exit-protocol completion contract instructs it to run and pass those commands *before* emitting `<promise>DONE</promise>` (issue #849). The contract distinguishes two kinds of check: the **touched-package confidence checks** the agent runs while developing (the package's own `test`/`typecheck`/`lint`/`build`) versus the **binding merge gate** the orchestrator enforces after DONE (these backpressure commands plus `drift-guard`). So for repos with a broader gate than any single touched package — `cargo fmt --all -- --check`, a workspace-wide `cargo clippy`, an integration smoke — declare it once under `afk.backpressure` and the agent sees and satisfies it on the first attempt instead of bouncing as `blocked:validation`. On an automatic re-queue, the prior failure's summary remains visible through `<prev-failure-context>`, so the next agent can target the real blocker. The agent is told **not** to re-run an unbounded full repository suite after its final commit; the listed gate commands are the contract.
 
+### HUMAN-ONLY ticket types
+
+`afk.labels.hitl_types` is the list of TYPE labels this repo declares human-only. **A dependent carrying one is promoted to `ready-for-human`, never into the autonomous queue** (issue #2966): its blockers closing means the *human* may now act, not that an agent may act for them. Both promote paths honour it — the boot/periodic unblock sweep and the event-driven close cascade — and the `req:*` edges are consumed either way, so the dependency wait genuinely ends; only the lane differs.
+
+```yaml
+plugins:
+  dev:
+    afk:
+      labels:
+        hitl_types:
+          - wayfinder:grilling
+          - wayfinder:prototype
+```
+
+The audit comment then names the lane and the type that chose it, so an operator reading the Ticket can tell a sweep promotion from a hand-set label. **The names come from this list, never from a built-in one** — a repo whose decision tickets are called something else declares its own and inherits the same protection. An absent or empty list is today's behaviour exactly: every unblocked dependent reaches `ready-for-agent`, with the pre-existing comment text unchanged. A single-line scalar is accepted as a one-label list, and the namespaced `plugins.dev.afk.labels.hitl_types` location folds down like every other key (ADR 0042).
+
 ### Merge-gate policy
 
 The unlocked admin-merge (`gh pr merge --admin --merge`, ADR 0030) **ignores advisory review checks by default** — this is intentional, not an oversight. The binding gates on a landing are:

--- a/plugins/dev/skills/engineering/afk/docs/OPERATIONS.md
+++ b/plugins/dev/skills/engineering/afk/docs/OPERATIONS.md
@@ -148,7 +148,7 @@ Dependencies are first-class **`req:N` edge labels** (one per blocker), and a de
 
 1. `gh issue list --label req:N --state open --json number,labels`.
 2. For each dependent, read its `req:*` labels and resolve each referenced issue's state (the just-closed #N is known closed; others via a cached lookup).
-3. When **every** `req:*` of a dependent is now closed: `gh issue edit --remove-label blocked:dependency --add-label ready-for-agent` + post `🤖 /afk unblocked: all dependencies closed (#…)`.
+3. When **every** `req:*` of a dependent is now closed: `gh issue edit --remove-label blocked:dependency --add-label ready-for-agent` + post `🤖 /afk unblocked: all dependencies closed (#…)`. **The lane follows the dependent's TYPE**: one carrying a label declared under `afk.labels.hitl_types` gets `ready-for-human` instead, because its blockers closing frees the *human* to act, not an agent (#2966).
 
 Best-effort: a `gh` failure here logs a `warn:` and never fails the close — the boot sweep below catches anything the cascade missed.
 
@@ -157,7 +157,7 @@ Best-effort: a `gh` failure here logs a `warn:` and never fails the close — th
 1. `gh issue list` for open `blocked:dependency` issues with `number,labels,body`.
 2. Deps come from the `req:*` labels (the source of truth); for pre-`req:N` issues with no such label, fall back to extracting `#N` refs under the literal `## Blocked by` body heading (`- [ ] #N`) only when the issue is still labelled `blocked:dependency`.
 3. Resolve each dep via `gh issue view <N> --json state`; promote only when **every** dep is `CLOSED`.
-4. On promotion: remove the holding label (`blocked:dependency`), add `ready-for-agent`, post the audit comment, and log `unblocked N issue(s): #A #B`.
+4. On promotion: remove the holding label (`blocked:dependency`), add `ready-for-agent` — or `ready-for-human` when the dependent carries a HUMAN-ONLY type (`afk.labels.hitl_types`, see [CONFIG.md](./CONFIG.md)) — post the audit comment, and log `unblocked N issue(s): #A #B`. The comment names the lane it routed to and why, so a human can tell a sweep promotion from a hand-set label.
 
 `ready-for-human` is a human gate, not dependency-wait. The boot sweep must not promote it from a legacy `## Blocked by` body parse, because a closed blocker can still encode a failed measurement or a no-go decision. `blocked:dependency` issues do not have that ambiguity: the label *means* dependency-wait, which is the whole point of separating it from `ready-for-human`.
 

--- a/plugins/dev/skills/engineering/red-setup/triage-labels.md
+++ b/plugins/dev/skills/engineering/red-setup/triage-labels.md
@@ -101,6 +101,22 @@ The issue body contains a complete `## Agent brief` section (see `triage/AGENT-B
 ### `ready-for-human`
 The issue requires human decision or resolution before it can proceed or be delegated. Two sources: `/triage` decides it during evaluation (e.g. architectural call, design review needed), or `/afk` promotes it from `running` after a blocker (inner agent gave up, merge conflict couldn't be auto-resolved, both runners exhausted). When `/afk` promotes, the worktree is **preserved at the moment of blocker** so the human can inspect or resolve the blocker in place.
 
+### HUMAN-ONLY types (`afk.labels.hitl_types`)
+
+**A type can be declared human-only, and the dependency machinery then routes it to `ready-for-human` instead of the queue.** A Ticket of such a type resolves only through a live exchange with a human — an agent answering its own grilling questions has broken exactly the thing the type exists to protect. List those type labels in `.red/config.yaml`:
+
+```yaml
+plugins:
+  dev:
+    afk:
+      labels:
+        hitl_types:
+          - wayfinder:grilling
+          - wayfinder:prototype
+```
+
+When the last `req:N` blocker of a dependent carrying one of these labels closes, the unblock sweep and the close cascade promote it to **`ready-for-human`** (edges consumed, `blocked:dependency` shed) rather than `ready-for-agent`, and the audit comment names the lane and the type that chose it. **Declare your own repo's names here — the routing reads this list, never a built-in `wayfinder:*` list**, so a repo whose decision tickets are called something else inherits the same protection. A repo that declares none behaves exactly as before: every unblocked dependent goes to `ready-for-agent`.
+
 ### `quarantine`
 An issue-local safety hold for mechanically detected queue incoherence (ADR 0122). The probe removes `ready-for-agent`, adds `quarantine`, and appends its diagnosis to the issue body; healthy sibling issues continue through the same boot. The castle resident curator periodically re-runs the coherence check. It removes `quarantine` and restores `ready-for-agent` when the defect dissolves, or replaces `quarantine` with `ready-for-human` after three failed re-checks so `/hitl` owns the judgment. The per-issue heal ledger uses the same hold instead of applying a third heal within 24 hours.
 
@@ -140,8 +156,8 @@ These exist for filtering and don't drive lifecycle transitions:
 | `spec:{N}`      | Issue belongs to Spec #N                         | `/to-tickets` when splitting a Spec |
 | `wayfinder:map` | Planning map Ticket for work too large for one agent session. Carries `## Destination`, `## Not yet specified`, and `## Out of scope`; the map is an index, not a store. | `/wayfinder` |
 | `wayfinder:research` | Wayfinder child type for AFK-typed research scoped to one session. Unblocked children use `ready-for-agent`; blocked children use `blocked:dependency` plus `req:N`. | `/wayfinder` |
-| `wayfinder:grilling` | Wayfinder child type for HITL-typed decision work routed to a `/start` session and claimed by assignment. | `/wayfinder` |
-| `wayfinder:prototype` | Wayfinder child type for HITL-typed design or logic exploration routed to a `/prototype` session and claimed by assignment. | `/wayfinder` |
+| `wayfinder:grilling` | Wayfinder child type for HITL-typed decision work routed to a `/start` session and claimed by assignment. Declare it under `afk.labels.hitl_types` so an unblocked grilling Ticket parks for its human instead of joining the agent queue. | `/wayfinder` |
+| `wayfinder:prototype` | Wayfinder child type for HITL-typed design or logic exploration routed to a `/prototype` session and claimed by assignment. Declare it under `afk.labels.hitl_types` alongside `wayfinder:grilling`. | `/wayfinder` |
 | `wayfinder:task` | Wayfinder child type for AFK-typed implementation/docs work scoped to one session. Unblocked children use `ready-for-agent`; blocked children use `blocked:dependency` plus `req:N`. | `/wayfinder` |
 | `runner-error` | `/afk` fleet supervisor parked a slot after fast-death streak; affected issues were restored to `ready-for-agent` after the runner was discarded | `/afk` fleet supervisor on circuit trip |
 | `landing:manual` | Per-issue **manual-landing** mode (#1049): on a `ready-for-agent` issue, `/afk` runs the full pipeline + opens the PR, then **holds for a human's merge click** (parks `ready-for-human`, never auto-merges, never re-runs the agent). The issue auto-closes on PR merge via `Closes #N`. Lets agent-codable slices that must not be auto-merged stay in the autonomous lane instead of being hand-dispatched via `/go`. | `/triage` at brief time, or `/hitl`'s **delegable-manual-landing** disposition |

--- a/plugins/dev/skills/engineering/wayfinder/SKILL.md
+++ b/plugins/dev/skills/engineering/wayfinder/SKILL.md
@@ -74,6 +74,8 @@ The answer isn't part of the body — it's recorded on resolution (see [Work thr
 
 Every ticket is either **HITL** — human in the loop, worked *with* a human who speaks for themselves — or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this).
 
+**Declare the HITL types to the tracker, or the dependency machinery will queue them for an agent.** On a decision-shaped map most dependents of a decision ticket are themselves grilling or prototype, so every resolution would push human decisions into the autonomous lane (#2966). List them once in `.red/config.yaml` under `plugins.dev.afk.labels.hitl_types` — `wayfinder:grilling` and `wayfinder:prototype` for this skill's vocabulary — and an unblocked HITL child parks `ready-for-human` instead. See [triage-labels.md](../red-setup/triage-labels.md) *HUMAN-ONLY types*.
+
 - **Research** (AFK): Reading documentation, third-party APIs, or local resources like knowledge bases to surface a fact a decision waits on. Resolved by a `/research` **subagent**. Use when knowledge outside the current working directory is required.
 - **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
 - **Grilling** (HITL): Conversation via the /start skills, one question at a time. The default case.


### PR DESCRIPTION
Closes #2966

Opened by the drainage babysitter: this branch carried 23 commits on `origin` with no pull request — the #2893 class, finished work no surface mentions. No live Worker holds this issue, so nothing else was going to open it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788126306&installation_model_id=20659&pr_number=2970&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2970&signature=ee434cc70e78760660050dc2e1cdd1a89869e737863dde5367fe7d2536fd829a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->