### PR TITLE
fix: give the castle and rsp MCP launchers a candidate that resolves outside this repo

### DIFF
--- a/.changeset/mcp-launchers-resolve-outside-this-repo.md
+++ b/.changeset/mcp-launchers-resolve-outside-this-repo.md
@@ -1,0 +1,27 @@
+---
+"@reddb-io/dev": patch
+---
+
+Give the castle and rsp MCP launchers a candidate that resolves outside this repo
+
+An MCP server is declared once and started from EVERY directory the operator
+works in — which is almost never this repo. `plugins/dev/.mcp.json` shipped three
+servers with three different resolution strategies: `navigator` carried the
+installed-marketplace fallback and worked, while `castle` and `rsp`, declared
+three lines away, resolved only through `$CODEX_PLUGIN_ROOT` and `$PWD`.
+
+Outside the repo both are wrong — the env var is unset and `$PWD` is the
+operator's own project — so the launcher was never found and the host reported a
+transport failure rather than a missing file:
+
+```
+MCP client for `castle` failed to start: Broken pipe (os error 32),
+when send initialize request
+MCP client for `rsp` failed to start: connection closed: initialize response
+```
+
+Both now carry the same `$HOME`-anchored candidate `navigator` already had. A
+guard (`apps/dev/tests/mcp-launcher-reachability.test.ts`) fails any file-resolving
+launcher without one, and separately pins the dev plugin's three servers to the
+same contract — siblings in one file with nothing comparing them is how this
+shipped.

--- a/apps/dev/tests/mcp-launcher-reachability.test.ts
+++ b/apps/dev/tests/mcp-launcher-reachability.test.ts
@@ -1,0 +1,89 @@
+// An MCP server is declared once and started from EVERY directory the operator
+// works in — which is almost never this repo. A launcher chain that can only
+// resolve through `$CODEX_PLUGIN_ROOT` or `$PWD` therefore works where it was
+// developed and nowhere else, and the host reports the miss as a transport
+// failure ("Broken pipe when send initialize request"), not as a missing file.
+//
+// This shipped in `plugins/dev/.mcp.json` with THREE servers and three different
+// resolution strategies: `navigator` carried the installed-marketplace fallback
+// and worked; `castle` and `rsp`, declared three lines away, did not and failed
+// in every repo but this one. The difference was invisible because each server's
+// chain reads plausibly on its own.
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+/** A command that resolves its own program needs no path — npm/npx fetch it. */
+const SELF_RESOLVING = ["npx", "npm", "pnpm", "bunx"];
+
+/**
+ * A candidate that survives a foreign cwd with no plugin-root env var.
+ *
+ * `$HOME`-anchored is the whole test: `$root` is unset outside a plugin host and
+ * `$PWD` is the operator's repo, so a chain built only from those two resolves
+ * nothing. An absolute path under the user's home is the one candidate that is
+ * true wherever the agent was started.
+ */
+const HOME_ANCHORED = /"\$HOME\//;
+
+interface Declaration {
+  readonly file: string;
+  readonly server: string;
+  readonly command: string;
+  readonly script: string;
+}
+
+async function declarations(): Promise<Declaration[]> {
+  const found: Declaration[] = [];
+  for (const plugin of await readdir(join(ROOT, "plugins"))) {
+    const path = join(ROOT, "plugins", plugin, ".mcp.json");
+    let raw: string;
+    try {
+      raw = await readFile(path, "utf8");
+    } catch {
+      continue; // a plugin may ship no MCP servers at all
+    }
+    const parsed = JSON.parse(raw) as { mcpServers?: Record<string, { command?: string; args?: string[] }> };
+    for (const [server, config] of Object.entries(parsed.mcpServers ?? {})) {
+      found.push({
+        file: `plugins/${plugin}/.mcp.json`,
+        server,
+        command: config.command ?? "",
+        script: (config.args ?? []).join(" "),
+      });
+    }
+  }
+  return found;
+}
+
+describe("every MCP server resolves from a directory that is not this repo (#3186-adjacent)", () => {
+  it("gives each file-resolving launcher a $HOME-anchored candidate", async () => {
+    const all = await declarations();
+    expect(all.length, "found no MCP declarations — a walker that reaches nothing is green by accident")
+      .toBeGreaterThan(0);
+
+    const unreachable = all
+      .filter((d) => !SELF_RESOLVING.includes(d.command))
+      .filter((d) => !HOME_ANCHORED.test(d.script))
+      .map((d) => `${d.file}: "${d.server}" resolves only through $CODEX_PLUGIN_ROOT/$PWD`);
+
+    expect(
+      unreachable,
+      `these servers start only from this repo, and the host reports the miss as a broken transport:\n` +
+        `${unreachable.join("\n")}\n\n` +
+        `Add the installed-marketplace path to the candidate loop, the way \`navigator\` already does.`,
+    ).toEqual([]);
+  });
+
+  it("keeps the dev plugin's three servers on the SAME reachability contract", async () => {
+    // Stated separately because this is the shape that shipped: siblings in one
+    // file, one of them correct, and nothing comparing them.
+    const dev = (await declarations()).filter((d) => d.file === "plugins/dev/.mcp.json");
+    expect(dev.map((d) => d.server).sort()).toEqual(["castle", "navigator", "rsp"]);
+    for (const server of dev) {
+      expect(HOME_ANCHORED.test(server.script), `${server.server} lost its $HOME-anchored candidate`).toBe(true);
+    }
+  });
+});

