### PR TITLE
chore: #3342 Brand tokens package: vendored DTCG source with provenance and ANSI/CSS derivation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -20,6 +20,7 @@
       "@reddb-io/github",
       "@reddb-io/shared",
       "@reddb-io/build-info",
+      "@reddb-io/brand-tokens",
       "@reddb-io/red-skills",
       "@reddb-io/red-castle",
       "@reddb-io/red-browser",

--- a/packages/brand-tokens/.upstream
+++ b/packages/brand-tokens/.upstream
@@ -1,0 +1,2 @@
+repo=reddb-io/brand
+sha=c76366f10aaf52722eeedadbca67e20a8a34f008

--- a/packages/brand-tokens/index.test.ts
+++ b/packages/brand-tokens/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BrandTokenError,
+  resolveColorToken,
+  tokenToAnsiBackground,
+  tokenToAnsiForeground,
+  tokenToCssHex,
+} from "./index.js";
+
+describe("brand color tokens", () => {
+  it("resolves brand.primary through red.500 to its published hex", () => {
+    expect(resolveColorToken("brand.primary")).toEqual({
+      name: "red.500",
+      hex: "#ff2056",
+    });
+    expect(tokenToCssHex("brand.primary")).toBe("#ff2056");
+  });
+
+  it("derives truecolor ANSI foreground and background escapes", () => {
+    expect(tokenToAnsiForeground("brand.primary")).toBe("\u001B[38;2;255;32;86m");
+    expect(tokenToAnsiBackground("brand.primary")).toBe("\u001B[48;2;255;32;86m");
+  });
+
+  it("throws a named error for a malformed token instead of choosing a fallback", () => {
+    expect(() => tokenToCssHex("brand")).toThrowError(
+      expect.objectContaining<Partial<BrandTokenError>>({
+        name: "BrandTokenError",
+        code: "TOKEN_MALFORMED",
+        tokenName: "brand",
+      }),
+    );
+  });
+
+  it("throws the same named error type for a missing token", () => {
+    expect(() => tokenToCssHex("does.not.exist")).toThrowError(
+      expect.objectContaining<Partial<BrandTokenError>>({
+        name: "BrandTokenError",
+        code: "TOKEN_NOT_FOUND",
+        tokenName: "does.not.exist",
+      }),
+    );
+  });
+});

