### PR TITLE
chore: classify version-surfaces package.json reads in the TOON allowlist (fixes red main)

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -206,6 +206,16 @@
       "id": "apps/release/src/cli.ts#json-parse-file-read#06f60309d571",
       "classification": "external",
       "reason": "npm package.json manifests are an external JSON format the release engine must read as-is"
+    },
+    {
+      "id": "apps/release/src/version-surfaces.ts#json-parse-file-read#1a7789e22743",
+      "classification": "external",
+      "reason": "npm package.json version surfaces are ecosystem JSON the release engine rewrites in place"
+    },
+    {
+      "id": "apps/release/src/version-surfaces.ts#json-parse-file-read#4e3250e520ef",
+      "classification": "external",
+      "reason": "workspace package.json manifests are ecosystem JSON; version derivation reads them as-is"
     }
   ]
 }


### PR DESCRIPTION
Main is red on `toon-json-guard.test.ts` for every PR that runs the apps/dev suite: #3405 landed two `JSON.parse` file reads in `apps/release/src/version-surfaces.ts` without allowlist entries, and its own CI never ran the guard because cone narrowing skips the apps/dev invariant suite for an `apps/release`-only diff.

This classifies both sites as `external` (npm `package.json` is ecosystem JSON, same classification as the existing `apps/release/src/cli.ts` entry). Guard test green locally (10/10).

Known follow-up (not in this PR): the narrowing hole itself — an `apps/release` diff must still run `pnpm -C apps/dev test:invariants`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788558385&installation_model_id=20659&pr_number=3409&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3409&signature=3c0b34cc0636f519209be8562c5accfba608a40eaa197f9da58fb02b736ff957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->