### PR TITLE
fix(opencode): accept Windows skill paths

### DIFF
--- a/.changeset/fix-windows-opencode-skill-paths.md
+++ b/.changeset/fix-windows-opencode-skill-paths.md
@@ -1,0 +1,4 @@
+---
+"@reddb-io/red-skills": patch
+---
+Generate the complete OpenCode skill surface when installing RedSkills with native Windows Node.

--- a/apps/opencode-host/src/skills-to-opencode.ts
+++ b/apps/opencode-host/src/skills-to-opencode.ts
@@ -65,6 +65,11 @@ const DESCRIPTION_MAX = 1024;
 /** Buckets the generator skips — drafts only. */
 const SKIP_BUCKETS = new Set(["in-progress"]);
 
+/** Split a path returned by node:path.relative on either host family. */
+export function skillRelativeParts(path: string): string[] {
+  return path.split(/[\\/]/);
+}
+
 /**
  * Parse a RedSkills `SKILL.md` and return the `name` and `description`
  * from the YAML frontmatter. The RedSkills SKILL.md uses a constrained
@@ -151,7 +156,7 @@ export function planSkill(source: string, pluginsRoot: string, plugin: string): 
   // Expected layout: <bucket>/<name>/SKILL.md. The bucket must NOT be
   // `in-progress/` (filtered earlier) and must NOT be a flat SKILL.md
   // at the skills/ root.
-  const parts = rel.split("/");
+  const parts = skillRelativeParts(rel);
   if (parts.length !== 3 || parts[2] !== "SKILL.md") {
     errors.push({
       path: source,

--- a/apps/opencode-host/tests/skills-to-opencode.test.ts
+++ b/apps/opencode-host/tests/skills-to-opencode.test.ts
@@ -11,6 +11,7 @@ import {
   parseFrontmatter,
   planPluginSkills,
   planSkill,
+  skillRelativeParts,
 } from "../src/skills-to-opencode.js";
 
 let root: string;
@@ -75,6 +76,19 @@ describe("listSkillFiles", () => {
 });
 
 describe("planSkill (ADR 0076 §1 name validation)", () => {
+  it("accepts the path separators emitted by both POSIX and Windows", () => {
+    expect(skillRelativeParts("engineering/afk/SKILL.md")).toEqual([
+      "engineering",
+      "afk",
+      "SKILL.md",
+    ]);
+    expect(skillRelativeParts("engineering\\afk\\SKILL.md")).toEqual([
+      "engineering",
+      "afk",
+      "SKILL.md",
+    ]);
+  });
+
   it("accepts a valid lowercase-hyphenated name", () => {
     writeSkill("afk", "---\nname: afk\ndescription: x\n---\n");
     const files = listSkillFiles(root, "dev");


### PR DESCRIPTION
## What changed

- normalize the relative skill path separator before validating its three-part layout
- cover both POSIX and Windows `node:path.relative` output in the planner tests
- add a patch changeset for the native Windows OpenCode install fix

## Why

Native Windows Node returns backslashes from `path.relative`. The planner split only on `/`, rejected every valid skill, and emitted `skills=0` with 67 warnings while still exiting successfully.

## Impact

RedSkills now generates the complete OpenCode skill surface when installed with native Windows Node.

## Validation

- 113/113 `apps/opencode-host` tests
- `apps/opencode-host` typecheck
- oxlint on changed source and test
- pending changeset validation
- native `node.exe` ground-truth probe: `skills=67`, `warnings=0`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788718779&installation_model_id=20659&pr_number=3480&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3480&signature=59458946c333b18d2b2d84b19f767aeb924c2a43f1f448af5d4c74c8d8bd2fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->