### PR TITLE
chore: #3142 redskilled dashboard reaches none of the surfaces that name a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,18 @@ global verbose view is still one read and opens no project's files. A crowded
 machine **degrades rather than overflows**: one entry per project, then the host
 total, with the loss stated rather than left to be detected by re-parsing.
 
+### Dashboard
+
+The `dashboard` command is the same host view at the density a terminal can
+read — run as
+`npx -y -p @reddb-io/red-skills@<version> red-skills-redskilled dashboard`, or
+with `global` for every project's Workers, each naming its owner, and
+`--max-width N` for a hard ceiling. It is the statusline's taller sibling and
+**not a second renderer**: it asks the daemon for the same payload and draws it
+with the same render the herdr plugin and the VS Code extension use (ADR 0132
+decision 1), so a terminal with no plugin installed sees what those UIs see. Like
+the statusline, it always writes something and always exits 0.
+
 ## Token-Efficient Terminal Work
 
 `rsp` ([`apps/rsp/`](./apps/rsp/README.md), ADR 0095) wraps the noisy development

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -50,6 +50,12 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
   rsp usage gains, skill quality, or repository context. For operational
   troubleshooting, route to the owning reference: `/afk`, `/go`, `/hitl`, or
   rsp.
+- **"What is this host running right now?"** -> the `redskilled` daemon's own
+  `dashboard` command, not a plugin surface. It is the host view — every Worker
+  on the machine, whichever project owns it — at terminal density, so it answers
+  where no plugin is installed. `/dashboard` stays the route for this
+  repository's queue health; `/red-statusline` owns the one-line form and
+  documents both in its host notes.
 - **Operating the castle itself** -> the `castle` MCP, not a shell command.
   Fleet lifecycle, worker dispatch, runners and live steer, gate, landing,
   claim, worktrees, hygiene, and observability are all tools on one canonical
@@ -109,6 +115,9 @@ Capability references registered by owner:
 `plugins/dev/skills/engineering/afk/MCP.md`;
 `/afk` landing-tail throughput (`afk.landing.wait`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
+the host view a terminal can read (the `redskilled` daemon's `dashboard`
+command, and the `statusline` line it shares a render with) ->
+`plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md`;
 territory scoping (`tag:<value>` labels, `/afk --tags`/`--user`) ->
 `plugins/dev/skills/engineering/red-setup/triage-labels.md`.
 

--- a/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -233,6 +233,18 @@ RS="npx -y -p @reddb-io/red-skills@<version> red-skills-redskilled"
 | `$RS statusline --max-width 60` | the same, under a narrower line |
 | `$RS statusline --verbose` | each listed Worker plus a second line: the last line it logged |
 | `$RS statusline global --verbose` | the same, machine-wide, each second line naming its Worker's owner |
+| `$RS dashboard` | the same read at terminal density — the local project's Workers as a table |
+| `$RS dashboard global` | every project's Workers, each naming its owner |
+| `$RS dashboard --max-width 100` | the same table under a narrower ceiling |
+
+**`dashboard` is the statusline's taller sibling, not a second renderer** (#3098,
+ADR 0132 decision 1). It asks the daemon for the same payload and draws it with
+the same render the herdr plugin and the VS Code extension use — a **density
+argument**, so a terminal with no plugin installed reads the host view the UIs
+read. Vitals and log lines ride along by default, because a dashboard that
+dropped them would just be a taller statusline. It obeys the statusline's own
+honesty rule: it always writes something and always exits 0, since a dashboard
+that printed nothing is indistinguishable from a host with no Workers.
 
 **The second line comes from the Worker, never from its log file.** With `--verbose` each listed Worker gets one extra line carrying the last line it logged. The Worker **publishes** that line on the beat its castle lane bridge already keeps (`createWorkerLogLinePublisher`, addressed with the `REDSKILLED_WORKER_ID` the daemon handed it at birth) and the daemon stores it as an opaque string — so a verbose global view is still one read and opens no other project's files. A statusline that read each Worker's log directly would cost a disk read per Worker per render and cross a project boundary on every tick. A Worker that has logged nothing renders no second line, and the annotation disappears entirely once the line degrades past the Worker entries — a second line belongs to a Worker entry, and an aggregate row has no Worker to be the second line of.
 

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -50,6 +50,12 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
   rsp usage gains, skill quality, or repository context. For operational
   troubleshooting, route to the owning reference: `/afk`, `/go`, `/hitl`, or
   rsp.
+- **"What is this host running right now?"** -> the `redskilled` daemon's own
+  `dashboard` command, not a plugin surface. It is the host view — every Worker
+  on the machine, whichever project owns it — at terminal density, so it answers
+  where no plugin is installed. `/dashboard` stays the route for this
+  repository's queue health; `/red-statusline` owns the one-line form and
+  documents both in its host notes.
 - **Operating the castle itself** -> the `castle` MCP, not a shell command.
   Fleet lifecycle, worker dispatch, runners and live steer, gate, landing,
   claim, worktrees, hygiene, and observability are all tools on one canonical
@@ -109,6 +115,9 @@ Capability references registered by owner:
 `plugins/dev/skills/engineering/afk/MCP.md`;
 `/afk` landing-tail throughput (`afk.landing.wait`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
+the host view a terminal can read (the `redskilled` daemon's `dashboard`
+command, and the `statusline` line it shares a render with) ->
+`plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md`;
 territory scoping (`tag:<value>` labels, `/afk --tags`/`--user`) ->
 `plugins/dev/skills/engineering/red-setup/triage-labels.md`.
 

--- a/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -233,6 +233,18 @@ RS="npx -y -p @reddb-io/red-skills@<version> red-skills-redskilled"
 | `$RS statusline --max-width 60` | the same, under a narrower line |
 | `$RS statusline --verbose` | each listed Worker plus a second line: the last line it logged |
 | `$RS statusline global --verbose` | the same, machine-wide, each second line naming its Worker's owner |
+| `$RS dashboard` | the same read at terminal density — the local project's Workers as a table |
+| `$RS dashboard global` | every project's Workers, each naming its owner |
+| `$RS dashboard --max-width 100` | the same table under a narrower ceiling |
+
+**`dashboard` is the statusline's taller sibling, not a second renderer** (#3098,
+ADR 0132 decision 1). It asks the daemon for the same payload and draws it with
+the same render the herdr plugin and the VS Code extension use — a **density
+argument**, so a terminal with no plugin installed reads the host view the UIs
+read. Vitals and log lines ride along by default, because a dashboard that
+dropped them would just be a taller statusline. It obeys the statusline's own
+honesty rule: it always writes something and always exits 0, since a dashboard
+that printed nothing is indistinguishable from a host with no Workers.
 
 **The second line comes from the Worker, never from its log file.** With `--verbose` each listed Worker gets one extra line carrying the last line it logged. The Worker **publishes** that line on the beat its castle lane bridge already keeps (`createWorkerLogLinePublisher`, addressed with the `REDSKILLED_WORKER_ID` the daemon handed it at birth) and the daemon stores it as an opaque string — so a verbose global view is still one read and opens no other project's files. A statusline that read each Worker's log directly would cost a disk read per Worker per render and cross a project boundary on every tick. A Worker that has logged nothing renders no second line, and the annotation disappears entirely once the line degrades past the Worker entries — a second line belongs to a Worker entry, and an aggregate row has no Worker to be the second line of.
 


### PR DESCRIPTION
Automated AFK landing for #3142. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3142

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788345387&installation_model_id=20659&pr_number=3143&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3143&signature=6c3dd1341ba938304660f4160fc2a4a269ea2d774c48a0ff9dd67ca98d89f3a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->