### PR TITLE
fix: #2976 worker_dispatch births a Worker without the daemon, bypassing admission, the budget and the event lane

### DIFF
--- a/.changeset/mcp-dispatch-asks-the-host.md
+++ b/.changeset/mcp-dispatch-asks-the-host.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+`worker_dispatch` asks the daemon for its Workers instead of starting them itself. Every MCP dispatch — issue, demand and scout — held its own `spawn`, so three Workers ran on 3.1.1 while `host-state` reported `workers: 0`, nothing reached the host event lane and nothing was counted against the budget; unbudgeted Workers are unsampled Workers, and this is the memory pressure no OOM record survived. A dispatch now requests a birth over the same port the rest of the project uses and refuses with a named reason when no daemon answers, rather than falling back to a launch no admission verdict judged. `apps/dev/src/mcp-adapter.ts` is declared in the `host-owns-birth` inventory, so the ratchet watches the surface an operator actually reaches for — it read clean throughout, because a ratchet only watches the sites it is told about.

--- a/apps/dev/src/core/host-owns-birth-guard.ts
+++ b/apps/dev/src/core/host-owns-birth-guard.ts
@@ -89,6 +89,20 @@ export const HOST_OWNED_BIRTH_SITES: readonly HostOwnedBirthSite[] = [
     what: "the budget-gated Worker spawn",
     replacement: "the same birth port; the budget decides WHETHER to ask, never how to launch",
   },
+  {
+    // #2976. The site the cutover never crossed, and the reason a declared list
+    // is not the same thing as a covered surface: `worker_dispatch` held its own
+    // `spawn` for every MCP dispatch — issue, demand and scout — so three
+    // Workers ran while `host-state` reported `workers: 0`, nothing reached the
+    // event lane and nothing was counted. The ratchet read clean throughout,
+    // because a ratchet only watches what it was told about.
+    path: "apps/dev/src/mcp-adapter.ts",
+    what: "the `worker_dispatch` births — `dispatchIssue`, `dispatchDemand` and `dispatchScout`",
+    replacement:
+      "`runtime/mcp-worker-birth.ts` — `requestWorkerBirth(...)` over the same birth port," +
+      " which refuses when no daemon answers instead of spawning (the rsp-wait spawn, which is" +
+      " not a Worker, moved to `runtime/rsp-wait-launch.ts`)",
+  },
 ];
 
 /**

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1,9 +1,8 @@
-import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { logsDir, waitsDir, worktreesDir } from "@reddb-io/shared/red-paths.js";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { waitsDir, worktreesDir } from "@reddb-io/shared/red-paths.js";
 import { decode as decodeToon } from "@reddb-io/toon";
 import {
   armPr,
@@ -62,6 +61,8 @@ import { matchesSelector } from "./core/session.js";
 import { resolveHitlDecision } from "./core/hitl-resolve.js";
 import * as ghx from "./runtime/gh.js";
 import { publishedBundleArgv } from "./runtime/published-entry.js";
+import { requestWorkerBirth, type DispatchedWorkerBirth } from "./runtime/mcp-worker-birth.js";
+import { launchDetachedRspWait } from "./runtime/rsp-wait-launch.js";
 import {
   createRedskilledBirthPort,
   redskilledRegistrationRefusal,
@@ -178,7 +179,15 @@ export interface DevAfkMcpOperations {
 }
 
 export interface DevAfkMcpRuntime {
-  launchRun(root: string, args: readonly string[]): Promise<{ pid: number; log?: string }>;
+  /**
+   * Ask the HOST for one Worker, and refuse when it does not answer.
+   *
+   * Named for the request rather than for a launch because there is no launch
+   * here any more (#2976): `worker_dispatch` used to spawn the Worker itself, so
+   * a dispatched Worker was counted by no budget, absent from the host event
+   * lane and reported by no surface — the exact shape ADR 0130 rule 6 forbids.
+   */
+  birthWorker(root: string, args: readonly string[]): Promise<DispatchedWorkerBirth>;
   /** Spawn rsp wait detached; returns the child PID. */
   launchRspWait(args: readonly string[], cwd: string): Promise<number>;
   ensureLabel(root: string, name: string): Promise<void>;
@@ -195,103 +204,14 @@ function dispatchArgs(input: DispatchOperationInput): string[] {
   return args;
 }
 
