### PR TITLE
chore: #3311 The rsp resident embeds the budget-aware GitHub client, so every proxied gh read is cached, routed, and attributed — with no redskilled coupling

### DIFF
--- a/apps/rsp/package.json
+++ b/apps/rsp/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@reddb-io/toon": "catalog:",
     "@reddb-io/build-info": "workspace:*",
+    "@reddb-io/github": "workspace:*",
     "@reddb-io/red-castle": "workspace:*",
     "@reddb-io/shared": "workspace:*",
     "@reddb-io/sdk": "1.23.1",

--- a/apps/rsp/src/gh-conditional.ts
+++ b/apps/rsp/src/gh-conditional.ts
@@ -1,18 +1,15 @@
-import { spawn } from "node:child_process";
-import { createHash, randomUUID } from "node:crypto";
-import { readGhEtagEntry, writeGhEtagEntry } from "./gh-etag-cache.js";
-// The whole-document reader survives only as the legacy migration path; every
-// live lookup goes through one partition.
+import { execFileSync } from "node:child_process";
+import type { RspOverheadCeiling } from "./overhead-budget.js";
+import { resolveRspConfig } from "./config.js";
+import { residentElisionStore } from "./resident-store.js";
+import type {
+  RspResidentGithubRead,
+  RspResidentGithubResult,
+} from "./resident-github.js";
+
+// Kept as compatibility exports for `rsp sweep`; live reads are resident-owned
+// and no longer consult the old per-process disk cache.
 export { readGhEtagCache, sweepGhEtagCache } from "./gh-etag-cache.js";
