### PR TITLE
fix: #3081 A project cannot recognise its own Workers: the launch template's env never reaches the process, so host and project mint disjoint worker ids

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -1,12 +1,12 @@
 import { parseRunnerFlag, detectRunner } from "../../core/runner-detection.js";
 import { callerProcessTreeNative } from "../../runtime/caller-process.js";
 import {
+  resolveWorkerId,
   runModeForCandidate,
   type SessionContext,
   type SessionIssueTemplate,
   type IssueCandidate,
 } from "../../core/session.js";
-import { genWorkerId } from "../../core/session.js";
 import { SUPERVISOR_LANE_ENV } from "../../core/supervisor-lane.js";
 import { runBoot, type BootDeps, type BootOptions, type BootResult, type BootstrapInput } from "../../core/boot.js";
 import { processIssue, type ProcessIssueDeps, type ProcessIssueInput, type ProcessIssueResult } from "../../core/process-issue.js";
@@ -117,19 +117,20 @@ export async function runCommand(options: RunOptions): Promise<number> {
     if (guard === "refused") return 1;
   }
 
-  // Worker id — probe the workers root for collisions.
+  // Worker id — ADOPTED from the host, or minted when nobody assigned one.
   //
   // A Worker born through the host daemon is HANDED its id (`RED_AFK_WORKER_ID`,
   // #2851): the daemon already recorded that string as the Worker's identity on
   // the host event lane before this process existed, so minting a second one
   // here would leave the host and the work naming the same Worker differently
-  // and no surface able to join them. A directly-invoked `run` still mints,
-  // which is what keeps the standalone lane working with no daemon in it.
+  // and no surface able to join them (#3081). A directly-invoked `run` still
+  // mints, which is what keeps the standalone lane working with no daemon in it.
+  // The collision probe governs the MINTED id only: an assigned id is a fact.
   const existing = new Set((await collectMonitorInputs(cwd)).workers.map((w) => w.state.worker_id));
-  const assigned = (process.env.RED_AFK_WORKER_ID ?? "").trim();
-  const workerId = assigned !== "" && !existing.has(assigned)
-    ? assigned
-    : genWorkerId(Math.random, (id) => existing.has(id));
+  const workerId = resolveWorkerId(
+    process.env.RED_AFK_WORKER_ID,
+    (id) => existing.has(id),
+  );
   const pidStartTime = readPidStartTime(process.pid) ?? "";
   // Emit the per-slot boot-stamp immediately so the supervisor's slot log
   // captures this worker's ID before any failure. The circuit-trip sweep

--- a/apps/dev/src/core/mcp-lane-canary.ts
+++ b/apps/dev/src/core/mcp-lane-canary.ts
@@ -474,8 +474,8 @@ export async function runMcpLaneCanary(
           `${born.workers.map((worker) => `${worker.workerId} (pid=${worker.pid})`).join(", ")}`,
       );
 
-      // ---- 7. project_status: the canonical reader agrees the project runs
-      // no process of its own ----
+      // ---- 7. project_status: the canonical reader runs no process of its own,
+      // and RECOGNISES the Workers step 6 just watched the host birth ----
       const observedStatus = await call("project_status", "project_status", {});
       const supervisor = asRecord(observedStatus.supervisor);
       const reportedPid = supervisor ? readPid(supervisor.pid) : null;
@@ -486,14 +486,35 @@ export async function runMcpLaneCanary(
             `the lane's reader can still see a per-project process the start was supposed to have stopped creating`,
         );
       }
+      // A busy slot per Worker the host birthed. `busy: 0` here used to be the
+      // green answer, and it was the defect (#3081): attribution compared the
+      // daemon's ids against ids the project minted itself, matched nothing,
+      // and rendered a project with live Workers as an idle one. A reader that
+      // cannot count the Workers step 6 just proved exist is inert.
       const busy = readCount(asRecord(observedStatus.slots)?.busy);
