### PR TITLE
fix: #2981 The project-lifecycle refusal test talks to the operator's real daemon, failing on any host that runs one

### DIFF
--- a/apps/dev/tests/castle-mcp-output-contracts.test.ts
+++ b/apps/dev/tests/castle-mcp-output-contracts.test.ts
@@ -23,12 +23,8 @@ import {
  */
 
 const roots: string[] = [];
-let runtimeDirBefore: string | undefined;
 
 afterEach(async () => {
-  if (runtimeDirBefore === undefined) delete process.env.XDG_RUNTIME_DIR;
-  else process.env.XDG_RUNTIME_DIR = runtimeDirBefore;
-  runtimeDirBefore = undefined;
   await Promise.all(
     roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
   );
@@ -37,15 +33,10 @@ afterEach(async () => {
 async function fixtureRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "dev-afk-contracts-"));
   roots.push(root);
-  // The fixture states "no daemon answers", so it has to OWN the runtime
-  // directory the socket is resolved in (#2884's rule, applied to a contract
-  // test): resolved from the ambient environment, this asserted the operator's
-  // machine had no daemon running, and went red on every machine where the lane
-  // actually worked.
-  runtimeDirBefore = process.env.XDG_RUNTIME_DIR;
-  const runtimeDir = join(root, "runtime");
-  await mkdir(runtimeDir, { recursive: true });
-  process.env.XDG_RUNTIME_DIR = runtimeDir;
+  // The fixture states "no daemon answers", and the SUITE owns that absence:
+  // this file pinned its own `XDG_RUNTIME_DIR` (#2884's rule, applied to a
+  // contract test) until the pin moved into the package's setup file (#2981),
+  // where every test inherits it instead of each one remembering it.
   await writeWorkerAttempt(root, "wHU5U", 2335);
   await writeFleetState(root);
   return root;

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { SpawnOptions } from "node:child_process";
 import type { JsonObject } from "@reddb-io/toon";
 import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
 import { waitsDir } from "@reddb-io/shared/red-paths.js";
@@ -25,12 +26,35 @@ import { dispatchInput } from "../../../packages/red-castle/src/mcp/worker.js";
 import type { HookExec } from "../src/core/hook-dispatcher.js";
 import { readPidStartTime } from "../src/core/state.js";
 
+// Every process this suite starts, RECORDED — never replaced. The project
+// lifecycle's contract is that a refusal starts nothing, and a refusal that
+// quietly launched a producer of its own would still read as a rejected promise.
+// The call passes straight through to the real `spawn`, so the launches other
+// cases in this file depend on keep behaving exactly as they did.
+const spawned = vi.hoisted(() => [] as { command: string; args: readonly string[] }[]);
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (command: string, args: readonly string[], options: SpawnOptions) => {
+      spawned.push({ command, args });
+      return (actual.spawn as unknown as (
+        command: string,
+        args: readonly string[],
+        options: SpawnOptions,
+      ) => ReturnType<typeof actual.spawn>)(command, args, options);
+    },
+  };
+});
+
 const roots: string[] = [];
 
 afterEach(async () => {
   await Promise.all(
     roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
   );
+  spawned.length = 0;
 });
 
 async function root(): Promise<string> {
@@ -485,6 +509,11 @@ describe("castle MCP host adapter", () => {
   });
 });
 