-import {
-  DEFAULT_RSP_OVERHEAD_CEILING,
-  overheadCounters,
-  overheadFamilyDisabled,
-  recordOverheadSample,
-  startChildProcessTimer,
-  type RspOverheadCeiling,
-} from "./overhead-budget.js";
-import { appendTelemetryEvent, RSP_DECISIONS_COLLECTION } from "./telemetry.js";
 
 export interface GhConditionalRequest {
   path: string;
@@ -21,16 +18,13 @@ export interface GhConditionalRequest {
   telemetryRoot?: string;
   env?: NodeJS.ProcessEnv;
   command?: string;
-  /**
-   * Cancels the underlying `gh` call. Without it a hung GitHub request has no
-   * upper bound, so every caller that owns a deadline (notably `rsp wait`) must
-   * be able to reclaim the process rather than wait on it forever.
-   */
+  /** Explicit classified argv; inferred from the REST path for legacy callers. */
+  args?: readonly string[];
   signal?: AbortSignal;
-  /** The overhead ceiling this call holds itself to (#2746). */
   overheadCeiling?: RspOverheadCeiling;
-  /** The byte ceiling the ETag cache lane holds itself to (#2745). */
   cacheMaxBytes?: number;
+  /** Test seam; production always sends the request to the resident. */
+  residentRead?: (input: RspResidentGithubRead) => Promise<RspResidentGithubResult>;
 }
 
 export interface GhConditionalResult {
@@ -41,177 +35,98 @@ export interface GhConditionalResult {
   quotaFree: boolean;
 }
 
+/**
+ * Send one classified read to the resident-owned budget-aware GitHub client.
+ *
+ * No raw-gh fail-open exists here. A cold resident, missing credential, or
+ * budget refusal returns a structured repair with exit 75; silently spawning gh
+ * would recreate the unattributed pool drain this boundary exists to close.
+ */
 export async function readGhConditionalJson(request: GhConditionalRequest): Promise<GhConditionalResult> {
+  if (request.signal?.aborted) {
+    return { status: 1, stdout: "", stderr: "gh call cancelled", quotaFree: false };
+  }
   const cwd = request.cwd ?? process.cwd();
-  const telemetryRoot = request.telemetryRoot ?? cwd;
-  const started = process.hrtime.bigint();
-  const ceiling = request.overheadCeiling ?? DEFAULT_RSP_OVERHEAD_CEILING;
-  const identity = requestIdentity(request.path, request.params);
-  const key = cacheKey(identity);
-  // A self-disabled family still runs the command; it just stops paying the
-  // cache tax that disabled it.
-  const disabled = overheadFamilyDisabled(telemetryRoot, "gh-api-json");
-  // One partition, not the whole cache: the lookup cost no longer scales with
-  // everything cached before it (#2745).
-  const cached = disabled ? undefined : await readGhEtagEntry(telemetryRoot, key);
-  const args = ["api", "--include", "--method", "GET", request.path];
-  for (const [name, value] of sortedParams(request.params)) {
-    args.push("-f", `${name}=${String(value)}`);
-  }
-  if (cached?.etag) args.push("-H", `If-None-Match: ${cached.etag}`);
-
-  const result = await runGh(args, cwd, request.env, request.signal);
-  const recordOverhead = (bytesSaved: number) => {
-    const counters = overheadCounters();
-    recordOverheadSample(telemetryRoot, {
-      family: "gh-api-json",
-      wrapperMs: Number(process.hrtime.bigint() - started) / 1_000_000,
-      childMs: counters.childMs,
-      selfStateBytesRead: counters.selfStateBytesRead,
-      bytesSaved,
-    }, ceiling);
+  const env = request.env ?? process.env;
+  const repo = repositoryIdentity(cwd);
+  const params = {
+    ...(repo ? { owner: repo.owner, repo: repo.repo } : {}),
+    ...(request.params ?? {}),
   };
-  const parsed = parseIncludedResponse(result.stdout);
-  const quotaFree = parsed.statusCode === 304 && !!cached;
-  if (quotaFree) {
-    recordOverhead(Buffer.byteLength(cached.body));
-    await recordConditionalTelemetry(telemetryRoot, request.command ?? `gh api ${request.path}`, true);
-    return {
-      status: 0,
-      stdout: cached.body,
-      stderr: result.stderr,
-      etag: cached.etag,
-      quotaFree: true,
-    };
-  }
+  const input: RspResidentGithubRead = {
+    args: request.args ?? inferGithubArgs(request.path),
+    path: request.path,
+    actor: githubActor(env),
+    ...(Object.keys(params).length > 0 ? { params } : {}),
+  };
 
-  if (parsed.statusCode >= 200 && parsed.statusCode < 300) {
-    const etag = parsed.headers.get("etag");
-    if (etag) {
-      await writeGhEtagEntry(telemetryRoot, {
-        key,
-        request: identity,
-        etag,
-        body: parsed.body,
-        updated_at: new Date().toISOString(),
-      }, { maxBytes: request.cacheMaxBytes });
+  try {
+    let result: RspResidentGithubResult;
+    if (request.residentRead) {
+      result = await request.residentRead(input);
+    } else {
+      const config = resolveRspConfig(cwd, env);
+      const resident = residentElisionStore(cwd, config);
+      try {
+        result = await resident.githubRead(input);
+      } finally {
+        await resident.close();
+      }
     }
-    recordOverhead(0);
-    await recordConditionalTelemetry(telemetryRoot, request.command ?? `gh api ${request.path}`, false);
     return {
       status: result.status,
-      stdout: parsed.body,
+      stdout: result.stdout,
       stderr: result.stderr,
-      etag: etag ?? undefined,
+      quotaFree: result.quotaFree,
+    };
+  } catch (error) {
+    return {
+      status: 75,
+      stdout: "",
+      stderr: JSON.stringify({
+        refused: true,
+        reason: "rsp-github-resident-unavailable",
+        repair: "restore the rsp resident and GitHub credential, then retry",
+        detail: error instanceof Error ? error.message : String(error),
+      }),
       quotaFree: false,
     };
   }
-
-  recordOverhead(0);
-  await recordConditionalTelemetry(telemetryRoot, request.command ?? `gh api ${request.path}`, false);
-  return {
-    status: result.status,
-    stdout: parsed.body || result.stdout,
-    stderr: result.stderr,
-    quotaFree: false,
-  };
 }
 
-function sortedParams(params: GhConditionalRequest["params"]): Array<[string, string | number | boolean]> {
-  return Object.entries(params ?? {})
-    .filter((entry): entry is [string, string | number | boolean] => entry[1] !== undefined)
-    .sort(([a], [b]) => a.localeCompare(b));
+function githubActor(env: NodeJS.ProcessEnv): string {
+  const worker = (env.RED_AFK_GH_ACTOR ?? "").trim();
+  return worker === "" ? "session" : `proxied-agent:${worker}`;
 }
 
-function requestIdentity(path: string, params: GhConditionalRequest["params"]): string {
-  return JSON.stringify({ method: "GET", path, params: sortedParams(params) });
+function inferGithubArgs(path: string): readonly string[] {
+  if (/\/pulls\/[^/]+\/?$/.test(path)) return ["pr", "view"];
+  if (/\/pulls\/?$/.test(path)) return ["pr", "list"];
+  if (/\/issues\/[^/]+\/?$/.test(path)) return ["issue", "view"];
+  if (/\/issues\/?$/.test(path)) return ["issue", "list"];
+  if (/\/actions\/runs\/[^/]+\/?$/.test(path)) return ["run", "view"];
+  if (/\/actions\/runs\/?$/.test(path)) return ["run", "list"];
+  return ["api", path];
 }
 
-function cacheKey(identity: string): string {
-  return createHash("sha256").update(`rsp-gh-etag-v1\0${identity}`).digest("hex");
-}
-
-async function runGh(
-  args: readonly string[],
-  cwd: string,
-  env?: NodeJS.ProcessEnv,
-  signal?: AbortSignal,
-): Promise<{ status: number; stdout: string; stderr: string }> {
-  if (signal?.aborted) return { status: 1, stdout: "", stderr: "gh call cancelled" };
-  return await new Promise((resolveResult) => {
-    let settled = false;
-    const finish = (value: { status: number; stdout: string; stderr: string }) => {
-      if (settled) return;
-      settled = true;
-      signal?.removeEventListener("abort", onAbort);
-      resolveResult(value);
-    };
-    const child = spawn("gh", args, {
+function repositoryIdentity(cwd: string): { owner: string; repo: string } | null {
+  let remote = "";
+  try {
+    remote = String(execFileSync("git", ["config", "--get", "remote.origin.url"], {
       cwd,
-      env: env ? { ...process.env, ...env } : process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    // Cancellation must reclaim the process, not just stop awaiting it: a
-    // detached `gh` that outlives its caller keeps a network socket and a
-    // rate-limit slot for as long as GitHub keeps the connection open.
-    function onAbort(): void {
-      try {
-        child.kill("SIGKILL");
-      } catch {}
-      finish({ status: 1, stdout: "", stderr: "gh call cancelled" });
-    }
-    signal?.addEventListener("abort", onAbort, { once: true });
-    // The wrapped command's own runtime is never rsp's overhead (#2746).
-    const stopChildTimer = startChildProcessTimer();
-    child.once("close", stopChildTimer);
-    child.once("error", stopChildTimer);
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-    child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
-    child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
-    child.once("error", (err) => finish({ status: 1, stdout: "", stderr: err.message }));
-    child.once("close", (status) => {
-      finish({
-        status: status ?? 1,
-        stdout: Buffer.concat(stdout).toString("utf8"),
-        stderr: Buffer.concat(stderr).toString("utf8").trim(),
-      });
-    });
-  });
-}
-
-function parseIncludedResponse(raw: string): { statusCode: number; headers: Map<string, string>; body: string } {
-  const normalized = raw.replace(/\r\n/g, "\n");
-  const matches = [...normalized.matchAll(/^HTTP\/\S+\s+(\d{3})[^\n]*\n/gm)];
-  if (matches.length === 0) return { statusCode: 0, headers: new Map(), body: raw };
-  const last = matches[matches.length - 1]!;
-  const statusCode = Number(last[1]);
-  const headerStart = last.index! + last[0].length;
-  const bodyStart = normalized.indexOf("\n\n", headerStart);
-  const headerText = bodyStart >= 0 ? normalized.slice(headerStart, bodyStart) : normalized.slice(headerStart);
-  const headers = new Map<string, string>();
-  for (const line of headerText.split("\n")) {
-    const separator = line.indexOf(":");
-    if (separator <= 0) continue;
-    headers.set(line.slice(0, separator).trim().toLowerCase(), line.slice(separator + 1).trim());
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })).trim();
+  } catch {
+    return null;
   }
-  return {
-    statusCode,
-    headers,
-    body: bodyStart >= 0 ? normalized.slice(bodyStart + 2) : "",
-  };
-}
-
-async function recordConditionalTelemetry(root: string, command: string, quotaFree: boolean): Promise<void> {
-  await appendTelemetryEvent(root, {
-    collection: RSP_DECISIONS_COLLECTION,
-    id: randomUUID(),
-    created_at: new Date().toISOString(),
-    command,
-    command_family: "gh api",
-    decision: "contributed",
-    reason: quotaFree ? "gh-conditional-304" : "gh-conditional-fetch",
-    quota_free: quotaFree,
-    saved_units: quotaFree ? 1 : 0,
-  });
+  const normalized = remote
+    .replace(/^git@[^:]+:/, "")
+    .replace(/^ssh:\/\/git@[^/]+\//, "")
+    .replace(/^https?:\/\/[^/]+\//, "")
+    .replace(/\.git$/, "")
+    .replace(/^\/+|\/+$/g, "");
+  const parts = normalized.split("/").filter(Boolean);
+  if (parts.length < 2) return null;
+  return { owner: parts[parts.length - 2]!, repo: parts[parts.length - 1]! };
 }

--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -8,6 +8,7 @@ import type {
 } from "./elision-store.js";
 import type { RspAccountingLaneStats } from "./telemetry.js";
 import type { RspTelemetryGainsReport, RspTelemetryStats } from "./telemetry.js";
+import type { RspResidentGithubRead, RspResidentGithubResult } from "./resident-github.js";
 import type { RspResidentConfig, RspResidentRequest } from "./resident-protocol.js";
 import { sendResidentRequest } from "./resident-protocol.js";
 import {
@@ -112,6 +113,16 @@ export class ResidentRspElisionStore {
 
   async memory(action: "recall" | "ingest", payload: unknown): Promise<unknown> {
     return await this.request({ op: "memory", action, payload });
+  }
+
+  async githubRead(input: RspResidentGithubRead): Promise<RspResidentGithubResult> {
+    return await this.request({
+      op: "github-read",
+      args: [...input.args],
+      path: input.path,
+      actor: input.actor,
+      ...(input.params ? { params: { ...input.params } } : {}),
+    }) as RspResidentGithubResult;
   }
 
   async close(): Promise<void> {}

--- a/apps/rsp/src/resident-github.ts
+++ b/apps/rsp/src/resident-github.ts
@@ -82,15 +82,30 @@ function createRspResidentGithubReader(client: GithubClient): RspResidentGithubC
       if (operation.budget === "search") {
         return refusal(operation, "github-search-not-routable", "search reads are never a fallback; narrow the read to a classified object");
       }
-      if (operation.surface !== "rest") {
-        return refusal(
-          operation,
-          "github-graphql-read-not-realized",
-          "use a classified rsp summary whose GraphQL projection is declared",
-        );
-      }
-
       try {
+        if (operation.surface === "graphql") {
+          const plan = graphqlPlan(operation, input);
+          if (!plan) {
+            return refusal(
+              operation,
+              "github-graphql-read-not-realized",
+              "use a classified rsp summary whose GraphQL projection is declared",
+            );
+          }
+          const answer = await client.graphql<Record<string, unknown>>(
+            plan.query,
+            plan.variables,
+            { operation, actor: input.actor },
+          );
+          return {
+            status: 0,
+            stdout: JSON.stringify(plan.decode(answer)),
+            stderr: "",
+            surface: operation.surface,
+            pool: operation.budget,
+            quotaFree: false,
+          };
+        }
         const answer = await client.conditionalRest<unknown>({
           cacheKey: stableCacheKey(input.path, input.params),
           route: `GET /${input.path.replace(/^\/+/, "")}`,
@@ -125,6 +140,119 @@ function createRspResidentGithubReader(client: GithubClient): RspResidentGithubC
       }
     },
   };
+}
+
+interface RspGraphqlPlan {
+  readonly query: string;
+  readonly variables: Readonly<Record<string, unknown>>;
+  readonly decode: (answer: Record<string, unknown>) => unknown;
+}
+
+function graphqlPlan(
+  operation: GithubOperation,
+  input: RspResidentGithubRead,
+): RspGraphqlPlan | null {
+  const owner = stringParam(input.params, "owner");
+  const repo = stringParam(input.params, "repo");
+  if (!owner || !repo) return null;
+  const first = positiveIntParam(input.params, "per_page", 30);
+  const states = [String(input.params?.state ?? "open").toUpperCase()];
+
+  if (operation.key === "issue list") {
+    return {
+      query: `query RspIssueList($owner: String!, $repo: String!, $first: Int!, $states: [IssueState!], $labels: [String!]) {
+        repository(owner: $owner, name: $repo) {
+          issues(first: $first, states: $states, labels: $labels, orderBy: {field: UPDATED_AT, direction: DESC}) {
+            nodes { number title body state url updatedAt author { login } labels(first: 100) { nodes { name } } }
+          }
+        }
+      }`,
+      variables: {
+        owner,
+        repo,
+        first,
+        states,
+        labels: csvParam(input.params, "labels"),
+      },
+      decode: (answer) => connectionNodes(answer, "issues").map((node) => ({
+        number: node.number,
+        title: node.title,
+        body: node.body,
+        state: String(node.state ?? "").toLowerCase(),
+        html_url: node.url,
+        updated_at: node.updatedAt,
+        user: node.author,
+        labels: nestedNodes(node.labels),
+      })),
+    };
+  }
+
+  if (operation.key === "pr list") {
+    return {
+      query: `query RspPrList($owner: String!, $repo: String!, $first: Int!, $states: [PullRequestState!]) {
+        repository(owner: $owner, name: $repo) {
+          pullRequests(first: $first, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}) {
+            nodes { number title body state url updatedAt isDraft author { login } baseRefName headRefName labels(first: 100) { nodes { name } } }
+          }
+        }
+      }`,
+      variables: { owner, repo, first, states },
+      decode: (answer) => connectionNodes(answer, "pullRequests").map((node) => ({
+        number: node.number,
+        title: node.title,
+        body: node.body,
+        state: String(node.state ?? "").toLowerCase(),
+        html_url: node.url,
+        updated_at: node.updatedAt,
+        draft: node.isDraft === true,
+        user: node.author,
+        base: { ref: node.baseRefName },
+        head: { ref: node.headRefName },
+        labels: nestedNodes(node.labels),
+      })),
+    };
+  }
+  return null;
+}
+
+function connectionNodes(answer: Record<string, unknown>, key: string): Record<string, unknown>[] {
+  const repository = record(answer.repository);
+  const connection = record(repository?.[key]);
+  return Array.isArray(connection?.nodes)
+    ? connection.nodes.map(record).filter((node): node is Record<string, unknown> => node !== null)
+    : [];
+}
+
+function nestedNodes(value: unknown): Record<string, unknown>[] {
+  const connection = record(value);
+  return Array.isArray(connection?.nodes)
+    ? connection.nodes.map(record).filter((node): node is Record<string, unknown> => node !== null)
+    : [];
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function stringParam(params: RspResidentGithubRead["params"], key: string): string {
+  const value = params?.[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function positiveIntParam(
+  params: RspResidentGithubRead["params"],
+  key: string,
+  fallback: number,
+): number {
+  const value = Number(params?.[key]);
+  return Number.isSafeInteger(value) && value > 0 ? value : fallback;
+}
+
+function csvParam(params: RspResidentGithubRead["params"], key: string): string[] | null {
+  const value = stringParam(params, key);
+  return value === "" ? null : value.split(",").map((part) => part.trim()).filter(Boolean);
 }
 
 function refusal(operation: GithubOperation, reason: string, repair: string): RspResidentGithubResult {

--- a/apps/rsp/src/resident-github.ts
+++ b/apps/rsp/src/resident-github.ts
@@ -1,0 +1,176 @@
+import { join } from "node:path";
+import {
+  createGithubAttributionLedger,
+  createGithubClient,
+  isGithubRateLimitError,
+  routeGithubArgs,
+  type GithubClient,
+  type GithubOperation,
+  type GithubRequestFetch,
+} from "@reddb-io/github";
+import { rspStateDir } from "@reddb-io/shared/red-paths.js";
+
+export interface RspResidentGithubRead {
+  readonly args: readonly string[];
+  readonly path: string;
+  readonly params?: Readonly<Record<string, string | number | boolean | undefined>>;
+  readonly actor: string;
+}
+
+export interface RspResidentGithubResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly surface: GithubOperation["surface"];
+  readonly pool: GithubOperation["budget"];
+  readonly quotaFree: boolean;
+  readonly refused?: true;
+}
+
+export interface RspResidentGithubClient {
+  read(input: RspResidentGithubRead): Promise<RspResidentGithubResult>;
+}
+
+export interface CreateRspResidentGithubClientOptions {
+  readonly rootDir: string;
+  readonly token: string;
+  readonly baseUrl?: string;
+  readonly fetchImpl?: GithubRequestFetch;
+  readonly retryCount?: number;
+  readonly throttle?: boolean;
+}
+
+/**
+ * The resident-lifetime GitHub read boundary.
+ *
+ * The Octokit client and its in-memory validator store are deliberately created
+ * once here. CLI wrappers are short lived, but the resident survives across
+ * them, so the second unchanged read can earn GitHub's zero-cost 304 response.
+ * The attribution ledger lives below rsp's own state tier; no redskilled path or
+ * process is imported by this module.
+ */
+export function createRspResidentGithubClient(
+  options: CreateRspResidentGithubClientOptions,
+): RspResidentGithubClient {
+  const attribution = createGithubAttributionLedger({
+    path: join(rspStateDir(options.rootDir), "github", "spend.toonl"),
+  });
+  const client = createGithubClient({
+    token: options.token,
+    attribution,
+    ...(options.baseUrl ? { baseUrl: options.baseUrl } : {}),
+    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+    ...(options.retryCount === undefined ? {} : { retryCount: options.retryCount }),
+    ...(options.throttle === undefined ? {} : { throttle: options.throttle }),
+  });
+
+  return createRspResidentGithubReader(client);
+}
+
+function createRspResidentGithubReader(client: GithubClient): RspResidentGithubClient {
+  return {
+    async read(input): Promise<RspResidentGithubResult> {
+      const operation = routeGithubArgs(input.args);
+      if (operation.kind !== "read") {
+        return refusal(operation, "github-write-passthrough", "writes are executed by the original gh command unchanged");
+      }
+      if (input.actor.trim() === "") {
+        return refusal(operation, "github-actor-missing", "retry through rsp so the caller can be attributed");
+      }
+      // Search has its own minute pool. It must never become the escape hatch
+      // when REST or GraphQL is scarce, and rsp has no search fallback at all.
+      if (operation.budget === "search") {
+        return refusal(operation, "github-search-not-routable", "search reads are never a fallback; narrow the read to a classified object");
+      }
+      if (operation.surface !== "rest") {
+        return refusal(
+          operation,
+          "github-graphql-read-not-realized",
+          "use a classified rsp summary whose GraphQL projection is declared",
+        );
+      }
+
+      try {
+        const answer = await client.conditionalRest<unknown>({
+          cacheKey: stableCacheKey(input.path, input.params),
+          route: `GET /${input.path.replace(/^\/+/, "")}`,
+          parameters: definedParams(input.params),
+          operation,
+          actor: input.actor,
+        });
+        return {
+          status: 0,
+          stdout: JSON.stringify(answer.data),
+          stderr: "",
+          surface: operation.surface,
+          pool: operation.budget,
+          quotaFree: answer.quotaFree,
+        };
+      } catch (error) {
+        if (isGithubRateLimitError(error)) {
+          return refusal(
+            operation,
+            "github-budget-refused",
+            "wait for the reported GitHub rate-limit reset, then retry",
+          );
+        }
+        return {
+          status: errorStatus(error),
+          stdout: "",
+          stderr: error instanceof Error ? error.message : String(error),
+          surface: operation.surface,
+          pool: operation.budget,
+          quotaFree: false,
+        };
+      }
+    },
+  };
+}
+
+function refusal(operation: GithubOperation, reason: string, repair: string): RspResidentGithubResult {
+  return {
+    status: 75,
+    stdout: "",
+    stderr: JSON.stringify({
+      refused: true,
+      reason,
+      operation: operation.key,
+      pool: operation.budget,
+      repair,
+    }),
+    surface: operation.surface,
+    pool: operation.budget,
+    quotaFree: false,
+    refused: true,
+  };
+}
+
+function stableCacheKey(
+  path: string,
+  params: RspResidentGithubRead["params"],
+): string {
+  return JSON.stringify({
+    path,
+    params: Object.entries(params ?? {})
+      .filter((entry) => entry[1] !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  });
+}
+
+function definedParams(
+  params: RspResidentGithubRead["params"],
+): Readonly<Record<string, string | number | boolean>> {
+  return Object.fromEntries(
+    Object.entries(params ?? {}).filter(
+      (entry): entry is [string, string | number | boolean] => entry[1] !== undefined,
+    ),
+  );
+}
+
+function errorStatus(error: unknown): number {
+  if (typeof error === "object" && error !== null && "status" in error) {
+    const status = (error as { readonly status?: unknown }).status;
+    if (typeof status === "number" && Number.isInteger(status) && status > 0) return status;
+  }
+  return 1;
+}

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -14,6 +14,10 @@ import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
 import type { RspExpiredHandle, RspElisionRecord } from "./elision-store.js";
 import { RspElisionStore } from "./elision-store.js";
 import { createResidentBrainStore } from "./resident-brain.js";
+import {
+  createRspResidentGithubClient,
+  type RspResidentGithubClient,
+} from "./resident-github.js";
 import type { RspResidentConfig, RspResidentRequest, RspResidentResponse } from "./resident-protocol.js";
 import {
   parseTelemetryEvent,
@@ -50,6 +54,7 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
   let storeState: ResidentStoreState = { kind: "opening", startedAt: process.hrtime.bigint() };
   let telemetryTimer: NodeJS.Timeout | undefined;
   let shuttingDown = false;
+  const github = createLazyResidentGithub(opts.rootDir ?? process.cwd());
 
   const idleMs = opts.idleMs ?? DEFAULT_RSP_IDLE_MS;
   let idleTimer: NodeJS.Timeout | undefined;
@@ -63,7 +68,13 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
     touch();
     handleSocket(socket, async (request, reply) => {
       touch();
-      const value = await handleRequest(storeState, request, opts.storeUri, opts.residentVersion ?? "0.0.0-dev");
+      const value = await handleRequest(
+        storeState,
+        request,
+        opts.storeUri,
+        opts.residentVersion ?? "0.0.0-dev",
+        github,
+      );
       const response: RspResidentResponse = {
         id: request.id,
         ok: true,
@@ -800,6 +811,7 @@ async function handleRequest(
   request: RspResidentRequest,
   storeUri: string,
   residentVersion: string,
+  github: RspResidentGithubClient,
 ): Promise<unknown> {
   if (request.op === "handover") return { handover: true, version: residentVersion, clientVersion: request.clientVersion };
   if (state.kind === "opening") throw new Error("rsp resident store is not ready");
@@ -829,9 +841,34 @@ async function handleRequest(
     };
   }
   if (request.op === "get") return encodeRecord(await store.get(request.handle));
+  if (request.op === "github-read") {
+    return await github.read({
+      args: request.args,
+      path: request.path,
+      actor: request.actor,
+      ...(request.params ? { params: request.params } : {}),
+    });
+  }
   if (request.op === "memory") return await store.memory(request.action, request.payload);
   if (request.op === "brain") return await handleBrainRequest(store, storeUri, request.action, request.payload);
   throw new Error(`unsupported resident op: ${(request as { op?: string }).op ?? "unknown"}`);
+}
+
+function createLazyResidentGithub(rootDir: string): RspResidentGithubClient {
+  let client: RspResidentGithubClient | undefined;
+  return {
+    async read(input) {
+      if (!client) {
+        const token = String(execFileSync("gh", ["auth", "token"], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        })).trim();
+        if (token === "") throw new Error("rsp resident could not obtain a GitHub credential from gh");
+        client = createRspResidentGithubClient({ rootDir, token });
+      }
+      return await client.read(input);
+    },
+  };
 }
 
 async function handleBrainRequest(

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -43,6 +43,8 @@ export interface ResidentServerOptions extends RspResidentConfig {
   registryPath?: string;
   telemetryDrainIntervalMs?: number;
   telemetryDrainTimeoutMs?: number;
+  /** Injected resident-lifetime GitHub client for transport fixtures. */
+  github?: RspResidentGithubClient;
 }
 
 export async function runResidentServer(opts: ResidentServerOptions): Promise<void> {
@@ -54,7 +56,7 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
   let storeState: ResidentStoreState = { kind: "opening", startedAt: process.hrtime.bigint() };
   let telemetryTimer: NodeJS.Timeout | undefined;
   let shuttingDown = false;
-  const github = createLazyResidentGithub(opts.rootDir ?? process.cwd());
+  const github = opts.github ?? createLazyResidentGithub(opts.rootDir ?? process.cwd());
 
   const idleMs = opts.idleMs ?? DEFAULT_RSP_IDLE_MS;
   let idleTimer: NodeJS.Timeout | undefined;

--- a/apps/rsp/tests/gh-conditional.test.ts
+++ b/apps/rsp/tests/gh-conditional.test.ts
@@ -1,65 +1,56 @@
-import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { decode } from "@reddb-io/toon";
+
 import { readGhConditionalJson } from "../src/gh-conditional.js";
-import { telemetrySpoolPath } from "../src/telemetry.js";
+import { createRspResidentGithubClient } from "../src/resident-github.js";
 
 const roots: string[] = [];
-
-async function tempRoot(): Promise<string> {
-  const root = await mkdtemp(join(tmpdir(), "rsp-gh-conditional-"));
-  roots.push(root);
-  await mkdir(join(root, ".red", "state", "rsp"), { recursive: true });
-  return root;
-}
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
 describe("gh conditional requests", () => {
-  it("serves repeated unchanged GETs from a 304-backed cached body and records quota-free telemetry", async () => {
-    const root = await tempRoot();
-    const bin = join(root, "bin");
-    const countFile = join(root, "count");
-    await mkdir(bin, { recursive: true });
-    await writeFile(join(bin, "gh"), [
-      "#!/usr/bin/env bash",
-      "set -euo pipefail",
-      `count_file=${shellQuote(countFile)}`,
-      "count=0",
-      "[ -f \"$count_file\" ] && count=\"$(cat \"$count_file\")\"",
-      "next=$((count + 1))",
-      "printf '%s' \"$next\" > \"$count_file\"",
-      "if printf '%s\\n' \"$@\" | grep -q 'If-None-Match: rsp-test-etag'; then",
-      "  printf 'HTTP/2 304 Not Modified\\r\\netag: rsp-test-etag\\r\\n\\r\\n'",
-      "else",
-      "  printf 'HTTP/2 200 OK\\r\\netag: rsp-test-etag\\r\\n\\r\\n{\"number\":1975,\"state\":\"OPEN\"}\\n'",
-      "fi",
-      "",
-    ].join("\n"), "utf8");
-    await chmod(join(bin, "gh"), 0o755);
+  it("crosses the resident boundary and reuses its 304-backed answer", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rsp-gh-conditional-"));
+    roots.push(root);
+    const seen: Array<{ url: string; etag: string | null }> = [];
+    const github = createRspResidentGithubClient({
+      rootDir: root,
+      token: "fixture-token",
+      baseUrl: "https://github.invalid/api/v3",
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async (input, init) => {
+        const etag = new Headers(init?.headers).get("if-none-match");
+        seen.push({ url: String(input), etag });
+        if (etag === '"issue-v1"') return new Response(null, { status: 304, headers: { etag } });
+        return new Response(JSON.stringify({ number: 1975, state: "OPEN" }), {
+          status: 200,
+          headers: { "content-type": "application/json", etag: '"issue-v1"' },
+        });
+      },
+    });
+    const residentRead = github.read.bind(github);
+    const request = {
+      path: "repos/owner/repo/issues/1975",
+      args: ["issue", "view", "1975"],
+      cwd: root,
+      telemetryRoot: root,
+      residentRead,
+    } as const;
 
-    const env = { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` };
-    const first = await readGhConditionalJson({ path: "repos/owner/repo/issues/1975", cwd: root, telemetryRoot: root, env });
-    const second = await readGhConditionalJson({ path: "repos/owner/repo/issues/1975", cwd: root, telemetryRoot: root, env });
+    const first = await readGhConditionalJson(request);
+    const second = await readGhConditionalJson(request);
 
     expect(first).toMatchObject({ status: 0, quotaFree: false });
     expect(second).toMatchObject({ status: 0, quotaFree: true });
-    expect(second.stdout).toBe("{\"number\":1975,\"state\":\"OPEN\"}\n");
-    expect(await readFile(countFile, "utf8")).toBe("2");
-    // One partition per request key, so a lookup never reads the whole cache (#2745).
-    const partitions = await readdir(join(root, ".red", "state", "rsp", "gh-etag"));
-    expect(partitions).toHaveLength(1);
-    const cacheRaw = await readFile(join(root, ".red", "state", "rsp", "gh-etag", partitions[0]!), "utf8");
-    expect(() => JSON.parse(cacheRaw)).toThrow();
-    expect(decode(cacheRaw)).toMatchObject({ etag: "rsp-test-etag" });
-    await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toContain("quota_free");
+    expect(second.stdout).toBe('{"number":1975,"state":"OPEN"}');
+    expect(seen).toEqual([
+      { url: "https://github.invalid/api/v3/repos/owner/repo/issues/1975", etag: null },
+      { url: "https://github.invalid/api/v3/repos/owner/repo/issues/1975", etag: '"issue-v1"' },
+    ]);
   });
 });
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}

--- a/apps/rsp/tests/resident-github.test.ts
+++ b/apps/rsp/tests/resident-github.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseRecords } from "@reddb-io/toon";
+import { describe, expect, it } from "vitest";
+
+import { createRspResidentGithubClient } from "../src/resident-github.js";
+import { rewriteProxyCommandLine } from "../src/proxy.js";
+
+const ISSUE_ARGS = ["issue", "view", "42"] as const;
+const ISSUE_PATH = "repos/acme/widgets/issues/42";
+
+describe("resident-owned GitHub reads", () => {
+  it("keeps the ETag warm, routes the single object to REST, and attributes both calls", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rsp-resident-github-"));
+    const seen: Array<{ url: string; etag: string | null }> = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = String(input);
+      const etag = new Headers(init?.headers).get("if-none-match");
+      seen.push({ url, etag });
+      if (etag === '"issue-v1"') {
+        return new Response(null, { status: 304, headers: { etag } });
+      }
+      return new Response(JSON.stringify({ number: 42, state: "open" }), {
+        status: 200,
+        headers: { "content-type": "application/json", etag: '"issue-v1"' },
+      });
+    };
+    const github = createRspResidentGithubClient({
+      rootDir: root,
+      token: "fixture-token",
+      baseUrl: "https://github.invalid/api/v3",
+      fetchImpl,
+      retryCount: 0,
+      throttle: false,
+    });
+
+    const first = await github.read({
+      args: ISSUE_ARGS,
+      path: ISSUE_PATH,
+      actor: "session",
+    });
+    const second = await github.read({
+      args: ISSUE_ARGS,
+      path: ISSUE_PATH,
+      actor: "proxied-agent:worker-7",
+    });
+
+    expect(first).toMatchObject({ status: 0, quotaFree: false, surface: "rest" });
+    expect(second).toMatchObject({ status: 0, quotaFree: true, surface: "rest" });
+    expect(seen).toEqual([
+      { url: "https://github.invalid/api/v3/repos/acme/widgets/issues/42", etag: null },
+      { url: "https://github.invalid/api/v3/repos/acme/widgets/issues/42", etag: '"issue-v1"' },
+    ]);
+
+    const ledger = await readFile(join(root, ".red", "state", "rsp", "github", "spend.toonl"), "utf8");
+    expect(parseRecords(ledger)).toMatchObject([
+      { operation_key: "issue view", pool: "rest", actor: "session", cost: 1 },
+      { operation_key: "issue view", pool: "rest", actor: "proxied-agent:worker-7", cost: 0 },
+    ]);
+  });
+
+  it("never turns a classified read into a search fallback", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rsp-resident-github-"));
+    const github = createRspResidentGithubClient({
+      rootDir: root,
+      token: "fixture-token",
+      fetchImpl: async () => new Response("[]", { status: 200, headers: { "content-type": "application/json" } }),
+      retryCount: 0,
+      throttle: false,
+    });
+
+    const result = await github.read({ args: ["issue", "list", "--search", "bug"], path: ISSUE_PATH, actor: "session" });
+    expect(result).toMatchObject({ status: 75, refused: true, pool: "search" });
+    expect(result.stderr).toContain("search reads are never a fallback");
+  });
+
+  it("returns a structured repair when GitHub refuses the budget", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rsp-resident-github-"));
+    const github = createRspResidentGithubClient({
+      rootDir: root,
+      token: "fixture-token",
+      fetchImpl: async () => new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+        status: 403,
+        headers: { "content-type": "application/json", "x-ratelimit-remaining": "0" },
+      }),
+      retryCount: 0,
+      throttle: false,
+    });
+
+    const result = await github.read({ args: ISSUE_ARGS, path: ISSUE_PATH, actor: "session" });
+    expect(result).toMatchObject({ status: 75, refused: true, pool: "rest" });
+    expect(JSON.parse(result.stderr)).toMatchObject({
+      refused: true,
+      reason: "github-budget-refused",
+      repair: "wait for the reported GitHub rate-limit reset, then retry",
+    });
+  });
+});
+
+describe("proxy mutation semantics", () => {
+  it("leaves a write command byte-identical", () => {
+    const command = "gh issue comment 42 --body 'ship it'";
+    expect(rewriteProxyCommandLine(command)).toEqual({ commandLine: command, matches: [] });
+  });
+});

--- a/apps/rsp/tests/resident-github.test.ts
+++ b/apps/rsp/tests/resident-github.test.ts
@@ -75,6 +75,39 @@ describe("resident-owned GitHub reads", () => {
     expect(result.stderr).toContain("search reads are never a fallback");
   });
 
+  it("routes a multi-node listing to GraphQL without falling into search", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rsp-resident-github-"));
+    const seen: string[] = [];
+    const github = createRspResidentGithubClient({
+      rootDir: root,
+      token: "fixture-token",
+      baseUrl: "https://github.invalid/api/v3",
+      fetchImpl: async (input) => {
+        seen.push(String(input));
+        return new Response(JSON.stringify({
+          data: {
+            repository: {
+              issues: { nodes: [{ number: 42, title: "budget", state: "OPEN", labels: { nodes: [] } }] },
+            },
+          },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      },
+      retryCount: 0,
+      throttle: false,
+    });
+
+    const result = await github.read({
+      args: ["issue", "list"],
+      path: "repos/acme/widgets/issues",
+      params: { owner: "acme", repo: "widgets" },
+      actor: "session",
+    });
+
+    expect(result).toMatchObject({ status: 0, surface: "graphql", pool: "graphql" });
+    expect(seen).toEqual(["https://github.invalid/api/graphql"]);
+    expect(JSON.parse(result.stdout)).toMatchObject([{ number: 42, title: "budget", state: "open" }]);
+  });
+
   it("returns a structured repair when GitHub refuses the budget", async () => {
     const root = await mkdtemp(join(tmpdir(), "rsp-resident-github-"));
     const github = createRspResidentGithubClient({

--- a/apps/rsp/tests/resident-github.test.ts
+++ b/apps/rsp/tests/resident-github.test.ts
@@ -1,18 +1,33 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseRecords } from "@reddb-io/toon";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
+import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/config.js";
+import { ResidentRspElisionStore, resolveResidentPaths } from "../src/resident-client.js";
 import { createRspResidentGithubClient } from "../src/resident-github.js";
+import { runResidentServer } from "../src/resident-server.js";
 import { rewriteProxyCommandLine } from "../src/proxy.js";
+import { shutdownResident, waitForResident } from "./telemetry.helpers.js";
 
 const ISSUE_ARGS = ["issue", "view", "42"] as const;
 const ISSUE_PATH = "repos/acme/widgets/issues/42";
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-resident-github-"));
+  roots.push(root);
+  return root;
+}
 
 describe("resident-owned GitHub reads", () => {
   it("keeps the ETag warm, routes the single object to REST, and attributes both calls", async () => {
-    const root = await mkdtemp(join(tmpdir(), "rsp-resident-github-"));
+    const root = await tempRoot();
     const seen: Array<{ url: string; etag: string | null }> = [];
     const fetchImpl: typeof fetch = async (input, init) => {
       const url = String(input);
@@ -61,7 +76,7 @@ describe("resident-owned GitHub reads", () => {
   });
 
   it("never turns a classified read into a search fallback", async () => {
-    const root = await mkdtemp(join(tmpdir(), "rsp-resident-github-"));
+    const root = await tempRoot();
     const github = createRspResidentGithubClient({
       rootDir: root,
       token: "fixture-token",
@@ -76,7 +91,7 @@ describe("resident-owned GitHub reads", () => {
   });
 
   it("routes a multi-node listing to GraphQL without falling into search", async () => {
-    const root = await mkdtemp(join(tmpdir(), "rsp-resident-github-"));
+    const root = await tempRoot();
     const seen: string[] = [];
     const github = createRspResidentGithubClient({
       rootDir: root,
@@ -109,7 +124,7 @@ describe("resident-owned GitHub reads", () => {
   });
 
   it("returns a structured repair when GitHub refuses the budget", async () => {
-    const root = await mkdtemp(join(tmpdir(), "rsp-resident-github-"));
+    const root = await tempRoot();
     const github = createRspResidentGithubClient({
       rootDir: root,
       token: "fixture-token",
@@ -129,6 +144,50 @@ describe("resident-owned GitHub reads", () => {
       repair: "wait for the reported GitHub rate-limit reset, then retry",
     });
   });
+
+  it("serves separate clients through one resident-lifetime ETag store", async () => {
+    const root = await tempRoot();
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const github = createRspResidentGithubClient({
+      rootDir: root,
+      token: "fixture-token",
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async (_input, init) => {
+        const etag = new Headers(init?.headers).get("if-none-match");
+        return etag === '"wire-v1"'
+          ? new Response(null, { status: 304, headers: { etag } })
+          : new Response('{"number":42}', {
+              status: 200,
+              headers: { "content-type": "application/json", etag: '"wire-v1"' },
+            });
+      },
+    });
+    const server = runResidentServer({
+      socketPath: paths.socketPath,
+      rootDir: paths.rootDir,
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      idleMs: 30_000,
+      github,
+    });
+    await waitForResident(paths.socketPath, 20_000);
+    const config = { storeUri, ttlDays: DEFAULT_RSP_TTL_DAYS, byteBudget: DEFAULT_RSP_BYTE_BUDGET };
+
+    try {
+      const firstClient = new ResidentRspElisionStore(paths, config, { ensureResident: false });
+      const secondClient = new ResidentRspElisionStore(paths, config, { ensureResident: false });
+      const first = await firstClient.githubRead({ args: ISSUE_ARGS, path: ISSUE_PATH, actor: "session" });
+      const second = await secondClient.githubRead({ args: ISSUE_ARGS, path: ISSUE_PATH, actor: "session" });
+      expect(first.quotaFree).toBe(false);
+      expect(second.quotaFree).toBe(true);
+    } finally {
+      await shutdownResident(paths.socketPath);
+      await server;
+    }
+  }, 60_000);
 });
 
 describe("proxy mutation semantics", () => {

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -69,7 +69,16 @@ export interface GithubPaginatedRestAnswer<T> extends GithubRestAnswer<readonly 
 export interface GithubClient {
   conditionalRest<T>(request: GithubConditionalRestRequest): Promise<GithubRestAnswer<T>>;
   conditionalPaginate<T>(request: GithubConditionalRestRequest): Promise<GithubPaginatedRestAnswer<T>>;
-  graphql<T>(query: string, variables?: Readonly<Record<string, unknown>>): Promise<T>;
+  graphql<T>(
+    query: string,
+    variables?: Readonly<Record<string, unknown>>,
+    attribution?: GithubGraphqlAttribution,
+  ): Promise<T>;
+}
+
+export interface GithubGraphqlAttribution {
+  readonly operation: GithubAttributedOperation;
+  readonly actor?: string;
 }
 
 export interface CreateGithubClientOptions {
@@ -196,9 +205,24 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
       return { data, headers, requestCount, quotaFree };
     },
 
-    async graphql<T>(query: string, variables: Readonly<Record<string, unknown>> = {}): Promise<T> {
+    async graphql<T>(
+      query: string,
+      variables: Readonly<Record<string, unknown>> = {},
+      attribution?: GithubGraphqlAttribution,
+    ): Promise<T> {
       try {
-        return await octokit.graphql(query, variables) as T;
+        const answer = await octokit.graphql(query, variables) as T;
+        if (attribution) {
+          // Generic GraphQL does not expose the response's point cost. One is
+          // the minimum observed spend; callers with a rateLimit.cost field can
+          // replace this with the exact transport observation later.
+          await options.attribution?.record({
+            operation: attribution.operation,
+            cost: 1,
+            actor: attribution.actor,
+          });
+        }
+        return answer;
       } catch (error) {
         if (httpStatus(error) === 401) throw new GithubCredentialError({ cause: error });
         throw error;

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -46,6 +46,8 @@ export interface GithubConditionalRestRequest {
   readonly parameters?: Readonly<Record<string, unknown>>;
   /** Durable spend attribution for this call. */
   readonly operation: GithubAttributedOperation;
+  /** Named caller for durable spend attribution when several clients share one transport. */
+  readonly actor?: string;
 }
 
 /**
@@ -55,6 +57,8 @@ export interface GithubConditionalRestRequest {
 export interface GithubRestAnswer<T> {
   readonly data: T;
   readonly headers: GithubResponseHeaders;
+  /** True when a 304 reused the held answer and consumed no REST request budget. */
+  readonly quotaFree: boolean;
 }
 
 export interface GithubPaginatedRestAnswer<T> extends GithubRestAnswer<readonly T[]> {
@@ -142,8 +146,8 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         const headers = response.headers as GithubResponseHeaders;
         const etag = header(headers, "etag");
         if (etag !== undefined) etags.set(input.cacheKey, { etag, data: response.data, headers });
-        await options.attribution?.record({ operation: input.operation, cost: 1 });
-        return { data: response.data as T, headers };
+        await options.attribution?.record({ operation: input.operation, cost: 1, actor: input.actor });
+        return { data: response.data as T, headers, quotaFree: false };
       } catch (error) {
         if (httpStatus(error) === 304) {
           if (held === undefined) {
@@ -156,8 +160,8 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
           const headers = { ...held.headers, ...responseHeaders };
           const etag = header(headers, "etag") ?? held.etag;
           etags.set(input.cacheKey, { etag, data: held.data, headers });
-          await options.attribution?.record({ operation: input.operation, cost: 0 });
-          return { data: held.data as T, headers };
+          await options.attribution?.record({ operation: input.operation, cost: 0, actor: input.actor });
+          return { data: held.data as T, headers, quotaFree: true };
         }
         if (httpStatus(error) === 401) throw new GithubCredentialError({ cause: error });
         throw error;
@@ -171,6 +175,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
       const data: T[] = [];
       let headers: GithubResponseHeaders = {};
       let requestCount = 0;
+      let quotaFree = true;
       let page = 1;
       for (;;) {
         const answer = await conditionalRest<unknown>({
@@ -179,6 +184,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
           parameters: { ...(input.parameters ?? {}), per_page: 100, page },
         });
         requestCount += 1;
+        quotaFree = quotaFree && answer.quotaFree;
         if (!Array.isArray(answer.data)) {
           throw new Error(`GitHub returned a non-list body for ${JSON.stringify(input.cacheKey)} page ${page}`);
         }
@@ -187,7 +193,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         if (!hasNextPage(answer.headers)) break;
         page += 1;
       }
-      return { data, headers, requestCount };
+      return { data, headers, requestCount, quotaFree };
     },
 
     async graphql<T>(query: string, variables: Readonly<Record<string, unknown>> = {}): Promise<T> {

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -53,6 +53,7 @@ export {
   type GithubConditionalRestRequest,
   type GithubEtagEntry,
   type GithubEtagStore,
+  type GithubGraphqlAttribution,
   type GithubRequestFetch,
   type GithubPaginatedRestAnswer,
   type GithubResponseHeaders,

--- a/packages/shared/resident-protocol.ts
+++ b/packages/shared/resident-protocol.ts
@@ -25,6 +25,14 @@ export type RspResidentRequest =
   | { id: string; op: "telemetry-gains"; sinceDays: number }
   | { id: string; op: "mint"; original: string; meta: unknown }
   | { id: string; op: "get"; handle: string }
+  | {
+      id: string;
+      op: "github-read";
+      args: string[];
+      path: string;
+      params?: Record<string, string | number | boolean | undefined>;
+      actor: string;
+    }
   | { id: string; op: "memory"; action: "recall" | "ingest"; payload: unknown }
   | { id: string; op: "brain"; action: BrainResidentAction; payload?: unknown };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,9 @@ importers:
       '@reddb-io/build-info':
         specifier: workspace:*
         version: link:../../packages/build-info
+      '@reddb-io/github':
+        specifier: workspace:*
+        version: link:../../packages/github
       '@reddb-io/red-castle':
         specifier: workspace:*
         version: link:../../packages/red-castle


### PR DESCRIPTION
Automated AFK landing for #3311. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3311

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788499939&installation_model_id=20659&pr_number=3319&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3319&signature=e32b478b8a1989dfd4ec118bd3e384f19971f5adaf0fea0167b7807490b1ed97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->