### PR TITLE
fix: #3180 the registration outlives the daemon that held it — intent persisted, rehydrated on replacement

### DIFF
--- a/.red/adr/0130-redskilled-host-scoped-execution-daemon.md
+++ b/.red/adr/0130-redskilled-host-scoped-execution-daemon.md
@@ -642,6 +642,31 @@ record through the shared render, `project_status` publishes its timestamp and
 reason, and `/red-doctor` reports `lapsed-with-work` when executable queue items
 remain. A current registration always outranks an older lapse record.
 
+## Amendment 9 — daemon replacement preserves project intent (#3180)
+
+Amendment 8 kept a registration alive for as long as one daemon process lived,
+but the record itself remained only in that process's memory. A supervised
+restart or self-replacement deliberately left Workers running and reattached
+them in its successor while silently discarding the selector and launch needed
+to birth the next Worker. The liveness belt could not renew a record it no
+longer had.
+
+**Decision: the daemon atomically snapshots the opaque registration set and a
+successor rehydrates it before serving the socket.** Registration, renewal,
+work-driven sustainment, lapse recovery and deliberate deregistration all move
+the snapshot with the live set. Project-write operations do not answer until
+their snapshot mutation is durable, and graceful daemon departure flushes every
+queued sustainment before releasing the socket. The snapshot is mode `0600`
+because it carries the launch environment exactly as the project stated it.
+
+Durability does not make intent immortal. A record whose deadline still stands
+is restored as current. One that expired less than one original window ago is
+restored only into Amendment 8's bounded recovery set, where a live Worker or a
+fresh positive queue observation may sustain it. Older records are ignored, a
+counted-empty project removes its recovered intent, and `project_stop` removes
+both current and recoverable forms. The daemon still interprets none of the
+selector, argv, environment or workspace it persists.
+
 ## Recovering from a bad two-player migration
 
 The way back, for an operator whose machine the migration left confusing. Every

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -104,6 +104,10 @@ import {
 import { workerSpecFromLaunch, type RedskilledLaunchTemplate } from "./launch-template.js";
 import type { RedskilledPaths } from "./paths.js";
 import {
+  createRedskilledRegistrationIntentStore,
+  type RedskilledRegistrationIntentStore,
+} from "./registration-intent-store.js";
+import {
   buildProjectRegistration,
   renewProjectRegistration,
   RedskilledProjectUnregisteredError,
@@ -397,6 +401,8 @@ export interface RedskilledDaemonOptions {
   readonly launch?: (options: LaunchWorkerOptions) => LaunchedWorker;
   /** The append-only host event lane; defaults to this session's own. */
   readonly eventLane?: RedskilledEventLane;
+  /** The durable registration snapshot; defaults to this session's own. */
+  readonly registrationIntentStore?: RedskilledRegistrationIntentStore;
   /** How the daemon asks whether a re-attached Worker is still running. */
   readonly liveness?: RedskilledLivenessProbe;
   /**
@@ -900,6 +906,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
 
   const startedAt = clock();
   const eventLane = options.eventLane ?? createRedskilledEventLane(paths.eventLanePath);
+  const registrationIntentStore = options.registrationIntentStore ??
+    createRedskilledRegistrationIntentStore(paths.registrationIntentPath);
   const liveness = options.liveness ?? detectWorkerLiveness;
   const livenessGraceMs = options.livenessGraceMs ?? REDSKILLED_LIVENESS_GRACE_MS;
   const stopProbe = options.stopWorker ?? stopWorker;
@@ -970,15 +978,24 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // a calm zero in place of an absent instrument.
   let deathAttributions: RedskilledDeathObservation[] | undefined =
     options.deaths === undefined ? undefined : [...options.deaths];
-  // What each project asked the host to hold for it, by project label. In memory,
-  // like the log lines and for the same reason: a registration is a live statement
-  // a session renews, and a durable copy would outlive the thing it describes. The
-  // slice that polls it owns keeping the daemon alive while one stands.
+  // What each project asked the host to hold for it, by project label. The
+  // snapshot preserves that opaque intent across daemon replacement; its lease
+  // deadline still decides whether the successor may keep using it.
+  const restoredRegistrations = await registrationIntentStore.read().catch(() => []);
+  const restoredAtMs = Date.parse(startedAt);
   const registrations = new Map<string, RedskilledProjectRegistration>();
   // A lapsed record is retained for one more window so the next queue poll can
   // prove that work still exists and restore it without a person restating the
   // selector and launch. Bounded: a drained or one-window-old record is dropped.
   const recoverableRegistrations = new Map<string, RedskilledProjectRegistration>();
+  for (const restored of restoredRegistrations) {
+    const renewByMs = Date.parse(restored.renew_by);
+    if (!Number.isFinite(restoredAtMs) || !Number.isFinite(renewByMs) || renewByMs >= restoredAtMs) {
+      registrations.set(restored.project_label, restored);
+    } else if (restoredAtMs - renewByMs <= restored.renew_within_ms) {
+      recoverableRegistrations.set(restored.project_label, restored);
+    }
+  }
   const activeSockets = new Set<Socket>();
   // The last thing the sampler measured, kept so a read is dated rather than
   // dating itself: staleness belongs to the daemon that took the measurement.
@@ -1093,7 +1110,15 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       }
       rememberLapse(lapsed, nowMs);
     }
+    if (swept.lapsed.length > 0) persistRegistrationIntent();
     return swept.lapsed;
+  }
+
+  /** Persist the live set plus the bounded recovery set, in mutation order. */
+  function persistRegistrationIntent(): void {
+    const durable = new Map(recoverableRegistrations);
+    for (const [label, registration] of registrations) durable.set(label, registration);
+    void registrationIntentStore.replace([...durable.values()]).catch(() => undefined);
   }
 
   /**
@@ -1142,6 +1167,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     }
     const pollAt = lastQueue == null ? Number.NaN : Date.parse(lastQueue.fetched_at);
     const polled = new Map((lastQueue?.projects ?? []).map((project) => [project.project_label, project]));
+    let changed = false;
     for (const held of [...registrations.values()]) {
       // A read is not a new observation. Reusing a positive depth forever would
       // let status reads keep a closed project alive; one registration window is
@@ -1153,37 +1179,45 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         ...(poll == null ? {} : { queue: { outcome: poll.outcome, depth: poll.depth } }),
         liveWorkers: live[held.project_label] ?? 0,
       });
-      if (sustained.registration !== held) registrations.set(held.project_label, sustained.registration);
+      if (sustained.registration !== held) {
+        registrations.set(held.project_label, sustained.registration);
+        changed = true;
+      }
     }
+    if (changed) persistRegistrationIntent();
   }
 
   /** Restore a just-lapsed project when a fresh poll proves its queue is non-empty. */
   function recoverRegistrations(now: string): void {
-    if (recoverableRegistrations.size === 0 || lastQueue == null) return;
+    if (recoverableRegistrations.size === 0) return;
     const nowMs = Date.parse(now);
     if (!Number.isFinite(nowMs)) return;
-    const polled = new Map(lastQueue.projects.map((project) => [project.project_label, project]));
+    const polled = new Map((lastQueue?.projects ?? []).map((project) => [project.project_label, project]));
+    let changed = false;
     for (const [label, lapsed] of [...recoverableRegistrations]) {
       // Recovery is a belt, not immortal intent. After one original window there
       // is no live statement left to restore, so the extra polling stops.
       if (nowMs - Date.parse(lapsed.renew_by) > lapsed.renew_within_ms) {
         recoverableRegistrations.delete(label);
+        changed = true;
         continue;
       }
       const poll = polled.get(label);
-      if (poll == null) continue;
       const recovered = sustainProjectRegistration(lapsed, {
         now,
-        queue: { outcome: poll.outcome, depth: poll.depth },
+        ...(poll == null ? {} : { queue: { outcome: poll.outcome, depth: poll.depth } }),
         liveWorkers: [...workers.values()].filter((worker) => worker.project_label === label).length,
       });
       if (recovered.verdict === "open-work" || recovered.verdict === "live-worker") {
         registrations.set(label, recovered.registration);
         recoverableRegistrations.delete(label);
+        changed = true;
       } else if (recovered.verdict === "drained") {
         recoverableRegistrations.delete(label);
+        changed = true;
       }
     }
+    if (changed) persistRegistrationIntent();
   }
 
   function hostState(): RedskilledHostState {
@@ -1817,6 +1851,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       held: registrations.get(request.project_label),
     });
     registrations.set(registration.project_label, registration);
+    persistRegistrationIntent();
     // A current registration outranks every historical absence. Remove the old
     // tail now so a later deliberate stop cannot uncover an older lapse and lie
     // about which transition happened most recently.
@@ -1881,6 +1916,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       ...(options.launch == null ? {} : { launch: options.launch }),
     });
     registrations.set(registration.project_label, registration);
