### PR TITLE
chore: #3012 /go: Give apps/herdr-plugin-[REDACTED_SECRET] and apps/vscode-extension-[REDACTED_SECRET] a

### DIFF
--- a/apps/herdr-plugin-red-skills/README.md
+++ b/apps/herdr-plugin-red-skills/README.md
@@ -96,6 +96,7 @@ exactly what was there.
 | Action | What it does |
 | --- | --- |
 | `RedSkills: toggle dashboard` | the live pane, split beside the current one |
+| `RedSkills: toggle statusline board` | the statusline as a table: header plus one row per Worker |
 | `RedSkills: dashboard in a tab` | the same pane, in a tab of its own |
 | `RedSkills: toggle worker log` | tail the newest Worker's log |
 | `RedSkills: toggle host event lane` | birth, death and budget-kill, as they land |
@@ -119,7 +120,7 @@ Bind whichever you reach for; the rest live in herdr's action menu.
 | `?` | help |
 
 In a log view: `q` back, `f` follow/pause, `j`/`k` scroll, `g`/`G` top/end,
-`r` refresh.
+`r` refresh. In the board: `q` close, `r` re-read, `g` local/global.
 
 ### From a shell
 
@@ -130,6 +131,8 @@ node bin/red-skills-herdr.mjs doctor          # why this plugin sees what it see
 node bin/red-skills-herdr.mjs status          # the daemon's own status line
 node bin/red-skills-herdr.mjs status --json   # the line, the payload, and the socket
 node bin/red-skills-herdr.mjs dashboard       # the pane, in this terminal
+node bin/red-skills-herdr.mjs board           # the statusline as a table, live
+node bin/red-skills-herdr.mjs board --once    # the same table, printed and gone
 node bin/red-skills-herdr.mjs logs --worker w-2f91a
 node bin/red-skills-herdr.mjs logs --events
 node bin/red-skills-herdr.mjs watch --once    # one poll, printing what it would notify
@@ -192,6 +195,7 @@ Four ops, and no others:
 | `host-state` | registrations, scope, upgrade state |
 | `statusline-payload` | Workers, vitals, budgets, projects, repository activity |
 | `statusline-string` | the notification and `status` line, rendered by the daemon |
+| `statusline-dashboard` | the `board` pane: header and Worker rows, rendered by the daemon |
 
 Some properties this plugin holds itself to, because the daemon holds itself to
 them:
@@ -208,9 +212,12 @@ them:
 - **Staleness is rendered, never re-derived.** The payload dates itself and this
   pane prints the age it was handed, so it cannot disagree with the statusline
   beside it about the same instant.
-- **The status line is the daemon's.** ADR 0130 rule 10 keeps the string a pure
-  function of the payload precisely so no surface reimplements it; this plugin
-  asks for it rather than drawing its own.
+- **The status line is the daemon's, and so is the board.** ADR 0130 rule 10
+  keeps both a pure function of the payload precisely so no surface reimplements
+  them; this plugin asks for them rather than drawing its own. THE DAEMON
+  AGGREGATES AND RENDERS; SURFACES PRINT — a herdr pane and an editor panel each
+  doing their own Worker math would be two dashboards lying in two different ways
+  about the same instant.
 - **The event lane reader is tolerant.** The lane is written by a daemon version
   this plugin does not ship with, so it sniffs JSON, decodes TOONL segments, and
   keeps a line it cannot decode as raw text rather than dropping it.
@@ -258,7 +265,7 @@ width.
 bin/red-skills-herdr.mjs  the single entrypoint; --help and --version answer offline
 src/redskilled/           the daemon: socket derivation, wire, client, event lane, log tail
 src/ui/                   ansi widths, formatters, the screen loop, the three views
-src/commands/             dashboard, logs, status, watch, pane, doctor
+src/commands/             board, dashboard, logs, status, watch, pane, doctor
 src/watch/signals.mjs     what changed between two reads, as things worth interrupting for
 herdr-plugin.toml         panes, actions, the startup hook, and their Windows twins
 .upstream                 the repository this directory was absorbed from, and at which commit

--- a/apps/herdr-plugin-red-skills/bin/red-skills-herdr.mjs
+++ b/apps/herdr-plugin-red-skills/bin/red-skills-herdr.mjs
@@ -35,6 +35,7 @@ A herdr plugin that reads the redskilled host daemon: Workers, logs, open pull
 requests, and the notifications behind them. It reads and never writes.
 
 Commands:
+  board                the statusline as a table: header plus one row per Worker
   dashboard            the live pane: host, Workers, projects, pull requests
   logs                 tail one Worker's log, or the host event lane
   status               print the daemon's own status line
@@ -54,7 +55,8 @@ Options:
   --verbose            show each Worker's last published line
   --json               machine-readable output, where a command has one
   --notify             also raise the answer as a herdr notification
-  --once               one poll, then exit (watch)
+  --once               one poll, then exit (watch, board)
+  --max-width <n>      the width budget the daemon renders to (board)
   --detach             start the watcher as a detached child, then return
   --placement <p>      overlay | split | tab | zoomed (pane)
   --direction <d>      right | down (pane)
@@ -133,6 +135,10 @@ async function main(argv) {
   const config = await loadConfig();
 
   switch (command ?? "dashboard") {
+    case "board": {
+      const { runBoard } = await import("../src/commands/board.mjs");
+      return await runBoard({ config, flags });
+    }
     case "dashboard": {
       const { runDashboard } = await import("../src/commands/dashboard.mjs");
       await runDashboard({ config, flags });

--- a/apps/herdr-plugin-red-skills/herdr-plugin.toml
+++ b/apps/herdr-plugin-red-skills/herdr-plugin.toml
@@ -7,10 +7,10 @@
 # The plugin is a read client of `redskilled`, the host-scoped execution daemon
 # of reddb-io/red-skills (ADR 0130): exactly one singleton per machine, behind a
 # unix socket, owning Worker processes across every project on that machine. It
-# sends `ping`, `host-state`, `statusline-payload` and `statusline-string`, and
-# it sends nothing that changes the machine — ADR 0130 rule 9 makes reach
-# asymmetric (read the host, write the project), and a monitor belongs entirely
-# on the reading half.
+# sends `ping`, `host-state`, `statusline-payload`, `statusline-string` and
+# `statusline-dashboard`, and it sends nothing that changes the machine — ADR
+# 0130 rule 9 makes reach asymmetric (read the host, write the project), and a
+# monitor belongs entirely on the reading half.
 #
 # Zero dependencies and no bundling: every command is plain Node ESM run
 # straight from this checkout, so an install is a clone and nothing else.
@@ -77,6 +77,23 @@ platforms = ["windows"]
 # -NonInteractive breaks its input.
 command = ['powershell', '-NoProfile', '-Command', '& node "$env:HERDR_PLUGIN_ROOT\bin\red-skills-herdr.mjs" dashboard']
 
+# The statusline with a pane's height: the daemon's own header line and one row
+# per Worker, printed exactly as it renders them. Nothing here recomputes a cell.
+[[panes]]
+id = "board"
+title = "RedSkills board"
+placement = "split"
+platforms = ["linux", "macos"]
+command = ['sh', '-c', 'exec node "$HERDR_PLUGIN_ROOT/bin/red-skills-herdr.mjs" board']
+
+[[panes]]
+id = "board-windows"
+title = "RedSkills board"
+placement = "split"
+platforms = ["windows"]
+# Deliberately without -NonInteractive: this hosts a keyboard-driven TUI.
+command = ['powershell', '-NoProfile', '-Command', '& node "$env:HERDR_PLUGIN_ROOT\bin\red-skills-herdr.mjs" board']
+
 [[panes]]
 id = "logs"
 title = "Worker log"
@@ -134,6 +151,20 @@ title = "RedSkills: dashboard in a tab"
 contexts = ["global", "workspace", "tab", "pane"]
 platforms = ["windows"]
 command = ['powershell', '-NoProfile', '-NonInteractive', '-Command', '& node "$env:HERDR_PLUGIN_ROOT\bin\red-skills-herdr.mjs" pane open dashboard --placement tab']
+
+[[actions]]
+id = "toggle-board"
+title = "RedSkills: toggle statusline board"
+contexts = ["global", "workspace", "tab", "pane"]
+platforms = ["linux", "macos"]
+command = ['sh', '-c', 'exec node "$HERDR_PLUGIN_ROOT/bin/red-skills-herdr.mjs" pane toggle board']
+
+[[actions]]
+id = "toggle-board-windows"
+title = "RedSkills: toggle statusline board"
+contexts = ["global", "workspace", "tab", "pane"]
+platforms = ["windows"]
+command = ['powershell', '-NoProfile', '-NonInteractive', '-Command', '& node "$env:HERDR_PLUGIN_ROOT\bin\red-skills-herdr.mjs" pane toggle board']
 
 [[actions]]
 id = "toggle-logs"

--- a/apps/herdr-plugin-red-skills/scripts/fake-daemon.mjs
+++ b/apps/herdr-plugin-red-skills/scripts/fake-daemon.mjs
@@ -287,6 +287,55 @@ function value(op) {
         generated_at: current.generated_at,
       };
     }
+    case "statusline-dashboard": {
+      const current = payload();
+      const header =
+        `» ${"reddb-io/red-skills"} v0.4.1-fake · ` +
+        `wrk=${current.host.worker_count}/${current.host.worker_count} · ` +
+        `mem=${(current.host.observed_rss_bytes / 1024 ** 3).toFixed(1)}G · ` +
+        `prs=${world.pullRequests["reddb-io/red-skills"]}`;
+      const rows = current.workers.map((worker) => ({
+        worker_id: worker.worker_id,
+        project_label: worker.project_label,
+        mine: false,
+        cells: {},
+        line: `${worker.worker_id}  run=fake  org=afk  hb=?`,
+      }));
+      return {
+        version: 1,
+        generated_at: current.generated_at,
+        mode: "global",
+        project: null,
+        columns: ["wid", "run", "org", "iss", "bar", "phase", "elapsed", "hb", "loc", "tks", "tls", "rsn", "txt"],
+        header: {
+          repo: "reddb-io/red-skills",
+          project: null,
+          project_match: "unresolved",
+          version: "0.4.1-fake",
+          model: null,
+          windows: {
+            memory_used_fraction: null,
+            memory_used_bytes: current.host.observed_rss_bytes,
+            memory_ceiling_bytes: current.host.ceiling.memory_bytes,
+            worker_count: current.host.worker_count,
+            worker_ceiling: current.host.ceiling.worker_count,
+          },
+          counts: {
+            open_pull_requests: world.pullRequests["reddb-io/red-skills"],
+            recently_closed: null,
+            open_issues: null,
+            stale: false,
+          },
+          stale: false,
+          age_ms: 0,
+          line: header,
+        },
+        rows,
+        lines: [header, ...rows.map((row) => row.line)],
+        hidden_row_count: 0,
+        stale: false,
+      };
+    }
     default:
       return null;
   }

--- a/apps/herdr-plugin-red-skills/src/commands/board.mjs
+++ b/apps/herdr-plugin-red-skills/src/commands/board.mjs
@@ -1,0 +1,121 @@
+/**
+ * board — the statusline as a pane, and as a one-shot print.
+ *
+ * The whole document comes from the daemon's `statusline-dashboard` op, never
+ * from this plugin's own reading of the payload. ADR 0130 rule 10 keeps that
+ * answer a pure function of the payload precisely so no surface reimplements it,
+ * and a pane that drew its own Worker rows would be the drift the op exists to
+ * prevent — the same reason `status` prints `statusline-string` rather than
+ * rendering a line of its own.
+ *
+ * **What travels over the socket is taste already decided here.** Mode, width and
+ * the row budget are resolved from config and flags before the read, because the
+ * daemon must never learn what a config file is.
+ *
+ * `--once` prints the frame and returns, which is what an action and a script
+ * want; without it the command holds a pane open and re-reads on the interval.
+ */
+import { createRedskilledClient } from "../redskilled/client.mjs";
+import { resolveRedskilledPaths } from "../redskilled/paths.mjs";
+import { resolveProjectLabel } from "../redskilled/project-identity.mjs";
+import { notify } from "../herdr.mjs";
+import { renderBoard } from "../ui/board.mjs";
+import { runScreen } from "../ui/screen.mjs";
+
+/** One read, as a total answer: a failure is rendered, never raised. */
+export async function readBoard(client, { sessionProject, mode, maxWidth, maxRows }) {
+  try {
+    const dashboard = await client.statuslineDashboard(sessionProject, {
+      mode,
+      ...(sessionProject ? { project: sessionProject } : {}),
+      ...(maxWidth ? { max_width: maxWidth } : {}),
+      ...(maxRows ? { max_rows: maxRows } : {}),
+    });
+    return { dashboard, error: null };
+  } catch (error) {
+    return { dashboard: null, error: error?.message ?? String(error) };
+  }
+}
+
+export async function runBoard({ config, flags = {} }) {
+  const socket = resolveRedskilledPaths({ socketPath: flags.socket ?? config.socketPath });
+  const client = createRedskilledClient({ socketPath: socket.socketPath, timeoutMs: config.timeoutMs });
+  const localProject = await resolveProjectLabel(process.cwd()).catch(() => null);
+
+  const state = { mode: flags.mode ?? config.mode, message: null };
+  let read = { dashboard: null, error: null };
+
+  function sessionProject() {
+    return state.mode === "local" ? localProject ?? undefined : undefined;
+  }
+
+  /**
+   * Re-read the daemon, telling it the pane's actual size.
+   *
+   * The budgets are stated on the REQUEST rather than applied to the answer: the
+   * daemon degrades a crowded machine to an honest "N more Worker(s)" line, and a
+   * pane that trimmed rows itself would drop them in silence instead.
+   */
+  async function refresh(size = { columns: process.stdout.columns || 80, rows: process.stdout.rows || 24 }) {
+    read = await readBoard(client, {
+      sessionProject: sessionProject(),
+      mode: state.mode,
+      maxWidth: flags.maxWidth ?? Math.max(40, size.columns - 2),
+      maxRows: Math.max(1, size.rows - 6),
+    });
+  }
+
+  if (flags.once || flags.json || flags.notify) {
+    await refresh({ columns: flags.maxWidth ?? 200, rows: 32 });
+
+    if (flags.json) {
+      // Behind an explicit flag, which is where the TOON mandate leaves JSON: the
+      // DEFAULT render is the daemon's own lines, and this is the escape hatch a
+      // script asked for by name.
+      process.stdout.write(`${JSON.stringify({ socket: socket.socketPath, ...read }, null, 2)}\n`);
+      return read.error ? 1 : 0;
+    }
+
+    const lines = read.dashboard?.lines ?? [read.error ?? "redskilled: no host answered"];
+    if (flags.notify) {
+      await notify("redskilled", {
+        body: read.dashboard?.header?.line ?? lines[0],
+        position: config.notifications.position,
+        sound: config.notifications.sound,
+      });
+    }
+    process.stdout.write(`${lines.join("\n")}\n`);
+    return read.error ? 1 : 0;
+  }
+
+  await runScreen({
+    title: "red-skills board",
+    refreshMs: flags.refreshMs ?? config.refreshMs,
+    onTick: refresh,
+    render: (size) =>
+      renderBoard({ dashboard: read.dashboard, state, size, socketPath: socket.socketPath, error: read.error }),
+    onKey: async (key) => {
+      switch (key.name) {
+        case "q":
+        case "escape":
+        case "ctrl-c":
+          return "quit";
+        case "r":
+          state.message = null;
+          await refresh();
+          return;
+        case "g":
+          state.mode = state.mode === "global" ? "local" : "global";
+          state.message =
+            state.mode === "local" && localProject == null
+              ? "this directory resolves to no project label, so local mode has nothing to scope to"
+              : null;
+          await refresh();
+          return;
+        default:
+          return;
+      }
+    },
+  });
+  return 0;
+}

--- a/apps/herdr-plugin-red-skills/src/redskilled/client.mjs
+++ b/apps/herdr-plugin-red-skills/src/redskilled/client.mjs
@@ -2,7 +2,8 @@
  * client — one TOON-framed request over the daemon's unix socket.
  *
  * This plugin is a READ client and nothing else. It sends `ping`, `host-state`,
- * `statusline-payload` and `statusline-string`, and it never sends `worker-start`,
+ * `statusline-payload`, `statusline-string` and `statusline-dashboard`, and it
+ * never sends `worker-start`,
  * `worker-command`, `project-register` or `shutdown`. ADR 0130 rule 9 makes reach
  * asymmetric — read the host, write the project — and a dashboard has no business
  * on the writing half: a viewer that could stop another project's Worker would be
@@ -125,6 +126,20 @@ export function createRedskilledClient({ socketPath, timeoutMs = 2_000 }) {
       call("statusline-string", {
         ...(sessionProject ? { session_project: sessionProject } : {}),
         ...(render ? { render } : {}),
+      }),
+    /**
+     * The dashboard: the same read again, already laid out as a table.
+     *
+     * This plugin PRINTS what comes back and computes no cell of it. The daemon
+     * is the only process holding the Worker set across projects, so a pane that
+     * did its own Worker math would be the second authority ADR 0130 rule 10
+     * keeps the statusline pair pure to avoid — and two dashboards would lie in
+     * two different ways about the same instant.
+     */
+    statuslineDashboard: (sessionProject, dashboard) =>
+      call("statusline-dashboard", {
+        ...(sessionProject ? { session_project: sessionProject } : {}),
+        ...(dashboard ? { dashboard } : {}),
       }),
   };
 }

