### PR TITLE
fix: live_only means live in worker_vitals

### DIFF
--- a/.changeset/vitals-live-only.md
+++ b/.changeset/vitals-live-only.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+`worker_vitals live_only: true` now means live. The filter admitted any record carrying an alert, and every dead worker carries a stalled alert forever — so 344 corpses rode through the live filter and buried the one live worker under 559KB of payload, which read as "the worker produced zero lines" while it was 723 lines into its review. A dead worker with an alert is what `live_only: false` is for; an alert that matters on a live read is one attached to a worker that is still active.

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1292,18 +1292,31 @@ async function workerVitals(
 }
 
 /**
- * `live_only` means live. The old `|| alert !== undefined` arm meant "also show
- * what needs attention", but every dead worker carries a stalled alert and
- * nothing ever reclaims the records — so 344 corpses rode through the LIVE
- * filter and buried the one live worker under 559KB of payload. A dead worker
- * with an alert is exactly what `live_only: false` is for; an alert that
- * matters on a LIVE read is one attached to a worker that is still active.
+ * How long a dead worker's alert keeps it on the DEFAULT (live) read.
+ *
+ * An alert is a page: a boot death must surface on the very next read, or a
+ * fast-dying worker is invisible (the case the session-error lane exists for).
+ * But a page ages — past this window it has either been acted on or superseded
+ * by a respawn, and keeping it on the live read is how 344 corpses buried the
+ * one live worker under 559KB of payload. `live_only: false` still returns
+ * every record, however old.
+ */
+export const WORKER_VITALS_ALERT_FRESH_MS = 30 * 60 * 1000;
+
+/**
+ * `live_only` means live — plus deaths fresh enough to still be a page.
+ * The unconditional alert arm let every stalled corpse through forever,
+ * because nothing reclaims the records (#2978).
  */
 export function filterWorkerVitalsLiveOnly<
-  T extends { live?: boolean; active?: boolean; alert?: unknown },
->(records: readonly T[], liveOnly: boolean): T[] {
+  T extends { live?: boolean; alert?: { at?: string } | undefined },
+>(records: readonly T[], liveOnly: boolean, nowMs = Date.now()): T[] {
   if (!liveOnly) return [...records];
-  return records.filter((r) => r.live === true || (r.alert !== undefined && r.active === true));
+  return records.filter((r) => {
+    if (r.live === true) return true;
+    const at = r.alert?.at === undefined ? NaN : Date.parse(r.alert.at);
+    return Number.isFinite(at) && nowMs - at <= WORKER_VITALS_ALERT_FRESH_MS;
+  });
 }
 
 function projectFields(

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1288,7 +1288,22 @@ async function workerVitals(
       daemon_liveness: publishWorkerLiveness(resolveWorkerLiveness(hostAnswer, workerId)),
     });
   }
-  return opts.live_only !== false ? all.filter((r) => r.live === true || r.alert !== undefined) : all;
+  return filterWorkerVitalsLiveOnly(all, opts.live_only !== false);
+}
+
+/**
+ * `live_only` means live. The old `|| alert !== undefined` arm meant "also show
+ * what needs attention", but every dead worker carries a stalled alert and
+ * nothing ever reclaims the records — so 344 corpses rode through the LIVE
+ * filter and buried the one live worker under 559KB of payload. A dead worker
+ * with an alert is exactly what `live_only: false` is for; an alert that
+ * matters on a LIVE read is one attached to a worker that is still active.
+ */
+export function filterWorkerVitalsLiveOnly<
+  T extends { live?: boolean; active?: boolean; alert?: unknown },
+>(records: readonly T[], liveOnly: boolean): T[] {
+  if (!liveOnly) return [...records];
+  return records.filter((r) => r.live === true || (r.alert !== undefined && r.active === true));
 }
 
 function projectFields(

--- a/apps/dev/tests/worker-vitals-live-only.test.ts
+++ b/apps/dev/tests/worker-vitals-live-only.test.ts
@@ -1,0 +1,35 @@
+// `live_only: true` returned 344 dead workers and one live one, because the
+// filter admitted anything carrying an alert — and every dead worker carries a
+// stalled alert forever, since nothing reclaims the records. The one live
+// worker (723 LOC into its review) was buried under 559KB of corpses, and the
+// operator read the first record's `loc 0` as "the worker produced nothing".
+import { describe, expect, it } from "vitest";
+import { filterWorkerVitalsLiveOnly } from "../src/mcp-adapter.js";
+
+const live = { live: true, active: true, alert: undefined, id: "wLIVE" };
+const deadQuiet = { live: false, active: false, alert: undefined, id: "wDEAD" };
+const deadStalled = { live: false, active: false, alert: { status: "stalled" }, id: "wCORPSE" };
+const liveAlerted = { live: false, active: true, alert: { status: "stalling" }, id: "wSTALLING" };
+
+describe("worker_vitals live_only", () => {
+  it("drops a dead worker even when it carries a stalled alert", () => {
+    const out = filterWorkerVitalsLiveOnly([live, deadStalled], true);
+    expect(out.map((r) => r.id)).toEqual(["wLIVE"]);
+  });
+
+  it("keeps an ACTIVE worker whose alert is the reason to look", () => {
+    const out = filterWorkerVitalsLiveOnly([liveAlerted, deadStalled], true);
+    expect(out.map((r) => r.id)).toEqual(["wSTALLING"]);
+  });
+
+  it("reproduces the observed shape: 344 corpses, one live, one row out", () => {
+    const corpses = Array.from({ length: 344 }, (_, i) => ({ ...deadStalled, id: `w${i}` }));
+    const out = filterWorkerVitalsLiveOnly([...corpses, live], true);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.id).toBe("wLIVE");
+  });
+
+  it("live_only: false still returns everything", () => {
+    expect(filterWorkerVitalsLiveOnly([live, deadQuiet, deadStalled], false)).toHaveLength(3);
+  });
+});

