### PR TITLE
fix: #3041 The gate ran its commands with a relative -C path that resolved nowhere, and parked a green branch as blocked:validation

### DIFF
--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -64,6 +64,7 @@ import { buildFsPort } from "./ports/fs.js";
 import { buildHooks } from "./ports/hooks.js";
 import { buildEnvelopePort } from "./ports/envelope.js";
 import { buildLookups } from "./ports/lookups.js";
+import { realDirectoryProbe } from "../../core/validation-command.js";
 import {
   castleWorktreeUnder,
   decodeLocMemoSnapshot,
@@ -298,6 +299,10 @@ export function buildProcessDeps({
     // worktree manager materialises it and rebases pnpm/layout onto it.
     pnpm: feedback.pnpm,
     validationResourceBudget: readValidationResourceBudget(config),
+    // The gate's proof that a declared validation worktree is really there
+    // (#3041): a landing worktree that vanished refuses as an infrastructure
+    // error instead of composing commands against a path that resolves nowhere.
+    dirExists: realDirectoryProbe,
     layout: feedback.layout,
     // Backpressure gate (#430, PRD #429): operator-declared `afk.backpressure`
     // shell commands run against the same worker-branch checkout after feedback.

--- a/apps/dev/src/commands/run/reconcile.ts
+++ b/apps/dev/src/commands/run/reconcile.ts
@@ -31,6 +31,7 @@ import { join } from "node:path";
 import { workerIdentity } from "../../core/host-identity.js";
 import { type CastleWorkerLaneBridge } from "../../core/castle-worker-lane-bridge.js";
 import { runLinkedSubagent } from "./linked-subagent.js";
+import { realDirectoryProbe } from "../../core/validation-command.js";
 
 function parseSlot(val: string | undefined): number | undefined {
   if (val === undefined) return undefined;
@@ -217,6 +218,9 @@ export function makeBootReconcileRunner(
       mergeExec: gitx.mergeExec(gitCtx),
       remoteGit: gitx.gitExec(gitCtx),
       pnpm: feedback.pnpm,
+      // Proof that a declared validation worktree exists (#3041) — without it
+      // the gate would report a missing directory as the branch's red verdict.
+      dirExists: realDirectoryProbe,
       layout: feedback.layout,
       // Isolated landing worktree for the LOCKED reconcile-land (#572): the merge
       // /push/rollback runs in a throwaway detached worktree, never the primary.

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -32,12 +32,33 @@ import {
 
 import { pendingInvariantRuns } from "./repo-invariants.js";
 import { type ValidationScope } from "./validation-scope.js";
+import {
+  composeValidationCommand,
+  isSuspectInfraFailure,
+  recordedValidationCommand,
+  resolveValidationTarget,
+  suspectInfraSummary,
+  targetMissingSummary,
+  VALIDATION_TARGET_MISSING_MARKER,
+  type ValidationTarget,
+  type ValidationTargetKind,
+} from "./validation-command.js";
 
 /** Result of a single executed command. Mirrors a child-process completion. */
 export interface ExecResult {
   code: number;
   stdout: string;
   stderr: string;
+  /**
+   * The ABSOLUTE directory the command actually ran in, when the executor
+   * rewrote the `-C` token (#3041). The AFK gate is posed with a branch NAME;
+   * the feedback-worktree executor materialises it and runs the command in a
+   * real checkout, and only the executor knows that path. Reporting it back is
+   * what lets the record name a directory a reader can `ls` instead of the
+   * branch token that made the #3027 verdict unreadable. Absent → no rewrite
+   * happened and the composed command stands.
+   */
+  commandDir?: string;
 }
 
 export interface FeedbackExecOptions {
@@ -186,6 +207,13 @@ export interface ValidationRecord {
   exitCode?: number;
   durationMs?: number;
   summary?: string;
+  /**
+   * Set only on a failure that exited too fast to have run (#3041). A suite
+   * command that reports a verdict in under a second reported nothing; the flag
+   * says so in the record rather than leaving the operator to notice the
+   * millisecond count, which is how the #3027 phantom survived a whole park.
+   */
+  suspectInfra?: true;
 }
 
 /**
@@ -327,6 +355,7 @@ export function buildValidationRecord(input: {
   exitCode?: number;
   durationMs?: number;
   summary?: string;
+  suspectInfra?: boolean;
 }): ValidationRecord {
   const record: ValidationRecord = {
     schema: VALIDATION_SCHEMA,
@@ -337,7 +366,34 @@ export function buildValidationRecord(input: {
   if (input.exitCode !== undefined && Number.isFinite(input.exitCode)) record.exitCode = Math.trunc(input.exitCode);
   if (input.durationMs !== undefined) record.durationMs = input.durationMs;
   if (input.summary !== undefined && input.summary !== "") record.summary = input.summary;
+  if (input.suspectInfra === true) record.suspectInfra = true;
   return record;
+}
+
+/**
+ * Build the record for ONE executed validation command, applying the #3041
+ * honesty rules in one place: the recorded command names the directory the
+ * executor really ran in, and a sub-second failure is flagged `suspectInfra`
+ * with the evidence spelled into its summary.
+ */
+function buildRanRecord(input: {
+  name: string;
+  status: ValidationStatus;
+  command: string;
+  exitCode: number;
+  durationMs: number;
+  summary: string;
+}): ValidationRecord {
+  const suspect = isSuspectInfraFailure({ status: input.status, durationMs: input.durationMs });
+  const summary = suspect
+    ? suspectInfraSummary({
+        command: input.command,
+        exitCode: input.exitCode,
+        durationMs: input.durationMs,
+        summary: input.summary,
+      })
+    : input.summary;
+  return buildValidationRecord({ ...input, summary, suspectInfra: suspect });
 }
 
 /** Serialize a record to its single compact JSONL line (no trailing newline). */
@@ -406,7 +462,11 @@ export function isInfraValidationFailure(checks: readonly ClassifiableCheck[]): 
     if (
       summary.includes("feedback worktree setup failed") ||
       summary.includes("feedback worktree submodule init failed") ||
-      summary.includes("feedback worktree install failed")
+      summary.includes("feedback worktree install failed") ||
+      // A command the gate could not even pose — its worktree directory does not
+      // exist (#3041). An unrunnable command judged nothing, so it is an
+      // infrastructure error and never the branch's red verdict.
+      summary.includes(VALIDATION_TARGET_MISSING_MARKER)
     ) {
       return true;
     }
@@ -528,6 +588,19 @@ export interface FeedbackCheck {
 export interface RunFeedbackInput {
   /** Worktree root passed through to the `pnpm -C` directory arg. */
   worktree: string;
+  /**
+   * What {@link RunFeedbackInput.worktree} IS (#3041). `checkout` declares it a
+   * directory — it is resolved to an absolute path and a MISSING one refuses
+   * the whole gate as an infrastructure error. `branch` declares it a branch
+   * name the executor materialises. Omitted → auto-detect, which can only
+   * downgrade to `branch`: absent a declaration the gate has no grounds to call
+   * a token a missing directory.
+   */
+  worktreeKind?: ValidationTargetKind;
+  /** The checkout a relative worktree token anchors to. Defaults to the cwd. */
+  root?: string;
+  /** Injected directory probe for the target resolution. Defaults to `statSync`. */
+  dirExists?: (dir: string) => boolean;
   /** Resolved relevant scopes (from {@link relevantScopes}); empty for no-package. */
   scopes: readonly string[];
   /** Package layout, for the per-scope `hasScript` probe. */
@@ -803,6 +876,33 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     sidecar.push(formatValidationLine(check.record));
   };
 
+  // Resolve the target BEFORE composing anything (#3041). A declared checkout
+  // whose directory is gone refuses here: the gate would otherwise compose a
+  // command against a path that resolves nowhere, exit non-zero in about a
+  // millisecond, and hand that back as the branch's validation verdict.
+  const target: ValidationTarget = resolveValidationTarget(worktree, {
+    root: input.root ?? process.cwd(),
+    ...(input.worktreeKind === undefined ? {} : { kind: input.worktreeKind }),
+    ...(input.dirExists === undefined ? {} : { isDirectory: input.dirExists }),
+  });
+  if (target.missing) {
+    const name = "validation:worktree-missing";
+    const record = buildValidationRecord({
+      name,
+      status: "failed",
+      summary: targetMissingSummary(target),
+    });
+    push({ name, script: "test", label: "worktree", scope: "", status: "failed", record });
+    return {
+      ok: false,
+      checks,
+      sidecar,
+      baselineInconclusive: [],
+      quarantined: [],
+      ...(validationScope === undefined ? {} : { validationScope }),
+    };
+  }
+
   // Quarantine validation: a missing issue ref is a loud gate failure (never
   // a silent skip). Surface it as a failed sidecar record so the envelope shows
   // the misconfiguration clearly.
@@ -871,20 +971,15 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
         }
       }
 
-      const dir = scopeDir(worktree, scope);
-      const baseArgs = ["pnpm", "-C", dir, script];
-      const args = excludeArgs.length > 0 ? [...baseArgs, "--", ...excludeArgs] : baseArgs;
-      const command =
-        excludeArgs.length > 0
-          ? `pnpm -C ${dir} ${script} -- ${excludeArgs.join(" ")}`
-          : `pnpm -C ${dir} ${script}`;
+      const composed = composeValidationCommand({ target, scope, script, extraArgs: excludeArgs });
       const start = now();
-      const result = await exec(args, { env: subprocessEnv });
+      const result = await exec(composed.args, { env: subprocessEnv });
       const durationMs = now() - start;
       const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
       if (status === "failed") failed = true;
+      const command = recordedValidationCommand(composed, script, excludeArgs, result.commandDir);
       const summary = outputSummary(status, joinCommandOutput(result.stdout, result.stderr));
-      const record = buildValidationRecord({ name, status, command, exitCode: result.code, durationMs, summary });
+      const record = buildRanRecord({ name, status, command, exitCode: result.code, durationMs, summary });
       push({ name, script, label, scope, status, record });
     }
   }
@@ -901,15 +996,15 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     const name = "typecheck:workspace";
     const label = "workspace";
     const scope = ".";
-    const dir = scopeDir(worktree, ".");
-    const command = `pnpm -C ${dir} typecheck`;
+    const composed = composeValidationCommand({ target, scope: ".", script: "typecheck" });
     const start = now();
-    const result = await exec(["pnpm", "-C", dir, "typecheck"], { env: subprocessEnv });
+    const result = await exec(composed.args, { env: subprocessEnv });
     const durationMs = now() - start;
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") failed = true;
+    const command = recordedValidationCommand(composed, "typecheck", [], result.commandDir);
     const summary = outputSummary(status, joinCommandOutput(result.stdout, result.stderr));
-    const record = buildValidationRecord({ name, status, command, exitCode: result.code, durationMs, summary });
+    const record = buildRanRecord({ name, status, command, exitCode: result.code, durationMs, summary });
     push({ name, script: "typecheck", label, scope, status, record });
   }
 
@@ -936,13 +1031,13 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       }
       continue;
     }
-    const dir = scopeDir(worktree, run.scope);
-    const command = `pnpm -C ${dir} ${run.script}`;
+    const composed = composeValidationCommand({ target, scope: run.scope, script: run.script });
     const start = now();
-    const result = await exec(["pnpm", "-C", dir, run.script], { env: subprocessEnv });
+    const result = await exec(composed.args, { env: subprocessEnv });
     const durationMs = now() - start;
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") failed = true;
+    const command = recordedValidationCommand(composed, run.script, [], result.commandDir);
     const output = joinCommandOutput(result.stdout, result.stderr);
     // One execution, one record per invariant it carries: the park names the
     // constraint a human must satisfy, not only the script that reported it.
@@ -951,7 +1046,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
         status === "failed"
           ? `repo-wide invariant — ${suite.why}: ${outputSummary(status, output)}`.slice(0, 1000)
           : outputSummary(status, output);
-      const record = buildValidationRecord({
+      const record = buildRanRecord({
         name: suite.name,
         status,
         command,

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1373,6 +1373,10 @@ export async function processIssue(
     }
     const feedback: RunFeedbackResult = await runFeedback(deps.pnpm, {
       worktree: workerBranch,
+      // A branch NAME, not a directory (#3041): `deps.pnpm` materialises it and
+      // reports back the absolute checkout it ran in. Declaring the kind keeps
+      // the gate from ever reading the branch token as a missing directory.
+      worktreeKind: "branch",
       scopes: feedbackScopes,
       layout: deps.layout,
       now: deps.nowEpoch,
@@ -1603,6 +1607,12 @@ export async function processIssue(
       postMergeGate: async (mergedTreeDir) => {
         const mergedFeedback = await runFeedback(deps.pnpm, {
           worktree: mergedTreeDir,
+          // The landing worktree is a DIRECTORY the caller just provisioned
+          // (#3041). Declaring it means a vanished one refuses the gate as an
+          // infrastructure error instead of composing commands against a path
+          // that resolves nowhere and calling the result the branch's verdict.
+          worktreeKind: "checkout",
+          ...(deps.dirExists === undefined ? {} : { dirExists: deps.dirExists }),
           scopes: landingFeedbackScopes,
           layout: deps.layout,
           now: deps.nowEpoch,

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -279,6 +279,13 @@ export interface ProcessIssueDeps {
   remoteGit: GitExec;
   pnpm: PnpmExec;
   validationResourceBudget?: { nodeMaxOldSpaceMb?: number; vitestMaxWorkers?: number };
+  /**
+   * Directory probe the gate uses to PROVE a declared validation worktree
+   * exists (#3041). Wired to the real filesystem in production; absent in a
+   * fixture, which is why an unprobed gate resolves its target but never
+   * refuses — a gate that cannot look at the disk claims nothing about it.
+   */
+  dirExists?: (dir: string) => boolean;
   layout: PackageLayout;
   graph?: WorkspaceGraph;
   backpressure?: BackpressureExec;

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -210,6 +210,12 @@ export interface ReconcileDeps {
   pnpm: PnpmExec;
   /** Package layout probe for feedback scope resolution. */
   layout: PackageLayout;
+  /**
+   * Directory probe proving a declared validation worktree exists (#3041).
+   * Absent → the gate resolves its target but never refuses; it cannot claim a
+   * directory is gone without having looked.
+   */
+  dirExists?: (dir: string) => boolean;
   /** One-shot inner-agent merge-conflict resolver for the DIRECT land (optional). */
   conflictResolver?: ConflictResolver;
   /**
@@ -580,6 +586,10 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
       postMergeGate: async (mergedTreeDir) => {
         const mergedFeedback = await deps.feedback.runFeedback(deps.pnpm, {
           worktree: mergedTreeDir,
+          // A provisioned DIRECTORY, not a branch token (#3041) — a missing one
+          // is an infrastructure error, never a red validation verdict.
+          worktreeKind: "checkout",
+          ...(deps.dirExists === undefined ? {} : { dirExists: deps.dirExists }),
           scopes: deps.feedback.gateScopes(deps.layout, changedFiles),
           layout: deps.layout,
           now: deps.nowEpoch,

--- a/apps/dev/src/core/validation-command.ts
+++ b/apps/dev/src/core/validation-command.ts
@@ -1,0 +1,262 @@
+// validation-command.ts — the gate's command-composition layer (#3041).
+//
+// Every `pnpm -C <dir> <script>` the post-DONE gate runs — and, more sharply,
+// every one it RECORDS — is composed here. A recorded command carrying a
+// RELATIVE `-C` path is unfalsifiable: it resolves against whatever the process
+// cwd happened to be, so a gate that never executed a byte reads exactly like a
+// branch whose typecheck failed. Worker wO0AR (#3027) recorded
+// `pnpm -C afk/3027-…/apps/dev typecheck` exiting 1 after 0 ms, burned its
+// re-seed budget against that phantom, and parked a branch whose own PR CI was
+// fully green; the only tell was the millisecond count.
+//
+// Three rules, one per way that verdict lied:
+//
+//   1. **A checkout token resolves to an ABSOLUTE path before composition.**
+//      The record then names a directory a reader can `ls`, and a token that
+//      resolved nowhere is visible as such instead of reading as a package dir.
+//   2. **A DECLARED checkout whose directory is missing is an infrastructure
+//      error, never a red validation verdict.** An unrunnable command judged
+//      nothing, so it may not consume a re-seed round or park a branch — the
+//      same honesty rule the admission verdicts follow: a refusal carries what
+//      it judged.
+//   3. **A suite-shaped command that exits in under a second did not run a
+//      suite.** The record carries `suspectInfra` and says why, rather than
+//      leaving the operator to spot the duration.
+//
+// A branch TOKEN is left verbatim on purpose. The AFK gate is posed with the
+// worker branch name (`afk/<n>-<slug>`), which the feedback-worktree executor
+// materialises and rewrites onto a real checkout at exec time; absolutising it
+// here would turn a branch name into a path nothing can check out. What the
+// executor resolves it to comes back as `ExecResult.commandDir` and is what
+// lands in the record, so the branch lane gets an absolute path too — measured
+// rather than composed.
+
+import { statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+/**
+ * Frozen wire vocabulary: `isInfraValidationFailure` matches these as
+ * substrings, so a summary appends to them rather than weaving them in.
+ */
+export const VALIDATION_TARGET_MISSING_MARKER = "validation worktree directory is missing";
+/** @see VALIDATION_TARGET_MISSING_MARKER */
+export const SUSPECT_INFRA_MARKER = "suspect-infra";
+
+/**
+ * How fast a suite-shaped command has to exit before its verdict is suspect.
+ * `pnpm`'s own startup — resolving the workspace, spawning the script — costs
+ * more than this on every host we run on, so a sub-second exit means the suite
+ * never started. Deliberately coarse: the claim is "this did not run", not a
+ * performance budget.
+ */
+export const SUITE_MIN_PLAUSIBLE_MS = 1000;
+
+/**
+ * What the `worktree` token IS.
+ *
+ * - `checkout` — a directory on disk. Resolved to an absolute path; a missing
+ *   one is an infrastructure refusal.
+ * - `branch` — a branch name the executor materialises later. Left verbatim.
+ */
+export type ValidationTargetKind = "checkout" | "branch";
+
+export interface ValidationTarget {
+  kind: ValidationTargetKind;
+  /**
+   * What commands compose against: the ABSOLUTE checkout directory for a
+   * `checkout` target, the branch token verbatim for a `branch` one.
+   */
+  root: string;
+  /** The token exactly as the caller stated it. */
+  token: string;
+  /**
+   * True only for a `checkout` the caller DECLARED whose directory could not be
+   * found. An auto-detected token is never `missing` — absent a declaration
+   * there is no proof a token that is not a directory was meant to be one.
+   */
+  missing: boolean;
+  /** Every absolute path probed while resolving the token, for the diagnostic. */
+  probed: readonly string[];
+}
+
+export interface ResolveValidationTargetOptions {
+  /** The checkout a relative token is anchored to — never the process cwd. */
+  root: string;
+  /**
+   * Directory probe, and the gate's only source of PROOF. Injected so the
+   * composition layer stays pure; production passes {@link realDirectoryProbe}.
+   * Omitted → the target is resolved but never probed, and so is never
+   * `missing`: a gate that cannot look at the disk has no grounds to refuse.
+   */
+  isDirectory?: (dir: string) => boolean;
+  /**
+   * What the caller KNOWS the token to be. Omitted → auto-detect, which can
+   * only ever downgrade to `branch`: a caller that has not declared a checkout
+   * has not given the gate grounds to refuse.
+   */
+  kind?: ValidationTargetKind;
+}
+
+/** `statSync`-backed directory probe. Any error reads as "not a directory". */
+export function realDirectoryProbe(dir: string): boolean {
+  try {
+    return statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a `worktree` token to the thing commands compose against.
+ *
+ * A relative checkout token is anchored to `root` first and to the process cwd
+ * only as a fallback — the cwd is exactly the ambient state that made the
+ * #3027 record unreadable, so it is the last resort rather than the default.
+ */
+export function resolveValidationTarget(
+  token: string,
+  opts: ResolveValidationTargetOptions,
+): ValidationTarget {
+  const anchor = resolve(opts.root);
+  const isDirectory = opts.isDirectory;
+
+  if (opts.kind === "branch") {
+    return { kind: "branch", root: token, token, missing: false, probed: [] };
+  }
+
+  const probed = token === ""
+    ? [anchor]
+    : isAbsolute(token)
+      ? [resolve(token)]
+      : [resolve(anchor, token), resolve(token)];
+
+  // No probe, no proof. A DECLARED checkout still resolves to an ABSOLUTE path
+  // — that alone fixes the unreadable record — but it is never called missing,
+  // and an undeclared token stays the branch name the executor materialises.
+  if (isDirectory === undefined) {
+    if (opts.kind === "checkout") {
+      return { kind: "checkout", root: probed[0] ?? anchor, token, missing: false, probed };
+    }
+    return { kind: "branch", root: token, token, missing: false, probed: [] };
+  }
+
+  for (const candidate of probed) {
+    if (isDirectory(candidate)) {
+      return { kind: "checkout", root: candidate, token, missing: false, probed };
+    }
+  }
+
+  // Nothing on disk. Only a DECLARED checkout is refused; an undeclared token
+  // is a branch name the executor will materialise (the AFK gate's normal
+  // shape), and calling that a missing directory would refuse every worker run.
+  if (opts.kind === "checkout") {
+    return { kind: "checkout", root: probed[0] ?? anchor, token, missing: true, probed };
+  }
+  return { kind: "branch", root: token, token, missing: false, probed };
+}
+
+/** The one-line cause a missing-target refusal records. */
+export function targetMissingSummary(target: ValidationTarget): string {
+  const tried = target.probed.map((p) => `\`${p}\``).join(", ") || "no candidate";
+  return (
+    `${VALIDATION_TARGET_MISSING_MARKER}: \`${target.token}\` resolved to ${tried}, ` +
+    `none of which is a directory — the gate ran nothing, so this is an infrastructure ` +
+    `error and not the branch's validation verdict`
+  );
+}
+
+export interface ComposedValidationCommand {
+  /** The `-C` argument. Absolute whenever the target is a checkout. */
+  dir: string;
+  /** Full argv, `pnpm` head included, ready for the injected executor. */
+  args: string[];
+  /** The display string a `red.afk.validation.v1` record carries. */
+  command: string;
+}
+
+/**
+ * Compose one validation command for `scope` under `target`.
+ *
+ * The scope join is deliberately different per kind: a checkout is resolved
+ * (absolute, normalised), a branch token is concatenated so the executor's
+ * `splitBranchDir` can still peel the package suffix back off.
+ */
+export function composeValidationCommand(input: {
+  target: ValidationTarget;
+  /** Package scope, `"."` for the target root. */
+  scope: string;
+  /** The package script to run. */
+  script: string;
+  /** Extra args appended after `--` (the quarantine `--exclude` list). */
+  extraArgs?: readonly string[];
+}): ComposedValidationCommand {
+  const { target, scope, script } = input;
+  const extraArgs = input.extraArgs ?? [];
+  const dir =
+    scope === "." || scope === ""
+      ? target.root
+      : target.kind === "checkout"
+        ? resolve(target.root, scope)
+        : `${target.root}/${scope}`;
+  const args = ["pnpm", "-C", dir, script, ...(extraArgs.length > 0 ? ["--", ...extraArgs] : [])];
+  return { dir, args, command: renderValidationCommand(dir, script, extraArgs) };
+}
+
+/** `pnpm -C <dir> <script>[ -- <extra…>]` — the record's display string. */
+export function renderValidationCommand(
+  dir: string,
+  script: string,
+  extraArgs: readonly string[] = [],
+): string {
+  const tail = extraArgs.length > 0 ? ` -- ${extraArgs.join(" ")}` : "";
+  return `pnpm -C ${dir} ${script}${tail}`;
+}
+
+/**
+ * The command to RECORD, given where the executor actually ran it.
+ *
+ * `commandDir` is the executor's own answer: the feedback-worktree executor
+ * rewrites a branch token onto the materialised checkout, so the record can
+ * name the absolute directory the suite really ran in rather than the branch
+ * token that was posed to it. Absent (no rewrite, or setup failed before the
+ * command existed) → the composed command stands.
+ */
+export function recordedValidationCommand(
+  composed: ComposedValidationCommand,
+  script: string,
+  extraArgs: readonly string[] = [],
+  commandDir?: string,
+): string {
+  if (commandDir === undefined || commandDir === "") return composed.command;
+  return renderValidationCommand(commandDir, script, extraArgs);
+}
+
+/**
+ * Did this failure exit too fast to have run anything?
+ *
+ * Only failures are judged — a suite that PASSES in 3 ms is a caching win, not
+ * a lie — and only measured durations: an unmeasured check makes no claim.
+ */
+export function isSuspectInfraFailure(input: {
+  status: string;
+  durationMs?: number;
+}): boolean {
+  if (input.status !== "failed") return false;
+  const { durationMs } = input;
+  if (durationMs === undefined || !Number.isFinite(durationMs) || durationMs < 0) return false;
+  return durationMs < SUITE_MIN_PLAUSIBLE_MS;
+}
+
+/** Prefix a summary with the suspect-infra claim and the evidence for it. */
+export function suspectInfraSummary(input: {
+  command: string;
+  exitCode: number;
+  durationMs: number;
+  summary: string;
+}): string {
+  const head =
+    `${SUSPECT_INFRA_MARKER}: \`${input.command}\` exited ${input.exitCode} after ` +
+    `${input.durationMs}ms — under ${SUITE_MIN_PLAUSIBLE_MS}ms is too fast for a suite ` +
+    `command to have started, so read this as an environment failure before the branch's`;
+  return input.summary === "" ? head : `${head}. ${input.summary}`;
+}

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -46,7 +46,7 @@
 
 import { accessSync, constants, readFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
-import { dirname, isAbsolute, join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import {
   buildFeedbackSubprocessEnv,
   type Exec as PnpmExec,
@@ -770,12 +770,17 @@ export function makeFeedbackWorktree(
       if (base === null) {
         return { code: 1, stdout: "", stderr: setupFailureMessage(branch) };
       }
-      const rewritten = scope === "." ? base : join(base, scope);
+      const rewritten = resolve(scope === "." ? base : join(base, scope));
       const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
       const r = await runValidationCommand(
         () => io.pnpm(["-C", rewritten, ...rest], { cwd: root, env }),
       );
-      return { code: r.code, stdout: r.stdout, stderr: r.stderr };
+      // Report the ABSOLUTE directory the command really ran in (#3041). The
+      // gate composed its record against the BRANCH token it posed; without
+      // this the record reads `pnpm -C afk/<n>-<slug>/apps/dev …`, which looks
+      // like a relative path that resolves nowhere and is indistinguishable
+      // from a command that never ran.
+      return { code: r.code, stdout: r.stdout, stderr: r.stderr, commandDir: rewritten };
     }
     const head = args[0] === "pnpm" ? args.slice(1) : args;
     const r = await runValidationCommand(() => io.pnpm(head, { cwd: root, env }));

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -202,7 +202,10 @@ describe("runFeedback", () => {
     expect(result.ok).toBe(false);
     const test = result.checks.find((ch) => ch.name === "test:plugins/memory");
     expect(test?.status).toBe("failed");
-    expect(test?.record.summary).toBe("boom failed here");
+    // The fake clock advances 5ms per read, so this failure is sub-second and
+    // carries the #3041 suspect-infra prefix — the captured output survives it.
+    expect(test?.record.summary).toContain("boom failed here");
+    expect(test?.record.suspectInfra).toBe(true);
   });
 
   it("produces the exact red.afk.validation.v1 sidecar record shape", async () => {
@@ -236,6 +239,105 @@ describe("runFeedback", () => {
     expect(test?.record).toEqual(expected);
     // Sidecar line is the compact JSON of the record, schema-first.
     expect(result.sidecar).toContain(JSON.stringify(expected));
+  });
+
+  it("refuses a DECLARED checkout whose directory is gone, as infra, running nothing (#3041)", async () => {
+    const layout = fakeLayout({
+      packages: ["apps/dev"],
+      scripts: { "apps/dev": ["test", "typecheck"] },
+    });
+    const { exec, calls } = fakeExec();
+    const result = await runFeedback(exec, {
+      worktree: "afk/3027-dispatch-survives-the-dispatcher-workers",
+      worktreeKind: "checkout",
+      root: "/repo",
+      dirExists: () => false,
+      scopes: ["apps/dev"],
+      layout,
+      now: fakeClock(),
+    });
+
+    expect(result.ok).toBe(false);
+    // Not one command was composed, let alone run — an unrunnable gate judged
+    // nothing, so it may not spend a re-seed round or park the branch.
+    expect(calls).toEqual([]);
+    expect(result.checks.map((ch) => ch.name)).toEqual(["validation:worktree-missing"]);
+    // The routing that matters: INFRA, so the lifecycle takes the bounded
+    // recovery path instead of `blocked:validation`.
+    expect(isInfraFeedbackFailure(result)).toBe(true);
+    expect(result.checks[0]?.record.summary).toContain(
+      "validation worktree directory is missing",
+    );
+  });
+
+  it("records the ABSOLUTE directory the executor ran in, not the branch token (#3041)", async () => {
+    const layout = fakeLayout({
+      packages: ["apps/dev"],
+      scripts: { "apps/dev": ["typecheck"] },
+    });
+    // The AFK executor materialises the branch and reports back where it ran.
+    const exec: Exec = async () => ({
+      code: 0,
+      stdout: "",
+      stderr: "",
+      commandDir: "/repo/.red/tmp/feedback/afk-3027-dispatch/apps/dev",
+    });
+    const result = await runFeedback(exec, {
+      worktree: "afk/3027-dispatch",
+      worktreeKind: "branch",
+      scopes: ["apps/dev"],
+      layout,
+      now: fakeClock(),
+    });
+
+    const check = result.checks.find((ch) => ch.name === "typecheck:apps/dev");
+    expect(check?.record.command).toBe(
+      "pnpm -C /repo/.red/tmp/feedback/afk-3027-dispatch/apps/dev typecheck",
+    );
+  });
+
+  it("flags a sub-second suite failure as suspect-infra in the record (#3041)", async () => {
+    const layout = fakeLayout({
+      packages: ["apps/dev"],
+      scripts: { "apps/dev": ["typecheck"] },
+    });
+    const { exec } = fakeExec([
+      { match: (a) => a.includes("typecheck"), result: { code: 1, stdout: "", stderr: "" } },
+    ]);
+    const result = await runFeedback(exec, {
+      worktree: "afk/3027-dispatch",
+      worktreeKind: "branch",
+      scopes: ["apps/dev"],
+      layout,
+      // 1ms — the #3027 signature: a verdict reported before pnpm could start.
+      now: fakeClock(1),
+    });
+
+    const check = result.checks.find((ch) => ch.name === "typecheck:apps/dev");
+    expect(check?.record.durationMs).toBe(1);
+    expect(check?.record.suspectInfra).toBe(true);
+    expect(check?.record.summary).toContain("suspect-infra");
+  });
+
+  it("leaves a plausibly-timed failure unflagged (#3041)", async () => {
+    const layout = fakeLayout({
+      packages: ["apps/dev"],
+      scripts: { "apps/dev": ["typecheck"] },
+    });
+    const { exec } = fakeExec([
+      { match: (a) => a.includes("typecheck"), result: { code: 1, stdout: "3 errors\n" } },
+    ]);
+    const result = await runFeedback(exec, {
+      worktree: "afk/3027-dispatch",
+      worktreeKind: "branch",
+      scopes: ["apps/dev"],
+      layout,
+      now: fakeClock(9000),
+    });
+
+    const check = result.checks.find((ch) => ch.name === "typecheck:apps/dev");
+    expect(check?.record.suspectInfra).toBeUndefined();
+    expect(check?.record.summary).toBe("3 errors");
   });
 
   it("emits per-script no-package skips when the repo has no package", async () => {

--- a/apps/dev/tests/validation-command.test.ts
+++ b/apps/dev/tests/validation-command.test.ts
@@ -1,0 +1,200 @@
+// validation-command.test.ts — the gate's command-composition layer (#3041).
+//
+// The incident this pins: worker wO0AR recorded
+// `pnpm -C afk/3027-…/apps/dev typecheck` failing with exitCode 1 after 0 ms,
+// which is a command that never ran being reported as the branch's validation
+// verdict. Three claims are tested here, one per way that record lied.
+
+import { describe, expect, it } from "vitest";
+import { resolve } from "node:path";
+import {
+  composeValidationCommand,
+  isSuspectInfraFailure,
+  recordedValidationCommand,
+  renderValidationCommand,
+  resolveValidationTarget,
+  suspectInfraSummary,
+  targetMissingSummary,
+  SUITE_MIN_PLAUSIBLE_MS,
+  SUSPECT_INFRA_MARKER,
+  VALIDATION_TARGET_MISSING_MARKER,
+} from "../src/core/validation-command.js";
+
+/** Directory probe over a fixed set of existing dirs — no disk touched. */
+function fakeDirs(dirs: readonly string[]): (dir: string) => boolean {
+  const set = new Set(dirs.map((d) => resolve(d)));
+  return (dir) => set.has(resolve(dir));
+}
+
+describe("target resolution", () => {
+  it("anchors a relative checkout token to the root, never the process cwd", () => {
+    const target = resolveValidationTarget(".red/tmp/worktrees/rebase/slug-0", {
+      root: "/repo",
+      kind: "checkout",
+      isDirectory: fakeDirs(["/repo/.red/tmp/worktrees/rebase/slug-0"]),
+    });
+
+    expect(target.kind).toBe("checkout");
+    expect(target.root).toBe(resolve("/repo/.red/tmp/worktrees/rebase/slug-0"));
+    expect(target.missing).toBe(false);
+  });
+
+  it("normalises an absolute checkout token and keeps it absolute", () => {
+    const target = resolveValidationTarget("/repo/./worktree", {
+      root: "/repo",
+      kind: "checkout",
+      isDirectory: fakeDirs(["/repo/worktree"]),
+    });
+
+    expect(target.root).toBe(resolve("/repo/worktree"));
+    expect(target.missing).toBe(false);
+  });
+
+  it("marks a DECLARED checkout whose directory is gone as missing", () => {
+    const target = resolveValidationTarget("afk/3027-dispatch/worktree", {
+      root: "/repo",
+      kind: "checkout",
+      isDirectory: fakeDirs([]),
+    });
+
+    expect(target.kind).toBe("checkout");
+    expect(target.missing).toBe(true);
+    expect(target.probed[0]).toBe(resolve("/repo/afk/3027-dispatch/worktree"));
+    expect(targetMissingSummary(target)).toContain(VALIDATION_TARGET_MISSING_MARKER);
+  });
+
+  it("leaves a declared branch token verbatim and never calls it missing", () => {
+    const target = resolveValidationTarget("afk/3027-dispatch-survives", {
+      root: "/repo",
+      kind: "branch",
+      isDirectory: fakeDirs([]),
+    });
+
+    expect(target.kind).toBe("branch");
+    expect(target.root).toBe("afk/3027-dispatch-survives");
+    expect(target.missing).toBe(false);
+  });
+
+  it("without a probe, resolves a declared checkout absolutely but never calls it missing", () => {
+    // No probe, no proof: the gate still fixes the record (absolute `-C`) but
+    // makes no claim about a disk it was never given the means to read.
+    const target = resolveValidationTarget(".red/tmp/worktrees/rebase/slug-0", {
+      root: "/repo",
+      kind: "checkout",
+    });
+
+    expect(target.kind).toBe("checkout");
+    expect(target.root).toBe(resolve("/repo/.red/tmp/worktrees/rebase/slug-0"));
+    expect(target.missing).toBe(false);
+  });
+
+  it("without a probe, an undeclared token stays a branch the executor materialises", () => {
+    const target = resolveValidationTarget("afk/3027-dispatch", { root: "/repo" });
+
+    expect(target.kind).toBe("branch");
+    expect(target.root).toBe("afk/3027-dispatch");
+  });
+
+  it("auto-detection downgrades an unknown token to a branch rather than refusing", () => {
+    // Absent a declaration there is no proof the token was meant to be a
+    // directory — refusing here would refuse every AFK worker run.
+    const target = resolveValidationTarget("afk/3027-dispatch", {
+      root: "/repo",
+      isDirectory: fakeDirs([]),
+    });
+
+    expect(target.kind).toBe("branch");
+    expect(target.missing).toBe(false);
+  });
+});
+
+describe("command composition", () => {
+  it("records an ABSOLUTE -C path for every checkout scope", () => {
+    const target = resolveValidationTarget("wt", {
+      root: "/repo",
+      kind: "checkout",
+      isDirectory: fakeDirs(["/repo/wt"]),
+    });
+
+    const scoped = composeValidationCommand({ target, scope: "apps/dev", script: "typecheck" });
+    const root = composeValidationCommand({ target, scope: ".", script: "test" });
+
+    expect(scoped.dir).toBe(resolve("/repo/wt/apps/dev"));
+    expect(scoped.args).toEqual(["pnpm", "-C", resolve("/repo/wt/apps/dev"), "typecheck"]);
+    expect(scoped.command).toBe(`pnpm -C ${resolve("/repo/wt/apps/dev")} typecheck`);
+    expect(root.dir).toBe(resolve("/repo/wt"));
+  });
+
+  it("appends quarantine excludes after `--` in both the argv and the record", () => {
+    const target = resolveValidationTarget("wt", {
+      root: "/repo",
+      kind: "checkout",
+      isDirectory: fakeDirs(["/repo/wt"]),
+    });
+
+    const composed = composeValidationCommand({
+      target,
+      scope: "apps/dev",
+      script: "test",
+      extraArgs: ["--exclude", "**/flaky.test.ts"],
+    });
+
+    expect(composed.args.slice(-3)).toEqual(["--", "--exclude", "**/flaky.test.ts"]);
+    expect(composed.command).toContain("-- --exclude **/flaky.test.ts");
+  });
+
+  it("concatenates a branch token so the executor can peel the scope back off", () => {
+    const target = resolveValidationTarget("afk/3027-dispatch", { root: "/repo", kind: "branch" });
+    const composed = composeValidationCommand({ target, scope: "apps/dev", script: "typecheck" });
+
+    expect(composed.dir).toBe("afk/3027-dispatch/apps/dev");
+  });
+
+  it("records the directory the executor really ran in, not the branch token", () => {
+    const target = resolveValidationTarget("afk/3027-dispatch", { root: "/repo", kind: "branch" });
+    const composed = composeValidationCommand({ target, scope: "apps/dev", script: "typecheck" });
+
+    const recorded = recordedValidationCommand(
+      composed,
+      "typecheck",
+      [],
+      "/repo/.red/tmp/feedback/afk-3027-dispatch/apps/dev",
+    );
+
+    expect(recorded).toBe(
+      "pnpm -C /repo/.red/tmp/feedback/afk-3027-dispatch/apps/dev typecheck",
+    );
+    // No rewrite reported → the composed command stands, unchanged.
+    expect(recordedValidationCommand(composed, "typecheck", [])).toBe(composed.command);
+  });
+
+  it("renders the same shape whether the command is composed or re-rendered", () => {
+    expect(renderValidationCommand("/repo/apps/dev", "lint")).toBe("pnpm -C /repo/apps/dev lint");
+  });
+});
+
+describe("suspect-infra duration", () => {
+  it("flags a sub-second FAILURE of a suite command", () => {
+    expect(isSuspectInfraFailure({ status: "failed", durationMs: 0 })).toBe(true);
+    expect(isSuspectInfraFailure({ status: "failed", durationMs: SUITE_MIN_PLAUSIBLE_MS - 1 })).toBe(true);
+  });
+
+  it("leaves a plausible failure, a fast pass, and an unmeasured check alone", () => {
+    expect(isSuspectInfraFailure({ status: "failed", durationMs: SUITE_MIN_PLAUSIBLE_MS })).toBe(false);
+    expect(isSuspectInfraFailure({ status: "passed", durationMs: 3 })).toBe(false);
+    expect(isSuspectInfraFailure({ status: "failed" })).toBe(false);
+  });
+
+  it("spells the evidence into the summary instead of leaving a duration to notice", () => {
+    const summary = suspectInfraSummary({
+      command: "pnpm -C /repo/apps/dev typecheck",
+      exitCode: 1,
+      durationMs: 1,
+      summary: "command exited non-zero",
+    });
+
+    expect(summary).toContain(SUSPECT_INFRA_MARKER);
+    expect(summary).toContain("exited 1 after 1ms");
+    expect(summary).toContain("command exited non-zero");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3041. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3041

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788228298&installation_model_id=20659&pr_number=3051&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3051&signature=b24ad19383a4ac28a48a37740ea95c9c254f30598b737be3789de36b8867520b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->