-      if (busy > 0) {
+      if (busy !== born.workers.length) {
         inert(
           "project_status",
-          `project_status reports slots.busy=${busy} while this project started nothing — the lane's reader and writer disagree`,
+          `project_status reports slots.busy=${busy} while the host birthed ${born.workers.length} Worker(s) for this ` +
+            `project — the lane's reader and writer disagree about who is running`,
         );
       }
-      record("project_status", "ok", "project_status answers with no per-project supervisor and no busy slot");
+      // The other half of the same join: a Worker of ours in the unattributed
+      // bucket is two disjoint id spaces for one Worker, which reads as an
+      // empty fleet on every surface downstream.
+      const statusWarnings = Array.isArray(observedStatus.warnings) ? observedStatus.warnings : [];
+      if (statusWarnings.length > 0) {
+        inert(
+          "project_status",
+          `project_status answered with ${statusWarnings.length} attribution warning(s): ${statusWarnings.join("; ")}`,
+        );
+      }
+      record(
+        "project_status",
+        "ok",
+        `project_status answers with no per-project supervisor and counts ${busy} busy slot(s) — the Worker(s) the ` +
+          `host birthed for this project`,
+      );
     } finally {
       // ---- 8. project_stop: give the registration back, always ----
       // Nothing thrown here may mask the walk's own verdict, so the teardown

--- a/apps/dev/src/core/project-attribution.ts
+++ b/apps/dev/src/core/project-attribution.ts
@@ -1,0 +1,94 @@
+/**
+ * project-attribution — deciding which live Workers are THIS project's (#3081).
+ *
+ * **The join is on one id, and the whole defect was that there were two.** The
+ * daemon owns birth, so the id it minted is the Worker's identity; the project
+ * adopts that string from `RED_AFK_WORKER_ID` and files its worker directory,
+ * its claim comment and every project-side surface under it. When the launch
+ * env never reached the process, the project minted a second id instead, and
+ * this predicate compared one id space against the other — false for every
+ * Worker, always. `project_status` then rendered a project whose two Workers
+ * were mid-review as `live_workers: []` with `busy: 0`.
+ *
+ * **A predicate that matches nothing is reported, never rendered as calm.** The
+ * disjoint case and the genuinely-foreign case produce the same empty list, and
+ * only one of them is a working system: a host holding Workers for this project
+ * while none of the live Workers matches any of them is the structural failure,
+ * and it says so in the answer rather than looking like an idle repository.
+ *
+ * PURE: every input is passed in, the host's answer included.
+ */
+
+/** What this module needs of a live Worker: the one id it is filed under. */
+export interface AttributableWorker {
+  readonly state: { readonly worker_id: string };
+}
+
+export interface ProjectAttributionInput<W extends AttributableWorker> {
+  /** Every Worker this checkout can see running, whoever owns it. */
+  readonly workers: readonly W[];
+  /**
+   * The Workers the HOST says belong to this project, or `null` when it did not
+   * answer. `null` and `[]` are different facts: an unreachable daemon knows
+   * nothing about ownership, while an empty list is a host stating this project
+   * holds none.
+   */
+  readonly hostWorkerIds: readonly string[] | null;
+}
+
+export interface ProjectAttribution<W extends AttributableWorker> {
+  /** Workers the host attributes to this project. */
+  readonly live: readonly W[];
+  /** Workers of another project, or carrying no id the host holds. */
+  readonly unattributed: readonly W[];
+  /** How many slots are occupied — the host's count, which owns birth. */
+  readonly busy: number;
+  /** What went structurally wrong, in sentences an operator can act on. */
+  readonly warnings: readonly string[];
+}
+
+/**
+ * Split the live Workers into this project's and everyone else's. PURE.
+ *
+ * `busy` comes from the HOST's list rather than from the matched Workers,
+ * because the host is what occupies a slot: a Worker born a moment ago holds
+ * its slot before it has written any project-side state, and a slot count that
+ * waited for that file would read free while the daemon refused to fill it.
+ */
+export function attributeProjectWorkers<W extends AttributableWorker>(
+  input: ProjectAttributionInput<W>,
+): ProjectAttribution<W> {
+  const held = input.hostWorkerIds;
+  const ourWorkerIds = new Set(held ?? []);
+  const ours = (worker: W): boolean => ourWorkerIds.has(worker.state.worker_id);
+  const live = input.workers.filter(ours);
+  const unattributed = input.workers.filter((worker) => !ours(worker));
+  const warnings: string[] = [];
+  if (held == null) {
+    warnings.push(
+      "the redskilled daemon did not answer, so no live Worker could be attributed to this project: every one of " +
+        "them is listed as unattributed because ownership is the host's answer, never a guess made from a pid",
+    );
+  } else if (held.length > 0 && input.workers.length > 0 && live.length === 0) {
+    // The #3081 signature, stated where it is read. Two disjoint id spaces and a
+    // genuinely-foreign Worker set produce the same empty list, and reporting
+    // neither is how a project came to render its own busy fleet as idle.
+    warnings.push(
+      `the host holds ${held.length} Worker(s) for this project and ${input.workers.length} live Worker(s) are ` +
+        `running here, and not one of them matches: the host ids ` +
+        `(${[...ourWorkerIds].slice(0, 3).join(", ")}) and the project ids ` +
+        `(${input.workers.slice(0, 3).map((w) => w.state.worker_id).join(", ")}) are disjoint, which means a Worker ` +
+        `was born without the \`RED_AFK_WORKER_ID\` its launch declared and minted a second identity (#3081)`,
+    );
+  }
+  return {
+    live,
+    unattributed,
+    // An unreachable host states no occupancy at all, and a live Worker this
+    // checkout can see is NOT evidence of an occupied slot of ours — it may be
+    // another project's entirely. The zero rides with the warning above, which
+    // is what keeps it from reading as an idle project.
+    busy: held?.length ?? 0,
+    warnings,
+  };
+}

--- a/apps/dev/src/core/session.ts
+++ b/apps/dev/src/core/session.ts
@@ -55,6 +55,38 @@ export function genWorkerId(rand: () => number, exists: (id: string) => boolean 
   }
 }
 
