### PR TITLE
chore: #3506 Declare the public host event kinds and freeze their shape

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -21,6 +21,33 @@ daemon does not belong inside it either. It lives here and consumes the shared
 resident infrastructure (`packages/shared/resident-core.ts`) rather than a copy
 of it.
 
+## Public host-event contract
+
+An external program may watch `~/.red/redskilled/redskilled.log.toonl` for
+exactly three public event kinds: `worker-birth`, `worker-death`, and
+`worker-budget-kill`. Their kind membership and emitted field set are stable;
+changing either is a public contract change guarded by
+`tests/public-host-event-contract.test.ts`. Every other kind on the lane is
+internal telemetry and may be added, removed, or reshaped without notice. A
+consumer must ignore kinds outside the public set.
+
+Each public record is flat and total. It contains the following fields, with
+`null` used where a field does not apply:
+
+```text
+admission_verdict  base_commits_ahead  base_head_sha  cpu_weight  detail
+event  exit_code  fork_sha  heal_kind  isolated  kind  log_path  memory_high
+memory_max  model  phase  pid  project_label  reason  runner  signal  step
+tokens  tools  ts  unit  version  worker_id  workspace_path
+```
+
+`kind` is the discriminator; `event` carries the same value as its compatibility
+alias. All three kinds carry the Worker's identity and placement fields, so a
+consumer can handle a death or budget kill even after the corresponding birth
+has rotated out of the lane. Kind-specific facts are `admission_verdict` on a
+birth and `detail`, `exit_code`, `signal`, and `reason` on a death or budget
+kill.
+
 ## What it owns
 
 | Concern | Where it lives |

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -64,6 +64,20 @@ export const REDSKILLED_WORKER_EVENT_KINDS = [
   "worker-budget-kill",
 ] & { includes(searchElement: RedskilledWorkerEventKind | "demand-refusal" | "daemon-stop"): boolean };
 
+/**
+ * The host-event kinds external consumers may rely on (ADR 0140).
+ *
+ * Kinds absent from this declaration are internal telemetry. They may be added,
+ * removed or reshaped without widening this public contract.
+ */
+export const REDSKILLED_PUBLIC_HOST_EVENT_KINDS = [
+  "worker-birth",
+  "worker-death",
+  "worker-budget-kill",
+] as const satisfies readonly RedskilledWorkerEventKind[];
+
+export type RedskilledPublicHostEventKind = typeof REDSKILLED_PUBLIC_HOST_EVENT_KINDS[number];
+
 /** The daemon-owned records that deliberately name no Worker. */
 export const REDSKILLED_DAEMON_EVENT_KINDS = ["demand-refusal", "daemon-stop"] as const;
 
@@ -153,6 +167,12 @@ export interface RedskilledHostEvent {
   /** The signal that ended the Worker, when one did. */
   readonly signal: string | null;
 }
+
+/** A host-event record whose discriminator carries the public stability promise. */
+export type RedskilledPublicHostEvent = RedskilledHostEvent & {
+  readonly kind: RedskilledPublicHostEventKind;
+  readonly event: RedskilledPublicHostEventKind;
+};
 
 /** The daemon's one structured log, inside its host-scoped home. */
 export const REDSKILLED_EVENT_LANE_FILE = "redskilled.log.toonl";

--- a/apps/redskilled/tests/public-host-event-contract.test.ts
+++ b/apps/redskilled/tests/public-host-event-contract.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  REDSKILLED_PUBLIC_HOST_EVENT_KINDS,
+  buildHostEvent,
+  type RecordWorkerEventInput,
+  type RedskilledPublicHostEventKind,
+} from "../src/event-lane.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+
+const PUBLIC_HOST_EVENT_FIELDS = [
+  "admission_verdict",
+  "base_commits_ahead",
+  "base_head_sha",
+  "cpu_weight",
+  "detail",
+  "event",
+  "exit_code",
+  "fork_sha",
+  "heal_kind",
+  "isolated",
+  "kind",
+  "log_path",
+  "memory_high",
+  "memory_max",
+  "model",
+  "phase",
+  "pid",
+  "project_label",
+  "reason",
+  "runner",
+  "signal",
+  "step",
+  "tokens",
+  "tools",
+  "ts",
+  "unit",
+  "version",
+  "worker_id",
+  "workspace_path",
+] as const;
+
+const worker: RedskilledWorkerView = {
+  worker_id: "wPUB1",
+  project_label: "acme/widgets",
+  pid: 4242,
+  started_at: "2026-08-08T12:00:00.000Z",
+  workspace_path: "/tmp/worker",
+  fork_sha: "aaaa1111",
+  log_path: "/tmp/worker/worker.log.toonl",
+  isolated: true,
+  unit: "red-worker-wPUB1.service",
+  budget: {
+    memory_high: "4G",
+    memory_max: "6G",
+    cpu_weight: 100,
+  },
+  warnings: [],
+};
+
+const publicInputs = {
+  "worker-birth": {
+    kind: "worker-birth",
+    worker,
+    ts: "2026-08-08T12:00:00.000Z",
+    admissionVerdict: "admitted",
+  },
+  "worker-death": {
+    kind: "worker-death",
+    worker,
+    ts: "2026-08-08T12:01:00.000Z",
+    detail: "exited cleanly",
+    exitCode: 0,
+  },
+  "worker-budget-kill": {
+    kind: "worker-budget-kill",
+    worker,
+    ts: "2026-08-08T12:02:00.000Z",
+    detail: "memory ceiling exceeded",
+    signal: "SIGKILL",
+  },
+} satisfies Record<RedskilledPublicHostEventKind, RecordWorkerEventInput>;
+
+describe("public host-event contract", () => {
+  it("declares only lifecycle notifications and freezes each emitted field set", () => {
+    expect(REDSKILLED_PUBLIC_HOST_EVENT_KINDS).toEqual([
+      "worker-birth",
+      "worker-death",
+      "worker-budget-kill",
+    ]);
+
+    for (const kind of REDSKILLED_PUBLIC_HOST_EVENT_KINDS) {
+      const event = buildHostEvent(publicInputs[kind]);
+      expect(
+        Object.keys(event).sort(),
+        `${kind} public host-event field set`,
+      ).toEqual(PUBLIC_HOST_EVENT_FIELDS);
+    }
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3506. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3506

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788807226&installation_model_id=20659&pr_number=3517&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3517&signature=7d2adf5e950ce32eef9d8c71bad5c4e8e8244fe39551d3c820d6f16d88758a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->