### PR TITLE
chore: #3345 herdr panes adopt the Brand grammar: glyph-carried state, red-slot spotlight, package-sourced identity

### DIFF
--- a/apps/herdr-plugin-red-skills/package.json
+++ b/apps/herdr-plugin-red-skills/package.json
@@ -28,6 +28,7 @@
     "doctor": "node bin/red-skills-herdr.mjs doctor"
   },
   "dependencies": {
+    "@reddb-io/brand-tokens": "workspace:*",
     "@reddb-io/build-info": "workspace:*",
     "@reddb-io/toon": "catalog:"
   },

--- a/apps/herdr-plugin-red-skills/src/commands/doctor.mjs
+++ b/apps/herdr-plugin-red-skills/src/commands/doctor.mjs
@@ -21,7 +21,7 @@ import { herdrBin, insideHerdr, invocationCwd, pluginId } from "../herdr.mjs";
 import { style } from "../ui/ansi.mjs";
 
 function verdict(ok, text) {
-  return `${ok ? style.brightGreen("ok  ") : style.brightRed("fail")} ${text}`;
+  return `${ok ? style.dim("+ ok  ") : style.red("! fail")} ${text}`;
 }
 
 function note(text) {
@@ -32,7 +32,7 @@ export async function runDoctor({ config, flags = {} }) {
   const socket = resolveRedskilledPaths({ socketPath: flags.socket ?? config.socketPath });
   const lines = [];
 
-  lines.push(style.bold("herdr"));
+  lines.push(style.bold(style.identity("herdr")));
   lines.push(verdict(insideHerdr(), `HERDR_ENV=1 — this process ${insideHerdr() ? "is" : "is NOT"} inside a herdr pane`));
   lines.push(note(`binary       ${herdrBin()}`));
   lines.push(note(`plugin id    ${pluginId()}`));
@@ -41,7 +41,7 @@ export async function runDoctor({ config, flags = {} }) {
   lines.push(note(`config file  ${config.path}${config.present ? "" : style.gray(" (absent — running on declared defaults)")}`));
 
   lines.push("");
-  lines.push(style.bold("redskilled"));
+  lines.push(style.bold(style.identity("redskilled")));
   lines.push(note(`socket       ${socket.socketPath}`));
   lines.push(note(`resolved by  ${socket.source}`));
   lines.push(note(`runtime dir  ${socket.runtimeDir}`));
@@ -74,7 +74,7 @@ export async function runDoctor({ config, flags = {} }) {
         verdict(
           true,
           `statusline-payload: ${payload.host.worker_count} Worker(s) · ${payload.host.project_count} project(s) · ` +
-            `${payload.repository_activity?.projects?.length ?? 0} repository(ies) polled${payload.staleness.stale ? style.yellow(" · STALE") : ""}`,
+            `${payload.repository_activity?.projects?.length ?? 0} repository(ies) polled${payload.staleness.stale ? style.red(" · ▲ STALE") : ""}`,
         ),
       );
     } catch (error) {
@@ -102,7 +102,7 @@ export async function runDoctor({ config, flags = {} }) {
   const label = await resolveProjectLabel(target).catch(() => null);
   lines.push(
     label
-      ? verdict(true, `project label ${style.brightCyan(label)} — local mode scopes to this`)
+      ? verdict(true, `project label ${style.bold(label)} — local mode scopes to this`)
       : note("no project label resolves here, so local mode has nothing to scope to"),
   );
 

--- a/apps/herdr-plugin-red-skills/src/ui/ansi.mjs
+++ b/apps/herdr-plugin-red-skills/src/ui/ansi.mjs
@@ -6,6 +6,8 @@
  * table padded by byte length is a table that drifts one column further right
  * with every colour added to it.
  */
+import { tokenToAnsiForeground } from "@reddb-io/brand-tokens";
+
 const enabled = !process.env.NO_COLOR && process.env.TERM !== "dumb";
 
 const CODES = {
@@ -15,21 +17,9 @@ const CODES = {
   italic: 3,
   underline: 4,
   inverse: 7,
-  black: 30,
   red: 31,
-  green: 32,
-  yellow: 33,
-  blue: 34,
-  magenta: 35,
-  cyan: 36,
   white: 37,
   gray: 90,
-  brightRed: 91,
-  brightGreen: 92,
-  brightYellow: 93,
-  brightBlue: 94,
-  brightMagenta: 95,
-  brightCyan: 96,
 };
 
 /** The escape byte, written once here so no other module carries a raw one. */
@@ -42,7 +32,17 @@ function wrap(code) {
   return (text) => (enabled ? `\u001b[${code}m${text}\u001b[0m` : String(text));
 }
 
-export const style = Object.fromEntries(Object.entries(CODES).map(([name, code]) => [name, wrap(code)]));
+function wrapAnsi(open) {
+  return (text) => (enabled ? `${open}${text}\u001b[0m` : String(text));
+}
+
+export const style = {
+  ...Object.fromEntries(Object.entries(CODES).map(([name, code]) => [name, wrap(code)])),
+  // Identity is the only truecolor moment in a pane. The sequence and its value
+  // both come from the package; this surface owns neither a copied hex nor an
+  // ANSI derivation of its own.
+  identity: wrapAnsi(tokenToAnsiForeground("brand.primary")),
+};
 
 export const colorEnabled = enabled;
 

--- a/apps/herdr-plugin-red-skills/src/ui/board.mjs
+++ b/apps/herdr-plugin-red-skills/src/ui/board.mjs
@@ -90,16 +90,16 @@ export function renderBoard({ dashboard, state, size, socketPath, error }) {
   const { columns } = size;
   if (!dashboard) {
     return [
-      ` ${style.bold(style.brightRed("redskilled"))} ${style.gray("·")} ${style.brightRed("no host answered")}`,
+      ` ${style.bold(style.identity("redskilled"))} ${style.gray("·")} ${style.red("! no host answered")}`,
       ...renderBoardAbsence({ columns, error, socketPath }),
       ...renderBoardFooter({ columns, state }),
     ];
   }
 
   const [header, ...rows] = dashboard.lines;
-  const badge = dashboard.stale ? style.brightYellow("● stale") : style.brightGreen("● live");
+  const badge = dashboard.stale ? style.red("▲ stale") : style.dim("● live");
   const lines = [
-    truncate(` ${style.bold(style.brightRed(header ?? ""))}`, columns),
+    truncate(` ${style.bold(style.identity(header ?? ""))}`, columns),
     truncate(` ${badge} ${style.gray(dashboard.generated_at)}`, columns),
     rule("WORKERS", columns),
   ];
@@ -112,7 +112,7 @@ export function renderBoard({ dashboard, state, size, socketPath, error }) {
     for (const row of rows) lines.push(truncate(` ${paintRow(row)}`, columns));
   }
 
-  if (state.message) lines.push(truncate(` ${style.brightCyan(state.message)}`, columns));
+  if (state.message) lines.push(truncate(` ${style.red(`! ${state.message}`)}`, columns));
   lines.push(...renderBoardFooter({ columns, state }));
   return lines;
 }

--- a/apps/herdr-plugin-red-skills/src/ui/dashboard.mjs
+++ b/apps/herdr-plugin-red-skills/src/ui/dashboard.mjs
@@ -34,7 +34,7 @@ function blank() {
 export function renderHeader(snapshot, { columns, now }) {
   if (!snapshot.reachable) {
     return [
-      ` ${style.bold(style.brightRed("redskilled"))} ${style.gray("·")} ${style.brightRed("no host answered")}`,
+      ` ${style.bold(style.identity("redskilled"))} ${style.gray("·")} ${style.red("! no host answered")}`,
       ` ${style.gray(truncate(snapshot.error?.message ?? "the daemon did not answer", columns - 2))}`,
     ];
   }
@@ -42,8 +42,8 @@ export function renderHeader(snapshot, { columns, now }) {
   const daemon = snapshot.payload.daemon;
   const staleness = snapshot.payload.staleness;
   const badge = staleness.stale
-    ? style.brightYellow("● stale")
-    : style.brightGreen("● live");
+    ? style.red("▲ stale")
+    : style.dim("● live");
   // The payload's engine block first, the host-state's upgrade only where the
   // block is absent: one read answers "is my engine current" now, and the second
   // read stays only so a daemon older than the block still renders (ADR 0130
@@ -52,7 +52,7 @@ export function renderHeader(snapshot, { columns, now }) {
   const upgrade = snapshot.hostState?.upgrade;
 
   const left =
-    ` ${style.bold(style.brightRed("redskilled"))} ${style.white(engine?.running_version ?? daemon.daemon_version)}` +
+    ` ${style.bold(style.identity("redskilled"))} ${style.white(engine?.running_version ?? daemon.daemon_version)}` +
     ` ${style.gray("·")} pid ${daemon.pid}` +
     ` ${style.gray("·")} up ${duration(Date.parse(now) - Date.parse(daemon.started_at))}` +
     ` ${style.gray("·")} proto ${daemon.protocol_version}`;
@@ -65,7 +65,7 @@ export function renderHeader(snapshot, { columns, now }) {
     ` ${style.gray("host")} ${daemon.machine_id_hash}` +
     ` ${style.gray("· session")} ${daemon.session_key_hash}` +
     (scope?.kind ? ` ${style.gray("· scope")} ${scope.kind}` : "") +
-    ` ${style.gray("·")} ${staleness.stale ? style.yellow(staleness.reason) : style.gray(`measured ${duration(staleness.age_ms)} ago`)}`;
+    ` ${style.gray("·")} ${staleness.stale ? style.red(staleness.reason) : style.gray(`measured ${duration(staleness.age_ms)} ago`)}`;
   lines.push(truncate(detail, columns));
 
   // A held major is the daemon saying out loud that it is deliberately behind.
@@ -74,7 +74,7 @@ export function renderHeader(snapshot, { columns, now }) {
   if (upgrade?.major_held) {
     lines.push(
       truncate(
-        ` ${style.brightYellow("⇡ held at major")} ${upgrade.major_hold?.held_major ?? "?"}` +
+        ` ${style.red("⇡ held at major")} ${upgrade.major_hold?.held_major ?? "?"}` +
           ` ${style.gray("·")} ${upgrade.major_hold?.action ?? "see redskilled"}`,
         columns,
       ),
@@ -84,7 +84,7 @@ export function renderHeader(snapshot, { columns, now }) {
     const published = upgrade?.published_version ?? engine?.published_version ?? "?";
     lines.push(
       truncate(
-        ` ${style.brightYellow("⇡ upgrade pending")} ${running} → ${published}` +
+        ` ${style.red("⇡ upgrade pending")} ${running} → ${published}` +
           (upgrade?.replacement ? ` ${style.gray(`(${upgrade.replacement})`)}` : ""),
         columns,
       ),
@@ -115,8 +115,8 @@ export function renderDeaths(deaths, { columns }) {
   for (const death of deaths.recent ?? []) {
     lines.push(
       truncate(
-        ` ${style.brightRed("†")} ${style.white(`${death.kind} ${death.id}`)}` +
-          ` ${style.gray("·")} ${style.brightYellow(death.sender_class)}/${death.confidence}` +
+        ` ${style.red("†")} ${style.white(`${death.kind} ${death.id}`)}` +
+          ` ${style.gray("·")} ${style.bold(death.sender_class)}/${death.confidence}` +
           ` ${style.gray("· phase")} ${death.last_phase}` +
           (death.signal ? ` ${style.gray("· signal")} ${death.signal}` : "") +
           (death.evidence ? ` ${style.gray("·")} ${style.gray(death.evidence)}` : ""),
@@ -140,7 +140,7 @@ export function renderHost(payload, { columns }) {
   const repairing = (payload.workers ?? []).filter((worker) => worker.display?.origin === "repair").length;
   const workers = repairing > 0
     ? `${style.bold(String(Math.max(0, host.worker_count - repairing)))} coding + ` +
-      style.brightMagenta(`${style.bold(String(repairing))} repairing`)
+      style.bold(`${style.bold(String(repairing))} repairing`)
     : `${style.bold(String(host.worker_count))} worker${host.worker_count === 1 ? "" : "s"}`;
   const projects = `${style.bold(String(host.project_count))} project${host.project_count === 1 ? "" : "s"}`;
   const declared = host.consumption?.memory_bytes ?? null;
@@ -174,7 +174,7 @@ export function renderHost(payload, { columns }) {
     const parts = [];
     if (unisolated.length > 0) parts.push(`${unisolated.length} unisolated`);
     if (unaccounted.length > 0) parts.push(`${unaccounted.length} unaccounted`);
-    lines.push(truncate(`        ${style.yellow(`⚠ ${parts.join(" · ")}`)} ${style.gray("— charged to the daemon, not to a unit")}`, columns));
+    lines.push(truncate(`        ${style.red(`⚠ ${parts.join(" · ")}`)} ${style.gray("— charged to the daemon, not to a unit")}`, columns));
   }
 
   return lines;
@@ -224,7 +224,7 @@ export function renderMetrics(payload, { columns }) {
     const window = metrics[key];
     if (window == null) continue;
     const unavailable = (window.unavailable ?? []).length > 0
-      ? style.yellow((window.unavailable ?? []).join(" · "))
+      ? style.bold((window.unavailable ?? []).join(" · "))
       : style.gray("—");
     lines.push(
       truncate(
@@ -300,25 +300,25 @@ export function shortProject(label, width) {
  * opened this pane for — while a shortened project name still reads.
  */
 export function workerLayout(columns) {
-  if (columns >= 108) return { id: 14, project: 26, state: 11, bar: 10, short: false };
-  if (columns >= 92) return { id: 12, project: 18, state: 11, bar: 8, short: false };
-  return { id: 10, project: 12, state: 5, bar: 6, short: true };
+  if (columns >= 108) return { id: 14, project: 26, state: 12, bar: 10, short: false };
+  if (columns >= 92) return { id: 12, project: 18, state: 12, bar: 8, short: false };
+  return { id: 10, project: 12, state: 6, bar: 6, short: true };
 }
 
 /** One Worker's row, plus the line it last published. PURE. */
 export function renderWorkerRow(worker, { columns, selected, verbose, localProject, layout = workerLayout(columns) }) {
-  const marker = selected ? style.brightRed(SELECTED) : " ";
+  const marker = selected ? style.red(SELECTED) : " ";
   const mine = localProject != null && worker.project_label === localProject;
   const repair = worker.display?.origin === "repair";
 
   const id = padEnd(truncate(worker.worker_id, layout.id), layout.id);
   const label = shortProject(worker.project_label, layout.project);
-  const project = padEnd(truncate(mine ? style.brightCyan(label) : label, layout.project), layout.project);
+  const project = padEnd(truncate(mine ? style.bold(label) : label, layout.project), layout.project);
   const reattached = worker.state === "reattached";
   const stateText = repair
-    ? layout.short ? "heal" : "repairing"
-    : layout.short ? (reattached ? "reatt" : "run") : reattached ? "reattached" : "running";
-  const state = (repair ? style.brightMagenta : reattached ? style.cyan : style.green)(padEnd(stateText, layout.state));
+    ? layout.short ? "⟳heal" : "⟳ repairing"
+    : layout.short ? (reattached ? "↪reat" : "▶ run") : reattached ? "↪ reattached" : "▶ running";
+  const state = (repair ? style.bold : reattached ? style.dim : String)(padEnd(stateText, layout.state));
   const uptime = padStart(duration(worker.uptime_ms), 6);
 
   const budget = worker.budget ?? {};
@@ -333,9 +333,9 @@ export function renderWorkerRow(worker, { columns, selected, verbose, localProje
   // RSS would be, and a second word saying the same thing is what pushes the
   // flags that are NOT redundant off the right edge of a narrow pane.
   const flags = [];
-  if (!worker.isolated) flags.push(style.yellow("⚠ no unit"));
-  if (vitals.rss_bytes != null && vitals.fresh === false) flags.push(style.yellow("⚠ stale sample"));
-  if ((worker.warnings ?? []).length > 0) flags.push(style.yellow(`⚠ ${worker.warnings.length}`));
+  if (!worker.isolated) flags.push(style.red("⚠ no unit"));
+  if (vitals.rss_bytes != null && vitals.fresh === false) flags.push(style.red("⚠ stale sample"));
+  if ((worker.warnings ?? []).length > 0) flags.push(style.red(`⚠ ${worker.warnings.length}`));
 
   const row = ` ${marker} ${id} ${project} ${state} ${uptime}  ${usage} ${bar} ${share}${flags.length ? `  ${flags.join(" ")}` : ""}`;
   const lines = [truncate(row, columns)];
@@ -345,7 +345,7 @@ export function renderWorkerRow(worker, { columns, selected, verbose, localProje
     const step = worker.display?.step ?? worker.display?.phase ?? "step unknown";
     lines.push(
       truncate(
-        `     ${style.brightMagenta("⟳ repair lane")} ${style.gray("·")} PR #${issue} ${style.gray("·")} ${step}`,
+        `     ${style.bold("⟳ repair lane")} ${style.gray("·")} PR #${issue} ${style.gray("·")} ${step}`,
         columns,
       ),
     );
@@ -421,11 +421,11 @@ export function renderProjects(payload, hostState, { columns, localProject, budg
   for (const label of shown) {
     const project = byLabel.get(label);
     const registration = registrations.find((entry) => entry.project_label === label);
-    const name = label === localProject ? style.brightCyan(label) : label;
+    const name = label === localProject ? style.bold(label) : label;
     const held = registration
       ? registration.renewal === "renewing"
-        ? style.green(`renewing · target ${registration.target}`)
-        : style.yellow(`running on · target ${registration.target}`)
+        ? style.bold(`↻ renewing · target ${registration.target}`)
+        : style.dim(`● running on · target ${registration.target}`)
       : style.gray("—");
     lines.push(
       truncate(
@@ -460,15 +460,15 @@ export function renderActivity(payload, { columns, localProject, budgetRows }) {
   const visible = report.projects.slice(0, Math.max(1, budgetRows));
   for (const project of visible) {
     const counts = project.counts;
-    const name = project.project_label === localProject ? style.brightCyan(project.repository) : project.repository;
+    const name = project.project_label === localProject ? style.bold(project.repository) : project.repository;
     const state =
       project.outcome === "counted"
         ? project.stale
-          ? style.yellow(`stale · ${duration(project.age_ms)} old`)
-          : style.gray(`${duration(project.age_ms)} ago`)
+          ? style.red(`▲ stale · ${duration(project.age_ms)} old`)
+          : style.dim(`● ${duration(project.age_ms)} ago`)
         : project.outcome === "rate-limited"
-          ? style.brightRed("rate-limited")
-          : style.brightRed("unreachable");
+          ? style.red("! rate-limited")
+          : style.red("× unreachable");
     lines.push(
       truncate(
         `   ${padEnd(truncate(name, 34), 34)} ${padStart(counts ? style.bold(String(counts.open_pull_requests)) : "—", 8)}` +
@@ -485,7 +485,7 @@ export function renderActivity(payload, { columns, localProject, budgetRows }) {
   const limit = report.rate_limit ?? {};
   if (limit.exhausted || limit.remaining != null) {
     const quota = limit.exhausted
-      ? style.brightRed("quota spent")
+      ? style.red("! quota spent")
       : `${style.gray("quota")} ${limit.remaining} left`;
     const reset = limit.reset_at ? ` ${style.gray("· resets")} ${limit.reset_at.slice(11, 16)}Z` : "";
     lines.push(truncate(`   ${quota}${reset} ${style.gray("· one request for every project (ADR 0130 Am. 1)")}`, columns));
@@ -614,7 +614,7 @@ export function renderDashboard({ snapshot, state, size, localProject, now = new
   lines.push(...renderProjects(payload, snapshot.hostState, { columns, localProject, budgetRows: projectRows }));
   lines.push(...renderActivity(payload, { columns, localProject, budgetRows: activityRows }));
 
-  if (state.message) lines.push(truncate(` ${style.brightCyan(state.message)}`, columns));
+  if (state.message) lines.push(truncate(` ${style.red(`! ${state.message}`)}`, columns));
 
   lines.push(...renderFooter({ columns, state }));
   return lines;

--- a/apps/herdr-plugin-red-skills/src/ui/format.mjs
+++ b/apps/herdr-plugin-red-skills/src/ui/format.mjs
@@ -50,7 +50,7 @@ export function percent(fraction) {
 }
 
 /**
- * A meter for a fraction, coloured by how close it is to its ceiling. PURE.
+ * A meter for a fraction, with pressure carried by its final filled glyph. PURE.
  *
  * An unknown fraction draws an empty track rather than a full or an absent one:
  * a bar is read at a glance, and both alternatives read as a fact.
@@ -61,9 +61,9 @@ export function meter(fraction, width = 12) {
   const clamped = Math.min(1, Math.max(0, fraction));
   const filled = Math.round(clamped * track);
   const bar = `${"█".repeat(filled)}${"░".repeat(track - filled)}`;
-  if (clamped >= 0.9) return style.brightRed(bar);
-  if (clamped >= 0.7) return style.yellow(bar);
-  return style.green(bar);
+  if (clamped >= 0.9) return style.red(`${"█".repeat(filled - 1)}!${"░".repeat(track - filled)}`);
+  if (clamped >= 0.7) return style.bold(`${"█".repeat(filled - 1)}▲${"░".repeat(track - filled)}`);
+  return bar;
 }
 
 /** A count, or an em dash when the daemon deliberately sent no number. PURE. */

--- a/apps/herdr-plugin-red-skills/src/ui/logs.mjs
+++ b/apps/herdr-plugin-red-skills/src/ui/logs.mjs
@@ -20,9 +20,9 @@ function rule(label, columns) {
 
 /** Colour a log line by the level it announces, and by nothing else. PURE. */
 export function colourLogLine(line) {
-  if (/\b(error|fatal|refused|failed|panic)\b/i.test(line)) return style.brightRed(line);
-  if (/\b(warn|warning|degraded|stale|retry)\b/i.test(line)) return style.yellow(line);
-  if (/\b(ok|done|passed|merged|landed|green)\b/i.test(line)) return style.green(line);
+  if (/\b(error|fatal|refused|failed|panic)\b/i.test(line)) return style.red(line);
+  if (/\b(warn|warning|degraded|stale|retry)\b/i.test(line)) return style.bold(line);
+  if (/\b(ok|done|passed|merged|landed|green)\b/i.test(line)) return style.dim(line);
   return line;
 }
 
@@ -33,21 +33,21 @@ export function renderEventRow(record, { columns }) {
   const at = typeof record.ts === "string" ? record.ts.slice(11, 19) : "--:--:--";
   const kind =
     record.event === "worker-birth"
-      ? style.green(padEnd("birth", 12))
+      ? style.dim(padEnd("+ birth", 13))
       : record.event === "worker-budget-kill"
-        ? style.brightRed(padEnd("budget-kill", 12))
-        : style.yellow(padEnd("death", 12));
+        ? style.red(padEnd("! budget-kill", 13))
+        : style.bold(padEnd("† death", 13));
 
   const ending =
     record.event === "worker-birth"
       ? style.gray(`pid ${record.pid ?? "—"}${record.unit ? ` · ${record.unit}` : " · no unit"}`)
       : record.signal
-        ? style.brightRed(`signal ${record.signal}`)
+        ? style.red(`! signal ${record.signal}`)
         : record.exit_code === 0
-          ? style.green("exit 0")
+          ? style.dim("exit 0")
           : record.exit_code == null
             ? style.gray("exit —")
-            : style.brightRed(`exit ${record.exit_code}`);
+            : style.red(`! exit ${record.exit_code}`);
 
   const detail = record.detail ? ` ${style.gray("·")} ${style.dim(String(record.detail))}` : "";
 
@@ -68,7 +68,7 @@ export function renderEventRow(record, { columns }) {
 export function renderLogView({ title, subtitle, lines, offset, follow, size, empty, render = colourLogLine }) {
   const { columns, rows } = size;
   const head = [
-    truncate(` ${style.bold(style.brightRed("red-skills"))} ${style.gray("·")} ${style.bold(title)}`, columns),
+    truncate(` ${style.bold(style.identity("red-skills"))} ${style.gray("·")} ${style.bold(title)}`, columns),
     truncate(` ${style.gray(subtitle)}`, columns),
     rule(null, columns),
   ];
@@ -78,7 +78,7 @@ export function renderLogView({ title, subtitle, lines, offset, follow, size, em
   const foot = [
     rule(null, columns),
     truncate(
-      ` ${follow ? style.brightGreen("● following") : style.yellow("▲ paused")}` +
+      ` ${follow ? style.dim("● following") : style.red("▲ paused")}` +
         `  ${style.bold("q")} ${style.gray("back")}  ${style.bold("f")} ${style.gray(follow ? "unfollow" : "follow")}` +
         `  ${style.bold("j/k")} ${style.gray("scroll")}  ${style.bold("g/G")} ${style.gray("top/end")}` +
         `  ${style.bold("r")} ${style.gray("refresh")}`,
@@ -104,7 +104,7 @@ export function workerLogSubtitle(worker, tail) {
   const where = tail?.exists
     ? `${tail.path}${tail.truncated ? style.gray(" (tail)") : ""} · ${bytes(tail.size)}`
     : worker.workspace_path
-      ? style.yellow(`no readable log — the client declared ${tail?.path ? tail.path : "none"} at spawn`)
-      : style.yellow("no log path was declared for this Worker");
+      ? style.red(`⚠ no readable log — the client declared ${tail?.path ? tail.path : "none"} at spawn`)
+      : style.red("⚠ no log path was declared for this Worker");
   return `${worker.worker_id} · ${worker.project_label} · up ${duration(worker.uptime_ms)} · ${where}`;
 }

--- a/apps/herdr-plugin-red-skills/tests/board.test.mjs
+++ b/apps/herdr-plugin-red-skills/tests/board.test.mjs
@@ -117,7 +117,7 @@ test("a state change in the daemon reaches the pane without local re-derivation"
   const second = text(renderBoard({ dashboard: after, state: state(), size: SIZE }));
   assert.match(first, /● live/);
   assert.match(first, /iss=3012/);
-  assert.match(second, /● stale/);
+  assert.match(second, /▲ stale/);
   assert.ok(!second.includes("iss=3012"), "the pane kept a row the daemon no longer renders");
 });
 

--- a/apps/herdr-plugin-red-skills/tests/brand-grammar.test.mjs
+++ b/apps/herdr-plugin-red-skills/tests/brand-grammar.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import brandTokens from "../../../packages/brand-tokens/tokens.json" with { type: "json" };
+import { renderBoard } from "../src/ui/board.mjs";
+import { renderHeader, renderWorkerRow } from "../src/ui/dashboard.mjs";
+import { meter } from "../src/ui/format.mjs";
+import { renderEventRow, renderLogView } from "../src/ui/logs.mjs";
+import { colorEnabled, stripAnsi } from "../src/ui/ansi.mjs";
+import { dashboard, snapshot, statuslinePayload } from "./fixtures.mjs";
+
+const SOURCE_FILES = [
+  "../src/commands/doctor.mjs",
+  "../src/ui/ansi.mjs",
+  "../src/ui/board.mjs",
+  "../src/ui/dashboard.mjs",
+  "../src/ui/format.mjs",
+  "../src/ui/logs.mjs",
+];
+
+test("pane state uses glyphs, neutral intensity, and the red spotlight only", async () => {
+  for (const relative of SOURCE_FILES) {
+    const source = await readFile(new URL(relative, import.meta.url), "utf8");
+    assert.doesNotMatch(source, /style\.(?:green|yellow|cyan|magenta|brightGreen|brightYellow|brightCyan|brightMagenta)\b/);
+    assert.doesNotMatch(source, /(?:38|48);2;/, "truecolor must be derived by the brand package");
+  }
+});
+
+test("plain pane output preserves every state distinction formerly carried by colour", () => {
+  const fresh = snapshot();
+  const stale = snapshot();
+  stale.payload.staleness = { ...stale.payload.staleness, stale: true, reason: "sample expired" };
+  assert.match(stripAnsi(renderHeader(fresh, { columns: 120, now: fresh.readAt })[0]), /● live$/);
+  assert.match(stripAnsi(renderHeader(stale, { columns: 120, now: stale.readAt })[0]), /▲ stale$/);
+
+  const workers = statuslinePayload().workers;
+  assert.match(stripAnsi(renderWorkerRow(workers[0], { columns: 120, selected: false, verbose: false })[0]), /▶ running/);
+  assert.match(stripAnsi(renderWorkerRow({ ...workers[0], state: "reattached" }, { columns: 120, selected: false, verbose: false })[0]), /↪ reattached/);
+
+  const event = (kind) => stripAnsi(renderEventRow({ event: kind, worker_id: "w", project_label: "p" }, { columns: 120 }));
+  assert.match(event("worker-birth"), /\+ birth/);
+  assert.match(event("worker-death"), /† death/);
+  assert.match(event("worker-budget-kill"), /! budget-kill/);
+
+  assert.equal(stripAnsi(meter(0.5, 6)), "███░░░");
+  assert.equal(stripAnsi(meter(0.75, 6)), "████▲░");
+  assert.equal(stripAnsi(meter(0.95, 6)), "█████!");
+});
+
+test("identity moments resolve brand.primary through the tokens package", () => {
+  if (!colorEnabled) return;
+  const [red, green, blue] = brandTokens.color.brand.primary.$value
+    .replace(/^\{|\}$/g, "")
+    .split(".")
+    .reduce((node, part) => node[part], brandTokens).$value.components
+    .map((component) => Math.round(component * 255));
+  const brand = `\u001b[38;2;${red};${green};${blue}m`;
+  const snap = snapshot();
+  assert.ok(renderHeader(snap, { columns: 120, now: snap.readAt })[0].includes(`${brand}redskilled`));
+  assert.ok(renderBoard({ dashboard: dashboard(), state: { mode: "global", message: null }, size: { columns: 160, rows: 30 } })[0].includes(brand));
+  assert.ok(renderLogView({ title: "events", subtitle: "host", lines: [], offset: 0, follow: true, size: { columns: 80, rows: 10 }, empty: "none" })[0].includes(`${brand}red-skills`));
+});

--- a/apps/herdr-plugin-red-skills/tests/ui.test.mjs
+++ b/apps/herdr-plugin-red-skills/tests/ui.test.mjs
@@ -7,7 +7,7 @@ import { decodeKey } from "../src/ui/screen.mjs";
 
 test("displayWidth measures the visible text, not the bytes", () => {
   assert.equal(displayWidth(style.red("abc")), 3);
-  assert.equal(stripAnsi(style.bold(style.green("hi"))), "hi");
+  assert.equal(stripAnsi(style.bold(style.dim("hi"))), "hi");
 });
 
 test("padding aligns on visible width so styled columns stay square", () => {

--- a/packages/brand-tokens/index.mjs
+++ b/packages/brand-tokens/index.mjs
@@ -1,0 +1,101 @@
+import tokenDocumentJson from "./tokens.json" with { type: "json" };
+
+export class BrandTokenError extends Error {
+  name = "BrandTokenError";
+
+  constructor(code, tokenName, message) {
+    super(message);
+    this.code = code;
+    this.tokenName = tokenName;
+  }
+}
+
+function isObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+if (!isObject(tokenDocumentJson) || !isObject(tokenDocumentJson.color)) {
+  throw new BrandTokenError("TOKEN_MALFORMED", "color", "The vendored DTCG document has no color token group.");
+}
+
+const tokenDocument = tokenDocumentJson;
+
+function getTokenNode(path) {
+  let node = tokenDocument;
+  for (const segment of path.split(".")) {
+    if (!isObject(node) || !(segment in node)) return undefined;
+    node = node[segment];
+  }
+  return node;
+}
+
+function malformed(requestedName, detail) {
+  return new BrandTokenError(
+    "TOKEN_MALFORMED",
+    requestedName,
+    `Brand color token "${requestedName}" is malformed: ${detail}`,
+  );
+}
+
+function resolveColorTokenPath(path, requestedName, visited) {
+  if (visited.has(path)) {
+    throw new BrandTokenError(
+      "TOKEN_ALIAS_CYCLE",
+      requestedName,
+      `Brand color token "${requestedName}" contains an alias cycle at "${path}".`,
+    );
+  }
+
+  const node = getTokenNode(path);
+  if (node === undefined) {
+    throw new BrandTokenError(
+      "TOKEN_NOT_FOUND",
+      requestedName,
+      `Brand color token "${requestedName}" was not found (resolved path "${path}").`,
+    );
+  }
+  if (!isObject(node) || !("$value" in node)) {
+    throw malformed(requestedName, `"${path}" is not a token with a $value`);
+  }
+
+  const value = node.$value;
+  if (typeof value === "string") {
+    const alias = /^\{([^{}]+)\}$/.exec(value);
+    if (alias?.[1] === undefined) throw malformed(requestedName, `"${path}" has an invalid alias`);
+    return resolveColorTokenPath(alias[1], requestedName, new Set([...visited, path]));
+  }
+
+  if (!isObject(value) || typeof value.hex !== "string" || !/^#[0-9a-fA-F]{6}$/.test(value.hex)) {
+    throw malformed(requestedName, `"${path}" has no six-digit hex color value`);
+  }
+
+  return {
+    name: path.startsWith("color.") ? path.slice("color.".length) : path,
+    hex: value.hex.toLowerCase(),
+  };
+}
+
+export function resolveColorToken(name) {
+  const path = name.startsWith("color.") ? name : `color.${name}`;
+  return resolveColorTokenPath(path, name, new Set());
+}
+
+export function tokenToCssHex(name) {
+  return resolveColorToken(name).hex;
+}
+
+function tokenToAnsi(name, layer) {
+  const hex = tokenToCssHex(name);
+  const red = Number.parseInt(hex.slice(1, 3), 16);
+  const green = Number.parseInt(hex.slice(3, 5), 16);
+  const blue = Number.parseInt(hex.slice(5, 7), 16);
+  return `\u001B[${layer};2;${red};${green};${blue}m`;
+}
+
+export function tokenToAnsiForeground(name) {
+  return tokenToAnsi(name, 38);
+}
+
+export function tokenToAnsiBackground(name) {
+  return tokenToAnsi(name, 48);
+}

--- a/packages/brand-tokens/package.json
+++ b/packages/brand-tokens/package.json
@@ -6,7 +6,10 @@
   "description": "Vendored RedDB brand color tokens with ANSI and CSS derivation helpers (ADR 0137).",
   "license": "Apache-2.0",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./index.ts",
+      "default": "./index.mjs"
+    }
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
 
   apps/herdr-plugin-red-skills:
     dependencies:
+      '@reddb-io/brand-tokens':
+        specifier: workspace:*
+        version: link:../../packages/brand-tokens
       '@reddb-io/build-info':
         specifier: workspace:*
         version: link:../../packages/build-info


### PR DESCRIPTION
Automated AFK landing for #3345. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3345

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788533846&installation_model_id=20659&pr_number=3361&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3361&signature=76255bf6ab00bbd3ae438d97ce2f67b34970a241945283f38982c05f26e856a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->