### PR TITLE
chore: #3284 The moments declaration surface: afk.validation.{iteration,post_done,landing} parses, validates, and reads the legacy knobs as deprecated aliases

### DIFF
--- a/.changeset/calm-validation-moments.md
+++ b/.changeset/calm-validation-moments.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": minor
+---
+
+Expose ordered AFK Validation moment declarations for iteration, post-DONE, and Landing, with one-release warnings and compatibility contributions from the legacy validation knobs.

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -14,7 +14,18 @@ import * as fsx from "../../runtime/fs.js";
 import type { GhContext } from "../../runtime/gh.js";
 import type { GitContext } from "../../runtime/git.js";
 import { execTool, type ExecFn } from "../../runtime/exec.js";
-import { getConfig, loadConfig, readBackpressure, readFeedbackCommands, readPostWorkerFormat, readValidationResourceBudget, resolveTier, resolveCiTimeoutSeconds, resolveMergeQueueTimeoutSeconds } from "../../core/config.js";
+import {
+  getConfig,
+  loadConfig,
+  readBackpressure,
+  readFeedbackCommands,
+  readPostWorkerFormat,
+  readValidationMoments,
+  readValidationResourceBudget,
+  resolveTier,
+  resolveCiTimeoutSeconds,
+  resolveMergeQueueTimeoutSeconds,
+} from "../../core/config.js";
 import {
   makeExtractAdversarialReview,
   resolveAdversarialReviewConfig,
@@ -304,6 +315,7 @@ export function buildProcessDeps({
     // worktree manager materialises it and rebases pnpm/layout onto it.
     pnpm: feedback.pnpm,
     validationResourceBudget: readValidationResourceBudget(config),
+    validationMoments: readValidationMoments(config),
     // The gate's proof that a declared validation worktree is really there
     // (#3041): a landing worktree that vanished refuses as an infrastructure
     // error instead of composing commands against a path that resolves nowhere.

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -618,7 +618,8 @@ export function parseConfigYaml(text: string): ConfigValues {
     }
   }
 
-  return out;
+  validateValidationMomentShapes(out);
+  return ConfigValuesSchema.parse(out);
 }
 
 /** Injectable file reader. Returns the file's text, or `undefined` if absent. */
@@ -766,6 +767,17 @@ export function auditConfigLoad(path: string, options: LoadConfigOptions = {}): 
       gateClosed: false,
       retiredKeys: [],
     };
+  }
+
+  const validationMomentAliases = ["afk.feedback.commands", "afk.backpressure"] as const;
+  for (const alias of validationMomentAliases) {
+    const spellings = [alias, `plugins.dev.${alias}`];
+    if (Object.keys(parsed).some((key) => spellings.some((spelling) => key === spelling || key.startsWith(`${spelling}.`)))) {
+      warn(
+        `[afk:config] warn: \`${alias}\` is deprecated; declare its commands under ` +
+          "`afk.validation.post_done` instead",
+      );
+    }
   }
 
   const misplacedHostKeys = Object.keys(parsed)
@@ -1034,6 +1046,76 @@ export function readFeedbackCommands(values: ConfigValues): string[] | undefined
   if (scalar === undefined) return undefined;
   if (scalar.trim() === "[]" || scalar.trim() === "") return [];
   return [scalar];
