### PR TITLE
chore: #3377 /go: Fix the AFK engine's push/re-park chain that turns an orphaned origin ti

### DIFF
--- a/apps/dev/src/core/blocker-state.ts
+++ b/apps/dev/src/core/blocker-state.ts
@@ -25,6 +25,20 @@ export interface CurrentBlocker {
   ref?: string;
   summary: string;
   next: string;
+  /**
+   * Epoch seconds at which THIS park was written (#3377). The re-park loop
+   * detector needs to know not just that the previous park carried the same
+   * blocker but WHEN — an identical park a month later is an issue nobody got
+   * to, and an identical park ten minutes later is a loop.
+   */
+  parkedAtEpoch?: number;
+  /**
+   * Set when this park repeated the previous one's signature inside the loop
+   * window (#3377). Its presence is the escalation: a human is told the engine
+   * has stopped making progress, instead of the issue being reborn Worker by
+   * Worker forever.
+   */
+  loopNote?: string;
   /** Present when a `status: blocked` record is active but needs repair. */
   defect?: BlockerStateDefect;
 }
@@ -55,12 +69,33 @@ interface BlockerCauseRule {
 }
 
 const BLOCKER_CAUSE_RULES: readonly BlockerCauseRule[] = [
+  // #3377 — a rejected push and an unreachable remote are DIFFERENT causes with
+  // opposite cures, and one rule answered for both: an orphaned origin tip was
+  // parked with "restore push access" and every subsequent Worker re-parked it,
+  // because access was never the problem and nobody was going to restore it.
+  // This rule is FIRST: a summary naming a divergence is a divergence even when
+  // it also says "push failed".
+  {
+    kind: "push-rejected",
+    names: /\bnon-fast-forward\b|\bremote tip diverged\b|\bfetch first\b|\bstale info\b|\bupdates were rejected\b/i,
+    next:
+      "Reconcile the diverged remote tip — nothing is broken and no access was lost: the branch on origin is not an " +
+      "ancestor of the worker tip. Fetch it and re-push the attempt branch (the claim holder may force-with-lease on " +
+      "the observed tip), then requeue.",
+  },
   {
     kind: "push-failed",
     names: /\bpush (?:failed|did not run|was rejected)\b|\bfailed to push\b|the true cause is the push/i,
     next: "Restore push access to the worker branch's remote, then requeue — there is no merge conflict to resolve.",
   },
 ];
+
+/** Look a cause rule up by the kind it records. */
+function causeRule(kind: string): BlockerCauseRule {
+  const rule = BLOCKER_CAUSE_RULES.find((r) => r.kind === kind);
+  if (!rule) throw new Error(`blocker-state: no cause rule for kind ${kind}`);
+  return rule;
+}
 
 /** Evidence that REFUTES a kind, without naming a replacement. A summary that
  * denies its own kind loses the kind rather than keeping a contradiction. */
