### PR TITLE
chore: #3527 The daemon calls a hook the registering project declared

### DIFF
--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -78,6 +78,7 @@ import {
   type RedskilledProjectRegistration,
   type RedskilledProjectRegistrationRequest,
 } from "../project-registration.js";
+import { createRedskilledProjectHookRuntime } from "../project-hook.js";
 import {
   detectUnitMainPid,
   detectWorkerLiveness,
@@ -157,7 +158,9 @@ import {
 import {
   countRedskilledBaseMovement,
   refreshRedskilledTrunk,
+  redskilledTrunkRefreshKey,
   type RedskilledTrunkRefreshInput,
+  unreachableTrunkAdmission,
 } from "../trunk-mirror.js";
 import {
   readLastLogLine,
@@ -411,6 +414,15 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       recoverableRegistrations.set(restored.project_label, restored);
     }
   }
+  const projectHooks = createRedskilledProjectHookRuntime({
+    registration: (label) => registrations.get(label),
+    liveWorkerIds: () => workers.keys(),
+    admit,
+    start: (spec, admission) => startWorker(spec, { admission, hook: true }).worker,
+    refuse: (projectLabel, detail) => {
+      void eventLane.recordDemandRefusal({ ts: clock(), projectLabel, detail }).catch(() => undefined);
+    },
+  });
   const activeSockets = new Set<Socket>();
   // The last thing the sampler measured, kept so a read is dated rather than
   // dating itself: staleness belongs to the daemon that took the measurement.
@@ -972,7 +984,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
             const trunk = { workspace_path: birth.workspace_path, trunk: registration.trunk };
             const admission = admit(spec);
             if (!admission.admitted) throw new RedskilledAdmissionError(admission.reason, admission);
-            const key = trunkRefreshKey(trunk);
+            const key = redskilledTrunkRefreshKey(trunk);
             let fork = burstForks.get(key);
             if (fork == null) {
               fork = refreshFork(trunk);
@@ -1505,12 +1517,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     });
   }
 
-  function trunkRefreshKey(input: RedskilledTrunkRefreshInput): string {
-    return `${input.workspace_path}\0${input.trunk.remote}\0${input.trunk.branch}`;
-  }
-
   function refreshFork(input: RedskilledTrunkRefreshInput): Promise<string> {
-    const key = trunkRefreshKey(input);
+    const key = redskilledTrunkRefreshKey(input);
     const inFlight = trunkRefreshes.get(key);
     if (inFlight != null) return inFlight;
     const pending = refreshTrunk(input).finally(() => {
@@ -1518,22 +1526,6 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     });
     trunkRefreshes.set(key, pending);
     return pending;
-  }
-
-  function unreachableTrunkRefusal(
-    admission: RedskilledAdmissionVerdict,
-    input: RedskilledTrunkRefreshInput,
-    error: unknown,
-  ): RedskilledAdmissionVerdict {
-    const detail = error instanceof Error ? error.message : String(error);
-    return {
-      ...admission,
-      admitted: false,
-      verdict: "refused-unreachable-trunk-remote",
-      reason:
-        `refused-unreachable-trunk-remote: redskilled refused this Worker because trunk remote ` +
-        `${JSON.stringify(input.trunk.remote)} could not refresh branch ${JSON.stringify(input.trunk.branch)}: ${detail}`,
-    };
   }
 
   async function admitAndStartWorker(
@@ -1548,7 +1540,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     try {
       forkSha = await (fork ?? refreshFork(trunk));
     } catch (error) {
-      const refusal = unreachableTrunkRefusal(admission, trunk, error);
+      const refusal = unreachableTrunkAdmission(admission, trunk, error);
       throw new RedskilledAdmissionError(refusal.reason, refusal);
     }
     // The fetch is asynchronous. Re-judge against Workers born while it was in
@@ -1572,7 +1564,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
    */
   function startWorker(
     spec: RedskilledWorkerSpec,
-    grant: { readonly admission?: RedskilledAdmissionVerdict; readonly forkSha?: string } = {},
+    grant: {
+      readonly admission?: RedskilledAdmissionVerdict;
+      readonly forkSha?: string;
+      readonly hook?: boolean;
+    } = {},
   ): LaunchedWorker {
     // The ceiling is the host's to state, not the client's to remember: it comes
     // out of the same accounting admission was judged against, so every Worker is
@@ -1611,6 +1607,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       ...(forkSha == null || forkSha === "" ? {} : { fork_sha: forkSha }),
     };
     workers.set(worker.worker_id, worker);
+    if (grant.hook === true) projectHooks.track(worker.worker_id);
     record("worker-birth", worker, null, {
       admissionVerdict: grant.admission?.verdict ?? launched.admission.verdict,
     });
@@ -1656,6 +1653,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     void eventLane
       .recordWorker(input)
       .catch(() => undefined);
+    projectHooks.onEvent(kind, worker);
   }
 
   /** Put one host-observed loss on every surface, newest observation winning. */

