### PR TITLE
chore: #3510 A daemon that stood down is not a death

### DIFF
--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -34,6 +34,7 @@ import {
   renderRedskilledUserUnit,
 } from "./provision.js";
 import {
+  RedskilledAlreadyRunningError,
   startRedskilledDaemon,
   type RedskilledBalanceRegistration,
   type RedskilledQueueArming,
@@ -456,32 +457,42 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       id: `daemon:${process.pid}`,
       phase: "serving",
     });
-    const daemon = await startRedskilledDaemon({
-      paths: servePaths(values),
-      idleMs: hostSettings.idleMs,
-      ceiling: hostSettings.ceiling,
-      // The artifact states what it IS. Absent, the daemon reports the version
-      // baked into this build rather than a placeholder, because "what version is
-      // answering" is the first fact a skew investigation needs.
-      daemonVersion: values["daemon-version"] ?? readBuildInfo("redskilled").version,
-      // The verdicts reach the statusline and both dashboards from here, because
-      // this is the only moment they exist in memory: the reaper clears the
-      // anchors it read, so a surface asking later would find a lane it would
-      // have to re-derive them from (Spec #3022, slice #3032).
-      deaths: reaped.attributions,
-      // The two halves of the loop ADR 0130 Amendment 4 moved in here: what the
-      // tracker says exists, and how often this host decides what it can afford.
-      // Absent flags take the modules' own windows; an absent token leaves the
-      // poller unarmed — carrying the reason, so an unconfigured poll is
-      // REPORTED on every registration instead of passing for a drained queue.
-      queueDiscovery,
-      // The one poller that asks the token what it has left (ADR 0132 Amendment
-      // 2). Absent when no credential names a tracker for this host — and absent
-      // is `unknown`, never a full budget, because a full budget is the one
-      // answer that admits every call.
-      ...(githubBalance == null ? {} : { githubBalance }),
-      ...(values["demand-ms"] == null ? {} : { demandMs: values["demand-ms"] }),
-    });
+    let daemon;
+    try {
+      daemon = await startRedskilledDaemon({
+        paths: servePaths(values),
+        idleMs: hostSettings.idleMs,
+        ceiling: hostSettings.ceiling,
+        // The artifact states what it IS. Absent, the daemon reports the version
+        // baked into this build rather than a placeholder, because "what version is
+        // answering" is the first fact a skew investigation needs.
+        daemonVersion: values["daemon-version"] ?? readBuildInfo("redskilled").version,
+        // The verdicts reach the statusline and both dashboards from here, because
+        // this is the only moment they exist in memory: the reaper clears the
+        // anchors it read, so a surface asking later would find a lane it would
+        // have to re-derive them from (Spec #3022, slice #3032).
+        deaths: reaped.attributions,
+        // The two halves of the loop ADR 0130 Amendment 4 moved in here: what the
+        // tracker says exists, and how often this host decides what it can afford.
+        // Absent flags take the modules' own windows; an absent token leaves the
+        // poller unarmed — carrying the reason, so an unconfigured poll is
+        // REPORTED on every registration instead of passing for a drained queue.
+        queueDiscovery,
+        // The one poller that asks the token what it has left (ADR 0132 Amendment
+        // 2). Absent when no credential names a tracker for this host — and absent
+        // is `unknown`, never a full budget, because a full budget is the one
+        // answer that admits every call.
+        ...(githubBalance == null ? {} : { githubBalance }),
+        ...(values["demand-ms"] == null ? {} : { demandMs: values["demand-ms"] }),
+      });
+    } catch (error) {
+      if (!(error instanceof RedskilledAlreadyRunningError)) throw error;
+      // The candidate learned why it must leave from the singleton itself. It
+      // stood down; uninstalling also clears the presence anchor so the next boot
+      // does not invent an unexplained disappearance for this orderly refusal.
+      deaths.uninstall();
+      return 0;
+    }
     // A signalled daemon LETS GO rather than being cut off: the stop path flushes
     // the event lane, releases the lease and unlinks the socket, so the successor
     // inherits a complete record instead of whatever had reached disk by the time

--- a/apps/redskilled/tests/singleton-race.test.ts
+++ b/apps/redskilled/tests/singleton-race.test.ts
@@ -3,14 +3,19 @@
 // resolves with an exclusive bind plus a session lease — the failure mode being
 // guarded is two daemons that both believe they own the socket.
 import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { deathLaneFileIn, readProcessDeathLane } from "@reddb-io/shared/death-record.js";
+import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
 import { isPidAlive } from "@reddb-io/shared/resident-core.js";
 import { afterEach, describe, expect, it } from "vitest";
 import { ensureRedskilledDaemon, readRedskilledHostState } from "../src/client.js";
 import { RedskilledAlreadyRunningError, socketAnswers, startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { redskilledServeArgv } from "../src/daemon-entry.js";
 import { createRedskilledMachineClaimStore } from "../src/machine-scope.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { sendRedskilledRequest } from "../src/protocol.js";
@@ -54,6 +59,34 @@ describe("redskilled singleton", () => {
 
     await expect(startRedskilledDaemon({ paths })).rejects.toBeInstanceOf(RedskilledAlreadyRunningError);
     expect(await socketAnswers(paths.socketPath)).toBe(true);
+  });
+
+  it("lets a shipped candidate stand down without recording a daemon death", async () => {
+    const paths = await sessionPaths();
+    const first = await startRedskilledDaemon({ paths, idleMs: 60_000 });
+    running.push(first);
+    const home = paths.runtimeDir;
+    const candidate = spawn(
+      process.execPath,
+      ["--import", tsxLoader, cliEntry, ...redskilledServeArgv(paths, { idleMs: 60_000 })],
+      {
+        stdio: "ignore",
+        env: {
+          ...process.env,
+          HOME: home,
+          REDSKILLED_SESSION: `test:${paths.runtimeDir}`,
+          REDSKILLED_MACHINE_DIR: paths.runtimeDir,
+        },
+      },
+    );
+    children.push(candidate);
+
+    const [code, signal] = await once(candidate, "exit");
+
+    expect({ code, signal }).toEqual({ code: 0, signal: null });
+    expect(
+      readProcessDeathLane(deathLaneFileIn(join(redskilledHomeDir(home), "state"))),
+    ).toEqual([]);
   });
 
   it("resolves two concurrent auto-spawns into one daemon the loser joins", async () => {


### PR DESCRIPTION
Automated AFK landing for #3510. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3510

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788807713&installation_model_id=20659&pr_number=3519&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3519&signature=864184aac958fe3edb7568252b0eab6fdd44edbcf5445eeaa4adf1149092e2c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->