### PR TITLE
chore: #3334 The Park has one door: a single owner of the blocker block, one requeue applier with authority as a parameter, and malformed blocks active and named

### DIFF
--- a/apps/dev/src/commands/hitl-card.ts
+++ b/apps/dev/src/commands/hitl-card.ts
@@ -23,7 +23,6 @@ import { parseCurrentBlocker } from "../core/blocker-state.js";
 import { applyRequeue } from "../core/requeue.js";
 import { parseClaimRecords, renderClaimComment } from "../core/claim.js";
 import { LABEL_HUMAN } from "../core/triage-labels.js";
-import { isRefused, planTransition } from "../core/state-transition.js";
 import {
   renderCard,
   updateCardStatus,

--- a/apps/dev/src/commands/hitl-card.ts
+++ b/apps/dev/src/commands/hitl-card.ts
@@ -20,7 +20,8 @@ import { actorTrustSignals, type GhContext } from "../runtime/gh.js";
 import { loadConfig } from "../core/config.js";
 import { resolveConfigPath } from "./route-model-tier.js";
 import { parseCurrentBlocker } from "../core/blocker-state.js";
-import { planRequeue } from "../core/requeue.js";
+import { applyRequeue } from "../core/requeue.js";
+import { parseClaimRecords, renderClaimComment } from "../core/claim.js";
 import { LABEL_HUMAN } from "../core/triage-labels.js";
 import { isRefused, planTransition } from "../core/state-transition.js";
 import {
@@ -42,6 +43,7 @@ import {
   type CardCommand,
 } from "../core/hitl-card.js";
 import { enrichIssueReferences as enrichTicketRefs } from "../core/issue-reference.js";
+import { verifyFreshBase } from "./requeue.js";
 
 const FLAG_SCHEMA = {
   issue: { kind: "value", coerce: (raw: string): number => Number(raw) },
@@ -418,30 +420,62 @@ async function executeRequeue(exec: Exec, repo: string, issue: IssueData, guidan
     return "⚠️ `/requeue` requires guidance text, e.g. `/requeue Please fix the type errors in src/foo.ts`.";
   }
 
-  const plan = planRequeue({ body: issue.body, labels: issue.labels, guidance });
-  if (!plan.requeueable) {
-    return `Cannot requeue: ${plan.reason}`;
+  const claims = parseClaimRecords(issue.comments.map((comment) => ({
+    id: comment.id,
+    body: comment.body,
+  })));
+  const latestClaims = new Map<string, { id: number; kind: "claim" | "concede" }>();
+  for (const claim of claims) {
+    const prior = latestClaims.get(claim.worker);
+    if (!prior || claim.commentId >= prior.id) {
+      latestClaims.set(claim.worker, { id: claim.commentId, kind: claim.kind });
+    }
   }
 
-  // Apply the requeue transition. `planRequeue` owns the REFUSAL gates (is the
-  // issue parked? are its blocked:* labels unambiguous?); since #2663 the LABEL
-  // DELTA comes from the ADR 0122 planner instead of planRequeue's hand-rolled
-  // sets, so the card's re-queue sheds every state role, the `running`
-  // projection, and every `blocked:*` reason in ONE proven edit. A refused plan
-  // (a `queue` while `req:*` edges survive) falls back to planRequeue's sets —
-  // the maintainer's directive still lands.
-  if (plan.bodyChanged) {
-    await exec(["gh", "issue", "edit", String(issue.number), ...repoArgs(repo), "--body", scrubOutbound(plan.body)]);
-  }
-  const queued = planTransition(issue.labels, { kind: "queue" });
-  const removeLabels = isRefused(queued) ? plan.removeLabels : [...queued.remove];
-  const addLabels = isRefused(queued) ? plan.addLabels : [...queued.add];
-  if (removeLabels.length > 0 || addLabels.length > 0) {
-    const editArgs = ["gh", "issue", "edit", String(issue.number), ...repoArgs(repo)];
-    for (const l of removeLabels) editArgs.push("--remove-label", l);
-    for (const l of addLabels) editArgs.push("--add-label", l);
-    await exec(editArgs);
-  }
+  const run = async (args: string[]): Promise<void> => {
+    const result = await exec(args);
+    if (result.code !== 0) throw new Error(result.stderr.trim() || result.stdout.trim());
+  };
+  const applied = await applyRequeue(
+    {
+      verifyBaseFreshness: (body) => verifyFreshBase(cwd, body),
+      releaseClaims: async (number) => {
+        const owners = [...latestClaims.entries()]
+          .filter(([, claim]) => claim.kind === "claim")
+          .map(([worker]) => worker)
+          .sort();
+        for (const worker of owners) {
+          await run([
+            "gh", "issue", "comment", String(number), ...repoArgs(repo),
+            "--body", renderClaimComment({ worker }, "concede"),
+          ]);
+        }
+        return owners;
+      },
+      editBody: (number, body) => run([
+        "gh", "issue", "edit", String(number), ...repoArgs(repo),
+        "--body", scrubOutbound(body),
+      ]),
+      comment: (number, body) => run([
+        "gh", "issue", "comment", String(number), ...repoArgs(repo),
+        "--body", scrubOutbound(body),
+      ]),
+      editLabels: (number, remove, add) => {
+        const args = ["gh", "issue", "edit", String(number), ...repoArgs(repo)];
+        for (const label of remove) args.push("--remove-label", label);
+        for (const label of add) args.push("--add-label", label);
+        return run(args);
+      },
+    },
+    {
+      issue: issue.number,
+      authority: "human",
+      body: issue.body,
+      labels: issue.labels,
+      guidance,
+    },
+  );
+  if (!applied.applied) return `Cannot requeue: ${applied.reason}`;
 
   return `Issue #${issue.number} requeued to ready-for-agent with guidance.`;
 }

--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -24,12 +24,7 @@ import { encodeLines } from "@reddb-io/toon";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
 import { scrubOutbound } from "../runtime/outbound-redaction.js";
-import { planRequeue, type RequeuePlan } from "../core/requeue.js";
-import {
-  applyTransition,
-  isRefused,
-  planTransition,
-} from "../core/state-transition.js";
+import { applyRequeue, planRequeue, type RequeuePlan } from "../core/requeue.js";
 import { parseClaimRecords, renderClaimComment, type RawClaimComment } from "../core/claim.js";
 import { LABEL_READY } from "../core/triage-labels.js";
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
@@ -187,7 +182,7 @@ function ghFor(cwd: string, repo: string): RequeueGh {
   };
 }
 
-async function verifyFreshBase(
+export async function verifyFreshBase(
   cwd: string,
   issueBody: string,
 ): Promise<RequeueBaseFreshnessResult> {
@@ -247,20 +242,6 @@ async function sweepRequeueClaims(gh: RequeueGh, issue: number): Promise<string[
     );
   }
   return owners;
-}
-
-function directiveComment(plan: RequeuePlan, guidance?: string): string {
-  const lines = [
-    "<details data-kind=\"directive\">",
-    "<summary>Requeue</summary>",
-    "",
-    "Human guidance:",
-    guidance?.trim() || "(none recorded)",
-    "",
-    `Disposition:\nrequeued to ready-for-agent${plan.activeBlocker ? ` (cleared active blocker: ${plan.activeBlocker.kind})` : ""}`,
-    "</details>",
-  ];
-  return lines.join("\n");
 }
 
 async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
@@ -590,23 +571,6 @@ export async function executeRequeue(
   const isBaseStale =
     plan.activeBlocker?.kind === "base-stale" ||
     plan.removeLabels.includes("blocked:base-stale");
-  if (plan.requeueable && isBaseStale) {
-    const freshness = await (
-      options.verifyBaseFreshness ?? ((body) => verifyFreshBase(cwd, body))
-    )(issueState.body);
-    if (!freshness.ok) {
-      return {
-        issue: input.issue,
-        plan,
-        applied: false,
-        outcome: "refused",
-        exitCode: 1,
-        reason: `base freshness verification failed: ${freshness.evidence}`,
-        ...(adoptBranch ? { adoptBranch } : {}),
-      };
-    }
-  }
-
   if (input.dryRun) {
     return {
       issue: input.issue,
@@ -622,29 +586,42 @@ export async function executeRequeue(
   let removeLabels: string[] | undefined;
   let addLabels: string[] | undefined;
   if (plan.requeueable) {
-    await sweepRequeueClaims(gh, input.issue);
-    if (plan.bodyChanged) await gh.editBody(input.issue, plan.body);
-    await gh.comment(input.issue, directiveComment(plan, guidance));
-    const lifecyclePlan = planTransition(issueState.labels, { kind: "queue" });
-    if (isRefused(lifecyclePlan)) {
-      throw new Error(`requeue transition refused: ${lifecyclePlan.reason}`);
-    }
-    removeLabels = [...plan.removeLabels];
-    addLabels = [...plan.addLabels];
-    await applyTransition(
+    const transition = await applyRequeue(
       {
-        editIssue: async (issue, edit) => {
-          await gh.editLabels(issue, [...edit.remove], [...edit.add]);
-          return true;
-        },
-        readBody: async () => plan.body,
+        verifyBaseFreshness: options.verifyBaseFreshness
+          ?? (isBaseStale
+            ? (body) => verifyFreshBase(cwd, body)
+            : async () => ({ ok: true, evidence: "fresh queue base" })),
+        releaseClaims: (issue) => sweepRequeueClaims(gh, issue),
+        editBody: (issue, body) => gh.editBody(issue, body),
+        comment: (issue, body) => gh.comment(issue, body),
+        editLabels: (issue, remove, add) => gh.editLabels(issue, remove, add),
       },
-      input.issue,
-      { remove: removeLabels, add: addLabels },
+      {
+        issue: input.issue,
+        authority: "machine",
+        body: issueState.body,
+        labels: issueState.labels,
+        guidance,
+        adoptBranch: adoptBranch !== undefined,
+      },
     );
+    if (!transition.applied) {
+      return {
+        issue: input.issue,
+        plan: transition.plan,
+        applied: false,
+        outcome: "refused",
+        exitCode: 1,
+        reason: transition.reason,
+        ...(adoptBranch ? { adoptBranch } : {}),
+      };
+    }
+    removeLabels = [...transition.plan.removeLabels];
+    addLabels = [...transition.plan.addLabels];
     return {
       issue: input.issue,
-      plan,
+      plan: transition.plan,
       applied: true,
       removeLabels,
       addLabels,

--- a/apps/dev/src/core/blocker-state.ts
+++ b/apps/dev/src/core/blocker-state.ts
@@ -9,6 +9,15 @@ export const BLOCKER_HEADING = "Current blocker";
 export const RESOLVED_BLOCKERS_HEADING = "Resolved blockers";
 export const BLOCKER_OPEN = "<!-- red:blocker-state v1 -->";
 export const BLOCKER_CLOSE = "<!-- /red:blocker-state -->";
+export const MALFORMED_BLOCKER_STATE = "malformed-blocker-state";
+export const QUARANTINE_MARKER_PREFIX = "afk:quarantine v1 issue=#";
+
+export type BlockerRequiredField = "kind" | "summary" | "next";
+
+export interface BlockerStateDefect {
+  name: typeof MALFORMED_BLOCKER_STATE;
+  missingFields: BlockerRequiredField[];
+}
 
 export interface CurrentBlocker {
   status: "blocked";
@@ -16,6 +25,8 @@ export interface CurrentBlocker {
   ref?: string;
   summary: string;
   next: string;
+  /** Present when a `status: blocked` record is active but needs repair. */
+  defect?: BlockerStateDefect;
 }
 
 export interface ResolvedBlocker {
@@ -137,15 +148,19 @@ export function parseCurrentBlocker(markdown: string): CurrentBlocker | null {
   if (inner === null) return null;
   const fields = parseFields(inner);
   if (fields.status !== "blocked") return null;
-  const summary = safeField(fields.summary);
-  const next = safeField(fields.next);
-  if (!summary || !next) return null;
+  const required: readonly BlockerRequiredField[] = ["kind", "summary", "next"];
+  const missingFields = required.filter((field) => safeField(fields[field]).length === 0);
+  const summary = safeField(fields.summary, "Malformed blocker-state block.");
+  const next = safeField(fields.next, "Repair the malformed blocker-state block before requeueing.");
   return {
     status: "blocked",
     kind: safeField(fields.kind, "unknown"),
     ...(fields.ref ? { ref: safeField(fields.ref) } : {}),
     summary,
     next,
+    ...(missingFields.length > 0
+      ? { defect: { name: MALFORMED_BLOCKER_STATE, missingFields } }
+      : {}),
   };
 }
 
@@ -272,4 +287,21 @@ export function clearCurrentBlocker(markdown: string, resolved?: ResolvedBlocker
   }
   if (!resolved || !active) return next;
   return appendResolvedBlocker(next, resolved);
+}
+
+export function quarantineMarker(issue: number): string {
+  return `<!-- ${QUARANTINE_MARKER_PREFIX}${issue} -->`;
+}
+
+/** Append one idempotent quarantine diagnosis using the shared issue-body shape. */
+export function appendQuarantineDiagnosis(
+  markdown: string,
+  issue: number,
+  diagnosis: string,
+): string {
+  const marker = quarantineMarker(issue);
+  if (markdown.includes(marker)) return markdown;
+  const body = markdown.replace(/\s+$/, "");
+  const entry = diagnosis.includes(marker) ? diagnosis : `${marker}\n${diagnosis}`;
+  return `${body}${body ? "\n\n" : ""}## Quarantine diagnosis\n\n${entry.trim()}\n`;
 }

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -97,6 +97,13 @@ import type { WorkerStateRecordReclaimPlan } from "./worker-state-reclaim.js";
 import { LABEL_HUMAN, LABEL_QUARANTINE, LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
 import { readHitlTypeLabels } from "./config.js";
 import { isRefused, planTransition, type StateTransition } from "./state-transition.js";
+import {
+  appendQuarantineDiagnosis,
+  makeBlocker,
+  parseCurrentBlocker,
+  quarantineMarker,
+  upsertCurrentBlocker,
+} from "./blocker-state.js";
 
 // ---------- precheck (hard preconditions) ----------
 
@@ -532,23 +539,17 @@ async function quarantineClaimIssue(
   issue: number,
   summary: string,
 ): Promise<void> {
-  const marker = `<!-- afk:quarantine v1 issue=#${issue} -->`;
+  const marker = quarantineMarker(issue);
   try {
     const body = await deps.gh.viewBody?.(issue);
     if (body !== undefined && !body.includes(marker)) {
-      const blocker = body.includes("<!-- red:blocker-state v1 -->")
-        ? ""
-        : [
-            "## Current blocker",
-            "",
-            "<!-- red:blocker-state v1 -->",
-            "status: blocked",
-            "kind: claim-hygiene",
-            `summary: ${summary}`,
-            "next: Resolve the claim state, then clear this blocker for curator release.",
-            "<!-- /red:blocker-state -->",
-            "",
-          ].join("\n");
+      const withBlocker = parseCurrentBlocker(body)
+        ? body
+        : upsertCurrentBlocker(body, makeBlocker({
+            kind: "claim-hygiene",
+            summary,
+            next: "Resolve the claim state, then clear this blocker for curator release.",
+          }));
       const diagnosis = [
         marker,
         "🤖 Claim-hygiene probe quarantined this issue instead of halting the fleet.",
@@ -557,7 +558,7 @@ async function quarantineClaimIssue(
       ].join("\n");
       await deps.gh.editBody?.(
         issue,
-        `${body.replace(/\s+$/, "")}\n\n${blocker}## Quarantine diagnosis\n\n${diagnosis}\n`,
+        appendQuarantineDiagnosis(withBlocker, issue, diagnosis),
       );
     }
   } catch (error) {

--- a/apps/dev/src/core/deadend-audit.ts
+++ b/apps/dev/src/core/deadend-audit.ts
@@ -18,6 +18,7 @@
 // out of the canonical state vocabulary (#2664).
 
 import { LABEL_DEPENDENCY, LABEL_HUMAN, LABEL_READY } from "./triage-labels.js";
+import { parseCurrentBlocker } from "./blocker-state.js";
 
 /** The stuck-pattern taxonomy. One entry per detected deadend class. */
 export type DeadendClass =
@@ -148,28 +149,6 @@ function reqTargets(labels: readonly string[]): number[] {
   return out;
 }
 
-/**
- * Whether the anchored Current-blocker region carries an active blocker. Kept
- * local (not importing blocker-state) so the detector stays IO- and
- * dependency-free; the collector normalizes the body before handing it in.
- */
-const BLOCKER_OPEN = "<!-- red:blocker-state v1 -->";
-const BLOCKER_CLOSE = "<!-- /red:blocker-state -->";
-
-function hasActiveBlocker(body: string): boolean {
-  const start = body.indexOf(BLOCKER_OPEN);
-  if (start < 0) return false;
-  const end = body.indexOf(BLOCKER_CLOSE, start + BLOCKER_OPEN.length);
-  if (end < 0) return false;
-  const inner = body.slice(start + BLOCKER_OPEN.length, end);
-  const fields: Record<string, string> = {};
-  for (const line of inner.split("\n")) {
-    const match = /^([a-z_]+):\s*(.*)$/.exec(line.trim());
-    if (match) fields[match[1]!] = match[2]!.trim();
-  }
-  return fields.status === "blocked" && Boolean(fields.summary) && Boolean(fields.next);
-}
-
 function danglingClaims(inputs: DeadendAuditInputs, live: ReadonlySet<string>): DeadendFinding[] {
   const findings: DeadendFinding[] = [];
   for (const claim of inputs.claims) {
@@ -236,12 +215,15 @@ function activeCurrentBlockers(inputs: DeadendAuditInputs): DeadendFinding[] {
   const findings: DeadendFinding[] = [];
   for (const issue of inputs.issues) {
     if (!issue.labels.includes(LABEL_READY)) continue;
-    if (!hasActiveBlocker(issue.body)) continue;
+    const blocker = parseCurrentBlocker(issue.body);
+    if (!blocker) continue;
     findings.push({
       deadendClass: "active_current_blocker",
       cure: CURE_BY_CLASS.active_current_blocker,
       subject: `#${issue.number}`,
-      detail: "ready-for-agent Ticket carries an active Current blocker",
+      detail: blocker.defect
+        ? `ready-for-agent Ticket carries an active Current blocker (${blocker.defect.name}: missing ${blocker.defect.missingFields.join(", ")})`
+        : "ready-for-agent Ticket carries an active Current blocker",
       healTarget: issue.number,
     });
   }

--- a/apps/dev/src/core/hitl-resolve.ts
+++ b/apps/dev/src/core/hitl-resolve.ts
@@ -1,4 +1,4 @@
-import { clearCurrentBlocker, parseCurrentBlocker } from "./blocker-state.js";
+import { applyRequeue, type RequeueFreshnessResult } from "./requeue.js";
 import { isRefused, planTransition } from "./state-transition.js";
 
 /**
@@ -22,6 +22,7 @@ export interface HitlResolveDeps {
   viewBody(issue: number): Promise<string>;
   /** Overwrite the issue body with the new markdown. */
   editBody(issue: number, body: string): Promise<void>;
+  verifyBaseFreshness(body: string): Promise<RequeueFreshnessResult>;
 }
 
 export interface HitlResolveResult {
@@ -39,11 +40,9 @@ export async function resolveHitlDecision(
   const rationaleComment =
     "> *This was recorded by the maintainer's session agent.*\n\n" +
     `🤖 HITL decision **${input.decision}** on #${input.issue}: ${input.rationale}`;
-  // Every decision leaves the rationale on the issue — the audit trail is not optional.
-  await deps.comment(input.issue, rationaleComment);
-  actions.push("rationale comment posted");
-
   if (input.decision === "close") {
+    await deps.comment(input.issue, rationaleComment);
+    actions.push("rationale comment posted");
     // Closing is a TRANSITION, not just a tracker verb (#2749): the park role
     // that brought the issue to HITL must not outlive the decision that ends
     // it, or the audit reads a resolved issue as still human-escalated. The
@@ -63,6 +62,8 @@ export async function resolveHitlDecision(
   const labels = await deps.viewLabels(input.issue);
 
   if (input.decision === "park") {
+    await deps.comment(input.issue, rationaleComment);
+    actions.push("rationale comment posted");
     const plan = planTransition(labels, { kind: "human" });
     if (!isRefused(plan) && (plan.add.length > 0 || plan.remove.length > 0)) {
       await deps.editLabels(input.issue, [...plan.remove], [...plan.add]);
@@ -71,34 +72,27 @@ export async function resolveHitlDecision(
     return { issue: input.issue, decision: input.decision, actions };
   }
 
-  // requeue / retake both free the issue: concede dangling claims first, then
-  // one atomic transition. A HUMAN decision consumes dangling req:* edges
-  // (promote) instead of refusing the way the automated queue path must.
-  const conceded = await deps.releaseClaims(input.issue);
-  if (conceded.length > 0) actions.push(`claims conceded: ${conceded.join(", ")}`);
-
-  // Clear any active Current blocker so the issue passes the coherence probe
-  // after the label transition. A hitl_resolve is an explicit human decision,
-  // so every blocker kind is accepted here regardless of the narrower set the
-  // CLI requeue operator enforces (#2597).
+  // Requeue / retake use the same complete transition as every machine caller;
+  // human authority is the only difference and permits every blocker kind.
   const body = await deps.viewBody(input.issue);
-  const activeBlocker = parseCurrentBlocker(body);
-  if (activeBlocker) {
-    const clearedBody = clearCurrentBlocker(body, {
-      summary: activeBlocker.summary,
-      resolution: input.rationale.trim() || "Resolved via hitl_resolve.",
-    });
-    await deps.editBody(input.issue, clearedBody);
-    actions.push(`body blocker cleared (kind=${activeBlocker.kind})`);
+  const applied = await applyRequeue(deps, {
+    issue: input.issue,
+    authority: "human",
+    body,
+    labels,
+    guidance: input.rationale,
+  });
+  if (!applied.applied) {
+    return { issue: input.issue, decision: input.decision, actions, refused: applied.reason };
   }
-
-  const hasReqEdges = labels.some((label) => label.startsWith("req:"));
-  const plan = planTransition(labels, { kind: hasReqEdges ? "promote" : "queue" });
-  if (isRefused(plan)) {
-    return { issue: input.issue, decision: input.decision, actions, refused: plan.reason };
+  actions.push("requeue directive posted");
+  if (applied.releasedClaims.length > 0) {
+    actions.push(`claims conceded: ${applied.releasedClaims.join(", ")}`);
   }
-  await deps.editLabels(input.issue, [...plan.remove], [...plan.add]);
-  actions.push(`labels transitioned (+${plan.add.join(",") || "∅"} -${plan.remove.join(",") || "∅"})`);
+  if (applied.plan.activeBlocker) {
+    actions.push(`body blocker cleared (kind=${applied.plan.activeBlocker.kind})`);
+  }
+  actions.push(`labels transitioned (+${applied.plan.addLabels.join(",") || "∅"} -${applied.plan.removeLabels.join(",") || "∅"})`);
   if (input.decision === "retake") {
     actions.push(
       "routed to the no-agent landing lane (ADR 0055): the reconcile dispatcher adopts the existing branch",

--- a/apps/dev/src/core/operational-probes/label-body-coherence.ts
+++ b/apps/dev/src/core/operational-probes/label-body-coherence.ts
@@ -1,4 +1,10 @@
-import { clearCurrentBlocker, parseCurrentBlocker, type CurrentBlocker } from "../blocker-state.js";
+import {
+  appendQuarantineDiagnosis,
+  clearCurrentBlocker,
+  parseCurrentBlocker,
+  quarantineMarker,
+  type CurrentBlocker,
+} from "../blocker-state.js";
 import { LABEL_READY } from "../triage-labels.js";
 import type {
   LabelBodyCoherenceIssueInput,
@@ -99,7 +105,7 @@ function labelBodyCoherenceData(finding: OperationalProbeResult): LabelBodyCoher
 export function buildLabelBodyCoherenceQuarantineComment(action: LabelBodyCoherenceAction): string {
   const ref = action.blocker.ref ? ` ref=${action.blocker.ref}` : "";
   return [
-    `<!-- afk:quarantine v1 issue=#${action.issue} -->`,
+    quarantineMarker(action.issue),
     `🤖 /afk coherence probe quarantined this issue: it carried \`ready-for-agent\` while the body still contained an active \`Current blocker\`.`,
     ``,
     `**Incoherence:** labels=\`[${action.labels.join(",")}]\` body-blocker=\`{kind=${action.blocker.kind}${ref} summary=${JSON.stringify(action.blocker.summary)}}\``,
@@ -112,10 +118,11 @@ export function buildLabelBodyCoherenceQuarantineComment(action: LabelBodyCohere
  * existing body. The marker makes retries idempotent even when a prior label
  * mutation failed after the body write. */
 export function appendLabelBodyCoherenceQuarantineDiagnosis(action: LabelBodyCoherenceAction): string {
-  const marker = `<!-- afk:quarantine v1 issue=#${action.issue} -->`;
-  if (action.body.includes(marker)) return action.body;
-  const body = action.body.replace(/\s+$/, "");
-  return `${body}\n\n## Quarantine diagnosis\n\n${buildLabelBodyCoherenceQuarantineComment(action)}\n`;
+  return appendQuarantineDiagnosis(
+    action.body,
+    action.issue,
+    buildLabelBodyCoherenceQuarantineComment(action),
+  );
 }
 
 function archiveBody(action: LabelBodyCoherenceAction): string {

--- a/apps/dev/src/core/requeue.ts
+++ b/apps/dev/src/core/requeue.ts
@@ -23,11 +23,8 @@ import {
   parseCurrentBlocker,
   type CurrentBlocker,
 } from "./blocker-state.js";
-import {
-  blockedLabelsIn,
-  validateIssueLifecycleTransition,
-} from "./issue-lifecycle.js";
-import { LABEL_HUMAN, LABEL_READY } from "./triage-labels.js";
+import { isRefused, planTransition } from "./state-transition.js";
+import { LABEL_READY } from "./triage-labels.js";
 
 /**
  * Blocker kinds AFK preflight treats as mechanical (auto-recoverable) and so
@@ -50,6 +47,8 @@ export const REQUEUE_SUPPORTED_KINDS = new Set([
 ]);
 
 export interface RequeueInput {
+  /** Machine callers are restricted to the mechanical allowlist; human callers may resolve any blocker kind. */
+  authority?: RequeueAuthority;
   /** The current issue body markdown. */
   body: string;
   /** The labels the issue currently carries. */
@@ -59,6 +58,8 @@ export interface RequeueInput {
   /** True when paired with `--adopt-branch`: a maintainer has reviewed a hand-done branch and is landing it through the ADR-0055 no-agent lane. */
   adoptBranch?: boolean;
 }
+
+export type RequeueAuthority = "machine" | "human";
 
 /**
  * Is `kind` requeueable? The supported set is
@@ -88,6 +89,46 @@ export interface RequeuePlan {
   addLabels: string[];
   /** Labels to remove: stale `ready-for-human` plus every `blocked:*` present. */
   removeLabels: string[];
+}
+
+export interface RequeueFreshnessResult {
+  ok: boolean;
+  evidence: string;
+}
+
+export interface RequeueApplierDeps {
+  verifyBaseFreshness(body: string): Promise<RequeueFreshnessResult>;
+  releaseClaims(issue: number): Promise<string[]>;
+  editBody(issue: number, body: string): Promise<void>;
+  comment(issue: number, body: string): Promise<void>;
+  editLabels(issue: number, remove: string[], add: string[]): Promise<void>;
+}
+
+export interface ApplyRequeueInput extends RequeueInput {
+  issue: number;
+  authority: RequeueAuthority;
+}
+
+export interface ApplyRequeueResult {
+  plan: RequeuePlan;
+  applied: boolean;
+  reason?: string;
+  releasedClaims: string[];
+  freshness?: RequeueFreshnessResult;
+}
+
+/** The audit directive emitted by every successful requeue, regardless of caller. */
+export function formatRequeueDirective(plan: RequeuePlan, guidance: string): string {
+  return [
+    '<details data-kind="directive">',
+    "<summary>Requeue</summary>",
+    "",
+    "Human guidance:",
+    guidance.trim() || "(none recorded)",
+    "",
+    `Disposition:\nrequeued to ready-for-agent${plan.activeBlocker ? ` (cleared active blocker: ${plan.activeBlocker.kind})` : ""}`,
+    "</details>",
+  ].join("\n");
 }
 
 function refuse(
@@ -135,9 +176,10 @@ export function isRequeueComplete(body: string, labels: readonly string[]): bool
  * the caller to `/hitl` instead.
  */
 export function planRequeue(input: RequeueInput): RequeuePlan {
+  const authority = input.authority ?? "machine";
   const activeBlocker = parseCurrentBlocker(input.body);
-  const blocked = blockedLabelsIn(input.labels);
-  const hasHuman = input.labels.includes(LABEL_HUMAN);
+  const blocked = input.labels.filter((label) => label.startsWith("blocked:"));
+  const hasHuman = input.labels.includes("ready-for-human");
 
   // "Parked" = something marks this issue as needing the human lane. Without an
   // active blocker, a blocked:* label, or ready-for-human there is nothing to
@@ -172,9 +214,9 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
   const labelKind = blocked.length === 1 ? blocked[0].slice("blocked:".length) : null;
 
   // Unsupported label kind → /hitl handles other human-input blocker types.
-  if (labelKind !== null && !kindRequeueable(labelKind)) {
+  if (authority === "machine" && labelKind !== null && !kindRequeueable(labelKind)) {
     return refuse(
-      `blocked:${labelKind} is not in the supported set (validation, spec, infra, base-stale): use /hitl`,
+      `blocked:${labelKind} is not in the supported set for machine authority (validation, spec, infra, base-stale): use /hitl for human authority`,
       true,
       activeBlocker,
       input.body,
@@ -184,11 +226,12 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
   // Active body blocker with an unsupported kind (no matching label to catch it above).
   if (
     activeBlocker !== null &&
+    authority === "machine" &&
     !MECHANICAL_BLOCKER_KINDS.has(activeBlocker.kind) &&
     !kindRequeueable(activeBlocker.kind)
   ) {
     return refuse(
-      `active blocker kind "${activeBlocker.kind}" is not in the supported set (validation, spec, infra, base-stale): use /hitl`,
+      `active blocker kind "${activeBlocker.kind}" is not in the supported set for machine authority (validation, spec, infra, base-stale): use /hitl for human authority`,
       true,
       activeBlocker,
       input.body,
@@ -212,14 +255,16 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
       })
     : input.body;
 
-  const removeLabels = [...(hasHuman ? [LABEL_HUMAN] : []), ...blocked];
-  const addLabels = [LABEL_READY];
-  validateIssueLifecycleTransition({
-    edge: "requeue",
-    fromLabels: input.labels,
-    removeLabels,
-    addLabels,
-  });
+  const hasReqEdges = input.labels.some((label) => label.startsWith("req:"));
+  const transition = planTransition(
+    input.labels,
+    { kind: authority === "human" && hasReqEdges ? "promote" : "queue" },
+  );
+  if (isRefused(transition)) {
+    return refuse(transition.reason, authority === "machine", activeBlocker, input.body);
+  }
+  const removeLabels = [...transition.remove];
+  const addLabels = [...transition.add];
 
   return {
     requeueable: true,
@@ -233,4 +278,42 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
     addLabels,
     removeLabels,
   };
+}
+
+/**
+ * Apply the complete requeue transition through the Park's single door. The
+ * authority matrix lives in {@link planRequeue}; every accepted caller then
+ * crosses the same freshness guard, claim sweep, body clear, directive audit,
+ * and label transition in that order.
+ */
+export async function applyRequeue(
+  deps: RequeueApplierDeps,
+  input: ApplyRequeueInput,
+): Promise<ApplyRequeueResult> {
+  const plan = planRequeue(input);
+  if (!plan.requeueable) {
+    return {
+      plan,
+      applied: false,
+      reason: plan.reason,
+      releasedClaims: [],
+    };
+  }
+
+  const freshness = await deps.verifyBaseFreshness(input.body);
+  if (!freshness.ok) {
+    return {
+      plan,
+      applied: false,
+      reason: `base freshness verification failed: ${freshness.evidence}`,
+      releasedClaims: [],
+      freshness,
+    };
+  }
+
+  const releasedClaims = await deps.releaseClaims(input.issue);
+  if (plan.bodyChanged) await deps.editBody(input.issue, plan.body);
+  await deps.comment(input.issue, formatRequeueDirective(plan, input.guidance ?? ""));
+  await deps.editLabels(input.issue, [...plan.removeLabels], [...plan.addLabels]);
+  return { plan, applied: true, releasedClaims, freshness };
 }

--- a/apps/dev/src/mcp-adapter.ts
+++ b/apps/dev/src/mcp-adapter.ts
@@ -106,7 +106,7 @@ import {
 import { readAllWorkerStates } from "./core/worker-state-reader.js";
 import { resolveProject } from "./commands/statusline.js";
 import { executeStopWorker } from "./commands/stop.js";
-import { executeRequeue } from "./commands/requeue.js";
+import { executeRequeue, verifyFreshBase } from "./commands/requeue.js";
 import { executeRetake } from "./commands/retake.js";
 import {
   dispatchGo,
@@ -812,6 +812,7 @@ export function createDefaultDevAfkMcpOperations(
           editBody: async (issue, body) => {
             await ghx.editBody(gh, issue, body);
           },
+          verifyBaseFreshness: (body) => verifyFreshBase(context.root, body),
         },
         input,
       );

--- a/apps/dev/tests/blocker-state.test.ts
+++ b/apps/dev/tests/blocker-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  MALFORMED_BLOCKER_STATE,
   clearCurrentBlocker,
   formatCurrentBlocker,
   parseCurrentBlocker,
@@ -25,6 +26,24 @@ describe("blocker-state", () => {
     expect(parseCurrentBlocker("<!-- red:blocker-state v1 -->\nstatus: resolved\n<!-- /red:blocker-state -->")).toBeNull();
   });
 
+  it("fails closed on a malformed active block and names the repair defect", () => {
+    const malformed = [
+      "<!-- red:blocker-state v1 -->",
+      "status: blocked",
+      "kind: push-failed",
+      "<!-- /red:blocker-state -->",
+    ].join("\n");
+
+    expect(parseCurrentBlocker(malformed)).toMatchObject({
+      status: "blocked",
+      kind: "push-failed",
+      defect: {
+        name: MALFORMED_BLOCKER_STATE,
+        missingFields: ["summary", "next"],
+      },
+    });
+  });
+
   it("upserts the Current blocker section without touching later sections", () => {
     const body = "## Summary\nDo this.\n\n## Current blocker\n\nOld text.\n\n## Acceptance\n- [ ] Done\n";
     const next = upsertCurrentBlocker(body, blocker);
@@ -48,4 +67,3 @@ describe("blocker-state", () => {
     expect(next).toContain("- [x] Phase 2 measured no decode-layer win. - Continue only after redesigning the decode path.");
   });
 });
-

--- a/apps/dev/tests/deadend-audit.test.ts
+++ b/apps/dev/tests/deadend-audit.test.ts
@@ -117,6 +117,22 @@ describe("auditDeadends — per-class detection with pinned cure", () => {
     expect(cls.findings.map((f) => f.subject)).toEqual(["#300"]);
   });
 
+  it("quarantines a malformed status: blocked record and names its defect", () => {
+    const malformed = [
+      "<!-- red:blocker-state v1 -->",
+      "status: blocked",
+      "kind: runner",
+      "<!-- /red:blocker-state -->",
+    ].join("\n");
+    const report = auditDeadends(baseInputs({
+      issues: [{ number: 303, labels: ["ready-for-agent"], body: malformed }],
+    }));
+
+    const finding = findingsFor(report, "active_current_blocker").findings[0]!;
+    expect(finding.subject).toBe("#303");
+    expect(finding.detail).toContain("malformed-blocker-state");
+  });
+
   it("detects a dependency-blocked Ticket whose req targets all closed → unblock_sweep", () => {
     const report = auditDeadends(
       baseInputs({

--- a/apps/dev/tests/hitl-resolve.test.ts
+++ b/apps/dev/tests/hitl-resolve.test.ts
@@ -24,6 +24,7 @@ function makeDeps(labels: string[], conceded: string[] = [], body = ""): HitlRes
   releaseClaims: ReturnType<typeof vi.fn>;
   viewBody: ReturnType<typeof vi.fn>;
   editBody: ReturnType<typeof vi.fn>;
+  verifyBaseFreshness: ReturnType<typeof vi.fn>;
 } {
   let currentBody = body;
   return {
@@ -36,6 +37,7 @@ function makeDeps(labels: string[], conceded: string[] = [], body = ""): HitlRes
     editBody: vi.fn(async (_, newBody: string) => {
       currentBody = newBody;
     }),
+    verifyBaseFreshness: vi.fn(async () => ({ ok: true, evidence: "fresh" })),
   };
 }
 
@@ -50,7 +52,7 @@ describe("hitl_resolve decisions (#2369)", () => {
     });
 
     expect(deps.comment).toHaveBeenCalledTimes(1);
-    expect(String(deps.comment.mock.calls[0]![1])).toContain("HITL decision **requeue**");
+    expect(String(deps.comment.mock.calls[0]![1])).toContain('data-kind="directive"');
     expect(deps.releaseClaims).toHaveBeenCalledWith(2404);
     expect(deps.editLabels).toHaveBeenCalledTimes(1);
     const [, remove, add] = deps.editLabels.mock.calls[0]!;
@@ -141,12 +143,32 @@ describe("hitl_resolve decisions (#2369)", () => {
     });
 
     expect(deps.viewBody).toHaveBeenCalledWith(2428);
+    expect(deps.verifyBaseFreshness).toHaveBeenCalledWith(ACTIVE_BLOCKER_BODY);
     expect(deps.editBody).toHaveBeenCalledTimes(1);
     const writtenBody = deps.editBody.mock.calls[0]![1] as string;
     expect(parseCurrentBlocker(writtenBody)).toBeNull();
     expect(writtenBody).toContain("Resolved blockers");
     expect(result.actions.some((a) => a.includes("body blocker cleared"))).toBe(true);
     expect(result.actions.some((a) => a.includes("kind=runner"))).toBe(true);
+  });
+
+  it("requeues push-failed with human authority through freshness, claim sweep, directive, and one label edit", async () => {
+    const body = ACTIVE_BLOCKER_BODY.replace("kind: runner", "kind: push-failed");
+    const deps = makeDeps(["ready-for-human", "blocked:push-failed"], ["wOLD"], body);
+
+    const result = await resolveHitlDecision(deps, {
+      issue: 3334,
+      decision: "requeue",
+      rationale: "remote access restored",
+    });
+
+    expect(result.refused).toBeUndefined();
+    expect(deps.verifyBaseFreshness.mock.invocationCallOrder[0]!).toBeLessThan(
+      deps.releaseClaims.mock.invocationCallOrder[0]!,
+    );
+    expect(deps.releaseClaims).toHaveBeenCalledWith(3334);
+    expect(String(deps.comment.mock.calls[0]![1])).toContain('data-kind="directive"');
+    expect(deps.editLabels).toHaveBeenCalledTimes(1);
   });
 
   it("requeue: skips editBody when the issue has no active body blocker", async () => {

--- a/apps/dev/tests/requeue-applier.test.ts
+++ b/apps/dev/tests/requeue-applier.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatCurrentBlocker } from "../src/core/blocker-state.js";
+import { applyRequeue } from "../src/core/requeue.js";
+
+const pushFailedBody = `## Current blocker\n\n${formatCurrentBlocker({
+  status: "blocked",
+  kind: "push-failed",
+  summary: "The worker push failed after validation passed.",
+  next: "Restore remote access, then requeue.",
+})}\n`;
+
+function makeDeps() {
+  const order: string[] = [];
+  return {
+    order,
+    deps: {
+      verifyBaseFreshness: vi.fn(async (_body: string) => { order.push("freshness"); return { ok: true, evidence: "fresh" }; }),
+      releaseClaims: vi.fn(async (_issue: number) => { order.push("claims"); return ["wOLD"]; }),
+      editBody: vi.fn(async (_issue: number, _body: string) => { order.push("body"); }),
+      comment: vi.fn(async (_issue: number, _body: string) => { order.push("directive"); }),
+      editLabels: vi.fn(async (_issue: number, _remove: string[], _add: string[]) => { order.push("labels"); }),
+    },
+  };
+}
+
+describe("applyRequeue — the one Park door", () => {
+  it("refuses push-failed under machine authority without side effects", async () => {
+    const fixture = makeDeps();
+    const result = await applyRequeue(fixture.deps, {
+      issue: 3334,
+      authority: "machine",
+      body: pushFailedBody,
+      labels: ["ready-for-human", "blocked:push-failed"],
+      guidance: "Remote access restored.",
+    });
+
+    expect(result.applied).toBe(false);
+    expect(result.plan.reason).toContain("machine authority");
+    expect(fixture.order).toEqual([]);
+  });
+
+  it("passes push-failed under human authority with freshness, claim sweep, directive, and transition", async () => {
+    const fixture = makeDeps();
+    const result = await applyRequeue(fixture.deps, {
+      issue: 3334,
+      authority: "human",
+      body: pushFailedBody,
+      labels: ["ready-for-human", "blocked:push-failed"],
+      guidance: "Remote access restored.",
+    });
+
+    expect(result.applied).toBe(true);
+    expect(fixture.order).toEqual(["freshness", "claims", "body", "directive", "labels"]);
+    expect(fixture.deps.comment.mock.calls[0]![1]).toContain('data-kind="directive"');
+    expect(fixture.deps.editLabels).toHaveBeenCalledWith(
+      3334,
+      expect.arrayContaining(["ready-for-human", "blocked:push-failed"]),
+      ["ready-for-agent"],
+    );
+  });
+});

--- a/apps/dev/tests/requeue.test.ts
+++ b/apps/dev/tests/requeue.test.ts
@@ -37,6 +37,13 @@ const baseStaleBlocker = {
   next: "Refresh the local base from origin, then requeue.",
 };
 
+const pushFailedBlocker = {
+  status: "blocked" as const,
+  kind: "push-failed",
+  summary: "The worker push failed after validation passed.",
+  next: "Restore remote access, then requeue.",
+};
+
 const parkedBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${formatCurrentBlocker(
   validationBlocker,
 )}\n\n## Acceptance\n- [ ] Done\n`;
@@ -244,6 +251,38 @@ describe("requeue — unsupported kinds refuse even under --adopt-branch", () =>
     expect(plan.requeueable).toBe(false);
     expect(plan.refuseForHitl).toBe(true);
     expect(plan.reason).toMatch(/not in the supported set/);
+  });
+});
+
+describe("requeue — one-door authority matrix", () => {
+  const pushFailedBody = `## Current blocker\n\n${formatCurrentBlocker(pushFailedBlocker)}\n`;
+
+  it("refuses a non-mechanical park under machine authority", () => {
+    const plan = planRequeue({
+      authority: "machine",
+      body: pushFailedBody,
+      labels: ["ready-for-human", "blocked:push-failed"],
+      guidance: "Remote access is restored.",
+    });
+
+    expect(plan.requeueable).toBe(false);
+    expect(plan.reason).toContain("machine authority");
+  });
+
+  it("accepts the same push-failed park under human authority", () => {
+    const plan = planRequeue({
+      authority: "human",
+      body: pushFailedBody,
+      labels: ["ready-for-human", "blocked:push-failed"],
+      guidance: "Remote access is restored.",
+    });
+
+    expect(plan.requeueable).toBe(true);
+    expect(plan.activeBlocker?.kind).toBe("push-failed");
+    expect(plan.body).toContain("## Resolved blockers");
+    expect(plan.removeLabels).toEqual(
+      expect.arrayContaining(["ready-for-human", "blocked:push-failed"]),
+    );
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #3334. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3334

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788524386&installation_model_id=20659&pr_number=3338&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3338&signature=547158319c05f62a06d77db61d73e25bccdfcd2023512ede320c5da9a129ddbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->