### PR TITLE
merge: #3267 The daemon counts open work, holds six free slots, and births nothing for three hours — an in-memory latch no surface reports, cleared only by a restart

### DIFF
--- a/.changeset/calm-demons-probe.md
+++ b/.changeset/calm-demons-probe.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Report project birth-breaker latches on host and project status, persist every birth refusal, half-open with one probe after cooldown, and expose the structured `project_reset` repair.

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -947,6 +947,7 @@ async function projectStatus(root: string): Promise<ProjectStatusOutput> {
       ...(held?.last_poll ? { last_poll: held.last_poll } : {}),
       ...(version.published_version ? { published_version: version.published_version } : {}),
     },
+    birth_latch: registrationState?.birthLatch ?? null,
     slots: {
       busy,
       free: Math.max(0, target - busy),
@@ -1881,6 +1882,7 @@ export function createCastleMcpDependencies(
     projectStatus: () => projectStatus(root),
     projectStart: (input) => projectStart(root, input),
     projectResize: (input) => projectResize(root, input),
+    projectReset: async () => createRedskilledBirthPort({ root }).resetBirthBreaker(),
     // Stopping is giving the registration back and asking the host to end this
     // project's Workers. There is no process of the project's own left to kill
     // (ADR 0130 Amendment 4), so `force` no longer selects a harder teardown —

--- a/apps/dev/src/runtime/redskilled-birth.ts
+++ b/apps/dev/src/runtime/redskilled-birth.ts
@@ -30,6 +30,7 @@ import {
   renewRedskilledProject,
   readRedskilledHostState,
   readRedskilledStatuslinePayload,
+  resetRedskilledProjectBirthBreaker,
   redskilledPresenceAdvice,
   RedskilledRequestRefusedError,
   RedskilledUnreachableError,
@@ -59,6 +60,8 @@ import type {
   RedskilledRegistrationView,
 } from "@reddb-io/redskilled/host-state";
 import type { RedskilledLaunchTemplate } from "@reddb-io/redskilled/launch-template";
+import type { RedskilledBirthLatch } from "@reddb-io/redskilled/demand-loop";
+import type { RedskilledProjectReset } from "@reddb-io/redskilled/protocol";
 
 // Re-exported so a consumer of this port imports the host's vocabulary from the
 // one module that owns the project's reach into it — a second import path for
@@ -119,6 +122,7 @@ export interface GrantedWorkerBirth {
 export interface ProjectRegistrationState {
   readonly held: RedskilledRegistrationView | null;
   readonly lapse: RedskilledRegistrationLapse | null;
+  readonly birthLatch: RedskilledBirthLatch | null;
 }
 
 /**
@@ -172,6 +176,8 @@ export interface RedskilledBirthPort {
    * without an env replaces the env with none.
    */
   restateLaunch(launch: RedskilledLaunchTemplate): Promise<RedskilledProjectRegistration>;
+  /** Clear the host's birth breaker for this project. */
+  resetBirthBreaker(): Promise<RedskilledProjectReset>;
   /**
    * Take this project's presence back. Reports whether a record stood.
    *
@@ -266,6 +272,8 @@ export function createRedskilledBirthPort(options: CreateRedskilledBirthOptions)
         [...(state.lapsed_registrations ?? [])]
           .reverse()
           .find((lapse) => lapse.project_label === projectLabel) ?? null,
+      birthLatch:
+        (state.birth_latches ?? []).find((latch) => latch.project_label === projectLabel) ?? null,
     };
   };
 
@@ -328,6 +336,10 @@ export function createRedskilledBirthPort(options: CreateRedskilledBirthOptions)
     async restateLaunch(launch) {
       const renewed = await renewRedskilledProject(paths, { project_label: projectLabel, launch }, config);
       return renewed.registration;
+    },
+
+    async resetBirthBreaker() {
+      return resetRedskilledProjectBirthBreaker(paths, { project_label: projectLabel }, config);
     },
 
     async deregister() {

--- a/apps/dev/tests/castle-mcp-client-docs.test.ts
+++ b/apps/dev/tests/castle-mcp-client-docs.test.ts
@@ -78,7 +78,7 @@ describe("castle MCP client docs contract", () => {
       readRepoFile(`${AFK}/monitor.md`),
     ]);
 
-    for (const tool of ["project_start", "project_status", "project_resize", "project_stop", "logs"]) {
+    for (const tool of ["project_start", "project_status", "project_resize", "project_reset", "project_stop", "logs"]) {
       expect(fleet, `fleet.md should route through ${tool}`).toContain(`\`${tool}\``);
     }
     for (const tool of ["monitor", "worker_vitals", "queue_status"]) {

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -219,6 +219,41 @@ describe("starting work registers the project", () => {
       reason: expect.stringContaining("nothing renewed it"),
     });
   });
+
+  it("carries the host birth latch and its callable reset on project_status", async () => {
+    const daemon = await liveHost();
+    const root = await project();
+    const deps = createCastleMcpDependencies(root);
+    await deps.projectStart({ runner: "codex", target: 6 });
+
+    for (let death = 0; death < 3; death += 1) {
+      const workerId = `fast-${death}`;
+      daemon.trackWorker({
+        worker_id: workerId,
+        project_label: "acme/widgets",
+        pid: 8_000 + death,
+        started_at: new Date(Date.now() - 13_000).toISOString(),
+        workspace_path: root,
+        isolated: false,
+        warnings: [],
+      });
+      daemon.releaseWorker(workerId);
+    }
+
+    const status = await deps.projectStatus();
+    expect(status.birth_latch).toMatchObject({
+      name: "project-birth-breaker",
+      state: "open",
+      repair: { tool: "project_reset", args: { latch: "project-birth-breaker" } },
+    });
+    expect(daemon.hostState().birth_latches).toEqual([status.birth_latch]);
+
+    await expect(deps.projectReset({ latch: "project-birth-breaker" })).resolves.toMatchObject({
+      latch: "project-birth-breaker",
+      reset: true,
+    });
+    await expect(deps.projectStatus()).resolves.toMatchObject({ birth_latch: null });
+  });
 });
 
 describe("stopping work deregisters the project", () => {

--- a/apps/dev/tests/red-doctor-command.test.ts
+++ b/apps/dev/tests/red-doctor-command.test.ts
@@ -23,6 +23,7 @@ const listLabelNames = vi.fn(async () => ({
 const projectRegistrationState = vi.fn<() => Promise<ProjectRegistrationState>>(async () => ({
   held: null,
   lapse: null,
+  birthLatch: null,
 }));
 
 vi.mock("../src/runtime/redskilled-birth.js", async (importOriginal) => ({
@@ -193,6 +194,7 @@ describe("redDoctorCommand — executable acceptance criteria lint", () => {
   it("finds a lapsed registration while the executable queue is non-empty", async () => {
     projectRegistrationState.mockResolvedValueOnce({
       held: null,
+      birthLatch: null,
       lapse: {
         project_label: "acme/widgets",
         at: "2026-08-03T17:20:00.000Z",

--- a/apps/dev/tests/statusline-aggregate-coverage.test.ts
+++ b/apps/dev/tests/statusline-aggregate-coverage.test.ts
@@ -85,6 +85,7 @@ const PAYLOAD: StatuslineAggregate = {
       bundle_version: "3.3.24",
       plugin_cache_version: "3.3.21",
     },
+    birth_latch: null,
     slots: { busy: 2, free: 1, parked: 1, total: 4, interactive_reservation: 1 },
     live_workers: [
       { id: "wTST1", pid: 4243, issue: "2344", activity: "editing", origin: "afk" },

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -52,6 +52,7 @@ import {
   isRedskilledDaemonStopped,
   isRedskilledProjectRegistered,
   isRedskilledProjectRenewed,
+  isRedskilledProjectReset,
   isRedskilledStatuslinePayload,
   isRedskilledStatuslineRender,
   isRedskilledWorkerCommandResult,
@@ -61,6 +62,7 @@ import {
   type RedskilledProjectDeregistered,
   type RedskilledProjectRegistered,
   type RedskilledProjectRenewed,
+  type RedskilledProjectReset,
   type RedskilledRequest,
   type RedskilledStatuslinePayload,
   type RedskilledStatuslineRender,
@@ -802,6 +804,26 @@ export async function renewRedskilledProject(
     config,
   );
   if (!isRedskilledProjectRenewed(value)) throw new Error("redskilled daemon returned a malformed renewal");
+  return value;
+}
+
+/** Clear this project's in-memory birth breaker and resume ordinary demand. */
+export async function resetRedskilledProjectBirthBreaker(
+  paths: RedskilledPaths,
+  request: { project_label: string },
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledProjectReset> {
+  const value = await requestRedskilled(
+    paths,
+    {
+      op: "project-reset",
+      project_label: request.project_label,
+      latch: "project-birth-breaker",
+      session_project: config.sessionProject ?? request.project_label,
+    },
+    config,
+  );
+  if (!isRedskilledProjectReset(value)) throw new Error("redskilled daemon returned a malformed project reset");
   return value;
 }
 

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -59,11 +59,13 @@ import {
 } from "./event-lane.js";
 import {
   DEFAULT_REDSKILLED_DEMAND_MS,
+  beginBirthProbe,
+  describeBirthLatches,
   emptyDemandTick,
   planHostDemand,
-  birthHaltMap,
   foldWorkerDeath,
   EMPTY_BIRTH_HEALTH,
+  resetBirthHealth,
   REDSKILLED_SHORT_LIFE_MS,
   type RedskilledBirthHealth,
   REDSKILLED_DEMAND_BACKOFF_MS,
@@ -141,6 +143,7 @@ import {
   type RedskilledProjectDeregistered,
   type RedskilledProjectRegistered,
   type RedskilledProjectRenewed,
+  type RedskilledProjectReset,
   type RedskilledWorkerCommandResult,
   type RedskilledWorkerHeartbeatAck,
   type RedskilledWorkerHeartbeatRequest,
@@ -680,6 +683,8 @@ export interface RedskilledDaemon {
       readonly launch?: RedskilledLaunchTemplate;
     },
   ): RedskilledProjectRenewed;
+  /** Explicitly clear this project's birth breaker. */
+  resetProjectBirthBreaker(projectLabel: string, sessionProject?: string): RedskilledProjectReset;
   /** The registrations this daemon holds, ordered by project label; lapsed ones swept. */
   registrations(): readonly RedskilledProjectRegistration[];
   hostState(): RedskilledHostState;
@@ -1240,6 +1245,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       lapses,
       stops,
       orphanedRegistrations: [...orphanedRegistrations.values()],
+      birthLatches: describeBirthLatches(birthHealth, Date.parse(now)),
       // The poll each registration was last covered by, so "why is nothing
       // happening" is answerable from one read instead of from a log.
       queue: lastQueue,
@@ -1500,6 +1506,16 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       for (const project of lastQueue?.projects ?? []) queue[project.project_label] = project.depth;
 
       const nowMs = Date.parse(at);
+      const demandNowMs = Number.isFinite(nowMs) ? nowMs : 0;
+      // A half-open Worker closes the latch only after proving it survived the
+      // same short-life window that opened it. Until then it is the sole probe.
+      for (const [projectLabel, health] of Object.entries(birthHealth)) {
+        if (health.probeWorkerId == null) continue;
+        const probe = workers.get(health.probeWorkerId);
+        if (probe != null && demandNowMs - Date.parse(probe.started_at) >= REDSKILLED_SHORT_LIFE_MS) {
+          birthHealth[projectLabel] = resetBirthHealth();
+        }
+      }
       const plan = planHostDemand({
         projects: [...registrations.values()].map((registration) => ({
           project_label: registration.project_label,
@@ -1510,9 +1526,9 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         })),
         queue,
         live,
-        nowMs: Number.isFinite(nowMs) ? nowMs : 0,
+        nowMs: demandNowMs,
         backoffUntilMs: demandBackoffUntilMs,
-        birthHaltUntilMs: birthHaltMap(birthHealth, Number.isFinite(nowMs) ? nowMs : 0),
+        birthHealth,
       });
 
       const granted: RedskilledDemandGrant[] = [];
@@ -1561,11 +1577,29 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
             ]
             : launched.warnings,
         });
+        const health = birthHealth[birth.project_label];
+        if (health?.haltUntilMs != null && demandNowMs >= health.haltUntilMs) {
+          birthHealth[birth.project_label] = beginBirthProbe(health, launched.worker.worker_id);
+        }
       }
       // A tick that asked and was never refused clears the hold, so the room a
       // dying Worker freed is spent on the next tick rather than on the timer
       // the last refusal set.
       if (refusal == null && plan.births.length > 0) demandBackoffUntilMs = null;
+
+      // A counted positive queue and free project slots is birth-eligible. If
+      // this tick granted that project nothing, the host lane must state why —
+      // otherwise the silent three-hour stall from #3267 is indistinguishable
+      // from a healthy idle daemon.
+      const grantedProjects = new Set(granted.map((worker) => worker.project_label));
+      for (const intent of plan.intents) {
+        if (intent.queue_depth == null || intent.queue_depth <= 0 || intent.live >= intent.target) continue;
+        if (grantedProjects.has(intent.project_label)) continue;
+        const detail = refusal != null && (intent.outcome === "asking" || intent.outcome === "half-open-probe")
+          ? `project ${JSON.stringify(intent.project_label)} was birth-eligible but the host refused it: ${refusal}`
+          : intent.detail;
+        await eventLane.recordDemandRefusal({ ts: at, projectLabel: intent.project_label, detail }).catch(() => undefined);
+      }
 
       lastDemand = {
         version: 1,
@@ -1796,6 +1830,24 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
           `${new Date(after.haltUntilMs).toISOString()}\n`,
       );
     }
+  }
+
+  /** Clear one project's birth breaker after project-scoped reach permits it. */
+  function resetProjectBirthBreaker(projectLabel: string, sessionProject?: string): RedskilledProjectReset {
+    const reach = authorize("project-reset", sessionProject, projectLabel);
+    if (!reach.permitted) throw new Error(reach.reason);
+    const reset = birthHealth[projectLabel]?.haltUntilMs != null || birthHealth[projectLabel]?.probeWorkerId != null;
+    birthHealth[projectLabel] = resetBirthHealth();
+    return {
+      version: 1,
+      project_label: projectLabel,
+      latch: "project-birth-breaker",
+      reset,
+      reach,
+      detail: reset
+        ? `redskilled cleared project ${JSON.stringify(projectLabel)}'s birth breaker; the next demand tick may birth normally`
+        : `redskilled found no open birth breaker for project ${JSON.stringify(projectLabel)}; nothing changed`,
+    };
   }
 
   /** Ask the host about one Worker; an unanswerable probe is not a confirmation. */
