### PR TITLE
fix: #3096 One render implementation outside the daemon, drawn at parameterized densities

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -25,6 +25,7 @@
       "@reddb-io/red-browser",
       "@reddb-io/rsp",
       "@reddb-io/redskilled",
+      "@reddb-io/redskilled-render",
       "@reddb-io/afk-container",
       "@reddb-io/cdp-driver",
       "@reddb-io/browser-bridge",

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -23,6 +23,7 @@
     "@reddb-io/github": "workspace:*",
     "@reddb-io/red-castle": "workspace:*",
     "@reddb-io/redskilled": "workspace:*",
+    "@reddb-io/redskilled-render": "workspace:*",
     "@reddb-io/shared": "workspace:*",
     "@reddb-io/toon": "catalog:",
     "zod": "catalog:"

--- a/apps/dev/src/core/statusline-command-doc.ts
+++ b/apps/dev/src/core/statusline-command-doc.ts
@@ -62,7 +62,7 @@ export const STATUSLINE_COMMAND_TERMINATOR = "; exit 0";
 /**
  * The sentence the command prints when no daemon bundle answers its glob.
  *
- * It is a COPY of `REDSKILLED_STATUSLINE_ABSENCE`, kept here as a literal so
+ * It is a COPY of `REDSKILLED_RENDER_ABSENCE`, kept here as a literal so
  * this module stays free of the daemon package it describes; the test pins the
  * two together, so the shell branch and the daemon's own render can never say
  * the absence in two different sentences.

--- a/apps/dev/tests/statusline-command-doc.test.ts
+++ b/apps/dev/tests/statusline-command-doc.test.ts
@@ -11,7 +11,7 @@ import {
   ensureBundle,
   packagedBundleRelPath,
 } from "@reddb-io/shared/bundle-fetch.js";
-import { REDSKILLED_STATUSLINE_ABSENCE } from "@reddb-io/redskilled/statusline-render";
+import { REDSKILLED_RENDER_ABSENCE } from "@reddb-io/redskilled-render";
 import { REPO_INVARIANT_SUITES } from "../src/core/repo-invariants.js";
 import {
   STATUSLINE_COMMAND_ABSENCE,
@@ -199,7 +199,7 @@ describe("daemon bundle resolution (#3074)", () => {
   });
 
   it("says the absence in the daemon's own sentence, never a second spelling", () => {
-    expect(STATUSLINE_COMMAND_ABSENCE).toBe(REDSKILLED_STATUSLINE_ABSENCE);
+    expect(STATUSLINE_COMMAND_ABSENCE).toBe(REDSKILLED_RENDER_ABSENCE);
   });
 
   it("states the absence in every published copy", () => {
@@ -246,7 +246,7 @@ describe("daemon bundle resolution (#3074)", () => {
     const run = renderStatusline(hostWithoutDaemonBundle("» fixture (main) Opus"));
 
     expect(run.stdout).toContain("» fixture (main) Opus");
-    expect(run.stdout).toContain(REDSKILLED_STATUSLINE_ABSENCE);
+    expect(run.stdout).toContain(REDSKILLED_RENDER_ABSENCE);
     expect(run.status, run.stderr).toBe(0);
   });
 });

--- a/apps/herdr-plugin-red-skills/src/commands/board.mjs
+++ b/apps/herdr-plugin-red-skills/src/commands/board.mjs
@@ -2,11 +2,11 @@
  * board — the statusline as a pane, and as a one-shot print.
  *
  * The whole document comes from the daemon's `statusline-dashboard` op, never
- * from this plugin's own reading of the payload. ADR 0130 rule 10 keeps that
- * answer a pure function of the payload precisely so no surface reimplements it,
- * and a pane that drew its own Worker rows would be the drift the op exists to
- * prevent — the same reason `status` prints `statusline-string` rather than
- * rendering a line of its own.
+ * from this plugin's own reading of the payload. Behind that op is
+ * `@reddb-io/redskilled-render`, the ONE layout every surface shares (ADR 0132
+ * decision 1), so a pane that drew its own Worker rows would be a second
+ * implementation of a module that already exists — the same reason `status`
+ * prints `statusline-string` rather than rendering a line of its own.
  *
  * **What travels over the socket is taste already decided here.** Mode, width and
  * the row budget are resolved from config and flags before the read, because the

--- a/apps/herdr-plugin-red-skills/src/commands/status.mjs
+++ b/apps/herdr-plugin-red-skills/src/commands/status.mjs
@@ -1,12 +1,13 @@
 /**
  * status — one read, printed or raised as a notification.
  *
- * The line comes from the daemon's own `statusline-string` op, never from this
- * plugin's rendering of the payload. ADR 0130 rule 10 makes the string a pure
- * function of the payload precisely so no surface has to reimplement it, and a
- * plugin that drew its own line would be the drift that pair of ops exists to
- * prevent. What travels over the socket is taste already decided here — mode,
- * width, verbosity — because the daemon must never learn what a config file is.
+ * The line comes from the daemon's `statusline-string` op, never from this
+ * plugin's own rendering of the payload. Behind that op is `@reddb-io/redskilled-
+ * render`, the ONE layout every surface shares (ADR 0132 decision 1) — so a
+ * plugin that drew its own line would be a second implementation of a module
+ * that already exists. What travels over the socket is taste already decided
+ * here — mode, width, verbosity — because the daemon must never learn what a
+ * config file is.
  */
 import { createRedskilledClient, readRedskilledSnapshot } from "../redskilled/client.mjs";
 import { resolveRedskilledPaths } from "../redskilled/paths.mjs";

