### PR TITLE
fix: #3263 One front door: drain makes the project's drain true, reports the difference, and is never an error to call again

### DIFF
--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -15,6 +15,7 @@ import {
   castleLanePath,
   createCastleLaneWriters,
   createEnginePaths,
+  planDrain,
   createFileMergeDriverStore,
   releasePr,
   readCastleHistoryRecords,
@@ -32,6 +33,7 @@ import type {
   HitlResolveInput,
   DailyReviewInput,
   EventsSinceInput,
+  ProjectDrainInput,
   ProjectStartInput,
   ProjectResizeInput,
   ProjectStatusOutput,
@@ -1164,6 +1166,92 @@ async function projectStart(root: string, rawInput: ProjectStartInput) {
   };
 }
 
+function registrationRunner(registration: {
+  readonly argv: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+}): string | undefined {
+  const fromEnv = registration.env?.RED_AFK_RUNNER;
+  if (fromEnv) return fromEnv;
+  const flag = registration.argv.lastIndexOf("--runner");
+  const fromArgv = flag >= 0 ? registration.argv[flag + 1] : undefined;
+  return fromArgv === "" ? undefined : fromArgv;
+}
+
+/**
+ * Ensure this project's queue is draining, whatever safe state already stands.
+ *
+ * The pure planner owns the decision and difference report. This adapter only
+ * observes the daemon and applies the named actions. A target-only resize
+ * replaces the registration while leaving its Workers alone; if replacement
+ * fails, the old registration is restored before the error escapes.
+ */
+async function drain(root: string, input: ProjectDrainInput) {
+  const port = createRedskilledBirthPort({ root });
+  try {
+    await port.reach();
+  } catch (err) {
+    throw new Error(redskilledRegistrationRefusal(port.socketPath, err));
+  }
+
+  const state = await port.registrationState();
+  const held = state.held;
+  const currentRunner = held == null ? undefined : registrationRunner(held);
+  const plan = planDrain(
+    {
+      daemon_reachable: true,
+      registration:
+        held == null
+          ? null
+          : {
+              runner: currentRunner ?? "unknown",
+              target: held.target,
+            },
+      lapsed: held == null && state.lapse != null,
+      workers: await port.liveWorkers(),
+    },
+    input,
+  );
+
+  if (plan.outcome === "refuse") {
+    return { ...plan, outcome: "refused" as const };
+  }
+
+  for (const action of plan.actions) {
+    if (action.kind === "reach-daemon") {
+      await port.reach();
+      continue;
+    }
+    if (action.kind === "register") {
+      await projectStart(root, {
+        runner: action.runner,
+        target: action.target,
+      });
+      continue;
+    }
+
+    if (held == null) throw new Error("drain resize planned without a registration");
+    const request = {
+      selector: held.selector,
+      ...(held.queue_poll == null ? {} : { queue_poll: held.queue_poll }),
+      argv: [...held.argv],
+      workspace_path: held.workspace_path,
+      env: { ...held.env },
+      ...(held.log_path == null ? {} : { log_path: held.log_path }),
+      target: action.target,
+      renew_within_ms: held.renew_within_ms,
+    };
+    await port.deregister();
+    try {
+      await port.register(request);
+    } catch (err) {
+      await port.register({ ...request, target: held.target }).catch(() => undefined);
+      throw err;
+    }
+  }
+
+  return { ...plan, outcome: "applied" as const };
+}
+
 /**
  * Give this project's registration back — the other half of stopping work.
  *
@@ -1909,6 +1997,7 @@ export function createCastleMcpDependencies(
 ): CastleMcpDependencies {
   const baseDeps: CastleMcpDependencies = {
     projectStatus: () => projectStatus(root),
+    drain: (input) => drain(root, input),
     projectStart: (input) => projectStart(root, input),
     projectResize: (input) => projectResize(root, input),
     projectReset: async () => createRedskilledBirthPort({ root }).resetBirthBreaker(),

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -306,6 +306,36 @@ describe("starting work registers the project", () => {
     });
   });
 
+  it("re-creates a lapsed registration through drain", async () => {
+    const daemon = await liveHost();
+    const root = await project();
+    daemon.registerProject({
+      project_label: "acme/widgets",
+      selector: 'repo:acme/widgets is:issue is:open label:"ready-for-agent"',
+      argv: ["red-skills-dev", "run", "--once", "--runner", "codex"],
+      workspace_path: root,
+      env: { RED_AFK_RUNNER: "codex" },
+      target: 1,
+      renew_within_ms: 20,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(daemon.hostState().registrations).toEqual([]);
+
+    await expect(
+      createCastleMcpDependencies(root).drain({ runner: "codex", target: 2 }),
+    ).resolves.toMatchObject({
+      outcome: "applied",
+      report: {
+        registration: "re-created",
+        target: "0→2",
+        runner: "none→codex",
+        workers_born: 2,
+      },
+    });
+    expect(daemon.registrations()).toHaveLength(1);
+    expect(daemon.registrations()[0]).toMatchObject({ target: 2 });
+  });
+
   it("carries the host birth latch and its callable reset on project_status", async () => {
     const daemon = await liveHost();
     const root = await project();

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -132,6 +132,47 @@ describe("starting work registers the project", () => {
     expect(daemon.registrations()[0]).toMatchObject({ target: 2 });
   });
 
+  it("keeps an identical drain, resizes its target, and refuses a runner change", async () => {
+    const daemon = await liveHost();
+    const root = await project();
+    const deps = createCastleMcpDependencies(root);
+
+    await deps.drain({ runner: "codex", target: 2 });
+    await expect(deps.drain({ runner: "codex", target: 2 })).resolves.toMatchObject({
+      outcome: "applied",
+      report: {
+        registration: "kept",
+        target: "kept",
+        runner: "kept",
+        workers_born: "kept",
+      },
+    });
+
+    await expect(deps.drain({ runner: "codex", target: 4 })).resolves.toMatchObject({
+      outcome: "applied",
+      report: {
+        registration: "kept",
+        target: "2→4",
+        runner: "kept",
+        workers_born: 2,
+      },
+    });
+    expect(daemon.registrations()).toHaveLength(1);
+    expect(daemon.registrations()[0]).toMatchObject({ target: 4 });
+
+    await expect(deps.drain({ runner: "claude", target: 4 })).resolves.toMatchObject({
+      outcome: "refused",
+      report: {
+        registration: "kept",
+        target: "kept",
+        runner: "kept",
+        workers_born: "kept",
+      },
+      repair: { tool: "project_stop", args: {} },
+    });
+    expect(daemon.registrations()[0]?.env.RED_AFK_RUNNER).toBe("codex");
+  });
+
   it("gives an absent registration a pasteable project_start repair", async () => {
     await liveHost();
     const root = await project();

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -110,6 +110,28 @@ async function liveHost(): Promise<RedskilledDaemon> {
 }
 
 describe("starting work registers the project", () => {
+  it("reaches a draining registration through drain alone", async () => {
+    const daemon = await liveHost();
+    const root = await project();
+
+    const result = await createCastleMcpDependencies(root).drain({
+      runner: "codex",
+      target: 2,
+    }) as Record<string, unknown>;
+
+    expect(result).toMatchObject({
+      outcome: "applied",
+      report: {
+        registration: "created",
+        target: "0→2",
+        runner: "none→codex",
+        workers_born: 2,
+      },
+    });
+    expect(daemon.registrations()).toHaveLength(1);
+    expect(daemon.registrations()[0]).toMatchObject({ target: 2 });
+  });
+
   it("gives an absent registration a pasteable project_start repair", async () => {
     await liveHost();
     const root = await project();

--- a/packages/red-castle/src/engine/drain.test.ts
+++ b/packages/red-castle/src/engine/drain.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { planDrain } from "./drain.js";
+
+describe("drain ensure planner", () => {
+  it("creates an absent registration and reports every changed dimension", () => {
+    expect(
+      planDrain(
+        {
+          daemon_reachable: true,
+          registration: null,
+          lapsed: false,
+          workers: 0,
+        },
+        { runner: "codex", target: 2 },
+      ),
+    ).toEqual({
+      outcome: "apply",
+      actions: [{ kind: "register", runner: "codex", target: 2 }],
+      report: {
+        registration: "created",
+        target: "0→2",
+        runner: "none→codex",
+        workers_born: 2,
+      },
+      summary:
+        "registration: created; target: 0→2; runner: none→codex; workers born: 2",
+    });
+  });
+});

--- a/packages/red-castle/src/engine/drain.test.ts
+++ b/packages/red-castle/src/engine/drain.test.ts
@@ -51,4 +51,29 @@ describe("drain ensure planner", () => {
         "registration: kept; target: kept; runner: kept; workers born: kept",
     });
   });
+
+  it("resizes a standing drain and reports the target difference", () => {
+    expect(
+      planDrain(
+        {
+          daemon_reachable: true,
+          registration: { runner: "codex", target: 4 },
+          lapsed: false,
+          workers: 4,
+        },
+        { runner: "codex", target: 6 },
+      ),
+    ).toEqual({
+      outcome: "apply",
+      actions: [{ kind: "resize", runner: "codex", target: 6 }],
+      report: {
+        registration: "kept",
+        target: "4→6",
+        runner: "kept",
+        workers_born: 2,
+      },
+      summary:
+        "registration: kept; target: 4→6; runner: kept; workers born: 2",
+    });
+  });
 });

--- a/packages/red-castle/src/engine/drain.test.ts
+++ b/packages/red-castle/src/engine/drain.test.ts
@@ -76,4 +76,34 @@ describe("drain ensure planner", () => {
         "registration: kept; target: 4→6; runner: kept; workers born: 2",
     });
   });
+
+  it("refuses a runner change with the explicit stop-then-drain repair", () => {
+    const plan = planDrain(
+      {
+        daemon_reachable: true,
+        registration: { runner: "codex", target: 4 },
+        lapsed: false,
+        workers: 4,
+      },
+      { runner: "claude", target: 6 },
+    );
+
+    expect(plan).toMatchObject({
+      outcome: "refuse",
+      actions: [],
+      report: {
+        registration: "kept",
+        target: "kept",
+        runner: "kept",
+        workers_born: "kept",
+      },
+      repair: {
+        tool: "project_stop",
+        args: {},
+      },
+    });
+    expect(plan.reason).toContain("runner change from \"codex\" to \"claude\"");
+    expect(plan.repair.why).toContain("then call `drain`");
+    expect(plan.repair.why).toContain('{"runner":"claude","target":6}');
+  });
 });

--- a/packages/red-castle/src/engine/drain.test.ts
+++ b/packages/red-castle/src/engine/drain.test.ts
@@ -102,6 +102,8 @@ describe("drain ensure planner", () => {
         args: {},
       },
     });
+    expect(plan.outcome).toBe("refuse");
+    if (plan.outcome !== "refuse") throw new Error("expected runner change refusal");
     expect(plan.reason).toContain("runner change from \"codex\" to \"claude\"");
     expect(plan.repair.why).toContain("then call `drain`");
     expect(plan.repair.why).toContain('{"runner":"claude","target":6}');

--- a/packages/red-castle/src/engine/drain.test.ts
+++ b/packages/red-castle/src/engine/drain.test.ts
@@ -26,4 +26,29 @@ describe("drain ensure planner", () => {
         "registration: created; target: 0→2; runner: none→codex; workers born: 2",
     });
   });
+
+  it("keeps every dimension when the requested drain already stands", () => {
+    expect(
+      planDrain(
+        {
+          daemon_reachable: true,
+          registration: { runner: "codex", target: 2 },
+          lapsed: false,
+          workers: 2,
+        },
+        { runner: "codex", target: 2 },
+      ),
+    ).toEqual({
+      outcome: "apply",
+      actions: [],
+      report: {
+        registration: "kept",
+        target: "kept",
+        runner: "kept",
+        workers_born: "kept",
+      },
+      summary:
+        "registration: kept; target: kept; runner: kept; workers born: kept",
+    });
+  });
 });

--- a/packages/red-castle/src/engine/drain.ts
+++ b/packages/red-castle/src/engine/drain.ts
@@ -1,3 +1,8 @@
+import {
+  composeRepair,
+  type RepairAction,
+} from "@reddb-io/shared/repair.js";
+
 export interface DrainRequest {
   readonly runner: string;
   readonly target: number;
@@ -27,12 +32,23 @@ export interface DrainReport {
   readonly workers_born: number | "kept";
 }
 
-export interface DrainPlan {
+export interface DrainApplyPlan {
   readonly outcome: "apply";
   readonly actions: readonly DrainAction[];
   readonly report: DrainReport;
   readonly summary: string;
 }
+
+export interface DrainRefusalPlan {
+  readonly outcome: "refuse";
+  readonly actions: readonly [];
+  readonly report: DrainReport;
+  readonly summary: string;
+  readonly reason: string;
+  readonly repair: RepairAction;
+}
+
+export type DrainPlan = DrainApplyPlan | DrainRefusalPlan;
 
 function renderDrainReport(report: DrainReport): string {
   return `registration: ${report.registration}; target: ${report.target}; runner: ${report.runner}; workers born: ${report.workers_born}`;
@@ -69,7 +85,35 @@ export function planDrain(state: DrainState, request: DrainRequest): DrainPlan {
         summary: renderDrainReport(report),
       };
     }
-    throw new Error("a runner change is not implemented yet");
+    const report: DrainReport = {
+      registration: "kept",
+      target: "kept",
+      runner: "kept",
+      workers_born: "kept",
+    };
+    const composed = composeRepair({
+      state:
+        `drain refused runner change from ${JSON.stringify(state.registration.runner)} to ` +
+        JSON.stringify(request.runner),
+      repair: {
+        tool: "project_stop",
+        args: {},
+        why:
+          `stop runner ${JSON.stringify(state.registration.runner)}, then call \`drain\` with ` +
+          `\`${JSON.stringify(request)}\`; changing runners can end its live Workers`,
+      },
+    });
+    if (composed.repair === "none") {
+      throw new Error("runner-change repair must be callable");
+    }
+    return {
+      outcome: "refuse",
+      actions: [],
+      report,
+      summary: renderDrainReport(report),
+      reason: composed.prose,
+      repair: composed.repair,
+    };
   }
   const report: DrainReport = {
     registration: state.lapsed ? "re-created" : "created",

--- a/packages/red-castle/src/engine/drain.ts
+++ b/packages/red-castle/src/engine/drain.ts
@@ -17,7 +17,8 @@ export interface DrainState {
 
 export type DrainAction =
   | { readonly kind: "reach-daemon" }
-  | { readonly kind: "register"; readonly runner: string; readonly target: number };
+  | { readonly kind: "register"; readonly runner: string; readonly target: number }
+  | { readonly kind: "resize"; readonly runner: string; readonly target: number };
 
 export interface DrainReport {
   readonly registration: string;
@@ -40,10 +41,21 @@ function renderDrainReport(report: DrainReport): string {
 /** Plan how `drain` makes the requested project state true. PURE. */
 export function planDrain(state: DrainState, request: DrainRequest): DrainPlan {
   if (state.registration !== null) {
-    if (
-      state.registration.runner === request.runner &&
-      state.registration.target === request.target
-    ) {
+    if (state.registration.runner === request.runner) {
+      if (state.registration.target !== request.target) {
+        const report: DrainReport = {
+          registration: "kept",
+          target: `${state.registration.target}→${request.target}`,
+          runner: "kept",
+          workers_born: Math.max(0, request.target - state.registration.target),
+        };
+        return {
+          outcome: "apply",
+          actions: [{ kind: "resize", runner: request.runner, target: request.target }],
+          report,
+          summary: renderDrainReport(report),
+        };
+      }
       const report: DrainReport = {
         registration: "kept",
         target: "kept",
@@ -57,7 +69,7 @@ export function planDrain(state: DrainState, request: DrainRequest): DrainPlan {
         summary: renderDrainReport(report),
       };
     }
-    throw new Error("a changed standing registration is not implemented yet");
+    throw new Error("a runner change is not implemented yet");
   }
   const report: DrainReport = {
     registration: state.lapsed ? "re-created" : "created",

--- a/packages/red-castle/src/engine/drain.ts
+++ b/packages/red-castle/src/engine/drain.ts
@@ -1,0 +1,60 @@
+export interface DrainRequest {
+  readonly runner: string;
+  readonly target: number;
+}
+
+export interface DrainRegistrationState {
+  readonly runner: string;
+  readonly target: number;
+}
+
+export interface DrainState {
+  readonly daemon_reachable: boolean;
+  readonly registration: DrainRegistrationState | null;
+  readonly lapsed: boolean;
+  readonly workers: number;
+}
+
+export type DrainAction =
+  | { readonly kind: "reach-daemon" }
+  | { readonly kind: "register"; readonly runner: string; readonly target: number };
+
+export interface DrainReport {
+  readonly registration: string;
+  readonly target: string;
+  readonly runner: string;
+  readonly workers_born: number | "kept";
+}
+
+export interface DrainPlan {
+  readonly outcome: "apply";
+  readonly actions: readonly DrainAction[];
+  readonly report: DrainReport;
+  readonly summary: string;
+}
+
+function renderDrainReport(report: DrainReport): string {
+  return `registration: ${report.registration}; target: ${report.target}; runner: ${report.runner}; workers born: ${report.workers_born}`;
+}
+
+/** Plan how `drain` makes the requested project state true. PURE. */
+export function planDrain(state: DrainState, request: DrainRequest): DrainPlan {
+  if (state.registration !== null) {
+    throw new Error("a standing registration is not implemented yet");
+  }
+  const report: DrainReport = {
+    registration: state.lapsed ? "re-created" : "created",
+    target: `0→${request.target}`,
+    runner: `none→${request.runner}`,
+    workers_born: Math.max(0, request.target - state.workers),
+  };
+  return {
+    outcome: "apply",
+    actions: [
+      ...(state.daemon_reachable ? [] : [{ kind: "reach-daemon" as const }]),
+      { kind: "register", runner: request.runner, target: request.target },
+    ],
+    report,
+    summary: renderDrainReport(report),
+  };
+}

--- a/packages/red-castle/src/engine/drain.ts
+++ b/packages/red-castle/src/engine/drain.ts
@@ -40,7 +40,24 @@ function renderDrainReport(report: DrainReport): string {
 /** Plan how `drain` makes the requested project state true. PURE. */
 export function planDrain(state: DrainState, request: DrainRequest): DrainPlan {
   if (state.registration !== null) {
-    throw new Error("a standing registration is not implemented yet");
+    if (
+      state.registration.runner === request.runner &&
+      state.registration.target === request.target
+    ) {
+      const report: DrainReport = {
+        registration: "kept",
+        target: "kept",
+        runner: "kept",
+        workers_born: "kept",
+      };
+      return {
+        outcome: "apply",
+        actions: [],
+        report,
+        summary: renderDrainReport(report),
+      };
+    }
+    throw new Error("a changed standing registration is not implemented yet");
   }
   const report: DrainReport = {
     registration: state.lapsed ? "re-created" : "created",

--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -25,6 +25,7 @@ export * from "./terminal-events.js";
 export * from "./validation-cone.js";
 export * from "./worker-drain.js";
 export * from "./config.js";
+export * from "./drain.js";
 export * from "./work-selector.js";
 export * from "./extinct-nouns.js";
 export * from "./host-capability-profile.js";

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -163,6 +163,7 @@ describe("castle MCP tools", () => {
     expect(createCastleMcpTools(deps()).map((tool) => tool.name)).toEqual([
       "help",
       "project_status",
+      "drain",
       "project_start",
       "project_resize",
       "project_reset",

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -36,6 +36,16 @@ function deps(): CastleMcpDependencies {
       ],
       unattributed_workers: [],
     })),
+    drain: vi.fn(async () => ({
+      outcome: "applied",
+      report: {
+        registration: "kept",
+        target: "kept",
+        runner: "kept",
+        workers_born: "kept",
+      },
+      summary: "registration: kept; target: kept; runner: kept; workers born: kept",
+    })),
     projectStart: vi.fn(async (input) => ({
       status: "launched",
       runner: input.runner,
@@ -223,6 +233,21 @@ describe("castle MCP tools", () => {
       slots: { total: 2 },
       live_workers: [{ id: "worker-1" }],
     });
+  });
+
+  it("ensures a drain through the host adapter", async () => {
+    const d = deps();
+    const tool = createCastleMcpTools(d).find((candidate) => candidate.name === "drain")!;
+
+    await expect(tool.invoke({ runner: "codex", target: 2 })).resolves.toMatchObject({
+      report: {
+        registration: "kept",
+        target: "kept",
+        runner: "kept",
+        workers_born: "kept",
+      },
+    });
+    expect(d.drain).toHaveBeenCalledWith({ runner: "codex", target: 2 });
   });
 
   it("resets the named project latch", async () => {

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -53,6 +53,7 @@ export type {
 } from "./mcp/contracts.js";
 export type {
   WorkSelectorInput,
+  ProjectDrainInput,
   ProjectStartInput,
   ProjectResizeInput,
   ProjectResetInput,

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -33,6 +33,13 @@ const SURFACE: ReadonlyArray<{
     schema: ["fleet"],
   },
   {
+    name: "drain",
+    title: "Make this project drain",
+    description:
+      "MUTATING: ensure the daemon is reachable and this project is registered at the requested runner and target; repeated calls report what was kept.",
+    schema: ["runner", "target"],
+  },
+  {
     name: "project_start",
     title: "Start this project's workers",
     description:

--- a/packages/red-castle/src/mcp/project.ts
+++ b/packages/red-castle/src/mcp/project.ts
@@ -35,6 +35,11 @@ export interface ProjectStartInput {
   base?: string;
 }
 
+export interface ProjectDrainInput {
+  runner: string;
+  target: number;
+}
+
 export interface ProjectResizeInput {
   runner?: string;
   target?: number;
@@ -53,6 +58,7 @@ export interface ProjectResetInput {
 
 export interface ProjectDependencies {
   projectStatus(): Promise<ProjectStatusOutput>;
+  drain(input: ProjectDrainInput): Promise<unknown>;
   projectStart(input: ProjectStartInput): Promise<unknown>;
   projectResize(input: ProjectResizeInput): Promise<unknown>;
   projectReset(input: ProjectResetInput): Promise<unknown>;
@@ -109,9 +115,7 @@ export function createProjectTools(deps: ProjectDependencies): CastleMcpTool[] {
         runner: z.string().min(1),
         target: z.number().int().min(0).default(DEFAULT_FLEET_WIDTH),
       },
-      invoke: async () => {
-        throw new Error("drain adapter is not implemented yet");
-      },
+      invoke: async (input) => deps.drain(input as unknown as ProjectDrainInput),
     },
     {
       name: "project_start",

--- a/packages/red-castle/src/mcp/project.ts
+++ b/packages/red-castle/src/mcp/project.ts
@@ -101,6 +101,19 @@ export function createProjectTools(deps: ProjectDependencies): CastleMcpTool[] {
       },
     },
     {
+      name: "drain",
+      title: "Make this project drain",
+      description:
+        "MUTATING: ensure the daemon is reachable and this project is registered at the requested runner and target; repeated calls report what was kept.",
+      inputSchema: {
+        runner: z.string().min(1),
+        target: z.number().int().min(0).default(DEFAULT_FLEET_WIDTH),
+      },
+      invoke: async () => {
+        throw new Error("drain adapter is not implemented yet");
+      },
+    },
+    {
       name: "project_start",
       title: "Start this project's workers",
       description:

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -67,12 +67,14 @@ document defines the protocol without copying its state-dependent routes.
 **A project has exactly one producer.** The named fleet is gone (ADR 0130): the
 host daemon owns the budget, so nothing is left for a fleet name to address and
 no registry of profiles to keep. What the profile carried that was about *work* —
-the selector, the runner, the base branch — is passed to `project_start` and
-re-aimed by `project_resize`.
+the selector, the runner, the base branch — is registered by the project tools.
+`drain` is the ensure-style front door; `project_start` and `project_resize`
+remain available for specialized lifecycle operations during consolidation.
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
 | `project_status` | read | Supervisor pid, slots, churn, and live workers for this project. |
+| `drain` | mutating | Ensure the daemon is reachable and this project is registered at the requested runner and target. Repeated calls succeed with a four-dimension difference report; a runner change is refused with the explicit stop-then-drain repair. |
 | `project_start` | mutating | Register this project with the host daemon — a runner, a target width, and its work policy. It registers; it launches no process of the project's own. |
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |
 | `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `project_status.birth_latch.repair`; the structured repair supplies the exact args. |

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -67,12 +67,14 @@ document defines the protocol without copying its state-dependent routes.
 **A project has exactly one producer.** The named fleet is gone (ADR 0130): the
 host daemon owns the budget, so nothing is left for a fleet name to address and
 no registry of profiles to keep. What the profile carried that was about *work* —
-the selector, the runner, the base branch — is passed to `project_start` and
-re-aimed by `project_resize`.
+the selector, the runner, the base branch — is registered by the project tools.
+`drain` is the ensure-style front door; `project_start` and `project_resize`
+remain available for specialized lifecycle operations during consolidation.
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
 | `project_status` | read | Supervisor pid, slots, churn, and live workers for this project. |
+| `drain` | mutating | Ensure the daemon is reachable and this project is registered at the requested runner and target. Repeated calls succeed with a four-dimension difference report; a runner change is refused with the explicit stop-then-drain repair. |
 | `project_start` | mutating | Register this project with the host daemon — a runner, a target width, and its work policy. It registers; it launches no process of the project's own. |
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |
 | `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `project_status.birth_latch.repair`; the structured repair supplies the exact args. |


### PR DESCRIPTION
Automated AFK landing for #3263. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3263

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788480373&installation_model_id=20659&pr_number=3298&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3298&signature=d79f690460be587a87c36c3d4bad06f02294207d702b6ecdbb9f29849a44327b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->