### PR TITLE
merge: #3265 The surface consolidates for real: status {scope} absorbs the worker, monitor and host_* sibling families behind deprecation aliases

### DIFF
--- a/apps/dev/src/commands/codex-statusline.ts
+++ b/apps/dev/src/commands/codex-statusline.ts
@@ -73,7 +73,7 @@ function renderPlain(path: string, inspection: CodexStatuslineInspection, change
     lines.push("fix: afk codex-statusline --fix");
   }
   lines.push(
-    "boundary: Codex supports built-in footer IDs only; read rich AFK worker state from the castle `monitor` and `worker_vitals` tools (no-MCP fallback: /afk monitor).",
+    "boundary: Codex supports built-in footer IDs only; read rich AFK worker state from castle `status {scope: worker}` (no-MCP fallback: /afk monitor).",
   );
   lines.push("opencode: AFK API-auth runner only; no interactive host footer/plugin UI.");
   return `${lines.join("\n")}\n`;

--- a/apps/dev/src/commands/mcp-lane-canary.ts
+++ b/apps/dev/src/commands/mcp-lane-canary.ts
@@ -42,7 +42,7 @@ const USAGE = `Usage: castle-mcp __mcp-canary [options]
 
 Drives the shipped MCP lane end to end — project_start -> a registration the
 daemon holds -> no process of the project's own -> one poll covering it -> a
-Worker the daemon birthed -> project_status -> project_stop — and fails loudly
+Worker the daemon birthed -> status {scope: project} -> project_stop — and fails loudly
 naming the step that went inert.
 
   --entry <path>              MCP bundle entry (default: the castle-mcp bundle

--- a/apps/dev/src/core/codex-monitor-agent.ts
+++ b/apps/dev/src/core/codex-monitor-agent.ts
@@ -32,7 +32,7 @@ export interface CodexMonitorAgentPromptOptions {
 export const DEFAULT_CODEX_MONITOR_INTERVAL_SECONDS = 30;
 
 /**
- * The castle `monitor` tool is the canonical read (ADR 0120/0123); this CLI
+ * The castle `status {scope: worker}` intent is the canonical read (ADR 0120/0134); this CLI
  * invocation is the no-MCP fallback for hosts that cannot reach the MCP.
  */
 export const DEFAULT_CODEX_MONITOR_COMMAND =
@@ -67,12 +67,12 @@ export function renderCodexMonitorAgentPrompt(options: CodexMonitorAgentPromptOp
     "Purpose: keep AFK progress visible in the Codex UI while the main session continues working.",
     "",
     "Loop:",
-    `1. Every ${intervalSeconds} seconds, read live state from the castle MCP: call the castle \`monitor\` tool for the current workers, history events, and fleet inputs, and \`worker_vitals\` when you must tell a quiet-but-alive worker from a dead one.`,
+    `1. Every ${intervalSeconds} seconds, read live state from the castle MCP: call the castle \`status\` tool with \`scope: worker\` for normalized worker state, vitals, and monitor inputs.`,
     "2. When the castle MCP is not reachable from this host, say so once, then use the no-MCP fallback from the project root:",
     `   ${monitorCommand}`,
     "3. Report a concise progress update when live worker state changes, when a worker becomes stale/wedged, or at least every five minutes.",
-    "4. Exit once there is no live .red/tmp/supervisors/default/afk-supervisor.pid and the monitor read has no [live] or [quiet] workers.",
-    "5. If the monitor read fails three times in a row, report the failure and exit.",
+    "4. Exit once there is no live .red/tmp/supervisors/default/afk-supervisor.pid and the worker status read has no [live] or [quiet] workers.",
+    "5. If the status read fails three times in a row, report the failure and exit.",
     "",
     "Hard read-only rules:",
     "- Do not edit files.",
@@ -81,7 +81,7 @@ export function renderCodexMonitorAgentPrompt(options: CodexMonitorAgentPromptOp
     "- Do not repair state. Only observe and report.",
     "",
     "Allowed actions:",
-    "- Call the read-only castle tools above (`monitor`, `worker_vitals`), or the fallback command when the MCP is unreachable.",
+    "- Call the read-only castle `status` tool above, or the fallback command when the MCP is unreachable.",
     "- Use read-only process/file checks such as ps, test -f, cat, tail, and ls when needed to decide whether to exit.",
     "- Summarize worker id, issue number, runner, stage, live/stale/wedged state, duration, and diffstat.",
   ].join("\n") + "\n";

--- a/apps/dev/src/core/mcp-lane-canary.ts
+++ b/apps/dev/src/core/mcp-lane-canary.ts
@@ -44,7 +44,7 @@ export type McpLaneCanaryStep =
   | "no_project_process"
   | "queue_polled"
   | "worker_born"
