### PR TITLE
chore: #3509 post_done covers the packages a change touches

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -10,8 +10,9 @@ plugins:
     afk:
       setup:
         - pnpm install --frozen-lockfile
-      # Local AFK validation stays inside the per-Ticket budget. The merge
-      # queue's required `test` check owns the full-suite verdict on the live tip.
+      # Local AFK validation reproves workspace types and repo invariants inside
+      # the per-Ticket budget. The merge queue's required `test` check owns the
+      # full-suite verdict on the live tip.
       # Declared as the ADR 0135 Validation-moment schedule; the legacy
       # feedback.commands/backpressure knobs are RETIRED at 3.6.0.
       validation:
@@ -29,7 +30,8 @@ plugins:
             - packaging/pi/**
           command: pnpm generate-manifests && pnpm pi:packages:build
         post_done:
-          - pnpm -C apps/dev exec tsc --noEmit
+          - pnpm typecheck
+          - pnpm -C apps/dev test:invariants
       # Maintainer decision 2026-08-03: codex is this repo's executor.
       #
       # The `models.codex.*` table below only says WHICH MODEL codex uses once

--- a/apps/dev/tests/validation-setting-keys.test.ts
+++ b/apps/dev/tests/validation-setting-keys.test.ts
@@ -6,6 +6,7 @@ import {
   VALIDATION_SETTING_KEYS,
   isValidationSettingKey,
 } from "../src/core/validation-moments.js";
+import { loadConfig, readValidationMoments } from "../src/core/config.js";
 
 const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
 
@@ -47,5 +48,15 @@ describe("validation setting keys (#3466)", () => {
       expect(isValidationSettingKey(setting), `${setting} is a setting, not a moment`).toBe(true);
     }
     expect(isValidationSettingKey("post_done")).toBe(false);
+  });
+
+  it("reproves workspace types and repo invariants before a Worker reports DONE (#3509)", () => {
+    const configPath = join(REPO_ROOT, ".red", "config.yaml");
+    const values = loadConfig(configPath);
+
+    expect(readValidationMoments(values).post_done).toEqual([
+      "pnpm typecheck",
+      "pnpm -C apps/dev test:invariants",
+    ]);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #3509. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3509

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788807393&installation_model_id=20659&pr_number=3518&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3518&signature=57dce9bbf3726f588b0db00d8d68ffe776e2948260c3d99d0052ae7f4ba277e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->