### PR TITLE
chore: changeset for the push/re-park chain fixes

### DIFF
--- a/.changeset/push-repark-chain-fixes.md
+++ b/.changeset/push-repark-chain-fixes.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Fix the AFK engine's push/re-park chain: an attempt-branch push rejected non-fast-forward now reconciles with --force-with-lease under claim ownership instead of parking; the push-failed blocker names the real cause (divergence vs access); requeue guidance can no longer evaporate on the adopt fast-path; and an identical-signature re-park within a short window escalates as a detected loop instead of rebirthing workers forever.


### PR DESCRIPTION
Patch changeset for the #3377 /go delivery (PR #3394): force-with-lease reconciliation under claim, honest push-failed diagnosis, requeue guidance preserved on the adopt path, re-park loop detection. Ensures the fixes ship in the next version instead of stranding unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788541631&installation_model_id=20659&pr_number=3395&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3395&signature=eaf485457430e3c3b087c3ee8c022056e6d8a8d8c532989e0d3527edd061c785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->