--- a/plugins/dev/.mcp.json
+++ b/plugins/dev/.mcp.json
@@ -11,14 +11,14 @@
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; for launcher in \"$root/hooks/castle-mcp.sh\" \"$PWD/plugins/dev/hooks/castle-mcp.sh\"; do if [ -f \"$launcher\" ]; then exec bash \"$launcher\"; fi; done; printf 'castle: could not locate castle MCP launcher\\n' >&2; exit 1"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; for launcher in \"$root/hooks/castle-mcp.sh\" \"$PWD/plugins/dev/hooks/castle-mcp.sh\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/dev/hooks/castle-mcp.sh\"; do if [ -f \"$launcher\" ]; then exec bash \"$launcher\"; fi; done; printf 'castle: could not locate castle MCP launcher\\n' >&2; exit 1"
       ]
     },
     "rsp": {
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if command -v rsp >/dev/null 2>&1; then exec rsp mcp; fi; for bundle in \"$PWD/dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\"; do if [ -f \"$bundle\" ]; then exec node \"$bundle\" mcp; fi; done; printf 'rsp: could not locate rsp MCP launcher\\n' >&2; exit 1"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if command -v rsp >/dev/null 2>&1; then exec rsp mcp; fi; for bundle in \"$PWD/dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\" \"$HOME/.codex/.tmp/marketplaces/red-skills/packaging/npm/bin/rsp.mjs\"; do if [ -f \"$bundle\" ]; then exec node \"$bundle\" mcp; fi; done; printf 'rsp: could not locate rsp MCP launcher\\n' >&2; exit 1"
       ]
     }
   }


### PR DESCRIPTION
Reported from a fresh codex session in `~/workspace/brand`:

```
⚠ MCP client for `castle` failed to start: Broken pipe (os error 32),
  when send initialize request
⚠ MCP client for `rsp` failed to start: connection closed: initialize response
```

`navigator`, declared in the same file, started fine.

## The difference is three lines apart

`plugins/dev/.mcp.json` ships three servers with three different resolution strategies:

| server | candidates | resolves outside this repo |
| --- | --- | --- |
| `navigator` | `$root/...`, `$PWD/...`, **`$HOME/.codex/.tmp/marketplaces/...`** | yes |
| `castle` | `$root/...`, `$PWD/...` | **no** |
| `rsp` | `command -v rsp`, `$PWD/dist/...`, `$root/dist/...` | **no** |

**An MCP server is declared once and started from every directory the operator works in** — which is almost never this repo. Outside it, `$CODEX_PLUGIN_ROOT` is unset and `$PWD` is the operator's own project, so both candidates miss and the loop falls through to `exit 1`.

**The launcher was never broken.** Running `~/.codex/.tmp/marketplaces/red-skills/plugins/dev/hooks/castle-mcp.sh` by hand from `~/workspace/brand` starts cleanly and exits 0. It was only unreachable — and the host reports an unreachable launcher as a broken transport, which sends the reader looking at the socket, the daemon, and the handshake instead of at a `for` loop.

## The change

`castle` and `rsp` get the same `$HOME`-anchored candidate `navigator` already had. Nothing else moves.

## The guard

`apps/dev/tests/mcp-launcher-reachability.test.ts` sweeps every `plugins/*/.mcp.json` and fails any file-resolving launcher with no `$HOME`-anchored candidate. A command that resolves its own program (`npx`, `pnpm`, …) is exempt — it needs no path.

The second assertion pins the dev plugin's three servers to one contract by name. **Siblings in one file, one of them correct, and nothing comparing them** is precisely how this shipped: each chain reads plausibly on its own, and the working neighbour made the file look considered.

## What this does not fix

`brain` and `red-memory` also show `(none)` in `/mcp` from that repo, and that is **correct** — `brand`'s `.red/config.yaml` enables neither, so ADR 0067's strict opt-in keeps them inert. The same is true of `rsp`, which that repo declined at `/red-setup` (`rsp.enabled: false`); this PR makes its launcher findable, not enabled.

That a deliberately-inert plugin is drawn identically to a crashed one is a separate reporting defect, filed separately.

## Verification

- guard fails on this branch's parent, naming `castle` and `rsp` by server and file; passes with the fix
- `pnpm -C apps/dev test:invariants`: 141 tests, all pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788377621&installation_model_id=20659&pr_number=3200&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3200&signature=7e8bd7e70ac1b6c1fe9366a9c230beafcc8860913d86db9454b89c550ba1ac5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->