### PR TITLE
test: the approval-gate assertion follows the prose into docs/RELEASING.md

### DIFF
--- a/scripts/test-red-release-approval-gate.sh
+++ b/scripts/test-red-release-approval-gate.sh
@@ -42,9 +42,11 @@ assert_release_job_environment() {
 }
 
 assert_release_job_environment
-assert_grep "README documents approval requirement" \
+# The approval prose moved from the README to docs/RELEASING.md when the README
+# was restructured around core-versus-complementary; the assertion follows it.
+assert_grep "release docs document approval requirement" \
   "environment.*${ENVIRONMENT_NAME}.*approval|required reviewers" \
-  "$README"
+  "docs/RELEASING.md"
 
 printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
 [ "$fail_count" -eq 0 ]


### PR DESCRIPTION
PR #3008 moved the release-approval prose from the README to docs/RELEASING.md, but the queue's merge group formed before the matching script fix was pushed, so the squash landed without it — main's workflow-security is red on every PR since. This is that one-commit fix: the assertion points at docs/RELEASING.md, where the prose now lives.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788186859&installation_model_id=20659&pr_number=3009&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3009&signature=f9b337f70eeaa66b0ad6eefa243f986d2dcef25d2d48a2ff1d36f528165a6542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->