### PR TITLE
chore: #3030 The merge-poll ends: dirty PR detection, one rebase attempt, then a park with a card

### DIFF
--- a/.changeset/the-merge-poll-ends-on-a-dirty-pr.md
+++ b/.changeset/the-merge-poll-ends-on-a-dirty-pr.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The landing's merge confirmation now ends on a pull request the queue can never accept. "Is it merged yet?" is a question a CONFLICTING PR answers `no` forever, and a worker was observed polling one until its whole budget drained, because the confirmation asked only about the merge and never about mergeability. The probe now reads the PR's settled conflict state in the same `gh pr view` it already paid for, and a settled `CONFLICTING` verdict ends the wait immediately instead of after thirty minutes of asking — `mergeable: UNKNOWN` still keeps polling, so a mid-computation `DIRTY` is never mistaken for a verdict. On that terminal read the landing attempts the ONE repair it owns: rebase the worker branch onto the base as it stands NOW, in the rebase worktree it already provisioned, then give the merge exactly one more round on what is LEFT of the declared budget. So the whole tail costs one deadline, not two. A conflict that survives its rebase is a human's: the flow parks with the existing card, naming the conflicting PR, and leaves the branch, the pull request and the issue intact.

--- a/apps/dev/src/core/declared-wait-guard.ts
+++ b/apps/dev/src/core/declared-wait-guard.ts
@@ -608,9 +608,12 @@ export const DECLARED_WAITS: readonly DeclaredWait[] = [
   {
     path: "apps/dev/src/core/merge.ts",
     fn: "waitForQueuedMerge",
-    subject: "the native merge queue merging the PR, or dequeuing it without merging",
-    deadline: "`maxPolls` × `intervalMs`, default 120 × 15s = 30 minutes; ONE probe when no clock is injected",
-    escalation: "returns `pending`, leaving the PR queued for the next sweep to re-read",
+    subject:
+      "the native merge queue merging the PR, dequeuing it without merging, or the PR settling to a conflict no queue can accept",
+    deadline:
+      "`maxPolls` × `intervalMs`, default 120 × 15s = 30 minutes, shared with the post-rebase retry so the whole tail costs ONE deadline; ONE probe when no clock is injected",
+    escalation:
+      "returns `pending`, leaving the PR queued for the next sweep to re-read; a settled conflict returns `unqueueable` early (#3030) and the caller rebases ONCE, then parks the branch, the PR and the issue for a human",
     heartbeat: { sink: "onPoll" },
   },
   {

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -583,6 +583,25 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
       // #2986: the enqueue is not the merge. This budget owns the hold between
       // `--auto` exiting 0 and the forge reporting `merged: true`.
       mergeQueueWait: decorateMergeQueueWait(deps, input),
+      // #3030: the confirmation's ONE repair for a PR the queue can never accept.
+      // The pre-merge rebase worktree is already provisioned and already on this
+      // branch, so the repair is the same integration step run once more against
+      // the base as it stands NOW — the base moved under the branch while CI ran,
+      // which is how a landing arrives at a conflicted PR in the first place.
+      rebaseOntoBase: async () => {
+        await deps.landingPhase?.("gate", { step: "rebase", status: "start" });
+        const rebased = await preMergeRebase(deps.mergeExec, {
+          repo: prepared.dir,
+          remote: input.remote,
+          base: input.base,
+          branch: input.branch,
+          resolveMechanical: deps.resolveMechanicalConflict,
+          resolveAgent: deps.resolveAgentConflict,
+          maxAgentResolveAttempts: deps.maxAgentConflictResolveAttempts,
+        });
+        await deps.landingPhase?.("gate", { step: "rebase", status: "done" });
+        return rebased.ok;
+      },
       // Untouchable primary (ADR 0083 / 0108): landPr promotes the fleet mirror,
       // not a local primary branch. `locked` is observability only.
       locked: input.locked,
@@ -649,7 +668,17 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
         }
         return { ok: false, reason: "post-merge-gate", locked: input.locked, prNumber: result.prNumber };
       }
