### PR TITLE
ci: run AFK lane on free public runner

### DIFF
--- a/.github/workflows/rs-afk-attempt.yml
+++ b/.github/workflows/rs-afk-attempt.yml
@@ -11,11 +11,9 @@
 # Auth: opencode + the org-level `MINIMAX_API_KEY` secret. Model: minimax/MiniMax-M3.
 # Trust gate: only issues authored AND labelled by an allowlisted login run.
 #
-# Runner: Blacksmith. We pass `runs_on: blacksmith-2vcpu-ubuntu-2404` (the
-# smallest Blacksmith tier — there is no "nano"; 2vcpu is the floor) to the
-# reusable, which exposes a `runs_on` input defaulting to `ubuntu-latest` for
-# adopters without Blacksmith. The Blacksmith GitHub App is installed on the org;
-# without it a Blacksmith label leaves the job queued forever.
+# Runner: GitHub-hosted Ubuntu. Standard runners are free for this public
+# repository, and the reusable already defaults to ubuntu-latest. Adopters can
+# still pass a Blacksmith runner label when faster paid compute is intentional.
 
 name: rs-afk-attempt
 
@@ -50,7 +48,7 @@ jobs:
       issue_number: ${{ github.event_name == 'workflow_dispatch' && inputs.issue_number || github.event.issue.number }}
       runner: opencode
       model: minimax/MiniMax-M3
-      runs_on: blacksmith-2vcpu-ubuntu-2404
+      runs_on: ubuntu-24.04
       enforce_trust_gate: ${{ 'true' }}
       allowlist_authors: "filipeforattini"
       allowlist_label_actors: "filipeforattini"

--- a/packaging/pi/dev/skills/engineering/afk/actions-lane.md
+++ b/packaging/pi/dev/skills/engineering/afk/actions-lane.md
@@ -123,7 +123,7 @@ with:
 "nano"; 2 vCPU is the floor (other shapes: `-4vcpu-`, `-8vcpu-`, …). The
 **Blacksmith GitHub App must be installed on the org/repo** first — a Blacksmith
 label with no app installed leaves the job **queued forever**. red-skills' own
-`rs-afk-attempt.yml` caller runs on `blacksmith-2vcpu-ubuntu-2404`.
+`rs-afk-attempt.yml` caller uses `ubuntu-24.04` because the repository is public.
 
 ## Runner + auth
 

--- a/plugins/dev/skills/engineering/afk/actions-lane.md
+++ b/plugins/dev/skills/engineering/afk/actions-lane.md
@@ -123,7 +123,7 @@ with:
 "nano"; 2 vCPU is the floor (other shapes: `-4vcpu-`, `-8vcpu-`, …). The
 **Blacksmith GitHub App must be installed on the org/repo** first — a Blacksmith
 label with no app installed leaves the job **queued forever**. red-skills' own
-`rs-afk-attempt.yml` caller runs on `blacksmith-2vcpu-ubuntu-2404`.
+`rs-afk-attempt.yml` caller uses `ubuntu-24.04` because the repository is public.
 
 ## Runner + auth
 


### PR DESCRIPTION
## Why

The self-hosted AFK Actions lane was paying for Blacksmith even though red-skills is public and the workload is primarily agent/API orchestration.

## What changes

- run red-skills' AFK caller on the free public `ubuntu-24.04` runner
- keep the reusable workflow's configurable runner input so adopters can still choose Blacksmith intentionally
- update both distributed copies of the AFK Actions-lane documentation

## Validation

- actionlint on `rs-afk-attempt.yml`
- `bash scripts/test-workflow-security-pins.sh`
- `bash scripts/test-workflow-fork-posture.sh`
- `pnpm pi:packages:check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788488998&installation_model_id=20659&pr_number=3308&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3308&signature=53147938f6d3812dfb8ca614d74d8e7021ce5e9b2a0e9bc9c96a99208a6a4c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->