@@ -2787,6 +2839,13 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         await registrationIntentStore.flush();
         return { id: request.id, ok: true, value };
       }
+      if (request.op === "project-reset") {
+        return {
+          id: request.id,
+          ok: true,
+          value: resetProjectBirthBreaker(request.project_label, request.session_project),
+        };
+      }
       if (request.op === "worker-command") {
         return { id: request.id, ok: true, value: await runWorkerCommand(request.command) };
       }
@@ -2871,6 +2930,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     workerCount: () => workers.size,
     registerProject,
     renewProject,
+    resetProjectBirthBreaker,
     deregisterProject,
     registrations: () => hostState().registrations ?? [],
     hostState,

--- a/apps/redskilled/src/demand-loop.ts
+++ b/apps/redskilled/src/demand-loop.ts
@@ -111,7 +111,9 @@ export type RedskilledDemandOutcome =
   | "queue-unknown"
   | "backing-off"
   /** This project's Workers keep dying in boot, so it is not asked again yet. */
-  | "birth-halted";
+  | "birth-halted"
+  /** One birth is due or running after the breaker's cooldown. */
+  | "half-open-probe";
 
 export interface RedskilledDemandIntent {
   readonly project_label: string;
@@ -155,6 +157,12 @@ export interface PlanHostDemandInput {
    * healthy one, which a host-wide backoff would.
    */
   readonly birthHaltUntilMs?: Readonly<Record<string, number>>;
+  /**
+   * The complete breaker state. New callers pass this instead of reducing the
+   * state to a halt instant, because an expired halt is a half-open circuit —
+   * exactly one probe — rather than an ordinary unlatched project.
+   */
+  readonly birthHealth?: Readonly<Record<string, RedskilledBirthHealth>>;
 }
 
 /**
@@ -196,7 +204,8 @@ export function planHostDemand(input: PlanHostDemandInput): RedskilledDemandPlan
     // for a Worker whether or not anyone has counted its queue, and reporting
     // "nobody counted yet" for a project whose Workers are dying in boot names
     // the wrong problem to whoever reads it.
-    const haltUntilMs = input.birthHaltUntilMs?.[project.project_label];
+    const health = input.birthHealth?.[project.project_label];
+    const haltUntilMs = health?.haltUntilMs ?? input.birthHaltUntilMs?.[project.project_label];
     if (haltUntilMs != null && input.nowMs < haltUntilMs) {
       intents.push({
         ...base,
@@ -208,6 +217,18 @@ export function planHostDemand(input: PlanHostDemandInput): RedskilledDemandPlan
           `${REDSKILLED_SHORT_LIFE_MS}ms of birth, so it is not asked for another before ` +
           `${new Date(haltUntilMs).toISOString()} — a Worker that cannot survive boot will not ` +
           `survive the next one either, and every birth spends host quota shared with every project`,
+      });
+      continue;
+    }
+    if (health?.probeWorkerId != null) {
+      intents.push({
+        ...base,
+        outcome: "half-open-probe",
+        wanted: 0,
+        detail:
+          `project ${JSON.stringify(project.project_label)} is half-open and probe Worker ` +
+          `${JSON.stringify(health.probeWorkerId)} has not yet survived ${REDSKILLED_SHORT_LIFE_MS}ms, ` +
+          `so no second birth is admitted`,
       });
       continue;
     }
@@ -248,15 +269,19 @@ export function planHostDemand(input: PlanHostDemandInput): RedskilledDemandPlan
       });
       continue;
     }
+    const halfOpen = health?.haltUntilMs != null && input.nowMs >= health.haltUntilMs;
+    const admitted = halfOpen ? 1 : wanted;
     intents.push({
       ...base,
-      outcome: "asking",
-      wanted,
-      detail:
-        `project ${JSON.stringify(project.project_label)} holds ${live} Worker(s) against a target of ` +
-        `${project.target} and a queue of ${depth}, so it asks for ${wanted} more`,
+      outcome: halfOpen ? "half-open-probe" : "asking",
+      wanted: admitted,
+      detail: halfOpen
+        ? `project ${JSON.stringify(project.project_label)} finished its birth-breaker cooldown, so exactly one ` +
+          `probe Worker is admitted before the remaining ${Math.max(0, wanted - 1)} birth(s)`
+        : `project ${JSON.stringify(project.project_label)} holds ${live} Worker(s) against a target of ` +
+          `${project.target} and a queue of ${depth}, so it asks for ${wanted} more`,
     });
-    for (let index = 0; index < wanted; index += 1) {
+    for (let index = 0; index < admitted; index += 1) {
       const round = rounds[index] ?? (rounds[index] = []);
       round.push({
         project_label: project.project_label,
@@ -340,10 +365,38 @@ export interface RedskilledBirthHealth {
   readonly shortLifeStreak: number;
   /** When this project may be asked for a Worker again; `null` when it may now. */
   readonly haltUntilMs: number | null;
+  /** The instant the current open period began; refreshed after a failed probe. */
+  readonly openedAtMs: number | null;
+  /** The sole half-open Worker; while present no second birth is admitted. */
+  readonly probeWorkerId: string | null;
 }
 
 /** A project with no history — never halted, no streak. */
