### PR TITLE
chore: #3529 A /go dispatch does not race the search index for the issue it just minted

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -492,7 +492,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     ProcessIssueResult,
     SessionIssueTemplate
   > = {
-    gh: { listCandidates: () => ghx.listCandidates(ghCtx, consultedQueue) },
+    gh: { listCandidates: () => ghx.resolveDispatchCandidates(ghCtx, flags.filter, consultedQueue) },
     classifyEligibility: async (candidate) => {
       queueTrustPolicy ??= parseTrustPolicy(
         config,

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -3,7 +3,12 @@
 export type { GhContext } from "./gh/common.js";
 export { ghInstalled, ghAuthenticated } from "./gh/auth.js";
 export type { CandidateListDiagnostics, IssueStateRow } from "./gh/candidates.js";
-export { listCandidates, listHitlCandidates, listIssueStates } from "./gh/candidates.js";
+export {
+  listCandidates,
+  resolveDispatchCandidates,
+  listHitlCandidates,
+  listIssueStates,
+} from "./gh/candidates.js";
 export { resolveViewerLogin, resolveSelectorUser } from "./gh/viewer.js";
 export {
   viewLabels,

--- a/apps/dev/src/runtime/gh/candidates.ts
+++ b/apps/dev/src/runtime/gh/candidates.ts
@@ -3,13 +3,14 @@ import {
   LABEL_HUMAN,
   LABEL_READY,
 } from "../../core/triage-labels.js";
-import type { IssueCandidate } from "../../core/session.js";
+import type { IssueCandidate, SelectionFilter } from "../../core/session.js";
 import type { HitlCandidate } from "../../core/hitl-selection.js";
 import type {
   QueueVisibilityTransportFailure,
   QueueVisibilityTransportSurface,
 } from "../../core/operational-probes.js";
 import { isRecord, repoArgs, runGh, runRsp, type GhContext } from "./common.js";
+import { readSingleObject } from "./single-object.js";
 
 interface RspIssueListItem {
   number: number;
@@ -127,6 +128,54 @@ export async function listCandidates(
       author,
     };
   });
+}
+
+/**
+ * Resolve the candidate pool for one Worker dispatch.
+ *
+ * Explicit issue targets are point reads, not queue searches: `/go` has just
+ * minted its target and GitHub's label-search index may not contain it yet.
+ * The point read still enforces the queue contract the label listing supplied
+ * implicitly — the Ticket must be open and carry the consulted lane label — so
+ * a targeted fleet Worker cannot reach into `lane:go`, and a stale/absent
+ * target remains missing for the existing selection refusal to explain.
+ */
+export async function resolveDispatchCandidates(
+  ctx: GhContext,
+  filter: SelectionFilter,
+  consultedQueue: string = LABEL_READY,
+): Promise<IssueCandidate[]> {
+  if (filter.kind !== "issues") return listCandidates(ctx, consultedQueue);
+
+  const rows = await Promise.all(
+    filter.numbers.map(async (issue): Promise<IssueCandidate | null> => {
+      const read = await readSingleObject(ctx, "issue", issue, [
+        "number",
+        "title",
+        "body",
+        "state",
+        "labels",
+      ]);
+      if (read.row === null) return null;
+      const number = Number(read.row.number ?? 0);
+      const state = String(read.row.state ?? "").toUpperCase();
+      const labels = Array.isArray(read.row.labels)
+        ? read.row.labels
+            .map((label) => (isRecord(label) ? String(label.name ?? "") : ""))
+            .filter(Boolean)
+        : [];
+      if (number !== issue || state !== "OPEN" || !labels.includes(consultedQueue)) {
+        return null;
+      }
+      return {
+        number,
+        title: String(read.row.title ?? ""),
+        body: String(read.row.body ?? ""),
+        labels,
+      };
+    }),
+  );
+  return rows.filter((row): row is IssueCandidate => row !== null);
 }
 
 /** List the ready-for-human candidate pool projected to HitlCandidate[].

--- a/apps/dev/tests/gh-targeted-candidates.test.ts
+++ b/apps/dev/tests/gh-targeted-candidates.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { selectCastleIssues } from "@reddb-io/red-castle/engine";
+import { resolveDispatchCandidates } from "../src/runtime/gh/candidates.js";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+import type { GhContext } from "../src/runtime/gh.js";
+
+function issue(number: number, labels: string[] = ["lane:go"]): string {
+  return JSON.stringify({
+    number,
+    title: `Issue ${number}`,
+    body: "do the thing",
+    state: "open",
+    labels: labels.map((name) => ({ name })),
+  });
+}
+
+describe("targeted dispatch candidate resolution", () => {
+  it("resolves consecutive /go targets directly by number without consulting the lane listing", async () => {
+    const calls: { cmd: string; args: readonly string[] }[] = [];
+    const exec: ExecFn = async (cmd, args): Promise<ExecOutput> => {
+      calls.push({ cmd, args: [...args] });
+      const number = Number(args.at(-1)?.split("/").at(-1));
+      return { code: 0, stdout: issue(number), stderr: "" };
+    };
+    const ctx: GhContext = { cwd: "/repo", repo: "acme/widgets", exec };
+
+    const first = await resolveDispatchCandidates(
+      ctx,
+      { kind: "issues", numbers: [3524] },
+      "lane:go",
+    );
+    const second = await resolveDispatchCandidates(
+      ctx,
+      { kind: "issues", numbers: [3525] },
+      "lane:go",
+    );
+
+    expect(first.map((candidate) => candidate.number)).toEqual([3524]);
+    expect(second.map((candidate) => candidate.number)).toEqual([3525]);
+    expect(calls.map((call) => call.cmd)).toEqual(["gh", "gh"]);
+    expect(calls.map((call) => call.args)).toEqual([
+      ["api", "repos/acme/widgets/issues/3524"],
+      ["api", "repos/acme/widgets/issues/3525"],
+    ]);
+  });
+
+  it("preserves the existing missing-target evidence when the direct read cannot find the issue", async () => {
+    const exec: ExecFn = async (): Promise<ExecOutput> => ({
+      code: 1,
+      stdout: "",
+      stderr: "HTTP 404",
+    });
+    const ctx: GhContext = { cwd: "/repo", repo: "acme/widgets", exec };
+    const filter = { kind: "issues" as const, numbers: [404] };
+
+    const candidates = await resolveDispatchCandidates(ctx, filter, "lane:go");
+
+    expect(() =>
+      selectCastleIssues(candidates, filter, undefined, "lane:go", "lane:go"),
+    ).toThrow(
+      "requested issue(s) missing: #404 (declared lane `lane:go`; consulted queue `lane:go`)",
+    );
+  });
+
+  it("does not admit a direct target that is closed or outside the declared lane", async () => {
+    const replies = [
+      issue(41, ["ready-for-agent"]),
+      issue(42, ["lane:go"]).replace('"state":"open"', '"state":"closed"'),
+    ];
+    const exec: ExecFn = async (): Promise<ExecOutput> => ({
+      code: 0,
+      stdout: replies.shift()!,
+      stderr: "",
+    });
+    const ctx: GhContext = { cwd: "/repo", repo: "acme/widgets", exec };
+
+    await expect(
+      resolveDispatchCandidates(ctx, { kind: "issues", numbers: [41] }, "lane:go"),
+    ).resolves.toEqual([]);
+    await expect(
+      resolveDispatchCandidates(ctx, { kind: "issues", numbers: [42] }, "lane:go"),
+    ).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3529. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3529

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788833334&installation_model_id=20659&pr_number=3533&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3533&signature=4e75bae9dd33ca7ae218b71f18df14e3374892f17f3027672030c804dc0dcf57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->