### PR TITLE
fix: #3186 ask the kernel who owns the socket, not a 250ms clock

### DIFF
--- a/.changeset/ask-the-kernel-not-the-clock.md
+++ b/.changeset/ask-the-kernel-not-the-clock.md
@@ -1,0 +1,25 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Ask the kernel who owns the socket, not a 250ms clock
+
+`bindExclusive` resolved an ambiguous `EADDRINUSE` — a live peer and the socket
+file a crash left behind look identical on disk — by pinging the path and
+treating silence as debris to unlink. A ping asks whether the owner is HEALTHY,
+and health is not title: a daemon busy on a long request, or hung in a shutdown
+drain, fails a 250ms ping while owning its socket completely. Reading that
+`false` as an absent owner unlinked live sockets out from under running daemons,
+which then went on believing they were the machine's single arbiter.
+
+One host recorded **1166 daemon births in a day**, 985 of them living two seconds
+or less, with **four daemons `serving` simultaneously**. Each theft also dropped
+the standing project registrations onto a daemon nobody would reach again.
+
+Ownership is now asked of the kernel: a `connect()` that succeeds proves a
+listener is bound, whether or not it ever replies; only `ECONNREFUSED`/`ENOENT`
+proves the inode is debris. An unresolved probe keeps the path, because the two
+mistakes do not cost the same — refusing to start loses one daemon that says
+why, and unlinking a live socket loses every client that came after it, silently.
+The lease and the machine claim are consulted as a second belt: a probe is not
+owed the last word over two records that already name a live pid.

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -40,7 +40,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
-import { createServer, type Server, type Socket } from "node:net";
+import { connect, createServer, type Server, type Socket } from "node:net";
 import { dirname } from "node:path";
 import type { DeathAttribution } from "@reddb-io/shared/death-attribution.js";
 import { isPidAlive, sendLineRequest, serveWireSocket } from "@reddb-io/shared/resident-core.js";
@@ -815,7 +815,18 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
 
   let server: Server;
   try {
-    server = await bindExclusive(paths.socketPath);
+    // The two records that already name this socket's holder. Consulted only to
+    // REFUSE — an absent, stale or unreadable record decides nothing and falls
+    // through to the bind, which is the arbiter it always was.
+    server = await bindExclusive(paths.socketPath, async () => {
+      const [lease, claim] = await Promise.all([
+        leaseStore.read().catch(() => undefined),
+        machineClaimStore.read().catch(() => undefined),
+      ]);
+      if (lease != null && lease.pid !== owner.pid && isPidAlive(lease.pid)) return true;
+      return claim != null && claim.socket_path === paths.socketPath &&
+        claim.pid !== machineOwner.pid && isPidAlive(claim.pid);
+    });
   } catch (err) {
     await leaseStore.release(owner).catch(() => undefined);
     await machineClaimStore.release(machineOwner).catch(() => undefined);
@@ -2547,13 +2558,77 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
 }
 
 /**
- * Bind the socket, refusing to steal one another daemon is answering on.
+ * What a socket path is, to the one caller allowed to delete it.
+ *
+ * `owned` and `unowned` are the two the ambiguity is between; `unknown` is the
+ * third answer a probe owes when it resolved neither, and it exists so that a
+ * failure to decide can never be spelled as a decision.
+ */
+export type RedskilledSocketOwnership = "owned" | "unowned" | "unknown";
+
+/**
+ * Who owns a socket path, asked of the KERNEL rather than of a clock.
+ *
+ * A `connect()` that SUCCEEDS proves a listener is bound to the path — that is
+ * the whole of what ownership means here, and it is true whether the owner
+ * replies in a millisecond, in a minute, or never. A `connect()` REFUSED
+ * (`ECONNREFUSED`, `ENOENT`) proves the opposite just as cheaply: the inode is
+ * there and nothing is listening behind it, which is exactly the debris a crash
+ * leaves. Anything else resolved nothing and says so.
+ *
+ * **This is deliberately not `socketAnswers`.** A ping asks whether the owner is
+ * HEALTHY, and health is not title: a daemon busy on a long request, or hung in
+ * a shutdown drain, fails a ping while owning its socket completely. Reading
+ * that `false` as an absent owner is how a live daemon's socket got unlinked out
+ * from under it — 1166 daemon births in one day, four of them serving at once
+ * (#3186). Health is still worth asking; it is just not what licenses a delete.
+ */
+export async function probeSocketOwnership(
+  socketPath: string,
+  timeoutMs = 250,
+): Promise<RedskilledSocketOwnership> {
+  return await new Promise<RedskilledSocketOwnership>((resolve) => {
+    const probe = connect(socketPath);
+    let settled = false;
+    const settle = (ownership: RedskilledSocketOwnership): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      probe.destroy();
+      resolve(ownership);
+    };
+    // A local unix connect resolves at kernel speed, so the timeout is a
+    // backstop rather than the mechanism. It resolves `unknown` — never
+    // `unowned` — because a slow answer is the case this whole function exists
+    // to stop reading as an absent one.
+    const timer = setTimeout(() => settle("unknown"), timeoutMs);
+    timer.unref?.();
+    probe.once("connect", () => settle("owned"));
+    probe.once("error", (error: NodeJS.ErrnoException) => {
+      settle(error.code === "ECONNREFUSED" || error.code === "ENOENT" ? "unowned" : "unknown");
+    });
+  });
+}
+
+/**
+ * Bind the socket, refusing to steal one another daemon is bound to.
  *
  * `EADDRINUSE` is ambiguous — a live peer and a socket file a crash left behind
- * look identical on disk — so it is resolved by *asking*: a path that answers a
- * ping has an owner, and a path that does not is debris to unlink and retry.
+ * look identical on disk — so it is resolved by *asking the kernel*: a path a
+ * `connect()` reaches has an owner, and only a path that refuses the connection
+ * is debris to unlink and retry. An unresolved probe keeps the path, because the
+ * cost of the two mistakes is not symmetric: refusing to start loses one daemon
+ * that says why, and unlinking a live socket loses every client that came after
+ * it, silently, while the daemon it orphaned goes on believing it is the one.
+ *
+ * `ownerRecorded` is the second belt. The lease and the machine claim already
+ * name the pid that holds this path, and a probe is not owed the last word over
+ * two records that name a live process.
  */
