### PR TITLE
chore: #3499 /go: Stop the redskilled statusline from reporting healthy states as defects.

### DIFF
--- a/apps/dev/src/core/file-size-guard.ts
+++ b/apps/dev/src/core/file-size-guard.ts
@@ -78,7 +78,7 @@ export const FILE_SIZE_BASELINE: readonly FileSizeBaselineEntry[] = [
   { path: "apps/redskilled/src/daemon/lifecycle.ts", lines: 2489 },
   { path: "apps/redskilled/src/cli.ts", lines: 1036 },
   { path: "apps/redskilled/src/client.ts", lines: 1003 },
-  { path: "apps/redskilled/src/statusline-payload.ts", lines: 996 },
+  { path: "apps/redskilled/src/statusline-payload.ts", lines: 864 },
   { path: "apps/rsp/src/resident-server.ts", lines: 931 },
   { path: "apps/rsp/src/two-axis-benchmark.ts", lines: 878 },
   { path: "apps/rsp/tests/cli.helpers.ts", lines: 828 },

--- a/apps/redskilled/src/daemon/tunables.ts
+++ b/apps/redskilled/src/daemon/tunables.ts
@@ -103,8 +103,10 @@ export function observedWorkerDeath(
   context: { readonly startedAt?: string; readonly refusal?: string } = {},
 ): RedskilledDeathObservation | null {
   if (event.event !== "worker-death" && event.event !== "worker-budget-kill") return null;
+  if (event.event === "worker-death" && event.exit_code === 0) return null;
   const hostEndedWorker = event.event === "worker-budget-kill";
   const bootRefused = !hostEndedWorker && context.refusal != null;
+  const signalled = !hostEndedWorker && !bootRefused && event.signal != null;
   const observation = context.refusal ?? event.detail ??
     `redskilled observed exit code=${event.exit_code ?? "null"} signal=${event.signal ?? "null"}`;
   const startedAt = context.startedAt == null ? null : Date.parse(context.startedAt);
@@ -122,18 +124,19 @@ export function observedWorkerDeath(
     // finer heartbeat or phase, and inventing either would be worse than saying so.
     last_seen: event.ts,
     last_phase: bootRefused ? "boot-refused" : "unreported",
-    sender_class: hostEndedWorker ? "teardown" : bootRefused ? "boot-refused" : "unknown",
-    confidence: hostEndedWorker || bootRefused ? "high" : "none",
+    sender_class: hostEndedWorker ? "teardown" : bootRefused ? "boot-refused" : signalled ? "user-signal" : "unknown",
+    confidence: hostEndedWorker || bootRefused || signalled ? "high" : "none",
     signal: event.signal,
     host_boot_changed: false,
     // A budget kill is the daemon's own act and therefore evidence. A spontaneous
     // exit has an observation but no known sender; keep that receipt under
     // `checked` so `unknown` remains honest rather than becoming a guessed cause.
-    evidence: hostEndedWorker || bootRefused ? [observation] : [],
+    evidence: hostEndedWorker || bootRefused || signalled ? [observation] : [],
     checked: bootRefused ? ["Worker log tail"] : [`redskilled host event: ${observation}`],
     project_label: event.project_label,
     ...(uptimeS === undefined ? {} : { uptime_s: uptimeS }),
     detail: context.refusal ?? event.detail,
+    observed_exit: event.exit_code != null || event.signal != null,
   };
 }
 

--- a/apps/redskilled/src/statusline-deaths.ts
+++ b/apps/redskilled/src/statusline-deaths.ts
@@ -1,0 +1,201 @@
+/**
+ * statusline-deaths — the death block every rendering density shares.
+ *
+ * It sits beside the payload builder rather than inside it because the block is a
+ * DOMAIN, not a field: what counts as a death, which subset a head may print, and
+ * when repetition becomes a boot loop are three judgements with one owner. They
+ * lived in `statusline-payload.ts` while that file was also assembling the host,
+ * the Workers, the budget and the engine — and a reader looking for "why does the
+ * statusline say †332" had to walk a thousand lines of unrelated assembly first.
+ *
+ * It imports NOTHING from the payload builder, deliberately: the observation
+ * shape is a death fact, so owning it here keeps the dependency one-way and
+ * spares this module the payload-consumer exception `statusline-string` would
+ * otherwise have to widen for it.
+ *
+ * PURE: attributions in, the block a surface prints out. Nothing here reads a
+ * clock, a socket or a file.
+ */
+import type {
+  AttributionConfidence,
+  DeathAttribution,
+  DeathSenderClass,
+} from "@reddb-io/shared/death-attribution.js";
+import type { ProcessDeathKind } from "@reddb-io/shared/death-record.js";
+
+/** Host-observed facts that enrich a generic death attribution when they exist. */
+export interface RedskilledDeathObservation extends DeathAttribution {
+  readonly project_label?: string;
+  readonly uptime_s?: number;
+  readonly detail?: string | null;
+  /** The daemon witnessed an exit status or signal, rather than discovering absence in a later sweep. */
+  readonly observed_exit?: boolean;
+}
+
+/** A Worker dead by this age never reached work; repeated refusals are a boot loop. */
+export const REDSKILLED_BOOT_REFUSAL_MAX_UPTIME_S = 2;
+/** One refusal can be incidental and two can be a retry; three establishes repetition. */
+export const REDSKILLED_BOOT_LOOP_MIN_DEATHS = 3;
+
+/** How many verdicts a payload carries before the rest are counted instead. */
+export const REDSKILLED_RECENT_DEATH_LIMIT = 4;
+
+/**
+ * One posed death, reduced to what a surface prints.
+ *
+ * The lane's verdict carries its whole receipt — every source consulted, every
+ * line of evidence — and none of that fits a statusline. What survives here is
+ * the answer to "why did it die": who ended it, how sure the reaper is, and the
+ * one piece of evidence the verdict rests on. The receipt stays on the lane, and
+ * `id` is the handle that reaches it.
+ */
+export interface RedskilledStatuslineDeath {
+  readonly kind: ProcessDeathKind;
+  readonly id: string;
+  readonly pid: number;
+  /** When the reaper concluded — NOT when the process died, which nobody saw. */
+  readonly ts: string;
+  /** The last moment the dead process is known to have lived. */
+  readonly last_seen: string;
+  readonly last_phase: string;
+  readonly sender_class: DeathSenderClass;
+  readonly confidence: AttributionConfidence;
+  /** The signal, when a source NAMED one; never inferred from the class alone. */
+  readonly signal: string | null;
+  /** The first fact the verdict rests on; `null` exactly when the class is unknown. */
+  readonly evidence: string | null;
+}
+
+/**
+ * What this host could not explain, as of the last reaping.
+ *
+ * `count` is stated beside `recent` rather than left to a consumer's `.length`,
+ * because the list is capped: a statusline that printed `†2` from a truncated
+ * array would under-report a machine that killed a dozen processes, and "how many
+ * died" is the number that decides whether an operator looks further.
+ *
+ * An empty block is a REAPING THAT FOUND NOTHING and is never the same fact as an
+ * absent one, which is a daemon that never reaped — the distinction #3028 exists
+ * to keep, carried the one hop to the surfaces.
+ */
+export interface RedskilledStatuslineDeaths {
+  readonly count: number;
+  /** Deaths in the window whose evidence names a sender; this is the statusline head's count. */
+  readonly sender_attributed_count: number;
+  /** The newest verdicts first, capped — `count` is the whole number. */
+  readonly recent: readonly RedskilledStatuslineDeath[];
+  /** The newest verdict, or `null` when the reaping attributed nothing. */
+  readonly latest: RedskilledStatuslineDeath | null;
+  /** The newest verdict whose evidence names a sender, independent of the capped receipt list. */
+  readonly latest_sender_attributed: RedskilledStatuslineDeath | null;
+  /** When the reaper concluded; `null` when it attributed nothing. */
+  readonly reaped_at: string | null;
+  /** A repeated same-project boot refusal, absent when the deaths do not establish one. */
+  readonly boot_loop?: RedskilledStatuslineBootLoop;
+}
+
+/** The actionable shape hidden by a flat death count. */
+export interface RedskilledStatuslineBootLoop {
+  readonly project_label: string;
+  readonly count: number;
+  readonly span_ms: number;
+  readonly latest_refusal: string;
+}
+
+/** The death block a surface prints, newest verdict first. PURE. */
+export function buildDeaths(
+  attributions: readonly RedskilledDeathObservation[],
+  limit: number,
+): RedskilledStatuslineDeaths {
+  const ordered = [...attributions].sort((a, b) => (instant(b.ts) ?? 0) - (instant(a.ts) ?? 0));
+  const recent = ordered.slice(0, Math.max(0, Math.floor(limit))).map(statuslineDeath);
+  const senderAttributed = ordered.filter(
+    (attribution) =>
+      attribution.observed_exit === true ||
+      (attribution.sender_class !== "unknown" && attribution.confidence !== "none"),
+  );
+  const bootLoop = buildBootLoop(ordered);
+  return {
+    count: ordered.length,
+    sender_attributed_count: senderAttributed.length,
+    recent,
+    latest: recent[0] ?? null,
+    latest_sender_attributed: senderAttributed[0] == null ? null : statuslineDeath(senderAttributed[0]),
+    reaped_at: recent[0]?.ts ?? null,
+    ...(bootLoop == null ? {} : { boot_loop: bootLoop }),
+  };
+}
+
+/** Reduce one full attribution to the receipt every rendering density shares. PURE. */
+function statuslineDeath(attribution: RedskilledDeathObservation): RedskilledStatuslineDeath {
+  return {
+    kind: attribution.kind,
+    id: attribution.id,
+    pid: attribution.pid,
+    ts: attribution.ts,
+    last_seen: attribution.last_seen,
+    last_phase: attribution.last_phase,
+    sender_class: attribution.sender_class,
+    confidence: attribution.confidence,
+    signal: attribution.signal,
+    evidence: attribution.evidence[0] ?? null,
+  };
+}
+
+/** Reduce the rolling death window to its strongest same-project boot loop. PURE. */
+function buildBootLoop(
+  ordered: readonly RedskilledDeathObservation[],
+): RedskilledStatuslineBootLoop | null {
+  const byProject = new Map<string, RedskilledDeathObservation[]>();
+  for (const death of ordered) {
+    if (
+      death.sender_class !== "boot-refused" ||
+      death.uptime_s == null ||
+      death.uptime_s > REDSKILLED_BOOT_REFUSAL_MAX_UPTIME_S ||
+      death.project_label == null ||
+      death.project_label === "" ||
+      instant(death.ts) == null
+    ) continue;
+    const grouped = byProject.get(death.project_label) ?? [];
+    grouped.push(death);
+    byProject.set(death.project_label, grouped);
+  }
+
+  const loops = [...byProject.entries()]
+    .filter(([, deaths]) => deaths.length >= REDSKILLED_BOOT_LOOP_MIN_DEATHS)
+    .map(([projectLabel, deaths]): RedskilledStatuslineBootLoop | null => {
+      const newest = deaths[0]!;
+      const newestAt = instant(newest.ts)!;
+      const oldestAt = Math.min(...deaths.map((death) => instant(death.ts)!));
+      const refusal = newest.detail?.trim() || newest.evidence[0]?.trim();
+      if (refusal == null || refusal === "") return null;
+      return {
+        project_label: projectLabel,
+        count: deaths.length,
+        span_ms: Math.max(0, newestAt - oldestAt),
+        latest_refusal: refusal,
+      };
+    })
+    .filter((loop): loop is RedskilledStatuslineBootLoop => loop != null)
+    .sort((left, right) => right.count - left.count || right.span_ms - left.span_ms);
+  return loops[0] ?? null;
+}
+
+/** True when `value` carries a death block's two load-bearing fields. PURE. */
+export function isStatuslineDeaths(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const deaths = value as Record<string, unknown>;
+  return Number.isInteger(deaths.count) && Array.isArray(deaths.recent);
+}
+
+/**
+ * An ISO instant in milliseconds, or `null` when it is not one. PURE.
+ *
+ * Its own copy rather than an import from the payload builder, which holds an
+ * identical one: a three-line date parse is a cheaper duplication than the
+ * dependency the module header exists to avoid.
+ */
+function instant(value: string): number | null {
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -65,6 +65,8 @@ export interface RedskilledDeathObservation extends DeathAttribution {
   readonly project_label?: string;
   readonly uptime_s?: number;
   readonly detail?: string | null;
+  /** The daemon witnessed an exit status or signal, rather than discovering absence in a later sweep. */
+  readonly observed_exit?: boolean;
 }
 
 /** What a Worker is doing, as the daemon knows it. */
@@ -250,10 +252,14 @@ export interface RedskilledStatuslineDeath {
  */
 export interface RedskilledStatuslineDeaths {
   readonly count: number;
+  /** Deaths in the window whose evidence names a sender; this is the statusline head's count. */
+  readonly sender_attributed_count: number;
   /** The newest verdicts first, capped — `count` is the whole number. */
   readonly recent: readonly RedskilledStatuslineDeath[];
   /** The newest verdict, or `null` when the reaping attributed nothing. */
   readonly latest: RedskilledStatuslineDeath | null;
+  /** The newest verdict whose evidence names a sender, independent of the capped receipt list. */
+  readonly latest_sender_attributed: RedskilledStatuslineDeath | null;
   /** When the reaper concluded; `null` when it attributed nothing. */
   readonly reaped_at: string | null;
   /** A repeated same-project boot refusal, absent when the deaths do not establish one. */
@@ -663,27 +669,37 @@ function buildDeaths(
   limit: number,
 ): RedskilledStatuslineDeaths {
   const ordered = [...attributions].sort((a, b) => (instant(b.ts) ?? 0) - (instant(a.ts) ?? 0));
-  const recent = ordered.slice(0, Math.max(0, Math.floor(limit))).map(
-    (attribution): RedskilledStatuslineDeath => ({
-      kind: attribution.kind,
-      id: attribution.id,
-      pid: attribution.pid,
-      ts: attribution.ts,
-      last_seen: attribution.last_seen,
-      last_phase: attribution.last_phase,
-      sender_class: attribution.sender_class,
-      confidence: attribution.confidence,
-      signal: attribution.signal,
-      evidence: attribution.evidence[0] ?? null,
-    }),
+  const recent = ordered.slice(0, Math.max(0, Math.floor(limit))).map(statuslineDeath);
+  const senderAttributed = ordered.filter(
+    (attribution) =>
+      attribution.observed_exit === true ||
+      (attribution.sender_class !== "unknown" && attribution.confidence !== "none"),
   );
   const bootLoop = buildBootLoop(ordered);
   return {
     count: ordered.length,
+    sender_attributed_count: senderAttributed.length,
     recent,
     latest: recent[0] ?? null,
+    latest_sender_attributed: senderAttributed[0] == null ? null : statuslineDeath(senderAttributed[0]),
     reaped_at: recent[0]?.ts ?? null,
     ...(bootLoop == null ? {} : { boot_loop: bootLoop }),
+  };
+}
+
+/** Reduce one full attribution to the receipt every rendering density shares. PURE. */
+function statuslineDeath(attribution: RedskilledDeathObservation): RedskilledStatuslineDeath {
+  return {
+    kind: attribution.kind,
+    id: attribution.id,
+    pid: attribution.pid,
+    ts: attribution.ts,
+    last_seen: attribution.last_seen,
+    last_phase: attribution.last_phase,
+    sender_class: attribution.sender_class,
+    confidence: attribution.confidence,
+    signal: attribution.signal,
+    evidence: attribution.evidence[0] ?? null,
   };
 }
 

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -20,18 +20,12 @@
  *
  * PURE: the host state, the ceiling, the reading and both instants are inputs.
  */
-import type {
-  AttributionConfidence,
-  DeathAttribution,
-  DeathSenderClass,
-} from "@reddb-io/shared/death-attribution.js";
 import {
   buildGithubBalanceReport,
   isGithubBalanceReport,
   type GithubBalance,
   type GithubBalanceReport,
 } from "@reddb-io/github";
-import type { ProcessDeathKind } from "@reddb-io/shared/death-record.js";
 import { measureHostConsumption, type RedskilledHostCeiling, type RedskilledHostConsumption } from "./admission.js";
 import type { RedskilledBudgetAccounting } from "./budget-accounting.js";
 import type { RedskilledHostState, RedskilledRssSource, RedskilledWorkerView } from "./host-state.js";
@@ -44,6 +38,13 @@ import {
   type RedskilledRepositoryActivity,
 } from "./repository-activity.js";
 import type { RedskilledWorkerDisplay, RedskilledWorkerDisplayRecord } from "./worker-display.js";
+import {
+  buildDeaths,
+  REDSKILLED_RECENT_DEATH_LIMIT,
+  isStatuslineDeaths,
+  type RedskilledDeathObservation,
+  type RedskilledStatuslineDeaths,
+} from "./statusline-deaths.js";
 import type { RedskilledWorkerLogLine } from "./worker-log.js";
 
 /**
@@ -55,19 +56,20 @@ import type { RedskilledWorkerLogLine } from "./worker-log.js";
  */
 export const REDSKILLED_STALENESS_MS = 30_000;
 
-/** A Worker dead by this age never reached work; repeated refusals are a boot loop. */
-export const REDSKILLED_BOOT_REFUSAL_MAX_UPTIME_S = 2;
-/** One refusal can be incidental and two can be a retry; three establishes repetition. */
-export const REDSKILLED_BOOT_LOOP_MIN_DEATHS = 3;
-
-/** Host-observed facts that enrich a generic death attribution when they exist. */
-export interface RedskilledDeathObservation extends DeathAttribution {
-  readonly project_label?: string;
-  readonly uptime_s?: number;
-  readonly detail?: string | null;
-  /** The daemon witnessed an exit status or signal, rather than discovering absence in a later sweep. */
-  readonly observed_exit?: boolean;
-}
+// The death block's own judgements — what counts as a death, which subset a head
+// prints, when repetition is a boot loop — live in `./statusline-deaths.js`. They
+// are re-exported below because this module's payload interface NAMES them, so a
+// consumer typing a payload reaches them from the module it already imports.
+export {
+  isStatuslineDeaths,
+  type RedskilledDeathObservation,
+  REDSKILLED_BOOT_LOOP_MIN_DEATHS,
+  REDSKILLED_BOOT_REFUSAL_MAX_UPTIME_S,
+  REDSKILLED_RECENT_DEATH_LIMIT,
+  type RedskilledStatuslineBootLoop,
+  type RedskilledStatuslineDeath,
+  type RedskilledStatuslineDeaths,
+} from "./statusline-deaths.js";
 
 /** What a Worker is doing, as the daemon knows it. */
 export type RedskilledWorkerState = "running" | "reattached";
@@ -213,68 +215,6 @@ export interface RedskilledStatuslineDaemon {
 }
 
 /**
- * One posed death, reduced to what a surface prints.
- *
- * The lane's verdict carries its whole receipt — every source consulted, every
- * line of evidence — and none of that fits a statusline. What survives here is
- * the answer to "why did it die": who ended it, how sure the reaper is, and the
- * one piece of evidence the verdict rests on. The receipt stays on the lane, and
- * `id` is the handle that reaches it.
- */
-export interface RedskilledStatuslineDeath {
-  readonly kind: ProcessDeathKind;
-  readonly id: string;
-  readonly pid: number;
-  /** When the reaper concluded — NOT when the process died, which nobody saw. */
-  readonly ts: string;
-  /** The last moment the dead process is known to have lived. */
-  readonly last_seen: string;
-  readonly last_phase: string;
-  readonly sender_class: DeathSenderClass;
-  readonly confidence: AttributionConfidence;
-  /** The signal, when a source NAMED one; never inferred from the class alone. */
-  readonly signal: string | null;
-  /** The first fact the verdict rests on; `null` exactly when the class is unknown. */
-  readonly evidence: string | null;
-}
-
-/**
- * What this host could not explain, as of the last reaping.
- *
- * `count` is stated beside `recent` rather than left to a consumer's `.length`,
- * because the list is capped: a statusline that printed `†2` from a truncated
- * array would under-report a machine that killed a dozen processes, and "how many
- * died" is the number that decides whether an operator looks further.
- *
- * An empty block is a REAPING THAT FOUND NOTHING and is never the same fact as an
- * absent one, which is a daemon that never reaped — the distinction #3028 exists
- * to keep, carried the one hop to the surfaces.
- */
-export interface RedskilledStatuslineDeaths {
-  readonly count: number;
-  /** Deaths in the window whose evidence names a sender; this is the statusline head's count. */
-  readonly sender_attributed_count: number;
-  /** The newest verdicts first, capped — `count` is the whole number. */
-  readonly recent: readonly RedskilledStatuslineDeath[];
-  /** The newest verdict, or `null` when the reaping attributed nothing. */
-  readonly latest: RedskilledStatuslineDeath | null;
-  /** The newest verdict whose evidence names a sender, independent of the capped receipt list. */
-  readonly latest_sender_attributed: RedskilledStatuslineDeath | null;
-  /** When the reaper concluded; `null` when it attributed nothing. */
-  readonly reaped_at: string | null;
-  /** A repeated same-project boot refusal, absent when the deaths do not establish one. */
-  readonly boot_loop?: RedskilledStatuslineBootLoop;
-}
-
-/** The actionable shape hidden by a flat death count. */
-export interface RedskilledStatuslineBootLoop {
-  readonly project_label: string;
-  readonly count: number;
-  readonly span_ms: number;
-  readonly latest_refusal: string;
-}
-
-/**
  * Which engine is answering, and whether it is the current one.
  *
  * Two versions, never one: `running` is the code answering this read and
@@ -299,9 +239,6 @@ export interface RedskilledStatuslineEngine {
   /** True/false when the published answer is known; `null` when it never resolved. */
   readonly current: boolean | null;
 }
-
-/** How many verdicts a payload carries before the rest are counted instead. */
-export const REDSKILLED_RECENT_DEATH_LIMIT = 4;
 
 export interface RedskilledStatuslinePayload {
   readonly version: 1;
@@ -663,85 +600,6 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
   };
 }
 
-/** The death block a surface prints, newest verdict first. PURE. */
-function buildDeaths(
-  attributions: readonly RedskilledDeathObservation[],
-  limit: number,
-): RedskilledStatuslineDeaths {
-  const ordered = [...attributions].sort((a, b) => (instant(b.ts) ?? 0) - (instant(a.ts) ?? 0));
-  const recent = ordered.slice(0, Math.max(0, Math.floor(limit))).map(statuslineDeath);
-  const senderAttributed = ordered.filter(
-    (attribution) =>
-      attribution.observed_exit === true ||
-      (attribution.sender_class !== "unknown" && attribution.confidence !== "none"),
-  );
-  const bootLoop = buildBootLoop(ordered);
-  return {
-    count: ordered.length,
-    sender_attributed_count: senderAttributed.length,
-    recent,
-    latest: recent[0] ?? null,
-    latest_sender_attributed: senderAttributed[0] == null ? null : statuslineDeath(senderAttributed[0]),
-    reaped_at: recent[0]?.ts ?? null,
-    ...(bootLoop == null ? {} : { boot_loop: bootLoop }),
-  };
-}
-
-/** Reduce one full attribution to the receipt every rendering density shares. PURE. */
-function statuslineDeath(attribution: RedskilledDeathObservation): RedskilledStatuslineDeath {
-  return {
-    kind: attribution.kind,
-    id: attribution.id,
-    pid: attribution.pid,
-    ts: attribution.ts,
-    last_seen: attribution.last_seen,
-    last_phase: attribution.last_phase,
-    sender_class: attribution.sender_class,
-    confidence: attribution.confidence,
-    signal: attribution.signal,
-    evidence: attribution.evidence[0] ?? null,
-  };
-}
-
-/** Reduce the rolling death window to its strongest same-project boot loop. PURE. */
-function buildBootLoop(
-  ordered: readonly RedskilledDeathObservation[],
-): RedskilledStatuslineBootLoop | null {
-  const byProject = new Map<string, RedskilledDeathObservation[]>();
-  for (const death of ordered) {
-    if (
-      death.sender_class !== "boot-refused" ||
-      death.uptime_s == null ||
-      death.uptime_s > REDSKILLED_BOOT_REFUSAL_MAX_UPTIME_S ||
-      death.project_label == null ||
-      death.project_label === "" ||
-      instant(death.ts) == null
-    ) continue;
-    const grouped = byProject.get(death.project_label) ?? [];
-    grouped.push(death);
-    byProject.set(death.project_label, grouped);
-  }
-
-  const loops = [...byProject.entries()]
-    .filter(([, deaths]) => deaths.length >= REDSKILLED_BOOT_LOOP_MIN_DEATHS)
-    .map(([projectLabel, deaths]): RedskilledStatuslineBootLoop | null => {
-      const newest = deaths[0]!;
-      const newestAt = instant(newest.ts)!;
-      const oldestAt = Math.min(...deaths.map((death) => instant(death.ts)!));
-      const refusal = newest.detail?.trim() || newest.evidence[0]?.trim();
-      if (refusal == null || refusal === "") return null;
-      return {
-        project_label: projectLabel,
-        count: deaths.length,
-        span_ms: Math.max(0, newestAt - oldestAt),
-        latest_refusal: refusal,
-      };
-    })
-    .filter((loop): loop is RedskilledStatuslineBootLoop => loop != null)
-    .sort((left, right) => right.count - left.count || right.span_ms - left.span_ms);
-  return loops[0] ?? null;
-}
-
 /**
  * The engine block, from the version state the daemon already holds. PURE.
  *
@@ -996,12 +854,6 @@ function isStatuslineStop(value: unknown): boolean {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const stopped = value as Record<string, unknown>;
   return typeof stopped.project_label === "string" && typeof stopped.at === "string";
-}
-
-function isStatuslineDeaths(value: unknown): boolean {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const deaths = value as Record<string, unknown>;
-  return Number.isInteger(deaths.count) && Array.isArray(deaths.recent);
 }
 
 function isStatuslineEngine(value: unknown): boolean {

--- a/apps/redskilled/tests/early-worker-death.test.ts
+++ b/apps/redskilled/tests/early-worker-death.test.ts
@@ -77,6 +77,35 @@ function spec(overrides: Partial<RedskilledWorkerSpec> = {}): RedskilledWorkerSp
 }
 
 describe("a Worker that exits before its first write", () => {
+  it("keeps a clean completion on the event lane without presenting it as a death", async () => {
+    const paths = await sessionPaths();
+    const launched: { exit?: (code: number) => void } = {};
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      clock: () => "2026-08-03T16:47:09.000Z",
+      launch: earlyExitLaunch(launched),
+      unitInventory: () => [],
+    });
+    running.push(daemon);
+
+    daemon.startWorker(spec());
+    launched.exit?.(0);
+    await daemon.flushEvents();
+
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.map((event) => event.event)).toEqual(["worker-birth", "worker-death"]);
+    expect(events[1]).toMatchObject({ worker_id: "w-early", exit_code: 0, signal: null });
+
+    const payload = daemon.statuslinePayload();
+    expect(payload.deaths).toBeUndefined();
+    const line = renderRedskilledStatusline(payload, {
+      ...REDSKILLED_STATUSLINE_DEFAULTS,
+      project: "acme/widgets",
+    });
+    expect(line.line).not.toContain("†");
+  });
+
   it("leaves a host-written death and renders as a loss, not quiet idleness", async () => {
     const paths = await sessionPaths();
     const launched: { exit?: (code: number) => void } = {};

--- a/apps/redskilled/tests/statusline-deaths.test.ts
+++ b/apps/redskilled/tests/statusline-deaths.test.ts
@@ -135,7 +135,14 @@ describe("the aggregate carries what could not be explained", () => {
     // Absent is a daemon with no reaper — the block is not there to be read.
     expect(payloadWith(undefined).deaths).toBeUndefined();
     // Empty is a reaping that concluded: a real answer, and a count of zero.
-    expect(payloadWith([]).deaths).toEqual({ count: 0, recent: [], latest: null, reaped_at: null });
+    expect(payloadWith([]).deaths).toEqual({
+      count: 0,
+      sender_attributed_count: 0,
+      recent: [],
+      latest: null,
+      latest_sender_attributed: null,
+      reaped_at: null,
+    });
   });
 
   it("caps the listed verdicts and still states how many there were", () => {
@@ -145,6 +152,42 @@ describe("the aggregate carries what could not be explained", () => {
     const payload = payloadWith(many);
     expect(payload.deaths?.count).toBe(9);
     expect(payload.deaths?.recent.length).toBeLessThan(9);
+  });
+
+  it("states the sender-attributed subset without dropping bookkeeping gaps", () => {
+    const gap = attribution({
+      id: "worker:w-gap",
+      ts: "2026-07-29T00:59:30.000Z",
+      sender_class: "unknown",
+      confidence: "none",
+      signal: null,
+      evidence: [],
+      checked: ["the host no longer confirms this Worker"],
+    });
+    const payload = payloadWith([attribution(), gap]);
+
+    expect(payload.deaths).toMatchObject({
+      count: 2,
+      sender_attributed_count: 1,
+      latest_sender_attributed: { id: "worker:w-9", sender_class: "oomd" },
+    });
+    expect(payload.deaths?.recent.map((death) => death.id)).toContain("worker:w-gap");
+
+    const line = renderRedskilledStatusline(payload, {
+      ...REDSKILLED_STATUSLINE_DEFAULTS,
+      project: "acme/widgets",
+    });
+    expect(line.line).toContain("†1 oomd");
+    expect(line.line).not.toContain("unknown");
+
+    const dashboard = renderRedskilledDashboard(payload, {
+      mode: "local",
+      project: "acme/widgets",
+      maxWidth: 200,
+      maxRows: 16,
+      showDeathDetails: true,
+    });
+    expect(dashboard.lines.some((entry) => entry.includes("worker:w-gap"))).toBe(true);
   });
 });
 

--- a/apps/redskilled/tests/statusline-local-project.test.ts
+++ b/apps/redskilled/tests/statusline-local-project.test.ts
@@ -202,18 +202,16 @@ describe("`project unknown`", () => {
     expect(render.line).toContain("idle");
   });
 
-  it("names the mismatch when the directory resolved to a project this host never heard of", () => {
+  it("renders healthy idleness when the directory's project has no drain registration", () => {
     const render = renderRedskilledStatusline(
       payloadOf([worker({ project_label: "acme/other" })]),
       options({ project: "acme/widgets" }),
     );
 
     expect(render.project_match).toBe("unregistered");
-    expect(render.line).toContain("project unknown");
-    expect(render.line).toContain("acme/widgets was never registered on this host");
-    // No idle zero to read as calm — the host may be busy for someone else.
-    expect(render.line).not.toContain("0w");
-    expect(render.line).not.toContain("idle");
+    expect(render.line).toBe("acme/widgets 0w 0B idle v0.1.0");
+    expect(render.repair).toBeUndefined();
+    expect(render.repair_reason).toBeUndefined();
   });
 
   it("says so plainly when the directory resolved to no project at all", () => {

--- a/apps/vscode-extension-red-skills/tests/fixtures.ts
+++ b/apps/vscode-extension-red-skills/tests/fixtures.ts
@@ -194,8 +194,14 @@ export function statuslinePayload(overrides: PayloadOverrides = {}): RedskilledS
     // in no Worker row, which is the whole reason it has to ride on the header.
     deaths: {
       count: 1,
+      // The canned verdict names systemd-oomd, so it is sender-attributed and
+      // rides the head. The two counts coincide here on purpose: this fixture
+      // proves the surface prints an ATTRIBUTED death, and a fixture whose only
+      // death were un-narrated would prove the head prints nothing.
+      sender_attributed_count: 1,
       recent: [CANNED_DEATH],
       latest: CANNED_DEATH,
+      latest_sender_attributed: CANNED_DEATH,
       reaped_at: CANNED_DEATH.ts,
     },
     engine: {

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -305,11 +305,11 @@ function renderHead(
   unmatched: string,
 ): string {
   const parts: string[] = [];
-  const unmatchedProject = match !== "matched" && match !== "name-only";
+  const unmatchedProject = match !== "matched" && match !== "unregistered" && match !== "name-only";
   if (options.mode === "global") {
     parts.push(`host ${workerActivity(payload.workers, payload.host.worker_count)}/${payload.host.project_count}p`);
     parts.push(memoryFigure(payload, options));
-  } else if (match === "matched") {
+  } else if (match === "matched" || match === "unregistered") {
     parts.push(`${options.project} ${workerActivity(workers, workers.length)}`);
     parts.push(memoryFigure(payload, options));
     if (workers.length === 0) parts.push("idle");
@@ -408,14 +408,21 @@ function budgetMark(payload: RedskilledRenderPayload): string | null {
  */
 function deathMark(payload: RedskilledRenderPayload): string | null {
   const deaths = payload.deaths;
-  if (deaths == null || deaths.count <= 0 || deaths.latest == null) return null;
+  if (deaths == null) return null;
+  // Older daemons did not state the sender-attributed subset. Preserve their
+  // wire meaning without re-deriving it; current daemons are the sole authority.
+  const count = deaths.sender_attributed_count ?? deaths.count;
+  const latest = deaths.sender_attributed_count === undefined
+    ? deaths.latest
+    : deaths.latest_sender_attributed ?? null;
+  if (count <= 0 || latest == null) return null;
   const loop = deaths.boot_loop;
   if (loop != null) {
     const refusal = flattenPublishedLine(loop.latest_refusal);
-    return `${DEATH_MARK}${deaths.count} boot-refused ×${loop.count} in ${compactLoopSpan(loop.span_ms)}` +
+    return `${DEATH_MARK}${count} boot-refused ×${loop.count} in ${compactLoopSpan(loop.span_ms)}` +
       (refusal == null ? "" : ` — ${refusal}`);
   }
-  return `${DEATH_MARK}${deaths.count} ${deaths.latest.sender_class}`;
+  return `${DEATH_MARK}${count} ${latest.sender_class}`;
 }
 
 /** A loop span without zero-valued trailing units (`4m`, not `4m0s`). PURE. */
@@ -427,12 +434,11 @@ function compactLoopSpan(spanMs: number): string {
 }
 
 /**
- * The head for a directory this host knows no project for. PURE.
+ * The head for a directory that is not currently matched to a registration. PURE.
  *
- * `project unknown` appears HERE and nowhere else, and it always carries the
- * reason: the two mismatches are fixed by different actions — one wants a
- * `project.name` or a git remote, the other wants the project registered — and a
- * line that named neither would leave the operator with a word and no next step.
+ * `unregistered` is ordinary idleness: no drain declared intent, so there is no
+ * defect or repair to narrate. Every other branch represents prior intent or an
+ * unresolved identity and keeps its explicit reason and actionability.
  */
 function unmatchedHead(
   payload: RedskilledRenderPayload,
@@ -443,12 +449,7 @@ function unmatchedHead(
   readonly repair?: RepairAction | "none";
   readonly repair_reason?: string;
 } {
-  if (match === "unregistered") {
-    return composeRepair({
-      state: `project unknown — ${project} was never registered on this host`,
-      repair: registrationRepair(),
-    });
-  }
+  if (match === "unregistered") return { prose: "" };
   if (match === "orphaned") {
     return composeRepair({
       state: `project unknown — ${project} is registered on a daemon this socket does not reach`,

--- a/packages/redskilled-render/payload.ts
+++ b/packages/redskilled-render/payload.ts
@@ -220,8 +220,12 @@ export interface RedskilledRenderDeath {
 /** What this host could not explain, as of the last reaping. */
 export interface RedskilledRenderDeaths {
   readonly count: number;
+  /** Optional for payloads composed before the daemon stated the sender-attributed subset. */
+  readonly sender_attributed_count?: number;
   readonly recent: readonly RedskilledRenderDeath[];
   readonly latest: RedskilledRenderDeath | null;
+  /** Optional for the same rolling-upgrade window as `sender_attributed_count`. */
+  readonly latest_sender_attributed?: RedskilledRenderDeath | null;
   readonly reaped_at: string | null;
   readonly boot_loop?: RedskilledRenderBootLoop;
 }

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -410,7 +410,7 @@ describe("an unknown project's registration history (#3191)", () => {
     ceiling_used_fraction: 0,
   };
 
-  it("carries the pasteable registration repair beside the unregistered head", () => {
+  it("renders an unregistered project as ordinary healthy idleness", () => {
     const rendered = renderRedskilledStatusline(
       payload({
         host: emptyHost,
@@ -422,30 +422,13 @@ describe("an unknown project's registration history (#3191)", () => {
       { ...LOCAL, maxWidth: 400 },
     );
 
-    expect(rendered.repair).toEqual({
-      tool: "project_start",
-      args: { runner: "claude", target: 1 },
-      why: "register this project with the host so its queue can drain",
-    });
-    expect(rendered.line).toBe(
-      "project unknown — acme/widgets was never registered on this host; repair: call `project_start` with " +
-      "`{\"runner\":\"claude\",\"target\":1}` because register this project with the host so its queue can drain v3.3.11",
-    );
+    expect(rendered.project_match).toBe("unregistered");
+    expect(rendered.repair).toBeUndefined();
+    expect(rendered.repair_reason).toBeUndefined();
+    expect(rendered.line).toBe("acme/widgets 0w 0B idle v3.3.11");
   });
 
   it.each([
-    [
-      "was never registered",
-      payload({
-        host: emptyHost,
-        projects: [],
-        workers: [],
-        known_projects: [],
-        registered_projects: [],
-      }),
-      "project unknown — acme/widgets was never registered on this host; repair: call `project_start` with " +
-        "`{\"runner\":\"claude\",\"target\":1}` because register this project with the host so its queue can drain v3.3.11",
-    ],
     [
       "lapsed",
       payload({


### PR DESCRIPTION
Automated AFK landing for #3499. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3499

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788782229&installation_model_id=20659&pr_number=3500&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3500&signature=1e0fff3f3d3fd5266d947b6b89ba8f7a69e7acfe87e2fd5d9e85bfbd9c9f7689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->