### PR TITLE
fix: #3184 Two Workers were born and vanished within nine minutes leaving no death record, while every surface reported a healthy idle host

### DIFF
--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -306,6 +306,34 @@ export const DEFAULT_REDSKILLED_REGISTRATION_SUSTAIN_MS = 60_000;
  */
 export const REDSKILLED_LAPSE_MEMORY = 16;
 
+/** Project one durable host event into the loss shape every renderer consumes. */
+function observedWorkerDeath(event: RedskilledHostEvent): DeathAttribution | null {
+  if (event.event !== "worker-death" && event.event !== "worker-budget-kill") return null;
+  const hostEndedWorker = event.event === "worker-budget-kill";
+  const observation = event.detail ??
+    `redskilled observed exit code=${event.exit_code ?? "null"} signal=${event.signal ?? "null"}`;
+  return {
+    version: 1,
+    ts: event.ts,
+    kind: "worker",
+    id: event.worker_id,
+    pid: event.pid,
+    // The daemon observed the loss at this instant; an early Worker published no
+    // finer heartbeat or phase, and inventing either would be worse than saying so.
+    last_seen: event.ts,
+    last_phase: "unreported",
+    sender_class: hostEndedWorker ? "teardown" : "unknown",
+    confidence: hostEndedWorker ? "high" : "none",
+    signal: event.signal,
+    host_boot_changed: false,
+    // A budget kill is the daemon's own act and therefore evidence. A spontaneous
+    // exit has an observation but no known sender; keep that receipt under
+    // `checked` so `unknown` remains honest rather than becoming a guessed cause.
+    evidence: hostEndedWorker ? [observation] : [],
+    checked: [`redskilled host event: ${observation}`],
+  };
+}
+
 /** Raised when another daemon already serves this user session. */
 export class RedskilledAlreadyRunningError extends Error {
   constructor(
@@ -910,6 +938,14 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // replayed into them at boot.
   let observations: RedskilledWorkerMetricObservation[] = [];
   let outcomeMarks: RedskilledWorkerOutcomeMark[] = [];
+  // Boot attributions and deaths this daemon observed share one surface feed.
+  // The latter stay durable through the host event lane and are replayed below;
+  // keeping a second on-disk death record would create two authorities for the
+  // same Worker exit. `undefined` remains until either source has answered,
+  // because a daemon that never reaped and never observed a death must not render
+  // a calm zero in place of an absent instrument.
+  let deathAttributions: DeathAttribution[] | undefined =
+    options.deaths === undefined ? undefined : [...options.deaths];
   // What each project asked the host to hold for it, by project label. In memory,
   // like the log lines and for the same reason: a registration is a live statement
   // a session renews, and a durable copy would outlive the thing it describes. The
@@ -1170,7 +1206,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       reattachedWorkerIds: [...reattached],
       repositoryActivity: lastActivity,
       githubBalance: lastBalance,
-      ...(options.deaths === undefined ? {} : { deaths: options.deaths }),
+      ...(deathAttributions === undefined ? {} : { deaths: deathAttributions }),
       // Derived here, once, for every surface: the observation history belongs
       // to this process, so a statusline dividing its own counters would be a
       // second authority on a number that has one answer.
@@ -1916,6 +1952,25 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     // describe the same ending at two different times.
     if (event === "worker-death" || event === "worker-budget-kill") {
       markWorkerOutcome({ worker_id: worker.worker_id, ts, outcome: event });
+      rememberObservedDeath({
+        version: 1,
+        ts,
+        event,
+        worker_id: worker.worker_id,
+        project_label: worker.project_label,
+        pid: worker.pid,
+        workspace_path: worker.workspace_path,
+        log_path: worker.log_path ?? null,
+        isolated: worker.isolated,
+        unit: worker.unit ?? null,
+        memory_high: worker.budget?.memory_high ?? null,
+        memory_max: worker.budget?.memory_max ?? null,
+        cpu_weight: worker.budget?.cpu_weight ?? null,
+        detail,
+        reason: null,
+        exit_code: exit.exitCode ?? null,
+        signal: exit.signal ?? null,
+      });
       // Every death reaches here, which is why the breaker folds here rather
       // than at the five call sites that end a Worker. What it reads is a
       // lifetime, never a cause: the daemon is not owed a reason (rule 3), and
@@ -1932,6 +1987,22 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         ...(exit.signal !== undefined ? { signal: exit.signal } : {}),
       })
       .catch(() => undefined);
+  }
+
+  /** Put one host-observed loss on every surface, newest observation winning. */
+  function rememberObservedDeath(event: RedskilledHostEvent): void {
+    const attribution = observedWorkerDeath(event);
+    if (attribution == null) return;
+    const merged = [
+      attribution,
+      ...(deathAttributions ?? []).filter(
+        (existing) => existing.kind !== attribution.kind || existing.id !== attribution.id,
+      ),
+    ].sort((left, right) => Date.parse(left.ts) - Date.parse(right.ts));
+    // The badge describes the same rolling day as the daemon's outcome feed,
+    // rather than turning an append-only lane's lifetime total into current
+    // health. The generic pruner also caps an unreadable clock safely.
+    deathAttributions = pruneRedskilledMetricHistory(merged, (death) => death.ts, { now: clock() });
   }
 
   /**
@@ -2424,6 +2495,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // in the window between binding and replay would be told this session holds
   // nothing, and would then birth a second Worker for work already running.
   const laneEvents = await eventLane.read().catch(() => []);
+  // A successor must render yesterday's loss too. The event lane is the durable
+  // host witness, so replaying it here restores the exact feed a live exit updates
+  // above without asking a project artifact that an early Worker never created.
+  for (const event of laneEvents) rememberObservedDeath(event);
   // The outcomes a predecessor recorded are this host's history too: a daemon
   // that restarted mid-day and reported an empty 24h window would tell an
   // operator the machine finished nothing, when what happened is that the

--- a/apps/redskilled/tests/early-worker-death.test.ts
+++ b/apps/redskilled/tests/early-worker-death.test.ts
@@ -1,0 +1,151 @@
+// A Worker that leaves before its first heartbeat still has two witnesses: the
+// host event lane records what the daemon observed, and the shared payload makes
+// that loss visible instead of rendering the newly-free host as merely idle.
+import type { ChildProcess } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  REDSKILLED_DASHBOARD_DEFAULTS,
+  REDSKILLED_STATUSLINE_DEFAULTS,
+  renderRedskilledDashboard,
+  renderRedskilledStatusline,
+} from "@reddb-io/redskilled-render";
+import { afterEach, describe, expect, it } from "vitest";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { readRedskilledEvents } from "../src/event-lane.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import type { LaunchedWorker, LaunchWorkerOptions, RedskilledWorkerSpec } from "../src/worker-launch.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths() {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-early-death-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+function earlyExitLaunch(state: { exit?: (code: number) => void }) {
+  return (options: LaunchWorkerOptions): LaunchedWorker => {
+    const workerId = options.spec.worker_id ?? "w-early";
+    const worker: RedskilledWorkerView = {
+      worker_id: workerId,
+      project_label: options.spec.project_label,
+      pid: 4_242,
+      started_at: "2026-08-03T16:47:00.000Z",
+      workspace_path: options.spec.workspace_path,
+      isolated: false,
+      warnings: [],
+    };
+    state.exit = (code) => options.onExit?.(workerId, code, null);
+    return {
+      worker,
+      admission: options.admission,
+      warnings: [],
+      plan: {
+        isolated: false,
+        backend: "none",
+        command: options.spec.command,
+        args: [],
+        budget: {},
+        environment: {},
+      },
+      child: { pid: worker.pid } as ChildProcess,
+    };
+  };
+}
+
+function spec(): RedskilledWorkerSpec {
+  return {
+    worker_id: "w-early",
+    project_label: "acme/widgets",
+    workspace_path: "/tmp/acme/w-early",
+    command: process.execPath,
+  };
+}
+
+describe("a Worker that exits before its first write", () => {
+  it("leaves a host-written death and renders as a loss, not quiet idleness", async () => {
+    const paths = await sessionPaths();
+    const launched: { exit?: (code: number) => void } = {};
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      clock: () => "2026-08-03T16:47:09.000Z",
+      launch: earlyExitLaunch(launched),
+      unitInventory: () => [],
+    });
+    running.push(daemon);
+
+    daemon.startWorker(spec());
+    launched.exit?.(70);
+    await daemon.flushEvents();
+
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.map((event) => event.event)).toEqual(["worker-birth", "worker-death"]);
+    expect(events[1]).toMatchObject({ worker_id: "w-early", pid: 4_242, exit_code: 70, signal: null });
+
+    const payload = daemon.statuslinePayload();
+    expect(payload.deaths?.latest).toMatchObject({
+      id: "w-early",
+      pid: 4_242,
+      sender_class: "unknown",
+      confidence: "none",
+      last_phase: "unreported",
+    });
+
+    const line = renderRedskilledStatusline(payload, {
+      ...REDSKILLED_STATUSLINE_DEFAULTS,
+      project: "acme/widgets",
+    });
+    expect(line.line).toContain("†1 unknown");
+    const dashboard = renderRedskilledDashboard(payload, {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      mode: "local",
+      project: "acme/widgets",
+    });
+    expect(dashboard.lines.some((entry) => entry.includes("w-early"))).toBe(true);
+  });
+
+  it("remains visible when a successor daemon replays the host event lane", async () => {
+    const paths = await sessionPaths();
+    const launched: { exit?: (code: number) => void } = {};
+    const first = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      clock: () => "2026-08-03T16:47:09.000Z",
+      launch: earlyExitLaunch(launched),
+      unitInventory: () => [],
+    });
+    running.push(first);
+    first.startWorker(spec());
+    launched.exit?.(70);
+    await first.flushEvents();
+    await first.stop();
+
+    const successor = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      clock: () => "2026-08-03T16:48:00.000Z",
+      unitInventory: () => [],
+    });
+    running.push(successor);
+
+    expect(successor.statuslinePayload().deaths?.latest).toMatchObject({
+      id: "w-early",
+      pid: 4_242,
+      sender_class: "unknown",
+      confidence: "none",
+    });
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3184. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3184

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788374736&installation_model_id=20659&pr_number=3194&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3194&signature=91db0bd713cf4f31d9a7b702c5d4cc8351e8ea16ea20b6286a51b79ec08dd37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->