### PR TITLE
merge: #3289 The docs close the vocabulary: the merge queue is the documented CI-side final moment and the validation ceiling is a visible knob

### DIFF
--- a/.changeset/closed-validation-vocabulary.md
+++ b/.changeset/closed-validation-vocabulary.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Document the complete declared Validation moment schedule, the merge queue's CI-side final verdict, and the host-wide validation concurrency ceiling across the AFK and Go skills.

--- a/apps/dev/tests/validation-moments-docs.test.ts
+++ b/apps/dev/tests/validation-moments-docs.test.ts
@@ -1,0 +1,61 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+async function readRepoFile(path: string): Promise<string> {
+  return readFile(join(ROOT, path), "utf8");
+}
+
+describe("Validation moments documentation (ADR 0135, #3289)", () => {
+  it("states the complete schedule and its host concurrency knob in one reference", async () => {
+    const config = await readRepoFile("plugins/dev/skills/engineering/afk/docs/CONFIG.md");
+
+    expect(config).toContain("### Validation moments");
+    expect(config).toContain("`plugins.dev.afk.validation.iteration`");
+    expect(config).toContain("`plugins.dev.afk.validation.post_done`");
+    expect(config).toContain("`plugins.dev.afk.validation.landing`");
+    expect(config).toContain("CI-side final Validation moment");
+    expect(config).toContain("`plugins.dev.redskilled.validation_ceiling`");
+    expect(config).toContain("omitted moment is skipped loudly");
+  });
+
+  it("teaches AFK and Go through declared moments, not retired discovery defaults", async () => {
+    const [afk, go, config] = await Promise.all([
+      readRepoFile("plugins/dev/skills/engineering/afk/SKILL.md"),
+      readRepoFile("plugins/dev/skills/engineering/go/SKILL.md"),
+      readRepoFile("plugins/dev/skills/engineering/afk/docs/CONFIG.md"),
+    ]);
+
+    expect(afk).toContain("`plugins.dev.afk.validation`");
+    expect(afk).toContain("undeclared moment is skipped loudly");
+    expect(afk).not.toContain("Feedback plus the operator's");
+    expect(afk).not.toContain("replaces feedback script discovery");
+
+    expect(go).toContain("declared `post_done` Validation moment");
+    expect(go).toContain("`--verify` appends one command to `post_done`");
+    expect(go).not.toContain("normal feedback harness");
+    expect(go).not.toContain("feedback/backpressure");
+    expect(go).not.toContain("RED_GATE_STALE_BASE_CORRECTIONS");
+
+    expect(config).toContain("#### Deprecated `post_done` aliases");
+    expect(config).not.toContain("When the key is absent, discovery is byte-for-byte unchanged");
+  });
+
+  it("keeps the generated Pi skill mirrors byte-identical", async () => {
+    const paths = [
+      "skills/engineering/afk/SKILL.md",
+      "skills/engineering/afk/docs/CONFIG.md",
+      "skills/engineering/go/SKILL.md",
+    ];
+
+    for (const path of paths) {
+      const [source, mirror] = await Promise.all([
+        readRepoFile(`plugins/dev/${path}`),
+        readRepoFile(`packaging/pi/dev/${path}`),
+      ]);
+      expect(mirror).toBe(source);
+    }
+  });
+});

--- a/packaging/pi/dev/skills/engineering/afk/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/afk/SKILL.md
@@ -159,8 +159,9 @@ Read the focused reference before touching that concern:
   [`runner-hermes.md`](./runner-hermes.md).
 - Liveness, stall protection, and lane-idle rules:
   [`docs/LIVENESS.md`](./docs/LIVENESS.md).
-- Config, env overrides, lifecycle hooks, sandbox/runner/model settings, and
-  backpressure commands: [`docs/CONFIG.md`](./docs/CONFIG.md).
+- Config, env overrides, lifecycle hooks, sandbox/runner/model settings, the
+  declared Validation moments, and their concurrency ceiling:
+  [`docs/CONFIG.md`](./docs/CONFIG.md).
 - Safety rules for shell and git actions: [`SAFETY.md`](SAFETY.md).
 
 ## Load-Bearing Rules
@@ -184,16 +185,20 @@ Read the focused reference before touching that concern:
   labels by hand.
 - The inner agent's canonical completion signals are
   `<promise>DONE</promise>` and `<promise>BLOCKED</promise>`.
-- The gate command is canonical. Feedback plus the operator's
-  `afk.backpressure` commands are the sole validation authority; workers run
-  those exact commands and never self-impose stricter flags, extra lint
-  restrictions, widened target sets, or a harder contract than the gate defines.
-  If an error appears only under an extra check, reconcile it against the real
-  gate command before reporting a red `main`.
-- A declared `plugins.dev.afk.feedback.commands` list replaces feedback script
-  discovery completely (including workspace and invariant suites); absent keeps
-  discovery unchanged. The Worker runs the declared list exactly and never runs
-  an omitted full suite locally. `afk.backpressure` remains additive.
+- `plugins.dev.afk.validation` is the sole local validation authority. Its
+  ordered `iteration`, `post_done`, and `landing` command lists are run only at
+  those named moments; an undeclared moment is skipped loudly and `[]` is an
+  explicit empty declaration. The engine never discovers or improvises a suite.
+- `iteration` is handed to the inner agent while it writes. `post_done` runs at
+  the branch's fork point after DONE, and a correction re-runs only its failed
+  subset before folding back to the full declaration. `landing` runs before
+  push/PR/queue. The merge queue is the CI-side final Validation moment and owns
+  freshness against the merged result.
+- Declared commands are canonical. Workers run the exact commands handed to
+  them and never self-impose stricter flags, extra lint restrictions, widened
+  target sets, or a harder contract. If an error appears only under an extra
+  check, reconcile it against the declared schedule before reporting a red
+  `main`.
 - `blocked:ci` leaves the completed PR open and escalates to `ready-for-human`;
   AFK does not re-run the inner agent for already-complete work waiting on CI.
 - On DONE, completion sweep reclaims all attempt directories for that issue

--- a/packaging/pi/dev/skills/engineering/afk/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/afk/SKILL.md
@@ -194,7 +194,7 @@ Read the focused reference before touching that concern:
   subset before folding back to the full declaration. `landing` runs before
   push/PR/queue. The merge queue is the CI-side final Validation moment and owns
   freshness against the merged result.
-- Declared commands are canonical. Workers run the exact commands handed to
+- The gate command is canonical. Workers run the exact commands handed to
   them and never self-impose stricter flags, extra lint restrictions, widened
   target sets, or a harder contract. If an error appears only under an extra
   check, reconcile it against the declared schedule before reporting a red

