### PR TITLE
merge: #3285 A repair lane heals merge-queue ejections mechanically, so a stale mirror or release bump never strands a PR waiting for a human

### DIFF
--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -147,7 +147,7 @@ The bound on how many **Re-seed** rounds one **Worker** may spend. A single ceil
 _Avoid_: correction budget, convergence budget, stall convergence budget (the `afk.stallConvergenceBudget` key names the retired shape), heal ledger (that is the per-Ticket repair history, a different object), attempt ledger, per-attempt budget (the rounds are events inside one running **Worker**, never a new unit of work)
 
 **Worker kind**:
-The castle engine provenance stamp that distinguishes why a **Worker** exists while all new workers share `.red/tmp/workers/`: `current.kind=afk` for the **Demand producer**'s queue-draining work, `current.kind=go` for approved one-off `/go` dispatch, and `current.kind=scout` for read-only `/go --scout` investigations. The legacy `.red/tmp/go-workers/` and `.red/tmp/scout-workers/` roots are read only as transitional observability inputs until they age out; they are not the live isolation contract.
+The castle engine provenance stamp that distinguishes why a **Worker** exists while all new workers share `.red/tmp/workers/`: `current.kind=afk` for the **Demand producer**'s queue-draining work, `current.kind=go` for approved one-off `/go` dispatch, `current.kind=scout` for read-only `/go --scout` investigations, and `current.kind=repair` for the mechanical merge-queue lane that merges the fresh base, regenerates declared mirrors, publishes, and re-queues without waking the owning Worker. The legacy `.red/tmp/go-workers/` and `.red/tmp/scout-workers/` roots are read only as transitional observability inputs until they age out; they are not the live isolation contract.
 _Avoid_: worker namespace, go-workers root, scout-workers root
 
 **Worker state reader**:

