### PR TITLE
fix: #3279 A branch that reverts after-fork landed work passes every gate green, because deleted tests cannot fail — caught today only because a human read `loc=-9692`

### DIFF
--- a/.changeset/silent-reversions-stop.md
+++ b/.changeset/silent-reversions-stop.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Park branches that erase after-fork base work or silently shrink test source, with cited deletion declarations and an exact-file restoration command.

--- a/apps/dev/src/commands/run/ports/lookups.ts
+++ b/apps/dev/src/commands/run/ports/lookups.ts
@@ -83,6 +83,11 @@ export function buildLookups({
     // The review stage's subject (#2730): the branch as it stands against the
     // merge base, read before any PR exists.
     worktreeDiff: (branch, base) => gitx.worktreeDiff(gitCtx, branch, base),
+    branchReversionBaseline: async (branch, remote, base) => {
+      await gitx.fetchBranchRequired(gitCtx, base, remote);
+      return gitx.branchReversionBaseline(gitCtx, branch, `${remote}/${base}`);
+    },
+    branchReversionDiffAt: (repo, baseRef) => gitx.branchReversionDiffAt(repo, baseRef),
     // Stale-base drift evidence (#2711). The remote-tracking ref only advances
     // on a fetch, and the last one ran when the attempt started — so refresh it
     // first, otherwise a base that moved mid-run reads as standing still and the

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -314,6 +314,8 @@ export function buildProcessDeps({
     // Feedback runs against a checkout of the worker branch — the feedback
     // worktree manager materialises it and rebases pnpm/layout onto it.
     pnpm: feedback.pnpm,
+    baseMergeReversionGeometry: feedback.baseMergeReversionGeometry,
+    requireBranchReversionSafety: true,
     validationResourceBudget: readValidationResourceBudget(config),
     validationMoments: readValidationMoments(config),
     // The gate's proof that a declared validation worktree is really there

--- a/apps/dev/src/core/branch-reversion.ts
+++ b/apps/dev/src/core/branch-reversion.ts
@@ -1,0 +1,297 @@
+// branch-reversion — geometric guard against erasing work that reached the
+// base after a worker branch forked (#3279).
+//
+// Both inputs are zero-context unified patches in the coordinate system of the
+// current base:
+//   afterForkBasePatch: fork point -> current base (added line coordinates)
+//   diff:               current base -> worker branch (deleted line coordinates)
+// Their coordinate intersection is content the base gained after the fork and
+// the branch would erase. No semantic guess or LLM review is involved.
+
+export interface BranchReversionDeclaration {
+  readonly files: readonly string[];
+  readonly citation: string;
+}
+
+export interface BranchReversionRepair {
+  readonly files: readonly string[];
+  readonly command: string;
+}
+
+/** Raw evidence captured around one completed base integration. */
+export interface BranchReversionGeometry {
+  readonly diff: string;
+  readonly forkPoint: string;
+  readonly afterForkBasePatch: string;
+  readonly baseRef: string;
+}
+
+export interface BranchReversionFinding {
+  readonly forkPoint: string;
+  readonly blocked: boolean;
+  /** All files that erase at least one after-fork base line. */
+  readonly revertingFiles: readonly string[];
+  /** Reverting files not covered by an issue-body deletion declaration. */
+  readonly undeclaredRevertingFiles: readonly string[];
+  /** Test-source line delta from current base to branch, before declarations. */
+  readonly testLineDelta: number;
+  /** Test-source line delta after declared files are excluded. */
+  readonly undeclaredTestLineDelta: number;
+  readonly testFilesShrunk: readonly string[];
+  /** Per-test-file evidence; the #3279 incident names birth-latch.test.ts at -173. */
+  readonly testFileLineDeltas: readonly { readonly file: string; readonly delta: number }[];
+  readonly declaredFiles: readonly string[];
+  readonly declarations: readonly BranchReversionDeclaration[];
+  readonly repair: BranchReversionRepair | null;
+}
+
+export interface TestSourceLineRatchet {
+  readonly testLineDelta: number;
+  readonly testFilesShrunk: readonly string[];
+  readonly testFileLineDeltas: readonly { readonly file: string; readonly delta: number }[];
+}
+
+export const BRANCH_REVERSION_SCHEMA = "red.afk.branch-reversion.v1" as const;
+
+/** One audit/validation record for either call site. PURE. */
+export function formatBranchReversionRecord(
+  finding: BranchReversionFinding,
+  stage: "base-merge" | "landing",
+): string {
+  return JSON.stringify({
+    schema: BRANCH_REVERSION_SCHEMA,
+    stage,
+    status: finding.blocked ? "failed" : "passed",
+    fork_point: finding.forkPoint,
+    reverting_files: finding.revertingFiles,
+    undeclared_reverting_files: finding.undeclaredRevertingFiles,
+    test_line_delta: finding.testLineDelta,
+    undeclared_test_line_delta: finding.undeclaredTestLineDelta,
+    test_files_shrunk: finding.testFilesShrunk,
+    test_file_line_deltas: finding.testFileLineDeltas,
+    declarations: finding.declarations,
+    repair: finding.repair,
+  });
+}
+
+interface FilePatchGeometry {
+  added: Set<number>;
+  deleted: Set<number>;
+}
+
+interface PatchGeometry {
+  files: Map<string, FilePatchGeometry>;
+}
+
+function geometryFor(files: Map<string, FilePatchGeometry>, file: string): FilePatchGeometry {
+  let geometry = files.get(file);
+  if (!geometry) {
+    geometry = { added: new Set(), deleted: new Set() };
+    files.set(file, geometry);
+  }
+  return geometry;
+}
+
+function patchPath(header: string): string | null {
+  const raw = header.slice(4).trim();
+  if (raw === "/dev/null") return null;
+  const unquoted = raw.startsWith('"') && raw.endsWith('"')
+    ? raw.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\")
+    : raw;
+  return unquoted.replace(/^[ab]\//, "");
+}
+
+/** Parse the line coordinates of a `git diff --unified=0` patch. PURE. */
+function parsePatchGeometry(patch: string): PatchGeometry {
+  const files = new Map<string, FilePatchGeometry>();
+  let oldFile: string | null = null;
+  let newFile: string | null = null;
+  let oldLine = 0;
+  let newLine = 0;
+  let inHunk = false;
+
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      oldFile = null;
+      newFile = null;
+      inHunk = false;
+      continue;
+    }
+    if (line.startsWith("--- ")) {
+      oldFile = patchPath(line);
+      continue;
+    }
+    if (line.startsWith("+++ ")) {
+      newFile = patchPath(line);
+      continue;
+    }
+    const hunk = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(line);
+    if (hunk) {
+      oldLine = Number(hunk[1]);
+      newLine = Number(hunk[3]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk || line.startsWith("\\ No newline at end of file")) continue;
+    if (line.startsWith("-")) {
+      if (oldFile) geometryFor(files, oldFile).deleted.add(oldLine);
+      oldLine += 1;
+      continue;
+    }
+    if (line.startsWith("+")) {
+      if (newFile) geometryFor(files, newFile).added.add(newLine);
+      newLine += 1;
+      continue;
+    }
+    // Context is normally absent (`--unified=0`) but accepting it makes the
+    // pure function safe for callers that provide a wider patch.
+    if (line.startsWith(" ")) {
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+  return { files };
+}
+
+function isTestSource(file: string): boolean {
+  return /(^|\/)(?:__tests__|tests?)(\/|$)/i.test(file) || /\.(?:test|spec)\.[^/]+$/i.test(file);
+}
+
+function testSourceLineRatchetFor(branch: PatchGeometry): TestSourceLineRatchet {
+  const testDeltaByFile = new Map<string, number>();
+  for (const [file, geometry] of branch.files) {
+    if (isTestSource(file)) {
+      testDeltaByFile.set(file, geometry.added.size - geometry.deleted.size);
+    }
+  }
+  const testFilesShrunk = [...testDeltaByFile]
+    .filter(([, delta]) => delta < 0)
+    .map(([file]) => file)
+    .sort();
+  const testFileLineDeltas = [...testDeltaByFile]
+    .map(([file, delta]) => ({ file, delta }))
+    .sort((a, b) => a.file.localeCompare(b.file));
+  return {
+    testLineDelta: [...testDeltaByFile.values()].reduce((total, delta) => total + delta, 0),
+    testFilesShrunk,
+    testFileLineDeltas,
+  };
+}
+
+/**
+ * Independent belt against silently shrinking test source. This deliberately
+ * does not depend on fork geometry: deleting a test that predates the branch is
+ * still a decrease that must be declared.
+ */
+export function testSourceLineRatchet(diff: string): TestSourceLineRatchet {
+  return testSourceLineRatchetFor(parsePatchGeometry(diff));
+}
+
+function deletionSentences(body: string): string[] {
+  return body
+    .split(/\n+|(?<=[.!?])\s+/)
+    .map((part) => part.replace(/^[-*]\s*(?:\[[ xX]\]\s*)?/, "").replace(/\s+/g, " ").trim())
+    .filter((part) => {
+      if (!/\b(?:delet(?:e|es|ed|ing|ion)|remov(?:e|es|ed|ing|al)|drop(?:s|ped|ping)?|retir(?:e|es|ed|ing))\b/i.test(part)) {
+        return false;
+      }
+      return !/\b(?:do not|don't|must not|never|without|avoid|prevent|should not)\b.{0,48}\b(?:delete|remove|drop|retire)\b/i.test(part);
+    });
+}
+
+function declarationForFile(file: string, sentences: readonly string[]): string | undefined {
+  const basename = file.slice(file.lastIndexOf("/") + 1);
+  return sentences.find((sentence) => {
+    const plain = sentence.replace(/`/g, "");
+    if (plain.includes(file) || (basename.length > 0 && plain.includes(basename))) return true;
+    if (!/\bcontract phase\b/i.test(sentence)) return false;
+    // #3266 names the removed API object (`deprecation aliases`) rather than a
+    // path. Match that object to meaningful basename tokens, never every file in
+    // the diff: one declared alias removal must not whitelist an unrelated
+    // after-fork reversion elsewhere.
+    const tokens = basename
+      .replace(/\.[^.]+$/, "")
+      .split(/[^A-Za-z0-9]+|(?=[A-Z])/)
+      .map((token) => token.toLowerCase())
+      .filter((token) => token.length >= 5 && !["index", "source", "tests"].includes(token));
+    const lower = plain.toLowerCase();
+    return tokens.some((token) => lower.includes(token) || lower.includes(token.replace(/ed$/, "ion")));
+  });
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+/**
+ * Detect after-fork base reversion and silent test-source shrinkage. PURE.
+ *
+ * `diff` is `base..branch`; `afterForkBasePatch` is the net `forkPoint..base` patch. Both
+ * should be produced with `--unified=0`, so their line numbers share the current
+ * base coordinate system.
+ */
+export function detectBranchReversion(
+  diff: string,
+  forkPoint: string,
+  afterForkBasePatch: string,
+  issueBody: string,
+  baseRef: string,
+): BranchReversionFinding {
+  const branch = parsePatchGeometry(diff);
+  const afterFork = parsePatchGeometry(afterForkBasePatch);
+  const revertingFiles: string[] = [];
+
+  for (const [file, geometry] of branch.files) {
+    const mainAdded = afterFork.files.get(file)?.added;
+    if (mainAdded && [...geometry.deleted].some((line) => mainAdded.has(line))) {
+      revertingFiles.push(file);
+    }
+  }
+
+  revertingFiles.sort();
+  const { testLineDelta, testFilesShrunk, testFileLineDeltas } = testSourceLineRatchetFor(branch);
+  const candidateFiles = [...new Set([...revertingFiles, ...testFilesShrunk])].sort();
+  const sentences = deletionSentences(issueBody);
+  const declarationByFile = new Map<string, string>();
+  for (const file of candidateFiles) {
+    const citation = declarationForFile(file, sentences);
+    if (citation) declarationByFile.set(file, citation);
+  }
+
+  const declaredFiles = [...declarationByFile.keys()].sort();
+  const declarations = [...new Set(declarationByFile.values())].map((citation) => ({
+    files: declaredFiles.filter((file) => declarationByFile.get(file) === citation),
+    citation,
+  }));
+  const undeclaredRevertingFiles = revertingFiles.filter((file) => !declarationByFile.has(file));
+  const undeclaredTestLineDelta = testFileLineDeltas
+    .filter(({ file }) => !declarationByFile.has(file))
+    .reduce((total, { delta }) => total + delta, 0);
+  const repairFiles = [...new Set([
+    ...undeclaredRevertingFiles,
+    ...(undeclaredTestLineDelta < 0
+      ? testFilesShrunk.filter((file) => !declarationByFile.has(file))
+      : []),
+  ])].sort();
+  const blocked = undeclaredRevertingFiles.length > 0 || undeclaredTestLineDelta < 0;
+
+  return {
+    forkPoint,
+    blocked,
+    revertingFiles,
+    undeclaredRevertingFiles,
+    testLineDelta,
+    undeclaredTestLineDelta,
+    testFilesShrunk,
+    testFileLineDeltas,
+    declaredFiles,
+    declarations,
+    repair: blocked
+      ? {
+          files: repairFiles,
+          command: `git checkout ${shellQuote(baseRef)} -- ${repairFiles.map(shellQuote).join(" ")}`,
+        }
+      : null,
+  };
+}

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -155,6 +155,11 @@ export interface LandingDeps {
    */
   postMergeGate?: (mergedTreeDir: string) => Promise<{ ok: boolean }>;
   /**
+   * Deterministic intent barrier (#3279), run on the integrated tree before any
+   * PR is opened or attempt commit is merged. A refusal is never auto-repaired.
+   */
+  intentGate?: (integratedTreeDir: string) => Promise<{ ok: boolean }>;
+  /**
    * When true, a landing that cannot use fresh PR CI must have `postMergeGate`.
    * This lets validation-aware callers fail as infra instead of silently landing
    * without either CI provenance or a local fallback.
@@ -216,6 +221,8 @@ export interface LandingInput {
   validatedBranchTip?: string;
   /** Resolved base branch (lock > pin > main). */
   base: string;
+  /** Immutable base commit shared by the Landing integration and intent geometry. */
+  intentBaseRef?: string;
   /**
    * The configured Trunk (`plugins.dev.trunk`, default `main`; ADR 0083). Kept
    * for caller compatibility and observability; trunk freshness is resolved
@@ -353,6 +360,9 @@ export type LandingResult =
         // routes this through the existing merge-conflict/validation recovery so
         // an unvalidated or stale-main-broken result is never merged.
         | "post-merge-gate"
+        // Geometric after-fork reversion/test-count intent finding (#3279).
+        // The integrated tree is discarded before a PR or base write occurs.
+        | "intent-finding"
         // Land-lock serialization (#2596): another worker held the land-lock past
         // the wait timeout. This is a BACKOFF signal, not an infra failure — the
         // caller routes it to self-requeue rather than parking the issue.
@@ -559,6 +569,9 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
   const waitForReview = decorateReviewWait(deps, input);
   const ciAwait = decorateCiAwait(deps, input);
   try {
+    if (deps.intentGate && !(await deps.intentGate(prepared.dir)).ok) {
+      return { ok: false, reason: "intent-finding", locked: input.locked };
+    }
     await deps.landingPhase?.("push-pr", { step: "pr", status: "start" });
     const r = await landPr(deps.mergeExec, {
       repo: input.repo,
@@ -813,6 +826,7 @@ async function preparePrRebaseWorktree(
       repo: dir,
       remote: input.remote,
       base: input.base,
+      ...(input.intentBaseRef ? { baseRef: input.intentBaseRef } : {}),
       branch: input.branch,
       resolveMechanical: deps.resolveMechanicalConflict,
       resolveAgent: deps.resolveAgentConflict,
@@ -876,38 +890,17 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
   let postMergeValidation: LandingPostMergeValidation | undefined;
   try {
     // Integrate origin/<base> into the detached worktree HEAD (not the primary).
-    const integrated = await integrateOrigin(deps.mergeExec, {
-      repo: landDir,
-      remote: input.remote,
-      branch: input.base,
-      stillBehind: true,
-      inSync: false,
-    });
+    const integrated = input.intentBaseRef
+      ? await deps.mergeExec(["git", "-C", landDir, "reset", "--hard", input.intentBaseRef])
+          .then((result) => ({ ok: result.code === 0, action: "fast-forward" as const }))
+      : await integrateOrigin(deps.mergeExec, {
+          repo: landDir,
+          remote: input.remote,
+          branch: input.base,
+          stillBehind: true,
+          inSync: false,
+        });
     if (!integrated.ok) return { ok: false, reason: "integrate-failed", locked: input.locked };
-
-    // Post-merge-integration gate (#1335): re-run the feedback gate on the
-    // already-integrated worktree (worker branch merged with current
-    // origin/<base>) before pushing anything to the remote. A failure aborts
-    // here so a stale-main-broken result is never merged.
-    if (!deps.postMergeGate && deps.requirePostMergeValidation) {
-      return {
-        ok: false,
-        reason: "infra",
-        locked: input.locked,
-        infraReason: "Post-merge validation fallback is not configured for a direct landing that bypassed PR CI.",
-      };
-    }
-    if (!deps.postMergeGate) {
-      postMergeValidation = undefined;
-    } else {
-      await deps.landingPhase?.("gate", { step: "re-validation", status: "start" });
-      const gateResult = await deps.postMergeGate(landDir);
-      if (!gateResult.ok) return { ok: false, reason: "post-merge-gate", locked: input.locked };
-      postMergeValidation = {
-        path: "local-rerun",
-        reason: "Direct landing bypassed PR CI; local post-merge validation fallback ran.",
-      };
-    }
 
     const branchTip = input.validatedBranchTip ?? (await resolveRemoteBranchTip(deps.mergeExec, {
       repo: landDir,
@@ -921,9 +914,10 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
     // the issue as done without delivering any work. The PR path rejects this
     // naturally — `gh pr create` fails on an empty branch — so mirror that guard
     // here: route a zero-commit direct landing to land-failed.
+    const baseComparisonRef = input.intentBaseRef ?? `origin/${input.base}`;
     const countRes = await deps.mergeExec([
       "git", "-C", landDir,
-      "rev-list", "--count", `origin/${input.base}..${branchTip}`,
+      "rev-list", "--count", `${baseComparisonRef}..${branchTip}`,
     ]);
     const commitCount = parseInt(countRes.stdout.trim(), 10);
     if (countRes.code !== 0 || !Number.isInteger(commitCount) || commitCount === 0) {
@@ -932,15 +926,42 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
 
     // Capture the integrated tip from the worktree as the rollback anchor.
     const preMergeSha = (await deps.mergeExec(["git", "-C", landDir, "rev-parse", "--short", "HEAD"])).stdout.trim();
+    const validateIntegratedTree = async (): Promise<LandingResult | undefined> => {
+      if (deps.intentGate && !(await deps.intentGate(landDir)).ok) {
+        return { ok: false, reason: "intent-finding", locked: input.locked };
+      }
+      if (!deps.postMergeGate && deps.requirePostMergeValidation) {
+        return {
+          ok: false,
+          reason: "infra",
+          locked: input.locked,
+          infraReason: "Post-merge validation fallback is not configured for a direct landing that bypassed PR CI.",
+        };
+      }
+      if (!deps.postMergeGate) return undefined;
+      await deps.landingPhase?.("gate", { step: "re-validation", status: "start" });
+      const gateResult = await deps.postMergeGate(landDir);
+      if (!gateResult.ok) return { ok: false, reason: "post-merge-gate", locked: input.locked };
+      postMergeValidation = {
+        path: "local-rerun",
+        reason: "Direct landing bypassed PR CI; local post-merge validation fallback ran.",
+      };
+      return undefined;
+    };
 
     const fastForwardable = await deps.mergeExec([
       "git", "-C", landDir,
-      "merge-base", "--is-ancestor", `origin/${input.base}`, branchTip,
+      "merge-base", "--is-ancestor", baseComparisonRef, branchTip,
     ]);
     if (fastForwardable.code === 0) {
       await deps.landingPhase?.("merge", { step: "fast-forward", status: "start" });
       const ff = await deps.mergeExec(["git", "-C", landDir, "merge", "--ff-only", branchTip]);
       if (ff.code !== 0) return { ok: false, reason: "land-failed", locked: input.locked };
+      const validationFailure = await validateIntegratedTree();
+      if (validationFailure) {
+        await deps.mergeExec(["git", "-C", landDir, "reset", "--hard", preMergeSha]);
+        return validationFailure;
+      }
       const push = await deps.mergeExec([
         "git",
         "-C",
@@ -973,6 +994,7 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
       title: input.title,
       mergeTitle: landingMergeTitle(input),
       preMergeSha,
+      push: false,
     });
     let landed = merged.ok;
 
@@ -990,24 +1012,29 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
         target: input.base,
       });
       if (resolved.resolved) {
-        const push = await deps.mergeExec([
-          "git",
-          "-C",
-          landDir,
-          "push",
-          input.remote,
-          `HEAD:refs/heads/${input.base}`,
-        ]);
-        if (push.code === 0) {
-          landed = true;
-        } else {
-          await deps.mergeExec(["git", "-C", landDir, "reset", "--hard", preMergeSha]);
-        }
+        landed = true;
       } else {
         await deps.mergeExec(["git", "-C", landDir, "merge", "--abort"]);
       }
     }
     if (!landed) return { ok: false, reason: "land-failed", locked: input.locked };
+    const validationFailure = await validateIntegratedTree();
+    if (validationFailure) {
+      await deps.mergeExec(["git", "-C", landDir, "reset", "--hard", preMergeSha]);
+      return validationFailure;
+    }
+    const push = await deps.mergeExec([
+      "git",
+      "-C",
+      landDir,
+      "push",
+      input.remote,
+      `HEAD:refs/heads/${input.base}`,
+    ]);
+    if (push.code !== 0) {
+      await deps.mergeExec(["git", "-C", landDir, "reset", "--hard", preMergeSha]);
+      return { ok: false, reason: "land-failed", locked: input.locked };
+    }
 
     // The merge commit lives on the worktree's HEAD (and now origin/<base>); the
     // primary HEAD did not advance, so carry the landed sha back for the close.

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -110,6 +110,8 @@ export interface PreMergeRebaseInput {
   remote: string;
   /** Base branch to rebase onto (e.g. `main`). */
   base: string;
+  /** Immutable base commit used by geometric intent validation when present. */
+  baseRef?: string;
   /** Worker branch being rebased + force-pushed. */
   branch: string;
   /**
@@ -281,7 +283,7 @@ export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Pr
   const { repo, remote, base, branch } = input;
   const maxRetries = input.maxPushRetries ?? 2;
   const maxAgentResolveAttempts = Math.max(0, input.maxAgentResolveAttempts ?? 2);
-  const baseRef = `${remote}/${base}`;
+  const baseRef = input.baseRef ?? `${remote}/${base}`;
 
   // Squash the branch's own micro-history down to one commit at its fork point
   // (issue #2481). Field pathology: a five-worker retry chain accumulated 65
@@ -427,6 +429,8 @@ export interface LandMergeInput {
   mergeTitle?: string;
   /** Integrated tip captured before the merge, for rollback on push reject. */
   preMergeSha: string;
+  /** Leave the completed merge in the isolated worktree for a pre-push gate. */
+  push?: boolean;
 }
 
 export interface LandMergeResult {
@@ -470,6 +474,7 @@ export async function landMerge(exec: Exec, input: LandMergeInput): Promise<Land
     mergeTitle,
   ]);
   if (merge.code !== 0) return { ok: false, rolledBack: false };
+  if (input.push === false) return { ok: true, rolledBack: false };
 
   const push = await exec(["git", "-C", repo, "push", remote, `HEAD:refs/heads/${target}`]);
   if (push.code !== 0) {

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -133,6 +133,12 @@ import {
 } from "../shared-gate.js";
 import { isPrePrPipelineActive } from "../pre-pr-pipeline.js";
 import {
+  detectBranchReversion,
+  formatBranchReversionRecord,
+  type BranchReversionFinding,
+  type BranchReversionGeometry,
+} from "../branch-reversion.js";
+import {
   aggregateAdversarialReviewFindings,
   decideAdversarialReview,
   renderAdversarialReviewBlockerSummary,
@@ -647,6 +653,11 @@ export async function processIssue(
     resolvedBase: baseResolution,
   };
   let validationSidecar: string[] = [];
+  const branchReversionRecords = new Map<"base-merge" | "landing", string>();
+  const completeValidationSidecar = (): string[] => [
+    ...branchReversionRecords.values(),
+    ...validationSidecar,
+  ];
   let lastValidationScope: ValidationScope | undefined = undefined;
   let landingFeedbackScopes: string[] = ["."];
   let noSourceDiffWarning: string | undefined;
@@ -657,6 +668,41 @@ export async function processIssue(
   // failure, not a flake worth another free cycle or outer recovery attempt.
   let previousSuspectInfraSignature: string | undefined;
   let deterministicInfraSignature: string | undefined;
+
+  const evaluateBranchReversion = (
+    stage: "base-merge" | "landing",
+    geometry: BranchReversionGeometry,
+  ): BranchReversionFinding => {
+    const finding = detectBranchReversion(
+      geometry.diff,
+      geometry.forkPoint,
+      geometry.afterForkBasePatch,
+      input.body,
+      remoteTrackingBaseRef(input.remote, base),
+    );
+    const record = formatBranchReversionRecord(finding, stage);
+    branchReversionRecords.set(stage, record);
+    return finding;
+  };
+  const parkBranchReversion = async (
+    finding: BranchReversionFinding,
+  ): Promise<ProcessIssueResult> => {
+    const intentSidecar = completeValidationSidecar();
+    await writeValidationSidecar(deps, input.attemptDir, intentSidecar);
+    const files = finding.repair?.files.join(", ") || "the recorded files";
+    const repair = finding.repair?.command ?? "human intent resolution required";
+    const notes =
+      `Intent finding: the branch would erase after-fork base work or silently shrink test source ` +
+      `(${files}). The branch was parked without an automatic fix. Repair: ${repair}`;
+    deps.appendIterLog(`🤖 /afk: ${notes}`);
+    return await terminalFailure(
+      common,
+      "feedback-failed",
+      "validation",
+      { notes, validation: intentSidecar.join("\n") },
+      { validationSummary: intentSidecar.join("\n") },
+    );
+  };
   // A stale-base attribution buys another GATE run, not another implementer
   // run: the branch did not change, only the merge result did (#3231).
   let gateRevalidationSkip = false;
@@ -1484,6 +1530,11 @@ export async function processIssue(
     ) {
       return await abortAfterClaim(deps, input, branch, base, hooksFired, "pre_feedback");
     }
+    if (deps.requireBranchReversionSafety && !deps.baseMergeReversionGeometry) {
+      const reason = "branch reversion safety is required but the feedback base-merge geometry port is absent";
+      deps.appendIterLog(`🤖 /afk: ${reason}`);
+      return await terminalFailure(common, "infra", "infra", { log: reason }, { notes: reason });
+    }
     const feedback: RunFeedbackResult = await runFeedback(deps.pnpm, {
       worktree: workerBranch,
       // A branch NAME, not a directory (#3041): `deps.pnpm` materialises it and
@@ -1501,6 +1552,11 @@ export async function processIssue(
         : { commands: deps.feedbackCommands, commandExec: deps.backpressure }),
     });
     markProcessSafetyStep("post-agent:feedback-done");
+    const baseMergeGeometry = deps.baseMergeReversionGeometry?.(workerBranch);
+    if (baseMergeGeometry) {
+      const finding = evaluateBranchReversion("base-merge", baseMergeGeometry);
+      if (finding.blocked) return await parkBranchReversion(finding);
+    }
     gateStages.push({ stage: "feedback", ok: feedback.ok });
     if (!feedback.ok) {
       await fireHook(
@@ -1673,7 +1729,7 @@ export async function processIssue(
     }
     if (review.next === "park") {
       const validation = review.validation ?? "Blocking review findings remain.";
-      await writeValidationSidecar(deps, input.attemptDir, [...validationSidecar, validation]);
+      await writeValidationSidecar(deps, input.attemptDir, [...completeValidationSidecar(), validation]);
       await parkReseedTrail(validation);
       return await terminalFailure(
         common,
@@ -1706,11 +1762,32 @@ export async function processIssue(
   const locked = await deps.lookups.isLocked();
   const openPr = deps.worktreeLaunchesPr !== false;
   if (labels.includes(LABEL_LANDING_MANUAL)) {
-    return await handoffForManualLanding(common, base, validationSidecar);
+    return await handoffForManualLanding(common, base, completeValidationSidecar());
   }
   if (openPr && deps.reviewGate && shouldRequestReview(activeTaskClass, deps.reviewGate)) {
-    return await handoffForReview(common, activeTaskClass, validationSidecar);
+    return await handoffForReview(common, activeTaskClass, completeValidationSidecar());
   }
+  const baselineProbe = deps.lookups.branchReversionBaseline;
+  const integratedDiffProbe = deps.lookups.branchReversionDiffAt;
+  if (deps.requireBranchReversionSafety && (!baselineProbe || !integratedDiffProbe)) {
+    const reason = "branch reversion safety is required but the Landing geometry ports are absent";
+    deps.appendIterLog(`🤖 /afk: ${reason}`);
+    return await terminalFailure(common, "infra", "infra", { log: reason }, { notes: reason });
+  }
+  let landingBaseline: Omit<BranchReversionGeometry, "diff"> | undefined;
+  if (baselineProbe && integratedDiffProbe) {
+    try {
+      landingBaseline = await baselineProbe(workerBranch, input.remote, base);
+    } catch (err) {
+      const reason =
+        "branch reversion safety could not capture the fresh Landing baseline: " +
+        (err instanceof Error ? err.message : String(err));
+      deps.appendIterLog(`🤖 /afk: ${reason}`);
+      return await terminalFailure(common, "infra", "infra", { log: reason }, { notes: reason });
+    }
+  }
+  let landingIntentFinding: BranchReversionFinding | undefined;
+  let landingIntentError: string | undefined;
   const markLandingPhase = (phase: LandingPhase, detail: Record<string, unknown> = {}): void => {
     const startedAt = deps.nowIso();
     deps.markState?.({
@@ -1748,6 +1825,25 @@ export async function processIssue(
       makeRebaseWorktree: deps.makeRebaseWorktree,
       removeRebaseWorktree: deps.removeRebaseWorktree,
       landLock: deps.landLock,
+      ...(landingBaseline && integratedDiffProbe
+        ? {
+            intentGate: async (integratedTreeDir: string) => {
+              try {
+                const diff = await integratedDiffProbe(integratedTreeDir, landingBaseline.baseRef);
+                landingIntentFinding = evaluateBranchReversion("landing", {
+                  ...landingBaseline,
+                  diff,
+                });
+                return { ok: !landingIntentFinding.blocked };
+              } catch (err) {
+                landingIntentError =
+                  "branch reversion safety could not inspect the integrated Landing tree: " +
+                  (err instanceof Error ? err.message : String(err));
+                return { ok: false };
+              }
+            },
+          }
+        : {}),
       // Backpressure evidence only. Review left this callback for the gate fold
       // (#2730): it now runs before the PR exists, on the worktree diff.
       onPrResolved: async (pr) => {
@@ -1773,8 +1869,8 @@ export async function processIssue(
             : { commands: deps.feedbackCommands, commandExec: deps.backpressure }),
         });
         if (!mergedFeedback.ok) {
-          validationSidecar = mergedFeedback.sidecar;
-          await writeValidationSidecar(deps, input.attemptDir, mergedFeedback.sidecar);
+          validationSidecar = [...mergedFeedback.sidecar];
+          await writeValidationSidecar(deps, input.attemptDir, completeValidationSidecar());
           return { ok: false };
         }
         const gateBackpressureCommands = deps.backpressureCommands ?? [];
@@ -1787,11 +1883,11 @@ export async function processIssue(
           common.backpressureChecks = mergedBackpressure.checks;
           validationSidecar = [...mergedFeedback.sidecar, ...mergedBackpressure.sidecar];
           if (!mergedBackpressure.ok) {
-            await writeValidationSidecar(deps, input.attemptDir, validationSidecar);
+            await writeValidationSidecar(deps, input.attemptDir, completeValidationSidecar());
           }
           return { ok: mergedBackpressure.ok };
         }
-        validationSidecar = mergedFeedback.sidecar;
+        validationSidecar = [...mergedFeedback.sidecar];
         return { ok: true };
       },
       requirePostMergeValidation: true,
@@ -1805,6 +1901,7 @@ export async function processIssue(
       remote: input.remote,
       branch: workerBranch,
       base,
+      ...(landingBaseline ? { intentBaseRef: landingBaseline.baseRef } : {}),
       trunk,
       issue,
       title: input.title,
@@ -1843,8 +1940,9 @@ export async function processIssue(
     }
     markLandingPhase("cascade");
     deps.recordWorkerEvent?.("worker.landed", { merge_sha: mergeSha, base });
-    await writeValidationSidecar(deps, input.attemptDir, validationSidecar);
-    const posted = await emitDone(common, mergeSha, durationS, validationSidecar, lastValidationScope, noSourceDiffWarning);
+    const finalValidationSidecar = completeValidationSidecar();
+    await writeValidationSidecar(deps, input.attemptDir, finalValidationSidecar);
+    const posted = await emitDone(common, mergeSha, durationS, finalValidationSidecar, lastValidationScope, noSourceDiffWarning);
     await recordOutcomeBestEffort(common, "done", { durationS });
     markLandingPhase("close", { step: "close-issue", status: "start" });
     await deps.gh.close(issue);
@@ -1947,6 +2045,21 @@ export async function processIssue(
     }
   }
   if (!landing.ok) {
+    if (landing.reason === "intent-finding") {
+      if (landingIntentError) {
+        deps.appendIterLog(`🤖 /afk: ${landingIntentError}`);
+        return await terminalFailure(
+          common,
+          "infra",
+          "infra",
+          { log: landingIntentError },
+          { notes: landingIntentError },
+        );
+      }
+      if (landingIntentFinding) return await parkBranchReversion(landingIntentFinding);
+      const reason = "Landing intent barrier refused without a structured reversion finding";
+      return await terminalFailure(common, "infra", "infra", { log: reason }, { notes: reason });
+    }
     if (landing.reason === "pr-resolved-abort") {
       // No pre-merge observer aborts any more — review left this path for the
       // gate fold (#2730). A surviving abort is an unexplained landing refusal.
@@ -2008,7 +2121,7 @@ export async function processIssue(
       // when the gate could not even materialise its worktree and every check
       // short-circuited with `durationMs: 0`.
       const validation =
-        validationSidecar.join("\n") ||
+        completeValidationSidecar().join("\n") ||
         "The post-merge integration gate failed on the rebased tree; nothing was merged.";
       return await terminalFailure(
         common,

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -1,5 +1,6 @@
 import { resolveBase, type ResolveBaseDeps, type ResolveBaseInput } from "../base-resolver.js";
 import type { BranchRef } from "../branch-cleanup.js";
+import type { BranchReversionGeometry } from "../branch-reversion.js";
 import type { AttemptPullRequest } from "../branch-resume.js";
 import {
   buildRefFromSlug,
@@ -204,6 +205,14 @@ export interface ProcessLookups {
    * pass a Ticket it never saw.
    */
   worktreeDiff?(branch: string, base: string): Promise<string>;
+  /** Capture fork→fresh-base geometry before Landing integrates the branch. */
+  branchReversionBaseline?(
+    branch: string,
+    remote: string,
+    base: string,
+  ): Promise<Omit<BranchReversionGeometry, "diff">>;
+  /** Read fresh-base→HEAD geometry inside the integrated Landing worktree. */
+  branchReversionDiffAt?(repo: string, baseRef: string): Promise<string>;
   /**
    * What the base ref did while this attempt ran (issue #2711): its head sha
    * NOW plus the subjects of the commits it gained since `sinceSha`. The gate
@@ -287,6 +296,10 @@ export interface ProcessIssueDeps {
   mergeExec: MergeExec;
   remoteGit: GitExec;
   pnpm: PnpmExec;
+  /** Geometry captured around feedback's successful stale-base correction. */
+  baseMergeReversionGeometry?(branch: string): BranchReversionGeometry | undefined;
+  /** Production wiring fails closed when either geometric safety barrier is absent. */
+  requireBranchReversionSafety?: boolean;
   validationResourceBudget?: { nodeMaxOldSpaceMb?: number; vitestMaxWorkers?: number };
   /** Resolved declaration schedule; lifecycle consumption lands in the dependent slice. */
   validationMoments?: ValidationMoments;

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -70,6 +70,7 @@ import {
 import * as gitx from "./git.js";
 import { createPathLock, createPathSemaphore } from "./land-lock.js";
 import type { LandLockWaitInfo } from "../core/land-lock.js";
+import type { BranchReversionGeometry } from "../core/branch-reversion.js";
 
 /**
  * Is `token` an ALREADY-MATERIALISED checkout rather than a branch name (#2339)?
@@ -184,6 +185,12 @@ export interface FeedbackWorktreeIO {
    * throws — the gate still has to run.
    */
   rebase(ctx: gitx.GitContext, dest: string, base: string): Promise<{ ok: true } | { ok: false; stderr: string }>;
+  reversionBaseline?(
+    ctx: gitx.GitContext,
+    dest: string,
+    base: string,
+  ): Promise<Omit<BranchReversionGeometry, "diff">>;
+  reversionDiff?(ctx: gitx.GitContext, dest: string, base: string): Promise<string>;
   /** Run `pnpm <args>` with the given cwd. */
   pnpm(args: readonly string[], opts: ExecOptions): Promise<ExecOutput>;
   /** Run an arbitrary tool (used by the backpressure `sh -c` executor). */
@@ -410,6 +417,9 @@ const defaultIO: FeedbackWorktreeIO = {
     await execTool("git", ["-C", dest, "rebase", "--abort"], { cwd: dest });
     return { ok: false, stderr: r.stderr.trim() };
   },
+  reversionBaseline: async (_ctx, dest, base) =>
+    gitx.branchReversionBaseline({ cwd: dest }, "HEAD", base),
+  reversionDiff: async (_ctx, dest, base) => gitx.branchReversionDiffAt(dest, base),
   pnpm: runPnpm,
   exec: execTool,
   lock: async (dest, onWait) => {
@@ -461,6 +471,8 @@ export interface FeedbackWorktree {
    * branch token (materialised the same way as the pnpm/backpressure executors).
    */
   postWorkerFormat: PostWorkerFormatExec;
+  /** Geometry captured around feedback's completed stale-base correction. */
+  baseMergeReversionGeometry(branch: string): BranchReversionGeometry | undefined;
   /** Remove every worktree this manager created in THIS session (best-effort). */
   cleanup(): Promise<void>;
 }
@@ -573,6 +585,7 @@ export function makeFeedbackWorktree(
   // into every validation record produced from this checkout; success must not
   // erase what setup actually ran.
   const setupRecord = new Map<string, string>();
+  const reversionGeometry = new Map<string, BranchReversionGeometry>();
 
   async function runGateChild(
     subject: string,
@@ -863,12 +876,18 @@ export function makeFeedbackWorktree(
     // after a FRESH materialise (not a cache hit), so the cached worktree's
     // HEAD stays aligned with the branch ref for the next session's cache check.
     if (rebaseOnto) {
+      const baseline = io.reversionBaseline
+        ? await io.reversionBaseline(gitCtx, dest, rebaseOnto)
+        : undefined;
       const rb = await io.rebase(gitCtx, dest, rebaseOnto);
       if (!rb.ok) {
         process.stderr.write(
           `warn: feedback worktree rebase of ${branch} onto ${rebaseOnto} failed ` +
-            `(${rb.stderr || "no detail"}); running the gate on the un-rebased branch\n`,
+          `(${rb.stderr || "no detail"}); running the gate on the un-rebased branch\n`,
         );
+      } else if (baseline && io.reversionDiff) {
+        const diff = await io.reversionDiff(gitCtx, dest, baseline.baseRef);
+        reversionGeometry.set(branch, { ...baseline, diff });
       }
     }
     created.add(dest);
@@ -1033,6 +1052,7 @@ export function makeFeedbackWorktree(
     layout,
     backpressure,
     postWorkerFormat,
+    baseMergeReversionGeometry: (branch) => reversionGeometry.get(branch),
     async cleanup() {
       for (const dest of created) {
         await io.worktreeRemove(gitCtx, dest);
@@ -1042,6 +1062,7 @@ export function makeFeedbackWorktree(
       setupFailures.clear();
       setupFailureReason.clear();
       setupRecord.clear();
+      reversionGeometry.clear();
     },
   };
 }

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -9,6 +9,11 @@ import { execTool, type ExecOptions, type ExecFn, type ExecOutput } from "./exec
 import type { GitExec, GitExecResult } from "../core/remote-branch.js";
 import type { Exec as MergeExec, ExecResult as MergeExecResult } from "../core/merge.js";
 import type { BranchRef } from "../core/branch-cleanup.js";
+import {
+  detectBranchReversion,
+  type BranchReversionFinding,
+  type BranchReversionGeometry,
+} from "../core/branch-reversion.js";
 import type { RemoteUrlFact } from "../core/operational-probes.js";
 import { resolveGhQuotaBackoff, withGhQuotaBackoff, type GhQuotaBackoffOpts } from "./gh/quota.js";
 
@@ -272,11 +277,27 @@ export async function localRemoteDivergence(
   };
 }
 
-/** Best-effort `git fetch origin <branch>` (FIX E recovery: try once to pull a
- * sandcastle-pushed worker branch onto the host before declaring it absent). */
-export async function fetchBranch(ctx: GitContext, branch: string): Promise<void> {
+/** Best-effort `git fetch <remote> <branch>` (FIX E recovery defaults to origin). */
+export async function fetchBranch(
+  ctx: GitContext,
+  branch: string,
+  remote = "origin",
+): Promise<void> {
   if (!branch) return;
-  await runGit(ctx, ["fetch", "origin", branch]);
+  await runGit(ctx, ["fetch", remote, branch]);
+}
+
+/** Required fetch for safety barriers that must never inspect a stale remote ref. */
+export async function fetchBranchRequired(
+  ctx: GitContext,
+  branch: string,
+  remote = "origin",
+): Promise<void> {
+  if (!branch) throw new Error("required git fetch was given an empty branch");
+  const fetched = await runGit(ctx, ["fetch", remote, branch]);
+  if (fetched.code !== 0) {
+    throw new Error(`required git fetch failed for ${remote}/${branch}`);
+  }
 }
 
 export interface ResolveFreshBaseInput {
@@ -551,6 +572,67 @@ export async function changedFileContents(
 export async function worktreeDiff(ctx: GitContext, branch: string, base: string): Promise<string> {
   const r = await runGit(ctx, ["diff", `${base}...${branch}`]);
   return r.code === 0 ? r.stdout : "";
+}
+
+/**
+ * Read the two zero-context patches whose shared base-line coordinates prove an
+ * after-fork reversion (#3279), then hand all judgment to the pure detector.
+ * A failed read rejects: inability to run a safety check is not a clean result.
+ */
+export async function branchReversion(
+  ctx: GitContext,
+  branch: string,
+  base: string,
+  issueBody: string,
+  restoreRef: string,
+): Promise<BranchReversionFinding> {
+  const baseline = await branchReversionBaseline(ctx, branch, base);
+  const diff = await branchReversionDiff(ctx, branch, baseline.baseRef);
+  return detectBranchReversion(
+    diff,
+    baseline.forkPoint,
+    baseline.afterForkBasePatch,
+    issueBody,
+    restoreRef,
+  );
+}
+
+const REVERSION_DIFF_ARGS = ["diff", "--no-ext-diff", "--no-renames", "--unified=0"] as const;
+
+/** Capture fork→base evidence before a branch is integrated into that base. */
+export async function branchReversionBaseline(
+  ctx: GitContext,
+  branch: string,
+  baseRef: string,
+): Promise<Omit<BranchReversionGeometry, "diff">> {
+  const resolvedBase = await runGit(ctx, ["rev-parse", "--verify", `${baseRef}^{commit}`]);
+  const baseSha = resolvedBase.code === 0 ? resolvedBase.stdout.trim() : "";
+  if (!baseSha) throw new Error("branch reversion check could not pin the base tip");
+  const mergeBase = await runGit(ctx, ["merge-base", baseSha, branch]);
+  const forkPoint = mergeBase.code === 0 ? mergeBase.stdout.trim() : "";
+  if (!forkPoint) throw new Error("branch reversion check could not resolve the fork point");
+  const patch = await runGit(ctx, [...REVERSION_DIFF_ARGS, `${forkPoint}..${baseSha}`]);
+  if (patch.code !== 0) throw new Error("branch reversion check could not read the after-fork base patch");
+  return { forkPoint, afterForkBasePatch: patch.stdout, baseRef: baseSha };
+}
+
+/** Read base→candidate geometry after integration; `candidate` may be a ref. */
+export async function branchReversionDiff(
+  ctx: GitContext,
+  candidate: string,
+  baseRef: string,
+): Promise<string> {
+  const diff = await runGit(ctx, [...REVERSION_DIFF_ARGS, `${baseRef}..${candidate}`]);
+  if (diff.code !== 0) throw new Error("branch reversion check could not read the integrated diff");
+  return diff.stdout;
+}
+
+/** Read base→HEAD geometry inside an already-integrated Worktree. */
+export async function branchReversionDiffAt(
+  repo: string,
+  baseRef: string,
+): Promise<string> {
+  return branchReversionDiff({ cwd: repo }, "HEAD", baseRef);
 }
 
 /** How many base commits to name when reporting stale-base drift. Enough to

--- a/apps/dev/tests/branch-reversion.test.ts
+++ b/apps/dev/tests/branch-reversion.test.ts
@@ -1,0 +1,238 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  detectBranchReversion,
+  testSourceLineRatchet,
+} from "../src/core/branch-reversion.js";
+
+function patchForAddedFile(file: string, lines: readonly string[]): string {
+  return [
+    `diff --git a/${file} b/${file}`,
+    "new file mode 100644",
+    "--- /dev/null",
+    `+++ b/${file}`,
+    `@@ -0,0 +1,${lines.length} @@`,
+    ...lines.map((line) => `+${line}`),
+  ].join("\n");
+}
+
+function patchForDeletedFile(file: string, lines: readonly string[]): string {
+  return [
+    `diff --git a/${file} b/${file}`,
+    "deleted file mode 100644",
+    `--- a/${file}`,
+    "+++ /dev/null",
+    `@@ -1,${lines.length} +0,0 @@`,
+    ...lines.map((line) => `-${line}`),
+  ].join("\n");
+}
+
+function addedHunk(file: string, start: number, lines: readonly string[]): string {
+  return [
+    `diff --git a/${file} b/${file}`,
+    `--- a/${file}`,
+    `+++ b/${file}`,
+    `@@ -${start - 1},0 +${start},${lines.length} @@`,
+    ...lines.map((line) => `+${line}`),
+  ].join("\n");
+}
+
+function deletedHunk(file: string, start: number, lines: readonly string[]): string {
+  return [
+    `diff --git a/${file} b/${file}`,
+    `--- a/${file}`,
+    `+++ b/${file}`,
+    `@@ -${start},${lines.length} +${start - 1},0 @@`,
+    ...lines.map((line) => `-${line}`),
+  ].join("\n");
+}
+
+describe("detectBranchReversion", () => {
+  it("runs the test-source shrink ratchet independently of after-fork geometry", () => {
+    const file = "apps/dev/tests/removed.test.ts";
+
+    const ratchet = testSourceLineRatchet(patchForDeletedFile(file, ["one", "two"]));
+
+    expect(ratchet.testLineDelta).toBe(-2);
+    expect(ratchet.testFilesShrunk).toEqual([file]);
+    expect(ratchet.testFileLineDeltas).toEqual([{ file, delta: -2 }]);
+  });
+
+  it("fails both belts for the pre-rescue #3262 geometry at be56bfc05", () => {
+    const birthLatch = Array.from({ length: 173 }, (_, index) => `birth latch test line ${index + 1}`);
+    const mainLog = [
+      addedHunk("apps/redskilled/src/demand-loop.ts", 398, ["birth latch source"]),
+      addedHunk("apps/dev/src/runtime/feedback-worktree.ts", 461, ["declared setup source"]),
+      patchForAddedFile("apps/dev/src/core/worktree-setup-doctor.ts", ["setup doctor source"]),
+      patchForAddedFile("apps/redskilled/tests/birth-latch.test.ts", birthLatch),
+    ].join("\n");
+    const diff = [
+      deletedHunk("apps/redskilled/src/demand-loop.ts", 398, ["birth latch source"]),
+      deletedHunk("apps/dev/src/runtime/feedback-worktree.ts", 461, ["declared setup source"]),
+      patchForDeletedFile("apps/dev/src/core/worktree-setup-doctor.ts", ["setup doctor source"]),
+      patchForDeletedFile("apps/redskilled/tests/birth-latch.test.ts", birthLatch),
+    ].join("\n");
+
+    const finding = detectBranchReversion(diff, "be56bfc05", mainLog, "", "origin/main");
+
+    expect(finding.blocked).toBe(true);
+    expect(finding.revertingFiles).toEqual([
+      "apps/dev/src/core/worktree-setup-doctor.ts",
+      "apps/dev/src/runtime/feedback-worktree.ts",
+      "apps/redskilled/src/demand-loop.ts",
+      "apps/redskilled/tests/birth-latch.test.ts",
+    ]);
+    expect(finding.testLineDelta).toBe(-173);
+    expect(finding.testFilesShrunk).toEqual(["apps/redskilled/tests/birth-latch.test.ts"]);
+    expect(finding.testFileLineDeltas).toContainEqual({
+      file: "apps/redskilled/tests/birth-latch.test.ts",
+      delta: -173,
+    });
+    expect(finding.repair).toEqual({
+      files: finding.revertingFiles,
+      command:
+        "git checkout origin/main -- apps/dev/src/core/worktree-setup-doctor.ts " +
+        "apps/dev/src/runtime/feedback-worktree.ts apps/redskilled/src/demand-loop.ts " +
+        "apps/redskilled/tests/birth-latch.test.ts",
+    });
+  });
+
+  it("passes an intentional contract-phase deletion and cites its declaration", () => {
+    const file = "packages/red-castle/src/deprecated-aliases.ts";
+    const body = [
+      "## What to build",
+      "",
+      "Consolidation, contract phase: remove the deprecation aliases and add the old verb names to the extinct-names guard so they cannot return.",
+    ].join("\n");
+
+    const finding = detectBranchReversion(
+      patchForDeletedFile(file, ["export const oldAlias = nextVerb;"]),
+      "fork-sha",
+      patchForAddedFile(file, ["export const oldAlias = nextVerb;"]),
+      body,
+      "origin/main",
+    );
+
+    expect(finding.blocked).toBe(false);
+    expect(finding.revertingFiles).toEqual([file]);
+    expect(finding.declaredFiles).toEqual([file]);
+    expect(finding.declarations).toEqual([
+      {
+        files: [file],
+        citation:
+          "Consolidation, contract phase: remove the deprecation aliases and add the old verb names to the extinct-names guard so they cannot return.",
+      },
+    ]);
+    expect(finding.repair).toBeNull();
+  });
+
+  it("lets a path-specific declaration silence only the named file", () => {
+    const declared = "apps/dev/tests/legacy.test.ts";
+    const undeclared = "apps/dev/tests/current.test.ts";
+    const diff = [
+      patchForDeletedFile(declared, ["legacy"]),
+      patchForDeletedFile(undeclared, ["current"]),
+    ].join("\n");
+    const mainLog = [
+      patchForAddedFile(declared, ["legacy"]),
+      patchForAddedFile(undeclared, ["current"]),
+    ].join("\n");
+
+    const finding = detectBranchReversion(
+      diff,
+      "fork-sha",
+      mainLog,
+      "Deletion declaration: remove `apps/dev/tests/legacy.test.ts`.",
+      "origin/main",
+    );
+
+    expect(finding.blocked).toBe(true);
+    expect(finding.declaredFiles).toEqual([declared]);
+    expect(finding.undeclaredRevertingFiles).toEqual([undeclared]);
+    expect(finding.undeclaredTestLineDelta).toBe(-1);
+    expect(finding.repair?.files).toEqual([undeclared]);
+  });
+
+  it("ratchets test-source lines even when the removed lines predate the fork", () => {
+    const file = "apps/dev/tests/old-behaviour.test.ts";
+    const finding = detectBranchReversion(
+      deletedHunk(file, 20, ["test one", "test two"]),
+      "fork-sha",
+      "",
+      "",
+      "origin/main",
+    );
+
+    expect(finding.revertingFiles).toEqual([]);
+    expect(finding.testLineDelta).toBe(-2);
+    expect(finding.undeclaredTestLineDelta).toBe(-2);
+    expect(finding.testFilesShrunk).toEqual([file]);
+    expect(finding.blocked).toBe(true);
+    expect(finding.repair?.command).toBe(`git checkout origin/main -- ${file}`);
+  });
+
+  it("does not let a contract-phase alias declaration whitelist unrelated files", () => {
+    const aliasFile = "packages/red-castle/src/deprecated-aliases.ts";
+    const unrelated = "apps/dev/src/runtime/feedback-worktree.ts";
+    const finding = detectBranchReversion(
+      [patchForDeletedFile(aliasFile, ["alias"]), patchForDeletedFile(unrelated, ["setup"])].join("\n"),
+      "fork-sha",
+      [patchForAddedFile(aliasFile, ["alias"]), patchForAddedFile(unrelated, ["setup"])].join("\n"),
+      "Consolidation, contract phase: remove the deprecation aliases.",
+      "origin/main",
+    );
+
+    expect(finding.declaredFiles).toEqual([aliasFile]);
+    expect(finding.undeclaredRevertingFiles).toEqual([unrelated]);
+    expect(finding.blocked).toBe(true);
+  });
+
+  const repo = resolve(import.meta.dirname, "../../..");
+  const incidentBase = "6b59aab261aed2dc472698c1ac7409bd21a16913";
+  const incidentTip = "be56bfc051644fc6604670a1d1b3d051efe7b7b2";
+  const incidentObjectsAvailable = (() => {
+    try {
+      execFileSync("git", ["cat-file", "-e", `${incidentBase}^{commit}`], { cwd: repo });
+      execFileSync("git", ["cat-file", "-e", `${incidentTip}^{commit}`], { cwd: repo });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  it.runIf(incidentObjectsAvailable)("rejects the actual pre-rescue be56bfc05 tree", () => {
+    const forkPoint = execFileSync("git", ["merge-base", incidentBase, incidentTip], {
+      cwd: repo,
+      encoding: "utf8",
+    }).trim();
+    const args = ["diff", "--no-ext-diff", "--no-renames", "--unified=0"];
+    const afterForkBasePatch = execFileSync("git", [...args, `${forkPoint}..${incidentBase}`], {
+      cwd: repo,
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    const diff = execFileSync("git", [...args, `${incidentBase}..${incidentTip}`], {
+      cwd: repo,
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    });
+
+    const finding = detectBranchReversion(diff, forkPoint, afterForkBasePatch, "", "origin/main");
+
+    expect(finding.blocked).toBe(true);
+    expect(finding.revertingFiles).toEqual(expect.arrayContaining([
+      "apps/redskilled/src/demand-loop.ts",
+      "apps/dev/src/runtime/feedback-worktree.ts",
+      "apps/dev/src/core/worktree-setup-doctor.ts",
+    ]));
+    expect(finding.testFileLineDeltas).toContainEqual({
+      file: "apps/redskilled/tests/birth-latch.test.ts",
+      delta: -173,
+    });
+    expect(finding.repair?.command).toBe(
+      `git checkout origin/main -- ${finding.repair?.files.join(" ")}`,
+    );
+  });
+});

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -676,6 +676,34 @@ describe("makeFeedbackWorktree — rebaseOnto (Pattern 2 drift mitigation)", () 
     expect(rebaseCall.base).toBe("main");
   });
 
+  it("captures the original fork before rebase and the integrated diff after it", async () => {
+    const { io } = fakeIO(0, true, 0, { enabled: false });
+    io.reversionBaseline = async () => ({
+      forkPoint: "fork-sha",
+      afterForkBasePatch: "after-fork patch",
+      baseRef: "pinned-base-sha",
+    });
+    const diffBaseRefs: string[] = [];
+    io.reversionDiff = async (_ctx, _dest, baseRef) => {
+      diffBaseRefs.push(baseRef);
+      return "integrated diff";
+    };
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io, {
+      cacheEnabled: false,
+      rebaseOnto: "main",
+    });
+
+    await fb.pnpm(["pnpm", "-C", BRANCH, "test"]);
+
+    expect(fb.baseMergeReversionGeometry(BRANCH)).toEqual({
+      forkPoint: "fork-sha",
+      afterForkBasePatch: "after-fork patch",
+      baseRef: "pinned-base-sha",
+      diff: "integrated diff",
+    });
+    expect(diffBaseRefs).toEqual(["pinned-base-sha"]);
+  });
+
   it("does NOT rebase when `rebaseOnto` is unset (default OFF — no behaviour change)", async () => {
     const { io, calls } = fakeIO(0, true, 0, { enabled: false });
     const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io, { cacheEnabled: false });

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -90,6 +90,40 @@ describe("doLanding — happy paths", () => {
   });
 });
 
+describe("doLanding — after-fork intent barrier (#3279)", () => {
+  it("checks the rebased PR worktree before opening or merging a pull request", async () => {
+    const h = harness({ locked: false, openPr: true, createPr: true });
+    const checked: string[] = [];
+    h.deps.intentGate = async (dir) => {
+      checked.push(dir);
+      return { ok: false };
+    };
+
+    const result = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(result).toEqual({ ok: false, reason: "intent-finding", locked: false });
+    expect(checked).toEqual([RWT]);
+    expect(joined(h.mergeCalls).some((call) => call.includes("pr create"))).toBe(false);
+    expect(joined(h.mergeCalls).some((call) => call.includes("pr merge"))).toBe(false);
+  });
+
+  it("checks the integrated direct worktree before merging the attempt", async () => {
+    const h = harness({ locked: true, openPr: false });
+    const checked: string[] = [];
+    h.deps.intentGate = async (dir) => {
+      checked.push(dir);
+      return { ok: false };
+    };
+
+    const result = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(result).toEqual({ ok: false, reason: "intent-finding", locked: true });
+    expect(checked).toEqual([WT]);
+    expect(joined(h.mergeCalls).some((call) => call.includes("merge --no-ff"))).toBe(true);
+    expect(joined(h.mergeCalls).some((call) => call.includes("push origin HEAD:refs/heads/main"))).toBe(false);
+  });
+});
+
 describe("doLanding — conventional landing titles (#1267)", () => {
   it.each([
     { labels: ["type:bug"], title: "fix: #9 Fix the thing" },
@@ -836,7 +870,7 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
     expect(h.postMergeGateDirs).toEqual([WT]);
     // The merge still happened (gate passed, not a no-merge).
     expect(joined(h.mergeCalls).some((c) => c.includes("merge"))).toBe(true);
-    expect(h.landingPhases).toEqual(["gate", "gate", "merge", "cascade"]);
+    expect(h.landingPhases).toEqual(["gate", "merge", "gate", "cascade"]);
   });
 
   it("PR path: usable CI evidence → records satisfied-by-CI and skips the local gate", async () => {
@@ -885,8 +919,9 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
     // Nothing was pushed to the remote base (origin/<base>).
     const j = joined(h.mergeCalls);
     expect(j.some((c) => c.includes(`push origin HEAD:refs/heads/`))).toBe(false);
-    // No --no-ff landing merge was created (integrateOrigin's ff-only is allowed).
-    expect(j.some((c) => c.includes("merge --no-ff"))).toBe(false);
+    // The attempt is merged only in the disposable checkout so the gate can
+    // inspect the real integrated tree; the failed gate prevents its push.
+    expect(j.some((c) => c.includes("merge --no-ff"))).toBe(true);
   });
 
   it("PR path: gate wired + fails → returns post-merge-gate, no admin-merge attempted", async () => {

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -145,6 +145,25 @@ describe("integrateOrigin", () => {
 });
 
 describe("landMerge (locked path)", () => {
+  it("can leave the integrated tree unpushed for intent validation", async () => {
+    const { exec, calls } = fakeExec();
+
+    const result = await landMerge(exec, {
+      repo: "/repo",
+      remote: "origin",
+      branch: "afk/wAAAA/9-x",
+      target: "work-branch",
+      n: 9,
+      title: "do thing",
+      preMergeSha: "deadbeef",
+      push: false,
+    });
+
+    expect(result).toEqual({ ok: true, rolledBack: false });
+    expect(joined(calls).some((call) => call.includes("merge --no-ff"))).toBe(true);
+    expect(joined(calls).some((call) => call.includes("push"))).toBe(false);
+  });
+
   it("merges --no-ff into the locked branch then pushes it", async () => {
     const { exec, calls } = fakeExec();
     const result = await landMerge(exec, {

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -14,7 +14,113 @@ import {
 } from "./process-issue.test-helpers.js";
 import type { AttemptProgressInfo, ConfigValues, ProcessIssueDeps } from "./process-issue.test-helpers.js";
 import { failureSignature } from "../src/core/failure-signature.js";
+import type { BranchReversionGeometry } from "../src/core/branch-reversion.js";
+
+function addedFilePatch(file: string, lines: number): string {
+  const body = Array.from({ length: lines }, (_, index) => `+line ${index + 1}`).join("\n");
+  return `diff --git a/${file} b/${file}\n--- /dev/null\n+++ b/${file}\n@@ -0,0 +1,${lines} @@\n${body}\n`;
+}
+
+function deletedFilePatch(file: string, lines: number): string {
+  const body = Array.from({ length: lines }, (_, index) => `-line ${index + 1}`).join("\n");
+  return `diff --git a/${file} b/${file}\n--- a/${file}\n+++ /dev/null\n@@ -1,${lines} +0,0 @@\n${body}\n`;
+}
+
+function reversionGeometry(): BranchReversionGeometry {
+  const source = "apps/redskilled/src/demand-loop.ts";
+  const test = "apps/redskilled/tests/birth-latch.test.ts";
+  return {
+    forkPoint: "fork-sha",
+    baseRef: "origin/main",
+    afterForkBasePatch: addedFilePatch(source, 1) + addedFilePatch(test, 173),
+    diff: deletedFilePatch(source, 1) + deletedFilePatch(test, 173),
+  };
+}
 describe("processIssue — feedback fail", () => {
+  it("fails closed when production omits the feedback reversion barrier", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    deps.requireBranchReversionSafety = true;
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("infra");
+    expect(trace.pnpmArgs).toEqual([]);
+    expect(trace.closed).toEqual([]);
+  });
+
+  it("fails closed when production omits the Landing reversion barrier", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    deps.requireBranchReversionSafety = true;
+    deps.baseMergeReversionGeometry = () => undefined;
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("infra");
+    expect(trace.pnpmArgs.length).toBeGreaterThan(0);
+    expect(trace.mergeCalls.some((argv) => argv.includes("create"))).toBe(false);
+    expect(trace.closed).toEqual([]);
+  });
+
+  it("parks an after-fork reversion created by the feedback worktree base correction", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    const calls: string[] = [];
+    deps.baseMergeReversionGeometry = () => {
+      calls.push("base-merge");
+      return reversionGeometry();
+    };
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(calls).toEqual(["base-merge"]);
+    expect(trace.pnpmArgs.length).toBeGreaterThan(0);
+    expect(trace.closed).toEqual([]);
+    const record = trace.sidecarWrites.at(-1)?.lines.at(-1) ?? "";
+    expect(record).toContain('"schema":"red.afk.branch-reversion.v1"');
+    expect(record).toContain('"test_line_delta":-173');
+    expect(record).toContain("apps/redskilled/src/demand-loop.ts");
+    expect(record).toContain("git checkout origin/main --");
+  });
+
+  it("checks again at the landing/PR-open net after a green machine gate", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    const geometry = reversionGeometry();
+    let baselineCalls = 0;
+    let diffCalls = 0;
+    deps.baseMergeReversionGeometry = () => undefined;
+    deps.lookups.branchReversionBaseline = async () => {
+      baselineCalls += 1;
+      const { diff: _diff, ...baseline } = geometry;
+      return baseline;
+    };
+    deps.lookups.branchReversionDiffAt = async () => {
+      diffCalls += 1;
+      return geometry.diff;
+    };
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(baselineCalls).toBe(1);
+    expect(diffCalls).toBe(1);
+    expect(trace.pnpmArgs.length).toBeGreaterThan(0);
+    expect(trace.mergeCalls.some((argv) => argv.includes("create"))).toBe(false);
+    expect(trace.closed).toEqual([]);
+  });
+
+  it("records the cited declaration when an intentional deletion passes", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    const citation =
+      "Consolidation, contract phase: remove demand-loop.ts and birth-latch.test.ts as deprecation aliases.";
+    input.body = citation;
+    deps.baseMergeReversionGeometry = () => reversionGeometry();
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.sidecarWrites.flatMap((write) => write.lines).some((line) => line.includes(citation))).toBe(true);
+  });
+
   it("rejects a DONE attempt whose worker branch has no diff against base", async () => {
     const { deps, input, trace } = harness({
       outcome: "done",

--- a/apps/dev/tests/runtime-git-branch.test.ts
+++ b/apps/dev/tests/runtime-git-branch.test.ts
@@ -6,7 +6,9 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import {
   branchExists,
+  branchReversionBaseline,
   fetchBranch,
+  fetchBranchRequired,
   FLEET_TRUNK_REF,
   changedFiles,
   prepareFreshWorkerBranch,
@@ -82,6 +84,46 @@ describe("fetchBranch (FIX E recovery)", () => {
     const ctx: GitContext = { cwd: "/repo", exec };
     await fetchBranch(ctx, "");
     expect(calls).toEqual([]);
+  });
+});
+
+describe("fetchBranchRequired (safety barriers)", () => {
+  it("fetches the named remote before reading safety geometry", async () => {
+    const { exec, calls } = recordingExec(() => ok());
+    const ctx: GitContext = { cwd: "/repo", exec };
+
+    await fetchBranchRequired(ctx, "main", "upstream");
+
+    expect(calls[0]).toEqual(["git", "fetch", "upstream", "main"]);
+  });
+
+  it("rejects a failed fetch instead of reading a stale tracking ref", async () => {
+    const { exec } = recordingExec(() => fail());
+    const ctx: GitContext = { cwd: "/repo", exec };
+
+    await expect(fetchBranchRequired(ctx, "main", "origin")).rejects.toThrow(
+      "required git fetch failed for origin/main",
+    );
+  });
+});
+
+describe("branchReversionBaseline", () => {
+  it("pins the base SHA so both geometry patches share immutable coordinates", async () => {
+    const { exec, calls } = recordingExec((_cmd, args) => {
+      if (args.join(" ") === "rev-parse --verify origin/main^{commit}") return ok("base-sha\n");
+      if (args.join(" ") === "merge-base base-sha afk/w/9-x") return ok("fork-sha\n");
+      if (args.at(-1) === "fork-sha..base-sha") return ok("after-fork patch");
+      return fail();
+    });
+
+    await expect(
+      branchReversionBaseline({ cwd: "/repo", exec }, "afk/w/9-x", "origin/main"),
+    ).resolves.toEqual({
+      forkPoint: "fork-sha",
+      afterForkBasePatch: "after-fork patch",
+      baseRef: "base-sha",
+    });
+    expect(calls.some((call) => call.at(-1) === "fork-sha..origin/main")).toBe(false);
   });
 });
 

--- a/packaging/pi/dev/skills/engineering/afk/TROUBLESHOOTING.md
+++ b/packaging/pi/dev/skills/engineering/afk/TROUBLESHOOTING.md
@@ -67,6 +67,44 @@ tracked issue or a global land block.
 This manual verification is a stopgap for the queue reconciler and validation
 authority hardening tracked in #1739.
 
+## After-fork reversion intent finding
+
+### Symptom
+
+A Worker parks on `blocked:validation` with a
+`red.afk.branch-reversion.v1` record. The record names `reverting_files`, a
+negative `test_line_delta`, or both, and carries a structured `repair`.
+
+### Confirm
+
+1. Read the record's `stage`: `base-merge` inspected the feedback Worktree
+   immediately after it corrected a stale base; `landing` is the final net on
+   the integrated tree before a PR opens or the base is written.
+2. Inspect `fork_point`, `reverting_files`, and `test_files_shrunk`. A reverting
+   file deletes lines that reached the base after that fork; the test ratchet
+   independently refuses an undeclared decrease in test-source lines.
+3. Check `declarations`. A path-specific issue-body deletion statement covers
+   only the named path; an explicit `contract phase: remove ...` statement (the
+   #3266 shape) covers the contract deletion and is retained verbatim as its
+   citation. Problem prose or a prohibition on deletion is not a declaration.
+
+### Recover
+
+1. If the deletion was accidental, run the record's pasteable `repair.command`.
+   It is composed as `git checkout origin/<base> -- <exact flagged files>` and
+   restores only `repair.files`.
+2. Reconcile any legitimate branch edits in those files, commit the repair, and
+   re-run the same gate. Never auto-apply the checkout: restoring a whole file
+   can discard intentional edits, which is why this is an intent finding.
+3. If the deletion is intentional, add a precise deletion declaration to the
+   Ticket body (name the paths when the intent is path-specific), then requeue.
+   The next passing record cites the declaration used.
+
+### Root fix
+
+The two deterministic barriers and test-line ratchet are the root fix in #3279;
+adversarial review remains complementary and is not required for this check.
+
 ## Scout and worker salvage after crashed or no-sentinel runs
 
 ### Symptom

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -130,6 +130,9 @@ repair) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` local validation authority (`plugins.dev.afk.feedback.commands`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
+`/afk` after-fork reversion/test-line intent finding
+(`red.afk.branch-reversion.v1`, with its pasteable restoration repair) ->
+`plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md`;
 `/go` interactive admission (`REDSKILLED_INTERACTIVE_RESERVATION`) ->
 `plugins/dev/skills/engineering/go/SKILL.md`;
 the host view a terminal can read (the `redskilled` daemon's `dashboard`

--- a/plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md
+++ b/plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md
@@ -67,6 +67,44 @@ tracked issue or a global land block.
 This manual verification is a stopgap for the queue reconciler and validation
 authority hardening tracked in #1739.
 
+## After-fork reversion intent finding
+
+### Symptom
+
+A Worker parks on `blocked:validation` with a
+`red.afk.branch-reversion.v1` record. The record names `reverting_files`, a
+negative `test_line_delta`, or both, and carries a structured `repair`.
+
+### Confirm
+
+1. Read the record's `stage`: `base-merge` inspected the feedback Worktree
+   immediately after it corrected a stale base; `landing` is the final net on
+   the integrated tree before a PR opens or the base is written.
+2. Inspect `fork_point`, `reverting_files`, and `test_files_shrunk`. A reverting
+   file deletes lines that reached the base after that fork; the test ratchet
+   independently refuses an undeclared decrease in test-source lines.
+3. Check `declarations`. A path-specific issue-body deletion statement covers
+   only the named path; an explicit `contract phase: remove ...` statement (the
+   #3266 shape) covers the contract deletion and is retained verbatim as its
+   citation. Problem prose or a prohibition on deletion is not a declaration.
+
+### Recover
+
+1. If the deletion was accidental, run the record's pasteable `repair.command`.
+   It is composed as `git checkout origin/<base> -- <exact flagged files>` and
+   restores only `repair.files`.
+2. Reconcile any legitimate branch edits in those files, commit the repair, and
+   re-run the same gate. Never auto-apply the checkout: restoring a whole file
+   can discard intentional edits, which is why this is an intent finding.
+3. If the deletion is intentional, add a precise deletion declaration to the
+   Ticket body (name the paths when the intent is path-specific), then requeue.
+   The next passing record cites the declaration used.
+
+### Root fix
+
+The two deterministic barriers and test-line ratchet are the root fix in #3279;
+adversarial review remains complementary and is not required for this check.
+
 ## Scout and worker salvage after crashed or no-sentinel runs
 
 ### Symptom

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -130,6 +130,9 @@ repair) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` local validation authority (`plugins.dev.afk.feedback.commands`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
+`/afk` after-fork reversion/test-line intent finding
+(`red.afk.branch-reversion.v1`, with its pasteable restoration repair) ->
+`plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md`;
 `/go` interactive admission (`REDSKILLED_INTERACTIVE_RESERVATION`) ->
 `plugins/dev/skills/engineering/go/SKILL.md`;
 the host view a terminal can read (the `redskilled` daemon's `dashboard`


### PR DESCRIPTION
Automated AFK landing for #3279. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3279

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788474511&installation_model_id=20659&pr_number=3293&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3293&signature=f258ec319bc783460e6f1cdb75423ca3cb48d201e105322b6ed7ff5a48908dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->