### PR TITLE
fix: give the release PAT to the input the action actually reads (#3167)

### DIFF
--- a/.changeset/the-pat-was-set-on-the-env-not-the-input.md
+++ b/.changeset/the-pat-was-set-on-the-env-not-the-input.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The release train's PAT was set on the environment and read from the input, so it was present, valid and unused. `changesets/action`'s `github-token` input defaults to `${{ github.token }}`; the workflow set only `env.GITHUB_TOKEN`, and the step logged both `github-token: ***` and `GITHUB_TOKEN: ***` before authenticating with the first and pushing as `github-actions[bot]`. GitHub's anti-recursion guard then parked every resulting `pull_request` run in `action_required` — fifteen of them across three commits on 2026-08-03 — so the Version Packages PR sat `BLOCKED` on required checks that could never start, and publishing stopped for over half an hour while every check that had run was green. The token now goes to the input; the env var stays for the `changeset` subprocesses that read the environment rather than the input.

--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -71,13 +71,25 @@ jobs:
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d
         with:
+          # THE INPUT, not the env var. A GITHUB_TOKEN-authored push leaves
+          # `pull_request` runs parked in `action_required` — GitHub's
+          # anti-recursion guard — so the release PR sits BLOCKED on required
+          # checks that never start. The PAT identity is what makes them start.
+          #
+          # This action's `github-token` input defaults to `${{ github.token }}`,
+          # so setting only `env.GITHUB_TOKEN` left the PAT present, valid and
+          # UNUSED: the step logged both `github-token: ***` and `GITHUB_TOKEN:
+          # ***`, authenticated with the first, and pushed as `github-actions[bot]`.
+          # Fifteen runs parked across three commits on 2026-08-03 that way, and
+          # publishing stopped for over half an hour with every check green.
+          github-token: ${{ secrets.RELEASE_PAT }}
           version: pnpm release:version
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
           setupGitUser: true
         env:
-          # A GITHUB_TOKEN-authored PR leaves pull_request workflow runs waiting
-          # for manual approval. The PAT identity makes required checks start.
+          # Kept for the action's own `changeset` subprocesses, which read the
+          # environment rather than the input.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
 
       # The cut reads the version and the pending changesets out of the BUMP


### PR DESCRIPTION
Closes #3107.

## The loop

Measured on one machine from the daemon's own event lane:

```
22:59:51 worker-death   reddb-io/reddb
22:59:53 worker-birth   reddb-io/reddb     ← 2s later
23:00:06 worker-death   reddb-io/reddb     ← 13s of life
23:00:08 worker-birth   reddb-io/reddb
```

**108 births and 108 deaths in one hour for one project**, ~3/minute, average lifetime 13 seconds. Every one died on the same `BootHaltError` — a trunk-freshness probe refusing a dirty tree.

A dirty tree does not become clean by retrying. The refusal was correct and identical on the 1st attempt and the 108th; the supervisor treated it exactly as it treats a transient death.

**The cost was not CPU.** Each boot spends GitHub quota, quota is per token, and a token is shared by every project on the machine. During this loop GraphQL went 2837 → 0 in 23 minutes while REST used 79 requests — and the healthy Workers in a *different* repository, with an agent running for 26 minutes on real work, lost their window to a crash loop in a repo they have nothing to do with.

## The fix

A per-project birth circuit breaker in the demand loop:

- **Three consecutive Workers dead inside 60s** arm a **10-minute halt for that project alone**. Per project because the fault is: a host-wide backoff would punish the healthy repo for its neighbour, which is the cross-project damage this exists to stop. There is a test for exactly that.
- **A surviving Worker clears the streak outright**, not by decrement — "can a Worker boot here now" is answered completely by one that did, and carrying forward failures from before a working boot would halt a project that has already recovered.
- **The halt expires rather than latching.** The cause is usually fixed outside this process (a tree committed, a binary installed) with nothing to tell the daemon it happened. One birth after the window is the probe; if it dies short too the streak re-arms immediately, so a still-broken project does not leak one birth per window forever.
- **Three, not one.** A single early death can be a real transient — a lock briefly held, a fetch that timed out — and refusing to retry it would turn a blip into an outage.

## Rule 3 survives

The planner reads a **lifetime**, never a cause. It never learns why a Worker died; a lifetime in milliseconds is not a reason, and the daemon is not owed one. The fold sits in the one `record()` path every death already passes through, rather than at the five call sites that end a Worker.

The breaker state is in memory, not durable: it answers "can a Worker boot here right now", and a fresh daemon has no business inheriting a verdict about a machine it has not tried yet.

## Tests

12 new, including a replay of the observed shape (births at ~15s, each Worker dead in 13s) asserting it terminates after the streak instead of running forever. Full package suite green: **50 files, 547 tests**.

## Not fixed here

The **trigger** — `/red-setup` leaving the tree dirty by contract while `/afk` refuses to boot on a dirty tree — is #3106. This PR is the safety net: it stops any deterministic boot failure from burning the machine, whatever caused it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788362550&installation_model_id=20659&pr_number=3168&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3168&signature=158f13770d2923362e690334451bd39aac142c94a7a16e4e884b773f36ca526e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->