+// The host these cases speak to is the SANDBOX's, pinned by the suite's setup
+// file (#2981): both assert what happens when no daemon answers, and resolved
+// from the ambient environment that is an assertion about the developer's
+// machine — on a host running a daemon the start reached it and was registered,
+// so the refusal went red on untouched code.
 describe("project lifecycle — a registration, never a process (#2909)", () => {
   // ADR 0130 Amendment 4: the record lives on the host, so both a duplicate
   // start and a re-aim are decided by the daemon. A pre-check of our own would be
@@ -499,21 +528,29 @@ describe("project lifecycle — a registration, never a process (#2909)", () => 
 
     await expect(
       createCastleMcpDependencies(cwd).projectResize({ target: 3, runner: "codex" }),
-    ).rejects.toThrow(/registration|daemon/);
+    ).rejects.toThrow(/registration rather than a process/);
+
+    // Asking the host is allowed to start the HOST (ADR 0130 rule 7, and the
+    // sandbox pins that executable at a path that cannot run). What a re-aim may
+    // never start is a producer of this project's own.
+    expect(spawned.map((launch) => launch.command)).toEqual([process.env.REDSKILLED_BIN]);
   });
 
   it("refuses the start rather than falling back to a process of its own", async () => {
-    // A bare scratch directory: no daemon of its own and no `origin`. Either
-    // refusal is the contract — what is never allowed is a process started
-    // locally to make up for what the start could not do. The daemon-down
-    // refusal names the socket, and `mcp-project-registration` pins that one
-    // against an isolated host; this one pins that a checkout with no tracker
-    // to count is refused rather than registered with a query about everything.
+    // The daemon is down, so the start ends there: the refusal names the socket
+    // and the fact that a project contributes a registration rather than a
+    // process. What is never allowed is a process started locally to make up for
+    // what the start could not do.
     const cwd = await root();
 
     await expect(
       createCastleMcpDependencies(cwd).projectStart({ runner: "claude", target: 1 }),
-    ).rejects.toThrow(/registration rather than a process|no `origin` remote/);
+    ).rejects.toThrow(/registration rather than a process/);
+
+    // Fail closed (ADR 0130 rule 6). The one launch this path may attempt is the
+    // host daemon's own auto-start (rule 7), which the sandbox pins at a path
+    // that cannot run — and nothing else was started to compensate.
+    expect(spawned.map((launch) => launch.command)).toEqual([process.env.REDSKILLED_BIN]);
   });
 });
 

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -180,6 +180,21 @@ describe("starting work registers the project", () => {
     // Fail closed (ADR 0130 rule 6): a refused registration falls back to nothing.
     expect(spawn.mock.calls.filter((call) => (call[1] ?? []).includes("__supervise"))).toEqual([]);
   });
