### PR TITLE
fix: #3209 Diversion is all-or-nothing, so the healthy pool stays idle until the other one is already spent

### DIFF
--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -143,6 +143,28 @@ So semi-offline stops being a mode discovered through a 403 and becomes a postur
 entered at a threshold an operator can see. `buildGithubBalanceReport` is what
 they see it on.
 
+## Routing is graduated too
+
+`githubDiversionDecision` gives the same balance a second axis: which declared
+surface should answer an eligible read. Below 70% source pressure the preferred
+surface decides alone. At 70% and 90%, progressively larger budget shares can
+move to the fallback; a spent preferred pool moves every eligible read. Each
+entry threshold has a lower exit threshold so small balance changes do not
+bounce a route between surfaces and cool both caches.
+
+Pressure alone does not arm the ramp. The observed spend must project exhaustion
+before the pool's hourly reset, so a pool with 7% left and twenty seconds to wait
+does not burn its healthy peer merely to avoid that wait. An unread source or
+destination balance diverts nothing, and a table entry with no fallback remains
+on its only surface.
+
+Partial diversion is denominated in destination budget, not call count. A read
+projected to cost five paginated REST requests receives one fifth the call share
+of a one-request fallback at the same rung. Selection uses a stable hash of the
+operation and concrete routing key, making identical decisions replayable rather
+than random. Full diversion is the exception to cost weighting: once the source
+is spent, its declared fallback is the only available route.
+
 ## A cache that carries its own age
 
 `createGithubCache` keeps counts, bodies and states, and every read comes back

--- a/packages/github/balance.test.ts
+++ b/packages/github/balance.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   GITHUB_BALANCE_CADENCE,
+  GITHUB_DIVERSION_BANDS,
   GITHUB_BALANCE_MIN_CADENCE_MS,
   GITHUB_RATE_LIMIT_ARGV,
   GITHUB_RESERVED_FRACTION,
@@ -11,6 +12,7 @@ import {
   fetchGithubBalance,
   githubBalanceCadenceMs,
   githubBalancePosture,
+  githubDiversionDecision,
   parseGithubBalance,
   unaskedGithubBalance,
 } from "./balance.js";
@@ -216,6 +218,84 @@ describe("the reserved band refuses convenience, never the claim", () => {
     expect(listing.admitted).toBe(true);
     expect(view.pool).toBe("rest");
     expect(view.admitted).toBe(true);
+  });
+});
+
+describe("graduated routing spends the fallback before the preferred pool is spent", () => {
+  const operation = routeGithubArgs(["label", "list"]);
+  const decision = (over: {
+    readonly graphqlRemaining?: number;
+    readonly restRemaining?: number;
+    readonly resetInMs?: number;
+    readonly projectedDestinationCost?: number;
+    readonly routingKey?: string;
+    readonly previousBand?: "none" | "low" | "high" | "full";
+  } = {}) => {
+    const now = Date.parse(ASKED_AT);
+    return githubDiversionDecision({
+      balance: parseGithubBalance(payload({
+        core: [5000, over.restRemaining ?? 5000],
+        graphql: [5000, over.graphqlRemaining ?? 500],
+        resetAt: Math.floor((now + (over.resetInMs ?? 55 * 60_000)) / 1000),
+      }), { askedAt: ASKED_AT }),
+      operation,
+      now: ASKED_AT,
+      projectedDestinationCost: over.projectedDestinationCost ?? 1,
+      routingKey: over.routingKey ?? "label list:acme/widgets",
+      ...(over.previousBand === undefined ? {} : { previousBand: over.previousBand }),
+    });
+  };
+
+  it("gates high raw pressure on projected exhaustion before reset", () => {
+    expect(decision({ resetInMs: 20_000 }).band).toBe("none");
+    expect(decision({ resetInMs: 55 * 60_000 }).band).toBe("high");
+  });
+
+  it("denominates a partial ramp in projected destination budget", () => {
+    const oneRestRequest = decision({ projectedDestinationCost: 1 });
+    const fiveRestPages = decision({ projectedDestinationCost: 5 });
+
+    expect(oneRestRequest.diversion_share).toBe(GITHUB_DIVERSION_BANDS.high.budget_share);
+    expect(fiveRestPages.diversion_share).toBeCloseTo(oneRestRequest.diversion_share / 5, 8);
+    expect(fiveRestPages.projected_destination_cost).toBe(5);
+  });
+
+  it("is deterministic and uses an exit band below the entry threshold", () => {
+    const first = decision();
+    expect(decision()).toEqual(first);
+
+    const belowEntry = decision({ graphqlRemaining: 1600, previousBand: "low" });
+    expect(belowEntry.source_pressure).toBeCloseTo(0.68, 8);
+    expect(belowEntry.band).toBe("low");
+  });
+
+  it("fully diverts a spent preferred pool regardless of pagination cost", () => {
+    const spent = decision({ graphqlRemaining: 0, projectedDestinationCost: 20 });
+
+    expect(spent.band).toBe("full");
+    expect(spent.diversion_share).toBe(1);
+    expect(spent.diverted).toBe(true);
+    expect(spent.surface).toBe("rest");
+  });
+
+  it("never treats an unread destination ledger as a free pool", () => {
+    const balance = parseGithubBalance({
+      resources: {
+        graphql: { limit: 5000, remaining: 0, used: 5000, reset: Date.parse(ASKED_AT) / 1000 + 3600 },
+      },
+    }, { askedAt: ASKED_AT });
+    const result = githubDiversionDecision({
+      balance,
+      operation,
+      now: ASKED_AT,
+      projectedDestinationCost: 1,
+      routingKey: "label list:acme/widgets",
+    });
+
+    expect(result.band).toBe("none");
+    expect(result.diverted).toBe(false);
+    expect(result.surface).toBe("graphql");
+    expect(result.reason).toContain("unknown");
   });
 });
 

