### PR TITLE
chore: #3280 A wedged test suite sleeps for an hour while every liveness surface reads it as a healthy run

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -376,7 +376,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
       if (current.attemptDir !== "") {
         const line = waiting
           ? `⏳ /afk gate: waiting on ${notice.subject} (pid ${notice.pid}).`
-          : `✅ /afk gate: ${notice.subject} exited (pid ${notice.pid}).`;
+          : notice.state === "stalled"
+            ? `⛔ /afk gate: reaped stalled ${notice.subject} (pid ${notice.pid}); ` +
+              `${notice.infraEvidence?.cpuDeltaMs ?? 0}ms CPU over ` +
+              `${notice.infraEvidence?.sampleWindowMs ?? 0}ms.`
+            : `✅ /afk gate: ${notice.subject} exited (pid ${notice.pid}).`;
         gateWaitPublication = gateWaitPublication.then(async () => {
           await fsx.appendLine(join(current.attemptDir, "afk.log"), line);
           await updateState(workerStatePath(current.attemptDir), {
@@ -396,6 +400,10 @@ export async function runCommand(options: RunOptions): Promise<number> {
             started_at: notice.startedAt,
             deadline: notice.deadline,
             escalation: notice.escalation,
+            infra: notice.infraEvidence?.kind ?? "",
+            cpu_delta_ms: notice.infraEvidence?.cpuDeltaMs ?? 0,
+            sample_window_ms: notice.infraEvidence?.sampleWindowMs ?? 0,
+            wall_time_ms: notice.infraEvidence?.wallTimeMs ?? 0,
           });
         }).catch(() => {});
       }

--- a/apps/dev/src/core/backpressure.ts
+++ b/apps/dev/src/core/backpressure.ts
@@ -123,10 +123,20 @@ export async function runBackpressure(
     // no useful captured output — give the operator an explicit timed-out
     // summary instead of the generic `command exited non-zero`.
     const summary =
-      result.code === KILLED_EXIT_CODE
+      result.infraEvidence?.kind === "stall"
+        ? outputSummary(status, `${result.stdout}${result.stderr}`)
+        : result.code === KILLED_EXIT_CODE
         ? `command timed out after ${timeoutMs}ms`
         : outputSummary(status, `${result.stdout}${result.stderr}`);
-    const record = buildValidationRecord({ name, status, command, exitCode: result.code, durationMs, summary });
+    const record = buildValidationRecord({
+      name,
+      status,
+      command,
+      exitCode: result.code,
+      durationMs,
+      summary,
+      infra: result.infraEvidence?.kind,
+    });
     checks.push({ name, command, status, record });
     sidecar.push(formatValidationLine(record));
   }

--- a/apps/dev/src/core/declared-wait-guard.ts
+++ b/apps/dev/src/core/declared-wait-guard.ts
@@ -645,6 +645,19 @@ export const DECLARED_WAITS: readonly DeclaredWait[] = [
     heartbeat: { silent: "a sub-second drain bounded by two fixed try counts; the boolean IS the report" },
   },
   {
+    path: "apps/dev/src/runtime/exec.ts",
+    fn: "monitorCpuStall",
+    subject: "the validation process group consuming CPU after its normal wall-time envelope",
+    deadline:
+      "one `sampleIntervalMs` window after `minWallTimeMs`; production defaults to 30 seconds after 20 minutes",
+    escalation:
+      "terminates the process group and returns typed `stall` infrastructure evidence to the validation sidecar",
+    heartbeat: {
+      silent:
+        "the enclosing gate-child wait already publishes the pid and subject; this sampler publishes its terminal stall evidence through that same sink",
+    },
+  },
+  {
     path: "apps/dev/src/runtime/gh/quota.ts",
     fn: "withGhQuotaBackoff",
     subject: "the GitHub rate-limit window reopening",

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -49,6 +49,13 @@ export interface ExecResult {
   code: number;
   stdout: string;
   stderr: string;
+  /** Typed infrastructure evidence from the real validation process boundary. */
+  infraEvidence?: {
+    kind: "stall";
+    wallTimeMs: number;
+    sampleWindowMs: number;
+    cpuDeltaMs: number;
+  };
   /**
    * The ABSOLUTE directory the command actually ran in, when the executor
    * rewrote the `-C` token (#3041). The AFK gate is posed with a branch NAME;
@@ -236,6 +243,8 @@ export interface ValidationRecord {
    * millisecond count, which is how the #3027 phantom survived a whole park.
    */
   suspectInfra?: true;
+  /** The command ran, but infrastructure reaped it after observing no progress. */
+  infra?: "stall";
 }
 
 /**
@@ -379,6 +388,7 @@ export function buildValidationRecord(input: {
   summary?: string;
   setup?: string;
   suspectInfra?: boolean;
+  infra?: "stall";
 }): ValidationRecord {
   const record: ValidationRecord = {
     schema: VALIDATION_SCHEMA,
@@ -391,6 +401,7 @@ export function buildValidationRecord(input: {
   if (input.summary !== undefined && input.summary !== "") record.summary = input.summary;
   if (input.setup !== undefined && input.setup !== "") record.setup = input.setup;
   if (input.suspectInfra === true) record.suspectInfra = true;
+  if (input.infra !== undefined) record.infra = input.infra;
   return record;
 }
 
@@ -408,6 +419,7 @@ function buildRanRecord(input: {
   durationMs: number;
   summary: string;
   setup?: string;
+  infra?: "stall";
 }): ValidationRecord {
   const suspect = isSuspectInfraFailure({ status: input.status, durationMs: input.durationMs });
   const summary = suspect
@@ -482,6 +494,7 @@ export function isInfraValidationFailure(checks: readonly ClassifiableCheck[]): 
     if (check.status !== "failed") continue;
     const exitCode = check.record.exitCode;
     if (exitCode === 0) continue;
+    if (check.record.infra === "stall") return true;
     if (exitCode === 137) return true;
     const summary = check.record.summary ?? "";
     if (
@@ -1018,6 +1031,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
         durationMs,
         summary: outputSummary(status, joinCommandOutput(result.stdout, result.stderr)),
         setup: result.setup,
+        infra: result.infraEvidence?.kind,
       });
       push({ name, script: "test", label: "operator", scope: "", status, record });
     }
@@ -1116,6 +1130,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
         durationMs,
         summary,
         setup: result.setup,
+        infra: result.infraEvidence?.kind,
       });
       push({ name, script, label, scope, status, record });
     }
@@ -1149,6 +1164,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       durationMs,
       summary,
       setup: result.setup,
+      infra: result.infraEvidence?.kind,
     });
     push({ name, script: "typecheck", label, scope, status, record });
   }
@@ -1199,6 +1215,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
         durationMs,
         summary,
         setup: result.setup,
+        infra: result.infraEvidence?.kind,
       });
       push({ name: suite.name, script: "test", label, scope: run.scope, runScript: run.script, status, record });
     }
@@ -1206,7 +1223,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
 
   // AFK runner improvement: baseline probe for pre-existing failures. Only
   // triggered when the gate failed AND a baseline worktree was supplied.
-  if (failed && baselineWorktree) {
+  if (failed && baselineWorktree && !isInfraValidationFailure(checks)) {
     const failing = checks
       .filter((c) => c.status === "failed")
       .map((c) => ({ name: c.name, script: c.script, scope: c.scope, runScript: c.runScript }));
@@ -1236,6 +1253,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
         exitCode: check.record.exitCode,
         durationMs: check.record.durationMs,
         summary: baselineComparisonSummary(evidence?.summary),
+        infra: check.record.infra,
       });
       checks[i] = { ...check, record: newRecord };
       sidecar[i] = formatValidationLine(newRecord);

--- a/apps/dev/src/runtime/exec.ts
+++ b/apps/dev/src/runtime/exec.ts
@@ -8,12 +8,28 @@
 // head so call sites read as argv arrays.
 
 import { spawn } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
 
 const PROCESS_GROUP_POLL_MS = 50;
 const PROCESS_GROUP_GRACE_TRIES = 10;
 const PROCESS_GROUP_KILL_TRIES = 20;
 
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number, signal?: AbortSignal): Promise<boolean> =>
+  new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", abort);
+      resolve(true);
+    }, ms);
+    const abort = (): void => {
+      clearTimeout(timer);
+      resolve(false);
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
 
 function processGroupAlive(pgid: number): boolean {
   try {
@@ -50,7 +66,32 @@ export interface ExecOutput {
   code: number;
   stdout: string;
   stderr: string;
+  /** Typed infrastructure evidence emitted when validation made no CPU progress. */
+  infraEvidence?: ValidationInfraEvidence;
 }
+
+export interface ValidationInfraEvidence {
+  kind: "stall";
+  wallTimeMs: number;
+  sampleWindowMs: number;
+  cpuDeltaMs: number;
+}
+
+export interface ValidationStallDetection {
+  /** Do not judge CPU idleness until the command exceeds its normal envelope. */
+  minWallTimeMs: number;
+  /** One CPU-progress observation window. */
+  sampleIntervalMs: number;
+  /** CPU growth at or below this value is treated as no progress. */
+  idleCpuThresholdMs: number;
+}
+
+/** Production validation envelope: 20 minutes, then one 30-second CPU window. */
+export const DEFAULT_VALIDATION_STALL_DETECTION: Readonly<ValidationStallDetection> = Object.freeze({
+  minWallTimeMs: 20 * 60_000,
+  sampleIntervalMs: 30_000,
+  idleCpuThresholdMs: 5,
+});
 
 export interface ExecOptions {
   cwd?: string;
@@ -70,6 +111,79 @@ export interface ExecOptions {
    * exit. Callback failures are observability failures and never affect the
    * child. */
   onSpawn?: (pid: number) => void;
+  /** Linux process-group CPU-idle detector, enabled only for validation children. */
+  stallDetection?: ValidationStallDetection;
+}
+
+/** Linux exposes process CPU in USER_HZ ticks; USER_HZ is 100 on supported hosts. */
+const LINUX_USER_TICK_MS = 10;
+
+/** Aggregate current CPU for every process in the detached validation group. */
+function processGroupCpuMs(pgid: number): number | null {
+  if (process.platform !== "linux") return null;
+  let ticks = 0;
+  let seen = false;
+  let entries: string[];
+  try {
+    entries = readdirSync("/proc");
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue;
+    try {
+      const stat = readFileSync(`/proc/${entry}/stat`, "utf8");
+      const close = stat.lastIndexOf(")");
+      if (close < 0) continue;
+      const fields = stat.slice(close + 2).trim().split(/\s+/);
+      if (Number(fields[2]) !== pgid) continue;
+      const utime = Number(fields[11]);
+      const stime = Number(fields[12]);
+      if (!Number.isFinite(utime) || !Number.isFinite(stime)) continue;
+      ticks += utime + stime;
+      seen = true;
+    } catch {
+      // A process can exit between the /proc directory read and its stat read.
+    }
+  }
+  return seen ? ticks * LINUX_USER_TICK_MS : null;
+}
+
+/**
+ * Watch one detached validation process group until it exits or exceeds the
+ * normal wall envelope without consuming CPU for a complete sampling window.
+ */
+async function monitorCpuStall(
+  pgid: number,
+  options: ValidationStallDetection,
+  signal: AbortSignal,
+  onStall: (evidence: ValidationInfraEvidence) => void,
+): Promise<void> {
+  const started = Date.now();
+  let previousCpuMs = processGroupCpuMs(pgid);
+  let previousSampleAt = started;
+  while (!signal.aborted) {
+    const elapsed = await sleep(options.sampleIntervalMs, signal);
+    if (!elapsed || signal.aborted) return;
+    const sampledAt = Date.now();
+    const cpuMs = processGroupCpuMs(pgid);
+    if (cpuMs === null || previousCpuMs === null) {
+      previousCpuMs = cpuMs;
+      previousSampleAt = sampledAt;
+      continue;
+    }
+    const wallTimeMs = sampledAt - started;
+    const sampleWindowMs = sampledAt - previousSampleAt;
+    const cpuDeltaMs = Math.max(0, cpuMs - previousCpuMs);
+    const sampleStartedAfterEnvelope = previousSampleAt - started >= options.minWallTimeMs;
+    previousCpuMs = cpuMs;
+    previousSampleAt = sampledAt;
+    if (wallTimeMs < options.minWallTimeMs) continue;
+    if (!sampleStartedAfterEnvelope) continue;
+    if (cpuDeltaMs > options.idleCpuThresholdMs) continue;
+    onStall({ kind: "stall", wallTimeMs, sampleWindowMs, cpuDeltaMs });
+    return;
+  }
 }
 
 /**
@@ -145,8 +259,10 @@ export function execTool(cmd: string, args: readonly string[], opts: ExecOptions
     let stderrBytes = 0;
     let overflow = false;
     let timedOut = false;
+    let infraEvidence: ValidationInfraEvidence | undefined;
     let spawnError: Error | undefined;
     let termination: Promise<boolean> | undefined;
+    const monitorAbort = new AbortController();
 
     const terminate = (): Promise<boolean> => {
       if (termination) return termination;
@@ -158,6 +274,17 @@ export function execTool(cmd: string, args: readonly string[], opts: ExecOptions
       termination = terminateProcessGroup(child.pid);
       return termination;
     };
+
+    if (
+      child.pid !== undefined &&
+      process.platform === "linux" &&
+      opts.stallDetection !== undefined
+    ) {
+      void monitorCpuStall(child.pid, opts.stallDetection, monitorAbort.signal, (evidence) => {
+        infraEvidence = evidence;
+        void terminate();
+      });
+    }
 
     const capture = (stream: "stdout" | "stderr", chunk: Buffer): void => {
       const used = stream === "stdout" ? stdoutBytes : stderrBytes;
@@ -189,6 +316,7 @@ export function execTool(cmd: string, args: readonly string[], opts: ExecOptions
       : undefined;
 
     child.on("close", async (code, signal) => {
+      monitorAbort.abort();
       if (timeout) clearTimeout(timeout);
       const cleaned = signal !== null
         ? await terminate()
@@ -217,10 +345,15 @@ export function execTool(cmd: string, args: readonly string[], opts: ExecOptions
         return;
       }
       if (timedOut || signal !== null) {
+        const stallMessage = infraEvidence
+          ? `validation child stalled: ${infraEvidence.cpuDeltaMs}ms CPU over ` +
+            `${infraEvidence.sampleWindowMs}ms while wall time reached ${infraEvidence.wallTimeMs}ms`
+          : undefined;
         resolve({
           code: KILLED_EXIT_CODE,
           stdout,
-          stderr: stderr || `command terminated by ${signal ?? "timeout"}`,
+          stderr: stallMessage ?? (stderr || `command terminated by ${signal ?? "timeout"}`),
+          ...(infraEvidence === undefined ? {} : { infraEvidence }),
         });
         return;
       }

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -59,7 +59,14 @@ import {
   readRedskilledHostConfig,
   resolveRedskilledHostSettings,
 } from "@reddb-io/redskilled/host-config";
-import { execTool, pnpm as runPnpm, type ExecOptions, type ExecOutput } from "./exec.js";
+import {
+  DEFAULT_VALIDATION_STALL_DETECTION,
+  execTool,
+  pnpm as runPnpm,
+  type ExecOptions,
+  type ExecOutput,
+  type ValidationStallDetection,
+} from "./exec.js";
 import * as gitx from "./git.js";
 import { createPathLock, createPathSemaphore } from "./land-lock.js";
 import type { LandLockWaitInfo } from "../core/land-lock.js";
@@ -236,13 +243,14 @@ export type LockWaitSink = (notice: LockWaitNotice) => void;
  * escalation deliberately match the declared-wait vocabulary; pid + start are
  * the process facts only the spawning Worker can publish. */
 export interface GateWaitNotice {
-  state: "waiting" | "completed";
+  state: "waiting" | "completed" | "stalled";
   kind: "gate";
   subject: string;
   pid: number;
   startedAt: string;
   deadline: string;
   escalation: string;
+  infraEvidence?: ExecOutput["infraEvidence"];
 }
 
 export type GateWaitSink = (notice: GateWaitNotice) => void;
@@ -509,6 +517,8 @@ export interface FeedbackWorktreeOptions {
   onGateWait?: GateWaitSink;
   /** Clock for the child wait's own age anchor. */
   nowIso?: () => string;
+  /** CPU-idle detection envelope for real validation process groups. */
+  stallDetection?: ValidationStallDetection;
 }
 
 /**
@@ -531,6 +541,7 @@ export function makeFeedbackWorktree(
   const onLockWait = options.onLockWait;
   const onGateWait = options.onGateWait;
   const nowIso = options.nowIso ?? (() => new Date().toISOString());
+  const stallDetection = options.stallDetection ?? DEFAULT_VALIDATION_STALL_DETECTION;
   const gitCtx: gitx.GitContext = { cwd: root };
   // branch -> resolved checkout path, or null when setup failed (block all runs).
   const resolved = new Map<string, string | null>();
@@ -576,7 +587,7 @@ export function makeFeedbackWorktree(
       }
     };
     try {
-      return await run((pid) => {
+      const result = await run((pid) => {
         active = {
           kind: "gate",
           subject,
@@ -587,6 +598,16 @@ export function makeFeedbackWorktree(
         };
         publish({ state: "waiting", ...active });
       });
+      const completed = active as Omit<GateWaitNotice, "state"> | null;
+      if (completed !== null) {
+        publish(
+          result.infraEvidence?.kind === "stall"
+            ? { state: "stalled", ...completed, infraEvidence: result.infraEvidence }
+            : { state: "completed", ...completed },
+        );
+        active = null;
+      }
+      return result;
     } finally {
       const completed = active as Omit<GateWaitNotice, "state"> | null;
       if (completed !== null) publish({ state: "completed", ...completed });
@@ -775,7 +796,7 @@ export function makeFeedbackWorktree(
     if (setupCommands.length > 0) {
       for (const command of setupCommands) {
         const result = await runGateChild(`setup: ${command}`, (onSpawn) =>
-          io.exec("sh", ["-c", command], { cwd: dest, onSpawn })
+          io.exec("sh", ["-c", command], { cwd: dest, onSpawn, stallDetection })
         );
         if (result.code !== 0) {
           setupFailure = { command, result };
@@ -790,7 +811,7 @@ export function makeFeedbackWorktree(
       const env = { ...process.env, LEFTHOOK: "0", HUSKY: "0" };
       const command = "pnpm install --frozen-lockfile";
       let result = await runGateChild("pnpm install", (onSpawn) =>
-        io.pnpm(["install", "--frozen-lockfile"], { cwd: dest, env, onSpawn })
+        io.pnpm(["install", "--frozen-lockfile"], { cwd: dest, env, onSpawn, stallDetection })
       );
       if (result.code !== 0 && refusedCustomHooksPath(result.stderr)) {
         const retryCommand = `${command} --ignore-scripts`;
@@ -799,6 +820,7 @@ export function makeFeedbackWorktree(
             cwd: dest,
             env,
             onSpawn,
+            stallDetection,
           })
         );
         if (result.code === 0) {
@@ -900,7 +922,7 @@ export function makeFeedbackWorktree(
       const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
       const r = await runValidationCommand(() =>
         runGateChild(`pnpm ${rest[0] ?? "validation"}`, (onSpawn) =>
-          io.pnpm(["-C", rewritten, ...rest], { cwd: root, env, onSpawn })
+          io.pnpm(["-C", rewritten, ...rest], { cwd: root, env, onSpawn, stallDetection })
         )
       );
       // Report the ABSOLUTE directory the command really ran in (#3041). The
@@ -912,6 +934,7 @@ export function makeFeedbackWorktree(
         code: r.code,
         stdout: r.stdout,
         stderr: r.stderr,
+        ...(r.infraEvidence === undefined ? {} : { infraEvidence: r.infraEvidence }),
         commandDir: rewritten,
         ...(setupRecord.has(branch) ? { setup: setupRecord.get(branch)! } : {}),
       };
@@ -919,10 +942,15 @@ export function makeFeedbackWorktree(
     const head = args[0] === "pnpm" ? args.slice(1) : args;
     const r = await runValidationCommand(() =>
       runGateChild(`pnpm ${head[0] ?? "validation"}`, (onSpawn) =>
-        io.pnpm(head, { cwd: root, env, onSpawn })
+        io.pnpm(head, { cwd: root, env, onSpawn, stallDetection })
       )
     );
-    return { code: r.code, stdout: r.stdout, stderr: r.stderr };
+    return {
+      code: r.code,
+      stdout: r.stdout,
+      stderr: r.stderr,
+      ...(r.infraEvidence === undefined ? {} : { infraEvidence: r.infraEvidence }),
+    };
   };
 
   // Backpressure commands are operator-declared shell strings (e.g. `npm run
@@ -941,10 +969,15 @@ export function makeFeedbackWorktree(
     const env = buildFeedbackSubprocessEnv(process.env, resourceBudget);
     const r = await runValidationCommand(() =>
       runGateChild("sh backpressure", (onSpawn) =>
-        io.exec("sh", ["-c", command], { cwd: dir, timeoutMs, env, onSpawn })
+        io.exec("sh", ["-c", command], { cwd: dir, timeoutMs, env, onSpawn, stallDetection })
       )
     );
-    return { code: r.code, stdout: r.stdout, stderr: r.stderr };
+    return {
+      code: r.code,
+      stdout: r.stdout,
+      stderr: r.stderr,
+      ...(r.infraEvidence === undefined ? {} : { infraEvidence: r.infraEvidence }),
+    };
   };
 
   // Post-attempt-format commands run in the worker-branch checkout (same

--- a/apps/dev/tests/backpressure.test.ts
+++ b/apps/dev/tests/backpressure.test.ts
@@ -187,6 +187,36 @@ describe("runBackpressure", () => {
     // The earlier command still passed — only the hung one blocks.
     expect(result.checks.find((c) => c.name === "backpressure:npm run test")?.status).toBe("passed");
   });
+
+  it("distinguishes a CPU stall reap from the ordinary wall-time deadline (#3280)", async () => {
+    const { exec } = fakeExec([
+      {
+        match: (command) => command === "pnpm test",
+        result: {
+          code: KILLED_EXIT_CODE,
+          stderr: "validation child stalled: 0ms CPU over 30000ms",
+          infraEvidence: {
+            kind: "stall",
+            wallTimeMs: 1_230_000,
+            sampleWindowMs: 30_000,
+            cpuDeltaMs: 0,
+          },
+        },
+      },
+    ]);
+
+    const result = await runBackpressure(exec, {
+      worktree: "/wt",
+      commands: ["pnpm test"],
+      now: fakeClock(1_230_000),
+    });
+
+    expect(result.checks[0]?.record).toMatchObject({
+      status: "failed",
+      infra: "stall",
+      summary: "validation child stalled: 0ms CPU over 30000ms",
+    });
+  });
 });
 
 describe("renderBackpressureReviewBody (#1279)", () => {

--- a/apps/dev/tests/exec.test.ts
+++ b/apps/dev/tests/exec.test.ts
@@ -46,6 +46,50 @@ describe("execTool", () => {
     expect(r.code).toBe(KILLED_EXIT_CODE);
   });
 
+  it.skipIf(process.platform !== "linux")(
+    "kills a CPU-idle validation child within one sampling window after its normal envelope (#3280)",
+    async () => {
+      const started = Date.now();
+      const r = await execTool("sh", ["-c", "sleep 60"], {
+        stallDetection: {
+          minWallTimeMs: 100,
+          sampleIntervalMs: 100,
+          idleCpuThresholdMs: 1,
+        },
+      });
+
+      expect(Date.now() - started).toBeLessThan(1_500);
+      expect(r.code).toBe(KILLED_EXIT_CODE);
+      expect(r.infraEvidence).toMatchObject({
+        kind: "stall",
+        cpuDeltaMs: 0,
+      });
+      expect(r.infraEvidence!.sampleWindowMs).toBeGreaterThanOrEqual(100);
+      expect(r.infraEvidence!.wallTimeMs).toBeGreaterThanOrEqual(200);
+      expect(r.stderr).toContain("validation child stalled");
+    },
+  );
+
+  it.skipIf(process.platform !== "linux")(
+    "leaves a slow CPU-active validation child alive (#3280)",
+    async () => {
+      const r = await execTool(
+        process.execPath,
+        ["-e", "const end = Date.now() + 450; while (Date.now() < end) {}"],
+        {
+          stallDetection: {
+            minWallTimeMs: 100,
+            sampleIntervalMs: 100,
+            idleCpuThresholdMs: 1,
+          },
+        },
+      );
+
+      expect(r.code).toBe(0);
+      expect(r.infraEvidence).toBeUndefined();
+    },
+  );
+
   it.skipIf(process.platform === "win32")("reaps fork children when a gate parent times out", async () => {
     const r = await execTool(
       "sh",

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -7,7 +7,9 @@ import {
   resolveCheckoutDir,
   splitBranchDir,
   type FeedbackWorktreeIO,
+  type GateWaitNotice,
 } from "../src/runtime/feedback-worktree.js";
+import { DEFAULT_VALIDATION_STALL_DETECTION } from "../src/runtime/exec.js";
 
 // A monorepo's package dirs are full root-relative paths. The probe is true for
 // exactly these and nothing else (mirroring the real accessSync layout check).
@@ -1182,7 +1184,7 @@ describe("the gate's lock waits reach the caller's sink (#2985)", () => {
 
 describe("the gate child declares what the Worker awaits (#3182)", () => {
   it("publishes each child pid, safe command subject, start, deadline, escalation, and completion", async () => {
-    const notices: Array<Record<string, unknown>> = [];
+    const notices: GateWaitNotice[] = [];
     let nextPid = 7000;
     const io: FeedbackWorktreeIO = {
       worktreeAdd: async () => ({ ok: true, stderr: "" }),
@@ -1202,8 +1204,8 @@ describe("the gate child declares what the Worker awaits (#3182)", () => {
     const fb = makeFeedbackWorktree("/repo", "/repo/.red/tmp/feedback", io, {
       cacheEnabled: false,
       nowIso: () => "2026-08-03T18:00:00.000Z",
-      onGateWait: (notice: Record<string, unknown>) => notices.push(notice),
-    } as never);
+      onGateWait: (notice) => notices.push(notice),
+    });
 
     await fb.pnpm(["pnpm", "-C", "afk/wAAAA/3182-x", "test"]);
 
@@ -1245,5 +1247,54 @@ describe("the gate child declares what the Worker awaits (#3182)", () => {
         escalation: "fail the validation stage",
       },
     ]);
+  });
+
+  it("publishes terminal stall evidence from the default validation detector (#3280)", async () => {
+    const notices: GateWaitNotice[] = [];
+    const detectorOptions: unknown[] = [];
+    let call = 0;
+    const evidence = {
+      kind: "stall" as const,
+      wallTimeMs: 1_230_000,
+      sampleWindowMs: 30_000,
+      cpuDeltaMs: 0,
+    };
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async () => ({ ok: true }),
+      worktreeRemove: async () => {},
+      branchHead: async () => null,
+      worktreeHead: async () => null,
+      rebase: async () => ({ ok: true }),
+      pnpm: async (_args, opts) => {
+        detectorOptions.push(opts.stallDetection);
+        opts.onSpawn?.(7100 + ++call);
+        return call === 1
+          ? { code: 0, stdout: "", stderr: "" }
+          : {
+              code: 124,
+              stdout: "",
+              stderr: "validation child stalled",
+              infraEvidence: evidence,
+            };
+      },
+      exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+    };
+    const fb = makeFeedbackWorktree("/repo", "/repo/.red/tmp/feedback", io, {
+      cacheEnabled: false,
+      onGateWait: (notice) => notices.push(notice),
+    });
+
+    const result = await fb.pnpm(["pnpm", "-C", "afk/wAAAA/3280-x", "test"]);
+
+    expect(detectorOptions).toEqual([
+      DEFAULT_VALIDATION_STALL_DETECTION,
+      DEFAULT_VALIDATION_STALL_DETECTION,
+    ]);
+    expect(result.infraEvidence).toEqual(evidence);
+    expect(notices.at(-1)).toMatchObject({
+      state: "stalled",
+      subject: "pnpm test",
+      infraEvidence: evidence,
+    });
   });
 });

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -238,6 +238,43 @@ describe("runFeedback", () => {
     expect(test?.record.suspectInfra).toBe(true);
   });
 
+  it("records a reaped CPU-idle child as stall infra evidence, not a branch verdict (#3280)", async () => {
+    const layout = fakeLayout({
+      packages: ["apps/dev"],
+      scripts: { "apps/dev": ["test"] },
+    });
+    const { exec, calls } = fakeExec([
+      {
+        match: (a) => a.includes("test"),
+        result: {
+          code: 124,
+          stderr: "validation child stalled: 0ms CPU over 30000ms while wall time reached 1200000ms",
+          infraEvidence: {
+            kind: "stall",
+            wallTimeMs: 1_200_000,
+            sampleWindowMs: 30_000,
+            cpuDeltaMs: 0,
+          },
+        },
+      },
+    ]);
+    const result = await runFeedback(exec, {
+      worktree: "afk/3280-stalled-suite",
+      worktreeKind: "branch",
+      scopes: ["apps/dev"],
+      layout,
+      now: fakeClock(1_200_000),
+      baselineWorktree: "origin/main",
+    });
+
+    const check = result.checks.find((entry) => entry.name === "test:apps/dev");
+    expect(check?.record.infra).toBe("stall");
+    expect(check?.record.suspectInfra).toBeUndefined();
+    expect(check?.record.summary).toContain("validation child stalled");
+    expect(isInfraFeedbackFailure(result)).toBe(true);
+    expect(calls).toHaveLength(1);
+  });
+
   it("produces the exact red.afk.validation.v1 sidecar record shape", async () => {
     const layout = fakeLayout({
       packages: ["plugins/memory"],

--- a/packaging/pi/dev/skills/engineering/afk/docs/ENVELOPE.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/ENVELOPE.md
@@ -82,6 +82,10 @@ Fields:
 - `status`: `passed`, `failed`, or `skipped`.
 - `durationMs`: command duration when a command ran.
 - `summary`: short relevant output/error summary, or a skip reason.
+- `infra`: typed infrastructure evidence when the command did not produce a
+  branch verdict. `stall` means the validation process group exceeded its normal
+  wall-time envelope and consumed no CPU for a complete sampling window before
+  the gate reaped it.
 
 The Memory attempt writer only consumes this structured sidecar after parsing it
 as JSON. It must not derive validation graph nodes by parsing free-form stdout,

--- a/plugins/dev/skills/engineering/afk/docs/ENVELOPE.md
+++ b/plugins/dev/skills/engineering/afk/docs/ENVELOPE.md
@@ -82,6 +82,10 @@ Fields:
 - `status`: `passed`, `failed`, or `skipped`.
 - `durationMs`: command duration when a command ran.
 - `summary`: short relevant output/error summary, or a skip reason.
+- `infra`: typed infrastructure evidence when the command did not produce a
+  branch verdict. `stall` means the validation process group exceeded its normal
+  wall-time envelope and consumed no CPU for a complete sampling window before
+  the gate reaped it.
 
 The Memory attempt writer only consumes this structured sidecar after parsing it
 as JSON. It must not derive validation graph nodes by parsing free-form stdout,


### PR DESCRIPTION
Automated AFK landing for #3280. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3280

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788472171&installation_model_id=20659&pr_number=3290&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3290&signature=fa66a0aaa9ea68992c8fbfd4fde2779517879bb5ffe7848771c544dfc9bb32df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->