### PR TITLE
fix: #3092 Every client reports a live, working redskilled daemon as one that never started — and tells the operator to provision it

### DIFF
--- a/apps/dev/src/runtime/redskilled-birth.ts
+++ b/apps/dev/src/runtime/redskilled-birth.ts
@@ -28,6 +28,8 @@ import {
   registerRedskilledProject,
   renewRedskilledProject,
   readRedskilledHostState,
+  redskilledPresenceAdvice,
+  RedskilledUnreachableError,
   startRedskilledWorker,
   type RedskilledClientConfig,
 } from "@reddb-io/redskilled/client";
@@ -44,7 +46,7 @@ import type { RedskilledLaunchTemplate } from "@reddb-io/redskilled/launch-templ
 // Re-exported so a consumer of this port imports the host's vocabulary from the
 // one module that owns the project's reach into it — a second import path for
 // the same names is how two spellings of one boundary start.
-export { RedskilledUnreachableError } from "@reddb-io/redskilled/client";
+export { RedskilledDaemonHeldError, RedskilledUnreachableError } from "@reddb-io/redskilled/client";
 export type { RedskilledWorkerStarted } from "@reddb-io/redskilled/protocol";
 export type {
   RedskilledHostEvent,
@@ -302,8 +304,7 @@ export function redskilledRegistrationRefusal(socketPath: string, cause: unknown
     `this project was not registered: the redskilled daemon did not answer on ${socketPath}. ` +
     `Since ADR 0130 Amendment 4 a project contributes a registration rather than a process, so a project ` +
     `that cannot reach the daemon starts nothing rather than launching a demand producer no host admitted, ` +
-    `counts or can stop. Run \`${canonicalInvocation("red-skills-redskilled", ["provision"])}\` ` +
-    `(or \`/red-setup\`) to install it, then retry. (${detail})`
+    `counts or can stop. ${repairFor(cause)} (${detail})`
   );
 }
 
@@ -312,8 +313,24 @@ export function redskilledUnreachableAdvice(socketPath: string, cause: unknown):
   return (
     `no Worker was started: the redskilled daemon did not answer on ${socketPath}. ` +
     `Since ADR 0130 the daemon owns every birth, so a project that cannot reach it starts nothing ` +
-    `rather than spawning an unbudgeted Worker of its own. Run ` +
-    `\`${canonicalInvocation("red-skills-redskilled", ["provision"])}\` (or \`/red-setup\`) to install it, ` +
-    `then retry. (${detail})`
+    `rather than spawning an unbudgeted Worker of its own. ${repairFor(cause)} (${detail})`
+  );
+}
+
+/**
+ * The repair the observed silence actually takes.
+ *
+ * **Never advise provisioning a daemon that is running** (#3092). When the reach
+ * established that a live pid holds the socket, the operator's next action is on
+ * THAT process — the presence carries its pid, its uptime and its socket — and
+ * telling them to install one instead sends them to reinstall what is already
+ * serving. Only a silence with no live holder is an absence.
+ */
+function repairFor(cause: unknown): string {
+  const presence = cause instanceof RedskilledUnreachableError ? cause.presence : undefined;
+  if (presence != null && presence.kind === "held-unresponsive") return redskilledPresenceAdvice(presence);
+  return (
+    `Run \`${canonicalInvocation("red-skills-redskilled", ["provision"])}\` (or \`/red-setup\`) to install it, ` +
+    `then retry.`
   );
 }

--- a/apps/dev/tests/redskilled-birth.test.ts
+++ b/apps/dev/tests/redskilled-birth.test.ts
@@ -12,8 +12,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startRedskilledDaemon, type RedskilledDaemon } from "@reddb-io/redskilled/daemon";
 import { resolveRedskilledPaths, type RedskilledPaths } from "@reddb-io/redskilled/paths";
+import { describeRedskilledPresence, RedskilledUnreachableError } from "@reddb-io/redskilled/client";
 import {
   createRedskilledBirthPort,
+  redskilledRegistrationRefusal,
   redskilledUnreachableAdvice,
   resolveProjectLabel,
 } from "../src/runtime/redskilled-birth.js";
