### PR TITLE
fix: do not claim a baseline comparison that never happened

### DIFF
--- a/.changeset/a-comparison-that-never-ran.md
+++ b/.changeset/a-comparison-that-never-ran.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A validation record no longer claims a baseline comparison that never happened. `baselineComparisonSummary` concatenated whatever the baseline produced behind the words "also fails on the baseline", so a worktree that could not be built at all — a missing ref, a busy lock, an `ENOENT` on the path — was reported as a failure the baseline had reproduced. That parked #3082 as broken work for hours on a record reading `failed` in 146 milliseconds, with `typecheck` and `build` green and no test having run; the change was complete and landed unmodified once rebased. The summary now distinguishes the two, saying "the baseline could not be built, so nothing was compared" when the message is about infrastructure rather than about a test. Blocking on a genuinely inconclusive result is unchanged and deliberate (#2380) — the probe downgrades nothing, because pre-merge gating is the sole quality gate — and the tests pin both directions so a real reproduced failure is never mistaken for a harness fault.

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -740,8 +740,49 @@ function isWorktreeSetupFailure(output: string): boolean {
  * The sidecar summary for an `inconclusive` check — the comparison evidence a
  * human needs to read the `blocked:validation` park without re-running anything.
  */
+/**
+ * Patterns that mean the baseline was never BUILT, not that it also failed.
+ *
+ * A baseline worktree that could not be created, checked out or installed
+ * produces a message about a path or a ref, not about a test — and calling that
+ * "also fails on the baseline" asserts a comparison that never ran.
+ */
+const BASELINE_UNBUILT_PATTERNS: readonly RegExp[] = [
+  /\bENOENT\b/i,
+  /couldn't find remote ref/i,
+  /could not find remote ref/i,
+  /\bunable to lock ref\b/i,
+  /worktree (?:add|install) failed/i,
+  /lock wait timed out/i,
+  /\bEACCES\b/i,
+];
+
+/** True when the baseline never ran, so nothing was compared. PURE. */
+export function baselineNeverRan(baselineSummary: string | undefined): boolean {
+  const detail = baselineSummary?.trim();
+  if (detail == null || detail === "") return false;
+  return BASELINE_UNBUILT_PATTERNS.some((pattern) => pattern.test(detail));
+}
+
+/**
+ * What the branch's record says once the baseline has been consulted.
+ *
+ * **"Also fails on the baseline" is a claim about a comparison, and it must not
+ * be made when the comparison never happened.** A baseline worktree that could
+ * not be constructed — a missing ref, a busy lock, an `ENOENT` on the path —
+ * produces a message about infrastructure, and the old wording concatenated it
+ * behind "also fails on the baseline", asserting a result nobody measured.
+ *
+ * That mattered: #3082 sat parked as broken work for hours on a record reading
+ * `failed` in 146ms, with `typecheck` and `build` green, because the baseline
+ * worktree for `main` did not exist. The change was complete and landed
+ * unmodified once rebased.
+ */
 function baselineComparisonSummary(baselineSummary: string | undefined): string {
   const detail = baselineSummary?.trim();
+  if (detail && baselineNeverRan(detail)) {
+    return `inconclusive: the baseline could not be built, so nothing was compared — ${detail}`;
+  }
   return detail
     ? `inconclusive: also fails on the baseline — ${detail}`
     : "inconclusive: also fails on the baseline";

--- a/apps/dev/tests/baseline-never-ran.test.ts
+++ b/apps/dev/tests/baseline-never-ran.test.ts
@@ -1,0 +1,54 @@
+// "Also fails on the baseline" is a claim about a comparison (#3126).
+//
+// #3082 sat parked as broken work for hours on a validation record that read
+// `failed` in 146 milliseconds — no test ran — with `typecheck` and `build`
+// green. Its summary said "inconclusive: also fails on the baseline — ENOENT:
+// no such file or directory, lstat '.../feedback/main'".
+//
+// The baseline worktree did not exist. Nothing was compared. The change was
+// complete and landed unmodified once rebased.
+//
+// Blocking on a genuinely inconclusive result is deliberate (#2380): the probe
+// downgrades nothing, because pre-merge gating is the sole quality gate. This
+// is about the OTHER case — asserting a comparison that never happened.
+import { describe, expect, it } from "vitest";
+import { baselineNeverRan } from "../src/core/feedback.js";
+
+describe("baselineNeverRan", () => {
+  it("recognises the exact message that parked #3082", () => {
+    expect(
+      baselineNeverRan("ENOENT: no such file or directory, lstat '/w/.red/tmp/worktrees/feedback/main'"),
+    ).toBe(true);
+  });
+
+  it("recognises the other harness failures seen in the same logs", () => {
+    for (const message of [
+      "feedback worktree add failed for main; fatal: couldn't find remote ref refs/heads/main",
+      "feedback worktree install failed for afk/w1/42-fix (exit 1)",
+      "fatal: unable to lock ref",
+      "feedback worktree /root/.red/tmp/feedback/afk-w1-9-x is busy (lock wait timed out)",
+      "EACCES: permission denied",
+    ]) {
+      expect(baselineNeverRan(message), message).toBe(true);
+    }
+  });
+
+  it("does NOT claim a real reproduced failure was a harness fault", () => {
+    // These are genuine inconclusive results: the baseline ran and also failed.
+    // Blocking on them is the documented behaviour and must not change.
+    for (const message of [
+      "2 tests failed",
+      "command exited 1",
+      "AssertionError: expected 1 to be 2",
+      "Test Files 1 failed | 8 passed",
+    ]) {
+      expect(baselineNeverRan(message), message).toBe(false);
+    }
+  });
+
+  it("is false for an absent or empty summary rather than guessing", () => {
+    expect(baselineNeverRan(undefined)).toBe(false);
+    expect(baselineNeverRan("")).toBe(false);
+    expect(baselineNeverRan("   ")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #3126.

## The issue as filed was partly wrong, and I am correcting it

#3126 asked for `inconclusive` to stop blocking. **It should keep blocking** — that is deliberate and documented:

> *A failure absent from the baseline is the branch fault; a failure reproduced on the baseline is inconclusive. Both block the branch — the probe downgrades nothing and files nothing, because pre-merge gating is the sole quality gate (#2380).*

Nothing here changes that.

## What was actually broken

`baselineComparisonSummary` concatenated **whatever** the baseline produced behind the words *"also fails on the baseline"*. So a baseline worktree that could not be **built** was reported as a failure the baseline had **reproduced**:

```
inconclusive: also fails on the baseline —
  ENOENT: no such file or directory, lstat .../feedback/main
```

The baseline did not fail. **The baseline did not exist.** Nothing was compared, and the record asserted a comparison anyway.

That parked #3082 for hours as broken work: `failed` in **146 milliseconds** — no test ran — with `typecheck` and `build` green. The change was complete and landed unmodified once rebased.

## What is here

- `baselineNeverRan` recognises harness failures — missing refs, busy locks, `ENOENT`, `EACCES`, worktree add/install failures — all drawn from messages this repo actually produced.
- The summary then says *"the baseline could not be built, so nothing was compared"*, which sends a reader to the harness instead of to a diff that was never the problem.
- Tests pin **both** directions: the exact message that parked #3082, and a set of genuine reproduced failures that must keep reading as inconclusive.

## Verification

393 files, 5847 tests · typecheck 14/14.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788331433&installation_model_id=20659&pr_number=3137&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3137&signature=cc5832170ea4883f96ca44659326a65d2c46305a3b9c787456cc2b254dd091a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->