-/** Where a detached worker's boot stdout/stderr is persisted, in the disposable
- * logs lane (ADR 0098). A worker that dies before it writes its own state used
- * to leave nothing but `worker.pid` — three silent spawn deaths in a row with
- * zero evidence anywhere (#2385, #2376). The dispatch keeps the bytes. */
-export function dispatchLogPath(root: string, stampIso: string): string {
-  const safe = stampIso.replace(/[:.]/g, "-");
-  return join(logsDir(root, stampIso.slice(0, 10)), `dispatch-${safe}.log`);
-}
+// The dispatch surface starts nothing itself: `dispatchLogPath` and the birth
+// request live in `runtime/mcp-worker-birth.ts`, and the rsp-wait spawn — which
+// is not a Worker — lives in `runtime/rsp-wait-launch.ts`. Both are re-exported
+// here because this module is a declared `host-owns-birth` site (#2976), and
+// that ratchet reads whether a MODULE can create a process at all.
+export { dispatchLogPath } from "./runtime/mcp-worker-birth.js";
+export { resolveRspCliBundle } from "./runtime/rsp-wait-launch.js";
 
-async function launchDetachedRun(
-  root: string,
-  args: readonly string[],
-): Promise<{ pid: number; log?: string }> {
-  const mcpBundle = process.argv[1];
-  if (!mcpBundle) {
-    throw new Error("cannot dispatch worker: MCP bundle path is missing");
-  }
-  const bundle = resolveDevCliBundle(mcpBundle);
-  if (!existsSync(bundle)) {
-    throw new Error("cannot dispatch worker: sibling dev bundle is missing");
-  }
-  // Capture boot stdout+stderr to a discoverable file. Best-effort: if the log
-  // cannot be opened, the dispatch still runs (with the old blind stdio) rather
-  // than failing over an observability concern.
-  const logFile = dispatchLogPath(root, `${new Date().toISOString()}-${randomUUID().slice(0, 8)}`);
-  let fd: number | undefined;
-  try {
-    mkdirSync(dirname(logFile), { recursive: true });
-    fd = openSync(logFile, "a");
-  } catch {
-    fd = undefined;
-  }
-  try {
-    const child = spawn(process.execPath, [bundle, "run", ...args], {
-      cwd: root,
-      env: process.env,
-      detached: true,
-      stdio: fd === undefined ? "ignore" : ["ignore", fd, fd],
-    });
-    const pid = child.pid;
-    if (!pid) throw new Error("cannot dispatch worker: spawn returned no pid");
-    child.unref();
-    return { pid, log: fd === undefined ? undefined : logFile };
-  } finally {
-    if (fd !== undefined) closeSync(fd);
-  }
-}
-
-export function resolveDevCliBundle(mcpBundle: string): string {
-  const file = basename(mcpBundle);
-  if (file === "castle-mcp.bundle.min.mjs") {
-    return join(dirname(mcpBundle), "dev.bundle.min.mjs");
-  }
-  if (file.startsWith("castle-mcp-") && file.endsWith(".bundle.min.mjs")) {
-    return join(dirname(mcpBundle), file.replace(/^castle-mcp-/, "dev-"));
-  }
-  throw new Error(
-    `cannot dispatch worker: unrecognized MCP bundle name ${JSON.stringify(file)}`,
-  );
-}
-
-export function resolveRspCliBundle(mcpBundle: string): string {
-  const file = basename(mcpBundle);
-  if (file === "castle-mcp.bundle.min.mjs") {
-    return join(dirname(mcpBundle), "rsp.bundle.min.mjs");
-  }
-  if (file.startsWith("castle-mcp-") && file.endsWith(".bundle.min.mjs")) {
-    return join(dirname(mcpBundle), file.replace(/^castle-mcp-/, "rsp-"));
-  }
-  throw new Error(
-    `cannot spawn rsp wait: unrecognized MCP bundle name ${JSON.stringify(file)}`,
-  );
-}
-
-async function launchDetachedRspWait(
-  args: readonly string[],
-  cwd: string,
-): Promise<number> {
-  const mcpBundle = process.argv[1];
-  if (!mcpBundle) {
-    throw new Error("cannot spawn rsp wait: MCP bundle path is missing");
-  }
-  const bundle = resolveRspCliBundle(mcpBundle);
-  if (!existsSync(bundle)) {
-    throw new Error("cannot spawn rsp wait: sibling rsp bundle is missing");
-  }
-  const child = spawn(process.execPath, [bundle, ...args], {
-    cwd,
-    env: process.env,
-    detached: true,
-    stdio: "ignore",
-  });
-  const pid = child.pid;
-  if (!pid) throw new Error("cannot spawn rsp wait: spawn returned no pid");
-  child.unref();
-  return pid;
-}
 
 function buildWaitArgs(
   kind: WaitStartInput["kind"],
@@ -316,7 +236,7 @@ function buildWaitArgs(
 }
 
 const defaultMcpRuntime: DevAfkMcpRuntime = {
-  launchRun: launchDetachedRun,
+  birthWorker: (root, args) => requestWorkerBirth(root, args),
   launchRspWait: launchDetachedRspWait,
   async ensureLabel(root, name) {
     const context = await resolveRepoContext(root);
@@ -383,20 +303,24 @@ export function createDefaultDevAfkMcpOperations(
         "--once",
         ...dispatchArgs(input),
       ];
-      const launch = await runtime.launchRun(cwd, args);
+      const granted = await runtime.birthWorker(cwd, args);
       return {
         kind: "afk",
         issue: input.issue,
-        worker_pid: launch.pid,
+        // The host's id for this Worker, so the surface that dispatched it and
+        // the surface that reports it name the same thing (#2976).
+        worker_id: granted.worker_id,
+        worker_pid: granted.pid,
         // Post-mortem handle for a worker that dies before writing its own
         // state (#2385): its boot stdout/stderr lands here.
-        worker_log: launch.log,
+        worker_log: granted.log,
+        admission: granted.admission,
+        ...(granted.warnings.length > 0 ? { warnings: [...granted.warnings] } : {}),
         status: "dispatched",
       };
     },
     async dispatchDemand(cwd, input) {
-      let workerPid: number | undefined;
-      let workerLog: string | undefined;
+      let granted: DispatchedWorkerBirth | undefined;
       const configuredBackpressure = readBackpressure(
         loadConfig(afkPaths(cwd).configPath, { warn: () => undefined }),
       );
@@ -405,9 +329,7 @@ export function createDefaultDevAfkMcpOperations(
           ensureLabel: (name) => runtime.ensureLabel(cwd, name),
           createIssue: (spec) => runtime.createIssue(cwd, spec),
           runEngine: async (args) => {
-            const launch = await runtime.launchRun(cwd, args);
-            workerPid = launch.pid;
-            workerLog = launch.log;
+            granted = await runtime.birthWorker(cwd, args);
             return 0;
           },
         },
@@ -420,44 +342,47 @@ export function createDefaultDevAfkMcpOperations(
           hasHarness: configuredBackpressure.length > 0,
         },
       );
-      if (workerPid === undefined) {
-        throw new Error("cannot dispatch demand: worker was not spawned");
+      if (granted === undefined) {
+        throw new Error("cannot dispatch demand: the host granted no Worker");
       }
       return {
         kind: "go",
         demand: input.demand,
         issue: result.issue,
-        worker_pid: workerPid,
-        worker_log: workerLog,
+        worker_id: granted.worker_id,
+        worker_pid: granted.pid,
+        worker_log: granted.log,
+        admission: granted.admission,
+        ...(granted.warnings.length > 0 ? { warnings: [...granted.warnings] } : {}),
         status: "dispatched",
       };
     },
     async dispatchScout(cwd, input) {
-      let workerPid: number | undefined;
-      let workerLog: string | undefined;
+      let granted: DispatchedWorkerBirth | undefined;
       const result = await dispatchScoutCore(
         {
           ensureLabel: (name) => runtime.ensureLabel(cwd, name),
           createIssue: (spec) => runtime.createIssue(cwd, spec),
           runEngine: async (args) => {
-            const launch = await runtime.launchRun(cwd, args);
-            workerPid = launch.pid;
-            workerLog = launch.log;
+            granted = await runtime.birthWorker(cwd, args);
             return 0;
           },
         },
         input.demand,
         { runner: input.runner },
       );
-      if (workerPid === undefined) {
-        throw new Error("cannot dispatch scout: worker was not spawned");
+      if (granted === undefined) {
+        throw new Error("cannot dispatch scout: the host granted no Worker");
       }
       return {
         kind: "scout",
         demand: input.demand,
         issue: result.issue,
-        worker_pid: workerPid,
-        worker_log: workerLog,
+        worker_id: granted.worker_id,
+        worker_pid: granted.pid,
+        worker_log: granted.log,
+        admission: granted.admission,
+        ...(granted.warnings.length > 0 ? { warnings: [...granted.warnings] } : {}),
         status: "dispatched",
       };
     },

--- a/apps/dev/src/runtime/mcp-worker-birth.ts
+++ b/apps/dev/src/runtime/mcp-worker-birth.ts
@@ -1,0 +1,120 @@
+// mcp-worker-birth — how the MCP dispatch surface gets a Worker (#2976, ADR 0130).
+//
+// `worker_dispatch` was the birth path the cutover never crossed. The runtime's
+// own spawn was deleted and its module declared, and the adapter went on
+// starting Workers itself — one `spawn` behind an operator-facing tool, so three
+// Workers ran while `host-state` said `workers: 0`, nothing on the event lane
+// and nothing against the budget. **The tool an operator reaches for was the one
+// path the ratchet never watched**, because a ratchet only covers the sites it
+// is told about, and this one was never declared.
+//
+// So the dispatch asks the same daemon the rest of the project asks, through the
+// same port, and **refuses when it cannot** (ADR 0130 rule 6). A dispatch that
+// fell back to a local spawn would be exactly the Worker this module exists to
+// stop: outside the host budget, absent from the host event lane, reported by no
+// surface — and it would be invisible, because it would still say `dispatched`.
+//
+// The module holds no work knowledge: which ticket the Worker claims and which
+// runner serves it are already in the argv the caller states, and neither the
+// bundle nor the spawn is decided here. What it owns is the one translation the
+// dispatch needs — an engine argv becomes a host worker spec.
+
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { logsDir } from "@reddb-io/shared/red-paths.js";
+import type { RedskilledClientConfig } from "@reddb-io/redskilled/client";
+import type { RedskilledPaths } from "@reddb-io/redskilled/paths";
+import { publishedBundleArgv } from "./published-entry.js";
+import {
+  createRedskilledBirthPort,
+  redskilledUnreachableAdvice,
+} from "./redskilled-birth.js";
+
+/** Where a dispatched Worker's stdout/stderr is persisted, in the disposable
+ * logs lane (ADR 0098). A Worker that dies before it writes its own state used
+ * to leave nothing but `worker.pid` — three silent deaths in a row with zero
+ * evidence anywhere (#2385, #2376). The dispatch keeps the bytes; since #2976
+ * the daemon is the one that opens the file, because the daemon owns the
+ * process whose descriptors those are. */
+export function dispatchLogPath(root: string, stampIso: string): string {
+  const safe = stampIso.replace(/[:.]/g, "-");
+  return join(logsDir(root, stampIso.slice(0, 10)), `dispatch-${safe}.log`);
+}
+
+/** A Worker the host granted to a dispatch, in the facts the caller reports. */
+export interface DispatchedWorkerBirth {
+  readonly worker_id: string;
+  readonly pid: number;
+  /** Post-mortem handle: where the host pointed this Worker's output. */
+  readonly log: string;
+  /** Warnings the host attached — a downgraded unit is running AND degraded. */
+  readonly warnings: readonly string[];
+  /** The host's own sentence about the ceiling that admitted this birth. */
+  readonly admission: string;
+}
+
+/** Everything a test poses as; a real dispatch passes none of it. */
+export interface WorkerBirthOptions {
+  readonly paths?: RedskilledPaths;
+  readonly config?: RedskilledClientConfig;
+  readonly projectLabel?: string;
+  /** The published bundle argv head — resolved from the published entry by default. */
+  readonly entry?: readonly string[];
+  /** The stamp naming the log file; defaults to now plus a short uniquifier. */
+  readonly stamp?: string;
+}
+
+/**
+ * Ask the host for one dispatched Worker, or refuse and start nothing.
+ *
+ * `args` is the engine argv AFTER `run` — the same list the dispatch used to
+ * hand its own spawn — so the caller states the work and this states the host
+ * spec. The bundle comes from the PUBLISHED entry rather than from this
+ * process's own, for the reason #2808 names: a Worker born from the caller's
+ * bundle inherits whatever skew that caller is carrying.
+ */
+export async function requestWorkerBirth(
+  root: string,
+  args: readonly string[],
+  options: WorkerBirthOptions = {},
+): Promise<DispatchedWorkerBirth> {
+  const port = createRedskilledBirthPort({
+    root,
+    ...(options.projectLabel !== undefined ? { projectLabel: options.projectLabel } : {}),
+    ...(options.paths !== undefined ? { paths: options.paths } : {}),
+    ...(options.config !== undefined ? { config: options.config } : {}),
+  });
+  const [command, ...head] = options.entry ?? publishedBundleArgv();
+  if (command === undefined) {
+    throw new Error("cannot dispatch worker: the published bundle resolved to an empty argv");
+  }
+  const stamp = options.stamp ?? `${new Date().toISOString()}-${randomUUID().slice(0, 8)}`;
+  const log = dispatchLogPath(root, stamp);
+
+  let granted;
+  try {
+    await port.reach();
+    granted = await port.start({
+      // The port states the project label itself; a caller that could name it
+      // would be a caller that could file another project's Worker (rule 11).
+      project_label: "",
+      workspace_path: root,
+      log_path: log,
+      command,
+      args: [...head, "run", ...args],
+    });
+  } catch (err) {
+    // Named, and it starts nothing: an operator reading this needs to know that
+    // no Worker exists, and which of "start the daemon" / "fix the client that
+    // stopped asking it" is their repair.
+    throw new Error(redskilledUnreachableAdvice(port.socketPath, err));
+  }
+
+  return {
+    worker_id: granted.workerId,
+    pid: granted.pid,
+    log,
+    warnings: granted.warnings,
+    admission: granted.admission,
+  };
+}

--- a/apps/dev/src/runtime/rsp-wait-launch.ts
+++ b/apps/dev/src/runtime/rsp-wait-launch.ts
@@ -1,0 +1,60 @@
+// rsp-wait-launch — the one process the MCP surface still starts itself.
+//
+// An `rsp wait` is NOT a Worker: it claims no ticket, runs no runner, spends no
+// host budget and dies when the thing it watches resolves. The daemon owns Worker
+// birth (ADR 0130), and this is deliberately outside that authority.
+//
+// It lives in its own module because `mcp-adapter.ts` is now a declared
+// `host-owns-birth` site (#2976), and that ratchet reads a MODULE rather than a
+// call: a file that may not birth a Worker must hold no way to create a process
+// at all, because "this particular spawn is fine" is exactly the judgement a
+// ratchet exists to stop making. Keeping the wait's spawn here states the
+// distinction structurally instead of asking a reader to re-litigate it.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+/**
+ * The rsp bundle shipped beside the MCP bundle this process is running.
+ *
+ * In MCP context `process.argv[1]` is the castle-mcp bundle, which routes no
+ * `wait` subcommand; its sibling does.
+ */
+export function resolveRspCliBundle(mcpBundle: string): string {
+  const file = basename(mcpBundle);
+  if (file === "castle-mcp.bundle.min.mjs") {
+    return join(dirname(mcpBundle), "rsp.bundle.min.mjs");
+  }
+  if (file.startsWith("castle-mcp-") && file.endsWith(".bundle.min.mjs")) {
+    return join(dirname(mcpBundle), file.replace(/^castle-mcp-/, "rsp-"));
+  }
+  throw new Error(
+    `cannot spawn rsp wait: unrecognized MCP bundle name ${JSON.stringify(file)}`,
+  );
+}
+
+/** Start a detached `rsp wait`; returns the child PID. */
+export async function launchDetachedRspWait(
+  args: readonly string[],
+  cwd: string,
+): Promise<number> {
+  const mcpBundle = process.argv[1];
+  if (!mcpBundle) {
+    throw new Error("cannot spawn rsp wait: MCP bundle path is missing");
+  }
+  const bundle = resolveRspCliBundle(mcpBundle);
+  if (!existsSync(bundle)) {
+    throw new Error("cannot spawn rsp wait: sibling rsp bundle is missing");
+  }
+  const child = spawn(process.execPath, [bundle, ...args], {
+    cwd,
+    env: process.env,
+    detached: true,
+    stdio: "ignore",
+  });
+  const pid = child.pid;
+  if (!pid) throw new Error("cannot spawn rsp wait: spawn returned no pid");
+  child.unref();
+  return pid;
+}

--- a/apps/dev/tests/host-owns-birth-guard.test.ts
+++ b/apps/dev/tests/host-owns-birth-guard.test.ts
@@ -34,6 +34,12 @@ describe("the per-project runtime holds no way to birth a Worker", () => {
     expect(HOST_OWNED_BIRTH_SITES.map((site) => site.path)).toContain(
       "apps/dev/src/commands/supervise.ts",
     );
+    // The MCP dispatch surface (#2976). It birthed Workers with the ratchet in
+    // force, because it was never declared — an undeclared site is not a site
+    // the guard judged safe, it is a site the guard never looked at.
+    expect(HOST_OWNED_BIRTH_SITES.map((site) => site.path)).toContain(
+      "apps/dev/src/mcp-adapter.ts",
+    );
     for (const site of HOST_OWNED_BIRTH_SITES) {
       expect(site.what.trim()).not.toBe("");
       expect(site.replacement.trim()).not.toBe("");
@@ -53,6 +59,25 @@ describe("the ratchet can go red", () => {
     expect(findings[0]!.match).toBe("spawn(");
     expect(formatHostOwnedBirthFailure(findings)).toContain("apps/dev/src/commands/supervise.ts:1");
     expect(formatHostOwnedBirthFailure(findings)).toContain("the birth port");
+  });
+
+  it("catches the dispatch spawn #2976 shipped, on the MCP site now that it is declared", () => {
+    // The exact code that was live on 3.1.1, against the site that now covers
+    // it: the fixture proves the ratchet would have gone red on the real defect
+    // rather than only on a synthetic one.
+    const mcpSite = HOST_OWNED_BIRTH_SITES.find(
+      (site) => site.path === "apps/dev/src/mcp-adapter.ts",
+    );
+    expect(mcpSite).toBeDefined();
+    const findings = collectHostOwnedBirthFindings(
+      "/repo",
+      [mcpSite!],
+      () => 'const child = spawn(process.execPath, [bundle, "run", ...args], { detached: true });\n',
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.match).toBe("spawn(");
+    expect(formatHostOwnedBirthFailure(findings)).toContain("requestWorkerBirth");
   });
 
   it("catches an import of child_process, even with no call beside it", () => {

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -17,10 +17,10 @@ import {
   createDefaultDevAfkMcpOperations,
   createCastleMcpDependencies,
   dispatchLogPath,
-  resolveDevCliBundle,
   resolveRspCliBundle,
   type DevAfkMcpOperations,
 } from "../src/mcp-adapter.js";
+import type { DispatchedWorkerBirth } from "../src/runtime/mcp-worker-birth.js";
 import { dispatchInput } from "../../../packages/red-castle/src/mcp/worker.js";
 import type { HookExec } from "../src/core/hook-dispatcher.js";
 import { readPidStartTime } from "../src/core/state.js";
@@ -39,17 +39,22 @@ async function root(): Promise<string> {
   return value;
 }
 
+/** A Worker the host granted, as the birth request reports it (#2976). */
+function granted(pid: number): DispatchedWorkerBirth {
+  return {
+    worker_id: "wHOST",
+    pid,
+    log: join("/repo", ".red", "tmp", "logs", "2026-08-01", "dispatch-test.log"),
+    warnings: [],
+    admission: "within the host ceiling",
+  };
+}
+
 describe("castle MCP host adapter", () => {
-  it("resolves the sibling dev CLI bundle from local and cached MCP assets", () => {
-    expect(
-      resolveDevCliBundle(join("dist", "castle-mcp.bundle.min.mjs")),
-    ).toBe(join("dist", "dev.bundle.min.mjs"));
-    expect(
-      resolveDevCliBundle(
-        join("cache", "castle-mcp-2.76.1.bundle.min.mjs"),
-      ),
-    ).toBe(join("cache", "dev-2.76.1.bundle.min.mjs"));
-  });
+  // The sibling dev-bundle resolution a dispatch needs now lives on the
+  // published-entry path (`resolveDevScriptPath`, covered by its own suite): the
+  // adapter's copy existed only to hand a bundle to its own `spawn`, and since
+  // #2976 the daemon is the one that runs it.
 
   // Three consecutive dispatches died silently leaving only `worker.pid` — the
   // spawn discarded stdout/stderr, so a boot death left zero evidence (#2385).
@@ -210,14 +215,14 @@ describe("castle MCP host adapter", () => {
     );
   });
 
-  it("detaches MCP dispatches without writing progress to stdout", async () => {
+  it("dispatches through the host birth request without writing progress to stdout", async () => {
     const cwd = await root();
-    const launchRun = vi.fn(async (_cwd: string, _args: string[]) => ({ pid: 73 }));
+    const birthWorker = vi.fn(async (_cwd: string, _args: readonly string[]) => granted(73));
     const createIssue = vi.fn(async (_title: string, _opts: { labels: string[]; body: string }) => 2308);
     const ensureLabel = vi.fn(async () => undefined);
     const stdout = vi.spyOn(process.stdout, "write");
     const operations = createDefaultDevAfkMcpOperations(cwd, {
-      launchRun,
+      birthWorker,
       createIssue,
       ensureLabel,
     });
@@ -228,7 +233,11 @@ describe("castle MCP host adapter", () => {
       ).resolves.toMatchObject({
         kind: "afk",
         issue: 2306,
+        worker_id: "wHOST",
         worker_pid: 73,
+        // The host's verdict travels back: a dispatch nothing judged is the
+        // defect #2976 closed, so the reply says which ceiling admitted it.
+        admission: "within the host ceiling",
         status: "dispatched",
       });
       await expect(
@@ -241,6 +250,7 @@ describe("castle MCP host adapter", () => {
         kind: "go",
         demand: "--repair release",
         issue: 2308,
+        worker_id: "wHOST",
         worker_pid: 73,
         status: "dispatched",
       });
@@ -248,7 +258,7 @@ describe("castle MCP host adapter", () => {
       stdout.mockRestore();
     }
 
-    expect(launchRun).toHaveBeenNthCalledWith(
+    expect(birthWorker).toHaveBeenNthCalledWith(
       1,
       cwd,
       ["--issues", "2306", "--once", "--runner", "codex"],
@@ -257,18 +267,32 @@ describe("castle MCP host adapter", () => {
       labels: ["lane:go"],
     });
     expect(createIssue.mock.calls[0]?.[1].body).toContain("--repair release");
-    expect(launchRun.mock.calls[1]?.[1]).not.toContain("--repair release");
+    expect(birthWorker.mock.calls[1]?.[1]).not.toContain("--repair release");
     expect(stdout).not.toHaveBeenCalled();
+  });
+
+  it("reports a refused dispatch rather than a pid, when the host does not answer", async () => {
+    // Fail closed (ADR 0130 rule 6): the operator learns nothing was started and
+    // which repair is theirs — the alternative is a `dispatched` that lied.
+    const cwd = await root();
+    const birthWorker = vi.fn(async () => {
+      throw new Error("no Worker was started: the redskilled daemon did not answer on /run/rs.sock");
+    });
+    const operations = createDefaultDevAfkMcpOperations(cwd, { birthWorker });
+
+    await expect(
+      operations.dispatchIssue(cwd, { issue: 2306, runner: "codex" }),
+    ).rejects.toThrow(/the redskilled daemon did not answer/);
   });
 
   it("pins scout dispatch argv/engine wiring: lane:scout label, origin/run-mode flags, no mutation", async () => {
     const cwd = await root();
-    const launchRun = vi.fn(async (_cwd: string, _args: string[]) => ({ pid: 91 }));
+    const birthWorker = vi.fn(async (_cwd: string, _args: readonly string[]) => granted(91));
     const createIssue = vi.fn(async (_root: string, _spec: { title: string; body: string; labels: string[] }) => 2346);
     const ensureLabel = vi.fn(async () => undefined);
     const stdout = vi.spyOn(process.stdout, "write");
     const operations = createDefaultDevAfkMcpOperations(cwd, {
-      launchRun,
+      birthWorker,
       createIssue,
       ensureLabel,
     });
@@ -292,7 +316,7 @@ describe("castle MCP host adapter", () => {
 
     expect(ensureLabel).toHaveBeenCalledWith(cwd, "lane:scout");
     expect(createIssue.mock.calls[0]?.[1]).toMatchObject({ labels: ["lane:scout"] });
-    const engineArgs = launchRun.mock.calls[0]?.[1] as string[];
+    const engineArgs = birthWorker.mock.calls[0]?.[1] as string[];
     expect(engineArgs).toContain("--origin");
     expect(engineArgs[engineArgs.indexOf("--origin") + 1]).toBe("scout");
     expect(engineArgs).toContain("--run-mode");

--- a/apps/dev/tests/mcp-dispatch-birth.test.ts
+++ b/apps/dev/tests/mcp-dispatch-birth.test.ts
@@ -1,0 +1,117 @@
+// The MCP dispatch surface asks the host for its Workers (#2976, ADR 0130).
+//
+// `worker_dispatch` used to start the Worker itself: a `spawn` in the adapter,
+// no admission verdict, no host budget, nothing on the event lane. Three live
+// Workers, and a `host-state` that said `workers: 0`. The invariant was already
+// written down — the daemon is the only thing that births a Worker — and the
+// ratchet did not catch this path because the path was never declared.
+//
+// The daemon under test is the real one, started in-process on a scratch session
+// socket. A mock would answer whatever the assertion wanted, and the fact worth
+// proving is precisely that a second process does the launching now.
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startRedskilledDaemon, type RedskilledDaemon } from "@reddb-io/redskilled/daemon";
+import { resolveRedskilledPaths, type RedskilledPaths } from "@reddb-io/redskilled/paths";
+import { readRedskilledEvents } from "@reddb-io/redskilled/event-lane";
+import { readRedskilledHostState } from "@reddb-io/redskilled/client";
+import { dispatchLogPath, requestWorkerBirth } from "../src/runtime/mcp-worker-birth.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await scratch("mcp-dispatch-session-");
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+/** A Worker that idles long enough to be observed, then exits on its own. */
+const IDLE_ENTRY = ["-e", "setTimeout(() => undefined, 30_000);"];
+
+/** Paths that resolve to nothing on this machine — no daemon can answer here. */
+async function unreachablePaths(): Promise<RedskilledPaths> {
+  const root = await scratch("mcp-dispatch-nowhere-");
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+describe("a Worker dispatched through the MCP is born by the daemon", () => {
+  it("appears in host state under this project's label and on the event lane", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("mcp-dispatch-workspace-");
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000 });
+    running.push(daemon);
+
+    const granted = await requestWorkerBirth(workspace, ["--issues", "2976", "--once"], {
+      paths,
+      projectLabel: "acme/widgets",
+      entry: [process.execPath, ...IDLE_ENTRY],
+      stamp: "2026-08-01T05:45:43.492Z-abcd1234",
+    });
+
+    expect(granted.pid).toBeGreaterThan(0);
+    expect(granted.worker_id).not.toBe("");
+    // The host's own sentence about the ceiling that admitted this birth: a
+    // dispatch that reported no verdict would be a dispatch nothing judged.
+    expect(granted.admission.trim()).not.toBe("");
+
+    const state = await readRedskilledHostState(paths, { readyTimeoutMs: 5_000 });
+    const held = state.workers.find((worker) => worker.worker_id === granted.worker_id);
+    expect(held?.project_label).toBe("acme/widgets");
+    expect(held?.workspace_path).toBe(workspace);
+    // Counted by the budget, which is the whole point of asking: the host's own
+    // per-project tally is what an unbudgeted spawn never reached.
+    expect(state.projects).toContainEqual({ project_label: "acme/widgets", worker_count: 1 });
+
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    const birth = events.find(
+      (event) => event.worker_id === granted.worker_id && event.event === "worker-birth",
+    );
+    expect(birth?.project_label).toBe("acme/widgets");
+  });
+
+  it("refuses with a named reason and starts nothing when the daemon does not answer", async () => {
+    const workspace = await scratch("mcp-dispatch-workspace-");
+    const paths = await unreachablePaths();
+
+    await expect(
+      requestWorkerBirth(workspace, ["--issues", "2976", "--once"], {
+        paths,
+        projectLabel: "acme/widgets",
+        entry: [process.execPath, ...IDLE_ENTRY],
+        // No published bundle to auto-spawn a daemon from, and none invented.
+        config: { entryLookup: {}, readyTimeoutMs: 250 },
+      }),
+    ).rejects.toThrow(/no Worker was started: the redskilled daemon did not answer/);
+
+    // Nothing ran: the host holds no record, because nothing was ever launched.
+    const events = await readRedskilledEvents(paths.eventLanePath).catch(() => []);
+    expect(events.filter((event) => event.event === "worker-birth")).toEqual([]);
+  });
+
+  it("names a log path in the disposable logs lane, and the host opens it", async () => {
+    const stamp = "2026-08-01T05:45:43.492Z-abcd1234";
+    expect(dispatchLogPath("/repo", stamp)).toBe(
+      join("/repo", ".red", "tmp", "logs", "2026-08-01", "dispatch-2026-08-01T05-45-43-492Z-abcd1234.log"),
+    );
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2976. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2976

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788157305&installation_model_id=20659&pr_number=2988&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2988&signature=a97c1a8ecd3676cf14f333d8cc1c4dccdf9835d1047680a5f47b5afc0bd0e985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->