@@ -202,5 +204,42 @@ describe("the project's identity and its advice", () => {
     expect(advice).toContain("/run/user/1/redskilled.sock");
     expect(advice).toContain("redskilled provision");
     expect(advice).toContain("boom");
+  });
+
+  it("never advises provisioning a daemon a live pid is already holding", () => {
+    // #3092: the reach established that pid 900870 holds the socket and did not
+    // answer. Telling an operator to install one sends them to reinstall what is
+    // already serving — the sentence that cost three rounds of ps/ss to see past.
+    const socketPath = "/run/user/1/redskilled.sock";
+    const presence = describeRedskilledPresence({
+      socketPath,
+      answers: false,
+      lease: {
+        version: 1,
+        pid: 900_870,
+        start_time: "2026-08-02T17:04:25.362Z",
+        session_key_hash: "aaa",
+        machine_id_hash: "bbb",
+        socket_path: socketPath,
+        acquired_at: "2026-08-02T17:04:25.362Z",
+        renewed_at: "2026-08-02T17:04:25.362Z",
+      },
+      holderAlive: true,
+      now: "2026-08-02T21:47:51.362Z",
+    });
+    const advice = redskilledUnreachableAdvice(
+      socketPath,
+      new RedskilledUnreachableError(socketPath, new Error("no answer"), presence),
+    );
+
+    expect(advice).toContain("900870");
+    expect(advice).toContain("Do not provision");
+    expect(advice).not.toContain("redskilled provision");
+    // The same discrimination on the registration refusal, which is a sibling
+    // sentence rather than a reuse of this one.
+    expect(redskilledRegistrationRefusal(
+      socketPath,
+      new RedskilledUnreachableError(socketPath, new Error("no answer"), presence),
+    )).toContain("Do not provision");
   });
 });

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -27,6 +27,12 @@ import {
 } from "./daemon-entry.js";
 import { requireRedskilledEntryWithFetch } from "./entry-fetch.js";
 import { socketAnswers } from "./daemon.js";
+import {
+  describeRedskilledPresence,
+  redskilledPresenceAdvice,
+  type RedskilledPresence,
+} from "./daemon-presence.js";
+import { readRedskilledLeaseFile } from "./session-lease.js";
 import { buildRedskilledNotRunningStop, type RedskilledDaemonStopped } from "./daemon-stop.js";
 import { isRedskilledHostState, type RedskilledHostState } from "./host-state.js";
 import { createRedskilledMachineClaimStore, RedskilledMachineHeldError } from "./machine-scope.js";
@@ -91,6 +97,19 @@ export {
   type RedskilledMachineRefusal,
 } from "./machine-scope.js";
 
+// Presence travels with the reach for the same reason: the surface that catches
+// an unreachable daemon is the surface that must tell an operator which of the
+// three silences it was, and it should not need a second import path to read it.
+export {
+  describeRedskilledPresence,
+  formatUptime,
+  isRedskilledPresence,
+  redskilledPresenceAdvice,
+  type RedskilledPresence,
+  type RedskilledPresenceHolder,
+  type RedskilledPresenceKind,
+} from "./daemon-presence.js";
+
 /** How long a client waits for a daemon — its own or the race winner's — to answer. */
 export const DEFAULT_REDSKILLED_READY_TIMEOUT_MS = 10_000;
 