+}
+
+export const VALIDATION_MOMENTS = ["iteration", "post_done", "landing"] as const;
+export type ValidationMoment = (typeof VALIDATION_MOMENTS)[number];
+
+/**
+ * The final product release allowed to read the ADR 0135 legacy aliases.
+ * Do not advance this constant: the live-version test deliberately fails on
+ * the next release so the aliases and their warnings are removed together.
+ */
+export const VALIDATION_MOMENT_ALIASES_LAST_RELEASE = "3.5.0";
+
+export const ValidationMomentsSchema = z.object({
+  iteration: z.array(z.string()).optional(),
+  post_done: z.array(z.string()).optional(),
+  landing: z.array(z.string()).optional(),
+});
+export type ValidationMoments = z.infer<typeof ValidationMomentsSchema>;
+
+function validateValidationMomentShapes(values: ConfigValues): void {
+  for (const root of ["afk.validation", "plugins.dev.afk.validation"]) {
+    for (const moment of VALIDATION_MOMENTS) {
+      const key = `${root}.${moment}`;
+      const scalar = values[key];
+      const descendants = Object.keys(values).filter((candidate) => candidate.startsWith(`${key}.`));
+      const hasOnlyIndexedItems = descendants.every((candidate) => /^\d+$/.test(candidate.slice(key.length + 1)));
+      if ((scalar !== undefined && scalar.trim() !== "[]") || !hasOnlyIndexedItems) {
+        throw new MalformedConfigError(`invalid config shape: \`${key}\` must be an ordered list of commands`);
+      }
+    }
+  }
+}
+
+function readValidationMoment(values: ConfigValues, moment: ValidationMoment): string[] | undefined {
+  const prefix = `afk.validation.${moment}`;
+  const commands: string[] = [];
+  let declared = false;
+  for (let i = 0; ; i++) {
+    const command = values[`${prefix}.${i}`];
+    if (command === undefined) break;
+    declared = true;
+    if (command.trim() !== "") commands.push(command);
+  }
+  if (declared) return commands;
+  return values[prefix]?.trim() === "[]" ? [] : undefined;
+}
+
+function hasConfigDeclaration(values: ConfigValues, key: string): boolean {
+  return Object.keys(values).some((candidate) => candidate === key || candidate.startsWith(`${key}.`));
+}
+
+/** Read the operator-declared Validation moment schedule (ADR 0135). */
+export function readValidationMoments(values: ConfigValues): ValidationMoments {
+  const schedule = Object.fromEntries(
+    VALIDATION_MOMENTS.flatMap((moment) => {
+      const commands = readValidationMoment(values, moment);
+      return commands === undefined ? [] : [[moment, commands]];
+    }),
+  ) as ValidationMoments;
+
+  const feedback = readFeedbackCommands(values);
+  const backpressureDeclared = hasConfigDeclaration(values, "afk.backpressure");
+  if (schedule.post_done !== undefined || feedback !== undefined || backpressureDeclared) {
+    schedule.post_done = [
+      ...(schedule.post_done ?? []),
+      ...(feedback ?? []),
+      ...(backpressureDeclared ? readBackpressure(values) : []),
+    ];
+  }
+  return ValidationMomentsSchema.parse(schedule);
 }
 
 /**

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -491,6 +491,7 @@ export function parseConfigYaml(text: string): ConfigValues {
   const out: ConfigValues = {};
   const stack: string[] = [];
   const indents: number[] = [];
+  const mappingContainers = new Set<string>();
   // Per-parent running index for block-sequence items (`- value`). A sequence
   // under the dotted parent path `p` materialises as `p.0`, `p.1`, … so the
   // flat config map keeps its `dotted.key -> value` shape (see readBackpressure).
@@ -611,6 +612,7 @@ export function parseConfigYaml(text: string): ConfigValues {
       lineIndex = block.nextIndex;
       out[full] = block.value;
     } else if (value === "") {
+      mappingContainers.add(full);
       stack.push(key);
       indents.push(indent);
     } else {
@@ -618,7 +620,7 @@ export function parseConfigYaml(text: string): ConfigValues {
     }
   }
 
-  validateValidationMomentShapes(out);
+  validateValidationMomentShapes(out, mappingContainers);
   return ConfigValuesSchema.parse(out);
 }
 
@@ -775,7 +777,7 @@ export function auditConfigLoad(path: string, options: LoadConfigOptions = {}): 
     if (Object.keys(parsed).some((key) => spellings.some((spelling) => key === spelling || key.startsWith(`${spelling}.`)))) {
       warn(
         `[afk:config] warn: \`${alias}\` is deprecated; declare its commands under ` +
-          "`afk.validation.post_done` instead",
+          "`plugins.dev.afk.validation.post_done` instead",
       );
     }
   }
@@ -1065,14 +1067,15 @@ export const ValidationMomentsSchema = z.object({
 });
 export type ValidationMoments = z.infer<typeof ValidationMomentsSchema>;
 
-function validateValidationMomentShapes(values: ConfigValues): void {
+function validateValidationMomentShapes(values: ConfigValues, mappingContainers: ReadonlySet<string>): void {
   for (const root of ["afk.validation", "plugins.dev.afk.validation"]) {
     for (const moment of VALIDATION_MOMENTS) {
       const key = `${root}.${moment}`;
       const scalar = values[key];
       const descendants = Object.keys(values).filter((candidate) => candidate.startsWith(`${key}.`));
       const hasOnlyIndexedItems = descendants.every((candidate) => /^\d+$/.test(candidate.slice(key.length + 1)));
-      if ((scalar !== undefined && scalar.trim() !== "[]") || !hasOnlyIndexedItems) {
+      const emptyMapping = mappingContainers.has(key) && descendants.length === 0;
+      if ((scalar !== undefined && scalar.trim() !== "[]") || !hasOnlyIndexedItems || emptyMapping) {
         throw new MalformedConfigError(`invalid config shape: \`${key}\` must be an ordered list of commands`);
       }
     }
@@ -1087,7 +1090,7 @@ function readValidationMoment(values: ConfigValues, moment: ValidationMoment): s
     const command = values[`${prefix}.${i}`];
     if (command === undefined) break;
     declared = true;
-    if (command.trim() !== "") commands.push(command);
+    commands.push(command);
   }
   if (declared) return commands;
   return values[prefix]?.trim() === "[]" ? [] : undefined;

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -91,7 +91,7 @@ import {
   type ActorTrustSignals,
 } from "../trust-gate.js";
 import { getConfig } from "../config.js";
-import type { AfkModelTier, ConfigValues } from "../config.js";
+import type { AfkModelTier, ConfigValues, ValidationMoments } from "../config.js";
 import { runNotesLoop, notesPath, type NotesLoopConfig } from "../notes-loop.js";
 import {
   buildIssueClassificationMetadata,
@@ -288,6 +288,8 @@ export interface ProcessIssueDeps {
   remoteGit: GitExec;
   pnpm: PnpmExec;
   validationResourceBudget?: { nodeMaxOldSpaceMb?: number; vitestMaxWorkers?: number };
+  /** Resolved declaration schedule; lifecycle consumption lands in the dependent slice. */
+  validationMoments?: ValidationMoments;
   /**
    * Directory probe the gate uses to PROVE a declared validation worktree
    * exists (#3041). Wired to the real filesystem in production; absent in a

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -7,12 +7,14 @@ import {
   auditConfigLoad,
   CONFIG_DEFAULTS,
   DELETED_CONFIG_KEYS,
+  VALIDATION_MOMENT_ALIASES_LAST_RELEASE,
   getConfig,
   loadConfig,
   MalformedConfigError,
   parseConfigYaml,
   readBackpressure,
   readFeedbackCommands,
+  readValidationMoments,
   readSetupCommands,
   readHitlTypeLabels,
   readValidationResourceBudget,
@@ -879,6 +881,87 @@ describe("config — feedback command authority (#3276)", () => {
 
     expect(readFeedbackCommands(absent)).toBeUndefined();
     expect(readFeedbackCommands(disabled)).toEqual([]);
+  });
+});
+
+describe("config — validation moments (ADR 0135, #3284)", () => {
+  it("reads every declared moment in command order", () => {
+    const text = [
+      "plugins:",
+      "  dev:",
+      "    enabled: true",
+      "    afk:",
+      "      validation:",
+      "        iteration:",
+      "          - pnpm --filter @reddb-io/dev test -- config.test.ts",
+      "          - pnpm --filter @reddb-io/dev typecheck",
+      "        post_done:",
+      "          - pnpm --filter @reddb-io/dev test",
+      "        landing:",
+      "          - pnpm --filter @reddb-io/dev build",
+      "",
+    ].join("\n");
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+
+    expect(readValidationMoments(values)).toEqual({
+      iteration: [
+        "pnpm --filter @reddb-io/dev test -- config.test.ts",
+        "pnpm --filter @reddb-io/dev typecheck",
+      ],
+      post_done: ["pnpm --filter @reddb-io/dev test"],
+      landing: ["pnpm --filter @reddb-io/dev build"],
+    });
+  });
+
+  it("rejects a non-list moment and names the offending key", () => {
+    expect(() =>
+      parseConfigYaml(
+        "plugins:\n  dev:\n    afk:\n      validation:\n        iteration: pnpm test\n",
+      ),
+    ).toThrow(/afk\.validation\.iteration.*ordered list/);
+  });
+
+  it("reads both legacy knobs as post_done contributions and warns with the moments key", () => {
+    const warnings: string[] = [];
+    const text = [
+      "plugins:",
+      "  dev:",
+      "    enabled: true",
+      "    afk:",
+      "      feedback:",
+      "        commands:",
+      "          - pnpm test",
+      "      backpressure:",
+      "        - pnpm lint",
+      "",
+    ].join("\n");
+    const values = loadConfig("/x/.red/config.yaml", {
+      read: () => text,
+      warn: (warning) => warnings.push(warning),
+    });
+
+    expect(readValidationMoments(values)).toEqual({ post_done: ["pnpm test", "pnpm lint"] });
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("afk.validation.post_done");
+    expect(warnings[1]).toContain("afk.validation.post_done");
+    expect(warnings.join("\n")).toContain("afk.feedback.commands");
+    expect(warnings.join("\n")).toContain("afk.backpressure");
+  });
+
+  it("expires the legacy aliases after their one-release window", () => {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { version: string };
+    const ordinal = (version: string): number => {
+      const [major = 0, minor = 0, patch = 0] = version.split(".").map(Number);
+      return major * 1_000_000 + minor * 1_000 + patch;
+    };
+
+    expect(
+      ordinal(manifest.version),
+      "remove the Validation moment aliases when advancing beyond their one-release window",
+    ).toBeLessThanOrEqual(ordinal(VALIDATION_MOMENT_ALIASES_LAST_RELEASE));
+    expect(ordinal("3.5.1")).toBeGreaterThan(ordinal(VALIDATION_MOMENT_ALIASES_LAST_RELEASE));
   });
 });
 

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -919,6 +919,20 @@ describe("config — validation moments (ADR 0135, #3284)", () => {
         "plugins:\n  dev:\n    afk:\n      validation:\n        iteration: pnpm test\n",
       ),
     ).toThrow(/afk\.validation\.iteration.*ordered list/);
+    expect(() =>
+      parseConfigYaml(
+        "plugins:\n  dev:\n    afk:\n      validation:\n        iteration:\n",
+      ),
+    ).toThrow(/afk\.validation\.iteration.*ordered list/);
+  });
+
+  it("preserves every declared command string verbatim", () => {
+    const values = loadConfig("/x/.red/config.yaml", {
+      ignoreActivationGate: true,
+      read: () => 'afk:\n  validation:\n    iteration:\n      - "   "\n      - echo ok\n',
+    });
+
+    expect(readValidationMoments(values)).toEqual({ iteration: ["   ", "echo ok"] });
   });
 
   it("reads both legacy knobs as post_done contributions and warns with the moments key", () => {
@@ -942,8 +956,8 @@ describe("config — validation moments (ADR 0135, #3284)", () => {
 
     expect(readValidationMoments(values)).toEqual({ post_done: ["pnpm test", "pnpm lint"] });
     expect(warnings).toHaveLength(2);
-    expect(warnings[0]).toContain("afk.validation.post_done");
-    expect(warnings[1]).toContain("afk.validation.post_done");
+    expect(warnings[0]).toContain("plugins.dev.afk.validation.post_done");
+    expect(warnings[1]).toContain("plugins.dev.afk.validation.post_done");
     expect(warnings.join("\n")).toContain("afk.feedback.commands");
     expect(warnings.join("\n")).toContain("afk.backpressure");
   });

--- a/apps/dev/tests/wiring-integration.test.ts
+++ b/apps/dev/tests/wiring-integration.test.ts
@@ -89,6 +89,47 @@ function makeFakeExec(repoRoot: string): { exec: ExecFn; trace: TraceEntry[] } {
 }
 
 describe("wiring integration — real buildProcessDeps over a fake exec", () => {
+  it("exposes the declared Validation moments to the engine dependency surface", () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-wiring-validation-moments-"));
+    mkdirSync(join(root, ".red"), { recursive: true });
+    writeFileSync(
+      join(root, ".red", "config.yaml"),
+      [
+        "plugins:",
+        "  dev:",
+        "    enabled: true",
+        "    afk:",
+        "      validation:",
+        "        iteration:",
+        "          - pnpm test",
+        "        post_done:",
+        "          - pnpm typecheck",
+        "        landing:",
+        "          - pnpm build",
+        "",
+      ].join("\n"),
+    );
+    const ctx: RepoContext = { root, repo: "acme/widgets", remote: "origin" };
+    const { exec } = makeFakeExec(root);
+    const feedback = makeFeedbackWorktree(root, join(root, ".red", "tmp", "feedback"));
+    const deps = buildProcessDeps({
+      ctx,
+      model: "gpt-5.5",
+      sandbox: "none",
+      feedback,
+      current: { attemptDir: join(root, ".red", "tmp", "workers", "w1", "42-a1") },
+      fallbackRunner: false,
+      runner: "codex",
+      exec,
+    });
+
+    expect(deps.validationMoments).toEqual({
+      iteration: ["pnpm test"],
+      post_done: ["pnpm typecheck"],
+      landing: ["pnpm build"],
+    });
+  });
+
   it("feeds a landing conflict resolver's native stream into its parent Worker lane (#2480)", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-wiring-linked-resolver-"));
     const attemptDir = join(root, ".red", "tmp", "workers", "wLINK", "2480");


### PR DESCRIPTION
Automated AFK landing for #3284. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3284

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788472451&installation_model_id=20659&pr_number=3291&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3291&signature=3e5a07be6a2fc31dfd7e139cc3beab29f818d04defb685f60cb7b4038c028b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->