+/**
+ * The id this Worker answers to — ADOPTED when the host assigned one. PURE.
+ *
+ * **One Worker, one id** (#3081). A Worker born through the daemon is handed its
+ * identity in `RED_AFK_WORKER_ID`: the host recorded that exact string on its
+ * event lane, keyed its budget and its unit by it, and told every one of its
+ * surfaces about it before this process existed. Minting a second id here would
+ * leave the host and the work naming one Worker differently, and there is no
+ * later join that recovers from that — which is precisely what happened while
+ * the launch env never reached the process: `project_status` compared daemon
+ * UUIDs against project `wXXXX` handles, matched nothing, and rendered a busy
+ * fleet as an empty one.
+ *
+ * **There is deliberately no collision fallback on the assigned id.** A probe
+ * that regenerated on collision is an id generator that runs after the host has
+ * already named the Worker, which is the defect rather than a safety net: the
+ * assigned string is a fact, not a preference. Only a `run` invoked directly —
+ * no daemon, no assignment — mints, and that is what keeps the standalone lane
+ * working.
+ *
+ * @param assigned the value of `RED_AFK_WORKER_ID`; empty/absent when unassigned.
+ * @param exists true when `.red/tmp/workers/{id}/` is already taken.
+ */
+export function resolveWorkerId(
+  assigned: string | undefined,
+  exists: (id: string) => boolean = () => false,
+  rand: () => number = Math.random,
+): string {
+  const handed = (assigned ?? "").trim();
+  return handed !== "" ? handed : genWorkerId(rand, exists);
+}
+
 // ---------- issue selection (pure) ----------
 
 /** One candidate from `gh issue list --json number,title,labels,body,author`.

--- a/apps/dev/src/core/supervisor/launch-template.ts
+++ b/apps/dev/src/core/supervisor/launch-template.ts
@@ -37,10 +37,16 @@ export const RED_AFK_WORKER_ID_PLACEHOLDER = "{{worker_id}}";
 export const RED_AFK_SLOT_PLACEHOLDER = "{{slot}}";
 
 export interface ProjectLaunchInput {
-  /** The interpreter that runs the bundle — `process.execPath` at the call site. */
-  readonly interpreter: string;
-  /** The bundle this project's Workers run. */
-  readonly bundle: string;
+  /**
+   * How this project's bundle is invoked, as the whole leading argv.
+   *
+   * A pair of `interpreter` and `bundle` would have been the shorter statement
+   * and is the wrong shape: `publishedBundleArgv()` resolves to a version-pinned
+   * dispatch on a host with no bundle on disk, which is a command followed by
+   * SEVERAL words. Splitting it in two would have silently dropped every word
+   * after the first argument.
+   */
+  readonly bundleArgv: readonly string[];
   /**
    * The runner the NEXT Worker uses, as this tick decided it.
    *
@@ -59,6 +65,15 @@ export interface ProjectLaunchInput {
   readonly taskTierDowngrade?: boolean;
   /** The Ticket a reconcile Worker is born for; an ordinary drain when absent. */
   readonly reconcileIssue?: number | null;
+  /**
+   * Where the NEXT Worker's output goes — a template, like the rest (#3079).
+   *
+   * Stated HERE rather than beside the launch, because restating a launch is
+   * all-or-nothing: a renewal that carried an argv and no log path would clear
+   * the path the registration declared, and the Worker born from it would reach
+   * every surface with nothing to show.
+   */
+  readonly logPath?: string | null;
 }
 
 /**
@@ -71,8 +86,7 @@ export interface ProjectLaunchInput {
  */
 export function buildProjectLaunchTemplate(input: ProjectLaunchInput): RedskilledLaunchTemplate {
   const argv = [
-    input.interpreter,
-    input.bundle,
+    ...input.bundleArgv,
     "run",
     "--once",
     "--runner",
@@ -96,5 +110,9 @@ export function buildProjectLaunchTemplate(input: ProjectLaunchInput): Redskille
     env.RED_AFK_RETIRE_FILE = `${input.retireDir}/afk-supervisor-slot-${RED_AFK_SLOT_PLACEHOLDER}.retire`;
   } else delete env.RED_AFK_RETIRE_FILE;
 
-  return { argv, env };
+  return {
+    argv,
+    env,
+    ...(input.logPath == null || input.logPath === "" ? {} : { log_path: input.logPath }),
+  };
 }

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -61,7 +61,6 @@ import { matchesSelector } from "./core/session.js";
 import { resolveHitlDecision } from "./core/hitl-resolve.js";
 import { detectWedgedOrchestrator } from "./core/wedged-orchestrator.js";
 import * as ghx from "./runtime/gh.js";
-import { publishedBundleArgv } from "./runtime/published-entry.js";
 import { requestWorkerBirth, type DispatchedWorkerBirth } from "./runtime/mcp-worker-birth.js";
 import { checkDispatchEngineFloor } from "./runtime/engine-floor-check.js";
 import type { EngineFloorVerdict } from "./core/engine-floor.js";
@@ -70,10 +69,9 @@ import {
   createRedskilledBirthPort,
   redskilledRegistrationRefusal,
 } from "./runtime/redskilled-birth.js";