@@ -106,14 +125,59 @@ export class RedskilledUnreachableError extends Error {
   constructor(
     readonly socketPath: string,
     override readonly cause: unknown,
+    /**
+     * Which of the three silences this was, when it could be established.
+     *
+     * Carried on the error rather than left to each surface to re-derive: a
+     * consumer that re-probed would be asking a second time, a second later, and
+     * could print an answer the failure it is reporting never had (#3092).
+     */
+    readonly presence?: RedskilledPresence,
   ) {
     super(
       `redskilled daemon is unreachable on ${JSON.stringify(socketPath)}, so no Worker was started: ${
         cause instanceof Error ? cause.message : String(cause)
-      }`,
+      }${presence != null && presence.kind === "held-unresponsive" ? `. ${redskilledPresenceAdvice(presence)}` : ""}`,
     );
     this.name = "RedskilledUnreachableError";
   }
+}
+
+/**
+ * Raised when the daemon IS there — a live pid holds this socket's lease — and
+ * still did not answer.
+ *
+ * A subclass rather than a sibling, so every consumer that already fails closed
+ * on {@link RedskilledUnreachableError} keeps doing so, while a surface that
+ * renders operator advice can tell the two apart and stop telling an operator to
+ * install a daemon that is running (#3092).
+ */
+export class RedskilledDaemonHeldError extends RedskilledUnreachableError {
+  constructor(socketPath: string, override readonly presence: RedskilledPresence, cause: unknown) {
+    super(socketPath, cause, presence);
+    this.name = "RedskilledDaemonHeldError";
+  }
+}
+
+/**
+ * Ask what is actually on this socket: answering, held-but-silent, or absent.
+ *
+ * The one probe every surface shares. It reads the socket and the lease and hands
+ * both to the pure classifier, so "which of the three states is this?" has one
+ * answer on the machine rather than one per caller.
+ */
+export async function probeRedskilledPresence(
+  paths: RedskilledPaths,
+  options: { readonly answers?: boolean } = {},
+): Promise<RedskilledPresence> {
+  const answers = options.answers ?? (await socketAnswers(paths.socketPath));
+  const lease = await readRedskilledLeaseFile(paths.leasePath).catch(() => undefined);
+  return describeRedskilledPresence({
+    socketPath: paths.socketPath,
+    answers,
+    lease,
+    holderAlive: lease != null && isPidAlive(lease.pid),
+  });
 }
 
 export interface RedskilledClientConfig {
@@ -161,7 +225,12 @@ export async function ensureRedskilledDaemon(
     // OTHER way this ends without a live socket becomes ONE named state, so a
     // caller can never read "no host answered" as "the host answered nothing".
     if (err instanceof RedskilledMachineHeldError) throw err;
-    throw err instanceof RedskilledUnreachableError ? err : new RedskilledUnreachableError(paths.socketPath, err);
+    if (err instanceof RedskilledUnreachableError) throw err;
+    // The presence is read HERE, once, on the way out: a failure that carries no
+    // account of what is on the socket is the failure that told an operator to
+    // provision a daemon serving five hours of work (#3092).
+    const presence = await probeRedskilledPresence(paths).catch(() => undefined);
+    throw new RedskilledUnreachableError(paths.socketPath, err, presence);
   }
 }
 
@@ -176,6 +245,14 @@ async function reachRedskilledDaemon(
   // already has a daemon somewhere this session cannot see (ADR 0130 Amendment 3).
   // Spawning first and refusing afterwards would still have been two daemons.
   await refuseWhenMachineIsHeld(paths);
+
+  // And ask the socket's own lease before spawning too. A live pid holding THIS
+  // socket is a daemon that exists, so the spawn about to happen would be refused
+  // by the singleton guard — correctly — and its `exit 1` would then be reported
+  // as "the daemon did not start" (#3092). Waiting is what a client owes a daemon
+  // that is booting; naming the holder is what it owes one that is wedged.
+  const held = await waitOutTheLeaseHolder(paths, config);
+  if (held != null) return held;
 
   const lock = await tryAcquireExclusiveLock(paths.lockPath);
   if (!lock) {
@@ -196,6 +273,47 @@ async function reachRedskilledDaemon(
     await lock.close();
     await rm(paths.lockPath, { force: true });
   }
+}
+
+/**
+ * Wait for the daemon the lease already names, instead of spawning a rival.
+ *
+ * Returns `"joined"` when the holder started answering inside the ready window,
+ * `null` when there is no live holder (so the ordinary spawn should proceed), and
+ * THROWS {@link RedskilledDaemonHeldError} when a live pid holds this socket and
+ * never answered — which is a daemon to inspect or stop, not one to install.
+ *
+ * A lease is written before the socket is bound, so a holder that is merely mid-
+ * boot is the common case and waiting for it is exactly right; the throw is what
+ * an operator gets only after the same window the spawn path would have used.
+ */
+async function waitOutTheLeaseHolder(
+  paths: RedskilledPaths,
+  config: RedskilledClientConfig,
+): Promise<"joined" | null> {
+  const presence = await probeRedskilledPresence(paths, { answers: false }).catch(() => undefined);
+  if (presence == null || presence.kind !== "held-unresponsive") return null;
+
+  const timeoutMs = config.readyTimeoutMs ?? DEFAULT_REDSKILLED_READY_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await socketAnswers(paths.socketPath)) return "joined";
+    if (Date.now() >= deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  // Re-read rather than reusing the opening snapshot: a holder that exited during
+  // the wait leaves a stale record, and reporting a dead pid as the live owner is
+  // the same class of lie in the other direction.
+  const settled = await probeRedskilledPresence(paths).catch(() => undefined);
+  if (settled == null || settled.kind !== "held-unresponsive") return null;
+  throw new RedskilledDaemonHeldError(
+    paths.socketPath,
+    settled,
+    new Error(
+      `it did not answer a ping within ${timeoutMs}ms, and no second daemon was spawned because pid ` +
+        `${settled.holder?.pid ?? "unknown"} still holds this socket`,
+    ),
+  );
 }
 
 /**
@@ -250,7 +368,12 @@ export async function requestRedskilled(
   } catch (err) {
     // A socket that answered a ping and then died mid-request is still the host
     // saying nothing; only an `ok: false` answer is the host refusing something.
-    throw new RedskilledUnreachableError(paths.socketPath, err);
+    // Which of the three silences it became is read now, while it is true.
+    throw new RedskilledUnreachableError(
+      paths.socketPath,
+      err,
+      await probeRedskilledPresence(paths).catch(() => undefined),
+    );
   }
   if (!response.ok) throw new Error(response.error);
   return response.value;

--- a/apps/redskilled/src/daemon-presence.ts
+++ b/apps/redskilled/src/daemon-presence.ts
@@ -1,0 +1,162 @@
+/**
+ * daemon-presence — "I could not reach it" is not "it is not there" (#3092).
+ *
+ * A client that finds no answer on the socket has learned ONE thing: it got no
+ * answer. Three different worlds produce that silence, and they take three
+ * different repairs:
+ *
+ * 1. **absent** — no socket, no lease, nothing holding the machine. The repair is
+ *    to start one, and that is the only state where telling an operator to
+ *    provision is true.
+ * 2. **held-unresponsive** — a lease names a pid that is alive and holds this very
+ *    socket, and it still did not answer a ping. There IS a daemon; the repair is
+ *    to inspect or stop THAT process, never to install another.
+ * 3. **answering** — it answered, and there is nothing to repair.
+ *
+ * Collapsing the first two is what #3092 was: a client whose redundant spawn was
+ * refused (correctly — the singleton guard working) rendered that refusal as "the
+ * daemon did not start", and then advised provisioning a daemon that had been
+ * serving for five hours. **The healthy path and the broken path printed the same
+ * sentence**, so the operator's next action was to install what was already
+ * installed.
+ *
+ * `reason` and `repair` are whole sentences because this text is what an operator
+ * reads when nothing happened, and the pid, the socket and the uptime are what
+ * they act on.
+ *
+ * PURE: every input is passed in — the probe that reads the socket and the lease
+ * lives in `client.ts`, so this module is testable without a host.
+ */
+import { canonicalInvocation } from "@reddb-io/shared/canonical-invocation.js";
+import type { RedskilledLease } from "./session-lease.js";
+
+/** The three states a silent socket can actually be in. */
+export type RedskilledPresenceKind = "answering" | "held-unresponsive" | "absent";
+
+/** The process a lease names, as an operator needs to read it. */
+export interface RedskilledPresenceHolder {
+  readonly pid: number;
+  readonly socket_path: string;
+  readonly acquired_at: string;
+  readonly renewed_at: string;
+  /** Wall-clock milliseconds since the lease was taken; `null` when undatable. */
+  readonly uptime_ms: number | null;
+}
+
+export interface RedskilledPresence {
+  readonly version: 1;
+  readonly kind: RedskilledPresenceKind;
+  readonly socket_path: string;
+  /** The live lease holder, when there is one; `null` in every other state. */
+  readonly holder: RedskilledPresenceHolder | null;
+  /** What was observed, as a sentence. */
+  readonly reason: string;
+  /** What to do about it, as a sentence. */
+  readonly repair: string;
+}
+
+export interface DescribeRedskilledPresenceInput {
+  readonly socketPath: string;
+  /** Whether a ping was answered on {@link socketPath}. */
+  readonly answers: boolean;
+  /** The lease record found on disk, when there was one. */
+  readonly lease?: RedskilledLease | undefined;
+  /** Whether the pid the lease names can still be signalled. */
+  readonly holderAlive?: boolean;
+  /** Now, for the uptime; defaults to the wall clock. */
+  readonly now?: string;
+}
+
+/**
+ * Classify one silence. PURE.
+ *
+ * A lease on ANOTHER socket does not make this socket held: it names a daemon
+ * this client is not talking to, and reporting it as the holder of a path it
+ * never bound would send the operator after the wrong process.
+ */
+export function describeRedskilledPresence(input: DescribeRedskilledPresenceInput): RedskilledPresence {
+  const socketPath = input.socketPath;
+  const holder = holderOf(input);
+  if (input.answers) {
+    return {
+      version: 1,
+      kind: "answering",
+      socket_path: socketPath,
+      holder,
+      reason: `a redskilled daemon answered on ${JSON.stringify(socketPath)}`,
+      repair: "nothing to repair",
+    };
+  }
+  if (holder != null) {
+    return {
+      version: 1,
+      kind: "held-unresponsive",
+      socket_path: socketPath,
+      holder,
+      reason:
+        `redskilled pid ${holder.pid} is alive and has held ${JSON.stringify(socketPath)} since ` +
+        `${holder.acquired_at}${holder.uptime_ms == null ? "" : ` (up ${formatUptime(holder.uptime_ms)})`}, ` +
+        `but it did not answer a ping — this is a daemon that could not be REACHED, not one that is missing.`,
+      repair:
+        `Do not provision: a daemon is already running. Inspect it (\`ps -p ${holder.pid}\`), or stop it with ` +
+        `\`${canonicalInvocation("red-skills-redskilled", ["stop"])}\` and let the next client start a fresh one.`,
+    };
+  }
+  return {
+    version: 1,
+    kind: "absent",
+    socket_path: socketPath,
+    holder: null,
+    reason: `nothing answered on ${JSON.stringify(socketPath)} and no live process holds its lease`,
+    repair:
+      `Install and start one with \`${canonicalInvocation("red-skills-redskilled", ["provision"])}\` ` +
+      `(or \`/red-setup\`), then retry.`,
+  };
+}
+
+/** The repair-carrying half of a presence, for a surface that renders its own lead. PURE. */
+export function redskilledPresenceAdvice(presence: RedskilledPresence): string {
+  return `${presence.reason} ${presence.repair}`;
+}
+
+function holderOf(input: DescribeRedskilledPresenceInput): RedskilledPresenceHolder | null {
+  const lease = input.lease;
+  if (lease == null || input.holderAlive !== true) return null;
+  if (lease.socket_path !== input.socketPath) return null;
+  return {
+    pid: lease.pid,
+    socket_path: lease.socket_path,
+    acquired_at: lease.acquired_at,
+    renewed_at: lease.renewed_at,
+    uptime_ms: elapsedMs(lease.acquired_at, input.now ?? new Date().toISOString()),
+  };
+}
+
+function elapsedMs(from: string, now: string): number | null {
+  const start = Date.parse(from);
+  const end = Date.parse(now);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  return Math.max(0, end - start);
+}
+
+/** `4h43m`, `12m`, `30s` — the shape an operator reads uptime in. PURE. */
+export function formatUptime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h${String(minutes).padStart(2, "0")}m`;
+  if (minutes > 0) return `${minutes}m${String(seconds).padStart(2, "0")}s`;
+  return `${seconds}s`;
+}
+
+/** True when `value` is a complete presence — a consumer's fail-closed check. PURE. */
+export function isRedskilledPresence(value: unknown): value is RedskilledPresence {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const presence = value as Record<string, unknown>;
+  return presence.version === 1 &&
+    typeof presence.kind === "string" &&
+    typeof presence.socket_path === "string" &&
+    typeof presence.reason === "string" &&
+    typeof presence.repair === "string";
+}

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -258,6 +258,18 @@ export const DEFAULT_REDSKILLED_REPLACE_BOOT_CHECK_MS = 60_000;
 export const DEFAULT_REDSKILLED_SAMPLE_MS = 15_000;
 
 /**
+ * Default window between lease renewals.
+ *
+ * A lease whose `renewed_at` never moves is worse than one without the field: it
+ * reads as a five-hour-stale record on a daemon that has been serving for five
+ * hours, and it invites exactly the freshness check that would then be
+ * permanently wrong about a healthy host (#3092). Renewal is a one-file rewrite,
+ * so the window is chosen for how quickly a reader should be able to tell a live
+ * holder from an abandoned record, not for cost.
+ */
+export const DEFAULT_REDSKILLED_LEASE_RENEW_MS = 30_000;
+
+/**
  * How many lapsed registrations the daemon keeps where a reader can see them.
  *
  * A tail, not a history: the question a lapse block answers is "did my drain stop,
@@ -322,6 +334,8 @@ export interface RedskilledDaemonOptions {
   readonly treeSampler?: RedskilledTreeSampler;
   /** Window between memory samples; 0 or below leaves the sampler unarmed. */
   readonly sampleMs?: number;
+  /** Window between lease renewals; 0 or below leaves the renewer unarmed. */
+  readonly leaseRenewMs?: number;
   /**
    * How the daemon recovers a Worker's last logged line after a restart.
    *
@@ -565,6 +579,15 @@ export interface RedskilledDaemon {
    */
   sampleMemoryBudgets(): Promise<readonly RedskilledBudgetTermination[]>;
   /**
+   * Advance the lease's `renewed_at`, once.
+   *
+   * Exposed for the same reason the memory sample is: the timer drives it in
+   * production and a test drives it directly. `null` means the renewal did not
+   * happen — the lease is gone or belongs to someone else — which is a fact to
+   * read, never a reason for a serving daemon to fall over.
+   */
+  renewLease(): Promise<RedskilledLease | null>;
+  /**
    * Store one Worker's last logged line, exactly as it was published.
    *
    * The daemon widens by one string and learns nothing: it does not parse the
@@ -744,6 +767,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const treeSampler = options.treeSampler ?? sampleWorkerTrees;
   const readLogTail = options.readLogTail ?? readLastLogLine;
   const sampleMs = options.sampleMs ?? DEFAULT_REDSKILLED_SAMPLE_MS;
+  const leaseRenewMs = options.leaseRenewMs ?? DEFAULT_REDSKILLED_LEASE_RENEW_MS;
   const publishedProbe = options.publishedVersion ?? ((running: string) => probePublishedRedskilledVersion(running));
   const replaceCheckMs = options.replaceCheckMs ?? DEFAULT_REDSKILLED_REPLACE_CHECK_MS;
   const publishedProbeTimeoutMs = options.publishedProbeTimeoutMs ?? DEFAULT_REDSKILLED_PUBLISHED_PROBE_TIMEOUT_MS;
@@ -837,6 +861,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   let demandTicking = false;
   let idleTimer: NodeJS.Timeout | undefined;
   let sampleTimer: NodeJS.Timeout | undefined;
+  let leaseTimer: NodeJS.Timeout | undefined;
   let demandTimer: NodeJS.Timeout | undefined;
   let replaceTimer: NodeJS.Timeout | undefined;
   let replaceBootTimer: NodeJS.Timeout | undefined;
@@ -1843,6 +1868,27 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     replaceTimer.unref();
   }
 
+  /**
+   * Say the lease is still ours, on its own window.
+   *
+   * `renew()` shipped with the lease and had ZERO callers, so `renewed_at` was a
+   * field that only ever equalled `acquired_at` — a record that looked stale on a
+   * daemon in perfect health (#3092). A failure costs the renewal and never the
+   * daemon: a lease another owner has taken is a fact to report, not a reason for
+   * a serving process to fall over.
+   */
+  async function renewLease(): Promise<RedskilledLease | null> {
+    return await leaseStore.renew(owner).catch(() => null);
+  }
+
+  function armLeaseTimer(): void {
+    if (stopping || leaseTimer != null || leaseRenewMs <= 0) return;
+    leaseTimer = setInterval(() => {
+      void renewLease();
+    }, leaseRenewMs);
+    leaseTimer.unref();
+  }
+
   function armSampleTimer(): void {
     if (stopping || sampleTimer != null || sampleMs <= 0) return;
     sampleTimer = setInterval(() => {
@@ -2028,6 +2074,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     stopping = true;
     if (idleTimer) clearTimeout(idleTimer);
     if (sampleTimer) clearInterval(sampleTimer);
+    if (leaseTimer) clearInterval(leaseTimer);
     if (replaceTimer) clearInterval(replaceTimer);
     if (replaceBootTimer) clearTimeout(replaceBootTimer);
     if (activityTimer) clearInterval(activityTimer);
@@ -2213,6 +2260,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
 
   armIdleTimer();
   armSampleTimer();
+  armLeaseTimer();
   armReplaceTimer();
   armActivityTimer();
   armQueueTimer();
@@ -2228,6 +2276,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     ceiling: () => ceiling,
     killWorkerOverBudget,
     sampleMemoryBudgets,
+    renewLease,
     pollRepositoryActivity,
     pollQueueDiscovery,
     queueDiscovery: () => lastQueue,

--- a/apps/redskilled/tests/daemon-presence.test.ts
+++ b/apps/redskilled/tests/daemon-presence.test.ts
@@ -1,0 +1,205 @@
+// "I could not reach it" is not "it is not there" (#3092).
+//
+// Every client refused a daemon that was alive, listening and actively working,
+// and reported it as one that never started — then advised provisioning it. The
+// mechanism was a correctly-functioning singleton: the client's own redundant
+// spawn was refused because a live pid held the lease, and that `exit 1` was
+// rendered as "the daemon did not start". The healthy path and the broken path
+// printed the same sentence.
+//
+// These checks pin the four facts that keep them apart:
+//
+//   1. the classifier separates answering / held-unresponsive / absent, and only
+//      the last one is an absence to provision;
+//   2. a client facing a socket a live pid holds does NOT spawn a rival, and its
+//      refusal names that pid and socket rather than "did not start";
+//   3. a live daemon stays reachable from every surface no matter how old its
+//      lease record is — no freshness check may reject a working host;
+//   4. the operator advice a project prints never says "provision" when the reach
+//      established that a daemon is running.
+import { createServer, type Server, type Socket } from "node:net";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { encode, type JsonValue } from "@reddb-io/toon";
+import {
+  describeRedskilledPresence,
+  ensureRedskilledDaemon,
+  formatUptime,
+  probeRedskilledPresence,
+  readRedskilledHostState,
+  readRedskilledStatuslinePayload,
+  RedskilledDaemonHeldError,
+  RedskilledUnreachableError,
+  stopRedskilledDaemon,
+} from "../src/client.js";
+import { socketAnswers, startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import type { RedskilledLease } from "../src/session-lease.js";
+
+const running: RedskilledDaemon[] = [];
+const servers: Server[] = [];
+const openSockets: Socket[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  // Connections first: a wedged daemon's whole point is that it never replies, so
+  // every probe left a socket open and `close()` alone would wait for them.
+  for (const socket of openSockets.splice(0)) socket.destroy();
+  for (const server of servers.splice(0)) await new Promise<void>((resolve) => server.close(() => resolve()));
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-presence-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+function lease(paths: RedskilledPaths, overrides: Partial<RedskilledLease> = {}): RedskilledLease {
+  return {
+    version: 1,
+    pid: process.pid,
+    start_time: "2026-08-02T17:04:25.362Z",
+    session_key_hash: paths.sessionKeyHash,
+    machine_id_hash: paths.machineIdHash,
+    socket_path: paths.socketPath,
+    acquired_at: "2026-08-02T17:04:25.362Z",
+    renewed_at: "2026-08-02T17:04:25.362Z",
+    ...overrides,
+  };
+}
+
+async function writeLease(paths: RedskilledPaths, record: RedskilledLease): Promise<void> {
+  await writeFile(paths.leasePath, `${encode(record as unknown as JsonValue, { keyedMapCollapse: true })}\n`, "utf8");
+}
+
+/** A socket that accepts a connection and never answers — the wedged daemon. */
+async function silentSocket(socketPath: string): Promise<Server> {
+  const server = createServer((socket) => openSockets.push(socket));
+  servers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => resolve());
+  });
+  return server;
+}
+
+describe("the three silences a redskilled client can meet", () => {
+  it("separates answering, held-unresponsive and absent", () => {
+    const socketPath = "/run/user/1000/red-skills/abc/redskilled.sock";
+    const record = {
+      version: 1,
+      pid: 900_870,
+      start_time: "2026-08-02T17:04:25.362Z",
+      session_key_hash: "aaa",
+      machine_id_hash: "bbb",
+      socket_path: socketPath,
+      acquired_at: "2026-08-02T17:04:25.362Z",
+      renewed_at: "2026-08-02T17:04:25.362Z",
+    } as const satisfies RedskilledLease;
+    const now = "2026-08-02T21:47:51.362Z";
+
+    const answering = describeRedskilledPresence({ socketPath, answers: true, lease: record, holderAlive: true, now });
+    expect(answering.kind).toBe("answering");
+
+    const held = describeRedskilledPresence({ socketPath, answers: false, lease: record, holderAlive: true, now });
+    expect(held.kind).toBe("held-unresponsive");
+    expect(held.holder).toMatchObject({ pid: 900_870, socket_path: socketPath });
+    // The pid, the socket and the uptime — what the operator acts on.
+    expect(held.reason).toContain("900870");
+    expect(held.reason).toContain(socketPath);
+    expect(held.reason).toContain("4h43m");
+    // And never the repair for the state this is not.
+    expect(held.repair).toContain("Do not provision");
+    expect(held.repair).not.toContain("provision`");
+
+    const dead = describeRedskilledPresence({ socketPath, answers: false, lease: record, holderAlive: false, now });
+    expect(dead.kind).toBe("absent");
+    expect(dead.repair).toContain("provision");
+
+    const bare = describeRedskilledPresence({ socketPath, answers: false, now });
+    expect(bare.kind).toBe("absent");
+    expect(bare.holder).toBeNull();
+
+    // A lease on ANOTHER socket names a daemon this client is not talking to.
+    const elsewhere = describeRedskilledPresence({
+      socketPath,
+      answers: false,
+      lease: { ...record, socket_path: "/run/user/1000/other.sock" },
+      holderAlive: true,
+      now,
+    });
+    expect(elsewhere.kind).toBe("absent");
+  });
+
+  it("reads uptime the way an operator does", () => {
+    expect(formatUptime(4 * 3_600_000 + 43 * 60_000)).toBe("4h43m");
+    expect(formatUptime(90_000)).toBe("1m30s");
+    expect(formatUptime(9_000)).toBe("9s");
+  });
+
+  it("never spawns a rival, and names the live holder instead of 'did not start'", async () => {
+    const paths = await sessionPaths();
+    // A daemon that is alive and listening — and does not answer. Exactly the
+    // host in #3092: a raw client connects, a ping gets nothing back.
+    await silentSocket(paths.socketPath);
+    await writeLease(paths, lease(paths));
+    expect(await socketAnswers(paths.socketPath)).toBe(false);
+
+    const probed = await probeRedskilledPresence(paths);
+    expect(probed.kind).toBe("held-unresponsive");
+
+    const error = await ensureRedskilledDaemon(paths, {
+      // A spawn would run this and fail loudly, which is how "nothing was
+      // spawned" is an observation rather than an assumption.
+      serverCommand: process.execPath,
+      serverArgs: ["-e", "process.exit(1)"],
+      readyTimeoutMs: 400,
+    }).then((outcome) => outcome as never, (err: unknown) => err);
+
+    expect(error).toBeInstanceOf(RedskilledDaemonHeldError);
+    expect(error).toBeInstanceOf(RedskilledUnreachableError);
+    const message = (error as Error).message;
+    expect(message).toContain(String(process.pid));
+    expect(message).toContain(paths.socketPath);
+    expect(message).not.toContain("did not start");
+    expect(message).toContain("Do not provision");
+  });
+
+  it("keeps a live daemon reachable from every surface however old its lease is", async () => {
+    const paths = await sessionPaths();
+    // Renewal off, then the record backdated by a week: past any staleness
+    // threshold anyone could reasonably invent.
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000, leaseRenewMs: 0 });
+    running.push(daemon);
+    await writeLease(paths, lease(paths, {
+      pid: process.pid,
+      start_time: daemon.lease.start_time,
+      acquired_at: "2026-07-26T09:00:00.000Z",
+      renewed_at: "2026-07-26T09:00:00.000Z",
+    }));
+
+    expect(await socketAnswers(paths.socketPath)).toBe(true);
+    expect(await ensureRedskilledDaemon(paths, { readyTimeoutMs: 2_000 })).toBe("already-running");
+    expect((await probeRedskilledPresence(paths)).kind).toBe("answering");
+    expect((await readRedskilledHostState(paths)).pid).toBe(process.pid);
+    expect((await readRedskilledStatuslinePayload(paths)).version).toBeGreaterThan(0);
+
+    const stopped = await stopRedskilledDaemon(paths, { detail: "presence probe" });
+    expect(stopped.stopped).toBe(true);
+  }, 30_000);
+
+  it("reports a genuinely absent daemon as absent", async () => {
+    const paths = await sessionPaths();
+    const presence = await probeRedskilledPresence(paths);
+    expect(presence.kind).toBe("absent");
+    expect(presence.holder).toBeNull();
+    expect(presence.repair).toContain("provision");
+  });
+});

