### PR TITLE
chore: #2972 Prove redskilled works on WSL2: no XDG_RUNTIME_DIR, no systemd, still a Worker

### DIFF
--- a/.changeset/wsl2-host-is-posed-not-assumed.md
+++ b/.changeset/wsl2-host-is-posed-not-assumed.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+WSL2 is proven rather than assumed: a test poses the host — no `XDG_RUNTIME_DIR`, no `systemd-run` on the PATH the probe reads, no `--user` session, a relocated `TMPDIR` — and a real Worker is born on it, unisolated, carrying the warning that names what was lost, with the RSS sampling floor still terminating it over budget off a synthetic `/proc`. Posing the host found the one thing reading the code did not: the `tmpdir()` socket fallback carried no `sun_path` check of its own, so a `TMPDIR` longer than 54 bytes produced a 168-byte socket path and `bind` would have answered `ENAMETOOLONG` — an outage that reads like anything but a path four bytes too long, and one that surfaces only on someone else's machine. `runtimeSocketDir` now falls back once more to `/tmp` when `tmpdir()` will not fit, and the supported version boundary is stated where an operator meets it: WSL2 yes, WSL1 no, because the memory floor walks the Worker's tree through a `/proc` WSL1 does not have.

--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -208,6 +208,19 @@ of it.
   unit the Worker still starts, and the reply — and the host-state record it
   keeps for its whole life — carries a warning naming what was lost. A declared
   budget that cannot be enforced says so as its own warning.
+- **WSL2 is supported; WSL1 is not.** WSL2 is a Linux host missing the two things
+  the Linux path prefers, and each has a stated degradation rather than a
+  failure: with no `XDG_RUNTIME_DIR` the socket lands under `tmpdir()` and the
+  session is scoped `uid:<n>`, and with no `systemd-run` and no `--user` session
+  the Worker is born **unisolated**, carrying the warning that names what was
+  lost. The memory ceiling is then the daemon's own RSS sampling floor and
+  nothing else, which is why that floor is uniform across backends. **A
+  memory-pressure kill on such a host lands on the whole session**, not on one
+  Worker — plan the host budget accordingly. WSL1 is excluded because the floor
+  walks the Worker's process tree through `/proc`, which WSL2 has and WSL1 does
+  not: there the ceiling would silently have nothing to read. A long `TMPDIR` —
+  WSL and some distros relocate it — falls back once more to `/tmp` so the socket
+  path stays inside the kernel's 108-byte `sun_path` limit.
 
 ## Provisioning
 

