### PR TITLE
docs(dev): the ask and its options are one block, the recommendation stands apart

### DIFF
--- a/packaging/pi/dev/skills/engineering/start/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/start/SKILL.md
@@ -28,18 +28,17 @@ Each question is formatted like so — the emoji are load-bearing, because a rou
 
 ```
 ❓ **Q##** — <the question, ONE line, ending in a question mark>
-
 **Branches:**
   (a) <option A>
   (b) <option B>
   (c) <option C>
 
-➡️ **(<letter>)** — <one-sentence reason>
+➡️ **(<letter>)**: <one-sentence reason>
 ```
 
 **One line per thing to read: the question is a line, and each branch is a line of its own.** A round is read by scanning, and both failures break the scan — a question that swells into a paragraph loses the reader's place, and branches run together on one line make the reader parse separators to find the option they want. Keep the question to a single line that ends in a question mark, and put every branch on its own indented line.
 
-**Blank lines around the branch block.** The ask, the options and the recommendation are three things the eye lands on separately, so let whitespace separate them rather than making the reader find the boundary.
+**The ask and its options are one block; the recommendation stands apart.** The branch list is part of the question — it is what the question offers — so it sits directly under it with no blank line. The recommendation is a separate act, so a blank line separates it, and a colon rather than a dash marks where the reason begins.
 
 **Evidence goes above the round, never inside a question.** Whatever the user needs in order to answer — what you found in the code, the numbers, the trade-off you are weighing — belongs in prose *before* the first `❓`, written once for the whole round. A question is the ask alone.
 
@@ -69,13 +68,12 @@ The argument is optional. Treat it as the plan or context to grill.
 - **Empty argument** → open with the literal `Q01` as a one-question round:
 
   > ❓ **Q01** — What plan are we grilling?
-  >
   > **Branches:**
   >   (a) paste it inline
   >   (b) share a URL or file path
   >   (c) describe it in a sentence
   >
-  > ➡️ **(a)** — inline context lets us start grilling immediately.
+  > ➡️ **(a)**: inline context lets us start grilling immediately.
 
 After successful ingestion, emit a **single-line receipt** then open the first round:
 

--- a/plugins/dev/skills/engineering/start/SKILL.md
+++ b/plugins/dev/skills/engineering/start/SKILL.md
@@ -28,18 +28,17 @@ Each question is formatted like so — the emoji are load-bearing, because a rou
 
 ```
 ❓ **Q##** — <the question, ONE line, ending in a question mark>
-
 **Branches:**
   (a) <option A>
   (b) <option B>
   (c) <option C>
 
-➡️ **(<letter>)** — <one-sentence reason>
+➡️ **(<letter>)**: <one-sentence reason>
 ```
 
 **One line per thing to read: the question is a line, and each branch is a line of its own.** A round is read by scanning, and both failures break the scan — a question that swells into a paragraph loses the reader's place, and branches run together on one line make the reader parse separators to find the option they want. Keep the question to a single line that ends in a question mark, and put every branch on its own indented line.
 
-**Blank lines around the branch block.** The ask, the options and the recommendation are three things the eye lands on separately, so let whitespace separate them rather than making the reader find the boundary.
+**The ask and its options are one block; the recommendation stands apart.** The branch list is part of the question — it is what the question offers — so it sits directly under it with no blank line. The recommendation is a separate act, so a blank line separates it, and a colon rather than a dash marks where the reason begins.
 
 **Evidence goes above the round, never inside a question.** Whatever the user needs in order to answer — what you found in the code, the numbers, the trade-off you are weighing — belongs in prose *before* the first `❓`, written once for the whole round. A question is the ask alone.
 
@@ -69,13 +68,12 @@ The argument is optional. Treat it as the plan or context to grill.
 - **Empty argument** → open with the literal `Q01` as a one-question round:
 
   > ❓ **Q01** — What plan are we grilling?
-  >
   > **Branches:**
   >   (a) paste it inline
   >   (b) share a URL or file path
   >   (c) describe it in a sentence
   >
-  > ➡️ **(a)** — inline context lets us start grilling immediately.
+  > ➡️ **(a)**: inline context lets us start grilling immediately.
 
 After successful ingestion, emit a **single-line receipt** then open the first round:
 


### PR DESCRIPTION
The maintainer's edit, carried to `main`.

The blank line was in the wrong place. The branch list is part of the question — it is what the question *offers* — so it belongs directly under it. The recommendation is a separate act, so that is where the separation goes. A colon rather than a dash marks where the reason begins.

```
❓ **Q##** — <the question, ONE line, ending in a question mark>
**Branches:**
  (a) <option A>
  (b) <option B>
  (c) <option C>

➡️ **(<letter>)**: <one-sentence reason>
```

The prose now states this arrangement, and the boot `Q01` example takes the same shape — an example in the old shape teaches the old shape.

**Not carried:** the working copy this came from predates #3438 and #3441, so landing it verbatim would have reverted the prose to "three lines per question" (contradicted by its own 7-line example) and the boot example to the inline `·` form. Only the new arrangement is here.

One judgement call: the edit had a leading space before `➡️` inside the fenced template. Left out — inside a code fence it is literal, so it would teach a leading space on every recommendation. Say the word if it was deliberate.

Pi mirror regenerated. Invariants green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788616471&installation_model_id=20659&pr_number=3442&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3442&signature=b5cd2e78a66c6a11f6206427cf63aa92b48d9edc3d3c2c6b6096a14ac710be44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->