### PR TITLE
chore: #3025 The release tag is cut from the bump commit itself, and a skipped cut says so loudly

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -80,28 +80,24 @@ jobs:
           # for manual approval. The PAT identity makes required checks start.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
 
-      # No pending changesets means the Version Packages PR has already merged
-      # (or there was nothing to release). Cut the tag only when the version in
-      # the tree is genuinely new.
+      # The cut reads the version and the pending changesets out of the BUMP
+      # COMMIT the push event named, never out of the checkout: a merge racing
+      # onto main between the Version Packages PR merge and this run rewrites
+      # `.changeset/`, which made the bump look un-merged and swallowed two tags
+      # in silence (2026-08-01). Gating the step on the live
+      # `hasChangesets` output reintroduces exactly that race, so the script —
+      # not the `if:` — owns the decision, and every skip prints its reason.
       - name: Cut the release tag
         id: cut
-        if: steps.changesets.outputs.hasChangesets == 'false'
+        env:
+          BUMP_SHA: ${{ github.sha }}
+        run: scripts/release-cut-tag.sh
+
+      - name: Dispatch red-publish
+        if: steps.cut.outputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          version="$(node -p "require('./package.json').version")"
-          tag="v${version}"
-          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
-            echo "${tag} already tagged — nothing to cut"
-            exit 0
-          fi
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git tag -a "$tag" -m "Release $tag"
-          git push origin "$tag"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "::notice::cut ${tag}; dispatching red-publish"
-          # See the header: a GITHUB_TOKEN tag push cannot trigger `on: push:
-          # tags`, so start the publish workflow explicitly.
-          gh workflow run red-publish.yml --ref main -f tag="$tag"
+          TAG: ${{ steps.cut.outputs.tag }}
+        # See the header: a GITHUB_TOKEN tag push cannot trigger `on: push:
+        # tags`, so start the publish workflow explicitly.
+        run: gh workflow run red-publish.yml --ref main -f tag="$TAG"

--- a/scripts/release-cut-tag.sh
+++ b/scripts/release-cut-tag.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Cut the release tag for a merged Version Packages PR (ADR 0121).
+#
+# The tag target is the BUMP COMMIT ITSELF, carried in from the push event
+# payload as BUMP_SHA (`github.sha`) — never the working tree, never HEAD, and
+# never the live state of `.changeset/`. A merge landing between the Version
+# Packages PR merge and this run rewrites that directory, which made the bump
+# look un-merged and swallowed two tags in silence on 2026-08-01.
+#
+# Every decision NOT to cut prints a `::notice::` naming its reason: a release
+# that quietly skips reads exactly like a release that succeeded.
+
+set -euo pipefail
+
+sha="${BUMP_SHA:-}"
+remote="${RELEASE_REMOTE:-origin}"
+
+notice() { printf '::notice::%s\n' "$*"; }
+die() { printf '::error::%s\n' "$*" >&2; exit 1; }
+
+emit_output() {
+  [ -n "${GITHUB_OUTPUT:-}" ] || return 0
+  printf '%s\n' "$1" >> "$GITHUB_OUTPUT"
+}
+
+[ -n "$sha" ] ||
+  die "release cut: BUMP_SHA is empty — the push event carried no commit sha"
+
+git cat-file -e "${sha}^{commit}" 2>/dev/null ||
+  die "release cut: bump commit ${sha} is not in this checkout (the cut needs fetch-depth: 0)"
+
+sha="$(git rev-parse "${sha}^{commit}")"
+
+# Everything below is read out of the bump commit's own tree. The working tree
+# may already carry a later merge, and every answer it gives belongs to
+# somebody else's commit.
+package_json="$(git show "${sha}:package.json" 2>/dev/null)" ||
+  die "release cut: ${sha} has no package.json to read a version from"
+
+version="$(printf '%s' "$package_json" | node -e '
+  let raw = "";
+  process.stdin.on("data", (d) => { raw += d; });
+  process.stdin.on("end", () => {
+    const version = JSON.parse(raw).version;
+    if (typeof version !== "string" || version === "") process.exit(1);
+    process.stdout.write(version);
+  });
+')" || die "release cut: ${sha} carries no readable package.json version"
+
+tag="v${version}"
+
+# Pending changesets AT THE BUMP COMMIT mean the Version Packages PR has not
+# merged yet — this push is an ordinary commit, and there is nothing to cut.
+pending="$(
+  git ls-tree -r --name-only "$sha" -- .changeset |
+    { grep -E '^\.changeset/[^/]+\.md$' || true; } |
+    { grep -vE '^\.changeset/README\.md$' || true; } |
+    wc -l | tr -d '[:space:]'
+)"
+if [ "$pending" != "0" ]; then
+  notice "no cut at ${sha}: ${pending} pending changeset(s) in that commit — the Version Packages PR has not merged yet"
+  exit 0
+fi
+
+existing="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" || true)"
+if [ -n "$existing" ]; then
+  if [ "$existing" = "$sha" ]; then
+    notice "no cut at ${sha}: ${tag} already points at this bump commit — release already cut"
+  else
+    notice "no cut at ${sha}: ${tag} already exists at ${existing} — version ${version} was released from another commit"
+  fi
+  exit 0
+fi
+
+git config user.name 'github-actions[bot]'
+git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+git tag -a "$tag" -m "Release $tag" "$sha"
+git push "$remote" "refs/tags/${tag}"
+
+emit_output "tag=${tag}"
+emit_output "sha=${sha}"
+notice "cut ${tag} at ${sha}; dispatching red-publish"