--- a/apps/herdr-plugin-red-skills/src/ui/board.mjs
+++ b/apps/herdr-plugin-red-skills/src/ui/board.mjs
@@ -1,12 +1,13 @@
 /**
  * board — the statusline, given a pane's height. This file PRINTS.
  *
- * **Every cell on this screen was computed by the daemon.** The header, the
- * Worker rows, the pipeline bars and the counts all arrive finished from
- * `statusline-dashboard`, and nothing here recomputes one. That is the whole
- * rule the statusline pair was built on (ADR 0130 rule 10): a herdr pane and an
- * editor panel each doing their own Worker math would be two dashboards lying in
- * two different ways about the same instant.
+ * **Every cell on this screen was computed elsewhere.** The header, the Worker
+ * rows, the pipeline bars and the counts all arrive finished from
+ * `statusline-dashboard`, and behind that op sits `@reddb-io/redskilled-render`
+ * — one layout, drawn at parameterized densities (ADR 0132 decision 1). Nothing
+ * here recomputes a cell: a herdr pane and an editor panel each doing their own
+ * Worker math would be two dashboards lying in two different ways about the same
+ * instant.
  *
  * **The only judgement here is where a line goes.** Colour, the scroll window and
  * the key map belong to a terminal and to nothing else, so they live here; the

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -7,7 +7,6 @@
     "./cli": "./src/cli.ts",
     "./client": "./src/client.ts",
     "./daemon": "./src/daemon.ts",
-    "./dashboard-render": "./src/dashboard-render.ts",
     "./daemon-stop": "./src/daemon-stop.ts",
     "./demand-loop": "./src/demand-loop.ts",
     "./demand-producer": "./src/demand-producer.ts",
@@ -23,7 +22,6 @@
     "./reclaim": "./src/reclaim.ts",
     "./provision": "./src/provision.ts",
     "./statusline-payload": "./src/statusline-payload.ts",
-    "./statusline-render": "./src/statusline-render.ts",
     "./worker-display": "./src/worker-display.ts",
     "./worker-launch": "./src/worker-launch.ts"
   },
@@ -40,6 +38,7 @@
   "dependencies": {
     "@reddb-io/build-info": "workspace:*",
     "@reddb-io/github": "workspace:*",
+    "@reddb-io/redskilled-render": "workspace:*",
     "@reddb-io/shared": "workspace:*",
     "@reddb-io/toon": "catalog:"
   },

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -23,7 +23,7 @@ import {
 import {
   ensureRedskilledDaemon,
   readRedskilledHostState,
-  readRedskilledStatuslineString,
+  readRedskilledStatuslineRender,
   stopRedskilledDaemon,
   type RedskilledClientConfig,
 } from "./client.js";
@@ -54,7 +54,7 @@ import {
   parseRedskilledStatuslineFlags,
   resolveRedskilledStatuslineOptions,
 } from "./statusline-config.js";
-import { renderRedskilledStatuslineAbsence } from "./statusline-render.js";
+import { renderRedskilledStatuslineAbsence } from "@reddb-io/redskilled-render";
 import {
   installRedskilledUnit,
   planRedskilledUnit,
@@ -539,9 +539,13 @@ export async function runUnit(
  * host's job.
  *
  * The host runs this and prints the one line it writes; it decides nothing about
- * shape, order, width or degradation, because ADR 0130 rule 10 moves rendering
- * off every host so that a second host cannot drift from the first. Config is
- * read HERE, on the client side, and only decided values cross the socket.
+ * shape, order, width or degradation, because the layout belongs to
+ * `@reddb-io/redskilled-render` and to nothing else (ADR 0132 decision 1). The
+ * PAYLOAD crosses the socket and the line is drawn here (decision 9): a
+ * `statusLine` entry is a shell command, not an MCP client, and what keeps this
+ * surface from drifting away from the MCP one is shared code rather than a
+ * shared string. Config is read HERE, on the client side, and only decided
+ * values reach the render.
  *
  * **It always writes a line and always exits 0.** A statusline that printed
  * nothing when the daemon was down would be indistinguishable from a machine
@@ -579,7 +583,7 @@ export async function runStatusline(
 
   let render;
   try {
-    render = await readRedskilledStatuslineString(io.paths ?? resolveRedskilledPaths(), resolved.options, {
+    render = await readRedskilledStatuslineRender(io.paths ?? resolveRedskilledPaths(), resolved.options, {
       ...(io.client ?? {}),
       ...(resolved.options.project == null ? {} : { sessionProject: resolved.options.project }),
     });
@@ -590,9 +594,9 @@ export async function runStatusline(
       generated_at: (io.now ?? (() => new Date().toISOString()))(),
     });
   }
-  // Every line the daemon rendered, in order — one write, whatever the taste.
-  // With `--verbose` that is the Worker line plus a second line per Worker; the
-  // host still decides nothing about shape (ADR 0130 rule 10).
+  // Every line the shared render produced, in order — one write, whatever the
+  // taste. With `--verbose` that is the Worker line plus a second line per
+  // Worker; the host still decides nothing about shape.
   write(`${render.lines.join("\n")}\n`);
   return 0;
 }

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -66,8 +66,13 @@ import {
   type RedskilledWorkerHeartbeatAck,
   type RedskilledWorkerStarted,
 } from "./protocol.js";
-import type { RedskilledStatuslineOptions } from "./statusline-render.js";
-import type { RedskilledDashboardOptions } from "./dashboard-render.js";
+import {
+  REDSKILLED_STATUSLINE_DEFAULTS,
+  renderRedskilledStatusline,
+  type RedskilledDashboardOptions,
+  type RedskilledStatuslineOptions,
+} from "@reddb-io/redskilled-render";
+import type { RedskilledStatuslineExtrasRequest } from "./statusline-payload.js";
 import { clampPublishedWorkerDisplay } from "./worker-display.js";
 import { clampPublishedLogLine } from "./worker-log.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
@@ -461,14 +466,53 @@ export async function readRedskilledHostState(
 export async function readRedskilledStatuslinePayload(
   paths: RedskilledPaths,
   config: RedskilledClientConfig = {},
+  /**
+   * Which count-scaling extras this reader needs; every one of them when absent.
+   *
+   * Absent is the compatibility spelling and the honest one: a caller that says
+   * nothing gets the whole document, exactly as every bundle pinned before ADR
+   * 0132 decision 2 does. A caller that knows its density — a one-line statusline
+   * needs no log lines — states it and pays for less.
+   */
+  extras?: RedskilledStatuslineExtrasRequest,
 ): Promise<RedskilledStatuslinePayload> {
   const value = await requestRedskilled(
     paths,
-    { op: "statusline-payload", ...(config.sessionProject != null ? { session_project: config.sessionProject } : {}) },
+    {
+      op: "statusline-payload",
+      ...(config.sessionProject != null ? { session_project: config.sessionProject } : {}),
+      ...(extras == null ? {} : { extras }),
+    },
     config,
   );
   if (!isRedskilledStatuslinePayload(value)) throw new Error("redskilled daemon returned a malformed statusline payload");
   return value;
+}
+
+/**
+ * The statusline, read from the socket and drawn HERE. PURE after the read.
+ *
+ * **The command-backed host keeps the socket and passes through the shared
+ * render** (ADR 0132 decision 9). A `statusLine` entry is a shell command, not an
+ * MCP client, so routing this tick through a server would mean a handshake per
+ * tick and a blank line whenever the server is not up — the hardest failure mode
+ * in this system to diagnose. What keeps this surface from drifting away from the
+ * MCP one is no longer a shared string but shared code: both call
+ * `renderRedskilledStatusline` on the payload the daemon composed.
+ *
+ * The log lines are asked for only in `verbose`, which is the one density that
+ * draws them; every other read pays for the skeleton and the vitals alone.
+ */
+export async function readRedskilledStatuslineRender(
+  paths: RedskilledPaths,
+  options: RedskilledStatuslineOptions = REDSKILLED_STATUSLINE_DEFAULTS,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledStatuslineRender> {
+  const payload = await readRedskilledStatuslinePayload(paths, config, {
+    vitals: true,
+    logs: options.verbose,
+  });
+  return renderRedskilledStatusline(payload, options);
 }
 
 /**

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -161,17 +161,21 @@ import {
   type RedskilledQueueDiscovery,
   type RedskilledQueueTransport,
 } from "./queue-discovery.js";
-import { buildStatuslinePayload, type RedskilledStatuslinePayload } from "./statusline-payload.js";
+import {
+  buildStatuslinePayload,
+  withholdStatuslineExtras,
+  type RedskilledStatuslinePayload,
+} from "./statusline-payload.js";
 import {
   REDSKILLED_STATUSLINE_DEFAULTS,
   renderRedskilledStatusline,
   type RedskilledStatuslineRender,
-} from "./statusline-render.js";
+} from "@reddb-io/redskilled-render";
 import {
   REDSKILLED_DASHBOARD_DEFAULTS,
   renderRedskilledDashboard,
   type RedskilledDashboard,
-} from "./dashboard-render.js";
+} from "@reddb-io/redskilled-render";
 import { coerceWorkerDisplay, type RedskilledWorkerDisplayRecord } from "./worker-display.js";
 import {
   deriveRedskilledLiveMetrics,
@@ -1378,13 +1382,19 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   /**
-   * The rendered line, from that same payload and from nothing else.
+   * The rendered line, for a client that cannot draw one itself.
+   *
+   * **The layout is no longer this process's** (ADR 0132 decision 1): this calls
+   * `@reddb-io/redskilled-render`, the one implementation every surface shares,
+   * on the payload the other op returns. The op survives the move because a
+   * plugin pinned to an older bundle still asks for it (ADR 0130 rule 3), and a
+   * daemon that answered "render it yourself" would blank that plugin's pane.
    *
    * The request carries taste already settled by the client — mode, project and
    * the count budgets — because a daemon that resolved a config would have to
-   * know what a `.red/config.yaml` is, and ADR 0130 rule 3 keeps repository
-   * layout out of this process entirely. An absent field takes the shared
-   * default, so a bare read still renders.
+   * know what a `.red/config.yaml` is, and rule 3 keeps repository layout out of
+   * this process entirely. An absent field takes the shared default, so a bare
+   * read still renders.
    */
   function statuslineString(render?: RedskilledStatuslineRenderRequest): RedskilledStatuslineRender {
     return renderRedskilledStatusline(statuslinePayload(), {
@@ -1401,12 +1411,14 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   /**
    * The same payload, given the vertical dimension a pane has and a line has not.
    *
-   * THE DAEMON AGGREGATES AND RENDERS; SURFACES PRINT. A herdr pane and an editor
+   * **THE DAEMON COMPOSES; THE RENDER MODULE DRAWS.** A herdr pane and an editor
    * panel that each did their own Worker math would be two dashboards lying in
-   * two different ways about one instant — which is the drift ADR 0130 rule 10
-   * settled for the statusline and this settles for the table. As with the line,
-   * the request carries taste the client already resolved, because a daemon that
-   * looked up a config would have to know what a `.red/config.yaml` is.
+   * two different ways about one instant, and what stops that is now shared code
+   * rather than a shared string: this is one call of
+   * `@reddb-io/redskilled-render`, which every other surface also calls. As with
+   * the line, the request carries taste the client already resolved, because a
+   * daemon that looked up a config would have to know what a `.red/config.yaml`
+   * is.
    */
   function statuslineDashboard(render?: RedskilledDashboardRenderRequest): RedskilledDashboard {
     return renderRedskilledDashboard(statuslinePayload(), {
@@ -2367,7 +2379,14 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         // A host read, permitted from any project: seeing the machine is the
         // requirement, and a session that could not would diagnose contention
         // by leaving the session it is in.
-        return { id: request.id, ok: true, value: statuslinePayload() };
+        //
+        // The SKELETON — Workers, projects and budget — is served whatever the
+        // request says, because rule 9 already entitles a session to the whole
+        // machine and withholding it would buy only a second round trip (ADR
+        // 0132 decision 2). What scales with Worker count travels on request,
+        // and a request that names no extras is a client pinned to a bundle
+        // that predates them: it asked for everything by saying nothing.
+        return { id: request.id, ok: true, value: withholdStatuslineExtras(statuslinePayload(), request.extras) };
       }
       if (request.op === "statusline-string") {
         // The same host read, already rendered. The daemon renders it from the

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -88,9 +88,13 @@ import type {
   RedskilledUsageShare,
   RedskilledUsageShares,
 } from "./live-metrics.js";
-import { isRedskilledStatuslinePayload, type RedskilledStatuslinePayload } from "./statusline-payload.js";
-import type { RedskilledStatuslineMode, RedskilledStatuslineRender } from "./statusline-render.js";
-import { isRedskilledDashboard, type RedskilledDashboard } from "./dashboard-render.js";
+import {
+  isRedskilledStatuslinePayload,
+  type RedskilledStatuslineExtrasRequest,
+  type RedskilledStatuslinePayload,
+} from "./statusline-payload.js";
+import type { RedskilledStatuslineMode, RedskilledStatuslineRender } from "@reddb-io/redskilled-render";
+import { isRedskilledDashboard, type RedskilledDashboard } from "@reddb-io/redskilled-render";
 import type { RedskilledWorkerDisplay } from "./worker-display.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
 
@@ -172,7 +176,7 @@ export interface RedskilledDashboardRenderRequest {
 export type RedskilledRequest =
   | { id: string; op: "ping" }
   | { id: string; op: "host-state" }
-  | { id: string; op: "statusline-payload"; session_project?: string }
+  | { id: string; op: "statusline-payload"; session_project?: string; extras?: RedskilledStatuslineExtrasRequest }
   | { id: string; op: "statusline-string"; session_project?: string; render?: RedskilledStatuslineRenderRequest }
   | { id: string; op: "statusline-dashboard"; session_project?: string; dashboard?: RedskilledDashboardRenderRequest }
   | { id: string; op: "worker-start"; spec: RedskilledWorkerSpec; session_project?: string }

--- a/apps/redskilled/src/statusline-config.ts
+++ b/apps/redskilled/src/statusline-config.ts
@@ -23,7 +23,7 @@ import {
   REDSKILLED_STATUSLINE_DEFAULTS,
   type RedskilledStatuslineMode,
   type RedskilledStatuslineOptions,
-} from "./statusline-render.js";
+} from "@reddb-io/redskilled-render";
 
 /**
  * The canonical config block.

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -363,7 +363,94 @@ export interface RedskilledStatuslinePayload {
    * not an idle one.
    */
   readonly metrics?: RedskilledStatuslineMetrics;
+  /**
+   * Which count-scaling extras this response deliberately left out.
+   *
+   * **Stated, because a withheld fact and a missing one are opposite things**
+   * (ADR 0132 decision 2). The skeleton — Workers, projects, budget — is served
+   * on every response, since ADR 0130 rule 9 already entitles a session to the
+   * whole machine and withholding it buys only a second round trip. What scales
+   * with Worker count travels on request; a Worker whose vitals were not asked
+   * for carries the same `rss_bytes: null` a Worker nobody measured carries, and
+   * without this field a consumer would read a cheap read as a broken sampler.
+   *
+   * Absent — never `[]` — on a full response, so the field's presence alone means
+   * something was left out.
+   */
+  readonly withheld?: readonly RedskilledStatuslineExtra[];
 }
+
+/**
+ * One block that scales with Worker count, and so travels on request.
+ *
+ * Named individually rather than as one `verbose` boolean because the surfaces
+ * want different subsets: a statusline wants vitals and no logs, a dashboard
+ * wants the display records, and a health probe wants none of the three.
+ */
+export type RedskilledStatuslineExtra = "logs" | "vitals" | "display";
+
+/** Every extra there is, so a caller can ask for the skeleton by subtracting. */
+export const REDSKILLED_STATUSLINE_EXTRAS: readonly RedskilledStatuslineExtra[] = ["logs", "vitals", "display"];
+
+/**
+ * Which extras a reader wants; an omitted flag is a block it does not need.
+ *
+ * A record of opt-INS rather than opt-outs: the expensive direction should be
+ * the one a caller had to type.
+ */
+export interface RedskilledStatuslineExtrasRequest {
+  readonly logs?: boolean;
+  readonly vitals?: boolean;
+  readonly display?: boolean;
+}
+
+/**
+ * The same payload with the extras nobody asked for removed. PURE.
+ *
+ * **A withheld block is replaced by its own honest absence, never deleted**: the
+ * shape stays total, so a consumer written against the full document renders a
+ * skeleton response without a single existence check. What it must not do is
+ * read the absence as a measurement — which is exactly what `withheld` is for.
+ *
+ * `undefined` extras means the whole document, because that is what every client
+ * pinned to an older bundle asks for by saying nothing (ADR 0130 rule 3). A
+ * caller that wants less says so.
+ */
+export function withholdStatuslineExtras(
+  payload: RedskilledStatuslinePayload,
+  extras: RedskilledStatuslineExtrasRequest | undefined,
+): RedskilledStatuslinePayload {
+  if (extras === undefined) return payload;
+  const withheld = REDSKILLED_STATUSLINE_EXTRAS.filter((extra) => extras[extra] !== true);
+  if (withheld.length === 0) return payload;
+  const keep = (extra: RedskilledStatuslineExtra) => extras[extra] === true;
+  return {
+    ...payload,
+    workers: payload.workers.map((worker) => ({
+      ...worker,
+      ...(keep("vitals") ? {} : { vitals: WITHHELD_VITALS, budget: { ...worker.budget, used_bytes: null, used_fraction: null } }),
+      ...(keep("logs") ? {} : { log: WITHHELD_LOG }),
+      ...(keep("display") ? {} : { display: null, display_published_at: null }),
+    })),
+    withheld,
+  };
+}
+
+/** The vitals of a Worker nobody asked about — total in shape, empty in fact. */
+const WITHHELD_VITALS: RedskilledStatuslineVitals = {
+  rss_bytes: null,
+  sampled_at: null,
+  age_ms: null,
+  fresh: false,
+  rss_source: null,
+};
+
+/** The log of a Worker nobody asked about. `null`, exactly as an unpublished one. */
+const WITHHELD_LOG: RedskilledStatuslineWorkerLog = {
+  last_line: null,
+  published_at: null,
+  source: null,
+};
 
 export interface BuildStatuslinePayloadInput {
   readonly hostState: RedskilledHostState;

--- a/apps/redskilled/tests/github-balance.test.ts
+++ b/apps/redskilled/tests/github-balance.test.ts
@@ -11,8 +11,8 @@ import { GITHUB_RATE_LIMIT_PATH, createGithubBalanceTransport } from "@reddb-io/
 import { afterEach, describe, expect, it } from "vitest";
 
 import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
-import { renderRedskilledDashboard } from "../src/dashboard-render.js";
-import { renderRedskilledStatusline } from "../src/statusline-render.js";
+import { renderRedskilledDashboard } from "@reddb-io/redskilled-render";
+import { renderRedskilledStatusline } from "@reddb-io/redskilled-render";
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { isRedskilledStatuslinePayload } from "../src/statusline-payload.js";

--- a/apps/redskilled/tests/help-offline.test.ts
+++ b/apps/redskilled/tests/help-offline.test.ts
@@ -27,8 +27,8 @@ vi.mock("../src/client.js", async (importActual) => {
       reached.push("readRedskilledHostState");
       return { workers: [] };
     },
-    readRedskilledStatuslineString: async () => {
-      reached.push("readRedskilledStatuslineString");
+    readRedskilledStatuslineRender: async () => {
+      reached.push("readRedskilledStatuslineRender");
       return { lines: ["…"] };
     },
   };

--- a/apps/redskilled/tests/registration-sustain.test.ts
+++ b/apps/redskilled/tests/registration-sustain.test.ts
@@ -26,7 +26,7 @@ import {
   renderRedskilledStatusline,
   REDSKILLED_STATUSLINE_DEFAULTS,
   type RedskilledStatuslineOptions,
-} from "../src/statusline-render.js";
+} from "@reddb-io/redskilled-render";
 import type { LaunchedWorker, LaunchWorkerOptions } from "../src/worker-launch.js";
 
 const T0 = "2026-07-31T12:00:00.000Z";

--- a/apps/redskilled/tests/render-contract.test.ts
+++ b/apps/redskilled/tests/render-contract.test.ts
@@ -1,0 +1,185 @@
+// One render implementation, outside the daemon (ADR 0132 decisions 1, 2 and 9).
+//
+// The four claims this file pins are the issue's acceptance criteria: the layout
+// lives in exactly one module, that module holds no state and opens no transport,
+// the daemon serves the skeleton unconditionally and the count-scaling extras on
+// request, and no layout logic is left behind in `apps/redskilled`.
+import { readdirSync, readFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { encode as encodeToon } from "@reddb-io/toon";
+import {
+  decodeRedskilledPayload,
+  renderRedskilled,
+  renderRedskilledStatusline,
+  REDSKILLED_STATUSLINE_DEFAULTS,
+  type RedskilledRenderPayload,
+} from "@reddb-io/redskilled-render";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { readRedskilledStatuslinePayload } from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import {
+  REDSKILLED_STATUSLINE_EXTRAS,
+  withholdStatuslineExtras,
+  type RedskilledStatuslinePayload,
+} from "../src/statusline-payload.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-render-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+function worker(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorkerView {
+  return {
+    worker_id: "w-1",
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-08-03T00:00:00.000Z",
+    workspace_path: "/tmp/acme/w-1",
+    isolated: true,
+    unit: "red-worker-acme-widgets-w-1.service",
+    budget: { memory_max: "1G" },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+async function liveDaemon(): Promise<{ daemon: RedskilledDaemon; paths: RedskilledPaths }> {
+  const paths = await sessionPaths();
+  const daemon = await startRedskilledDaemon({
+    paths,
+    idleMs: 60_000,
+    sampleMs: 0,
+    ceiling: UNBOUNDED_HOST_CEILING,
+    stopWorker: () => true,
+    treeSampler: () => ({ rss: { "w-1": 512 * 1024 * 1024 }, cpu_seconds: {} }),
+  });
+  running.push(daemon);
+  daemon.trackWorker(worker());
+  await daemon.sampleMemoryBudgets();
+  return { daemon, paths };
+}
+
+describe("one render module, and the daemon's payload satisfies it", () => {
+  it("hands the daemon's own payload to the shared render with no adaptation", async () => {
+    const { daemon } = await liveDaemon();
+    const live: RedskilledStatuslinePayload = daemon.statuslinePayload();
+    // The assignment IS the ratchet: the daemon composes a superset of the wire
+    // document the render declares, and a field that changed shape here fails to
+    // compile rather than failing to draw.
+    const asRendered: RedskilledRenderPayload = live;
+    const drawn = renderRedskilledStatusline(asRendered, {
+      ...REDSKILLED_STATUSLINE_DEFAULTS,
+      project: "acme/widgets",
+    });
+    expect(drawn.line).toContain("acme/widgets 1w");
+    // Known by NAME: this daemon holds the Worker and no registration for its
+    // project, and the shared render says so from the payload alone (#2973).
+    expect(drawn.project_match).toBe("name-only");
+  });
+
+  it("draws a live payload exactly as it draws the same bytes off a file", async () => {
+    const { daemon } = await liveDaemon();
+    const live = daemon.statuslinePayload();
+    const taste = { density: "line", options: { project: "acme/widgets" } } as const;
+
+    const fromLive = renderRedskilled(live, taste);
+    const fromJson = renderRedskilled(JSON.stringify(live), taste);
+    const fromToon = renderRedskilled(encodeToon(live as never), taste);
+
+    expect(fromJson.lines).toEqual(fromLive.lines);
+    expect(fromToon.lines).toEqual(fromLive.lines);
+    expect(decodeRedskilledPayload(encodeToon(live as never)).encoding).toBe("toon");
+  });
+});
+
+describe("the skeleton is unconditional and the extras are asked for", () => {
+  it("serves Workers, projects and the budget on every response", async () => {
+    const { paths } = await liveDaemon();
+    const skeleton = await readRedskilledStatuslinePayload(paths, {}, {});
+
+    expect(skeleton.workers).toHaveLength(1);
+    expect(skeleton.projects).toHaveLength(1);
+    expect(skeleton.github_balance).toBeDefined();
+    expect(skeleton.host.observed_rss_bytes).toBeGreaterThan(0);
+    // Every count-scaling block was withheld, and the payload SAYS so: without
+    // this a consumer would read a cheap read as a stopped sampler.
+    expect([...(skeleton.withheld ?? [])].sort()).toEqual([...REDSKILLED_STATUSLINE_EXTRAS].sort());
+    expect(skeleton.workers[0]!.vitals.rss_bytes).toBeNull();
+  });
+
+  it("serves the extras that were named, and nothing more", async () => {
+    const { paths } = await liveDaemon();
+    const withVitals = await readRedskilledStatuslinePayload(paths, {}, { vitals: true });
+
+    expect(withVitals.withheld).toEqual(["logs", "display"]);
+    expect(withVitals.workers[0]!.vitals.rss_bytes).toBe(512 * 1024 * 1024);
+    expect(withVitals.workers[0]!.log.last_line).toBeNull();
+  });
+
+  it("answers a client that names no extras with the whole document", async () => {
+    const { paths } = await liveDaemon();
+    // The compatibility spelling: every bundle pinned before ADR 0132 decision 2
+    // sends no `extras`, and a daemon that read that as "the skeleton" would
+    // silently impoverish every surface on the machine (ADR 0130 rule 3).
+    const whole = await readRedskilledStatuslinePayload(paths, {});
+    expect(whole.withheld).toBeUndefined();
+    expect(whole.workers[0]!.vitals.rss_bytes).toBe(512 * 1024 * 1024);
+  });
+
+  it("withholds purely — the shape stays total, so a consumer needs no guard", async () => {
+    const { daemon } = await liveDaemon();
+    const whole = daemon.statuslinePayload();
+    const thin = withholdStatuslineExtras(whole, {});
+
+    expect(thin.workers[0]!.vitals).toEqual({
+      rss_bytes: null,
+      sampled_at: null,
+      age_ms: null,
+      fresh: false,
+      rss_source: null,
+    });
+    expect(thin.workers[0]!.log).toEqual({ last_line: null, published_at: null, source: null });
+    expect(thin.workers[0]!.display).toBeNull();
+    // The aggregates are skeleton and survive: the head answers "how much of this
+    // machine is in use" whatever a reader declined to fetch.
+    expect(thin.host).toEqual(whole.host);
+    expect(thin.projects).toEqual(whole.projects);
+  });
+});
+
+describe("no layout logic remains in apps/redskilled", () => {
+  it("holds no render module of its own", () => {
+    const src = readdirSync(join(import.meta.dirname, "..", "src"));
+    expect(src).not.toContain("statusline-render.ts");
+    expect(src).not.toContain("dashboard-render.ts");
+  });
+
+  it("spells no line, row or column anywhere but the render package", () => {
+    const src = join(import.meta.dirname, "..", "src");
+    // The marks are the smallest piece of layout there is, so they are the
+    // cheapest thing to fork and the surest signal that a second layout started.
+    for (const name of readdirSync(src).filter((file) => file.endsWith(".ts"))) {
+      const body = readFileSync(join(src, name), "utf8").replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, "");
+      expect(body, name).not.toMatch(/["'`][^"'`]*†[^"'`]*["'`]/);
+      expect(body, name).not.toMatch(/["'`][^"'`]*↳[^"'`]*["'`]/);
+      expect(body, name).not.toMatch(/!unregistered|!lapsed|slots=|wrk=|tk\/m=/);
+    }
+  });
+});

--- a/apps/redskilled/tests/statusline-bound.test.ts
+++ b/apps/redskilled/tests/statusline-bound.test.ts
@@ -22,14 +22,14 @@ import { buildHostState, type RedskilledWorkerView } from "../src/host-state.js"
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { buildStatuslinePayload, type RedskilledStatuslinePayload } from "../src/statusline-payload.js";
 import {
-  REDSKILLED_STATUSLINE_ABSENCE,
+  REDSKILLED_RENDER_ABSENCE,
   REDSKILLED_STATUSLINE_DEFAULTS,
   redskilledStatuslineBound,
   redskilledStatuslineCharacters,
   renderRedskilledStatusline,
   renderRedskilledStatuslineAbsence,
   type RedskilledStatuslineOptions,
-} from "../src/statusline-render.js";
+} from "@reddb-io/redskilled-render";
 import type { RedskilledWorkerLogLine } from "../src/worker-log.js";
 
 const running: RedskilledDaemon[] = [];
@@ -160,8 +160,8 @@ describe("a host that did not answer", () => {
       generated_at: "2026-07-29T01:00:05.000Z",
     });
 
-    expect(render.line).toBe(REDSKILLED_STATUSLINE_ABSENCE);
-    expect(render.lines).toEqual([REDSKILLED_STATUSLINE_ABSENCE]);
+    expect(render.line).toBe(REDSKILLED_RENDER_ABSENCE);
+    expect(render.lines).toEqual([REDSKILLED_RENDER_ABSENCE]);
     expect(render.line.trim()).not.toBe("");
     // Neither a fresh answer nor a project verdict: nobody was there to give one.
     expect(render.stale).toBe(true);
@@ -187,7 +187,7 @@ describe("a host that did not answer", () => {
     });
 
     expect(code).toBe(0);
-    expect(written).toEqual([`${REDSKILLED_STATUSLINE_ABSENCE}\n`]);
+    expect(written).toEqual([`${REDSKILLED_RENDER_ABSENCE}\n`]);
     // The diagnosis is not lost — it goes where a statusline does not show it.
     expect(warned.join("")).toContain("redskilled statusline:");
   });

--- a/apps/redskilled/tests/statusline-dashboard.test.ts
+++ b/apps/redskilled/tests/statusline-dashboard.test.ts
@@ -16,7 +16,7 @@ import {
   REDSKILLED_DASHBOARD_DEFAULTS,
   progressBar,
   renderRedskilledDashboard,
-} from "../src/dashboard-render.js";
+} from "@reddb-io/redskilled-render";
 import { buildHostState, type RedskilledWorkerView } from "../src/host-state.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { isRedskilledDashboard } from "../src/protocol.js";

--- a/apps/redskilled/tests/statusline-deaths.test.ts
+++ b/apps/redskilled/tests/statusline-deaths.test.ts
@@ -11,11 +11,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
 import { readRedskilledDashboard, readRedskilledStatuslineString } from "../src/client.js";
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
-import { renderRedskilledDashboard } from "../src/dashboard-render.js";
+import { renderRedskilledDashboard } from "@reddb-io/redskilled-render";
 import { buildHostState, type RedskilledWorkerView } from "../src/host-state.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { buildStatuslinePayload } from "../src/statusline-payload.js";
-import { renderRedskilledStatusline, REDSKILLED_STATUSLINE_DEFAULTS } from "../src/statusline-render.js";
+import { renderRedskilledStatusline, REDSKILLED_STATUSLINE_DEFAULTS } from "@reddb-io/redskilled-render";
 
 const running: RedskilledDaemon[] = [];
 const roots: string[] = [];

--- a/apps/redskilled/tests/statusline-local-project.test.ts
+++ b/apps/redskilled/tests/statusline-local-project.test.ts
@@ -28,7 +28,7 @@ import {
   REDSKILLED_STATUSLINE_DEFAULTS,
   renderRedskilledStatusline,
   type RedskilledStatuslineOptions,
-} from "../src/statusline-render.js";
+} from "@reddb-io/redskilled-render";
 
 const running: RedskilledDaemon[] = [];
 const roots: string[] = [];

--- a/apps/redskilled/tests/statusline-string.test.ts
+++ b/apps/redskilled/tests/statusline-string.test.ts
@@ -25,7 +25,7 @@ import {
   REDSKILLED_STATUSLINE_DEFAULTS,
   renderRedskilledStatusline,
   type RedskilledStatuslineOptions,
-} from "../src/statusline-render.js";
+} from "@reddb-io/redskilled-render";
 import type { RedskilledStatuslinePayload } from "../src/statusline-payload.js";
 import { buildStatuslinePayload } from "../src/statusline-payload.js";
 

--- a/apps/redskilled/tests/statusline-verbose.test.ts
+++ b/apps/redskilled/tests/statusline-verbose.test.ts
@@ -29,7 +29,7 @@ import {
   REDSKILLED_STATUSLINE_DEFAULTS,
   renderRedskilledStatusline,
   type RedskilledStatuslineOptions,
-} from "../src/statusline-render.js";
+} from "@reddb-io/redskilled-render";
 import { buildStatuslinePayload, type RedskilledStatuslinePayload } from "../src/statusline-payload.js";
 import type { RedskilledWorkerLogLine } from "../src/worker-log.js";
 
@@ -329,8 +329,10 @@ describe("the line the Worker publishes", () => {
 
     // The renderer could not open a foreign project's log even if it wanted to:
     // it is a pure function of the payload and reaches no filesystem at all.
-    const source = readFileSync(join(import.meta.dirname, "..", "src", "statusline-render.ts"), "utf8");
-    expect(source).not.toMatch(/from "node:fs/);
+    const renderRoot = join(import.meta.dirname, "..", "..", "..", "packages", "redskilled-render");
+    for (const module of ["line.ts", "panel.ts", "dashboard.ts", "select.ts", "format.ts"]) {
+      expect(readFileSync(join(renderRoot, module), "utf8")).not.toMatch(/from "node:/);
+    }
   });
 });
 

--- a/apps/vscode-extension-red-skills/package.json
+++ b/apps/vscode-extension-red-skills/package.json
@@ -178,6 +178,7 @@
   },
   "dependencies": {
     "@reddb-io/redskilled": "workspace:*",
+    "@reddb-io/redskilled-render": "workspace:*",
     "@reddb-io/shared": "workspace:*"
   },
   "devDependencies": {

--- a/apps/vscode-extension-red-skills/src/model/snapshot.ts
+++ b/apps/vscode-extension-red-skills/src/model/snapshot.ts
@@ -9,11 +9,12 @@
  * what is running now and the lane says how the last thing ended, and a view
  * holding only one of the two can always be asked a question it cannot answer.
  */
-import type {
-  RedskilledDashboard,
-  RedskilledHostState,
-  RedskilledStatuslinePayload,
-} from "@reddb-io/redskilled/protocol";
+import type { RedskilledHostState, RedskilledStatuslinePayload } from "@reddb-io/redskilled/protocol";
+import {
+  renderRedskilledDashboard,
+  REDSKILLED_DASHBOARD_DEFAULTS,
+  type RedskilledDashboard,
+} from "@reddb-io/redskilled-render";
 import type { RedskilledReadClient } from "../redskilled/client.js";
 import { readEventLane, type EventLaneRead } from "../redskilled/event-lane.js";
 
@@ -37,12 +38,13 @@ export interface HostSnapshot {
    */
   readonly hostState: RedskilledHostState | null;
   /**
-   * The dashboard the daemon rendered for this frame, or `null`.
+   * The table for this frame, drawn HERE from the payload beside it.
    *
-   * Read beside the payload rather than derived from it: THE DAEMON AGGREGATES
-   * AND RENDERS; SURFACES PRINT. Null does NOT imply unreachable — a daemon too
-   * old to serve the op still yields a usable frame for the trees, and the
-   * dashboard panel says so rather than drawing a table nobody rendered.
+   * **One read, one render** (ADR 0132 decisions 1 and 9): it used to be a second
+   * socket call, which spent a round trip per frame to receive text this process
+   * could compute from bytes it already held. It is `null` exactly when the
+   * payload is — an unreachable daemon — and never because a daemon was too old
+   * to lay a table out, because no daemon lays one out any more.
    */
   readonly dashboard: RedskilledDashboard | null;
   readonly lane: EventLaneRead;
@@ -55,7 +57,7 @@ export interface ReadSnapshotOptions {
   readonly eventLanePath: string;
   readonly source: string;
   readonly sessionProject?: string;
-  /** The size the panel has, stated on the request so the daemon renders to it. */
+  /** The size the panel has; the render is clamped to it on this side. */
   readonly dashboardRender?: { readonly maxWidth?: number; readonly maxRows?: number };
   readonly now?: () => string;
 }
@@ -73,21 +75,20 @@ export async function readHostSnapshot(options: ReadSnapshotOptions): Promise<Ho
   const lane = await readEventLane(options.eventLanePath).catch(() => EMPTY_LANE(options.eventLanePath));
 
   try {
-    const [payload, hostState, dashboard] = await Promise.all([
-      options.client.statuslinePayload(options.sessionProject),
+    const [payload, hostState] = await Promise.all([
+      // The panel draws every published field, so this frame asks for all three
+      // count-scaling extras; a reader that wanted only the totals would name
+      // fewer and the daemon would serve the skeleton alone.
+      options.client.statuslinePayload(options.sessionProject, { vitals: true, display: true, logs: true }),
       options.client.hostState().catch(() => null),
-      options.client
-        .dashboard(options.sessionProject, {
-          mode: options.sessionProject ? "local" : "global",
-          ...(options.sessionProject ? { project: options.sessionProject } : {}),
-          ...(options.dashboardRender?.maxWidth == null ? {} : { max_width: options.dashboardRender.maxWidth }),
-          ...(options.dashboardRender?.maxRows == null ? {} : { max_rows: options.dashboardRender.maxRows }),
-        })
-        // Best-effort beside the payload, for the reason `host-state` is: a
-        // daemon that serves one and refuses the other still yields a usable
-        // frame instead of an outage.
-        .catch(() => null),
     ]);
+    const dashboard = renderRedskilledDashboard(payload, {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      mode: options.sessionProject ? "local" : "global",
+      project: options.sessionProject ?? null,
+      ...(options.dashboardRender?.maxWidth == null ? {} : { maxWidth: options.dashboardRender.maxWidth }),
+      ...(options.dashboardRender?.maxRows == null ? {} : { maxRows: options.dashboardRender.maxRows }),
+    });
     return {
       reachable: true,
       socketPath: options.client.socketPath,

--- a/apps/vscode-extension-red-skills/src/redskilled/client.ts
+++ b/apps/vscode-extension-red-skills/src/redskilled/client.ts
@@ -26,15 +26,14 @@
  */
 import { sendLineRequest } from "@reddb-io/shared/resident-core.js";
 import type {
-  RedskilledDashboard,
-  RedskilledDashboardRenderRequest,
   RedskilledHostState,
   RedskilledPong,
   RedskilledRequest,
   RedskilledResponse,
   RedskilledStatuslinePayload,
 } from "@reddb-io/redskilled/protocol";
-import { isRedskilledDashboard, isRedskilledStatuslinePayload } from "@reddb-io/redskilled/protocol";
+import { isRedskilledStatuslinePayload } from "@reddb-io/redskilled/protocol";
+import type { RedskilledStatuslineExtrasRequest } from "@reddb-io/redskilled/statusline-payload";
 import { isRedskilledHostState } from "@reddb-io/redskilled/host-state";
 
 /** Raised when nothing answered — never confused with "the host is idle". */
@@ -63,20 +62,23 @@ export interface RedskilledReadClient {
   readonly socketPath: string;
   ping(): Promise<RedskilledPong>;
   hostState(): Promise<RedskilledHostState>;
-  statuslinePayload(sessionProject?: string): Promise<RedskilledStatuslinePayload>;
   /**
-   * The dashboard: the same read again, already laid out as a table.
+   * The whole machine in one read, and the only read a frame makes.
    *
-   * The extension PRINTS what comes back and computes no cell of it. The daemon
-   * is the only process holding the Worker set across projects, so a panel doing
-   * its own Worker math would be a second authority on a question one document
-   * already answers — and an editor panel and a terminal pane would describe two
-   * different machines (ADR 0130 rule 10).
+   * **The table is drawn from THIS document, in this process, by the shared
+   * render module** (ADR 0132 decisions 1 and 9). It used to be a second socket
+   * call to `statusline-dashboard`, which bought a round trip per frame to
+   * receive text this extension could compute itself from bytes it already held.
+   * What keeps the panel from drifting away from a terminal pane is no longer a
+   * shared string but shared code: both call `renderRedskilledDashboard`.
+   *
+   * `extras` names the count-scaling blocks this frame needs — the panel wants
+   * the display records, and a health check wants none of them.
    */
-  dashboard(
+  statuslinePayload(
     sessionProject?: string,
-    render?: RedskilledDashboardRenderRequest,
-  ): Promise<RedskilledDashboard>;
+    extras?: RedskilledStatuslineExtrasRequest,
+  ): Promise<RedskilledStatuslinePayload>;
 }
 
 export interface CreateReadClientOptions {
@@ -133,31 +135,17 @@ export function createRedskilledReadClient(options: CreateReadClientOptions): Re
       }
       return value;
     },
-    async statuslinePayload(sessionProject?: string) {
+    async statuslinePayload(sessionProject?: string, extras?: RedskilledStatuslineExtrasRequest) {
       const value = await call({
         id: nextRequestId("statusline-payload"),
         op: "statusline-payload",
         ...(sessionProject ? { session_project: sessionProject } : {}),
+        ...(extras ? { extras } : {}),
       });
       if (!isRedskilledStatuslinePayload(value)) {
         throw new RedskilledRefusedError(
           "the daemon answered statusline-payload with a shape this view cannot read",
           "statusline-payload",
-        );
-      }
-      return value;
-    },
-    async dashboard(sessionProject?: string, render?: RedskilledDashboardRenderRequest) {
-      const value = await call({
-        id: nextRequestId("statusline-dashboard"),
-        op: "statusline-dashboard",
-        ...(sessionProject ? { session_project: sessionProject } : {}),
-        ...(render ? { dashboard: render } : {}),
-      });
-      if (!isRedskilledDashboard(value)) {
-        throw new RedskilledRefusedError(
-          "the daemon answered statusline-dashboard with a shape this view cannot read",
-          "statusline-dashboard",
         );
       }
       return value;

--- a/apps/vscode-extension-red-skills/tests/dashboard.test.ts
+++ b/apps/vscode-extension-red-skills/tests/dashboard.test.ts
@@ -1,9 +1,10 @@
 /**
- * The dashboard is the one view whose correctness is NOT this extension's to
- * prove. Every cell arrives finished from `statusline-dashboard`, so what these
- * assert is the only thing a surface can get wrong: that it shows what it was
- * handed, that it re-derives nothing, that a state change in the daemon reaches
- * both surfaces, and that an absence is drawn as an absence.
+ * The dashboard is drawn HERE, by the one render module every surface shares
+ * (ADR 0132 decisions 1 and 9) — this extension owns no layout of its own. So
+ * what these assert is the only thing a surface can get wrong: that it shows
+ * what the shared render handed it, that it re-derives no cell, that a state
+ * change in the daemon reaches both surfaces, and that an absence is drawn as an
+ * absence.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -18,6 +19,36 @@ import { readHostSnapshot, type HostSnapshot } from "../src/model/snapshot.js";
 import { createRedskilledReadClient } from "../src/redskilled/client.js";
 import { startFakeDaemon, type FakeDaemon } from "./fake-daemon.js";
 import { dashboard, hostState, statuslinePayload } from "./fixtures.js";
+
+/** The same payload with a published display record, so the row has cells. */
+function withDisplay(payload: ReturnType<typeof statuslinePayload>): ReturnType<typeof statuslinePayload> {
+  return {
+    ...payload,
+    workers: payload.workers.map((entry) => ({
+      ...entry,
+      display: {
+        runner: "claude",
+        model: "opus",
+        effort: "high",
+        origin: "afk",
+        issue: "3096",
+        phase: "coding",
+        step: null,
+        phase_index: 2,
+        phase_total: 6,
+        failed: false,
+        heartbeat: "3s",
+        added: null,
+        removed: null,
+        tokens: null,
+        tools: null,
+        reasoning: null,
+        text: null,
+      },
+      display_published_at: payload.generated_at,
+    })),
+  };
+}
 
 const daemons: FakeDaemon[] = [];
 
@@ -143,9 +174,9 @@ describe("the dashboard panel shows the rows the daemon rendered", () => {
   });
 });
 
-describe("the frame is read from the daemon, not derived from the payload", () => {
-  it("asks statusline-dashboard beside the payload and states the size it has", async () => {
-    const daemon = await fake();
+describe("the frame is drawn here, from the one document the daemon composed", () => {
+  it("draws the table from the payload it already read, at the size the panel has", async () => {
+    const daemon = await fake({ payload: () => withDisplay(statuslinePayload()) });
     const snapshot = await readHostSnapshot({
       client: createRedskilledReadClient({ socketPath: daemon.socketPath }),
       eventLanePath: daemon.eventLanePath,
@@ -155,10 +186,13 @@ describe("the frame is read from the daemon, not derived from the payload", () =
     });
 
     expect(snapshot.reachable).toBe(true);
-    expect(daemon.served.get("statusline-dashboard")).toBe(1);
+    // ONE read, and no second round trip for text this process can compute from
+    // bytes it already holds (ADR 0132 decisions 1 and 9).
+    expect(daemon.served.get("statusline-payload")).toBe(1);
+    expect(daemon.served.has("statusline-dashboard")).toBe(false);
     expect(snapshot.dashboard?.header.line).toContain("» reddb-io/red-skills");
-    // The rows are the daemon's own, verbatim: nothing in this extension built
-    // one, so a field the daemon stops rendering vanishes here too.
+    // The cells come from the shared render module, so a terminal pane standing
+    // in the same directory draws this row character for character.
     expect(snapshot.dashboard?.rows[0]?.cells.bar).toBe("██▶░░░");
   });
 
@@ -254,8 +288,8 @@ describe("the frame is read from the daemon, not derived from the payload", () =
     expect(rows[0]!.label).toBe("no metrics on this daemon");
   });
 
-  it("keeps the trees usable when a daemon refuses the op", async () => {
-    const daemon = await fake({ refuse: ["statusline-dashboard"] });
+  it("keeps the frame usable when a daemon refuses the read beside the payload", async () => {
+    const daemon = await fake({ refuse: ["host-state"] });
     const snapshot = await readHostSnapshot({
       client: createRedskilledReadClient({ socketPath: daemon.socketPath }),
       eventLanePath: daemon.eventLanePath,
@@ -264,12 +298,17 @@ describe("the frame is read from the daemon, not derived from the payload", () =
 
     expect(snapshot.reachable).toBe(true);
     expect(snapshot.payload).not.toBeNull();
-    expect(snapshot.dashboard).toBeNull();
+    expect(snapshot.hostState).toBeNull();
+    // The table survives a refused `host-state`, because it is drawn from the
+    // payload and from nothing else — there is no second op to lose.
+    expect(snapshot.dashboard).not.toBeNull();
   });
 
-  it("reflects a state change in the daemon without local re-derivation", async () => {
+  it("reflects a state change in the daemon on the next payload it reads", async () => {
     let stale = false;
-    const daemon = await fake({ dashboard: () => dashboard({ stale, rows: stale ? [] : dashboard().rows }) });
+    const daemon = await fake({
+      payload: () => statuslinePayload({ stale, ...(stale ? { workers: [] } : {}) }),
+    });
     const client = createRedskilledReadClient({ socketPath: daemon.socketPath });
     const read = async (): Promise<HostSnapshot> =>
       await readHostSnapshot({ client, eventLanePath: daemon.eventLanePath, source: "the test pinned it" });

--- a/packages/redskilled-render/README.md
+++ b/packages/redskilled-render/README.md
@@ -1,0 +1,98 @@
+# @reddb-io/redskilled-render
+
+One render implementation, outside the daemon, drawn at parameterized densities.
+ADR 0132 decisions 1, 2 and 9; issue #3096.
+
+## Why it exists
+
+ADR 0130 rule 10 moved rendering into the `redskilled` daemon so that "the string
+is a pure function of the payload" would keep surfaces from drifting. What that
+bought was a statusline **poorer** than the one it replaced —
+
+```
+reddb-io/red-skills 2w 14.4M v3.3.9
+```
+
+— while the documented format carries runner, model, effort, phase, elapsed,
+diffstat, tokens and vitals. Nothing regressed by accident: rule 3 forbids the
+daemon castle semantics, and one rendered string cannot serve a one-line
+statusline and a full TUI at once. The impoverished line was the designed
+consequence of two rules meeting.
+
+**The no-drift guarantee is one implementation, not one string.** This package is
+that implementation. Four surfaces at four densities cannot share a string, and
+they must not each own a layout.
+
+## What it is
+
+- **Stateless, and it opens no transport.** A pure function from one decoded
+  payload to one drawn surface. Nothing here reads a clock, a directory, an
+  environment variable or a file descriptor — which is why a fixture payload
+  renders byte-identically to a live one, and why that claim is a test rather
+  than a comment.
+- **Encoding-agnostic inbound.** `decodeRedskilledPayload` accepts JSON, JSONL,
+  TOON and TOONL, matching the decoder that already sniffs JSON-or-TOON. The
+  repo's TOON mandate governs **writers** and is unchanged: what a reader
+  tolerates and what a writer must emit are different contracts.
+- **Three densities, composed rather than duplicated.** The degradation ladder,
+  the Worker selection, the project-match verdict and the marks are shared, so a
+  line and a table standing in the same directory describe the same machine by
+  construction.
+
+| density | what it draws | who asks for it |
+| --- | --- | --- |
+| `line` | one row, degrading workers → projects → host | the `statusLine` shell command |
+| `panel` | a head plus a few rows; its first row **is** the line | a tooltip, a sidebar, a notification body |
+| `dashboard` | the aligned table, the header, the death receipts | the editor panel, the terminal pane |
+
+## Using it
+
+```ts
+import { renderRedskilled } from "@reddb-io/redskilled-render";
+
+const drawn = renderRedskilled(payloadTextOrValue, {
+  density: "panel",
+  options: { project: "acme/widgets", maxWidth: 96, maxRows: 6 },
+});
+process.stdout.write(`${drawn.lines.join("\n")}\n`);
+```
+
+Each density is also exported on its own (`renderRedskilledStatusline`,
+`renderRedskilledPanel`, `renderRedskilledDashboard`) for a caller whose height is
+fixed at compile time. `renderRedskilled` exists for the callers whose height is
+configuration — a pane an operator resizes, a tooltip that expands — because
+choosing between three imports at run time is how a fourth layout gets written.
+
+## The inbound contract
+
+`payload.ts` declares the wire document this module reads, on the **reading**
+side, and names only the fields a layout draws. One daemon serves checkouts
+pinned to different bundle versions (ADR 0130 rule 3), so a renderer that
+demanded the daemon's whole internal record would blank a pane over a field it
+never prints. `apps/redskilled/tests/render-contract.test.ts` is the ratchet: the
+daemon's own `RedskilledStatuslinePayload` is assigned to
+`RedskilledRenderPayload` there, so a field that changes shape fails to compile
+rather than failing to draw.
+
+## Who draws through it
+
+- **The statusline** — `redskilled statusline` reads the socket and renders here
+  (ADR 0132 decision 9: a `statusLine` entry is a shell command, not an MCP
+  client, so routing the tick through a server would mean a handshake per tick
+  and a blank line whenever the server is not up).
+- **The VS Code extension** — one `statusline-payload` read per frame, drawn
+  here. It used to spend a second round trip on `statusline-dashboard` to receive
+  text it could compute from bytes it already held.
+- **The terminal dashboard and the herdr plugin** — through the daemon's
+  `statusline-string` and `statusline-dashboard` ops, which are now one call of
+  this module. Those ops stay because a pinned older plugin still asks for them;
+  the layout behind them is no longer the daemon's.
+
+## Withheld is not missing
+
+The daemon serves the skeleton — Workers, projects, budget — on every response,
+and the count-scaling extras (`logs`, `vitals`, `display`) on request. A Worker
+whose vitals nobody asked for carries the same `rss_bytes: null` a Worker nobody
+measured carries, so the payload's `withheld` array is what tells a consumer a
+cheap read from a stopped sampler. A response that withheld nothing omits the
+field entirely.

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -1,49 +1,47 @@
 /**
- * dashboard-render — the statusline, given the vertical dimension it never had.
+ * dashboard — the richest density: the payload given a vertical dimension.
  *
- * **THE DAEMON AGGREGATES AND RENDERS; SURFACES PRINT.** The statusline pair
- * (`statusline-payload` / `statusline-string`) already settled this for one line;
- * this module settles it for the table. Every cell here is computed once, in the
- * one process that holds the Worker set across projects, and a surface receives
- * finished text plus the structure behind it. A terminal pane and an editor panel
- * that each did their own worker math would be two dashboards lying in two
- * different ways about the same instant — which is the whole failure the pair of
- * statusline ops exists to prevent (ADR 0130 rule 10).
+ * **One implementation, four densities.** The statusline pair settled drift for
+ * one line by making the string a pure function of the payload; ADR 0132 decision
+ * 1 finishes the argument — four surfaces at four densities cannot share a
+ * string, and they must not each own a layout. So the table is drawn HERE, beside
+ * the line, from the same selection and the same marks, and a surface prints.
  *
  * **The string is a pure function of the payload.** Nothing here reads a clock, a
  * directory or an environment variable; the elapsed figures are the payload's own
  * `uptime_ms`, dated by the daemon's sampler, so the dashboard and the statusline
  * beside it can only disagree if a pure function is impure.
  *
- * **The daemon never learns the pipeline.** The progress bar is drawn from the
- * two integers a project published (`phase_index`, `phase_total`) and from
- * nothing else — see `worker-display.ts`. A daemon that knew what `coding` or
- * `validating` meant would be carrying castle semantics, which rule 3 forbids.
+ * **Nothing here learns the pipeline.** The progress bar is drawn from the two
+ * integers a project published (`phase_index`, `phase_total`) and from nothing
+ * else. A renderer that knew what `coding` or `validating` meant would be
+ * carrying castle semantics, which ADR 0130 rule 3 keeps out of the host lane
+ * entirely — and this module runs on both sides of it.
  *
  * **Host-side session facts stay absent rather than faked.** The context window
  * and the Pro/Max 5h/7d usage windows arrive from a Claude Code stdin payload
- * that never reaches this process. The header carries the windows the daemon DOES
+ * that never reaches the daemon. The header carries the windows the daemon DOES
  * own — the memory ceiling and the Worker slots — and says nothing about the ones
  * it does not, because a plausible zero is worse than a missing column.
  */
-import type { RedskilledMetricsWindow, RedskilledStatuslineMetrics } from "./live-metrics.js";
-import type {
-  RedskilledStatuslineDeaths,
-  RedskilledStatuslineEngine,
-  RedskilledStatuslinePayload,
-  RedskilledStatuslineWorker,
-} from "./statusline-payload.js";
+import { clamp, formatBytes, formatCount, formatDuration, formatRate, pad, width } from "./format.js";
+import { BUDGET_BAND_MARK, BUDGET_SPENT_MARK, DEATH_MARK, ENGINE_BEHIND_MARK } from "./marks.js";
 import {
-  BUDGET_BAND_MARK as DASHBOARD_BUDGET_BAND_MARK,
-  BUDGET_SPENT_MARK as DASHBOARD_BUDGET_SPENT_MARK,
-  DEATH_MARK as DASHBOARD_DEATH_MARK,
-  ENGINE_BEHIND_MARK as DASHBOARD_ENGINE_BEHIND_MARK,
-  formatBytes,
-  resolveStatuslineProjectMatch,
+  REDSKILLED_RENDER_DISPLAY_ABSENT,
+  type RedskilledRenderDeaths,
+  type RedskilledRenderEngine,
+  type RedskilledRenderMetrics,
+  type RedskilledRenderMetricsWindow,
+  type RedskilledRenderPayload,
+  type RedskilledRenderWorker,
+  type RedskilledRenderWorkerDisplay,
   type RedskilledStatuslineMode,
+} from "./payload.js";
+import {
+  resolveStatuslineProjectMatch,
+  selectRenderWorkers,
   type RedskilledStatuslineProjectMatch,
-} from "./statusline-render.js";
-import { REDSKILLED_WORKER_DISPLAY_ABSENT, type RedskilledWorkerDisplay } from "./worker-display.js";
+} from "./select.js";
 
 /** The row columns, in the order the statusline's per-worker line prints them. */
 export const REDSKILLED_DASHBOARD_COLUMNS = [
@@ -92,7 +90,7 @@ export interface RedskilledDashboardCounts {
  *
  * Named `windows` because that is the header slot the statusline spends on the
  * Pro/Max rate limits. Those are host-side and unknowable here; these two are the
- * ceilings this process actually enforces, so the slot carries a real answer
+ * ceilings the daemon actually enforces, so the slot carries a real answer
  * rather than an empty one.
  */
 export interface RedskilledDashboardWindows {
@@ -108,7 +106,7 @@ export interface RedskilledDashboardHeader {
   readonly repo: string | null;
   readonly project: string | null;
   readonly project_match: RedskilledStatuslineProjectMatch;
-  /** The daemon's version — the one version this process can honestly state. */
+  /** The daemon's version — the one version the answering process can state. */
   readonly version: string;
   /**
    * Which engine answered and whether it is current; `null` on an older daemon.
@@ -117,9 +115,9 @@ export interface RedskilledDashboardHeader {
    * with no interpretation, and this is the comparison behind the `⇡`. A `null`
    * here is "this daemon predates the block", never "it is up to date".
    */
-  readonly engine: RedskilledStatuslineEngine | null;
+  readonly engine: RedskilledRenderEngine | null;
   /** What this host could not explain; `null` when nothing has reaped. */
-  readonly deaths: RedskilledStatuslineDeaths | null;
+  readonly deaths: RedskilledRenderDeaths | null;
   /**
    * The rates the daemon derived; `null` on a daemon that derives none.
    *
@@ -128,7 +126,7 @@ export interface RedskilledDashboardHeader {
    * and a surface printing the line gets whatever the width allowed. `null` here
    * is "this daemon has no metrics block", never "this machine did nothing".
    */
-  readonly metrics: RedskilledStatuslineMetrics | null;
+  readonly metrics: RedskilledRenderMetrics | null;
   /** `runner model effort`, from the first Worker that published one; else `null`. */
   readonly model: string | null;
   readonly windows: RedskilledDashboardWindows;
@@ -177,9 +175,6 @@ export const REDSKILLED_DASHBOARD_DEFAULTS: RedskilledDashboardOptions = {
   maxRows: 16,
 };
 
-/** What a surface prints when nothing answered. PURE. */
-export const REDSKILLED_DASHBOARD_ABSENCE = "redskilled unreachable — Worker state unknown";
-
 const GUTTER = "  ";
 const BAR_DONE = "█";
 const BAR_CURSOR = "▶";
@@ -195,11 +190,11 @@ const BAR_AHEAD = "░";
  * are the ones that make the remainder attributable.
  */
 export function renderRedskilledDashboard(
-  payload: RedskilledStatuslinePayload,
+  payload: RedskilledRenderPayload,
   options: RedskilledDashboardOptions = REDSKILLED_DASHBOARD_DEFAULTS,
 ): RedskilledDashboard {
   const match = resolveStatuslineProjectMatch(payload, options.project);
-  const selected = selectWorkers(payload, options);
+  const selected = selectRenderWorkers(payload, options);
   const visible = selected.slice(0, Math.max(0, Math.floor(options.maxRows)));
   const cells = visible.map((worker) => workerCells(worker, options));
   const widths = columnWidths(cells);
@@ -244,23 +239,6 @@ export function renderRedskilledDashboard(
 }
 
 /**
- * The Workers this view is about.
- *
- * The same selection the statusline makes, and deliberately so: a dashboard that
- * listed a different set than the line above it would be the second authority
- * both surfaces exist to avoid. A local session that declared no project shows
- * none — the header still carries the host total, so the view stays truthful.
- */
-function selectWorkers(
-  payload: RedskilledStatuslinePayload,
-  options: RedskilledDashboardOptions,
-): readonly RedskilledStatuslineWorker[] {
-  if (options.mode === "global") return payload.workers;
-  if (options.project == null) return [];
-  return payload.workers.filter((worker) => worker.project_label === options.project);
-}
-
-/**
  * One Worker's cells, in the statusline's own vocabulary. PURE.
  *
  * A field the project never published renders as an EMPTY cell rather than as a
@@ -268,10 +246,10 @@ function selectWorkers(
  * publishes no display record has spent an unknown amount.
  */
 function workerCells(
-  worker: RedskilledStatuslineWorker,
+  worker: RedskilledRenderWorker,
   options: RedskilledDashboardOptions,
 ): RedskilledDashboardCells {
-  const display = worker.display ?? REDSKILLED_WORKER_DISPLAY_ABSENT;
+  const display = worker.display ?? REDSKILLED_RENDER_DISPLAY_ABSENT;
   const run = [display.runner, display.model, display.effort].filter((part): part is string => Boolean(part)).join(" ");
   return {
     wid: options.mode === "global" ? `${worker.project_label}:${worker.worker_id}` : worker.worker_id,
@@ -295,9 +273,9 @@ function workerCells(
  *
  * `index` completed cells, one cursor, and the rest ahead. A project that
  * published no position gets no bar at all — a bar with an invented cursor would
- * put a Worker somewhere in a pipeline this process cannot see.
+ * put a Worker somewhere in a pipeline this module cannot see.
  */
-export function progressBar(display: RedskilledWorkerDisplay): string {
+export function progressBar(display: RedskilledRenderWorkerDisplay): string {
   const total = display.phase_total;
   const index = display.phase_index;
   if (total == null || total <= 0 || index == null || index < 0) return "";
@@ -316,9 +294,9 @@ export function progressBar(display: RedskilledWorkerDisplay): string {
  * alone.
  */
 function buildHeader(
-  payload: RedskilledStatuslinePayload,
+  payload: RedskilledRenderPayload,
   options: RedskilledDashboardOptions,
-  selected: readonly RedskilledStatuslineWorker[],
+  selected: readonly RedskilledRenderWorker[],
   match: RedskilledStatuslineProjectMatch,
 ): RedskilledDashboardHeader {
   const activity = (payload.repository_activity?.projects ?? []).find(
@@ -349,7 +327,7 @@ function buildHeader(
   // surface reading `v3.1.0` on its own cannot tell a current daemon from one
   // three releases behind, and that is the whole of "is my engine current".
   const parts: string[] = [
-    `» ${repo ?? "host"} v${version}${engine != null && engine.current === false ? DASHBOARD_ENGINE_BEHIND_MARK : ""}`,
+    `» ${repo ?? "host"} v${version}${engine != null && engine.current === false ? ENGINE_BEHIND_MARK : ""}`,
   ];
   if (match === "unregistered") parts.push("!unregistered");
   if (match === "name-only") parts.push("!lapsed");
@@ -373,7 +351,7 @@ function buildHeader(
   // about the machine and not about one project's Workers — and the header is
   // the whole of what a status bar shows.
   if (deaths != null && deaths.count > 0 && deaths.latest != null) {
-    parts.push(`${DASHBOARD_DEATH_MARK}${deaths.count} ${deaths.latest.sender_class}`);
+    parts.push(`${DEATH_MARK}${deaths.count} ${deaths.latest.sender_class}`);
   }
   if (payload.staleness.stale) {
     const age = payload.staleness.age_ms;
@@ -420,7 +398,7 @@ function buildHeader(
  * must not assert the wrong one. A window that derived nothing at all yields
  * `null` here and costs the line no characters.
  */
-export function compactRates(window: RedskilledMetricsWindow): string | null {
+export function compactRates(window: RedskilledRenderMetricsWindow): string | null {
   const parts: string[] = [];
   if (window.tokens_per_min.value != null) parts.push(`tk/m=${formatRate(window.tokens_per_min.value)}`);
   if (window.tools_per_min.value != null) parts.push(`tl/m=${formatRate(window.tools_per_min.value)}`);
@@ -430,6 +408,26 @@ export function compactRates(window: RedskilledMetricsWindow): string | null {
   const leader = window.runner_share.shares[0];
   if (leader != null) parts.push(`${leader.key}=${Math.round(leader.share * 100)}%`);
   return parts.length === 0 ? null : parts.join(" ");
+}
+
+/**
+ * The budget posture, drawn only when it is something an operator must act on.
+ *
+ * An `open` balance draws nothing: a line that is always there is a line nobody
+ * reads, and the whole value of this one is that its presence means something.
+ * `unknown` is silent for the same reason it opens the gate — the daemon has not
+ * asked, which is a fact about the observer and not about the token.
+ */
+function balanceLines(
+  payload: RedskilledRenderPayload,
+  options: RedskilledDashboardOptions,
+): readonly string[] {
+  const balance = payload.github_balance;
+  if (balance == null) return [];
+  if (balance.posture !== "spent" && balance.posture !== "reserved") return [];
+  const mark = balance.posture === "spent" ? BUDGET_SPENT_MARK : BUDGET_BAND_MARK;
+  const age = balance.age_ms == null ? "" : ` (${Math.round(balance.age_ms / 1000)}s ago)`;
+  return [clamp(`${mark} github budget ${balance.posture}${age} — ${balance.reason}`, options.maxWidth)];
 }
 
 /**
@@ -444,35 +442,15 @@ export function compactRates(window: RedskilledMetricsWindow): string | null {
  * Nothing is drawn when the block is absent or empty — a dashboard that printed
  * `deaths 0` would spend a row telling a healthy machine it is healthy.
  */
-/**
- * The budget posture, drawn only when it is something an operator must act on.
- *
- * An `open` balance draws nothing: a line that is always there is a line nobody
- * reads, and the whole value of this one is that its presence means something.
- * `unknown` is silent for the same reason it opens the gate — the daemon has not
- * asked, which is a fact about the observer and not about the token.
- */
-function balanceLines(
-  payload: RedskilledStatuslinePayload,
-  options: RedskilledDashboardOptions,
-): readonly string[] {
-  const balance = payload.github_balance;
-  if (balance == null) return [];
-  if (balance.posture !== "spent" && balance.posture !== "reserved") return [];
-  const mark = balance.posture === "spent" ? DASHBOARD_BUDGET_SPENT_MARK : DASHBOARD_BUDGET_BAND_MARK;
-  const age = balance.age_ms == null ? "" : ` (${Math.round(balance.age_ms / 1000)}s ago)`;
-  return [clamp(`${mark} github budget ${balance.posture}${age} — ${balance.reason}`, options.maxWidth)];
-}
-
 function deathLines(
-  payload: RedskilledStatuslinePayload,
+  payload: RedskilledRenderPayload,
   options: RedskilledDashboardOptions,
 ): readonly string[] {
   const deaths = payload.deaths;
   if (deaths == null || deaths.count <= 0) return [];
   const lines = deaths.recent.map((death) =>
     clamp(
-      `${DASHBOARD_DEATH_MARK} ${death.kind} ${death.id} pid=${death.pid}` +
+      `${DEATH_MARK} ${death.kind} ${death.id} pid=${death.pid}` +
         ` ${death.sender_class}/${death.confidence} phase=${death.last_phase}` +
         (death.signal == null ? "" : ` signal=${death.signal}`) +
         (death.evidence == null ? "" : ` — ${death.evidence}`),
@@ -503,7 +481,7 @@ function memoryWindow(windows: RedskilledDashboardWindows): string {
  * answer, and a header that invented one would be stating something no Worker
  * said. The per-Worker `run=` cells carry the truth for each row.
  */
-function firstPublishedModel(workers: readonly RedskilledStatuslineWorker[]): string | null {
+function firstPublishedModel(workers: readonly RedskilledRenderWorker[]): string | null {
   for (const worker of workers) {
     const display = worker.display;
     if (display == null) continue;
@@ -520,48 +498,6 @@ function formatSignedPair(added: number | null, removed: number | null): string 
   if (added != null && added > 0) parts.push(`+${added}`);
   if (removed != null && removed > 0) parts.push(`-${removed}`);
   return `loc=${parts.length > 0 ? parts.join(" ") : "0"}`;
-}
-
-/** A count at dashboard resolution: at most one decimal, no trailing `.0`. PURE. */
-export function formatCount(value: number): string {
-  if (!Number.isFinite(value) || value <= 0) return "0";
-  const scale = (scaled: number, suffix: string): string => {
-    const text = (Math.round(scaled * 10) / 10).toFixed(1);
-    return `${text.endsWith(".0") ? text.slice(0, -2) : text}${suffix}`;
-  };
-  if (value >= 1e9) return scale(value / 1e9, "B");
-  if (value >= 1e6) return scale(value / 1e6, "M");
-  if (value >= 1e3) return scale(value / 1e3, "k");
-  return String(Math.round(value));
-}
-
-/**
- * A rate at dashboard resolution, keeping the digit that survives rounding. PURE.
- *
- * `formatCount` rounds a small figure to a whole number, which turns a real
- * `0.4 issues/hour` into a `0` indistinguishable from an idle machine — the one
- * confusion every surface here exists to prevent. Below ten the first decimal is
- * kept; above it the count formatting takes over, because nobody reads the tenth
- * of a thousand tokens per minute.
- */
-export function formatRate(value: number): string {
-  if (!Number.isFinite(value)) return "—";
-  if (value >= 10) return formatCount(value);
-  if (value <= 0) return "0";
-  const text = (Math.round(value * 10) / 10).toFixed(1);
-  return text.endsWith(".0") ? text.slice(0, -2) : text;
-}
-
-/** An elapsed span in the two most significant units; `—` when unstated. PURE. */
-export function formatDuration(ms: number | null): string {
-  if (ms == null || !Number.isFinite(ms) || ms < 0) return "—";
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m${seconds % 60}s`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h${minutes % 60}m`;
-  return `${Math.floor(hours / 24)}d${hours % 24}h`;
 }
 
 /**
@@ -614,21 +550,4 @@ function formatRow(
     pad(cells[column], widths[column]),
   );
   return parts.join(GUTTER).replace(/\s+$/, "");
-}
-
-function pad(text: string, target: number): string {
-  return text + " ".repeat(Math.max(0, target - width(text)));
-}
-
-/** The visible width. One character is one column here — no line carries ANSI. */
-function width(line: string): number {
-  return [...line].length;
-}
-
-function clamp(line: string, maxWidth: number): string {
-  if (maxWidth <= 0) return "";
-  const chars = [...line];
-  if (chars.length <= maxWidth) return line;
-  if (maxWidth === 1) return "…";
-  return `${chars.slice(0, maxWidth - 1).join("")}…`;
 }

--- a/packages/redskilled-render/decode.ts
+++ b/packages/redskilled-render/decode.ts
@@ -1,0 +1,152 @@
+/**
+ * decode — one payload, whatever encoding it arrived in.
+ *
+ * **The render is encoding-agnostic on the way IN** (ADR 0132 decision 1). The
+ * same module has to serve a socket read, a piped file and a checked-in fixture,
+ * and those three arrive as JSON, as TOON and as a single line of either; a
+ * renderer that accepted only one of them would push a decoder into every surface
+ * that wanted to draw from a file. The repo's TOON mandate governs WRITERS and is
+ * untouched by this: what a reader tolerates and what a writer must emit are
+ * different contracts, and conflating them is what makes a fixture unreadable.
+ *
+ * **A line-delimited lane yields its LAST complete record.** A `.toonl` or
+ * `.jsonl` file of payload snapshots is a history, and the thing a surface draws
+ * is the newest one; earlier rows are returned beside it so a caller that wants
+ * the history has it without parsing twice.
+ *
+ * **A torn tail is skipped, never fatal.** These lanes are append-only and a
+ * reader can land mid-write. A decoder that threw on the last half-written row
+ * would blank a surface over a race that resolves itself on the next tick.
+ *
+ * PURE: text in, values out. Nothing here opens a file or a socket.
+ */
+import { decode as decodeToon } from "@reddb-io/toon";
+import { isRedskilledRenderPayload, type RedskilledRenderPayload } from "./payload.js";
+
+/** Which encoding a document turned out to be, stated rather than guessed twice. */
+export type RedskilledRenderEncoding = "json" | "jsonl" | "toon" | "toonl";
+
+export interface RedskilledRenderDecoded {
+  /** The record a surface draws — the last complete one in a line-delimited lane. */
+  readonly payload: RedskilledRenderPayload;
+  readonly encoding: RedskilledRenderEncoding;
+  /** Every record the document held, oldest first; one entry for a snapshot. */
+  readonly records: readonly RedskilledRenderPayload[];
+}
+
+/**
+ * The reason a document could not be drawn, as a sentence a surface can print.
+ *
+ * An Error rather than a `null` return: "this text is not a payload" and "this
+ * payload has no Workers" are opposite facts, and a decoder that answered both
+ * with an absence would let an unparseable document render as an idle machine.
+ */
+export class RedskilledRenderDecodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RedskilledRenderDecodeError";
+  }
+}
+
+/**
+ * Decode one payload document. PURE.
+ *
+ * Accepts the already-parsed value too, because the socket path has one: a client
+ * that decoded the frame itself must not have to re-encode it to reach the same
+ * render.
+ */
+export function decodeRedskilledPayload(input: string | unknown): RedskilledRenderDecoded {
+  if (typeof input !== "string") {
+    if (!isRedskilledRenderPayload(input)) {
+      throw new RedskilledRenderDecodeError("the value handed to the render is not a redskilled statusline payload");
+    }
+    return { payload: input, encoding: "json", records: [input] };
+  }
+
+  const text = input.trim();
+  if (text === "") throw new RedskilledRenderDecodeError("the document handed to the render is empty");
+
+  // A snapshot first, because a whole-document parse is the unambiguous case: a
+  // JSON object and a TOON block both decode in one call, and only when neither
+  // does is the document worth reading as a lane of lines.
+  const snapshot = decodeSnapshot(text);
+  if (snapshot != null) return snapshot;
+
+  const lane = decodeLane(text);
+  if (lane != null) return lane;
+
+  throw new RedskilledRenderDecodeError(
+    "the document handed to the render decoded as neither JSON, JSONL, TOON nor TOONL — or held no payload record",
+  );
+}
+
+/** A whole-document parse, in either encoding; `null` when it is not one. */
+function decodeSnapshot(text: string): RedskilledRenderDecoded | null {
+  if (text.startsWith("{")) {
+    const value = tryJson(text);
+    if (isRedskilledRenderPayload(value)) return { payload: value, encoding: "json", records: [value] };
+    // A single JSON object that is NOT a payload is still a decisive answer; it
+    // falls through so the caller gets the "not a payload" sentence rather than a
+    // TOON parse error about a brace.
+    if (value !== undefined) return null;
+  }
+  const toon = tryToon(text);
+  if (isRedskilledRenderPayload(toon)) return { payload: toon, encoding: "toon", records: [toon] };
+  return null;
+}
+
+/**
+ * A line-delimited lane, in either encoding; `null` when no row is a payload.
+ *
+ * TOONL rows share one header line, so a row is decoded by pairing it with the
+ * header that preceded it — the same reading the repo's other TOONL lanes use.
+ */
+function decodeLane(text: string): RedskilledRenderDecoded | null {
+  const records: RedskilledRenderPayload[] = [];
+  let sawToonRow = false;
+  let header = "";
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line === "") continue;
+    if (line.startsWith("{")) {
+      const value = tryJson(line);
+      if (isRedskilledRenderPayload(value)) records.push(value);
+      continue;
+    }
+    if (/^\[(?:[0-9]+)?\](?:\{[^}]+\}:|:)$/.test(line)) {
+      header = line;
+      continue;
+    }
+    if (header === "") continue;
+    // A count in the header describes the whole lane, not this row, so it is
+    // normalized to one: decoding a single row against `[42]` fails on a document
+    // that is otherwise perfectly readable.
+    const value = tryToon(`${header.replace(/^\[(?:[0-9]+)?\]/, "[1]")}\n${line}\n`);
+    const row = Array.isArray(value) ? value[0] : value;
+    if (isRedskilledRenderPayload(row)) {
+      records.push(row);
+      sawToonRow = true;
+    }
+  }
+  const payload = records[records.length - 1];
+  if (payload == null) return null;
+  return { payload, encoding: sawToonRow ? "toonl" : "jsonl", records };
+}
+
+/** `undefined` when the text is not JSON at all — never a thrown parse error. */
+function tryJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/** `undefined` when the text is not TOON at all — never a thrown parse error. */
+function tryToon(text: string): unknown {
+  try {
+    return decodeToon(text);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/redskilled-render/format.ts
+++ b/packages/redskilled-render/format.ts
@@ -1,0 +1,121 @@
+/**
+ * format — the sentence-level primitives every density shares.
+ *
+ * **One spelling per figure, whatever draws it.** A line saying `14.4M` and a
+ * table saying `14.36 MiB` for the same byte count is the drift this whole module
+ * exists to end, so the formatters live once and are imported rather than
+ * restated. They are the smallest pieces of layout there are, which is exactly
+ * why four copies of them appeared before anyone noticed.
+ *
+ * PURE, to the last function: nothing here reads a clock, a directory or an
+ * environment variable.
+ */
+
+/** The visible width. One character is one column here — no line carries ANSI. */
+export function width(line: string): number {
+  return [...line].length;
+}
+
+/**
+ * A line cut to fit, with the cut made visible.
+ *
+ * The ellipsis is kept even at the tightest budget, because a line that ends
+ * mid-word and says nothing about it reads as a shorter fact rather than as a
+ * truncated one.
+ */
+export function clamp(line: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  const chars = [...line];
+  if (chars.length <= maxWidth) return line;
+  if (maxWidth === 1) return "…";
+  return `${chars.slice(0, maxWidth - 1).join("")}…`;
+}
+
+/** One cell padded to a column width. PURE. */
+export function pad(text: string, target: number): string {
+  return text + " ".repeat(Math.max(0, target - width(text)));
+}
+
+/**
+ * Bytes at statusline resolution: three significant characters, never more.
+ *
+ * Exactness is the payload's job. A line that read `1.234567G` would spend the
+ * width it does not have on precision nobody acts on.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0B";
+  const units = ["B", "K", "M", "G", "T"] as const;
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  const rendered = value >= 100 || unit === 0 ? Math.round(value).toString() : value.toFixed(1).replace(/\.0$/, "");
+  return `${rendered}${units[unit]}`;
+}
+
+/** A count at dashboard resolution: at most one decimal, no trailing `.0`. PURE. */
+export function formatCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  const scale = (scaled: number, suffix: string): string => {
+    const text = (Math.round(scaled * 10) / 10).toFixed(1);
+    return `${text.endsWith(".0") ? text.slice(0, -2) : text}${suffix}`;
+  };
+  if (value >= 1e9) return scale(value / 1e9, "B");
+  if (value >= 1e6) return scale(value / 1e6, "M");
+  if (value >= 1e3) return scale(value / 1e3, "k");
+  return String(Math.round(value));
+}
+
+/**
+ * A rate at dashboard resolution, keeping the digit that survives rounding. PURE.
+ *
+ * `formatCount` rounds a small figure to a whole number, which turns a real
+ * `0.4 issues/hour` into a `0` indistinguishable from an idle machine — the one
+ * confusion every surface here exists to prevent. Below ten the first decimal is
+ * kept; above it the count formatting takes over, because nobody reads the tenth
+ * of a thousand tokens per minute.
+ */
+export function formatRate(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  if (value >= 10) return formatCount(value);
+  if (value <= 0) return "0";
+  const text = (Math.round(value * 10) / 10).toFixed(1);
+  return text.endsWith(".0") ? text.slice(0, -2) : text;
+}
+
+/** An elapsed span in the two most significant units; `—` when unstated. PURE. */
+export function formatDuration(ms: number | null): string {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return "—";
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h${minutes % 60}m`;
+  return `${Math.floor(hours / 24)}d${hours % 24}h`;
+}
+
+/** An age in whole seconds, the way every density states one. PURE. */
+export function formatAgeSeconds(ageMs: number | null): string | null {
+  if (ageMs == null || !Number.isFinite(ageMs)) return null;
+  return `${Math.round(ageMs / 1000)}s`;
+}
+
+/**
+ * A published line reduced to something that fits on one row. PURE.
+ *
+ * Whitespace — a newline included — is collapsed rather than escaped, and control
+ * characters are dropped: the daemon stored the string a Worker published
+ * verbatim, and this is the last moment before it becomes a terminal's line.
+ * Returns `null` when nothing survives, which is the same absence as no publish.
+ */
+export function flattenPublishedLine(line: string | null | undefined): string | null {
+  if (line == null) return null;
+  const collapsed = line
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return collapsed === "" ? null : collapsed;
+}

--- a/packages/redskilled-render/index.ts
+++ b/packages/redskilled-render/index.ts
@@ -1,0 +1,171 @@
+/**
+ * @reddb-io/redskilled-render — one render implementation, drawn at parameterized
+ * densities.
+ *
+ * **The no-drift guarantee is one implementation, not one string** (ADR 0132
+ * decision 1). ADR 0130 rule 10 had moved rendering into the daemon so that "the
+ * string is a pure function of the payload" would keep surfaces from drifting;
+ * what that bought was a statusline poorer than the one it replaced, because a
+ * single rendered string cannot serve a one-line statusline and a full TUI at
+ * once. This module amends the letter of that rule to serve its intent: the
+ * layout lives in exactly one place, and each surface asks it for the density it
+ * has room for.
+ *
+ * **Stateless, and it opens no transport.** A pure function from one decoded
+ * payload to one drawn surface, so the same module serves a socket read, a piped
+ * file and a checked-in fixture — and a fixture payload renders byte-identically
+ * to a live one. Nothing here reads a clock, a directory, an environment variable
+ * or a file descriptor.
+ *
+ * **Three densities, composed rather than duplicated.** `line` is the statusline;
+ * `panel` is the middle height, whose first row IS the line; `dashboard` is the
+ * table. The degradation ladder, the selection and the marks are shared by all
+ * three, which is what makes "they cannot drift" rest on code instead of on a
+ * shared string.
+ */
+export {
+  decodeRedskilledPayload,
+  RedskilledRenderDecodeError,
+  type RedskilledRenderDecoded,
+  type RedskilledRenderEncoding,
+} from "./decode.js";
+
+export {
+  clamp,
+  flattenPublishedLine,
+  formatAgeSeconds,
+  formatBytes,
+  formatCount,
+  formatDuration,
+  formatRate,
+  pad,
+  width,
+} from "./format.js";
+
+export {
+  BUDGET_BAND_MARK,
+  BUDGET_SPENT_MARK,
+  DEATH_MARK,
+  ENGINE_BEHIND_MARK,
+  LOG_LINE_MARK,
+  REDSKILLED_RENDER_ABSENCE,
+  UNREGISTERED_MARK,
+} from "./marks.js";
+
+export * from "./payload.js";
+
+export {
+  detailLadder,
+  resolveStatuslineProjectMatch,
+  selectRenderProjects,
+  selectRenderWorkers,
+  type RedskilledStatuslineDetail,
+  type RedskilledStatuslineProjectMatch,
+} from "./select.js";
+
+export {
+  redskilledStatuslineBound,
+  redskilledStatuslineCharacters,
+  REDSKILLED_STATUSLINE_DEFAULTS,
+  renderRedskilledStatusline,
+  renderRedskilledStatuslineAbsence,
+  workerName,
+  type RedskilledStatuslineBound,
+  type RedskilledStatuslineOptions,
+  type RedskilledStatuslineRender,
+} from "./line.js";
+
+export {
+  REDSKILLED_PANEL_DEFAULTS,
+  renderRedskilledPanel,
+  type RedskilledPanel,
+  type RedskilledPanelOptions,
+} from "./panel.js";
+
+export {
+  compactRates,
+  isRedskilledDashboard,
+  progressBar,
+  REDSKILLED_DASHBOARD_COLUMNS,
+  REDSKILLED_DASHBOARD_DEFAULTS,
+  renderRedskilledDashboard,
+  type RedskilledDashboard,
+  type RedskilledDashboardCells,
+  type RedskilledDashboardColumn,
+  type RedskilledDashboardCounts,
+  type RedskilledDashboardHeader,
+  type RedskilledDashboardOptions,
+  type RedskilledDashboardRow,
+  type RedskilledDashboardWindows,
+} from "./dashboard.js";
+
+import { decodeRedskilledPayload } from "./decode.js";
+import {
+  REDSKILLED_DASHBOARD_DEFAULTS,
+  renderRedskilledDashboard,
+  type RedskilledDashboard,
+  type RedskilledDashboardOptions,
+} from "./dashboard.js";
+import {
+  REDSKILLED_STATUSLINE_DEFAULTS,
+  renderRedskilledStatusline,
+  type RedskilledStatuslineOptions,
+  type RedskilledStatuslineRender,
+} from "./line.js";
+import {
+  REDSKILLED_PANEL_DEFAULTS,
+  renderRedskilledPanel,
+  type RedskilledPanel,
+  type RedskilledPanelOptions,
+} from "./panel.js";
+
+/** How much of the machine a surface has room to draw. */
+export type RedskilledRenderDensity = "line" | "panel" | "dashboard";
+
+/**
+ * One request to draw, at one density.
+ *
+ * A discriminated union rather than one options record with every field on it:
+ * `maxWorkers` is meaningless to a table and `maxRows` is meaningless to a line,
+ * and an options bag carrying both would let a caller set the one its density
+ * ignores and believe it took effect.
+ */
+export type RedskilledRenderRequest =
+  | { readonly density: "line"; readonly options?: Partial<RedskilledStatuslineOptions> }
+  | { readonly density: "panel"; readonly options?: Partial<RedskilledPanelOptions> }
+  | { readonly density: "dashboard"; readonly options?: Partial<RedskilledDashboardOptions> };
+
+/** What one density drew, tagged so a caller need not re-derive which it asked for. */
+export type RedskilledRendered =
+  | { readonly density: "line"; readonly render: RedskilledStatuslineRender; readonly lines: readonly string[] }
+  | { readonly density: "panel"; readonly render: RedskilledPanel; readonly lines: readonly string[] }
+  | { readonly density: "dashboard"; readonly render: RedskilledDashboard; readonly lines: readonly string[] };
+
+/**
+ * Draw one payload at one density. PURE.
+ *
+ * **The one entry point, so a surface names a density rather than a module.** A
+ * caller that imported `renderRedskilledDashboard` directly is doing nothing
+ * wrong — the densities are public — but a surface whose height is configuration
+ * (a pane an operator resizes, a tooltip that expands) needs to choose at run
+ * time, and choosing between three imports is how a fourth layout gets written.
+ *
+ * `input` is text or an already-decoded value: the socket path holds a parsed
+ * frame and a fixture path holds bytes, and both reach the same render.
+ */
+export function renderRedskilled(
+  input: string | unknown,
+  request: RedskilledRenderRequest = { density: "line" },
+): RedskilledRendered {
+  const { payload } = decodeRedskilledPayload(input);
+  if (request.density === "dashboard") {
+    const render = renderRedskilledDashboard(payload, { ...REDSKILLED_DASHBOARD_DEFAULTS, ...request.options });
+    return { density: "dashboard", render, lines: render.lines };
+  }
+  if (request.density === "panel") {
+    const render = renderRedskilledPanel(payload, { ...REDSKILLED_PANEL_DEFAULTS, ...request.options });
+    return { density: "panel", render, lines: render.lines };
+  }
+  const render = renderRedskilledStatusline(payload, { ...REDSKILLED_STATUSLINE_DEFAULTS, ...request.options });
+  return { density: "line", render, lines: render.lines };
+}

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -1,14 +1,13 @@
 /**
- * statusline-render — the finished line, and nothing behind it.
+ * line — the statusline density: one row, and nothing behind it.
  *
  * **The string is a pure function of the payload.** That purity is the whole
- * mitigation for having two surfaces at all (ADR 0130 rule 10): a renderer that
- * could reach for one extra fact — a directory listing, a clock, an environment
- * variable — would be a second authority on a question the payload already
- * answers, and the two surfaces would eventually describe different machines.
- * Everything this function needs is an argument, so a test can prove the string
- * the daemon serves is the string this function computes from the payload the
- * daemon serves alongside it.
+ * mitigation for having four surfaces at all (ADR 0132 decision 1): a renderer
+ * that could reach for one extra fact — a directory listing, a clock, an
+ * environment variable — would be a second authority on a question the payload
+ * already answers, and the surfaces would eventually describe different machines.
+ * Everything this function needs is an argument, so a fixture payload renders
+ * byte-identically to a live one.
  *
  * **The default mode is quiet: only the local project's Workers.** The common
  * case is one operator in one repository, and a line that listed every project
@@ -31,42 +30,30 @@
  * project, and when the projects do not fit it drops to the host total — losing
  * detail on purpose, never losing the line.
  */
+import { clamp, flattenPublishedLine, formatBytes, width } from "./format.js";
+import {
+  BUDGET_BAND_MARK,
+  BUDGET_SPENT_MARK,
+  DEATH_MARK,
+  ENGINE_BEHIND_MARK,
+  LOG_LINE_MARK,
+  REDSKILLED_RENDER_ABSENCE,
+  UNREGISTERED_MARK,
+} from "./marks.js";
 import type {
-  RedskilledStatuslinePayload,
-  RedskilledStatuslineProject,
-  RedskilledStatuslineWorker,
-} from "./statusline-payload.js";
-
-/** Which Workers the line is about. */
-export type RedskilledStatuslineMode = "local" | "global";
-
-/** How much detail survived the width and count budgets. */
-export type RedskilledStatuslineDetail = "workers" | "projects" | "host";
-
-/**
- * Whether the calling directory's project is one this host knows.
- *
- * Three states rather than a boolean, because the two failures need different
- * sentences: a directory that resolved to no project at all has nothing to look
- * up, while one that resolved to `acme/widgets` and found no such project on the
- * host has a name to put in front of the operator. Collapsing either into
- * `matched` is how "the host holds three of your Workers" renders as `0w`.
- */
-export type RedskilledStatuslineProjectMatch =
-  | "matched"
-  /**
-   * The host knows this label, and holds no registration for it.
-   *
-   * A name is not a state (#2973). A project whose registration lapsed while a
-   * Worker of its own is still finishing is still *known* — the label is on the
-   * Worker — but nothing will be born for it again, so rendering it as a matched
-   * project is rendering a stopped drain as a healthy one.
-   */
-  | "name-only"
-  | "unregistered"
-  | "unresolved"
-  /** No daemon answered, so whether this host knows the project is unknowable. */
-  | "unanswered";
+  RedskilledRenderPayload,
+  RedskilledRenderProject,
+  RedskilledRenderWorker,
+  RedskilledStatuslineMode,
+} from "./payload.js";
+import {
+  detailLadder,
+  resolveStatuslineProjectMatch,
+  selectRenderProjects,
+  selectRenderWorkers,
+  type RedskilledStatuslineDetail,
+  type RedskilledStatuslineProjectMatch,
+} from "./select.js";
 
 export interface RedskilledStatuslineOptions {
   readonly mode: RedskilledStatuslineMode;
@@ -88,7 +75,7 @@ export interface RedskilledStatuslineOptions {
  *
  * `detail` is stated rather than inferred from the text: a consumer that had to
  * detect degradation by counting separators would be parsing the rendered line,
- * which is the failure this whole tool exists to remove.
+ * which is the failure this whole module exists to remove.
  */
 export interface RedskilledStatuslineRender {
   readonly version: 1;
@@ -139,15 +126,21 @@ export const REDSKILLED_STATUSLINE_DEFAULTS: RedskilledStatuslineOptions = {
  * memory figure is worse than an honest aggregate.
  */
 export function renderRedskilledStatusline(
-  payload: RedskilledStatuslinePayload,
+  payload: RedskilledRenderPayload,
   options: RedskilledStatuslineOptions = REDSKILLED_STATUSLINE_DEFAULTS,
 ): RedskilledStatuslineRender {
-  const match = resolveProjectMatch(payload, options);
-  const workers = selectWorkers(payload, options);
-  const projects = selectProjects(payload, options);
+  const match = resolveStatuslineProjectMatch(payload, options.project);
+  const workers = selectRenderWorkers(payload, options);
+  const projects = selectRenderProjects(payload, options);
   const head = renderHead(payload, options, workers, match);
 
-  const ladder = detailLadder(options, workers, projects);
+  const ladder = detailLadder({
+    mode: options.mode,
+    maxWorkers: options.maxWorkers,
+    maxProjects: options.maxProjects,
+    workers,
+    projects,
+  });
   let chosen: { detail: RedskilledStatuslineDetail; line: string } = {
     detail: "host",
     line: head,
@@ -241,7 +234,7 @@ export function renderRedskilledStatuslineAbsence(input: {
   readonly generated_at: string;
 }): RedskilledStatuslineRender {
   const options = input.options ?? REDSKILLED_STATUSLINE_DEFAULTS;
-  const line = clamp(REDSKILLED_STATUSLINE_ABSENCE, options.maxWidth);
+  const line = clamp(REDSKILLED_RENDER_ABSENCE, options.maxWidth);
   return {
     version: 1,
     line,
@@ -259,139 +252,15 @@ export function renderRedskilledStatuslineAbsence(input: {
   };
 }
 
-/**
- * The mark a known-by-name project carries, and the reason it carries one.
- *
- * `!` for the same reason the staleness mark has one: it is a state the operator
- * has to act on, not a detail, and it must survive being read at a glance next to
- * a Worker count that looks perfectly healthy. One word, because the head is the
- * part of the line that never degrades — a sentence here would push the Workers
- * off a narrow terminal to say something `project_status` says in full.
- */
-export const UNREGISTERED_MARK = "!unregistered";
-
-/** What a daemon that is not the current one appends to its version. */
-export const ENGINE_BEHIND_MARK = "⇡";
-
-/**
- * What a posed death is marked with — a dagger, and never a word.
- *
- * The head is the part of the line that never degrades, so a death has to fit
- * beside a Worker count on a narrow terminal; the class that follows is the
- * reason, and the lane holds the receipt.
- */
-export const DEATH_MARK = "†";
-
-/**
- * What a budget inside the reserved band is marked with, and what a spent one is.
- *
- * Two marks rather than one, because they call for opposite actions: inside the
- * band the machine is still landing work and refusing only convenience, and spent
- * means nothing goes out until the reset. A surface that drew one symbol for both
- * would make an operator read the sentence to learn which it was.
- */
-export const BUDGET_BAND_MARK = "◐";
-/** What a spent GitHub budget is marked with. */
-export const BUDGET_SPENT_MARK = "◯";
-
-/** The one sentence an unreachable host renders as. */
-export const REDSKILLED_STATUSLINE_ABSENCE = "redskilled unreachable — Worker state unknown";
-
-/**
- * The detail levels this render may use, richest first.
- *
- * A level whose count budget is already blown is never attempted: the budgets
- * are the operator's declared taste, and honouring them only when the line
- * happens to be long would make the setting mean nothing on a wide terminal.
- */
-function detailLadder(
-  options: RedskilledStatuslineOptions,
-  workers: readonly RedskilledStatuslineWorker[],
-  projects: readonly RedskilledStatuslineProject[],
-): readonly RedskilledStatuslineDetail[] {
-  const ladder: RedskilledStatuslineDetail[] = [];
-  if (workers.length > 0 && workers.length <= options.maxWorkers) ladder.push("workers");
-  // The local mode holds one project by construction, so a per-project line
-  // would repeat the head verbatim. Only `global` has an aggregate worth a step.
-  if (options.mode === "global" && projects.length > 0 && projects.length <= options.maxProjects) {
-    ladder.push("projects");
-  }
-  ladder.push("host");
-  return ladder;
-}
-
 function body(
   detail: RedskilledStatuslineDetail,
   options: RedskilledStatuslineOptions,
-  workers: readonly RedskilledStatuslineWorker[],
-  projects: readonly RedskilledStatuslineProject[],
+  workers: readonly RedskilledRenderWorker[],
+  projects: readonly RedskilledRenderProject[],
 ): readonly string[] {
   if (detail === "workers") return workers.map((worker) => renderWorker(worker, options));
   if (detail === "projects") return projects.map(renderProject);
   return [];
-}
-
-/**
- * The Workers this line is about.
- *
- * The default mode keeps the session inside its own repository; a session that
- * declared no project has nothing to filter on, and rather than guess it shows
- * none — the head still carries the host total, so the line stays truthful.
- */
-function selectWorkers(
-  payload: RedskilledStatuslinePayload,
-  options: RedskilledStatuslineOptions,
-): readonly RedskilledStatuslineWorker[] {
-  if (options.mode === "global") return payload.workers;
-  if (options.project == null) return [];
-  return payload.workers.filter((worker) => worker.project_label === options.project);
-}
-
-function selectProjects(
-  payload: RedskilledStatuslinePayload,
-  options: RedskilledStatuslineOptions,
-): readonly RedskilledStatuslineProject[] {
-  if (options.mode === "global") return payload.projects;
-  return payload.projects.filter((project) => project.project_label === options.project);
-}
-
-/**
- * Does this host know the project the caller is standing in? PURE.
- *
- * A daemon older than `known_projects` cannot say, and the answer then is
- * `matched`, never a guess at a mismatch: this decides whether an operator is
- * told their project is unregistered, and inventing that from a missing field
- * would put a false accusation on every line a skewed daemon serves.
- */
-function resolveProjectMatch(
-  payload: RedskilledStatuslinePayload,
-  options: RedskilledStatuslineOptions,
-): RedskilledStatuslineProjectMatch {
-  return resolveStatuslineProjectMatch(payload, options.project);
-}
-
-/**
- * The same verdict, for a renderer that is not the statusline. PURE.
- *
- * Exported so the dashboard reaches it by CALLING it rather than by restating
- * it: two renderers with two copies of this ladder is exactly how one surface
- * comes to accuse a project the other calls healthy. It takes the project alone
- * rather than a whole options record, so a caller with different budgets — a
- * table has row counts, a line has widths — can still ask.
- */
-export function resolveStatuslineProjectMatch(
-  payload: RedskilledStatuslinePayload,
-  project: string | null,
-): RedskilledStatuslineProjectMatch {
-  if (project == null) return "unresolved";
-  if (payload.known_projects == null) return "matched";
-  if (!payload.known_projects.includes(project)) return "unregistered";
-  // Known, and possibly known only by NAME. A daemon too old to state its
-  // registrations cannot say which, and the answer then is `matched` for the same
-  // reason it is above: a lapse invented from a missing field would put a false
-  // accusation on every line a skewed daemon serves.
-  if (payload.registered_projects == null) return "matched";
-  return payload.registered_projects.includes(project) ? "matched" : "name-only";
 }
 
 /**
@@ -401,9 +270,9 @@ export function resolveStatuslineProjectMatch(
  * because that is the question the statusline exists to answer.
  */
 function renderHead(
-  payload: RedskilledStatuslinePayload,
+  payload: RedskilledRenderPayload,
   options: RedskilledStatuslineOptions,
-  workers: readonly RedskilledStatuslineWorker[],
+  workers: readonly RedskilledRenderWorker[],
   match: RedskilledStatuslineProjectMatch,
 ): string {
   const parts: string[] = [];
@@ -446,7 +315,7 @@ function renderHead(
  * daemon still states the version it is actually running, since the number a
  * report quotes has to be the one answering the read.
  */
-function engineMark(payload: RedskilledStatuslinePayload): string {
+function engineMark(payload: RedskilledRenderPayload): string {
   const engine = payload.engine;
   const version = engine?.running_version ?? payload.daemon.daemon_version;
   if (engine == null || engine.current !== false) return `v${version}`;
@@ -466,7 +335,7 @@ function engineMark(payload: RedskilledStatuslinePayload): string {
  * about this daemon's polling rather than about the token, which the dashboard
  * has room to say and a head does not.
  */
-function budgetMark(payload: RedskilledStatuslinePayload): string | null {
+function budgetMark(payload: RedskilledRenderPayload): string | null {
   const balance = payload.github_balance;
   if (balance == null) return null;
   if (balance.posture === "spent") return `${BUDGET_SPENT_MARK} quota spent`;
@@ -487,7 +356,7 @@ function budgetMark(payload: RedskilledStatuslinePayload): string | null {
  * `†0` would be a badge for the healthy case, which is how a mark stops being
  * read at all.
  */
-function deathMark(payload: RedskilledStatuslinePayload): string | null {
+function deathMark(payload: RedskilledRenderPayload): string | null {
   const deaths = payload.deaths;
   if (deaths == null || deaths.count <= 0 || deaths.latest == null) return null;
   return `${DEATH_MARK}${deaths.count} ${deaths.latest.sender_class}`;
@@ -514,7 +383,7 @@ function unmatchedHead(project: string | null, match: RedskilledStatuslineProjec
  * quiet line wants to know what *their* repository is spending; the host figure
  * is one mode away.
  */
-function memoryFigure(payload: RedskilledStatuslinePayload, options: RedskilledStatuslineOptions): string {
+function memoryFigure(payload: RedskilledRenderPayload, options: RedskilledStatuslineOptions): string {
   const observed = options.mode === "global"
     ? payload.host.observed_rss_bytes
     : payload.projects
@@ -528,7 +397,7 @@ function memoryFigure(payload: RedskilledStatuslinePayload, options: RedskilledS
 }
 
 /** How old the answer is, in the shortest sentence that stays honest. */
-function stalenessMark(payload: RedskilledStatuslinePayload): string {
+function stalenessMark(payload: RedskilledRenderPayload): string {
   const age = payload.staleness.age_ms;
   return age == null ? "!unmeasured" : `!stale ${Math.round(age / 1000)}s`;
 }
@@ -540,8 +409,8 @@ function stalenessMark(payload: RedskilledStatuslinePayload): string {
  * no vertical dimension to group in, so the owner has to travel with the Worker
  * or it is not shown at all.
  */
-function renderWorker(worker: RedskilledStatuslineWorker, options: RedskilledStatuslineOptions): string {
-  const name = workerName(worker, options);
+function renderWorker(worker: RedskilledRenderWorker, options: RedskilledStatuslineOptions): string {
+  const name = workerName(worker, options.mode);
   const used = worker.vitals.rss_bytes;
   // An unmeasured Worker says so. A zero here would read as an idle Worker, and
   // "nothing measured it" and "it is using nothing" are opposite facts.
@@ -561,79 +430,27 @@ function renderWorker(worker: RedskilledStatuslineWorker, options: RedskilledSta
  * an unlabelled log line would belong to whichever Worker the reader guessed.
  */
 function workerLogLines(
-  workers: readonly RedskilledStatuslineWorker[],
+  workers: readonly RedskilledRenderWorker[],
   options: RedskilledStatuslineOptions,
 ): readonly string[] {
   const lines: string[] = [];
   for (const worker of workers) {
-    const logged = flatten(worker.log.last_line);
+    const logged = flattenPublishedLine(worker.log.last_line);
     if (logged == null) continue;
-    lines.push(clamp(`  ${LOG_LINE_MARK} ${workerName(worker, options)}: ${logged}`, options.maxWidth));
+    lines.push(clamp(`  ${LOG_LINE_MARK} ${workerName(worker, options.mode)}: ${logged}`, options.maxWidth));
   }
   return lines;
 }
 
-/** The mark that says "this line belongs to the entry above it". */
-const LOG_LINE_MARK = "↳";
-
-/**
- * A published line reduced to something that fits on one row. PURE.
- *
- * Whitespace — a newline included — is collapsed rather than escaped, and control
- * characters are dropped: the daemon stored the string a Worker published
- * verbatim, and this is the last moment before it becomes a terminal's line.
- * Returns `null` when nothing survives, which is the same absence as no publish.
- */
-function flatten(line: string | null): string | null {
-  if (line == null) return null;
-  const collapsed = line
-    .replace(/[\u0000-\u001f\u007f]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  return collapsed === "" ? null : collapsed;
+/** How one Worker is named at any density: owner-qualified in `global`. PURE. */
+export function workerName(worker: RedskilledRenderWorker, mode: RedskilledStatuslineMode): string {
+  return mode === "global" ? `${worker.project_label}:${worker.worker_id}` : worker.worker_id;
 }
 
-/** How one Worker is named on this line: owner-qualified in `global`. PURE. */
-function workerName(worker: RedskilledStatuslineWorker, options: RedskilledStatuslineOptions): string {
-  return options.mode === "global" ? `${worker.project_label}:${worker.worker_id}` : worker.worker_id;
-}
-
-function renderProject(project: RedskilledStatuslineProject): string {
+function renderProject(project: RedskilledRenderProject): string {
   return `${project.project_label} ${project.worker_count}w ${formatBytes(project.observed_rss_bytes)}`;
 }
 
 function compose(head: string, body: readonly string[], separator: string): string {
   return [head, ...body].join(separator);
-}
-
-/** The visible width. One character is one column here — the line carries no ANSI. */
-function width(line: string): number {
-  return [...line].length;
-}
-
-function clamp(line: string, maxWidth: number): string {
-  if (maxWidth <= 0) return "";
-  const chars = [...line];
-  if (chars.length <= maxWidth) return line;
-  if (maxWidth === 1) return "…";
-  return `${chars.slice(0, maxWidth - 1).join("")}…`;
-}
-
-/**
- * Bytes at statusline resolution: three significant characters, never more.
- *
- * Exactness is the payload's job. A line that read `1.234567G` would spend the
- * width it does not have on precision nobody acts on.
- */
-export function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return "0B";
-  const units = ["B", "K", "M", "G", "T"] as const;
-  let value = bytes;
-  let unit = 0;
-  while (value >= 1024 && unit < units.length - 1) {
-    value /= 1024;
-    unit += 1;
-  }
-  const rendered = value >= 100 || unit === 0 ? Math.round(value).toString() : value.toFixed(1).replace(/\.0$/, "");
-  return `${rendered}${units[unit]}`;
 }

--- a/packages/redskilled-render/marks.ts
+++ b/packages/redskilled-render/marks.ts
@@ -1,0 +1,49 @@
+/**
+ * marks — the one-character vocabulary every density shares.
+ *
+ * A mark is the cheapest thing a layout owns and the easiest to fork: a line
+ * drawing `†` for a posed death while a table drew `x` would make an operator
+ * learn two alphabets for one machine. They live here so that a density imports
+ * a mark rather than spelling one.
+ */
+
+/**
+ * The mark a known-by-name project carries, and the reason it carries one.
+ *
+ * `!` for the same reason the staleness mark has one: it is a state the operator
+ * has to act on, not a detail, and it must survive being read at a glance next to
+ * a Worker count that looks perfectly healthy. One word, because the head is the
+ * part of the line that never degrades — a sentence here would push the Workers
+ * off a narrow terminal to say something `project_status` says in full.
+ */
+export const UNREGISTERED_MARK = "!unregistered";
+
+/** What a daemon that is not the current one appends to its version. */
+export const ENGINE_BEHIND_MARK = "⇡";
+
+/**
+ * What a posed death is marked with — a dagger, and never a word.
+ *
+ * The head is the part of the line that never degrades, so a death has to fit
+ * beside a Worker count on a narrow terminal; the class that follows is the
+ * reason, and the lane holds the receipt.
+ */
+export const DEATH_MARK = "†";
+
+/**
+ * What a budget inside the reserved band is marked with, and what a spent one is.
+ *
+ * Two marks rather than one, because they call for opposite actions: inside the
+ * band the machine is still landing work and refusing only convenience, and spent
+ * means nothing goes out until the reset. A surface that drew one symbol for both
+ * would make an operator read the sentence to learn which it was.
+ */
+export const BUDGET_BAND_MARK = "◐";
+/** What a spent GitHub budget is marked with. */
+export const BUDGET_SPENT_MARK = "◯";
+
+/** The mark that says "this line belongs to the entry above it". */
+export const LOG_LINE_MARK = "↳";
+
+/** The one sentence an unreachable host renders as, at every density. */
+export const REDSKILLED_RENDER_ABSENCE = "redskilled unreachable — Worker state unknown";

--- a/packages/redskilled-render/package.json
+++ b/packages/redskilled-render/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@reddb-io/redskilled-render",
+  "version": "3.3.12",
+  "private": true,
+  "type": "module",
+  "description": "One render implementation outside the daemon (ADR 0132 decision 1): a stateless, transport-free function from one decoded redskilled payload to one drawn surface, at parameterized densities — statusline line, host panel, full dashboard.",
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./index.ts",
+    "./dashboard.js": "./dashboard.ts",
+    "./decode.js": "./decode.ts",
+    "./format.js": "./format.ts",
+    "./line.js": "./line.ts",
+    "./marks.js": "./marks.ts",
+    "./panel.js": "./panel.ts",
+    "./payload.js": "./payload.ts",
+    "./select.js": "./select.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@reddb-io/toon": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/redskilled-render/panel.ts
+++ b/packages/redskilled-render/panel.ts
@@ -1,0 +1,203 @@
+/**
+ * panel — the middle density: a few rows, for a surface with height and no table.
+ *
+ * **A panel composes; it does not re-draw.** Its first row IS the statusline
+ * line, produced by the line density, and its Worker rows are the dashboard's
+ * identity columns without the table. That is the whole point of parameterizing
+ * densities instead of shipping three renderers: a status-bar tooltip, a herdr
+ * pane header and an editor hover want the same facts at three heights, and the
+ * only thing that should differ between them is how many rows they may spend.
+ *
+ * **It is the density that fits where a table will not.** A `statusLine` entry
+ * gets one row; a webview gets a screen; between them sits everything with four
+ * to ten — a notification body, a tooltip, a narrow sidebar. Before this existed
+ * those surfaces either printed the one-line render and lost the Workers, or
+ * printed the dashboard and overflowed.
+ *
+ * PURE, like every other density: payload and options in, rows out.
+ */
+import { clamp, formatBytes, formatDuration } from "./format.js";
+import { BUDGET_BAND_MARK, BUDGET_SPENT_MARK, DEATH_MARK } from "./marks.js";
+import type { RedskilledRenderPayload, RedskilledStatuslineMode } from "./payload.js";
+import {
+  REDSKILLED_STATUSLINE_DEFAULTS,
+  renderRedskilledStatusline,
+  workerName,
+  type RedskilledStatuslineRender,
+} from "./line.js";
+import { selectRenderProjects, selectRenderWorkers } from "./select.js";
+
+export interface RedskilledPanelOptions {
+  readonly mode: RedskilledStatuslineMode;
+  /** The project this session belongs to; `null` when it declared none. */
+  readonly project: string | null;
+  /** The hard ceiling in characters. No row exceeds it. */
+  readonly maxWidth: number;
+  /** How many Worker rows may be drawn before the rest are counted instead. */
+  readonly maxRows: number;
+  /** Give each drawn Worker the last line it logged, under its own row. */
+  readonly verbose: boolean;
+}
+
+export const REDSKILLED_PANEL_DEFAULTS: RedskilledPanelOptions = {
+  mode: "local",
+  project: null,
+  maxWidth: 100,
+  maxRows: 8,
+  verbose: false,
+};
+
+/**
+ * The panel, as rows plus the structure behind them.
+ *
+ * `head` is the whole statusline render rather than just its text, so a surface
+ * showing one row and a surface showing eight read the same `detail`, the same
+ * `project_match` and the same `stale` — three facts a consumer would otherwise
+ * have to re-derive per density and would derive differently.
+ */
+export interface RedskilledPanel {
+  readonly version: 1;
+  readonly generated_at: string;
+  readonly mode: RedskilledStatuslineMode;
+  readonly project: string | null;
+  readonly head: RedskilledStatuslineRender;
+  /** One row per drawn Worker, identity first. */
+  readonly worker_rows: readonly string[];
+  /** One row per project, drawn only in `global` where they differ from the head. */
+  readonly project_rows: readonly string[];
+  /** Deaths, budget and staleness — what an operator must act on. */
+  readonly notes: readonly string[];
+  readonly lines: readonly string[];
+  /** Workers the row budget left out — stated, never silently dropped. */
+  readonly hidden_row_count: number;
+  readonly stale: boolean;
+}
+
+/**
+ * The finished panel. PURE — payload and options in, rows out.
+ *
+ * The head is asked for at the panel's own width and never at the line's default,
+ * because a panel that showed a 120-column statusline inside an 80-column sidebar
+ * would degrade in a place the operator cannot see.
+ */
+export function renderRedskilledPanel(
+  payload: RedskilledRenderPayload,
+  options: RedskilledPanelOptions = REDSKILLED_PANEL_DEFAULTS,
+): RedskilledPanel {
+  const head = renderRedskilledStatusline(payload, {
+    ...REDSKILLED_STATUSLINE_DEFAULTS,
+    mode: options.mode,
+    project: options.project,
+    maxWidth: options.maxWidth,
+    // The head is a HEAD here: the Workers get rows of their own below it, and a
+    // line that also listed them would say everything twice on a surface whose
+    // whole advantage over the statusline is that it has somewhere else to put
+    // them.
+    maxWorkers: 0,
+    maxProjects: 0,
+    verbose: false,
+  });
+
+  const selected = selectRenderWorkers(payload, options);
+  const visible = selected.slice(0, Math.max(0, Math.floor(options.maxRows)));
+  const hidden = selected.length - visible.length;
+
+  const workerRows: string[] = [];
+  for (const worker of visible) {
+    workerRows.push(clamp(`  ${workerRow(worker, options.mode)}`, options.maxWidth));
+    if (!options.verbose) continue;
+    const logged = worker.log.last_line == null ? null : worker.log.last_line.replace(/\s+/g, " ").trim();
+    if (logged == null || logged === "") continue;
+    workerRows.push(clamp(`    ${logged}`, options.maxWidth));
+  }
+  if (hidden > 0) {
+    workerRows.push(clamp(`  … ${hidden} more Worker(s) — the row budget is short, not the host`, options.maxWidth));
+  }
+
+  // Only in `global`: the local mode holds one project by construction, and a row
+  // repeating the head verbatim is a row that costs height and says nothing.
+  const projectRows = options.mode === "global"
+    ? selectRenderProjects(payload, options).map((project) =>
+      clamp(
+        `  ${project.project_label} ${project.worker_count}w ${formatBytes(project.observed_rss_bytes)}`,
+        options.maxWidth,
+      )
+    )
+    : [];
+
+  const notes = panelNotes(payload, options);
+
+  return {
+    version: 1,
+    generated_at: payload.generated_at,
+    mode: options.mode,
+    project: options.project,
+    head,
+    worker_rows: workerRows,
+    project_rows: projectRows,
+    notes,
+    lines: [head.line, ...workerRows, ...projectRows, ...notes],
+    hidden_row_count: Math.max(0, hidden),
+    stale: payload.staleness.stale,
+  };
+}
+
+/**
+ * One Worker in a row: who it is, what it is doing, and what it costs. PURE.
+ *
+ * The phase and the elapsed span come first because a panel is read to answer
+ * "is this one stuck", and the memory figure last because it is the fact the
+ * head already carries in aggregate.
+ */
+function workerRow(
+  worker: RedskilledRenderPayload["workers"][number],
+  mode: RedskilledStatuslineMode,
+): string {
+  const display = worker.display;
+  const phase = display == null
+    ? null
+    : [display.phase, display.step].filter((part): part is string => Boolean(part)).join("·");
+  const used = worker.vitals.rss_bytes;
+  const parts = [
+    workerName(worker, mode),
+    phase == null || phase === "" ? null : phase,
+    formatDuration(worker.uptime_ms),
+    // An unmeasured Worker says so. A zero here would read as an idle Worker, and
+    // "nothing measured it" and "it is using nothing" are opposite facts.
+    used == null ? "?" : formatBytes(used),
+  ].filter((part): part is string => part != null);
+  return parts.join(" ");
+}
+
+/**
+ * What an operator must act on, and nothing they need not. PURE.
+ *
+ * A healthy machine produces no notes at all — a panel that always ended in
+ * `deaths 0 · quota open` would train the reader to stop looking at the last
+ * rows, which is the one place these lines have to be seen.
+ */
+function panelNotes(
+  payload: RedskilledRenderPayload,
+  options: RedskilledPanelOptions,
+): readonly string[] {
+  const notes: string[] = [];
+  const deaths = payload.deaths;
+  if (deaths != null && deaths.count > 0 && deaths.latest != null) {
+    notes.push(
+      clamp(
+        `${DEATH_MARK} ${deaths.count} posed death(s) — newest ${deaths.latest.sender_class}/` +
+          `${deaths.latest.confidence} on pid ${deaths.latest.pid}`,
+        options.maxWidth,
+      ),
+    );
+  }
+  const balance = payload.github_balance;
+  if (balance != null && (balance.posture === "spent" || balance.posture === "reserved")) {
+    const mark = balance.posture === "spent" ? BUDGET_SPENT_MARK : BUDGET_BAND_MARK;
+    notes.push(clamp(`${mark} github budget ${balance.posture} — ${balance.reason}`, options.maxWidth));
+  }
+  if (payload.staleness.stale) {
+    notes.push(clamp(`! ${payload.staleness.reason}`, options.maxWidth));
+  }
+  return notes;
+}

--- a/packages/redskilled-render/payload.ts
+++ b/packages/redskilled-render/payload.ts
@@ -1,0 +1,318 @@
+/**
+ * payload — the document this module draws, declared by the reader.
+ *
+ * **The render is a consumer of a wire document, not of the daemon's internals.**
+ * One daemon serves checkouts pinned to different bundle versions (ADR 0130 rule
+ * 3), so the shape a surface may rely on is the shape it can still read when the
+ * writer is a release ahead or behind. That is why the contract is declared here,
+ * on the reading side, and why it names only the fields a layout actually draws:
+ * a renderer that demanded the daemon's whole internal record would blank a pane
+ * over a field it never prints.
+ *
+ * **Every block the daemon may not carry is optional, and absence is never zero.**
+ * A missing `deaths` block is a daemon that never reaped; an empty one is a
+ * reaping that attributed nothing. A missing `metrics` block is a daemon that
+ * derives none; a null rate inside one is a window nobody measured. Collapsing
+ * either pair is how a broken observer renders as a calm machine.
+ *
+ * The daemon's own `RedskilledStatuslinePayload` is a superset of this and is
+ * assignable to it — `apps/redskilled/tests/render-payload-contract.test.ts` is
+ * the ratchet that fails the moment it stops being.
+ */
+
+/** Which Workers a surface is about. */
+export type RedskilledStatuslineMode = "local" | "global";
+
+/** Which instrument produced a memory figure; `null` when the daemon named none. */
+export type RedskilledRenderRssSource = "cgroup" | "process-tree" | (string & {});
+
+/** One Worker's measured consumption, or the honest absence of it. */
+export interface RedskilledRenderVitals {
+  /** Tree RSS at the last sample, in bytes; `null` when nothing measured it. */
+  readonly rss_bytes: number | null;
+  readonly sampled_at: string | null;
+  readonly age_ms: number | null;
+  readonly fresh: boolean;
+  readonly rss_source?: RedskilledRenderRssSource | null;
+}
+
+/** What a Worker was promised, and how much of it the daemon has seen it take. */
+export interface RedskilledRenderWorkerBudget {
+  readonly declared: string | null;
+  readonly bytes: number | null;
+  readonly used_bytes: number | null;
+  readonly used_fraction: number | null;
+  readonly enforceable: boolean;
+}
+
+/** The last line a Worker logged, as the daemon received it. */
+export interface RedskilledRenderWorkerLog {
+  readonly last_line: string | null;
+  readonly published_at: string | null;
+}
+
+/** What a Worker's project says a surface should SHOW about it. */
+export interface RedskilledRenderWorkerDisplay {
+  readonly runner: string | null;
+  readonly model: string | null;
+  readonly effort: string | null;
+  readonly origin: string | null;
+  readonly issue: string | null;
+  readonly phase: string | null;
+  readonly step: string | null;
+  readonly phase_index: number | null;
+  readonly phase_total: number | null;
+  readonly failed: boolean;
+  readonly heartbeat: string | null;
+  readonly added: number | null;
+  readonly removed: number | null;
+  readonly tokens: number | null;
+  readonly tools: number | null;
+  readonly reasoning: number | null;
+  readonly text: number | null;
+}
+
+/** A display record that says nothing — the honest shape of an unpublished row. */
+export const REDSKILLED_RENDER_DISPLAY_ABSENT: RedskilledRenderWorkerDisplay = {
+  runner: null,
+  model: null,
+  effort: null,
+  origin: null,
+  issue: null,
+  phase: null,
+  step: null,
+  phase_index: null,
+  phase_total: null,
+  failed: false,
+  heartbeat: null,
+  added: null,
+  removed: null,
+  tokens: null,
+  tools: null,
+  reasoning: null,
+  text: null,
+};
+
+export interface RedskilledRenderWorker {
+  readonly worker_id: string;
+  readonly project_label: string;
+  readonly pid: number;
+  readonly started_at: string;
+  readonly uptime_ms: number | null;
+  readonly vitals: RedskilledRenderVitals;
+  readonly budget: RedskilledRenderWorkerBudget;
+  readonly log: RedskilledRenderWorkerLog;
+  readonly display?: RedskilledRenderWorkerDisplay | null;
+  readonly display_published_at?: string | null;
+}
+
+/** One project's share of the machine. */
+export interface RedskilledRenderProject {
+  readonly project_label: string;
+  readonly worker_count: number;
+  readonly observed_rss_bytes: number;
+  readonly measured_worker_count: number;
+}
+
+/** The ceilings this host enforces; `null` on any dimension it does not. */
+export interface RedskilledRenderCeiling {
+  readonly memory_bytes: number | null;
+  readonly worker_count: number | null;
+}
+
+/** What the host is charged with right now. */
+export interface RedskilledRenderConsumption {
+  readonly memory_bytes: number;
+}
+
+/** The host aggregate — the numbers an operator feels before an incident. */
+export interface RedskilledRenderHost {
+  readonly worker_count: number;
+  readonly project_count: number;
+  readonly ceiling: RedskilledRenderCeiling;
+  readonly consumption: RedskilledRenderConsumption;
+  readonly observed_rss_bytes: number;
+  readonly measured_worker_count: number;
+  readonly ceiling_used_fraction: number | null;
+}
+
+/** How current this answer is, decided by the daemon and rendered by a surface. */
+export interface RedskilledRenderStaleness {
+  readonly sampled_at: string | null;
+  readonly age_ms: number | null;
+  readonly threshold_ms: number;
+  readonly stale: boolean;
+  readonly measured_worker_count: number;
+  readonly unmeasured_workers: readonly string[];
+  readonly reason: string;
+}
+
+/** Which daemon answered, so two answers can be told apart rather than averaged. */
+export interface RedskilledRenderDaemon {
+  readonly pid: number;
+  readonly daemon_version: string;
+  readonly protocol_version: number;
+  readonly started_at: string;
+}
+
+/** One posed death, reduced to what a surface prints. */
+export interface RedskilledRenderDeath {
+  readonly kind: string;
+  readonly id: string;
+  readonly pid: number;
+  readonly ts: string;
+  readonly last_seen: string;
+  readonly last_phase: string;
+  readonly sender_class: string;
+  readonly confidence: string;
+  readonly signal: string | null;
+  readonly evidence: string | null;
+}
+
+/** What this host could not explain, as of the last reaping. */
+export interface RedskilledRenderDeaths {
+  readonly count: number;
+  readonly recent: readonly RedskilledRenderDeath[];
+  readonly latest: RedskilledRenderDeath | null;
+  readonly reaped_at: string | null;
+}
+
+/** Which engine is answering, and whether it is the current one. */
+export interface RedskilledRenderEngine {
+  readonly running_version: string;
+  readonly published_version: string | null;
+  readonly newer_published: boolean;
+  readonly major_held: boolean;
+  readonly current: boolean | null;
+}
+
+/** One derived figure, with the reason it has no value. */
+export interface RedskilledRenderMetricValue {
+  readonly value: number | null;
+  readonly absent_reason: string | null;
+  readonly samples: number;
+}
+
+/** One key's share of a window — a runner name, or a model name. */
+export interface RedskilledRenderUsageShare {
+  readonly key: string;
+  readonly worker_count: number;
+  readonly share: number;
+}
+
+/** How a window's Workers divide over one dimension. */
+export interface RedskilledRenderUsageShares {
+  readonly attributed_workers: number;
+  readonly unattributed_workers: number;
+  readonly shares: readonly RedskilledRenderUsageShare[];
+  readonly absent_reason: string | null;
+}
+
+/** Everything one rolling window has to say. */
+export interface RedskilledRenderMetricsWindow {
+  readonly window_ms: number;
+  readonly from: string;
+  readonly to: string;
+  readonly tokens_per_min: RedskilledRenderMetricValue;
+  readonly tools_per_min: RedskilledRenderMetricValue;
+  readonly issues_per_hour: RedskilledRenderMetricValue;
+  readonly runner_share: RedskilledRenderUsageShares;
+  readonly model_share: RedskilledRenderUsageShares;
+  readonly unavailable: readonly string[];
+}
+
+/** The metrics block, as it travels on the aggregate payload. */
+export interface RedskilledRenderMetrics {
+  readonly generated_at: string;
+  readonly hour: RedskilledRenderMetricsWindow;
+  readonly day: RedskilledRenderMetricsWindow;
+}
+
+/** One project's repository counts; `null` for every outcome but a count. */
+export interface RedskilledRenderActivityCounts {
+  readonly open_pull_requests: number;
+  readonly open_issues: number;
+  readonly recently_closed: number;
+}
+
+export interface RedskilledRenderActivityProject {
+  readonly project_label: string;
+  readonly repository: string;
+  readonly counts: RedskilledRenderActivityCounts | null;
+  readonly stale?: boolean;
+}
+
+/** Each registered project's repository counts, dated on their own clock. */
+export interface RedskilledRenderActivity {
+  readonly fetched_at: string | null;
+  readonly age_ms: number | null;
+  readonly stale: boolean;
+  readonly projects: readonly RedskilledRenderActivityProject[];
+  readonly reason: string;
+}
+
+/** The graduated breaker's state, made observable. */
+export type RedskilledRenderBalancePosture = "open" | "reserved" | "spent" | "unknown";
+
+/** What the TOKEN has left, asked rather than counted, with its own age. */
+export interface RedskilledRenderBalance {
+  readonly asked_at: string | null;
+  readonly age_ms: number | null;
+  readonly stale: boolean;
+  readonly posture: RedskilledRenderBalancePosture;
+  readonly reserved_fraction: number;
+  readonly reason: string;
+}
+
+/**
+ * One decoded answer to "what is this machine doing".
+ *
+ * Every optional block is one a daemon of another version may not carry, and a
+ * surface that finds it absent draws nothing rather than a zero.
+ */
+export interface RedskilledRenderPayload {
+  readonly version: 1;
+  readonly generated_at: string;
+  readonly daemon: RedskilledRenderDaemon;
+  readonly staleness: RedskilledRenderStaleness;
+  readonly host: RedskilledRenderHost;
+  readonly projects: readonly RedskilledRenderProject[];
+  readonly workers: readonly RedskilledRenderWorker[];
+  readonly known_projects?: readonly string[];
+  readonly registered_projects?: readonly string[];
+  readonly repository_activity?: RedskilledRenderActivity;
+  readonly github_balance?: RedskilledRenderBalance;
+  readonly deaths?: RedskilledRenderDeaths;
+  readonly engine?: RedskilledRenderEngine;
+  readonly metrics?: RedskilledRenderMetrics;
+  /**
+   * Which count-scaling extras the composer deliberately left out.
+   *
+   * A withheld block and a missing measurement are opposite facts wearing the
+   * same `null`: a Worker whose vitals nobody asked for and a Worker nobody
+   * measured both carry `rss_bytes: null`, and only this field tells them apart.
+   * Absent — never `[]` — on a full response, so its presence alone means
+   * something was left out.
+   */
+  readonly withheld?: readonly ("logs" | "vitals" | "display")[];
+}
+
+/**
+ * True when `value` is a payload this module can draw — fail-closed. PURE.
+ *
+ * The check stops at the skeleton every density needs, because a daemon that grew
+ * a field this reader has never heard of still serves a drawable answer and
+ * rejecting it would blank a surface over version skew (ADR 0130 rule 3).
+ */
+export function isRedskilledRenderPayload(value: unknown): value is RedskilledRenderPayload {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const payload = value as Record<string, unknown>;
+  if (payload.version !== 1 || typeof payload.generated_at !== "string") return false;
+  if (!Array.isArray(payload.workers) || !Array.isArray(payload.projects)) return false;
+  const host = payload.host as Record<string, unknown> | undefined;
+  const staleness = payload.staleness as Record<string, unknown> | undefined;
+  const daemon = payload.daemon as Record<string, unknown> | undefined;
+  return host != null && typeof host === "object" && typeof host.worker_count === "number" &&
+    staleness != null && typeof staleness === "object" && typeof staleness.stale === "boolean" &&
+    daemon != null && typeof daemon === "object" && typeof daemon.daemon_version === "string";
+}

--- a/packages/redskilled-render/select.ts
+++ b/packages/redskilled-render/select.ts
@@ -1,0 +1,122 @@
+/**
+ * select — which Workers a surface is about, and how much of them survives.
+ *
+ * **The degradation ladder is layout, so it lives here** (ADR 0132 decision 4).
+ * It used to sit inside the statusline renderer, where it was reachable by one
+ * density and invisible to the other three; a dashboard that dropped rows without
+ * the ladder's vocabulary would degrade differently from the line above it, which
+ * is the two-authorities failure the whole module exists to end.
+ *
+ * **A selection is never a second answer.** Every density asks these functions
+ * rather than filtering the Worker set itself, so a line and a table standing in
+ * the same directory list the same Workers by construction.
+ *
+ * PURE: payload and taste in, a subset out.
+ */
+import type {
+  RedskilledRenderPayload,
+  RedskilledRenderProject,
+  RedskilledRenderWorker,
+  RedskilledStatuslineMode,
+} from "./payload.js";
+
+/** How much detail survived the width and count budgets. */
+export type RedskilledStatuslineDetail = "workers" | "projects" | "host";
+
+/**
+ * Whether the calling directory's project is one this host knows.
+ *
+ * Three states rather than a boolean, because the two failures need different
+ * sentences: a directory that resolved to no project at all has nothing to look
+ * up, while one that resolved to `acme/widgets` and found no such project on the
+ * host has a name to put in front of the operator. Collapsing either into
+ * `matched` is how "the host holds three of your Workers" renders as `0w`.
+ */
+export type RedskilledStatuslineProjectMatch =
+  | "matched"
+  /**
+   * The host knows this label, and holds no registration for it.
+   *
+   * A name is not a state (#2973). A project whose registration lapsed while a
+   * Worker of its own is still finishing is still *known* — the label is on the
+   * Worker — but nothing will be born for it again, so rendering it as a matched
+   * project is rendering a stopped drain as a healthy one.
+   */
+  | "name-only"
+  | "unregistered"
+  | "unresolved"
+  /** No daemon answered, so whether this host knows the project is unknowable. */
+  | "unanswered";
+
+/**
+ * The Workers a surface is about.
+ *
+ * The default mode keeps the session inside its own repository; a session that
+ * declared no project has nothing to filter on, and rather than guess it shows
+ * none — the head still carries the host total, so the render stays truthful.
+ */
+export function selectRenderWorkers(
+  payload: RedskilledRenderPayload,
+  taste: { readonly mode: RedskilledStatuslineMode; readonly project: string | null },
+): readonly RedskilledRenderWorker[] {
+  if (taste.mode === "global") return payload.workers;
+  if (taste.project == null) return [];
+  return payload.workers.filter((worker) => worker.project_label === taste.project);
+}
+
+/** The projects a surface is about — the same rule, one level up. PURE. */
+export function selectRenderProjects(
+  payload: RedskilledRenderPayload,
+  taste: { readonly mode: RedskilledStatuslineMode; readonly project: string | null },
+): readonly RedskilledRenderProject[] {
+  if (taste.mode === "global") return payload.projects;
+  return payload.projects.filter((project) => project.project_label === taste.project);
+}
+
+/**
+ * Does this host know the project the caller is standing in? PURE.
+ *
+ * A daemon older than `known_projects` cannot say, and the answer then is
+ * `matched`, never a guess at a mismatch: this decides whether an operator is
+ * told their project is unregistered, and inventing that from a missing field
+ * would put a false accusation on every line a skewed daemon serves.
+ */
+export function resolveStatuslineProjectMatch(
+  payload: RedskilledRenderPayload,
+  project: string | null,
+): RedskilledStatuslineProjectMatch {
+  if (project == null) return "unresolved";
+  if (payload.known_projects == null) return "matched";
+  if (!payload.known_projects.includes(project)) return "unregistered";
+  // Known, and possibly known only by NAME. A daemon too old to state its
+  // registrations cannot say which, and the answer then is `matched` for the same
+  // reason it is above: a lapse invented from a missing field would put a false
+  // accusation on every line a skewed daemon serves.
+  if (payload.registered_projects == null) return "matched";
+  return payload.registered_projects.includes(project) ? "matched" : "name-only";
+}
+
+/**
+ * The detail levels a render may use, richest first. PURE.
+ *
+ * A level whose count budget is already blown is never attempted: the budgets
+ * are the operator's declared taste, and honouring them only when the line
+ * happens to be long would make the setting mean nothing on a wide terminal.
+ */
+export function detailLadder(input: {
+  readonly mode: RedskilledStatuslineMode;
+  readonly maxWorkers: number;
+  readonly maxProjects: number;
+  readonly workers: readonly RedskilledRenderWorker[];
+  readonly projects: readonly RedskilledRenderProject[];
+}): readonly RedskilledStatuslineDetail[] {
+  const ladder: RedskilledStatuslineDetail[] = [];
+  if (input.workers.length > 0 && input.workers.length <= input.maxWorkers) ladder.push("workers");
+  // The local mode holds one project by construction, so a per-project line
+  // would repeat the head verbatim. Only `global` has an aggregate worth a step.
+  if (input.mode === "global" && input.projects.length > 0 && input.projects.length <= input.maxProjects) {
+    ladder.push("projects");
+  }
+  ladder.push("host");
+  return ladder;
+}

--- a/packages/redskilled-render/tests/fixture.ts
+++ b/packages/redskilled-render/tests/fixture.ts
@@ -1,0 +1,107 @@
+/**
+ * fixture — one payload, built by hand, so a render can be asserted with no host.
+ *
+ * **This file is the whole claim of ADR 0132 decision 1 made testable**: the
+ * render holds no state and opens no transport, so a payload typed out here must
+ * draw byte-identically to one a live daemon composed. If it ever does not, the
+ * renderer reached for something that was not an argument.
+ */
+import type {
+  RedskilledRenderPayload,
+  RedskilledRenderWorker,
+  RedskilledRenderWorkerDisplay,
+} from "../payload.js";
+
+export function worker(overrides: Partial<RedskilledRenderWorker> = {}): RedskilledRenderWorker {
+  return {
+    worker_id: "w-1",
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-08-03T00:00:00.000Z",
+    uptime_ms: 125_000,
+    vitals: {
+      rss_bytes: 512 * 1024 * 1024,
+      sampled_at: "2026-08-03T00:02:00.000Z",
+      age_ms: 5_000,
+      fresh: true,
+      rss_source: "cgroup",
+    },
+    budget: {
+      declared: "2G",
+      bytes: 2 * 1024 * 1024 * 1024,
+      used_bytes: 512 * 1024 * 1024,
+      used_fraction: 0.25,
+      enforceable: true,
+    },
+    log: { last_line: "coding: touched src/index.ts", published_at: "2026-08-03T00:02:00.000Z" },
+    ...overrides,
+  };
+}
+
+export function display(
+  overrides: Partial<RedskilledRenderWorkerDisplay> = {},
+): RedskilledRenderWorkerDisplay {
+  return {
+    runner: "claude",
+    model: "opus",
+    effort: "high",
+    origin: "afk",
+    issue: "3096",
+    phase: "coding",
+    step: "edit",
+    phase_index: 2,
+    phase_total: 5,
+    failed: false,
+    heartbeat: "3s",
+    added: 120,
+    removed: 8,
+    tokens: 42_000,
+    tools: 31,
+    reasoning: 9,
+    text: 4,
+    ...overrides,
+  };
+}
+
+export function payload(overrides: Partial<RedskilledRenderPayload> = {}): RedskilledRenderPayload {
+  return {
+    version: 1,
+    generated_at: "2026-08-03T00:02:05.000Z",
+    daemon: {
+      pid: 111,
+      daemon_version: "3.3.11",
+      protocol_version: 1,
+      started_at: "2026-08-02T22:00:00.000Z",
+    },
+    staleness: {
+      sampled_at: "2026-08-03T00:02:00.000Z",
+      age_ms: 5_000,
+      threshold_ms: 30_000,
+      stale: false,
+      measured_worker_count: 1,
+      unmeasured_workers: [],
+      reason: "measured 5s ago",
+    },
+    host: {
+      worker_count: 1,
+      project_count: 1,
+      ceiling: { memory_bytes: 8 * 1024 * 1024 * 1024, worker_count: 4 },
+      consumption: { memory_bytes: 512 * 1024 * 1024 },
+      observed_rss_bytes: 512 * 1024 * 1024,
+      measured_worker_count: 1,
+      ceiling_used_fraction: 0.0625,
+    },
+    projects: [
+      {
+        project_label: "acme/widgets",
+        worker_count: 1,
+        observed_rss_bytes: 512 * 1024 * 1024,
+        measured_worker_count: 1,
+      },
+    ],
+    workers: [worker()],
+    known_projects: ["acme/widgets"],
+    registered_projects: ["acme/widgets"],
+    ...overrides,
+  };
+}

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -1,0 +1,149 @@
+/**
+ * render — the four acceptance claims of ADR 0132 decision 1, as assertions.
+ *
+ * One module, three densities, no state and no transport, and a fixture that
+ * draws exactly what a live read draws.
+ */
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { encode as encodeToon } from "@reddb-io/toon";
+import {
+  decodeRedskilledPayload,
+  detailLadder,
+  RedskilledRenderDecodeError,
+  renderRedskilled,
+  renderRedskilledDashboard,
+  renderRedskilledPanel,
+  renderRedskilledStatusline,
+  renderRedskilledStatuslineAbsence,
+  REDSKILLED_DASHBOARD_DEFAULTS,
+  REDSKILLED_PANEL_DEFAULTS,
+  REDSKILLED_RENDER_ABSENCE,
+  REDSKILLED_STATUSLINE_DEFAULTS,
+} from "../index.js";
+import { display, payload, worker } from "./fixture.js";
+
+const LOCAL = { ...REDSKILLED_STATUSLINE_DEFAULTS, project: "acme/widgets" };
+
+describe("one module, three densities", () => {
+  it("draws the same payload at a line, a panel and a table", () => {
+    const doc = payload({ workers: [worker({ display: display() })] });
+
+    const line = renderRedskilledStatusline(doc, LOCAL);
+    const panel = renderRedskilledPanel(doc, { ...REDSKILLED_PANEL_DEFAULTS, project: "acme/widgets" });
+    const table = renderRedskilledDashboard(doc, { ...REDSKILLED_DASHBOARD_DEFAULTS, project: "acme/widgets" });
+
+    expect(line.lines).toHaveLength(1);
+    expect(line.line).toContain("acme/widgets 1w");
+    // The panel's FIRST row is the line density's own output, not a second
+    // spelling of it — the composition is the no-drift guarantee.
+    expect(panel.head.line).toBe(panel.lines[0]);
+    expect(panel.lines.length).toBeGreaterThan(line.lines.length);
+    expect(panel.worker_rows[0]).toContain("w-1");
+    expect(table.rows).toHaveLength(1);
+    expect(table.header.line).toContain("wrk=1/1");
+  });
+
+  it("routes a density by name through the one entry point", () => {
+    const doc = payload();
+    const drawn = renderRedskilled(doc, { density: "panel", options: { project: "acme/widgets" } });
+    expect(drawn.density).toBe("panel");
+    expect(drawn.lines[0]).toContain("acme/widgets");
+    expect(renderRedskilled(doc, { density: "line", options: { project: "acme/widgets" } }).lines)
+      .toEqual(renderRedskilledStatusline(doc, LOCAL).lines);
+  });
+
+  it("degrades a crowded line down the shared ladder rather than overflowing", () => {
+    const workers = Array.from({ length: 3 }, (_, index) => worker({ worker_id: `w-${index}` }));
+    const doc = payload({ workers, host: { ...payload().host, worker_count: 3 } });
+    const narrow = renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 40 });
+    expect(narrow.detail).toBe("host");
+    expect(narrow.degraded).toBe(true);
+    expect([...narrow.line].length).toBeLessThanOrEqual(40);
+
+    // The ladder is layout, and it now lives beside every density rather than
+    // inside one of them.
+    expect(detailLadder({ mode: "global", maxWorkers: 2, maxProjects: 4, workers, projects: doc.projects }))
+      .toEqual(["projects", "host"]);
+  });
+});
+
+describe("stateless, and it opens no transport", () => {
+  it("reaches no node builtin from any layout module", () => {
+    const root = join(import.meta.dirname, "..");
+    const layout = readdirSync(root).filter((name) => name.endsWith(".ts") && name !== "decode.ts");
+    expect(layout.length).toBeGreaterThan(4);
+    for (const module of layout) {
+      expect(readFileSync(join(root, module), "utf8"), module).not.toMatch(/from "node:/);
+    }
+  });
+
+  it("renders one payload identically however many times it is asked", () => {
+    const doc = payload({ workers: [worker({ display: display() })] });
+    const once = renderRedskilledDashboard(doc, REDSKILLED_DASHBOARD_DEFAULTS);
+    const twice = renderRedskilledDashboard(doc, REDSKILLED_DASHBOARD_DEFAULTS);
+    expect(twice).toEqual(once);
+  });
+
+  it("states an unreachable host rather than drawing a calm blank", () => {
+    const absent = renderRedskilledStatuslineAbsence({ generated_at: "2026-08-03T00:00:00.000Z" });
+    expect(absent.line).toBe(REDSKILLED_RENDER_ABSENCE);
+    expect(absent.stale).toBe(true);
+    expect(absent.project_match).toBe("unanswered");
+  });
+});
+
+describe("a fixture payload renders identically to a live one", () => {
+  it("draws the same line from JSON, from TOON and from an already-decoded value", () => {
+    const doc = payload({ workers: [worker({ display: display() })] });
+    const fromValue = renderRedskilled(doc, { density: "line", options: { project: "acme/widgets" } });
+    const fromJson = renderRedskilled(JSON.stringify(doc), { density: "line", options: { project: "acme/widgets" } });
+    const fromToon = renderRedskilled(encodeToon(doc as never), {
+      density: "line",
+      options: { project: "acme/widgets" },
+    });
+
+    expect(fromJson.lines).toEqual(fromValue.lines);
+    expect(fromToon.lines).toEqual(fromValue.lines);
+    expect(decodeRedskilledPayload(JSON.stringify(doc)).encoding).toBe("json");
+    expect(decodeRedskilledPayload(encodeToon(doc as never)).encoding).toBe("toon");
+  });
+
+  it("draws the newest record of a line-delimited lane and keeps the history", () => {
+    const older = payload({ generated_at: "2026-08-03T00:00:00.000Z" });
+    const newer = payload({ generated_at: "2026-08-03T00:05:00.000Z" });
+    const lane = `${JSON.stringify(older)}\n${JSON.stringify(newer)}\n`;
+
+    const decoded = decodeRedskilledPayload(lane);
+    expect(decoded.encoding).toBe("jsonl");
+    expect(decoded.records).toHaveLength(2);
+    expect(decoded.payload.generated_at).toBe("2026-08-03T00:05:00.000Z");
+  });
+
+  it("skips a torn tail rather than blanking a surface over a race", () => {
+    const complete = payload();
+    const lane = `${JSON.stringify(complete)}\n{"version":1,"generated_`;
+    expect(decodeRedskilledPayload(lane).payload.generated_at).toBe(complete.generated_at);
+  });
+
+  it("refuses a document that is not a payload, rather than rendering an idle machine", () => {
+    expect(() => decodeRedskilledPayload("")).toThrow(RedskilledRenderDecodeError);
+    expect(() => decodeRedskilledPayload('{"hello":"world"}')).toThrow(RedskilledRenderDecodeError);
+    expect(() => decodeRedskilledPayload("not a document at all")).toThrow(RedskilledRenderDecodeError);
+  });
+});
+
+describe("a withheld extra is not a measurement gap", () => {
+  it("draws an unmeasured Worker and a withheld one the same, and says which it was", () => {
+    const withheld = payload({
+      workers: [worker({ vitals: { rss_bytes: null, sampled_at: null, age_ms: null, fresh: false } })],
+      withheld: ["vitals", "logs", "display"],
+    });
+    const panel = renderRedskilledPanel(withheld, { ...REDSKILLED_PANEL_DEFAULTS, project: "acme/widgets" });
+    expect(panel.worker_rows[0]).toContain("?");
+    // The render prints the honest `?`; the FIELD is what lets a consumer tell a
+    // cheap read from a broken sampler.
+    expect(withheld.withheld).toContain("vitals");
+  });
+});

--- a/packages/redskilled-render/tsconfig.json
+++ b/packages/redskilled-render/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts", "tests"]
+}

--- a/packages/redskilled-render/vitest.config.ts
+++ b/packages/redskilled-render/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+    pool: "forks",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@reddb-io/redskilled':
         specifier: workspace:*
         version: link:../redskilled
+      '@reddb-io/redskilled-render':
+        specifier: workspace:*
+        version: link:../../packages/redskilled-render
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -335,6 +338,9 @@ importers:
       '@reddb-io/github':
         specifier: workspace:*
         version: link:../../packages/github
+      '@reddb-io/redskilled-render':
+        specifier: workspace:*
+        version: link:../../packages/redskilled-render
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -400,6 +406,9 @@ importers:
       '@reddb-io/redskilled':
         specifier: workspace:*
         version: link:../redskilled
+      '@reddb-io/redskilled-render':
+        specifier: workspace:*
+        version: link:../../packages/redskilled-render
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -509,6 +518,22 @@ importers:
       vitest:
         specifier: ^3.2.0
         version: 3.2.7(@types/node@25.9.5)(tsx@4.23.1)(yaml@2.9.0)
+
+  packages/redskilled-render:
+    dependencies:
+      '@reddb-io/toon':
+        specifier: 'catalog:'
+        version: 0.13.0
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.20.1)
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
Automated AFK landing for #3096. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3096

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788323499&installation_model_id=20659&pr_number=3125&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3125&signature=3d088e2bd32026da3a4b01a01100a1dcb6b153b30e5705f7b1d8e2514d6fef9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->