### PR TITLE
chore: #3346 VS Code dashboard identity header paints package-derived brand hex; functional chrome stays theme-resolved

### DIFF
--- a/apps/vscode-extension-red-skills/package.json
+++ b/apps/vscode-extension-red-skills/package.json
@@ -177,6 +177,7 @@
     }
   },
   "dependencies": {
+    "@reddb-io/brand-tokens": "workspace:*",
     "@reddb-io/redskilled": "workspace:*",
     "@reddb-io/redskilled-render": "workspace:*",
     "@reddb-io/shared": "workspace:*"

--- a/apps/vscode-extension-red-skills/src/model/dashboard-view.ts
+++ b/apps/vscode-extension-red-skills/src/model/dashboard-view.ts
@@ -14,6 +14,7 @@
  * `views/dashboard-panel.ts` hold the `vscode` imports and nothing else.
  */
 import { canonicalInvocation } from "@reddb-io/shared/canonical-invocation.js";
+import { tokenToCssHex } from "@reddb-io/brand-tokens";
 import { stripAnsi } from "@reddb-io/redskilled-render/format.js";
 import type { RedskilledDashboard } from "@reddb-io/redskilled/protocol";
 import type { HostSnapshot } from "./snapshot.js";
@@ -86,6 +87,8 @@ export function escapeHtml(text: string): string {
  */
 export function renderDashboardHtml(snapshot: HostSnapshot): string {
   const body = dashboardBody(snapshot);
+  const identityBackground = tokenToCssHex("brand.primary");
+  const identityForeground = tokenToCssHex("brand.on-primary");
   return [
     "<!DOCTYPE html>",
     '<html lang="en">',
@@ -93,10 +96,9 @@ export function renderDashboardHtml(snapshot: HostSnapshot): string {
     '<meta charset="UTF-8">',
     '<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src \'unsafe-inline\';">',
     "<style>",
-    "body { font-family: var(--vscode-editor-font-family, monospace); color: var(--vscode-foreground); padding: 0.5rem; }",
+    "body { font-family: var(--vscode-editor-font-family, monospace); color: var(--vscode-foreground); background-color: var(--vscode-editor-background); padding: 0.5rem; }",
     "pre { font-family: var(--vscode-editor-font-family, monospace); font-size: var(--vscode-editor-font-size, 12px); margin: 0; white-space: pre; overflow-x: auto; }",
-    ".header { font-weight: 600; }",
-    ".stale { color: var(--vscode-editorWarning-foreground); }",
+    `.header { background-color: ${identityBackground}; color: ${identityForeground}; font-weight: 600; }`,
     ".absence { color: var(--vscode-descriptionForeground); }",
     "</style>",
     "</head>",
@@ -135,7 +137,7 @@ function dashboardBody(snapshot: HostSnapshot): string {
     ].join("\n");
   }
   return [
-    `<pre class="header${dashboard.stale ? " stale" : ""}">${escapeHtml(stripAnsi(dashboard.header.line))}</pre>`,
+    `<pre class="header">${escapeHtml(stripAnsi(dashboard.header.line))}</pre>`,
     ...(dashboard.rows.length === 0
       ? [
           '<pre class="absence">no Workers here — the machine is idle, and this is the daemon saying so</pre>',

--- a/apps/vscode-extension-red-skills/src/views/status-bar.ts
+++ b/apps/vscode-extension-red-skills/src/views/status-bar.ts
@@ -27,11 +27,9 @@ export class RedskilledStatusBar {
     const view = statusBarView(snapshot);
     this.item.text = view.text;
     this.item.tooltip = view.tooltip;
-    // Only a warning is coloured. A background on every healthy frame would make
-    // the one frame that matters look like all the others.
-    this.item.backgroundColor = view.warning
-      ? new vscode.ThemeColor("statusBarItem.warningBackground")
-      : undefined;
+    // State is carried by the warning glyph and text. The status bar stays in
+    // the editor's own chrome rather than borrowing a green/yellow state slot.
+    this.item.backgroundColor = undefined;
   }
 
   dispose(): void {

--- a/apps/vscode-extension-red-skills/tests/dashboard.test.ts
+++ b/apps/vscode-extension-red-skills/tests/dashboard.test.ts
@@ -7,6 +7,7 @@
  * absence.
  */
 import { afterEach, describe, expect, it } from "vitest";
+import { tokenToCssHex } from "@reddb-io/brand-tokens";
 import { stripAnsi } from "@reddb-io/redskilled-render/format.js";
 import {
   dashboardRows,
@@ -149,6 +150,28 @@ describe("the status bar shows the daemon's own summary", () => {
 });
 
 describe("the dashboard panel shows the rows the daemon rendered", () => {
+  it("paints only the identity header from the brand token package", () => {
+    const html = renderDashboardHtml(snapshotOf());
+    const style = html.match(/<style>\n([\s\S]*?)\n<\/style>/)?.[1] ?? "";
+
+    expect(style).toContain(`background-color: ${tokenToCssHex("brand.primary")};`);
+    expect(style).toContain(`color: ${tokenToCssHex("brand.on-primary")};`);
+    expect(style.match(/#[0-9a-f]{6}/gi)).toEqual([
+      tokenToCssHex("brand.primary"),
+      tokenToCssHex("brand.on-primary"),
+    ]);
+    expect(style.replace(/\.header \{[^}]+\}/, "")).not.toMatch(/#[0-9a-f]{6}/i);
+  });
+
+  it("keeps stale state in text instead of a green or yellow paint slot", () => {
+    const view = statusBarView(snapshotOf({ dashboard: dashboard({ stale: true }) }));
+    const html = renderDashboardHtml(snapshotOf({ dashboard: dashboard({ stale: true }) }));
+
+    expect(view.text).toContain("$(warning)");
+    expect(html).not.toContain("editorWarning");
+    expect(html).not.toContain('class="header stale"');
+  });
+
   it("carries every statusline field into the body", () => {
     const html = renderDashboardHtml(snapshotOf());
     for (const cell of [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,6 +406,9 @@ importers:
 
   apps/vscode-extension-red-skills:
     dependencies:
+      '@reddb-io/brand-tokens':
+        specifier: workspace:*
+        version: link:../../packages/brand-tokens
       '@reddb-io/redskilled':
         specifier: workspace:*
         version: link:../redskilled


### PR DESCRIPTION
Automated AFK landing for #3346. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3346

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788536948&installation_model_id=20659&pr_number=3374&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3374&signature=6ce8628e8f58c2c92936e59d24adb1d3d633d49e0df8268a2d9c45a76619ffe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->