-export const EMPTY_BIRTH_HEALTH: RedskilledBirthHealth = { shortLifeStreak: 0, haltUntilMs: null };
+export const EMPTY_BIRTH_HEALTH: RedskilledBirthHealth = {
+  shortLifeStreak: 0,
+  haltUntilMs: null,
+  openedAtMs: null,
+  probeWorkerId: null,
+};
+
+/** The structured cure carried beside every visible birth latch. */
+export interface RedskilledBirthLatchRepair {
+  readonly tool: "project_reset";
+  readonly args: { readonly latch: "project-birth-breaker" };
+  readonly why: string;
+}
+
+/** One project's birth-refusing latch, in the shape read surfaces expose. */
+export interface RedskilledBirthLatch {
+  readonly name: "project-birth-breaker";
+  readonly project_label: string;
+  readonly state: "open" | "half-open";
+  readonly opened_at: string;
+  readonly reason: string;
+  readonly closes: string;
+  readonly probe_worker_id: string | null;
+  readonly repair: RedskilledBirthLatchRepair;
+}
 
 /**
  * Fold one Worker's death into its project's birth health. PURE.
@@ -365,8 +418,71 @@ export function foldWorkerDeath(
 ): RedskilledBirthHealth {
   if (lifetimeMs >= REDSKILLED_SHORT_LIFE_MS) return EMPTY_BIRTH_HEALTH;
   const shortLifeStreak = health.shortLifeStreak + 1;
-  if (shortLifeStreak < REDSKILLED_SHORT_LIFE_STREAK) return { shortLifeStreak, haltUntilMs: null };
-  return { shortLifeStreak, haltUntilMs: nowMs + REDSKILLED_BIRTH_HALT_MS };
+  const wasLatched = health.haltUntilMs != null || health.probeWorkerId != null;
+  if (!wasLatched && shortLifeStreak < REDSKILLED_SHORT_LIFE_STREAK) {
+    return { shortLifeStreak, haltUntilMs: null, openedAtMs: null, probeWorkerId: null };
+  }
+  return {
+    shortLifeStreak,
+    haltUntilMs: nowMs + REDSKILLED_BIRTH_HALT_MS,
+    openedAtMs: nowMs,
+    probeWorkerId: null,
+  };
+}
+
+/** Mark the one Worker admitted by a half-open circuit. PURE. */
+export function beginBirthProbe(health: RedskilledBirthHealth, workerId: string): RedskilledBirthHealth {
+  return health.haltUntilMs == null
+    ? health
+    : { ...health, probeWorkerId: workerId };
+}
+
+/** Explicit operator reset and successful-probe closure share one transition. PURE. */
+export function resetBirthHealth(): RedskilledBirthHealth {
+  return EMPTY_BIRTH_HEALTH;
+}
+
+/** Compose the one truthful latch record every read surface carries. PURE. */
+export function describeBirthLatch(
+  projectLabel: string,
+  health: RedskilledBirthHealth,
+  nowMs: number,
+): RedskilledBirthLatch | null {
+  if (health.haltUntilMs == null || health.openedAtMs == null) return null;
+  const halfOpen = nowMs >= health.haltUntilMs;
+  return {
+    name: "project-birth-breaker",
+    project_label: projectLabel,
+    state: halfOpen ? "half-open" : "open",
+    opened_at: new Date(health.openedAtMs).toISOString(),
+    reason:
+      `${health.shortLifeStreak} Workers from this project died before surviving ` +
+      `${REDSKILLED_SHORT_LIFE_MS}ms`,
+    closes: halfOpen
+      ? health.probeWorkerId == null
+        ? "the next demand tick admits one probe Worker; surviving the short-life window closes the latch"
+        : `probe Worker ${JSON.stringify(health.probeWorkerId)} surviving ${REDSKILLED_SHORT_LIFE_MS}ms closes ` +
+          "the latch; a fast death re-opens it with a fresh cooldown"
+      : `the cooldown ends at ${new Date(health.haltUntilMs).toISOString()}, then one probe Worker is admitted; ` +
+        "surviving the short-life window closes the latch",
+    probe_worker_id: health.probeWorkerId,
+    repair: {
+      tool: "project_reset",
+      args: { latch: "project-birth-breaker" },
+      why: "clear the project's birth-breaker history and allow the next demand tick to birth normally",
+    },
+  };
+}
+
+/** Every active latch, stable by project label for host-state readers. PURE. */
+export function describeBirthLatches(
+  health: Readonly<Record<string, RedskilledBirthHealth>>,
+  nowMs: number,
+): readonly RedskilledBirthLatch[] {
+  return Object.entries(health)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([projectLabel, record]) => describeBirthLatch(projectLabel, record, nowMs))
+    .filter((latch): latch is RedskilledBirthLatch => latch != null);
 }
 
 /**

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -1,7 +1,7 @@
 /**
  * event-lane — the daemon's own append-only memory of the Workers it birthed.
  *
- * **One lane, three facts: birth, death, and a budget-driven kill.** ADR 0130
+ * **One lane, host facts: birth, death, budget kill, and demand refusal.** ADR 0130
  * gives the daemon exactly one thing no other authority holds — Worker-to-process
  * — and this lane is the durable form of it. The tracker already owns
  * issue-to-PR and git already owns branch-to-commits, so a per-Worker durable
@@ -31,14 +31,19 @@ import type { RedskilledWorkerView } from "./host-state.js";
 import type { RedskilledWorkerBudget } from "./worker-placement.js";
 
 /**
- * The four facts the lane carries. Nothing else is a host event.
+ * The five facts the lane carries. Nothing else is a host event.
  *
- * `daemon-stop` is the one that is not about a Worker, and it is here because
+ * `daemon-stop` and `demand-refusal` are not about a Worker. The first is here because
  * its absence is what a successor otherwise has to guess at: a lane that ends
  * mid-life reads identically whether the daemon was asked to leave or was killed,
  * and only one of those is a fault worth reporting.
  */
