### PR TITLE
fix: #3160 A landing Worker polled a merged PR 48 times past its merge, because an unreadable probe and an unmerged PR are the same answer to the wait loop

### DIFF
--- a/apps/dev/src/core/declared-wait-guard.ts
+++ b/apps/dev/src/core/declared-wait-guard.ts
@@ -613,7 +613,7 @@ export const DECLARED_WAITS: readonly DeclaredWait[] = [
     deadline:
       "`maxPolls` × `intervalMs`, default 120 × 15s = 30 minutes, shared with the post-rebase retry so the whole tail costs ONE deadline; ONE probe when no clock is injected",
     escalation:
-      "returns `pending`, leaving the PR queued for the next sweep to re-read; a settled conflict returns `unqueueable` early (#3030) and the caller rebases ONCE, then parks the branch, the PR and the issue for a human",
+      "returns `pending`, leaving the PR queued for the next sweep to re-read; a settled conflict returns `unqueueable` early (#3030) and the caller rebases ONCE, then parks the branch, the PR and the issue for a human; four CONSECUTIVE unreadable probes return `probe-failing` early (#3160), which parks as `infra` because a confirmation that cannot see is a broken client rather than a slow queue",
     heartbeat: { sink: "onPoll" },
   },
   {

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -653,6 +653,19 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
       if (result.reason === "queue-pending") {
         return { ok: false, reason: "ci-pending", locked: input.locked, prNumber: result.prNumber };
       }
+      // #3160: the confirmation went BLIND, which says nothing about the PR. Route
+      // it to `infra` — the thing that is broken is this host's ability to read
+      // GitHub, and an operator told `ci-pending` would go look at the wrong thing.
+      if (result.reason === "queue-probe-failing") {
+        return {
+          ok: false,
+          reason: "infra",
+          locked: input.locked,
+          prNumber: result.prNumber,
+          infraReason:
+            result.queueDetail ?? "the merge confirmation could not read the pull request",
+        };
+      }
       if (result.reason === "pr-resolved-abort") {
         return { ok: false, reason: "pr-resolved-abort", locked: input.locked, prNumber: result.prNumber };
       }
@@ -1042,8 +1055,12 @@ function decorateMergeQueueWait(deps: LandingDeps, input: LandingInput): MergeQu
       await configured?.onPoll?.(event);
       // The FIRST probe is the confirmation itself — a synchronous merge answers
       // it immediately and never waited for anything. Narrate a wait only once
-      // there is one, so the phase trail of an ordinary landing is unchanged.
-      if (event.attempt > 1) await emitLandingWaitHeartbeat(deps, input, event);
+      // there is one, so the phase trail of an ordinary landing is unchanged. A
+      // probe that FAILED is narrated from the first one (#3160): a confirmation
+      // that cannot see is never the ordinary landing this silence was for.
+      if (event.attempt > 1 || event.status === "probe-failed") {
+        await emitLandingWaitHeartbeat(deps, input, event);
+      }
     },
   };
 }
