### PR TITLE
feat(redskilled): render responsive dashboard tables

### DIFF
--- a/.changeset/render-redskilled-responsive-table.md
+++ b/.changeset/render-redskilled-responsive-table.md
@@ -1,0 +1,4 @@
+---
+"@reddb-io/dev": patch
+---
+Render the live redskilled TTY dashboard as a responsive Tuiuiu table, using a compact grouped layout on narrow terminals while preserving pipe snapshots.

--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -146,6 +146,10 @@ of it.
   purpose and the loss is stated (`detail`, `degraded`) rather than left to be
   detected by re-parsing the line. The full picture stays with the dashboard and
   the monitor.
+- **The live TTY is a real responsive table.** The shared renderer publishes an
+  operational column hierarchy on terminals at least 110 columns wide and a
+  grouped Worker/Work/State/Activity hierarchy below that. Tuiuiu paints the
+  declared table; pipe output stays the stable one-shot text snapshot.
 - **`--verbose` adds a second line per Worker, and the Worker supplies it.** The
   Worker publishes its last logged line on its heartbeat (`worker-heartbeat`) as an
   opaque string; the daemon stores and returns it without ever parsing it, so the

--- a/apps/redskilled/src/dashboard-command.ts
+++ b/apps/redskilled/src/dashboard-command.ts
@@ -3,7 +3,11 @@ import {
   readRedskilledDashboardRender,
   type RedskilledClientConfig,
 } from "./client.js";
