### PR TITLE
chore: #3512 Rotate the host event lane, and re-baseline a consumer that fell behind

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -31,6 +31,22 @@ changing either is a public contract change guarded by
 internal telemetry and may be added, removed, or reshaped without notice. A
 consumer must ignore kinds outside the public set.
 
+The lane is append-only within a generation and rotates atomically at 4 MiB.
+Compaction keeps every live Worker's birth and the newest history that fits, so
+daemon boot replays a fixed upper bound without losing a process it must
+re-attach. A reader may start at the new generation's head: every public death
+and budget-kill repeats the Worker's identity and can be understood without its
+birth.
+
+A stateful consumer should use `readRedskilledEventsFrom` positions (or preserve
+the same generation-and-offset semantics in another language). A position from
+the replaced generation returns `rebaseline-required` together with everything
+the current generation can show; it never silently treats the old byte offset as
+current history. `followRedskilledPublicEvents` performs the recovery contract:
+on first attach or a rotated position it captures the new position, asks
+`host-state` for the current picture, and resumes event following from there.
+The missing prefix is never replayed or guessed.
+
 Each public record is flat and total. It contains the following fields, with
 `null` used where a field does not apply:
 
@@ -64,7 +80,7 @@ kill.
 | Where a Worker's resources are charged | `src/worker-placement.ts` — pure planner over injected probes |
 | Birth itself | `src/worker-launch.ts` — plan, spawn once, report the downgrade |
 | The host-wide read | `src/host-state.ts` — total shape, Workers plus the budget total |
-| What the daemon remembers across a restart | `src/event-lane.ts` — append-only TOONL: Worker lifecycle, metric observations, and the daemon's own stop |
+| What the daemon remembers across a restart | `src/event-lane.ts` — bounded TOONL generations: Worker lifecycle, metric observations, and the daemon's own stop |
 | What a stop is giving up | `src/daemon-stop.ts` — the pure report: what is held, what survives, why it stopped |
 | Finding the Workers a restart left running | `src/reattach.ts` — the unit name first, the pid only as fallback |
 | What the host has been promised | `src/budget-accounting.ts` — pure totals over the Worker set |

--- a/apps/redskilled/src/event-lane-position.ts
+++ b/apps/redskilled/src/event-lane-position.ts
@@ -1,0 +1,78 @@
+/** Position-aware reads for one atomically rotated append lane. */
+import { open } from "node:fs/promises";
+
+/** Opaque file-generation identity and byte boundary held by a tailing consumer. */
+export interface EventLanePosition {
+  /** File identity plus creation instant, preventing inode-reuse ABA after several rotations. */
+  readonly generation: string;
+  readonly offset: number;
+}
+
+export interface PositionedEventRead<TEvent> {
+  readonly status: "current" | "rebaseline-required";
+  readonly exists: boolean;
+  /** Everything after a current position, or the whole visible generation after rotation. */
+  readonly events: readonly TEvent[];
+  readonly position: EventLanePosition | null;
+}
+
+/**
+ * Read from one observed generation without confusing a reused offset for history.
+ *
+ * A stale reader still receives every event the current bounded lane can show.
+ * The status is separate because those events are not a replacement for the
+ * missing prefix; stateful consumers must re-baseline before following again.
+ */
+export async function readPositionedEventLane<TEvent>(
+  path: string,
+  position: EventLanePosition | null | undefined,
+  decode: (raw: string) => TEvent[],
+): Promise<PositionedEventRead<TEvent>> {
+  let handle;
+  try {
+    handle = await open(path, "r");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        status: position == null ? "current" : "rebaseline-required",
+        exists: false,
+        events: [],
+        position: null,
+      };
+    }
+    throw error;
+  }
+
+  try {
+    const metadata = await handle.stat({ bigint: true });
+    const raw = await handle.readFile();
+    const nextPosition: EventLanePosition = {
+      generation: `${metadata.dev}:${metadata.ino}:${metadata.birthtimeNs}`,
+      offset: raw.byteLength,
+    };
+    const rotated = position != null &&
+      (position.generation !== nextPosition.generation || position.offset > raw.byteLength);
+    const all = decode(raw.toString("utf8"));
+    if (position == null || rotated) {
+      return {
+        status: rotated ? "rebaseline-required" : "current",
+        exists: true,
+        events: all,
+        position: nextPosition,
+      };
+    }
+
+    // Positions are handed out only at complete append boundaries. Parsing the
+    // prefix through the lane decoder keeps headers out of the count and avoids
+    // inventing a second record parser for cursor reads.
+    const seen = decode(raw.subarray(0, position.offset).toString("utf8")).length;
+    return {
+      status: "current",
+      exists: true,
+      events: all.slice(seen),
+      position: nextPosition,
+    };
+  } finally {
+    await handle.close();
+  }
+}

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -30,6 +30,11 @@
 import { appendFile, mkdir, open, readFile, rename, rm, stat, truncate, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
+import {
+  readPositionedEventLane,
+  type EventLanePosition,
+  type PositionedEventRead,
+} from "./event-lane-position.js";
 import type { RedskilledWorkerView } from "./host-state.js";
 import type { RedskilledWorkerBudget } from "./worker-placement.js";
 
@@ -552,80 +557,15 @@ export async function readRedskilledEvents(path: string): Promise<RedskilledHost
   return parseEventLane(raw);
 }
 