-  | "project_status"
+  | "status"
   | "project_stop";
 
 export const MCP_LANE_CANARY_STEPS: readonly McpLaneCanaryStep[] = [
@@ -54,14 +54,14 @@ export const MCP_LANE_CANARY_STEPS: readonly McpLaneCanaryStep[] = [
   "no_project_process",
   "queue_polled",
   "worker_born",
-  "project_status",
+  "status",
   "project_stop",
 ];
 
 /** The MCP tools the lane must expose before the canary can walk it at all. */
 export const MCP_LANE_CANARY_REQUIRED_TOOLS: readonly string[] = [
   "project_start",
-  "project_status",
+  "status",
   "project_stop",
 ];
 
@@ -474,15 +474,15 @@ export async function runMcpLaneCanary(
           `${born.workers.map((worker) => `${worker.workerId} (pid=${worker.pid})`).join(", ")}`,
       );
 
-      // ---- 7. project_status: the canonical reader runs no process of its own,
+      // ---- 7. status: the canonical reader runs no process of its own,
       // and RECOGNISES the Workers step 6 just watched the host birth ----
-      const observedStatus = await call("project_status", "project_status", {});
+      const observedStatus = await call("status", "status", { scope: "project" });
       const supervisor = asRecord(observedStatus.supervisor);
       const reportedPid = supervisor ? readPid(supervisor.pid) : null;
       if (supervisor && readBool(supervisor.alive)) {
         inert(
-          "project_status",
-          `project_status reports supervisor pid ${reportedPid ?? "none"} alive after a registration — ` +
+          "status",
+          `status {scope: project} reports supervisor pid ${reportedPid ?? "none"} alive after a registration — ` +
             `the lane's reader can still see a per-project process the start was supposed to have stopped creating`,
         );
       }
@@ -494,8 +494,8 @@ export async function runMcpLaneCanary(
       const busy = readCount(asRecord(observedStatus.slots)?.busy);
       if (busy !== born.workers.length) {
         inert(
-          "project_status",
-          `project_status reports slots.busy=${busy} while the host birthed ${born.workers.length} Worker(s) for this ` +
+          "status",
+          `status {scope: project} reports slots.busy=${busy} while the host birthed ${born.workers.length} Worker(s) for this ` +
             `project — the lane's reader and writer disagree about who is running`,
         );
       }
@@ -505,14 +505,14 @@ export async function runMcpLaneCanary(
       const statusWarnings = Array.isArray(observedStatus.warnings) ? observedStatus.warnings : [];
       if (statusWarnings.length > 0) {
         inert(
-          "project_status",
-          `project_status answered with ${statusWarnings.length} attribution warning(s): ${statusWarnings.join("; ")}`,
+          "status",
+          `status {scope: project} answered with ${statusWarnings.length} attribution warning(s): ${statusWarnings.join("; ")}`,
         );
       }
       record(
-        "project_status",
+        "status",
         "ok",
-        `project_status answers with no per-project supervisor and counts ${busy} busy slot(s) — the Worker(s) the ` +
+        `status {scope: project} answers with no per-project supervisor and counts ${busy} busy slot(s) — the Worker(s) the ` +
           `host birthed for this project`,
       );
     } finally {
@@ -564,7 +564,7 @@ export async function runMcpLaneCanary(
     ...(resolvedInert ? { inertStep: resolvedInert } : {}),
     summary: ok
       ? "MCP lane canary green: project_start → a registration the daemon holds → no process of the project's own → one poll covering it → " +
-        "a Worker the daemon birthed → project_status → project_stop all answered"
+        "a Worker the daemon birthed → status {scope: project} → project_stop all answered"
       : `MCP lane canary FAILED — the ${resolvedInert} step went inert: ${
         steps.find((entry) => entry.step === resolvedInert)?.detail ?? "no detail"
       }`,

--- a/apps/dev/tests/castle-mcp-client-docs.test.ts
+++ b/apps/dev/tests/castle-mcp-client-docs.test.ts
@@ -60,9 +60,10 @@ describe("castle MCP client docs contract", () => {
 
     expect(skill).toContain("`castle` MCP");
     expect(skill).toContain("[`MCP.md`](./MCP.md)");
-    for (const tool of ["queue_status", "worker_dispatch", "status"]) {
+    for (const tool of ["queue_status", "worker_dispatch"]) {
       expect(skill, `/afk should route through ${tool}`).toContain(`\`${tool}\``);
     }
+    expect(skill).toContain("`status {scope:");
   });
 
   it("makes /go dispatch through the same MCP surface", async () => {

--- a/apps/dev/tests/castle-mcp-client-docs.test.ts
+++ b/apps/dev/tests/castle-mcp-client-docs.test.ts
@@ -15,6 +15,7 @@ function readRepoFile(path: string): Promise<string> {
 }
 
 const tools = createCastleMcpTools({} as CastleMcpDependencies);
+const intentTools = tools.filter((tool) => !tool.description.startsWith("DEPRECATED:"));
 
 interface DocumentedTool {
   readonly name: string;
@@ -29,18 +30,18 @@ function documentedTools(doc: string): DocumentedTool[] {
 }
 
 describe("castle MCP client docs contract", () => {
-  it("documents every castle MCP tool exactly once in MCP.md", async () => {
+  it("documents every canonical castle intent exactly once in MCP.md", async () => {
     const doc = await readRepoFile(MCP_DOC);
     const documented = documentedTools(doc).map((entry) => entry.name);
 
-    expect([...documented].sort()).toEqual([...tools.map((tool) => tool.name)].sort());
+    expect([...documented].sort()).toEqual([...intentTools.map((tool) => tool.name)].sort());
   });
 
-  it("marks each documented tool with the mutation mode its description declares", async () => {
+  it("marks each documented intent with the mutation mode its description declares", async () => {
     const doc = await readRepoFile(MCP_DOC);
     const modeByName = new Map(documentedTools(doc).map((entry) => [entry.name, entry.mode]));
 
-    for (const tool of tools) {
+    for (const tool of intentTools) {
       const expected = tool.description.startsWith("MUTATING:") ? "mutating" : "read";
       expect(modeByName.get(tool.name), `${tool.name} mode`).toBe(expected);
     }
@@ -59,7 +60,7 @@ describe("castle MCP client docs contract", () => {
 
     expect(skill).toContain("`castle` MCP");
     expect(skill).toContain("[`MCP.md`](./MCP.md)");
-    for (const tool of ["queue_status", "worker_dispatch", "project_status", "monitor"]) {
+    for (const tool of ["queue_status", "worker_dispatch", "status"]) {
       expect(skill, `/afk should route through ${tool}`).toContain(`\`${tool}\``);
     }
   });
@@ -78,7 +79,7 @@ describe("castle MCP client docs contract", () => {
       readRepoFile(`${AFK}/monitor.md`),
     ]);
 
-    for (const tool of ["project_start", "project_status", "project_resize", "project_reset", "project_stop", "logs"]) {
+    for (const tool of ["project_start", "status", "project_resize", "project_reset", "project_stop", "logs"]) {
       expect(fleet, `fleet.md should route through ${tool}`).toContain(`\`${tool}\``);
     }
     for (const tool of ["monitor", "worker_vitals", "queue_status"]) {

--- a/apps/dev/tests/mcp-first-suggestions.test.ts
+++ b/apps/dev/tests/mcp-first-suggestions.test.ts
@@ -69,12 +69,12 @@ describe("MCP-first suggestion compliance", () => {
     }
   });
 
-  it("makes the Codex monitor agent poll the castle monitor tool first", () => {
+  it("makes the Codex monitor agent poll scoped castle status first", () => {
     const prompt = renderCodexMonitorAgentPrompt({ projectRoot: "/repo", mode: "fleet" });
 
-    expect(prompt).toContain("castle `monitor` tool");
-    expect(prompt).toContain("`worker_vitals`");
-    expect(prompt.indexOf("castle `monitor` tool")).toBeLessThan(
+    expect(prompt).toContain("castle `status` tool");
+    expect(prompt).toContain("scope: worker");
+    expect(prompt.indexOf("castle `status` tool")).toBeLessThan(
       prompt.indexOf("red-skills-dev monitor --once"),
     );
     expect(prompt).toContain(NO_MCP_LABEL);

--- a/apps/dev/tests/mcp-help.test.ts
+++ b/apps/dev/tests/mcp-help.test.ts
@@ -88,7 +88,7 @@ function heldRegistration(root: string) {
 }
 
 describe("castle MCP help", () => {
-  it("narrates declared and skipped Validation moments in help and project_status", async () => {
+  it("narrates declared and skipped Validation moments in help and project status", async () => {
     const root = await scratch();
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(join(root, ".red", "config.yaml"), [
@@ -106,7 +106,7 @@ describe("castle MCP help", () => {
     host.hostState.mockResolvedValue({ daemon_version: "3.5.0", demand: null });
     const tools = createCastleMcpTools(createCastleMcpDependencies(root));
     const help = tools.find((tool) => tool.name === "help")!;
-    const projectStatus = tools.find((tool) => tool.name === "project_status")!;
+    const status = tools.find((tool) => tool.name === "status")!;
     const expected = {
       narration:
         "Validation moments — iteration: declared [pnpm test]; " +
@@ -118,7 +118,7 @@ describe("castle MCP help", () => {
       ],
     };
 
-    await expect(projectStatus.invoke({})).resolves.toMatchObject({
+    await expect(status.invoke({ scope: "project" })).resolves.toMatchObject({
       validation_schedule: expected,
     });
     await expect(help.invoke({})).resolves.toMatchObject({
@@ -182,12 +182,13 @@ describe("castle MCP help", () => {
         workers: { busy: 0, live: 0, target: 2 },
         last_refusal: "host ceiling is temporarily full",
       },
-      next: { tool: "project_status", args: {} },
+      next: { tool: "status", args: { scope: "project" } },
     });
 
     const advertised = answer.intent_map.flatMap((group) => group.tools);
-    expect(advertised.map(({ name }) => name)).toEqual(tools.map(({ name }) => name));
-    expect(advertised.map(({ title }) => title)).toEqual(tools.map(({ title }) => title));
+    const intents = tools.filter((tool) => !tool.description.startsWith("DEPRECATED:"));
+    expect(advertised.map(({ name }) => name)).toEqual(intents.map(({ name }) => name));
+    expect(advertised.map(({ title }) => title)).toEqual(intents.map(({ title }) => title));
     expect(github.calls).toBe(0);
   });
 });

--- a/apps/dev/tests/mcp-lane-canary.test.ts
+++ b/apps/dev/tests/mcp-lane-canary.test.ts
@@ -101,7 +101,7 @@ function harness(options: HarnessOptions = {}) {
     listTools: async () =>
       options.tools ?? [
         "project_start",
-        "project_status",
+        "status",
         "project_stop",
         "worker_vitals",
         "worker_status",
@@ -111,7 +111,7 @@ function harness(options: HarnessOptions = {}) {
       if (tool === "project_start") {
         return options.create ?? registered();
       }
-      if (tool === "project_status") {
+      if (tool === "status") {
         return (
           // One busy slot, because the default host read births one Worker: a
           // reader that counted 0 over a live fleet is the #3081 defect, not
@@ -184,7 +184,7 @@ describe("MCP lane canary — green lane", () => {
     // The real tool surface was driven, in lane order.
     expect(calls.map((call) => call.tool)).toEqual([
       "project_start",
-      "project_status",
+      "status",
       "project_stop",
     ]);
   });
@@ -225,7 +225,7 @@ describe("MCP lane canary — the registration is the whole presence (#2902)", (
     const byStep = new Map(result.steps.map((step) => [step.step, step.verdict]));
     expect(byStep.get("project_start")).toBe("ok");
     expect(byStep.get("registration_held")).toBe("ok");
-    expect(byStep.get("project_status")).toBe("skipped");
+    expect(byStep.get("status")).toBe("skipped");
     // An inert lane still gives its registration back.
     expect(byStep.get("project_stop")).toBe("ok");
   });
@@ -450,7 +450,7 @@ describe("MCP lane canary — the other inert steps", () => {
     const result = await runMcpLaneCanary(deps, OPTIONS);
 
     expect(result.inertStep).toBe("connect");
-    expect(result.summary).toContain("project_start, project_status, project_stop");
+    expect(result.summary).toContain("project_start, status, project_stop");
     expect(result.steps.every((step) => step.verdict !== "ok")).toBe(true);
   });
 
@@ -466,18 +466,18 @@ describe("MCP lane canary — the other inert steps", () => {
     expect(result.summary).toContain("registration refused");
   });
 
-  it("fails at project_status when the reader still sees a per-project supervisor", async () => {
+  it("fails at status when the reader still sees a per-project supervisor", async () => {
     const { deps } = harness({
       status: { supervisor: { pid: STRAY_PID, alive: true }, slots: { busy: 1 } },
     });
 
     const result = await runMcpLaneCanary(deps, OPTIONS);
 
-    expect(result.inertStep).toBe("project_status");
+    expect(result.inertStep).toBe("status");
     expect(result.summary).toContain(`supervisor pid ${STRAY_PID} alive`);
   });
 
-  it("fails at project_status when the reader cannot count the Worker the host birthed", async () => {
+  it("fails at status when the reader cannot count the Worker the host birthed", async () => {
     // The #3081 shape: the host birthed a Worker, the reader says the project
     // has nothing running. An empty fleet over a busy one is indistinguishable
     // from an idle repository, which is exactly why it must go inert here.
@@ -487,12 +487,12 @@ describe("MCP lane canary — the other inert steps", () => {
 
     const result = await runMcpLaneCanary(deps, OPTIONS);
 
-    expect(result.inertStep).toBe("project_status");
+    expect(result.inertStep).toBe("status");
     expect(result.summary).toContain("slots.busy=0");
     expect(result.summary).toContain("birthed 1 Worker(s)");
   });
 
-  it("fails at project_status when the reader could not attribute its own Workers", async () => {
+  it("fails at status when the reader could not attribute its own Workers", async () => {
     // A warning here means the join between host ids and project ids came apart:
     // the reader answered, and its answer says it cannot recognise its own fleet.
     const { deps } = harness({
@@ -505,7 +505,7 @@ describe("MCP lane canary — the other inert steps", () => {
 
     const result = await runMcpLaneCanary(deps, OPTIONS);
 
-    expect(result.inertStep).toBe("project_status");
+    expect(result.inertStep).toBe("status");
     expect(result.summary).toContain("attribution warning(s)");
   });
 

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -180,6 +180,7 @@ describe("castle MCP tools", () => {
   it("publishes the Fleet and Observability domains", () => {
     expect(createCastleMcpTools(deps()).map((tool) => tool.name)).toEqual([
       "help",
+      "status",
       "project_status",
       "drain",
       "project_start",
@@ -231,6 +232,61 @@ describe("castle MCP tools", () => {
       "respond",
       "statusline_aggregate",
     ]);
+  });
+
+  it("answers project, worker, and host status through one intent tool", async () => {
+    const d = deps();
+    const status = createCastleMcpTools(d).find((tool) => tool.name === "status")!;
+
+    await expect(status.invoke({ scope: "project" })).resolves.toMatchObject({
+      registration: { held: true },
+      slots: { total: 2 },
+    });
+    await expect(status.invoke({ scope: "worker", worker: "worker-1", live_only: false })).resolves.toEqual({
+      status: [],
+      vitals: [],
+      monitor: { workers: [], events: [], fleet: null },
+    });
+    expect(d.workerStatus).toHaveBeenCalledWith({
+      worker: "worker-1",
+      live_only: false,
+      fields: undefined,
+    });
+    expect(d.workerVitals).toHaveBeenCalledWith({ live_only: false, fields: undefined });
+    await expect(status.invoke({ scope: "host" })).resolves.toEqual({
+      state: { pid: 42, workers: [] },
+      dashboard: { version: 1, mode: "global", rows: [] },
+      provision_check: { verdict: "ok", rows: [], findings: [] },
+      unit_status: {
+        installed: false,
+        enabled: false,
+        active: false,
+        floor: "auto-spawn",
+      },
+    });
+  });
+
+  it("keeps every absorbed verb as an answering deprecation alias", async () => {
+    const tools = createCastleMcpTools(deps());
+    const aliases = [
+      ["project_status", "project"],
+      ["worker_status", "worker"],
+      ["worker_vitals", "worker"],
+      ["monitor", "worker"],
+      ["host_state", "host"],
+      ["host_dashboard", "host"],
+      ["host_provision_check", "host"],
+      ["host_unit_status", "host"],
+    ] as const;
+
+    for (const [name, scope] of aliases) {
+      const answer = await tools.find((tool) => tool.name === name)!.invoke({});
+      expect(answer).toMatchObject({
+        deprecated: true,
+        replacement: { tool: "status", args: { scope } },
+      });
+      expect(answer).toHaveProperty("result");
+    }
   });
 
   it("returns structured project status without rendering command output", async () => {

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -289,13 +289,15 @@ describe("castle MCP tools", () => {
     }
   });
 
-  it("returns structured project status without rendering command output", async () => {
+  it("keeps structured project status inside the deprecated alias answer", async () => {
     const tools = createCastleMcpTools(deps());
     const status = tools.find((tool) => tool.name === "project_status")!;
     await expect(status.invoke({})).resolves.toMatchObject({
-      registration: { held: true, renewal: "renewing", target: 2 },
-      slots: { total: 2 },
-      live_workers: [{ id: "worker-1" }],
+      result: {
+        registration: { held: true, renewal: "renewing", target: 2 },
+        slots: { total: 2 },
+        live_workers: [{ id: "worker-1" }],
+      },
     });
   });
 
@@ -326,19 +328,17 @@ describe("castle MCP tools", () => {
     const d = deps();
     const tools = createCastleMcpTools(d);
 
-    await expect(tools.find((tool) => tool.name === "host_state")!.invoke({})).resolves.toEqual({
-      pid: 42,
-      workers: [],
+    await expect(tools.find((tool) => tool.name === "host_state")!.invoke({})).resolves.toMatchObject({
+      result: { pid: 42, workers: [] },
     });
     await expect(tools.find((tool) => tool.name === "host_dashboard")!.invoke({})).resolves.toMatchObject({
-      version: 1,
-      mode: "global",
+      result: { version: 1, mode: "global" },
     });
     await expect(tools.find((tool) => tool.name === "host_provision_check")!.invoke({})).resolves.toMatchObject({
-      verdict: "ok",
+      result: { verdict: "ok" },
     });
     await expect(tools.find((tool) => tool.name === "host_unit_status")!.invoke({})).resolves.toMatchObject({
-      floor: "auto-spawn",
+      result: { floor: "auto-spawn" },
     });
   });
 

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -24,6 +24,7 @@ import {
   createStatuslineTools,
   type StatuslineDependencies,
 } from "./mcp/statusline.js";
+import { createStatusTools } from "./mcp/status.js";
 import type { CastleMcpTool } from "./mcp/tool.js";
 import { applyDangerPosture, type DangerPosture } from "./mcp/posture.js";
 import { createWaitTools, type WaitDependencies } from "./mcp/wait.js";
@@ -37,6 +38,7 @@ export type { CastleMcpTool } from "./mcp/tool.js";
 export { CASTLE_MCP_PROMPTS } from "./mcp/prompt.js";
 export type { CastleMcpPrompt } from "./mcp/prompt.js";
 export type { DangerPosture } from "./mcp/posture.js";
+export type { StatusInput, StatusScope } from "./mcp/status.js";
 export {
   CASTLE_MCP_CONTRACT_VERSION,
   projectStatusOutputSchema,
@@ -134,6 +136,7 @@ export function createCastleMcpTools(
   let publishedTools: CastleMcpTool[] = [];
   const tools = [
     ...createHelpTools(deps, () => publishedTools),
+    ...createStatusTools(deps),
     ...createProjectTools(deps),
     ...createHostTools(deps),
     ...createObservabilityTools(deps),

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -26,10 +26,17 @@ const SURFACE: ReadonlyArray<{
     schema: [],
   },
   {
-    name: "project_status",
-    title: "Get project worker status",
+    name: "status",
+    title: "Read Castle status",
     description:
-      "Return this project's host registration, slots, and live-worker status.",
+      "Answer the current worker, project, or host status through one intent-scoped read.",
+    schema: ["scope", "worker", "live_only", "fields"],
+  },
+  {
+    name: "project_status",
+    title: "Deprecated project status alias",
+    description:
+      "DEPRECATED: use status { scope: project }. Returns the project answer and names its replacement.",
     schema: ["fleet"],
   },
   {
@@ -70,30 +77,30 @@ const SURFACE: ReadonlyArray<{
   },
   {
     name: "host_state",
-    title: "Read daemon host state",
+    title: "Deprecated host state alias",
     description:
-      "Return every project and Worker the redskilled daemon holds on this machine.",
+      "DEPRECATED: use status { scope: host }. Returns daemon host state and names its replacement.",
     schema: [],
   },
   {
     name: "host_dashboard",
-    title: "Read daemon host dashboard",
+    title: "Deprecated host dashboard alias",
     description:
-      "Return the structured global dashboard for every project's Workers on this machine.",
+      "DEPRECATED: use status { scope: host }. Returns the global dashboard and names its replacement.",
     schema: [],
   },
   {
     name: "host_provision_check",
-    title: "Check daemon host provisioning",
+    title: "Deprecated host provisioning alias",
     description:
-      "Read whether this machine is ready to run redskilled and what is missing; creates and starts nothing.",
+      "DEPRECATED: use status { scope: host }. Returns the provisioning check and names its replacement.",
     schema: [],
   },
   {
     name: "host_unit_status",
-    title: "Read daemon unit status",
+    title: "Deprecated host unit status alias",
     description:
-      "Return whether the optional redskilled supervisor unit is installed, enabled, and active.",
+      "DEPRECATED: use status { scope: host }. Returns the unit status and names its replacement.",
     schema: [],
   },
   {
@@ -105,9 +112,9 @@ const SURFACE: ReadonlyArray<{
   },
   {
     name: "worker_vitals",
-    title: "Read worker vitals",
+    title: "Deprecated worker vitals alias",
     description:
-      "Return the liveness-qualified state of local workers. Defaults to live workers only; pass `live_only: false` to include stopped/dead workers. Pass `fields` to project top-level keys.",
+      "DEPRECATED: use status { scope: worker }. Returns liveness-qualified worker state and names its replacement.",
     schema: ["live_only", "fields"],
   },
   {
@@ -119,9 +126,9 @@ const SURFACE: ReadonlyArray<{
   },
   {
     name: "monitor",
-    title: "Read AFK monitor",
+    title: "Deprecated worker monitor alias",
     description:
-      "Return the current workers, history events, and monitor inputs.",
+      "DEPRECATED: use status { scope: worker }. Returns worker monitor inputs and names its replacement.",
     schema: [],
   },
   {
@@ -161,9 +168,9 @@ const SURFACE: ReadonlyArray<{
   },
   {
     name: "worker_status",
-    title: "Read worker status",
+    title: "Deprecated worker status alias",
     description:
-      "Return normalized, liveness-qualified state for one worker or every local worker. Defaults to live workers only; pass `live_only: false` to include stopped/dead workers.",
+      "DEPRECATED: use status { scope: worker }. Returns normalized worker state and names its replacement.",
     schema: ["worker", "live_only", "fields"],
   },
   {

--- a/packages/red-castle/src/mcp/contracts.test.ts
+++ b/packages/red-castle/src/mcp/contracts.test.ts
@@ -90,6 +90,7 @@ describe("observability output contracts", () => {
   it("declares a versioned contract on every observability tool", () => {
     const tools = createCastleMcpTools({} as CastleMcpDependencies);
     const contracted = [
+      "status",
       "project_status",
       "worker_vitals",
       "monitor",
@@ -177,6 +178,7 @@ describe("observability output contracts", () => {
   it("validates the observability payloads a live tool call returns", async () => {
     const deps = {
       projectStatus: vi.fn(async () => PROJECT_STATUS),
+      workerStatus: vi.fn(async () => []),
       workerVitals: vi.fn(async () => []),
       monitor: vi.fn(async () => ({ workers: [], events: [], fleet: null })),
       queueStatus: vi.fn(async () => ({
@@ -193,16 +195,22 @@ describe("observability output contracts", () => {
       })),
     } as unknown as CastleMcpDependencies;
     const tools = createCastleMcpTools(deps);
-    const invoke = (name: string) =>
-      tools.find((t) => t.name === name)!.invoke({});
+    const invoke = (name: string, input: Record<string, unknown> = {}) =>
+      tools.find((t) => t.name === name)!.invoke(input);
 
     expect(
-      projectStatusOutputSchema.safeParse(await invoke("project_status")).success,
+      projectStatusOutputSchema.safeParse(
+        await invoke("status", { scope: "project" }),
+      ).success,
     ).toBe(true);
+    const workers = await invoke("status", { scope: "worker" }) as {
+      vitals: unknown;
+      monitor: unknown;
+    };
     expect(
-      workerVitalsOutputSchema.safeParse(await invoke("worker_vitals")).success,
+      workerVitalsOutputSchema.safeParse(workers.vitals).success,
     ).toBe(true);
-    expect(monitorOutputSchema.safeParse(await invoke("monitor")).success).toBe(
+    expect(monitorOutputSchema.safeParse(workers.monitor).success).toBe(
       true,
     );
     expect(

--- a/packages/red-castle/src/mcp/help.ts
+++ b/packages/red-castle/src/mcp/help.ts
@@ -1,7 +1,7 @@
 // help.ts — the castle's one live source of operating choreography (ADR 0134).
 //
 // The answer is deliberately assembled from the same two socket-local reads an
-// operator already has: project_status and host_state. It never asks the issue
+// operator reaches through status {scope: project | host}. It never asks the issue
 // tracker for a fresher queue. The daemon's last registration poll and demand
 // refusal are the live facts, and every next action is rendered through the
 // shared repair composer so the prose cannot name a different mechanism.
@@ -51,16 +51,16 @@ function lastRefusal(hostState: unknown): string | null {
 
 function inspectAgain(why: string): RepairAction {
   return {
-    tool: "project_status",
-    args: {},
+    tool: "status",
+    args: { scope: "project" },
     why,
   };
 }
 
 function daemonRepair(): RepairAction {
   return {
-    tool: "host_provision_check",
-    args: {},
+    tool: "status",
+    args: { scope: "host" },
     why: "diagnose why the host daemon does not answer before changing registration",
   };
 }
@@ -76,8 +76,8 @@ function nextAction(
   }
   if (status.live_workers.length > 0 && refusal === null) {
     return {
-      tool: "worker_vitals",
-      args: {},
+      tool: "status",
+      args: { scope: "worker" },
       why: "observe the Workers already draining this project's queue",
     };
   }
@@ -110,7 +110,9 @@ function location(status: ProjectStatusOutput): string {
 function intentMap(tools: readonly CastleMcpTool[]): readonly HelpIntentGroup[] {
   return [{
     intent: "choose the capability that matches your intent",
-    tools: tools.map(({ name, title }) => ({ name, title })),
+    tools: tools
+      .filter((tool) => !tool.description.startsWith("DEPRECATED:"))
+      .map(({ name, title }) => ({ name, title })),
   }];
 }
 

--- a/packages/red-castle/src/mcp/host.ts
+++ b/packages/red-castle/src/mcp/host.ts
@@ -6,6 +6,7 @@
 // mutating `provision` or `reclaim` commands (ADR 0130, issue #3163).
 
 import type { CastleMcpTool } from "./tool.js";
+import { deprecatedStatusAlias } from "./status.js";
 
 export interface HostDependencies {
   hostState(): Promise<unknown>;
@@ -18,35 +19,51 @@ export function createHostTools(deps: HostDependencies): CastleMcpTool[] {
   return [
     {
       name: "host_state",
-      title: "Read daemon host state",
+      title: "Deprecated host state alias",
       description:
-        "Return every project and Worker the redskilled daemon holds on this machine.",
+        "DEPRECATED: use status { scope: host }. Returns daemon host state and names its replacement.",
       inputSchema: {},
-      invoke: async () => deps.hostState(),
+      invoke: async () =>
+        deprecatedStatusAlias("host_state", "host", await deps.hostState()),
     },
     {
       name: "host_dashboard",
-      title: "Read daemon host dashboard",
+      title: "Deprecated host dashboard alias",
       description:
-        "Return the structured global dashboard for every project's Workers on this machine.",
+        "DEPRECATED: use status { scope: host }. Returns the global dashboard and names its replacement.",
       inputSchema: {},
-      invoke: async () => deps.hostDashboard(),
+      invoke: async () =>
+        deprecatedStatusAlias(
+          "host_dashboard",
+          "host",
+          await deps.hostDashboard(),
+        ),
     },
     {
       name: "host_provision_check",
-      title: "Check daemon host provisioning",
+      title: "Deprecated host provisioning alias",
       description:
-        "Read whether this machine is ready to run redskilled and what is missing; creates and starts nothing.",
+        "DEPRECATED: use status { scope: host }. Returns the provisioning check and names its replacement.",
       inputSchema: {},
-      invoke: async () => deps.hostProvisionCheck(),
+      invoke: async () =>
+        deprecatedStatusAlias(
+          "host_provision_check",
+          "host",
+          await deps.hostProvisionCheck(),
+        ),
     },
     {
       name: "host_unit_status",
-      title: "Read daemon unit status",
+      title: "Deprecated host unit status alias",
       description:
-        "Return whether the optional redskilled supervisor unit is installed, enabled, and active.",
+        "DEPRECATED: use status { scope: host }. Returns the unit status and names its replacement.",
       inputSchema: {},
-      invoke: async () => deps.hostUnitStatus(),
+      invoke: async () =>
+        deprecatedStatusAlias(
+          "host_unit_status",
+          "host",
+          await deps.hostUnitStatus(),
+        ),
     },
   ];
 }

--- a/packages/red-castle/src/mcp/observability.ts
+++ b/packages/red-castle/src/mcp/observability.ts
@@ -1,13 +1,12 @@
 import { z } from "zod/v3";
 import {
-  monitorContract,
   queueStatusContract,
-  workerVitalsContract,
   type MonitorOutput,
   type QueueStatusOutput,
   type WorkerVitalsOutput,
   type WorkerVitalsProjectedOutput,
 } from "./contracts.js";
+import { deprecatedStatusAlias } from "./status.js";
 import type { CastleMcpTool } from "./tool.js";
 import { workSelectorShape, type WorkSelectorInput } from "./project.js";
 
@@ -63,19 +62,22 @@ export function createObservabilityTools(
     },
     {
       name: "worker_vitals",
-      title: "Read worker vitals",
+      title: "Deprecated worker vitals alias",
       description:
-        "Return the liveness-qualified state of local workers. Defaults to live workers only; pass `live_only: false` to include stopped/dead workers. Pass `fields` to project top-level keys.",
+        "DEPRECATED: use status { scope: worker }. Returns liveness-qualified worker state and names its replacement.",
       inputSchema: {
         live_only: z.boolean().default(true),
         fields: z.array(z.string().min(1)).optional(),
       },
-      outputContract: workerVitalsContract,
-      invoke: (input) =>
-        deps.workerVitals({
-          live_only: (input.live_only ?? true) as boolean,
-          fields: input.fields as string[] | undefined,
-        }),
+      invoke: async (input) =>
+        deprecatedStatusAlias(
+          "worker_vitals",
+          "worker",
+          await deps.workerVitals({
+            live_only: (input.live_only ?? true) as boolean,
+            fields: input.fields as string[] | undefined,
+          }),
+        ),
     },
     {
       name: "dashboard",
@@ -90,12 +92,12 @@ export function createObservabilityTools(
     },
     {
       name: "monitor",
-      title: "Read AFK monitor",
+      title: "Deprecated worker monitor alias",
       description:
-        "Return the current workers, history events, and monitor inputs.",
+        "DEPRECATED: use status { scope: worker }. Returns worker monitor inputs and names its replacement.",
       inputSchema: {},
-      outputContract: monitorContract,
-      invoke: () => deps.monitor(),
+      invoke: async () =>
+        deprecatedStatusAlias("monitor", "worker", await deps.monitor()),
     },
     {
       name: "history",

--- a/packages/red-castle/src/mcp/observability.ts
+++ b/packages/red-castle/src/mcp/observability.ts
@@ -1,12 +1,17 @@
 import { z } from "zod/v3";
 import {
+  monitorContract,
   queueStatusContract,
+  workerVitalsContract,
   type MonitorOutput,
   type QueueStatusOutput,
   type WorkerVitalsOutput,
   type WorkerVitalsProjectedOutput,
 } from "./contracts.js";
-import { deprecatedStatusAlias } from "./status.js";
+import {
+  deprecatedStatusAlias,
+  deprecatedStatusAliasContract,
+} from "./status.js";
 import type { CastleMcpTool } from "./tool.js";
 import { workSelectorShape, type WorkSelectorInput } from "./project.js";
 
@@ -69,6 +74,7 @@ export function createObservabilityTools(
         live_only: z.boolean().default(true),
         fields: z.array(z.string().min(1)).optional(),
       },
+      outputContract: deprecatedStatusAliasContract(workerVitalsContract),
       invoke: async (input) =>
         deprecatedStatusAlias(
           "worker_vitals",
@@ -96,6 +102,7 @@ export function createObservabilityTools(
       description:
         "DEPRECATED: use status { scope: worker }. Returns worker monitor inputs and names its replacement.",
       inputSchema: {},
+      outputContract: deprecatedStatusAliasContract(monitorContract),
       invoke: async () =>
         deprecatedStatusAlias("monitor", "worker", await deps.monitor()),
     },

--- a/packages/red-castle/src/mcp/project.ts
+++ b/packages/red-castle/src/mcp/project.ts
@@ -14,8 +14,11 @@
 
 import { z } from "zod/v3";
 import { refuseFleetNaming } from "../engine/extinct-nouns.js";
-import type { ProjectStatusOutput } from "./contracts.js";
-import { deprecatedStatusAlias } from "./status.js";
+import { projectStatusContract, type ProjectStatusOutput } from "./contracts.js";
+import {
+  deprecatedStatusAlias,
+  deprecatedStatusAliasContract,
+} from "./status.js";
 import type { CastleMcpTool } from "./tool.js";
 import { DEFAULT_FLEET_WIDTH } from "@reddb-io/shared/default-fleet-width.js";
 
@@ -101,6 +104,7 @@ export function createProjectTools(deps: ProjectDependencies): CastleMcpTool[] {
       description:
         "DEPRECATED: use status { scope: project }. Returns the project answer and names its replacement.",
       inputSchema: { fleet: removedFleetName },
+      outputContract: deprecatedStatusAliasContract(projectStatusContract),
       invoke: async ({ fleet }) => {
         refuseFleetNaming(fleet);
         return deprecatedStatusAlias(

--- a/packages/red-castle/src/mcp/project.ts
+++ b/packages/red-castle/src/mcp/project.ts
@@ -14,7 +14,8 @@
 
 import { z } from "zod/v3";
 import { refuseFleetNaming } from "../engine/extinct-nouns.js";
-import { projectStatusContract, type ProjectStatusOutput } from "./contracts.js";
+import type { ProjectStatusOutput } from "./contracts.js";
+import { deprecatedStatusAlias } from "./status.js";
 import type { CastleMcpTool } from "./tool.js";
 import { DEFAULT_FLEET_WIDTH } from "@reddb-io/shared/default-fleet-width.js";
 
@@ -96,14 +97,17 @@ export function createProjectTools(deps: ProjectDependencies): CastleMcpTool[] {
   return [
     {
       name: "project_status",
-      title: "Get project worker status",
+      title: "Deprecated project status alias",
       description:
-        "Return this project's host registration, slots, and live-worker status.",
+        "DEPRECATED: use status { scope: project }. Returns the project answer and names its replacement.",
       inputSchema: { fleet: removedFleetName },
-      outputContract: projectStatusContract,
       invoke: async ({ fleet }) => {
         refuseFleetNaming(fleet);
-        return deps.projectStatus();
+        return deprecatedStatusAlias(
+          "project_status",
+          "project",
+          await deps.projectStatus(),
+        );
       },
     },
     {

--- a/packages/red-castle/src/mcp/status.ts
+++ b/packages/red-castle/src/mcp/status.ts
@@ -2,6 +2,14 @@ import { z } from "zod/v3";
 import type { HostDependencies } from "./host.js";
 import type { ObservabilityDependencies } from "./observability.js";
 import type { ProjectDependencies } from "./project.js";
+import {
+  CASTLE_MCP_CONTRACT_VERSION,
+  monitorOutputSchema,
+  projectStatusOutputSchema,
+  workerVitalsOutputSchema,
+  workerVitalsProjectedOutputSchema,
+  type CastleMcpOutputContract,
+} from "./contracts.js";
 import type { CastleMcpTool } from "./tool.js";
 import type { WorkerDependencies } from "./worker.js";
 
@@ -30,6 +38,74 @@ export interface DeprecatedStatusAliasOutput {
   };
   result: unknown;
 }
+
+const replacementSchema = z.object({
+  tool: z.literal("status"),
+  args: z.object({ scope: z.enum(["worker", "project", "host"]) }),
+});
+
+function aliasSchema(result: z.ZodTypeAny): z.ZodTypeAny {
+  return z.object({
+    deprecated: z.literal(true),
+    message: z.string().min(1),
+    replacement: replacementSchema,
+    result,
+  });
+}
+
+/** Preserve each absorbed tool's output validation around its alias envelope. */
+export function deprecatedStatusAliasContract(
+  source: CastleMcpOutputContract,
+): CastleMcpOutputContract {
+  return {
+    version: source.version,
+    schema: aliasSchema(source.schema),
+    ...(source.projection === undefined
+      ? {}
+      : {
+          projection: {
+            input: source.projection.input,
+            schema: aliasSchema(source.projection.schema),
+          },
+        }),
+  };
+}
+
+const workerStatusOutputSchema = z.object({
+  status: z.unknown(),
+  vitals: workerVitalsOutputSchema,
+  monitor: monitorOutputSchema,
+});
+
+const projectedWorkerStatusOutputSchema = z.object({
+  status: z.unknown(),
+  vitals: workerVitalsProjectedOutputSchema,
+  monitor: monitorOutputSchema,
+});
+
+const hostStatusOutputSchema = z.object({
+  state: z.unknown(),
+  dashboard: z.unknown(),
+  provision_check: z.unknown(),
+  unit_status: z.unknown(),
+});
+
+export const statusContract: CastleMcpOutputContract = {
+  version: CASTLE_MCP_CONTRACT_VERSION,
+  schema: z.union([
+    projectStatusOutputSchema,
+    workerStatusOutputSchema,
+    hostStatusOutputSchema,
+  ]),
+  projection: {
+    input: "fields",
+    schema: z.union([
+      projectStatusOutputSchema,
+      projectedWorkerStatusOutputSchema,
+      hostStatusOutputSchema,
+    ]),
+  },
+};
 
 /** Keep an absorbed verb useful during its one-release alias window. */
 export function deprecatedStatusAlias(
@@ -87,6 +163,7 @@ export function createStatusTools(deps: StatusDependencies): CastleMcpTool[] {
         live_only: z.boolean().default(true),
         fields: z.array(z.string().min(1)).optional(),
       },
+      outputContract: statusContract,
       invoke: (input) => readStatus(deps, input as unknown as StatusInput),
     },
   ];

--- a/packages/red-castle/src/mcp/status.ts
+++ b/packages/red-castle/src/mcp/status.ts
@@ -1,0 +1,93 @@
+import { z } from "zod/v3";
+import type { HostDependencies } from "./host.js";
+import type { ObservabilityDependencies } from "./observability.js";
+import type { ProjectDependencies } from "./project.js";
+import type { CastleMcpTool } from "./tool.js";
+import type { WorkerDependencies } from "./worker.js";
+
+export type StatusScope = "worker" | "project" | "host";
+
+export interface StatusInput {
+  scope: StatusScope;
+  worker?: string;
+  live_only?: boolean;
+  fields?: string[];
+}
+
+export interface StatusDependencies
+  extends
+    Pick<ProjectDependencies, "projectStatus">,
+    HostDependencies,
+    Pick<ObservabilityDependencies, "workerVitals" | "monitor">,
+    Pick<WorkerDependencies, "workerStatus"> {}
+
+export interface DeprecatedStatusAliasOutput {
+  deprecated: true;
+  message: string;
+  replacement: {
+    tool: "status";
+    args: { scope: StatusScope };
+  };
+  result: unknown;
+}
+
+/** Keep an absorbed verb useful during its one-release alias window. */
+export function deprecatedStatusAlias(
+  alias: string,
+  scope: StatusScope,
+  result: unknown,
+): DeprecatedStatusAliasOutput {
+  return {
+    deprecated: true,
+    message: `${alias} is deprecated; use status { scope: ${scope} }`,
+    replacement: { tool: "status", args: { scope } },
+    result,
+  };
+}
+
+async function readStatus(deps: StatusDependencies, input: StatusInput): Promise<unknown> {
+  if (input.scope === "project") return deps.projectStatus();
+
+  if (input.scope === "host") {
+    const [state, dashboard, provision_check, unit_status] = await Promise.all([
+      deps.hostState(),
+      deps.hostDashboard(),
+      deps.hostProvisionCheck(),
+      deps.hostUnitStatus(),
+    ]);
+    return { state, dashboard, provision_check, unit_status };
+  }
+
+  const workerInput = {
+    worker: input.worker,
+    live_only: input.live_only ?? true,
+    fields: input.fields,
+  };
+  const [status, vitals, monitor] = await Promise.all([
+    deps.workerStatus(workerInput),
+    deps.workerVitals({
+      live_only: workerInput.live_only,
+      fields: workerInput.fields,
+    }),
+    deps.monitor(),
+  ]);
+  return { status, vitals, monitor };
+}
+
+export function createStatusTools(deps: StatusDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "status",
+      title: "Read Castle status",
+      description:
+        "Answer the current worker, project, or host status through one intent-scoped read.",
+      inputSchema: {
+        scope: z.enum(["worker", "project", "host"]),
+        worker: z.string().min(1).optional(),
+        live_only: z.boolean().default(true),
+        fields: z.array(z.string().min(1)).optional(),
+      },
+      invoke: (input) => readStatus(deps, input as unknown as StatusInput),
+    },
+  ];
+}

--- a/packages/red-castle/src/mcp/status.ts
+++ b/packages/red-castle/src/mcp/status.ts
@@ -121,7 +121,10 @@ export function deprecatedStatusAlias(
   };
 }
 
-async function readStatus(deps: StatusDependencies, input: StatusInput): Promise<unknown> {
+async function readStatus(
+  deps: StatusDependencies,
+  input: StatusInput,
+): Promise<unknown> {
   if (input.scope === "project") return deps.projectStatus();
 
   if (input.scope === "host") {

--- a/packages/red-castle/src/mcp/worker.ts
+++ b/packages/red-castle/src/mcp/worker.ts
@@ -5,6 +5,7 @@ import {
   noRepair,
   type RepairAction,
 } from "@reddb-io/shared/repair.js";
+import { deprecatedStatusAlias } from "./status.js";
 
 export interface WorkerDispatchInput {
   issue?: number;
@@ -95,20 +96,24 @@ export function createWorkerTools(deps: WorkerDependencies): CastleMcpTool[] {
     },
     {
       name: "worker_status",
-      title: "Read worker status",
+      title: "Deprecated worker status alias",
       description:
-        "Return normalized, liveness-qualified state for one worker or every local worker. Defaults to live workers only; pass `live_only: false` to include stopped/dead workers.",
+        "DEPRECATED: use status { scope: worker }. Returns normalized worker state and names its replacement.",
       inputSchema: {
         worker: z.string().min(1).optional(),
         live_only: z.boolean().default(true),
         fields: z.array(z.string().min(1)).optional(),
       },
-      invoke: ({ worker, live_only, fields }) =>
-        deps.workerStatus({
-          worker: worker as string | undefined,
-          live_only: (live_only ?? true) as boolean,
-          fields: fields as string[] | undefined,
-        }),
+      invoke: async ({ worker, live_only, fields }) =>
+        deprecatedStatusAlias(
+          "worker_status",
+          "worker",
+          await deps.workerStatus({
+            worker: worker as string | undefined,
+            live_only: (live_only ?? true) as boolean,
+            fields: fields as string[] | undefined,
+          }),
+        ),
     },
     {
       name: "worker_stop",

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -12,7 +12,7 @@ The server is registered as `castle` in `plugins/dev/.mcp.json`, so a host that
 loaded the `dev` plugin already has it. **Hosts prefix MCP tool names — call the
 tool your host actually exposes, not the bare name.** Claude Code and Codex
 surface plugin MCP tools as `mcp__<server-slug>__<tool>` (for example
-`mcp__plugin_dev_castle__project_status` under Claude Code); the slug is derived
+`mcp__plugin_dev_castle__status` under Claude Code); the slug is derived
 from the server name, so it never contains a colon — codex rejects `:` in server
 names. Resolve the exact identifier with a tool search for the bare name in the
 table below before the first call, then reuse it for the rest of the session.
@@ -62,6 +62,12 @@ When the next castle call is unclear, call `help` and follow its structured
 `next` action. It is the sole runtime source of operating choreography; this
 document defines the protocol without copying its state-dependent routes.
 
+### Status — one scoped read intent
+
+| Tool | Mode | What it does |
+| --- | --- | --- |
+| `status` | read | With `scope: worker`, return normalized worker state, vitals, and monitor inputs; with `scope: project`, return registration, slots, latch, and live workers; with `scope: host`, return daemon state, the global dashboard, provisioning check, and unit status. Worker scope also accepts `worker`, `live_only`, and `fields`. |
+
 ### Fleet — named multi-fleet lifecycle
 
 **A project has exactly one producer.** The named fleet is gone (ADR 0130): the
@@ -73,26 +79,19 @@ remain available for specialized lifecycle operations during consolidation.
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `project_status` | read | Supervisor pid, slots, churn, and live workers for this project. |
 | `drain` | mutating | Ensure the daemon is reachable and this project is registered at the requested runner and target. Repeated calls succeed with a four-dimension difference report; a runner change is refused with the explicit stop-then-drain repair. |
 | `project_start` | mutating | Register this project with the host daemon — a runner, a target width, and its work policy. It registers; it launches no process of the project's own. |
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |
-| `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `project_status.birth_latch.repair`; the structured repair supplies the exact args. |
+| `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `status {scope: project}` at `birth_latch.repair`; the structured repair supplies the exact args. |
 | `project_stop` | mutating | Give this project's registration back and stop what it still holds; pass `force: true` to hard-stop only its attributed workers. |
 
 ### Host daemon diagnostics
 
-These reads describe the machine-wide `redskilled` daemon, not only the current
-project. They expose the daemon commands that already own these answers. No
-host-scoped mutation is available here: provisioning and reclaim remain operator
-commands, while the provisioning tool is the read-only `--check` half.
-
-| Tool | Mode | What it does |
-| --- | --- | --- |
-| `host_state` | read | Return every project and Worker the daemon holds on this machine. |
-| `host_dashboard` | read | Return the structured global dashboard across every project. |
-| `host_provision_check` | read | Audit whether the machine is ready and name missing prerequisites; creates and starts nothing. |
-| `host_unit_status` | read | Report whether the optional daemon supervisor unit is installed, enabled, and active. |
+`status {scope: host}` describes the machine-wide `redskilled` daemon, not only
+the current project. Its one answer contains every project and Worker, the
+global dashboard, the provisioning audit, and optional supervisor-unit state.
+No host-scoped mutation is available here: provisioning and reclaim remain
+operator commands.
 
 `selector` scopes what the producer drains — `{spec, lane, label, issues, tags,
 user}`. Graceful stop leaves in-flight detached workers to finish; force never
@@ -106,7 +105,7 @@ interface drained zero issues while the CLI lane kept working and no surface
 reported the difference (#2677). Run
 `castle-mcp __mcp-canary --root <scratch-repo>` to walk the shipped lane end to
 end — `project_start` → a registration the daemon holds → no process of the
-project's own → `project_status` → `project_stop`. It exits non-zero naming the
+project's own → `status {scope: project}` → `project_stop`. It exits non-zero naming the
 step that went inert.
 
 **The load-bearing assertion inverted with the lane.** The canary once refused
@@ -137,7 +136,6 @@ holds both halves of that in place.
 | Tool | Mode | What it does |
 | --- | --- | --- |
 | `worker_dispatch` | mutating | Run one tracked issue, or mint and run one disposable demand. |
-| `worker_status` | read | Liveness-qualified state for one worker or all of them. |
 | `worker_stop` | mutating | Terminate one worker process tree. |
 | `worker_recycle` | mutating | Terminate one fleet worker so its supervisor refills the slot. |
 | `worker_request` | mutating | Dispatch a worker with a special request injected at spawn time. |
@@ -231,9 +229,7 @@ state survives resident restarts in `.red/state/castle/merge-driver.toon`.
 | Tool | Mode | What it does |
 | --- | --- | --- |
 | `logs` | read | Raw `CastleLaneRecord` entries from one lane (`worker`/`supervisor`/`monitor`/`liveness`). |
-| `worker_vitals` | read | Liveness-qualified state of every local worker (includes `model` and `effort` per worker). |
 | `dashboard` | read | The operational dashboard over a `periodDays` window. |
-| `monitor` | read | Current workers, history events, and fleet monitor inputs. |
 | `history` | read | Structured castle history records, newest last. |
 | `statusline_aggregate` | read | Castle-side statusline aggregate (project, repo counters, docs drift, fleet, worker rows, aggregated AFK block, queue) — the same data the command-backed `statusLine` renders, as structured data with the same 180s cache discipline. Host-side fields (session model/effort, context %, usage quotas) are out of scope. |
 
@@ -257,7 +253,7 @@ pattern and the cure to apply, without mutating anything. The resident cron
 refreshes it and `/red-doctor` renders the same report.
 
 `events_since` is the incremental read surface: use it instead of re-calling
-`queue_status`, `worker_status`, or `project_status` on every polling tick. **Cost
+`queue_status` or `status` on every polling tick. **Cost
 guidance:** omit `cursor` on the first call to get a baseline cursor with no
 events; store that cursor; pass it on every subsequent tick to receive only
 what changed. The resident caches `queue_status`, `claim_status`, and
@@ -265,7 +261,7 @@ what changed. The resident caches `queue_status`, `claim_status`, and
 `events_since` for longer-running monitors where you need sub-second awareness
 of history completions and worker phase changes without polling GitHub directly.
 Unknown or expired cursors (> 7 days old) are refused with a terse `refused:
-true` response; re-baseline by calling `queue_status` and `worker_status` to
+true` response; re-baseline by calling `queue_status` and `status {scope: worker}` to
 rebuild state, then call `events_since` with no cursor to get a fresh handle.
 
 ### Wait — programmatic outcome polling

--- a/packaging/pi/dev/skills/engineering/afk/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/afk/SKILL.md
@@ -26,8 +26,8 @@ The usual shape of a drain:
 1. `queue_status` — what is drainable now, before anything is claimed.
 2. `runner_detect` — confirm the runner this host resolves to.
 3. `worker_dispatch` (one issue) or `project_start` (this project's workers) to start work.
-4. `monitor`, `worker_vitals`, `project_status` — read progress; never poll a
-   mutating tool for status.
+4. `status {scope: worker | project | host}` — read progress at the needed
+   boundary; never poll a mutating tool for status.
 5. `gate_run` → `land_branch` when a worker branch needs validation and landing
    outside the normal in-worker path.
 
@@ -99,7 +99,7 @@ CLI fallback for the same operation.
   unlimited queue drain.
 - `/afk --once` - single supervised iteration for debugging the prompt.
 - `/afk --boot-only` - run boot sweeps and prechecks without claiming work.
-- `/afk monitor` - read-only status board over `monitor`, `worker_vitals`, and
+- `/afk monitor` - read-only status board over `status {scope: worker}` and
   `queue_status`; read [`monitor.md`](./monitor.md) for the dashboard and
   native-task mirror contract.
 - `/afk dashboard [--period 30d] [--json]` - process dashboard for open work,
@@ -114,7 +114,7 @@ CLI fallback for the same operation.
 - `/afk fleet stop [--force]` - `project_stop`: gracefully stop this project's
   supervisor while in-flight workers drain; `--force` hard-stops only workers
   attributed to its lane.
-- `/afk fleet status` - `project_status`: read-only ground truth — supervisor pid, health verdict,
+- `/afk fleet status` - `status {scope: project}`: read-only ground truth — supervisor pid, health verdict,
   runner, slot occupancy, bundle version/skew, churn, live workers, and whether
   a watchdog respawn would fire. Answers "what is actually running?" without
   cross-referencing pid files and snapshots by hand.

--- a/packaging/pi/dev/skills/engineering/afk/fleet.md
+++ b/packaging/pi/dev/skills/engineering/afk/fleet.md
@@ -17,8 +17,8 @@ and mutation modes.
 | --- | --- | --- |
 | launch | `project_start` | `{runner, target, selector?, config?, base?}` — hands the work policy to the host daemon as a registration; the project spawns nothing. |
 | resize / switch | `project_resize` | Same fields, all optional; restates the launch on the registration's renewal (Amendment 5). |
-| ground truth | `project_status` | The registration the host holds, its renewal and last poll, plus slots and live workers. |
-| reset birth latch | `project_reset` | Invoke the structured repair returned in `project_status.birth_latch`; clears only this project's birth breaker. |
+| ground truth | `status {scope: project}` | The registration the host holds, its renewal and last poll, plus slots and live workers. |
+| reset birth latch | `project_reset` | Invoke the structured repair returned in `status {scope: project}` at `birth_latch`; clears only this project's birth breaker. |
 | shutdown | `project_stop` | Asks the host to end this project's Workers, then gives the registration back. |
 | logs | `logs` | One structured lane per call (`supervisor` / `worker` / `monitor` / `liveness`). |
 
@@ -47,7 +47,7 @@ $ /dev:afk fleet 1   # every worker sees both vars
 
 Fleet mode is **runner-portable**: registering a project is plain host bookkeeping, not a Claude Code primitive. Claude Code, Codex, and bare terminals may all start and stop a project's workers when the normal AFK hard preconditions pass. Runner-specific observability degrades independently:
 
-- Claude Code: register the project. For manual monitoring, read the castle `monitor` and `project_status` tools; without the MCP, run `/dev:afk monitor`.
+- Claude Code: register the project. For manual monitoring, read `status {scope: worker}` and `status {scope: project}`; without the MCP, run `/dev:afk monitor`.
 - Codex: register with `RED_AFK_RUNNER=codex` and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, register anyway and print the monitor status line below.
 - Bare terminal / unknown runner: register and print the manual-monitor guidance.
 
@@ -66,7 +66,7 @@ against, resolved from the PUBLISHED version rather than from the registering
 process's own. After any RedSkills release that changes AFK or
 castle engine behavior, stop and re-register the project before starting or
 counting a proving drain; otherwise the drain may still be executing on the
-pre-release engine. `monitor` and the statusline fleet cell show the running
+pre-release engine. `status {scope: worker}` and the statusline fleet cell show the running
 bundle version and mark skew against a newer locally cached bundle so a stale
 project is visible. Automatic drain-and-respawn on version change is a future enhancement,
 not part of the current fleet contract.
@@ -95,20 +95,20 @@ over, or read a pid file for. The steps below are the whole flow.
    A `target` change does not travel on a renewal and is reported as unapplied
    rather than silently dropped.
 4. **Attach the best available monitor surface.**
-   - Claude Code: no automatic monitor cron. Tell the user to read the castle
-     `monitor` tool (with `worker_vitals` for liveness), or — without the MCP —
+   - Claude Code: no automatic monitor cron. Tell the user to read
+     `status {scope: worker}`, or — without the MCP —
      to run `/dev:afk monitor` manually.
    - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query:
      `spawn agent background monitor`). If available, spawn exactly one read-only
      Codex monitor agent with `RED_AFK_RUNNER=codex red-skills-dev
      codex-monitor-agent --project-root "$PWD" --mode fleet`. Its task:
-     periodically read the castle `monitor` tool, report concise progress, and
+     periodically read `status {scope: worker}`, report concise progress, and
      auto-close when this project holds no registration and no `[live]` workers
      remain. It must never edit files, claim issues, stop workers, or run merges.
    - Bare/unknown: skip native monitor setup and use the manual-monitor line.
 5. **Report back.** Print the registration the daemon handed back — its project
    label, target, selector and renewal deadline — then the monitor line:
-   `monitor: call the castle monitor tool (and worker_vitals for liveness);
+   `monitor: call status {scope: worker};
    no-MCP fallback: run /dev:afk monitor.`
 
 ### Stopping — give the registration back
@@ -163,6 +163,6 @@ The safe fleet width for a given queue is the **degree of disjunction** — the 
 
 ### Refs
 
-- [`MCP.md`](./MCP.md) — the `castle` tool surface; `project_start`, `project_resize`, `project_status`, `project_reset`, `project_stop`, and `logs` are the primary interface.
+- [`MCP.md`](./MCP.md) — the `castle` tool surface; `status`, `project_start`, `project_resize`, `project_reset`, `project_stop`, and `logs` are the primary interface.
 - ADR 0130 Amendment 4 — why a project contributes a registration and holds no process of its own, and why the `fleet` launcher, the `__supervise` entrypoint and the self-heal watchdog were deleted rather than renamed.
 - [`monitor.md`](./monitor.md) — the readonly dashboard and native-task mirror.

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -125,10 +125,9 @@ The LLM Wiki routes ship with the `memory` plugin as `/memory:wiki-init` and
 
 Capability references registered by owner:
 `castle` MCP (the canonical project interface; start with its situational
-`help` tool, while `host_state`, `host_dashboard`, `host_provision_check`, and
-`host_unit_status` provide read-only host diagnostics, and a visible
-`project_status.birth_latch` routes through its structured `project_reset`
-repair) ->
+`help` tool, while `status {scope: worker | project | host}` provides scoped
+read-only diagnostics, and a visible project `birth_latch` routes through its
+structured `project_reset` repair) ->
 `plugins/dev/skills/engineering/afk/MCP.md`;
 `/afk` landing-tail throughput (`afk.landing.wait`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
@@ -188,8 +187,8 @@ through `/memory:view`, `memory docs reference-graph`, and
   package-manifest harness discovery and confirmation of the proposed
   `plugins.dev.afk.validation` schedule.
 - Execution-daemon operation is a host route, not a feature-work one:
-  diagnose through the castle MCP's read-only `host_provision_check` and other
-  `host_*` tools first; no castle tool provisions or reclaims the host.
+  diagnose through the castle MCP's read-only `status {scope: host}` first; no
+  castle tool provisions or reclaims the host.
   `/redskilled` owns provisioning, host policy, status, and lifecycle;
   `/red-doctor` (check 24) reports whether the host is provisioned. The daemon's
   home `~/.red/redskilled/` and host policy file `~/.red/config.yaml` belong to

--- a/packaging/pi/dev/skills/engineering/go/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/go/SKILL.md
@@ -37,7 +37,7 @@ Scout mode is read-only and report-producing, so this Task+DoD gate does not app
 the demand with the `worker_dispatch` tool — `{demand, runner?, mode?}`, where
 `mode` is exactly the `--mode` selector below. Pass a per-dispatch inner-agent
 instruction with `worker_request` instead, and reach a run already in flight
-with `runner_steer`. Watch it with `worker_status` and `monitor`; a `/go` worker
+with `runner_steer`. Watch it with `status {scope: worker}`; a `/go` worker
 is stamped `origin=go` / `current.kind=go`, so it is distinguishable from fleet
 workers in every observability tool. The complete surface, host tool-name
 prefixing, and the mutation-mode contract are in
@@ -88,7 +88,7 @@ Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex`
 
 **Dispatch survives the dispatcher.** Every `/go` — standard and `--scout` — is an ORDER, never the work: the host daemon owns the worker process, so a UI stop, a session teardown, or a closed terminal kills the launcher and leaves the run alive. The command returns as soon as the host grants the worker and answers with the two handles that outlive it — the worker id and its log lane:
 
-**Dispatch also skips the autonomous line.** Standard `/go` and `--scout` claim the host's bounded interactive reservation, so a saturated `/afk` target does not make a human-attached demand wait for an AFK Worker to finish. Nothing already running is stopped or resized: the daemon may admit the interactive Worker above the ordinary Worker ceiling, up to `REDSKILLED_INTERACTIVE_RESERVATION` extra Workers (default `1`). Host dashboard, project status, and monitor slot surfaces state that reservation beside their ordinary target, so `target+1` is policy rather than unexplained occupancy.
+**Dispatch also skips the autonomous line.** Standard `/go` and `--scout` claim the host's bounded interactive reservation, so a saturated `/afk` target does not make a human-attached demand wait for an AFK Worker to finish. Nothing already running is stopped or resized: the daemon may admit the interactive Worker above the ordinary Worker ceiling, up to `REDSKILLED_INTERACTIVE_RESERVATION` extra Workers (default `1`). The scoped host, project, and worker status answers state that reservation beside their ordinary target, so `target+1` is policy rather than unexplained occupancy.
 
 ```
 🔍 /go --scout dispatched disposable issue #4210 (origin=scout, kind=scout, lane:scout).
@@ -96,7 +96,7 @@ Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex`
    watch: .red/tmp/logs/2026-08-01/dispatch-2026-08-01T20-14-02-114Z-1f0c9d2e.log
 ```
 
-Follow it from those handles, never from the launcher's stdout: `worker_status`, the statusline, or the log path above. A dispatch the host refuses starts nothing and says so — it never falls back to running the engine here.
+Follow it from those handles, never from the launcher's stdout: `status {scope: worker}`, the statusline, or the log path above. A dispatch the host refuses starts nothing and says so — it never falls back to running the engine here.
 
 **Dispatch refuses a superseded engine.** Before anything is minted or born, the engine the dispatch would actually run is compared against the published dist-tag. Under the default `warn` policy a superseded engine dispatches loudly, naming both versions and the span of fixes it forfeits; set `plugins.dev.dispatch.engine_floor: refuse` to make it a hard stop that mints nothing, or `off` to silence it. A registry the host cannot reach always degrades to a warning and proceeds — offline dispatch must not die — and a source checkout or prerelease is never floored. `RED_DEV_ENGINE_FLOOR=warn|refuse|off` overrides the file for one run.
 

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -12,7 +12,7 @@ The server is registered as `castle` in `plugins/dev/.mcp.json`, so a host that
 loaded the `dev` plugin already has it. **Hosts prefix MCP tool names — call the
 tool your host actually exposes, not the bare name.** Claude Code and Codex
 surface plugin MCP tools as `mcp__<server-slug>__<tool>` (for example
-`mcp__plugin_dev_castle__project_status` under Claude Code); the slug is derived
+`mcp__plugin_dev_castle__status` under Claude Code); the slug is derived
 from the server name, so it never contains a colon — codex rejects `:` in server
 names. Resolve the exact identifier with a tool search for the bare name in the
 table below before the first call, then reuse it for the rest of the session.
@@ -62,6 +62,12 @@ When the next castle call is unclear, call `help` and follow its structured
 `next` action. It is the sole runtime source of operating choreography; this
 document defines the protocol without copying its state-dependent routes.
 
+### Status — one scoped read intent
+
+| Tool | Mode | What it does |
+| --- | --- | --- |
+| `status` | read | With `scope: worker`, return normalized worker state, vitals, and monitor inputs; with `scope: project`, return registration, slots, latch, and live workers; with `scope: host`, return daemon state, the global dashboard, provisioning check, and unit status. Worker scope also accepts `worker`, `live_only`, and `fields`. |
+
 ### Fleet — named multi-fleet lifecycle
 
 **A project has exactly one producer.** The named fleet is gone (ADR 0130): the
@@ -73,26 +79,19 @@ remain available for specialized lifecycle operations during consolidation.
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `project_status` | read | Supervisor pid, slots, churn, and live workers for this project. |
 | `drain` | mutating | Ensure the daemon is reachable and this project is registered at the requested runner and target. Repeated calls succeed with a four-dimension difference report; a runner change is refused with the explicit stop-then-drain repair. |
 | `project_start` | mutating | Register this project with the host daemon — a runner, a target width, and its work policy. It registers; it launches no process of the project's own. |
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |
-| `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `project_status.birth_latch.repair`; the structured repair supplies the exact args. |
+| `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `status {scope: project}` at `birth_latch.repair`; the structured repair supplies the exact args. |
 | `project_stop` | mutating | Give this project's registration back and stop what it still holds; pass `force: true` to hard-stop only its attributed workers. |
 
 ### Host daemon diagnostics
 
-These reads describe the machine-wide `redskilled` daemon, not only the current
-project. They expose the daemon commands that already own these answers. No
-host-scoped mutation is available here: provisioning and reclaim remain operator
-commands, while the provisioning tool is the read-only `--check` half.
-
-| Tool | Mode | What it does |
-| --- | --- | --- |
-| `host_state` | read | Return every project and Worker the daemon holds on this machine. |
-| `host_dashboard` | read | Return the structured global dashboard across every project. |
-| `host_provision_check` | read | Audit whether the machine is ready and name missing prerequisites; creates and starts nothing. |
-| `host_unit_status` | read | Report whether the optional daemon supervisor unit is installed, enabled, and active. |
+`status {scope: host}` describes the machine-wide `redskilled` daemon, not only
+the current project. Its one answer contains every project and Worker, the
+global dashboard, the provisioning audit, and optional supervisor-unit state.
+No host-scoped mutation is available here: provisioning and reclaim remain
+operator commands.
 
 `selector` scopes what the producer drains — `{spec, lane, label, issues, tags,
 user}`. Graceful stop leaves in-flight detached workers to finish; force never
@@ -106,7 +105,7 @@ interface drained zero issues while the CLI lane kept working and no surface
 reported the difference (#2677). Run
 `castle-mcp __mcp-canary --root <scratch-repo>` to walk the shipped lane end to
 end — `project_start` → a registration the daemon holds → no process of the
-project's own → `project_status` → `project_stop`. It exits non-zero naming the
+project's own → `status {scope: project}` → `project_stop`. It exits non-zero naming the
 step that went inert.
 
 **The load-bearing assertion inverted with the lane.** The canary once refused
@@ -137,7 +136,6 @@ holds both halves of that in place.
 | Tool | Mode | What it does |
 | --- | --- | --- |
 | `worker_dispatch` | mutating | Run one tracked issue, or mint and run one disposable demand. |
-| `worker_status` | read | Liveness-qualified state for one worker or all of them. |
 | `worker_stop` | mutating | Terminate one worker process tree. |
 | `worker_recycle` | mutating | Terminate one fleet worker so its supervisor refills the slot. |
 | `worker_request` | mutating | Dispatch a worker with a special request injected at spawn time. |
@@ -231,9 +229,7 @@ state survives resident restarts in `.red/state/castle/merge-driver.toon`.
 | Tool | Mode | What it does |
 | --- | --- | --- |
 | `logs` | read | Raw `CastleLaneRecord` entries from one lane (`worker`/`supervisor`/`monitor`/`liveness`). |
-| `worker_vitals` | read | Liveness-qualified state of every local worker (includes `model` and `effort` per worker). |
 | `dashboard` | read | The operational dashboard over a `periodDays` window. |
-| `monitor` | read | Current workers, history events, and fleet monitor inputs. |
 | `history` | read | Structured castle history records, newest last. |
 | `statusline_aggregate` | read | Castle-side statusline aggregate (project, repo counters, docs drift, fleet, worker rows, aggregated AFK block, queue) — the same data the command-backed `statusLine` renders, as structured data with the same 180s cache discipline. Host-side fields (session model/effort, context %, usage quotas) are out of scope. |
 
@@ -257,7 +253,7 @@ pattern and the cure to apply, without mutating anything. The resident cron
 refreshes it and `/red-doctor` renders the same report.
 
 `events_since` is the incremental read surface: use it instead of re-calling
-`queue_status`, `worker_status`, or `project_status` on every polling tick. **Cost
+`queue_status` or `status` on every polling tick. **Cost
 guidance:** omit `cursor` on the first call to get a baseline cursor with no
 events; store that cursor; pass it on every subsequent tick to receive only
 what changed. The resident caches `queue_status`, `claim_status`, and
@@ -265,7 +261,7 @@ what changed. The resident caches `queue_status`, `claim_status`, and
 `events_since` for longer-running monitors where you need sub-second awareness
 of history completions and worker phase changes without polling GitHub directly.
 Unknown or expired cursors (> 7 days old) are refused with a terse `refused:
-true` response; re-baseline by calling `queue_status` and `worker_status` to
+true` response; re-baseline by calling `queue_status` and `status {scope: worker}` to
 rebuild state, then call `events_since` with no cursor to get a fresh handle.
 
 ### Wait — programmatic outcome polling

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -26,8 +26,8 @@ The usual shape of a drain:
 1. `queue_status` — what is drainable now, before anything is claimed.
 2. `runner_detect` — confirm the runner this host resolves to.
 3. `worker_dispatch` (one issue) or `project_start` (this project's workers) to start work.
-4. `monitor`, `worker_vitals`, `project_status` — read progress; never poll a
-   mutating tool for status.
+4. `status {scope: worker | project | host}` — read progress at the needed
+   boundary; never poll a mutating tool for status.
 5. `gate_run` → `land_branch` when a worker branch needs validation and landing
    outside the normal in-worker path.
 
@@ -99,7 +99,7 @@ CLI fallback for the same operation.
   unlimited queue drain.
 - `/afk --once` - single supervised iteration for debugging the prompt.
 - `/afk --boot-only` - run boot sweeps and prechecks without claiming work.
-- `/afk monitor` - read-only status board over `monitor`, `worker_vitals`, and
+- `/afk monitor` - read-only status board over `status {scope: worker}` and
   `queue_status`; read [`monitor.md`](./monitor.md) for the dashboard and
   native-task mirror contract.
 - `/afk dashboard [--period 30d] [--json]` - process dashboard for open work,
@@ -114,7 +114,7 @@ CLI fallback for the same operation.
 - `/afk fleet stop [--force]` - `project_stop`: gracefully stop this project's
   supervisor while in-flight workers drain; `--force` hard-stops only workers
   attributed to its lane.
-- `/afk fleet status` - `project_status`: read-only ground truth — supervisor pid, health verdict,
+- `/afk fleet status` - `status {scope: project}`: read-only ground truth — supervisor pid, health verdict,
   runner, slot occupancy, bundle version/skew, churn, live workers, and whether
   a watchdog respawn would fire. Answers "what is actually running?" without
   cross-referencing pid files and snapshots by hand.

--- a/plugins/dev/skills/engineering/afk/fleet.md
+++ b/plugins/dev/skills/engineering/afk/fleet.md
@@ -17,8 +17,8 @@ and mutation modes.
 | --- | --- | --- |
 | launch | `project_start` | `{runner, target, selector?, config?, base?}` — hands the work policy to the host daemon as a registration; the project spawns nothing. |
 | resize / switch | `project_resize` | Same fields, all optional; restates the launch on the registration's renewal (Amendment 5). |
-| ground truth | `project_status` | The registration the host holds, its renewal and last poll, plus slots and live workers. |
-| reset birth latch | `project_reset` | Invoke the structured repair returned in `project_status.birth_latch`; clears only this project's birth breaker. |
+| ground truth | `status {scope: project}` | The registration the host holds, its renewal and last poll, plus slots and live workers. |
+| reset birth latch | `project_reset` | Invoke the structured repair returned in `status {scope: project}` at `birth_latch`; clears only this project's birth breaker. |
 | shutdown | `project_stop` | Asks the host to end this project's Workers, then gives the registration back. |
 | logs | `logs` | One structured lane per call (`supervisor` / `worker` / `monitor` / `liveness`). |
 
@@ -47,7 +47,7 @@ $ /dev:afk fleet 1   # every worker sees both vars
 
 Fleet mode is **runner-portable**: registering a project is plain host bookkeeping, not a Claude Code primitive. Claude Code, Codex, and bare terminals may all start and stop a project's workers when the normal AFK hard preconditions pass. Runner-specific observability degrades independently:
 
-- Claude Code: register the project. For manual monitoring, read the castle `monitor` and `project_status` tools; without the MCP, run `/dev:afk monitor`.
+- Claude Code: register the project. For manual monitoring, read `status {scope: worker}` and `status {scope: project}`; without the MCP, run `/dev:afk monitor`.
 - Codex: register with `RED_AFK_RUNNER=codex` and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, register anyway and print the monitor status line below.
 - Bare terminal / unknown runner: register and print the manual-monitor guidance.
 
@@ -66,7 +66,7 @@ against, resolved from the PUBLISHED version rather than from the registering
 process's own. After any RedSkills release that changes AFK or
 castle engine behavior, stop and re-register the project before starting or
 counting a proving drain; otherwise the drain may still be executing on the
-pre-release engine. `monitor` and the statusline fleet cell show the running
+pre-release engine. `status {scope: worker}` and the statusline fleet cell show the running
 bundle version and mark skew against a newer locally cached bundle so a stale
 project is visible. Automatic drain-and-respawn on version change is a future enhancement,
 not part of the current fleet contract.
@@ -95,20 +95,20 @@ over, or read a pid file for. The steps below are the whole flow.
    A `target` change does not travel on a renewal and is reported as unapplied
    rather than silently dropped.
 4. **Attach the best available monitor surface.**
-   - Claude Code: no automatic monitor cron. Tell the user to read the castle
-     `monitor` tool (with `worker_vitals` for liveness), or — without the MCP —
+   - Claude Code: no automatic monitor cron. Tell the user to read
+     `status {scope: worker}`, or — without the MCP —
      to run `/dev:afk monitor` manually.
    - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query:
      `spawn agent background monitor`). If available, spawn exactly one read-only
      Codex monitor agent with `RED_AFK_RUNNER=codex red-skills-dev
      codex-monitor-agent --project-root "$PWD" --mode fleet`. Its task:
-     periodically read the castle `monitor` tool, report concise progress, and
+     periodically read `status {scope: worker}`, report concise progress, and
      auto-close when this project holds no registration and no `[live]` workers
      remain. It must never edit files, claim issues, stop workers, or run merges.
    - Bare/unknown: skip native monitor setup and use the manual-monitor line.
 5. **Report back.** Print the registration the daemon handed back — its project
    label, target, selector and renewal deadline — then the monitor line:
-   `monitor: call the castle monitor tool (and worker_vitals for liveness);
+   `monitor: call status {scope: worker};
    no-MCP fallback: run /dev:afk monitor.`
 
 ### Stopping — give the registration back
@@ -163,6 +163,6 @@ The safe fleet width for a given queue is the **degree of disjunction** — the 
 
 ### Refs
 
-- [`MCP.md`](./MCP.md) — the `castle` tool surface; `project_start`, `project_resize`, `project_status`, `project_reset`, `project_stop`, and `logs` are the primary interface.
+- [`MCP.md`](./MCP.md) — the `castle` tool surface; `status`, `project_start`, `project_resize`, `project_reset`, `project_stop`, and `logs` are the primary interface.
 - ADR 0130 Amendment 4 — why a project contributes a registration and holds no process of its own, and why the `fleet` launcher, the `__supervise` entrypoint and the self-heal watchdog were deleted rather than renamed.
 - [`monitor.md`](./monitor.md) — the readonly dashboard and native-task mirror.

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -125,10 +125,9 @@ The LLM Wiki routes ship with the `memory` plugin as `/memory:wiki-init` and
 
 Capability references registered by owner:
 `castle` MCP (the canonical project interface; start with its situational
-`help` tool, while `host_state`, `host_dashboard`, `host_provision_check`, and
-`host_unit_status` provide read-only host diagnostics, and a visible
-`project_status.birth_latch` routes through its structured `project_reset`
-repair) ->
+`help` tool, while `status {scope: worker | project | host}` provides scoped
+read-only diagnostics, and a visible project `birth_latch` routes through its
+structured `project_reset` repair) ->
 `plugins/dev/skills/engineering/afk/MCP.md`;
 `/afk` landing-tail throughput (`afk.landing.wait`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
@@ -188,8 +187,8 @@ through `/memory:view`, `memory docs reference-graph`, and
   package-manifest harness discovery and confirmation of the proposed
   `plugins.dev.afk.validation` schedule.
 - Execution-daemon operation is a host route, not a feature-work one:
-  diagnose through the castle MCP's read-only `host_provision_check` and other
-  `host_*` tools first; no castle tool provisions or reclaims the host.
+  diagnose through the castle MCP's read-only `status {scope: host}` first; no
+  castle tool provisions or reclaims the host.
   `/redskilled` owns provisioning, host policy, status, and lifecycle;
   `/red-doctor` (check 24) reports whether the host is provisioned. The daemon's
   home `~/.red/redskilled/` and host policy file `~/.red/config.yaml` belong to

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -37,7 +37,7 @@ Scout mode is read-only and report-producing, so this Task+DoD gate does not app
 the demand with the `worker_dispatch` tool — `{demand, runner?, mode?}`, where
 `mode` is exactly the `--mode` selector below. Pass a per-dispatch inner-agent
 instruction with `worker_request` instead, and reach a run already in flight
-with `runner_steer`. Watch it with `worker_status` and `monitor`; a `/go` worker
+with `runner_steer`. Watch it with `status {scope: worker}`; a `/go` worker
 is stamped `origin=go` / `current.kind=go`, so it is distinguishable from fleet
 workers in every observability tool. The complete surface, host tool-name
 prefixing, and the mutation-mode contract are in
@@ -88,7 +88,7 @@ Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex`
 
 **Dispatch survives the dispatcher.** Every `/go` — standard and `--scout` — is an ORDER, never the work: the host daemon owns the worker process, so a UI stop, a session teardown, or a closed terminal kills the launcher and leaves the run alive. The command returns as soon as the host grants the worker and answers with the two handles that outlive it — the worker id and its log lane:
 
-**Dispatch also skips the autonomous line.** Standard `/go` and `--scout` claim the host's bounded interactive reservation, so a saturated `/afk` target does not make a human-attached demand wait for an AFK Worker to finish. Nothing already running is stopped or resized: the daemon may admit the interactive Worker above the ordinary Worker ceiling, up to `REDSKILLED_INTERACTIVE_RESERVATION` extra Workers (default `1`). Host dashboard, project status, and monitor slot surfaces state that reservation beside their ordinary target, so `target+1` is policy rather than unexplained occupancy.
+**Dispatch also skips the autonomous line.** Standard `/go` and `--scout` claim the host's bounded interactive reservation, so a saturated `/afk` target does not make a human-attached demand wait for an AFK Worker to finish. Nothing already running is stopped or resized: the daemon may admit the interactive Worker above the ordinary Worker ceiling, up to `REDSKILLED_INTERACTIVE_RESERVATION` extra Workers (default `1`). The scoped host, project, and worker status answers state that reservation beside their ordinary target, so `target+1` is policy rather than unexplained occupancy.
 
 ```
 🔍 /go --scout dispatched disposable issue #4210 (origin=scout, kind=scout, lane:scout).
@@ -96,7 +96,7 @@ Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex`
    watch: .red/tmp/logs/2026-08-01/dispatch-2026-08-01T20-14-02-114Z-1f0c9d2e.log
 ```
 
-Follow it from those handles, never from the launcher's stdout: `worker_status`, the statusline, or the log path above. A dispatch the host refuses starts nothing and says so — it never falls back to running the engine here.
+Follow it from those handles, never from the launcher's stdout: `status {scope: worker}`, the statusline, or the log path above. A dispatch the host refuses starts nothing and says so — it never falls back to running the engine here.
 
 **Dispatch refuses a superseded engine.** Before anything is minted or born, the engine the dispatch would actually run is compared against the published dist-tag. Under the default `warn` policy a superseded engine dispatches loudly, naming both versions and the span of fixes it forfeits; set `plugins.dev.dispatch.engine_floor: refuse` to make it a hard stop that mints nothing, or `off` to silence it. A registry the host cannot reach always degrades to a warning and proceeds — offline dispatch must not die — and a source checkout or prerelease is never floored. `RED_DEV_ENGINE_FLOOR=warn|refuse|off` overrides the file for one run.
 


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3265 -->
🤖 **Re-seed trail** — #3265 on `afk/3265-the-surface-consolidates-for-real-status`, lane `/afk`.

Rounds spent: 1/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3265 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: whole-workspace (trigger: `.github/workflows/rs-afk-attempt.yml`)
{"schema":"red.afk.validation.v1","name":"test:root","status":"failed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3265-the-surface-consolidates-for-real-status test","exitCode":1,"durationMs":78,"summary":"suspect-infra: `pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3265-the-surface-consolidates-for-real-status test` exited 1 after 78ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. @reddb-io/redskilled:test:  @reddb-io/redskilled:test:  Test Files  2 failed | 68 passed (70) @reddb-io/redskilled:test:       Tests  4 failed | 676 passed (680) @reddb-io/redskilled:test:    Start at  01:13:49 @reddb-io/redskilled:test:    Duration  75.96s (transform 1.77s, setup 0ms, collect 13.49s, tests 41.79s, environment 18ms, prepare 6.06s) @reddb-io/redskilled:test:  @reddb-io/redskilled:test: [ELIFECYCLE] Test failed. See above for more details. @reddb-io/memory:test: [ELIFECYCLE] Test failed. See above for more details. @reddb-io/dev:test: [ELIFECYCLE] Test failed. See above for more details.   Tasks:    12 successful, 15 total Cached:    11 cached, 15 total   Time:    1m17.563s  Failed:    @reddb-io/redskilled#test  [ELIFECYCLE] Test failed. See above for more details. $ turbo run test --filter=!@reddb-io/red-castle --only • turbo 2.10.5 @reddb-io/redskilled#test:  ERROR  command ([REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3265-the-surface-consolidates-","suspectInfra":true}
{"schema":"red.afk.validation.v1","name":"typecheck:root","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3265-the-surface-consolidates-for-real-status typecheck","exitCode":0,"durationMs":1,"summary":"command exited 0"}
{"schema":"red.afk.validation.v1","name":"lint:root","status":"skipped","summary":"script missing"}
{"schema":"red.afk.validation.v1","name":"build:root","status":"passed","command":"pnpm -C [REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3265-the-surface-consolidates-for-real-status build","exitCode":0,"durationMs":22,"summary":"command exited 0"}
🤖 classification override: the `on_feedback_classify` hook set the feedback failure to `semantic` (the classifier read it as `semantic`).
```

Closes #3265