-import {
-  registrationLaunchEnv,
-  registrationLogPathTemplate,
-} from "./runtime/redskilled-worker-log.js";
+import { registrationLogPathTemplate } from "./runtime/redskilled-worker-log.js";
+import { registrationLaunch } from "./runtime/registration-launch.js";
+import { attributeProjectWorkers } from "./core/project-attribution.js";
 import { migrateToTwoPlayer } from "./runtime/two-player-migration.js";
 import {
   publishWorkerLiveness,
@@ -824,18 +822,26 @@ async function projectStatus(root: string): Promise<ProjectStatusOutput> {
   // Attribution is the HOST's, never a pid map of our own: a Worker is ours when
   // the daemon says its project is ours. A stamp for another project — or none
   // at all — lands in the unattributed bucket even when the pid looks familiar.
-  const ourWorkerIds = new Set(
-    await port.workerIds().catch(() => [] as readonly string[]),
-  );
-  const attributedToThisProject = (worker: (typeof allLiveWorkers)[number]): boolean =>
-    ourWorkerIds.has(worker.state.worker_id);
-  const liveWorkers = allLiveWorkers.filter(attributedToThisProject);
-  const unattributedWorkers = allLiveWorkers.filter((w) => !attributedToThisProject(w));
+  //
+  // The join works because the two ids are ONE id: the launch declares
+  // `RED_AFK_WORKER_ID={{worker_id}}` and the Worker adopts the string the host
+  // assigned rather than minting its own (#3081). A predicate that matches
+  // nothing across a non-empty Worker set is that wire broken, and it is
+  // reported rather than rendered as an idle project.
+  const attribution = attributeProjectWorkers({
+    workers: allLiveWorkers,
+    hostWorkerIds: await port.workerIds().catch(() => null),
+  });
+  const liveWorkers = attribution.live;
+  const unattributedWorkers = attribution.unattributed;
   // The published version comes from the one owner the boot probe also consults
   // (#2809), so a reader replays that answer instead of deriving its own.
   const version = publishedVersionReport("", readPublishedBundleVersion());
   const target = held?.target ?? 0;
-  const busy = liveWorkers.length;
+  // The host's count, not the matched list's: a Worker born a moment ago holds
+  // its slot before it has written any project-side state, and a `busy` that
+  // waited for that file would read free while the daemon refused to fill it.
+  const busy = attribution.busy;
   return {
     registration: {
       held: held != null,
@@ -871,6 +877,7 @@ async function projectStatus(root: string): Promise<ProjectStatusOutput> {
       activity: worker.state.current.activity,
       origin: worker.state.origin ?? "afk",
     })),
+    ...(attribution.warnings.length > 0 ? { warnings: [...attribution.warnings] } : {}),
   };
 }
 
@@ -975,19 +982,6 @@ async function projectStart(root: string, rawInput: ProjectStartInput) {
   }
   const selector = encodeRegistrationSelector(repo, input.selector);
   const warnings = startWarnings(input, registrationQueryUnexpressedFacets(input.selector));
-  // What runs when a Worker is born for this project — resolved from the
-  // PUBLISHED bundle rather than from this process's own entry (#2808), so a
-  // registration made from a stale plugin cache never commits the host to an
-  // older Worker than the one this project publishes.
-  const argv = [
-    ...publishedBundleArgv(),
-    "run",
-    "--once",
-    "--runner",
-    input.runner,
-    ...(input.selector ? ["--selector", JSON.stringify(input.selector)] : []),
-  ];
-
   // Where this project's Workers write their output, and how each one addresses
   // the host it must publish its last line to (#3079). Declared HERE because a
   // registration is the only thing this lane ever tells the daemon: a project
