### PR TITLE
fix: #3264 Per-intent MCP prompts make the castle discoverable as slash entries, each a thin door that delegates to help

### DIFF
--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -6,7 +6,10 @@ import { encode, type JsonValue } from "@reddb-io/toon";
 import { deathLaneFile, installDeathRecorder } from "@reddb-io/shared/death-record.js";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createCastleMcpTools } from "@reddb-io/red-castle/mcp-server";
+import {
+  CASTLE_MCP_PROMPTS,
+  createCastleMcpTools,
+} from "@reddb-io/red-castle/mcp-server";
 import {
   createEnginePaths,
   createFileIssueCuratorStore,
@@ -109,6 +112,23 @@ export function createCastleMcpServer(root = process.cwd()): McpServer {
       async (input) => ({
         content: [
           { type: "text" as const, text: toon(await tool.invoke(input)) },
+        ],
+      }),
+    );
+  }
+  for (const prompt of CASTLE_MCP_PROMPTS) {
+    server.registerPrompt(
+      prompt.name,
+      {
+        title: prompt.title,
+        description: prompt.description,
+      },
+      async () => ({
+        messages: [
+          {
+            role: "user" as const,
+            content: { type: "text" as const, text: prompt.body },
+          },
         ],
       }),
     );

--- a/apps/dev/tests/mcp-prompts.test.ts
+++ b/apps/dev/tests/mcp-prompts.test.ts
@@ -18,10 +18,14 @@ describe("castle MCP intent prompts", () => {
   it("lists four thin doors that delegate only to help", async () => {
     const server = createCastleMcpServer();
     const client = new Client({ name: "castle-prompt-test", version: "1" });
-    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
     await server.connect(serverTransport);
     await client.connect(clientTransport);
-    close.push(() => client.close(), () => server.close());
+    close.push(
+      () => client.close(),
+      () => server.close(),
+    );
 
     const listed = await client.listPrompts();
     expect(listed.prompts.map(({ name }) => name)).toEqual(PROMPT_NAMES);

--- a/apps/dev/tests/mcp-prompts.test.ts
+++ b/apps/dev/tests/mcp-prompts.test.ts
@@ -1,0 +1,68 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { createCastleMcpServer } from "../src/mcp-server.js";
+
+const THIN_PROMPT_MAX_CHARS = 160;
+const PROMPT_NAMES = ["drain", "diagnose", "configure", "stop"];
+
+describe("castle MCP intent prompts", () => {
+  const close: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.all(close.splice(0).map((shutdown) => shutdown()));
+  });
+
+  it("lists four thin doors that delegate only to help", async () => {
+    const server = createCastleMcpServer();
+    const client = new Client({ name: "castle-prompt-test", version: "1" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    close.push(() => client.close(), () => server.close());
+
+    const listed = await client.listPrompts();
+    expect(listed.prompts.map(({ name }) => name)).toEqual(PROMPT_NAMES);
+
+    const toolNames = (await client.listTools()).tools
+      .map(({ name }) => name)
+      .filter((name) => name !== "help");
+
+    for (const name of PROMPT_NAMES) {
+      const expanded = await client.getPrompt({ name });
+      expect(expanded.messages).toHaveLength(1);
+      const content = expanded.messages[0]?.content;
+      expect(content?.type).toBe("text");
+      const body = content?.type === "text" ? content.text : "";
+      expect(body.length).toBeLessThanOrEqual(THIN_PROMPT_MAX_CHARS);
+      expect(body).toMatch(/\bhelp\b/);
+      for (const toolName of toolNames) {
+        expect(body).not.toMatch(new RegExp(`\\b${toolName}\\b`));
+      }
+    }
+  });
+
+  it.each([".claude-plugin/plugin.json", ".codex-plugin/plugin.json"])(
+    "projects the castle prompts through the %s host manifest",
+    async (manifestPath) => {
+      const pluginRoot = resolve(import.meta.dirname, "../../../plugins/dev");
+      const manifest = JSON.parse(
+        await readFile(resolve(pluginRoot, manifestPath), "utf8"),
+      ) as { mcpServers?: string };
+      const mcp = JSON.parse(
+        await readFile(resolve(pluginRoot, manifest.mcpServers ?? ""), "utf8"),
+      ) as { mcpServers?: Record<string, unknown> };
+
+      expect(manifest.mcpServers).toBe("./.mcp.json");
+      expect(mcp.mcpServers).toHaveProperty("castle");
+      expect(PROMPT_NAMES.map((name) => `castle:${name}`)).toEqual([
+        "castle:drain",
+        "castle:diagnose",
+        "castle:configure",
+        "castle:stop",
+      ]);
+    },
+  );
+});

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -34,6 +34,8 @@ import {
 } from "./mcp/worktree.js";
 
 export type { CastleMcpTool } from "./mcp/tool.js";
+export { CASTLE_MCP_PROMPTS } from "./mcp/prompt.js";
+export type { CastleMcpPrompt } from "./mcp/prompt.js";
 export type { DangerPosture } from "./mcp/posture.js";
 export {
   CASTLE_MCP_CONTRACT_VERSION,

--- a/packages/red-castle/src/mcp/prompt.ts
+++ b/packages/red-castle/src/mcp/prompt.ts
@@ -1,0 +1,42 @@
+export interface CastleMcpPrompt {
+  readonly name: string;
+  readonly title: string;
+  readonly description: string;
+  readonly body: string;
+}
+
+const HELP_DELEGATION =
+  "Call the castle MCP's `help` tool.\nFollow its guidance and invoke the returned `next` call.";
+
+/**
+ * Discoverability doors for the castle's common operator intents.
+ *
+ * The bodies deliberately share one delegation instead of restating any
+ * operating choreography: `help` is the castle's only live source of it.
+ */
+export const CASTLE_MCP_PROMPTS: readonly CastleMcpPrompt[] = [
+  {
+    name: "drain",
+    title: "Drain this project's queue",
+    description: "Find the next action for starting or continuing a project drain.",
+    body: HELP_DELEGATION,
+  },
+  {
+    name: "diagnose",
+    title: "Diagnose the castle",
+    description: "Find the next action for understanding a castle problem.",
+    body: HELP_DELEGATION,
+  },
+  {
+    name: "configure",
+    title: "Configure the castle",
+    description: "Find the next action for changing castle configuration.",
+    body: HELP_DELEGATION,
+  },
+  {
+    name: "stop",
+    title: "Stop the castle",
+    description: "Find the next action for stopping castle work safely.",
+    body: HELP_DELEGATION,
+  },
+];

--- a/packages/red-castle/src/mcp/prompt.ts
+++ b/packages/red-castle/src/mcp/prompt.ts
@@ -18,7 +18,8 @@ export const CASTLE_MCP_PROMPTS: readonly CastleMcpPrompt[] = [
   {
     name: "drain",
     title: "Drain this project's queue",
-    description: "Find the next action for starting or continuing a project drain.",
+    description:
+      "Find the next action for starting or continuing a project drain.",
     body: HELP_DELEGATION,
   },
   {


### PR DESCRIPTION
Automated AFK landing for #3264. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3264

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788482592&installation_model_id=20659&pr_number=3300&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3300&signature=71f8fff22054807eba920868674b570caf200bdebfa1a45392bc992d91047615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->