### PR TITLE
chore: #3231 /go: The validation gate charges two costs that do not belong to the Worker p

### DIFF
--- a/.changeset/calm-gates-revalidate.md
+++ b/.changeset/calm-gates-revalidate.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Keep release-only version bumps inside a Worker's validation cone and rerun only the gate after stale-base drift.

--- a/apps/dev/src/commands/run/ports/lookups.ts
+++ b/apps/dev/src/commands/run/ports/lookups.ts
@@ -77,6 +77,8 @@ export function buildLookups({
         },
       }),
     changedFiles: (branch, base) => gitx.changedFiles(gitCtx, branch, base),
+    changedFileContents: (branch, base, file) =>
+      gitx.changedFileContents(gitCtx, branch, base, file),
     diffstat: (branch, base) => gitx.diffstat(gitCtx, branch, base),
     // The review stage's subject (#2730): the branch as it stands against the
     // merge base, read before any PR exists.

--- a/apps/dev/src/commands/run/reconcile.ts
+++ b/apps/dev/src/commands/run/reconcile.ts
@@ -208,6 +208,8 @@ export function makeBootReconcileRunner(
       },
       lookups: {
         changedFiles: (branch, base) => gitx.changedFiles(gitCtx, branch, base),
+        changedFileContents: (branch, base, file) =>
+          gitx.changedFileContents(gitCtx, branch, base, file),
         branchPresent: async (branch) => {
           if (await gitx.branchExists(gitCtx, branch)) return true;
           await gitx.fetchBranch(gitCtx, branch);

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -643,6 +643,9 @@ export async function processIssue(
   let noSourceDiffWarning: string | undefined;
   let currentHandoff = handoff;
   let correctionLedger: CorrectionLedger = EMPTY_CORRECTION_LEDGER;
+  // A stale-base attribution buys another GATE run, not another implementer
+  // run: the branch did not change, only the merge result did (#3231).
+  let gateRevalidationSkip = false;
   const scoutTextChunks: string[] = [];
   const agentEventSink: typeof deps.recordAgentEvent =
     input.runMode === "scout"
@@ -824,20 +827,42 @@ export async function processIssue(
    * bumps the round ordinal, appends to the handoff, fires `pre_attempt`, and
    * emits one worker event naming the trigger.
    *
-   * A drift-attributed gate round is FREE: it is recorded on the ledger but
-   * never drawn from the budget, so an already-spent counter can no longer park
-   * a branch whose gate only failed because the base moved beneath it (#2711). */
+   * A drift-attributed failure exits before the Re-seed mechanics: it records a
+   * free ledger cycle and requests gate-only re-validation, because no
+   * implementer work changed (#3231). */
   const requestReseed = async (req: ReseedRequest): Promise<ReseedOutcome> => {
     const cause = reseedTriggerCause(req.trigger);
     const { attribution, drift } =
       cause === "gate"
         ? await attributeGateFailureNow(req.driftEligible ?? false)
         : { attribution: undefined, drift: undefined };
-    const free = drift !== undefined;
+    if (drift) {
+      correctionLedger = chargeCorrection(correctionLedger, attribution.cause);
+      gateRevalidationSkip = true;
+      const gate = req.gate ?? "feedback";
+      const releaseBumps = attribution.releaseBumps.length > 0
+        ? ` Release bump: ${attribution.releaseBumps.join("; ")}.`
+        : "";
+      const note =
+        `🤖 ${reseedLane}: ${gate} machine gate failed after DONE, but ${attribution.reason}; ` +
+        `granting a free stale-base correction (${correctionLedger.refunded}/${staleBaseDriftCap}), ` +
+        `re-running validation without re-seeding; budget untouched at ` +
+        `${reseedSpend.gate ?? 0}/${gateSubCap}.${releaseBumps}`;
+      deps.appendIterLog(note);
+      deps.recordWorkerEvent?.("worker.gate_revalidation_requested", {
+        trigger: req.trigger,
+        cause: "stale-base-drift",
+        lane: reseedBudget.lane,
+        free: true,
+        cycle: correctionLedger.refunded,
+        cap: staleBaseDriftCap,
+      });
+      return "granted";
+    }
     const draw = reseedDraw(reseedBudget, cause, reseedSpend);
-    if (!free && !draw.allowed) return "refused";
+    if (!draw.allowed) return "refused";
     if (attribution) correctionLedger = chargeCorrection(correctionLedger, attribution.cause);
-    if (!free) reseedSpend = recordReseedDraw(reseedSpend, cause);
+    reseedSpend = recordReseedDraw(reseedSpend, cause);
     roundOrdinal += 1;
     reseedRound += 1;
     const gate = req.gate ?? "feedback";
@@ -882,13 +907,9 @@ export async function processIssue(
     } else {
       currentHandoff = composeReseed(
         isGoLane ? "go-machine-gate-retry" : "afk-gate-correction",
-        gateReseedDirectives({ gate, retry: gateSpend, cap: gateSubCap, drift }),
+        gateReseedDirectives({ gate, retry: gateSpend, cap: gateSubCap }),
       );
-      note = drift
-        ? `🤖 ${reseedLane}: ${gate} machine gate failed after DONE, but ${attribution?.reason}; ` +
-          `granting a free stale-base correction (${correctionLedger.refunded}/${staleBaseDriftCap}), ` +
-          `budget untouched at ${gateSpend}/${gateSubCap}.`
-        : `🤖 ${reseedLane}: ${gate} machine gate failed after DONE; correction retry ${gateSpend}/${gateSubCap}.`;
+      note = `🤖 ${reseedLane}: ${gate} machine gate failed after DONE; correction retry ${gateSpend}/${gateSubCap}.`;
     }
     deps.appendIterLog(note);
     await publishReseedTrail({ round: reseedRound, trigger: req.trigger, cause, note });
@@ -896,7 +917,7 @@ export async function processIssue(
       trigger: req.trigger,
       cause,
       lane: reseedBudget.lane,
-      free,
+      free: false,
       round: totalReseedSpend(reseedSpend),
       ceiling: reseedBudget.ceiling,
       cause_spent: reseedSpend[cause] ?? 0,
@@ -1097,14 +1118,21 @@ export async function processIssue(
       effort: routedEffort,
     });
     let run: RunAgentResult;
-    if (gateGreenSkip) {
-      // Consume the flag — subsequent loop iterations (e.g. go-verify retries)
-      // run the agent normally.
-      gateGreenSkip = false;
-      const fastBranch = resumableBranch!.branch;
-      deps.appendIterLog(
-        `🤖 /afk #${issue}: gate-green fast path — re-validating \`${fastBranch}\`, agent skipped.`,
-      );
+    let skippedAgentForGateOnly = false;
+    if (gateGreenSkip || gateRevalidationSkip) {
+      const fastBranch = gateGreenSkip ? resumableBranch!.branch : workerBranch;
+      if (gateGreenSkip) {
+        gateGreenSkip = false;
+        deps.appendIterLog(
+          `🤖 /afk #${issue}: gate-green fast path — re-validating \`${fastBranch}\`, agent skipped.`,
+        );
+      } else {
+        gateRevalidationSkip = false;
+        skippedAgentForGateOnly = true;
+        deps.appendIterLog(
+          `🤖 ${reseedLane} #${issue}: stale-base fast path — re-validating \`${fastBranch}\`, agent skipped.`,
+        );
+      }
       run = { outcome: "done", branch: fastBranch, commits: [], stdout: "" };
     } else {
       const baseAgentInput: RunAgentInput = {
@@ -1309,7 +1337,9 @@ export async function processIssue(
       };
     } else {
       const pwStatus = run.outcome === "done" ? "success" : "fail";
-      await fireHook("post_attempt", postAttemptContext(current, workerBranch, pwStatus, run.outcome));
+      if (!skippedAgentForGateOnly) {
+        await fireHook("post_attempt", postAttemptContext(current, workerBranch, pwStatus, run.outcome));
+      }
       if (run.outcome === "blocked") {
         return await terminalFailure(common, "blocked", "blocked", {
           notes: `_(inner agent emitted BLOCKED — see iteration log at \`${input.attemptDir}\`)_`,
@@ -1343,7 +1373,7 @@ export async function processIssue(
       return await mergeFailed(common, "worker branch absent — sandcastle commits did not reach the host");
     }
     const postWorkerFormatCommands = deps.postWorkerFormatCommands ?? [];
-    if (deps.postWorkerFormat && postWorkerFormatCommands.length > 0) {
+    if (!skippedAgentForGateOnly && deps.postWorkerFormat && postWorkerFormatCommands.length > 0) {
       markProcessSafetyStep("post-agent:post-attempt-format");
       const pfmt = await runPostWorkerFormat(deps.postWorkerFormat, {
         worktree: workerBranch,
@@ -1376,10 +1406,17 @@ export async function processIssue(
     if (noSourceDiffWarning) {
       deps.appendIterLog(`🤖 /afk: ${noSourceDiffWarning}`);
     }
+    let rootPackageJson: { before: string; after: string } | undefined;
+    if (changedFiles.some((file) => file === "package.json" || file === "./package.json")) {
+      rootPackageJson = await deps.lookups
+        .changedFileContents?.(workerBranch, baseRef, "package.json")
+        .catch(() => undefined);
+    }
     const validationScope = computeValidationScope(
       changedFiles,
       deps.layout,
       deps.graph ?? { packages: [] },
+      rootPackageJson ? { rootPackageJson } : undefined,
     );
     const feedbackScopes = scopesForValidationScope(validationScope);
     landingFeedbackScopes = feedbackScopes;

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -186,6 +186,15 @@ export interface ProcessLookups {
   /** Best-effort owning-glossary and path-local exemplar supplement (#2402). */
   handoffEnrichment?(input: HandoffEnrichmentInput & { issue: number }): Promise<string | undefined>;
   changedFiles(branch: string, base: string): Promise<string[]>;
+  /**
+   * File contents at the merge-base and branch endpoints of `base...branch`.
+   * Optional narrowing evidence: absence must retain path-based validation.
+   */
+  changedFileContents?(
+    branch: string,
+    base: string,
+    file: string,
+  ): Promise<{ before: string; after: string } | undefined>;
   diffstat(branch: string, base: string): Promise<string>;
   /**
    * The WORKTREE diff of `branch` against the merge base (#2730) — what the gate

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -123,6 +123,12 @@ export interface ReconcileFs {
 export interface ReconcileLookups {
   /** Changed files of the worker branch vs the base, for feedback scope resolution. */
   changedFiles(branch: string, base: string): Promise<string[]>;
+  /** Optional before/after content evidence for safe root-manifest narrowing. */
+  changedFileContents?(
+    branch: string,
+    base: string,
+    file: string,
+  ): Promise<{ before: string; after: string } | undefined>;
   /** Confirm the worker branch actually reached the host (optional → assume present). */
   branchPresent?(branch: string): Promise<boolean>;
   /** True when the session is locked to a branch. Since #842 the lock only
@@ -497,6 +503,14 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     );
     return { outcome: "skipped", reason: "no-commits" };
   }
+  const rootPackageJson = changedFiles.includes("package.json")
+    ? await deps.lookups.changedFileContents?.(branch, baseRef, "package.json").catch(() => undefined)
+    : undefined;
+  const feedbackScopes = deps.feedback.gateScopes(
+    deps.layout,
+    changedFiles,
+    rootPackageJson ? { rootPackageJson } : undefined,
+  );
 
   // ---- 4. feedback gate (the verdict — SAME authority as the DONE path) ----
   // The merge-conflict reland route (#1095) trusts the prior green validation
@@ -527,7 +541,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     // Mirrors the DONE path.
     feedback = await deps.feedback.runFeedback(deps.pnpm, {
       worktree: branch,
-      scopes: deps.feedback.gateScopes(deps.layout, changedFiles),
+      scopes: feedbackScopes,
       layout: deps.layout,
       now: deps.nowEpoch,
       baselineWorktree: input.base,
@@ -590,7 +604,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
           // is an infrastructure error, never a red validation verdict.
           worktreeKind: "checkout",
           ...(deps.dirExists === undefined ? {} : { dirExists: deps.dirExists }),
-          scopes: deps.feedback.gateScopes(deps.layout, changedFiles),
+          scopes: feedbackScopes,
           layout: deps.layout,
           now: deps.nowEpoch,
           baselineWorktree: input.base,

--- a/apps/dev/src/core/validation-scope.ts
+++ b/apps/dev/src/core/validation-scope.ts
@@ -43,6 +43,15 @@ export interface WorkspaceGraph {
   packages: WorkspacePackage[];
 }
 
+/** Content evidence for root files whose path alone cannot prove blast radius. */
+export interface ValidationScopeContentEvidence {
+  /** The two endpoints of the `base...branch` diff for the root manifest. */
+  rootPackageJson?: {
+    before: string;
+    after: string;
+  };
+}
+
 /**
  * The computed validation scope — either a filtered cone (touching only the
  * affected packages and their transitive dependents) or whole-workspace (when a
@@ -133,6 +142,51 @@ export type PathClass =
 
 function stripDotSlash(file: string): string {
   return file.startsWith("./") ? file.slice(2) : file;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function jsonValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => jsonValuesEqual(value, right[index]))
+    );
+  }
+  if (!isJsonObject(left) || !isJsonObject(right)) return false;
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key, index) => key === rightKeys[index] && jsonValuesEqual(left[key], right[key]),
+    )
+  );
+}
+
+/**
+ * Prove that two package manifests differ only in their top-level `version`.
+ * Parse failures, missing/non-string versions, and an unchanged version all
+ * fail closed: path-only evidence must retain whole-workspace validation.
+ */
+export function isVersionOnlyPackageJsonChange(before: string, after: string): boolean {
+  try {
+    const left: unknown = JSON.parse(before);
+    const right: unknown = JSON.parse(after);
+    if (!isJsonObject(left) || !isJsonObject(right)) return false;
+    if (typeof left.version !== "string" || typeof right.version !== "string") return false;
+    if (left.version === right.version) return false;
+    const { version: _leftVersion, ...leftWithoutVersion } = left;
+    const { version: _rightVersion, ...rightWithoutVersion } = right;
+    return jsonValuesEqual(leftWithoutVersion, rightWithoutVersion);
+  } catch {
+    return false;
+  }
 }
 
 /** The doc-contract owners this layout actually declares. */
@@ -264,6 +318,7 @@ export function computeValidationScope(
   changedFiles: readonly string[],
   layout: PackageLayout,
   graph: WorkspaceGraph,
+  contentEvidence: ValidationScopeContentEvidence = {},
 ): ValidationScope {
   const coreTrigger = coreModuleTriggerFile(changedFiles);
   if (coreTrigger !== undefined) {
@@ -271,9 +326,19 @@ export function computeValidationScope(
   }
 
   const touched = new Set<string>();
+  const versionOnlyRootManifest =
+    contentEvidence.rootPackageJson !== undefined &&
+    isVersionOnlyPackageJsonChange(
+      contentEvidence.rootPackageJson.before,
+      contentEvidence.rootPackageJson.after,
+    );
   for (const raw of changedFiles) {
     if (raw === "") continue;
     const file = stripDotSlash(raw);
+    // `package.json` remains a root trigger by default. It is discounted only
+    // when the diff endpoints prove that the top-level version is the sole
+    // semantic change; any missing or mixed evidence falls through to `whole`.
+    if (file === "package.json" && versionOnlyRootManifest) continue;
     const verdict = classifyChangedPath(file, layout);
     if (verdict.kind === "whole") return { type: "whole-workspace", triggerFile: file };
     if (verdict.kind === "inert") continue;
@@ -311,8 +376,14 @@ export function scopesForValidationScope(scope: ValidationScope): string[] {
  * these gates either (#2984). Prefer `computeValidationScope` wherever a graph
  * IS available: this resolves the trigger packages only, never their dependents.
  */
-export function gateScopes(layout: PackageLayout, changedFiles: readonly string[]): string[] {
-  return scopesForValidationScope(computeValidationScope(changedFiles, layout, { packages: [] }));
+export function gateScopes(
+  layout: PackageLayout,
+  changedFiles: readonly string[],
+  contentEvidence: ValidationScopeContentEvidence = {},
+): string[] {
+  return scopesForValidationScope(
+    computeValidationScope(changedFiles, layout, { packages: [] }, contentEvidence),
+  );
 }
 
 /**

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -540,9 +540,16 @@ export function createDefaultDevAfkMcpOperations(
       );
       try {
         const changedFiles = await gitx.changedFiles({ cwd: root }, input.branch, base);
+        const rootPackageJson = changedFiles.includes("package.json")
+          ? await gitx.changedFileContents({ cwd: root }, input.branch, base, "package.json")
+          : undefined;
         const result = await runFeedback(feedback.pnpm, {
           worktree: input.branch,
-          scopes: gateScopes(feedback.layout, changedFiles),
+          scopes: gateScopes(
+            feedback.layout,
+            changedFiles,
+            rootPackageJson ? { rootPackageJson } : undefined,
+          ),
           layout: feedback.layout,
           now: () => Date.now(),
           baselineWorktree: base,

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -519,6 +519,28 @@ export async function changedFiles(ctx: GitContext, branch: string, base: string
 }
 
 /**
+ * Read one file at both endpoints of the same three-dot diff used by
+ * {@link changedFiles}. Missing refs/files or any git failure return undefined,
+ * so callers that use this as narrowing evidence fail closed.
+ */
+export async function changedFileContents(
+  ctx: GitContext,
+  branch: string,
+  base: string,
+  file: string,
+): Promise<{ before: string; after: string } | undefined> {
+  if (!branch || !base || !file) return undefined;
+  const mergeBase = await runGit(ctx, ["merge-base", base, branch]);
+  const beforeRef = mergeBase.code === 0 ? mergeBase.stdout.trim() : "";
+  if (!beforeRef) return undefined;
+  const before = await runGit(ctx, ["show", `${beforeRef}:${file}`]);
+  if (before.code !== 0) return undefined;
+  const after = await runGit(ctx, ["show", `${branch}:${file}`]);
+  if (after.code !== 0) return undefined;
+  return { before: before.stdout, after: after.stdout };
+}
+
+/**
  * The worktree diff of <branch> against the merge base (git diff base...branch).
  *
  * This is what the gate fold's review stage reads (#2730): the stage runs BEFORE

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -1521,7 +1521,7 @@ describe("processIssue — stale-base drift never spends the correction budget (
    * a probe that echoes it back means the base stood still. */
   const BASE_START_SHA = "origin/main-tip";
 
-  it("charges nothing to /go's budget for a gate failure the base caused, and lands on the re-validation", async () => {
+  it("charges nothing to /go's budget and reruns only the gate when the base caused the failures", async () => {
     const { deps, input, trace } = harness({
       labels: ["lane:go"],
       laneLabel: "lane:go",
@@ -1539,7 +1539,7 @@ describe("processIssue — stale-base drift never spends the correction budget (
     // Two gate failures under a cap of ONE, and the branch still landed: both
     // were attributed to the base moving, so neither consumed the budget.
     expect(result.outcome).toBe("done");
-    expect(trace.runAgentCalls).toHaveLength(3);
+    expect(trace.runAgentCalls).toHaveLength(1);
     expect(trace.closed).toEqual([9]);
     expect(trace.baseMovementCalls).toEqual([
       { baseRef: "red-trunk", sinceSha: BASE_START_SHA },
@@ -1586,7 +1586,7 @@ describe("processIssue — stale-base drift never spends the correction budget (
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("done");
-    expect(trace.runAgentCalls).toHaveLength(3);
+    expect(trace.runAgentCalls).toHaveLength(2);
     expect(trace.closed).toEqual([9]);
     // Criterion: a complete, mergeable branch is never left reading blocked:validation.
     expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(false);
@@ -1611,14 +1611,9 @@ describe("processIssue — stale-base drift never spends the correction budget (
     // The /go correction cap is ZERO here: only the free stale-base cycle can
     // explain a second attempt at all.
     expect(result.outcome).toBe("done");
-    expect(trace.runAgentCalls).toHaveLength(2);
-    const retryHandoff = trace.runAgentCalls[1]?.handoffContent ?? "";
-    expect(retryHandoff).toContain("<go-machine-gate-retry>");
-    expect(retryHandoff).toContain("<stale-base-drift>");
-    expect(retryHandoff).toContain(RELEASE_BUMP);
-    expect(retryHandoff).toContain("git merge origin/main");
-    expect(retryHandoff).toContain("this correction is FREE");
-    expect(retryHandoff).not.toContain("bounded correction retry");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.iterLogs.some((line) => line.includes(RELEASE_BUMP))).toBe(true);
+    expect(trace.iterLogs.some((line) => line.includes("re-running validation without re-seeding"))).toBe(true);
     expect(trace.closed).toEqual([9]);
   });
 
@@ -1640,8 +1635,8 @@ describe("processIssue — stale-base drift never spends the correction budget (
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("feedback-failed");
-    // 2 free stale-base cycles + 1 charged cycle + the park.
-    expect(trace.runAgentCalls).toHaveLength(4);
+    // Two free gate-only cycles, then one charged Re-seed before the park.
+    expect(trace.runAgentCalls).toHaveLength(2);
     const envelope = trace.envelopeBodies.at(-1) ?? "";
     expect(envelope).toContain("Post-DONE gate-correction budget exhausted");
     expect(envelope).toContain("1/1 charged");
@@ -1663,7 +1658,7 @@ describe("processIssue — stale-base drift never spends the correction budget (
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("feedback-failed");
-    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.runAgentCalls).toHaveLength(1);
     expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(true);
   });
 
@@ -1677,10 +1672,8 @@ describe("processIssue — stale-base drift never spends the correction budget (
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("done");
-    expect(trace.runAgentCalls).toHaveLength(2);
-    const retryHandoff = trace.runAgentCalls[1]?.handoffContent ?? "";
-    expect(retryHandoff).toContain("<afk-gate-correction>");
-    expect(retryHandoff).toContain("<stale-base-drift>");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.iterLogs.some((line) => line.includes("re-running validation without re-seeding"))).toBe(true);
     expect(trace.closed).toEqual([9]);
     expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(false);
   });

--- a/apps/dev/tests/validation-scope.test.ts
+++ b/apps/dev/tests/validation-scope.test.ts
@@ -142,6 +142,46 @@ describe("computeValidationScope — whole-workspace escalation", () => {
     }
     expect(scopesForValidationScope(scope)).toEqual(["apps/dev"]);
   });
+
+  it("does not widen a package cone for a proven version-only root manifest change", () => {
+    const scope = computeValidationScope(
+      ["package.json", "apps/dev/src/core/go.ts"],
+      layout,
+      g,
+      {
+        rootPackageJson: {
+          before: JSON.stringify({ name: "red-skills", version: "1.2.3", scripts: { test: "vitest" } }),
+          after: JSON.stringify({ name: "red-skills", version: "1.2.4", scripts: { test: "vitest" } }),
+        },
+      },
+    );
+
+    expect(scope.type).toBe("cone");
+    expect(scopesForValidationScope(scope)).toEqual(["apps/dev"]);
+    expect(scopesForValidationScope(scope)).not.toContain(".");
+  });
+
+  it("keeps a root manifest global when version and behavioural content both change", () => {
+    const scope = computeValidationScope(
+      ["package.json", "apps/dev/src/core/go.ts"],
+      layout,
+      g,
+      {
+        rootPackageJson: {
+          before: JSON.stringify({ name: "red-skills", version: "1.2.3", dependencies: { a: "1" } }),
+          after: JSON.stringify({ name: "red-skills", version: "1.2.4", dependencies: { a: "2" } }),
+        },
+      },
+    );
+
+    expect(scope.type).toBe("whole-workspace");
+    expect(scopesForValidationScope(scope)).toEqual(["."]);
+  });
+
+  it("keeps a root manifest global when no content comparison proves the change safe", () => {
+    const scope = computeValidationScope(["package.json", "apps/dev/src/core/go.ts"], layout, g);
+    expect(scope.type).toBe("whole-workspace");
+  });
 });
 
 // ---- computeValidationScope — cone expansion ----


### PR DESCRIPTION
Automated AFK landing for #3231. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3231

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788394182&installation_model_id=20659&pr_number=3234&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3234&signature=7009ac0718b7a14f832e37aca3e9d6cb73ccb06ec9a9a350cd135d5282b7f438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->