### PR TITLE
fix: #3014 blocked:dependency lingers after every blocker closes on a repo where no sweep ever runs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ Upstream base: `mattpocock/skills@66898f60e8c744e269f8ce06c2b2b99ce7660d5f` (rev
 
 ---
 
+## afk (engineering) — the Unblock Sweep gets its own belt, outside the boot suite (issue #3014)
+
+- **status**: modified
+- **upstream**: —
+- **why**: On a repo operated through live sessions only, a dependent kept `blocked:dependency` after a human closed its last `req:*` blocker. The close cascade fires only when the *agent* closes the blocker; the boot-time Unblock Sweep is awake in the resident janitor but is step 7 of a suite that aborts before it on a failing precheck, a red operational probe, or a stranded `.red/` doc. The promote path was reachable in principle and starved in practice.
+- **what changed**:
+  - `docs/BOOT-SWEEPS.md`: a new *Unblock belt* section naming each clearer that was expected, why each could not fire, and the belt that replaces the dependency on the boot suite.
+
 ## afk (engineering) — `project_start` registers the project instead of launching it (issue #2902)
 
 - **status**: modified

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -127,7 +127,7 @@ import {
   registrationQueryUnexpressedFacets,
 } from "./core/registration-query.js";
 import { resolveRepoSlugForDir } from "@reddb-io/shared/project-identity-resolve.js";
-import { executeUnblockSweep } from "./core/boot-sweep.js";
+import { runRepoUnblockPass } from "./runtime/unblock-pass.js";
 import { collectReapInputs } from "./runtime/wire/reap.js";
 import { collectActivityReview } from "./commands/activity-review.js";
 import { executeTriage } from "./commands/triage.js";
