### PR TITLE
fix: #2984 Every worker gate runs the whole workspace suite, because the changeset every slice must carry maps to the root scope

### DIFF
--- a/.changeset/gate-scopes-the-changeset-away.md
+++ b/.changeset/gate-scopes-the-changeset-away.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The AFK gate no longer runs the whole workspace on every slice. Each changed file mapped to its *nearest* package, so a file outside every package — `.changeset/*.md` above all — walked up to the root, whose `test` script is the whole workspace. A changeset is mandatory on every slice, so the dependency cone was computed correctly and then made irrelevant: every gate run degenerated to `pnpm -C <worktree> test`, ~10 minutes a pass, twice or more per issue. Changed paths are now classified explicitly against the taxonomy CI already used (`scripts/ci-affected-scope.mjs`) — `.changeset/` and the disposable `.red/` lanes contribute no scope, `.red/adr/` and the other doc lanes still validate their doc-contract owners, `.red/config.yaml` and anything unclassifiable still escalate to the whole workspace. The two sibling gate paths that resolved scopes without the classifier, `gate_run` and reconcile's pre-land and post-merge gates, were leaking the same root scope and now share it.

--- a/apps/dev/src/core/reconcile-ports.ts
+++ b/apps/dev/src/core/reconcile-ports.ts
@@ -14,9 +14,9 @@ import {
   buildValidationRecord,
   formatValidationLine,
   isInfraFeedbackFailure,
-  relevantScopes,
   runFeedback,
 } from "./feedback.js";
+import { gateScopes } from "./validation-scope.js";
 import { emitEnvelope } from "./envelope-emit.js";
 import { deleteRemote, pushAttempt } from "./remote-branch.js";
 import { DEFAULT_TRIAGE_LABELS } from "./triage-labels.js";
