### PR TITLE
chore: #3368 Release engine: Version-PR maintainer + auto trigger mode

### DIFF
--- a/apps/release/src/github-release-adapter.ts
+++ b/apps/release/src/github-release-adapter.ts
@@ -38,6 +38,28 @@ export interface GithubReleaseAdapter {
   uploadAsset(input: UploadReleaseAssetInput): Promise<void>;
 }
 
+export interface VersionPullRequestInput {
+  readonly base: string;
+  readonly head: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface VersionPullRequest {
+  readonly number: number;
+  readonly body: string;
+  readonly headCommit: string;
+  readonly merged: boolean;
+  readonly mergeCommit: string | null;
+}
+
+export interface ReleaseEngineGithub extends GithubReleaseAdapter {
+  upsertVersionPullRequest(
+    input: VersionPullRequestInput,
+  ): Promise<{ readonly number: number; readonly created: boolean }>;
+  findVersionPullRequest(number: number): Promise<VersionPullRequest | null>;
+}
+
 export interface CreateGithubReleaseAdapterOptions {
   readonly client: GithubClient;
   readonly owner: string;
@@ -57,20 +79,106 @@ const RELEASE_ASSET_UPLOAD: GithubAttributedOperation = {
   key: "release asset upload",
   budget: "rest",
 };
+const VERSION_PR_LIST: GithubAttributedOperation = {
+  key: "release version-pr list",
+  budget: "rest",
+};
+const VERSION_PR_CREATE: GithubAttributedOperation = {
+  key: "release version-pr create",
+  budget: "rest",
+};
+const VERSION_PR_UPDATE: GithubAttributedOperation = {
+  key: "release version-pr update",
+  budget: "rest",
+};
+const VERSION_PR_VIEW: GithubAttributedOperation = {
+  key: "release version-pr view",
+  budget: "rest",
+};
 
 /**
- * Adapt Release REST calls onto the house GitHub client so retries,
- * credentials, and durable request attribution stay at one transport boundary.
+ * Adapt Version-PR and Release REST calls onto the house GitHub client so
+ * retries, credentials, and durable attribution stay at one transport boundary.
  */
 export function createGithubReleaseAdapter(
   options: CreateGithubReleaseAdapterOptions,
-): GithubReleaseAdapter {
+): ReleaseEngineGithub {
   const owner = required(options.owner, "GitHub owner");
   const repository = required(options.repository, "GitHub repository");
   const actor = options.actor ?? "release-engine";
   const repositoryKey = `${owner}/${repository}`;
 
   return {
+    async upsertVersionPullRequest(input) {
+      const answer = await options.client.conditionalRest<unknown>({
+        cacheKey: `release-version-pr-list:${repositoryKey}:${input.base}:${input.head}`,
+        route: "GET /repos/{owner}/{repo}/pulls",
+        parameters: {
+          owner,
+          repo: repository,
+          state: "open",
+          base: input.base,
+          head: `${owner}:${input.head}`,
+          per_page: 2,
+        },
+        operation: VERSION_PR_LIST,
+        actor,
+      });
+      const existing = pullRequestList(answer.data);
+      if (existing.length > 1) {
+        throw new Error(`repository has multiple open Version PRs for ${input.head}`);
+      }
+      if (existing.length === 1) {
+        const pullRequest = existing[0]!;
+        const updated = await options.client.conditionalRest<unknown>({
+          cacheKey: `release-version-pr-update:${repositoryKey}:${pullRequest.number}`,
+          route: "PATCH /repos/{owner}/{repo}/pulls/{pull_number}",
+          parameters: {
+            owner,
+            repo: repository,
+            pull_number: pullRequest.number,
+            title: input.title,
+            body: input.body,
+          },
+          operation: VERSION_PR_UPDATE,
+          actor,
+        });
+        return { number: pullRequestFrom(updated.data).number, created: false };
+      }
+
+      const created = await options.client.conditionalRest<unknown>({
+        cacheKey: `release-version-pr-create:${repositoryKey}:${input.head}`,
+        route: "POST /repos/{owner}/{repo}/pulls",
+        parameters: {
+          owner,
+          repo: repository,
+          title: input.title,
+          body: input.body,
+          head: input.head,
+          base: input.base,
+        },
+        operation: VERSION_PR_CREATE,
+        actor,
+      });
+      return { number: pullRequestFrom(created.data).number, created: true };
+    },
+
+    async findVersionPullRequest(number) {
+      try {
+        const answer = await options.client.conditionalRest<unknown>({
+          cacheKey: `release-version-pr:${repositoryKey}:${number}`,
+          route: "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+          parameters: { owner, repo: repository, pull_number: number },
+          operation: VERSION_PR_VIEW,
+          actor,
+        });
+        return pullRequestFrom(answer.data);
+      } catch (error) {
+        if (httpStatus(error) === 404) return null;
+        throw error;
+      }
+    },
+
     async findByTag(tag): Promise<PublishedRelease | null> {
       try {
         const answer = await options.client.conditionalRest<unknown>({
@@ -126,6 +234,37 @@ export function createGithubReleaseAdapter(
         actor,
       });
     },
+  };
+}
+
+function pullRequestList(value: unknown): Array<{ readonly number: number }> {
+  if (!Array.isArray(value)) throw new Error("GitHub returned an invalid Version PR list");
+  return value.map((item) => {
+    if (!isRecord(item) || !positiveInteger(item.number)) {
+      throw new Error("GitHub returned an invalid Version PR list");
+    }
+    return { number: item.number };
+  });
+}
+
+function pullRequestFrom(value: unknown): VersionPullRequest {
+  if (!isRecord(value) || !positiveInteger(value.number) || !isRecord(value.head)) {
+    throw new Error("GitHub returned an invalid Version PR payload");
+  }
+  if (typeof value.body !== "string" || typeof value.head.sha !== "string" ||
+      typeof value.merged !== "boolean") {
+    throw new Error("GitHub returned an invalid Version PR payload");
+  }
+  const mergeCommit = value.merge_commit_sha;
+  if (mergeCommit !== null && typeof mergeCommit !== "string") {
+    throw new Error("GitHub returned an invalid Version PR merge commit");
+  }
+  return {
+    number: value.number,
+    body: value.body,
+    headCommit: value.head.sha,
+    merged: value.merged,
+    mergeCommit,
   };
 }
 

--- a/apps/release/src/release-engine.ts
+++ b/apps/release/src/release-engine.ts
@@ -1,0 +1,277 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChangesetQueue, QueuedChange } from "./changeset-queue.js";
+import { readChangesetQueue } from "./changeset-queue.js";
+import type {
+  ReleaseEngineGithub,
+  VersionPullRequest,
+  VersionPullRequestInput,
+} from "./github-release-adapter.js";
+import { writeReleaseArtifacts } from "./release-artifacts.js";
+import { publishRelease } from "./release-publication.js";
+import { computeNextVersion, type ReleaseClock } from "./version-core.js";
+import { readReleaseConfig, writeVersionSurfaces } from "./version-surfaces.js";
+
+export const RELEASE_BOT_AUTHOR = "red-skills-release[bot]";
+export const VERSION_PR_BRANCH = "red-release/version-pr";
+
+export type { ReleaseEngineGithub, VersionPullRequest, VersionPullRequestInput };
+
+export type ReleaseEngineEvent =
+  | { readonly kind: "push"; readonly commitAuthor: string }
+  | { readonly kind: "version-pr-merged"; readonly number: number };
+
+export interface RunReleaseEngineInput {
+  readonly repoRoot: string;
+  readonly event: ReleaseEngineEvent;
+  readonly github: ReleaseEngineGithub;
+  readonly clock: ReleaseClock;
+  readonly remote?: string;
+  readonly baseBranch?: string;
+  readonly date?: string;
+}
+
+export type ReleaseEngineResult =
+  | {
+      readonly kind: "version-pr";
+      readonly action: "created" | "updated";
+      readonly number: number;
+      readonly version: string;
+    }
+  | {
+      readonly kind: "published";
+      readonly version: string;
+      readonly tag: string;
+      readonly commit: string;
+    }
+  | { readonly kind: "ignored"; readonly reason: "release-bump" }
+  | { readonly kind: "idle"; readonly reason: "empty-queue" };
+
+interface ReleasePlan {
+  readonly version: string;
+  readonly date: string;
+  readonly changes: readonly QueuedChange[];
+}
+
+const PLAN_MARKER = "red-release-plan:v1";
+
+/** Converge one repository release event according to its configured trigger. */
+export async function runReleaseEngine(
+  input: RunReleaseEngineInput,
+): Promise<ReleaseEngineResult> {
+  if (input.event.kind === "push" && input.event.commitAuthor === RELEASE_BOT_AUTHOR) {
+    return { kind: "ignored", reason: "release-bump" };
+  }
+  const config = readReleaseConfig(input.repoRoot);
+  if (input.event.kind === "version-pr-merged") {
+    return publishMergedVersionPullRequest(input, input.event.number);
+  }
+
+  const queue = readChangesetQueue(join(input.repoRoot, ".changeset"));
+  if (queue.changes.length === 0) return { kind: "idle", reason: "empty-queue" };
+  const plan = releasePlan(input, queue, config.scheme);
+  if (config.trigger === "auto") {
+    createReleaseCommit(input.repoRoot, plan, queue);
+    git(
+      input.repoRoot,
+      "push", input.remote ?? "origin",
+      `HEAD:refs/heads/${input.baseBranch ?? "main"}`,
+    );
+    return publishPlan(input, plan);
+  }
+  maintainVersionBranch(input, plan, queue);
+  const pullRequest = await input.github.upsertVersionPullRequest({
+    base: input.baseBranch ?? "main",
+    head: VERSION_PR_BRANCH,
+    title: `chore(release): ${plan.version}`,
+    body: renderVersionPullRequestBody(plan),
+  });
+  return {
+    kind: "version-pr",
+    action: pullRequest.created ? "created" : "updated",
+    number: pullRequest.number,
+    version: plan.version,
+  };
+}
+
+function releasePlan(
+  input: RunReleaseEngineInput,
+  queue: ChangesetQueue,
+  scheme: "semver" | "calver",
+): ReleasePlan {
+  return {
+    version: computeNextVersion({
+      currentVersion: currentVersion(input.repoRoot),
+      pending: queue.pending,
+      scheme,
+      clock: input.clock,
+    }),
+    date: input.date ?? new Date().toISOString().slice(0, 10),
+    changes: queue.changes,
+  };
+}
+
+function maintainVersionBranch(
+  input: RunReleaseEngineInput,
+  plan: ReleasePlan,
+  queue: ChangesetQueue,
+): void {
+  const originalBranch = git(input.repoRoot, "branch", "--show-current");
+  if (originalBranch === "") throw new Error("release engine requires a named checkout branch");
+  const baseCommit = git(input.repoRoot, "rev-parse", "HEAD");
+  try {
+    git(input.repoRoot, "checkout", "-B", VERSION_PR_BRANCH, baseCommit);
+    createReleaseCommit(input.repoRoot, plan, queue);
+    git(
+      input.repoRoot,
+      "push", "--force-with-lease", input.remote ?? "origin",
+      `HEAD:refs/heads/${VERSION_PR_BRANCH}`,
+    );
+  } finally {
+    git(input.repoRoot, "checkout", originalBranch);
+  }
+}
+
+function createReleaseCommit(repoRoot: string, plan: ReleasePlan, queue: ChangesetQueue): string {
+  writeVersionSurfaces({ repoRoot, nextVersion: plan.version });
+  for (const change of queue.changes) {
+    rmSync(join(repoRoot, ".changeset", change.file));
+  }
+  git(repoRoot, "add", "--all");
+  git(
+    repoRoot,
+    "-c", `user.name=${RELEASE_BOT_AUTHOR}`,
+    "-c", "user.email=release-bot@example.invalid",
+    "commit", "-m", `chore(release): ${plan.version}`,
+  );
+  return git(repoRoot, "rev-parse", "HEAD");
+}
+
+async function publishMergedVersionPullRequest(
+  input: RunReleaseEngineInput,
+  number: number,
+): Promise<ReleaseEngineResult> {
+  const pullRequest = await input.github.findVersionPullRequest(number);
+  if (pullRequest === null) throw new Error(`Version PR #${number} was not found`);
+  if (!pullRequest.merged || pullRequest.mergeCommit === null) {
+    throw new Error(`Version PR #${number} has not merged`);
+  }
+  const commit = git(input.repoRoot, "rev-parse", "HEAD");
+  if (commit !== pullRequest.mergeCommit) {
+    throw new Error(
+      `Version PR #${number} merged as ${pullRequest.mergeCommit}, but checkout is ${commit}`,
+    );
+  }
+  const plan = parseVersionPullRequestBody(pullRequest.body);
+  return publishPlan(input, plan);
+}
+
+async function publishPlan(
+  input: RunReleaseEngineInput,
+  plan: ReleasePlan,
+): Promise<ReleaseEngineResult> {
+  const artifactDirectory = mkdtempSync(join(tmpdir(), "red-release-artifacts-"));
+  try {
+    const artifacts = writeReleaseArtifacts({
+      outputDirectory: join(artifactDirectory, "release"),
+      version: plan.version,
+      date: plan.date,
+      changes: plan.changes.map((change) => ({
+        ...change,
+        authors: [],
+        pullRequests: [],
+      })),
+    });
+    const published = await publishRelease({
+      repoRoot: input.repoRoot,
+      version: plan.version,
+      artifacts,
+      github: input.github,
+      remote: input.remote,
+    });
+    return {
+      kind: "published",
+      version: plan.version,
+      tag: published.tag,
+      commit: published.commit,
+    };
+  } finally {
+    rmSync(artifactDirectory, { recursive: true, force: true });
+  }
+}
+
+function renderVersionPullRequestBody(plan: ReleasePlan): string {
+  const notes = writeReleaseArtifactsPreview(plan);
+  const encoded = Buffer.from(JSON.stringify(plan), "utf8").toString("base64url");
+  return `${notes}\n<!-- ${PLAN_MARKER} ${encoded} -->\n`;
+}
+
+function writeReleaseArtifactsPreview(plan: ReleasePlan): string {
+  const directory = mkdtempSync(join(tmpdir(), "red-release-preview-"));
+  try {
+    const artifacts = writeReleaseArtifacts({
+      outputDirectory: join(directory, "release"),
+      version: plan.version,
+      date: plan.date,
+      changes: plan.changes.map((change) => ({
+        ...change,
+        authors: [],
+        pullRequests: [],
+      })),
+    });
+    return readFileSync(artifacts.notesPath, "utf8").trimEnd();
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function parseVersionPullRequestBody(body: string): ReleasePlan {
+  const match = new RegExp(`<!-- ${PLAN_MARKER} ([A-Za-z0-9_-]+) -->`).exec(body);
+  if (match === null) throw new Error("Version PR has no release plan metadata");
+  let value: unknown;
+  try {
+    value = JSON.parse(Buffer.from(match[1]!, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new Error(`Version PR has invalid release plan metadata: ${errorMessage(error)}`);
+  }
+  if (!isReleasePlan(value)) throw new Error("Version PR has invalid release plan metadata");
+  return value;
+}
+
+function currentVersion(repoRoot: string): string {
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+  } catch (error) {
+    throw new Error(`cannot read current version from package.json: ${errorMessage(error)}`);
+  }
+  if (!isRecord(manifest) || typeof manifest.version !== "string" || manifest.version === "") {
+    throw new Error("cannot read current version: package.json has no version");
+  }
+  return manifest.version;
+}
+
+function isReleasePlan(value: unknown): value is ReleasePlan {
+  return isRecord(value) && typeof value.version === "string" &&
+    /^\d{4}-\d{2}-\d{2}$/.test(String(value.date)) && Array.isArray(value.changes);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function git(cwd: string, ...args: string[]): string {
+  try {
+    return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] })
+      .trim();
+  } catch (error) {
+    const detail = isRecord(error) && typeof error.stderr === "string" ? error.stderr.trim() : "";
+    throw new Error(`git ${args[0] ?? "command"} failed${detail === "" ? "" : `: ${detail}`}`);
+  }
+}

--- a/apps/release/tests/release-engine.test.ts
+++ b/apps/release/tests/release-engine.test.ts
@@ -1,0 +1,343 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createGithubClient,
+  type GithubRequestFetch,
+} from "@reddb-io/github";
+import {
+  RELEASE_BOT_AUTHOR,
+  runReleaseEngine,
+  type ReleaseEngineGithub,
+  type VersionPullRequest,
+  type VersionPullRequestInput,
+} from "../src/release-engine.js";
+import type {
+  CreateReleaseInput,
+  PublishedRelease,
+  UploadReleaseAssetInput,
+} from "../src/github-release-adapter.js";
+import { createGithubReleaseAdapter } from "../src/github-release-adapter.js";
+
+const temporaryDirectories: string[] = [];
+const FIXED_CLOCK = { today: () => ({ year: 2026, month: 8 }) };
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("release engine", () => {
+  it("maintains one Version PR as the queue grows, then publishes its merged revision", async () => {
+    const fixture = releaseFixture("version-pr");
+    fixture.addChangeset("calm-cats-dance.md", "minor", "Add the release engine.");
+
+    await expect(fixture.push()).resolves.toMatchObject({
+      kind: "version-pr",
+      action: "created",
+      number: 1,
+      version: "1.3.0",
+    });
+    expect(fixture.github.pullRequests).toHaveLength(1);
+    expect(fixture.github.pullRequests[0]?.title).toBe("chore(release): 1.3.0");
+    expect(fixture.github.pullRequests[0]?.body).toContain("Add the release engine.");
+    expect(fixture.versionOnRemoteBranch("red-release/version-pr")).toBe("1.3.0");
+
+    fixture.addChangeset("bright-dogs-smile.md", "patch", "Correct the release notes.");
+    await expect(fixture.push()).resolves.toMatchObject({
+      kind: "version-pr",
+      action: "updated",
+      number: 1,
+      version: "1.3.0",
+    });
+    expect(fixture.github.pullRequests).toHaveLength(1);
+    expect(fixture.github.pullRequests[0]?.body).toContain("Correct the release notes.");
+
+    const mergeCommit = fixture.mergeVersionPullRequest();
+    await expect(fixture.merge(1)).resolves.toMatchObject({
+      kind: "published",
+      version: "1.3.0",
+      tag: "v1.3.0",
+      commit: mergeCommit,
+    });
+    expect(git(fixture.remote, "show-ref", "--hash", "refs/tags/v1.3.0")).toBe(mergeCommit);
+    expect(fixture.github.release).toMatchObject({
+      tag: "v1.3.0",
+      targetCommitish: mergeCommit,
+      body: expect.stringContaining("Correct the release notes."),
+    });
+  });
+
+  it("consumes the queue and publishes directly on an auto-mode push", async () => {
+    const fixture = releaseFixture("auto");
+    fixture.addChangeset("quick-foxes-jump.md", "patch", "Correct the auto release.");
+
+    await expect(fixture.push()).resolves.toMatchObject({
+      kind: "published",
+      version: "1.2.4",
+      tag: "v1.2.4",
+    });
+
+    expect(fixture.github.pullRequests).toEqual([]);
+    expect(fixture.versionOnRemoteBranch("main")).toBe("1.2.4");
+    expect(fixture.filesOnRemoteBranch("main")).not.toContain(
+      ".changeset/quick-foxes-jump.md",
+    );
+    expect(fixture.github.release).toMatchObject({
+      tag: "v1.2.4",
+      targetCommitish: git(fixture.repository, "rev-parse", "origin/main"),
+      body: expect.stringContaining("Correct the auto release."),
+    });
+  });
+
+  it("does not retrigger from the flow-authored bump commit", async () => {
+    const fixture = releaseFixture("auto");
+    fixture.addChangeset("quiet-owls-rest.md", "patch", "Pin the release anti-loop.");
+    await fixture.push();
+    const releasedHead = git(fixture.repository, "rev-parse", "origin/main");
+
+    await expect(fixture.pushAs(RELEASE_BOT_AUTHOR)).resolves.toEqual({
+      kind: "ignored",
+      reason: "release-bump",
+    });
+
+    expect(git(fixture.repository, "rev-parse", "origin/main")).toBe(releasedHead);
+    expect(fixture.github.pullRequests).toEqual([]);
+    expect(fixture.github.release?.tag).toBe("v1.2.4");
+  });
+
+  it("routes Version-PR create, update, and merge reads through the house GitHub adapter", async () => {
+    const api = new FakePullRequestApi();
+    const client = createGithubClient({
+      token: "fixture-token",
+      baseUrl: "https://github.invalid/api/v3",
+      fetchImpl: api.fetch,
+      retryCount: 0,
+      throttle: false,
+    });
+    const github = createGithubReleaseAdapter({
+      client,
+      owner: "example",
+      repository: "widgets",
+    });
+
+    await expect(github.upsertVersionPullRequest({
+      base: "main",
+      head: "red-release/version-pr",
+      title: "chore(release): 1.3.0",
+      body: "first preview",
+    })).resolves.toEqual({ number: 7, created: true });
+    await expect(github.upsertVersionPullRequest({
+      base: "main",
+      head: "red-release/version-pr",
+      title: "chore(release): 1.3.0",
+      body: "grown preview",
+    })).resolves.toEqual({ number: 7, created: false });
+
+    api.merge("merged-commit");
+    await expect(github.findVersionPullRequest(7)).resolves.toEqual({
+      number: 7,
+      body: "grown preview",
+      headCommit: "version-head",
+      merged: true,
+      mergeCommit: "merged-commit",
+    });
+    expect(api.routes).toEqual([
+      "GET /repos/example/widgets/pulls",
+      "POST /repos/example/widgets/pulls",
+      "GET /repos/example/widgets/pulls",
+      "PATCH /repos/example/widgets/pulls/7",
+      "GET /repos/example/widgets/pulls/7",
+    ]);
+  });
+});
+
+function releaseFixture(trigger: "version-pr" | "auto") {
+  const root = mkdtempSync(join(tmpdir(), "red-release-engine-"));
+  temporaryDirectories.push(root);
+  const remote = join(root, "remote.git");
+  const repository = join(root, "repository");
+  git(root, "init", "--bare", remote);
+  git(root, "init", "--initial-branch=main", repository);
+  git(repository, "config", "user.name", "Release Fixture");
+  git(repository, "config", "user.email", "release-fixture@example.invalid");
+  write(repository, "package.json", `{
+  "name": "fixture",
+  "version": "1.2.3"
+}\n`);
+  write(repository, ".red/config.yaml", `release:
+  scheme: semver
+  trigger: ${trigger}
+  version_surfaces:
+    - path: package.json
+      format: npm
+`);
+  git(repository, "add", "package.json", ".red/config.yaml");
+  git(repository, "commit", "-m", "chore: fixture baseline");
+  git(repository, "remote", "add", "origin", remote);
+  git(repository, "push", "-u", "origin", "main");
+  const github = new FakeGithub(repository);
+
+  const invoke = (event: Parameters<typeof runReleaseEngine>[0]["event"]) =>
+    runReleaseEngine({ repoRoot: repository, event, github, clock: FIXED_CLOCK });
+
+  return {
+    remote,
+    repository,
+    github,
+    addChangeset(file: string, impact: "minor" | "patch", summary: string): void {
+      write(repository, `.changeset/${file}`, `---\n"fixture": ${impact}\n---\n${summary}\n`);
+      git(repository, "add", `.changeset/${file}`);
+      git(repository, "commit", "-m", `feat: ${summary}`);
+      git(repository, "push", "origin", "main");
+    },
+    push: () => invoke({ kind: "push", commitAuthor: "fixture-maintainer" }),
+    pushAs: (commitAuthor: string) => invoke({ kind: "push", commitAuthor }),
+    merge: (number: number) => invoke({ kind: "version-pr-merged", number }),
+    mergeVersionPullRequest(): string {
+      git(repository, "fetch", "origin", "red-release/version-pr");
+      git(repository, "merge", "--no-ff", "origin/red-release/version-pr", "-m", "merge: Version PR");
+      git(repository, "push", "origin", "main");
+      const commit = git(repository, "rev-parse", "HEAD");
+      github.markMerged(1, commit);
+      return commit;
+    },
+    versionOnRemoteBranch(branch: string): string {
+      const source = git(repository, "show", `origin/${branch}:package.json`);
+      return (JSON.parse(source) as { version: string }).version;
+    },
+    filesOnRemoteBranch(branch: string): string[] {
+      return git(repository, "ls-tree", "-r", "--name-only", `origin/${branch}`).split("\n");
+    },
+  };
+}
+
+type MutableVersionPullRequest = {
+  -readonly [Key in keyof VersionPullRequest]: VersionPullRequest[Key];
+} & { title: string };
+
+class FakeGithub implements ReleaseEngineGithub {
+  readonly pullRequests: MutableVersionPullRequest[] = [];
+  release: PublishedRelease | null = null;
+  private assets: Array<{ id: number; name: string }> = [];
+
+  constructor(private readonly repository: string) {}
+
+  async upsertVersionPullRequest(input: VersionPullRequestInput) {
+    const existing = this.pullRequests.find((pullRequest) => !pullRequest.merged);
+    if (existing !== undefined) {
+      existing.title = input.title;
+      existing.body = input.body;
+      existing.headCommit = git(this.repository, "rev-parse", `origin/${input.head}`);
+      return { number: existing.number, created: false };
+    }
+    this.pullRequests.push({
+      number: 1,
+      title: input.title,
+      body: input.body,
+      headCommit: git(this.repository, "rev-parse", `origin/${input.head}`),
+      merged: false,
+      mergeCommit: null,
+    });
+    return { number: 1, created: true };
+  }
+
+  async findVersionPullRequest(number: number): Promise<VersionPullRequest | null> {
+    return this.pullRequests.find((pullRequest) => pullRequest.number === number) ?? null;
+  }
+
+  markMerged(number: number, mergeCommit: string): void {
+    const pullRequest = this.pullRequests.find((candidate) => candidate.number === number);
+    if (pullRequest === undefined) throw new Error(`missing fixture pull request ${number}`);
+    pullRequest.merged = true;
+    pullRequest.mergeCommit = mergeCommit;
+  }
+
+  async findByTag(tag: string): Promise<PublishedRelease | null> {
+    return this.release?.tag === tag ? { ...this.release, assets: this.assets } : null;
+  }
+
+  async create(input: CreateReleaseInput): Promise<PublishedRelease> {
+    this.release = { id: 1, ...input, assets: [] };
+    return this.release;
+  }
+
+  async uploadAsset(input: UploadReleaseAssetInput): Promise<void> {
+    this.assets.push({ id: this.assets.length + 1, name: input.name });
+  }
+}
+
+class FakePullRequestApi {
+  readonly routes: string[] = [];
+  readonly fetch: GithubRequestFetch;
+  private pullRequest: Record<string, unknown> | null = null;
+
+  constructor() {
+    this.fetch = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      const path = url.pathname.replace(/^\/api\/v3/, "");
+      this.routes.push(`${method} ${path}`);
+      if (method === "GET" && path === "/repos/example/widgets/pulls") {
+        return response(
+          this.pullRequest === null ? [] : [{ number: this.pullRequest.number }],
+        );
+      }
+      if (method === "POST" && path === "/repos/example/widgets/pulls") {
+        const payload = JSON.parse(await requestBody(init?.body)) as Record<string, unknown>;
+        this.pullRequest = this.payload(payload);
+        return response(this.pullRequest, 201);
+      }
+      if (method === "PATCH" && path === "/repos/example/widgets/pulls/7") {
+        const payload = JSON.parse(await requestBody(init?.body)) as Record<string, unknown>;
+        this.pullRequest = this.payload({ ...this.pullRequest, ...payload });
+        return response(this.pullRequest);
+      }
+      if (method === "GET" && path === "/repos/example/widgets/pulls/7") {
+        return response(this.pullRequest);
+      }
+      return response({ message: `unexpected ${method} ${path}` }, 500);
+    };
+  }
+
+  merge(commit: string): void {
+    this.pullRequest = { ...this.pullRequest, merged: true, merge_commit_sha: commit };
+  }
+
+  private payload(fields: Record<string, unknown>): Record<string, unknown> {
+    return {
+      number: 7,
+      body: fields.body,
+      head: { sha: "version-head" },
+      merged: false,
+      merge_commit_sha: null,
+    };
+  }
+}
+
+function write(root: string, path: string, source: string): void {
+  const absolutePath = join(root, path);
+  mkdirSync(join(absolutePath, ".."), { recursive: true });
+  writeFileSync(absolutePath, source);
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+async function requestBody(
+  body: ConstructorParameters<typeof Response>[0] | undefined,
+): Promise<string> {
+  if (body === undefined || body === null) return "";
+  return new Response(body).text();
+}
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}


### PR DESCRIPTION
Automated AFK landing for #3368. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3368

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788562588&installation_model_id=20659&pr_number=3420&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3420&signature=2adb6e297d9a85654a2fc7a2a98d684dd7f1150a1432debe2ebdaf8a3053bb71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->