### PR TITLE
fix: stop asking a project for Workers that keep dying in boot

### DIFF
--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -61,6 +61,11 @@ import {
   DEFAULT_REDSKILLED_DEMAND_MS,
   emptyDemandTick,
   planHostDemand,
+  birthHaltMap,
+  foldWorkerDeath,
+  EMPTY_BIRTH_HEALTH,
+  REDSKILLED_SHORT_LIFE_MS,
+  type RedskilledBirthHealth,
   REDSKILLED_DEMAND_BACKOFF_MS,
   type RedskilledDemandGrant,
   type RedskilledDemandTick,
@@ -834,6 +839,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // a healthy one (#2973).
   const lapses: RedskilledRegistrationLapse[] = [];
   let demandBackoffUntilMs: number | null = null;
+  // Per project, its record of Workers that died before they could work. In
+  // memory rather than durable on purpose: it answers "can a Worker boot here
+  // right now", and a fresh daemon has no business inheriting a verdict about a
+  // machine it has not tried yet.
+  const birthHealth: Record<string, RedskilledBirthHealth> = {};
   let demandTicking = false;
   let idleTimer: NodeJS.Timeout | undefined;
   let sampleTimer: NodeJS.Timeout | undefined;
@@ -1161,6 +1171,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         live,
         nowMs: Number.isFinite(nowMs) ? nowMs : 0,
         backoffUntilMs: demandBackoffUntilMs,
+        birthHaltUntilMs: birthHaltMap(birthHealth, Number.isFinite(nowMs) ? nowMs : 0),
       });
 
       const granted: RedskilledDemandGrant[] = [];
@@ -1379,6 +1390,32 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     forgetWorker(worker.worker_id);
     record("worker-death", worker, ended, { exitCode: code, signal });
     armIdleTimer();
+  }
+
+  /**
+   * Fold one death into its project's birth health.
+   *
+   * An unreadable lifetime is treated as long, never as short: the breaker
+   * exists to stop a loop it can prove, and halting a project on a clock it
+   * could not parse would be the same silent overreach in the other direction.
+   */
+  function foldBirthHealth(projectLabel: string, lifetimeMs: number): void {
+    if (!Number.isFinite(lifetimeMs) || lifetimeMs < 0) {
+      birthHealth[projectLabel] = EMPTY_BIRTH_HEALTH;
+      return;
+    }
+    const before = birthHealth[projectLabel] ?? EMPTY_BIRTH_HEALTH;
+    const after = foldWorkerDeath(before, lifetimeMs, Date.parse(clock()));
+    birthHealth[projectLabel] = after;
+    if (after.haltUntilMs != null && before.haltUntilMs == null) {
+      // Said once, when the breaker opens rather than on every death after it:
+      // a loop that logs per cycle is the second thing filling a disk.
+      process.stderr.write(
+        `redskilled: project ${JSON.stringify(projectLabel)} lost ${after.shortLifeStreak} Workers in a row ` +
+          `inside ${REDSKILLED_SHORT_LIFE_MS}ms of birth; not asking for another until ` +
+          `${new Date(after.haltUntilMs).toISOString()}\n`,
+      );
+    }
   }
 
   /** Ask the host about one Worker; an unanswerable probe is not a confirmation. */
