### PR TITLE
chore: #3286 The engine runs declared moments end to end: post_done declared-or-skipped at the fork point, corrections re-run only the failed subset, landing is a declared moment

### DIFF
--- a/apps/dev/src/commands/go.ts
+++ b/apps/dev/src/commands/go.ts
@@ -36,7 +36,7 @@ import {
   type DisposableIssueSpec,
   type GoMode,
 } from "../core/go.js";
-import { loadConfig, readBackpressure, readFeedbackCommands } from "../core/config.js";
+import { loadConfig, readValidationMoments } from "../core/config.js";
 import { dispatchScout, SCOUT_WORKERS_SEGMENT, type ScoutIssueSpec } from "../core/scout.js";
 import { afkPaths, resolveRepoContext } from "../runtime/wire.js";
 import { runCommand } from "./run.js";
@@ -107,8 +107,7 @@ async function createDefaultGoRuntime(cwd: string): Promise<GoRuntime> {
     },
   });
   const gateConfig = loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined });
-  const configuredBackpressure = readBackpressure(gateConfig);
-  const configuredFeedback = readFeedbackCommands(gateConfig);
+  const postDone = readValidationMoments(gateConfig).post_done;
   return {
     ensureLabel: (name) => ghx.ensureLabel(ghCtx, name),
     createGoIssue: (spec) => tracker.createIssue!(spec),
@@ -144,7 +143,7 @@ async function createDefaultGoRuntime(cwd: string): Promise<GoRuntime> {
     birthWorker: (args) => requestWorkerBirth(ctx.root, args, { reservation: "interactive" }),
     runEngineAttached: (args) => runCommand({ args, cwd }),
     checkEngineFloor: () => checkDispatchEngineFloor(ctx.root),
-    hasHarness: configuredFeedback !== undefined || configuredBackpressure.length > 0,
+    hasHarness: postDone !== undefined && postDone.length > 0,
     write: (text) => process.stdout.write(text),
   };
 }

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -310,10 +310,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
     return 1;
   }
 
-  // Feedback worktree manager — checks out the worker branch for the gate.
-  // AFK runner improvement (Pattern 2): `feedbackRebaseBase` is set only when
-  // the `afk.feedback.rebase_on_base` flag is on; undefined → no rebase
-  // (default behaviour unchanged).
+  // Load the declaration schedule before constructing the feedback worktree
+  // that will materialise the Worker's fixed branch tip.
   const config = loadConfig(paths.configPath, { warn: () => undefined });
 
   // Per-issue mutable attempt context the process deps' envelope/iter-log close
@@ -334,12 +332,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
   });
   let gateWaitPublication: Promise<void> = Promise.resolve();
 
