### PR TITLE
fix: #3080 Memory accounting is blind: observed RSS reads 377x low, applied budgets never recorded, and unbounded slots over-commit the host 2x

### DIFF
--- a/apps/redskilled/src/admission.ts
+++ b/apps/redskilled/src/admission.ts
@@ -270,8 +270,20 @@ export function deriveWorkerScopeCeiling(input: {
         "the daemon's RSS sampling floor is the only remaining ceiling",
     };
   }
+  // **With no slot count, the derived ceiling is a per-Worker wall and NOT
+  // memory the host sets aside, and it says so.** The arithmetic is unchanged — a
+  // share cannot be divided by a number nobody stated — but the promise it was
+  // silently making could not be kept: two Workers each derived the whole
+  // ceiling, so the host carried 2× what it admits against while reporting
+  // nothing (#3080). Narrowing the share instead would be worse, not better: the
+  // second Worker would derive zero and fall through to `memory_max: null`,
+  // trading a stated over-commitment for a Worker with no kernel wall at all.
+  // So the host states the exposure here, and `buildBudgetAccounting` totals it.
   const from = slots == null
-    ? `the headroom under this host's memory ceiling of ${input.ceiling.memory_bytes} bytes`
+    ? `the headroom under this host's memory ceiling of ${input.ceiling.memory_bytes} bytes; this host declares no ` +
+      `Worker slot count (${REDSKILLED_WORKER_CEILING_ENV} is unset), so this ceiling is a per-Worker wall and not ` +
+      "memory the host sets aside — N Workers may carry N such walls, and the host ceiling is not enforced " +
+      "host-wide. Declare a slot count to make it divide into shares that sum to it"
     : `this host's memory ceiling of ${input.ceiling.memory_bytes} bytes shared across its ${slots} Worker slot(s)`;
   return {
     memory_max: String(bytes),

--- a/apps/redskilled/src/budget-accounting.ts
+++ b/apps/redskilled/src/budget-accounting.ts
@@ -14,9 +14,17 @@
  * host, `infinity`), and quietly counting those as nothing would understate the
  * host's exposure exactly when it is largest.
  *
