### PR TITLE
merge: #3205 Nothing reports WHO spent the GitHub budget, so every routing proposal argues about an unattributed number

### DIFF
--- a/apps/rsp/tests/telemetry-resident.test.ts
+++ b/apps/rsp/tests/telemetry-resident.test.ts
@@ -90,7 +90,6 @@ describe("rsp telemetry spool", () => {
   it("pipes a real Codex PreToolUse payload through the built bundle and drains a decision event", async () => {
     const root = await tempRoot();
     const bundle = await ensureRspBundle();
-    const env = await envWithRsp(root);
     const payload = {
       cwd: root,
       tool_name: "bash",
@@ -99,7 +98,7 @@ describe("rsp telemetry spool", () => {
 
     const hook = spawnSync(process.execPath, [bundle, "hook", "codex-pre-exec"], {
       cwd: root,
-      env,
+      env: await rspBundleEnv(root, bundle),
       input: Buffer.from(JSON.stringify(payload)),
       encoding: "buffer",
     });
@@ -108,7 +107,7 @@ describe("rsp telemetry spool", () => {
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "allow",
-        updatedInput: { command: `${process.execPath} ${bundle} proxy -- 'git status'` },
+        updatedInput: { command: "rsp proxy -- 'git status'" },
       },
     });
 
@@ -156,7 +155,6 @@ describe("rsp telemetry spool", () => {
     const root = await tempRoot();
     await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: true\n", "utf8");
     const bundle = await ensureRspBundle();
-    const env = await envWithRsp(root);
     const command = "printf 'out\\n'; printf 'err\\n' >&2";
     const payload = {
       cwd: root,
@@ -166,7 +164,7 @@ describe("rsp telemetry spool", () => {
 
     const hook = spawnSync(process.execPath, [bundle, "hook", "codex-pre-exec"], {
       cwd: root,
-      env,
+      env: await rspBundleEnv(root, bundle),
       input: Buffer.from(JSON.stringify(payload)),
       encoding: "buffer",
     });
@@ -174,9 +172,7 @@ describe("rsp telemetry spool", () => {
     const updated = JSON.parse(hook.stdout.toString("utf8")) as {
       hookSpecificOutput: { updatedInput: { command: string } };
     };
-    expect(updated.hookSpecificOutput.updatedInput.command).toBe(
-      `${process.execPath} ${bundle} proxy -- 'printf '\\''out\\n'\\''; printf '\\''err\\n'\\'' >&2'`,
-    );
+    expect(updated.hookSpecificOutput.updatedInput.command).toBe("rsp proxy -- 'printf '\\''out\\n'\\''; printf '\\''err\\n'\\'' >&2'");
 
     const raw = spawnSync(command, { cwd: root, shell: true, encoding: "buffer" });
     const proxied = spawnSync(process.execPath, [bundle, "proxy", "--", command], {
@@ -620,11 +616,11 @@ describe("rsp telemetry spool", () => {
   });
 });
 
-async function envWithRsp(root: string): Promise<NodeJS.ProcessEnv> {
-  const binDir = join(root, "bin");
-  const rsp = join(binDir, "rsp");
-  await mkdir(binDir, { recursive: true });
-  await writeFile(rsp, "#!/bin/sh\nexit 0\n", "utf8");
+async function rspBundleEnv(root: string, bundle: string): Promise<NodeJS.ProcessEnv> {
+  const bin = join(root, "bin");
+  const rsp = join(bin, "rsp");
+  await mkdir(bin, { recursive: true });
+  await writeFile(rsp, `#!/usr/bin/env bash\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(bundle)} "$@"\n`, "utf8");
   await chmod(rsp, 0o755);
-  return { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` };
+  return { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` };
 }

--- a/packages/github/attribution.test.ts
+++ b/packages/github/attribution.test.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createGithubAttributionLedger } from "./attribution.js";
+import { routeGithubArgs } from "./surface.js";
+
+const HOUR_START = "2026-08-03T12:00:00.000Z";
+const HOUR_END = "2026-08-03T13:00:00.000Z";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+async function ledgerPath(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "github-attribution-"));
+  temporaryDirectories.push(directory);
+  return join(directory, "spend.jsonl");
+}
+
+describe("the GitHub spend attribution ledger", () => {
+  it("answers what spent the GraphQL pool in a window after a process restart", async () => {
+    const path = await ledgerPath();
+    const firstProcess = createGithubAttributionLedger({ path });
+
+    await firstProcess.record({
+      operation: routeGithubArgs(["pr", "list"]),
+      cost: 7,
+      observedAt: "2026-08-03T12:10:00.000Z",
+    });
+    await firstProcess.record({
+      operation: routeGithubArgs(["pr", "list"]),
+      cost: 5,
+      observedAt: "2026-08-03T12:20:00.000Z",
+    });
+    await firstProcess.record({
+      operation: routeGithubArgs(["issue", "list"]),
+      cost: 3,
+      observedAt: "2026-08-03T12:30:00.000Z",
+    });
+    await firstProcess.record({
+      operation: routeGithubArgs(["issue", "view", "42"]),
+      cost: 1,
+      observedAt: "2026-08-03T12:40:00.000Z",
+    });
+    await firstProcess.record({
+      operation: routeGithubArgs(["pr", "list"]),
+      cost: 99,
+      observedAt: "2026-08-03T11:59:59.999Z",
+    });
+
+    const persisted = await readFile(path, "utf8");
+    expect(persisted).toMatch(/^\[\]/);
+    expect(persisted).not.toContain('{"version":1');
+
+    // A new ledger instance models a restarted process: the answer must come
+    // from durable observations, not from counters held by the first instance.
+    const restartedProcess = createGithubAttributionLedger({ path });
+    const report = await restartedProcess.report({
+      from: HOUR_START,
+      to: HOUR_END,
+      pool: "graphql",
+    });
+
+    expect(report.origin).toBe("process-attribution");
+    expect(report.window).toEqual({ from: HOUR_START, to: HOUR_END });
+    expect(report.pool).toBe("graphql");
+    expect(report.total_count).toBe(3);
+    expect(report.total_cost).toBe(15);
+    expect(report.operations).toEqual([
+      { operation_key: "pr list", pool: "graphql", count: 2, cost: 12 },
+      { operation_key: "issue list", pool: "graphql", count: 1, cost: 3 },
+    ]);
+  });
+
+  it("keeps pool attribution separate when one window reports every pool", async () => {
+    const path = await ledgerPath();
+    const ledger = createGithubAttributionLedger({ path });
+
+    await ledger.record({
+      operation: routeGithubArgs(["issue", "list"]),
+      cost: 4,
+      observedAt: "2026-08-03T12:05:00.000Z",
+    });
+    await ledger.record({
+      operation: routeGithubArgs(["issue", "view", "42"]),
+      cost: 1,
+      observedAt: "2026-08-03T12:06:00.000Z",
+    });
+
+    const report = await ledger.report({ from: HOUR_START, to: HOUR_END });
+
+    expect(report.pool).toBeNull();
+    expect(report.operations).toEqual([
+      { operation_key: "issue list", pool: "graphql", count: 1, cost: 4 },
+      { operation_key: "issue view", pool: "rest", count: 1, cost: 1 },
+    ]);
+  });
+});

--- a/packages/github/attribution.ts
+++ b/packages/github/attribution.ts
@@ -1,0 +1,235 @@
+// attribution.ts — what THIS process believes it spent, by operation key.
+//
+// This is deliberately not a balance. `GithubBalance` remains the authoritative
+// answer from `GET /rate_limit`; this append-only ledger is local evidence about
+// calls that passed through the routed client. A mismatch between the two is a
+// finding (for example, another process used the token), never a reason to turn
+// these observations into GitHub's balance.
+
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
+
+import type { GithubOperation, GithubRateBudget } from "./surface.js";
+
+/** One completed routed call, priced by the transport that observed it. */
+export interface GithubSpendObservation {
+  readonly version: 1;
+  readonly observed_at: string;
+  readonly operation_key: string;
+  readonly pool: GithubRateBudget;
+  readonly cost: number;
+}
+
+/** One operation/pool row in a spend report. */
+export interface GithubOperationSpend {
+  readonly operation_key: string;
+  readonly pool: GithubRateBudget;
+  readonly count: number;
+  readonly cost: number;
+}
+
+/** A reproducible projection over the durable local observation ledger. */
+export interface GithubSpendAttributionReport {
+  readonly version: 1;
+  /** Keeps this document structurally and semantically distinct from a balance. */
+  readonly origin: "process-attribution";
+  /** The report uses the half-open interval `[from, to)`. */
+  readonly window: { readonly from: string; readonly to: string };
+  /** `null` means every pool was included. */
+  readonly pool: GithubRateBudget | null;
+  readonly total_count: number;
+  readonly total_cost: number;
+  readonly operations: readonly GithubOperationSpend[];
+  /** Invalid or torn JSONL records ignored while rebuilding the report. */
+  readonly unreadable_records: number;
+}
+
+export interface GithubAttributionLedger {
+  /** Append one transport-observed call to durable storage. */
+  record(input: {
+    readonly operation: GithubOperation;
+    readonly cost: number;
+    readonly observedAt?: string;
+  }): Promise<void>;
+  /** Aggregate durable observations for a half-open time window. */
+  report(input: {
+    readonly from: string;
+    readonly to: string;
+    readonly pool?: GithubRateBudget;
+  }): Promise<GithubSpendAttributionReport>;
+}
+
+export interface CreateGithubAttributionLedgerOptions {
+  /** Durable TOONL path. The caller owns where project/host state lives. */
+  readonly path: string;
+  readonly now?: () => string;
+}
+
+/**
+ * Create an append-only, restart-durable spend ledger.
+ *
+ * The transport supplies `cost`: REST/Search hooks normally observe one request,
+ * while GraphQL observes the response's point cost. Requiring the value here is
+ * what prevents the ledger from silently equating one GraphQL call with one
+ * point. The operation supplies both key and pool from the routing table, so a
+ * caller cannot price a GraphQL operation against REST by accident.
+ */
+export function createGithubAttributionLedger(
+  options: CreateGithubAttributionLedgerOptions,
+): GithubAttributionLedger {
+  const now = options.now ?? (() => new Date().toISOString());
+  // Serialize writes made by one process. Separate processes still append whole
+  // JSONL records independently; rebuilding never depends on in-memory state.
+  let pendingWrite: Promise<void> = Promise.resolve();
+
+  return {
+    record(input): Promise<void> {
+      const observation = makeObservation(input.operation, input.cost, input.observedAt ?? now());
+      const segment = encodeLines().push(toToonlRecord(observation));
+      pendingWrite = pendingWrite.then(async () => {
+        await mkdir(dirname(options.path), { recursive: true });
+        await appendFile(options.path, segment, "utf8");
+      });
+      return pendingWrite;
+    },
+
+    async report(input): Promise<GithubSpendAttributionReport> {
+      await pendingWrite;
+      const from = instant(input.from, "report window start");
+      const to = instant(input.to, "report window end");
+      if (to <= from) throw new Error("GitHub attribution report window end must be after its start");
+
+      const read = await readObservations(options.path);
+      const grouped = new Map<string, GithubOperationSpend>();
+      for (const observation of read.observations) {
+        const observedAt = Date.parse(observation.observed_at);
+        if (observedAt < from || observedAt >= to) continue;
+        if (input.pool !== undefined && observation.pool !== input.pool) continue;
+        const groupKey = `${observation.pool}\u0000${observation.operation_key}`;
+        const current = grouped.get(groupKey);
+        grouped.set(groupKey, {
+          operation_key: observation.operation_key,
+          pool: observation.pool,
+          count: (current?.count ?? 0) + 1,
+          cost: (current?.cost ?? 0) + observation.cost,
+        });
+      }
+
+      const operations = [...grouped.values()].sort(
+        (left, right) =>
+          right.cost - left.cost ||
+          right.count - left.count ||
+          left.operation_key.localeCompare(right.operation_key) ||
+          left.pool.localeCompare(right.pool),
+      );
+      return {
+        version: 1,
+        origin: "process-attribution",
+        window: { from: input.from, to: input.to },
+        pool: input.pool ?? null,
+        total_count: operations.reduce((sum, operation) => sum + operation.count, 0),
+        total_cost: operations.reduce((sum, operation) => sum + operation.cost, 0),
+        operations,
+        unreadable_records: read.unreadable,
+      };
+    },
+  };
+}
+
+function makeObservation(
+  operation: GithubOperation,
+  cost: number,
+  observedAt: string,
+): GithubSpendObservation {
+  instant(observedAt, "GitHub spend observation");
+  if (!Number.isSafeInteger(cost) || cost < 0) {
+    throw new Error(`GitHub spend observation cost must be a non-negative safe integer; received ${cost}`);
+  }
+  return {
+    version: 1,
+    observed_at: observedAt,
+    operation_key: operation.key,
+    pool: operation.budget,
+    cost,
+  };
+}
+
+async function readObservations(
+  path: string,
+): Promise<{ readonly observations: GithubSpendObservation[]; readonly unreadable: number }> {
+  let contents: string;
+  try {
+    contents = await readFile(path, "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return { observations: [], unreadable: 0 };
+    throw error;
+  }
+
+  const observations: GithubSpendObservation[] = [];
+  let unreadable = 0;
+  const lines = contents.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const header = lines[index]!;
+    if (header.trim() === "") continue;
+    const row = lines[index + 1];
+    if (!header.startsWith("[]{") || row === undefined || row.trim() === "") {
+      unreadable += 1;
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = parseRecords(`${header}\n${row}\n`)[0];
+    } catch {
+      unreadable += 1;
+      index += 1;
+      continue;
+    }
+    if (!isObservation(parsed)) {
+      unreadable += 1;
+      index += 1;
+      continue;
+    }
+    observations.push(parsed);
+    index += 1;
+  }
+  return { observations, unreadable };
+}
+
+function toToonlRecord(observation: GithubSpendObservation): ToonlRecord {
+  return {
+    version: observation.version,
+    observed_at: observation.observed_at,
+    operation_key: observation.operation_key,
+    pool: observation.pool,
+    cost: observation.cost,
+  };
+}
+
+function isObservation(value: unknown): value is GithubSpendObservation {
+  if (!isRecord(value)) return false;
+  return value.version === 1 &&
+    typeof value.observed_at === "string" &&
+    Number.isFinite(Date.parse(value.observed_at)) &&
+    typeof value.operation_key === "string" &&
+    value.operation_key !== "" &&
+    (value.pool === "rest" || value.pool === "graphql" || value.pool === "search") &&
+    typeof value.cost === "number" &&
+    Number.isSafeInteger(value.cost) &&
+    value.cost >= 0;
+}
+
+function instant(value: string, label: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error(`${label} must be an ISO-8601 instant; received ${JSON.stringify(value)}`);
+  return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(value: unknown): value is NodeJS.ErrnoException {
+  return value instanceof Error && "code" in value;
+}

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -1,11 +1,12 @@
 // @reddb-io/github — the one budget-aware GitHub client.
 //
-// ADR 0132 decision 4 as superseded by Amendment 2. Four modules, one question
+// ADR 0132 decision 4 as superseded by Amendment 2. Five modules, one question
 // each:
 //   surface.ts   — WHICH API answers a call, decided by cardinality.
 //   rest-plan.ts — HOW a single-object read is actually issued on REST.
 //   balance.ts   — WHAT the token has left, asked rather than counted, and what
 //                  that balance admits.
+//   attribution.ts — WHO this process believes spent each pool, durably.
 //   cache.ts     — WHAT was kept, and how old it is.
 //
 // The daemon and the castle both import this package rather than each keeping a
@@ -30,6 +31,15 @@ export {
   type GithubRateBudget,
   type GithubReadVolatility,
 } from "./surface.js";
+
+export {
+  createGithubAttributionLedger,
+  type CreateGithubAttributionLedgerOptions,
+  type GithubAttributionLedger,
+  type GithubOperationSpend,
+  type GithubSpendAttributionReport,
+  type GithubSpendObservation,
+} from "./attribution.js";
 
 export {
   GITHUB_BALANCE_CADENCE,

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -7,9 +7,13 @@
   "license": "Apache-2.0",
   "exports": {
     ".": "./index.ts",
+    "./attribution.js": "./attribution.ts",
     "./surface.js": "./surface.ts",
     "./rest-plan.js": "./rest-plan.ts",
     "./balance.js": "./balance.ts",
     "./cache.js": "./cache.ts"
+  },
+  "dependencies": {
+    "@reddb-io/toon": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,7 +465,11 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.20.1)
 
-  packages/github: {}
+  packages/github:
+    dependencies:
+      '@reddb-io/toon':
+        specifier: 'catalog:'
+        version: 0.13.0
 
   packages/red-castle:
     dependencies:


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3205 -->
🤖 **Re-seed trail** — #3205 on `afk/3205-nothing-reports-who-spent-the-github-bud`, lane `/afk`.

Rounds spent: 6/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 3/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3205; re-seeding on the think tier before terminal validation routing. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE, but the base gained 2 commits under this attempt; the gate ran on a tree merged with that newer base, so the failure is attributed to stale-base drift, not the branch; granting a free stale-base correction (1/2), budget untouched at 2/3. |
| 5/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE, but the base gained 4 commits under this attempt; the gate ran on a tree merged with that newer base, so the failure is attributed to stale-base drift, not the branch; granting a free stale-base correction (2/2), budget untouched at 2/3. |
| 6/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3205 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: whole-workspace (trigger: `pnpm-lock.yaml`)
{"schema":"red.afk.validation.v1","name":"test:root","status":"failed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3205-nothing-reports-who-spent-the-github-bud test","exitCode":1,"durationMs":1057,"summary":"inconclusive: the baseline could not be built, so nothing was compared — [ERROR] ENOENT: no such file or directory, lstat '[REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/main' For help, run: pnpm help run"}
{"schema":"red.afk.validation.v1","name":"typecheck:root","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3205-nothing-reports-who-spent-the-github-bud typecheck","exitCode":0,"durationMs":0,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"lint:root","status":"skipped","summary":"script missing"}
{"schema":"red.afk.validation.v1","name":"build:root","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3205-nothing-reports-who-spent-the-github-bud build","exitCode":0,"durationMs":18,"summary":"command exited 0"}
🤖 classification override: the `on_feedback_classify` hook set the feedback failure to `semantic` (the classifier read it as `semantic`).
```

Closes #3205