### PR TITLE
chore: #3352 Mechanical regeneration cure: operator-declared generated surfaces heal stale-base drift with zero agent iterations

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -15,6 +15,14 @@ plugins:
       # Declared as the ADR 0135 Validation-moment schedule; the legacy
       # feedback.commands/backpressure knobs are RETIRED at 3.6.0.
       validation:
+        generated:
+          paths:
+            - plugins/*/package.json
+            - plugins/*/.claude-plugin/plugin.json
+            - plugins/*/.codex-plugin/plugin.json
+            - plugins/*/.gemini-plugin/plugin.json
+            - packaging/pi/**
+          command: pnpm version:sync && pnpm generate-manifests && pnpm pi:packages:build
         post_done:
           - pnpm -C apps/dev exec tsc --noEmit
       # Maintainer decision 2026-08-03: codex is this repo's executor.

--- a/apps/dev/src/commands/run/ports/mechanical-regeneration.ts
+++ b/apps/dev/src/commands/run/ports/mechanical-regeneration.ts
@@ -1,0 +1,85 @@
+import { join } from "node:path";
+
+import {
+  healGeneratedDrift,
+  type MechanicalRegenerator,
+} from "../../../core/generated-surfaces.js";
+import { execTool, type ExecFn, type ExecOutput } from "../../../runtime/exec.js";
+
+function evidence(result: ExecOutput): string {
+  return (result.stderr || result.stdout).trim() || `exit ${result.code}`;
+}
+
+function statusPaths(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => line.slice(3))
+    .map((path) => path.includes(" -> ") ? path.slice(path.lastIndexOf(" -> ") + 4) : path)
+    .filter(Boolean);
+}
+
+/** Bind the pure mechanical sequence to the active Worker's real worktree. */
+export function makeMechanicalRegenerator(
+  attemptDir: () => string,
+  exec?: ExecFn,
+): MechanicalRegenerator {
+  const run = exec ?? execTool;
+  return async (input) => {
+    const worktree = join(attemptDir(), "worktree");
+    return healGeneratedDrift({
+      mergeBase: async () => {
+        const clean = await run("git", ["status", "--porcelain"], { cwd: worktree });
+        if (clean.code !== 0) return { ok: false, evidence: evidence(clean) };
+        if (clean.stdout.trim() !== "") return { ok: false, evidence: "worker worktree is dirty before base merge" };
+        const merged = await run(
+          "git",
+          ["merge", "--no-edit", "--no-verify", input.baseRef],
+          { cwd: worktree },
+        );
+        return merged.code === 0 ? { ok: true } : { ok: false, evidence: evidence(merged) };
+      },
+      runCommand: async (command) => {
+        const generated = await run("bash", ["-lc", command], { cwd: worktree });
+        return generated.code === 0 ? { ok: true } : { ok: false, evidence: evidence(generated) };
+      },
+      changedFiles: async () => {
+        const status = await run("git", ["status", "--porcelain", "--untracked-files=all"], { cwd: worktree });
+        if (status.code !== 0) throw new Error(`generated-surface status failed: ${evidence(status)}`);
+        return statusPaths(status.stdout);
+      },
+      commitAndPublish: async (paths) => {
+        if (paths.length > 0) {
+          const added = await run("git", ["add", "--", ...paths], { cwd: worktree });
+          if (added.code !== 0) return { ok: false, evidence: evidence(added) };
+          const committed = await run(
+            "git",
+            [
+              "commit",
+              "--no-verify",
+              "-m",
+              "chore(afk): regenerate generated surfaces",
+              "-m",
+              `Refs #${input.issue}`,
+            ],
+            { cwd: worktree },
+          );
+          if (committed.code !== 0) return { ok: false, evidence: evidence(committed) };
+        }
+        const pushed = await run(
+          "git",
+          ["push", input.remote, `HEAD:refs/heads/${input.branch}`],
+          { cwd: worktree },
+        );
+        return pushed.code === 0 ? { ok: true } : { ok: false, evidence: evidence(pushed) };
+      },
+    }, {
+      paths: [...input.paths],
+      command: input.command,
+    }).catch((error: unknown) => ({
+      ok: false,
+      evidence: error instanceof Error ? error.message : String(error),
+    }));
+  };
+}

--- a/apps/dev/src/commands/run/process-deps.ts
+++ b/apps/dev/src/commands/run/process-deps.ts
@@ -77,6 +77,7 @@ import { buildFsPort } from "./ports/fs.js";
 import { buildHooks } from "./ports/hooks.js";
 import { buildEnvelopePort } from "./ports/envelope.js";
 import { buildLookups } from "./ports/lookups.js";
