### PR TITLE
merge: #3207 Every poll pays full price for an answer that did not change, because nothing sends a conditional request

### DIFF
--- a/.changeset/quiet-polls-reuse-etags.md
+++ b/.changeset/quiet-polls-reuse-etags.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Poll repository activity and queue discovery through conditional Octokit REST reads, preserving the last answer on `304 Not Modified` while keeping quota and network failures distinct.

--- a/apps/dev/src/core/registration-query.ts
+++ b/apps/dev/src/core/registration-query.ts
@@ -38,6 +38,14 @@ export interface RegistrationQueryInput {
   readonly readyLabel?: string;
 }
 
+/** The repository list request equivalent to a registration query. */
+export interface RegistrationPollPlan {
+  readonly owner: string;
+  readonly repo: string;
+  readonly labels: readonly string[];
+  readonly creator?: string;
+}
+
 /**
  * Build the tracker query for one registration.
  *
@@ -52,13 +60,7 @@ export interface RegistrationQueryInput {
  * `spec`/`issues` are carried by the argv to the Worker instead.
  */
 export function buildRegistrationQuery(input: RegistrationQueryInput): string {
-  const repo = input.repo.trim();
-  if (repo === "") {
-    throw new Error(
-      "a registration needs the repository its queue lives in: the daemon polls the string it is handed and " +
-        "cannot work out which tracker a checkout belongs to",
-    );
-  }
+  const repo = requireRepo(input.repo).join("/");
   const selector = input.selector ?? {};
   const terms = [`repo:${repo}`, "is:issue", "is:open", label(input.readyLabel ?? LABEL_READY)];
   if (selector.lane != null && selector.lane !== "") terms.push(label(`lane:${selector.lane}`));
@@ -70,6 +72,28 @@ export function buildRegistrationQuery(input: RegistrationQueryInput): string {
     terms.push(`author:${selector.user}`);
   }
   return terms.join(" ");
+}
+
+/**
+ * Build the typed REST list description beside the opaque tracker query. PURE.
+ *
+ * The project owns this translation because it understands selector facets. The
+ * daemon only carries the resulting route parameters to the transport, so moving
+ * the poll to an ETag-capable endpoint does not teach the host to parse selectors.
+ */
+export function buildRegistrationPollPlan(input: RegistrationQueryInput): RegistrationPollPlan {
+  const [owner, repo] = requireRepo(input.repo);
+  const selector = input.selector ?? {};
+  const labels = [input.readyLabel ?? LABEL_READY];
+  if (selector.lane != null && selector.lane !== "") labels.push(`lane:${selector.lane}`);
+  if (selector.label != null && selector.label !== "") labels.push(selector.label);
+  for (const tag of selector.tags ?? []) {
+    if (tag !== "") labels.push(`${TAG_LABEL_PREFIX}${tag}`);
+  }
+  const creator = selector.user != null && selector.user !== "" && selector.user !== "@me"
+    ? selector.user
+    : undefined;
+  return { owner, repo, labels, ...(creator === undefined ? {} : { creator }) };
 }
 
 /**
@@ -89,4 +113,15 @@ export function registrationQueryUnexpressedFacets(
 
 function label(value: string): string {
   return `label:${JSON.stringify(value)}`;
+}
+
+function requireRepo(value: string): readonly [string, string] {
+  const parts = value.trim().split("/");
+  if (parts.length !== 2 || parts[0] === "" || parts[1] === "") {
+    throw new Error(
+      "a registration needs the repository its queue lives in: the daemon polls the string it is handed and " +
+        "cannot work out which tracker a checkout belongs to",
+    );
+  }
+  return [parts[0]!, parts[1]!];
 }

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -141,6 +141,7 @@ import {
 } from "./core/branch-cleanup.js";
 import { planBranchReclaim } from "./core/branch-reclaim.js";
 import {
+  buildRegistrationPollPlan,
   buildRegistrationQuery,
   registrationQueryUnexpressedFacets,
 } from "./core/registration-query.js";
@@ -1101,6 +1102,7 @@ async function projectStart(root: string, rawInput: ProjectStartInput) {
     // like — the one thing rule 3 forbids.
     registered = await port.register({
       selector,
+      queue_poll: buildRegistrationPollPlan({ repo, selector: input.selector }),
       argv: [...launch.argv],
       workspace_path: root,
       // Both halves of the env come from the ONE composer (#3081): the host's log

--- a/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
@@ -59,9 +59,9 @@ export interface CanarySandbox {
  *
  * The transport under test is the shipped one, built from a token and pointed at
  * an endpoint, so the only thing standing in for GitHub is GitHub: the daemon
- * really issues its aliased query over a socket and really parses an answer. It
- * counts its requests, which is what makes "one request covers every registered
- * project" an assertion rather than a hope.
+ * really issues its conditional REST list over a socket and really parses an
+ * answer. The tracker returns an ETag and then 304 so the repeated-poll path must
+ * retain the original queue depth rather than turning "unchanged" into empty.
  */
 interface CanaryTracker {
   readonly endpoint: string;
@@ -75,6 +75,7 @@ const CANARY_QUEUE_DEPTH = 1;
 
 async function startCanaryTracker(): Promise<CanaryTracker> {
   let requests = 0;
+  const queueEtag = '"canary-queue-v1"';
   const server: Server = createServer((request, response) => {
     let body = "";
     request.on("data", (chunk: Buffer) => {
@@ -82,6 +83,17 @@ async function startCanaryTracker(): Promise<CanaryTracker> {
     });
     request.on("end", () => {
       requests += 1;
+      const url = new URL(request.url ?? "/", "http://canary.invalid");
+      if (request.method === "GET" && url.pathname === "/repos/acme/canary/issues") {
+        if (request.headers["if-none-match"] === queueEtag) {
+          response.writeHead(304, { etag: queueEtag });
+          response.end();
+          return;
+        }
+        response.writeHead(200, { "content-type": "application/json", etag: queueEtag });
+        response.end(JSON.stringify([{ number: 1 }]));
+        return;
+      }
       // One `issueCount` per alias the query asked for, answered from the query
       // itself: a stub that invented its own aliases would answer a question the
       // daemon never asked, and the parser would read every project as unreachable.

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -154,6 +154,11 @@ describe("starting work registers the project", () => {
     expect(held.selector).toBe(
       'repo:acme/widgets is:issue is:open label:"ready-for-agent" label:"lane:go"',
     );
+    expect(held.queue_poll).toEqual({
+      owner: "acme",
+      repo: "widgets",
+      labels: ["ready-for-agent", "lane:go"],
+    });
     expect(started.warnings).toEqual([expect.stringContaining("issues")]);
     // The argv is what runs when a Worker is born for this project, so it carries
     // the runner the operator chose and the same selector the registration does.

--- a/apps/dev/tests/registration-query.test.ts
+++ b/apps/dev/tests/registration-query.test.ts
@@ -6,6 +6,7 @@
 // shape the daemon can act on, and the facets the query cannot carry.
 import { describe, expect, it } from "vitest";
 import {
+  buildRegistrationPollPlan,
   buildRegistrationQuery,
   registrationQueryUnexpressedFacets,
 } from "../src/core/registration-query.js";
@@ -33,6 +34,18 @@ describe("the query a registration hands the host", () => {
       'repo:acme/widgets is:issue is:open label:"ready-for-agent" label:"lane:go" label:"type:ticket" ' +
         'label:"tag:alpha" label:"tag:beta" author:octocat',
     );
+  });
+
+  it("describes the equivalent conditional REST list without asking the daemon to parse the query", () => {
+    expect(buildRegistrationPollPlan({
+      repo: "acme/widgets",
+      selector: { lane: "go", label: "type:ticket", tags: ["alpha", "beta"], user: "octocat" },
+    })).toEqual({
+      owner: "acme",
+      repo: "widgets",
+      labels: ["ready-for-agent", "lane:go", "type:ticket", "tag:alpha", "tag:beta"],
+      creator: "octocat",
+    });
   });
 
   it("leaves an unresolved `@me` out rather than searching for the literal", () => {

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -44,7 +44,11 @@ import {
   type RedskilledQueueArming,
   type RedskilledQueueRegistration,
 } from "./daemon.js";
-import { createGithubBalanceTransport } from "@reddb-io/github";
+import {
+  createGithubAttributionLedger,
+  createGithubBalanceTransport,
+  type GithubAttributionLedger,
+} from "@reddb-io/github";
 import { createGitHubActivityTransport } from "./repository-activity.js";
 import {
   reclaimRedskilledRuntimeDirs,
@@ -282,16 +286,17 @@ export function resolveServeQueueDiscovery(
   values: { readonly "queue-endpoint"?: string; readonly "queue-ms"?: number },
   env: NodeJS.ProcessEnv = process.env,
   readTrackerToken: RedskilledTrackerTokenReader = readTrackerCliToken,
+  attribution?: GithubAttributionLedger,
 ): RedskilledQueueRegistration {
   const interval = values["queue-ms"] == null ? {} : { intervalMs: values["queue-ms"] };
   return {
     ...interval,
-    ...armRedskilledQueueTransport(values, env, readTrackerToken),
+    ...armRedskilledQueueTransport(values, env, readTrackerToken, attribution),
     // The same lookup, handed over so the daemon can repeat it. A credential
     // resolved once at start is resolved in the environment of whichever session
     // auto-spawned this daemon — and that session exits, while the daemon stays
     // (#3056). The daemon asks again only while it holds no transport.
-    armTransport: () => armRedskilledQueueTransport(values, env, readTrackerToken),
+    armTransport: () => armRedskilledQueueTransport(values, env, readTrackerToken, attribution),
   };
 }
 
@@ -328,6 +333,7 @@ export function armRedskilledQueueTransport(
   values: { readonly "queue-endpoint"?: string },
   env: NodeJS.ProcessEnv = process.env,
   readTrackerToken: RedskilledTrackerTokenReader = readTrackerCliToken,
+  attribution?: GithubAttributionLedger,
 ): RedskilledQueueArming {
   const host = resolveRedskilledHostToken(env, readTrackerToken);
   if (host == null) {
@@ -339,7 +345,13 @@ export function armRedskilledQueueTransport(
     };
   }
   const endpoint = values["queue-endpoint"] ?? env.GITHUB_GRAPHQL_URL;
-  return { transport: createGitHubActivityTransport({ token: host.token, ...(endpoint ? { endpoint } : {}) }) };
+  return {
+    transport: createGitHubActivityTransport({
+      token: host.token,
+      ...(endpoint ? { endpoint } : {}),
+      ...(attribution ? { attribution } : {}),
+    }),
+  };
 }
 
 export async function runRedskilledCli(argv: readonly string[]): Promise<number> {
@@ -388,14 +400,22 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       },
       config: hostConfig,
     });
-    const queueDiscovery = resolveServeQueueDiscovery(values);
-    const githubBalance = resolveServeGithubBalance(values);
     // The daemon's own black box (Spec #3022, slice #3023). The event lane already
     // carries `daemon-stop` for the stop this process CHOSE; this record carries
     // the death it did not — a signal, an uncaught error — in the one shape every
     // worker and launcher writes, on a lane that outlives the runtime directory
     // the event lane lives in.
     const hostStateRoot = join(redskilledHomeDir(homedir()), "state");
+    const githubAttribution = createGithubAttributionLedger({
+      path: join(hostStateRoot, "github", "spend.toonl"),
+    });
+    const queueDiscovery = resolveServeQueueDiscovery(
+      values,
+      process.env,
+      readTrackerCliToken,
+      githubAttribution,
+    );
+    const githubBalance = resolveServeGithubBalance(values);
     // Before this daemon anchors itself, it speaks for whatever the last one
     // could not (slice #3028). The host singleton is the only process guaranteed
     // to boot after a machine freeze, so an un-trap-able death on this lane has

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -1430,7 +1430,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       ...registrations,
     ]);
     const projects = [...candidates.values()]
-      .map((registration) => ({ project_label: registration.project_label, selector: registration.selector }))
+      .map((registration) => ({
+        project_label: registration.project_label,
+        selector: registration.selector,
+        ...(registration.queue_poll == null ? {} : { poll: registration.queue_poll }),
+      }))
       // By label, like every other list the daemon reports: the order a client
       // happened to register in is not a fact about the host.
       .sort((left, right) => left.project_label.localeCompare(right.project_label));

--- a/apps/redskilled/src/project-registration.ts
+++ b/apps/redskilled/src/project-registration.ts
@@ -7,7 +7,8 @@
  * machine, which will own the demand loop. A registration is the whole of the
  * project's side of that seam: a record the daemon stores and reports back.
  *
- * **A registration carries six things, and the daemon interprets none of them.**
+ * **A registration carries its work, launch, placement and lifetime, and the
+ * daemon interprets none of the project-authored parts.**
  * The repository identity — already carried today as the opaque project label. An
  * opaque **selector**, the query that names this project's work. An opaque
  * **argv**, what to run when a Worker is born for it. An opaque **workspace
@@ -24,8 +25,9 @@
  * an Issue, a label, a Spec, a gate or a Landing *is*. A selector is a string it
  * carries and hands back, never a sentence it reads — exactly as it already
  * carries a Worker's last logged line without parsing it. Amendment 1 moved the
- * frontier by a repository identity and a token; this moves it by a query string
- * and no further.
+ * frontier by a repository identity and a token; ADR 0133 adds a typed REST
+ * equivalent beside the query so the transport can revalidate it without making
+ * the daemon parse project semantics.
  *
  * **Shape is checked; meaning never is.** The daemon asks whether it holds a
  * string and whether that string is empty, and that is the last thing it ever
@@ -86,6 +88,17 @@ export const REDSKILLED_RENEWAL_CADENCE = 0.5;
 export type RedskilledRenewalStatus = "renewing" | "self-renewing" | "running-on";
 
 /**
+ * An ETag-capable repository list, authored by the project that understands the
+ * selector and carried by the daemon without interpreting it.
+ */
+export interface RedskilledQueuePollPlan {
+  readonly owner: string;
+  readonly repo: string;
+  readonly labels: readonly string[];
+  readonly creator?: string;
+}
+
+/**
  * One project asking to be held, as it states itself.
  *
  * The deadline arrives as a WINDOW rather than as an instant, and the daemon
@@ -98,6 +111,8 @@ export interface RedskilledProjectRegistrationRequest {
   readonly project_label: string;
   /** The query that names this project's work. Opaque — carried, never read. */
   readonly selector: string;
+  /** REST equivalent of the selector; optional for mixed-version clients. */
+  readonly queue_poll?: RedskilledQueuePollPlan;
   /** What to run when a Worker is born for this project. Opaque, likewise. */
   readonly argv: readonly string[];
   /** Where to run it — used verbatim as the Worker's working directory. */
@@ -132,6 +147,7 @@ export interface RedskilledProjectRegistration {
   readonly version: 1;
   readonly project_label: string;
   readonly selector: string;
+  readonly queue_poll?: RedskilledQueuePollPlan;
   readonly argv: readonly string[];
   readonly workspace_path: string;
   readonly env: Readonly<Record<string, string>>;
@@ -232,6 +248,7 @@ export function buildProjectRegistration(
   // Shape, not meaning. The daemon asks whether it holds a non-empty string and
   // never asks a second question about what the string says.
   const selector = requireText(request.selector, "a selector");
+  const queuePoll = requireQueuePollPlan(request.queue_poll, projectLabel);
   const argv = requireLaunchArgv(request.argv, projectLabel);
   const env = requireLaunchEnv(request.env, projectLabel);
   const logPath = requireLaunchLogPath(request.log_path, projectLabel);
@@ -264,6 +281,7 @@ export function buildProjectRegistration(
     version: 1,
     project_label: projectLabel,
     selector,
+    ...(queuePoll == null ? {} : { queue_poll: queuePoll }),
     argv,
     workspace_path: workspacePath,
     env,
@@ -595,6 +613,7 @@ export function isRedskilledProjectRegistration(value: unknown): value is Redski
   return registration.version === 1 &&
     typeof registration.project_label === "string" &&
     typeof registration.selector === "string" &&
+    (registration.queue_poll === undefined || isQueuePollPlanShape(registration.queue_poll)) &&
     Array.isArray(registration.argv) &&
     registration.argv.every((word) => typeof word === "string") &&
     typeof registration.workspace_path === "string" &&
@@ -620,6 +639,27 @@ export function isRedskilledProjectRegistration(value: unknown): value is Redski
     (registration.sustained_by === undefined ||
       registration.sustained_by === "open-work" ||
       registration.sustained_by === "live-worker");
+}
+
+function requireQueuePollPlan(value: unknown, projectLabel: string): RedskilledQueuePollPlan | undefined {
+  if (value === undefined) return undefined;
+  if (!isQueuePollPlanShape(value)) {
+    throw new Error(
+      `redskilled needs a complete queue poll plan for project ${JSON.stringify(projectLabel)} when one is stated`,
+    );
+  }
+  return value;
+}
+
+function isQueuePollPlanShape(value: unknown): value is RedskilledQueuePollPlan {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const plan = value as Record<string, unknown>;
+  return typeof plan.owner === "string" && plan.owner !== "" &&
+    typeof plan.repo === "string" && plan.repo !== "" &&
+    Array.isArray(plan.labels) &&
+    plan.labels.length > 0 &&
+    plan.labels.every((label) => typeof label === "string" && label !== "") &&
+    (plan.creator === undefined || typeof plan.creator === "string");
 }
 
 /** True when `value` is a map of strings to strings — a launch env's whole shape. */

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -39,12 +39,13 @@
  * carries the commanding verbs — stop, recycle, steer — as data rather than as
  * three ops, so the reach rule is decided once for all of them.
  *
- * `project-register` widens the contract by a query string and no further (ADR
- * 0130 Amendment 4). A project contributes a registration rather than a process,
- * and the two strings it carries — a selector and an argv — are opaque in exactly
- * the sense a Worker's last logged line already is: stored, echoed, never read.
- * The daemon still does not know what an Issue, a label, a Spec, a gate or a
- * Landing is, which is what keeps this a frozen surface rather than a growing one.
+ * `project-register` widens the contract by a query string and its typed REST
+ * polling equivalent (ADR 0130 Amendment 4, ADR 0133). The project understands
+ * selector facets and authors both; the daemon stores and passes them to their
+ * transports without deriving either. The selector and argv remain opaque in
+ * exactly the sense a Worker's last logged line already is: stored, echoed, never
+ * read. The daemon still does not know what an Issue, a label, a Spec, a gate or
+ * a Landing is, which keeps this a frozen transport surface rather than semantics.
  * `project-deregister` widens it by nothing at all: it names a project the daemon
  * already keys registrations by, and takes the record back out. `project-renew`
  * names that same project and obliges a client to state nothing further, because

--- a/apps/redskilled/src/queue-discovery.ts
+++ b/apps/redskilled/src/queue-discovery.ts
@@ -1,27 +1,24 @@
 /**
- * queue-discovery — every registered project's queue depth, in one request.
+ * queue-discovery — every registered project's conditionally revalidated depth.
  *
- * ADR 0130 Amendment 3: **the daemon fetches every registered project's queue in
- * one aliased request per interval, alongside the activity counts it already
- * batches.** The reasoning is the one Amendment 1 already accepted for activity:
- * GitHub quota is per token, not per process, so several projects polling with one
- * credential already share a budget and splitting the poller saves nothing — what
- * saves is one request instead of N.
+ * ADR 0130 Amendment 3 keeps one host-scoped poller over every registration.
+ * ADR 0133 changes its production transport: one conditional REST list per
+ * project, whose unchanged 304 costs no API budget, replaces a charged aliased
+ * GraphQL query. N round trips are the deliberate latency trade.
  *
- * **The bigger half was the one left outside.** Queue depth is the same fetch
- * against the same token, and it is the larger consumer: activity moves at human
- * speed, while the queue is read every tick. Batching the smaller half and leaving
- * the larger one per-project was an inconsistency, not a boundary.
+ * **A 304 is a depth, not zero.** The ETag store retains the body with its
+ * validator, so unchanged is indistinguishable from a fresh identical count.
+ * Quota refusal and transport failure still carry null and their own outcome.
  *
  * **Two cadences, not one.** Activity and queue keep their own intervals. Forcing
  * the slow half onto the fast half's rhythm would spend more quota than the
  * batching saves, which is the opposite of the point — so the interval lives with
  * the caller and nothing here assumes the two ever tick together.
  *
- * **A selector is carried, never read.** The daemon asks whether it holds a
- * non-empty string and hands that string to the tracker verbatim; it still does
- * not know what an Issue, a label, a Spec, a gate or a Landing *is* (rule 3). The
- * frontier moved by a query string and no further.
+ * **A selector is carried, never read.** The project also supplies the equivalent
+ * repository-list parameters because it understands selector facets. The daemon
+ * carries both shapes to the transport and derives neither, so it still does not
+ * know what an Issue, a label, a Spec, a gate or a Landing *is* (rule 3).
  *
  * **Never a zero standing in for an absence.** A selector the token cannot resolve
  * and a spent quota each carry a `null` depth and their own outcome, because "this
@@ -32,6 +29,15 @@
  *
  * PURE, apart from `fetchQueueDiscovery`, whose transport is injected.
  */
+
+import {
+  isGithubRateLimitError,
+  type GithubAttributedOperation,
+  type GithubResponseHeaders,
+} from "@reddb-io/github";
+
+import type { RedskilledActivityTransport } from "./repository-activity.js";
+import type { RedskilledQueuePollPlan } from "./project-registration.js";
 
 /**
  * How many selectors one aliased query may span.
@@ -59,6 +65,8 @@ export interface RedskilledProjectSelector {
   readonly project_label: string;
   /** The query, carried verbatim to the tracker and never parsed here. */
   readonly selector: string;
+  /** Typed list parameters supplied by the project; carried, never derived here. */
+  readonly poll?: RedskilledQueuePollPlan;
 }
 
 /**
@@ -90,7 +98,7 @@ export interface RedskilledQueueRateLimit {
 export interface RedskilledQueueDiscovery {
   readonly version: 1;
   readonly fetched_at: string;
-  /** How many requests this interval cost — one per batch, not one per project. */
+  /** Network requests issued: one per conditional project, or one per legacy batch. */
   readonly request_count: number;
   readonly project_count: number;
   readonly batch_size: number;
@@ -257,8 +265,8 @@ export function unconfiguredQueueDiscovery(
   };
 }
 
-/** How a fetch reaches the tracker; injected so nothing here opens a socket. */
-export type RedskilledQueueTransport = (query: string) => Promise<unknown>;
+/** The queue shares the host's conditional-capable activity transport. */
+export type RedskilledQueueTransport = RedskilledActivityTransport;
 
 export interface FetchQueueDiscoveryInput {
   readonly projects: readonly RedskilledProjectSelector[];
@@ -268,7 +276,8 @@ export interface FetchQueueDiscoveryInput {
 }
 
 /**
- * One interval's queue fetch: ONE request, however many projects are registered.
+ * One interval's queue fetch: one conditional request per project in production,
+ * or aliased batches for an injected migration adapter.
  *
  * Batches are issued in order rather than at once, because a host past the bound
  * is spending one token's quota either way and a burst is the shape that trips a
@@ -278,6 +287,7 @@ export interface FetchQueueDiscoveryInput {
  */
 export async function fetchQueueDiscovery(input: FetchQueueDiscoveryInput): Promise<RedskilledQueueDiscovery> {
   if (input.projects.length === 0) return emptyQueueDiscovery(input.now);
+  if (input.transport.conditionalList) return await fetchConditionalQueueDiscovery(input);
   const batchSize = input.batchSize ?? REDSKILLED_QUEUE_BATCH_SIZE;
   const batches = planQueueDiscoveryBatches(input.projects, batchSize);
 
@@ -311,6 +321,80 @@ export async function fetchQueueDiscovery(input: FetchQueueDiscoveryInput): Prom
     request_count: batches.length,
     project_count: projects.length,
     batch_size: batchSize,
+    rate_limit: rateLimit,
+    projects,
+  };
+}
+
+const REDSKILLED_QUEUE_REST_OPERATION: GithubAttributedOperation = {
+  key: "redskilled queue poll",
+  budget: "rest",
+};
+
+async function fetchConditionalQueueDiscovery(
+  input: FetchQueueDiscoveryInput,
+): Promise<RedskilledQueueDiscovery> {
+  assertQueueProjects(input.projects);
+  const list = input.transport.conditionalList!;
+  const projects: RedskilledProjectQueue[] = [];
+  let rateLimit: RedskilledQueueRateLimit = { remaining: null, reset_at: null, exhausted: false };
+  let requestCount = 0;
+
+  for (const project of input.projects) {
+    try {
+      if (project.poll == null) {
+        const operation = buildQueueDiscoveryQuery([project], { batchSize: 1 });
+        const parsed = parseQueueDiscoveryResponse(operation, await input.transport(operation.query));
+        requestCount += 1;
+        projects.push(...parsed.projects);
+        rateLimit = mergeRateLimit(rateLimit, parsed.rate_limit);
+        continue;
+      }
+      const answer = await list({
+        cacheKey: `queue:${project.project_label}:${JSON.stringify(project.poll)}`,
+        route: "GET /repos/{owner}/{repo}/issues",
+        parameters: {
+          owner: project.poll.owner,
+          repo: project.poll.repo,
+          state: "open",
+          labels: project.poll.labels.join(","),
+          ...(project.poll.creator == null ? {} : { creator: project.poll.creator }),
+        },
+        operation: REDSKILLED_QUEUE_REST_OPERATION,
+      });
+      requestCount += answer.requestCount;
+      const depth = answer.data.filter((item) => !isRecord(item.pull_request)).length;
+      rateLimit = mergeRateLimit(rateLimit, queueRateLimitFromHeaders(answer.headers));
+      projects.push({
+        project_label: project.project_label,
+        outcome: "counted",
+        depth,
+        detail: `project ${JSON.stringify(project.project_label)} has ${depth} item(s) matching its selector`,
+      });
+    } catch (error) {
+      const rateLimited = isGithubRateLimitError(error);
+      rateLimit = mergeRateLimit(rateLimit, {
+        remaining: null,
+        reset_at: null,
+        exhausted: rateLimited,
+      });
+      projects.push({
+        project_label: project.project_label,
+        outcome: rateLimited ? "rate-limited" : "unreachable",
+        depth: null,
+        detail:
+          `the queue fetch failed before project ${JSON.stringify(project.project_label)} answered: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  }
+
+  return {
+    version: 1,
+    fetched_at: input.now,
+    request_count: requestCount,
+    project_count: projects.length,
+    batch_size: 1,
     rate_limit: rateLimit,
     projects,
   };
@@ -438,6 +522,23 @@ function mergeRateLimit(held: RedskilledQueueRateLimit, next: RedskilledQueueRat
     reset_at: next.reset_at ?? held.reset_at,
     exhausted: held.exhausted || next.exhausted,
   };
+}
+
+function queueRateLimitFromHeaders(headers: GithubResponseHeaders): RedskilledQueueRateLimit {
+  const remaining = integerHeader(headers, "x-ratelimit-remaining");
+  const resetSeconds = integerHeader(headers, "x-ratelimit-reset");
+  return {
+    remaining,
+    reset_at: resetSeconds == null ? null : new Date(resetSeconds * 1000).toISOString(),
+    exhausted: remaining === 0,
+  };
+}
+
+function integerHeader(headers: GithubResponseHeaders, name: string): number | null {
+  const raw = headers[name];
+  if (typeof raw !== "string" && typeof raw !== "number") return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 function readRateLimit(value: unknown, errors: readonly Record<string, unknown>[]): RedskilledQueueRateLimit {

--- a/apps/redskilled/src/repository-activity.ts
+++ b/apps/redskilled/src/repository-activity.ts
@@ -1,9 +1,9 @@
 /**
- * repository-activity — every registered project's counts, in one request.
+ * repository-activity — every registered project's conditionally revalidated counts.
  *
  * ADR 0130 Amendment 1: **the daemon holds one token and the repository identity
- * of each registered project, and fetches every project's activity counts in a
- * single aliased query per interval.** Rendering the statusline needs open pull
+ * of each registered project, and fetches every project's activity counts with
+ * one host-scoped poller.** Rendering the statusline needs open pull
  * requests, open Issues and recently closed work, and those come from the issue
  * tracker rather than from any process the daemon owns.
  *
@@ -13,17 +13,16 @@
  * returns without interpreting, exactly as it carries a Worker's last logged line
  * without parsing it.
  *
- * **One request, not N.** GitHub quota is per token, not per process, so several
- * projects polling with the same credential already share one budget and splitting
- * the poller across processes saves nothing. What saves is issuing one aliased
- * query that spans every repository at once — the machinery the shared batch layer
- * already had, bound to a single repository, with the parameter widened.
+ * **N round trips, usually zero budget.** Each project has three stable REST
+ * list representations. Their ETags make an unchanged collection answer 304,
+ * which costs no API budget; GraphQL charged the full aggregate on every poll.
+ * The latency trade is deliberate on a poller, where budget binds and wall-clock
+ * slack exists. The aliased GraphQL path remains only for injected migration
+ * adapters that do not expose conditional lists.
  *
- * **Flat in REQUESTS, and never claimed flat in points.** The GraphQL pool is
- * metered by nodes returned, so an aliased query spanning ten repositories is one
- * request and ten repositories' worth of points. The query therefore asks GitHub
- * what it charged (`rateLimit { cost }`) and the document echoes that answer, so
- * no reader of this module can mistake one number for the other (#3095).
+ * **A 304 is the held answer, never an empty one.** The typed client keeps each
+ * validator with the body it validates. Rate-limit and network failures remain
+ * failures with null counts; only an actual unchanged response reuses data.
  *
  * **The condition is checked in code, not assumed in prose.** Every repository on
  * the host must be reachable with the same token; a project that declares its own
@@ -39,17 +38,24 @@
  * **The surface is not this module's to pick.** Which GitHub API answers a call
  * is owned by `@reddb-io/github`, which the castle imports too (ADR 0132
  * decision 4): one table, because two implementations of one routing rule drift.
- * This poll is a multi-repository aggregate, and cardinality sends a
- * multi-repository aggregate to GraphQL — so the endpoint below is DERIVED from
- * the route rather than hardcoded next to it. Note the third budget: an aliased
- * query makes cost flat in the number of projects by REQUEST count and not by
- * node POINTS, and the aliased `search` fields draw the Search pool (30/min)
- * rather than either.
+ * Stable-poll volatility selects conditional REST for production. The legacy
+ * aliased-query constants below stay explicit for migration adapters; they are
+ * not a second production surface decision.
  *
  * PURE, apart from `fetchRepositoryActivity`, whose transport is injected.
  */
 
-import { githubSurfaceFor, type GithubApiSurface } from "@reddb-io/github";
+import {
+  createGithubClient,
+  githubSurfaceFor,
+  isGithubRateLimitError,
+  type GithubApiSurface,
+  type GithubAttributionLedger,
+  type GithubAttributedOperation,
+  type GithubRequestFetch,
+  type GithubPaginatedRestAnswer,
+  type GithubResponseHeaders,
+} from "@reddb-io/github";
 
 /**
  * The gh argv this poll is equivalent to. It exists so the surface below is a
@@ -167,7 +173,7 @@ export interface RedskilledActivityRateLimit {
 export interface RedskilledRepositoryActivity {
   readonly version: 1;
   readonly fetched_at: string;
-  /** How many requests the whole fetch cost — one, for any number of projects. */
+  /** Network requests issued; a 304 is included even though its API-budget cost is zero. */
   readonly request_count: number;
   readonly project_count: number;
   readonly rate_limit: RedskilledActivityRateLimit;
@@ -336,8 +342,25 @@ export function emptyRepositoryActivity(fetchedAt: string): RedskilledRepository
   };
 }
 
-/** How a fetch reaches the tracker; injected so nothing here opens a socket. */
-export type RedskilledActivityTransport = (query: string) => Promise<unknown>;
+export interface RedskilledConditionalListRequest {
+  readonly cacheKey: string;
+  readonly route: string;
+  readonly parameters: Readonly<Record<string, unknown>>;
+  readonly operation: GithubAttributedOperation;
+}
+
+/**
+ * How a fetch reaches the tracker; injected so nothing here opens a socket.
+ *
+ * The callable GraphQL half remains for test adapters and migration fallback.
+ * Production transports add `conditionalList`, which is the stable poll path.
+ */
+export interface RedskilledActivityTransport {
+  (query: string): Promise<unknown>;
+  conditionalList?(
+    input: RedskilledConditionalListRequest,
+  ): Promise<GithubPaginatedRestAnswer<Record<string, unknown>>>;
+}
 
 export interface FetchRepositoryActivityInput {
   readonly projects: readonly RedskilledProjectRepository[];
@@ -348,7 +371,8 @@ export interface FetchRepositoryActivityInput {
 }
 
 /**
- * One interval's fetch: one request, however many projects are registered.
+ * One interval's fetch: conditional REST in production, aliased GraphQL for a
+ * migration adapter that exposes no conditional list.
  *
  * A transport that throws is not swallowed into zeros — the whole document comes
  * back with every project unreachable and the thrown sentence as its detail, so a
@@ -359,6 +383,7 @@ export async function fetchRepositoryActivity(
 ): Promise<RedskilledRepositoryActivity> {
   if (input.projects.length === 0) return emptyRepositoryActivity(input.now);
   assertOneHostToken(input.projects, input.hostTokenRef);
+  if (input.transport.conditionalList) return await fetchConditionalRepositoryActivity(input);
   const operation = buildRepositoryActivityQuery(input.projects, {
     now: input.now,
     closedWindowMs: input.closedWindowMs,
@@ -384,6 +409,107 @@ export async function fetchRepositoryActivity(
       })),
     };
   }
+}
+
+const REDSKILLED_ACTIVITY_REST_OPERATION: GithubAttributedOperation = {
+  key: "redskilled repository activity poll",
+  budget: "rest",
+};
+
+async function fetchConditionalRepositoryActivity(
+  input: FetchRepositoryActivityInput,
+): Promise<RedskilledRepositoryActivity> {
+  assertActivityProjects(input.projects);
+  // A sliding timestamp would make the recently-closed URL different on every
+  // poll and therefore impossible to revalidate. Bucket that human-speed count
+  // by hour: its seven-day meaning changes by at most one hour, while 59 of 60
+  // minute polls can reuse the same representation validator.
+  const nowMs = Date.parse(input.now);
+  const queryNow = Number.isFinite(nowMs)
+    ? new Date(Math.floor(nowMs / (60 * 60 * 1000)) * 60 * 60 * 1000).toISOString()
+    : input.now;
+  const operation = buildRepositoryActivityQuery(input.projects, {
+    now: queryNow,
+    closedWindowMs: input.closedWindowMs,
+  });
+  const list = input.transport.conditionalList!;
+  const projects: RedskilledProjectActivity[] = [];
+  let requestCount = 0;
+  let rateLimit: RedskilledActivityRateLimit = {
+    remaining: null,
+    reset_at: null,
+    exhausted: false,
+    point_cost: null,
+  };
+
+  for (const project of input.projects) {
+    const repository = `${project.owner}/${project.name}`;
+    const queries = [
+      ["open-prs", "GET /repos/{owner}/{repo}/pulls", { owner: project.owner, repo: project.name, state: "open" }],
+      ["open-issues", "GET /repos/{owner}/{repo}/issues", { owner: project.owner, repo: project.name, state: "open" }],
+      [
+        "recently-closed",
+        "GET /repos/{owner}/{repo}/issues",
+        { owner: project.owner, repo: project.name, state: "closed", since: operation.closed_since },
+      ],
+    ] as const;
+    const counts: number[] = [];
+    try {
+      for (const [kind, route, parameters] of queries) {
+        const answer = await list({
+          cacheKey: `activity:${repository}:${kind}:${JSON.stringify(parameters)}`,
+          route,
+          parameters,
+          operation: REDSKILLED_ACTIVITY_REST_OPERATION,
+        });
+        requestCount += answer.requestCount;
+        const items = kind === "open-prs"
+          ? answer.data
+          : answer.data.filter((item) => !isRecord(item.pull_request));
+        counts.push(kind === "recently-closed"
+          ? items.filter((item) => stringValue(item.closed_at) >= operation.closed_since).length
+          : items.length);
+        rateLimit = mergeActivityRateLimit(rateLimit, activityRateLimitFromHeaders(answer.headers));
+      }
+      projects.push({
+        project_label: project.project_label,
+        repository,
+        outcome: "counted",
+        counts: {
+          open_pull_requests: counts[0]!,
+          open_issues: counts[1]!,
+          recently_closed: counts[2]!,
+        },
+        detail: `counted ${repository} for project ${JSON.stringify(project.project_label)}`,
+      });
+    } catch (error) {
+      const rateLimited = isGithubRateLimitError(error);
+      rateLimit = mergeActivityRateLimit(rateLimit, {
+        remaining: null,
+        reset_at: null,
+        exhausted: rateLimited,
+        point_cost: null,
+      });
+      projects.push({
+        project_label: project.project_label,
+        repository,
+        outcome: rateLimited ? "rate-limited" : "unreachable",
+        counts: null,
+        detail:
+          `the activity fetch failed before ${repository} answered: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  }
+
+  return {
+    version: 1,
+    fetched_at: input.now,
+    request_count: requestCount,
+    project_count: projects.length,
+    rate_limit: rateLimit,
+    projects,
+  };
 }
 
 /** One project's counts, dated — the shape a consumer renders. */
@@ -487,30 +613,71 @@ export function isRedskilledActivityReport(value: unknown): value is RedskilledA
 export function createGitHubActivityTransport(options: {
   readonly token: string;
   readonly endpoint?: string;
-  readonly fetchImpl?: typeof fetch;
+  readonly fetchImpl?: GithubRequestFetch;
+  readonly attribution?: GithubAttributionLedger;
+  readonly retryCount?: number;
+  readonly throttle?: boolean;
 }): RedskilledActivityTransport {
-  const endpoint = options.endpoint ?? githubEndpointFor(REDSKILLED_ACTIVITY_SURFACE);
-  const call = options.fetchImpl ?? fetch;
-  return async (query: string): Promise<unknown> => {
-    const response = await call(endpoint, {
-      method: "POST",
-      headers: {
-        authorization: `bearer ${options.token}`,
-        "content-type": "application/json",
-        accept: "application/vnd.github+json",
-      },
-      body: JSON.stringify({ query }),
+  const baseUrl = options.endpoint == null ? undefined : restBaseUrl(options.endpoint);
+  const client = createGithubClient({
+    token: options.token,
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+    ...(options.attribution ? { attribution: options.attribution } : {}),
+    ...(options.retryCount === undefined ? {} : { retryCount: options.retryCount }),
+    ...(options.throttle === undefined ? {} : { throttle: options.throttle }),
+  });
+  const transport = (async (query: string): Promise<unknown> => await client.graphql(query)) as RedskilledActivityTransport;
+  transport.conditionalList = async (input) =>
+    await client.conditionalPaginate<Record<string, unknown>>({
+      cacheKey: input.cacheKey,
+      route: input.route,
+      parameters: input.parameters,
+      operation: input.operation,
     });
-    if (!response.ok) {
-      const remaining = response.headers.get("x-ratelimit-remaining");
-      const quotaSpent = response.status === 429 || remaining === "0";
-      throw new Error(
-        `the activity query was refused with HTTP ${response.status}` +
-          (quotaSpent ? ": the host token's rate limit is spent" : ""),
-      );
-    }
-    return await response.json();
+  return transport;
+}
+
+function restBaseUrl(endpoint: string): string {
+  const url = new URL(endpoint);
+  if (/\/api\/graphql\/?$/.test(url.pathname)) url.pathname = url.pathname.replace(/\/api\/graphql\/?$/, "/api/v3");
+  else url.pathname = url.pathname.replace(/\/graphql\/?$/, "");
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}
+
+function activityRateLimitFromHeaders(headers: GithubResponseHeaders): RedskilledActivityRateLimit {
+  const remaining = integerHeader(headers, "x-ratelimit-remaining");
+  const resetSeconds = integerHeader(headers, "x-ratelimit-reset");
+  return {
+    remaining,
+    reset_at: resetSeconds == null ? null : new Date(resetSeconds * 1000).toISOString(),
+    exhausted: remaining === 0,
+    point_cost: null,
   };
+}
+
+function mergeActivityRateLimit(
+  held: RedskilledActivityRateLimit,
+  next: RedskilledActivityRateLimit,
+): RedskilledActivityRateLimit {
+  const remaining = next.remaining == null
+    ? held.remaining
+    : held.remaining == null ? next.remaining : Math.min(held.remaining, next.remaining);
+  return {
+    remaining,
+    reset_at: next.reset_at ?? held.reset_at,
+    exhausted: held.exhausted || next.exhausted,
+    point_cost: null,
+  };
+}
+
+function integerHeader(headers: GithubResponseHeaders, name: string): number | null {
+  const raw = headers[name];
+  if (typeof raw !== "string" && typeof raw !== "number") return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 function assertActivityProjects(projects: readonly RedskilledProjectRepository[]): void {

--- a/apps/redskilled/tests/conditional-polling.test.ts
+++ b/apps/redskilled/tests/conditional-polling.test.ts
@@ -1,0 +1,111 @@
+// The daemon's hot poll path pays for a changed REST collection and revalidates
+// an unchanged one for zero primary/search budget. A 304 must carry the prior
+// value all the way to the daemon document; it is never an empty queue/count.
+import { describe, expect, it } from "vitest";
+
+import {
+  createGitHubActivityTransport,
+  fetchRepositoryActivity,
+} from "../src/repository-activity.js";
+import { fetchQueueDiscovery } from "../src/queue-discovery.js";
+
+const FIRST = "2026-08-04T12:00:00.000Z";
+const SECOND = "2026-08-04T12:00:15.000Z";
+
+describe("the daemon's conditional REST poll path", () => {
+  it("returns the held queue depth when GitHub answers 304", async () => {
+    const headers: Headers[] = [];
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      const seen = new Headers(init?.headers);
+      headers.push(seen);
+      if (seen.get("if-none-match") === '"queue-v1"') {
+        return new Response(null, { status: 304, headers: { etag: '"queue-v1"' } });
+      }
+      return new Response(JSON.stringify([
+        { number: 1 },
+        { number: 2 },
+        { number: 3 },
+        { number: 4 },
+        { number: 5, pull_request: {} },
+      ]), {
+        status: 200,
+        headers: { "content-type": "application/json", etag: '"queue-v1"' },
+      });
+    };
+    const transport = createGitHubActivityTransport({
+      token: "test-token",
+      endpoint: "https://tracker.example/graphql",
+      fetchImpl,
+      retryCount: 0,
+      throttle: false,
+    });
+    const input = {
+      projects: [{
+        project_label: "acme/widgets",
+        selector: "repo:acme/widgets is:issue is:open",
+        poll: { owner: "acme", repo: "widgets", labels: ["ready-for-agent"] },
+      }],
+      transport,
+    };
+
+    const fresh = await fetchQueueDiscovery({ ...input, now: FIRST });
+    const unchanged = await fetchQueueDiscovery({ ...input, now: SECOND });
+
+    expect(fresh.projects[0]).toMatchObject({ outcome: "counted", depth: 4 });
+    expect(unchanged.projects).toEqual(fresh.projects);
+    expect(unchanged.request_count).toBe(1);
+    expect(headers).toHaveLength(2);
+    expect(headers[1]!.get("if-none-match")).toBe('"queue-v1"');
+  });
+
+  it("reuses every held activity count when all three collections answer 304", async () => {
+    const requests: Array<{ readonly path: string; readonly etag: string | null }> = [];
+    const fetchImpl: typeof fetch = async (url, init) => {
+      const parsed = new URL(String(url));
+      const path = parsed.pathname;
+      const etag = new Headers(init?.headers).get("if-none-match");
+      requests.push({ path, etag });
+      const kind = path.endsWith("/pulls") ? "prs" : parsed.searchParams.get("state") === "open" ? "issues" : "closed";
+      if (etag === `"${kind}-v1"`) {
+        return new Response(null, { status: 304, headers: { etag } });
+      }
+      const count = kind === "prs" ? 2 : kind === "issues" ? 3 : 5;
+      const items = Array.from({ length: count }, (_, index) => ({
+        number: index + 1,
+        ...(kind === "closed" ? { closed_at: "2026-08-04T11:00:00.000Z" } : {}),
+      }));
+      return new Response(JSON.stringify(items), {
+        status: 200,
+        headers: { "content-type": "application/json", etag: `"${kind}-v1"` },
+      });
+    };
+    const transport = createGitHubActivityTransport({
+      token: "test-token",
+      endpoint: "https://tracker.example/graphql",
+      fetchImpl,
+      retryCount: 0,
+      throttle: false,
+    });
+    const input = {
+      projects: [{ project_label: "acme/widgets", owner: "acme", name: "widgets" }],
+      hostTokenRef: "host",
+      transport,
+    };
+
+    const fresh = await fetchRepositoryActivity({ ...input, now: FIRST });
+    const unchanged = await fetchRepositoryActivity({ ...input, now: SECOND });
+
+    expect(fresh.projects[0]).toMatchObject({
+      outcome: "counted",
+      counts: { open_pull_requests: 2, open_issues: 3, recently_closed: 5 },
+    });
+    expect(unchanged.projects).toEqual(fresh.projects);
+    expect(unchanged.request_count).toBe(3);
+    expect(requests).toHaveLength(6);
+    expect(requests.slice(3).map((request) => request.etag)).toEqual([
+      '"prs-v1"',
+      '"issues-v1"',
+      '"closed-v1"',
+    ]);
+  });
+});

--- a/apps/redskilled/tests/queue-transport-supply.test.ts
+++ b/apps/redskilled/tests/queue-transport-supply.test.ts
@@ -51,22 +51,19 @@ async function sessionPaths(): Promise<RedskilledPaths> {
   });
 }
 
-/** A tracker that answers every alias with one depth, and counts what it was asked. */
+/** A tracker that answers every conditional REST search with one depth. */
 async function trackerStandingIn(depth: number): Promise<{ url: string; requests: string[] }> {
   const requests: string[] = [];
   const server = createServer((req, res) => {
-    let body = "";
-    req.on("data", (chunk) => {
-      body += chunk;
+    const url = new URL(req.url ?? "/", "http://tracker.invalid");
+    const query = url.searchParams.get("q") ?? "";
+    requests.push(query);
+    res.writeHead(200, {
+      "content-type": "application/json",
+      etag: `"${Buffer.from(query).toString("base64url")}"`,
+      "x-ratelimit-remaining": "4900",
     });
-    req.on("end", () => {
-      requests.push(body);
-      const aliases = [...body.matchAll(/q(\d+): search/g)].map((match) => match[1]);
-      const data: Record<string, unknown> = { rateLimit: { remaining: 4_900, resetAt: null } };
-      for (const alias of aliases) data[`q${alias}`] = { issueCount: depth };
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ data }));
-    });
+    res.end(JSON.stringify(Array.from({ length: depth }, (_, index) => ({ number: index + 1 }))));
   });
   servers.push(server);
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -74,9 +71,11 @@ async function trackerStandingIn(depth: number): Promise<{ url: string; requests
 }
 
 function registration(label: string, workspace: string, target = 1) {
+  const [owner, repo] = label.split("/") as [string, string];
   return {
     project_label: label,
     selector: `repo:${label} is:issue is:open label:"ready-for-agent"`,
+    queue_poll: { owner, repo, labels: ["ready-for-agent"] },
     // A Worker that leaves proof it ran, in the workspace it was handed.
     argv: [process.execPath, "-e", "require('node:fs').writeFileSync('proof.txt', process.cwd());"],
     workspace_path: workspace,
@@ -119,9 +118,9 @@ describe("whatever registers a project reaches the tracker for it", () => {
       .toBe(workspace);
   });
 
-  it("costs one tracker request per interval, however many projects are registered", async () => {
-    // The reason the poll moved into the host at all: quota is per credential, so
-    // three registered projects that cost three requests is the shape this replaced.
+  it("makes one conditional request per registered project", async () => {
+    // N round trips are the deliberate cost of making each unchanged collection
+    // free against the API budget instead of charging one aliased GraphQL query.
     const tracker = await trackerStandingIn(2);
     const paths = await sessionPaths();
     const workspace = await scratch("redskilled-workspace-");
@@ -142,8 +141,8 @@ describe("whatever registers a project reaches the tracker for it", () => {
     }
     const discovery = await daemon.pollQueueDiscovery();
 
-    expect(tracker.requests).toHaveLength(1);
-    expect(discovery!.request_count).toBe(1);
+    expect(tracker.requests).toHaveLength(3);
+    expect(discovery!.request_count).toBe(3);
     expect(discovery!.projects.map((entry) => entry.project_label)).toEqual(["acme/a", "acme/b", "acme/c"]);
   });
 
@@ -151,8 +150,11 @@ describe("whatever registers a project reaches the tracker for it", () => {
     // A tracker that refuses is not a drained backlog. Nothing is born, and the
     // depth stays absent rather than becoming the zero that reads as "done".
     const server = createServer((_req, res) => {
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ errors: [{ type: "RATE_LIMITED", message: "API rate limit exceeded" }] }));
+      res.writeHead(403, {
+        "content-type": "application/json",
+        "x-ratelimit-remaining": "0",
+      });
+      res.end(JSON.stringify({ message: "API rate limit exceeded" }));
     });
     servers.push(server);
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));

--- a/apps/redskilled/tests/repository-activity.test.ts
+++ b/apps/redskilled/tests/repository-activity.test.ts
@@ -311,7 +311,7 @@ describe("a rate-limited fetch is not an empty one", () => {
 
     expect(seen).toHaveLength(1);
     expect(seen[0]!.url).toBe("https://api.github.com/graphql");
-    expect((seen[0]!.init.headers as Record<string, string>).authorization).toBe("bearer host-token");
+    expect((seen[0]!.init.headers as Record<string, string>).authorization).toBe("token host-token");
   });
 });
 

--- a/apps/redskilled/tests/unattended-demand.test.ts
+++ b/apps/redskilled/tests/unattended-demand.test.ts
@@ -29,6 +29,7 @@ import { registerRedskilledProject } from "../src/client.js";
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { REDSKILLED_HOST_TOKEN_ENV, resolveServeQueueDiscovery } from "../src/cli.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { createGitHubActivityTransport } from "../src/repository-activity.js";
 
 const running: RedskilledDaemon[] = [];
 const roots: string[] = [];
@@ -54,22 +55,19 @@ async function sessionPaths(): Promise<RedskilledPaths> {
   });
 }
 
-/** A tracker that answers every alias with one depth, and counts what it was asked. */
+/** A tracker that answers every conditional REST search with one depth. */
 async function trackerStandingIn(depth: number): Promise<{ url: string; requests: string[] }> {
   const requests: string[] = [];
   const server = createServer((req, res) => {
-    let body = "";
-    req.on("data", (chunk) => {
-      body += chunk;
+    const url = new URL(req.url ?? "/", "http://tracker.invalid");
+    const query = url.searchParams.get("q") ?? "";
+    requests.push(query);
+    res.writeHead(200, {
+      "content-type": "application/json",
+      etag: `"${Buffer.from(query).toString("base64url")}"`,
+      "x-ratelimit-remaining": "4900",
     });
-    req.on("end", () => {
-      requests.push(body);
-      const aliases = [...body.matchAll(/q(\d+): search/g)].map((match) => match[1]);
-      const data: Record<string, unknown> = { rateLimit: { remaining: 4_900, resetAt: null } };
-      for (const alias of aliases) data[`q${alias}`] = { issueCount: depth };
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ data }));
-    });
+    res.end(JSON.stringify(Array.from({ length: depth }, (_, index) => ({ number: index + 1 }))));
   });
   servers.push(server);
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -77,9 +75,11 @@ async function trackerStandingIn(depth: number): Promise<{ url: string; requests
 }
 
 function registration(label: string, workspace: string, target = 1, renewWithinMs?: number) {
+  const [owner, repo] = label.split("/") as [string, string];
   return {
     project_label: label,
     selector: `repo:${label} is:issue is:open label:"ready-for-agent"`,
+    queue_poll: { owner, repo, labels: ["ready-for-agent"] },
     // A Worker that leaves proof it ran, in the workspace it was handed.
     argv: [process.execPath, "-e", "require('node:fs').writeFileSync('proof.txt', process.cwd());"],
     workspace_path: workspace,
@@ -178,7 +178,12 @@ describe("the sustain and the idle exit follow the poll outcome", () => {
       // No births: this is about what keeps the RECORD standing, not about work.
       demandMs: 0,
       queueDiscovery: {
-        ...resolveServeQueueDiscovery({ "queue-endpoint": tracker.url }, { [REDSKILLED_HOST_TOKEN_ENV]: "t" }),
+        transport: createGitHubActivityTransport({
+          token: "t",
+          endpoint: tracker.url,
+          retryCount: 0,
+          throttle: false,
+        }),
         intervalMs: 40,
       },
     });

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -25,6 +25,22 @@ refuses a read entry that states anything else. The one exception is declared,
 not silent: `only` marks a resource that just one API exposes (Actions runs,
 Releases, the search endpoints), where there is no routing choice to make.
 
+## Stable polls use conditional REST
+
+Volatility is the exception cardinality cannot price. The daemon's repository
+activity and queue discovery reads repeat against usually unchanged collections,
+so their production transport uses repository issue and pull-request list
+endpoints through `createGithubClient().conditionalPaginate()`. GitHub's Search
+endpoint did not return a validator in the migration measurement, while these
+list endpoints did. The first `200` stores each page with its `ETag`, and the next
+request sends `If-None-Match` per page. A `304` reuses the stored page and records
+zero spend; it never becomes an empty answer. Rate-limit refusals and network
+failures still fail and cannot fall back to the stored value.
+
+The client is built from `@octokit/rest`, retry, throttling, and the pagination
+plugin bundled by REST.js. Interactive and not-yet-migrated reads keep their
+existing route while migration proceeds one slice at a time under ADR 0133.
+
 ## Three budgets, not two
 
 | Pool      | Metered by  | Limit    |
@@ -52,6 +68,11 @@ Deciding that a read belongs on REST changes nothing on its own — `gh issue vi
 `gh api repos/{o}/{r}/issues/{n}` argv plus a decoder projecting the REST body
 back into the shape `--json` would have printed, so a call site swaps its argv
 and keeps its parsing.
+
+That argv planner remains for call sites not yet migrated. The stable daemon poll
+path is the first typed-client slice: it calls REST directly through Octokit,
+keeps validators with their response bodies, and attributes a changed response
+as cost one and an unchanged response as cost zero.
 
 A field with no single-request REST equivalent is **named, not approximated**:
 `comments` (REST carries a count, not the list), `author` (gh normalizes a bot to
@@ -117,12 +138,12 @@ the reads that would refill it.
 ## Consumers
 
 `apps/dev` (the read boundary, the migrated single-object reads and the reserved
-band in `runtime/gh/band.ts`), `apps/redskilled` (the daemon's multi-repository
-activity query and its one balance poller) and `packages/red-castle` (the tracker
+band in `runtime/gh/band.ts`), `apps/redskilled` (the daemon's conditional REST
+pollers and its one balance poller) and `packages/red-castle` (the tracker
 adapter) all import this package. One table, because two implementations of one
 routing rule drift — and one balance, because two would be two fictions.
 
-An aliased multi-repository query is flat in **requests** and not in **points**:
-the GraphQL pool is metered by nodes returned, so the daemon's activity query
-asks GitHub what it charged (`rateLimit { cost }`) rather than letting one number
-pass for the other.
+The old aliased GraphQL path remains available to injected migration adapters and
+states its point cost explicitly. Production stable polls accept N sequential
+round trips instead: unchanged collections answer `304`, so the API budget pays
+only for the repositories whose representation actually changed.

--- a/packages/github/attribution.ts
+++ b/packages/github/attribution.ts
@@ -10,7 +10,13 @@ import { appendFile, mkdir, readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
 
-import type { GithubOperation, GithubRateBudget } from "./surface.js";
+import type { GithubRateBudget } from "./surface.js";
+
+/** The two routing facts attribution consumes, without re-stating policy. */
+export interface GithubAttributedOperation {
+  readonly key: string;
+  readonly budget: GithubRateBudget;
+}
 
 /** One completed routed call, priced by the transport that observed it. */
 export interface GithubSpendObservation {
@@ -48,7 +54,7 @@ export interface GithubSpendAttributionReport {
 export interface GithubAttributionLedger {
   /** Append one transport-observed call to durable storage. */
   record(input: {
-    readonly operation: GithubOperation;
+    readonly operation: GithubAttributedOperation;
     readonly cost: number;
     readonly observedAt?: string;
   }): Promise<void>;
@@ -138,7 +144,7 @@ export function createGithubAttributionLedger(
 }
 
 function makeObservation(
-  operation: GithubOperation,
+  operation: GithubAttributedOperation,
   cost: number,
   observedAt: string,
 ): GithubSpendObservation {

--- a/packages/github/conditional-client.test.ts
+++ b/packages/github/conditional-client.test.ts
@@ -1,0 +1,165 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createGithubAttributionLedger } from "./attribution.js";
+import {
+  createGithubClient,
+  isGithubRateLimitError,
+  type GithubRequestFetch,
+} from "./conditional-client.js";
+import type { GithubAttributedOperation } from "./attribution.js";
+
+const SEARCH_POLL: GithubAttributedOperation = {
+  key: "redskilled queue poll",
+  budget: "search",
+};
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function ledgerPath(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "github-conditional-client-"));
+  roots.push(root);
+  return join(root, "spend.toonl");
+}
+
+describe("the conditional GitHub client", () => {
+  it("revalidates every page and joins held pages into the same collection", async () => {
+    const seen: Array<{ readonly page: string | null; readonly etag: string | null }> = [];
+    const fetchImpl: GithubRequestFetch = async (url, init) => {
+      const page = new URL(String(url)).searchParams.get("page");
+      const etag = new Headers(init?.headers).get("if-none-match");
+      seen.push({ page, etag });
+      const validator = `"page-${page}"`;
+      if (etag === validator) return new Response(null, { status: 304, headers: { etag } });
+      return new Response(JSON.stringify([{ number: Number(page) }]), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          etag: validator,
+          ...(page === "1"
+            ? { link: '<https://api.github.com/repos/acme/widgets/issues?page=2>; rel="next"' }
+            : {}),
+        },
+      });
+    };
+    const client = createGithubClient({ token: "test-token", fetchImpl, retryCount: 0, throttle: false });
+    const request = {
+      cacheKey: "queue:acme/widgets",
+      route: "GET /repos/{owner}/{repo}/issues",
+      parameters: { owner: "acme", repo: "widgets", state: "open" },
+      operation: { key: "redskilled queue poll", budget: "rest" as const },
+    };
+
+    const fresh = await client.conditionalPaginate<{ number: number }>(request);
+    const unchanged = await client.conditionalPaginate<{ number: number }>(request);
+
+    expect(fresh).toMatchObject({ data: [{ number: 1 }, { number: 2 }], requestCount: 2 });
+    expect(unchanged.data).toEqual(fresh.data);
+    expect(seen).toEqual([
+      { page: "1", etag: null },
+      { page: "2", etag: null },
+      { page: "1", etag: '"page-1"' },
+      { page: "2", etag: '"page-2"' },
+    ]);
+  });
+
+  it("revalidates with the stored ETag and returns the held answer on 304", async () => {
+    const seen: Headers[] = [];
+    const responses = [
+      new Response(JSON.stringify({ total_count: 7, items: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json", etag: '"queue-v1"' },
+      }),
+      new Response(null, { status: 304, headers: { etag: '"queue-v1"' } }),
+    ];
+    const fetchImpl: GithubRequestFetch = async (_url, init) => {
+      seen.push(new Headers(init?.headers));
+      return responses.shift()!;
+    };
+    const ledger = createGithubAttributionLedger({ path: await ledgerPath() });
+    const client = createGithubClient({
+      token: "test-token",
+      fetchImpl,
+      attribution: ledger,
+      retryCount: 0,
+      throttle: false,
+    });
+    const request = {
+      cacheKey: "queue:acme/widgets",
+      route: "GET /search/issues" as const,
+      parameters: { q: "repo:acme/widgets is:issue is:open", per_page: 1 },
+      operation: SEARCH_POLL,
+    };
+
+    const fresh = await client.conditionalRest<{ total_count: number; items: unknown[] }>(request);
+    const unchanged = await client.conditionalRest<{ total_count: number; items: unknown[] }>(request);
+
+    expect(fresh.data).toEqual({ total_count: 7, items: [] });
+    expect(unchanged.data).toEqual(fresh.data);
+    expect(seen[0]!.get("if-none-match")).toBeNull();
+    expect(seen[1]!.get("if-none-match")).toBe('"queue-v1"');
+
+    const report = await ledger.report({
+      from: "2000-01-01T00:00:00.000Z",
+      to: "2100-01-01T00:00:00.000Z",
+      pool: "search",
+    });
+    expect(report.operations).toEqual([
+      { operation_key: "redskilled queue poll", pool: "search", count: 2, cost: 1 },
+    ]);
+  });
+
+  it("never turns a network failure into the held answer", async () => {
+    let calls = 0;
+    const fetchImpl: GithubRequestFetch = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response(JSON.stringify({ total_count: 3 }), {
+          status: 200,
+          headers: { "content-type": "application/json", etag: '"queue-v1"' },
+        });
+      }
+      throw new Error("socket closed");
+    };
+    const client = createGithubClient({ token: "test-token", fetchImpl, retryCount: 0, throttle: false });
+    const request = {
+      cacheKey: "queue:acme/widgets",
+      route: "GET /search/issues" as const,
+      parameters: { q: "repo:acme/widgets", per_page: 1 },
+      operation: SEARCH_POLL,
+    };
+
+    await client.conditionalRest(request);
+    await expect(client.conditionalRest(request)).rejects.toThrow("socket closed");
+  });
+
+  it("keeps a rate-limit refusal distinct from an unchanged response", async () => {
+    const fetchImpl: GithubRequestFetch = async () =>
+      new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+        status: 403,
+        headers: {
+          "content-type": "application/json",
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": "1924992000",
+        },
+      });
+    const client = createGithubClient({ token: "test-token", fetchImpl, retryCount: 0, throttle: false });
+
+    const error = await client
+      .conditionalRest({
+        cacheKey: "queue:acme/widgets",
+        route: "GET /search/issues",
+        parameters: { q: "repo:acme/widgets", per_page: 1 },
+        operation: SEARCH_POLL,
+      })
+      .then(() => null, (thrown: unknown) => thrown);
+
+    expect(isGithubRateLimitError(error)).toBe(true);
+  });
+});

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -1,0 +1,235 @@
+// conditional-client.ts — the HTTP transport for stable GitHub reads.
+//
+// A 304 is a successful revalidation, not an empty response. The client owns the
+// ETag and the answer it validates together, so no caller can observe a 304
+// without the data from the preceding 200. Rate-limit and network failures are
+// allowed through as failures: neither is evidence that the held answer is still
+// current.
+
+import { retry } from "@octokit/plugin-retry";
+import { throttling } from "@octokit/plugin-throttling";
+import { Octokit as RestOctokit } from "@octokit/rest";
+
+import type { GithubAttributionLedger, GithubAttributedOperation } from "./attribution.js";
+
+const Octokit = RestOctokit.plugin(retry, throttling);
+
+export type GithubRequestFetch = typeof fetch;
+export type GithubResponseHeaders = Readonly<Record<string, string | number | undefined>>;
+
+export interface GithubEtagEntry {
+  readonly etag: string;
+  readonly data: unknown;
+  readonly headers: GithubResponseHeaders;
+}
+
+/** The ETag and answer are one entry: retaining only the validator makes 304 empty. */
+export interface GithubEtagStore {
+  get(key: string): GithubEtagEntry | undefined;
+  set(key: string, entry: GithubEtagEntry): void;
+}
+
+/** A daemon-lifetime store. Callers may provide a durable implementation later. */
+export function createMemoryGithubEtagStore(): GithubEtagStore {
+  const entries = new Map<string, GithubEtagEntry>();
+  return {
+    get: (key) => entries.get(key),
+    set: (key, entry) => entries.set(key, entry),
+  };
+}
+
+export interface GithubConditionalRestRequest {
+  /** Stable identity of one collection across poll cycles. */
+  readonly cacheKey: string;
+  /** An Octokit route such as `GET /search/issues`. */
+  readonly route: string;
+  readonly parameters?: Readonly<Record<string, unknown>>;
+  /** Durable spend attribution for this call. */
+  readonly operation: GithubAttributedOperation;
+}
+
+/**
+ * The caller deliberately cannot distinguish 200 from 304. Both answers carry
+ * the same data; only a failure escapes as a different outcome.
+ */
+export interface GithubRestAnswer<T> {
+  readonly data: T;
+  readonly headers: GithubResponseHeaders;
+}
+
+export interface GithubPaginatedRestAnswer<T> extends GithubRestAnswer<readonly T[]> {
+  /** HTTP requests issued, including free 304 revalidations. */
+  readonly requestCount: number;
+}
+
+export interface GithubClient {
+  conditionalRest<T>(request: GithubConditionalRestRequest): Promise<GithubRestAnswer<T>>;
+  conditionalPaginate<T>(request: GithubConditionalRestRequest): Promise<GithubPaginatedRestAnswer<T>>;
+  graphql<T>(query: string, variables?: Readonly<Record<string, unknown>>): Promise<T>;
+}
+
+export interface CreateGithubClientOptions {
+  readonly token: string;
+  readonly baseUrl?: string;
+  readonly fetchImpl?: GithubRequestFetch;
+  readonly etags?: GithubEtagStore;
+  readonly attribution?: GithubAttributionLedger;
+  /** Transient retries; the plugin default in production, overridable in tests. */
+  readonly retryCount?: number;
+  /** Disable plugin pacing only for a caller-supplied transport test. */
+  readonly throttle?: boolean;
+}
+
+/** An expired credential stated in operator language rather than as a bare 401. */
+export class GithubCredentialError extends Error {
+  readonly status = 401;
+
+  constructor(options?: { readonly cause?: unknown }) {
+    super(
+      "GitHub rejected the host credential; refresh the stored login with `gh auth login` or provide a current host token",
+      options,
+    );
+    this.name = "GithubCredentialError";
+  }
+}
+
+/**
+ * Build the typed GitHub transport decided by ADR 0133.
+ *
+ * `@octokit/rest` already composes `plugin-paginate-rest`; retry handles
+ * transient server failures, while throttling serializes and classifies primary
+ * and secondary limits. The callbacks decline a long in-call retry so the
+ * daemon's existing poll cadence can pace the next cycle from the response.
+ */
+export function createGithubClient(options: CreateGithubClientOptions): GithubClient {
+  const etags = options.etags ?? createMemoryGithubEtagStore();
+  const octokit = new Octokit({
+    auth: options.token,
+    // REST.js logs every non-2xx before the caller can classify it, including
+    // the expected 304 that is this client's success path. Outcomes travel as
+    // typed returns/errors instead of turning every quiet poll into stderr.
+    log: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    ...(options.baseUrl ? { baseUrl: options.baseUrl } : {}),
+    ...(options.fetchImpl ? { request: { fetch: options.fetchImpl } } : {}),
+    retry: {
+      doNotRetry: [304, 403, 429],
+      ...(options.retryCount === undefined ? {} : { retries: options.retryCount }),
+    },
+    throttle: options.throttle === false
+      ? { enabled: false }
+      : {
+          onRateLimit: () => false,
+          onSecondaryRateLimit: () => false,
+        },
+  });
+
+  const conditionalRest = async <T>(input: GithubConditionalRestRequest): Promise<GithubRestAnswer<T>> => {
+      const held = etags.get(input.cacheKey);
+      const parameters = { ...(input.parameters ?? {}) } as Record<string, unknown>;
+      const callerHeaders = isRecord(parameters.headers) ? parameters.headers : {};
+      parameters.headers = {
+        ...callerHeaders,
+        ...(held ? { "if-none-match": held.etag } : {}),
+      };
+
+      try {
+        const response = await octokit.request(input.route, parameters);
+        const headers = response.headers as GithubResponseHeaders;
+        const etag = header(headers, "etag");
+        if (etag !== undefined) etags.set(input.cacheKey, { etag, data: response.data, headers });
+        await options.attribution?.record({ operation: input.operation, cost: 1 });
+        return { data: response.data as T, headers };
+      } catch (error) {
+        if (httpStatus(error) === 304) {
+          if (held === undefined) {
+            throw new Error(
+              `GitHub returned 304 for ${JSON.stringify(input.cacheKey)} without a held answer to reuse`,
+              { cause: error },
+            );
+          }
+          const responseHeaders = errorHeaders(error);
+          const headers = { ...held.headers, ...responseHeaders };
+          const etag = header(headers, "etag") ?? held.etag;
+          etags.set(input.cacheKey, { etag, data: held.data, headers });
+          await options.attribution?.record({ operation: input.operation, cost: 0 });
+          return { data: held.data as T, headers };
+        }
+        if (httpStatus(error) === 401) throw new GithubCredentialError({ cause: error });
+        throw error;
+      }
+    };
+
+  return {
+    conditionalRest,
+
+    async conditionalPaginate<T>(input: GithubConditionalRestRequest): Promise<GithubPaginatedRestAnswer<T>> {
+      const data: T[] = [];
+      let headers: GithubResponseHeaders = {};
+      let requestCount = 0;
+      let page = 1;
+      for (;;) {
+        const answer = await conditionalRest<unknown>({
+          ...input,
+          cacheKey: `${input.cacheKey}:page:${page}`,
+          parameters: { ...(input.parameters ?? {}), per_page: 100, page },
+        });
+        requestCount += 1;
+        if (!Array.isArray(answer.data)) {
+          throw new Error(`GitHub returned a non-list body for ${JSON.stringify(input.cacheKey)} page ${page}`);
+        }
+        data.push(...answer.data as T[]);
+        headers = answer.headers;
+        if (!hasNextPage(answer.headers)) break;
+        page += 1;
+      }
+      return { data, headers, requestCount };
+    },
+
+    async graphql<T>(query: string, variables: Readonly<Record<string, unknown>> = {}): Promise<T> {
+      try {
+        return await octokit.graphql(query, variables) as T;
+      } catch (error) {
+        if (httpStatus(error) === 401) throw new GithubCredentialError({ cause: error });
+        throw error;
+      }
+    },
+  };
+}
+
+function hasNextPage(headers: GithubResponseHeaders): boolean {
+  const link = header(headers, "link");
+  return link !== undefined && /(?:^|,)\s*<[^>]+>;\s*rel="next"(?:\s*;|\s*(?:,|$))/i.test(link);
+}
+
+/** Primary/secondary quota refusal, distinct from 304 and transport failure. */
+export function isGithubRateLimitError(error: unknown): boolean {
+  const status = httpStatus(error);
+  const headers = errorHeaders(error);
+  return status === 429 ||
+    (status === 403 && header(headers, "x-ratelimit-remaining") === "0") ||
+    (error instanceof Error && /secondary rate|rate limit/i.test(error.message));
+}
+
+function httpStatus(error: unknown): number | undefined {
+  if (!isRecord(error)) return undefined;
+  return typeof error.status === "number" ? error.status : undefined;
+}
+
+function errorHeaders(error: unknown): GithubResponseHeaders {
+  if (!isRecord(error) || !isRecord(error.response) || !isRecord(error.response.headers)) return {};
+  return error.response.headers as GithubResponseHeaders;
+}
+
+function header(headers: GithubResponseHeaders, name: string): string | undefined {
+  const value = headers[name] ?? headers[name.toLowerCase()];
+  return typeof value === "string" ? value : typeof value === "number" ? String(value) : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -1,12 +1,13 @@
 // @reddb-io/github — the one budget-aware GitHub client.
 //
-// ADR 0132 decision 4 as superseded by Amendment 2. Five modules, one question
+// ADR 0132 decision 4 as superseded by Amendment 2. Six modules, one question
 // each:
 //   surface.ts   — WHICH API answers a call, decided by cardinality.
 //   rest-plan.ts — HOW a single-object read is actually issued on REST.
 //   balance.ts   — WHAT the token has left, asked rather than counted, and what
 //                  that balance admits.
 //   attribution.ts — WHO this process believes spent each pool, durably.
+//   conditional-client.ts — HOW stable REST polls make an unchanged answer free.
 //   cache.ts     — WHAT was kept, and how old it is.
 //
 // The daemon and the castle both import this package rather than each keeping a
@@ -34,12 +35,29 @@ export {
 
 export {
   createGithubAttributionLedger,
+  type GithubAttributedOperation,
   type CreateGithubAttributionLedgerOptions,
   type GithubAttributionLedger,
   type GithubOperationSpend,
   type GithubSpendAttributionReport,
   type GithubSpendObservation,
 } from "./attribution.js";
+
+export {
+  GithubCredentialError,
+  createGithubClient,
+  createMemoryGithubEtagStore,
+  isGithubRateLimitError,
+  type CreateGithubClientOptions,
+  type GithubClient,
+  type GithubConditionalRestRequest,
+  type GithubEtagEntry,
+  type GithubEtagStore,
+  type GithubRequestFetch,
+  type GithubPaginatedRestAnswer,
+  type GithubResponseHeaders,
+  type GithubRestAnswer,
+} from "./conditional-client.js";
 
 export {
   GITHUB_BALANCE_CADENCE,

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -8,12 +8,16 @@
   "exports": {
     ".": "./index.ts",
     "./attribution.js": "./attribution.ts",
+    "./conditional-client.js": "./conditional-client.ts",
     "./surface.js": "./surface.ts",
     "./rest-plan.js": "./rest-plan.ts",
     "./balance.js": "./balance.ts",
     "./cache.js": "./cache.ts"
   },
   "dependencies": {
+    "@octokit/plugin-retry": "^8.1.1",
+    "@octokit/plugin-throttling": "^11.0.5",
+    "@octokit/rest": "^22.0.1",
     "@reddb-io/toon": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,15 @@ importers:
 
   packages/github:
     dependencies:
+      '@octokit/plugin-retry':
+        specifier: ^8.1.1
+        version: 8.1.1(@octokit/core@7.0.7)
+      '@octokit/plugin-throttling':
+        specifier: ^11.0.5
+        version: 11.0.5(@octokit/core@7.0.7)
+      '@octokit/rest':
+        specifier: ^22.0.1
+        version: 22.0.1
       '@reddb-io/toon':
         specifier: 'catalog:'
         version: 0.13.0
@@ -1397,6 +1406,76 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.7':
+    resolution: {integrity: sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.4':
+    resolution: {integrity: sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.4':
+    resolution: {integrity: sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-types@28.0.0':
+    resolution: {integrity: sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-retry@8.1.1':
+    resolution: {integrity: sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=7'
+
+  '@octokit/plugin-throttling@11.0.5':
+    resolution: {integrity: sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': ^7.0.0
+
+  '@octokit/request-error@7.1.1':
+    resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.13':
+    resolution: {integrity: sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/types@17.0.0':
+    resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
+
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
     engines: {node: '>= 10.0.0'}
@@ -1838,6 +1917,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -1845,6 +1927,9 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2259,6 +2344,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-with-bigint@3.5.10:
+    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -2769,6 +2857,9 @@ packages:
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3619,6 +3710,88 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.7':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.4
+      '@octokit/request': 10.0.13
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.4':
+    dependencies:
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.4':
+    dependencies:
+      '@octokit/request': 10.0.13
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/openapi-types@28.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-retry@8.1.1(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/plugin-throttling@11.0.5(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 17.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/request-error@7.1.1':
+    dependencies:
+      '@octokit/types': 17.0.0
+
+  '@octokit/request@10.0.13':
+    dependencies:
+      '@octokit/endpoint': 11.0.4
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.10
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.7)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/types@17.0.0':
+    dependencies:
+      '@octokit/openapi-types': 28.0.0
+
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
 
@@ -3956,6 +4129,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  before-after-hook@4.0.0: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -3973,6 +4148,8 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  bottleneck@2.19.5: {}
 
   braces@3.0.3:
     dependencies:
@@ -4462,6 +4639,8 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-with-bigint@3.5.10: {}
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -4944,6 +5123,8 @@ snapshots:
   undici-types@7.24.6: {}
 
   undici@7.28.0: {}
+
+  universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3207 -->
🤖 **Re-seed trail** — #3207 on `afk/3207-every-poll-pays-full-price-for-an-answer`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3207; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3207 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: whole-workspace (trigger: `pnpm-lock.yaml`)
{"schema":"red.afk.validation.v1","name":"test:root","status":"failed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3207-every-poll-pays-full-price-for-an-answer test","exitCode":1,"durationMs":425,"summary":"suspect-infra: `pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3207-every-poll-pays-full-price-for-an-answer test` exited 1 after 425ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. @reddb-io/dev:test:  @reddb-io/dev:test: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯ @reddb-io/dev:test:  @reddb-io/dev:test:  Test Files  1 failed | 405 passed (406) @reddb-io/dev:test:       Tests  2 failed | 5897 passed (5899) @reddb-io/dev:test:    Start at  09:22:39 @reddb-io/dev:test:    Duration  406.39s (transform 6.18s, setup 2.43s, collect 123.11s, tests 197.16s, environment 64ms, prepare 22.19s) @reddb-io/dev:test:  @reddb-io/dev:test: [ELIFECYCLE] Test failed. See above for more details.   Tasks:    14 successful, 15 total Cached:    14 cached, 15 total   Time:    7m3.803s  Failed:    @reddb-io/dev#test  [ELIFECYCLE] Test failed. See above for more details. $ turbo run test --filter=!@reddb-io/red-castle --only • turbo 2.10.5 @reddb-io/dev#test:  ERROR  command ([REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3207-every-poll-pays-full-price-for-an-answer/apps/dev) [REDACTED_HOME]/.local/share/mise/installs/node/24.18.0/bin/pnpm run test exited (1)  ERROR  run failed: comman","suspectInfra":true}
{"schema":"red.afk.validation.v1","name":"typecheck:root","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3207-every-poll-pays-full-price-for-an-answer typecheck","exitCode":0,"durationMs":0,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"lint:root","status":"skipped","summary":"script missing"}
{"schema":"red.afk.validation.v1","name":"build:root","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3207-every-poll-pays-full-price-for-an-answer build","exitCode":0,"durationMs":18,"summary":"command exited 0"}
🤖 classification override: the `on_feedback_classify` hook set the feedback failure to `semantic` (the classifier read it as `semantic`).
```

Closes #3207