### PR TITLE
fix: hand a Worker the slot the host placed it on

### DIFF
--- a/.changeset/the-slot-reaches-the-worker.md
+++ b/.changeset/the-slot-reaches-the-worker.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A registration now hands its Workers the slot the host placed them on. `RED_AFK_SLOT` is READ in five places — the reconcile lane, the process-deps resolver and the hook environment, each as `parseSlot(process.env.RED_AFK_SLOT) ?? 0` — and was never written on the registration path, so every Worker resolved to slot 0 and the per-slot isolation the variable exists for collapsed onto one: retire files, cargo target directories and hook scoping all addressed the same slot no matter how wide the project ran. The runner the registration decided is pinned alongside it rather than inherited, because the passthrough environment may still carry an operator's runner from before the registration chose one. `RED_AFK_WORKER_ID` is deliberately still NOT set: it names the work's own identity — the worker directory, the claim comment, every project-side surface — and assigning the host's handle to it would rename the work to satisfy an address, so the host's id goes on travelling under its own name and a test now pins that distinction rather than leaving it to the next reader's judgement.

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -1006,7 +1006,7 @@ async function projectStart(root: string, rawInput: ProjectStartInput) {
       selector,
       argv,
       workspace_path: root,
-      env: registrationLaunchEnv(),
+      env: registrationLaunchEnv(input.runner),
       log_path: logPathTemplate,
       target: input.target,
     });

--- a/apps/dev/src/runtime/redskilled-worker-log.ts
+++ b/apps/dev/src/runtime/redskilled-worker-log.ts
@@ -35,7 +35,10 @@ import { join } from "node:path";
 import { logsDir } from "@reddb-io/shared/red-paths.js";
 import { publishRedskilledWorkerLogLine } from "@reddb-io/redskilled/client";
 import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
-import { RED_AFK_WORKER_ID_PLACEHOLDER } from "../core/supervisor/launch-template.js";
+import {
+  RED_AFK_SLOT_PLACEHOLDER,
+  RED_AFK_WORKER_ID_PLACEHOLDER,
+} from "../core/supervisor/launch-template.js";
 import { resolveProjectLabel } from "./redskilled-birth.js";
 
 /**
@@ -62,8 +65,27 @@ export function registrationLogPathTemplate(root: string, date: string): string 
 }
 
 /** What a registration adds to its Workers' environment. PURE. */
-export function registrationLaunchEnv(): Record<string, string> {
-  return { [REDSKILLED_HOST_WORKER_ID_ENV]: RED_AFK_WORKER_ID_PLACEHOLDER };
+export function registrationLaunchEnv(runner?: string): Record<string, string> {
+  return {
+    [REDSKILLED_HOST_WORKER_ID_ENV]: RED_AFK_WORKER_ID_PLACEHOLDER,
+    // The slot the host placed this Worker on. Read in five places
+    // (`reconcile.ts`, `process-deps.ts`, the hook env) and, until #3081, never
+    // written on this path — so `parseSlot(process.env.RED_AFK_SLOT) ?? 0`
+    // resolved every Worker to slot 0 and the per-slot isolation it exists for
+    // (retire files, cargo target dirs, hook scoping) collapsed onto one.
+    RED_AFK_SLOT: RED_AFK_SLOT_PLACEHOLDER,
+    // `RED_AFK_WORKER_ID` is deliberately NOT set here. It names the work's own
+    // identity — the worker directory, the claim comment, every project-side
+    // surface — and assigning the host's handle to it would rename the work to
+    // satisfy an address. The two ids both exist on purpose; #3081's cure is to
+    // make attribution read the host's id where the host is the authority, not
+    // to collapse one name onto the other.
+    //
+    // Re-pinned rather than inherited: the passthrough environment may carry an
+    // operator's runner from before the registration decided one, and the
+    // Worker's detection cascade must read the one this registration states.
+    ...(runner == null || runner === "" ? {} : { RED_AFK_RUNNER: runner }),
+  };
 }
 
 /** Publish one line, or do nothing at all. Never throws, never blocks the work. */

--- a/apps/dev/tests/redskilled-worker-log.test.ts
+++ b/apps/dev/tests/redskilled-worker-log.test.ts
@@ -10,6 +10,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  RED_AFK_SLOT_PLACEHOLDER,
+  RED_AFK_WORKER_ID_PLACEHOLDER,
+} from "../src/core/supervisor/launch-template.js";
+import {
   createCastleWorkerLaneBridge,
   workerLogLine,
 } from "../src/core/castle-worker-lane-bridge.js";
