### PR TITLE
chore: #3513 Bound the death lane

### DIFF
--- a/packages/shared/death-attribution.test.ts
+++ b/packages/shared/death-attribution.test.ts
@@ -21,10 +21,12 @@ import {
   type ProcessPresence,
 } from "./death-attribution.js";
 import {
+  PROCESS_DEATH_LANE_RETENTION_MS,
   appendProcessDeathRecord,
   buildProcessDeathRecord,
   deathLaneFileIn,
   installDeathRecorder,
+  readProcessDeathLane,
   type DeathRecorderHost,
   type ProcessResourceSample,
 } from "./death-record.js";
@@ -335,6 +337,38 @@ describe("the boot reaper", () => {
     expect(result.self_recorded.map((p) => p.pid)).toEqual([4242]);
     // The stale anchor still goes: the death it stood for is explained.
     expect(readProcessPresences(dir)).toEqual([]);
+  });
+
+  it("attributes anchors before removing deaths outside the retention window", () => {
+    const stateRoot = scratch();
+    const dir = deathPresenceDirIn(stateRoot);
+    const reapedAt = Date.parse("2026-08-08T20:00:00.000Z");
+    writeProcessPresence(dir, presence());
+    appendProcessDeathRecord(
+      deathLaneFileIn(stateRoot),
+      buildProcessDeathRecord(
+        {
+          ts: new Date(reapedAt - PROCESS_DEATH_LANE_RETENTION_MS - 1).toISOString(),
+          kind: "worker",
+          id: "wOLFU",
+          pid: 4242,
+          exit_path: "signal",
+          signal: "SIGTERM",
+          last_phase: "gate",
+        },
+        SAMPLE,
+      ),
+    );
+
+    const result = runBootDeathReaper({
+      stateRoot,
+      evidence: collectHostDeathEvidence({ procRoot: poseProc("boot-a", [1]), journalPaths: [] }),
+      now: () => new Date(reapedAt).toISOString(),
+    });
+
+    expect(result.attributions).toEqual([]);
+    expect(result.self_recorded.map((anchor) => anchor.pid)).toEqual([4242]);
+    expect(readProcessDeathLane(deathLaneFileIn(stateRoot))).toEqual([]);
   });
 
   it("reports its verdicts on one line, and says so when there are none", () => {

--- a/packages/shared/death-attribution.ts
+++ b/packages/shared/death-attribution.ts
@@ -33,6 +33,7 @@ import { join } from "node:path";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
 import { deathAttributionFileIn, deathLaneFileIn, deathPresenceDirIn } from "./red-paths.js";
 import {
+  compactProcessDeathLane,
   decodeProcessDeathRecords,
   readProcessDeathLane,
   type ProcessDeathKind,
@@ -449,6 +450,7 @@ export function runBootDeathReaper(options: BootDeathReaperOptions): BootDeathRe
   const presenceDir = deathPresenceDirIn(options.stateRoot);
   const attributionPath = deathAttributionFileIn(options.stateRoot);
   const now = options.now ?? (() => new Date().toISOString());
+  const reapedAt = now();
   const evidence =
     options.evidence ??
     collectHostDeathEvidence({ procRoot: options.procRoot, journalPaths: options.journalPaths });
@@ -472,10 +474,12 @@ export function runBootDeathReaper(options: BootDeathReaperOptions): BootDeathRe
       clearProcessPresence(presenceDir, presence);
       continue;
     }
-    attributions.push(attributeDeath(presence, evidence, deaths, now()));
+    attributions.push(attributeDeath(presence, evidence, deaths, reapedAt));
     clearProcessPresence(presenceDir, presence);
   }
 
+  const reapedAtMs = Date.parse(reapedAt);
+  if (Number.isFinite(reapedAtMs)) compactProcessDeathLane(deathLaneFileIn(options.stateRoot), reapedAtMs);
   if (attributions.length > 0) appendAttributions(attributionPath, attributions);
 
   return {

--- a/packages/shared/death-record.test.ts
+++ b/packages/shared/death-record.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { parseRecords } from "@reddb-io/toon";
 import {
   DEATH_PHASE_UNSTARTED,
+  PROCESS_DEATH_LANE_RETENTION_MS,
   activeDeathRecorder,
   appendProcessDeathRecord,
   buildProcessDeathRecord,
@@ -338,6 +339,29 @@ describe("death-record", () => {
     const records = readProcessDeathLane(lanePath);
     expect(records.map((r) => r.id)).toEqual(["mcp", "w1"]);
     expect(records.map((r) => r.kind)).toEqual(["launcher", "worker"]);
+  });
+
+  it("keeps fourteen days of deaths and drops older history when the lane advances", () => {
+    const now = Date.parse("2026-08-08T20:00:00.000Z");
+    const recordAt = (id: string, at: number) =>
+      buildProcessDeathRecord(
+        {
+          ts: new Date(at).toISOString(),
+          kind: "worker",
+          id,
+          pid: at,
+          exit_path: "exit",
+          exit_code: 0,
+          last_phase: "done",
+        },
+        sampleProcessResources(poseHost()),
+      );
+
+    appendProcessDeathRecord(lanePath, recordAt("too-old", now - PROCESS_DEATH_LANE_RETENTION_MS - 1));
+    appendProcessDeathRecord(lanePath, recordAt("cutoff", now - PROCESS_DEATH_LANE_RETENTION_MS));
+    appendProcessDeathRecord(lanePath, recordAt("recent", now));
+
+    expect(readProcessDeathLane(lanePath).map((record) => record.id)).toEqual(["cutoff", "recent"]);
   });
 
   it("answers the process-wide phase marker and lets go on uninstall", () => {

--- a/packages/shared/death-record.ts
+++ b/packages/shared/death-record.ts
@@ -27,7 +27,7 @@
  * in flight when the process leaves is the very silence the record exists to
  * break.
  */
-import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
 import { UNSCOPED_PROCESS, readWorkerScopeFacts, type WorkerScopeFacts } from "./worker-scope.js";
@@ -47,6 +47,13 @@ export { UNSCOPED_PROCESS, readWorkerScopeFacts, type WorkerScopeFacts } from ".
 
 /** The record shape's version; bumped only when a field's meaning changes. */
 export const PROCESS_DEATH_RECORD_VERSION = 1;
+
+/**
+ * Deaths remain useful for fourteen days. Older host history no longer explains
+ * the processes and anchors present today, so every writer advances the lane to
+ * this explicit age window before appending its own record.
+ */
+export const PROCESS_DEATH_LANE_RETENTION_MS = 14 * 24 * 60 * 60 * 1_000;
 
 /**
  * Which of the engine's three process classes died.
@@ -218,6 +225,8 @@ export interface DeathLaneIo {
   /** True when the lane is absent or already ends on a line boundary. */
   endsClean(path: string): boolean;
   append(path: string, text: string): void;
+  /** Atomically replace a complete lane after retention has removed old rows. */
+  replace(path: string, text: string): void;
   read(path: string): string;
 }
 
@@ -245,6 +254,16 @@ export const nodeDeathLaneIo: DeathLaneIo = {
   append(path, text) {
     appendFileSync(path, text, { encoding: "utf8", mode: 0o600 });
   },
+  replace(path, text) {
+    const temporary = `${path}.retaining-${process.pid}`;
+    try {
+      writeFileSync(temporary, text, { encoding: "utf8", mode: 0o600 });
+      renameSync(temporary, path);
+    } catch (error) {
+      rmSync(temporary, { force: true });
+      throw error;
+    }
+  },
   read(path) {
     return readFileSync(path, "utf8");
   },
@@ -271,11 +290,45 @@ export function appendProcessDeathRecord(
   record: ProcessDeathRecord,
   io: DeathLaneIo = nodeDeathLaneIo,
 ): ProcessDeathRecord {
+  const recordedAt = Date.parse(record.ts);
+  if (Number.isFinite(recordedAt)) compactProcessDeathLane(lanePath, recordedAt, io);
   const line = encodeLines({ trailer: false }).push(toRow(record));
   io.mkdir(dirname(lanePath));
   if (!io.endsClean(lanePath)) io.append(lanePath, "\n");
   io.append(lanePath, line);
   return record;
+}
+
+/**
+ * Remove deaths outside the stated retention window, returning what remains.
+ *
+ * Unknown timestamps are preserved: retention may discard history proven old,
+ * never a record whose age cannot be established. The replacement is one whole
+ * TOONL segment, so a reader never observes a lane without its schema header.
+ */
+export function compactProcessDeathLane(
+  lanePath: string,
+  nowMs: number = Date.now(),
+  io: DeathLaneIo = nodeDeathLaneIo,
+): ProcessDeathRecord[] {
+  let records: ProcessDeathRecord[];
+  try {
+    records = decodeProcessDeathRecords(io.read(lanePath));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+
+  const cutoff = nowMs - PROCESS_DEATH_LANE_RETENTION_MS;
+  const retained = records.filter((record) => {
+    const timestamp = Date.parse(record.ts);
+    return !Number.isFinite(timestamp) || timestamp >= cutoff;
+  });
+  if (retained.length === records.length) return retained;
+
+  const encoder = encodeLines({ trailer: false });
+  io.replace(lanePath, retained.map((record) => encoder.push(toRow(record))).join(""));
+  return retained;
 }
 
 /**


### PR DESCRIPTION
Automated AFK landing for #3513. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3513

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788817735&installation_model_id=20659&pr_number=3523&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3523&signature=ae95e3f20975886cd9c7dea0598b801b675672d65012b1c6d7819af257fefd2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->