### PR TITLE
feat(redskilled): the host view in a terminal

### DIFF
--- a/.changeset/the-host-view-in-a-terminal.md
+++ b/.changeset/the-host-view-in-a-terminal.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+`redskilled dashboard` renders the host view a terminal can read — the same screen the herdr plugin and the VS Code extension draw, at the density a terminal wants. It is a density argument to the shared render rather than a second renderer: ADR 0132 decision 1 moved layout out of the daemon precisely so four surfaces could differ in HEIGHT without differing in content, and a command that drew its own would be the drift that decision exists to prevent. It reuses the statusline's flag parse, so `global` and `--max-width` mean here exactly what they mean there — two spellings of one scope is how a second vocabulary starts — and it keeps the statusline's promise to always write something and always exit `0`, because a dashboard that printed nothing is indistinguishable from a host with no Workers, and an operator reaching for it is usually already trying to find out why something is quiet. The name is `redskilled dashboard` rather than `dashboard`, which already names the project/DORA view that `/afk dashboard`, `daily-review` and `weekly-review` all depend on.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -23,6 +23,7 @@ import {
 import {
   ensureRedskilledDaemon,
   readRedskilledHostState,
+  readRedskilledDashboardRender,
   readRedskilledStatuslineRender,
   stopRedskilledDaemon,
   type RedskilledClientConfig,
@@ -78,6 +79,7 @@ Commands:
   host-state (default)  print the host's state as JSON
   serve                 run the daemon in this process
   statusline [global]   render one agent-host status line
+  dashboard [global]    render the host view a terminal can read
   unit                  install | uninstall | status — the optional supervisor
   provision             make this machine ready; --check is the read-only half
   reclaim               clear runtime dirs left by dead sessions
@@ -114,6 +116,17 @@ no queue — an honest unknown, never a drained one.
 Prints the host's state as JSON. Contacts the running daemon; the default
 command when none is named.
 `,
+  dashboard: `Usage: redskilled dashboard [global] [flags]
+
+The host view the herdr plugin and the VS Code extension draw, at the density a
+terminal can read. Same payload and same render as the statusline (ADR 0132
+decision 1) — a density argument, never a second renderer.
+
+  global          every project's Workers, each naming its owner
+  --max-width N   hard ceiling in characters
+
+It always writes something and always exits 0: a dashboard that printed nothing
+is indistinguishable from a host with no Workers.`,
   statusline: `Usage: redskilled statusline [global] [--verbose] [flags]
 
 Renders the status line the agent host prints verbatim. Config is read on this
@@ -346,9 +359,9 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
   }
 
   const { command, args } = routeCommand<
-    "serve" | "stop" | "host-state" | "statusline" | "unit" | "provision" | "reclaim"
+    "serve" | "stop" | "host-state" | "statusline" | "dashboard" | "unit" | "provision" | "reclaim"
   >(argv, {
-    commands: { serve: {}, stop: {}, "host-state": {}, statusline: {}, unit: {}, provision: {}, reclaim: {} },
+    commands: { serve: {}, stop: {}, "host-state": {}, statusline: {}, dashboard: {}, unit: {}, provision: {}, reclaim: {} },
     default: "host-state",
   });
 
@@ -424,6 +437,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
 
   if (command === "stop") return await runStop(args);
   if (command === "statusline") return await runStatusline(args);
+  if (command === "dashboard") return await runDashboard(args);
   if (command === "unit") return await runUnit(args);
 
   if (command === "provision") return await runProvision(args);
@@ -815,4 +829,72 @@ if (invokedDirectly) {
       process.exitCode = 1;
     },
   );