+
+  it("refuses a checkout with no `origin`, rather than registering a query about everything", async () => {
+    // The second refusal, against a daemon that DOES answer, so the reason is
+    // the checkout rather than the host. It lived as an alternation in the
+    // adapter suite's daemon-down case until #2981 pinned that host: which of
+    // the two refusals fired there depended on whether the developer's machine
+    // ran a daemon, which is no way to pin either of them.
+    await liveHost();
+    const root = await scratch("dev-register-untracked-");
+    execFileSync("git", ["init", "-q"], { cwd: root, stdio: "ignore" });
+
+    await expect(
+      createCastleMcpDependencies(root).projectStart({ runner: "claude", target: 1 }),
+    ).rejects.toThrow(/no `origin` remote/);
+  });
 });
 
 describe("stopping work deregisters the project", () => {

--- a/apps/dev/tests/redskilled-test-isolation.test.ts
+++ b/apps/dev/tests/redskilled-test-isolation.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The suite's daemon absence is its OWN (#2981).
+ *
+ * Every refusal test in this package asserts that no `redskilled` daemon
+ * answers. Resolved from the ambient environment that assertion is about the
+ * developer's machine, so a contributor running a daemon saw a red suite on
+ * untouched code. These cases pin the pin: the isolation is wired as a setup
+ * file, the derived socket is inside the sandbox, and nothing on the host can be
+ * reached or started from here.
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
+import { resolveRedskilledEntry } from "../../redskilled/src/daemon-entry.js";
+import {
+  ISOLATED_REDSKILLED_HOST_ROOT,
+  pinIsolatedRedskilledHost,
+} from "./support/redskilled-isolation.js";
+
+const SETUP_FILE = "./tests/support/redskilled-isolation.ts";
+
+describe("the test host is the sandbox's, not the operator's", () => {
+  it("wires the isolation as a setup file, so no test has to remember it", () => {
+    // The leak was a DEFAULT, so the cure has to be one too: a per-file pin is a
+    // pin the next test file can forget, and forgetting is invisible until the
+    // next machine with a live daemon runs the suite.
+    const config = readFileSync(join(import.meta.dirname, "..", "vitest.config.ts"), "utf8");
+
+    expect(config).toContain(SETUP_FILE);
+  });
+
+  it("resolves this session's socket inside the sandbox", () => {
+    const paths = resolveRedskilledPaths();
+
+    expect(paths.sessionKey).toContain(ISOLATED_REDSKILLED_HOST_ROOT);
+    expect(paths.socketPath.startsWith(ISOLATED_REDSKILLED_HOST_ROOT)).toBe(true);
+    // The machine claim lives in a SHARED directory by design, so an unpinned
+    // read finds the live claim of the operator's daemon rather than nothing.
+    expect(paths.machineClaimPath.startsWith(ISOLATED_REDSKILLED_HOST_ROOT)).toBe(true);
+  });
+
+  it("resolves an auto-spawn entry that cannot start a daemon", () => {
+    // ADR 0130 rule 7 makes reaching a silent socket a START. Unpinned, a host
+    // with a cached bundle answers its own refusal test by launching the daemon
+    // whose absence is under assertion.
+    const entry = resolveRedskilledEntry();
+
+    expect(entry).toMatchObject({ source: "env-redskilled-bin" });
+    expect((entry as { command: string }).command.startsWith(ISOLATED_REDSKILLED_HOST_ROOT)).toBe(true);
+  });
+
+  it("reaps the sandboxes of processes that are gone, and spares the living", () => {
+    // A vitest worker is usually SIGKILLed at the end of a run, which runs no
+    // exit hook: one suite left 362 directories in the temp dir before the
+    // reaper existed. Keyed on a DEAD pid, so a run happening right now keeps its
+    // own sandbox.
+    const parent = dirname(ISOLATED_REDSKILLED_HOST_ROOT);
+    const dead = spawnSync(process.execPath, ["-e", ""]).pid!;
+    const abandoned = join(parent, String(dead));
+    const living = join(parent, String(process.ppid));
+    mkdirSync(join(abandoned, "runtime"), { recursive: true });
+    mkdirSync(living, { recursive: true });
+
+    try {
+      pinIsolatedRedskilledHost({ ...process.env });
+
+      expect(existsSync(abandoned)).toBe(false);
+      expect(existsSync(living)).toBe(true);
+      expect(existsSync(ISOLATED_REDSKILLED_HOST_ROOT)).toBe(true);
+    } finally {
+      rmSync(living, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/dev/tests/support/redskilled-isolation.ts
+++ b/apps/dev/tests/support/redskilled-isolation.ts
@@ -1,0 +1,117 @@
+/**
+ * redskilled-isolation — "no daemon" is a fact about the SANDBOX, never about
+ * the developer's machine (#2981, the rule #2884 established for the canary).
+ *
+ * A test that asserts a refusal from an absent daemon has to own the absence.
+ * Resolved from the ambient environment, `resolveRedskilledPaths()` lands on the
+ * operator's real socket, so `project_start` succeeded with `status: registered`
+ * on every host that runs a daemon and the refusal assertion went red on
+ * untouched code. Three files had already pinned their own scope by hand — the
+ * canary sandbox, the MCP contract fixture, and redskilled's own offline
+ * `--help` suite — which is three spellings of one boundary and a fourth waiting
+ * to be forgotten. This module is the boundary for THIS package: imported once
+ * as its vitest setup file, so every test in the suite inherits it and no new
+ * one has to remember it. The canary's sandbox stays as it is — it pins the
+ * environment of the child processes it launches, which no setup file can do.
+ *
+ * Four pins, and each closes a different way to the operator's host:
+ *
+ * 1. `REDSKILLED_SESSION` — the scope itself. A key nothing else uses means the
+ *    derived socket is one no daemon on this machine is listening on.
+ * 2. `XDG_RUNTIME_DIR` — where that socket lives. Pinned so a suite does not
+ *    deposit dead session directories in the operator's real runtime dir, which
+ *    is the litter #2884 named.
+ * 3. `REDSKILLED_MACHINE_DIR` — the machine claim. It lives in a SHARED
+ *    directory by design, so an unpinned test reads the live claim of the
+ *    operator's daemon and gets "the machine is held" instead of "nothing is
+ *    there".
+ * 4. `REDSKILLED_BIN` — the auto-spawn (ADR 0130 rule 7). Reaching a silent
+ *    socket tries to START a daemon from the published bundle, so a host with a
+ *    cached bundle would answer its own refusal test by launching the very
+ *    daemon it is asserting the absence of. Pinned to a path that does not
+ *    exist: the spawn fails immediately, by name, without a network fetch.
+ *
+ * Every pin is an environment variable rather than an injected parameter,
+ * because the leak is in the DEFAULT derivation — a test that had to remember to
+ * inject is a test that can forget.
+ */
+import { mkdirSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Plugin roots the entry resolver probes for a bundle to spawn a daemon from. */
+const PLUGIN_ROOT_ENV = [
+  "RED_SKILLS_DEV_PLUGIN_ROOT",
+  "CLAUDE_PLUGIN_ROOT",
+  "CODEX_PLUGIN_ROOT",
+  "OPENCODE_PLUGIN_ROOT",
+] as const;
+
+/**
+ * Pin this process's whole reach into `redskilled` inside one scratch directory.
+ *
+ * Returns the directory, so a caller can assert that a resolved socket is inside
+ * it. Idempotent per process: the same pid pins the same root.
+ */
+export function pinIsolatedRedskilledHost(env: NodeJS.ProcessEnv = process.env): string {
+  const parent = join(tmpdir(), "red-skills-test-host");
+  const root = join(parent, String(process.pid));
+  mkdirSync(root, { recursive: true });
+  reapDeadSandboxes(parent);
+  env.REDSKILLED_SESSION = `red-skills-test-host:${root}`;
+  env.XDG_RUNTIME_DIR = join(root, "runtime");
+  env.REDSKILLED_MACHINE_DIR = join(root, "machine");
+  // Named for what it is, so the failure a spawn reports reads as the pin rather
+  // than as a broken installation.
+  env.REDSKILLED_BIN = join(root, "no-daemon-in-this-sandbox");
+  for (const variable of PLUGIN_ROOT_ENV) delete env[variable];
+  mkdirSync(env.XDG_RUNTIME_DIR, { recursive: true });
+  mkdirSync(env.REDSKILLED_MACHINE_DIR, { recursive: true });
+  return root;
+}
+
+/**
+ * Remove the sandboxes of processes that are gone.
+ *
+ * A sandbox that outlives its process is the litter the pin exists to avoid, and
+ * the exit hook below is not enough on its own: a vitest worker is usually
+ * SIGKILLed at the end of a run, which runs no hook — one suite left 362
+ * directories behind before this reaper existed. Keyed on the pid being DEAD, so
+ * a concurrent run's sandbox is never taken out from under it.
+ */
+function reapDeadSandboxes(parent: string): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(parent);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const pid = Number(entry);
+    if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid || isAlive(pid)) continue;
+    rmSync(join(parent, entry), { recursive: true, force: true });
+  }
+}
+
+/** Signal 0: does this pid exist? `EPERM` means it does, under another user. */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * The scratch host this test process owns.
+ *
+ * Exported as a top-level constant on purpose: importing this module IS the pin,
+ * which is what makes it usable as a vitest `setupFiles` entry.
+ */
+export const ISOLATED_REDSKILLED_HOST_ROOT = pinIsolatedRedskilledHost();
+
+// The tidy exit, for the runs that get one.
+process.on("exit", () => {
+  rmSync(ISOLATED_REDSKILLED_HOST_ROOT, { recursive: true, force: true });
+});

--- a/apps/dev/vitest.config.ts
+++ b/apps/dev/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
     // Dev tests + the shared-layer tests (packages/shared/*.test.ts).
     // The dev app carries the toolchain that runs the shared suite.
     include: ["tests/**/*.test.ts", "../../packages/shared/**/*.test.ts"],
+    // Every test file reaches `redskilled` through a sandbox of its own (#2981):
+    // "no daemon answers" has to be a fact about this process, not about the
+    // machine the suite happens to run on.
+    setupFiles: ["./tests/support/redskilled-isolation.ts"],
     environment: "node",
     pool: "forks",
     fileParallelism: false,


### PR DESCRIPTION
Automated AFK landing for #2981. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2981

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788165661&installation_model_id=20659&pr_number=2993&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2993&signature=42743fc9d5d15b89709cc820fe3d31b76cf5d893e4629eac82702c7c62d0c0f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->