### PR TITLE
fix: #3192 A machine respawning workers that die at boot draws as a quiet machine with `†1 unknown`, so the loop is invisible for as long as it runs

### DIFF
--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -166,6 +166,7 @@ import {
 import {
   buildStatuslinePayload,
   withholdStatuslineExtras,
+  type RedskilledDeathObservation,
   type RedskilledStatuslinePayload,
 } from "./statusline-payload.js";
 import {
@@ -308,11 +309,20 @@ export const DEFAULT_REDSKILLED_REGISTRATION_SUSTAIN_MS = 60_000;
 export const REDSKILLED_LAPSE_MEMORY = 16;
 
 /** Project one durable host event into the loss shape every renderer consumes. */
-function observedWorkerDeath(event: RedskilledHostEvent): DeathAttribution | null {
+function observedWorkerDeath(
+  event: RedskilledHostEvent,
+  context: { readonly startedAt?: string; readonly refusal?: string } = {},
+): RedskilledDeathObservation | null {
   if (event.event !== "worker-death" && event.event !== "worker-budget-kill") return null;
   const hostEndedWorker = event.event === "worker-budget-kill";
-  const observation = event.detail ??
+  const bootRefused = !hostEndedWorker && context.refusal != null;
+  const observation = context.refusal ?? event.detail ??
     `redskilled observed exit code=${event.exit_code ?? "null"} signal=${event.signal ?? "null"}`;
+  const startedAt = context.startedAt == null ? null : Date.parse(context.startedAt);
+  const endedAt = Date.parse(event.ts);
+  const uptimeS = startedAt != null && Number.isFinite(startedAt) && Number.isFinite(endedAt)
+    ? Math.max(0, endedAt - startedAt) / 1_000
+    : undefined;
   return {
     version: 1,
     ts: event.ts,
@@ -322,17 +332,26 @@ function observedWorkerDeath(event: RedskilledHostEvent): DeathAttribution | nul
     // The daemon observed the loss at this instant; an early Worker published no
     // finer heartbeat or phase, and inventing either would be worse than saying so.
     last_seen: event.ts,
-    last_phase: "unreported",
-    sender_class: hostEndedWorker ? "teardown" : "unknown",
-    confidence: hostEndedWorker ? "high" : "none",
+    last_phase: bootRefused ? "boot-refused" : "unreported",
+    sender_class: hostEndedWorker ? "teardown" : bootRefused ? "boot-refused" : "unknown",
+    confidence: hostEndedWorker || bootRefused ? "high" : "none",
     signal: event.signal,
     host_boot_changed: false,
     // A budget kill is the daemon's own act and therefore evidence. A spontaneous
     // exit has an observation but no known sender; keep that receipt under
     // `checked` so `unknown` remains honest rather than becoming a guessed cause.
-    evidence: hostEndedWorker ? [observation] : [],
-    checked: [`redskilled host event: ${observation}`],
+    evidence: hostEndedWorker || bootRefused ? [observation] : [],
+    checked: bootRefused ? ["Worker log tail"] : [`redskilled host event: ${observation}`],
+    project_label: event.project_label,
+    ...(uptimeS === undefined ? {} : { uptime_s: uptimeS }),
+    detail: context.refusal ?? event.detail,
   };
+}
+
+/** The explicit boot-guard refusal from one bounded log-tail read, if present. PURE. */
+function bootRefusalFromLog(line: string | null): string | null {
+  const refusal = line?.match(/\bsession-error:\s*(.+)$/)?.[1]?.trim();
+  return refusal == null || refusal === "" ? null : refusal;
 }
 
 /** Raised when another daemon already serves this user session. */
@@ -945,7 +964,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // same Worker exit. `undefined` remains until either source has answered,
   // because a daemon that never reaped and never observed a death must not render
   // a calm zero in place of an absent instrument.
-  let deathAttributions: DeathAttribution[] | undefined =
+  let deathAttributions: RedskilledDeathObservation[] | undefined =
     options.deaths === undefined ? undefined : [...options.deaths];
   // What each project asked the host to hold for it, by project label. In memory,
   // like the log lines and for the same reason: a registration is a live statement
@@ -1693,8 +1712,15 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       );
       return;
     }
+    const refusal = worker.log_path == null
+      ? null
+      : bootRefusalFromLog(await readLogTail(worker.log_path).catch(() => null));
     forgetWorker(worker.worker_id);
-    record("worker-death", worker, ended, { exitCode: code, signal });
+    record("worker-death", worker, refusal == null ? ended : `session-error: ${refusal}`, {
+      exitCode: code,
+      signal,
+      refusal,
+    });
     armIdleTimer();
   }
 
