### PR TITLE
chore: #3344 Brand watch workflow: drift between recorded brand SHA and reddb-io/brand becomes a drainable issue

### DIFF
--- a/.github/workflows/red-brand-watch.yml
+++ b/.github/workflows/red-brand-watch.yml
@@ -1,0 +1,98 @@
+name: red-brand-watch
+
+on:
+  schedule:
+    - cron: '20 12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: red-brand-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Load recorded brand provenance
+        id: pin
+        run: |
+          set -euo pipefail
+          . ./packages/brand-tokens/.upstream
+
+          if ! [[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "::error::brand provenance contains an invalid repository"
+            exit 1
+          fi
+          if ! [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::brand provenance contains an invalid SHA"
+            exit 1
+          fi
+
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch brand HEAD
+        id: head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ steps.pin.outputs.repo }}
+        run: |
+          set -euo pipefail
+          sha="$(gh api "repos/$REPO/commits/HEAD" --jq .sha)"
+          if ! [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::brand HEAD did not resolve to a full SHA"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update drift issue
+        if: steps.head.outputs.sha != steps.pin.outputs.sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ steps.pin.outputs.repo }}
+          OLD: ${{ steps.pin.outputs.sha }}
+          NEW: ${{ steps.head.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          title="brand: refresh vendored tokens to ${NEW:0:7}"
+          existing="$(gh issue list --search '"brand: refresh vendored tokens" in:title' --state open --limit 100 --json number --jq '.[0].number')"
+          body_file="$(mktemp)"
+          trap 'rm -f "$body_file"' EXIT
+
+          {
+            printf 'The vendored brand tokens trail `%s` HEAD.\n\n' "$REPO"
+            printf -- '- recorded SHA: `%s`\n' "$OLD"
+            printf -- '- upstream HEAD: `%s`\n' "$NEW"
+            printf -- '- compare: https://github.com/%s/compare/%s...%s\n\n' "$REPO" "$OLD" "$NEW"
+            cat <<'BODY'
+          ## Agent brief
+
+          Refresh `packages/brand-tokens/tokens.json` from `tokens/tokens.json` at the upstream HEAD, then update `packages/brand-tokens/.upstream` to record that full SHA. Verify the brand-token package tests and preserve the vendored DTCG document as the only token source.
+
+          The watch workflow reports drift only; it does not change vendored source.
+          BODY
+          } > "$body_file"
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" \
+              --title "$title" \
+              --body-file "$body_file" \
+              --add-label upstream-drift \
+              --add-label type:task \
+              --add-label ready-for-agent
+          else
+            gh issue create \
+              --title "$title" \
+              --body-file "$body_file" \
+              --label upstream-drift \
+              --label type:task \
+              --label ready-for-agent
+          fi

--- a/apps/dev/tests/red-brand-watch-workflow.test.ts
+++ b/apps/dev/tests/red-brand-watch-workflow.test.ts
@@ -1,0 +1,140 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import yaml from "js-yaml";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+interface WorkflowStep {
+  name?: string;
+  id?: string;
+  if?: string;
+  run?: string;
+}
+
+interface WorkflowFile {
+  name?: string;
+  on?: Record<string, unknown>;
+  permissions?: Record<string, string>;
+  jobs: Record<string, { steps: WorkflowStep[] }>;
+}
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function readWorkflow(): Promise<{ source: string; workflow: WorkflowFile }> {
+  const source = await readFile(join(ROOT, ".github/workflows/red-brand-watch.yml"), "utf8");
+  return { source, workflow: yaml.load(source) as WorkflowFile };
+}
+
+function namedStep(workflow: WorkflowFile, name: string): WorkflowStep {
+  const step = workflow.jobs.watch?.steps.find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`red-brand-watch is missing the '${name}' step`);
+  return step;
+}
+
+async function runIssueStepTwice(scriptBody: string): Promise<{ calls: string[]; body: string }> {
+  const root = await mkdtemp(join(tmpdir(), "red-brand-watch-"));
+  roots.push(root);
+
+  const bin = join(root, "bin");
+  await mkdir(bin, { recursive: true });
+  await writeFile(
+    join(bin, "gh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+case "$1 $2" in
+  "issue list")
+    if [ -f "$FAKE_ISSUE_STATE" ]; then printf '41\\n'; fi
+    ;;
+  "issue create"|"issue edit")
+    action="$2"
+    shift 2
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--body-file" ]; then cp "$2" "$FAKE_ISSUE_BODY"; break; fi
+      shift
+    done
+    printf '%s\\n' "$action" >> "$FAKE_GH_LOG"
+    touch "$FAKE_ISSUE_STATE"
+    ;;
+  *)
+    printf 'unexpected gh invocation: %s\\n' "$*" >&2
+    exit 1
+    ;;
+esac
+`,
+    "utf8",
+  );
+  await chmod(join(bin, "gh"), 0o755);
+
+  const script = join(root, "step.sh");
+  const log = join(root, "gh.log");
+  const state = join(root, "issue-state");
+  const body = join(root, "issue-body.md");
+  await writeFile(script, scriptBody, "utf8");
+  await writeFile(log, "", "utf8");
+
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH ?? ""}`,
+    GH_TOKEN: "posed",
+    REPO: "reddb-io/brand",
+    OLD: "1111111111111111111111111111111111111111",
+    NEW: "2222222222222222222222222222222222222222",
+    FAKE_GH_LOG: log,
+    FAKE_ISSUE_STATE: state,
+    FAKE_ISSUE_BODY: body,
+  };
+
+  await execFileAsync("bash", [script], { cwd: root, env });
+  await execFileAsync("bash", [script], { cwd: root, env });
+
+  return {
+    calls: (await readFile(log, "utf8")).trim().split("\n"),
+    body: await readFile(body, "utf8"),
+  };
+}
+
+describe("red-brand-watch workflow", () => {
+  it("reads the repository and recorded SHA from the brand tokens provenance", async () => {
+    const { source, workflow } = await readWorkflow();
+    const pin = namedStep(workflow, "Load recorded brand provenance");
+    const head = namedStep(workflow, "Fetch brand HEAD");
+
+    expect(workflow.name).toBe("red-brand-watch");
+    expect(workflow.on).toHaveProperty("schedule");
+    expect(workflow.on).toHaveProperty("workflow_dispatch");
+    expect(workflow.permissions).toEqual({ contents: "read", issues: "write" });
+    expect(pin.run).toContain(". ./packages/brand-tokens/.upstream");
+    expect(pin.run).toContain('echo "repo=$repo" >> "$GITHUB_OUTPUT"');
+    expect(pin.run).toContain('echo "sha=$sha" >> "$GITHUB_OUTPUT"');
+    expect(source).toContain("REPO: ${{ steps.pin.outputs.repo }}");
+    expect(head.run).toContain('repos/$REPO/commits/HEAD');
+    expect(source).not.toMatch(/c76366f10aaf52722eeedadbca67e20a8a34f008/);
+  });
+
+  it("creates one drift issue and updates it on the next posed drift run", async () => {
+    const { workflow } = await readWorkflow();
+    const issue = namedStep(workflow, "Open or update drift issue");
+
+    expect(issue.if).toBe("steps.head.outputs.sha != steps.pin.outputs.sha");
+    expect(issue.run).toContain("gh issue list");
+    expect(issue.run).toContain("--state open");
+    expect(issue.run).toContain("gh issue edit");
+    expect(issue.run).toContain("gh issue create");
+
+    const outcome = await runIssueStepTwice(issue.run ?? "");
+    expect(outcome.calls).toEqual(["create", "edit"]);
+    expect(outcome.body).toContain("1111111111111111111111111111111111111111");
+    expect(outcome.body).toContain("2222222222222222222222222222222222222222");
+    expect(outcome.body).toContain("## Agent brief");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3344. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3344

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788533395&installation_model_id=20659&pr_number=3360&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3360&signature=57ee79526869366044136967391a19ce52a56b12873b478ca84d91e0338c1928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->