### PR TITLE
fix(rsp): start bundle on native Windows

### DIFF
--- a/.changeset/fix-windows-rsp-entry.md
+++ b/.changeset/fix-windows-rsp-entry.md
@@ -1,0 +1,4 @@
+---
+"@reddb-io/red-skills": patch
+---
+Start the bundled rsp CLI and MCP correctly when Node receives a native Windows entrypoint path.

--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -1,10 +1,31 @@
 #!/usr/bin/env node
+import { posix, win32 } from "node:path";
+import { fileURLToPath } from "node:url";
 import { isStructuredUsageRenderable } from "./cli/args.js";
 import { main } from "./cli/main.js";
 import { renderSetupResult, renderStats } from "./cli/stats.js";
 import { renderStructuredError } from "./structured-error.js";
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+export function isDirectExecution(
+  moduleUrl: string,
+  entrypoint: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (!entrypoint) return false;
+  const windows = platform === "win32";
+  const paths = windows ? win32 : posix;
+  try {
+    const modulePath = paths.resolve(fileURLToPath(moduleUrl, { windows }));
+    const entryPath = paths.resolve(entrypoint);
+    return windows
+      ? modulePath.toLowerCase() === entryPath.toLowerCase()
+      : modulePath === entryPath;
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectExecution(import.meta.url, process.argv[1])) {
   main().then((code) => process.exit(code), (err) => {
     if (isStructuredUsageRenderable(err)) {
       process.stdout.write(err.render());

--- a/apps/rsp/tests/windows-entry.test.ts
+++ b/apps/rsp/tests/windows-entry.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isDirectExecution } from "../src/cli.js";
+
+describe("rsp bundle direct execution", () => {
+  it("recognizes a native Windows argv path as the file URL being executed", () => {
+    expect(isDirectExecution(
+      "file:///C:/Users/filip/.red-skills/current/packaging/npm/dist/rsp.bundle.min.mjs",
+      "C:\\Users\\filip\\.red-skills\\current\\packaging\\npm\\dist\\rsp.bundle.min.mjs",
+      "win32",
+    )).toBe(true);
+  });
+
+  it("decodes spaces and compares Windows paths case-insensitively", () => {
+    expect(isDirectExecution(
+      "file:///C:/Program%20Files/RedSkills/rsp.bundle.min.mjs",
+      "c:\\program files\\redskills\\rsp.bundle.min.mjs",
+      "win32",
+    )).toBe(true);
+  });
+
+  it("does not mistake an imported bundle for the process entrypoint", () => {
+    expect(isDirectExecution(
+      "file:///C:/Users/filip/rsp.bundle.min.mjs",
+      "C:\\Users\\filip\\rsp.mjs",
+      "win32",
+    )).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- compare the rsp bundle URL and process entrypoint with platform-native path semantics
- handle native Windows paths, URL-encoded spaces, and case-insensitive paths
- add focused Windows entrypoint regressions

## Ground truth
The rebuilt bundle answered an MCP initialize request under native `node.exe` on Windows.

## Validation
- `pnpm test` (apps/rsp)
- `pnpm typecheck` (apps/rsp)
- `pnpm bundle` (apps/rsp)
- `scripts/test-validate-changesets.sh`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788724089&installation_model_id=20659&pr_number=3490&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3490&signature=200899508fff42af0917ee27945f587985e19dffefb687cbb9e73af7b3b95644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->