### PR TITLE
fix(release): the release job carries the repository's toolchain

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
+      - name: Enable the repository package manager
+        run: corepack enable
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
       - name: Maintain Version PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -42,6 +46,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
+      - name: Enable the repository package manager
+        run: corepack enable
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
       - name: Publish Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/apps/release/src/workflow-generator.ts
+++ b/apps/release/src/workflow-generator.ts
@@ -9,6 +9,23 @@ export const VENDORED_RELEASE_BUNDLE_PATH = ".github/red-skills/release.bundle.m
 
 const CHECKOUT_ACTION = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5";
 const SETUP_NODE_ACTION = "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020";
+
+/**
+ * The repository's own package manager, made available to the release job.
+ *
+ * `sync_command` is declared by the OPERATOR and may reach anything the repo
+ * normally uses — this workspace's runs `pnpm generate-manifests`. A job that
+ * installs only Node dies with `pnpm: not found` at the first sync, which is a
+ * release refusing on the toolchain rather than on the release. Corepack takes
+ * the version from `packageManager`, so the job matches the repo without a
+ * second place to keep that number.
+ */
+const TOOLCHAIN_STEPS: readonly string[] = [
+  "      - name: Enable the repository package manager",
+  "        run: corepack enable",
+  "      - name: Install workspace dependencies",
+  "        run: pnpm install --frozen-lockfile",
+];
 const RELEASE_BOT = "red-skills-release[bot]";
 
 export interface RenderReleaseWorkflowInput {
@@ -192,6 +209,7 @@ function renderVersionPullRequestWorkflow(invocation: string): string {
     `      - uses: ${SETUP_NODE_ACTION}`,
     "        with:",
     "          node-version: 22",
+    ...TOOLCHAIN_STEPS,
     "      - name: Maintain Version PR",
     "        env:",
     "          GITHUB_TOKEN: ${{ github.token }}",
@@ -210,6 +228,7 @@ function renderVersionPullRequestWorkflow(invocation: string): string {
     `      - uses: ${SETUP_NODE_ACTION}`,
     "        with:",
     "          node-version: 22",
+    ...TOOLCHAIN_STEPS,
     "      - name: Publish Release",
     "        env:",
     "          GITHUB_TOKEN: ${{ github.token }}",
@@ -242,6 +261,7 @@ function renderAutoWorkflow(invocation: string): string {
     `      - uses: ${SETUP_NODE_ACTION}`,
     "        with:",
     "          node-version: 22",
+    ...TOOLCHAIN_STEPS,
     "      - name: Publish Release",
     "        env:",
     "          GITHUB_TOKEN: ${{ github.token }}",

--- a/apps/release/tests/fixtures/workflows/auto-vendored.yml
+++ b/apps/release/tests/fixtures/workflows/auto-vendored.yml
@@ -20,6 +20,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
+      - name: Enable the repository package manager
+        run: corepack enable
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
       - name: Publish Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/apps/release/tests/fixtures/workflows/auto.yml
+++ b/apps/release/tests/fixtures/workflows/auto.yml
@@ -20,6 +20,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
+      - name: Enable the repository package manager
+        run: corepack enable
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
       - name: Publish Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/apps/release/tests/fixtures/workflows/version-pr-vendored.yml
+++ b/apps/release/tests/fixtures/workflows/version-pr-vendored.yml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
+      - name: Enable the repository package manager
+        run: corepack enable
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
       - name: Maintain Version PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -42,6 +46,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
+      - name: Enable the repository package manager
+        run: corepack enable
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
       - name: Publish Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/apps/release/tests/fixtures/workflows/version-pr.yml
+++ b/apps/release/tests/fixtures/workflows/version-pr.yml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
+      - name: Enable the repository package manager
+        run: corepack enable
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
       - name: Maintain Version PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -42,6 +46,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
+      - name: Enable the repository package manager
+        run: corepack enable
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
       - name: Publish Release
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The vendored engine ran — and died at the first sync with `pnpm: not found`.

`sync_command` is declared by the **operator** and may reach anything the repo normally uses. This workspace's runs `pnpm generate-manifests && pnpm pi:packages:build`. The generated job installed only Node, so the release refused on the toolchain rather than on the release.

Both jobs now `corepack enable` and `pnpm install --frozen-lockfile`. Corepack takes the version from `packageManager`, so the job matches the repo without a second place to keep that number in step.

**Fixed in the generator, not only in the emitted file** — the next repository to adopt the standard inherits a job that can actually run the sync it declares. Golden fixtures move with it.

Release suite 41/41, workspace typecheck 16/16, invariants green, workflow security pins ok.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788663939&installation_model_id=20659&pr_number=3460&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3460&signature=5a99f8ec1327f1e6cdd4aca714fc3ef98bbb2cb5846949881dc1a19c87ae722c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->