### PR TITLE
fix: #3156 The claim-lost diagnostic is written to the one directory the claim-lost path deletes, so the arbitration destroys its own testimony

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -63,7 +63,7 @@ import { workerIdentity } from "../../core/host-identity.js";
 import { initStateSync, readPidStartTime, updateState, workerStatePath, writeIdentitySync } from "../../core/state.js";
 import { createCastleWorkerLaneBridge } from "../../core/castle-worker-lane-bridge.js";
 import { createWorkerLogLinePublisher } from "../../runtime/redskilled-worker-log.js";
-import { HOST_CONFIG_EXIT_CODE } from "../../core/worker-outcome.js";
+import { HOST_CONFIG_EXIT_CODE, sweepDiscardsWorkspace } from "../../core/worker-outcome.js";
 
 import { checkBootGuard, isNamespacedDispatch, parseRunFlags, resolveRunDispatchIdentity, shouldSkipBootSweeps, type RunOptions } from "./flags.js";
 import { buildProcessDeps, parseSlot, type CurrentAttempt } from "./process-deps.js";
@@ -415,7 +415,12 @@ export async function runCommand(options: RunOptions): Promise<number> {
       // leaves them naming an issue this worker never owned. The next boot's
       // orphan sweep would misread that as a mid-issue crash and restore
       // ready-for-agent over the live winner's `running` label.
-      if (result.outcome === "claim-lost") {
+      //
+      // The deletion stands; what changed (#3156) is that it is a NAMED policy
+      // (`sweepDiscardsWorkspace`) and no longer takes the explanation with it —
+      // `claimLost` has already written the arbitration account to the durable
+      // history lane, so this removes a workspace, not the testimony.
+      if (sweepDiscardsWorkspace(result.outcome) && result.outcome === "claim-lost") {
         await fsx.removeDir(pi.attemptDir).catch(() => {});
         return result;
       }

--- a/apps/dev/src/core/go.ts
+++ b/apps/dev/src/core/go.ts
@@ -325,11 +325,16 @@ export const NO_ATTEMPT_OUTCOMES: readonly string[] = ["claim-lost", "hook-abort
  */
 export function zeroAttemptDispatchFailure(
   targeted: boolean,
-  processed: readonly { issue: number; outcome: string }[],
+  processed: readonly { issue: number; outcome: string; reason?: string }[],
 ): string | null {
   if (!targeted) return null;
   if (processed.length === 0) return "no targeted issue was selected or processed";
   const attempted = processed.filter((p) => !NO_ATTEMPT_OUTCOMES.includes(p.outcome));
   if (attempted.length > 0) return null;
-  return `no attempt ran (${processed.map((p) => `#${p.issue}: ${p.outcome}`).join(", ")})`;
+  // The outcome NAMES the withdrawal; the reason explains it (#3156). A verdict
+  // that printed only `claim-lost` sent an operator to the claim arbitration for
+  // an answer the withdrawal already held — and to a log the sweep had deleted.
+  return `no attempt ran (${processed
+    .map((p) => `#${p.issue}: ${p.outcome}${p.reason ? ` — ${p.reason}` : ""}`)
+    .join(", ")})`;
 }

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -251,14 +251,22 @@ export async function processIssue(
   const fireHook = async (name: HookName, context: string): Promise<boolean> => {
     return !(await fireHookCtx(name, context)).aborted;
   };
+  /** Withdraw from the issue, naming the cause. Every exit routes through here
+   * so no withdrawal is anonymous: the sweep deletes this worker's workspace on
+   * a claim-lost, so the account has to reach the durable lane (#3156). */
+  const withdraw = (reason: string, decision?: ClaimDecision): Promise<ProcessIssueResult> =>
+    claimLost(issue, hooksFired, deps, decision, reason, {
+      workerId: input.workerId,
+      runner: input.runner,
+    });
   if (!(await deps.claimLock.acquire(issue))) {
-    return claimLost(issue, hooksFired);
+    return withdraw("the host-local claim lock is already held by another worker on this machine");
   }
   const laneLabel = input.laneLabel ?? LABEL_READY;
   const labels = await deps.gh.viewLabels(issue);
   if (!labels.includes(laneLabel)) {
     await deps.claimLock.release(issue);
-    return claimLost(issue, hooksFired);
+    return withdraw(`the issue no longer carries its lane label \`${laneLabel}\``);
   }
   // The lane label implies the run mode, enforced HERE — at the claim, the one
   // path every entrance shares (#3026). A `lane:scout` issue picked up without
