### PR TITLE
fix(release): the pin names a build that contains the binary it calls

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Maintain Version PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npx -y -p @reddb-io/red-skills@3.8.0 red-skills-release run
+        run: npx -y -p @reddb-io/red-skills@3.9.0 red-skills-release run
 
   publish-release:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'red-release/version-pr'
@@ -45,4 +45,4 @@ jobs:
       - name: Publish Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npx -y -p @reddb-io/red-skills@3.8.0 red-skills-release run
+        run: npx -y -p @reddb-io/red-skills@3.9.0 red-skills-release run

--- a/apps/dev/tests/writing-for-agents-docs.test.ts
+++ b/apps/dev/tests/writing-for-agents-docs.test.ts
@@ -62,7 +62,10 @@ describe("writing-for-agents docs contract (#3433)", () => {
     // survive in NO tracked file — `git grep` exiting 1 is the pass.
     let hits: string[] = [];
     try {
-      hits = execFileSync("git", ["grep", "-l", PREVIOUS_NAME, "--", "."], {
+      // `.changeset/` is exempt: a release note explaining a rename must NAME
+      // what was renamed. That is a record of history, like an ADR describing a
+      // removed surface — not a pointer some reader could still follow.
+      hits = execFileSync("git", ["grep", "-l", PREVIOUS_NAME, "--", ".", ":(exclude).changeset"], {
         cwd: ROOT,
         encoding: "utf8",
       })

--- a/apps/release/src/workflow-generator.ts
+++ b/apps/release/src/workflow-generator.ts
@@ -130,9 +130,30 @@ function prepareVendoredBundle(
   return { path, source, changed };
 }
 
+/**
+ * The first published version that ships the `red-skills-release` binary.
+ *
+ * The generator stamps the version the repo is AT, which is one version behind
+ * the feature the first time it runs: a repo on 3.8.0 generated a workflow
+ * invoking a binary 3.8.0 does not contain, and the release died with
+ * `red-skills-release: not found`. Same shape as the `/red-setup` dead end the
+ * house invariants record — an instruction pointing at its own precondition.
+ */
+const RELEASE_BINARY_SINCE = "3.9.0";
+
 function pinnedInvocation(engineVersion: string): string {
-  const version = normalizedEngineVersion(engineVersion);
+  const version = atLeast(normalizedEngineVersion(engineVersion), RELEASE_BINARY_SINCE);
   return `npx -y -p @reddb-io/red-skills@${version} red-skills-release run`;
+}
+
+/** The later of two `x.y.z` versions, so a pin can never name a build without the binary. */
+function atLeast(version: string, floor: string): string {
+  const parts = (value: string): number[] => value.split(".").map(Number);
+  const [a, b] = [parts(version), parts(floor)];
+  for (let i = 0; i < 3; i += 1) {
+    if ((a[i] ?? 0) !== (b[i] ?? 0)) return (a[i] ?? 0) > (b[i] ?? 0) ? version : floor;
+  }
+  return version;
 }
 
 function normalizedEngineVersion(value: string): string {

--- a/apps/release/tests/fixtures/workflows/auto.yml
+++ b/apps/release/tests/fixtures/workflows/auto.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Publish Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npx -y -p @reddb-io/red-skills@3.8.0 red-skills-release run
+        run: npx -y -p @reddb-io/red-skills@3.9.0 red-skills-release run

--- a/apps/release/tests/fixtures/workflows/version-pr.yml
+++ b/apps/release/tests/fixtures/workflows/version-pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Maintain Version PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npx -y -p @reddb-io/red-skills@3.8.0 red-skills-release run
+        run: npx -y -p @reddb-io/red-skills@3.9.0 red-skills-release run
 
   publish-release:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'red-release/version-pr'
@@ -45,4 +45,4 @@ jobs:
       - name: Publish Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npx -y -p @reddb-io/red-skills@3.8.0 red-skills-release run
+        run: npx -y -p @reddb-io/red-skills@3.9.0 red-skills-release run

--- a/apps/release/tests/workflow-generator.test.ts
+++ b/apps/release/tests/workflow-generator.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../src/workflow-generator.js";
 
 const FIXTURES = join(import.meta.dirname, "fixtures", "workflows");
-const ENGINE_VERSION = "3.8.0";
+const ENGINE_VERSION = "3.9.0";
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
@@ -93,20 +93,33 @@ describe("release workflow generator", () => {
     expect(source).not.toContain("npx");
   });
 
+  it("floors the pin at the version that introduced the binary", () => {
+    // The generator stamps the version the repo is AT, which is one behind the
+    // feature the first time it runs: a repo on 3.8.0 generated a workflow
+    // invoking `red-skills-release`, a binary 3.8.0 does not contain, and the
+    // release died with `red-skills-release: not found`. An instruction may not
+    // point at its own precondition.
+    const repository = fixtureRepository("version-pr", "pinned");
+    generateReleaseWorkflows({ repoRoot: repository, engineVersion: "3.8.0" });
+    const text = readFileSync(join(repository, RELEASE_WORKFLOW_PATH), "utf8");
+    expect(text).toContain("@reddb-io/red-skills@3.9.0 red-skills-release run");
+    expect(text).not.toContain("@reddb-io/red-skills@3.8.0");
+  });
+
   it("reads the trigger from config, refreshes only the pin, and then becomes a no-op", () => {
     const repository = fixtureRepository("version-pr", "pinned");
 
-    const first = generateReleaseWorkflows({ repoRoot: repository, engineVersion: "3.8.0" });
+    const first = generateReleaseWorkflows({ repoRoot: repository, engineVersion: "3.9.0" });
     const firstBytes = readFileSync(join(repository, RELEASE_WORKFLOW_PATH), "utf8");
-    expect(first).toMatchObject({ changed: true, trigger: "version-pr", engineVersion: "3.8.0" });
+    expect(first).toMatchObject({ changed: true, trigger: "version-pr", engineVersion: "3.9.0" });
 
-    const refreshed = generateReleaseWorkflows({ repoRoot: repository, engineVersion: "3.8.1" });
+    const refreshed = generateReleaseWorkflows({ repoRoot: repository, engineVersion: "3.9.1" });
     const refreshedBytes = readFileSync(join(repository, RELEASE_WORKFLOW_PATH), "utf8");
-    expect(refreshed).toMatchObject({ changed: true, trigger: "version-pr", engineVersion: "3.8.1" });
-    expect(refreshedBytes).toBe(firstBytes.replaceAll("@3.8.0", "@3.8.1"));
+    expect(refreshed).toMatchObject({ changed: true, trigger: "version-pr", engineVersion: "3.9.1" });
+    expect(refreshedBytes).toBe(firstBytes.replaceAll("@3.9.0", "@3.9.1"));
 
-    const repeated = generateReleaseWorkflows({ repoRoot: repository, engineVersion: "3.8.1" });
-    expect(repeated).toMatchObject({ changed: false, trigger: "version-pr", engineVersion: "3.8.1" });
+    const repeated = generateReleaseWorkflows({ repoRoot: repository, engineVersion: "3.9.1" });
+    expect(repeated).toMatchObject({ changed: false, trigger: "version-pr", engineVersion: "3.9.1" });
     expect(readFileSync(join(repository, RELEASE_WORKFLOW_PATH), "utf8")).toBe(refreshedBytes);
   });
 


### PR DESCRIPTION
The first release under the new standard died at the first step:

```
npx -y -p @reddb-io/red-skills@3.8.0 red-skills-release run
sh: 1: red-skills-release: not found
```

`red-skills-release` arrived in **3.9.0** — the version that introduced the release standard itself. The workflow pinned 3.8.0 because **the generator stamps the version the repo is AT**, and on the run that installs a feature, that version is always one behind the feature.

This is the shape the house invariants already record from #2961: *an instruction pointing at its own precondition*. There it was `/red-setup` telling an operator to run `redskilled provision` — the binary that only exists after the thing it installs. Same trap, different surface.

- The generated pin now **floors at the version that introduced the binary**, so a repo generating from any earlier version still emits a runnable command.
- The emitted `red-release.yml` is corrected to 3.9.0 so the next push to `main` actually runs.
- A test pins the floor, carrying the failure that earned it.

The golden fixtures move with the generator. The vendored-bundle tests keep their own 3.8.x versions — those assert the bundle's self-reported version, which is a different fact from the pin.

Workspace typecheck 16/16, invariants green, release suite 41/41, Pi mirror clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788657622&installation_model_id=20659&pr_number=3458&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3458&signature=5923c1931c797140c0d855ea85628fcbacd8cb93eecc54d0c123818c36e06b76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->