@@ -440,26 +440,13 @@ export function createDefaultDevAfkMcpOperations(
       };
     },
     async unblockSweep() {
-      const context = await resolveRepoContext(root);
-      const gh = { cwd: context.root, repo: context.repo };
-      const candidates = await ghx.listUnblockCandidates(gh);
-      // The lane comes from THIS repo's installed vocabulary (#2966), so a
-      // HUMAN-ONLY dependent parks for its human instead of joining the queue.
-      const hitlTypes = readHitlTypeLabels(
-        loadConfig(afkPaths(root).configPath, { warn: () => undefined }),
-      );
-      const promoted = await executeUnblockSweep(
-        candidates,
-        async (issue) => ((await ghx.issueClosed(gh, issue)) ? "CLOSED" : "OPEN"),
-        {
-          editLabels: async (issue, remove, add) => {
-            await ghx.editLabels(gh, issue, remove, add);
-          },
-          comment: (issue, body) => ghx.comment(gh, issue, body),
-          issueReference: (issue) => ghx.issueReference(gh, issue),
-        },
-        hitlTypes,
-      );
+      // One pass, one implementation (#3014): the tool, the resident's Unblock
+      // belt, and the boot suite's step 7 promote through the same core, so an
+      // operator invoking this by hand gets exactly what the belt does on its
+      // own schedule. The lane comes from THIS repo's installed vocabulary
+      // (#2966), so a HUMAN-ONLY dependent parks for its human instead of
+      // joining the queue.
+      const promoted = await runRepoUnblockPass(root);
       return { promoted };
     },
     async gateRun(input) {

--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -37,6 +37,7 @@ import {
   createResidentJanitor,
   type ResidentJanitor,
 } from "./resident-cron.js";
+import { startResidentUnblockSweep } from "./resident-unblock.js";
 
 const buildInfo = readBuildInfo("castle");
 
@@ -250,6 +251,10 @@ export async function startResidentIssueCurator(
 export interface McpEntrypointDependencies {
   startCurator(): Promise<void>;
   startMergeDriver(): Promise<void>;
+  /** The #3014 Unblock belt: the session-reachable clearer for a dependent whose
+   * last `req:*` blocker closed. Optional so every existing caller keeps
+   * working; omitted means the belt does not run in that host. */
+  startUnblockSweep?(): Promise<void>;
   connect(): Promise<void>;
   /** The lane's own canary (#2706). Optional so every existing caller keeps
    * working; omitted means the real probe. */
@@ -281,6 +286,9 @@ export async function main(
   dependencies: McpEntrypointDependencies = {
     startCurator: startResidentIssueCurator,
     startMergeDriver: startResidentMergeDriver,
+    startUnblockSweep: async () => {
+      await startResidentUnblockSweep();
+    },
     connect: run,
   },
 ): Promise<number> {
@@ -323,6 +331,9 @@ export async function main(
   }
   await dependencies.startCurator();
   await dependencies.startMergeDriver();
+  // Started BEFORE the transport (#3014): its first pass is the session-boot
+  // clearer, and it is detached inside, so a slow tracker delays no handshake.
+  await dependencies.startUnblockSweep?.();
   await dependencies.connect();
   return 0;
 }

--- a/apps/dev/src/resident-unblock.ts
+++ b/apps/dev/src/resident-unblock.ts
@@ -1,0 +1,132 @@
+// resident-unblock.ts — the session-reachable Unblock belt (#3014).
+//
+// The castle MCP resident is what is awake on a repo operated through live
+// sessions only: no `redskilled` daemon, no `/afk` boot, no worker to run the
+// close cascade. Its janitor already runs the Unblock Sweep, but only as step 7
+// of the full boot suite, behind a precheck, the operational probes, and the
+// docs sweep — any of which aborts the run before the promote path (the full
+// diagnosis lives in `runtime/unblock-pass.ts`). So a dependent whose last
+// blocker a human closed in the GitHub UI kept `blocked:dependency` forever.
+//
+// This belt gives the sweep its OWN schedule: one pass detached at resident
+// start — the session-boot clearer — and one per interval afterwards. It shares
+// nothing with the boot suite, so no unrelated halt can starve it, and it costs
+// a single `gh issue list` on a repo with nothing blocked.
+import { join } from "node:path";
+import {
+  createEnginePaths,
+  createSingletonLeaseStore,
+  type SingletonLeaseOwner,
+  type SingletonLeaseStore,
+} from "@reddb-io/red-castle/engine";
+import { resolveRepoRoot } from "@reddb-io/shared/repo-root.js";
+import { readPidStartTime } from "./core/state.js";
+import { runRepoUnblockPass } from "./runtime/unblock-pass.js";
+
+/** How often the belt re-runs after its start-time pass. Matched to the
+ * resident's other belts: frequent enough that drift dies within one working
+ * session, cheap enough to be one `gh issue list` when nothing is blocked. */
+export const RESIDENT_UNBLOCK_INTERVAL_MS = 5 * 60 * 1000;
+
+/** The repo-scoped singleton that owns the belt, so several stdio hosts for the
+ * same repo do not each sweep the same tracker. */
+export const UNBLOCK_SWEEP_SINGLETON = "unblock-sweep";
+
+export interface ResidentUnblockTimers {
+  setInterval(callback: () => void, intervalMs: number): unknown;
+  clearInterval(timer: unknown): void;
+}
+
+export interface ResidentUnblockOptions {
+  readonly root?: string;
+  /** The pass to run. Injected in tests; the default is the real `gh` pass. */
+  readonly pass?: (root: string) => Promise<number[]>;
+  readonly leases?: SingletonLeaseStore;
+  readonly owner?: SingletonLeaseOwner;
+  readonly intervalMs?: number;
+  readonly timers?: ResidentUnblockTimers;
+  readonly notice?: (message: string) => void;
+}
+
+export interface ResidentUnblockSweep {
+  /** Run one pass now, returning the promoted issue numbers. Concurrent callers
+   * share the in-flight pass rather than doubling the tracker reads. */
+  sweep(): Promise<number[]>;
+  /** Stop the belt, drain any in-flight pass, and release the singleton. */
+  stop(): Promise<void>;
+}
+
+function defaultTimers(): ResidentUnblockTimers {
+  return {
+    setInterval(callback, intervalMs) {
+      const timer = setInterval(callback, intervalMs);
+      timer.unref();
+      return timer;
+    },
+    clearInterval(timer) {
+      clearInterval(timer as NodeJS.Timeout);
+    },
+  };
+}
+
+/**
+ * Start the Unblock belt inside the castle resident. Returns the handle, or
+ * `null` when another live host for this repo already owns the singleton.
+ *
+ * The first pass is DETACHED from the caller: a slow or unavailable tracker
+ * delays no stdio handshake, and a failing pass costs itself and nothing else —
+ * the belt keeps its next tick, because a sweep that dies on one transport fault
+ * is exactly the starvation this module exists to end.
+ */
+export async function startResidentUnblockSweep(
+  options: ResidentUnblockOptions = {},
+): Promise<ResidentUnblockSweep | null> {
+  const root = resolveRepoRoot(options.root ?? process.cwd());
+  const leases =
+    options.leases ?? createSingletonLeaseStore(createEnginePaths(join(root, ".red")));
+  const owner = options.owner ?? {
+    pid: process.pid,
+    startTime: readPidStartTime(process.pid) ?? `pid-${process.pid}`,
+  };
+  const acquired = await leases.acquire(UNBLOCK_SWEEP_SINGLETON, owner);
+  if (!acquired.acquired) return null;
+
+  const pass = options.pass ?? runRepoUnblockPass;
+  const notice = options.notice ?? (() => undefined);
+  const timers = options.timers ?? defaultTimers();
+  let running: Promise<number[]> | undefined;
+  let timer: unknown;
+
+  const sweep = (): Promise<number[]> => {
+    if (running) return running;
+    running = pass(root)
+      .catch((error): number[] => {
+        notice(
+          `unblock sweep failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return [];
+      })
+      .finally(() => {
+        running = undefined;
+      });
+    return running;
+  };
+
+  timer = timers.setInterval(
+    () => void sweep(),
+    options.intervalMs ?? RESIDENT_UNBLOCK_INTERVAL_MS,
+  );
+  void sweep();
+
+  return {
+    sweep,
+    async stop() {
+      if (timer !== undefined) {
+        timers.clearInterval(timer);
+        timer = undefined;
+      }
+      await running;
+      await leases.release(UNBLOCK_SWEEP_SINGLETON, owner);
+    },
+  };
+}

--- a/apps/dev/src/runtime/unblock-pass.ts
+++ b/apps/dev/src/runtime/unblock-pass.ts
@@ -1,0 +1,104 @@
+// runtime/unblock-pass.ts — the Unblock Sweep as a STANDALONE pass (#3014).
+//
+// DIAGNOSIS — which clearer was expected, and why it could not fire. Three
+// paths can drop a stale `blocked:dependency` label once the last `req:*`
+// blocker closes:
+//
+//   1. the event-driven close cascade (`runCloseCascade`), reachable ONLY from a
+//      worker's terminal stage or from `reconcile()` — i.e. only when the AGENT
+//      is the one that closes the blocker;
+//   2. the Unblock Sweep as step 7 of `runBoot`, reachable from an `/afk` boot
+//      and from the castle resident's periodic janitor;
+//   3. the `unblock_sweep` MCP tool, reachable only when somebody calls it.
+//
+// On a repo operated through live sessions only, a HUMAN closes the blocker in
+// the GitHub UI, so (1) never runs — no local code observes that tracker event
+// (webhook deliveries land in the singleton lane, where only `rsp wait` reads
+// them). (2) IS awake there — the resident janitor runs the boot suite every
+// five minutes — but it is the SEVENTH step of a suite that routinely aborts
+// before reaching it: a failing precheck returns after step 1, a red operational
+// probe throws `BootHaltError` at step 1a, and step 6's docs sweep halts on any
+// stranded `.red/` doc, which is the ordinary state of a repo a human edits by
+// hand. So the promote path was reachable in principle and starved in practice,
+// and the drift outlived every session until a human pointed at it.
+//
+// THE FIX starts here: the sweep expressed as a pass that needs `gh` and NOTHING
+// else — no probes, no git, no worktrees, no boot suite — so the resident can
+// schedule it on its own belt (`resident-unblock.ts`) where no unrelated halt
+// can starve it. The IO is injected, so the promote path is provable without a
+// tracker.
+import { executeUnblockSweep, type UnblockCandidate } from "../core/boot-sweep.js";
+import { loadConfig, readHitlTypeLabels } from "../core/config.js";
+import * as ghx from "./gh.js";
+import { afkPaths, resolveRepoContext } from "./wire.js";
+
+/** The whole tracker surface one Unblock pass touches: read the blocked set,
+ * resolve each blocker's closed-state, rotate labels, post the audit comment.
+ * Injected so the pass is testable without gh — and so a reader can see at a
+ * glance that it needs no git, no worktree, and no boot probe. */
+export interface UnblockPassIo {
+  /** Every open issue carrying `blocked:dependency`, with body and labels. */
+  listCandidates(): Promise<UnblockCandidate[]>;
+  /** Whether blocker `issue` is CLOSED. A transient miss answers false, which
+   * leaves the dependent blocked — the conservative direction. */
+  issueClosed(issue: number): Promise<boolean>;
+  /** Rotate labels — REMOVE first, ADD second (BootDeps.gh order). */
+  editLabels(issue: number, remove: string[], add: string[]): Promise<void>;
+  comment(issue: number, body: string): Promise<void>;
+  /** Optional human-facing metadata for the rendered dependency refs. */
+  issueReference?(
+    issue: number,
+  ): Promise<{ number: number; title?: string; url?: string } | undefined>;
+  /** The types this repo's vocabulary declares HUMAN-ONLY, deciding the lane a
+   * promotion routes to (#2966). */
+  hitlTypes(): readonly string[];
+}
+
+/**
+ * Run one Unblock pass over `io`: promote every `blocked:dependency` issue whose
+ * declared `req:*` blockers are all CLOSED, and return the promoted numbers.
+ *
+ * A repo with nothing blocked costs ONE `gh issue list` and no further call —
+ * that cheapness is what makes the pass affordable at every session boot. The
+ * promote decision itself is unchanged: {@link executeUnblockSweep} stays the
+ * single mutation path, so a boot-time sweep, the MCP tool, and this pass all
+ * promote identically.
+ */
+export async function runUnblockPass(io: UnblockPassIo): Promise<number[]> {
+  const candidates = await io.listCandidates();
+  if (candidates.length === 0) return [];
+  return executeUnblockSweep(
+    candidates,
+    async (issue) => ((await io.issueClosed(issue)) ? "CLOSED" : "OPEN"),
+    {
+      editLabels: (issue, remove, add) => io.editLabels(issue, remove, add),
+      comment: (issue, body) => io.comment(issue, body),
+      ...(io.issueReference ? { issueReference: io.issueReference.bind(io) } : {}),
+    },
+    io.hitlTypes(),
+  );
+}
+
+/** Bind {@link UnblockPassIo} to this repo's real `gh` surface and config. */
+export async function createUnblockPassIo(root: string): Promise<UnblockPassIo> {
+  const context = await resolveRepoContext(root);
+  const gh = { cwd: context.root, repo: context.repo };
+  const hitlTypes = readHitlTypeLabels(
+    loadConfig(afkPaths(root).configPath, { warn: () => undefined }),
+  );
+  return {
+    listCandidates: () => ghx.listUnblockCandidates(gh),
+    issueClosed: (issue) => ghx.issueClosed(gh, issue),
+    editLabels: async (issue, remove, add) => {
+      await ghx.editLabels(gh, issue, remove, add);
+    },
+    comment: (issue, body) => ghx.comment(gh, issue, body),
+    issueReference: (issue) => ghx.issueReference(gh, issue),
+    hitlTypes: () => hitlTypes,
+  };
+}
+
+/** Run one Unblock pass against the real repo at `root`. */
+export async function runRepoUnblockPass(root: string): Promise<number[]> {
+  return runUnblockPass(await createUnblockPassIo(root));
+}

--- a/apps/dev/tests/mcp-server-routing.test.ts
+++ b/apps/dev/tests/mcp-server-routing.test.ts
@@ -106,6 +106,33 @@ describe("dev:afk MCP entrypoint routing", () => {
     expect(calls).toEqual(["curator", "merge-driver", "connect"]);
   });
 
+  // #3014: on a repo operated through live sessions only, the resident is the
+  // one thing awake when a human closes a dependent's last `req:*` blocker. The
+  // Unblock belt has to start with it — and before the transport, since its own
+  // first pass is detached and must not wait on the stdio handshake.
+  it("starts the unblock belt in the castle resident before opening stdio", async () => {
+    const calls: string[] = [];
+
+    await expect(
+      main([], {
+        startCurator: async () => {
+          calls.push("curator");
+        },
+        startMergeDriver: async () => {
+          calls.push("merge-driver");
+        },
+        startUnblockSweep: async () => {
+          calls.push("unblock");
+        },
+        connect: async () => {
+          calls.push("connect");
+        },
+      }),
+    ).resolves.toBe(0);
+
+    expect(calls).toEqual(["curator", "merge-driver", "unblock", "connect"]);
+  });
+
   it("awaits resident cleanup after the MCP transport closes", async () => {
     let finishStop!: () => void;
     const resident = {

--- a/apps/dev/tests/resident-unblock.test.ts
+++ b/apps/dev/tests/resident-unblock.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  SingletonLease,
+  SingletonLeaseAcquireResult,
+  SingletonLeaseOwner,
+  SingletonLeaseStore,
+} from "@reddb-io/red-castle/engine";
+import {
+  RESIDENT_UNBLOCK_INTERVAL_MS,
+  UNBLOCK_SWEEP_SINGLETON,
+  startResidentUnblockSweep,
+  type ResidentUnblockTimers,
+} from "../src/resident-unblock.js";
+import { runUnblockPass, type UnblockPassIo } from "../src/runtime/unblock-pass.js";
+
+const LEASE: SingletonLease = {
+  pid: 4242,
+  start_time: "start",
+  acquired_at: "2026-08-01T00:00:00.000Z",
+  renewed_at: "2026-08-01T00:00:00.000Z",
+};
+
+function leaseStore(
+  acquire: SingletonLeaseAcquireResult = { acquired: true, reaped: false, lease: LEASE },
+): SingletonLeaseStore & { released: string[] } {
+  const released: string[] = [];
+  return {
+    released,
+    read: async () => LEASE,
+    acquire: async () => acquire,
+    renew: async () => LEASE,
+    release: async (name: string, _owner: SingletonLeaseOwner) => {
+      released.push(name);
+      return true;
+    },
+  };
+}
+
+/** A hand-driven interval: the belt's tick is invoked explicitly, so no test
+ * waits on wall-clock time to prove the schedule. */
+function manualTimers(): ResidentUnblockTimers & { fire(): void; cleared: number } {
+  const state = {
+    callback: undefined as (() => void) | undefined,
+    cleared: 0,
+    fire() {
+      state.callback?.();
+    },
+    setInterval(callback: () => void) {
+      state.callback = callback;
+      return "timer";
+    },
+    clearInterval() {
+      state.cleared += 1;
+    },
+  };
+  return state as unknown as ResidentUnblockTimers & { fire(): void; cleared: number };
+}
+
+describe("Unblock pass (#3014)", () => {
+  // THE ACCEPTANCE CASE. No daemon, no `/afk` boot, no worker: a human closed
+  // the last `req:*` blocker in the GitHub UI, so nothing ran the close cascade.
+  // The dependent must still lose `blocked:dependency` through the pass the
+  // resident can reach.
+  it("drops blocked:dependency once the last blocker is closed", async () => {
+    const edits: Array<{ issue: number; remove: string[]; add: string[] }> = [];
+    const comments: Array<{ issue: number; body: string }> = [];
+    const io: UnblockPassIo = {
+      listCandidates: async () => [
+        { number: 17, body: "", labels: ["blocked:dependency", "req:5", "type:ticket"] },
+      ],
+      issueClosed: async (issue) => issue === 5,
+      editLabels: async (issue, remove, add) => {
+        edits.push({ issue, remove, add });
+      },
+      comment: async (issue, body) => {
+        comments.push({ issue, body });
+      },
+      hitlTypes: () => [],
+    };
+
+    await expect(runUnblockPass(io)).resolves.toEqual([17]);
+    expect(edits).toHaveLength(1);
+    expect(edits[0]!.issue).toBe(17);
+    expect(edits[0]!.remove).toContain("blocked:dependency");
+    expect(edits[0]!.remove).toContain("req:5");
+    expect(edits[0]!.add).toContain("ready-for-agent");
+    expect(comments[0]!.body).toContain("#5");
+  });
+
+  // The conservative direction is unchanged: one still-open blocker keeps the
+  // dependent blocked, so a session-time belt can never promote work early.
+  it("leaves a dependent blocked while any blocker is still open", async () => {
+    const edits: number[] = [];
+    const io: UnblockPassIo = {
+      listCandidates: async () => [
+        { number: 19, body: "", labels: ["blocked:dependency", "req:5", "req:6"] },
+      ],
+      issueClosed: async (issue) => issue === 5,
+      editLabels: async (issue) => {
+        edits.push(issue);
+      },
+      comment: async () => undefined,
+      hitlTypes: () => [],
+    };
+
+    await expect(runUnblockPass(io)).resolves.toEqual([]);
+    expect(edits).toEqual([]);
+  });
+
+  // What makes the pass affordable at every session boot: a repo with nothing
+  // blocked costs the candidate listing and NO per-blocker round-trip.
+  it("costs one listing and no blocker lookup when nothing is blocked", async () => {
+    const issueClosed = vi.fn(async () => true);
+    const io: UnblockPassIo = {
+      listCandidates: async () => [],
+      issueClosed,
+      editLabels: async () => undefined,
+      comment: async () => undefined,
+      hitlTypes: () => [],
+    };
+
+    await expect(runUnblockPass(io)).resolves.toEqual([]);
+    expect(issueClosed).not.toHaveBeenCalled();
+  });
+});
+
+describe("resident Unblock belt (#3014)", () => {
+  // The session-boot clearer: starting the belt sweeps immediately, which is the
+  // whole point on a repo where the only thing that ever wakes is a live session.
+  it("sweeps once at start without waiting for the interval", async () => {
+    const pass = vi.fn(async () => [17]);
+    const timers = manualTimers();
+
+    const belt = await startResidentUnblockSweep({
+      root: process.cwd(),
+      pass,
+      leases: leaseStore(),
+      owner: { pid: 4242, startTime: "start" },
+      timers,
+    });
+
+    expect(belt).not.toBeNull();
+    await belt!.sweep();
+    expect(pass).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-sweeps on every interval tick", async () => {
+    const pass = vi.fn(async () => []);
+    const timers = manualTimers();
+
+    const belt = await startResidentUnblockSweep({
+      pass,
+      leases: leaseStore(),
+      owner: { pid: 4242, startTime: "start" },
+      timers,
+      intervalMs: RESIDENT_UNBLOCK_INTERVAL_MS,
+    });
+    await belt!.sweep();
+    timers.fire();
+    await belt!.sweep();
+
+    expect(pass).toHaveBeenCalledTimes(2);
+  });
+
+  // The regression this module exists for: a pass that throws must cost ITSELF
+  // and nothing else. Coupling the sweep to a suite whose earlier steps halt is
+  // exactly how the promote path was starved on the reporting repo.
+  it("keeps its schedule after a failing pass", async () => {
+    const notices: string[] = [];
+    let calls = 0;
+    const pass = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("tracker unavailable");
+      return [17];
+    });
+    const timers = manualTimers();
+
+    const belt = await startResidentUnblockSweep({
+      pass,
+      leases: leaseStore(),
+      owner: { pid: 4242, startTime: "start" },
+      timers,
+      notice: (line) => notices.push(line),
+    });
+    await belt!.sweep();
+
+    expect(notices[0]).toContain("tracker unavailable");
+    await expect(belt!.sweep()).resolves.toEqual([17]);
+  });
+
+  // Several stdio hosts for one repo must not each sweep the same tracker.
+  it("stands down when another live host owns the singleton", async () => {
+    const pass = vi.fn(async () => []);
+
+    const belt = await startResidentUnblockSweep({
+      pass,
+      leases: leaseStore({ acquired: false, lease: LEASE }),
+      owner: { pid: 4242, startTime: "start" },
+      timers: manualTimers(),
+    });
+
+    expect(belt).toBeNull();
+    expect(pass).not.toHaveBeenCalled();
+  });
+
+  it("clears its timer and releases the singleton on stop", async () => {
+    const timers = manualTimers();
+    const leases = leaseStore();
+
+    const belt = await startResidentUnblockSweep({
+      pass: async () => [],
+      leases,
+      owner: { pid: 4242, startTime: "start" },
+      timers,
+    });
+    await belt!.stop();
+
+    expect(timers.cleared).toBe(1);
+    expect(leases.released).toEqual([UNBLOCK_SWEEP_SINGLETON]);
+  });
+});

--- a/packaging/pi/dev/skills/engineering/afk/docs/BOOT-SWEEPS.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/BOOT-SWEEPS.md
@@ -72,6 +72,37 @@ has no tracked precedent on `origin/<base>`, boot halts before issue selection o
 fleet slot spawn. The halt message carries the explicit relative file list so a
 maintainer can land or remove the stranded docs deliberately.
 
+## Unblock belt: the sweep also runs OUTSIDE the boot suite (issue #3014)
+
+**A dependent whose last `req:*` blocker closed must lose `blocked:dependency`
+even on a repo where nothing but a live session is ever awake.** Three clearers
+exist, and on such a repo every one of them missed:
+
+1. **the close cascade** (`runCloseCascade`) is event-driven but reachable only
+   from a worker's terminal stage or from `reconcile()` — it fires when the
+   *agent* closes the blocker. A human closing it in the GitHub UI runs no local
+   code; the webhook delivery lands in the singleton lane, where only `rsp wait`
+   reads it;
+2. **the boot-time Unblock Sweep** *is* awake — the castle resident's janitor
+   runs the whole suite every five minutes — but it is **step 7** of a suite that
+   routinely aborts before reaching it: a failing precheck returns after step 1,
+   a red operational probe throws `BootHaltError` at step 1a, and the *Docs
+   Sweep* halts on any stranded `.red/` doc, which is the ordinary state of a
+   repo a human edits by hand;
+3. **the `unblock_sweep` MCP tool** promotes correctly, but only when somebody
+   thinks to call it.
+
+So the promote path was reachable in principle and starved in practice. The
+resident therefore runs the sweep on its **own belt**, independent of the boot
+suite: one pass detached at resident start — the session-boot clearer — and one
+per interval afterwards. The belt needs `gh` and nothing else (no probes, no
+git, no worktrees), it costs a single `gh issue list` when nothing is blocked,
+and a repo-scoped singleton keeps several stdio hosts from each sweeping the
+same tracker. A failing pass costs itself and nothing else; the next tick still
+runs. Promotion itself is unchanged — the belt, the boot suite's step 7, and the
+MCP tool all promote through the one shared core, so the lane rules (`#2966`)
+and the audit comment are identical whichever trigger fired.
+
 ## Fleet mode: the supervisor owns the boot (issue #623)
 
 The sweeps above (*Orphan Cleanup*, *Attempt Cap*, live branch cleanup, *Docs Sweep*, the *Unblock Sweep*, and the *Straggler Check*) all read and mutate **shared** `.red/tmp` / branch / `gh` state. When several workers boot at once they would race over that state — the observed failure mode was a fleet collapsing to a single live worker because peers fast-died in their boot sweeps.

--- a/plugins/dev/skills/engineering/afk/docs/BOOT-SWEEPS.md
+++ b/plugins/dev/skills/engineering/afk/docs/BOOT-SWEEPS.md
@@ -72,6 +72,37 @@ has no tracked precedent on `origin/<base>`, boot halts before issue selection o
 fleet slot spawn. The halt message carries the explicit relative file list so a
 maintainer can land or remove the stranded docs deliberately.
 
+## Unblock belt: the sweep also runs OUTSIDE the boot suite (issue #3014)
+
+**A dependent whose last `req:*` blocker closed must lose `blocked:dependency`
+even on a repo where nothing but a live session is ever awake.** Three clearers
+exist, and on such a repo every one of them missed:
+
+1. **the close cascade** (`runCloseCascade`) is event-driven but reachable only
+   from a worker's terminal stage or from `reconcile()` — it fires when the
+   *agent* closes the blocker. A human closing it in the GitHub UI runs no local
+   code; the webhook delivery lands in the singleton lane, where only `rsp wait`
+   reads it;
+2. **the boot-time Unblock Sweep** *is* awake — the castle resident's janitor
+   runs the whole suite every five minutes — but it is **step 7** of a suite that
+   routinely aborts before reaching it: a failing precheck returns after step 1,
+   a red operational probe throws `BootHaltError` at step 1a, and the *Docs
+   Sweep* halts on any stranded `.red/` doc, which is the ordinary state of a
+   repo a human edits by hand;
+3. **the `unblock_sweep` MCP tool** promotes correctly, but only when somebody
+   thinks to call it.
+
+So the promote path was reachable in principle and starved in practice. The
+resident therefore runs the sweep on its **own belt**, independent of the boot
+suite: one pass detached at resident start — the session-boot clearer — and one
+per interval afterwards. The belt needs `gh` and nothing else (no probes, no
+git, no worktrees), it costs a single `gh issue list` when nothing is blocked,
+and a repo-scoped singleton keeps several stdio hosts from each sweeping the
+same tracker. A failing pass costs itself and nothing else; the next tick still
+runs. Promotion itself is unchanged — the belt, the boot suite's step 7, and the
+MCP tool all promote through the one shared core, so the lane rules (`#2966`)
+and the audit comment are identical whichever trigger fired.
+
 ## Fleet mode: the supervisor owns the boot (issue #623)
 
 The sweeps above (*Orphan Cleanup*, *Attempt Cap*, live branch cleanup, *Docs Sweep*, the *Unblock Sweep*, and the *Straggler Check*) all read and mutate **shared** `.red/tmp` / branch / `gh` state. When several workers boot at once they would race over that state — the observed failure mode was a fleet collapsing to a single live worker because peers fast-died in their boot sweeps.


### PR DESCRIPTION
Automated AFK landing for #3014. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3014

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788200388&installation_model_id=20659&pr_number=3015&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3015&signature=75a6d8b5acc35a8af2f2202ad63796502e0c881a8f8785a0318dc0f96390af54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->