### PR TITLE
chore: changeset for the unreleased span since v3.6.2

### DIFF
--- a/.changeset/release-engine-and-brand-span.md
+++ b/.changeset/release-engine-and-brand-span.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/dev": minor
+"@reddb-io/release": minor
+---
+
+Ship the unreleased span since v3.6.2: the release engine app skeleton with its pure clock-injected version core (semver, calver YYYY.M.MICRO, rc derivation — ADR 0139 S1), the vendored brand tokens package with ANSI/CSS derivation and the VS Code dashboard brand header (ADR 0137), the Park's single blocker-block owner with one requeue applier, the Queue Custodian owning the merge with vanished-intent repair, and the contract-phase deletion of deprecated verb aliases.


### PR DESCRIPTION
Since v3.6.2 (08:50Z) seven substantive merges landed without a changeset — including the new `@reddb-io/release` app (S1 of Spec #3362) and the brand tokens package — so no Version Packages PR opened and the span is stranded unreleased. This adds the minor changeset that lets the release train move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788540254&installation_model_id=20659&pr_number=3379&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3379&signature=91d3855d9d668cdb81f8c90c4f5ee05a0a9be8fed9827c222379158aef4da410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->