### PR TITLE
fix(installer): include Windows release assets

### DIFF
--- a/.changeset/fix-windows-release-assets.md
+++ b/.changeset/fix-windows-release-assets.md
@@ -1,0 +1,4 @@
+---
+"@reddb-io/red-skills": patch
+---
+Install the bundled rsp MCP and create a complete RedSkills `current` tree on native Windows Git Bash.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -229,6 +229,20 @@ download_release_asset_if_available() {
       warn "optional release asset $generated_asset is unavailable for $tag; OpenCode install may generate from source"
     fi
   fi
+
+  local rsp_asset="rsp.bundle.min.mjs"
+  local rsp_out="$source/packaging/npm/dist/$rsp_asset"
+  local rsp_url="https://github.com/$REPO/releases/download/$tag/$rsp_asset"
+  mkdir -p "$source/packaging/npm/dist"
+  if [[ "$REFRESH" == "true" || ! -f "$rsp_out" ]]; then
+    if curl_file "$rsp_url" "$rsp_out.tmp"; then
+      mv "$rsp_out.tmp" "$rsp_out"
+      log "downloaded optional release asset $rsp_asset"
+    else
+      rm -f "$rsp_out.tmp"
+      warn "optional release asset $rsp_asset is unavailable for $tag; RSP may build from source"
+    fi
+  fi
 }
 
 prepare_source() {
@@ -295,9 +309,9 @@ prepare_source() {
     log "using cached source $dest"
   fi
 
+  download_release_asset_if_available "$tag" "$dest"
   rm -f "$current"
   ln -s "$dest" "$current"
-  download_release_asset_if_available "$tag" "$dest"
   SOURCE_DIR="$current"
   log "current source -> $dest"
 }

--- a/scripts/test-install-release-assets.sh
+++ b/scripts/test-install-release-assets.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Regression test for release assets in the installed `current` tree on Git Bash.
+#
+# Git Bash emulates `ln -s <directory>` by copying the directory.  Therefore all
+# release-only assets must be downloaded before `current` is created.  The RSP
+# launcher also needs its separately published bundle beside the source archive.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fixture="$tmp/red-skills-v9.9.9"
+mkdir -p \
+  "$fixture/.claude-plugin" \
+  "$fixture/.agents/plugins" \
+  "$fixture/scripts" \
+  "$fixture/packaging/npm/bin"
+printf '{}\n' >"$fixture/.claude-plugin/marketplace.json"
+printf '{}\n' >"$fixture/.agents/plugins/marketplace.json"
+
+cat >"$fixture/scripts/install-opencode.sh" <<'INSTALL_OPENCODE'
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test -f "$root/dist/opencode-host.bundle.min.mjs"
+test -f "$root/packaging/npm/dist/rsp.bundle.min.mjs"
+INSTALL_OPENCODE
+chmod +x "$fixture/scripts/install-opencode.sh"
+printf '%s\n' '#!/usr/bin/env node' >"$fixture/packaging/npm/bin/rsp.mjs"
+
+fixture_archive="$tmp/v9.9.9.tar.gz"
+tar -czf "$fixture_archive" -C "$tmp" "$(basename "$fixture")"
+
+# curl serves the source archive and the two independently published bundles.
+# The generated OpenCode archive is optional and intentionally unavailable.
+cat >"$tmp/curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+url=""
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    http*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+case "$url" in
+  */archive/refs/tags/v9.9.9.tar.gz) cp "$FIXTURE_ARCHIVE" "$out" ;;
+  */opencode-host.bundle.min.mjs) printf 'opencode bundle\n' >"$out" ;;
+  */rsp.bundle.min.mjs) printf 'rsp bundle\n' >"$out" ;;
+  */opencode-host.generated.tgz) exit 22 ;;
+  *) printf 'unexpected URL: %s\n' "$url" >&2; exit 64 ;;
+esac
+FAKE_CURL
+chmod +x "$tmp/curl"
+
+# Reproduce Git Bash rather than Unix symlinks: `ln -s dir current` copies dir.
+cat >"$tmp/ln" <<'FAKE_LN'
+#!/usr/bin/env bash
+set -euo pipefail
+test "$1" = "-s"
+cp -R "$2" "$3"
+FAKE_LN
+chmod +x "$tmp/ln"
+
+cat >"$tmp/opencode" <<'FAKE_OPENCODE'
+#!/usr/bin/env bash
+exit 0
+FAKE_OPENCODE
+chmod +x "$tmp/opencode"
+
+stdout="$tmp/stdout"
+if ! FIXTURE_ARCHIVE="$fixture_archive" PATH="$tmp:$PATH" \
+  scripts/install.sh \
+    --version v9.9.9 \
+    --install-root "$tmp/install" \
+    --only opencode >"$stdout" 2>&1; then
+  printf 'FAIL: installer did not leave a complete current tree under Git Bash semantics\n' >&2
+  sed 's/^/    /' "$stdout" >&2
+  exit 1
+fi
+
+test -f "$tmp/install/current/dist/opencode-host.bundle.min.mjs"
+test -f "$tmp/install/current/packaging/npm/dist/rsp.bundle.min.mjs"
+printf 'ok: release assets are present before Git Bash creates current\n'


### PR DESCRIPTION
## Summary
- download the published RSP bundle into the installed npm launcher tree
- download release-only assets before creating `current`, so Git Bash copied links are complete
- add a regression test that reproduces Git Bash directory-link semantics

## Validation
- `scripts/test-install-release-assets.sh`
- `scripts/test-install-marketplace-source.sh`
- `shellcheck scripts/install.sh scripts/test-install-release-assets.sh`
- `scripts/test-validate-changesets.sh`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788721545&installation_model_id=20659&pr_number=3485&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3485&signature=d983c373a8e7ab17ae967ad38b26d3b8fef66253783358ebf582352fa0cc2793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->