-export type RedskilledEventKind = "worker-birth" | "worker-death" | "worker-budget-kill" | "daemon-stop";
+export type RedskilledEventKind =
+  | "worker-birth"
+  | "worker-death"
+  | "worker-budget-kill"
+  | "demand-refusal"
+  | "daemon-stop";
 
 /**
  * One host event, flat and total.
@@ -120,6 +125,13 @@ export interface RecordDaemonStopInput {
   readonly signal?: string | null;
 }
 
+/** One positive-depth project the demand loop deliberately did not birth for. */
+export interface RecordDemandRefusalInput {
+  readonly ts: string;
+  readonly projectLabel: string;
+  readonly detail: string;
+}
+
 /** Build one event from a Worker view. PURE. */
 export function buildHostEvent(input: RecordEventInput): RedskilledHostEvent {
   const budget = input.worker.budget ?? {};
@@ -170,6 +182,29 @@ export function buildDaemonStopEvent(input: RecordDaemonStopInput): RedskilledHo
   };
 }
 
+/** Build a project demand refusal without inventing a Worker. PURE. */
+export function buildDemandRefusalEvent(input: RecordDemandRefusalInput): RedskilledHostEvent {
+  return {
+    version: 1,
+    ts: input.ts,
+    event: "demand-refusal",
+    worker_id: `demand:${input.projectLabel}`,
+    project_label: input.projectLabel,
+    pid: 0,
+    workspace_path: "",
+    log_path: null,
+    isolated: false,
+    unit: null,
+    memory_high: null,
+    memory_max: null,
+    cpu_weight: null,
+    detail: input.detail,
+    exit_code: null,
+    signal: null,
+    reason: null,
+  };
+}
+
 /**
  * An open lane writer.
  *
@@ -183,6 +218,8 @@ export interface RedskilledEventLane {
   readonly path: string;
   /** Append one event; resolves once the bytes are on the lane. */
   record(input: RecordEventInput): Promise<RedskilledHostEvent>;
