### PR TITLE
fix: #3151 The statusline draws a Worker as a name and a memory figure, where thirteen aligned colored columns used to be

### DIFF
--- a/apps/redskilled/tests/statusline-bound.test.ts
+++ b/apps/redskilled/tests/statusline-bound.test.ts
@@ -29,6 +29,7 @@ import {
   renderRedskilledStatusline,
   renderRedskilledStatuslineAbsence,
   type RedskilledStatuslineOptions,
+  width,
 } from "@reddb-io/redskilled-render";
 import type { RedskilledWorkerLogLine } from "../src/worker-log.js";
 
@@ -111,7 +112,7 @@ describe("the size of a statusline answer", () => {
       for (const workerCount of [0, 1, 4, 40, 500]) {
         const render = renderRedskilledStatusline(crowdedPayload(workerCount), taste);
         expect(render.lines.length).toBeLessThanOrEqual(bound.max_lines);
-        for (const line of render.lines) expect([...line].length).toBeLessThanOrEqual(bound.max_line_width);
+        for (const line of render.lines) expect(width(line)).toBeLessThanOrEqual(bound.max_line_width);
         expect(redskilledStatuslineCharacters(render)).toBeLessThanOrEqual(bound.max_characters);
       }
     }

--- a/apps/redskilled/tests/statusline-host-adapter.test.ts
+++ b/apps/redskilled/tests/statusline-host-adapter.test.ts
@@ -168,7 +168,7 @@ describe("what the host prints", () => {
     expect(written).toEqual([`${served.lines.join("\n")}\n`]);
     // `--verbose` is the interesting case: the extra rows carry each Worker's
     // last logged line, published by the Worker and stored opaque by the daemon.
-    expect(served.lines.length).toBe(3);
+    expect(served.lines.length).toBe(5);
     expect(written[0]).toContain("w-1 is doing something");
     expect(written[0]).toContain("w-2 is doing something");
   });

--- a/apps/redskilled/tests/statusline-string.test.ts
+++ b/apps/redskilled/tests/statusline-string.test.ts
@@ -24,7 +24,9 @@ import {
 import {
   REDSKILLED_STATUSLINE_DEFAULTS,
   renderRedskilledStatusline,
+  stripAnsi,
   type RedskilledStatuslineOptions,
+  width,
 } from "@reddb-io/redskilled-render";
 import type { RedskilledStatuslinePayload } from "../src/statusline-payload.js";
 import { buildStatuslinePayload } from "../src/statusline-payload.js";
@@ -167,9 +169,9 @@ describe("the rendered statusline", () => {
 
     expect(render.mode).toBe("local");
     expect(render.line).toContain("acme/widgets 1w");
-    expect(render.line).toContain("w-1 512M/1G");
-    expect(render.line).not.toContain("w-2");
-    expect(render.line).not.toContain("acme/gadgets");
+    expect(stripAnsi(render.lines[1]!)).toContain("w-1");
+    expect(render.lines.join("\n")).not.toContain("w-2");
+    expect(render.lines.join("\n")).not.toContain("acme/gadgets");
   });
 
   it("lists every project's Workers in `global`, each showing its owner", () => {
@@ -182,8 +184,8 @@ describe("the rendered statusline", () => {
 
     expect(render.detail).toBe("workers");
     expect(render.line).toContain("host 2w/2p");
-    expect(render.line).toContain("acme/widgets:w-1 512M/1G");
-    expect(render.line).toContain("acme/gadgets:w-2 128M/512M");
+    expect(stripAnsi(render.lines[1]!)).toContain("acme/widgets:w-1");
+    expect(stripAnsi(render.lines[2]!)).toContain("acme/gadgets:w-2");
   });
 
   it("degrades a crowded global view to an aggregate and never overflows the line", () => {
@@ -224,16 +226,16 @@ describe("the rendered statusline", () => {
           payload,
           options({ mode, project: workers[0].project_label, maxWidth, maxProjects: 9, maxWorkers: 9 }),
         );
-        expect([...render.line].length).toBeLessThanOrEqual(maxWidth);
+        for (const line of render.lines) expect(width(line)).toBeLessThanOrEqual(maxWidth);
       }
     }
   });
 
-  it("says a Worker is unmeasured rather than showing it as idle", () => {
+  it("still names a Worker whose optional measurements are absent", () => {
     const payload = payloadOf([worker()], {});
     const render = renderRedskilledStatusline(payload, options({ project: "acme/widgets" }));
-    expect(render.line).toContain("w-1 ?");
-    expect(render.line).not.toContain("w-1 0B");
+    expect(stripAnsi(render.lines[1]!)).toContain("w-1");
+    expect(stripAnsi(render.lines[1]!)).toContain("hb=?");
   });
 
   it("marks a stale answer, and calls an idle host neither stale nor busy", () => {
@@ -384,7 +386,7 @@ describe("the host's whole job", () => {
     // The config declared `global`; the host passed no flag and still gets it,
     // and the owning project rides on the Worker.
     expect(written[0]).toContain("host 1w/1p");
-    expect(written[0]).toContain("acme/widgets:w-1 512M/1G");
+    expect(stripAnsi(written[0])).toContain("acme/widgets:w-1");
     expect(written[0].endsWith("\n")).toBe(true);
   });
 

--- a/apps/redskilled/tests/statusline-verbose.test.ts
+++ b/apps/redskilled/tests/statusline-verbose.test.ts
@@ -29,6 +29,7 @@ import {
   REDSKILLED_STATUSLINE_DEFAULTS,
   renderRedskilledStatusline,
   type RedskilledStatuslineOptions,
+  width,
 } from "@reddb-io/redskilled-render";
 import { buildStatuslinePayload, type RedskilledStatuslinePayload } from "../src/statusline-payload.js";
 import type { RedskilledWorkerLogLine } from "../src/worker-log.js";
@@ -133,11 +134,11 @@ describe("the verbose statusline", () => {
     const render = renderRedskilledStatusline(payload, options({ project: "acme/widgets", verbose: true }));
 
     expect(render.verbose).toBe(true);
-    expect(render.lines).toHaveLength(3);
+    expect(render.lines).toHaveLength(5);
     expect(render.lines[0]).toBe(render.line);
     expect(render.lines[1]).toContain("w-1");
-    expect(render.lines[1]).toContain("running the gate: 41 files");
-    expect(render.lines[2]).toContain("waiting on PR checks");
+    expect(render.lines[2]).toContain("running the gate: 41 files");
+    expect(render.lines[4]).toContain("waiting on PR checks");
   });
 
   it("gives each Worker a second line in the global mode, still naming its owner", () => {
@@ -153,11 +154,11 @@ describe("the verbose statusline", () => {
     );
 
     expect(render.detail).toBe("workers");
-    expect(render.lines).toHaveLength(3);
+    expect(render.lines).toHaveLength(5);
     expect(render.lines[1]).toContain("acme/widgets:w-1");
-    expect(render.lines[1]).toContain("gate green");
-    expect(render.lines[2]).toContain("acme/gadgets:w-2");
-    expect(render.lines[2]).toContain("rebasing onto main");
+    expect(render.lines[2]).toContain("gate green");
+    expect(render.lines[3]).toContain("acme/gadgets:w-2");
+    expect(render.lines[4]).toContain("rebasing onto main");
   });
 
   it("renders no empty or broken second line for a Worker that has logged nothing", () => {
@@ -171,7 +172,7 @@ describe("the verbose statusline", () => {
 
     const render = renderRedskilledStatusline(payload, options({ project: "acme/widgets", verbose: true }));
 
-    expect(render.lines).toHaveLength(1);
+    expect(render.lines).toHaveLength(3);
     expect(render.lines[0]).toBe(render.line);
     for (const line of render.lines) expect(line.trim()).not.toBe("");
   });
@@ -191,14 +192,14 @@ describe("the verbose statusline", () => {
       options({ project: "acme/widgets", verbose: true, maxWidth: 41 }),
     );
 
-    expect(render.lines).toHaveLength(2);
+    expect(render.lines).toHaveLength(3);
     for (const line of render.lines) {
       expect(line).not.toContain("\n");
-      expect([...line].length).toBeLessThanOrEqual(41);
+      expect(width(line)).toBeLessThanOrEqual(41);
     }
     // Collapsed, not re-interpreted: the words survive in the order published.
-    expect(render.lines[1]).toContain("first second");
-    expect(render.lines[1].endsWith("…")).toBe(true);
+    expect(render.lines[2]).toContain("first second");
+    expect(render.lines[2].endsWith("…")).toBe(true);
   });
 
   it("annotates nothing once the line has degraded past the Workers", () => {
@@ -255,7 +256,7 @@ describe("the line the Worker publishes", () => {
     const render = await readRedskilledStatuslineString(paths, asked, { sessionProject: "acme/widgets" });
     expect(isRedskilledStatuslineRender(render)).toBe(true);
     expect(render.lines).toEqual(renderRedskilledStatusline(payload, asked).lines);
-    expect(render.lines[1]).toContain(opaque);
+    expect(render.lines[2]).toContain(opaque);
   });
 
   it("is refused from a session in another project, and never stored", async () => {
@@ -323,9 +324,9 @@ describe("the line the Worker publishes", () => {
     expect(code).toBe(0);
     expect(written).toHaveLength(1);
     const lines = written[0].trimEnd().split("\n");
-    expect(lines).toHaveLength(3);
-    expect(lines[1]).toContain("busy in acme/widgets");
-    expect(lines[2]).toContain("busy in acme/gadgets");
+    expect(lines).toHaveLength(5);
+    expect(lines[2]).toContain("busy in acme/widgets");
+    expect(lines[4]).toContain("busy in acme/gadgets");
 
     // The renderer could not open a foreign project's log even if it wanted to:
     // it is a pure function of the payload and reaches no filesystem at all.

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -24,7 +24,7 @@
  * own — the memory ceiling and the Worker slots — and says nothing about the ones
  * it does not, because a plausible zero is worse than a missing column.
  */
-import { clamp, formatBytes, formatCount, formatDuration, formatRate, pad, width } from "./format.js";
+import { clamp, formatBytes, formatCount, formatDuration, formatRate, pad, shortModel, width } from "./format.js";
 import {
   BUDGET_BAND_MARK,
   BUDGET_SPENT_MARK,
@@ -190,6 +190,8 @@ const BAR_DONE = "█";
 const BAR_CURSOR = "▶";
 const BAR_FAILED = "✗";
 const BAR_AHEAD = "░";
+const LANDING_PHASES = new Set(["gate", "push-pr", "merge", "cascade"]);
+const NO_AGENT_ORIGINS = new Set(["requeue"]);
 
 /**
  * The finished dashboard. PURE — payload and options in, header and rows out.
@@ -255,17 +257,21 @@ export function renderRedskilledDashboard(
  * zero: `tks=0` is a Worker that has spent nothing, and a Worker whose bundle
  * publishes no display record has spent an unknown amount.
  */
-function workerCells(
+export function workerCells(
   worker: RedskilledRenderWorker,
-  options: RedskilledDashboardOptions,
+  options: Pick<RedskilledDashboardOptions, "mode">,
   generatedAt: string,
 ): RedskilledDashboardCells {
   const display = worker.display ?? REDSKILLED_RENDER_DISPLAY_ABSENT;
-  const run = [display.runner, display.model, display.effort].filter((part): part is string => Boolean(part)).join(" ");
+  const run = [display.runner, display.model == null ? null : shortModel(display.model), display.effort]
+    .filter((part): part is string => Boolean(part))
+    .join(" ");
+  const landing = display.phase != null && LANDING_PHASES.has(display.phase);
+  const noAgent = landing || (display.origin != null && NO_AGENT_ORIGINS.has(display.origin));
   return {
     wid: options.mode === "global" ? `${worker.project_label}:${worker.worker_id}` : worker.worker_id,
     run: run === "" ? "" : `run=${run}`,
-    org: display.origin == null ? "" : `org=${display.origin}`,
+    org: landing ? "org=landing" : display.origin == null ? "" : `org=${display.origin}`,
     iss: display.issue == null ? "" : `iss=${display.issue}`,
     bar: progressBar(display),
     phase: [display.phase, display.step].filter((part): part is string => Boolean(part)).join("·"),
@@ -275,12 +281,12 @@ function workerCells(
     // beside it. The absence is the honest answer and it is legible as one.
     eta: display.eta == null ? "" : `eta=${formatDuration(display.eta * 1000)}`,
     hb: `hb=${display.heartbeat ?? "?"}`,
-    loc: formatSignedPair(display.added, display.removed),
-    tks: display.tokens == null ? "" : `tks=${formatCount(display.tokens)}`,
+    loc: noAgent ? "" : formatSignedPair(display.added, display.removed),
+    tks: noAgent || display.tokens == null ? "" : `tks=${formatCount(display.tokens)}`,
     ctx: display.context == null ? "" : `ctx=${formatCount(display.context)}`,
-    tls: display.tools == null ? "" : `tls=${display.tools}`,
-    rsn: display.reasoning == null ? "" : `rsn=${display.reasoning}`,
-    txt: display.text == null ? "" : `txt=${display.text}`,
+    tls: noAgent || display.tools == null ? "" : `tls=${display.tools}`,
+    rsn: noAgent || display.reasoning == null ? "" : `rsn=${display.reasoning}`,
+    txt: noAgent || display.text == null ? "" : `txt=${display.text}`,
   };
 }
 

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -1,5 +1,5 @@
 /**
- * line — the statusline density: one row, and nothing behind it.
+ * line — the statusline density: one head, then one row per Worker.
  *
  * **The string is a pure function of the payload.** That purity is the whole
  * mitigation for having four surfaces at all (ADR 0132 decision 1): a renderer
@@ -24,13 +24,18 @@
  * logged nothing gets no second line at all — a blank one would be a render
  * defect wearing the shape of information.
  *
- * **A crowded machine degrades to an aggregate rather than overflowing.** The
- * statusline answers "who is using this machine and how much"; it is not the
- * dashboard. When the Workers do not fit, the line drops to one entry per
- * project, and when the projects do not fit it drops to the host total — losing
- * detail on purpose, never losing the line.
+ * **Width degrades cells, never Workers.** A selected Worker keeps its row at
+ * every terminal width; cells leave from the right until the row fits. Count
+ * budgets may still choose a project or host aggregate, but width alone never
+ * erases the identities the operator came here to see.
  */
-import { clamp, flattenPublishedLine, formatBytes, width } from "./format.js";
+import {
+  REDSKILLED_DASHBOARD_COLUMNS,
+  workerCells,
+  type RedskilledDashboardCells,
+  type RedskilledDashboardColumn,
+} from "./dashboard.js";
+import { clamp, flattenPublishedLine, formatBytes, pad, width } from "./format.js";
 import {
   BUDGET_BAND_MARK,
   BUDGET_SPENT_MARK,
@@ -41,6 +46,7 @@ import {
   REDSKILLED_RENDER_ABSENCE,
   UNREGISTERED_MARK,
 } from "./marks.js";
+import { BAR_AHEAD, BAR_CURRENT, BAR_DONE, BOLD, KEY, NOBG, NOBOLD, RED, RESET, SOFT, VAL } from "./palette.js";
 import type {
   RedskilledRenderPayload,
   RedskilledRenderProject,
@@ -119,12 +125,11 @@ export const REDSKILLED_STATUSLINE_DEFAULTS: RedskilledStatuslineOptions = {
 };
 
 /**
- * The finished statusline. PURE — payload and options in, one line out.
+ * The finished statusline. PURE — payload and options in, printable rows out.
  *
- * The line is built at the richest detail the budgets allow and then re-built
- * one step poorer for as long as it does not fit. Rebuilding rather than
- * trimming is deliberate: a trimmed line ends mid-fact, and a half-printed
- * memory figure is worse than an honest aggregate.
+ * Count budgets choose the detail. At Worker detail the head and every Worker
+ * get their own row; a narrow width removes whole cells from the right instead
+ * of replacing all Workers with an aggregate.
  */
 export function renderRedskilledStatusline(
   payload: RedskilledRenderPayload,
@@ -147,18 +152,27 @@ export function renderRedskilledStatusline(
     line: head,
   };
   for (const detail of ladder) {
-    const line = compose(head, body(detail, options, workers, projects), options.separator);
+    const line = detail === "workers"
+      ? head
+      : compose(head, projectBody(detail, projects), options.separator);
     chosen = { detail, line };
-    if (width(line) <= options.maxWidth) break;
+    // Worker rows have their own width ladder below. Aggregate detail retains
+    // the old all-or-nothing rule so a project figure is never cut in half.
+    if (detail === "workers" || width(line) <= options.maxWidth) break;
   }
   // Even the host aggregate can outgrow a very narrow line; a clamp is the last
   // resort and never the normal path, so it keeps the ellipsis visible.
   const line = clamp(chosen.line, options.maxWidth);
-  // Second lines belong to Worker entries, so they exist only while the line is
-  // still listing Workers: annotating an aggregate would attach a Worker's log to
-  // a row that names a project.
-  const extra = options.verbose && chosen.detail === "workers"
-    ? workerLogLines(workers, options)
+  const table = chosen.detail === "workers"
+    ? renderWorkerRows(workers, options, payload.generated_at)
+    : { lines: [] as readonly string[], degraded: false };
+  // A verbose line follows the Worker row it annotates. An aggregate gets no
+  // Worker log because there is no attributable row for that log to belong to.
+  const workerLines = chosen.detail === "workers"
+    ? workers.flatMap((worker, index) => {
+        const logged = options.verbose ? workerLogLine(worker, options) : null;
+        return logged == null ? [table.lines[index]!] : [table.lines[index]!, logged];
+      })
     : [];
   // Degradation is measured against the richest detail this payload COULD have
   // shown, not against the richest one the budgets allowed: a line that dropped
@@ -169,13 +183,13 @@ export function renderRedskilledStatusline(
   return {
     version: 1,
     line,
-    lines: [line, ...extra],
+    lines: [line, ...workerLines],
     verbose: options.verbose,
     mode: options.mode,
     project: options.project,
     project_match: match,
     detail: chosen.detail,
-    degraded: chosen.detail !== richest || line !== chosen.line,
+    degraded: chosen.detail !== richest || line !== chosen.line || table.degraded,
     stale: payload.staleness.stale,
     generated_at: payload.generated_at,
   };
@@ -191,7 +205,7 @@ export function renderRedskilledStatusline(
  * #2928 found in that path was sized by the host instead.
  */
 export interface RedskilledStatuslineBound {
-  /** The head, plus at most one second line per listed Worker. */
+  /** The head, one row per listed Worker, plus optional log rows. */
   readonly max_lines: number;
   readonly max_line_width: number;
   /** Every rendered line together, separators included. */
@@ -202,10 +216,10 @@ export interface RedskilledStatuslineBound {
 export function redskilledStatuslineBound(
   options: RedskilledStatuslineOptions = REDSKILLED_STATUSLINE_DEFAULTS,
 ): RedskilledStatuslineBound {
-  // A second line exists only while the line still lists Workers, and the line
-  // lists Workers only while there are no more of them than the budget allows —
-  // so the Worker budget bounds the row count, whatever the host holds.
-  const maxLines = options.verbose ? 1 + Math.max(0, options.maxWorkers) : 1;
+  // Worker detail exists only while there are no more Workers than the count
+  // budget, so that budget bounds both table rows and optional log rows.
+  const workerLines = Math.max(0, options.maxWorkers) * (options.verbose ? 2 : 1);
+  const maxLines = 1 + workerLines;
   const maxWidth = Math.max(0, options.maxWidth);
   return {
     max_lines: maxLines,
@@ -253,13 +267,10 @@ export function renderRedskilledStatuslineAbsence(input: {
   };
 }
 
-function body(
+function projectBody(
   detail: RedskilledStatuslineDetail,
-  options: RedskilledStatuslineOptions,
-  workers: readonly RedskilledRenderWorker[],
   projects: readonly RedskilledRenderProject[],
 ): readonly string[] {
-  if (detail === "workers") return workers.map((worker) => renderWorker(worker, options));
   if (detail === "projects") return projects.map(renderProject);
   return [];
 }
@@ -404,23 +415,71 @@ function stalenessMark(payload: RedskilledRenderPayload): string {
 }
 
 /**
- * One Worker. In `global`, the owning project rides on the entry itself.
- *
- * A separate "these belong to acme/widgets" grouping was rejected: the line has
- * no vertical dimension to group in, so the owner has to travel with the Worker
- * or it is not shown at all.
+ * One coloured, aligned Worker row. The values come from the dashboard's cell
+ * composer; this density owns only colour and width.
  */
-function renderWorker(worker: RedskilledRenderWorker, options: RedskilledStatuslineOptions): string {
-  const name = workerName(worker, options.mode);
-  const used = worker.vitals.rss_bytes;
-  // An unmeasured Worker says so. A zero here would read as an idle Worker, and
-  // "nothing measured it" and "it is using nothing" are opposite facts.
-  const usage = used == null
-    ? "?"
-    : worker.budget.bytes == null
-      ? formatBytes(used)
-      : `${formatBytes(used)}/${formatBytes(worker.budget.bytes)}`;
-  return `${name} ${usage}`;
+function renderWorker(
+  cells: RedskilledDashboardCells,
+  widths: Record<RedskilledDashboardColumn, number>,
+  columns: readonly RedskilledDashboardColumn[],
+  maxWidth: number,
+): string {
+  const parts = columns.map((column) => colourWorkerCell(column, pad(cells[column], widths[column])));
+  return clamp(`${NOBG}${SOFT}${parts.join("  ")}${RESET}`, maxWidth);
+}
+
+function renderWorkerRows(
+  workers: readonly RedskilledRenderWorker[],
+  options: RedskilledStatuslineOptions,
+  generatedAt: string,
+): { readonly lines: readonly string[]; readonly degraded: boolean } {
+  const rows = workers.map((worker) => workerCells(worker, options, generatedAt));
+  const populated = REDSKILLED_DASHBOARD_COLUMNS.filter((column) =>
+    rows.some((row) => width(row[column]) > 0));
+  const columns = [...populated];
+  let widths = workerWidths(rows, columns);
+  while (columns.length > 1 && workerRowWidth(widths, columns) > options.maxWidth) {
+    columns.pop();
+    widths = workerWidths(rows, columns);
+  }
+  return {
+    lines: rows.map((row) => renderWorker(row, widths, columns, options.maxWidth)),
+    degraded: columns.length < populated.length || workerRowWidth(widths, columns) > options.maxWidth,
+  };
+}
+
+function workerWidths(
+  rows: readonly RedskilledDashboardCells[],
+  columns: readonly RedskilledDashboardColumn[],
+): Record<RedskilledDashboardColumn, number> {
+  const widths = Object.fromEntries(
+    REDSKILLED_DASHBOARD_COLUMNS.map((column) => [column, 0]),
+  ) as Record<RedskilledDashboardColumn, number>;
+  for (const row of rows) {
+    for (const column of columns) widths[column] = Math.max(widths[column], width(row[column]));
+  }
+  return widths;
+}
+
+function workerRowWidth(
+  widths: Record<RedskilledDashboardColumn, number>,
+  columns: readonly RedskilledDashboardColumn[],
+): number {
+  return columns.reduce((total, column) => total + widths[column], 0) + Math.max(0, columns.length - 1) * 2;
+}
+
+function colourWorkerCell(column: RedskilledDashboardColumn, raw: string): string {
+  if (column === "wid") return `${BOLD}${raw}${NOBOLD}`;
+  if (column === "bar") {
+    return raw
+      .replace(/█+/g, (done) => `${BAR_DONE}${done}`)
+      .replace("▶", `${BAR_CURRENT}▶`)
+      .replace("✗", `${RED}✗`)
+      .replace(/░+/g, (ahead) => `${BAR_AHEAD}${ahead}`) + SOFT;
+  }
+  const equals = raw.indexOf("=");
+  if (equals > 0) return `${KEY}${raw.slice(0, equals + 1)}${VAL}${raw.slice(equals + 1)}${SOFT}`;
+  return raw;
 }
 
 /**
@@ -430,17 +489,13 @@ function renderWorker(worker: RedskilledRenderWorker, options: RedskilledStatusl
  * under a first line whose entries may have been reordered or clamped away, and
  * an unlabelled log line would belong to whichever Worker the reader guessed.
  */
-function workerLogLines(
-  workers: readonly RedskilledRenderWorker[],
+function workerLogLine(
+  worker: RedskilledRenderWorker,
   options: RedskilledStatuslineOptions,
-): readonly string[] {
-  const lines: string[] = [];
-  for (const worker of workers) {
-    const logged = flattenPublishedLine(worker.log.last_line);
-    if (logged == null) continue;
-    lines.push(clamp(`  ${LOG_LINE_MARK} ${workerName(worker, options.mode)}: ${logged}`, options.maxWidth));
-  }
-  return lines;
+): string | null {
+  const logged = flattenPublishedLine(worker.log.last_line);
+  if (logged == null) return null;
+  return clamp(`  ${LOG_LINE_MARK} ${workerName(worker, options.mode)}: ${logged}`, options.maxWidth);
 }
 
 /** How one Worker is named at any density: owner-qualified in `global`. PURE. */

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -11,6 +11,12 @@ import { encode as encodeToon } from "@reddb-io/toon";
 import {
   decodeRedskilledPayload,
   detailLadder,
+  BAR_AHEAD,
+  BAR_CURRENT,
+  BAR_DONE,
+  BOLD,
+  KEY,
+  RED,
   RedskilledRenderDecodeError,
   renderRedskilled,
   renderRedskilledDashboard,
@@ -21,6 +27,9 @@ import {
   REDSKILLED_PANEL_DEFAULTS,
   REDSKILLED_RENDER_ABSENCE,
   REDSKILLED_STATUSLINE_DEFAULTS,
+  stripAnsi,
+  VAL,
+  width,
 } from "../index.js";
 import { display, payload, worker } from "./fixture.js";
 
@@ -34,12 +43,13 @@ describe("one module, three densities", () => {
     const panel = renderRedskilledPanel(doc, { ...REDSKILLED_PANEL_DEFAULTS, project: "acme/widgets" });
     const table = renderRedskilledDashboard(doc, { ...REDSKILLED_DASHBOARD_DEFAULTS, project: "acme/widgets" });
 
-    expect(line.lines).toHaveLength(1);
+    expect(line.lines).toHaveLength(2);
     expect(line.line).toContain("acme/widgets 1w");
+    expect(stripAnsi(line.lines[1]!)).toContain("w-1");
     // The panel's FIRST row is the line density's own output, not a second
     // spelling of it — the composition is the no-drift guarantee.
     expect(panel.head.line).toBe(panel.lines[0]);
-    expect(panel.lines.length).toBeGreaterThan(line.lines.length);
+    expect(panel.lines.length).toBeGreaterThan(1);
     expect(panel.worker_rows[0]).toContain("w-1");
     expect(table.rows).toHaveLength(1);
     expect(table.header.line).toContain("wrk=1/1");
@@ -54,18 +64,82 @@ describe("one module, three densities", () => {
       .toEqual(renderRedskilledStatusline(doc, LOCAL).lines);
   });
 
-  it("degrades a crowded line down the shared ladder rather than overflowing", () => {
-    const workers = Array.from({ length: 3 }, (_, index) => worker({ worker_id: `w-${index}` }));
+  it("degrades cells from the right without dropping selected Workers", () => {
+    const workers = Array.from({ length: 3 }, (_, index) =>
+      worker({ worker_id: `w-${index}`, display: display({ issue: String(3100 + index) }) }));
     const doc = payload({ workers, host: { ...payload().host, worker_count: 3 } });
     const narrow = renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 40 });
-    expect(narrow.detail).toBe("host");
+    expect(narrow.detail).toBe("workers");
     expect(narrow.degraded).toBe(true);
-    expect([...narrow.line].length).toBeLessThanOrEqual(40);
+    expect(narrow.lines).toHaveLength(4);
+    for (const [index, line] of narrow.lines.entries()) {
+      expect(width(line)).toBeLessThanOrEqual(40);
+      if (index > 0) expect(stripAnsi(line)).toContain(`w-${index - 1}`);
+    }
+    expect(stripAnsi(narrow.lines[1]!)).not.toContain("txt=");
 
     // The ladder is layout, and it now lives beside every density rather than
     // inside one of them.
     expect(detailLadder({ mode: "global", maxWorkers: 2, maxProjects: 4, workers, projects: doc.projects }))
       .toEqual(["projects", "host"]);
+  });
+});
+
+describe("the statusline Worker table (#3151)", () => {
+  it("draws every dashboard cell in colour on a row beneath the head", () => {
+    const doc = payload({ workers: [worker({ display: display({ model: "claude-opus-5" }) })] });
+    const rendered = renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 240 });
+
+    expect(rendered.lines).toHaveLength(2);
+    expect(rendered.line).toBe(rendered.lines[0]);
+    const raw = rendered.lines[1]!;
+    expect(stripAnsi(raw)).toBe(
+      "w-1  run=claude opus high  org=afk  iss=3096  ██▶░░  coding·edit  2m5s  eta=10m40s  hb=3s  loc=+120 -8  tks=42k  ctx=108k  tls=31  rsn=9  txt=4",
+    );
+    expect(raw).toContain(`${BOLD}w-1`);
+    expect(raw).toContain(`${KEY}run=${VAL}claude opus high`);
+    expect(raw).toContain(`${BAR_DONE}██${BAR_CURRENT}▶${BAR_AHEAD}░░`);
+    for (const key of ["run", "org", "iss", "eta", "hb", "loc", "tks", "ctx", "tls", "rsn", "txt"]) {
+      expect(raw).toContain(`${KEY}${key}=${VAL}`);
+    }
+  });
+
+  it("aligns every populated column across Workers", () => {
+    const doc = payload({
+      workers: [
+        worker({ worker_id: "w-1", display: display() }),
+        worker({
+          worker_id: "worker-long",
+          display: display({ runner: "opencode", model: "gpt-5.4", effort: "xhigh", issue: "42", phase: "validating" }),
+        }),
+      ],
+      host: { ...payload().host, worker_count: 2 },
+    });
+    const rendered = renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 260 });
+    const rows = rendered.lines.slice(1).map(stripAnsi);
+
+    expect(rows).toHaveLength(2);
+    for (const token of ["run=", "org=", "iss=", "coding", "2m5s", "hb=", "loc=", "tks=", "ctx=", "tls=", "rsn=", "txt="]) {
+      const starts = rows.map((row) => row.indexOf(token === "coding" ? (row.includes("coding") ? "coding" : "validating") : token));
+      expect(starts[0], token).toBeGreaterThanOrEqual(0);
+      expect(starts[1], token).toBe(starts[0]);
+    }
+  });
+
+  it("uses the failure colour for a failed lifecycle cursor", () => {
+    const doc = payload({ workers: [worker({ display: display({ failed: true }) })] });
+    expect(renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 240 }).lines[1]).toContain(`${RED}✗`);
+  });
+
+  it.each([
+    ["landing", display({ phase: "merge", origin: "afk" })],
+    ["requeue", display({ phase: "validating", origin: "requeue" })],
+  ])("omits agent activity cells from a %s row", (_kind, workerDisplay) => {
+    const doc = payload({ workers: [worker({ display: workerDisplay })] });
+    const row = stripAnsi(renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 240 }).lines[1]!);
+    for (const key of ["loc=", "tks=", "tls=", "rsn=", "txt="]) expect(row).not.toContain(key);
+    expect(row).toContain("ctx=108k");
+    expect(row).toContain("hb=3s");
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #3151. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3151

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788375711&installation_model_id=20659&pr_number=3196&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3196&signature=b72cdbcbf4c644b80e1499fc38661c3559f6a1e06051639d2606c8089074db85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->