### PR TITLE
fix: herdr plugin build survives a missing HERDR_PLUGIN_ROOT (#3303)

### DIFF
--- a/apps/herdr-plugin-red-skills/herdr-plugin.toml
+++ b/apps/herdr-plugin-red-skills/herdr-plugin.toml
@@ -37,13 +37,18 @@ description = "Watch the redskilled host daemon from herdr: live Workers and the
 #      it imports are not downloaded with it — so the hook fetches the release's
 #      single-file bundle and writes it over `bin/red-skills-herdr.mjs`, the path
 #      every pane, action and startup entry below already names.
+# `$HERDR_PLUGIN_ROOT` is not injected during some herdr versions' BUILD phase
+# (#3303: it resolved empty and node loaded "/scripts/…" off the filesystem
+# root), so the build commands fall back to the build's working directory —
+# which herdr guarantees is the plugin root. Runtime commands (services, panes,
+# actions) keep the plain variable: the injection gap is build-phase only.
 [[build]]
 platforms = ["linux", "macos"]
-command = ['sh', '-c', 'node --version >/dev/null 2>&1 || { echo "red-skills needs Node.js 20+ on PATH"; exit 1; }; exec node "$HERDR_PLUGIN_ROOT/scripts/materialize-entrypoint.mjs"']
+command = ['sh', '-c', 'node --version >/dev/null 2>&1 || { echo "red-skills needs Node.js 20+ on PATH"; exit 1; }; exec node "${HERDR_PLUGIN_ROOT:-.}/scripts/materialize-entrypoint.mjs"']
 
 [[build]]
 platforms = ["windows"]
-command = ['powershell', '-NoProfile', '-NonInteractive', '-Command', 'if (-not (Get-Command node -ErrorAction SilentlyContinue)) { Write-Error "red-skills needs Node.js 20+ on PATH"; exit 1 }; & node "$env:HERDR_PLUGIN_ROOT\scripts\materialize-entrypoint.mjs"; exit $LASTEXITCODE']
+command = ['powershell', '-NoProfile', '-NonInteractive', '-Command', 'if (-not (Get-Command node -ErrorAction SilentlyContinue)) { Write-Error "red-skills needs Node.js 20+ on PATH"; exit 1 }; $root = if ($env:HERDR_PLUGIN_ROOT) { $env:HERDR_PLUGIN_ROOT } else { "." }; & node "$root\scripts\materialize-entrypoint.mjs"; exit $LASTEXITCODE']
 
 # The notification watcher. herdr fires this once per enabled plugin after the
 # session is restored and its API socket is ready.

--- a/apps/herdr-plugin-red-skills/scripts/check-manifest.py
+++ b/apps/herdr-plugin-red-skills/scripts/check-manifest.py
@@ -67,7 +67,13 @@ for section in ("panes", "actions", "startup", "build"):
         if entry.get("platforms") == ["windows"]:
             continue
         if "HERDR_PLUGIN_ROOT" in joined:
-            check("$HERDR_PLUGIN_ROOT" in joined, f"{section}: the plugin root must be read as a shell variable")
+            # Both spellings are a shell-variable read: the plain `$HERDR_PLUGIN_ROOT`
+            # and the build hook's `${HERDR_PLUGIN_ROOT:-.}` fallback (#3303 — some
+            # herdr versions do not inject the variable during the BUILD phase).
+            check(
+                "$HERDR_PLUGIN_ROOT" in joined or "${HERDR_PLUGIN_ROOT" in joined,
+                f"{section}: the plugin root must be read as a shell variable",
+            )
 
 # Every command must name an entry that is actually there. A pane whose command
 # points at a renamed file opens and closes again with nothing to read, which is
@@ -78,7 +84,7 @@ for section in ("panes", "actions", "startup", "build"):
         joined = " ".join(entry["command"])
         # `startup` and `build` entries carry no id; the section names them well enough.
         who = entry.get("id", section)
-        for match in re.finditer(r"HERDR_PLUGIN_ROOT[/\\]([\w./\\-]+\.mjs)", joined):
+        for match in re.finditer(r"HERDR_PLUGIN_ROOT(?::-\.)?\}?[/\\]([\w./\\-]+\.mjs)", joined):
             named = match.group(1).replace("\\", "/")
             check((ROOT / named).is_file(), f"{section} {who!r} runs {named!r}, which is not in this checkout")
 


### PR DESCRIPTION
External report #3303 (@JuninhoFreitas, root cause already isolated in the report): some herdr versions do not inject `HERDR_PLUGIN_ROOT` during the BUILD phase, so the materialize hook resolved `/scripts/materialize-entrypoint.mjs` off the filesystem root and `herdr plugin install` died with MODULE_NOT_FOUND.

The two build commands now fall back to the build's working directory (`${HERDR_PLUGIN_ROOT:-.}` / PowerShell equivalent), which herdr guarantees is the plugin root. Runtime commands (services, panes, actions) keep the plain variable — the injection gap is build-phase only, and a defensive fallback there would mask a real runtime injection break.

Verified by reproducing the empty-variable scenario: the hook fetches and materializes the release bundle and exits 0.

Closes #3303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788491267&installation_model_id=20659&pr_number=3309&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3309&signature=591daca902ea22c7cca6063f994bb46bc2de709f14645989817af3610eb4e97b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->