--- a/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
@@ -56,16 +56,18 @@ MCP, and non-essential host hooks are absent from every projection.
 | `afk.claim_reaper.grace_s` | `RED_AFK_CLAIM_REAPER_GRACE_S` | `300` | Minimum claim age before the stale-claim sweep may recover a `running` issue, even if the stale window is configured aggressively. |
 | `afk.claim_reaper.recent_commit_s` | `RED_AFK_CLAIM_REAPER_RECENT_COMMIT_S` | `2700` | Sliding progress-protection window: a live `afk/*/<issue>-*` attempt branch with a commit this recent protects the claimed issue from stale-claim recovery. |
 | `afk.statusline_cache_ttl` | `RED_AFK_STATUSLINE_CACHE_TTL_S` | `180` | TTL (seconds) of every EXPENSIVE FETCHED statusline number — the GitHub-derived queue/human + open-PR/open-issue counts AND the repo-global local diffstat, cached in `.red/state/statusline/statusline-cache.toon` / `.red/state/statusline/statusline-repo-cache.toon` (issue #1178, #1217). The statusline renders on every prompt, so a per-render gh/git round-trip would freeze the TUI; the network cost is paid at most once per TTL. Also drives the monitor's stale-cache marker. Use the **flat** key — do **not** nest it under `afk.statusline` (that key is the boolean statusline opt-out; YAML cannot make one key both a boolean and a map). Typo-safe (env > config > default): a non-numeric / zero / negative value in **either** source falls through to the next and ultimately the 180 default — never 0 (a 0 TTL would refresh on every render, defeating the cache). |
-| `afk.backpressure` | — | _(empty)_ | Ordered list of shell commands run as an extra pre-merge gate on the DONE path (issue #430, PRD #429). |
 | `plugins.dev.afk.setup` | — | _(undeclared fallback)_ | Ordered repository-owned commands that prepare dependencies in fresh Worker/feedback Worktrees. Commands run verbatim through `sh -c`; AFK never changes a declared command. `/red-setup` detects and confirms this value, and `/red-doctor` checks it against package/hook managers (#3268). |
-| `afk.validation.node_max_old_space_mb` | — | `2048` | Node heap cap applied to feedback/backpressure validation subprocesses via `NODE_OPTIONS=--max-old-space-size=<mb>` (#1758). Keeps heavy Vitest/build validation bounded per worker. |
+| `plugins.dev.afk.validation.iteration` | — | _(undeclared; skip)_ | Ordered light checks handed to the inner agent for use while writing. |
+| `plugins.dev.afk.validation.post_done` | — | _(undeclared; skip)_ | Ordered branch checks run after DONE against the branch's fork point. |
+| `plugins.dev.afk.validation.landing` | — | _(undeclared; skip)_ | Ordered final local checks run before push, PR creation, and queue entry. |
+| `plugins.dev.afk.validation.node_max_old_space_mb` | — | `2048` | Node heap cap applied to Validation moment subprocesses via `NODE_OPTIONS=--max-old-space-size=<mb>` (#1758). Keeps heavy validation bounded per Worker. |
 | `afk.fleet.target` | — | `1` | How many Workers a project registers for when nothing states a number (ADR 0132 decision 7). **One** because a second Worker doubles GitHub polling against a budget metered per token — two spend ~2200 GraphQL points/hour of a 5000/hour window — and doubles memory against a host ceiling every Worker is already granted in full (#3080); that is worth choosing deliberately rather than inheriting. The daemon's host-scoped ceiling bounds it from above, because width is machine budget rather than project preference. The value is not the decision — the EQUALITY is: this number, the MCP `project_start` schema default and `CONFIG_DEFAULTS` all read one namer, and a test fails when they disagree. |
-| `afk.validation.vitest_max_workers` | — | `1` | Vitest worker fan-out cap exposed as `VITEST_MAX_WORKERS` to validation subprocesses (#1758). Repos with larger machines may raise it; the conservative default prevents width-2 fleets from multiplying heavy suites. |
-| `afk.validation.heavy_available_memory_mb` | — | `4096` | Minimum free-memory threshold for admitting known-heavy validation work (#1758). Heavy validation admission serializes when another heavy validation is active, and otherwise waits until this much memory is available. |
+| `plugins.dev.afk.validation.vitest_max_workers` | — | `1` | Vitest worker fan-out cap exposed as `VITEST_MAX_WORKERS` to validation subprocesses (#1758). Repos with larger machines may raise it; the conservative default prevents width-2 fleets from multiplying heavy suites. |
+| `plugins.dev.afk.validation.heavy_available_memory_mb` | — | `4096` | Minimum free-memory threshold for admitting known-heavy validation work (#1758). Heavy validation admission serializes when another heavy validation is active, and otherwise waits until this much memory is available. |
 | `afk.output_shaping.terse_steering` | — | `false` | Opt-in AFK output-shaping experiment (#1638). When true, even-numbered issues receive a phrasing-only terse steering block; odd-numbered issues are the holdout. The assignment is persisted in worker state beside heartbeat output-token counters and reported by `afk-output-shaping`. |
 | `afk.worktree_launches_pull_request` | — | `true` | Landing **mode**, decoupled from the branch-lock (ADR 0030 amended, #842). `true` (default) → the attempt lands via an **admin-merged PR** into the resolved base; `false` → a **direct merge** into that base (offline, no PR — only the post-commit push the worker already does). The branch-lock now only resolves the *target* base (lock > pin > main, ADR 0031); this flag decides PR-vs-direct **independently**. So: no lock + `true` → admin-PR to `main`; no lock + `false` → direct merge to `main`; lock=`X` + `true` → admin-PR to `X`; lock=`X` + `false` → direct merge to `X`. *How* a PR merges (admin vs `wait_for_review` vs `review_gate`) stays governed by `afk.merge.*`. **Migration:** the default `true` flips the old *locked* behaviour (which direct-merged) — a locked repo now gets an admin-PR to its lock branch; set `false` to keep the old offline/direct-promotion flow. |
 | `afk.landing.wait` | — | `merge` | Worker-slot release point across the PR landing tail (#2427): `merge` keeps today’s byte-compatible flow and releases only after merge + Ticket close; `ci` releases once required CI is green; `none` releases as soon as the PR opens. For `ci`/`none`, the background landing observer finishes merge + close. It uses the resident’s shared webhook lane when available and the established per-wait forwarder otherwise. **Trade-off:** earlier release pipelines more Tickets through each fleet slot, but leaves a larger asynchronous tail; if that observer dies, the open PR/running Ticket is an orphan for the deadend audit/healer instead of work the slot still owns. |
-| `afk.merge.wait_for_review` | — | `false` | Merge-gate policy (ADR 0048). When `false` (default), the unlocked admin-merge proceeds **ignoring advisory review checks** (e.g. CodeRabbit) — the binding gates are `drift-guard` (the `pre_merge` hook) + in-process backpressure/feedback. When `true`, the unlocked landing **waits** for the configured review check to conclude before merging, then merges regardless of its verdict (the review stays advisory). `drift-guard` is a hard gate either way. |
+| `afk.merge.wait_for_review` | — | `false` | Merge-gate policy (ADR 0048). When `false` (default), the unlocked admin-merge proceeds **ignoring advisory review checks** (e.g. CodeRabbit) — the binding local checks are the declared Validation moments plus `drift-guard` (the `pre_merge` hook). When `true`, the unlocked landing **waits** for the configured review check to conclude before merging, then merges regardless of its verdict (the review stays advisory). `drift-guard` is a hard gate either way. |
 | `afk.merge.review_check` | — | `CodeRabbit` | Name (case-insensitive substring) of the advisory review check `wait_for_review` polls via `gh pr checks`. Only consulted when `afk.merge.wait_for_review` is `true`. |
 | `afk.merge.ci_aware` | — | `false` | CI-aware merge (#812). When `false` (default), the unlocked admin-merge fires immediately — correct only on a base with **no** required status checks. When `true`, the unlocked landing first polls `gh pr view --json mergeStateStatus,statusCheckRollup` until the PR settles, then admin-merges **only** once it is genuinely ready (`CLEAN`, or `BLOCKED` solely by a required review `--admin` waives). Required for any `enforce_admins` base, where an admin-merge **cannot** bypass required checks: a real conflict / `DIRTY` / `BEHIND` → `blocked:merge-conflict`; a **failed** required check → `blocked:ci`; checks still **pending** at the timeout → `blocked:ci` with the open PR preserved (never re-runs the inner agent). |
 | `RED_AFK_MERGE_CI_TIMEOUT_S` | env | `1800` | CI-aware merge wait budget, in seconds (#812). The poll runs at a fixed 10s cadence until `mergeStateStatus` settles; on timeout the open, MERGEABLE PR is handed off (`ci-pending` → `blocked:ci`) instead of re-running the agent. Non-positive / unparseable → the 1800s default. Only consulted when `afk.merge.ci_aware` is `true`. |
@@ -116,6 +118,17 @@ plugins:
       implementer:
         skills: dev:tdd, dev:diagnose # optional exact worker allowlist; activation gates still apply
         runner_startup_baseline_ms: 840 # optional measured pre-projection historical baseline
+      validation:
+        iteration:
+          - pnpm --filter @reddb-io/dev exec vitest run tests/config.test.ts
+        post_done:
+          - pnpm --filter @reddb-io/dev test
+          - pnpm --filter @reddb-io/dev typecheck
+        landing:
+          - pnpm pi:packages:check
+        node_max_old_space_mb: 2048
+        vitest_max_workers: 1
+        heavy_available_memory_mb: 4096
 
 afk:
   worktree_launches_pull_request: true   # true → admin-PR landing; false → direct merge (offline). Decoupled from the lock (#842)
@@ -133,16 +146,6 @@ afk:
   sandbox: none
   max_iterations: 12      # override the default re-invocation ceiling here
   statusline_cache_ttl: 180   # statusline gh/git cache TTL (seconds); flat key, NOT under afk.statusline
-  feedback:
-    commands:             # declared → replaces discovery; [] disables locally
-      - pnpm -C apps/dev exec tsc --noEmit
-  backpressure:           # extra pre-merge gate, runs after the feedback gate
-    - npm run test
-    - npm run lint
-  validation:
-    node_max_old_space_mb: 2048
-    vitest_max_workers: 1
-    heavy_available_memory_mb: 4096
   output_shaping:
     terse_steering: false # true → even issues steered, odd issues holdout; report with afk-output-shaping
   merge:
@@ -156,21 +159,53 @@ afk:
 
 `RED_AFK_IDLE_TIMEOUT_S` is env-only (no `afk.*` config key); `sandbox`, `max_iterations`, and `statusline_cache_ttl` resolve env > config > default. The three runtime bounds — silence (`idleTimeoutSeconds`), re-invocation count (`maxIterations`), and the fixed no-commit-progress worker guard — are detailed under *Attempt Completion & Termination Bounds*.
 
-### Feedback command authority
+### Validation moments
 
-`plugins.dev.afk.feedback.commands` declares exactly what AFK runs for the feedback stage. When present, it **replaces** package-script discovery rather than extending it: the ordered shell strings run verbatim through `sh -c` at the validation Worktree root, and the discovered `test`/`typecheck`/`lint`/`build`, workspace typecheck, and invariant suites run nowhere locally. `commands: []` explicitly disables the local feedback stage. When the key is absent, discovery is byte-for-byte unchanged.
+`plugins.dev.afk.validation` is the single repository-owned schedule. Commands
+are ordered shell strings run verbatim; there is no discovered default. An
+omitted moment is skipped loudly, while `[]` is an explicitly declared empty
+list and also skips loudly.
 
-Narrowing local feedback moves the full-suite verdict to CI. That is sound only when branch protection requires the merge queue's `test` check; `/red-doctor` warns when it sees a replacement without that required check. Every declared feedback command is also placed verbatim in the Worker's `<merge-gate>` contract, before any additive backpressure commands, so the Worker runs the same command and must not invent a broader suite.
+| Moment | Owner and timing | Freshness contract |
+|---|---|---|
+| `plugins.dev.afk.validation.iteration` | The inner agent receives these light checks in its handoff and runs them while writing. | Confidence only; do not improvise a broader suite. |
+| `plugins.dev.afk.validation.post_done` | The engine runs these commands after DONE against the branch's fork point. The Worker's `<merge-gate>` repeats the exact list. | A correction re-runs only the failed subset, then folds back to the full declaration after that subset passes. |
+| `plugins.dev.afk.validation.landing` | The engine runs these commands immediately before push, PR creation, and queue entry. | Last local verdict; it does not try to predict a moving base. |
+| Merge queue | The repository's required CI checks run on the merge group. This is configured at the forge, not in RedSkills. | The merge queue is the CI-side final Validation moment and owns freshness against the merged result. |
 
-### Backpressure gate
+`setup` and `format` remain separate declarations rather than Validation
+moments. `/red-setup` inventories the repository's real scripts, proposes the
+three ordered lists, and writes them only after operator confirmation.
 
-`afk.backpressure` is an operator-declared, ordered list of shell commands that **supplements** the auto-derived feedback gate (it does not replace it). On a successful DONE attempt — after the scope-derived `test`/`typecheck`/`lint`/`build` feedback gate passes, before landing — AFK runs each backpressure command in order (`sh -c <command>`) against a checkout of the worker branch. If **any** command exits non-zero the merge is blocked and the issue is parked to `ready-for-human` with `blocked:validation`, exactly like a feedback failure: the failing command and its output tail land in the terminal envelope and in the `red.afk.validation.v1` validation sidecar (records named `backpressure:<command>`). An absent or empty block is a no-op (today's behaviour). The namespaced `plugins.dev.afk.backpressure` location is honoured with the legacy bare `afk.backpressure` fallback (ADR 0042).
+Validation is admitted through one host-wide semaphore shared by every project.
+Tune it with `plugins.dev.redskilled.validation_ceiling` in the machine's home
+config (or `REDSKILLED_VALIDATION_CEILING` for the process). The derived default
+is bounded by CPU, memory, and the Worker ceiling; `host-state` reports the
+resolved `ceiling.validation_count` and its source, while the statusline shows
+live occupancy as `gate N/M`. This host knob sits beside the schedule because a
+declared moment answers *what and when*, while the ceiling answers *how many may
+run concurrently*; it never changes or invents commands.
+
+```yaml
+# Machine home config, not the repository's .red/config.yaml
+plugins:
+  dev:
+    redskilled:
+      validation_ceiling: 2
+```
+
+#### Deprecated `post_done` aliases
+
+`plugins.dev.afk.feedback.commands` and `plugins.dev.afk.backpressure` are
+one-release migration aliases that contribute commands to `post_done` and warn
+with the canonical replacement. They are not separate stages, do not restore
+discovery, and must not be proposed for new configuration.
 
 `plugins.dev.afk.setup` is the dependency-install authority for every fresh AFK validation Worktree. `/red-setup` inspects lockfiles, `packageManager`, Corepack metadata, and `prepare`/dependencies for hook managers, then asks the maintainer to confirm exact commands such as `LEFTHOOK=0 pnpm install --frozen-lockfile`, `HUSKY=0 npm ci`, or `bun install --frozen-lockfile`. The engine executes the ordered strings verbatim and never appends flags or substitutes its detected package manager. This lets a repo keep lifecycle scripts that perform real builds while disabling only the hook installer that conflicts with AFK's intentional `core.hooksPath` redirect.
 
 For older undeclared repos only, AFK retains a hardened compatibility fallback: `pnpm install --frozen-lockfile` with `LEFTHOOK=0` and `HUSKY=0`. If stderr still names the custom-hooksPath refusal, AFK retries once with `--ignore-scripts`; a successful retry is recorded on each `red.afk.validation.v1` record as setup that skipped lifecycle scripts. Any unrelated install failure remains fatal without retry. `/red-doctor` reports an undeclared or mismatched setup so the fallback is migration scaffolding, not permanent guessed policy.
 
-**This is how maintainers tell an inner agent the exact gate it must satisfy — without ad-hoc `-r` retry guidance.** When `feedback.commands` or `afk.backpressure` is set, every inner-agent handoff carries a `<merge-gate>` section listing the configured commands verbatim, and the agent's exit-protocol completion contract instructs it to run and pass those commands *before* emitting `<promise>DONE</promise>` (issues #849 and #3276). The contract distinguishes two kinds of check: the **touched-package confidence checks** the agent runs while developing versus the **binding merge gate** the orchestrator enforces after DONE. The declared feedback list may intentionally be narrower than discovery; backpressure remains additive. On an automatic re-queue, the prior failure's summary remains visible through `<prev-failure-context>`, so the next agent can target the real blocker. The agent is told **not** to re-run an unbounded full repository suite after its final commit; the listed gate commands are the contract.
+**This is how maintainers tell an inner agent the exact checks it must satisfy — without ad-hoc `-r` retry guidance.** The handoff carries the `iteration` list and a `<merge-gate>` containing the declared `post_done` commands verbatim. The contract distinguishes the **touched-package confidence checks** the agent chooses while developing from the **declared moments** the orchestrator enforces. On an automatic re-queue, the prior failure's summary remains visible through `<prev-failure-context>`, so the next agent can target the real blocker. The agent is told **not** to re-run an unbounded full repository suite after its final commit; the declared commands are the contract.
 
 ### HUMAN-ONLY ticket types
 

--- a/packaging/pi/dev/skills/engineering/go/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/go/SKILL.md
@@ -27,7 +27,7 @@ Only after the maintainer approves do you run the `go` bundle command. The appro
 
 This gate is always required. `+yolo` only raises in-run autonomy; it never skips Task+DoD approval. `--dod "<condition>"` may pre-fill the Definition of Done draft, but it still requires maintainer approval before dispatch.
 
-At approval time, check whether the repo has configured machine validation (`afk.backpressure` / the normal feedback harness). If no harness is configured, offer one ephemeral inline check with `--verify "<cmd>"`; that command runs as backpressure for this single dispatch only. If the maintainer declines an inline check, proceed best-effort; the engine applies a tightened iteration cap so a check-less dispatch fails fast instead of looping.
+At approval time, read the repo's declared `plugins.dev.afk.validation` schedule. If its `post_done` Validation moment is undeclared or explicitly empty, offer one ephemeral inline check with `--verify "<cmd>"`; `--verify` appends one command to `post_done` for this dispatch only. If the maintainer declines, proceed best-effort: the undeclared moment is skipped loudly and the engine applies a tightened iteration cap so a check-less dispatch fails fast instead of looping.
 
 Scout mode is read-only and report-producing, so this Task+DoD gate does not apply to `/go --scout`.
 
@@ -106,7 +106,7 @@ Follow it from those handles, never from the launcher's stdout: `worker_status`,
 
 **`--request "<instruction>"`** forwards a special per-dispatch instruction block to the inner agent prompt, matching `/afk --request`. It is not part of the approved Task and is not recorded on the disposable `lane:go` issue.
 
-**`--verify "<cmd>"`** adds a one-off inline machine check for this dispatch. Use it only when the repo lacks a configured harness/backpressure and the maintainer approved the command during the confirmation gate. A chain ending in a bare `git diff --exit-code` — the usual "regenerating leaves the tree clean" tail — is rewritten to `git add -A --intent-to-add . && git diff --exit-code` before it runs, because plain `git diff` reads tracked files only and would go green over a mirror the generator newly created. The verdict is unchanged: generated output the run has not committed still fails the check.
+**`--verify "<cmd>"`** adds a one-off inline machine check for this dispatch. `--verify` appends one command to `post_done`; use it only when that declared moment otherwise has no commands and the maintainer approved the command during the confirmation gate. A chain ending in a bare `git diff --exit-code` — the usual "regenerating leaves the tree clean" tail — is rewritten to `git add -A --intent-to-add . && git diff --exit-code` before it runs, because plain `git diff` reads tracked files only and would go green over a mirror the generator newly created. The verdict is unchanged: generated output the run has not committed still fails the check.
 
 **`--tags a,b`** stamps territory `tag:<value>` labels (bare values, comma-separated) on the minted disposable issue, so the dispatch is visible under the same territory filters `/afk --tags` uses. Missing `tag:<value>` labels are auto-created before the mint — never pre-create them by hand.
 
@@ -115,16 +115,16 @@ Follow it from those handles, never from the launcher's stdout: `worker_status`,
 1. **Mints a disposable tracking issue** in the isolated `lane:go` lane — labelled `lane:go` and **never** `ready-for-agent`, so a running fleet's candidate listing can never surface it. With `--tags`, the mint also stamps the requested `tag:<value>` territory labels (auto-created when missing). The issue is minted only after Task+DoD approval; its body carries the approved Task, the approved semantic Definition of Done, and the machine gate reference.
 2. **Spins a castle worker** under the shared `.red/tmp/workers/` root. It does not create a separate worker namespace; the worker state carries `origin=go` and `current.kind=go`, and observability surfaces use those stamps to keep `/go` distinct from the `/afk` fleet.
 3. **Processes the issue in an isolated worktree** created by the castle engine, using the stamped kind as provenance for monitor/statusline display.
-4. **Runs the shared validation gate** with the **interactive** (pause/ask) escalation sink: mechanical findings auto-apply + commit; an intent finding pauses and asks you to approve / fix / skip.
-5. **Runs bounded post-DONE machine-gate correction** for `/go`: if feedback/backpressure fails after the inner agent emits DONE, the engine re-seeds the agent with the failing validation tail under a small `RED_GO_VERIFY_RETRIES` cap, then deterministically parks to `ready-for-human` / `blocked:validation` when the cap is exhausted. **The cap counts causes, not attempts.** The gate runs on the branch merged with the live base, so a base that moves mid-run — most sharply a `chore(release): version packages` bump, which rewrites every generated package mirror — can redden a branch that is itself green. A gate failure observed while the base moved is attributed to stale-base drift and granted a **free** correction cycle: the agent is told to merge the base and regenerate, and the budget is untouched. Those free cycles are bounded by `RED_GATE_STALE_BASE_CORRECTIONS` (default 2), so a churning base cannot buy an unbounded run, and an already-spent counter can never park a branch whose latest validation passed.
-6. **Brings back a PR**; the disposable issue **auto-closes on merge** (the engine's PR body carries `Closes #N`).
+4. **Runs the shared review stage** with the **interactive** (pause/ask) escalation sink: mechanical findings auto-apply + commit; an intent finding pauses and asks you to approve / fix / skip.
+5. **Runs the declared `post_done` Validation moment at the branch's fork point.** If a command fails after the inner agent emits DONE, the engine re-seeds it with only the failing subset under the bounded `/go` Re-seed budget, then folds back to the full declaration after that subset passes. Exhaustion parks the Ticket at `ready-for-human` / `blocked:validation`. An undeclared or empty moment skips loudly; `--verify` is the one-dispatch addition described above.
+6. **Runs the declared `landing` Validation moment before push/PR/queue, then brings back a PR.** Freshness against the merged result belongs to the merge queue, the CI-side final Validation moment. The disposable issue **auto-closes on merge** (the engine's PR body carries `Closes #N`).
 
 **What `--scout` does differently:**
 
 1. **Mints a disposable issue** in the isolated `lane:scout` lane (never `ready-for-agent` or `lane:go`).
 2. **Spins a castle worker** under the shared `.red/tmp/workers/` root with `origin=scout`, `current.kind=scout`, and `run_mode=scout`.
 3. **Runs the agent in read-only mode** — the SCOUT_EXIT_PROTOCOL explicitly forbids commits. `continuousPush` is disabled so no branch is pushed during the run.
-4. **Skips push / feedback gate / PR / landing entirely** — the engine enforces this at the `run_mode=scout` check in `process-issue.ts`.
+4. **Skips local Validation moments, push, PR, and Landing entirely** — the engine enforces this at the `run_mode=scout` check in `process-issue.ts`.
 5. **Posts the agent's markdown report** as a comment on the disposable issue, then closes it. Nothing lands on main.
 
 **Hard rules:**
@@ -167,9 +167,9 @@ For failure-state playbooks, see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
 - **Worker root:** the castle engine writes the worker and worktree under the shared `.red/tmp/workers/…` root. Legacy `.red/tmp/go-workers/…` entries may still appear in observability until they age out, but new `/go` runs do not use that root.
 - **Provenance:** `--origin go` is stamped once on the worker state as `origin=go` and `current.kind=go`, then never mutated.
 
-## Gate behaviour (standard /go — shared with `/afk`, ADR 0081)
+## Review behaviour (standard /go — shared with `/afk`, ADR 0081)
 
-The validation gate splits findings two ways:
+The shared review stage splits findings two ways:
 
 - **Mechanical** (closed allowlist: formatter, import-organizer, lint-fix, comment-typo, trailing-whitespace, trailing-newline) → auto-applied and committed, always.
 - **Intent** (anything else) → escalated. In `/go` the sink is **interactive**: it pauses and asks you to approve, fix, or skip.

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -159,8 +159,9 @@ Read the focused reference before touching that concern:
   [`runner-hermes.md`](./runner-hermes.md).
 - Liveness, stall protection, and lane-idle rules:
   [`docs/LIVENESS.md`](./docs/LIVENESS.md).
-- Config, env overrides, lifecycle hooks, sandbox/runner/model settings, and
-  backpressure commands: [`docs/CONFIG.md`](./docs/CONFIG.md).
+- Config, env overrides, lifecycle hooks, sandbox/runner/model settings, the
+  declared Validation moments, and their concurrency ceiling:
+  [`docs/CONFIG.md`](./docs/CONFIG.md).
 - Safety rules for shell and git actions: [`SAFETY.md`](SAFETY.md).
 
 ## Load-Bearing Rules
@@ -184,16 +185,20 @@ Read the focused reference before touching that concern:
   labels by hand.
 - The inner agent's canonical completion signals are
   `<promise>DONE</promise>` and `<promise>BLOCKED</promise>`.
-- The gate command is canonical. Feedback plus the operator's
-  `afk.backpressure` commands are the sole validation authority; workers run
-  those exact commands and never self-impose stricter flags, extra lint
-  restrictions, widened target sets, or a harder contract than the gate defines.
-  If an error appears only under an extra check, reconcile it against the real
-  gate command before reporting a red `main`.
-- A declared `plugins.dev.afk.feedback.commands` list replaces feedback script
-  discovery completely (including workspace and invariant suites); absent keeps
-  discovery unchanged. The Worker runs the declared list exactly and never runs
-  an omitted full suite locally. `afk.backpressure` remains additive.
+- `plugins.dev.afk.validation` is the sole local validation authority. Its
+  ordered `iteration`, `post_done`, and `landing` command lists are run only at
+  those named moments; an undeclared moment is skipped loudly and `[]` is an
+  explicit empty declaration. The engine never discovers or improvises a suite.
+- `iteration` is handed to the inner agent while it writes. `post_done` runs at
+  the branch's fork point after DONE, and a correction re-runs only its failed
+  subset before folding back to the full declaration. `landing` runs before
+  push/PR/queue. The merge queue is the CI-side final Validation moment and owns
+  freshness against the merged result.
+- Declared commands are canonical. Workers run the exact commands handed to
+  them and never self-impose stricter flags, extra lint restrictions, widened
+  target sets, or a harder contract. If an error appears only under an extra
+  check, reconcile it against the declared schedule before reporting a red
+  `main`.
 - `blocked:ci` leaves the completed PR open and escalates to `ready-for-human`;
   AFK does not re-run the inner agent for already-complete work waiting on CI.
 - On DONE, completion sweep reclaims all attempt directories for that issue

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -194,7 +194,7 @@ Read the focused reference before touching that concern:
   subset before folding back to the full declaration. `landing` runs before
   push/PR/queue. The merge queue is the CI-side final Validation moment and owns
   freshness against the merged result.
-- Declared commands are canonical. Workers run the exact commands handed to
+- The gate command is canonical. Workers run the exact commands handed to
   them and never self-impose stricter flags, extra lint restrictions, widened
   target sets, or a harder contract. If an error appears only under an extra
   check, reconcile it against the declared schedule before reporting a red

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -56,16 +56,18 @@ MCP, and non-essential host hooks are absent from every projection.
 | `afk.claim_reaper.grace_s` | `RED_AFK_CLAIM_REAPER_GRACE_S` | `300` | Minimum claim age before the stale-claim sweep may recover a `running` issue, even if the stale window is configured aggressively. |
 | `afk.claim_reaper.recent_commit_s` | `RED_AFK_CLAIM_REAPER_RECENT_COMMIT_S` | `2700` | Sliding progress-protection window: a live `afk/*/<issue>-*` attempt branch with a commit this recent protects the claimed issue from stale-claim recovery. |
 | `afk.statusline_cache_ttl` | `RED_AFK_STATUSLINE_CACHE_TTL_S` | `180` | TTL (seconds) of every EXPENSIVE FETCHED statusline number — the GitHub-derived queue/human + open-PR/open-issue counts AND the repo-global local diffstat, cached in `.red/state/statusline/statusline-cache.toon` / `.red/state/statusline/statusline-repo-cache.toon` (issue #1178, #1217). The statusline renders on every prompt, so a per-render gh/git round-trip would freeze the TUI; the network cost is paid at most once per TTL. Also drives the monitor's stale-cache marker. Use the **flat** key — do **not** nest it under `afk.statusline` (that key is the boolean statusline opt-out; YAML cannot make one key both a boolean and a map). Typo-safe (env > config > default): a non-numeric / zero / negative value in **either** source falls through to the next and ultimately the 180 default — never 0 (a 0 TTL would refresh on every render, defeating the cache). |
-| `afk.backpressure` | — | _(empty)_ | Ordered list of shell commands run as an extra pre-merge gate on the DONE path (issue #430, PRD #429). |
 | `plugins.dev.afk.setup` | — | _(undeclared fallback)_ | Ordered repository-owned commands that prepare dependencies in fresh Worker/feedback Worktrees. Commands run verbatim through `sh -c`; AFK never changes a declared command. `/red-setup` detects and confirms this value, and `/red-doctor` checks it against package/hook managers (#3268). |
-| `afk.validation.node_max_old_space_mb` | — | `2048` | Node heap cap applied to feedback/backpressure validation subprocesses via `NODE_OPTIONS=--max-old-space-size=<mb>` (#1758). Keeps heavy Vitest/build validation bounded per worker. |
+| `plugins.dev.afk.validation.iteration` | — | _(undeclared; skip)_ | Ordered light checks handed to the inner agent for use while writing. |
+| `plugins.dev.afk.validation.post_done` | — | _(undeclared; skip)_ | Ordered branch checks run after DONE against the branch's fork point. |
+| `plugins.dev.afk.validation.landing` | — | _(undeclared; skip)_ | Ordered final local checks run before push, PR creation, and queue entry. |
+| `plugins.dev.afk.validation.node_max_old_space_mb` | — | `2048` | Node heap cap applied to Validation moment subprocesses via `NODE_OPTIONS=--max-old-space-size=<mb>` (#1758). Keeps heavy validation bounded per Worker. |
 | `afk.fleet.target` | — | `1` | How many Workers a project registers for when nothing states a number (ADR 0132 decision 7). **One** because a second Worker doubles GitHub polling against a budget metered per token — two spend ~2200 GraphQL points/hour of a 5000/hour window — and doubles memory against a host ceiling every Worker is already granted in full (#3080); that is worth choosing deliberately rather than inheriting. The daemon's host-scoped ceiling bounds it from above, because width is machine budget rather than project preference. The value is not the decision — the EQUALITY is: this number, the MCP `project_start` schema default and `CONFIG_DEFAULTS` all read one namer, and a test fails when they disagree. |
-| `afk.validation.vitest_max_workers` | — | `1` | Vitest worker fan-out cap exposed as `VITEST_MAX_WORKERS` to validation subprocesses (#1758). Repos with larger machines may raise it; the conservative default prevents width-2 fleets from multiplying heavy suites. |
-| `afk.validation.heavy_available_memory_mb` | — | `4096` | Minimum free-memory threshold for admitting known-heavy validation work (#1758). Heavy validation admission serializes when another heavy validation is active, and otherwise waits until this much memory is available. |
+| `plugins.dev.afk.validation.vitest_max_workers` | — | `1` | Vitest worker fan-out cap exposed as `VITEST_MAX_WORKERS` to validation subprocesses (#1758). Repos with larger machines may raise it; the conservative default prevents width-2 fleets from multiplying heavy suites. |
+| `plugins.dev.afk.validation.heavy_available_memory_mb` | — | `4096` | Minimum free-memory threshold for admitting known-heavy validation work (#1758). Heavy validation admission serializes when another heavy validation is active, and otherwise waits until this much memory is available. |
 | `afk.output_shaping.terse_steering` | — | `false` | Opt-in AFK output-shaping experiment (#1638). When true, even-numbered issues receive a phrasing-only terse steering block; odd-numbered issues are the holdout. The assignment is persisted in worker state beside heartbeat output-token counters and reported by `afk-output-shaping`. |
 | `afk.worktree_launches_pull_request` | — | `true` | Landing **mode**, decoupled from the branch-lock (ADR 0030 amended, #842). `true` (default) → the attempt lands via an **admin-merged PR** into the resolved base; `false` → a **direct merge** into that base (offline, no PR — only the post-commit push the worker already does). The branch-lock now only resolves the *target* base (lock > pin > main, ADR 0031); this flag decides PR-vs-direct **independently**. So: no lock + `true` → admin-PR to `main`; no lock + `false` → direct merge to `main`; lock=`X` + `true` → admin-PR to `X`; lock=`X` + `false` → direct merge to `X`. *How* a PR merges (admin vs `wait_for_review` vs `review_gate`) stays governed by `afk.merge.*`. **Migration:** the default `true` flips the old *locked* behaviour (which direct-merged) — a locked repo now gets an admin-PR to its lock branch; set `false` to keep the old offline/direct-promotion flow. |
 | `afk.landing.wait` | — | `merge` | Worker-slot release point across the PR landing tail (#2427): `merge` keeps today’s byte-compatible flow and releases only after merge + Ticket close; `ci` releases once required CI is green; `none` releases as soon as the PR opens. For `ci`/`none`, the background landing observer finishes merge + close. It uses the resident’s shared webhook lane when available and the established per-wait forwarder otherwise. **Trade-off:** earlier release pipelines more Tickets through each fleet slot, but leaves a larger asynchronous tail; if that observer dies, the open PR/running Ticket is an orphan for the deadend audit/healer instead of work the slot still owns. |
-| `afk.merge.wait_for_review` | — | `false` | Merge-gate policy (ADR 0048). When `false` (default), the unlocked admin-merge proceeds **ignoring advisory review checks** (e.g. CodeRabbit) — the binding gates are `drift-guard` (the `pre_merge` hook) + in-process backpressure/feedback. When `true`, the unlocked landing **waits** for the configured review check to conclude before merging, then merges regardless of its verdict (the review stays advisory). `drift-guard` is a hard gate either way. |
+| `afk.merge.wait_for_review` | — | `false` | Merge-gate policy (ADR 0048). When `false` (default), the unlocked admin-merge proceeds **ignoring advisory review checks** (e.g. CodeRabbit) — the binding local checks are the declared Validation moments plus `drift-guard` (the `pre_merge` hook). When `true`, the unlocked landing **waits** for the configured review check to conclude before merging, then merges regardless of its verdict (the review stays advisory). `drift-guard` is a hard gate either way. |
 | `afk.merge.review_check` | — | `CodeRabbit` | Name (case-insensitive substring) of the advisory review check `wait_for_review` polls via `gh pr checks`. Only consulted when `afk.merge.wait_for_review` is `true`. |
 | `afk.merge.ci_aware` | — | `false` | CI-aware merge (#812). When `false` (default), the unlocked admin-merge fires immediately — correct only on a base with **no** required status checks. When `true`, the unlocked landing first polls `gh pr view --json mergeStateStatus,statusCheckRollup` until the PR settles, then admin-merges **only** once it is genuinely ready (`CLEAN`, or `BLOCKED` solely by a required review `--admin` waives). Required for any `enforce_admins` base, where an admin-merge **cannot** bypass required checks: a real conflict / `DIRTY` / `BEHIND` → `blocked:merge-conflict`; a **failed** required check → `blocked:ci`; checks still **pending** at the timeout → `blocked:ci` with the open PR preserved (never re-runs the inner agent). |
 | `RED_AFK_MERGE_CI_TIMEOUT_S` | env | `1800` | CI-aware merge wait budget, in seconds (#812). The poll runs at a fixed 10s cadence until `mergeStateStatus` settles; on timeout the open, MERGEABLE PR is handed off (`ci-pending` → `blocked:ci`) instead of re-running the agent. Non-positive / unparseable → the 1800s default. Only consulted when `afk.merge.ci_aware` is `true`. |
@@ -116,6 +118,17 @@ plugins:
       implementer:
         skills: dev:tdd, dev:diagnose # optional exact worker allowlist; activation gates still apply
         runner_startup_baseline_ms: 840 # optional measured pre-projection historical baseline
+      validation:
+        iteration:
+          - pnpm --filter @reddb-io/dev exec vitest run tests/config.test.ts
+        post_done:
+          - pnpm --filter @reddb-io/dev test
+          - pnpm --filter @reddb-io/dev typecheck
+        landing:
+          - pnpm pi:packages:check
+        node_max_old_space_mb: 2048
+        vitest_max_workers: 1
+        heavy_available_memory_mb: 4096
 
 afk:
   worktree_launches_pull_request: true   # true → admin-PR landing; false → direct merge (offline). Decoupled from the lock (#842)
@@ -133,16 +146,6 @@ afk:
   sandbox: none
   max_iterations: 12      # override the default re-invocation ceiling here
   statusline_cache_ttl: 180   # statusline gh/git cache TTL (seconds); flat key, NOT under afk.statusline
-  feedback:
-    commands:             # declared → replaces discovery; [] disables locally
-      - pnpm -C apps/dev exec tsc --noEmit
-  backpressure:           # extra pre-merge gate, runs after the feedback gate
-    - npm run test
-    - npm run lint
-  validation:
-    node_max_old_space_mb: 2048
-    vitest_max_workers: 1
-    heavy_available_memory_mb: 4096
   output_shaping:
     terse_steering: false # true → even issues steered, odd issues holdout; report with afk-output-shaping
   merge:
@@ -156,21 +159,53 @@ afk:
 
 `RED_AFK_IDLE_TIMEOUT_S` is env-only (no `afk.*` config key); `sandbox`, `max_iterations`, and `statusline_cache_ttl` resolve env > config > default. The three runtime bounds — silence (`idleTimeoutSeconds`), re-invocation count (`maxIterations`), and the fixed no-commit-progress worker guard — are detailed under *Attempt Completion & Termination Bounds*.
 
-### Feedback command authority
+### Validation moments
 
-`plugins.dev.afk.feedback.commands` declares exactly what AFK runs for the feedback stage. When present, it **replaces** package-script discovery rather than extending it: the ordered shell strings run verbatim through `sh -c` at the validation Worktree root, and the discovered `test`/`typecheck`/`lint`/`build`, workspace typecheck, and invariant suites run nowhere locally. `commands: []` explicitly disables the local feedback stage. When the key is absent, discovery is byte-for-byte unchanged.
+`plugins.dev.afk.validation` is the single repository-owned schedule. Commands
+are ordered shell strings run verbatim; there is no discovered default. An
+omitted moment is skipped loudly, while `[]` is an explicitly declared empty
+list and also skips loudly.
 
-Narrowing local feedback moves the full-suite verdict to CI. That is sound only when branch protection requires the merge queue's `test` check; `/red-doctor` warns when it sees a replacement without that required check. Every declared feedback command is also placed verbatim in the Worker's `<merge-gate>` contract, before any additive backpressure commands, so the Worker runs the same command and must not invent a broader suite.
+| Moment | Owner and timing | Freshness contract |
+|---|---|---|
+| `plugins.dev.afk.validation.iteration` | The inner agent receives these light checks in its handoff and runs them while writing. | Confidence only; do not improvise a broader suite. |
+| `plugins.dev.afk.validation.post_done` | The engine runs these commands after DONE against the branch's fork point. The Worker's `<merge-gate>` repeats the exact list. | A correction re-runs only the failed subset, then folds back to the full declaration after that subset passes. |
+| `plugins.dev.afk.validation.landing` | The engine runs these commands immediately before push, PR creation, and queue entry. | Last local verdict; it does not try to predict a moving base. |
+| Merge queue | The repository's required CI checks run on the merge group. This is configured at the forge, not in RedSkills. | The merge queue is the CI-side final Validation moment and owns freshness against the merged result. |
 
-### Backpressure gate
+`setup` and `format` remain separate declarations rather than Validation
+moments. `/red-setup` inventories the repository's real scripts, proposes the
+three ordered lists, and writes them only after operator confirmation.
 
-`afk.backpressure` is an operator-declared, ordered list of shell commands that **supplements** the auto-derived feedback gate (it does not replace it). On a successful DONE attempt — after the scope-derived `test`/`typecheck`/`lint`/`build` feedback gate passes, before landing — AFK runs each backpressure command in order (`sh -c <command>`) against a checkout of the worker branch. If **any** command exits non-zero the merge is blocked and the issue is parked to `ready-for-human` with `blocked:validation`, exactly like a feedback failure: the failing command and its output tail land in the terminal envelope and in the `red.afk.validation.v1` validation sidecar (records named `backpressure:<command>`). An absent or empty block is a no-op (today's behaviour). The namespaced `plugins.dev.afk.backpressure` location is honoured with the legacy bare `afk.backpressure` fallback (ADR 0042).
+Validation is admitted through one host-wide semaphore shared by every project.
+Tune it with `plugins.dev.redskilled.validation_ceiling` in the machine's home
+config (or `REDSKILLED_VALIDATION_CEILING` for the process). The derived default
+is bounded by CPU, memory, and the Worker ceiling; `host-state` reports the
+resolved `ceiling.validation_count` and its source, while the statusline shows
+live occupancy as `gate N/M`. This host knob sits beside the schedule because a
+declared moment answers *what and when*, while the ceiling answers *how many may
+run concurrently*; it never changes or invents commands.
+
+```yaml
+# Machine home config, not the repository's .red/config.yaml
+plugins:
+  dev:
+    redskilled:
+      validation_ceiling: 2
+```
+
+#### Deprecated `post_done` aliases
+
+`plugins.dev.afk.feedback.commands` and `plugins.dev.afk.backpressure` are
+one-release migration aliases that contribute commands to `post_done` and warn
+with the canonical replacement. They are not separate stages, do not restore
+discovery, and must not be proposed for new configuration.
 
 `plugins.dev.afk.setup` is the dependency-install authority for every fresh AFK validation Worktree. `/red-setup` inspects lockfiles, `packageManager`, Corepack metadata, and `prepare`/dependencies for hook managers, then asks the maintainer to confirm exact commands such as `LEFTHOOK=0 pnpm install --frozen-lockfile`, `HUSKY=0 npm ci`, or `bun install --frozen-lockfile`. The engine executes the ordered strings verbatim and never appends flags or substitutes its detected package manager. This lets a repo keep lifecycle scripts that perform real builds while disabling only the hook installer that conflicts with AFK's intentional `core.hooksPath` redirect.
 
 For older undeclared repos only, AFK retains a hardened compatibility fallback: `pnpm install --frozen-lockfile` with `LEFTHOOK=0` and `HUSKY=0`. If stderr still names the custom-hooksPath refusal, AFK retries once with `--ignore-scripts`; a successful retry is recorded on each `red.afk.validation.v1` record as setup that skipped lifecycle scripts. Any unrelated install failure remains fatal without retry. `/red-doctor` reports an undeclared or mismatched setup so the fallback is migration scaffolding, not permanent guessed policy.
 
-**This is how maintainers tell an inner agent the exact gate it must satisfy — without ad-hoc `-r` retry guidance.** When `feedback.commands` or `afk.backpressure` is set, every inner-agent handoff carries a `<merge-gate>` section listing the configured commands verbatim, and the agent's exit-protocol completion contract instructs it to run and pass those commands *before* emitting `<promise>DONE</promise>` (issues #849 and #3276). The contract distinguishes two kinds of check: the **touched-package confidence checks** the agent runs while developing versus the **binding merge gate** the orchestrator enforces after DONE. The declared feedback list may intentionally be narrower than discovery; backpressure remains additive. On an automatic re-queue, the prior failure's summary remains visible through `<prev-failure-context>`, so the next agent can target the real blocker. The agent is told **not** to re-run an unbounded full repository suite after its final commit; the listed gate commands are the contract.
+**This is how maintainers tell an inner agent the exact checks it must satisfy — without ad-hoc `-r` retry guidance.** The handoff carries the `iteration` list and a `<merge-gate>` containing the declared `post_done` commands verbatim. The contract distinguishes the **touched-package confidence checks** the agent chooses while developing from the **declared moments** the orchestrator enforces. On an automatic re-queue, the prior failure's summary remains visible through `<prev-failure-context>`, so the next agent can target the real blocker. The agent is told **not** to re-run an unbounded full repository suite after its final commit; the declared commands are the contract.
 
 ### HUMAN-ONLY ticket types
 

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -27,7 +27,7 @@ Only after the maintainer approves do you run the `go` bundle command. The appro
 
 This gate is always required. `+yolo` only raises in-run autonomy; it never skips Task+DoD approval. `--dod "<condition>"` may pre-fill the Definition of Done draft, but it still requires maintainer approval before dispatch.
 
-At approval time, check whether the repo has configured machine validation (`afk.backpressure` / the normal feedback harness). If no harness is configured, offer one ephemeral inline check with `--verify "<cmd>"`; that command runs as backpressure for this single dispatch only. If the maintainer declines an inline check, proceed best-effort; the engine applies a tightened iteration cap so a check-less dispatch fails fast instead of looping.
+At approval time, read the repo's declared `plugins.dev.afk.validation` schedule. If its `post_done` Validation moment is undeclared or explicitly empty, offer one ephemeral inline check with `--verify "<cmd>"`; `--verify` appends one command to `post_done` for this dispatch only. If the maintainer declines, proceed best-effort: the undeclared moment is skipped loudly and the engine applies a tightened iteration cap so a check-less dispatch fails fast instead of looping.
 
 Scout mode is read-only and report-producing, so this Task+DoD gate does not apply to `/go --scout`.
 
@@ -106,7 +106,7 @@ Follow it from those handles, never from the launcher's stdout: `worker_status`,
 
 **`--request "<instruction>"`** forwards a special per-dispatch instruction block to the inner agent prompt, matching `/afk --request`. It is not part of the approved Task and is not recorded on the disposable `lane:go` issue.
 
-**`--verify "<cmd>"`** adds a one-off inline machine check for this dispatch. Use it only when the repo lacks a configured harness/backpressure and the maintainer approved the command during the confirmation gate. A chain ending in a bare `git diff --exit-code` — the usual "regenerating leaves the tree clean" tail — is rewritten to `git add -A --intent-to-add . && git diff --exit-code` before it runs, because plain `git diff` reads tracked files only and would go green over a mirror the generator newly created. The verdict is unchanged: generated output the run has not committed still fails the check.
+**`--verify "<cmd>"`** adds a one-off inline machine check for this dispatch. `--verify` appends one command to `post_done`; use it only when that declared moment otherwise has no commands and the maintainer approved the command during the confirmation gate. A chain ending in a bare `git diff --exit-code` — the usual "regenerating leaves the tree clean" tail — is rewritten to `git add -A --intent-to-add . && git diff --exit-code` before it runs, because plain `git diff` reads tracked files only and would go green over a mirror the generator newly created. The verdict is unchanged: generated output the run has not committed still fails the check.
 
 **`--tags a,b`** stamps territory `tag:<value>` labels (bare values, comma-separated) on the minted disposable issue, so the dispatch is visible under the same territory filters `/afk --tags` uses. Missing `tag:<value>` labels are auto-created before the mint — never pre-create them by hand.
 
@@ -115,16 +115,16 @@ Follow it from those handles, never from the launcher's stdout: `worker_status`,
 1. **Mints a disposable tracking issue** in the isolated `lane:go` lane — labelled `lane:go` and **never** `ready-for-agent`, so a running fleet's candidate listing can never surface it. With `--tags`, the mint also stamps the requested `tag:<value>` territory labels (auto-created when missing). The issue is minted only after Task+DoD approval; its body carries the approved Task, the approved semantic Definition of Done, and the machine gate reference.
 2. **Spins a castle worker** under the shared `.red/tmp/workers/` root. It does not create a separate worker namespace; the worker state carries `origin=go` and `current.kind=go`, and observability surfaces use those stamps to keep `/go` distinct from the `/afk` fleet.
 3. **Processes the issue in an isolated worktree** created by the castle engine, using the stamped kind as provenance for monitor/statusline display.
-4. **Runs the shared validation gate** with the **interactive** (pause/ask) escalation sink: mechanical findings auto-apply + commit; an intent finding pauses and asks you to approve / fix / skip.
-5. **Runs bounded post-DONE machine-gate correction** for `/go`: if feedback/backpressure fails after the inner agent emits DONE, the engine re-seeds the agent with the failing validation tail under a small `RED_GO_VERIFY_RETRIES` cap, then deterministically parks to `ready-for-human` / `blocked:validation` when the cap is exhausted. **The cap counts causes, not attempts.** The gate runs on the branch merged with the live base, so a base that moves mid-run — most sharply a `chore(release): version packages` bump, which rewrites every generated package mirror — can redden a branch that is itself green. A gate failure observed while the base moved is attributed to stale-base drift and granted a **free** correction cycle: the agent is told to merge the base and regenerate, and the budget is untouched. Those free cycles are bounded by `RED_GATE_STALE_BASE_CORRECTIONS` (default 2), so a churning base cannot buy an unbounded run, and an already-spent counter can never park a branch whose latest validation passed.
-6. **Brings back a PR**; the disposable issue **auto-closes on merge** (the engine's PR body carries `Closes #N`).
+4. **Runs the shared review stage** with the **interactive** (pause/ask) escalation sink: mechanical findings auto-apply + commit; an intent finding pauses and asks you to approve / fix / skip.
+5. **Runs the declared `post_done` Validation moment at the branch's fork point.** If a command fails after the inner agent emits DONE, the engine re-seeds it with only the failing subset under the bounded `/go` Re-seed budget, then folds back to the full declaration after that subset passes. Exhaustion parks the Ticket at `ready-for-human` / `blocked:validation`. An undeclared or empty moment skips loudly; `--verify` is the one-dispatch addition described above.
+6. **Runs the declared `landing` Validation moment before push/PR/queue, then brings back a PR.** Freshness against the merged result belongs to the merge queue, the CI-side final Validation moment. The disposable issue **auto-closes on merge** (the engine's PR body carries `Closes #N`).
 
 **What `--scout` does differently:**
 
 1. **Mints a disposable issue** in the isolated `lane:scout` lane (never `ready-for-agent` or `lane:go`).
 2. **Spins a castle worker** under the shared `.red/tmp/workers/` root with `origin=scout`, `current.kind=scout`, and `run_mode=scout`.
 3. **Runs the agent in read-only mode** — the SCOUT_EXIT_PROTOCOL explicitly forbids commits. `continuousPush` is disabled so no branch is pushed during the run.
-4. **Skips push / feedback gate / PR / landing entirely** — the engine enforces this at the `run_mode=scout` check in `process-issue.ts`.
+4. **Skips local Validation moments, push, PR, and Landing entirely** — the engine enforces this at the `run_mode=scout` check in `process-issue.ts`.
 5. **Posts the agent's markdown report** as a comment on the disposable issue, then closes it. Nothing lands on main.
 
 **Hard rules:**
@@ -167,9 +167,9 @@ For failure-state playbooks, see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
 - **Worker root:** the castle engine writes the worker and worktree under the shared `.red/tmp/workers/…` root. Legacy `.red/tmp/go-workers/…` entries may still appear in observability until they age out, but new `/go` runs do not use that root.
 - **Provenance:** `--origin go` is stamped once on the worker state as `origin=go` and `current.kind=go`, then never mutated.
 
-## Gate behaviour (standard /go — shared with `/afk`, ADR 0081)
+## Review behaviour (standard /go — shared with `/afk`, ADR 0081)
 
-The validation gate splits findings two ways:
+The shared review stage splits findings two ways:
 
 - **Mechanical** (closed allowlist: formatter, import-organizer, lint-fix, comment-typo, trailing-whitespace, trailing-newline) → auto-applied and committed, always.
 - **Intent** (anything else) → escalated. In `/go` the sink is **interactive**: it pauses and asks you to approve, fix, or skip.


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3289 -->
🤖 **Re-seed trail** — #3289 on `afk/3289-the-docs-close-the-vocabulary-the-merge`, lane `/afk`.

Rounds spent: 2/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3289; re-seeding on the think tier before terminal validation routing. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

Closes #3289