### PR TITLE
fix: #2985 The orchestrator hangs forever after a post-DONE correction round, parked in a review stage that is disabled

### DIFF
--- a/.changeset/orchestrator-lock-wait-is-loud.md
+++ b/.changeset/orchestrator-lock-wait-is-loud.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+An orchestrator hang after a post-DONE correction round is no longer silent. The gate's two host-wide file locks — the `validation-gate` semaphore (60-minute wait budget) and the feedback baseline worktree (10 minutes) — polled every 500ms with no child process, no socket and no write, so a worker blocked behind another worker's gate sat 30+ minutes in `ep_poll` reading `live=true` on every surface. Each wait now announces itself: the lock reports its holder, the holder's age, its own age and the budget left, throttled to one line every 30s, and it announces the end of the wait too, so a "blocked" banner can never outlive its block. `worker_vitals` gained the classifier for the shape the liveness lane cannot see — alive, orchestrator-owned phase, no child, silent for ten minutes — as an `orchestrator-wedged` alert (or `orchestrator-blocked` when the wait named itself). And a deactivated review stage is now a true no-op: the Re-seed budget no longer holds a round in reserve for a stage that will never draw it, which used to refuse the last correction round with `reservation` while the ceiling still had room.

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -263,18 +263,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // the `afk.feedback.rebase_on_base` flag is on; undefined → no rebase
   // (default behaviour unchanged).
   const config = loadConfig(paths.configPath, { warn: () => undefined });
-  const feedback = makeFeedbackWorktree(ctx.root, paths.feedbackWorktreesDir, undefined, {
-    rebaseOnto: settings.feedbackRebaseBase,
-    resourceBudget: readValidationResourceBudget(config),
-  });
-
-  // Wire the boot reconcile runner only when this boot actually owns sweeps.
-  if (!skipSweeps) {
-    bootDeps = { ...bootDeps, reconcileRunner: makeBootReconcileRunner(ctx, paths, workerId, runner, feedback) };
-  }
 
   // Per-issue mutable attempt context the process deps' envelope/iter-log close
