### PR TITLE
fix: #3301 An inconclusive gate round is free and heals itself: the baseline latch retries, and an environment failure can never charge the correction budget

### DIFF
--- a/.changeset/free-suspect-infra-rounds.md
+++ b/.changeset/free-suspect-infra-rounds.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Treat sub-second suspect-infra gate failures as environment failures that retry without consuming the Worker's re-seed budget.

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -494,6 +494,11 @@ export function isInfraValidationFailure(checks: readonly ClassifiableCheck[]): 
     if (check.status !== "failed") continue;
     const exitCode = check.record.exitCode;
     if (exitCode === 0) continue;
+    // The validation command classifier has already proved that a sub-second
+    // suite failure did not run long enough to judge the branch. Preserve that
+    // environment verdict at round classification so it receives bounded infra
+    // recovery and cannot be charged (or overridden to semantic) downstream.
+    if (check.record.suspectInfra === true) return true;
     if (check.record.infra === "stall") return true;
     if (exitCode === 137) return true;
     const summary = check.record.summary ?? "";

--- a/apps/dev/tests/afk-resilience.test.ts
+++ b/apps/dev/tests/afk-resilience.test.ts
@@ -32,6 +32,11 @@ function fakeExec(plan: Record<string, number>): Exec {
   };
 }
 
+function healthyGateClock(): () => number {
+  let now = 0;
+  return () => (now += 1000);
+}
+
 // Pattern 1: Submodule lifecycle in a fresh worktree — git worktree add does
 // NOT populate submodules, so the feedback-worktree setup fails with
 // "feedback worktree setup failed for <branch>; validation blocked" and the
@@ -94,7 +99,7 @@ describe("Pattern 2 — test drift between worker branch and main", () => {
       worktree: "afk/wX/123-slug",
       scopes: ["apps/dev"],
       layout: makeLayout(),
-      now: () => 0,
+      now: healthyGateClock(),
       baselineWorktree: "main",
     });
     expect(result.ok).toBe(false);
@@ -111,7 +116,7 @@ describe("Pattern 2 — test drift between worker branch and main", () => {
       worktree: "afk/wX/123-slug",
       scopes: ["apps/dev"],
       layout: makeLayout(),
-      now: () => 0,
+      now: healthyGateClock(),
       baselineWorktree: "main",
     });
     expect(result.ok).toBe(false); // inconclusive still blocks THIS branch
@@ -162,7 +167,7 @@ describe("Pattern 3 — failures inherited from the base branch", () => {
       worktree: "afk/wX/123-slug",
       scopes: [".", "apps/dev"],
       layout: makeLayout(),
-      now: () => 0,
+      now: healthyGateClock(),
       baselineWorktree: "main",
     });
     expect(result.ok).toBe(false);

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -883,7 +883,7 @@ describe("runFeedback — baseline comparison classifies the branch verdict", ()
       worktree: "afk/wX/123-slug",
       scopes: ["apps/dev"],
       layout: makeLayout(),
-      now: () => 0,
+      now: fakeClock(1000),
       baselineWorktree: "main",
     });
     // test:apps/dev failed on worker AND on baseline → inconclusive; the gate
@@ -913,7 +913,7 @@ describe("runFeedback — baseline comparison classifies the branch verdict", ()
       worktree: "afk/wX/123-slug",
       scopes: ["apps/dev"],
       layout: makeLayout(),
-      now: () => 0,
+      now: fakeClock(1000),
       baselineWorktree: "main",
     });
     expect(result.ok).toBe(false);
@@ -945,7 +945,7 @@ describe("runFeedback — baseline comparison classifies the branch verdict", ()
       worktree: "afk/wX/123-slug",
       scopes: ["apps/dev"],
       layout: makeLayout(),
-      now: () => 0,
+      now: fakeClock(1000),
       baselineWorktree: "main",
     });
     expect(result.baselineProbeRan).toBe(true);
@@ -973,7 +973,7 @@ describe("runFeedback — baseline comparison classifies the branch verdict", ()
       worktree: "afk/wX/123-slug",
       scopes: ["apps/dev"],
       layout: makeLayout(),
-      now: () => 0,
+      now: fakeClock(1000),
       baselineWorktree: "main",
     });
     expect(result.ok).toBe(false);
