### PR TITLE
chore: #3406 /go: Shard the `test` job of `.github/workflows/red-workspace-ci.yml` so the 

### DIFF
--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -190,23 +190,34 @@ jobs:
         if: env.RUN_ANY != 'true'
         run: echo "No typed or manifest input changed (scope ${{ needs.scope.outputs.mode }}) — nothing to check."
 
-  test:
+  # The apps/dev suite is the merge-latency critical path: 423 files / 6000+
+  # tests, and `fileParallelism: false` in its vitest config runs them one file
+  # at a time, so a single runner spends ~4m45s of a ~5m job on this one step.
+  # `--shard=N/4` splits the FILE set four ways across four runners that each
+  # keep the serial-within-runner semantics the config asks for; per-runner
+  # fixed cost is seconds (checkout 4s, install 6s), so the fan-out is nearly
+  # pure win. The narrowing is unchanged — the whole matrix idles on a PR whose
+  # cone does not contain apps/dev.
+  test-shard:
     runs-on: ubuntu-latest
     needs: scope
+    strategy:
+      # A failing shard must not cancel its siblings: the run has to report
+      # every failure at once, not just the first shard to notice one.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
-      # JSON array of every package in the affected cone; each step below asks
-      # whether its own package is in it.
-      PACKAGES: ${{ needs.scope.outputs.test_packages }}
-      RUN_ANY: ${{ needs.scope.outputs.test_packages != '[]' }}
+      RUN_DEV: ${{ contains(fromJSON(needs.scope.outputs.test_packages), 'apps/dev') }}
     steps:
       - name: Checkout
-        if: env.RUN_ANY == 'true'
+        if: env.RUN_DEV == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - if: env.RUN_ANY == 'true'
+      - if: env.RUN_DEV == 'true'
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
 
-      - if: env.RUN_ANY == 'true'
+      - if: env.RUN_DEV == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
@@ -216,7 +227,7 @@ jobs:
       # binary must exist here exactly as it does on dev machines (/red-setup)
       # and in red-rsp-benchmark-ci.yml. Same pinned installer, no fallback.
       - name: Install pinned tq
-        if: contains(fromJSON(env.PACKAGES), 'apps/dev')
+        if: env.RUN_DEV == 'true'
         env:
           TQ_VERSION: v0.13.0
           GH_TOKEN: ${{ github.token }}
@@ -232,7 +243,7 @@ jobs:
           sh "$installer"
 
       - name: Install workspace dependencies
-        if: env.RUN_ANY == 'true'
+        if: env.RUN_DEV == 'true'
         env:
           # This PR gate typechecks/tests apps/dev; it does not execute the
           # @reddb-io/sdk-backed memory/brain runtimes. Skip the SDK postinstall
