### PR TITLE
fix: #3206 The routing table cannot express volatility, so it cannot see the one thing that makes a read free

### DIFF
--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -28,6 +28,7 @@ export {
   type GithubOperation,
   type GithubOperationKind,
   type GithubRateBudget,
+  type GithubReadVolatility,
 } from "./surface.js";
 
 export {

--- a/packages/github/surface.test.ts
+++ b/packages/github/surface.test.ts
@@ -10,6 +10,7 @@ import {
   surfaceForCardinality,
   tryRouteGithubArgs,
   type GithubOperation,
+  type GithubReadVolatility,
 } from "./surface.js";
 
 /**
@@ -18,44 +19,62 @@ import {
  * call runs on stopped being an emergent property of a default and became a
  * declared fact somebody has to edit on purpose.
  */
-const PINNED: ReadonlyArray<[key: string, kind: string, cardinality: string, surface: string, budget: string]> = [
-  ["issue view", "read", "single-object", "rest", "rest"],
-  ["pr view", "read", "single-object", "rest", "rest"],
-  ["repo view", "read", "single-object", "rest", "rest"],
-  ["run view", "read", "single-object", "rest", "rest"],
-  ["release view", "read", "single-object", "rest", "rest"],
-  ["pr diff", "read", "single-object", "rest", "rest"],
-  ["issue list", "read", "multi-node", "graphql", "graphql"],
-  ["pr list", "read", "multi-node", "graphql", "graphql"],
-  ["pr checks", "read", "multi-node", "graphql", "graphql"],
-  ["release list", "read", "multi-node", "rest", "rest"],
-  ["run list", "read", "multi-node", "rest", "rest"],
-  ["label list", "read", "multi-node", "graphql", "graphql"],
-  ["issue list (search)", "read", "multi-node", "graphql", "search"],
-  ["pr list (search)", "read", "multi-node", "graphql", "search"],
-  ["search issues", "read", "multi-repository", "rest", "search"],
-  ["search prs", "read", "multi-repository", "rest", "search"],
-  ["search repos", "read", "multi-repository", "rest", "search"],
-  ["api graphql", "read", "multi-node", "graphql", "graphql"],
-  ["api rest", "read", "single-object", "rest", "rest"],
-  ["issue create", "write", "single-object", "graphql", "graphql"],
-  ["issue edit", "write", "single-object", "graphql", "graphql"],
-  ["issue close", "write", "single-object", "graphql", "graphql"],
-  ["issue reopen", "write", "single-object", "graphql", "graphql"],
-  ["issue comment", "write", "single-object", "rest", "rest"],
-  ["issue develop", "write", "single-object", "graphql", "graphql"],
-  ["pr create", "write", "single-object", "rest", "rest"],
-  ["pr comment", "write", "single-object", "rest", "rest"],
-  ["pr merge", "write", "single-object", "graphql", "graphql"],
-  ["pr close", "write", "single-object", "graphql", "graphql"],
-  ["pr edit", "write", "single-object", "graphql", "graphql"],
-  ["pr ready", "write", "single-object", "graphql", "graphql"],
-  ["pr update-branch", "write", "single-object", "rest", "rest"],
-  ["label create", "write", "single-object", "rest", "rest"],
+const PINNED: ReadonlyArray<
+  [
+    key: string,
+    kind: string,
+    cardinality: string,
+    volatility: GithubReadVolatility | undefined,
+    surface: string,
+    budget: string,
+  ]
+> = [
+  ["issue view", "read", "single-object", "stable-poll", "rest", "rest"],
+  ["pr view", "read", "single-object", "stable-poll", "rest", "rest"],
+  ["repo view", "read", "single-object", "stable-poll", "rest", "rest"],
+  ["run view", "read", "single-object", "stable-poll", "rest", "rest"],
+  ["release view", "read", "single-object", "stable-poll", "rest", "rest"],
+  ["pr diff", "read", "single-object", "one-shot", "rest", "rest"],
+  ["issue list", "read", "multi-node", "stable-poll", "graphql", "graphql"],
+  ["pr list", "read", "multi-node", "stable-poll", "graphql", "graphql"],
+  ["pr checks", "read", "multi-node", "stable-poll", "graphql", "graphql"],
+  ["release list", "read", "multi-node", "stable-poll", "rest", "rest"],
+  ["run list", "read", "multi-node", "stable-poll", "rest", "rest"],
+  ["label list", "read", "multi-node", "one-shot", "graphql", "graphql"],
+  ["issue list (search)", "read", "multi-node", "stable-poll", "graphql", "search"],
+  ["pr list (search)", "read", "multi-node", "stable-poll", "graphql", "search"],
+  ["search issues", "read", "multi-repository", "one-shot", "rest", "search"],
+  ["search prs", "read", "multi-repository", "one-shot", "rest", "search"],
+  ["search repos", "read", "multi-repository", "one-shot", "rest", "search"],
+  ["api graphql", "read", "multi-node", "one-shot", "graphql", "graphql"],
+  ["api rest", "read", "single-object", "one-shot", "rest", "rest"],
+  ["issue create", "write", "single-object", undefined, "graphql", "graphql"],
+  ["issue edit", "write", "single-object", undefined, "graphql", "graphql"],
+  ["issue close", "write", "single-object", undefined, "graphql", "graphql"],
+  ["issue reopen", "write", "single-object", undefined, "graphql", "graphql"],
+  ["issue comment", "write", "single-object", undefined, "rest", "rest"],
+  ["issue develop", "write", "single-object", undefined, "graphql", "graphql"],
+  ["pr create", "write", "single-object", undefined, "rest", "rest"],
+  ["pr comment", "write", "single-object", undefined, "rest", "rest"],
+  ["pr merge", "write", "single-object", undefined, "graphql", "graphql"],
+  ["pr close", "write", "single-object", undefined, "graphql", "graphql"],
+  ["pr edit", "write", "single-object", undefined, "graphql", "graphql"],
+  ["pr ready", "write", "single-object", undefined, "graphql", "graphql"],
+  ["pr update-branch", "write", "single-object", undefined, "rest", "rest"],
+  ["label create", "write", "single-object", undefined, "rest", "rest"],
 ];
 
-function row(operation: GithubOperation): [string, string, string, string, string] {
-  return [operation.key, operation.kind, operation.cardinality, operation.surface, operation.budget];
+function row(
+  operation: GithubOperation,
+): [string, string, string, GithubReadVolatility | undefined, string, string] {
+  return [
+    operation.key,
+    operation.kind,
+    operation.cardinality,
+    operation.volatility,
+    operation.surface,
+    operation.budget,
+  ];
 }
 
 describe("the routing table", () => {
@@ -91,6 +110,7 @@ describe("the routing table", () => {
         key: "issue view",
         kind: "read",
         cardinality: "single-object",
+        volatility: "one-shot",
         surface: "graphql",
         budget: "graphql",
         why: "a single object sent to the node-point pool",
@@ -101,11 +121,26 @@ describe("the routing table", () => {
     ]);
   });
 
+  it("catches a read whose volatility is undeclared", () => {
+    const problems = assertGithubRoutingTable([
+      {
+        key: "issue view",
+        kind: "read",
+        cardinality: "single-object",
+        surface: "rest",
+        budget: "rest",
+        why: "one issue",
+      },
+    ]);
+    expect(problems).toEqual(["issue view states no volatility"]);
+  });
+
   it("catches a duplicate key", () => {
     const entry: GithubOperation = {
       key: "issue view",
       kind: "read",
       cardinality: "single-object",
+      volatility: "one-shot",
       surface: "rest",
       budget: "rest",
       why: "one issue",

--- a/packages/github/surface.ts
+++ b/packages/github/surface.ts
@@ -41,6 +41,14 @@ export type GithubRateBudget = "rest" | "graphql" | "search";
  */
 export type GithubCardinality = "single-object" | "multi-node" | "multi-repository";
 
+/**
+ * Whether a read is repeated against usually-stable data or made once.
+ *
+ * A stable poll can later exploit REST conditional requests: an unchanged
+ * answer costs no rate-limit request, while GraphQL charges every query.
+ */
+export type GithubReadVolatility = "stable-poll" | "one-shot";
+
 /** Whether the operation observes state or changes it. */
 export type GithubOperationKind = "read" | "write";
 
@@ -50,6 +58,8 @@ export interface GithubOperation {
   readonly key: string;
   readonly kind: GithubOperationKind;
   readonly cardinality: GithubCardinality;
+  /** Required for reads; omitted for writes, whose surface is observed. */
+  readonly volatility?: GithubReadVolatility;
   /**
    * The API that answers this operation.
    *
@@ -87,6 +97,7 @@ export function surfaceForCardinality(cardinality: GithubCardinality): GithubApi
 function read(
   key: string,
   cardinality: GithubCardinality,
+  volatility: GithubReadVolatility,
   budget: GithubRateBudget,
   why: string,
   only?: GithubApiSurface,
@@ -95,6 +106,7 @@ function read(
     key,
     kind: "read",
     cardinality,
+    volatility,
     surface: only ?? surfaceForCardinality(cardinality),
     budget,
     ...(only ? { only } : {}),
@@ -120,31 +132,31 @@ function write(
  */
 export const GITHUB_OPERATIONS: readonly GithubOperation[] = [
   // ── single-object reads: the hot path, and the whole reason this module exists
-  read("issue view", "single-object", "rest", "one issue by number; REST answers it in one request against the idle pool"),
-  read("pr view", "single-object", "rest", "one pull request by number, polled per Worker per iteration"),
-  read("repo view", "single-object", "rest", "one repository's own metadata"),
-  read("run view", "single-object", "rest", "one Actions run; the Actions API has no GraphQL surface either way"),
-  read("release view", "single-object", "rest", "one release by tag"),
-  read("pr diff", "single-object", "rest", "one pull request's diff, served by a REST media type"),
+  read("issue view", "single-object", "stable-poll", "rest", "one issue by number, repeatedly polled while usually unchanged; REST answers in one request"),
+  read("pr view", "single-object", "stable-poll", "rest", "one pull request by number, polled per Worker per iteration"),
+  read("repo view", "single-object", "stable-poll", "rest", "one repository's own metadata, repeatedly read while usually unchanged"),
+  read("run view", "single-object", "stable-poll", "rest", "one Actions run repeatedly polled to terminal; Actions has no GraphQL surface"),
+  read("release view", "single-object", "stable-poll", "rest", "one release by tag, repeatedly checked while usually absent or unchanged"),
+  read("pr diff", "single-object", "one-shot", "rest", "one pull request's diff, read once for review and served by a REST media type"),
 
   // ── multi-node listings: a connection inside one repository
-  read("issue list", "multi-node", "graphql", "a connection of issues; one GraphQL query beats N REST pages"),
-  read("pr list", "multi-node", "graphql", "a connection of pull requests; one GraphQL query beats N REST pages"),
-  read("pr checks", "multi-node", "graphql", "every check context on one commit, which is a connection, not an object"),
-  read("release list", "multi-node", "rest", "Releases have no GraphQL connection gh reads; REST pages them", "rest"),
-  read("run list", "multi-node", "rest", "the Actions API has no GraphQL surface, so a listing draws the request pool", "rest"),
-  read("label list", "multi-node", "graphql", "a connection of labels inside one repository"),
+  read("issue list", "multi-node", "stable-poll", "graphql", "a repeatedly polled, usually-unchanged issue connection; GraphQL avoids N REST pages"),
+  read("pr list", "multi-node", "stable-poll", "graphql", "a repeatedly polled, usually-unchanged pull-request connection; GraphQL avoids N REST pages"),
+  read("pr checks", "multi-node", "stable-poll", "graphql", "check contexts form a connection repeatedly polled while awaiting terminal state"),
+  read("release list", "multi-node", "stable-poll", "rest", "release waits poll a usually-unchanged list; Releases has no GraphQL connection gh reads", "rest"),
+  read("run list", "multi-node", "stable-poll", "rest", "run waits poll a usually-unchanged list; Actions has no GraphQL surface", "rest"),
+  read("label list", "multi-node", "one-shot", "graphql", "a label connection loaded once for the current operation"),
 
   // ── search: a third pool, metered by the minute
-  read("issue list (search)", "multi-node", "search", "`--search` routes the listing through the search connection, metered 30/min"),
-  read("pr list (search)", "multi-node", "search", "`--search` routes the listing through the search connection, metered 30/min"),
-  read("search issues", "multi-repository", "search", "gh's `search` drives the REST search endpoints, metered 30/min", "rest"),
-  read("search prs", "multi-repository", "search", "gh's `search` drives the REST search endpoints, metered 30/min", "rest"),
-  read("search repos", "multi-repository", "search", "gh's `search` drives the REST search endpoints, metered 30/min", "rest"),
+  read("issue list (search)", "multi-node", "stable-poll", "search", "queue discovery polls usually-unchanged search results through the 30/min search connection"),
+  read("pr list (search)", "multi-node", "stable-poll", "search", "PR discovery polls usually-unchanged search results through the 30/min search connection"),
+  read("search issues", "multi-repository", "one-shot", "search", "a one-shot cross-repository read through the REST search endpoint, metered 30/min", "rest"),
+  read("search prs", "multi-repository", "one-shot", "search", "a one-shot cross-repository read through the REST search endpoint, metered 30/min", "rest"),
+  read("search repos", "multi-repository", "one-shot", "search", "a one-shot cross-repository read through the REST search endpoint, metered 30/min", "rest"),
 
   // ── the raw API escape hatches: the caller has already chosen
-  read("api graphql", "multi-node", "graphql", "the caller wrote the query; `gh api graphql` is GraphQL by construction"),
-  read("api rest", "single-object", "rest", "any `gh api <path>` that is not `graphql` is a REST request"),
+  read("api graphql", "multi-node", "one-shot", "graphql", "the caller supplies one explicit GraphQL query rather than a routed poll"),
+  read("api rest", "single-object", "one-shot", "rest", "the caller supplies one explicit REST path rather than a routed poll"),
 
   // ── writes: the surface is gh's, observed rather than chosen
   write("issue create", "graphql", "graphql", "gh files an issue with the createIssue mutation — an exhausted GraphQL pool blocks filing"),
@@ -266,6 +278,7 @@ export function assertGithubRoutingTable(
     seen.add(operation.key);
     if (operation.why.trim() === "") problems.push(`${operation.key} states no reason`);
     if (operation.kind !== "read") continue;
+    if (operation.volatility === undefined) problems.push(`${operation.key} states no volatility`);
     const implied = operation.only ?? surfaceForCardinality(operation.cardinality);
     if (operation.surface !== implied) {
       problems.push(


### PR DESCRIPTION
Automated AFK landing for #3206. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3206

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788389979&installation_model_id=20659&pr_number=3226&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3226&signature=e86edf3061e39a5fbbe5ec9d09e2e81e21c27e019038d91698e6ff9b92a83350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->