-      if (result.reason === "conflict") return { ok: false, reason: "pr-conflict", locked: input.locked, prNumber: result.prNumber };
+      // #3030: a conflict the confirmation detected carries what it observed, so
+      // the human card names the conflicting PR instead of a bare park.
+      if (result.reason === "conflict") {
+        return {
+          ok: false,
+          reason: "pr-conflict",
+          locked: input.locked,
+          prNumber: result.prNumber,
+          ...(result.queueDetail ? { message: result.queueDetail } : {}),
+        };
+      }
       if (result.reason === "merge-failed" && result.prNumber !== undefined) {
         return {
           ok: false,

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -1130,6 +1130,15 @@ export interface LandPrInput {
    */
   mergeQueueWait?: MergeQueueWaitInput;
   /**
+   * The ONE repair the confirmation is allowed to attempt on a PR the queue can
+   * never accept (#3030): rebase the worker branch onto the live base and
+   * force-push it, returning true only when the branch actually moved. Called at
+   * most once per landing — a conflict that survives its rebase is a human's, and
+   * a second round would just be the eternal poll wearing a different shape.
+   * Absent (the default) → a conflicted PR parks immediately.
+   */
+  rebaseOntoBase?: () => Promise<boolean>;
+  /**
    * Final PR-path validation hook. Called after the PR exists and CI-aware merge
    * has observed its current readiness, but before `gh pr merge`. Callers use it
    * to either trust fresh green CI or run their local fallback gate.
@@ -1220,12 +1229,14 @@ export interface MergeQueueWaitInput {
 
 /**
  * How a queued PR left the merge queue.
- *   - `merged`   — the forge reports the PR MERGED; the landing may close/clean up.
- *   - `rejected` — the queue gave the PR back (closed unmerged, or the auto-merge
- *                  request it accepted is gone while the PR is still open). Terminal.
- *   - `pending`  — still queued when the budget ran out. NOT a merge.
+ *   - `merged`      — the forge reports the PR MERGED; the landing may close/clean up.
+ *   - `rejected`    — the queue gave the PR back (closed unmerged, or the auto-merge
+ *                     request it accepted is gone while the PR is still open). Terminal.
+ *   - `unqueueable` — the PR is settled CONFLICTING: no queue will ever accept it, so
+ *                     asking again is the eternal poll #3030 observed. Terminal.
+ *   - `pending`     — still queued when the budget ran out. NOT a merge.
  */
-export type QueuedMergeOutcome = "merged" | "rejected" | "pending";
+export type QueuedMergeOutcome = "merged" | "rejected" | "unqueueable" | "pending";
 
 export interface QueuedMergeResult {
   outcome: QueuedMergeOutcome;
@@ -1233,6 +1244,12 @@ export interface QueuedMergeResult {
   mergeSha?: string;
   /** One line naming what was observed, for the terminal record on `rejected`. */
   detail?: string;
+  /**
+   * Probes actually spent (#3030). The caller's repair round subtracts these from
+   * the declared budget, so ONE deadline bounds the whole tail rather than each
+   * confirmation buying a fresh one.
+   */
+  polls: number;
 }
 
 interface QueuedPrView {
@@ -1241,15 +1258,28 @@ interface QueuedPrView {
   mergeSha?: string;
   /** Whether the PR still carries the auto-merge request the enqueue created. */
   autoMerge: boolean;
+  /**
+   * A SETTLED conflict — `mergeable: CONFLICTING`, or a `DIRTY` state read from a
+   * payload with no `mergeable` field at all. `mergeable: UNKNOWN` is deliberately
+   * not one: the forge is still computing mergeability, and a mid-computation
+   * `DIRTY` is the #2084 phantom conflict, not a verdict.
+   */
+  conflicted: boolean;
   /** False when the probe failed or its payload was unparseable. */
   observed: boolean;
 }
 
-/** Parse `gh pr view --json state,mergedAt,mergeCommit,autoMergeRequest`. Tolerant:
- * an unreadable payload yields `observed: false` so the caller polls again rather
- * than inventing a verdict from a failed probe. */
+/** Parse `gh pr view --json state,mergedAt,mergeCommit,autoMergeRequest,mergeStateStatus,mergeable`.
+ * Tolerant: an unreadable payload yields `observed: false` so the caller polls again
+ * rather than inventing a verdict from a failed probe. */
 export function parseQueuedPrView(stdout: string): QueuedPrView {
-  const absent: QueuedPrView = { merged: false, state: "", autoMerge: false, observed: false };
+  const absent: QueuedPrView = {
+    merged: false,
+    state: "",
+    autoMerge: false,
+    conflicted: false,
+    observed: false,
+  };
   const text = stdout.trim();
   if (text === "") return absent;
   try {
@@ -1260,6 +1290,8 @@ export function parseQueuedPrView(stdout: string): QueuedPrView {
       mergedAt?: unknown;
       mergeCommit?: unknown;
       autoMergeRequest?: unknown;
+      mergeStateStatus?: unknown;
+      mergeable?: unknown;
     };
     const mergeCommit = row.mergeCommit;
     const oid =
@@ -1267,6 +1299,9 @@ export function parseQueuedPrView(stdout: string): QueuedPrView {
         ? (mergeCommit as { oid?: unknown }).oid
         : undefined;
     const state = typeof row.state === "string" ? row.state.trim().toUpperCase() : "";
+    const mergeable = typeof row.mergeable === "string" ? row.mergeable.trim().toUpperCase() : "";
+    const mergeStateStatus =
+      typeof row.mergeStateStatus === "string" ? row.mergeStateStatus.trim().toUpperCase() : "";
     // `gh pr view` has no `merged` boolean — `state: MERGED` and a non-null
     // `mergedAt` are the two forms the forge reports the completed merge in.
     return {
@@ -1274,6 +1309,10 @@ export function parseQueuedPrView(stdout: string): QueuedPrView {
       state,
       ...(typeof oid === "string" && oid !== "" ? { mergeSha: oid } : {}),
       autoMerge: typeof row.autoMergeRequest === "object" && row.autoMergeRequest !== null,
+      // Same settled-vs-computing authority `classifyMergeState` applies: only a
+      // CONFLICTING verdict is terminal, and a bare DIRTY counts only when the
+      // payload carried no `mergeable` field to settle it either way.
+      conflicted: mergeable === "CONFLICTING" || (mergeable === "" && mergeStateStatus === "DIRTY"),
       observed: true,
     };
   } catch {
@@ -1292,6 +1331,12 @@ export function parseQueuedPrView(stdout: string): QueuedPrView {
  * trusted once this wait has actually SEEN the request present, because `gh pr
  * merge --auto` and the field's appearance are not simultaneous — an
  * unseen-then-absent request is the enqueue still registering, not a rejection.
+ *
+ * A SETTLED CONFLICT ENDS THE WAIT (#3030). "Is it merged yet?" is a question a
+ * CONFLICTING pull request answers `no` forever, and a worker was observed asking
+ * it until the whole budget drained. A conflicted PR is not slow, it is
+ * unacceptable to any queue, so it returns `unqueueable` on the first settled read
+ * and the caller decides whether one rebase can make it queueable again.
  */
 export async function waitForQueuedMerge(
   exec: Exec,
@@ -1319,19 +1364,28 @@ export async function waitForQueuedMerge(
       () =>
         exec([
           "gh", "-R", repo, "pr", "view", String(prNumber),
-          "--json", "state,mergedAt,mergeCommit,autoMergeRequest",
+          "--json", "state,mergedAt,mergeCommit,autoMergeRequest,mergeStateStatus,mergeable",
         ]),
       input.probeTimeoutMs,
     );
+    const polls = attempt + 1;
     const view = res.code === 0 ? parseQueuedPrView(res.stdout) : parseQueuedPrView("");
     if (view.observed) {
       if (view.merged) {
-        return { outcome: "merged", ...(view.mergeSha ? { mergeSha: view.mergeSha } : {}) };
+        return { outcome: "merged", ...(view.mergeSha ? { mergeSha: view.mergeSha } : {}), polls };
       }
       if (view.state === "CLOSED") {
         return {
           outcome: "rejected",
           detail: `PR #${prNumber} left the merge queue CLOSED without merging`,
+          polls,
+        };
+      }
+      if (view.conflicted) {
+        return {
+          outcome: "unqueueable",
+          detail: `PR #${prNumber} conflicts with its base — no merge queue can accept it, so the confirmation stopped asking after ${polls} probe(s)`,
+          polls,
         };
       }
       if (view.autoMerge) {
@@ -1340,12 +1394,13 @@ export async function waitForQueuedMerge(
         return {
           outcome: "rejected",
           detail: `the merge queue dequeued PR #${prNumber} without merging it (its auto-merge request is gone and the PR is still open)`,
+          polls,
         };
       }
     }
     if (attempt + 1 < maxPollsWithClock) await sleep(intervalMs);
   }
-  return { outcome: "pending" };
+  return { outcome: "pending", polls: maxPollsWithClock };
 }
 
 const PR_BODY_PREFIX = "Automated AFK landing for #";
@@ -1720,7 +1775,28 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
     // merge queue AFK was never told about) answers `merged=false` and is held
     // here until the forge finishes or hands the PR back. Only `merged` returns
     // `ok`, because `ok` is what unlocks the caller's close/cleanup steps.
-    const confirmed = await waitForQueuedMerge(exec, repo, prNumber, input.mergeQueueWait ?? {});
+    const waitInput = input.mergeQueueWait ?? {};
+    let confirmed = await waitForQueuedMerge(exec, repo, prNumber, waitInput);
+
+    // 4b. #3030: the PR conflicts, so no amount of asking will make it merge. Try
+    // the one repair a landing owns — rebase the branch onto the live base — and
+    // give the merge exactly one more round, on what is LEFT of the declared
+    // budget. Anything but a merge after that parks with the branch, the PR and
+    // the issue intact for the human card.
+    if (confirmed.outcome === "unqueueable") {
+      const detail = confirmed.detail;
+      if (!(await input.rebaseOntoBase?.())) {
+        return { ok: false, prNumber, reason: "conflict" };
+      }
+      const merged = await exec(mergeArgs);
+      if (merged.code !== 0) return { ok: false, prNumber, reason: "conflict" };
+      const remaining = Math.max(1, (waitInput.maxPolls ?? 120) - confirmed.polls);
+      confirmed = await waitForQueuedMerge(exec, repo, prNumber, { ...waitInput, maxPolls: remaining });
+      if (confirmed.outcome === "unqueueable") {
+        return { ok: false, prNumber, reason: "conflict", queueDetail: confirmed.detail ?? detail };
+      }
+    }
+
     if (confirmed.outcome === "rejected") {
       return { ok: false, prNumber, reason: "queue-rejected", queueDetail: confirmed.detail };
     }

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -1180,7 +1180,10 @@ describe("landPr CI-aware wiring (#812)", () => {
       repo: "o/r", gitRepo: "/repo", remote: "origin", branch: "afk/wX/9-x", target: "main", n: 9, title: "t",
     });
     expect(r.ok).toBe(true);
-    expect(joined(calls).some((c) => c.includes("mergeStateStatus"))).toBe(false);
+    // The readiness poll is what stays absent. The merge confirmation's own probe
+    // reads `mergeStateStatus` unconditionally since #3030 — that is one `gh pr
+    // view` asking whether the merge happened, not a CI wait.
+    expect(joined(calls).some((c) => c.includes("statusCheckRollup"))).toBe(false);
     expect(joined(calls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
   });
 });
@@ -1634,9 +1637,11 @@ describe("waitForQueuedMerge (#2986)", () => {
       JSON.stringify({ merged: true, state: "MERGED", mergeCommit: { oid: "queuesha" }, autoMergeRequest: null }),
     ]);
     const r = await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 5 });
-    expect(r).toEqual({ outcome: "merged", mergeSha: "queuesha" });
+    expect(r).toEqual({ outcome: "merged", mergeSha: "queuesha", polls: 3 });
     expect(calls).toHaveLength(3);
-    expect(calls[0]!.join(" ")).toContain("pr view 42 --json state,mergedAt,mergeCommit,autoMergeRequest");
+    expect(calls[0]!.join(" ")).toContain(
+      "pr view 42 --json state,mergedAt,mergeCommit,autoMergeRequest,mergeStateStatus,mergeable",
+    );
   });
 
   it("reports a dequeue once the accepted auto-merge request disappears", async () => {
@@ -1659,7 +1664,7 @@ describe("waitForQueuedMerge (#2986)", () => {
       JSON.stringify({ merged: true, state: "MERGED", mergeCommit: { oid: "queuesha" }, autoMergeRequest: null }),
     ]);
     const r = await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 5 });
-    expect(r).toEqual({ outcome: "merged", mergeSha: "queuesha" });
+    expect(r).toEqual({ outcome: "merged", mergeSha: "queuesha", polls: 3 });
   });
 
   it("reports a PR the queue closed without merging as rejected", async () => {
@@ -1681,7 +1686,7 @@ describe("waitForQueuedMerge (#2986)", () => {
         polls.push(event.attempt);
       },
     });
-    expect(r).toEqual({ outcome: "pending" });
+    expect(r).toEqual({ outcome: "pending", polls: 3 });
     expect(calls).toHaveLength(3);
     expect(polls).toEqual([1, 2, 3]);
   });
@@ -1692,7 +1697,7 @@ describe("waitForQueuedMerge (#2986)", () => {
       JSON.stringify({ merged: true, state: "MERGED", mergeCommit: { oid: "queuesha" }, autoMergeRequest: null }),
     ]);
     const r = await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 5 });
