### PR TITLE
fix: #3219 The validation gate is a capacity-one mutex, so four Workers buy one validation at a time and the parallelism is spent waiting

### DIFF
--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -54,9 +54,13 @@ import {
 } from "../core/feedback.js";
 import type { BackpressureExec } from "../core/backpressure.js";
 import type { PostWorkerFormatExec } from "../core/post-worker-format.js";
+import {
+  readRedskilledHostConfig,
+  resolveRedskilledHostSettings,
+} from "@reddb-io/redskilled/host-config";
 import { execTool, pnpm as runPnpm, type ExecOptions, type ExecOutput } from "./exec.js";
 import * as gitx from "./git.js";
-import { createPathLock } from "./land-lock.js";
+import { createPathLock, createPathSemaphore } from "./land-lock.js";
 import type { LandLockWaitInfo } from "../core/land-lock.js";
 
 /**
@@ -191,8 +195,8 @@ export interface FeedbackWorktreeIO {
    */
   lock?(dest: string, onWait?: LockWaitSink): Promise<(() => Promise<void>) | null>;
   /**
-   * Host-wide capacity-one semaphore for validation commands. Every live worker
-   * and no-agent reconcile manager binds the same `.red/state` lock.
+   * Host-wide sized semaphore for validation commands. Every live worker and
+   * no-agent reconcile manager binds the same `.red/state` slot set.
    */
   gateLock?(root: string, onWait?: LockWaitSink): Promise<(() => Promise<void>) | null>;
 }