-  // over; buildProcessInput resets it before each processIssue call.
+  // over; buildProcessInput resets it before each processIssue call. Built
+  // BEFORE the feedback manager so the gate's lock-wait sink can reach the live
+  // attempt dir and the worker event lane (#2985).
   const current: CurrentAttempt = { attemptDir: "" };
   const castleBridge = createCastleWorkerLaneBridge({
     redRoot: join(ctx.root, ".red"),
@@ -282,6 +275,49 @@ export async function runCommand(options: RunOptions): Promise<number> {
     attemptDir: () => current.attemptDir,
     supervisorLane: process.env[SUPERVISOR_LANE_ENV] || undefined,
   });
+
+  // Feedback worktree manager — checks out the worker branch for the gate.
+  // AFK runner improvement (Pattern 2): `feedbackRebaseBase` is set only when
+  // the `afk.feedback.rebase_on_base` flag is on; undefined → no rebase
+  // (default behaviour unchanged).
+  const feedback = makeFeedbackWorktree(ctx.root, paths.feedbackWorktreesDir, undefined, {
+    rebaseOnto: settings.feedbackRebaseBase,
+    resourceBudget: readValidationResourceBudget(config),
+    // A host-wide lock wait is the gate's only silent stall: no child, no
+    // socket, no write, and `live=true` on every surface for as long as an hour
+    // (#2985). Say it out loud on all three lanes the operator reads.
+    onLockWait: (notice) => {
+      const waiting = notice.state === "waiting";
+      if (current.attemptDir !== "") {
+        void fsx.appendLine(join(current.attemptDir, "afk.log"), notice.message);
+        void updateState(workerStatePath(current.attemptDir), {
+          // The terminal notice RETIRES the banner. A blocked marker that
+          // outlives its block is the same observability lie in reverse.
+          "current.blocked_on": waiting ? `lock:${notice.lock}` : "",
+          "current.blocked_detail": waiting ? notice.message : "",
+          "current.blocked_for_s": waiting ? String(Math.floor(notice.waitedMs / 1000)) : "",
+          "current.last_event_at": new Date().toISOString(),
+        }).catch(() => {});
+      }
+      void castleBridge
+        .record("worker.lock_wait", {
+          lock: notice.lock,
+          state: notice.state,
+          path: notice.path,
+          held_by: notice.heldBy ?? "",
+          held_by_pid: notice.heldByPid ?? 0,
+          held_for_s: Math.floor((notice.heldForMs ?? 0) / 1000),
+          waited_s: Math.floor(notice.waitedMs / 1000),
+          remaining_s: Math.floor(notice.remainingMs / 1000),
+        })
+        .catch(() => {});
+    },
+  });
+
+  // Wire the boot reconcile runner only when this boot actually owns sweeps.
+  if (!skipSweeps) {
+    bootDeps = { ...bootDeps, reconcileRunner: makeBootReconcileRunner(ctx, paths, workerId, runner, feedback) };
+  }
 
   // --request/-r special block, threaded into the handoff the agent reads.
   const requestBlock = specialUserRequestBlock(flags.request);

--- a/apps/dev/src/core/land-lock.ts
+++ b/apps/dev/src/core/land-lock.ts
@@ -8,5 +8,6 @@ export {
   type LandLockOptions,
   type LandLockRecord,
   type LandLockRelease,
+  type LandLockWaitInfo,
   type LandSerialization,
 } from "@reddb-io/red-castle/engine";

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -649,12 +649,32 @@ export async function processIssue(
   const afkGateCap = resolveReseedGateBudget(deps);
   const isGoLane = input.laneLabel === LABEL_GO_LANE;
   const reseedLane: "/go" | "/afk" = isGoLane ? "/go" : "/afk";
+  /**
+   * Is the fold's review stage ACTIVATED for this Worker? Decided ONCE, from
+   * everything that can switch it off — the operator's `enabled` flag, a missing
+   * reviewer/publisher port, a `/go` direct-PR dispatch, or no worktree-diff
+   * reader — because a disabled stage has to be a no-op on EVERY surface it
+   * touches, not just at its own call site (#2985). It gates two things: whether
+   * `runReviewStage` runs at all, and whether the Re-seed budget reserves the
+   * round it would have drawn.
+   */
+  const reviewStageActivated =
+    deps.adversarialReview?.enabled === true &&
+    deps.extractAdversarialReview !== undefined &&
+    deps.postAdversarialReview !== undefined &&
+    deps.lookups.worktreeDiff !== undefined &&
+    // /go direct-PR skips review; /go no-mistakes and /afk run it.
+    (!isGoLane || isPrePrPipelineActive(input.runMode, input.laneLabel));
   // ONE budget for every Re-seed this Worker may spend (ADR 0129): the lane
   // supplies the ceiling and the review's reservation, the operator's configured
   // counter supplies only the gate's share. A tier escalation therefore draws
   // its own round instead of muting gate correction outright.
   const reseedBudget = withGateSubCap(
-    resolveReseedBudget({ laneLabel: input.laneLabel, runMode: input.runMode }),
+    resolveReseedBudget({
+      laneLabel: input.laneLabel,
+      runMode: input.runMode,
+      reviewEnabled: reviewStageActivated,
+    }),
     isGoLane ? goVerifyRetryCap : afkGateCap,
   );
   let reseedSpend: ReseedSpend = {};
@@ -934,14 +954,14 @@ export async function processIssue(
    * budget and the review's own round would never fire.
    */
   const runReviewStage = async (): Promise<ReviewStageResult> => {
-    const config = deps.adversarialReview;
-    if (!config?.enabled || !deps.extractAdversarialReview || !deps.postAdversarialReview) {
-      return skippedReviewStage;
-    }
-    // /go direct-PR skips review; /go no-mistakes and /afk run it.
-    if (isGoLane && !isPrePrPipelineActive(input.runMode, input.laneLabel)) return skippedReviewStage;
-    const readWorktreeDiff = deps.lookups.worktreeDiff;
-    if (!readWorktreeDiff) return skippedReviewStage;
+    // ONE predicate, resolved at Worker start (see `reviewStageActivated`): a
+    // deactivated stage returns the SKIPPED outcome without reading a diff,
+    // spawning a reviewer, or awaiting anything.
+    if (!reviewStageActivated) return skippedReviewStage;
+    const config = deps.adversarialReview!;
+    const readWorktreeDiff = deps.lookups.worktreeDiff!;
+    const extractReview = deps.extractAdversarialReview!;
+    const postReview = deps.postAdversarialReview!;
     let findings: AdversarialReviewFindings;
     let decision: AdversarialReviewDecision;
     let diff: string;
@@ -971,7 +991,7 @@ export async function processIssue(
       const reviews: AdversarialReviewFindings[] = [];
       for (let i = 0; i < config.reviewerCount; i++) {
         reviews.push(
-          await deps.extractAdversarialReview({
+          await extractReview({
             context,
             runner: reviewer.runner,
             model: reviewer.model,
@@ -982,7 +1002,7 @@ export async function processIssue(
       }
       findings = aggregateAdversarialReviewFindings(reviews, config.quorum);
       decision = decideAdversarialReview(findings);
-      await deps.postAdversarialReview({
+      await postReview({
         issue: input.issue,
         findings,
         body: renderAdversarialReviewComment(findings, decision),

--- a/apps/dev/src/core/process-issue/reseed-budget.ts
+++ b/apps/dev/src/core/process-issue/reseed-budget.ts
@@ -95,14 +95,41 @@ export interface ResolveReseedBudgetInput {
   readonly laneLabel?: string;
   /** The `/go` dispatch mode; `no-mistakes` widens the ceiling. */
   readonly runMode?: string;
+  /**
+   * Is the fold's review stage ACTIVATED (`afk.review.enabled`)? Default `true`
+   * — every existing caller resolved the review-bearing ruler.
+   */
+  readonly reviewEnabled?: boolean;
+}
+
+/**
+ * Strip the review's share AND its reservation from a profile. A DISABLED stage
+ * must be a no-op, and a reservation is not one: the reserved round sits inside
+ * the ceiling, invisible to every other cause, waiting for a stage that will
+ * never ask for it (#2985). Under `/afk`'s ruler that silently converted the
+ * last round of a 4-round ceiling into dead capacity — a tier escalation after
+ * three gate corrections was refused with `reservation` while the ceiling still
+ * had room.
+ */
+export function withoutReviewReservation(budget: ReseedBudget): ReseedBudget {
+  return {
+    ...budget,
+    subCaps: { ...budget.subCaps, review: 0 },
+    reserved: { ...budget.reserved, review: 0 },
+  };
 }
 
 /** Resolve the lane's Re-seed budget. Anything that is not the `/go` lane is
  * `/afk`'s ruler, including the scout and manual dispatches, because they run
  * the same unattended pipeline. */
 export function resolveReseedBudget(input: ResolveReseedBudgetInput): ReseedBudget {
-  if (input.laneLabel !== LABEL_GO_LANE) return AFK_RESEED_BUDGET;
-  return input.runMode === "no-mistakes" ? GO_NO_MISTAKES_RESEED_BUDGET : GO_RESEED_BUDGET;
+  const lane =
+    input.laneLabel !== LABEL_GO_LANE
+      ? AFK_RESEED_BUDGET
+      : input.runMode === "no-mistakes"
+        ? GO_NO_MISTAKES_RESEED_BUDGET
+        : GO_RESEED_BUDGET;
+  return input.reviewEnabled === false ? withoutReviewReservation(lane) : lane;
 }
 
 /** What asked for a Re-seed round. A closed vocabulary of four: a gate stage

--- a/apps/dev/src/core/wedged-orchestrator.ts
+++ b/apps/dev/src/core/wedged-orchestrator.ts
@@ -1,0 +1,97 @@
+// core/wedged-orchestrator.ts — name the hang the liveness lane cannot see.
+//
+// Every stall signal this engine has watches the INNER AGENT: the liveness lane
+// advances on agent stream events, the reaper keys off its mtime, the vitals
+// call a worker with a live descendant healthy. None of them describes the
+// window AFTER the agent emits DONE, when the orchestrator itself owns the turn
+// — and an orchestrator that blocks there spawns no child, opens no socket and
+// writes nothing, so every surface reads `live=true` while nothing happens
+// (#2985: 30+ minutes parked in `ep_poll` behind a host-wide gate lock).
+//
+// This module is the classifier for that shape and nothing else. It is pure: it
+// takes what `worker_vitals` already knows and answers with an alert or null.
+
+/**
+ * The phases in which the ORCHESTRATOR — not the inner agent — owns the turn.
+ * Silence here means the engine itself is stuck; silence during `coding` means
+ * the agent is thinking, which is a different question with its own detector.
+ */
+export const ORCHESTRATOR_OWNED_PHASES: readonly string[] = ["validating", "merging"];
+
+/**
+ * How long an orchestrator-owned phase may be silent before it is a page.
+ *
+ * The gate's own steps are loud — every stage writes a validation record and
+ * spawns children — so ten minutes of nothing is not a slow test run, it is a
+ * wait nobody declared. Below this a genuinely long `pnpm install` between
+ * writes would page; far above it the hang outlives the fleet's patience.
+ */
+export const WEDGED_ORCHESTRATOR_SILENCE_MS = 10 * 60_000;
+
+export interface WedgedOrchestratorInput {
+  /** Is the worker process itself alive? A dead one is somebody else's alert. */
+  readonly live: boolean;
+  /** `current.phase` — which side of the DONE boundary the worker is on. */
+  readonly phase: string;
+  /** Age of the newest liveness-lane record, from the evaluator's verdict. */
+  readonly laneAgeMs?: number;
+  /** Does the worker have a live descendant process? */
+  readonly liveDescendants?: boolean;
+  /** `current.blocked_on` — a wait that NAMED itself (e.g. `lock:validation-gate`). */
+  readonly blockedOn?: string;
+  /** `current.blocked_detail` — that wait's own one-line account. */
+  readonly blockedDetail?: string;
+  /** Override for {@link WEDGED_ORCHESTRATOR_SILENCE_MS}. */
+  readonly silenceThresholdMs?: number;
+}
+
+export interface WedgedOrchestratorAlert {
+  /** `orchestrator-blocked` — waiting, and it said so. `orchestrator-wedged` —
+   * waiting, and nothing anywhere says on what. The second is the bug class. */
+  readonly type: "orchestrator-blocked" | "orchestrator-wedged";
+  readonly message: string;
+}
+
+function humanizeMs(ms: number): string {
+  const minutes = Math.floor(ms / 60_000);
+  return minutes >= 60 ? `${Math.floor(minutes / 60)}h${minutes % 60}m` : `${minutes}m`;
+}
+
+/**
+ * Classify the post-DONE stuck shape: alive, orchestrator-owned phase, no child
+ * process, and no lane record for {@link WEDGED_ORCHESTRATOR_SILENCE_MS}.
+ *
+ * A wait that NAMED itself still pages once it ages past the threshold — a
+ * declared hour-long block is a smaller lie than an undeclared one, not a
+ * healthy state — but it pages under its own name, carrying what it waits for.
+ * Returns `null` for every shape that is somebody else's problem.
+ */
+export function detectWedgedOrchestrator(
+  input: WedgedOrchestratorInput,
+): WedgedOrchestratorAlert | null {
+  if (!input.live) return null;
+  if (!ORCHESTRATOR_OWNED_PHASES.includes(input.phase)) return null;
+  // A live descendant IS the work; only the childless silence is the hang.
+  if (input.liveDescendants === true) return null;
+  const threshold = input.silenceThresholdMs ?? WEDGED_ORCHESTRATOR_SILENCE_MS;
+  const age = input.laneAgeMs;
+  if (age === undefined || age < threshold) return null;
+  const silent = humanizeMs(age);
+  const blockedOn = (input.blockedOn ?? "").trim();
+  if (blockedOn !== "") {
+    const detail = (input.blockedDetail ?? "").trim();
+    return {
+      type: "orchestrator-blocked",
+      message:
+        `Orchestrator has been blocked on \`${blockedOn}\` for ${silent} in phase \`${input.phase}\`` +
+        ` with no child process.${detail === "" ? "" : ` ${detail}`}`,
+    };
+  }
+  return {
+    type: "orchestrator-wedged",
+    message:
+      `Orchestrator has written nothing for ${silent} in phase \`${input.phase}\` with no child process` +
+      ` and nothing naming a wait — the inner agent is done and the engine is not progressing.` +
+      ` \`live=true\` here is liveness of the process, not of the work.`,
+  };
+}

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -60,6 +60,7 @@ import type { IssueCandidate } from "./core/session.js";
 import { listCandidates, listHitlCandidates } from "./runtime/gh.js";
 import { matchesSelector } from "./core/session.js";
 import { resolveHitlDecision } from "./core/hitl-resolve.js";
+import { detectWedgedOrchestrator } from "./core/wedged-orchestrator.js";
 import * as ghx from "./runtime/gh.js";
 import { publishedBundleArgv } from "./runtime/published-entry.js";
 import {
@@ -1226,7 +1227,19 @@ async function workerVitals(
       });
     }
   }));
+  const nowIso = new Date().toISOString();
   const all = records.map(({ state, ...record }) => {
+    // The post-DONE hang the liveness lane cannot see (#2985): alive, no child,
+    // orchestrator-owned phase, silent for minutes. A session-error alert is a
+    // harder fact and always wins; this fills the gap where there is none.
+    const wedged = detectWedgedOrchestrator({
+      live: record.live,
+      phase: state.current.phase,
+      laneAgeMs: record.livenessVerdict?.laneAgeMs,
+      liveDescendants: record.livenessVerdict?.liveDescendants,
+      blockedOn: state.current.blocked_on,
+      blockedDetail: state.current.blocked_detail,
+    });
     return {
     worker: {
       id: state.worker_id,
@@ -1266,7 +1279,9 @@ async function workerVitals(
     renderable_live: record.renderableLive,
     liveness: record.liveness,
     liveness_verdict: record.livenessVerdict,
-    alert: alerts.get(state.worker_id),
+    alert:
+      alerts.get(state.worker_id) ??
+      (wedged ? { type: wedged.type, at: nowIso, message: wedged.message } : undefined),
     // The record's own live flag can only WITHHOLD a death claim (see the
     // anchor): it never becomes an `alive` verdict of its own, so this payload
     // stays one anchor deep while refusing to call a visibly running Worker gone.

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -57,6 +57,7 @@ import type { PostWorkerFormatExec } from "../core/post-worker-format.js";
 import { execTool, pnpm as runPnpm, type ExecOptions, type ExecOutput } from "./exec.js";
 import * as gitx from "./git.js";
 import { createPathLock } from "./land-lock.js";
+import type { LandLockWaitInfo } from "../core/land-lock.js";
 
 /**
  * Is `token` an ALREADY-MATERIALISED checkout rather than a branch name (#2339)?
@@ -188,13 +189,43 @@ export interface FeedbackWorktreeIO {
    * Optional: an injected IO without it (every test fake) serializes only
    * in-process, which is all a single-process fixture needs.
    */
-  lock?(dest: string): Promise<(() => Promise<void>) | null>;
+  lock?(dest: string, onWait?: LockWaitSink): Promise<(() => Promise<void>) | null>;
   /**
    * Host-wide capacity-one semaphore for validation commands. Every live worker
    * and no-agent reconcile manager binds the same `.red/state` lock.
    */
-  gateLock?(root: string): Promise<(() => Promise<void>) | null>;
+  gateLock?(root: string, onWait?: LockWaitSink): Promise<(() => Promise<void>) | null>;
 }
+
+/**
+ * What the orchestrator is BLOCKED ON, named. The two host-wide locks here are
+ * the gate's only unbounded-looking waits, and both used to poll in complete
+ * silence — no child, no socket, no write — which read on every surface as a
+ * healthy `live=true` worker doing nothing for half an hour (#2985).
+ */
+export interface LockWaitNotice {
+  /** `validation-gate` (host-wide capacity-one) or `feedback-worktree`. */
+  lock: "validation-gate" | "feedback-worktree";
+  /**
+   * Where the wait stands. A `waiting` notice is only ever followed by exactly
+   * one terminal notice, so a reader that latches "blocked" on the first always
+   * gets the un-latch — a stall banner that outlives its stall is its own lie.
+   */
+  state: "waiting" | "acquired" | "timed-out";
+  /** The contended path. */
+  path: string;
+  /** Who holds it right now, when the lock record could be read. */
+  heldBy?: string;
+  heldByPid?: number;
+  heldForMs?: number;
+  /** How long this waiter has waited, and how much budget is left. */
+  waitedMs: number;
+  remainingMs: number;
+  /** One line naming the wait, ready for the iteration log. */
+  message: string;
+}
+
+export type LockWaitSink = (notice: LockWaitNotice) => void;
 
 /**
  * How long a landing revalidation waits for the baseline worktree before giving
@@ -214,6 +245,115 @@ const GATE_LOCK_STALE_MS = 24 * 60 * 60_000;
  * lockfile drift costs three installs, not one per check in the cycle.
  */
 const MAX_SETUP_ATTEMPTS = 3;
+
+/**
+ * How often a still-blocked waiter re-announces itself. The first poll speaks
+ * IMMEDIATELY — a wait nobody hears about for 30s is still a wait nobody can
+ * see at second 1 — and every later notice is spaced so a 60-minute gate-lock
+ * wait costs ~120 log lines rather than ~7200.
+ */
+export const LOCK_WAIT_NOTICE_INTERVAL_MS = 30_000;
+
+/** `754321` → `12m34s`. Coarse on purpose: the reader wants an order of
+ * magnitude, not a stopwatch. */
+export function formatWaitDuration(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}m${String(seconds).padStart(2, "0")}s`;
+}
+
+/**
+ * Render ONE wait observation as the notice the iteration log carries. It names
+ * the lock, the holder, how long the holder has had it, how long we have
+ * waited, and when we give up — everything a reader needs to tell "contended,
+ * making progress" from "wedged behind a corpse" without attaching a debugger.
+ */
+export function renderLockWaitNotice(
+  lock: LockWaitNotice["lock"],
+  info: LandLockWaitInfo,
+): LockWaitNotice {
+  const held =
+    info.heldBy === undefined
+      ? "held by an unreadable lock record"
+      : `held by \`${info.heldBy}\`` +
+        (info.heldByPid === undefined ? "" : ` (pid ${info.heldByPid})`) +
+        (info.heldForMs === undefined ? "" : ` for ${formatWaitDuration(info.heldForMs)}`);
+  return {
+    lock,
+    state: "waiting",
+    path: info.path,
+    ...(info.heldBy === undefined ? {} : { heldBy: info.heldBy }),
+    ...(info.heldByPid === undefined ? {} : { heldByPid: info.heldByPid }),
+    ...(info.heldForMs === undefined ? {} : { heldForMs: info.heldForMs }),
+    waitedMs: info.waitedMs,
+    remainingMs: info.remainingMs,
+    message:
+      `⏳ /afk gate: blocked on the host-wide \`${lock}\` lock (\`${info.path}\`), ${held} — ` +
+      `waited ${formatWaitDuration(info.waitedMs)}, giving up in ${formatWaitDuration(info.remainingMs)}.`,
+  };
+}
+
+/** The reporter behind one `acquire()`: a throttled per-poll sink plus the ONE
+ * terminal notice that retires whatever the waiting notices latched. */
+export interface LockWaitReporter {
+  onWait: (info: LandLockWaitInfo) => void;
+  /** Emit the terminal notice — only when a wait was actually announced. */
+  finish(acquired: boolean): void;
+}
+
+/**
+ * Adapt the lock's per-poll `onWait` to the caller's sink, throttled to
+ * {@link LOCK_WAIT_NOTICE_INTERVAL_MS}. Returns `undefined` when there is no
+ * sink, so the lock skips the work entirely.
+ */
+export function lockWaitReporter(
+  lock: LockWaitNotice["lock"],
+  sink: LockWaitSink | undefined,
+): LockWaitReporter | undefined {
+  if (!sink) return undefined;
+  let lastAnnouncedMs = -Infinity;
+  let announced = false;
+  let lastWaitedMs = 0;
+  let path = "";
+  return {
+    onWait(info) {
+      lastWaitedMs = info.waitedMs;
+      path = info.path;
+      if (info.attempt !== 1 && info.waitedMs - lastAnnouncedMs < LOCK_WAIT_NOTICE_INTERVAL_MS) return;
+      lastAnnouncedMs = info.waitedMs;
+      announced = true;
+      sink(renderLockWaitNotice(lock, info));
+    },
+    finish(acquired) {
+      // An UNCONTENDED acquire said nothing and so has nothing to retire.
+      if (!announced) return;
+      const waited = formatWaitDuration(lastWaitedMs);
+      sink({
+        lock,
+        state: acquired ? "acquired" : "timed-out",
+        path,
+        waitedMs: lastWaitedMs,
+        remainingMs: 0,
+        message: acquired
+          ? `✅ /afk gate: took the host-wide \`${lock}\` lock after waiting ${waited}.`
+          : `⛔ /afk gate: gave up on the host-wide \`${lock}\` lock after ${waited}; validation blocked.`,
+      });
+    },
+  };
+}
+
+/** Acquire through a reporter so both the wait and its end are announced. */
+async function acquireAnnounced(
+  lock: LockWaitNotice["lock"],
+  sink: LockWaitSink | undefined,
+  build: (onWait?: (info: LandLockWaitInfo) => void) => Promise<(() => Promise<void>) | null>,
+): Promise<(() => Promise<void>) | null> {
+  const reporter = lockWaitReporter(lock, sink);
+  const release = await build(reporter ? (info) => reporter.onWait(info) : undefined);
+  reporter?.finish(release !== null);
+  return release;
+}
 
 const defaultIO: FeedbackWorktreeIO = {
   worktreeAdd: gitx.worktreeAdd,
@@ -244,29 +384,31 @@ const defaultIO: FeedbackWorktreeIO = {
   },
   pnpm: runPnpm,
   exec: execTool,
-  lock: async (dest) => {
+  lock: async (dest, onWait) => {
     // The lock file sits BESIDE the worktree, not inside it — `git worktree
     // add` refuses a non-empty destination, so a lock file within `dest` would
     // block the very operation it guards.
     await mkdir(dirname(dest), { recursive: true });
-    return createPathLock(`${dest}.lock`, `feedback-worktree:${dest}`, {
-      waitTimeoutMs: WORKTREE_LOCK_WAIT_MS,
-      staleAfterMs: WORKTREE_LOCK_STALE_MS,
-      pollMs: 500,
-    }).acquire();
+    return acquireAnnounced("feedback-worktree", onWait, (report) =>
+      createPathLock(`${dest}.lock`, `feedback-worktree:${dest}`, {
+        waitTimeoutMs: WORKTREE_LOCK_WAIT_MS,
+        staleAfterMs: WORKTREE_LOCK_STALE_MS,
+        pollMs: 500,
+        ...(report ? { onWait: report } : {}),
+      }).acquire(),
+    );
   },
-  gateLock: async (root) => {
+  gateLock: async (root, onWait) => {
     const stateDir = join(root, ".red", "state");
     await mkdir(stateDir, { recursive: true });
-    return createPathLock(
-      join(stateDir, "validation-gate.lock"),
-      `validation-gate:${process.pid}`,
-      {
+    return acquireAnnounced("validation-gate", onWait, (report) =>
+      createPathLock(join(stateDir, "validation-gate.lock"), `validation-gate:${process.pid}`, {
         waitTimeoutMs: GATE_LOCK_WAIT_MS,
         staleAfterMs: GATE_LOCK_STALE_MS,
         pollMs: 500,
-      },
-    ).acquire();
+        ...(report ? { onWait: report } : {}),
+      }).acquire(),
+    );
   },
 };
 
@@ -322,6 +464,14 @@ export interface FeedbackWorktreeOptions {
   rebaseOnto?: string;
   /** Resource budget applied to validation subprocesses (#1758). */
   resourceBudget?: { nodeMaxOldSpaceMb?: number; vitestMaxWorkers?: number };
+  /**
+   * Where a BLOCKED wait announces itself (#2985). Both host-wide locks here
+   * can hold a worker for tens of minutes with no child process and no write,
+   * which every liveness surface reads as a healthy worker; the sink is how the
+   * wait reaches the iteration log, the worker event lane, and the vitals.
+   * Absent → the locks skip the reporting entirely (unchanged behaviour).
+   */
+  onLockWait?: LockWaitSink;
 }
 
 /**
@@ -340,6 +490,7 @@ export function makeFeedbackWorktree(
   const cacheEnabled = options.cacheEnabled !== false; // default: ON
   const rebaseOnto = options.rebaseOnto; // default: undefined (OFF)
   const resourceBudget = options.resourceBudget ?? {};
+  const onLockWait = options.onLockWait;
   const gitCtx: gitx.GitContext = { cwd: root };
   // branch -> resolved checkout path, or null when setup failed (block all runs).
   const resolved = new Map<string, string | null>();
@@ -389,7 +540,7 @@ export function makeFeedbackWorktree(
     run: () => Promise<ExecOutput>,
   ): Promise<ExecOutput> {
     if (!io.gateLock) return run();
-    const release = await io.gateLock(root);
+    const release = await io.gateLock(root, onLockWait);
     if (release === null) {
       return {
         code: 1,
@@ -468,7 +619,7 @@ export function makeFeedbackWorktree(
     // to a clean re-materialise — under the host-wide lock (#2437), because a
     // worktree path is a singleton and two processes materialising it at once
     // corrupt each other's setup.
-    const release = io.lock ? await io.lock(dest) : null;
+    const release = io.lock ? await io.lock(dest, onLockWait) : null;
     if (io.lock && release === null) {
       // Timed out waiting for the holder. This is CONTENTION, not corruption:
       // report it as a retryable setup failure so the next validation call

--- a/apps/dev/src/runtime/land-lock.ts
+++ b/apps/dev/src/runtime/land-lock.ts
@@ -10,7 +10,12 @@
 import { open, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { createFileLandLock, type LandLock, type LandLockFs } from "../core/land-lock.js";
+import {
+  createFileLandLock,
+  type LandLock,
+  type LandLockFs,
+  type LandLockWaitInfo,
+} from "../core/land-lock.js";
 
 /** Standard land-lock path for an AFK tmp dir (`.red/tmp/afk-land.lock`). */
 export function landLockPath(tmpDir: string): string {
@@ -71,7 +76,12 @@ function isHolderAlive(pid: number): boolean {
 export function createPathLock(
   path: string,
   holder: string,
-  options: { waitTimeoutMs?: number; pollMs?: number; staleAfterMs?: number } = {},
+  options: {
+    waitTimeoutMs?: number;
+    pollMs?: number;
+    staleAfterMs?: number;
+    onWait?: (info: LandLockWaitInfo) => void;
+  } = {},
   pid: number = process.pid,
 ): LandLock {
   return createFileLandLock(

--- a/apps/dev/src/types/state.ts
+++ b/apps/dev/src/types/state.ts
@@ -107,6 +107,15 @@ export const AfkCurrentSchema = z.object({
    * the existing `output_tokens` heartbeat counter for the report surface. */
   output_shaping_variant: z.string().default(""),
   output_shaping_enabled: z.boolean().default(false),
+  /** What the ORCHESTRATOR is blocked on, when it is blocked on something that
+   * spawns no child and writes nothing — today the two host-wide gate locks
+   * (#2985). Empty means "not blocked". Without it a worker waiting up to an
+   * hour on `validation-gate.lock` was indistinguishable from a healthy one:
+   * `live=true`, no child, no write, and nothing anywhere naming the wait.
+   * `blocked_for_s` is the wait's own age, distinct from `silent_for_s`. */
+  blocked_on: z.string().default(""),
+  blocked_detail: z.string().default(""),
+  blocked_for_s: z.union([z.number(), z.string()]).optional().default(""),
   /** Implementer projection measurements consumed by the throughput dashboard. */
   implementer_runner_startup_before_ms: z.number().default(0),
   implementer_runner_startup_after_ms: z.number().default(0),

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -1025,3 +1025,64 @@ describe("makeFeedbackWorktree setup failure names its cause (#2964)", () => {
     expect(latched.stderr).toContain("worktree add failed");
   });
 });
+
+describe("the gate's lock waits reach the caller's sink (#2985)", () => {
+  it("hands `onLockWait` to BOTH host-wide locks", async () => {
+    const reached: Array<{ lock: string; sinkWired: boolean }> = [];
+    const sink = (): void => {};
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async () => ({ ok: true, stderr: "" }),
+      worktreeRemove: async () => {},
+      pnpm: async () => ({ code: 0, stdout: "", stderr: "" }),
+      exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+      branchHead: async () => null,
+      worktreeHead: async () => null,
+      rebase: async () => ({ ok: true }),
+      lock: async (_dest, onWait) => {
+        reached.push({ lock: "feedback-worktree", sinkWired: onWait === sink });
+        return async () => {};
+      },
+      gateLock: async (_root, onWait) => {
+        reached.push({ lock: "validation-gate", sinkWired: onWait === sink });
+        return async () => {};
+      },
+    };
+
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io, {
+      cacheEnabled: false,
+      onLockWait: sink,
+    });
+    await fb.pnpm(["pnpm", "-C", "afk/wAAAA/1-x", "test"]);
+
+    expect(reached.map((r) => r.lock).sort()).toEqual(["feedback-worktree", "validation-gate"]);
+    // A sink that reaches only one lock leaves the other silent — which is the
+    // whole defect, half-fixed.
+    expect(reached.every((r) => r.sinkWired)).toBe(true);
+  });
+
+  it("leaves both locks unreported when no sink is wired (unchanged behaviour)", async () => {
+    const seen: Array<unknown> = [];
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async () => ({ ok: true, stderr: "" }),
+      worktreeRemove: async () => {},
+      pnpm: async () => ({ code: 0, stdout: "", stderr: "" }),
+      exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+      branchHead: async () => null,
+      worktreeHead: async () => null,
+      rebase: async () => ({ ok: true }),
+      lock: async (_dest, onWait) => {
+        seen.push(onWait);
+        return async () => {};
+      },
+      gateLock: async (_root, onWait) => {
+        seen.push(onWait);
+        return async () => {};
+      },
+    };
+
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io, { cacheEnabled: false });
+    await fb.pnpm(["pnpm", "-C", "afk/wAAAA/1-x", "test"]);
+
+    expect(seen).toEqual([undefined, undefined]);
+  });
+});

--- a/apps/dev/tests/gate-lock-wait-observability.test.ts
+++ b/apps/dev/tests/gate-lock-wait-observability.test.ts
@@ -1,0 +1,118 @@
+// The gate's two host-wide locks are the orchestrator's only silent waits: no
+// child, no socket, no write, and up to an hour of `ep_poll` that every
+// liveness surface reads as a healthy `live=true` worker (#2985). These tests
+// pin the cure — the wait announces itself, and it announces its END.
+
+import { describe, expect, it } from "vitest";
+import {
+  LOCK_WAIT_NOTICE_INTERVAL_MS,
+  formatWaitDuration,
+  lockWaitReporter,
+  renderLockWaitNotice,
+  type LockWaitNotice,
+} from "../src/runtime/feedback-worktree.js";
+import type { LandLockWaitInfo } from "../src/core/land-lock.js";
+
+function wait(overrides: Partial<LandLockWaitInfo> = {}): LandLockWaitInfo {
+  return {
+    path: "/repo/.red/state/validation-gate.lock",
+    holder: "validation-gate:2001",
+    heldBy: "validation-gate:1007",
+    heldByPid: 1007,
+    heldForMs: 12 * 60_000,
+    waitedMs: 0,
+    remainingMs: 60 * 60_000,
+    attempt: 1,
+    ...overrides,
+  };
+}
+
+describe("gate lock-wait notice", () => {
+  it("names the lock, the holder, the wait's age and when it gives up", () => {
+    const notice = renderLockWaitNotice("validation-gate", wait({ waitedMs: 90_000, remainingMs: 3_510_000 }));
+
+    expect(notice.state).toBe("waiting");
+    expect(notice.lock).toBe("validation-gate");
+    expect(notice.heldByPid).toBe(1007);
+    expect(notice.message).toContain("validation-gate");
+    expect(notice.message).toContain("/repo/.red/state/validation-gate.lock");
+    expect(notice.message).toContain("pid 1007");
+    expect(notice.message).toContain("waited 1m30s");
+    expect(notice.message).toContain("giving up in 58m30s");
+  });
+
+  it("stays legible when the lock record cannot be read", () => {
+    const notice = renderLockWaitNotice(
+      "feedback-worktree",
+      wait({ heldBy: undefined, heldByPid: undefined, heldForMs: undefined }),
+    );
+
+    expect(notice.heldBy).toBeUndefined();
+    expect(notice.message).toContain("unreadable lock record");
+  });
+
+  it("renders coarse durations", () => {
+    expect(formatWaitDuration(0)).toBe("0m00s");
+    expect(formatWaitDuration(9_400)).toBe("0m09s");
+    expect(formatWaitDuration(30 * 60_000 + 5_000)).toBe("30m05s");
+  });
+});
+
+describe("gate lock-wait reporter", () => {
+  it("is absent entirely when no sink is wired", () => {
+    expect(lockWaitReporter("validation-gate", undefined)).toBeUndefined();
+  });
+
+  it("speaks on the first poll, then no more often than the notice interval", () => {
+    const seen: LockWaitNotice[] = [];
+    const reporter = lockWaitReporter("validation-gate", (n) => seen.push(n))!;
+
+    // A 500ms poll over three minutes: 360 observations.
+    for (let i = 1; i <= 360; i++) reporter.onWait(wait({ attempt: i, waitedMs: (i - 1) * 500 }));
+
+    expect(seen[0]?.waitedMs).toBe(0);
+    // First poll + one per 30s across 179.5s of waiting.
+    expect(seen).toHaveLength(1 + Math.floor((359 * 500) / LOCK_WAIT_NOTICE_INTERVAL_MS));
+    for (let i = 1; i < seen.length; i++) {
+      expect(seen[i]!.waitedMs - seen[i - 1]!.waitedMs).toBeGreaterThanOrEqual(
+        LOCK_WAIT_NOTICE_INTERVAL_MS,
+      );
+    }
+  });
+
+  it("retires the banner when the lock is finally taken", () => {
+    const seen: LockWaitNotice[] = [];
+    const reporter = lockWaitReporter("validation-gate", (n) => seen.push(n))!;
+
+    reporter.onWait(wait({ attempt: 1, waitedMs: 0 }));
+    reporter.onWait(wait({ attempt: 2, waitedMs: 45_000 }));
+    reporter.finish(true);
+
+    const last = seen.at(-1)!;
+    expect(last.state).toBe("acquired");
+    expect(last.message).toContain("after waiting 0m45s");
+  });
+
+  it("says so out loud when the wait times out", () => {
+    const seen: LockWaitNotice[] = [];
+    const reporter = lockWaitReporter("feedback-worktree", (n) => seen.push(n))!;
+
+    reporter.onWait(wait({ attempt: 1, waitedMs: 0 }));
+    reporter.onWait(wait({ attempt: 2, waitedMs: 600_000 }));
+    reporter.finish(false);
+
+    const last = seen.at(-1)!;
+    expect(last.state).toBe("timed-out");
+    expect(last.message).toContain("gave up");
+    expect(last.message).toContain("validation blocked");
+  });
+
+  it("emits nothing at all for an uncontended acquire", () => {
+    const seen: LockWaitNotice[] = [];
+    const reporter = lockWaitReporter("validation-gate", (n) => seen.push(n))!;
+
+    reporter.finish(true);
+
+    expect(seen).toEqual([]);
+  });
+});

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -1167,6 +1167,54 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
 });
 
 
+describe("processIssue — a DEACTIVATED review stage is a no-op (#2985)", () => {
+  it("carries a post-DONE correction round straight to landing with no review await", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      // Round 1's gate fails, the Re-seed round's gate passes — the exact shape
+      // that parked worker wAX3A in `validating` forever.
+      feedbackResults: [false, true],
+      reseedGateBudget: 1,
+      locked: false,
+      worktreeDiff: "diff --git a/packages/x/src/a.ts b/packages/x/src/a.ts\n+const x = 1;\n",
+      adversarialReview: { enabled: false, maxIterations: 2, reviewerCount: 1, quorum: "any" },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.closed).toEqual([9]);
+    // Nothing about the deactivated stage ran: no diff read, no reviewer
+    // spawned, no verdict published — and, above all, nothing awaited.
+    expect(trace.worktreeDiffCalls).toEqual([]);
+    expect(trace.adversarialReviewContexts).toEqual([]);
+    expect(trace.adversarialReviews).toEqual([]);
+    // The correction round really happened; this is not a green-first-pass.
+    expect(trace.iterLogs.some((l) => l.includes("correction retry 1/"))).toBe(true);
+  });
+
+  it("spends the round the review would have reserved instead of parking on it", async () => {
+    // The operator bought FOUR gate corrections, which is the whole `/afk`
+    // ceiling. With review deactivated its reserved round is dead capacity: the
+    // fourth correction used to be refused with `reservation` while the ceiling
+    // still had room, parking a branch one green round short.
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackResults: [false, false, false, false, true],
+      reseedGateBudget: 4,
+      locked: false,
+      adversarialReview: { enabled: false, maxIterations: 1, reviewerCount: 1, quorum: "any" },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(5);
+    expect(trace.iterLogs.some((l) => l.includes("correction retry 4/4"))).toBe(true);
+    expect(trace.adversarialReviewContexts).toEqual([]);
+  });
+});
+
 describe("processIssue — review is the gate fold's third stage (#2730)", () => {
   it("default-off path lands without running the reviewer", async () => {
     const { deps, input, trace } = harness({

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -1762,6 +1762,8 @@ describe("processIssue — one Re-seed request path (#2727, ADR 0129)", () => {
       // A gate sub-cap far above the lane ceiling: the ceiling is what binds,
       // and the review's reserved round stays unreachable to gate and tier.
       reseedGateBudget: 9,
+      adversarialReview: { enabled: true, maxIterations: 1, reviewerCount: 1, quorum: "any" },
+      adversarialFindings: { summary: "Clean.", findings: [] },
     });
 
     const result = await processIssue(deps, input);
@@ -1771,6 +1773,24 @@ describe("processIssue — one Re-seed request path (#2727, ADR 0129)", () => {
     expect(reseeds(trace)).toHaveLength(3);
     expect(reseeds(trace).map((e) => e.payload?.round)).toEqual([1, 2, 3]);
     expect(trace.runAgentCalls).toHaveLength(4);
+  });
+
+  it("frees the review's reserved round to the other causes when the stage is deactivated (#2985)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackResults: [false, false, false, false, false, false],
+      classifyIssue: async () => "simple",
+      reseedGateBudget: 9,
+      // No `adversarialReview` — the fold's third stage never runs, so holding
+      // a round for it converts the last of the ceiling into dead capacity.
+      });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(reseeds(trace)).toHaveLength(4);
+    expect(reseeds(trace).map((e) => e.payload?.round)).toEqual([1, 2, 3, 4]);
+    expect(trace.runAgentCalls).toHaveLength(5);
   });
 
   it("names the cause on every emitted Re-seed event", async () => {

--- a/apps/dev/tests/reseed-budget.test.ts
+++ b/apps/dev/tests/reseed-budget.test.ts
@@ -105,6 +105,44 @@ describe("Re-seed budget — the review reservation", () => {
   });
 });
 
+describe("Re-seed budget — a DEACTIVATED review stage reserves nothing (#2985)", () => {
+  it("drops both the review sub-cap and its reservation", () => {
+    const budget = resolveReseedBudget({ reviewEnabled: false });
+
+    expect(budget.lane).toBe("/afk");
+    expect(budget.ceiling).toBe(AFK_RESEED_BUDGET.ceiling);
+    expect(budget.subCaps.review).toBe(0);
+    expect(budget.reserved.review).toBe(0);
+    // The other causes' shares are untouched: deactivating review must not
+    // quietly re-tune the gate's budget.
+    expect(budget.subCaps.gate).toBe(AFK_RESEED_BUDGET.subCaps.gate);
+    expect(budget.subCaps.tier).toBe(AFK_RESEED_BUDGET.subCaps.tier);
+  });
+
+  it("hands the freed round to a post-DONE tier escalation instead of holding it for a stage that never runs", () => {
+    const gateChurn = spend("gate", "gate", "gate");
+    // With review ACTIVATED the last round of the ceiling is held for it.
+    expect(reseedDraw(AFK_RESEED_BUDGET, "tier", gateChurn).refusal).toBe("reservation");
+    // Deactivated, the same correction round is drawable — a disabled stage is
+    // a no-op, never a withheld round.
+    const disabled = resolveReseedBudget({ reviewEnabled: false });
+    expect(reseedDraw(disabled, "tier", gateChurn).allowed).toBe(true);
+  });
+
+  it("refuses the review cause outright rather than leaving it half-funded", () => {
+    const disabled = resolveReseedBudget({ reviewEnabled: false });
+    expect(reseedDraw(disabled, "review", {}).allowed).toBe(false);
+    expect(reseedDraw(disabled, "review", {}).refusal).toBe("sub-cap");
+    expect(reseedBudgetDefects(disabled)).toEqual([]);
+  });
+
+  it("keeps the review-bearing ruler for every caller that does not say otherwise", () => {
+    expect(resolveReseedBudget({})).toBe(AFK_RESEED_BUDGET);
+    expect(resolveReseedBudget({ reviewEnabled: true })).toBe(AFK_RESEED_BUDGET);
+    expect(resolveReseedBudget({ laneLabel: LABEL_GO_LANE, reviewEnabled: false }).reserved.review).toBe(0);
+  });
+});
+
 describe("Re-seed budget — the ceiling binds the sub-caps", () => {
   it("stops the sub-caps drawing more rounds than the ceiling, whatever the mix", () => {
     for (const budget of [AFK_RESEED_BUDGET, GO_RESEED_BUDGET, GO_NO_MISTAKES_RESEED_BUDGET]) {

--- a/apps/dev/tests/wedged-orchestrator.test.ts
+++ b/apps/dev/tests/wedged-orchestrator.test.ts
@@ -1,0 +1,80 @@
+// The post-DONE hang has no detector of its own: every stall signal watches the
+// inner agent, and after DONE the agent is gone. #2985 is that gap — 30+ minutes
+// of `live=true` with no child, no socket and no write.
+
+import { describe, expect, it } from "vitest";
+import {
+  ORCHESTRATOR_OWNED_PHASES,
+  WEDGED_ORCHESTRATOR_SILENCE_MS,
+  detectWedgedOrchestrator,
+  type WedgedOrchestratorInput,
+} from "../src/core/wedged-orchestrator.js";
+
+/** The wAX3A shape: alive, phase `validating`, agent finished, nothing since. */
+function wedgedShape(overrides: Partial<WedgedOrchestratorInput> = {}): WedgedOrchestratorInput {
+  return {
+    live: true,
+    phase: "validating",
+    laneAgeMs: 31 * 60_000,
+    liveDescendants: false,
+    ...overrides,
+  };
+}
+
+describe("wedged orchestrator detection (#2985)", () => {
+  it("pages on the observed shape instead of reporting a healthy worker", () => {
+    const alert = detectWedgedOrchestrator(wedgedShape());
+
+    expect(alert?.type).toBe("orchestrator-wedged");
+    expect(alert?.message).toContain("31m");
+    expect(alert?.message).toContain("validating");
+    expect(alert?.message).toContain("no child process");
+    expect(alert?.message).toContain("`live=true`");
+  });
+
+  it("names the wait when the orchestrator declared one", () => {
+    const alert = detectWedgedOrchestrator(
+      wedgedShape({
+        blockedOn: "lock:validation-gate",
+        blockedDetail: "⏳ /afk gate: blocked on the host-wide `validation-gate` lock.",
+      }),
+    );
+
+    expect(alert?.type).toBe("orchestrator-blocked");
+    expect(alert?.message).toContain("lock:validation-gate");
+    expect(alert?.message).toContain("host-wide");
+  });
+
+  it("stays quiet while the inner agent owns the turn", () => {
+    expect(detectWedgedOrchestrator(wedgedShape({ phase: "coding" }))).toBeNull();
+    expect(detectWedgedOrchestrator(wedgedShape({ phase: "setup" }))).toBeNull();
+    for (const phase of ORCHESTRATOR_OWNED_PHASES) {
+      expect(detectWedgedOrchestrator(wedgedShape({ phase }))).not.toBeNull();
+    }
+  });
+
+  it("stays quiet when something is actually running", () => {
+    expect(detectWedgedOrchestrator(wedgedShape({ liveDescendants: true }))).toBeNull();
+  });
+
+  it("stays quiet below the silence threshold, and pages at it", () => {
+    expect(
+      detectWedgedOrchestrator(wedgedShape({ laneAgeMs: WEDGED_ORCHESTRATOR_SILENCE_MS - 1 })),
+    ).toBeNull();
+    expect(
+      detectWedgedOrchestrator(wedgedShape({ laneAgeMs: WEDGED_ORCHESTRATOR_SILENCE_MS })),
+    ).not.toBeNull();
+    // An unknown lane age is not evidence of a hang.
+    expect(detectWedgedOrchestrator(wedgedShape({ laneAgeMs: undefined }))).toBeNull();
+  });
+
+  it("leaves a dead worker to the machinery that owns death", () => {
+    expect(detectWedgedOrchestrator(wedgedShape({ live: false }))).toBeNull();
+  });
+
+  it("honours a caller-supplied threshold", () => {
+    expect(
+      detectWedgedOrchestrator(wedgedShape({ laneAgeMs: 120_000, silenceThresholdMs: 60_000 }))?.type,
+    ).toBe("orchestrator-wedged");
+  });
+});

--- a/packages/red-castle/src/engine/land-lock.test.ts
+++ b/packages/red-castle/src/engine/land-lock.test.ts
@@ -185,3 +185,70 @@ describe("castle file land-lock", () => {
     expect(h.elapsed()).toBe(10);
   });
 });
+
+describe("land lock — a wait names itself (#2985)", () => {
+  const LOCK = "/tmp/afk-land.lock";
+
+  it("says nothing when the lock is uncontended", async () => {
+    const h = harness();
+    const seen: unknown[] = [];
+
+    const release = await createFileLandLock(h.deps, {
+      path: LOCK,
+      holder: "wAAAA",
+      pid: 100,
+      onWait: (info) => seen.push(info),
+    }).acquire();
+
+    expect(release).not.toBeNull();
+    expect(seen).toEqual([]);
+  });
+
+  it("reports the holder, the wait's age and the budget left on every poll", async () => {
+    const h = harness();
+    await createFileLandLock(h.deps, { path: LOCK, holder: "wAAAA", pid: 100 }).acquire();
+    const waits: Array<Record<string, unknown>> = [];
+
+    const release = await createFileLandLock(h.deps, {
+      path: LOCK,
+      holder: "wBBBB",
+      pid: 200,
+      pollMs: 10,
+      waitTimeoutMs: 30,
+      onWait: (info) => waits.push({ ...info }),
+    }).acquire();
+
+    // 30ms budget at a 10ms poll: three announced waits, then the give-up.
+    expect(release).toBeNull();
+    expect(waits).toHaveLength(3);
+    expect(waits[0]).toMatchObject({
+      path: LOCK,
+      holder: "wBBBB",
+      heldBy: "wAAAA",
+      heldByPid: 100,
+      waitedMs: 0,
+      remainingMs: 30,
+      attempt: 1,
+    });
+    expect(waits[2]).toMatchObject({ waitedMs: 20, remainingMs: 10, attempt: 3 });
+  });
+
+  it("swallows a throwing sink — observability may never cost the lock", async () => {
+    const h = harness();
+    await createFileLandLock(h.deps, { path: LOCK, holder: "wAAAA", pid: 100 }).acquire();
+
+    const release = await createFileLandLock(h.deps, {
+      path: LOCK,
+      holder: "wBBBB",
+      pid: 200,
+      pollMs: 5,
+      waitTimeoutMs: 10,
+      onWait: () => {
+        throw new Error("sink exploded");
+      },
+    }).acquire();
+
+    expect(release).toBeNull();
+    expect(h.elapsed()).toBe(10);
+  });
+});

--- a/packages/red-castle/src/engine/land-lock.ts
+++ b/packages/red-castle/src/engine/land-lock.ts
@@ -21,6 +21,32 @@ export interface LandLockDeps {
   isHolderAlive(pid: number): boolean;
 }
 
+/**
+ * One observation of a WAIT — emitted before every poll sleep, so a contended
+ * lock is loud instead of silent. A file lock's whole cost is invisible by
+ * construction: no child process, no socket, no write, just `sleep(pollMs)` in
+ * a loop, which is exactly the shape an orchestrator hang wears (#2985). The
+ * waiter names what it waits for so nobody has to read a stack to find out.
+ */
+export interface LandLockWaitInfo {
+  /** The contended lock's path. */
+  path: string;
+  /** Who this waiter is. */
+  holder: string;
+  /** Who currently holds it, when the record could be read. */
+  heldBy?: string;
+  /** The holder's pid, when the record could be read. */
+  heldByPid?: number;
+  /** How long the CURRENT holder has held it. */
+  heldForMs?: number;
+  /** How long THIS waiter has waited so far. */
+  waitedMs: number;
+  /** How much of the wait budget is left before `acquire()` gives up. */
+  remainingMs: number;
+  /** 1-based poll count. */
+  attempt: number;
+}
+
 export interface LandLockOptions {
   path: string;
   holder: string;
@@ -28,6 +54,11 @@ export interface LandLockOptions {
   waitTimeoutMs?: number;
   pollMs?: number;
   staleAfterMs?: number;
+  /**
+   * Called before each poll sleep with {@link LandLockWaitInfo}. A throw is
+   * swallowed: observability may never cost the lock.
+   */
+  onWait?: (info: LandLockWaitInfo) => void;
 }
 
 export type LandLockRelease = () => Promise<void>;
@@ -102,6 +133,15 @@ export function createFileLandLock(
     };
   }
 
+  /** Fire the wait sink, swallowing its throw. */
+  function notifyWait(info: LandLockWaitInfo): void {
+    try {
+      options.onWait?.(info);
+    } catch {
+      /* observability may never cost the lock */
+    }
+  }
+
   function abandoned(record: LandLockRecord | null): boolean {
     if (record === null) return true;
     if (clock.now() - record.acquiredAtMs >= staleAfterMs) return true;
@@ -110,18 +150,37 @@ export function createFileLandLock(
 
   return {
     async acquire(): Promise<LandLockRelease | null> {
-      const deadline = clock.now() + waitTimeoutMs;
+      const startedAtMs = clock.now();
+      const deadline = startedAtMs + waitTimeoutMs;
+      let attempt = 0;
       for (;;) {
         const taken = await tryTake();
         if (taken) return taken;
 
-        if (abandoned(parseRecord(await fs.read(options.path)))) {
+        const record = parseRecord(await fs.read(options.path));
+        if (abandoned(record)) {
           await fs.remove(options.path);
           const stolen = await tryTake();
           if (stolen) return stolen;
         }
 
-        if (clock.now() >= deadline) return null;
+        const now = clock.now();
+        if (now >= deadline) return null;
+        attempt += 1;
+        notifyWait({
+          path: options.path,
+          holder: options.holder,
+          ...(record === null
+            ? {}
+            : {
+                heldBy: record.holder,
+                heldByPid: record.pid,
+                heldForMs: Math.max(0, now - record.acquiredAtMs),
+              }),
+          waitedMs: Math.max(0, now - startedAtMs),
+          remainingMs: Math.max(0, deadline - now),
+          attempt,
+        });
         await clock.sleep(pollMs);
       }
     },


### PR DESCRIPTION
Automated AFK landing for #2985. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2985

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788157833&installation_model_id=20659&pr_number=2989&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2989&signature=6a02c65ef7b0e907c200b8766417fefc48576af4830ac6ff295e3e2e0f53d611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->