### PR TITLE
fix(release): publish rsp bundle asset

### DIFF
--- a/.changeset/publish-rsp-release-asset.md
+++ b/.changeset/publish-rsp-release-asset.md
@@ -1,0 +1,4 @@
+---
+"@reddb-io/red-skills": patch
+---
+Publish the bundled rsp MCP as a GitHub Release asset for standalone Windows and OpenCode installations.

--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -581,11 +581,12 @@ jobs:
           console.log('benchmark-code-understanding bundle manifest:', JSON.stringify(manifest));
           EOF
 
-      # The rsp CLI ships its single bundle (dist/rsp.bundle.min.mjs) INSIDE the
-      # npm package (bin/rsp.mjs resolves it), not as a release-fetched runtime,
-      # so it needs no checksum manifest. Every other runtime app has its own
-      # per-app bundle step; rsp had a bin + prepare/verify entry but no build
-      # step, so the pack contract check failed on a genuinely-missing bundle.
+      # The rsp CLI ships its single bundle (dist/rsp.bundle.min.mjs) inside the
+      # npm package (bin/rsp.mjs resolves it) and as a GitHub Release asset for
+      # standalone installs. It needs no checksum manifest. Every other runtime
+      # app has its own per-app bundle step; rsp had a bin + prepare/verify entry
+      # but no build step, so the pack contract check failed on a genuinely-
+      # missing bundle.
       # Build it from its own app dir so pnpm bundle emits ../../dist/rsp.bundle.min.mjs.
       - name: Build rsp runtime bundle
         if: steps.target.outputs.publish == 'true'
@@ -897,6 +898,7 @@ jobs:
             dist/brain.bundle.min.mjs
             dist/brain-mcp.bundle.min.mjs
             dist/brain-runtime-manifest.json
+            dist/rsp.bundle.min.mjs
             dist/redskilled.bundle.min.mjs
           )
           # The Release standard owns the Release; this job only ever attaches to

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -272,6 +272,22 @@ else
   fail "asset upload must converge on retry while major-tag reconciliation still runs"
 fi
 
+# The standalone installer downloads the RSP bundle into the source snapshot
+# used by OpenCode. Building it only for the npm tarball is insufficient: the
+# GitHub Release upload list is the installer's public artifact contract.
+github_release_step="$(mktemp)"
+trap 'rm -f "$github_release_step"' EXIT
+awk '
+  $0 == "      - name: GitHub Release" { in_step = 1 }
+  in_step && /^      - name:/ && $0 != "      - name: GitHub Release" { exit }
+  in_step { print }
+' "$WORKFLOW" >"$github_release_step"
+if grep -qF 'dist/rsp.bundle.min.mjs' "$github_release_step"; then
+  pass "GitHub Release publishes the RSP bundle consumed by the installer"
+else
+  fail "GitHub Release must upload dist/rsp.bundle.min.mjs for standalone installs"
+fi
+
 # The fleet-activity deferral was REMOVED (2026-07-22): red-publish never
 # touches main and running workers pin their bundle at spawn, so publishing
 # during a fleet is safe; the old gate repeatedly held releases hostage to


### PR DESCRIPTION
## Summary
- upload `rsp.bundle.min.mjs` to every RedSkills GitHub Release
- keep the npm and standalone installer artifact contracts aligned
- add a release workflow regression check

## Validation
- `scripts/test-red-release-npm-publish-contract.sh`
- `scripts/test-workflow-security-pins.sh`
- `scripts/test-install-release-assets.sh`
- `scripts/test-validate-changesets.sh`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788722335&installation_model_id=20659&pr_number=3488&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3488&signature=857a307c2de7478ab0442f196a11dbd5389f9b6889bbbf65b2b6f915e91c213b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->