-async function bindExclusive(socketPath: string): Promise<Server> {
+async function bindExclusive(
+  socketPath: string,
+  ownerRecorded?: () => Promise<boolean>,
+): Promise<Server> {
   for (let attempt = 0; attempt < 2; attempt++) {
     const server = createServer();
     try {
@@ -2568,7 +2643,10 @@ async function bindExclusive(socketPath: string): Promise<Server> {
     } catch (err) {
       server.close();
       if ((err as NodeJS.ErrnoException).code !== "EADDRINUSE") throw err;
-      if (await socketAnswers(socketPath)) throw new RedskilledAlreadyRunningError(socketPath);
+      if ((await probeSocketOwnership(socketPath)) !== "unowned") {
+        throw new RedskilledAlreadyRunningError(socketPath);
+      }
+      if (await ownerRecorded?.()) throw new RedskilledAlreadyRunningError(socketPath);
       await rm(socketPath, { force: true });
     }
   }

--- a/apps/redskilled/tests/socket-ownership.test.ts
+++ b/apps/redskilled/tests/socket-ownership.test.ts
@@ -1,0 +1,108 @@
+// A socket's OWNER and a socket's HEALTH are different questions, and only the
+// first one licenses a delete. The failure being guarded is the one that filled
+// a day's death lane with 1166 daemon births (#3186): a daemon busy or hung
+// behind its socket fails a 250ms ping, the newcomer reads that silence as
+// debris, unlinks the live socket and binds its own — and now two daemons each
+// believe they are the machine's single arbiter.
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  probeSocketOwnership,
+  RedskilledAlreadyRunningError,
+  socketAnswers,
+  startRedskilledDaemon,
+  type RedskilledDaemon,
+} from "../src/daemon.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+
+const running: RedskilledDaemon[] = [];
+const servers: Server[] = [];
+const accepted: Socket[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const socket of accepted.splice(0)) socket.destroy();
+  for (const server of servers.splice(0)) await new Promise<void>((r) => server.close(() => r()));
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-ownership-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+/** A listener that accepts every connection and answers none — a busy or hung daemon. */
+async function silentListener(socketPath: string): Promise<Server> {
+  const server = createServer((socket) => {
+    // Accepted and then ignored — what a daemon draining a stuck shutdown looks
+    // like from the outside. Kept so teardown can destroy it: `close()` only
+    // stops accepting, and a connection nobody ever answers is never released.
+    accepted.push(socket);
+  });
+  servers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return server;
+}
+
+describe("socket ownership is asked of the kernel, not of a clock", () => {
+  it("reads a listener that never replies as OWNED, where a ping reads it as absent", async () => {
+    const paths = await sessionPaths();
+    await silentListener(paths.socketPath);
+
+    // The two questions, side by side. `socketAnswers` is not wrong — it is
+    // answering about health — it is just not the question a delete may consult.
+    await expect(socketAnswers(paths.socketPath, 100)).resolves.toBe(false);
+    await expect(probeSocketOwnership(paths.socketPath)).resolves.toBe("owned");
+  });
+
+  it("reads a socket file nothing listens behind as UNOWNED", async () => {
+    const paths = await sessionPaths();
+    const server = await silentListener(paths.socketPath);
+    // Close the listener while leaving the inode: exactly the debris a crash
+    // leaves behind, and the only case an unlink is for.
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    await expect(probeSocketOwnership(paths.socketPath)).resolves.toBe("unowned");
+  });
+
+  it("never resolves an unreadable probe as unowned", async () => {
+    const paths = await sessionPaths();
+    // A path with no socket at all: absent is refused-with-ENOENT, still a
+    // definite answer. What must never appear is `unowned` from a probe that
+    // resolved nothing — that is the read this whole module exists to forbid.
+    const ownership = await probeSocketOwnership(join(paths.runtimeDir, "no-such.sock"));
+    expect(ownership).toBe("unowned");
+  });
+});
+
+describe("a daemon refuses to steal a socket whose owner is silent", () => {
+  it("refuses to start, and leaves the live socket where it found it", async () => {
+    const paths = await sessionPaths();
+    const holder = await silentListener(paths.socketPath);
+    const inodeBefore = (await stat(paths.socketPath)).ino;
+
+    // On the pre-#3186 code this call SUCCEEDS: the ping times out, the socket
+    // is unlinked as debris, the rebind wins, and the silent holder is orphaned
+    // on a path that no longer names it.
+    await expect(startRedskilledDaemon({ paths })).rejects.toBeInstanceOf(RedskilledAlreadyRunningError);
+
+    // The holder still owns the same inode — nothing was replaced underneath it.
+    expect((await stat(paths.socketPath)).ino).toBe(inodeBefore);
+    expect(holder.listening).toBe(true);
+    await expect(probeSocketOwnership(paths.socketPath)).resolves.toBe("owned");
+  });
+});


### PR DESCRIPTION
Closes #3186.

`bindExclusive` resolved an ambiguous `EADDRINUSE` — a live peer and the socket file a crash left behind look identical on disk — by pinging the path and treating silence as debris to unlink.

**A ping asks whether the owner is HEALTHY, and health is not title.** A daemon busy on a long request, or hung in a shutdown drain, fails a 250ms ping while owning its socket completely. Reading that `false` as an absent owner unlinked live sockets out from under running daemons, which then went on believing they were the machine's single arbiter.

## What the machine did

The host death lane recorded **1166 daemon births in one day**, 985 of them living two seconds or less — 99.2 GB of transient RSS and 439s of CPU spent on processes whose whole life was losing a race. **421 reached `serving`**, and four held that belief at the same instant:

```
17:39:50.015 pid=63949 up=16s serving SIGTERM
17:39:50.015 pid=67522 up= 6s serving SIGTERM
17:39:50.015 pid=68365 up= 1s serving SIGTERM
17:39:50.016 pid=68497 up= 0s serving SIGTERM
```

Each theft also stranded the standing project registrations on a daemon nobody would reach again — the mechanism under #3180 and #3184.

## The change

Ownership is asked of the kernel. `probeSocketOwnership` returns `owned` when `connect()` succeeds (a listener is bound, whether or not it ever replies), `unowned` only on `ECONNREFUSED`/`ENOENT` (the inode is there and nothing is behind it), and `unknown` when it resolved neither.

**An unresolved probe keeps the path.** The two mistakes do not cost the same: refusing to start loses one daemon that says why; unlinking a live socket loses every client that came after it, silently.

`socketAnswers` is untouched and still used for health — it is simply no longer what licenses a delete. The lease and machine claim are the second belt: a probe is not owed the last word over two records that already name a live pid.

## Verification

`apps/redskilled/tests/socket-ownership.test.ts` — **fails on the pre-fix code**, where `startRedskilledDaemon` *resolves* instead of rejecting because the old bind steals the silent listener's socket and starts anyway. Confirmed by reverting `daemon.ts` to `origin/main` and re-running: 4/4 fail, then 4/4 pass with the fix.

- `apps/redskilled`: 652 tests, 65 files — all pass, including the pre-existing `singleton-race` and `auto-spawn` suites
- `tsc --noEmit`: clean
- `pnpm -C apps/dev test:invariants`: 141 tests, all pass

Ships as a `patch` — this is an urgent correction and operators are on the broken path today.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788373545&installation_model_id=20659&pr_number=3189&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3189&signature=45dac8e487afa2cd9c9f4c68b9d66c44690bbe2f001b6ccbf63da086df79318e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->