-/** Opaque-enough file identity and byte boundary held by a tailing consumer. */
-export interface RedskilledEventLanePosition {
-  /** File identity plus creation instant, preventing inode-reuse ABA after several rotations. */
-  readonly generation: string;
-  readonly offset: number;
-}
+export type RedskilledEventLanePosition = EventLanePosition;
+export type RedskilledPositionedEventRead = PositionedEventRead<RedskilledHostEvent>;
 
-export interface RedskilledPositionedEventRead {
-  readonly status: "current" | "rebaseline-required";
-  readonly exists: boolean;
-  /** Everything visible after a current position, or the whole visible generation after rotation. */
-  readonly events: readonly RedskilledHostEvent[];
-  readonly position: RedskilledEventLanePosition | null;
-}
-
-/**
- * Read from one observed generation without confusing a reused offset for history.
- *
- * A stale reader still receives every event the current bounded lane can show.
- * The status is separate because those events are not a replacement for the
- * missing prefix; stateful consumers must re-baseline before following again.
- */
+/** Read from one generation, reporting the current bounded lane after rotation. */
 export async function readRedskilledEventsFrom(
   path: string,
   position?: RedskilledEventLanePosition | null,
 ): Promise<RedskilledPositionedEventRead> {
-  let handle;
-  try {
-    handle = await open(path, "r");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return {
-        status: position == null ? "current" : "rebaseline-required",
-        exists: false,
-        events: [],
-        position: null,
-      };
-    }
-    throw error;
-  }
-
-  try {
-    const metadata = await handle.stat({ bigint: true });
-    const raw = await handle.readFile();
-    const nextPosition: RedskilledEventLanePosition = {
-      generation: `${metadata.dev}:${metadata.ino}:${metadata.birthtimeNs}`,
-      offset: raw.byteLength,
-    };
-    const rotated = position != null &&
-      (position.generation !== nextPosition.generation ||
-        position.offset > raw.byteLength);
-    const all = parseEventLane(raw.toString("utf8"));
-    if (position == null || rotated) {
-      return {
-        status: rotated ? "rebaseline-required" : "current",
-        exists: true,
-        events: all,
-        position: nextPosition,
-      };
-    }
-
-    // Positions are handed out only at complete append boundaries. Parsing the
-    // prefix through the same public decoder keeps segment headers out of the
-    // count and avoids inventing a second TOONL parser for cursor reads.
-    const seen = parseEventLane(raw.subarray(0, position.offset).toString("utf8")).length;
-    return {
-      status: "current",
-      exists: true,
-      events: all.slice(seen),
-      position: nextPosition,
-    };
-  } finally {
-    await handle.close();
-  }
+  return await readPositionedEventLane(path, position, parseEventLane);
 }
 
 export type RedskilledPublicEventFollow<TBaseline> =

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -552,6 +552,129 @@ export async function readRedskilledEvents(path: string): Promise<RedskilledHost
   return parseEventLane(raw);
 }
 
