### PR TITLE
merge: #3240 /go: Redesign dev:adr-editor into a proposal-driven reverse grill. Rank activ

### DIFF
--- a/apps/dev/src/core/adr-operations.ts
+++ b/apps/dev/src/core/adr-operations.ts
@@ -18,6 +18,14 @@ export interface IndexArchiveInput {
   number: string;
 }
 
+export interface IndexReviewAnnotationInput {
+  path: string;
+  text: string;
+  number: string;
+  reviewedOn: string;
+  baseSha: string;
+}
+
 export interface ArchiveMoveInput extends StatusAndSuccessorInput {
   indexPath: string;
   indexText: string;
@@ -148,6 +156,25 @@ export function planIndexArchive(input: IndexArchiveInput): AdrTextPlan {
 /** Apply a planned INDEX resync through an injected filesystem. */
 export async function applyIndexArchive(plan: AdrTextPlan, fs: AdrOperationFs): Promise<void> {
   await fs.writeFile(plan.path, plan.text);
+}
+
+/** Plan the visible review date and short base SHA on one existing INDEX bullet. */
+export function planIndexReviewAnnotation(input: IndexReviewAnnotationInput): AdrTextPlan {
+  if (!/^\d{4}$/.test(input.number)) throw new Error(`Invalid ADR number: ${input.number}`);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(input.reviewedOn)) {
+    throw new Error(`Invalid ADR review date: ${input.reviewedOn}`);
+  }
+  if (!/^[0-9a-f]{7,12}$/i.test(input.baseSha)) {
+    throw new Error(`Invalid short base SHA: ${input.baseSha}`);
+  }
+  const bullet = new RegExp(`^- \\*\\*${input.number}\\*\\*.*$`, "m").exec(input.text);
+  if (!bullet) throw new Error(`ADR ${input.number} has no INDEX bullet`);
+  const unmarked = bullet[0].replace(/\s+— reviewed \d{4}-\d{2}-\d{2} @ [0-9a-f]{7,12}\s*$/i, "");
+  const annotation = `${unmarked} — reviewed ${input.reviewedOn} @ ${input.baseSha}`;
+  return {
+    path: input.path,
+    text: input.text.slice(0, bullet.index) + annotation + input.text.slice(bullet.index + bullet[0].length),
+  };
 }
 
 /** Plan the status, history-preserving archive path, and INDEX change together. */
@@ -400,6 +427,29 @@ export interface MergeInput {
   indexText: string;
 }
 
+export interface AbsorbInput {
+  /** The active ADR that remains authoritative after incorporating amendments. */
+  governing: AdrOriginal;
+  /** Complete post-absorb text for the governing ADR. */
+  rewrittenGoverningText: string;
+  /** Active amendment records that become auxiliaries in the archive. */
+  auxiliaries: readonly AdrOriginal[];
+  indexPath: string;
+  indexText: string;
+}
+
+export interface AdrAbsorbPlan {
+  governing: {
+    path: string;
+    originalText: string;
+    text: string;
+  };
+  archives: AdrArchiveStep[];
+  indexPath: string;
+  originalIndexText: string;
+  indexText: string;
+}
+
 function draftNumbers(drafts: readonly AdrDraft[]): string[] {
   return drafts.map((draft) => draft.number);
 }
@@ -478,6 +528,75 @@ export function planMerge(input: MergeInput): AdrCompositePlan {
     originalIndexText: input.indexText,
     indexText: addDraftBullets([input.successor], input.indexPath, indexText),
   };
+}
+
+/**
+ * Absorb auxiliary amendments into one governing ADR. Unlike merge, absorb
+ * mints no successor and never archives the governor.
+ */
+export function planAbsorb(input: AbsorbInput): AdrAbsorbPlan {
+  const governingMatch = /^\.red\/adr\/(\d{4})-.+\.md$/.exec(input.governing.path);
+  if (!governingMatch) throw new Error(`Governing ADR is not in the active lane: ${input.governing.path}`);
+  if (input.rewrittenGoverningText === input.governing.text) {
+    throw new Error("Absorb must rewrite the governing ADR with the accepted amendments");
+  }
+  if (input.auxiliaries.length < 1) throw new Error("Absorb must archive at least one auxiliary ADR");
+  if (input.auxiliaries.some((auxiliary) => auxiliary.path === input.governing.path)) {
+    throw new Error("The governing ADR cannot absorb itself");
+  }
+
+  const archives: AdrArchiveStep[] = [];
+  let indexText = input.indexText;
+  for (const auxiliary of input.auxiliaries) {
+    const archived = archiveStep(auxiliary, [governingMatch[1]!], input.indexPath, indexText);
+    archives.push(archived.step);
+    indexText = archived.indexText;
+  }
+  return {
+    governing: {
+      path: input.governing.path,
+      originalText: input.governing.text,
+      text: input.rewrittenGoverningText,
+    },
+    archives,
+    indexPath: input.indexPath,
+    originalIndexText: input.indexText,
+    indexText,
+  };
+}
+
+/** Apply an absorb plan in dependency order, compensating every completed step on failure. */
+export async function applyAbsorb(plan: AdrAbsorbPlan, io: AdrOperationIo): Promise<void> {
+  let governingTouched = false;
+  let indexTouched = false;
+  const prepared: AdrArchiveStep[] = [];
+  const moved: AdrArchiveStep[] = [];
+  try {
+    governingTouched = true;
+    await io.fs.writeFile(plan.governing.path, plan.governing.text);
+    for (const step of plan.archives) {
+      prepared.push(step);
+      await io.fs.writeFile(step.from, step.adrText);
+      await io.git.mv(step.from, step.to);
+      moved.push(step);
+    }
+    indexTouched = true;
+    await io.fs.writeFile(plan.indexPath, plan.indexText);
+  } catch (error) {
+    if (indexTouched) await io.fs.writeFile(plan.indexPath, plan.originalIndexText);
+    const movedPaths = new Set(moved.map((step) => step.from));
+    for (const step of moved.reverse()) {
+      await io.git.mv(step.to, step.from);
+      await io.fs.writeFile(step.from, step.originalAdrText);
+    }
+    for (const step of prepared.reverse()) {
+      if (!movedPaths.has(step.from)) await io.fs.writeFile(step.from, step.originalAdrText);
+    }
+    if (governingTouched) {
+      await io.fs.writeFile(plan.governing.path, plan.governing.originalText);
+    }
+    throw error;
+  }
 }
 
 /**

--- a/apps/dev/src/core/adr-triage.ts
+++ b/apps/dev/src/core/adr-triage.ts
@@ -63,12 +63,33 @@ export interface AdrTriageContext {
    * every record as undocumented.
    */
   indexNumbers?: readonly string[];
-  /** An unlinked ADR older than this is inert. Default 365. */
+  /** @deprecated Age is evidence to inspect, never a terminal disposition. */
   inertAfterDays?: number;
   /** Decision points at/above which an ADR is overloaded. Default 5. */
   splitDecisionThreshold?: number;
   /** Shared title terms at/above which two ADRs cover one subject. Default 3. */
   mergeOverlapThreshold?: number;
+  /** Current code, test, documentation, and newer-ADR evidence gathered by the caller. */
+  candidateEvidence?: readonly AdrCandidateEvidence[];
+  /** Visible INDEX review annotations parsed by the caller. */
+  reviewMarkers?: readonly AdrReviewMarker[];
+}
+
+export type AdrCandidateEvidenceKind = "code" | "test" | "documentation" | "newer-adr";
+
+export interface AdrCandidateEvidence {
+  kind: AdrCandidateEvidenceKind;
+  path: string;
+  detail: string;
+  numbers: readonly string[];
+  /** Git-aware callers set this only when the evidence changed after the recorded review SHA. */
+  changedSinceReview: boolean;
+}
+
+export interface AdrReviewMarker {
+  number: string;
+  reviewedOn: string;
+  baseSha: string;
 }
 
 export type AdrSubjectFilter =
@@ -104,7 +125,6 @@ export interface AdrTriageReport {
   subject?: AdrTriageSubjectReport;
 }
 
-const DEFAULT_INERT_AFTER_DAYS = 365;
 const DEFAULT_SPLIT_THRESHOLD = 5;
 const DEFAULT_MERGE_OVERLAP = 3;
 