--- a/apps/dev/src/core/repair-lane.ts
+++ b/apps/dev/src/core/repair-lane.ts
@@ -1,0 +1,214 @@
+// repair-lane — mechanical merge-queue recovery for fleet pull requests
+// (Spec #3283, issue #3285).
+//
+// A repair Worker is not an owning issue Worker and never runs an inner agent.
+// It has its own provenance in the shared Worker root, merges the current base,
+// runs the repository's declared generators verbatim, publishes the repaired
+// branch, and asks the merge queue again. Only a semantic failure observed
+// AFTER that re-queue is attached to and escalated through the owning Ticket.
+//
+// PURE SEQUENCING: forge, git, shell, tracker, and Worker-state effects are
+// injected. This keeps queue-event and periodic-sweep callers on one behavior.
+
+/** Spawn-time provenance written to `origin` in the shared Worker state. */
+export const REPAIR_ORIGIN = "repair";
+
+/** Castle Worker kind written to `current.kind`. */
+export const REPAIR_KIND = "repair";
+
+export interface RepairCandidate {
+  readonly prNumber: number;
+  readonly ownerTicket: number;
+  readonly branch: string;
+  readonly base: string;
+  readonly mergeStateStatus: string;
+  readonly mergeable: string;
+  /** True while the forge still carries the auto-merge/queue request. */
+  readonly queued: boolean;
+}
+
+export interface RepairWorkerStamp {
+  readonly origin: typeof REPAIR_ORIGIN;
+  readonly kind: typeof REPAIR_KIND;
+  readonly prNumber: number;
+  readonly ownerTicket: number;
+}
+
+export interface QueueFailure {
+  readonly summary: string;
+  readonly check?: string;
+  readonly detailsUrl?: string;
+}
+
+export type QueueObservation =
+  | { readonly outcome: "accepted" | "merged" | "pending" }
+  | { readonly outcome: "semantic-failure"; readonly failure: QueueFailure }
+  | { readonly outcome: "mechanical-failure"; readonly reason: string };
+
+export interface RepairStepResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+}
+
+export interface RepairLaneDeps {
+  /** Materialize the Worker row under the shared root before doing any work. */
+  readonly stampWorker: (stamp: RepairWorkerStamp) => Promise<void>;
+  /** Merge the candidate's fresh base into its existing branch. */
+  readonly mergeBase: (candidate: RepairCandidate) => Promise<RepairStepResult>;
+  /** Run one declared generator command verbatim in declaration order. */
+  readonly runGenerator: (
+    command: string,
+    candidate: RepairCandidate,
+  ) => Promise<RepairStepResult>;
+  /** Commit as needed and publish the merged, regenerated branch. */
+  readonly pushBranch: (candidate: RepairCandidate) => Promise<RepairStepResult>;
+  /** Ask the forge to place the PR in its merge queue. */
+  readonly enqueue: (candidate: RepairCandidate) => Promise<RepairStepResult>;
+  /** Observe the result of the new queue request. */
+  readonly waitForQueue: (candidate: RepairCandidate) => Promise<QueueObservation>;
+  /** Persist exact queue evidence on the owning Ticket before escalation. */
+  readonly attachQueueFailure: (
+    ownerTicket: number,
+    prNumber: number,
+    failure: QueueFailure,
+  ) => Promise<void>;
+  /** Route the owning Ticket back to its semantic-correction path. */
+  readonly escalateOwner: (
+    ownerTicket: number,
+    prNumber: number,
+    failure: QueueFailure,
+  ) => Promise<void>;
+}
+
+export type RepairLaneResult =
+  | { readonly outcome: "requeued"; readonly prNumber: number }
+  | {
+      readonly outcome: "escalated";
+      readonly prNumber: number;
+      readonly ownerTicket: number;
+      readonly failure: QueueFailure;
+    }
+  | {
+      readonly outcome: "deferred";
+      readonly prNumber: number;
+      readonly stage: "merge" | "generator" | "push" | "enqueue" | "queue";
+      readonly reason: string;
+    };
+
+function stamp(candidate: RepairCandidate): RepairWorkerStamp {
+  return {
+    origin: REPAIR_ORIGIN,
+    kind: REPAIR_KIND,
+    prNumber: candidate.prNumber,
+    ownerTicket: candidate.ownerTicket,
+  };
+}
+
+function deferred(
+  candidate: RepairCandidate,
+  stage: Extract<RepairLaneResult, { outcome: "deferred" }>["stage"],
+  step: RepairStepResult,
+): RepairLaneResult {
+  return {
+    outcome: "deferred",
+    prNumber: candidate.prNumber,
+    stage,
+    reason: step.reason?.trim() || `${stage} repair did not complete`,
+  };
+}
+
+async function observeRequeue(
+  deps: RepairLaneDeps,
+  candidate: RepairCandidate,
+): Promise<RepairLaneResult> {
+  const observation = await deps.waitForQueue(candidate);
+  if (observation.outcome === "semantic-failure") {
+    await deps.attachQueueFailure(
+      candidate.ownerTicket,
+      candidate.prNumber,
+      observation.failure,
+    );
+    await deps.escalateOwner(
+      candidate.ownerTicket,
+      candidate.prNumber,
+      observation.failure,
+    );
+    return {
+      outcome: "escalated",
+      prNumber: candidate.prNumber,
+      ownerTicket: candidate.ownerTicket,
+      failure: observation.failure,
+    };
+  }
+  if (observation.outcome === "mechanical-failure") {
+    return {
+      outcome: "deferred",
+      prNumber: candidate.prNumber,
+      stage: "queue",
+      reason: observation.reason,
+    };
+  }
+  return { outcome: "requeued", prNumber: candidate.prNumber };
+}
+
+async function enqueueAndObserve(
+  deps: RepairLaneDeps,
+  candidate: RepairCandidate,
+): Promise<RepairLaneResult> {
+  const enqueued = await deps.enqueue(candidate);
+  if (!enqueued.ok) return deferred(candidate, "enqueue", enqueued);
+  return observeRequeue(deps, candidate);
+}
+
+/**
+ * Handle one queue-ejection event without waking the owning Worker. Mechanical
+ * failures remain in the repair lane; only the re-queued semantic verdict can
+ * cross the boundary back to the owning Ticket.
+ */
+export async function healQueueEjection(
+  deps: RepairLaneDeps,
+  candidate: RepairCandidate,
+  generatorCommands: readonly string[],
+): Promise<RepairLaneResult> {
+  await deps.stampWorker(stamp(candidate));
+
+  const merged = await deps.mergeBase(candidate);
+  if (!merged.ok) return deferred(candidate, "merge", merged);
+
+  for (const command of generatorCommands) {
+    const generated = await deps.runGenerator(command, candidate);
+    if (!generated.ok) return deferred(candidate, "generator", generated);
+  }
+
+  const pushed = await deps.pushBranch(candidate);
+  if (!pushed.ok) return deferred(candidate, "push", pushed);
+
+  return enqueueAndObserve(deps, candidate);
+}
+
+/** A CLEAN + MERGEABLE open PR outside the queue needs no branch rewrite. */
+export function isUnqueuedMergeable(candidate: RepairCandidate): boolean {
+  return (
+    !candidate.queued &&
+    candidate.mergeStateStatus.trim().toUpperCase() === "CLEAN" &&
+    candidate.mergeable.trim().toUpperCase() === "MERGEABLE"
+  );
+}
+
+/**
+ * Periodic belt for the event gap: enqueue every clean mergeable fleet PR that
+ * is sitting outside the queue. Already-queued and conflicting PRs are not
+ * touched; each selected PR is represented by a repair Worker stamp.
+ */
+export async function sweepRepairLane(
+  deps: RepairLaneDeps,
+  candidates: readonly RepairCandidate[],
+): Promise<RepairLaneResult[]> {
+  const results: RepairLaneResult[] = [];
+  for (const candidate of candidates) {
+    if (!isUnqueuedMergeable(candidate)) continue;
+    await deps.stampWorker(stamp(candidate));
+    results.push(await enqueueAndObserve(deps, candidate));
+  }
+  return results;
+}

