### PR TITLE
chore: #3530 A boot-refused Worker is not an unreachable daemon

### DIFF
--- a/apps/dev/src/runtime/mcp-worker-birth.ts
+++ b/apps/dev/src/runtime/mcp-worker-birth.ts
@@ -27,6 +27,7 @@ import { afkPaths } from "./wire/paths.js";
 import {
   createRedskilledBirthPort,
   redskilledUnreachableAdvice,
+  type RedskilledBirthPort,
 } from "./redskilled-birth.js";
 import { workerLogPathTemplate } from "./redskilled-worker-log.js";
 
@@ -59,7 +60,23 @@ export interface WorkerBirthOptions {
   readonly entry?: readonly string[];
   /** Host capacity claimed by `/go` and `/go --scout`; ordinary AFK omits it. */
   readonly reservation?: "interactive";
+  /** The host boundary; injected only when replaying a dispatch in tests. */
+  readonly port?: WorkerBirthPort;
 }
+
+/** The narrow host boundary a detached dispatch crosses. */
+export interface WorkerBirthPort {
+  readonly socketPath: string;
+  readonly reach: RedskilledBirthPort["reach"];
+  readonly start: RedskilledBirthPort["start"];
+  readonly drainEvents: () => Promise<readonly WorkerBirthEvent[]>;
+}
+
+/** The only event facts a dispatcher needs to attribute a failed birth. */
+export type WorkerBirthEvent = Pick<
+  Awaited<ReturnType<RedskilledBirthPort["drainEvents"]>>[number],
+  "kind" | "worker_id" | "detail"
+>;
 
 /**
  * Ask the host for one dispatched Worker, or refuse and start nothing.
@@ -75,7 +92,7 @@ export async function requestWorkerBirth(
   args: readonly string[],
   options: WorkerBirthOptions = {},
 ): Promise<DispatchedWorkerBirth> {
-  const port = createRedskilledBirthPort({
+  const port = options.port ?? createRedskilledBirthPort({
     root,
     ...(options.projectLabel !== undefined ? { projectLabel: options.projectLabel } : {}),
     ...(options.paths !== undefined ? { paths: options.paths } : {}),
@@ -98,8 +115,14 @@ export async function requestWorkerBirth(
   const trunk = getConfig(config, "dev.trunk") || "main";
 
   let granted;
+  let freshEventWindow = false;
   try {
     await port.reach();
+    // Establish the cursor before asking for a Worker. Only events after this
+    // read can describe this dispatch; an old boot refusal must never overwrite
+    // a current transport failure with a more convenient story.
+    await port.drainEvents();
+    freshEventWindow = true;
     granted = await port.start({
       // The port states the project label itself; a caller that could name it
       // would be a caller that could file another project's Worker (rule 11).
@@ -112,9 +135,18 @@ export async function requestWorkerBirth(
       ...(options.reservation == null ? {} : { reservation: options.reservation }),
     });
   } catch (err) {
-    // Named, and it starts nothing: an operator reading this needs to know that
-    // no Worker exists, and which of "start the daemon" / "fix the client that
-    // stopped asking it" is their repair.
+    const events = freshEventWindow
+      ? await port.drainEvents().catch(() => [])
+      : [];
+    const refusal = bootRefusalAfterGrant(events);
+    if (refusal != null) {
+      throw new Error(
+        `Worker ${refusal.workerId} was granted and then refused at boot. ` +
+          `Daemon evidence: ${refusal.evidence}`,
+      );
+    }
+    // No fresh host evidence contradicted the transport failure. Keep the
+    // existing unreachability detail and its cause-specific repair unchanged.
     throw new Error(redskilledUnreachableAdvice(port.socketPath, err));
   }
 
@@ -129,4 +161,25 @@ export async function requestWorkerBirth(
     warnings: granted.warnings,
     admission: granted.admission,
   };
+}
+
+/** A fresh birth followed by the daemon's explicit session-error refusal. */
+function bootRefusalAfterGrant(
+  events: readonly WorkerBirthEvent[],
+): { readonly workerId: string; readonly evidence: string } | null {
+  const births = new Set<string>();
+  for (const event of events) {
+    if (event.kind === "worker-birth") {
+      births.add(event.worker_id);
+      continue;
+    }
+    if (
+      event.kind === "worker-death" &&
+      births.has(event.worker_id) &&
+      event.detail?.startsWith("session-error:")
+    ) {
+      return { workerId: event.worker_id, evidence: event.detail };
+    }
+  }
+  return null;
 }

--- a/apps/dev/tests/mcp-worker-birth.test.ts
+++ b/apps/dev/tests/mcp-worker-birth.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  describeRedskilledPresence,
+  RedskilledUnreachableError,
+} from "@reddb-io/redskilled/client";
+import {
+  requestWorkerBirth,
+  type WorkerBirthPort,
+} from "../src/runtime/mcp-worker-birth.js";
+
+describe("the dispatch launcher's birth attribution", () => {
+  it("replays the 2026-08-09 granted Worker as a boot refusal, not daemon unreachability", async () => {
+    const socketPath = "/run/redskilled.sock";
+    const transportFailure = new RedskilledUnreachableError(
+      socketPath,
+      new Error("request timed out"),
+      describeRedskilledPresence({
+        socketPath,
+        answers: false,
+        lease: {
+          version: 1,
+          pid: 35_290,
+          start_time: "2026-08-09T01:55:00.000Z",
+          session_key_hash: "session",
+          machine_id_hash: "machine",
+          socket_path: socketPath,
+          acquired_at: "2026-08-09T01:55:00.000Z",
+          renewed_at: "2026-08-09T02:10:00.000Z",
+        },
+        holderAlive: true,
+        now: "2026-08-09T02:10:21.000Z",
+      }),
+    );
+    const drainEvents = vi
+      .fn<WorkerBirthPort["drainEvents"]>()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { kind: "worker-birth", worker_id: "w3529", detail: null },
+        {
+          kind: "worker-death",
+          worker_id: "w3529",
+          detail: "session-error: could not find freshly minted issue #3529",
+        },
+      ]);
+    const port: WorkerBirthPort = {
+      socketPath,
+      reach: async () => undefined,
+      start: async () => {
+        throw transportFailure;
+      },
+      drainEvents,
+    };
+
+    const birth = requestWorkerBirth(".", ["--issues", "3529", "--once"], {
+      port,
+      entry: [process.execPath],
+    });
+
+    await expect(birth).rejects.toThrow(/Worker w3529 was granted and then refused at boot/);
+    await expect(birth).rejects.toThrow(/could not find freshly minted issue #3529/);
+    await expect(birth).rejects.not.toThrow(/did not answer/);
+    await expect(birth).rejects.not.toThrow(/red-skills-redskilled stop/);
+    expect(drainEvents).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3530. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3530

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788833926&installation_model_id=20659&pr_number=3535&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3535&signature=7a8bb9ac34596b6915ee432f404a5e98492d5f073f0d7783d4c6396fac3500a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->