### PR TITLE
fix: #2986 The landing closes the issue and starts cleanup before the merge queue confirms the merge

### DIFF
--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -103,7 +103,7 @@ The repo's configured focal branch — the default base every AFK **Worktree** f
 _Avoid_: main (as a hardcoded assumption), default branch, primary branch
 
 **Landing**:
-How a completed **Worker**'s branch is integrated into its base, toggled by the **Branch lock** (ADR 0030/0031, write target moved to the remote by ADR 0083): a locked branch is integrated on `origin/<locked-branch>` for human promotion by pull (`landMerge`, with a one-shot self-resolve of merge conflicts), an unlocked branch lands via an admin-merged PR carrying the worker history (`landPr`). Never writes to the **Primary checkout**. Owns the push → integrate → land → post-merge sequence as one operation.
+How a completed **Worker**'s branch is integrated into its base, toggled by the **Branch lock** (ADR 0030/0031, write target moved to the remote by ADR 0083): a locked branch is integrated on `origin/<locked-branch>` for human promotion by pull (`landMerge`, with a one-shot self-resolve of merge conflicts), an unlocked branch lands via an admin-merged PR carrying the worker history (`landPr`). Never writes to the **Primary checkout**. Owns the push → integrate → land → confirm → post-merge sequence as one operation. **The merge command exiting 0 is not the merge** (#2986): under a merge queue — the forge's own, or `--auto` — exit 0 means ENQUEUED, so the landing ends by asking the pull request itself and treats only `state: MERGED` as landed. A queue that hands the PR back parks `blocked:ci` with the issue open and the branch on origin; nothing closes, relabels, deletes or cascades before the confirmation.
 _Avoid_: merge, merge-back, integrate (these are sub-steps of Landing, not the operation)
 
 **Baseline comparison**:

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -14,7 +14,7 @@ import * as fsx from "../../runtime/fs.js";
 import type { GhContext } from "../../runtime/gh.js";
 import type { GitContext } from "../../runtime/git.js";
 import { execTool, type ExecFn } from "../../runtime/exec.js";
