### PR TITLE
fix: #3152 The dashboard and the panel draw the right facts in no color, so the lifecycle bar cannot say whether the Worker is failing

### DIFF
--- a/.changeset/colour-rich-renderers.md
+++ b/.changeset/colour-rich-renderers.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-render": patch
+---
+
+Colour the dashboard and panel with the shared wine palette, including distinct healthy and failed Worker lifecycle cursors.

--- a/apps/vscode-extension-red-skills/src/model/dashboard-view.ts
+++ b/apps/vscode-extension-red-skills/src/model/dashboard-view.ts
@@ -14,6 +14,7 @@
  * `views/dashboard-panel.ts` hold the `vscode` imports and nothing else.
  */
 import { canonicalInvocation } from "@reddb-io/shared/canonical-invocation.js";
+import { stripAnsi } from "@reddb-io/redskilled-render/format.js";
 import type { RedskilledDashboard } from "@reddb-io/redskilled/protocol";
 import type { HostSnapshot } from "./snapshot.js";
 
@@ -55,9 +56,12 @@ export function statusBarView(snapshot: HostSnapshot): StatusBarView {
     };
   }
   const header = snapshot.dashboard.header;
+  // The daemon colours its render unconditionally (#3150/#3152) and the editor
+  // status bar draws no ANSI, so this caller strips at its boundary — the rule
+  // the renderer states: the pipe decision belongs to the reader.
   return {
-    text: `${snapshot.dashboard.stale ? "$(warning)" : "$(server)"} ${header.line}`,
-    tooltip: snapshot.dashboard.lines.join("\n"),
+    text: stripAnsi(`${snapshot.dashboard.stale ? "$(warning)" : "$(server)"} ${header.line}`),
+    tooltip: snapshot.dashboard.lines.map(stripAnsi).join("\n"),
     warning: snapshot.dashboard.stale,
   };
 }
