### PR TITLE
fix(release): recognize descendant hotfixes on major channels

### DIFF
--- a/.changeset/release-major-channel-hotfix.md
+++ b/.changeset/release-major-channel-hotfix.md
@@ -1,0 +1,4 @@
+---
+"@reddb-io/dev": patch
+---
+Keep the release queue moving when a `vX` install channel points to a descendant hotfix instead of the exact `vX.Y.Z` release commit.

--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -88,20 +88,14 @@ jobs:
           # remain retryable. A major ref at this release OR a newer release in
           # the same major means this tag's tail was reconciled successfully.
           major_reaches() {
-            local candidate="$1" major major_sha pointed pointed_version candidate_version
+            local candidate="$1" major major_sha
             major="$(major_for "$candidate")"
             major_sha="$(git rev-parse -q --verify "refs/tags/${major}^{commit}" 2>/dev/null || true)"
             [ -n "$major_sha" ] || return 1
-            candidate_version="${candidate#v}"
-            while IFS= read -r pointed; do
-              [ -n "$pointed" ] || continue
-              [ "$(major_for "$pointed")" = "$major" ] || continue
-              pointed_version="${pointed#v}"
-              if [ "$(printf '%s\n%s\n' "$candidate_version" "$pointed_version" | sort -V | tail -n1)" = "$pointed_version" ]; then
-                echo "::notice::$candidate has a GitHub Release and $major ref already reaches $pointed"
-                return 0
-              fi
-            done < <(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --points-at "$major_sha")
+            if git merge-base --is-ancestor "refs/tags/${candidate}^{commit}" "$major_sha"; then
+              echo "::notice::$candidate has a GitHub Release and $major ref already reaches it"
+              return 0
+            fi
             return 1
           }
 
@@ -131,7 +125,7 @@ jobs:
                  [ "$(printf '%s\n%s\n' "$candidate_version" "$pointed_version" | sort -V | tail -n1)" = "$pointed_version" ]; then
                 return 0
               fi
-            done < <(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --points-at "$major_sha")
+            done < <(git tag --merged "$major_sha" --list "${major}.[0-9]*.[0-9]*")
             return 1
           }
 

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -189,6 +189,66 @@ else
   fail "a GitHub Release alone must not suppress major-tag reconciliation"
 fi
 
+# A moving major ref is an install channel, not necessarily an alias of the
+# exact release commit. A hotfix may advance `v2` one commit past `v2.88.0`;
+# the FIFO resolver must still recognise that the channel reaches v2.88.0,
+# otherwise every historical v2 release becomes pending again and blocks v3.
+resolver_fixture="$(mktemp -d)"
+trap 'rm -rf "$resolver_fixture"' EXIT
+
+mkdir -p "$resolver_fixture/bin" "$resolver_fixture/repo"
+git -C "$resolver_fixture/repo" init -q
+git -C "$resolver_fixture/repo" config user.name "Release Contract"
+git -C "$resolver_fixture/repo" config user.email "release-contract@example.invalid"
+
+git -C "$resolver_fixture/repo" commit --allow-empty -qm "release v2.88.0"
+git -C "$resolver_fixture/repo" tag v2.88.0
+git -C "$resolver_fixture/repo" commit --allow-empty -qm "v2 install-channel hotfix"
+git -C "$resolver_fixture/repo" tag v2
+git -C "$resolver_fixture/repo" switch -qc historical-v3.1.2
+git -C "$resolver_fixture/repo" commit --allow-empty -qm "divergent release v3.1.2"
+git -C "$resolver_fixture/repo" tag v3.1.2
+git -C "$resolver_fixture/repo" switch -q -
+git -C "$resolver_fixture/repo" commit --allow-empty -qm "release v3.10.1"
+git -C "$resolver_fixture/repo" tag v3.10.1
+git -C "$resolver_fixture/repo" tag v3
+git -C "$resolver_fixture/repo" commit --allow-empty -qm "release v3.11.0"
+git -C "$resolver_fixture/repo" tag v3.11.0
+
+cat > "$resolver_fixture/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "release" ] && [ "${2:-}" = "view" ]; then
+  case "${3:-}" in
+    v2.88.0 | v3.1.2 | v3.10.1 | v3.11.0) exit 0 ;;
+  esac
+fi
+exit 1
+EOF
+chmod +x "$resolver_fixture/bin/gh"
+
+awk '
+  $0 == "      - name: Resolve the release tag" { in_step = 1; next }
+  in_step && $0 == "        run: |" { capture = 1; next }
+  capture && /^      - name:/ { exit }
+  capture { sub(/^          /, ""); print }
+' "$WORKFLOW" > "$resolver_fixture/resolve-release-tag.sh"
+
+if (
+  cd "$resolver_fixture/repo"
+  PATH="$resolver_fixture/bin:$PATH" \
+    EVENT_NAME=workflow_dispatch \
+    REF_NAME= \
+    INPUT_TAG=v3.11.0 \
+    GITHUB_OUTPUT="$resolver_fixture/github-output" \
+    bash "$resolver_fixture/resolve-release-tag.sh"
+) > "$resolver_fixture/stdout" 2>&1 &&
+   grep -q '^publish=true$' "$resolver_fixture/github-output" &&
+   grep -q '^tag=v3.11.0$' "$resolver_fixture/github-output"; then
+  pass "a moving major ref may carry a descendant hotfix without reopening its release line"
+else
+  fail "a descendant hotfix on a moving major ref must not block the next release"
+fi
+
 # One Release, one owner. The release engine creates it and re-reads the body it
 # wrote; a Release created here with generated notes would fail the engine's own
 # publish, and the tag push that starts this job is the same event that starts


### PR DESCRIPTION
## What changed

- treat a moving `vX` ref as reaching any release commit in its ancestry
- detect later releases reachable from a descendant hotfix when enforcing FIFO
- add a behavioral fixture that runs the workflow's real resolver against a hotfixed major channel and divergent release history
- record the release-flow fix as a patch changeset

## Root cause

The `v2` install channel intentionally points one commit past `v2.88.0` to carry the Windows tar hotfix. The resolver required `v2` to point exactly at a `v2.X.Y` commit, so it reopened the entire v2 release line and blocked `v3.11.0` behind `v2.0.0`.

## Impact

The release queue preserves the hotfixed `v2` channel and can publish `v3.11.0` without replaying historical v2 releases.

## Validation

- `bash scripts/test-red-release-npm-publish-contract.sh`
- `bash scripts/test-workflow-security-pins.sh`
- `pnpm --dir apps/dev exec vitest run tests/ask-red-router-doctor.test.ts tests/ask-red-docs.test.ts tests/release-setup-docs.test.ts`
- extracted resolver run against the real remote tags and Releases: selected `v3.11.0` with previous `v3.10.1`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788715370&installation_model_id=20659&pr_number=3476&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3476&signature=5d0cf4b8f0fa54c9e98e95c8bf4417bf41509d599c36750f13c89ee8f6ae3618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->