### PR TITLE
fix: #3261 A ratchet holds every castle refusal to a declared repair, so the guarantee survives authors who never read the Spec

### DIFF
--- a/apps/dev/src/core/repair-guard.ts
+++ b/apps/dev/src/core/repair-guard.ts
@@ -1,5 +1,5 @@
-// repair-guard — every structured castle refusal carries a callable repair or
-// an argued none (ADR 0134 decision 5, issue #3260).
+// repair-guard — every castle refusal and empty state is declared and carries
+// a callable repair or an argued none (ADR 0134 decision 5, issues #3260/#3261).
 
 import { readdirSync, readFileSync } from "node:fs";
 import { join, relative, sep } from "node:path";
@@ -9,6 +9,54 @@ export interface RepairScanFile {
   readonly sourceText: string;
 }
 
+export type RepairSurface = "refusal" | "empty-state";
+
+/** One outward castle site that must keep its repair contract. */
+export interface RepairSite {
+  readonly path: string;
+  /** Stable enclosing function name; line numbers are diagnostics only. */
+  readonly fn: string;
+  readonly line: number;
+  readonly surface: RepairSurface;
+}
+
+/** One reviewed member of the repair inventory. */
+export interface DeclaredRepairSite {
+  readonly path: string;
+  readonly fn: string;
+  readonly surface: RepairSurface;
+}
+
+/**
+ * The live castle repair inventory.
+ *
+ * The scan finds structured refusals (`refused: true`) and composed empty
+ * states. A new site must be added here in the same slice that gives it a
+ * repair; a removed path must remove its declaration in the same slice.
+ */
+export const DECLARED_REPAIR_SITES: readonly DeclaredRepairSite[] = [
+  {
+    path: "packages/red-castle/src/mcp/posture.ts",
+    fn: "refusal",
+    surface: "refusal",
+  },
+  {
+    path: "packages/red-castle/src/mcp/worker.ts",
+    fn: "workerInputRefusal",
+    surface: "refusal",
+  },
+  {
+    path: "apps/dev/src/mcp-adapter.ts",
+    fn: "projectStatus",
+    surface: "empty-state",
+  },
+  {
+    path: "apps/dev/src/mcp-adapter.ts",
+    fn: "cursorRefusal",
+    surface: "refusal",
+  },
+];
+
 export interface RepairViolation {
   readonly path: string;
   readonly line: number;
@@ -16,6 +64,11 @@ export interface RepairViolation {
     | "structured refusal has no repair or argued none"
     | "repair none has no repair_reason";
 }
+
+export type RepairDeclarationViolation =
+  | ({ readonly kind: "undeclared" } & RepairSite)
+  | ({ readonly kind: "stale" } & DeclaredRepairSite)
+  | ({ readonly kind: "invalid-repair" } & RepairViolation);
 
 export const REPAIR_SCAN_ROOTS = [
   "packages/red-castle/src/mcp",
@@ -48,6 +101,104 @@ export function readRepairScanFiles(
   return files;
 }
 
+/**
+ * Enumerate outward repair sites by stable `(path, function, surface)` key.
+ *
+ * A composed state without `refused: true` is an empty state. If a function
+ * contains both a composer and an explicit refusal marker it is one refusal
+ * site, not two implementation-detail reaches.
+ */
+export function collectRepairSites(files: readonly RepairScanFile[]): RepairSite[] {
+  const sites = new Map<string, RepairSite>();
+  for (const file of files) {
+    const structural = blankCommentsAndStrings(file.sourceText);
+    const reaches: Array<{ index: number; surface: RepairSurface }> = [];
+    for (const match of structural.matchAll(/\bcomposeRepair\s*\(/g)) {
+      reaches.push({ index: match.index ?? 0, surface: "empty-state" });
+    }
+    for (const match of structural.matchAll(/\brefused\s*:\s*true\b/g)) {
+      const index = match.index ?? 0;
+      const open = enclosingOpenBrace(structural, index);
+      if (open >= 0 && isTypeDeclaration(structural, open)) continue;
+      reaches.push({ index, surface: "refusal" });
+    }
+    reaches.sort((a, b) => a.index - b.index);
+
+    for (const reach of reaches) {
+      const fn = enclosingFunctionName(structural, reach.index);
+      const line = file.sourceText.slice(0, reach.index).split("\n").length;
+      const baseKey = `${file.path}\0${fn}`;
+      const existing = sites.get(baseKey);
+      if (existing === undefined || reach.surface === "refusal") {
+        sites.set(baseKey, { path: file.path, fn, line, surface: reach.surface });
+      }
+    }
+  }
+  return [...sites.values()];
+}
+
+/** Compare the swept tree with the declaration table in both directions. */
+export function findRepairDeclarationViolations(
+  sites: readonly RepairSite[],
+  declared: readonly DeclaredRepairSite[] = DECLARED_REPAIR_SITES,
+  files: readonly RepairScanFile[] = [],
+): RepairDeclarationViolation[] {
+  const violations: RepairDeclarationViolation[] = [];
+  const declaredKeys = new Set(declared.map(repairSiteKey));
+  const liveKeys = new Set(sites.map(repairSiteKey));
+
+  for (const site of sites) {
+    if (!declaredKeys.has(repairSiteKey(site))) {
+      violations.push({ kind: "undeclared", ...site });
+    }
+  }
+  for (const site of declared) {
+    if (!liveKeys.has(repairSiteKey(site))) {
+      violations.push({ kind: "stale", ...site });
+    }
+  }
+  for (const violation of collectRepairViolations(files)) {
+    violations.push({ kind: "invalid-repair", ...violation });
+  }
+  return violations;
+}
+
+function repairSiteKey(site: DeclaredRepairSite): string {
+  return `${site.path}\0${site.fn}\0${site.surface}`;
+}
+
+/** Name every inventory disagreement so the failing site is immediately actionable. */
+export function formatRepairDeclarationFailure(
+  violations: readonly RepairDeclarationViolation[],
+): string {
+  if (violations.length === 0) return "";
+  const lines = [
+    `structured-repair ratchet (#3261): ${violations.length} disagreement(s) between the castle` +
+      " surface and `DECLARED_REPAIR_SITES` in apps/dev/src/core/repair-guard.ts.",
+  ];
+  for (const violation of violations) {
+    if (violation.kind === "undeclared") {
+      lines.push(
+        `  - UNDECLARED ${violation.path}:${violation.line} in \`${violation.fn}\` ` +
+          `(${violation.surface}) — add a composed repair or an argued \`repair: none\`, then declare the site.`,
+      );
+      continue;
+    }
+    if (violation.kind === "stale") {
+      lines.push(
+        `  - STALE ${violation.path} \`${violation.fn}\` (${violation.surface}) — the path is gone; ` +
+          "delete the declaration with it.",
+      );
+      continue;
+    }
+    lines.push(
+      `  - INVALID ${violation.path}:${violation.line} — ${violation.reason}.`,
+    );
+  }
+  return lines.join("\n");
+}
+
+/** Preserve the #3260 field-level check inside each explicit refusal object. */
 export function collectRepairViolations(
   files: readonly RepairScanFile[],
 ): RepairViolation[] {
@@ -81,6 +232,71 @@ export function collectRepairViolations(
   }
   return violations;
 }
+
+interface FunctionFrame {
+  readonly fn: string | null;
+  readonly resumeHeader: string | null;
+  readonly resumeParenDepth: number;
+}
+
+/** Find the innermost stable function name at one source offset. */
+function enclosingFunctionName(source: string, target: number): string {
+  const frames: FunctionFrame[] = [];
+  let header = "";
+  let parenDepth = 0;
+  for (let index = 0; index < target; index += 1) {
+    const ch = source[index]!;
+    if (ch === "\n") {
+      header += " ";
+      continue;
+    }
+    if (ch === "(" || ch === "[") parenDepth += 1;
+    else if (ch === ")" || ch === "]") parenDepth = Math.max(0, parenDepth - 1);
+    if (ch === "{") {
+      frames.push({
+        fn: functionNameFromHeader(header),
+        resumeHeader: parenDepth > 0 ? header : null,
+        resumeParenDepth: parenDepth,
+      });
+      header = "";
+      parenDepth = 0;
+      continue;
+    }
+    if (ch === "}") {
+      const closed = frames.pop();
+      header = closed?.resumeHeader ?? "";
+      parenDepth = closed?.resumeParenDepth ?? 0;
+      continue;
+    }
+    if (ch === ";" && parenDepth === 0) {
+      header = "";
+      continue;
+    }
+    header += ch;
+  }
+  for (let index = frames.length - 1; index >= 0; index -= 1) {
+    if (frames[index]!.fn !== null) return frames[index]!.fn!;
+  }
+  return "<module>";
+}
+
+const FUNCTION_HEADERS: readonly RegExp[] = [
+  /\bfunction\s*\*?\s*([A-Za-z_$][\w$]*)/,
+  /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=]*)?=\s*(?:async\s*)?(?:function|\()/,
+  /(?<![.\w$])([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*(?::[^=]*)?$/,
+  /(?<![.\w$])([A-Za-z_$][\w$]*)\s*:\s*(?:async\s*)?(?:function|\()/,
+];
+
+function functionNameFromHeader(header: string): string | null {
+  const collapsed = header.replace(/\s+/g, " ").trim();
+  for (const pattern of FUNCTION_HEADERS) {
+    const hit = pattern.exec(collapsed);
+    if (hit?.[1] !== undefined && !RESERVED.has(hit[1])) return hit[1];
+  }
+  return null;
+}
+
+const RESERVED = new Set(["if", "for", "while", "switch", "catch", "try", "return", "new"]);
 
 function enclosingOpenBrace(source: string, index: number): number {
   let depth = 0;

--- a/apps/dev/tests/repair-guard.test.ts
+++ b/apps/dev/tests/repair-guard.test.ts
@@ -1,8 +1,13 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  collectRepairSites,
   collectRepairViolations,
+  DECLARED_REPAIR_SITES,
+  findRepairDeclarationViolations,
+  formatRepairDeclarationFailure,
   readRepairScanFiles,
+  type DeclaredRepairSite,
   type RepairScanFile,
 } from "../src/core/repair-guard.js";
 import { REPO_INVARIANT_SUITES } from "../src/core/repo-invariants.js";
@@ -15,7 +20,14 @@ function file(path: string, sourceText: string): RepairScanFile {
 
 describe("every structured castle refusal carries a repair (#3260)", () => {
   it("is green on the live castle refusal surfaces", () => {
-    expect(collectRepairViolations(readRepairScanFiles(ROOT))).toEqual([]);
+    const files = readRepairScanFiles(ROOT);
+    const violations = findRepairDeclarationViolations(
+      collectRepairSites(files),
+      DECLARED_REPAIR_SITES,
+      files,
+    );
+
+    expect(violations, formatRepairDeclarationFailure(violations)).toEqual([]);
   });
 
   it("fails a new refusal that has only prose", () => {
@@ -58,5 +70,82 @@ describe("every structured castle refusal carries a repair (#3260)", () => {
   it("runs in every cone-scoped gate", () => {
     expect(REPO_INVARIANT_SUITES.map((suite) => suite.name))
       .toContain("invariants:structured-repairs");
+  });
+});
+
+describe("every castle refusal and empty state is declared (#3261)", () => {
+  it("fails an undeclared refusal, naming its file and site", () => {
+    const files = [
+      file(
+        "packages/red-castle/src/mcp/demo.ts",
+        [
+          "export function refuseDemo() {",
+          '  return { refused: true, reason: "not available", repair: "none", repair_reason: "demo" };',
+          "}",
+        ].join("\n"),
+      ),
+    ];
+
+    const violations = findRepairDeclarationViolations(collectRepairSites(files), [], files);
+
+    expect(violations).toEqual([
+      {
+        kind: "undeclared",
+        path: "packages/red-castle/src/mcp/demo.ts",
+        fn: "refuseDemo",
+        line: 2,
+        surface: "refusal",
+      },
+    ]);
+    const message = formatRepairDeclarationFailure(violations);
+    expect(message).toContain("packages/red-castle/src/mcp/demo.ts:2");
+    expect(message).toContain("refuseDemo");
+  });
+
+  it("fails a declaration whose refusal path is gone", () => {
+    const declared: DeclaredRepairSite[] = [
+      {
+        path: "packages/red-castle/src/mcp/demo.ts",
+        fn: "refuseDemo",
+        surface: "refusal",
+      },
+    ];
+
+    const violations = findRepairDeclarationViolations([], declared, []);
+
+    expect(violations).toEqual([
+      {
+        kind: "stale",
+        path: "packages/red-castle/src/mcp/demo.ts",
+        fn: "refuseDemo",
+        surface: "refusal",
+      },
+    ]);
+    expect(formatRepairDeclarationFailure(violations)).toContain("delete the declaration");
+  });
+
+  it("declares the live refusal and empty-state sites by stable function name", () => {
+    expect(DECLARED_REPAIR_SITES).toEqual([
+      {
+        path: "packages/red-castle/src/mcp/posture.ts",
+        fn: "refusal",
+        surface: "refusal",
+      },
+      {
+        path: "packages/red-castle/src/mcp/worker.ts",
+        fn: "workerInputRefusal",
+        surface: "refusal",
+      },
+      {
+        path: "apps/dev/src/mcp-adapter.ts",
+        fn: "projectStatus",
+        surface: "empty-state",
+      },
+      {
+        path: "apps/dev/src/mcp-adapter.ts",
+        fn: "cursorRefusal",
+        surface: "refusal",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #3261. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3261

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788453117&installation_model_id=20659&pr_number=3272&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3272&signature=ad4567b887babe3d9eaa3a301c452e245fa3f6fecf0398e78f496e51c20bfda2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->