### PR TITLE
Queue the redskilled Worker PATH patch release

### DIFF
--- a/.changeset/preserve-redskilled-worker-tool-path.md
+++ b/.changeset/preserve-redskilled-worker-tool-path.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Keep shipped companion tools such as `rsp` available to detached redskilled Workers by carrying the registering runtime's tool path into every registration launch and renewal.

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -187,9 +187,11 @@ jobs:
       # checkout and nothing else, so every `pnpm` was `command not found` and
       # the contract read that as manifest drift.
       - name: Test bundle-app contract
+        if: env.RUN_ANY == 'true'
         run: scripts/test-bundle-app-contract.sh
 
       - name: Test generate-manifests contract
+        if: env.RUN_ANY == 'true'
         run: scripts/test-generate-manifests-contract.sh
 
       - name: Lint workspace (oxlint, import + correctness)

--- a/apps/dev/tests/ci-fetch-retry.test.ts
+++ b/apps/dev/tests/ci-fetch-retry.test.ts
@@ -181,3 +181,14 @@ describe("CI setup network fetches", () => {
     }
   });
 });
+
+describe("CI narrowed typecheck job", () => {
+  it.each(["Test bundle-app contract", "Test generate-manifests contract"])(
+    "does not run %s when the scope skipped checkout (#3495)",
+    async (name) => {
+      const step = stepBody(await readWorkflow("red-workspace-ci.yml"), name);
+
+      expect(step).toContain("if: env.RUN_ANY == 'true'");
+    },
+  );
+});


### PR DESCRIPTION
Follow-up to #3494 and #3493.

Adds the missing patch changeset so the Worker PATH fix enters the release queue and can reach npm-installed hosts.

It also fixes the changeset-only CI path exposed by this PR: when validation scope skips checkout, the two script-backed contract steps now skip with it instead of calling files that are not present.

Validation:

- `pnpm --filter @reddb-io/release exec vitest run tests/changeset-queue.test.ts tests/status.test.ts` — 8 passed
- `pnpm --filter @reddb-io/dev exec vitest run tests/ci-fetch-retry.test.ts` — 11 passed
- `pnpm --filter @reddb-io/dev typecheck`
- full release suite: 43 passed, with the pre-existing vendored release bundle drift on `origin/main` as the sole failure; this branch changes neither the release source nor its vendored bundle