@@ -42,7 +42,7 @@ export const HOST_RECONCILE_PORTS: HostReconcilePorts = {
   landing: { doLanding },
   feedback: {
     runFeedback,
-    relevantScopes,
+    gateScopes,
     isInfraFeedbackFailure,
     buildValidationRecord,
     formatValidationLine,

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -40,7 +40,6 @@
 import type {
   buildValidationRecord,
   formatValidationLine,
-  relevantScopes,
   runFeedback,
   isInfraFeedbackFailure,
   Exec as PnpmExec,
@@ -48,6 +47,7 @@ import type {
   PackageLayout,
   RunFeedbackResult,
 } from "./feedback.js";
+import type { gateScopes } from "./validation-scope.js";
 import type { doLanding, LandingFailureReason, LandingPostMergeValidation } from "./landing.js";
 import { type CiAwaitInput, type ConflictResolver, type Exec as MergeExec, type WaitForReviewInput } from "./merge.js";
 import type { deleteRemote, pushAttempt, GitExec } from "./remote-branch.js";
@@ -137,10 +137,13 @@ export interface ReconcileLandingPort {
 
 /** The feedback-gate port: `runFeedback` plus the four helpers reconcile reads
  * around it (scope resolution, the infra-root classifier, and the two
- * validation-record formatters used by the post-merge sidecar line). */
+ * validation-record formatters used by the post-merge sidecar line).
+ * Scope resolution is `gateScopes`, NOT the raw nearest-package `relevantScopes`:
+ * mapping a changed file to its nearest package sends the mandatory changeset to
+ * the root, whose `test` script is the whole workspace (#2984). */
 export interface ReconcileFeedbackPort {
   runFeedback: typeof runFeedback;
-  relevantScopes: typeof relevantScopes;
+  gateScopes: typeof gateScopes;
   isInfraFeedbackFailure: typeof isInfraFeedbackFailure;
   buildValidationRecord: typeof buildValidationRecord;
   formatValidationLine: typeof formatValidationLine;
@@ -518,7 +521,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     // Mirrors the DONE path.
     feedback = await deps.feedback.runFeedback(deps.pnpm, {
       worktree: branch,
-      scopes: deps.feedback.relevantScopes(deps.layout, changedFiles),
+      scopes: deps.feedback.gateScopes(deps.layout, changedFiles),
       layout: deps.layout,
       now: deps.nowEpoch,
       baselineWorktree: input.base,
@@ -577,7 +580,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
       postMergeGate: async (mergedTreeDir) => {
         const mergedFeedback = await deps.feedback.runFeedback(deps.pnpm, {
           worktree: mergedTreeDir,
-          scopes: deps.feedback.relevantScopes(deps.layout, changedFiles),
+          scopes: deps.feedback.gateScopes(deps.layout, changedFiles),
           layout: deps.layout,
           now: deps.nowEpoch,
           baselineWorktree: input.base,

--- a/apps/dev/src/core/validation-scope.ts
+++ b/apps/dev/src/core/validation-scope.ts
@@ -9,8 +9,18 @@
 // Root-config changes (lockfile, workspace manifest, tsconfig, turbo.json,
 // .github/**) have global blast radius and escalate to whole-workspace mode
 // (scopes = ["."]) so they are never under-validated.
+//
+// Every changed path is classified explicitly (#2984). Mapping a path to its
+// *nearest* package was not enough: a file outside every package — `.changeset/*.md`
+// above all — walked up to the root package and returned scope ".", whose `test`
+// script is the whole workspace. Since a changeset is mandatory on every slice,
+// the cone was computed correctly and then made irrelevant, and each gate run
+// degenerated to `pnpm -C <worktree> test`. The classification here is the same
+// taxonomy CI already uses (`scripts/ci-affected-scope.mjs`), kept in lockstep by
+// `apps/dev/tests/validation-scope.test.ts`'s parity table — one taxonomy, two
+// consumers, never a third.
 
-import { type PackageLayout, relevantScopes } from "./feedback.js";
+import { nearestPackageScope, type PackageLayout } from "./feedback.js";
 
 /** A workspace package: its repo-relative dir and the dirs it directly depends on. */
 export interface WorkspacePackage {
@@ -79,8 +89,99 @@ const ROOT_TRIGGER_FILES = new Set([
   ".nvmrc",
 ]);
 
+/**
+ * Doc lanes that no suite reads — a change here contributes no scope at all.
+ * Keep this list short and provable: an entry is a promise that no test asserts
+ * the file's content. `.changeset/` is the entry that matters most, because a
+ * changeset is mandatory on every slice.
+ */
+const INERT_PREFIXES = [".changeset/", ".red/tmp/", ".red/researches/"];
+
+/**
+ * Packages whose suites assert the content of the repo's doc lanes (the
+ * `*-docs.test.ts` contracts, ADR governance, the skill/manifest audits). A docs
+ * change runs these packages' tests and nothing else — it affects no type.
+ * A repo whose layout declares none of them escalates to whole-workspace rather
+ * than under-validating.
+ */
+const DOC_CONTRACT_PACKAGES = ["apps/dev"];
+
+/** Doc lanes whose content the doc-contract packages assert. */
+const DOC_PREFIXES = [".red/"];
+
+/**
+ * Doc lanes that are ALSO inputs to generated artifacts (Codex/Gemini/Pi
+ * manifests, Pi package payloads). Same owners as the doc lanes on the gate
+ * side — CI additionally re-runs its manifest checks, which the gate does not have.
+ */
+const MANIFEST_INPUT_PREFIXES = ["plugins/", ".claude-plugin/", ".agents/", "packaging/pi/"];
+
+/** Root-level docs the suite reads (README/CLAUDE/CHANGES are asserted). */
+const ROOT_DOC_FILES = new Set(["README.md", "CLAUDE.md", "CHANGES.md", "NOTICE", "LICENSE"]);
+
+/**
+ * The verdict for one changed path.
+ * - `whole` — global blast radius, or unclassifiable. Runs the whole workspace,
+ *   because a wrongly-skipped test costs far more than a needlessly-run one.
+ * - `inert` — no suite reads it; contributes no scope.
+ * - `scoped` — contributes the named packages to the cone's trigger set.
+ */
+export type PathClass =
+  | { kind: "whole" }
+  | { kind: "inert" }
+  | { kind: "scoped"; packages: string[] };
+
 function stripDotSlash(file: string): string {
   return file.startsWith("./") ? file.slice(2) : file;
+}
+
+/** The doc-contract owners this layout actually declares. */
+function docContractPackages(layout: PackageLayout): string[] {
+  return DOC_CONTRACT_PACKAGES.filter((dir) => layout.hasPackage(dir));
+}
+
+/**
+ * Classify one changed path against the shared taxonomy. Pure: `layout` is only
+ * consulted to resolve a path's owning package (and to confirm a doc-contract
+ * owner exists), never to read the filesystem.
+ *
+ * Order matters — `.red/adr/` is checked before the inert prefixes so an ADR is
+ * never mistaken for disposable `.red/` scratch, and `.red/config.yaml` is
+ * checked before the docs discount because it is configuration the runtimes
+ * read, not prose.
+ */
+export function classifyChangedPath(file: string, layout: PackageLayout): PathClass {
+  const clean = stripDotSlash(file);
+  const docOwners = docContractPackages(layout);
+  // A docs change with no owner package in this layout cannot be narrowed
+  // honestly — run everything rather than validate nothing.
+  const docScoped = (): PathClass =>
+    docOwners.length > 0 ? { kind: "scoped", packages: docOwners } : { kind: "whole" };
+
+  // Known root-config files and `.github/**` — global blast radius, checked
+  // first so nothing below can discount them.
+  if (isRootTrigger(clean)) return { kind: "whole" };
+
+  if (clean.startsWith(".red/adr/")) return docScoped();
+  if (INERT_PREFIXES.some((p) => clean.startsWith(p))) return { kind: "inert" };
+  if (MANIFEST_INPUT_PREFIXES.some((p) => clean.startsWith(p))) return docScoped();
+  if (DOC_PREFIXES.some((p) => clean.startsWith(p))) {
+    if (clean === ".red/config.yaml") return { kind: "whole" };
+    return docScoped();
+  }
+
+  if (!clean.includes("/")) {
+    if (ROOT_DOC_FILES.has(clean)) return docScoped();
+    // Every other root file (package.json, lockfile, turbo.json, tsconfig, …)
+    // has global blast radius.
+    return { kind: "whole" };
+  }
+
+  const dir = nearestPackageScope(layout, clean);
+  if (dir !== undefined && dir !== ".") return { kind: "scoped", packages: [dir] };
+
+  // scripts/**, .github/**, dist/**, anything unrecognised: unclassifiable.
+  return { kind: "whole" };
 }
 
 /**
@@ -148,31 +249,38 @@ function expandToCone(touchedDirs: readonly string[], graph: WorkspaceGraph): st
 
 /**
  * Pure function: given changed files, a package layout, and a workspace graph,
- * compute the validation scope.
+ * compute the validation scope. Every path is classified by
+ * {@link classifyChangedPath}; the first `whole` verdict wins outright.
  *
- * - Any root-config file in `changedFiles` → `whole-workspace` (global blast
+ * - Any root-config or unclassifiable file → `whole-workspace` (global blast
  *   radius; must not under-validate).
+ * - `inert` files (`.changeset/**` above all) contribute NO scope, so the
+ *   mandatory changeset never drags the root package into the cone (#2984).
  * - All other changes → `cone` (touched packages + their transitive dependents).
  * - Empty changed-file set → `cone` with empty packages (gate runs no-package
- *   skips, matching the current `relevantScopes` fallback).
+ *   skips; the caller already terminal-fails a no-diff branch before this).
  */
 export function computeValidationScope(
   changedFiles: readonly string[],
   layout: PackageLayout,
   graph: WorkspaceGraph,
 ): ValidationScope {
-  for (const file of changedFiles) {
-    if (isRootTrigger(file)) {
-      return { type: "whole-workspace", triggerFile: stripDotSlash(file) };
-    }
-  }
-
   const coreTrigger = coreModuleTriggerFile(changedFiles);
   if (coreTrigger !== undefined) {
     return { type: "whole-workspace", triggerFile: coreTrigger };
   }
 
-  const touchedDirs = relevantScopes(layout, changedFiles);
+  const touched = new Set<string>();
+  for (const raw of changedFiles) {
+    if (raw === "") continue;
+    const file = stripDotSlash(raw);
+    const verdict = classifyChangedPath(file, layout);
+    if (verdict.kind === "whole") return { type: "whole-workspace", triggerFile: file };
+    if (verdict.kind === "inert") continue;
+    for (const pkg of verdict.packages) touched.add(pkg);
+  }
+
+  const touchedDirs = [...touched].sort();
   const coneDirs = expandToCone(touchedDirs, graph);
 
   return {
@@ -193,6 +301,18 @@ export function computeValidationScope(
 export function scopesForValidationScope(scope: ValidationScope): string[] {
   if (scope.type === "whole-workspace") return ["."];
   return scope.packages;
+}
+
+/**
+ * The classified scope list for a gate path that has no workspace graph to
+ * expand a cone with — `gate_run` and reconcile's pre-land / post-merge gates.
+ * Same taxonomy as {@link computeValidationScope}, so the mandatory changeset
+ * does not drag the root package (and with it the whole-workspace suite) into
+ * these gates either (#2984). Prefer `computeValidationScope` wherever a graph
+ * IS available: this resolves the trigger packages only, never their dependents.
+ */
+export function gateScopes(layout: PackageLayout, changedFiles: readonly string[]): string[] {
+  return scopesForValidationScope(computeValidationScope(changedFiles, layout, { packages: [] }));
 }
 
 /**

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -102,7 +102,8 @@ import {
 } from "./core/config.js";
 import * as gitx from "./runtime/git.js";
 import { makeFeedbackWorktree } from "./runtime/feedback-worktree.js";
-import { relevantScopes, runFeedback } from "./core/feedback.js";
+import { runFeedback } from "./core/feedback.js";
+import { gateScopes } from "./core/validation-scope.js";
 import { doLanding } from "./core/landing.js";
 import { dispatchHooks, type HookExec } from "./core/hook-dispatcher.js";
 import { resolveHooks } from "./core/hook-config.js";
@@ -549,7 +550,7 @@ export function createDefaultDevAfkMcpOperations(
         const changedFiles = await gitx.changedFiles({ cwd: root }, input.branch, base);
         const result = await runFeedback(feedback.pnpm, {
           worktree: input.branch,
-          scopes: relevantScopes(feedback.layout, changedFiles),
+          scopes: gateScopes(feedback.layout, changedFiles),
           layout: feedback.layout,
           now: () => Date.now(),
           baselineWorktree: base,

--- a/apps/dev/tests/validation-scope.test.ts
+++ b/apps/dev/tests/validation-scope.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { computeCiScope } from "../../../scripts/ci-affected-scope.mjs";
 import {
   computeValidationScope,
   formatValidationScope,
+  gateScopes,
   isRootTrigger,
   scopeNeedsWholeSuite,
   scopesForValidationScope,
@@ -230,6 +232,163 @@ describe("computeValidationScope — cone expansion", () => {
   });
 });
 
+// ---- computeValidationScope — path classification (#2984) ----
+
+describe("computeValidationScope — the mandatory changeset never widens the cone", () => {
+  // A layout shaped like this repo: a root package plus the two packages the
+  // acceptance criteria name.
+  const layout = fakeLayout([".", "apps/dev", "apps/redskilled", "packages/shared"]);
+  const g = fakeGraph([
+    { dir: "apps/dev", dependsOn: ["packages/shared"] },
+    { dir: "apps/redskilled", dependsOn: ["packages/shared"] },
+    { dir: "packages/shared", dependsOn: [] },
+  ]);
+
+  it("a slice + its changeset scopes to the slice's cone, not the root", () => {
+    const scope = computeValidationScope(
+      ["apps/redskilled/src/x.ts", ".changeset/lucky-pandas-shave.md"],
+      layout,
+      g,
+    );
+
+    expect(scope.type).toBe("cone");
+    if (scope.type === "cone") {
+      expect(scope.packages).toEqual(["apps/redskilled"]);
+      expect(scope.triggerPackages).toEqual(["apps/redskilled"]);
+    }
+    expect(scopesForValidationScope(scope)).toEqual(["apps/redskilled"]);
+    expect(scopesForValidationScope(scope)).not.toContain(".");
+  });
+
+  it("a changeset-only branch contributes no scope at all", () => {
+    const scope = computeValidationScope([".changeset/quiet-moons-wave.md"], layout, g);
+    expect(scope.type).toBe("cone");
+    if (scope.type === "cone") {
+      expect(scope.packages).toEqual([]);
+    }
+  });
+
+  it("disposable `.red/` lanes are inert too", () => {
+    const scope = computeValidationScope(
+      ["apps/dev/src/core/x.ts", ".red/tmp/scratch/note.md", ".red/researches/r.md"],
+      layout,
+      g,
+    );
+    expect(scope.type).toBe("cone");
+    if (scope.type === "cone") {
+      expect(scope.triggerPackages).toEqual(["apps/dev"]);
+    }
+  });
+
+  it("`.red/adr/*.md` still validates its doc-contract owner (no under-validation)", () => {
+    const scope = computeValidationScope([".red/adr/0131-something.md"], layout, g);
+    expect(scope.type).toBe("cone");
+    if (scope.type === "cone") {
+      expect(scope.triggerPackages).toEqual(["apps/dev"]);
+      expect(scope.packages).toEqual(["apps/dev"]);
+    }
+  });
+
+  it("other `.red/` docs and `plugins/**` map to the same doc-contract owner", () => {
+    for (const file of [
+      ".red/contexts/dev/CONTEXT.md",
+      "plugins/dev/skills/engineering/red-setup/domain.md",
+      ".claude-plugin/marketplace.json",
+      "README.md",
+      "CLAUDE.md",
+    ]) {
+      const scope = computeValidationScope([file], layout, g);
+      expect(scope.type, file).toBe("cone");
+      if (scope.type === "cone") expect(scope.triggerPackages, file).toEqual(["apps/dev"]);
+    }
+  });
+
+  it("`.red/config.yaml` is configuration, not prose — it escalates", () => {
+    const scope = computeValidationScope([".red/config.yaml"], layout, g);
+    expect(scope.type).toBe("whole-workspace");
+    if (scope.type === "whole-workspace") expect(scope.triggerFile).toBe(".red/config.yaml");
+  });
+
+  it("an unclassifiable path escalates rather than narrowing", () => {
+    for (const file of ["scripts/ci-affected-scope.mjs", "dist/bundle.mjs", "Makefile"]) {
+      const scope = computeValidationScope([file], layout, g);
+      expect(scope.type, file).toBe("whole-workspace");
+    }
+  });
+
+  it("a docs change escalates when no doc-contract owner exists in the layout", () => {
+    // A repo without apps/dev cannot narrow a docs change honestly.
+    const bare = fakeLayout([".", "packages/shared"]);
+    const scope = computeValidationScope([".red/adr/0001-x.md"], bare, fakeGraph([]));
+    expect(scope.type).toBe("whole-workspace");
+  });
+});
+
+// ---- taxonomy parity with scripts/ci-affected-scope.mjs ----
+
+describe("classification parity — the gate and CI share one taxonomy", () => {
+  // Mirrors this repo's real shape closely enough to exercise every rule.
+  const ciGraph = [
+    { dir: "apps/dev", name: "@reddb-io/dev", dependsOn: ["packages/shared"] },
+    { dir: "apps/redskilled", name: "@reddb-io/redskilled", dependsOn: ["packages/shared"] },
+    { dir: "packages/shared", name: "@reddb-io/shared", dependsOn: [] },
+  ];
+  const layout = fakeLayout([".", ...ciGraph.map((p) => p.dir)]);
+  const gateGraph = fakeGraph(ciGraph.map(({ dir, dependsOn }) => ({ dir, dependsOn })));
+
+  const PATHS = [
+    "apps/redskilled/src/x.ts",
+    "packages/shared/src/args.ts",
+    "apps/dev/tests/feedback.test.ts",
+    ".changeset/lucky-pandas-shave.md",
+    ".red/tmp/scratch/note.md",
+    ".red/researches/report.md",
+    ".red/adr/0131-something.md",
+    ".red/contexts/dev/CONTEXT.md",
+    ".red/config.yaml",
+    "plugins/dev/skills/engineering/red-setup/domain.md",
+    ".claude-plugin/marketplace.json",
+    ".agents/plugins/marketplace.json",
+    "README.md",
+    "CHANGES.md",
+    "package.json",
+    "pnpm-lock.yaml",
+    "turbo.json",
+    ".github/workflows/red-workspace-ci.yml",
+    "scripts/ci-affected-scope.mjs",
+  ];
+
+  it.each(PATHS)("classifies %s the same way CI does", (file) => {
+    const ci = computeCiScope([file], ciGraph);
+    const gate = computeValidationScope([file], layout, gateGraph);
+
+    if (ci.mode === "whole-workspace") {
+      expect(gate.type).toBe("whole-workspace");
+      return;
+    }
+    expect(gate.type).toBe("cone");
+    if (gate.type === "cone") expect(gate.triggerPackages).toEqual(ci.triggerPackages);
+  });
+
+  it("agrees on a realistic slice diff (source + changeset + ADR)", () => {
+    const files = [
+      "apps/redskilled/src/registration.ts",
+      "apps/redskilled/tests/registration.test.ts",
+      ".changeset/lucky-pandas-shave.md",
+    ];
+    const ci = computeCiScope(files, ciGraph);
+    const gate = computeValidationScope(files, layout, gateGraph);
+
+    expect(ci.mode).toBe("cone");
+    expect(gate.type).toBe("cone");
+    if (gate.type === "cone") {
+      expect(gate.triggerPackages).toEqual(ci.triggerPackages);
+      expect(gate.packages).toEqual(ci.testPackages);
+      expect(gate.packages).toEqual(["apps/redskilled"]);
+    }
+  });
+});
+
 // ---- scopesForValidationScope ----
 
 describe("scopesForValidationScope", () => {
@@ -250,6 +409,26 @@ describe("scopesForValidationScope", () => {
   it("empty cone → []", () => {
     const scope: ValidationScope = { type: "cone", packages: [], triggerPackages: [] };
     expect(scopesForValidationScope(scope)).toEqual([]);
+  });
+});
+
+// ---- gateScopes — the graph-less gate paths (gate_run, reconcile) ----
+
+describe("gateScopes", () => {
+  const layout = fakeLayout([".", "apps/dev", "apps/redskilled"]);
+
+  it("classifies the changeset away on a graph-less gate path too", () => {
+    expect(gateScopes(layout, ["apps/redskilled/src/x.ts", ".changeset/y.md"])).toEqual([
+      "apps/redskilled",
+    ]);
+  });
+
+  it("still escalates a root change to the whole workspace", () => {
+    expect(gateScopes(layout, ["pnpm-lock.yaml", "apps/dev/src/x.ts"])).toEqual(["."]);
+  });
+
+  it("resolves trigger packages only — no dependents, having no graph to expand", () => {
+    expect(gateScopes(layout, ["apps/dev/src/x.ts"])).toEqual(["apps/dev"]);
   });
 });
 
@@ -358,6 +537,49 @@ describe("gate integration — runFeedback runs the cone", () => {
     // All pnpm calls must target the workspace root ("/wt"), never a sub-package.
     const dirs = pnpmCalls.map((a) => a[a.indexOf("-C") + 1] ?? "");
     expect(dirs.every((d) => d === "/wt")).toBe(true);
+  });
+
+  it("a branch that carries a changeset runs the cone's `pnpm -C` line, not the root's", async () => {
+    // The regression #2984 names: source + the mandatory changeset. The gate
+    // command the worker actually runs must target the slice's package.
+    const layout = fakeLayout([".", "apps/dev", "apps/redskilled", "packages/shared"]);
+    const g = fakeGraph([
+      { dir: "apps/dev", dependsOn: ["packages/shared"] },
+      { dir: "apps/redskilled", dependsOn: ["packages/shared"] },
+      { dir: "packages/shared", dependsOn: [] },
+    ]);
+    const changedFiles = ["apps/redskilled/src/x.ts", ".changeset/lucky-pandas-shave.md"];
+    const scope = computeValidationScope(changedFiles, layout, g);
+    const scopes = scopesForValidationScope(scope);
+
+    const { exec, pnpmCalls } = trackingExec();
+    const result = await runFeedback(exec, {
+      worktree: "/wt",
+      scopes,
+      layout,
+      now: () => 0,
+      validationScope: scope,
+    });
+
+    expect(result.ok).toBe(true);
+
+    // The command line the worker actually runs — what a human also reads off
+    // the envelope — targets the slice's package.
+    const commands = pnpmCalls.map((a) => a.join(" "));
+    expect(commands).toContain("pnpm -C /wt/apps/redskilled test");
+    // The whole-workspace suite is exactly what #2984 was paying for. It is gone.
+    expect(commands).not.toContain("pnpm -C /wt test");
+    for (const script of ["test", "lint", "build"]) {
+      expect(commands, script).not.toContain(`pnpm -C /wt/apps/dev ${script}`);
+    }
+    // Two repo-wide sweeps survive the narrowing on purpose: the cross-package
+    // typecheck and apps/dev's repo-invariant suite (#2762).
+    expect(commands).toContain("pnpm -C /wt typecheck");
+    expect(commands).toContain("pnpm -C /wt/apps/dev test:invariants");
+
+    const recorded = result.checks.map((c) => c.record.command).filter((c): c is string => !!c);
+    expect(recorded).toContain("pnpm -C /wt/apps/redskilled test");
+    expect(recorded).not.toContain("pnpm -C /wt test");
   });
 
   it("validationScope is undefined in result when not provided (backwards compat)", async () => {

--- a/scripts/ci-affected-scope.d.mts
+++ b/scripts/ci-affected-scope.d.mts
@@ -1,0 +1,19 @@
+export interface CiWorkspacePackage {
+  dir: string;
+  name: string;
+  dependsOn: string[];
+}
+
+export interface CiScope {
+  mode: "cone" | "whole-workspace";
+  trigger: string | null;
+  testPackages: string[];
+  triggerPackages: string[];
+  runTypecheck: boolean;
+  runManifestChecks: boolean;
+}
+
+export declare function computeCiScope(
+  changedFiles: readonly string[],
+  graph: readonly CiWorkspacePackage[],
+): CiScope;


### PR DESCRIPTION
Automated AFK landing for #2984. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2984

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788156784&installation_model_id=20659&pr_number=2987&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2987&signature=4aaad5cfcff0f3f1dc80c20c4ac041317728d28c841886845f000960049c541b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->