### PR TITLE
fix(release): the asset reuse names the previous release, not `latest`

### DIFF
--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -315,6 +315,7 @@ jobs:
         working-directory: apps/memory
         env:
           NEXT: ${{ steps.target.outputs.tag }}
+          PREVIOUS: ${{ steps.target.outputs.previous }}
           RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
           RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
           RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
@@ -348,9 +349,20 @@ jobs:
           // live from the new tag. Carrying them across a bump is how a dead pointer
           // survived unnoticed: reddb aged out the pinned release, the live .sha256
           // 404'd, and the stale checksums were copied forward release after release.
+          // Named explicitly, never via `releases/latest`. The release engine
+          // publishes the Release before this job attaches anything to it, so
+          // `latest` is THIS release — empty — and reading it 404s on the very
+          // manifest we are about to write. The previous release is what "the
+          // manifest we might carry forward from" has always meant.
           async function previousRedAssets() {
-            const url = 'https://github.com/reddb-io/red-skills/releases/latest/download/memory-runtime-manifest.json';
+            const previousTag = process.env.PREVIOUS ?? '';
+            if (previousTag === '') return {};
+            const url = `https://github.com/reddb-io/red-skills/releases/download/${previousTag}/memory-runtime-manifest.json`;
             const response = await fetch(url, { redirect: 'follow' });
+            // A previous release without this manifest is not a failure: with no
+            // checksums to carry, every asset resolves live from the pinned tag,
+            // which is the safe path the pin-bump case already takes.
+            if (response.status === 404) return {};
             if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
             const previous = await response.json();
             if (previous?.reddb?.sdk !== sdk || previous?.reddb?.tag !== reddb.tag) return {};
@@ -395,6 +407,7 @@ jobs:
         working-directory: apps/brain
         env:
           NEXT: ${{ steps.target.outputs.tag }}
+          PREVIOUS: ${{ steps.target.outputs.previous }}
           RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
           RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
           RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
@@ -420,10 +433,15 @@ jobs:
             'macos-aarch64': 'red-macos-aarch64',
             'windows-x86_64': 'red-windows-x86_64.exe',
           };
-          // No fallback across a pin bump — see the memory manifest step above.
+          // No fallback across a pin bump, and the PREVIOUS release named
+          // explicitly rather than `releases/latest` — see the memory manifest
+          // step above for both reasons.
           async function previousRedAssets() {
-            const url = 'https://github.com/reddb-io/red-skills/releases/latest/download/brain-runtime-manifest.json';
+            const previousTag = process.env.PREVIOUS ?? '';
+            if (previousTag === '') return {};
+            const url = `https://github.com/reddb-io/red-skills/releases/download/${previousTag}/brain-runtime-manifest.json`;
             const response = await fetch(url, { redirect: 'follow' });
+            if (response.status === 404) return {};
             if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
             const previous = await response.json();
             if (previous?.reddb?.sdk !== sdk || previous?.reddb?.tag !== reddb.tag) return {};


### PR DESCRIPTION
The restored publisher got as far as building the memory runtime and died:

```
GET https://github.com/reddb-io/red-skills/releases/latest/download/memory-runtime-manifest.json -> 404
```

## Why

The step carries reddb binary checksums forward from the last manifest, reading them through `releases/latest`. That was correct while this job also **created** the Release — `latest` was always a finished one.

The release engine publishes the Release before this job attaches anything to it. So `latest` is now **this** release, which is empty, and the job 404s on the very manifest it is about to write. Same root as #3463's ownership split, seen from the other side: the Release exists earlier than it used to, and everything that read `latest` as "the last complete release" is now reading an empty one.

## The fix

Both the memory and brain steps name `$PREVIOUS` explicitly — which is what "the manifest we might carry forward from" always meant. The resolver already computes it.

A previous release without the manifest returns no checksums rather than failing: with none to carry, every asset resolves live from the pinned tag, which is exactly the safe path the pin-bump case already takes. The loud failure is preserved for any status that is not 404.

Contracts green: npm publish, reddb assets, workflow pins. `releases/latest/download` no longer appears in the workflow.

Follow-up, not in this PR: `push: tags:` no longer fires this workflow at all, because the engine pushes the tag with `GITHUB_TOKEN` and GitHub does not trigger workflows from it. Only the hourly retry cron reaches a new tag today.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788681279&installation_model_id=20659&pr_number=3468&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3468&signature=4305054ff1bef220a7c23ff5484ceb05c77e769828a5745e5508c2166694f7c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->