### PR TITLE
chore: #3369 Release engine: RC graduation from the Version-PR branch

### DIFF
--- a/apps/release/src/github-release-adapter.ts
+++ b/apps/release/src/github-release-adapter.ts
@@ -14,6 +14,7 @@ export interface PublishedRelease {
   readonly targetCommitish: string;
   readonly name: string;
   readonly body: string;
+  readonly prerelease: boolean;
   readonly assets: readonly PublishedReleaseAsset[];
 }
 
@@ -22,6 +23,7 @@ export interface CreateReleaseInput {
   readonly targetCommitish: string;
   readonly name: string;
   readonly body: string;
+  readonly prerelease: boolean;
 }
 
 export interface UploadReleaseAssetInput {
@@ -207,7 +209,7 @@ export function createGithubReleaseAdapter(
           name: input.name,
           body: input.body,
           draft: false,
-          prerelease: false,
+          prerelease: input.prerelease,
         },
         operation: RELEASE_CREATE,
         actor,
@@ -272,6 +274,9 @@ function releaseFrom(value: unknown): PublishedRelease {
   if (!isRecord(value) || !positiveInteger(value.id)) {
     throw new Error("GitHub returned an invalid Release payload");
   }
+  if (typeof value.prerelease !== "boolean") {
+    throw new Error("GitHub returned an invalid Release prerelease marking");
+  }
   const assets = Array.isArray(value.assets)
     ? value.assets.map((asset): PublishedReleaseAsset => {
         if (!isRecord(asset) || !positiveInteger(asset.id) || typeof asset.name !== "string") {
@@ -286,6 +291,7 @@ function releaseFrom(value: unknown): PublishedRelease {
     targetCommitish: stringField(value, "target_commitish"),
     name: stringField(value, "name"),
     body: stringField(value, "body"),
+    prerelease: value.prerelease,
     assets,
   };
 }

--- a/apps/release/src/release-engine.ts
+++ b/apps/release/src/release-engine.ts
@@ -21,6 +21,7 @@ export type { ReleaseEngineGithub, VersionPullRequest, VersionPullRequestInput }
 
 export type ReleaseEngineEvent =
   | { readonly kind: "push"; readonly commitAuthor: string }
+  | { readonly kind: "release-candidate"; readonly number: number }
   | { readonly kind: "version-pr-merged"; readonly number: number };
 
 export interface RunReleaseEngineInput {
@@ -65,6 +66,13 @@ export async function runReleaseEngine(
     return { kind: "ignored", reason: "release-bump" };
   }
   const config = readReleaseConfig(input.repoRoot);
+  if (input.event.kind === "release-candidate") {
+    if (!config.prerelease) throw new Error("RC graduation is disabled by release.prerelease");
+    if (config.trigger !== "version-pr") {
+      throw new Error("RC graduation requires the version-pr release trigger");
+    }
+    return publishReleaseCandidate(input, input.event.number);
+  }
   if (input.event.kind === "version-pr-merged") {
     return publishMergedVersionPullRequest(input, input.event.number);
   }
@@ -168,9 +176,38 @@ async function publishMergedVersionPullRequest(
   return publishPlan(input, plan);
 }
 
+async function publishReleaseCandidate(
+  input: RunReleaseEngineInput,
+  number: number,
+): Promise<ReleaseEngineResult> {
+  const pullRequest = await input.github.findVersionPullRequest(number);
+  if (pullRequest === null) throw new Error(`Version PR #${number} was not found`);
+  if (pullRequest.merged) throw new Error(`Version PR #${number} has already merged`);
+
+  const remote = input.remote ?? "origin";
+  git(input.repoRoot, "fetch", remote, `refs/heads/${VERSION_PR_BRANCH}`);
+  const fetchedCommit = git(input.repoRoot, "rev-parse", "FETCH_HEAD");
+  if (fetchedCommit !== pullRequest.headCommit) {
+    throw new Error(
+      `Version PR #${number} names ${pullRequest.headCommit}, but ${VERSION_PR_BRANCH} is ${fetchedCommit}`,
+    );
+  }
+
+  const plan = parseVersionPullRequestBody(pullRequest.body);
+  const version = nextReleaseCandidateVersion(input.repoRoot, remote, plan.version);
+  return publishPlan(
+    input,
+    { ...plan, version },
+    pullRequest.headCommit,
+    true,
+  );
+}
+
 async function publishPlan(
   input: RunReleaseEngineInput,
   plan: ReleasePlan,
+  commit?: string,
+  prerelease = false,
 ): Promise<ReleaseEngineResult> {
   const artifactDirectory = mkdtempSync(join(tmpdir(), "red-release-artifacts-"));
   try {
@@ -190,6 +227,8 @@ async function publishPlan(
       artifacts,
       github: input.github,
       remote: input.remote,
+      commit,
+      prerelease,
     });
     return {
       kind: "published",
@@ -200,6 +239,20 @@ async function publishPlan(
   } finally {
     rmSync(artifactDirectory, { recursive: true, force: true });
   }
+}
+
+function nextReleaseCandidateVersion(repoRoot: string, remote: string, version: string): string {
+  const tagPrefix = `refs/tags/v${version}-rc.`;
+  const refs = git(repoRoot, "ls-remote", "--tags", "--refs", remote, `${tagPrefix}*`);
+  let latest = 0;
+  for (const line of refs.split("\n")) {
+    if (line === "") continue;
+    const ref = line.split(/\s+/, 2)[1];
+    if (ref === undefined || !ref.startsWith(tagPrefix)) continue;
+    const candidate = Number(ref.slice(tagPrefix.length));
+    if (Number.isSafeInteger(candidate) && candidate > latest) latest = candidate;
+  }
+  return `${version}-rc.${latest + 1}`;
 }
 
 function renderVersionPullRequestBody(plan: ReleasePlan): string {

--- a/apps/release/src/release-publication.ts
+++ b/apps/release/src/release-publication.ts
@@ -12,6 +12,8 @@ export interface PublishReleaseInput {
   readonly artifacts: WrittenReleaseArtifacts;
   readonly github: GithubReleaseAdapter;
   readonly remote?: string;
+  readonly commit?: string;
+  readonly prerelease?: boolean;
 }
 
 export interface PublishReleaseResult {
@@ -41,7 +43,10 @@ export async function publishRelease(
   const tag = `v${version}`;
   const remote = input.remote ?? "origin";
   assertTagName(input.repoRoot, tag);
-  const commit = git(input.repoRoot, ["rev-parse", "HEAD"]);
+  const commit = input.commit === undefined
+    ? git(input.repoRoot, ["rev-parse", "HEAD"])
+    : git(input.repoRoot, ["rev-parse", "--verify", `${input.commit}^{commit}`]);
+  const prerelease = input.prerelease ?? false;
   const tagCreated = ensureRemoteTag(input.repoRoot, remote, tag, commit);
   const notes = readFileSync(input.artifacts.notesPath, "utf8");
   const assets: readonly ManifestAsset[] = [
@@ -66,6 +71,7 @@ export async function publishRelease(
         targetCommitish: commit,
         name: tag,
         body: notes,
+        prerelease,
       });
       releaseCreated = true;
     } catch (error) {
@@ -75,7 +81,7 @@ export async function publishRelease(
       if (release === null) throw error;
     }
   }
-  assertReleaseMatches(release, { tag, commit, notes });
+  assertReleaseMatches(release, { tag, commit, notes, prerelease });
 
   const attached = uniqueAssetNames(release);
   const uploadedAssets: string[] = [];
@@ -97,7 +103,7 @@ export async function publishRelease(
       if (observed === null || !observed.assets.some(({ name }) => name === asset.name)) {
         throw error;
       }
-      assertReleaseMatches(observed, { tag, commit, notes });
+      assertReleaseMatches(observed, { tag, commit, notes, prerelease });
       attached.add(asset.name);
       uploadedAssets.push(asset.name);
     }
@@ -175,7 +181,12 @@ function assertSameTagTarget(
 
 function assertReleaseMatches(
   release: PublishedRelease,
-  expected: { readonly tag: string; readonly commit: string; readonly notes: string },
+  expected: {
+    readonly tag: string;
+    readonly commit: string;
+    readonly notes: string;
+    readonly prerelease: boolean;
+  },
 ): void {
   if (release.tag !== expected.tag) {
     throw new Error(`GitHub Release tag mismatch: ${release.tag} != ${expected.tag}`);
@@ -190,6 +201,9 @@ function assertReleaseMatches(
   }
   if (release.body !== expected.notes) {
     throw new Error(`GitHub Release ${expected.tag} notes do not match the rendered notes`);
+  }
+  if (release.prerelease !== expected.prerelease) {
+    throw new Error(`GitHub Release ${expected.tag} has unexpected prerelease marking`);
   }
 }
 

--- a/apps/release/src/version-surfaces.ts
+++ b/apps/release/src/version-surfaces.ts
@@ -20,6 +20,7 @@ export interface DeclaredVersionSurface {
 export interface ReleaseConfig {
   readonly scheme: VersionScheme;
   readonly trigger: ReleaseTrigger;
+  readonly prerelease: boolean;
   readonly versionSurfaces: readonly DeclaredVersionSurface[];
   readonly syncCommand?: string;
 }
@@ -81,6 +82,10 @@ export function readReleaseConfig(
   if (trigger !== "version-pr" && trigger !== "auto") {
     throw configError("release.trigger must be version-pr or auto");
   }
+  const prerelease = release.prerelease ?? false;
+  if (typeof prerelease !== "boolean") {
+    throw configError("release.prerelease must be true or false");
+  }
   const rawSurfaces = release.version_surfaces;
   if (!Array.isArray(rawSurfaces) || rawSurfaces.length === 0) {
     throw configError("release.version_surfaces must be a non-empty sequence");
@@ -110,6 +115,7 @@ export function readReleaseConfig(
   return {
     scheme,
     trigger,
+    prerelease,
     versionSurfaces,
     ...(typeof syncCommand === "string" ? { syncCommand } : {}),
   };

--- a/apps/release/tests/release-engine.test.ts
+++ b/apps/release/tests/release-engine.test.ts
@@ -278,7 +278,7 @@ type MutableVersionPullRequest = {
 class FakeGithub implements ReleaseEngineGithub {
   readonly pullRequests: MutableVersionPullRequest[] = [];
   readonly releases: PublishedRelease[] = [];
-  private assets: Array<{ id: number; name: string }> = [];
+  private readonly assets = new Map<number, Array<{ id: number; name: string }>>();
 
   constructor(private readonly repository: string) {}
 
@@ -318,17 +318,22 @@ class FakeGithub implements ReleaseEngineGithub {
 
   async findByTag(tag: string): Promise<PublishedRelease | null> {
     const release = this.releases.find((candidate) => candidate.tag === tag);
-    return release === undefined ? null : { ...release, assets: this.assets };
+    return release === undefined
+      ? null
+      : { ...release, assets: this.assets.get(release.id) ?? [] };
   }
 
   async create(input: CreateReleaseInput): Promise<PublishedRelease> {
     const release = { id: this.releases.length + 1, ...input, assets: [] };
     this.releases.push(release);
+    this.assets.set(release.id, []);
     return release;
   }
 
   async uploadAsset(input: UploadReleaseAssetInput): Promise<void> {
-    this.assets.push({ id: this.assets.length + 1, name: input.name });
+    const assets = this.assets.get(input.releaseId);
+    if (assets === undefined) throw new Error(`missing fixture release ${input.releaseId}`);
+    assets.push({ id: assets.length + 1, name: input.name });
   }
 }
 

--- a/apps/release/tests/release-engine.test.ts
+++ b/apps/release/tests/release-engine.test.ts
@@ -31,6 +31,57 @@ afterEach(() => {
 });
 
 describe("release engine", () => {
+  it("graduates successive RCs from the Version-PR revision before consuming its queue once", async () => {
+    const fixture = releaseFixture("version-pr", { prerelease: true });
+    fixture.addChangeset("patient-otters-build.md", "minor", "Graduate the tested release.");
+
+    await fixture.push();
+    const versionPullRequestCommit = fixture.github.pullRequests[0]!.headCommit;
+    const versionPullRequestTree = git(
+      fixture.repository,
+      "rev-parse", `${versionPullRequestCommit}^{tree}`,
+    );
+
+    await expect(fixture.releaseCandidate(1)).resolves.toMatchObject({
+      kind: "published",
+      version: "1.3.0-rc.1",
+      tag: "v1.3.0-rc.1",
+      commit: versionPullRequestCommit,
+    });
+    await expect(fixture.releaseCandidate(1)).resolves.toMatchObject({
+      kind: "published",
+      version: "1.3.0-rc.2",
+      tag: "v1.3.0-rc.2",
+      commit: versionPullRequestCommit,
+    });
+
+    expect(fixture.github.releases).toMatchObject([
+      { tag: "v1.3.0-rc.1", prerelease: true },
+      { tag: "v1.3.0-rc.2", prerelease: true },
+    ]);
+    expect(git(
+      fixture.repository,
+      "rev-parse", "refs/tags/v1.3.0-rc.2^{tree}",
+    )).toBe(versionPullRequestTree);
+    expect(fixture.versionOnRemoteBranch("main")).toBe("1.2.3");
+    expect(fixture.filesOnRemoteBranch("main")).toContain(
+      ".changeset/patient-otters-build.md",
+    );
+
+    const mergeCommit = fixture.mergeVersionPullRequest();
+    await fixture.merge(1);
+    await fixture.merge(1);
+
+    expect(git(fixture.repository, "rev-parse", `${mergeCommit}^{tree}`))
+      .toBe(versionPullRequestTree);
+    expect(fixture.versionOnRemoteBranch("main")).toBe("1.3.0");
+    expect(fixture.filesOnRemoteBranch("main")).not.toContain(
+      ".changeset/patient-otters-build.md",
+    );
+    expect(fixture.github.releases.filter(({ tag }) => tag === "v1.3.0"))
+      .toMatchObject([{ tag: "v1.3.0", prerelease: false }]);
+  });
+
   it("maintains one Version PR as the queue grows, then publishes its merged revision", async () => {
     const fixture = releaseFixture("version-pr");
     fixture.addChangeset("calm-cats-dance.md", "minor", "Add the release engine.");
@@ -155,7 +206,10 @@ describe("release engine", () => {
   });
 });
 
-function releaseFixture(trigger: "version-pr" | "auto") {
+function releaseFixture(
+  trigger: "version-pr" | "auto",
+  options: { readonly prerelease?: boolean } = {},
+) {
   const root = mkdtempSync(join(tmpdir(), "red-release-engine-"));
   temporaryDirectories.push(root);
   const remote = join(root, "remote.git");
@@ -171,6 +225,7 @@ function releaseFixture(trigger: "version-pr" | "auto") {
   write(repository, ".red/config.yaml", `release:
   scheme: semver
   trigger: ${trigger}
+  prerelease: ${options.prerelease ?? false}
   version_surfaces:
     - path: package.json
       format: npm
@@ -196,6 +251,7 @@ function releaseFixture(trigger: "version-pr" | "auto") {
     },
     push: () => invoke({ kind: "push", commitAuthor: "fixture-maintainer" }),
     pushAs: (commitAuthor: string) => invoke({ kind: "push", commitAuthor }),
+    releaseCandidate: (number: number) => invoke({ kind: "release-candidate", number }),
     merge: (number: number) => invoke({ kind: "version-pr-merged", number }),
     mergeVersionPullRequest(): string {
       git(repository, "fetch", "origin", "red-release/version-pr");
@@ -221,10 +277,14 @@ type MutableVersionPullRequest = {
 
 class FakeGithub implements ReleaseEngineGithub {
   readonly pullRequests: MutableVersionPullRequest[] = [];
-  release: PublishedRelease | null = null;
+  readonly releases: PublishedRelease[] = [];
   private assets: Array<{ id: number; name: string }> = [];
 
   constructor(private readonly repository: string) {}
+
+  get release(): PublishedRelease | null {
+    return this.releases.at(-1) ?? null;
+  }
 
   async upsertVersionPullRequest(input: VersionPullRequestInput) {
     const existing = this.pullRequests.find((pullRequest) => !pullRequest.merged);
@@ -257,12 +317,14 @@ class FakeGithub implements ReleaseEngineGithub {
   }
 
   async findByTag(tag: string): Promise<PublishedRelease | null> {
-    return this.release?.tag === tag ? { ...this.release, assets: this.assets } : null;
+    const release = this.releases.find((candidate) => candidate.tag === tag);
+    return release === undefined ? null : { ...release, assets: this.assets };
   }
 
   async create(input: CreateReleaseInput): Promise<PublishedRelease> {
-    this.release = { id: 1, ...input, assets: [] };
-    return this.release;
+    const release = { id: this.releases.length + 1, ...input, assets: [] };
+    this.releases.push(release);
+    return release;
   }
 
   async uploadAsset(input: UploadReleaseAssetInput): Promise<void> {


### PR DESCRIPTION
Automated AFK landing for #3369. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3369

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788563363&installation_model_id=20659&pr_number=3421&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3421&signature=bc3cfcc1b7a009b9c1349f70551e7bbd444fe6fc6bbbc631d7c854aeb682c74b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->