--- a/packages/brand-tokens/index.ts
+++ b/packages/brand-tokens/index.ts
@@ -1,0 +1,137 @@
+import tokenDocumentJson from "./tokens.json" with { type: "json" };
+
+export type BrandTokenErrorCode =
+  | "TOKEN_NOT_FOUND"
+  | "TOKEN_MALFORMED"
+  | "TOKEN_ALIAS_CYCLE";
+
+export class BrandTokenError extends Error {
+  override readonly name = "BrandTokenError";
+
+  constructor(
+    readonly code: BrandTokenErrorCode,
+    readonly tokenName: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export interface ResolvedColorToken {
+  readonly name: string;
+  readonly hex: `#${string}`;
+}
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseTokenDocument(value: unknown): JsonObject {
+  if (!isObject(value) || !isObject(value.color)) {
+    throw new BrandTokenError(
+      "TOKEN_MALFORMED",
+      "color",
+      "The vendored DTCG document has no color token group.",
+    );
+  }
+  return value;
+}
+
+// Importing and validating here makes the vendored DTCG document the
+// module-load source of truth. Helpers never carry a copied fallback palette.
+const tokenDocument = parseTokenDocument(tokenDocumentJson);
+
+function qualifyColorTokenName(name: string): string {
+  return name.startsWith("color.") ? name : `color.${name}`;
+}
+
+function publicColorTokenName(name: string): string {
+  return name.startsWith("color.") ? name.slice("color.".length) : name;
+}
+
+function getTokenNode(path: string): unknown {
+  let node: unknown = tokenDocument;
+  for (const segment of path.split(".")) {
+    if (!isObject(node) || !(segment in node)) return undefined;
+    node = node[segment];
+  }
+  return node;
+}
+
+function malformed(requestedName: string, detail: string): BrandTokenError {
+  return new BrandTokenError(
+    "TOKEN_MALFORMED",
+    requestedName,
+    `Brand color token "${requestedName}" is malformed: ${detail}`,
+  );
+}
+
+function resolveColorTokenPath(
+  path: string,
+  requestedName: string,
+  visited: ReadonlySet<string>,
+): ResolvedColorToken {
+  if (visited.has(path)) {
+    throw new BrandTokenError(
+      "TOKEN_ALIAS_CYCLE",
+      requestedName,
+      `Brand color token "${requestedName}" contains an alias cycle at "${path}".`,
+    );
+  }
+
+  const node = getTokenNode(path);
+  if (node === undefined) {
+    throw new BrandTokenError(
+      "TOKEN_NOT_FOUND",
+      requestedName,
+      `Brand color token "${requestedName}" was not found (resolved path "${path}").`,
+    );
+  }
+  if (!isObject(node) || !("$value" in node)) {
+    throw malformed(requestedName, `"${path}" is not a token with a $value`);
+  }
+
+  const value = node.$value;
+  if (typeof value === "string") {
+    const alias = /^\{([^{}]+)\}$/.exec(value);
+    if (alias?.[1] === undefined) {
+      throw malformed(requestedName, `"${path}" has an invalid alias`);
+    }
+    return resolveColorTokenPath(alias[1], requestedName, new Set([...visited, path]));
+  }
+
+  if (!isObject(value) || typeof value.hex !== "string" || !/^#[0-9a-fA-F]{6}$/.test(value.hex)) {
+    throw malformed(requestedName, `"${path}" has no six-digit hex color value`);
+  }
+
+  return {
+    name: publicColorTokenName(path),
+    hex: value.hex.toLowerCase() as `#${string}`,
+  };
+}
+
+export function resolveColorToken(name: string): ResolvedColorToken {
+  return resolveColorTokenPath(qualifyColorTokenName(name), name, new Set());
+}
+
+export function tokenToCssHex(name: string): `#${string}` {
+  return resolveColorToken(name).hex;
+}
+
+function tokenToAnsi(name: string, layer: 38 | 48): string {
+  const hex = tokenToCssHex(name);
+  const red = Number.parseInt(hex.slice(1, 3), 16);
+  const green = Number.parseInt(hex.slice(3, 5), 16);
+  const blue = Number.parseInt(hex.slice(5, 7), 16);
+  return `\u001B[${layer};2;${red};${green};${blue}m`;
+}
+
+export function tokenToAnsiForeground(name: string): string {
+  return tokenToAnsi(name, 38);
+}
+
+export function tokenToAnsiBackground(name: string): string {
+  return tokenToAnsi(name, 48);
+}

--- a/packages/brand-tokens/package.json
+++ b/packages/brand-tokens/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@reddb-io/brand-tokens",
+  "version": "3.6.2",
+  "private": true,
+  "type": "module",
+  "description": "Vendored RedDB brand color tokens with ANSI and CSS derivation helpers (ADR 0137).",
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/brand-tokens/tokens.json
+++ b/packages/brand-tokens/tokens.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://tr.designtokens.org/format/2025.10/schema.json",
+  "$description": "RedDB design tokens — the canonical, machine-readable source of truth. DTCG 2025.10 (Design Tokens Format Module, first stable version). Hand-authored; tokens.css and tailwind-preset.js are build outputs of generators/build-tokens.mjs — never hand-edit them. Locked brand values: red #ff2056, ink #07080a, paper #f4f5f7 (from the marks, issues #13/#16); type Space Grotesk + JetBrains Mono (ADR 0001).",
+  "color": {
+    "$type": "color",
+    "$description": "Primitive palette (raw scale) and semantic roles (aliases). Feedback colours (success/warning/danger) are intentionally not published yet; issue #10 locked --ok #4ade80, --warn #fbbf24, and --danger #ff5470, with the rule that the accent never signals error.",
+    "red": {
+      "$description": "The brand accent. red.500 is the locked mark colour #ff2056; the other stops are derived by mixing toward white/black for hover, active, and on-light emphasis.",
+      "400": { "$value": { "colorSpace": "srgb", "components": [1, 0.3882, 0.5373], "hex": "#ff6389" } },
+      "500": {
+        "$value": { "colorSpace": "srgb", "components": [1, 0.1255, 0.3373], "hex": "#ff2056" },
+        "$extensions": {
+          "reddb": {
+            "contrastGuardrail": {
+              "normalText": { "passesOn": ["color.neutral.950", "color.neutral.900"], "failsOn": ["color.neutral.800"] },
+              "asFill": { "textPasses": ["color.neutral.950"], "textFails": ["color.neutral.0"] }
+            }
+          }
+        }
+      },
+      "600": { "$value": { "colorSpace": "srgb", "components": [0.8196, 0.102, 0.2745], "hex": "#d11a46" } },
+      "700": { "$value": { "colorSpace": "srgb", "components": [0.6784, 0.0863, 0.2275], "hex": "#ad163a" } }
+    },
+    "neutral": {
+      "$description": "Cool-gray ramp on the ink↔paper axis. neutral.50 is the locked paper #f4f5f7; neutral.950 is the locked ink #07080a; intermediate stops are hand-tuned on the same hue.",
+      "0": { "$value": { "colorSpace": "srgb", "components": [1, 1, 1], "hex": "#ffffff" } },
+      "50": { "$value": { "colorSpace": "srgb", "components": [0.9569, 0.9608, 0.9686], "hex": "#f4f5f7" } },
+      "100": { "$value": { "colorSpace": "srgb", "components": [0.9059, 0.9137, 0.9333], "hex": "#e7e9ee" } },
+      "200": { "$value": { "colorSpace": "srgb", "components": [0.8275, 0.8392, 0.8706], "hex": "#d3d6de" } },
+      "300": {
+        "$value": { "colorSpace": "srgb", "components": [0.702, 0.7216, 0.7686], "hex": "#b3b8c4" },
+        "$extensions": {
+          "reddb": {
+            "contrastGuardrail": {
+              "normalText": { "passesOn": ["color.neutral.950", "color.neutral.900", "color.neutral.800"], "failsOn": [] }
+            }
+          }
+        }
+      },
+      "400": {
+        "$value": { "colorSpace": "srgb", "components": [0.5451, 0.5686, 0.6314], "hex": "#8b91a1" },
+        "$extensions": {
+          "reddb": {
+            "contrastGuardrail": {
+              "normalText": { "passesOn": ["color.neutral.950", "color.neutral.900", "color.neutral.800"], "failsOn": [] }
+            }
+          }
+        }
+      },
+      "500": {
+        "$value": { "colorSpace": "srgb", "components": [0.4, 0.4275, 0.4941], "hex": "#666d7e" },
+        "$extensions": {
+          "reddb": {
+            "contrastGuardrail": {
+              "normalText": { "passesOn": [], "failsOn": ["color.neutral.950", "color.neutral.900", "color.neutral.800"] }
+            }
+          }
+        }
+      },
+      "600": { "$value": { "colorSpace": "srgb", "components": [0.2902, 0.3176, 0.3843], "hex": "#4a5162" } },
+      "700": { "$value": { "colorSpace": "srgb", "components": [0.2, 0.2235, 0.2863], "hex": "#333949" } },
+      "800": { "$value": { "colorSpace": "srgb", "components": [0.1176, 0.1333, 0.1765], "hex": "#1e222d" } },
+      "900": { "$value": { "colorSpace": "srgb", "components": [0.0706, 0.0784, 0.1059], "hex": "#12141b" } },
+      "950": { "$value": { "colorSpace": "srgb", "components": [0.0275, 0.0314, 0.0392], "hex": "#07080a" } }
+    },
+    "brand": {
+      "$description": "Semantic brand roles. on-primary is the black R the mark sets on the red field.",
+      "primary": { "$value": "{color.red.500}" },
+      "hover": { "$value": "{color.red.600}" },
+      "active": { "$value": "{color.red.700}" },
+      "on-primary": { "$value": "{color.neutral.950}" }
+    },
+    "ink": { "$value": "{color.neutral.950}", "$description": "The near-black foreground; the brand is dark-first." },
+    "paper": { "$value": "{color.neutral.50}", "$description": "The off-white ground." },
+    "surface": {
+      "muted": { "$value": "{color.neutral.100}" }
+    },
+    "border": {
+      "subtle": { "$value": "{color.neutral.200}" },
+      "strong": { "$value": "{color.neutral.300}" }
+    }
+  },
+  "fontFamily": {
+    "$type": "fontFamily",
+    "$description": "Space Grotesk for display and body, JetBrains Mono for code (ADR 0001). Space Grotesk has no italic and no weight 300; <em> maps to weight 500 and italic exists only in the mono.",
+    "sans": { "$value": ["Space Grotesk", "system-ui", "-apple-system", "Segoe UI", "sans-serif"] },
+    "mono": { "$value": ["JetBrains Mono", "ui-monospace", "SFMono-Regular", "Menlo", "monospace"] }
+  },
+  "fontWeight": {
+    "$type": "fontWeight",
+    "$description": "Weight 300 is excluded (dark-first: thin strokes lose weight to halation).",
+    "regular": { "$value": 400 },
+    "medium": { "$value": 500 },
+    "bold": { "$value": 700 }
+  },
+  "fontSize": {
+    "$type": "dimension",
+    "$description": "Modular scale, ~1.2 (minor third) from a 1rem base.",
+    "xs": { "$value": { "value": 0.75, "unit": "rem" } },
+    "sm": { "$value": { "value": 0.875, "unit": "rem" } },
+    "base": { "$value": { "value": 1, "unit": "rem" } },
+    "lg": { "$value": { "value": 1.125, "unit": "rem" } },
+    "xl": { "$value": { "value": 1.25, "unit": "rem" } },
+    "2xl": { "$value": { "value": 1.5, "unit": "rem" } },
+    "3xl": { "$value": { "value": 1.875, "unit": "rem" } },
+    "4xl": { "$value": { "value": 2.25, "unit": "rem" } },
+    "5xl": { "$value": { "value": 3, "unit": "rem" } },
+    "6xl": { "$value": { "value": 3.75, "unit": "rem" } }
+  },
+  "lineHeight": {
+    "$type": "number",
+    "$description": "Unitless multipliers.",
+    "tight": { "$value": 1.1 },
+    "snug": { "$value": 1.25 },
+    "normal": { "$value": 1.5 },
+    "relaxed": { "$value": 1.65 }
+  },
+  "letterSpacing": {
+    "$type": "dimension",
+    "tight": { "$value": { "value": -0.02, "unit": "em" } },
+    "normal": { "$value": { "value": 0, "unit": "em" } },
+    "wide": { "$value": { "value": 0.04, "unit": "em" } }
+  },
+  "spacing": {
+    "$type": "dimension",
+    "$description": "4px base grid; 1 unit = 0.25rem.",
+    "0": { "$value": { "value": 0, "unit": "rem" } },
+    "px": { "$value": { "value": 1, "unit": "px" } },
+    "0.5": { "$value": { "value": 0.125, "unit": "rem" } },
+    "1": { "$value": { "value": 0.25, "unit": "rem" } },
+    "2": { "$value": { "value": 0.5, "unit": "rem" } },
+    "3": { "$value": { "value": 0.75, "unit": "rem" } },
+    "4": { "$value": { "value": 1, "unit": "rem" } },
+    "5": { "$value": { "value": 1.25, "unit": "rem" } },
+    "6": { "$value": { "value": 1.5, "unit": "rem" } },
+    "8": { "$value": { "value": 2, "unit": "rem" } },
+    "10": { "$value": { "value": 2.5, "unit": "rem" } },
+    "12": { "$value": { "value": 3, "unit": "rem" } },
+    "16": { "$value": { "value": 4, "unit": "rem" } },
+    "20": { "$value": { "value": 5, "unit": "rem" } },
+    "24": { "$value": { "value": 6, "unit": "rem" } }
+  },
+  "radius": {
+    "$type": "dimension",
+    "$description": "The symbol's clipped corner is a hard geometric cut, so brand chrome favours restrained radii.",
+    "none": { "$value": { "value": 0, "unit": "rem" } },
+    "sm": { "$value": { "value": 0.125, "unit": "rem" } },
+    "md": { "$value": { "value": 0.375, "unit": "rem" } },
+    "lg": { "$value": { "value": 0.5, "unit": "rem" } },
+    "xl": { "$value": { "value": 0.75, "unit": "rem" } },
+    "2xl": { "$value": { "value": 1, "unit": "rem" } },
+    "full": { "$value": { "value": 9999, "unit": "px" } }
+  },
+  "duration": {
+    "$type": "duration",
+    "instant": { "$value": { "value": 75, "unit": "ms" } },
+    "fast": { "$value": { "value": 150, "unit": "ms" } },
+    "normal": { "$value": { "value": 250, "unit": "ms" } },
+    "slow": { "$value": { "value": 400, "unit": "ms" } }
+  },
+  "easing": {
+    "$type": "cubicBezier",
+    "$description": "Standard for most transitions; entrance decelerates, exit accelerates, emphasized for hero motion.",
+    "standard": { "$value": [0.4, 0, 0.2, 1] },
+    "entrance": { "$value": [0, 0, 0.2, 1] },
+    "exit": { "$value": [0.4, 0, 1, 1] },
+    "emphasized": { "$value": [0.2, 0, 0, 1] }
+  },
+  "shadow": {
+    "$type": "shadow",
+    "$description": "Elevation cast in ink at low alpha; tuned for a dark-first surface.",
+    "sm": { "$value": {
+      "color": { "colorSpace": "srgb", "components": [0.0275, 0.0314, 0.0392], "alpha": 0.12, "hex": "#07080a" },
+      "offsetX": { "value": 0, "unit": "px" }, "offsetY": { "value": 1, "unit": "px" },
+      "blur": { "value": 2, "unit": "px" }, "spread": { "value": 0, "unit": "px" }
+    } },
+    "md": { "$value": {
+      "color": { "colorSpace": "srgb", "components": [0.0275, 0.0314, 0.0392], "alpha": 0.16, "hex": "#07080a" },
+      "offsetX": { "value": 0, "unit": "px" }, "offsetY": { "value": 2, "unit": "px" },
+      "blur": { "value": 8, "unit": "px" }, "spread": { "value": 0, "unit": "px" }
+    } },
+    "lg": { "$value": {
+      "color": { "colorSpace": "srgb", "components": [0.0275, 0.0314, 0.0392], "alpha": 0.2, "hex": "#07080a" },
+      "offsetX": { "value": 0, "unit": "px" }, "offsetY": { "value": 8, "unit": "px" },
+      "blur": { "value": 24, "unit": "px" }, "spread": { "value": 0, "unit": "px" }
+    } },
+    "xl": { "$value": {
+      "color": { "colorSpace": "srgb", "components": [0.0275, 0.0314, 0.0392], "alpha": 0.24, "hex": "#07080a" },
+      "offsetX": { "value": 0, "unit": "px" }, "offsetY": { "value": 16, "unit": "px" },
+      "blur": { "value": 48, "unit": "px" }, "spread": { "value": 0, "unit": "px" }
+    } }
+  }
+}

--- a/packages/brand-tokens/tsconfig.json
+++ b/packages/brand-tokens/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,6 +435,18 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.20.1)
 
+  packages/brand-tokens:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.20.1)
+
   packages/browser-bridge:
     dependencies:
       '@reddb-io/toon':


### PR DESCRIPTION
Automated AFK landing for #3342. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3342

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788531436&installation_model_id=20659&pr_number=3356&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3356&signature=d4373a8a27e45788bba38ebf4548b0c2ce93a7eb82778cf072f65500ba8e5056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->