### PR TITLE
fix: #3191 `project unknown` is one string for four histories the daemon can already tell apart, so the operator is told to register something that is registered

### DIFF
--- a/.changeset/explain-project-history.md
+++ b/.changeset/explain-project-history.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/redskilled": patch
+"@reddb-io/redskilled-render": patch
+---
+
+Distinguish never-registered, lapsed, deliberately stopped, and orphaned-daemon project histories in statusline and renewal diagnostics.

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -1902,6 +1902,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
 
   /** Forget an older absence when a newer registration transition supersedes it. */
   function removeRegistrationHistory(projectLabel: string): void {
+    recoverableRegistrations.delete(projectLabel);
     for (let index = lapses.length - 1; index >= 0; index -= 1) {
       if (lapses[index]!.project_label === projectLabel) lapses.splice(index, 1);
     }

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -78,7 +78,9 @@ import {
 import {
   buildHostState,
   type RedskilledHostState,
+  type RedskilledOrphanedRegistration,
   type RedskilledRegistrationLapse,
+  type RedskilledRegistrationStop,
   type RedskilledWorkerView,
 } from "./host-state.js";
 import {
@@ -360,6 +362,8 @@ export interface RedskilledDaemonOptions {
    * never reaped and not a machine where nothing died.
    */
   readonly deaths?: readonly DeathAttribution[];
+  /** Registrations proved to remain behind another live daemon beyond this socket. */
+  readonly orphanedRegistrations?: readonly RedskilledOrphanedRegistration[];
   readonly idleMs?: number;
   /** The host-wide ceiling admission is decided against; the host's own by default. */
   readonly ceiling?: RedskilledHostCeiling;
@@ -998,6 +1002,13 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // otherwise only an absence, and an absence is what let a stopped drain read as
   // a healthy one (#2973).
   const lapses: RedskilledRegistrationLapse[] = [];
+  // A deliberate stop is not a lapse and not an absence nobody can explain.
+  // Retained on the same bounded tail as lapses so `project_stop` remains visible
+  // without turning live registration state into a durable second authority.
+  const stops: RedskilledRegistrationStop[] = [];
+  const orphanedRegistrations = new Map(
+    (options.orphanedRegistrations ?? []).map((record) => [record.project_label, record]),
+  );
   let demandBackoffUntilMs: number | null = null;
   // Per project, its record of Workers that died before they could work. In
   // memory rather than durable on purpose: it answers "can a Worker boot here
@@ -1079,6 +1090,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     const at = Number.isFinite(nowMs) ? new Date(nowMs).toISOString() : registration.renew_by;
     lapses.push({
       project_label: registration.project_label,
+      registered_at: registration.registered_at,
       at,
       renew_by: registration.renew_by,
       renewals: registration.renewals,
@@ -1173,6 +1185,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       // the set is either one that never registered or one whose drain ended, and
       // only the second is something an operator has to act on.
       lapses,
+      stops,
+      orphanedRegistrations: [...orphanedRegistrations.values()],
       // The poll each registration was last covered by, so "why is nothing
       // happening" is answerable from one read instead of from a log.
       queue: lastQueue,
@@ -1777,6 +1791,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       held: registrations.get(request.project_label),
     });
     registrations.set(registration.project_label, registration);
+    // A current registration outranks every historical absence. Remove the old
+    // tail now so a later deliberate stop cannot uncover an older lapse and lie
+    // about which transition happened most recently.
+    removeRegistrationHistory(registration.project_label);
     // A registration holds the daemon awake, exactly as a Worker does: a drain the
     // operator walked away from must outlive the terminal, and a daemon that idled
     // out under a standing registration would take the promise with it.
@@ -1813,7 +1831,24 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     const now = clock();
     expireLapsedRegistrations(now);
     const held = registrations.get(projectLabel);
-    if (held == null) throw new RedskilledProjectUnregisteredError(projectLabel);
+    if (held == null) {
+      if (orphanedRegistrations.has(projectLabel)) {
+        throw new RedskilledProjectUnregisteredError(projectLabel, { kind: "orphaned" });
+      }
+      const stopped = [...stops].reverse().find((record) => record.project_label === projectLabel);
+      if (stopped != null) {
+        throw new RedskilledProjectUnregisteredError(projectLabel, { kind: "stopped", at: stopped.at });
+      }
+      const lapsed = [...lapses].reverse().find((record) => record.project_label === projectLabel);
+      if (lapsed != null) {
+        throw new RedskilledProjectUnregisteredError(projectLabel, {
+          kind: "lapsed",
+          at: lapsed.at,
+          ...(lapsed.registered_at == null ? {} : { registered_at: lapsed.registered_at }),
+        });
+      }
+      throw new RedskilledProjectUnregisteredError(projectLabel);
+    }
     const registration = renewProjectRegistration(held, {
       now,
       ...(options.renewWithinMs == null ? {} : { renew_within_ms: options.renewWithinMs }),
@@ -1846,7 +1881,14 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   function deregisterProject(projectLabel: string, sessionProject?: string): RedskilledProjectDeregistered {
     const reach = authorize("project-deregister", sessionProject, projectLabel);
     if (!reach.permitted) throw new Error(reach.reason);
+    const held = registrations.get(projectLabel);
     const released = registrations.delete(projectLabel);
+    if (held != null) {
+      const detail = `redskilled released the registration for project ${JSON.stringify(projectLabel)}`;
+      removeRegistrationHistory(projectLabel);
+      stops.push({ project_label: projectLabel, registered_at: held.registered_at, at: clock(), detail });
+      if (stops.length > REDSKILLED_LAPSE_MEMORY) stops.splice(0, stops.length - REDSKILLED_LAPSE_MEMORY);
+    }
     return {
       version: 1,
       project_label: projectLabel,
@@ -1856,6 +1898,17 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         ? `redskilled released the registration for project ${JSON.stringify(projectLabel)}`
         : `redskilled held no registration for project ${JSON.stringify(projectLabel)}, so there was nothing to release`,
     };
+  }
+
+  /** Forget an older absence when a newer registration transition supersedes it. */
+  function removeRegistrationHistory(projectLabel: string): void {
+    for (let index = lapses.length - 1; index >= 0; index -= 1) {
+      if (lapses[index]!.project_label === projectLabel) lapses.splice(index, 1);
+    }
+    for (let index = stops.length - 1; index >= 0; index -= 1) {
+      if (stops[index]!.project_label === projectLabel) stops.splice(index, 1);
+    }
+    orphanedRegistrations.delete(projectLabel);
   }
 
   /** Stop one Worker the daemon holds, and record its death. */

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -246,6 +246,8 @@ export interface RedskilledRegistrationPoll {
  */
 export interface RedskilledRegistrationLapse {
   readonly project_label: string;
+  /** When the registration began; absent on records from older daemons. */
+  readonly registered_at?: string;
   /** When the daemon noticed — a lapse is observed at a read, never at a timer. */
   readonly at: string;
   /** The deadline the record actually stood on. */
@@ -255,6 +257,20 @@ export interface RedskilledRegistrationLapse {
   /** How many times the project's own work had held it up (Amendment 7). */
   readonly sustains: number;
   readonly detail: string;
+}
+
+/** One registration an operator deliberately released. */
+export interface RedskilledRegistrationStop {
+  readonly project_label: string;
+  readonly registered_at: string;
+  readonly at: string;
+  readonly detail: string;
+}
+
+/** One registration known to remain on a live daemon beyond this socket. */
+export interface RedskilledOrphanedRegistration {
+  readonly project_label: string;
+  readonly registered_at?: string;
 }
 
 export interface RedskilledHostState {
@@ -295,6 +311,10 @@ export interface RedskilledHostState {
    * registration lapsed, and only one of those is a drain that stopped.
    */
   readonly lapsed_registrations?: readonly RedskilledRegistrationLapse[];
+  /** Registrations deliberately released through `project_stop`, oldest first. */
+  readonly stopped_registrations?: readonly RedskilledRegistrationStop[];
+  /** Registrations held by another live daemon which this socket cannot reach. */
+  readonly orphaned_registrations?: readonly RedskilledOrphanedRegistration[];
   /** What the daemon has promised the machine, derived from `workers`. */
   readonly budget_accounting: RedskilledBudgetAccounting;
   /** Running version against published version, and what is being done about it. */
@@ -324,6 +344,10 @@ export interface BuildHostStateInput {
   readonly registrations?: readonly RedskilledProjectRegistration[];
   /** The ones it dropped, in the order it dropped them; absent when none lapsed. */
   readonly lapses?: readonly RedskilledRegistrationLapse[];
+  /** Deliberate registration releases, oldest first. */
+  readonly stops?: readonly RedskilledRegistrationStop[];
+  /** Registrations proved to remain behind another live daemon. */
+  readonly orphanedRegistrations?: readonly RedskilledOrphanedRegistration[];
   /**
    * The last queue poll, as the poller left it; absent when none has run.
    *
@@ -384,6 +408,10 @@ export function buildHostState(input: BuildHostStateInput): RedskilledHostState 
     // block at all, so a reader never has to tell an empty list from a daemon too
     // old to keep one.
     ...(input.lapses == null || input.lapses.length === 0 ? {} : { lapsed_registrations: [...input.lapses] }),
+    ...(input.stops == null || input.stops.length === 0 ? {} : { stopped_registrations: [...input.stops] }),
+    ...(input.orphanedRegistrations == null || input.orphanedRegistrations.length === 0
+      ? {}
+      : { orphaned_registrations: [...input.orphanedRegistrations] }),
     budget_accounting: buildBudgetAccounting(workers, {
       hostCeilingBytes: input.ceiling?.memory_bytes ?? input.hostCeilingBytes ?? null,
     }),
@@ -498,11 +526,45 @@ export function isRedskilledHostState(value: unknown): value is RedskilledHostSt
     // while a block that IS there and is the wrong shape still fails closed.
     (state.registrations === undefined ||
       (Array.isArray(state.registrations) && state.registrations.every(isRedskilledProjectRegistration))) &&
+    (state.lapsed_registrations === undefined ||
+      (Array.isArray(state.lapsed_registrations) && state.lapsed_registrations.every(isRegistrationLapse))) &&
+    (state.stopped_registrations === undefined ||
+      (Array.isArray(state.stopped_registrations) && state.stopped_registrations.every(isRegistrationStop))) &&
+    (state.orphaned_registrations === undefined ||
+      (Array.isArray(state.orphaned_registrations) && state.orphaned_registrations.every(isOrphanedRegistration))) &&
     // Checked only when present. One daemon serves checkouts pinned to different
     // bundle versions (ADR 0130 rule 3), so a field this bundle added must not
     // make an older daemon's complete answer read as malformed — while a field
     // that IS there and is the wrong shape still fails closed.
     (state.upgrade === undefined || isRedskilledUpgradeState(state.upgrade));
+}
+
+function isRegistrationLapse(value: unknown): value is RedskilledRegistrationLapse {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.project_label === "string" &&
+    (record.registered_at === undefined || typeof record.registered_at === "string") &&
+    typeof record.at === "string" &&
+    typeof record.renew_by === "string" &&
+    Number.isInteger(record.renewals) &&
+    Number.isInteger(record.sustains) &&
+    typeof record.detail === "string";
+}
+
+function isRegistrationStop(value: unknown): value is RedskilledRegistrationStop {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.project_label === "string" &&
+    typeof record.registered_at === "string" &&
+    typeof record.at === "string" &&
+    typeof record.detail === "string";
+}
+
+function isOrphanedRegistration(value: unknown): value is RedskilledOrphanedRegistration {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.project_label === "string" &&
+    (record.registered_at === undefined || typeof record.registered_at === "string");
 }
 
 function isHostCeiling(value: unknown): value is RedskilledHostCeiling {

--- a/apps/redskilled/src/project-registration.ts
+++ b/apps/redskilled/src/project-registration.ts
@@ -288,13 +288,42 @@ export function buildProjectRegistration(
  * that quietly minted a record would resurrect an argv nobody restated.
  */
 export class RedskilledProjectUnregisteredError extends Error {
-  constructor(readonly projectLabel: string) {
-    super(
-      `redskilled holds no registration for project ${JSON.stringify(projectLabel)} to renew: it lapsed or was never ` +
-        `held, and a renewal never mints a record — register again, stating the selector, the argv and the target`,
-    );
+  constructor(
+    readonly projectLabel: string,
+    readonly absence: RedskilledProjectRegistrationAbsence = { kind: "never" },
+  ) {
+    super(describeRegistrationAbsence(projectLabel, absence));
     this.name = "RedskilledProjectUnregisteredError";
   }
+}
+
+/** Why a project has no registration on the daemon which answered. */
+export type RedskilledProjectRegistrationAbsence =
+  | { readonly kind: "never" }
+  | { readonly kind: "lapsed"; readonly at: string; readonly registered_at?: string }
+  | { readonly kind: "stopped"; readonly at: string }
+  | { readonly kind: "orphaned" };
+
+function describeRegistrationAbsence(
+  projectLabel: string,
+  absence: RedskilledProjectRegistrationAbsence,
+): string {
+  const project = JSON.stringify(projectLabel);
+  if (absence.kind === "lapsed") {
+    const registered = absence.registered_at == null ? "" : ` (registered ${absence.registered_at})`;
+    return `redskilled holds no registration for project ${project} to renew: it lapsed at ${absence.at}${registered}; ` +
+      `renewal stopped — find why before registering it again`;
+  }
+  if (absence.kind === "stopped") {
+    return `redskilled holds no registration for project ${project} to renew: it was stopped at ${absence.at}; ` +
+      `this is the requested state, so there is nothing to renew`;
+  }
+  if (absence.kind === "orphaned") {
+    return `redskilled holds no registration for project ${project} to renew: it is registered on a daemon this ` +
+      `socket does not reach — do not register it again`;
+  }
+  return `redskilled holds no registration for project ${project} to renew: it was never registered on this host; ` +
+    `register it first, stating the selector, the argv and the target`;
 }
 
 export interface RenewProjectRegistrationOptions {

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -318,8 +318,16 @@ export interface RedskilledStatuslinePayload {
   readonly lapsed_projects?: readonly {
     readonly project_label: string;
     readonly at: string;
+    readonly registered_at?: string;
     readonly reason: string;
   }[];
+  /** Registrations deliberately released through `project_stop`. */
+  readonly stopped_projects?: readonly {
+    readonly project_label: string;
+    readonly at: string;
+  }[];
+  /** Registrations held by a live daemon beyond the socket that answered. */
+  readonly orphaned_projects?: readonly string[];
   readonly workers: readonly RedskilledStatuslineWorker[];
   /**
    * Each registered project's repository counts, dated on their own clock.
@@ -596,8 +604,14 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
     lapsed_projects: (input.hostState.lapsed_registrations ?? []).map((lapse) => ({
       project_label: lapse.project_label,
       at: lapse.at,
+      ...(lapse.registered_at == null ? {} : { registered_at: lapse.registered_at }),
       reason: lapse.detail,
     })),
+    stopped_projects: (input.hostState.stopped_registrations ?? []).map((stopped) => ({
+      project_label: stopped.project_label,
+      at: stopped.at,
+    })),
+    orphaned_projects: (input.hostState.orphaned_registrations ?? []).map((record) => record.project_label),
     workers,
     github_balance: buildGithubBalanceReport({
       balance: input.githubBalance ?? null,
@@ -753,6 +767,8 @@ function knownProjects(hostState: RedskilledHostState): readonly string[] {
   for (const registration of hostState.registrations ?? []) labels.add(registration.project_label);
   for (const project of hostState.projects) labels.add(project.project_label);
   for (const lapse of hostState.lapsed_registrations ?? []) labels.add(lapse.project_label);
+  for (const stopped of hostState.stopped_registrations ?? []) labels.add(stopped.project_label);
+  for (const orphaned of hostState.orphaned_registrations ?? []) labels.add(orphaned.project_label);
   return [...labels].sort((a, b) => a.localeCompare(b));
 }
 
@@ -862,6 +878,11 @@ export function isRedskilledStatuslinePayload(value: unknown): value is Redskill
         payload.registered_projects.every((label) => typeof label === "string"))) &&
     (payload.lapsed_projects === undefined ||
       (Array.isArray(payload.lapsed_projects) && payload.lapsed_projects.every(isStatuslineLapse))) &&
+    (payload.stopped_projects === undefined ||
+      (Array.isArray(payload.stopped_projects) && payload.stopped_projects.every(isStatuslineStop))) &&
+    (payload.orphaned_projects === undefined ||
+      (Array.isArray(payload.orphaned_projects) &&
+        payload.orphaned_projects.every((label) => typeof label === "string"))) &&
     // Absent is accepted, malformed is not: a daemon older than the activity
     // poller answers a newer client's read, and rejecting its whole payload over
     // a field this consumer did not ask for would lose the Worker set — the very
@@ -885,7 +906,14 @@ function isStatuslineLapse(value: unknown): boolean {
   const lapse = value as Record<string, unknown>;
   return typeof lapse.project_label === "string" &&
     typeof lapse.at === "string" &&
+    (lapse.registered_at === undefined || typeof lapse.registered_at === "string") &&
     typeof lapse.reason === "string";
+}
+
+function isStatuslineStop(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const stopped = value as Record<string, unknown>;
+  return typeof stopped.project_label === "string" && typeof stopped.at === "string";
 }
 
 function isStatuslineDeaths(value: unknown): boolean {

--- a/apps/redskilled/tests/project-registration.test.ts
+++ b/apps/redskilled/tests/project-registration.test.ts
@@ -245,6 +245,29 @@ describe("redskilled project registration", () => {
 });
 
 describe("redskilled project deregistration", () => {
+  it("retains a deliberate stop as the project's latest registration history", async () => {
+    let now = "2026-08-03T17:25:30.000Z";
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({ paths, clock: () => now });
+    running.push(daemon);
+
+    daemon.registerProject(request());
+    now = "2026-08-03T17:41:02.000Z";
+    daemon.deregisterProject("acme/widgets", "acme/widgets");
+
+    expect(daemon.hostState().stopped_registrations).toEqual([{
+      project_label: "acme/widgets",
+      registered_at: "2026-08-03T17:25:30.000Z",
+      at: now,
+      detail: "redskilled released the registration for project \"acme/widgets\"",
+    }]);
+    expect(daemon.statuslinePayload()).toMatchObject({
+      known_projects: ["acme/widgets"],
+      stopped_projects: [{ project_label: "acme/widgets", at: now }],
+    });
+    expect(() => daemon.renewProject("acme/widgets")).toThrow(/was stopped at 2026-08-03T17:41:02\.000Z/);
+  });
+
   it("releases the registration a project stops, and holds the others", async () => {
     const paths = await sessionPaths();
     const daemon = await startRedskilledDaemon({ paths });

--- a/apps/redskilled/tests/registration-renewal.test.ts
+++ b/apps/redskilled/tests/registration-renewal.test.ts
@@ -242,13 +242,16 @@ describe("renewing a registration the daemon does not hold", () => {
 
     await expect(
       renewRedskilledProject(paths, { project_label: "acme/widgets" }, { sessionProject: "acme/widgets" }),
-    ).rejects.toThrow(/acme\/widgets/);
+    ).rejects.toThrow(/was never registered on this host/);
 
     daemon.registerProject(request());
     clock.advance(WINDOW_MS);
-    // A lapsed record renews into the same refusal as one that never existed: the
-    // client's next move is to register again, stating its selector and argv.
+    // The operation is still refused, but its diagnosis is not the never-held
+    // case: renewal stopped after a real registration and that is what to fix.
     expect(() => daemon.renewProject("acme/widgets")).toThrow(RedskilledProjectUnregisteredError);
+    expect(() => daemon.renewProject("acme/widgets")).toThrow(
+      /lapsed at 2026-07-31T12:01:00\.000Z \(registered 2026-07-31T12:00:00\.000Z\)/,
+    );
     expect(daemon.hostState().registrations).toEqual([]);
   });
 

--- a/apps/redskilled/tests/registration-sustain.test.ts
+++ b/apps/redskilled/tests/registration-sustain.test.ts
@@ -346,7 +346,8 @@ describe("a project that no longer intends to drain lapses, and says so", () => 
       },
     );
     expect(render.project_match).toBe("lapsed");
-    expect(render.line).toContain("!lapsed");
+    expect(render.line).toContain("project unknown — acme/widgets lapsed at");
+    expect(render.line).toContain("(registered ");
     expect(render.line).not.toContain("idle");
 
     const polled = await daemon.pollQueueDiscovery();

--- a/apps/redskilled/tests/statusline-local-project.test.ts
+++ b/apps/redskilled/tests/statusline-local-project.test.ts
@@ -210,7 +210,7 @@ describe("`project unknown`", () => {
 
     expect(render.project_match).toBe("unregistered");
     expect(render.line).toContain("project unknown");
-    expect(render.line).toContain("acme/widgets is not registered on this host");
+    expect(render.line).toContain("acme/widgets was never registered on this host");
     // No idle zero to read as calm — the host may be busy for someone else.
     expect(render.line).not.toContain("0w");
     expect(render.line).not.toContain("idle");

--- a/apps/redskilled/tests/statusline-payload.test.ts
+++ b/apps/redskilled/tests/statusline-payload.test.ts
@@ -164,6 +164,49 @@ describe("the statusline payload", () => {
     expect(payload.host.observed_rss_bytes).toBe(0);
   });
 
+  it("carries each absent registration history without collapsing it", () => {
+    const historical = {
+      ...hostStateOf([]),
+      lapsed_registrations: [{
+        project_label: "acme/lapsed",
+        registered_at: "2026-08-03T17:25:30.000Z",
+        at: "2026-08-03T17:36:15.000Z",
+        renew_by: "2026-08-03T17:36:15.000Z",
+        renewals: 2,
+        sustains: 0,
+        detail: "nothing renewed it",
+      }],
+      stopped_registrations: [{
+        project_label: "acme/stopped",
+        registered_at: "2026-08-03T17:25:30.000Z",
+        at: "2026-08-03T17:41:02.000Z",
+        detail: "released by project_stop",
+      }],
+      orphaned_registrations: [{ project_label: "acme/orphaned" }],
+    };
+    const answer = buildStatuslinePayload({
+      hostState: historical,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      rss: {},
+      sampledAt: null,
+      now: "2026-08-03T17:42:00.000Z",
+    });
+
+    expect(answer.known_projects).toEqual(["acme/lapsed", "acme/orphaned", "acme/stopped"]);
+    expect(answer.lapsed_projects).toEqual([{
+      project_label: "acme/lapsed",
+      registered_at: "2026-08-03T17:25:30.000Z",
+      at: "2026-08-03T17:36:15.000Z",
+      reason: "nothing renewed it",
+    }]);
+    expect(answer.stopped_projects).toEqual([{
+      project_label: "acme/stopped",
+      at: "2026-08-03T17:41:02.000Z",
+    }]);
+    expect(answer.orphaned_projects).toEqual(["acme/orphaned"]);
+    expect(isRedskilledStatuslinePayload(answer)).toBe(true);
+  });
+
   it("carries the derived metrics block, and validates with or without it", () => {
     const now = "2026-07-29T12:00:00.000Z";
     const metrics = deriveRedskilledLiveMetrics({

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -41,7 +41,6 @@ import {
   BUDGET_SPENT_MARK,
   DEATH_MARK,
   ENGINE_BEHIND_MARK,
-  LAPSED_MARK,
   LOG_LINE_MARK,
   REDSKILLED_RENDER_ABSENCE,
   UNREGISTERED_MARK,
@@ -295,18 +294,18 @@ function renderHead(
     parts.push(`${options.project} ${workers.length}w`);
     parts.push(memoryFigure(payload, options));
     if (workers.length === 0) parts.push("idle");
-  } else if (match === "name-only" || match === "lapsed") {
+  } else if (match === "name-only") {
     // The Workers still count — they are running — but the line says out loud
     // that the host holds no registration, and it never says `idle`: a project
     // nothing will be born for is stopped, not resting (#2973).
     parts.push(`${options.project} ${workers.length}w`);
     parts.push(memoryFigure(payload, options));
-    parts.push(match === "lapsed" ? LAPSED_MARK : UNREGISTERED_MARK);
+    parts.push(UNREGISTERED_MARK);
   } else {
     // NOT `0w idle`. An unmatched directory has no Worker count to report — the
     // host may be holding a dozen for a project this one failed to name — so the
     // head states the mismatch instead of an aggregate that reads as calm.
-    parts.push(unmatchedHead(options.project, match));
+    parts.push(unmatchedHead(payload, options.project, match));
   }
   parts.push(engineMark(payload));
   const budget = budgetMark(payload);
@@ -382,10 +381,33 @@ function deathMark(payload: RedskilledRenderPayload): string | null {
  * `project.name` or a git remote, the other wants the project registered — and a
  * line that named neither would leave the operator with a word and no next step.
  */
-function unmatchedHead(project: string | null, match: RedskilledStatuslineProjectMatch): string {
-  return match === "unregistered"
-    ? `project unknown — ${project} is not registered on this host`
-    : "project unknown — this directory resolved to no project";
+function unmatchedHead(
+  payload: RedskilledRenderPayload,
+  project: string | null,
+  match: RedskilledStatuslineProjectMatch,
+): string {
+  if (match === "unregistered") return `project unknown — ${project} was never registered on this host`;
+  if (match === "orphaned") {
+    return `project unknown — ${project} is registered on a daemon this socket does not reach`;
+  }
+  if (match === "stopped") {
+    const stopped = payload.stopped_projects?.find((record) => record.project_label === project);
+    return `project unknown — ${project} was stopped${stopped == null ? "" : ` at ${clockTime(stopped.at)}`}`;
+  }
+  if (match === "lapsed") {
+    const lapse = payload.lapsed_projects?.find((record) => record.project_label === project);
+    if (lapse != null) {
+      const registered = lapse.registered_at == null ? "" : ` (registered ${clockTime(lapse.registered_at)})`;
+      return `project unknown — ${project} lapsed at ${clockTime(lapse.at)}${registered}`;
+    }
+    return `project unknown — ${project} lapsed`;
+  }
+  return "project unknown — this directory resolved to no project";
+}
+
+/** The clock part of a daemon instant, without consulting this process's locale. PURE. */
+function clockTime(instant: string): string {
+  return /^\d{4}-\d{2}-\d{2}T(\d{2}:\d{2}:\d{2})/.exec(instant)?.[1] ?? instant;
 }
 
 /**

--- a/packages/redskilled-render/payload.ts
+++ b/packages/redskilled-render/payload.ts
@@ -329,8 +329,17 @@ export interface RedskilledRenderPayload {
   readonly lapsed_projects?: readonly {
     readonly project_label: string;
     readonly at: string;
+    /** When the registration began; absent on payloads from older daemons. */
+    readonly registered_at?: string;
     readonly reason: string;
   }[];
+  /** Registrations deliberately released through `project_stop`, newest last. */
+  readonly stopped_projects?: readonly {
+    readonly project_label: string;
+    readonly at: string;
+  }[];
+  /** Registrations held by a live daemon other than the one this socket reached. */
+  readonly orphaned_projects?: readonly string[];
   readonly repository_activity?: RedskilledRenderActivity;
   readonly github_balance?: RedskilledRenderBalance;
   readonly deaths?: RedskilledRenderDeaths;

--- a/packages/redskilled-render/select.ts
+++ b/packages/redskilled-render/select.ts
@@ -45,6 +45,10 @@ export type RedskilledStatuslineProjectMatch =
   | "name-only"
   /** The daemon recorded when and why this project's registration lapsed. */
   | "lapsed"
+  /** The daemon recorded that an operator deliberately released the registration. */
+  | "stopped"
+  /** Another live daemon still owns the registration, beyond this socket. */
+  | "orphaned"
   | "unregistered"
   | "unresolved"
   /** No daemon answered, so whether this host knows the project is unknowable. */
@@ -96,6 +100,10 @@ export function resolveStatuslineProjectMatch(
   // accusation on every line a skewed daemon serves.
   if (payload.registered_projects == null) return "matched";
   if (payload.registered_projects.includes(project)) return "matched";
+  if (payload.orphaned_projects?.includes(project) === true) return "orphaned";
+  if (payload.stopped_projects?.some((stopped) => stopped.project_label === project) === true) {
+    return "stopped";
+  }
   if (payload.lapsed_projects?.some((lapse) => lapse.project_label === project) === true) {
     return "lapsed";
   }

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -182,6 +182,74 @@ describe("stateless, and it opens no transport", () => {
   });
 });
 
+describe("an unknown project's registration history (#3191)", () => {
+  const emptyHost = {
+    ...payload().host,
+    worker_count: 0,
+    project_count: 0,
+    observed_rss_bytes: 0,
+    measured_worker_count: 0,
+    ceiling_used_fraction: 0,
+  };
+
+  it.each([
+    [
+      "was never registered",
+      payload({
+        host: emptyHost,
+        projects: [],
+        workers: [],
+        known_projects: [],
+        registered_projects: [],
+      }),
+      "project unknown — acme/widgets was never registered on this host v3.3.11",
+    ],
+    [
+      "lapsed",
+      payload({
+        host: emptyHost,
+        projects: [],
+        workers: [],
+        known_projects: ["acme/widgets"],
+        registered_projects: [],
+        lapsed_projects: [{
+          project_label: "acme/widgets",
+          at: "2026-08-03T17:36:15.000Z",
+          registered_at: "2026-08-03T17:25:30.000Z",
+          reason: "nothing renewed it",
+        }],
+      }),
+      "project unknown — acme/widgets lapsed at 17:36:15 (registered 17:25:30) v3.3.11",
+    ],
+    [
+      "was deliberately stopped",
+      payload({
+        host: emptyHost,
+        projects: [],
+        workers: [],
+        known_projects: ["acme/widgets"],
+        registered_projects: [],
+        stopped_projects: [{ project_label: "acme/widgets", at: "2026-08-03T17:41:02.000Z" }],
+      }),
+      "project unknown — acme/widgets was stopped at 17:41:02 v3.3.11",
+    ],
+    [
+      "belongs to an orphaned daemon",
+      payload({
+        host: emptyHost,
+        projects: [],
+        workers: [],
+        known_projects: ["acme/widgets"],
+        registered_projects: [],
+        orphaned_projects: ["acme/widgets"],
+      }),
+      "project unknown — acme/widgets is registered on a daemon this socket does not reach v3.3.11",
+    ],
+  ])("states that it %s", (_history, doc, expected) => {
+    expect(renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 240 }).line).toBe(expected);
+  });
+});
+
 describe("a fixture payload renders identically to a live one", () => {
   it("draws the same line from JSON, from TOON and from an already-decoded value", () => {
     const doc = payload({ workers: [worker({ display: display() })] });


### PR DESCRIPTION
Automated AFK landing for #3191. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3191

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788390714&installation_model_id=20659&pr_number=3229&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3229&signature=3534e841edf1a1b2b6453e37001a511a4cb2540e88e15b67cc6833dc4dee833a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->