--- a/scripts/test-version-sync-contract.sh
+++ b/scripts/test-version-sync-contract.sh
@@ -205,6 +205,182 @@ else
   fail "the cut must dispatch red-publish.yml explicitly"
 fi
 
+# --- the cut targets the bump commit, not the tree that raced past it -------
+
+# Two tags were swallowed on 2026-08-01: the cut read `.changeset/` and the
+# version out of the CURRENT checkout, so a merge landing between the Version
+# Packages PR merge and this run made the bump look un-merged. The tag target is
+# the bump commit the push event named, and the run is exercised here for real
+# against a repository where a later commit already moved main past it.
+
+CUT="scripts/release-cut-tag.sh"
+
+if [ -x "$ROOT/$CUT" ]; then
+  pass "the release cut is an executable script the contract can run"
+else
+  fail "$CUT must exist and be executable"
+fi
+
+# Build: commit A (1.0.0, one pending changeset) → commit B, the bump (1.1.0, no
+# changesets) → commit C, a merge racing in behind it (2.0.0 + a new changeset).
+# Reading anything from the working tree yields C's answers, and every one of
+# them is wrong.
+cut_repo="$TMP/cut"
+bump_sha=""
+race_sha=""
+if [ -x "$ROOT/$CUT" ]; then
+  (
+    set -e
+    mkdir -p "$cut_repo"
+    git init -q --bare "$cut_repo/remote.git"
+    git init -q -b main "$cut_repo/work"
+    cd "$cut_repo/work"
+    git config user.email 'contract@example.invalid'
+    git config user.name 'contract'
+    mkdir -p .changeset
+    printf 'changesets readme\n' > .changeset/README.md
+    printf '{\n  "version": "1.0.0"\n}\n' > package.json
+    printf -- '---\n"@scope/pkg": minor\n---\n\nfeature a\n' > .changeset/feature-a.md
+    git add -A && git commit -qm 'feat: a'
+    printf '{\n  "version": "1.1.0"\n}\n' > package.json
+    git rm -q .changeset/feature-a.md
+    git commit -qam 'chore(release): version packages'
+    git rev-parse HEAD > "$cut_repo/bump.sha"
+    printf '{\n  "version": "2.0.0"\n}\n' > package.json
+    printf -- '---\n"@scope/pkg": major\n---\n\nfeature b\n' > .changeset/feature-b.md
+    git add -A && git commit -qm 'feat: b (raced in behind the bump)'
+    git rev-parse HEAD > "$cut_repo/race.sha"
+    git remote add origin "$cut_repo/remote.git"
+    git push -q origin main
+  ) || fail "could not build the release-cut fixture repository"
+  bump_sha="$(cat "$cut_repo/bump.sha" 2>/dev/null || true)"
+  race_sha="$(cat "$cut_repo/race.sha" 2>/dev/null || true)"
+fi
+
+run_cut() {
+  local sha="$1" out="$2"
+  : > "$out"
+  (cd "$cut_repo/work" && BUMP_SHA="$sha" GITHUB_OUTPUT="$out" \
+    bash "$ROOT/$CUT" 2>&1)
+}
+
+if [ -n "$bump_sha" ] && [ -n "$race_sha" ]; then
+  cut_log="$TMP/cut.log"
+  cut_out="$TMP/cut.out"
+  if run_cut "$bump_sha" "$cut_out" > "$cut_log" 2>&1; then
+    pass "the cut runs green against a main that already moved past the bump"
+  else
+    fail "the cut failed against a main that moved past the bump"
+    cat "$cut_log" >&2 || true
+  fi
+
+  tagged="$(git -C "$cut_repo/work" rev-list -n1 v1.1.0 2>/dev/null || true)"
+  if [ "$tagged" = "$bump_sha" ]; then
+    pass "the tag targets the bump commit sha, not the tip that raced past it"
+  else
+    fail "the tag must target the bump commit ($bump_sha), got '${tagged:-<no tag>}'"
+  fi
+
+  if [ -z "$(git -C "$cut_repo/work" tag -l v2.0.0)" ]; then
+    pass "the version comes from the bump commit's tree, not the working tree"
+  else
+    fail "the cut read the version out of the working tree (tagged v2.0.0)"
+  fi
+
+  pushed="$(git -C "$cut_repo/remote.git" rev-parse -q --verify 'refs/tags/v1.1.0^{commit}' 2>/dev/null || true)"
+  if [ "$pushed" = "$bump_sha" ]; then
+    pass "the cut pushes the tag at the bump commit to the remote"
+  else
+    fail "the remote must carry v1.1.0 at the bump commit, got '${pushed:-<nothing>}'"
+  fi
+
+  if grep -qF 'tag=v1.1.0' "$cut_out"; then
+    pass "the cut reports the tag it cut through GITHUB_OUTPUT"
+  else
+    fail "the cut must write tag=v1.1.0 to GITHUB_OUTPUT so the publish dispatch fires"
+  fi
+
+  if grep -qF '::notice::' "$cut_log" && grep -qF 'v1.1.0' "$cut_log"; then
+    pass "a completed cut announces the tag as a workflow notice"
+  else
+    fail "the cut must announce the tag it cut with ::notice::"
+  fi
+
+  # A run whose commit still carries changesets did not cut — and must say why.
+  race_log="$TMP/cut-race.log"
+  if run_cut "$race_sha" "$TMP/cut-race.out" > "$race_log" 2>&1; then
+    pass "a commit with pending changesets exits clean instead of erroring"
+  else
+    fail "a commit with pending changesets must not fail the workflow"
+  fi
+  if grep -qF '::notice::' "$race_log" && grep -qiF 'changeset' "$race_log"; then
+    pass "a skipped cut names pending changesets as its reason"
+  else
+    fail "a skip for pending changesets must print a ::notice:: naming the reason"
+    cat "$race_log" >&2 || true
+  fi
+  if [ -z "$(git -C "$cut_repo/work" tag -l v2.0.0)" ]; then
+    pass "no tag is cut while changesets are still pending at that commit"
+  else
+    fail "the cut must not tag a commit that still carries changesets"
+  fi
+
+  # Re-running the same push (a re-dispatch, a retried job) is a skip, not a
+  # second tag and not a failure.
+  again_log="$TMP/cut-again.log"
+  if run_cut "$bump_sha" "$TMP/cut-again.out" > "$again_log" 2>&1; then
+    pass "re-cutting an already-tagged bump commit exits clean"
+  else
+    fail "re-cutting an already-tagged bump commit must not fail the workflow"
+  fi
+  if grep -qF '::notice::' "$again_log" && grep -qF 'v1.1.0' "$again_log"; then
+    pass "an already-tagged cut says so instead of going silent"
+  else
+    fail "an already-cut tag must print a ::notice:: naming the existing tag"
+  fi
+
+  # A missing/absent sha is a broken run, not a quiet no-op.
+  miss_log="$TMP/cut-missing.log"
+  if run_cut "" "$TMP/cut-missing.out" > "$miss_log" 2>&1; then
+    fail "an empty BUMP_SHA must fail the cut loudly"
+  else
+    pass "an empty BUMP_SHA fails the cut instead of skipping silently"
+  fi
+  if grep -qF '::error::' "$miss_log"; then
+    pass "a broken cut reports itself as a workflow error"
+  else
+    fail "a broken cut must print ::error:: naming the problem"
+  fi
+fi
+
+# --- the workflow hands the cut the event's own sha -------------------------
+
+if grep -qF 'BUMP_SHA: ${{ github.sha }}' "$RELEASE_WORKFLOW"; then
+  pass "the workflow carries the pushed bump commit sha into the cut"
+else
+  fail "the cut must receive BUMP_SHA: \${{ github.sha }} from the push event payload"
+fi
+
+if grep -qF 'scripts/release-cut-tag.sh' "$RELEASE_WORKFLOW"; then
+  pass "the workflow cuts through the contract-tested script"
+else
+  fail "the workflow must cut the tag through scripts/release-cut-tag.sh"
+fi
+
+if grep -qE '^\s*git tag ' "$RELEASE_WORKFLOW"; then
+  fail "the workflow must not tag inline — the cut logic belongs in the tested script"
+else
+  pass "the workflow holds no inline tagging logic"
+fi
+
+# The live changesets state is exactly what a racing merge rewrites; gating the
+# step on it is how the two swallowed tags happened.
+if grep -qF "hasChangesets == 'false'" "$RELEASE_WORKFLOW"; then
+  fail "the cut must not be gated on the live hasChangesets output — a racing merge rewrites it"
+else
+  pass "the cut decides from the bump commit, not from the live changesets state"
+fi
+
 if (( failures > 0 )); then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
Automated AFK landing for #3025. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3025

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788213969&installation_model_id=20659&pr_number=3040&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3040&signature=fb2f1a95e37031ee080a04b10b9302d87a39d8e68d547f482587e650e5e8e7e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->