--- a/apps/redskilled/tests/session-lease-renewal.test.ts
+++ b/apps/redskilled/tests/session-lease-renewal.test.ts
@@ -1,0 +1,81 @@
+// `renewed_at` must advance while the daemon runs — #3092.
+//
+// The lease shipped with a `renew()` and ZERO callers, so after five hours of
+// continuous, working uptime the record still read `renewed_at == acquired_at`.
+// A field nothing advances is worse than no field at all: it invites exactly the
+// freshness check that would then be permanently wrong about a healthy host.
+//
+// The first check is the behaviour; the second is the wiring. Both are here
+// because the wiring is what regressed — a mechanism designed on one side and
+// called from nowhere reads as present in review and is absent in production,
+// the same shape as #3079's heartbeat publisher and #3081's dropped launch env.
+import { readFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { readRedskilledLeaseFile } from "../src/session-lease.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-renew-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+describe("the redskilled session lease is renewed while the daemon serves", () => {
+  it("advances renewed_at past acquired_at on its own tick", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000, leaseRenewMs: 20 });
+    running.push(daemon);
+
+    const acquired = await readRedskilledLeaseFile(paths.leasePath);
+    expect(acquired?.renewed_at).toBe(acquired?.acquired_at);
+
+    const deadline = Date.now() + 5_000;
+    let renewed = acquired;
+    while (Date.now() < deadline && renewed?.renewed_at === acquired?.acquired_at) {
+      await new Promise((r) => setTimeout(r, 25));
+      renewed = await readRedskilledLeaseFile(paths.leasePath);
+    }
+
+    expect(renewed?.renewed_at).not.toBe(acquired?.acquired_at);
+    expect(Date.parse(renewed?.renewed_at ?? "")).toBeGreaterThan(Date.parse(acquired?.acquired_at ?? ""));
+    // Everything that identifies the holder survives the rewrite: a renewal that
+    // moved the pid would hand the session to a process that never took it.
+    expect(renewed?.pid).toBe(acquired?.pid);
+    expect(renewed?.acquired_at).toBe(acquired?.acquired_at);
+    expect(renewed?.socket_path).toBe(paths.socketPath);
+  }, 30_000);
+
+  it("keeps `.renew()` wired — a mechanism with zero callers is a mechanism that is off", async () => {
+    const daemonSource = await readFile(resolve(__dirname, "..", "src", "daemon.ts"), "utf8");
+    // Named at the call site, not merely defined: this is the exact grep that came
+    // back empty in #3092 while the field it feeds sat five hours stale.
+    expect(daemonSource).toMatch(/leaseStore\.renew\(/);
+    expect(daemonSource).toMatch(/armLeaseTimer\(\)/);
+  });
+
+  it("leaves the renewer unarmed when the window is zero, and still serves", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000, leaseRenewMs: 0 });
+    running.push(daemon);
+
+    await new Promise((r) => setTimeout(r, 60));
+    const held = await readRedskilledLeaseFile(paths.leasePath);
+    expect(held?.renewed_at).toBe(held?.acquired_at);
+    // And the explicit drive still works, which is what the timer calls.
+    expect((await daemon.renewLease())?.renewed_at).not.toBe(held?.acquired_at);
+  }, 30_000);
+});


### PR DESCRIPTION
Automated AFK landing for #3092. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3092

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788303472&installation_model_id=20659&pr_number=3105&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3105&signature=a31a6032328159b3ff434300eb5b8dff6caeb11f45ac9dff307ed6b1dcf83a27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->