--- a/apps/herdr-plugin-red-skills/src/ui/board.mjs
+++ b/apps/herdr-plugin-red-skills/src/ui/board.mjs
@@ -1,0 +1,117 @@
+/**
+ * board — the statusline, given a pane's height. This file PRINTS.
+ *
+ * **Every cell on this screen was computed by the daemon.** The header, the
+ * Worker rows, the pipeline bars and the counts all arrive finished from
+ * `statusline-dashboard`, and nothing here recomputes one. That is the whole
+ * rule the statusline pair was built on (ADR 0130 rule 10): a herdr pane and an
+ * editor panel each doing their own Worker math would be two dashboards lying in
+ * two different ways about the same instant.
+ *
+ * **The only judgement here is where a line goes.** Colour, the scroll window and
+ * the key map belong to a terminal and to nothing else, so they live here; the
+ * text does not, so it does not. A reader looking for why a number reads the way
+ * it does will not find the answer in this file, which is correct — the answer is
+ * in the daemon.
+ *
+ * PURE: every input is passed in, so a frame can be asserted without a daemon.
+ */
+import { displayWidth, style, truncate } from "./ansi.mjs";
+
+/** How the daemon's `key=value` cells are tinted: light key, default value. */
+function paintCell(cell) {
+  const equals = cell.indexOf("=");
+  if (equals <= 0) return cell;
+  return `${style.gray(cell.slice(0, equals + 1))}${cell.slice(equals + 1)}`;
+}
+
+/**
+ * One row line, tinted without being re-laid-out. PURE.
+ *
+ * The daemon's alignment survives because the tint is applied per WHITESPACE-
+ * SEPARATED RUN and adds no visible character: a pane that re-padded the row
+ * would be deciding a column width the daemon already decided, and the two would
+ * drift the first time either changed.
+ */
+export function paintRow(line) {
+  return line
+    .split(/(\s+)/)
+    .map((part) => (/^\s+$/.test(part) ? part : paintCell(part)))
+    .join("");
+}
+
+function rule(label, columns) {
+  const text = label ? ` ${label} ` : "";
+  const width = Math.max(0, columns - displayWidth(text) - 1);
+  return style.gray(`─${text}${"─".repeat(width)}`);
+}
+
+/** The key map, which is the only documentation a pane can carry. PURE. */
+export function renderBoardFooter({ columns, state }) {
+  const keys = [
+    ["q", "quit"],
+    ["r", "refresh"],
+    ["g", state.mode === "global" ? "local" : "global"],
+  ];
+  const map = keys.map(([key, label]) => `${style.bold(key)} ${style.gray(label)}`).join("  ");
+  return [rule(null, columns), truncate(` ${map}`, columns)];
+}
+
+/** What to draw when nothing answered — an absence, said plainly. PURE. */
+export function renderBoardAbsence({ columns, error, socketPath }) {
+  return [
+    rule("NO HOST ANSWERED", columns),
+    truncate(` ${style.gray("socket")} ${style.white(socketPath ?? "?")}`, columns),
+    "",
+    truncate(` ${style.gray(error ?? "the daemon did not answer")}`, columns),
+    "",
+    truncate(
+      ` ${style.gray("An empty host must mean an idle machine, never a failed lookup — so this pane")}`,
+      columns,
+    ),
+    truncate(` ${style.gray("refuses to draw a table it did not read.")}`, columns),
+    "",
+    truncate(
+      ` ${style.gray("Bring one up with")} ${style.white("redskilled provision")}${style.gray(".")}`,
+      columns,
+    ),
+  ];
+}
+
+/**
+ * One frame of the board. PURE.
+ *
+ * The daemon was already told the width and the row budget, so what arrives
+ * fits; the clamp here is a belt against a pane resized between the read and the
+ * paint, never a second layout.
+ */
+export function renderBoard({ dashboard, state, size, socketPath, error }) {
+  const { columns } = size;
+  if (!dashboard) {
+    return [
+      ` ${style.bold(style.brightRed("redskilled"))} ${style.gray("·")} ${style.brightRed("no host answered")}`,
+      ...renderBoardAbsence({ columns, error, socketPath }),
+      ...renderBoardFooter({ columns, state }),
+    ];
+  }
+
+  const [header, ...rows] = dashboard.lines;
+  const badge = dashboard.stale ? style.brightYellow("● stale") : style.brightGreen("● live");
+  const lines = [
+    truncate(` ${style.bold(style.brightRed(header ?? ""))}`, columns),
+    truncate(` ${badge} ${style.gray(dashboard.generated_at)}`, columns),
+    rule("WORKERS", columns),
+  ];
+
+  if (rows.length === 0) {
+    lines.push(
+      ` ${style.gray("no Workers here — the machine is idle, and this is the daemon saying so")}`,
+    );
+  } else {
+    for (const row of rows) lines.push(truncate(` ${paintRow(row)}`, columns));
+  }
+
+  if (state.message) lines.push(truncate(` ${style.brightCyan(state.message)}`, columns));
+  lines.push(...renderBoardFooter({ columns, state }));
+  return lines;
+}

--- a/apps/herdr-plugin-red-skills/tests/board.test.mjs
+++ b/apps/herdr-plugin-red-skills/tests/board.test.mjs
@@ -1,0 +1,184 @@
+/**
+ * The board is the one view whose correctness is NOT this plugin's to prove.
+ *
+ * Every cell arrives finished from `statusline-dashboard`, so what these assert
+ * is the only thing a surface can get wrong: that it prints what it was handed,
+ * that it re-derives nothing, that it asks the daemon for the size it has, and
+ * that an unreachable host draws an absence rather than a table of zeros.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { readBoard } from "../src/commands/board.mjs";
+import { createRedskilledClient } from "../src/redskilled/client.mjs";
+import { decodeFrame, encodeFrame, takeFrame } from "../src/redskilled/wire.mjs";
+import { stripAnsi } from "../src/ui/ansi.mjs";
+import { paintRow, renderBoard } from "../src/ui/board.mjs";
+import { dashboard } from "./fixtures.mjs";
+
+const SIZE = { columns: 160, rows: 30 };
+
+function state(overrides = {}) {
+  return { mode: "global", message: null, ...overrides };
+}
+
+function text(lines) {
+  return lines.map(stripAnsi).join("\n");
+}
+
+async function withDaemon(handler, run) {
+  const dir = await mkdtemp(join(tmpdir(), "red-skills-board-"));
+  const socketPath = join(dir, "redskilled.sock");
+  const seen = [];
+  const server = createServer((socket) => {
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      for (let framed = takeFrame(buffer); framed; framed = takeFrame(buffer)) {
+        buffer = framed.rest;
+        const request = decodeFrame(framed.frame);
+        seen.push(request);
+        const response = handler(request);
+        if (response !== undefined) socket.write(encodeFrame(response));
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  try {
+    await run({ socketPath, seen });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("the frame prints the daemon's own lines, header first", () => {
+  const board = dashboard();
+  const rendered = text(renderBoard({ dashboard: board, state: state(), size: SIZE }));
+  for (const line of board.lines) {
+    assert.ok(rendered.includes(line), `the board dropped a line the daemon rendered: ${JSON.stringify(line)}`);
+  }
+  assert.ok(rendered.indexOf(board.header.line) < rendered.indexOf(board.rows[0].line));
+});
+
+test("every statusline field reaches the pane", () => {
+  const rendered = text(renderBoard({ dashboard: dashboard(), state: state(), size: SIZE }));
+  for (const cell of [
+    "run=claude opus high",
+    "org=afk",
+    "iss=3012",
+    "██▶░░░",
+    "coding·impl",
+    "1h0m",
+    "hb=3s",
+    "loc=+142 -36",
+    "tks=45k",
+    "tls=12",
+    "rsn=4",
+    "txt=9",
+  ]) {
+    assert.ok(rendered.includes(cell), `the pane lost the ${JSON.stringify(cell)} cell`);
+  }
+});
+
+test("the header line carries the repo, the version, the model and the counts", () => {
+  const rendered = text(renderBoard({ dashboard: dashboard(), state: state(), size: SIZE }));
+  assert.match(rendered, /» reddb-io\/red-skills v0\.4\.1/);
+  assert.match(rendered, /claude·opus·high/);
+  assert.match(rendered, /prs=3/);
+  assert.match(rendered, /cpr=7/);
+  assert.match(rendered, /iss=24/);
+});
+
+test("tinting a row changes no visible character, so the daemon's alignment survives", () => {
+  const line = dashboard().rows[0].line;
+  assert.equal(stripAnsi(paintRow(line)), line);
+});
+
+test("no frame is ever wider than the pane", () => {
+  const lines = renderBoard({ dashboard: dashboard(), state: state(), size: { columns: 64, rows: 20 } });
+  for (const line of lines) {
+    assert.ok(stripAnsi(line).length <= 64, `line overflows the pane: ${JSON.stringify(stripAnsi(line))}`);
+  }
+});
+
+test("a state change in the daemon reaches the pane without local re-derivation", () => {
+  const before = dashboard();
+  const after = dashboard({
+    lines: ["» reddb-io/red-skills v0.4.1 · wrk=0/0", "…"],
+    rows: [],
+    stale: true,
+  });
+  const first = text(renderBoard({ dashboard: before, state: state(), size: SIZE }));
+  const second = text(renderBoard({ dashboard: after, state: state(), size: SIZE }));
+  assert.match(first, /● live/);
+  assert.match(first, /iss=3012/);
+  assert.match(second, /● stale/);
+  assert.ok(!second.includes("iss=3012"), "the pane kept a row the daemon no longer renders");
+});
+
+test("an unreachable daemon draws an absence, never a table of zeros", () => {
+  const rendered = text(
+    renderBoard({
+      dashboard: null,
+      state: state(),
+      size: SIZE,
+      socketPath: "/run/redskilled.sock",
+      error: "redskilled is not reachable",
+    }),
+  );
+  assert.match(rendered, /no host answered/);
+  assert.match(rendered, /redskilled provision/);
+  assert.ok(!/wrk=/.test(rendered), "an absence must not render counts nobody read");
+});
+
+test("the read asks statusline-dashboard, states the size, and never writes", async () => {
+  await withDaemon(
+    (request) =>
+      request.op === "statusline-dashboard"
+        ? { id: request.id, ok: true, value: dashboard() }
+        : { id: request.id, ok: false, error: `unknown op ${request.op}` },
+    async ({ socketPath, seen }) => {
+      const client = createRedskilledClient({ socketPath });
+      const read = await readBoard(client, {
+        sessionProject: "reddb-io/red-skills",
+        mode: "local",
+        maxWidth: 118,
+        maxRows: 9,
+      });
+      assert.equal(read.error, null);
+      assert.equal(read.dashboard.version, 1);
+
+      const [request] = seen;
+      assert.equal(request.op, "statusline-dashboard");
+      assert.equal(request.session_project, "reddb-io/red-skills");
+      assert.deepEqual(request.dashboard, {
+        mode: "local",
+        project: "reddb-io/red-skills",
+        max_width: 118,
+        max_rows: 9,
+      });
+      assert.deepEqual(
+        seen.filter((entry) => entry.op !== "statusline-dashboard"),
+        [],
+        "reach is asymmetric: the board is entirely on the reading half",
+      );
+    },
+  );
+});
+
+test("a daemon that refuses the op yields an absence rather than a throw", async () => {
+  await withDaemon(
+    (request) => ({ id: request.id, ok: false, error: "this daemon predates the dashboard" }),
+    async ({ socketPath }) => {
+      const client = createRedskilledClient({ socketPath });
+      const read = await readBoard(client, { mode: "global" });
+      assert.equal(read.dashboard, null);
+      assert.match(read.error, /predates the dashboard/);
+    },
+  );
+});

--- a/apps/herdr-plugin-red-skills/tests/fixtures.mjs
+++ b/apps/herdr-plugin-red-skills/tests/fixtures.mjs
@@ -200,3 +200,89 @@ export function snapshot(overrides = {}) {
     ...overrides,
   };
 }
+
+/**
+ * A dashboard shaped exactly as `statusline-dashboard` sends it.
+ *
+ * Written against `apps/redskilled/src/dashboard-render.ts`. Every cell here is
+ * already finished — which is the point: a surface test that had to compute a
+ * cell to assert it would be testing the very re-derivation this document
+ * exists to remove.
+ */
+export function dashboard(overrides = {}) {
+  const header = {
+    repo: "reddb-io/red-skills",
+    project: "reddb-io/red-skills",
+    project_match: "matched",
+    version: "0.4.1",
+    model: "claude·opus·high",
+    windows: {
+      memory_used_fraction: 0.375,
+      memory_used_bytes: 3 * 1024 ** 3,
+      memory_ceiling_bytes: 8 * 1024 ** 3,
+      worker_count: 2,
+      worker_ceiling: 6,
+    },
+    counts: { open_pull_requests: 3, recently_closed: 7, open_issues: 24, stale: false },
+    stale: false,
+    age_ms: 5_000,
+    line: "» reddb-io/red-skills v0.4.1 · claude·opus·high · wrk=2/2 · slots=2/6 · mem=3G/8G 38% · prs=3 · cpr=7 · iss=24",
+  };
+  const rows = [
+    {
+      worker_id: "w-busy",
+      project_label: "reddb-io/red-skills",
+      mine: true,
+      cells: {
+        wid: "w-busy",
+        run: "run=claude opus high",
+        org: "org=afk",
+        iss: "iss=3012",
+        bar: "██▶░░░",
+        phase: "coding·impl",
+        elapsed: "1h0m",
+        hb: "hb=3s",
+        loc: "loc=+142 -36",
+        tks: "tks=45k",
+        tls: "tls=12",
+        rsn: "rsn=4",
+        txt: "txt=9",
+      },
+      line: "w-busy  run=claude opus high  org=afk  iss=3012  ██▶░░░  coding·impl  1h0m  hb=3s  loc=+142 -36  tks=45k  tls=12  rsn=4  txt=9",
+    },
+    {
+      worker_id: "w-idle",
+      project_label: "acme/widgets",
+      mine: false,
+      cells: {
+        wid: "w-idle",
+        run: "",
+        org: "",
+        iss: "",
+        bar: "",
+        phase: "",
+        elapsed: "12m0s",
+        hb: "hb=?",
+        loc: "",
+        tks: "",
+        tls: "",
+        rsn: "",
+        txt: "",
+      },
+      line: "w-idle                                        12m0s  hb=?",
+    },
+  ];
+  return {
+    version: 1,
+    generated_at: "2026-07-31T12:00:00.000Z",
+    mode: "global",
+    project: "reddb-io/red-skills",
+    columns: ["wid", "run", "org", "iss", "bar", "phase", "elapsed", "hb", "loc", "tks", "tls", "rsn", "txt"],
+    header,
+    rows,
+    lines: [header.line, ...rows.map((row) => row.line)],
+    hidden_row_count: 0,
+    stale: false,
+    ...overrides,
+  };
+}

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -7,6 +7,7 @@
     "./cli": "./src/cli.ts",
     "./client": "./src/client.ts",
     "./daemon": "./src/daemon.ts",
+    "./dashboard-render": "./src/dashboard-render.ts",
     "./daemon-stop": "./src/daemon-stop.ts",
     "./demand-loop": "./src/demand-loop.ts",
     "./demand-producer": "./src/demand-producer.ts",
