### PR TITLE
docs(dev): whitespace separates the ask, the options and the recommendation

### DIFF
--- a/packaging/pi/dev/skills/engineering/start/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/start/SKILL.md
@@ -28,14 +28,18 @@ Each question is formatted like so — the emoji are load-bearing, because a rou
 
 ```
 ❓ **Q##** — <the question, ONE line, ending in a question mark>
+
 **Branches:**
   (a) <option A>
   (b) <option B>
   (c) <option C>
+
 ➡️ **(<letter>)** — <one-sentence reason>
 ```
 
 **One line per thing to read: the question is a line, and each branch is a line of its own.** A round is read by scanning, and both failures break the scan — a question that swells into a paragraph loses the reader's place, and branches run together on one line make the reader parse separators to find the option they want. Keep the question to a single line that ends in a question mark, and put every branch on its own indented line.
+
+**Blank lines around the branch block.** The ask, the options and the recommendation are three things the eye lands on separately, so let whitespace separate them rather than making the reader find the boundary.
 
 **Evidence goes above the round, never inside a question.** Whatever the user needs in order to answer — what you found in the code, the numbers, the trade-off you are weighing — belongs in prose *before* the first `❓`, written once for the whole round. A question is the ask alone.
 
@@ -65,10 +69,12 @@ The argument is optional. Treat it as the plan or context to grill.
 - **Empty argument** → open with the literal `Q01` as a one-question round:
 
   > ❓ **Q01** — What plan are we grilling?
+  >
   > **Branches:**
   >   (a) paste it inline
   >   (b) share a URL or file path
   >   (c) describe it in a sentence
+  >
   > ➡️ **(a)** — inline context lets us start grilling immediately.
 
 After successful ingestion, emit a **single-line receipt** then open the first round:

--- a/plugins/dev/skills/engineering/start/SKILL.md
+++ b/plugins/dev/skills/engineering/start/SKILL.md
@@ -28,14 +28,18 @@ Each question is formatted like so — the emoji are load-bearing, because a rou
 
 ```
 ❓ **Q##** — <the question, ONE line, ending in a question mark>
+
 **Branches:**
   (a) <option A>
   (b) <option B>
   (c) <option C>
+
 ➡️ **(<letter>)** — <one-sentence reason>
 ```
 
 **One line per thing to read: the question is a line, and each branch is a line of its own.** A round is read by scanning, and both failures break the scan — a question that swells into a paragraph loses the reader's place, and branches run together on one line make the reader parse separators to find the option they want. Keep the question to a single line that ends in a question mark, and put every branch on its own indented line.
+
+**Blank lines around the branch block.** The ask, the options and the recommendation are three things the eye lands on separately, so let whitespace separate them rather than making the reader find the boundary.
 
 **Evidence goes above the round, never inside a question.** Whatever the user needs in order to answer — what you found in the code, the numbers, the trade-off you are weighing — belongs in prose *before* the first `❓`, written once for the whole round. A question is the ask alone.
 
@@ -65,10 +69,12 @@ The argument is optional. Treat it as the plan or context to grill.
 - **Empty argument** → open with the literal `Q01` as a one-question round:
 
   > ❓ **Q01** — What plan are we grilling?
+  >
   > **Branches:**
   >   (a) paste it inline
   >   (b) share a URL or file path
   >   (c) describe it in a sentence
+  >
   > ➡️ **(a)** — inline context lets us start grilling immediately.
 
 After successful ingestion, emit a **single-line receipt** then open the first round:


### PR DESCRIPTION
The maintainer's edit, carried to `main`.

The ask, the branch block and the recommendation are three things the eye lands on separately. With no blank line between them the reader has to find the boundary — the last remaining scan cost after each branch got its own line in #3438.

```
❓ **Q##** — <the question, ONE line, ending in a question mark>

**Branches:**
  (a) <option A>
  (b) <option B>
  (c) <option C>

➡️ **(<letter>)** — <one-sentence reason>
```

The boot `Q01` example takes the same spacing, because an example in the old shape teaches the old shape. The rule is stated so it survives the next edit.

**Not carried:** the working copy this came from predates #3438, so landing it verbatim would have reverted two consistency fixes already on `main` — the prose back to "three lines per question" (which its own 7-line example contradicts) and the boot example back to the inline `·` form. Only the new spacing is in this PR.

`CHANGES.md` is deleted in the primary checkout again; left out again for the same reason as last time.

Pi mirror regenerated. Invariants green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788614720&installation_model_id=20659&pr_number=3441&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3441&signature=70bfed2780084212dde8e0a808d2632d8165f6972aa44005a93c40543f868051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->