--- a/apps/redskilled/src/project-hook.ts
+++ b/apps/redskilled/src/project-hook.ts
@@ -1,0 +1,68 @@
+/** Project-scoped async hooks, dispatched through ordinary Worker admission and birth. */
+import type { RedskilledAdmissionVerdict } from "./admission.js";
+import {
+  REDSKILLED_PUBLIC_HOST_EVENT_KINDS,
+  type RedskilledPublicHostEventKind,
+  type RedskilledWorkerEventKind,
+} from "./event-lane.js";
+import type { RedskilledWorkerView } from "./host-state.js";
+import { workerSpecFromLaunch } from "./launch-template.js";
+import type { RedskilledProjectRegistration } from "./project-registration.js";
+import { mintHostWorkerId, RedskilledAdmissionError, type RedskilledWorkerSpec } from "./worker-launch.js";
+
+export interface RedskilledProjectHookRuntimeOptions {
+  readonly registration: (projectLabel: string) => RedskilledProjectRegistration | undefined;
+  readonly liveWorkerIds: () => Iterable<string>;
+  readonly admit: (spec: RedskilledWorkerSpec) => RedskilledAdmissionVerdict;
+  readonly start: (spec: RedskilledWorkerSpec, admission: RedskilledAdmissionVerdict) => RedskilledWorkerView;
+  readonly refuse: (projectLabel: string, detail: string) => void;
+}
+
+export interface RedskilledProjectHookRuntime {
+  /** Mark a newborn as a hook before its birth reaches the event dispatcher. */
+  track(workerId: string): void;
+  /** Observe a recorded Worker event, firing only project-declared public kinds. */
+  onEvent(kind: RedskilledWorkerEventKind, worker: RedskilledWorkerView): void;
+}
+
+export function createRedskilledProjectHookRuntime(
+  options: RedskilledProjectHookRuntimeOptions,
+): RedskilledProjectHookRuntime {
+  const hookWorkers = new Set<string>();
+
+  function fire(kind: RedskilledPublicHostEventKind, eventWorker: RedskilledWorkerView): void {
+    const template = options.registration(eventWorker.project_label)?.hooks?.[kind];
+    if (template == null) return;
+    try {
+      const spec = workerSpecFromLaunch(
+        template,
+        { worker_id: mintHostWorkerId(options.liveWorkerIds()), slot: 0, workspace_path: eventWorker.workspace_path },
+        { project_label: eventWorker.project_label },
+      );
+      const admission = options.admit(spec);
+      if (!admission.admitted) throw new RedskilledAdmissionError(admission.reason, admission);
+      const hook = options.start(spec, admission);
+      hookWorkers.add(hook.worker_id);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      options.refuse(
+        eventWorker.project_label,
+        `project ${JSON.stringify(eventWorker.project_label)} registered an async ${kind} hook, but redskilled ` +
+          `refused it before launch: ${reason}`,
+      );
+    }
+  }
+
+  return {
+    track: (workerId) => hookWorkers.add(workerId),
+    onEvent(kind, worker) {
+      const isHookWorker = hookWorkers.has(worker.worker_id);
+      if (!isHookWorker && REDSKILLED_PUBLIC_HOST_EVENT_KINDS.includes(kind as RedskilledPublicHostEventKind)) {
+        fire(kind as RedskilledPublicHostEventKind, worker);
+      }
+      if (isHookWorker && (kind === "worker-death" || kind === "worker-budget-kill")) {
+        hookWorkers.delete(worker.worker_id);
+      }
+    },
+  };
+}

