### PR TITLE
chore: name codex this repo's executor, in the key that selects one

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -8,6 +8,20 @@ plugins:
     lock:
       primary-branch: true       # primary-checkout branch-switch guard
     afk:
+      # Maintainer decision 2026-08-03: codex is this repo's executor.
+      #
+      # The `models.codex.*` table below only says WHICH MODEL codex uses once
+      # codex runs — it never SELECTS the runner. That is why a fully-populated
+      # codex model table still drained the whole backlog on claude: the table
+      # was right and nothing was reading it, because nothing chose codex.
+      #
+      # Two things still beat this key, and both beat it silently:
+      #   - `RED_AFK_RUNNER` in the environment, and an explicit `--runner`;
+      #   - a `project_start` that NAMES a runner, which pins the registration
+      #     for its whole life. A dispatcher passing `runner: claude` wins over
+      #     this file every time, so changing this line alone does not move a
+      #     registration that is already standing.
+      default_runner: codex
       models:
         # Maintainer decision 2026-07-28: the claude runner is pinned to Opus 5
         # on EVERY tier — validate included — so the local fleet never falls back


### PR DESCRIPTION
## What this changes

One key: `plugins.dev.afk.default_runner: codex`.

## Why it was needed

The `afk.models.codex.*` table in this file has been fully populated — `gpt-5.6-sol` on three tiers, `gpt-5.5` held on `validate` by maintainer choice — and **every issue still drained on claude**. The table only says *which model codex uses once codex runs*. It never selects the runner. That is `afk.default_runner`, it defaults to `claude`, and it had never been set.

A complete model table for a runner that never runs reads, at a glance, exactly like a configured runner.

## Why it is committed rather than left in the checkout

A Worker reads its config from its own root:

```ts
configPath: join(rp.redDir(root), "config.yaml")
```

and a Worker's root is **its worktree**, not the primary checkout. Measured while a Worker was live:

```
worker worktree      → default_runner: 0 occurrences
primary checkout     → default_runner: 'codex'
```

An uncommitted config change reaches the directory a human inspects and no directory any Worker works in. It would have looked correct in every place we would think to look.

## The comment is the load-bearing part

Two things beat this key **silently**, and both did today:

1. **`RED_AFK_RUNNER` in the environment**, and an explicit `--runner`.
2. **A `project_start` that names a runner.** It pins the registration for its whole life. Three dispatches sent `runner: claude` today and overrode the file every time with no warning — the file was right and the caller won.

The second is the one worth reading twice: changing this line does **not** move a registration that is already standing. The registration must be replaced.

## Verification

The switch is proven live, not asserted. After re-registering on codex and freeing one slot:

```
2916385  12:09:53  claude   <- born before the switch
2920174  12:10:08  claude   <- born before the switch
3308481  12:44:21  codex    <- first born after
```

The three pre-existing Workers were all born *before* the codex registration — the newest by 28 seconds — which is why the switch looked ignored for several minutes. It was not being ignored; there was no free slot to be born into.

## Not in scope

The stale-plugin problem this sits next to: the argv a registration carries — including which `dev-*.bundle.min.mjs` runs — is composed by the MCP server, which ships in the installed plugin. An old plugin composes an old argv silently. Tracked separately (#3147, #3153).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788364079&installation_model_id=20659&pr_number=3173&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3173&signature=3ad1b5d8c617ae06f1c7c4b9467302161919e25c2750d85baeaf1e54153674fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->