### PR TITLE
docs(dev): the question is one line, the evidence goes above the round

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,9 +18,14 @@ Upstream base: `mattpocock/skills@66898f60e8c744e269f8ce06c2b2b99ce7660d5f` (rev
     whose prerequisites are settled — and a question depending on one still open
     in this round waits for the next. That rule is what keeps a batch from
     asking the user to guess.
-  - Adopted upstream's scannable question format (`❓ **Q##** — **title**` +
-    `➡️` recommendation) and kept our enumerated `Branches:`, which upstream has
+  - Adopted upstream's scannable question format (`❓ **Q##**` + `➡️`
+    recommendation) and kept our enumerated `Branches:`, which upstream has
     no equivalent for and which gives the user a stable handle to answer with.
+  - **The question is one line.** A round is read by scanning, and a question
+    that swells into a paragraph stops being scannable — the reader loses which
+    line they are answering. Evidence is written once above the round, never
+    inside a question; a branch needing a sentence of explanation is evidence
+    in the wrong place.
   - Fact-finding is stated as the agent's job, with the non-blocking rule made
     explicit: a fact still being fetched is an unsettled prerequisite, so only
     the questions downstream of it wait. We keep read-only inline exploration

--- a/packaging/pi/dev/skills/engineering/start/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/start/SKILL.md
@@ -27,12 +27,18 @@ A round is as small as the tree makes it. One critical question that unblocks ev
 Each question is formatted like so — the emoji are load-bearing, because a round of five questions is read by scanning for them:
 
 ```
-❓ **Q##** — **<question title>**: <question body, may be several sentences>
+❓ **Q##** — <the question, ONE line, ending in a question mark>
 **Branches:** (a) <option A> · (b) <option B> · (c) <option C>
 ➡️ **(<letter>)** — <one-sentence reason>
 ```
 
-**Enumerate the branches whenever the decision space is finite.** They give the user a stable handle — "ok (b) but with X tweak" — and force the skill to make the choice space explicit instead of gesturing at it. Omit `Branches:` only when the question is genuinely open-ended; `➡️` then recommends in prose.
+**Three lines per question, and the question itself is one of them.** A round is read by scanning, and a question that swells into a paragraph stops being scannable — the reader loses which line they are answering. Keep the question to a single line that ends in a question mark.
+
+**Evidence goes above the round, never inside a question.** Whatever the user needs in order to answer — what you found in the code, the numbers, the trade-off you are weighing — belongs in prose *before* the first `❓`, written once for the whole round. A question is the ask alone.
+
+Separate consecutive questions with a blank line, so each `❓` starts its own visual block.
+
+**Enumerate the branches whenever the decision space is finite.** They give the user a stable handle — "ok (b) but with X tweak" — and force the skill to make the choice space explicit instead of gesturing at it. Keep each branch to a short phrase; a branch needing a sentence of explanation is evidence that belongs above the round. Omit `Branches:` only when the question is genuinely open-ended; `➡️` then recommends in prose.
 
 Close each round with a one-line invitation to answer, redirect, or push back.
 
@@ -55,7 +61,7 @@ The argument is optional. Treat it as the plan or context to grill.
 - **Prose** (short description) → no fetch, the prose is the plan.
 - **Empty argument** → open with the literal `Q01` as a one-question round:
 
-  > ❓ **Q01** — **What plan are we grilling?**: I need the material before the tree has a root.
+  > ❓ **Q01** — What plan are we grilling?
   > **Branches:** (a) paste it inline · (b) share a URL or file path · (c) describe it in a sentence
   > ➡️ **(a)** — inline context lets us start grilling immediately.
 
@@ -85,6 +91,7 @@ When the frontier is empty — or the user stops — run the shared end-of-sessi
 **Hard rules — do not break these:**
 
 - ❌ Do **not** ask a question whose answer depends on another question open in the same round — it belongs to the next round, once its prerequisite is settled.
+- ❌ Do **not** let a question run past one line. The evidence behind it goes above the round, where it is written once and read once.
 - ❌ Do **not** implement, write code, or run commands beyond read-only codebase exploration, except for the end-of-session doc-landing finalizer.
 - ❌ Do **not** summarise the user's answers back at them. They know what they said.
 - ❌ Do **not** propose a final plan, design doc, or Spec. This skill ends in shared understanding, not artefacts.

