### PR TITLE
fix(release): upload assets to the host the Release names

### DIFF
--- a/apps/release/src/github-release-adapter.ts
+++ b/apps/release/src/github-release-adapter.ts
@@ -16,6 +16,17 @@ export interface PublishedRelease {
   readonly body: string;
   readonly prerelease: boolean;
   readonly assets: readonly PublishedReleaseAsset[];
+  /**
+   * Where THIS host wants the Release's assets, as the Release itself answered.
+   *
+   * Asset upload is the one Release call that does not live on the API host:
+   * github.com serves it from `uploads.github.com`, and an Enterprise install
+   * answers with its own. A route spelled relative to the client's base URL
+   * therefore resolves to a path that exists nowhere and comes back 404. The
+   * environment is the source of truth for its own address, so the uploader
+   * reads it here rather than reconstructing it.
+   */
+  readonly uploadUrl: string;
 }
 
 export interface CreateReleaseInput {
@@ -28,6 +39,8 @@ export interface CreateReleaseInput {
 
 export interface UploadReleaseAssetInput {
   readonly releaseId: number;
+  /** The owning Release's `uploadUrl` — see {@link PublishedRelease.uploadUrl}. */
+  readonly uploadUrl: string;
   readonly name: string;
   readonly contentType: string;
   readonly data: Uint8Array;
@@ -220,11 +233,8 @@ export function createGithubReleaseAdapter(
     async uploadAsset(input): Promise<void> {
       await options.client.conditionalRest<unknown>({
         cacheKey: `release-asset:${repositoryKey}:${input.releaseId}:${input.name}`,
-        route: "POST /repos/{owner}/{repo}/releases/{release_id}/assets{?name}",
+        route: assetUploadRoute(input.uploadUrl),
         parameters: {
-          owner,
-          repo: repository,
-          release_id: input.releaseId,
           name: input.name,
           data: input.data,
           headers: {
@@ -293,7 +303,24 @@ function releaseFrom(value: unknown): PublishedRelease {
     body: stringField(value, "body"),
     prerelease: value.prerelease,
     assets,
+    uploadUrl: stringField(value, "upload_url"),
   };
+}
+
+/**
+ * The upload endpoint from a Release's `upload_url` RFC 6570 template.
+ *
+ * GitHub answers `https://uploads.github.com/…/assets{?name,label}`. The
+ * variable list is dropped and re-declared as `{?name}`: the caller supplies a
+ * name and never a label, and leaving `label` in the template would make the
+ * client expand a parameter nothing passes.
+ */
+function assetUploadRoute(uploadUrl: string): string {
+  const endpoint = uploadUrl.split("{")[0] ?? "";
+  if (!/^https?:\/\/\S+\/assets$/.test(endpoint)) {
+    throw new Error(`GitHub returned an unusable Release upload_url: ${uploadUrl}`);
+  }
+  return `POST ${endpoint}{?name}`;
 }
 
 function stringField(value: Record<string, unknown>, key: string): string {

--- a/apps/release/src/release-publication.ts
+++ b/apps/release/src/release-publication.ts
@@ -90,6 +90,7 @@ export async function publishRelease(
     try {
       await input.github.uploadAsset({
         releaseId: release.id,
+        uploadUrl: release.uploadUrl,
         name: asset.name,
         contentType: asset.contentType,
         data: asset.data,

--- a/apps/release/tests/release-engine.test.ts
+++ b/apps/release/tests/release-engine.test.ts
@@ -324,7 +324,13 @@ class FakeGithub implements ReleaseEngineGithub {
   }
 
   async create(input: CreateReleaseInput): Promise<PublishedRelease> {
-    const release = { id: this.releases.length + 1, ...input, assets: [] };
+    const id = this.releases.length + 1;
+    const release = {
+      id,
+      ...input,
+      assets: [],
+      uploadUrl: `https://uploads.github.invalid/releases/${id}/assets{?name,label}`,
+    };
     this.releases.push(release);
     this.assets.set(release.id, []);
     return release;

--- a/apps/release/tests/release-publication.test.ts
+++ b/apps/release/tests/release-publication.test.ts
@@ -164,8 +164,14 @@ function publicationFixture(options: { readonly failOnceFor?: string } = {}) {
   };
 }
 
+/** github.com serves asset upload from `uploads.github.com`; the fixture mirrors
+ * that split so the API host and the upload host are not the same origin. */
+const UPLOAD_ORIGIN = "https://uploads.github.invalid";
+const UPLOAD_URL = `${UPLOAD_ORIGIN}/repos/example/widgets/releases/1/assets{?name,label}`;
+
 interface FakeRelease {
   readonly id: number;
+  readonly upload_url: string;
   readonly tag_name: string;
   readonly target_commitish: string;
   readonly name: string;
@@ -194,6 +200,15 @@ class FakeReleaseApi {
       const url = new URL(String(input));
       const method = init?.method ?? "GET";
       const path = url.pathname.replace(/^\/api\/v3/, "");
+      const onUploadHost = url.origin === UPLOAD_ORIGIN;
+
+      // Asset upload is the one Release call GitHub does not serve from the API
+      // host, so the fixture does not either. A uploader that builds the route
+      // relative to the client's base URL gets the 404 the real host gives —
+      // the whole failure this file exists to catch.
+      if (method === "POST" && !onUploadHost && path.endsWith("/assets")) {
+        return json({ message: "Not Found" }, 404);
+      }
 
       if (method === "GET" && path === "/repos/example/widgets/releases/tags/v2.0.0") {
         if (this.release === null) return json({ message: "Not Found" }, 404);
@@ -201,11 +216,14 @@ class FakeReleaseApi {
       }
       if (method === "POST" && path === "/repos/example/widgets/releases") {
         this.createCalls += 1;
-        const payload = JSON.parse(await bodyText(init?.body)) as Omit<FakeRelease, "id" | "assets">;
-        this.release = { id: 1, ...payload, assets: [] };
+        const payload = JSON.parse(await bodyText(init?.body)) as Omit<
+          FakeRelease,
+          "id" | "assets" | "upload_url"
+        >;
+        this.release = { id: 1, ...payload, assets: [], upload_url: UPLOAD_URL };
         return json(this.release, 201);
       }
-      if (method === "POST" && path === "/repos/example/widgets/releases/1/assets") {
+      if (method === "POST" && onUploadHost && path === "/repos/example/widgets/releases/1/assets") {
         const name = url.searchParams.get("name") ?? "";
         if (name === this.failOnceFor && !this.failed) {
           this.failed = true;


### PR DESCRIPTION
The `v3.10.0` publish created the Release, then died with a bare `Not Found - https://docs.github.com/rest`. The Release is real and marked Latest; `assets` is empty.

## Why

Asset upload is the one Release call GitHub does not serve from the API host. github.com serves it from `uploads.github.com`, and an Enterprise install answers with its own address. The uploader spelled the route relative to the client's base URL:

```
POST /repos/{owner}/{repo}/releases/{release_id}/assets{?name}
```

…so it resolved against `api.github.com` — a path that exists nowhere, which is a 404.

## The fix

The Release itself carries `upload_url`: the environment answering for its own address. The uploader reads it rather than reconstructing it, so this holds for Enterprise as much as for github.com. The RFC 6570 variable list is re-declared as `{?name}` — the caller supplies a name and never a label, and leaving `label` in would expand a parameter nothing passes.

## The fixture is where this hid

It served the upload from the same origin as the API, so no test could observe that the real host does not. It now splits the two origins and answers a POST to the API host's asset path with the 404 GitHub gives. Verified by reverting the source fix against the new fixture: **3 of 41 fail**, all three publication tests. With the fix, 41/41.

Workspace typecheck 16/16.

Independent of #3463, which restores the artifact publisher that builds the other twenty assets.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788666515&installation_model_id=20659&pr_number=3464&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3464&signature=7bc867491d4b268ae40ca0a0f17b5c94558f63ef522e8229ee8ab97e09c39d38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->