### PR TITLE
fix(config): the regeneration trigger watches the source, not only the mirror

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -21,6 +21,11 @@ plugins:
             - plugins/*/.claude-plugin/plugin.json
             - plugins/*/.codex-plugin/plugin.json
             - plugins/*/.gemini-plugin/plugin.json
+            # The SOURCE the mirror is generated FROM, not just the mirror. A
+            # branch that adds or edits a skill touched none of the paths above,
+            # so the regeneration moment never fired and the staleness surfaced
+            # in CI instead — four times over (#3403, #3419, #3436, #3445).
+            - plugins/*/skills/**
             - packaging/pi/**
           command: pnpm generate-manifests && pnpm pi:packages:build
         post_done:


### PR DESCRIPTION
**Four branches failed CI today with the identical signature**, and the cause was one missing line.

`plugins.dev.afk.validation.generated.paths` listed the manifests and `packaging/pi/**` — the mirror — but never `plugins/*/skills/**`, the source the mirror is generated *from*. So a branch that adds or edits a skill touches nothing the trigger watches, the regeneration moment never fires, and the staleness surfaces later in CI as two red checks (`validate-marketplace` and the typecheck job's generated-package step) whose message names neither the branch's mistake nor its cure.

Each one cost a diagnosis and a hand-run of `pnpm pi:packages:build`: #3403, #3419, #3436, #3445.

The fix is to watch what the generator reads, not only what it writes.

Invariants green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788622107&installation_model_id=20659&pr_number=3447&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3447&signature=747bffd7b29b43ff5a4fdafaada6983c6cf4cc3e5fd3c32cc7f233fe03fdd0b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->