+ * **One resolver answers "what is this Worker's budget", host-wide and
+ * per-project.** {@link appliedWorkerBudget} is that resolver, and every surface
+ * reads it. The alternative has already shipped and been wrong on screen (#3080):
+ * the HOST panel totalled `worker.budget` while the PROJECTS panel resolved the
+ * derived ceiling too, so one frame said `MemoryMax 0B` and `declared 21.8G` at
+ * the same time. Two panels derived from one function cannot disagree.
+ *
  * PURE: every input is a Worker view.
  */
 import type { RedskilledWorkerView } from "./host-state.js";
+import type { RedskilledWorkerBudget } from "./worker-placement.js";
 
 export interface RedskilledBudgetAccounting {
   readonly version: 1;
@@ -31,6 +39,60 @@ export interface RedskilledBudgetAccounting {
   readonly unaccounted_workers: readonly string[];
   /** Workers with no unit of their own; their charge lands on the daemon. */
   readonly unisolated_workers: readonly string[];
+  /**
+   * The host memory ceiling these totals were judged against; `null` when unbounded.
+   *
+   * It rides ON the accounting rather than beside it because the one question an
+   * operator asks of a total is "against what?" — and a reader that had to fetch
+   * the ceiling from a second document could report a sum as safe that the
+   * ceiling it never read calls an over-commitment.
+   */
+  readonly memory_ceiling_bytes?: number | null;
+  /**
+   * How far the applied `MemoryMax` walls exceed the host ceiling, in bytes.
+   *
+   * Zero on a host inside its ceiling. Non-zero is not an error — a per-Worker
+   * ceiling is a WALL and never a reservation, so N Workers may legitimately
+   * carry N walls that sum past the host's own — but it is the fact the host
+   * budget's promise rests on, and it was previously unsayable (#3080).
+   */
+  readonly over_committed_bytes?: number;
+  /** A whole sentence naming the over-commitment; `null` when there is none. */
+  readonly over_commitment_reason?: string | null;
+}
+
+/**
+ * Whatever carries a budget — structural, so a caller need not build a whole view.
+ *
+ * Three fields rather than one because they are three different facts: what the
+ * CLIENT declared, what the placement APPLIED, and the wall the host derived.
+ */
+export interface RedskilledBudgetBearer {
+  /** What the client declared. This, and only this, is what admission charges. */
+  readonly budget?: RedskilledWorkerBudget;
+  /** What the placement really handed the kernel, recorded at launch. */
+  readonly applied_budget?: RedskilledWorkerBudget;
+  /** The wall the host derived when the client declared none. */
+  readonly memory_ceiling?: string;
+}
+
+/**
+ * The budget this Worker is really running under. PURE.
+ *
+ * **What the machine carries, not what the client asked for.** The applied
+ * budget wins because it is the one the kernel was handed; absent it, a derived
+ * `memory_ceiling` stands in for a `MemoryMax` the client did not declare,
+ * exactly as the placement substituted it at launch. A reader that stopped at
+ * `worker.budget` reports `0B` for a Worker whose unit carries `10.9G` — which
+ * is precisely how a half-full host rendered a `0%` bar.
+ */
+export function appliedWorkerBudget(worker: RedskilledBudgetBearer): RedskilledWorkerBudget {
+  if (worker.applied_budget != null) return worker.applied_budget;
+  const declared = worker.budget ?? {};
+  if (declared.memory_max == null && declared.memory_high == null && worker.memory_ceiling != null) {
+    return { ...declared, memory_max: worker.memory_ceiling };
+  }
+  return declared;
 }
 
 /** The empty accounting — a daemon holding nothing still states a total. */
@@ -42,10 +104,24 @@ export const EMPTY_BUDGET_ACCOUNTING: RedskilledBudgetAccounting = {
   cpu_weight_total: 0,
   unaccounted_workers: [],
   unisolated_workers: [],
+  memory_ceiling_bytes: null,
+  over_committed_bytes: 0,
+  over_commitment_reason: null,
 };
 
-/** Total the declared budgets of a Worker set. PURE. */
-export function buildBudgetAccounting(workers: readonly RedskilledWorkerView[]): RedskilledBudgetAccounting {
+/**
+ * Total the budgets a Worker set is really running under. PURE.
+ *
+ * The totals come from {@link appliedWorkerBudget}, so this document states what
+ * the units carry rather than what their clients happened to declare. Pass the
+ * host ceiling and the over-commitment is reported rather than left for a reader
+ * to notice; omit it and the totals stand alone, which is the honest answer on a
+ * host that admits against no ceiling.
+ */
+export function buildBudgetAccounting(
+  workers: readonly RedskilledWorkerView[],
+  options: { readonly hostCeilingBytes?: number | null } = {},
+): RedskilledBudgetAccounting {
   let memoryHigh = 0;
   let memoryMax = 0;
   let cpuWeight = 0;
@@ -53,7 +129,7 @@ export function buildBudgetAccounting(workers: readonly RedskilledWorkerView[]):
   const unisolated: string[] = [];
 
   for (const worker of workers) {
-    const budget = worker.budget ?? {};
+    const budget = appliedWorkerBudget(worker);
     let opaque = false;
     for (const [declared, add] of [
       [budget.memory_high, (bytes: number) => (memoryHigh += bytes)],
@@ -69,6 +145,8 @@ export function buildBudgetAccounting(workers: readonly RedskilledWorkerView[]):
     if (!worker.isolated) unisolated.push(worker.worker_id);
   }
 
+  const ceilingBytes = options.hostCeilingBytes ?? null;
+  const over = ceilingBytes == null ? 0 : Math.max(0, memoryMax - ceilingBytes);
   return {
     version: 1,
     worker_count: workers.length,
@@ -77,7 +155,25 @@ export function buildBudgetAccounting(workers: readonly RedskilledWorkerView[]):
     cpu_weight_total: cpuWeight,
     unaccounted_workers: unaccounted.sort(),
     unisolated_workers: unisolated.sort(),
+    memory_ceiling_bytes: ceilingBytes,
+    over_committed_bytes: over,
+    over_commitment_reason: over === 0 ? null : overCommitmentReason(workers.length, memoryMax, ceilingBytes!, over),
   };
+}
+
+/**
+ * Why the walls sum past the ceiling, in one sentence an operator can act on. PURE.
+ *
+ * It names the arithmetic rather than declaring a fault, because the state is
+ * not one: a per-Worker `MemoryMax` is the most a Worker may take, so a host
+ * whose Workers never all peak at once runs over-committed and perfectly safe.
+ * What the sentence buys is that the host stops claiming a promise it is not
+ * keeping — which is the whole defect (#3080).
+ */
+function overCommitmentReason(workers: number, memoryMax: number, ceiling: number, over: number): string {
+  return `this host's ${workers} Worker(s) carry ${memoryMax} bytes of applied MemoryMax against a host ceiling of ` +
+    `${ceiling} bytes — ${over} bytes over. A per-Worker MemoryMax is a wall rather than a reservation, so the host ` +
+    "stays safe only while the Workers do not all peak together; the ceiling is not enforced host-wide.";
 }
 
 /**

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -985,6 +985,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       startedAt,
       scope: describeMachineScope(machineClaimStore.claimPath, claimLabels, machineOwner),
       workers: [...workers.values()],
+      // The ceiling the accounting is judged against, from the one place that
+      // resolved it. Without it the totals are a sum nobody compared to anything,
+      // which is how a host carrying 2× its ceiling reported no over-commitment.
+      hostCeilingBytes: ceiling.memory_bytes,
       registrations: [...registrations.values()],
       // The ones that stopped, beside the ones that stand: a project missing from
       // the set is either one that never registered or one whose drain ended, and
@@ -1750,7 +1754,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     lastReading = rss;
     lastSampledAt = clock();
     recordCpuReading(reading.cpu_seconds, lastSampledAt);
-    const { terminations } = evaluateMemoryBudgets({ workers: live, rss });
+    recordRssSources(reading.sources);
+    const { terminations } = evaluateMemoryBudgets({ workers: live, rss, ...(reading.sources == null ? {} : { sources: reading.sources }) });
     const done: RedskilledBudgetTermination[] = [];
     for (const termination of terminations) {
       if (await killWorkerOverBudget(termination.worker_id, termination.reason)) done.push(termination);
@@ -1772,6 +1777,23 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       const held = workers.get(workerId);
       if (!held) continue;
       workers.set(workerId, { ...held, cpu: { cpu_seconds: seconds, sampled_at: sampledAt } });
+    }
+  }
+
+  /**
+   * Carry which instrument answered onto the Workers it answered for.
+   *
+   * The number and its provenance travel together for the whole reason the
+   * provenance exists: a kernel charge and a ppid walk differ by a factor a
+   * reader cannot spot from the value alone, and one of them once read 377×
+   * low (#3080). A sampler that named no instrument leaves the Worker's last
+   * source standing rather than asserting one.
+   */
+  function recordRssSources(sources: RedskilledTreeReading["sources"]): void {
+    for (const [workerId, source] of Object.entries(sources ?? {})) {
+      const held = workers.get(workerId);
+      if (!held) continue;
+      workers.set(workerId, { ...held, rss_source: source });
     }
   }
 

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -26,6 +26,17 @@ import type { RedskilledMajorHold, RedskilledReplacementHoldReason } from "./sel
 import type { RedskilledWorkerBudget } from "./worker-placement.js";
 
 /**
+ * Which instrument produced an RSS reading.
+ *
+ * `cgroup` is the kernel's own charge for the unit and cannot miss a descendant;
+ * `process-tree` is a ppid walk over the host's process table and misses anything
+ * that reparented out of the tree. Named as a value rather than left implicit so
+ * a surface can show the weaker guarantee instead of presenting both as one
+ * number (#3080).
+ */
+export type RedskilledRssSource = "cgroup" | "process-tree";
+
+/**
  * One Worker process, as the daemon sees it.
  *
  * `project_label` and `workspace_path` are the client's own opaque strings,
@@ -61,6 +72,26 @@ export interface RedskilledWorkerView {
    * could state once and never again after a restart.
    */
   readonly budget?: RedskilledWorkerBudget;
+  /**
+   * The budget the placement really handed the kernel, recorded at launch.
+   *
+   * Distinct from `budget` because they answer different questions and a single
+   * field made one of them unanswerable (#3080): `budget` is what the CLIENT
+   * declared and is what admission charges, while this is what the unit CARRIES
+   * — the `--property=MemoryMax=…` systemd was actually given, derived ceiling
+   * included. The host accounting totals THIS, so the number on screen is the
+   * number the machine is holding.
+   */
+  readonly applied_budget?: RedskilledWorkerBudget;
+  /**
+   * Where this Worker's last RSS reading came from — the kernel, or a walk.
+   *
+   * Present because the two carry different guarantees and the weaker one must
+   * not pass for the stronger: a cgroup's `memory.current` cannot miss a
+   * descendant by construction, while a ppid walk misses anything that reparented
+   * away, which is how a 5.38 GiB tree once reported 14.6M (#3080).
+   */
+  readonly rss_source?: RedskilledRssSource;
   /**
    * The memory ceiling this Worker's scope carries, however it was arrived at.
    *
@@ -276,6 +307,14 @@ export interface BuildHostStateInput {
   /** The scope block; absent leaves the document without one rather than inventing it. */
   readonly scope?: RedskilledScopeState;
   readonly workers?: readonly RedskilledWorkerView[];
+  /**
+   * The host memory ceiling the accounting is judged against; `null` is unbounded.
+   *
+   * Absent leaves the totals unjudged rather than judged against a guess — but a
+   * daemon that HAS a ceiling must pass it, because an over-commitment nobody
+   * states is the promise this document exists to keep (#3080).
+   */
+  readonly hostCeilingBytes?: number | null;
   /** The registrations the daemon holds; absent is a host with none, not an error. */
   readonly registrations?: readonly RedskilledProjectRegistration[];
   /** The ones it dropped, in the order it dropped them; absent when none lapsed. */
@@ -339,7 +378,7 @@ export function buildHostState(input: BuildHostStateInput): RedskilledHostState 
     // block at all, so a reader never has to tell an empty list from a daemon too
     // old to keep one.
     ...(input.lapses == null || input.lapses.length === 0 ? {} : { lapsed_registrations: [...input.lapses] }),
-    budget_accounting: buildBudgetAccounting(workers),
+    budget_accounting: buildBudgetAccounting(workers, { hostCeilingBytes: input.hostCeilingBytes ?? null }),
     upgrade: buildUpgradeState(input),
   };
 }

--- a/apps/redskilled/src/memory-sampler.ts
+++ b/apps/redskilled/src/memory-sampler.ts
@@ -27,13 +27,25 @@
  * for RSS, so the second measurement costs no second instrument and no per-Worker
  * read: the tick's price stays the host's process table.
  *
+ * **The cgroup is asked first, because the daemon created it.** A unit's
+ * `memory.current` is the kernel's own charge for every process inside the
+ * boundary the placement drew, so it cannot miss a descendant by construction —
+ * no ppid chain to walk, nothing to reparent away, and no way for the recorded
+ * pid to be the `systemd-run` client rather than the unit's main process. That
+ * last case is not hypothetical: it read a 5.38 GiB pair of Workers as `14.6M`,
+ * low by a factor of 377, because the pid the daemon holds under `--wait` lives
+ * in the DAEMON's cgroup and its subtree is the client, not the Worker (#3080).
+ * The walk remains the floor for a Worker genuinely without a unit, and the
+ * reading says which instrument answered rather than presenting both as one
+ * number.
+ *
  * PURE except for {@link sampleWorkerTrees}, the one function that reads the host.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
-import { parseMemoryBudget } from "./budget-accounting.js";
-import type { RedskilledWorkerView } from "./host-state.js";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { appliedWorkerBudget, parseMemoryBudget } from "./budget-accounting.js";
+import type { RedskilledRssSource, RedskilledWorkerView } from "./host-state.js";
 import type { RedskilledWorkerBudget } from "./worker-placement.js";
 
 /** How the daemon classifies a termination it decided itself. */
@@ -116,6 +128,20 @@ export type RedskilledCpuReading = Readonly<Record<string, number>>;
 export interface RedskilledTreeReading {
   readonly rss: RedskilledRssReading;
   readonly cpu_seconds: RedskilledCpuReading;
+  /**
+   * Which instrument answered for each Worker, keyed by `worker_id`.
+   *
+   * Present because the two instruments do not carry the same guarantee, and the
+   * weaker one must not pass for the stronger: a reader shown one number could
+   * not tell a kernel charge from a ppid walk that quietly missed most of the
+   * tree. Absent for a Worker nothing measured, exactly as `rss` is.
+   *
+   * OPTIONAL on the reading rather than required, because an injected sampler
+   * that names no instrument has honestly named none — and a default of `cgroup`
+   * would be the silent upgrade this field exists to prevent. {@link
+   * sampleWorkerTrees} always states it.
+   */
+  readonly sources?: Readonly<Record<string, RedskilledRssSource>>;
 }
 
 /** Measures the whole Worker set in one call. Injected, so a test needs no process. */
@@ -132,18 +158,25 @@ export type RedskilledTreeSampler = (
  * willing to keep running. PURE.
  */
 export function resolveEnforcedBudget(
-  worker: { readonly budget?: RedskilledWorkerBudget; readonly memory_ceiling?: string },
+  worker: {
+    readonly budget?: RedskilledWorkerBudget;
+    readonly applied_budget?: RedskilledWorkerBudget;
+    readonly memory_ceiling?: string;
+  },
 ): { readonly name: RedskilledBudgetName; readonly declared: string; readonly bytes: number } | null {
-  const budget = worker.budget ?? {};
+  // The SAME resolver the host accounting totals, so the floor enforces exactly
+  // the wall the accounting reports. Two resolutions of one question is how the
+  // HOST and PROJECTS panels came to disagree in a single frame (#3080).
+  //
+  // The scope's ceiling is folded in last and answers only for a Worker whose
+  // client declared nothing: on a host with no cgroup to hold it — no systemd, or
+  // a Mac — the derived ceiling would otherwise be a wall with nothing behind it
+  // (#3029). Where the kernel does hold it, the floor is the redundant second
+  // ceiling it has always been.
+  const budget = appliedWorkerBudget(worker);
   const candidates: ReadonlyArray<readonly [RedskilledBudgetName, string | undefined]> = [
-    // The scope's ceiling comes last and answers only for a Worker whose client
-    // declared nothing: on a host with no cgroup to hold it — no systemd, or a
-    // Mac — the derived ceiling would otherwise be a wall with nothing behind it
-    // (#3029). Where the kernel does hold it, the floor is the redundant second
-    // ceiling it has always been.
     ["MemoryMax", budget.memory_max],
     ["MemoryHigh", budget.memory_high],
-    ["MemoryMax", worker.memory_ceiling],
   ];
   for (const [name, declared] of candidates) {
     if (declared == null) continue;
@@ -162,10 +195,21 @@ export function resolveEnforcedBudget(
  * its ceiling all leave the Worker running. The floor exists to stop a runaway,
  * and a floor that killed on missing evidence would be a worse failure than the
  * one it prevents.
+ *
+ * **The floor stands down where the kernel is already holding the wall.** A
+ * cgroup reading is `memory.current`, which counts reclaimable page cache that a
+ * process-tree RSS never saw — so a Worker that merely read a large repository
+ * can sit near its `MemoryMax` with no anonymous pressure at all, and the kernel
+ * reclaims that cache rather than killing it. A software floor acting on the
+ * same number would kill the Worker the kernel deliberately kept. The unit
+ * carries that exact `MemoryMax`, so the enforcement is not lost, only left to
+ * the one enforcer that can tell cache from anonymous memory.
  */
 export function evaluateMemoryBudgets(input: {
   readonly workers: readonly RedskilledWorkerView[];
   readonly rss: RedskilledRssReading;
+  /** Which instrument produced each reading; absent leaves every Worker judged. */
+  readonly sources?: Readonly<Record<string, RedskilledRssSource>>;
 }): RedskilledMemoryTickOutcome {
   const terminations: RedskilledBudgetTermination[] = [];
   const unenforceable: RedskilledUnenforceableBudget[] = [];
@@ -175,7 +219,7 @@ export function evaluateMemoryBudgets(input: {
     if (budget == null) {
       unenforceable.push({
         worker_id: worker.worker_id,
-        reason: (worker.budget?.memory_max ?? worker.budget?.memory_high ?? worker.memory_ceiling) == null
+        reason: (appliedWorkerBudget(worker).memory_max ?? appliedWorkerBudget(worker).memory_high) == null
           ? "this Worker declared no memory budget and the host derived no ceiling for it, so the sampler has none to enforce"
           : "this Worker's declared memory budget cannot be reduced to bytes, so the sampler has no ceiling to enforce",
       });
@@ -190,6 +234,15 @@ export function evaluateMemoryBudgets(input: {
       continue;
     }
     if (observed <= budget.bytes) continue;
+    if (input.sources?.[worker.worker_id] === "cgroup" && budget.name === "MemoryMax") {
+      unenforceable.push({
+        worker_id: worker.worker_id,
+        reason: `this Worker's ${budget.name} of ${budget.declared} is held by the kernel on its own cgroup, and the ` +
+          "reading is memory.current — which counts reclaimable page cache the kernel drops before it kills anything, " +
+          "so the daemon does not duplicate an enforcement that can tell cache from anonymous memory",
+      });
+      continue;
+    }
     terminations.push(buildBudgetTermination(worker, budget, observed));
   }
 
@@ -247,19 +300,33 @@ const PAGE_SIZE_BYTES = 4096;
  */
 export function sampleWorkerTrees(
   workers: readonly RedskilledWorkerView[],
-  options: {
-    readonly procRoot?: string;
-    readonly platform?: NodeJS.Platform;
-    /** Injected `ps` output, so the macOS arm is provable off a Mac. */
-    readonly psTable?: () => string;
-  } = {},
+  options: SampleWorkerTreesOptions = {},
 ): RedskilledTreeReading {
   const platform = options.platform ?? process.platform;
-  const empty: RedskilledTreeReading = { rss: {}, cpu_seconds: {} };
+  const empty: RedskilledTreeReading = { rss: {}, cpu_seconds: {}, sources: {} };
   if (workers.length === 0) return empty;
 
+  const rss: Record<string, number> = {};
+  const cpuSeconds: Record<string, number> = {};
+  const sources: Record<string, RedskilledRssSource> = {};
+
+  // The kernel's own charge first, for every Worker the daemon put in a unit.
+  const cgroups = resolveUnitCgroups(workers, platform, options);
+  for (const [workerId, dir] of cgroups) {
+    const charge = readCgroupCharge(dir);
+    if (charge == null) continue;
+    rss[workerId] = charge.memoryBytes;
+    if (charge.cpuSeconds != null) cpuSeconds[workerId] = charge.cpuSeconds;
+    sources[workerId] = "cgroup";
+  }
+
+  // The walk answers only for whoever the kernel did not: an unisolated Worker, a
+  // host with no cgroup filesystem, or a unit whose directory is already gone.
+  const remaining = workers.filter((worker) => sources[worker.worker_id] == null);
+  if (remaining.length === 0) return { rss, cpu_seconds: cpuSeconds, sources };
+
   const table = readHostProcessTable(platform, options);
-  if (table.size === 0) return empty;
+  if (table.size === 0) return { rss, cpu_seconds: cpuSeconds, sources };
 
   const children = new Map<number, number[]>();
   for (const entry of table.values()) {
@@ -268,9 +335,7 @@ export function sampleWorkerTrees(
     else children.set(entry.ppid, [entry.pid]);
   }
 
-  const rss: Record<string, number> = {};
-  const cpuSeconds: Record<string, number> = {};
-  for (const worker of workers) {
+  for (const worker of remaining) {
     if (!table.has(worker.pid)) continue;
     let totalRss = 0;
     let totalCpu = 0;
@@ -288,8 +353,161 @@ export function sampleWorkerTrees(
     }
     rss[worker.worker_id] = totalRss;
     cpuSeconds[worker.worker_id] = totalCpu;
+    sources[worker.worker_id] = "process-tree";
   }
-  return { rss, cpu_seconds: cpuSeconds };
+  return { rss, cpu_seconds: cpuSeconds, sources };
+}
+
+export interface SampleWorkerTreesOptions {
+  readonly procRoot?: string;
+  readonly platform?: NodeJS.Platform;
+  /** Injected `ps` output, so the macOS arm is provable off a Mac. */
+  readonly psTable?: () => string;
+  /** The unified cgroup mount point; injected so the arm is provable off a host. */
+  readonly cgroupRoot?: string;
+  /** The daemon's own cgroup path, as `/proc/self/cgroup` states it. Injected in tests. */
+  readonly selfCgroupPath?: string;
+  /** The uid whose `user@<uid>.service` slice holds the units. Defaults to the daemon's. */
+  readonly uid?: number;
+}
+
+/** The unified cgroup hierarchy's conventional mount point. */
+export const DEFAULT_CGROUP_ROOT = "/sys/fs/cgroup";
+
+/**
+ * The cgroup directory holding each Worker's unit, keyed by `worker_id`. PURE-ish.
+ *
+ * **Keyed by the unit's NAME, never by the Worker's pid.** The pid the daemon
+ * holds is the `systemd-run --wait` client, which lives in the daemon's own
+ * cgroup — reading `/proc/<pid>/cgroup` would therefore hand back the DAEMON's
+ * directory and charge every Worker with the daemon's memory (#3080). The unit
+ * name is the one identifier that survives that indirection, and the placement
+ * already recorded it.
+ *
+ * A Worker with no unit is simply absent: it has no cgroup to read, which is the
+ * `unisolated_workers` case the walk exists for.
+ */
+function resolveUnitCgroups(
+  workers: readonly RedskilledWorkerView[],
+  platform: NodeJS.Platform,
+  options: SampleWorkerTreesOptions,
+): Map<string, string> {
+  const found = new Map<string, string>();
+  const explicitRoot = options.cgroupRoot != null;
+  if (!explicitRoot && platform !== "linux") return found;
+  const root = options.cgroupRoot ?? DEFAULT_CGROUP_ROOT;
+  const units = workers.filter((worker) => worker.unit != null && worker.unit !== "");
+  if (units.length === 0) return found;
+
+  const parents = candidateUnitParents(root, options);
+  for (const worker of units) {
+    for (const parent of parents) {
+      const dir = join(parent, worker.unit!);
+      if (existsSync(join(dir, "memory.current"))) {
+        found.set(worker.worker_id, dir);
+        break;
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Where a transient `--user` unit's directory could be, best guess first. PURE-ish.
+ *
+ * Derived from the daemon's OWN cgroup rather than hard-coded, because the two
+ * are siblings whenever the daemon itself runs under a unit — which is the
+ * arrangement ADR 0130 rule 5 puts it in. The ancestors are walked because the
+ * daemon may sit one level deeper (`app.slice/redskilled.service`) or shallower
+ * (a login `session-N.scope`), and `user@<uid>.service/app.slice` is appended
+ * last for the case where the daemon is not in the user manager's slice at all.
+ *
+ * Every candidate costs one `existsSync`, so the whole search is cheaper than the
+ * `/proc` walk it replaces even when it misses.
+ */
+function candidateUnitParents(root: string, options: SampleWorkerTreesOptions): readonly string[] {
+  const self = options.selfCgroupPath ?? readSelfCgroupPath();
+  const parents: string[] = [];
+  const push = (path: string) => {
+    if (!parents.includes(path)) parents.push(path);
+  };
+
+  let relative = self;
+  while (relative != null && relative !== "" && relative !== "/" && relative !== ".") {
+    push(join(root, relative));
+    const parent = dirname(relative);
+    if (parent === relative) break;
+    relative = parent;
+  }
+  push(root);
+
+  const uid = options.uid ?? process.getuid?.();
+  if (uid != null) {
+    push(join(root, "user.slice", `user-${uid}.slice`, `user@${uid}.service`, "app.slice"));
+  }
+  return parents;
+}
+
+/** The daemon's own cgroup path, or `null` — an unreadable `/proc` is never a crash. */
+function readSelfCgroupPath(): string | null {
+  try {
+    // cgroup v2 writes exactly one line, `0::<path>`; on a v1/hybrid host the
+    // unified controller is the same `0::` row, so the same read answers both.
+    for (const line of readFileSync("/proc/self/cgroup", "utf8").split("\n")) {
+      if (line.startsWith("0::")) return line.slice(3).trim();
+    }
+  } catch {
+    // A host with no `/proc` falls back to the conventional slice path below.
+  }
+  return null;
+}
+
+/**
+ * One unit's memory charge and accumulated CPU, straight from the kernel.
+ *
+ * `memory.current` is the whole cgroup's charge — every process inside the
+ * boundary, however it got there — so it is a single read where the walk is a
+ * traversal, and it is exact where the walk is a best effort. CPU rides along
+ * from `cpu.stat` for the reason it rides the `/proc` line: the question "is this
+ * Worker alive and working?" must not need a second instrument.
+ *
+ * `null` when the directory holds no readable `memory.current`, which is a unit
+ * that has already gone away — the caller then falls back to the walk rather
+ * than reporting a Worker at zero.
+ */
+function readCgroupCharge(dir: string): { readonly memoryBytes: number; readonly cpuSeconds: number | null } | null {
+  let raw: string;
+  try {
+    raw = readFileSync(join(dir, "memory.current"), "utf8");
+  } catch {
+    return null;
+  }
+  const memoryBytes = Number(raw.trim());
+  if (!Number.isFinite(memoryBytes) || memoryBytes < 0) return null;
+  return { memoryBytes, cpuSeconds: readCgroupCpuSeconds(dir) };
+}
+
+/** `usage_usec` out of `cpu.stat`, in seconds; `null` when the host keeps none. */
+function readCgroupCpuSeconds(dir: string): number | null {
+  let raw: string;
+  try {
+    raw = readFileSync(join(dir, "cpu.stat"), "utf8");
+  } catch {
+    return null;
+  }
+  return parseCgroupCpuStat(raw);
+}
+
+/** Microseconds of `usage_usec` as seconds, or `null` when the key is absent. PURE. */
+export function parseCgroupCpuStat(raw: string): number | null {
+  for (const line of raw.split("\n")) {
+    const [key, value] = line.trim().split(/\s+/);
+    if (key !== "usage_usec") continue;
+    const usec = Number(value);
+    if (!Number.isFinite(usec) || usec < 0) return null;
+    return usec / 1_000_000;
+  }
+  return null;
 }
 
 /** One `/proc` row, in the kernel's own units. */

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -28,7 +28,7 @@ import type {
 import type { ProcessDeathKind } from "@reddb-io/shared/death-record.js";
 import { measureHostConsumption, type RedskilledHostCeiling, type RedskilledHostConsumption } from "./admission.js";
 import type { RedskilledBudgetAccounting } from "./budget-accounting.js";
-import type { RedskilledHostState, RedskilledWorkerView } from "./host-state.js";
+import type { RedskilledHostState, RedskilledRssSource, RedskilledWorkerView } from "./host-state.js";
 import { isRedskilledStatuslineMetrics, type RedskilledStatuslineMetrics } from "./live-metrics.js";
 import { resolveEnforcedBudget, type RedskilledBudgetName, type RedskilledRssReading } from "./memory-sampler.js";
 import {
@@ -65,6 +65,18 @@ export interface RedskilledStatuslineVitals {
   readonly age_ms: number | null;
   /** True when this Worker was measured within the staleness window. */
   readonly fresh: boolean;
+  /**
+   * Which instrument produced `rss_bytes`; `null` when the daemon named none.
+   *
+   * A surface shows it because the two instruments do not carry the same
+   * guarantee: `cgroup` is the kernel's charge for the unit, `process-tree` is a
+   * ppid walk that misses whatever reparented away. Rendering both as one
+   * unlabelled number is how a 5.38 GiB host displayed `14.6M` (#3080). OPTIONAL
+   * on the wire, because one daemon serves checkouts pinned to different bundle
+   * versions and a consumer finding it absent must render an unnamed source
+   * rather than reject the Worker.
+   */
+  readonly rss_source?: RedskilledRssSource | null;
 }
 
 /** What this Worker was promised, and how much of it the daemon has seen it take. */
@@ -563,6 +575,7 @@ function buildWorker(
       sampled_at: rssBytes == null ? null : ctx.sampledAt,
       age_ms: rssBytes == null ? null : ctx.ageMs,
       fresh: rssBytes != null && ctx.sampleFresh,
+      rss_source: rssBytes == null ? null : worker.rss_source ?? null,
     },
     budget: {
       name: enforced?.name ?? null,

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -290,6 +290,12 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     isolated,
     ...(plan.unit != null ? { unit: plan.unit } : {}),
     ...(spec.budget != null ? { budget: spec.budget } : {}),
+    // What the placement really applied, beside what the client declared. The two
+    // are recorded separately because they are charged separately: admission
+    // charges the declaration, and the host accounting totals this (#3080). A
+    // Worker carrying neither records nothing rather than an empty object, so
+    // "declared no budget" stays distinguishable from "applied an empty one".
+    ...(Object.keys(plan.budget).length > 0 ? { applied_budget: plan.budget } : {}),
     // Carried for the Worker's whole life, beside the budget and for the same
     // reason: a ceiling stated once at launch is a ceiling no later reader —
     // the sampling floor included — can ask for.

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -159,6 +159,18 @@ export interface WorkerPlacementPlan {
    */
   readonly memoryCeiling?: string;
   /**
+   * The budget this placement APPLIED — the properties systemd was really given.
+   *
+   * It is the client's declared budget merged with the ceiling the host derived,
+   * which is exactly the object the `--property=…` flags above are written from.
+   * Stated on the plan rather than re-derived by the caller because a caller that
+   * re-derived it would be a second authority on what the unit carries, and the
+   * two would drift: the host accounting once totalled the client's declaration
+   * while the units carried the derived ceiling, and reported `0B` for a machine
+   * holding 21.8 GiB of walls (#3080).
+   */
+  readonly budget: RedskilledWorkerBudget;
+  /**
    * What the Worker is told about its own placement — the scope, its ceiling and
    * the degradation when there is no scope (`@reddb-io/shared/worker-scope`).
    *
@@ -334,6 +346,7 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
     args,
     cwd: opts.workspacePath,
     warning,
+    budget,
     ...(ceilingValue != null ? { memoryCeiling: ceilingValue } : {}),
     // The Worker still learns its ceiling here, and learns WHY it has no scope:
     // an unscoped death that named neither would be the silent degradation this
@@ -406,6 +419,9 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
     unit,
     command: opts.probes.systemdRun,
     args: [...unitArgs, "--", opts.command, ...args],
+    // The very object the `--property=` flags above were written from, so the
+    // accounting reads what the unit carries rather than a second derivation.
+    budget,
     ...(ceilingValue != null ? { memoryCeiling: ceilingValue } : {}),
     environment,
     ...(unenforced != null ? { budgetWarning: unenforced } : {}),
@@ -450,6 +466,7 @@ function planPosixLimitsPlacement(
     cwd: opts.workspacePath,
     posix: limits,
     warning,
+    budget: effectiveBudget,
     ...(ceilingValue != null ? { memoryCeiling: ceilingValue } : {}),
     // No scope: macOS has no resource group to name, so the Worker is told its
     // ceiling and told, in the same breath, that nothing but the floor holds it.
@@ -508,6 +525,7 @@ function planJobObjectPlacement(
     args: [...args],
     cwd: opts.workspacePath,
     job: { name, limits },
+    budget: effectiveBudget,
     ...(ceilingValue != null ? { memoryCeiling: ceilingValue } : {}),
     // The job IS the scope on Windows, so the Worker names it exactly as a Linux
     // Worker names its unit — one vocabulary, whichever kernel drew the wall.

--- a/apps/redskilled/tests/daemon-reattach-survivor.test.ts
+++ b/apps/redskilled/tests/daemon-reattach-survivor.test.ts
@@ -120,6 +120,7 @@ function unitBackedLaunch(state: { exitLaunchClient?: (signal: NodeJS.Signals) =
         command: "systemd-run",
         args: [],
         unit: worker.unit!,
+        budget: options.spec.budget ?? {},
         environment: {},
       },
       child: { pid: worker.pid } as ChildProcess,

--- a/apps/redskilled/tests/macos-posix-limits.test.ts
+++ b/apps/redskilled/tests/macos-posix-limits.test.ts
@@ -147,7 +147,7 @@ describe("macOS placement — the memory ceiling it refuses to claim", () => {
       },
     });
 
-    expect(reading).toEqual({ rss: {}, cpu_seconds: {} });
+    expect(reading).toEqual({ rss: {}, cpu_seconds: {}, sources: {} });
   });
 
   it("parses `ps` output and ignores every line that is not a process row", () => {

--- a/apps/redskilled/tests/memory-accounting.test.ts
+++ b/apps/redskilled/tests/memory-accounting.test.ts
@@ -1,0 +1,315 @@
+// Memory accounting describes the machine the daemon is running on: the reported
+// figure is the cgroup's own charge, the accounting totals what the units really
+// carry, and an over-commitment the host cannot enforce is stated rather than
+// hidden behind a zero (#3080).
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { deriveWorkerScopeCeiling, measureHostConsumption, type RedskilledHostCeiling } from "../src/admission.js";
+import { appliedWorkerBudget, buildBudgetAccounting } from "../src/budget-accounting.js";
+import { buildHostState, type RedskilledWorkerView } from "../src/host-state.js";
+import { evaluateMemoryBudgets, resolveEnforcedBudget, sampleWorkerTrees } from "../src/memory-sampler.js";
+import { buildStatuslinePayload } from "../src/statusline-payload.js";
+import { detectWorkerPlacementProbes, planWorkerPlacement } from "../src/worker-placement.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function scratch(): string {
+  const root = mkdtempSync(join(tmpdir(), "redskilled-accounting-"));
+  roots.push(root);
+  return root;
+}
+
+const GIB = 1024 ** 3;
+
+function worker(overrides: Partial<RedskilledWorkerView> & { readonly worker_id: string }): RedskilledWorkerView {
+  return {
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-08-03T00:00:00.000Z",
+    workspace_path: "/tmp/ws",
+    isolated: true,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+/**
+ * A fake unified cgroup hierarchy holding one unit, charged at `bytes`.
+ *
+ * Built on disk rather than mocked, because the defect was a path the code never
+ * reached: a mocked reader would have passed against the very tree that produced
+ * `14.6M` for 5.38 GiB.
+ */
+function cgroupHost(units: Readonly<Record<string, { readonly bytes: number; readonly cpuUsec?: number }>>): {
+  readonly cgroupRoot: string;
+  readonly selfCgroupPath: string;
+} {
+  const cgroupRoot = scratch();
+  const selfCgroupPath = "/user.slice/user-1000.slice/user@1000.service/app.slice/redskilled.service";
+  const appSlice = join(cgroupRoot, "user.slice", "user-1000.slice", "user@1000.service", "app.slice");
+  mkdirSync(join(appSlice, "redskilled.service"), { recursive: true });
+  // The daemon's own cgroup carries a charge too — a reader that walked up to the
+  // parent slice would hand every Worker this number instead of its own.
+  writeFileSync(join(appSlice, "redskilled.service", "memory.current"), "104857600\n");
+  for (const [unit, charge] of Object.entries(units)) {
+    const dir = join(appSlice, unit);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "memory.current"), `${charge.bytes}\n`);
+    if (charge.cpuUsec != null) {
+      writeFileSync(join(dir, "cpu.stat"), `usage_usec ${charge.cpuUsec}\nuser_usec 1\nsystem_usec 2\n`);
+    }
+  }
+  return { cgroupRoot, selfCgroupPath };
+}
+
+/** One synthetic `/proc` tree, so the walk arm is provable without real processes. */
+function procHost(rows: ReadonlyArray<{ readonly pid: number; readonly ppid: number; readonly rssPages: number }>): string {
+  const procRoot = scratch();
+  for (const row of rows) {
+    const dir = join(procRoot, String(row.pid));
+    mkdirSync(dir, { recursive: true });
+    const fields = Array.from({ length: 50 }, () => "0");
+    fields[0] = String(row.ppid);
+    fields[10] = "0";
+    fields[11] = "0";
+    fields[20] = String(row.rssPages);
+    writeFileSync(join(dir, "stat"), `${row.pid} (worker) S ${fields.join(" ")}\n`);
+  }
+  return procRoot;
+}
+
+describe("reported memory tracks the cgroup", () => {
+  it("reports the unit's own memory.current, not a walk over the recorded pid", () => {
+    // The exact shape of the defect: the pid the daemon holds is the
+    // `systemd-run --wait` client, a small process in the DAEMON's cgroup, while
+    // the unit itself is charged gigabytes.
+    const CGROUP_BYTES = 4_963_123_200;
+    const { cgroupRoot, selfCgroupPath } = cgroupHost({
+      "red-worker-acme-widgets-w1.service": { bytes: CGROUP_BYTES, cpuUsec: 12_000_000 },
+    });
+    const procRoot = procHost([
+      { pid: 1, ppid: 0, rssPages: 100 },
+      // 7.26 MiB of client, exactly the figure the walk used to report.
+      { pid: 4242, ppid: 1, rssPages: 1_860 },
+    ]);
+
+    const reading = sampleWorkerTrees(
+      [worker({ worker_id: "w1", unit: "red-worker-acme-widgets-w1.service" })],
+      { platform: "linux", cgroupRoot, selfCgroupPath, procRoot, uid: 1000 },
+    );
+
+    expect(reading.rss.w1).toBe(CGROUP_BYTES);
+    expect(reading.sources?.w1).toBe("cgroup");
+    expect(reading.cpu_seconds.w1).toBe(12);
+  });
+
+  it("fails when the reported figure diverges from the cgroup by more than a small factor", () => {
+    // The regression guard the defect asks for. `14.6M` against `5.38G` is a
+    // factor of 377; anything past 1% of the kernel's own number is a bug.
+    const TOLERANCE = 0.01;
+    const charges = { "red-worker-acme-widgets-w1.service": 5_100_000_000, "red-worker-acme-widgets-w2.service": 677_000_000 };
+    const { cgroupRoot, selfCgroupPath } = cgroupHost({
+      "red-worker-acme-widgets-w1.service": { bytes: charges["red-worker-acme-widgets-w1.service"] },
+      "red-worker-acme-widgets-w2.service": { bytes: charges["red-worker-acme-widgets-w2.service"] },
+    });
+    const workers = [
+      worker({ worker_id: "w1", pid: 4242, unit: "red-worker-acme-widgets-w1.service" }),
+      worker({ worker_id: "w2", pid: 4243, unit: "red-worker-acme-widgets-w2.service" }),
+    ];
+    // The process table the walk would have used, and which is nowhere near right.
+    const procRoot = procHost([
+      { pid: 4242, ppid: 1, rssPages: 1_860 },
+      { pid: 4243, ppid: 1, rssPages: 1_000 },
+    ]);
+
+    const reading = sampleWorkerTrees(workers, { platform: "linux", cgroupRoot, selfCgroupPath, procRoot, uid: 1000 });
+
+    for (const held of workers) {
+      const cgroup = charges[held.unit as keyof typeof charges];
+      const reported = reading.rss[held.worker_id]!;
+      expect(Math.abs(reported - cgroup) / cgroup).toBeLessThanOrEqual(TOLERANCE);
+    }
+    // And the host total is the sum of the cgroups, not a rounding of the walk.
+    const total = Object.values(reading.rss).reduce((sum, value) => sum + value, 0);
+    expect(total).toBe(charges["red-worker-acme-widgets-w1.service"] + charges["red-worker-acme-widgets-w2.service"]);
+  });
+
+  it("falls back to the walk for a Worker with no unit, and says which instrument answered", () => {
+    const { cgroupRoot, selfCgroupPath } = cgroupHost({ "red-worker-acme-widgets-w1.service": { bytes: 8 * GIB } });
+    const procRoot = procHost([
+      { pid: 5000, ppid: 1, rssPages: 1_024 },
+      { pid: 5001, ppid: 5000, rssPages: 2_048 },
+    ]);
+
+    const reading = sampleWorkerTrees(
+      [
+        worker({ worker_id: "w1", unit: "red-worker-acme-widgets-w1.service" }),
+        worker({ worker_id: "w2", pid: 5000, isolated: false }),
+      ],
+      { platform: "linux", cgroupRoot, selfCgroupPath, procRoot, uid: 1000 },
+    );
+
+    expect(reading.sources?.w1).toBe("cgroup");
+    expect(reading.sources?.w2).toBe("process-tree");
+    // The walk's weaker guarantee is visible rather than silent: same shape of
+    // number, explicitly different provenance.
+    expect(reading.rss.w2).toBe(3_072 * 4096);
+  });
+
+  it("never charges a Worker with the daemon's own cgroup when its unit is gone", () => {
+    const { cgroupRoot, selfCgroupPath } = cgroupHost({});
+    const procRoot = procHost([{ pid: 4242, ppid: 1, rssPages: 512 }]);
+
+    const reading = sampleWorkerTrees(
+      [worker({ worker_id: "w1", unit: "red-worker-acme-widgets-gone.service" })],
+      { platform: "linux", cgroupRoot, selfCgroupPath, procRoot, uid: 1000 },
+    );
+
+    expect(reading.sources?.w1).toBe("process-tree");
+    expect(reading.rss.w1).toBe(512 * 4096);
+  });
+});
+
+describe("the floor stands down where the kernel holds the wall", () => {
+  it("does not kill a cgroup-measured Worker over its kernel-held MemoryMax", () => {
+    const held = worker({ worker_id: "w1", unit: "u1", applied_budget: { memory_max: "1G" } });
+    const over = { workers: [held], rss: { w1: 2 * GIB } };
+
+    // Measured by a walk, the daemon is the only enforcer and acts.
+    expect(evaluateMemoryBudgets({ ...over, sources: { w1: "process-tree" } }).terminations).toHaveLength(1);
+
+    // Measured by the cgroup, `memory.current` counts reclaimable page cache and
+    // the unit already carries the same MemoryMax — so the kernel decides.
+    const kernelHeld = evaluateMemoryBudgets({ ...over, sources: { w1: "cgroup" } });
+    expect(kernelHeld.terminations).toEqual([]);
+    expect(kernelHeld.unenforceable[0]?.reason).toContain("held by the kernel on its own cgroup");
+  });
+
+  it("still enforces a MemoryHigh, which no kernel wall holds", () => {
+    const held = worker({ worker_id: "w1", unit: "u1", applied_budget: { memory_high: "1G" } });
+    const outcome = evaluateMemoryBudgets({ workers: [held], rss: { w1: 2 * GIB }, sources: { w1: "cgroup" } });
+    expect(outcome.terminations[0]?.budget_name).toBe("MemoryHigh");
+  });
+});
+
+describe("the accounting totals what the units carry", () => {
+  it("records the applied budget at placement, derived ceiling included", () => {
+    const plan = planWorkerPlacement({
+      workerId: "w1",
+      projectLabel: "acme/widgets",
+      workspacePath: "/tmp/ws",
+      command: "node",
+      memoryCeiling: { memory_max: "11709286400", reason: "derived from the host ceiling" },
+      probes: { ...detectWorkerPlacementProbes({}, "linux"), platform: "linux", systemdRun: "/usr/bin/systemd-run", userSession: true },
+    });
+
+    expect(plan.args).toContain("--property=MemoryMax=11709286400");
+    // The plan states the very object those flags were written from.
+    expect(plan.budget).toEqual({ memory_max: "11709286400" });
+  });
+
+  it("makes HOST and PROJECTS agree on one frame", () => {
+    const CEILING = 11_709_286_400;
+    const workers = [
+      worker({ worker_id: "w1", unit: "u1", applied_budget: { memory_max: String(CEILING) }, memory_ceiling: String(CEILING) }),
+      worker({ worker_id: "w2", unit: "u2", applied_budget: { memory_max: String(CEILING) }, memory_ceiling: String(CEILING) }),
+    ];
+    const ceiling: RedskilledHostCeiling = { memory_bytes: CEILING, worker_count: null, source: "host-fraction" };
+    const hostState = buildHostState({
+      daemonVersion: "3.3.9",
+      machineIdHash: "m",
+      sessionKeyHash: "s",
+      pid: 1,
+      startedAt: "2026-08-03T00:00:00.000Z",
+      workers,
+      hostCeilingBytes: ceiling.memory_bytes,
+    });
+
+    const payload = buildStatuslinePayload({
+      hostState,
+      ceiling,
+      now: "2026-08-03T00:00:10.000Z",
+      rss: { w1: 4_963_123_200, w2: 4_800_000_000 },
+      sampledAt: "2026-08-03T00:00:09.000Z",
+    });
+
+    // HOST: what the units carry, not `0B`.
+    expect(payload.host.budget_accounting.memory_max_bytes).toBe(2 * CEILING);
+    // PROJECTS: the same number, because both come from one resolver.
+    const declared = payload.projects.reduce((sum, project) => sum + project.declared_memory_bytes, 0);
+    expect(declared).toBe(payload.host.budget_accounting.memory_max_bytes);
+    // And the observed figure is the sum of the samples, not a rounding of zero.
+    expect(payload.host.observed_rss_bytes).toBe(4_963_123_200 + 4_800_000_000);
+  });
+
+  it("resolves a derived ceiling the same way the floor enforces it", () => {
+    const held = worker({ worker_id: "w1", unit: "u1", memory_ceiling: "10G" });
+    expect(appliedWorkerBudget(held)).toEqual({ memory_max: "10G" });
+    expect(resolveEnforcedBudget(held)).toEqual({ name: "MemoryMax", declared: "10G", bytes: 10 * GIB });
+    expect(buildBudgetAccounting([held]).memory_max_bytes).toBe(10 * GIB);
+  });
+
+  it("keeps the admission charge on the DECLARED budget alone", () => {
+    // The applied ceiling is a wall, never memory set aside — counting it as
+    // committed would let the first Worker born spend the whole host's accounting.
+    const held = worker({ worker_id: "w1", unit: "u1", applied_budget: { memory_max: "10G" }, memory_ceiling: "10G" });
+    expect(measureHostConsumption([held]).memory_bytes).toBe(0);
+  });
+});
+
+describe("an unenforceable host promise is reported as such", () => {
+  it("states the over-commitment unbounded slots create", () => {
+    const CEILING = 11_709_286_400;
+    const workers = [
+      worker({ worker_id: "w1", unit: "u1", applied_budget: { memory_max: String(CEILING) } }),
+      worker({ worker_id: "w2", unit: "u2", applied_budget: { memory_max: String(CEILING) } }),
+    ];
+
+    const accounting = buildBudgetAccounting(workers, { hostCeilingBytes: CEILING });
+
+    expect(accounting.memory_max_bytes).toBe(2 * CEILING);
+    expect(accounting.memory_ceiling_bytes).toBe(CEILING);
+    expect(accounting.over_committed_bytes).toBe(CEILING);
+    expect(accounting.over_commitment_reason).toContain("wall rather than a reservation");
+  });
+
+  it("reports no over-commitment on a host inside its ceiling", () => {
+    const accounting = buildBudgetAccounting(
+      [worker({ worker_id: "w1", unit: "u1", applied_budget: { memory_max: "1G" } })],
+      { hostCeilingBytes: 8 * GIB },
+    );
+    expect(accounting.over_committed_bytes).toBe(0);
+    expect(accounting.over_commitment_reason).toBeNull();
+  });
+
+  it("says plainly that an undeclared slot count makes the ceiling per-Worker", () => {
+    const derived = deriveWorkerScopeCeiling({
+      ceiling: { memory_bytes: 11_709_286_400, worker_count: null, source: "host-fraction" },
+      workers: [],
+    });
+    expect(derived.memory_max).toBe("11709286400");
+    expect(derived.reason).toContain("per-Worker wall and not memory the host sets aside");
+  });
+
+  it("shares the ceiling across declared slots, so the walls sum to it", () => {
+    const CEILING = 11_709_286_400;
+    const derived = deriveWorkerScopeCeiling({
+      ceiling: { memory_bytes: CEILING, worker_count: 2, source: "declared" },
+      workers: [],
+    });
+    const accounting = buildBudgetAccounting(
+      [
+        worker({ worker_id: "w1", unit: "u1", applied_budget: { memory_max: derived.memory_max! } }),
+        worker({ worker_id: "w2", unit: "u2", applied_budget: { memory_max: derived.memory_max! } }),
+      ],
+      { hostCeilingBytes: CEILING },
+    );
+    expect(accounting.over_committed_bytes).toBe(0);
+  });
+});

--- a/apps/redskilled/tests/memory-floor.test.ts
+++ b/apps/redskilled/tests/memory-floor.test.ts
@@ -286,7 +286,7 @@ describe("the memory floor", () => {
   });
 
   it("measures nothing when no process table can be read at all, rather than reporting zero", () => {
-    const empty = { rss: {}, cpu_seconds: {} };
+    const empty = { rss: {}, cpu_seconds: {}, sources: {} };
     expect(sampleWorkerTrees([worker()], { platform: "aix" })).toEqual(empty);
     expect(sampleWorkerTrees([worker()], { platform: "darwin", psTable: () => "" })).toEqual(empty);
   });


### PR DESCRIPTION
Automated AFK landing for #3080. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3080

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788313772&installation_model_id=20659&pr_number=3116&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3116&signature=5307918faa38929bd5e10fe3a8539339ef3ad3f13d7df9c721ba43613d592977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->