### PR TITLE
chore: #3349 Trunk-freshness guard: tolerate dirty .red/ docs (CONTEXT.md, adr/**) like setup-owned paths

### DIFF
--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -23,8 +23,8 @@ import {
   describeCleanTreeRefusal,
   describeSetupDirtCollisionRefusal,
   describeSupersededSetupDirt,
-  describeToleratedSetupDirt,
-  isSetupOwnedDirtOnly,
+  describeToleratedDirt,
+  isToleratedDirtOnly,
   SUPERSEDED_SETUP_DIRT_LANE,
 } from "./setup-owned-dirt.js";
 
@@ -1668,6 +1668,7 @@ export type FastForwardLocalTargetRefusal =
   | "not-ancestor"
   | "superseded-commits"
   | "dirt-collision"
+  | "index-lock"
   | "supersede-failed"
   | "reconcile-failed"
   | "merge-failed";
@@ -1684,7 +1685,7 @@ export interface FastForwardLocalTargetGuardResult {
   readonly currentBranch?: string;
   readonly failed?: FastForwardLocalTargetRefusal;
   readonly failedCondition?: "on-trunk" | "clean-tree" | "fetch" | "ancestor" | "superseded-commits" | "dirt-collision" | "merge";
-  /** Setup-owned dirty paths the clean-tree condition tolerated (#3106). */
+  /** Reconciliation-owned dirty paths the clean-tree condition tolerated. */
   readonly toleratedDirt?: readonly string[];
   /** Tolerated dirt the incoming commits carry as tracked files, so the local
    * untracked copy is stale: moved aside before the merge, never merged over (#3155). */
@@ -1843,12 +1844,10 @@ export async function evaluateFastForwardLocalTarget(
     };
   }
   // 2. A dirty primary keeps pending WIP — never write over it (#1019). The one
