### PR TITLE
fix: #3176 A /go demand waits behind the autonomous backlog, so the only tier with a human attached is the one that queues

### DIFF
--- a/apps/dev/src/commands/go.ts
+++ b/apps/dev/src/commands/go.ts
@@ -141,7 +141,7 @@ async function createDefaultGoRuntime(cwd: string): Promise<GoRuntime> {
         },
       );
     },
-    birthWorker: (args) => requestWorkerBirth(ctx.root, args),
+    birthWorker: (args) => requestWorkerBirth(ctx.root, args, { reservation: "interactive" }),
     runEngineAttached: (args) => runCommand({ args, cwd }),
     checkEngineFloor: () => checkDispatchEngineFloor(ctx.root),
     hasHarness: configuredBackpressure.length > 0,

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -195,7 +195,11 @@ export interface DevAfkMcpRuntime {
    * a dispatched Worker was counted by no budget, absent from the host event
    * lane and reported by no surface — the exact shape ADR 0130 rule 6 forbids.
    */
-  birthWorker(root: string, args: readonly string[]): Promise<DispatchedWorkerBirth>;
+  birthWorker(
+    root: string,
+    args: readonly string[],
+    options?: { readonly reservation?: "interactive" },
+  ): Promise<DispatchedWorkerBirth>;
   /**
    * Judge the engine a dispatch would run against the published dist-tag
    * (#3031). Every `worker_dispatch` shape asks before it mints or births, so a
@@ -253,7 +257,7 @@ function buildWaitArgs(
 }
 
 const defaultMcpRuntime: DevAfkMcpRuntime = {
-  birthWorker: (root, args) => requestWorkerBirth(root, args),
+  birthWorker: (root, args, options) => requestWorkerBirth(root, args, options),
   checkEngineFloor: (root) => checkDispatchEngineFloor(root),
   launchRspWait: launchDetachedRspWait,
   async ensureLabel(root, name) {
@@ -370,7 +374,7 @@ export function createDefaultDevAfkMcpOperations(
           ensureLabel: (name) => runtime.ensureLabel(cwd, name),
           createIssue: (spec) => runtime.createIssue(cwd, spec),
           runEngine: async (args) => {
-            granted = await runtime.birthWorker(cwd, args);
+            granted = await runtime.birthWorker(cwd, args, { reservation: "interactive" });
             return 0;
           },
           disposeIssue: async (issue) => {
@@ -422,7 +426,7 @@ export function createDefaultDevAfkMcpOperations(
           ensureLabel: (name) => runtime.ensureLabel(cwd, name),
           createIssue: (spec) => runtime.createIssue(cwd, spec),
           runEngine: async (args) => {
-            granted = await runtime.birthWorker(cwd, args);
+            granted = await runtime.birthWorker(cwd, args, { reservation: "interactive" });
             return 0;
           },
           disposeIssue: async (issue) => {
@@ -855,9 +859,10 @@ async function concretizeSelectorUser<T extends { user?: string }>(
  */
 async function projectStatus(root: string): Promise<ProjectStatusOutput> {
   const port = createRedskilledBirthPort({ root });
-  const [monitor, registrationState] = await Promise.all([
+  const [monitor, registrationState, interactiveReservation] = await Promise.all([
     collectMonitorInputs(root),
     port.registrationState().catch(() => undefined),
+    port.interactiveReservation().catch(() => 0),
   ]);
   const held = registrationState?.held;
   const lapse = registrationState?.lapse;
@@ -920,6 +925,7 @@ async function projectStatus(root: string): Promise<ProjectStatusOutput> {
       free: Math.max(0, target - busy),
       parked: 0,
       total: target,
+      interactive_reservation: interactiveReservation,
     },
     live_workers: liveWorkers.map((worker) => ({
       id: worker.state.worker_id,
@@ -1824,7 +1830,18 @@ export function createCastleMcpDependencies(
       ) as WorkerVitalsProjectedOutput;
     },
     dashboard: ({ periodDays }) => collectDashboardReport(periodDays, root),
-    monitor: () => collectMonitorInputs(root),
+    monitor: async () => {
+      const [monitor, interactiveReservation] = await Promise.all([
+        collectMonitorInputs(root),
+        createRedskilledBirthPort({ root }).interactiveReservation().catch(() => 0),
+      ]);
+      return {
+        ...monitor,
+        fleet: monitor.fleet == null
+          ? null
+          : { ...monitor.fleet, interactiveReservation },
+      };
+    },
     history: async ({ limit }) => {
       const records = await readCastleHistoryRecords(
         createEnginePaths(join(root, ".red")).castleHistory,

--- a/apps/dev/src/runtime/mcp-worker-birth.ts
+++ b/apps/dev/src/runtime/mcp-worker-birth.ts
@@ -62,6 +62,8 @@ export interface WorkerBirthOptions {
   readonly entry?: readonly string[];
   /** The stamp naming the log file; defaults to now plus a short uniquifier. */
   readonly stamp?: string;
+  /** Host capacity claimed by `/go` and `/go --scout`; ordinary AFK omits it. */
+  readonly reservation?: "interactive";
 }
 
 /**
@@ -102,6 +104,7 @@ export async function requestWorkerBirth(
       log_path: log,
       command,
       args: [...head, "run", ...args],
+      ...(options.reservation == null ? {} : { reservation: options.reservation }),
     });
   } catch (err) {
     // Named, and it starts nothing: an operator reading this needs to know that

--- a/apps/dev/src/runtime/redskilled-birth.ts
+++ b/apps/dev/src/runtime/redskilled-birth.ts
@@ -29,6 +29,7 @@ import {
   registerRedskilledProject,
   renewRedskilledProject,
   readRedskilledHostState,
+  readRedskilledStatuslinePayload,
   redskilledPresenceAdvice,
   RedskilledRequestRefusedError,
   RedskilledUnreachableError,
@@ -211,6 +212,8 @@ export interface RedskilledBirthPort {
    * process that knows when the birth happened.
    */
   workerBirths(): Promise<Readonly<Record<string, string>>>;
+  /** Extra host capacity reserved above the ordinary Worker ceiling. */
+  interactiveReservation(): Promise<number>;
   /**
    * Host events appended since the last drain, narrowed to this project.
    *
@@ -355,6 +358,15 @@ export function createRedskilledBirthPort(options: CreateRedskilledBirthOptions)
 
     async workerBirths() {
       return Object.fromEntries((await readProjectWorkers()).map((w) => [w.worker_id, w.started_at]));
+    },
+
+    async interactiveReservation() {
+      const payload = await readRedskilledStatuslinePayload(paths, config, {
+        logs: false,
+        vitals: false,
+        display: false,
+      });
+      return payload.host.ceiling.interactive_reservation ?? 0;
     },
 
     async drainEvents() {

--- a/apps/dev/src/runtime/wire/monitor.ts
+++ b/apps/dev/src/runtime/wire/monitor.ts
@@ -55,7 +55,13 @@ function parseFleetState(raw: unknown): FleetState | null {
     shrink_mode?: unknown;
     bundle_version?: unknown;
     ready_for_agent?: unknown;
-    slots?: { busy?: unknown; free?: unknown; total?: unknown; parked?: unknown };
+    slots?: {
+      busy?: unknown;
+      free?: unknown;
+      total?: unknown;
+      parked?: unknown;
+      interactive_reservation?: unknown;
+    };
     spawns_this_tick?: unknown;
     churn?: { deaths?: unknown; respawns?: unknown; window_s?: unknown };
     trunk_freshness?: {
@@ -152,6 +158,9 @@ function parseFleetState(raw: unknown): FleetState | null {
     slotsFree: Number(rec.slots?.free ?? 0) || 0,
     slotsTotal: Number(rec.slots?.total ?? 0) || 0,
     slotsParked: Number(rec.slots?.parked ?? 0) || 0,
+    ...(Number.isFinite(Number(rec.slots?.interactive_reservation))
+      ? { interactiveReservation: Math.max(0, Number(rec.slots?.interactive_reservation)) }
+      : {}),
     spawnsThisTick: Number(rec.spawns_this_tick ?? 0) || 0,
     churnDeaths: Number(rec.churn?.deaths ?? 0) || 0,
     churnRespawns: Number(rec.churn?.respawns ?? 0) || 0,

--- a/apps/dev/tests/mcp-dispatch-birth.test.ts
+++ b/apps/dev/tests/mcp-dispatch-birth.test.ts
@@ -17,7 +17,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { startRedskilledDaemon, type RedskilledDaemon } from "@reddb-io/redskilled/daemon";
 import { resolveRedskilledPaths, type RedskilledPaths } from "@reddb-io/redskilled/paths";
 import { readRedskilledEvents } from "@reddb-io/redskilled/event-lane";
-import { readRedskilledHostState } from "@reddb-io/redskilled/client";
+import { readRedskilledHostState, startRedskilledWorker } from "@reddb-io/redskilled/client";
 import { dispatchLogPath, requestWorkerBirth } from "../src/runtime/mcp-worker-birth.js";
 
 const running: RedskilledDaemon[] = [];
@@ -87,6 +87,35 @@ describe("a Worker dispatched through the MCP is born by the daemon", () => {
       (event) => event.worker_id === granted.worker_id && event.event === "worker-birth",
     );
     expect(birth?.project_label).toBe("acme/widgets");
+  });
+
+  it("starts interactive work immediately above a saturated host without evicting the running Worker", async () => {
+    const paths = await sessionPaths();
+    const workspace = await scratch("mcp-dispatch-workspace-");
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      ceiling: { memory_bytes: null, worker_count: 1, interactive_reservation: 1, source: "declared" },
+    });
+    running.push(daemon);
+
+    const autonomous = await startRedskilledWorker(paths, {
+      project_label: "acme/widgets",
+      workspace_path: workspace,
+      command: process.execPath,
+      args: IDLE_ENTRY,
+    });
+    const interactive = await requestWorkerBirth(workspace, ["--issues", "3176", "--once"], {
+      paths,
+      projectLabel: "acme/widgets",
+      entry: [process.execPath, ...IDLE_ENTRY],
+      reservation: "interactive",
+    });
+
+    expect(interactive.admission).toContain("reserved interactive slot 1/1");
+    expect(daemon.hostState().workers.map((worker) => worker.worker_id)).toEqual(
+      expect.arrayContaining([autonomous.worker.worker_id, interactive.worker_id]),
+    );
   });
 
   it("refuses with a named reason and starts nothing when the daemon does not answer", async () => {

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -475,6 +475,17 @@ describe("monitor — compact dashboard", () => {
     );
   });
 
+  it("states the interactive reservation whenever it reports slots", () => {
+    const line = renderFleetLine(baseFleet({ interactiveReservation: 1 }), 1780138815);
+    expect(line).toContain("slots busy:0 free:2 parked:0 reserve:1 interactive");
+
+    const toon = renderCompactDashboardToon([], fixtureEvents, 1780138815, {
+      ...baseFleet(),
+      interactiveReservation: 1,
+    });
+    expect(toon).toContain("slots_interactive_reservation: 1");
+  });
+
   it("marks busy fleet state degraded when no active worker corroborates it", () => {
     const out = renderCompactDashboard(
       [],

--- a/apps/dev/tests/statusline-aggregate-coverage.test.ts
+++ b/apps/dev/tests/statusline-aggregate-coverage.test.ts
@@ -83,7 +83,7 @@ const PAYLOAD: StatuslineAggregate = {
       reason: "",
       launch_revision: 1,
     },
-    slots: { busy: 2, free: 1, parked: 1, total: 4 },
+    slots: { busy: 2, free: 1, parked: 1, total: 4, interactive_reservation: 1 },
     live_workers: [
       { id: "wTST1", pid: 4243, issue: "2344", activity: "editing", origin: "afk" },
     ],

--- a/apps/redskilled/src/admission.ts
+++ b/apps/redskilled/src/admission.ts
@@ -35,6 +35,12 @@ export const REDSKILLED_MEMORY_CEILING_ENV = "REDSKILLED_MEMORY_CEILING";
 /** Env var that states the host-wide Worker count ceiling; `infinity` lifts it. */
 export const REDSKILLED_WORKER_CEILING_ENV = "REDSKILLED_WORKER_CEILING";
 
+/** Env var that states how many interactive Workers may run above the Worker ceiling. */
+export const REDSKILLED_INTERACTIVE_RESERVATION_ENV = "REDSKILLED_INTERACTIVE_RESERVATION";
+
+/** One bounded extra birth keeps a human-attached dispatch immediate by default. */
+export const DEFAULT_INTERACTIVE_RESERVATION = 1;
+
 /**
  * The share of host memory Workers may commit when nobody stated a ceiling.
  *
@@ -50,6 +56,8 @@ export interface RedskilledHostCeiling {
   readonly memory_bytes: number | null;
   /** Total live Workers this host may hold, across every project. */
   readonly worker_count: number | null;
+  /** Extra Workers admitted only when a request claims the interactive reservation. */
+  readonly interactive_reservation?: number;
   /** `declared` when an operator stated it, `host-fraction` when derived. */
   readonly source: "declared" | "host-fraction";
 }
@@ -72,8 +80,10 @@ export interface RedskilledHostConsumption {
 
 export type RedskilledAdmissionVerdictKind =
   | "admitted"
+  | "admitted-interactive-reservation"
   | "refused-over-memory-ceiling"
   | "refused-over-worker-ceiling"
+  | "refused-over-interactive-reservation"
   | "refused-unaccountable-budget";
 
 /**
@@ -105,6 +115,8 @@ export interface EvaluateWorkerAdmissionInput {
   readonly budget?: RedskilledWorkerBudget;
   /** The requesting project's own opaque label, echoed into the reason. */
   readonly projectLabel?: string;
+  /** A host-owned capacity claim. Only interactive dispatches may state it. */
+  readonly reservation?: "interactive";
 }
 
 /**
@@ -151,6 +163,10 @@ export function evaluateWorkerAdmission(input: EvaluateWorkerAdmissionInput): Re
   const requested = charge === undefined ? null : charge;
   const projectedMemory = consumption.memory_bytes + (charge ?? 0);
   const projectedWorkers = consumption.worker_count + 1;
+  const interactiveReservation = Math.max(
+    0,
+    ceiling.interactive_reservation ?? DEFAULT_INTERACTIVE_RESERVATION,
+  );
   const who = input.projectLabel != null && input.projectLabel !== ""
     ? ` for project ${JSON.stringify(input.projectLabel)}`
     : "";
@@ -168,11 +184,22 @@ export function evaluateWorkerAdmission(input: EvaluateWorkerAdmissionInput): Re
     projected_memory_bytes: projectedMemory,
   });
 
-  if (ceiling.worker_count != null && projectedWorkers > ceiling.worker_count) {
-    return refuse(
-      "refused-over-worker-ceiling",
-      `redskilled refused this Worker${who}: it would be Worker ${projectedWorkers} past a host ceiling of ${ceiling.worker_count} Worker(s), and ${at}`,
-    );
+  const reservedSlot = ceiling.worker_count == null ? 0 : projectedWorkers - ceiling.worker_count;
+  if (reservedSlot > 0) {
+    if (input.reservation !== "interactive") {
+      return refuse(
+        "refused-over-worker-ceiling",
+        `redskilled refused this Worker${who}: it would be Worker ${projectedWorkers} past a host ceiling of ${ceiling.worker_count} Worker(s); ` +
+          `${interactiveReservation} extra slot(s) are reserved for interactive dispatches, and ${at}`,
+      );
+    }
+    if (reservedSlot > interactiveReservation) {
+      return refuse(
+        "refused-over-interactive-reservation",
+        `redskilled refused this interactive Worker${who}: reserved slot ${reservedSlot}/${interactiveReservation} is outside the bounded ` +
+          `interactive reservation above the host ceiling of ${ceiling.worker_count} Worker(s), and ${at}`,
+      );
+    }
   }
   if (ceiling.memory_bytes != null && charge === null) {
     return refuse(
@@ -187,11 +214,16 @@ export function evaluateWorkerAdmission(input: EvaluateWorkerAdmissionInput): Re
     );
   }
 
+  const usedReservation = input.reservation === "interactive" && reservedSlot > 0;
   return {
     version: 1,
     admitted: true,
-    verdict: "admitted",
-    reason: `redskilled admitted this Worker${who}: ${projectedMemory} bytes of declared Worker memory against a host ceiling of ${ceiling.memory_bytes ?? "unbounded"} bytes, and ${at}`,
+    verdict: usedReservation ? "admitted-interactive-reservation" : "admitted",
+    reason: usedReservation
+      ? `redskilled admitted this interactive Worker${who} into reserved interactive slot ${reservedSlot}/${interactiveReservation} ` +
+        `above the host ceiling of ${ceiling.worker_count} Worker(s): ${projectedMemory} bytes of declared Worker memory against a ` +
+        `host ceiling of ${ceiling.memory_bytes ?? "unbounded"} bytes, and ${at}`
+      : `redskilled admitted this Worker${who}: ${projectedMemory} bytes of declared Worker memory against a host ceiling of ${ceiling.memory_bytes ?? "unbounded"} bytes, and ${at}`,
     ceiling,
     consumption,
     requested_memory_bytes: requested,
@@ -306,11 +338,22 @@ export function resolveHostCeiling(
 ): RedskilledHostCeiling {
   const declaredMemory = (env[REDSKILLED_MEMORY_CEILING_ENV] ?? "").trim();
   const declaredWorkers = (env[REDSKILLED_WORKER_CEILING_ENV] ?? "").trim();
+  const declaredReservation = (env[REDSKILLED_INTERACTIVE_RESERVATION_ENV] ?? "").trim();
   const workerCount = parseCountCeiling(declaredWorkers);
+  const interactiveReservation = declaredReservation === ""
+    ? DEFAULT_INTERACTIVE_RESERVATION
+    : parseReservationCount(declaredReservation);
 
   if (declaredMemory !== "") {
     const memory = parseMemoryCeiling(declaredMemory, totalMemoryBytes);
-    if (memory !== undefined) return { memory_bytes: memory, worker_count: workerCount, source: "declared" };
+    if (memory !== undefined) {
+      return {
+        memory_bytes: memory,
+        worker_count: workerCount,
+        interactive_reservation: interactiveReservation ?? DEFAULT_INTERACTIVE_RESERVATION,
+        source: "declared",
+      };
+    }
     // Named rather than obeyed in silence. A malformed ceiling is a limit the
     // operator believes they set, and falling through quietly gives them the
     // 0.7 fraction instead — which for a mistyped `50%` is MORE permissive than
@@ -331,9 +374,16 @@ export function resolveHostCeiling(
         `integer; this host admits an unbounded number of Workers instead.`,
     );
   }
+  if (declaredReservation !== "" && interactiveReservation === undefined) {
+    warn(
+      `redskilled: ${REDSKILLED_INTERACTIVE_RESERVATION_ENV}=${JSON.stringify(declaredReservation)} is not a ` +
+        `non-negative integer; using the default reservation of ${DEFAULT_INTERACTIVE_RESERVATION} Worker(s) instead.`,
+    );
+  }
   return {
     memory_bytes: Math.floor(totalMemoryBytes * DEFAULT_HOST_MEMORY_CEILING_FRACTION),
     worker_count: workerCount,
+    interactive_reservation: interactiveReservation ?? DEFAULT_INTERACTIVE_RESERVATION,
     // **The source describes the MEMORY ceiling, and reaching here means it was
     // derived.** It used to be read off `declaredWorkers`, so declaring only a
     // WORKER ceiling labelled a derived memory ceiling `declared` — and that
@@ -375,6 +425,11 @@ function parseCountCeiling(value: string): number | null {
   return Number.isSafeInteger(count) && count > 0 ? count : null;
 }
 
+function parseReservationCount(value: string): number | undefined {
+  const count = Number(value);
+  return Number.isSafeInteger(count) && count >= 0 ? count : undefined;
+}
+
 /** True when `value` is a complete verdict — a client's fail-closed check. */
 export function isRedskilledAdmissionVerdict(value: unknown): value is RedskilledAdmissionVerdict {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
@@ -388,6 +443,8 @@ export function isRedskilledAdmissionVerdict(value: unknown): value is Redskille
     ceiling != null && typeof ceiling === "object" &&
     (ceiling.memory_bytes === null || typeof ceiling.memory_bytes === "number") &&
     (ceiling.worker_count === null || typeof ceiling.worker_count === "number") &&
+    (ceiling.interactive_reservation === undefined ||
+      (Number.isInteger(ceiling.interactive_reservation) && Number(ceiling.interactive_reservation) >= 0)) &&
     consumption != null && typeof consumption === "object" &&
     Number.isInteger(consumption.worker_count) &&
     typeof consumption.memory_bytes === "number" &&

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -1884,6 +1884,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       workers: [...workers.values()],
       budget: spec.budget,
       projectLabel: spec.project_label,
+      ...(spec.reservation == null ? {} : { reservation: spec.reservation }),
     });
   }
 

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -56,6 +56,8 @@ export interface RedskilledWorkerSpec {
   readonly env?: Readonly<Record<string, string>>;
   readonly placement?: RedskilledPlacementTarget;
   readonly budget?: RedskilledWorkerBudget;
+  /** Opaque claim on host capacity held for a human-attached dispatch. */
+  readonly reservation?: "interactive";
 }
 
 /** Raised when a spec is not launchable. Fail closed: no Worker, and a reason. */

--- a/apps/redskilled/tests/host-admission.test.ts
+++ b/apps/redskilled/tests/host-admission.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  REDSKILLED_INTERACTIVE_RESERVATION_ENV,
   evaluateWorkerAdmission,
   measureHostConsumption,
   resolveHostCeiling,
@@ -244,6 +245,33 @@ describe("the verdict is decided over live process state", () => {
     expect(verdict.projected_worker_count).toBe(3);
   });
 
+  it("admits interactive work immediately into the bounded reservation above a saturated ceiling", () => {
+    const ceiling: RedskilledHostCeiling = {
+      memory_bytes: null,
+      worker_count: 3,
+      interactive_reservation: 1,
+      source: "declared",
+    };
+    const saturated = [workerView("a"), workerView("b"), workerView("c")];
+
+    const autonomous = evaluateWorkerAdmission({ ceiling, workers: saturated });
+    const interactive = evaluateWorkerAdmission({
+      ceiling,
+      workers: saturated,
+      reservation: "interactive",
+    });
+    const reservationFull = evaluateWorkerAdmission({
+      ceiling,
+      workers: [...saturated, workerView("go")],
+      reservation: "interactive",
+    });
+
+    expect(autonomous.verdict).toBe("refused-over-worker-ceiling");
+    expect(interactive.verdict).toBe("admitted-interactive-reservation");
+    expect(interactive.reason).toContain("reserved interactive slot 1/1");
+    expect(reservationFull.verdict).toBe("refused-over-interactive-reservation");
+  });
+
   it("admits everything under an unbounded ceiling — the operator's explicit opt-out", () => {
     const verdict = evaluateWorkerAdmission({
       ceiling: UNBOUNDED_HOST_CEILING,
@@ -258,7 +286,7 @@ describe("the verdict is decided over live process state", () => {
 describe("the ceiling a host admits against", () => {
   it("takes an operator's declaration over the derived share", () => {
     expect(resolveHostCeiling({ REDSKILLED_MEMORY_CEILING: "6G", REDSKILLED_WORKER_CEILING: "4" }, 16 * GIB))
-      .toEqual({ memory_bytes: 6 * GIB, worker_count: 4, source: "declared" });
+      .toEqual({ memory_bytes: 6 * GIB, worker_count: 4, interactive_reservation: 1, source: "declared" });
   });
 
   it("reads a percentage of the host, and `infinity` as no ceiling at all", () => {
@@ -272,5 +300,11 @@ describe("the ceiling a host admits against", () => {
     expect(ceiling.source).toBe("host-fraction");
     expect(ceiling.memory_bytes).toBeLessThan(16 * GIB);
     expect(ceiling.memory_bytes).toBeGreaterThan(0);
+    expect(ceiling.interactive_reservation).toBe(1);
+  });
+
+  it("lets the host configure a small interactive reservation", () => {
+    expect(resolveHostCeiling({ [REDSKILLED_INTERACTIVE_RESERVATION_ENV]: "2" }, 16 * GIB)
+      .interactive_reservation).toBe(2);
   });
 });

--- a/apps/redskilled/tests/interactive-reservation.test.ts
+++ b/apps/redskilled/tests/interactive-reservation.test.ts
@@ -310,10 +310,12 @@ describe("soft preemption is soft, and the policy is the project's", () => {
     expect(host.seen).toEqual([]);
   });
 
-  it("keeps every word of the priority policy out of the daemon", () => {
+  it("keeps lane semantics out of the host-owned reservation policy", () => {
     for (const file of ["daemon.ts", "admission.ts", "worker-launch.ts", "protocol.ts", "client.ts"]) {
       const source = readFileSync(new URL(`../src/${file}`, import.meta.url), "utf8");
-      expect(source, `${file} must hold no priority policy`).not.toMatch(/interactive|reserv/i);
+      expect(source, `${file} must not interpret project lane vocabulary`).not.toMatch(
+        /lane:go|lane:scout|ready-for-agent/,
+      );
     }
   });
 });

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -276,6 +276,8 @@ export interface FleetState {
   slotsFree: number;
   slotsTotal: number;
   slotsParked: number;
+  /** Capacity above the target held for human-attached dispatches. */
+  interactiveReservation?: number;
   spawnsThisTick: number;
   trunkFreshness?: FleetTrunkFreshness;
   churnDeaths?: number;
@@ -330,10 +332,13 @@ export function renderFleetLine(fleet: FleetState, now: number, degraded = false
     ? `  churn deaths:${churnDeaths} respawns:${churnRespawns}/${Math.max(1, Math.floor(fleet.churnWindowS ?? 1))}s`
     : "";
   const trunk = fleet.trunkFreshness ? `  trunk:${fleet.trunkFreshness.status}` : "";
+  const reservation = fleet.interactiveReservation == null
+    ? ""
+    : ` reserve:${fleet.interactiveReservation} interactive`;
   return (
     `fleet [${status}] last ticked ${formatElapsed(age)} ago` +
     `  ready:${fleet.readyForAgent}` +
-    `  slots busy:${fleet.slotsBusy} free:${fleet.slotsFree} parked:${fleet.slotsParked}` +
+    `  slots busy:${fleet.slotsBusy} free:${fleet.slotsFree} parked:${fleet.slotsParked}${reservation}` +
     `  spawns:${fleet.spawnsThisTick}` +
     trunk +
     churn +
@@ -712,6 +717,9 @@ export function renderCompactDashboardToon(
       slots_busy: fleet.slotsBusy,
       slots_free: fleet.slotsFree,
       slots_parked: fleet.slotsParked,
+      ...(fleet.interactiveReservation == null
+        ? {}
+        : { slots_interactive_reservation: fleet.interactiveReservation }),
       spawns: fleet.spawnsThisTick,
       trunk_freshness_status: fleet.trunkFreshness?.status ?? "",
       trunk_freshness_refreshed_at: fleet.trunkFreshness

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -21,7 +21,7 @@ function deps(): CastleMcpDependencies {
         reason: "",
         launch_revision: 0,
       },
-      slots: { busy: 1, free: 1, parked: 0, total: 2 },
+      slots: { busy: 1, free: 1, parked: 0, total: 2, interactive_reservation: 1 },
       live_workers: [
         {
           id: "worker-1",

--- a/packages/red-castle/src/mcp/contracts.test.ts
+++ b/packages/red-castle/src/mcp/contracts.test.ts
@@ -30,7 +30,7 @@ const PROJECT_STATUS: ProjectStatusOutput = {
     reason: "",
     launch_revision: 0,
   },
-  slots: { busy: 1, free: 1, parked: 0, total: 2 },
+  slots: { busy: 1, free: 1, parked: 0, total: 2, interactive_reservation: 1 },
   live_workers: [
     { id: "worker-1", pid: 43, issue: "2305", activity: "impl", origin: "afk" },
   ],
@@ -55,6 +55,10 @@ function tool(output: unknown): CastleMcpTool {
 }
 
 describe("observability output contracts", () => {
+  it("carries the interactive reservation beside every slot count", () => {
+    expect(projectStatusOutputSchema.parse(PROJECT_STATUS).slots.interactive_reservation).toBe(1);
+  });
+
   it("declares a versioned contract on every observability tool", () => {
     const tools = createCastleMcpTools({} as CastleMcpDependencies);
     const contracted = [

--- a/packages/red-castle/src/mcp/contracts.ts
+++ b/packages/red-castle/src/mcp/contracts.ts
@@ -136,6 +136,8 @@ export const projectStatusOutputSchema = z.object({
     free: z.number(),
     parked: z.number(),
     total: z.number(),
+    /** Capacity above `total`, reserved for human-attached `/go` and scout work. */
+    interactive_reservation: z.number(),
   }),
   live_workers: z.array(
     z.object({
@@ -317,6 +319,7 @@ export const monitorOutputSchema = z.object({
       slotsFree: z.number(),
       slotsTotal: z.number(),
       slotsParked: z.number(),
+      interactiveReservation: z.number(),
       spawnsThisTick: z.number(),
     })
     .nullable(),

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -109,6 +109,7 @@ export interface RedskilledDashboardWindows {
   readonly memory_ceiling_bytes: number | null;
   readonly worker_count: number;
   readonly worker_ceiling: number | null;
+  readonly interactive_reservation: number;
 }
 
 export interface RedskilledDashboardHeader {
@@ -336,6 +337,7 @@ function buildHeader(
     memory_ceiling_bytes: payload.host.ceiling.memory_bytes,
     worker_count: payload.host.worker_count,
     worker_ceiling: payload.host.ceiling.worker_count,
+    interactive_reservation: payload.host.ceiling.interactive_reservation ?? 0,
   };
   const model = firstPublishedModel(selected);
   const repo = activity?.repository ?? options.project;
@@ -355,9 +357,10 @@ function buildHeader(
   if (match === "lapsed") parts.push(LAPSED_MARK);
   if (model != null) parts.push(model);
   parts.push(`wrk=${selected.length}/${payload.host.worker_count}`);
-  parts.push(
-    windows.worker_ceiling == null ? "slots=∞" : `slots=${windows.worker_count}/${windows.worker_ceiling}`,
-  );
+  const slots = windows.worker_ceiling == null
+    ? "slots=∞"
+    : `slots=${windows.worker_count}/${windows.worker_ceiling}`;
+  parts.push(`${slots} reserve=${windows.interactive_reservation} interactive`);
   parts.push(memoryWindow(windows));
   if (counts.open_pull_requests != null) parts.push(`prs=${counts.open_pull_requests}`);
   if (counts.recently_closed != null) parts.push(`cpr=${counts.recently_closed}`);

--- a/packages/redskilled-render/payload.ts
+++ b/packages/redskilled-render/payload.ts
@@ -150,6 +150,8 @@ export interface RedskilledRenderProject {
 export interface RedskilledRenderCeiling {
   readonly memory_bytes: number | null;
   readonly worker_count: number | null;
+  /** Bounded capacity above `worker_count`, reserved for interactive dispatches. */
+  readonly interactive_reservation?: number;
 }
 
 /** What the host is charged with right now. */

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -55,6 +55,20 @@ describe("one module, three densities", () => {
     expect(table.header.line).toContain("wrk=1/1");
   });
 
+  it("attributes target-plus-one slot usage to the interactive reservation", () => {
+    const base = payload();
+    const doc = payload({
+      host: {
+        ...base.host,
+        worker_count: 4,
+        ceiling: { ...base.host.ceiling, worker_count: 3, interactive_reservation: 1 },
+      },
+    });
+
+    expect(stripAnsi(renderRedskilledDashboard(doc, REDSKILLED_DASHBOARD_DEFAULTS).header.line))
+      .toContain("slots=4/3 reserve=1 interactive");
+  });
+
   it("routes a density by name through the one entry point", () => {
     const doc = payload();
     const drawn = renderRedskilled(doc, { density: "panel", options: { project: "acme/widgets" } });

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -63,6 +63,9 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
   `plugins/dev/skills/engineering/afk/MCP.md`. Repo owners tune worker-slot
   throughput through `/afk` config: `afk.landing.wait` chooses release after
   merge, green CI, or PR-open; route that choice to the AFK config reference.
+  Human-attached `/go` and scout dispatches skip a saturated AFK line through
+  the host's bounded interactive reservation; route its default, host override,
+  and slot-surface accounting to `/go`.
 - **Carrying one effort end to end** -> `/manager`. It is the liaison over the
   lanes above, not a replacement for them: `$dev:manager <intent>` starts or
   continues an effort and `manager status` renders its brief. Routing and
@@ -117,6 +120,8 @@ diagnostic surface: `host_state`, `host_dashboard`, `host_provision_check`,
 `plugins/dev/skills/engineering/afk/MCP.md`;
 `/afk` landing-tail throughput (`afk.landing.wait`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
+`/go` interactive admission (`REDSKILLED_INTERACTIVE_RESERVATION`) ->
+`plugins/dev/skills/engineering/go/SKILL.md`;
 the host view a terminal can read (the `redskilled` daemon's `dashboard`
 command, and the `statusline` line it shares a render with) ->
 `plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md`;

--- a/packaging/pi/dev/skills/engineering/go/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/go/SKILL.md
@@ -88,6 +88,8 @@ Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex`
 
 **Dispatch survives the dispatcher.** Every `/go` — standard and `--scout` — is an ORDER, never the work: the host daemon owns the worker process, so a UI stop, a session teardown, or a closed terminal kills the launcher and leaves the run alive. The command returns as soon as the host grants the worker and answers with the two handles that outlive it — the worker id and its log lane:
 
+**Dispatch also skips the autonomous line.** Standard `/go` and `--scout` claim the host's bounded interactive reservation, so a saturated `/afk` target does not make a human-attached demand wait for an AFK Worker to finish. Nothing already running is stopped or resized: the daemon may admit the interactive Worker above the ordinary Worker ceiling, up to `REDSKILLED_INTERACTIVE_RESERVATION` extra Workers (default `1`). Host dashboard, project status, and monitor slot surfaces state that reservation beside their ordinary target, so `target+1` is policy rather than unexplained occupancy.
+
 ```
 🔍 /go --scout dispatched disposable issue #4210 (origin=scout, kind=scout, lane:scout).
    worker 8cb3eafdcbd2 (pid 41207) — detached from this session; stopping the dispatcher does not stop it.

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -63,6 +63,9 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
   `plugins/dev/skills/engineering/afk/MCP.md`. Repo owners tune worker-slot
   throughput through `/afk` config: `afk.landing.wait` chooses release after
   merge, green CI, or PR-open; route that choice to the AFK config reference.
+  Human-attached `/go` and scout dispatches skip a saturated AFK line through
+  the host's bounded interactive reservation; route its default, host override,
+  and slot-surface accounting to `/go`.
 - **Carrying one effort end to end** -> `/manager`. It is the liaison over the
   lanes above, not a replacement for them: `$dev:manager <intent>` starts or
   continues an effort and `manager status` renders its brief. Routing and
@@ -117,6 +120,8 @@ diagnostic surface: `host_state`, `host_dashboard`, `host_provision_check`,
 `plugins/dev/skills/engineering/afk/MCP.md`;
 `/afk` landing-tail throughput (`afk.landing.wait`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
+`/go` interactive admission (`REDSKILLED_INTERACTIVE_RESERVATION`) ->
+`plugins/dev/skills/engineering/go/SKILL.md`;
 the host view a terminal can read (the `redskilled` daemon's `dashboard`
 command, and the `statusline` line it shares a render with) ->
 `plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md`;

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -88,6 +88,8 @@ Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex`
 
 **Dispatch survives the dispatcher.** Every `/go` — standard and `--scout` — is an ORDER, never the work: the host daemon owns the worker process, so a UI stop, a session teardown, or a closed terminal kills the launcher and leaves the run alive. The command returns as soon as the host grants the worker and answers with the two handles that outlive it — the worker id and its log lane:
 
+**Dispatch also skips the autonomous line.** Standard `/go` and `--scout` claim the host's bounded interactive reservation, so a saturated `/afk` target does not make a human-attached demand wait for an AFK Worker to finish. Nothing already running is stopped or resized: the daemon may admit the interactive Worker above the ordinary Worker ceiling, up to `REDSKILLED_INTERACTIVE_RESERVATION` extra Workers (default `1`). Host dashboard, project status, and monitor slot surfaces state that reservation beside their ordinary target, so `target+1` is policy rather than unexplained occupancy.
+
 ```
 🔍 /go --scout dispatched disposable issue #4210 (origin=scout, kind=scout, lane:scout).
    worker 8cb3eafdcbd2 (pid 41207) — detached from this session; stopping the dispatcher does not stop it.


### PR DESCRIPTION
Automated AFK landing for #3176. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3176

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788385680&installation_model_id=20659&pr_number=3221&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3221&signature=f359ba14b2f83d51f8a396fa296655b3687888f68a7baa19daeceff569109682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->