### PR TITLE
fix: the push identity is not the API identity, and only the push is watched

### DIFF
--- a/.changeset/the-push-identity-is-not-the-api-identity.md
+++ b/.changeset/the-push-identity-is-not-the-api-identity.md
@@ -1,0 +1,23 @@
+---
+"@reddb-io/dev": patch
+---
+
+Give every pushing workflow a push identity that is not the bot
+
+A workflow's PUSH identity is not its API identity, and only the push is what
+GitHub's anti-recursion guard watches. `actions/checkout` persists whatever token
+it is given as the git credential and defaults to `GITHUB_TOKEN` — so a workflow
+can hold a PAT, spend it on every API call, open its PR as the PAT identity, and
+still push as `github-actions[bot]`, leaving every `pull_request` run on that
+branch parked in `action_required` with every check green.
+
+The earlier repair moved the PAT to the changesets action's `github-token` input.
+The PR author changed to the PAT identity, so the fix looked complete, while the
+commit stayed bot-authored and the release train kept stopping — once per merge
+to main, which on a busy day is one manual approval per merge.
+
+`red-release.yml`, `red-toon-watch.yml` and `red-publish.yml` now check out with
+`secrets.RELEASE_PAT`. A guard (`apps/dev/tests/push-identity-guard.test.ts`)
+fails any workflow that pushes while checking out as the bot — an ABSENT `token:`
+fails the same way an explicit one does, because the default is the bot and that
+silence is how this shipped twice.

