### PR TITLE
docs(dev): one line per thing to read — each branch gets its own line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,11 +21,16 @@ Upstream base: `mattpocock/skills@66898f60e8c744e269f8ce06c2b2b99ce7660d5f` (rev
   - Adopted upstream's scannable question format (`❓ **Q##**` + `➡️`
     recommendation) and kept our enumerated `Branches:`, which upstream has
     no equivalent for and which gives the user a stable handle to answer with.
-  - **The question is one line.** A round is read by scanning, and a question
-    that swells into a paragraph stops being scannable — the reader loses which
-    line they are answering. Evidence is written once above the round, never
-    inside a question; a branch needing a sentence of explanation is evidence
-    in the wrong place.
+  - **One line per thing to read.** A round is read by scanning, and both
+    failures break the scan: a question that swells into a paragraph loses the
+    reader's place, and branches run together on one line make the reader parse
+    separators to find the option they want. The question is one line ending in
+    a question mark; each branch is its own indented line. Evidence is written
+    once above the round, never inside a question; a branch needing a sentence
+    of explanation is evidence in the wrong place.
+  - Wiki integration moved to the end of `<supporting-info>` and retitled
+    "if enabled by Memory plugin" — it is the one section that depends on
+    another plugin being on, so it reads last rather than first.
   - Fact-finding is stated as the agent's job, with the non-blocking rule made
     explicit: a fact still being fetched is an unsettled prerequisite, so only
     the questions downstream of it wait. We keep read-only inline exploration

--- a/packaging/pi/dev/skills/engineering/start/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/start/SKILL.md
@@ -28,11 +28,14 @@ Each question is formatted like so — the emoji are load-bearing, because a rou
 
 ```
 ❓ **Q##** — <the question, ONE line, ending in a question mark>
-**Branches:** (a) <option A> · (b) <option B> · (c) <option C>
+**Branches:**
+  (a) <option A>
+  (b) <option B>
+  (c) <option C>
 ➡️ **(<letter>)** — <one-sentence reason>
 ```
 
-**Three lines per question, and the question itself is one of them.** A round is read by scanning, and a question that swells into a paragraph stops being scannable — the reader loses which line they are answering. Keep the question to a single line that ends in a question mark.
+**One line per thing to read: the question is a line, and each branch is a line of its own.** A round is read by scanning, and both failures break the scan — a question that swells into a paragraph loses the reader's place, and branches run together on one line make the reader parse separators to find the option they want. Keep the question to a single line that ends in a question mark, and put every branch on its own indented line.
 
 **Evidence goes above the round, never inside a question.** Whatever the user needs in order to answer — what you found in the code, the numbers, the trade-off you are weighing — belongs in prose *before* the first `❓`, written once for the whole round. A question is the ask alone.
 
@@ -62,7 +65,10 @@ The argument is optional. Treat it as the plan or context to grill.
 - **Empty argument** → open with the literal `Q01` as a one-question round:
 
   > ❓ **Q01** — What plan are we grilling?
-  > **Branches:** (a) paste it inline · (b) share a URL or file path · (c) describe it in a sentence
+  > **Branches:**
+  >   (a) paste it inline
+  >   (b) share a URL or file path
+  >   (c) describe it in a sentence
   > ➡️ **(a)** — inline context lets us start grilling immediately.
 
 After successful ingestion, emit a **single-line receipt** then open the first round:
@@ -108,19 +114,6 @@ When the frontier is empty — or the user stops — run the shared end-of-sessi
 </what-to-do>
 
 <supporting-info>
-
-## Wiki integration
-
-External references (URL, PDF, md/txt) flow through the `/wiki` skill so every fetched source is cached at `.red/wiki/raw/<slug>.md` and reusable across sessions and other skills (`/diagnose`, `/afk`, `/tdd`).
-
-Behaviour summary (full contract in [`/wiki`](../../../../memory/skills/core/wiki/SKILL.md)):
-
-- URL → `WebFetch` → `.red/wiki/raw/<slug>.md` with YAML header (`url`, `fetched`, `title`).
-- Local PDF → `pdftotext` → `.red/wiki/raw/<slug>.txt`, original kept alongside.
-- Local md/txt → copied to `.red/wiki/raw/<slug>.md` if not already there.
-- Every ingest is logged at `.red/wiki/log.md`.
-
-When `.red/wiki/` is missing, `/start` prompts once to run `/wiki-init`. Decline path: plain `WebFetch`/`Read` into context, no caching, receipt marked `(not cached)`.
 
 ## Domain awareness
 
@@ -196,5 +189,18 @@ Only offer to create an ADR when all three are true:
 3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
 
 If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+## Wiki integration (if enabled by Memory plugin)
+
+External references (URL, PDF, md/txt) flow through the `/wiki` skill so every fetched source is cached at `.red/wiki/raw/<slug>.md` and reusable across sessions and other skills (`/diagnose`, `/afk`, `/tdd`).
+
+Behaviour summary (full contract in [`/wiki`](../../../../memory/skills/core/wiki/SKILL.md)):
+
+- URL → `WebFetch` → `.red/wiki/raw/<slug>.md` with YAML header (`url`, `fetched`, `title`).
+- Local PDF → `pdftotext` → `.red/wiki/raw/<slug>.txt`, original kept alongside.
+- Local md/txt → copied to `.red/wiki/raw/<slug>.md` if not already there.
+- Every ingest is logged at `.red/wiki/log.md`.
+
+When `.red/wiki/` is missing, `/start` prompts once to run `/wiki-init`. Decline path: plain `WebFetch`/`Read` into context, no caching, receipt marked `(not cached)`.
 
 </supporting-info>