--- a/apps/dev/tests/repair-lane.test.ts
+++ b/apps/dev/tests/repair-lane.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  REPAIR_KIND,
+  REPAIR_ORIGIN,
+  healQueueEjection,
+  sweepRepairLane,
+  type QueueFailure,
+  type RepairCandidate,
+  type RepairLaneDeps,
+} from "../src/core/repair-lane.js";
+
+function candidate(overrides: Partial<RepairCandidate> = {}): RepairCandidate {
+  return {
+    prNumber: 3291,
+    ownerTicket: 3284,
+    branch: "afk/3284-validation-moments",
+    base: "main",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    queued: false,
+    ...overrides,
+  };
+}
+
+function deps(overrides: Partial<RepairLaneDeps> = {}): RepairLaneDeps {
+  return {
+    stampWorker: vi.fn(async () => undefined),
+    mergeBase: vi.fn(async () => ({ ok: true })),
+    runGenerator: vi.fn(async () => ({ ok: true })),
+    pushBranch: vi.fn(async () => ({ ok: true })),
+    enqueue: vi.fn(async () => ({ ok: true })),
+    waitForQueue: vi.fn(async () => ({ outcome: "accepted" as const })),
+    attachQueueFailure: vi.fn(async () => undefined),
+    escalateOwner: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe("repair lane worker", () => {
+  it("heals a stale generated mirror end-to-end without re-seeding the owning Worker", async () => {
+    const state = { baseVersion: 1, mirrorVersion: 1, queued: false };
+    const calls: string[] = [];
+    const d = deps({
+      stampWorker: vi.fn(async (stamp) => {
+        calls.push(`stamp:${stamp.origin}/${stamp.kind}`);
+      }),
+      mergeBase: vi.fn(async () => {
+        calls.push("merge-base");
+        state.baseVersion = 2;
+        return { ok: true };
+      }),
+      runGenerator: vi.fn(async (command) => {
+        calls.push(`generate:${command}`);
+        state.mirrorVersion = state.baseVersion;
+        return { ok: true };
+      }),
+      pushBranch: vi.fn(async () => {
+        calls.push("push");
+        return { ok: true };
+      }),
+      enqueue: vi.fn(async () => {
+        calls.push("enqueue");
+        state.queued = true;
+        return { ok: true };
+      }),
+      waitForQueue: vi.fn(async () => {
+        calls.push("confirm");
+        return state.queued && state.mirrorVersion === state.baseVersion
+          ? { outcome: "accepted" as const }
+          : {
+              outcome: "semantic-failure" as const,
+              failure: { summary: "generated mirror is stale" },
+            };
+      }),
+    });
+
+    const result = await healQueueEjection(
+      d,
+      candidate(),
+      ["pnpm pi:manifests"],
+    );
+
+    expect(result).toEqual({ outcome: "requeued", prNumber: 3291 });
+    expect(calls).toEqual([
+      "stamp:repair/repair",
+      "merge-base",
+      "generate:pnpm pi:manifests",
+      "push",
+      "enqueue",
+      "confirm",
+    ]);
+    expect(d.attachQueueFailure).not.toHaveBeenCalled();
+    expect(d.escalateOwner).not.toHaveBeenCalled();
+    expect(REPAIR_ORIGIN).toBe("repair");
+    expect(REPAIR_KIND).toBe("repair");
+  });
+
+  it("attaches a semantic queue failure and escalates it to the owning Ticket", async () => {
+    const failure: QueueFailure = {
+      summary: "test: release manifest disagrees with package versions",
+      check: "test",
+      detailsUrl: "https://example.test/checks/17",
+    };
+    const d = deps({
+      waitForQueue: vi.fn(async () => ({ outcome: "semantic-failure" as const, failure })),
+    });
+
+    const result = await healQueueEjection(d, candidate(), ["pnpm pi:manifests"]);
+
+    expect(result).toEqual({
+      outcome: "escalated",
+      prNumber: 3291,
+      ownerTicket: 3284,
+      failure,
+    });
+    expect(d.attachQueueFailure).toHaveBeenCalledWith(3284, 3291, failure);
+    expect(d.escalateOwner).toHaveBeenCalledWith(3284, 3291, failure);
+  });
+
+  it("enqueues an unqueued mergeable PR during the periodic sweep", async () => {
+    const d = deps();
+
+    const results = await sweepRepairLane(d, [
+      candidate({ prNumber: 4001, mergeStateStatus: "CLEAN", queued: false }),
+      candidate({ prNumber: 4002, mergeStateStatus: "CLEAN", queued: true }),
+      candidate({ prNumber: 4003, mergeStateStatus: "DIRTY", mergeable: "CONFLICTING" }),
+    ]);
+
+    expect(results).toEqual([{ outcome: "requeued", prNumber: 4001 }]);
+    expect(d.enqueue).toHaveBeenCalledTimes(1);
+    expect(d.enqueue).toHaveBeenCalledWith(expect.objectContaining({ prNumber: 4001 }));
+    expect(d.mergeBase).not.toHaveBeenCalled();
+    expect(d.runGenerator).not.toHaveBeenCalled();
+    expect(d.stampWorker).toHaveBeenCalledWith({
+      origin: "repair",
+      kind: "repair",
+      prNumber: 4001,
+      ownerTicket: 3284,
+    });
+  });
+});

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -69,6 +69,10 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
   tool protocol is `plugins/dev/skills/engineering/afk/MCP.md`. Repo owners tune worker-slot
   throughput through `/afk` config: `afk.landing.wait` chooses release after
   merge, green CI, or PR-open; route that choice to the AFK config reference.
+  A merge-queue ejection, or a clean fleet PR found outside the queue, belongs
+  to AFK's automatic `current.kind=repair` Worker lane; route to `/hitl` only
+  after that lane attaches a genuinely semantic queue failure to the owning
+  Ticket. A mechanical ejection is not a `/retake` or human-requeue task.
   Human-attached `/go` and scout dispatches skip a saturated AFK line through
   the host's bounded interactive reservation; route its default, host override,
   and slot-surface accounting to `/go`.

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -69,6 +69,10 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
   tool protocol is `plugins/dev/skills/engineering/afk/MCP.md`. Repo owners tune worker-slot
   throughput through `/afk` config: `afk.landing.wait` chooses release after
   merge, green CI, or PR-open; route that choice to the AFK config reference.
+  A merge-queue ejection, or a clean fleet PR found outside the queue, belongs
+  to AFK's automatic `current.kind=repair` Worker lane; route to `/hitl` only
+  after that lane attaches a genuinely semantic queue failure to the owning
+  Ticket. A mechanical ejection is not a `/retake` or human-requeue task.
   Human-attached `/go` and scout dispatches skip a saturated AFK line through
   the host's bounded interactive reservation; route its default, host override,
   and slot-surface accounting to `/go`.


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3285 -->
🤖 **Re-seed trail** — #3285 on `afk/3285-a-repair-lane-heals-merge-queue-ejection`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3285; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3285 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/dev`]
{"schema":"red.afk.validation.v1","name":"test:apps/dev","status":"failed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3285-a-repair-lane-heals-merge-queue-ejection/apps/dev test","exitCode":1,"durationMs":474,"summary":"inconclusive: the baseline could not be built, so nothing was compared — [ERROR] ENOENT: no such file or directory, lstat '[REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/main' For help, run: pnpm help run"}
{"schema":"red.afk.validation.v1","name":"typecheck:apps/dev","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3285-a-repair-lane-heals-merge-queue-ejection/apps/dev typecheck","exitCode":0,"durationMs":13,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"lint:apps/dev","status":"skipped","summary":"script missing"}
{"schema":"red.afk.validation.v1","name":"build:apps/dev","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3285-a-repair-lane-heals-merge-queue-ejection/apps/dev build","exitCode":0,"durationMs":3,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"typecheck:workspace","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3285-a-repair-lane-heals-merge-queue-ejection typecheck","exitCode":0,"durationMs":1,"summary":"command exited 0"}
🤖 classification override: the `on_feedback_classify` hook set the feedback failure to `semantic` (the classifier read it as `semantic`).
```

Closes #3285