@@ -1945,7 +1971,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     detail: string | null,
     // The exit facts a project's policy turns on, when the daemon witnessed
     // them. Absent for every event that is not an observed process exit.
-    exit: { readonly exitCode?: number | null; readonly signal?: NodeJS.Signals | null } = {},
+    exit: {
+      readonly exitCode?: number | null;
+      readonly signal?: NodeJS.Signals | null;
+      readonly refusal?: string | null;
+    } = {},
   ): void {
     // A stopped daemon writes nothing. Its beliefs about who is alive stopped
     // being authoritative when it let go of the session, and the next daemon
@@ -1974,7 +2004,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         reason: null,
         exit_code: exit.exitCode ?? null,
         signal: exit.signal ?? null,
-      });
+      }, { startedAt: worker.started_at, ...(exit.refusal == null ? {} : { refusal: exit.refusal }) });
       // Every death reaches here, which is why the breaker folds here rather
       // than at the five call sites that end a Worker. What it reads is a
       // lifetime, never a cause: the daemon is not owed a reason (rule 3), and
@@ -1994,13 +2024,17 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   /** Put one host-observed loss on every surface, newest observation winning. */
-  function rememberObservedDeath(event: RedskilledHostEvent): void {
-    const attribution = observedWorkerDeath(event);
+  function rememberObservedDeath(
+    event: RedskilledHostEvent,
+    context: { readonly startedAt?: string; readonly refusal?: string } = {},
+  ): void {
+    const attribution = observedWorkerDeath(event, context);
     if (attribution == null) return;
     const merged = [
       attribution,
       ...(deathAttributions ?? []).filter(
-        (existing) => existing.kind !== attribution.kind || existing.id !== attribution.id,
+        (existing) =>
+          existing.kind !== attribution.kind || existing.id !== attribution.id || existing.ts !== attribution.ts,
       ),
     ].sort((left, right) => Date.parse(left.ts) - Date.parse(right.ts));
     // The badge describes the same rolling day as the daemon's outcome feed,
@@ -2502,7 +2536,21 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // A successor must render yesterday's loss too. The event lane is the durable
   // host witness, so replaying it here restores the exact feed a live exit updates
   // above without asking a project artifact that an early Worker never created.
-  for (const event of laneEvents) rememberObservedDeath(event);
+  const birthInstants = new Map<string, string>();
+  for (const event of laneEvents) {
+    if (event.event === "worker-birth") {
+      birthInstants.set(event.worker_id, event.ts);
+      continue;
+    }
+    const refusal = bootRefusalFromLog(event.detail);
+    rememberObservedDeath(event, {
+      ...(birthInstants.get(event.worker_id) == null ? {} : { startedAt: birthInstants.get(event.worker_id)! }),
+      ...(refusal == null ? {} : { refusal }),
+    });
+    if (event.event === "worker-death" || event.event === "worker-budget-kill") {
+      birthInstants.delete(event.worker_id);
+    }
+  }
   // The outcomes a predecessor recorded are this host's history too: a daemon
   // that restarted mid-day and reported an empty 24h window would tell an
   // operator the machine finished nothing, when what happened is that the

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -422,11 +422,11 @@ export interface RedskilledDaemonOptions {
   /** Window between registration sustain passes; 0 or below leaves the belt unarmed. */
   readonly registrationSustainMs?: number;
   /**
-   * How the daemon recovers a Worker's last logged line after a restart.
+   * How the daemon performs a bounded read after restart or pre-heartbeat death.
    *
    * Injected so a test can prove the read happens exactly once, on exactly the
-   * path the client gave. It is never used on the normal path: a live Worker's
-   * line arrives on its own heartbeat.
+   * path the client gave. A live Worker's line still arrives on its own heartbeat;
+   * an early death gets one read solely to surface an explicit boot refusal.
    */
   readonly readLogTail?: RedskilledLogTailProbe;
   /**

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -55,6 +55,18 @@ import type { RedskilledWorkerLogLine } from "./worker-log.js";
  */
 export const REDSKILLED_STALENESS_MS = 30_000;
 
+/** A Worker dead by this age never reached work; repeated refusals are a boot loop. */
+export const REDSKILLED_BOOT_REFUSAL_MAX_UPTIME_S = 2;
+/** One refusal can be incidental and two can be a retry; three establishes repetition. */
+export const REDSKILLED_BOOT_LOOP_MIN_DEATHS = 3;
+
+/** Host-observed facts that enrich a generic death attribution when they exist. */
+export interface RedskilledDeathObservation extends DeathAttribution {
+  readonly project_label?: string;
+  readonly uptime_s?: number;
+  readonly detail?: string | null;
+}
+
 /** What a Worker is doing, as the daemon knows it. */
 export type RedskilledWorkerState = "running" | "reattached";
 
@@ -242,6 +254,16 @@ export interface RedskilledStatuslineDeaths {
   readonly latest: RedskilledStatuslineDeath | null;
   /** When the reaper concluded; `null` when it attributed nothing. */
   readonly reaped_at: string | null;
+  /** A repeated same-project boot refusal, absent when the deaths do not establish one. */
+  readonly boot_loop?: RedskilledStatuslineBootLoop;
+}
+
+/** The actionable shape hidden by a flat death count. */
+export interface RedskilledStatuslineBootLoop {
+  readonly project_label: string;
+  readonly count: number;
+  readonly span_ms: number;
+  readonly latest_refusal: string;
 }
 
 /**
@@ -517,7 +539,7 @@ export interface BuildStatuslinePayloadInput {
    * An empty array is a reaping that found nothing — a real answer — and absent is
    * a reaper that never ran; the two must not collapse.
    */
-  readonly deaths?: readonly DeathAttribution[];
+  readonly deaths?: readonly RedskilledDeathObservation[];
   /** How many verdicts the payload lists before the rest are counted instead. */
   readonly recentDeathLimit?: number;
   /**
@@ -621,7 +643,7 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
 
 /** The death block a surface prints, newest verdict first. PURE. */
 function buildDeaths(
-  attributions: readonly DeathAttribution[],
+  attributions: readonly RedskilledDeathObservation[],
   limit: number,
 ): RedskilledStatuslineDeaths {
   const ordered = [...attributions].sort((a, b) => (instant(b.ts) ?? 0) - (instant(a.ts) ?? 0));
@@ -639,12 +661,53 @@ function buildDeaths(
       evidence: attribution.evidence[0] ?? null,
     }),
   );
+  const bootLoop = buildBootLoop(ordered);
   return {
     count: ordered.length,
     recent,
     latest: recent[0] ?? null,
     reaped_at: recent[0]?.ts ?? null,
+    ...(bootLoop == null ? {} : { boot_loop: bootLoop }),
   };
+}
+
+/** Reduce the rolling death window to its strongest same-project boot loop. PURE. */
+function buildBootLoop(
+  ordered: readonly RedskilledDeathObservation[],
+): RedskilledStatuslineBootLoop | null {
+  const byProject = new Map<string, RedskilledDeathObservation[]>();
+  for (const death of ordered) {
+    if (
+      death.sender_class !== "boot-refused" ||
+      death.uptime_s == null ||
+      death.uptime_s > REDSKILLED_BOOT_REFUSAL_MAX_UPTIME_S ||
+      death.project_label == null ||
+      death.project_label === "" ||
+      instant(death.ts) == null
+    ) continue;
+    const grouped = byProject.get(death.project_label) ?? [];
+    grouped.push(death);
+    byProject.set(death.project_label, grouped);
+  }
+
+  const loops = [...byProject.entries()]
+    .filter(([, deaths]) => deaths.length >= REDSKILLED_BOOT_LOOP_MIN_DEATHS)
+    .map(([projectLabel, deaths]): RedskilledStatuslineBootLoop | null => {
+      const newest = deaths[0]!;
+      const newestAt = instant(newest.ts)!;
+      const oldestAt = Math.min(...deaths.map((death) => instant(death.ts)!));
+      const refusal = newest.detail?.trim() || newest.evidence[0]?.trim();
+      if (refusal == null || refusal === "") return null;
+      return {
+        project_label: projectLabel,
+        count: deaths.length,
+        span_ms: Math.max(0, newestAt - oldestAt),
+        latest_refusal: refusal,
+      };
+    })
+    .filter((loop): loop is RedskilledStatuslineBootLoop => loop != null)
+    .sort((left, right) => right.count - left.count || right.span_ms - left.span_ms);
+  return loops[0] ?? null;
 }
 
 /**

--- a/apps/redskilled/src/worker-log.ts
+++ b/apps/redskilled/src/worker-log.ts
@@ -2,8 +2,8 @@
  * worker-log — the last line a Worker logged, as a published string.
  *
  * **The Worker publishes; the daemon stores.** The line travels on the Worker's
- * heartbeat and the daemon never reads it for meaning — no level is parsed, no
- * progress is inferred, no field is extracted. That is what keeps the global
+ * heartbeat and the daemon normally never reads it for meaning — no level is
+ * parsed, no progress is inferred. That is what keeps the global
  * verbose view to ONE read: the line is already in the payload, so a statusline
  * never opens a log, and the daemon never learns what a repository's log layout
  * is (ADR 0130 rule 3).
@@ -14,12 +14,13 @@
  * single-anchor rule forbids — a second authority on a question the payload
  * already answers.
  *
- * **One bounded exception: a restart.** A daemon that has just come back holds
- * Workers it has never heard a heartbeat from, and for those it may read the log
- * ONCE — from the path it was GIVEN at spawn, never from a path it derives. A
- * Worker whose client gave no log path simply has no line until it publishes one;
- * guessing a filename inside its workspace would be the derived layout this whole
- * design refuses.
+ * **Two bounded exceptions: restart and death before first heartbeat.** A daemon
+ * that has just come back may recover one display line for a Worker it adopted.
+ * A Worker that exits before publishing anything may have its tail read once so
+ * an explicit `session-error:` boot refusal reaches the death surface. Both reads
+ * use the path GIVEN at spawn, never one the daemon derives. A Worker whose client
+ * gave no log path stays honestly unexplained; guessing a filename inside its
+ * workspace would be the derived layout this whole design refuses.
  */
 import { open, stat } from "node:fs/promises";
 
@@ -37,7 +38,7 @@ export interface RedskilledWorkerLogLine {
   readonly source: "heartbeat" | "rehydrated";
 }
 
-/** How the daemon recovers a line after a restart; injected so a test can refuse it. */
+/** How the daemon performs either bounded log-tail read; injected so tests can pose the bytes. */
 export type RedskilledLogTailProbe = (path: string) => Promise<string | null>;
 
 /**

--- a/apps/redskilled/tests/early-worker-death.test.ts
+++ b/apps/redskilled/tests/early-worker-death.test.ts
@@ -44,6 +44,7 @@ function earlyExitLaunch(state: { exit?: (code: number) => void }) {
       pid: 4_242,
       started_at: options.clock?.() ?? "2026-08-03T16:47:00.000Z",
       workspace_path: options.spec.workspace_path,
+      ...(options.spec.log_path == null ? {} : { log_path: options.spec.log_path }),
       isolated: false,
       warnings: [],
     };

--- a/apps/redskilled/tests/early-worker-death.test.ts
+++ b/apps/redskilled/tests/early-worker-death.test.ts
@@ -187,5 +187,20 @@ describe("a Worker that exits before its first write", () => {
       span_ms: 240_000,
       latest_refusal: "trunk freshness: dirt-collision (.red/config.yaml)",
     });
+
+    await daemon.flushEvents();
+    await daemon.stop();
+    const successor = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      clock: () => now,
+      unitInventory: () => [],
+    });
+    running.push(successor);
+    expect(successor.statuslinePayload().deaths?.boot_loop).toMatchObject({
+      project_label: "acme/widgets",
+      count: 3,
+      latest_refusal: "trunk freshness: dirt-collision (.red/config.yaml)",
+    });
   });
 });

--- a/apps/redskilled/tests/early-worker-death.test.ts
+++ b/apps/redskilled/tests/early-worker-death.test.ts
@@ -11,7 +11,7 @@ import {
   renderRedskilledDashboard,
   renderRedskilledStatusline,
 } from "@reddb-io/redskilled-render";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { readRedskilledEvents } from "../src/event-lane.js";
 import type { RedskilledWorkerView } from "../src/host-state.js";
@@ -42,7 +42,7 @@ function earlyExitLaunch(state: { exit?: (code: number) => void }) {
       worker_id: workerId,
       project_label: options.spec.project_label,
       pid: 4_242,
-      started_at: "2026-08-03T16:47:00.000Z",
+      started_at: options.clock?.() ?? "2026-08-03T16:47:00.000Z",
       workspace_path: options.spec.workspace_path,
       isolated: false,
       warnings: [],
@@ -65,12 +65,13 @@ function earlyExitLaunch(state: { exit?: (code: number) => void }) {
   };
 }
 
-function spec(): RedskilledWorkerSpec {
+function spec(overrides: Partial<RedskilledWorkerSpec> = {}): RedskilledWorkerSpec {
   return {
     worker_id: "w-early",
     project_label: "acme/widgets",
     workspace_path: "/tmp/acme/w-early",
     command: process.execPath,
+    ...overrides,
   };
 }
 
@@ -146,6 +147,44 @@ describe("a Worker that exits before its first write", () => {
       pid: 4_242,
       sender_class: "unknown",
       confidence: "none",
+    });
+  });
+
+  it("counts a repeated two-second boot refusal and carries the refusal out of the log", async () => {
+    const paths = await sessionPaths();
+    const launched: { exit?: (code: number) => void } = {};
+    let now = "2026-08-03T16:40:00.000Z";
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      clock: () => now,
+      launch: earlyExitLaunch(launched),
+      unitInventory: () => [],
+      readLogTail: async () => "[afk] session-error: trunk freshness: dirt-collision (.red/config.yaml)",
+    });
+    running.push(daemon);
+
+    for (const minute of [0, 2, 4]) {
+      now = `2026-08-03T16:${String(40 + minute).padStart(2, "0")}:00.000Z`;
+      daemon.startWorker(spec({ log_path: "/tmp/acme/w-early/dispatch.log" }));
+      now = `2026-08-03T16:${String(40 + minute).padStart(2, "0")}:01.000Z`;
+      launched.exit?.(1);
+      await vi.waitFor(() => {
+        expect(daemon.statuslinePayload().deaths?.count).toBe(minute / 2 + 1);
+      });
+    }
+
+    expect(daemon.statuslinePayload().deaths?.latest).toMatchObject({
+      id: "w-early",
+      sender_class: "boot-refused",
+      last_phase: "boot-refused",
+      evidence: "trunk freshness: dirt-collision (.red/config.yaml)",
+    });
+    expect(daemon.statuslinePayload().deaths?.boot_loop).toEqual({
+      project_label: "acme/widgets",
+      count: 3,
+      span_ms: 240_000,
+      latest_refusal: "trunk freshness: dirt-collision (.red/config.yaml)",
     });
   });
 });

--- a/apps/redskilled/tests/statusline-deaths.test.ts
+++ b/apps/redskilled/tests/statusline-deaths.test.ts
@@ -69,6 +69,26 @@ function attribution(overrides: Partial<DeathAttribution> = {}): DeathAttributio
   };
 }
 
+/** One host-observed boot refusal, carrying the grouping facts the renderer needs. */
+function bootRefusal(id: string, ts: string): DeathAttribution {
+  return {
+    ...attribution({
+      id,
+      ts,
+      last_seen: ts,
+      last_phase: "boot-refused",
+      sender_class: "boot-refused" as DeathAttribution["sender_class"],
+      confidence: "high",
+      signal: null,
+      evidence: ["trunk freshness: dirt-collision (.red/config.yaml)"],
+      checked: ["Worker log tail"],
+    }),
+    project_label: "acme/widgets",
+    uptime_s: 1,
+    detail: "trunk freshness: dirt-collision (.red/config.yaml)",
+  } as unknown as DeathAttribution;
+}
+
 function payloadWith(
   deaths: readonly DeathAttribution[] | undefined,
   published?: { version: string | null; newer?: boolean; newest?: string | null },
@@ -168,6 +188,30 @@ describe("the statusline head answers both questions", () => {
       project: "acme/widgets",
     });
     expect(render.line).not.toContain("†");
+  });
+
+  it("names a repeated boot refusal as a loop, with its span and repair clue", () => {
+    const payload = payloadWith([
+      bootRefusal("worker:w-9", "2026-07-29T00:04:00.000Z"),
+      bootRefusal("worker:w-9", "2026-07-29T00:02:00.000Z"),
+      bootRefusal("worker:w-9", "2026-07-29T00:00:00.000Z"),
+    ]);
+    const render = renderRedskilledStatusline(payload, {
+      ...REDSKILLED_STATUSLINE_DEFAULTS,
+      project: "acme/widgets",
+    });
+
+    expect(render.line).toContain("†3 boot-refused ×3 in 4m");
+    expect(render.line).toContain("trunk freshness: dirt-collision (.red/config.yaml)");
+
+    const dashboard = renderRedskilledDashboard(payload, {
+      mode: "local",
+      project: "acme/widgets",
+      maxWidth: 200,
+      maxRows: 16,
+    });
+    expect(dashboard.header.line).toContain("†3 boot-refused ×3 in 4m");
+    expect(dashboard.header.line).toContain("trunk freshness: dirt-collision (.red/config.yaml)");
   });
 });
 

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -24,7 +24,17 @@
  * own — the memory ceiling and the Worker slots — and says nothing about the ones
  * it does not, because a plausible zero is worse than a missing column.
  */
