### PR TITLE
chore: changeset for the daemon-lifecycle fixes and the Release-standard engine span

### DIFF
--- a/.changeset/daemon-lifecycle-and-release-engine.md
+++ b/.changeset/daemon-lifecycle-and-release-engine.md
@@ -1,0 +1,30 @@
+---
+"@reddb-io/dev": minor
+---
+
+Daemon lifecycle fixes and the complete Release-standard engine (ADR 0139).
+
+- `redskilled stop` now exits the process it reports stopping: the lease is
+  released with the socket, a successor binds without an operator SIGKILL, and
+  the `serve` exit boundary reads the sliced argv instead of walking
+  `process.argv`.
+- The daemon's user unit survives self-shutdown: operator-requested stop is the
+  only clean exit, so `Restart=on-failure` covers every self-recycle, and an
+  enabled-but-dead unit is now a provisioning finding instead of silence.
+- Queryable daemon log: every worker event carries a required `kind`
+  discriminator (with `event` as its legacy alias) plus admission, phase,
+  base-drift and heal columns, with documented `tq` recipes.
+- Fork grant end-to-end: the daemon owns the trunk fetch, the grant names the
+  fork SHA, an unreachable trunk remote refuses birth, and base movement is
+  stamped per live Worker on every surface.
+- Release-standard engine (ADR 0139), all slices: changeset queue parser and
+  status verb, version surfaces with drift refusal, release notes +
+  JSON-and-TOON release-manifest assets, idempotent tag + Release publication,
+  Version-PR maintainer with auto trigger, RC graduation, thin least-privilege
+  workflows, vendored single-file execution mode, and the `/red-setup` release
+  interview with the `release.*` config contract.
+- `/redskilled <issue>` debug dossier: a self-serve handoff file resolving a
+  worker by issue with fiche, event sequence, log excerpts and diagnosis.
+- Statusline repaint over the published brand tokens package, held by the
+  truecolor-extinction ratchet.
+- 4-way sharded `test` job in workspace CI.


### PR DESCRIPTION
Today's ~20 worker PRs landed with zero changesets on main, so the version train had nothing to open a version PR from — no release would ever carry the daemon stop/restart fixes, the fork grant, or the complete ADR 0139 Release-standard engine, and the release-gated Fallback-deletion ticket would stay parked forever.

One minor changeset summarizing the span. When it lands, the changesets action opens the `chore(release): version packages` PR; merging that tags and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788569935&installation_model_id=20659&pr_number=3426&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3426&signature=dd6f768fe3233bd31fb0a36c6311713883d7fbaff1871db2988358f3c0c4e8a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->