### PR TITLE
merge: #3181 queue_status counts a trust-gate-held issue as available work, so a fully-barred queue reports progress: 1/1 (100%) and every drain looks successful

### DIFF
--- a/.changeset/queue-census-sees-trust-holds.md
+++ b/.changeset/queue-census-sees-trust-holds.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/dev": patch
+---
+
+Partition `queue_status` into eligible and trust-held ready work, and keep
+maintainer-summon holds out of AFK drain progress totals.

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -65,6 +65,7 @@ import { createCastleWorkerLaneBridge } from "../../core/castle-worker-lane-brid
 import { createWorkerLogLinePublisher } from "../../runtime/redskilled-worker-log.js";
 import { HOST_CONFIG_EXIT_CODE, sweepDiscardsWorkspace } from "../../core/worker-outcome.js";
 import { LABEL_READY } from "../../core/triage-labels.js";
+import { evaluateClaimTrust, parseTrustPolicy } from "../../core/trust-gate.js";
 
 import { checkBootGuard, isNamespacedDispatch, parseRunFlags, resolveRunDispatchIdentity, shouldSkipBootSweeps, type RunOptions } from "./flags.js";
 import { buildProcessDeps, parseSlot, type CurrentAttempt } from "./process-deps.js";
@@ -453,6 +454,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     goVerifyRetries: flags.goVerifyRetries,
     workerId,
   });
+  let queueTrustPolicy: ReturnType<typeof parseTrustPolicy> | undefined;
 
   const deps: CastleWorkerDrainDeps<
     BootDeps,