+  /** Append one demand decision that refused an otherwise birth-eligible project. */
+  recordDemandRefusal(input: RecordDemandRefusalInput): Promise<RedskilledHostEvent>;
   /**
    * Append the daemon's own stop; resolves once the bytes are on the lane.
    *
@@ -218,6 +255,7 @@ export function createRedskilledEventLane(path: string): RedskilledEventLane {
   return {
     path,
     record: (input) => append(buildHostEvent(input)),
+    recordDemandRefusal: (input) => append(buildDemandRefusalEvent(input)),
     recordDaemonStop: (input) => append(buildDaemonStopEvent(input)),
     read: () => readRedskilledEvents(path),
     flush: async () => {
@@ -318,7 +356,7 @@ export function rehydrateWorkers(events: readonly RedskilledHostEvent[]): Redski
   for (const event of events) {
     // A daemon's own stop retires nothing: the daemon left and every Worker it
     // held is still running, which is exactly what the successor replays to find.
-    if (event.event === "daemon-stop") continue;
+    if (event.event === "daemon-stop" || event.event === "demand-refusal") continue;
     if (event.event === "worker-birth") alive.set(event.worker_id, toWorkerView(event));
     else alive.delete(event.worker_id);
   }
@@ -373,7 +411,8 @@ function isHostEventRecord(record: ToonlRecord): boolean {
     typeof record.ts === "string" &&
     typeof record.worker_id === "string" &&
     (record.event === "worker-birth" || record.event === "worker-death" ||
-      record.event === "worker-budget-kill" || record.event === "daemon-stop");
+      record.event === "worker-budget-kill" || record.event === "demand-refusal" ||
+      record.event === "daemon-stop");
 }
 
 function fromRow(record: ToonlRecord): RedskilledHostEvent {

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -22,6 +22,7 @@ import {
   type RedskilledRenewalStatus,
 } from "./project-registration.js";
 import { REDSKILLED_PROTOCOL_VERSION } from "./protocol.js";
+import type { RedskilledBirthLatch } from "./demand-loop.js";
 import type { RedskilledQueueDiscovery, RedskilledQueueOutcome } from "./queue-discovery.js";
 import type { RedskilledMajorHold, RedskilledReplacementHoldReason } from "./self-replace.js";
 import type { RedskilledWorkerBudget } from "./worker-placement.js";
@@ -315,6 +316,8 @@ export interface RedskilledHostState {
   readonly stopped_registrations?: readonly RedskilledRegistrationStop[];
   /** Registrations held by another live daemon which this socket cannot reach. */
   readonly orphaned_registrations?: readonly RedskilledOrphanedRegistration[];
+  /** Every project whose autonomous births are currently latched. */
+  readonly birth_latches?: readonly RedskilledBirthLatch[];
   /** What the daemon has promised the machine, derived from `workers`. */
   readonly budget_accounting: RedskilledBudgetAccounting;
   /** Running version against published version, and what is being done about it. */
