### PR TITLE
fix: report a plugin that is behind, with both numbers

### DIFF
--- a/.changeset/nothing-watched-the-plugin-lane.md
+++ b/.changeset/nothing-watched-the-plugin-lane.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+`red-doctor` now reports when the installed plugin is behind the published one, with both numbers and the command that closes the gap. Two update lanes exist and only one was watched: the bundle lane self-updates and reports, while the plugin lane — the host's own install, which carries the MCP server and the skills — sat nine releases behind under a doctor that answered `marketplace findings: 0`. The skew is invisible from outside, and that is what makes it costly: the MCP server is what COMPOSES a project registration, so an old one registers with an empty launch environment while writing the CURRENT bundle path into the argv — a fresh Worker running new code, born from a registration composed by old code, with every version number on screen true about something else. An unaskable registry reports `unknown` rather than `current`, because reporting an unreachable npm as up-to-date would be the loudest instance yet of the unknown-read-as-negative confusion this repo has hit in four organs — it would certify the machine.

--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -224,6 +224,7 @@ function renderClassifierSections(
     runtimeUnresolved,
     hostBinaries,
     marketplaceSources,
+    pluginVersion,
     mcpLoad,
     dependencyEdges,
     dependencyEdgesUnread,
@@ -260,6 +261,10 @@ function renderClassifierSections(
     ...hostBinaries.findings.map((finding) => `  ${finding.kind}: ${finding.reason}`),
     ...hostBinaries.findings.map((finding) => `  fix: ${finding.remediation}`),
     "",
+    "red-doctor plugin version",
+    `  installed=${pluginVersion.installed ?? "none"} published=${pluginVersion.published ?? "unknown"} → ${pluginVersion.verdict}`,
+    ...(pluginVersion.verdict === "current" ? [] : [`  ${pluginVersion.detail}`]),
+    ...(pluginVersion.fix == null ? [] : [`  fix: ${pluginVersion.fix}`]),
     "red-doctor marketplace registration source",
     ...marketplaceSources.rows.map(
       (row) => `  ${MARKETPLACE_VERDICT_ICON[row.verdict]} ${row.host} ${row.marketplace} source=${row.source} (${row.detail})`,

--- a/apps/dev/src/core/plugin-version-doctor.ts
+++ b/apps/dev/src/core/plugin-version-doctor.ts
@@ -1,0 +1,227 @@
+// plugin-version-doctor — is the plugin that answers actually current? (#3147)
+//
+// **Two update lanes exist and only one was watched.** The BUNDLE lane
+// self-updates and works: `dev-stable.current` tracks the published version, the
+// status file says `up-to-date`, and a registration's argv correctly names the
+// newest cached bundle. The PLUGIN lane — the host's own install, which carries
+// the MCP server and the skills — is updated by the agent host's plugin manager,
+// and nothing here ever looked at its version.
+//
+// It sat eight releases behind while every surface read green. `red-doctor`
+// reported `marketplace findings: 0`, and `mcp-load-doctor` asked only whether
+// servers loaded, never which bundle answered them.
+//
+// **The skew is invisible from the outside, which is why it needs a probe.** The
+// MCP server is what COMPOSES a project registration; an old adapter registers
+// with an empty launch environment and writes the CURRENT bundle path into the
+// argv. So a fresh Worker runs new code, born from a registration composed by
+// old code, and every version number on screen is true about something else.
+// That cost a full session of debugging a fix that had already shipped.
+//
+// PURE: the caller reads the filesystem and the registry; this decides.
+
+/** Where a version came from, so a report can name it. */
+export type PluginVersionSource = "installed-plugin" | "published";
+
+export interface PluginVersionFacts {
+  /** Newest version present in the host's plugin cache; `null` when none is. */
+  readonly installed: string | null;
+  /** What the registry publishes; `null` when it could not be asked. */
+  readonly published: string | null;
+  /** Every version the plugin cache holds, newest last. For the report only. */
+  readonly cached?: readonly string[];
+}
+
+export type PluginVersionVerdict =
+  | "current"
+  /** Behind by less than the bound — worth saying, not worth shouting. */
+  | "behind"
+  /** Behind by the bound or more: the machine is running something else. */
+  | "stale"
+  /** Nothing installed at all. */
+  | "absent"
+  /**
+   * The registry could not be asked.
+   *
+   * **Unknown is not current.** Reporting an unaskable registry as up-to-date is
+   * the same confusion — an inconclusive result read as a negative one — that
+   * this repo has now hit in four organs, so it gets its own verdict.
+   */
+  | "unknown";
+
+export interface PluginVersionReport {
+  readonly verdict: PluginVersionVerdict;
+  readonly installed: string | null;
+  readonly published: string | null;
+  /** How many patch releases behind, when both versions parse; `null` otherwise. */
+  readonly behindBy: number | null;
+  /** One sentence naming both numbers, for an operator who reads nothing else. */
+  readonly detail: string;
+  /** The command that closes the gap, or `null` when nothing is to be done. */
+  readonly fix: string | null;
+}
+
+/**
+ * How far behind is loud rather than merely noted.
+ *
+ * Two, because one release behind is the ordinary state of a machine between a
+ * publish and its next restart, and three is where the adapter that composes a
+ * registration starts predating fixes the bundle already carries.
+ */
+export const PLUGIN_VERSION_STALE_AFTER = 2;
+
+/** Parse a dotted version into comparable parts; `null` when it is not one. */
+function parts(version: string | null): readonly number[] | null {
+  if (version == null) return null;
+  const matched = /^(\d+)\.(\d+)\.(\d+)/.exec(version.trim());
+  return matched === null ? null : [Number(matched[1]), Number(matched[2]), Number(matched[3])];
+}
+
+/** Negative when `a` is older, 0 when equal, positive when newer. PURE. */
+export function compareVersions(a: string | null, b: string | null): number | null {
+  const left = parts(a);
+  const right = parts(b);
+  if (left === null || right === null) return null;
+  for (let i = 0; i < 3; i += 1) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * The recipe that closes the gap.
+ *
+ * Names the marketplace rather than a package: the plugin lane is installed by
+ * the agent host, and telling an operator to run npm would repair the lane that
+ * was never broken.
+ */
+export function pluginUpdateRecipe(marketplace = "red-skills"): string {
+  return `update the ${marketplace} plugin from its marketplace, then restart the session ` +
+    `(an MCP server registers at plugin load and keeps whatever bundle it started with)`;
+}
+
+/** Decide whether the plugin answering is the one that shipped. PURE. */
+export function judgePluginVersion(facts: PluginVersionFacts): PluginVersionReport {
+  const { installed, published } = facts;
+  const base = { installed, published };
+
+  if (installed == null) {
+    return {
+      ...base,
+      verdict: "absent",
+      behindBy: null,
+      detail: "no red-skills plugin is installed for this host, so nothing of ours answers here",
+      fix: pluginUpdateRecipe(),
+    };
+  }
+  if (published == null) {
+    return {
+      ...base,
+      verdict: "unknown",
+      behindBy: null,
+      detail:
+        `the registry could not be asked, so whether the installed plugin ${installed} is current is unknown — ` +
+        "and unknown is not current",
+      fix: null,
+    };
+  }
+
+  const order = compareVersions(installed, published);
+  if (order === null) {
+    return {
+      ...base,
+      verdict: "unknown",
+      behindBy: null,
+      detail:
+        `installed ${JSON.stringify(installed)} or published ${JSON.stringify(published)} is not a version this ` +
+        "probe can compare, so the gap is unknown",
+      fix: null,
+    };
+  }
+  if (order >= 0) {
+    return {
+      ...base,
+      verdict: "current",
+      behindBy: 0,
+      detail: `the installed plugin ${installed} is the published one`,
+      fix: null,
+    };
+  }
+
+  const behindBy = patchDistance(installed, published);
+  const stale = behindBy == null || behindBy >= PLUGIN_VERSION_STALE_AFTER;
+  return {
+    ...base,
+    verdict: stale ? "stale" : "behind",
+    behindBy,
+    detail:
+      `the installed plugin is ${installed} and ${published} is published` +
+      (behindBy == null ? "" : ` — ${behindBy} release${behindBy === 1 ? "" : "s"} behind`) +
+      (stale
+        ? ". The MCP server this plugin carries is what COMPOSES a project registration, so an old one registers " +
+          "with an empty launch environment while writing the CURRENT bundle path into the argv — a fresh Worker " +
+          "running new code, born from a registration composed by old code."
+        : "."),
+    fix: pluginUpdateRecipe(),
+  };
+}
+
+/** Patch releases between two versions on the same minor; `null` across minors. */
+function patchDistance(installed: string, published: string): number | null {
+  const left = parts(installed);
+  const right = parts(published);
+  if (left === null || right === null) return null;
+  if (left[0] !== right[0] || left[1] !== right[1]) return null;
+  return (right[2] ?? 0) - (left[2] ?? 0);
+}
+
+/**
+ * Read the host's plugin cache and the registry. IO — the only impure thing here.
+ *
+ * The cache directory is the agent host's, not ours, so a missing one is an
+ * ordinary machine rather than a fault: it yields `installed: null` and the
+ * judgement calls that `absent`.
+ */
+export async function readInstalledPluginVersions(io: {
+  readonly homedir?: () => string;
+  readonly readdir?: (path: string) => Promise<readonly string[]>;
+  readonly publishedVersion?: () => Promise<string | null>;
+} = {}): Promise<PluginVersionFacts> {
+  const home = (io.homedir ?? (() => process.env.HOME ?? ""))();
+  const dir = `${home}/.claude/plugins/cache/red-skills/dev`;
+  let cached: string[] = [];
+  try {
+    const readdir = io.readdir ?? (async (path: string) => {
+      const { readdir: read } = await import("node:fs/promises");
+      return await read(path);
+    });
+    cached = [...(await readdir(dir))]
+      .filter((name) => /^\d+\.\d+\.\d+/.test(name))
+      .sort((a, b) => compareVersions(a, b) ?? 0);
+  } catch {
+    cached = [];
+  }
+  const published = await (io.publishedVersion ?? readPublishedVersion)();
+  return {
+    installed: cached.length === 0 ? null : cached[cached.length - 1]!,
+    published,
+    cached,
+  };
+}
+
+/** What the registry publishes; `null` when it cannot be asked. */
+async function readPublishedVersion(): Promise<string | null> {
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const run = promisify(execFile);
+    const { stdout } = await run("npm", ["view", "@reddb-io/red-skills", "version"], { timeout: 15_000 });
+    const version = stdout.trim();
+    return /^\d+\.\d+\.\d+/.test(version) ? version : null;
+  } catch {
+    // Offline, no npm, a private registry that refused: all the same answer.
+    // `null` becomes `unknown`, never `current`.
+    return null;
+  }
+}

--- a/apps/dev/src/runtime/doctor-classifiers.ts
+++ b/apps/dev/src/runtime/doctor-classifiers.ts
@@ -48,6 +48,12 @@ import {
 import { collectDocsSweepInput } from "./wire/docs.js";
 import type { RepoContext } from "./wire/paths.js";
 import { listDependencyEdgeTickets, type GhContext } from "./gh.js";
+import {
+  judgePluginVersion,
+  readInstalledPluginVersions,
+  type PluginVersionFacts,
+  type PluginVersionReport,
+} from "../core/plugin-version-doctor.js";
 
 /**
  * doctor-classifiers.ts — the fact-collection half of the `/red-doctor` checks
@@ -99,6 +105,7 @@ export interface DoctorClassifierReports {
   readonly hostBinaries: HostBinaryReport;
   /** Check 26 — marketplace registration source per host CLI. */
   readonly marketplaceSources: MarketplaceSourceReport;
+  readonly pluginVersion: PluginVersionReport;
   /** Check 27 — declared MCP servers that never loaded in this session. */
   readonly mcpLoad: McpLoadReport;
   /** Check 15 — native blocked-by vs `req:N` divergence. */
@@ -477,6 +484,8 @@ export interface DoctorClassifierOptions {
    * means nobody told this run, which the audit reports as unobserved rather
    * than assuming a clean session.
    */
+  /** Injected so a test needs no plugin cache and no registry. */
+  readonly readPluginVersions?: () => Promise<PluginVersionFacts>;
   readonly sessionMcpServers?: readonly string[] | null;
 }
 
@@ -557,6 +566,18 @@ export async function collectDoctorClassifierReports(
     notes.push(`marketplace source audit unavailable: ${message(error)}`);
   }
 
+  // The plugin lane, which nothing watched until #3147. The bundle lane
+  // self-updates and reports; this one is installed by the agent host and its
+  // version was never read — so an eight-release skew sat under a green doctor.
+  let pluginVersion: PluginVersionReport = judgePluginVersion({ installed: null, published: null });
+  try {
+    pluginVersion = judgePluginVersion(
+      await (options.readPluginVersions ?? readInstalledPluginVersions)(),
+    );
+  } catch (error) {
+    notes.push(`plugin version probe unavailable: ${message(error)}`);
+  }
+
   let mcpLoad: McpLoadReport = { findings: [], rows: [] };
   try {
     mcpLoad = collectMcpLoadReport(ctx.root, configText, options.sessionMcpServers ?? null, notes);
@@ -631,6 +652,7 @@ export async function collectDoctorClassifierReports(
     runtimeUnresolved,
     hostBinaries,
     marketplaceSources,
+    pluginVersion,
     mcpLoad,
     dependencyEdges,
     dependencyEdgesUnread,

--- a/apps/dev/tests/plugin-version-doctor.test.ts
+++ b/apps/dev/tests/plugin-version-doctor.test.ts
@@ -1,0 +1,90 @@
+// Is the plugin that answers actually current? (#3147)
+//
+// Two update lanes exist and only one was watched. The BUNDLE lane self-updates
+// and reports; the PLUGIN lane — the host's install, carrying the MCP server —
+// sat eight releases behind while `red-doctor` said `marketplace findings: 0`.
+//
+// The skew is invisible from outside: the MCP server COMPOSES a registration, so
+// an old one registers with an empty launch environment and writes the CURRENT
+// bundle path into the argv. A fresh Worker running new code, born from a
+// registration composed by old code, and every version on screen true about
+// something else.
+import { describe, expect, it } from "vitest";
+import {
+  PLUGIN_VERSION_STALE_AFTER,
+  compareVersions,
+  judgePluginVersion,
+} from "../src/core/plugin-version-doctor.js";
+
+describe("compareVersions", () => {
+  it("orders by major, minor then patch", () => {
+    expect(compareVersions("3.3.9", "3.3.17")).toBeLessThan(0);
+    expect(compareVersions("3.4.0", "3.3.17")).toBeGreaterThan(0);
+    expect(compareVersions("3.3.9", "3.3.9")).toBe(0);
+  });
+
+  it("is null rather than a guess when either side is not a version", () => {
+    expect(compareVersions("latest", "3.3.9")).toBeNull();
+    expect(compareVersions(null, "3.3.9")).toBeNull();
+  });
+});
+
+describe("judgePluginVersion", () => {
+  it("calls the exact gap this issue was filed for", () => {
+    const report = judgePluginVersion({ installed: "3.3.9", published: "3.3.17" });
+    expect(report.verdict).toBe("stale");
+    expect(report.behindBy).toBe(8);
+    // Both numbers in the sentence: an operator who reads nothing else must
+    // still know what is installed and what shipped.
+    expect(report.detail).toContain("3.3.9");
+    expect(report.detail).toContain("3.3.17");
+    expect(report.fix).toContain("marketplace");
+    expect(report.fix).toContain("restart");
+  });
+
+  it("names WHY it matters, not only that it is behind", () => {
+    // The MCP server composes a registration; that is the whole reason a stale
+    // plugin is not cosmetic, and the report is where a reader learns it.
+    expect(judgePluginVersion({ installed: "3.3.9", published: "3.3.17" }).detail)
+      .toContain("registration");
+  });
+
+  it("is quiet when current or ahead", () => {
+    expect(judgePluginVersion({ installed: "3.3.17", published: "3.3.17" }).verdict).toBe("current");
+    expect(judgePluginVersion({ installed: "3.4.0", published: "3.3.17" }).verdict).toBe("current");
+  });
+
+  it("distinguishes one release behind from a real skew", () => {
+    expect(judgePluginVersion({ installed: "3.3.16", published: "3.3.17" }).verdict).toBe("behind");
+    const stale = judgePluginVersion({
+      installed: "3.3.15",
+      published: `3.3.${15 + PLUGIN_VERSION_STALE_AFTER}`,
+    });
+    expect(stale.verdict).toBe("stale");
+  });
+
+  it("treats an unaskable registry as UNKNOWN, never as current", () => {
+    // Unknown read as a negative is the confusion this repo has hit in four
+    // organs; reporting "up to date" because npm was unreachable would be a
+    // fifth, and the loudest, because it certifies the machine.
+    const report = judgePluginVersion({ installed: "3.3.9", published: null });
+    expect(report.verdict).toBe("unknown");
+    expect(report.detail).toContain("unknown is not current");
+    expect(report.fix).toBeNull();
+  });
+
+  it("reports an absent install rather than pretending it is current", () => {
+    expect(judgePluginVersion({ installed: null, published: "3.3.17" }).verdict).toBe("absent");
+  });
+
+  it("says unknown when a version cannot be compared, and never crashes", () => {
+    expect(judgePluginVersion({ installed: "nightly", published: "3.3.17" }).verdict).toBe("unknown");
+  });
+
+  it("does not claim a patch distance across a minor bump", () => {
+    // 3.2.9 → 3.3.1 is not "negative eight releases".
+    const report = judgePluginVersion({ installed: "3.2.9", published: "3.3.1" });
+    expect(report.behindBy).toBeNull();
+    expect(report.verdict).toBe("stale");
+  });
+});


### PR DESCRIPTION
Closes #3147.

## Two update lanes, one of them unwatched

| Lane | State |
| --- | --- |
| **Bundle** — self-updates | ✅ tracked 3.3.17, status `up-to-date` |
| **Plugin** — the host's install, carrying the MCP server | ❌ **nine releases behind** |
| `red-doctor` | `marketplace findings: 0` |
| `mcp-load-doctor` | asked only *whether* servers loaded |

## Why a stale plugin is not cosmetic

The MCP server **composes** a project registration. An old one registers with an **empty launch environment** while writing the **current** bundle path into the argv — so a fresh Worker runs new code, born from a registration composed by old code, and every version number on screen is true about something else.

That is exactly how #3144 hid: the fix had shipped, the bundle was current, the argv was right, and the Worker still got no environment. It took reading `/proc/<pid>/environ` on a live Worker to find, and cost a full session.

## What is here

- `judgePluginVersion` — pure, decides `current` / `behind` / `stale` / `absent` / `unknown`.
- **An unaskable registry is `unknown`, never `current`.** Reporting an unreachable npm as up-to-date would be the loudest instance yet of the unknown-read-as-negative confusion this repo has hit in four organs — it would *certify* the machine.
- The report names **both numbers**, why it matters, and the fix: update from the marketplace **and restart the session**, because an MCP server registers at plugin load and keeps whatever bundle it started with.
- No patch distance is claimed across a minor bump — `3.2.9 → 3.3.1` is not "negative eight releases".

## Verified on the machine that had the gap

```
red-doctor plugin version
  installed=3.3.9 published=3.3.18 → stale
  9 releases behind. The MCP server this plugin carries is what COMPOSES a
  project registration...
  fix: update the red-skills plugin from its marketplace, then restart the session
```

10 new tests · **396 files, 5880 tests** · typecheck 14/14.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788347918&installation_model_id=20659&pr_number=3148&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3148&signature=19ecdbd2036d45b5f5ab116a277e567f44f8610e53ea7dd1adb6f35839cf77e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->