### PR TITLE
chore: #3366 Release engine: notes + release-manifest renderer (JSON/TOON parity)

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -203,6 +203,11 @@
       "moveKey": "e57f5cae7679"
     },
     {
+      "id": "apps/release/src/release-artifacts.ts#json-stringify-file-write#fda264d13ec5",
+      "classification": "external",
+      "reason": "Release manifest JSON is an interop asset for downstream CI/CD (ADR 0139)."
+    },
+    {
       "id": "apps/release/src/cli.ts#json-parse-file-read#06f60309d571",
       "classification": "external",
       "reason": "npm package.json manifests are an external JSON format the release engine must read as-is"

--- a/apps/release/package.json
+++ b/apps/release/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@reddb-io/build-info": "workspace:*",
     "@reddb-io/shared": "workspace:*",
+    "@reddb-io/toon": "catalog:",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/apps/release/src/release-artifacts.ts
+++ b/apps/release/src/release-artifacts.ts
@@ -1,0 +1,209 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { encode, type JsonValue } from "@reddb-io/toon";
+import type { ImpactClass, QueuedChange } from "./changeset-queue.js";
+
+export interface AttributedReleaseChange extends QueuedChange {
+  readonly authors: readonly string[];
+  readonly pullRequests: readonly number[];
+}
+
+export interface ReleaseArtifactInput {
+  readonly version: string;
+  readonly date: string;
+  readonly changes: readonly AttributedReleaseChange[];
+}
+
+export interface WriteReleaseArtifactsInput extends ReleaseArtifactInput {
+  readonly outputDirectory: string;
+}
+
+export interface ReleaseManifestChange {
+  file: string;
+  summary: string;
+  body: string;
+  packages: string[];
+  authors: string[];
+  pullRequests: number[];
+}
+
+export interface ReleaseManifest {
+  version: string;
+  date: string;
+  changes: {
+    major: ReleaseManifestChange[];
+    minor: ReleaseManifestChange[];
+    patch: ReleaseManifestChange[];
+  };
+  authors: string[];
+  pullRequests: number[];
+}
+
+export interface RenderedReleaseArtifacts {
+  readonly manifest: ReleaseManifest;
+  readonly notes: string;
+  readonly json: string;
+  readonly toon: string;
+}
+
+export interface WrittenReleaseArtifacts {
+  readonly directory: string;
+  readonly notesPath: string;
+  readonly jsonManifestPath: string;
+  readonly toonManifestPath: string;
+}
+
+const IMPACT_ORDER: readonly ImpactClass[] = ["major", "minor", "patch"];
+const IMPACT_HEADINGS: Readonly<Record<ImpactClass, string>> = {
+  major: "Major (breaking changes)",
+  minor: "Minor changes",
+  patch: "Patch changes",
+};
+
+/** Render every public release artifact from one normalized manifest value. */
+export function renderReleaseArtifacts(input: ReleaseArtifactInput): RenderedReleaseArtifacts {
+  const manifest = buildReleaseManifest(input);
+  return {
+    manifest,
+    notes: renderReleaseNotes(manifest),
+    json: `${JSON.stringify(manifest, null, 2)}\n`,
+    toon: withTrailingNewline(encode(manifest as unknown as JsonValue, { keyedMapCollapse: true })),
+  };
+}
+
+/**
+ * Publish the notes and both manifests as one directory rename. The destination
+ * must be new: callers never observe a subset of the three release artifacts.
+ */
+export function writeReleaseArtifacts(input: WriteReleaseArtifactsInput): WrittenReleaseArtifacts {
+  const rendered = renderReleaseArtifacts(input);
+  const directory = resolve(input.outputDirectory);
+  if (existsSync(directory)) {
+    throw new Error(`release artifact directory already exists: ${input.outputDirectory}`);
+  }
+
+  const parent = dirname(directory);
+  mkdirSync(parent, { recursive: true });
+  const staging = mkdtempSync(join(parent, `.${basename(directory)}-`));
+  try {
+    writeFileSync(join(staging, "release-notes.md"), rendered.notes, "utf8");
+    writeFileSync(
+      join(staging, "release-manifest.json"),
+      `${JSON.stringify(rendered.manifest, null, 2)}\n`,
+      "utf8",
+    );
+    writeFileSync(join(staging, "release-manifest.toon"), rendered.toon, "utf8");
+    renameSync(staging, directory);
+  } catch (error) {
+    rmSync(staging, { recursive: true, force: true });
+    throw error;
+  }
+
+  return {
+    directory,
+    notesPath: join(directory, "release-notes.md"),
+    jsonManifestPath: join(directory, "release-manifest.json"),
+    toonManifestPath: join(directory, "release-manifest.toon"),
+  };
+}
+
+export function buildReleaseManifest(input: ReleaseArtifactInput): ReleaseManifest {
+  if (input.version.trim() === "") throw new Error("release version must not be empty");
+  assertIsoDate(input.date);
+
+  const changes: ReleaseManifest["changes"] = { major: [], minor: [], patch: [] };
+  for (const change of [...input.changes].sort(compareChanges)) {
+    const authors = sortedUniqueStrings(change.authors, `${change.file} author`);
+    const pullRequests = sortedUniquePullRequests(change.pullRequests, change.file);
+    const packages = sortedUniqueStrings(
+      change.releases.map((release) => release.packageName),
+      `${change.file} package`,
+    );
+    changes[change.impact].push({
+      file: change.file,
+      summary: change.summary,
+      body: change.body,
+      packages,
+      authors,
+      pullRequests,
+    });
+  }
+
+  return {
+    version: input.version,
+    date: input.date,
+    changes,
+    authors: sortedUniqueStrings(
+      input.changes.flatMap((change) => change.authors),
+      "release author",
+    ),
+    pullRequests: sortedUniquePullRequests(
+      input.changes.flatMap((change) => change.pullRequests),
+      "release",
+    ),
+  };
+}
+
+export function renderReleaseNotes(manifest: ReleaseManifest): string {
+  const lines = [`# Release ${manifest.version}`, "", `Released ${manifest.date}.`];
+  for (const impact of IMPACT_ORDER) {
+    const changes = manifest.changes[impact];
+    if (changes.length === 0) continue;
+    lines.push("", `## ${IMPACT_HEADINGS[impact]}`, "");
+    for (const change of changes) {
+      const attribution = [
+        change.pullRequests.map((pullRequest) => `#${pullRequest}`).join(", "),
+        change.authors.join(", "),
+      ].filter((value) => value !== "").join(" — ");
+      lines.push(`- **${change.summary}**${attribution === "" ? "" : ` (${attribution})`}`);
+
+      const details = bodyDetails(change.body, change.summary);
+      if (details !== "") lines.push("", ...details.split("\n").map((line) => `  ${line}`));
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function compareChanges(left: AttributedReleaseChange, right: AttributedReleaseChange): number {
+  const impact = IMPACT_ORDER.indexOf(left.impact) - IMPACT_ORDER.indexOf(right.impact);
+  return impact === 0 ? left.file.localeCompare(right.file) : impact;
+}
+
+function sortedUniqueStrings(values: readonly string[], label: string): string[] {
+  const normalized = values.map((value) => value.trim());
+  if (normalized.some((value) => value === "")) throw new Error(`${label} must not be empty`);
+  return [...new Set(normalized)].sort((left, right) => left.localeCompare(right));
+}
+
+function sortedUniquePullRequests(values: readonly number[], label: string): number[] {
+  if (values.some((value) => !Number.isSafeInteger(value) || value < 1)) {
+    throw new Error(`${label} pull request numbers must be positive safe integers`);
+  }
+  return [...new Set(values)].sort((left, right) => left - right);
+}
+
+function bodyDetails(body: string, summary: string): string {
+  const trimmed = body.trim();
+  if (trimmed === summary) return "";
+  if (!trimmed.startsWith(summary)) return trimmed;
+  return trimmed.slice(summary.length).trim();
+}
+
+function assertIsoDate(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) throw new Error(`invalid release date: ${value}`);
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.valueOf()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`invalid release date: ${value}`);
+  }
+}
+
+function withTrailingNewline(value: string): string {
+  return value.endsWith("\n") ? value : `${value}\n`;
+}

--- a/apps/release/tests/fixtures/release-artifacts/release-manifest.json
+++ b/apps/release/tests/fixtures/release-artifacts/release-manifest.json
@@ -1,0 +1,69 @@
+{
+  "version": "2.0.0",
+  "date": "2026-08-05",
+  "changes": {
+    "major": [
+      {
+        "file": "calm-cats-dance.md",
+        "summary": "Replace the legacy release API.",
+        "body": "Replace the legacy release API.\n\nThe new API keeps every package on one version train.",
+        "packages": [
+          "@example/cli",
+          "@example/core"
+        ],
+        "authors": [
+          "@ada",
+          "@zoe"
+        ],
+        "pullRequests": [
+          319,
+          321
+        ]
+      }
+    ],
+    "minor": [
+      {
+        "file": "quiet-bears-wave.md",
+        "summary": "Add a read-only release status command.",
+        "body": "Add a read-only release status command.",
+        "packages": [
+          "@example/cli"
+        ],
+        "authors": [
+          "@lee"
+        ],
+        "pullRequests": [
+          320
+        ]
+      }
+    ],
+    "patch": [
+      {
+        "file": "bright-dogs-smile.md",
+        "summary": "Correct version rendering for release candidates.",
+        "body": "Correct version rendering for release candidates.",
+        "packages": [
+          "@example/core"
+        ],
+        "authors": [
+          "@sam"
+        ],
+        "pullRequests": [
+          318
+        ]
+      }
+    ]
+  },
+  "authors": [
+    "@ada",
+    "@lee",
+    "@sam",
+    "@zoe"
+  ],
+  "pullRequests": [
+    318,
+    319,
+    320,
+    321
+  ]
+}

--- a/apps/release/tests/fixtures/release-artifacts/release-manifest.toon
+++ b/apps/release/tests/fixtures/release-artifacts/release-manifest.toon
@@ -1,0 +1,26 @@
+version: 2.0.0
+date: 2026-08-05
+changes:
+  major[1]:
+    - file: calm-cats-dance.md
+      summary: Replace the legacy release API.
+      body: "Replace the legacy release API.\n\nThe new API keeps every package on one version train."
+      packages[2]: @example/cli,@example/core
+      authors[2]: @ada,@zoe
+      pullRequests[2]: 319,321
+  minor[1]:
+    - file: quiet-bears-wave.md
+      summary: Add a read-only release status command.
+      body: Add a read-only release status command.
+      packages[1]: @example/cli
+      authors[1]: @lee
+      pullRequests[1]: 320
+  patch[1]:
+    - file: bright-dogs-smile.md
+      summary: Correct version rendering for release candidates.
+      body: Correct version rendering for release candidates.
+      packages[1]: @example/core
+      authors[1]: @sam
+      pullRequests[1]: 318
+authors[4]: @ada,@lee,@sam,@zoe
+pullRequests[4]: 318,319,320,321

--- a/apps/release/tests/fixtures/release-artifacts/release-notes.md
+++ b/apps/release/tests/fixtures/release-artifacts/release-notes.md
@@ -1,0 +1,17 @@
+# Release 2.0.0
+
+Released 2026-08-05.
+
+## Major (breaking changes)
+
+- **Replace the legacy release API.** (#319, #321 — @ada, @zoe)
+
+  The new API keeps every package on one version train.
+
+## Minor changes
+
+- **Add a read-only release status command.** (#320 — @lee)
+
+## Patch changes
+
+- **Correct version rendering for release candidates.** (#318 — @sam)

--- a/apps/release/tests/release-artifacts.test.ts
+++ b/apps/release/tests/release-artifacts.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { decode } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  renderReleaseArtifacts,
+  writeReleaseArtifacts,
+  type ReleaseArtifactInput,
+} from "../src/release-artifacts.js";
+
+const GOLDENS = join(import.meta.dirname, "fixtures", "release-artifacts");
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("release notes and manifest artifacts", () => {
+  it("pins human notes and JSON/TOON manifests for a representative queue", () => {
+    const rendered = renderReleaseArtifacts(REPRESENTATIVE_RELEASE);
+
+    expect(rendered.notes).toBe(golden("release-notes.md"));
+    expect(rendered.json).toBe(golden("release-manifest.json"));
+    expect(rendered.toon).toBe(golden("release-manifest.toon"));
+  });
+
+  it("keeps the JSON and TOON manifests structurally identical", () => {
+    const rendered = renderReleaseArtifacts(REPRESENTATIVE_RELEASE);
+
+    expect(decode(rendered.toon)).toEqual(JSON.parse(rendered.json));
+    expect(decode(golden("release-manifest.toon"))).toEqual(
+      JSON.parse(golden("release-manifest.json")),
+    );
+  });
+
+  it("publishes all three artifacts together in a new directory", () => {
+    const root = mkdtempSync(join(tmpdir(), "red-release-artifacts-"));
+    temporaryDirectories.push(root);
+    const outputDirectory = join(root, "release");
+
+    expect(writeReleaseArtifacts({
+      ...REPRESENTATIVE_RELEASE,
+      outputDirectory,
+    })).toEqual({
+      directory: outputDirectory,
+      notesPath: join(outputDirectory, "release-notes.md"),
+      jsonManifestPath: join(outputDirectory, "release-manifest.json"),
+      toonManifestPath: join(outputDirectory, "release-manifest.toon"),
+    });
+    expect(readFileSync(join(outputDirectory, "release-notes.md"), "utf8"))
+      .toBe(golden("release-notes.md"));
+    expect(readFileSync(join(outputDirectory, "release-manifest.json"), "utf8"))
+      .toBe(golden("release-manifest.json"));
+    expect(readFileSync(join(outputDirectory, "release-manifest.toon"), "utf8"))
+      .toBe(golden("release-manifest.toon"));
+  });
+});
+
+const REPRESENTATIVE_RELEASE: ReleaseArtifactInput = {
+  version: "2.0.0",
+  date: "2026-08-05",
+  changes: [
+    {
+      file: "bright-dogs-smile.md",
+      summary: "Correct version rendering for release candidates.",
+      body: "Correct version rendering for release candidates.",
+      impact: "patch",
+      releases: [{ packageName: "@example/core", impact: "patch" }],
+      authors: ["@sam"],
+      pullRequests: [318],
+    },
+    {
+      file: "calm-cats-dance.md",
+      summary: "Replace the legacy release API.",
+      body: "Replace the legacy release API.\n\nThe new API keeps every package on one version train.",
+      impact: "major",
+      releases: [
+        { packageName: "@example/cli", impact: "minor" },
+        { packageName: "@example/core", impact: "major" },
+      ],
+      authors: ["@zoe", "@ada", "@ada"],
+      pullRequests: [321, 319, 321],
+    },
+    {
+      file: "quiet-bears-wave.md",
+      summary: "Add a read-only release status command.",
+      body: "Add a read-only release status command.",
+      impact: "minor",
+      releases: [{ packageName: "@example/cli", impact: "minor" }],
+      authors: ["@lee"],
+      pullRequests: [320],
+    },
+  ],
+};
+
+function golden(file: string): string {
+  return readFileSync(join(GOLDENS, file), "utf8");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@reddb-io/toon':
+        specifier: 'catalog:'
+        version: 0.13.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0


### PR DESCRIPTION
Automated AFK landing for #3366. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3366

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788558988&installation_model_id=20659&pr_number=3412&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3412&signature=1e50718ff3036f0a4a6db00135e6cc6fabb966c24730a74f0cba17b4ebab50d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->