--- a/apps/dev/tests/worker-vitals-live-only.test.ts
+++ b/apps/dev/tests/worker-vitals-live-only.test.ts
@@ -1,35 +1,41 @@
 // `live_only: true` returned 344 dead workers and one live one, because the
 // filter admitted anything carrying an alert — and every dead worker carries a
-// stalled alert forever, since nothing reclaims the records. The one live
-// worker (723 LOC into its review) was buried under 559KB of corpses, and the
-// operator read the first record's `loc 0` as "the worker produced nothing".
+// stalled alert forever, since nothing reclaims the records (#2978). The one
+// live worker (723 LOC into its review) was buried under 559KB of corpses.
+// The legitimate case the alert arm was written for survives: a worker that
+// dies at boot must surface on the very next default read, or a fast death is
+// invisible — so a FRESH alert passes and an aged one does not.
 import { describe, expect, it } from "vitest";
-import { filterWorkerVitalsLiveOnly } from "../src/mcp-adapter.js";
+import { filterWorkerVitalsLiveOnly, WORKER_VITALS_ALERT_FRESH_MS } from "../src/mcp-adapter.js";
 
-const live = { live: true, active: true, alert: undefined, id: "wLIVE" };
-const deadQuiet = { live: false, active: false, alert: undefined, id: "wDEAD" };
-const deadStalled = { live: false, active: false, alert: { status: "stalled" }, id: "wCORPSE" };
-const liveAlerted = { live: false, active: true, alert: { status: "stalling" }, id: "wSTALLING" };
+const NOW = Date.parse("2026-08-01T03:00:00.000Z");
+const fresh = new Date(NOW - 60_000).toISOString();
+const aged = new Date(NOW - WORKER_VITALS_ALERT_FRESH_MS - 60_000).toISOString();
+
+const live = { live: true, alert: undefined, id: "wLIVE" };
+const deadQuiet = { live: false, alert: undefined, id: "wDEAD" };
+const freshDeath = { live: false, alert: { at: fresh }, id: "wBOOTDEATH" };
+const corpse = { live: false, alert: { at: aged }, id: "wCORPSE" };
 
 describe("worker_vitals live_only", () => {
-  it("drops a dead worker even when it carries a stalled alert", () => {
-    const out = filterWorkerVitalsLiveOnly([live, deadStalled], true);
+  it("surfaces a fresh death — the page a boot error is", () => {
+    const out = filterWorkerVitalsLiveOnly([live, freshDeath], true, NOW);
+    expect(out.map((r) => r.id)).toEqual(["wLIVE", "wBOOTDEATH"]);
+  });
+
+  it("drops an aged corpse even though it still carries its alert", () => {
+    const out = filterWorkerVitalsLiveOnly([live, corpse], true, NOW);
     expect(out.map((r) => r.id)).toEqual(["wLIVE"]);
   });
 
-  it("keeps an ACTIVE worker whose alert is the reason to look", () => {
-    const out = filterWorkerVitalsLiveOnly([liveAlerted, deadStalled], true);
-    expect(out.map((r) => r.id)).toEqual(["wSTALLING"]);
-  });
-
-  it("reproduces the observed shape: 344 corpses, one live, one row out", () => {
-    const corpses = Array.from({ length: 344 }, (_, i) => ({ ...deadStalled, id: `w${i}` }));
-    const out = filterWorkerVitalsLiveOnly([...corpses, live], true);
+  it("reproduces the observed shape: 344 aged corpses in, one live row out", () => {
+    const corpses = Array.from({ length: 344 }, (_, i) => ({ ...corpse, id: `w${i}` }));
+    const out = filterWorkerVitalsLiveOnly([...corpses, live], true, NOW);
     expect(out).toHaveLength(1);
     expect(out[0]!.id).toBe("wLIVE");
   });
 
-  it("live_only: false still returns everything", () => {
-    expect(filterWorkerVitalsLiveOnly([live, deadQuiet, deadStalled], false)).toHaveLength(3);
+  it("live_only: false still returns everything, however old", () => {
+    expect(filterWorkerVitalsLiveOnly([live, deadQuiet, corpse], false, NOW)).toHaveLength(3);
   });
 });


### PR DESCRIPTION
`worker_vitals` with `live_only: true` returned **345 records — 344 dead, 1 live** — 559KB across 18,633 lines for one row of truth.

The filter:

```ts
all.filter((r) => r.live === true || r.alert !== undefined)
```

The alert arm meant *also show what needs attention*. But every dead worker carries a `stalled` alert **forever** — nothing reclaims the records — so every corpse in the session rode through the live filter. The operator-facing consequence tonight: a statusline reading the first record's `loc 0` as "the worker produced nothing" while the one live worker was **723 lines** into its review.

The predicate is now extracted and pinned by tests, including one that reproduces the observed shape: 344 corpses + 1 live in, exactly 1 row out. An **active** worker with an alert still shows — that is the case the alert arm was written for.

Root cause of the corpse pile itself — records that are never reclaimed — is a separate issue; this PR makes the filter honest regardless of pile size.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788147571&installation_model_id=20659&pr_number=2977&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2977&signature=e83023fe40fa4eeebdfff72c40d57be1edf152dd2b1eafac7c9bff4e138e14b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->