### PR TITLE
chore: #3353 Base-movement stamps: the daemon stamps 'base +N' per live Worker and every surface renders it

### DIFF
--- a/apps/dev/src/commands/run/ports/lookups.ts
+++ b/apps/dev/src/commands/run/ports/lookups.ts
@@ -14,6 +14,7 @@ import { branchLockPath, readLockedBranch, isLocked } from "../../../runtime/loc
 import { parseTrustPolicy, resolveActorTrust } from "../../../core/trust-gate.js";
 import { buildHandoffEnrichment } from "../../../core/handoff-enrichment.js";
 import { lookupPrevFailureContext } from "../../../core/prev-failure.js";
+import { createRedskilledBirthPort } from "../../../runtime/redskilled-birth.js";
 
 export interface LookupsPortContext {
   ghCtx: GhContext;
@@ -39,6 +40,7 @@ export function buildLookups({
   const lockPath = branchLockPath(root);
   // Trust policy for the guidance-channel source-trust projection (issue #1100).
   const trustPolicy = parseTrustPolicy(config);
+  const host = createRedskilledBirthPort({ root });
 
   return {
     base: {
@@ -97,6 +99,20 @@ export function buildLookups({
       const branch = baseRef.startsWith("origin/") ? baseRef.slice("origin/".length) : baseRef;
       await gitx.fetchBranch(gitCtx, branch).catch(() => {});
       return gitx.baseMovementSince(gitCtx, baseRef, sinceSha);
+    },
+    workerBaseMovement: async (workerId) => {
+      const worker = (await host.hostState()).workers.find((candidate) => candidate.worker_id === workerId);
+      if (
+        worker?.fork_sha == null || worker.fork_sha === "" ||
+        worker.base_head_sha == null || worker.base_head_sha === "" ||
+        worker.base_commits_ahead == null
+      ) return undefined;
+      return {
+        startSha: worker.fork_sha,
+        gateSha: worker.base_head_sha,
+        commitsAhead: worker.base_commits_ahead,
+        subjects: [],
+      };
     },
     // FIX E: confirm the sandcastle worker branch actually landed on the host
     // before the merge gate. Try once, fetch on a miss, then re-check — a still

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -818,12 +818,21 @@ export async function processIssue(
         rounds: [{ cause: "prior-environment", signature: carriedValidationSignature }],
       }
     : emptyEnvironmentLedger(environmentRoundCap);
-  // Issue #2711 — the gate runs on the branch MERGED WITH the live base, so a
-  // base that moved under the attempt can redden a branch that is itself green.
-  // Ask git what the base did before charging the failure to anyone. A missing
-  // probe, an unresolved base sha, or a throwing lookup all yield `undefined`,
-  // which attributes the failure to the branch exactly as before.
-  const observeBaseMovement = async (): Promise<BaseMovement | undefined> => {
+  // The daemon's stamp is the ready environment fact (ADR 0138). The legacy git
+  // probe remains only for the one-release compatibility path: a missing or
+  // unreadable fact yields `undefined` instead of inventing movement.
+  const observeBaseMovement = async (allowLegacyProbe: boolean): Promise<BaseMovement | undefined> => {
+    const hostFact = deps.lookups.workerBaseMovement;
+    if (hostFact) {
+      try {
+        const movement = await hostFact(input.workerId);
+        if (movement != null && (!input.forkSha || movement.startSha === input.forkSha)) return movement;
+      } catch {
+        // Mixed-version or temporarily unreachable daemon: the legacy probe may
+        // still supply evidence during its one-release compatibility window.
+      }
+    }
+    if (!allowLegacyProbe) return undefined;
     const probe = deps.lookups.baseMovement;
     if (!probe || !baseResolution.sha) return undefined;
     try {
@@ -1085,7 +1094,7 @@ export async function processIssue(
     signature,
     history: { environment: environmentLedger, branchBudgetAvailable },
     environment: {
-      movement: driftEligible ? await observeBaseMovement() : undefined,
+      movement: await observeBaseMovement(driftEligible),
       subsecondFailuresAreBranchFault: deps.validationMoments?.subsecondFailuresAreBranchFault,
       generated: deps.validationMoments?.generated,
       mechanicalHealFailure,

--- a/apps/dev/src/core/process-issue/types.ts
+++ b/apps/dev/src/core/process-issue/types.ts
@@ -235,6 +235,13 @@ export interface ProcessLookups {
     subjects: string[];
     files?: string[];
   }>;
+  /** Daemon-stamped base movement for this live Worker, read without fetching. */
+  workerBaseMovement?(workerId: string): Promise<{
+    startSha: string;
+    gateSha: string;
+    commitsAhead: number;
+    subjects: readonly string[];
+  } | undefined>;
   branchPresent?(branch: string): Promise<boolean>;
   branchMerged?(branch: string, base: string): Promise<boolean>;
   /** Discover all remote afk/* branches (issue #2397). Used to detect a prior

--- a/apps/dev/src/core/stale-base-drift.ts
+++ b/apps/dev/src/core/stale-base-drift.ts
@@ -12,10 +12,13 @@ export interface BaseMovement {
   readonly subjects: readonly string[];
   /** Repository-relative paths changed by the gained base commits. */
   readonly files?: readonly string[];
+  /** Daemon-computed distance from the granted fork; absent on the legacy git probe. */
+  readonly commitsAhead?: number;
 }
 
 /** Missing or incomplete evidence never invents movement. */
 export function baseMoved(movement: BaseMovement | undefined): boolean {
   if (!movement?.startSha || !movement.gateSha) return false;
+  if (movement.commitsAhead !== undefined) return movement.commitsAhead > 0;
   return movement.startSha !== movement.gateSha;
 }

--- a/apps/dev/src/core/verdict.ts
+++ b/apps/dev/src/core/verdict.ts
@@ -235,7 +235,9 @@ export function decideVerdict(input: VerdictInput): Verdict {
     : input.signature;
   const narration = fault.kind === "base" && input.environment.movement?.subjects.length
     ? `${cause} (${input.environment.movement.subjects.join("; ")})`
-    : cause;
+    : fault.kind === "base" && input.environment.movement?.commitsAhead != null
+      ? `${cause} (base +${input.environment.movement.commitsAhead})`
+      : cause;
   const previous = ledger.rounds.at(-1);
   if (signature !== "" && previous?.signature === signature) {
     return {

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -1637,6 +1637,38 @@ describe("processIssue — stale-base drift never spends the correction budget (
    * a probe that echoes it back means the base stood still. */
   const BASE_START_SHA = "origin/main-tip";
 
+  it("passes the daemon's ready base stamp to Verdict without re-deriving it from git", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      reseedGateBudget: 0,
+    });
+    input.forkSha = "granted-fork-sha";
+    deps.validationMoments = { post_done: ["pnpm test"] };
+    let validations = 0;
+    deps.backpressure = async () => ({
+      code: validations++ === 0 ? 1 : 0,
+      stdout: "",
+      stderr: "",
+    });
+    const factCalls: string[] = [];
+    deps.lookups.workerBaseMovement = async (workerId) => {
+      factCalls.push(workerId);
+      return {
+        startSha: "granted-fork-sha",
+        gateSha: "refreshed-head-sha",
+        commitsAhead: 2,
+        subjects: [],
+      };
+    };
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(factCalls).toEqual(["wAAAA"]);
+    expect(trace.baseMovementCalls).toEqual([]);
+    expect(trace.iterLogs.some((line) => line.includes("base +2"))).toBe(true);
+  });
+
   it("charges nothing to /go's budget and reruns only the gate when the base caused the failures", async () => {
     const { deps, input, trace } = harness({
       labels: ["lane:go"],

--- a/apps/redskilled/src/daemon.ts
+++ b/apps/redskilled/src/daemon.ts
@@ -204,7 +204,9 @@ import {
   type RedskilledWorkerSpec,
 } from "./worker-launch.js";
 import {
+  countRedskilledBaseMovement,
   refreshRedskilledTrunk,
+  type RedskilledBaseMovementCounter,
   type RedskilledTrunkRefresh,
   type RedskilledTrunkRefreshInput,
 } from "./trunk-mirror.js";
@@ -410,6 +412,8 @@ export interface RedskilledDaemonOptions {
   readonly launch?: (options: LaunchWorkerOptions) => LaunchedWorker;
   /** Daemon-owned git seam; injected by concurrency and unreachable-remote fixtures. */
   readonly refreshTrunk?: RedskilledTrunkRefresh;
+  /** Daemon-owned fork-to-refreshed-head counter; injected by moved-base fixtures. */
+  readonly countBaseMovement?: RedskilledBaseMovementCounter;
   /** The append-only host event lane; defaults to this session's own. */
   readonly eventLane?: RedskilledEventLane;
   /** The durable registration snapshot; defaults to this session's own. */
@@ -696,6 +700,8 @@ export interface RedskilledDaemon {
   /** The registrations this daemon holds, ordered by project label; lapsed ones swept. */
   registrations(): readonly RedskilledProjectRegistration[];
   hostState(): RedskilledHostState;
+  /** Run the background trunk-refresh body now; exposed so timer behavior is fixture-driven. */
+  refreshRegisteredTrunks(): Promise<void>;
   /**
    * The whole machine in one document, dated by the daemon's own last sample.
    *
@@ -851,6 +857,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const clock = options.clock ?? (() => new Date().toISOString());
   const launch = options.launch ?? launchWorker;
   const refreshTrunk = options.refreshTrunk ?? refreshRedskilledTrunk;
+  const countBaseMovement = options.countBaseMovement ?? countRedskilledBaseMovement;
   const ceiling = options.ceiling ?? resolveHostCeiling();
   // Before the lease, before the socket: a host whose repositories do not all
   // answer to one token has no arrangement to start with, and discovering that a
@@ -2192,10 +2199,19 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         void resolveObservedExit(worker, code, signal).catch(() => undefined);
       },
     });
-    workers.set(launched.worker.worker_id, launched.worker);
-    record("worker-birth", launched.worker, null);
+    const forkSha = grant.forkSha ?? launched.fork_sha ?? launched.worker.fork_sha;
+    const worker = forkSha == null || forkSha === ""
+      ? launched.worker
+      : { ...launched.worker, fork_sha: forkSha };
+    const tracked: LaunchedWorker = {
+      ...launched,
+      worker,
+      ...(forkSha == null || forkSha === "" ? {} : { fork_sha: forkSha }),
+    };
+    workers.set(worker.worker_id, worker);
+    record("worker-birth", worker, null);
     armIdleTimer();
-    return launched;
+    return tracked;
   }
 
   /**
@@ -2613,10 +2629,29 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     await Promise.allSettled(
       [...registrations.values()]
         .filter((registration) => registration.trunk != null)
-        .map((registration) => refreshFork({
-          workspace_path: registration.workspace_path,
-          trunk: registration.trunk!,
-        })),
+        .map(async (registration) => {
+          const headSha = await refreshFork({
+            workspace_path: registration.workspace_path,
+            trunk: registration.trunk!,
+          });
+          const live = [...workers.values()].filter((worker) =>
+            worker.project_label === registration.project_label && worker.fork_sha != null && worker.fork_sha !== ""
+          );
+          await Promise.allSettled(live.map(async (worker) => {
+            const commitsAhead = await countBaseMovement({
+              workspace_path: registration.workspace_path,
+              fork_sha: worker.fork_sha!,
+              head_sha: headSha,
+            });
+            const current = workers.get(worker.worker_id);
+            if (current == null || current.fork_sha !== worker.fork_sha) return;
+            workers.set(worker.worker_id, {
+              ...current,
+              base_head_sha: headSha,
+              base_commits_ahead: commitsAhead,
+            });
+          }));
+        }),
     );
   }
 
@@ -3053,6 +3088,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     deregisterProject,
     registrations: () => hostState().registrations ?? [],
     hostState,
+    refreshRegisteredTrunks,
     statuslinePayload,
     evaluateIdle,
     observePublishedVersion,

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -61,6 +61,8 @@ export interface RedskilledHostEvent {
   readonly project_label: string;
   readonly pid: number;
   readonly workspace_path: string;
+  /** Granted fork point, null on legacy and non-trunk births. */
+  readonly fork_sha?: string | null;
   /** The log path the client gave at spawn, so a restart can recover a heartbeat. */
   readonly log_path: string | null;
   readonly isolated: boolean;
@@ -143,6 +145,7 @@ export function buildHostEvent(input: RecordEventInput): RedskilledHostEvent {
     project_label: input.worker.project_label,
     pid: input.worker.pid,
     workspace_path: input.worker.workspace_path,
+    fork_sha: input.worker.fork_sha ?? null,
     log_path: input.worker.log_path ?? null,
     isolated: input.worker.isolated,
     unit: input.worker.unit ?? null,
@@ -169,6 +172,7 @@ export function buildDaemonStopEvent(input: RecordDaemonStopInput): RedskilledHo
     project_label: "",
     pid: input.pid,
     workspace_path: input.socketPath,
+    fork_sha: null,
     log_path: null,
     isolated: false,
     unit: null,
@@ -192,6 +196,7 @@ export function buildDemandRefusalEvent(input: RecordDemandRefusalInput): Redski
     project_label: input.projectLabel,
     pid: 0,
     workspace_path: "",
+    fork_sha: null,
     log_path: null,
     isolated: false,
     unit: null,
@@ -394,6 +399,7 @@ export function toWorkerView(event: RedskilledHostEvent): RedskilledWorkerView {
     pid: event.pid,
     started_at: event.ts,
     workspace_path: event.workspace_path,
+    ...(event.fork_sha != null ? { fork_sha: event.fork_sha } : {}),
     ...(event.log_path != null ? { log_path: event.log_path } : {}),
     isolated: event.isolated,
     ...(event.unit != null ? { unit: event.unit } : {}),
@@ -424,6 +430,7 @@ function fromRow(record: ToonlRecord): RedskilledHostEvent {
     project_label: text(record.project_label) ?? "",
     pid: Number(record.pid ?? 0),
     workspace_path: text(record.workspace_path) ?? "",
+    fork_sha: text(record.fork_sha),
     log_path: text(record.log_path),
     isolated: record.isolated === true || record.isolated === "true",
     unit: text(record.unit),

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -58,6 +58,12 @@ export interface RedskilledWorkerView {
   readonly started_at: string;
   /** The path the client handed over, used verbatim as the Worker's workspace. */
   readonly workspace_path: string;
+  /** Exact trunk commit this Worker was granted at birth (ADR 0138). */
+  readonly fork_sha?: string;
+  /** Latest daemon-refreshed trunk head compared with {@link fork_sha}. */
+  readonly base_head_sha?: string;
+  /** Commits reachable from the refreshed head but not from {@link fork_sha}. */
+  readonly base_commits_ahead?: number;
   /**
    * Where this Worker's log is, when the client said so at spawn.
    *
@@ -508,6 +514,10 @@ export function isRedskilledWorkerView(value: unknown): value is RedskilledWorke
     Number.isInteger(worker.pid) &&
     typeof worker.started_at === "string" &&
     typeof worker.workspace_path === "string" &&
+    (worker.fork_sha === undefined || typeof worker.fork_sha === "string") &&
+    (worker.base_head_sha === undefined || typeof worker.base_head_sha === "string") &&
+    (worker.base_commits_ahead === undefined ||
+      (Number.isInteger(worker.base_commits_ahead) && Number(worker.base_commits_ahead) >= 0)) &&
     typeof worker.isolated === "boolean" &&
     Array.isArray(worker.warnings) &&
     // Checked only when present, exactly as the upgrade block is: a daemon that

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -133,6 +133,8 @@ export interface RedskilledStatuslineWorker {
   readonly workspace_path: string;
   readonly pid: number;
   readonly started_at: string;
+  /** Host-computed movement from this Worker's granted fork to refreshed trunk. */
+  readonly base_commits_ahead?: number;
   readonly uptime_ms: number | null;
   readonly state: RedskilledWorkerState;
   readonly isolated: boolean;
@@ -777,6 +779,7 @@ function buildWorker(
     workspace_path: worker.workspace_path,
     pid: worker.pid,
     started_at: worker.started_at,
+    ...(worker.base_commits_ahead == null ? {} : { base_commits_ahead: worker.base_commits_ahead }),
     uptime_ms: ctx.nowMs == null || startedMs == null ? null : Math.max(0, ctx.nowMs - startedMs),
     state: ctx.state,
     isolated: worker.isolated,

--- a/apps/redskilled/src/trunk-mirror.ts
+++ b/apps/redskilled/src/trunk-mirror.ts
@@ -11,6 +11,14 @@ export interface RedskilledTrunkRefreshInput {
 
 export type RedskilledTrunkRefresh = (input: RedskilledTrunkRefreshInput) => Promise<string>;
 
+export interface RedskilledBaseMovementInput {
+  readonly workspace_path: string;
+  readonly fork_sha: string;
+  readonly head_sha: string;
+}
+
+export type RedskilledBaseMovementCounter = (input: RedskilledBaseMovementInput) => Promise<number>;
+
 function git(cwd: string, args: readonly string[]): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile("git", [...args], { cwd }, (error, stdout, stderr) => {
@@ -30,4 +38,12 @@ export async function refreshRedskilledTrunk(input: RedskilledTrunkRefreshInput)
   if (sha === "") throw new Error("the fetched trunk did not resolve to a commit");
   await git(input.workspace_path, ["update-ref", REDSKILLED_TRUNK_MIRROR_REF, sha]);
   return sha;
+}
+
+/** Count the refreshed trunk commits a live Worker's granted fork does not contain. */
+export async function countRedskilledBaseMovement(input: RedskilledBaseMovementInput): Promise<number> {
+  const raw = await git(input.workspace_path, ["rev-list", "--count", `${input.fork_sha}..${input.head_sha}`]);
+  const count = Number(raw);
+  if (!Number.isInteger(count) || count < 0) throw new Error(`git returned an invalid base movement count: ${raw}`);
+  return count;
 }

--- a/apps/redskilled/tests/demand-loop.test.ts
+++ b/apps/redskilled/tests/demand-loop.test.ts
@@ -224,6 +224,42 @@ function registration(label: string, target: number, workspace: string) {
 }
 
 describe("the daemon drives the demand loop itself", () => {
+  it("stamps each live Worker with base movement from its granted fork SHA", async () => {
+    const workspace = await scratch("redskilled-workspace-");
+    const counts: Array<{ fork_sha: string; head_sha: string }> = [];
+    let head = "fork-sha-123";
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      demandMs: 0,
+      launch: recordingLaunch([]),
+      refreshTrunk: async () => head,
+      countBaseMovement: async ({ fork_sha, head_sha }) => {
+        counts.push({ fork_sha, head_sha });
+        return 3;
+      },
+      queueDiscovery: { intervalMs: 0, transport: async () => answer([1]) },
+    });
+    running.push(daemon);
+
+    daemon.registerProject({
+      ...registration("acme/widgets", 1, workspace),
+      trunk: { remote: "origin", branch: "main" },
+    });
+    await daemon.pollQueueDiscovery();
+    await daemon.driveDemand();
+    head = "moved-head-sha";
+    await daemon.refreshRegisteredTrunks();
+
+    expect(counts).toEqual([{ fork_sha: "fork-sha-123", head_sha: "moved-head-sha" }]);
+    expect(daemon.hostState().workers[0]).toMatchObject({
+      fork_sha: "fork-sha-123",
+      base_head_sha: "moved-head-sha",
+      base_commits_ahead: 3,
+    });
+  });
+
   it("refreshes one fork SHA for a burst and refuses an unreachable trunk before any Worker is born", async () => {
     const launched: LaunchWorkerOptions[] = [];
     const workspace = await scratch("redskilled-workspace-");

--- a/apps/redskilled/tests/statusline-dashboard.test.ts
+++ b/apps/redskilled/tests/statusline-dashboard.test.ts
@@ -191,7 +191,7 @@ const LOCAL = { ...REDSKILLED_DASHBOARD_DEFAULTS, project: "acme/widgets" };
 describe("the dashboard carries the statusline's own fields", () => {
   it("renders one row per Worker with run, org, iss, phase, elapsed, heartbeat, loc and the vitals", () => {
     const dashboard = renderRedskilledDashboard(
-      payloadOf([worker()], { "w-1": display({ model: "claude-opus-4-8" }) }),
+      payloadOf([worker({ base_commits_ahead: 2 })], { "w-1": display({ model: "claude-opus-4-8" }) }),
       LOCAL,
     );
 
@@ -202,6 +202,7 @@ describe("the dashboard carries the statusline's own fields", () => {
     expect(cells.org).toBe("org=afk");
     expect(cells.iss).toBe("iss=3012");
     expect(cells.phase).toBe("coding·impl");
+    expect(cells.base).toBe("base +2");
     expect(cells.elapsed).toBe("1h0m");
     expect(cells.hb).toBe("hb=3s");
     expect(cells.loc).toBe("loc=+142 -36");
@@ -239,6 +240,7 @@ describe("the dashboard carries the statusline's own fields", () => {
       "iss",
       "bar",
       "phase",
+      "base",
       "elapsed",
       "eta",
       "hb",

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -87,6 +87,7 @@ export const REDSKILLED_DASHBOARD_COLUMNS = [
   "iss",
   "bar",
   "phase",
+  "base",
   "elapsed",
   "eta",
   "hb",
@@ -311,6 +312,7 @@ export function workerCells(
     iss: display.issue == null ? "" : repair ? `pr=#${display.issue.replace(/^#/, "")}` : `iss=${display.issue}`,
     bar: progressBar(display),
     phase: [display.phase, display.step].filter((part): part is string => Boolean(part)).join("·"),
+    base: worker.base_commits_ahead == null ? "" : `base +${worker.base_commits_ahead}`,
     elapsed: formatDuration(workerElapsedMs(worker, generatedAt)),
     // A Worker whose project will not estimate gets NO cell — not `eta=—`, and
     // certainly not a figure this module could have extrapolated off the bar

--- a/packages/redskilled-render/panel.ts
+++ b/packages/redskilled-render/panel.ts
@@ -164,8 +164,8 @@ function workerRow(
 ): string {
   const cells = workerCells(worker, { mode }, generatedAt);
   const columns: readonly RedskilledDashboardColumn[] = isRepairWorker(worker)
-    ? ["wid", "org", "iss", "bar", "phase", "elapsed", "eta"]
-    : ["wid", "bar", "phase", "elapsed", "eta"];
+    ? ["wid", "org", "iss", "bar", "phase", "base", "elapsed", "eta"]
+    : ["wid", "bar", "phase", "base", "elapsed", "eta"];
   const parts = columns
     .filter((column) => cells[column] !== "")
     .map((column) => colourWorkerCell(column, cells[column]));

--- a/packages/redskilled-render/payload.ts
+++ b/packages/redskilled-render/payload.ts
@@ -119,6 +119,8 @@ export interface RedskilledRenderWorker {
   readonly project_label: string;
   readonly pid: number;
   readonly started_at: string;
+  /** Daemon-owned count from the Worker's granted fork to refreshed trunk. */
+  readonly base_commits_ahead?: number;
   readonly uptime_ms: number | null;
   readonly vitals: RedskilledRenderVitals;
   readonly budget: RedskilledRenderWorkerBudget;

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -44,6 +44,28 @@ import { display, payload, worker } from "./fixture.js";
 const LOCAL = { ...REDSKILLED_STATUSLINE_DEFAULTS, project: "acme/widgets" };
 
 describe("one module, three densities", () => {
+  it("renders the daemon's base-movement stamp at every Worker-row density", () => {
+    const doc = payload({
+      workers: [worker({ base_commits_ahead: 4, display: display() })],
+    });
+
+    const line = renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 240 });
+    const panel = renderRedskilledPanel(doc, {
+      ...REDSKILLED_PANEL_DEFAULTS,
+      project: "acme/widgets",
+      maxWidth: 240,
+    });
+    const dashboard = renderRedskilledDashboard(doc, {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      project: "acme/widgets",
+      maxWidth: 240,
+    });
+
+    expect(stripAnsi(line.lines[1]!)).toContain("base +4");
+    expect(stripAnsi(panel.worker_rows[0]!)).toContain("base +4");
+    expect(stripAnsi(dashboard.rows[0]!.line)).toContain("base +4");
+  });
+
   it("draws the same payload at a line, a panel and a table", () => {
     const doc = payload({ workers: [worker({ display: display() })] });
 


### PR DESCRIPTION
Automated AFK landing for #3353. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3353

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788557246&installation_model_id=20659&pr_number=3408&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3408&signature=2656f46da70cf0cc55e9ada51aa82e4bf45a9f511be3acb5d61d32a5d0beb2a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->