### PR TITLE
chore: #3333 The Queue Custodian owns the merge: landing hands off and ends, the daemon detects a vanished intent, and an admission-born repair Worker heals or escalates

### DIFF
--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -61,6 +61,10 @@ import { resolveImplementerPluginRoots } from "../../runtime/implementer-environ
 import { createCastleWorkerLaneBridge } from "../../core/castle-worker-lane-bridge.js";
 import { createWorkerLogLinePublisher } from "../../runtime/redskilled-worker-log.js";
 import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../../core/claim-staleness.js";
+import {
+  createFileQueueCustodyStore,
+  handoffQueueCustody,
+} from "../../core/queue-custodian.js";
 
 import type { CurrentAttempt } from "./attempt.js";
 import { deriveActivity } from "./activity.js";
@@ -129,6 +133,9 @@ export function buildProcessDeps({
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo, exec };
   const gitCtx: GitContext = { cwd: ctx.root, exec, ghProbeTimeoutMs: LANDING_GH_PROBE_TIMEOUT_MS };
   const paths = afkPaths(ctx.root);
+  const queueCustodyStore = createFileQueueCustodyStore(
+    join(ctx.root, ".red", "state", "afk", "queue-custody.toon"),
+  );
   // The same beat reaches the host here too (#3079); null when this Worker was
   // not born by the daemon, so a direct `run` publishes nothing.
   const publishHostLogLine = createWorkerLogLinePublisher({ root: ctx.root });
@@ -364,6 +371,14 @@ export function buildProcessDeps({
     waitForReview,
     ciAwait,
     landingWait,
+    queueCustody: (identity, armNativeIntent) => handoffQueueCustody(
+      {
+        store: queueCustodyStore,
+        now: () => new Date().toISOString(),
+        armNativeIntent,
+      },
+      identity,
+    ),
     landingTailObserver:
       landingWait === "merge"
         ? undefined

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -43,6 +43,10 @@ import {
 } from "./merge.js";
 import { resolveLandSerialization, type LandLock } from "./land-lock.js";
 import { pushAttempt, type GitExec } from "./remote-branch.js";
+import type {
+  QueueCustodyHandoffResult,
+  QueueCustodyIdentity,
+} from "./queue-custodian.js";
 
 /** Everything the landing needs, all side effects injected — mirroring how
  * process-issue called each of these inline. */
@@ -132,6 +136,14 @@ export interface LandingDeps {
    * synchronous landing. `ci` and `none` return a deferred tail to the caller.
    */
   landingWait?: "merge" | "ci" | "none";
+  /**
+   * Native merge-queue custody. The callback arms the supplied forge intent,
+   * persists the hand-off, and returns only after both are established.
+   */
+  queueCustody?: (
+    identity: QueueCustodyIdentity,
+    armNativeIntent: () => Promise<{ readonly ok: boolean; readonly reason?: string }>,
+  ) => Promise<QueueCustodyHandoffResult>;
   /**
    * Non-blocking observability hook (issue #1279): invoked by the PR landing path
    * the moment the PR number is RESOLVED (open-or-reused, before the merge), so
@@ -329,6 +341,7 @@ export type LandingResult =
       mergeSha?: string;
       postMergeValidation?: LandingPostMergeValidation;
       deferred?: DeferredLandingTail;
+      custody?: { readonly prNumber: number; readonly outcome: "handed-off" };
     }
   | {
       ok: false;
@@ -506,6 +519,7 @@ export async function doLanding(
     await release?.();
   }
   if (!landed.ok) return landed;
+  if (landed.custody) return landed;
   if (landed.deferred) {
     const deferred = landed.deferred;
     return {
@@ -596,6 +610,21 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
       // #2986: the enqueue is not the merge. This budget owns the hold between
       // `--auto` exiting 0 and the forge reporting `merged: true`.
       mergeQueueWait: decorateMergeQueueWait(deps, input),
+      ...(deps.queueCustody
+        ? {
+            queueHandoff: (prNumber: number, armNativeIntent: () => Promise<{ ok: boolean; reason?: string }>) =>
+              deps.queueCustody!(
+                {
+                  repo: input.repo,
+                  prNumber,
+                  ownerTicket: input.issue,
+                  branch: input.branch,
+                  base: input.base,
+                },
+                armNativeIntent,
+              ),
+          }
+        : {}),
       // #3030: the confirmation's ONE repair for a PR the queue can never accept.
       // The pre-merge rebase worktree is already provisioned and already on this
       // branch, so the repair is the same integration step run once more against
@@ -643,6 +672,9 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
         return {
           ok: true,
           locked: input.locked,
+          ...(result.custody && result.prNumber != null
+            ? { custody: { prNumber: result.prNumber, outcome: "handed-off" as const } }
+            : {}),
           ...(result.mergeSha ? { mergeSha: result.mergeSha } : {}),
           ...(postMergeValidation ? { postMergeValidation } : {}),
         };

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -1156,6 +1156,15 @@ export interface LandPrInput {
    */
   mergeQueue?: boolean;
   /**
+   * Queue Custodian hand-off (ADR 0136). When present on a native queue, this
+   * owns arming the supplied native intent and durably accepting custody. A
+   * successful hand-off ends Landing; no merge-confirmation poll is started.
+   */
+  queueHandoff?: (
+    prNumber: number,
+    armNativeIntent: () => Promise<{ readonly ok: boolean; readonly reason?: string }>,
+  ) => Promise<{ readonly ok: boolean; readonly reason?: string }>;
+  /**
    * Budget for the merge confirmation every landing ends with (#2986). Absent →
    * {@link waitForQueuedMerge}'s defaults, and with no injected clock a single
    * probe — enough to answer a synchronous merge, never enough to claim a queued
@@ -1212,6 +1221,8 @@ export interface LandPrResult {
   mergeSha?: string;
   /** Fresh green CI evidence observed immediately before merge, when usable. */
   ciEvidence?: CiGreenEvidence;
+  /** Native intent was armed and durable custody now owns the asynchronous tail. */
+  custody?: boolean;
   /** Set on `ok:false` — the distinct failure mode (#812). */
   reason?: LandPrFailReason;
   /** Set on `reason: "merge-failed"` — the OBSERVED rejection cause and the one
@@ -2117,6 +2128,38 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
     const mergeArgs = ["gh", "-R", repo, "pr", "merge", String(prNumber), "--merge"];
     if (mergeQueue) mergeArgs.push("--auto");
     if (mergeTitle) mergeArgs.push("--subject", mergeTitle);
+    if (mergeQueue && input.queueHandoff) {
+      const custody = await input.queueHandoff(prNumber, async () => {
+        const rejected = await mergeWithStaleBranchRecovery(exec, {
+          repo,
+          gitRepo,
+          remote,
+          target,
+          prNumber,
+          mergeArgs,
+          ...(ciAwait ? { ciAwait } : {}),
+        });
+        return rejected == null
+          ? { ok: true }
+          : {
+              ok: false,
+              reason: rejected.mergeFailure?.summary ?? rejected.reason ?? "native merge intent was refused",
+            };
+      });
+      if (!custody.ok) {
+        return {
+          ok: false,
+          prNumber,
+          reason: "merge-failed",
+          mergeFailure: {
+            cause: "unknown",
+            summary: custody.reason ?? "the Queue Custodian could not arm native merge intent",
+            retryable: false,
+          },
+        };
+      }
+      return { ok: true, prNumber, custody: true };
+    }
     const rejected = await mergeWithStaleBranchRecovery(exec, {
       repo,
       gitRepo,

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -2241,6 +2241,15 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
     return mergeAfterCi(ciEvidence);
   };
 
+  // ADR 0136: a native queue with durable custody has no resident-owned tail.
+  // The legacy slot-release settings controlled where that tail detached; once
+  // custody owns it there is nothing to detach. Advisory review still concludes
+  // before the intent is armed, while freshness/CI belong to the queue itself.
+  if (mergeQueue && input.queueHandoff) {
+    if (waitForReview) await waitForReviewCheck(exec, repo, prNumber, waitForReview);
+    return mergeAfterCi();
+  }
+
   if (releaseAt === "none") {
     return {
       ok: true,

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1946,6 +1946,7 @@ export async function processIssue(
       ciAwait: deps.ciAwait,
       mergeQueueWait: deps.mergeQueueWait,
       landingWait: deps.landingWait,
+      queueCustody: deps.queueCustody,
       makeLandingWorktree: deps.makeLandingWorktree,
       removeLandingWorktree: deps.removeLandingWorktree,
       makeRebaseWorktree: deps.makeRebaseWorktree,
@@ -2111,6 +2112,25 @@ export async function processIssue(
       swept: true,
     };
   };
+  if (landing.ok && landing.custody) {
+    await releaseClaim();
+    deps.recordWorkerEvent?.("worker.landing_handed_off", {
+      issue,
+      pr_number: landing.custody.prNumber,
+      owner: "queue-custodian",
+    });
+    markTerminalState(deps, "done");
+    return {
+      outcome: "done",
+      issue,
+      branch: workerBranch,
+      base,
+      locked,
+      hooksFired,
+      preserved: true,
+      swept: false,
+    };
+  }
   if (landing.ok && landing.deferred) {
     const deferred = landing.deferred;
     if (!deps.landingTailObserver) {

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -59,6 +59,10 @@ import {
   type DeferredLandingTail,
   type LandingResult,
 } from "../landing.js";
+import type {
+  QueueCustodyHandoffResult,
+  QueueCustodyIdentity,
+} from "../queue-custodian.js";
 import { reconcile, type ReconcileInput } from "../reconcile.js";
 import { markProcessSafetyStep } from "../process-safety.js";
 import {
@@ -362,6 +366,11 @@ export interface ProcessIssueDeps {
   mergeQueueWait?: MergeQueueWaitInput;
   /** Slot-release boundary across the PR landing tail (#2427). */
   landingWait?: "merge" | "ci" | "none";
+  /** Durable native-queue hand-off; when present Landing arms and terminates. */
+  queueCustody?: (
+    identity: QueueCustodyIdentity,
+    armNativeIntent: () => Promise<{ readonly ok: boolean; readonly reason?: string }>,
+  ) => Promise<QueueCustodyHandoffResult>;
   /**
    * Shared tail observer. The call starts observation and returns the eventual
    * landing verdict; processIssue deliberately does not await it so the worker

--- a/apps/dev/src/core/queue-custodian.ts
+++ b/apps/dev/src/core/queue-custodian.ts
@@ -14,6 +14,9 @@ import {
   type RepairLaneDeps,
   type RepairLaneResult,
 } from "./repair-lane.js";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
 
 export interface QueueCustodyIdentity {
   readonly repo: string;
@@ -45,6 +48,72 @@ export interface QueueCustodyState {
 export interface QueueCustodyStore {
   read(): Promise<QueueCustodyState>;
   write(state: QueueCustodyState): Promise<void>;
+}
+
+const EMPTY_CUSTODY: QueueCustodyState = { version: 1, prs: {} };
+
+function decodeCustody(value: unknown): QueueCustodyState {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return EMPTY_CUSTODY;
+  const root = value as { version?: unknown; prs?: unknown };
+  if (root.version !== 1 || root.prs == null || typeof root.prs !== "object" || Array.isArray(root.prs)) {
+    return EMPTY_CUSTODY;
+  }
+  const prs: Record<string, QueueCustodyRecord> = {};
+  for (const [key, raw] of Object.entries(root.prs)) {
+    if (!/^\d+$/.test(key) || raw == null || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const record = raw as Partial<QueueCustodyRecord>;
+    if (
+      !Number.isSafeInteger(record.prNumber) ||
+      !Number.isSafeInteger(record.ownerTicket) ||
+      typeof record.repo !== "string" ||
+      typeof record.branch !== "string" ||
+      typeof record.base !== "string" ||
+      typeof record.handedOffAt !== "string" ||
+      typeof record.updatedAt !== "string" ||
+      !["watching", "repairing", "semantic-bounce", "human"].includes(record.status ?? "")
+    ) continue;
+    const semanticBounces = Array.isArray(record.semanticBounces)
+      ? record.semanticBounces.filter((failure): failure is QueueCustodyFailure =>
+          failure != null && typeof failure === "object" &&
+          typeof (failure as Partial<QueueCustodyFailure>).summary === "string" &&
+          typeof (failure as Partial<QueueCustodyFailure>).observedAt === "string")
+      : [];
+    prs[key] = {
+      repo: record.repo,
+      prNumber: record.prNumber as number,
+      ownerTicket: record.ownerTicket as number,
+      branch: record.branch,
+      base: record.base,
+      status: record.status as QueueCustodyRecord["status"],
+      semanticBounces,
+      handedOffAt: record.handedOffAt,
+      updatedAt: record.updatedAt,
+    };
+  }
+  return { version: 1, prs };
+}
+
+/** Atomic TOON store in the durable `.red/state/afk/` lane. */
+export function createFileQueueCustodyStore(path: string): QueueCustodyStore {
+  return {
+    async read() {
+      try {
+        return decodeCustody(decode(await readFile(path, "utf8")));
+      } catch {
+        return EMPTY_CUSTODY;
+      }
+    },
+    async write(state) {
+      await mkdir(dirname(path), { recursive: true });
+      const temporary = `${path}.tmp-${process.pid}-${crypto.randomUUID()}`;
+      await writeFile(
+        temporary,
+        encode(decodeCustody(state) as unknown as JsonValue, { keyedMapCollapse: true }),
+        "utf8",
+      );
+      await rename(temporary, path);
+    },
+  };
 }
 
 export interface QueueCustodyArmResult {

--- a/apps/dev/src/core/queue-custodian.ts
+++ b/apps/dev/src/core/queue-custodian.ts
@@ -16,7 +16,7 @@ export interface QueueCustodyIdentity {
 }
 
 export interface QueueCustodyRecord extends QueueCustodyIdentity {
-  readonly status: "watching";
+  readonly status: "watching" | "repairing";
   readonly semanticBounces: readonly QueueCustodyFailure[];
   readonly handedOffAt: string;
   readonly updatedAt: string;
@@ -50,6 +50,39 @@ export interface QueueCustodyHandoffDeps {
   readonly armNativeIntent: () => Promise<QueueCustodyArmResult>;
   /** Test/telemetry seam invoked only after the atomic store write resolves. */
   readonly afterWrite?: (record: QueueCustodyRecord) => void | Promise<void>;
+}
+
+export interface QueueCustodyPullRequestView {
+  readonly state: "OPEN" | "MERGED" | "CLOSED";
+  readonly nativeIntent: boolean;
+  readonly checks: "green" | "pending" | "failing";
+  readonly mergeStateStatus: string;
+  readonly mergeable: string;
+}
+
+export interface QueueCustodyRepairAdmission extends QueueCustodyIdentity {
+  readonly origin: "repair";
+  readonly kind: "repair";
+  readonly mergeStateStatus: string;
+  readonly mergeable: string;
+}
+
+export interface QueueCustodySweepDeps {
+  readonly store: QueueCustodyStore;
+  readonly now: () => string;
+  /** One budget-aware, batchable read for every open custody record. */
+  readonly observePullRequests: (
+    records: readonly QueueCustodyRecord[],
+  ) => Promise<Readonly<Record<string, QueueCustodyPullRequestView>>>;
+  /** The daemon's ordinary admission boundary; no private spawn is permitted. */
+  readonly admitRepairWorker: (
+    repair: QueueCustodyRepairAdmission,
+  ) => Promise<{ readonly admitted: boolean; readonly workerId?: string }>;
+}
+
+export interface QueueCustodySweepResult {
+  readonly merged: readonly number[];
+  readonly admitted: readonly { readonly prNumber: number; readonly workerId: string }[];
 }
 
 export type QueueCustodyHandoffResult =
@@ -87,4 +120,53 @@ export async function handoffQueueCustody(
   });
   await deps.afterWrite?.(record);
   return { ok: true, prNumber: identity.prNumber, outcome: "handed-off" };
+}
+
+/**
+ * One daemon sweep over durable custody. A live native intent remains entirely
+ * GitHub's job. A vanished intent on an open PR crosses the host's normal
+ * admission boundary exactly once and becomes visible as a repair Worker.
+ */
+export async function sweepQueueCustody(
+  deps: QueueCustodySweepDeps,
+): Promise<QueueCustodySweepResult> {
+  const state = await deps.store.read();
+  const watching = Object.values(state.prs).filter((record) => record.status === "watching");
+  if (watching.length === 0) return { merged: [], admitted: [] };
+
+  const views = await deps.observePullRequests(watching);
+  const next = { ...state.prs };
+  const merged: number[] = [];
+  const admitted: { prNumber: number; workerId: string }[] = [];
+
+  for (const record of watching) {
+    const view = views[String(record.prNumber)];
+    if (view == null) continue;
+    if (view.state === "MERGED") {
+      delete next[String(record.prNumber)];
+      merged.push(record.prNumber);
+      continue;
+    }
+    if (view.state !== "OPEN" || view.nativeIntent) continue;
+
+    const birth = await deps.admitRepairWorker({
+      ...record,
+      origin: "repair",
+      kind: "repair",
+      mergeStateStatus: view.mergeStateStatus,
+      mergeable: view.mergeable,
+    });
+    if (!birth.admitted || birth.workerId == null) continue;
+    next[String(record.prNumber)] = {
+      ...record,
+      status: "repairing",
+      updatedAt: deps.now(),
+    };
+    admitted.push({ prNumber: record.prNumber, workerId: birth.workerId });
+  }
+
+  if (merged.length > 0 || admitted.length > 0) {
+    await deps.store.write({ version: 1, prs: next });
+  }
+  return { merged, admitted };
 }

--- a/apps/dev/src/core/queue-custodian.ts
+++ b/apps/dev/src/core/queue-custodian.ts
@@ -1,0 +1,90 @@
+// queue-custodian — the one owner of "this pull request ends merged"
+// (ADR 0136, issue #3333).
+//
+// Landing gives this module an arm operation and the identity of the work. The
+// native intent is established first and the durable record is written second:
+// a record may therefore never claim custody of a PR the forge was not asked to
+// merge. Detection and repair build on this same record rather than inventing a
+// second queue inventory.
+
+export interface QueueCustodyIdentity {
+  readonly repo: string;
+  readonly prNumber: number;
+  readonly ownerTicket: number;
+  readonly branch: string;
+  readonly base: string;
+}
+
+export interface QueueCustodyRecord extends QueueCustodyIdentity {
+  readonly status: "watching";
+  readonly semanticBounces: readonly QueueCustodyFailure[];
+  readonly handedOffAt: string;
+  readonly updatedAt: string;
+}
+
+export interface QueueCustodyFailure {
+  readonly summary: string;
+  readonly check?: string;
+  readonly detailsUrl?: string;
+  readonly observedAt: string;
+}
+
+export interface QueueCustodyState {
+  readonly version: 1;
+  readonly prs: Readonly<Record<string, QueueCustodyRecord>>;
+}
+
+export interface QueueCustodyStore {
+  read(): Promise<QueueCustodyState>;
+  write(state: QueueCustodyState): Promise<void>;
+}
+
+export interface QueueCustodyArmResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+}
+
+export interface QueueCustodyHandoffDeps {
+  readonly store: QueueCustodyStore;
+  readonly now: () => string;
+  readonly armNativeIntent: () => Promise<QueueCustodyArmResult>;
+  /** Test/telemetry seam invoked only after the atomic store write resolves. */
+  readonly afterWrite?: (record: QueueCustodyRecord) => void | Promise<void>;
+}
+
+export type QueueCustodyHandoffResult =
+  | { readonly ok: true; readonly prNumber: number; readonly outcome: "handed-off" }
+  | { readonly ok: false; readonly prNumber: number; readonly outcome: "arm-failed"; readonly reason: string };
+
+/** Arm GitHub's durable native intent, then persist the custody hand-off. */
+export async function handoffQueueCustody(
+  deps: QueueCustodyHandoffDeps,
+  identity: QueueCustodyIdentity,
+): Promise<QueueCustodyHandoffResult> {
+  const armed = await deps.armNativeIntent();
+  if (!armed.ok) {
+    return {
+      ok: false,
+      prNumber: identity.prNumber,
+      outcome: "arm-failed",
+      reason: armed.reason?.trim() || "the native merge intent could not be armed",
+    };
+  }
+
+  const now = deps.now();
+  const state = await deps.store.read();
+  const existing = state.prs[String(identity.prNumber)];
+  const record: QueueCustodyRecord = {
+    ...identity,
+    status: "watching",
+    semanticBounces: existing?.semanticBounces ?? [],
+    handedOffAt: existing?.handedOffAt ?? now,
+    updatedAt: now,
+  };
+  await deps.store.write({
+    version: 1,
+    prs: { ...state.prs, [String(identity.prNumber)]: record },
+  });
+  await deps.afterWrite?.(record);
+  return { ok: true, prNumber: identity.prNumber, outcome: "handed-off" };
+}

--- a/apps/dev/src/core/queue-custodian.ts
+++ b/apps/dev/src/core/queue-custodian.ts
@@ -7,6 +7,14 @@
 // merge. Detection and repair build on this same record rather than inventing a
 // second queue inventory.
 
+import {
+  healQueueEjection,
+  type QueueFailure,
+  type RepairCandidate,
+  type RepairLaneDeps,
+  type RepairLaneResult,
+} from "./repair-lane.js";
+
 export interface QueueCustodyIdentity {
   readonly repo: string;
   readonly prNumber: number;
@@ -16,7 +24,7 @@ export interface QueueCustodyIdentity {
 }
 
 export interface QueueCustodyRecord extends QueueCustodyIdentity {
-  readonly status: "watching" | "repairing";
+  readonly status: "watching" | "repairing" | "semantic-bounce" | "human";
   readonly semanticBounces: readonly QueueCustodyFailure[];
   readonly handedOffAt: string;
   readonly updatedAt: string;
@@ -84,6 +92,33 @@ export interface QueueCustodySweepResult {
   readonly merged: readonly number[];
   readonly admitted: readonly { readonly prNumber: number; readonly workerId: string }[];
 }
+
+export interface QueueCustodySemanticEvidence {
+  readonly prNumber: number;
+  readonly branch: string;
+  readonly failure: QueueFailure;
+  readonly history: readonly QueueCustodyFailure[];
+}
+
+export interface QueueCustodyRepairDeps {
+  readonly store: QueueCustodyStore;
+  readonly now: () => string;
+  readonly repair: Omit<RepairLaneDeps, "attachQueueFailure" | "escalateOwner">;
+  readonly adoptBranch: (ownerTicket: number, branch: string) => Promise<void>;
+  readonly readyForAgent: (
+    ownerTicket: number,
+    evidence: QueueCustodySemanticEvidence,
+  ) => Promise<void>;
+  readonly readyForHuman: (
+    ownerTicket: number,
+    evidence: QueueCustodySemanticEvidence,
+  ) => Promise<void>;
+}
+
+export type QueueCustodyRepairResult =
+  | RepairLaneResult
+  | { readonly outcome: "ready-for-agent"; readonly prNumber: number; readonly bounce: 1 }
+  | { readonly outcome: "ready-for-human"; readonly prNumber: number; readonly bounce: number };
 
 export type QueueCustodyHandoffResult =
   | { readonly ok: true; readonly prNumber: number; readonly outcome: "handed-off" }
@@ -169,4 +204,76 @@ export async function sweepQueueCustody(
     await deps.store.write({ version: 1, prs: next });
   }
   return { merged, admitted };
+}
+
+/**
+ * Run one admission-born repair Worker. Mechanical recovery remains entirely in
+ * the repair lane. Only its semantic verdict crosses back to the Ticket, with
+ * branch adoption and a durable two-bounce history owned here.
+ */
+export async function repairQueueCustody(
+  deps: QueueCustodyRepairDeps,
+  candidate: RepairCandidate & QueueCustodyIdentity,
+  generatorCommands: readonly string[],
+): Promise<QueueCustodyRepairResult> {
+  const result = await healQueueEjection(
+    {
+      ...deps.repair,
+      attachQueueFailure: async () => undefined,
+      escalateOwner: async () => undefined,
+    },
+    candidate,
+    generatorCommands,
+  );
+
+  const state = await deps.store.read();
+  const record = state.prs[String(candidate.prNumber)];
+  if (record == null) return result;
+
+  if (result.outcome !== "escalated") {
+    await deps.store.write({
+      version: 1,
+      prs: {
+        ...state.prs,
+        [String(candidate.prNumber)]: {
+          ...record,
+          status: "watching",
+          updatedAt: deps.now(),
+        },
+      },
+    });
+    return result;
+  }
+
+  const observedAt = deps.now();
+  const failure: QueueCustodyFailure = { ...result.failure, observedAt };
+  const history = [...record.semanticBounces, failure];
+  const bounce = history.length;
+  const status = bounce >= 2 ? "human" as const : "semantic-bounce" as const;
+  await deps.store.write({
+    version: 1,
+    prs: {
+      ...state.prs,
+      [String(candidate.prNumber)]: {
+        ...record,
+        status,
+        semanticBounces: history,
+        updatedAt: observedAt,
+      },
+    },
+  });
+
+  const evidence: QueueCustodySemanticEvidence = {
+    prNumber: candidate.prNumber,
+    branch: candidate.branch,
+    failure: result.failure,
+    history,
+  };
+  await deps.adoptBranch(candidate.ownerTicket, candidate.branch);
+  if (bounce >= 2) {
+    await deps.readyForHuman(candidate.ownerTicket, evidence);
+    return { outcome: "ready-for-human", prNumber: candidate.prNumber, bounce };
+  }
+  await deps.readyForAgent(candidate.ownerTicket, evidence);
+  return { outcome: "ready-for-agent", prNumber: candidate.prNumber, bounce: 1 };
 }

--- a/apps/dev/src/mcp-server.ts
+++ b/apps/dev/src/mcp-server.ts
@@ -410,7 +410,10 @@ export async function main(
     return 2;
   }
   await dependencies.startCurator();
-  await dependencies.startMergeDriver();
+  // ADR 0136: the session-bound merge loop is retired. Native auto-merge holds
+  // the durable intent and the Queue Custodian invokes the merge-driver state
+  // machine only as a recovery arm after an observed ejection; opening an MCP
+  // session must not create a second watcher.
   // Started BEFORE the transport (#3014): its first pass is the session-boot
   // clearer, and it is detached inside, so a slow tracker delays no handshake.
   await dependencies.startUnblockSweep?.();

--- a/apps/dev/tests/mcp-server-routing.test.ts
+++ b/apps/dev/tests/mcp-server-routing.test.ts
@@ -86,7 +86,7 @@ describe("dev:afk MCP entrypoint routing", () => {
     expect(connect).not.toHaveBeenCalled();
   });
 
-  it("starts the issue curator in the castle resident before opening stdio", async () => {
+  it("starts the issue curator without reviving the retired session-bound merge driver", async () => {
     const calls: string[] = [];
 
     await expect(
@@ -103,7 +103,7 @@ describe("dev:afk MCP entrypoint routing", () => {
       }),
     ).resolves.toBe(0);
 
-    expect(calls).toEqual(["curator", "merge-driver", "connect"]);
+    expect(calls).toEqual(["curator", "connect"]);
   });
 
   // #3014: on a repo operated through live sessions only, the resident is the

--- a/apps/dev/tests/mcp-server-routing.test.ts
+++ b/apps/dev/tests/mcp-server-routing.test.ts
@@ -133,7 +133,7 @@ describe("dev:afk MCP entrypoint routing", () => {
       }),
     ).resolves.toBe(0);
 
-    expect(calls).toEqual(["curator", "merge-driver", "unblock", "self-update", "connect"]);
+    expect(calls).toEqual(["curator", "unblock", "self-update", "connect"]);
   });
 
   it("awaits resident cleanup after the MCP transport closes", async () => {

--- a/apps/dev/tests/queue-custodian.test.ts
+++ b/apps/dev/tests/queue-custodian.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  createFileQueueCustodyStore,
   handoffQueueCustody,
   repairQueueCustody,
   sweepQueueCustody,
@@ -21,6 +25,35 @@ function memoryStore(): QueueCustodyStore & { state: QueueCustodyState } {
 }
 
 describe("Queue Custodian", () => {
+  it("reloads custody from its durable AFK state lane", async () => {
+    const root = await mkdtemp(join(tmpdir(), "queue-custody-"));
+    try {
+      const path = join(root, ".red", "state", "afk", "queue-custody.toon");
+      const store = createFileQueueCustodyStore(path);
+      await handoffQueueCustody(
+        {
+          store,
+          now: () => "2026-08-05T12:30:00.000Z",
+          armNativeIntent: async () => ({ ok: true }),
+        },
+        {
+          repo: "reddb-io/red-skills",
+          prNumber: 3334,
+          ownerTicket: 3333,
+          branch: "afk/3333-queue-custodian",
+          base: "main",
+        },
+      );
+
+      expect((await createFileQueueCustodyStore(path).read()).prs["3334"]).toMatchObject({
+        status: "watching",
+        ownerTicket: 3333,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("arms native merge intent before durably accepting custody", async () => {
     const store = memoryStore();
     const calls: string[] = [];

--- a/apps/dev/tests/queue-custodian.test.ts
+++ b/apps/dev/tests/queue-custodian.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   handoffQueueCustody,
+  repairQueueCustody,
   sweepQueueCustody,
   type QueueCustodyState,
   type QueueCustodyStore,
@@ -102,5 +103,88 @@ describe("Queue Custodian", () => {
       }),
     );
     expect(store.state.prs["3334"]?.status).toBe("repairing");
+  });
+
+  it("requeues one semantic bounce with adoption, then parks the second with history", async () => {
+    const store = memoryStore();
+    const identity = {
+      repo: "reddb-io/red-skills",
+      prNumber: 3334,
+      ownerTicket: 3333,
+      branch: "afk/3333-queue-custodian",
+      base: "main",
+    };
+    let instant = "2026-08-05T13:00:00.000Z";
+    const readyForAgent = vi.fn(async () => undefined);
+    const readyForHuman = vi.fn(async () => undefined);
+    const adoptBranch = vi.fn(async () => undefined);
+    const summary = "required check integration rejected the merged tree";
+    const repairDeps = {
+      stampWorker: vi.fn(async () => undefined),
+      mergeBase: vi.fn(async () => ({ ok: true })),
+      runGenerator: vi.fn(async () => ({ ok: true })),
+      pushBranch: vi.fn(async () => ({ ok: true })),
+      enqueue: vi.fn(async () => ({ ok: true })),
+      waitForQueue: vi.fn(async () => ({
+        outcome: "semantic-failure" as const,
+        failure: { summary, check: "integration" },
+      })),
+    };
+    const handoff = () => handoffQueueCustody(
+      { store, now: () => instant, armNativeIntent: async () => ({ ok: true }) },
+      identity,
+    );
+    const admit = () => sweepQueueCustody({
+      store,
+      now: () => instant,
+      observePullRequests: async () => ({
+        "3334": {
+          state: "OPEN" as const,
+          nativeIntent: false,
+          checks: "failing" as const,
+          mergeStateStatus: "BLOCKED",
+          mergeable: "MERGEABLE",
+        },
+      }),
+      admitRepairWorker: async () => ({ admitted: true, workerId: `repair-${instant}` }),
+    });
+
+    await handoff();
+    await admit();
+    const first = await repairQueueCustody(
+      { store, now: () => instant, repair: repairDeps, adoptBranch, readyForAgent, readyForHuman },
+      { ...identity, mergeStateStatus: "BLOCKED", mergeable: "MERGEABLE", queued: false },
+      [],
+    );
+
+    expect(first).toMatchObject({ outcome: "ready-for-agent", bounce: 1 });
+    expect(adoptBranch).toHaveBeenCalledWith(3333, "afk/3333-queue-custodian");
+    expect(readyForAgent).toHaveBeenCalledWith(
+      3333,
+      expect.objectContaining({ prNumber: 3334, failure: expect.objectContaining({ summary }) }),
+    );
+    expect(readyForHuman).not.toHaveBeenCalled();
+
+    instant = "2026-08-05T14:00:00.000Z";
+    await handoff();
+    await admit();
+    const second = await repairQueueCustody(
+      { store, now: () => instant, repair: repairDeps, adoptBranch, readyForAgent, readyForHuman },
+      { ...identity, mergeStateStatus: "BLOCKED", mergeable: "MERGEABLE", queued: false },
+      [],
+    );
+
+    expect(second).toMatchObject({ outcome: "ready-for-human", bounce: 2 });
+    expect(readyForHuman).toHaveBeenCalledWith(
+      3333,
+      expect.objectContaining({
+        prNumber: 3334,
+        history: [
+          expect.objectContaining({ summary, observedAt: "2026-08-05T13:00:00.000Z" }),
+          expect.objectContaining({ summary, observedAt: "2026-08-05T14:00:00.000Z" }),
+        ],
+      }),
+    );
+    expect(store.state.prs["3334"]?.status).toBe("human");
   });
 });

--- a/apps/dev/tests/queue-custodian.test.ts
+++ b/apps/dev/tests/queue-custodian.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { doLanding } from "../src/core/landing.js";
+import { harness } from "./landing.test-support.js";
+import { readsPull } from "./support/gh-rest-fixtures.js";
 import {
   createFileQueueCustodyStore,
   handoffQueueCustody,
@@ -25,6 +28,36 @@ function memoryStore(): QueueCustodyStore & { state: QueueCustodyState } {
 }
 
 describe("Queue Custodian", () => {
+  it("ends Landing at custody hand-off without a merge-poll tail", async () => {
+    const store = memoryStore();
+    const landing = harness({
+      locked: false,
+      openPr: true,
+      nativeMergeQueue: true,
+      queueOutcome: "pending",
+    });
+    landing.deps.queueCustody = (identity, armNativeIntent) => handoffQueueCustody(
+      {
+        store,
+        now: () => "2026-08-05T12:30:00.000Z",
+        armNativeIntent,
+      },
+      identity,
+    );
+
+    const result = await doLanding(landing.deps, landing.input, landing.hooks);
+
+    expect(result).toEqual({
+      ok: true,
+      locked: false,
+      custody: { prNumber: 42, outcome: "handed-off" },
+    });
+    expect(landing.mergeCalls.some((argv) => argv.includes("--auto"))).toBe(true);
+    expect(landing.mergeCalls.filter((argv) => readsPull(argv))).toHaveLength(0);
+    expect(landing.firedHooks).toEqual(["pre_merge"]);
+    expect(store.state.prs["42"]).toMatchObject({ ownerTicket: 9, status: "watching" });
+  });
+
   it("reloads custody from its durable AFK state lane", async () => {
     const root = await mkdtemp(join(tmpdir(), "queue-custody-"));
     try {

--- a/apps/dev/tests/queue-custodian.test.ts
+++ b/apps/dev/tests/queue-custodian.test.ts
@@ -6,6 +6,10 @@ import { doLanding } from "../src/core/landing.js";
 import { harness } from "./landing.test-support.js";
 import { readsPull } from "./support/gh-rest-fixtures.js";
 import {
+  harness as processHarness,
+  processIssue,
+} from "./process-issue.test-helpers.js";
+import {
   createFileQueueCustodyStore,
   handoffQueueCustody,
   repairQueueCustody,
@@ -55,6 +59,31 @@ describe("Queue Custodian", () => {
     expect(landing.mergeCalls.some((argv) => argv.includes("--auto"))).toBe(true);
     expect(landing.mergeCalls.filter((argv) => readsPull(argv))).toHaveLength(0);
     expect(landing.firedHooks).toEqual(["pre_merge"]);
+    expect(store.state.prs["42"]).toMatchObject({ ownerTicket: 9, status: "watching" });
+  });
+
+  it("terminates the owning Worker without closing the Ticket at custody hand-off", async () => {
+    const store = memoryStore();
+    const { deps, input, trace } = processHarness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: false,
+      queueOutcome: "pending",
+    });
+    Object.assign(deps, {
+      nativeMergeQueue: true,
+      queueCustody: (identity: Parameters<typeof handoffQueueCustody>[1], armNativeIntent: () => Promise<{ ok: boolean; reason?: string }>) =>
+        handoffQueueCustody(
+          { store, now: () => "2026-08-05T12:30:00.000Z", armNativeIntent },
+          identity,
+        ),
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result).toMatchObject({ outcome: "done", swept: false });
+    expect(trace.released).toEqual([9]);
+    expect(trace.closed).toEqual([]);
     expect(store.state.prs["42"]).toMatchObject({ ownerTicket: 9, status: "watching" });
   });
 

--- a/apps/dev/tests/queue-custodian.test.ts
+++ b/apps/dev/tests/queue-custodian.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handoffQueueCustody,
+  type QueueCustodyState,
+  type QueueCustodyStore,
+} from "../src/core/queue-custodian.js";
+
+function memoryStore(): QueueCustodyStore & { state: QueueCustodyState } {
+  const store = {
+    state: { version: 1 as const, prs: {} },
+    async read() {
+      return store.state;
+    },
+    async write(state: QueueCustodyState) {
+      store.state = state;
+    },
+  };
+  return store;
+}
+
+describe("Queue Custodian", () => {
+  it("arms native merge intent before durably accepting custody", async () => {
+    const store = memoryStore();
+    const calls: string[] = [];
+    const armNativeIntent = vi.fn(async () => {
+      calls.push("arm-native-intent");
+      return { ok: true as const };
+    });
+
+    const result = await handoffQueueCustody(
+      {
+        store,
+        now: () => "2026-08-05T12:30:00.000Z",
+        armNativeIntent,
+        afterWrite: () => calls.push("custody-durable"),
+      },
+      {
+        repo: "reddb-io/red-skills",
+        prNumber: 3334,
+        ownerTicket: 3333,
+        branch: "afk/3333-queue-custodian",
+        base: "main",
+      },
+    );
+
+    expect(result).toEqual({ ok: true, prNumber: 3334, outcome: "handed-off" });
+    expect(calls).toEqual(["arm-native-intent", "custody-durable"]);
+    expect(store.state.prs["3334"]).toEqual({
+      repo: "reddb-io/red-skills",
+      prNumber: 3334,
+      ownerTicket: 3333,
+      branch: "afk/3333-queue-custodian",
+      base: "main",
+      status: "watching",
+      semanticBounces: [],
+      handedOffAt: "2026-08-05T12:30:00.000Z",
+      updatedAt: "2026-08-05T12:30:00.000Z",
+    });
+  });
+});

--- a/apps/dev/tests/queue-custodian.test.ts
+++ b/apps/dev/tests/queue-custodian.test.ts
@@ -129,7 +129,9 @@ describe("Queue Custodian", () => {
         store,
         now: () => "2026-08-05T12:30:00.000Z",
         armNativeIntent,
-        afterWrite: () => calls.push("custody-durable"),
+        afterWrite: () => {
+          calls.push("custody-durable");
+        },
       },
       {
         repo: "reddb-io/red-skills",

--- a/apps/dev/tests/queue-custodian.test.ts
+++ b/apps/dev/tests/queue-custodian.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   handoffQueueCustody,
+  sweepQueueCustody,
   type QueueCustodyState,
   type QueueCustodyStore,
 } from "../src/core/queue-custodian.js";
@@ -56,5 +57,50 @@ describe("Queue Custodian", () => {
       handedOffAt: "2026-08-05T12:30:00.000Z",
       updatedAt: "2026-08-05T12:30:00.000Z",
     });
+  });
+
+  it("turns a daemon-observed vanished intent into one admission-born repair Worker", async () => {
+    const store = memoryStore();
+    await handoffQueueCustody(
+      {
+        store,
+        now: () => "2026-08-05T12:30:00.000Z",
+        armNativeIntent: async () => ({ ok: true }),
+      },
+      {
+        repo: "reddb-io/red-skills",
+        prNumber: 3334,
+        ownerTicket: 3333,
+        branch: "afk/3333-queue-custodian",
+        base: "main",
+      },
+    );
+    const admitRepairWorker = vi.fn(async () => ({ admitted: true as const, workerId: "repair-1" }));
+
+    const sweep = await sweepQueueCustody({
+      store,
+      now: () => "2026-08-05T12:45:00.000Z",
+      observePullRequests: async () => ({
+        "3334": {
+          state: "OPEN",
+          nativeIntent: false,
+          checks: "green",
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+        },
+      }),
+      admitRepairWorker,
+    });
+
+    expect(sweep).toEqual({ merged: [], admitted: [{ prNumber: 3334, workerId: "repair-1" }] });
+    expect(admitRepairWorker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: "repair",
+        kind: "repair",
+        prNumber: 3334,
+        ownerTicket: 3333,
+      }),
+    );
+    expect(store.state.prs["3334"]?.status).toBe("repairing");
   });
 });

--- a/apps/dev/tests/queue-custodian.test.ts
+++ b/apps/dev/tests/queue-custodian.test.ts
@@ -62,6 +62,24 @@ describe("Queue Custodian", () => {
     expect(store.state.prs["42"]).toMatchObject({ ownerTicket: 9, status: "watching" });
   });
 
+  it("makes native custody the terminal hand-off regardless of legacy slot-release settings", async () => {
+    const store = memoryStore();
+    const landing = harness({ locked: false, openPr: true, nativeMergeQueue: true });
+    landing.deps.landingWait = "none";
+    landing.deps.queueCustody = (identity, armNativeIntent) => handoffQueueCustody(
+      { store, now: () => "2026-08-05T12:30:00.000Z", armNativeIntent },
+      identity,
+    );
+
+    const result = await doLanding(landing.deps, landing.input, landing.hooks);
+
+    expect(result).toMatchObject({
+      ok: true,
+      custody: { prNumber: 42, outcome: "handed-off" },
+    });
+    expect(result.ok && result.deferred).toBeUndefined();
+  });
+
   it("terminates the owning Worker without closing the Ticket at custody hand-off", async () => {
     const store = memoryStore();
     const { deps, input, trace } = processHarness({


### PR DESCRIPTION
Automated AFK landing for #3333. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3333

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788524523&installation_model_id=20659&pr_number=3339&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3339&signature=2dd599ae58a1f1259662d11cc18bcbb9c3f4ca152de2e432844badf9ac34ea7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->