-    expect(r).toEqual({ outcome: "merged", mergeSha: "queuesha" });
+    expect(r).toEqual({ outcome: "merged", mergeSha: "queuesha", polls: 2 });
   });
 
   it("parses a merged view and tolerates a broken payload", () => {
@@ -1701,6 +1706,7 @@ describe("waitForQueuedMerge (#2986)", () => {
       state: "MERGED",
       mergeSha: "s",
       autoMerge: false,
+      conflicted: false,
       observed: true,
     });
     expect(parseQueuedPrView("{oops").observed).toBe(false);
@@ -1778,5 +1784,181 @@ describe("landPr on a merge-queue base (#2986)", () => {
     expect(r.ok).toBe(false);
     expect(r.reason).toBe("queue-rejected");
     expect(r.queueDetail).toContain("dequeued PR #42");
+  });
+});
+
+// #3030 — a PR the queue can never accept is not a PR that is still queued. A
+// worker was observed polling a CONFLICTING pull request until its whole budget
+// drained, because the confirmation asked only "merged yet?" and a dirty PR
+// answers "no" forever. The terminal condition: detect it, rebase ONCE, and park.
+describe("the merge confirmation on a dirty PR (#3030)", () => {
+  const dirty = JSON.stringify({
+    merged: false,
+    state: "OPEN",
+    mergeCommit: null,
+    autoMergeRequest: { enabledAt: "t" },
+    mergeStateStatus: "DIRTY",
+    mergeable: "CONFLICTING",
+  });
+  const queued = JSON.stringify({
+    merged: false,
+    state: "OPEN",
+    mergeCommit: null,
+    autoMergeRequest: { enabledAt: "t" },
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+  const merged = JSON.stringify({
+    merged: true,
+    state: "MERGED",
+    mergeCommit: { oid: "queuesha" },
+    autoMergeRequest: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+
+  const viewExec = (views: string[]): { exec: Exec; calls: string[][] } => {
+    const calls: string[][] = [];
+    let i = 0;
+    const exec: Exec = async (argv) => {
+      calls.push(argv);
+      const stdout = views[Math.min(i, views.length - 1)] ?? "";
+      i += 1;
+      return { code: 0, stdout, stderr: "" };
+    };
+    return { exec, calls };
+  };
+
+  it("stops on the first settled CONFLICTING read instead of draining the budget", async () => {
+    const { exec, calls } = viewExec([queued, dirty]);
+    const r = await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 60 });
+    expect(r.outcome).toBe("unqueueable");
+    expect(r.detail).toContain("PR #42");
+    expect(r.polls).toBe(2);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("keeps polling while mergeability is still UNKNOWN — a computing read is not a conflict", async () => {
+    const { exec } = viewExec([
+      JSON.stringify({
+        merged: false,
+        state: "OPEN",
+        mergeCommit: null,
+        autoMergeRequest: { enabledAt: "t" },
+        mergeStateStatus: "DIRTY",
+        mergeable: "UNKNOWN",
+      }),
+      merged,
+    ]);
+    const r = await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 5 });
+    expect(r.outcome).toBe("merged");
+  });
+
+  const landExec = (opts: {
+    views: string[];
+    onMerge?: () => void;
+  }): { exec: Exec; calls: string[][] } => {
+    const calls: string[][] = [];
+    let i = 0;
+    const exec: Exec = async (argv) => {
+      calls.push(argv);
+      const cmd = argv.join(" ");
+      if (cmd.includes("pr list")) return { code: 0, stdout: "42\n", stderr: "" };
+      if (cmd.includes("pr merge")) {
+        opts.onMerge?.();
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (cmd.includes("autoMergeRequest")) {
+        const stdout = opts.views[Math.min(i, opts.views.length - 1)] ?? "";
+        i += 1;
+        return { code: 0, stdout, stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    return { exec, calls };
+  };
+
+  const base = {
+    repo: "o/r",
+    gitRepo: "/repo",
+    remote: "origin",
+    branch: "afk/wX/9-x",
+    target: "main",
+    n: 9,
+    title: "t",
+    mergeQueue: true,
+  };
+
+  it("attempts ONE rebase and completes the merge when the rebase clears the conflict", async () => {
+    // dirty → (rebase) → queued → merged.
+    const { exec } = landExec({ views: [dirty, queued, merged] });
+    let rebases = 0;
+    const r = await landPr(exec, {
+      ...base,
+      mergeQueueWait: { sleep: async () => {}, maxPolls: 6 },
+      rebaseOntoBase: async () => {
+        rebases += 1;
+        return true;
+      },
+    });
+    expect(rebases).toBe(1);
+    expect(r.ok).toBe(true);
+    expect(r.mergeSha).toBe("queuesha");
+  });
+
+  it("parks as a conflict — branch and issue intact — when the one rebase does not clear it", async () => {
+    const { exec } = landExec({ views: [dirty] });
+    let rebases = 0;
+    const r = await landPr(exec, {
+      ...base,
+      mergeQueueWait: { sleep: async () => {}, maxPolls: 6 },
+      rebaseOntoBase: async () => {
+        rebases += 1;
+        return true;
+      },
+    });
+    expect(rebases).toBe(1);
+    expect(r.ok).toBe(false);
+    expect(r.prNumber).toBe(42);
+    expect(r.reason).toBe("conflict");
+    expect(r.queueDetail).toContain("conflicts with its base");
+  });
+
+  it("parks without a second try when the rebase itself refuses", async () => {
+    const { exec } = landExec({ views: [dirty] });
+    let rebases = 0;
+    const r = await landPr(exec, {
+      ...base,
+      mergeQueueWait: { sleep: async () => {}, maxPolls: 6 },
+      rebaseOntoBase: async () => {
+        rebases += 1;
+        return false;
+      },
+    });
+    expect(rebases).toBe(1);
+    expect(r.reason).toBe("conflict");
+  });
+
+  it("parks straight away when no rebase hook is wired", async () => {
+    const { exec } = landExec({ views: [dirty] });
+    const r = await landPr(exec, {
+      ...base,
+      mergeQueueWait: { sleep: async () => {}, maxPolls: 6 },
+    });
+    expect(r.reason).toBe("conflict");
+  });
+
+  it("bounds the WHOLE tail by the declared budget — the retry inherits what is left", async () => {
+    // The first confirmation burns 2 of 5 polls before reading the conflict; the
+    // post-rebase confirmation may spend the remaining 3 and no more, so a dirty
+    // PR can never buy itself a second full deadline.
+    const { exec, calls } = landExec({ views: [queued, dirty, queued] });
+    const r = await landPr(exec, {
+      ...base,
+      mergeQueueWait: { sleep: async () => {}, maxPolls: 5 },
+      rebaseOntoBase: async () => true,
+    });
+    expect(r.reason).toBe("queue-pending");
+    expect(calls.filter((c) => c.join(" ").includes("autoMergeRequest"))).toHaveLength(5);
   });
 });

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -179,7 +179,10 @@ function harness(opts: HarnessOptions = {}): {
         if (j.includes("pr merge") && !branchUpdated) {
           return { code: 1, stdout: "", stderr: "Base branch was modified. Review and try the merge again." };
         }
-        if (j.includes("pr view") && j.includes("mergeStateStatus")) {
+        // The READINESS probe only: since #3030 the merge confirmation also asks
+        // for `mergeStateStatus`, and answering it with a payload carrying no
+        // `state` would read the completed merge as an unmerged PR.
+        if (j.includes("pr view") && j.includes("statusCheckRollup")) {
           return {
             code: 0,
             stdout: JSON.stringify({


### PR DESCRIPTION
Automated AFK landing for #3030. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3030

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788218111&installation_model_id=20659&pr_number=3045&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3045&signature=a642e80b3ab374971f1d91a4b38da56a8285a205c1bd22768eac5bf14d6e4606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->