@@ -204,7 +208,7 @@ export interface FeedbackWorktreeIO {
  * healthy `live=true` worker doing nothing for half an hour (#2985).
  */
 export interface LockWaitNotice {
-  /** `validation-gate` (host-wide capacity-one) or `feedback-worktree`. */
+  /** `validation-gate` (host-wide sized semaphore) or `feedback-worktree`. */
   lock: "validation-gate" | "feedback-worktree";
   /**
    * Where the wait stands. A `waiting` notice is only ever followed by exactly
@@ -416,8 +420,10 @@ const defaultIO: FeedbackWorktreeIO = {
   gateLock: async (root, onWait) => {
     const stateDir = join(root, ".red", "state");
     await mkdir(stateDir, { recursive: true });
+    const hostConfig = await readRedskilledHostConfig();
+    const capacity = resolveRedskilledHostSettings({ config: hostConfig }).ceiling.validation_count ?? 1;
     return acquireAnnounced("validation-gate", onWait, (report) =>
-      createPathLock(join(stateDir, "validation-gate.lock"), `validation-gate:${process.pid}`, {
+      createPathSemaphore(join(stateDir, "validation-gate.lock"), `validation-gate:${process.pid}`, capacity, {
         waitTimeoutMs: GATE_LOCK_WAIT_MS,
         staleAfterMs: GATE_LOCK_STALE_MS,
         pollMs: 500,

--- a/apps/dev/src/runtime/land-lock.ts
+++ b/apps/dev/src/runtime/land-lock.ts
@@ -90,6 +90,88 @@ export function createPathLock(
   );
 }
 
+/**
+ * Build a host-backed sized semaphore from independent file-lock slots.
+ *
+ * Slot one deliberately keeps `path` unchanged, so a capacity-one host and a
+ * rolling upgrade from the old mutex coordinate through the exact historical
+ * lock file. Higher capacities add numbered sibling locks. Acquisition scans
+ * every slot without waiting before it polls one, so a busy first slot cannot
+ * hide a free later slot.
+ */
+export function createPathSemaphore(
+  path: string,
+  holder: string,
+  capacity: number,
+  options: {
+    waitTimeoutMs?: number;
+    pollMs?: number;
+    staleAfterMs?: number;
+    onWait?: (info: LandLockWaitInfo) => void;
+  } = {},
+  pid: number = process.pid,
+): LandLock {
+  const slots = Number.isSafeInteger(capacity) && capacity > 0 ? capacity : 1;
+  const waitTimeoutMs = options.waitTimeoutMs ?? 15 * 60_000;
+  const pollMs = options.pollMs ?? 1_000;
+  let nextSlot = Math.abs(pid) % slots;
+  let attempt = 0;
+  let startedAtMs = 0;
+  let deadline = 0;
+
+  const slotPath = (index: number): string => {
+    if (index === 0) return path;
+    return path.endsWith(".lock")
+      ? `${path.slice(0, -".lock".length)}.${index + 1}.lock`
+      : `${path}.${index + 1}`;
+  };
+
+  const lockFor = (
+    index: number,
+    timeout: number,
+    onWait?: (info: LandLockWaitInfo) => void,
+  ): LandLock => createPathLock(slotPath(index), `${holder}:slot-${index + 1}`, {
+    waitTimeoutMs: timeout,
+    pollMs: Math.max(1, Math.min(pollMs, timeout || pollMs)),
+    ...(options.staleAfterMs == null ? {} : { staleAfterMs: options.staleAfterMs }),
+    ...(onWait == null ? {} : { onWait }),
+  }, pid);
+
+  return {
+    async acquire() {
+      startedAtMs = Date.now();
+      deadline = startedAtMs + waitTimeoutMs;
+      for (;;) {
+        for (let offset = 0; offset < slots; offset += 1) {
+          const index = (nextSlot + offset) % slots;
+          const release = await lockFor(index, 0).acquire();
+          if (release !== null) return release;
+        }
+
+        const now = Date.now();
+        if (now >= deadline) return null;
+        const index = nextSlot;
+        nextSlot = (nextSlot + 1) % slots;
+        const waitForMs = Math.max(1, Math.min(pollMs, deadline - now));
+        const release = await lockFor(index, waitForMs, (info) => {
+          attempt += 1;
+          try {
+            options.onWait?.({
+              ...info,
+              waitedMs: Math.max(0, Date.now() - startedAtMs),
+              remainingMs: Math.max(0, deadline - Date.now()),
+              attempt,
+            });
+          } catch {
+            // Observability cannot change semaphore ownership.
+          }
+        }).acquire();
+        if (release !== null) return release;
+      }
+    },
+  };
+}
+
 /** Build the host-backed global land-lock for this worker process. */
 export function createLandLock(tmpDir: string, holder: string, pid: number = process.pid): LandLock {
   return createPathLock(landLockPath(tmpDir), holder, {}, pid);

--- a/apps/dev/tests/path-semaphore.test.ts
+++ b/apps/dev/tests/path-semaphore.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createPathSemaphore } from "../src/runtime/land-lock.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("file-backed validation semaphore", () => {
+  it("admits K holders and queues the next one until a slot is released", async () => {
+    const root = await mkdtemp(join(tmpdir(), "validation-semaphore-"));
+    roots.push(root);
+    const path = join(root, "validation-gate.lock");
+    const first = await createPathSemaphore(path, "first", 2, { pollMs: 5 }).acquire();
+    const second = await createPathSemaphore(path, "second", 2, { pollMs: 5 }).acquire();
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+
+    let acquired = false;
+    const third = createPathSemaphore(path, "third", 2, { pollMs: 5 })
+      .acquire()
+      .then((release) => {
+        acquired = true;
+        return release;
+      });
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    expect(acquired).toBe(false);
+
+    await first?.();
+    const releaseThird = await third;
+    expect(releaseThird).not.toBeNull();
+
+    await second?.();
+    await releaseThird?.();
+  });
+
+  it("uses the legacy lock path as the only slot when K = 1", async () => {
+    const root = await mkdtemp(join(tmpdir(), "validation-semaphore-one-"));
+    roots.push(root);
+    const path = join(root, "validation-gate.lock");
+    const release = await createPathSemaphore(path, "only", 1).acquire();
+
+    expect(release).not.toBeNull();
+    await expect(createPathSemaphore(path, "blocked", 1, { waitTimeoutMs: 0 }).acquire())
+      .resolves.toBeNull();
+    await release?.();
+  });
+});

--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -296,12 +296,17 @@ plugins:
     redskilled:
       worker_ceiling: 6
       memory_ceiling: 8G
+      validation_ceiling: 2
       idle_ms: 300000
 ```
 
 Resolution is `serve` flag > environment > home config > derived default.
 The ceiling flags are `--worker-ceiling` and `--memory-ceiling`; their environment
 counterparts are `REDSKILLED_WORKER_CEILING` and `REDSKILLED_MEMORY_CEILING`.
+`validation_ceiling` (or `REDSKILLED_VALIDATION_CEILING`) sizes the host-wide
+full-suite semaphore. When absent, its capacity is the tightest of half the
+available CPU count, the resolved memory ceiling in 2 GiB shares, and the
+Worker ceiling; every dimension retains a minimum capacity of one.
 `REDSKILLED_IDLE_MS` follows the same precedence for idle time. `host-state`
 reports the resolved `ceiling` and the `memory_source` / `worker_source` that won,
 so a restart or an auto-spawn from another project remains directly auditable.

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -12,6 +12,7 @@
     "./demand-producer": "./src/demand-producer.ts",
     "./event-lane": "./src/event-lane.ts",
     "./host-state": "./src/host-state.ts",
+    "./host-config": "./src/host-config.ts",
     "./launch-template": "./src/launch-template.ts",
     "./live-metrics": "./src/live-metrics.ts",
     "./paths": "./src/paths.ts",

--- a/apps/redskilled/src/admission.ts
+++ b/apps/redskilled/src/admission.ts
@@ -24,7 +24,7 @@
  * that reads the environment, and even that takes the host's memory as an
  * argument.
  */
-import { totalmem } from "node:os";
+import { availableParallelism, totalmem } from "node:os";
 import { parseMemoryBudget } from "./budget-accounting.js";
 import type { RedskilledWorkerView } from "./host-state.js";
 import type { RedskilledWorkerBudget } from "./worker-placement.js";
@@ -34,6 +34,9 @@ export const REDSKILLED_MEMORY_CEILING_ENV = "REDSKILLED_MEMORY_CEILING";
 
 /** Env var that states the host-wide Worker count ceiling; `infinity` lifts it. */
 export const REDSKILLED_WORKER_CEILING_ENV = "REDSKILLED_WORKER_CEILING";
+
+/** Env var that states how many validation suites may run at once on this host. */
+export const REDSKILLED_VALIDATION_CEILING_ENV = "REDSKILLED_VALIDATION_CEILING";
 
 /** Env var that states how many interactive Workers may run above the Worker ceiling. */
 export const REDSKILLED_INTERACTIVE_RESERVATION_ENV = "REDSKILLED_INTERACTIVE_RESERVATION";
@@ -50,6 +53,12 @@ export const DEFAULT_INTERACTIVE_RESERVATION = 1;
  */
 export const DEFAULT_HOST_MEMORY_CEILING_FRACTION = 0.7;
 
+/** One validation child may use this much old-space before Node terminates it. */
+export const DEFAULT_VALIDATION_MEMORY_BYTES = 2 * 1024 ** 3;
+
+/** Keep one core available to the Worker/orchestrator for every validation child. */
+export const DEFAULT_VALIDATION_CORES_PER_SLOT = 2;
+
 /** The operator-facing origin of one resolved host setting. */
 export type RedskilledHostSettingSource = "flag" | "environment" | "home-config" | "derived-default";
 
@@ -59,6 +68,8 @@ export interface RedskilledHostCeiling {
   readonly memory_bytes: number | null;
   /** Total live Workers this host may hold, across every project. */
   readonly worker_count: number | null;
+  /** Concurrent full validation suites this host may run. */
+  readonly validation_count?: number;
   /** Extra Workers admitted only when a request claims the interactive reservation. */
   readonly interactive_reservation?: number;
   /** `declared` when an operator stated it, `host-fraction` when derived. */
@@ -67,17 +78,23 @@ export interface RedskilledHostCeiling {
   readonly memory_source?: RedskilledHostSettingSource;
   /** How the Worker-count dimension was resolved. Present on daemon-resolved ceilings. */
   readonly worker_source?: RedskilledHostSettingSource;
+  /** How the validation-count dimension was resolved. Present on daemon-resolved ceilings. */
+  readonly validation_source?: RedskilledHostSettingSource;
 }
 
 export interface RedskilledHostCeilingOptions {
   readonly flags?: {
     readonly memoryCeiling?: string;
     readonly workerCeiling?: string;
+    readonly validationCeiling?: string;
   };
   readonly config?: {
     readonly memoryCeiling?: string;
     readonly workerCeiling?: string;
+    readonly validationCeiling?: string;
   };
+  /** Injectable host fact for deterministic capacity tests. */
+  readonly availableParallelism?: number;
 }
 
 /** No ceiling at all — an operator's explicit opt-out, and the tests' baseline. */
@@ -365,6 +382,11 @@ export function resolveHostCeiling(
     env[REDSKILLED_WORKER_CEILING_ENV],
     options.config?.workerCeiling,
   );
+  const validationDeclaration = selectDeclaration(
+    options.flags?.validationCeiling,
+    env[REDSKILLED_VALIDATION_CEILING_ENV],
+    options.config?.validationCeiling,
+  );
   const declaredMemory = memoryDeclaration?.value ?? "";
   const declaredWorkers = workerDeclaration?.value ?? "";
   const declaredReservation = (env[REDSKILLED_INTERACTIVE_RESERVATION_ENV] ?? "").trim();
@@ -388,14 +410,14 @@ export function resolveHostCeiling(
   if (declaredMemory !== "") {
     const memory = parseMemoryCeiling(declaredMemory, totalMemoryBytes);
     if (memory !== undefined) {
-      return {
+      return withValidationCapacity({
         memory_bytes: memory,
         worker_count: workerCount,
         interactive_reservation: interactiveReservation ?? DEFAULT_INTERACTIVE_RESERVATION,
         source: "declared",
         memory_source: memoryDeclaration!.source,
         worker_source: workerSource,
-      };
+      }, validationDeclaration, options.availableParallelism ?? availableParallelism());
     }
     // Named rather than obeyed in silence. A malformed ceiling is a limit the
     // operator believes they set, and falling through quietly gives them the
@@ -415,7 +437,7 @@ export function resolveHostCeiling(
         `non-negative integer; using the default reservation of ${DEFAULT_INTERACTIVE_RESERVATION} Worker(s) instead.`,
     );
   }
-  return {
+  return withValidationCapacity({
     memory_bytes: Math.floor(totalMemoryBytes * DEFAULT_HOST_MEMORY_CEILING_FRACTION),
     worker_count: workerCount,
     interactive_reservation: interactiveReservation ?? DEFAULT_INTERACTIVE_RESERVATION,
@@ -428,6 +450,35 @@ export function resolveHostCeiling(
     // memory. An operator debugging a denied Worker was told they had stated a
     // number they never stated.
     source: "host-fraction",
+  }, validationDeclaration, options.availableParallelism ?? availableParallelism());
+}
+
+function withValidationCapacity(
+  ceiling: RedskilledHostCeiling,
+  declaration: { readonly value: string; readonly source: RedskilledHostSettingSource } | undefined,
+  hostParallelism: number,
+): RedskilledHostCeiling {
+  if (declaration !== undefined) {
+    const count = parseCountCeiling(declaration.value);
+    if (count !== null) {
+      return { ...ceiling, validation_count: count, validation_source: declaration.source };
+    }
+    warn(
+      `redskilled: ${describeDeclaration(declaration)} ${REDSKILLED_VALIDATION_CEILING_ENV}=` +
+        `${JSON.stringify(declaration.value)} is not a positive integer; deriving the validation ceiling from ` +
+        "host CPU, memory, and Worker capacity instead.",
+    );
+  }
+
+  const cpuSlots = Math.max(1, Math.floor(Math.max(1, hostParallelism) / DEFAULT_VALIDATION_CORES_PER_SLOT));
+  const memorySlots = ceiling.memory_bytes == null
+    ? Number.POSITIVE_INFINITY
+    : Math.max(1, Math.floor(ceiling.memory_bytes / DEFAULT_VALIDATION_MEMORY_BYTES));
+  const workerSlots = ceiling.worker_count ?? Number.POSITIVE_INFINITY;
+  return {
+    ...ceiling,
+    validation_count: Math.max(1, Math.min(cpuSlots, memorySlots, workerSlots)),
+    validation_source: "derived-default",
   };
 }
 
@@ -498,6 +549,8 @@ export function isRedskilledAdmissionVerdict(value: unknown): value is Redskille
     ceiling != null && typeof ceiling === "object" &&
     (ceiling.memory_bytes === null || typeof ceiling.memory_bytes === "number") &&
     (ceiling.worker_count === null || typeof ceiling.worker_count === "number") &&
+    (ceiling.validation_count === undefined ||
+      (Number.isInteger(ceiling.validation_count) && Number(ceiling.validation_count) > 0)) &&
     (ceiling.interactive_reservation === undefined ||
       (Number.isInteger(ceiling.interactive_reservation) && Number(ceiling.interactive_reservation) >= 0)) &&
     consumption != null && typeof consumption === "object" &&

--- a/apps/redskilled/src/host-config.ts
+++ b/apps/redskilled/src/host-config.ts
@@ -21,12 +21,14 @@ export const REDSKILLED_HOST_CONFIG_PATH = ".red/config.yaml";
 export interface RedskilledHostConfig {
   readonly workerCeiling?: string;
   readonly memoryCeiling?: string;
+  readonly validationCeiling?: string;
   readonly idleMs?: string;
 }
 
 export interface RedskilledHostSettingFlags {
   readonly workerCeiling?: string;
   readonly memoryCeiling?: string;
+  readonly validationCeiling?: string;
   readonly idleMs?: number;
 }
 
@@ -55,6 +57,7 @@ export async function readRedskilledHostConfig(
     return {
       ...valueAt(values, "plugins.dev.redskilled.worker_ceiling", "workerCeiling"),
       ...valueAt(values, "plugins.dev.redskilled.memory_ceiling", "memoryCeiling"),
+      ...valueAt(values, "plugins.dev.redskilled.validation_ceiling", "validationCeiling"),
       ...valueAt(values, "plugins.dev.redskilled.idle_ms", "idleMs"),
     };
   } catch (error) {
@@ -71,12 +74,14 @@ export function resolveRedskilledHostSettings(input: {
   readonly env?: NodeJS.ProcessEnv;
   readonly config?: RedskilledHostConfig;
   readonly totalMemoryBytes?: number;
+  readonly availableParallelism?: number;
 } = {}): RedskilledHostSettings {
   const env = input.env ?? process.env;
   const config = input.config ?? {};
   const ceiling = resolveHostCeiling(env, input.totalMemoryBytes ?? totalmem(), {
     flags: input.flags,
     config,
+    ...(input.availableParallelism == null ? {} : { availableParallelism: input.availableParallelism }),
   });
   const idle = select(input.flags?.idleMs == null ? undefined : String(input.flags.idleMs), env[REDSKILLED_IDLE_MS_ENV], config.idleMs);
   if (idle == null) {

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -511,9 +511,12 @@ function isHostCeiling(value: unknown): value is RedskilledHostCeiling {
   const origins = new Set(["flag", "environment", "home-config", "derived-default"]);
   return (ceiling.memory_bytes === null || typeof ceiling.memory_bytes === "number") &&
     (ceiling.worker_count === null || typeof ceiling.worker_count === "number") &&
+    (ceiling.validation_count === undefined ||
+      (Number.isInteger(ceiling.validation_count) && Number(ceiling.validation_count) > 0)) &&
     (ceiling.source === "declared" || ceiling.source === "host-fraction") &&
     (ceiling.memory_source === undefined || origins.has(String(ceiling.memory_source))) &&
-    (ceiling.worker_source === undefined || origins.has(String(ceiling.worker_source)));
+    (ceiling.worker_source === undefined || origins.has(String(ceiling.worker_source))) &&
+    (ceiling.validation_source === undefined || origins.has(String(ceiling.validation_source)));
 }
 
 /** True when `value` is a complete version block. */

--- a/apps/redskilled/src/provision.ts
+++ b/apps/redskilled/src/provision.ts
@@ -72,6 +72,7 @@ plugins:
     redskilled:
       # worker_ceiling: 6
       # memory_ceiling: 8G
+      # validation_ceiling: 2
       # idle_ms: 300000
 `;
 

--- a/apps/redskilled/tests/host-admission.test.ts
+++ b/apps/redskilled/tests/host-admission.test.ts
@@ -289,10 +289,12 @@ describe("the ceiling a host admits against", () => {
       .toEqual({
         memory_bytes: 6 * GIB,
         worker_count: 4,
+        validation_count: 3,
         interactive_reservation: 1,
         source: "declared",
         memory_source: "environment",
         worker_source: "environment",
+        validation_source: "derived-default",
       });
   });
 

--- a/apps/redskilled/tests/host-config.test.ts
+++ b/apps/redskilled/tests/host-config.test.ts
@@ -39,6 +39,7 @@ describe("the daemon-owned host config", () => {
       "    redskilled:",
       "      worker_ceiling: 6",
       "      memory_ceiling: 8G",
+      "      validation_ceiling: 3",
       "      idle_ms: 61000",
       "",
     ].join("\n"));
@@ -46,6 +47,7 @@ describe("the daemon-owned host config", () => {
     await expect(readRedskilledHostConfig(home)).resolves.toEqual({
       workerCeiling: "6",
       memoryCeiling: "8G",
+      validationCeiling: "3",
       idleMs: "61000",
     });
   });
@@ -131,5 +133,35 @@ describe("host setting precedence", () => {
       config: { idleMs: "60000" },
       totalMemoryBytes: TOTAL,
     })).toMatchObject({ idleMs: 60_000, idleMsSource: "home-config" });
