### PR TITLE
fix: #2978 Worker state records are never reclaimed: 345 accumulated, 1 live, and every reader pays for the pile

### DIFF
--- a/apps/dev/src/commands/boot-sweeps.ts
+++ b/apps/dev/src/commands/boot-sweeps.ts
@@ -48,7 +48,10 @@ export function formatBootSweepResult(result: BootResult): string {
     // `spared` is reported beside `local` on purpose (#2866): a reclaim that
     // only ever prints its deletions cannot be audited for what it refused.
     ` | branches remote=${bc?.remoteLiveReaped.length ?? 0} local=${bc?.localLiveReaped.length ?? 0} spared=${bc?.localSpared?.length ?? 0}` +
-    ` | tmp-janitor expired=${tj?.expiredLanes.length ?? 0} workers=${tj?.staleWorkers.length ?? 0} orphan-runners=${tj?.orphanTestRunners?.length ?? 0} unknown=${tj?.unknownTmpRoots.length ?? 0} protected=${(tj?.protectedLiveWorkers.length ?? 0) + (tj?.protectedLiveFeedback.length ?? 0)}` +
+    // `state-records` is reported beside the lanes (#2978): the record reclaim
+    // states what it removed AND what it kept, so a pile that stops shrinking is
+    // visible as a protected count rather than as silence.
+    ` | tmp-janitor expired=${tj?.expiredLanes.length ?? 0} workers=${tj?.staleWorkers.length ?? 0} state-records=${tj?.workerStateRecords?.length ?? 0} orphan-runners=${tj?.orphanTestRunners?.length ?? 0} unknown=${tj?.unknownTmpRoots.length ?? 0} protected=${(tj?.protectedLiveWorkers.length ?? 0) + (tj?.protectedLiveFeedback.length ?? 0) + (tj?.protectedLiveWorkerStateRecords?.length ?? 0)}` +
     janitorRemovalLog +
     ` | docs-sweep ${ds?.action ?? "clean"} files=${ds?.files.length ?? 0}` +
     ` | unblocked=${us?.promoted.length ?? 0}` +

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -92,6 +92,7 @@ import { runHostPrerequisiteProbe } from "./operational-probes/host-prerequisite
 import { pathIsInsideTmp, removableUnknownTmpRoots } from "./tmp-janitor.js";
 import type { TmpJanitorPlan, WorkerDirJanitorPlan } from "./tmp-janitor.js";
 import type { WorkerProcessVerdict, WorkerReclaimPlan } from "./worker-reclaim.js";
+import type { WorkerStateRecordReclaimPlan } from "./worker-state-reclaim.js";
 import { LABEL_HUMAN, LABEL_QUARANTINE, LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
 import { readHitlTypeLabels } from "./config.js";
 import { isRefused, planTransition, type StateTransition } from "./state-transition.js";
@@ -247,6 +248,12 @@ export interface BootFs {
    * re-authorises each removal against a current answer.
    */
   workerWorkspaceLivenessVerdict?(path: string): Promise<WorkerProcessVerdict>;
+  /**
+   * The same question about the Worker a durable STATE RECORD names (#2978),
+   * asked by worker id because the record's path carries no workspace. An
+   * unwired or throwing probe spares the record, exactly like the two above.
+   */
+  workerStateRecordLivenessVerdict?(workerId: string): Promise<WorkerProcessVerdict>;
   /** Fresh owner-liveness verdict before removing a feedback worktree. */
   feedbackWorktreeLiveness?(
     path: string,
@@ -747,6 +754,10 @@ export interface BootOptions {
      * had no daemon answer to plan against, so the sweep reclaims nothing on its
      * behalf. */
     workerReclaim?: WorkerReclaimPlan;
+    /** The durable Worker STATE RECORD reclaim (#2978). Absent means the caller
+     * planned none, so the sweep removes no record — the pile is left intact
+     * rather than reclaimed on a plan nobody built. */
+    workerStateRecords?: WorkerStateRecordReclaimPlan;
   };
   /**
    * Skip every shared boot sweep (#623). When true, `runBoot` runs precheck +
@@ -837,6 +848,10 @@ export interface TmpJanitorSweepResult {
   workerWorkspaces: string[];
   /** Workspaces spared because the daemon did not call their Worker gone. */
   protectedLiveWorkspaces: string[];
+  /** Worker state records removed: gone, settled, and past the retention (#2978). */
+  workerStateRecords: string[];
+  /** Worker state records spared because the daemon did not call their Worker gone. */
+  protectedLiveWorkerStateRecords: string[];
   /** Paths a plan named outside this tmp tier: reported, never removed. */
   refusedOutsideTmp: string[];
   removals: Array<{
@@ -1052,6 +1067,8 @@ async function runTmpJanitorSweep(
     orphanTestRunners: [],
     workerWorkspaces: [],
     protectedLiveWorkspaces: [],
+    workerStateRecords: [],
+    protectedLiveWorkerStateRecords: [],
     refusedOutsideTmp: [],
     removals: [],
   };
@@ -1078,6 +1095,23 @@ async function runTmpJanitorSweep(
     await deps.fs.removeDir(path);
     result.removals.push({ path, livenessVerdict: "worker-dead" });
     result.workerWorkspaces.push(path);
+  }
+
+  // The durable Worker STATE RECORD lane (#2978). It runs beside the workspace
+  // pass because it answers to the same authority: the record of a Worker the
+  // daemon calls gone, settled past its retention, is the pile every reader was
+  // paying for. Fail CLOSED here too — an unwired or unanswerable probe keeps
+  // the record.
+  for (const verdict of sweep.workerStateRecords?.reclaim ?? []) {
+    const live = await deps.fs.workerStateRecordLivenessVerdict?.(verdict.worker_id)
+      .catch(() => "unknown" as const);
+    if (live !== "dead") {
+      result.protectedLiveWorkerStateRecords.push(verdict.path);
+      continue;
+    }
+    await deps.fs.removeDir(verdict.path);
+    result.removals.push({ path: verdict.path, livenessVerdict: "worker-dead" });
+    result.workerStateRecords.push(verdict.path);
   }
 
   const expired = [

--- a/apps/dev/src/core/worker-state-reclaim.ts
+++ b/apps/dev/src/core/worker-state-reclaim.ts
@@ -1,0 +1,200 @@
+// worker-state-reclaim.ts — reclaim for the durable Worker STATE RECORD lane,
+// `.red/state/castle/workers/<id>/state.toon` (issue #2978).
+//
+// PURE: every input is pre-read by the caller. No I/O, no process reads, no
+// clock — `nowMs` is injected.
+//
+// THE GAP THIS CLOSES. The tmp-lane janitor reclaims what a dead Worker left in
+// `.red/tmp/` and the daemon reclaims its own session runtime dirs, but the
+// record that NAMES those bytes was owned by neither, so it accumulated without
+// bound: 345 records to convey one live Worker. Every reader paid for the pile —
+// `worker_vitals` serialised 559KB across 18,633 lines — and the pile is what
+// turned a filter bug into an operator-facing lie, because the corpses buried
+// the live row.
+//
+// THE RULE, STATED ONCE. A record is reclaimable when its Worker's process is
+// gone AND the record has been settled for longer than the retention. Both
+// halves are load-bearing:
+//
+//   - "its process is gone" is the DAEMON's verdict (ADR 0130): it owns birth
+//     and death, so it cannot be out of date about a process it holds. A record
+//     born outside the daemon contributes its own recorded pid as EVIDENCE OF
+//     LIFE, which can only WITHHOLD a death claim, never manufacture one — the
+//     same asymmetry the liveness anchor publishes.
+//   - "settled" is what `updated_at` means once the process is gone: the record
+//     is written by its own Worker and by nothing else, so a Worker that no
+//     longer exists has written its last word. Whatever outcome the record
+//     carries at that instant IS its terminal outcome, and the verdict carries
+//     it so the reclaim reports what it removed rather than a bare path.
+//
+// THREE VERDICTS ON LIVENESS, NOT TWO, and the third is the load-bearing one:
+// `unknown` — an unreachable or stale daemon — is not `dead`, so it retains.
+// A reader that could not reach the authority must never report a running Worker
+// as gone; that inversion is what deleted a live lane once already (#2679).
+//
+// A SILENT TRUNCATION IS A FAILURE: every considered record lands in exactly one
+// of `reclaim` or `retain`, and `totals` states the identity so a caller can
+// assert it.
+
+import type { WorkerProcessVerdict } from "./worker-reclaim.js";
+
+/**
+ * How long a settled Worker state record is kept after its Worker's process is
+ * gone. DECLARED ONCE, HERE, and nowhere else.
+ *
+ * Twenty-four hours, because that is the shortest window that still covers a
+ * full overnight drain: an operator triaging the morning after a night of AFK
+ * work reads yesterday's records at their desk, and a retention shorter than a
+ * day would delete exactly the evidence that triage needs. Past a day the record
+ * is no longer the material anyone reads — the Worker's own lane log, the
+ * castle history and the tracker all outlive it — while every extra day of
+ * records is payload that every reader of every surface pays for on every read.
+ */
+export const WORKER_STATE_RECORD_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+/** One Worker state record on disk, with its liveness already resolved. */
+export interface WorkerStateRecordEntry {
+  /** The Worker the record belongs to. */
+  worker_id: string;
+  /** Absolute path of the record's directory (the parent of `state.toon`). */
+  path: string;
+  /**
+   * The DAEMON's verdict on this Worker's process, with the record's own pid
+   * already folded in as evidence of life. `unknown` retains — see the header.
+   */
+  liveness: WorkerProcessVerdict;
+  /**
+   * Epoch-ms of the record's last write, or `null` when the record carries no
+   * readable instant. A record whose settled instant cannot be read is RETAINED
+   * and reported: the janitor never guesses an age it could not measure.
+   */
+  updatedAtMs: number | null;
+  /** The outcome the record last recorded, carried into the verdict so the
+   * reclaim reports WHAT it removed and not merely that it removed something. */
+  outcome: string;
+}
+
+export type WorkerStateRecordVerdictKind =
+  /** The daemon names this Worker — the veto that outranks the retention. */
+  | "worker-live"
+  /** The daemon did not answer, or its answer is stale. Never a death. */
+  | "liveness-unknown"
+  /** No readable `updated_at`: the record's age is unmeasurable, so it stays. */
+  | "no-settled-instant"
+  /** The Worker is gone, but the record settled inside the retention window. */
+  | "within-retention"
+  /** Gone, settled, and past the retention: the only verdict that releases bytes. */
+  | "settled-reclaimable";
+
+/** One record, one verdict, one reason. */
+export interface WorkerStateRecordVerdict {
+  worker_id: string;
+  path: string;
+  liveness: WorkerProcessVerdict;
+  outcome: string;
+  /** How long the record has been settled, in ms, or `null` when unmeasurable. */
+  age_ms: number | null;
+  reclaim: boolean;
+  verdict: WorkerStateRecordVerdictKind;
+  reason: string;
+}
+
+export interface WorkerStateRecordReclaimTotals {
+  considered: number;
+  reclaim: number;
+  retain: number;
+}
+
+export interface WorkerStateRecordReclaimPlan {
+  reclaim: WorkerStateRecordVerdict[];
+  retain: WorkerStateRecordVerdict[];
+  totals: WorkerStateRecordReclaimTotals;
+}
+
+export interface WorkerStateRecordReclaimOptions {
+  /** The instant the retention is measured against. Injected, so this is pure. */
+  nowMs: number;
+  /** Retention override for tests. Defaults to {@link WORKER_STATE_RECORD_RETENTION_MS}. */
+  retentionMs?: number;
+}
+
+function judge(
+  entry: WorkerStateRecordEntry,
+  nowMs: number,
+  retentionMs: number,
+): WorkerStateRecordVerdict {
+  const ageMs = entry.updatedAtMs === null ? null : Math.max(0, nowMs - entry.updatedAtMs);
+  const base = {
+    worker_id: entry.worker_id,
+    path: entry.path,
+    liveness: entry.liveness,
+    outcome: entry.outcome,
+    age_ms: ageMs,
+  } as const;
+  const retain = (
+    verdict: WorkerStateRecordVerdictKind,
+    reason: string,
+  ): WorkerStateRecordVerdict => ({ ...base, reclaim: false, verdict, reason });
+
+  if (entry.liveness === "alive") {
+    return retain(
+      "worker-live",
+      "the daemon names this Worker, so its record is the record of a running Worker",
+    );
+  }
+  if (entry.liveness === "unknown") {
+    return retain(
+      "liveness-unknown",
+      "nothing could vouch for this Worker's process, and an unanswered question is not a death",
+    );
+  }
+  if (ageMs === null) {
+    return retain(
+      "no-settled-instant",
+      "this record carries no readable last-write instant, so its age cannot be measured",
+    );
+  }
+  if (ageMs <= retentionMs) {
+    return retain(
+      "within-retention",
+      `settled ${ageMs}ms ago, inside the ${retentionMs}ms retention`,
+    );
+  }
+  return {
+    ...base,
+    reclaim: true,
+    verdict: "settled-reclaimable",
+    reason:
+      `the daemon calls this Worker gone and its record has been settled for ${ageMs}ms, ` +
+      `past the ${retentionMs}ms retention`,
+  };
+}
+
+/**
+ * Plan the reclaim for a set of Worker state records.
+ *
+ * The plan is total: every entry appears exactly once across `reclaim` and
+ * `retain`, and `totals` states that identity.
+ */
+export function planWorkerStateRecordReclaim(
+  entries: readonly WorkerStateRecordEntry[],
+  options: WorkerStateRecordReclaimOptions,
+): WorkerStateRecordReclaimPlan {
+  const retentionMs = options.retentionMs ?? WORKER_STATE_RECORD_RETENTION_MS;
+  const reclaim: WorkerStateRecordVerdict[] = [];
+  const retain: WorkerStateRecordVerdict[] = [];
+  // Counted from the INPUT, never from the output arrays, so the accounting
+  // identity in `totals` is a real assertion rather than a tautology.
+  let considered = 0;
+  for (const entry of entries) {
+    considered += 1;
+    const verdict = judge(entry, options.nowMs, retentionMs);
+    if (verdict.reclaim) reclaim.push(verdict);
+    else retain.push(verdict);
+  }
+  return {
+    reclaim,
+    retain,
+    totals: { considered, reclaim: reclaim.length, retain: retain.length },
+  };
+}

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1256,7 +1256,7 @@ async function workerVitals(
       daemon_liveness: publishWorkerLiveness(resolveWorkerLiveness(hostAnswer, workerId)),
     });
   }
-  return filterWorkerVitalsLiveOnly(all, opts.live_only !== false);
+  return boundWorkerVitals(filterWorkerVitalsLiveOnly(all, opts.live_only !== false));
 }
 
 /**
@@ -1285,6 +1285,51 @@ export function filterWorkerVitalsLiveOnly<
     const at = r.alert?.at === undefined ? NaN : Date.parse(r.alert.at);
     return Number.isFinite(at) && nowMs - at <= WORKER_VITALS_ALERT_FRESH_MS;
   });
+}
+
+/**
+ * The ceiling on how many rows one `worker_vitals` answer may carry.
+ *
+ * The reclaim (#2978) is what keeps the record lane small; this is what keeps
+ * the PAYLOAD small while a pile exists at all — a surface must stay correct
+ * during the window between a Worker dying and the retention releasing its
+ * record, and on a `live_only: false` read that deliberately asks for the dead
+ * ones. Thirty-two rows is an order of magnitude above any real fleet width on
+ * one host, so a bounded answer never truncates a live fleet, and it holds the
+ * payload near the ~1KB-per-row this record shape costs instead of the 559KB
+ * that 345 corpses produced.
+ */
+export const WORKER_VITALS_MAX_RECORDS = 32;
+
+/**
+ * Bound the answer, LIVE ROWS FIRST.
+ *
+ * The ordering is the whole point, not a tidiness preference: when the pile
+ * buried the one live Worker, the first row a reader saw was a corpse whose
+ * `loc 0` read as "the worker produced nothing". Live rows sort ahead of dead
+ * ones and recent ahead of old, so the rows a bound can ever drop are the
+ * oldest dead ones — the rows whose evidence the Worker's own lane log and the
+ * castle history still carry.
+ */
+export function boundWorkerVitals<
+  T extends {
+    live?: boolean;
+    worker?: { started_at?: string; current?: { last_event_at?: string } };
+  },
+>(records: readonly T[], limit = WORKER_VITALS_MAX_RECORDS): T[] {
+  if (records.length <= limit) return [...records];
+  const recency = (record: T): number => {
+    const last = Date.parse(record.worker?.current?.last_event_at ?? "");
+    if (Number.isFinite(last)) return last;
+    const started = Date.parse(record.worker?.started_at ?? "");
+    return Number.isFinite(started) ? started : 0;
+  };
+  return [...records]
+    .sort((a, b) => {
+      if (a.live !== b.live) return a.live === true ? -1 : 1;
+      return recency(b) - recency(a);
+    })
+    .slice(0, limit);
 }
 
 function projectFields(

--- a/apps/dev/src/runtime/tmp-janitor.ts
+++ b/apps/dev/src/runtime/tmp-janitor.ts
@@ -24,6 +24,14 @@ import {
   type WorkerProcessVerdict,
   type WorkerReclaimPlan,
 } from "../core/worker-reclaim.js";
+import {
+  planWorkerStateRecordReclaim,
+  type WorkerStateRecordReclaimPlan,
+} from "../core/worker-state-reclaim.js";
+import {
+  applyWorkerStateRecordReclaim,
+  collectWorkerStateRecordEntries,
+} from "./worker-state-reclaim.js";
 import { decodeDevSnapshotSniff } from "../core/toon-snapshot.js";
 import { allWorkersRoots, parseReapableWorkerPath } from "../core/worker-paths.js";
 import { execTool } from "./exec.js";
@@ -103,6 +111,15 @@ export interface TmpJanitorReport {
    * it, never widen it.
    */
   workerReclaim: WorkerReclaimPlan;
+  /**
+   * The durable Worker STATE RECORD lane, `.red/state/castle/workers/` (#2978).
+   *
+   * It sits OUTSIDE this tmp tier on purpose — the record is durable state, not
+   * scratch — and it is swept here because this is the pass that already holds
+   * the daemon read every reclaim decision is made against. Nothing else owned
+   * the record, which is how 345 of them accumulated to convey one live Worker.
+   */
+  workerStateRecords: WorkerStateRecordReclaimPlan;
   staleWorkers: ReturnType<typeof planWorkerDirJanitor>;
   /** Supervisor fleet dirs partitioned by pid liveness. Live dirs are spared;
    * dead dirs are eligible for removal. */
@@ -134,6 +151,10 @@ export interface TmpJanitorApplyResult {
   workerWorkspaces: string[];
   /** Workspaces spared because the daemon did not call their Worker gone. */
   protectedLiveWorkspaces: string[];
+  /** Worker state records removed: gone, settled, and past the retention (#2978). */
+  workerStateRecords: string[];
+  /** Worker state records spared because the daemon did not call their Worker gone. */
+  protectedLiveWorkerStateRecords: string[];
   /** Paths a plan named outside this tmp tier: reported, never removed. */
   refusedOutsideTmp: string[];
   /** Every destructive action, including the liveness verdict authorising it. */
@@ -497,6 +518,16 @@ export interface TmpJanitorSources {
   daemon?: DaemonWorkerSetReader;
 }
 
+/**
+ * The repo root a `.red/tmp` dir belongs to. The tmp tier is always
+ * `<root>/.red/tmp` (ADR 0098), so the durable state lane this sweep also
+ * reclaims is reachable from the one path the janitor is already given —
+ * no second parameter that a caller could point somewhere else.
+ */
+function repoRootFromTmpDir(tmpDir: string): string {
+  return resolve(tmpDir, "..", "..");
+}
+
 export async function collectTmpJanitorReport(
   tmpDir: string,
   nowS: number,
@@ -513,6 +544,13 @@ export async function collectTmpJanitorReport(
     nowIso: new Date(nowS * 1000).toISOString(),
     observedPaths: workerArtifacts.observedPaths,
   });
+  const workerStateRecords = planWorkerStateRecordReclaim(
+    await collectWorkerStateRecordEntries(repoRootFromTmpDir(tmpDir), {
+      nowMs: nowS * 1000,
+      ...(sources.daemon === undefined ? {} : { daemon: sources.daemon }),
+    }),
+    { nowMs: nowS * 1000 },
+  );
   const [tmpRootNames, tmpRootEntries, logEntries, scratchEntries, diagnosticsEntries, feedbackEntries, workers, orphanFeedbackData, supervisorEntries] =
     await Promise.all([
       listNames(tmpDir),
@@ -543,6 +581,7 @@ export async function collectTmpJanitorReport(
       tmpRootNames,
     }),
     workerReclaim,
+    workerStateRecords,
     staleWorkers: planWorkerDirJanitor(workers),
     staleSupervisors: planSupervisorLaneJanitor(supervisorEntries),
     orphanFeedback,
@@ -585,6 +624,8 @@ export async function applyTmpJanitorReport(
     orphanTestRunners: [],
     workerWorkspaces: [],
     protectedLiveWorkspaces: [],
+    workerStateRecords: [],
+    protectedLiveWorkerStateRecords: [],
     refusedOutsideTmp: [],
     removals: [],
   };
@@ -632,6 +673,23 @@ export async function applyTmpJanitorReport(
     await rm(path, { recursive: true, force: true });
     result.removals.push({ path, livenessVerdict: "worker-dead" });
     result.workerWorkspaces.push(path);
+  }
+
+  // The durable Worker state records. Their own gate applies — the lane sits
+  // outside this tmp tier — and their own apply-time daemon re-read authorises
+  // each removal, exactly as the workspace pass above does (#2978).
+  {
+    const applied = await applyWorkerStateRecordReclaim(
+      repoRootFromTmpDir(tmpDir),
+      report.workerStateRecords,
+      options.daemon === undefined ? {} : { daemon: options.daemon },
+    );
+    result.workerStateRecords.push(...applied.removed);
+    result.protectedLiveWorkerStateRecords.push(...applied.protectedLive);
+    result.refusedOutsideTmp.push(...applied.refusedOutsideStateRoot);
+    for (const path of applied.removed) {
+      result.removals.push({ path, livenessVerdict: "worker-dead" });
+    }
   }
 
   for (const worker of report.staleWorkers.reclaim) {

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -28,6 +28,7 @@ import { readWorkerState } from "../../core/worker-state-reader.js";
 import { isLivePid, killTreeAndWait } from "../kill-tree.js";
 import { execTool, type ExecFn } from "../exec.js";
 import { collectTmpJanitorReport, readWorkerLivenessForTmpPath } from "../tmp-janitor.js";
+import { readWorkerLiveness } from "../liveness-anchor.js";
 import { issueMeta, type GhContext, type IssueStateRow } from "../gh.js";
 import * as ghx from "../gh.js";
 import * as gitx from "../git.js";
@@ -471,6 +472,10 @@ export async function buildBootDeps(
       // and never a pid file (Spec #2772 US 46).
       workerLivenessVerdict: (workerDir) => readWorkerLivenessForTmpPath(paths.tmpDir, workerDir),
       workerWorkspaceLivenessVerdict: (path) => readWorkerLivenessForTmpPath(paths.tmpDir, path),
+      // The state record carries no workspace path, so its Worker is named
+      // directly — the same daemon, asked the same question (#2978).
+      workerStateRecordLivenessVerdict: async (workerId) =>
+        (await readWorkerLiveness(workerId)).verdict,
       feedbackWorktreeLiveness: async (path) => {
         // Re-collect immediately before deletion: the boot plan may have been
         // built before another fleet spawned the feedback worktree's owner.

--- a/apps/dev/src/runtime/worker-state-reclaim.ts
+++ b/apps/dev/src/runtime/worker-state-reclaim.ts
@@ -1,0 +1,180 @@
+// runtime/worker-state-reclaim.ts — the IO half of the Worker state record
+// reclaim (issue #2978). The decision lives in `core/worker-state-reclaim.ts`;
+// this module reads the records, resolves liveness through the single anchor,
+// and removes exactly what the plan released.
+
+import { readdir, rm } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+  castleStateSnapshotPath,
+  createEnginePaths,
+  readCastleStateSnapshot,
+} from "@reddb-io/red-castle/engine";
+import type {
+  WorkerStateRecordEntry,
+  WorkerStateRecordReclaimPlan,
+} from "../core/worker-state-reclaim.js";
+import { isLivePid } from "./kill-tree.js";
+import {
+  readDaemonWorkerSet,
+  resolveWorkerLiveness,
+  type DaemonWorkerSet,
+  type DaemonWorkerSetReader,
+} from "./liveness-anchor.js";
+
+/**
+ * The durable Worker state record root for a repo: `.red/state/castle/workers`.
+ * Spelled once, so the containment gate and the collector cannot drift into two
+ * answers about which directory this sweep is allowed to touch.
+ */
+export function castleWorkerStateRoot(root: string): string {
+  return join(createEnginePaths(join(root, ".red")).castleStateRoot, "workers");
+}
+
+/**
+ * Whether a path lies strictly inside the Worker state root. A plan may name any
+ * path at all — it may have been built by an older bundle, or by hand — so every
+ * removal is gated on this: a path outside the lane is REPORTED and refused,
+ * never obeyed.
+ */
+export function pathIsInsideWorkerStateRoot(root: string, path: string): boolean {
+  const rel = relative(resolve(castleWorkerStateRoot(root)), resolve(path));
+  return rel !== "" && rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+export interface WorkerStateRecordSources {
+  /** How this sweep reaches the daemon. Injected so the read is testable at the
+   * seam the shipped path uses, and so a caller can hand over an answer it holds. */
+  daemon?: DaemonWorkerSetReader;
+}
+
+export interface CollectWorkerStateRecordOptions extends WorkerStateRecordSources {
+  /** Clock for the collector's own bookkeeping. Defaults to `Date.now()`. */
+  nowMs?: number;
+}
+
+/** One daemon read, or null when it did not answer. */
+async function readDaemon(read: DaemonWorkerSetReader): Promise<DaemonWorkerSet | null> {
+  try {
+    return await read();
+  } catch {
+    return null;
+  }
+}
+
+async function listRecordIds(root: string): Promise<string[]> {
+  try {
+    return (await readdir(castleWorkerStateRoot(root), { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The sweep's ONE liveness question, asked of the daemon with the record's own
+ * recorded pid folded in as evidence.
+ *
+ * The evidence is one-way by construction (see the liveness anchor): a live pid
+ * WITHHOLDS a death claim, and can never manufacture an `alive` verdict of its
+ * own. That is what keeps a record born outside the daemon — a Worker the daemon
+ * never birthed and so cannot vouch for — out of reclaim eligibility while the
+ * daemon stays the single source of every positive verdict.
+ */
+function livenessFor(
+  hostAnswer: DaemonWorkerSet | null,
+  workerId: string,
+  recordedPid: number | undefined,
+): WorkerStateRecordEntry["liveness"] {
+  const evidenceOfLife =
+    typeof recordedPid === "number" && recordedPid > 0 && isLivePid(recordedPid);
+  return resolveWorkerLiveness(hostAnswer, workerId, { evidenceOfLife }).verdict;
+}
+
+/**
+ * Read every Worker state record under `.red/state/castle/workers/` and resolve
+ * each one's liveness against a SINGLE daemon read, so two records of one sweep
+ * cannot be judged against two different answers.
+ *
+ * A record directory with no readable `state.toon` contributes nothing: it is
+ * not a record, and this sweep never removes what it could not read.
+ */
+export async function collectWorkerStateRecordEntries(
+  root: string,
+  options: CollectWorkerStateRecordOptions = {},
+): Promise<WorkerStateRecordEntry[]> {
+  const paths = createEnginePaths(join(root, ".red"));
+  const hostAnswer = await readDaemon(options.daemon ?? readDaemonWorkerSet);
+  const ids = await listRecordIds(root);
+  const entries: WorkerStateRecordEntry[] = [];
+  for (const id of ids) {
+    const snapshot = await readCastleStateSnapshot(
+      castleStateSnapshotPath(paths, "worker", id),
+    ).catch(() => undefined);
+    if (!snapshot || snapshot.kind !== "worker") continue;
+    const workerId = snapshot.worker_id ?? snapshot.id ?? id;
+    const updatedAtMs = Date.parse(snapshot.updated_at ?? "");
+    const phase = snapshot.current?.phase;
+    entries.push({
+      worker_id: workerId,
+      path: join(castleWorkerStateRoot(root), id),
+      liveness: livenessFor(hostAnswer, workerId, snapshot.pid),
+      updatedAtMs: Number.isFinite(updatedAtMs) ? updatedAtMs : null,
+      outcome: typeof phase === "string" && phase !== "" ? phase : "unknown",
+    });
+  }
+  return entries;
+}
+
+export interface WorkerStateRecordReclaimResult {
+  /** Record directories removed, in plan order. */
+  removed: string[];
+  /** Records the apply-time daemon read spared: a Worker was born since the plan. */
+  protectedLive: string[];
+  /** Paths the plan named outside the Worker state root: reported, never removed. */
+  refusedOutsideStateRoot: string[];
+  /** What was kept, and why — the plan's retain verdicts, carried through so the
+   * sweep reports what it KEPT alongside what it removed. */
+  retained: Array<{ path: string; verdict: string; reason: string }>;
+}
+
+/**
+ * Remove exactly the records the plan released.
+ *
+ * The daemon is RE-READ here, not carried from the plan: a Worker may have been
+ * born between collect and apply, and the plan is history the moment it is
+ * built. A removal is authorised by a CURRENT answer or it does not happen.
+ */
+export async function applyWorkerStateRecordReclaim(
+  root: string,
+  plan: WorkerStateRecordReclaimPlan,
+  options: WorkerStateRecordSources = {},
+): Promise<WorkerStateRecordReclaimResult> {
+  const hostAnswer = await readDaemon(options.daemon ?? readDaemonWorkerSet);
+  const result: WorkerStateRecordReclaimResult = {
+    removed: [],
+    protectedLive: [],
+    refusedOutsideStateRoot: [],
+    retained: plan.retain.map((verdict) => ({
+      path: verdict.path,
+      verdict: verdict.verdict,
+      reason: verdict.reason,
+    })),
+  };
+  for (const verdict of plan.reclaim) {
+    if (!pathIsInsideWorkerStateRoot(root, verdict.path)) {
+      result.refusedOutsideStateRoot.push(verdict.path);
+      continue;
+    }
+    // Fail CLOSED: only a current `dead` releases bytes. `unknown` — including an
+    // unreachable daemon — spares the record.
+    if (resolveWorkerLiveness(hostAnswer, verdict.worker_id).verdict !== "dead") {
+      result.protectedLive.push(verdict.path);
+      continue;
+    }
+    await rm(verdict.path, { recursive: true, force: true });
+    result.removed.push(verdict.path);
+  }
+  return result;
+}

--- a/apps/dev/tests/boot-cleanup.test.ts
+++ b/apps/dev/tests/boot-cleanup.test.ts
@@ -42,6 +42,95 @@ function workspaceVerdict(workerId: string, path: string): WorkerArtifactVerdict
   };
 }
 
+/** One dead Worker's durable state record, condemned by the record planner. */
+function stateRecordVerdict(workerId: string) {
+  return {
+    worker_id: workerId,
+    path: `/p/.red/state/castle/workers/${workerId}`,
+    liveness: "dead" as const,
+    outcome: "terminal",
+    age_ms: 2 * 24 * 60 * 60 * 1000,
+    reclaim: true,
+    verdict: "settled-reclaimable" as const,
+    reason: "the daemon calls this Worker gone and its record is past the retention",
+  };
+}
+
+// #2978: nothing owned the durable Worker STATE RECORD, so 345 accumulated to
+// convey one live Worker. The boot sweep reclaims it on the same authority every
+// other reclaim answers to, and fails CLOSED on anything short of `dead`.
+describe("runBoot Worker state record reclaim", () => {
+  it("removes a record whose Worker the daemon calls gone", async () => {
+    const { deps, fsCalls } = makeDeps({ workerStateRecordLivenessVerdict: async () => "dead" });
+    const result = await runBoot(
+      deps,
+      options({
+        tmpJanitor: {
+          plan: emptyJanitorPlan(),
+          staleWorkers: { reclaim: [], spare: [] },
+          workerStateRecords: {
+            reclaim: [stateRecordVerdict("wDEAD")],
+            retain: [],
+            totals: { considered: 1, reclaim: 1, retain: 0 },
+          },
+        },
+      }),
+    );
+    expect(fsCalls.removeDir).toEqual(["/p/.red/state/castle/workers/wDEAD"]);
+    expect(result.tmpJanitor?.workerStateRecords).toEqual([
+      "/p/.red/state/castle/workers/wDEAD",
+    ]);
+    expect(result.tmpJanitor?.removals).toContainEqual({
+      path: "/p/.red/state/castle/workers/wDEAD",
+      livenessVerdict: "worker-dead",
+    });
+  });
+
+  it("keeps the record when the probe answers anything but dead", async () => {
+    const { deps, fsCalls } = makeDeps({ workerStateRecordLivenessVerdict: async () => "unknown" });
+    const result = await runBoot(
+      deps,
+      options({
+        tmpJanitor: {
+          plan: emptyJanitorPlan(),
+          staleWorkers: { reclaim: [], spare: [] },
+          workerStateRecords: {
+            reclaim: [stateRecordVerdict("wMAYBE")],
+            retain: [],
+            totals: { considered: 1, reclaim: 1, retain: 0 },
+          },
+        },
+      }),
+    );
+    expect(fsCalls.removeDir).toEqual([]);
+    expect(result.tmpJanitor?.protectedLiveWorkerStateRecords).toEqual([
+      "/p/.red/state/castle/workers/wMAYBE",
+    ]);
+  });
+
+  it("keeps the record when the probe is not wired at all — fail closed", async () => {
+    const { deps, fsCalls } = makeDeps();
+    const result = await runBoot(
+      deps,
+      options({
+        tmpJanitor: {
+          plan: emptyJanitorPlan(),
+          staleWorkers: { reclaim: [], spare: [] },
+          workerStateRecords: {
+            reclaim: [stateRecordVerdict("wUNWIRED")],
+            retain: [],
+            totals: { considered: 1, reclaim: 1, retain: 0 },
+          },
+        },
+      }),
+    );
+    expect(fsCalls.removeDir).toEqual([]);
+    expect(result.tmpJanitor?.protectedLiveWorkerStateRecords).toEqual([
+      "/p/.red/state/castle/workers/wUNWIRED",
+    ]);
+  });
+});
+
 describe("runBoot tmp janitor", () => {
   it("reaps orphan test-runner groups and records an audit row", async () => {
     const { deps } = makeDeps();
@@ -109,6 +198,8 @@ describe("runBoot tmp janitor", () => {
       orphanTestRunners: [],
       workerWorkspaces: [],
       protectedLiveWorkspaces: [],
+      workerStateRecords: [],
+      protectedLiveWorkerStateRecords: [],
       refusedOutsideTmp: [],
       removals: [
         { path: "/p/.red/tmp/logs/old", livenessVerdict: "not-worker-workspace" },

--- a/apps/dev/tests/boot.helpers.ts
+++ b/apps/dev/tests/boot.helpers.ts
@@ -53,6 +53,7 @@ export function makeDeps(over: Partial<{
   claimedIssues: BootDeps["lookups"]["claimedIssues"];
   workerLivenessVerdict: BootDeps["fs"]["workerLivenessVerdict"];
   workerWorkspaceLivenessVerdict: BootDeps["fs"]["workerWorkspaceLivenessVerdict"];
+  workerStateRecordLivenessVerdict: BootDeps["fs"]["workerStateRecordLivenessVerdict"];
   viewLabels: (issue: number) => Promise<string[]>;
   env: Record<string, string | undefined>;
   config: Record<string, string | undefined>;
@@ -111,6 +112,14 @@ export function makeDeps(over: Partial<{
             async workerWorkspaceLivenessVerdict(path: string) {
               calls.push(`fs.workerWorkspaceLivenessVerdict:${path}`);
               return over.workerWorkspaceLivenessVerdict!(path);
+            },
+          }
+        : {}),
+      ...(over.workerStateRecordLivenessVerdict
+        ? {
+            async workerStateRecordLivenessVerdict(workerId: string) {
+              calls.push(`fs.workerStateRecordLivenessVerdict:${workerId}`);
+              return over.workerStateRecordLivenessVerdict!(workerId);
             },
           }
         : {}),

--- a/apps/dev/tests/worker-state-reclaim.test.ts
+++ b/apps/dev/tests/worker-state-reclaim.test.ts
@@ -1,0 +1,319 @@
+// worker-state-reclaim.test.ts — the durable Worker STATE RECORD lane is
+// reclaimed on the daemon's process truth plus a retention (#2978).
+//
+// The pile this covers is `.red/state/castle/workers/<id>/state.toon`: 345
+// records where one Worker was live, because nothing ever reclaimed a record
+// once its Worker died. The tmp-lane janitor reclaimed the workspace bytes and
+// left the record that names them behind.
+
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { encode } from "@reddb-io/toon";
+import {
+  WORKER_STATE_RECORD_RETENTION_MS,
+  planWorkerStateRecordReclaim,
+  type WorkerStateRecordEntry,
+} from "../src/core/worker-state-reclaim.js";
+import {
+  applyWorkerStateRecordReclaim,
+  castleWorkerStateRoot,
+  collectWorkerStateRecordEntries,
+} from "../src/runtime/worker-state-reclaim.js";
+import { applyTmpJanitorReport, collectTmpJanitorReport } from "../src/runtime/tmp-janitor.js";
+import type { DaemonWorkerSetReader } from "../src/runtime/liveness-anchor.js";
+
+const NOW_MS = 1_800_000_000_000;
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "red-skills-worker-state-reclaim-"));
+  roots.push(root);
+  return root;
+}
+
+/** A fresh daemon answer naming exactly these Workers. */
+function daemonNaming(...workerIds: readonly string[]): DaemonWorkerSetReader {
+  return async () => ({
+    staleness: { stale: false, age_ms: 120, threshold_ms: 90_000, reason: "measured 120ms ago" },
+    workers: workerIds.map((worker_id, index) => ({
+      worker_id,
+      project_label: "red-skills",
+      pid: 4_000 + index,
+    })),
+  });
+}
+
+/** A daemon that did not answer at all. */
+const noDaemon: DaemonWorkerSetReader = async () => null;
+
+function entry(over: Partial<WorkerStateRecordEntry> = {}): WorkerStateRecordEntry {
+  return {
+    worker_id: "wDEAD",
+    path: "/tmp/.red/state/castle/workers/wDEAD",
+    liveness: "dead",
+    updatedAtMs: NOW_MS - WORKER_STATE_RECORD_RETENTION_MS - 1,
+    outcome: "terminal",
+    ...over,
+  };
+}
+
+/** Write one castle Worker state record with a chosen `updated_at` and pid. */
+async function writeRecord(
+  root: string,
+  workerId: string,
+  opts: { updatedAtMs?: number; pid?: number; phase?: string } = {},
+): Promise<string> {
+  const dir = join(castleWorkerStateRoot(root), workerId);
+  await mkdir(dir, { recursive: true });
+  const updatedAt = new Date(opts.updatedAtMs ?? NOW_MS).toISOString();
+  await writeFile(
+    join(dir, "state.toon"),
+    encode({
+      kind: "worker",
+      id: workerId,
+      version: 1,
+      updated_at: updatedAt,
+      worker_id: workerId,
+      runner: "claude",
+      pid: opts.pid ?? 0,
+      started_at: updatedAt,
+      current: { number: 1, phase: opts.phase ?? "terminal" },
+    }),
+    "utf8",
+  );
+  return dir;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("the retention is declared once, with its reason", () => {
+  it("is a single exported constant the planner defaults to", () => {
+    expect(WORKER_STATE_RECORD_RETENTION_MS).toBe(24 * 60 * 60 * 1000);
+    const settled = entry({ updatedAtMs: NOW_MS - WORKER_STATE_RECORD_RETENTION_MS - 1 });
+    const fresh = entry({ updatedAtMs: NOW_MS - WORKER_STATE_RECORD_RETENTION_MS + 1 });
+    expect(planWorkerStateRecordReclaim([settled], { nowMs: NOW_MS }).reclaim).toHaveLength(1);
+    expect(planWorkerStateRecordReclaim([fresh], { nowMs: NOW_MS }).reclaim).toHaveLength(0);
+  });
+});
+
+describe("planWorkerStateRecordReclaim", () => {
+  it("reclaims a dead Worker's record once the retention has passed", () => {
+    const plan = planWorkerStateRecordReclaim([entry()], { nowMs: NOW_MS });
+    expect(plan.reclaim.map((v) => v.verdict)).toEqual(["settled-reclaimable"]);
+    expect(plan.retain).toHaveLength(0);
+    expect(plan.totals).toEqual({ considered: 1, reclaim: 1, retain: 0 });
+  });
+
+  it("NEVER reclaims a live Worker's record, however old the record is", () => {
+    const plan = planWorkerStateRecordReclaim(
+      [entry({ liveness: "alive", updatedAtMs: 0 })],
+      { nowMs: NOW_MS },
+    );
+    expect(plan.reclaim).toHaveLength(0);
+    expect(plan.retain.map((v) => v.verdict)).toEqual(["worker-live"]);
+  });
+
+  it("retains a record the daemon could not answer for — unknown is not a death", () => {
+    const plan = planWorkerStateRecordReclaim(
+      [entry({ liveness: "unknown", updatedAtMs: 0 })],
+      { nowMs: NOW_MS },
+    );
+    expect(plan.reclaim).toHaveLength(0);
+    expect(plan.retain.map((v) => v.verdict)).toEqual(["liveness-unknown"]);
+  });
+
+  it("retains a dead Worker's record while it is still inside the retention", () => {
+    const plan = planWorkerStateRecordReclaim(
+      [entry({ updatedAtMs: NOW_MS - 60_000 })],
+      { nowMs: NOW_MS },
+    );
+    expect(plan.retain.map((v) => v.verdict)).toEqual(["within-retention"]);
+  });
+
+  it("retains a record whose settled instant it cannot read, rather than guessing", () => {
+    const plan = planWorkerStateRecordReclaim([entry({ updatedAtMs: null })], { nowMs: NOW_MS });
+    expect(plan.retain.map((v) => v.verdict)).toEqual(["no-settled-instant"]);
+  });
+
+  it("reports every considered record exactly once — no silent truncation", () => {
+    const entries = [
+      entry({ worker_id: "wA" }),
+      entry({ worker_id: "wB", liveness: "alive" }),
+      entry({ worker_id: "wC", liveness: "unknown" }),
+      entry({ worker_id: "wD", updatedAtMs: NOW_MS }),
+    ];
+    const plan = planWorkerStateRecordReclaim(entries, { nowMs: NOW_MS });
+    expect(plan.totals.considered).toBe(4);
+    expect(plan.totals.reclaim + plan.totals.retain).toBe(4);
+    expect([...plan.reclaim, ...plan.retain].map((v) => v.worker_id).sort()).toEqual([
+      "wA",
+      "wB",
+      "wC",
+      "wD",
+    ]);
+  });
+
+  it("carries the outcome the record last recorded into its verdict", () => {
+    const plan = planWorkerStateRecordReclaim([entry({ outcome: "gate" })], { nowMs: NOW_MS });
+    expect(plan.reclaim[0]?.outcome).toBe("gate");
+  });
+});
+
+describe("the reclaim runs against real records on disk", () => {
+  it("removes the dead Worker's record and keeps the live one", async () => {
+    const root = await tempRoot();
+    const deadDir = await writeRecord(root, "wDEAD", {
+      updatedAtMs: NOW_MS - WORKER_STATE_RECORD_RETENTION_MS - 1,
+    });
+    const liveDir = await writeRecord(root, "wLIVE", { updatedAtMs: 0 });
+
+    const collected = await collectWorkerStateRecordEntries(root, {
+      nowMs: NOW_MS,
+      daemon: daemonNaming("wLIVE"),
+    });
+    const plan = planWorkerStateRecordReclaim(collected, { nowMs: NOW_MS });
+    const applied = await applyWorkerStateRecordReclaim(root, plan, {
+      daemon: daemonNaming("wLIVE"),
+    });
+
+    expect(applied.removed).toEqual([deadDir]);
+    expect(applied.refusedOutsideStateRoot).toEqual([]);
+    expect(await exists(deadDir)).toBe(false);
+    expect(await exists(liveDir)).toBe(true);
+  });
+
+  it("spares every record when the daemon is unreachable", async () => {
+    const root = await tempRoot();
+    const dir = await writeRecord(root, "wDEAD", { updatedAtMs: 0 });
+    const collected = await collectWorkerStateRecordEntries(root, {
+      nowMs: NOW_MS,
+      daemon: noDaemon,
+    });
+    const plan = planWorkerStateRecordReclaim(collected, { nowMs: NOW_MS });
+    expect(plan.reclaim).toHaveLength(0);
+    const applied = await applyWorkerStateRecordReclaim(root, plan, { daemon: noDaemon });
+    expect(applied.removed).toEqual([]);
+    expect(await exists(dir)).toBe(true);
+  });
+
+  it("spares a record whose own recorded pid is still running — pid liveness for records born outside the daemon", async () => {
+    const root = await tempRoot();
+    const dir = await writeRecord(root, "wSELF", { updatedAtMs: 0, pid: process.pid });
+    const collected = await collectWorkerStateRecordEntries(root, {
+      nowMs: NOW_MS,
+      daemon: daemonNaming(),
+    });
+    expect(collected.map((e) => e.liveness)).toEqual(["unknown"]);
+    const plan = planWorkerStateRecordReclaim(collected, { nowMs: NOW_MS });
+    const applied = await applyWorkerStateRecordReclaim(root, plan, { daemon: daemonNaming() });
+    expect(applied.removed).toEqual([]);
+    expect(await exists(dir)).toBe(true);
+  });
+
+  it("re-asks the daemon at apply time — a Worker born since the plan keeps its record", async () => {
+    const root = await tempRoot();
+    const dir = await writeRecord(root, "wRACE", { updatedAtMs: 0 });
+    const collected = await collectWorkerStateRecordEntries(root, {
+      nowMs: NOW_MS,
+      daemon: daemonNaming(),
+    });
+    const plan = planWorkerStateRecordReclaim(collected, { nowMs: NOW_MS });
+    expect(plan.reclaim).toHaveLength(1);
+    // Between plan and apply the daemon births wRACE again.
+    const applied = await applyWorkerStateRecordReclaim(root, plan, {
+      daemon: daemonNaming("wRACE"),
+    });
+    expect(applied.removed).toEqual([]);
+    expect(applied.protectedLive).toEqual([dir]);
+    expect(await exists(dir)).toBe(true);
+  });
+
+  it("refuses a plan naming a path outside the Worker state root", async () => {
+    const root = await tempRoot();
+    const outside = join(root, "elsewhere");
+    await mkdir(outside, { recursive: true });
+    const applied = await applyWorkerStateRecordReclaim(
+      root,
+      planWorkerStateRecordReclaim([entry({ worker_id: "wOUT", path: outside })], {
+        nowMs: NOW_MS,
+      }),
+      { daemon: daemonNaming() },
+    );
+    expect(applied.removed).toEqual([]);
+    expect(applied.refusedOutsideStateRoot).toEqual([outside]);
+    expect(await exists(outside)).toBe(true);
+  });
+
+  it("drains the pile the issue reported: many corpses go, the one live record stays", async () => {
+    const root = await tempRoot();
+    for (let index = 0; index < 40; index += 1) {
+      await writeRecord(root, `wD${index}`, { updatedAtMs: 0 });
+    }
+    const liveDir = await writeRecord(root, "wLIVE", { updatedAtMs: 0 });
+
+    const daemon = daemonNaming("wLIVE");
+    const collected = await collectWorkerStateRecordEntries(root, { nowMs: NOW_MS, daemon });
+    const plan = planWorkerStateRecordReclaim(collected, { nowMs: NOW_MS });
+    const applied = await applyWorkerStateRecordReclaim(root, plan, { daemon });
+
+    expect(applied.removed).toHaveLength(40);
+    expect(await exists(liveDir)).toBe(true);
+    const left = await collectWorkerStateRecordEntries(root, { nowMs: NOW_MS, daemon });
+    expect(left.map((e) => e.worker_id)).toEqual(["wLIVE"]);
+  });
+});
+
+describe("the janitor sweep owns the record lane", () => {
+  it("plans and applies the record reclaim alongside the tmp lanes", async () => {
+    const root = await tempRoot();
+    const tmpDir = join(root, ".red", "tmp");
+    await mkdir(tmpDir, { recursive: true });
+    const deadDir = await writeRecord(root, "wDEAD", { updatedAtMs: 0 });
+    const liveDir = await writeRecord(root, "wLIVE", { updatedAtMs: 0 });
+    const daemon = daemonNaming("wLIVE");
+
+    const report = await collectTmpJanitorReport(
+      tmpDir,
+      Math.floor(NOW_MS / 1000),
+      () => "UNKNOWN",
+      { daemon },
+    );
+    expect(report.workerStateRecords.reclaim.map((v) => v.worker_id)).toEqual(["wDEAD"]);
+    expect(report.workerStateRecords.retain.map((v) => v.verdict)).toEqual(["worker-live"]);
+
+    const applied = await applyTmpJanitorReport(tmpDir, report, { daemon });
+    expect(applied.workerStateRecords).toEqual([deadDir]);
+    expect(applied.removals).toContainEqual({ path: deadDir, livenessVerdict: "worker-dead" });
+    expect(await exists(deadDir)).toBe(false);
+    expect(await exists(liveDir)).toBe(true);
+  });
+
+  it("reclaims no record when the daemon is unreachable", async () => {
+    const root = await tempRoot();
+    const tmpDir = join(root, ".red", "tmp");
+    await mkdir(tmpDir, { recursive: true });
+    const dir = await writeRecord(root, "wDEAD", { updatedAtMs: 0 });
+    const report = await collectTmpJanitorReport(
+      tmpDir,
+      Math.floor(NOW_MS / 1000),
+      () => "UNKNOWN",
+      { daemon: noDaemon },
+    );
+    const applied = await applyTmpJanitorReport(tmpDir, report, { daemon: noDaemon });
+    expect(applied.workerStateRecords).toEqual([]);
+    expect(await exists(dir)).toBe(true);
+  });
+});

--- a/apps/dev/tests/worker-vitals-bounded.test.ts
+++ b/apps/dev/tests/worker-vitals-bounded.test.ts
@@ -1,0 +1,100 @@
+// worker_vitals answers a BOUNDED payload, live rows first (#2978).
+//
+// The reclaim keeps the record lane small; this keeps the payload small while a
+// pile exists at all — the window between a Worker dying and the retention
+// releasing its record, and every `live_only: false` read that deliberately asks
+// for the dead ones. The bound is pinned here because the number is the
+// contract: an unbounded read serialised 559KB across 18,633 lines to convey one
+// live row, and the corpse it put FIRST read as "the worker produced nothing".
+
+import { describe, expect, it } from "vitest";
+import { boundWorkerVitals, WORKER_VITALS_MAX_RECORDS } from "../src/mcp-adapter.js";
+
+const NOW = Date.parse("2026-08-01T03:00:00.000Z");
+
+function record(over: {
+  id: string;
+  live?: boolean;
+  lastEventAtMs?: number;
+  startedAtMs?: number;
+}) {
+  return {
+    id: over.id,
+    live: over.live ?? false,
+    worker: {
+      started_at: new Date(over.startedAtMs ?? 0).toISOString(),
+      current: {
+        last_event_at:
+          over.lastEventAtMs === undefined ? "" : new Date(over.lastEventAtMs).toISOString(),
+      },
+    },
+  };
+}
+
+describe("the worker_vitals payload bound", () => {
+  it("pins the bound at 32 rows", () => {
+    expect(WORKER_VITALS_MAX_RECORDS).toBe(32);
+  });
+
+  it("caps the answer at the bound, whatever the pile size", () => {
+    const pile = Array.from({ length: 345 }, (_, i) =>
+      record({ id: `w${i}`, lastEventAtMs: NOW - i * 1_000 }),
+    );
+    expect(boundWorkerVitals(pile)).toHaveLength(WORKER_VITALS_MAX_RECORDS);
+  });
+
+  it("leaves an answer already inside the bound untouched, in order", () => {
+    const few = [record({ id: "wA" }), record({ id: "wB", live: true }), record({ id: "wC" })];
+    expect(boundWorkerVitals(few).map((r) => r.id)).toEqual(["wA", "wB", "wC"]);
+  });
+
+  it("puts the live row FIRST when the pile would otherwise bury it", () => {
+    // The observed shape: the live worker arrives last, behind 344 corpses whose
+    // events are all more recent than its start.
+    const corpses = Array.from({ length: 344 }, (_, i) =>
+      record({ id: `w${i}`, lastEventAtMs: NOW - i * 1_000 }),
+    );
+    const live = record({ id: "wLIVE", live: true, lastEventAtMs: NOW - 10_000_000 });
+    const out = boundWorkerVitals([...corpses, live]);
+    expect(out[0]!.id).toBe("wLIVE");
+    expect(out).toHaveLength(WORKER_VITALS_MAX_RECORDS);
+  });
+
+  it("never drops a live row: a fleet at the bound is returned whole", () => {
+    const fleet = Array.from({ length: WORKER_VITALS_MAX_RECORDS }, (_, i) =>
+      record({ id: `wL${i}`, live: true, lastEventAtMs: NOW - i }),
+    );
+    const corpses = Array.from({ length: 300 }, (_, i) =>
+      record({ id: `wD${i}`, lastEventAtMs: NOW }),
+    );
+    const out = boundWorkerVitals([...corpses, ...fleet]);
+    expect(out.every((r) => r.live)).toBe(true);
+    expect(new Set(out.map((r) => r.id))).toEqual(new Set(fleet.map((r) => r.id)));
+  });
+
+  it("drops the OLDEST dead rows first — the ones the lane log still carries", () => {
+    const rows = Array.from({ length: 40 }, (_, i) =>
+      record({ id: `w${i}`, lastEventAtMs: NOW - i * 60_000 }),
+    );
+    const out = boundWorkerVitals(rows);
+    expect(out.map((r) => r.id)).toEqual(
+      rows.slice(0, WORKER_VITALS_MAX_RECORDS).map((r) => r.id),
+    );
+  });
+
+  it("falls back to started_at when a row records no last event", () => {
+    const rows = [
+      ...Array.from({ length: 32 }, (_, i) => record({ id: `w${i}`, startedAtMs: NOW - 1_000 })),
+      record({ id: "wNEWEST", startedAtMs: NOW }),
+    ];
+    expect(boundWorkerVitals(rows)[0]!.id).toBe("wNEWEST");
+  });
+
+  it("keeps the payload small: the bound holds the serialised size in kilobytes, not hundreds", () => {
+    const pile = Array.from({ length: 345 }, (_, i) =>
+      record({ id: `w${i}`, lastEventAtMs: NOW - i * 1_000 }),
+    );
+    const bounded = JSON.stringify(boundWorkerVitals(pile)).length;
+    expect(bounded).toBeLessThan(JSON.stringify(pile).length / 10);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #2978. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2978

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788164433&installation_model_id=20659&pr_number=2991&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2991&signature=90903776a4b5da19225b562ca7528dd267559313c3916281e4c1943b4404b378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->