@@ -1029,7 +1029,7 @@ describe("runFeedback — baseline comparison classifies the branch verdict", ()
       worktree: "afk/wX/123-slug",
       scopes: ["apps/dev"],
       layout: makeLayout(),
-      now: () => 0,
+      now: fakeClock(1000),
       baselineWorktree: "main",
     });
     expect(result.ok).toBe(false);
@@ -1187,7 +1187,7 @@ describe("runFeedback — workspace typecheck", () => {
       worktree: "afk/wX/123-slug",
       scopes: ["apps/dev"],
       layout: workspaceLayout(),
-      now: () => 0,
+      now: fakeClock(1000),
       baselineWorktree: "main",
     });
 
@@ -1212,7 +1212,7 @@ describe("runFeedback — workspace typecheck", () => {
       worktree: "afk/wX/123-slug",
       scopes: ["apps/dev"],
       layout: workspaceLayout(),
-      now: () => 0,
+      now: fakeClock(1000),
       baselineWorktree: "main",
     });
 

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -1856,88 +1856,59 @@ describe("processIssue — an empty-diff DONE is never stale-base drift (#2711)"
   });
 });
 
-describe("processIssue — suspect-infra uses the bounded free correction pool (#3233)", () => {
-  it("re-runs only the gate without charging the branch when the record says suspect-infra", async () => {
+describe("processIssue — suspect-infra is an environment-inconclusive round (#3301)", () => {
+  it("charges no correction and cannot be overridden to semantic by the classification hook", async () => {
     const { deps, input, trace } = harness({
       labels: ["lane:go"],
       laneLabel: "lane:go",
       outcome: "done",
-      feedbackResults: [false, true],
-      feedbackDurationsMs: [465, 1000],
-      recoveryEnv: { RED_GO_VERIFY_RETRIES: "0" },
-    });
-
-    const result = await processIssue(deps, input);
-
-    expect(result.outcome).toBe("done");
-    expect(trace.runAgentCalls).toHaveLength(1);
-    expect(trace.iterLogs.some((line) => line.includes("free suspect-infra correction (1/2)"))).toBe(true);
-    expect(trace.iterLogs.some((line) => line.includes("budget untouched at 0/0"))).toBe(true);
-    expect(trace.closed).toEqual([9]);
-  });
-
-  it("charges the next red gate when suspect-infra is no longer present", async () => {
-    const { deps, input, trace } = harness({
-      labels: ["lane:go"],
-      laneLabel: "lane:go",
-      outcome: "done",
-      feedbackResults: [false, false, true],
-      feedbackDurationsMs: [465, 1000, 1000],
+      feedbackOk: false,
+      feedbackDurationsMs: [465],
       recoveryEnv: { RED_GO_VERIFY_RETRIES: "1" },
     });
+    const customDeps: ProcessIssueDeps = {
+      ...deps,
+      hooks: {
+        ...deps.hooks,
+        config: { "afk.hooks.on_feedback_classify": "cls" },
+        exec: async (command) =>
+          command === "cls"
+            ? { code: 0, stdout: JSON.stringify({ class: "semantic" }) }
+            : { code: 0, stdout: "" },
+      },
+    };
 
-    const result = await processIssue(deps, input);
+    const result = await processIssue(customDeps, input);
 
-    expect(result.outcome).toBe("done");
-    expect(trace.runAgentCalls).toHaveLength(2);
-    expect(trace.iterLogs.some((line) => line.includes("free suspect-infra correction (1/2)"))).toBe(true);
-    expect(trace.iterLogs.some((line) => line.includes("correction retry 1/1"))).toBe(true);
-    expect(trace.closed).toEqual([9]);
-  });
-
-  it("cannot buy unbounded gate runs while the environment stays suspect", async () => {
-    const { deps, input, trace } = harness({
-      labels: ["lane:go"],
-      laneLabel: "lane:go",
-      outcome: "done",
-      feedbackResults: [false],
-      feedbackDurationsMs: [465],
-      recoveryEnv: { RED_GO_VERIFY_RETRIES: "0", RED_GATE_STALE_BASE_CORRECTIONS: "1" },
-    });
-
-    const result = await processIssue(deps, input);
-
-    expect(result.outcome).toBe("feedback-failed");
+    expect(result.outcome).toBe("feedback-failed-infra");
     expect(trace.runAgentCalls).toHaveLength(1);
-    expect(trace.iterLogs.filter((line) => line.includes("free suspect-infra correction"))).toHaveLength(1);
-    expect(trace.labelEdits.some((edit) => edit.add.includes("blocked:validation"))).toBe(true);
+    expect(trace.workerEvents.filter((event) => event.kind === "worker.reseeded")).toEqual([]);
+    expect(trace.workerEvents.filter((event) => event.kind === "worker.gate_revalidation_requested")).toEqual([]);
+    const evidence = trace.envelopeBodies.join("\n");
+    expect(evidence).toContain("suspect-infra");
+    expect(evidence).toContain("environment failure");
+    expect(evidence).toContain("hook requested `semantic`, but environment verdicts cannot be overridden");
+    expect(evidence).not.toContain("correction budget exhausted");
+    expect(evidence).not.toContain("failure is the branch's");
   });
 
-  it("parks the second identical suspect-infra signature without spending another retry (#3268)", async () => {
+  it("still charges a genuinely failing branch check on a healthy environment", async () => {
     const { deps, input, trace } = harness({
       labels: ["lane:go"],
       laneLabel: "lane:go",
       outcome: "done",
       feedbackResults: [false, false],
-      feedbackDurationsMs: [465, 465],
-      recoveryEnv: { RED_GO_VERIFY_RETRIES: "0" },
+      feedbackDurationsMs: [1000, 1000],
+      recoveryEnv: { RED_GO_VERIFY_RETRIES: "1" },
     });
 
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("feedback-failed");
-    expect(trace.runAgentCalls).toHaveLength(1);
-    expect(trace.iterLogs.filter((line) => line.includes("free suspect-infra correction"))).toHaveLength(1);
-    expect(
-      trace.iterLogs.some(
-        (line) => line.includes("deterministic suspect-infra") && line.includes("signature="),
-      ),
-    ).toBe(true);
-    expect(
-      trace.labelEdits.some(
-        (edit) => edit.add.includes("ready-for-human") && edit.add.includes("blocked:validation"),
-      ),
-    ).toBe(true);
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.iterLogs.some((line) => line.includes("correction retry 1/1"))).toBe(true);
+    expect(trace.workerEvents.filter((event) => event.kind === "worker.reseeded")).toHaveLength(1);
+    expect(trace.envelopeBodies.join("\n")).toContain("gate-correction budget exhausted");
   });
 
   it("parks an identical carried INFRA signature instead of exhausting outer recovery (#3268)", async () => {

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -80,6 +80,7 @@ function harness(opts: HarnessOptions = {}): {
   input: ReconcileInput;
   trace: Trace;
 } {
+  let nowEpoch = 0;
   const trace: Trace = {
     labelEdits: [],
     comments: [],
@@ -285,7 +286,7 @@ function harness(opts: HarnessOptions = {}): {
     },
     makeRebaseWorktree: async () => "/rwt",
     removeRebaseWorktree: async () => {},
-    nowEpoch: () => 1000,
+    nowEpoch: () => (nowEpoch += 1000),
     ciAwait: opts.ciAware ? { sleep: async () => {}, maxPolls: 2 } : undefined,
     appendIterLog: (line) => {
       trace.iterLogs.push(line);

--- a/apps/dev/tests/repo-invariants.test.ts
+++ b/apps/dev/tests/repo-invariants.test.ts
@@ -59,7 +59,7 @@ function fakeExec(
   return { exec, calls };
 }
 
-const clock = (step = 5): (() => number) => {
+const clock = (step = 1000): (() => number) => {
   let t = 0;
   return () => (t += step);
 };


### PR DESCRIPTION
Automated AFK landing for #3301. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3301

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788498651&installation_model_id=20659&pr_number=3317&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3317&signature=2a8ed142081cda782851984e68605193cfc4c0def200279b3a762b1038e2879f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->