### PR TITLE
fix: #3205 Nothing reports WHO spent the GitHub budget, so every routing proposal argues about an unattributed number

### DIFF
--- a/apps/dev/src/core/shipped-primitive-guard.ts
+++ b/apps/dev/src/core/shipped-primitive-guard.ts
@@ -78,6 +78,17 @@ export const SHIPPED_PRIMITIVES: readonly ShippedPrimitive[] = [
     consequence:
       "no daemon-side surface can show what an AFK Worker is logging: the herdr plugin and the VS Code extension report a Worker that declared no log path, and `redskilled statusline --verbose` has no second line to print",
   },
+  {
+    id: "github-spend-report",
+    what: "the durable report naming which operation and Worker spent each GitHub budget pool",
+    definedIn: "packages/github/attribution.ts",
+    // The awaited dispatch is the shipped surface, not merely a constructed
+    // ledger. The first implementation created and exported the ledger while no
+    // production caller read it, leaving the incident question unanswered.
+    enabler: /\bawait runGithubSpend\s*\(/,
+    consequence:
+      "the host can append GitHub spend observations but no operator surface can answer what spent the GraphQL budget in a window, so attribution survives only as unread local bytes",
+  },
 ];
 
 /** One file that references a primitive's enabler, and whether it is a test. */

--- a/apps/dev/tests/shipped-primitive-guard.test.ts
+++ b/apps/dev/tests/shipped-primitive-guard.test.ts
@@ -82,6 +82,19 @@ describe("the live tree enables every declared safety primitive (#2800)", () => 
       expect.arrayContaining(["apps/dev/src/runtime/git.ts", "apps/dev/src/runtime/gh/common.ts"]),
     );
   });