-import { clamp, formatBytes, formatCount, formatDuration, formatRate, pad, shortModel, width } from "./format.js";
+import {
+  clamp,
+  flattenPublishedLine,
+  formatBytes,
+  formatCount,
+  formatDuration,
+  formatRate,
+  pad,
+  shortModel,
+  width,
+} from "./format.js";
 import {
   BUDGET_BAND_MARK,
   BUDGET_SPENT_MARK,
@@ -398,7 +408,12 @@ function buildHeader(
   // about the machine and not about one project's Workers — and the header is
   // the whole of what a status bar shows.
   if (deaths != null && deaths.count > 0 && deaths.latest != null) {
-    parts.push(`${DEATH_MARK}${deaths.count} ${deaths.latest.sender_class}`);
+    const loop = deaths.boot_loop;
+    const refusal = flattenPublishedLine(loop?.latest_refusal);
+    parts.push(loop == null
+      ? `${DEATH_MARK}${deaths.count} ${deaths.latest.sender_class}`
+      : `${DEATH_MARK}${deaths.count} boot-refused ×${loop.count} in ${compactLoopSpan(loop.span_ms)}` +
+        (refusal == null ? "" : ` — ${refusal}`));
   }
   if (payload.staleness.stale) {
     const age = payload.staleness.age_ms;
@@ -429,6 +444,14 @@ function buildHeader(
     age_ms: payload.staleness.age_ms,
     line: clamp(line, options.maxWidth),
   };
+}
+
+/** A loop span without zero-valued trailing units (`4m`, not `4m0s`). PURE. */
+function compactLoopSpan(spanMs: number): string {
+  return formatDuration(spanMs)
+    .replace(/m0s$/, "m")
+    .replace(/h0m$/, "h")
+    .replace(/d0h$/, "d");
 }
 
 /**

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -35,7 +35,7 @@ import {
   type RedskilledDashboardCells,
   type RedskilledDashboardColumn,
 } from "./dashboard.js";
-import { clamp, flattenPublishedLine, formatBytes, pad, width } from "./format.js";
+import { clamp, flattenPublishedLine, formatBytes, formatDuration, pad, width } from "./format.js";
 import {
   BUDGET_BAND_MARK,
   BUDGET_SPENT_MARK,
@@ -360,9 +360,10 @@ function budgetMark(payload: RedskilledRenderPayload): string | null {
  *
  * The class rides with the count because `†1` alone sends the operator to a lane
  * to learn the one thing they came for, and the classes differ in what they cost:
- * `oomd` is a machine to resize and `user-signal` is somebody's Ctrl-C. Only the
- * newest verdict's class is named — a head has no room for a census, and
- * `deaths.count` says how many more are behind it.
+ * `oomd` is a machine to resize and `user-signal` is somebody's Ctrl-C. A proved
+ * boot loop spends that space on its repetition, span and repair clue. Otherwise
+ * only the newest verdict's class is named — a head has no room for a census,
+ * and `deaths.count` says how many more are behind it.
  *
  * An ABSENT block prints nothing, and so does a reaping that attributed nothing:
  * `†0` would be a badge for the healthy case, which is how a mark stops being
@@ -371,7 +372,21 @@ function budgetMark(payload: RedskilledRenderPayload): string | null {
 function deathMark(payload: RedskilledRenderPayload): string | null {
   const deaths = payload.deaths;
   if (deaths == null || deaths.count <= 0 || deaths.latest == null) return null;
+  const loop = deaths.boot_loop;
+  if (loop != null) {
+    const refusal = flattenPublishedLine(loop.latest_refusal);
+    return `${DEATH_MARK}${deaths.count} boot-refused ×${loop.count} in ${compactLoopSpan(loop.span_ms)}` +
+      (refusal == null ? "" : ` — ${refusal}`);
+  }
   return `${DEATH_MARK}${deaths.count} ${deaths.latest.sender_class}`;
+}
+
+/** A loop span without zero-valued trailing units (`4m`, not `4m0s`). PURE. */
+function compactLoopSpan(spanMs: number): string {
+  return formatDuration(spanMs)
+    .replace(/m0s$/, "m")
+    .replace(/h0m$/, "h")
+    .replace(/d0h$/, "d");
 }
 
 /**

--- a/packages/redskilled-render/payload.ts
+++ b/packages/redskilled-render/payload.ts
@@ -221,6 +221,15 @@ export interface RedskilledRenderDeaths {
   readonly recent: readonly RedskilledRenderDeath[];
   readonly latest: RedskilledRenderDeath | null;
   readonly reaped_at: string | null;
+  readonly boot_loop?: RedskilledRenderBootLoop;
+}
+
+/** A repeated same-project refusal that ended before any Worker reached work. */
+export interface RedskilledRenderBootLoop {
+  readonly project_label: string;
+  readonly count: number;
+  readonly span_ms: number;
+  readonly latest_refusal: string;
 }
 
 /** Which engine is answering, and whether it is the current one. */

--- a/packages/shared/death-attribution.ts
+++ b/packages/shared/death-attribution.ts
@@ -72,7 +72,13 @@ export {
 export const DEATH_ATTRIBUTION_VERSION = 1;
 
 /** Who ended the process. Five classes, one of which is honest ignorance. */
-export type DeathSenderClass = "oomd" | "user-signal" | "parent-death" | "teardown" | "unknown";
+export type DeathSenderClass =
+  | "oomd"
+  | "user-signal"
+  | "parent-death"
+  | "teardown"
+  | "boot-refused"
+  | "unknown";
 
 /**
  * How far the evidence goes.


### PR DESCRIPTION
Automated AFK landing for #3192. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3192

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788390152&installation_model_id=20659&pr_number=3228&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3228&signature=327896126994bf7847505a036b9f6ec15168284d576ca74240e85f08a721a7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->