@@ -348,6 +351,8 @@ export interface BuildHostStateInput {
   readonly stops?: readonly RedskilledRegistrationStop[];
   /** Registrations proved to remain behind another live daemon. */
   readonly orphanedRegistrations?: readonly RedskilledOrphanedRegistration[];
+  /** The daemon's in-memory birth latches, already composed for read surfaces. */
+  readonly birthLatches?: readonly RedskilledBirthLatch[];
   /**
    * The last queue poll, as the poller left it; absent when none has run.
    *
@@ -412,6 +417,7 @@ export function buildHostState(input: BuildHostStateInput): RedskilledHostState 
     ...(input.orphanedRegistrations == null || input.orphanedRegistrations.length === 0
       ? {}
       : { orphaned_registrations: [...input.orphanedRegistrations] }),
+    birth_latches: [...(input.birthLatches ?? [])],
     budget_accounting: buildBudgetAccounting(workers, {
       hostCeilingBytes: input.ceiling?.memory_bytes ?? input.hostCeilingBytes ?? null,
     }),
@@ -532,11 +538,29 @@ export function isRedskilledHostState(value: unknown): value is RedskilledHostSt
       (Array.isArray(state.stopped_registrations) && state.stopped_registrations.every(isRegistrationStop))) &&
     (state.orphaned_registrations === undefined ||
       (Array.isArray(state.orphaned_registrations) && state.orphaned_registrations.every(isOrphanedRegistration))) &&
+    (state.birth_latches === undefined ||
+      (Array.isArray(state.birth_latches) && state.birth_latches.every(isBirthLatch))) &&
     // Checked only when present. One daemon serves checkouts pinned to different
     // bundle versions (ADR 0130 rule 3), so a field this bundle added must not
     // make an older daemon's complete answer read as malformed — while a field
     // that IS there and is the wrong shape still fails closed.
     (state.upgrade === undefined || isRedskilledUpgradeState(state.upgrade));
+}
+
+function isBirthLatch(value: unknown): value is RedskilledBirthLatch {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const latch = value as Record<string, unknown>;
+  const repair = latch.repair as Record<string, unknown> | undefined;
+  return latch.name === "project-birth-breaker" &&
+    typeof latch.project_label === "string" &&
+    (latch.state === "open" || latch.state === "half-open") &&
+    typeof latch.opened_at === "string" &&
+    typeof latch.reason === "string" &&
+    typeof latch.closes === "string" &&
+    (latch.probe_worker_id === null || typeof latch.probe_worker_id === "string") &&
+    repair != null && repair.tool === "project_reset" &&
+    typeof repair.args === "object" && repair.args !== null &&
+    typeof repair.why === "string";
 }
 
 function isRegistrationLapse(value: unknown): value is RedskilledRegistrationLapse {

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -193,6 +193,13 @@ export type RedskilledRequest =
     session_project?: string;
   }
   | { id: string; op: "project-deregister"; project_label: string; session_project?: string }
+  | {
+    id: string;
+    op: "project-reset";
+    project_label: string;
+    latch: "project-birth-breaker";
+    session_project?: string;
+  }
   // `detail` is the operator's own words for WHY — opaque to the daemon, recorded
   // with the stop on the event lane so the successor inherits the intent and not
   // just the fact (#2919).
@@ -227,6 +234,27 @@ export interface RedskilledWorkerStarted {
    */
   readonly admission: RedskilledAdmissionVerdict;
   readonly warnings: readonly string[];
+}
+
+/** The answer to an explicit reset of this project's in-memory birth latch. */
+export interface RedskilledProjectReset {
+  readonly version: 1;
+  readonly project_label: string;
+  readonly latch: "project-birth-breaker";
+  readonly reset: boolean;
+  readonly reach: RedskilledReachVerdict;
+  readonly detail: string;
+}
+
+export function isRedskilledProjectReset(value: unknown): value is RedskilledProjectReset {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const reset = value as Record<string, unknown>;
+  return reset.version === 1 &&
+    typeof reset.project_label === "string" &&
+    reset.latch === "project-birth-breaker" &&
+    typeof reset.reset === "boolean" &&
+    typeof reset.detail === "string" &&
+    isRedskilledReachVerdict(reset.reach);
 }
 
 export function isRedskilledWorkerStarted(value: unknown): value is RedskilledWorkerStarted {

--- a/apps/redskilled/src/session-reach.ts
+++ b/apps/redskilled/src/session-reach.ts
@@ -42,6 +42,7 @@ export type RedskilledSessionOp =
   | "worker-heartbeat"
   | "project-register"
   | "project-renew"
+  | "project-reset"
   | "project-deregister";
 
 /** The three reaches. A reader of this type knows the whole model. */
@@ -71,6 +72,9 @@ export const REDSKILLED_OP_REACH: Readonly<Record<RedskilledSessionOp, Redskille
   // session that could renew another project's registration could keep a drain
   // nobody is watching running past the deadline that exists to end it.
   "project-renew": "project-write",
+  // Clearing a birth latch resumes this project's autonomous births, so only a
+  // session in that project may perform it.
+  "project-reset": "project-write",
   // Releasing one lands exactly where taking it did: a session that could release
   // another project's registration could stop its work from outside it.
   "project-deregister": "project-write",

--- a/apps/redskilled/tests/birth-latch.test.ts
+++ b/apps/redskilled/tests/birth-latch.test.ts
@@ -46,7 +46,7 @@ function recordingLaunch(launched: LaunchWorkerOptions[]) {
         project_label: options.spec.project_label,
         workspace_path: options.spec.workspace_path,
         pid: 4_000 + born,
-        started_at: options.clock(),
+        started_at: options.clock!(),
         isolated: false,
         warnings: [],
       },

--- a/apps/redskilled/tests/birth-latch.test.ts
+++ b/apps/redskilled/tests/birth-latch.test.ts
@@ -1,0 +1,173 @@
+// A birth-eligible project can be idle only with a stated reason (#3267).
+// The daemon used to keep its project birth breaker solely in process memory:
+// host_state showed open work, free slots and no Workers while naming no latch,
+// and the demand tick that refused the birth left no durable event behind.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import {
+  REDSKILLED_BIRTH_HALT_MS,
+  REDSKILLED_SHORT_LIFE_MS,
+  REDSKILLED_SHORT_LIFE_STREAK,
+} from "../src/demand-loop.js";
+import { readRedskilledEvents } from "../src/event-lane.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import type { LaunchedWorker, LaunchWorkerOptions } from "../src/worker-launch.js";
+
+const START_MS = Date.parse("2026-08-04T13:03:15.000Z");
+const PROJECT = "acme/widgets";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function recordingLaunch(launched: LaunchWorkerOptions[]) {
+  let born = 0;
+  return (options: LaunchWorkerOptions): LaunchedWorker => {
+    if (!options.admission.admitted) throw new Error(options.admission.reason);
+    launched.push(options);
+    born += 1;
+    return {
+      worker: {
+        worker_id: `w${born}`,
+        project_label: options.spec.project_label,
+        workspace_path: options.spec.workspace_path,
+        pid: 4_000 + born,
+        started_at: options.clock(),
+        isolated: false,
+        warnings: [],
+      },
+      admission: options.admission,
+      warnings: [],
+      plan: {
+        backend: "none",
+        command: options.spec.command,
+        args: [...(options.spec.args ?? [])],
+        isolated: false,
+        warnings: [],
+      } as unknown as LaunchedWorker["plan"],
+      child: { pid: 4_000 + born, once: () => undefined, unref: () => undefined } as unknown as LaunchedWorker["child"],
+    };
+  };
+}
+
+describe("the daemon's project birth latch", () => {
+  it("reports, records, half-opens one probe, and reopens on a failed probe", async () => {
+    let nowMs = START_MS;
+    let depth = 1;
+    const launched: LaunchWorkerOptions[] = [];
+    const session = await scratch("redskilled-birth-latch-");
+    const workspace = await scratch("redskilled-birth-latch-workspace-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${session}`, REDSKILLED_MACHINE_DIR: session },
+      runtimeDir: session,
+    });
+    const daemon = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      clock: () => new Date(nowMs).toISOString(),
+      sampleMs: 0,
+      demandMs: 0,
+      liveness: () => true,
+      launch: recordingLaunch(launched),
+      queueDiscovery: { intervalMs: 0, transport: async () => answer(depth) },
+    });
+    running.push(daemon);
+    daemon.registerProject({
+      project_label: PROJECT,
+      selector: `repo:${PROJECT} label:ready-for-agent`,
+      argv: ["red-skills-dev", "run", "--once"],
+      workspace_path: workspace,
+      target: 6,
+    });
+
+    // Three short lives trip the breaker. A depth of one keeps each tick to one
+    // birth so this is the observed consecutive-death shape, not a burst.
+    for (let death = 0; death < REDSKILLED_SHORT_LIFE_STREAK; death += 1) {
+      await daemon.pollQueueDiscovery();
+      const tick = await daemon.driveDemand();
+      expect(tick.granted).toHaveLength(1);
+      nowMs += 13_000;
+      expect(daemon.releaseWorker(tick.granted[0]!.worker_id)).toBe(true);
+      nowMs += 2_000;
+    }
+
+    const openedAt = new Date(nowMs - 2_000).toISOString();
+    const state = daemon.hostState();
+    expect(state.birth_latches).toEqual([
+      expect.objectContaining({
+        name: "project-birth-breaker",
+        project_label: PROJECT,
+        state: "open",
+        opened_at: openedAt,
+        reason: expect.stringContaining(`${REDSKILLED_SHORT_LIFE_STREAK} Workers`),
+        closes: expect.stringContaining("one probe Worker"),
+        repair: {
+          tool: "project_reset",
+          args: { latch: "project-birth-breaker" },
+          why: expect.stringContaining("clear"),
+        },
+      }),
+    ]);
+
+    // Positive depth + six free slots + no birth must leave a host event naming
+    // the refusal. This is the record the three-hour stall had none of.
+    await daemon.pollQueueDiscovery();
+    const held = await daemon.driveDemand();
+    expect(held.granted).toEqual([]);
+    expect(held.projects[0]?.outcome).toBe("birth-halted");
+    await daemon.flushEvents();
+    const refusals = (await readRedskilledEvents(paths.eventLanePath)).filter(
+      (event) => event.event === "demand-refusal",
+    );
+    expect(refusals.at(-1)).toMatchObject({
+      project_label: PROJECT,
+      detail: expect.stringContaining("not asked for another"),
+    });
+
+    // After cooldown the breaker is half-open: even with six queued and six
+    // free, exactly one birth is admitted. A second tick waits on that probe.
+    nowMs = Date.parse(openedAt) + REDSKILLED_BIRTH_HALT_MS;
+    depth = 6;
+    await daemon.pollQueueDiscovery();
+    const probe = await daemon.driveDemand();
+    expect(probe.granted).toHaveLength(1);
+    expect(probe.projects[0]?.outcome).toBe("half-open-probe");
+    expect(daemon.hostState().birth_latches?.[0]).toMatchObject({
+      state: "half-open",
+      probe_worker_id: probe.granted[0]!.worker_id,
+    });
+    expect((await daemon.driveDemand()).granted).toEqual([]);
+
+    // A fast probe death re-opens immediately and dates the new refusal to this
+    // death, rather than leaving the original trip timestamp latched forever.
+    nowMs += Math.min(13_000, REDSKILLED_SHORT_LIFE_MS - 1);
+    daemon.releaseWorker(probe.granted[0]!.worker_id);
+    expect(daemon.hostState().birth_latches?.[0]).toMatchObject({
+      state: "open",
+      opened_at: new Date(nowMs).toISOString(),
+    });
+  });
+});
+
+function answer(depth: number): unknown {
+  return {
+    data: {
+      rateLimit: { remaining: 4_900, resetAt: null },
+      q0: { issueCount: depth },
+    },
+  };
+}

--- a/apps/redskilled/tests/demand-producer.test.ts
+++ b/apps/redskilled/tests/demand-producer.test.ts
@@ -509,12 +509,12 @@ describe("the seam holds in both directions", () => {
     }
   });
 
