### PR TITLE
chore: #3364 Release engine: changeset queue parser + status verb

### DIFF
--- a/.changeset/calm-releases-report.md
+++ b/.changeset/calm-releases-report.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/release": minor
+---
+
+Parse changeset queues and report the pending release from the release engine status command.

--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -201,6 +201,11 @@
       "classification": "external",
       "reason": "TOON migration accepts legacy JSON inputs.",
       "moveKey": "e57f5cae7679"
+    },
+    {
+      "id": "apps/release/src/cli.ts#json-parse-file-read#06f60309d571",
+      "classification": "external",
+      "reason": "npm package.json manifests are an external JSON format the release engine must read as-is"
     }
   ]
 }

--- a/apps/release/package.json
+++ b/apps/release/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@reddb-io/build-info": "workspace:*",
-    "@reddb-io/shared": "workspace:*"
+    "@reddb-io/shared": "workspace:*",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/apps/release/src/changeset-queue.ts
+++ b/apps/release/src/changeset-queue.ts
@@ -1,0 +1,121 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { basename, join } from "node:path";
+import { parse } from "yaml";
+import type { PendingBumpSummary } from "./version-core.js";
+
+export type ImpactClass = "major" | "minor" | "patch";
+
+export interface QueuedRelease {
+  readonly packageName: string;
+  readonly impact: ImpactClass;
+}
+
+export interface QueuedChange {
+  readonly file: string;
+  readonly summary: string;
+  readonly body: string;
+  readonly impact: ImpactClass;
+  readonly releases: readonly QueuedRelease[];
+}
+
+export interface ChangesetQueue {
+  readonly changes: readonly QueuedChange[];
+  readonly pending: PendingBumpSummary;
+}
+
+export class ChangesetParseError extends Error {
+  readonly file: string;
+
+  constructor(file: string, reason: string) {
+    super(`${file}: ${reason}`);
+    this.name = "ChangesetParseError";
+    this.file = file;
+  }
+}
+
+const IMPACT_RANK: Readonly<Record<ImpactClass, number>> = {
+  patch: 0,
+  minor: 1,
+  major: 2,
+};
+
+/** Read the market-standard `.changeset/*.md` queue in deterministic filename order. */
+export function readChangesetQueue(changesetDirectory: string): ChangesetQueue {
+  let files: string[];
+  try {
+    files = readdirSync(changesetDirectory)
+      .filter((file) => file.endsWith(".md") && file !== "README.md")
+      .sort((left, right) => left.localeCompare(right));
+  } catch (error) {
+    if (isMissingDirectory(error)) return emptyQueue();
+    throw error;
+  }
+
+  const changes = files.map((file) =>
+    parseChangeset(file, readFileSync(join(changesetDirectory, file), "utf8"))
+  );
+  const pending = { major: 0, minor: 0, patch: 0 };
+  for (const change of changes) pending[change.impact] += 1;
+  return { changes, pending };
+}
+
+export function parseChangeset(filePath: string, source: string): QueuedChange {
+  const file = basename(filePath);
+  const match = /^---[\t ]*\r?\n([\s\S]*?)\r?\n---[\t ]*(?:\r?\n|$)([\s\S]*)$/.exec(
+    source.replace(/^\uFEFF/, ""),
+  );
+  if (match === null) throw new ChangesetParseError(file, "expected YAML frontmatter between --- delimiters");
+
+  let frontmatter: unknown;
+  try {
+    frontmatter = parse(match[1]!, { uniqueKeys: true });
+  } catch (error) {
+    throw new ChangesetParseError(file, `invalid YAML frontmatter: ${errorMessage(error)}`);
+  }
+  if (!isRecord(frontmatter) || Object.keys(frontmatter).length === 0) {
+    throw new ChangesetParseError(file, "frontmatter must name at least one package");
+  }
+
+  const releases: QueuedRelease[] = [];
+  for (const [packageName, impact] of Object.entries(frontmatter)) {
+    if (packageName.trim() === "") {
+      throw new ChangesetParseError(file, "frontmatter contains an empty package name");
+    }
+    if (!isImpactClass(impact)) {
+      throw new ChangesetParseError(
+        file,
+        `package ${JSON.stringify(packageName)} has invalid impact ${JSON.stringify(impact)}; expected major, minor, or patch`,
+      );
+    }
+    releases.push({ packageName, impact });
+  }
+
+  const body = match[2]!.trim();
+  if (body === "") throw new ChangesetParseError(file, "markdown body must not be empty");
+  const summary = body.split(/\r?\n/, 1)[0]!.trim();
+  const impact = releases.reduce<ImpactClass>(
+    (highest, release) => IMPACT_RANK[release.impact] > IMPACT_RANK[highest] ? release.impact : highest,
+    "patch",
+  );
+  return { file, summary, body, impact, releases };
+}
+
+function emptyQueue(): ChangesetQueue {
+  return { changes: [], pending: { major: 0, minor: 0, patch: 0 } };
+}
+
+function isImpactClass(value: unknown): value is ImpactClass {
+  return value === "major" || value === "minor" || value === "patch";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissingDirectory(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/release/src/cli.ts
+++ b/apps/release/src/cli.ts
@@ -1,32 +1,101 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
+import { readChangesetQueue } from "./changeset-queue.js";
+import { computeReleaseStatus, renderReleaseStatus } from "./status.js";
+import type { ReleaseClock, VersionScheme } from "./version-core.js";
 
 const FLAGS = {
   version: { kind: "boolean", aliases: ["v"] },
   help: { kind: "boolean", aliases: ["h"] },
+  root: { kind: "value", coerce: String },
+  "changeset-dir": { kind: "value", coerce: String },
+  "current-version": { kind: "value", coerce: String },
+  scheme: { kind: "value", coerce: parseScheme },
 } satisfies FlagSchema;
 
 const RELEASE_USAGE = `red-skills-release
 
 Usage:
+  red-skills-release status [--root <repository>] [--scheme semver|calver]
   red-skills-release --version
   red-skills-release --help
 `;
 
-export function main(argv: readonly string[] = process.argv.slice(2)): number {
+export interface ReleaseCliIo {
+  readonly cwd?: string;
+  readonly clock?: ReleaseClock;
+  readonly write?: (text: string) => void;
+}
+
+export function main(
+  argv: readonly string[] = process.argv.slice(2),
+  io: ReleaseCliIo = {},
+): number {
   const { values, positionals } = parseFlags(argv, FLAGS, { unknownFlags: "error" });
   const command = positionals[0];
+  const write = io.write ?? ((text: string) => process.stdout.write(text));
 
   if (values.version === true || command === "version") {
-    process.stdout.write(`${renderVersion(readBuildInfo("red-skills-release"))}\n`);
+    write(`${renderVersion(readBuildInfo("red-skills-release"))}\n`);
     return 0;
   }
   if (values.help === true || command === "help" || command === undefined) {
-    process.stdout.write(RELEASE_USAGE);
+    write(RELEASE_USAGE);
+    return 0;
+  }
+  if (command === "status") {
+    const repoRoot = resolve(io.cwd ?? process.cwd(), values.root ?? ".");
+    const changesetDirectory = values["changeset-dir"] === undefined
+      ? join(repoRoot, ".changeset")
+      : resolve(repoRoot, values["changeset-dir"]);
+    const currentVersion = values["current-version"] ?? readCurrentVersion(repoRoot);
+    const status = computeReleaseStatus({
+      queue: readChangesetQueue(changesetDirectory),
+      currentVersion,
+      scheme: values.scheme ?? "semver",
+      clock: io.clock ?? SYSTEM_CLOCK,
+    });
+    write(renderReleaseStatus(status));
     return 0;
   }
   throw new Error(`unknown release command: ${command}\n\n${RELEASE_USAGE}`);
+}
+
+const SYSTEM_CLOCK: ReleaseClock = {
+  today: () => {
+    const now = new Date();
+    return { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
+  },
+};
+
+function parseScheme(value: string): VersionScheme {
+  if (value === "semver" || value === "calver") return value;
+  throw new Error(`invalid release scheme: ${value}; expected semver or calver`);
+}
+
+function readCurrentVersion(repoRoot: string): string {
+  const manifestPath = join(repoRoot, "package.json");
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    throw new Error(`cannot read current version from package.json: ${errorMessage(error)}`);
+  }
+  if (!isRecord(manifest) || typeof manifest.version !== "string" || manifest.version === "") {
+    throw new Error("cannot read current version: package.json has no version");
+  }
+  return manifest.version;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/apps/release/src/status.ts
+++ b/apps/release/src/status.ts
@@ -1,0 +1,65 @@
+import type { ChangesetQueue, QueuedChange } from "./changeset-queue.js";
+import {
+  computeNextVersion,
+  type ReleaseClock,
+  type VersionScheme,
+} from "./version-core.js";
+
+interface ReleaseStatusInput {
+  readonly queue: ChangesetQueue;
+  readonly currentVersion: string;
+  readonly scheme: VersionScheme;
+  readonly clock: ReleaseClock;
+}
+
+export interface NoReleaseStatus {
+  readonly outcome: "no-release";
+  readonly currentVersion: string;
+  readonly changes: readonly [];
+}
+
+export interface PendingReleaseStatus {
+  readonly outcome: "pending-release";
+  readonly currentVersion: string;
+  readonly nextVersion: string;
+  readonly changes: readonly QueuedChange[];
+}
+
+export type ReleaseStatus = NoReleaseStatus | PendingReleaseStatus;
+
+/** Turn queue data into a first-class release/no-release result through the pure version core. */
+export function computeReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
+  if (input.queue.changes.length === 0) {
+    return { outcome: "no-release", currentVersion: input.currentVersion, changes: [] };
+  }
+  return {
+    outcome: "pending-release",
+    currentVersion: input.currentVersion,
+    nextVersion: computeNextVersion({
+      currentVersion: input.currentVersion,
+      pending: input.queue.pending,
+      scheme: input.scheme,
+      clock: input.clock,
+    }),
+    changes: input.queue.changes,
+  };
+}
+
+export function renderReleaseStatus(status: ReleaseStatus): string {
+  const lines = ["Release status", `Current version: ${status.currentVersion}`];
+  if (status.outcome === "no-release") {
+    lines.push("Outcome: no release", "Pending changes: 0");
+    return `${lines.join("\n")}\n`;
+  }
+
+  lines.push(
+    `Next version: ${status.nextVersion}`,
+    `Pending changes: ${status.changes.length}`,
+    "Changes:",
+  );
+  for (const change of status.changes) {
+    const packages = change.releases.map((release) => release.packageName).join(", ");
+    lines.push(`  - ${change.impact}: ${change.file} — ${change.summary} [${packages}]`);
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/apps/release/tests/changeset-queue.test.ts
+++ b/apps/release/tests/changeset-queue.test.ts
@@ -1,0 +1,66 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  ChangesetParseError,
+  readChangesetQueue,
+} from "../src/changeset-queue.js";
+
+const FIXTURES = join(import.meta.dirname, "fixtures", "changesets");
+
+describe("changeset queue", () => {
+  it("pins a single changeset", () => {
+    expect(readChangesetQueue(join(FIXTURES, "single"))).toEqual({
+      changes: [
+        {
+          file: "quiet-bears-wave.md",
+          summary: "Add a read-only release status command.",
+          body: "Add a read-only release status command.",
+          impact: "minor",
+          releases: [{ packageName: "@example/cli", impact: "minor" }],
+        },
+      ],
+      pending: { major: 0, minor: 1, patch: 0 },
+    });
+  });
+
+  it("sorts multiple changesets and classifies each by its highest package impact", () => {
+    expect(readChangesetQueue(join(FIXTURES, "multiple"))).toEqual({
+      changes: [
+        {
+          file: "bright-dogs-smile.md",
+          summary: "Correct version rendering for release candidates.",
+          body: "Correct version rendering for release candidates.",
+          impact: "patch",
+          releases: [{ packageName: "@example/core", impact: "patch" }],
+        },
+        {
+          file: "calm-cats-dance.md",
+          summary: "Replace the legacy release API.",
+          body: "Replace the legacy release API.\n\nThe new API keeps every package on one version train.",
+          impact: "major",
+          releases: [
+            { packageName: "@example/cli", impact: "minor" },
+            { packageName: "@example/core", impact: "major" },
+          ],
+        },
+      ],
+      pending: { major: 1, minor: 0, patch: 1 },
+    });
+  });
+
+  it("returns an empty queue as data", () => {
+    expect(readChangesetQueue(join(FIXTURES, "empty"))).toEqual({
+      changes: [],
+      pending: { major: 0, minor: 0, patch: 0 },
+    });
+  });
+
+  it("fails loudly with the malformed filename", () => {
+    expect(() => readChangesetQueue(join(FIXTURES, "malformed"))).toThrowError(
+      expect.objectContaining({
+        name: ChangesetParseError.name,
+        message: expect.stringContaining("broken-entry.md"),
+      }),
+    );
+  });
+});

--- a/apps/release/tests/fixtures/changesets/malformed/broken-entry.md
+++ b/apps/release/tests/fixtures/changesets/malformed/broken-entry.md
@@ -1,0 +1,5 @@
+---
+"@example/cli": enormous
+---
+
+This impact class is not valid.

--- a/apps/release/tests/fixtures/changesets/multiple/bright-dogs-smile.md
+++ b/apps/release/tests/fixtures/changesets/multiple/bright-dogs-smile.md
@@ -1,0 +1,5 @@
+---
+"@example/core": patch
+---
+
+Correct version rendering for release candidates.

--- a/apps/release/tests/fixtures/changesets/multiple/calm-cats-dance.md
+++ b/apps/release/tests/fixtures/changesets/multiple/calm-cats-dance.md
@@ -1,0 +1,8 @@
+---
+"@example/cli": minor
+"@example/core": major
+---
+
+Replace the legacy release API.
+
+The new API keeps every package on one version train.

--- a/apps/release/tests/fixtures/changesets/single/quiet-bears-wave.md
+++ b/apps/release/tests/fixtures/changesets/single/quiet-bears-wave.md
@@ -1,0 +1,5 @@
+---
+"@example/cli": minor
+---
+
+Add a read-only release status command.

--- a/apps/release/tests/status.test.ts
+++ b/apps/release/tests/status.test.ts
@@ -15,7 +15,7 @@ describe("release status", () => {
       main(
         [
           "status",
-          "--root",
+          "--changeset-dir",
           join(FIXTURES, "multiple"),
           "--current-version",
           "1.2.3",
@@ -57,7 +57,7 @@ describe("release status", () => {
     let output = "";
     expect(
       main(
-        ["status", "--root", join(FIXTURES, "empty"), "--current-version", "1.2.3"],
+        ["status", "--changeset-dir", join(FIXTURES, "empty"), "--current-version", "1.2.3"],
         { clock: CLOCK, write: (text) => { output += text; } },
       ),
     ).toBe(0);

--- a/apps/release/tests/status.test.ts
+++ b/apps/release/tests/status.test.ts
@@ -1,0 +1,72 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { main } from "../src/cli.js";
+import { readChangesetQueue } from "../src/changeset-queue.js";
+import { computeReleaseStatus } from "../src/status.js";
+import type { ReleaseClock } from "../src/version-core.js";
+
+const FIXTURES = join(import.meta.dirname, "fixtures", "changesets");
+const CLOCK: ReleaseClock = { today: () => ({ year: 2026, month: 8 }) };
+
+describe("release status", () => {
+  it("pins the status verb output with the next version and every impact class", () => {
+    let output = "";
+    expect(
+      main(
+        [
+          "status",
+          "--root",
+          join(FIXTURES, "multiple"),
+          "--current-version",
+          "1.2.3",
+          "--scheme",
+          "semver",
+        ],
+        { clock: CLOCK, write: (text) => { output += text; } },
+      ),
+    ).toBe(0);
+
+    expect(output).toMatchInlineSnapshot(`
+      "Release status
+      Current version: 1.2.3
+      Next version: 2.0.0
+      Pending changes: 2
+      Changes:
+        - patch: bright-dogs-smile.md — Correct version rendering for release candidates. [@example/core]
+        - major: calm-cats-dance.md — Replace the legacy release API. [@example/cli, @example/core]
+      "
+    `);
+  });
+
+  it("pins an empty queue as a distinct successful no-release outcome", () => {
+    const status = computeReleaseStatus({
+      queue: readChangesetQueue(join(FIXTURES, "empty")),
+      currentVersion: "1.2.3",
+      scheme: "semver",
+      clock: CLOCK,
+    });
+
+    expect(status).toEqual({
+      outcome: "no-release",
+      currentVersion: "1.2.3",
+      changes: [],
+    });
+  });
+
+  it("renders no release without treating it as an error", () => {
+    let output = "";
+    expect(
+      main(
+        ["status", "--root", join(FIXTURES, "empty"), "--current-version", "1.2.3"],
+        { clock: CLOCK, write: (text) => { output += text; } },
+      ),
+    ).toBe(0);
+    expect(output).toMatchInlineSnapshot(`
+      "Release status
+      Current version: 1.2.3
+      Outcome: no release
+      Pending changes: 0
+      "
+    `);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
Automated AFK landing for #3364. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3364

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788539709&installation_model_id=20659&pr_number=3376&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3376&signature=e07e63574034bc390a9b231e7c761cecb30558ac77a82a514f51f4703e6a7930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->