### PR TITLE
ci: archive inactive HITL card workflow

### DIFF
--- a/.github/workflows/archive/red-hitl-card.yml
+++ b/.github/workflows/archive/red-hitl-card.yml
@@ -1,4 +1,4 @@
-# red-hitl-card — actionable decision cards for ready-for-human issues (issue #927).
+# Archived: red-hitl-card — actionable decision cards for ready-for-human issues (issue #927).
 #
 # Turns a ready-for-human issue into an IssueOps UI:
 #

--- a/scripts/test-red-hitl-card-merge-token-contract.sh
+++ b/scripts/test-red-hitl-card-merge-token-contract.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-WORKFLOW=".github/workflows/red-hitl-card.yml"
+WORKFLOW=".github/workflows/archive/red-hitl-card.yml"
 failures=0
 
 fail() {

--- a/scripts/test-workflow-security-pins.sh
+++ b/scripts/test-workflow-security-pins.sh
@@ -48,7 +48,7 @@ grep -qF 'ref: ${{ github.event.pull_request.base.sha }}' .github/workflows/red-
 grep -qF 'ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}' .github/workflows/red-comment-respond.yml ||
   fail "red-comment-respond.yml must checkout a base-repo ref before running the launcher"
 
-grep -qF 'ref: ${{ github.event.pull_request.base.sha }}' .github/workflows/red-hitl-card.yml ||
+grep -qF 'ref: ${{ github.event.pull_request.base.sha }}' .github/workflows/archive/red-hitl-card.yml ||
   fail "red-hitl-card.yml must checkout the base PR SHA before running the launcher"
 
 for workflow in \


### PR DESCRIPTION
## Why

The inactive HITL card workflow should remain available as source without being discoverable or runnable by GitHub Actions.

## What changes

- move `red-hitl-card.yml` to `.github/workflows/archive/`
- update workflow contract scripts to validate the archived source

GitHub Actions only discovers workflow files directly under `.github/workflows`, so the nested archived file will not run.

## Validation

- actionlint across active workflows
- `bash scripts/test-red-hitl-card-merge-token-contract.sh`
- `bash scripts/test-workflow-security-pins.sh`
- `bash scripts/test-workflow-fork-posture.sh`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788486263&installation_model_id=20659&pr_number=3302&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3302&signature=1ae6722eec895bc53d64e9398bf9b4fb3d7e8407c1347bc4a97be8a19cec65c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->