@@ -241,8 +252,55 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Test apps/dev (includes packages/shared)
-        if: contains(fromJSON(env.PACKAGES), 'apps/dev')
-        run: pnpm -C apps/dev test
+        if: env.RUN_DEV == 'true'
+        # No `--` before the flag: pnpm forwards the separator VERBATIM, and
+        # vitest then reads `--shard=…` as a filename filter and runs the whole
+        # suite on every shard — four full runs that all pass, which is exactly
+        # what a broken shard split looks like from the outside.
+        run: pnpm -C apps/dev test --shard=${{ matrix.shard }}/4
+
+      - name: Report narrowed scope
+        if: env.RUN_DEV != 'true'
+        run: echo "apps/dev is not in the affected cone (scope ${{ needs.scope.outputs.mode }}) — no shard to run."
+
+  # The remaining suites are seconds-cheap, so they stay in one job rather than
+  # paying a runner's fixed cost each.
+  test-packages:
+    runs-on: ubuntu-latest
+    needs: scope
+    env:
+      # JSON array of every package in the affected cone; each step below asks
+      # whether its own package is in it.
+      PACKAGES: ${{ needs.scope.outputs.test_packages }}
+      # apps/dev is deliberately absent: it belongs to the shard matrix, and
+      # asking for it here would install a workspace for no step to use.
+      RUN_ANY: >-
+        ${{ contains(fromJSON(needs.scope.outputs.test_packages), 'packages/red-castle')
+        || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/opencode-host')
+        || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/afk-container')
+        || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/herdr-plugin-red-skills')
+        || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/vscode-extension-red-skills') }}
+    steps:
+      - name: Checkout
+        if: env.RUN_ANY == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - if: env.RUN_ANY == 'true'
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+
+      - if: env.RUN_ANY == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+
+      - name: Install workspace dependencies
+        if: env.RUN_ANY == 'true'
+        env:
+          # This PR gate typechecks/tests apps/dev; it does not execute the
+          # @reddb-io/sdk-backed memory/brain runtimes. Skip the SDK postinstall
+          # binary download so CI is not coupled to reddb release assets.
+          REDDB_SKIP_POSTINSTALL: "1"
+        run: pnpm install --frozen-lockfile
 
       # The engine's own suite carries the castle-tree transition-API contract
       # lint (#2666). The root `test` script filters red-castle out, so without
@@ -275,4 +333,27 @@ jobs:
 
       - name: Report narrowed scope
         if: env.RUN_ANY != 'true'
-        run: echo "No package is in the affected cone (scope ${{ needs.scope.outputs.mode }}) — no suite to run."
+        run: echo "No non-dev package is in the affected cone (scope ${{ needs.scope.outputs.mode }}) — no suite to run."
+
+  # Branch protection requires a check named `test`, so the name survives the
+  # fan-out as an aggregate: the work moved, the contract did not.
+  test:
+    # `always()` is what keeps this a gate. Without it a FAILED dependency
+    # skips this job, and a skipped required check is one branch protection
+    # reads as satisfied — the gate would go quiet exactly when it should be
+    # loud. Narrowing never produces a skip here: the dependencies always run
+    # and shrink their own steps, so a docs-only PR reaches this job green.
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [scope, test-shard, test-packages]
+    steps:
+      - name: Fail when a test dependency failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "scope=${{ needs.scope.result }}"
+          echo "test-shard=${{ needs['test-shard'].result }}"
+          echo "test-packages=${{ needs['test-packages'].result }}"
+          exit 1
+
+      - name: Report aggregate result
+        run: echo "All test dependencies reported success (scope ${{ needs.scope.outputs.mode }})."

--- a/scripts/test-ci-affected-scope.sh
+++ b/scripts/test-ci-affected-scope.sh
@@ -135,18 +135,50 @@ need(!/^\s*paths(-ignore)?:/m.test(trigger),
 need(/^\s{2}scope:/m.test(text), 'red-workspace-ci defines a scope job');
 need(/ci-affected-scope\.mjs/.test(text), 'the scope job runs the affected-cone scoper');
 
-for (const job of ['typecheck', 'test']) {
+const jobBody = (job) => {
   const start = text.indexOf(`\n  ${job}:`);
   need(start !== -1, `red-workspace-ci still defines the ${job} job`);
   const rest = text.slice(start + 1);
   const end = rest.search(/\n {2}[a-z][a-z0-9-]*:\n/);
-  const body = end === -1 ? rest : rest.slice(0, end);
+  return end === -1 ? rest : rest.slice(0, end);
+};
+
+// The narrowing jobs do the work. Each one always runs and shrinks itself from
+// the inside.
+for (const job of ['typecheck', 'test-shard', 'test-packages']) {
+  const body = jobBody(job);
   need(/needs:\s*(scope|\[[^\]]*scope)/.test(body), `${job} consumes the scope job`);
   need(/if:\s/.test(body), `${job} narrows its work with step-level conditions`);
   // A job-level `if:` would report as "skipped", which branch protection treats
   // as a missing conclusion for a required check.
   need(!/^ {4}if:/m.test(body), `${job} has no job-level if (it must always report)`);
 }
+
+// The apps/dev suite is the critical path, so it fans out across a shard matrix
+// rather than running as one serial step.
+const shard = jobBody('test-shard');
+need(/^\s+matrix:\n\s+shard: \[1, 2, 3, 4\]$/m.test(shard),
+  'test-shard fans the apps/dev suite out over a 4-way matrix');
+need(/--shard=\$\{\{ matrix\.shard \}\}\/4/.test(shard),
+  'test-shard passes its matrix index to vitest');
+// pnpm forwards a `--` separator VERBATIM, so vitest reads the flag behind it
+// as a filename filter and every shard runs the whole suite — four full runs
+// that all pass, which is what a broken split looks like from the outside.
+need(!/test\s+--\s+--shard=/.test(shard),
+  'test-shard passes the shard flag with no `--` separator for pnpm to forward');
+need(/fail-fast: false/.test(shard),
+  'test-shard reports every failing shard, not only the first');
+
+// `test` is the required check name. It survives the fan-out as an aggregate,
+// and it is the ONE job here that carries a job-level `if:` — `always()`, so a
+// failed dependency cannot skip it into a silent pass.
+const aggregate = jobBody('test');
+need(/needs:\s*\[[^\]]*test-shard[^\]]*\]/.test(aggregate), 'test aggregates the shard matrix');
+need(/needs:\s*\[[^\]]*test-packages[^\]]*\]/.test(aggregate), 'test aggregates the per-package suites');
+need(/^ {4}if: always\(\)$/m.test(aggregate), 'test always runs, so it always reports a conclusion');
+need(/contains\(needs\.\*\.result, 'failure'\)/.test(aggregate)
+  && /contains\(needs\.\*\.result, 'cancelled'\)/.test(aggregate),
+  'test fails when any dependency failed or was cancelled');
 NODE
 
 printf '\nAll CI affected-scope contract checks passed.\n'


### PR DESCRIPTION
Automated AFK landing for #3406. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3406

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788558518&installation_model_id=20659&pr_number=3410&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3410&signature=a901222e4170a9030ed0e2298ac87c3c2031f32fcc461cc5eef7cc68328fdddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->