### PR TITLE
fix(release): restore the artifact publisher the version train replaced

### DIFF
--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -1,0 +1,917 @@
+name: red-publish
+
+# Publish the release a tag names (ADR 0121).
+#
+# red-release.yml decides the version and cuts the `vX.Y.Z` tag through a
+# reviewed Version Packages PR. THIS workflow owns everything downstream of the
+# tag and nothing upstream of it:
+#
+#   1. Build every plugin/runtime bundle + checksum manifest at the tagged tree.
+#   2. Pack the npm package, run the REAL packaged client against the packed
+#      tarball as a producer/consumer contract check, publish, and smoke the
+#      published package from the registry.
+#   3. Cut the GitHub Release with the assets and move the matching major tag.
+#
+# There is NO fleet-activity deferral here (removed 2026-07-22): the old flow
+# deferred because it pushed a bump commit to main mid-fleet; this workflow
+# never touches main, and running workers pin their bundle at spawn, so a new
+# npm latest cannot retarget an in-flight fleet. Orphaned `running` labels
+# repeatedly held releases hostage under the old gate.
+#
+# It never writes a version and never pushes a commit: the tagged tree already
+# carries the synced manifests, and `Verify the tag matches the tree` fails the
+# publish if it does not.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (default: the oldest incomplete vX.Y.Z release)"
+        required: false
+        type: string
+  schedule:
+    # Retry a publish deferred by an active /afk fleet. The resolver below
+    # drains incomplete vX.Y.Z releases oldest-first, so npm's latest dist-tag
+    # and the moving major tag can only advance.
+    - cron: "17 * * * *"
+
+permissions:
+  contents: write
+  id-token: write
+  actions: write
+
+concurrency:
+  group: red-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Repository settings protect the red-release environment with required
+    # reviewers. Approval happens before this job can build, publish assets, or
+    # move the matching major tag.
+    environment:
+      name: red-release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # This job force-pushes the moving `vX` major ref, so it needs a push
+          # identity like any other pushing workflow. A bot-authored tag push also
+          # starts no workflow — the anti-recursion guard this repo already works
+          # around with an explicit `gh workflow run` dispatch — so a consumer that
+          # ever keys off `vX` would silently never fire.
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve the release tag
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          major_for() {
+            local version="${1#v}"
+            printf 'v%s\n' "${version%%.*}"
+          }
+
+          # A GitHub Release is not the whole completion marker: the workflow
+          # creates it before moving vX, and a failure in that final push must
+          # remain retryable. A major ref at this release OR a newer release in
+          # the same major means this tag's tail was reconciled successfully.
+          major_reaches() {
+            local candidate="$1" major major_sha pointed pointed_version candidate_version
+            major="$(major_for "$candidate")"
+            major_sha="$(git rev-parse -q --verify "refs/tags/${major}^{commit}" 2>/dev/null || true)"
+            [ -n "$major_sha" ] || return 1
+            candidate_version="${candidate#v}"
+            while IFS= read -r pointed; do
+              [ -n "$pointed" ] || continue
+              [ "$(major_for "$pointed")" = "$major" ] || continue
+              pointed_version="${pointed#v}"
+              if [ "$(printf '%s\n%s\n' "$candidate_version" "$pointed_version" | sort -V | tail -n1)" = "$pointed_version" ]; then
+                echo "::notice::$candidate has a GitHub Release and $major ref already reaches $pointed"
+                return 0
+              fi
+            done < <(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --points-at "$major_sha")
+            return 1
+          }
+
+          release_complete() {
+            local candidate="$1"
+            gh release view "$candidate" >/dev/null 2>&1 && major_reaches "$candidate"
+          }
+
+          major_is_ahead() {
+            local candidate="$1" major major_sha pointed pointed_version candidate_version newest
+            major="$(major_for "$candidate")"
+            major_sha="$(git rev-parse -q --verify "refs/tags/${major}^{commit}" 2>/dev/null || true)"
+            if [ -z "$major_sha" ]; then
+              # A major line with no moving ref (pre-scheme history, e.g. v0.x)
+              # can never become complete. When the repo has already moved on to
+              # a newer major, the whole line is stale, not pending.
+              newest="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=v:refname | tail -n1)"
+              [ -n "$newest" ] && [ "$(major_for "$newest")" != "$major" ] && return 0
+              return 1
+            fi
+            candidate_version="${candidate#v}"
+            while IFS= read -r pointed; do
+              [ -n "$pointed" ] || continue
+              [ "$(major_for "$pointed")" = "$major" ] || continue
+              pointed_version="${pointed#v}"
+              if [ "$pointed_version" != "$candidate_version" ] &&
+                 [ "$(printf '%s\n%s\n' "$candidate_version" "$pointed_version" | sort -V | tail -n1)" = "$pointed_version" ]; then
+                return 0
+              fi
+            done < <(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --points-at "$major_sha")
+            return 1
+          }
+
+          requested=""
+          if [ -n "${INPUT_TAG:-}" ]; then
+            requested="$INPUT_TAG"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            requested="$REF_NAME"
+          fi
+
+          if [ -n "$requested" ] && ! git rev-parse -q --verify "refs/tags/$requested" >/dev/null; then
+            echo "::error::tag $requested does not exist"
+            exit 1
+          fi
+
+          # FIFO is a correctness rule, not just a retry preference. If tags
+          # accumulate during fleet deferral, newest-first would publish an old
+          # version second and move npm/latest plus vX backwards.
+          # A stale incomplete release (its major line already moved past it, or
+          # its major line predates the moving-ref scheme entirely) can never be
+          # published — doing so would move npm/latest and vX backwards, which
+          # is exactly what FIFO exists to prevent. Skipping keeps the queue
+          # alive for genuinely pending tags; erroring here wedged EVERY publish
+          # behind hundreds of pre-flow tags that never had a release tail
+          # (first hit: v2.79.1 blocked behind v0.0.1, then v1.2.0 — #2460).
+          oldest_pending=""
+          while IFS= read -r candidate; do
+            if ! release_complete "$candidate"; then
+              if major_is_ahead "$candidate"; then
+                echo "::warning::skipping stale incomplete release $candidate: its major line already points past it"
+                continue
+              fi
+              oldest_pending="$candidate"
+              break
+            fi
+          done < <(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=v:refname)
+
+          if [ -z "$oldest_pending" ]; then
+            echo "no incomplete vX.Y.Z release — nothing to do"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$requested" ] && release_complete "$requested"; then
+            echo "::notice::$requested release tail already complete"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$requested" ] && [ "$requested" != "$oldest_pending" ]; then
+            echo "::error::cannot publish $requested: oldest incomplete release is $oldest_pending"
+            exit 1
+          fi
+
+          tag="${requested:-$oldest_pending}"
+          previous="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' "${tag}^" 2>/dev/null || true)"
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse "refs/tags/$tag^{commit}")" >> "$GITHUB_OUTPUT"
+          echo "built_at=$(git log -1 --format=%cI "refs/tags/$tag^{commit}")" >> "$GITHUB_OUTPUT"
+          echo "publishing $tag (previous=${previous:-none})"
+
+      # Everything below runs against the TAGGED tree, not main's HEAD.
+      - name: Check out the release tag
+        if: steps.target.outputs.publish == 'true'
+        run: git checkout --detach "refs/tags/${{ steps.target.outputs.tag }}"
+
+      - name: Validate install metadata
+        if: steps.target.outputs.publish == 'true'
+        run: scripts/validate-install-metadata.sh
+
+      - name: Test workflow security pins
+        if: steps.target.outputs.publish == 'true'
+        run: scripts/test-workflow-security-pins.sh
+
+      - name: Test canary channel promotion contract
+        if: steps.target.outputs.publish == 'true'
+        run: scripts/test-afk-promote-channel.sh
+
+      - name: Test red-release npm publish contract
+        if: steps.target.outputs.publish == 'true'
+        run: scripts/test-red-release-npm-publish-contract.sh
+
+      - name: Test red-castle vendor contract
+        if: steps.target.outputs.publish == 'true'
+        run: scripts/test-red-castle-vendor-contract.sh
+
+      - name: Test red-release reddb asset contract
+        if: steps.target.outputs.publish == 'true'
+        run: scripts/test-red-release-reddb-assets-contract.sh
+
+      - name: Test agent metadata fixtures
+        if: steps.target.outputs.publish == 'true'
+        run: scripts/test-validate-agent-metadata.sh
+
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+        if: steps.target.outputs.publish == 'true'
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        if: steps.target.outputs.publish == 'true'
+        with:
+          node-version: 22
+
+      - name: Install workspace dependencies
+        if: steps.target.outputs.publish == 'true'
+        env:
+          # The publish job builds JS bundles and manifests; it does not execute
+          # the @reddb-io/sdk-backed memory/brain runtimes during install. Skip
+          # the SDK postinstall binary download so publish is not blocked when
+          # the matching reddb binary asset is unavailable.
+          REDDB_SKIP_POSTINSTALL: "1"
+        run: pnpm install --frozen-lockfile
+
+      # The tag is the contract. The release engine wrote every version surface
+      # when it made the Version PR, so a tag that disagrees with the tree means
+      # someone tagged by hand at the wrong commit — fail before publishing
+      # bundles stamped with a version nothing else carries. That the surfaces
+      # agree with EACH OTHER is the version-train invariant's job, run on every
+      # PR; this step asks the one question that invariant cannot, because the
+      # tag is not in the tree.
+      - name: Verify the tag matches the tree
+        if: steps.target.outputs.publish == 'true'
+        env:
+          VERSION: ${{ steps.target.outputs.version }}
+        run: |
+          set -euo pipefail
+          tree="$(node -p "require('./package.json').version")"
+          if [ "$tree" != "$VERSION" ]; then
+            echo "::error::tag v${VERSION} points at a tree whose version is ${tree}"
+            exit 1
+          fi
+          echo "tag and tree agree on ${VERSION}"
+
+      # ADR 0091: the plugin bundles are distributed over npm with npm's own
+      # tarball shasum/provenance for integrity — the client no longer verifies a
+      # hand-rolled sigstore manifest signature, so cosign is not installed and
+      # manifests are not signed.
+
+      # ADR 0039: the two committed, dependency-free entrypoints —
+      # plugins/dev/hooks/red-fetch.mjs (fetch role) and
+      # plugins/dev/skills/engineering/afk/bin/afk.mjs (run:dev role) — are built
+      # from ONE source, packages/shared/entrypoint-cli.ts, and are committed on
+      # main. `build` re-emits them plus the dist/dev.bundle.min.mjs asset
+      # (ADR 0034); esbuild output is deterministic, so the tagged tree already
+      # carries the bytes this rebuild produces.
+      - name: Build dev runtime bundle
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/dev
+        env:
+          NEXT: ${{ steps.target.outputs.tag }}
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          pnpm build
+          # Checksum manifest the dynamic-fetch hook (packages/shared/bundle-fetch.ts)
+          # verifies before caching. Mirrors memory-runtime-manifest.json.
+          node --input-type=module <<'EOF'
+          import { createHash } from 'node:crypto';
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const bytes = readFileSync('../../dist/dev.bundle.min.mjs');
+          const manifest = {
+            plugin: 'dev',
+            version: process.env.NEXT.replace(/^v/, ''),
+            sha256: createHash('sha256').update(bytes).digest('hex'),
+          };
+          writeFileSync('../../dist/dev.manifest.json', JSON.stringify(manifest, null, 2));
+          console.log('dev runtime manifest:', JSON.stringify(manifest));
+          EOF
+
+      # ADR 0029: the Memory runtime ships as release assets, not committed
+      # build output. esbuild bundles the CLI (all JS deps inlined) into one
+      # platform-independent file; a manifest pins its checksum + the reddb tag
+      # whose per-platform `red` binaries the bootstrap reuses. Assets are
+      # uploaded onto the Release the release engine published for this tag.
+      - name: Build memory runtime bundle + manifest
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/memory
+        env:
+          NEXT: ${{ steps.target.outputs.tag }}
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          # ADR 0052: one canonical, minified bundle per entrypoint, all under
+          # ./dist/ (memory.bundle.min.mjs = CLI, memory-mcp.bundle.min.mjs = MCP).
+          # The legacy dist-bundle/*-cli.mjs model was removed; the bootstrap reads
+          # the asset names from this manifest, so the rename follows per-version.
+          pnpm bundle
+          node --input-type=module <<'EOF'
+          import { createHash } from 'node:crypto';
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+          const sdk = pkg.dependencies['@reddb-io/sdk'];
+          const reddb = {
+            repo: 'reddb-io/reddb',
+            tag: `v${sdk}`,
+          };
+          const assetNames = {
+            'linux-x86_64': 'red-linux-x86_64',
+            'linux-aarch64': 'red-linux-aarch64',
+            'linux-armv7': 'red-linux-armv7',
+            'macos-x86_64': 'red-macos-x86_64',
+            'macos-aarch64': 'red-macos-aarch64',
+            'windows-x86_64': 'red-windows-x86_64.exe',
+          };
+          // Checksums carried forward from the last manifest, usable only while the
+          // pin is unchanged. When the pin moves, the old checksums describe a
+          // different binary, so there is no fallback and every asset must resolve
+          // live from the new tag. Carrying them across a bump is how a dead pointer
+          // survived unnoticed: reddb aged out the pinned release, the live .sha256
+          // 404'd, and the stale checksums were copied forward release after release.
+          async function previousRedAssets() {
+            const url = 'https://github.com/reddb-io/red-skills/releases/latest/download/memory-runtime-manifest.json';
+            const response = await fetch(url, { redirect: 'follow' });
+            if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
+            const previous = await response.json();
+            if (previous?.reddb?.sdk !== sdk || previous?.reddb?.tag !== reddb.tag) return {};
+            return previous.reddb.assets ?? {};
+          }
+          const fallbackAssets = await previousRedAssets();
+          const redAssets = {};
+          for (const [platform, asset] of Object.entries(assetNames)) {
+            const url = `https://github.com/${reddb.repo}/releases/download/${reddb.tag}/${asset}.sha256`;
+            const response = await fetch(url, { redirect: 'follow' });
+            let sha256 = "";
+            if (response.ok) {
+              sha256 = (await response.text()).match(/\b[0-9a-f]{64}\b/i)?.[0]?.toLowerCase() ?? "";
+            } else {
+              const fallback = fallbackAssets[platform];
+              if (fallback?.asset !== asset || !fallback?.sha256) throw new Error(`GET ${url} -> ${response.status}`);
+              sha256 = fallback.sha256;
+            }
+            if (!sha256) throw new Error(`invalid sha256 file for ${asset}`);
+            redAssets[platform] = { asset, sha256 };
+          }
+          const cli = readFileSync('../../dist/memory.bundle.min.mjs');
+          const mcp = readFileSync('../../dist/memory-mcp.bundle.min.mjs');
+          const manifest = {
+            schema: 'red.memory.runtime.v1',
+            version: process.env.NEXT.replace(/^v/, ''),
+            cli: { asset: 'memory.bundle.min.mjs', sha256: createHash('sha256').update(cli).digest('hex') },
+            mcp: { asset: 'memory-mcp.bundle.min.mjs', sha256: createHash('sha256').update(mcp).digest('hex') },
+            reddb: { ...reddb, sdk, assets: redAssets },
+          };
+          writeFileSync('../../dist/memory-runtime-manifest.json', JSON.stringify(manifest, null, 2));
+          console.log('runtime manifest:', JSON.stringify(manifest));
+          EOF
+
+      # ADR 0029/0038: the Brain runtime ships as release assets, not committed
+      # build output (mirrors memory). esbuild bundles the CLI + MCP (all JS deps
+      # inlined); a manifest pins their checksums + the reddb tag whose
+      # per-platform `red` binaries the bootstrap reuses. Uploaded onto this
+      # tag's Release; fetched by plugins/brain/scripts/bootstrap.mjs.
+      - name: Build brain runtime bundle + manifest
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/brain
+        env:
+          NEXT: ${{ steps.target.outputs.tag }}
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          # ADR 0052: canonical minified bundles under ./dist/ (brain.bundle.min.mjs
+          # = CLI, brain-mcp.bundle.min.mjs = MCP); legacy dist-bundle removed.
+          pnpm bundle
+          node --input-type=module <<'EOF'
+          import { createHash } from 'node:crypto';
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+          const sdk = pkg.dependencies['@reddb-io/sdk'];
+          const reddb = {
+            repo: 'reddb-io/reddb',
+            tag: `v${sdk}`,
+          };
+          const assetNames = {
+            'linux-x86_64': 'red-linux-x86_64',
+            'linux-aarch64': 'red-linux-aarch64',
+            'linux-armv7': 'red-linux-armv7',
+            'macos-x86_64': 'red-macos-x86_64',
+            'macos-aarch64': 'red-macos-aarch64',
+            'windows-x86_64': 'red-windows-x86_64.exe',
+          };
+          // No fallback across a pin bump — see the memory manifest step above.
+          async function previousRedAssets() {
+            const url = 'https://github.com/reddb-io/red-skills/releases/latest/download/brain-runtime-manifest.json';
+            const response = await fetch(url, { redirect: 'follow' });
+            if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
+            const previous = await response.json();
+            if (previous?.reddb?.sdk !== sdk || previous?.reddb?.tag !== reddb.tag) return {};
+            return previous.reddb.assets ?? {};
+          }
+          const fallbackAssets = await previousRedAssets();
+          const redAssets = {};
+          for (const [platform, asset] of Object.entries(assetNames)) {
+            const url = `https://github.com/${reddb.repo}/releases/download/${reddb.tag}/${asset}.sha256`;
+            const response = await fetch(url, { redirect: 'follow' });
+            let sha256 = "";
+            if (response.ok) {
+              sha256 = (await response.text()).match(/\b[0-9a-f]{64}\b/i)?.[0]?.toLowerCase() ?? "";
+            } else {
+              const fallback = fallbackAssets[platform];
+              if (fallback?.asset !== asset || !fallback?.sha256) throw new Error(`GET ${url} -> ${response.status}`);
+              sha256 = fallback.sha256;
+            }
+            if (!sha256) throw new Error(`invalid sha256 file for ${asset}`);
+            redAssets[platform] = { asset, sha256 };
+          }
+          const cli = readFileSync('../../dist/brain.bundle.min.mjs');
+          const mcp = readFileSync('../../dist/brain-mcp.bundle.min.mjs');
+          const manifest = {
+            schema: 'red.brain.runtime.v1',
+            version: process.env.NEXT.replace(/^v/, ''),
+            cli: { asset: 'brain.bundle.min.mjs', sha256: createHash('sha256').update(cli).digest('hex') },
+            mcp: { asset: 'brain-mcp.bundle.min.mjs', sha256: createHash('sha256').update(mcp).digest('hex') },
+            reddb: { ...reddb, sdk, assets: redAssets },
+          };
+          writeFileSync('../../dist/brain-runtime-manifest.json', JSON.stringify(manifest, null, 2));
+          console.log('brain runtime manifest:', JSON.stringify(manifest));
+          EOF
+
+      - name: Verify reddb release assets
+        if: steps.target.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          node scripts/verify-reddb-release-assets.mjs dist/memory-runtime-manifest.json
+          node scripts/verify-reddb-release-assets.mjs dist/brain-runtime-manifest.json
+
+      # ADR 0034: the code-nav MCP server ships as a release-asset bundle, like
+      # the dev/memory runtimes. Its package lives under apps/code-nav.
+      # `build` (typecheck + bundle) emits the dev-checkout
+      # file dist/code-nav-mcp.bundle.min.mjs; the release asset the dynamic fetch
+      # resolves is named code-nav.bundle.min.mjs (bundleAssetName('code-nav')),
+      # with a code-nav.manifest.json mirroring dev.manifest.json.
+      - name: Build code-nav MCP bundle + manifest
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/code-nav
+        env:
+          NEXT: ${{ steps.target.outputs.tag }}
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          pnpm typecheck
+          pnpm bundle
+          node --input-type=module <<'EOF'
+          import { createHash } from 'node:crypto';
+          import { readFileSync, writeFileSync, copyFileSync } from 'node:fs';
+          const built = '../../dist/code-nav-mcp.bundle.min.mjs';
+          // Publish the fetch-resolvable asset name code-nav.bundle.min.mjs.
+          const asset = '../../dist/code-nav.bundle.min.mjs';
+          copyFileSync(built, asset);
+          const bytes = readFileSync(asset);
+          const manifest = {
+            plugin: 'code-nav',
+            version: process.env.NEXT.replace(/^v/, ''),
+            sha256: createHash('sha256').update(bytes).digest('hex'),
+          };
+          writeFileSync('../../dist/code-nav.manifest.json', JSON.stringify(manifest, null, 2));
+          console.log('code-nav bundle manifest:', JSON.stringify(manifest));
+          EOF
+
+      - name: Build benchmark-memory bundle + manifest
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/benchmark-memory
+        env:
+          NEXT: ${{ steps.target.outputs.tag }}
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          pnpm build
+          node --input-type=module <<'EOF'
+          import { createHash } from 'node:crypto';
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const asset = '../../dist/benchmark-memory.bundle.min.mjs';
+          const bytes = readFileSync(asset);
+          const manifest = {
+            plugin: 'benchmark-memory',
+            version: process.env.NEXT.replace(/^v/, ''),
+            sha256: createHash('sha256').update(bytes).digest('hex'),
+          };
+          writeFileSync('../../dist/benchmark-memory.manifest.json', JSON.stringify(manifest, null, 2));
+          console.log('benchmark-memory bundle manifest:', JSON.stringify(manifest));
+          EOF
+
+      - name: Build OpenCode host installer bundle
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/opencode-host
+        env:
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          pnpm build
+          node ../../dist/opencode-host.bundle.min.mjs \
+            --config ../../.red/config.yaml \
+            --plugins-root ../../plugins \
+            --out ../../dist/opencode.json \
+            --out-dir ../../dist/opencode \
+            --copy
+          touch ../../dist/opencode/.release-generated
+          tar -czf ../../dist/opencode-host.generated.tgz -C ../.. dist/opencode
+
+      - name: Build benchmark-code-understanding bundle + manifest
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/benchmark-code-understanding
+        env:
+          NEXT: ${{ steps.target.outputs.tag }}
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          pnpm build
+          node --input-type=module <<'EOF'
+          import { createHash } from 'node:crypto';
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const asset = '../../dist/benchmark-code-understanding.bundle.min.mjs';
+          const bytes = readFileSync(asset);
+          const manifest = {
+            plugin: 'benchmark-code-understanding',
+            version: process.env.NEXT.replace(/^v/, ''),
+            sha256: createHash('sha256').update(bytes).digest('hex'),
+          };
+          writeFileSync('../../dist/benchmark-code-understanding.manifest.json', JSON.stringify(manifest, null, 2));
+          console.log('benchmark-code-understanding bundle manifest:', JSON.stringify(manifest));
+          EOF
+
+      # The rsp CLI ships its single bundle (dist/rsp.bundle.min.mjs) INSIDE the
+      # npm package (bin/rsp.mjs resolves it), not as a release-fetched runtime,
+      # so it needs no checksum manifest. Every other runtime app has its own
+      # per-app bundle step; rsp had a bin + prepare/verify entry but no build
+      # step, so the pack contract check failed on a genuinely-missing bundle.
+      # Build it from its own app dir so pnpm bundle emits ../../dist/rsp.bundle.min.mjs.
+      - name: Build rsp runtime bundle
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/rsp
+        env:
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          pnpm bundle
+
+      # The redskilled daemon ships its single bundle
+      # (dist/redskilled.bundle.min.mjs) INSIDE the npm package, like rsp: the
+      # client's auto-spawn (ADR 0130 rule 7) resolves the packaged bundle, so it
+      # needs no checksum manifest. Without this step the app is a workspace
+      # member nothing packages — complete in source and absent from every
+      # release, which is exactly the silent failure issue #2842 closed.
+      - name: Build redskilled daemon bundle
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/redskilled
+        env:
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          pnpm bundle
+
+      # The two companion surfaces that read the daemon are installed by hand
+      # rather than resolved by a launcher, so a release is the ONLY place they
+      # can come from (issue #3060). Both were complete in source and absent from
+      # every release: the extension shipped no `.vsix` at all, and the herdr
+      # plugin could only be installed by `pnpm install`-ing this whole workspace
+      # first — which is not a thing a machine with no checkout can do.
+      #
+      # The herdr plugin bundles like every other app here: one esbuild file with
+      # `@reddb-io/toon` and `@reddb-io/build-info` inlined. Its install-time
+      # build hook downloads this asset and writes it over its own entry, so the
+      # asset name is a contract, checked by apps/herdr-plugin-red-skills/tests.
+      - name: Build herdr plugin bundle
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/herdr-plugin-red-skills
+        env:
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          pnpm bundle
+
+      # The `.vsix` is built by the extension's own packager (an OPC zip, not
+      # `@vscode/vsce`) and stamped with the release version, because an editor
+      # keys "already installed" off the manifest inside the archive: a second
+      # release carrying the extension's static 0.1.0 would be a download nothing
+      # installs. It is attached to the Release and pushed to no marketplace.
+      - name: Package the VS Code extension .vsix
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/vscode-extension-red-skills
+        env:
+          RED_BUILD_VERSION: ${{ steps.target.outputs.version }}
+        run: |
+          set -euo pipefail
+          pnpm package
+
+      # ADR 0091: npm is the ONLY client transport. Stage the built bundles into
+      # the packaging/npm package, pnpm pack it, then run the REAL client resolver
+      # (the packaged bin) against the packed tarball as a producer/consumer
+      # contract check BEFORE publishing. Publish and a real registry smoke both
+      # complete BEFORE the tag's GitHub Release, so a missing token, failed
+      # publish, or stale registry aborts the publish while the Release (and the
+      # moving major tag) still point at the previous working version.
+      - name: Pack npm package + producer/consumer contract check
+        if: steps.target.outputs.publish == 'true'
+        env:
+          NEXT: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${NEXT#v}"
+          # Pin the package version to the tag being published. packaging/npm is
+          # outside the pnpm workspace, so changesets never versions it; the tag
+          # is its only source of truth and `Verify the tag matches the tree`
+          # already proved the tag agrees with every in-workspace manifest.
+          node -e "const fs=require('fs');const p='packaging/npm/package.json';const j=JSON.parse(fs.readFileSync(p));j.version=process.env.NEXT.replace(/^v/,'');fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n');"
+          # Stage the platform-independent JS bundles into the package's dist/.
+          node packaging/npm/scripts/prepare.mjs
+          cd packaging/npm
+          pnpm pack --pack-destination .
+          tarball="$(ls reddb-io-red-skills-*.tgz | head -n1)"
+          echo "packed $tarball"
+          # Materialize the tar listing ONCE. Never pipe `tar -tzf` straight into
+          # `grep -q`: grep closes the pipe on its first match, tar then dies with
+          # SIGPIPE (exit 141), and `pipefail` propagates that failure — so once the
+          # tarball grew past the pipe buffer the check misreported a present bundle
+          # as missing. Matching each expected entry against the captured listing with
+          # a here-string (no pipe) lets tar always read to completion.
+          listing="$(tar -tzf "$tarball")"
+          for expected in \
+            package/dist/dev.bundle.min.mjs \
+            package/dist/code-nav.bundle.min.mjs \
+            package/dist/memory.bundle.min.mjs \
+            package/dist/brain.bundle.min.mjs \
+            package/dist/rsp.bundle.min.mjs \
+            package/dist/redskilled.bundle.min.mjs; do
+            if ! grep -qxF "$expected" <<<"$listing"; then
+              echo "::error::npm tarball missing $expected"
+              exit 1
+            fi
+          done
+          # Contract check: install the packed tarball into a throwaway prefix and
+          # run the REAL packaged clients (the bins the launcher execs) — proves the
+          # tarball resolves and runs before we publish it.
+          smoke="$(mktemp -d)"
+          npm install "./$tarball" --prefix "$smoke" --no-audit --no-fund --ignore-scripts --loglevel=error
+          pkg="$smoke/node_modules/@reddb-io/red-skills"
+          node "$pkg/bin/red-skills-dev.mjs" --version
+          # code-nav launches via an npm-shim bin (#1396) that resolves the packaged
+          # code-nav bundle; smoke both the shim and the bundle it resolves.
+          test -x "$smoke/node_modules/.bin/red-skills-code-nav"
+          test -f "$smoke/node_modules/@reddb-io/red-skills/dist/code-nav.bundle.min.mjs"
+          # rsp needs a provisioned RedDB store (the `red` binary is not present under
+          # --ignore-scripts), so it cannot reach exit 0 here. What we DO smoke is that
+          # the packaged rsp bin resolves its bundle: a bin-without-bundle makes the
+          # shim print "packaged bundle missing" and exit before ever loading the
+          # runtime. Fail iff that guard fires — that is the exact "dangling bin" defect.
+          rsp_out="$(node "$pkg/bin/rsp.mjs" --store-uri "file://$smoke/rsp-store" 2>&1 || true)"
+          if grep -qF 'packaged bundle missing' <<<"$rsp_out"; then
+            echo "::error::packaged rsp bin shipped without its dist/rsp.bundle.min.mjs bundle"
+            printf '%s\n' "$rsp_out"
+            exit 1
+          fi
+          echo "packaged rsp bin resolved its bundle"
+          # redskilled: start the packaged daemon for real and prove it binds its
+          # session socket. A `host-state` read would auto-spawn one anyway, so the
+          # cheap presence check would not distinguish a working artifact from a
+          # bundle that throws on load — and "present but not executable" is the
+          # failure this artifact was added to make impossible (issue #2842).
+          test -x "$smoke/node_modules/.bin/red-skills-redskilled"
+          rsdir="$(mktemp -d)"
+          REDSKILLED_SESSION="pack-smoke:$rsdir" node "$pkg/bin/red-skills-redskilled.mjs" serve \
+            --socket "$rsdir/redskilled.sock" \
+            --lease "$rsdir/redskilled.lease.toon" \
+            --events "$rsdir/redskilled.events.toonl" \
+            --idle-ms 5000 &
+          rspid=$!
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            [ -S "$rsdir/redskilled.sock" ] && break
+            if [ "$attempt" -eq 10 ]; then
+              echo "::error::packaged redskilled bundle never bound its socket"
+              kill "$rspid" 2>/dev/null || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "packaged redskilled bundle started the daemon and bound its socket"
+          kill "$rspid" 2>/dev/null || true
+          wait "$rspid" 2>/dev/null || true
+          rm -rf "$rsdir"
+          rm -rf "$smoke"
+
+      - name: Publish to npm
+        if: steps.target.outputs.publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NEXT: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${NEXT#v}"
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN secret absent — cannot publish @reddb-io/red-skills@${version}"
+            exit 1
+          fi
+          cd packaging/npm
+          npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
+          # Publish must be idempotent so a re-run after a transient
+          # post-publish failure (for example registry-propagation lag in the
+          # smoke step) can resume the publish tail instead of dying on a
+          # publish-over-published conflict. npm versions are immutable, so an
+          # already-served version IS the successful publish outcome.
+          if npm view "@reddb-io/red-skills@${version}" version >/dev/null 2>&1; then
+            echo "@reddb-io/red-skills@${version} already on the registry — publish already complete, resuming release tail"
+            exit 0
+          fi
+          # Stable releases publish to npm's default `latest` tag. The opt-in
+          # canary channel is moved later with scripts/afk-promote-channel.sh,
+          # which points npm dist-tag `canary` at an already-published version.
+          pnpm publish --access public --no-git-checks
+
+      - name: Build + publish Pi packages to npm
+        if: steps.target.outputs.publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NEXT: ${{ steps.target.outputs.tag }}
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${NEXT#v}"
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN secret absent — cannot publish @reddb-io/red-skills-<plugin>@${version}"
+            exit 1
+          fi
+          # Stage the npm-ready Pi packages from plugins/<name>/skills/<bucket>/
+          # into packaging/pi/<name>/. The build runs before publish so the
+          # tarball carries the current source, not a stale staging.
+          pnpm pi:packages:build
+          # Idempotent on already-published (same shape as @reddb-io/red-skills):
+          # a re-run after transient post-publish failure resumes the publish
+          # tail instead of dying on publish-over-published conflict.
+          pnpm pi:packages:publish
+
+      - name: Smoke published Pi packages from registry
+        if: steps.target.outputs.publish == 'true'
+        env:
+          NEXT: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${NEXT#v}"
+          # Registry read replicas can lag the publish by several minutes
+          # (same budget as the @reddb-io/red-skills smoke above).
+          for plugin in dev memory brain; do
+            for attempt in 1 2 3 4 5 6 7 8 9 10; do
+              # `npm view <pkg>@<version> version` prints just the resolved
+              # version string (e.g. `2.76.0`); compare it exactly. The prior
+              # `name version` + grep for "<name> <version>" never matched npm's
+              # multi-field `field = 'value'` output, so the smoke always failed
+              # even after the packages were published.
+              if resolved="$(npm view "@reddb-io/red-skills-${plugin}@${version}" version 2>/dev/null)" && [ "$resolved" = "${version}" ]; then
+                echo "registry smoke returned @reddb-io/red-skills-${plugin}@${version}"
+                continue 2
+              fi
+              echo "registry smoke attempt ${attempt}/10 for @reddb-io/red-skills-${plugin}@${version} not yet resolvable; sleeping ${attempt}*15s"
+              sleep "$((attempt * 15))"
+            done
+            echo "::error::registry smoke failed for @reddb-io/red-skills-${plugin}@${version} after 10 attempts"
+            exit 1
+          done
+
+      - name: Smoke published npm package from registry
+        if: steps.target.outputs.publish == 'true'
+        env:
+          NEXT: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${NEXT#v}"
+          smoke="$(mktemp -d)"
+          trap 'rm -rf "$smoke"' EXIT
+          export npm_config_cache="$smoke/npm-cache"
+          export npm_config_prefix="$smoke/npm-prefix"
+          # Registry read replicas can lag the publish by several minutes
+          # (v2.0.1 took >2min to become resolvable, exhausting the previous
+          # ~105s budget). 10 attempts at attempt*15s ≈ 11min total budget.
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            if output="$(npx -y -p "@reddb-io/red-skills@${version}" red-skills-dev --version 2>&1)"; then
+              printf '%s\n' "$output"
+              if grep -qF "dev ${version} " <<<"$output"; then
+                echo "registry smoke returned @reddb-io/red-skills@${version}"
+                exit 0
+              fi
+              echo "::error::registry smoke returned unexpected version output for @reddb-io/red-skills@${version}"
+              exit 1
+            fi
+            printf '%s\n' "$output" >&2
+            if [ "$attempt" -eq 10 ]; then
+              echo "::error::registry did not serve @reddb-io/red-skills@${version} after publish"
+              exit 1
+            fi
+            sleep $((attempt * 15))
+          done
+
+      # `release-manifest.json` is written and attached by the release engine,
+      # which owns the Release. This job used to build a second file under the
+      # same name; one name carrying two meanings is how a reader ends up
+      # trusting the wrong one. The per-bundle checksums it summarised are still
+      # published — each bundle ships its own `*.manifest.json` alongside it.
+
+      - name: GitHub Release
+        if: steps.target.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+          major="v${NEXT#v}"
+          major="${major%%.*}"
+
+          # ADR 0091: the client resolves bundles over npm; these Release assets
+          # are kept as an INERT backup artifact the client never reads. No
+          # sigstore signatures are uploaded (client signature verification
+          # removed).
+          # Two of these are not an inert backup: the `.vsix` and the herdr
+          # bundle are the ONLY way either companion surface is installed on a
+          # machine without this monorepo (issue #3060).
+          assets=(
+            "dist/vscode-extension-red-skills-${NEXT#v}.vsix"
+            dist/herdr-plugin-red-skills.bundle.min.mjs
+            dist/dev.bundle.min.mjs
+            dist/dev.manifest.json
+            dist/code-nav.bundle.min.mjs
+            dist/code-nav.manifest.json
+            dist/benchmark-memory.bundle.min.mjs
+            dist/benchmark-memory.manifest.json
+            dist/opencode-host.bundle.min.mjs
+            dist/opencode-host.generated.tgz
+            dist/benchmark-code-understanding.bundle.min.mjs
+            dist/benchmark-code-understanding.manifest.json
+            dist/memory.bundle.min.mjs
+            dist/memory-mcp.bundle.min.mjs
+            dist/memory-runtime-manifest.json
+            dist/brain.bundle.min.mjs
+            dist/brain-mcp.bundle.min.mjs
+            dist/brain-runtime-manifest.json
+            dist/redskilled.bundle.min.mjs
+          )
+          # The Release standard owns the Release; this job only ever attaches to
+          # it. Two owners would race over one object: the engine re-reads the
+          # Release it created and refuses a body it did not write, so a Release
+          # created here with generated notes would fail the engine's own
+          # publish. One owner, one body, and this job supplies the artifacts
+          # that body describes.
+          #
+          # WAIT: for the Release the engine creates seconds after pushing this
+          # tag. DEADLINE: 5 minutes. ON DEADLINE: fail, naming the owner — a
+          # tag with no Release means the release engine did not finish, and
+          # uploading into a Release nobody published would hide that.
+          deadline=$(( SECONDS + 300 ))
+          until gh release view "$NEXT" >/dev/null 2>&1; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::$NEXT has no GitHub Release after 5 minutes — the release engine (.github/workflows/red-release.yml) publishes it, and this job only attaches artifacts to it"
+              exit 1
+            fi
+            sleep 15
+          done
+          # `--clobber` makes the cron retry converge: a publish that died
+          # midway leaves some assets attached, and re-uploading them is the
+          # reconciliation, not a duplicate.
+          gh release upload "$NEXT" "${assets[@]}" --clobber
+
+          # `vX.Y.Z` is immutable release history; `vX` is the moving major ref
+          # GitHub reusable workflows/actions consume via `uses: ...@vX`.
+          git tag -f "$major" "refs/tags/${NEXT}^{commit}"
+          git push --force origin "refs/tags/$major:refs/tags/$major"

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -91,6 +91,17 @@ jobs:
       - name: Test canary channel promotion contract
         run: scripts/test-afk-promote-channel.sh
 
+      # These two ran only inside red-publish.yml, which is to say only at
+      # publish time — after the last chance to fix anything. That is how a
+      # refactor deleted five scripts the publish workflow calls and no check
+      # went red: the only thing that reads the publish workflow was the publish
+      # workflow. Reading it on every PR is the point.
+      - name: Test red-release npm publish contract
+        run: scripts/test-red-release-npm-publish-contract.sh
+
+      - name: Test red-release reddb asset contract
+        run: scripts/test-red-release-reddb-assets-contract.sh
+
       # ADR 0139: a changeset that cannot resolve does not get skipped — it
       # throws and abandons the whole release plan, so one bad file fails every
       # release after it (#2863). This job is the only one a changeset-only PR

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Static contract tests for the npm publish ordering in red-publish.yml.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+WORKFLOW=".github/workflows/red-publish.yml"
+WORKSPACE_CI=".github/workflows/red-workspace-ci.yml"
+failures=0
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+
+pass() {
+  printf 'PASS: %s\n' "$*"
+}
+
+line_of_step() {
+  local step="$1"
+  local line
+  line="$(grep -nF -- "- name: $step" "$WORKFLOW" | head -n1 | cut -d: -f1 || true)"
+  if [ -z "$line" ]; then
+    fail "missing release workflow step: $step"
+    printf '0\n'
+  else
+    printf '%s\n' "$line"
+  fi
+}
+
+assert_before() {
+  local left_name="$1" left_line="$2" right_name="$3" right_line="$4"
+  if [ "$left_line" -gt 0 ] && [ "$right_line" -gt 0 ] && [ "$left_line" -lt "$right_line" ]; then
+    pass "$left_name runs before $right_name"
+  else
+    fail "$left_name must run before $right_name"
+  fi
+}
+
+verify_line="$(line_of_step "Verify the tag matches the tree")"
+pack_line="$(line_of_step "Pack npm package + producer/consumer contract check")"
+publish_line="$(line_of_step "Publish to npm")"
+smoke_line="$(line_of_step "Smoke published npm package from registry")"
+release_line="$(line_of_step "GitHub Release")"
+
+# ADR 0121: manifest stamping moved OUT of the publish path into the Version
+# Packages PR, so the tag arrives with the versions already written. What the
+# publish must still prove, in order: the tag agrees with the tree it points at,
+# the tarball resolves before it is published, and the GitHub Release is cut
+# only after the registry actually serves the version.
+assert_before "tag/tree verification" "$verify_line" "pack/contract check" "$pack_line"
+assert_before "pack/contract check" "$pack_line" "publish" "$publish_line"
+assert_before "publish" "$publish_line" "registry smoke" "$smoke_line"
+assert_before "registry smoke" "$smoke_line" "GitHub release" "$release_line"
+
+# That the version surfaces agree with EACH OTHER is the version-train
+# invariant, run on every PR by the release engine's own gate. What this
+# workflow must still prove is the one thing that invariant cannot see, because
+# the tag is not in the tree: the tag names the version the tree carries.
+if grep -qF 'tag v${VERSION} points at a tree whose version is ${tree}' "$WORKFLOW"; then
+  pass "publish proves the tag names the version the tagged tree carries"
+else
+  fail "publish must fail a tag whose version disagrees with the tree it points at"
+fi
+
+if grep -qF 'tag v${VERSION} points at a tree whose version is' "$WORKFLOW"; then
+  pass "a tag that disagrees with the tree fails the publish"
+else
+  fail "publish must fail when the tag disagrees with the tree's version"
+fi
+
+if grep -qF 'HEAD:main' "$WORKFLOW" || grep -qF 'git push origin HEAD' "$WORKFLOW"; then
+  fail "the publish workflow must never push a commit to main"
+else
+  pass "the publish workflow pushes no commit to main"
+fi
+
+if grep -qF '::error::NPM_TOKEN secret absent' "$WORKFLOW"; then
+  pass "missing NPM_TOKEN is reported as an error"
+else
+  fail "missing NPM_TOKEN must emit ::error::"
+fi
+
+if grep -qF 'skipping npm publish' "$WORKFLOW"; then
+  fail "release workflow still skips npm publish when NPM_TOKEN is absent"
+else
+  pass "missing NPM_TOKEN does not skip publish"
+fi
+
+if grep -qF 'npx -y -p "@reddb-io/red-skills@${version}" red-skills-dev --version' "$WORKFLOW"; then
+  pass "registry smoke uses npx against the published package version"
+else
+  fail "registry smoke must run the real client via npx from the npm registry"
+fi
+
+if grep -qF 'package/dist/code-nav.bundle.min.mjs' "$WORKFLOW" &&
+   grep -qF 'npm tarball missing $expected' "$WORKFLOW"; then
+  pass "pack contract checks the code-nav bundle is in the npm tarball"
+else
+  fail "pack contract must fail when code-nav is missing from the npm tarball"
+fi
+
+if grep -qF 'test -x "$smoke/node_modules/.bin/red-skills-code-nav"' "$WORKFLOW" &&
+   grep -qF 'test -f "$smoke/node_modules/@reddb-io/red-skills/dist/code-nav.bundle.min.mjs"' "$WORKFLOW"; then
+  pass "pack contract checks the code-nav npm bin and packaged bundle"
+else
+  fail "pack contract must verify the code-nav npm bin and packaged bundle"
+fi
+
+if grep -qF 'registry smoke returned' "$WORKFLOW" &&
+   grep -qF 'dev ${version} ' "$WORKFLOW"; then
+  pass "registry smoke verifies the reported release version"
+else
+  fail "registry smoke must fail when --version does not report the release version"
+fi
+
+if grep -qF 'already on the registry — publish already complete' "$WORKFLOW"; then
+  pass "publish is idempotent so a re-run can resume the release tail"
+else
+  fail "publish must no-op when the version is already on the registry (resumable release tail)"
+fi
+
+if grep -q '^  workflow_dispatch:$' "$WORKFLOW" &&
+   grep -q '^  schedule:$' "$WORKFLOW" &&
+   grep -q 'cron:' "$WORKFLOW"; then
+  pass "publish workflow has manual and scheduled retry triggers"
+else
+  fail "publish workflow must expose workflow_dispatch and schedule retry triggers"
+fi
+
+# changesets/action writes its PR through RELEASE_PAT, so GitHub emits the
+# normal pull_request event. Keeping a push trigger for that branch would run
+# the workspace gate twice for the same Version Packages PR head.
+if grep -qF 'branches: [main, automation/toon-bump]' "$WORKSPACE_CI" &&
+   ! grep -qF 'changeset-release/main' "$WORKSPACE_CI"; then
+  pass "Version Packages PR relies on its PAT-authored pull_request checks"
+else
+  fail "red-workspace-ci must not duplicate Version Packages PR checks with a push trigger"
+fi
+
+# Deferred tags form a FIFO publication queue. Publishing newest-first can move
+# npm's latest dist-tag and the moving vX tag backwards on the next retry.
+if grep -qF -- "--sort=v:refname" "$WORKFLOW" &&
+   ! grep -qF -- "--sort=-v:refname" "$WORKFLOW"; then
+  pass "scheduled retries inspect release tags oldest-first"
+else
+  fail "scheduled retries must inspect release tags oldest-first"
+fi
+
+if grep -qF 'oldest incomplete release is $oldest_pending' "$WORKFLOW"; then
+  pass "an explicit target cannot jump ahead of the oldest incomplete release"
+else
+  fail "explicit targets must be rejected when an older release is incomplete"
+fi
+
+# Pre-flow tags never had a release tail and can never gain one (their major
+# line already moved past them, or has no moving ref at all). They must be
+# skipped, not fatal: erroring wedged every publish behind v0.0.1/v1.2.0 (#2460).
+if grep -qF 'skipping stale incomplete release' "$WORKFLOW" &&
+   ! grep -qF 'refusing stale incomplete release' "$WORKFLOW"; then
+  pass "stale incomplete releases are skipped, never fatal"
+else
+  fail "a stale incomplete release must be skipped by the FIFO scan, not error the run"
+fi
+
+# ADR 0121: the tag is the publish trigger. A `push: branches` trigger would put
+# the publish back on every commit to main, which is exactly the design this
+# replaced.
+if grep -qE '^      - "v\[0-9\]\+\.\[0-9\]\+\.\[0-9\]\+"$' "$WORKFLOW" &&
+   grep -q '^    tags:$' "$WORKFLOW"; then
+  pass "publish is triggered by a vX.Y.Z tag push"
+else
+  fail "publish must trigger on a vX.Y.Z tag push"
+fi
+
+if grep -qE '^    branches:' "$WORKFLOW"; then
+  fail "publish must not trigger on a branch push"
+else
+  pass "publish does not trigger on a branch push"
+fi
+
+if grep -qF 'release_complete()' "$WORKFLOW" &&
+   grep -qF 'major ref already reaches' "$WORKFLOW"; then
+  pass "completion requires both the GitHub Release and a reconciled major tag"
+else
+  fail "a GitHub Release alone must not suppress major-tag reconciliation"
+fi
+
+# One Release, one owner. The release engine creates it and re-reads the body it
+# wrote; a Release created here with generated notes would fail the engine's own
+# publish, and the tag push that starts this job is the same event that starts
+# the engine's. So this job must hold no `gh release create` at all. Prose
+# describing what the Release once did is documentation, not a call: comments
+# are stripped before matching.
+if sed 's/[[:space:]]*#.*$//' "$WORKFLOW" | grep -qF 'gh release create'; then
+  fail "the release engine owns Release creation — this job must only attach assets to it"
+else
+  pass "this job creates no Release, leaving one owner for the object"
+fi
+
+# The release engine owns the Release; this job only attaches to it. A retry
+# must therefore converge rather than duplicate — `--clobber` re-uploads what a
+# half-finished publish already attached — and must still reconcile the major
+# tag, which is the completion marker the retry resolver reads.
+if grep -qF 'gh release upload "$NEXT" "${assets[@]}" --clobber' "$WORKFLOW" &&
+   grep -qF 'git push --force origin "refs/tags/$major:refs/tags/$major"' "$WORKFLOW"; then
+  pass "a retry re-attaches assets and still reconciles the major tag"
+else
+  fail "asset upload must converge on retry while major-tag reconciliation still runs"
+fi
+
+# The fleet-activity deferral was REMOVED (2026-07-22): red-publish never
+# touches main and running workers pin their bundle at spawn, so publishing
+# during a fleet is safe; the old gate repeatedly held releases hostage to
+# orphaned `running` labels.
+if ! grep -qF 'Defer if /afk fleet is active' "$WORKFLOW" &&
+   ! grep -qF "steps.fleet.outputs.running" "$WORKFLOW"; then
+  pass "publish has no fleet-activity deferral gate"
+else
+  fail "red-publish must not defer on fleet activity — it never touches main"
+fi
+
+if grep -qF 'for attempt in 1 2 3 4 5 6 7 8 9 10' "$WORKFLOW" &&
+   grep -qF 'sleep $((attempt * 15))' "$WORKFLOW"; then
+  pass "registry smoke budget covers multi-minute registry propagation lag"
+else
+  fail "registry smoke must retry across a multi-minute propagation window (10 attempts, attempt*15s backoff)"
+fi
+
+if (( failures > 0 )); then
+  printf '\n%d failure(s)\n' "$failures" >&2
+  exit 1
+fi
+
+printf '\nred-publish npm publish contract ok\n'

--- a/scripts/test-red-release-reddb-assets-contract.sh
+++ b/scripts/test-red-release-reddb-assets-contract.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Static contract test for the red-publish guard that catches dead reddb binary pointers.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+WORKFLOW=".github/workflows/red-publish.yml"
+SCRIPT="scripts/verify-reddb-release-assets.mjs"
+failures=0
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+
+pass() {
+  printf 'PASS: %s\n' "$*"
+}
+
+line_of_step() {
+  local step="$1"
+  local line
+  line="$(grep -nF -- "- name: $step" "$WORKFLOW" | head -n1 | cut -d: -f1 || true)"
+  if [ -z "$line" ]; then
+    fail "missing release workflow step: $step"
+    printf '0\n'
+  else
+    printf '%s\n' "$line"
+  fi
+}
+
+assert_before() {
+  local left_name="$1" left_line="$2" right_name="$3" right_line="$4"
+  if [ "$left_line" -gt 0 ] && [ "$right_line" -gt 0 ] && [ "$left_line" -lt "$right_line" ]; then
+    pass "$left_name runs before $right_name"
+  else
+    fail "$left_name must run before $right_name"
+  fi
+}
+
+memory_manifest_line="$(line_of_step "Build memory runtime bundle + manifest")"
+verify_line="$(line_of_step "Verify reddb release assets")"
+tag_line="$(line_of_step "GitHub Release")"
+
+assert_before "memory runtime manifest build" "$memory_manifest_line" "reddb asset verification" "$verify_line"
+assert_before "reddb asset verification" "$verify_line" "tag/GitHub release" "$tag_line"
+
+if grep -qF "node scripts/verify-reddb-release-assets.mjs dist/memory-runtime-manifest.json" "$WORKFLOW"; then
+  pass "publish workflow verifies the generated memory runtime manifest"
+else
+  fail "publish workflow must verify dist/memory-runtime-manifest.json"
+fi
+
+if grep -qF 'method: "HEAD"' "$SCRIPT" &&
+   grep -qF '`${entry.asset}.sha256`' "$SCRIPT" &&
+   grep -qF 'process.exitCode = 1' "$SCRIPT"; then
+  pass "reddb asset verifier HEAD-checks binaries and checksum sidecars"
+else
+  fail "reddb asset verifier must fail on missing binary or .sha256 asset"
+fi
+
+if (( failures > 0 )); then
+  printf '\n%d failure(s)\n' "$failures" >&2
+  exit 1
+fi
+
+printf '\nred-publish reddb asset contract ok\n'

--- a/scripts/verify-reddb-release-assets.mjs
+++ b/scripts/verify-reddb-release-assets.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+
+const manifestPath = process.argv[2] ?? "dist/memory-runtime-manifest.json";
+const releaseBase = process.env.REDDB_RELEASE_ASSET_BASE ?? "https://github.com";
+const timeoutMs = Number(process.env.REDDB_RELEASE_ASSET_TIMEOUT_MS ?? 15000);
+const attempts = Math.max(1, Number(process.env.REDDB_RELEASE_ASSET_ATTEMPTS ?? 4));
+const retryDelayMs = Math.max(0, Number(process.env.REDDB_RELEASE_ASSET_RETRY_DELAY_MS ?? 1000));
+
+function fail(message) {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+function assetUrl(repo, tag, asset) {
+  return `${releaseBase.replace(/\/+$/, "")}/${repo}/releases/download/${tag}/${asset}`;
+}
+
+function readReddbManifest(manifest) {
+  const reddb = manifest?.reddb;
+  if (!reddb || typeof reddb !== "object") {
+    throw new Error("runtime manifest is missing reddb metadata");
+  }
+  if (typeof reddb.repo !== "string" || !reddb.repo) {
+    throw new Error("runtime manifest is missing reddb.repo");
+  }
+  if (typeof reddb.tag !== "string" || !reddb.tag) {
+    throw new Error("runtime manifest is missing reddb.tag");
+  }
+  if (!reddb.assets || typeof reddb.assets !== "object") {
+    throw new Error("runtime manifest is missing reddb.assets");
+  }
+  return reddb;
+}
+
+async function headAsset(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method: "HEAD",
+      redirect: "follow",
+      signal: controller.signal,
+    });
+    if (response.status === 404) return { outcome: "absent", status: response.status };
+    if (response.ok) return { outcome: "present", status: response.status };
+    return { outcome: "http-error", status: response.status };
+  } catch (error) {
+    return { outcome: "unanswered", status: error instanceof Error ? error.message : String(error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function headAssetWithRetry(url) {
+  let result;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    result = await headAsset(url);
+    if (result.outcome !== "unanswered") return { ...result, attempts: attempt };
+    if (attempt < attempts) await delay(retryDelayMs * 2 ** (attempt - 1));
+  }
+  return { ...result, attempts };
+}
+
+const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+const reddb = readReddbManifest(manifest);
+const checks = [];
+
+for (const [platform, entry] of Object.entries(reddb.assets)) {
+  if (!entry || typeof entry !== "object" || typeof entry.asset !== "string" || !entry.asset) {
+    throw new Error(`runtime manifest has invalid asset entry for ${platform}`);
+  }
+  checks.push({ platform, url: assetUrl(reddb.repo, reddb.tag, entry.asset) });
+  checks.push({ platform, url: assetUrl(reddb.repo, reddb.tag, `${entry.asset}.sha256`) });
+}
+
+if (checks.length === 0) {
+  throw new Error("runtime manifest contains no reddb release assets");
+}
+
+for (const check of checks) {
+  const result = await headAssetWithRetry(check.url);
+  if (result.outcome === "present") {
+    console.log(`ok ${check.platform} ${check.url}`);
+  } else if (result.outcome === "absent") {
+    fail(`missing reddb release asset for ${check.platform}: HEAD ${check.url} -> 404`);
+  } else if (result.outcome === "unanswered") {
+    fail(
+      `could not verify reddb release asset for ${check.platform}: the network never answered HEAD ${check.url} ` +
+        `after ${result.attempts} attempts -> ${result.status}`,
+    );
+    break;
+  } else {
+    fail(`reddb release asset check failed for ${check.platform}: HEAD ${check.url} -> HTTP ${result.status}`);
+  }
+}


### PR DESCRIPTION
`v3.10.0` has a tag and a GitHub Release and nothing else: no bundles, no `.vsix`, no npm. `@reddb-io/red-skills` is still `3.9.0` on the registry.

Nothing broke on its own. The dogfood cutover (#3425) deleted `.github/workflows/red-publish.yml` and put the Release standard in its place — but the two are not the same job.

| | decides **which version** | publishes **what it contains** |
|---|---|---|
| before | changesets, by hand | `red-publish.yml` — tag → 20 assets + npm |
| after the cutover | the release engine ✅ | **nobody** ❌ |

That is also why 3.7.0, 3.8.0 and 3.9.0 all carry twenty assets and 3.10.0 carries zero: the first three were published by a workflow that no longer exists.

## What this restores

`red-publish.yml`, on its original `push: tags: v[0-9]+.[0-9]+.[0-9]+` trigger — exactly what the new engine produces. It builds every bundle, uploads the assets, publishes `@reddb-io/red-skills` and the Pi packages, smoke-tests the install, and moves the `vX` ref. Its `workflow_dispatch` and hourly retry come back with it, so **v3.10.0 can be published by dispatching this workflow at that tag**.

## Three things changed, each because the engine now exists

**One Release, one owner.** Restoring the file unchanged would have published nothing. The assets only ever uploaded on the branch that *creates* the Release, and the engine creates it now — so that branch is unreachable and every future release would have come out as empty as this one. The job now waits up to five minutes for the Release its tag's engine run publishes, then `gh release upload --clobber`. It holds no `gh release create` at all, and a contract test refuses one: the engine re-reads the body it wrote, so a second creator with generated notes would fail the engine's own publish.

**`sync-version.mjs` stays deleted.** It owned version-surface agreement — the version-train invariant's job now, run on every PR. The workflow keeps only the question that invariant cannot answer, because the tag is not in the tree: does the tag name the version the tree carries.

**`release-manifest.json` stays the engine's.** Two files under one name is how a reader trusts the wrong one. The per-bundle checksums it summarised still ship — each bundle carries its own `*.manifest.json`.

## The gap that let this happen

The two contract tests guarding this workflow ran **only inside `red-publish.yml`** — only at publish time, after the last chance to fix anything. That is how one refactor deleted five scripts this workflow calls with nothing going red: the only thing that read the publish workflow was the publish workflow. They are restored, updated to the new ownership, and now run in the PR gate.

Contracts green: npm publish, reddb assets, red-castle vendor, canary promotion, agent metadata, workflow pins, fork posture. Repo invariants 177/177.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788666297&installation_model_id=20659&pr_number=3463&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3463&signature=d3132d969d7825d354aa75a554d892a4cf98d390371b34999ccfa66a2f9b171d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->