@@ -1067,7 +1084,10 @@ async function emitLandingWaitHeartbeat(
   const step = event.kind === "review" ? "review-wait" : "merge-poll";
   await deps.landingPhase?.("wait", {
     step,
-    status: "poll",
+    // #3160: a probe that ANSWERED and one that did not are different states, and
+    // publishing both as `poll` is what let a slot burn on a blind probe while
+    // every observability surface read it as healthy waiting.
+    status: event.status ?? "poll",
     issue: input.issue,
     pr_number: event.prNumber,
     attempt: event.attempt,
@@ -1075,6 +1095,9 @@ async function emitLandingWaitHeartbeat(
     interval_ms: event.intervalMs,
     ...(event.probeTimeoutMs ? { probe_timeout_ms: event.probeTimeoutMs } : {}),
     ...(event.check ? { check: event.check } : {}),
+    ...(event.unobservedStreak !== undefined ? { unobserved_probes: event.unobservedStreak } : {}),
+    ...(event.probeExitCode !== undefined ? { probe_exit_code: event.probeExitCode } : {}),
+    ...(event.probeStderr ? { probe_stderr: event.probeStderr } : {}),
   });
 }
 

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -546,6 +546,19 @@ export interface LandingWaitPollEvent {
   intervalMs: number;
   probeTimeoutMs?: number;
   check?: string;
+  /**
+   * What this event says about the probe (#3160). `poll` — the wait is about to
+   * ask, or asked and got an answer. `probe-failed` — the probe just came back
+   * unreadable, so the slot is burning on a blind wait and no observability
+   * surface may render it as healthy waiting.
+   */
+  status?: "poll" | "probe-failed";
+  /** On `status: "probe-failed"` — how many CONSECUTIVE probes have now failed. */
+  unobservedStreak?: number;
+  /** On `status: "probe-failed"` — the probe's exit code, so the heartbeat names the mechanism. */
+  probeExitCode?: number;
+  /** On `status: "probe-failed"` — the first line of the probe's stderr, truncated. */
+  probeStderr?: string;
 }
 
 async function boundedProbe(exec: () => Promise<ExecResult>, timeoutMs: number | undefined): Promise<ExecResult> {
@@ -1174,7 +1187,9 @@ export type LandPrFailReason =
   /** The merge queue took the PR and then kicked it back out (#2986). */
   | "queue-rejected"
   /** The PR was still queued when the confirmation budget ran out (#2986). */
-  | "queue-pending";
+  | "queue-pending"
+  /** The confirmation could not READ the PR — repeated unreadable probes (#3160). */
+  | "queue-probe-failing";
 
 export interface LandPrResult {
   ok: boolean;
@@ -1190,7 +1205,8 @@ export interface LandPrResult {
    * line describing it, read back from the PR (#2807). The caller records this
    * verbatim instead of guessing at branch protection. */
   mergeFailure?: MergeRejectionDiagnosis;
-  /** Set on `reason: "queue-rejected"` — what the queue was observed doing (#2986). */
+  /** Set on `reason: "queue-rejected"` — what the queue was observed doing (#2986) —
+   * and on `reason: "queue-probe-failing"` — why the confirmation went blind (#3160). */
   queueDetail?: string;
   /** Remaining landing tail when `releaseAt` stopped before the merge. */
   deferred?: {
@@ -1242,8 +1258,12 @@ export interface MergeQueueWaitInput {
  *   - `unqueueable` — the PR is settled CONFLICTING: no queue will ever accept it, so
  *                     asking again is the eternal poll #3030 observed. Terminal.
  *   - `pending`     — still queued when the budget ran out. NOT a merge.
+ *   - `probe-failing` — the confirmation could not SEE the PR: {@link MAX_UNOBSERVED_QUEUED_PROBES}
+ *                     consecutive unreadable probes (#3160). A broken client is not
+ *                     a slow queue, so it ends the wait with its own verdict rather
+ *                     than spending the whole budget being told nothing. Terminal.
  */
-export type QueuedMergeOutcome = "merged" | "rejected" | "unqueueable" | "pending";
+export type QueuedMergeOutcome = "merged" | "rejected" | "unqueueable" | "pending" | "probe-failing";
 
 export interface QueuedMergeResult {
   outcome: QueuedMergeOutcome;
@@ -1287,6 +1307,29 @@ const QUEUED_PR_FIELDS = [
   "mergeStateStatus",
   "mergeable",
 ] as const;
+
+/**
+ * How many CONSECUTIVE unreadable probes end the wait (#3160). An unreadable
+ * probe is not a rejected merge — but it is not a "not yet" either, and "not yet"
+ * is the most expensive answer in the loop because it is the one that buys another
+ * poll. Three or four in a row is a broken client, not a slow merge queue: two
+ * Workers were observed polling ALREADY-MERGED PRs 48 and 19 times past their
+ * merge on a probe that answered in 0.57s beside them. Small enough that a lone
+ * flaky probe still costs nothing but one retry.
+ */
+const MAX_UNOBSERVED_QUEUED_PROBES = 4;
+
+/** How much of a failed probe's stderr the terminal record and the heartbeat carry. */
+const PROBE_STDERR_LIMIT = 300;
+
+/** The probe's own report: what it saw, and — when it saw nothing — why. */
+interface QueuedPrProbe {
+  view: QueuedPrView;
+  /** Exec code of the probe. `0` with `observed: false` is an unparseable payload. */
+  code: number;
+  /** First lines of stderr, truncated, so a blind wait names its mechanism (#3160). */
+  stderr: string;
+}
 
 /** An unreadable payload yields `observed: false` so the caller polls again
  * rather than inventing a verdict from a failed probe. */
@@ -1363,20 +1406,29 @@ async function readQueuedPrView(
   repo: string,
   prNumber: number,
   probeTimeoutMs: number | undefined,
-): Promise<QueuedPrView> {
+): Promise<QueuedPrProbe> {
   const plan = planGithubRestRead({ kind: "pr", number: prNumber, fields: QUEUED_PR_FIELDS, repo });
   const args =
     plan.outcome === "plan"
       ? ["gh", "-R", repo, ...plan.args]
       : ["gh", "-R", repo, "pr", "view", String(prNumber), "--json", QUEUED_PR_FIELDS.join(",")];
   const res = await boundedProbe(() => exec(args), probeTimeoutMs);
-  if (res.code !== 0) return ABSENT_QUEUED_PR_VIEW;
-  if (plan.outcome !== "plan") return parseQueuedPrView(res.stdout);
-  try {
-    return queuedPrViewFrom(plan.decode(res.stdout));
-  } catch {
-    return ABSENT_QUEUED_PR_VIEW;
-  }
+  // #3160: the probe's exit code and stderr travel WITH the view, because the one
+  // moment they are needed is the one moment the view carries nothing.
+  const stderr = (res.stderr ?? "").trim().slice(0, PROBE_STDERR_LIMIT);
+  const blind = { view: ABSENT_QUEUED_PR_VIEW, code: res.code, stderr };
+  if (res.code !== 0) return blind;
+  const view =
+    plan.outcome !== "plan"
+      ? parseQueuedPrView(res.stdout)
+      : ((): QueuedPrView => {
+          try {
+            return queuedPrViewFrom(plan.decode(res.stdout));
+          } catch {
+            return ABSENT_QUEUED_PR_VIEW;
+          }
+        })();
+  return view.observed ? { view, code: res.code, stderr } : blind;
 }
 
 /**
@@ -1409,19 +1461,23 @@ export async function waitForQueuedMerge(
   const maxPollsWithClock = input.sleep ? maxPolls : 1;
   const sleep = input.sleep ?? (async () => {});
   let everQueued = false;
+  let unobserved = 0;
 
   for (let attempt = 0; attempt < maxPollsWithClock; attempt++) {
-    await input.onPoll?.({
+    const event: LandingWaitPollEvent = {
       kind: "merge",
       prNumber,
       attempt: attempt + 1,
       maxPolls: maxPollsWithClock,
       intervalMs,
       ...(input.probeTimeoutMs ? { probeTimeoutMs: input.probeTimeoutMs } : {}),
-    });
-    const view = await readQueuedPrView(exec, repo, prNumber, input.probeTimeoutMs);
+    };
+    await input.onPoll?.({ ...event, status: "poll" });
+    const probe = await readQueuedPrView(exec, repo, prNumber, input.probeTimeoutMs);
+    const view = probe.view;
     const polls = attempt + 1;
     if (view.observed) {
+      unobserved = 0;
       if (view.merged) {
         return { outcome: "merged", ...(view.mergeSha ? { mergeSha: view.mergeSha } : {}), polls };
       }
@@ -1445,6 +1501,26 @@ export async function waitForQueuedMerge(
         return {
           outcome: "rejected",
           detail: `the merge queue dequeued PR #${prNumber} without merging it (its auto-merge request is gone and the PR is still open)`,
+          polls,
+        };
+      }
+    } else {
+      // #3160: an unreadable probe is neither a merge nor a rejection — but it is
+      // not "not yet" either, and the loop's only other move is to buy another
+      // poll. Count the blind reads SEPARATELY from the polls, say so on the
+      // heartbeat, and stop once the streak says client rather than queue.
+      unobserved += 1;
+      await input.onPoll?.({
+        ...event,
+        status: "probe-failed",
+        unobservedStreak: unobserved,
+        probeExitCode: probe.code,
+        ...(probe.stderr ? { probeStderr: probe.stderr } : {}),
+      });
+      if (unobserved >= MAX_UNOBSERVED_QUEUED_PROBES) {
+        return {
+          outcome: "probe-failing",
+          detail: `the merge confirmation could not read PR #${prNumber}: ${unobserved} consecutive unreadable probes (last exit ${probe.code}${probe.stderr ? `: ${probe.stderr}` : ", empty or unparseable payload"})`,
           polls,
         };
       }
@@ -1860,6 +1936,12 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
 
     if (confirmed.outcome === "rejected") {
       return { ok: false, prNumber, reason: "queue-rejected", queueDetail: confirmed.detail };
+    }
+    // #3160: blind, not slow. The PR may well have merged — this says only that
+    // the confirmation cannot see, which is an operator's problem and not the
+    // work's, so it must never wear the timeout's clothes.
+    if (confirmed.outcome === "probe-failing") {
+      return { ok: false, prNumber, reason: "queue-probe-failing", queueDetail: confirmed.detail };
     }
     if (confirmed.outcome === "pending") return { ok: false, prNumber, reason: "queue-pending" };
     await promoteFleetTrunkMirror(exec, { gitRepo, remote, target });

--- a/apps/dev/tests/landing-serialized.test.ts
+++ b/apps/dev/tests/landing-serialized.test.ts
@@ -237,3 +237,47 @@ describe("doLanding — a queued merge is not a completed one (#2986)", () => {
     expect(h.firedHooks).toContain("post_merge");
   });
 });
+
+// #3160 — a confirmation that cannot SEE the PR spent its whole budget saying
+// "not yet", and every heartbeat rendered the blind slot as healthy waiting. The
+// blind read is its own outcome, and it says so on the beat.
+describe("doLanding — a merge confirmation that cannot read the PR (#3160)", () => {
+  it("parks as infra after a few blind probes instead of burning the whole budget", async () => {
+    const h = harness({ locked: false, openPr: true, nativeMergeQueue: true, queueOutcome: "probe-failing" });
+
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    // Not `ci-pending`: nothing here says anything about CI, and an operator sent
+    // to the PR's checks would be looking at the wrong machine.
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.reason).toBe("infra");
+    expect(r.ok === false && r.infraReason).toContain("could not read PR #42");
+    expect(h.firedHooks).not.toContain("post_merge");
+    // Four blind probes, not the declared 30.
+    expect(h.mergeCalls.filter((argv) => readsPull(argv))).toHaveLength(4);
+  });
+
+  it("publishes the blind probe on the heartbeat, so no surface reads it as healthy waiting", async () => {
+    const h = harness({ locked: false, openPr: true, nativeMergeQueue: true, queueOutcome: "probe-failing" });
+
+    await doLanding(h.deps, h.input, h.hooks);
+
+    const failed = h.landingEvents.filter((event) => event.detail.status === "probe-failed");
+    expect(failed).toHaveLength(4);
+    expect(failed[0]).toEqual(
+      expect.objectContaining({
+        phase: "wait",
+        detail: expect.objectContaining({
+          step: "merge-poll",
+          status: "probe-failed",
+          pr_number: 42,
+          attempt: 1,
+          unobserved_probes: 1,
+          probe_exit_code: 1,
+          probe_stderr: "gh: could not resolve host api.github.com",
+        }),
+      }),
+    );
+    expect(failed[3]?.detail).toEqual(expect.objectContaining({ unobserved_probes: 4 }));
+  });
+});

--- a/apps/dev/tests/landing.test-support.ts
+++ b/apps/dev/tests/landing.test-support.ts
@@ -140,8 +140,10 @@ export interface Opts {
    *   - `merged`   → queued first, then merged.
    *   - `rejected` → queued first, then the auto-merge request disappears.
    *   - `pending`  → still queued for the whole (test-sized) budget.
+   *   - `probe-failing` → every confirmation probe exits non-zero, so the wait
+   *     never sees the PR at all (#3160).
    */
-  queueOutcome?: "merged" | "rejected" | "pending";
+  queueOutcome?: "merged" | "rejected" | "pending" | "probe-failing";
   /** Explicit PR-resolved callback abort used by adversarial correction before merge. */
   onPrResolvedAbort?: boolean;
   /**
@@ -282,6 +284,11 @@ export function harness(opts: Opts = {}): Harness {
       // (#3094) and answers a REST body.
       if (readsPull(argv)) {
         queuePolls += 1;
+        // #3160: a confirmation that cannot READ the PR — the probe fails, so the
+        // wait observes nothing rather than observing "not merged".
+        if (opts.queueOutcome === "probe-failing") {
+          return { code: 1, stdout: "", stderr: "gh: could not resolve host api.github.com" };
+        }
         const accepted = restPullBody({ state: "OPEN", mergedAt: null, mergeCommitOid: null, autoMerge: true });
         // Unset → the forge merged on the spot and the very first confirmation
         // says so. A test that opts in models the ENQUEUE: accepted first, then
@@ -363,7 +370,9 @@ export function harness(opts: Opts = {}): Harness {
     waitForReview: opts.waitForReview ? { check: "CodeRabbit", sleep: async () => {} } : undefined,
     ciAwait: opts.ciAware ? { sleep: async () => {}, maxPolls: 2 } : undefined,
     // #2986: always injected so no queue landing under test can reach a real timer.
-    mergeQueueWait: { sleep: async () => {}, maxPolls: 3 },
+    // A blind confirmation needs a budget LARGER than the blind-probe threshold,
+    // or `pending` would win the race and hide the outcome under test (#3160).
+    mergeQueueWait: { sleep: async () => {}, maxPolls: opts.queueOutcome === "probe-failing" ? 30 : 3 },
     makeLandingWorktree: async () => (opts.noWorktree ? null : WT),
     removeLandingWorktree: async (dir) => {
       removedWorktrees.push(dir);

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -1822,6 +1822,130 @@ describe("landPr on a merge-queue base (#2986)", () => {
     expect(r.reason).toBe("queue-rejected");
     expect(r.queueDetail).toContain("dequeued PR #42");
   });
+
+  it("reports queue-probe-failing — never queue-pending — when the confirmation goes blind", async () => {
+    const calls: string[][] = [];
+    const exec: Exec = async (argv) => {
+      calls.push(argv);
+      const cmd = argv.join(" ");
+      if (cmd.includes("pr list")) return { code: 0, stdout: "42\n", stderr: "" };
+      if (readsPull(argv)) return { code: 1, stdout: "", stderr: "gh: could not read PR" };
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const r = await landPr(exec, {
+      ...base,
+      mergeQueueWait: { sleep: async () => {}, maxPolls: 60 },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("queue-probe-failing");
+    expect(r.queueDetail).toContain("could not read PR #42");
+    // The whole 60-probe budget was NOT spent on a client that cannot see.
+    expect(calls.filter((c) => readsPull(c))).toHaveLength(4);
+  });
+});
+
+// #3160 — a Worker polled an ALREADY-MERGED PR 48 times past its merge, because
+// an unreadable probe and an unmerged PR were the same answer to the loop. "Not
+// yet" is the most expensive spelling of an inconclusive read: it is the one
+// answer that buys another poll.
+describe("the merge confirmation on a blind probe (#3160)", () => {
+  const queued = JSON.stringify(
+    restPullBody({ state: "OPEN", mergedAt: null, mergeCommitOid: null, autoMerge: true }),
+  );
+  const merged = JSON.stringify(
+    restPullBody({ state: "MERGED", mergeCommitOid: "queuesha", autoMerge: false }),
+  );
+
+  /** Each entry is one probe: a string is stdout, a number is a non-zero exit. */
+  const probeExec = (script: (string | number)[]): Exec => {
+    let i = 0;
+    return async () => {
+      const step = script[Math.min(i, script.length - 1)];
+      i += 1;
+      return typeof step === "number"
+        ? { code: step, stdout: "", stderr: "gh: connection reset by peer" }
+        : { code: 0, stdout: step ?? "", stderr: "" };
+    };
+  };
+
+  it("ends the wait with probe-failing, not with the timeout outcome", async () => {
+    const r = await waitForQueuedMerge(probeExec([1]), "o/r", 42, {
+      sleep: async () => {},
+      maxPolls: 180,
+    });
+    expect(r.outcome).toBe("probe-failing");
+    expect(r.polls).toBe(4);
+    expect(r.detail).toContain("4 consecutive unreadable probes");
+    expect(r.detail).toContain("last exit 1");
+    expect(r.detail).toContain("connection reset by peer");
+  });
+
+  it("names an exit-0 probe whose payload is unreadable, which has no stderr to quote", async () => {
+    const r = await waitForQueuedMerge(probeExec(["not json"]), "o/r", 42, {
+      sleep: async () => {},
+      maxPolls: 180,
+    });
+    expect(r.outcome).toBe("probe-failing");
+    expect(r.detail).toContain("empty or unparseable payload");
+  });
+
+  it("counts CONSECUTIVE blind probes, so a lone flaky probe still costs one retry", async () => {
+    // Three failures, an answer, three more failures, then the merge: seven blind
+    // probes in total and never four in a row.
+    const r = await waitForQueuedMerge(probeExec([1, 1, 1, queued, 1, 1, 1, merged]), "o/r", 42, {
+      sleep: async () => {},
+      maxPolls: 180,
+    });
+    expect(r).toEqual({ outcome: "merged", mergeSha: "queuesha", polls: 8 });
+  });
+
+  it("publishes a probe that did NOT answer as a distinct heartbeat status", async () => {
+    const events: { attempt: number; status?: string; streak?: number; code?: number }[] = [];
+    await waitForQueuedMerge(probeExec([1, 1, queued, merged]), "o/r", 42, {
+      sleep: async () => {},
+      maxPolls: 180,
+      onPoll: (event) => {
+        events.push({
+          attempt: event.attempt,
+          ...(event.status ? { status: event.status } : {}),
+          ...(event.unobservedStreak !== undefined ? { streak: event.unobservedStreak } : {}),
+          ...(event.probeExitCode !== undefined ? { code: event.probeExitCode } : {}),
+        });
+      },
+    });
+    expect(events).toEqual([
+      { attempt: 1, status: "poll" },
+      { attempt: 1, status: "probe-failed", streak: 1, code: 1 },
+      { attempt: 2, status: "poll" },
+      { attempt: 2, status: "probe-failed", streak: 2, code: 1 },
+      { attempt: 3, status: "poll" },
+      { attempt: 4, status: "poll" },
+    ]);
+  });
+
+  it("ends the wait on the merge itself — one poll interval, no probe past it", async () => {
+    let sleeps = 0;
+    let probes = 0;
+    const script = probeExec([queued, queued, merged]);
+    const r = await waitForQueuedMerge(
+      async (argv) => {
+        probes += 1;
+        return await script(argv);
+      },
+      "o/r",
+      42,
+      {
+        sleep: async () => {
+          sleeps += 1;
+        },
+        maxPolls: 180,
+      },
+    );
+    expect(r.outcome).toBe("merged");
+    expect(probes).toBe(3);
+    // Two intervals between three probes, and none after the merge was seen.
+    expect(sleeps).toBe(2);
+  });
 });
 
 // #3030 — a PR the queue can never accept is not a PR that is still queued. A


### PR DESCRIPTION
Automated AFK landing for #3160. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3160

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788358258&installation_model_id=20659&pr_number=3164&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3164&signature=7e36736717c73a175ba21ebc750bccadf9cdbbe91f995d84b4a49b0f71a94fa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->