@@ -267,7 +275,7 @@ export async function processIssue(
   const laneModeRefusal = laneRunModeRefusal(labels, input.runMode);
   if (laneModeRefusal) {
     await deps.claimLock.release(issue);
-    return claimLost(issue, hooksFired, deps, undefined, laneModeRefusal);
+    return withdraw(laneModeRefusal);
   }
   if (deps.claimGh) {
     // **A Worker that cannot WRITE its claim declines the issue** (#3095, ADR
@@ -289,17 +297,13 @@ export async function processIssue(
     } catch (err) {
       await deps.claimLock.release(issue);
       const reason = err instanceof Error ? err.message : String(err);
-      return claimLost(
-        issue,
-        hooksFired,
-        deps,
-        undefined,
+      return withdraw(
         `the claim could not be written, so this issue is declined rather than worked on a host-local lock: ${reason}`,
       );
     }
     if (decision.verdict === "lost") {
       await deps.claimLock.release(issue);
-      return claimLost(issue, hooksFired, deps, decision);
+      return withdraw("another worker holds the claim", decision);
     }
     ownsCommentClaim = true;
     setActiveClaimFinalizer(async () => {
@@ -309,7 +313,7 @@ export async function processIssue(
     });
   } else if (labels.includes(LABEL_RUNNING)) {
     await deps.claimLock.release(issue);
-    return claimLost(issue, hooksFired, deps, undefined, "running label already present");
+    return withdraw("the `running` label is already present on the issue");
   }
   const activeBlocker = parseCurrentBlocker(input.body);
   if (activeBlocker && !MECHANICAL_BLOCKER_KINDS.has(activeBlocker.kind)) {
@@ -387,7 +391,9 @@ export async function processIssue(
         `🤖 /afk trust gate refused #${issue} [${describeTrustPosture(trustPolicy)}]: ${verdict.reason} — not claimed; no worktree/handoff materialised.`,
       );
       await releaseClaim();
-      return claimLost(issue, hooksFired, deps, undefined, verdict.reason);
+      return withdraw(
+        `the trust gate refused the issue [${describeTrustPosture(trustPolicy)}]: ${verdict.reason ?? "no rationale reported"}`,
+      );
     }
   }
   const sandboxDecision = await resolveUntrustedAuthorSandbox(deps, trustPolicy, provenance);
@@ -405,7 +411,7 @@ export async function processIssue(
   const promoted = await editIssueLifecycleLabels(deps, issue, labels, claimRemoveLabels, [LABEL_RUNNING], "claim");
   if (!promoted && !deps.claimGh) {
     await releaseClaim();
-    return claimLost(issue, hooksFired);
+    return withdraw("the `running` label could not be projected onto the issue");
   }
   deps.recordWorkerEvent?.("worker.claimed", { title: input.title });
   const slug = slugifyRef(input.title);
@@ -413,7 +419,7 @@ export async function processIssue(
   if (branch === null) {
     await editIssueLifecycleLabels(deps, issue, [LABEL_RUNNING], [LABEL_RUNNING], [LABEL_READY], "retry");
     await releaseClaim();
-    return claimLost(issue, hooksFired);
+    return withdraw(`no valid branch name could be built from the issue title ${JSON.stringify(input.title)}`);
   }
   const base = await resolveBase(input.baseInput, deps.lookups.base);
   const trunk = (deps.lookups.base.configTrunk ?? "").trim() || "main";

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -1014,25 +1014,77 @@ export async function runCascadeRebase(
     );
   }
 }
-export function claimLost(
-  issue: number,
-  hooksFired: HookName[],
-  deps?: Pick<ProcessIssueDeps, "appendIterLog" | "nowEpoch">,
+/** Everything known about why this worker walked away from the issue. The
+ * console line, the iteration log line and the durable history record are all
+ * rendered from ONE account, so no surface can carry less than the others. */
+export interface ClaimLostAccount {
+  /** The bare cause — what an operator asks first. Never empty. */
+  reason: string;
+  /** The cause plus the arbitration qualifiers (`holder`, `claim_id`, `age_s`)
+   * that were known, as one line. */
+  detail: string;
+}
+
+export function claimLostAccount(
+  nowEpoch: () => number,
   decision?: ClaimDecision,
   fallbackReason?: string,
-): ProcessIssueResult {
-  if (deps) {
-    const parts = [`🤖 /afk claim-lost #${issue}`];
-    if (decision?.winner) parts.push(`holder=${decision.winner}`);
-    if (decision?.winnerClaimId !== undefined) parts.push(`claim_id=${decision.winnerClaimId}`);
-    if (decision?.winnerCreatedAt) {
-      const createdMs = Date.parse(decision.winnerCreatedAt);
-      if (!Number.isNaN(createdMs)) parts.push(`age_s=${Math.max(0, deps.nowEpoch() - Math.floor(createdMs / 1000))}`);
-    }
-    parts.push(`reason=${decision?.reason ?? fallbackReason ?? "issue no longer claimable"}`);
-    deps.appendIterLog(parts.join(" "));
+): ClaimLostAccount {
+  const reason = decision?.reason ?? fallbackReason ?? "issue no longer claimable";
+  const parts: string[] = [];
+  if (decision?.winner) parts.push(`holder=${decision.winner}`);
+  if (decision?.winnerClaimId !== undefined) parts.push(`claim_id=${decision.winnerClaimId}`);
+  if (decision?.winnerCreatedAt) {
+    const createdMs = Date.parse(decision.winnerCreatedAt);
+    if (!Number.isNaN(createdMs)) parts.push(`age_s=${Math.max(0, nowEpoch() - Math.floor(createdMs / 1000))}`);
   }
-  return { outcome: "claim-lost", issue, hooksFired, preserved: false, swept: false };
+  parts.push(`reason=${reason}`);
+  return { reason, detail: parts.join(" ") };
+}
+
+/**
+ * The abandoned ending — and the ONE outcome whose whole diagnostic value is its
+ * `reason` (#3156).
+ *
+ * **The account goes to a lane the sweep does not delete.** `claim-lost` returns
+ * `preserved: false`, so the per-worker workspace — and the iteration log inside
+ * it — is removed the moment this returns (`sweepDiscardsWorkspace`). Writing the
+ * only explanation there is how eight consecutive claim-lost deaths retained zero
+ * causes. The iteration log still gets the line for a live tail; the durable
+ * `.red/state/castle/history.toonl` record is what an operator reads afterwards,
+ * and the `reason` rides back on the result for the console.
+ */
+export async function claimLost(
+  issue: number,
+  hooksFired: HookName[],
+  deps?: Pick<ProcessIssueDeps, "appendIterLog" | "nowEpoch" | "historyPath" | "historyClock">,
+  decision?: ClaimDecision,
+  fallbackReason?: string,
+  who?: { workerId?: string; runner?: Runner },
+): Promise<ProcessIssueResult> {
+  const account = claimLostAccount(deps?.nowEpoch ?? (() => 0), decision, fallbackReason);
+  if (deps) {
+    deps.appendIterLog(`🤖 /afk claim-lost #${issue} ${account.detail}`);
+    if (deps.historyPath && deps.historyClock) {
+      const { historyAppend } = await import("../history.js");
+      // Best-effort: a ledger that cannot be written must never turn an orderly
+      // withdrawal into a throw. The console still carries the reason.
+      await historyAppend(deps.historyPath, deps.historyClock, "claim-lost", {
+        ...(who?.workerId ? { worker: who.workerId } : {}),
+        issue,
+        ...(who?.runner ? { runner: who.runner } : {}),
+        reason: account.detail,
+      }).catch(() => {});
+    }
+  }
+  return {
+    outcome: "claim-lost",
+    issue,
+    hooksFired,
+    preserved: false,
+    swept: false,
+    reason: account.reason,
+  };
 }
 export async function releaseOwnedClaim(deps: ProcessIssueDeps, input: ProcessIssueInput): Promise<void> {
   if (deps.claimGh) {

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -432,6 +432,10 @@ export interface ProcessIssueResult {
   envelopePosted?: boolean;
   preserved: boolean;
   swept: boolean;
+  /** Why this ending happened, in one operator-facing line. Set by the endings
+   * whose workspace the sweep discards (#3156) — a `claim-lost` that reported
+   * only its outcome name withheld the answer it already had. */
+  reason?: string;
 }
 const CLEAN_EXIT_CODE = 0;
 const CRASH_EXIT_CODE = 1;

--- a/apps/dev/src/core/worker-outcome.ts
+++ b/apps/dev/src/core/worker-outcome.ts
@@ -49,9 +49,12 @@ import {
  *   - `stalled` — the supervisor stall-reaper hard-killed the slot.
  *   - `infra`   — worktree/base/push setup failed before the agent ran.
  *
- * Successful or abandoned endings (`done`, `claim-lost`, `review-requested`) are
- * members so every mapping is total, but they carry no typed `blocked:*` label
- * (null).
+ * Successful endings (`done`, `review-requested`) and the ABANDONED one
+ * (`claim-lost`) are members so every mapping is total, but they carry no typed
+ * `blocked:*` label (null). **Successful and abandoned are not one group** — they
+ * share the label mapping and nothing else. `claim-lost` is a withdrawal with a
+ * cause, and grouping it with `done` is what let its explanation be deleted with
+ * its workspace (#3156); see {@link sweepDiscardsWorkspace}.
  */
 export type WorkerOutcome =
   | "done"
@@ -135,6 +138,33 @@ export type WorkerOutcome =
  * subset are NON-recoverable (always escalate, see `recoveryReasonFor`).
  */
 export type RecoveryReason = "quota" | "runner-transient" | "merge-conflict" | "crashed" | "policy" | "validation-infra";
+
+/**
+ * Does the terminal path itself DELETE this ending's per-worker workspace, so a
+ * diagnostic written into that directory does not outlive the iteration?
+ *
+ * **The grouping is what made the deletion invisible** (#3156). `claim-lost`
+ * shares this fate with `done` — for a good reason each: `done` is swept because
+ * the work landed, `claim-lost` because the workspace names an issue this worker
+ * never owned and the next boot's orphan sweep would misread it as a mid-issue
+ * crash (#644). But the two have opposite DIAGNOSTIC needs: `done` has nothing to
+ * say, and `claim-lost` is a failure whose entire value is its `reason`. Sharing
+ * the sweep must therefore never mean sharing the silence — every ending that
+ * answers true here owes its account to a durable lane (`claimLost` writes the
+ * arbitration record to `.red/state/castle/history.toonl`).
+ *
+ * Every other ending keeps its directory through the terminal path; a later
+ * reclaim may release it, but the explanation is readable in the meantime.
+ */
+export function sweepDiscardsWorkspace(o: WorkerOutcome): boolean {
+  switch (o) {
+    case "done":
+    case "claim-lost":
+      return true;
+    default:
+      return false;
+  }
+}
 
 /**
  * Pure mapping from a terminal outcome to its DESCRIPTIVE `blocked:<…>`

--- a/apps/dev/tests/claim-lost-diagnostic.test.ts
+++ b/apps/dev/tests/claim-lost-diagnostic.test.ts
@@ -1,0 +1,105 @@
+// A diagnostic outlives the artifact it describes, or it is not a diagnostic
+// (#3156).
+//
+// `claim-lost` is the one outcome whose entire value is its `reason=` string —
+// and it wrote that string to the per-worker iteration log, the very directory
+// the claim-lost path deletes on the way out. Eight consecutive claim-lost
+// deaths on #3155 therefore retained ZERO explanations, and the investigation
+// went to the innocent subsystem because the guilty one had deleted its own
+// testimony.
+//
+// These tests pin the two halves of the route: the arbitration account reaches
+// a lane the sweep does not touch, and the operator-facing surface carries the
+// same reason the log line does.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { readHistoryRecords } from "../src/core/history.js";
+import { zeroAttemptDispatchFailure } from "../src/core/go.js";
+import { processIssue } from "../src/core/process-issue.js";
+import { sweepDiscardsWorkspace } from "../src/core/worker-outcome.js";
+import { harness } from "./process-issue.test-helpers.js";
+
+describe("a claim-lost explanation survives its own sweep", () => {
+  let root: string;
+  let historyPath: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "claim-lost-diag-"));
+    // The canonical durable lane — the one `.red/state/castle/` path the
+    // per-worker sweep never reaches.
+    historyPath = join(root, ".red", "state", "castle", "history.toonl");
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("writes the arbitration account to the durable history lane, not only the swept iteration log", async () => {
+    const { deps, input, trace } = harness({
+      claim: { winner: "other" },
+      labels: ["ready-for-agent", "running"],
+      historyPath,
+    });
+
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("claim-lost");
+
+    // The iteration log still says it — but that directory is deleted.
+    expect(trace.iterLogs.some((l) => /claim-lost #9 .*reason=/.test(l))).toBe(true);
+
+    // The durable lane says it too, and that one is kept.
+    const records = await readHistoryRecords(historyPath);
+    const lost = records.filter((r) => r.event === "claim-lost");
+    expect(lost).toHaveLength(1);
+    expect(lost[0]!.issue).toBe(9);
+    expect(lost[0]!.reason).toMatch(/holder=/);
+    expect(lost[0]!.reason).toMatch(/reason=/);
+  });
+
+  it("keeps the lane-mode refusal readable after the sweep, naming the cause rather than the outcome", async () => {
+    const { deps, input } = harness({
+      labels: ["ready-for-agent", "lane:scout"],
+      historyPath,
+    });
+
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("claim-lost");
+
+    const records = await readHistoryRecords(historyPath);
+    const lost = records.find((r) => r.event === "claim-lost");
+    expect(lost?.reason).toMatch(/lane:scout/);
+  });
+
+  it("returns the reason on the result, so the console does not have to read a deleted log", async () => {
+    const { deps, input } = harness({
+      claim: { winner: "other" },
+      historyPath,
+    });
+
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("claim-lost");
+    expect(result.reason).toBeTruthy();
+    expect(result.reason).not.toBe("");
+  });
+
+  it("reports the reason in the zero-attempt dispatch verdict the operator reads", () => {
+    const verdict = zeroAttemptDispatchFailure(true, [
+      { issue: 3155, outcome: "claim-lost", reason: "boot probe failed: trunk fast-forward blocked" },
+    ]);
+    expect(verdict).toContain("#3155: claim-lost");
+    expect(verdict).toContain("boot probe failed: trunk fast-forward blocked");
+  });
+});
+
+describe("claim-lost is not silently grouped with the retention policy meant for done", () => {
+  it("discards the workspace like done — which is exactly why its testimony must go elsewhere", () => {
+    expect(sweepDiscardsWorkspace("done")).toBe(true);
+    expect(sweepDiscardsWorkspace("claim-lost")).toBe(true);
+    // A failure that kept its workspace keeps its own explanation with it.
+    expect(sweepDiscardsWorkspace("blocked")).toBe(false);
+    expect(sweepDiscardsWorkspace("no-sentinel")).toBe(false);
+  });
+});

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -107,6 +107,10 @@ export interface Trace {
 export interface HarnessOptions {
   labels?: string[];
   acquire?: boolean;
+  /** Durable history ledger path (`.red/state/castle/history.toonl` in a real
+   * run). Set it to assert that a terminal's testimony outlives the swept
+   * per-worker workspace (#3156). */
+  historyPath?: string;
   /** Inject the ADR 0066 GitHub-native claim arbiter. When set, the claim path
    * is the authority and `running` is a projection. The `winner` field decides
    * the verdict for the test (self worker is "h:w"). */
@@ -863,6 +867,9 @@ export function harness(opts: HarnessOptions = {}): {
     },
     nowEpoch: () => 1000,
     nowIso: () => "2026-05-30T00:00:00Z",
+    ...(opts.historyPath
+      ? { historyPath: opts.historyPath, historyClock: { ts: "2026-05-30T00:00:00Z", epoch: 1000 } }
+      : {}),
     appendIterLog: (line) => {
       trace.iterLogs.push(line);
     },

--- a/packages/red-castle/src/engine/worker-drain.ts
+++ b/packages/red-castle/src/engine/worker-drain.ts
@@ -190,6 +190,9 @@ export type CastleWorkerOutcome =
 
 export interface CastleWorkerProcessResult {
   outcome: CastleWorkerOutcome;
+  /** Why this ending happened, in one operator-facing line. Optional: only the
+   * endings whose workspace the sweep discards must supply it (#3156). */
+  reason?: string;
 }
 
 export interface CastleWorkerDrainBudgetSnapshot {
@@ -247,6 +250,8 @@ export interface CastleWorkerDrainContext<TIssueTemplate = unknown> {
 export interface CastleWorkerDrainProcessed {
   issue: number;
   outcome: CastleWorkerOutcome;
+  /** The ending's one-line cause, when it reported one (#3156). */
+  reason?: string;
 }
 
 export interface CastleWorkerDrainSummary<TBootResult = unknown> {
@@ -474,7 +479,16 @@ export async function runCastleWorkerDrain<
       if (bucket === "done") done++;
       else if (bucket === "blocked") blocked++;
       else failed++;
-      processed.push({ issue: candidate.number, outcome: result.outcome });
+      processed.push({
+        issue: candidate.number,
+        outcome: result.outcome,
+        ...(result.reason ? { reason: result.reason } : {}),
+      });
+      // Say WHY a withdrawal happened on the console the operator is watching
+      // (#3156). The per-worker workspace holding the long form is deleted the
+      // moment a `claim-lost` returns, so a drain that printed only the outcome
+      // name left nothing behind to read.
+      if (result.reason) deps.emit(`#${candidate.number} ${result.outcome}: ${result.reason}`);
 
       const idx = i + 1;
       const pct = Math.floor((idx * 100) / total);


### PR DESCRIPTION
Automated AFK landing for #3156. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3156

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788363953&installation_model_id=20659&pr_number=3171&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3171&signature=d943648d71ea2ae3dcba80f9d4f7140740559a8439970b22523dc662d91644e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->