@@ -131,7 +135,7 @@ function dashboardBody(snapshot: HostSnapshot): string {
     ].join("\n");
   }
   return [
-    `<pre class="header${dashboard.stale ? " stale" : ""}">${escapeHtml(dashboard.header.line)}</pre>`,
+    `<pre class="header${dashboard.stale ? " stale" : ""}">${escapeHtml(stripAnsi(dashboard.header.line))}</pre>`,
     ...(dashboard.rows.length === 0
       ? [
           '<pre class="absence">no Workers here — the machine is idle, and this is the daemon saying so</pre>',
@@ -148,5 +152,5 @@ function dashboardBody(snapshot: HostSnapshot): string {
  * dropped by a panel that only knew about Workers.
  */
 export function dashboardRows(dashboard: RedskilledDashboard): readonly string[] {
-  return dashboard.lines.slice(1);
+  return dashboard.lines.slice(1).map(stripAnsi);
 }

--- a/apps/vscode-extension-red-skills/tests/dashboard.test.ts
+++ b/apps/vscode-extension-red-skills/tests/dashboard.test.ts
@@ -7,6 +7,7 @@
  * absence.
  */
 import { afterEach, describe, expect, it } from "vitest";
+import { stripAnsi } from "@reddb-io/redskilled-render/format.js";
 import {
   dashboardRows,
   escapeHtml,
@@ -201,7 +202,9 @@ describe("the frame is drawn here, from the one document the daemon composed", (
     // bytes it already holds (ADR 0132 decisions 1 and 9).
     expect(daemon.served.get("statusline-payload")).toBe(1);
     expect(daemon.served.has("statusline-dashboard")).toBe(false);
-    expect(snapshot.dashboard?.header.line).toContain("» reddb-io/red-skills");
+    // The wire line is coloured by design (#3150/#3152); the identity is asserted
+    // through the same strip every ANSI-free reader applies at its boundary.
+    expect(stripAnsi(snapshot.dashboard?.header.line ?? "")).toContain("» reddb-io/red-skills");
     // The cells come from the shared render module, so a terminal pane standing
     // in the same directory draws this row character for character.
     expect(snapshot.dashboard?.rows[0]?.cells.bar).toBe("██▶░░░");

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -44,6 +44,24 @@ import {
   UNREGISTERED_MARK,
 } from "./marks.js";
 import {
+  BAR_AHEAD as BAR_AHEAD_TONE,
+  BAR_CURRENT as BAR_CURRENT_TONE,
+  BAR_DONE as BAR_DONE_TONE,
+  BOLD,
+  DIM,
+  GOLD,
+  KEY,
+  NOBG,
+  NOBOLD,
+  RED,
+  RESET,
+  SOFT,
+  VAL,
+  WHITE,
+  WINE,
+  WINE2,
+} from "./palette.js";
+import {
   REDSKILLED_RENDER_DISPLAY_ABSENT,
   type RedskilledRenderDeaths,
   type RedskilledRenderEngine,
@@ -382,28 +400,31 @@ function buildHeader(
   // The version carries its own currency mark rather than a separate token: a
   // surface reading `v3.1.0` on its own cannot tell a current daemon from one
   // three releases behind, and that is the whole of "is my engine current".
-  const parts: string[] = [
-    `» ${repo ?? "host"} v${version}${engine != null && engine.current === false ? ENGINE_BEHIND_MARK : ""}`,
-  ];
+  const parts: string[] = [dashboardIdentity(
+    repo ?? "host",
+    version,
+    engine != null && engine.current === false ? ENGINE_BEHIND_MARK : "",
+  )];
   if (match === "unregistered" || match === "name-only") parts.push(UNREGISTERED_MARK);
   if (match === "lapsed") parts.push(LAPSED_MARK);
-  if (model != null) parts.push(model);
-  parts.push(`wrk=${selected.length}/${payload.host.worker_count}`);
+  if (model != null) parts.push(`${WINE}${WHITE}${model}${NOBG}${SOFT}`);
+  parts.push(colourKeyValues(`wrk=${selected.length}/${payload.host.worker_count}`));
   const slots = windows.worker_ceiling == null
     ? "slots=∞"
     : `slots=${windows.worker_count}/${windows.worker_ceiling}`;
-  parts.push(`${slots} reserve=${windows.interactive_reservation} interactive`);
-  parts.push(memoryWindow(windows));
-  if (counts.open_pull_requests != null) parts.push(`prs=${counts.open_pull_requests}`);
-  if (counts.recently_closed != null) parts.push(`cpr=${counts.recently_closed}`);
-  if (counts.open_issues != null) parts.push(`iss=${counts.open_issues}`);
+  parts.push(colourKeyValues(`${slots} reserve=${windows.interactive_reservation} interactive`));
+  parts.push(colourKeyValues(memoryWindow(windows)));
+  if (counts.open_pull_requests != null) parts.push(colourKeyValues(`prs=${counts.open_pull_requests}`));
+  if (counts.recently_closed != null) parts.push(colourKeyValues(`cpr=${counts.recently_closed}`));
+  if (counts.open_issues != null) parts.push(colourKeyValues(`iss=${counts.open_issues}`));
   if (counts.stale) parts.push("!counts stale");
   // The rates go here, where a status bar still reads them, and they are the
   // FIRST thing dropped when the line does not fit — see below. Everything
   // before them answers "is this machine healthy"; the rates answer "how fast is
   // it going", which is the question that can wait for the table.
   const rates = metrics == null ? null : compactRates(metrics.hour);
-  if (rates != null) parts.push(rates);
+  const colouredRates = rates == null ? null : colourKeyValues(rates);
+  if (colouredRates != null) parts.push(colouredRates);
   // Beside the counts rather than under the table, because a death is a fact
   // about the machine and not about one project's Workers — and the header is
   // the whole of what a status bar shows.
@@ -424,9 +445,9 @@ function buildHeader(
   // reads as a smaller number than the one measured (`tk/m=1.2` for 1.2k), so
   // they are dropped whole rather than truncated. Every other part survived a
   // narrow pane before this one existed and still does.
-  const full = parts.join(" · ");
+  const full = `${parts.join(" · ")}${RESET}`;
   const line = rates != null && width(full) > options.maxWidth
-    ? parts.filter((part) => part !== rates).join(" · ")
+    ? `${parts.filter((part) => part !== colouredRates).join(" · ")}${RESET}`
     : full;
 
   return {
@@ -444,6 +465,20 @@ function buildHeader(
     age_ms: payload.staleness.age_ms,
     line: clamp(line, options.maxWidth),
   };
+}
+
+/** The dashboard's wine identity zone: accent, owner, and quiet version. PURE. */
+function dashboardIdentity(repo: string, version: string, currency: string): string {
+  return `${WINE2}${WHITE}${GOLD}»${WHITE} ${BOLD}${repo}${NOBOLD} ${DIM}v${version}${currency}` +
+    `${WHITE}${NOBG}${SOFT}`;
+}
+
+/** Paint every compact `k=v` token while leaving its surrounding prose soft. PURE. */
+function colourKeyValues(text: string): string {
+  return text.replace(
+    /(^|\s)([A-Za-z][A-Za-z0-9/]*=)([^\s]+)/g,
+    (_match, lead: string, key: string, value: string) => `${lead}${KEY}${key}${VAL}${value}${SOFT}`,
+  );
 }
 
 /** A loop span without zero-valued trailing units (`4m`, not `4m0s`). PURE. */
@@ -616,8 +651,28 @@ function formatRow(
   cells: RedskilledDashboardCells,
   widths: Record<RedskilledDashboardColumn, number>,
 ): string {
-  const parts = REDSKILLED_DASHBOARD_COLUMNS.filter((column) => widths[column] > 0).map((column) =>
-    pad(cells[column], widths[column]),
+  const columns = REDSKILLED_DASHBOARD_COLUMNS.filter((column) => widths[column] > 0);
+  if (columns.length === 0) return "";
+  const parts = columns.map((column, index) =>
+    colourWorkerCell(
+      column,
+      pad(cells[column], index === columns.length - 1 ? width(cells[column]) : widths[column]),
+    )
   );
-  return parts.join(GUTTER).replace(/\s+$/, "");
+  return `${NOBG}${SOFT}${parts.join(GUTTER)}${RESET}`;
+}
+
+/** One dashboard cell in the single palette role shared by every density. PURE. */
+export function colourWorkerCell(column: RedskilledDashboardColumn, raw: string): string {
+  if (column === "wid") return `${BOLD}${raw}${NOBOLD}`;
+  if (column === "bar") {
+    return raw
+      .replace(/█+/g, (done) => `${BAR_DONE_TONE}${done}`)
+      .replace("▶", `${BAR_CURRENT_TONE}▶`)
+      .replace("✗", `${RED}✗`)
+      .replace(/░+/g, (ahead) => `${BAR_AHEAD_TONE}${ahead}`) + SOFT;
+  }
+  const equals = raw.indexOf("=");
+  if (equals > 0) return `${KEY}${raw.slice(0, equals + 1)}${VAL}${raw.slice(equals + 1)}${SOFT}`;
+  return raw;
 }

--- a/packages/redskilled-render/index.ts
+++ b/packages/redskilled-render/index.ts
@@ -50,6 +50,7 @@ export {
   BAR_DONE,
   BOLD,
   DIM,
+  GOLD,
   KEY,
   NOBG,
   NOBOLD,

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -30,6 +30,7 @@
  * erases the identities the operator came here to see.
  */
 import {
+  colourWorkerCell,
   REDSKILLED_DASHBOARD_COLUMNS,
   workerCells,
   type RedskilledDashboardCells,
@@ -45,7 +46,7 @@ import {
   REDSKILLED_RENDER_ABSENCE,
   UNREGISTERED_MARK,
 } from "./marks.js";
-import { BAR_AHEAD, BAR_CURRENT, BAR_DONE, BOLD, KEY, NOBG, NOBOLD, RED, RESET, SOFT, VAL } from "./palette.js";
+import { NOBG, RESET, SOFT } from "./palette.js";
 import type {
   RedskilledRenderPayload,
   RedskilledRenderProject,
@@ -563,20 +564,6 @@ function workerRowWidth(
   columns: readonly RedskilledDashboardColumn[],
 ): number {
   return columns.reduce((total, column) => total + widths[column], 0) + Math.max(0, columns.length - 1) * 2;
-}
-
-function colourWorkerCell(column: RedskilledDashboardColumn, raw: string): string {
-  if (column === "wid") return `${BOLD}${raw}${NOBOLD}`;
-  if (column === "bar") {
-    return raw
-      .replace(/█+/g, (done) => `${BAR_DONE}${done}`)
-      .replace("▶", `${BAR_CURRENT}▶`)
-      .replace("✗", `${RED}✗`)
-      .replace(/░+/g, (ahead) => `${BAR_AHEAD}${ahead}`) + SOFT;
-  }
-  const equals = raw.indexOf("=");
-  if (equals > 0) return `${KEY}${raw.slice(0, equals + 1)}${VAL}${raw.slice(equals + 1)}${SOFT}`;
-  return raw;
 }
 
 /**

--- a/packages/redskilled-render/palette.ts
+++ b/packages/redskilled-render/palette.ts
@@ -43,6 +43,8 @@ export const KEY = sgr("38;2;255;214;214");
 export const VAL = sgr("39");
 /** General transparent-zone text — runners, sigils, the bare phase cell. */
 export const SOFT = sgr("38;2;224;138;148");
+/** The `»` identity accent. */
+export const GOLD = sgr("38;2;240;200;120");
 
 // ---------- the lifecycle bar's wine ramp ----------
 //

--- a/packages/redskilled-render/panel.ts
+++ b/packages/redskilled-render/panel.ts
@@ -16,13 +16,14 @@
  *
  * PURE, like every other density: payload and options in, rows out.
  */
-import { clamp, formatBytes, formatDuration } from "./format.js";
+import { colourWorkerCell, workerCells, type RedskilledDashboardColumn } from "./dashboard.js";
+import { clamp, formatBytes } from "./format.js";
 import { BUDGET_BAND_MARK, BUDGET_SPENT_MARK, DEATH_MARK } from "./marks.js";
-import { workerElapsedMs, type RedskilledRenderPayload, type RedskilledStatuslineMode } from "./payload.js";
+import { KEY, NOBG, RESET, SOFT, VAL } from "./palette.js";
+import { type RedskilledRenderPayload, type RedskilledStatuslineMode } from "./payload.js";
 import {
   REDSKILLED_STATUSLINE_DEFAULTS,
   renderRedskilledStatusline,
-  workerName,
   type RedskilledStatuslineRender,
 } from "./line.js";
 import { selectRenderProjects, selectRenderWorkers } from "./select.js";
@@ -156,21 +157,16 @@ function workerRow(
   mode: RedskilledStatuslineMode,
   generatedAt: string,
 ): string {
-  const display = worker.display;
-  const phase = display == null
-    ? null
-    : [display.phase, display.step].filter((part): part is string => Boolean(part)).join("·");
+  const cells = workerCells(worker, { mode }, generatedAt);
+  const columns: readonly RedskilledDashboardColumn[] = ["wid", "bar", "phase", "elapsed", "eta"];
+  const parts = columns
+    .filter((column) => cells[column] !== "")
+    .map((column) => colourWorkerCell(column, cells[column]));
   const used = worker.vitals.rss_bytes;
-  const parts = [
-    workerName(worker, mode),
-    phase == null || phase === "" ? null : phase,
-    formatDuration(workerElapsedMs(worker, generatedAt)),
-    display?.eta == null ? null : `eta=${formatDuration(display.eta * 1000)}`,
-    // An unmeasured Worker says so. A zero here would read as an idle Worker, and
-    // "nothing measured it" and "it is using nothing" are opposite facts.
-    used == null ? "?" : formatBytes(used),
-  ].filter((part): part is string => part != null);
-  return parts.join(" ");
+  // An unmeasured Worker says so. A zero here would read as an idle Worker, and
+  // "nothing measured it" and "it is using nothing" are opposite facts.
+  parts.push(`${KEY}mem=${VAL}${used == null ? "?" : formatBytes(used)}${SOFT}`);
+  return `${NOBG}${SOFT}${parts.join(" ")}${RESET}`;
 }
 
 /**

--- a/packages/redskilled-render/tests/palette.test.ts
+++ b/packages/redskilled-render/tests/palette.test.ts
@@ -20,6 +20,7 @@ describe("the wine identity family, lifted rather than re-picked", () => {
     expect(params(palette.KEY)).toBe("38;2;255;214;214");
     expect(params(palette.VAL)).toBe("39");
     expect(params(palette.SOFT)).toBe("38;2;224;138;148");
+    expect(params(palette.GOLD)).toBe("38;2;240;200;120");
     expect(params(palette.DIM)).toBe("38;2;201;150;158");
     expect(params(palette.WHITE)).toBe("38;2;255;255;255");
   });

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -15,8 +15,12 @@ import {
   BAR_CURRENT,
   BAR_DONE,
   BOLD,
+  DIM,
+  GOLD,
   KEY,
+  NOBG,
   RED,
+  RESET,
   RedskilledRenderDecodeError,
   renderRedskilled,
   renderRedskilledDashboard,
@@ -28,7 +32,11 @@ import {
   REDSKILLED_RENDER_ABSENCE,
   REDSKILLED_STATUSLINE_DEFAULTS,
   stripAnsi,
+  SOFT,
   VAL,
+  WHITE,
+  WINE,
+  WINE2,
   width,
 } from "../index.js";
 import { display, payload, worker } from "./fixture.js";
@@ -52,7 +60,7 @@ describe("one module, three densities", () => {
     expect(panel.lines.length).toBeGreaterThan(1);
     expect(panel.worker_rows[0]).toContain("w-1");
     expect(table.rows).toHaveLength(1);
-    expect(table.header.line).toContain("wrk=1/1");
+    expect(stripAnsi(table.header.line)).toContain("wrk=1/1");
   });
 
   it("attributes target-plus-one slot usage to the interactive reservation", () => {
@@ -154,6 +162,73 @@ describe("the statusline Worker table (#3151)", () => {
     for (const key of ["loc=", "tks=", "tls=", "rsn=", "txt="]) expect(row).not.toContain(key);
     expect(row).toContain("ctx=108k");
     expect(row).toContain("hb=3s");
+  });
+});
+
+describe("the coloured panel and dashboard (#3152)", () => {
+  it("draws the dashboard identity, version, model and header pairs in their palette roles", () => {
+    const doc = payload({ workers: [worker({ display: display({ model: "claude-opus-5" }) })] });
+    const header = renderRedskilledDashboard(doc, {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      project: "acme/widgets",
+    }).header.line;
+
+    expect(header).toContain(`${WINE2}${WHITE}${GOLD}»${WHITE} ${BOLD}acme/widgets`);
+    expect(header).toContain(`${DIM}v3.3.11${WHITE}`);
+    expect(header).toContain(`${WINE}${WHITE}claude·claude-opus-5·high${NOBG}${SOFT}`);
+    for (const key of ["wrk", "slots", "reserve", "mem"]) {
+      expect(header).toContain(`${KEY}${key}=${VAL}`);
+    }
+    expect(header.endsWith(RESET)).toBe(true);
+  });
+
+  it.each([
+    ["healthy", false, BAR_CURRENT],
+    ["failed", true, RED],
+  ])("draws a %s lifecycle cursor in the same tone at every density", (_state, failed, cursorTone) => {
+    const doc = payload({ workers: [worker({ display: display({ failed }) })] });
+    const line = renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 240 }).lines[1]!;
+    const panel = renderRedskilledPanel(doc, {
+      ...REDSKILLED_PANEL_DEFAULTS,
+      project: "acme/widgets",
+      maxWidth: 240,
+    }).worker_rows[0]!;
+    const dashboard = renderRedskilledDashboard(doc, {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      project: "acme/widgets",
+      maxWidth: 240,
+    }).rows[0]!.line;
+    const cursor = failed ? "✗" : "▶";
+
+    for (const row of [line, panel, dashboard]) {
+      expect(row).toContain(`${BAR_DONE}██${cursorTone}${cursor}${BAR_AHEAD}░░`);
+      expect(row).toContain(`${KEY}eta=${VAL}10m40s`);
+    }
+  });
+
+  it("keeps dashboard columns aligned after colouring their cells", () => {
+    const doc = payload({
+      workers: [
+        worker({ worker_id: "w-1", display: display() }),
+        worker({
+          worker_id: "worker-long",
+          display: display({ runner: "opencode", model: "gpt-5.4", effort: "xhigh", issue: "42" }),
+        }),
+      ],
+      host: { ...payload().host, worker_count: 2 },
+    });
+    const rendered = renderRedskilledDashboard(doc, {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      project: "acme/widgets",
+      maxWidth: 260,
+    });
+    const rows = rendered.rows.map((row) => stripAnsi(row.line));
+
+    expect(rendered.rows[0]!.line).toContain(`${KEY}run=${VAL}`);
+    for (const token of ["run=", "org=", "iss=", "eta=", "hb=", "loc=", "tks=", "ctx=", "tls=", "rsn=", "txt="]) {
+      expect(rows[0]!.indexOf(token), token).toBeGreaterThanOrEqual(0);
+      expect(rows[1]!.indexOf(token), token).toBe(rows[0]!.indexOf(token));
+    }
   });
 });
 
@@ -383,7 +458,7 @@ describe("the elapsed span, the context figure and the estimate (#3097)", () => 
     const table = renderRedskilledDashboard(doc, { ...REDSKILLED_DASHBOARD_DEFAULTS, project: "acme/widgets" });
     expect(table.rows[0]!.cells.eta).toBe("eta=10m40s");
     expect(table.rows[0]!.cells.ctx).toBe("ctx=108k");
-    expect(table.rows[0]!.line).toContain("eta=10m40s");
+    expect(stripAnsi(table.rows[0]!.line)).toContain("eta=10m40s");
   });
 
   it("draws NO estimate for a Worker with none — absent is null, never a zero", () => {


### PR DESCRIPTION
Automated AFK landing for #3152. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3152

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788488527&installation_model_id=20659&pr_number=3306&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3306&signature=f8f31d277d6bf0ecb867be4bf829163d12e8e7b7ea433b67c5061fd2c3d77275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->