### PR TITLE
chore: declare wayfinder HITL types for the AFK trust gate

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -60,6 +60,10 @@ plugins:
           think:
             model: gpt-5.6-sol   # design/routing — grouped with coding
             effort: high
+      labels:
+        hitl_types:
+          - wayfinder:grilling
+          - wayfinder:prototype
     # Adversarial review (ADR 0110, Spec #2205 — all slices landed 2026-07-19).
     # Folds to `review.*`. Review is the gate fold's third stage (ADR 0129): a
     # blocking finding draws the RESERVED review round of the Re-seed budget, and


### PR DESCRIPTION
Companion to wayfinder map #3381: lists wayfinder:grilling + wayfinder:prototype under plugins.dev.afk.labels.hitl_types so unblocked HITL decision tickets park ready-for-human instead of entering the autonomous queue (#3013).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788540735&installation_model_id=20659&pr_number=3392&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3392&signature=fa54fce7515506afd90d06930a1921bf0dc32df6fadf55ac5046749b32135ba8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->