@@ -228,7 +248,6 @@ interface Classification {
 }
 
 function classify(record: AdrRecord, context: AdrTriageContext): Classification {
-  const inertAfterDays = context.inertAfterDays ?? DEFAULT_INERT_AFTER_DAYS;
   const splitThreshold = context.splitDecisionThreshold ?? DEFAULT_SPLIT_THRESHOLD;
   const mergeThreshold = context.mergeOverlapThreshold ?? DEFAULT_MERGE_OVERLAP;
 
@@ -296,14 +315,6 @@ function classify(record: AdrRecord, context: AdrTriageContext): Classification 
 
   if (isDeprecated(record)) {
     return { bucket: "archive-candidate", signals, reason: "Deprecated; terminal record, safe to archive." };
-  }
-
-  if (ageDays >= inertAfterDays && inboundLinks === 0) {
-    return {
-      bucket: "archive-candidate",
-      signals,
-      reason: `Inert: ${ageDays} days old and no ADR links to it.`,
-    };
   }
 
   if (points >= splitThreshold) {
@@ -531,6 +542,94 @@ export function groupAdrs(context: AdrTriageContext, options: AdrTriageOptions =
         : { kind: subject.kind, matched };
   }
   return report;
+}
+
+// ---------------------------------------------------------------------------
+// reverse-grill cluster ranking
+// ---------------------------------------------------------------------------
+
+export type AdrClusterRecommendation = "review-now" | "review-next" | "defer-until-new-evidence";
+
+export interface AdrRankedCluster {
+  rank: number;
+  title: string;
+  numbers: string[];
+  evidence: AdrCandidateEvidence[];
+  hasNewEvidence: boolean;
+  recommendation: AdrClusterRecommendation;
+  /** Deterministic ordering aid, not a disposition or replacement for maintainer judgment. */
+  score: number;
+}
+
+export interface AdrClusterRankingReport {
+  clusters: AdrRankedCluster[];
+  excludedArchived: string[];
+}
+
+function isArchivedPath(path: string): boolean {
+  return /^\.red\/adr\/archive\//.test(path);
+}
+
+/**
+ * Rank active ADR clusters for the reverse grill. The helper emits candidate
+ * evidence and a stable place to start; it never chooses an ADR disposition.
+ * Archived records are deliberately absent from both clustering and evidence.
+ */
+export function rankAdrClusters(context: AdrTriageContext): AdrClusterRankingReport {
+  const activeAdrs = context.adrs.filter((record) => !isArchivedPath(record.path));
+  const activeNumbers = new Set(activeAdrs.map((record) => record.number));
+  const excludedArchived = context.adrs
+    .filter((record) => isArchivedPath(record.path))
+    .map((record) => record.number)
+    .sort();
+  const activeContext: AdrTriageContext = {
+    ...context,
+    adrs: activeAdrs,
+    indexSections: context.indexSections?.map((section) => ({
+      ...section,
+      numbers: section.numbers.filter((number) => activeNumbers.has(number)),
+    })),
+  };
+  const grouped = groupAdrs(activeContext);
+  const clusterSeeds = [
+    ...grouped.groups.map((group) => ({ title: group.title, numbers: group.numbers })),
+    ...grouped.ungrouped.map((number) => ({
+      title: activeAdrs.find((record) => record.number === number)?.title ?? `ADR ${number}`,
+      numbers: [number],
+    })),
+  ];
+  const reviewMarkers = new Set((context.reviewMarkers ?? []).map((marker) => marker.number));
+
+  const scored = clusterSeeds.map((seed) => {
+    const numberSet = new Set(seed.numbers);
+    const evidence = (context.candidateEvidence ?? [])
+      .filter((item) => item.numbers.some((number) => numberSet.has(number)))
+      .map((item) => ({
+        ...item,
+        numbers: item.numbers.filter((number) => numberSet.has(number) && activeNumbers.has(number)),
+      }))
+      .filter((item) => item.numbers.length > 0);
+    const hasNewEvidence = evidence.some((item) => item.changedSinceReview);
+    const reviewed = seed.numbers.every((number) => reviewMarkers.has(number));
+    const triageWeight = triageAdrs(activeContext, {
+      subject: { kind: "numbers", numbers: seed.numbers },
+    }).entries.reduce((score, entry) => score + (entry.bucket === "keep" ? 0 : 5), 0);
+    const score = (hasNewEvidence ? 100 : 0) + (reviewed ? 0 : 20) + triageWeight + evidence.length;
+    const recommendation: AdrClusterRecommendation = reviewed && !hasNewEvidence
+      ? "defer-until-new-evidence"
+      : hasNewEvidence
+        ? "review-now"
+        : "review-next";
+    return { ...seed, evidence, hasNewEvidence, recommendation, score };
+  });
+
+  scored.sort(
+    (a, b) => b.score - a.score || a.numbers[0]!.localeCompare(b.numbers[0]!) || a.title.localeCompare(b.title),
+  );
+  return {
+    clusters: scored.map((cluster, index) => ({ rank: index + 1, ...cluster })),
+    excludedArchived,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/dev/tests/adr-editor-docs.test.ts
+++ b/apps/dev/tests/adr-editor-docs.test.ts
@@ -4,27 +4,26 @@ import { describe, expect, it } from "vitest";
 
 const ROOT = join(import.meta.dirname, "..", "..", "..");
 
-async function readAdrEditorSkill(): Promise<string> {
-  return readFile(join(ROOT, "plugins/dev/skills/engineering/adr-editor/SKILL.md"), "utf8");
-}
-
-async function readSkill(path: string): Promise<string> {
+async function readSkill(path = "plugins/dev/skills/engineering/adr-editor/SKILL.md"): Promise<string> {
   return readFile(join(ROOT, path), "utf8");
 }
 
-describe("adr-editor docs contract", () => {
-  it("declares the totipotent charter with the maintainer as the decider", async () => {
-    const skill = await readAdrEditorSkill();
+describe("adr-editor reverse-grill contract", () => {
+  it("ranks active clusters, recommends where to start, and processes one cluster per PR", async () => {
+    const skill = await readSkill();
 
     expect(skill).toContain("name: adr-editor");
-    expect(skill).toContain("The maintainer decides; the editor executes");
-    expect(skill).toContain("there is no read-only default");
-    expect(skill).toContain(".red/adr/archive/");
+    expect(skill).toContain("proposal-driven reverse grill");
+    expect(skill).toContain("rankAdrClusters");
+    expect(skill).toContain("recommend where to start");
+    expect(skill).toContain("one cluster per PR");
+    expect(skill).toContain("exclude `.red/adr/archive/` from future cluster analysis");
   });
 
-  it("enables all eleven operations in-session", async () => {
-    const skill = await readAdrEditorSkill();
+  it("preserves all eleven operations with the maintainer as decider", async () => {
+    const skill = await readSkill();
 
+    expect(skill).toContain("The maintainer decides; the editor executes");
     for (const operation of [
       "list",
       "group",
@@ -38,96 +37,80 @@ describe("adr-editor docs contract", () => {
       "renumber",
       "re-index",
     ]) {
-      expect(skill, `adr-editor should enable ${operation}`).toContain(operation);
+      expect(skill, `adr-editor should retain ${operation}`).toContain(operation);
     }
     expect(skill).toContain("eleven operations");
-    expect(skill).toContain("applied here, not");
   });
 
-  it("opens with a subject interview built from the collection's real groups", async () => {
-    const skill = await readAdrEditorSkill();
+  it("presents one numbered proposal per turn with evidence and judgment left to the model", async () => {
+    const skill = await readSkill();
 
-    expect(skill).toContain("Ask first, sweep second");
-    expect(skill).toContain("Phase 0 — Interview for the subject");
-    expect(skill).toContain("offer them as numbered choices with their record counts");
-    expect(skill).toContain("Which subject should I work on?");
-    expect(skill).toContain("one question per turn, each narrowing the last");
-    expect(skill).toContain("Skip the question when the invocation already names the subject");
-
-    // The whole-collection sweep that pushed the maintainer out of the loop is gone.
-    expect(skill).not.toContain("all ADRs by default");
+    expect(skill).toContain("P01");
+    expect(skill).toContain("one proposal per turn");
+    for (const field of ["Evidence", "Exact operation", "Alternatives", "Recommendation"]) {
+      expect(skill).toContain(field);
+    }
+    expect(skill).toContain("candidate evidence, not a disposition");
+    expect(skill).toContain("explicit maintainer disposition");
+    expect(skill).toContain("every active ADR in the cluster");
   });
 
-  it("reports the chosen subject only, with everything as an explicit choice", async () => {
-    const skill = await readAdrEditorSkill();
+  it("confronts active ADRs with current implementation evidence without changing product code", async () => {
+    const skill = await readSkill();
 
-    expect(skill).toContain("Phase 1 — Answer about the chosen subject");
-    expect(skill).toContain("never a silent default");
-    expect(skill).toContain("nothing outside it");
+    for (const evidence of ["current code", "tests", "documentation", "newer active ADRs"]) {
+      expect(skill).toContain(evidence);
+    }
+    expect(skill).toContain("Do not change analyzed product code");
+    expect(skill).toContain("Age or lack of links is never sufficient archival evidence");
   });
 
-  it("keeps exactly one gate — the destructive-or-wide batch confirmation", async () => {
-    const skill = await readAdrEditorSkill();
+  it("distinguishes absorb from merge and routes absorb through the safe primitive", async () => {
+    const skill = await readSkill();
 
-    expect(skill).toContain("Confirm once before a destructive or wide batch mutation");
-    expect(skill).toContain("Apply these N operations now?");
-    expect(skill).toContain("needs no gate at all");
-
-    // The retired read-only / Spec-routing framing must not come back.
-    expect(skill).not.toContain("Read-only is the default");
-    expect(skill).not.toContain("never applied in-session");
-    expect(skill).not.toContain("Merge and split remain judgment operations");
-    expect(skill).not.toContain("Spec work item");
+    expect(skill).toContain("Absorb");
+    expect(skill).toContain("rewrites one governing ADR");
+    expect(skill).toContain("archives only the auxiliaries");
+    expect(skill).toContain("Merge");
+    expect(skill).toContain("mints a successor");
+    expect(skill).toContain("archives all originals");
+    expect(skill).toContain("planAbsorb");
+    expect(skill).toContain("applyAbsorb");
   });
 
-  it("offers /to-spec as an escape hatch instead of a routing gate", async () => {
-    const skill = await readAdrEditorSkill();
+  it("annotates reviewed INDEX bullets and re-reviews only on new evidence", async () => {
+    const skill = await readSkill();
 
-    expect(skill).toContain("Escape hatch");
-    expect(skill).toContain("`/to-spec` is never a gate and");
-    expect(skill).toContain("The maintainer chooses.");
+    expect(skill).toContain("reviewed YYYY-MM-DD @ <short-base-sha>");
+    expect(skill).toContain("visibly annotate every reviewed INDEX bullet");
+    expect(skill).toContain("Prioritize re-review only when new evidence exists");
   });
 
-  it("backs grouping and inconsistency detection with the shipped classifier", async () => {
-    const skill = await readAdrEditorSkill();
+  it("accumulates accepted proposals before one preview and destructive-batch confirmation", async () => {
+    const skill = await readSkill();
+
+    expect(skill).toContain("accumulate accepted proposals");
+    expect(skill).toContain("show the complete resulting text and exact diff");
+    expect(skill).toContain("Apply this destructive batch now?");
+    expect(skill).toContain("one confirmation");
+  });
+
+  it("composes the deterministic helpers and preserves governance and landing safeguards", async () => {
+    const skill = await readSkill();
 
     expect(skill).toContain("apps/dev/src/core/adr-triage.ts");
-    for (const entryPoint of ["triageAdrs", "groupAdrs", "detectAdrInconsistencies"]) {
-      expect(skill).toContain(`\`${entryPoint}\``);
-    }
-    for (const bucket of [
-      "keep",
-      "stale-reference",
-      "missing-supersession",
-      "merge-candidate",
-      "split-candidate",
-      "archive-candidate",
-    ]) {
-      expect(skill).toContain(`\`${bucket}\``);
-    }
-    for (const kind of [
-      "numbering-collision",
-      "dangling-supersede",
-      "supersession-cycle",
-      "index-drift",
-      "stale-path",
-      "subject-overlap",
-    ]) {
-      expect(skill).toContain(`\`${kind}\``);
-    }
-  });
-
-  it("routes every mutation through a shipped planner and apply helper", async () => {
-    const skill = await readAdrEditorSkill();
-
-    expect(skill).toContain("apps/dev/src/core/adr-operations.ts");
     for (const helper of [
+      "triageAdrs",
+      "groupAdrs",
+      "detectAdrInconsistencies",
+      "rankAdrClusters",
       "planArchiveMove",
       "applyArchiveMove",
       "planStatusAndSuccessor",
       "applyStatusAndSuccessor",
       "planIndexArchive",
       "applyIndexArchive",
+      "planIndexReviewAnnotation",
       "planStalePathFix",
       "applyStalePathFix",
       "planRenumber",
@@ -135,30 +118,17 @@ describe("adr-editor docs contract", () => {
       "planIndexEntry",
       "planSplit",
       "planMerge",
+      "planAbsorb",
+      "applyAbsorb",
       "applyComposite",
     ]) {
       expect(skill).toContain(`\`${helper}\``);
     }
-  });
-
-  it("keeps the INDEX, ADR format, and git-flow safeties", async () => {
-    const skill = await readAdrEditorSkill();
-
     expect(skill).toContain("`.red/adr/INDEX.md` coherent after every mutation");
     expect(skill).toContain("Set(active ∪ archived numbers) === Set(INDEX numbers)");
     expect(skill).toContain("start/ADR-FORMAT.md");
     expect(skill).toContain("Branch, worktree, commit, PR");
-  });
-
-  it("points doc-writing skills at the shared doc-landing finalizer", async () => {
-    const start = await readSkill("plugins/dev/skills/engineering/start/SKILL.md");
-    const adrEditor = await readSkill("plugins/dev/skills/engineering/adr-editor/SKILL.md");
-    const context = await readSkill("plugins/dev/skills/engineering/context/SKILL.md");
-    const reflect = await readSkill("plugins/dev/skills/productivity/reflect/SKILL.md");
-
-    for (const skill of [start, adrEditor, context, reflect]) {
-      expect(skill).toContain("shared end-of-session doc-landing finalizer");
-      expect(skill).toContain("DOC-LANDING-FINALIZER.md");
-    }
+    expect(skill).toContain("shared end-of-session doc-landing finalizer");
+    expect(skill).toContain("DOC-LANDING-FINALIZER.md");
   });
 });

--- a/apps/dev/tests/adr-operations.test.ts
+++ b/apps/dev/tests/adr-operations.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyAbsorb,
   applyArchiveMove,
   applyComposite,
   applyIndexArchive,
   applyRenumber,
   applyStalePathFix,
   applyStatusAndSuccessor,
+  planAbsorb,
   planArchiveMove,
   planIndexArchive,
   planIndexEntry,
+  planIndexReviewAnnotation,
   planMerge,
   planRenumber,
   planSplit,
@@ -212,6 +215,30 @@ describe("planIndexArchive", () => {
     });
 
     expect(writes).toEqual([[plan.path, plan.text]]);
+  });
+});
+
+describe("planIndexReviewAnnotation", () => {
+  it("visibly stamps a reviewed bullet and replaces an older review marker", () => {
+    const first = planIndexReviewAnnotation({
+      path: ".red/adr/INDEX.md",
+      text: INDEX,
+      number: "0001",
+      reviewedOn: "2026-08-04",
+      baseSha: "abc1234",
+    });
+    const second = planIndexReviewAnnotation({
+      path: first.path,
+      text: first.text,
+      number: "0001",
+      reviewedOn: "2026-09-10",
+      baseSha: "def5678",
+    });
+
+    expect(first.text).toContain("- **0001** Live decision — reviewed 2026-08-04 @ abc1234");
+    expect(second.text).toContain("- **0001** Live decision — reviewed 2026-09-10 @ def5678");
+    expect(second.text).not.toContain("reviewed 2026-08-04");
+    expect(second.text.match(/reviewed /g)).toHaveLength(1);
   });
 });
 
@@ -633,6 +660,110 @@ describe("planMerge", () => {
         indexText: INDEX,
       }),
     ).toThrow("A merge must consolidate at least two records");
+  });
+});
+
+describe("planAbsorb", () => {
+  const SECOND = ADR.replace("# Retired decision", "# Auxiliary decision");
+
+  it("rewrites one governing ADR and archives only its auxiliaries", () => {
+    const rewritten = ADR.replace(
+      "Keep `apps/old/runtime.ts` as the canonical runtime.",
+      "Keep `apps/new/runtime.ts` as the canonical runtime, including the auxiliary amendment.",
+    );
+    const plan = planAbsorb({
+      governing: { path: ".red/adr/0001-live.md", text: ADR },
+      rewrittenGoverningText: rewritten,
+      auxiliaries: [{ path: ".red/adr/0002-retired.md", text: SECOND }],
+      indexPath: ".red/adr/INDEX.md",
+      indexText: INDEX,
+    });
+
+    expect(plan.governing).toEqual({
+      path: ".red/adr/0001-live.md",
+      originalText: ADR,
+      text: rewritten,
+    });
+    expect(plan.archives).toHaveLength(1);
+    expect(plan.archives[0]!.to).toBe(".red/adr/archive/0002-retired.md");
+    expect(plan.archives[0]!.adrText).toContain("superseded-by: 0001");
+    expect(plan.indexText.match(/- \*\*0001\*\*/g)).toHaveLength(1);
+    expect(plan.indexText.indexOf("- **0001**")).toBeLessThan(plan.indexText.indexOf("## Archived"));
+    expect(plan.indexText.indexOf("- **0002**")).toBeGreaterThan(plan.indexText.indexOf("## Archived"));
+  });
+});
+
+describe("applyAbsorb", () => {
+  it("rewrites the governor, archives auxiliaries, then writes the INDEX once", async () => {
+    const plan = planAbsorb({
+      governing: { path: ".red/adr/0001-live.md", text: ADR },
+      rewrittenGoverningText: ADR.replace("canonical runtime", "governing runtime"),
+      auxiliaries: [{ path: ".red/adr/0002-retired.md", text: ADR }],
+      indexPath: ".red/adr/INDEX.md",
+      indexText: INDEX,
+    });
+    const events: string[] = [];
+
+    await applyAbsorb(plan, {
+      fs: {
+        writeFile: async (path) => {
+          events.push(`write:${path}`);
+        },
+      },
+      git: {
+        mv: async (from, to) => {
+          events.push(`git-mv:${from}:${to}`);
+        },
+      },
+    });
+
+    expect(events).toEqual([
+      "write:.red/adr/0001-live.md",
+      "write:.red/adr/0002-retired.md",
+      "git-mv:.red/adr/0002-retired.md:.red/adr/archive/0002-retired.md",
+      "write:.red/adr/INDEX.md",
+    ]);
+  });
+
+  it("rolls back the INDEX, auxiliaries, and governor when apply fails", async () => {
+    const plan = planAbsorb({
+      governing: { path: ".red/adr/0001-live.md", text: ADR },
+      rewrittenGoverningText: ADR.replace("canonical runtime", "governing runtime"),
+      auxiliaries: [{ path: ".red/adr/0002-retired.md", text: ADR }],
+      indexPath: ".red/adr/INDEX.md",
+      indexText: INDEX,
+    });
+    const events: string[] = [];
+
+    await expect(applyAbsorb(plan, {
+      fs: {
+        writeFile: async (path, text) => {
+          const version = path === plan.indexPath
+            ? text === plan.indexText ? "planned" : "original"
+            : path === plan.governing.path
+              ? text === plan.governing.text ? "planned" : "original"
+              : text === plan.archives[0]!.adrText ? "planned" : "original";
+          events.push(`write:${path}:${version}`);
+          if (path === plan.indexPath && text === plan.indexText) throw new Error("INDEX write failed");
+        },
+      },
+      git: {
+        mv: async (from, to) => {
+          events.push(`git-mv:${from}:${to}`);
+        },
+      },
+    })).rejects.toThrow("INDEX write failed");
+
+    expect(events).toEqual([
+      "write:.red/adr/0001-live.md:planned",
+      "write:.red/adr/0002-retired.md:planned",
+      "git-mv:.red/adr/0002-retired.md:.red/adr/archive/0002-retired.md",
+      "write:.red/adr/INDEX.md:planned",
+      "write:.red/adr/INDEX.md:original",
+      "git-mv:.red/adr/archive/0002-retired.md:.red/adr/0002-retired.md",
+      "write:.red/adr/0002-retired.md:original",
+      "write:.red/adr/0001-live.md:original",
+    ]);
   });
 });
 

--- a/apps/dev/tests/adr-triage.test.ts
+++ b/apps/dev/tests/adr-triage.test.ts
@@ -4,6 +4,7 @@ import {
   type AdrTriageContext,
   detectAdrInconsistencies,
   groupAdrs,
+  rankAdrClusters,
   triageAdrs,
 } from "../src/core/adr-triage.js";
 
@@ -65,7 +66,7 @@ function fixtureTree(): AdrTriageContext {
       // merge-candidate pair — near-identical subjects
       adr("0008", { title: "AFK worker heartbeat protocol" }),
       adr("0009", { title: "AFK worker heartbeat sampling" }),
-      // archive-candidate — accepted but old and nothing links to it
+      // keep — age and a lack of links are evidence to inspect, never terminal evidence
       adr("0010", { title: "Inert shipped decision", ageDays: 900 }),
     ],
     existingPaths: ["apps/memory/src/index.ts", "apps/dev/src/cli.ts"],
@@ -94,7 +95,7 @@ describe("triageAdrs", () => {
       "0007": "split-candidate",
       "0008": "merge-candidate",
       "0009": "merge-candidate",
-      "0010": "archive-candidate",
+      "0010": "keep",
     });
   });
 
@@ -102,12 +103,12 @@ describe("triageAdrs", () => {
     const report = triageAdrs(fixtureTree());
 
     expect(report.countsByBucket).toEqual({
-      keep: 3,
+      keep: 4,
       "stale-reference": 1,
       "missing-supersession": 1,
       "merge-candidate": 2,
       "split-candidate": 1,
-      "archive-candidate": 2,
+      "archive-candidate": 1,
     });
   });
 
@@ -226,6 +227,15 @@ describe("triageAdrs", () => {
     expect(bucketsByNumber(context)["0030"]).toBe("keep");
   });
 
+  it("never treats age and a lack of links as sufficient archival evidence", () => {
+    const entry = triageAdrs({ adrs: [adr("0030", { ageDays: 9_000 })] }).entries[0]!;
+
+    expect(entry.bucket).toBe("keep");
+    expect(entry.signals).toContain("age-days:9000");
+    expect(entry.signals).toContain("inbound-links:0");
+    expect(entry.reason).not.toMatch(/archive|inert/i);
+  });
+
   it("is pure — it does not mutate the records it classifies", () => {
     const context = fixtureTree();
     const snapshot = JSON.parse(JSON.stringify(context));
@@ -332,6 +342,72 @@ describe("groupAdrs", () => {
       { kind: "subject-cluster", title: "castle + execution + owns", numbers: ["0001"] },
     ]);
     expect(report.subject).toEqual({ kind: "numbers", matched: ["0001"], unmatched: ["0099"] });
+  });
+});
+
+describe("rankAdrClusters", () => {
+  it("ranks active clusters by candidate evidence and excludes archived records", () => {
+    const context: AdrTriageContext = {
+      adrs: [
+        adr("0001", { title: "Worker launch contract" }),
+        adr("0002", { title: "Worker launch policy" }),
+        adr("0003", { title: "Memory graph contract" }),
+        adr("0004", {
+          path: ".red/adr/archive/0004-worker-launch-history.md",
+          title: "Worker launch history",
+          status: "Superseded by ADR 0002.",
+        }),
+      ],
+      indexSections: [
+        { title: "Execution", numbers: ["0001", "0002", "0004"] },
+        { title: "Memory", numbers: ["0003"] },
+      ],
+      candidateEvidence: [
+        {
+          kind: "code",
+          path: "apps/dev/src/core/launch.ts",
+          detail: "runtime behavior differs from the launch ADRs",
+          numbers: ["0001", "0002", "0004"],
+          changedSinceReview: true,
+        },
+        {
+          kind: "documentation",
+          path: "docs/memory.md",
+          detail: "documentation still matches the memory ADR",
+          numbers: ["0003"],
+          changedSinceReview: false,
+        },
+      ],
+      reviewMarkers: [
+        { number: "0003", reviewedOn: "2026-08-01", baseSha: "abc1234" },
+      ],
+    };
+
+    const report = rankAdrClusters(context);
+
+    expect(report.clusters.map((cluster) => cluster.title)).toEqual(["Execution", "Memory"]);
+    expect(report.clusters[0]).toMatchObject({
+      rank: 1,
+      numbers: ["0001", "0002"],
+      hasNewEvidence: true,
+      recommendation: "review-now",
+    });
+    expect(report.clusters[0]!.evidence).toEqual([
+      {
+        kind: "code",
+        path: "apps/dev/src/core/launch.ts",
+        detail: "runtime behavior differs from the launch ADRs",
+        numbers: ["0001", "0002"],
+        changedSinceReview: true,
+      },
+    ]);
+    expect(report.clusters[1]).toMatchObject({
+      rank: 2,
+      numbers: ["0003"],
+      hasNewEvidence: false,
+      recommendation: "defer-until-new-evidence",
+    });
+    expect(report.excludedArchived).toEqual(["0004"]);
   });
 });
 

--- a/apps/dev/tests/ask-red-docs.test.ts
+++ b/apps/dev/tests/ask-red-docs.test.ts
@@ -68,6 +68,15 @@ describe("ask-red router docs contract", () => {
     expect(askRedSkill).toContain("/red-doctor");
   });
 
+  it("routes ADR curation through the proposal-driven reverse grill", async () => {
+    const askRedSkill = await readRepoFile("plugins/dev/skills/engineering/ask-red/SKILL.md");
+
+    expect(askRedSkill).toContain("proposal-driven reverse grill");
+    expect(askRedSkill).toContain("ranks active ADR clusters");
+    expect(askRedSkill).toContain("one cluster per PR");
+    expect(askRedSkill).toContain("P01");
+  });
+
   it("documents the maintenance rule in both repo agent instruction files", async () => {
     const [claude, agents] = await Promise.all([readRepoFile("CLAUDE.md"), readRepoFile("AGENTS.md")]);
 

--- a/packaging/pi/dev/skills/engineering/adr-editor/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/adr-editor/SKILL.md
@@ -1,276 +1,239 @@
 ---
 name: adr-editor
-description: Totipotent editor for the `.red/adr/` decision collection — opens by asking which subject to work on, offering the collection's real INDEX themes and subject clusters, then lists, groups, surfaces inconsistencies, adds, removes, rewrites, merges, splits, archives, renumbers, and re-indexes, all applied in-session. Use when asked to review, curate, reorganise, fix, or extend the ADRs, after adding or reversing a decision, or to pay down accumulated decision debt.
+description: Proposal-driven reverse grill for the active `.red/adr/` collection. Ranks active ADR clusters, recommends where to start, confronts one cluster with current implementation evidence, and applies maintainer-approved dispositions through the full ADR verb set. Use to review, curate, reorganise, fix, or extend ADRs and to pay down accumulated decision debt.
 ---
 
-# ADR Editor (interview-first, totipotent, one confirmation for destructive batches)
+# ADR Editor — proposal-driven reverse grill
 
-**The maintainer decides; the editor executes.** Every ADR operation is available
-in this session — there is no read-only default, no judgment lane held back for
-later, and no Spec routing to pass through first.
+**The maintainer decides; the editor executes.** The editor supplies ranked
+evidence and a recommendation, then asks the maintainer to dispose of one
+proposal at a time. It completes one cluster per PR so the review remains a
+coherent decision-history change.
 
-**Open by asking where it hurts.** A collection-wide sweep nobody asked for buries
-the one record the maintainer came for, so the run starts with a question and the
-question arrives with answers already in it.
-
-The `.red/adr/` collection is the repository's decision memory: `.red/adr/*.md`
-holds live guidance, `.red/adr/archive/*.md` holds retired records, and
-`.red/adr/INDEX.md` is the map over both. This skill is one of the few entry
-doors to that collection, so it carries the whole verb set rather than a subset.
+The active collection is `.red/adr/*.md`. Retired records live under
+`.red/adr/archive/`; preserve them as history, but exclude `.red/adr/archive/` from future cluster analysis. `.red/adr/INDEX.md` maps both lanes.
 
 <what-to-do>
 
-Run the loop: **interview for the subject → read that slice → report (list,
-groups, inconsistencies) → agree the operations → confirm once if the batch is
-destructive or wide → apply in-session → verify → land**.
+Run the loop: **inventory active records → rank clusters → recommend one →
+confront it with current evidence → reverse-grill P01, P02, … → accumulate
+accepted proposals → preview all resulting text and the exact diff → confirm
+one destructive batch → apply → verify → land one cluster per PR**.
 
 ## Hard rules
 
-- ✅ **Ask first, sweep second.** Every run opens with the subject question; the
-  buckets, groups, and inconsistencies come after the answer. A report the
-  maintainer did not scope is noise they have to re-read the collection to use.
-- ✅ **Ask with the collection's own subjects in hand.** `groupAdrs` names the
-  INDEX themes and the title-term clusters that actually exist — offer those with
-  counts. A bare "which subject?" hands the work straight back to the maintainer,
-  which is the failure this skill exists to avoid.
-- ✅ **Execute what the maintainer asks, in this session.** Every one of the
-  eleven operations — list, group, surface inconsistencies, add, remove,
-  rewrite, merge, split, archive, renumber, re-index — is applied here, not
-  deferred, not converted into a proposal.
-- ✅ **Confirm once before a destructive or wide batch mutation.** Destructive
-  means it removes or rewrites existing decision content: remove, rewrite a
-  `## Decision`, merge, split, renumber, or archive. Wide means it touches more
-  than three records at once. Ask one question, get one answer, then apply the
-  whole agreed batch — never re-ask per record.
-- ✅ **Leave `.red/adr/INDEX.md` coherent after every mutation.** The governance
-  bijection `Set(active ∪ archived numbers) === Set(INDEX numbers)` must hold
-  when the session ends, and every archived record must carry a terminal status.
-  A `superseded-by:` pointer is required only when a successor exists — a record
-  archived for going inert has none, so do not invent one to satisfy the rule.
-- ✅ **Read supersession by direction.** `missing-supersession` means *this*
-  record is superseded and says so badly; a status that names a record this one
-  supersedes is the healthy forward end and is never debt. A successor pointer
-  that names an issue or PR (`Superseded by: #2417`) stays flagged — a decision
-  is superseded only by another decision — so cure it by naming the successor
-  ADR, never by writing a fabricated pointer into a live record.
-- ✅ **Honour `start/ADR-FORMAT.md`.** Sequential four-digit numbering, an H1 that
-  reads `# NNNN — Title` and matches its filename, and sections only where they
-  earn their place.
-- ✅ **Compose the shipped core.** Detection, bucketing, grouping, archive layout,
-  and every mutation planner live in `apps/dev/src/core/adr-triage.ts` and
-  `apps/dev/src/core/adr-operations.ts`. Extend those modules when a capability
-  lacks a primitive — never re-derive their parsing in prose here.
-- ✅ **Work through the repo's normal git flow.** Branch, worktree, commit, PR —
-  the same discipline as any other change. The primary checkout never switches
-  branch.
-- ✅ Read the collection from the fetched remote default branch when the question
-  is "what has actually landed": `git fetch origin`, resolve `origin/HEAD`, and
-  read with `git ls-tree` / `git show` from `origin/<default-branch>`. Fall back
-  to local `HEAD` when no `origin` ref exists, and say so. Mutations always apply
-  to the working tree.
-- ✅ Ask **one question per turn, each narrowing the last** — the subject first,
-  then only what stays genuinely ambiguous: the correct successor, the right
-  split boundary, which of two records survives a merge. Wait for each answer;
-  stacked questions turn an interview into an interrogation.
-- ❌ Do not silently propagate to the wiki or the Memory graph — propagation is
-  its own request, so offer it and act only when asked.
+- ✅ **One cluster per PR.** Do not mix another cluster into the current change.
+  Finish or stop the selected cluster before recommending the next one.
+- ✅ **Active records only.** Cluster and rank `.red/adr/*.md`; exclude
+  `.red/adr/archive/` from future cluster analysis. Archived records may be read
+  only as historical evidence for the active cluster.
+- ✅ **Evidence informs; the maintainer disposes.** Deterministic helpers emit
+  candidate evidence, not a disposition. The model reads the evidence, explains
+  judgment, recommends an operation, and receives an explicit maintainer
+  disposition for every active ADR in the cluster.
+- ✅ **One proposal per turn.** Present P01, wait for `accept`, `reject`, or an
+  amendment, then present P02. Never stack proposals into one question.
+- ✅ **Confront decisions with reality.** Read current code, tests,
+  documentation, and newer active ADRs before recommending any disposition. Do
+  not infer current behavior from an ADR alone.
+- ❌ **Do not change analyzed product code.** This workflow edits ADR support
+  artifacts only. A product mismatch is evidence for the proposal, not authority
+  to repair the product in this PR.
+- ✅ **Age or lack of links is never sufficient archival evidence.** Archive
+  only when the record is demonstrably auxiliary, deprecated, superseded,
+  absorbed, or otherwise terminal from current evidence and maintainer judgment.
+- ✅ **Absorb and merge are different.** Absorb rewrites one governing ADR to
+  incorporate accepted amendments and archives only the auxiliaries. Merge mints
+  a successor and archives all originals. State this tradeoff whenever both are
+  plausible.
+- ✅ **Review every active record in scope.** No apply step is allowed until
+  every active ADR in the cluster has an explicit maintainer disposition.
+- ✅ **Visible review markers.** After review, visibly annotate every reviewed INDEX bullet
+  with `reviewed YYYY-MM-DD @ <short-base-sha>`, whether its ADR
+  changes or stays as-is. Prioritize re-review only when new evidence exists
+  after that base SHA; age alone never triggers re-review.
+- ✅ **Keep `.red/adr/INDEX.md` coherent after every mutation.** The governance
+  bijection `Set(active ∪ archived numbers) === Set(INDEX numbers)` must hold,
+  and every archived record must carry terminal status and a successor pointer
+  whenever a successor exists.
+- ✅ **Honour `start/ADR-FORMAT.md`.** Sequential four-digit numbering, matching
+  filename/H1, and only sections that earn their place.
+- ✅ **Preserve the complete verb set.** All eleven operations remain available:
+  list, group, surface inconsistencies, add, remove, rewrite, merge, split,
+  archive, renumber, re-index.
+- ✅ **Use the shipped deterministic core.** Triage lives in
+  `apps/dev/src/core/adr-triage.ts`; mutations live in
+  `apps/dev/src/core/adr-operations.ts`. Do not reimplement their parsing in
+  prose or let their heuristics replace model judgment.
+- ✅ **Work through normal git flow.** Branch, worktree, commit, PR; never switch
+  the primary checkout's branch.
+- ❌ Do not silently propagate to the wiki or Memory graph.
 
-## Phase 0 — Interview for the subject (before any deep read)
+## Phase 0 — Build and rank the active inventory
 
-**Derive the choices, then ask once.** Two moves, in that order:
+Fetch the remote base used by the repository and record its short SHA. Build
+`AdrRecord[]` from active files only, plus INDEX sections and numbers. Gather
+candidate evidence for each active record from:
 
-1. **Derive** — build `AdrRecord[]`, the existing-path inventory,
-   `indexSections`, `indexNumbers`, and age facts, then call `groupAdrs` with no
-   subject filter. It returns `index-section` groups for records an INDEX theme
-   already claims and `subject-cluster` groups for the rest, clustered by shared
-   title terms, plus the `ungrouped` singletons. This cheap whole-tree
-   derivation is the only collection-wide read this phase earns — no deep read
-   of any record yet.
-2. **Ask** — one question that carries its own answers: take the group titles and
-   **offer them as numbered choices with their record counts**.
+1. current code paths that implement or contradict it;
+2. tests that bind current behavior;
+3. documentation that presents the behavior to operators;
+4. newer active ADRs that amend, conflict with, or supersede it.
 
-> **Which subject should I work on?** 1. Execution and AFK (14) · 2. Memory
-> graph (9) · … · 8. ungrouped singletons (6) · 9. everything (131 records)
+Call `triageAdrs`, `groupAdrs`, and `detectAdrInconsistencies`, then pass the
+active records, review markers, and evidence to `rankAdrClusters`. Ranking is a
+stable prioritization aid: changed-since-review evidence comes first; unreviewed
+clusters come next; reviewed clusters with no new evidence defer. The helper's
+output is candidate evidence, not a disposition.
 
-**Skip the question when the invocation already names the subject** — "merge
-0034 and 0060", "the ADRs about rsp", "the Execution INDEX theme" all fix the
-slice. Echo the resolved filter in one line and go straight to Phase 1.
+Show the ranked active clusters with record counts, fresh-evidence summaries,
+and review-marker posture. Explicitly recommend where to start and why. If the
+maintainer already named a cluster, use it and do not reopen selection. Otherwise
+ask for the cluster choice once.
 
-**Classify the answer into exactly one of the three subject forms** the
-classifier accepts:
+## Phase 1 — Confront the selected cluster
 
-- ADR numbers — `{ kind: "numbers", numbers: [...] }`;
-- text in title/path/status/body — `{ kind: "text", query: "..." }`;
-- an INDEX theme — `{ kind: "index-section", section: "..." }`.
+Deep-read every active ADR in the chosen cluster and the relevant current code,
+tests, documentation, and newer active ADRs. Archived ADRs can explain history
+but cannot join the active cluster.
 
-**Keep "everything" reachable as the last choice — never a silent default.** The
-maintainer picking it runs the whole collection with no filter; nobody picking it
-means nobody asked for it.
+Produce a private coverage ledger with one row per active ADR. Track evidence,
+proposed disposition, maintainer response, and final accepted disposition. The
+ledger is complete only when every row has an explicit maintainer answer.
 
-A filter narrows what is reported and mutated, never the cross-record evidence
-used to classify it. Report matched numbers and any requested number the tree
-does not have. Done only when a subject filter — or an explicit "everything" — is
-fixed and echoed back.
+The read-only operations remain first-class:
 
-## Phase 1 — Answer about the chosen subject (only after the subject is fixed)
+- **list** — `triageAdrs` entries and evidence;
+- **group** — `groupAdrs` membership;
+- **surface inconsistencies** — `detectAdrInconsistencies` findings.
 
-**Pass the agreed subject filter to all three read-only entry points** from
-`apps/dev/src/core/adr-triage.ts`, so every number reported is one the maintainer
-asked to see:
+## Phase 2 — Reverse grill, one proposal per turn
 
-1. **`triageAdrs`** — buckets every record as `keep`, `stale-reference`,
-   `missing-supersession`, `merge-candidate`, `split-candidate`, or
-   `archive-candidate`, with each entry's signals and reason. This is the
-   **list** operation: report counts per bucket plus the entries in scope.
-2. **`groupAdrs`** — the **group** operation, re-run under the filter so the
-   report shows how the chosen slice sits inside its `index-section` and
-   `subject-cluster` groups.
-3. **`detectAdrInconsistencies`** — the **surface inconsistencies** operation. It
-   reports `numbering-collision`, `dangling-supersede`, `supersession-cycle`,
-   `index-drift`, `missing-supersession`, `stale-path`, and `subject-overlap`
-   findings, each with its implicated numbers and one actionable line. Report a
-   finding that reaches outside the slice when it implicates a record inside it —
-   a dangling pointer is a fact about the pair, not about the filter.
+Number proposals monotonically as P01, P02, and so on. Present exactly one
+proposal per turn in this shape:
 
-Deep-read the flagged records in the slice before proposing anything about them.
-Done only when the maintainer has seen the buckets, the groups, and the
-inconsistency list for the subject they chose — and **nothing outside it**.
+```text
+P01 — <short proposal title>
+ADRs: <active numbers covered>
+Evidence: <specific current code/tests/documentation/newer ADR findings>
+Exact operation: <files, status/pointers, rewritten sections, INDEX movement>
+Alternatives: <at least keep-as-is plus any credible absorb/merge/rewrite option>
+Recommendation: <one choice and why>
+Disposition? accept / reject / amend
+```
 
-## Phase 2 — Agree the operations (anchored on the slice just reported)
+Wait for the answer. Record `accept`, `reject`, or the maintainer's amended
+operation before showing the next proposal. A rejected operation still produces
+an explicit disposition such as keep-as-is; it cannot leave the ADR unresolved.
 
-**Name each operation with its exact inputs** — which ADRs, which numbers are
-minted, which are archived, which pointers are written, which INDEX bullets
-move. Recommend the operation you would run and say why in one sentence.
+Use the operation vocabulary precisely:
 
-| Operation | What it does | Primitive |
-|---|---|---|
-| **add** | mint a new record at the next free number | `planIndexEntry` for its bullet |
-| **remove** | retire a record; prefer archive, delete only when asked outright | `planArchiveMove` |
-| **rewrite** | edit any section of a live record, `## Decision` included | direct edit + `planIndexEntry` |
-| **merge** | consolidate N records into one successor, archiving the originals | `planMerge` |
-| **split** | replace one overloaded record with N focused ones | `planSplit` |
-| **archive** | status a terminal record and `git mv` it to `.red/adr/archive/` | `planArchiveMove` |
-| **renumber** | move a record to a free number — filename, H1, and bullet together | `planRenumber` |
-| **re-index** | place or move one bullet under the right INDEX theme | `planIndexEntry` |
+- **keep** — current evidence still supports the active ADR;
+- **rewrite** — update a governing ADR to match the current decision, including
+  incorporating amendments into its Decision when accepted;
+- **Absorb** — `planAbsorb` rewrites one governing ADR and archives only the
+  auxiliaries; `applyAbsorb` applies it with rollback and INDEX coherence;
+- **Merge** — `planMerge` mints a successor and archives all originals, then
+  `applyComposite` applies the replacement;
+- **split** — `planSplit` mints focused successors and archives the original;
+- **archive/remove** — `planArchiveMove` retires an auxiliary, deprecated,
+  superseded, or absorbed record via `git mv`; outright deletion requires an
+  explicit maintainer request;
+- **add**, **renumber**, and **re-index** retain their ordinary meanings.
 
-Rewriting a `## Decision` in place is permitted — the maintainer owns the
-record. Say plainly when supersede-and-replace would preserve more history and
-let them choose; do not impose it.
+## Phase 3 — Preview one accepted batch, then confirm once
 
-Three narrower planners cover metadata-only work: `planStatusAndSuccessor` sets
-a terminal status and successor pointer, `planIndexArchive` resyncs one INDEX
-bullet into the Archived section, and `planStalePathFix` repairs a backticked
-path that moved.
+As proposals are accepted, accumulate accepted proposals without mutating the
+tree. After every active ADR has an explicit disposition, construct the complete
+batch through the shipped planners.
 
-## Phase 3 — Confirm once (only for a destructive or wide batch)
+Before any destructive write, show the complete resulting text and exact diff
+for every affected ADR and `.red/adr/INDEX.md`. Include terminal statuses,
+successor pointers, archive moves, and the visible
+`reviewed YYYY-MM-DD @ <short-base-sha>` annotations.
 
-**Ask exactly one question, listing the whole batch:**
+Then ask exactly once:
 
-> Apply these N operations now? (`apply` / `stop`) — M records mutated, K archived.
+> Apply this destructive batch now? (`apply` / `stop`)
 
-`apply` authorises the entire listed batch. `stop`, silence, or a requested
-change cancels it: re-plan, show the replacement in full, ask once more. A
-non-destructive, narrow run — list, group, surface inconsistencies, re-index,
-or a single add — needs no gate at all.
+This is the one confirmation for the cluster. `stop`, silence, or requested edits
+cancel the plan; revise it, show the full text and diff again, and obtain a new
+single confirmation. Read-only work needs no confirmation.
 
-## Phase 4 — Apply with the shipped helpers
+## Phase 4 — Apply through deterministic helpers
 
-Immediately before writing, verify each target's working-tree content still
-matches what produced the plan; drift cancels the confirmation, so re-detect and
-re-plan. Then apply through the matching helper:
+Immediately before apply, verify target content still matches the planned input.
+Drift invalidates the preview and confirmation.
 
-- `applyArchiveMove` for a `planArchiveMove` result;
-- `applyStatusAndSuccessor` for a `planStatusAndSuccessor` result;
-- `applyIndexArchive` for a `planIndexArchive` result;
-- `applyStalePathFix` for a `planStalePathFix` result;
-- `applyRenumber` for a `planRenumber` result;
-- `applyComposite` for a `planSplit` or `planMerge` result.
+Use these public helpers:
 
-The injected filesystem and git adapters must perform real writes and real
-`git mv`; keep their compensation behavior, which rolls a failed split or merge
-back in reverse. Stop at the first apply failure and report it — never continue
-into later operations on a half-applied tree.
+- `planArchiveMove` / `applyArchiveMove`;
+- `planStatusAndSuccessor` / `applyStatusAndSuccessor`;
+- `planIndexArchive` / `applyIndexArchive`;
+- `planIndexReviewAnnotation` for the visible review marker;
+- `planStalePathFix` / `applyStalePathFix`;
+- `planRenumber` / `applyRenumber`;
+- `planIndexEntry` for add and re-index;
+- `planSplit` / `applyComposite`;
+- `planMerge` / `applyComposite`;
+- `planAbsorb` / `applyAbsorb`.
 
-## Phase 5 — Verify, then land
+Stop on the first failure. Preserve rollback behavior; never continue on a
+half-applied tree. Update each reviewed INDEX bullet with the review date and
+the short base SHA used for the evidence confrontation.
 
-**Re-run all three read-only entry points against the resulting tree**, under the
-same subject filter, and show the post-apply buckets, groups, and remaining
-inconsistencies. Run the ADR governance and operation tests. Inspect the exact
-diff before committing.
+## Phase 5 — Verify and land
 
-Land through the repo's normal flow: commit in the worktree, push the branch,
-open the PR. When the session ends, run the
-shared end-of-session doc-landing finalizer in
-[`/start`'s DOC-LANDING-FINALIZER.md](../start/DOC-LANDING-FINALIZER.md); it
-stays silent when no docs changed.
+Rebuild the active-only inventory and re-run `triageAdrs`, `groupAdrs`,
+`detectAdrInconsistencies`, and `rankAdrClusters`. Verify:
 
-## Escape hatch — offer `/to-spec` only for genuinely large batches
+- every formerly active cluster member has its accepted disposition;
+- archived auxiliaries/deprecated/superseded/absorbed records are under
+  `.red/adr/archive/` and absent from active ranking;
+- absorb retained and rewrote its governor; merge created one successor;
+- INDEX number bijection and review annotations are coherent;
+- no analyzed product code changed;
+- the diff contains only this cluster's ADR support changes.
 
-When the agreed work is too large to land coherently in one session — a
-collection-wide renumbering, a restructure spanning dozens of records — **offer**
-`/to-spec` so `/to-tickets` and `/afk` can slice it. The maintainer chooses. A
-declined offer means this session does the work. `/to-spec` is never a gate and
-never the default route.
+Run ADR triage, operation, editor-doc, ask-red, and router tests. Inspect the
+exact diff, then land through the repository's normal flow. When the session
+ends, run the shared end-of-session doc-landing finalizer in
+[`/start`'s DOC-LANDING-FINALIZER.md](../start/DOC-LANDING-FINALIZER.md).
 
 </what-to-do>
 
 <supporting-info>
 
-## Composition map
+## Operation map
 
-| Operation | Reuses |
+| Operation | Primitive |
 |---|---|
-| subject interview | `groupAdrs` unfiltered — its group titles are the choices |
-| list | `triageAdrs` + its subject filter and bucket report |
-| group | `groupAdrs` — INDEX sections then title-term clusters |
-| surface inconsistencies | `detectAdrInconsistencies` — seven finding kinds |
+| list | `triageAdrs` |
+| group | `groupAdrs` |
+| surface inconsistencies | `detectAdrInconsistencies` |
+| cluster recommendation | `rankAdrClusters` |
 | add / re-index | `planIndexEntry` |
 | archive / remove | `planArchiveMove` + `applyArchiveMove` |
-| merge | `planMerge` + `applyComposite` |
-| split | `planSplit` + `applyComposite` |
+| rewrite metadata | `planStatusAndSuccessor` + `applyStatusAndSuccessor` |
+| repair stale prose | `planStalePathFix` + `applyStalePathFix` |
+| move INDEX bullet | `planIndexArchive` + `applyIndexArchive` |
+| annotate INDEX review | `planIndexReviewAnnotation` |
 | renumber | `planRenumber` + `applyRenumber` |
-| rewrite | direct edit, with `planStalePathFix` for moved paths |
-| landing | shared `DOC-LANDING-FINALIZER.md` |
+| split | `planSplit` + `applyComposite` |
+| merge | `planMerge` + `applyComposite` |
+| absorb | `planAbsorb` + `applyAbsorb` |
 
-## Inconsistency kinds and their usual cure
+## Disposition guard
 
-| Kind | Usual cure |
-|---|---|
-| `numbering-collision` | `planRenumber` the later record onto a free number |
-| `dangling-supersede` | fix the pointer, or mint the missing successor |
-| `supersession-cycle` | decide which record is terminal, then re-status the pair |
-| `index-drift` | `planIndexEntry` to add the bullet, or drop the orphan bullet |
-| `missing-supersession` | `planStatusAndSuccessor` on the superseded record |
-| `stale-path` | `planStalePathFix` with the verified replacement path |
-| `subject-overlap` | `planMerge`, or record why the two records stay distinct |
-
-## Boundary examples
-
-- "Review the ADRs" names no subject: derive the groups, offer them with counts,
-  and report only the one the maintainer picks. It never becomes a
-  whole-collection dump.
-- "Group the ADRs by theme" is an explicit whole-collection ask — the everything
-  choice, already made. Run `groupAdrs` unfiltered and report: no question, no
-  gate, no mutation, no Spec.
-- "Fix the rsp ADRs" already carries its subject: resolve it to
-  `{ kind: "text", query: "rsp" }`, echo the matched numbers, and skip Phase 0's
-  question entirely.
-- "0112 is wrong now" is a rewrite or a supersede, and this session does it.
-  Ask which shape the maintainer wants; do not default to supersede-and-replace.
-- "Merge 0034 and 0060" runs `planMerge` + `applyComposite` after one
-  confirmation — the merge lands in this session, never as deferred backlog.
-- A split whose boundary is genuinely unclear earns one question about the
-  boundary, then the split. It does not earn a deferral.
-- Renumbering a collided pair is a single confirmed batch: `planRenumber` per
-  record, INDEX bullets carried along by the same plan.
-- Deleting a record outright is only correct when the maintainer asks for a
-  delete rather than an archive; archive preserves history and is the default
-  reading of "remove".
+Do not substitute a heuristic for a decision. Title overlap suggests a cluster;
+it does not prove merge. A stale path proves stale prose; it does not prove the
+Decision is obsolete. Age and zero inbound links prove neither deprecation nor
+inertness. Current implementation evidence plus maintainer judgment supplies the
+disposition.
 
 ## Sibling doctors
 
-`/red-doctor` owns process and adoption drift; `memory:doctor` owns graph
-health; this skill owns the decision collection. Three axes, three doors — do
-not expand into the other two.
+`/red-doctor` owns process and adoption drift; `memory:doctor` owns graph health;
+this skill owns the decision collection.
 
 </supporting-info>

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -186,13 +186,13 @@ through `/memory:view`, `memory docs reference-graph`, and
   adopt a hand-done branch through the no-agent gate, or hand off to `/hitl`.
 - An on-fire Ticket carries the `priority:urgent` label; the `/afk` queue
   promotes it ahead of every `--spec` / `--issues` filter.
-- `/adr-editor` is the totipotent editor over the `.red/adr/` collection. It
-  opens by asking which subject to work on, offering the collection's real INDEX
-  themes and title-term clusters with counts, then reports and mutates that slice:
-  list, group by subject, surface inconsistencies, add, remove, rewrite, merge,
-  split, archive, renumber, and re-index all apply in-session. One confirmation
-  gates a destructive or wide batch; `/to-spec` is an offered escape hatch for
-  genuinely large batches, never a required route.
+- `/adr-editor` is the proposal-driven reverse grill over the active `.red/adr/`
+  collection. It ranks active ADR clusters, recommends where to start, and works
+  one cluster per PR. Inside that cluster it confronts each ADR with code, tests,
+  documentation, and newer ADR evidence, then presents P01, P02, and so on — one
+  proposal per turn — until every active record has an explicit disposition.
+  Accepted proposals accumulate behind one full-text/diff preview and one
+  destructive-batch confirmation; all eleven ADR operations remain available.
 - `/model-tier-policy` answers runner/model tier choices; `runner_list` and
   `runner_detect` on the `castle` MCP answer which backend a host resolves to.
 - `/zoom-out`, `/research`, `/handoff`, `/ff`, and `/reflect` are understanding

--- a/plugins/dev/skills/engineering/adr-editor/SKILL.md
+++ b/plugins/dev/skills/engineering/adr-editor/SKILL.md
@@ -1,276 +1,239 @@
 ---
 name: adr-editor
-description: Totipotent editor for the `.red/adr/` decision collection — opens by asking which subject to work on, offering the collection's real INDEX themes and subject clusters, then lists, groups, surfaces inconsistencies, adds, removes, rewrites, merges, splits, archives, renumbers, and re-indexes, all applied in-session. Use when asked to review, curate, reorganise, fix, or extend the ADRs, after adding or reversing a decision, or to pay down accumulated decision debt.
+description: Proposal-driven reverse grill for the active `.red/adr/` collection. Ranks active ADR clusters, recommends where to start, confronts one cluster with current implementation evidence, and applies maintainer-approved dispositions through the full ADR verb set. Use to review, curate, reorganise, fix, or extend ADRs and to pay down accumulated decision debt.
 ---
 
-# ADR Editor (interview-first, totipotent, one confirmation for destructive batches)
+# ADR Editor — proposal-driven reverse grill
 
-**The maintainer decides; the editor executes.** Every ADR operation is available
-in this session — there is no read-only default, no judgment lane held back for
-later, and no Spec routing to pass through first.
+**The maintainer decides; the editor executes.** The editor supplies ranked
+evidence and a recommendation, then asks the maintainer to dispose of one
+proposal at a time. It completes one cluster per PR so the review remains a
+coherent decision-history change.
 
-**Open by asking where it hurts.** A collection-wide sweep nobody asked for buries
-the one record the maintainer came for, so the run starts with a question and the
-question arrives with answers already in it.
-
-The `.red/adr/` collection is the repository's decision memory: `.red/adr/*.md`
-holds live guidance, `.red/adr/archive/*.md` holds retired records, and
-`.red/adr/INDEX.md` is the map over both. This skill is one of the few entry
-doors to that collection, so it carries the whole verb set rather than a subset.
+The active collection is `.red/adr/*.md`. Retired records live under
+`.red/adr/archive/`; preserve them as history, but exclude `.red/adr/archive/` from future cluster analysis. `.red/adr/INDEX.md` maps both lanes.
 
 <what-to-do>
 
-Run the loop: **interview for the subject → read that slice → report (list,
-groups, inconsistencies) → agree the operations → confirm once if the batch is
-destructive or wide → apply in-session → verify → land**.
+Run the loop: **inventory active records → rank clusters → recommend one →
+confront it with current evidence → reverse-grill P01, P02, … → accumulate
+accepted proposals → preview all resulting text and the exact diff → confirm
+one destructive batch → apply → verify → land one cluster per PR**.
 
 ## Hard rules
 
-- ✅ **Ask first, sweep second.** Every run opens with the subject question; the
-  buckets, groups, and inconsistencies come after the answer. A report the
-  maintainer did not scope is noise they have to re-read the collection to use.
-- ✅ **Ask with the collection's own subjects in hand.** `groupAdrs` names the
-  INDEX themes and the title-term clusters that actually exist — offer those with
-  counts. A bare "which subject?" hands the work straight back to the maintainer,
-  which is the failure this skill exists to avoid.
-- ✅ **Execute what the maintainer asks, in this session.** Every one of the
-  eleven operations — list, group, surface inconsistencies, add, remove,
-  rewrite, merge, split, archive, renumber, re-index — is applied here, not
-  deferred, not converted into a proposal.
-- ✅ **Confirm once before a destructive or wide batch mutation.** Destructive
-  means it removes or rewrites existing decision content: remove, rewrite a
-  `## Decision`, merge, split, renumber, or archive. Wide means it touches more
-  than three records at once. Ask one question, get one answer, then apply the
-  whole agreed batch — never re-ask per record.
-- ✅ **Leave `.red/adr/INDEX.md` coherent after every mutation.** The governance
-  bijection `Set(active ∪ archived numbers) === Set(INDEX numbers)` must hold
-  when the session ends, and every archived record must carry a terminal status.
-  A `superseded-by:` pointer is required only when a successor exists — a record
-  archived for going inert has none, so do not invent one to satisfy the rule.
-- ✅ **Read supersession by direction.** `missing-supersession` means *this*
-  record is superseded and says so badly; a status that names a record this one
-  supersedes is the healthy forward end and is never debt. A successor pointer
-  that names an issue or PR (`Superseded by: #2417`) stays flagged — a decision
-  is superseded only by another decision — so cure it by naming the successor
-  ADR, never by writing a fabricated pointer into a live record.
-- ✅ **Honour `start/ADR-FORMAT.md`.** Sequential four-digit numbering, an H1 that
-  reads `# NNNN — Title` and matches its filename, and sections only where they
-  earn their place.
-- ✅ **Compose the shipped core.** Detection, bucketing, grouping, archive layout,
-  and every mutation planner live in `apps/dev/src/core/adr-triage.ts` and
-  `apps/dev/src/core/adr-operations.ts`. Extend those modules when a capability
-  lacks a primitive — never re-derive their parsing in prose here.
-- ✅ **Work through the repo's normal git flow.** Branch, worktree, commit, PR —
-  the same discipline as any other change. The primary checkout never switches
-  branch.
-- ✅ Read the collection from the fetched remote default branch when the question
-  is "what has actually landed": `git fetch origin`, resolve `origin/HEAD`, and
-  read with `git ls-tree` / `git show` from `origin/<default-branch>`. Fall back
-  to local `HEAD` when no `origin` ref exists, and say so. Mutations always apply
-  to the working tree.
-- ✅ Ask **one question per turn, each narrowing the last** — the subject first,
-  then only what stays genuinely ambiguous: the correct successor, the right
-  split boundary, which of two records survives a merge. Wait for each answer;
-  stacked questions turn an interview into an interrogation.
-- ❌ Do not silently propagate to the wiki or the Memory graph — propagation is
-  its own request, so offer it and act only when asked.
+- ✅ **One cluster per PR.** Do not mix another cluster into the current change.
+  Finish or stop the selected cluster before recommending the next one.
+- ✅ **Active records only.** Cluster and rank `.red/adr/*.md`; exclude
+  `.red/adr/archive/` from future cluster analysis. Archived records may be read
+  only as historical evidence for the active cluster.
+- ✅ **Evidence informs; the maintainer disposes.** Deterministic helpers emit
+  candidate evidence, not a disposition. The model reads the evidence, explains
+  judgment, recommends an operation, and receives an explicit maintainer
+  disposition for every active ADR in the cluster.
+- ✅ **One proposal per turn.** Present P01, wait for `accept`, `reject`, or an
+  amendment, then present P02. Never stack proposals into one question.
+- ✅ **Confront decisions with reality.** Read current code, tests,
+  documentation, and newer active ADRs before recommending any disposition. Do
+  not infer current behavior from an ADR alone.
+- ❌ **Do not change analyzed product code.** This workflow edits ADR support
+  artifacts only. A product mismatch is evidence for the proposal, not authority
+  to repair the product in this PR.
+- ✅ **Age or lack of links is never sufficient archival evidence.** Archive
+  only when the record is demonstrably auxiliary, deprecated, superseded,
+  absorbed, or otherwise terminal from current evidence and maintainer judgment.
+- ✅ **Absorb and merge are different.** Absorb rewrites one governing ADR to
+  incorporate accepted amendments and archives only the auxiliaries. Merge mints
+  a successor and archives all originals. State this tradeoff whenever both are
+  plausible.
+- ✅ **Review every active record in scope.** No apply step is allowed until
+  every active ADR in the cluster has an explicit maintainer disposition.
+- ✅ **Visible review markers.** After review, visibly annotate every reviewed INDEX bullet
+  with `reviewed YYYY-MM-DD @ <short-base-sha>`, whether its ADR
+  changes or stays as-is. Prioritize re-review only when new evidence exists
+  after that base SHA; age alone never triggers re-review.
+- ✅ **Keep `.red/adr/INDEX.md` coherent after every mutation.** The governance
+  bijection `Set(active ∪ archived numbers) === Set(INDEX numbers)` must hold,
+  and every archived record must carry terminal status and a successor pointer
+  whenever a successor exists.
+- ✅ **Honour `start/ADR-FORMAT.md`.** Sequential four-digit numbering, matching
+  filename/H1, and only sections that earn their place.
+- ✅ **Preserve the complete verb set.** All eleven operations remain available:
+  list, group, surface inconsistencies, add, remove, rewrite, merge, split,
+  archive, renumber, re-index.
+- ✅ **Use the shipped deterministic core.** Triage lives in
+  `apps/dev/src/core/adr-triage.ts`; mutations live in
+  `apps/dev/src/core/adr-operations.ts`. Do not reimplement their parsing in
+  prose or let their heuristics replace model judgment.
+- ✅ **Work through normal git flow.** Branch, worktree, commit, PR; never switch
+  the primary checkout's branch.
+- ❌ Do not silently propagate to the wiki or Memory graph.
 
-## Phase 0 — Interview for the subject (before any deep read)
+## Phase 0 — Build and rank the active inventory
 
-**Derive the choices, then ask once.** Two moves, in that order:
+Fetch the remote base used by the repository and record its short SHA. Build
+`AdrRecord[]` from active files only, plus INDEX sections and numbers. Gather
+candidate evidence for each active record from:
 
-1. **Derive** — build `AdrRecord[]`, the existing-path inventory,
-   `indexSections`, `indexNumbers`, and age facts, then call `groupAdrs` with no
-   subject filter. It returns `index-section` groups for records an INDEX theme
-   already claims and `subject-cluster` groups for the rest, clustered by shared
-   title terms, plus the `ungrouped` singletons. This cheap whole-tree
-   derivation is the only collection-wide read this phase earns — no deep read
-   of any record yet.
-2. **Ask** — one question that carries its own answers: take the group titles and
-   **offer them as numbered choices with their record counts**.
+1. current code paths that implement or contradict it;
+2. tests that bind current behavior;
+3. documentation that presents the behavior to operators;
+4. newer active ADRs that amend, conflict with, or supersede it.
 
-> **Which subject should I work on?** 1. Execution and AFK (14) · 2. Memory
-> graph (9) · … · 8. ungrouped singletons (6) · 9. everything (131 records)
+Call `triageAdrs`, `groupAdrs`, and `detectAdrInconsistencies`, then pass the
+active records, review markers, and evidence to `rankAdrClusters`. Ranking is a
+stable prioritization aid: changed-since-review evidence comes first; unreviewed
+clusters come next; reviewed clusters with no new evidence defer. The helper's
+output is candidate evidence, not a disposition.
 
-**Skip the question when the invocation already names the subject** — "merge
-0034 and 0060", "the ADRs about rsp", "the Execution INDEX theme" all fix the
-slice. Echo the resolved filter in one line and go straight to Phase 1.
+Show the ranked active clusters with record counts, fresh-evidence summaries,
+and review-marker posture. Explicitly recommend where to start and why. If the
+maintainer already named a cluster, use it and do not reopen selection. Otherwise
+ask for the cluster choice once.
 
-**Classify the answer into exactly one of the three subject forms** the
-classifier accepts:
+## Phase 1 — Confront the selected cluster
 
-- ADR numbers — `{ kind: "numbers", numbers: [...] }`;
-- text in title/path/status/body — `{ kind: "text", query: "..." }`;
-- an INDEX theme — `{ kind: "index-section", section: "..." }`.
+Deep-read every active ADR in the chosen cluster and the relevant current code,
+tests, documentation, and newer active ADRs. Archived ADRs can explain history
+but cannot join the active cluster.
 
-**Keep "everything" reachable as the last choice — never a silent default.** The
-maintainer picking it runs the whole collection with no filter; nobody picking it
-means nobody asked for it.
+Produce a private coverage ledger with one row per active ADR. Track evidence,
+proposed disposition, maintainer response, and final accepted disposition. The
+ledger is complete only when every row has an explicit maintainer answer.
 
-A filter narrows what is reported and mutated, never the cross-record evidence
-used to classify it. Report matched numbers and any requested number the tree
-does not have. Done only when a subject filter — or an explicit "everything" — is
-fixed and echoed back.
+The read-only operations remain first-class:
 
-## Phase 1 — Answer about the chosen subject (only after the subject is fixed)
+- **list** — `triageAdrs` entries and evidence;
+- **group** — `groupAdrs` membership;
+- **surface inconsistencies** — `detectAdrInconsistencies` findings.
 
-**Pass the agreed subject filter to all three read-only entry points** from
-`apps/dev/src/core/adr-triage.ts`, so every number reported is one the maintainer
-asked to see:
+## Phase 2 — Reverse grill, one proposal per turn
 
-1. **`triageAdrs`** — buckets every record as `keep`, `stale-reference`,
-   `missing-supersession`, `merge-candidate`, `split-candidate`, or
-   `archive-candidate`, with each entry's signals and reason. This is the
-   **list** operation: report counts per bucket plus the entries in scope.
-2. **`groupAdrs`** — the **group** operation, re-run under the filter so the
-   report shows how the chosen slice sits inside its `index-section` and
-   `subject-cluster` groups.
-3. **`detectAdrInconsistencies`** — the **surface inconsistencies** operation. It
-   reports `numbering-collision`, `dangling-supersede`, `supersession-cycle`,
-   `index-drift`, `missing-supersession`, `stale-path`, and `subject-overlap`
-   findings, each with its implicated numbers and one actionable line. Report a
-   finding that reaches outside the slice when it implicates a record inside it —
-   a dangling pointer is a fact about the pair, not about the filter.
+Number proposals monotonically as P01, P02, and so on. Present exactly one
+proposal per turn in this shape:
 
-Deep-read the flagged records in the slice before proposing anything about them.
-Done only when the maintainer has seen the buckets, the groups, and the
-inconsistency list for the subject they chose — and **nothing outside it**.
+```text
+P01 — <short proposal title>
+ADRs: <active numbers covered>
+Evidence: <specific current code/tests/documentation/newer ADR findings>
+Exact operation: <files, status/pointers, rewritten sections, INDEX movement>
+Alternatives: <at least keep-as-is plus any credible absorb/merge/rewrite option>
+Recommendation: <one choice and why>
+Disposition? accept / reject / amend
+```
 
-## Phase 2 — Agree the operations (anchored on the slice just reported)
+Wait for the answer. Record `accept`, `reject`, or the maintainer's amended
+operation before showing the next proposal. A rejected operation still produces
+an explicit disposition such as keep-as-is; it cannot leave the ADR unresolved.
 
-**Name each operation with its exact inputs** — which ADRs, which numbers are
-minted, which are archived, which pointers are written, which INDEX bullets
-move. Recommend the operation you would run and say why in one sentence.
+Use the operation vocabulary precisely:
 
-| Operation | What it does | Primitive |
-|---|---|---|
-| **add** | mint a new record at the next free number | `planIndexEntry` for its bullet |
-| **remove** | retire a record; prefer archive, delete only when asked outright | `planArchiveMove` |
-| **rewrite** | edit any section of a live record, `## Decision` included | direct edit + `planIndexEntry` |
-| **merge** | consolidate N records into one successor, archiving the originals | `planMerge` |
-| **split** | replace one overloaded record with N focused ones | `planSplit` |
-| **archive** | status a terminal record and `git mv` it to `.red/adr/archive/` | `planArchiveMove` |
-| **renumber** | move a record to a free number — filename, H1, and bullet together | `planRenumber` |
-| **re-index** | place or move one bullet under the right INDEX theme | `planIndexEntry` |
+- **keep** — current evidence still supports the active ADR;
+- **rewrite** — update a governing ADR to match the current decision, including
+  incorporating amendments into its Decision when accepted;
+- **Absorb** — `planAbsorb` rewrites one governing ADR and archives only the
+  auxiliaries; `applyAbsorb` applies it with rollback and INDEX coherence;
+- **Merge** — `planMerge` mints a successor and archives all originals, then
+  `applyComposite` applies the replacement;
+- **split** — `planSplit` mints focused successors and archives the original;
+- **archive/remove** — `planArchiveMove` retires an auxiliary, deprecated,
+  superseded, or absorbed record via `git mv`; outright deletion requires an
+  explicit maintainer request;
+- **add**, **renumber**, and **re-index** retain their ordinary meanings.
 
-Rewriting a `## Decision` in place is permitted — the maintainer owns the
-record. Say plainly when supersede-and-replace would preserve more history and
-let them choose; do not impose it.
+## Phase 3 — Preview one accepted batch, then confirm once
 
-Three narrower planners cover metadata-only work: `planStatusAndSuccessor` sets
-a terminal status and successor pointer, `planIndexArchive` resyncs one INDEX
-bullet into the Archived section, and `planStalePathFix` repairs a backticked
-path that moved.
+As proposals are accepted, accumulate accepted proposals without mutating the
+tree. After every active ADR has an explicit disposition, construct the complete
+batch through the shipped planners.
 
-## Phase 3 — Confirm once (only for a destructive or wide batch)
+Before any destructive write, show the complete resulting text and exact diff
+for every affected ADR and `.red/adr/INDEX.md`. Include terminal statuses,
+successor pointers, archive moves, and the visible
+`reviewed YYYY-MM-DD @ <short-base-sha>` annotations.
 
-**Ask exactly one question, listing the whole batch:**
+Then ask exactly once:
 
-> Apply these N operations now? (`apply` / `stop`) — M records mutated, K archived.
+> Apply this destructive batch now? (`apply` / `stop`)
 
-`apply` authorises the entire listed batch. `stop`, silence, or a requested
-change cancels it: re-plan, show the replacement in full, ask once more. A
-non-destructive, narrow run — list, group, surface inconsistencies, re-index,
-or a single add — needs no gate at all.
+This is the one confirmation for the cluster. `stop`, silence, or requested edits
+cancel the plan; revise it, show the full text and diff again, and obtain a new
+single confirmation. Read-only work needs no confirmation.
 
-## Phase 4 — Apply with the shipped helpers
+## Phase 4 — Apply through deterministic helpers
 
-Immediately before writing, verify each target's working-tree content still
-matches what produced the plan; drift cancels the confirmation, so re-detect and
-re-plan. Then apply through the matching helper:
+Immediately before apply, verify target content still matches the planned input.
+Drift invalidates the preview and confirmation.
 
-- `applyArchiveMove` for a `planArchiveMove` result;
-- `applyStatusAndSuccessor` for a `planStatusAndSuccessor` result;
-- `applyIndexArchive` for a `planIndexArchive` result;
-- `applyStalePathFix` for a `planStalePathFix` result;
-- `applyRenumber` for a `planRenumber` result;
-- `applyComposite` for a `planSplit` or `planMerge` result.
+Use these public helpers:
 
-The injected filesystem and git adapters must perform real writes and real
-`git mv`; keep their compensation behavior, which rolls a failed split or merge
-back in reverse. Stop at the first apply failure and report it — never continue
-into later operations on a half-applied tree.
+- `planArchiveMove` / `applyArchiveMove`;
+- `planStatusAndSuccessor` / `applyStatusAndSuccessor`;
+- `planIndexArchive` / `applyIndexArchive`;
+- `planIndexReviewAnnotation` for the visible review marker;
+- `planStalePathFix` / `applyStalePathFix`;
+- `planRenumber` / `applyRenumber`;
+- `planIndexEntry` for add and re-index;
+- `planSplit` / `applyComposite`;
+- `planMerge` / `applyComposite`;
+- `planAbsorb` / `applyAbsorb`.
 
-## Phase 5 — Verify, then land
+Stop on the first failure. Preserve rollback behavior; never continue on a
+half-applied tree. Update each reviewed INDEX bullet with the review date and
+the short base SHA used for the evidence confrontation.
 
-**Re-run all three read-only entry points against the resulting tree**, under the
-same subject filter, and show the post-apply buckets, groups, and remaining
-inconsistencies. Run the ADR governance and operation tests. Inspect the exact
-diff before committing.
+## Phase 5 — Verify and land
 
-Land through the repo's normal flow: commit in the worktree, push the branch,
-open the PR. When the session ends, run the
-shared end-of-session doc-landing finalizer in
-[`/start`'s DOC-LANDING-FINALIZER.md](../start/DOC-LANDING-FINALIZER.md); it
-stays silent when no docs changed.
+Rebuild the active-only inventory and re-run `triageAdrs`, `groupAdrs`,
+`detectAdrInconsistencies`, and `rankAdrClusters`. Verify:
 
-## Escape hatch — offer `/to-spec` only for genuinely large batches
+- every formerly active cluster member has its accepted disposition;
+- archived auxiliaries/deprecated/superseded/absorbed records are under
+  `.red/adr/archive/` and absent from active ranking;
+- absorb retained and rewrote its governor; merge created one successor;
+- INDEX number bijection and review annotations are coherent;
+- no analyzed product code changed;
+- the diff contains only this cluster's ADR support changes.
 
-When the agreed work is too large to land coherently in one session — a
-collection-wide renumbering, a restructure spanning dozens of records — **offer**
-`/to-spec` so `/to-tickets` and `/afk` can slice it. The maintainer chooses. A
-declined offer means this session does the work. `/to-spec` is never a gate and
-never the default route.
+Run ADR triage, operation, editor-doc, ask-red, and router tests. Inspect the
+exact diff, then land through the repository's normal flow. When the session
+ends, run the shared end-of-session doc-landing finalizer in
+[`/start`'s DOC-LANDING-FINALIZER.md](../start/DOC-LANDING-FINALIZER.md).
 
 </what-to-do>
 
 <supporting-info>
 
-## Composition map
+## Operation map
 
-| Operation | Reuses |
+| Operation | Primitive |
 |---|---|
-| subject interview | `groupAdrs` unfiltered — its group titles are the choices |
-| list | `triageAdrs` + its subject filter and bucket report |
-| group | `groupAdrs` — INDEX sections then title-term clusters |
-| surface inconsistencies | `detectAdrInconsistencies` — seven finding kinds |
+| list | `triageAdrs` |
+| group | `groupAdrs` |
+| surface inconsistencies | `detectAdrInconsistencies` |
+| cluster recommendation | `rankAdrClusters` |
 | add / re-index | `planIndexEntry` |
 | archive / remove | `planArchiveMove` + `applyArchiveMove` |
-| merge | `planMerge` + `applyComposite` |
-| split | `planSplit` + `applyComposite` |
+| rewrite metadata | `planStatusAndSuccessor` + `applyStatusAndSuccessor` |
+| repair stale prose | `planStalePathFix` + `applyStalePathFix` |
+| move INDEX bullet | `planIndexArchive` + `applyIndexArchive` |
+| annotate INDEX review | `planIndexReviewAnnotation` |
 | renumber | `planRenumber` + `applyRenumber` |
-| rewrite | direct edit, with `planStalePathFix` for moved paths |
-| landing | shared `DOC-LANDING-FINALIZER.md` |
+| split | `planSplit` + `applyComposite` |
+| merge | `planMerge` + `applyComposite` |
+| absorb | `planAbsorb` + `applyAbsorb` |
 
-## Inconsistency kinds and their usual cure
+## Disposition guard
 
-| Kind | Usual cure |
-|---|---|
-| `numbering-collision` | `planRenumber` the later record onto a free number |
-| `dangling-supersede` | fix the pointer, or mint the missing successor |
-| `supersession-cycle` | decide which record is terminal, then re-status the pair |
-| `index-drift` | `planIndexEntry` to add the bullet, or drop the orphan bullet |
-| `missing-supersession` | `planStatusAndSuccessor` on the superseded record |
-| `stale-path` | `planStalePathFix` with the verified replacement path |
-| `subject-overlap` | `planMerge`, or record why the two records stay distinct |
-
-## Boundary examples
-
-- "Review the ADRs" names no subject: derive the groups, offer them with counts,
-  and report only the one the maintainer picks. It never becomes a
-  whole-collection dump.
-- "Group the ADRs by theme" is an explicit whole-collection ask — the everything
-  choice, already made. Run `groupAdrs` unfiltered and report: no question, no
-  gate, no mutation, no Spec.
-- "Fix the rsp ADRs" already carries its subject: resolve it to
-  `{ kind: "text", query: "rsp" }`, echo the matched numbers, and skip Phase 0's
-  question entirely.
-- "0112 is wrong now" is a rewrite or a supersede, and this session does it.
-  Ask which shape the maintainer wants; do not default to supersede-and-replace.
-- "Merge 0034 and 0060" runs `planMerge` + `applyComposite` after one
-  confirmation — the merge lands in this session, never as deferred backlog.
-- A split whose boundary is genuinely unclear earns one question about the
-  boundary, then the split. It does not earn a deferral.
-- Renumbering a collided pair is a single confirmed batch: `planRenumber` per
-  record, INDEX bullets carried along by the same plan.
-- Deleting a record outright is only correct when the maintainer asks for a
-  delete rather than an archive; archive preserves history and is the default
-  reading of "remove".
+Do not substitute a heuristic for a decision. Title overlap suggests a cluster;
+it does not prove merge. A stale path proves stale prose; it does not prove the
+Decision is obsolete. Age and zero inbound links prove neither deprecation nor
+inertness. Current implementation evidence plus maintainer judgment supplies the
+disposition.
 
 ## Sibling doctors
 
-`/red-doctor` owns process and adoption drift; `memory:doctor` owns graph
-health; this skill owns the decision collection. Three axes, three doors — do
-not expand into the other two.
+`/red-doctor` owns process and adoption drift; `memory:doctor` owns graph health;
+this skill owns the decision collection.
 
 </supporting-info>

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -186,13 +186,13 @@ through `/memory:view`, `memory docs reference-graph`, and
   adopt a hand-done branch through the no-agent gate, or hand off to `/hitl`.
 - An on-fire Ticket carries the `priority:urgent` label; the `/afk` queue
   promotes it ahead of every `--spec` / `--issues` filter.
-- `/adr-editor` is the totipotent editor over the `.red/adr/` collection. It
-  opens by asking which subject to work on, offering the collection's real INDEX
-  themes and title-term clusters with counts, then reports and mutates that slice:
-  list, group by subject, surface inconsistencies, add, remove, rewrite, merge,
-  split, archive, renumber, and re-index all apply in-session. One confirmation
-  gates a destructive or wide batch; `/to-spec` is an offered escape hatch for
-  genuinely large batches, never a required route.
+- `/adr-editor` is the proposal-driven reverse grill over the active `.red/adr/`
+  collection. It ranks active ADR clusters, recommends where to start, and works
+  one cluster per PR. Inside that cluster it confronts each ADR with code, tests,
+  documentation, and newer ADR evidence, then presents P01, P02, and so on — one
+  proposal per turn — until every active record has an explicit disposition.
+  Accepted proposals accumulate behind one full-text/diff preview and one
+  destructive-batch confirmation; all eleven ADR operations remain available.
 - `/model-tier-policy` answers runner/model tier choices; `runner_list` and
   `runner_detect` on the `castle` MCP answer which backend a host resolves to.
 - `/zoom-out`, `/research`, `/handoff`, `/ff`, and `/reflect` are understanding


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3240 -->
🤖 **Re-seed trail** — #3240 on `afk/3240-go-redesign-dev-adr-editor-into-a-propos`, lane `/go`.

Rounds spent: 1/2. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/2 | `gate-stage` (gate) | 🤖 /go: backpressure machine gate failed after DONE; correction retry 1/2. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

Closes #3240

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788407569&installation_model_id=20659&pr_number=3241&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3241&signature=f75d9fe81ccd0bf801e57c3d93f362ccbc5f522f347a73993e1e42487bd5880c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->