### PR TITLE
fix: #3266 Contract phase: the deprecation aliases go, and the extinct-names guard keeps the old verbs from returning

### DIFF
--- a/apps/dev/src/core/codex-monitor-agent.ts
+++ b/apps/dev/src/core/codex-monitor-agent.ts
@@ -68,7 +68,6 @@ export function renderCodexMonitorAgentPrompt(options: CodexMonitorAgentPromptOp
     "",
     "Loop:",
     `1. Every ${intervalSeconds} seconds, read live state from the castle MCP: call the castle \`status\` tool with \`scope: worker\` for normalized worker state, vitals, and monitor inputs.`,
-    "   The castle `monitor` tool and `worker_vitals` remain answering deprecation aliases for that scoped status read; treat them as compatibility surface, not the primary route.",
     "2. When the castle MCP is not reachable from this host, say so once, then use the no-MCP fallback from the project root:",
     `   ${monitorCommand}`,
     "3. Report a concise progress update when live worker state changes, when a worker becomes stale/wedged, or at least every five minutes.",

--- a/apps/dev/src/core/extinct-source-guard.ts
+++ b/apps/dev/src/core/extinct-source-guard.ts
@@ -46,7 +46,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 
 /** The noun an extinct source belonged to. */
-export type ExtinctNoun = "fleet" | "attempt" | "supervisor";
+export type ExtinctNoun = "fleet" | "attempt" | "supervisor" | "alias";
 
 /** One artifact ADR 0130 removed, with the route that replaced it. */
 export interface ExtinctSource {
@@ -69,6 +69,15 @@ export interface ExtinctSource {
  * work selector outlived the fleet that owned it).
  */
 export const EXTINCT_SOURCES: readonly ExtinctSource[] = [
+  {
+    id: "deprecated-status-alias",
+    noun: "alias",
+    what: "an expired status reader published as a separate MCP verb",
+    replacement:
+      "the consolidated `status { scope: worker | project | host }` intent read (ADR 0134)",
+    pattern:
+      /\bname\s*:\s*["'](?:worker_status|worker_vitals|monitor|host_state|host_dashboard|host_provision_check|host_unit_status)["']/,
+  },
   {
     id: "fleet-registry",
     noun: "fleet",

--- a/apps/dev/tests/castle-mcp-client-docs.test.ts
+++ b/apps/dev/tests/castle-mcp-client-docs.test.ts
@@ -74,7 +74,7 @@ describe("castle MCP client docs contract", () => {
     expect(skill).toContain("`worker_dispatch`");
   });
 
-  it("routes the fleet and observability verbs through the project tools", async () => {
+  it("routes fleet and observability reads through the intent surface", async () => {
     const [fleet, monitor] = await Promise.all([
       readRepoFile(`${AFK}/fleet.md`),
       readRepoFile(`${AFK}/monitor.md`),
@@ -83,9 +83,12 @@ describe("castle MCP client docs contract", () => {
     for (const tool of ["project_start", "status", "project_resize", "project_reset", "project_stop", "logs"]) {
       expect(fleet, `fleet.md should route through ${tool}`).toContain(`\`${tool}\``);
     }
-    for (const tool of ["monitor", "worker_vitals", "queue_status"]) {
+    for (const tool of ["status", "queue_status"]) {
       expect(monitor, `monitor.md should route through ${tool}`).toContain(`\`${tool}\``);
     }
+    expect(monitor).not.toContain("`worker_status`");
+    expect(monitor).not.toContain("`worker_vitals`");
+    expect(monitor).not.toContain("castle `monitor` tool");
   });
 
   it("makes every castle-verb skill an MCP-first client of its tools", async () => {

--- a/apps/dev/tests/castle-mcp-output-contracts.test.ts
+++ b/apps/dev/tests/castle-mcp-output-contracts.test.ts
@@ -142,19 +142,21 @@ describe("dev:afk observability output contracts", () => {
     ]);
   });
 
-  it("keeps a worker_vitals `fields` projection callable through the contract", async () => {
+  it("keeps a worker fields projection callable through scoped status", async () => {
     const root = await fixtureRoot();
     const tools = createCastleMcpTools(createCastleMcpDependencies(root));
-    const workerVitals = tools.find((tool) => tool.name === "worker_vitals")!;
+    const status = tools.find((tool) => tool.name === "status")!;
 
     // A caller-requested projection is a deliberate narrowing of the declared
     // shape — the contract must not turn that supported input into an error.
     await expect(
-      workerVitals.invoke({ live_only: true, fields: ["live", "liveness"] }),
+      status.invoke({
+        scope: "worker",
+        live_only: true,
+        fields: ["live", "liveness"],
+      }),
     ).resolves.toMatchObject({
-      deprecated: true,
-      replacement: { tool: "status", args: { scope: "worker" } },
-      result: [{ live: true, liveness: "active" }],
+      vitals: [{ live: true, liveness: "active" }],
     });
   });
 

--- a/apps/dev/tests/codex-monitor-agent.test.ts
+++ b/apps/dev/tests/codex-monitor-agent.test.ts
@@ -71,8 +71,10 @@ describe("codex monitor agent prompt", () => {
     expect(prompt).toContain("Project root: /repo");
     expect(prompt).toContain("AFK launch mode: fleet");
     expect(prompt).toContain("Every 10 seconds");
-    expect(prompt).toContain("castle `monitor` tool");
-    expect(prompt).toContain("`worker_vitals`");
+    expect(prompt).toContain("castle `status` tool");
+    expect(prompt).toContain("`scope: worker`");
+    expect(prompt).not.toContain("castle `monitor` tool");
+    expect(prompt).not.toContain("`worker_vitals`");
     expect(prompt).toContain("no-MCP fallback");
     expect(prompt).toContain("env RED_AFK_RUNNER=codex red-skills-dev monitor --once");
     expect(prompt).not.toContain(`${"r"}${"t"}${"k"} `);

--- a/apps/dev/tests/extinct-source-guard.test.ts
+++ b/apps/dev/tests/extinct-source-guard.test.ts
@@ -113,6 +113,28 @@ describe("the live tree carries no fleet or attempt source (#2795)", () => {
 });
 
 describe("a newly added source fails, naming the offending location (#2795)", () => {
+  it("rejects reintroducing an expired status alias as an MCP tool", () => {
+    const findings = collectExtinctSourceFindingsFromFiles([
+      {
+        relativePath: "packages/red-castle/src/mcp/legacy-status.ts",
+        sourceText: `
+export const tools = [
+  { name: "worker_status", invoke: () => readWorkers() },
+  { name: "worker_vitals", invoke: () => readVitals() },
+  { name: "monitor", invoke: () => readMonitor() },
+  { name: "host_state", invoke: () => readHost() },
+];
+`,
+      },
+    ]);
+
+    expect(findings.filter((finding) => finding.sourceId === "deprecated-status-alias")).toHaveLength(4);
+    const message = formatExtinctSourceFailureMessage(
+      formatExtinctSourceViolations({ findings, baseline: [] }),
+    );
+    expect(message).toContain("status { scope: worker | project | host }");
+  });
+
   it("names the file, line and column of a reintroduced fleet source", () => {
     const findings = collectExtinctSourceFindingsFromFiles([
       { relativePath: "apps/dev/src/core/worker-attribution.ts", sourceText: FLEET_READER },

--- a/apps/dev/tests/extinct-source-guard.test.ts
+++ b/apps/dev/tests/extinct-source-guard.test.ts
@@ -433,6 +433,7 @@ describe("promoted into the normal check set (#2795)", () => {
 /** One line that must trip each declared source, so no entry can go dead. */
 function probeTextFor(id: string): string {
   const probes: Record<string, string> = {
+    "deprecated-status-alias": `const tools = [{ name: "worker_status", invoke: readWorkers }];`,
     "fleet-registry": `const p = await readFleetProfiles(path);`,
     "fleet-registry-lane": `const p = join(root, "fleets.toonl");`,
     "fleet-name": `const name = parseFleetFlag(argv) ?? env["RED_AFK_FLEET"];`,

--- a/apps/opencode-host/src/statusline.ts
+++ b/apps/opencode-host/src/statusline.ts
@@ -159,7 +159,7 @@ export const AFKStatusline: Plugin = async (ctx) => {
       const block = [
         "## AFK live state",
         s,
-        "If the user resumes this session, the castle \`monitor\` tool is the source of truth for current worker state (\`worker_vitals\` for liveness) — re-read it before acting on any compaction summary; without the MCP, /afk monitor is the fallback.",
+        "If the user resumes this session, castle \`status { scope: worker }\` is the source of truth for current worker state and liveness — re-read it before acting on any compaction summary; without the MCP, /afk monitor is the fallback.",
         "",
       ].join("\\n");
       output.context.push(block);

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -187,20 +187,13 @@ describe("castle MCP tools", () => {
       "project_resize",
       "project_reset",
       "project_stop",
-      "host_state",
-      "host_dashboard",
-      "host_provision_check",
-      "host_unit_status",
       "logs",
-      "worker_vitals",
       "dashboard",
-      "monitor",
       "history",
       "queue_status",
       "events_since",
       "deadend_audit",
       "worker_dispatch",
-      "worker_status",
       "worker_stop",
       "worker_recycle",
       "runner_list",
@@ -266,27 +259,19 @@ describe("castle MCP tools", () => {
     });
   });
 
-  it("keeps every absorbed verb as an answering deprecation alias", async () => {
+  it("does not publish the expired worker and host status aliases", () => {
     const tools = createCastleMcpTools(deps());
     const aliases = [
-      ["project_status", "project"],
-      ["worker_status", "worker"],
-      ["worker_vitals", "worker"],
-      ["monitor", "worker"],
-      ["host_state", "host"],
-      ["host_dashboard", "host"],
-      ["host_provision_check", "host"],
-      ["host_unit_status", "host"],
-    ] as const;
+      "worker_status",
+      "worker_vitals",
+      "monitor",
+      "host_state",
+      "host_dashboard",
+      "host_provision_check",
+      "host_unit_status",
+    ];
 
-    for (const [name, scope] of aliases) {
-      const answer = await tools.find((tool) => tool.name === name)!.invoke({});
-      expect(answer).toMatchObject({
-        deprecated: true,
-        replacement: { tool: "status", args: { scope } },
-      });
-      expect(answer).toHaveProperty("result");
-    }
+    expect(tools.filter((tool) => aliases.includes(tool.name))).toEqual([]);
   });
 
   it("keeps structured project status inside the deprecated alias answer", async () => {
@@ -321,24 +306,6 @@ describe("castle MCP tools", () => {
     await expect(tool.invoke({ latch: "project-birth-breaker" })).resolves.toEqual({
       status: "reset",
       latch: "project-birth-breaker",
-    });
-  });
-
-  it("returns the daemon's read-only host diagnostics", async () => {
-    const d = deps();
-    const tools = createCastleMcpTools(d);
-
-    await expect(tools.find((tool) => tool.name === "host_state")!.invoke({})).resolves.toMatchObject({
-      result: { pid: 42, workers: [] },
-    });
-    await expect(tools.find((tool) => tool.name === "host_dashboard")!.invoke({})).resolves.toMatchObject({
-      result: { version: 1, mode: "global" },
-    });
-    await expect(tools.find((tool) => tool.name === "host_provision_check")!.invoke({})).resolves.toMatchObject({
-      result: { verdict: "ok" },
-    });
-    await expect(tools.find((tool) => tool.name === "host_unit_status")!.invoke({})).resolves.toMatchObject({
-      result: { floor: "auto-spawn" },
     });
   });
 
@@ -589,40 +556,33 @@ describe("castle MCP tools", () => {
     expect(d.statuslineAggregate).toHaveBeenCalledOnce();
   });
 
-  it("passes live_only and fields through to the worker_vitals dep", async () => {
+  it("passes worker filters through the consolidated status read", async () => {
     const d = deps();
     const tools = createCastleMcpTools(d);
+    const status = tools.find((tool) => tool.name === "status")!;
 
-    await tools.find((tool) => tool.name === "worker_vitals")!.invoke({});
+    await status.invoke({ scope: "worker" });
     expect(d.workerVitals).toHaveBeenCalledWith(
       expect.objectContaining({ live_only: true }),
     );
-
-    await tools
-      .find((tool) => tool.name === "worker_vitals")!
-      .invoke({ live_only: false, fields: ["worker", "live"] });
-    expect(d.workerVitals).toHaveBeenLastCalledWith({
-      live_only: false,
-      fields: ["worker", "live"],
-    });
-  });
-
-  it("passes live_only and fields through to the worker_status dep", async () => {
-    const d = deps();
-    const tools = createCastleMcpTools(d);
-
-    await tools.find((tool) => tool.name === "worker_status")!.invoke({});
     expect(d.workerStatus).toHaveBeenCalledWith(
       expect.objectContaining({ live_only: true }),
     );
 
-    await tools
-      .find((tool) => tool.name === "worker_status")!
-      .invoke({ worker: "wVM2Z", live_only: false, fields: ["worker"] });
+    await status.invoke({
+      scope: "worker",
+      worker: "wVM2Z",
+      live_only: false,
+      fields: ["worker", "live"],
+    });
+    expect(d.workerVitals).toHaveBeenLastCalledWith({
+      live_only: false,
+      fields: ["worker", "live"],
+    });
     expect(d.workerStatus).toHaveBeenLastCalledWith({
       worker: "wVM2Z",
       live_only: false,
-      fields: ["worker"],
+      fields: ["worker", "live"],
     });
   });
 

--- a/packages/red-castle/src/mcp-server.ts
+++ b/packages/red-castle/src/mcp-server.ts
@@ -3,7 +3,7 @@ import { createClaimTools, type ClaimDependencies } from "./mcp/claim.js";
 import { createHelpTools, type HelpDependencies } from "./mcp/help.js";
 import { createMergeTools, type MergeDependencies } from "./mcp/merge.js";
 import { createHitlTools, type HitlDependencies } from "./mcp/hitl.js";
-import { createHostTools, type HostDependencies } from "./mcp/host.js";
+import type { HostDependencies } from "./mcp/host.js";
 import { applyOutputContracts } from "./mcp/contracts.js";
 import { createProjectTools, type ProjectDependencies } from "./mcp/project.js";
 import { createGateTools, type GateDependencies } from "./mcp/gate.js";
@@ -138,7 +138,6 @@ export function createCastleMcpTools(
     ...createHelpTools(deps, () => publishedTools),
     ...createStatusTools(deps),
     ...createProjectTools(deps),
-    ...createHostTools(deps),
     ...createObservabilityTools(deps),
     ...createDeadendTools(deps),
     ...createWorkerTools(deps),

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -76,34 +76,6 @@ const SURFACE: ReadonlyArray<{
     schema: ["force", "fleet"],
   },
   {
-    name: "host_state",
-    title: "Deprecated host state alias",
-    description:
-      "DEPRECATED: use status { scope: host }. Returns daemon host state and names its replacement.",
-    schema: [],
-  },
-  {
-    name: "host_dashboard",
-    title: "Deprecated host dashboard alias",
-    description:
-      "DEPRECATED: use status { scope: host }. Returns the global dashboard and names its replacement.",
-    schema: [],
-  },
-  {
-    name: "host_provision_check",
-    title: "Deprecated host provisioning alias",
-    description:
-      "DEPRECATED: use status { scope: host }. Returns the provisioning check and names its replacement.",
-    schema: [],
-  },
-  {
-    name: "host_unit_status",
-    title: "Deprecated host unit status alias",
-    description:
-      "DEPRECATED: use status { scope: host }. Returns the unit status and names its replacement.",
-    schema: [],
-  },
-  {
     name: "logs",
     title: "Read Castle logs",
     description:
@@ -111,25 +83,11 @@ const SURFACE: ReadonlyArray<{
     schema: ["lane", "id", "limit", "kind"],
   },
   {
-    name: "worker_vitals",
-    title: "Deprecated worker vitals alias",
-    description:
-      "DEPRECATED: use status { scope: worker }. Returns liveness-qualified worker state and names its replacement.",
-    schema: ["live_only", "fields"],
-  },
-  {
     name: "dashboard",
     title: "Build AFK dashboard",
     description:
       "Build the structured operational dashboard from GitHub and local state.",
     schema: ["periodDays"],
-  },
-  {
-    name: "monitor",
-    title: "Deprecated worker monitor alias",
-    description:
-      "DEPRECATED: use status { scope: worker }. Returns worker monitor inputs and names its replacement.",
-    schema: [],
   },
   {
     name: "history",
@@ -165,13 +123,6 @@ const SURFACE: ReadonlyArray<{
     description:
       "MUTATING: run one tracked issue or mint and run one disposable demand through the AFK worker lifecycle.",
     schema: ["issue", "demand", "runner", "mode"],
-  },
-  {
-    name: "worker_status",
-    title: "Deprecated worker status alias",
-    description:
-      "DEPRECATED: use status { scope: worker }. Returns normalized worker state and names its replacement.",
-    schema: ["worker", "live_only", "fields"],
   },
   {
     name: "worker_stop",

--- a/packages/red-castle/src/mcp/contracts.test.ts
+++ b/packages/red-castle/src/mcp/contracts.test.ts
@@ -92,8 +92,6 @@ describe("observability output contracts", () => {
     const contracted = [
       "status",
       "project_status",
-      "worker_vitals",
-      "monitor",
       "queue_status",
     ];
 

--- a/packages/red-castle/src/mcp/host.ts
+++ b/packages/red-castle/src/mcp/host.ts
@@ -1,69 +1,13 @@
 // host.ts — read-only visibility into the machine-wide redskilled daemon.
 //
-// A project tool answers only for the checkout that called it. These tools
-// deliberately cross that read boundary so an operator can diagnose the host
+// A project read answers only for the checkout that called it. Host-scoped
+// status deliberately crosses that boundary so an operator can diagnose the host
 // that owns every project's Workers, while exposing none of the daemon's
 // mutating `provision` or `reclaim` commands (ADR 0130, issue #3163).
-
-import type { CastleMcpTool } from "./tool.js";
-import { deprecatedStatusAlias } from "./status.js";
 
 export interface HostDependencies {
   hostState(): Promise<unknown>;
   hostDashboard(): Promise<unknown>;
   hostProvisionCheck(): Promise<unknown>;
   hostUnitStatus(): Promise<unknown>;
-}
-
-export function createHostTools(deps: HostDependencies): CastleMcpTool[] {
-  return [
-    {
-      name: "host_state",
-      title: "Deprecated host state alias",
-      description:
-        "DEPRECATED: use status { scope: host }. Returns daemon host state and names its replacement.",
-      inputSchema: {},
-      invoke: async () =>
-        deprecatedStatusAlias("host_state", "host", await deps.hostState()),
-    },
-    {
-      name: "host_dashboard",
-      title: "Deprecated host dashboard alias",
-      description:
-        "DEPRECATED: use status { scope: host }. Returns the global dashboard and names its replacement.",
-      inputSchema: {},
-      invoke: async () =>
-        deprecatedStatusAlias(
-          "host_dashboard",
-          "host",
-          await deps.hostDashboard(),
-        ),
-    },
-    {
-      name: "host_provision_check",
-      title: "Deprecated host provisioning alias",
-      description:
-        "DEPRECATED: use status { scope: host }. Returns the provisioning check and names its replacement.",
-      inputSchema: {},
-      invoke: async () =>
-        deprecatedStatusAlias(
-          "host_provision_check",
-          "host",
-          await deps.hostProvisionCheck(),
-        ),
-    },
-    {
-      name: "host_unit_status",
-      title: "Deprecated host unit status alias",
-      description:
-        "DEPRECATED: use status { scope: host }. Returns the unit status and names its replacement.",
-      inputSchema: {},
-      invoke: async () =>
-        deprecatedStatusAlias(
-          "host_unit_status",
-          "host",
-          await deps.hostUnitStatus(),
-        ),
-    },
-  ];
 }

--- a/packages/red-castle/src/mcp/observability.ts
+++ b/packages/red-castle/src/mcp/observability.ts
@@ -1,17 +1,11 @@
 import { z } from "zod/v3";
 import {
-  monitorContract,
   queueStatusContract,
-  workerVitalsContract,
   type MonitorOutput,
   type QueueStatusOutput,
   type WorkerVitalsOutput,
   type WorkerVitalsProjectedOutput,
 } from "./contracts.js";
-import {
-  deprecatedStatusAlias,
-  deprecatedStatusAliasContract,
-} from "./status.js";
 import type { CastleMcpTool } from "./tool.js";
 import { workSelectorShape, type WorkSelectorInput } from "./project.js";
 
@@ -66,26 +60,6 @@ export function createObservabilityTools(
       invoke: (input) => deps.logs(input as unknown as LogsInput),
     },
     {
-      name: "worker_vitals",
-      title: "Deprecated worker vitals alias",
-      description:
-        "DEPRECATED: use status { scope: worker }. Returns liveness-qualified worker state and names its replacement.",
-      inputSchema: {
-        live_only: z.boolean().default(true),
-        fields: z.array(z.string().min(1)).optional(),
-      },
-      outputContract: deprecatedStatusAliasContract(workerVitalsContract),
-      invoke: async (input) =>
-        deprecatedStatusAlias(
-          "worker_vitals",
-          "worker",
-          await deps.workerVitals({
-            live_only: (input.live_only ?? true) as boolean,
-            fields: input.fields as string[] | undefined,
-          }),
-        ),
-    },
-    {
       name: "dashboard",
       title: "Build AFK dashboard",
       description:
@@ -95,16 +69,6 @@ export function createObservabilityTools(
       },
       invoke: ({ periodDays }) =>
         deps.dashboard({ periodDays: periodDays as number }),
-    },
-    {
-      name: "monitor",
-      title: "Deprecated worker monitor alias",
-      description:
-        "DEPRECATED: use status { scope: worker }. Returns worker monitor inputs and names its replacement.",
-      inputSchema: {},
-      outputContract: deprecatedStatusAliasContract(monitorContract),
-      invoke: async () =>
-        deprecatedStatusAlias("monitor", "worker", await deps.monitor()),
     },
     {
       name: "history",

--- a/packages/red-castle/src/mcp/worker.ts
+++ b/packages/red-castle/src/mcp/worker.ts
@@ -5,7 +5,6 @@ import {
   noRepair,
   type RepairAction,
 } from "@reddb-io/shared/repair.js";
-import { deprecatedStatusAlias } from "./status.js";
 
 export interface WorkerDispatchInput {
   issue?: number;
@@ -93,27 +92,6 @@ export function createWorkerTools(deps: WorkerDependencies): CastleMcpTool[] {
         }
         return deps.workerDispatch(parsed);
       },
-    },
-    {
-      name: "worker_status",
-      title: "Deprecated worker status alias",
-      description:
-        "DEPRECATED: use status { scope: worker }. Returns normalized worker state and names its replacement.",
-      inputSchema: {
-        worker: z.string().min(1).optional(),
-        live_only: z.boolean().default(true),
-        fields: z.array(z.string().min(1)).optional(),
-      },
-      invoke: async ({ worker, live_only, fields }) =>
-        deprecatedStatusAlias(
-          "worker_status",
-          "worker",
-          await deps.workerStatus({
-            worker: worker as string | undefined,
-            live_only: (live_only ?? true) as boolean,
-            fields: fields as string[] | undefined,
-          }),
-        ),
     },
     {
       name: "worker_stop",

--- a/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
@@ -107,7 +107,7 @@ resolved tiers as documented by the model-tier policy.
 
 Every spawn appends a route line to the Worker log and stamps
 `current.model_tier`, `current.model`, and `current.effort` in the Worker state.
-The castle `monitor` and `worker_vitals` tools carry the active tier as a field;
+Castle `status { scope: worker }` carries the active tier as a field;
 the no-MCP fallback `npx -y -p @reddb-io/red-skills@<version> red-skills-dev monitor` renders it as `tier:<name>` on the
 Worker row, alongside the existing vitals.
 

--- a/packaging/pi/dev/skills/engineering/afk/monitor.md
+++ b/packaging/pi/dev/skills/engineering/afk/monitor.md
@@ -12,8 +12,8 @@ command renders the same truth for a human terminal. See [`MCP.md`](./MCP.md).
 
 | Question | Tool |
 | --- | --- |
-| What are the workers, history events, and fleet inputs right now? | `monitor` |
-| Is a quiet worker actually alive? | `worker_vitals`, `worker_status` |
+| What are the workers, history events, and fleet inputs right now? | `status { scope: worker }` |
+| Is a quiet worker actually alive? | `status { scope: worker }` |
 | What is drainable, and what is parked for a human? | `queue_status` |
 | What happened over the last N days? | `dashboard` (`periodDays`), `history` |
 | What did one lane actually record? | `logs` |
@@ -33,7 +33,7 @@ non-empty `held_for_summon` bucket is still zero drainable work; release it with
 
 ## Dashboard
 
-`/afk monitor` is the readonly aggregated view across all live workers. **Call the castle `monitor` tool for the data, and pair it with `worker_vitals` when liveness is the question — do not reinvent the rendering in inline bash.** The bundle's `monitor` command renders the same truth for a human terminal and is the no-MCP fallback. Either way it:
+`/afk monitor` is the readonly aggregated view across all live workers. **Call the castle `status` tool with `scope: worker` for the data — do not reinvent the rendering in inline bash.** The bundle's `monitor` command renders the same truth for a human terminal and is the no-MCP fallback. Either way it:
 
 1. Globs `.red/tmp/workers/*/*/afk.state.json` and renders one section per active attempt.
 2. Verifies liveness via the orchestrator PID recorded in `afk.state.json` (`.pid` field), paired with `pid_start_time` when the platform exposes a stable process-start token. Attempts whose PID identity is dead or mismatched are flagged `stale`/`gone`; PID-live but agent-lane-quiet workers render `[quiet]` and are still counted as running.
@@ -168,7 +168,7 @@ supervisor under Codex:
 1. Fetch a sub-agent spawn primitive via `ToolSearch` (query:
    `spawn agent background monitor`).
 2. If unavailable, continue the worker launch and print:
-   `monitor loop unavailable in this runner; call the castle monitor tool (and worker_vitals for liveness); no-MCP fallback: run /dev:afk monitor or tail .red/tmp/workers/*/worker.log.toonl manually.`
+   `monitor loop unavailable in this runner; call castle status with scope: worker; no-MCP fallback: run /dev:afk monitor or tail .red/tmp/workers/*/worker.log.toonl manually.`
 3. If available, emit the canonical prompt from the bundle (use `--mode run` for a
    single worker, `--mode fleet` for a supervisor, so the read-only rules stay
    identical across launches):
@@ -176,12 +176,12 @@ supervisor under Codex:
    RED_AFK_RUNNER=codex npx -y -p @reddb-io/red-skills@<version> red-skills-dev codex-monitor-agent --project-root "$PWD" --mode run
    ```
    Spawn exactly one monitor agent with that prompt. The monitor agent is a
-   presentation consumer only: it periodically reads the castle `monitor` tool
-   (with `worker_vitals` for liveness), reports concise progress in the Codex
+   presentation consumer only: it periodically reads castle `status` with
+   `scope: worker`, reports concise progress in the Codex
    UI, and exits once no supervisor or live workers remain. Its prompt carries
    the `/dev:afk monitor --once` CLI form as the no-MCP fallback.
 4. Tell the user one line:
-   `Codex monitor agent spawned — auto-closes when AFK exits; manual monitor: the castle monitor tool, or /dev:afk monitor without the MCP.`
+   `Codex monitor agent spawned — auto-closes when AFK exits; manual monitor: castle status with scope: worker, or /dev:afk monitor without the MCP.`
 
 Hard boundaries for the monitor agent are non-negotiable: it must never edit
 files, claim issues, change labels, comment, stop workers, run validation, push,

--- a/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -128,7 +128,7 @@ The script writes `${XDG_BIN_HOME:-$HOME/.local/bin}/red-skills-dev` and `${XDG_
 - prefers the active CLI plugin-root env var when the host exposes one;
 - otherwise finds the latest installed dev plugin under `~/.codex/plugins/cache/red-skills/dev/*` or `~/.claude/plugins/cache/red-skills/dev/*`;
 - falls back to the latest warmed dev bundle under `~/.cache/red-skills/bundles/`;
-- forwards all arguments to the dev runtime, so skills reach the same cores the castle `monitor`, `dashboard`, and `worker_dispatch` tools drive. The shim is a **warm-cache optimization over the canonical `npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand>` form** (ADR 0091), never a replacement for it: the same no-MCP fallbacks are `go ...`, `dashboard`, or `RED_AFK_RUNNER=codex … monitor --once`;
+- forwards all arguments to the dev runtime, so skills reach the same cores castle `status { scope: worker }`, `dashboard`, and `worker_dispatch` drive. The shim is a **warm-cache optimization over the canonical `npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand>` form** (ADR 0091), never a replacement for it: the same no-MCP fallbacks are `go ...`, `dashboard`, or `RED_AFK_RUNNER=codex … monitor --once`;
 - stores no secrets and does not replace the `.red/config.yaml` opt-in gate.
 
 The `rsp` shim uses the same local-first shape: active plugin-root env var, installed host plugin cache, then the warmed rsp bundle under `${RED_SKILLS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/red-skills/bundles}`. It never runs npm, installs a global package, or performs network resolution during session startup.

--- a/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -35,7 +35,7 @@ Install or inspect the RedSkills statusline for this repository. The shared prod
 
   The **`/afk monitor` dashboard keeps its fuller per-worker row** (title, `[live]`/`[quiet]`, `wait`, `log`) — it is a full dashboard, not a compact statusline — but its vitals tokens are the same `tls`/`rsn`/`txt` vocabulary as the statusline.
 
-  The same per-worker fields arrive as structured data from the castle `statusline_aggregate` and `worker_vitals` tools, so an agent decodes the tokens by reading the fields instead of the legend.
+  The same per-worker fields arrive as structured data from castle `statusline_aggregate` and `status { scope: worker }`, so an agent decodes the tokens by reading the fields instead of the legend.
   For an on-demand human decode table — the no-MCP fallback — run `npx -y -p @reddb-io/red-skills@<version> red-skills-dev statusline --legend` or the same binary's `monitor --legend`. The legend prints `token / name / gloss` rows and exits without rendering the live statusline or monitor surface.
 - **Codex — single line.** The `tui.status_line` footer is single-line only, so the plain producer stays ONE aggregate line (project · model · context · usage · repo counts · the AFK block). The multi-line layout is Claude-Code-only.
 

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -107,7 +107,7 @@ resolved tiers as documented by the model-tier policy.
 
 Every spawn appends a route line to the Worker log and stamps
 `current.model_tier`, `current.model`, and `current.effort` in the Worker state.
-The castle `monitor` and `worker_vitals` tools carry the active tier as a field;
+Castle `status { scope: worker }` carries the active tier as a field;
 the no-MCP fallback `npx -y -p @reddb-io/red-skills@<version> red-skills-dev monitor` renders it as `tier:<name>` on the
 Worker row, alongside the existing vitals.
 

--- a/plugins/dev/skills/engineering/afk/monitor.md
+++ b/plugins/dev/skills/engineering/afk/monitor.md
@@ -12,8 +12,8 @@ command renders the same truth for a human terminal. See [`MCP.md`](./MCP.md).
 
 | Question | Tool |
 | --- | --- |
-| What are the workers, history events, and fleet inputs right now? | `monitor` |
-| Is a quiet worker actually alive? | `worker_vitals`, `worker_status` |
+| What are the workers, history events, and fleet inputs right now? | `status { scope: worker }` |
+| Is a quiet worker actually alive? | `status { scope: worker }` |
 | What is drainable, and what is parked for a human? | `queue_status` |
 | What happened over the last N days? | `dashboard` (`periodDays`), `history` |
 | What did one lane actually record? | `logs` |
@@ -33,7 +33,7 @@ non-empty `held_for_summon` bucket is still zero drainable work; release it with
 
 ## Dashboard
 
-`/afk monitor` is the readonly aggregated view across all live workers. **Call the castle `monitor` tool for the data, and pair it with `worker_vitals` when liveness is the question — do not reinvent the rendering in inline bash.** The bundle's `monitor` command renders the same truth for a human terminal and is the no-MCP fallback. Either way it:
+`/afk monitor` is the readonly aggregated view across all live workers. **Call the castle `status` tool with `scope: worker` for the data — do not reinvent the rendering in inline bash.** The bundle's `monitor` command renders the same truth for a human terminal and is the no-MCP fallback. Either way it:
 
 1. Globs `.red/tmp/workers/*/*/afk.state.json` and renders one section per active attempt.
 2. Verifies liveness via the orchestrator PID recorded in `afk.state.json` (`.pid` field), paired with `pid_start_time` when the platform exposes a stable process-start token. Attempts whose PID identity is dead or mismatched are flagged `stale`/`gone`; PID-live but agent-lane-quiet workers render `[quiet]` and are still counted as running.
@@ -168,7 +168,7 @@ supervisor under Codex:
 1. Fetch a sub-agent spawn primitive via `ToolSearch` (query:
    `spawn agent background monitor`).
 2. If unavailable, continue the worker launch and print:
-   `monitor loop unavailable in this runner; call the castle monitor tool (and worker_vitals for liveness); no-MCP fallback: run /dev:afk monitor or tail .red/tmp/workers/*/worker.log.toonl manually.`
+   `monitor loop unavailable in this runner; call castle status with scope: worker; no-MCP fallback: run /dev:afk monitor or tail .red/tmp/workers/*/worker.log.toonl manually.`
 3. If available, emit the canonical prompt from the bundle (use `--mode run` for a
    single worker, `--mode fleet` for a supervisor, so the read-only rules stay
    identical across launches):
@@ -176,12 +176,12 @@ supervisor under Codex:
    RED_AFK_RUNNER=codex npx -y -p @reddb-io/red-skills@<version> red-skills-dev codex-monitor-agent --project-root "$PWD" --mode run
    ```
    Spawn exactly one monitor agent with that prompt. The monitor agent is a
-   presentation consumer only: it periodically reads the castle `monitor` tool
-   (with `worker_vitals` for liveness), reports concise progress in the Codex
+   presentation consumer only: it periodically reads castle `status` with
+   `scope: worker`, reports concise progress in the Codex
    UI, and exits once no supervisor or live workers remain. Its prompt carries
    the `/dev:afk monitor --once` CLI form as the no-MCP fallback.
 4. Tell the user one line:
-   `Codex monitor agent spawned — auto-closes when AFK exits; manual monitor: the castle monitor tool, or /dev:afk monitor without the MCP.`
+   `Codex monitor agent spawned — auto-closes when AFK exits; manual monitor: castle status with scope: worker, or /dev:afk monitor without the MCP.`
 
 Hard boundaries for the monitor agent are non-negotiable: it must never edit
 files, claim issues, change labels, comment, stop workers, run validation, push,

--- a/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -128,7 +128,7 @@ The script writes `${XDG_BIN_HOME:-$HOME/.local/bin}/red-skills-dev` and `${XDG_
 - prefers the active CLI plugin-root env var when the host exposes one;
 - otherwise finds the latest installed dev plugin under `~/.codex/plugins/cache/red-skills/dev/*` or `~/.claude/plugins/cache/red-skills/dev/*`;
 - falls back to the latest warmed dev bundle under `~/.cache/red-skills/bundles/`;
-- forwards all arguments to the dev runtime, so skills reach the same cores the castle `monitor`, `dashboard`, and `worker_dispatch` tools drive. The shim is a **warm-cache optimization over the canonical `npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand>` form** (ADR 0091), never a replacement for it: the same no-MCP fallbacks are `go ...`, `dashboard`, or `RED_AFK_RUNNER=codex … monitor --once`;
+- forwards all arguments to the dev runtime, so skills reach the same cores castle `status { scope: worker }`, `dashboard`, and `worker_dispatch` drive. The shim is a **warm-cache optimization over the canonical `npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand>` form** (ADR 0091), never a replacement for it: the same no-MCP fallbacks are `go ...`, `dashboard`, or `RED_AFK_RUNNER=codex … monitor --once`;
 - stores no secrets and does not replace the `.red/config.yaml` opt-in gate.
 
 The `rsp` shim uses the same local-first shape: active plugin-root env var, installed host plugin cache, then the warmed rsp bundle under `${RED_SKILLS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/red-skills/bundles}`. It never runs npm, installs a global package, or performs network resolution during session startup.

--- a/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -35,7 +35,7 @@ Install or inspect the RedSkills statusline for this repository. The shared prod
 
   The **`/afk monitor` dashboard keeps its fuller per-worker row** (title, `[live]`/`[quiet]`, `wait`, `log`) — it is a full dashboard, not a compact statusline — but its vitals tokens are the same `tls`/`rsn`/`txt` vocabulary as the statusline.
 
-  The same per-worker fields arrive as structured data from the castle `statusline_aggregate` and `worker_vitals` tools, so an agent decodes the tokens by reading the fields instead of the legend.
+  The same per-worker fields arrive as structured data from castle `statusline_aggregate` and `status { scope: worker }`, so an agent decodes the tokens by reading the fields instead of the legend.
   For an on-demand human decode table — the no-MCP fallback — run `npx -y -p @reddb-io/red-skills@<version> red-skills-dev statusline --legend` or the same binary's `monitor --legend`. The legend prints `token / name / gloss` rows and exits without rendering the live statusline or monitor surface.
 - **Codex — single line.** The `tui.status_line` footer is single-line only, so the plain producer stays ONE aggregate line (project · model · context · usage · repo counts · the AFK block). The multi-line layout is Claude-Code-only.
 


### PR DESCRIPTION
Automated AFK landing for #3266. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3266

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788512768&installation_model_id=20659&pr_number=3324&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3324&signature=4e2dac67671cc6d81c3d9e6ad5341757f9e4797a200adb60330bd1c9c5cb49ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->