@@ -48,7 +52,10 @@ describe("what a registration declares", () => {
   });
 
   it("hands each Worker the host's own handle for it, without renaming the work's", () => {
-    expect(registrationLaunchEnv()).toEqual({ REDSKILLED_WORKER_ID: "{{worker_id}}" });
+    expect(registrationLaunchEnv()).toEqual({
+      REDSKILLED_WORKER_ID: "{{worker_id}}",
+      RED_AFK_SLOT: "{{slot}}",
+    });
     expect(Object.keys(registrationLaunchEnv())).not.toContain("RED_AFK_WORKER_ID");
   });
 });
@@ -127,5 +134,31 @@ describe("the beat the bridge already keeps", () => {
   it("renders a line a statusline can print, dropping the structures it cannot", () => {
     expect(workerLogLine("worker.validated", 42, { gate: "green", detail: { rows: 3 } }))
       .toBe("worker.validated #42 gate=green");
+  });
+});
+
+// #3081 — the slot the host placed a Worker on must reach the Worker.
+describe("registrationLaunchEnv slot and runner", () => {
+  it("declares RED_AFK_SLOT so per-slot isolation is not all slot 0", () => {
+    // `parseSlot(process.env.RED_AFK_SLOT) ?? 0` is read in reconcile.ts and
+    // process-deps.ts. Unset, every Worker resolved to slot 0 and the isolation
+    // it exists for — retire files, cargo target dirs, hook scoping — collapsed.
+    expect(registrationLaunchEnv().RED_AFK_SLOT).toBe(RED_AFK_SLOT_PLACEHOLDER);
+  });
+
+  it("pins the runner the registration decided, and omits it when none is given", () => {
+    expect(registrationLaunchEnv("codex").RED_AFK_RUNNER).toBe("codex");
+    expect(registrationLaunchEnv()).not.toHaveProperty("RED_AFK_RUNNER");
+    expect(registrationLaunchEnv("")).not.toHaveProperty("RED_AFK_RUNNER");
+  });
+
+  it("NEVER sets RED_AFK_WORKER_ID — the host's handle must not rename the work", () => {
+    // The two ids exist on purpose. RED_AFK_WORKER_ID names the work: its
+    // directory, its claim comment, every project-side surface. Assigning the
+    // host's handle to it would rename the work to satisfy an address, so the
+    // host's id travels under its own name and attribution reads THAT.
+    const env = registrationLaunchEnv("claude");
+    expect(env).not.toHaveProperty("RED_AFK_WORKER_ID");
+    expect(env[REDSKILLED_HOST_WORKER_ID_ENV]).toBe(RED_AFK_WORKER_ID_PLACEHOLDER);
   });
 });


### PR DESCRIPTION
Toward #3081.

## What was measured

`RED_AFK_SLOT` is **read in five places** — `reconcile.ts` (twice), `process-deps.ts` (three times), and the hook environment — always as:

```ts
const slot = parseSlot(process.env.RED_AFK_SLOT) ?? 0;
```

And it was **never written on the registration path**. So every Worker resolved to slot `0`, and the per-slot isolation the variable exists for collapsed onto one: retire files, cargo target directories and hook scoping all addressed the same slot however wide the project ran.

## The diagnosis in #3081 was partly wrong

The issue says the launch template's `env` is "dropped in transit". It is not dropped — **it is never built**. `buildProjectLaunchTemplate` has zero callers; the registration path composes its own `argv` inline and its `env` from `registrationLaunchEnv()`, which returned a single variable. That is the sixth instance in this repo of an exported symbol nobody calls.

## What is here

- `RED_AFK_SLOT` is declared, so the five readers get the slot the host actually placed the Worker on.
- The runner the registration decided is pinned alongside it rather than inherited — the passthrough environment may still carry an operator's runner from before the registration chose one, and the Worker's detection cascade must read the one this registration states.

## What is deliberately NOT here

**`RED_AFK_WORKER_ID` stays unset.** I started to set it to the host's handle and backed that out: the module documents the reason, and it is right.

> *Deliberately not `RED_AFK_WORKER_ID`: that one is the work's own identity, the name its worker directory, its claim comment and every project-side surface are filed under, and overwriting it with the host's would rename the work to satisfy an address.*

The two ids exist on purpose. #3081's cure is to make **attribution read the host's id where the host is the authority** — not to collapse one name onto the other. A test now pins that distinction so the next reader does not have to re-derive it.

## Still open on #3081

The attribution itself: `project_status` compares `port.workerIds()` (host uuids) against `worker.state.worker_id` (the project's `wXXXX`), so the predicate is false for every Worker and the unattributed bucket swallows them all. That is the half that makes `live_workers: []` show up with Workers running, and it needs the host id recorded project-side to fix — which is #3102's territory too.

Monorepo `typecheck` 13/13 and `test` 14/14 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hZobkv9P8Su16hA1hLB9x

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788315717&installation_model_id=20659&pr_number=3118&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3118&signature=55a1b77624146ea2ad02364eee75c5b36fb54490684f28397fe45fc00217cae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->