-  it("keeps every breaker policy out of the daemon's half", () => {
+  it("keeps the selector/work-policy breaker out of the daemon's half", () => {
     for (const file of ["daemon.ts", "protocol.ts", "host-state.ts", "admission.ts", "event-lane.ts"]) {
       const source = readFileSync(new URL(`../src/${file}`, import.meta.url), "utf8");
       const code = source.replace(/\/\*\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
-      expect(code, `${file} must hold no circuit-breaker policy`).not.toMatch(
-        /breaker|half.?open|cooldown|\bparked?\b/i,
+      expect(code, `${file} must hold no selector circuit policy`).not.toMatch(
+        /project-breaker|ProjectBreaker|SelectorBreaker|selectorPark|selector_id|selectorId/,
       );
     }
   });

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -23,6 +23,7 @@ function deps(): CastleMcpDependencies {
         bundle_version: "3.3.24",
         plugin_cache_version: "3.3.21",
       },
+      birth_latch: null,
       slots: { busy: 1, free: 1, parked: 0, total: 2, interactive_reservation: 1 },
       live_workers: [
         {
@@ -41,6 +42,7 @@ function deps(): CastleMcpDependencies {
       pid: 42,
     })),
     projectResize: vi.fn(async (input) => ({ status: "resized", target: input.target })),
+    projectReset: vi.fn(async (input) => ({ status: "reset", latch: input.latch })),
     projectStop: vi.fn(async (input) => ({
       status: "stopped",
       force: input.force ?? false,
@@ -162,6 +164,7 @@ describe("castle MCP tools", () => {
       "project_status",
       "project_start",
       "project_resize",
+      "project_reset",
       "project_stop",
       "host_state",
       "host_dashboard",
@@ -217,6 +220,14 @@ describe("castle MCP tools", () => {
       registration: { held: true, renewal: "renewing", target: 2 },
       slots: { total: 2 },
       live_workers: [{ id: "worker-1" }],
+    });
+  });
+
+  it("resets the named project latch", async () => {
+    const tool = createCastleMcpTools(deps()).find((candidate) => candidate.name === "project_reset")!;
+    await expect(tool.invoke({ latch: "project-birth-breaker" })).resolves.toEqual({
+      status: "reset",
+      latch: "project-birth-breaker",
     });
   });
 

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -54,6 +54,7 @@ export type {
   WorkSelectorInput,
   ProjectStartInput,
   ProjectResizeInput,
+  ProjectResetInput,
   ProjectStopInput,
 } from "./mcp/project.js";
 export type { EventsSinceInput, LogsInput, QueueStatusInput, WorkerVitalsInput } from "./mcp/observability.js";

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -41,6 +41,13 @@ const SURFACE: ReadonlyArray<{
     schema: ["runner", "target", "selector", "config", "base", "fleet"],
   },
   {
+    name: "project_reset",
+    title: "Reset project execution latch",
+    description:
+      "MUTATING: clear a named in-memory latch for this project so autonomous demand may retry immediately.",
+    schema: ["latch", "fleet"],
+  },
+  {
     name: "project_stop",
     title: "Stop this project's workers",
     description:

--- a/packages/red-castle/src/mcp/contracts.test.ts
+++ b/packages/red-castle/src/mcp/contracts.test.ts
@@ -32,6 +32,7 @@ const PROJECT_STATUS: ProjectStatusOutput = {
     bundle_version: "3.3.24",
     plugin_cache_version: "3.3.21",
   },
+  birth_latch: null,
   slots: { busy: 1, free: 1, parked: 0, total: 2, interactive_reservation: 1 },
   live_workers: [
     { id: "worker-1", pid: 43, issue: "2305", activity: "impl", origin: "afk" },

--- a/packages/red-castle/src/mcp/contracts.ts
+++ b/packages/red-castle/src/mcp/contracts.ts
@@ -133,8 +133,25 @@ export const projectRegistrationStatusSchema = z.object({
 
 export type ProjectRegistrationStatusOutput = z.infer<typeof projectRegistrationStatusSchema>;
 
+export const projectBirthLatchSchema = z.object({
+  name: z.literal("project-birth-breaker"),
+  project_label: z.string(),
+  state: z.enum(["open", "half-open"]),
+  opened_at: z.string(),
+  reason: z.string(),
+  closes: z.string(),
+  probe_worker_id: z.string().nullable(),
+  repair: z.object({
+    tool: z.literal("project_reset"),
+    args: z.object({ latch: z.literal("project-birth-breaker") }),
+    why: z.string(),
+  }),
+});
+
 export const projectStatusOutputSchema = z.object({
   registration: projectRegistrationStatusSchema,
+  /** The project-wide birth latch, or null when autonomous births are allowed. */
+  birth_latch: projectBirthLatchSchema.nullable(),
   slots: z.object({
     busy: z.number(),
     free: z.number(),

--- a/packages/red-castle/src/mcp/project.ts
+++ b/packages/red-castle/src/mcp/project.ts
@@ -47,10 +47,15 @@ export interface ProjectStopInput {
   force?: boolean;
 }
 
+export interface ProjectResetInput {
+  latch: "project-birth-breaker";
+}
+
 export interface ProjectDependencies {
   projectStatus(): Promise<ProjectStatusOutput>;
   projectStart(input: ProjectStartInput): Promise<unknown>;
   projectResize(input: ProjectResizeInput): Promise<unknown>;
+  projectReset(input: ProjectResetInput): Promise<unknown>;
   projectStop(input: ProjectStopInput): Promise<unknown>;
 }
 
@@ -130,6 +135,20 @@ export function createProjectTools(deps: ProjectDependencies): CastleMcpTool[] {
       invoke: async (input) => {
         refuseFleetNaming(input.fleet);
         return deps.projectResize(input as unknown as ProjectResizeInput);
+      },
+    },
+    {
+      name: "project_reset",
+      title: "Reset project execution latch",
+      description:
+        "MUTATING: clear a named in-memory latch for this project so autonomous demand may retry immediately.",
+      inputSchema: {
+        latch: z.literal("project-birth-breaker"),
+        fleet: removedFleetName,
+      },
+      invoke: async ({ latch, fleet }) => {
+        refuseFleetNaming(fleet);
+        return deps.projectReset({ latch: latch as "project-birth-breaker" });
       },
     },
     {

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -65,6 +65,7 @@ re-aimed by `project_resize`.
 | `project_status` | read | Supervisor pid, slots, churn, and live workers for this project. |
 | `project_start` | mutating | Register this project with the host daemon — a runner, a target width, and its work policy. It registers; it launches no process of the project's own. |
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |
+| `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `project_status.birth_latch.repair`; the structured repair supplies the exact args. |
 | `project_stop` | mutating | Give this project's registration back and stop what it still holds; pass `force: true` to hard-stop only its attributed workers. |
 
 ### Host daemon diagnostics

--- a/packaging/pi/dev/skills/engineering/afk/fleet.md
+++ b/packaging/pi/dev/skills/engineering/afk/fleet.md
@@ -18,6 +18,7 @@ and mutation modes.
 | launch | `project_start` | `{runner, target, selector?, config?, base?}` — hands the work policy to the host daemon as a registration; the project spawns nothing. |
 | resize / switch | `project_resize` | Same fields, all optional; restates the launch on the registration's renewal (Amendment 5). |
 | ground truth | `project_status` | The registration the host holds, its renewal and last poll, plus slots and live workers. |
+| reset birth latch | `project_reset` | Invoke the structured repair returned in `project_status.birth_latch`; clears only this project's birth breaker. |
 | shutdown | `project_stop` | Asks the host to end this project's Workers, then gives the registration back. |
 | logs | `logs` | One structured lane per call (`supervisor` / `worker` / `monitor` / `liveness`). |
 
@@ -162,6 +163,6 @@ The safe fleet width for a given queue is the **degree of disjunction** — the 
 
 ### Refs
 
-- [`MCP.md`](./MCP.md) — the `castle` tool surface; `project_start`, `project_resize`, `project_status`, `project_stop`, and `logs` are the primary interface.
+- [`MCP.md`](./MCP.md) — the `castle` tool surface; `project_start`, `project_resize`, `project_status`, `project_reset`, `project_stop`, and `logs` are the primary interface.
 - ADR 0130 Amendment 4 — why a project contributes a registration and holds no process of its own, and why the `fleet` launcher, the `__supervise` entrypoint and the self-heal watchdog were deleted rather than renamed.
 - [`monitor.md`](./monitor.md) — the readonly dashboard and native-task mirror.

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -122,7 +122,8 @@ The LLM Wiki routes ship with the `memory` plugin as `/memory:wiki-init` and
 Capability references registered by owner:
 `castle` MCP (the canonical project interface and read-only host-daemon
 diagnostic surface: `host_state`, `host_dashboard`, `host_provision_check`,
-`host_unit_status`) ->
+`host_unit_status`; a visible `project_status.birth_latch` routes through its
+structured `project_reset` repair) ->
 `plugins/dev/skills/engineering/afk/MCP.md`;
 `/afk` landing-tail throughput (`afk.landing.wait`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -65,6 +65,7 @@ re-aimed by `project_resize`.
 | `project_status` | read | Supervisor pid, slots, churn, and live workers for this project. |
 | `project_start` | mutating | Register this project with the host daemon — a runner, a target width, and its work policy. It registers; it launches no process of the project's own. |
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |
+| `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `project_status.birth_latch.repair`; the structured repair supplies the exact args. |
 | `project_stop` | mutating | Give this project's registration back and stop what it still holds; pass `force: true` to hard-stop only its attributed workers. |
 
 ### Host daemon diagnostics

--- a/plugins/dev/skills/engineering/afk/fleet.md
+++ b/plugins/dev/skills/engineering/afk/fleet.md
@@ -18,6 +18,7 @@ and mutation modes.
 | launch | `project_start` | `{runner, target, selector?, config?, base?}` — hands the work policy to the host daemon as a registration; the project spawns nothing. |
 | resize / switch | `project_resize` | Same fields, all optional; restates the launch on the registration's renewal (Amendment 5). |
 | ground truth | `project_status` | The registration the host holds, its renewal and last poll, plus slots and live workers. |
+| reset birth latch | `project_reset` | Invoke the structured repair returned in `project_status.birth_latch`; clears only this project's birth breaker. |
 | shutdown | `project_stop` | Asks the host to end this project's Workers, then gives the registration back. |
 | logs | `logs` | One structured lane per call (`supervisor` / `worker` / `monitor` / `liveness`). |
 
@@ -162,6 +163,6 @@ The safe fleet width for a given queue is the **degree of disjunction** — the 
 
 ### Refs
 
-- [`MCP.md`](./MCP.md) — the `castle` tool surface; `project_start`, `project_resize`, `project_status`, `project_stop`, and `logs` are the primary interface.
+- [`MCP.md`](./MCP.md) — the `castle` tool surface; `project_start`, `project_resize`, `project_status`, `project_reset`, `project_stop`, and `logs` are the primary interface.
 - ADR 0130 Amendment 4 — why a project contributes a registration and holds no process of its own, and why the `fleet` launcher, the `__supervise` entrypoint and the self-heal watchdog were deleted rather than renamed.
 - [`monitor.md`](./monitor.md) — the readonly dashboard and native-task mirror.

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -122,7 +122,8 @@ The LLM Wiki routes ship with the `memory` plugin as `/memory:wiki-init` and
 Capability references registered by owner:
 `castle` MCP (the canonical project interface and read-only host-daemon
 diagnostic surface: `host_state`, `host_dashboard`, `host_provision_check`,
-`host_unit_status`) ->
+`host_unit_status`; a visible `project_status.birth_latch` routes through its
+structured `project_reset` repair) ->
 `plugins/dev/skills/engineering/afk/MCP.md`;
 `/afk` landing-tail throughput (`afk.landing.wait`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3267 -->
🤖 **Re-seed trail** — #3267 on `afk/3267-the-daemon-counts-open-work-holds-six-fr`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 3/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3267; re-seeding on the think tier before terminal validation routing. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3267 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/dev`, `apps/redskilled`, `packages/red-castle`]
{"schema":"red.afk.validation.v1","name":"test:apps/dev","status":"failed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3267-the-daemon-counts-open-work-holds-six-fr/apps/dev test","exitCode":1,"durationMs":418,"summary":"inconclusive: the baseline could not be built, so nothing was compared — [ERROR] ENOENT: no such file or directory, lstat '[REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/main' For help, run: pnpm help run"}
{"schema":"red.afk.validation.v1","name":"test:apps/redskilled","status":"failed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3267-the-daemon-counts-open-work-holds-six-fr/apps/redskilled test","exitCode":1,"durationMs":42,"summary":"inconclusive: the baseline could not be built, so nothing was compared — [ERROR] ENOENT: no such file or directory, lstat '[REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/main' For help, run: pnpm help run"}
{"schema":"red.afk.validation.v1","name":"test:packages/red-castle","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3267-the-daemon-counts-open-work-holds-six-fr/packages/red-castle test","exitCode":0,"durationMs":32,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"typecheck:apps/dev","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3267-the-daemon-counts-open-work-holds-six-fr/apps/dev typecheck","exitCode":0,"durationMs":17,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"typecheck:apps/redskilled","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3267-the-daemon-counts-open-work-holds-six-fr/apps/redskilled typecheck","exitCode":0,"durationMs":4,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"typecheck:packages/red-castle","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3267-the-daemon-counts-open-work-holds-six-fr/packages/red-castle typecheck","exitCode":0,"durationMs":1,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"lint:apps/dev","status":"skipped","summary":"script missing"}
{"schema":"red.afk.validation.v1","name":"lint:apps/redskilled","status":"skipped","summary":"script missing"}
{"schema":"red.afk.validation.v1","name":"lint:packages/red-castle","status":"skipped","summary":"script missing"}
{"schema":"red.afk.validation.v1","name":"build:apps/dev","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3267-the-daemon-counts-open-work-holds-six-fr/apps/dev build","exitCode":0,"durationMs":3,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"build:apps/redskilled","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3267-the-daemon-counts-open-work-holds-six-fr/apps/redskilled build","exitCode":0,"durationMs":5,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"build:packages/red-castle","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3267-the-daemon-counts-open-work-holds-six-fr/packages/red-castle build","exitCode":0,"durationMs":10,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"typecheck:workspace","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3267-the-daemon-counts-open-work-holds-six-fr typecheck","exitCode":0,"durationMs":1,"summary":"command exited 0"}
🤖 classification override: the `on_feedback_classify` hook set the feedback failure to `semantic` (the classifier read it as `semantic`).
```

Closes #3267