@@ -995,6 +989,18 @@ async function projectStart(root: string, rawInput: ProjectStartInput) {
   // exactly how the herdr plugin, the VS Code extension and the verbose
   // statusline all came to report a Worker with nothing to say.
   const logPathTemplate = registrationLogPathTemplate(root, new Date().toISOString().slice(0, 10));
+
+  // What runs when a Worker is born for this project — resolved from the
+  // PUBLISHED bundle rather than from this process's own entry (#2808), so a
+  // registration made from a stale plugin cache never commits the host to an
+  // older Worker than the one this project publishes.
+  //
+  // Composed by the ONE namer (#3081). The argv used to be assembled here and
+  // the env stated separately, so the env carried only the host's log handle
+  // while the three vars a Worker needs to know who and where it is — its id,
+  // its slot and its runner — lived in a builder nothing called. A Worker born
+  // without its id minted a second one, and no surface could join the two.
+  const launch = registrationLaunch({ runner: input.runner, selector: input.selector, logPath: logPathTemplate });
 
   let registered;
   try {
@@ -1004,10 +1010,14 @@ async function projectStart(root: string, rawInput: ProjectStartInput) {
     // like — the one thing rule 3 forbids.
     registered = await port.register({
       selector,
-      argv,
+      argv: [...launch.argv],
       workspace_path: root,
-      env: registrationLaunchEnv(input.runner),
-      log_path: logPathTemplate,
+      // Both halves of the env come from the ONE composer (#3081): the host's log
+      // handle it carries through `registrationLaunchEnv`, and the per-birth facts
+      // — the runner this start decided, the slot the host places the Worker on
+      // (#3118) and the worker id it assigns — that the pure builder re-pins.
+      env: launch.env ?? {},
+      ...(launch.log_path == null ? {} : { log_path: launch.log_path }),
       target: input.target,
     });
   } catch (err) {
@@ -1108,17 +1118,18 @@ async function projectResize(root: string, rawInput: ProjectResizeInput) {
   const warnings: string[] = [];
   if (input.runner !== undefined) {
     // All-or-nothing, as the amendment requires: the argv is restated whole, and
-    // the env travels with it, so the next Worker is never half one tick's
-    // decision and half an older one.
-    const argv = [
-      ...publishedBundleArgv(),
-      "run",
-      "--once",
-      "--runner",
-      input.runner,
-      ...(input.selector ? ["--selector", JSON.stringify(input.selector)] : []),
-    ];
-    await port.restateLaunch({ argv, env: held.env });
+    // the env and the log path travel with it, so the next Worker is never half
+    // one tick's decision and half an older one. Restated through the SAME namer
+    // the registration used (#3081) — a resize that rebuilt the argv by hand and
+    // carried the old env forward is how a launch came to be half-composed, and
+    // a restatement that omitted the log path would clear it outright.
+    await port.restateLaunch(
+      registrationLaunch({
+        runner: input.runner,
+        selector: input.selector,
+        logPath: held.log_path ?? registrationLogPathTemplate(root, new Date().toISOString().slice(0, 10)),
+      }),
+    );
     directive = "restated";
   }
   if (input.target !== undefined && input.target !== held.target) {

--- a/apps/dev/src/runtime/registration-launch.ts
+++ b/apps/dev/src/runtime/registration-launch.ts
@@ -1,0 +1,48 @@
+/**
+ * registration-launch — the ONE namer for what this project's next Worker runs.
+ *
+ * **One composition site, because two of them lost a Worker's identity** (#3081).
+ * `project_start` assembled an argv inline and stated an env of one entry beside
+ * it; `project_resize` assembled a second argv inline and carried the old env
+ * forward. Meanwhile `buildProjectLaunchTemplate` — the pure builder that states
+ * `RED_AFK_WORKER_ID`, `RED_AFK_SLOT` and `RED_AFK_RUNNER` as the per-birth facts
+ * they are — had zero callers. So every registration-lane Worker was born
+ * knowing neither the id the host had assigned it nor the slot it occupied, and
+ * it minted a second id of its own. The host and the project then held disjoint
+ * id spaces for one Worker, and `project_status` reported an empty fleet over a
+ * busy one.
+ *
+ * This module is the seam: the registration lane resolves the published bundle
+ * and the log path, and hands both to the pure builder. Nothing else composes a
+ * launch.
+ */
+import type { RedskilledLaunchTemplate } from "@reddb-io/redskilled/launch-template";
+import { buildProjectLaunchTemplate } from "../core/supervisor/launch-template.js";
+import { publishedBundleArgv } from "./published-entry.js";
+import { registrationLaunchEnv } from "./redskilled-worker-log.js";
+
+export interface RegistrationLaunchInput {
+  /** The runner the NEXT Worker uses, as this start or this resize decided it. */
+  readonly runner: string;
+  /** The project's own work selector, carried to the one reader that reads it. */
+  readonly selector?: unknown;
+  /** Where the NEXT Worker's output goes; a template, carrying `{{worker_id}}`. */
+  readonly logPath?: string | null;
+  /** The leading argv; defaults to the published bundle's, an input for tests. */
+  readonly bundleArgv?: readonly string[];
+}
+
+/** Compose the launch a registration or a renewal states. */
+export function registrationLaunch(input: RegistrationLaunchInput): RedskilledLaunchTemplate {
+  return buildProjectLaunchTemplate({
+    bundleArgv: input.bundleArgv ?? publishedBundleArgv(),
+    runner: input.runner,
+    ...(input.selector ? { slotArgs: ["--selector", JSON.stringify(input.selector)] } : {}),
+    // The host's own handle for this process rides alongside the work's id
+    // rather than instead of it: a heartbeat is addressed with the daemon's
+    // string, and every project-side surface is filed under the same one now
+    // that the Worker adopts what the host assigned.
+    workerEnv: registrationLaunchEnv(),
+    ...(input.logPath == null ? {} : { logPath: input.logPath }),
+  });
+}

--- a/apps/dev/src/runtime/supervisor-fs.ts
+++ b/apps/dev/src/runtime/supervisor-fs.ts
@@ -61,9 +61,14 @@ function slotLogReadPaths(tmpDir: string, slot: number, logDir?: string): string
 }
 
 /**
- * Parse each unique worker ID (`wXXXX`) from a slot log's boot-stamp lines,
- * first-seen order preserved. Mirrors parse_worker_ids_from_log's awk over
- * `[afk] worker: wXXXX` lines. A missing / unreadable file → [].
+ * Parse each unique worker ID from a slot log's boot-stamp lines, first-seen
+ * order preserved. Mirrors parse_worker_ids_from_log's awk over
+ * `[afk] worker: <id>` lines. A missing / unreadable file → [].
+ *
+ * The id grammar is the worker-directory grammar (`[A-Za-z0-9_-]+`), not the
+ * minted `wXXXX` shape: a Worker born through the daemon ADOPTS the id the host
+ * assigned it (#3081), and a pattern that only matched a minted id would drop
+ * every daemon-born Worker out of the parked-slot sweep.
  */
 export function parseWorkerIdsFromLog(path: string): string[] {
   let text: string;
@@ -75,7 +80,7 @@ export function parseWorkerIdsFromLog(path: string): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
   for (const line of text.split("\n")) {
-    const m = line.match(/^\[afk\] worker: (w[A-Z0-9]+)$/);
+    const m = line.match(/^\[afk\] worker: ([A-Za-z0-9_-]+)$/);
     if (!m) continue;
     const wid = m[1]!;
     if (!seen.has(wid)) {

--- a/apps/dev/tests/mcp-lane-canary.test.ts
+++ b/apps/dev/tests/mcp-lane-canary.test.ts
@@ -113,9 +113,12 @@ function harness(options: HarnessOptions = {}) {
       }
       if (tool === "project_status") {
         return (
+          // One busy slot, because the default host read births one Worker: a
+          // reader that counted 0 over a live fleet is the #3081 defect, not
+          // the green answer it used to be asserted as.
           options.status ?? {
             supervisor: { pid: null, alive: false },
-            slots: { busy: 0, free: 0, total: 0, parked: 0 },
+            slots: { busy: 1, free: 0, total: 1, parked: 0 },
           }
         );
       }
@@ -465,7 +468,7 @@ describe("MCP lane canary — the other inert steps", () => {
 
   it("fails at project_status when the reader still sees a per-project supervisor", async () => {
     const { deps } = harness({
-      status: { supervisor: { pid: STRAY_PID, alive: true }, slots: { busy: 0 } },
+      status: { supervisor: { pid: STRAY_PID, alive: true }, slots: { busy: 1 } },
     });
 
     const result = await runMcpLaneCanary(deps, OPTIONS);
@@ -474,15 +477,36 @@ describe("MCP lane canary — the other inert steps", () => {
     expect(result.summary).toContain(`supervisor pid ${STRAY_PID} alive`);
   });
 
-  it("fails at project_status when the reader reports busy slots nothing started", async () => {
+  it("fails at project_status when the reader cannot count the Worker the host birthed", async () => {
+    // The #3081 shape: the host birthed a Worker, the reader says the project
+    // has nothing running. An empty fleet over a busy one is indistinguishable
+    // from an idle repository, which is exactly why it must go inert here.
     const { deps } = harness({
-      status: { supervisor: { pid: null, alive: false }, slots: { busy: 1, free: 0, total: 1 } },
+      status: { supervisor: { pid: null, alive: false }, slots: { busy: 0, free: 1, total: 1 } },
     });
 
     const result = await runMcpLaneCanary(deps, OPTIONS);
 
     expect(result.inertStep).toBe("project_status");
-    expect(result.summary).toContain("slots.busy=1");
+    expect(result.summary).toContain("slots.busy=0");
+    expect(result.summary).toContain("birthed 1 Worker(s)");
+  });
+
+  it("fails at project_status when the reader could not attribute its own Workers", async () => {
+    // A warning here means the join between host ids and project ids came apart:
+    // the reader answered, and its answer says it cannot recognise its own fleet.
+    const { deps } = harness({
+      status: {
+        supervisor: { pid: null, alive: false },
+        slots: { busy: 1, free: 0, total: 1 },
+        warnings: ["the host ids and the project ids are disjoint (#3081)"],
+      },
+    });
+
+    const result = await runMcpLaneCanary(deps, OPTIONS);
+
+    expect(result.inertStep).toBe("project_status");
+    expect(result.summary).toContain("attribution warning(s)");
   });
 
   it("fails at project_stop when the registration is not given back", async () => {

--- a/apps/dev/tests/project-launch-template.test.ts
+++ b/apps/dev/tests/project-launch-template.test.ts
@@ -10,8 +10,7 @@ import { resolveTier, type ConfigValues } from "../src/core/config.js";
 import { buildProjectLaunchTemplate } from "../src/core/supervisor/launch-template.js";
 
 const BASE = {
-  interpreter: "/usr/bin/node",
-  bundle: "/bundle.mjs",
+  bundleArgv: ["/usr/bin/node", "/bundle.mjs"],
   workerEnv: { PATH: "/usr/bin", RED_AFK_RUNNER: "claude", RED_AFK_SWEEPS_DONE: "1" },
   retireDir: "/state",
 } as const;
@@ -82,6 +81,39 @@ describe("the launch a project states for its next Worker", () => {
 
     expect(downgraded.env!.RED_AFK_TASK_TIER_DOWNGRADE).toBe("1");
     expect(ordinary.env).not.toHaveProperty("RED_AFK_TASK_TIER_DOWNGRADE");
+  });
+
+  it("carries every word of a multi-word bundle invocation", () => {
+    // A host with no bundle on disk resolves to a version-pinned dispatch, which
+    // is a command followed by SEVERAL words. An interpreter/bundle pair would
+    // have dropped everything after the first argument.
+    const template = buildProjectLaunchTemplate({
+      ...BASE,
+      bundleArgv: ["/usr/bin/npx", "-y", "-p", "@reddb-io/red-skills@1.2.3", "red-skills-dev"],
+      runner: "claude",
+    });
+    expect(template.argv.slice(0, 6)).toEqual([
+      "/usr/bin/npx",
+      "-y",
+      "-p",
+      "@reddb-io/red-skills@1.2.3",
+      "red-skills-dev",
+      "run",
+    ]);
+  });
+
+  it("states where the next Worker logs, so a restatement cannot clear it", () => {
+    // Restating a launch is all-or-nothing: a renewal carrying an argv and no log
+    // path clears the one the registration declared (#3079), and the Worker born
+    // from it reaches every surface with nothing to show.
+    const template = buildProjectLaunchTemplate({
+      ...BASE,
+      runner: "claude",
+      logPath: "/repo/.red/tmp/logs/2026-08-03/worker-{{worker_id}}.log",
+    });
+    expect(template.log_path).toBe("/repo/.red/tmp/logs/2026-08-03/worker-{{worker_id}}.log");
+    const born = expandLaunchTemplate(template, { worker_id: "wAAAA", slot: 0, workspace_path: "/repo" });
+    expect(born.log_path).toBe("/repo/.red/tmp/logs/2026-08-03/worker-wAAAA.log");
   });
 
   it("carries a reconcile Ticket when a tick asks for a reconcile Worker", () => {

--- a/apps/dev/tests/project-worker-identity.test.ts
+++ b/apps/dev/tests/project-worker-identity.test.ts
@@ -1,0 +1,184 @@
+// One Worker, one id (#3081).
+//
+// `project_status` — the tool `/afk` documents as read-only ground truth for
+// "what is actually running?" — reported an empty fleet over two Workers that
+// were mid-review on this repository's own issues. Nothing was wrong with the
+// Workers: the launch template's env never reached the process, so the Worker
+// never received the id the host had assigned and minted its own. Attribution
+// then compared daemon ids against project ids, and the two sets were
+// STRUCTURALLY disjoint — the predicate was false for every Worker, always.
+//
+// What is pinned here is the whole wire, end to end: the launch a registration
+// states, the facts the daemon writes into it, the id the Worker adopts from the
+// result, and the attribution that joins the two ends back together.
+import { describe, expect, it } from "vitest";
+import { expandLaunchTemplate } from "@reddb-io/redskilled/launch-template";
+import { attributeProjectWorkers } from "../src/core/project-attribution.js";
+import { resolveWorkerId } from "../src/core/session.js";
+import { registrationLaunch } from "../src/runtime/registration-launch.js";
+
+const BUNDLE_ARGV = ["/usr/bin/node", "/published/bundle.mjs"] as const;
+
+/** The launch a `project_start` hands the daemon, with no host in the test. */
+function launch(runner = "claude") {
+  return registrationLaunch({
+    runner,
+    bundleArgv: BUNDLE_ARGV,
+    logPath: "/repo/.red/tmp/logs/2026-08-03/worker-{{worker_id}}.log",
+  });
+}
+
+/** One Worker, born the way the daemon births it from a registration. */
+function born(hostWorkerId: string, slot: number, runner = "claude") {
+  const expanded = expandLaunchTemplate(launch(runner), {
+    worker_id: hostWorkerId,
+    slot,
+    workspace_path: "/repo",
+  });
+  // The project's side of the same birth: `run` reads the env it was started
+  // with and decides what to call itself.
+  const projectWorkerId = resolveWorkerId(expanded.env.RED_AFK_WORKER_ID);
+  return { expanded, projectWorkerId };
+}
+
+describe("the launch a registration states", () => {
+  it("carries the id, the slot and the runner a Worker needs to know itself", () => {
+    const stated = launch("codex");
+
+    // Placeholders, not values: one registration serves every Worker it births.
+    expect(stated.env?.RED_AFK_WORKER_ID).toBe("{{worker_id}}");
+    expect(stated.env?.RED_AFK_SLOT).toBe("{{slot}}");
+    expect(stated.env?.RED_AFK_RUNNER).toBe("codex");
+  });
+
+  it("carries the project's own env passthrough alongside them", () => {
+    // The host's handle for the process rides beside the work's id rather than
+    // instead of it: a heartbeat is addressed with the daemon's string (#3079).
+    expect(launch().env?.REDSKILLED_WORKER_ID).toBe("{{worker_id}}");
+  });
+
+  it("delivers all four to the process, with the daemon's facts written in", () => {
+    const { expanded } = born("2aa48bea-81a5-409d-9310-ab0a9805", 1, "codex");
+
+    expect(expanded.env.RED_AFK_WORKER_ID).toBe("2aa48bea-81a5-409d-9310-ab0a9805");
+    expect(expanded.env.RED_AFK_SLOT).toBe("1");
+    expect(expanded.env.RED_AFK_RUNNER).toBe("codex");
+    expect(expanded.env.REDSKILLED_WORKER_ID).toBe("2aa48bea-81a5-409d-9310-ab0a9805");
+    // The argv half always arrived, which is why the loss stayed invisible.
+    expect(expanded.argv).toEqual([...BUNDLE_ARGV, "run", "--once", "--runner", "codex"]);
+  });
+});
+
+describe("host-side and project-side worker ids", () => {
+  it("are the same string for one Worker", () => {
+    // The disjointness the issue describes, made impossible to reintroduce: the
+    // daemon's id IS the id the work files itself under.
+    const hostWorkerId = "2aa48bea-81a5-409d-9310-ab0a9805";
+    const { projectWorkerId } = born(hostWorkerId, 0);
+
+    expect(projectWorkerId).toBe(hostWorkerId);
+  });
+
+  it("stay the same string across every slot of one registration", () => {
+    const ids = ["host-a", "host-b", "host-c"];
+    const workers = ids.map((id, slot) => born(id, slot));
+
+    expect(workers.map((w) => w.projectWorkerId)).toEqual(ids);
+    // And each Worker still learns the slot it was placed on, so per-slot state
+    // is addressable rather than permanently slot 0.
+    expect(workers.map((w) => w.expanded.env.RED_AFK_SLOT)).toEqual(["0", "1", "2"]);
+  });
+
+  it("still mints an id when no host assigned one", () => {
+    // The standalone lane: a directly-invoked `run` with no daemon in it.
+    const minted = resolveWorkerId(undefined, () => false, () => 0);
+    expect(minted).toMatch(/^w[A-Z0-9]{4}$/);
+    expect(resolveWorkerId("   ", () => false, () => 0)).toBe(minted);
+  });
+
+  it("adopts the assigned id even when a directory of that name exists", () => {
+    // No fallback, deliberately: an id generator that runs after the host has
+    // already named the Worker is the defect, not a safety net.
+    expect(resolveWorkerId("host-a", () => true)).toBe("host-a");
+  });
+});
+
+describe("attributing live Workers to this project", () => {
+  const worker = (id: string) => ({ state: { worker_id: id } });
+
+  it("lists a Worker born from a registration as this project's own", () => {
+    const hostWorkerId = "2aa48bea-81a5-409d-9310-ab0a9805";
+    const { projectWorkerId } = born(hostWorkerId, 0);
+
+    const attribution = attributeProjectWorkers({
+      workers: [worker(projectWorkerId)],
+      hostWorkerIds: [hostWorkerId],
+    });
+
+    expect(attribution.live.map((w) => w.state.worker_id)).toEqual([hostWorkerId]);
+    expect(attribution.unattributed).toEqual([]);
+    expect(attribution.warnings).toEqual([]);
+  });
+
+  it("counts busy slots from the host, which owns birth", () => {
+    // A Worker born a moment ago holds its slot before it has written any
+    // project-side state; a count that waited for that file would read free
+    // while the daemon refused to fill it.
+    const attribution = attributeProjectWorkers({
+      workers: [worker("host-a")],
+      hostWorkerIds: ["host-a", "host-b"],
+    });
+
+    expect(attribution.busy).toBe(2);
+  });
+
+  it("keeps another project's Workers unattributed, and stays quiet about it", () => {
+    const attribution = attributeProjectWorkers({
+      workers: [worker("ours"), worker("theirs")],
+      hostWorkerIds: ["ours"],
+    });
+
+    expect(attribution.live.map((w) => w.state.worker_id)).toEqual(["ours"]);
+    expect(attribution.unattributed.map((w) => w.state.worker_id)).toEqual(["theirs"]);
+    expect(attribution.warnings).toEqual([]);
+  });
+
+  it("reports a predicate that matches NOTHING across a non-empty Worker set", () => {
+    // The #3081 signature: the host holds Workers for this project, live Workers
+    // are running here, and not one of them matches. An empty `live_workers`
+    // renders exactly like an idle repository, and this is the opposite state.
+    const attribution = attributeProjectWorkers({
+      workers: [worker("wS807"), worker("wVHHH")],
+      hostWorkerIds: ["2aa48bea-81a5-409d-9310-ab0a9805", "8c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f"],
+    });
+
+    expect(attribution.live).toEqual([]);
+    expect(attribution.warnings).toHaveLength(1);
+    expect(attribution.warnings[0]).toContain("disjoint");
+    expect(attribution.warnings[0]).toContain("#3081");
+  });
+
+  it("says the host did not answer rather than calling every Worker foreign", () => {
+    const attribution = attributeProjectWorkers({
+      workers: [worker("wS807")],
+      hostWorkerIds: null,
+    });
+
+    expect(attribution.live).toEqual([]);
+    expect(attribution.unattributed).toHaveLength(1);
+    expect(attribution.warnings[0]).toContain("did not answer");
+    // An unreachable host states no occupancy at all, and a live Worker this
+    // checkout can see is not evidence of an occupied slot of OURS. The zero
+    // rides with the warning, which is what keeps it from reading as idle.
+    expect(attribution.busy).toBe(0);
+  });
+
+  it("stays quiet when there is genuinely nothing running", () => {
+    expect(attributeProjectWorkers({ workers: [], hostWorkerIds: [] })).toEqual({
+      live: [],
+      unattributed: [],
+      busy: 0,
+      warnings: [],
+    });
+  });
+});

--- a/packages/red-castle/src/mcp/contracts.ts
+++ b/packages/red-castle/src/mcp/contracts.ts
@@ -156,6 +156,16 @@ export const projectStatusOutputSchema = z.object({
       origin: z.string(),
     }),
   ),
+  /**
+   * What went structurally wrong with the read itself (#3081).
+   *
+   * A project whose own Workers all land in `unattributed_workers` renders
+   * exactly like an idle repository, and the two are opposite states: the first
+   * is a broken identity wire, the second is nothing to do. An attribution
+   * predicate that matched nothing across a non-empty Worker set says so here
+   * rather than letting `live_workers: []` read as calm.
+   */
+  warnings: z.array(z.string()).optional(),
 });
 
 export type ProjectStatusOutput = z.infer<typeof projectStatusOutputSchema>;


### PR DESCRIPTION
Automated AFK landing for #3081. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3081

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788316635&installation_model_id=20659&pr_number=3120&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3120&signature=98d09dfbb80207bb2b78c586b7a9172bbcdcc473c107c7b552143188ad97df60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->