--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          # This job force-pushes the moving `vX` major ref, so it needs a push
+          # identity like any other pushing workflow. A bot-authored tag push also
+          # starts no workflow — the anti-recursion guard this repo already works
+          # around with an explicit `gh workflow run` dispatch — so a consumer that
+          # ever keys off `vX` would silently never fire.
+          token: ${{ secrets.RELEASE_PAT }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -45,6 +45,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          # THE PUSH IDENTITY, and it is not the same thing as the API identity.
+          # `actions/checkout` persists whatever token it is given as the git
+          # credential, defaulting to GITHUB_TOKEN — so a workflow can hold a PAT,
+          # spend it on every API call, open the PR as the PAT identity, and still
+          # PUSH as `github-actions[bot]`. GitHub's anti-recursion guard watches
+          # the push, not the API call, which parks every `pull_request` run in
+          # `action_required`.
+          #
+          # #3168 moved the PAT to the action's `github-token` input and the PR
+          # author changed to the PAT identity — so the repair looked complete
+          # while the commit stayed bot-authored and the runs kept parking. Both
+          # halves are needed: this line owns the push, `github-token` owns the API.
+          token: ${{ secrets.RELEASE_PAT }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/red-toon-watch.yml
+++ b/.github/workflows/red-toon-watch.yml
@@ -28,7 +28,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # This job pushes a bump branch, and a GITHUB_TOKEN-authored push leaves
+          # the resulting PR's checks parked in `action_required` — the same guard
+          # that stopped the release train (#3168, and its other half). A workflow
+          # that pushes needs a push identity that is not the bot.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
 

--- a/apps/dev/tests/push-identity-guard.test.ts
+++ b/apps/dev/tests/push-identity-guard.test.ts
@@ -1,0 +1,74 @@
+// A workflow's PUSH identity is not its API identity, and only the push is what
+// GitHub's anti-recursion guard watches. A workflow can hold a PAT, spend it on
+// every API call, open its PR as the PAT identity, and still push as
+// `github-actions[bot]` — leaving every `pull_request` run on that branch parked
+// in `action_required`, waiting on a human, with every check green.
+//
+// This bit twice in one day. #3168 moved the PAT to the changesets action's
+// `github-token` input; the PR author changed, the repair looked complete, and
+// the commit stayed bot-authored, so the release train kept stopping. The second
+// half is `actions/checkout`'s `token:`, which is what git actually pushes with.
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+const WORKFLOW_DIR = join(ROOT, ".github/workflows");
+
+/**
+ * How a workflow can end up pushing a ref. `changesets/action` is here because it
+ * pushes its release branch internally — a workflow that names it never spells
+ * `git push` and pushes on every run regardless.
+ */
+const PUSH_MECHANISMS = [/^\s*[^#]*git push/m, /uses:\s*changesets\/action/];
+
+/** A checkout `token:` that is the bot — the exact credential that parks runs. */
+const BOT_TOKEN = /token:\s*\$\{\{\s*(secrets\.GITHUB_TOKEN|github\.token)\s*\}\}/;
+
+/** A checkout step's `with:` block, or null when the step declares none. */
+function checkoutBlocks(workflow: string): string[] {
+  const blocks: string[] = [];
+  const marker = /uses:\s*actions\/checkout@/g;
+  let match: RegExpExecArray | null;
+  while ((match = marker.exec(workflow)) !== null) {
+    // The step runs until the next list item at any indentation — enough to hold
+    // its own `with:` block and nothing of its neighbour's.
+    const rest = workflow.slice(match.index);
+    const next = rest.search(/\n\s*- (name|uses):/);
+    blocks.push(next === -1 ? rest : rest.slice(0, next));
+  }
+  return blocks;
+}
+
+describe("a workflow that pushes does not push as the bot (#3168)", () => {
+  it("gives every pushing workflow a checkout credential that is not GITHUB_TOKEN", async () => {
+    const files = (await readdir(WORKFLOW_DIR)).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+    expect(files.length, "found no workflows — a walker that reaches nothing is green by accident")
+      .toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const workflow = await readFile(join(WORKFLOW_DIR, file), "utf8");
+      if (!PUSH_MECHANISMS.some((pattern) => pattern.test(workflow))) continue;
+
+      const blocks = checkoutBlocks(workflow);
+      if (blocks.length === 0) continue; // pushes without checking out: not this guard's case
+
+      // Every checkout in a pushing workflow must state a non-bot credential.
+      // An ABSENT `token:` fails the same way an explicit GITHUB_TOKEN does —
+      // the default IS GITHUB_TOKEN, and silence is how this shipped twice.
+      for (const block of blocks) {
+        const hasToken = /token:\s*\$\{\{/.test(block);
+        if (!hasToken) offenders.push(`${file}: checkout declares no token: (defaults to GITHUB_TOKEN)`);
+        else if (BOT_TOKEN.test(block)) offenders.push(`${file}: checkout pushes as github-actions[bot]`);
+      }
+    }
+
+    expect(
+      offenders,
+      `these workflows push, so their pushes land in \`action_required\` and wait on a human:\n` +
+        `${offenders.join("\n")}\n\n` +
+        `Give the checkout step \`token: \${{ secrets.RELEASE_PAT }}\` — the credential git pushes with.`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Every release today needed a human to press approve.** Not once — once per merge to `main`, because each merge rewrites the Version Packages PR with a fresh bot-authored commit whose checks park all over again. On a 30-merge day that is 30 approvals standing between a merged fix and a published one.

## The half that was missing

`actions/checkout` persists whatever token it is given as the **git credential**, defaulting to `GITHUB_TOKEN`. So a workflow can hold a PAT, spend it on every API call, open its PR as the PAT identity — and still **push** as `github-actions[bot]`.

GitHub's anti-recursion guard watches the push, not the API call.

#3168 moved the PAT to the changesets action's `github-token` input. The PR author changed to the PAT identity, so the repair read as complete:

```json
{"author": "filipeforattini"}      // the PR — opened via API, with the PAT
{"author": "github-actions[bot]",  // the commit — pushed by git, with the bot
 "committer": "github-actions[bot]"}
```

Two operations, two credentials. Only one was fixed.

## The change

`red-release.yml`, `red-toon-watch.yml` and `red-publish.yml` check out with `secrets.RELEASE_PAT` — the credential git actually pushes with.

**`red-publish.yml` was found by the guard, not by hand.** A manual grep for `git push` over that file came back empty because the output was truncated; the file force-pushes the moving `vX` major ref at line 926. That is the whole argument for the guard existing.

## The guard

`apps/dev/tests/push-identity-guard.test.ts` fails any workflow that pushes — `git push`, or `uses: changesets/action`, which pushes its release branch internally without ever spelling it — while checking out as the bot.

**An absent `token:` fails the same way an explicit `GITHUB_TOKEN` does.** The default is the bot, and that silence is how this shipped twice. The failure message names the file and the line to add.

## Verification

- `push-identity-guard`: fails on this branch's parent (names `red-publish.yml`), passes with the fix
- `red-toon-watch-workflow`: 5 tests, unchanged and green
- `pnpm -C apps/dev test:invariants`: 141 tests, all pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788375977&installation_model_id=20659&pr_number=3197&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3197&signature=7350c742fb1b59371bec2b685a0071599b5791d1b7018532396371b13a79aa7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->