### PR TITLE
fix(opencode): launch installed rsp MCP

### DIFF
--- a/.changeset/fix-installed-rsp-launcher.md
+++ b/.changeset/fix-installed-rsp-launcher.md
@@ -1,0 +1,4 @@
+---
+"@reddb-io/red-skills": patch
+---
+Launch the bundled rsp MCP from native Windows OpenCode installations without requiring a separate rsp command.

--- a/apps/opencode-host/src/mcp-passthrough.ts
+++ b/apps/opencode-host/src/mcp-passthrough.ts
@@ -19,7 +19,7 @@
  * No filesystem IO happens here beyond the `.mcp.json` read. The
  * planner is pure; the emit step is the thin shell that writes.
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -114,6 +114,22 @@ export function resolveScriptPath(
   return { path: null, candidate: candidates[0] ?? null };
 }
 
+/** Resolve explicit `$HOME/...` launchers from a source shell fallback. */
+export function resolveHomeScriptPath(
+  body: string,
+  home: string = homedir(),
+): string | null {
+  for (const match of body.matchAll(/\$HOME\/([\w./-]+)/g)) {
+    const candidate = join(home, match[1]!);
+    try {
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      // Try the next explicit home-relative candidate.
+    }
+  }
+  return null;
+}
+
 /** Rewrite a single Claude/Codex `mcpServers` entry to opencode's
  *  `mcp:` shape. The rewrite has three branches:
  *    - `command: "sh"` + `args: ["-c", "<body>"]` (the common
@@ -196,12 +212,14 @@ function rewriteShC(
     }
   }
 
-  let resolvedPath: string | null = null;
-  for (const rel of candidates) {
-    const { path } = resolveScriptPath(pluginsRoot, plugin, rel);
-    if (path) {
-      resolvedPath = path;
-      break;
+  let resolvedPath = resolveHomeScriptPath(body);
+  if (!resolvedPath) {
+    for (const rel of candidates) {
+      const { path } = resolveScriptPath(pluginsRoot, plugin, rel);
+      if (path) {
+        resolvedPath = path;
+        break;
+      }
     }
   }
 
@@ -238,7 +256,7 @@ function rewriteShC(
   // for the bootstrap, `< $tmp` style stdin redirects are not
   // expressible in the opencode command array — the bootstrap
   // reads its own stdin if needed).
-  const trailing = body.match(/mcp(?=['"\s]|$)/) ? ["mcp"] : [];
+  const trailing = body.match(/mcp(?=['"\s;|&]|$)/) ? ["mcp"] : [];
 
   const entry: McpEntry = {
     type: "local",

--- a/apps/opencode-host/tests/mcp-passthrough.test.ts
+++ b/apps/opencode-host/tests/mcp-passthrough.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   planPluginMcp,
   readMcpJson,
+  resolveHomeScriptPath,
   resolveScriptPath,
   rewriteServer,
 } from "../src/mcp-passthrough.js";
@@ -62,6 +63,38 @@ describe("resolveScriptPath (Slice 3 search order)", () => {
     writeFile("dev/hooks/red-fetch.mjs", "console.log(1)");
     const r = resolveScriptPath(root, "dev", "hooks/red-fetch.mjs");
     expect(r.path).toContain("dev/hooks/red-fetch.mjs");
+  });
+});
+
+describe("resolveHomeScriptPath", () => {
+  it("resolves a launcher installed under the user's home", () => {
+    writeFile("home/.red-skills/current/packaging/npm/bin/rsp.mjs", "console.log(1)");
+    const body =
+      'if [ -f "$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs" ]; then exec node "$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs" mcp; fi';
+
+    expect(resolveHomeScriptPath(body, join(root, "home"))).toBe(
+      join(root, "home/.red-skills/current/packaging/npm/bin/rsp.mjs"),
+    );
+  });
+
+  it("keeps the mcp argument before a shell command separator", () => {
+    writeFile("home/.red-skills/current/packaging/npm/bin/rsp.mjs", "console.log(1)");
+    const launcher = join(root, "home/.red-skills/current/packaging/npm/bin/rsp.mjs");
+    const previousHome = process.env.HOME;
+    process.env.HOME = join(root, "home");
+    try {
+      const { entry, warnings } = rewriteServer(root, "dev", "rsp", {
+        command: "sh",
+        args: [
+          "-c",
+          'if [ -f "$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs" ]; then exec node "$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs" mcp; fi',
+        ],
+      });
+      expect(warnings).toEqual([]);
+      expect(entry.command).toEqual(["node", launcher, "mcp"]);
+    } finally {
+      process.env.HOME = previousHome;
+    }
   });
 });
 
@@ -150,6 +183,12 @@ describe("planPluginMcp against the real source tree", () => {
     expect(castle).toBeDefined();
     expect(castle!.entry.type).toBe("local");
     expect(castle!.entry.command[1]).toMatch(/castle-mcp\.sh$/);
+  });
+
+  it("keeps the installed RedSkills rsp launcher in the runtime fallback chain", () => {
+    const raw = readMcpJson(REAL_PLUGINS, "dev")!;
+    const body = raw.mcpServers!.rsp!.args![1]!;
+    expect(body).toContain('$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs');
   });
 
   it("plans the memory plugin's red-memory and red-ui MCPs", () => {

--- a/plugins/dev/.mcp.json
+++ b/plugins/dev/.mcp.json
@@ -18,7 +18,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if command -v rsp >/dev/null 2>&1; then exec rsp mcp; fi; for bundle in \"$PWD/dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\" \"$HOME/.codex/.tmp/marketplaces/red-skills/packaging/npm/bin/rsp.mjs\"; do if [ -f \"$bundle\" ]; then exec node \"$bundle\" mcp; fi; done; printf 'rsp: could not locate rsp MCP launcher\\n' >&2; exit 1"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if command -v rsp >/dev/null 2>&1; then exec rsp mcp; fi; for bundle in \"$PWD/dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\" \"$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs\" \"$HOME/.codex/.tmp/marketplaces/red-skills/packaging/npm/bin/rsp.mjs\"; do if [ -f \"$bundle\" ]; then exec node \"$bundle\" mcp; fi; done; printf 'rsp: could not locate rsp MCP launcher\\n' >&2; exit 1"
       ]
     }
   }


### PR DESCRIPTION
## What changed

- include the installed RedSkills rsp launcher in the dev plugin runtime fallback chain
- teach the OpenCode generator to resolve explicit `$HOME/...` launcher paths
- preserve the `mcp` argument when it precedes a shell command separator
- add a patch changeset and regression coverage

## Why

Native Windows installs carried `rsp.mjs` under `~/.red-skills/current/packaging/npm/bin`, but the generated OpenCode MCP command did not search that location. The generator warned and emitted a fallback that could not start rsp. Its first direct-path rewrite also dropped `mcp` before `;`.

## Impact

OpenCode can launch the bundled rsp MCP on native Windows without a separately installed `rsp` command.

## Validation

- 116/116 `apps/opencode-host` tests
- `apps/opencode-host` typecheck and oxlint
- pending changeset validation
- native `node.exe` ground-truth probe: `skills=67`, `warnings=0`, command ends in `rsp.mjs mcp`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788720177&installation_model_id=20659&pr_number=3482&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3482&signature=e8c50d59702256486fe620f5017407daa92720c5d9439db4333190a4be7d93ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->