--- a/apps/redskilled/tests/wsl2-host.test.ts
+++ b/apps/redskilled/tests/wsl2-host.test.ts
@@ -1,0 +1,318 @@
+// WSL2: the Linux-shaped host that lacks the two things the Linux path assumes.
+//
+// Everything here already "should work" by reading the code — and that is
+// precisely the claim this file exists to stop trusting. The daemon entry
+// resolver read correctly and could not start on a fresh host (#2961); the idle
+// window and the upgrade check each read sensibly and together made
+// self-replacement unreachable (#2968). So the WSL2 host is POSED rather than
+// described: no `XDG_RUNTIME_DIR`, no `systemd-run` on PATH, no `--user`
+// session, a relocated `TMPDIR`, and a `/proc` that is walked for real.
+//
+// **WSL2 only.** WSL1 has no real `/proc`, so the tree walk the memory floor
+// stands on has nothing to read there; that boundary is stated in the app README
+// where an operator will meet it, and the last case in this file holds the
+// README to it.
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { UNIX_SOCKET_PATH_LIMIT } from "@reddb-io/shared/resident-core.js";
+import { evaluateWorkerAdmission, UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { evaluateMemoryBudgets, sampleWorkerTrees } from "../src/memory-sampler.js";
+import {
+  createRedskilledMachineClaimStore,
+  resolveMachineClaimDir,
+  resolveMachineClaimPath,
+} from "../src/machine-scope.js";
+import { resolveRedskilledPaths, resolveSessionKey, REDSKILLED_SOCKET_FILE } from "../src/paths.js";
+import { launchWorker } from "../src/worker-launch.js";
+import { detectWorkerPlacementProbes, planWorkerPlacement } from "../src/worker-placement.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+
+const roots: string[] = [];
+const restoreEnv: Array<() => void> = [];
+
+afterEach(async () => {
+  for (const restore of restoreEnv.splice(0)) restore();
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+/** Point the host's own `tmpdir()` somewhere else, the way WSL and some distros do. */
+function relocateTmpdir(dir: string): void {
+  const before = { TMPDIR: process.env.TMPDIR, TMP: process.env.TMP, TEMP: process.env.TEMP };
+  restoreEnv.push(() => {
+    for (const [key, value] of Object.entries(before)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+  process.env.TMPDIR = dir;
+  process.env.TMP = dir;
+  process.env.TEMP = dir;
+}
+
+/**
+ * The environment a WSL2 shell really hands a process.
+ *
+ * No `XDG_RUNTIME_DIR`, because nothing creates one without a login session. The
+ * PATH names directories that do not exist on ANY host, which is how a machine
+ * that happens to have `systemd-run` installed — this repository's own CI and
+ * every maintainer's Linux box — can still pose as one that does not. The probe
+ * looks the binary up on exactly this PATH, so posing the PATH poses the host.
+ */
+const WSL2_ENV: NodeJS.ProcessEnv = {
+  PATH: "/wsl2-pose/usr/local/bin:/wsl2-pose/usr/bin:/wsl2-pose/bin",
+  HOME: "/home/wsluser",
+};
+
+function worker(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorkerView {
+  return {
+    worker_id: "wWSL2",
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-08-01T00:00:00.000Z",
+    workspace_path: "/home/wsluser/acme",
+    isolated: false,
+    budget: { memory_max: "4G" },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("WSL2 — the probes a host without systemd answers", () => {
+  it("finds no systemd-run and no --user session, and says so as facts rather than absences", () => {
+    const probes = detectWorkerPlacementProbes(WSL2_ENV, "linux");
+
+    expect(probes.platform).toBe("linux");
+    // Nothing was spawned to learn this: the binary is looked for on the PATH the
+    // Worker would inherit, and the session is proven by its private socket.
+    expect(probes.systemdRun).toBeNull();
+    expect(probes.userSession).toBe(false);
+    // The other two backends belong to other platforms, and each says which.
+    expect(probes.jobObjects.available).toBe(false);
+    expect(probes.posix.available).toBe(false);
+  });
+
+  it("still finds no session when XDG_RUNTIME_DIR names a directory with no systemd socket in it", async () => {
+    // WSL2 with an operator-set XDG_RUNTIME_DIR is the near-miss case: the
+    // variable exists, and there is still no session behind it.
+    const runtimeDir = await scratch("redskilled-wsl-xdg-");
+    const probes = detectWorkerPlacementProbes({ ...WSL2_ENV, XDG_RUNTIME_DIR: runtimeDir }, "linux");
+
+    expect(probes.userSession).toBe(false);
+  });
+});
+
+describe("WSL2 — a Worker is born, unisolated, and the loss is named", () => {
+  const WSL2_PROBES = detectWorkerPlacementProbes(WSL2_ENV, "linux");
+
+  it("plans an unwrapped launch and names systemd-run as what it could not reach", () => {
+    const plan = planWorkerPlacement({
+      workerId: "wWSL2",
+      projectLabel: "acme/widgets",
+      workspacePath: "/home/wsluser/acme",
+      command: "/usr/bin/node",
+      args: ["worker.js"],
+      budget: { memory_max: "4G" },
+      probes: WSL2_PROBES,
+    });
+
+    expect(plan.backend).toBe("none");
+    expect(plan.isolated).toBe(false);
+    // The argv is the caller's own, untouched — there is no launcher to wrap it in.
+    expect(plan.command).toBe("/usr/bin/node");
+    expect(plan.args).toEqual(["worker.js"]);
+    expect(plan.cwd).toBe("/home/wsluser/acme");
+    expect(plan.unit).toBeUndefined();
+    expect(plan.warning).toMatch(/systemd-run is not on PATH/);
+    expect(plan.warning).toMatch(/charged to the daemon's own resource group/);
+    // A declared budget the placement cannot carry is its own sentence, so the
+    // floor that does carry it is never something an operator has to infer.
+    expect(plan.budgetWarning).toMatch(/RSS sampling/);
+  });
+
+  it("really spawns one, in the workspace it was handed, and hands the warnings back to the caller", async () => {
+    // A real process, not an injected spawn: "it should work" is the claim under
+    // test, so the Worker has to actually run on this host and prove it did.
+    const workspace = await scratch("redskilled-wsl-workspace-");
+    const launched = launchWorker({
+      admission: evaluateWorkerAdmission({ ceiling: UNBOUNDED_HOST_CEILING, workers: [] }),
+      spec: {
+        project_label: "acme/widgets",
+        workspace_path: workspace,
+        command: process.execPath,
+        args: ["-e", "require('node:fs').writeFileSync('proof.txt', process.cwd());"],
+        budget: { memory_max: "4G" },
+      },
+      probes: WSL2_PROBES,
+      env: WSL2_ENV,
+    });
+
+    expect(launched.worker.pid).toBeGreaterThan(0);
+    expect(launched.worker.isolated).toBe(false);
+    expect(launched.worker.unit).toBeUndefined();
+    // The warning reaches the caller AND stays on the record the Worker keeps for
+    // its whole life — a downgrade nobody can read later is a silent one.
+    expect(launched.warnings.join(" ")).toMatch(/systemd-run is not on PATH/);
+    expect(launched.worker.warnings).toEqual(launched.warnings);
+
+    const proof = join(workspace, "proof.txt");
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      try {
+        expect(await readFile(proof, "utf8")).toBe(workspace);
+        return;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    throw new Error(`the Worker never wrote ${proof}`);
+  });
+});
+
+describe("WSL2 — the uniform sampling floor is the ceiling here", () => {
+  /** A synthetic `/proc`, in the kernel's own layout: one directory, one `stat`. */
+  async function procTable(rows: ReadonlyArray<{ pid: number; ppid: number; rssPages: number }>): Promise<string> {
+    const procRoot = await scratch("redskilled-wsl-proc-");
+    for (const row of rows) {
+      const fields = new Array(50).fill("0");
+      fields[1] = String(row.ppid); // ppid, once the (comm) field is read past
+      fields[21] = String(row.rssPages); // rss, in pages
+      await mkdir(join(procRoot, String(row.pid)), { recursive: true });
+      await writeFile(join(procRoot, String(row.pid), "stat"), `${row.pid} (node) ${fields.join(" ")}\n`, "utf8");
+    }
+    return procRoot;
+  }
+
+  it("reads the Worker's whole tree out of /proc — the file system WSL2 has and WSL1 does not", async () => {
+    const procRoot = await procTable([
+      { pid: 4242, ppid: 1, rssPages: 512 * 1024 },
+      { pid: 4243, ppid: 4242, rssPages: 256 * 1024 },
+      { pid: 9999, ppid: 1, rssPages: 999 * 1024 },
+    ]);
+
+    const reading = sampleWorkerTrees([worker()], { procRoot, platform: "linux" });
+
+    // The child is summed into the Worker; the stranger stays a stranger.
+    expect(reading.rss.wWSL2).toBe((512 + 256) * 1024 * 4096);
+  });
+
+  it("terminates an over-budget Worker on a host with no cgroup to have stopped it", async () => {
+    // This is the whole point of ADR 0130 rule 4: with no transient unit there is
+    // no kernel ceiling, so the sampler's is the only one — and it must still hold.
+    const procRoot = await procTable([{ pid: 4242, ppid: 1, rssPages: 5 * 1024 * 1024 * 1024 / 4096 }]);
+    const rss = sampleWorkerTrees([worker()], { procRoot, platform: "linux" });
+    const outcome = evaluateMemoryBudgets({ workers: [worker()], rss: rss.rss });
+
+    expect(outcome.terminations).toHaveLength(1);
+    expect(outcome.terminations[0]).toMatchObject({
+      worker_id: "wWSL2",
+      outcome: "terminated-over-memory-budget",
+      classification: "budget-exceeded",
+      budget_name: "MemoryMax",
+      budget_declared: "4G",
+    });
+  });
+
+  it("decides identically whether the Worker was isolated or not — the floor takes no platform input", () => {
+    const over = { wWSL2: 5 * 1024 ** 3 };
+    const unisolated = evaluateMemoryBudgets({ workers: [worker({ isolated: false })], rss: over });
+    const isolated = evaluateMemoryBudgets({
+      workers: [worker({ isolated: true, unit: "red-worker-acme-widgets-wwsl2.service" })],
+      rss: over,
+    });
+
+    expect(unisolated.terminations[0]?.reason).toBe(isolated.terminations[0]?.reason);
+  });
+});
+
+describe("WSL2 — the socket lands somewhere the kernel will actually bind", () => {
+  it("falls back to tmpdir with no XDG_RUNTIME_DIR, and scopes the session by uid", () => {
+    const paths = resolveRedskilledPaths({ env: WSL2_ENV, uid: 1000, host: "wsl-host" });
+
+    expect(resolveSessionKey({ env: WSL2_ENV, uid: 1000 })).toBe("uid:1000");
+    expect(paths.sessionKey).toBe("uid:1000");
+    expect(paths.runtimeDir.startsWith(join(tmpdir(), "red-skills-1000"))).toBe(true);
+    expect(paths.socketPath).toBe(join(paths.runtimeDir, REDSKILLED_SOCKET_FILE));
+    expect(paths.socketPath.length).toBeLessThan(UNIX_SOCKET_PATH_LIMIT);
+  });
+
+  it("keeps the socket inside sun_path even when TMPDIR is long enough to overflow it", async () => {
+    // The failure mode that would surface only on someone else's machine: a
+    // relocated TMPDIR pushes the fallback past 108 bytes and `bind` returns
+    // ENAMETOOLONG — an outage with no kernel error anyone reads as a path bug.
+    const long = join(await scratch("redskilled-wsl-longtmp-"), "a".repeat(80));
+    await mkdir(long, { recursive: true });
+    relocateTmpdir(long);
+    expect(tmpdir().length).toBeGreaterThan(UNIX_SOCKET_PATH_LIMIT);
+
+    const paths = resolveRedskilledPaths({ env: WSL2_ENV, uid: 1000, host: "wsl-host" });
+
+    expect(paths.socketPath.length).toBeLessThan(UNIX_SOCKET_PATH_LIMIT);
+    // Every path the daemon lives by shares the directory, so a fitting socket
+    // that left the lease behind in the overlong one would be half a fallback.
+    expect(paths.lockPath.startsWith(paths.runtimeDir)).toBe(true);
+    expect(paths.leasePath.startsWith(paths.runtimeDir)).toBe(true);
+    expect(paths.eventLanePath.startsWith(paths.runtimeDir)).toBe(true);
+  });
+
+  it("prefers a fitting XDG_RUNTIME_DIR when one exists, so the fallback is a fallback", () => {
+    const withXdg = resolveRedskilledPaths({ env: { ...WSL2_ENV, XDG_RUNTIME_DIR: "/run/user/1000" }, uid: 1000 });
+
+    expect(withXdg.runtimeDir.startsWith("/run/user/1000/red-skills/")).toBe(true);
+  });
+});
+
+describe("WSL2 — the machine claim on a relocated tmpdir", () => {
+  it("resolves the shared directory from tmpdir, not from a hardcoded /tmp", async () => {
+    const relocated = await scratch("redskilled-wsl-tmp-");
+    relocateTmpdir(relocated);
+
+    const dir = resolveMachineClaimDir({ env: WSL2_ENV, machineIdHash: "abc123def456", platform: "linux" });
+
+    expect(dir).toBe(join(relocated, "redskilled-abc123def456"));
+  });
+
+  it("claims, refuses a live foreign holder, and releases — all under that relocated root", async () => {
+    const relocated = await scratch("redskilled-wsl-claim-");
+    relocateTmpdir(relocated);
+    const claimPath = resolveMachineClaimPath({ env: WSL2_ENV, machineIdHash: "abc123def456", platform: "linux" });
+    expect(claimPath.startsWith(relocated)).toBe(true);
+
+    const labels = { machineIdHash: "abc123def456", sessionKeyHash: "0123456789ab", socketPath: "/tmp/x/redskilled.sock" };
+    const store = createRedskilledMachineClaimStore(claimPath, labels, {
+      clock: () => "2026-08-01T00:00:00.000Z",
+      isPidAlive: () => true,
+    });
+    const owner = { pid: 111, startTime: "2026-08-01T00:00:00.000Z", uid: 1000 };
+
+    const first = await store.claim(owner);
+    expect(first).toMatchObject({ claimed: true });
+
+    // A second daemon, another pid, still alive: refused with the holder named.
+    const rival = createRedskilledMachineClaimStore(claimPath, { ...labels, socketPath: "/tmp/y/redskilled.sock" }, {
+      clock: () => "2026-08-01T00:00:01.000Z",
+      isPidAlive: () => true,
+    });
+    const second = await rival.claim({ pid: 222, startTime: "2026-08-01T00:00:01.000Z", uid: 1000 });
+    expect(second).toMatchObject({ claimed: false, reason: "held" });
+
+    expect(await store.release(owner)).toBe(true);
+    expect(await store.read()).toBeUndefined();
+  });
+});
+
+describe("WSL2 — the supported version is stated where an operator reads it", () => {
+  it("names WSL2 and the /proc requirement in the app README", async () => {
+    const readme = await readFile(new URL("../README.md", import.meta.url), "utf8");
+
+    expect(readme).toMatch(/WSL2/);
+    expect(readme).toMatch(/WSL1/);
+    expect(readme).toMatch(/\/proc/);
+  });
+});

--- a/packages/shared/resident-core.ts
+++ b/packages/shared/resident-core.ts
@@ -222,20 +222,41 @@ export interface RuntimeSocketDirOptions {
 }
 
 /**
+ * The POSIX temp root every Unix has, used only when `tmpdir()` will not fit.
+ *
+ * Not a preference — a last resort. `TMPDIR` is the operator's answer and is
+ * honoured first; this exists because a relocated one can be long enough that no
+ * socket under it fits `sun_path`, and a shorter root that binds beats a
+ * respectful one that cannot.
+ */
+export const FALLBACK_TMP_ROOT = "/tmp";
+
+/**
  * The runtime directory for a scope's socket, preferring `XDG_RUNTIME_DIR`.
  *
- * The `XDG_RUNTIME_DIR` candidate is used only when the resulting socket path
- * still fits `sun_path`; otherwise the shorter `tmpdir()` form wins, because a
- * path the kernel refuses to bind is not an option, it is an outage.
+ * Each candidate is used only when the resulting socket path still fits
+ * `sun_path`, because a path the kernel refuses to bind is not an option, it is
+ * an outage — and one that surfaces as `ENAMETOOLONG` from `bind`, which reads
+ * like anything but a path too long by four bytes. `XDG_RUNTIME_DIR` first (the
+ * OS's own per-user answer), then `tmpdir()` for a host that has no session to
+ * have made one, then `/tmp` for the host whose `TMPDIR` is itself too long —
+ * WSL2 and the distros that relocate it are where that last case lives.
  */
 export function runtimeSocketDir(options: RuntimeSocketDirOptions): string {
   const env = options.env ?? process.env;
   const hash = createHash("sha256").update(options.key).digest("hex").slice(0, 20);
+  const fits = (dir: string): boolean =>
+    join(dir, options.socketFileName).length < UNIX_SOCKET_PATH_LIMIT;
   const xdg = env.XDG_RUNTIME_DIR;
   if (xdg) {
     const candidate = join(xdg, "red-skills", hash);
-    if (join(candidate, options.socketFileName).length < UNIX_SOCKET_PATH_LIMIT) return candidate;
+    if (fits(candidate)) return candidate;
   }
   const uid = options.uid ?? (typeof process.getuid === "function" ? process.getuid() : "nouid");
-  return join(tmpdir(), `red-skills-${uid}`, hash);
+  const leaf = join(`red-skills-${uid}`, hash);
+  const candidate = join(tmpdir(), leaf);
+  if (fits(candidate) || process.platform === "win32") return candidate;
+  // Windows is excluded above rather than falling through: it has no `/tmp`, and
+  // its named pipes are not bound by `sun_path` in the first place.
+  return join(FALLBACK_TMP_ROOT, leaf);
 }


### PR DESCRIPTION
Automated AFK landing for #2972. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2972

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788170659&installation_model_id=20659&pr_number=2995&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2995&signature=2cbd200a0a0345c0a835da5f380733b4ab2654ddcca38b38104a3c9744f0f194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->