--- a/packages/github/balance.test.ts
+++ b/packages/github/balance.test.ts
@@ -267,6 +267,9 @@ describe("graduated routing spends the fallback before the preferred pool is spe
     const belowEntry = decision({ graphqlRemaining: 1600, previousBand: "low" });
     expect(belowEntry.source_pressure).toBeCloseTo(0.68, 8);
     expect(belowEntry.band).toBe("low");
+
+    expect(decision({ graphqlRemaining: 550, previousBand: "high" }).band).toBe("high");
+    expect(decision({ graphqlRemaining: 50, previousBand: "full" }).band).toBe("full");
   });
 
   it("fully diverts a spent preferred pool regardless of pagination cost", () => {

--- a/packages/github/balance.ts
+++ b/packages/github/balance.ts
@@ -670,12 +670,12 @@ function projectsExhaustionBeforeReset(pool: GithubPoolBalance, now: string): bo
 
 function diversionBand(pressure: number, previous: GithubDiversionBand | undefined): GithubDiversionBand {
   if (pressure >= GITHUB_DIVERSION_BANDS.full.enter_pressure) return "full";
+  if (previous === "full" && pressure >= GITHUB_DIVERSION_BANDS.full.leave_pressure) return "full";
   if (pressure >= GITHUB_DIVERSION_BANDS.high.enter_pressure) return "high";
-  if (pressure >= GITHUB_DIVERSION_BANDS.low.enter_pressure) return "low";
-
   if (previous === "full" || previous === "high") {
     if (pressure >= GITHUB_DIVERSION_BANDS.high.leave_pressure) return "high";
   }
+  if (pressure >= GITHUB_DIVERSION_BANDS.low.enter_pressure) return "low";
   if (previous !== undefined && previous !== "none") {
     if (pressure >= GITHUB_DIVERSION_BANDS.low.leave_pressure) return "low";
   }

--- a/packages/github/balance.ts
+++ b/packages/github/balance.ts
@@ -47,7 +47,7 @@
 // PURE, apart from `fetchGithubBalance` and `createGithubBalanceTransport`, whose
 // transport is injected.
 
-import type { GithubOperation, GithubRateBudget } from "./surface.js";
+import type { GithubApiSurface, GithubOperation, GithubRateBudget } from "./surface.js";
 
 /**
  * The gh argv this ask is equivalent to: `gh api rate_limit`.
@@ -227,6 +227,60 @@ export type GithubBalancePosture = "open" | "reserved" | "spent" | "unknown";
  * - `convenience` — a read that can be answered from cache, later, or not at all.
  */
 export type GithubCallCriticality = "essential" | "convenience";
+
+/** One stable rung of the preferred-to-fallback routing ramp. */
+export type GithubDiversionBand = "none" | "low" | "high" | "full";
+
+export interface GithubDiversionBandDefinition {
+  /** Source-pool pressure that enters this rung. */
+  readonly enter_pressure: number;
+  /** Lower pressure that must be crossed before leaving this rung. */
+  readonly leave_pressure: number;
+  /** Destination-budget share to spend before pricing the operation itself. */
+  readonly budget_share: number;
+}
+
+/**
+ * The routing ramp, expressed as budget shares rather than call shares.
+ *
+ * Entry and exit differ deliberately. A balance moving around 70% or 90% must
+ * not alternate surfaces on every ask and discard both surfaces' warm caches.
+ */
+export const GITHUB_DIVERSION_BANDS: Readonly<Record<GithubDiversionBand, GithubDiversionBandDefinition>> = {
+  none: { enter_pressure: 0, leave_pressure: 0, budget_share: 0 },
+  low: { enter_pressure: 0.7, leave_pressure: 0.65, budget_share: 0.25 },
+  high: { enter_pressure: 0.9, leave_pressure: 0.85, budget_share: 0.6 },
+  full: { enter_pressure: 1, leave_pressure: 0.98, budget_share: 1 },
+};
+
+/** GitHub's REST and GraphQL primary pools both reset on an hourly window. */
+const GITHUB_PRIMARY_RATE_WINDOW_MS = 60 * 60_000;
+
+export interface GithubDiversionInput {
+  readonly balance: GithubBalance | null;
+  readonly operation: GithubOperation;
+  /** The decision instant, explicit so replaying a Worker is deterministic. */
+  readonly now: string;
+  /** Stable identity of the concrete read, such as operation + repository. */
+  readonly routingKey: string;
+  /** Number of fallback-pool units this read is projected to consume. */
+  readonly projectedDestinationCost: number;
+  /** Last rung observed for this route, when a caller retains hysteresis state. */
+  readonly previousBand?: GithubDiversionBand;
+}
+
+export interface GithubDiversionDecision {
+  readonly surface: GithubApiSurface;
+  readonly preferred: GithubApiSurface;
+  readonly fallback: GithubApiSurface | null;
+  readonly diverted: boolean;
+  readonly band: GithubDiversionBand;
+  readonly source_pressure: number | null;
+  /** Call share after the destination cost has priced the budget share. */
+  readonly diversion_share: number;
+  readonly projected_destination_cost: number;
+  readonly reason: string;
+}
 
 /** One admission verdict, with everything an operator needs to argue with it. */
 export interface GithubAdmission {
@@ -489,6 +543,153 @@ export function admitGithubOperation(input: {
     criticality: input.criticality,
     ...(input.reservedFraction === undefined ? {} : { reservedFraction: input.reservedFraction }),
   });
+}
+
+/**
+ * Choose between a read's preferred surface and its declared fallback. PURE.
+ *
+ * Raw source pressure only opens a rung when the observed burn rate projects
+ * exhaustion before reset. A nearly-spent pool twenty seconds from reset
+ * therefore stays preferred, while the same balance early in its window starts
+ * spending the idle fallback. Partial rungs are priced in destination budget:
+ * a five-page REST collection gets one fifth the call share of a one-page read.
+ */
+export function githubDiversionDecision(input: GithubDiversionInput): GithubDiversionDecision {
+  const preferred = input.operation.surface;
+  const fallback = input.operation.fallback ?? null;
+  const base = {
+    preferred,
+    fallback,
+    projected_destination_cost: input.projectedDestinationCost,
+  } as const;
+  const stay = (
+    reason: string,
+    sourcePressure: number | null = null,
+  ): GithubDiversionDecision => ({
+    ...base,
+    surface: preferred,
+    diverted: false,
+    band: "none",
+    source_pressure: sourcePressure,
+    diversion_share: 0,
+    reason,
+  });
+
+  if (fallback == null) {
+    return stay(
+      `${input.operation.key} has no fallback surface, so balance cannot divert it`,
+    );
+  }
+  if (input.operation.kind !== "read" || input.operation.budget === "search") {
+    return stay(`${input.operation.key} is not eligible for diverted read traffic`);
+  }
+
+  const destinationPoolName = budgetForSurface(fallback);
+  const source = input.balance?.pools[input.operation.budget] ?? null;
+  const destination = input.balance?.pools[destinationPoolName] ?? null;
+  if (source == null || destination == null) {
+    return stay(
+      `the ${source == null ? input.operation.budget : destinationPoolName} pool is unknown; an unread ledger is not evidence of a free fallback`,
+    );
+  }
+
+  const sourcePressure = pressureOf(source);
+  if (!Number.isFinite(input.projectedDestinationCost) || input.projectedDestinationCost <= 0) {
+    return stay("the projected destination cost is not a positive finite budget amount", sourcePressure);
+  }
+  if (destination.remaining < input.projectedDestinationCost) {
+    return stay(
+      `the ${destinationPoolName} fallback has ${destination.remaining} left, below this read's projected cost of ${input.projectedDestinationCost}`,
+      sourcePressure,
+    );
+  }
+  if (pressureOf(destination) >= sourcePressure) {
+    return stay(
+      `the ${destinationPoolName} fallback is not healthier than the ${input.operation.budget} preferred pool`,
+      sourcePressure,
+    );
+  }
+
+  const spent = source.remaining <= 0 || sourcePressure >= 1;
+  if (!spent && !projectsExhaustionBeforeReset(source, input.now)) {
+    return stay(
+      `the ${input.operation.budget} pool does not project exhaustion before its reset at ${source.reset_at}`,
+      sourcePressure,
+    );
+  }
+
+  const band = diversionBand(sourcePressure, input.previousBand);
+  if (band === "none") {
+    return stay(
+      `the ${input.operation.budget} pool is below the first diversion entry band`,
+      sourcePressure,
+    );
+  }
+
+  const budgetShare = GITHUB_DIVERSION_BANDS[band].budget_share;
+  const diversionShare = band === "full"
+    ? 1
+    : Math.min(1, budgetShare / input.projectedDestinationCost);
+  const bucket = stableDiversionBucket(`${input.operation.key}\u0000${input.routingKey}`);
+  const diverted = bucket < diversionShare;
+  return {
+    ...base,
+    surface: diverted ? fallback : preferred,
+    diverted,
+    band,
+    source_pressure: sourcePressure,
+    diversion_share: diversionShare,
+    reason:
+      `${input.operation.budget} pressure ${sourcePressure.toFixed(3)} entered the ${band} ramp; ` +
+      `${input.projectedDestinationCost} projected ${destinationPoolName} budget unit(s) price ` +
+      `the ${budgetShare.toFixed(2)} budget share as a ${diversionShare.toFixed(3)} call share; ` +
+      `stable bucket ${bucket.toFixed(3)} ${diverted ? "selects" : "does not select"} the fallback`,
+  };
+}
+
+function budgetForSurface(surface: GithubApiSurface): GithubRateBudget {
+  return surface;
+}
+
+function pressureOf(pool: GithubPoolBalance): number {
+  if (pool.limit <= 0) return pool.remaining <= 0 ? 1 : 0;
+  return Math.max(0, Math.min(1, pool.used / pool.limit));
+}
+
+function projectsExhaustionBeforeReset(pool: GithubPoolBalance, now: string): boolean {
+  if (pool.remaining <= 0) return true;
+  if (pool.used <= 0) return false;
+  const nowMs = Date.parse(now);
+  const resetMs = Date.parse(pool.reset_at);
+  if (!Number.isFinite(nowMs) || !Number.isFinite(resetMs) || resetMs <= nowMs) return false;
+  const untilResetMs = Math.min(GITHUB_PRIMARY_RATE_WINDOW_MS, resetMs - nowMs);
+  const elapsedMs = Math.max(1, GITHUB_PRIMARY_RATE_WINDOW_MS - untilResetMs);
+  const projectedAdditionalSpend = (pool.used / elapsedMs) * untilResetMs;
+  return projectedAdditionalSpend >= pool.remaining;
+}
+
+function diversionBand(pressure: number, previous: GithubDiversionBand | undefined): GithubDiversionBand {
+  if (pressure >= GITHUB_DIVERSION_BANDS.full.enter_pressure) return "full";
+  if (pressure >= GITHUB_DIVERSION_BANDS.high.enter_pressure) return "high";
+  if (pressure >= GITHUB_DIVERSION_BANDS.low.enter_pressure) return "low";
+
+  if (previous === "full" || previous === "high") {
+    if (pressure >= GITHUB_DIVERSION_BANDS.high.leave_pressure) return "high";
+  }
+  if (previous !== undefined && previous !== "none") {
+    if (pressure >= GITHUB_DIVERSION_BANDS.low.leave_pressure) return "low";
+  }
+  return "none";
+}
+
+/** FNV-1a mapped to [0, 1), stable across processes and JavaScript runtimes. */
+function stableDiversionBucket(key: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < key.length; index += 1) {
+    hash ^= key.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0) / 0x1_0000_0000;
 }
 
 /**

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -63,6 +63,7 @@ export {
 
 export {
   GITHUB_BALANCE_CADENCE,
+  GITHUB_DIVERSION_BANDS,
   GITHUB_BALANCE_MIN_CADENCE_MS,
   GITHUB_BALANCE_STALENESS_FACTOR,
   GITHUB_POOLS,
@@ -78,6 +79,7 @@ export {
   fetchGithubBalance,
   githubBalanceCadenceMs,
   githubBalancePosture,
+  githubDiversionDecision,
   githubReservedFloor,
   isGithubBalanceReport,
   parseGithubBalance,
@@ -92,6 +94,10 @@ export {
   type GithubBalanceReport,
   type GithubBalanceTransport,
   type GithubCallCriticality,
+  type GithubDiversionBand,
+  type GithubDiversionBandDefinition,
+  type GithubDiversionDecision,
+  type GithubDiversionInput,
   type GithubPoolBalance,
 } from "./balance.js";
 


### PR DESCRIPTION
Automated AFK landing for #3209. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3209

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788507377&installation_model_id=20659&pr_number=3321&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3321&signature=d5d8a146b2d980ce3e6723d97af3b1bd1560144a83cb5162330c4af4866b93fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->