### PR TITLE
fix: #3123 An orphaned spawn lock blocks every auto-spawn, and a dead Worker record holds a slot no verb can release

### DIFF
--- a/apps/dev/src/commands/stop.ts
+++ b/apps/dev/src/commands/stop.ts
@@ -60,9 +60,28 @@ export async function releaseProject(root: string): Promise<ProjectStopResult> {
   }
 }
 
+/**
+ * Ask the host to let go of one Worker record, whatever is left of the process.
+ *
+ * The daemon's stop verb ends a process AND drops the record, so it is the one
+ * verb that expresses "stop counting this" — the intent an operator holding a
+ * dead-pid record has and previously had no way to say (#3123). A host that
+ * holds no such record answers `false`, which is the same outcome asked for.
+ */
+export async function releaseHostWorker(root: string, workerId: string, detail: string): Promise<boolean> {
+  try {
+    return await createRedskilledBirthPort({ root }).stop(workerId, detail);
+  } catch {
+    // An unreachable host is not a released record, and it is not this verb's to
+    // repair: the local classification stands and says what it found.
+    return false;
+  }
+}
+
 /** Injectable IO for deterministic testing. */
 export interface StopIO {
   releaseProject(root: string): Promise<ProjectStopResult>;
+  releaseHostWorker(root: string, workerId: string, detail: string): Promise<boolean>;
   listStaleClaimDirs(tmpDir: string): Promise<Array<{ path: string; issue?: number }>>;
   restoreClaimLabels(root: string, issue: number): Promise<boolean>;
   removeDir(path: string): Promise<void>;
@@ -73,6 +92,7 @@ export interface StopIO {
 
 const defaultIO: StopIO = {
   releaseProject,
+  releaseHostWorker,
   listStaleClaimDirs,
   restoreClaimLabels,
   removeDir,
@@ -123,7 +143,7 @@ export async function stopCommand(
 
   try {
     if (parsed.worker !== null) {
-      return await stopWorker(parsed.worker, paths.tmpDir, stdout, io);
+      return await stopWorker(parsed.worker, paths.tmpDir, stdout, io, cwd);
     }
     return await stopProjectWithReconcile(cwd, paths.tmpDir, stdout, io);
   } catch (error) {
@@ -187,7 +207,16 @@ export interface StopWorkerResult {
   op: "stop-worker";
   worker: string;
   worker_pid: number | null;
-  worker_status: "none" | "stale" | "stopped" | "timeout";
+  /**
+   * `released` — there was no process, and the host's record was dropped.
+   *
+   * It sits beside `none` and `stale` rather than replacing them, because those
+   * two still describe what an unreachable host leaves behind: nothing local,
+   * and nothing said about the record.
+   */
+  worker_status: "none" | "stale" | "stopped" | "timeout" | "released";
+  /** What happened, when the answer needs a sentence rather than a word. */
+  detail?: string;
 }
 
 /**
@@ -196,21 +225,40 @@ export interface StopWorkerResult {
  * the structured outcome — the CLI encodes it to TOON, the MCP `worker_stop`/
  * `worker_recycle` ops return it verbatim (TOON-encoded at the transport boundary).
  * Throws on a malformed worker id.
+ *
+ * **A record with no process is released, not merely reported (#3123).** The
+ * operator's intent is "stop counting this", and reporting `none` while the host
+ * kept holding the slot left them no verb that expressed it: the queue stayed
+ * undrained behind a Worker that had been dead for two hours. So both processless
+ * classifications ask the host to drop the record before they answer.
  */
 export async function executeStopWorker(
   workerId: string,
   tmpDir: string,
   io: StopIO = defaultIO,
+  /** The checkout whose host holds the record; omitted skips the host release. */
+  root?: string,
 ): Promise<StopWorkerResult> {
   if (!isValidWorkerId(workerId)) {
     throw new Error(`invalid worker id: ${JSON.stringify(workerId)}`);
   }
   const pid = await io.readWorkerPid(workerPidFile(tmpDir, workerId));
-  if (pid === null) {
-    return { op: "stop-worker", worker: workerId, worker_pid: null, worker_status: "none" };
-  }
-  if (!io.isLivePid(pid)) {
-    return { op: "stop-worker", worker: workerId, worker_pid: pid, worker_status: "stale" };
+  if (pid === null || !io.isLivePid(pid)) {
+    const found = pid === null
+      ? "no local pid file names a process for it"
+      : `its recorded pid ${pid} is dead`;
+    const released = root === undefined
+      ? false
+      : await io.releaseHostWorker(root, workerId, `afk stop released a record with no process: ${found}`);
+    return {
+      op: "stop-worker",
+      worker: workerId,
+      worker_pid: pid,
+      worker_status: released ? "released" : pid === null ? "none" : "stale",
+      detail: released
+        ? `${found}, so the host was asked to forget the record and it did: the slot it held is free`
+        : `${found}, and the host holds no record of it to release`,
+    };
   }
   const dead = await io.killTreeAndWait(pid);
   return {
@@ -226,12 +274,13 @@ async function stopWorker(
   tmpDir: string,
   stdout: NodeJS.WritableStream,
   io: StopIO,
+  root: string,
 ): Promise<number> {
   if (!isValidWorkerId(workerId)) {
     process.stderr.write(`[afk stop] invalid worker id: ${JSON.stringify(workerId)}\n`);
     return 1;
   }
-  const result = await executeStopWorker(workerId, tmpDir, io);
+  const result = await executeStopWorker(workerId, tmpDir, io, root);
   stdout.write(encodeToon(result as unknown as Parameters<typeof encodeToon>[0]) + "\n");
   return result.worker_status === "timeout" ? 1 : 0;
 }

--- a/apps/dev/src/core/project-attribution.ts
+++ b/apps/dev/src/core/project-attribution.ts
@@ -34,7 +34,31 @@ export interface ProjectAttributionInput<W extends AttributableWorker> {
    * holds none.
    */
   readonly hostWorkerIds: readonly string[] | null;
+  /**
+   * When the host says each of its Workers was born, by id.
+   *
+   * Supplied so "the host counts a Worker this checkout sees no trace of" can be
+   * told apart from the ordinary newborn window, where a Worker legitimately
+   * holds its slot before it has written any project-side state. Omitted means
+   * the caller cannot date them, and the disagreement stays unreported rather
+   * than guessed at — a false alarm on every birth would be the louder defect.
+   */
+  readonly hostWorkerBirths?: Readonly<Record<string, string>>;
+  /** The instant to date those births against; `Date.now()` when unstated. */
+  readonly nowMs?: number;
+  /** How long a newborn is exempt; {@link NEWBORN_ATTRIBUTION_GRACE_MS} by default. */
+  readonly newbornGraceMs?: number;
 }
+
+/**
+ * How long a host Worker is too young for its absence here to mean anything.
+ *
+ * A Worker holds its slot from the instant the daemon births it, and writes its
+ * project-side state a moment later. Inside this window "the host holds one and
+ * we see none" is a birth in progress; past it, it is a record outliving its
+ * Worker (#3123).
+ */
+export const NEWBORN_ATTRIBUTION_GRACE_MS = 60_000;
 
 export interface ProjectAttribution<W extends AttributableWorker> {
   /** Workers the host attributes to this project. */
@@ -55,6 +79,27 @@ export interface ProjectAttribution<W extends AttributableWorker> {
  * its slot before it has written any project-side state, and a slot count that
  * waited for that file would read free while the daemon refused to fill it.
  */
+/**
+ * True when every held Worker is old enough for its absence to mean something.
+ *
+ * Undatable is treated as NEWBORN, not settled: a caller that supplied no births
+ * — or a host record missing one — has given no evidence, and inventing an alarm
+ * out of no evidence is how a warning teaches an operator to ignore it. PURE.
+ */
+function allSettled<W extends AttributableWorker>(
+  input: ProjectAttributionInput<W>,
+  held: readonly string[],
+): boolean {
+  const births = input.hostWorkerBirths;
+  if (births == null) return false;
+  const nowMs = input.nowMs ?? Date.now();
+  const graceMs = input.newbornGraceMs ?? NEWBORN_ATTRIBUTION_GRACE_MS;
+  return held.every((id) => {
+    const bornMs = Date.parse(births[id] ?? "");
+    return Number.isFinite(bornMs) && nowMs - bornMs >= graceMs;
+  });
+}
+
 export function attributeProjectWorkers<W extends AttributableWorker>(
   input: ProjectAttributionInput<W>,
 ): ProjectAttribution<W> {
@@ -68,6 +113,17 @@ export function attributeProjectWorkers<W extends AttributableWorker>(
     warnings.push(
       "the redskilled daemon did not answer, so no live Worker could be attributed to this project: every one of " +
         "them is listed as unattributed because ownership is the host's answer, never a guess made from a pid",
+    );
+  } else if (held.length > 0 && input.workers.length === 0 && allSettled(input, held)) {
+    // The #3123 signature: the host counts Workers this checkout can see no trace
+    // of, and none of them is young enough for a birth in progress to explain it.
+    // Silence here is what let `live_workers: []` sit beside `busy: 1` for two
+    // hours while a queue went undrained — the two surfaces described the same
+    // machine and disagreed, and neither said so.
+    warnings.push(
+      `the host holds ${held.length} Worker(s) for this project (${[...ourWorkerIds].slice(0, 3).join(", ")}) and ` +
+        "not one of them is running here: the daemon's count and this project's own read disagree, which is a record " +
+        "outliving its Worker — the host's liveness sweep reaps it, and `worker_stop <id>` releases it now (#3123)",
     );
   } else if (held.length > 0 && input.workers.length > 0 && live.length === 0) {
     // The #3081 signature, stated where it is read. Two disjoint id spaces and a

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -421,7 +421,10 @@ export function createDefaultDevAfkMcpOperations(
       };
     },
     async stopWorker(cwd, input) {
-      const result = await executeStopWorker(input.worker, afkPaths(cwd).tmpDir);
+      // The checkout travels with the stop so a record with no process is
+      // RELEASED rather than reported as `none` (#3123): the host is the only
+      // thing holding the slot, and this verb is the only one that can free it.
+      const result = await executeStopWorker(input.worker, afkPaths(cwd).tmpDir, undefined, cwd);
       return { ...result, recycle: input.recycle };
     },
     requeue: (input) => runtime.executeRequeue(root, input),
@@ -828,9 +831,14 @@ async function projectStatus(root: string): Promise<ProjectStatusOutput> {
   // assigned rather than minting its own (#3081). A predicate that matches
   // nothing across a non-empty Worker set is that wire broken, and it is
   // reported rather than rendered as an idle project.
+  // ONE host read for both the ids and their birth instants: the dates are what
+  // tell a newborn holding its slot apart from a record outliving its Worker
+  // (#3123), and asking twice would date them to two different answers.
+  const hostBirths = await port.workerBirths().catch(() => null);
   const attribution = attributeProjectWorkers({
     workers: allLiveWorkers,
-    hostWorkerIds: await port.workerIds().catch(() => null),
+    hostWorkerIds: hostBirths == null ? null : Object.keys(hostBirths),
+    ...(hostBirths == null ? {} : { hostWorkerBirths: hostBirths }),
   });
   const liveWorkers = attribution.live;
   const unattributedWorkers = attribution.unattributed;

--- a/apps/dev/src/runtime/redskilled-birth.ts
+++ b/apps/dev/src/runtime/redskilled-birth.ts
@@ -168,6 +168,14 @@ export interface RedskilledBirthPort {
    */
   workerIds(): Promise<readonly string[]>;
   /**
+   * WHEN the host says each of those Workers was born, by id.
+   *
+   * The dates the host holds, never dates inferred here: a reader that wants to
+   * tell a newborn from a record outliving its Worker (#3123) must ask the one
+   * process that knows when the birth happened.
+   */
+  workerBirths(): Promise<Readonly<Record<string, string>>>;
+  /**
    * Host events appended since the last drain, narrowed to this project.
    *
    * The lane is the daemon's record of birth, death and budget-kill, so a death
@@ -203,12 +211,13 @@ export function createRedskilledBirthPort(options: CreateRedskilledBirthOptions)
   let drained = 0;
 
   /** This project's Workers, as the host names them. One read, two callers. */
-  const readProjectWorkerIds = async (): Promise<readonly string[]> => {
+  const readProjectWorkers = async () => {
     const state = await readRedskilledHostState(paths, config);
-    return state.workers
-      .filter((worker) => worker.project_label === projectLabel)
-      .map((worker) => worker.worker_id);
+    return state.workers.filter((worker) => worker.project_label === projectLabel);
   };
+
+  const readProjectWorkerIds = async (): Promise<readonly string[]> =>
+    (await readProjectWorkers()).map((worker) => worker.worker_id);
 
   return {
     projectLabel,
@@ -268,6 +277,10 @@ export function createRedskilledBirthPort(options: CreateRedskilledBirthOptions)
 
     async workerIds() {
       return await readProjectWorkerIds();
+    },
+
+    async workerBirths() {
+      return Object.fromEntries((await readProjectWorkers()).map((w) => [w.worker_id, w.started_at]));
     },
 
     async drainEvents() {

--- a/apps/dev/tests/project-worker-identity.test.ts
+++ b/apps/dev/tests/project-worker-identity.test.ts
@@ -173,6 +173,44 @@ describe("attributing live Workers to this project", () => {
     expect(attribution.busy).toBe(0);
   });
 
+  // #3123: the host said `1w`, `project_status` said none, and neither said the
+  // two disagreed. That silence is what let a record outlive its Worker for two
+  // hours while a queue of eight went undrained.
+  it("reports a host count this checkout can see no trace of", () => {
+    const attribution = attributeProjectWorkers({
+      workers: [],
+      hostWorkerIds: ["71982926-abf"],
+      hostWorkerBirths: { "71982926-abf": "2026-08-03T01:52:04.000Z" },
+      nowMs: Date.parse("2026-08-03T03:52:04.000Z"),
+    });
+
+    expect(attribution.live).toEqual([]);
+    expect(attribution.busy).toBe(1);
+    expect(attribution.warnings).toHaveLength(1);
+    expect(attribution.warnings[0]).toContain("71982926-abf");
+    expect(attribution.warnings[0]).toContain("disagree");
+  });
+
+  it("stays quiet through the newborn window, where the host is simply ahead", () => {
+    // The canary's own shape: a Worker born a second ago holds its slot before it
+    // has written any project-side state, and calling that a phantom would put a
+    // false alarm on every single birth.
+    const attribution = attributeProjectWorkers({
+      workers: [],
+      hostWorkerIds: ["fresh-1"],
+      hostWorkerBirths: { "fresh-1": "2026-08-03T03:52:03.000Z" },
+      nowMs: Date.parse("2026-08-03T03:52:04.000Z"),
+    });
+
+    expect(attribution.warnings).toEqual([]);
+    expect(attribution.busy).toBe(1);
+  });
+
+  it("says nothing when the host's Workers cannot be dated at all", () => {
+    // No evidence is not evidence of a phantom.
+    expect(attributeProjectWorkers({ workers: [], hostWorkerIds: ["undated"] }).warnings).toEqual([]);
+  });
+
   it("stays quiet when there is genuinely nothing running", () => {
     expect(attributeProjectWorkers({ workers: [], hostWorkerIds: [] })).toEqual({
       live: [],

--- a/apps/dev/tests/stop-command.test.ts
+++ b/apps/dev/tests/stop-command.test.ts
@@ -39,27 +39,37 @@ function fakeIO(opts: {
   workerPid?: number | null;
   workerLive?: boolean;
   workerKillResult?: boolean;
+  hostReleased?: boolean;
 } = {}): StopIO & {
   releaseProjectCalled: boolean;
   removedDirs: string[];
   labelRestores: Array<{ issue: number; labels: string[] }>;
   workerKillCalled: boolean;
+  hostReleases: Array<{ worker: string; detail: string }>;
 } {
   let releaseProjectCalled = false;
   const removedDirs: string[] = [];
   const labelRestores: Array<{ issue: number; labels: string[] }> = [];
   let workerKillCalled = false;
+  const hostReleases: Array<{ worker: string; detail: string }> = [];
 
   const io: StopIO & {
     releaseProjectCalled: boolean;
     removedDirs: string[];
     labelRestores: Array<{ issue: number; labels: string[] }>;
     workerKillCalled: boolean;
+    hostReleases: Array<{ worker: string; detail: string }>;
   } = {
     get releaseProjectCalled() { return releaseProjectCalled; },
     get removedDirs() { return removedDirs; },
     get labelRestores() { return labelRestores; },
     get workerKillCalled() { return workerKillCalled; },
+    get hostReleases() { return hostReleases; },
+
+    async releaseHostWorker(_root, worker, detail) {
+      hostReleases.push({ worker, detail });
+      return opts.hostReleased ?? false;
+    },
 
     async releaseProject(_root: string) {
       releaseProjectCalled = true;
@@ -263,6 +273,43 @@ describe("stopCommand — --worker recycle", () => {
     expect(code).toBe(0);
     expect(text()).toContain("worker_status: stale");
     expect(io.workerKillCalled).toBe(false);
+  });
+
+  // #3123: `worker_stop` on a record with no process reported `none` and left the
+  // host holding the slot. There was no verb for "this record describes nothing;
+  // forget it", so a dead Worker's record blocked a whole queue until the daemon
+  // restarted. Both processless classifications now ASK, and say what came back.
+  it("releases the host's record when no pid file names a process", async () => {
+    const io = fakeIO({ workerPid: null, hostReleased: true });
+    const { stream, text } = capture();
+    const code = await stopCommand(["--worker", "wXXXX"], "/repo", stream, io);
+
+    expect(code).toBe(0);
+    expect(text()).toContain("worker_status: released");
+    expect(io.hostReleases.map((r) => r.worker)).toEqual(["wXXXX"]);
+    expect(text()).toContain("the slot it held is free");
+    expect(io.workerKillCalled).toBe(false);
+  });
+
+  it("releases the host's record when the recorded pid is dead", async () => {
+    const io = fakeIO({ workerPid: 7777, workerLive: false, hostReleased: true });
+    const { stream, text } = capture();
+    const code = await stopCommand(["--worker", "wSTAL"], "/repo", stream, io);
+
+    expect(code).toBe(0);
+    expect(text()).toContain("worker_status: released");
+    expect(io.hostReleases[0]!.detail).toContain("7777");
+  });
+
+  it("keeps saying none when the host holds no record to release", async () => {
+    const io = fakeIO({ workerPid: null, hostReleased: false });
+    const { stream, text } = capture();
+    await stopCommand(["--worker", "wXXXX"], "/repo", stream, io);
+
+    // The host was asked — silence about it is what made the slot un-releasable.
+    expect(io.hostReleases).toHaveLength(1);
+    expect(text()).toContain("worker_status: none");
+    expect(text()).toContain("holds no record of it to release");
   });
 
   it("returns exit code 1 and worker_status=timeout when the worker survives SIGKILL", async () => {

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -17,9 +17,16 @@
  */
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
-import { isPidAlive, tryAcquireExclusiveLock } from "@reddb-io/shared/resident-core.js";
+import {
+  acquireSpawnLock,
+  describeSpawnLockHolder,
+  isPidAlive,
+  releaseSpawnLock,
+  type SpawnLockHeld,
+  type SpawnLockReaping,
+} from "@reddb-io/shared/resident-core.js";
 import {
   redskilledServeArgv,
   type RedskilledEntryLookup,
@@ -208,6 +215,15 @@ export interface RedskilledClientConfig {
    * in the config is how a client stays inside its own repository by default.
    */
   readonly sessionProject?: string;
+  /**
+   * How long a spawn lock is believed before this client reaps it.
+   *
+   * Injected so a test can age a lock without waiting a minute; a real caller
+   * passes nothing and gets `DEFAULT_SPAWN_LOCK_MAX_AGE_MS`.
+   */
+  readonly spawnLockMaxAgeMs?: number;
+  /** Where a reaping is reported; stderr when nothing else is stated. */
+  readonly onSpawnLockReaped?: (reaping: SpawnLockReaping) => void;
 }
 
 /**
@@ -259,11 +275,16 @@ async function reachRedskilledDaemon(
   const held = await waitOutTheLeaseHolder(paths, config);
   if (held != null) return held;
 
-  const lock = await tryAcquireExclusiveLock(paths.lockPath);
-  if (!lock) {
+  const lock = await acquireSpawnLock(paths.lockPath, {
+    ...(config.spawnLockMaxAgeMs == null ? {} : { maxAgeMs: config.spawnLockMaxAgeMs }),
+    onReap: config.onSpawnLockReaped ?? reportSpawnLockReaping,
+  });
+  if (!lock.acquired) {
     // Lost the spawn race. The winner is starting the very daemon we wanted, so
-    // waiting for it is the whole job — restarting one would be the bug.
-    await waitForDaemon(paths, config);
+    // waiting for it is the whole job — restarting one would be the bug. What is
+    // new is the gate travelling with the wait: if the winner never appears, the
+    // failure names the lock rather than blaming a daemon that was never asked.
+    await waitForDaemon(paths, config, undefined, lock);
     return "joined";
   }
   try {
@@ -275,9 +296,23 @@ async function reachRedskilledDaemon(
     await waitForDaemon(paths, config, spawned);
     return "spawned";
   } finally {
-    await lock.close();
-    await rm(paths.lockPath, { force: true });
+    await releaseSpawnLock(lock);
   }
+}
+
+/**
+ * Say out loud that a lock was reaped — the default, overridable per client.
+ *
+ * A reaping that left no trace would be indistinguishable from the lock never
+ * having existed, and the one moment an operator needs this line is when the
+ * guess was wrong and two daemons raced.
+ */
+function reportSpawnLockReaping(reaping: SpawnLockReaping): void {
+  process.stderr.write(
+    `redskilled: reaped the spawn lock ${JSON.stringify(reaping.lockPath)} (${reaping.reason}, ` +
+      `${Math.round(reaping.ageMs / 1_000)}s old, holder ${reaping.holder == null ? "unnamed" : `pid ${reaping.holder.pid}`}) ` +
+      "and went on to spawn\n",
+  );
 }
 
 /**
@@ -794,6 +829,15 @@ async function waitForDaemon(
   paths: RedskilledPaths,
   config: RedskilledClientConfig,
   spawned?: SpawnedDaemon,
+  /**
+   * The gate that stopped this client spawning, when one did.
+   *
+   * Carried into the wait rather than re-read at the timeout, because a lock
+   * released a moment before the deadline would leave the failure describing a
+   * gate that is no longer there — and the sentence owed is about the gate that
+   * refused, not the state afterwards.
+   */
+  heldBy?: SpawnLockHeld,
 ): Promise<void> {
   const deadline = Date.now() + (config.readyTimeoutMs ?? DEFAULT_REDSKILLED_READY_TIMEOUT_MS);
   for (;;) {
@@ -805,6 +849,15 @@ async function waitForDaemon(
       );
     }
     if (Date.now() >= deadline) {
+      // A spawn this client never attempted must not be reported as one that
+      // failed: "the daemon did not start" sends an operator to inspect a daemon
+      // that is healthy, which is #3092's misattribution through another door.
+      if (heldBy != null) {
+        throw new Error(
+          `no redskilled daemon answered on ${JSON.stringify(paths.socketPath)} within the ready window, and ` +
+            `${describeSpawnLockHolder(heldBy)}`,
+        );
+      }
       const from = spawned
         ? ` from ${JSON.stringify(spawned.entry.entry ?? spawned.entry.command)} (resolved as ${spawned.entry.source})${
             spawned.exit ? `, which ${spawned.exit}` : ""

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -118,6 +118,7 @@ import {
   maySweepMachine,
   nameUnownedProject,
   reattachWorkers,
+  REDSKILLED_LIVENESS_GRACE_MS,
   stopWorker,
   type RedskilledLivenessProbe,
   type RedskilledStopProbe,
@@ -335,6 +336,13 @@ export interface RedskilledDaemonOptions {
   readonly eventLane?: RedskilledEventLane;
   /** How the daemon asks whether a re-attached Worker is still running. */
   readonly liveness?: RedskilledLivenessProbe;
+  /**
+   * How long a newborn Worker is exempt from the liveness sweep.
+   *
+   * Injected so a test can prove the sweep without waiting out the grace; a real
+   * daemon takes {@link REDSKILLED_LIVENESS_GRACE_MS}.
+   */
+  readonly livenessGraceMs?: number;
   /** How the daemon stops a Worker it is reclaiming a budget from. */
   readonly stopWorker?: RedskilledStopProbe;
   /**
@@ -687,8 +695,8 @@ export interface RedskilledDaemon {
   driveDemand(): Promise<RedskilledDemandTick>;
   /** The last demand tick; `null` before the first one ran. */
   demand(): RedskilledDemandTick | null;
-  /** Re-probe every re-attached Worker, retiring the ones the host no longer confirms. */
-  sweepReattached(): Promise<readonly RedskilledWorkerView[]>;
+  /** Re-probe every held Worker, retiring the ones the host no longer confirms. */
+  sweepWorkerLiveness(): Promise<readonly RedskilledWorkerView[]>;
   /** The Workers this daemon adopted at start rather than birthing itself. */
   reattached(): readonly RedskilledWorkerView[];
   /** Resolves once every event handed to the lane has reached disk. */
@@ -817,6 +825,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const startedAt = clock();
   const eventLane = options.eventLane ?? createRedskilledEventLane(paths.eventLanePath);
   const liveness = options.liveness ?? detectWorkerLiveness;
+  const livenessGraceMs = options.livenessGraceMs ?? REDSKILLED_LIVENESS_GRACE_MS;
   const stopProbe = options.stopWorker ?? stopWorker;
   const unitInventory = options.unitInventory ??
     (() =>
@@ -1290,6 +1299,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     if (demandTicking) return lastDemand ?? emptyDemandTick(at);
     demandTicking = true;
     try {
+      // Swept BEFORE the live count is taken (#3123). A record whose Worker is
+      // gone occupies a slot the planner then declines to fill, so a queue with
+      // work sits undrained beside a machine that is entirely free — and the
+      // idle timer, five minutes away, is not the cadence a birth decision runs at.
+      await sweepWorkerLiveness().catch(() => undefined);
       const live: Record<string, number> = {};
       for (const worker of workers.values()) {
         live[worker.project_label] = (live[worker.project_label] ?? 0) + 1;
@@ -1838,13 +1852,30 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   /**
-   * Ask the host about every re-attached Worker, and retire the ones it no
-   * longer confirms. Returns the Workers that were retired.
+   * Ask the host about EVERY Worker it holds, and retire the ones it no longer
+   * confirms. Returns the Workers that were retired.
+   *
+   * **Every record, not just the re-attached ones (#3123).** The narrow sweep
+   * trusted a child handle to deliver each birth's death, and a record whose
+   * launch client died without one — its pid reclaimed, its unit gone — then held
+   * a slot for two hours with no verb able to release it: the daemon's statusline
+   * said `1w` while the project's own read said none, and the machine refused to
+   * birth anything at `target: 1`. Two hours is not a race.
+   *
+   * The grace window is what keeps that from becoming the opposite bug: a Worker
+   * born a moment ago has not necessarily reached the init system, so probing it
+   * would reap a Worker mid-birth. Younger than {@link REDSKILLED_LIVENESS_GRACE_MS}
+   * is left to the child handle, which is authoritative for exactly that window.
    */
-  async function sweepReattached(): Promise<readonly RedskilledWorkerView[]> {
-    const adopted = [...reattached].map((id) => workers.get(id)).filter((w): w is RedskilledWorkerView => w != null);
-    if (adopted.length === 0) return [];
-    const { dead } = await reattachWorkers(adopted, liveness);
+  async function sweepWorkerLiveness(): Promise<readonly RedskilledWorkerView[]> {
+    const nowMs = Date.parse(clock());
+    const held = [...workers.values()].filter((worker) => {
+      if (reattached.has(worker.worker_id)) return true;
+      const bornMs = Date.parse(worker.started_at);
+      return !Number.isFinite(bornMs) || nowMs - bornMs >= livenessGraceMs;
+    });
+    if (held.length === 0) return [];
+    const { dead } = await reattachWorkers(held, liveness);
     for (const worker of dead) {
       forgetWorker(worker.worker_id);
       record("worker-death", worker, "the host no longer confirms this Worker");
@@ -2145,7 +2176,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     idleTimer = setTimeout(() => {
       // Sweep before deciding: a daemon that exited on a stale belief in a
       // re-attached Worker would hold this session's socket for nothing.
-      void sweepReattached()
+      void sweepWorkerLiveness()
         .catch(() => undefined)
         .then(() => evaluateIdle());
     }, idleMs);
@@ -2481,7 +2512,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     queueDiscovery: () => lastQueue,
     driveDemand,
     demand: () => lastDemand,
-    sweepReattached,
+    sweepWorkerLiveness,
     publishWorkerHeartbeat,
     reattached: () => [...reattached].map((id) => workers.get(id)).filter((w): w is RedskilledWorkerView => w != null),
     flushEvents: () => eventLane.flush(),

--- a/apps/redskilled/src/reattach.ts
+++ b/apps/redskilled/src/reattach.ts
@@ -71,6 +71,16 @@ export async function reattachWorkers(
   return { alive, dead };
 }
 
+/**
+ * How long a newborn Worker is exempt from the liveness sweep.
+ *
+ * The sweep asks the init system, and a Worker whose unit is still being created
+ * would answer "not active" for reasons that are birth rather than death — so
+ * inside this window the child handle is authoritative and the probe is not
+ * asked. Past it, silence from the host means the Worker is gone (#3123).
+ */
+export const REDSKILLED_LIVENESS_GRACE_MS = 30_000;
+
 /** The default probe: the unit when there is one, the pid when there is not. */
 export function detectWorkerLiveness(worker: RedskilledWorkerView): boolean {
   if (worker.unit != null && worker.unit !== "") return isUnitActive(worker.unit);

--- a/apps/redskilled/tests/auto-spawn.test.ts
+++ b/apps/redskilled/tests/auto-spawn.test.ts
@@ -17,11 +17,17 @@
 // launch log answer "how many daemons?" and "from which file, at which version?".
 import type { ChildProcess } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireSpawnLock,
+  releaseSpawnLock,
+  type SpawnLockReaping,
+  type SpawnLockTaken,
+} from "@reddb-io/shared/resident-core.js";
 import {
   ensureRedskilledDaemon,
   readRedskilledHostState,
@@ -236,6 +242,51 @@ describe("redskilled auto-spawn at the client reach boundary", () => {
     // all the caller's own file.
     expect(launches(callerLog)).toEqual([]);
     expect(await socketAnswers(paths.socketPath)).toBe(false);
+  }, 60_000);
+
+  it("spawns past an orphaned lock instead of obeying it forever", async () => {
+    const { paths, config, launchLog } = await host();
+    // The field artifact: zero bytes, hours old, naming nobody (#3123).
+    await mkdir(dirname(paths.lockPath), { recursive: true });
+    await writeFile(paths.lockPath, "");
+    const aged = new Date(Date.now() - 6 * 60 * 60 * 1_000);
+    await utimes(paths.lockPath, aged, aged);
+
+    const reaped: SpawnLockReaping[] = [];
+    const outcome = await ensureRedskilledDaemon(paths, {
+      ...config,
+      spawnLockMaxAgeMs: 60_000,
+      onSpawnLockReaped: (reaping) => reaped.push(reaping),
+    });
+    started.push(paths.socketPath);
+
+    expect(outcome, "an orphaned lock still blocked the only path to a daemon").toBe("spawned");
+    expect(launches(launchLog)).toHaveLength(1);
+    expect(reaped.map((r) => r.reason)).toEqual(["unattributed"]);
+    expect(await socketAnswers(paths.socketPath)).toBe(true);
+  }, 60_000);
+
+  it("blames the lock, not the daemon, when a fresh lock's winner never appears", async () => {
+    const { paths, config, launchLog } = await host();
+    // A live holder's fresh lock: obeyed, correctly — and the winner never binds.
+    const held = await acquireSpawnLock(paths.lockPath, { pid: process.pid });
+    expect(held.acquired).toBe(true);
+
+    const error = await ensureRedskilledDaemon(paths, { ...config, readyTimeoutMs: 500 }).then(
+      (outcome) => outcome as never,
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(RedskilledUnreachableError);
+    const message = (error as Error).message;
+    expect(message).toContain(paths.lockPath);
+    expect(message).toContain(`pid ${process.pid}`);
+    expect(message).toContain("no spawn was attempted");
+    // The misattribution this replaces: nothing was ever asked to start.
+    expect(message, "a spawn never attempted was reported as one that failed").not.toContain("did not start on");
+    expect(launches(launchLog)).toEqual([]);
+
+    await releaseSpawnLock(held as SpawnLockTaken);
   }, 60_000);
 
   it("surfaces an unreachable daemon as its own state, never as an empty answer", async () => {

--- a/apps/redskilled/tests/daemon-restart.test.ts
+++ b/apps/redskilled/tests/daemon-restart.test.ts
@@ -318,7 +318,7 @@ describe("a sweep retires a re-attached Worker the host stopped confirming", () 
     expect(daemon.workerCount()).toBe(1);
 
     alive = false;
-    const retired = await daemon.sweepReattached();
+    const retired = await daemon.sweepWorkerLiveness();
     await daemon.flushEvents();
 
     expect(retired.map((worker) => worker.worker_id)).toEqual(["w-fading"]);

--- a/apps/redskilled/tests/dead-record-reaping.test.ts
+++ b/apps/redskilled/tests/dead-record-reaping.test.ts
@@ -1,0 +1,135 @@
+// A dead Worker's record occupied a slot forever, and no verb could release it
+// (#3123).
+//
+// The pid was dead, the systemd unit was gone, and the record was two hours old.
+// The daemon still said `host 1w/1p` and refused to birth anything at `target: 1`
+// while eight ready issues sat undrained. The sweep it already ran only ever
+// asked about RE-ATTACHED Workers — the ones adopted across a restart — so a
+// record born here whose launch client died without delivering an exit was never
+// asked about at all.
+//
+// These checks pin the reaping and its cadence: the record goes on the liveness
+// sweep, WITHOUT a daemon restart, and the sweep runs before a birth decision
+// rather than only when the machine goes idle. The newborn grace is pinned too,
+// because the opposite bug — reaping a Worker mid-birth — is the one a wider
+// sweep invites.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createRedskilledEventLane, readRedskilledEvents } from "../src/event-lane.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-reap-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+function workerView(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorkerView {
+  return {
+    worker_id: "71982926-abf",
+    project_label: "reddb-io/red-skills",
+    pid: 3275525,
+    started_at: "2026-08-03T01:52:04.000Z",
+    workspace_path: "/tmp/workspace",
+    isolated: true,
+    unit: "red-worker-reddb-io-red-skills-71982926.service",
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("a record whose Worker is gone is reaped on the liveness sweep", () => {
+  it("reaps a two-hour-old record with a dead pid and an absent unit", async () => {
+    const paths = await sessionPaths();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    await lane.record({ event: "worker-birth", worker: workerView(), ts: "2026-08-03T01:52:04.000Z" });
+
+    // Adopted at start because the host still confirmed it, then the unit went
+    // away: exactly the shape a record acquires between two sweeps.
+    let confirmed = true;
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      liveness: () => confirmed,
+      livenessGraceMs: 0,
+    });
+    running.push(daemon);
+    expect(daemon.workerCount()).toBe(1);
+
+    confirmed = false;
+    const reaped = await daemon.sweepWorkerLiveness();
+    await daemon.flushEvents();
+
+    expect(reaped.map((worker) => worker.worker_id)).toEqual(["71982926-abf"]);
+    // No restart was needed, and the slot is free.
+    expect(daemon.workerCount()).toBe(0);
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.at(-1)!.event).toBe("worker-death");
+  });
+
+  it("frees the slot before the birth decision, not only when the machine idles", async () => {
+    const paths = await sessionPaths();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    await lane.record({ event: "worker-birth", worker: workerView(), ts: "2026-08-03T01:52:04.000Z" });
+
+    let confirmed = true;
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 300_000,
+      liveness: () => confirmed,
+      livenessGraceMs: 0,
+    });
+    running.push(daemon);
+    expect(daemon.workerCount()).toBe(1);
+
+    confirmed = false;
+    // The demand tick is where `target: 1` was refused against a phantom Worker.
+    // Its own sweep is what makes the refusal impossible, five minutes before the
+    // idle timer would have noticed.
+    await daemon.driveDemand();
+
+    expect(daemon.workerCount(), "the demand tick judged its targets against a dead record").toBe(0);
+  });
+
+  it("leaves a newborn alone — a Worker mid-birth is not a Worker that died", async () => {
+    const paths = await sessionPaths();
+    const workspace = await mkdtemp(join(tmpdir(), "redskilled-reap-ws-"));
+    roots.push(workspace);
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      // Nothing this daemon holds is confirmed, so only the grace can save it.
+      liveness: () => false,
+      livenessGraceMs: 30_000,
+    });
+    running.push(daemon);
+
+    daemon.startWorker({
+      project_label: "acme/widgets",
+      workspace_path: workspace,
+      command: process.execPath,
+      args: ["-e", "setTimeout(() => {}, 3_000)"],
+      budget: { memory_high: "512M" },
+    });
+
+    const reaped = await daemon.sweepWorkerLiveness();
+
+    expect(reaped, "a Worker born a moment ago was swept as dead").toEqual([]);
+    expect(daemon.workerCount()).toBe(1);
+  });
+});

--- a/apps/redskilled/tests/demand-loop.test.ts
+++ b/apps/redskilled/tests/demand-loop.test.ts
@@ -259,6 +259,10 @@ describe("the daemon drives the demand loop itself", () => {
       ceiling: UNBOUNDED_HOST_CEILING,
       sampleMs: 0,
       demandMs: 0,
+      // The recording launch births no process, so the host must be told these
+      // are alive: the tick's own liveness sweep (#3123) would otherwise retire
+      // the very Workers the second tick is meant to count.
+      liveness: () => true,
       launch: recordingLaunch([]),
       queueDiscovery: { intervalMs: 0, transport: async () => answer([9]) },
     });

--- a/apps/redskilled/tests/idle-exit.test.ts
+++ b/apps/redskilled/tests/idle-exit.test.ts
@@ -47,7 +47,9 @@ describe("redskilled idle exit", () => {
 
   it("does not exit on idle while it believes a worker is alive", async () => {
     const paths = await sessionPaths();
-    const daemon = await startRedskilledDaemon({ paths, idleMs: 20 });
+    // The fixture Worker has no process behind it, so the host is told it is
+    // alive: what this pins is the idle rule, not the liveness sweep (#3123).
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 20, liveness: () => true });
     running.push(daemon);
     daemon.trackWorker(WORKER);
 

--- a/apps/redskilled/tests/spawn-lock-reaping.test.ts
+++ b/apps/redskilled/tests/spawn-lock-reaping.test.ts
@@ -1,0 +1,146 @@
+// An orphaned spawn lock blocked every auto-spawn, forever (#3123).
+//
+// The lock was zero bytes and six hours old. It named no pid and no instant, so
+// nothing could decide it was stale; rule 7's auto-spawn is the only path a fresh
+// session has to a daemon, so the machine was permanently un-spawnable until a
+// human deleted a file they had no reason to look for. And the sentence they got
+// meanwhile — "the daemon did not start" — described a spawn that was never
+// attempted, sending them to inspect a daemon that was perfectly healthy.
+//
+// These checks pin both halves: the lock now carries its owner and its age and is
+// REAPED past a stated bound, and a spawn refused by a lock names THE LOCK.
+import { mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireSpawnLock,
+  describeSpawnLockHolder,
+  parseSpawnLockHolder,
+  releaseSpawnLock,
+  type SpawnLockHeld,
+  type SpawnLockReaping,
+  type SpawnLockTaken,
+} from "@reddb-io/shared/resident-core.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function lockPath(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-lock-"));
+  roots.push(root);
+  return join(root, "redskilled.spawn.lock");
+}
+
+/** The exact artifact from the field: zero bytes, aged by its mtime alone. */
+async function orphanedLock(path: string, ageMs: number): Promise<void> {
+  await writeFile(path, "");
+  const aged = new Date(Date.now() - ageMs);
+  await utimes(path, aged, aged);
+}
+
+describe("an aged spawn lock is reaped rather than obeyed", () => {
+  it("reaps a zero-byte lock older than the stated bound, and says it did", async () => {
+    const path = await lockPath();
+    await orphanedLock(path, 6 * 60 * 60 * 1_000);
+
+    const reaped: SpawnLockReaping[] = [];
+    const outcome = await acquireSpawnLock(path, { maxAgeMs: 60_000, onReap: (r) => reaped.push(r) });
+
+    expect(outcome.acquired, "an unattributed six-hour lock blocked the spawn").toBe(true);
+    // The reaping is logged, not silent: deleting another process's lock on a
+    // guess must leave a trail for the day the guess was wrong.
+    expect(reaped).toHaveLength(1);
+    expect(reaped[0]!.reason).toBe("unattributed");
+    expect(reaped[0]!.ageMs).toBeGreaterThan(5 * 60 * 60 * 1_000);
+
+    await releaseSpawnLock(outcome as SpawnLockTaken);
+  });
+
+  it("reaps a lock whose named holder is dead, however young it is", async () => {
+    const path = await lockPath();
+    const held = await acquireSpawnLock(path, { pid: 4242, now: () => Date.now() });
+    expect(held.acquired).toBe(true);
+    // The handle stays open: the holder crashed, it did not release.
+    (held as SpawnLockTaken).handle.close();
+
+    const reaped: SpawnLockReaping[] = [];
+    const outcome = await acquireSpawnLock(path, {
+      isPidAlive: (pid) => pid !== 4242,
+      onReap: (r) => reaped.push(r),
+    });
+
+    expect(outcome.acquired).toBe(true);
+    expect(reaped.map((r) => r.reason)).toEqual(["holder-dead"]);
+    expect(reaped[0]!.holder?.pid).toBe(4242);
+    await releaseSpawnLock(outcome as SpawnLockTaken);
+  });
+
+  it("reaps a live holder that has held the lock past the bound", async () => {
+    const path = await lockPath();
+    const taken = await acquireSpawnLock(path, { now: () => Date.now() - 120_000 });
+    expect(taken.acquired).toBe(true);
+    await (taken as SpawnLockTaken).handle.close();
+
+    const outcome = await acquireSpawnLock(path, { maxAgeMs: 60_000, isPidAlive: () => true });
+    expect(outcome.acquired).toBe(true);
+    await releaseSpawnLock(outcome as SpawnLockTaken);
+  });
+
+  it("obeys a fresh lock held by a live owner — the race it exists to resolve", async () => {
+    const path = await lockPath();
+    const first = await acquireSpawnLock(path, { pid: 777 });
+    expect(first.acquired).toBe(true);
+
+    const second = await acquireSpawnLock(path, { maxAgeMs: 60_000, isPidAlive: () => true });
+
+    expect(second.acquired, "a live holder's fresh lock was robbed").toBe(false);
+    const held = second as SpawnLockHeld;
+    expect(held.holder?.pid).toBe(777);
+    expect(held.ageMs).not.toBeNull();
+    await releaseSpawnLock(first as SpawnLockTaken);
+  });
+});
+
+describe("the lock says who took it and when", () => {
+  it("writes an attributed, human-legible line", async () => {
+    const path = await lockPath();
+    const taken = await acquireSpawnLock(path, { pid: 31337, now: () => Date.parse("2026-08-03T05:00:00.000Z") });
+
+    const raw = await readFile(path, "utf8");
+    expect(raw).toContain("pid=31337");
+    expect(parseSpawnLockHolder(raw)).toEqual({ pid: 31337, takenAt: "2026-08-03T05:00:00.000Z" });
+
+    await releaseSpawnLock(taken as SpawnLockTaken);
+    // Released means gone: a closed handle beside a standing file is the orphan.
+    await expect(stat(path)).rejects.toThrow();
+  });
+
+  it("reads an older bundle's unattributed lock as naming nobody", () => {
+    expect(parseSpawnLockHolder("")).toBeNull();
+    expect(parseSpawnLockHolder("something else entirely\n")).toBeNull();
+    expect(parseSpawnLockHolder("resident-spawn-lock v1 pid=0 taken=nonsense")).toBeNull();
+  });
+});
+
+describe("a refused spawn names the gate that refused it", () => {
+  it("names the lock, its holder and how to clear it", async () => {
+    const path = await lockPath();
+    const first = await acquireSpawnLock(path, { pid: 909 });
+    const second = await acquireSpawnLock(path, { maxAgeMs: 60_000, isPidAlive: () => true });
+
+    const sentence = describeSpawnLockHolder(second as SpawnLockHeld);
+
+    expect(sentence).toContain(path);
+    expect(sentence).toContain("pid 909");
+    expect(sentence).toContain("no spawn was attempted");
+    expect(sentence).toContain("remove the file to clear it");
+    // The sentence it replaces must not be what an operator reads here.
+    expect(sentence).not.toContain("did not start");
+
+    await releaseSpawnLock(first as SpawnLockTaken);
+  });
+});

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -6,7 +6,15 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { decode, encode, type JsonObject } from "@reddb-io/toon";
 import { rspStateDir } from "./red-paths.js";
-import { isPidAlive, runtimeSocketDir, terminatePid, tryAcquireExclusiveLock } from "./resident-core.js";
+import {
+  acquireSpawnLock,
+  describeSpawnLockHolder,
+  isPidAlive,
+  releaseSpawnLock,
+  runtimeSocketDir,
+  terminatePid,
+  tryAcquireExclusiveLock,
+} from "./resident-core.js";
 import type { RspResidentConfig, RspResidentRequest } from "./resident-protocol.js";
 import { sendResidentRequest } from "./resident-protocol.js";
 import { requireRspEntry } from "./rsp-entry.js";
@@ -98,8 +106,17 @@ export async function ensureResidentServer(paths: RspResidentPaths, config: RspR
   if (await isResidentUsable(paths.socketPath, config)) return;
   await reconcileResidentRegistry(paths, config);
 
-  const lock = await tryAcquireLock(paths.lockPath);
-  if (lock) {
+  // Reaping, not merely exclusive: an orphaned lock here refuses every auto-spawn
+  // for as long as it exists, and the resident is the only path a fresh session
+  // has to a store (#3123). The reaping is reported rather than silent.
+  const lock = await acquireSpawnLock(paths.lockPath, {
+    onReap: (reaping) =>
+      process.stderr.write(
+        `rsp: reaped the resident spawn lock ${JSON.stringify(reaping.lockPath)} ` +
+          `(${reaping.reason}, ${Math.round(reaping.ageMs / 1_000)}s old)\n`,
+      ),
+  });
+  if (lock.acquired) {
     try {
       if (await isResidentUsable(paths.socketPath, config)) return;
       await reconcileResidentRegistry(paths, config);
@@ -108,12 +125,16 @@ export async function ensureResidentServer(paths: RspResidentPaths, config: RspR
       await waitForServer(paths.socketPath, child);
       return;
     } finally {
-      await lock.close();
-      await rm(paths.lockPath, { force: true });
+      await releaseSpawnLock(lock);
     }
   }
 
-  await waitForServer(paths.socketPath);
+  try {
+    await waitForServer(paths.socketPath);
+  } catch (err) {
+    // The gate that refused, not a daemon that failed: this client never spawned.
+    throw new Error(`${err instanceof Error ? err.message : String(err)}; ${describeSpawnLockHolder(lock)}`);
+  }
 }
 
 export async function pingResident(socketPath: string, timeoutMs = 200): Promise<boolean> {

--- a/packages/shared/resident-core.ts
+++ b/packages/shared/resident-core.ts
@@ -19,7 +19,7 @@
  */
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { mkdir, open, type FileHandle } from "node:fs/promises";
+import { mkdir, open, readFile, rm, stat, type FileHandle } from "node:fs/promises";
 import { createConnection, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -172,6 +172,11 @@ export function serveWireSocket<TRequest>(
  * `O_CREAT | O_EXCL` is the whole mechanism: exactly one concurrent caller gets
  * a handle, every other gets `null` and must wait for the winner rather than
  * start a second daemon.
+ *
+ * **The raw primitive: it attributes nothing and reaps nothing.** A caller that
+ * can be blocked forever by a lock its owner never released wants
+ * {@link acquireSpawnLock} instead; this stays for the wake-marker case, where
+ * the file is a deliberate once-per-window token rather than a held lock.
  */
 export async function tryAcquireExclusiveLock(lockPath: string): Promise<FileHandle | null> {
   await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
@@ -179,6 +184,200 @@ export async function tryAcquireExclusiveLock(lockPath: string): Promise<FileHan
     return await open(lockPath, constants.O_CREAT | constants.O_EXCL | constants.O_RDWR);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    return null;
+  }
+}
+
+/**
+ * How long a spawn lock is believed before the next spawner reaps it.
+ *
+ * Six times the ready window a client gives a booting daemon, so a spawn that is
+ * merely slow is never robbed of its lock, and one whose owner vanished is not
+ * believed for an afternoon (#3123).
+ */
+export const DEFAULT_SPAWN_LOCK_MAX_AGE_MS = 60_000;
+
+/** Who took a spawn lock and when — read back off the lock file itself. */
+export interface SpawnLockHolder {
+  readonly pid: number;
+  readonly takenAt: string;
+}
+
+/** One lock this acquisition refused to obey, and the reason it did not. */
+export interface SpawnLockReaping {
+  readonly lockPath: string;
+  /**
+   * `holder-dead` — the pid on the lock is gone.
+   * `aged-out` — a live holder has held it past `maxAgeMs`.
+   * `unattributed` — the lock names nobody, and is older than `maxAgeMs`.
+   */
+  readonly reason: "holder-dead" | "aged-out" | "unattributed";
+  readonly holder: SpawnLockHolder | null;
+  readonly ageMs: number;
+}
+
+export interface SpawnLockTaken {
+  readonly acquired: true;
+  readonly lockPath: string;
+  readonly handle: FileHandle;
+  /** The stale locks cleared on the way in; empty on an uncontended take. */
+  readonly reaped: readonly SpawnLockReaping[];
+}
+
+export interface SpawnLockHeld {
+  readonly acquired: false;
+  readonly lockPath: string;
+  /** Null when the lock names nobody — the shape an older bundle's lock has. */
+  readonly holder: SpawnLockHolder | null;
+  /** Null when the lock's age could not be established at all. */
+  readonly ageMs: number | null;
+}
+
+export type SpawnLockOutcome = SpawnLockTaken | SpawnLockHeld;
+
+export interface SpawnLockOptions {
+  readonly maxAgeMs?: number;
+  readonly now?: () => number;
+  readonly pid?: number;
+  readonly isPidAlive?: (pid: number) => boolean;
+  /** Called for every lock reaped, so the reaping is never silent. */
+  readonly onReap?: (reaping: SpawnLockReaping) => void;
+}
+
+/** The lock file's one line. Deliberately not TOON: an operator `cat`s this. */
+const SPAWN_LOCK_MAGIC = "resident-spawn-lock v1";
+
+/** How many times an acquisition will reap and retry before reporting held. */
+const SPAWN_LOCK_REAP_ATTEMPTS = 3;
+
+/**
+ * Take the spawn lock, saying who took it, and reap one nobody released.
+ *
+ * **A lock that names no owner and no instant is a lock nothing can decide is
+ * stale**, which is how a zero-byte file six hours old came to refuse every
+ * auto-spawn on a healthy machine (#3123). So the record carries its pid and its
+ * instant, and this acquisition reaps three kinds of lock rather than obeying
+ * them: one whose holder is gone, one a live holder has held past `maxAgeMs`,
+ * and one from an older bundle that says nothing and is older than `maxAgeMs`.
+ *
+ * A reap is never silent — `onReap` is handed every one — because a mechanism
+ * that quietly deletes another process's lock must leave a trail when the guess
+ * was wrong. Losing the race is still the ordinary outcome and still not a
+ * failure: the caller waits for the winner, and now has a holder to name if the
+ * winner never appears.
+ */
+export async function acquireSpawnLock(
+  lockPath: string,
+  options: SpawnLockOptions = {},
+): Promise<SpawnLockOutcome> {
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_SPAWN_LOCK_MAX_AGE_MS;
+  const now = options.now ?? Date.now;
+  const pid = options.pid ?? process.pid;
+  const alive = options.isPidAlive ?? isPidAlive;
+  await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
+
+  const reaped: SpawnLockReaping[] = [];
+  for (let attempt = 0; ; attempt += 1) {
+    const handle = await tryAcquireExclusiveLock(lockPath);
+    if (handle) {
+      // Written after the exclusive create, which is why a lock caught mid-write
+      // reads as unattributed: that window is milliseconds wide, and the age
+      // bound is what keeps a reader from mistaking it for an orphan.
+      await handle
+        .writeFile(`${SPAWN_LOCK_MAGIC} pid=${pid} taken=${new Date(now()).toISOString()}\n`)
+        .catch(() => undefined);
+      return { acquired: true, lockPath, handle, reaped };
+    }
+
+    const holder = await readSpawnLockHolder(lockPath);
+    const ageMs = await spawnLockAgeMs(lockPath, holder, now());
+    if (attempt >= SPAWN_LOCK_REAP_ATTEMPTS || ageMs == null) {
+      return { acquired: false, lockPath, holder, ageMs };
+    }
+    const reason = spawnLockReapReason(holder, ageMs, maxAgeMs, alive);
+    if (reason == null) return { acquired: false, lockPath, holder, ageMs };
+
+    const reaping: SpawnLockReaping = { lockPath, reason, holder, ageMs };
+    await rm(lockPath, { force: true });
+    reaped.push(reaping);
+    options.onReap?.(reaping);
+  }
+}
+
+/** Give the lock back: close the handle, then remove the file. */
+export async function releaseSpawnLock(taken: SpawnLockTaken): Promise<void> {
+  await taken.handle.close().catch(() => undefined);
+  await rm(taken.lockPath, { force: true });
+}
+
+/** Why this lock may be reaped, or `null` when it must still be obeyed. PURE. */
+function spawnLockReapReason(
+  holder: SpawnLockHolder | null,
+  ageMs: number,
+  maxAgeMs: number,
+  alive: (pid: number) => boolean,
+): SpawnLockReaping["reason"] | null {
+  if (holder == null) return ageMs > maxAgeMs ? "unattributed" : null;
+  if (!alive(holder.pid)) return "holder-dead";
+  return ageMs > maxAgeMs ? "aged-out" : null;
+}
+
+/**
+ * The sentence a refused spawn owes its operator.
+ *
+ * Named here rather than at each caller because every caller owes the same three
+ * facts — which lock, whose it is, how old — and "the daemon did not start" is
+ * exactly the sentence this replaces: it describes a spawn that was never
+ * attempted, and sends an operator to inspect a daemon that is perfectly healthy.
+ */
+export function describeSpawnLockHolder(held: SpawnLockHeld): string {
+  const age = held.ageMs == null ? "of unknown age" : `taken ${Math.round(held.ageMs / 1_000)}s ago`;
+  const who = held.holder == null
+    ? "an owner it does not name"
+    : `pid ${held.holder.pid} (at ${held.holder.takenAt})`;
+  return (
+    `no spawn was attempted: the spawn lock ${JSON.stringify(held.lockPath)} is held by ${who}, ${age}. ` +
+    `If that process is gone, remove the file to clear it`
+  );
+}
+
+/** Read the holder a lock names; `null` when it names nobody or cannot be read. */
+async function readSpawnLockHolder(lockPath: string): Promise<SpawnLockHolder | null> {
+  try {
+    return parseSpawnLockHolder(await readFile(lockPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Parse the lock's one line. PURE. Anything else reads as unattributed. */
+export function parseSpawnLockHolder(raw: string): SpawnLockHolder | null {
+  const line = raw.split("\n", 1)[0]?.trim() ?? "";
+  if (!line.startsWith(SPAWN_LOCK_MAGIC)) return null;
+  const pid = Number(/\bpid=(\d+)\b/.exec(line)?.[1] ?? "");
+  const takenAt = /\btaken=(\S+)/.exec(line)?.[1] ?? "";
+  if (!Number.isInteger(pid) || pid <= 0 || !Number.isFinite(Date.parse(takenAt))) return null;
+  return { pid, takenAt };
+}
+
+/**
+ * How old this lock is: by its own stated instant, else by its mtime.
+ *
+ * The mtime fallback is what gives an unattributed lock an age at all — the
+ * whole reason the six-hour zero-byte file could not be judged. A negative age
+ * (a clock that moved backwards) is clamped to zero rather than reaped: a lock
+ * from the future is a machine problem, not an orphan.
+ */
+async function spawnLockAgeMs(
+  lockPath: string,
+  holder: SpawnLockHolder | null,
+  nowMs: number,
+): Promise<number | null> {
+  const stated = holder == null ? Number.NaN : Date.parse(holder.takenAt);
+  if (Number.isFinite(stated)) return Math.max(0, nowMs - stated);
+  try {
+    return Math.max(0, nowMs - (await stat(lockPath)).mtimeMs);
+  } catch {
     return null;
   }
 }


### PR DESCRIPTION
Automated AFK landing for #3123. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3123

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788328012&installation_model_id=20659&pr_number=3130&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3130&signature=54d5c8618d355de2a2cf8417f627d4df25f8442f5f95b490d43aa8ae50d9d294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->