@@ -1611,6 +1648,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     // describe the same ending at two different times.
     if (event === "worker-death" || event === "worker-budget-kill") {
       markWorkerOutcome({ worker_id: worker.worker_id, ts, outcome: event });
+      // Every death reaches here, which is why the breaker folds here rather
+      // than at the five call sites that end a Worker. What it reads is a
+      // lifetime, never a cause: the daemon is not owed a reason (rule 3), and
+      // a Worker dead in seconds is spent whatever the reason was.
+      foldBirthHealth(worker.project_label, Date.parse(ts) - Date.parse(worker.started_at));
     }
     void eventLane
       .record({

--- a/apps/redskilled/src/demand-loop.ts
+++ b/apps/redskilled/src/demand-loop.ts
@@ -29,9 +29,24 @@
  * is recorded as an ordinary outcome carrying the host's own words, never as an
  * error, because the host is the party that knows.
  *
+ * **A project that cannot keep a Worker alive stops being asked.** A refusal is
+ * the host saying no; a Worker that is born and dies seconds later is the host
+ * saying yes to something that cannot run. The second shape has no natural end:
+ * the target is unmet, so the loop asks again, and a boot that fails
+ * deterministically — a probe that refuses, a precondition that will not become
+ * true by waiting — fails identically on the first attempt and the hundredth.
+ * Measured before this existed: 108 births and 108 deaths in one hour for one
+ * project, average lifetime 13 seconds, each birth spending GitHub quota that is
+ * per token and therefore shared with every other project on the machine. The
+ * breaker is per project because the fault is: a looping project must not hold
+ * back a healthy neighbour, and a host-wide backoff would make it do exactly
+ * that.
+ *
  * **Rule 3 survives.** A selector and an argv are carried and handed back; not
  * one branch here turns on what either of them says. The planner reads a depth,
- * a target and a count of live Workers — three integers — and nothing else.
+ * a target, a count of live Workers and a streak of short-lived deaths — four
+ * integers — and nothing else. It never learns WHY a Worker died; a lifetime in
+ * milliseconds is not a reason, and the daemon is not owed one.
  *
  * PURE.
  */
@@ -47,6 +62,34 @@ export const REDSKILLED_DEMAND_BACKOFF_MS = 30_000;
 
 /** Default window between demand ticks — the queue's cadence, by construction. */
 export const DEFAULT_REDSKILLED_DEMAND_MS = 15_000;
+
+/**
+ * A Worker dead sooner than this never reached its work; its birth was spent.
+ *
+ * Generous on purpose. A Worker that claims an issue, opens a worktree and
+ * starts an agent is minutes old before it does anything; one that dies inside
+ * this window died in boot, and boot failures are the deterministic kind.
+ */
+export const REDSKILLED_SHORT_LIFE_MS = 60_000;
+
+/**
+ * How many short lives in a row stop a project from being asked again.
+ *
+ * Three rather than one: a single early death can be a genuine transient (a
+ * lock briefly held, a fetch that timed out), and refusing to retry it would
+ * turn a blip into an outage. Three in a row is not a blip.
+ */
+export const REDSKILLED_SHORT_LIFE_STREAK = 3;
+
+/**
+ * How long a halted project waits before one Worker is allowed through.
+ *
+ * The halt expires rather than latching, because the cause is usually outside
+ * this process and gets fixed there — a tree committed, a binary installed —
+ * with nothing to tell the daemon it happened. One birth after the window is
+ * the probe; if it dies short too, the streak re-arms the halt immediately.
+ */
+export const REDSKILLED_BIRTH_HALT_MS = 600_000;
 
 /** One registered project, as the loop reads it: three integers and two opaque values. */
 export interface RedskilledDemandProject {
@@ -66,7 +109,9 @@ export type RedskilledDemandOutcome =
   | "at-target"
   | "queue-drained"
   | "queue-unknown"
-  | "backing-off";
+  | "backing-off"
+  /** This project's Workers keep dying in boot, so it is not asked again yet. */
+  | "birth-halted";
 
 export interface RedskilledDemandIntent {
   readonly project_label: string;
@@ -104,6 +149,12 @@ export interface PlanHostDemandInput {
   readonly nowMs: number;
   /** When the host's last refusal stops holding the loop back; absent when none does. */
   readonly backoffUntilMs?: number | null;
+  /**
+   * Per project, when its birth halt expires — a project absent from this map
+   * is not halted. Keyed by label so one looping project never holds back a
+   * healthy one, which a host-wide backoff would.
+   */
+  readonly birthHaltUntilMs?: Readonly<Record<string, number>>;
 }
 
 /**
@@ -138,6 +189,25 @@ export function planHostDemand(input: PlanHostDemandInput): RedskilledDemandPlan
         detail:
           `the host refused a Worker, so no project is asked for one again before ` +
           `${new Date(backoffUntilMs!).toISOString()}`,
+      });
+      continue;
+    }
+    // Checked before the depth, and deliberately: a halted project is not asked
+    // for a Worker whether or not anyone has counted its queue, and reporting
+    // "nobody counted yet" for a project whose Workers are dying in boot names
+    // the wrong problem to whoever reads it.
+    const haltUntilMs = input.birthHaltUntilMs?.[project.project_label];
+    if (haltUntilMs != null && input.nowMs < haltUntilMs) {
+      intents.push({
+        ...base,
+        outcome: "birth-halted",
+        wanted: 0,
+        detail:
+          `project ${JSON.stringify(project.project_label)} lost ` +
+          `${REDSKILLED_SHORT_LIFE_STREAK} Workers in a row inside ` +
+          `${REDSKILLED_SHORT_LIFE_MS}ms of birth, so it is not asked for another before ` +
+          `${new Date(haltUntilMs).toISOString()} — a Worker that cannot survive boot will not ` +
+          `survive the next one either, and every birth spends host quota shared with every project`,
       });
       continue;
     }
@@ -255,4 +325,63 @@ export function isRedskilledDemandTick(value: unknown): value is RedskilledDeman
     (tick.refusal === null || typeof tick.refusal === "string") &&
     (tick.retry_after === null || typeof tick.retry_after === "string") &&
     Array.isArray(tick.projects);
+}
+
+/**
+ * One project's record of Workers that died before they could work.
+ *
+ * The streak, not a rate: a project that loses one Worker an hour is not
+ * looping, and a rate would eventually smear a tight loop into an average that
+ * looks survivable. Consecutive is the property that distinguishes "boot cannot
+ * succeed here" from "one Worker had bad luck".
+ */
+export interface RedskilledBirthHealth {
+  /** Consecutive Workers that died inside {@link REDSKILLED_SHORT_LIFE_MS}. */
+  readonly shortLifeStreak: number;
+  /** When this project may be asked for a Worker again; `null` when it may now. */
+  readonly haltUntilMs: number | null;
+}
+
+/** A project with no history — never halted, no streak. */
+export const EMPTY_BIRTH_HEALTH: RedskilledBirthHealth = { shortLifeStreak: 0, haltUntilMs: null };
+
+/**
+ * Fold one Worker's death into its project's birth health. PURE.
+ *
+ * **A long life clears the streak outright rather than decrementing it.** The
+ * question the streak answers is "can a Worker boot here right now", and one
+ * that did is a complete answer — carrying forward failures from before a
+ * working boot would halt a project that has already recovered.
+ *
+ * The halt is armed on the death that completes the streak and re-armed by
+ * every short death after it, so a project probed after the window and still
+ * broken goes quiet again immediately instead of leaking one birth per window
+ * forever.
+ */
+export function foldWorkerDeath(
+  health: RedskilledBirthHealth,
+  lifetimeMs: number,
+  nowMs: number,
+): RedskilledBirthHealth {
+  if (lifetimeMs >= REDSKILLED_SHORT_LIFE_MS) return EMPTY_BIRTH_HEALTH;
+  const shortLifeStreak = health.shortLifeStreak + 1;
+  if (shortLifeStreak < REDSKILLED_SHORT_LIFE_STREAK) return { shortLifeStreak, haltUntilMs: null };
+  return { shortLifeStreak, haltUntilMs: nowMs + REDSKILLED_BIRTH_HALT_MS };
+}
+
+/**
+ * The halt map `planHostDemand` reads, from a health record per project. PURE.
+ *
+ * An expired halt is dropped rather than kept as a past instant, so the planner
+ * compares against present halts only and a stale entry can never read as one.
+ */
+export function birthHaltMap(
+  health: Readonly<Record<string, RedskilledBirthHealth>>,
+  nowMs: number,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [label, record] of Object.entries(health)) {
+    if (record.haltUntilMs != null && nowMs < record.haltUntilMs) out[label] = record.haltUntilMs;
+  }
+  return out;
 }

--- a/apps/redskilled/tests/birth-breaker.test.ts
+++ b/apps/redskilled/tests/birth-breaker.test.ts
@@ -1,0 +1,161 @@
+// The birth circuit breaker (issue #3107). A project whose Workers die in boot
+// stops being asked for another, because a boot that fails deterministically
+// fails identically every time and each birth spends host-shared GitHub quota.
+//
+// Measured before this existed: 108 births and 108 deaths in one hour for one
+// project, average lifetime 13 seconds.
+import { describe, expect, it } from "vitest";
+import {
+  birthHaltMap,
+  EMPTY_BIRTH_HEALTH,
+  foldWorkerDeath,
+  planHostDemand,
+  REDSKILLED_BIRTH_HALT_MS,
+  REDSKILLED_SHORT_LIFE_MS,
+  REDSKILLED_SHORT_LIFE_STREAK,
+  type RedskilledDemandProject,
+} from "../src/demand-loop.js";
+
+const NOW_MS = Date.parse("2026-08-02T23:00:00.000Z");
+
+function project(label: string, overrides: Partial<RedskilledDemandProject> = {}): RedskilledDemandProject {
+  return {
+    project_label: label,
+    selector: `repo:${label} label:ready-for-agent`,
+    argv: ["red-skills-dev", "run", "--once"],
+    workspace_path: `/tmp/${label}`,
+    target: 2,
+    ...overrides,
+  };
+}
+
+/** Kill `n` Workers in a row after `lifetimeMs` each, from a clean record. */
+function streak(n: number, lifetimeMs: number, nowMs = NOW_MS) {
+  let health = EMPTY_BIRTH_HEALTH;
+  for (let i = 0; i < n; i += 1) health = foldWorkerDeath(health, lifetimeMs, nowMs);
+  return health;
+}
+
+describe("foldWorkerDeath", () => {
+  it("does not halt before the streak completes", () => {
+    const health = streak(REDSKILLED_SHORT_LIFE_STREAK - 1, 13_000);
+    expect(health.shortLifeStreak).toBe(REDSKILLED_SHORT_LIFE_STREAK - 1);
+    expect(health.haltUntilMs).toBeNull();
+  });
+
+  it("halts on the death that completes the streak", () => {
+    const health = streak(REDSKILLED_SHORT_LIFE_STREAK, 13_000);
+    expect(health.haltUntilMs).toBe(NOW_MS + REDSKILLED_BIRTH_HALT_MS);
+  });
+
+  it("clears the streak outright when a Worker survives", () => {
+    // The question is "can a Worker boot here NOW"; one that did is a complete
+    // answer, so failures from before it must not be carried forward.
+    const nearly = streak(REDSKILLED_SHORT_LIFE_STREAK - 1, 13_000);
+    const recovered = foldWorkerDeath(nearly, REDSKILLED_SHORT_LIFE_MS + 1, NOW_MS);
+    expect(recovered).toEqual(EMPTY_BIRTH_HEALTH);
+  });
+
+  it("re-arms immediately when the probe after the window dies short too", () => {
+    const halted = streak(REDSKILLED_SHORT_LIFE_STREAK, 13_000);
+    const later = NOW_MS + REDSKILLED_BIRTH_HALT_MS + 1;
+    const again = foldWorkerDeath(halted, 13_000, later);
+    expect(again.haltUntilMs).toBe(later + REDSKILLED_BIRTH_HALT_MS);
+  });
+
+  it("treats a lifetime exactly at the threshold as long enough", () => {
+    expect(foldWorkerDeath(EMPTY_BIRTH_HEALTH, REDSKILLED_SHORT_LIFE_MS, NOW_MS)).toEqual(EMPTY_BIRTH_HEALTH);
+  });
+});
+
+describe("birthHaltMap", () => {
+  it("drops an expired halt rather than reporting a past instant", () => {
+    const health = { looping: streak(REDSKILLED_SHORT_LIFE_STREAK, 13_000) };
+    expect(birthHaltMap(health, NOW_MS)).toHaveProperty("looping");
+    expect(birthHaltMap(health, NOW_MS + REDSKILLED_BIRTH_HALT_MS + 1)).toEqual({});
+  });
+});
+
+describe("planHostDemand with a halted project", () => {
+  const queue = { looping: 5, healthy: 5 };
+  const live = { looping: 0, healthy: 0 };
+
+  it("asks for nothing and says why", () => {
+    const plan = planHostDemand({
+      projects: [project("looping")],
+      queue: { looping: 5 },
+      live: { looping: 0 },
+      nowMs: NOW_MS,
+      birthHaltUntilMs: { looping: NOW_MS + REDSKILLED_BIRTH_HALT_MS },
+    });
+    expect(plan.births).toHaveLength(0);
+    const intent = plan.intents.find((i) => i.project_label === "looping");
+    expect(intent?.outcome).toBe("birth-halted");
+    expect(intent?.wanted).toBe(0);
+    expect(intent?.detail).toContain("in a row");
+  });
+
+  it("holds back ONLY the looping project — a neighbour still gets Workers", () => {
+    // The whole reason the breaker is per project: a host-wide backoff would
+    // punish the healthy repo for its neighbour's broken tree, which is exactly
+    // the cross-project damage this exists to stop.
+    const plan = planHostDemand({
+      projects: [project("looping"), project("healthy")],
+      queue,
+      live,
+      nowMs: NOW_MS,
+      birthHaltUntilMs: { looping: NOW_MS + REDSKILLED_BIRTH_HALT_MS },
+    });
+    expect(plan.births.every((b) => b.project_label === "healthy")).toBe(true);
+    expect(plan.births.length).toBeGreaterThan(0);
+  });
+
+  it("asks again once the halt expires", () => {
+    const plan = planHostDemand({
+      projects: [project("looping")],
+      queue: { looping: 5 },
+      live: { looping: 0 },
+      nowMs: NOW_MS + REDSKILLED_BIRTH_HALT_MS + 1,
+      birthHaltUntilMs: { looping: NOW_MS + REDSKILLED_BIRTH_HALT_MS },
+    });
+    expect(plan.births.length).toBeGreaterThan(0);
+  });
+
+  it("reports the halt even when no poll has counted the queue", () => {
+    // Reporting "nobody counted yet" for a project whose Workers die in boot
+    // names the wrong problem to whoever reads it.
+    const plan = planHostDemand({
+      projects: [project("looping")],
+      queue: {},
+      live: { looping: 0 },
+      nowMs: NOW_MS,
+      birthHaltUntilMs: { looping: NOW_MS + REDSKILLED_BIRTH_HALT_MS },
+    });
+    expect(plan.intents[0]?.outcome).toBe("birth-halted");
+  });
+
+  it("is inert when no project is halted", () => {
+    const plan = planHostDemand({ projects: [project("healthy")], queue, live, nowMs: NOW_MS });
+    expect(plan.intents[0]?.outcome).toBe("asking");
+  });
+});
+
+describe("the loop this closes", () => {
+  it("stops after the streak instead of birthing forever", () => {
+    // Replays the observed shape: births at ~15s intervals, each Worker dead in
+    // 13s. Without the breaker this never terminates.
+    let health = EMPTY_BIRTH_HEALTH;
+    let births = 0;
+    let nowMs = NOW_MS;
+    for (let tick = 0; tick < 200; tick += 1) {
+      const halted = birthHaltMap({ looping: health }, nowMs).looping != null;
+      if (!halted) {
+        births += 1;
+        nowMs += 13_000;
+        health = foldWorkerDeath(health, 13_000, nowMs);
+      }
+      nowMs += 2_000;
+    }
+    expect(births).toBe(REDSKILLED_SHORT_LIFE_STREAK);
+  });
+});


### PR DESCRIPTION
Closes #3107.

## The loop

Measured on one machine from the daemon's own event lane:

```
22:59:51 worker-death   reddb-io/reddb
22:59:53 worker-birth   reddb-io/reddb     ← 2s later
23:00:06 worker-death   reddb-io/reddb     ← 13s of life
23:00:08 worker-birth   reddb-io/reddb
```

**108 births and 108 deaths in one hour for one project**, ~3/minute, average lifetime 13 seconds. Every one died on the same `BootHaltError` — a trunk-freshness probe refusing a dirty tree.

A dirty tree does not become clean by retrying. The refusal was correct and identical on the 1st attempt and the 108th; the supervisor treated it exactly as it treats a transient death.

**The cost was not CPU.** Each boot spends GitHub quota, quota is per token, and a token is shared by every project on the machine. During this loop GraphQL went 2837 → 0 in 23 minutes while REST used 79 requests — and the healthy Workers in a *different* repository, with an agent running for 26 minutes on real work, lost their window to a crash loop in a repo they have nothing to do with.

## The fix

A per-project birth circuit breaker in the demand loop:

- **Three consecutive Workers dead inside 60s** arm a **10-minute halt for that project alone**. Per project because the fault is: a host-wide backoff would punish the healthy repo for its neighbour, which is the cross-project damage this exists to stop. There is a test for exactly that.
- **A surviving Worker clears the streak outright**, not by decrement — "can a Worker boot here now" is answered completely by one that did, and carrying forward failures from before a working boot would halt a project that has already recovered.
- **The halt expires rather than latching.** The cause is usually fixed outside this process (a tree committed, a binary installed) with nothing to tell the daemon it happened. One birth after the window is the probe; if it dies short too the streak re-arms immediately, so a still-broken project does not leak one birth per window forever.
- **Three, not one.** A single early death can be a real transient — a lock briefly held, a fetch that timed out — and refusing to retry it would turn a blip into an outage.

## Rule 3 survives

The planner reads a **lifetime**, never a cause. It never learns why a Worker died; a lifetime in milliseconds is not a reason, and the daemon is not owed one. The fold sits in the one `record()` path every death already passes through, rather than at the five call sites that end a Worker.

The breaker state is in memory, not durable: it answers "can a Worker boot here right now", and a fresh daemon has no business inheriting a verdict about a machine it has not tried yet.

## Tests

12 new, including a replay of the observed shape (births at ~15s, each Worker dead in 13s) asserting it terminates after the streak instead of running forever. Full package suite green: **50 files, 547 tests**.

## Not fixed here

The **trigger** — `/red-setup` leaving the tree dirty by contract while `/afk` refuses to boot on a dirty tree — is #3106. This PR is the safety net: it stops any deterministic boot failure from burning the machine, whatever caused it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hZobkv9P8Su16hA1hLB9x

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788305683&installation_model_id=20659&pr_number=3109&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3109&signature=d5367fa06c0527e5b6084a60855b3c5d14ac5ad8c1c6f037ee810335cf5d2b42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->