@@ -21,6 +22,8 @@
     "./reclaim": "./src/reclaim.ts",
     "./provision": "./src/provision.ts",
     "./statusline-payload": "./src/statusline-payload.ts",
+    "./statusline-render": "./src/statusline-render.ts",
+    "./worker-display": "./src/worker-display.ts",
     "./worker-launch": "./src/worker-launch.ts"
   },
   "description": "redskilled — the host-scoped execution daemon (ADR 0130): exactly one singleton per machine behind a unix socket, owning Worker processes across every project on that machine while each project's bundle keeps owning the work.",

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -34,6 +34,7 @@ import type { RedskilledLaunchTemplate } from "./launch-template.js";
 import type { RedskilledPaths } from "./paths.js";
 import type { RedskilledProjectRegistrationRequest } from "./project-registration.js";
 import {
+  isRedskilledDashboard,
   isRedskilledProjectDeregistered,
   isRedskilledDaemonStopped,
   isRedskilledProjectRegistered,
@@ -51,12 +52,17 @@ import {
   type RedskilledStatuslinePayload,
   type RedskilledStatuslineRender,
   type RedskilledStatuslineRenderRequest,
+  type RedskilledDashboard,
+  type RedskilledDashboardRenderRequest,
+  type RedskilledWorkerDisplay,
   type RedskilledWorkerCommandRequest,
   type RedskilledWorkerCommandResult,
   type RedskilledWorkerHeartbeatAck,
   type RedskilledWorkerStarted,
 } from "./protocol.js";
 import type { RedskilledStatuslineOptions } from "./statusline-render.js";
+import type { RedskilledDashboardOptions } from "./dashboard-render.js";
+import { clampPublishedWorkerDisplay } from "./worker-display.js";
 import { clampPublishedLogLine } from "./worker-log.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
 
@@ -369,6 +375,43 @@ export async function readRedskilledStatuslineString(
   return value;
 }
 
+/**
+ * The dashboard: the same read again, rendered as a table.
+ *
+ * A surface with a vertical dimension — a terminal pane, an editor panel — calls
+ * this and PRINTS what comes back. It never re-derives a cell: the header, the
+ * rows and the pipeline bars are computed once, in the one process that holds the
+ * Worker set across projects, so a pane and the statusline beside it cannot
+ * describe two different machines (ADR 0130 rule 10).
+ */
+export async function readRedskilledDashboard(
+  paths: RedskilledPaths,
+  options: Partial<RedskilledDashboardOptions> | undefined = undefined,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledDashboard> {
+  const value = await requestRedskilled(
+    paths,
+    {
+      op: "statusline-dashboard",
+      ...(config.sessionProject != null ? { session_project: config.sessionProject } : {}),
+      ...(options == null ? {} : { dashboard: dashboardRequest(options) }),
+    },
+    config,
+  );
+  if (!isRedskilledDashboard(value)) throw new Error("redskilled daemon returned a malformed dashboard");
+  return value;
+}
+
+/** The wire shape of decided dashboard options. PURE. */
+function dashboardRequest(options: Partial<RedskilledDashboardOptions>): RedskilledDashboardRenderRequest {
+  return {
+    ...(options.mode == null ? {} : { mode: options.mode }),
+    ...(options.project === undefined ? {} : { project: options.project }),
+    ...(options.maxWidth == null ? {} : { max_width: options.maxWidth }),
+    ...(options.maxRows == null ? {} : { max_rows: options.maxRows }),
+  };
+}
+
 /** The wire shape of decided render options. PURE. */
 function renderRequest(options: RedskilledStatuslineOptions): RedskilledStatuslineRenderRequest {
   return {
@@ -394,7 +437,13 @@ function renderRequest(options: RedskilledStatuslineOptions): RedskilledStatusli
  */
 export async function publishRedskilledWorkerLogLine(
   paths: RedskilledPaths,
-  heartbeat: { readonly worker_id: string; readonly line: string; readonly session_project?: string },
+  heartbeat: {
+    readonly worker_id: string;
+    readonly line: string;
+    /** What a surface should SHOW about this Worker; omitted publishes nothing. */
+    readonly display?: RedskilledWorkerDisplay;
+    readonly session_project?: string;
+  },
   config: RedskilledClientConfig = {},
 ): Promise<RedskilledWorkerHeartbeatAck> {
   const sessionProject = heartbeat.session_project ?? config.sessionProject;
@@ -405,6 +454,7 @@ export async function publishRedskilledWorkerLogLine(
       heartbeat: {
         worker_id: heartbeat.worker_id,
         last_log_line: clampPublishedLogLine(heartbeat.line),
+        ...(heartbeat.display == null ? {} : { display: clampPublishedWorkerDisplay(heartbeat.display) }),
         ...(sessionProject == null ? {} : { session_project: sessionProject }),
       },
     },

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -122,6 +122,7 @@ import {
   type RedskilledRequest,
   type RedskilledResponse,
   type RedskilledStatuslineRenderRequest,
+  type RedskilledDashboardRenderRequest,
   type RedskilledWorkerCommandRequest,
   type RedskilledProjectDeregistered,
   type RedskilledProjectRegistered,
@@ -152,6 +153,12 @@ import {
   renderRedskilledStatusline,
   type RedskilledStatuslineRender,
 } from "./statusline-render.js";
+import {
+  REDSKILLED_DASHBOARD_DEFAULTS,
+  renderRedskilledDashboard,
+  type RedskilledDashboard,
+} from "./dashboard-render.js";
+import { coerceWorkerDisplay, type RedskilledWorkerDisplayRecord } from "./worker-display.js";
 import {
   launchWorker,
   type LaunchWorkerOptions,
@@ -718,6 +725,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // a live progress note, and a durable copy would be a third authority on a
   // Worker's story next to the tracker and git (ADR 0130).
   const logLines = new Map<string, RedskilledWorkerLogLine>();
+  // What each project says a surface should SHOW about its Workers, by Worker id.
+  // In memory beside the log lines and for the same reason: a display record is a
+  // live progress note, and a durable copy would outlive the Worker it describes.
+  const displays = new Map<string, RedskilledWorkerDisplayRecord>();
   // What each project asked the host to hold for it, by project label. In memory,
   // like the log lines and for the same reason: a registration is a live statement
   // a session renews, and a durable copy would outlive the thing it describes. The
@@ -912,6 +923,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       rss: lastReading,
       sampledAt: lastSampledAt,
       logLines: Object.fromEntries(logLines),
+      displays: Object.fromEntries(displays),
       now: clock(),
       reattachedWorkerIds: [...reattached],
       repositoryActivity: lastActivity,
@@ -1092,6 +1104,25 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   /**
+   * The same payload, given the vertical dimension a pane has and a line has not.
+   *
+   * THE DAEMON AGGREGATES AND RENDERS; SURFACES PRINT. A herdr pane and an editor
+   * panel that each did their own Worker math would be two dashboards lying in
+   * two different ways about one instant — which is the drift ADR 0130 rule 10
+   * settled for the statusline and this settles for the table. As with the line,
+   * the request carries taste the client already resolved, because a daemon that
+   * looked up a config would have to know what a `.red/config.yaml` is.
+   */
+  function statuslineDashboard(render?: RedskilledDashboardRenderRequest): RedskilledDashboard {
+    return renderRedskilledDashboard(statuslinePayload(), {
+      mode: render?.mode ?? REDSKILLED_DASHBOARD_DEFAULTS.mode,
+      project: render?.project ?? REDSKILLED_DASHBOARD_DEFAULTS.project,
+      maxWidth: render?.max_width ?? REDSKILLED_DASHBOARD_DEFAULTS.maxWidth,
+      maxRows: render?.max_rows ?? REDSKILLED_DASHBOARD_DEFAULTS.maxRows,
+    });
+  }
+
+  /**
    * Decide whether a session may do this, before any mechanism runs.
    *
    * Reach is checked FIRST and against the target's project, so a cross-project
@@ -1141,6 +1172,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     workers.delete(workerId);
     reattached.delete(workerId);
     logLines.delete(workerId);
+    displays.delete(workerId);
   }
 
   /**
@@ -1171,6 +1203,12 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     }
     const publishedAt = clock();
     logLines.set(request.worker_id, { line: request.last_log_line, published_at: publishedAt, source: "heartbeat" });
+    // Shape-checked and stored, exactly as the line above it is. A record whose
+    // fields the daemon cannot recognise degrades field by field rather than
+    // failing the heartbeat: a project shipping a newer bundle than its neighbour
+    // is the ordinary state of a host-scoped daemon (ADR 0130 rule 3).
+    const display = request.display === undefined ? null : coerceWorkerDisplay(request.display);
+    if (display != null) displays.set(request.worker_id, { display, published_at: publishedAt });
     return {
       version: 1,
       worker_id: request.worker_id,
@@ -1952,6 +1990,12 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         // two surfaces are the same answer twice and never two answers.
         return { id: request.id, ok: true, value: statuslineString(request.render) };
       }
+      if (request.op === "statusline-dashboard") {
+        // The third of the statusline family, and the same host read again: one
+        // call of a pure function on the payload the first op returns, so a pane
+        // and a line are the same answer twice and never two answers.
+        return { id: request.id, ok: true, value: statuslineDashboard(request.dashboard) };
+      }
       if (request.op === "worker-heartbeat") {
         return { id: request.id, ok: true, value: publishWorkerHeartbeat(request.heartbeat) };
       }
@@ -2042,6 +2086,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       const removed = workers.delete(workerId);
       reattached.delete(workerId);
       logLines.delete(workerId);
+      displays.delete(workerId);
       if (worker) record("worker-death", worker, "released by the daemon");
       armIdleTimer();
       return removed;

--- a/apps/redskilled/src/dashboard-render.ts
+++ b/apps/redskilled/src/dashboard-render.ts
@@ -1,0 +1,467 @@
+/**
+ * dashboard-render — the statusline, given the vertical dimension it never had.
+ *
+ * **THE DAEMON AGGREGATES AND RENDERS; SURFACES PRINT.** The statusline pair
+ * (`statusline-payload` / `statusline-string`) already settled this for one line;
+ * this module settles it for the table. Every cell here is computed once, in the
+ * one process that holds the Worker set across projects, and a surface receives
+ * finished text plus the structure behind it. A terminal pane and an editor panel
+ * that each did their own worker math would be two dashboards lying in two
+ * different ways about the same instant — which is the whole failure the pair of
+ * statusline ops exists to prevent (ADR 0130 rule 10).
+ *
+ * **The string is a pure function of the payload.** Nothing here reads a clock, a
+ * directory or an environment variable; the elapsed figures are the payload's own
+ * `uptime_ms`, dated by the daemon's sampler, so the dashboard and the statusline
+ * beside it can only disagree if a pure function is impure.
+ *
+ * **The daemon never learns the pipeline.** The progress bar is drawn from the
+ * two integers a project published (`phase_index`, `phase_total`) and from
+ * nothing else — see `worker-display.ts`. A daemon that knew what `coding` or
+ * `validating` meant would be carrying castle semantics, which rule 3 forbids.
+ *
+ * **Host-side session facts stay absent rather than faked.** The context window
+ * and the Pro/Max 5h/7d usage windows arrive from a Claude Code stdin payload
+ * that never reaches this process. The header carries the windows the daemon DOES
+ * own — the memory ceiling and the Worker slots — and says nothing about the ones
+ * it does not, because a plausible zero is worse than a missing column.
+ */
+import type {
+  RedskilledStatuslinePayload,
+  RedskilledStatuslineWorker,
+} from "./statusline-payload.js";
+import {
+  formatBytes,
+  resolveStatuslineProjectMatch,
+  type RedskilledStatuslineMode,
+  type RedskilledStatuslineProjectMatch,
+} from "./statusline-render.js";
+import { REDSKILLED_WORKER_DISPLAY_ABSENT, type RedskilledWorkerDisplay } from "./worker-display.js";
+
+/** The row columns, in the order the statusline's per-worker line prints them. */
+export const REDSKILLED_DASHBOARD_COLUMNS = [
+  "wid",
+  "run",
+  "org",
+  "iss",
+  "bar",
+  "phase",
+  "elapsed",
+  "hb",
+  "loc",
+  "tks",
+  "tls",
+  "rsn",
+  "txt",
+] as const;
+
+export type RedskilledDashboardColumn = (typeof REDSKILLED_DASHBOARD_COLUMNS)[number];
+
+/** One row's cells, before alignment. A cell nothing was published for is `""`. */
+export type RedskilledDashboardCells = Record<RedskilledDashboardColumn, string>;
+
+export interface RedskilledDashboardRow {
+  readonly worker_id: string;
+  readonly project_label: string;
+  /** True when this Worker belongs to the project the reading session named. */
+  readonly mine: boolean;
+  readonly cells: RedskilledDashboardCells;
+  /** The finished, column-aligned line. A surface prints this and adds nothing. */
+  readonly line: string;
+}
+
+/** The repo-global counts the header carries, each `null` when unpolled. */
+export interface RedskilledDashboardCounts {
+  readonly open_pull_requests: number | null;
+  /** Pull requests and Issues closed inside the poller's window — the `cpr` cell. */
+  readonly recently_closed: number | null;
+  readonly open_issues: number | null;
+  /** True when the counts are older than the poller's own staleness window. */
+  readonly stale: boolean;
+}
+
+/**
+ * The windows the daemon owns, as fractions.
+ *
+ * Named `windows` because that is the header slot the statusline spends on the
+ * Pro/Max rate limits. Those are host-side and unknowable here; these two are the
+ * ceilings this process actually enforces, so the slot carries a real answer
+ * rather than an empty one.
+ */
+export interface RedskilledDashboardWindows {
+  readonly memory_used_fraction: number | null;
+  readonly memory_used_bytes: number;
+  readonly memory_ceiling_bytes: number | null;
+  readonly worker_count: number;
+  readonly worker_ceiling: number | null;
+}
+
+export interface RedskilledDashboardHeader {
+  /** The repository or project this view is standing in; `null` when unresolved. */
+  readonly repo: string | null;
+  readonly project: string | null;
+  readonly project_match: RedskilledStatuslineProjectMatch;
+  /** The daemon's version — the one version this process can honestly state. */
+  readonly version: string;
+  /** `runner model effort`, from the first Worker that published one; else `null`. */
+  readonly model: string | null;
+  readonly windows: RedskilledDashboardWindows;
+  readonly counts: RedskilledDashboardCounts;
+  readonly stale: boolean;
+  readonly age_ms: number | null;
+  /** The finished header line — the summary a status bar shows on its own. */
+  readonly line: string;
+}
+
+export interface RedskilledDashboard {
+  readonly version: 1;
+  readonly generated_at: string;
+  readonly mode: RedskilledStatuslineMode;
+  readonly project: string | null;
+  readonly columns: readonly RedskilledDashboardColumn[];
+  readonly header: RedskilledDashboardHeader;
+  readonly rows: readonly RedskilledDashboardRow[];
+  /**
+   * Every line to print, the header first.
+   *
+   * A list rather than one string with newlines in it, for the reason the
+   * statusline render gives: a surface that had to split on `\n` to know how many
+   * rows to reserve would be parsing the render.
+   */
+  readonly lines: readonly string[];
+  /** Workers the row budget left out — stated, never silently dropped. */
+  readonly hidden_row_count: number;
+  readonly stale: boolean;
+}
+
+export interface RedskilledDashboardOptions {
+  readonly mode: RedskilledStatuslineMode;
+  /** The project this session belongs to; `null` when it declared none. */
+  readonly project: string | null;
+  /** The hard ceiling in characters. No line exceeds it. */
+  readonly maxWidth: number;
+  /** How many Worker rows may be drawn before the rest are counted instead. */
+  readonly maxRows: number;
+}
+
+export const REDSKILLED_DASHBOARD_DEFAULTS: RedskilledDashboardOptions = {
+  mode: "local",
+  project: null,
+  maxWidth: 200,
+  maxRows: 16,
+};
+
+/** What a surface prints when nothing answered. PURE. */
+export const REDSKILLED_DASHBOARD_ABSENCE = "redskilled unreachable — Worker state unknown";
+
+const GUTTER = "  ";
+const BAR_DONE = "█";
+const BAR_CURSOR = "▶";
+const BAR_FAILED = "✗";
+const BAR_AHEAD = "░";
+
+/**
+ * The finished dashboard. PURE — payload and options in, header and rows out.
+ *
+ * Rows are laid out against the widest cell in each column so the table reads as
+ * a table at any Worker count, and the whole thing is clamped to `maxWidth`
+ * afterwards: a row cut mid-cell still begins with the identity columns, which
+ * are the ones that make the remainder attributable.
+ */
+export function renderRedskilledDashboard(
+  payload: RedskilledStatuslinePayload,
+  options: RedskilledDashboardOptions = REDSKILLED_DASHBOARD_DEFAULTS,
+): RedskilledDashboard {
+  const match = resolveStatuslineProjectMatch(payload, options.project);
+  const selected = selectWorkers(payload, options);
+  const visible = selected.slice(0, Math.max(0, Math.floor(options.maxRows)));
+  const cells = visible.map((worker) => workerCells(worker, options));
+  const widths = columnWidths(cells);
+
+  const rows: RedskilledDashboardRow[] = visible.map((worker, index) => ({
+    worker_id: worker.worker_id,
+    project_label: worker.project_label,
+    mine: options.project != null && worker.project_label === options.project,
+    cells: cells[index]!,
+    line: clamp(formatRow(cells[index]!, widths), options.maxWidth),
+  }));
+
+  const header = buildHeader(payload, options, selected, match);
+  const hidden = selected.length - visible.length;
+  const lines = [header.line, ...rows.map((row) => row.line)];
+  if (hidden > 0) {
+    lines.push(clamp(`… ${hidden} more Worker(s) — the row budget is short, not the host`, options.maxWidth));
+  }
+
+  return {
+    version: 1,
+    generated_at: payload.generated_at,
+    mode: options.mode,
+    project: options.project,
+    columns: REDSKILLED_DASHBOARD_COLUMNS,
+    header,
+    rows,
+    lines,
+    hidden_row_count: Math.max(0, hidden),
+    stale: payload.staleness.stale,
+  };
+}
+
+/**
+ * The Workers this view is about.
+ *
+ * The same selection the statusline makes, and deliberately so: a dashboard that
+ * listed a different set than the line above it would be the second authority
+ * both surfaces exist to avoid. A local session that declared no project shows
+ * none — the header still carries the host total, so the view stays truthful.
+ */
+function selectWorkers(
+  payload: RedskilledStatuslinePayload,
+  options: RedskilledDashboardOptions,
+): readonly RedskilledStatuslineWorker[] {
+  if (options.mode === "global") return payload.workers;
+  if (options.project == null) return [];
+  return payload.workers.filter((worker) => worker.project_label === options.project);
+}
+
+/**
+ * One Worker's cells, in the statusline's own vocabulary. PURE.
+ *
+ * A field the project never published renders as an EMPTY cell rather than as a
+ * zero: `tks=0` is a Worker that has spent nothing, and a Worker whose bundle
+ * publishes no display record has spent an unknown amount.
+ */
+function workerCells(
+  worker: RedskilledStatuslineWorker,
+  options: RedskilledDashboardOptions,
+): RedskilledDashboardCells {
+  const display = worker.display ?? REDSKILLED_WORKER_DISPLAY_ABSENT;
+  const run = [display.runner, display.model, display.effort].filter((part): part is string => Boolean(part)).join(" ");
+  return {
+    wid: options.mode === "global" ? `${worker.project_label}:${worker.worker_id}` : worker.worker_id,
+    run: run === "" ? "" : `run=${run}`,
+    org: display.origin == null ? "" : `org=${display.origin}`,
+    iss: display.issue == null ? "" : `iss=${display.issue}`,
+    bar: progressBar(display),
+    phase: [display.phase, display.step].filter((part): part is string => Boolean(part)).join("·"),
+    elapsed: formatDuration(worker.uptime_ms),
+    hb: `hb=${display.heartbeat ?? "?"}`,
+    loc: formatSignedPair(display.added, display.removed),
+    tks: display.tokens == null ? "" : `tks=${formatCount(display.tokens)}`,
+    tls: display.tools == null ? "" : `tls=${display.tools}`,
+    rsn: display.reasoning == null ? "" : `rsn=${display.reasoning}`,
+    txt: display.text == null ? "" : `txt=${display.text}`,
+  };
+}
+
+/**
+ * The pipeline bar, drawn from two integers and no vocabulary. PURE.
+ *
+ * `index` completed cells, one cursor, and the rest ahead. A project that
+ * published no position gets no bar at all — a bar with an invented cursor would
+ * put a Worker somewhere in a pipeline this process cannot see.
+ */
+export function progressBar(display: RedskilledWorkerDisplay): string {
+  const total = display.phase_total;
+  const index = display.phase_index;
+  if (total == null || total <= 0 || index == null || index < 0) return "";
+  const done = Math.min(Math.floor(index), Math.floor(total));
+  if (done >= total) return BAR_DONE.repeat(Math.floor(total));
+  const cursor = display.failed ? BAR_FAILED : BAR_CURSOR;
+  return `${BAR_DONE.repeat(done)}${cursor}${BAR_AHEAD.repeat(Math.floor(total) - done - 1)}`;
+}
+
+/**
+ * The header line — the one row that is drawn whatever else is dropped. PURE.
+ *
+ * It is also the whole answer a status bar shows, which is why it repeats the
+ * host totals rather than relying on the table beneath it: a summary that only
+ * made sense with the rows visible would be useless in the one place it is shown
+ * alone.
+ */
+function buildHeader(
+  payload: RedskilledStatuslinePayload,
+  options: RedskilledDashboardOptions,
+  selected: readonly RedskilledStatuslineWorker[],
+  match: RedskilledStatuslineProjectMatch,
+): RedskilledDashboardHeader {
+  const activity = (payload.repository_activity?.projects ?? []).find(
+    (project) => project.project_label === options.project,
+  );
+  const counts: RedskilledDashboardCounts = {
+    open_pull_requests: activity?.counts?.open_pull_requests ?? null,
+    recently_closed: activity?.counts?.recently_closed ?? null,
+    open_issues: activity?.counts?.open_issues ?? null,
+    stale: activity?.stale === true,
+  };
+  const windows: RedskilledDashboardWindows = {
+    memory_used_fraction: payload.host.ceiling_used_fraction,
+    memory_used_bytes: payload.host.consumption.memory_bytes,
+    memory_ceiling_bytes: payload.host.ceiling.memory_bytes,
+    worker_count: payload.host.worker_count,
+    worker_ceiling: payload.host.ceiling.worker_count,
+  };
+  const model = firstPublishedModel(selected);
+  const repo = activity?.repository ?? options.project;
+
+  const parts: string[] = [`» ${repo ?? "host"} v${payload.daemon.daemon_version}`];
+  if (match === "unregistered") parts.push("!unregistered");
+  if (match === "name-only") parts.push("!lapsed");
+  if (model != null) parts.push(model);
+  parts.push(`wrk=${selected.length}/${payload.host.worker_count}`);
+  parts.push(
+    windows.worker_ceiling == null ? "slots=∞" : `slots=${windows.worker_count}/${windows.worker_ceiling}`,
+  );
+  parts.push(memoryWindow(windows));
+  if (counts.open_pull_requests != null) parts.push(`prs=${counts.open_pull_requests}`);
+  if (counts.recently_closed != null) parts.push(`cpr=${counts.recently_closed}`);
+  if (counts.open_issues != null) parts.push(`iss=${counts.open_issues}`);
+  if (counts.stale) parts.push("!counts stale");
+  if (payload.staleness.stale) {
+    const age = payload.staleness.age_ms;
+    parts.push(age == null ? "!unmeasured" : `!stale ${Math.round(age / 1000)}s`);
+  }
+
+  return {
+    repo,
+    project: options.project,
+    project_match: match,
+    version: payload.daemon.daemon_version,
+    model,
+    windows,
+    counts,
+    stale: payload.staleness.stale,
+    age_ms: payload.staleness.age_ms,
+    line: clamp(parts.join(" · "), options.maxWidth),
+  };
+}
+
+/** `mem=1.2G/8G 15%`, or the observed figure alone when nothing caps it. PURE. */
+function memoryWindow(windows: RedskilledDashboardWindows): string {
+  if (windows.memory_ceiling_bytes == null || windows.memory_ceiling_bytes <= 0) {
+    return `mem=${formatBytes(windows.memory_used_bytes)}`;
+  }
+  const percent =
+    windows.memory_used_fraction == null ? "" : ` ${Math.round(windows.memory_used_fraction * 100)}%`;
+  return `mem=${formatBytes(windows.memory_used_bytes)}/${formatBytes(windows.memory_ceiling_bytes)}${percent}`;
+}
+
+/**
+ * The first `runner model effort` any listed Worker published. PURE.
+ *
+ * First rather than merged: a host running two runners at once has no single
+ * answer, and a header that invented one would be stating something no Worker
+ * said. The per-Worker `run=` cells carry the truth for each row.
+ */
+function firstPublishedModel(workers: readonly RedskilledStatuslineWorker[]): string | null {
+  for (const worker of workers) {
+    const display = worker.display;
+    if (display == null) continue;
+    const parts = [display.runner, display.model, display.effort].filter((part): part is string => Boolean(part));
+    if (parts.length > 0) return parts.join("·");
+  }
+  return null;
+}
+
+/** `loc=+12 -3`; empty when the project published neither side. PURE. */
+function formatSignedPair(added: number | null, removed: number | null): string {
+  if (added == null && removed == null) return "";
+  const parts: string[] = [];
+  if (added != null && added > 0) parts.push(`+${added}`);
+  if (removed != null && removed > 0) parts.push(`-${removed}`);
+  return `loc=${parts.length > 0 ? parts.join(" ") : "0"}`;
+}
+
+/** A count at dashboard resolution: at most one decimal, no trailing `.0`. PURE. */
+export function formatCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  const scale = (scaled: number, suffix: string): string => {
+    const text = (Math.round(scaled * 10) / 10).toFixed(1);
+    return `${text.endsWith(".0") ? text.slice(0, -2) : text}${suffix}`;
+  };
+  if (value >= 1e9) return scale(value / 1e9, "B");
+  if (value >= 1e6) return scale(value / 1e6, "M");
+  if (value >= 1e3) return scale(value / 1e3, "k");
+  return String(Math.round(value));
+}
+
+/** An elapsed span in the two most significant units; `—` when unstated. PURE. */
+export function formatDuration(ms: number | null): string {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return "—";
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h${minutes % 60}m`;
+  return `${Math.floor(hours / 24)}d${hours % 24}h`;
+}
+
+/**
+ * True when `value` is a dashboard this surface can print — fail-closed. PURE.
+ *
+ * The check stops at `lines` and the header's own line, because those are what a
+ * surface prints; a daemon that grew a field this consumer has never heard of
+ * still serves a printable answer, and rejecting it would blank a pane over
+ * version skew the host-scoped daemon exists to stop managing (ADR 0130 rule 3).
+ */
+export function isRedskilledDashboard(value: unknown): value is RedskilledDashboard {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const dashboard = value as Record<string, unknown>;
+  const header = dashboard.header as Record<string, unknown> | undefined;
+  return dashboard.version === 1 &&
+    typeof dashboard.generated_at === "string" &&
+    Array.isArray(dashboard.columns) &&
+    Array.isArray(dashboard.rows) &&
+    Array.isArray(dashboard.lines) &&
+    dashboard.lines.every((line) => typeof line === "string") &&
+    typeof dashboard.stale === "boolean" &&
+    header != null && typeof header === "object" && typeof header.line === "string";
+}
+
+function columnWidths(rows: readonly RedskilledDashboardCells[]): Record<RedskilledDashboardColumn, number> {
+  const widths = Object.fromEntries(REDSKILLED_DASHBOARD_COLUMNS.map((column) => [column, 0])) as Record<
+    RedskilledDashboardColumn,
+    number
+  >;
+  for (const row of rows) {
+    for (const column of REDSKILLED_DASHBOARD_COLUMNS) {
+      widths[column] = Math.max(widths[column], width(row[column]));
+    }
+  }
+  return widths;
+}
+
+/**
+ * One aligned row. A column no row filled costs nothing at all. PURE.
+ *
+ * The trailing edge is trimmed rather than padded: a table whose rows all end in
+ * fourteen spaces looks identical in a terminal and is not identical in an
+ * editor's diff, a clipboard, or a test assertion.
+ */
+function formatRow(
+  cells: RedskilledDashboardCells,
+  widths: Record<RedskilledDashboardColumn, number>,
+): string {
+  const parts = REDSKILLED_DASHBOARD_COLUMNS.filter((column) => widths[column] > 0).map((column) =>
+    pad(cells[column], widths[column]),
+  );
+  return parts.join(GUTTER).replace(/\s+$/, "");
+}
+
+function pad(text: string, target: number): string {
+  return text + " ".repeat(Math.max(0, target - width(text)));
+}
+
+/** The visible width. One character is one column here — no line carries ANSI. */
+function width(line: string): number {
+  return [...line].length;
+}
+
+function clamp(line: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  const chars = [...line];
+  if (chars.length <= maxWidth) return line;
+  if (maxWidth === 1) return "…";
+  return `${chars.slice(0, maxWidth - 1).join("")}…`;
+}

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -23,9 +23,17 @@
  * string because the alternative is every agent host reimplementing the line —
  * which is the drift the pair of ops exists to prevent (ADR 0130 rule 10). The
  * daemon renders it from the very payload the other op returns, so the two can
- * disagree only if a pure function is impure. `worker-heartbeat` widens it by one
- * more string, in the one direction the daemon has no other way to learn: the
- * Worker's own last logged line. It is stored and echoed, never parsed — transport
+ * disagree only if a pure function is impure. `statusline-dashboard` is the third
+ * of that family and widens the contract by no new FACT at all: it is the same
+ * payload rendered with a vertical dimension, for the surfaces that have one — a
+ * herdr pane and an editor panel. It is here rather than in each surface for the
+ * reason `statusline-string` is: two surfaces doing their own Worker math are two
+ * dashboards that lie in two different ways about one instant. `worker-heartbeat`
+ * widens it by one more string, in the one direction the daemon has no other way
+ * to learn: the Worker's own last logged line — and, since #3012, by one opaque
+ * DISPLAY RECORD beside it. That record is stored and laid out, never read: the
+ * pipeline bar is drawn from two integers a project published, so the daemon
+ * reaches statusline parity without ever learning what a phase is. It is stored and echoed, never parsed — transport
  * is not semantics — which is what keeps the verbose statusline one read and keeps
  * the daemon ignorant of where a project's logs live. `worker-command`
  * carries the commanding verbs — stop, recycle, steer — as data rather than as
@@ -74,6 +82,8 @@ import {
 import { isRedskilledReachVerdict, type RedskilledReachVerdict, type RedskilledWorkerCommandName } from "./session-reach.js";
 import { isRedskilledStatuslinePayload, type RedskilledStatuslinePayload } from "./statusline-payload.js";
 import type { RedskilledStatuslineMode, RedskilledStatuslineRender } from "./statusline-render.js";
+import { isRedskilledDashboard, type RedskilledDashboard } from "./dashboard-render.js";
+import type { RedskilledWorkerDisplay } from "./worker-display.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
 
 /** The wire version. A daemon states it; a client that cannot read it must not proceed. */
@@ -124,7 +134,31 @@ export interface RedskilledStatuslineRenderRequest {
 export interface RedskilledWorkerHeartbeatRequest {
   readonly worker_id: string;
   readonly last_log_line: string;
+  /**
+   * What a surface should SHOW about this Worker, as its project says it.
+   *
+   * Opaque in exactly the sense `last_log_line` is: the daemon shape-checks the
+   * record, stores it and lays it out, and nothing in this process ever asks what
+   * a phase, an origin or an issue number MEANS. It is the frozen contract's one
+   * concession to dashboard parity — a project that published nothing simply has
+   * a row of absences, which is the honest render, not a broken one.
+   */
+  readonly display?: RedskilledWorkerDisplay;
   readonly session_project?: string;
+}
+
+/**
+ * How one dashboard read wants to be rendered.
+ *
+ * Taste already settled by the client, exactly as
+ * {@link RedskilledStatuslineRenderRequest} carries it: `max_rows` is a table's
+ * version of `max_workers`, because a pane has a height where a line has none.
+ */
+export interface RedskilledDashboardRenderRequest {
+  readonly mode?: RedskilledStatuslineMode;
+  readonly project?: string | null;
+  readonly max_width?: number;
+  readonly max_rows?: number;
 }
 
 export type RedskilledRequest =
@@ -132,6 +166,7 @@ export type RedskilledRequest =
   | { id: string; op: "host-state" }
   | { id: string; op: "statusline-payload"; session_project?: string }
   | { id: string; op: "statusline-string"; session_project?: string; render?: RedskilledStatuslineRenderRequest }
+  | { id: string; op: "statusline-dashboard"; session_project?: string; dashboard?: RedskilledDashboardRenderRequest }
   | { id: string; op: "worker-start"; spec: RedskilledWorkerSpec; session_project?: string }
   | { id: string; op: "worker-command"; command: RedskilledWorkerCommandRequest }
   | { id: string; op: "worker-heartbeat"; heartbeat: RedskilledWorkerHeartbeatRequest }
@@ -373,6 +408,15 @@ export function isRedskilledStatuslineRender(value: unknown): value is Redskille
 export { isRedskilledStatuslinePayload };
 
 /**
+ * True when `value` is a dashboard — re-exported so a client checks one surface.
+ *
+ * Beside the payload guard for the reason that one is here: a surface that
+ * speaks this wire reads every shape it trusts off one module, and a second
+ * import path is how one consumer comes to trust a shape another rejects.
+ */
+export { isRedskilledDashboard };
+
+/**
  * The answer to `shutdown`: what the daemon holds, and what survives it.
  *
  * Re-exported here for the same reason the payload guard is — a client that
@@ -394,6 +438,8 @@ export type {
   RedskilledStatuslineMode,
   RedskilledStatuslinePayload,
   RedskilledStatuslineRender,
+  RedskilledDashboard,
+  RedskilledWorkerDisplay,
   RedskilledWorkerCommandName,
   RedskilledWorkerView,
   RedskilledWorkerSpec,

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -30,6 +30,7 @@ import {
   type RedskilledActivityReport,
   type RedskilledRepositoryActivity,
 } from "./repository-activity.js";
+import type { RedskilledWorkerDisplay, RedskilledWorkerDisplayRecord } from "./worker-display.js";
 import type { RedskilledWorkerLogLine } from "./worker-log.js";
 
 /**
@@ -103,6 +104,24 @@ export interface RedskilledStatuslineWorker {
   readonly vitals: RedskilledStatuslineVitals;
   readonly budget: RedskilledStatuslineWorkerBudget;
   readonly log: RedskilledStatuslineWorkerLog;
+  /**
+   * What this Worker's project says a surface should SHOW about it.
+   *
+   * It rides on the payload for the same reason `log` does: the dashboard is ONE
+   * read, and a surface that had to ask each project for its own Worker rows
+   * would cross a project boundary per render and become a second authority on a
+   * question this document already answers.
+   *
+   * `null` — never a record of zeros — for a Worker whose project publishes none,
+   * because "nothing was published" and "it has done nothing" are opposite facts
+   * about a busy Worker. OPTIONAL on the wire for the reason `known_projects` is:
+   * one daemon serves checkouts pinned to different bundle versions (ADR 0130
+   * rule 3), and a consumer finding it absent must render an unpublished row, not
+   * reject the Worker set.
+   */
+  readonly display?: RedskilledWorkerDisplay | null;
+  /** When the display record landed; `null` when none has. */
+  readonly display_published_at?: string | null;
 }
 
 /** One project's share of the machine. */
@@ -214,6 +233,14 @@ export interface BuildStatuslinePayloadInput {
    * the heartbeats, and this document stays a pure function of its inputs.
    */
   readonly logLines?: Readonly<Record<string, RedskilledWorkerLogLine>>;
+  /**
+   * The display record each Worker's project published, by Worker id.
+   *
+   * Passed in for the same reason the log lines are: the records belong to the
+   * daemon that received the heartbeats, and this document stays a pure function
+   * of its inputs.
+   */
+  readonly displays?: Readonly<Record<string, RedskilledWorkerDisplayRecord>>;
   readonly now: string;
   /** Workers this daemon adopted at start rather than birthing itself, by id. */
   readonly reattachedWorkerIds?: readonly string[];
@@ -246,6 +273,7 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
       sampleFresh,
       nowMs,
       log: input.logLines?.[worker.worker_id],
+      display: input.displays?.[worker.worker_id],
       state: reattached.has(worker.worker_id) ? "reattached" : "running",
     })
   );
@@ -310,6 +338,8 @@ function buildWorker(
     readonly nowMs: number | null;
     /** What this Worker published, when it has published anything. */
     readonly log?: RedskilledWorkerLogLine;
+    /** What this Worker's project says a surface should show about it. */
+    readonly display?: RedskilledWorkerDisplayRecord;
     readonly state: RedskilledWorkerState;
   },
 ): RedskilledStatuslineWorker {
@@ -345,6 +375,8 @@ function buildWorker(
       enforceable: enforced != null,
     },
     log: workerLog(ctx.log),
+    display: ctx.display?.display ?? null,
+    display_published_at: ctx.display?.published_at ?? null,
   };
 }
 

--- a/apps/redskilled/src/statusline-render.ts
+++ b/apps/redskilled/src/statusline-render.ts
@@ -343,15 +343,31 @@ function resolveProjectMatch(
   payload: RedskilledStatuslinePayload,
   options: RedskilledStatuslineOptions,
 ): RedskilledStatuslineProjectMatch {
-  if (options.project == null) return "unresolved";
+  return resolveStatuslineProjectMatch(payload, options.project);
+}
+
+/**
+ * The same verdict, for a renderer that is not the statusline. PURE.
+ *
+ * Exported so the dashboard reaches it by CALLING it rather than by restating
+ * it: two renderers with two copies of this ladder is exactly how one surface
+ * comes to accuse a project the other calls healthy. It takes the project alone
+ * rather than a whole options record, so a caller with different budgets — a
+ * table has row counts, a line has widths — can still ask.
+ */
+export function resolveStatuslineProjectMatch(
+  payload: RedskilledStatuslinePayload,
+  project: string | null,
+): RedskilledStatuslineProjectMatch {
+  if (project == null) return "unresolved";
   if (payload.known_projects == null) return "matched";
-  if (!payload.known_projects.includes(options.project)) return "unregistered";
+  if (!payload.known_projects.includes(project)) return "unregistered";
   // Known, and possibly known only by NAME. A daemon too old to state its
   // registrations cannot say which, and the answer then is `matched` for the same
   // reason it is above: a lapse invented from a missing field would put a false
   // accusation on every line a skewed daemon serves.
   if (payload.registered_projects == null) return "matched";
-  return payload.registered_projects.includes(options.project) ? "matched" : "name-only";
+  return payload.registered_projects.includes(project) ? "matched" : "name-only";
 }
 
 /**

--- a/apps/redskilled/src/worker-display.ts
+++ b/apps/redskilled/src/worker-display.ts
@@ -1,0 +1,166 @@
+/**
+ * worker-display — what a surface SHOWS about one Worker, as its project said it.
+ *
+ * **The project publishes; the daemon stores and lays out.** Every field here
+ * travels on the heartbeat the Worker's own project already sends, exactly as its
+ * last logged line does, and the daemon never reads one for meaning: no branch in
+ * this process asks what a phase is, whether an origin is `afk` or `go`, or what
+ * an issue number refers to. That is what keeps ADR 0130 rule 3 intact while the
+ * dashboard reaches statusline parity — the frozen contract widens by one opaque
+ * record, not by castle semantics.
+ *
+ * **The progress bar arrives as two integers, never as a vocabulary.** A daemon
+ * that drew a pipeline bar would have to know the pipeline, and the phase order is
+ * a per-project fact that changes on a bundle version the daemon does not track.
+ * `phase_index` and `phase_total` are the whole of it: the renderer draws
+ * `index` completed cells, one cursor and the remainder ahead, and stays ignorant
+ * of what any of them are called.
+ *
+ * **Absent is `null`, never a zero.** A Worker whose project publishes no display
+ * record and a Worker genuinely holding zero tokens are opposite facts, and a
+ * surface that could not tell them apart would render an unmeasured row as an
+ * idle one — the same failure `RedskilledStatuslineVitals` refuses for RSS.
+ *
+ * PURE.
+ */
+
+/**
+ * One Worker's display record, as its project published it.
+ *
+ * The field names are the statusline's own, so a reader comparing the dashboard
+ * against the line it mirrors is comparing like with like rather than translating
+ * between two vocabularies for the same fact.
+ */
+export interface RedskilledWorkerDisplay {
+  /** The agent CLI driving this Worker (`claude`, `codex`, …). */
+  readonly runner: string | null;
+  readonly model: string | null;
+  readonly effort: string | null;
+  /** Where the work came from (`afk`, `go`, `landing`, …), opaque here. */
+  readonly origin: string | null;
+  /** The work item this Worker is on, as a string the daemon never parses. */
+  readonly issue: string | null;
+  readonly phase: string | null;
+  /** What the phase is doing right now — the statusline's `phase·step` tail. */
+  readonly step: string | null;
+  /** How many pipeline steps are behind this one; `null` when unstated. */
+  readonly phase_index: number | null;
+  /** How many steps the pipeline has at all; `null` when unstated. */
+  readonly phase_total: number | null;
+  /** True when the project reports this Worker blocked or failed. */
+  readonly failed: boolean;
+  /** Proof-of-life as the project spells it (`3s`, `~11m+`, `!4m`). */
+  readonly heartbeat: string | null;
+  readonly added: number | null;
+  readonly removed: number | null;
+  readonly tokens: number | null;
+  readonly tools: number | null;
+  readonly reasoning: number | null;
+  readonly text: number | null;
+}
+
+/** The record the daemon keeps: the published fields, and when they landed. */
+export interface RedskilledWorkerDisplayRecord {
+  readonly display: RedskilledWorkerDisplay;
+  readonly published_at: string;
+}
+
+/**
+ * How long a published display string may be.
+ *
+ * Clamped by the PUBLISHER, never by the daemon — the same split the log line
+ * already answers to. The daemon shortening a value would be the daemon
+ * interpreting content, and every surface clamps to its own width anyway; this
+ * bound exists only so a runaway value cannot make a heartbeat expensive.
+ */
+export const REDSKILLED_DISPLAY_FIELD_MAX = 64;
+
+/** A record that says nothing — the honest shape of a Worker that published none. */
+export const REDSKILLED_WORKER_DISPLAY_ABSENT: RedskilledWorkerDisplay = {
+  runner: null,
+  model: null,
+  effort: null,
+  origin: null,
+  issue: null,
+  phase: null,
+  step: null,
+  phase_index: null,
+  phase_total: null,
+  failed: false,
+  heartbeat: null,
+  added: null,
+  removed: null,
+  tokens: null,
+  tools: null,
+  reasoning: null,
+  text: null,
+};
+
+const TEXT_FIELDS = ["runner", "model", "effort", "origin", "issue", "phase", "step", "heartbeat"] as const;
+const COUNT_FIELDS = [
+  "phase_index",
+  "phase_total",
+  "added",
+  "removed",
+  "tokens",
+  "tools",
+  "reasoning",
+  "text",
+] as const;
+
+/**
+ * The published record, shape-checked and nothing more. PURE.
+ *
+ * A field the daemon cannot recognise as a string or a finite count becomes
+ * `null` rather than failing the whole heartbeat: one project shipping a newer
+ * bundle than another is the ordinary state of a host-scoped daemon (ADR 0130
+ * rule 3), and refusing a Worker's whole record over one unreadable field would
+ * lose the twelve it could read. `null` is returned only for a value that is not
+ * an object at all — there is then nothing published to store.
+ */
+export function coerceWorkerDisplay(value: unknown): RedskilledWorkerDisplay | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  const display: Record<string, unknown> = { ...REDSKILLED_WORKER_DISPLAY_ABSENT };
+  for (const field of TEXT_FIELDS) {
+    const candidate = raw[field];
+    display[field] = typeof candidate === "string" && candidate.trim() !== "" ? candidate : null;
+  }
+  for (const field of COUNT_FIELDS) {
+    const candidate = raw[field];
+    display[field] = typeof candidate === "number" && Number.isFinite(candidate) ? candidate : null;
+  }
+  display.failed = raw.failed === true;
+  return display as unknown as RedskilledWorkerDisplay;
+}
+
+/**
+ * The publisher's own clamp, applied before the record goes on the wire. PURE.
+ *
+ * Here rather than in the daemon for the reason {@link REDSKILLED_DISPLAY_FIELD_MAX}
+ * gives: the project owns its content, and a daemon that trimmed a value would be
+ * reading it.
+ */
+export function clampPublishedWorkerDisplay(display: RedskilledWorkerDisplay): RedskilledWorkerDisplay {
+  const clamped: Record<string, unknown> = { ...display };
+  for (const field of TEXT_FIELDS) {
+    const value = display[field];
+    clamped[field] = value == null ? null : value.slice(0, REDSKILLED_DISPLAY_FIELD_MAX);
+  }
+  return clamped as unknown as RedskilledWorkerDisplay;
+}
+
+/** True when `value` is a complete display record — a consumer's fail-closed check. */
+export function isRedskilledWorkerDisplay(value: unknown): value is RedskilledWorkerDisplay {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const display = value as Record<string, unknown>;
+  if (typeof display.failed !== "boolean") return false;
+  for (const field of TEXT_FIELDS) {
+    if (display[field] !== null && typeof display[field] !== "string") return false;
+  }
+  for (const field of COUNT_FIELDS) {
+    const candidate = display[field];
+    if (candidate !== null && !(typeof candidate === "number" && Number.isFinite(candidate))) return false;
+  }
+  return true;
+}

--- a/apps/redskilled/tests/statusline-dashboard.test.ts
+++ b/apps/redskilled/tests/statusline-dashboard.test.ts
@@ -1,0 +1,308 @@
+// The dashboard is the statusline with a vertical dimension, and it is rendered
+// where the statusline is: in the daemon. These prove the three things a surface
+// depends on and cannot check for itself — the rows carry the statusline's own
+// fields, the bar is drawn from two published integers rather than from a
+// pipeline vocabulary the daemon does not have, and the op serves the same answer
+// a direct render of the payload produces.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { publishRedskilledWorkerLogLine, readRedskilledDashboard } from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import {
+  REDSKILLED_DASHBOARD_COLUMNS,
+  REDSKILLED_DASHBOARD_DEFAULTS,
+  progressBar,
+  renderRedskilledDashboard,
+} from "../src/dashboard-render.js";
+import { buildHostState, type RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { isRedskilledDashboard } from "../src/protocol.js";
+import { buildStatuslinePayload, type RedskilledStatuslinePayload } from "../src/statusline-payload.js";
+import {
+  REDSKILLED_WORKER_DISPLAY_ABSENT,
+  clampPublishedWorkerDisplay,
+  coerceWorkerDisplay,
+  REDSKILLED_DISPLAY_FIELD_MAX,
+  type RedskilledWorkerDisplay,
+} from "../src/worker-display.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await scratch("rsk-dash-");
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+function worker(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorkerView {
+  return {
+    worker_id: "w-1",
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-07-29T00:00:00.000Z",
+    workspace_path: "/tmp/acme/w-1",
+    isolated: true,
+    unit: "red-worker-acme-widgets-w-1.service",
+    budget: { memory_max: "1G" },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function display(overrides: Partial<RedskilledWorkerDisplay> = {}): RedskilledWorkerDisplay {
+  return {
+    ...REDSKILLED_WORKER_DISPLAY_ABSENT,
+    runner: "claude",
+    model: "opus",
+    effort: "high",
+    origin: "afk",
+    issue: "3012",
+    phase: "coding",
+    step: "impl",
+    phase_index: 2,
+    phase_total: 6,
+    heartbeat: "3s",
+    added: 142,
+    removed: 36,
+    tokens: 45_000,
+    tools: 12,
+    reasoning: 4,
+    text: 9,
+    ...overrides,
+  };
+}
+
+function payloadOf(
+  workers: readonly RedskilledWorkerView[],
+  displays: Record<string, RedskilledWorkerDisplay> = {},
+): RedskilledStatuslinePayload {
+  return buildStatuslinePayload({
+    hostState: buildHostState({
+      daemonVersion: "0.1.0",
+      machineIdHash: "mach",
+      sessionKeyHash: "sess",
+      pid: 99,
+      startedAt: "2026-07-29T00:00:00.000Z",
+      workers,
+      registrations: [],
+    }),
+    ceiling: UNBOUNDED_HOST_CEILING,
+    rss: {},
+    sampledAt: "2026-07-29T01:00:00.000Z",
+    displays: Object.fromEntries(
+      Object.entries(displays).map(([id, value]) => [id, { display: value, published_at: "2026-07-29T01:00:00.000Z" }]),
+    ),
+    now: "2026-07-29T01:00:05.000Z",
+  });
+}
+
+const LOCAL = { ...REDSKILLED_DASHBOARD_DEFAULTS, project: "acme/widgets" };
+
+describe("the dashboard carries the statusline's own fields", () => {
+  it("renders one row per Worker with run, org, iss, phase, elapsed, heartbeat, loc and the vitals", () => {
+    const dashboard = renderRedskilledDashboard(payloadOf([worker()], { "w-1": display() }), LOCAL);
+
+    expect(dashboard.rows).toHaveLength(1);
+    const cells = dashboard.rows[0]!.cells;
+    expect(cells.wid).toBe("w-1");
+    expect(cells.run).toBe("run=claude opus high");
+    expect(cells.org).toBe("org=afk");
+    expect(cells.iss).toBe("iss=3012");
+    expect(cells.phase).toBe("coding·impl");
+    expect(cells.elapsed).toBe("1h0m");
+    expect(cells.hb).toBe("hb=3s");
+    expect(cells.loc).toBe("loc=+142 -36");
+    expect(cells.tks).toBe("tks=45k");
+    expect(cells.tls).toBe("tls=12");
+    expect(cells.rsn).toBe("rsn=4");
+    expect(cells.txt).toBe("txt=9");
+  });
+
+  it("names every column the statusline's per-worker line prints", () => {
+    expect([...REDSKILLED_DASHBOARD_COLUMNS]).toEqual([
+      "wid",
+      "run",
+      "org",
+      "iss",
+      "bar",
+      "phase",
+      "elapsed",
+      "hb",
+      "loc",
+      "tks",
+      "tls",
+      "rsn",
+      "txt",
+    ]);
+  });
+
+  it("puts the repo, the version, the model and the prs/cpr/iss counts on the header line", () => {
+    const payload = {
+      ...payloadOf([worker()], { "w-1": display() }),
+      repository_activity: {
+        version: 1 as const,
+        outcome: "counted" as const,
+        fetched_at: "2026-07-29T01:00:00.000Z",
+        age_ms: 1_000,
+        threshold_ms: 120_000,
+        stale: false,
+        request_count: 1,
+        project_count: 1,
+        rate_limit: { remaining: 4_900, reset_at: null, exhausted: false },
+        reason: "counted",
+        projects: [
+          {
+            project_label: "acme/widgets",
+            repository: "acme/widgets",
+            outcome: "counted" as const,
+            counts: { open_pull_requests: 3, open_issues: 24, recently_closed: 7 },
+            detail: "counted",
+            age_ms: 1_000,
+            stale: false,
+          },
+        ],
+      },
+    } as unknown as RedskilledStatuslinePayload;
+
+    const header = renderRedskilledDashboard(payload, LOCAL).header;
+    expect(header.repo).toBe("acme/widgets");
+    expect(header.version).toBe("0.1.0");
+    expect(header.model).toBe("claude·opus·high");
+    expect(header.counts).toMatchObject({ open_pull_requests: 3, open_issues: 24, recently_closed: 7 });
+    expect(header.line).toContain("» acme/widgets v0.1.0");
+    expect(header.line).toContain("prs=3");
+    expect(header.line).toContain("cpr=7");
+    expect(header.line).toContain("iss=24");
+  });
+
+  it("prints the header first and one line per row, so a surface prints and splits nothing", () => {
+    const dashboard = renderRedskilledDashboard(
+      payloadOf([worker(), worker({ worker_id: "w-2" })], { "w-1": display(), "w-2": display() }),
+      LOCAL,
+    );
+    expect(dashboard.lines[0]).toBe(dashboard.header.line);
+    expect(dashboard.lines.slice(1)).toEqual(dashboard.rows.map((row) => row.line));
+  });
+
+  it("says how many Workers the row budget left out rather than dropping them in silence", () => {
+    const workers = [worker(), worker({ worker_id: "w-2" }), worker({ worker_id: "w-3" })];
+    const dashboard = renderRedskilledDashboard(payloadOf(workers), { ...LOCAL, maxRows: 1 });
+    expect(dashboard.rows).toHaveLength(1);
+    expect(dashboard.hidden_row_count).toBe(2);
+    expect(dashboard.lines.at(-1)).toContain("2 more Worker(s)");
+  });
+});
+
+describe("an unpublished field is an absence, never a zero", () => {
+  it("leaves every published cell empty for a Worker whose project publishes nothing", () => {
+    const cells = renderRedskilledDashboard(payloadOf([worker()]), LOCAL).rows[0]!.cells;
+    expect(cells.run).toBe("");
+    expect(cells.iss).toBe("");
+    expect(cells.tks).toBe("");
+    expect(cells.loc).toBe("");
+    expect(cells.hb).toBe("hb=?");
+    // The identity and the daemon's own clock still render: they were never the
+    // project's to publish.
+    expect(cells.wid).toBe("w-1");
+    expect(cells.elapsed).toBe("1h0m");
+  });
+
+  it("renders a genuine zero as a zero", () => {
+    const cells = renderRedskilledDashboard(
+      payloadOf([worker()], { "w-1": display({ tokens: 0, added: 0, removed: 0 }) }),
+      LOCAL,
+    ).rows[0]!.cells;
+    expect(cells.tks).toBe("tks=0");
+    expect(cells.loc).toBe("loc=0");
+  });
+});
+
+describe("the pipeline bar is two integers, not a vocabulary", () => {
+  it("draws completed cells, one cursor, and the rest ahead", () => {
+    expect(progressBar(display({ phase_index: 2, phase_total: 6 }))).toBe("██▶░░░");
+  });
+
+  it("marks a failed Worker's cursor without moving it", () => {
+    expect(progressBar(display({ phase_index: 2, phase_total: 6, failed: true }))).toBe("██✗░░░");
+  });
+
+  it("fills the bar at the end of the pipeline", () => {
+    expect(progressBar(display({ phase_index: 6, phase_total: 6 }))).toBe("██████");
+  });
+
+  it("draws no bar at all when the project published no position", () => {
+    expect(progressBar(REDSKILLED_WORKER_DISPLAY_ABSENT)).toBe("");
+  });
+});
+
+describe("the published display record is stored and never interpreted", () => {
+  it("keeps a recognisable field and nulls one it cannot read, rather than failing the record", () => {
+    const coerced = coerceWorkerDisplay({ runner: "codex", tokens: "many", issue: 17, phase_index: 3 });
+    expect(coerced).not.toBeNull();
+    expect(coerced!.runner).toBe("codex");
+    expect(coerced!.tokens).toBeNull();
+    // A number where a string was promised is not a string; the daemon says so
+    // rather than stringifying it, because coercing content is reading it.
+    expect(coerced!.issue).toBeNull();
+    expect(coerced!.phase_index).toBe(3);
+  });
+
+  it("refuses a value that is not a record at all", () => {
+    expect(coerceWorkerDisplay("coding")).toBeNull();
+    expect(coerceWorkerDisplay(null)).toBeNull();
+    expect(coerceWorkerDisplay([1, 2])).toBeNull();
+  });
+
+  it("clamps on the publisher's side, so a runaway value never makes a heartbeat expensive", () => {
+    const clamped = clampPublishedWorkerDisplay(display({ step: "x".repeat(500) }));
+    expect(clamped.step).toHaveLength(REDSKILLED_DISPLAY_FIELD_MAX);
+  });
+});
+
+describe("the daemon serves the dashboard it renders", () => {
+  it("answers statusline-dashboard with the same document a direct render produces", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({ paths, daemonVersion: "0.1.0", idleExitMs: 0 });
+    running.push(daemon);
+
+    const dashboard = await readRedskilledDashboard(paths, { mode: "global" });
+    expect(isRedskilledDashboard(dashboard)).toBe(true);
+    expect(dashboard.version).toBe(1);
+    expect(dashboard.mode).toBe("global");
+    expect(dashboard.lines[0]).toBe(dashboard.header.line);
+    expect(dashboard.header.version).toBe("0.1.0");
+  });
+
+  it("reports no such Worker rather than storing a display record for one it does not hold", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({ paths, daemonVersion: "0.1.0", idleExitMs: 0 });
+    running.push(daemon);
+
+    const ack = await publishRedskilledWorkerLogLine(paths, {
+      worker_id: "ghost",
+      line: "still here",
+      display: display(),
+    });
+    expect(ack.accepted).toBe(false);
+
+    const dashboard = await readRedskilledDashboard(paths, { mode: "global" });
+    expect(dashboard.rows).toHaveLength(0);
+  });
+});

--- a/apps/redskilled/tests/statusline-dashboard.test.ts
+++ b/apps/redskilled/tests/statusline-dashboard.test.ts
@@ -279,7 +279,14 @@ describe("the published display record is stored and never interpreted", () => {
 describe("the daemon serves the dashboard it renders", () => {
   it("answers statusline-dashboard with the same document a direct render produces", async () => {
     const paths = await sessionPaths();
-    const daemon = await startRedskilledDaemon({ paths, daemonVersion: "0.1.0", idleExitMs: 0 });
+    const daemon = await startRedskilledDaemon({
+      paths,
+      daemonVersion: "0.1.0",
+      idleMs: 60_000,
+      sampleMs: 0,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      stopWorker: () => true,
+    });
     running.push(daemon);
 
     const dashboard = await readRedskilledDashboard(paths, { mode: "global" });
@@ -292,7 +299,14 @@ describe("the daemon serves the dashboard it renders", () => {
 
   it("reports no such Worker rather than storing a display record for one it does not hold", async () => {
     const paths = await sessionPaths();
-    const daemon = await startRedskilledDaemon({ paths, daemonVersion: "0.1.0", idleExitMs: 0 });
+    const daemon = await startRedskilledDaemon({
+      paths,
+      daemonVersion: "0.1.0",
+      idleMs: 60_000,
+      sampleMs: 0,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      stopWorker: () => true,
+    });
     running.push(daemon);
 
     const ack = await publishRedskilledWorkerLogLine(paths, {

--- a/apps/redskilled/tests/statusline-string.test.ts
+++ b/apps/redskilled/tests/statusline-string.test.ts
@@ -304,10 +304,12 @@ describe("the statusline config block", () => {
 });
 
 describe("one renderer, machine-wide", () => {
-  // Sources that may legitimately touch the payload: the renderer itself, the
-  // daemon that serves both surfaces, the wire contract, the client, and tests.
+  // Sources that may legitimately touch the payload: the renderers themselves —
+  // the line and the table are both the DAEMON's, which is the whole point — the
+  // daemon that serves them, the wire contract, the client, and tests.
   const PAYLOAD_CONSUMERS = new Set([
     "apps/redskilled/src/statusline-render.ts",
+    "apps/redskilled/src/dashboard-render.ts",
     "apps/redskilled/src/statusline-payload.ts",
     "apps/redskilled/src/daemon.ts",
     "apps/redskilled/src/protocol.ts",

--- a/apps/vscode-extension-red-skills/README.md
+++ b/apps/vscode-extension-red-skills/README.md
@@ -1,13 +1,15 @@
 # vscode-extension-red-skills
 
 A VSCode extension that connects to the `redskilled` host daemon (ADR 0130) and
-surfaces its state inside the editor: the live Workers with their vitals, a
+surfaces its state inside the editor: a status-bar statusline, a dashboard panel
+carrying the same header and Worker rows, the live Workers with their vitals, a
 per-Worker log panel, the host event lane, the open pull requests of every
 registered project, and a notification whenever any of it changes.
 
 **It reads and never writes.** ADR 0130 rule 9 makes reach asymmetric — a session
 reads the whole host and writes only its own project — so the extension sends
-`ping`, `host-state` and `statusline-payload`, and nothing else. It also never
+`ping`, `host-state`, `statusline-payload` and `statusline-dashboard`, and
+nothing else. It also never
 starts the daemon: `redskilled provision` and the dev bundle own auto-spawn, and
 a tree view restoring with a window must not be what births a machine-wide
 singleton. An absent daemon is reported as absent.
@@ -20,6 +22,15 @@ singleton. An absent daemon is reported as absent.
 | **Host events** | the TOONL event lane beside the socket | What *happened* — births, deaths with their exit status, budget kills, the daemon's own stop |
 | **Pull requests** | `statusline-payload` | Each registered project's open PR and issue counts, as the host polled them |
 | **Worker log** | the Worker's own `log_path` | The tail of one Worker's log, following it as it grows |
+| **Status bar** | `statusline-dashboard` | The daemon's own header line: repo, version, model, slots, memory, prs/cpr/iss |
+| **Dashboard panel** | `statusline-dashboard` | The same header plus one row per Worker — runner/model/effort, origin, issue, the pipeline bar, phase·step, elapsed, heartbeat, loc, tokens, tools, reasoning, text |
+
+**THE DAEMON AGGREGATES AND RENDERS; SURFACES PRINT.** The header line and every
+Worker row arrive finished from `statusline-dashboard`; nothing here recomputes a
+cell. ADR 0130 rule 10 keeps that answer a pure function of the payload precisely
+so no surface reimplements it — an editor panel and a herdr pane each doing their
+own Worker math would be two dashboards lying in two different ways about the
+same instant.
 
 The socket answers "what is running NOW" and the lane answers "what happened".
 Both are read every tick, because a view holding only one of them can always be
@@ -94,6 +105,7 @@ src/
 ├── config.ts             the settings block, read into plain values
 ├── model/
 │   ├── snapshot.ts       one read of everything, as a total answer
+│   ├── dashboard-view.ts what the status bar says and the panel shows
 │   ├── nodes.ts          what the three trees show, as plain values
 │   ├── log-follow.ts     which lines of a re-read tail are new
 │   └── format.ts         the handful of numbers a row shows
@@ -105,7 +117,7 @@ src/
 ├── watch/
 │   ├── signals.ts        what changed, as things worth interrupting for
 │   └── watcher.ts        the poll loop, with the editor kept outside
-├── views/                TreeDataProvider and the log output channel
+├── views/                TreeDataProvider, the log channel, the status bar, the dashboard panel
 └── packaging/vsix.ts     the installable archive
 ```
 

--- a/apps/vscode-extension-red-skills/package.json
+++ b/apps/vscode-extension-red-skills/package.json
@@ -65,6 +65,11 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "redskilled.showDashboard",
+        "title": "redskilled: Show the dashboard",
+        "icon": "$(dashboard)"
+      },
+      {
         "command": "redskilled.showWorkerLog",
         "title": "redskilled: Show this Worker's log"
       },
@@ -79,6 +84,11 @@
     ],
     "menus": {
       "view/title": [
+        {
+          "command": "redskilled.showDashboard",
+          "when": "view == redskilled.workers",
+          "group": "navigation"
+        },
         {
           "command": "redskilled.refresh",
           "when": "view == redskilled.workers",

--- a/apps/vscode-extension-red-skills/src/extension.ts
+++ b/apps/vscode-extension-red-skills/src/extension.ts
@@ -19,6 +19,8 @@ import { readHostSnapshot, type HostSnapshot } from "./model/snapshot.js";
 import { createRedskilledReadClient } from "./redskilled/client.js";
 import { resolveExtensionPaths } from "./redskilled/paths.js";
 import { RedskilledTreeProvider } from "./views/tree.js";
+import { RedskilledDashboardPanel } from "./views/dashboard-panel.js";
+import { RedskilledStatusBar } from "./views/status-bar.js";
 import { WorkerLogPanel } from "./views/log-panel.js";
 import { createWatcher } from "./watch/watcher.js";
 import type { Signal } from "./watch/signals.js";
@@ -33,6 +35,11 @@ export function activate(context: vscode.ExtensionContext): void {
   const events = new RedskilledTreeProvider(buildEventsTree);
   const pullRequests = new RedskilledTreeProvider(buildPullRequestsTree);
   const logPanel = new WorkerLogPanel();
+  // The statusline and its table, both fed by the aggregate the DAEMON renders.
+  // Neither recomputes a cell: a panel doing its own Worker math would describe a
+  // different machine than the herdr pane beside it (ADR 0130 rule 10).
+  const statusBar = new RedskilledStatusBar();
+  const dashboardPanel = new RedskilledDashboardPanel();
 
   const watcher = createWatcher({
     read: async (): Promise<HostSnapshot> =>
@@ -47,6 +54,8 @@ export function activate(context: vscode.ExtensionContext): void {
       workers.update(snapshot);
       events.update(snapshot);
       pullRequests.update(snapshot);
+      statusBar.update(snapshot);
+      dashboardPanel.update(snapshot);
       const following = logPanel.following();
       if (following !== null) void logPanel.refresh(following);
     },
@@ -76,11 +85,20 @@ export function activate(context: vscode.ExtensionContext): void {
     events,
     pullRequests,
     logPanel,
+    statusBar,
+    dashboardPanel,
     new vscode.Disposable(() => {
       disposed = true;
       if (timer) clearTimeout(timer);
     }),
     vscode.commands.registerCommand("redskilled.refresh", () => watcher.tick()),
+    vscode.commands.registerCommand("redskilled.showDashboard", async () => {
+      dashboardPanel.show();
+      // Opened, then read: the panel draws the last frame immediately and the
+      // fresh one a moment later, rather than showing an empty body until the
+      // poll interval comes round.
+      await watcher.tick();
+    }),
     vscode.commands.registerCommand("redskilled.showWorkerLog", async (node?: ViewNode) => {
       if (!node?.workerId) return;
       await logPanel.show(node.workerId, node.logPath ?? null);

--- a/apps/vscode-extension-red-skills/src/model/dashboard-view.ts
+++ b/apps/vscode-extension-red-skills/src/model/dashboard-view.ts
@@ -1,0 +1,150 @@
+/**
+ * dashboard-view — what the status bar says and what the panel shows. PURE.
+ *
+ * **Every fact here was computed by the daemon.** The header line, the Worker
+ * rows, the pipeline bars and the counts arrive finished from
+ * `statusline-dashboard`; this module decides only where the text goes and how it
+ * is escaped for a webview. That is the rule the statusline pair was built on
+ * (ADR 0130 rule 10): an editor panel and a herdr pane each doing their own
+ * Worker math would be two dashboards lying in two different ways about the same
+ * instant.
+ *
+ * Editor-free on purpose, so the whole of what a reader SEES is asserted by a
+ * test that never opens a window. `views/status-bar.ts` and
+ * `views/dashboard-panel.ts` hold the `vscode` imports and nothing else.
+ */
+import type { RedskilledDashboard } from "@reddb-io/redskilled/protocol";
+import type { HostSnapshot } from "./snapshot.js";
+
+/** What one status-bar item says, in the three parts the editor asks for. */
+export interface StatusBarView {
+  readonly text: string;
+  readonly tooltip: string;
+  /** True when the item should be drawn in the editor's warning colour. */
+  readonly warning: boolean;
+}
+
+/** The text an unreachable host puts in the status bar — an outage, not an idle machine. */
+export const STATUS_BAR_ABSENCE = "$(circle-slash) redskilled unreachable";
+
+/**
+ * The status bar's one line: the daemon's header, and nothing added to it. PURE.
+ *
+ * The header is used verbatim because it is already the summary — the dashboard
+ * renderer builds it to stand alone, for exactly this place. A status bar that
+ * assembled its own from the payload would be the second renderer whose drift
+ * from the first nobody notices for weeks.
+ */
+export function statusBarView(snapshot: HostSnapshot): StatusBarView {
+  if (!snapshot.reachable) {
+    return {
+      text: STATUS_BAR_ABSENCE,
+      tooltip: `redskilled did not answer at ${snapshot.socketPath} (${snapshot.source}): ${
+        snapshot.error?.message ?? "no reason given"
+      }`,
+      warning: true,
+    };
+  }
+  if (snapshot.dashboard === null) {
+    return {
+      text: "$(server) redskilled",
+      tooltip:
+        "This daemon does not serve statusline-dashboard. It answers the Worker set, and the dashboard is rendered by the daemon rather than here, so there is nothing to draw until it does.",
+      warning: false,
+    };
+  }
+  const header = snapshot.dashboard.header;
+  return {
+    text: `${snapshot.dashboard.stale ? "$(warning)" : "$(server)"} ${header.line}`,
+    tooltip: snapshot.dashboard.lines.join("\n"),
+    warning: snapshot.dashboard.stale,
+  };
+}
+
+/** HTML-escape one line of daemon-rendered text. PURE. */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * The panel's body: the daemon's own lines, in a monospaced block. PURE.
+ *
+ * A `<pre>` rather than a `<table>` deliberately. The rows arrive column-aligned
+ * because the daemon aligned them, and a table would hand that decision to the
+ * browser — at which point the panel and the pane beside it would space the same
+ * Worker set two different ways, and the alignment the daemon paid for would be
+ * dead weight on the wire.
+ */
+export function renderDashboardHtml(snapshot: HostSnapshot): string {
+  const body = dashboardBody(snapshot);
+  return [
+    "<!DOCTYPE html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charset="UTF-8">',
+    '<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src \'unsafe-inline\';">',
+    "<style>",
+    "body { font-family: var(--vscode-editor-font-family, monospace); color: var(--vscode-foreground); padding: 0.5rem; }",
+    "pre { font-family: var(--vscode-editor-font-family, monospace); font-size: var(--vscode-editor-font-size, 12px); margin: 0; white-space: pre; overflow-x: auto; }",
+    ".header { font-weight: 600; }",
+    ".stale { color: var(--vscode-editorWarning-foreground); }",
+    ".absence { color: var(--vscode-descriptionForeground); }",
+    "</style>",
+    "</head>",
+    "<body>",
+    body,
+    "</body>",
+    "</html>",
+  ].join("\n");
+}
+
+function dashboardBody(snapshot: HostSnapshot): string {
+  if (!snapshot.reachable) {
+    return [
+      '<p class="absence">',
+      escapeHtml(`redskilled did not answer at ${snapshot.socketPath} (${snapshot.source}).`),
+      "</p>",
+      '<p class="absence">',
+      escapeHtml(snapshot.error?.message ?? "the daemon did not answer"),
+      "</p>",
+      '<p class="absence">',
+      escapeHtml(
+        "An empty host must mean an idle machine, never a failed lookup — so this panel refuses to draw a table it did not read. Bring one up with `redskilled provision`.",
+      ),
+      "</p>",
+    ].join("\n");
+  }
+  const dashboard = snapshot.dashboard;
+  if (dashboard === null) {
+    return [
+      '<p class="absence">',
+      escapeHtml(
+        "This daemon does not serve statusline-dashboard. The dashboard is rendered by the daemon rather than here, so there is nothing to draw until it does.",
+      ),
+      "</p>",
+    ].join("\n");
+  }
+  return [
+    `<pre class="header${dashboard.stale ? " stale" : ""}">${escapeHtml(dashboard.header.line)}</pre>`,
+    ...(dashboard.rows.length === 0
+      ? [
+          '<pre class="absence">no Workers here — the machine is idle, and this is the daemon saying so</pre>',
+        ]
+      : [`<pre>${dashboardRows(dashboard).map(escapeHtml).join("\n")}</pre>`]),
+  ].join("\n");
+}
+
+/**
+ * Every line below the header, exactly as the daemon rendered them. PURE.
+ *
+ * Taken from `lines` rather than rebuilt from `rows`, so a trailing line the
+ * daemon added — "… 3 more Worker(s)" — reaches the reader instead of being
+ * dropped by a panel that only knew about Workers.
+ */
+export function dashboardRows(dashboard: RedskilledDashboard): readonly string[] {
+  return dashboard.lines.slice(1);
+}

--- a/apps/vscode-extension-red-skills/src/model/snapshot.ts
+++ b/apps/vscode-extension-red-skills/src/model/snapshot.ts
@@ -10,6 +10,7 @@
  * holding only one of the two can always be asked a question it cannot answer.
  */
 import type {
+  RedskilledDashboard,
   RedskilledHostState,
   RedskilledStatuslinePayload,
 } from "@reddb-io/redskilled/protocol";
@@ -35,6 +36,15 @@ export interface HostSnapshot {
    * usable frame instead of an outage.
    */
   readonly hostState: RedskilledHostState | null;
+  /**
+   * The dashboard the daemon rendered for this frame, or `null`.
+   *
+   * Read beside the payload rather than derived from it: THE DAEMON AGGREGATES
+   * AND RENDERS; SURFACES PRINT. Null does NOT imply unreachable — a daemon too
+   * old to serve the op still yields a usable frame for the trees, and the
+   * dashboard panel says so rather than drawing a table nobody rendered.
+   */
+  readonly dashboard: RedskilledDashboard | null;
   readonly lane: EventLaneRead;
   readonly error: SnapshotFailure | null;
   readonly readAt: string;
@@ -45,6 +55,8 @@ export interface ReadSnapshotOptions {
   readonly eventLanePath: string;
   readonly source: string;
   readonly sessionProject?: string;
+  /** The size the panel has, stated on the request so the daemon renders to it. */
+  readonly dashboardRender?: { readonly maxWidth?: number; readonly maxRows?: number };
   readonly now?: () => string;
 }
 
@@ -61,9 +73,20 @@ export async function readHostSnapshot(options: ReadSnapshotOptions): Promise<Ho
   const lane = await readEventLane(options.eventLanePath).catch(() => EMPTY_LANE(options.eventLanePath));
 
   try {
-    const [payload, hostState] = await Promise.all([
+    const [payload, hostState, dashboard] = await Promise.all([
       options.client.statuslinePayload(options.sessionProject),
       options.client.hostState().catch(() => null),
+      options.client
+        .dashboard(options.sessionProject, {
+          mode: options.sessionProject ? "local" : "global",
+          ...(options.sessionProject ? { project: options.sessionProject } : {}),
+          ...(options.dashboardRender?.maxWidth == null ? {} : { max_width: options.dashboardRender.maxWidth }),
+          ...(options.dashboardRender?.maxRows == null ? {} : { max_rows: options.dashboardRender.maxRows }),
+        })
+        // Best-effort beside the payload, for the reason `host-state` is: a
+        // daemon that serves one and refuses the other still yields a usable
+        // frame instead of an outage.
+        .catch(() => null),
     ]);
     return {
       reachable: true,
@@ -71,6 +94,7 @@ export async function readHostSnapshot(options: ReadSnapshotOptions): Promise<Ho
       source: options.source,
       payload,
       hostState,
+      dashboard,
       lane,
       error: null,
       readAt: now(),
@@ -82,6 +106,7 @@ export async function readHostSnapshot(options: ReadSnapshotOptions): Promise<Ho
       source: options.source,
       payload: null,
       hostState: null,
+      dashboard: null,
       lane,
       error: {
         name: error instanceof Error ? error.name : "Error",

--- a/apps/vscode-extension-red-skills/src/redskilled/client.ts
+++ b/apps/vscode-extension-red-skills/src/redskilled/client.ts
@@ -1,8 +1,9 @@
 /**
  * client — the extension's READ half of the `redskilled` wire.
  *
- * **Read-only, and deliberately.** It sends `ping`, `host-state` and
- * `statusline-payload`, and it never sends `worker-start`, `worker-command`,
+ * **Read-only, and deliberately.** It sends `ping`, `host-state`,
+ * `statusline-payload` and `statusline-dashboard`, and it never sends
+ * `worker-start`, `worker-command`,
  * `project-register` or `shutdown`. ADR 0130 rule 9 makes reach asymmetric — a
  * session reads the whole host and writes only its own project — and an editor
  * panel has no business on the writing half: a view that could stop another
@@ -25,13 +26,15 @@
  */
 import { sendLineRequest } from "@reddb-io/shared/resident-core.js";
 import type {
+  RedskilledDashboard,
+  RedskilledDashboardRenderRequest,
   RedskilledHostState,
   RedskilledPong,
   RedskilledRequest,
   RedskilledResponse,
   RedskilledStatuslinePayload,
 } from "@reddb-io/redskilled/protocol";
-import { isRedskilledStatuslinePayload } from "@reddb-io/redskilled/protocol";
+import { isRedskilledDashboard, isRedskilledStatuslinePayload } from "@reddb-io/redskilled/protocol";
 import { isRedskilledHostState } from "@reddb-io/redskilled/host-state";
 
 /** Raised when nothing answered — never confused with "the host is idle". */
@@ -61,6 +64,19 @@ export interface RedskilledReadClient {
   ping(): Promise<RedskilledPong>;
   hostState(): Promise<RedskilledHostState>;
   statuslinePayload(sessionProject?: string): Promise<RedskilledStatuslinePayload>;
+  /**
+   * The dashboard: the same read again, already laid out as a table.
+   *
+   * The extension PRINTS what comes back and computes no cell of it. The daemon
+   * is the only process holding the Worker set across projects, so a panel doing
+   * its own Worker math would be a second authority on a question one document
+   * already answers — and an editor panel and a terminal pane would describe two
+   * different machines (ADR 0130 rule 10).
+   */
+  dashboard(
+    sessionProject?: string,
+    render?: RedskilledDashboardRenderRequest,
+  ): Promise<RedskilledDashboard>;
 }
 
 export interface CreateReadClientOptions {
@@ -127,6 +143,21 @@ export function createRedskilledReadClient(options: CreateReadClientOptions): Re
         throw new RedskilledRefusedError(
           "the daemon answered statusline-payload with a shape this view cannot read",
           "statusline-payload",
+        );
+      }
+      return value;
+    },
+    async dashboard(sessionProject?: string, render?: RedskilledDashboardRenderRequest) {
+      const value = await call({
+        id: nextRequestId("statusline-dashboard"),
+        op: "statusline-dashboard",
+        ...(sessionProject ? { session_project: sessionProject } : {}),
+        ...(render ? { dashboard: render } : {}),
+      });
+      if (!isRedskilledDashboard(value)) {
+        throw new RedskilledRefusedError(
+          "the daemon answered statusline-dashboard with a shape this view cannot read",
+          "statusline-dashboard",
         );
       }
       return value;

--- a/apps/vscode-extension-red-skills/src/views/dashboard-panel.ts
+++ b/apps/vscode-extension-red-skills/src/views/dashboard-panel.ts
@@ -1,0 +1,61 @@
+/**
+ * dashboard-panel — the Worker rows, in a panel that refreshes with the daemon.
+ *
+ * ONE panel, created on demand and disposed with the window that closes it. It
+ * re-renders on every frame the watcher delivers, so a state change in the daemon
+ * reaches the reader without a command, a click, or a second read.
+ *
+ * What it shows is decided entirely by `model/dashboard-view.ts`, which is pure
+ * and reads a document the DAEMON rendered. This file owns the webview lifetime
+ * and nothing else — there is no cell here to get wrong.
+ */
+import * as vscode from "vscode";
+import { renderDashboardHtml } from "../model/dashboard-view.js";
+import type { HostSnapshot } from "../model/snapshot.js";
+
+const VIEW_TYPE = "redskilled.dashboard";
+
+export class RedskilledDashboardPanel {
+  private panel: vscode.WebviewPanel | null = null;
+  private snapshot: HostSnapshot | null = null;
+
+  /** Reveal the panel, creating it on the first call. */
+  show(): void {
+    if (this.panel === null) {
+      this.panel = vscode.window.createWebviewPanel(VIEW_TYPE, "redskilled — dashboard", vscode.ViewColumn.Active, {
+        // Nothing here runs a script or reads a file: the body is text the daemon
+        // rendered, escaped once. A webview that could do more would be a control
+        // surface wearing a monitor's name (ADR 0130 rule 9).
+        enableScripts: false,
+        retainContextWhenHidden: true,
+      });
+      this.panel.onDidDispose(() => {
+        this.panel = null;
+      });
+      this.paint();
+      return;
+    }
+    this.panel.reveal(undefined, true);
+  }
+
+  /** True while a panel is open — the poll loop skips the render otherwise. */
+  open(): boolean {
+    return this.panel !== null;
+  }
+
+  /** Hand the panel a new frame. Silent when nothing is open to draw on. */
+  update(snapshot: HostSnapshot): void {
+    this.snapshot = snapshot;
+    if (this.panel !== null) this.paint();
+  }
+
+  dispose(): void {
+    this.panel?.dispose();
+    this.panel = null;
+  }
+
+  private paint(): void {
+    if (this.panel === null || this.snapshot === null) return;
+    this.panel.webview.html = renderDashboardHtml(this.snapshot);
+  }
+}

--- a/apps/vscode-extension-red-skills/src/views/status-bar.ts
+++ b/apps/vscode-extension-red-skills/src/views/status-bar.ts
@@ -1,0 +1,40 @@
+/**
+ * status-bar — the statusline, in the one place an editor already keeps one.
+ *
+ * It has one job: put the daemon's header line where the operator can see it
+ * without opening anything. Every question about WHAT the line says was already
+ * answered in `model/dashboard-view.ts` by a pure function reading a document the
+ * daemon rendered, so this file holds no layout logic to test and no branch a
+ * test would have to open a window to reach.
+ */
+import * as vscode from "vscode";
+import { statusBarView } from "../model/dashboard-view.js";
+import type { HostSnapshot } from "../model/snapshot.js";
+
+export class RedskilledStatusBar {
+  private readonly item: vscode.StatusBarItem;
+
+  constructor(item?: vscode.StatusBarItem) {
+    this.item =
+      item ?? vscode.window.createStatusBarItem("redskilled.statusline", vscode.StatusBarAlignment.Left, 100);
+    this.item.name = "redskilled";
+    this.item.command = "redskilled.showDashboard";
+    this.item.show();
+  }
+
+  /** Hand the bar a new frame; it re-reads the daemon's own summary from it. */
+  update(snapshot: HostSnapshot): void {
+    const view = statusBarView(snapshot);
+    this.item.text = view.text;
+    this.item.tooltip = view.tooltip;
+    // Only a warning is coloured. A background on every healthy frame would make
+    // the one frame that matters look like all the others.
+    this.item.backgroundColor = view.warning
+      ? new vscode.ThemeColor("statusBarItem.warningBackground")
+      : undefined;
+  }
+
+  dispose(): void {
+    this.item.dispose();
+  }
+}

--- a/apps/vscode-extension-red-skills/tests/dashboard.test.ts
+++ b/apps/vscode-extension-red-skills/tests/dashboard.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The dashboard is the one view whose correctness is NOT this extension's to
+ * prove. Every cell arrives finished from `statusline-dashboard`, so what these
+ * assert is the only thing a surface can get wrong: that it shows what it was
+ * handed, that it re-derives nothing, that a state change in the daemon reaches
+ * both surfaces, and that an absence is drawn as an absence.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  dashboardRows,
+  escapeHtml,
+  renderDashboardHtml,
+  statusBarView,
+  STATUS_BAR_ABSENCE,
+} from "../src/model/dashboard-view.js";
+import { readHostSnapshot, type HostSnapshot } from "../src/model/snapshot.js";
+import { createRedskilledReadClient } from "../src/redskilled/client.js";
+import { startFakeDaemon, type FakeDaemon } from "./fake-daemon.js";
+import { dashboard, hostState, statuslinePayload } from "./fixtures.js";
+
+const daemons: FakeDaemon[] = [];
+
+afterEach(async () => {
+  for (const daemon of daemons.splice(0)) await daemon.stop();
+});
+
+async function fake(options: Parameters<typeof startFakeDaemon>[0] = {}): Promise<FakeDaemon> {
+  const daemon = await startFakeDaemon(options);
+  daemons.push(daemon);
+  return daemon;
+}
+
+function snapshotOf(overrides: Partial<HostSnapshot> = {}): HostSnapshot {
+  return {
+    reachable: true,
+    socketPath: "/tmp/rsk/d.sock",
+    source: "derived from XDG_RUNTIME_DIR",
+    payload: statuslinePayload(),
+    hostState: hostState(),
+    dashboard: dashboard(),
+    lane: { path: "/tmp/rsk/lane.toonl", exists: true, truncated: false, events: [] },
+    error: null,
+    readAt: "2026-08-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("the status bar shows the daemon's own summary", () => {
+  it("puts the header line in the bar verbatim, and the whole render in the tooltip", () => {
+    const view = statusBarView(snapshotOf());
+    expect(view.text).toContain("» reddb-io/red-skills v0.4.1");
+    expect(view.text).toContain("prs=3");
+    expect(view.text).toContain("iss=24");
+    expect(view.warning).toBe(false);
+    expect(view.tooltip).toContain("iss=3012");
+  });
+
+  it("warns on a stale frame and says so in the bar, not only in the tooltip", () => {
+    const view = statusBarView(snapshotOf({ dashboard: dashboard({ stale: true }) }));
+    expect(view.warning).toBe(true);
+    expect(view.text).toContain("$(warning)");
+  });
+
+  it("reports an unreachable daemon as an outage, never as an idle machine", () => {
+    const view = statusBarView(
+      snapshotOf({
+        reachable: false,
+        payload: null,
+        hostState: null,
+        dashboard: null,
+        error: { name: "RedskilledUnreachableError", message: "not reachable" },
+      }),
+    );
+    expect(view.text).toBe(STATUS_BAR_ABSENCE);
+    expect(view.warning).toBe(true);
+    expect(view.tooltip).toContain("not reachable");
+  });
+
+  it("says a daemon predating the op has nothing to draw, rather than drawing zeros", () => {
+    const view = statusBarView(snapshotOf({ dashboard: null }));
+    expect(view.warning).toBe(false);
+    expect(view.text).not.toContain("wrk=");
+    expect(view.tooltip).toContain("statusline-dashboard");
+  });
+});
+
+describe("the dashboard panel shows the rows the daemon rendered", () => {
+  it("carries every statusline field into the body", () => {
+    const html = renderDashboardHtml(snapshotOf());
+    for (const cell of [
+      "run=claude opus high",
+      "org=afk",
+      "iss=3012",
+      "██▶░░░",
+      "coding·impl",
+      "1h0m",
+      "hb=3s",
+      "loc=+142 -36",
+      "tks=45k",
+      "tls=12",
+      "rsn=4",
+      "txt=9",
+    ]) {
+      expect(html).toContain(cell);
+    }
+  });
+
+  it("keeps a trailing line the daemon added, like the row budget's own", () => {
+    const board = dashboard();
+    const withMore = dashboard({
+      lines: [...board.lines, "… 3 more Worker(s) — the row budget is short, not the host"],
+      hidden_row_count: 3,
+    });
+    expect(dashboardRows(withMore).at(-1)).toContain("3 more Worker(s)");
+    expect(renderDashboardHtml(snapshotOf({ dashboard: withMore }))).toContain("3 more Worker(s)");
+  });
+
+  it("escapes what the daemon rendered rather than trusting it as markup", () => {
+    expect(escapeHtml('<script>&"')).toBe("&lt;script&gt;&amp;&quot;");
+    const html = renderDashboardHtml(
+      snapshotOf({ dashboard: dashboard({ lines: ["<script>alert(1)</script>"], rows: [] }) }),
+    );
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  it("draws an absence when nothing answered, never a table of zeros", () => {
+    const html = renderDashboardHtml(
+      snapshotOf({
+        reachable: false,
+        payload: null,
+        dashboard: null,
+        error: { name: "RedskilledUnreachableError", message: "not reachable" },
+      }),
+    );
+    expect(html).toContain("redskilled provision");
+    expect(html).not.toContain("wrk=");
+  });
+
+  it("says the host is idle when the daemon renders no rows", () => {
+    const html = renderDashboardHtml(snapshotOf({ dashboard: dashboard({ rows: [], lines: ["» host v0.4.1"] }) }));
+    expect(html).toContain("the machine is idle, and this is the daemon saying so");
+  });
+});
+
+describe("the frame is read from the daemon, not derived from the payload", () => {
+  it("asks statusline-dashboard beside the payload and states the size it has", async () => {
+    const daemon = await fake();
+    const snapshot = await readHostSnapshot({
+      client: createRedskilledReadClient({ socketPath: daemon.socketPath }),
+      eventLanePath: daemon.eventLanePath,
+      source: "the test pinned it",
+      sessionProject: "reddb-io/red-skills",
+      dashboardRender: { maxWidth: 118, maxRows: 9 },
+    });
+
+    expect(snapshot.reachable).toBe(true);
+    expect(daemon.served.get("statusline-dashboard")).toBe(1);
+    expect(snapshot.dashboard?.header.line).toContain("» reddb-io/red-skills");
+    // The rows are the daemon's own, verbatim: nothing in this extension built
+    // one, so a field the daemon stops rendering vanishes here too.
+    expect(snapshot.dashboard?.rows[0]?.cells.bar).toBe("██▶░░░");
+  });
+
+  it("keeps the trees usable when a daemon refuses the op", async () => {
+    const daemon = await fake({ refuse: ["statusline-dashboard"] });
+    const snapshot = await readHostSnapshot({
+      client: createRedskilledReadClient({ socketPath: daemon.socketPath }),
+      eventLanePath: daemon.eventLanePath,
+      source: "the test pinned it",
+    });
+
+    expect(snapshot.reachable).toBe(true);
+    expect(snapshot.payload).not.toBeNull();
+    expect(snapshot.dashboard).toBeNull();
+  });
+
+  it("reflects a state change in the daemon without local re-derivation", async () => {
+    let stale = false;
+    const daemon = await fake({ dashboard: () => dashboard({ stale, rows: stale ? [] : dashboard().rows }) });
+    const client = createRedskilledReadClient({ socketPath: daemon.socketPath });
+    const read = async (): Promise<HostSnapshot> =>
+      await readHostSnapshot({ client, eventLanePath: daemon.eventLanePath, source: "the test pinned it" });
+
+    const before = statusBarView(await read());
+    expect(before.warning).toBe(false);
+
+    stale = true;
+    const after = await read();
+    expect(statusBarView(after).warning).toBe(true);
+    expect(renderDashboardHtml(after)).toContain("the machine is idle");
+  });
+});

--- a/apps/vscode-extension-red-skills/tests/fake-daemon.ts
+++ b/apps/vscode-extension-red-skills/tests/fake-daemon.ts
@@ -25,11 +25,13 @@ import {
   type RedskilledEventLane,
 } from "@reddb-io/redskilled/event-lane";
 import type { RedskilledRequest, RedskilledResponse } from "@reddb-io/redskilled/protocol";
-import { hostState, statuslinePayload } from "./fixtures.js";
+import { dashboard, hostState, statuslinePayload } from "./fixtures.js";
 
 export interface FakeDaemonOptions {
   /** What `statusline-payload` answers; re-read on every request. */
   readonly payload?: () => unknown;
+  /** What `statusline-dashboard` answers; re-read on every request. */
+  readonly dashboard?: () => unknown;
   /** What `host-state` answers; `null` refuses the op. */
   readonly hostState?: () => unknown | null;
   /** Ops named here are refused with the daemon's own error shape. */
@@ -77,6 +79,8 @@ export async function startFakeDaemon(options: FakeDaemonOptions = {}): Promise<
       }
       case "statusline-payload":
         return { id: request.id, ok: true, value: options.payload ? options.payload() : statuslinePayload() };
+      case "statusline-dashboard":
+        return { id: request.id, ok: true, value: options.dashboard ? options.dashboard() : dashboard() };
       default:
         return { id: request.id, ok: false, error: `this fake daemon does not serve ${request.op}` };
     }

--- a/apps/vscode-extension-red-skills/tests/fixtures.ts
+++ b/apps/vscode-extension-red-skills/tests/fixtures.ts
@@ -6,6 +6,7 @@
  * suite test a shape that no longer exists.
  */
 import type {
+  RedskilledDashboard,
   RedskilledHostState,
   RedskilledStatuslinePayload,
 } from "@reddb-io/redskilled/protocol";
@@ -209,4 +210,68 @@ export function hostState(overrides: HostStateOverrides = {}): RedskilledHostSta
       major_hold: null,
     },
   } as RedskilledHostState;
+}
+
+/**
+ * A dashboard shaped exactly as `statusline-dashboard` sends it.
+ *
+ * Every cell here is already finished — which is the point: a surface test that
+ * had to compute a cell to assert it would be testing the very re-derivation
+ * this document exists to remove.
+ */
+export function dashboard(overrides: Record<string, unknown> = {}): RedskilledDashboard {
+  const header = {
+    repo: "reddb-io/red-skills",
+    project: "reddb-io/red-skills",
+    project_match: "matched",
+    version: "0.4.1",
+    model: "claude·opus·high",
+    windows: {
+      memory_used_fraction: 0.375,
+      memory_used_bytes: 3 * 1024 ** 3,
+      memory_ceiling_bytes: 8 * 1024 ** 3,
+      worker_count: 2,
+      worker_ceiling: 6,
+    },
+    counts: { open_pull_requests: 3, recently_closed: 7, open_issues: 24, stale: false },
+    stale: false,
+    age_ms: 5_000,
+    line: "» reddb-io/red-skills v0.4.1 · claude·opus·high · wrk=1/1 · slots=1/6 · mem=3G/8G 38% · prs=3 · cpr=7 · iss=24",
+  };
+  const rows = [
+    {
+      worker_id: "wA1B2",
+      project_label: "reddb-io/red-skills",
+      mine: true,
+      cells: {
+        wid: "wA1B2",
+        run: "run=claude opus high",
+        org: "org=afk",
+        iss: "iss=3012",
+        bar: "██▶░░░",
+        phase: "coding·impl",
+        elapsed: "1h0m",
+        hb: "hb=3s",
+        loc: "loc=+142 -36",
+        tks: "tks=45k",
+        tls: "tls=12",
+        rsn: "rsn=4",
+        txt: "txt=9",
+      },
+      line: "wA1B2  run=claude opus high  org=afk  iss=3012  ██▶░░░  coding·impl  1h0m  hb=3s  loc=+142 -36  tks=45k  tls=12  rsn=4  txt=9",
+    },
+  ];
+  return {
+    version: 1,
+    generated_at: FIXED_NOW,
+    mode: "local",
+    project: "reddb-io/red-skills",
+    columns: ["wid", "run", "org", "iss", "bar", "phase", "elapsed", "hb", "loc", "tks", "tls", "rsn", "txt"],
+    header,
+    rows,
+    lines: [header.line, ...rows.map((row) => row.line)],
+    hidden_row_count: 0,
+    stale: false,
+    ...overrides,
+  } as unknown as RedskilledDashboard;
 }

--- a/apps/vscode-extension-red-skills/tests/packaging.test.ts
+++ b/apps/vscode-extension-red-skills/tests/packaging.test.ts
@@ -73,7 +73,7 @@ describe("the extension manifest", () => {
     expect(manifest.main).toBe("./out/extension.cjs");
   });
 
-  it("contributes the three views and the four read-only commands", async () => {
+  it("contributes the three views and the five read-only commands", async () => {
     const manifest = JSON.parse(await readFile(join(EXTENSION_ROOT, "package.json"), "utf8")) as {
       contributes: { views: Record<string, { id: string }[]>; commands: { command: string }[] };
     };
@@ -87,6 +87,7 @@ describe("the extension manifest", () => {
       "redskilled.copyWorkerId",
       "redskilled.refresh",
       "redskilled.revealWorkspace",
+      "redskilled.showDashboard",
       "redskilled.showWorkerLog",
     ]);
   });

--- a/apps/vscode-extension-red-skills/tests/signals.test.ts
+++ b/apps/vscode-extension-red-skills/tests/signals.test.ts
@@ -19,6 +19,7 @@ function snapshotOf(overrides: Partial<HostSnapshot> = {}): HostSnapshot {
     source: "a test",
     payload: statuslinePayload(),
     hostState: hostState(),
+    dashboard: null,
     lane: { path: "/tmp/rsk/lane.toonl", exists: true, truncated: false, events: [] },
     error: null,
     readAt: "2026-08-01T10:00:00.000Z",

--- a/apps/vscode-extension-red-skills/tests/views.test.ts
+++ b/apps/vscode-extension-red-skills/tests/views.test.ts
@@ -19,6 +19,7 @@ function snapshotOf(overrides: Partial<HostSnapshot> = {}): HostSnapshot {
     source: "derived from XDG_RUNTIME_DIR",
     payload: statuslinePayload(),
     hostState: hostState(),
+    dashboard: null,
     lane: { path: "/tmp/rsk/lane.toonl", exists: true, truncated: false, events: [] },
     error: null,
     readAt: "2026-08-01T10:00:00.000Z",


### PR DESCRIPTION
Automated AFK landing for #3012. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3012

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788200800&installation_model_id=20659&pr_number=3016&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3016&signature=4201eb5c99a421a7cbac210e435e03a704e1d5e2ba3c1032d2695c3d25785926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->