-  // exception is dirt our OWN setup authored: `/red-setup` writes
-  // `.red/config.yaml`, `.red/.gitignore` and hook scripts it is forbidden to
-  // `git add`, so a fresh repo is dirty by contract and could never boot a
-  // Worker (#3106). Tolerating that named class costs nothing the guard was
-  // protecting — `merge --ff-only` still refuses on its own if the incoming
-  // commits would clobber one of those files.
+  // exceptions are named reconciliation-owned sets: output `/red-setup` leaves
+  // uncommitted (#3106), and docs `/start` holds dirty until ADR 0092 landing
+  // (#3349). Tolerating them costs nothing the guard protects because an
+  // incoming edit to the same path is classified as a real collision below.
   const status = await exec(["git", "-C", gitRepo, "status", "--porcelain"]);
   if (status.code !== 0) {
     return {
@@ -1873,7 +1872,7 @@ export async function evaluateFastForwardLocalTarget(
       evidence: describeCleanTreeRefusal(tree),
     };
   }
-  const toleratedDirt = isSetupOwnedDirtOnly(tree) ? describeToleratedSetupDirt(tree) : undefined;
+  const toleratedDirt = isToleratedDirtOnly(tree) ? describeToleratedDirt(tree) : undefined;
   // Refresh the remote ref so the ancestry test and the FF see the merge.
   const fetch = await exec(["git", "-C", gitRepo, "fetch", "--quiet", remote, target]);
   if (fetch.code !== 0) {
@@ -1907,10 +1906,10 @@ export async function evaluateFastForwardLocalTarget(
         target,
         remote,
         currentBranch,
-        toleratedDirt: tree.setupOwned,
+        toleratedDirt: tree.tolerated,
         failed: "dirty-tree",
         failedCondition: "clean-tree",
-        evidence: `condition failed: clean-tree (superseded-commit reconciliation requires no dirty paths; ${tree.setupOwned.join(", ")})`,
+        evidence: `condition failed: clean-tree (superseded-commit reconciliation requires no dirty paths; ${tree.tolerated.join(", ")})`,
       };
     }
     const classified = await classifySupersededCommits(exec, {
@@ -1949,10 +1948,10 @@ export async function evaluateFastForwardLocalTarget(
         target,
         remote,
         currentBranch,
-        toleratedDirt: tree.setupOwned,
+        toleratedDirt: tree.tolerated,
         failed: "dirt-collision",
         failedCondition: "dirt-collision",
-        evidence: `condition failed: dirt-collision (could not read the incoming path list for ${remoteRef} while ${tree.setupOwned.length} /red-setup file(s) are dirty)`,
+        evidence: `condition failed: dirt-collision (could not read the incoming path list for ${remoteRef} while ${tree.tolerated.length} tolerated path(s) are dirty)`,
       };
     }
     const collision = classifySetupDirtCollision(
@@ -1965,7 +1964,7 @@ export async function evaluateFastForwardLocalTarget(
         target,
         remote,
         currentBranch,
-        toleratedDirt: tree.setupOwned,
+        toleratedDirt: tree.tolerated,
         failed: "dirt-collision",
         failedCondition: "dirt-collision",
         evidence: describeSetupDirtCollisionRefusal(collision.conflicting, remoteRef),
@@ -1979,7 +1978,7 @@ export async function evaluateFastForwardLocalTarget(
     target,
     remote,
     currentBranch,
-    ...(toleratedDirt ? { toleratedDirt: tree.setupOwned } : {}),
+    ...(toleratedDirt ? { toleratedDirt: tree.tolerated } : {}),
     ...(supersededDirt.length > 0 ? { supersededDirt } : {}),
     ...(supersededCommits.length > 0 ? { supersededCommits } : {}),
     evidence: `guard passed: on-trunk clean-tree ${lineageEvidence}${toleratedDirt ? `; ${toleratedDirt}` : ""}${supersededNote ? `; ${supersededNote}` : ""}`,
@@ -2013,6 +2012,81 @@ async function supersedeSetupOwnedDirt(
   return { ok: true, evidence: "" };
 }
 
+interface IndexLockRetry {
+  readonly result: ExecResult;
+  readonly reclaimed: boolean;
+  readonly refusal?: string;
+}
+
+function failedOnIndexLock(result: ExecResult): boolean {
+  return result.code !== 0 && /(?:^|[/\\])index\.lock(?:['":\s]|$)/i.test(`${result.stderr}\n${result.stdout}`);
+}
+
+/**
+ * Retry one index-writing Git command after the only safe lock reclamation:
+ * the lock is zero bytes and `fuser` reports that no live process has it open.
+ * `fuser` is the kernel-backed ownership answer; an absent tool or ambiguous
+ * result refuses closed. A new Git process cannot race the unlink by adopting
+ * this existing lock — Git acquires it with exclusive creation.
+ */
+async function retryAfterOrphanedIndexLock(
+  exec: Exec,
+  gitRepo: string,
+  args: string[],
+): Promise<IndexLockRetry> {
+  const first = await exec(args);
+  if (!failedOnIndexLock(first)) return { result: first, reclaimed: false };
+
+  const lockPath = `${gitRepo}/.git/index.lock`;
+  const measured = await exec(["stat", "-c", "%s", lockPath]);
+  if (measured.code !== 0) {
+    // The owner may have completed between Git's refusal and inspection. With
+    // no lock left to reclaim, one bounded retry is safe and avoids a false halt.
+    return { result: await exec(args), reclaimed: false };
+  }
+  const size = measured.stdout.trim();
+  if (!/^\d+$/.test(size)) {
+    return {
+      result: first,
+      reclaimed: false,
+      refusal: "condition failed: index-lock (could not determine .git/index.lock size)",
+    };
+  }
+  if (size !== "0") {
+    return {
+      result: first,
+      reclaimed: false,
+      refusal: `condition failed: index-lock (non-empty .git/index.lock has ${size} byte(s))`,
+    };
+  }
+
+  const held = await exec(["fuser", "--silent", lockPath]);
+  if (held.code === 0) {
+    return {
+      result: first,
+      reclaimed: false,
+      refusal: "condition failed: index-lock (empty .git/index.lock is held by a live process)",
+    };
+  }
+  if (held.code !== 1) {
+    return {
+      result: first,
+      reclaimed: false,
+      refusal: "condition failed: index-lock (could not prove .git/index.lock is unheld)",
+    };
+  }
+
+  const removed = await exec(["rm", "--", lockPath]);
+  if (removed.code !== 0) {
+    return {
+      result: first,
+      reclaimed: false,
+      refusal: "condition failed: index-lock (could not reclaim empty unheld .git/index.lock)",
+    };
+  }
+  return { result: await exec(args), reclaimed: true };
+}
+
 export async function fastForwardLocalTarget(
   exec: Exec,
   input: { gitRepo: string; remote: string; target: string },
@@ -2038,8 +2112,22 @@ export async function fastForwardLocalTarget(
   // patch landed. The clean-tree + one-to-one patch proof above makes moving the
   // pointer to the fetched tip safe; the pair list remains in the receipt.
   if ((guard.supersededCommits?.length ?? 0) > 0) {
-    const reset = await exec(["git", "-C", input.gitRepo, "reset", "--hard", `${input.remote}/${input.target}`]);
-    if (reset.code !== 0) {
+    const reset = await retryAfterOrphanedIndexLock(
+      exec,
+      input.gitRepo,
+      ["git", "-C", input.gitRepo, "reset", "--hard", `${input.remote}/${input.target}`],
+    );
+    if (reset.refusal) {
+      return {
+        ...guard,
+        guard: "refused",
+        action: "noop",
+        failed: "index-lock",
+        failedCondition: "merge",
+        evidence: reset.refusal,
+      };
+    }
+    if (reset.result.code !== 0) {
       return {
         ...guard,
         guard: "refused",
@@ -2052,13 +2140,27 @@ export async function fastForwardLocalTarget(
     return {
       ...guard,
       action: "fast-forward",
-      evidence: `reconciled superseded commits and moved ${input.target} to ${input.remote}/${input.target}: ${describeSupersededCommits(guard.supersededCommits ?? [])}`,
+      evidence: `${reset.reclaimed ? "reclaimed empty unheld .git/index.lock; " : ""}reconciled superseded commits and moved ${input.target} to ${input.remote}/${input.target}: ${describeSupersededCommits(guard.supersededCommits ?? [])}`,
     };
   }
   // 4c. Advance the ordinary behind-only pointer. ff-only can only succeed as a
   // pure fast-forward.
-  const ff = await exec(["git", "-C", input.gitRepo, "merge", "--ff-only", `${input.remote}/${input.target}`]);
-  if (ff.code !== 0) {
+  const ff = await retryAfterOrphanedIndexLock(
+    exec,
+    input.gitRepo,
+    ["git", "-C", input.gitRepo, "merge", "--ff-only", `${input.remote}/${input.target}`],
+  );
+  if (ff.refusal) {
+    return {
+      ...guard,
+      guard: "refused",
+      action: "noop",
+      failed: "index-lock",
+      failedCondition: "merge",
+      evidence: ff.refusal,
+    };
+  }
+  if (ff.result.code !== 0) {
     return {
       ...guard,
       guard: "refused",
@@ -2068,7 +2170,11 @@ export async function fastForwardLocalTarget(
       evidence: `condition failed: merge (ff-only merge of ${input.remote}/${input.target} failed)`,
     };
   }
-  return { ...guard, action: "fast-forward", evidence: `fast-forwarded ${input.target} to ${input.remote}/${input.target}` };
+  return {
+    ...guard,
+    action: "fast-forward",
+    evidence: `${ff.reclaimed ? "reclaimed empty unheld .git/index.lock; " : ""}fast-forwarded ${input.target} to ${input.remote}/${input.target}`,
+  };
 }
 
 /**

--- a/apps/dev/src/core/setup-owned-dirt.ts
+++ b/apps/dev/src/core/setup-owned-dirt.ts
@@ -33,6 +33,10 @@ export const SETUP_OWNED_FILES: readonly string[] = [".red/config.yaml", ".red/.
 /** The trees `/red-setup` seeds scripts into, none of them `git add`ed (INTERVIEW.md hooks section). */
 export const SETUP_OWNED_PREFIXES: readonly string[] = [".red/hooks/"];
 
+/** Documentation `/start` edits inline and ADR 0092 lands as one session-owned set. */
+export const DOC_LANDING_FILES: readonly string[] = [".red/CONTEXT.md", ".red/CONTEXT-MAP.md"];
+export const DOC_LANDING_PREFIXES: readonly string[] = [".red/contexts/", ".red/adr/"];
+
 /** The one spelling of the repair, so the guard, the doctor and the skill agree. */
 export const SETUP_OWNED_DIRT_REMEDIATION =
   "commit the /red-setup-generated files (git add .red/config.yaml .red/.gitignore .red/hooks && git commit) or ignore them";
@@ -48,13 +52,17 @@ export interface DirtyPath {
   /** The two-character porcelain XY code (`" M"`, `"??"`, `"R "`, …). */
   readonly status: string;
   readonly setupOwned: boolean;
+  /** Safe for a pure fast-forward when the incoming commits do not touch it. */
+  readonly tolerated: boolean;
 }
 
 export interface DirtyTreeClassification {
   readonly dirty: readonly DirtyPath[];
   /** Dirty paths `/red-setup` wrote, in porcelain order. */
   readonly setupOwned: readonly string[];
-  /** Every other dirty path — the operator's own work, in porcelain order. */
+  /** Every path the trunk guard may preserve across a non-conflicting fast-forward. */
+  readonly tolerated: readonly string[];
+  /** Every non-tolerated dirty path — the operator's own work, in porcelain order. */
   readonly foreign: readonly string[];
 }
 
@@ -86,6 +94,17 @@ export function isSetupOwnedPath(path: string): boolean {
   return SETUP_OWNED_PREFIXES.some((prefix) => path.startsWith(prefix));
 }
 
+/** True for the exact doc set `/start` holds dirty until ADR 0092 landing. */
+export function isDocLandingPath(path: string): boolean {
+  if (DOC_LANDING_FILES.includes(path)) return true;
+  return DOC_LANDING_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+/** The complete named tolerance; everything outside it remains protected WIP. */
+export function isToleratedDirtyPath(path: string): boolean {
+  return isSetupOwnedPath(path) || isDocLandingPath(path);
+}
+
 /** Strip git's quoting from a porcelain path. Setup-owned paths are ASCII, so the
  * common escapes are enough — an exotic name simply classifies as foreign dirt. */
 function unquote(raw: string): string {
@@ -109,12 +128,18 @@ export function classifyDirtyTree(porcelain: string): DirtyTreeClassification {
     if (arrow !== -1) path = path.slice(arrow + 4);
     path = unquote(path.trim());
     if (path === "") continue;
-    dirty.push({ path, status, setupOwned: isSetupOwnedPath(path) });
+    dirty.push({
+      path,
+      status,
+      setupOwned: isSetupOwnedPath(path),
+      tolerated: isToleratedDirtyPath(path),
+    });
   }
   return {
     dirty,
     setupOwned: dirty.filter((entry) => entry.setupOwned).map((entry) => entry.path),
-    foreign: dirty.filter((entry) => !entry.setupOwned).map((entry) => entry.path),
+    tolerated: dirty.filter((entry) => entry.tolerated).map((entry) => entry.path),
+    foreign: dirty.filter((entry) => !entry.tolerated).map((entry) => entry.path),
   };
 }
 
@@ -129,6 +154,11 @@ export function renderDirtyPathList(paths: readonly string[], limit = EVIDENCE_P
 
 /** True when the whole tree's dirt is `/red-setup`'s own uncommitted output. */
 export function isSetupOwnedDirtOnly(tree: DirtyTreeClassification): boolean {
+  return tree.dirty.length > 0 && tree.dirty.every((entry) => entry.setupOwned);
+}
+
+/** True when every dirty path belongs to a reconciliation-owned tolerance. */
+export function isToleratedDirtOnly(tree: DirtyTreeClassification): boolean {
   return tree.dirty.length > 0 && tree.foreign.length === 0;
 }
 
@@ -146,6 +176,11 @@ export function describeCleanTreeRefusal(tree: DirtyTreeClassification): string 
 /** The evidence for a guard that PASSED over tolerated setup-owned dirt. */
 export function describeToleratedSetupDirt(tree: DirtyTreeClassification): string {
   return `tolerated ${tree.setupOwned.length} /red-setup-owned dirty path(s) (${renderDirtyPathList(tree.setupOwned)})`;
+}
+
+/** Evidence for the complete named class the trunk guard preserved. */
+export function describeToleratedDirt(tree: DirtyTreeClassification): string {
+  return `tolerated ${tree.tolerated.length} reconciliation-owned dirty path(s) (${renderDirtyPathList(tree.tolerated)})`;
 }
 
 /** The `.red/tmp/` lane a superseded setup-owned file is moved to, never deleted:
@@ -176,7 +211,7 @@ export function classifySetupDirtCollision(
   const superseded: string[] = [];
   const conflicting: string[] = [];
   for (const entry of tree.dirty) {
-    if (!entry.setupOwned || !incoming.has(entry.path)) continue;
+    if (!entry.tolerated || !incoming.has(entry.path)) continue;
     // `??` is git's untracked code; anything else means the path is tracked here.
     if (entry.status === "??") superseded.push(entry.path);
     else conflicting.push(entry.path);
@@ -198,7 +233,7 @@ export function describeSetupDirtCollisionRefusal(
   paths: readonly string[],
   ref: string,
 ): string {
-  return `condition failed: dirt-collision (${paths.length} locally-modified /red-setup file(s) also changed by ${ref}: ${renderDirtyPathList(paths)}) — commit or stash them, then the fast-forward can land`;
+  return `condition failed: dirt-collision (${paths.length} locally-modified tolerated path(s) also changed by ${ref}: ${renderDirtyPathList(paths)}) — commit or stash them, then the fast-forward can land`;
 }
 
 /**

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -404,6 +404,29 @@ describe("fastForwardLocalTarget (post-merge primary promotion, ADR 0083 §2 ame
     expect(joined(calls).some((x) => x.includes("merge --ff-only"))).toBe(true);
   });
 
+  it("fast-forwards when only the ADR 0092 documentation set is dirty (#3349)", async () => {
+    const { exec, calls } = fakeExec([
+      onTarget,
+      {
+        match: (a) => a.join(" ").includes("status --porcelain"),
+        result: {
+          stdout: " M .red/CONTEXT.md\n M .red/CONTEXT-MAP.md\n M .red/contexts/dev/CONTEXT.md\n?? .red/adr/0132-trunk.md\n",
+        },
+      },
+    ]);
+
+    const result = await fastForwardLocalTarget(exec, base);
+
+    expect(result.action).toBe("fast-forward");
+    expect(result.toleratedDirt).toEqual([
+      ".red/CONTEXT.md",
+      ".red/CONTEXT-MAP.md",
+      ".red/contexts/dev/CONTEXT.md",
+      ".red/adr/0132-trunk.md",
+    ]);
+    expect(joined(calls)).toContain("git -C /repo merge --ff-only origin/main");
+  });
+
   it("still refuses when setup-owned dirt sits beside the operator's own WIP (#3106)", async () => {
     const { exec, calls } = fakeExec([
       onTarget,
@@ -418,6 +441,88 @@ describe("fastForwardLocalTarget (post-merge primary promotion, ADR 0083 §2 ame
     // The refusal says which half our own tooling authored.
     expect(result.evidence).toContain("/red-setup");
     expect(joined(calls).some((x) => x.includes("merge --ff-only"))).toBe(false);
+  });
+
+  it("still refuses an ordinary source edit beside tolerated documentation dirt (#3349)", async () => {
+    const { exec, calls } = fakeExec([
+      onTarget,
+      {
+        match: (a) => a.join(" ").includes("status --porcelain"),
+        result: { stdout: " M .red/CONTEXT.md\n M apps/dev/src/x.ts\n" },
+      },
+    ]);
+
+    const result = await fastForwardLocalTarget(exec, base);
+
+    expect(result.action).toBe("noop");
+    expect(result.failedCondition).toBe("clean-tree");
+    expect(result.evidence).toContain("apps/dev/src/x.ts");
+    expect(joined(calls).some((x) => x.includes("merge --ff-only"))).toBe(false);
+  });
+
+  describe("orphaned primary index lock (#3349)", () => {
+    const lockFailure = { code: 128, stderr: "fatal: Unable to create '/repo/.git/index.lock': File exists.\n" };
+
+    it("reclaims an empty lock no live process holds, logs it in the receipt, and retries the fast-forward", async () => {
+      let mergeAttempts = 0;
+      const { exec, calls } = fakeExec([
+        onTarget,
+        {
+          match: (a) => a.join(" ").includes("merge --ff-only") && ++mergeAttempts === 1,
+          result: lockFailure,
+        },
+        { match: (a) => a[0] === "stat", result: { stdout: "0\n" } },
+        { match: (a) => a[0] === "fuser", result: { code: 1 } },
+      ]);
+
+      const result = await fastForwardLocalTarget(exec, base);
+
+      expect(result.action).toBe("fast-forward");
+      expect(result.evidence).toContain("reclaimed empty unheld .git/index.lock");
+      expect(joined(calls)).toContain("rm -- /repo/.git/index.lock");
+      expect(mergeAttempts).toBe(2);
+    });
+
+    it("refuses a non-empty lock without removing it or retrying", async () => {
+      let mergeAttempts = 0;
+      const { exec, calls } = fakeExec([
+        onTarget,
+        {
+          match: (a) => a.join(" ").includes("merge --ff-only") && ++mergeAttempts === 1,
+          result: lockFailure,
+        },
+        { match: (a) => a[0] === "stat", result: { stdout: "12\n" } },
+      ]);
+
+      const result = await fastForwardLocalTarget(exec, base);
+
+      expect(result.action).toBe("noop");
+      expect(result.failed).toBe("index-lock");
+      expect(result.evidence).toContain("non-empty .git/index.lock");
+      expect(joined(calls).some((x) => x.startsWith("rm "))).toBe(false);
+      expect(mergeAttempts).toBe(1);
+    });
+
+    it("refuses an empty lock held by a live process without removing it or retrying", async () => {
+      let mergeAttempts = 0;
+      const { exec, calls } = fakeExec([
+        onTarget,
+        {
+          match: (a) => a.join(" ").includes("merge --ff-only") && ++mergeAttempts === 1,
+          result: lockFailure,
+        },
+        { match: (a) => a[0] === "stat", result: { stdout: "0\n" } },
+        { match: (a) => a[0] === "fuser", result: { code: 0 } },
+      ]);
+
+      const result = await fastForwardLocalTarget(exec, base);
+
+      expect(result.action).toBe("noop");
+      expect(result.failed).toBe("index-lock");
+      expect(result.evidence).toContain("held by a live process");
+      expect(joined(calls).some((x) => x.startsWith("rm "))).toBe(false);
+      expect(mergeAttempts).toBe(1);
+    });
   });
 
   /**

--- a/apps/dev/tests/setup-owned-dirt.test.ts
+++ b/apps/dev/tests/setup-owned-dirt.test.ts
@@ -61,6 +61,35 @@ describe("classifyDirtyTree", () => {
     expect(tree.setupOwned).toEqual([]);
     expect(tree.foreign).toEqual([]);
   });
+
+  it("tolerates exactly the ADR 0092 documentation set without calling it setup-owned (#3349)", () => {
+    const tree = classifyDirtyTree(
+      " M .red/CONTEXT.md\n M .red/CONTEXT-MAP.md\n M .red/contexts/dev/CONTEXT.md\n?? .red/adr/0132-trunk.md\n M apps/dev/src/x.ts\n",
+    );
+
+    expect(tree.tolerated).toEqual([
+      ".red/CONTEXT.md",
+      ".red/CONTEXT-MAP.md",
+      ".red/contexts/dev/CONTEXT.md",
+      ".red/adr/0132-trunk.md",
+    ]);
+    expect(tree.setupOwned).toEqual([]);
+    expect(tree.foreign).toEqual(["apps/dev/src/x.ts"]);
+  });
+
+  it("does not dissolve the guard for paths merely adjacent to the documentation set (#3349)", () => {
+    const tree = classifyDirtyTree(
+      " M .red/CONTEXT.md.bak\n M .red/contexts-old/x.md\n M .red/adr-old/0132.md\n M apps/dev/src/x.ts\n",
+    );
+
+    expect(tree.tolerated).toEqual([]);
+    expect(tree.foreign).toEqual([
+      ".red/CONTEXT.md.bak",
+      ".red/contexts-old/x.md",
+      ".red/adr-old/0132.md",
+      "apps/dev/src/x.ts",
+    ]);
+  });
 });
 
 describe("describeCleanTreeRefusal", () => {


### PR DESCRIPTION
Automated AFK landing for #3349. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3349

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788610105&installation_model_id=20659&pr_number=3437&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3437&signature=6fb23630835c3b0acc28e4e9ad2491c48937638a834ffa24f685c1222a2d57be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->