+}
+
+/**
+ * `redskilled dashboard [global] [--max-width N]` — the host view in a terminal.
+ *
+ * **The same payload and the same render as the statusline, at a taller
+ * density** (#3098, ADR 0132 decision 1). Layout moved out of the daemon so four
+ * surfaces could differ in HEIGHT without differing in content; this is the
+ * terminal one, and it asks for a density rather than importing a second
+ * renderer. A host that drew its own dashboard would be the drift the decision
+ * exists to prevent.
+ *
+ * **It always writes something and always exits 0**, for the same reason the
+ * statusline does: a dashboard that printed nothing is indistinguishable from a
+ * host with no Workers, and an operator reaching for it is usually already
+ * trying to find out why something is quiet.
+ */
+export async function runDashboard(
+  args: readonly string[],
+  io: {
+    readonly cwd?: string;
+    readonly paths?: RedskilledPaths;
+    readonly write?: (line: string) => void;
+    readonly warn?: (line: string) => void;
+    readonly client?: RedskilledClientConfig;
+    readonly now?: () => string;
+  } = {},
+): Promise<number> {
+  const write = io.write ?? ((line: string) => process.stdout.write(line));
+  const warn = io.warn ?? ((line: string) => process.stderr.write(line));
+
+  // The statusline's own flag parse, so `global` and `--max-width` mean here
+  // exactly what they mean there — two spellings of one scope is how a second
+  // vocabulary starts.
+  const parsed = parseRedskilledStatuslineFlags(args);
+  const project = readStatuslineProject(io.cwd ?? process.cwd());
+  const resolved = resolveRedskilledStatuslineOptions({
+    ...(project.configText == null ? {} : { configText: project.configText }),
+    project: project.label,
+    flags: parsed.flags,
+  });
+  for (const warning of [...resolved.warnings, ...parsed.warnings]) {
+    warn(`redskilled dashboard: ignoring ${warning.key}=${warning.value} — ${warning.reason}\n`);
+  }
+
+  try {
+    const render = await readRedskilledDashboardRender(
+      io.paths ?? resolveRedskilledPaths(),
+      {
+        ...(resolved.options.project == null ? {} : { project: resolved.options.project }),
+        // `mode` is the shared vocabulary for scope — `local` or `global` — and
+        // the statusline's resolver already decided it from config and flags.
+        mode: resolved.options.mode,
+        ...(resolved.options.maxWidth == null ? {} : { maxWidth: resolved.options.maxWidth }),
+      },
+      {
+        ...(io.client ?? {}),
+        ...(resolved.options.project == null ? {} : { sessionProject: resolved.options.project }),
+      },
+    );
+    write(`${render.lines.join("\n")}\n`);
+  } catch (err) {
+    // A stated absence, never silence. The operator asked what the host is
+    // doing; "I could not ask" is an answer and an empty screen is not.
+    warn(`redskilled dashboard: ${err instanceof Error ? err.message : String(err)}\n`);
+    write("redskilled unreachable — the host was not asked, so its Workers are unknown\n");
+  }
+  return 0;
 }

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -74,8 +74,11 @@ import {
   type RedskilledWorkerStarted,
 } from "./protocol.js";
 import {
+  REDSKILLED_DASHBOARD_DEFAULTS,
   REDSKILLED_STATUSLINE_DEFAULTS,
+  renderRedskilledDashboard,
   renderRedskilledStatusline,
+  type RedskilledDashboard as RedskilledDashboardRender,
   type RedskilledDashboardOptions,
   type RedskilledStatuslineOptions,
 } from "@reddb-io/redskilled-render";
@@ -548,6 +551,28 @@ export async function readRedskilledStatuslineRender(
     logs: options.verbose,
   });
   return renderRedskilledStatusline(payload, options);