--- a/plugins/dev/skills/engineering/start/SKILL.md
+++ b/plugins/dev/skills/engineering/start/SKILL.md
@@ -28,11 +28,14 @@ Each question is formatted like so — the emoji are load-bearing, because a rou
 
 ```
 ❓ **Q##** — <the question, ONE line, ending in a question mark>
-**Branches:** (a) <option A> · (b) <option B> · (c) <option C>
+**Branches:**
+  (a) <option A>
+  (b) <option B>
+  (c) <option C>
 ➡️ **(<letter>)** — <one-sentence reason>
 ```
 
-**Three lines per question, and the question itself is one of them.** A round is read by scanning, and a question that swells into a paragraph stops being scannable — the reader loses which line they are answering. Keep the question to a single line that ends in a question mark.
+**One line per thing to read: the question is a line, and each branch is a line of its own.** A round is read by scanning, and both failures break the scan — a question that swells into a paragraph loses the reader's place, and branches run together on one line make the reader parse separators to find the option they want. Keep the question to a single line that ends in a question mark, and put every branch on its own indented line.
 
 **Evidence goes above the round, never inside a question.** Whatever the user needs in order to answer — what you found in the code, the numbers, the trade-off you are weighing — belongs in prose *before* the first `❓`, written once for the whole round. A question is the ask alone.
 
@@ -62,7 +65,10 @@ The argument is optional. Treat it as the plan or context to grill.
 - **Empty argument** → open with the literal `Q01` as a one-question round:
 
   > ❓ **Q01** — What plan are we grilling?
-  > **Branches:** (a) paste it inline · (b) share a URL or file path · (c) describe it in a sentence
+  > **Branches:**
+  >   (a) paste it inline
+  >   (b) share a URL or file path
+  >   (c) describe it in a sentence
   > ➡️ **(a)** — inline context lets us start grilling immediately.
 
 After successful ingestion, emit a **single-line receipt** then open the first round:
@@ -108,19 +114,6 @@ When the frontier is empty — or the user stops — run the shared end-of-sessi
 </what-to-do>
 
 <supporting-info>
-
-## Wiki integration
-
-External references (URL, PDF, md/txt) flow through the `/wiki` skill so every fetched source is cached at `.red/wiki/raw/<slug>.md` and reusable across sessions and other skills (`/diagnose`, `/afk`, `/tdd`).
-
-Behaviour summary (full contract in [`/wiki`](../../../../memory/skills/core/wiki/SKILL.md)):
-
-- URL → `WebFetch` → `.red/wiki/raw/<slug>.md` with YAML header (`url`, `fetched`, `title`).
-- Local PDF → `pdftotext` → `.red/wiki/raw/<slug>.txt`, original kept alongside.
-- Local md/txt → copied to `.red/wiki/raw/<slug>.md` if not already there.
-- Every ingest is logged at `.red/wiki/log.md`.
-
-When `.red/wiki/` is missing, `/start` prompts once to run `/wiki-init`. Decline path: plain `WebFetch`/`Read` into context, no caching, receipt marked `(not cached)`.
 
 ## Domain awareness
 
@@ -196,5 +189,18 @@ Only offer to create an ADR when all three are true:
 3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
 
 If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+## Wiki integration (if enabled by Memory plugin)
+
+External references (URL, PDF, md/txt) flow through the `/wiki` skill so every fetched source is cached at `.red/wiki/raw/<slug>.md` and reusable across sessions and other skills (`/diagnose`, `/afk`, `/tdd`).
+
+Behaviour summary (full contract in [`/wiki`](../../../../memory/skills/core/wiki/SKILL.md)):
+
+- URL → `WebFetch` → `.red/wiki/raw/<slug>.md` with YAML header (`url`, `fetched`, `title`).
+- Local PDF → `pdftotext` → `.red/wiki/raw/<slug>.txt`, original kept alongside.
+- Local md/txt → copied to `.red/wiki/raw/<slug>.md` if not already there.
+- Every ingest is logged at `.red/wiki/log.md`.
+
+When `.red/wiki/` is missing, `/start` prompts once to run `/wiki-init`. Decline path: plain `WebFetch`/`Read` into context, no caching, receipt marked `(not cached)`.
 
 </supporting-info>


### PR DESCRIPTION
The maintainer's own edit to `/start`, carried to `main`.

Putting the question on one line fixed half the scan. Branches still ran together behind `·` separators, so finding the option you wanted meant parsing punctuation. **Each branch is now its own indented line.**

```
❓ **Q##** — <the question, ONE line, ending in a question mark>
**Branches:**
  (a) <option A>
  (b) <option B>
  (c) <option C>
➡️ **(<letter>)** — <one-sentence reason>
```

**Wiki integration** moves to the end of `<supporting-info>` and names its precondition in the heading — *(if enabled by Memory plugin)*. It is the one section gated on another plugin being on, so it reads last rather than first.

Two consistency repairs on top of the edit:

- The prose still claimed **"three lines per question"**, contradicting its own example. It now states the rule the example shows.
- The boot `Q01` example still used the inline `·` form. An example in the old form teaches the old form, so it moved to the new one.

Pi mirror regenerated. Invariants green, `agent metadata ok`, `install metadata ok`.

**Not carried:** the primary checkout also has `CHANGES.md` deleted. That looked unrelated to this edit and the house rules require it, so I left it out rather than land a deletion by accident — say the word if it was deliberate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788610399&installation_model_id=20659&pr_number=3438&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3438&signature=bb7f250a60bc6c2619fddbf8c943d813596acf96c09d7cdc74835c792076e94e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->