-  // Feedback worktree manager — checks out the worker branch for the gate.
-  // AFK runner improvement (Pattern 2): `feedbackRebaseBase` is set only when
-  // the `afk.feedback.rebase_on_base` flag is on; undefined → no rebase
-  // (default behaviour unchanged).
+  // Feedback worktree manager — checks out the worker branch at its own tip.
+  // ADR 0135 deliberately does not rebase it onto the moving live base:
+  // post_done validates against the Worker's fork point, while freshness is
+  // owned by the merge queue.
   const feedback = makeFeedbackWorktree(ctx.root, paths.feedbackWorktreesDir, undefined, {
-    rebaseOnto: settings.feedbackRebaseBase,
     resourceBudget: readValidationResourceBudget(config),
     setupCommands: readSetupCommands(config),
     // A host-wide lock wait is the gate's only silent stall: no child, no

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -283,6 +283,13 @@ export function buildProcessDeps({
     inlineVerifyCommand && inlineVerifyCommand.trim() !== ""
       ? [...backpressureCommands, inlineVerifyCommand.trim()]
       : backpressureCommands;
+  const validationMoments = readValidationMoments(config);
+  if (inlineVerifyCommand && inlineVerifyCommand.trim() !== "") {
+    validationMoments.post_done = [
+      ...(validationMoments.post_done ?? []),
+      inlineVerifyCommand.trim(),
+    ];
+  }
 
   return {
     gh: buildGhPort(ghCtx),
@@ -311,13 +318,13 @@ export function buildProcessDeps({
     // the agent commits (the continuous-push hook, issue #191); a worktree still
     // dirty when the worker exits is disposable, and the terminal Envelope plus
     // those pushed commits are the forensic record.
-    // Feedback runs against a checkout of the worker branch — the feedback
-    // worktree manager materialises it and rebases pnpm/layout onto it.
+    // Validation runs against a checkout of the worker branch — the feedback
+    // worktree manager materialises pnpm/layout onto that fixed branch tip.
     pnpm: feedback.pnpm,
     baseMergeReversionGeometry: feedback.baseMergeReversionGeometry,
     requireBranchReversionSafety: true,
     validationResourceBudget: readValidationResourceBudget(config),
-    validationMoments: readValidationMoments(config),
+    validationMoments,
     // The gate's proof that a declared validation worktree is really there
     // (#3041): a landing worktree that vanished refuses as an infrastructure
     // error instead of composing commands against a path that resolves nowhere.

--- a/apps/dev/src/commands/run/reconcile.ts
+++ b/apps/dev/src/commands/run/reconcile.ts
@@ -10,7 +10,6 @@ import {
 } from "../../core/merge-conflict-reconcile.js";
 import type { Runner } from "../../types/runner.js";
 import {
-  resolveRunSettings,
   type RepoContext,
   type AfkPaths,
 } from "../../runtime/wire.js";
@@ -363,10 +362,8 @@ export async function runReconcileWorker(
     branch,
   };
 
-  const reconcileSettings = resolveRunSettings(ctx.root, process.env, runner);
   const config = loadConfig(paths.configPath);
   const feedback = makeFeedbackWorktree(ctx.root, paths.feedbackWorktreesDir, undefined, {
-    rebaseOnto: reconcileSettings.feedbackRebaseBase,
     resourceBudget: readValidationResourceBudget(config),
     setupCommands: readSetupCommands(config),
   });

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -106,17 +106,6 @@ export const CONFIG_DEFAULTS = {
   "afk.models.claude-minimax.think.effort": "low",
   "afk.hooks.defaults.cargo": "true",
   "afk.hooks.defaults.gradle": "true",
-  // Feedback-gate base rebase (AFK runner improvement, Pattern 2). When true,
-  // a freshly materialised worker worktree is rebased onto the session base
-  // BEFORE the gate runs, so a worker test written against a now-moved base
-  // (the wPB6F/wQYIB CLAUDE_CODE_SIMPLE drift) validates against the latest
-  // source rather than failing on stale expectations. Best-effort: a rebase
-  // conflict aborts and the gate runs un-rebased (the baseline probe then
-  // downgrades the resulting pre-existing failure). OFF by default — a repo
-  // that pins per-issue bases (issue body pinning to a non-main branch) must
-  // leave it off, since the session-level base would rebase onto the wrong
-  // ref. Safe to enable for repos whose issues all target one trunk.
-  "afk.feedback.rebase_on_base": "false",
   // Merge-gate policy (ADR 0048). The unlocked admin-merge ignores advisory
   // review checks by default — the binding gates are `drift-guard` (the
   // pre_merge hook) + in-process backpressure/feedback. Opt into waiting for an

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -623,7 +623,7 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
           postMergeValidation = ciSatisfiedValidation(prNumber, ciEvidence);
           return { ok: true };
         }
-        if (!deps.postMergeGate && (deps.requirePostMergeValidation || deps.ciAwait)) {
+        if (!deps.postMergeGate && deps.requirePostMergeValidation) {
           missingPostMergeFallback = true;
           return { ok: false };
         }

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -501,6 +501,7 @@ export async function processIssue(
       : null;
   const failureReason = extractFailureReason(prevFailureContext);
   const carriedValidationSignature = parseValidationFailureSignature(failureReason);
+  const usesDeclaredValidationMoments = deps.validationMoments !== undefined;
   const resumeIsGateGreen = adoptedPullRequest !== null ||
     (resumableBranch !== null && isGateGreenBranch(failureReason));
   if (adoptedPullRequest) {
@@ -535,10 +536,12 @@ export async function processIssue(
     comments,
     prevFailureContext,
     specRef: input.specRef,
-    mergeGateCommands: [
-      ...(deps.feedbackCommands ?? []),
-      ...(deps.backpressureCommands ?? []),
-    ],
+    mergeGateCommands: usesDeclaredValidationMoments
+      ? (deps.validationMoments?.post_done ?? [])
+      : [
+          ...(deps.feedbackCommands ?? []),
+          ...(deps.backpressureCommands ?? []),
+        ],
     outputShaping,
     resumeFromBranch: resumeInstruction,
     enrichment,
@@ -658,11 +661,60 @@ export async function processIssue(
     ...branchReversionRecords.values(),
     ...validationSidecar,
   ];
+  let postDoneCorrectionCommands: readonly string[] | undefined;
   let lastValidationScope: ValidationScope | undefined = undefined;
   let landingFeedbackScopes: string[] = ["."];
   let noSourceDiffWarning: string | undefined;
   let currentHandoff = handoff;
   let correctionLedger: CorrectionLedger = EMPTY_CORRECTION_LEDGER;
+  const validationBaseRef = usesDeclaredValidationMoments
+    ? (baseResolution.sha || baseRef)
+    : baseRef;
+  const skippedMomentResult = (
+    moment: "post_done" | "landing",
+    validationScope?: ValidationScope,
+  ): RunFeedbackResult => {
+    const record = buildValidationRecord({
+      name: `validation:${moment}`,
+      status: "skipped",
+      summary: "undeclared",
+    });
+    deps.appendIterLog(`🤖 /afk validation moment ${moment} skipped: undeclared.`);
+    return {
+      ok: true,
+      checks: [],
+      sidecar: [formatValidationLine(record)],
+      baselineInconclusive: [],
+      quarantined: [],
+      ...(validationScope === undefined ? {} : { validationScope }),
+    };
+  };
+  const runDeclaredMoment = async (
+    moment: "post_done" | "landing",
+    commands: readonly string[] | undefined,
+    scopes: readonly string[],
+    validationScope?: ValidationScope,
+  ): Promise<RunFeedbackResult> => {
+    if (commands === undefined) return skippedMomentResult(moment, validationScope);
+    deps.appendIterLog(
+      `🤖 /afk validation moment ${moment} running ${commands.length} declared command${commands.length === 1 ? "" : "s"}.`,
+    );
+    const result = await runFeedback(deps.pnpm, {
+      worktree: workerBranch,
+      worktreeKind: "branch",
+      scopes,
+      layout: deps.layout,
+      now: deps.nowEpoch,
+      validationScope,
+      resourceBudget: deps.validationResourceBudget,
+      commands,
+      commandExec: deps.backpressure,
+    });
+    deps.appendIterLog(
+      `🤖 /afk validation moment ${moment} ${result.ok ? "passed" : "failed"}.`,
+    );
+    return result;
+  };
   // Two consecutive identical suspect-infra readings on the gate-only rerun
   // saw the same branch and the same environment. That is deterministic setup
   // failure, not a flake worth another free cycle or outer recovery attempt.
@@ -1031,7 +1083,7 @@ export async function processIssue(
       gate,
       validation,
       sidecar,
-      driftEligible: trigger === "gate-stage",
+      driftEligible: trigger === "gate-stage" && !usesDeclaredValidationMoments,
       suspectInfra,
     })) ===
     "granted";
@@ -1483,7 +1535,7 @@ export async function processIssue(
     deps.markPhase?.("validating");
     markProcessSafetyStep("post-agent:feedback-start");
 
-    const changedFiles = await deps.lookups.changedFiles(workerBranch, baseRef);
+    const changedFiles = await deps.lookups.changedFiles(workerBranch, validationBaseRef);
     if (changedFiles.length === 0) {
       const validationText =
         "DONE rejected: attempt branch has no diff against the merge-base; no work changed, so the completion claim was not accepted.";
@@ -1504,7 +1556,7 @@ export async function processIssue(
     let rootPackageJson: { before: string; after: string } | undefined;
     if (changedFiles.some((file) => file === "package.json" || file === "./package.json")) {
       rootPackageJson = await deps.lookups
-        .changedFileContents?.(workerBranch, baseRef, "package.json")
+        .changedFileContents?.(workerBranch, validationBaseRef, "package.json")
         .catch(() => undefined);
     }
     const validationScope = computeValidationScope(
@@ -1535,22 +1587,46 @@ export async function processIssue(
       deps.appendIterLog(`🤖 /afk: ${reason}`);
       return await terminalFailure(common, "infra", "infra", { log: reason }, { notes: reason });
     }
-    const feedback: RunFeedbackResult = await runFeedback(deps.pnpm, {
-      worktree: workerBranch,
-      // A branch NAME, not a directory (#3041): `deps.pnpm` materialises it and
-      // reports back the absolute checkout it ran in. Declaring the kind keeps
-      // the gate from ever reading the branch token as a missing directory.
-      worktreeKind: "branch",
-      scopes: feedbackScopes,
-      layout: deps.layout,
-      now: deps.nowEpoch,
-      baselineWorktree: base,
-      validationScope,
-      resourceBudget: deps.validationResourceBudget,
-      ...(deps.feedbackCommands === undefined
-        ? {}
-        : { commands: deps.feedbackCommands, commandExec: deps.backpressure }),
-    });
+    let feedback: RunFeedbackResult;
+    if (usesDeclaredValidationMoments) {
+      const fullDeclaration = deps.validationMoments?.post_done;
+      feedback = await runDeclaredMoment(
+        "post_done",
+        postDoneCorrectionCommands ?? fullDeclaration,
+        feedbackScopes,
+        validationScope,
+      );
+      if (postDoneCorrectionCommands !== undefined && feedback.ok) {
+        deps.appendIterLog(
+          "🤖 /afk validation moment post_done correction subset passed; folding back to the full declaration.",
+        );
+        postDoneCorrectionCommands = undefined;
+        feedback = await runDeclaredMoment("post_done", fullDeclaration, feedbackScopes, validationScope);
+      }
+      if (!feedback.ok && fullDeclaration !== undefined) {
+        const failedCommands = feedback.checks.flatMap((check) =>
+          check.status === "failed" && check.record.command ? [check.record.command] : []
+        );
+        postDoneCorrectionCommands = failedCommands.length > 0 ? failedCommands : fullDeclaration;
+      }
+    } else {
+      feedback = await runFeedback(deps.pnpm, {
+        worktree: workerBranch,
+        // A branch NAME, not a directory (#3041): `deps.pnpm` materialises it and
+        // reports back the absolute checkout it ran in. Declaring the kind keeps
+        // the gate from ever reading the branch token as a missing directory.
+        worktreeKind: "branch",
+        scopes: feedbackScopes,
+        layout: deps.layout,
+        now: deps.nowEpoch,
+        baselineWorktree: base,
+        validationScope,
+        resourceBudget: deps.validationResourceBudget,
+        ...(deps.feedbackCommands === undefined
+          ? {}
+          : { commands: deps.feedbackCommands, commandExec: deps.backpressure }),
+      });
+    }
     markProcessSafetyStep("post-agent:feedback-done");
     const baseMergeGeometry = deps.baseMergeReversionGeometry?.(workerBranch);
     if (baseMergeGeometry) {
@@ -1658,7 +1734,7 @@ export async function processIssue(
         validation: validationText,
       }, { validationSummary: feedback.sidecar.join("\n") });
     }
-    const backpressureCommands = deps.backpressureCommands ?? [];
+    const backpressureCommands = usesDeclaredValidationMoments ? [] : (deps.backpressureCommands ?? []);
     let backpressureSidecar: string[] = [];
     if (deps.backpressure && backpressureCommands.length > 0) {
       markProcessSafetyStep("post-agent:backpressure-start");
@@ -1759,6 +1835,30 @@ export async function processIssue(
     });
 
   markProcessSafetyStep("post-agent:landing-start");
+  if (usesDeclaredValidationMoments) {
+    const landingValidation = await runDeclaredMoment(
+      "landing",
+      deps.validationMoments?.landing,
+      landingFeedbackScopes,
+      lastValidationScope,
+    );
+    validationSidecar = [...validationSidecar, ...landingValidation.sidecar];
+    if (!landingValidation.ok) {
+      const completeSidecar = completeValidationSidecar();
+      await writeValidationSidecar(deps, input.attemptDir, completeSidecar);
+      const validationText = completeSidecar.join("\n");
+      return await terminalFailure(
+        common,
+        "feedback-failed",
+        "feedback",
+        {
+          notes: "The declared landing validation moment failed before push or pull-request creation.",
+          validation: validationText,
+        },
+        { validationSummary: validationText },
+      );
+    }
+  }
   const locked = await deps.lookups.isLocked();
   const openPr = deps.worktreeLaunchesPr !== false;
   if (labels.includes(LABEL_LANDING_MANUAL)) {
@@ -1849,48 +1949,52 @@ export async function processIssue(
       onPrResolved: async (pr) => {
         await emitBackpressureReview(common, pr);
       },
-      postMergeGate: async (mergedTreeDir) => {
-        const mergedFeedback = await runFeedback(deps.pnpm, {
-          worktree: mergedTreeDir,
-          // The landing worktree is a DIRECTORY the caller just provisioned
-          // (#3041). Declaring it means a vanished one refuses the gate as an
-          // infrastructure error instead of composing commands against a path
-          // that resolves nowhere and calling the result the branch's verdict.
-          worktreeKind: "checkout",
-          ...(deps.dirExists === undefined ? {} : { dirExists: deps.dirExists }),
-          scopes: landingFeedbackScopes,
-          layout: deps.layout,
-          now: deps.nowEpoch,
-          baselineWorktree: base,
-          validationScope: lastValidationScope,
-          resourceBudget: deps.validationResourceBudget,
-          ...(deps.feedbackCommands === undefined
-            ? {}
-            : { commands: deps.feedbackCommands, commandExec: deps.backpressure }),
-        });
-        if (!mergedFeedback.ok) {
-          validationSidecar = [...mergedFeedback.sidecar];
-          await writeValidationSidecar(deps, input.attemptDir, completeValidationSidecar());
-          return { ok: false };
-        }
-        const gateBackpressureCommands = deps.backpressureCommands ?? [];
-        if (deps.backpressure && gateBackpressureCommands.length > 0) {
-          const mergedBackpressure = await runBackpressure(deps.backpressure, {
-            worktree: mergedTreeDir,
-            commands: gateBackpressureCommands,
-            now: deps.nowEpoch,
-          });
-          common.backpressureChecks = mergedBackpressure.checks;
-          validationSidecar = [...mergedFeedback.sidecar, ...mergedBackpressure.sidecar];
-          if (!mergedBackpressure.ok) {
-            await writeValidationSidecar(deps, input.attemptDir, completeValidationSidecar());
-          }
-          return { ok: mergedBackpressure.ok };
-        }
-        validationSidecar = [...mergedFeedback.sidecar];
-        return { ok: true };
-      },
-      requirePostMergeValidation: true,
+      ...(usesDeclaredValidationMoments
+        ? {}
+        : {
+            postMergeGate: async (mergedTreeDir: string) => {
+              const mergedFeedback = await runFeedback(deps.pnpm, {
+                worktree: mergedTreeDir,
+                // The landing worktree is a DIRECTORY the caller just provisioned
+                // (#3041). Declaring it means a vanished one refuses the gate as an
+                // infrastructure error instead of composing commands against a path
+                // that resolves nowhere and calling the result the branch's verdict.
+                worktreeKind: "checkout",
+                ...(deps.dirExists === undefined ? {} : { dirExists: deps.dirExists }),
+                scopes: landingFeedbackScopes,
+                layout: deps.layout,
+                now: deps.nowEpoch,
+                baselineWorktree: base,
+                validationScope: lastValidationScope,
+                resourceBudget: deps.validationResourceBudget,
+                ...(deps.feedbackCommands === undefined
+                  ? {}
+                  : { commands: deps.feedbackCommands, commandExec: deps.backpressure }),
+              });
+              if (!mergedFeedback.ok) {
+                validationSidecar = [...mergedFeedback.sidecar];
+                await writeValidationSidecar(deps, input.attemptDir, completeValidationSidecar());
+                return { ok: false };
+              }
+              const gateBackpressureCommands = deps.backpressureCommands ?? [];
+              if (deps.backpressure && gateBackpressureCommands.length > 0) {
+                const mergedBackpressure = await runBackpressure(deps.backpressure, {
+                  worktree: mergedTreeDir,
+                  commands: gateBackpressureCommands,
+                  now: deps.nowEpoch,
+                });
+                common.backpressureChecks = mergedBackpressure.checks;
+                validationSidecar = [...mergedFeedback.sidecar, ...mergedBackpressure.sidecar];
+                if (!mergedBackpressure.ok) {
+                  await writeValidationSidecar(deps, input.attemptDir, completeValidationSidecar());
+                }
+                return { ok: mergedBackpressure.ok };
+              }
+              validationSidecar = [...mergedFeedback.sidecar];
+              return { ok: true };
+            },
+            requirePostMergeValidation: true,
+          }),
       landingPhase: markLandingPhase,
     },
     {

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -115,8 +115,7 @@ import { cleanupDisposableDispatchOnBootFailure } from "./commands/run/disposabl
 import {
   getConfig,
   loadConfig,
-  readBackpressure,
-  readFeedbackCommands,
+  readValidationMoments,
   readHitlTypeLabels,
   readValidationResourceBudget,
   readSetupCommands,
@@ -388,8 +387,7 @@ export function createDefaultDevAfkMcpOperations(
       const floorWarnings = await engineFloorWarnings(cwd);
       let granted: DispatchedWorkerBirth | undefined;
       const gateConfig = loadConfig(afkPaths(cwd).configPath, { warn: () => undefined });
-      const configuredBackpressure = readBackpressure(gateConfig);
-      const configuredFeedback = readFeedbackCommands(gateConfig);
+      const postDone = readValidationMoments(gateConfig).post_done;
       const result = await dispatchGo(
         {
           ensureLabel: (name) => runtime.ensureLabel(cwd, name),
@@ -419,7 +417,7 @@ export function createDefaultDevAfkMcpOperations(
           // scout is routed before dispatchDemand is reached — cast to go-mode union
           mode: input.mode as "no-mistakes" | "direct-PR" | "local-only" | undefined,
           request: input.request,
-          hasHarness: configuredFeedback !== undefined || configuredBackpressure.length > 0,
+          hasHarness: postDone !== undefined && postDone.length > 0,
         },
       );
       if (granted === undefined) {

--- a/apps/dev/src/runtime/wire/settings.ts
+++ b/apps/dev/src/runtime/wire/settings.ts
@@ -50,19 +50,6 @@ export interface RunSettings {
    * stall threshold; the progress guard caps the whole attempt on no-commit.
    */
   laneIdle: LaneIdleStallConfig;
-  /**
-   * AFK runner improvement (Pattern 2): the base branch the feedback gate
-   * rebases a freshly materialised worker worktree onto, or `undefined` when
-   * the rebase is OFF. Resolved from `afk.feedback.rebase_on_base` (default
-   * false → undefined) AND the config-locked branch (`dev.lock.branch`,
-   * falling back to "main"). Left undefined when the flag is off, so the
-   * default behaviour — no rebase — is unchanged. The file-level branch lock
-   * (`.red/tmp/branch-lock.yaml`) is NOT consulted here: it pins the agent's
-   * interactive checkout, not the AFK base, which resolveBase derives
-   * per-issue. This session-level base is the common-case trunk; per-issue
-   * pinned bases are exactly why the flag defaults off.
-   */
-  feedbackRebaseBase?: string;
 }
 
 const SANDBOX_MODES: readonly SandboxMode[] = ["none", "docker", "podman"];
@@ -116,17 +103,6 @@ export function resolveRunSettings(
   // defaults and the same boot invariant (kill > soft) — throws here on a `<=`
   // config so the run fails fast before claiming an issue.
   const laneIdle = resolveLaneIdleStallConfig(env);
-  // Feedback-gate base rebase (Pattern 2). Only resolves to a base branch when
-  // the opt-in flag is on; the base is the config-locked branch or the Trunk
-  // (`dev.trunk`, ADR 0083 — defaults to "main").
-  // A RED_AFK_FEEDBACK_REBASE env knob lets an E2E/CI run force it without
-  // mutating .red/config.yaml, mirroring the other RED_AFK_* overrides.
-  const rebaseFlag =
-    (env.RED_AFK_FEEDBACK_REBASE ?? "").trim() === "1" ||
-    getConfig(cfg, "afk.feedback.rebase_on_base") === "true";
-  const feedbackRebaseBase = rebaseFlag
-    ? getConfig(cfg, "dev.lock.branch") || getConfig(cfg, "dev.trunk") || "main"
-    : undefined;
   return {
     sandbox,
     sandboxImage,
@@ -135,7 +111,6 @@ export function resolveRunSettings(
     effort: tier.effort,
     maxIterations,
     laneIdle,
-    feedbackRebaseBase,
   };
 }
 

--- a/apps/dev/tests/afk-resilience.test.ts
+++ b/apps/dev/tests/afk-resilience.test.ts
@@ -122,22 +122,16 @@ describe("Pattern 2 — test drift between worker branch and main", () => {
     expect(check.record.summary).toContain("inconclusive: also fails on the baseline");
   });
 
-  it("the optional rebase-on-base is wired through resolveRunSettings (opt-in, default OFF)", async () => {
-    // The deeper fix for drift: rebase the worker branch onto the moved base
-    // BEFORE the gate runs so the updated test runs against the worker's code.
-    // It is opt-in (afk.feedback.rebase_on_base) so a per-issue-pinned repo
-    // doesn't rebase onto the wrong base. Here we assert the resolution
-    // contract: OFF by default, ON via the flag.
+  it("retires the live-base feedback rebase from run settings", async () => {
     const { resolveRunSettings } = await import("../src/runtime/wire.js");
     const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
     const root = mkdtempSync(join(tmpdir(), "afk-resilience-rebase-"));
     try {
-      expect(resolveRunSettings(root).feedbackRebaseBase).toBeUndefined();
       mkdirSync(join(root, ".red"), { recursive: true });
       writeFileSync(join(root, ".red", "config.yaml"), "plugins:\n  dev:\n    enabled: true\nafk:\n  feedback:\n    rebase_on_base: true\n");
-      expect(resolveRunSettings(root).feedbackRebaseBase).toBe("main");
+      expect(resolveRunSettings(root)).not.toHaveProperty("feedbackRebaseBase");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -841,15 +841,13 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
     expect(h.postMergeGateDirs).toEqual([]);
   });
 
-  it("PR path: gate absent + unusable CI evidence → fails infra", async () => {
+  it("PR path: gate not required + unusable CI evidence → proceeds without a local rerun", async () => {
     const h = harness({ locked: false, openPr: true, ciAware: "skipped" });
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({
-      ok: false,
-      reason: "infra",
+      ok: true,
       locked: false,
-      prNumber: 42,
-      infraReason: "Post-merge validation fallback is not configured and PR CI evidence was absent or unusable.",
+      mergeSha: "abc1234",
     });
     expect(h.postMergeGateDirs).toEqual([]);
   });

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -1084,6 +1084,100 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
     expect(handoff).toContain(`- ${command}`);
   });
 
+  it("skips undeclared post_done and landing moments without discovering local commands", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", locked: false });
+    deps.validationMoments = {};
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.pnpmArgs).toEqual([]);
+    expect(trace.shellCommands).toEqual([]);
+    expect(trace.iterLogs).toContain("🤖 /afk validation moment post_done skipped: undeclared.");
+    expect(trace.iterLogs).toContain("🤖 /afk validation moment landing skipped: undeclared.");
+    expect(trace.envelopeBodies.at(-1) ?? "").toContain('"name":"validation:post_done","status":"skipped"');
+    expect(trace.envelopeBodies.at(-1) ?? "").toContain('"name":"validation:landing","status":"skipped"');
+  });
+
+  it("runs declared post_done at the branch fork point even when the live base moves", async () => {
+    const command = "pnpm test:fork-point";
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      baseMovements: [{ head: "new-main", subjects: ["chore: moved base"] }],
+      locked: false,
+    });
+    deps.validationMoments = { post_done: [command] };
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.shellCommands).toEqual([command]);
+    expect(trace.baseMovementCalls).toEqual([]);
+    expect(trace.changedFileCalls[0]?.base).toBe("origin/main-tip");
+  });
+
+  it("re-runs only the failed post_done subset, then folds back to the full declaration", async () => {
+    const commands = ["pnpm test:a", "pnpm test:b"];
+    const { deps, input, trace } = harness({ outcome: "done", reseedGateBudget: 1, locked: false });
+    deps.validationMoments = { post_done: commands };
+    let call = 0;
+    let clock = 0;
+    deps.nowEpoch = () => (clock += 1000);
+    deps.backpressure = async ({ command }) => {
+      trace.shellCommands.push(command);
+      call += 1;
+      return {
+        code: call === 1 ? 1 : 0,
+        stdout: call === 1 ? "a failed" : "",
+        stderr: "",
+      };
+    };
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.shellCommands).toEqual([
+      "pnpm test:a",
+      "pnpm test:b",
+      "pnpm test:a",
+      "pnpm test:a",
+      "pnpm test:b",
+    ]);
+    expect(trace.iterLogs).toContain(
+      "🤖 /afk validation moment post_done correction subset passed; folding back to the full declaration.",
+    );
+  });
+
+  it("runs a declared landing moment before push and PR creation", async () => {
+    const events: string[] = [];
+    const { deps, input, trace } = harness({ outcome: "done", locked: false });
+    deps.validationMoments = { landing: ["pnpm test:landing"] };
+    const shellExec = deps.backpressure!;
+    deps.backpressure = async (request) => {
+      events.push(`validation:${request.command}`);
+      return shellExec(request);
+    };
+    const remoteGit = deps.remoteGit;
+    deps.remoteGit = async (argv) => {
+      events.push(`push:${argv.join(" ")}`);
+      return remoteGit(argv);
+    };
+    const mergeExec = deps.mergeExec;
+    deps.mergeExec = async (argv) => {
+      if (argv.includes("pr") && argv.includes("create")) events.push("pr:create");
+      return mergeExec(argv);
+    };
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(events[0]).toBe("validation:pnpm test:landing");
+    expect(events.indexOf("validation:pnpm test:landing")).toBeLessThan(events.findIndex((event) => event.startsWith("push:")));
+    expect(events.indexOf("validation:pnpm test:landing")).toBeLessThan(events.indexOf("pr:create"));
+    expect(trace.shellCommands).toEqual(["pnpm test:landing"]);
+  });
+
   it("omits <merge-gate> from the handoff when no backpressure command is configured (#849)", async () => {
     const { deps, input, trace } = harness({ outcome: "done" });
     await processIssue(deps, input);

--- a/apps/dev/tests/wire-runtime.test.ts
+++ b/apps/dev/tests/wire-runtime.test.ts
@@ -199,60 +199,12 @@ describe("resolveRunSettings", () => {
     }
   });
 
-  // AFK runner improvement (Pattern 2): feedbackRebaseBase is undefined by
-  // default (the rebase is OFF), resolves to "main" when the flag is on with
-  // no lock, and to the config-locked branch when one is set. The
-  // RED_AFK_FEEDBACK_REBASE=1 env knob forces it on without config.
-  it("feedbackRebaseBase is undefined by default (rebase OFF)", () => {
-    const root = scratch();
-    try {
-      expect(resolveRunSettings(root).feedbackRebaseBase).toBeUndefined();
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it("feedbackRebaseBase resolves to 'main' when afk.feedback.rebase_on_base is true", () => {
+  it("does not expose the retired live-base feedback rebase setting", () => {
     const root = scratch();
     try {
       mkdirSync(join(root, ".red"), { recursive: true });
       writeFileSync(join(root, ".red", "config.yaml"), "plugins:\n  dev:\n    enabled: true\nafk:\n  feedback:\n    rebase_on_base: true\n");
-      expect(resolveRunSettings(root).feedbackRebaseBase).toBe("main");
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it("feedbackRebaseBase resolves to the config-locked branch when set + flag on", () => {
-    const root = scratch();
-    try {
-      mkdirSync(join(root, ".red"), { recursive: true });
-      writeFileSync(
-        join(root, ".red", "config.yaml"),
-        "plugins:\n  dev:\n    enabled: true\ndev:\n  lock:\n    branch: release-2\nafk:\n  feedback:\n    rebase_on_base: true\n",
-      );
-      expect(resolveRunSettings(root).feedbackRebaseBase).toBe("release-2");
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it("RED_AFK_FEEDBACK_REBASE=1 forces the rebase base on without config", () => {
-    const root = scratch();
-    try {
-      expect(resolveRunSettings(root, { RED_AFK_FEEDBACK_REBASE: "1" }).feedbackRebaseBase).toBe("main");
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it("the config-locked branch alone does NOT enable the rebase (flag must be on)", () => {
-    const root = scratch();
-    try {
-      mkdirSync(join(root, ".red"), { recursive: true });
-      writeFileSync(join(root, ".red", "config.yaml"), "plugins:\n  dev:\n    enabled: true\ndev:\n  lock:\n    branch: release-2\n");
-      // No rebase_on_base flag → undefined even though a locked branch exists.
-      expect(resolveRunSettings(root).feedbackRebaseBase).toBeUndefined();
+      expect(resolveRunSettings(root, { RED_AFK_FEEDBACK_REBASE: "1" })).not.toHaveProperty("feedbackRebaseBase");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/dev/tests/wiring-integration.test.ts
+++ b/apps/dev/tests/wiring-integration.test.ts
@@ -121,11 +121,12 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
       fallbackRunner: false,
       runner: "codex",
       exec,
+      inlineVerifyCommand: "pnpm test:inline",
     });
 
     expect(deps.validationMoments).toEqual({
       iteration: ["pnpm test"],
-      post_done: ["pnpm typecheck"],
+      post_done: ["pnpm typecheck", "pnpm test:inline"],
       landing: ["pnpm build"],
     });
   });


### PR DESCRIPTION
Automated AFK landing for #3286. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3286

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788475273&installation_model_id=20659&pr_number=3294&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3294&signature=2796d0dd1aaa032329b48ac75cd9208ae641f7ac5019b6ee0ab1b83a6135157c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->