### PR TITLE
fix: #3233 The gate names a failure `suspect-infra` — "not the branch's" — and charges the branch's correction budget for it anyway

### DIFF
--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -673,13 +673,14 @@ export async function processIssue(
   };
   /** Attribute one post-DONE gate failure and, when it is stale-base drift,
    * build the handoff note that tells the agent to merge the base. */
-  const attributeGateFailureNow = async (driftEligible: boolean): Promise<{
+  const attributeGateFailureNow = async (driftEligible: boolean, suspectInfra: boolean): Promise<{
     attribution: GateFailureAttribution;
     drift?: StaleBaseDriftNote;
   }> => {
-    const movement = driftEligible ? await observeBaseMovement() : undefined;
+    const movement = driftEligible && !suspectInfra ? await observeBaseMovement() : undefined;
     const attribution = attributeGateFailure({
       movement,
+      suspectInfra,
       refundsUsed: correctionLedger.refunded,
       maxRefunds: staleBaseDriftCap,
     });
@@ -759,6 +760,9 @@ export async function processIssue(
      * is unambiguously the branch's problem, and no amount of base movement can
      * explain it away. */
     driftEligible?: boolean;
+    /** True when the gate record already says the command failed too quickly to
+     * have started, so the cause belongs to the shared free-cycle pool. */
+    suspectInfra?: boolean;
     /** Tier escalation only — which tier failed and which one now runs. */
     tiers?: { from: string; to: string };
     /** Review only — the blocking findings and the diff they were raised
@@ -834,24 +838,25 @@ export async function processIssue(
     const cause = reseedTriggerCause(req.trigger);
     const { attribution, drift } =
       cause === "gate"
-        ? await attributeGateFailureNow(req.driftEligible ?? false)
+        ? await attributeGateFailureNow(req.driftEligible ?? false, req.suspectInfra ?? false)
         : { attribution: undefined, drift: undefined };
-    if (drift) {
+    if (attribution && attribution.cause !== "branch-fault") {
       correctionLedger = chargeCorrection(correctionLedger, attribution.cause);
       gateRevalidationSkip = true;
       const gate = req.gate ?? "feedback";
       const releaseBumps = attribution.releaseBumps.length > 0
         ? ` Release bump: ${attribution.releaseBumps.join("; ")}.`
         : "";
+      const freeCause = attribution.cause === "stale-base-drift" ? "stale-base" : attribution.cause;
       const note =
         `🤖 ${reseedLane}: ${gate} machine gate failed after DONE, but ${attribution.reason}; ` +
-        `granting a free stale-base correction (${correctionLedger.refunded}/${staleBaseDriftCap}), ` +
+        `granting a free ${freeCause} correction (${correctionLedger.refunded}/${staleBaseDriftCap}), ` +
         `re-running validation without re-seeding; budget untouched at ` +
         `${reseedSpend.gate ?? 0}/${gateSubCap}.${releaseBumps}`;
       deps.appendIterLog(note);
       deps.recordWorkerEvent?.("worker.gate_revalidation_requested", {
         trigger: req.trigger,
-        cause: "stale-base-drift",
+        cause: attribution.cause,
         lane: reseedBudget.lane,
         free: true,
         cycle: correctionLedger.refunded,
@@ -937,8 +942,16 @@ export async function processIssue(
     gate: "feedback" | "backpressure",
     validation: string,
     sidecar?: readonly string[],
+    suspectInfra: boolean = false,
   ): Promise<boolean> =>
-    (await requestReseed({ trigger, gate, validation, sidecar, driftEligible: trigger === "gate-stage" })) ===
+    (await requestReseed({
+      trigger,
+      gate,
+      validation,
+      sidecar,
+      driftEligible: trigger === "gate-stage",
+      suspectInfra,
+    })) ===
     "granted";
   /** The park-note suffix naming the exhausted correction budget. It reports the
    * CHARGED cycles against the lane's cap and, separately, the stale-base cycles
@@ -1522,7 +1535,10 @@ export async function processIssue(
         notes = "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.";
       }
       if (classification.note !== "") notes += ` ${classification.note}`;
-      if (!isInfra && (await reseedAfterGate("gate-stage", "feedback", validationText, feedback.sidecar))) {
+      const suspectInfra = feedback.checks.some(
+        (check) => check.status === "failed" && check.record.suspectInfra === true,
+      );
+      if (!isInfra && (await reseedAfterGate("gate-stage", "feedback", validationText, feedback.sidecar, suspectInfra))) {
         continue;
       }
       if (!isInfra) {
@@ -1562,7 +1578,12 @@ export async function processIssue(
         if (bpClass.note !== "") bpNotes += ` ${bpClass.note}`;
         const overrideFooter = bpClass.note === "" ? "" : `\n${bpClass.note}`;
         const validationText = `${backpressure.sidecar.join("\n")}${overrideFooter}`;
-        if (!bpInfra && (await reseedAfterGate("gate-stage", "backpressure", validationText, backpressure.sidecar))) {
+        const suspectInfra = backpressure.checks.some(
+          (check) => check.status === "failed" && check.record.suspectInfra === true,
+        );
+        if (!bpInfra && (
+          await reseedAfterGate("gate-stage", "backpressure", validationText, backpressure.sidecar, suspectInfra)
+        )) {
           continue;
         }
         if (!bpInfra) {

--- a/apps/dev/src/core/stale-base-drift.ts
+++ b/apps/dev/src/core/stale-base-drift.ts
@@ -13,12 +13,12 @@
 // as `blocked:validation`.
 //
 // The fix is an accounting one. A gate failure observed while the base moved
-// under the attempt is attributed to `stale-base-drift` and granted a FREE
-// correction cycle: the agent is told to merge the base and re-validate, and the
-// budget is untouched. The NEXT gate run is the re-validation that settles it —
-// green means the drift attribution was right and the engine opens the PR; red
-// again with a base that has since stood still is charged as `branch-fault` like
-// any other failure. The free cycles are bounded
+// under the attempt is attributed to `stale-base-drift`; a failure the gate has
+// already marked `suspectInfra` is attributed to `suspect-infra`. Either cause
+// grants a FREE correction cycle: the budget is untouched and the NEXT gate run
+// settles the attribution. Green means it was right; red again without a free
+// cause is charged as `branch-fault` like any other failure. The causes share
+// one bounded free-cycle pool
 // ({@link DEFAULT_STALE_BASE_DRIFT_CORRECTIONS}) so a churning base can never
 // buy an unbounded run.
 //
@@ -60,7 +60,7 @@ export function releaseBumpSubjects(movement: BaseMovement | undefined): string[
 }
 
 /** Who a post-DONE machine-gate failure belongs to. */
-export type GateFailureCause = "branch-fault" | "stale-base-drift";
+export type GateFailureCause = "branch-fault" | "stale-base-drift" | "suspect-infra";
 
 export interface GateFailureAttribution {
   cause: GateFailureCause;
@@ -97,6 +97,8 @@ export function resolveStaleBaseDriftCorrections(
  */
 export function attributeGateFailure(input: {
   movement?: BaseMovement;
+  /** The gate already classified the command as too fast to have run. */
+  suspectInfra?: boolean;
   /** Free cycles already granted to this attempt chain. */
   refundsUsed: number;
   maxRefunds?: number;
@@ -105,6 +107,25 @@ export function attributeGateFailure(input: {
   const releaseBumps = releaseBumpSubjects(movement);
   const movedCommits = baseMoved(movement) ? movement!.subjects.length : 0;
   const maxRefunds = input.maxRefunds ?? DEFAULT_STALE_BASE_DRIFT_CORRECTIONS;
+  if (input.suspectInfra === true) {
+    if (input.refundsUsed >= maxRefunds) {
+      return {
+        cause: "branch-fault",
+        reason:
+          `the gate marked the failure suspect-infra, but the shared free-correction ` +
+          `allowance (${maxRefunds}) is spent, so this failure is charged to the branch`,
+        releaseBumps,
+        movedCommits,
+      };
+    }
+    return {
+      cause: "suspect-infra",
+      reason:
+        "the gate marked the command too fast to have started, so it is an environment failure before the branch's",
+      releaseBumps,
+      movedCommits,
+    };
+  }
   if (!baseMoved(movement)) {
     return {
       cause: "branch-fault",
@@ -139,7 +160,7 @@ export function attributeGateFailure(input: {
 export interface CorrectionLedger {
   /** Cycles charged to the caller's correction budget (`branch-fault`). */
   charged: number;
-  /** Cycles granted free because the base moved under the run. */
+  /** Cycles granted free because the base moved or the gate suspected infra. */
   refunded: number;
   /** Every cycle in order, so a park can narrate what actually happened. */
   cycles: readonly GateFailureCause[];
@@ -156,7 +177,7 @@ export const EMPTY_CORRECTION_LEDGER: CorrectionLedger = Object.freeze({
 export function chargeCorrection(ledger: CorrectionLedger, cause: GateFailureCause): CorrectionLedger {
   return {
     charged: ledger.charged + (cause === "branch-fault" ? 1 : 0),
-    refunded: ledger.refunded + (cause === "stale-base-drift" ? 1 : 0),
+    refunded: ledger.refunded + (cause === "branch-fault" ? 0 : 1),
     cycles: [...ledger.cycles, cause],
   };
 }
@@ -171,11 +192,13 @@ export function correctionBudgetExhausted(ledger: CorrectionLedger, cap: number)
 /** Park-comment fragment naming both counters, so a reader sees which budget
  * ran out and how much of the run was spent absorbing base drift. */
 export function describeCorrectionLedger(ledger: CorrectionLedger, cap: number): string {
-  const drift =
-    ledger.refunded > 0
-      ? `, plus ${ledger.refunded} stale-base correction${ledger.refunded === 1 ? "" : "s"} that did not consume it`
-      : "";
-  return `${ledger.charged}/${cap} charged${drift}`;
+  const staleBase = ledger.cycles.filter((cause) => cause === "stale-base-drift").length;
+  const suspectInfra = ledger.cycles.filter((cause) => cause === "suspect-infra").length;
+  const free = [
+    staleBase > 0 ? `${staleBase} stale-base correction${staleBase === 1 ? "" : "s"}` : "",
+    suspectInfra > 0 ? `${suspectInfra} suspect-infra correction${suspectInfra === 1 ? "" : "s"}` : "",
+  ].filter(Boolean).join(" and ");
+  return `${ledger.charged}/${cap} charged${free === "" ? "" : `, plus ${free} that did not consume it`}`;
 }
 
 export interface StaleBaseDriftNote {

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -143,6 +143,10 @@ export interface HarnessOptions {
    * says whether a run failed, this says HOW — which is what moves the failure
    * signature (#2724) between rounds. Takes precedence when both are set. */
   feedbackFailures?: readonly string[][];
+  /** Per-feedback-run command duration in milliseconds. Defaults to 1000 so
+   * ordinary semantic failures are not accidentally marked `suspectInfra`;
+   * values below 1000 model the gate's too-fast environment classification. */
+  feedbackDurationsMs?: readonly number[];
   /** Operator-declared backpressure commands (afk.backpressure, #430). When set,
    * the backpressure gate runs after feedback against the worker branch. */
   backpressureCommands?: string[];
@@ -359,6 +363,7 @@ export function harness(opts: HarnessOptions = {}): {
   let queuePolls = 0;
   let pnpmCalls = 0;
   let changedFilesCalls = 0;
+  let pendingValidationDurationMs: number | undefined;
 
   const deps: ProcessIssueDeps = {
     gh: {
@@ -652,6 +657,8 @@ export function harness(opts: HarnessOptions = {}): {
       }
       const feedbackRun = Math.floor(pnpmCalls / 4);
       pnpmCalls += 1;
+      pendingValidationDurationMs =
+        opts.feedbackDurationsMs?.[feedbackRun] ?? opts.feedbackDurationsMs?.at(-1) ?? 1000;
       const failures = opts.feedbackFailures
         ? (opts.feedbackFailures[feedbackRun] ?? opts.feedbackFailures.at(-1) ?? [])
         : undefined;
@@ -865,7 +872,12 @@ export function harness(opts: HarnessOptions = {}): {
       async writeMarkers() {},
       async writePosted() {},
     },
-    nowEpoch: () => 1000,
+    nowEpoch: () => {
+      if (pendingValidationDurationMs === undefined) return 1000;
+      const end = 1000 + pendingValidationDurationMs;
+      pendingValidationDurationMs = undefined;
+      return end;
+    },
     nowIso: () => "2026-05-30T00:00:00Z",
     ...(opts.historyPath
       ? { historyPath: opts.historyPath, historyClock: { ts: "2026-05-30T00:00:00Z", epoch: 1000 } }

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -1715,6 +1715,64 @@ describe("processIssue — an empty-diff DONE is never stale-base drift (#2711)"
   });
 });
 
+describe("processIssue — suspect-infra uses the bounded free correction pool (#3233)", () => {
+  it("re-runs only the gate without charging the branch when the record says suspect-infra", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      outcome: "done",
+      feedbackResults: [false, true],
+      feedbackDurationsMs: [465, 1000],
+      recoveryEnv: { RED_GO_VERIFY_RETRIES: "0" },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.iterLogs.some((line) => line.includes("free suspect-infra correction (1/2)"))).toBe(true);
+    expect(trace.iterLogs.some((line) => line.includes("budget untouched at 0/0"))).toBe(true);
+    expect(trace.closed).toEqual([9]);
+  });
+
+  it("charges the next red gate when suspect-infra is no longer present", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      outcome: "done",
+      feedbackResults: [false, false, true],
+      feedbackDurationsMs: [465, 1000, 1000],
+      recoveryEnv: { RED_GO_VERIFY_RETRIES: "1" },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.iterLogs.some((line) => line.includes("free suspect-infra correction (1/2)"))).toBe(true);
+    expect(trace.iterLogs.some((line) => line.includes("correction retry 1/1"))).toBe(true);
+    expect(trace.closed).toEqual([9]);
+  });
+
+  it("cannot buy unbounded gate runs while the environment stays suspect", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      outcome: "done",
+      feedbackResults: [false],
+      feedbackDurationsMs: [465],
+      recoveryEnv: { RED_GO_VERIFY_RETRIES: "0", RED_GATE_STALE_BASE_CORRECTIONS: "1" },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.iterLogs.filter((line) => line.includes("free suspect-infra correction"))).toHaveLength(1);
+    expect(trace.labelEdits.some((edit) => edit.add.includes("blocked:validation"))).toBe(true);
+  });
+});
+
 describe("processIssue — one Re-seed request path (#2727, ADR 0129)", () => {
   /** Every `worker.reseeded` event this run emitted, in order. */
   const reseeds = (trace: { workerEvents: Array<{ kind: string; payload?: Record<string, unknown> }> }) =>

--- a/apps/dev/tests/stale-base-drift.test.ts
+++ b/apps/dev/tests/stale-base-drift.test.ts
@@ -66,6 +66,22 @@ describe("attributeGateFailure", () => {
     expect(attribution.reason).toContain("release version bump");
   });
 
+  it("attributes a gate-declared suspect-infra failure away from the branch", () => {
+    const attribution = attributeGateFailure({ suspectInfra: true, refundsUsed: 0 });
+    expect(attribution.cause).toBe("suspect-infra");
+    expect(attribution.reason).toContain("environment failure");
+    expect(attribution.movedCommits).toBe(0);
+  });
+
+  it("makes suspect-infra share the bounded free-cycle allowance with stale-base drift", () => {
+    const attribution = attributeGateFailure({
+      suspectInfra: true,
+      refundsUsed: DEFAULT_STALE_BASE_DRIFT_CORRECTIONS,
+    });
+    expect(attribution.cause).toBe("branch-fault");
+    expect(attribution.reason).toContain("allowance");
+  });
+
   it("falls back to branch-fault once the bounded stale-base allowance is spent", () => {
     const attribution = attributeGateFailure({
       movement: movement(),
@@ -93,6 +109,15 @@ describe("correction ledger", () => {
     ledger = chargeCorrection(ledger, "stale-base-drift");
     expect(ledger).toMatchObject({ charged: 1, refunded: 1 });
     expect(ledger.cycles).toEqual(["branch-fault", "stale-base-drift"]);
+  });
+
+  it("refunds suspect-infra from the same counter as stale-base drift", () => {
+    const ledger = chargeCorrection(
+      chargeCorrection(EMPTY_CORRECTION_LEDGER, "stale-base-drift"),
+      "suspect-infra",
+    );
+    expect(ledger).toMatchObject({ charged: 0, refunded: 2 });
+    expect(ledger.cycles).toEqual(["stale-base-drift", "suspect-infra"]);
   });
 
   it("never mutates the ledger it is handed", () => {


### PR DESCRIPTION
Automated AFK landing for #3233. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3233

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788401487&installation_model_id=20659&pr_number=3237&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3237&signature=b6df6ce4dfd3b69208cb66d51fe3d9585eb30a66e42d9e882024e014c53c52ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->