+    persistRegistrationIntent();
     armIdleTimer();
     return {
       version: 1,
@@ -1907,14 +1943,17 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   function deregisterProject(projectLabel: string, sessionProject?: string): RedskilledProjectDeregistered {
     const reach = authorize("project-deregister", sessionProject, projectLabel);
     if (!reach.permitted) throw new Error(reach.reason);
-    const held = registrations.get(projectLabel);
-    const released = registrations.delete(projectLabel);
+    const held = registrations.get(projectLabel) ?? recoverableRegistrations.get(projectLabel);
+    const releasedCurrent = registrations.delete(projectLabel);
+    const releasedRecoverable = recoverableRegistrations.delete(projectLabel);
+    const released = releasedCurrent || releasedRecoverable;
     if (held != null) {
       const detail = `redskilled released the registration for project ${JSON.stringify(projectLabel)}`;
       removeRegistrationHistory(projectLabel);
       stops.push({ project_label: projectLabel, registered_at: held.registered_at, at: clock(), detail });
       if (stops.length > REDSKILLED_LAPSE_MEMORY) stops.splice(0, stops.length - REDSKILLED_LAPSE_MEMORY);
     }
+    if (released) persistRegistrationIntent();
     return {
       version: 1,
       project_label: projectLabel,
@@ -2297,6 +2336,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     const prepared = prepareRedskilledReplacement(decision, replacementIO);
     replacementState = "in-progress";
     await eventLane.flush().catch(() => undefined);
+    await registrationIntentStore.flush().catch(() => undefined);
     await stop({ reason: "replaced" });
     completeRedskilledReplacement(prepared, paths, {
       ...(idleMs == null ? {} : { idleMs }),
@@ -2571,6 +2611,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     // of the session: a birth still in flight would leave the next daemon with a
     // Worker it holds a budget for and no record of.
     await eventLane.flush().catch(() => undefined);
+    await registrationIntentStore.flush().catch(() => undefined);
     server.close();
     for (const socket of activeSockets) socket.destroy();
     await new Promise<void>((resolve) => server.once("close", () => resolve()));
@@ -2648,6 +2689,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     reattached.add(worker.worker_id);
     record("worker-birth", worker, "adopted from an active unit with no birth on this lane");
   }
+  // A successor can prove an expired-but-recoverable intent immediately from a
+  // Worker the predecessor left running; no queue round-trip or human restart is
+  // needed before that project is registered again.
+  recoverRegistrations(clock());
   // The bounded exception. A daemon that has just come back holds Workers it has
   // never heard a heartbeat from, so for those — and only those — it reads the log
   // ONCE, from the path the client GAVE at spawn and carried on the event lane. A
@@ -2720,21 +2765,27 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         return { id: request.id, ok: true, value: publishWorkerHeartbeat(request.heartbeat) };
       }
       if (request.op === "project-register") {
-        return { id: request.id, ok: true, value: registerProject(request.registration, request.session_project) };
+        const value = registerProject(request.registration, request.session_project);
+        await registrationIntentStore.flush();
+        return { id: request.id, ok: true, value };
       }
       if (request.op === "project-renew") {
+        const value = renewProject(request.project_label, {
+          ...(request.session_project == null ? {} : { sessionProject: request.session_project }),
+          ...(request.renew_within_ms == null ? {} : { renewWithinMs: request.renew_within_ms }),
+          ...(request.launch == null ? {} : { launch: request.launch }),
+        });
+        await registrationIntentStore.flush();
         return {
           id: request.id,
           ok: true,
-          value: renewProject(request.project_label, {
-            ...(request.session_project == null ? {} : { sessionProject: request.session_project }),
-            ...(request.renew_within_ms == null ? {} : { renewWithinMs: request.renew_within_ms }),
-            ...(request.launch == null ? {} : { launch: request.launch }),
-          }),
+          value,
         };
       }
       if (request.op === "project-deregister") {
-        return { id: request.id, ok: true, value: deregisterProject(request.project_label, request.session_project) };
+        const value = deregisterProject(request.project_label, request.session_project);
+        await registrationIntentStore.flush();
+        return { id: request.id, ok: true, value };
       }
       if (request.op === "worker-command") {
         return { id: request.id, ok: true, value: await runWorkerCommand(request.command) };

--- a/apps/redskilled/src/paths.ts
+++ b/apps/redskilled/src/paths.ts
@@ -49,6 +49,8 @@ export interface RedskilledPaths {
   readonly leasePath: string;
   /** The append-only host event lane the daemon rehydrates itself from. */
   readonly eventLanePath: string;
+  /** The durable project registrations a successor daemon rehydrates. */
+  readonly registrationIntentPath: string;
   /**
    * The machine-wide claim: the one record every OS user of this host can read.
    *
@@ -119,6 +121,7 @@ export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = 
     lockPath: join(runtimeDir, "redskilled.spawn.lock"),
     leasePath: join(runtimeDir, "redskilled.lease.toon"),
     eventLanePath: join(runtimeDir, REDSKILLED_EVENT_LANE_FILE),
+    registrationIntentPath: join(runtimeDir, "redskilled.registrations.toon"),
     machineClaimPath: options.machineClaimPath ??
       resolveMachineClaimPath({ env: options.env, machineIdHash, platform: options.platform }),
   };

--- a/apps/redskilled/src/registration-intent-store.ts
+++ b/apps/redskilled/src/registration-intent-store.ts
@@ -1,0 +1,95 @@
+/**
+ * Durable project intent for the host daemon.
+ *
+ * A daemon replacement must not erase the registrations whose Workers it leaves
+ * running. This snapshot is the daemon's durable copy of the opaque records it
+ * already holds; it derives nothing from them and removes them when the live set
+ * does. Writes are serialised and atomic so a crash leaves either the preceding
+ * complete snapshot or the next one, never half a registration.
+ */
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import {
+  isRedskilledProjectRegistration,
+  type RedskilledProjectRegistration,
+} from "./project-registration.js";
+
+interface RedskilledRegistrationIntentSnapshot {
+  readonly version: 1;
+  readonly registrations: readonly RedskilledProjectRegistration[];
+}
+
+export interface RedskilledRegistrationIntentStore {
+  read(): Promise<readonly RedskilledProjectRegistration[]>;
+  replace(registrations: readonly RedskilledProjectRegistration[]): Promise<void>;
+  flush(): Promise<void>;
+}
+
+export function createRedskilledRegistrationIntentStore(
+  path: string,
+): RedskilledRegistrationIntentStore {
+  let tail: Promise<unknown> = Promise.resolve();
+
+  async function read(): Promise<readonly RedskilledProjectRegistration[]> {
+    await tail;
+    let raw: string;
+    try {
+      raw = await readFile(path, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+    const parsed = parseSnapshot(raw);
+    return isSnapshot(parsed) ? parsed.registrations : [];
+  }
+
+  async function write(registrations: readonly RedskilledProjectRegistration[]): Promise<void> {
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+    const snapshot: RedskilledRegistrationIntentSnapshot = {
+      version: 1,
+      registrations: [...registrations],
+    };
+    await writeFile(temporary, `${encode(snapshot as unknown as JsonValue, { keyedMapCollapse: true })}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(temporary, path);
+  }
+
+  return {
+    read,
+    replace(registrations) {
+      const writeSnapshot = tail.then(() => write(registrations));
+      tail = writeSnapshot.catch(() => undefined);
+      return writeSnapshot;
+    },
+    async flush() {
+      await tail;
+    },
+  };
+}
+
+function parseSnapshot(raw: string): unknown {
+  const body = raw.trim();
+  if (!body) return null;
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    try {
+      return decode(body);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function isSnapshot(value: unknown): value is RedskilledRegistrationIntentSnapshot {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const snapshot = value as Record<string, unknown>;
+  return snapshot.version === 1 &&
+    Array.isArray(snapshot.registrations) &&
+    snapshot.registrations.every(isRedskilledProjectRegistration);
+}

--- a/apps/redskilled/src/registration-intent-store.ts
+++ b/apps/redskilled/src/registration-intent-store.ts
@@ -31,6 +31,7 @@ export function createRedskilledRegistrationIntentStore(
   path: string,
 ): RedskilledRegistrationIntentStore {
   let tail: Promise<unknown> = Promise.resolve();
+  let failure: unknown | null = null;
 
   async function read(): Promise<readonly RedskilledProjectRegistration[]> {
     await tail;
@@ -63,11 +64,19 @@ export function createRedskilledRegistrationIntentStore(
     read,
     replace(registrations) {
       const writeSnapshot = tail.then(() => write(registrations));
-      tail = writeSnapshot.catch(() => undefined);
+      tail = writeSnapshot.then(
+        () => {
+          failure = null;
+        },
+        (error: unknown) => {
+          failure = error;
+        },
+      );
       return writeSnapshot;
     },
     async flush() {
       await tail;
+      if (failure != null) throw failure;
     },
   };
 }

--- a/apps/redskilled/tests/registration-sustain.test.ts
+++ b/apps/redskilled/tests/registration-sustain.test.ts
@@ -194,6 +194,40 @@ describe("sustainProjectRegistration — what holds a lease up", () => {
 });
 
 describe("a registration outlives its window while the project still drains", () => {
+  it("survives a daemon replacement and resumes polling without project_start", async () => {
+    const paths = await sessionPaths();
+    const first = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      demandMs: 0,
+      launch: recordingLaunch([]),
+      queueDiscovery: { intervalMs: 0, transport: async () => answer([3]) },
+    });
+    running.push(first);
+
+    first.registerProject(request());
+    await first.pollQueueDiscovery();
+    await first.stop({ reason: "replaced" });
+
+    const successor = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      demandMs: 0,
+      launch: recordingLaunch([]),
+      queueDiscovery: { intervalMs: 0, transport: async () => answer([3]) },
+    });
+    running.push(successor);
+
+    const polled = await successor.pollQueueDiscovery();
+    expect(polled?.projects[0]?.depth).toBe(3);
+    expect(successor.hostState().registrations?.[0]).toMatchObject({
+      project_label: "acme/widgets",
+      target: 1,
+    });
+  });
+
   it("keeps holding a project with open work past its deadline, with no session at all", async () => {
     const clock = testClock();
     const daemon = await startRedskilledDaemon({


### PR DESCRIPTION
Closes #3180.

The Worker completed this and parked on the last step: its local rebase diverged from the remote tip, the push came back non-fast-forward, and the park read "restore push access" for a branch that was already fully on origin. Push access is fine (verified with a probe push). This PR lands the remote branch, which carries the complete work:

- `feat(redskilled): persist project registration intent` — the durable snapshot
- `fix(redskilled): rehydrate registrations after daemon replacement`
- `docs(adr): preserve registration intent across daemon replacement`
- tests: `preserve drain intent across daemon replacement`

This is the fix for the fleet's top blocker: the registration lapsed silently at least six times across 2026-08-03/04, and every recovery was a human noticing an idle statusline and calling `project_start`. With intent persisted and rehydrated, a daemon replacement no longer erases the project's standing order.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788435126&installation_model_id=20659&pr_number=3246&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3246&signature=7f0ef74841ac8dd5951a7203d75acd924741c289479465ecd2e7c3eafd960729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->