### PR TITLE
fix: #3179 The host mints a 36-character UUID for a Worker whose sibling is called wVWHA, spending a fifth of the status line on a uniqueness guarantee nobody collects

### DIFF
--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -187,6 +187,7 @@ import {
 } from "./live-metrics.js";
 import {
   launchWorker,
+  mintHostWorkerId,
   type LaunchWorkerOptions,
   type LaunchedWorker,
   type RedskilledWorkerSpec,
@@ -1454,7 +1455,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         // template may mention it: an id substituted into an argv, an env or a log
         // path and a different id on the record would be one Worker the host and
         // the work disagree about.
-        const workerId = randomUUID();
+        const workerId = mintHostWorkerId(workers.keys());
         const registration = registrations.get(birth.project_label);
         const spec = workerSpecFromLaunch(
           // The argv comes from the plan (it is the registration's, copied), and
@@ -1912,6 +1913,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       spec,
       admission: admit(spec),
       memoryCeiling,
+      liveWorkerIds: workers.keys(),
       clock,
       onExit: (workerId, code, signal) => {
         const worker = workers.get(workerId);

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -18,7 +18,7 @@
  * verdict" is a property of this function instead of a convention every future
  * call site has to remember.
  */
-import { randomUUID } from "node:crypto";
+import { randomInt } from "node:crypto";
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { closeSync, mkdirSync, openSync } from "node:fs";
 import { dirname } from "node:path";
@@ -125,11 +125,33 @@ export interface LaunchWorkerOptions {
   readonly execPath?: string;
   readonly clock?: () => string;
   readonly workerId?: string;
+  /** Worker ids the host already holds, used when this launch has to mint one. */
+  readonly liveWorkerIds?: Iterable<string>;
   readonly spawnFn?: (command: string, args: readonly string[], options: SpawnOptions) => ChildProcess;
   /** Called when the daemon observes this Worker's process end. */
   readonly onExit?: (workerId: string, code: number | null, signal: NodeJS.Signals | null) => void;
   /** False to leave the spec's `log_path` unopened — for a test with no real fs. */
   readonly openLog?: boolean;
+}
+
+const HOST_WORKER_ID_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const HOST_WORKER_ID_RANDOM_LENGTH = 4;
+const HOST_WORKER_ID_SPACE = HOST_WORKER_ID_ALPHABET.length ** HOST_WORKER_ID_RANDOM_LENGTH;
+
+/** Mint the host's short, human-facing Worker handle without colliding with a live Worker. */
+export function mintHostWorkerId(
+  liveWorkerIds: Iterable<string>,
+  draw: (maxExclusive: number) => number = randomInt,
+): string {
+  const live = new Set(liveWorkerIds);
+  for (let attempt = 0; attempt < HOST_WORKER_ID_SPACE; attempt += 1) {
+    let workerId = "h";
+    for (let index = 0; index < HOST_WORKER_ID_RANDOM_LENGTH; index += 1) {
+      workerId += HOST_WORKER_ID_ALPHABET[draw(HOST_WORKER_ID_ALPHABET.length)]!;
+    }
+    if (!live.has(workerId)) return workerId;
+  }
+  throw new RedskilledWorkerSpecError("redskilled exhausted the host Worker id space");
 }
 
 /** Open a Worker's log for append, or null when it has none / cannot be opened. */
@@ -196,7 +218,8 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
 
   const env = options.env ?? process.env;
   const clock = options.clock ?? (() => new Date().toISOString());
-  const workerId = (spec.worker_id ?? options.workerId ?? randomUUID()).trim() || randomUUID();
+  const workerId = (spec.worker_id ?? options.workerId)?.trim()
+    || mintHostWorkerId(options.liveWorkerIds ?? []);
   const probes = options.probes ?? detectWorkerPlacementProbes(env);
   // The Worker's own output is the project's log, so the daemon opens the file
   // the client named and hands the descriptor to the process it owns. Failing to

--- a/apps/redskilled/tests/registration-log-path.test.ts
+++ b/apps/redskilled/tests/registration-log-path.test.ts
@@ -171,6 +171,7 @@ describe("the daemon writes its own facts into a registration's log path", () =>
     expect(tick.granted).toHaveLength(1);
     const spec = launched[0]!.spec;
     const workerId = tick.granted[0]!.worker_id;
+    expect(workerId).toMatch(/^h[A-Z0-9]{4}$/);
     expect(spec.log_path).toBe(`${workspace}/.red/tmp/logs/worker-${workerId}.log`);
     // The record the surfaces read carries it too — the whole point of stating it.
     expect(daemon.hostState().workers[0]!.log_path).toBe(spec.log_path);

--- a/apps/redskilled/tests/worker-birth.test.ts
+++ b/apps/redskilled/tests/worker-birth.test.ts
@@ -9,7 +9,12 @@ import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { isRedskilledWorkerView } from "../src/host-state.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { evaluateWorkerAdmission, UNBOUNDED_HOST_CEILING } from "../src/admission.js";
-import { launchWorker, RedskilledWorkerSpecError, type RedskilledWorkerSpec } from "../src/worker-launch.js";
+import {
+  launchWorker,
+  mintHostWorkerId,
+  RedskilledWorkerSpecError,
+  type RedskilledWorkerSpec,
+} from "../src/worker-launch.js";
 import { detectWorkerPlacementProbes, type WorkerPlacementProbes } from "../src/worker-placement.js";
 
 const running: RedskilledDaemon[] = [];
@@ -54,6 +59,8 @@ describe("worker birth through the socket", () => {
 
     expect(isRedskilledWorkerView(started.worker)).toBe(true);
     expect(started.worker.project_label).toBe("acme/widgets");
+    expect(started.worker.worker_id).toMatch(/^h[A-Z0-9]{4}$/);
+    expect(started.worker.worker_id).toHaveLength(5);
     expect(started.worker.pid).toBeGreaterThan(0);
     expect(started.worker.workspace_path).toBe(workspace);
 
@@ -135,6 +142,34 @@ describe("worker birth through the socket", () => {
       startRedskilledWorker(paths, { ...proofSpec(workspace), project_label: "" }, { readyTimeoutMs: 5_000 }),
     ).rejects.toThrow(/project_label/);
     expect(daemon.workerCount()).toBe(0);
+  });
+
+  it("keeps a project-minted Worker id distinguishable from a host fallback", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const daemon = await startRedskilledDaemon({ paths, idleMs: 60_000 });
+    running.push(daemon);
+
+    const started = await startRedskilledWorker(
+      paths,
+      proofSpec(workspace, { worker_id: "wVWHA" }),
+      { readyTimeoutMs: 5_000 },
+    );
+
+    expect(started.worker.worker_id).toBe("wVWHA");
+  });
+});
+
+describe("host-minted Worker ids", () => {
+  it("retries a collision against the live set and stays short", () => {
+    const draws = [0, 0, 0, 0, 0, 0, 0, 1];
+    const workerId = mintHostWorkerId(["hAAAA", "wVWHA"], () => draws.shift()!);
+
+    expect(workerId).toBe("hAAAB");
+    expect(workerId).toHaveLength(5);
+    expect(workerId.startsWith("h")).toBe(true);
+    expect(workerId.startsWith("w")).toBe(false);
+    expect(draws).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #3179. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3179

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788383900&installation_model_id=20659&pr_number=3218&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3218&signature=cf7d940f877c6a2518aef2df0f73609e2ae5c33aadab749b2cf7a47c3db59bf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->