+}
+
+/**
+ * The host dashboard, read from the socket and drawn HERE (#3098).
+ *
+ * **The same payload and the same render as the statusline, at a taller
+ * density.** ADR 0132 decision 1 moved layout out of the daemon precisely so
+ * four surfaces could differ in height without differing in content; this is
+ * the terminal one, and it is a density argument rather than a second renderer.
+ *
+ * Vitals and log lines are both asked for, because a dashboard is the density
+ * that draws them — the statusline pays for logs only under `--verbose`, and a
+ * dashboard that omitted them would be a taller statusline rather than a
+ * dashboard.
+ */
+export async function readRedskilledDashboardRender(
+  paths: RedskilledPaths,
+  options: Partial<RedskilledDashboardOptions> = {},
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledDashboardRender> {
+  const payload = await readRedskilledStatuslinePayload(paths, config, { vitals: true, logs: true });
+  return renderRedskilledDashboard(payload, { ...REDSKILLED_DASHBOARD_DEFAULTS, ...options });
 }
 
 /**

--- a/apps/redskilled/tests/dashboard-command.test.ts
+++ b/apps/redskilled/tests/dashboard-command.test.ts
@@ -1,0 +1,65 @@
+// `redskilled dashboard` — the host view a terminal can read (#3098).
+//
+// The same payload and the same render as the statusline, at a taller density
+// (ADR 0132 decision 1). Layout moved out of the daemon so four surfaces could
+// differ in HEIGHT without differing in content, so this asks for a density
+// rather than importing a second renderer.
+import { describe, expect, it } from "vitest";
+import { REDSKILLED_USAGE, runDashboard } from "../src/cli.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+
+function capture() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, write: (l: string) => out.push(l), warn: (l: string) => err.push(l) };
+}
+
+describe("the dashboard is reachable before anything works", () => {
+  it("is named in the front-door usage", () => {
+    // A shipped binary answers --help without a working machine, and a
+    // subcommand nobody can discover is one nobody uses.
+    expect(REDSKILLED_USAGE).toContain("dashboard");
+  });
+
+  it("names the scope word the statusline uses, not a second vocabulary", () => {
+    // `global` means here exactly what it means there; two spellings of one
+    // scope is how a second vocabulary starts.
+    expect(REDSKILLED_USAGE).toContain("dashboard [global]");
+  });
+});
+
+describe("the dashboard always answers", () => {
+  it("writes a stated absence and exits 0 when no daemon answers", async () => {
+    // A dashboard that printed nothing is indistinguishable from a host with no
+    // Workers — and an operator reaching for it is usually already trying to
+    // find out why something is quiet.
+    const io = capture();
+    const code = await runDashboard([], {
+      paths: resolveRedskilledPaths({ env: { XDG_RUNTIME_DIR: "/nonexistent-for-this-test" } }),
+      write: io.write,
+      warn: io.warn,
+      // No spawn, no wait: this test is about what the command WRITES when
+      // the host is not there, not about how long it is willing to wait.
+      client: { serverCommand: "/nonexistent-daemon-for-this-test", readyTimeoutMs: 200, requestTimeoutMs: 200 },
+      cwd: "/",
+    });
+    expect(code).toBe(0);
+    expect(io.out.join("")).toContain("unreachable");
+    expect(io.out.join("")).toMatch(/\n$/);
+  });
+
+  it("says why on stderr while still writing to stdout", async () => {
+    const io = capture();
+    await runDashboard([], {
+      paths: resolveRedskilledPaths({ env: { XDG_RUNTIME_DIR: "/nonexistent-for-this-test" } }),
+      write: io.write,
+      warn: io.warn,
+      // No spawn, no wait: this test is about what the command WRITES when
+      // the host is not there, not about how long it is willing to wait.
+      client: { serverCommand: "/nonexistent-daemon-for-this-test", readyTimeoutMs: 200, requestTimeoutMs: 200 },
+      cwd: "/",
+    });
+    expect(io.err.join("")).toContain("redskilled dashboard:");
+    expect(io.out.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #3098.

## What it is

`redskilled dashboard` renders the host view the herdr plugin and the VS Code extension draw, at the density a terminal can read. Verified end to end against a live daemon:

```
$ redskilled dashboard
» reddb-io/red-skills v3.3.13 · wrk=2/2 · slots=∞ · mem=0B/10.9G 0%
7a5a9b0f-e857-420f-99e3-53a5f31882f1  1h52m   hb=?
f08dc85e-d3c7-4f87-ab88-554e1e52f906  42m26s  hb=?

$ redskilled dashboard global
» reddb-io/red-skills v3.3.13 · wrk=2/2 · slots=∞ · mem=0B/10.9G 0%
reddb-io/red-skills:7a5a9b0f-…  1h52m   hb=?
reddb-io/red-skills:f08dc85e-…  42m34s  hb=?
```

## A density argument, never a second renderer

ADR 0132 decision 1 moved layout out of the daemon so four surfaces could differ in **height** without differing in **content**. This command asks `renderRedskilled` for the `dashboard` density and prints what comes back. A command that drew its own layout would be precisely the drift that decision exists to prevent — the fourth renderer nobody would notice diverging for weeks.

It reuses the **statusline's own flag parse**, so `global` and `--max-width` mean here exactly what they mean there. Two spellings of one scope is how a second vocabulary starts. (The scope word in the shared options is `mode`, not `scope` — the first version of this used `scope` and the typechecker caught it.)

## It always answers

Same promise as the statusline: **always writes something, always exits 0**. A dashboard that printed nothing is indistinguishable from a host with no Workers, and whoever reached for it is usually already trying to find out why something is quiet. With no daemon it writes a stated absence to stdout and the reason to stderr.

## The name

`redskilled dashboard`, not `dashboard`. That name already belongs to the project/DORA view — `/afk dashboard`, `daily-review` and `weekly-review` all depend on it. Renaming it would churn documented surface to gain one word.

## Shipped-binary obligations

- `--help` lists it on the static front door.
- `dashboard --help` answers before touching a socket, config, a store or the filesystem.
- `--version` answers without a working machine.

## Verification

`apps/redskilled` **62 files, 633 tests** · typecheck **14/14** · repo invariants **9 files, 141 tests** · live daemon end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hZobkv9P8Su16hA1hLB9x

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788332442&installation_model_id=20659&pr_number=3140&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3140&signature=b9f4153f4ff82dcff316ba65ea95e234caea63083da4ce5314e853226628e923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->