### PR TITLE
chore: classify the release engine's root package.json read in the TOON allowlist (fixes red main)

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -221,6 +221,11 @@
       "id": "apps/release/src/version-surfaces.ts#json-parse-file-read#4e3250e520ef",
       "classification": "external",
       "reason": "workspace package.json manifests are ecosystem JSON; version derivation reads them as-is"
+    },
+    {
+      "id": "apps/release/src/release-engine.ts#json-parse-file-read#87169b2357b0",
+      "classification": "external",
+      "reason": "the repo-root package.json is ecosystem JSON; the release engine reads the current version off it"
     }
   ]
 }


### PR DESCRIPTION
Third occurrence of the same class today: a release-engine slice landed a `JSON.parse` of the repo-root `package.json` (`apps/release/src/release-engine.ts:299`) without an allowlist entry, and its own CI never ran the guard because cone narrowing skips the apps/dev invariant suite for an `apps/release`-only diff (same hole as #3409 and #3417).

Classified `external` — package.json is ecosystem JSON. Guard green locally (10/10). Every open PR's `test-shard (2)` is red until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788565013&installation_model_id=20659&pr_number=3424&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3424&signature=fa1c3e87f99cee507bc6124c67f3c12726478a8bc8beb7738af5230044ffb5ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->