@@ -464,6 +466,29 @@ export async function runCommand(options: RunOptions): Promise<number> {
     SessionIssueTemplate
   > = {
     gh: { listCandidates: () => ghx.listCandidates(ghCtx, consultedQueue) },
+    classifyEligibility: async (candidate) => {
+      queueTrustPolicy ??= parseTrustPolicy(
+        config,
+        await processDeps.gh.repoVisibility?.(),
+      );
+      const canFailClosed =
+        queueTrustPolicy.failClosed === true &&
+        processDeps.gh.actorTrustSignals !== undefined;
+      if (!queueTrustPolicy.enabled && !canFailClosed) return { eligible: true };
+      if (!processDeps.gh.issueTrust) return { eligible: true };
+      const provenance = await processDeps.gh.issueTrust(
+        candidate.number,
+        consultedQueue,
+      );
+      const verdict = await evaluateClaimTrust(
+        queueTrustPolicy,
+        provenance,
+        processDeps.gh.actorTrustSignals
+          ? (actor) => processDeps.gh.actorTrustSignals!(actor)
+          : async () => ({}),
+      );
+      return { eligible: verdict.executable, reason: verdict.reason };
+    },
     runBoot,
     bootDeps,
     bootOptions,

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -108,6 +108,13 @@ import {
   readHitlTypeLabels,
   readValidationResourceBudget,
 } from "./core/config.js";
+import {
+  evaluateClaimTrust,
+  parseTrustPolicy,
+  type ActorTrustLookup,
+  type TrustPolicy,
+  type TrustProvenance,
+} from "./core/trust-gate.js";
 import * as gitx from "./runtime/git.js";
 import { makeFeedbackWorktree } from "./runtime/feedback-worktree.js";
 import { runFeedback } from "./core/feedback.js";
@@ -1505,19 +1512,52 @@ function projectFields(
  * and a full body per candidate would dwarf the rest of the payload.
  */
 export function buildQueueStatus(
-  readyForAgent: readonly IssueCandidate[],
+  eligibleForAgent: readonly IssueCandidate[],
+  heldForSummon: readonly IssueCandidate[],
   readyForHuman: readonly HitlCandidate[],
 ): QueueStatusOutput {
+  const projectCandidate = ({ body: _body, author: _author, ...candidate }: IssueCandidate) => candidate;
   return {
-    ready_for_agent: readyForAgent.map(
-      ({ body: _body, ...candidate }) => candidate,
-    ),
+    ready_for_agent: {
+      eligible: eligibleForAgent.map(projectCandidate),
+      held_for_summon: heldForSummon.map(projectCandidate),
+    },
     ready_for_human: [...readyForHuman],
     counts: {
-      ready_for_agent: readyForAgent.length,
+      ready_for_agent_eligible: eligibleForAgent.length,
+      ready_for_agent_held: heldForSummon.length,
       ready_for_human: readyForHuman.length,
     },
   };
+}
+
+export async function partitionReadyForAgentByTrust(
+  candidates: readonly IssueCandidate[],
+  policy: TrustPolicy,
+  deps: {
+    issueTrust(candidate: IssueCandidate): Promise<TrustProvenance>;
+    actorTrustSignals: ActorTrustLookup;
+  },
+): Promise<{
+  eligible: IssueCandidate[];
+  heldForSummon: IssueCandidate[];
+}> {
+  const eligible: IssueCandidate[] = [];
+  const heldForSummon: IssueCandidate[] = [];
+  const gateActive = policy.enabled || policy.failClosed === true;
+  for (const candidate of candidates) {
+    if (!gateActive) {
+      eligible.push(candidate);
+      continue;
+    }
+    const verdict = await evaluateClaimTrust(
+      policy,
+      await deps.issueTrust(candidate),
+      deps.actorTrustSignals,
+    );
+    (verdict.executable ? eligible : heldForSummon).push(candidate);
+  }
+  return { eligible, heldForSummon };
 }
 
 /** Every checkout under the disposable `.red/tmp/worktrees/<lane>/` lanes, in
@@ -1883,7 +1923,17 @@ export function createCastleMcpDependencies(
         );
         readyForAgent = readyForAgent.filter((c) => matchesSelector(c, selector ?? {}));
       }
-      return buildQueueStatus(readyForAgent, readyForHuman);
+      const config = loadConfig(afkPaths(root).configPath, { warn: () => undefined });
+      const policy = parseTrustPolicy(config, await ghx.repoVisibility(gh));
+      const { eligible, heldForSummon } = await partitionReadyForAgentByTrust(
+        readyForAgent,
+        policy,
+        {
+          issueTrust: (candidate) => ghx.issueTrust(gh, candidate.number),
+          actorTrustSignals: (actor) => ghx.actorTrustSignals(gh, actor),
+        },
+      );
+      return buildQueueStatus(eligible, heldForSummon, readyForHuman);
     },
     workerDispatch: (input) => {
       if (input.issue !== undefined) {

--- a/apps/dev/tests/castle-mcp-output-contracts.test.ts
+++ b/apps/dev/tests/castle-mcp-output-contracts.test.ts
@@ -166,6 +166,15 @@ describe("dev:afk observability output contracts", () => {
       ],
       [
         {
+          number: 2062,
+          title: "bot-authored canonical ticket",
+          body: "maintainer-curated body",
+          labels: ["ready-for-agent"],
+          author: "github-actions",
+        },
+      ],
+      [
+        {
           number: 2334,
           title: "H3",
           labels: ["ready-for-human"],
@@ -175,7 +184,16 @@ describe("dev:afk observability output contracts", () => {
     );
 
     expect(queueStatusOutputSchema.parse(queue)).toEqual({
-      ready_for_agent: [{ number: 2335, title: "E1", labels: ["type:ticket"] }],
+      ready_for_agent: {
+        eligible: [{ number: 2335, title: "E1", labels: ["type:ticket"] }],
+        held_for_summon: [
+          {
+            number: 2062,
+            title: "bot-authored canonical ticket",
+            labels: ["ready-for-agent"],
+          },
+        ],
+      },
       ready_for_human: [
         {
           number: 2334,
@@ -184,7 +202,11 @@ describe("dev:afk observability output contracts", () => {
           createdAt: null,
         },
       ],
-      counts: { ready_for_agent: 1, ready_for_human: 1 },
+      counts: {
+        ready_for_agent_eligible: 1,
+        ready_for_agent_held: 1,
+        ready_for_human: 1,
+      },
     });
   });
 });

--- a/apps/dev/tests/queue-status-trust.test.ts
+++ b/apps/dev/tests/queue-status-trust.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { partitionReadyForAgentByTrust } from "../src/mcp-adapter.js";
+import type { IssueCandidate } from "../src/core/session.js";
+import type { TrustPolicy } from "../src/core/trust-gate.js";
+
+describe("queue_status trust partition", () => {
+  it("enumerates an all-non-maintainer ready queue as held, not eligible", async () => {
+    const candidates: IssueCandidate[] = [
+      {
+        number: 2062,
+        title: "bot-authored canonical ticket",
+        body: "maintainer-curated body",
+        labels: ["ready-for-agent"],
+        author: "github-actions",
+      },
+    ];
+    const policy: TrustPolicy = {
+      enabled: false,
+      allowlist: [],
+      visibility: "public",
+      failClosed: true,
+    };
+
+    const partition = await partitionReadyForAgentByTrust(candidates, policy, {
+      issueTrust: async (candidate) => ({
+        author: candidate.author,
+        readyForAgentActor: "maintainer",
+      }),
+      actorTrustSignals: async (actor) => ({
+        hasWriteAccess: actor === "maintainer",
+        inCodeowners: false,
+      }),
+    });
+
+    expect(partition.eligible).toEqual([]);
+    expect(partition.heldForSummon.map((candidate) => candidate.number)).toEqual([2062]);
+  });
+});

--- a/apps/dev/tests/resident-read-cache.test.ts
+++ b/apps/dev/tests/resident-read-cache.test.ts
@@ -85,7 +85,18 @@ function makeFakeDeps(): Pick<
   }
   return {
     callCounts,
-    queueStatus: vi.fn(async () => { count("queueStatus"); return { ready_for_agent: [], ready_for_human: [], counts: { ready_for_agent: 0, ready_for_human: 0 } }; }),
+    queueStatus: vi.fn(async () => {
+      count("queueStatus");
+      return {
+        ready_for_agent: { eligible: [], held_for_summon: [] },
+        ready_for_human: [],
+        counts: {
+          ready_for_agent_eligible: 0,
+          ready_for_agent_held: 0,
+          ready_for_human: 0,
+        },
+      };
+    }),
     claimStatus: vi.fn(async () => { count("claimStatus"); return { issue: 2370, records: [], holders: [] }; }),
     cascadeStatus: vi.fn(async () => { count("cascadeStatus"); return { issue: 2370, dependents: [], promotable: [] }; }),
     claimRelease: vi.fn(async () => { count("claimRelease"); return { issue: 2370, conceded: [] }; }),

--- a/packages/red-castle/src/engine/worker-drain.test.ts
+++ b/packages/red-castle/src/engine/worker-drain.test.ts
@@ -290,6 +290,40 @@ describe("castle worker drain", () => {
     expect(emitted).toEqual([CASTLE_NO_MORE_TASKS]);
   });
 
+  it("reports a fully trust-held queue without claiming progress", async () => {
+    const emitted: string[] = [];
+    const processIssue = vi.fn(async () => ({ outcome: "done" as const }));
+    const result = await runCastleWorkerDrain(
+      {
+        gh: { listCandidates: async () => [{ ...candidate(2062), author: "github-actions" }] },
+        classifyEligibility: async () => ({
+          eligible: false,
+          reason: "untrusted author — held for maintainer summon",
+        }),
+        runBoot: async () => boot,
+        bootDeps: {},
+        bootOptions: {},
+        processIssue,
+        processDeps,
+        buildProcessInput: (row, ctx) => ({ issue: row.number, runner: ctx.runner }),
+        emit: (line) => emitted.push(line),
+      },
+      {
+        runner: "codex",
+        workerId: "wHELD",
+        filter: { kind: "all" },
+        issueTemplate: {},
+      },
+    );
+
+    expect(processIssue).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ total: 0, heldForSummon: 1, drained: true });
+    expect(emitted).toContain(
+      "0 eligible, 1 held for summon (#2062) — release with `triage:summon`, `dev triage --summon`, or `afk.trust-gate.allowlist`",
+    );
+    expect(emitted.some((line) => line.includes("progress:") || line.includes("100%"))).toBe(false);
+  });
+
   it.each([
     {
       name: "supervisor kill before budget, lifetime, and iteration caps",

--- a/packages/red-castle/src/engine/worker-drain.ts
+++ b/packages/red-castle/src/engine/worker-drain.ts
@@ -199,6 +199,11 @@ export interface CastleWorkerProcessResult {
   reason?: string;
 }
 
+export interface CastleIssueEligibility {
+  eligible: boolean;
+  reason?: string;
+}
+
 export interface CastleWorkerDrainBudgetSnapshot {
   used: number;
   cap: number;
@@ -268,6 +273,9 @@ export interface CastleWorkerDrainSummary<TBootResult = unknown> {
   blocked: number;
   failed: number;
   total: number;
+  /** Ready-labelled issues the executable-issue trust gate excluded before the
+   * progress denominator was calculated. */
+  heldForSummon: number;
   boot: TBootResult;
   processed: CastleWorkerDrainProcessed[];
   drained: boolean;
@@ -290,6 +298,11 @@ export interface CastleWorkerDrainDeps<
   gh: {
     listCandidates(): Promise<CastleIssueCandidate[]>;
   };
+  /** Trust-aware admission preview. Absent keeps legacy all-candidates-eligible
+   * behavior for embedders that do not expose the executable-issue gate. */
+  classifyEligibility?(
+    candidate: CastleIssueCandidate,
+  ): Promise<CastleIssueEligibility>;
   runBoot(deps: TBootDeps, options: TBootOptions): Promise<TBootResult>;
   bootDeps: TBootDeps;
   bootOptions: TBootOptions;
@@ -384,6 +397,7 @@ export async function runCastleWorkerDrain<
     blocked: 0,
     failed: 0,
     total: 0,
+    heldForSummon: 0,
     boot,
     processed: [],
     drained: false,
@@ -410,21 +424,43 @@ export async function runCastleWorkerDrain<
     await fireSessionHook("pre_pick", JSON.stringify({ filter: ctx.filter }));
     const candidates = await deps.gh.listCandidates();
     const quarantined = new Set(boot.quarantinedIssues ?? []);
-    const queue = selectCastleIssues(
+    const selected = selectCastleIssues(
       candidates.filter((candidate) => !quarantined.has(candidate.number)),
       ctx.filter,
       deps.labels,
       ctx.poolLabel,
       ctx.declaredLane,
     );
+    const queue: CastleIssueCandidate[] = [];
+    const held: CastleIssueCandidate[] = [];
+    for (const candidate of selected) {
+      const eligibility = deps.classifyEligibility
+        ? await deps.classifyEligibility(candidate)
+        : { eligible: true };
+      (eligibility.eligible ? queue : held).push(candidate);
+    }
     const total = queue.length;
     await fireSessionHook("post_pick", JSON.stringify({ issues: queue.map((candidate) => candidate.number) }));
+
+    if (held.length > 0) {
+      const issues = held.map((candidate) => `#${candidate.number}`).join(", ");
+      deps.emit(
+        `${total} eligible, ${held.length} held for summon (${issues}) — ` +
+          "release with `triage:summon`, `dev triage --summon`, or `afk.trust-gate.allowlist`",
+      );
+    }
 
     if (total === 0) {
       await fireSessionHook("on_idle", statsContext(0, 0, 0));
       deps.emit(CASTLE_NO_MORE_TASKS);
       await fireSessionHook("post_session", statsContext(0, 0, 0));
-      return { ...empty, total: 0, drained: true, stopReason: "drain-empty" };
+      return {
+        ...empty,
+        total: 0,
+        heldForSummon: held.length,
+        drained: true,
+        stopReason: "drain-empty",
+      };
     }
 
     const cap = ctx.iterCap && ctx.iterCap > 0 ? ctx.iterCap : total;
@@ -539,6 +575,7 @@ export async function runCastleWorkerDrain<
       blocked,
       failed,
       total,
+      heldForSummon: held.length,
       boot,
       processed,
       drained: false,

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -60,9 +60,13 @@ function deps(): CastleMcpDependencies {
     monitor: vi.fn(async () => ({ workers: [], events: [], fleet: null })),
     history: vi.fn(async () => []),
     queueStatus: vi.fn(async () => ({
-      ready_for_agent: [],
+      ready_for_agent: { eligible: [], held_for_summon: [] },
       ready_for_human: [],
-      counts: { ready_for_agent: 0, ready_for_human: 0 },
+      counts: {
+        ready_for_agent_eligible: 0,
+        ready_for_agent_held: 0,
+        ready_for_human: 0,
+      },
     })),
     deadendAudit: vi.fn(async () => ({ total: 0, classes: [] })),
     eventsSince: vi.fn(async (input) => {

--- a/packages/red-castle/src/mcp/contracts.test.ts
+++ b/packages/red-castle/src/mcp/contracts.test.ts
@@ -91,7 +91,7 @@ describe("observability output contracts", () => {
     const [wrapped] = applyOutputContracts([tool(drifted)]);
 
     await expect(wrapped!.invoke({})).rejects.toThrow(
-      /project_status output violates contract 1\.0\.0: slots\.total/,
+      /project_status output violates contract 2\.0\.0: slots\.total/,
     );
   });
 
@@ -128,7 +128,7 @@ describe("observability output contracts", () => {
     const [wrapped] = applyOutputContracts([drifted]);
 
     await expect(wrapped!.invoke({ fields: ["live"] })).rejects.toThrow(
-      /worker_vitals output violates contract 1\.0\.0: 0\.live/,
+      /worker_vitals output violates contract 2\.0\.0: 0\.live/,
     );
   });
 
@@ -152,11 +152,16 @@ describe("observability output contracts", () => {
       workerVitals: vi.fn(async () => []),
       monitor: vi.fn(async () => ({ workers: [], events: [], fleet: null })),
       queueStatus: vi.fn(async () => ({
-        ready_for_agent: [
-          { number: 2335, title: "E1", labels: ["type:ticket"] },
-        ],
+        ready_for_agent: {
+          eligible: [{ number: 2335, title: "E1", labels: ["type:ticket"] }],
+          held_for_summon: [],
+        },
         ready_for_human: [],
-        counts: { ready_for_agent: 1, ready_for_human: 0 },
+        counts: {
+          ready_for_agent_eligible: 1,
+          ready_for_agent_held: 0,
+          ready_for_human: 0,
+        },
       })),
     } as unknown as CastleMcpDependencies;
     const tools = createCastleMcpTools(deps);

--- a/packages/red-castle/src/mcp/contracts.ts
+++ b/packages/red-castle/src/mcp/contracts.ts
@@ -7,7 +7,7 @@ import type { CastleMcpTool } from "./tool.js";
  * string to detect a breaking change. Adding an OPTIONAL field is additive and
  * keeps the version.
  */
-export const CASTLE_MCP_CONTRACT_VERSION = "1.0.0";
+export const CASTLE_MCP_CONTRACT_VERSION = "2.0.0";
 
 /**
  * One tool's declared output shape plus the version that shape belongs to.
@@ -336,14 +336,17 @@ export type MonitorOutput = z.infer<typeof monitorOutputSchema>;
 // queue_status
 // ---------------------------------------------------------------------------
 
+const queueIssueSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  labels: z.array(z.string()),
+});
+
 export const queueStatusOutputSchema = z.object({
-  ready_for_agent: z.array(
-    z.object({
-      number: z.number(),
-      title: z.string(),
-      labels: z.array(z.string()),
-    }),
-  ),
+  ready_for_agent: z.object({
+    eligible: z.array(queueIssueSchema),
+    held_for_summon: z.array(queueIssueSchema),
+  }),
   ready_for_human: z.array(
     z.object({
       number: z.number(),
@@ -354,7 +357,8 @@ export const queueStatusOutputSchema = z.object({
     }),
   ),
   counts: z.object({
-    ready_for_agent: z.number(),
+    ready_for_agent_eligible: z.number(),
+    ready_for_agent_held: z.number(),
     ready_for_human: z.number(),
   }),
 });

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -226,12 +226,15 @@ state survives resident restarts in `.red/state/castle/merge-driver.toon`.
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `queue_status` | read | `ready-for-agent` and `ready-for-human` queue candidates. Optional `selector` previews one fleet's scoped view (same facets as fleet selectors, e.g. `tags`/`user`). |
+| `queue_status` | read | Trust-partitioned `ready-for-agent` candidates (`eligible` and `held_for_summon`) plus `ready-for-human`. Optional `selector` previews one fleet's scoped view (same facets as fleet selectors, e.g. `tags`/`user`). |
 | `events_since` | read | Castle history events and worker lane records after an opaque cursor, plus the next cursor. |
 | `deadend_audit` | read | Every stuck AFK pattern with its recommended cure: dangling claims, red PRs with dead owners, superseded PRs, executable Tickets carrying an active Current blocker, dependency blocks whose `req:*` targets all closed, human-queue age outliers, and stale worktrees. Cache-backed — repeated calls within the refresh window cost zero GitHub quota. Detection only. |
 
-`queue_status` is the first call of any drain: an empty `ready-for-agent` queue
-with a non-empty open backlog is a flow bug to census, not a clean stop.
+`queue_status` is the first call of any drain: zero eligible `ready-for-agent`
+entries with a non-empty open backlog is a flow bug to census, not a clean stop.
+That rule includes a non-empty queue whose every entry is `held_for_summon`;
+release it with `triage:summon`, `dev triage --summon`, or
+`afk.trust-gate.allowlist`.
 
 `deadend_audit` is the census surface for that flow bug: it names each stuck
 pattern and the cure to apply, without mutating anything. The resident cron

--- a/packaging/pi/dev/skills/engineering/afk/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/afk/SKILL.md
@@ -168,9 +168,11 @@ Read the focused reference before touching that concern:
 - The `castle` MCP is the canonical castle interface (ADR 0120). `/afk` is a
   client of it, so a capability missing from the tools is a gap to file against
   the MCP, never a reason to hand-roll the operation in shell.
-- Tracked work belongs in `/afk`. An empty `ready-for-agent` queue with a
-  non-empty open backlog is a flow bug to surface with a gate census, not a
-  clean "nothing to do" stop.
+- Tracked work belongs in `/afk`. A queue with zero eligible `ready-for-agent`
+  entries and a non-empty open backlog is a flow bug to surface with a gate
+  census, not a clean "nothing to do" stop. This includes a non-empty queue
+  whose entries are all `held_for_summon`; release those with `triage:summon`,
+  `dev triage --summon`, or `afk.trust-gate.allowlist`.
 - Dependencies use `req:N` edge labels plus `blocked:dependency`; human gates
   use `## Current blocker` / `ready-for-human`.
 - Worktrees live under `.red/tmp/workers/{id}/{N}-a{n}/worktree`; the worker
@@ -206,8 +208,9 @@ rather than as competing loops. Choose the width by disjointness; read
 
 ## Stop Conditions
 
-- Queue drained -> `<promise>NO MORE TASKS</promise>` and exit 0, with a gate
-  census when open non-Spec issues remain.
+- Eligible queue drained -> `<promise>NO MORE TASKS</promise>` and exit 0, with
+  a gate census when open non-Spec issues remain, including ready-labelled
+  issues held for maintainer summon.
 - `-n N` reached -> summary and exit 0.
 - Runner exhaustion or transient runner failure -> bounded recovery for the
   current issue, then outer exit 75.

--- a/packaging/pi/dev/skills/engineering/afk/monitor.md
+++ b/packaging/pi/dev/skills/engineering/afk/monitor.md
@@ -18,8 +18,10 @@ command renders the same truth for a human terminal. See [`MCP.md`](./MCP.md).
 | What happened over the last N days? | `dashboard` (`periodDays`), `history` |
 | What did one lane actually record? | `logs` |
 
-`queue_status` is the census tool: an empty `ready-for-agent` queue with a
-non-empty open backlog is a flow bug to diagnose, never a clean stop.
+`queue_status` is the census tool: zero eligible `ready-for-agent` entries with
+a non-empty open backlog is a flow bug to diagnose, never a clean stop. A
+non-empty `held_for_summon` bucket is still zero drainable work; release it with
+`triage:summon`, `dev triage --summon`, or `afk.trust-gate.allowlist`.
 
 ## The binding mirror rule (authoritative — stated once)
 

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -226,12 +226,15 @@ state survives resident restarts in `.red/state/castle/merge-driver.toon`.
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `queue_status` | read | `ready-for-agent` and `ready-for-human` queue candidates. Optional `selector` previews one fleet's scoped view (same facets as fleet selectors, e.g. `tags`/`user`). |
+| `queue_status` | read | Trust-partitioned `ready-for-agent` candidates (`eligible` and `held_for_summon`) plus `ready-for-human`. Optional `selector` previews one fleet's scoped view (same facets as fleet selectors, e.g. `tags`/`user`). |
 | `events_since` | read | Castle history events and worker lane records after an opaque cursor, plus the next cursor. |
 | `deadend_audit` | read | Every stuck AFK pattern with its recommended cure: dangling claims, red PRs with dead owners, superseded PRs, executable Tickets carrying an active Current blocker, dependency blocks whose `req:*` targets all closed, human-queue age outliers, and stale worktrees. Cache-backed — repeated calls within the refresh window cost zero GitHub quota. Detection only. |
 
-`queue_status` is the first call of any drain: an empty `ready-for-agent` queue
-with a non-empty open backlog is a flow bug to census, not a clean stop.
+`queue_status` is the first call of any drain: zero eligible `ready-for-agent`
+entries with a non-empty open backlog is a flow bug to census, not a clean stop.
+That rule includes a non-empty queue whose every entry is `held_for_summon`;
+release it with `triage:summon`, `dev triage --summon`, or
+`afk.trust-gate.allowlist`.
 
 `deadend_audit` is the census surface for that flow bug: it names each stuck
 pattern and the cure to apply, without mutating anything. The resident cron

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -168,9 +168,11 @@ Read the focused reference before touching that concern:
 - The `castle` MCP is the canonical castle interface (ADR 0120). `/afk` is a
   client of it, so a capability missing from the tools is a gap to file against
   the MCP, never a reason to hand-roll the operation in shell.
-- Tracked work belongs in `/afk`. An empty `ready-for-agent` queue with a
-  non-empty open backlog is a flow bug to surface with a gate census, not a
-  clean "nothing to do" stop.
+- Tracked work belongs in `/afk`. A queue with zero eligible `ready-for-agent`
+  entries and a non-empty open backlog is a flow bug to surface with a gate
+  census, not a clean "nothing to do" stop. This includes a non-empty queue
+  whose entries are all `held_for_summon`; release those with `triage:summon`,
+  `dev triage --summon`, or `afk.trust-gate.allowlist`.
 - Dependencies use `req:N` edge labels plus `blocked:dependency`; human gates
   use `## Current blocker` / `ready-for-human`.
 - Worktrees live under `.red/tmp/workers/{id}/{N}-a{n}/worktree`; the worker
@@ -206,8 +208,9 @@ rather than as competing loops. Choose the width by disjointness; read
 
 ## Stop Conditions
 
-- Queue drained -> `<promise>NO MORE TASKS</promise>` and exit 0, with a gate
-  census when open non-Spec issues remain.
+- Eligible queue drained -> `<promise>NO MORE TASKS</promise>` and exit 0, with
+  a gate census when open non-Spec issues remain, including ready-labelled
+  issues held for maintainer summon.
 - `-n N` reached -> summary and exit 0.
 - Runner exhaustion or transient runner failure -> bounded recovery for the
   current issue, then outer exit 75.

--- a/plugins/dev/skills/engineering/afk/monitor.md
+++ b/plugins/dev/skills/engineering/afk/monitor.md
@@ -18,8 +18,10 @@ command renders the same truth for a human terminal. See [`MCP.md`](./MCP.md).
 | What happened over the last N days? | `dashboard` (`periodDays`), `history` |
 | What did one lane actually record? | `logs` |
 
-`queue_status` is the census tool: an empty `ready-for-agent` queue with a
-non-empty open backlog is a flow bug to diagnose, never a clean stop.
+`queue_status` is the census tool: zero eligible `ready-for-agent` entries with
+a non-empty open backlog is a flow bug to diagnose, never a clean stop. A
+non-empty `held_for_summon` bucket is still zero drainable work; release it with
+`triage:summon`, `dev triage --summon`, or `afk.trust-gate.allowlist`.
 
 ## The binding mirror rule (authoritative — stated once)
 


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3181 -->
🤖 **Re-seed trail** — #3181 on `afk/3181-queue-status-counts-a-trust-gate-held-is`, lane `/afk`.

Rounds spent: 6/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3181; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE, but the base gained 5 commits under this attempt, including a release version bump; the gate ran on a tree merged with that newer base, so the failure is attributed to stale-base drift, not the branch; granting a free stale-base correction (1/2), budget untouched at 1/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE, but the base gained 5 commits under this attempt, including a release version bump; the gate ran on a tree merged with that newer base, so the failure is attributed to stale-base drift, not the branch; granting a free stale-base correction (2/2), budget untouched at 1/3. |
| 5/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 6/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3181 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/dev`, `packages/red-castle`]
{"schema":"red.afk.validation.v1","name":"test:apps/dev","status":"failed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3181-queue-status-counts-a-trust-gate-held-is/apps/dev test","exitCode":1,"durationMs":544,"summary":"suspect-infra: `pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3181-queue-status-counts-a-trust-gate-held-is/apps/dev test` exited 1 after 544ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. failing: FAIL tests/pi-package-builder.test.ts > Pi package builder > matches the builder output for the repo's committed plugin manifests (subprocess smoke) — -  \"description\": \"hand-edited drift\", +  \"description\": \"Dev.\",    \"license\": \"Apache-2.0\",    \"homepage\": \"https://github.com/reddb-io/red-skills\",    \"repository\": {  stderr | tests/go-dispatch-detached.test.ts > a /go dispatch hands the work to the host instead of running it > refuses the dispatch when the host grants no worker, and starts nothing ✗ /go --scout dispatch failed: redskilled is not reachable on this socket  ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯   FAIL  tests/pi-package-builder.test.ts > Pi package builder > matches the builder output for the repo's committed plugin manifests (subprocess smoke) Error: Command failed: node [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3181-queue-status-counts-a-trust-gate-held-is/scripts/build-pi-packages.mjs --root [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/","suspectInfra":true}
{"schema":"red.afk.validation.v1","name":"test:packages/red-castle","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3181-queue-status-counts-a-trust-gate-held-is/packages/red-castle test","exitCode":0,"durationMs":34,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"typecheck:apps/dev","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3181-queue-status-counts-a-trust-gate-held-is/apps/dev typecheck","exitCode":0,"durationMs":13,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"typecheck:packages/red-castle","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3181-queue-status-counts-a-trust-gate-held-is/packages/red-castle typecheck","exitCode":0,"durationMs":2,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"lint:apps/dev","status":"skipped","summary":"script missing"}
{"schema":"red.afk.validation.v1","name":"lint:packages/red-castle","status":"skipped","summary":"script missing"}
{"schema":"red.afk.validation.v1","name":"build:apps/dev","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3181-queue-status-counts-a-trust-gate-held-is/apps/dev build","exitCode":0,"durationMs":3,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"build:packages/red-castle","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3181-queue-status-counts-a-trust-gate-held-is/packages/red-castle build","exitCode":0,"durationMs":9,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"typecheck:workspace","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3181-queue-status-counts-a-trust-gate-held-is typecheck","exitCode":0,"durationMs":1,"summary":"command exited 0"}
🤖 classification override: the `on_feedback_classify` hook set the feedback failure to `semantic` (the classifier read it as `semantic`).
```

Closes #3181