### PR TITLE
test(daemon): measure what a terminal shows, and read the pool the routing chose

### DIFF
--- a/.changeset/the-gate-tells-you-which-thing-is-wrong.md
+++ b/.changeset/the-gate-tells-you-which-thing-is-wrong.md
@@ -1,0 +1,53 @@
+---
+"@reddb-io/dev": minor
+---
+
+The gate says which thing is wrong.
+
+A span of fixes that share one shape: a check reported the symptom it could see
+rather than the fault that caused it, so the reader was sent to repair something
+that was already correct.
+
+- **A missing toolchain is not manifest drift.** The manifest contract ran in a
+  job carrying only a checkout, so every `pnpm` was `command not found` and each
+  one was reported as "manifests drift — run pnpm generate-manifests". It runs
+  where the workspace is installed now, and refuses by name when the toolchain
+  is absent.
+- **A `tq` newer than the catalog is not drift either.** The version check
+  demanded equality in three places, so an operator running the current release
+  went red and the remediation told them to DOWNGRADE — to match a catalog a
+  broken watcher had failed to advance. The catalog is a floor now; only BEHIND
+  is a failure. The watcher can advance it again: `pnpm install --lockfile-only`
+  ran with pnpm's CI-implicit frozen lockfile, so the one command whose job is to
+  write the lockfile was forbidden from writing it.
+- **Durable state is not a live artifact, and a setting is not a moment.** Two
+  `/red-doctor` checks judged by hand-kept lists and reported findings that were
+  not defects — one calling the castle residents' own durable state "live
+  supervisor artifacts", the other telling an operator to delete four live
+  configuration keys, including the regeneration declaration that had just
+  stopped a mirror going stale in CI four times over. Both now judge by what the
+  thing is, declared beside the code that owns it.
+- **Colour is not width, and escapes are not content.** Dashboard assertions
+  measured the escaped string: a line that fits in 96 columns read as 433, and
+  fields that were present read as missing. They measure what a terminal shows.
+- **A read that moved pools did not vanish.** `issue list` routes to REST now —
+  an unchanged poll can come back free there — so a GraphQL-only spend assertion
+  read as a lost ledger record rather than a record in another pool.
+
+## Also in this span
+
+- **Worktrees come from git's inventory.** Host CLIs mint their own now
+  (`--worktree`), before any tool call exists, so a Bash pre-exec guard cannot
+  see them; this repo was already carrying 440MB of one. The audit asks git,
+  which answers for hosts that do not exist yet, and `red-skills-dev worktree`
+  gives the same ergonomics landing in a registered lane — for every runner,
+  including the ones with no such flag.
+- **A god file cannot grow back unnoticed.** A shrink-only file-size ratchet:
+  a file absent from the baseline may not exceed the threshold, a file in it may
+  only shrink, and one that passes under must leave the baseline. `mcp-adapter`'s
+  2070-line body is six domain modules; the daemon's option and interval surfaces
+  left its lifecycle.
+- **`.red/` carries its own ignore rules**, and boot stops writing a second copy
+  of them into the repo root.
+- **The release reaches the registry**: the artifact publisher the version-train
+  cutover removed is back, on the tag the engine produces.