+/** Opaque-enough file identity and byte boundary held by a tailing consumer. */
+export interface RedskilledEventLanePosition {
+  /** File identity plus creation instant, preventing inode-reuse ABA after several rotations. */
+  readonly generation: string;
+  readonly offset: number;
+}
+
+export interface RedskilledPositionedEventRead {
+  readonly status: "current" | "rebaseline-required";
+  readonly exists: boolean;
+  /** Everything visible after a current position, or the whole visible generation after rotation. */
+  readonly events: readonly RedskilledHostEvent[];
+  readonly position: RedskilledEventLanePosition | null;
+}
+
+/**
+ * Read from one observed generation without confusing a reused offset for history.
+ *
+ * A stale reader still receives every event the current bounded lane can show.
+ * The status is separate because those events are not a replacement for the
+ * missing prefix; stateful consumers must re-baseline before following again.
+ */
+export async function readRedskilledEventsFrom(
+  path: string,
+  position?: RedskilledEventLanePosition | null,
+): Promise<RedskilledPositionedEventRead> {
+  let handle;
+  try {
+    handle = await open(path, "r");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        status: position == null ? "current" : "rebaseline-required",
+        exists: false,
+        events: [],
+        position: null,
+      };
+    }
+    throw error;
+  }
+
+  try {
+    const metadata = await handle.stat({ bigint: true });
+    const raw = await handle.readFile();
+    const nextPosition: RedskilledEventLanePosition = {
+      generation: `${metadata.dev}:${metadata.ino}:${metadata.birthtimeNs}`,
+      offset: raw.byteLength,
+    };
+    const rotated = position != null &&
+      (position.generation !== nextPosition.generation ||
+        position.offset > raw.byteLength);
+    const all = parseEventLane(raw.toString("utf8"));
+    if (position == null || rotated) {
+      return {
+        status: rotated ? "rebaseline-required" : "current",
+        exists: true,
+        events: all,
+        position: nextPosition,
+      };
+    }
+
+    // Positions are handed out only at complete append boundaries. Parsing the
+    // prefix through the same public decoder keeps segment headers out of the
+    // count and avoids inventing a second TOONL parser for cursor reads.
+    const seen = parseEventLane(raw.subarray(0, position.offset).toString("utf8")).length;
+    return {
+      status: "current",
+      exists: true,
+      events: all.slice(seen),
+      position: nextPosition,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+export type RedskilledPublicEventFollow<TBaseline> =
+  | {
+      readonly status: "events";
+      readonly events: readonly RedskilledPublicHostEvent[];
+      readonly position: RedskilledEventLanePosition | null;
+    }
+  | {
+      readonly status: "baseline";
+      readonly reason: "initial" | "position-rotated";
+      readonly baseline: TBaseline;
+      readonly events: readonly [];
+      readonly position: RedskilledEventLanePosition | null;
+    };
+
+/**
+ * Follow only public host events, replacing a missing prefix with current state.
+ *
+ * The position is captured before `readBaseline` runs. An event racing the host
+ * read is therefore either already reflected by that state or appears again on
+ * the next follow; it is never silently skipped between the two authorities.
+ */
+export async function followRedskilledPublicEvents<TBaseline>(
+  path: string,
+  position: RedskilledEventLanePosition | null | undefined,
+  readBaseline: () => Promise<TBaseline>,
+): Promise<RedskilledPublicEventFollow<TBaseline>> {
+  const read = await readRedskilledEventsFrom(path, position);
+  if (position == null || read.status === "rebaseline-required") {
+    return {
+      status: "baseline",
+      reason: position == null ? "initial" : "position-rotated",
+      baseline: await readBaseline(),
+      events: [],
+      position: read.position,
+    };
+  }
+  return {
+    status: "events",
+    events: read.events.filter(isPublicHostEvent),
+    position: read.position,
+  };
+}
+
+function isPublicHostEvent(event: RedskilledHostEvent): event is RedskilledPublicHostEvent {
+  return (REDSKILLED_PUBLIC_HOST_EVENT_KINDS as readonly RedskilledEventKind[]).includes(event.kind);
+}
+
 /**
  * Decode a lane's text into events, dropping a crash-truncated tail. PURE.
  *

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -181,7 +181,7 @@ export type RedskilledPublicHostEvent = RedskilledHostEvent & {
 export const REDSKILLED_EVENT_LANE_FILE = "redskilled.log.toonl";
 
 /** The most history one daemon generation asks every successor to replay. */
-export const DEFAULT_REDSKILLED_EVENT_LANE_MAX_BYTES = 1024 * 1024;
+export const DEFAULT_REDSKILLED_EVENT_LANE_MAX_BYTES = 4 * 1024 * 1024;
 
 export interface RecordEventInput {
   readonly event: RedskilledEventKind;

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -8,9 +8,12 @@
  * record would be a third copy of facts two authorities already keep, and the
  * only thing a third copy reliably does is drift.
  *
- * **Append-only, never rewritten.** A restarted daemon rehydrates by replaying
- * the lane, so a writer that rewrote a record would be editing the past out from
- * under a reader mid-replay. Every event is a whole line appended in one call.
+ * **Append-only within one bounded generation.** Every event is a whole line
+ * appended in one call. Once the generation reaches its byte ceiling, the
+ * writer atomically replaces it with a compact generation containing every
+ * live Worker's birth plus the newest history that fits. A reader holding the
+ * previous inode can therefore name rotation instead of mistaking a new byte
+ * offset for uninterrupted history.
  *
  * **A crash mid-append costs the tail, never the lane.** The writer's process can
  * die between the `write` and the newline, which leaves a half-encoded row on
@@ -24,7 +27,7 @@
  * so one segment header covers a whole writer's session and a reader never
  * special-cases an event kind's row.
  */
-import { appendFile, mkdir, open, readFile, stat, truncate } from "node:fs/promises";
+import { appendFile, mkdir, open, readFile, rename, rm, stat, truncate, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
 import type { RedskilledWorkerView } from "./host-state.js";
@@ -176,6 +179,9 @@ export type RedskilledPublicHostEvent = RedskilledHostEvent & {
 
 /** The daemon's one structured log, inside its host-scoped home. */
 export const REDSKILLED_EVENT_LANE_FILE = "redskilled.log.toonl";
+
+/** The most history one daemon generation asks every successor to replay. */
+export const DEFAULT_REDSKILLED_EVENT_LANE_MAX_BYTES = 1024 * 1024;
 
 export interface RecordEventInput {
   readonly event: RedskilledEventKind;
@@ -372,8 +378,17 @@ export interface RedskilledEventLane {
   flush(): Promise<void>;
 }
 
-export function createRedskilledEventLane(path: string): RedskilledEventLane {
-  const emitter = encodeLines({ trailer: false });
+export interface RedskilledEventLaneOptions {
+  /** Override the production ceiling; exposed so tests can rotate tiny lanes. */
+  readonly maxBytes?: number;
+}
+
+export function createRedskilledEventLane(
+  path: string,
+  options: RedskilledEventLaneOptions = {},
+): RedskilledEventLane {
+  const maxBytes = options.maxBytes ?? DEFAULT_REDSKILLED_EVENT_LANE_MAX_BYTES;
+  let emitter = encodeLines({ trailer: false });
   // Appends are serialised through one chain: two concurrent `appendFile` calls
   // could interleave a header and a row, and a header the reader sees mid-row is
   // exactly the corruption this lane promises not to produce.
@@ -384,6 +399,12 @@ export function createRedskilledEventLane(path: string): RedskilledEventLane {
       await mkdir(dirname(path), { recursive: true, mode: 0o700 });
       await dropIncompleteTail(path);
       await appendFile(path, emitter.push(toRow(event)), { encoding: "utf8", mode: 0o600 });
+      if ((await stat(path)).size > maxBytes) {
+        await rotateEventLane(path, maxBytes);
+        // The compact generation has its own header. A new emitter makes the
+        // next append a complete segment even when its schema changes later.
+        emitter = encodeLines({ trailer: false });
+      }
     });
     tail = write.catch(() => undefined);
     await write;
@@ -401,6 +422,72 @@ export function createRedskilledEventLane(path: string): RedskilledEventLane {
       await tail;
     },
   };
+}
+
+/** Atomically replace an oversized generation with the boot-complete suffix. */
+async function rotateEventLane(path: string, maxBytes: number): Promise<void> {
+  const events = await readRedskilledEvents(path);
+  const compact = compactEventLane(events, maxBytes);
+  const temporary = `${path}.rotate-${process.pid}`;
+  try {
+    await writeFile(temporary, encodeEventLane(compact), { encoding: "utf8", mode: 0o600 });
+    await rename(temporary, path);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+/**
+ * Retain the newest history that fits, pinning every birth needed at boot.
+ *
+ * A suffix alone can strand a live Worker when its birth sits just before the
+ * cut. Those births are the compact generation's baseline. Every other daemon
+ * boot projection already tolerates a bounded history and reports absence when
+ * its rolling window no longer has a sample.
+ */
+export function compactEventLane(
+  events: readonly RedskilledHostEvent[],
+  maxBytes: number,
+): RedskilledHostEvent[] {
+  const liveIds = new Set(rehydrateWorkers(events).map((worker) => worker.worker_id));
+  const pinnedIndices = new Set<number>();
+  for (let index = events.length - 1; index >= 0 && liveIds.size > 0; index -= 1) {
+    const event = events[index]!;
+    if (event.kind !== "worker-birth" || !liveIds.has(event.worker_id)) continue;
+    pinnedIndices.add(index);
+    liveIds.delete(event.worker_id);
+  }
+
+  const optionalIndices = events.map((_event, index) => index).filter((index) => !pinnedIndices.has(index));
+  let low = 0;
+  let high = optionalIndices.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    const candidate = selectedEvents(events, pinnedIndices, optionalIndices.slice(middle));
+    if (Buffer.byteLength(encodeEventLane(candidate)) <= maxBytes) high = middle;
+    else low = middle + 1;
+  }
+
+  const compact = selectedEvents(events, pinnedIndices, optionalIndices.slice(low));
+  if (Buffer.byteLength(encodeEventLane(compact)) > maxBytes) {
+    throw new Error(`redskilled event-lane baseline exceeds its ${maxBytes}-byte ceiling`);
+  }
+  return compact;
+}
+
+function selectedEvents(
+  events: readonly RedskilledHostEvent[],
+  pinnedIndices: ReadonlySet<number>,
+  optionalIndices: readonly number[],
+): RedskilledHostEvent[] {
+  const selected = new Set([...pinnedIndices, ...optionalIndices]);
+  return events.filter((_event, index) => selected.has(index));
+}
+
+function encodeEventLane(events: readonly RedskilledHostEvent[]): string {
+  if (events.length === 0) return "";
+  const emitter = encodeLines({ trailer: false });
+  return events.map((event) => emitter.push(toRow(event))).join("");
 }
 
 /**

--- a/apps/redskilled/tests/event-lane-rotation.test.ts
+++ b/apps/redskilled/tests/event-lane-rotation.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createRedskilledEventLane,
+  rehydrateWorkers,
+} from "../src/event-lane.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+function worker(workerId: string): RedskilledWorkerView {
+  return {
+    worker_id: workerId,
+    project_label: "acme/widgets",
+    pid: 4242,
+    started_at: "2026-08-08T09:00:00.000Z",
+    workspace_path: "/tmp/workspace",
+    isolated: true,
+    unit: `red-worker-${workerId}.service`,
+    warnings: [],
+  };
+}
+
+describe("the bounded host event lane", () => {
+  it("rotates before the lane can make boot replay unbounded and retains live Worker births", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-rotation-"));
+    roots.push(root);
+    const maxBytes = 4_096;
+    const lane = createRedskilledEventLane(join(root, "redskilled.log.toonl"), { maxBytes });
+
+    await lane.recordWorker({
+      kind: "worker-birth",
+      worker: worker("w-live"),
+      ts: "2026-08-08T09:00:00.000Z",
+    });
+    for (let index = 0; index < 80; index += 1) {
+      await lane.recordDemandRefusal({
+        ts: new Date(Date.parse("2026-08-08T09:01:00.000Z") + index).toISOString(),
+        projectLabel: "acme/widgets",
+        detail: `refusal-${index}-${"x".repeat(120)}`,
+      });
+    }
+
+    expect((await stat(lane.path)).size).toBeLessThanOrEqual(maxBytes);
+    expect(rehydrateWorkers(await lane.read()).map((entry) => entry.worker_id)).toEqual(["w-live"]);
+  });
+});

--- a/apps/redskilled/tests/event-lane-rotation.test.ts
+++ b/apps/redskilled/tests/event-lane-rotation.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   createRedskilledEventLane,
+  followRedskilledPublicEvents,
+  readRedskilledEventsFrom,
   rehydrateWorkers,
 } from "../src/event-lane.js";
 import type { RedskilledWorkerView } from "../src/host-state.js";
@@ -49,5 +51,64 @@ describe("the bounded host event lane", () => {
 
     expect((await stat(lane.path)).size).toBeLessThanOrEqual(maxBytes);
     expect(rehydrateWorkers(await lane.read()).map((entry) => entry.worker_id)).toEqual(["w-live"]);
+  });
+
+  it("reports the visible generation when a reader's position rotated away", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-position-"));
+    roots.push(root);
+    const lane = createRedskilledEventLane(join(root, "redskilled.log.toonl"), { maxBytes: 4_096 });
+    await lane.recordWorker({
+      kind: "worker-birth",
+      worker: worker("w-live"),
+      ts: "2026-08-08T09:00:00.000Z",
+    });
+    const beforeRotation = await readRedskilledEventsFrom(lane.path);
+
+    for (let index = 0; index < 80; index += 1) {
+      await lane.recordDemandRefusal({
+        ts: new Date(Date.parse("2026-08-08T09:01:00.000Z") + index).toISOString(),
+        projectLabel: "acme/widgets",
+        detail: `refusal-${index}-${"x".repeat(120)}`,
+      });
+    }
+
+    const afterRotation = await readRedskilledEventsFrom(lane.path, beforeRotation.position);
+    expect(afterRotation.status).toBe("rebaseline-required");
+    expect(afterRotation.events.length).toBeGreaterThan(0);
+    expect(afterRotation.events.some((event) => event.worker_id === "w-live")).toBe(true);
+  });
+
+  it("re-baselines a public consumer from host state when its position rotated away", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-rebaseline-"));
+    roots.push(root);
+    const lane = createRedskilledEventLane(join(root, "redskilled.log.toonl"), { maxBytes: 4_096 });
+    await lane.recordWorker({
+      kind: "worker-birth",
+      worker: worker("w-live"),
+      ts: "2026-08-08T09:00:00.000Z",
+    });
+    const beforeRotation = await readRedskilledEventsFrom(lane.path);
+    for (let index = 0; index < 80; index += 1) {
+      await lane.recordDemandRefusal({
+        ts: new Date(Date.parse("2026-08-08T09:01:00.000Z") + index).toISOString(),
+        projectLabel: "acme/widgets",
+        detail: `refusal-${index}-${"x".repeat(120)}`,
+      });
+    }
+    const hostState = { workers: ["w-live"] };
+    let baselineReads = 0;
+
+    const followed = await followRedskilledPublicEvents(lane.path, beforeRotation.position, async () => {
+      baselineReads += 1;
+      return hostState;
+    });
+
+    expect(followed).toMatchObject({
+      status: "baseline",
+      reason: "position-rotated",
+      baseline: hostState,
+      events: [],
+    });
+    expect(baselineReads).toBe(1);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #3512. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3512

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788812800&installation_model_id=20659&pr_number=3522&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3522&signature=8624d30d89a23af5d4e8cd6ac39a5c650c39e6bc10b683a83f1d5425421cf32f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->