--- a/plugins/dev/skills/engineering/start/SKILL.md
+++ b/plugins/dev/skills/engineering/start/SKILL.md
@@ -27,12 +27,18 @@ A round is as small as the tree makes it. One critical question that unblocks ev
 Each question is formatted like so — the emoji are load-bearing, because a round of five questions is read by scanning for them:
 
 ```
-❓ **Q##** — **<question title>**: <question body, may be several sentences>
+❓ **Q##** — <the question, ONE line, ending in a question mark>
 **Branches:** (a) <option A> · (b) <option B> · (c) <option C>
 ➡️ **(<letter>)** — <one-sentence reason>
 ```
 
-**Enumerate the branches whenever the decision space is finite.** They give the user a stable handle — "ok (b) but with X tweak" — and force the skill to make the choice space explicit instead of gesturing at it. Omit `Branches:` only when the question is genuinely open-ended; `➡️` then recommends in prose.
+**Three lines per question, and the question itself is one of them.** A round is read by scanning, and a question that swells into a paragraph stops being scannable — the reader loses which line they are answering. Keep the question to a single line that ends in a question mark.
+
+**Evidence goes above the round, never inside a question.** Whatever the user needs in order to answer — what you found in the code, the numbers, the trade-off you are weighing — belongs in prose *before* the first `❓`, written once for the whole round. A question is the ask alone.
+
+Separate consecutive questions with a blank line, so each `❓` starts its own visual block.
+
+**Enumerate the branches whenever the decision space is finite.** They give the user a stable handle — "ok (b) but with X tweak" — and force the skill to make the choice space explicit instead of gesturing at it. Keep each branch to a short phrase; a branch needing a sentence of explanation is evidence that belongs above the round. Omit `Branches:` only when the question is genuinely open-ended; `➡️` then recommends in prose.
 
 Close each round with a one-line invitation to answer, redirect, or push back.
 
@@ -55,7 +61,7 @@ The argument is optional. Treat it as the plan or context to grill.
 - **Prose** (short description) → no fetch, the prose is the plan.
 - **Empty argument** → open with the literal `Q01` as a one-question round:
 
-  > ❓ **Q01** — **What plan are we grilling?**: I need the material before the tree has a root.
+  > ❓ **Q01** — What plan are we grilling?
   > **Branches:** (a) paste it inline · (b) share a URL or file path · (c) describe it in a sentence
   > ➡️ **(a)** — inline context lets us start grilling immediately.
 
@@ -85,6 +91,7 @@ When the frontier is empty — or the user stops — run the shared end-of-sessi
 **Hard rules — do not break these:**
 
 - ❌ Do **not** ask a question whose answer depends on another question open in the same round — it belongs to the next round, once its prerequisite is settled.
+- ❌ Do **not** let a question run past one line. The evidence behind it goes above the round, where it is written once and read once.
 - ❌ Do **not** implement, write code, or run commands beyond read-only codebase exploration, except for the end-of-session doc-landing finalizer.
 - ❌ Do **not** summarise the user's answers back at them. They know what they said.
 - ❌ Do **not** propose a final plan, design doc, or Spec. This skill ends in shared understanding, not artefacts.


### PR DESCRIPTION
Rounds fixed the turn cost but introduced a new one: a question grew a multi-sentence body, and a round of five became a wall. The reader loses which line they are answering — the exact confusion the round format exists to remove.

- **The question is one line**, ending in a question mark. Three lines per question total: the ask, `Branches:`, `➡️`.
- **Evidence goes above the round**, in prose, written once for the whole round — what was found in the code, the numbers, the trade-off being weighed. A question is the ask alone.
- **Branches are short phrases.** A branch needing a sentence of explanation is evidence sitting in the wrong place.
- Consecutive questions are separated by a blank line, so each `❓` starts its own visual block.
- New hard rule states it as a prohibition with its reason inline.

Follow-up to #3429, from using it. Repo invariants: 165/165 green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788609442&installation_model_id=20659&pr_number=3435&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3435&signature=8ef43548d2422f4ad2891b0671f2c222dad3c3cbfb9ec5691ee354e06689187e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->