+
+  it("keeps the GitHub spend ledger reachable from a shipped report surface (#3205)", () => {
+    const declared = SHIPPED_PRIMITIVES.find((primitive) => primitive.id === "github-spend-report");
+    const callers = collectShippedPrimitiveCallers(readShippedPrimitiveFiles(ROOT));
+    const shipped = callers.filter(
+      (caller) => caller.primitiveId === "github-spend-report" && !caller.isTest,
+    );
+
+    expect(declared?.definedIn).toBe("packages/github/attribution.ts");
+    expect(shipped.map((caller) => caller.relativePath)).toEqual([
+      "apps/redskilled/src/cli.ts",
+    ]);
+  });
 });
 
 describe("the test-only shape is the failure (#2800)", () => {

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -48,6 +48,7 @@ import {
   createGithubAttributionLedger,
   createGithubBalanceTransport,
   type GithubAttributionLedger,
+  type GithubRateBudget,
 } from "@reddb-io/github";
 import { createGitHubActivityTransport } from "./repository-activity.js";
 import {
@@ -84,6 +85,7 @@ Commands:
   serve                 run the daemon in this process
   statusline [global]   render one agent-host status line
   dashboard [global]    render the host view a terminal can read
+  github-spend          report which operations spent GitHub budget
   unit                  install | uninstall | status — the optional supervisor
   provision             make this machine ready; --check is the read-only half
   reclaim               clear runtime dirs left by dead sessions
@@ -133,6 +135,15 @@ decision 1) — a density argument, never a second renderer.
 
 It always writes something and always exits 0: a dashboard that printed nothing
 is indistinguishable from a host with no Workers.`,
+  "github-spend": `Usage: redskilled github-spend [--pool <pool|all>] [--hours <n>]
+
+Reports what this host observed itself spending from GitHub's API budget,
+grouped by operation key and Worker. Defaults to the GraphQL pool over the last
+hour. This is durable process attribution, never GitHub's authoritative balance.
+
+  --pool <pool|all>  graphql (default), rest, search, or every pool
+  --hours <n>        positive number of hours ending now (default: 1)
+`,
   statusline: `Usage: redskilled statusline [global] [--verbose] [flags]
 
 Renders the status line the agent host prints verbatim. Config is read on this
@@ -376,9 +387,27 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
   }
 
   const { command, args } = routeCommand<
-    "serve" | "stop" | "host-state" | "statusline" | "dashboard" | "unit" | "provision" | "reclaim"
+    | "serve"
+    | "stop"
+    | "host-state"
+    | "statusline"
+    | "dashboard"
+    | "github-spend"
+    | "unit"
+    | "provision"
+    | "reclaim"
   >(argv, {
-    commands: { serve: {}, stop: {}, "host-state": {}, statusline: {}, dashboard: {}, unit: {}, provision: {}, reclaim: {} },
+    commands: {
+      serve: {},
+      stop: {},
+      "host-state": {},
+      statusline: {},
+      dashboard: {},
+      "github-spend": {},
+      unit: {},
+      provision: {},
+      reclaim: {},
+    },
     default: "host-state",
   });
 
@@ -473,6 +502,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
   if (command === "stop") return await runStop(args);
   if (command === "statusline") return await runStatusline(args);
   if (command === "dashboard") return await runDashboard(args);
+  if (command === "github-spend") return await runGithubSpend(args);
   if (command === "unit") return await runUnit(args);
 
   if (command === "provision") return await runProvision(args);
@@ -481,6 +511,70 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
   const state = await readRedskilledHostState(resolveRedskilledPaths());
   process.stdout.write(`${JSON.stringify(state, null, 2)}\n`);
   return 0;
+}
+
+const GITHUB_SPEND_FLAGS = {
+  pool: { kind: "value", coerce: (raw: string) => raw },
+  hours: { kind: "value", coerce: (raw: string) => Number(raw) },
+} as const;
+
+/**
+ * `redskilled github-spend` — the durable answer to "who spent GraphQL?".
+ *
+ * The report is intentionally read from the host lane instead of from daemon
+ * memory: an incident may restart the daemon, and the Worker-side `gh` boundary
+ * appends from separate processes. Its `origin` remains process attribution so
+ * no caller can mistake observed spend for the balance asked from GitHub.
+ */
+export async function runGithubSpend(
+  args: readonly string[],
+  io: {
+    readonly ledger?: GithubAttributionLedger;
+    readonly homeDir?: string;
+    readonly now?: () => string;
+    readonly write?: (text: string) => void;
+  } = {},
+): Promise<number> {
+  const { values } = parseFlags(args, GITHUB_SPEND_FLAGS, { unknownFlags: "error" });
+  const hours = values.hours ?? 1;
+  if (!Number.isFinite(hours) || hours <= 0) {
+    throw new Error(`redskilled github-spend --hours must be a positive number; received ${String(hours)}`);
+  }
+
+  const rawPool = values.pool ?? "graphql";
+  const pool = rawPool === "all" ? undefined : githubSpendPool(rawPool);
+  const to = (io.now ?? (() => new Date().toISOString()))();
+  const toMs = Date.parse(to);
+  if (!Number.isFinite(toMs)) throw new Error(`redskilled github-spend clock returned an invalid instant: ${to}`);
+  const from = new Date(toMs - hours * 60 * 60 * 1_000).toISOString();
+  const ledger = io.ledger ?? createGithubAttributionLedger({
+    path: join(redskilledHomeDir(io.homeDir ?? homedir()), "state", "github", "spend.toonl"),
+  });
+  const report = await ledger.report({ from, to, ...(pool === undefined ? {} : { pool }) });
+  (io.write ?? ((text: string) => process.stdout.write(text)))(`${encodeToon({
+    version: report.version,
+    origin: report.origin,
+    window: { from: report.window.from, to: report.window.to },
+    pool: report.pool,
+    total_count: report.total_count,
+    total_cost: report.total_cost,
+    operations: report.operations.map((operation) => ({
+      operation_key: operation.operation_key,
+      pool: operation.pool,
+      ...(operation.actor === undefined ? {} : { actor: operation.actor }),
+      count: operation.count,
+      cost: operation.cost,
+    })),
+    unreadable_records: report.unreadable_records,
+  })}\n`);
+  return 0;
+}
+
+function githubSpendPool(raw: string): GithubRateBudget {
+  if (raw === "graphql" || raw === "rest" || raw === "search") return raw;
+  throw new Error(
+    `redskilled github-spend --pool must be graphql, rest, search or all; received ${JSON.stringify(raw)}`,
+  );
 }
 
 const STOP_FLAGS = {

--- a/apps/redskilled/tests/github-spend-command.test.ts
+++ b/apps/redskilled/tests/github-spend-command.test.ts
@@ -1,0 +1,76 @@
+// The attribution ledger is only useful when a shipped surface reads it. This
+// proves the operator's incident question end to end: a new process opens the
+// durable lane and reports which Worker operations spent GraphQL in the last
+// hour, without presenting those observations as GitHub's authoritative balance.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createGithubAttributionLedger, routeGithubArgs } from "@reddb-io/github";
+import { decode } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runGithubSpend } from "../src/cli.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("redskilled github-spend", () => {
+  it("reports the last hour's GraphQL spend from a restarted durable ledger", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-github-spend-"));
+    roots.push(root);
+    const path = join(root, "spend.toonl");
+    const writer = createGithubAttributionLedger({ path });
+    await writer.record({
+      operation: routeGithubArgs(["issue", "list"]),
+      actor: "worker:wONE",
+      cost: 7,
+      observedAt: "2026-08-04T18:30:00.000Z",
+    });
+    await writer.record({
+      operation: routeGithubArgs(["issue", "view", "3205"]),
+      actor: "worker:wONE",
+      cost: 1,
+      observedAt: "2026-08-04T18:40:00.000Z",
+    });
+    await writer.record({
+      operation: routeGithubArgs(["pr", "list"]),
+      actor: "worker:wOLD",
+      cost: 99,
+      observedAt: "2026-08-04T17:59:59.999Z",
+    });
+
+    let printed = "";
+    const restarted = createGithubAttributionLedger({ path });
+    const code = await runGithubSpend([], {
+      ledger: restarted,
+      now: () => "2026-08-04T19:00:00.000Z",
+      write: (text) => { printed += text; },
+    });
+
+    expect(code).toBe(0);
+    expect(decode(printed)).toEqual({
+      version: 1,
+      origin: "process-attribution",
+      window: {
+        from: "2026-08-04T18:00:00.000Z",
+        to: "2026-08-04T19:00:00.000Z",
+      },
+      pool: "graphql",
+      total_count: 1,
+      total_cost: 7,
+      operations: [
+        {
+          operation_key: "issue list",
+          pool: "graphql",
+          actor: "worker:wONE",
+          count: 1,
+          cost: 7,
+        },
+      ],
+      unreadable_records: 0,
+    });
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3205. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3205

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788465916&installation_model_id=20659&pr_number=3278&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3278&signature=5f5085f8830bb823fe8676f0cb7480f14cd95efb2370ca401d7856f37e6ce818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->