### PR TITLE
merge: #3158 A registration the daemon deliberately refused is reported as a daemon that did not answer, and the operator is told to install what just spoke

### DIFF
--- a/apps/dev/src/runtime/redskilled-birth.ts
+++ b/apps/dev/src/runtime/redskilled-birth.ts
@@ -29,6 +29,7 @@ import {
   renewRedskilledProject,
   readRedskilledHostState,
   redskilledPresenceAdvice,
+  RedskilledRequestRefusedError,
   RedskilledUnreachableError,
   startRedskilledWorker,
   type RedskilledClientConfig,
@@ -332,11 +333,18 @@ export function createRedskilledBirthPort(options: CreateRedskilledBirthOptions)
  *
  * A sibling of {@link redskilledUnreachableAdvice} rather than a reuse of it,
  * because the two refusals leave different states behind: that one says no Worker
- * was born, this one says the project has no presence at all. Both name the
- * socket, because "start the daemon" and "fix the client that stopped asking it"
- * are still the two repairs, and the socket is what tells them apart.
+ * was born, this one says the project has no presence at all. Transport silence
+ * names the socket and its reach repair; an answered application refusal preserves
+ * the daemon's reason and never routes the operator to provisioning (#3158).
  */
 export function redskilledRegistrationRefusal(socketPath: string, cause: unknown): string {
+  if (cause instanceof RedskilledRequestRefusedError) {
+    const deadline = standingRegistrationDeadline(cause.refusal);
+    return deadline == null
+      ? `this project was not registered because the redskilled daemon refused it: ${cause.refusal}`
+      : `this project was not registered: ${cause.refusal}; wait for the standing registration to lapse at ` +
+          `${deadline}, or stop the existing registration before retrying.`;
+  }
   const detail = cause instanceof Error ? cause.message : String(cause);
   return (
     `this project was not registered: the redskilled daemon did not answer on ${socketPath}. ` +
@@ -344,6 +352,11 @@ export function redskilledRegistrationRefusal(socketPath: string, cause: unknown
     `that cannot reach the daemon starts nothing rather than launching a demand producer no host admitted, ` +
     `counts or can stop. ${repairFor(cause)} (${detail})`
   );
+}
+
+/** The deadline carried by the daemon's canonical duplicate-registration refusal. */
+function standingRegistrationDeadline(refusal: string): string | undefined {
+  return / standing until (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z):/.exec(refusal)?.[1];
 }
 
 export function redskilledUnreachableAdvice(socketPath: string, cause: unknown): string {

--- a/apps/dev/tests/redskilled-birth.test.ts
+++ b/apps/dev/tests/redskilled-birth.test.ts
@@ -191,6 +191,41 @@ describe("a project's registration outlives the session that made it", () => {
     await expect(port.renew()).rejects.toThrow(/acme\/widgets/);
     expect(daemon.hostState().registrations).toEqual([]);
   });
+
+  it("reports a standing registration as the daemon's refusal, not silence", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("dev-birth-registration-refusal-");
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      clock: () => "2026-08-03T13:26:08.361Z",
+    });
+    running.push(daemon);
+
+    const port = createRedskilledBirthPort({ root: workspace, projectLabel: "acme/widgets", paths });
+    const request = {
+      selector: "is:open label:ready-for-agent",
+      argv: ["red-skills-dev", "__work"],
+      workspace_path: workspace,
+      target: 3,
+      renew_within_ms: 330_271,
+    } as const;
+    const held = await port.register(request);
+
+    let refusal: unknown;
+    try {
+      await port.register(request);
+    } catch (err) {
+      refusal = err;
+    }
+    const advice = redskilledRegistrationRefusal(port.socketPath, refusal);
+
+    expect(advice).toContain(held.renew_by);
+    expect(advice).toContain("wait for the standing registration to lapse");
+    expect(advice).toContain("stop the existing registration");
+    expect(advice).not.toContain("did not answer");
+    expect(advice).not.toContain("provision");
+  });
 });
 
 describe("the project's identity and its advice", () => {
@@ -200,10 +235,17 @@ describe("the project's identity and its advice", () => {
   });
 
   it("names the socket and the repair in one sentence", () => {
-    const advice = redskilledUnreachableAdvice("/run/user/1/redskilled.sock", new Error("boom"));
+    const socketPath = "/run/user/1/redskilled.sock";
+    const cause = new Error("boom");
+    const advice = redskilledUnreachableAdvice(socketPath, cause);
     expect(advice).toContain("/run/user/1/redskilled.sock");
     expect(advice).toContain("redskilled provision");
     expect(advice).toContain("boom");
+
+    const registrationAdvice = redskilledRegistrationRefusal(socketPath, cause);
+    expect(registrationAdvice).toContain("did not answer");
+    expect(registrationAdvice).toContain(socketPath);
+    expect(registrationAdvice).toContain("redskilled provision");
   });
 
   it("never advises provisioning a daemon a live pid is already holding", () => {

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -175,6 +175,21 @@ export class RedskilledDaemonHeldError extends RedskilledUnreachableError {
 }
 
 /**
+ * Raised when the daemon answered a request with an application-level refusal.
+ *
+ * This is deliberately distinct from {@link RedskilledUnreachableError}: both
+ * leave the requested operation unapplied, but only the latter is transport
+ * silence. Surfaces use the distinction to preserve the daemon's explanation
+ * instead of routing an answered refusal to installation advice (#3158).
+ */
+export class RedskilledRequestRefusedError extends Error {
+  constructor(readonly refusal: string) {
+    super(refusal);
+    this.name = "RedskilledRequestRefusedError";
+  }
+}
+
+/**
  * Ask what is actually on this socket: answering, held-but-silent, or absent.
  *
  * The one probe every surface shares. It reads the socket and the lease and hands
@@ -418,7 +433,7 @@ export async function requestRedskilled(
       await probeRedskilledPresence(paths).catch(() => undefined),
     );
   }
-  if (!response.ok) throw new Error(response.error);
+  if (!response.ok) throw new RedskilledRequestRefusedError(response.error);
   return response.value;
 }
 
@@ -458,7 +473,7 @@ export async function stopRedskilledDaemon(
     // saying nothing, which is the one thing a stop must not report as done.
     throw new RedskilledUnreachableError(paths.socketPath, err);
   }
-  if (!response.ok) throw new Error(response.error);
+  if (!response.ok) throw new RedskilledRequestRefusedError(response.error);
   if (!isRedskilledDaemonStopped(response.value)) throw new Error("redskilled daemon returned a malformed stop report");
   const report = response.value;
 

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -179,7 +179,7 @@ export class RedskilledDaemonHeldError extends RedskilledUnreachableError {
  *
  * This is deliberately distinct from {@link RedskilledUnreachableError}: both
  * leave the requested operation unapplied, but only the latter is transport
- * silence. Surfaces use the distinction to preserve the daemon's explanation
+ * silence. Surfaces use the distinction to keep the daemon's explanation
  * instead of routing an answered refusal to installation advice (#3158).
  */
 export class RedskilledRequestRefusedError extends Error {


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3158 -->
🤖 **Re-seed trail** — #3158 on `afk/3158-a-registration-the-daemon-deliberately-r`, lane `/afk`.

Rounds spent: 2/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE, but the base gained 1 commit under this attempt; the gate ran on a tree merged with that newer base, so the failure is attributed to stale-base drift, not the branch; granting a free stale-base correction (1/2), budget untouched at 1/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

Closes #3158