### PR TITLE
chore: #3363 Release engine: shipped app skeleton + pure version core (semver, calver YYYY.M.MICRO, rc)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -24,6 +24,7 @@
       "@reddb-io/red-skills",
       "@reddb-io/red-castle",
       "@reddb-io/red-browser",
+      "@reddb-io/release",
       "@reddb-io/rsp",
       "@reddb-io/redskilled",
       "@reddb-io/redskilled-render",

--- a/apps/release/package.json
+++ b/apps/release/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@reddb-io/release",
+  "version": "3.6.2",
+  "private": true,
+  "description": "RedSkills release engine — changeset-compatible version computation and release orchestration.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "red-skills-release": "dist/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.build.json && pnpm bundle",
+    "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/release.bundle.min.mjs --asset release.bundle.min.mjs --minify",
+    "test": "vitest run",
+    "dev": "node --import tsx src/cli.ts"
+  },
+  "dependencies": {
+    "@reddb-io/build-info": "workspace:*",
+    "@reddb-io/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "esbuild": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/apps/release/src/cli.ts
+++ b/apps/release/src/cli.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
+import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
+
+const FLAGS = {
+  version: { kind: "boolean", aliases: ["v"] },
+  help: { kind: "boolean", aliases: ["h"] },
+} satisfies FlagSchema;
+
+const RELEASE_USAGE = `red-skills-release
+
+Usage:
+  red-skills-release --version
+  red-skills-release --help
+`;
+
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+  const { values, positionals } = parseFlags(argv, FLAGS, { unknownFlags: "error" });
+  const command = positionals[0];
+
+  if (values.version === true || command === "version") {
+    process.stdout.write(`${renderVersion(readBuildInfo("red-skills-release"))}\n`);
+    return 0;
+  }
+  if (values.help === true || command === "help" || command === undefined) {
+    process.stdout.write(RELEASE_USAGE);
+    return 0;
+  }
+  throw new Error(`unknown release command: ${command}\n\n${RELEASE_USAGE}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    process.stderr.write(`error: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/apps/release/src/version-core.ts
+++ b/apps/release/src/version-core.ts
@@ -1,0 +1,109 @@
+/** The release schemes standardized by ADR 0139. */
+export type VersionScheme = "semver" | "calver";
+
+/** Counts of queued changesets by impact class. */
+export interface PendingBumpSummary {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+}
+
+/** Calendar input supplied at the release boundary; the core never reads wall time. */
+export interface ReleaseClock {
+  today(): { readonly year: number; readonly month: number };
+}
+
+export interface NextVersionInput {
+  readonly currentVersion: string;
+  readonly pending: PendingBumpSummary;
+  readonly scheme: VersionScheme;
+  readonly clock: ReleaseClock;
+  readonly prerelease?: "rc";
+}
+
+interface ParsedVersion {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+  readonly rc?: number;
+}
+
+const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-rc\.(0|[1-9]\d*))?$/;
+
+/**
+ * Compute the next version from explicit inputs only.
+ *
+ * Semver applies the highest queued impact. Calver treats that impact as
+ * metadata and advances `YYYY.M.MICRO` using the injected calendar. An RC is
+ * derived from that same target; a subsequent call advances only `rc.N`.
+ */
+export function computeNextVersion(input: NextVersionInput): string {
+  assertPending(input.pending);
+  const current = parseVersion(input.currentVersion);
+
+  if (current.rc !== undefined) {
+    const base = renderBase(current);
+    return input.prerelease === "rc" ? `${base}-rc.${current.rc + 1}` : base;
+  }
+
+  const target = input.scheme === "semver"
+    ? nextSemver(current, input.pending)
+    : nextCalver(current, input.clock.today());
+  const base = renderBase(target);
+  return input.prerelease === "rc" ? `${base}-rc.1` : base;
+}
+
+function assertPending(pending: PendingBumpSummary): void {
+  const counts = [pending.major, pending.minor, pending.patch];
+  if (counts.some((count) => !Number.isSafeInteger(count) || count < 0)) {
+    throw new Error("pending bump counts must be non-negative safe integers");
+  }
+  if (counts.every((count) => count === 0)) {
+    throw new Error("cannot compute a release version without a pending bump");
+  }
+}
+
+function parseVersion(value: string): ParsedVersion {
+  const match = VERSION_PATTERN.exec(value);
+  if (match === null) {
+    throw new Error(`invalid semver-compatible release version: ${value}`);
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    ...(match[4] === undefined ? {} : { rc: Number(match[4]) }),
+  };
+}
+
+function nextSemver(current: ParsedVersion, pending: PendingBumpSummary): ParsedVersion {
+  if (pending.major > 0) return { major: current.major + 1, minor: 0, patch: 0 };
+  if (pending.minor > 0) return { major: current.major, minor: current.minor + 1, patch: 0 };
+  return { major: current.major, minor: current.minor, patch: current.patch + 1 };
+}
+
+function nextCalver(
+  current: ParsedVersion,
+  date: { readonly year: number; readonly month: number },
+): ParsedVersion {
+  if (!Number.isSafeInteger(date.year) || date.year < 1) {
+    throw new Error(`invalid release year: ${date.year}`);
+  }
+  if (!Number.isSafeInteger(date.month) || date.month < 1 || date.month > 12) {
+    throw new Error(`invalid release month: ${date.month}`);
+  }
+
+  if (current.major > date.year || (current.major === date.year && current.minor > date.month)) {
+    throw new Error(
+      `release clock ${date.year}.${date.month} precedes current calver ${renderBase(current)}`,
+    );
+  }
+  return current.major === date.year && current.minor === date.month
+    ? { major: date.year, minor: date.month, patch: current.patch + 1 }
+    : { major: date.year, minor: date.month, patch: 0 };
+}
+
+function renderBase(version: ParsedVersion): string {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+

--- a/apps/release/tests/version-core.test.ts
+++ b/apps/release/tests/version-core.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeNextVersion,
+  type PendingBumpSummary,
+  type ReleaseClock,
+} from "../src/version-core.js";
+
+const PATCH: PendingBumpSummary = { major: 0, minor: 0, patch: 1 };
+
+function clock(year: number, month: number): ReleaseClock {
+  return { today: () => ({ year, month }) };
+}
+
+describe("semver release versions", () => {
+  it.each([
+    [{ major: 1, minor: 3, patch: 8 }, "1.2.3", "2.0.0"],
+    [{ major: 0, minor: 2, patch: 8 }, "1.2.3", "1.3.0"],
+    [{ major: 0, minor: 0, patch: 8 }, "1.2.3", "1.2.4"],
+  ] satisfies readonly (readonly [PendingBumpSummary, string, string])[])(
+    "uses the highest pending bump in %#",
+    (pending, currentVersion, expected) => {
+      expect(
+        computeNextVersion({
+          currentVersion,
+          pending,
+          scheme: "semver",
+          clock: clock(2040, 12),
+        }),
+      ).toBe(expected);
+    },
+  );
+});
+
+describe("YYYY.M.MICRO calver release versions", () => {
+  it("increments MICRO within the injected clock month", () => {
+    expect(
+      computeNextVersion({
+        currentVersion: "2026.8.2",
+        pending: { major: 1, minor: 0, patch: 0 },
+        scheme: "calver",
+        clock: clock(2026, 8),
+      }),
+    ).toBe("2026.8.3");
+  });
+
+  it("rolls to MICRO zero without leading zeroes when the injected month changes", () => {
+    expect(
+      computeNextVersion({
+        currentVersion: "2026.8.9",
+        pending: PATCH,
+        scheme: "calver",
+        clock: clock(2026, 9),
+      }),
+    ).toBe("2026.9.0");
+  });
+});
+
+describe("release candidates", () => {
+  it("derives rc.1 from the same pending semver release", () => {
+    expect(
+      computeNextVersion({
+        currentVersion: "1.2.3",
+        pending: { major: 0, minor: 1, patch: 2 },
+        scheme: "semver",
+        clock: clock(2026, 8),
+        prerelease: "rc",
+      }),
+    ).toBe("1.3.0-rc.1");
+  });
+
+  it("increments rc.N without applying the pending bump twice", () => {
+    expect(
+      computeNextVersion({
+        currentVersion: "1.3.0-rc.4",
+        pending: { major: 0, minor: 1, patch: 2 },
+        scheme: "semver",
+        clock: clock(2026, 8),
+        prerelease: "rc",
+      }),
+    ).toBe("1.3.0-rc.5");
+  });
+});
+

--- a/apps/release/tsconfig.build.json
+++ b/apps/release/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/apps/release/tsconfig.json
+++ b/apps/release/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["src", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,31 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.20.1)
 
+  apps/release:
+    dependencies:
+      '@reddb-io/build-info':
+        specifier: workspace:*
+        version: link:../../packages/build-info
+      '@reddb-io/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.24.2
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.20.1)
+
   apps/rsp:
     dependencies:
       '@reddb-io/build-info':


### PR DESCRIPTION
Automated AFK landing for #3363. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3363

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788538027&installation_model_id=20659&pr_number=3375&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3375&signature=53b77a27bd8e3f4f2e6e40e0d98b18c86452dc39454845da4d95b6304cae7e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->