### PR TITLE
chore(release): cut 3.10.1 with the release last-mile fixes

### DIFF
--- a/.changeset/the-release-reaches-the-registry.md
+++ b/.changeset/the-release-reaches-the-registry.md
@@ -1,0 +1,39 @@
+---
+"@reddb-io/dev": patch
+---
+
+The release reaches the registry again.
+
+The Release standard cutover moved the version half of releasing into an engine
+and, in the same commit, deleted the workflow that published the other half.
+Nothing went red, because the only thing that read the publish workflow was the
+publish workflow. The first release after the cutover produced a tag, a Release,
+and no artifacts at all — no bundles, no `.vsix`, no npm.
+
+- **The artifact publisher is back, on the tag the engine produces.** It builds
+  every bundle, uploads the assets, publishes the npm and Pi packages, smoke-tests
+  the install, and moves the `vX` ref. Restoring it unchanged would have published
+  nothing: the assets only ever uploaded on the branch that *creates* the Release,
+  and the engine creates it now, so that branch was unreachable. **One Release, one
+  owner** — the job waits for the Release its tag's engine run published, then
+  uploads onto it, and holds no `gh release create` at all. Two creators would race
+  over one object, and the engine re-reads the body it wrote.
+- **The contracts guarding that workflow run in the PR gate**, not only inside the
+  publish they guard — which is to say, no longer only after the last chance to fix
+  anything.
+- **Assets upload to the host the Release names.** Asset upload is the one Release
+  call GitHub does not serve from the API host. The route was spelled relative to
+  the client's base URL, so it resolved to a path that exists nowhere and came back
+  as a bare 404. The Release carries `upload_url`; the uploader reads it, which is
+  also what makes this correct on Enterprise. The fixture is where this hid — it
+  served the upload from the API origin, so no test could observe that the real
+  host does not.
+- **The release commit is authored by an account GitHub can resolve.** GitHub
+  attributes a commit by author email, and the engine used an address belonging to
+  nobody — so a repository whose approval policy is `first_time_contributors` read
+  every Version PR as exactly that and held its checks at `action_required`. The
+  autonomous train ended by asking a human to click Approve. The name stays the
+  loop-breaker the generated workflow reads; two roles, two fields.
+- **The release job carries the repository's toolchain.** The `sync_command` is
+  declared by the operator and may reach any tool the repo has; the generated job
+  installed only Node, so the first sync died on `pnpm: not found`.


### PR DESCRIPTION
Cuts **3.10.1**, carrying the four fixes that stood between a merge and a published version: the restored artifact publisher (#3463), the asset upload host (#3464), the release commit's authorship (#3462), and the release job's toolchain (#3460).

## Why not 3.10.0

**3.10.0 was retracted.** Its tag was cut inside the window where the repo had no artifact publisher, and the publish workflow checks out the tree the tag names — so 3.10.0's tree cannot run the publisher that would build it. It was also blocking every future release: the FIFO rule that stops `npm/latest` moving backwards treats an unpublished tag as the head of the queue.

Nothing consumed it. The Release carried zero assets, never reached npm, and was one hour old. The tag and the Release are deleted, which says plainly what happened: this version was never published.

npm therefore goes **3.9.0 → 3.10.1**.

## What happens when this merges

The engine opens `chore(release): 3.10.1`; merging that pushes the tag; the tag push runs the restored publisher against a tree that finally contains it.

Changeset validation green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788667052&installation_model_id=20659&pr_number=3465&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3465&signature=34cd42a469d7e6b1d3d7dbe2acfc43de58bbe5ae8d234b311d7bc1d1f27e2d8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->