+import { makeMechanicalRegenerator } from "./ports/mechanical-regeneration.js";
 import { realDirectoryProbe } from "../../core/validation-command.js";
 import {
   castleWorktreeUnder,
@@ -324,6 +325,7 @@ export function buildProcessDeps({
     requireBranchReversionSafety: true,
     validationResourceBudget: readValidationResourceBudget(config),
     validationMoments,
+    mechanicalRegenerate: makeMechanicalRegenerator(() => current.attemptDir, exec),
     // The gate's proof that a declared validation worktree is really there
     // (#3041): a landing worktree that vanished refuses as an infrastructure
     // error instead of composing commands against a path that resolves nowhere.

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -990,13 +990,30 @@ export const VALIDATION_MOMENTS = ["iteration", "post_done", "landing"] as const
 export type ValidationMoment = (typeof VALIDATION_MOMENTS)[number];
 export const SUBSECOND_BRANCH_FAULT_KEY = "subsecond_failures_are_branch_fault" as const;
 
+export interface GeneratedSurfaceDeclaration {
+  readonly paths: readonly string[];
+  readonly command: string;
+}
+
+export const GeneratedSurfaceDeclarationSchema = z.object({
+  paths: z.array(z.string().min(1)).min(1),
+  command: z.string().min(1),
+});
+
 export const ValidationMomentsSchema = z.object({
   iteration: z.array(z.string()).optional(),
   post_done: z.array(z.string()).optional(),
   landing: z.array(z.string()).optional(),
   subsecondFailuresAreBranchFault: z.boolean().optional(),
+  generated: GeneratedSurfaceDeclarationSchema.optional(),
 });
-export type ValidationMoments = z.infer<typeof ValidationMomentsSchema>;
+export interface ValidationMoments {
+  iteration?: string[];
+  post_done?: string[];
+  landing?: string[];
+  subsecondFailuresAreBranchFault?: boolean;
+  generated?: GeneratedSurfaceDeclaration;
+}
 
 function validateValidationMomentShapes(values: ConfigValues, mappingContainers: ReadonlySet<string>): void {
   for (const root of ["afk.validation", "plugins.dev.afk.validation"]) {
@@ -1020,6 +1037,39 @@ function validateValidationMomentShapes(values: ConfigValues, mappingContainers:
     ) {
       throw new MalformedConfigError(`invalid config shape: \`${declarationKey}\` must be a boolean`);
     }
+
+    const generatedRoot = `${root}.generated`;
+    const generatedKeys = Object.keys(values).filter((candidate) => candidate.startsWith(`${generatedRoot}.`));
+    const generatedDeclared = mappingContainers.has(generatedRoot) || generatedKeys.length > 0;
+    if (!generatedDeclared) continue;
+
+    const commandKey = `${generatedRoot}.command`;
+    const command = values[commandKey];
+    if (!command || command.trim() === "" || Object.keys(values).some((key) => key.startsWith(`${commandKey}.`))) {
+      throw new MalformedConfigError(`invalid config shape: \`${commandKey}\` must be a non-empty string`);
+    }
+
+    const pathsKey = `${generatedRoot}.paths`;
+    const pathKeys = Object.keys(values).filter((candidate) => candidate.startsWith(`${pathsKey}.`));
+    const paths = pathKeys
+      .filter((candidate) => /^\d+$/.test(candidate.slice(pathsKey.length + 1)))
+      .sort((a, b) => Number(a.slice(pathsKey.length + 1)) - Number(b.slice(pathsKey.length + 1)));
+    const pathsAreContiguous = paths.every((key, index) => key === `${pathsKey}.${index}`);
+    if (
+      values[pathsKey] !== undefined ||
+      paths.length === 0 ||
+      paths.length !== pathKeys.length ||
+      !pathsAreContiguous ||
+      paths.some((key) => values[key]?.trim() === "")
+    ) {
+      throw new MalformedConfigError(`invalid config shape: \`${pathsKey}\` must be a non-empty ordered list`);
+    }
+
+    const allowed = new Set([commandKey, ...paths]);
+    const unknown = generatedKeys.find((key) => !allowed.has(key));
+    if (unknown) {
+      throw new MalformedConfigError(`invalid config shape: unsupported generated-surface key \`${unknown}\``);
+    }
   }
 }
 
@@ -1037,6 +1087,19 @@ function readValidationMoment(values: ConfigValues, moment: ValidationMoment): s
   return values[prefix]?.trim() === "[]" ? [] : undefined;
 }
 
+function readGeneratedSurfaceDeclaration(values: ConfigValues): GeneratedSurfaceDeclaration | undefined {
+  const prefix = "afk.validation.generated.paths";
+  const paths: string[] = [];
+  for (let i = 0; ; i++) {
+    const path = values[`${prefix}.${i}`];
+    if (path === undefined) break;
+    paths.push(path);
+  }
+  const command = values["afk.validation.generated.command"];
+  if (paths.length === 0 || command === undefined) return undefined;
+  return GeneratedSurfaceDeclarationSchema.parse({ paths, command });
+}
+
 /** Read the operator-declared Validation moment schedule (ADR 0135). */
 export function readValidationMoments(values: ConfigValues): ValidationMoments {
   const schedule = Object.fromEntries(
@@ -1050,6 +1113,8 @@ export function readValidationMoments(values: ConfigValues): ValidationMoments {
   if (subsecondDeclaration !== undefined) {
     schedule.subsecondFailuresAreBranchFault = subsecondDeclaration === "true";
   }
+  const generated = readGeneratedSurfaceDeclaration(values);
+  if (generated) schedule.generated = generated;
 
   return ValidationMomentsSchema.parse(schedule);
 }

--- a/apps/dev/src/core/generated-surfaces.ts
+++ b/apps/dev/src/core/generated-surfaces.ts
@@ -1,0 +1,107 @@
+import type { GeneratedSurfaceDeclaration } from "./config.js";
+
+export interface MechanicalRegenerationStepResult {
+  readonly ok: boolean;
+  readonly evidence?: string;
+}
+
+export interface MechanicalRegenerationResult {
+  readonly ok: boolean;
+  readonly evidence: string;
+}
+
+export interface MechanicalRegenerationRequest {
+  readonly issue: number;
+  readonly branch: string;
+  readonly baseRef: string;
+  readonly remote: string;
+  readonly paths: readonly string[];
+  readonly command: string;
+}
+
+export type MechanicalRegenerator = (
+  input: MechanicalRegenerationRequest,
+) => Promise<MechanicalRegenerationResult>;
+
+export interface MechanicalRegenerationSteps {
+  readonly mergeBase: () => Promise<MechanicalRegenerationStepResult>;
+  readonly runCommand: (command: string) => Promise<MechanicalRegenerationStepResult>;
+  readonly changedFiles: () => Promise<readonly string[]>;
+  readonly commitAndPublish: (paths: readonly string[]) => Promise<MechanicalRegenerationStepResult>;
+}
+
+function normalisePath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function escapeRegex(character: string): string {
+  return /[\\^$.[\]{}()+|]/.test(character) ? `\\${character}` : character;
+}
+
+/** Convert the declaration's repository-relative glob vocabulary to a regex. */
+function globRegex(glob: string): RegExp {
+  const source = normalisePath(glob);
+  let pattern = "^";
+  for (let i = 0; i < source.length; i += 1) {
+    const character = source[i]!;
+    if (character === "*" && source[i + 1] === "*") {
+      i += 1;
+      if (source[i + 1] === "/") {
+        i += 1;
+        pattern += "(?:.*/)?";
+      } else {
+        pattern += ".*";
+      }
+    } else if (character === "*") {
+      pattern += "[^/]*";
+    } else if (character === "?") {
+      pattern += "[^/]";
+    } else {
+      pattern += escapeRegex(character);
+    }
+  }
+  return new RegExp(`${pattern}$`);
+}
+
+export function generatedPathMatches(path: string, globs: readonly string[]): boolean {
+  const candidate = normalisePath(path);
+  return globs.some((glob) => globRegex(glob).test(candidate));
+}
+
+/** Empty or mixed evidence never authorises a mechanical cure. */
+export function onlyGeneratedPaths(paths: readonly string[], globs: readonly string[]): boolean {
+  return paths.length > 0 && globs.length > 0 && paths.every((path) => generatedPathMatches(path, globs));
+}
+
+function failed(stage: string, result: MechanicalRegenerationStepResult): MechanicalRegenerationResult {
+  return {
+    ok: false,
+    evidence: `${stage} failed${result.evidence?.trim() ? `: ${result.evidence.trim()}` : ""}`,
+  };
+}
+
+/**
+ * The mechanical gate executor: merge the fresh base, run the one declared
+ * command verbatim, prove its output stayed inside the declaration, then commit
+ * and publish. Any failed step returns exact evidence to the agent correction.
+ */
+export async function healGeneratedDrift(
+  steps: MechanicalRegenerationSteps,
+  declaration: GeneratedSurfaceDeclaration,
+): Promise<MechanicalRegenerationResult> {
+  const merged = await steps.mergeBase();
+  if (!merged.ok) return failed("base merge", merged);
+
+  const generated = await steps.runCommand(declaration.command);
+  if (!generated.ok) return failed("generator", generated);
+
+  const changed = [...await steps.changedFiles()];
+  const undeclared = changed.filter((path) => !generatedPathMatches(path, declaration.paths));
+  if (undeclared.length > 0) {
+    return { ok: false, evidence: `generator changed undeclared paths: ${undeclared.join(", ")}` };
+  }
+
+  const published = await steps.commitAndPublish(changed);
+  if (!published.ok) return failed("commit/publish", published);
+  return { ok: true, evidence: "merge, regeneration, commit, and publish completed" };
+}

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -828,7 +828,12 @@ export async function processIssue(
     if (!probe || !baseResolution.sha) return undefined;
     try {
       const seen = await probe(baseRef, baseResolution.sha);
-      return { startSha: baseResolution.sha, gateSha: seen.head, subjects: seen.subjects };
+      return {
+        startSha: baseResolution.sha,
+        gateSha: seen.head,
+        subjects: seen.subjects,
+        files: seen.files,
+      };
     } catch {
       return undefined;
     }
@@ -1074,6 +1079,7 @@ export async function processIssue(
     signature: string,
     branchBudgetAvailable: boolean,
     driftEligible: boolean,
+    mechanicalHealFailure?: string,
   ): Promise<Verdict> => decideVerdict({
     checks,
     signature,
@@ -1081,6 +1087,8 @@ export async function processIssue(
     environment: {
       movement: driftEligible ? await observeBaseMovement() : undefined,
       subsecondFailuresAreBranchFault: deps.validationMoments?.subsecondFailuresAreBranchFault,
+      generated: deps.validationMoments?.generated,
+      mechanicalHealFailure,
     },
   });
   /** Apply the one free-round budget effect. A true result means the caller
@@ -1649,14 +1657,63 @@ export async function processIssue(
         budget: reseedBudget,
         spend: reseedSpend,
       });
-      const verdict = await decideGateVerdict(
+      const branchBudgetAvailable = escalationDecision.escalate || reseedDraw(reseedBudget, "gate", reseedSpend).allowed;
+      let verdict = await decideGateVerdict(
         feedback.checks,
         roundKey,
-        escalationDecision.escalate || reseedDraw(reseedBudget, "gate", reseedSpend).allowed,
-        !usesDeclaredValidationMoments,
+        branchBudgetAvailable,
+        true,
       );
+      let correctionValidationText = validationText;
+      if (verdict.remediation?.kind === "mechanical-regeneration-skipped") {
+        deps.appendIterLog(
+          `🤖 ${reseedLane}: mechanical regeneration skipped: undeclared; ${verdict.reason}.`,
+        );
+      } else if (verdict.remediation?.kind === "mechanical-regeneration") {
+        if (verdict.budgetEffect.kind === "consume-environment") {
+          environmentLedger = verdict.budgetEffect.ledger;
+        }
+        const declaration = verdict.remediation.declaration;
+        const healed = deps.mechanicalRegenerate
+          ? await deps.mechanicalRegenerate({
+              issue,
+              branch: workerBranch,
+              baseRef,
+              remote: input.remote,
+              paths: declaration.paths,
+              command: declaration.command,
+            })
+          : { ok: false, evidence: "mechanical regeneration executor is unavailable" };
+        if (healed.ok) {
+          gateRevalidationSkip = true;
+          const note =
+            `🤖 ${reseedLane}: mechanical regeneration cure completed; ${verdict.reason}; ` +
+            `re-validating with zero agent iterations. ${describeEnvironmentLedger(environmentLedger)}.`;
+          deps.appendIterLog(note);
+          deps.recordWorkerEvent?.("worker.mechanical_regeneration_cure", {
+            trigger: "gate-stage",
+            cause: "stale-base-drift",
+            lane: reseedBudget.lane,
+            free: true,
+            cycle: environmentLedger.rounds.length,
+            cap: environmentLedger.cap,
+          });
+          continue;
+        }
+        deps.appendIterLog(`🤖 ${reseedLane}: mechanical regeneration failed: ${healed.evidence}`);
+        verdict = await decideGateVerdict(
+          feedback.checks,
+          roundKey,
+          branchBudgetAvailable,
+          true,
+          healed.evidence,
+        );
+      }
+      if (verdict.remediation?.kind === "agent-correction") {
+        correctionValidationText = `${validationText}\nVerdict: ${verdict.reason}.`;
+      }
       if (grantEnvironmentRound("feedback", verdict)) continue;
-      if (verdict.fault.kind !== "branch") {
+      if (verdict.fault.kind !== "branch" && verdict.remediation?.kind !== "agent-correction") {
         const cause = verdict.fault.cause;
         deps.recordWorkerEvent?.("worker.gate_revalidation_refused", {
           trigger: "gate-stage",
@@ -1677,7 +1734,7 @@ export async function processIssue(
       if (escalationDecision.escalate) {
         const escalation = await requestReseed({
           trigger: "tier-escalation",
-          validation: validationText,
+          validation: correctionValidationText,
           sidecar: feedback.sidecar,
           signature: roundKey,
           tiers: { from: escalationDecision.from, to: escalationDecision.to },
@@ -1691,7 +1748,7 @@ export async function processIssue(
         }
       }
       if (!verdict.parkNow && verdict.budgetEffect.kind === "charge-branch" && (
-        await reseedAfterGate("gate-stage", "feedback", validationText, feedback.sidecar)
+        await reseedAfterGate("gate-stage", "feedback", correctionValidationText, feedback.sidecar)
       )) {
         continue;
       }
@@ -1699,10 +1756,10 @@ export async function processIssue(
         ? "Salvaged a no-sentinel branch (it carried work), but feedback validation failed — the branch was not merged."
         : "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.";
       notes += ` ${verdict.reason}.${correctionBudgetNote()}`;
-      await parkReseedTrail(validationText);
+      await parkReseedTrail(correctionValidationText);
       return await terminalFailure(common, "feedback-failed", "feedback", {
         notes,
-        validation: validationText,
+        validation: correctionValidationText,
       }, { validationSummary: feedback.sidecar.join("\n") });
     }
     const backpressureCommands = usesDeclaredValidationMoments ? [] : (deps.backpressureCommands ?? []);

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -108,6 +108,7 @@ import type { AttemptStatus } from "../envelope.js";
 import type { Runner } from "../../types/runner.js";
 import { runnerSupportsStructuredOutput, toAgentRunner } from "../runner-spec.js";
 import type { HistoryClock } from "../history.js";
+import type { MechanicalRegenerator } from "../generated-surfaces.js";
 import { DEFAULT_GO_VERIFY_RETRIES, LABEL_GO_LANE } from "../go.js";
 import { setActiveClaimFinalizer } from "../process-safety.js";
 import type {
@@ -229,7 +230,11 @@ export interface ProcessLookups {
    * instead of charging it to the correction budget. Optional: absent, every
    * gate failure stays `branch-fault`, exactly as before.
    */
-  baseMovement?(baseRef: string, sinceSha: string): Promise<{ head: string; subjects: string[] }>;
+  baseMovement?(baseRef: string, sinceSha: string): Promise<{
+    head: string;
+    subjects: string[];
+    files?: string[];
+  }>;
   branchPresent?(branch: string): Promise<boolean>;
   branchMerged?(branch: string, base: string): Promise<boolean>;
   /** Discover all remote afk/* branches (issue #2397). Used to detect a prior
@@ -310,6 +315,8 @@ export interface ProcessIssueDeps {
   validationResourceBudget?: { nodeMaxOldSpaceMb?: number; vitestMaxWorkers?: number };
   /** Resolved declaration schedule; lifecycle consumption lands in the dependent slice. */
   validationMoments?: ValidationMoments;
+  /** Mechanical stale-base cure selected by Verdict for generated-only drift. */
+  mechanicalRegenerate?: MechanicalRegenerator;
   /**
    * Directory probe the gate uses to PROVE a declared validation worktree
    * exists (#3041). Wired to the real filesystem in production; absent in a

--- a/apps/dev/src/core/stale-base-drift.ts
+++ b/apps/dev/src/core/stale-base-drift.ts
@@ -10,6 +10,8 @@ export interface BaseMovement {
   readonly gateSha: string;
   /** Subjects of commits gained in between, oldest to newest. */
   readonly subjects: readonly string[];
+  /** Repository-relative paths changed by the gained base commits. */
+  readonly files?: readonly string[];
 }
 
 /** Missing or incomplete evidence never invents movement. */

--- a/apps/dev/src/core/verdict.ts
+++ b/apps/dev/src/core/verdict.ts
@@ -7,6 +7,8 @@
 // affect, and whether the branch must park now.
 
 import type { ClassifiableCheck } from "./feedback.js";
+import type { GeneratedSurfaceDeclaration } from "./config.js";
+import { onlyGeneratedPaths } from "./generated-surfaces.js";
 import { VALIDATION_TARGET_MISSING_MARKER } from "./validation-command.js";
 import { baseMoved, type BaseMovement } from "./stale-base-drift.js";
 
@@ -63,11 +65,21 @@ export type VerdictParkReason =
   | "environment-exhausted"
   | "branch-exhausted";
 
+export type VerdictRemediation =
+  | { readonly kind: "mechanical-regeneration"; readonly declaration: GeneratedSurfaceDeclaration }
+  | { readonly kind: "mechanical-regeneration-skipped"; readonly reason: "undeclared" }
+  | {
+      readonly kind: "agent-correction";
+      readonly reason: "mixed-drift" | "mechanical-regeneration-failed";
+      readonly evidence?: string;
+    };
+
 export interface Verdict {
   readonly fault: VerdictFault;
   readonly budgetEffect: VerdictBudgetEffect;
   readonly parkNow: boolean;
   readonly parkReason?: VerdictParkReason;
+  readonly remediation?: VerdictRemediation;
   readonly reason: string;
 }
 
@@ -83,6 +95,8 @@ export interface VerdictInput {
     readonly movement?: BaseMovement;
     /** Explicit repository declaration beside the Validation moments. */
     readonly subsecondFailuresAreBranchFault?: boolean;
+    readonly generated?: GeneratedSurfaceDeclaration;
+    readonly mechanicalHealFailure?: string;
   };
 }
 
@@ -146,12 +160,53 @@ function environmentCauseOf(fault: VerdictFault): EnvironmentCause | undefined {
   return fault.kind === "branch" ? undefined : fault.cause;
 }
 
+function remediationFor(input: VerdictInput, fault: VerdictFault): VerdictRemediation | undefined {
+  if (fault.kind !== "base") return undefined;
+  if (input.environment.mechanicalHealFailure !== undefined) {
+    return {
+      kind: "agent-correction",
+      reason: "mechanical-regeneration-failed",
+      evidence: input.environment.mechanicalHealFailure,
+    };
+  }
+  const declaration = input.environment.generated;
+  if (!declaration) return { kind: "mechanical-regeneration-skipped", reason: "undeclared" };
+  if (onlyGeneratedPaths(input.environment.movement?.files ?? [], declaration.paths)) {
+    return { kind: "mechanical-regeneration", declaration };
+  }
+  return { kind: "agent-correction", reason: "mixed-drift" };
+}
+
 /**
  * Decide one failed round. Environment attribution is sticky: exhaustion can
  * only park that environment fault, never transmute it into branch blame.
  */
 export function decideVerdict(input: VerdictInput): Verdict {
   const fault = faultFor(input);
+  const remediation = remediationFor(input, fault);
+  if (remediation?.kind === "agent-correction") {
+    if (!input.history.branchBudgetAvailable) {
+      return {
+        fault,
+        remediation,
+        budgetEffect: { kind: "none" },
+        parkNow: true,
+        parkReason: "branch-exhausted",
+        reason: remediation.reason === "mixed-drift"
+          ? "mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted"
+          : `mechanical regeneration failed and requires an agent correction, but the branch repair budget is exhausted: ${remediation.evidence ?? "no evidence"}`,
+      };
+    }
+    return {
+      fault,
+      remediation,
+      budgetEffect: { kind: "charge-branch" },
+      parkNow: false,
+      reason: remediation.reason === "mixed-drift"
+        ? "mixed stale-base drift requires one agent correction"
+        : `mechanical regeneration failed; falling through to agent correction with evidence: ${remediation.evidence ?? "no evidence"}`,
+    };
+  }
   const cause = environmentCauseOf(fault);
   if (cause === undefined) {
     if (!input.history.branchBudgetAvailable) {
@@ -185,6 +240,7 @@ export function decideVerdict(input: VerdictInput): Verdict {
   if (signature !== "" && previous?.signature === signature) {
     return {
       fault,
+      ...(remediation ? { remediation } : {}),
       budgetEffect: { kind: "none" },
       parkNow: true,
       parkReason: "repeated-signature",
@@ -194,6 +250,7 @@ export function decideVerdict(input: VerdictInput): Verdict {
   if (ledger.rounds.length >= ledger.cap) {
     return {
       fault,
+      ...(remediation ? { remediation } : {}),
       budgetEffect: { kind: "none" },
       parkNow: true,
       parkReason: "environment-exhausted",
@@ -207,6 +264,7 @@ export function decideVerdict(input: VerdictInput): Verdict {
   };
   return {
     fault,
+    ...(remediation ? { remediation } : {}),
     budgetEffect: { kind: "consume-environment", ledger: nextLedger },
     parkNow: false,
     reason: `${narration} consumed environment round ${nextLedger.rounds.length}/${nextLedger.cap}`,

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -651,9 +651,9 @@ export async function baseMovementSince(
   ctx: GitContext,
   baseRef: string,
   sinceSha: string,
-): Promise<{ head: string; subjects: string[] }> {
+): Promise<{ head: string; subjects: string[]; files: string[] }> {
   const head = (baseRef ? await revParse(ctx, baseRef) : undefined) ?? "";
-  if (!head || !sinceSha || head === sinceSha) return { head, subjects: [] };
+  if (!head || !sinceSha || head === sinceSha) return { head, subjects: [], files: [] };
   const r = await runGit(ctx, [
     "log",
     "--reverse",
@@ -661,8 +661,12 @@ export async function baseMovementSince(
     `--max-count=${BASE_MOVEMENT_SUBJECT_LIMIT}`,
     `${sinceSha}..${head}`,
   ]);
-  if (r.code !== 0) return { head, subjects: [] };
-  return { head, subjects: r.stdout.split("\n").map((l) => l.trim()).filter(Boolean) };
+  const diff = await runGit(ctx, ["diff", "--name-only", `${sinceSha}..${head}`, "--"]);
+  return {
+    head,
+    subjects: r.code === 0 ? r.stdout.split("\n").map((l) => l.trim()).filter(Boolean) : [],
+    files: diff.code === 0 ? diff.stdout.split("\n").map((l) => l.trim()).filter(Boolean) : [],
+  };
 }
 
 /** Diffstat summary line of <branch> vs <base>. */

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -822,6 +822,43 @@ describe("config — block sequences (#430)", () => {
 });
 
 describe("config — validation moments (ADR 0135, #3284)", () => {
+  it("reads the generated-surface cure beside the Validation moments", () => {
+    const values = loadConfig("/x/.red/config.yaml", {
+      read: () => [
+        "plugins:",
+        "  dev:",
+        "    enabled: true",
+        "    afk:",
+        "      validation:",
+        "        generated:",
+        "          paths:",
+        "            - packaging/pi/**",
+        "            - plugins/*/package.json",
+        "          command: pnpm version:sync && pnpm pi:packages:build",
+        "        post_done:",
+        "          - pnpm test",
+        "",
+      ].join("\n"),
+    });
+
+    expect(readValidationMoments(values)).toEqual({
+      generated: {
+        paths: ["packaging/pi/**", "plugins/*/package.json"],
+        command: "pnpm version:sync && pnpm pi:packages:build",
+      },
+      post_done: ["pnpm test"],
+    });
+  });
+
+  it("rejects incomplete generated-surface declarations", () => {
+    expect(() => parseConfigYaml(
+      "plugins:\n  dev:\n    afk:\n      validation:\n        generated:\n          paths:\n            - packaging/pi/**\n",
+    )).toThrow(/afk\.validation\.generated\.command.*non-empty string/);
+    expect(() => parseConfigYaml(
+      "plugins:\n  dev:\n    afk:\n      validation:\n        generated:\n          command: pnpm version:sync\n",
+    )).toThrow(/afk\.validation\.generated\.paths.*non-empty ordered list/);
+  });
+
   it("reads the declared sub-second branch-fault escape beside the moments", () => {
     const values = loadConfig("/x/.red/config.yaml", {
       read: () => [

--- a/apps/dev/tests/generated-surfaces.test.ts
+++ b/apps/dev/tests/generated-surfaces.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  healGeneratedDrift,
+  onlyGeneratedPaths,
+  type MechanicalRegenerationSteps,
+} from "../src/core/generated-surfaces.js";
+
+describe("generated-surface mechanical cure", () => {
+  it("matches repository-relative * and ** globs without admitting mixed drift", () => {
+    expect(onlyGeneratedPaths(
+      ["packaging/pi/dev/package.json", "plugins/dev/package.json"],
+      ["packaging/pi/**", "plugins/*/package.json"],
+    )).toBe(true);
+    expect(onlyGeneratedPaths(
+      ["packaging/pi/dev/package.json", "apps/dev/src/core/verdict.ts"],
+      ["packaging/pi/**"],
+    )).toBe(false);
+    expect(onlyGeneratedPaths([], ["packaging/pi/**"])).toBe(false);
+  });
+
+  it("executes merge → command → generated-only commit/publish", async () => {
+    const calls: string[] = [];
+    const steps: MechanicalRegenerationSteps = {
+      mergeBase: async () => { calls.push("merge"); return { ok: true }; },
+      runCommand: async (command) => { calls.push(`run:${command}`); return { ok: true }; },
+      changedFiles: async () => ["packaging/pi/dev/package.json"],
+      commitAndPublish: async (paths) => { calls.push(`commit:${paths.join(",")}`); return { ok: true }; },
+    };
+
+    await expect(healGeneratedDrift(steps, {
+      paths: ["packaging/pi/**"],
+      command: "pnpm pi:packages:build",
+    })).resolves.toEqual({ ok: true, evidence: "merge, regeneration, commit, and publish completed" });
+    expect(calls).toEqual([
+      "merge",
+      "run:pnpm pi:packages:build",
+      "commit:packaging/pi/dev/package.json",
+    ]);
+  });
+
+  it("refuses generator output outside the declaration and preserves stage evidence", async () => {
+    const steps: MechanicalRegenerationSteps = {
+      mergeBase: async () => ({ ok: true }),
+      runCommand: async () => ({ ok: true }),
+      changedFiles: async () => ["packaging/pi/dev/package.json", "src/intent.ts"],
+      commitAndPublish: async () => ({ ok: true }),
+    };
+
+    await expect(healGeneratedDrift(steps, {
+      paths: ["packaging/pi/**"],
+      command: "pnpm pi:packages:build",
+    })).resolves.toEqual({
+      ok: false,
+      evidence: "generator changed undeclared paths: src/intent.ts",
+    });
+  });
+});

--- a/apps/dev/tests/process-issue.test-helpers.ts
+++ b/apps/dev/tests/process-issue.test-helpers.ts
@@ -93,6 +93,14 @@ export interface Trace {
   /** Every `lookups.worktreeDiff` read the review stage made (#2730). */
   worktreeDiffCalls: Array<{ branch: string; base: string }>;
   baseMovementCalls: Array<{ baseRef: string; sinceSha: string }>;
+  mechanicalRegenerations: Array<{
+    issue: number;
+    branch: string;
+    baseRef: string;
+    remote: string;
+    paths: readonly string[];
+    command: string;
+  }>;
   /** Raw pnpm argv vectors emitted by the feedback/backpressure fakes. */
   pnpmArgs: string[][];
   /** Operator-declared shell commands emitted by feedback/backpressure stages. */
@@ -211,7 +219,7 @@ export interface HarnessOptions {
    * Absent → no probe at all, and every gate failure stays branch-fault exactly
    * as it did before the drift accounting existed.
    */
-  baseMovements?: Array<{ head: string; subjects: string[] }>;
+  baseMovements?: Array<{ head: string; subjects: string[]; files?: string[] }>;
   changedFilesByBase?: Record<string, string[]>;
   packageScopes?: string[];
   /** FIX E: result of the worker-branch presence check. Defaults to true
@@ -353,6 +361,7 @@ export function harness(opts: HarnessOptions = {}): {
     cascadeRebaseAttempts: [],
     changedFileCalls: [],
     baseMovementCalls: [],
+    mechanicalRegenerations: [],
     pnpmArgs: [],
     shellCommands: [],
     handoffs: [],
@@ -845,7 +854,7 @@ export function harness(opts: HarnessOptions = {}): {
               trace.baseMovementCalls.push({ baseRef, sinceSha });
               const seq = opts.baseMovements!;
               const idx = trace.baseMovementCalls.length - 1;
-              return seq[idx] ?? seq.at(-1) ?? { head: sinceSha, subjects: [] };
+              return seq[idx] ?? seq.at(-1) ?? { head: sinceSha, subjects: [], files: [] };
             },
           }
         : {}),

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -1807,6 +1807,123 @@ describe("processIssue — stale-base drift never spends the correction budget (
   });
 });
 
+describe("processIssue — generated stale-base drift heals mechanically (#3352)", () => {
+  const generated = {
+    paths: ["packaging/pi/**"],
+    command: "pnpm version:sync && pnpm pi:packages:build",
+  } as const;
+
+  function declareGeneratedGate(deps: ProcessIssueDeps, results: readonly boolean[]): void {
+    deps.validationMoments = { post_done: ["pnpm generated:check"], generated };
+    let call = 0;
+    deps.backpressure = async () => {
+      const ok = results[call] ?? results.at(-1) ?? true;
+      call += 1;
+      return { code: ok ? 0 : 1, stdout: ok ? "" : "generated mirror stale", stderr: "" };
+    };
+  }
+
+  it("merges, regenerates, commits, and re-validates with zero agent iterations", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      reseedGateBudget: 1,
+      baseMovements: [{
+        head: "bumped",
+        subjects: ["chore(release): version packages"],
+        files: ["packaging/pi/dev/package.json"],
+      }],
+    });
+    declareGeneratedGate(deps, [false, true]);
+    deps.mechanicalRegenerate = async (request) => {
+      trace.mechanicalRegenerations.push(request);
+      return { ok: true, evidence: "merged base; generator passed; committed and pushed" };
+    };
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.mechanicalRegenerations).toEqual([expect.objectContaining({
+      branch: "afk/9-fix-the-thing",
+      command: generated.command,
+      paths: generated.paths,
+    })]);
+    expect(trace.workerEvents).toContainEqual(expect.objectContaining({
+      kind: "worker.mechanical_regeneration_cure",
+      payload: expect.objectContaining({ free: true, cycle: 1 }),
+    }));
+  });
+
+  it("routes mixed drift to an agent correction without invoking the generator", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      reseedGateBudget: 1,
+      baseMovements: [{
+        head: "mixed",
+        subjects: ["fix: base changed code and mirrors"],
+        files: ["packaging/pi/dev/package.json", "apps/dev/src/core/verdict.ts"],
+      }],
+    });
+    declareGeneratedGate(deps, [false, true]);
+    deps.mechanicalRegenerate = async (request) => {
+      trace.mechanicalRegenerations.push(request);
+      return { ok: true, evidence: "should not run" };
+    };
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.mechanicalRegenerations).toEqual([]);
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("mixed stale-base drift");
+  });
+
+  it("skips the undeclared cure loudly", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      reseedGateBudget: 1,
+      baseMovements: [{
+        head: "bumped",
+        subjects: ["chore(release): version packages"],
+        files: ["packaging/pi/dev/package.json"],
+      }],
+    });
+    deps.validationMoments = { post_done: ["pnpm generated:check"] };
+    let call = 0;
+    deps.backpressure = async () => ({ code: call++ === 0 ? 1 : 0, stdout: "", stderr: "" });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.iterLogs.some((line) => line.includes("mechanical regeneration skipped: undeclared"))).toBe(true);
+    expect(trace.mechanicalRegenerations).toEqual([]);
+  });
+
+  it("falls through to agent correction with failed-heal evidence", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      reseedGateBudget: 1,
+      baseMovements: [{
+        head: "bumped",
+        subjects: ["chore(release): version packages"],
+        files: ["packaging/pi/dev/package.json"],
+      }],
+    });
+    declareGeneratedGate(deps, [false, true]);
+    deps.mechanicalRegenerate = async (request) => {
+      trace.mechanicalRegenerations.push(request);
+      return { ok: false, evidence: "generator exited 1: mirror source missing" };
+    };
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("generator exited 1: mirror source missing");
+    expect(trace.iterLogs.some((line) => line.includes("mechanical regeneration failed"))).toBe(true);
+  });
+});
+
 describe("processIssue — an empty-diff DONE is never stale-base drift (#2711)", () => {
   it("charges the empty-diff rejection to the branch even while the base is moving", async () => {
     const { deps, input, trace } = harness({

--- a/apps/dev/tests/verdict.test.ts
+++ b/apps/dev/tests/verdict.test.ts
@@ -101,6 +101,57 @@ describe("decideVerdict — one fault, budget effect, and park decision", () => 
     });
   });
 
+  it("owns the generated-drift cure truth table", () => {
+    const movement = {
+      startSha: "before",
+      gateSha: "after",
+      subjects: ["chore(release): version packages"],
+      files: ["packaging/pi/dev/package.json"],
+    } as const;
+    const generated = {
+      paths: ["packaging/pi/**"],
+      command: "pnpm version:sync && pnpm pi:packages:build",
+    } as const;
+    const input = {
+      checks: [failedCheck()],
+      signature: SIGNATURE,
+      history: { environment: emptyEnvironmentLedger(2), branchBudgetAvailable: true },
+      environment: { movement, generated },
+    } as const;
+
+    expect(decideVerdict(input)).toMatchObject({
+      fault: { kind: "base", cause: "stale-base-drift" },
+      budgetEffect: { kind: "consume-environment" },
+      remediation: { kind: "mechanical-regeneration", declaration: generated },
+      parkNow: false,
+    });
+    expect(decideVerdict({
+      ...input,
+      environment: {
+        movement: { ...movement, files: [...movement.files, "apps/dev/src/core/verdict.ts"] },
+        generated,
+      },
+    })).toMatchObject({
+      budgetEffect: { kind: "charge-branch" },
+      remediation: { kind: "agent-correction", reason: "mixed-drift" },
+      parkNow: false,
+    });
+    expect(decideVerdict({ ...input, environment: { movement } })).toMatchObject({
+      remediation: { kind: "mechanical-regeneration-skipped", reason: "undeclared" },
+    });
+    expect(decideVerdict({
+      ...input,
+      environment: { movement, generated, mechanicalHealFailure: "generator exited 1" },
+    })).toMatchObject({
+      budgetEffect: { kind: "charge-branch" },
+      remediation: {
+        kind: "agent-correction",
+        reason: "mechanical-regeneration-failed",
+        evidence: "generator exited 1",
+      },
+    });
+  });
+
   it("keeps every environment cause off the branch budget, including exhaustion", () => {
     const cases: ReadonlyArray<{ cause: EnvironmentCause; checks: ClassifiableCheck[]; movement?: {
       startSha: string;


### PR DESCRIPTION
Automated AFK landing for #3352. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3352

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788556126&installation_model_id=20659&pr_number=3404&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3404&signature=4c72eceef14f3fd7c2fc7da3be9fd8df69e6790953f05e35570f98652b1965a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->