+  });
+
+  it("derives validation slots from the tightest CPU, memory, and Worker ceiling", () => {
+    const settings = resolveRedskilledHostSettings({
+      env: {},
+      config: { workerCeiling: "3", memoryCeiling: "16G" },
+      totalMemoryBytes: 32 * 1024 ** 3,
+      availableParallelism: 12,
+    });
+
+    expect(settings.ceiling.validation_count).toBe(3);
+    expect(settings.ceiling.validation_source).toBe("derived-default");
+  });
+
+  it("keeps a small host at one validation slot and lets the operator declare K = 1", () => {
+    const derived = resolveRedskilledHostSettings({
+      env: {},
+      totalMemoryBytes: 2 * 1024 ** 3,
+      availableParallelism: 2,
+    });
+    expect(derived.ceiling.validation_count).toBe(1);
+
+    const declared = resolveRedskilledHostSettings({
+      env: {},
+      config: { validationCeiling: "1" },
+      totalMemoryBytes: 64 * 1024 ** 3,
+      availableParallelism: 32,
+    });
+    expect(declared.ceiling.validation_count).toBe(1);
+    expect(declared.ceiling.validation_source).toBe("home-config");
   });
 });


### PR DESCRIPTION
Automated AFK landing for #3219. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3219

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788391821&installation_model_id=20659&pr_number=3230&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3230&signature=220af55f1b4d112619dab08ed46234aa76b24b597b699b5a1a8da32d5813791b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->