### PR TITLE
fix: #3307 The repair lane is visible while it heals: statusline, dashboard, herdr and VS Code name repair work as its own parallel activity

### DIFF
--- a/apps/herdr-plugin-red-skills/src/ui/dashboard.mjs
+++ b/apps/herdr-plugin-red-skills/src/ui/dashboard.mjs
@@ -137,7 +137,11 @@ export function renderHost(payload, { columns }) {
   const ceiling = host.ceiling ?? {};
   const accounting = host.budget_accounting ?? {};
 
-  const workers = `${style.bold(String(host.worker_count))} worker${host.worker_count === 1 ? "" : "s"}`;
+  const repairing = (payload.workers ?? []).filter((worker) => worker.display?.origin === "repair").length;
+  const workers = repairing > 0
+    ? `${style.bold(String(Math.max(0, host.worker_count - repairing)))} coding + ` +
+      style.brightMagenta(`${style.bold(String(repairing))} repairing`)
+    : `${style.bold(String(host.worker_count))} worker${host.worker_count === 1 ? "" : "s"}`;
   const projects = `${style.bold(String(host.project_count))} project${host.project_count === 1 ? "" : "s"}`;
   const declared = host.consumption?.memory_bytes ?? null;
   const ceilingBytes = ceiling.memory_bytes ?? null;
@@ -305,13 +309,16 @@ export function workerLayout(columns) {
 export function renderWorkerRow(worker, { columns, selected, verbose, localProject, layout = workerLayout(columns) }) {
   const marker = selected ? style.brightRed(SELECTED) : " ";
   const mine = localProject != null && worker.project_label === localProject;
+  const repair = worker.display?.origin === "repair";
 
   const id = padEnd(truncate(worker.worker_id, layout.id), layout.id);
   const label = shortProject(worker.project_label, layout.project);
   const project = padEnd(truncate(mine ? style.brightCyan(label) : label, layout.project), layout.project);
   const reattached = worker.state === "reattached";
-  const stateText = layout.short ? (reattached ? "reatt" : "run") : reattached ? "reattached" : "running";
-  const state = (reattached ? style.cyan : style.green)(padEnd(stateText, layout.state));
+  const stateText = repair
+    ? layout.short ? "heal" : "repairing"
+    : layout.short ? (reattached ? "reatt" : "run") : reattached ? "reattached" : "running";
+  const state = (repair ? style.brightMagenta : reattached ? style.cyan : style.green)(padEnd(stateText, layout.state));
   const uptime = padStart(duration(worker.uptime_ms), 6);
 
   const budget = worker.budget ?? {};
@@ -332,6 +339,17 @@ export function renderWorkerRow(worker, { columns, selected, verbose, localProje
 
   const row = ` ${marker} ${id} ${project} ${state} ${uptime}  ${usage} ${bar} ${share}${flags.length ? `  ${flags.join(" ")}` : ""}`;
   const lines = [truncate(row, columns)];
+
+  if (repair) {
+    const issue = String(worker.display?.issue ?? "?").replace(/^#/, "");
+    const step = worker.display?.step ?? worker.display?.phase ?? "step unknown";
+    lines.push(
+      truncate(
+        `     ${style.brightMagenta("⟳ repair lane")} ${style.gray("·")} PR #${issue} ${style.gray("·")} ${step}`,
+        columns,
+      ),
+    );
+  }
 
   if (verbose) {
     const line = oneLine(worker.log?.last_line ?? "");

--- a/apps/herdr-plugin-red-skills/tests/dashboard.test.mjs
+++ b/apps/herdr-plugin-red-skills/tests/dashboard.test.mjs
@@ -42,6 +42,31 @@ test("the host row states the ceiling it was given, and the fraction with it", (
   assert.match(rendered, /1 unisolated/);
 });
 
+test("repair activity names its lane, patient and step from the display record", () => {
+  const payload = statuslinePayload();
+  payload.workers[0].display = {
+    origin: "repair",
+    issue: "3291",
+    phase: "merging",
+    step: "regenerate",
+  };
+  payload.workers[1].display = { origin: "afk" };
+
+  const host = text(renderHost(payload, SIZE));
+  const row = text(renderWorkerRow(payload.workers[0], {
+    columns: 120,
+    selected: false,
+    verbose: false,
+    localProject: null,
+  }));
+
+  assert.match(host, /1 coding \+ 1 repairing/);
+  assert.match(row, /repair lane/);
+  assert.match(row, /PR #3291/);
+  assert.match(row, /regenerate/);
+  assert.doesNotMatch(text(renderHost(statuslinePayload(), SIZE)), /repairing/);
+});
+
 test("a host with no ceiling says so instead of drawing a full bar", () => {
   const payload = statuslinePayload();
   payload.host.ceiling = { memory_bytes: null, worker_count: null, source: "declared" };

--- a/apps/vscode-extension-red-skills/tests/dashboard.test.ts
+++ b/apps/vscode-extension-red-skills/tests/dashboard.test.ts
@@ -62,6 +62,26 @@ function withDisplay(payload: ReturnType<typeof statuslinePayload>): ReturnType<
   };
 }
 
+function withRepair(payload: ReturnType<typeof statuslinePayload>): ReturnType<typeof statuslinePayload> {
+  const published = withDisplay(payload);
+  return {
+    ...published,
+    workers: published.workers.map((entry) => ({
+      ...entry,
+      display: {
+        ...entry.display!,
+        runner: null,
+        model: null,
+        effort: null,
+        origin: "repair",
+        issue: "3291",
+        phase: "merging",
+        step: "regenerate",
+      },
+    })),
+  };
+}
+
 const daemons: FakeDaemon[] = [];
 
 afterEach(async () => {
@@ -208,6 +228,23 @@ describe("the frame is drawn here, from the one document the daemon composed", (
     // The cells come from the shared render module, so a terminal pane standing
     // in the same directory draws this row character for character.
     expect(snapshot.dashboard?.rows[0]?.cells.bar).toBe("██▶░░░");
+  });
+
+  it("shows the shared repair lane vocabulary in both editor surfaces", async () => {
+    const daemon = await fake({ payload: () => withRepair(statuslinePayload()) });
+    const snapshot = await readHostSnapshot({
+      client: createRedskilledReadClient({ socketPath: daemon.socketPath }),
+      eventLanePath: daemon.eventLanePath,
+      source: "the test pinned it",
+      sessionProject: "reddb-io/red-skills",
+      dashboardRender: { maxWidth: 180, maxRows: 9 },
+    });
+
+    expect(statusBarView(snapshot).text).toContain("workers=0 coding + 1 repairing");
+    const html = renderDashboardHtml(snapshot);
+    expect(html).toContain("lane=repair");
+    expect(html).toContain("pr=#3291");
+    expect(html).toContain("merging·regenerate");
   });
 
   it("shows why a process died, and the engine that answered, from the daemon's own frame", async () => {

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -221,6 +221,12 @@ const BAR_FAILED = "✗";
 const BAR_AHEAD = "░";
 const LANDING_PHASES = new Set(["gate", "push-pr", "merge", "cascade"]);
 const NO_AGENT_ORIGINS = new Set(["requeue"]);
+const REPAIR_ORIGIN = "repair";
+
+/** Whether the already-published provenance identifies the mechanical repair lane. PURE. */
+export function isRepairWorker(worker: RedskilledRenderWorker): boolean {
+  return worker.display?.origin === REPAIR_ORIGIN;
+}
 
 /**
  * The finished dashboard. PURE — payload and options in, header and rows out.
@@ -292,16 +298,17 @@ export function workerCells(
   generatedAt: string,
 ): RedskilledDashboardCells {
   const display = worker.display ?? REDSKILLED_RENDER_DISPLAY_ABSENT;
+  const repair = isRepairWorker(worker);
   const run = [display.runner, display.model == null ? null : shortModel(display.model), display.effort]
     .filter((part): part is string => Boolean(part))
     .join(" ");
   const landing = display.phase != null && LANDING_PHASES.has(display.phase);
-  const noAgent = landing || (display.origin != null && NO_AGENT_ORIGINS.has(display.origin));
+  const noAgent = repair || landing || (display.origin != null && NO_AGENT_ORIGINS.has(display.origin));
   return {
     wid: options.mode === "global" ? `${worker.project_label}:${worker.worker_id}` : worker.worker_id,
-    run: run === "" ? "" : `run=${run}`,
-    org: landing ? "org=landing" : display.origin == null ? "" : `org=${display.origin}`,
-    iss: display.issue == null ? "" : `iss=${display.issue}`,
+    run: repair || run === "" ? "" : `run=${run}`,
+    org: repair ? "lane=repair" : landing ? "org=landing" : display.origin == null ? "" : `org=${display.origin}`,
+    iss: display.issue == null ? "" : repair ? `pr=#${display.issue.replace(/^#/, "")}` : `iss=${display.issue}`,
     bar: progressBar(display),
     phase: [display.phase, display.step].filter((part): part is string => Boolean(part)).join("·"),
     elapsed: formatDuration(workerElapsedMs(worker, generatedAt)),
@@ -408,7 +415,15 @@ function buildHeader(
   if (match === "unregistered" || match === "name-only") parts.push(UNREGISTERED_MARK);
   if (match === "lapsed") parts.push(LAPSED_MARK);
   if (model != null) parts.push(`${WINE}${WHITE}${model}${NOBG}${SOFT}`);
-  parts.push(colourKeyValues(`wrk=${selected.length}/${payload.host.worker_count}`));
+  const repairing = payload.workers.filter(isRepairWorker).length;
+  if (repairing > 0) {
+    const coding = Math.max(0, payload.host.worker_count - repairing);
+    parts.push(
+      `${colourKeyValues(`workers=${coding} coding +`)} ${WINE}${WHITE}${repairing} repairing${NOBG}${SOFT}`,
+    );
+  } else {
+    parts.push(colourKeyValues(`wrk=${selected.length}/${payload.host.worker_count}`));
+  }
   const slots = windows.worker_ceiling == null
     ? "slots=∞"
     : `slots=${windows.worker_count}/${windows.worker_ceiling}`;
@@ -665,6 +680,10 @@ function formatRow(
 /** One dashboard cell in the single palette role shared by every density. PURE. */
 export function colourWorkerCell(column: RedskilledDashboardColumn, raw: string): string {
   if (column === "wid") return `${BOLD}${raw}${NOBOLD}`;
+  if (column === "org" && raw.trim() === "lane=repair") {
+    const suffix = raw.slice(raw.trimEnd().length);
+    return `${WINE}${WHITE}${raw.trimEnd()}${NOBG}${SOFT}${suffix}`;
+  }
   if (column === "bar") {
     return raw
       .replace(/█+/g, (done) => `${BAR_DONE_TONE}${done}`)

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -31,6 +31,7 @@
  */
 import {
   colourWorkerCell,
+  isRepairWorker,
   REDSKILLED_DASHBOARD_COLUMNS,
   workerCells,
   type RedskilledDashboardCells,
@@ -306,17 +307,17 @@ function renderHead(
   const parts: string[] = [];
   const unmatchedProject = match !== "matched" && match !== "name-only";
   if (options.mode === "global") {
-    parts.push(`host ${payload.host.worker_count}w/${payload.host.project_count}p`);
+    parts.push(`host ${workerActivity(payload.workers, payload.host.worker_count)}/${payload.host.project_count}p`);
     parts.push(memoryFigure(payload, options));
   } else if (match === "matched") {
-    parts.push(`${options.project} ${workers.length}w`);
+    parts.push(`${options.project} ${workerActivity(workers, workers.length)}`);
     parts.push(memoryFigure(payload, options));
     if (workers.length === 0) parts.push("idle");
   } else if (match === "name-only") {
     // The Workers still count — they are running — but the line says out loud
     // that the host holds no registration, and it never says `idle`: a project
     // nothing will be born for is stopped, not resting (#2973).
-    parts.push(`${options.project} ${workers.length}w`);
+    parts.push(`${options.project} ${workerActivity(workers, workers.length)}`);
     parts.push(memoryFigure(payload, options));
     parts.push(UNREGISTERED_MARK);
   } else {
@@ -344,6 +345,13 @@ function renderHead(
     : null]
     .filter((part): part is string => part != null)
     .join(" ");
+}
+
+/** Split mechanical healing out only when it exists; calm hosts keep the compact count. PURE. */
+function workerActivity(workers: readonly RedskilledRenderWorker[], total: number): string {
+  const repairing = workers.filter(isRepairWorker).length;
+  if (repairing === 0) return `${total}w`;
+  return `${Math.max(0, total - repairing)} coding + ${repairing} repairing`;
 }
 
 /**

--- a/packages/redskilled-render/panel.ts
+++ b/packages/redskilled-render/panel.ts
@@ -16,7 +16,12 @@
  *
  * PURE, like every other density: payload and options in, rows out.
  */
-import { colourWorkerCell, workerCells, type RedskilledDashboardColumn } from "./dashboard.js";
+import {
+  colourWorkerCell,
+  isRepairWorker,
+  workerCells,
+  type RedskilledDashboardColumn,
+} from "./dashboard.js";
 import { clamp, formatBytes } from "./format.js";
 import { BUDGET_BAND_MARK, BUDGET_SPENT_MARK, DEATH_MARK } from "./marks.js";
 import { KEY, NOBG, RESET, SOFT, VAL } from "./palette.js";
@@ -158,7 +163,9 @@ function workerRow(
   generatedAt: string,
 ): string {
   const cells = workerCells(worker, { mode }, generatedAt);
-  const columns: readonly RedskilledDashboardColumn[] = ["wid", "bar", "phase", "elapsed", "eta"];
+  const columns: readonly RedskilledDashboardColumn[] = isRepairWorker(worker)
+    ? ["wid", "org", "iss", "bar", "phase", "elapsed", "eta"]
+    : ["wid", "bar", "phase", "elapsed", "eta"];
   const parts = columns
     .filter((column) => cells[column] !== "")
     .map((column) => colourWorkerCell(column, cells[column]));

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -86,6 +86,50 @@ describe("one module, three densities", () => {
       .toEqual(renderRedskilledStatusline(doc, LOCAL).lines);
   });
 
+  it("names a repair lane, its patient and step at every density", () => {
+    const coding = worker({ worker_id: "w-code", display: display() });
+    const repair = worker({
+      worker_id: "w-heal",
+      display: display({
+        runner: null,
+        model: null,
+        effort: null,
+        origin: "repair",
+        issue: "3291",
+        phase: "merging",
+        step: "regenerate",
+      }),
+    });
+    const doc = payload({
+      workers: [coding, repair],
+      host: { ...payload().host, worker_count: 2 },
+      projects: [{ ...payload().projects[0]!, worker_count: 2 }],
+    });
+
+    const line = renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 240 });
+    const panel = renderRedskilledPanel(doc, {
+      ...REDSKILLED_PANEL_DEFAULTS,
+      project: "acme/widgets",
+      maxWidth: 240,
+    });
+    const table = renderRedskilledDashboard(doc, {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      project: "acme/widgets",
+      maxWidth: 240,
+    });
+
+    for (const row of [line.lines[2]!, panel.worker_rows[1]!, table.rows[1]!.line]) {
+      expect(stripAnsi(row)).toContain("lane=repair");
+      expect(stripAnsi(row)).toContain("pr=#3291");
+      expect(stripAnsi(row)).toContain("merging·regenerate");
+      expect(row).toContain(`${WINE}${WHITE}lane=repair`);
+    }
+    expect(line.line).toContain("1 coding + 1 repairing");
+    expect(stripAnsi(table.header.line)).toContain("workers=1 coding + 1 repairing");
+    expect(stripAnsi(renderRedskilledDashboard(payload(), REDSKILLED_DASHBOARD_DEFAULTS).header.line))
+      .not.toContain("repairing");
+  });
+
   it("degrades cells from the right without dropping selected Workers", () => {
     const workers = Array.from({ length: 3 }, (_, index) =>
       worker({ worker_id: `w-${index}`, display: display({ issue: String(3100 + index) }) }));


### PR DESCRIPTION
Automated AFK landing for #3307. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3307

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788494441&installation_model_id=20659&pr_number=3313&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3313&signature=d27120556a1be09c6c83fcc537033bf88ce614533084e183f2719d39dde76fd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->