### PR TITLE
fix: ask for the display record, or every surface shows a UUID

### DIFF
--- a/.changeset/ask-for-the-display.md
+++ b/.changeset/ask-for-the-display.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Every payload read that renders a Worker now asks for its display record, so the statusline, the dashboard, the herdr plugin and the VS Code extension can show runner, model, effort, issue, phase and the progress bar instead of a UUID and an age. The daemon serves three extras — `logs`, `vitals` and `display` — and withholds any a request does not name; the daemon's own comment says a request naming none "asked for everything by saying nothing", and ours named two, so by naming them it excluded the third. The record was built by the castle lane bridge, published on the beat it already keeps, accepted by the daemon and stored — and never requested. A test now asserts every payload read that renders a Worker names both `display` and `vitals`, because the absence was invisible: each module read correct in isolation and the chain was silent only at the one link nobody looked at.

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -549,6 +549,11 @@ export async function readRedskilledStatuslineRender(
   const payload = await readRedskilledStatuslinePayload(paths, config, {
     vitals: true,
     logs: options.verbose,
+    // Asked for, or the line renders a UUID and an age. The daemon holds a
+    // display record per Worker and hands it over only when a reader names the
+    // extra — so runner, model, effort, phase, the progress bar and the issue
+    // were built, published, stored, and never requested (#3144).
+    display: true,
   });
   return renderRedskilledStatusline(payload, options);
 }
@@ -571,7 +576,13 @@ export async function readRedskilledDashboardRender(
   options: Partial<RedskilledDashboardOptions> = {},
   config: RedskilledClientConfig = {},
 ): Promise<RedskilledDashboardRender> {
-  const payload = await readRedskilledStatuslinePayload(paths, config, { vitals: true, logs: true });
+  // All three extras: a dashboard is the density that draws every one of them,
+  // and the display is what makes a row a Worker rather than an identifier.
+  const payload = await readRedskilledStatuslinePayload(paths, config, {
+    vitals: true,
+    logs: true,
+    display: true,
+  });
   return renderRedskilledDashboard(payload, { ...REDSKILLED_DASHBOARD_DEFAULTS, ...options });
 }
 

--- a/apps/redskilled/tests/display-is-asked-for.test.ts
+++ b/apps/redskilled/tests/display-is-asked-for.test.ts
@@ -1,0 +1,50 @@
+// Every payload read that renders a Worker asks for its display (#3144).
+//
+// The daemon serves three extras — `logs`, `vitals`, `display` — and withholds
+// any a request does not name. The comment in the daemon says it plainly: a
+// request that names NO extras "asked for everything by saying nothing". Ours
+// named two, and by naming them excluded the third.
+//
+// So the display record was built by the castle bridge, published on the beat,
+// accepted by the daemon and stored — and never requested. Every surface
+// rendered a UUID and an age.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { REDSKILLED_STATUSLINE_EXTRAS } from "../src/statusline-payload.js";
+
+const CLIENT = readFileSync(join(import.meta.dirname, "..", "src", "client.ts"), "utf8");
+
+/** Each `readRedskilledStatuslinePayload(...)` call and the extras it names. */
+function payloadReads(source: string): readonly string[] {
+  const out: string[] = [];
+  const marker = "readRedskilledStatuslinePayload(";
+  let at = source.indexOf(marker);
+  while (at !== -1) {
+    // The call's argument list, up to the matching close — enough to see which
+    // extras it named without parsing TypeScript.
+    out.push(source.slice(at, source.indexOf(");", at)));
+    at = source.indexOf(marker, at + marker.length);
+  }
+  // The first hit is the function's own declaration, not a call.
+  return out.slice(1);
+}
+
+describe("the display is asked for", () => {
+  it("knows all three extras exist", () => {
+    expect([...REDSKILLED_STATUSLINE_EXTRAS].sort()).toEqual(["display", "logs", "vitals"]);
+  });
+
+  it("every render read names display", () => {
+    const reads = payloadReads(CLIENT);
+    expect(reads.length).toBeGreaterThan(0);
+    for (const read of reads) {
+      expect(read, `a payload read that renders a Worker must ask for its display:\n${read}`)
+        .toContain("display: true");
+    }
+  });
+
+  it("every render read also names vitals, so memory is never a blank", () => {
+    for (const read of payloadReads(CLIENT)) expect(read).toContain("vitals: true");
+  });
+});


### PR DESCRIPTION
Toward #3144, link 1 of 2.

The daemon serves three extras — `logs`, `vitals`, `display` — and withholds any a request does not name. Its own comment: a request naming NONE *"asked for everything by saying nothing"*. Ours named two, and by naming them **excluded the third**.

So the display record was built by the castle lane bridge, published on the beat it already keeps, accepted by the daemon and stored — and never requested. Every surface rendered a UUID and an age while runner, model, effort, issue, phase and the progress bar sat in the daemon unasked.

Both render reads now name `display` and `vitals`, and a test asserts it for every payload read in the client. The absence was invisible because each module read correct in isolation.

**Link 2 is documented on #3144 and not fixed here:** the Worker environment reaches the process empty, so nothing is published in the first place. Both are load-bearing — fixing either alone changes nothing on screen.

63 files / 638 tests in apps/redskilled; typecheck 14/14.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788346513&installation_model_id=20659&pr_number=3145&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3145&signature=3696ea2206440ef58cc3484d08343b886c74ab8c82d0f82d7fdbdb59e184588e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->