### PR TITLE
fix: #3244 The coherence probe's quarantine degrades to a silent strip when the label is missing, leaving the issue in NO pool — invisible to every census

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -643,7 +643,10 @@ async function tryBootAutoApplyLabelBodyCoherence(
     } catch (error) {
       deps.log?.(`boot coherence probe label quarantine failed for #${action.issue}: ${String(error)}`);
       try {
-        await deps.gh.editLabels(action.issue, [], [LABEL_READY]);
+        await applyBootStateTransition(deps, action.issue, { kind: "queue" }, [
+          [],
+          [LABEL_READY],
+        ]);
         deps.log?.(`boot coherence probe restored ready-for-agent for #${action.issue}`);
       } catch (restoreError) {
         const warning = `boot coherence probe left #${action.issue} without a visible quarantine; restoring ready-for-agent also failed: ${String(restoreError)}`;

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -587,20 +587,23 @@ async function applyBootStateTransition(
   issue: number,
   transition: StateTransition,
   legacyEdit: [string[], string[]],
-): Promise<void> {
+): Promise<boolean> {
   let labels: string[];
   try {
     labels = await deps.gh.viewLabels(issue);
   } catch {
-    await deps.gh.editLabels(issue, legacyEdit[0], legacyEdit[1]);
-    return;
+    const ok: unknown = await deps.gh.editLabels(issue, legacyEdit[0], legacyEdit[1]);
+    if (ok === false) throw new Error(`boot ${transition.kind} label edit rejected for #${issue}`);
+    return true;
   }
   const plan = planTransition(labels, transition);
   if (isRefused(plan)) {
     deps.log?.(`boot ${transition.kind} transition refused for #${issue}: ${plan.reason}`);
-    return;
+    return false;
   }
-  await deps.gh.editLabels(issue, [...plan.remove], [...plan.add]);
+  const ok: unknown = await deps.gh.editLabels(issue, [...plan.remove], [...plan.add]);
+  if (ok === false) throw new Error(`boot ${transition.kind} label edit rejected for #${issue}`);
+  return true;
 }
 
 /**
@@ -633,20 +636,22 @@ async function tryBootAutoApplyLabelBodyCoherence(
     }
     try {
       await deps.gh.ensureLabel?.(LABEL_QUARANTINE);
-      await applyBootStateTransition(deps, action.issue, { kind: "quarantine", diagnosis: "" }, [
+      const quarantined = await applyBootStateTransition(deps, action.issue, { kind: "quarantine", diagnosis: "" }, [
         [LABEL_READY],
         [LABEL_QUARANTINE],
       ]);
+      if (!quarantined) throw new Error("quarantine transition refused");
       deps.log?.(
         `boot coherence probe quarantined #${action.issue}: ready-for-agent→quarantine; blocker kind=${action.blocker.kind} summary=${JSON.stringify(action.blocker.summary)}`,
       );
     } catch (error) {
       deps.log?.(`boot coherence probe label quarantine failed for #${action.issue}: ${String(error)}`);
       try {
-        await applyBootStateTransition(deps, action.issue, { kind: "queue" }, [
+        const restored = await applyBootStateTransition(deps, action.issue, { kind: "queue" }, [
           [],
           [LABEL_READY],
         ]);
+        if (!restored) throw new Error("ready-for-agent restoration refused");
         deps.log?.(`boot coherence probe restored ready-for-agent for #${action.issue}`);
       } catch (restoreError) {
         const warning = `boot coherence probe left #${action.issue} without a visible quarantine; restoring ready-for-agent also failed: ${String(restoreError)}`;

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -275,6 +275,8 @@ export interface OrphanTestRunnerSweepEntry {
 
 /** gh side effects: label edits and audit/recovery comments. Best-effort. */
 export interface BootGh {
+  /** Idempotently create a label before a transition depends on it. */
+  ensureLabel?(name: string): Promise<void>;
   /** gh issue edit --remove-label … --add-label … */
   editLabels(issue: number, remove: string[], add: string[]): Promise<void>;
   /** gh issue comment --body … */
@@ -630,6 +632,7 @@ async function tryBootAutoApplyLabelBodyCoherence(
       deps.log?.(`boot coherence probe body diagnosis failed for #${action.issue}: ${String(error)}`);
     }
     try {
+      await deps.gh.ensureLabel?.(LABEL_QUARANTINE);
       await applyBootStateTransition(deps, action.issue, { kind: "quarantine", diagnosis: "" }, [
         [LABEL_READY],
         [LABEL_QUARANTINE],
@@ -639,6 +642,20 @@ async function tryBootAutoApplyLabelBodyCoherence(
       );
     } catch (error) {
       deps.log?.(`boot coherence probe label quarantine failed for #${action.issue}: ${String(error)}`);
+      try {
+        await deps.gh.editLabels(action.issue, [], [LABEL_READY]);
+        deps.log?.(`boot coherence probe restored ready-for-agent for #${action.issue}`);
+      } catch (restoreError) {
+        const warning = `boot coherence probe left #${action.issue} without a visible quarantine; restoring ready-for-agent also failed: ${String(restoreError)}`;
+        deps.log?.(warning);
+        try {
+          await deps.gh.comment(action.issue, `🤖 ${warning}`);
+        } catch (commentError) {
+          deps.log?.(
+            `boot coherence probe failed to publish recovery warning for #${action.issue}: ${String(commentError)}`,
+          );
+        }
+      }
     }
   }
 

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -521,12 +521,13 @@ export async function buildBootDeps(
     gh: {
       ensureLabel: (name) => ghx.ensureLabel(ghCtx, name),
       editLabels: async (issue, remove, add) => {
-        await editLabelsWithStatuslineCache(
+        const ok = await editLabelsWithStatuslineCache(
           countCachePath,
           () => ghx.editLabels(ghCtx, issue, remove, add),
           remove,
           add,
         );
+        if (!ok) throw new Error(`failed to edit labels for issue #${issue}`);
       },
       comment: (issue, body) => ghx.comment(ghCtx, issue, body),
       editBody: async (issue, body) => {

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -519,6 +519,7 @@ export async function buildBootDeps(
       reapProcessGroup: (pgid) => killTreeAndWait(pgid),
     },
     gh: {
+      ensureLabel: (name) => ghx.ensureLabel(ghCtx, name),
       editLabels: async (issue, remove, add) => {
         await editLabelsWithStatuslineCache(
           countCachePath,

--- a/apps/dev/tests/boot-coherence-quarantine.test.ts
+++ b/apps/dev/tests/boot-coherence-quarantine.test.ts
@@ -68,7 +68,7 @@ function wireIssueMutations(
     if (overrides.failBody) throw new Error("body mutation failed");
     issues.find((candidate) => candidate.number === number)!.body = body;
   });
-  deps.gh.editLabels = editLabels;
+  deps.gh.editLabels = editLabels as typeof deps.gh.editLabels;
   Object.assign(deps.gh, {
     editBody,
     // The transition API reads live labels before planning (#2528).

--- a/apps/dev/tests/boot-coherence-quarantine.test.ts
+++ b/apps/dev/tests/boot-coherence-quarantine.test.ts
@@ -60,7 +60,7 @@ function wireIssueMutations(
     const issue = issues.find((candidate) => candidate.number === number)!;
     issue.labels = issue.labels.filter((label) => !remove.includes(label));
     if (overrides.failQuarantineAddAfterRemove && add.includes("quarantine")) {
-      throw new Error("quarantine label missing");
+      return false;
     }
     issue.labels.push(...add.filter((label) => !issue.labels.includes(label)));
   });

--- a/apps/dev/tests/boot-coherence-quarantine.test.ts
+++ b/apps/dev/tests/boot-coherence-quarantine.test.ts
@@ -53,12 +53,15 @@ function coherenceOptions(issues: MutableIssue[]) {
 function wireIssueMutations(
   deps: ReturnType<typeof makeDeps>["deps"],
   issues: MutableIssue[],
-  overrides: { failLabels?: boolean; failBody?: boolean } = {},
+  overrides: { failLabels?: boolean; failQuarantineAddAfterRemove?: boolean; failBody?: boolean } = {},
 ) {
   const editLabels = vi.fn(async (number: number, remove: string[], add: string[]) => {
     if (overrides.failLabels) throw new Error("label mutation failed");
     const issue = issues.find((candidate) => candidate.number === number)!;
     issue.labels = issue.labels.filter((label) => !remove.includes(label));
+    if (overrides.failQuarantineAddAfterRemove && add.includes("quarantine")) {
+      throw new Error("quarantine label missing");
+    }
     issue.labels.push(...add.filter((label) => !issue.labels.includes(label)));
   });
   const editBody = vi.fn(async (number: number, body: string) => {
@@ -147,6 +150,21 @@ describe("ADR 0122 boot quarantine posture", () => {
       expect(processed).toEqual([1972]);
     },
   );
+
+  it("restores ready-for-agent when the tracker removes queue labels before rejecting quarantine", async () => {
+    const issues = [poisonedIssue(), healthyIssue()];
+    const { deps } = makeDeps();
+    const ensureLabel = vi.fn(async () => undefined);
+    Object.assign(deps.gh, { ensureLabel });
+    wireIssueMutations(deps, issues, { failQuarantineAddAfterRemove: true });
+
+    const { processed, result } = await drainAfterBoot(deps, issues);
+
+    expect(result.boot.bootstrap).toEqual({ ok: true });
+    expect(processed).toEqual([1972]);
+    expect(ensureLabel).toHaveBeenCalledWith("quarantine");
+    expect(issues[0]?.labels).toContain("ready-for-agent");
+  });
 
   it("is idempotent after the issue has left the executable queue", async () => {
     const issues = [poisonedIssue()];


### PR DESCRIPTION
Automated AFK landing for #3244. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3244

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788434979&installation_model_id=20659&pr_number=3245&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3245&signature=90aa34fdb6b4df4bb2537da425b5d5782aa21e17fa021615ea95b7dae70b9143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->