### PR TITLE
fix: stop handing `gh api` the -R flag it rejects, which parked two landings as broken infrastructure

### DIFF
--- a/.changeset/the-probe-hands-gh-api-a-flag-it-rejects.md
+++ b/.changeset/the-probe-hands-gh-api-a-flag-it-rejects.md
@@ -1,0 +1,25 @@
+---
+"@reddb-io/dev": patch
+---
+
+Stop handing `gh api` the `-R` flag it rejects, which parked landings as broken infrastructure
+
+`readQueuedPrView` prefixed `-R <repo>` onto whatever the REST plan produced. `-R`
+belongs to `gh pr view`; `gh api` refuses it outright — `unknown shorthand flag:
+'R' in -R` — and the plan already carries the repository inside its path,
+`repos/<owner>/<name>/pulls/<n>`.
+
+So every REST-routed merge confirmation failed before it reached GitHub. The wait
+loop is deliberately built so an unreadable probe is not a verdict, which is
+correct and which turned a permanently-failing command into four retries, an
+exhausted budget, and an issue parked `blocked:infra` telling a human to *"fix the
+landing infrastructure failure"* that was never there. Two issues sat in that
+state (#3182, #3169), one of them the last open ticket of a Spec and the other the
+fix for a flake blocking the release train.
+
+The sibling call site, `readSingleObject`, hands `plan.args` straight to `gh` and
+was always correct.
+
+The existing test asserted the PATH was present, which `gh -R o/r api
+repos/o/r/pulls/42` satisfies too — so it went on passing while every real probe
+failed. The new test asserts the flag's ABSENCE.

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -1412,9 +1412,16 @@ async function readQueuedPrView(
   probeTimeoutMs: number | undefined,
 ): Promise<QueuedPrProbe> {
   const plan = planGithubRestRead({ kind: "pr", number: prNumber, fields: QUEUED_PR_FIELDS, repo });
+  // `-R` belongs to `gh pr view` and NOT to `gh api`, which rejects it outright
+  // ("unknown shorthand flag: 'R' in -R") — the REST plan already carries the
+  // repository inside its path, `repos/<owner>/<name>/pulls/<n>`. Prefixing it
+  // anyway made every REST-routed confirmation fail before it reached GitHub, and
+  // an unreadable probe is deliberately not a verdict, so the caller retried,
+  // exhausted its budget and parked the issue `blocked:infra` asking a human to
+  // repair infrastructure that was never broken (#3182, #3169).
   const args =
     plan.outcome === "plan"
-      ? ["gh", "-R", repo, ...plan.args]
+      ? ["gh", ...plan.args]
       : ["gh", "-R", repo, "pr", "view", String(prNumber), "--json", QUEUED_PR_FIELDS.join(",")];
   const res = await boundedProbe(() => exec(args), probeTimeoutMs);
   // #3160: the probe's exit code and stderr travel WITH the view, because the one

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -1771,6 +1771,25 @@ describe("waitForQueuedMerge (#2986)", () => {
     expect(calls[0]!.join(" ")).toContain("api repos/o/r/pulls/42");
   });
 
+  it("does not hand `gh api` the `-R` flag it rejects (#3182, #3169)", async () => {
+    // `-R` belongs to `gh pr view`. `gh api` refuses it outright — "unknown
+    // shorthand flag: 'R' in -R" — and the REST plan already carries the repo in
+    // its path, so the flag is redundant as well as fatal.
+    //
+    // Asserting the PATH is present was not enough to catch this: `gh -R o/r api
+    // repos/o/r/pulls/42` contains the path too, and the existing test above went
+    // on passing while every real probe failed before it reached GitHub.
+    const { exec, calls } = queueExec([
+      JSON.stringify(restPullBody({ state: "MERGED", mergeCommitOid: "sha", autoMerge: false })),
+    ]);
+    await waitForQueuedMerge(exec, "o/r", 42, { sleep: async () => {}, maxPolls: 2 });
+
+    expect(calls[0]).not.toContain("-R");
+    expect(calls[0]).not.toContain("--repo");
+    // …and the repository is still addressed, by the only means `gh api` accepts.
+    expect(calls[0]!.join(" ")).toContain("repos/o/r/pulls/42");
+  });
+
   it("reports a dequeue once the accepted auto-merge request disappears", async () => {
     const { exec } = queueExec([
       queued,


### PR DESCRIPTION
Two issues were parked `ready-for-human` + `blocked:infra` with the same blocker:

```
summary: the merge confirmation could not read PR #3190: 4 consecutive unreadable
         probes (last exit 1: unknown shorthand flag: 'R' in -R
next: Fix the landing infrastructure failure, then requeue.
```

**Neither needed a human, and no infrastructure was broken.** `readQueuedPrView` prefixed `-R <repo>` onto whatever the REST plan produced:

```ts
plan.outcome === "plan"
  ? ["gh", "-R", repo, ...plan.args]   // → gh -R o/r api repos/o/r/pulls/42
  : ["gh", "-R", repo, "pr", "view", …]
```

`-R` belongs to `gh pr view`. **`gh api` refuses it outright**, and the plan already carries the repository inside its path:

```
$ gh -R reddb-io/red-skills api repos/reddb-io/red-skills
unknown shorthand flag: 'R' in -R
```

So every REST-routed merge confirmation failed before it reached GitHub.

## Why a one-flag bug parked issues instead of erroring

The wait loop is deliberately built so that **an unreadable probe is not a verdict** — `ABSENT_QUEUED_PR_VIEW` exists so the caller polls again rather than inventing an answer from a failed read. That is the right design, and it is what converted a permanently-failing command into four retries, an exhausted budget, and a park.

The two victims:

- **#3182** — the last open ticket of Spec #3183 ("eight unattended hours"), so the whole Spec was held behind it.
- **#3169** — the fix for a flake reddening the release train, so every correction waiting to publish queued behind a flag typo.

## The sibling that was always right

`readSingleObject` (`apps/dev/src/runtime/gh/single-object.ts:59`) hands `plan.args` straight to `runGh` with no prefix, and `runGh` injects nothing — `repoArgs()` is an explicit opt-in its callers use. One call site got it right, the other did not, and nothing compared them.

## Why the existing test did not catch it

There was already an assertion on this exact call:

```ts
expect(calls[0]!.join(" ")).toContain("api repos/o/r/pulls/42");
```

`gh -R o/r api repos/o/r/pulls/42` **contains that substring**, so the test passed while every real probe failed. Asserting a thing is present cannot catch a thing that should be absent.

The new test asserts the absence, and fails on this branch's parent with the argv printed:

```
expected [ 'gh', '-R', 'o/r', 'api', …(1) ] to not include '-R'
```

## Verification

- `merge.test.ts`: 137 tests pass with the fix; the new one fails without it
- `pnpm -C apps/dev test:invariants`: 141 tests, all pass

Once this lands, #3182 and #3169 can be requeued — their blocker is gone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788380467&installation_model_id=20659&pr_number=3214&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3214&signature=2ca090170252590f5621c98a3c3d167b4c5d2bb387457ed899c1da1ac88ab7fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->