--- a/apps/redskilled/tests/github-spend-command.test.ts
+++ b/apps/redskilled/tests/github-spend-command.test.ts
@@ -18,7 +18,12 @@ afterEach(async () => {
 });
 
 describe("redskilled github-spend", () => {
-  it("reports the last hour's GraphQL spend from a restarted durable ledger", async () => {
+  // Asks for the REST pool, because that is where these reads now live. Polling
+  // collection reads were routed to REST deliberately — an unchanged poll can
+  // come back free there — so a GraphQL-only assertion over `issue list` was
+  // asserting a routing decision the surface had already reversed, and read as
+  // "the ledger lost the record" instead of "the record went to another pool".
+  it("reports the last hour's spend from a restarted durable ledger", async () => {
     const root = await mkdtemp(join(tmpdir(), "redskilled-github-spend-"));
     roots.push(root);
     const path = join(root, "spend.toonl");
@@ -44,7 +49,7 @@ describe("redskilled github-spend", () => {
 
     let printed = "";
     const restarted = createGithubAttributionLedger({ path });
-    const code = await runGithubSpend([], {
+    const code = await runGithubSpend(["--pool", "rest"], {
       ledger: restarted,
       now: () => "2026-08-04T19:00:00.000Z",
       write: (text) => { printed += text; },
@@ -58,16 +63,23 @@ describe("redskilled github-spend", () => {
         from: "2026-08-04T18:00:00.000Z",
         to: "2026-08-04T19:00:00.000Z",
       },
-      pool: "graphql",
-      total_count: 1,
-      total_cost: 7,
+      pool: "rest",
+      total_count: 2,
+      total_cost: 8,
       operations: [
         {
           operation_key: "issue list",
-          pool: "graphql",
+          pool: "rest",
           actor: "worker:wONE",
           count: 1,
           cost: 7,
+        },
+        {
+          operation_key: "issue view",
+          pool: "rest",
+          actor: "worker:wONE",
+          count: 1,
+          cost: 1,
         },
       ],
       unreadable_records: 0,

--- a/apps/redskilled/tests/published-display-reaches-the-payload.test.ts
+++ b/apps/redskilled/tests/published-display-reaches-the-payload.test.ts
@@ -18,6 +18,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { stripAnsi } from "@reddb-io/redskilled-render";
 import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
 import {
   publishRedskilledWorkerLogLine,
@@ -185,7 +186,7 @@ describe("a published display reaches the payload", () => {
     expect(row?.cells.bar).toBe("██▶░░");
     expect(row?.cells.hb).toBe("hb=3s");
     // And the row a reader actually sees is the one that carried a UUID and an age.
-    expect(row?.line).toContain("iss=3144");
+    expect(stripAnsi(row?.line ?? "")).toContain("iss=3144");
     expect(row?.line).toContain("coding·tests");
   });
 

--- a/apps/redskilled/tests/statusline-dashboard.test.ts
+++ b/apps/redskilled/tests/statusline-dashboard.test.ts
@@ -13,6 +13,8 @@ import { publishRedskilledWorkerLogLine, readRedskilledDashboard } from "../src/
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import {
   REDSKILLED_DASHBOARD_COLUMNS,
+  stripAnsi,
+  width,
   REDSKILLED_DASHBOARD_DEFAULTS,
   progressBar,
   renderRedskilledDashboard,
@@ -286,10 +288,10 @@ describe("the dashboard carries the statusline's own fields", () => {
     expect(header.version).toBe("0.1.0");
     expect(header.model).toBe("claude·opus·high");
     expect(header.counts).toMatchObject({ open_pull_requests: 3, open_issues: 24, recently_closed: 7 });
-    expect(header.line).toContain("» acme/widgets v0.1.0");
-    expect(header.line).toContain("prs=3");
-    expect(header.line).toContain("cpr=7");
-    expect(header.line).toContain("iss=24");
+    expect(stripAnsi(header.line)).toContain("» acme/widgets v0.1.0");
+    expect(stripAnsi(header.line)).toContain("prs=3");
+    expect(stripAnsi(header.line)).toContain("cpr=7");
+    expect(stripAnsi(header.line)).toContain("iss=24");
   });
 
   it("prints the header first and one line per row, so a surface prints and splits nothing", () => {
@@ -341,9 +343,9 @@ describe("the header carries the rates the daemon derived", () => {
       LOCAL,
     );
 
-    expect(dashboard.header.line).toContain("tk/m=1.2k");
-    expect(dashboard.header.line).toContain("tl/m=8.4");
-    expect(dashboard.header.line).toContain("claude=67%");
+    expect(stripAnsi(dashboard.header.line)).toContain("tk/m=1.2k");
+    expect(stripAnsi(dashboard.header.line)).toContain("tl/m=8.4");
+    expect(stripAnsi(dashboard.header.line)).toContain("claude=67%");
     // The whole block travels beside the line, so a surface with room draws both
     // windows and both dimensions without a second read.
     expect(dashboard.header.metrics?.day.model_share.shares.map((share) => share.key)).toEqual(["opus", "sonnet"]);
@@ -367,9 +369,12 @@ describe("the header carries the rates the daemon derived", () => {
       { ...LOCAL, maxWidth: 96 },
     );
 
-    expect(narrow.header.line.length).toBeLessThanOrEqual(96);
+    // Measured as a terminal measures it. `.length` counts the colour escapes
+    // too, so a line that fits in 96 columns read as 433 and the assertion was
+    // about bytes, not about the one line a status bar shows.
+    expect(width(narrow.header.line)).toBeLessThanOrEqual(96);
     expect(narrow.header.line).not.toContain("tk/m");
-    expect(narrow.header.line).toContain("wrk=1/1");
+    expect(stripAnsi(narrow.header.line)).toContain("wrk=1/1");
     // Dropped from the LINE, never from the answer: the block a surface reads
     // structurally does not shrink because a status bar is narrow.
     expect(narrow.header.metrics).not.toBeNull();

--- a/apps/redskilled/tests/statusline-string.test.ts
+++ b/apps/redskilled/tests/statusline-string.test.ts
@@ -333,8 +333,12 @@ describe("one renderer, machine-wide", () => {
     "apps/redskilled/src/statusline-render.ts",
     "apps/redskilled/src/dashboard-render.ts",
     "apps/redskilled/src/statusline-payload.ts",
-    // The implementation, not the façade `daemon.ts`, which forwards only.
+    // The implementation, not the façade `daemon.ts`, which forwards only. The
+    // daemon's payload types and its intervals live beside it, so all three are
+    // consumers — the split moved the code, not the consumption.
     "apps/redskilled/src/daemon/lifecycle.ts",
+    "apps/redskilled/src/daemon/types.ts",
+    "apps/redskilled/src/daemon/tunables.ts",
     "apps/redskilled/src/protocol.ts",
     "apps/redskilled/src/client.ts",
   ]);


### PR DESCRIPTION
Clears the last six failures in `apps/redskilled` — **696/696** — and adds the changeset that cuts the version for everything landed since 3.10.1.

## The six

Every one was reporting a symptom rather than its cause.

**Three dashboard assertions measured the escaped string.** A line that fits in 96 columns read as **433**, and fields that were plainly present read as missing, because `.length` and `toContain` counted the colour codes sitting between the characters. The contract is about the one line a status bar shows, so they measure that now — `stripAnsi` and `width` already existed in the render package.

**The spend report asserted GraphQL over `issue list`.** That operation routes to **REST** now, deliberately: an unchanged poll can come back free there. So an empty GraphQL report read as *"the ledger lost the record"* when the truth was *"the record went to another pool"*. The test asks for the pool the routing actually chose, and says why in a comment so the next reader does not re-flip it.

**Two modules the god-file split created carry payload types**, so they join the declared consumer set. The split moved the code, not the consumption.

## The changeset

`minor`, covering the whole span since 3.10.1 — #3468 through #3473 plus this. Its spine is the shape they share: **a check that reports the symptom it can see, rather than the fault that caused it, sends the reader to repair something already correct.** A missing toolchain reported as manifest drift; a `tq` newer than the catalog reported as drift with a remediation to *downgrade*; durable resident state reported as a live artifact; live config keys reported as unsupported declarations; colour counted as width; a re-routed read counted as a lost record.

## Verified

`apps/redskilled` **696/696** · repo invariants **184/184** · workspace typecheck 16/16 · `pnpm lint` 0 · changeset validation ok.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788706423&installation_model_id=20659&pr_number=3474&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3474&signature=2ece5a5a94f460ec54c560d9ec4286326c5d5175f91774410c66d52aa34e45b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->