-import { runRedskilledDashboardTui, type RedskilledDashboardTuiOptions } from "./dashboard-tui.js";
+import {
+  runRedskilledDashboardTui,
+  type RedskilledDashboardTuiFrame,
+  type RedskilledDashboardTuiOptions,
+} from "./dashboard-tui.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
 import { readStatuslineProject } from "./statusline-project.js";
 import {
@@ -65,26 +69,29 @@ export async function runDashboard(
   const readFrame = async (
     options: Partial<RedskilledDashboardOptions>,
     warnOnFailure = true,
-  ): Promise<readonly string[]> => {
+  ): Promise<RedskilledDashboardTuiFrame> => {
     try {
       const render = await readDashboard(paths, options, {
         ...(io.client ?? {}),
         ...(resolved.options.project == null ? {} : { sessionProject: resolved.options.project }),
       });
-      return noColor ? render.lines.map(stripAnsi) : render.lines;
+      return {
+        dashboard: render,
+        lines: noColor ? render.lines.map(stripAnsi) : render.lines,
+      };
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       if (warnOnFailure) warn(`redskilled dashboard: ${reason}\n`);
-      return [`redskilled unreachable — ${reason}`];
+      return { lines: [`redskilled unreachable — ${reason}`] };
     }
   };
 
   if (!interactive) {
-    const lines = await readFrame({
+    const frame = await readFrame({
       ...baseOptions,
       ...(resolved.options.maxWidth == null ? {} : { maxWidth: resolved.options.maxWidth }),
     });
-    write(`${lines.join("\n")}\n`);
+    write(`${frame.lines.join("\n")}\n`);
     return 0;
   }
 
@@ -98,7 +105,9 @@ export async function runDashboard(
         ...baseOptions,
         maxWidth,
         maxHeight,
-        maxRows: Math.max(0, maxHeight - 5),
+        // Header + throughput + Table chrome + diagnostics consume eight rows
+        // before the first Worker; the renderer must budget the remainder.
+        maxRows: Math.max(0, maxHeight - 8),
         showDeathDetails,
       }, false);
     },

--- a/apps/redskilled/src/dashboard-tui.ts
+++ b/apps/redskilled/src/dashboard-tui.ts
@@ -9,7 +9,6 @@
  */
 import {
   Box,
-  Spacer,
   Text,
   render,
   useApp,
@@ -20,6 +19,11 @@ import {
   useTerminalSize,
   type VNode,
 } from "tuiuiu.js/minimal";
+import { Table, type TableColumn } from "tuiuiu.js/molecules";
+import {
+  stripAnsi,
+  type RedskilledDashboard,
+} from "@reddb-io/redskilled-render";
 
 export interface RedskilledDashboardViewport {
   readonly columns: number;
@@ -31,7 +35,7 @@ export interface RedskilledDashboardViewport {
 export interface RedskilledDashboardTuiOptions {
   readonly readFrame: (
     viewport: RedskilledDashboardViewport,
-  ) => Promise<readonly string[]>;
+  ) => Promise<RedskilledDashboardTuiFrame>;
   readonly initialShowDeathDetails: boolean;
   readonly refreshMs?: number;
   readonly noColor?: boolean;
@@ -39,12 +43,58 @@ export interface RedskilledDashboardTuiOptions {
   readonly stdout?: NodeJS.WriteStream;
 }
 
-export interface RedskilledDashboardFrameOptions {
+export interface RedskilledDashboardTuiFrame {
   readonly lines: readonly string[];
+  readonly dashboard?: RedskilledDashboard;
+}
+
+export interface RedskilledDashboardFrameOptions {
+  readonly frame: RedskilledDashboardTuiFrame;
   readonly columns: number;
   readonly rows: number;
   readonly showDeathDetails: boolean;
   readonly noColor?: boolean;
+}
+
+function paintedLine(line: string, noColor: boolean): VNode {
+  return Text({ wrap: "truncate-end" }, noColor ? stripAnsi(line) : line);
+}
+
+function dashboardBody(
+  dashboard: RedskilledDashboard,
+  columns: number,
+  noColor: boolean,
+): VNode[] {
+  if (dashboard.rows.length === 0 || dashboard.table == null) {
+    return dashboard.lines.map((line) => paintedLine(line, noColor));
+  }
+
+  const firstWorkerIndex = dashboard.lines.indexOf(dashboard.rows[0]!.line);
+  const lastWorkerIndex = dashboard.lines.lastIndexOf(dashboard.rows.at(-1)!.line);
+  const before = firstWorkerIndex < 0 ? dashboard.lines : dashboard.lines.slice(0, firstWorkerIndex);
+  const after = lastWorkerIndex < 0 ? [] : dashboard.lines.slice(lastWorkerIndex + 1);
+  const tableColumns: TableColumn[] = dashboard.table.columns.map((column) => ({ ...column }));
+  const tableRows = dashboard.table.rows.map((row) => Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [key, noColor ? stripAnsi(value) : value]),
+  ));
+
+  return [
+    ...before.map((line) => paintedLine(line, noColor)),
+    Table({
+      columns: tableColumns,
+      data: tableRows,
+      borderStyle: "round",
+      availableWidth: Math.max(1, columns - 1),
+      maxWidth: Math.max(1, columns - 1),
+      compact: true,
+      rowSeparator: false,
+      borderColor: noColor ? "" : "gray",
+      headerStyle: { bold: !noColor, color: noColor ? "" : "cyan" },
+      accessibilityLabel: `redskilled Workers — ${dashboard.table.variant} table`,
+      striped: !noColor,
+    }),
+    ...after.map((line) => paintedLine(line, noColor)),
+  ];
 }
 
 /** One complete frame, independently renderable for fixture tests. PURE. */
@@ -55,6 +105,10 @@ export function redskilledDashboardFrame(
   const rows = Math.max(1, Math.floor(options.rows));
   const bodyRows = Math.max(0, rows - 1);
   const footer = `q quit · r refresh · v deaths: ${options.showDeathDetails ? "details" : "summary"} · live 1s`;
+  const noColor = options.noColor === true;
+  const body = options.frame.dashboard == null
+    ? options.frame.lines.map((line) => paintedLine(line, noColor))
+    : dashboardBody(options.frame.dashboard, columns, noColor);
 
   return Box(
     {
@@ -63,11 +117,16 @@ export function redskilledDashboardFrame(
       height: rows,
       overflow: "hidden",
     },
-    ...options.lines
-      .slice(0, bodyRows)
-      .map((line, index) => Text({ key: index, wrap: "truncate-end" }, line)),
-    Spacer({ flex: 1 }),
-    Text({ dim: options.noColor !== true, wrap: "truncate-end" }, footer),
+    Box(
+      {
+        flexDirection: "column",
+        width: columns,
+        height: bodyRows,
+        overflow: "hidden",
+      },
+      ...body,
+    ),
+    Text({ dim: !noColor, wrap: "truncate-end" }, footer),
   );
 }
 
@@ -86,7 +145,9 @@ export async function runRedskilledDashboardTui(
   function App(): VNode {
     const app = useApp();
     const size = useTerminalSize();
-    const [lines, setLines] = useState<readonly string[]>(["redskilled · connecting to host…"]);
+    const [frame, setFrame] = useState<RedskilledDashboardTuiFrame>({
+      lines: ["redskilled · connecting to host…"],
+    });
     const [showDeathDetails, setShowDeathDetails] = useState(options.initialShowDeathDetails);
 
     const refresh = (): void => {
@@ -98,11 +159,11 @@ export async function runRedskilledDashboardTui(
           rows: Math.max(1, (size.rows || 24) - 1),
           showDeathDetails: showDeathDetails(),
         })
-        .then(setLines)
+        .then(setFrame)
         .catch((error: unknown) => {
-          setLines([
-            `redskilled dashboard failed — ${error instanceof Error ? error.message : String(error)}`,
-          ]);
+          setFrame({
+            lines: [`redskilled dashboard failed — ${error instanceof Error ? error.message : String(error)}`],
+          });
         })
         .finally(() => {
           inFlight = false;
@@ -135,7 +196,7 @@ export async function runRedskilledDashboardTui(
     });
 
     return redskilledDashboardFrame({
-      lines: lines(),
+      frame: frame(),
       columns: size.columns || 80,
       rows: size.rows || 24,
       showDeathDetails: showDeathDetails(),

--- a/apps/redskilled/tests/dashboard-command.test.ts
+++ b/apps/redskilled/tests/dashboard-command.test.ts
@@ -63,13 +63,14 @@ describe("the dashboard always answers", () => {
       },
       runTui: async (options) => {
         expect(options.initialShowDeathDetails).toBe(true);
-        await options.readFrame({ columns: 100, rows: 7, showDeathDetails: true });
+        const frame = await options.readFrame({ columns: 100, rows: 7, showDeathDetails: true });
+        expect(frame.dashboard).toBeDefined();
         await options.readFrame({ columns: 72, rows: 4, showDeathDetails: false });
       },
     });
 
     expect(asked).toEqual([
-      expect.objectContaining({ mode: "global", maxWidth: 100, maxHeight: 7, maxRows: 2, showDeathDetails: true }),
+      expect.objectContaining({ mode: "global", maxWidth: 100, maxHeight: 7, maxRows: 0, showDeathDetails: true }),
       expect.objectContaining({ mode: "global", maxWidth: 72, maxHeight: 4, maxRows: 0, showDeathDetails: false }),
     ]);
     expect(io.out).toEqual([]);

--- a/apps/redskilled/tests/dashboard-tui.test.ts
+++ b/apps/redskilled/tests/dashboard-tui.test.ts
@@ -2,6 +2,15 @@ import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { renderOnce } from "tuiuiu.js/minimal";
 import {
+  renderRedskilledDashboard,
+  REDSKILLED_DASHBOARD_DEFAULTS,
+} from "@reddb-io/redskilled-render";
+import {
+  display,
+  payload,
+  worker,
+} from "../../../packages/redskilled-render/tests/fixture.js";
+import {
   redskilledDashboardFrame,
   runRedskilledDashboardTui,
 } from "../src/dashboard-tui.js";
@@ -10,7 +19,7 @@ describe("the dashboard TUI frame", () => {
   it("keeps the operating data above a persistent command footer", () => {
     const frame = renderOnce(
       redskilledDashboardFrame({
-        lines: ["tk/h=12k  Tickets/h=4", "tokens 48h ▁▂▃", "Workers", "hE215 coding"],
+        frame: { lines: ["tk/h=12k  Tickets/h=4", "tokens 48h ▁▂▃", "Workers", "hE215 coding"] },
         columns: 80,
         rows: 5,
         showDeathDetails: false,
@@ -31,7 +40,7 @@ describe("the dashboard TUI frame", () => {
   it("clips the body before it can overwrite the footer", () => {
     const frame = renderOnce(
       redskilledDashboardFrame({
-        lines: ["one", "two", "three", "four"],
+        frame: { lines: ["one", "two", "three", "four"] },
         columns: 20,
         rows: 3,
         showDeathDetails: true,
@@ -44,6 +53,60 @@ describe("the dashboard TUI frame", () => {
     expect(frame).toContain("two");
     expect(frame).toContain("q quit");
     expect(frame).not.toContain("three");
+  });
+
+  it("paints the shared operational table on a wide terminal", () => {
+    const dashboard = renderRedskilledDashboard(
+      payload({
+        workers: [worker({
+          display: display({ runner: "codex", issue: "3495", phase: "validating", step: "tests" }),
+          log: { last_line: "running focused checks", published_at: "2026-08-03T00:02:00.000Z" },
+        })],
+      }),
+      { ...REDSKILLED_DASHBOARD_DEFAULTS, project: "acme/widgets", maxWidth: 120 },
+    );
+    const frame = renderOnce(
+      redskilledDashboardFrame({
+        frame: { lines: dashboard.lines, dashboard },
+        columns: 120,
+        rows: 12,
+        showDeathDetails: false,
+        noColor: true,
+      }),
+      120,
+    );
+
+    expect(frame).toContain("Worker");
+    expect(frame).toContain("Issue");
+    expect(frame).toContain("Runner");
+    expect(frame).toContain("Phase");
+    expect(frame).toContain("Activity");
+    expect(frame).toContain("running foc");
+    expect(frame).not.toContain("run=codex");
+    expect(frame).not.toContain("\x1b[");
+  });
+
+  it("paints the grouped table on a narrow terminal", () => {
+    const dashboard = renderRedskilledDashboard(
+      payload({ workers: [worker({ display: display({ issue: "3495", phase: "validating" }) })] }),
+      { ...REDSKILLED_DASHBOARD_DEFAULTS, project: "acme/widgets", maxWidth: 80 },
+    );
+    const frame = renderOnce(
+      redskilledDashboardFrame({
+        frame: { lines: dashboard.lines, dashboard },
+        columns: 80,
+        rows: 12,
+        showDeathDetails: false,
+        noColor: true,
+      }),
+      80,
+    );
+
+    expect(frame).toContain("Worker");
+    expect(frame).toContain("Work");
+    expect(frame).toContain("State");
+    expect(frame).toContain("Latest activity");
+    expect(frame).not.toContain("Runner");
   });
 });
 
@@ -62,7 +125,7 @@ describe("the dashboard TUI lifecycle", () => {
     });
     const chunks: string[] = [];
     stdout.on("data", (chunk) => chunks.push(chunk.toString()));
-    const readFrame = vi.fn(async () => ["frame"]);
+    const readFrame = vi.fn(async () => ({ lines: ["frame"] }));
 
     const running = runRedskilledDashboardTui({
       stdin,

--- a/packages/redskilled-render/dashboard-table.ts
+++ b/packages/redskilled-render/dashboard-table.ts
@@ -1,0 +1,95 @@
+/** Responsive table projection for the dashboard density. */
+import type { RedskilledRenderWorker } from "./payload.js";
+
+/** The terminal-width layout selected by the shared renderer, never by a surface. */
+export type RedskilledDashboardTableVariant = "compact" | "operational";
+
+export interface RedskilledDashboardTableColumn {
+  readonly key: string;
+  readonly header: string;
+  readonly width?: number;
+  readonly minWidth?: number;
+  readonly flex?: number;
+  readonly align?: "left" | "center" | "right";
+  readonly truncate?: boolean;
+}
+
+/** A semantic table projection that terminal and editor surfaces can paint. */
+export interface RedskilledDashboardTable {
+  readonly variant: RedskilledDashboardTableVariant;
+  readonly columns: readonly RedskilledDashboardTableColumn[];
+  readonly rows: readonly Record<string, string>[];
+}
+
+interface DashboardTableSourceRow {
+  readonly cells: {
+    readonly wid: string;
+    readonly run: string;
+    readonly iss: string;
+    readonly bar: string;
+    readonly phase: string;
+    readonly elapsed: string;
+    readonly eta: string;
+    readonly hb: string;
+  };
+}
+
+const OPERATIONAL_TABLE_MIN_WIDTH = 110;
+
+function withoutCellPrefix(value: string, prefix: string): string {
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+function presentCells(...values: readonly (string | null | undefined)[]): string {
+  const joined = values.filter((value): value is string => value != null && value !== "").join(" · ");
+  return joined === "" ? "—" : joined;
+}
+
+/** Choose and populate the table hierarchy from the already-decided Worker cells. PURE. */
+export function dashboardTable(
+  rows: readonly DashboardTableSourceRow[],
+  workers: readonly RedskilledRenderWorker[],
+  maxWidth: number,
+): RedskilledDashboardTable {
+  if (maxWidth < OPERATIONAL_TABLE_MIN_WIDTH) {
+    return {
+      variant: "compact",
+      columns: [
+        { key: "worker", header: "Worker", flex: 2, minWidth: 16, truncate: true },
+        { key: "work", header: "Work", flex: 2, minWidth: 14, truncate: true },
+        { key: "state", header: "State", flex: 2, minWidth: 14, truncate: true },
+        { key: "activity", header: "Latest activity", flex: 3, minWidth: 18, truncate: true },
+      ],
+      rows: rows.map((row, index) => ({
+        worker: row.cells.wid,
+        work: presentCells(withoutCellPrefix(row.cells.iss, "iss="), row.cells.phase),
+        state: presentCells(row.cells.bar, row.cells.elapsed, row.cells.eta),
+        activity: presentCells(row.cells.hb, workers[index]?.log.last_line),
+      })),
+    };
+  }
+
+  return {
+    variant: "operational",
+    columns: [
+      { key: "worker", header: "Worker", flex: 2, minWidth: 16, truncate: true },
+      { key: "issue", header: "Issue", width: 7 },
+      { key: "runner", header: "Runner", flex: 1, minWidth: 12, truncate: true },
+      { key: "phase", header: "Phase", flex: 2, minWidth: 16, truncate: true },
+      { key: "progress", header: "Progress", width: 9 },
+      { key: "elapsed", header: "Elapsed", width: 9, align: "right" },
+      { key: "eta", header: "ETA", width: 8, align: "right" },
+      { key: "activity", header: "Activity", flex: 2, minWidth: 16, truncate: true },
+    ],
+    rows: rows.map((row, index) => ({
+      worker: row.cells.wid,
+      issue: presentCells(withoutCellPrefix(row.cells.iss, "iss=")),
+      runner: presentCells(withoutCellPrefix(row.cells.run, "run=")),
+      phase: presentCells(row.cells.phase),
+      progress: presentCells(row.cells.bar),
+      elapsed: presentCells(row.cells.elapsed),
+      eta: withoutCellPrefix(presentCells(row.cells.eta), "eta="),
+      activity: presentCells(row.cells.hb, workers[index]?.log.last_line),
+    })),
+  };
+}

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -115,6 +115,26 @@ export interface RedskilledDashboardRow {
   readonly line: string;
 }
 
+/** The terminal-width layout selected by the shared renderer, never by a surface. */
+export type RedskilledDashboardTableVariant = "compact" | "operational";
+
+export interface RedskilledDashboardTableColumn {
+  readonly key: string;
+  readonly header: string;
+  readonly width?: number;
+  readonly minWidth?: number;
+  readonly flex?: number;
+  readonly align?: "left" | "center" | "right";
+  readonly truncate?: boolean;
+}
+
+/** A semantic table projection that terminal and editor surfaces can paint. */
+export interface RedskilledDashboardTable {
+  readonly variant: RedskilledDashboardTableVariant;
+  readonly columns: readonly RedskilledDashboardTableColumn[];
+  readonly rows: readonly Record<string, string>[];
+}
+
 /** The repo-global counts the header carries, each `null` when unpolled. */
 export interface RedskilledDashboardCounts {
   readonly open_pull_requests: number | null;
@@ -186,6 +206,8 @@ export interface RedskilledDashboard {
   readonly columns: readonly RedskilledDashboardColumn[];
   readonly header: RedskilledDashboardHeader;
   readonly rows: readonly RedskilledDashboardRow[];
+  /** Responsive column hierarchy, derived here so every surface shares it. */
+  readonly table?: RedskilledDashboardTable;
   /**
    * Every line to print, the header first.
    *
@@ -261,6 +283,7 @@ export function renderRedskilledDashboard(
     cells: cells[index]!,
     line: clamp(formatRow(cells[index]!, widths), options.maxWidth),
   }));
+  const table = dashboardTable(rows, visible, options.maxWidth);
 
   const header = buildHeader(payload, options, selected, match);
   const hidden = selected.length - visible.length;
@@ -298,9 +321,70 @@ export function renderRedskilledDashboard(
     columns: REDSKILLED_DASHBOARD_COLUMNS,
     header,
     rows,
+    table,
     lines: visibleLines,
     hidden_row_count: Math.max(0, hidden),
     stale: payload.staleness.stale,
+  };
+}
+
+const OPERATIONAL_TABLE_MIN_WIDTH = 110;
+
+function withoutCellPrefix(value: string, prefix: string): string {
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+function presentCells(...values: readonly (string | null | undefined)[]): string {
+  const joined = values.filter((value): value is string => value != null && value !== "").join(" · ");
+  return joined === "" ? "—" : joined;
+}
+
+/** Choose and populate the table hierarchy from the already-decided Worker cells. PURE. */
+export function dashboardTable(
+  rows: readonly RedskilledDashboardRow[],
+  workers: readonly RedskilledRenderWorker[],
+  maxWidth: number,
+): RedskilledDashboardTable {
+  if (maxWidth < OPERATIONAL_TABLE_MIN_WIDTH) {
+    return {
+      variant: "compact",
+      columns: [
+        { key: "worker", header: "Worker", flex: 2, minWidth: 16, truncate: true },
+        { key: "work", header: "Work", flex: 2, minWidth: 14, truncate: true },
+        { key: "state", header: "State", flex: 2, minWidth: 14, truncate: true },
+        { key: "activity", header: "Latest activity", flex: 3, minWidth: 18, truncate: true },
+      ],
+      rows: rows.map((row, index) => ({
+        worker: row.cells.wid,
+        work: presentCells(withoutCellPrefix(row.cells.iss, "iss="), row.cells.phase),
+        state: presentCells(row.cells.bar, row.cells.elapsed, row.cells.eta),
+        activity: presentCells(row.cells.hb, workers[index]?.log.last_line),
+      })),
+    };
+  }
+
+  return {
+    variant: "operational",
+    columns: [
+      { key: "worker", header: "Worker", flex: 2, minWidth: 16, truncate: true },
+      { key: "issue", header: "Issue", width: 7 },
+      { key: "runner", header: "Runner", flex: 1, minWidth: 12, truncate: true },
+      { key: "phase", header: "Phase", flex: 2, minWidth: 16, truncate: true },
+      { key: "progress", header: "Progress", width: 9 },
+      { key: "elapsed", header: "Elapsed", width: 9, align: "right" },
+      { key: "eta", header: "ETA", width: 8, align: "right" },
+      { key: "activity", header: "Activity", flex: 2, minWidth: 16, truncate: true },
+    ],
+    rows: rows.map((row, index) => ({
+      worker: row.cells.wid,
+      issue: presentCells(withoutCellPrefix(row.cells.iss, "iss=")),
+      runner: presentCells(withoutCellPrefix(row.cells.run, "run=")),
+      phase: presentCells(row.cells.phase),
+      progress: presentCells(row.cells.bar),
+      elapsed: presentCells(row.cells.elapsed),
+      eta: withoutCellPrefix(presentCells(row.cells.eta), "eta="),
+      activity: presentCells(row.cells.hb, workers[index]?.log.last_line),
+    })),
   };
 }
 

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -79,6 +79,10 @@ import {
   selectRenderWorkers,
   type RedskilledStatuslineProjectMatch,
 } from "./select.js";
+import {
+  dashboardTable,
+  type RedskilledDashboardTable,
+} from "./dashboard-table.js";
 
 /** The row columns, in the order the statusline's per-worker line prints them. */
 export const REDSKILLED_DASHBOARD_COLUMNS = [
@@ -113,26 +117,6 @@ export interface RedskilledDashboardRow {
   readonly cells: RedskilledDashboardCells;
   /** The finished, column-aligned line. A surface prints this and adds nothing. */
   readonly line: string;
-}
-
-/** The terminal-width layout selected by the shared renderer, never by a surface. */
-export type RedskilledDashboardTableVariant = "compact" | "operational";
-
-export interface RedskilledDashboardTableColumn {
-  readonly key: string;
-  readonly header: string;
-  readonly width?: number;
-  readonly minWidth?: number;
-  readonly flex?: number;
-  readonly align?: "left" | "center" | "right";
-  readonly truncate?: boolean;
-}
-
-/** A semantic table projection that terminal and editor surfaces can paint. */
-export interface RedskilledDashboardTable {
-  readonly variant: RedskilledDashboardTableVariant;
-  readonly columns: readonly RedskilledDashboardTableColumn[];
-  readonly rows: readonly Record<string, string>[];
 }
 
 /** The repo-global counts the header carries, each `null` when unpolled. */
@@ -325,66 +309,6 @@ export function renderRedskilledDashboard(
     lines: visibleLines,
     hidden_row_count: Math.max(0, hidden),
     stale: payload.staleness.stale,
-  };
-}
-
-const OPERATIONAL_TABLE_MIN_WIDTH = 110;
-
-function withoutCellPrefix(value: string, prefix: string): string {
-  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
-}
-
-function presentCells(...values: readonly (string | null | undefined)[]): string {
-  const joined = values.filter((value): value is string => value != null && value !== "").join(" · ");
-  return joined === "" ? "—" : joined;
-}
-
-/** Choose and populate the table hierarchy from the already-decided Worker cells. PURE. */
-export function dashboardTable(
-  rows: readonly RedskilledDashboardRow[],
-  workers: readonly RedskilledRenderWorker[],
-  maxWidth: number,
-): RedskilledDashboardTable {
-  if (maxWidth < OPERATIONAL_TABLE_MIN_WIDTH) {
-    return {
-      variant: "compact",
-      columns: [
-        { key: "worker", header: "Worker", flex: 2, minWidth: 16, truncate: true },
-        { key: "work", header: "Work", flex: 2, minWidth: 14, truncate: true },
-        { key: "state", header: "State", flex: 2, minWidth: 14, truncate: true },
-        { key: "activity", header: "Latest activity", flex: 3, minWidth: 18, truncate: true },
-      ],
-      rows: rows.map((row, index) => ({
-        worker: row.cells.wid,
-        work: presentCells(withoutCellPrefix(row.cells.iss, "iss="), row.cells.phase),
-        state: presentCells(row.cells.bar, row.cells.elapsed, row.cells.eta),
-        activity: presentCells(row.cells.hb, workers[index]?.log.last_line),
-      })),
-    };
-  }
-
-  return {
-    variant: "operational",
-    columns: [
-      { key: "worker", header: "Worker", flex: 2, minWidth: 16, truncate: true },
-      { key: "issue", header: "Issue", width: 7 },
-      { key: "runner", header: "Runner", flex: 1, minWidth: 12, truncate: true },
-      { key: "phase", header: "Phase", flex: 2, minWidth: 16, truncate: true },
-      { key: "progress", header: "Progress", width: 9 },
-      { key: "elapsed", header: "Elapsed", width: 9, align: "right" },
-      { key: "eta", header: "ETA", width: 8, align: "right" },
-      { key: "activity", header: "Activity", flex: 2, minWidth: 16, truncate: true },
-    ],
-    rows: rows.map((row, index) => ({
-      worker: row.cells.wid,
-      issue: presentCells(withoutCellPrefix(row.cells.iss, "iss=")),
-      runner: presentCells(withoutCellPrefix(row.cells.run, "run=")),
-      phase: presentCells(row.cells.phase),
-      progress: presentCells(row.cells.bar),
-      elapsed: presentCells(row.cells.elapsed),
-      eta: withoutCellPrefix(presentCells(row.cells.eta), "eta="),
-      activity: presentCells(row.cells.hb, workers[index]?.log.last_line),
-    })),
   };
 }
 

--- a/packages/redskilled-render/index.ts
+++ b/packages/redskilled-render/index.ts
@@ -111,6 +111,7 @@ export {
   REDSKILLED_DASHBOARD_COLUMNS,
   REDSKILLED_DASHBOARD_DEFAULTS,
   renderRedskilledDashboard,
+  dashboardTable,
   type RedskilledDashboard,
   type RedskilledDashboardCells,
   type RedskilledDashboardColumn,
@@ -118,6 +119,9 @@ export {
   type RedskilledDashboardHeader,
   type RedskilledDashboardOptions,
   type RedskilledDashboardRow,
+  type RedskilledDashboardTable,
+  type RedskilledDashboardTableColumn,
+  type RedskilledDashboardTableVariant,
   type RedskilledDashboardWindows,
 } from "./dashboard.js";
 

--- a/packages/redskilled-render/index.ts
+++ b/packages/redskilled-render/index.ts
@@ -111,7 +111,6 @@ export {
   REDSKILLED_DASHBOARD_COLUMNS,
   REDSKILLED_DASHBOARD_DEFAULTS,
   renderRedskilledDashboard,
-  dashboardTable,
   type RedskilledDashboard,
   type RedskilledDashboardCells,
   type RedskilledDashboardColumn,
@@ -119,11 +118,15 @@ export {
   type RedskilledDashboardHeader,
   type RedskilledDashboardOptions,
   type RedskilledDashboardRow,
+  type RedskilledDashboardWindows,
+} from "./dashboard.js";
+
+export {
+  dashboardTable,
   type RedskilledDashboardTable,
   type RedskilledDashboardTableColumn,
   type RedskilledDashboardTableVariant,
-  type RedskilledDashboardWindows,
-} from "./dashboard.js";
+} from "./dashboard-table.js";
 
 import { decodeRedskilledPayload } from "./decode.js";
 import {

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -119,6 +119,49 @@ describe("one module, three densities", () => {
     expect(stripAnsi(table.header.line)).toContain("wrk=1/1");
   });
 
+  it("publishes an operational table for wide terminals and a grouped table for narrow ones", () => {
+    const doc = payload({
+      workers: [worker({
+        display: display({ runner: "codex", issue: "3495", phase: "validating", step: "tests" }),
+        log: { last_line: "running focused checks", published_at: "2026-08-03T00:02:00.000Z" },
+      })],
+    });
+
+    const wide = renderRedskilledDashboard(doc, {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      project: "acme/widgets",
+      maxWidth: 120,
+    });
+    expect(wide.table).toBeDefined();
+    const wideTable = wide.table!;
+    expect(wideTable.variant).toBe("operational");
+    expect(wideTable.columns.map((column) => column.header)).toEqual([
+      "Worker", "Issue", "Runner", "Phase", "Progress", "Elapsed", "ETA", "Activity",
+    ]);
+    expect(wideTable.rows[0]).toEqual(expect.objectContaining({
+      issue: "3495",
+      runner: "codex opus high",
+      phase: "validating·tests",
+      activity: "hb=3s · running focused checks",
+    }));
+
+    const narrow = renderRedskilledDashboard(doc, {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      project: "acme/widgets",
+      maxWidth: 80,
+    });
+    expect(narrow.table).toBeDefined();
+    const narrowTable = narrow.table!;
+    expect(narrowTable.variant).toBe("compact");
+    expect(narrowTable.columns.map((column) => column.header)).toEqual([
+      "Worker", "Work", "State", "Latest activity",
+    ]);
+    expect(narrowTable.rows[0]).toEqual(expect.objectContaining({
+      work: "3495 · validating·tests",
+      activity: "hb=3s · running focused checks",
+    }));
+  });
+
   it("attributes target-plus-one slot usage to the interactive reservation", () => {
     const base = payload();
     const doc = payload({


### PR DESCRIPTION
## What changed

- render live TTY Worker rows with the real `tuiuiu.js/molecules` `Table`
- publish the responsive column hierarchy from the shared renderer
- use the operational table at 110+ columns and a grouped compact table below 110
- preserve pipe snapshots, `NO_COLOR`, resize, refresh, death-detail toggling, and older dashboard payloads
- add a patch changeset for the next RedSkills release

## Why

The existing TTY printed every Worker as one long abbreviated line. It was difficult to scan and degraded badly as more fields were published.

## Validation

- `@reddb-io/redskilled`: 74 files, 712 tests passed
- `@reddb-io/redskilled-render`: 3 files, 65 tests passed
- both package typechecks passed
- focused oxlint passed
- ask-red/router checks: 33 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788746820&installation_model_id=20659&pr_number=3497&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3497&signature=152511626462d4467401b6dec382b76a0a3cdaabda62bf74d454d0f121c2770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->