--- a/apps/redskilled/src/project-registration.ts
+++ b/apps/redskilled/src/project-registration.ts
@@ -52,7 +52,16 @@ import {
   requireLaunchLogPath,
   type RedskilledLaunchTemplate,
 } from "./launch-template.js";
+import {
+  REDSKILLED_PUBLIC_HOST_EVENT_KINDS,
+  type RedskilledPublicHostEventKind,
+} from "./event-lane.js";
 import type { RedskilledQueueOutcome } from "./queue-discovery.js";
+
+/** Async launch templates a project asks the daemon to fire for public host events. */
+export type RedskilledProjectHooks = Partial<
+  Readonly<Record<RedskilledPublicHostEventKind, RedskilledLaunchTemplate>>
+>;
 
 /**
  * Default window a registration survives without renewal.
@@ -144,6 +153,8 @@ export interface RedskilledProjectRegistrationRequest {
    * registration for stating no path.
    */
   readonly log_path?: string;
+  /** Project-scoped, async notifications keyed by the public host-event vocabulary. */
+  readonly hooks?: RedskilledProjectHooks;
   /** How many Workers this project wants; the host still decides how many it gets. */
   readonly target: number;
   /** How long this registration stands without renewal; the default when absent. */
@@ -162,6 +173,8 @@ export interface RedskilledProjectRegistration {
   readonly env: Readonly<Record<string, string>>;
   /** The declared log-path template; absent when this project declared none. */
   readonly log_path?: string;
+  /** Project-scoped, async notifications keyed by the public host-event vocabulary. */
+  readonly hooks?: RedskilledProjectHooks;
   readonly target: number;
   /** The daemon's own clock, at the instant it accepted this registration. */
   readonly registered_at: string;
@@ -261,6 +274,7 @@ export function buildProjectRegistration(
   const argv = requireLaunchArgv(request.argv, projectLabel);
   const env = requireLaunchEnv(request.env, projectLabel);
   const logPath = requireLaunchLogPath(request.log_path, projectLabel);
+  const hooks = requireProjectHooks(request.hooks, projectLabel);
   // Same shape check, same reason as the argv: a registration the host could
   // never start a Worker for is a client bug the daemon can see without reading
   // anything about what the path names.
@@ -302,6 +316,7 @@ export function buildProjectRegistration(
     ...(trunk == null ? {} : { trunk }),
     env,
     ...(logPath == null ? {} : { log_path: logPath }),
+    ...(hooks == null ? {} : { hooks }),
     target: request.target,
     registered_at: new Date(nowMs).toISOString(),
     renew_within_ms: renewWithinMs,
@@ -647,6 +662,7 @@ export function isRedskilledProjectRegistration(value: unknown): value is Redski
     (registration.session_renewals === undefined || Number.isInteger(registration.session_renewals)) &&
     (registration.env === undefined || isLaunchEnvShape(registration.env)) &&
     (registration.log_path === undefined || typeof registration.log_path === "string") &&
+    (registration.hooks === undefined || isProjectHooksShape(registration.hooks)) &&
     (registration.launch_revision === undefined || Number.isInteger(registration.launch_revision)) &&
     // Optional for the same reason, one amendment later: a daemon older than the
     // sustain holds no such fields, and a client that failed its records closed
@@ -656,6 +672,53 @@ export function isRedskilledProjectRegistration(value: unknown): value is Redski
     (registration.sustained_by === undefined ||
       registration.sustained_by === "open-work" ||
       registration.sustained_by === "live-worker");
+}
+
+function requireProjectHooks(value: unknown, projectLabel: string): RedskilledProjectHooks | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      `redskilled needs project hooks to be a map keyed by public host event kind for project ` +
+        `${JSON.stringify(projectLabel)}`,
+    );
+  }
+  const hooks: Partial<Record<RedskilledPublicHostEventKind, RedskilledLaunchTemplate>> = {};
+  for (const [kind, launch] of Object.entries(value as Record<string, unknown>)) {
+    if (!REDSKILLED_PUBLIC_HOST_EVENT_KINDS.includes(kind as RedskilledPublicHostEventKind)) {
+      throw new Error(
+        `redskilled cannot register project hook ${JSON.stringify(kind)} for project ${JSON.stringify(projectLabel)}: ` +
+          `public host event kinds are ${REDSKILLED_PUBLIC_HOST_EVENT_KINDS.join(", ")}`,
+      );
+    }
+    if (launch === null || typeof launch !== "object" || Array.isArray(launch)) {
+      throw new Error(
+        `redskilled needs hook ${JSON.stringify(kind)} for project ${JSON.stringify(projectLabel)} to be a launch template`,
+      );
+    }
+    const template = launch as Record<string, unknown>;
+    hooks[kind as RedskilledPublicHostEventKind] = {
+      argv: requireLaunchArgv(template.argv, projectLabel),
+      env: requireLaunchEnv(template.env, projectLabel),
+      ...(template.log_path == null
+        ? {}
+        : { log_path: requireLaunchLogPath(template.log_path, projectLabel) }),
+    };
+  }
+  return hooks;
+}
+
+function isProjectHooksShape(value: unknown): value is RedskilledProjectHooks {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.entries(value as Record<string, unknown>).every(([kind, launch]) => {
+    if (!REDSKILLED_PUBLIC_HOST_EVENT_KINDS.includes(kind as RedskilledPublicHostEventKind)) return false;
+    if (launch === null || typeof launch !== "object" || Array.isArray(launch)) return false;
+    const template = launch as Record<string, unknown>;
+    return Array.isArray(template.argv) &&
+      template.argv.length > 0 &&
+      template.argv.every((word) => typeof word === "string" && word !== "") &&
+      (template.env === undefined || isLaunchEnvShape(template.env)) &&
+      (template.log_path === undefined || (typeof template.log_path === "string" && template.log_path !== ""));
+  });
 }
 
 function isTrunkShape(value: unknown): value is RedskilledTrunk {

--- a/apps/redskilled/src/trunk-mirror.ts
+++ b/apps/redskilled/src/trunk-mirror.ts
@@ -1,5 +1,6 @@
 /** Daemon-owned refresh of one project's trunk mirror (ADR 0138). */
 import { execFile } from "node:child_process";
+import type { RedskilledAdmissionVerdict } from "./admission.js";
 import type { RedskilledTrunk } from "./project-registration.js";
 
 export const REDSKILLED_TRUNK_MIRROR_REF = "refs/heads/red-trunk";
@@ -10,6 +11,26 @@ export interface RedskilledTrunkRefreshInput {
 }
 
 export type RedskilledTrunkRefresh = (input: RedskilledTrunkRefreshInput) => Promise<string>;
+
+export function redskilledTrunkRefreshKey(input: RedskilledTrunkRefreshInput): string {
+  return `${input.workspace_path}\0${input.trunk.remote}\0${input.trunk.branch}`;
+}
+
+export function unreachableTrunkAdmission(
+  admission: RedskilledAdmissionVerdict,
+  input: RedskilledTrunkRefreshInput,
+  error: unknown,
+): RedskilledAdmissionVerdict {
+  const detail = error instanceof Error ? error.message : String(error);
+  return {
+    ...admission,
+    admitted: false,
+    verdict: "refused-unreachable-trunk-remote",
+    reason:
+      `refused-unreachable-trunk-remote: redskilled refused this Worker because trunk remote ` +
+      `${JSON.stringify(input.trunk.remote)} could not refresh branch ${JSON.stringify(input.trunk.branch)}: ${detail}`,
+  };
+}
 
 export interface RedskilledBaseMovementInput {
   readonly workspace_path: string;

--- a/apps/redskilled/tests/project-hook.test.ts
+++ b/apps/redskilled/tests/project-hook.test.ts
@@ -1,0 +1,202 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { readRedskilledEvents } from "../src/event-lane.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import type { RedskilledProjectRegistrationRequest } from "../src/project-registration.js";
+import type { LaunchedWorker, LaunchWorkerOptions, RedskilledWorkerSpec } from "../src/worker-launch.js";
+
+const PROJECT = "acme/widgets";
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function recordingLaunch(launched: LaunchWorkerOptions[], hookExitCode?: number) {
+  let born = 0;
+  return (options: LaunchWorkerOptions): LaunchedWorker => {
+    if (!options.admission.admitted) throw new Error(options.admission.reason);
+    launched.push(options);
+    born += 1;
+    const workerId = `w${born}`;
+    if (options.spec.command === "notify" && hookExitCode != null) {
+      queueMicrotask(() => options.onExit?.(workerId, hookExitCode, null));
+    }
+    return {
+      worker: {
+        worker_id: workerId,
+        project_label: options.spec.project_label,
+        workspace_path: options.spec.workspace_path,
+        pid: 7_000 + born,
+        started_at: options.clock!(),
+        isolated: false,
+        warnings: [],
+      },
+      admission: options.admission,
+      warnings: [],
+      plan: {
+        backend: "none",
+        command: options.spec.command,
+        args: [...(options.spec.args ?? [])],
+        isolated: false,
+        warnings: [],
+      } as unknown as LaunchedWorker["plan"],
+      child: { pid: 7_000 + born, once: () => undefined, unref: () => undefined } as unknown as LaunchedWorker["child"],
+    };
+  };
+}
+
+function registration(workspace: string, hookArgv: readonly string[]): RedskilledProjectRegistrationRequest {
+  return {
+    project_label: PROJECT,
+    selector: "is:open label:ready-for-agent",
+    argv: ["work"],
+    workspace_path: workspace,
+    target: 1,
+    hooks: { "worker-birth": { argv: hookArgv, env: { SOURCE: "{{worker_id}}" } } },
+  };
+}
+
+function source(workspace: string): RedskilledWorkerSpec {
+  return { worker_id: "source", project_label: PROJECT, workspace_path: workspace, command: "work" };
+}
+
+describe("a project-scoped daemon hook", () => {
+  it("is admitted, charged to its project, expanded, and recorded as another birth", async () => {
+    const root = await scratch("redskilled-project-hook-");
+    const workspace = await scratch("redskilled-project-hook-workspace-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const launched: LaunchWorkerOptions[] = [];
+    const daemon = await startRedskilledDaemon({ paths, launch: recordingLaunch(launched), sampleMs: 0 });
+    running.push(daemon);
+    daemon.registerProject(registration(workspace, ["notify", "{{worker_id}}", "{{workspace_path}}"]));
+
+    daemon.startWorker(source(workspace));
+    await daemon.flushEvents();
+
+    expect(launched).toHaveLength(2);
+    const hookWorkerId = launched[1]!.spec.worker_id!;
+    expect(launched[1]!.spec).toMatchObject({
+      project_label: PROJECT,
+      workspace_path: workspace,
+      command: "notify",
+      args: [hookWorkerId, workspace],
+      env: { SOURCE: hookWorkerId },
+    });
+    expect(launched[1]!.admission).toMatchObject({
+      admitted: true,
+      consumption: { worker_count: 1 },
+      projected_worker_count: 2,
+    });
+    const births = (await readRedskilledEvents(paths.eventLanePath)).filter((event) => event.kind === "worker-birth");
+    expect(births.map((event) => [event.worker_id, event.project_label])).toEqual([
+      ["w1", PROJECT],
+      ["w2", PROJECT],
+    ]);
+  });
+
+  it("refuses an unknown placeholder before launching the hook and names it on the lane", async () => {
+    const root = await scratch("redskilled-project-hook-");
+    const workspace = await scratch("redskilled-project-hook-workspace-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const launched: LaunchWorkerOptions[] = [];
+    const daemon = await startRedskilledDaemon({ paths, launch: recordingLaunch(launched), sampleMs: 0 });
+    running.push(daemon);
+    daemon.registerProject(registration(workspace, ["notify", "{{mystery}}"]));
+
+    expect(() => daemon.startWorker(source(workspace))).not.toThrow();
+    await daemon.flushEvents();
+
+    expect(launched).toHaveLength(1);
+    const refusal = (await readRedskilledEvents(paths.eventLanePath)).find((event) => event.kind === "demand-refusal");
+    expect(refusal?.detail).toContain("{{mystery}}");
+  });
+
+  it("records the host's own no-headroom reason without changing the triggering Worker", async () => {
+    const root = await scratch("redskilled-project-hook-");
+    const workspace = await scratch("redskilled-project-hook-workspace-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const launched: LaunchWorkerOptions[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      launch: recordingLaunch(launched),
+      ceiling: { memory_bytes: null, worker_count: 1, source: "declared" },
+      sampleMs: 0,
+    });
+    running.push(daemon);
+    daemon.registerProject(registration(workspace, ["notify"]));
+
+    const worker = daemon.startWorker(source(workspace)).worker;
+    await daemon.flushEvents();
+
+    expect(worker.worker_id).toBe("w1");
+    expect(daemon.hostState().workers.map((held) => held.worker_id)).toEqual(["w1"]);
+    expect(launched).toHaveLength(1);
+    const refusal = (await readRedskilledEvents(paths.eventLanePath)).find((event) => event.kind === "demand-refusal");
+    expect(refusal?.detail).toContain("host ceiling of 1 Worker");
+  });
+
+  it("does not let an async hook exit change the triggering Worker or recurse", async () => {
+    const root = await scratch("redskilled-project-hook-");
+    const workspace = await scratch("redskilled-project-hook-workspace-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const launched: LaunchWorkerOptions[] = [];
+    const daemon = await startRedskilledDaemon({ paths, launch: recordingLaunch(launched, 17), sampleMs: 0 });
+    running.push(daemon);
+    daemon.registerProject(registration(workspace, ["notify"]));
+
+    const worker = daemon.startWorker(source(workspace)).worker;
+    await new Promise((resolve) => setImmediate(resolve));
+    await daemon.flushEvents();
+
+    expect(worker.worker_id).toBe("w1");
+    expect(daemon.hostState().workers.map((held) => held.worker_id)).toEqual(["w1"]);
+    expect(launched).toHaveLength(2);
+    expect((await readRedskilledEvents(paths.eventLanePath)).map((event) => event.kind)).toEqual([
+      "worker-birth",
+      "worker-birth",
+      "worker-death",
+    ]);
+  });
+
+  it("leaves an unregistered project byte-for-byte on the existing event path", async () => {
+    const root = await scratch("redskilled-project-hook-");
+    const workspace = await scratch("redskilled-project-hook-workspace-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const launched: LaunchWorkerOptions[] = [];
+    const daemon = await startRedskilledDaemon({ paths, launch: recordingLaunch(launched), sampleMs: 0 });
+    running.push(daemon);
+
+    daemon.startWorker(source(workspace));
+    await daemon.flushEvents();
+
+    expect(launched).toHaveLength(1);
+    expect((await readRedskilledEvents(paths.eventLanePath)).map((event) => event.kind)).toEqual(["worker-birth"]);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3527. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3527

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788833611&installation_model_id=20659&pr_number=3534&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3534&signature=f5331a8c41e201b98cfe82f26ecc65356cafbcacc0be35c600b4ffa1578b696a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->