### PR TITLE
fix: #3178 The self-update fires once at SessionStart and never again, so an eight-hour session reports up-to-date against a number it last checked in its first second

### DIFF
--- a/apps/dev/src/core/bundle-version.ts
+++ b/apps/dev/src/core/bundle-version.ts
@@ -59,6 +59,9 @@ export interface DevBundleCacheState {
   readonly installedVersion?: string;
   readonly pointerVersion?: string;
   readonly laneNewestVersion?: string;
+  readonly lastStatus?: SelfUpdateStateRecord["lastStatus"];
+  readonly lastCheckAtMs?: number;
+  readonly lastCheckAgeMs?: number;
   readonly lastFailureAtMs?: number;
   readonly lastFailureAgeMs?: number;
   readonly lastError?: string;
@@ -84,6 +87,11 @@ export function readDevBundleCacheState(
     ...(installedVersion ? { installedVersion } : {}),
     ...(pointerVersion ? { pointerVersion } : {}),
     ...(laneNewestVersion ? { laneNewestVersion } : {}),
+    ...(state.lastStatus !== undefined ? { lastStatus: state.lastStatus } : {}),
+    ...(state.lastCheckAtMs !== undefined ? { lastCheckAtMs: state.lastCheckAtMs } : {}),
+    ...(state.lastCheckAtMs !== undefined
+      ? { lastCheckAgeMs: Math.max(0, nowMs - state.lastCheckAtMs) }
+      : {}),
     ...(live.lastFailureAtMs !== undefined ? { lastFailureAtMs: live.lastFailureAtMs } : {}),
     ...(live.lastFailureAtMs !== undefined ? { lastFailureAgeMs: Math.max(0, nowMs - live.lastFailureAtMs) } : {}),
     ...(live.lastError ? { lastError: live.lastError } : {}),
@@ -136,9 +144,16 @@ function readSelfUpdateState(path: string): SelfUpdateStateRecord {
   try {
     const parsed = decodeDevSnapshotSniff(readFileSync(path, "utf8")) as Record<string, unknown>;
     return {
+      ...(Number.isFinite(parsed.lastCheckAtMs) ? { lastCheckAtMs: Number(parsed.lastCheckAtMs) } : {}),
       ...(Number.isFinite(parsed.lastSuccessAtMs) ? { lastSuccessAtMs: Number(parsed.lastSuccessAtMs) } : {}),
       ...(Number.isFinite(parsed.lastFailureAtMs) ? { lastFailureAtMs: Number(parsed.lastFailureAtMs) } : {}),
       ...(typeof parsed.lastError === "string" ? { lastError: parsed.lastError } : {}),
+      ...(parsed.lastStatus === "updated" ||
+        parsed.lastStatus === "up-to-date" ||
+        parsed.lastStatus === "skipped-channel" ||
+        parsed.lastStatus === "error"
+        ? { lastStatus: parsed.lastStatus }
+        : {}),
     };
   } catch {
     return {};

--- a/apps/dev/src/core/operational-probes/bundle-coherence.ts
+++ b/apps/dev/src/core/operational-probes/bundle-coherence.ts
@@ -18,7 +18,9 @@ export type BundleCoherenceFindingKind =
   | "pointer-ahead-of-lane"
   | "pointer-behind-npm"
   | "lane-behind-npm"
-  | "stale-failed-check";
+  | "stale-failed-check"
+  | "stale-successful-check"
+  | "undated-successful-check";
 
 function effectivePointer(input: BundleCoherenceProbeInput): string | undefined {
   return input.pointerVersion ?? input.installedVersion;
@@ -48,6 +50,13 @@ function findings(input: BundleCoherenceProbeInput): BundleCoherenceFindingKind[
   if (input.lastFailureAgeMs !== undefined && input.lastFailureAgeMs > DEFAULT_STALE_FAILURE_MS) {
     out.push("stale-failed-check");
   }
+  if (input.lastStatus === "updated" || input.lastStatus === "up-to-date") {
+    if (input.lastCheckAgeMs === undefined) {
+      out.push("undated-successful-check");
+    } else if (input.lastCheckAgeMs > DEFAULT_STALE_FAILURE_MS) {
+      out.push("stale-successful-check");
+    }
+  }
   return out;
 }
 
@@ -68,11 +77,24 @@ function evidence(input: BundleCoherenceProbeInput, fs: readonly BundleCoherence
     `npm=${input.npmNewestVersion ?? (input.npmError ? "unknown" : "not-checked")}`,
   ];
   if (input.npmError) parts.push("npm_error=present");
+  const checkAge = age(input.lastCheckAgeMs);
+  if (input.lastStatus === "updated" || input.lastStatus === "up-to-date") {
+    parts.push(checkAge ? `last_check=${input.lastStatus}@${checkAge}` : "last_check=undated");
+    const shipped = versionsSinceCheck(input.pointerVersion ?? input.installedVersion, input.npmNewestVersion);
+    if (shipped !== undefined) parts.push(`versions_since_check=${shipped}`);
+  }
   const failureAge = age(input.lastFailureAgeMs);
   if (failureAge) parts.push(`last_failure_age=${failureAge}`);
   if (input.lastError) parts.push("last_error=present");
   if (fs.length > 0) parts.push(`findings=${fs.join(",")}`);
   return parts.join(" ");
+}
+
+function versionsSinceCheck(current: string | undefined, published: string | undefined): number | undefined {
+  const left = /^(\d+)\.(\d+)\.(\d+)/.exec(current ?? "");
+  const right = /^(\d+)\.(\d+)\.(\d+)/.exec(published ?? "");
+  if (!left || !right || left[1] !== right[1] || left[2] !== right[2]) return undefined;
+  return Math.max(0, Number(right[3]) - Number(left[3]));
 }
 
 export function runBundleCoherenceProbe(context: OperationalProbeContext): OperationalProbeResult {

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -111,6 +111,8 @@ export interface BundleCoherenceProbeInput {
   readonly laneNewestVersion?: string;
   readonly npmNewestVersion?: string;
   readonly npmError?: string;
+  readonly lastStatus?: "updated" | "up-to-date" | "skipped-channel" | "error";
+  readonly lastCheckAgeMs?: number;
   readonly lastFailureAgeMs?: number;
   readonly lastError?: string;
 }

--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -39,6 +39,7 @@ import {
   type ResidentJanitor,
 } from "./resident-cron.js";
 import { startResidentUnblockSweep } from "./resident-unblock.js";
+import { startResidentSelfUpdate } from "./resident-self-update.js";
 
 const buildInfo = readBuildInfo("castle");
 
@@ -268,6 +269,9 @@ export interface McpEntrypointDependencies {
    * last `req:*` blocker closed. Optional so every existing caller keeps
    * working; omitted means the belt does not run in that host. */
   startUnblockSweep?(): Promise<void>;
+  /** The #3178 bundle belt: refresh a SessionStart verdict throughout a
+   * long-lived session. Optional for compatibility with injected test hosts. */
+  startSelfUpdate?(): Promise<void>;
   connect(): Promise<void>;
   /** The lane's own canary (#2706). Optional so every existing caller keeps
    * working; omitted means the real probe. */
@@ -301,6 +305,11 @@ export async function main(
     startMergeDriver: startResidentMergeDriver,
     startUnblockSweep: async () => {
       await startResidentUnblockSweep();
+    },
+    startSelfUpdate: async () => {
+      await startResidentSelfUpdate({
+        notice: (line) => process.stderr.write(`castle resident: ${line}\n`),
+      });
     },
     connect: run,
   },
@@ -347,6 +356,9 @@ export async function main(
   // Started BEFORE the transport (#3014): its first pass is the session-boot
   // clearer, and it is detached inside, so a slow tracker delays no handshake.
   await dependencies.startUnblockSweep?.();
+  // Like the other belts, this starts before stdio and detaches its first pass:
+  // an eight-hour session keeps learning about releases after its first second.
+  await dependencies.startSelfUpdate?.();
   await dependencies.connect();
   return 0;
 }

--- a/apps/dev/src/resident-self-update.ts
+++ b/apps/dev/src/resident-self-update.ts
@@ -1,0 +1,200 @@
+// resident-self-update.ts — the session-long bundle self-update belt (#3178).
+//
+// SessionStart warms the cache once, but a long-lived session needs a long-lived
+// owner. The castle resident already owns periodic maintenance, so this belt
+// performs one immediate registry check and one cheap check every five minutes.
+// A successful update atomically advances the stable pointer through the shared
+// self-update implementation; the next Worker therefore starts on that bundle
+// without a restart or human action.
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { access, mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { readBuildInfo } from "@reddb-io/build-info";
+import {
+  createEnginePaths,
+  createSingletonLeaseStore,
+  type SingletonLeaseOwner,
+  type SingletonLeaseStore,
+} from "@reddb-io/red-castle/engine";
+import { NPM_PACKAGE } from "@reddb-io/shared/bundle-fetch.js";
+import { resolveChannel, type ReleaseChannel } from "@reddb-io/shared/channel.js";
+import { resolveRepoRoot } from "@reddb-io/shared/repo-root.js";
+import {
+  backgroundSelfUpdateWithRetry,
+  type SelfUpdateInput,
+  type SelfUpdateIO,
+  type SelfUpdateResult,
+} from "@reddb-io/shared/self-update.js";
+import { getConfig, loadConfig } from "./core/config.js";
+import { redSkillsCacheDir } from "./core/bundle-version.js";
+import { readPidStartTime } from "./core/state.js";
+
+export const RESIDENT_SELF_UPDATE_INTERVAL_MS = 5 * 60 * 1000;
+export const SELF_UPDATE_SINGLETON = "self-update";
+
+export interface ResidentSelfUpdateTimers {
+  setInterval(callback: () => void, intervalMs: number): unknown;
+  clearInterval(timer: unknown): void;
+}
+
+export interface ResidentSelfUpdateOptions {
+  readonly root?: string;
+  readonly installedVersion?: string;
+  readonly cacheDir?: string;
+  readonly channel?: ReleaseChannel;
+  readonly update?: (input: SelfUpdateInput) => Promise<SelfUpdateResult>;
+  readonly leases?: SingletonLeaseStore;
+  readonly owner?: SingletonLeaseOwner;
+  readonly intervalMs?: number;
+  readonly timers?: ResidentSelfUpdateTimers;
+  readonly notice?: (message: string) => void;
+}
+
+export interface ResidentSelfUpdate {
+  check(): Promise<SelfUpdateResult | undefined>;
+  stop(): Promise<void>;
+}
+
+const execFileAsync = promisify(execFile);
+
+const nodeSelfUpdateIO: SelfUpdateIO = {
+  async materialize(spec, stagingDir) {
+    await mkdir(stagingDir, { recursive: true });
+    await execFileAsync(
+      "npm",
+      [
+        "install",
+        spec,
+        "--prefix",
+        stagingDir,
+        "--no-save",
+        "--no-audit",
+        "--no-fund",
+        "--ignore-scripts",
+        "--loglevel=error",
+      ],
+      { encoding: "utf8" },
+    );
+    return join(stagingDir, "node_modules", ...NPM_PACKAGE.split("/"));
+  },
+  async readFile(path) {
+    return new Uint8Array(await readFile(path));
+  },
+  async writeFile(path, bytes) {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, bytes);
+  },
+  async exists(path) {
+    try {
+      await access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  sha256(bytes) {
+    return createHash("sha256").update(bytes).digest("hex");
+  },
+  async fetchText(url) {
+    const response = await fetch(url, { redirect: "follow" });
+    if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
+    return response.text();
+  },
+  readdir,
+  rename,
+};
+
+function defaultTimers(): ResidentSelfUpdateTimers {
+  return {
+    setInterval(callback, intervalMs) {
+      const timer = setInterval(callback, intervalMs);
+      timer.unref();
+      return timer;
+    },
+    clearInterval(timer) {
+      clearInterval(timer as NodeJS.Timeout);
+    },
+  };
+}
+
+function configuredChannel(root: string): ReleaseChannel {
+  const config = loadConfig(join(root, ".red", "config.yaml"));
+  return resolveChannel({
+    env: process.env,
+    configValue: getConfig(config, "afk.release.channel"),
+  });
+}
+
+async function runNodeSelfUpdate(input: SelfUpdateInput): Promise<SelfUpdateResult> {
+  return backgroundSelfUpdateWithRetry(nodeSelfUpdateIO, input);
+}
+
+/** Start the resident's repo-scoped self-update belt. The first check is
+ * detached from MCP startup, and concurrent ticks share one in-flight check. */
+export async function startResidentSelfUpdate(
+  options: ResidentSelfUpdateOptions = {},
+): Promise<ResidentSelfUpdate | null> {
+  const root = resolveRepoRoot(options.root ?? process.cwd());
+  const leases =
+    options.leases ?? createSingletonLeaseStore(createEnginePaths(join(root, ".red")));
+  const owner = options.owner ?? {
+    pid: process.pid,
+    startTime: readPidStartTime(process.pid) ?? `pid-${process.pid}`,
+  };
+  const acquired = await leases.acquire(SELF_UPDATE_SINGLETON, owner);
+  if (!acquired.acquired) return null;
+
+  const notice = options.notice ?? (() => undefined);
+  const update = options.update ?? runNodeSelfUpdate;
+  const timers = options.timers ?? defaultTimers();
+  const input: SelfUpdateInput = {
+    plugin: "dev",
+    installedVersion: options.installedVersion ?? readBuildInfo("dev").version,
+    repo: "reddb-io/red-skills",
+    cacheDir: options.cacheDir ?? redSkillsCacheDir(),
+    channel: options.channel ?? configuredChannel(root),
+  };
+  let running: Promise<SelfUpdateResult | undefined> | undefined;
+  let timer: unknown;
+
+  const check = (): Promise<SelfUpdateResult | undefined> => {
+    if (running) return running;
+    running = update(input)
+      .then((result) => {
+        if (result.status === "error") {
+          notice(`self-update check failed: ${result.error ?? "unknown error"}`);
+        }
+        return result;
+      })
+      .catch((error): undefined => {
+        notice(
+          `self-update check failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return undefined;
+      })
+      .finally(() => {
+        running = undefined;
+      });
+    return running;
+  };
+
+  timer = timers.setInterval(
+    () => void check(),
+    options.intervalMs ?? RESIDENT_SELF_UPDATE_INTERVAL_MS,
+  );
+  void check();
+
+  return {
+    check,
+    async stop() {
+      if (timer !== undefined) {
+        timers.clearInterval(timer);
+        timer = undefined;
+      }
+      await running;
+      await leases.release(SELF_UPDATE_SINGLETON, owner);
+    },
+  };
+}

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -421,6 +421,8 @@ export async function collectPrecheckFacts(
       laneNewestVersion: bundleCache.laneNewestVersion,
       npmNewestVersion,
       npmError,
+      lastStatus: bundleCache.lastStatus,
+      lastCheckAgeMs: bundleCache.lastCheckAgeMs,
       lastFailureAgeMs: bundleCache.lastFailureAgeMs,
       lastError: bundleCache.lastError,
     },

--- a/apps/dev/tests/bundle-version.test.ts
+++ b/apps/dev/tests/bundle-version.test.ts
@@ -39,6 +39,7 @@ describe("dev bundle cache state", () => {
       writeFileSync(
         join(root, statusFileName("dev")),
         encodeDevSnapshotToon({
+          lastCheckAtMs: 200,
           lastFailureAtMs: 100,
           lastSuccessAtMs: 200,
           lastStatus: "up-to-date",
@@ -48,6 +49,11 @@ describe("dev bundle cache state", () => {
 
       const state = readDevBundleCacheState("2.71.0", { RED_SKILLS_CACHE_DIR: root }, 100_000_000);
       expect(state.lastFailureAgeMs).toBeUndefined();
+      expect(state).toMatchObject({
+        lastStatus: "up-to-date",
+        lastCheckAtMs: 200,
+        lastCheckAgeMs: 100_000_000 - 200,
+      });
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/apps/dev/tests/mcp-server-routing.test.ts
+++ b/apps/dev/tests/mcp-server-routing.test.ts
@@ -124,13 +124,16 @@ describe("dev:afk MCP entrypoint routing", () => {
         startUnblockSweep: async () => {
           calls.push("unblock");
         },
+        startSelfUpdate: async () => {
+          calls.push("self-update");
+        },
         connect: async () => {
           calls.push("connect");
         },
       }),
     ).resolves.toBe(0);
 
-    expect(calls).toEqual(["curator", "merge-driver", "unblock", "connect"]);
+    expect(calls).toEqual(["curator", "merge-driver", "unblock", "self-update", "connect"]);
   });
 
   it("awaits resident cleanup after the MCP transport closes", async () => {

--- a/apps/dev/tests/operational-probes.test.ts
+++ b/apps/dev/tests/operational-probes.test.ts
@@ -142,6 +142,32 @@ describe("operational probe registry", () => {
     ]);
   });
 
+  it("reports a stale successful bundle check with the verdict age", async () => {
+    const report = await runOperationalProbes({
+      remoteUrls: [],
+      bundleCoherence: {
+        installedVersion: "3.3.19",
+        pointerVersion: "3.3.19",
+        laneNewestVersion: "3.3.19",
+        npmNewestVersion: "3.3.21",
+        lastStatus: "up-to-date",
+        lastCheckAgeMs: 5 * 60 * 60 * 1000,
+      },
+    });
+
+    expect(report.findings).toEqual([
+      expect.objectContaining({
+        id: "afk.bundle-coherence",
+        verdict: "red",
+        evidence: expect.stringContaining("last_check=up-to-date@5h"),
+        data: expect.objectContaining({
+          findings: expect.arrayContaining(["stale-successful-check"]),
+        }),
+      }),
+    ]);
+    expect(report.findings[0]?.evidence).toContain("versions_since_check=2");
+  });
+
   it("stays ok when the last self-update success supersedes an old failure", async () => {
     const root = await mkdtemp(join(tmpdir(), "probe-bundle-cache-"));
     try {

--- a/apps/dev/tests/resident-self-update.test.ts
+++ b/apps/dev/tests/resident-self-update.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  SingletonLease,
+  SingletonLeaseAcquireResult,
+  SingletonLeaseOwner,
+  SingletonLeaseStore,
+} from "@reddb-io/red-castle/engine";
+import {
+  RESIDENT_SELF_UPDATE_INTERVAL_MS,
+  SELF_UPDATE_SINGLETON,
+  startResidentSelfUpdate,
+  type ResidentSelfUpdateTimers,
+} from "../src/resident-self-update.js";
+
+const LEASE: SingletonLease = {
+  pid: 4242,
+  start_time: "start",
+  acquired_at: "2026-08-03T00:00:00.000Z",
+  renewed_at: "2026-08-03T00:00:00.000Z",
+};
+
+function leaseStore(
+  acquire: SingletonLeaseAcquireResult = { acquired: true, reaped: false, lease: LEASE },
+): SingletonLeaseStore & { released: string[] } {
+  const released: string[] = [];
+  return {
+    released,
+    read: async () => LEASE,
+    acquire: async () => acquire,
+    renew: async () => LEASE,
+    release: async (name: string, _owner: SingletonLeaseOwner) => {
+      released.push(name);
+      return true;
+    },
+  };
+}
+
+function manualTimers(): ResidentSelfUpdateTimers & { fire(): void; cleared: number } {
+  const state = {
+    callback: undefined as (() => void) | undefined,
+    cleared: 0,
+    fire() {
+      state.callback?.();
+    },
+    setInterval(callback: () => void) {
+      state.callback = callback;
+      return "timer";
+    },
+    clearInterval() {
+      state.cleared += 1;
+    },
+  };
+  return state as ResidentSelfUpdateTimers & { fire(): void; cleared: number };
+}
+
+describe("resident self-update belt (#3178)", () => {
+  it("checks at resident start and again on every interval", async () => {
+    const update = vi.fn(async () => ({ status: "up-to-date" as const, version: "3.3.19" }));
+    const timers = manualTimers();
+    const belt = await startResidentSelfUpdate({
+      root: process.cwd(),
+      installedVersion: "3.3.19",
+      cacheDir: "/cache/bundles",
+      channel: "stable",
+      update,
+      leases: leaseStore(),
+      owner: { pid: 4242, startTime: "start" },
+      timers,
+      intervalMs: RESIDENT_SELF_UPDATE_INTERVAL_MS,
+    });
+
+    expect(belt).not.toBeNull();
+    await belt!.check();
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenLastCalledWith(expect.objectContaining({
+      plugin: "dev",
+      installedVersion: "3.3.19",
+      cacheDir: "/cache/bundles",
+      channel: "stable",
+    }));
+
+    timers.fire();
+    await belt!.check();
+    expect(update).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps checking after a failed update and releases its singleton on stop", async () => {
+    let calls = 0;
+    const update = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("registry unavailable");
+      return { status: "up-to-date" as const, version: "3.3.19" };
+    });
+    const notices: string[] = [];
+    const timers = manualTimers();
+    const leases = leaseStore();
+    const belt = await startResidentSelfUpdate({
+      installedVersion: "3.3.19",
+      update,
+      leases,
+      owner: { pid: 4242, startTime: "start" },
+      timers,
+      notice: (line) => notices.push(line),
+    });
+
+    await belt!.check();
+    expect(notices[0]).toContain("registry unavailable");
+    await belt!.check();
+    expect(update).toHaveBeenCalledTimes(2);
+
+    await belt!.stop();
+    expect(timers.cleared).toBe(1);
+    expect(leases.released).toEqual([SELF_UPDATE_SINGLETON]);
+  });
+});

--- a/packages/shared/self-update.test.ts
+++ b/packages/shared/self-update.test.ts
@@ -251,6 +251,38 @@ describe("resolveActiveVersion (render/hook path — local reads only)", () => {
     expect(result.logNotes.join(" ")).toContain("self-update stale: last check failed 5h ago");
   });
 
+  it("reports the age of an up-to-date verdict and marks an old success stale", async () => {
+    const nowMs = 10 * 60 * 60 * 1000;
+    const checkedAtMs = nowMs - 5 * 60 * 60 * 1000;
+    const { io } = makeIO({
+      files: {
+        [statusPath(CACHE, PLUGIN)]: enc(JSON.stringify({
+          lastCheckAtMs: checkedAtMs,
+          lastSuccessAtMs: checkedAtMs,
+          lastStatus: "up-to-date",
+        })),
+      },
+    });
+
+    const result = await resolveActiveVersionDetailed(
+      io,
+      { plugin: PLUGIN, installedVersion: INSTALLED, cacheDir: CACHE, channel: "stable" },
+      { nowMs, staleAfterMs: 4 * 60 * 60 * 1000 },
+    );
+
+    expect(result.selfUpdateStatus).toEqual({
+      status: "up-to-date",
+      checkedAtMs,
+      ageMs: 5 * 60 * 60 * 1000,
+    });
+    expect(result.staleSuccess).toEqual({
+      status: "up-to-date",
+      ageMs: 5 * 60 * 60 * 1000,
+    });
+    expect(result.logNotes).toContain("self-update up-to-date: checked 5h ago");
+    expect(result.logNotes).toContain("self-update stale: last successful check was 5h ago");
+  });
+
   it("writes self-update status as TOON and reads legacy JSON status", async () => {
     const updated = "1.145.0";
     const nowMs = 10 * 60 * 60 * 1000;

--- a/packages/shared/self-update.ts
+++ b/packages/shared/self-update.ts
@@ -244,6 +244,19 @@ export interface ActiveVersionResolution {
     ageMs: number;
     lastError?: string;
   };
+  /** The persisted verdict together with when it was formed. A status without
+   * this age is not evidence about the current registry horizon. */
+  selfUpdateStatus?: {
+    status: SelfUpdateStatus;
+    checkedAtMs: number;
+    ageMs: number;
+  };
+  /** A successful registry check loses its authority at the same boundary as a
+   * failed check. Callers can distinguish stale success from live evidence. */
+  staleSuccess?: {
+    status: "updated" | "up-to-date";
+    ageMs: number;
+  };
   logNotes: string[];
 }
 
@@ -312,6 +325,14 @@ export async function resolveActiveVersionDetailed(
   const state = await readStateFile(io, cacheDir, plugin);
   const nowMs = options.nowMs ?? Date.now();
   const staleAfterMs = options.staleAfterMs ?? DEFAULT_SELF_UPDATE_STALE_AFTER_MS;
+  const selfUpdateStatus =
+    state.lastStatus !== undefined && state.lastCheckAtMs !== undefined
+      ? {
+          status: state.lastStatus,
+          checkedAtMs: state.lastCheckAtMs,
+          ageMs: Math.max(0, nowMs - state.lastCheckAtMs),
+        }
+      : undefined;
   let staleFailure: ActiveVersionResolution["staleFailure"];
   if (
     state.lastFailureAtMs !== undefined &&
@@ -321,6 +342,24 @@ export async function resolveActiveVersionDetailed(
     staleFailure = { ageMs: nowMs - state.lastFailureAtMs, lastError: state.lastError };
     logNotes.push(`self-update stale: last check failed ${formatAgeMs(staleFailure.ageMs)} ago`);
   }
+  let staleSuccess: ActiveVersionResolution["staleSuccess"];
+  if (
+    selfUpdateStatus !== undefined &&
+    (selfUpdateStatus.status === "updated" || selfUpdateStatus.status === "up-to-date")
+  ) {
+    logNotes.push(
+      `self-update ${selfUpdateStatus.status}: checked ${formatAgeMs(selfUpdateStatus.ageMs)} ago`,
+    );
+    if (selfUpdateStatus.ageMs > staleAfterMs) {
+      staleSuccess = {
+        status: selfUpdateStatus.status,
+        ageMs: selfUpdateStatus.ageMs,
+      };
+      logNotes.push(
+        `self-update stale: last successful check was ${formatAgeMs(staleSuccess.ageMs)} ago`,
+      );
+    }
+  }
 
   return {
     version,
@@ -328,6 +367,8 @@ export async function resolveActiveVersionDetailed(
     ...(laneNewestVersion ? { laneNewestVersion } : {}),
     ...(reconciled ? { reconciled } : {}),
     ...(staleFailure ? { staleFailure } : {}),
+    ...(selfUpdateStatus ? { selfUpdateStatus } : {}),
+    ...(staleSuccess ? { staleSuccess } : {}),
     logNotes,
   };
 }


### PR DESCRIPTION
Automated AFK landing for #3178. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3178

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788372066&installation_model_id=20659&pr_number=3187&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3187&signature=674cd383216504d5ba332985832b1d91d48a42f16d36434aaa92e089e0543699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->