### PR TITLE
Preserve shipped tool PATH for redskilled Workers

### DIFF
--- a/apps/dev/src/runtime/registration-launch.ts
+++ b/apps/dev/src/runtime/registration-launch.ts
@@ -30,10 +30,13 @@ export interface RegistrationLaunchInput {
   readonly logPath?: string | null;
   /** The leading argv; defaults to the published bundle's, an input for tests. */
   readonly bundleArgv?: readonly string[];
+  /** Tool lookup path owned by the registering runtime, not the host daemon (#3493). */
+  readonly path?: string;
 }
 
 /** Compose the launch a registration or a renewal states. */
 export function registrationLaunch(input: RegistrationLaunchInput): RedskilledLaunchTemplate {
+  const path = input.path === undefined ? process.env.PATH : input.path;
   return buildProjectLaunchTemplate({
     bundleArgv: input.bundleArgv ?? publishedBundleArgv(),
     runner: input.runner,
@@ -49,6 +52,13 @@ export function registrationLaunch(input: RegistrationLaunchInput): RedskilledLa
     workerEnv: {
       ...registrationLaunchEnv(),
       RED_AFK_RUNNER_ORIGIN: "project_start",
+      // The handoff tells implementers to use shipped companion tools such as
+      // `rsp` (#3493). Those binaries are resolved by the registering runtime (often an
+      // npm/npx package), while the detached Worker is born later by a systemd
+      // daemon with a deliberately smaller PATH. State the lookup path here so
+      // the daemon does not have to rediscover project-owned tools it never
+      // resolved. Its launcher still prepends the exact Node engine directory.
+      ...(path == null || path === "" ? {} : { PATH: path }),
     },
     ...(input.logPath == null ? {} : { logPath: input.logPath }),
   });

--- a/apps/dev/tests/project-worker-identity.test.ts
+++ b/apps/dev/tests/project-worker-identity.test.ts
@@ -20,11 +20,12 @@ import { registrationLaunch } from "../src/runtime/registration-launch.js";
 const BUNDLE_ARGV = ["/usr/bin/node", "/published/bundle.mjs"] as const;
 
 /** The launch a `project_start` hands the daemon, with no host in the test. */
-function launch(runner = "claude") {
+function launch(runner = "claude", path = "/published/node_modules/.bin:/usr/bin") {
   return registrationLaunch({
     runner,
     bundleArgv: BUNDLE_ARGV,
     logPath: "/repo/.red/tmp/logs/2026-08-03/worker-{{worker_id}}.log",
+    path,
   });
 }
 
@@ -57,13 +58,22 @@ describe("the launch a registration states", () => {
     expect(launch().env?.REDSKILLED_WORKER_ID).toBe("{{worker_id}}");
   });
 
-  it("delivers all four to the process, with the daemon's facts written in", () => {
+  it("carries the registering runtime's tool path to the detached Worker (#3493)", () => {
+    // The handoff explicitly tells the implementer to use `rsp`. Registrations
+    // outlive the MCP process that resolved that shipped binary, so the path to
+    // the published package must be stated in the launch rather than inferred
+    // later from the daemon's smaller service environment.
+    expect(launch("codex").env?.PATH).toBe("/published/node_modules/.bin:/usr/bin");
+  });
+
+  it("delivers the identity and tool-path facts to the process", () => {
     const { expanded } = born("2aa48bea-81a5-409d-9310-ab0a9805", 1, "codex");
 
     expect(expanded.env.RED_AFK_WORKER_ID).toBe("2aa48bea-81a5-409d-9310-ab0a9805");
     expect(expanded.env.RED_AFK_SLOT).toBe("1");
     expect(expanded.env.RED_AFK_RUNNER).toBe("codex");
     expect(expanded.env.REDSKILLED_WORKER_ID).toBe("2aa48bea-81a5-409d-9310-ab0a9805");
+    expect(expanded.env.PATH).toBe("/published/node_modules/.bin:/usr/bin");
     // The argv half always arrived, which is why the loss stayed invisible.
     expect(expanded.argv).toEqual([...BUNDLE_ARGV, "run", "--once", "--runner", "codex"]);
   });


### PR DESCRIPTION
Fixes #3493.

## What changed

Registration launches now carry the registering runtime's `PATH` into detached redskilled Workers. The daemon still prepends the exact Node engine directory when it births the process.

## Root cause

Codex AFK handoffs explicitly instruct implementers to use `rsp`, but registration-lane Workers were born from the redskilled systemd service's smaller `PATH`. The published package's `node_modules/.bin` directory was lost, so the first `rsp` command failed and the agent fell back to raw `git` and repository-wide `rg` output.

## Impact

Codex Workers retain the shipped companion tools and project toolchains resolved by the registration runtime. This prevents the missing-`rsp` failure and the noisy fallback exploration it triggered.

## Validation

- `pnpm --filter @reddb-io/dev exec vitest run tests/project-worker-identity.test.ts tests/mcp-project-registration.test.ts tests/ask-red-docs.test.ts tests/doctor-classifiers.test.ts` — 61 passed
- `pnpm --filter @reddb-io/dev typecheck`
- `pnpm exec oxlint apps/dev/src/runtime/registration-launch.ts apps/dev/tests/project-worker-identity.test.ts`
- live differential repro in design-system Worker hCTNG: `rsp git log` failed under the current Worker PATH and succeeded when only the published package bin directory was restored

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788728096&installation_model_id=20659&pr_number=3494&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3494&signature=db347d732e2d94dc3422e2ddf7d610736acab0a46559d4630195423e70e97605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->