@@ -72,7 +107,8 @@ const BLOCKER_KIND_REFUTED_BY: Readonly<Record<string, RegExp>> = {
  * cause it is derived from, so it is derived from the cause — never written
  * beside it. Kinds absent here keep the call site's own next-action. */
 const BLOCKER_NEXT_BY_KIND: Readonly<Record<string, string>> = {
-  "push-failed": BLOCKER_CAUSE_RULES[0]!.next,
+  "push-failed": causeRule("push-failed").next,
+  "push-rejected": causeRule("push-rejected").next,
   unclassified: "Read the summary and classify the real cause before choosing a recovery route.",
 };
 
@@ -105,6 +141,8 @@ export function makeBlocker(fields: {
   summary: string;
   next: string;
   ref?: string;
+  parkedAtEpoch?: number;
+  loopNote?: string;
 }): CurrentBlocker {
   const kind = reconcileBlockerKind(fields.kind, fields.summary);
   let next = BLOCKER_NEXT_BY_KIND[kind] ?? fields.next;
@@ -117,6 +155,8 @@ export function makeBlocker(fields: {
     ...(fields.ref !== undefined ? { ref: fields.ref } : {}),
     summary: fields.summary,
     next,
+    ...(fields.parkedAtEpoch !== undefined ? { parkedAtEpoch: fields.parkedAtEpoch } : {}),
+    ...(fields.loopNote !== undefined ? { loopNote: fields.loopNote } : {}),
   };
 }
 
@@ -143,6 +183,16 @@ function parseFields(block: string): Record<string, string> {
   return out;
 }
 
+/** A non-negative integer epoch, or undefined when the field is absent or junk.
+ * A malformed stamp is treated as NO stamp: the loop detector must never fire on
+ * a timestamp it cannot read. */
+function parseEpochField(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number(normalizeLine(value));
+  if (!Number.isInteger(parsed) || parsed < 0) return undefined;
+  return parsed;
+}
+
 export function parseCurrentBlocker(markdown: string): CurrentBlocker | null {
   const inner = readAnchoredRegion(markdown, BLOCKER_OPEN, BLOCKER_CLOSE);
   if (inner === null) return null;
@@ -158,6 +208,8 @@ export function parseCurrentBlocker(markdown: string): CurrentBlocker | null {
     ...(fields.ref ? { ref: safeField(fields.ref) } : {}),
     summary,
     next,
+    ...(parseEpochField(fields.parked_at) !== undefined ? { parkedAtEpoch: parseEpochField(fields.parked_at) } : {}),
+    ...(fields.loop_detected ? { loopNote: safeField(fields.loop_detected) } : {}),
     ...(missingFields.length > 0
       ? { defect: { name: MALFORMED_BLOCKER_STATE, missingFields } }
       : {}),
@@ -173,6 +225,8 @@ function formatBlockerFields(blocker: CurrentBlocker): string {
   if (blocker.ref) lines.push(`ref: ${safeField(blocker.ref)}`);
   lines.push(`summary: ${safeField(blocker.summary, "Unspecified blocker.")}`);
   lines.push(`next: ${safeField(blocker.next, "Human guidance required.")}`);
+  if (blocker.parkedAtEpoch !== undefined) lines.push(`parked_at: ${blocker.parkedAtEpoch}`);
+  if (blocker.loopNote) lines.push(`loop_detected: ${safeField(blocker.loopNote)}`);
   return `\n${lines.join("\n")}\n`;
 }
 
@@ -250,7 +304,9 @@ export function applyCurrentBlockerEdit(markdown: string, blocker: CurrentBlocke
     parsed.kind === blocker.kind &&
     parsed.summary === blocker.summary &&
     parsed.next === blocker.next &&
-    parsed.ref === blocker.ref;
+    parsed.ref === blocker.ref &&
+    parsed.parkedAtEpoch === blocker.parkedAtEpoch &&
+    parsed.loopNote === blocker.loopNote;
   return { body, changed, valid };
 }
 

--- a/apps/dev/src/core/branch-resume.ts
+++ b/apps/dev/src/core/branch-resume.ts
@@ -7,6 +7,8 @@
 // bypasses the agent entirely (validate + land directly).
 
 import type { BranchRef } from "./branch-cleanup.js";
+import { classifyComment } from "./comment-classification.js";
+import { isTrustedSource, type SourceTrustLevel } from "./source-trust.js";
 
 const LIVE_REF_ISSUE_RE = /^afk\/(?:([0-9]+)-[a-z0-9-]+|[^/]+\/([0-9]+)-[a-z0-9-]+)$/;
 
@@ -176,6 +178,53 @@ export function isGateGreenBranch(failureReason: string | undefined): boolean {
   // Strip trailing colon (e.g. "feedback-failed: detail text") before lookup.
   const first = (failureReason.trim().split(/\s+/)[0] ?? "").replace(/:$/, "");
   return first.length > 0 && !GATE_STAGE_REASONS.has(first);
+}
+
+// ---------- unconsumed requeue guidance (#3377) ----------
+
+/** The minimum a comment must expose for {@link hasUnconsumedGuidance}. */
+export interface GuidanceComment {
+  body: string;
+  sourceTrust?: SourceTrustLevel;
+}
+
+/**
+ * True when the thread's newest TRUSTED directive is newer than its newest
+ * Worker envelope — i.e. guidance arrived after the last Worker reported, so no
+ * Worker has yet run with it in its prompt (#3377).
+ *
+ * This is the condition under which the gate-green fast path must NOT be taken.
+ * The forbidden case it exists to close: a requeue writes fresh guidance, the
+ * next Worker finds an adoptable branch, skips the agent entirely, re-validates
+ * the identical tree and re-parks — with the guidance still sitting in the
+ * thread, intact and unexecuted, for the Worker after that to also skip.
+ *
+ * Comments are read in the chronological order the projection supplies them, so
+ * "newest" is a position, not a parsed timestamp: a missing or malformed
+ * `createdAt` cannot silently reorder the decision.
+ */
+export function hasUnconsumedGuidance(comments: readonly GuidanceComment[]): boolean {
+  let lastGuidance = -1;
+  let lastEnvelope = -1;
+  comments.forEach((comment, index) => {
+    const category = classifyComment({ body: comment.body });
+    if (category === "envelope") lastEnvelope = index;
+    else if (category === "directive" && isTrustedSource(comment.sourceTrust)) lastGuidance = index;
+  });
+  return lastGuidance !== -1 && lastGuidance > lastEnvelope;
+}
+
+/**
+ * The note a Worker owes the record when unconsumed guidance overrides a
+ * no-agent fast path (#3377). Loud by design: the skip that was happening
+ * silently is exactly what made the loop invisible.
+ */
+export function formatGuidanceOverrideNote(issue: number, branch: string): string {
+  return (
+    `🤖 /afk #${issue}: fresh requeue guidance has not been executed by any Worker yet, so the no-agent fast path ` +
+    `over \`${branch}\` is REFUSED — running one agent round with the guidance in the prompt instead. ` +
+    `Re-validating the same tree would re-park this issue with the guidance still unexecuted.`
+  );
 }
 
 /**

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -258,6 +258,14 @@ export interface LandingInput {
    * base falls back to the land-lock there. Defaults false/undefined.
    */
   nativeMergeQueue?: boolean;
+  /**
+   * True when the landing Worker holds this issue's claim (#3377). The claim is
+   * what licenses the gate's push step to RECONCILE a diverged `afk/*` tip with
+   * a leased force instead of parking: the attempt namespace belongs to the
+   * claim holder, so a tip it did not write is a dead attempt's leftover.
+   * Absent/false → a diverged tip stays a failure, exactly as before.
+   */
+  claimHeld?: boolean;
 }
 
 function isDocsOnlyPath(path: string): boolean {
@@ -452,7 +460,9 @@ export async function doLanding(
   // failure, not a merge conflict). Fail early with the real reason so no work
   // is silently lost and the issue is not mis-labelled blocked:merge-conflict.
   await deps.landingPhase?.("gate", { step: "push", status: "start" });
-  const pushed = await pushAttempt(deps.remoteGit, input.repoDir, input.branch, input.branch);
+  const pushed = await pushAttempt(deps.remoteGit, input.repoDir, input.branch, input.branch, {
+    claimHeld: input.claimHeld === true,
+  });
   if (!pushed.ok) {
     // Carry the REAL failure into the terminal record (#2576): a generic
     // land-failed with no diagnostic was being misread as a merge conflict.

--- a/apps/dev/src/core/park-loop.ts
+++ b/apps/dev/src/core/park-loop.ts
@@ -1,0 +1,88 @@
+// park-loop — the re-park loop detector (#3377).
+//
+// A park is a handoff to a human. A park REPEATED with the same blocker, minutes
+// after the last one, is not a handoff — it is the engine telling itself the
+// same thing forever. That is what #3335/#3336/#3343 did on 2026-08-05: an
+// orphaned origin tip parked with one diagnosis, the issue was requeued, the
+// next Worker reproduced the identical park, and the cycle had no floor because
+// nothing in the pipeline ever compared a park to the one before it.
+//
+// This module is PURE: it maps (previous blocker, next blocker, now) to a
+// verdict. The blocker's `parked_at` stamp is what makes "within a short window"
+// answerable at all — see blocker-state.ts.
+
+import type { CurrentBlocker } from "./blocker-state.js";
+
+/**
+ * How recently the previous park must have happened for a repeat to count as a
+ * loop. Three hours is deliberately SHORT: the signal being caught is
+ * worker-by-worker rebirth, which turns around in minutes. An identical park a
+ * day later is a stale issue nobody got to, and escalating that as a loop would
+ * teach humans to ignore the note.
+ */
+export const PARK_LOOP_WINDOW_S = 3 * 60 * 60;
+
+/** The comparable identity of a park: its kind and its summary, nothing else.
+ * The `next:` is derived from the kind, and the `ref:` moves between Workers
+ * without the blocker changing at all — including either would let a loop hide
+ * behind a field that carries no diagnosis. */
+export function parkSignature(blocker: Pick<CurrentBlocker, "kind" | "summary">): string {
+  const norm = (value: string): string => value.replace(/\s+/g, " ").trim().toLowerCase();
+  return `${norm(blocker.kind)}|${norm(blocker.summary)}`;
+}
+
+/** The verdict. `loop:true` means this park must ESCALATE rather than retry. */
+export interface ParkLoopVerdict {
+  loop: boolean;
+  /** The note the escalating park carries, or null when there is no loop. */
+  note: string | null;
+  /** Seconds between the two parks, when both stamps were readable. */
+  elapsedS?: number;
+}
+
+const NO_LOOP: ParkLoopVerdict = { loop: false, note: null };
+
+/**
+ * Detect a re-park loop: the SAME issue, the SAME blocker signature, inside the
+ * window. Three things deliberately return "no loop" rather than a guess:
+ *
+ *   - no previous park (the first park of a blocker is just a park);
+ *   - a previous park with no readable `parked_at` stamp (a record written
+ *     before this detector existed must not escalate on its first re-park);
+ *   - a differing signature (a NEW blocker is progress, even when it parks).
+ */
+export function detectParkLoop(input: {
+  previous: CurrentBlocker | null;
+  next: Pick<CurrentBlocker, "kind" | "summary">;
+  nowEpoch: number;
+  windowS?: number;
+}): ParkLoopVerdict {
+  const { previous, next, nowEpoch } = input;
+  const windowS = input.windowS ?? PARK_LOOP_WINDOW_S;
+  if (!previous) return NO_LOOP;
+  if (previous.parkedAtEpoch === undefined) return NO_LOOP;
+  if (parkSignature(previous) !== parkSignature(next)) return NO_LOOP;
+  const elapsedS = nowEpoch - previous.parkedAtEpoch;
+  // A stamp from the future is an unusable clock, not a zero-second loop.
+  if (elapsedS < 0 || elapsedS > windowS) return NO_LOOP;
+  return { loop: true, note: formatLoopNote(next.kind, elapsedS, windowS), elapsedS };
+}
+
+/** The note a loop-detected park carries. It names the repetition, the interval
+ * and the fact that the automatic route is now closed, because the cure for a
+ * loop is never another lap. */
+export function formatLoopNote(kind: string, elapsedS: number, windowS: number = PARK_LOOP_WINDOW_S): string {
+  return (
+    `re-park loop detected — this issue parked with the identical blocker (kind: ${kind}) ` +
+    `${describeInterval(elapsedS)} ago, inside the ${describeInterval(windowS)} loop window. ` +
+    `Automatic re-queue is withheld: each Worker is reproducing the same park, so the next lap changes nothing. ` +
+    `A human must change the blocker's cause or the guidance before this issue is queued again.`
+  );
+}
+
+function describeInterval(seconds: number): string {
+  if (seconds < 90) return `${Math.max(0, Math.round(seconds))}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 90) return `${minutes}m`;
+  return `${Math.round(minutes / 60)}h`;
+}

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -14,6 +14,8 @@ import {
   discoverResumableBranch,
   extractFailureReason,
   formatAdoptionNotice,
+  formatGuidanceOverrideNote,
+  hasUnconsumedGuidance,
   isExplicitRestartRequested,
   isGateGreenBranch,
   pullRequestMatchesAttempt,
@@ -467,12 +469,17 @@ export async function processIssue(
     .filter((pr) => pullRequestMatchesAttempt(pr, issue))
     .sort((a, b) => a.number - b.number);
   const adoptedPullRequest = selectAttemptPullRequest(matchingPullRequests, issue);
+  // #3377 — resolved BEFORE the census speaks, because the census is what tells a
+  // human which route this Worker took. Announcing "the no-agent gate" and then
+  // running an agent is the same kind of untrue record the loop was made of.
+  const guidanceUnconsumed = hasUnconsumedGuidance(comments);
   if (matchingPullRequests.length > 0) {
     await deps.gh.comment(
       issue,
       `🤖 /afk Attempt PRs for #${issue}: ${matchingPullRequests.map((pr) => `#${pr.number}`).join(", ")}. ` +
         (adoptedPullRequest
-          ? `Adopting #${adoptedPullRequest.number} from \`${adoptedPullRequest.headRefName}\` through the no-agent gate.`
+          ? `Adopting #${adoptedPullRequest.number} from \`${adoptedPullRequest.headRefName}\` through the ` +
+            (guidanceUnconsumed ? "agent, carrying the unexecuted requeue guidance." : "no-agent gate.")
           : "No adoptable head was found."),
     );
   }
@@ -514,9 +521,29 @@ export async function processIssue(
   const failureReason = extractFailureReason(prevFailureContext);
   const carriedValidationSignature = parseValidationFailureSignature(failureReason);
   const usesDeclaredValidationMoments = deps.validationMoments !== undefined;
-  const resumeIsGateGreen = adoptedPullRequest !== null ||
+  const fastPathIsGateGreen = adoptedPullRequest !== null ||
     (resumableBranch !== null && isGateGreenBranch(failureReason));
-  if (adoptedPullRequest) {
+  // #3377 — guidance nobody has run is guidance the fast path would evaporate.
+  // The no-agent path re-validates the SAME tree, so taking it here re-parks the
+  // issue with the requeue's Directive intact and unexecuted, and the Worker
+  // after that repeats it. One agent round with the guidance in the prompt is
+  // the whole cure; the refusal is announced rather than inferred from a
+  // missing log line.
+  const guidanceOverridesFastPath = fastPathIsGateGreen && guidanceUnconsumed;
+  const resumeIsGateGreen = fastPathIsGateGreen && !guidanceUnconsumed;
+  if (guidanceOverridesFastPath) {
+    const note = formatGuidanceOverrideNote(
+      issue,
+      adoptedPullRequest?.headRefName ?? resumableBranch?.branch ?? branch,
+    );
+    deps.appendIterLog(note);
+    await deps.gh.comment(issue, note);
+    deps.recordWorkerEvent?.("worker.fast_path_refused", {
+      issue,
+      reason: "unconsumed-requeue-guidance",
+    });
+  }
+  if (adoptedPullRequest && resumeIsGateGreen) {
     deps.appendIterLog(
       `🤖 /afk #${issue}: adopting open PR #${adoptedPullRequest.number} from \`${adoptedPullRequest.headRefName}\`; agent skipped.`,
     );
@@ -2038,6 +2065,10 @@ export async function processIssue(
       title: input.title,
       labels,
       nativeMergeQueue: deps.nativeMergeQueue,
+      // #3377 — the gate's push step may reconcile a diverged `afk/*` tip only
+      // while this Worker still OWNS the issue. `ownsCommentClaim` is that fact,
+      // not an assumption about how the Worker got here.
+      claimHeld: ownsCommentClaim,
     },
     {
       preMerge: () =>

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -78,6 +78,7 @@ import { deriveOutcomeRecord } from "../outcome-record.js";
 import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
 import { acquireClaim, renderClaimComment, type ClaimGh, type ClaimReconcileOptions, type ClaimDecision } from "../claim.js";
 import { applyCurrentBlockerEdit, makeBlocker, parseCurrentBlocker, type CurrentBlocker } from "../blocker-state.js";
+import { detectParkLoop, type ParkLoopVerdict } from "../park-loop.js";
 import {
   parseTrustPolicy,
   evaluateClaimTrust,
@@ -335,6 +336,10 @@ export const ACTIONABLE_BLOCKER_KINDS = new Set([
   "validation",
   "merge-conflict",
   "push-failed",
+  // #3377 — the divergence half of the old one-size push park. Actionable for
+  // the same reason `push-failed` is: it names a cause a later `runner` blocker
+  // must not overwrite.
+  "push-rejected",
   "ci",
   "stalled",
   "decision",
@@ -342,6 +347,24 @@ export const ACTIONABLE_BLOCKER_KINDS = new Set([
   "infra",
   "host-config",
 ]);
+/**
+ * The re-park loop verdict for the blocker this terminal is about to write
+ * (#3377), read off the issue body's previous park. A terminal with no blocker
+ * to write cannot be a repeat of one.
+ */
+export function parkLoopFor(
+  deps: ProcessIssueDeps,
+  input: ProcessIssueInput,
+  proposed: CurrentBlocker | null,
+): ParkLoopVerdict {
+  if (!proposed) return { loop: false, note: null };
+  return detectParkLoop({
+    previous: parseCurrentBlocker(input.body),
+    next: proposed,
+    nowEpoch: deps.nowEpoch(),
+  });
+}
+
 export function shouldPreserveCurrentBlocker(existing: CurrentBlocker | null, next: CurrentBlocker): boolean {
   if (!existing) return false;
   if (next.kind !== "runner") return false;
@@ -355,7 +378,15 @@ export async function writeCurrentBlockerBestEffort(
   if (!blocker || !deps.gh.editBody) return;
   try {
     const existing = parseCurrentBlocker(input.body);
-    const next = shouldPreserveCurrentBlocker(existing, blocker) ? existing! : blocker;
+    const preserved = shouldPreserveCurrentBlocker(existing, blocker) ? existing! : blocker;
+    // Every park this Worker WRITES carries the moment it wrote it (#3377). The
+    // stamp is what lets the next Worker's detector tell an issue nobody got to
+    // from an issue being reborn every few minutes. A preserved earlier blocker
+    // keeps its own stamp — it is not a new park.
+    const next =
+      preserved === blocker && blocker.parkedAtEpoch === undefined
+        ? { ...blocker, parkedAtEpoch: deps.nowEpoch() }
+        : preserved;
     const { body, changed } = applyCurrentBlockerEdit(input.body, next);
     if (!changed) return; // byte-exact no-op: body already reflects the desired blocker state
     await deps.gh.editBody(input.issue, body);
@@ -392,9 +423,35 @@ export async function terminalFailure(
 ): Promise<ProcessIssueResult> {
   const { deps, input } = c;
   markTerminalState(deps, outcome);
-  const decision = await routeRecovery(deps, input.issue, outcome, recoveryOrdinalFor(input));
+  // #3377 — compare this park to the last one BEFORE asking the recovery policy.
+  // The policy counts requeue ordinals, which a fresh Worker resets; an issue
+  // whose every Worker reproduces one blocker therefore never reaches a cap. An
+  // identical signature inside the window closes the automatic route instead.
+  const proposedBlocker = blockerForFailure(outcome, sections);
+  const loop = parkLoopFor(deps, input, proposedBlocker);
+  if (loop.loop && loop.note) {
+    deps.appendIterLog(`🤖 /afk #${input.issue}: ${loop.note}`);
+    deps.recordWorkerEvent?.("worker.park_loop_detected", {
+      issue: input.issue,
+      kind: proposedBlocker?.kind ?? "",
+      elapsed_s: loop.elapsedS ?? 0,
+    });
+  }
+  const decision = await routeRecovery(
+    deps,
+    input.issue,
+    outcome,
+    recoveryOrdinalFor(input),
+    loop.loop ? { forceDecision: "escalate" } : {},
+  );
   if (decision === "escalate") {
-    await writeCurrentBlockerBestEffort(deps, input, blockerForFailure(outcome, sections));
+    await writeCurrentBlockerBestEffort(
+      deps,
+      input,
+      loop.loop && loop.note && proposedBlocker
+        ? { ...proposedBlocker, loopNote: loop.note, parkedAtEpoch: deps.nowEpoch() }
+        : proposedBlocker,
+    );
   }
   const posted = await emitFailure(c, envelopeStatusFor(outcome), sectionKey, sections);
   if (record.validationSummary) {

--- a/apps/dev/src/core/remote-branch.ts
+++ b/apps/dev/src/core/remote-branch.ts
@@ -127,6 +127,31 @@ export function pushAttemptArgs(repoDir: string, branch: string, remoteName: str
   return ["-C", repoDir, "push", "origin", `${branch}:refs/heads/${remoteName}`];
 }
 
+/** argv for the CLAIM-OWNED reconciliation push (#3377): the same refspec as
+ * {@link pushAttemptArgs}, leased on the tip the remote was OBSERVED to carry.
+ * The lease is what keeps this a reconciliation rather than a clobber — a tip
+ * that moves between the observation and the push loses the lease and fails. */
+export function pushAttemptForceWithLeaseArgs(
+  repoDir: string,
+  branch: string,
+  remoteName: string,
+  observedTip: string,
+): string[] {
+  return [
+    "-C",
+    repoDir,
+    "push",
+    `--force-with-lease=refs/heads/${remoteName}:${observedTip}`,
+    "origin",
+    `${branch}:refs/heads/${remoteName}`,
+  ];
+}
+
+/** argv fetching the remote tip before a leased re-push (#3377). */
+export function fetchRemoteBranchArgs(repoDir: string, remoteName: string): string[] {
+  return ["-C", repoDir, "fetch", "origin", `refs/heads/${remoteName}`];
+}
+
 /** argv resolving a local ref to its sha (push verification, #2811). */
 export function localShaArgs(repoDir: string, ref: string): string[] {
   return ["-C", repoDir, "rev-parse", "--verify", "--quiet", `${ref}^{commit}`];
@@ -196,14 +221,94 @@ export async function deleteRemote(
   return { ok: true, ran: true, status: "pushed" };
 }
 
+/**
+ * Why a push was refused (#3377). The two classes need OPPOSITE cures and were
+ * being narrated with one sentence:
+ *
+ *   - `non-fast-forward` — the remote tip is not an ancestor of the local tip.
+ *     Nothing is broken; the branch diverged. The cure is mechanical.
+ *   - `access` — auth, permissions, DNS, transport. No amount of reconciliation
+ *     helps until someone restores access.
+ *   - `unknown` — git said something this classifier cannot read. Never guess.
+ */
+export type PushFailureClass = "non-fast-forward" | "access" | "unknown";
+
+/** Access/transport evidence. Checked FIRST: an auth failure never claims a
+ * non-fast-forward, so a haystack carrying both words is a rejection whose
+ * transport also complained, and the access cure is the wrong one to print. */
+const ACCESS_MARKERS = [
+  "permission denied",
+  "permission to",
+  "authentication failed",
+  "could not read from remote repository",
+  "invalid username or password",
+  "access denied",
+  "repository not found",
+  "terminal prompts disabled",
+  "could not resolve host",
+  "connection timed out",
+  "connection refused",
+  "network is unreachable",
+  "unable to access",
+  "http 401",
+  "http 403",
+  "error: 403",
+];
+
+/** Divergence evidence — the remote tip moved under the push. */
+const NON_FAST_FORWARD_MARKERS = [
+  "non-fast-forward",
+  "fetch first",
+  "stale info",
+  "behind its remote counterpart",
+  "tip of your current branch is behind",
+  "[rejected]",
+  "updates were rejected",
+];
+
+/**
+ * Classify a push refusal from git's stderr (#3377). An unreadable stderr is
+ * `unknown` rather than a guess: the whole point of the split is that each class
+ * prints a DIFFERENT cure, and printing the wrong one is what turned an orphaned
+ * origin tip into a park telling a human to restore access that was never lost.
+ */
+export function classifyPushFailure(stderr: string): PushFailureClass {
+  const haystack = (stderr ?? "").toLowerCase();
+  if (ACCESS_MARKERS.some((m) => haystack.includes(m))) return "access";
+  if (NON_FAST_FORWARD_MARKERS.some((m) => haystack.includes(m))) return "non-fast-forward";
+  return "unknown";
+}
+
+/** Options for {@link pushAttempt}. */
+export interface PushAttemptOptions {
+  /**
+   * True when THIS Worker holds the issue's claim. The `afk/<issue>-<slug>` head
+   * is attempt namespace and the claim grants exclusive ownership of it, so a
+   * diverged tip there is by definition a dead attempt's leftover — reconcilable
+   * with a leased force. Without the claim the same divergence is a live peer's
+   * work and the push stays a failure.
+   */
+  claimHeld?: boolean;
+}
+
 /** Push a live worker branch to another live worker ref. Returns ok:false
  * (caller warns) on a non-zero exec, never throws. Empty or non-live refs skip
- * the git call (ran:false). */
+ * the git call (ran:false).
+ *
+ * #3377 — a non-fast-forward refusal on a branch this Worker OWNS is reconciled
+ * rather than parked: fetch the tip origin actually carries and re-push leased
+ * on that exact sha. Three conditions gate the force and all three are checked
+ * here, never at a call site: the claim is held, both refs are in the `afk/*`
+ * attempt namespace (already asserted above), and the refusal really is a
+ * divergence. A lease LOST between the observation and the re-push is a real
+ * race — someone else is writing this branch — and stays a failure.
+ */
 export async function pushAttempt(
   git: GitExec,
   repoDir: string,
   branch: string,
   remoteName: string,
+  opts: PushAttemptOptions = {},
 ): Promise<RemoteBranchOutcome> {
   if (!branch || !remoteName) {
     return { ok: false, ran: false, status: "skipped", warn: "push_attempt called with empty branch or remote — skipping" };
@@ -211,8 +316,8 @@ export async function pushAttempt(
   if (!isValidRef(branch) || !isValidRef(remoteName)) {
     return { ok: false, ran: false, status: "skipped", warn: "push_attempt called with non-live branch or remote — skipping" };
   }
-  const { code } = await git(pushAttemptArgs(repoDir, branch, remoteName));
-  if (code !== 0) {
+  const first = await git(pushAttemptArgs(repoDir, branch, remoteName));
+  if (first.code !== 0) {
     // #2811: a non-zero push is EVIDENCE OF NOTHING until the remote ref is
     // read. A concurrent post-commit-hook push, a stale `--force-with-lease`
     // lease, or a transient forge hiccup on a ref that already advanced all
@@ -227,9 +332,81 @@ export async function pushAttempt(
         warn: `push to origin/${remoteName} exited non-zero but origin already carries ${verified.sha} — the push succeeded`,
       };
     }
-    return { ok: false, ran: true, status: "failed", warn: `failed to push attempt branch to origin/${remoteName}` };
+    const failure = classifyPushFailure(first.stderr ?? "");
+    if (failure === "non-fast-forward" && opts.claimHeld === true) {
+      const reconciled = await reconcileDivergedTip(git, repoDir, branch, remoteName, verified.remoteSha);
+      if (reconciled) return reconciled;
+    }
+    return {
+      ok: false,
+      ran: true,
+      status: "failed",
+      warn: describePushFailure(remoteName, failure, opts.claimHeld === true),
+    };
   }
   return { ok: true, ran: true, status: "pushed" };
+}
+
+/** The one-sentence diagnosis a park inherits. Each class names its own cure so
+ * the blocker's `next:` can be DERIVED from the cause instead of guessed. */
+function describePushFailure(remoteName: string, failure: PushFailureClass, claimHeld: boolean): string {
+  const head = `failed to push attempt branch to origin/${remoteName}`;
+  if (failure === "non-fast-forward") {
+    return claimHeld
+      ? `${head} — the remote tip diverged (non-fast-forward) and the leased reconciliation did not converge; ` +
+          `another writer holds this branch, so nothing was force-pushed`
+      : `${head} — the remote tip diverged (non-fast-forward) and this Worker does not hold the issue claim, ` +
+          `so the branch was left exactly as it is`;
+  }
+  if (failure === "access") {
+    return `${head} — push access to the remote failed (auth/network), so nothing reached origin`;
+  }
+  return `${head} — git refused the push for a reason this Worker could not classify`;
+}
+
+/**
+ * Re-push a claim-owned attempt branch leased on the tip origin was OBSERVED to
+ * carry. Returns the successful outcome, or `null` when the reconciliation did
+ * not converge (the caller then reports the ordinary failure). Never throws.
+ */
+async function reconcileDivergedTip(
+  git: GitExec,
+  repoDir: string,
+  branch: string,
+  remoteName: string,
+  observedFromVerify: string,
+): Promise<RemoteBranchOutcome | null> {
+  // The lease needs a tip, and a tip nobody read is a lease nobody can honour.
+  // `verifyPushed` already asked once; only re-ask when it came back empty.
+  let observed = observedFromVerify;
+  if (!observed) {
+    await git(fetchRemoteBranchArgs(repoDir, remoteName));
+    observed = (await shaOf(git, remoteShaArgs(repoDir, remoteName), (out) => out.split(/\s+/)[0] ?? "")).trim();
+  }
+  if (!observed) return null;
+  const leased = await git(pushAttemptForceWithLeaseArgs(repoDir, branch, remoteName, observed));
+  if (leased.code === 0) {
+    return {
+      ok: true,
+      ran: true,
+      status: "pushed",
+      warn:
+        `origin/${remoteName} carried a diverged tip ${observed.slice(0, 12)} from a dead attempt; ` +
+        `reconciled under this Worker's claim with --force-with-lease`,
+    };
+  }
+  // The leased push can still lose to a genuine race — or the tip may have moved
+  // to exactly our commit in the meantime, which is a success, not a failure.
+  const after = await verifyPushed(git, repoDir, branch, remoteName);
+  if (after.pushed) {
+    return {
+      ok: true,
+      ran: true,
+      status: "pushed",
+      warn: `leased re-push to origin/${remoteName} exited non-zero but origin now carries ${after.sha} — the push succeeded`,
+    };
+  }
+  return null;
 }
 
 /** Read a ref's sha, or "" when it does not resolve. */

--- a/apps/dev/tests/landing.test-support.ts
+++ b/apps/dev/tests/landing.test-support.ts
@@ -163,9 +163,27 @@ export interface Opts {
   remoteTipSha?: string;
   /** sha the local `rev-parse` answers (#2811 verification). */
   localTipSha?: string;
+  /** stderr the opening `pushAttempt` emits, which classifies the refusal (#3377). */
+  pushAttemptStderr?: string;
+  /** True when the landing Worker holds the issue claim (#3377). */
+  claimHeld?: boolean;
+  /**
+   * rc the CLAIM-OWNED `--force-with-lease` reconciliation push returns (#3377).
+   * Defaults to 0 — the lease is honoured and the diverged tip converges. Set to
+   * non-zero to drive the lost-lease race.
+   */
+  leasedPushCode?: number;
+  /**
+   * sha `ls-remote` answers AFTER the leased re-push. Absent → the same
+   * `remoteTipSha` as before, so a lost lease stays a failure.
+   */
+  remoteTipShaAfterLease?: string;
 }
 
 export function harness(opts: Opts = {}): Harness {
+  // Flipped by a successful leased re-push so the post-push verification can
+  // read the tip the reconciliation just wrote (#3377).
+  let leasedPushed = false;
   const mergeCalls: string[][] = [];
   const pushedAttempt: string[][] = [];
   const firedHooks: string[] = [];
@@ -349,13 +367,22 @@ export function harness(opts: Opts = {}): Harness {
       const j = argv.join(" ");
       // #2811 push verification reads — recorded, but not counted as pushes.
       if (j.includes("ls-remote")) {
-        return { code: 0, stdout: opts.remoteTipSha ? `${opts.remoteTipSha}\trefs/heads/x\n` : "", stderr: "" };
+        const tip = leasedPushed ? (opts.remoteTipShaAfterLease ?? opts.remoteTipSha) : opts.remoteTipSha;
+        return { code: 0, stdout: tip ? `${tip}\trefs/heads/x\n` : "", stderr: "" };
       }
       if (j.includes("rev-parse")) {
         return { code: opts.localTipSha ? 0 : 1, stdout: opts.localTipSha ?? "", stderr: "" };
       }
       pushedAttempt.push(argv);
-      return { code: opts.pushAttemptCode ?? 0, stdout: "", stderr: "" };
+      // #3377 — the claim-owned reconciliation push is a DISTINCT outcome from
+      // the plain push it follows: the plain one is rejected, the leased one
+      // converges unless the test drives a lost lease.
+      if (j.includes("--force-with-lease")) {
+        const code = opts.leasedPushCode ?? 0;
+        if (code === 0) leasedPushed = true;
+        return { code, stdout: "", stderr: code === 0 ? "" : "! [rejected] (stale info)" };
+      }
+      return { code: opts.pushAttemptCode ?? 0, stdout: "", stderr: opts.pushAttemptStderr ?? "" };
     },
     async fireHook(name) {
       firedHooks.push(name);
@@ -437,6 +464,7 @@ export function harness(opts: Opts = {}): Harness {
     ...(opts.labels ? { labels: opts.labels } : {}),
     ...(opts.changedFiles ? { changedFiles: opts.changedFiles } : {}),
     nativeMergeQueue: opts.nativeMergeQueue,
+    ...(opts.claimHeld === undefined ? {} : { claimHeld: opts.claimHeld }),
   };
 
   const hooks: LandingHookContexts = {

--- a/apps/dev/tests/push-repark-loop.test.ts
+++ b/apps/dev/tests/push-repark-loop.test.ts
@@ -1,0 +1,309 @@
+// #3377 — the push/re-park chain that turned an orphaned origin tip into an
+// eternal park loop (observed 2026-08-05 on #3335/#3336/#3343).
+//
+// Four seams compound into that loop, and each has its own contract here:
+//   1. a claim-owned attempt branch reconciles a diverged remote tip instead of
+//      failing, and a LOST lease still fails;
+//   2. a rejected push and an unreachable remote park with DIFFERENT cures;
+//   3. fresh requeue guidance is never evaporated by the no-agent fast path;
+//   4. a second identical park inside the window escalates as a loop.
+
+import { describe, expect, it } from "vitest";
+import {
+  classifyPushFailure,
+  pushAttempt,
+  pushAttemptForceWithLeaseArgs,
+  type GitExec,
+  type GitExecResult,
+} from "../src/core/remote-branch.js";
+import {
+  applyCurrentBlockerEdit,
+  makeBlocker,
+  parseCurrentBlocker,
+  type CurrentBlocker,
+} from "../src/core/blocker-state.js";
+import { blockerForFailure } from "../src/core/process-issue/terminal.js";
+import { detectParkLoop, parkSignature, PARK_LOOP_WINDOW_S } from "../src/core/park-loop.js";
+import { hasUnconsumedGuidance } from "../src/core/branch-resume.js";
+import { doLanding } from "../src/core/landing.js";
+import { harness } from "./landing.test-support.js";
+
+const BRANCH = "afk/3335-a-module";
+const LOCAL_TIP = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const ORPHAN_TIP = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const NON_FF_STDERR = "! [rejected] main -> main (non-fast-forward)\nhint: Updates were rejected because the tip ...";
+const ACCESS_STDERR = "remote: Permission to o/r.git denied to worker.\nfatal: unable to access 'https://…': 403";
+
+/**
+ * A GitExec whose plain push is rejected with `stderr`, whose remote answers
+ * `remoteTip`, and whose leased re-push exits `leaseCode` (converging the remote
+ * onto the local tip when it succeeds).
+ */
+function gitWithDivergedRemote(opts: {
+  stderr: string;
+  remoteTip: string;
+  leaseCode?: number;
+}): { git: GitExec; calls: string[][] } {
+  const calls: string[][] = [];
+  let remoteTip = opts.remoteTip;
+  const git: GitExec = async (args): Promise<GitExecResult> => {
+    calls.push(args);
+    const j = args.join(" ");
+    if (j.includes("ls-remote")) return { code: 0, stdout: `${remoteTip}\trefs/heads/${BRANCH}\n`, stderr: "" };
+    if (j.includes("rev-parse")) return { code: 0, stdout: `${LOCAL_TIP}\n`, stderr: "" };
+    if (j.includes("--force-with-lease")) {
+      const code = opts.leaseCode ?? 0;
+      if (code === 0) remoteTip = LOCAL_TIP;
+      return { code, stdout: "", stderr: code === 0 ? "" : "! [rejected] (stale info)" };
+    }
+    return { code: 1, stdout: "", stderr: opts.stderr };
+  };
+  return { git, calls };
+}
+
+describe("#3377 — a claim-owned attempt branch reconciles a diverged remote tip", () => {
+  it("re-pushes with --force-with-lease on the OBSERVED tip and reports pushed", async () => {
+    const { git, calls } = gitWithDivergedRemote({ stderr: NON_FF_STDERR, remoteTip: ORPHAN_TIP });
+    const result = await pushAttempt(git, "/repo", BRANCH, BRANCH, { claimHeld: true });
+
+    expect(result.status).toBe("pushed");
+    expect(result.ok).toBe(true);
+    expect(result.warn).toContain("dead attempt");
+    // The lease is pinned to the tip that was READ, not to a bare --force.
+    const leased = calls.find((c) => c.join(" ").includes("--force-with-lease"));
+    expect(leased).toEqual(pushAttemptForceWithLeaseArgs("/repo", BRANCH, BRANCH, ORPHAN_TIP));
+    expect(calls.some((c) => c.includes("--force"))).toBe(false);
+  });
+
+  it("keeps a LOST lease a failure — a real race is never clobbered", async () => {
+    const { git, calls } = gitWithDivergedRemote({ stderr: NON_FF_STDERR, remoteTip: ORPHAN_TIP, leaseCode: 1 });
+    const result = await pushAttempt(git, "/repo", BRANCH, BRANCH, { claimHeld: true });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("failed");
+    expect(result.warn).toContain("another writer holds this branch");
+    expect(calls.filter((c) => c.join(" ").includes("--force-with-lease"))).toHaveLength(1);
+  });
+
+  it("never forces without the claim", async () => {
+    const { git, calls } = gitWithDivergedRemote({ stderr: NON_FF_STDERR, remoteTip: ORPHAN_TIP });
+    const result = await pushAttempt(git, "/repo", BRANCH, BRANCH);
+
+    expect(result.ok).toBe(false);
+    expect(result.warn).toContain("does not hold the issue claim");
+    expect(calls.some((c) => c.join(" ").includes("force"))).toBe(false);
+  });
+
+  it("never forces outside the afk/* attempt namespace, claim or no claim", async () => {
+    const { git, calls } = gitWithDivergedRemote({ stderr: NON_FF_STDERR, remoteTip: ORPHAN_TIP });
+    const result = await pushAttempt(git, "/repo", "main", "main", { claimHeld: true });
+
+    expect(result.status).toBe("skipped");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("never forces an ACCESS failure — reconciliation is not the cure there", async () => {
+    const { git, calls } = gitWithDivergedRemote({ stderr: ACCESS_STDERR, remoteTip: ORPHAN_TIP });
+    const result = await pushAttempt(git, "/repo", BRANCH, BRANCH, { claimHeld: true });
+
+    expect(result.ok).toBe(false);
+    expect(result.warn).toContain("push access to the remote failed");
+    expect(calls.some((c) => c.join(" ").includes("force"))).toBe(false);
+  });
+
+  it("classifies the two failure families, and refuses to guess a third", () => {
+    expect(classifyPushFailure(NON_FF_STDERR)).toBe("non-fast-forward");
+    expect(classifyPushFailure(ACCESS_STDERR)).toBe("access");
+    // An access failure that also uses the word "rejected" is still access: the
+    // cure a human is told to apply must match what actually broke.
+    expect(classifyPushFailure("remote: Permission denied\n! [rejected] non-fast-forward")).toBe("access");
+    expect(classifyPushFailure("")).toBe("unknown");
+    expect(classifyPushFailure("fatal: something entirely new")).toBe("unknown");
+  });
+
+  it("converges the landing's gate push when the Worker holds the claim", async () => {
+    const h = harness({
+      openPr: true,
+      pushAttemptCode: 1,
+      pushAttemptStderr: NON_FF_STDERR,
+      claimHeld: true,
+      remoteTipSha: ORPHAN_TIP,
+      remoteTipShaAfterLease: LOCAL_TIP,
+      localTipSha: LOCAL_TIP,
+    });
+    const result = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(result.ok).toBe(true);
+    expect(h.pushedAttempt.some((c) => c.join(" ").includes("--force-with-lease"))).toBe(true);
+  });
+
+  it("parks the same landing when the Worker does NOT hold the claim", async () => {
+    const h = harness({
+      openPr: true,
+      pushAttemptCode: 1,
+      pushAttemptStderr: NON_FF_STDERR,
+      remoteTipSha: ORPHAN_TIP,
+      localTipSha: LOCAL_TIP,
+    });
+    const result = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("infra");
+    expect(h.pushedAttempt.some((c) => c.join(" ").includes("force"))).toBe(false);
+  });
+});
+
+describe("#3377 — a push park names the cause that actually broke", () => {
+  /** The landing's own infraReason text for a push that reached nothing. */
+  const landingSummary = (warn: string): string =>
+    `worker branch push failed: ${warn} — the branch is not on origin at its local tip, so nothing was merged`;
+
+  it("prescribes MECHANICAL reconciliation for a non-fast-forward rejection", () => {
+    const blocker = blockerForFailure("infra", {
+      log: landingSummary(
+        `failed to push attempt branch to origin/${BRANCH} — the remote tip diverged (non-fast-forward) and the ` +
+          "leased reconciliation did not converge; another writer holds this branch, so nothing was force-pushed",
+      ),
+    });
+    expect(blocker?.kind).toBe("push-rejected");
+    expect(blocker?.next).toMatch(/reconcile the diverged remote tip/i);
+    // The exact sentence that misdiagnosed the 2026-08-05 incident.
+    expect(blocker?.next).not.toMatch(/restore push access/i);
+  });
+
+  it("still prescribes restoring ACCESS when access is what failed", () => {
+    const blocker = blockerForFailure("infra", {
+      log: landingSummary(
+        `failed to push attempt branch to origin/${BRANCH} — push access to the remote failed (auth/network), ` +
+          "so nothing reached origin",
+      ),
+    });
+    expect(blocker?.kind).toBe("push-failed");
+    expect(blocker?.next).toMatch(/restore push access/i);
+    expect(blocker?.next).not.toMatch(/reconcile the diverged remote tip/i);
+  });
+
+  it("derives the cure from the cause even when a call site proposes the wrong one", () => {
+    const blocker = makeBlocker({
+      kind: "push-failed",
+      summary: "the push was rejected non-fast-forward; origin carries a tip this Worker never wrote",
+      next: "Restore push access to the worker branch's remote, then requeue.",
+    });
+    expect(blocker.kind).toBe("push-rejected");
+    expect(blocker.next).toMatch(/reconcile the diverged remote tip/i);
+  });
+});
+
+describe("#3377 — requeue guidance survives the adopt fast-path", () => {
+  const envelope = (n: number): string => `<details data-attempt-status="blocked">\n<summary>Attempt ${n}</summary>\n</details>`;
+  const guidance = (text: string): string =>
+    `<details data-kind="directive">\n<summary>Requeue</summary>\n\nHuman guidance:\n${text}\n</details>`;
+
+  it("reports guidance posted after the last envelope as unconsumed", () => {
+    expect(
+      hasUnconsumedGuidance([
+        { body: envelope(1), sourceTrust: "trusted" },
+        { body: guidance("force-push the branch"), sourceTrust: "trusted" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("reports guidance a Worker already reported against as consumed", () => {
+    expect(
+      hasUnconsumedGuidance([
+        { body: guidance("force-push the branch"), sourceTrust: "trusted" },
+        { body: envelope(1), sourceTrust: "trusted" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("never promotes an UNTRUSTED directive into a fast-path refusal", () => {
+    expect(
+      hasUnconsumedGuidance([
+        { body: envelope(1), sourceTrust: "trusted" },
+        { body: guidance("do a thing"), sourceTrust: "automation" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("is silent on a thread with no guidance at all", () => {
+    expect(hasUnconsumedGuidance([{ body: envelope(1) }, { body: "just talking" }])).toBe(false);
+    expect(hasUnconsumedGuidance([])).toBe(false);
+  });
+});
+
+describe("#3377 — an identical park inside the window is a loop, not a retry", () => {
+  const parked = (fields: Partial<CurrentBlocker> = {}): CurrentBlocker => ({
+    status: "blocked",
+    kind: "push-rejected",
+    summary: "worker branch push failed — the remote tip diverged (non-fast-forward)",
+    next: "Reconcile the diverged remote tip.",
+    parkedAtEpoch: 1_000_000,
+    ...fields,
+  });
+
+  it("escalates the second identical park", () => {
+    const verdict = detectParkLoop({
+      previous: parked(),
+      next: parked(),
+      nowEpoch: 1_000_000 + 600,
+    });
+    expect(verdict.loop).toBe(true);
+    expect(verdict.elapsedS).toBe(600);
+    expect(verdict.note).toMatch(/re-park loop detected/i);
+    expect(verdict.note).toMatch(/automatic re-queue is withheld/i);
+  });
+
+  it("lets a DIFFERENT blocker through — a new park is progress", () => {
+    expect(
+      detectParkLoop({
+        previous: parked(),
+        next: parked({ kind: "validation", summary: "the gate failed" }),
+        nowEpoch: 1_000_000 + 60,
+      }).loop,
+    ).toBe(false);
+  });
+
+  it("lets an identical park OUTSIDE the window through — that is a stale issue, not a loop", () => {
+    expect(
+      detectParkLoop({
+        previous: parked(),
+        next: parked(),
+        nowEpoch: 1_000_000 + PARK_LOOP_WINDOW_S + 1,
+      }).loop,
+    ).toBe(false);
+  });
+
+  it("never fires on a first park, an unstamped record, or a clock that runs backwards", () => {
+    expect(detectParkLoop({ previous: null, next: parked(), nowEpoch: 1_000_000 }).loop).toBe(false);
+    expect(
+      detectParkLoop({
+        previous: parked({ parkedAtEpoch: undefined }),
+        next: parked(),
+        nowEpoch: 1_000_000,
+      }).loop,
+    ).toBe(false);
+    expect(detectParkLoop({ previous: parked(), next: parked(), nowEpoch: 999_000 }).loop).toBe(false);
+  });
+
+  it("compares kind and summary only — a moved ref must not hide a loop", () => {
+    expect(parkSignature(parked())).toBe(parkSignature(parked({ ref: "afk/3335-other", next: "something else" })));
+  });
+
+  it("round-trips the park stamp and the loop note through the issue body", () => {
+    const blocker = parked({ loopNote: "re-park loop detected — identical blocker 10m ago." });
+    const { body, valid } = applyCurrentBlockerEdit("## Current blocker\n\nNone\n", blocker);
+    expect(valid).toBe(true);
+    const reparsed = parseCurrentBlocker(body);
+    expect(reparsed?.parkedAtEpoch).toBe(1_000_000);
+    expect(reparsed?.loopNote).toMatch(/re-park loop detected/);
+  });
+
+  it("treats a malformed stamp as NO stamp rather than as epoch zero", () => {
+    const reparsed = parseCurrentBlocker(
+      "<!-- red:blocker-state v1 -->\nstatus: blocked\nkind: infra\nsummary: s\nnext: n\nparked_at: nonsense\n<!-- /red:blocker-state -->",
+    );
+    expect(reparsed?.parkedAtEpoch).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3377. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3377

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788541416&installation_model_id=20659&pr_number=3394&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3394&signature=7a90ce49cd1f71af7c6367ffc3899b58944567497c3279ab9c0c6b957b77b70d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->