-import { getConfig, loadConfig, readBackpressure, readPostWorkerFormat, readValidationResourceBudget, resolveTier, resolveCiTimeoutSeconds } from "../../core/config.js";
+import { getConfig, loadConfig, readBackpressure, readPostWorkerFormat, readValidationResourceBudget, resolveTier, resolveCiTimeoutSeconds, resolveMergeQueueTimeoutSeconds } from "../../core/config.js";
 import {
   makeExtractAdversarialReview,
   resolveAdversarialReviewConfig,
@@ -72,6 +72,9 @@ import {
 } from "./state.js";
 
 const LANDING_GH_PROBE_TIMEOUT_MS = 60_000;
+/** Poll spacing for the queued-merge confirmation (#2986). A merge group takes
+ * minutes, so a tighter interval would only spend GitHub quota. */
+const MERGE_QUEUE_POLL_INTERVAL_MS = 15_000;
 
 export function parseSlot(val: string | undefined): number | undefined {
   if (val === undefined) return undefined;
@@ -413,6 +416,18 @@ export function buildProcessDeps({
     worktreeLaunchesPr,
     landLock,
     nativeMergeQueue,
+    // #2986: `gh pr merge --auto` exits 0 on ENQUEUE. This is the budget the
+    // landing holds for while the forge builds the merge group and runs its CI —
+    // nothing closes the issue or deletes the branch until the PR says merged.
+    mergeQueueWait: {
+      sleep: (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
+      intervalMs: MERGE_QUEUE_POLL_INTERVAL_MS,
+      maxPolls: Math.max(
+        1,
+        Math.ceil(resolveMergeQueueTimeoutSeconds(process.env) / (MERGE_QUEUE_POLL_INTERVAL_MS / 1000)),
+      ),
+      probeTimeoutMs: LANDING_GH_PROBE_TIMEOUT_MS,
+    },
     reviewGate,
     reviewGateLabel: LABEL_READY_FOR_REVIEW,
     // One-shot merge-conflict resolver (merge_resolve_conflict): re-enter the

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -1075,3 +1075,21 @@ export function resolveCiTimeoutSeconds(env: NodeJS.ProcessEnv = process.env): n
   const n = Number.parseInt(raw, 10);
   return Number.isInteger(n) && n > 0 ? n : DEFAULT_MERGE_CI_TIMEOUT_S;
 }
+
+/** Default wait for a QUEUED merge to complete, in seconds (#2986) — 45 minutes.
+ * The merge queue re-runs the whole required suite on its own merge group, and
+ * queues behind other entries while doing it, so this is deliberately longer
+ * than {@link DEFAULT_MERGE_CI_TIMEOUT_S}: a wait that expires early parks a
+ * landing that was about to succeed. */
+export const DEFAULT_MERGE_QUEUE_TIMEOUT_S = 2700;
+
+/**
+ * Resolve the queued-merge confirmation budget (#2986) from
+ * `RED_AFK_MERGE_QUEUE_TIMEOUT_S`. A non-positive / unparseable value falls back
+ * to {@link DEFAULT_MERGE_QUEUE_TIMEOUT_S}.
+ */
+export function resolveMergeQueueTimeoutSeconds(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = (env.RED_AFK_MERGE_QUEUE_TIMEOUT_S ?? "").trim();
+  const n = Number.parseInt(raw, 10);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_MERGE_QUEUE_TIMEOUT_S;
+}

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -38,6 +38,7 @@ import {
   type CiGreenEvidence,
   type Exec as MergeExec,
   type LandingWaitPollEvent,
+  type MergeQueueWaitInput,
   type WaitForReviewInput,
 } from "./merge.js";
 import { resolveLandSerialization, type LandLock } from "./land-lock.js";
@@ -119,6 +120,13 @@ export interface LandingDeps {
    * immediately. Ignored on the locked path, which never opens a PR.
    */
   ciAwait?: CiAwaitInput;
+  /**
+   * Budget for the post-enqueue merge confirmation on a native-merge-queue base
+   * (#2986). Absent → merge.ts defaults with a real timer. The sleep/probe
+   * settings of {@link LandingDeps.ciAwait} are reused when this is absent, so a
+   * caller that already injected a test clock does not get a live one here.
+   */
+  mergeQueueWait?: MergeQueueWaitInput;
   /**
    * Slot-release point for PR landings (#2427). Absent/`merge` preserves the
    * synchronous landing. `ci` and `none` return a deferred tail to the caller.
@@ -572,6 +580,9 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
       // Native merge queue (#1337): enqueue rather than merge on the spot, letting
       // the forge serialize + rebase + revalidate every entry onto the current tip.
       mergeQueue: input.nativeMergeQueue === true,
+      // #2986: the enqueue is not the merge. This budget owns the hold between
+      // `--auto` exiting 0 and the forge reporting `merged: true`.
+      mergeQueueWait: decorateMergeQueueWait(deps, input),
       // Untouchable primary (ADR 0083 / 0108): landPr promotes the fleet mirror,
       // not a local primary branch. `locked` is observability only.
       locked: input.locked,
@@ -606,6 +617,23 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
       }
       if (result.reason === "ci-failed") return { ok: false, reason: "ci-failed", locked: input.locked, prNumber: result.prNumber };
       if (result.reason === "ci-pending") return { ok: false, reason: "ci-pending", locked: input.locked, prNumber: result.prNumber };
+      // #2986: the merge queue handed the PR back. Nothing merged, so route it to
+      // the `blocked:ci` park that keeps the issue open and the branch on origin —
+      // never to a success the close/cleanup steps would act on.
+      if (result.reason === "queue-rejected") {
+        return {
+          ok: false,
+          reason: "pr-merge-failed",
+          locked: input.locked,
+          prNumber: result.prNumber,
+          message: result.queueDetail ?? "the merge queue rejected the pull request; nothing was merged",
+        };
+      }
+      // Still queued when the confirmation budget ran out: the merge may yet land,
+      // so this is `ci-pending` (hold the open PR), not a failure of the work.
+      if (result.reason === "queue-pending") {
+        return { ok: false, reason: "ci-pending", locked: input.locked, prNumber: result.prNumber };
+      }
       if (result.reason === "pr-resolved-abort") {
         return { ok: false, reason: "pr-resolved-abort", locked: input.locked, prNumber: result.prNumber };
       }
@@ -961,6 +989,32 @@ function decorateReviewWait(deps: LandingDeps, input: LandingInput): WaitForRevi
     onPoll: async (event) => {
       await deps.waitForReview?.onPoll?.(event);
       await emitLandingWaitHeartbeat(deps, input, event);
+    },
+  };
+}
+
+/**
+ * Confirmation budget for a queued merge (#2986). Only the queue path calls it,
+ * so it is built unconditionally: the clock and probe bound come from `ciAwait`
+ * when one is wired (a test clock stays a test clock), the poll budget is the
+ * queue's own, and every poll narrates through the same landing heartbeat the CI
+ * wait uses — a wait nobody can see is how a 10-minute hold reads as a hang.
+ */
+function decorateMergeQueueWait(deps: LandingDeps, input: LandingInput): MergeQueueWaitInput {
+  const configured = deps.mergeQueueWait;
+  const sleep = configured?.sleep ?? deps.ciAwait?.sleep;
+  const probeTimeoutMs = configured?.probeTimeoutMs ?? deps.ciAwait?.probeTimeoutMs;
+  return {
+    ...(sleep ? { sleep } : {}),
+    ...(probeTimeoutMs ? { probeTimeoutMs } : {}),
+    ...(configured?.maxPolls !== undefined ? { maxPolls: configured.maxPolls } : {}),
+    ...(configured?.intervalMs !== undefined ? { intervalMs: configured.intervalMs } : {}),
+    onPoll: async (event) => {
+      await configured?.onPoll?.(event);
+      // The FIRST probe is the confirmation itself — a synchronous merge answers
+      // it immediately and never waited for anything. Narrate a wait only once
+      // there is one, so the phase trail of an ordinary landing is unchanged.
+      if (event.attempt > 1) await emitLandingWaitHeartbeat(deps, input, event);
     },
   };
 }

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -1123,6 +1123,13 @@ export interface LandPrInput {
    */
   mergeQueue?: boolean;
   /**
+   * Budget for the merge confirmation every landing ends with (#2986). Absent →
+   * {@link waitForQueuedMerge}'s defaults, and with no injected clock a single
+   * probe — enough to answer a synchronous merge, never enough to claim a queued
+   * one landed.
+   */
+  mergeQueueWait?: MergeQueueWaitInput;
+  /**
    * Final PR-path validation hook. Called after the PR exists and CI-aware merge
    * has observed its current readiness, but before `gh pr merge`. Callers use it
    * to either trust fresh green CI or run their local fallback gate.
@@ -1147,7 +1154,11 @@ export type LandPrFailReason =
   | "ci-failed"
   | "ci-pending"
   | "before-merge-failed"
-  | "merge-failed";
+  | "merge-failed"
+  /** The merge queue took the PR and then kicked it back out (#2986). */
+  | "queue-rejected"
+  /** The PR was still queued when the confirmation budget ran out (#2986). */
+  | "queue-pending";
 
 export interface LandPrResult {
   ok: boolean;
@@ -1163,6 +1174,8 @@ export interface LandPrResult {
    * line describing it, read back from the PR (#2807). The caller records this
    * verbatim instead of guessing at branch protection. */
   mergeFailure?: MergeRejectionDiagnosis;
+  /** Set on `reason: "queue-rejected"` — what the queue was observed doing (#2986). */
+  queueDetail?: string;
   /** Remaining landing tail when `releaseAt` stopped before the merge. */
   deferred?: {
     prNumber: number;
@@ -1173,6 +1186,166 @@ export interface LandPrResult {
      */
     run(ciAlreadyGreen?: boolean): Promise<LandPrResult>;
   };
+}
+
+// ---------- merge confirmation (#2986) ----------
+//
+// A merge command exits 0 when the PR is ENQUEUED, not when it is merged: the
+// forge still has to build the merge group and run its CI, which takes minutes.
+// That is true of `gh pr merge --auto` on a base AFK knows carries a queue, and
+// equally true of a plain `gh pr merge` against a repository whose merge queue
+// AFK was never told about — which is how #2986 was observed. Reading either
+// exit 0 as "landed" closed the issue, stripped its labels and deleted the
+// remote branch while `pulls/N` still said `merged=false`; a merge group that
+// then fails kicks the PR back out, leaving a closed issue whose code never
+// reached the base. So EVERY merge ends with the PR itself being asked.
+
+/** Budget + injected clock for {@link waitForQueuedMerge}. */
+export interface MergeQueueWaitInput {
+  /**
+   * Injected sleep between polls. ABSENT → the confirmation asks once and never
+   * waits: without a clock there is nothing to wait on, and a caller with no
+   * clock still gets the honest answer rather than an assumed merge.
+   */
+  sleep?: Sleep;
+  /** Best-effort liveness callback fired before each bounded probe. */
+  onPoll?: (event: LandingWaitPollEvent) => void | Promise<void>;
+  /** Max poll attempts before the wait gives up (→ `queue-pending`). Default 120. */
+  maxPolls?: number;
+  /** Delay between polls, in ms. Default 15000. */
+  intervalMs?: number;
+  /** Max time for one GitHub probe before treating that poll as still queued. */
+  probeTimeoutMs?: number;
+}
+
+/**
+ * How a queued PR left the merge queue.
+ *   - `merged`   — the forge reports the PR MERGED; the landing may close/clean up.
+ *   - `rejected` — the queue gave the PR back (closed unmerged, or the auto-merge
+ *                  request it accepted is gone while the PR is still open). Terminal.
+ *   - `pending`  — still queued when the budget ran out. NOT a merge.
+ */
+export type QueuedMergeOutcome = "merged" | "rejected" | "pending";
+
+export interface QueuedMergeResult {
+  outcome: QueuedMergeOutcome;
+  /** Forge-reported merge commit, on `merged`. */
+  mergeSha?: string;
+  /** One line naming what was observed, for the terminal record on `rejected`. */
+  detail?: string;
+}
+
+interface QueuedPrView {
+  merged: boolean;
+  state: string;
+  mergeSha?: string;
+  /** Whether the PR still carries the auto-merge request the enqueue created. */
+  autoMerge: boolean;
+  /** False when the probe failed or its payload was unparseable. */
+  observed: boolean;
+}
+
+/** Parse `gh pr view --json state,mergedAt,mergeCommit,autoMergeRequest`. Tolerant:
+ * an unreadable payload yields `observed: false` so the caller polls again rather
+ * than inventing a verdict from a failed probe. */
+export function parseQueuedPrView(stdout: string): QueuedPrView {
+  const absent: QueuedPrView = { merged: false, state: "", autoMerge: false, observed: false };
+  const text = stdout.trim();
+  if (text === "") return absent;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (typeof parsed !== "object" || parsed === null) return absent;
+    const row = parsed as {
+      state?: unknown;
+      mergedAt?: unknown;
+      mergeCommit?: unknown;
+      autoMergeRequest?: unknown;
+    };
+    const mergeCommit = row.mergeCommit;
+    const oid =
+      typeof mergeCommit === "object" && mergeCommit !== null
+        ? (mergeCommit as { oid?: unknown }).oid
+        : undefined;
+    const state = typeof row.state === "string" ? row.state.trim().toUpperCase() : "";
+    // `gh pr view` has no `merged` boolean — `state: MERGED` and a non-null
+    // `mergedAt` are the two forms the forge reports the completed merge in.
+    return {
+      merged: state === "MERGED" || (typeof row.mergedAt === "string" && row.mergedAt.trim() !== ""),
+      state,
+      ...(typeof oid === "string" && oid !== "" ? { mergeSha: oid } : {}),
+      autoMerge: typeof row.autoMergeRequest === "object" && row.autoMergeRequest !== null,
+      observed: true,
+    };
+  } catch {
+    return absent;
+  }
+}
+
+/**
+ * Ask a pull request whether it merged, and keep asking while it is queued —
+ * until the forge reports it merged, hands it back, or the budget runs out
+ * (#2986). Only `merged` may unlock the landing's close/cleanup steps. A
+ * synchronous merge settles this on the first probe.
+ *
+ * The dequeue signal is the auto-merge request DISAPPEARING from a still-open PR:
+ * that is what the forge does when the merge group fails its CI. It is only
+ * trusted once this wait has actually SEEN the request present, because `gh pr
+ * merge --auto` and the field's appearance are not simultaneous — an
+ * unseen-then-absent request is the enqueue still registering, not a rejection.
+ */
+export async function waitForQueuedMerge(
+  exec: Exec,
+  repo: string,
+  prNumber: number,
+  input: MergeQueueWaitInput = {},
+): Promise<QueuedMergeResult> {
+  const maxPolls = input.maxPolls ?? 120;
+  const intervalMs = input.intervalMs ?? 15_000;
+  // No clock injected → one probe, no waiting (see MergeQueueWaitInput.sleep).
+  const maxPollsWithClock = input.sleep ? maxPolls : 1;
+  const sleep = input.sleep ?? (async () => {});
+  let everQueued = false;
+
+  for (let attempt = 0; attempt < maxPollsWithClock; attempt++) {
+    await input.onPoll?.({
+      kind: "merge",
+      prNumber,
+      attempt: attempt + 1,
+      maxPolls: maxPollsWithClock,
+      intervalMs,
+      ...(input.probeTimeoutMs ? { probeTimeoutMs: input.probeTimeoutMs } : {}),
+    });
+    const res = await boundedProbe(
+      () =>
+        exec([
+          "gh", "-R", repo, "pr", "view", String(prNumber),
+          "--json", "state,mergedAt,mergeCommit,autoMergeRequest",
+        ]),
+      input.probeTimeoutMs,
+    );
+    const view = res.code === 0 ? parseQueuedPrView(res.stdout) : parseQueuedPrView("");
+    if (view.observed) {
+      if (view.merged) {
+        return { outcome: "merged", ...(view.mergeSha ? { mergeSha: view.mergeSha } : {}) };
+      }
+      if (view.state === "CLOSED") {
+        return {
+          outcome: "rejected",
+          detail: `PR #${prNumber} left the merge queue CLOSED without merging`,
+        };
+      }
+      if (view.autoMerge) {
+        everQueued = true;
+      } else if (everQueued) {
+        return {
+          outcome: "rejected",
+          detail: `the merge queue dequeued PR #${prNumber} without merging it (its auto-merge request is gone and the PR is still open)`,
+        };
+      }
+    }
+    if (attempt + 1 < maxPollsWithClock) await sleep(intervalMs);
+  }
+  return { outcome: "pending" };
 }
 
 const PR_BODY_PREFIX = "Automated AFK landing for #";
@@ -1541,14 +1714,24 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
     });
     if (rejected) return rejected;
 
-    if (mergeQueue) return { ok: true, prNumber };
-
-    const mergedCommit = await exec([
-      "gh", "-R", repo, "pr", "view", String(prNumber), "--json", "mergeCommit", "--jq", ".mergeCommit.oid",
-    ]);
-    const mergeSha = mergedCommit.code === 0 ? mergedCommit.stdout.trim() : "";
+    // 4. #2986: the merge command exited 0 — ASK THE PR whether that meant
+    // merged. A synchronous merge answers on the first probe and this costs one
+    // `gh pr view`; an enqueue (with `--auto`, or against a repository whose
+    // merge queue AFK was never told about) answers `merged=false` and is held
+    // here until the forge finishes or hands the PR back. Only `merged` returns
+    // `ok`, because `ok` is what unlocks the caller's close/cleanup steps.
+    const confirmed = await waitForQueuedMerge(exec, repo, prNumber, input.mergeQueueWait ?? {});
+    if (confirmed.outcome === "rejected") {
+      return { ok: false, prNumber, reason: "queue-rejected", queueDetail: confirmed.detail };
+    }
+    if (confirmed.outcome === "pending") return { ok: false, prNumber, reason: "queue-pending" };
     await promoteFleetTrunkMirror(exec, { gitRepo, remote, target });
-    return { ok: true, prNumber, ...(mergeSha ? { mergeSha } : {}), ...(ciEvidence ? { ciEvidence } : {}) };
+    return {
+      ok: true,
+      prNumber,
+      ...(confirmed.mergeSha ? { mergeSha: confirmed.mergeSha } : {}),
+      ...(ciEvidence ? { ciEvidence } : {}),
+    };
   };
 
   const waitThenMerge = async (ciAlreadyGreen = false): Promise<LandPrResult> => {

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1558,6 +1558,7 @@ export async function processIssue(
       maxAgentConflictResolveAttempts: deps.maxAgentConflictResolveAttempts,
       waitForReview: deps.waitForReview,
       ciAwait: deps.ciAwait,
+      mergeQueueWait: deps.mergeQueueWait,
       landingWait: deps.landingWait,
       makeLandingWorktree: deps.makeLandingWorktree,
       removeLandingWorktree: deps.removeLandingWorktree,

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -50,6 +50,7 @@ import {
   type ConflictResolver,
   type WaitForReviewInput,
   type CiAwaitInput,
+  type MergeQueueWaitInput,
 } from "../merge.js";
 import type { LandLock } from "../land-lock.js";
 import {
@@ -324,6 +325,8 @@ export interface ProcessIssueDeps {
   removeRebaseWorktree?(dir: string): Promise<void>;
   waitForReview?: WaitForReviewInput;
   ciAwait?: CiAwaitInput;
+  /** Budget for the post-enqueue merge confirmation on a merge-queue base (#2986). */
+  mergeQueueWait?: MergeQueueWaitInput;
   /** Slot-release boundary across the PR landing tail (#2427). */
   landingWait?: "merge" | "ci" | "none";
   /**

--- a/apps/dev/tests/afk-e2e-local.test.ts
+++ b/apps/dev/tests/afk-e2e-local.test.ts
@@ -99,6 +99,9 @@ interface E2EState {
    * scenario (a different worker landing the SAME line first). */
   mainlineCommitSha?: string;
   prNumber?: number;
+  /** origin/main after the scripted `gh pr merge` really landed — the SHA the
+   * #2986 merge confirmation reports back as the merge commit. */
+  mergedTipSha?: string;
   prViewCalls: number;
   /** Every git/gh argv the merge + remote executors ran, for flow assertions. */
   execLog: string[][];
@@ -178,6 +181,28 @@ async function setup(opts: {
       state.prNumber = 101;
       return { code: 0, stdout: "", stderr: "" };
     }
+    if (sub === "view" && argv.some((a) => a.includes("mergedAt"))) {
+      // #2986 merge confirmation. This forge merges synchronously, so the probe
+      // reports MERGED exactly when the scripted `pr merge` actually landed —
+      // and reports an unmerged, still-open PR when it did not.
+      if (!state.mergedTipSha) {
+        return {
+          code: 0,
+          stdout: JSON.stringify({ state: "OPEN", mergedAt: null, mergeCommit: null, autoMergeRequest: null }),
+          stderr: "",
+        };
+      }
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          state: "MERGED",
+          mergedAt: "2026-08-01T00:00:00Z",
+          mergeCommit: { oid: state.mergedTipSha },
+          autoMergeRequest: null,
+        }),
+        stderr: "",
+      };
+    }
     if (sub === "view") {
       // The reader now fetches `mergeStateStatus,mergeable,statusCheckRollup` and
       // gates primarily on `mergeable` (#2085): CONFLICTING→conflict, UNKNOWN→pending
@@ -213,6 +238,7 @@ async function setup(opts: {
         return { code: 1, stdout: "", stderr: "refusing to merge a conflicting branch" };
       }
       const ff = await gitAt(originDir, ["update-ref", "refs/heads/main", `refs/heads/${state.workerBranchRef}`]);
+      if (ff.code === 0) state.mergedTipSha = await revParse(originDir, "refs/heads/main");
       return { code: ff.code, stdout: "", stderr: ff.stderr };
     }
     return { code: 0, stdout: "", stderr: "" };

--- a/apps/dev/tests/landing-quota.test.ts
+++ b/apps/dev/tests/landing-quota.test.ts
@@ -37,9 +37,19 @@ function buildFakeExec(prMergeResponses: ExecOutput[]): {
       const resp = prMergeResponses[mergeIdx++] ?? { code: 0, stdout: "", stderr: "" };
       return resp;
     }
-    // gh pr view (mergeCommit sha resolution after successful merge)
-    if (cmd === "gh" && args.includes("view") && j.includes("mergeCommit")) {
-      return { code: 0, stdout: "deadbeef\n", stderr: "" };
+    // gh pr view — the #2986 merge confirmation, answered by a forge that
+    // merged the PR on the spot once the quota window closed.
+    if (cmd === "gh" && args.includes("view") && j.includes("mergedAt")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          state: "MERGED",
+          mergedAt: "2026-08-01T00:00:00Z",
+          mergeCommit: { oid: "deadbeef" },
+          autoMergeRequest: null,
+        }),
+        stderr: "",
+      };
     }
     // git update-ref (fleet trunk mirror promotion)
     if (cmd === "git" && args.includes("update-ref")) {

--- a/apps/dev/tests/landing-serialized.test.ts
+++ b/apps/dev/tests/landing-serialized.test.ts
@@ -139,6 +139,9 @@ describe("doLanding — serialized landing (#1337)", () => {
     expect(r).toEqual({
       ok: true,
       locked: false,
+      // #2986: the merge commit the QUEUE produced, read back once the PR itself
+      // reported `merged: true` — not assumed from `--auto` exiting 0.
+      mergeSha: "abc1234",
       postMergeValidation: {
         path: "local-rerun",
         reason: "PR #42 CI evidence was absent or unusable; local post-merge validation fallback ran.",
@@ -185,5 +188,51 @@ describe("doLanding — serialized landing (#1337)", () => {
     expect(acquires).toBe(1);
     // Plain admin-merge, never enqueued.
     expect(joined(h.mergeCalls).some((c) => c.includes("--auto"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The enqueue is not the merge (#2986). `gh pr merge --auto` exits 0 the moment
+// the PR joins the queue; the merge group's CI then runs for minutes and may
+// hand the PR back. The landing used to read that exit 0 as "landed" and let its
+// caller close the issue, strip its labels and delete the remote branch — so a
+// rejected merge group left a closed issue whose code never reached the base.
+// Every result below is what gates those steps: only `ok: true` unlocks them.
+// ---------------------------------------------------------------------------
+describe("doLanding — a queued merge is not a completed one (#2986)", () => {
+  it("holds the landing (never ok) while the queued PR still reports merged=false", async () => {
+    const h = harness({ locked: false, openPr: true, nativeMergeQueue: true, queueOutcome: "pending" });
+
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    // ci-pending → the caller parks blocked:ci and keeps the issue and branch.
+    expect(r).toEqual({ ok: false, reason: "ci-pending", locked: false, prNumber: 42 });
+    // The post_merge hook is part of the close/cleanup tail — it must not fire.
+    expect(h.firedHooks).not.toContain("post_merge");
+    // It really did poll the PR rather than trusting the merge command's exit.
+    expect(joined(h.mergeCalls).filter((c) => c.includes("autoMergeRequest")).length).toBeGreaterThan(1);
+  });
+
+  it("parks a merge-queue rejection with the observed reason, issue and branch intact", async () => {
+    const h = harness({ locked: false, openPr: true, nativeMergeQueue: true, queueOutcome: "rejected" });
+
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r.ok).toBe(false);
+    // pr-merge-failed → prLandingBlocked(ci-failed): blocked:ci, issue open.
+    expect(r.ok === false && r.reason).toBe("pr-merge-failed");
+    expect(r.ok === false && r.message).toContain("dequeued PR #42");
+    expect(h.firedHooks).not.toContain("post_merge");
+    // The branch stays on origin — nothing here deletes it.
+    expect(joined(h.mergeCalls).some((c) => c.includes("push origin --delete"))).toBe(false);
+  });
+
+  it("completes only once the PR itself reports merged=true", async () => {
+    const h = harness({ locked: false, openPr: true, nativeMergeQueue: true, queueOutcome: "merged" });
+
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
+    expect(h.firedHooks).toContain("post_merge");
   });
 });

--- a/apps/dev/tests/landing.test-support.ts
+++ b/apps/dev/tests/landing.test-support.ts
@@ -133,6 +133,14 @@ export interface Opts {
   landLock?: LandLock;
   /** Native merge queue (#1337): set `input.nativeMergeQueue`. */
   nativeMergeQueue?: boolean;
+  /**
+   * Model an ENQUEUE rather than a synchronous merge (#2986). Absent → the
+   * confirmation's first probe already reports a MERGED pull request.
+   *   - `merged`   → queued first, then merged.
+   *   - `rejected` → queued first, then the auto-merge request disappears.
+   *   - `pending`  → still queued for the whole (test-sized) budget.
+   */
+  queueOutcome?: "merged" | "rejected" | "pending";
   /** Explicit PR-resolved callback abort used by adversarial correction before merge. */
   onPrResolvedAbort?: boolean;
   /**
@@ -168,6 +176,7 @@ export function harness(opts: Opts = {}): Harness {
   const landingEvents: { phase: string; detail: Record<string, unknown> }[] = [];
   let mergeResolved = false;
   let prCreated = false;
+  let queuePolls = 0;
 
   const deps: LandingDeps = {
     mergeExec: async (argv): Promise<ExecResult> => {
@@ -265,6 +274,37 @@ export function harness(opts: Opts = {}): Harness {
       if (j.includes("pr checks")) {
         return { code: 0, stdout: JSON.stringify([{ name: "CodeRabbit", state: "SUCCESS" }]), stderr: "" };
       }
+      // #2986 post-enqueue merge confirmation. The queue accepts the PR on the
+      // first poll (auto-merge request present, not yet merged) and resolves on
+      // the second, so a landing that skipped the wait cannot pass by accident.
+      if (j.includes("pr view") && j.includes("autoMergeRequest")) {
+        queuePolls += 1;
+        const accepted = { state: "OPEN", mergedAt: null, mergeCommit: null, autoMergeRequest: { enabledAt: "t" } };
+        // Unset → the forge merged on the spot and the very first confirmation
+        // says so. A test that opts in models the ENQUEUE: accepted first, then
+        // its outcome, so the landing has something to actually wait through.
+        const outcome = opts.queueOutcome;
+        if (outcome !== undefined && (queuePolls === 1 || outcome === "pending")) {
+          return { code: 0, stdout: JSON.stringify(accepted), stderr: "" };
+        }
+        if (outcome === "rejected") {
+          return {
+            code: 0,
+            stdout: JSON.stringify({ state: "OPEN", mergedAt: null, mergeCommit: null, autoMergeRequest: null }),
+            stderr: "",
+          };
+        }
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            state: "MERGED",
+            mergedAt: "2026-08-01T00:00:00Z",
+            mergeCommit: { oid: "abc1234" },
+            autoMergeRequest: null,
+          }),
+          stderr: "",
+        };
+      }
       if (j.includes("pr view") && j.includes("mergeCommit")) {
         // #2261: doLanding reads the landed commit SHA via
         // `gh pr view <n> --json mergeCommit --jq .mergeCommit.oid`. Return the
@@ -315,6 +355,8 @@ export function harness(opts: Opts = {}): Harness {
       : undefined,
     waitForReview: opts.waitForReview ? { check: "CodeRabbit", sleep: async () => {} } : undefined,
     ciAwait: opts.ciAware ? { sleep: async () => {}, maxPolls: 2 } : undefined,
+    // #2986: always injected so no queue landing under test can reach a real timer.
+    mergeQueueWait: { sleep: async () => {}, maxPolls: 3 },
     makeLandingWorktree: async () => (opts.noWorktree ? null : WT),
     removeLandingWorktree: async (dir) => {
       removedWorktrees.push(dir);

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -588,8 +588,19 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     const h = harness({ locked: false, openPr: true });
     const mergeExec = h.deps.mergeExec;
     h.deps.mergeExec = async (argv) => {
-      if (argv.join(" ").includes("pr view 42 --json mergeCommit --jq .mergeCommit.oid")) {
-        return { code: 0, stdout: "forge-merge-sha\n", stderr: "" };
+      // #2986: the SHA now comes from the merge CONFIRMATION — the same probe
+      // that proves the PR actually merged, not a separate optimistic read.
+      if (argv.join(" ").includes("--json state,mergedAt")) {
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            state: "MERGED",
+            mergedAt: "2026-08-01T00:00:00Z",
+            mergeCommit: { oid: "forge-merge-sha" },
+            autoMergeRequest: null,
+          }),
+          stderr: "",
+        };
       }
       return await mergeExec(argv);
     };

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -14,8 +14,10 @@ import {
   diagnoseMergeRejection,
   parseUnmergedPaths,
   parseMergeStateView,
+  parseQueuedPrView,
   waitForMergeReady,
   waitForMergeReadyWithEvidence,
+  waitForQueuedMerge,
   type Exec,
   type ExecResult,
 } from "../src/core/merge.js";
@@ -37,10 +39,25 @@ function fakeExec(
         return { code: 0, stdout: "", stderr: "", ...rule.result };
       }
     }
+    // #2986: the default forge merges synchronously — the merge-confirmation
+    // probe therefore reports a MERGED pull request. A test that models an
+    // enqueue overrides this with its own rule.
+    if (argv.join(" ").includes("--json state,mergedAt")) {
+      return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
+    }
     return { code: 0, stdout: "", stderr: "" };
   };
   return { exec, calls };
 }
+
+/** `gh pr view --json state,mergedAt,mergeCommit,autoMergeRequest` for a PR the
+ * forge merged on the spot (#2986). `mergeCommit.oid` is the SHA landPr reports. */
+const MERGED_PR_VIEW = JSON.stringify({
+  state: "MERGED",
+  mergedAt: "2026-08-01T00:00:00Z",
+  mergeCommit: { oid: "forge-merge-sha" },
+  autoMergeRequest: null,
+});
 
 const joined = (calls: string[][]): string[] => calls.map((c) => c.join(" "));
 
@@ -189,6 +206,7 @@ describe("landPr (unlocked path)", () => {
     const exec: Exec = async (argv) => {
       const cmd = argv.join(" ");
       if (cmd.includes("pr create")) prMade = true;
+      if (cmd.includes("--json state,mergedAt")) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
       if (cmd.includes("pr list")) {
         return { code: 0, stdout: prMade ? "77\n" : "\n", stderr: "" };
       }
@@ -361,6 +379,7 @@ describe("openReviewPr (review-gate handoff, #749)", () => {
       recorded.push(argv);
       const cmd = argv.join(" ");
       if (cmd.includes("pr create")) prMade = true;
+      if (cmd.includes("--json state,mergedAt")) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
       if (cmd.includes("pr list")) return { code: 0, stdout: prMade ? "88\n" : "\n", stderr: "" };
       return { code: 0, stdout: "", stderr: "" };
     };
@@ -506,6 +525,7 @@ describe("landPr wait_for_review wiring", () => {
       calls.push(argv);
       const cmd = argv.join(" ");
       if (cmd.includes("pr list")) return { code: 0, stdout: "77\n", stderr: "" };
+      if (cmd.includes("--json state,mergedAt")) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
       if (cmd.includes("pr checks")) {
         checksPolled = true;
         return { code: 0, stdout: JSON.stringify([{ name: "CodeRabbit", state: "SUCCESS" }]), stderr: "" };
@@ -874,9 +894,7 @@ describe("landPr CI-aware wiring (#812)", () => {
     const exec: Exec = async (argv) => {
       const cmd = argv.join(" ");
       if (cmd.includes("pr list")) return { code: 0, stdout: "42\n", stderr: "" };
-      if (cmd.includes("pr view 42 --json mergeCommit --jq .mergeCommit.oid")) {
-        return { code: 0, stdout: "forge-merge-sha\n", stderr: "" };
-      }
+      if (cmd.includes("--json state,mergedAt")) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
       return { code: 0, stdout: "", stderr: "" };
     };
 
@@ -901,6 +919,7 @@ describe("landPr CI-aware wiring (#812)", () => {
       calls.push(argv);
       const cmd = argv.join(" ");
       if (cmd.includes("pr list")) return { code: 0, stdout: "77\n", stderr: "" };
+      if (cmd.includes("--json state,mergedAt")) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
       if (cmd.includes("pr view")) {
         viewed = true;
         return { code: 0, stdout: JSON.stringify({ mergeStateStatus: "CLEAN", statusCheckRollup: [] }), stderr: "" };
@@ -969,6 +988,7 @@ describe("landPr CI-aware wiring (#812)", () => {
         const cmd = argv.join(" ");
         if (cmd.includes("pr list")) return { code: 0, stdout: "5\n", stderr: "" };
         if (cmd.includes("required_status_checks/contexts")) return { code: 0, stdout: protectionContexts, stderr: "" };
+        if (cmd.includes("--json state,mergedAt")) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
         if (cmd.includes("pr view")) {
           // checks not created yet: BLOCKED + MERGEABLE + an empty rollup
           return {
@@ -998,6 +1018,7 @@ describe("landPr CI-aware wiring (#812)", () => {
         const cmd = argv.join(" ");
         if (cmd.includes("pr list")) return { code: 0, stdout: "5\n", stderr: "" };
         if (cmd.includes("required_status_checks/contexts")) return { code: 0, stdout: protectionContexts, stderr: "" };
+        if (cmd.includes("--json state,mergedAt")) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
         if (cmd.includes("pr view") && cmd.includes("mergeStateStatus")) {
           polls += 1;
           const stdout = polls === 1
@@ -1059,6 +1080,7 @@ describe("landPr CI-aware wiring (#812)", () => {
         calls.push(argv);
         const cmd = argv.join(" ");
         if (cmd.includes("pr list")) return { code: 0, stdout: "5\n", stderr: "" };
+        if (cmd.includes("--json state,mergedAt")) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
         if (cmd.includes("pr view") && cmd.includes("mergeStateStatus")) {
           // CLEAN at the readiness poll, BEHIND once the base moves under the
           // merge, CLEAN again after the branch is updated. Green throughout.
@@ -1579,5 +1601,182 @@ describe("describeRebaseConflict / parseUnmergedPaths (#2864)", () => {
     expect(summary).toContain("in 12 file(s): f0.ts");
     expect(summary).toContain("f9.ts, and 2 more");
     expect(summary).not.toContain("f10.ts,");
+  });
+});
+
+// #2986 — `gh pr merge --auto` exits 0 on ENQUEUE, not on merge. Reading that
+// exit code as "landed" let the caller close the issue and delete the branch
+// while the merge group's CI was still running.
+describe("waitForQueuedMerge (#2986)", () => {
+  const queueExec = (views: string[]): { exec: Exec; calls: string[][] } => {
+    const calls: string[][] = [];
+    let i = 0;
+    const exec: Exec = async (argv) => {
+      calls.push(argv);
+      const stdout = views[Math.min(i, views.length - 1)] ?? "";
+      i += 1;
+      return { code: 0, stdout, stderr: "" };
+    };
+    return { exec, calls };
+  };
+
+  const queued = JSON.stringify({
+    merged: false,
+    state: "OPEN",
+    mergeCommit: null,
+    autoMergeRequest: { enabledAt: "t" },
+  });
+
+  it("holds while the PR is queued and returns the merge commit once it merges", async () => {
+    const { exec, calls } = queueExec([
+      queued,
+      queued,
+      JSON.stringify({ merged: true, state: "MERGED", mergeCommit: { oid: "queuesha" }, autoMergeRequest: null }),
+    ]);
+    const r = await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 5 });
+    expect(r).toEqual({ outcome: "merged", mergeSha: "queuesha" });
+    expect(calls).toHaveLength(3);
+    expect(calls[0]!.join(" ")).toContain("pr view 42 --json state,mergedAt,mergeCommit,autoMergeRequest");
+  });
+
+  it("reports a dequeue once the accepted auto-merge request disappears", async () => {
+    const { exec } = queueExec([
+      queued,
+      JSON.stringify({ merged: false, state: "OPEN", mergeCommit: null, autoMergeRequest: null }),
+    ]);
+    const r = await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 5 });
+    expect(r.outcome).toBe("rejected");
+    expect(r.detail).toContain("dequeued PR #42");
+  });
+
+  it("does NOT read the enqueue's own registration lag as a rejection", async () => {
+    // The auto-merge request is not visible on the first poll; the PR then
+    // merges. A wait that trusted the first absent request would park a landing
+    // that was about to succeed.
+    const { exec } = queueExec([
+      JSON.stringify({ merged: false, state: "OPEN", mergeCommit: null, autoMergeRequest: null }),
+      queued,
+      JSON.stringify({ merged: true, state: "MERGED", mergeCommit: { oid: "queuesha" }, autoMergeRequest: null }),
+    ]);
+    const r = await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 5 });
+    expect(r).toEqual({ outcome: "merged", mergeSha: "queuesha" });
+  });
+
+  it("reports a PR the queue closed without merging as rejected", async () => {
+    const { exec } = queueExec([
+      JSON.stringify({ merged: false, state: "CLOSED", mergeCommit: null, autoMergeRequest: null }),
+    ]);
+    const r = await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 5 });
+    expect(r.outcome).toBe("rejected");
+    expect(r.detail).toContain("CLOSED without merging");
+  });
+
+  it("returns pending — never merged — when the budget runs out", async () => {
+    const { exec, calls } = queueExec([queued]);
+    const polls: number[] = [];
+    const r = await waitForQueuedMerge(exec, "o/r", 42, {
+      sleep: async () => {},
+      maxPolls: 3,
+      onPoll: (event) => {
+        polls.push(event.attempt);
+      },
+    });
+    expect(r).toEqual({ outcome: "pending" });
+    expect(calls).toHaveLength(3);
+    expect(polls).toEqual([1, 2, 3]);
+  });
+
+  it("keeps polling through an unreadable probe instead of inventing a verdict", async () => {
+    const { exec } = queueExec([
+      "not json",
+      JSON.stringify({ merged: true, state: "MERGED", mergeCommit: { oid: "queuesha" }, autoMergeRequest: null }),
+    ]);
+    const r = await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 5 });
+    expect(r).toEqual({ outcome: "merged", mergeSha: "queuesha" });
+  });
+
+  it("parses a merged view and tolerates a broken payload", () => {
+    expect(parseQueuedPrView(JSON.stringify({ merged: true, state: "MERGED", mergeCommit: { oid: "s" } }))).toEqual({
+      merged: true,
+      state: "MERGED",
+      mergeSha: "s",
+      autoMerge: false,
+      observed: true,
+    });
+    expect(parseQueuedPrView("{oops").observed).toBe(false);
+    expect(parseQueuedPrView("").observed).toBe(false);
+  });
+});
+
+describe("landPr on a merge-queue base (#2986)", () => {
+  const queuedView = JSON.stringify({
+    merged: false,
+    state: "OPEN",
+    mergeCommit: null,
+    autoMergeRequest: { enabledAt: "t" },
+  });
+
+  const execFor = (views: string[]): { exec: Exec; calls: string[][] } => {
+    const calls: string[][] = [];
+    let i = 0;
+    const exec: Exec = async (argv) => {
+      calls.push(argv);
+      const cmd = argv.join(" ");
+      if (cmd.includes("pr list")) return { code: 0, stdout: "42\n", stderr: "" };
+      if (cmd.includes("autoMergeRequest")) {
+        const stdout = views[Math.min(i, views.length - 1)] ?? "";
+        i += 1;
+        return { code: 0, stdout, stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    return { exec, calls };
+  };
+
+  const base = {
+    repo: "o/r",
+    gitRepo: "/repo",
+    remote: "origin",
+    branch: "afk/wX/9-x",
+    target: "main",
+    n: 9,
+    title: "t",
+    mergeQueue: true,
+  };
+
+  it("does NOT report ok while the queued PR still reports merged=false", async () => {
+    const { exec, calls } = execFor([queuedView]);
+    const r = await landPr(exec, {
+      ...base,
+      mergeQueueWait: { sleep: async () => {}, maxPolls: 2 },
+    });
+    expect(r).toEqual({ ok: false, prNumber: 42, reason: "queue-pending" });
+    expect(calls.some((c) => c.join(" ").includes("pr merge 42 --merge --auto"))).toBe(true);
+  });
+
+  it("reports ok with the queue's merge commit once the PR reports merged=true", async () => {
+    const { exec } = execFor([
+      queuedView,
+      JSON.stringify({ merged: true, state: "MERGED", mergeCommit: { oid: "queuesha" }, autoMergeRequest: null }),
+    ]);
+    const r = await landPr(exec, {
+      ...base,
+      mergeQueueWait: { sleep: async () => {}, maxPolls: 4 },
+    });
+    expect(r).toEqual({ ok: true, prNumber: 42, mergeSha: "queuesha" });
+  });
+
+  it("reports queue-rejected when the merge group hands the PR back", async () => {
+    const { exec } = execFor([
+      queuedView,
+      JSON.stringify({ merged: false, state: "OPEN", mergeCommit: null, autoMergeRequest: null }),
+    ]);
+    const r = await landPr(exec, {
+      ...base,
+      mergeQueueWait: { sleep: async () => {}, maxPolls: 4 },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("queue-rejected");
+    expect(r.queueDetail).toContain("dequeued PR #42");
   });
 });

--- a/apps/dev/tests/outbound-redaction.test.ts
+++ b/apps/dev/tests/outbound-redaction.test.ts
@@ -172,6 +172,10 @@ describe("GitHub outbound write seams", () => {
       n: 1365,
       title: LEAK_TEXT,
       mergeQueue: true,
+      // #2986: the enqueue is followed by a merge-confirmation wait. This test is
+      // about the scrubbed PR create, so the wait is given a no-op clock and one
+      // poll instead of a live timer.
+      mergeQueueWait: { sleep: async () => {}, maxPolls: 1 },
     });
 
     const create = calls.find((args) => args.includes("create"));

--- a/apps/dev/tests/process-issue.recovery.test.ts
+++ b/apps/dev/tests/process-issue.recovery.test.ts
@@ -668,7 +668,10 @@ describe("Spec cascade rebase after DONE landing", () => {
     }
   });
 
-  it("does not cascade before a native merge queue has produced a merge SHA", async () => {
+  // #2986: a PR that is merely QUEUED has produced no merge SHA and no merge.
+  // Nothing downstream of the landing may run — not the cascade, and above all
+  // not the close/cleanup steps that a rejected merge group would strand.
+  it("does not close, clean up or cascade while the queued PR still reports merged=false", async () => {
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackOk: true,
@@ -677,13 +680,54 @@ describe("Spec cascade rebase after DONE landing", () => {
         "spec:42": [{ number: 20, labels: ["spec:42", "ready-for-agent"] }],
       },
       siblingBranches: ["afk/wBBBB/20-fix-sibling-a"],
+      queueOutcome: "pending",
+    });
+    deps.nativeMergeQueue = true;
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("ci-pending");
+    expect(trace.closed).not.toContain(9);
+    expect(trace.deletedRemote).toEqual([]);
+    expect(trace.cascadeRebaseAttempts).toEqual([]);
+  });
+
+  it("parks blocked:ci with the issue and the branch intact when the merge queue rejects the PR", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent"],
+      queueOutcome: "rejected",
+    });
+    deps.nativeMergeQueue = true;
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("ci-failed");
+    expect(trace.closed).not.toContain(9);
+    expect(trace.deletedRemote).toEqual([]);
+    expect(trace.comments.some((c) => c.issue === 9 && c.body.includes("dequeued PR #42"))).toBe(true);
+  });
+
+  it("closes and cascades only once the queued PR reports merged=true", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent", "spec:42"],
+      dependentsByLabel: {
+        "spec:42": [{ number: 20, labels: ["spec:42", "ready-for-agent"] }],
+      },
+      siblingBranches: ["afk/wBBBB/20-fix-sibling-a"],
+      queueOutcome: "merged",
     });
     deps.nativeMergeQueue = true;
 
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("done");
-    expect(trace.cascadeRebaseAttempts).toEqual([]);
+    expect(result.mergeSha).toBe("forge-merge-sha");
+    expect(trace.closed).toContain(9);
+    expect(trace.cascadeRebaseAttempts).toEqual(["afk/wBBBB/20-fix-sibling-a"]);
   });
 
   it("skips a sibling branch whose worker is still alive", async () => {

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -279,6 +279,13 @@ export interface HarnessOptions {
   /** CI-aware merge (#812). When set, register the `ciAwait` port and drive the
    * `gh pr view` verdict the unlocked landing polls before admin-merging. */
   ciAware?: "merge" | "ci-failed" | "ci-pending" | "conflict" | "skipped";
+  /**
+   * Model an ENQUEUE rather than a synchronous merge (#2986). Absent → the
+   * merge confirmation's first probe already reports a MERGED pull request.
+   * `merged` resolves on the second poll; `pending` stays queued for the whole
+   * (test-sized) budget; `rejected` models the merge group handing the PR back.
+   */
+  queueOutcome?: "merged" | "rejected" | "pending";
   /** Exit code for the final `gh pr merge` command. Defaults to 0. */
   prMergeCode?: number;
   /** Spec cascade rebase (#1007): remote afk/* branches returned by
@@ -344,6 +351,7 @@ export function harness(opts: HarnessOptions = {}): {
   // Whether a pull request exists for the attempt branch. Landing opens one when
   // no Re-seed minted a draft first; both go through `gh pr create`.
   let prOpen = false;
+  let queuePolls = 0;
   let pnpmCalls = 0;
   let changedFilesCalls = 0;
 
@@ -554,6 +562,37 @@ export function harness(opts: HarnessOptions = {}): {
       if (j.includes("api repos/o/r/branches/main/protection/required_status_checks/contexts")) {
         return { code: 0, stdout: JSON.stringify(["ci"]), stderr: "" };
       }
+      // #2986 post-enqueue merge confirmation. The queue accepts the PR on the
+      // first poll and resolves on the second, so a landing that skipped the
+      // wait cannot pass by accident.
+      if (j.includes("pr view") && j.includes("autoMergeRequest")) {
+        queuePolls += 1;
+        const accepted = { state: "OPEN", mergedAt: null, mergeCommit: null, autoMergeRequest: { enabledAt: "t" } };
+        // Unset → the forge merged on the spot and the very first confirmation
+        // says so. A test that opts in models the ENQUEUE: accepted first, then
+        // its outcome, so the landing has something to actually wait through.
+        const outcome = opts.queueOutcome;
+        if (outcome !== undefined && (queuePolls === 1 || outcome === "pending")) {
+          return { code: 0, stdout: JSON.stringify(accepted), stderr: "" };
+        }
+        if (outcome === "rejected") {
+          return {
+            code: 0,
+            stdout: JSON.stringify({ state: "OPEN", mergedAt: null, mergeCommit: null, autoMergeRequest: null }),
+            stderr: "",
+          };
+        }
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            state: "MERGED",
+            mergedAt: "2026-08-01T00:00:00Z",
+            mergeCommit: { oid: "forge-merge-sha" },
+            autoMergeRequest: null,
+          }),
+          stderr: "",
+        };
+      }
       if (j.includes("pr view") && j.includes("--json mergeCommit")) {
         return { code: 0, stdout: "forge-merge-sha\n", stderr: "" };
       }
@@ -709,6 +748,8 @@ export function harness(opts: HarnessOptions = {}): {
     reviewGate: opts.reviewGate,
     reviewGateLabel: "ready-for-review",
     ciAwait: opts.ciAware ? { sleep: async () => {}, maxPolls: 2 } : undefined,
+    // #2986: always injected so no queue landing under test reaches a real timer.
+    mergeQueueWait: { sleep: async () => {}, maxPolls: 3 },
     fallbackRunner: opts.fallbackRunner ?? false,
     conflictResolver: opts.conflictResolve
       ? async (prompt) => {

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -208,6 +208,20 @@ function harness(opts: HarnessOptions = {}): {
       if (argv.includes("pr") && argv.includes("list")) {
         return { code: 0, stdout: "42\n", stderr: "" };
       }
+      // #2986 merge confirmation: this forge merges on the spot, so the probe
+      // that follows the merge command reports a MERGED pull request.
+      if (j.includes("--json state,mergedAt")) {
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            state: "MERGED",
+            mergedAt: "2026-08-01T00:00:00Z",
+            mergeCommit: { oid: "abc1234" },
+            autoMergeRequest: null,
+          }),
+          stderr: "",
+        };
+      }
       if (j.includes("pr view") && j.includes("mergeStateStatus")) {
         const map = {
           merge: { mergeStateStatus: "CLEAN", mergeable: "MERGEABLE", baseRefOid: "0r1g1nsha", statusCheckRollup: [{ name: "ci", conclusion: "SUCCESS" }] },


### PR DESCRIPTION
Automated AFK landing for #2986. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2986

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788165417&installation_model_id=20659&pr_number=2992&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2992&signature=6eadcdc385c2a04a1dac2e00065a2d8ee534b944d89f2985c1edac693d72a7db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->