### PR TITLE
chore: #3532 The sweep deletes the error lane the closing comment tells you to read

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -84,7 +84,7 @@ import {
   runnerCircuitOpen,
   type RetainedBootDiagnostic,
 } from "./state.js";
-import { cleanupDisposableDispatchOnBootFailure } from "./disposable-cleanup.js";
+import { createDisposableBootFailureCleanup } from "./disposable-cleanup.js";
 
 export async function runCommand(options: RunOptions): Promise<number> {
   const cwd = options.cwd ?? process.cwd();
@@ -117,32 +117,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // mismatch can name both sides instead of blaming only the queue (#3175).
   const consultedQueue = dispatchIdentity.lane ?? LABEL_READY;
   let retainedBootDiagnostic: RetainedBootDiagnostic | undefined;
-  const cleanupBootFailure = async (failureType: "boot-error" | "session-error") => {
-    try {
-      await cleanupDisposableDispatchOnBootFailure(
-        {
-          comment: (issue, body) => ghx.comment(ghCtx, issue, body),
-          close: (issue) => ghx.closeIssue(ghCtx, issue),
-        },
-        {
-          declaredLane,
-          consultedQueue,
-          filter: flags.filter,
-          failureType,
-          ...(retainedBootDiagnostic === undefined
-            ? {}
-            : { retainedDiagnostic: retainedBootDiagnostic }),
-        },
-      );
-    } catch (error) {
-      // The original boot failure remains primary, but a refused close is loud:
-      // otherwise the dispatch would silently leave the tracker litter #3175
-      // exists to prevent.
-      process.stderr.write(
-        `[afk] disposable cleanup failed: ${error instanceof Error ? error.message : String(error)}\n`,
-      );
-    }
-  };
+  const cleanupBootFailure = createDisposableBootFailureCleanup(
+    { comment: (issue, body) => ghx.comment(ghCtx, issue, body), close: (issue) => ghx.closeIssue(ghCtx, issue) },
+    { declaredLane, consultedQueue, filter: flags.filter },
+    (error) => process.stderr.write(`[afk] disposable cleanup failed: ${error instanceof Error ? error.message : String(error)}\n`),
+  );
 
   // One-time boot migration: relocate any legacy `.red/tmp` durable artifacts to
   // canonical state or supervisor tmp lanes before this worker reads/writes supervisor/circuit state
@@ -186,6 +165,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
     process.env.RED_AFK_WORKER_ID,
     (id) => existing.has(id),
   );
+  const retainBootFailure = (type: "boot-error" | "session-error", error: unknown) =>
+    recordBootError(workerDirPath(paths.tmpDir, workerId), type, error).catch(() => {
+      process.stderr.write(`[afk] ${type}: ${error instanceof Error ? error.message : String(error)}\n`);
+      return undefined;
+    });
   const pidStartTime = readPidStartTime(process.pid) ?? "";
   // Emit the per-slot boot-stamp immediately so the supervisor's slot log
   // captures this worker's ID before any failure. The circuit-trip sweep
@@ -240,15 +224,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
   const forkSha = process.env.RED_AFK_FORK_SHA?.trim();
   if (!forkSha) {
     const error = new Error("redskilled granted this Worker no fork SHA — refusing unadmitted birth");
-    retainedBootDiagnostic = await recordBootError(
-      workerDirPath(paths.tmpDir, workerId),
-      "boot-error",
-      error,
-    ).catch(() => {
-      process.stderr.write(`[afk] boot-error: ${error.message}\n`);
-      return undefined;
-    });
-    await cleanupBootFailure("boot-error");
+    retainedBootDiagnostic = await retainBootFailure("boot-error", error);
+    await cleanupBootFailure("boot-error", retainedBootDiagnostic);
     return HOST_CONFIG_EXIT_CODE;
   }
 
@@ -338,11 +315,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
       bootDeps = await buildBootDeps(ctx, bootOptions, nowS);
     }
   } catch (err) {
-    retainedBootDiagnostic = await recordBootError(bootstrap.workerDir, "boot-error", err).catch(() => {
-      process.stderr.write(`[afk] boot-error: ${err instanceof Error ? err.message : String(err)}\n`);
-      return undefined;
-    });
-    await cleanupBootFailure("boot-error");
+    retainedBootDiagnostic = await retainBootFailure("boot-error", err);
+    await cleanupBootFailure("boot-error", retainedBootDiagnostic);
     return 1;
   }
 
@@ -465,8 +439,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
     if (retireFile) {
       try { writeFileSync(retireFile, ""); } catch { /* best-effort */ }
     }
-    retainedBootDiagnostic = await recordBootError(bootstrap.workerDir, "boot-error", err).catch(() => undefined);
-    await cleanupBootFailure("boot-error");
+    retainedBootDiagnostic = await retainBootFailure("boot-error", err);
+    await cleanupBootFailure("boot-error", retainedBootDiagnostic);
     return 1;
   }
 
@@ -721,11 +695,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
   try {
     summary = await runCastleWorkerDrain(deps, sessionCtx);
   } catch (err) {
-    retainedBootDiagnostic = await recordBootError(bootstrap.workerDir, "session-error", err).catch(() => {
-      process.stderr.write(`[afk] session-error: ${err instanceof Error ? err.message : String(err)}\n`);
-      return undefined;
-    });
-    await cleanupBootFailure("session-error");
+    retainedBootDiagnostic = await retainBootFailure("session-error", err);
+    await cleanupBootFailure("session-error", retainedBootDiagnostic);
     return 1;
   } finally {
     await feedback.cleanup();
@@ -734,12 +705,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
   if (!summary.boot.precheck.ok) {
     const failed = summary.boot.precheck.failed;
     process.stderr.write(`[afk] precheck failed: ${failed}\n`);
-    retainedBootDiagnostic = await recordBootError(
-      bootstrap.workerDir,
-      "boot-error",
-      new Error(`precheck failed: ${failed}`),
-    ).catch(() => undefined);
-    await cleanupBootFailure("boot-error");
+    retainedBootDiagnostic = await retainBootFailure("boot-error", new Error(`precheck failed: ${failed}`));
+    await cleanupBootFailure("boot-error", retainedBootDiagnostic);
     return 1;
   }
 

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -76,7 +76,14 @@ import { evaluateClaimTrust, parseTrustPolicy } from "../../core/trust-gate.js";
 import { checkBootGuard, isNamespacedDispatch, parseRunFlags, resolveRunDispatchIdentity, shouldSkipBootSweeps, type RunOptions } from "./flags.js";
 import { buildProcessDeps, parseSlot, type CurrentAttempt } from "./process-deps.js";
 import { makeBootReconcileRunner, runReconcileWorker } from "./reconcile.js";
-import { initBootWorkerState, openRunnerCircuit, recordBootError, requeueOrdinalSync, runnerCircuitOpen } from "./state.js";
+import {
+  initBootWorkerState,
+  openRunnerCircuit,
+  recordBootError,
+  requeueOrdinalSync,
+  runnerCircuitOpen,
+  type RetainedBootDiagnostic,
+} from "./state.js";
 import { cleanupDisposableDispatchOnBootFailure } from "./disposable-cleanup.js";
 
 export async function runCommand(options: RunOptions): Promise<number> {
@@ -109,6 +116,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // Kept as a separate fact from the declaration so any future transport
   // mismatch can name both sides instead of blaming only the queue (#3175).
   const consultedQueue = dispatchIdentity.lane ?? LABEL_READY;
+  let retainedBootDiagnostic: RetainedBootDiagnostic | undefined;
   const cleanupBootFailure = async (failureType: "boot-error" | "session-error") => {
     try {
       await cleanupDisposableDispatchOnBootFailure(
@@ -121,6 +129,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
           consultedQueue,
           filter: flags.filter,
           failureType,
+          ...(retainedBootDiagnostic === undefined
+            ? {}
+            : { retainedDiagnostic: retainedBootDiagnostic }),
         },
       );
     } catch (error) {
@@ -228,7 +239,16 @@ export async function runCommand(options: RunOptions): Promise<number> {
 
   const forkSha = process.env.RED_AFK_FORK_SHA?.trim();
   if (!forkSha) {
-    process.stderr.write("[afk] redskilled granted this Worker no fork SHA — refusing unadmitted birth\n");
+    const error = new Error("redskilled granted this Worker no fork SHA — refusing unadmitted birth");
+    retainedBootDiagnostic = await recordBootError(
+      workerDirPath(paths.tmpDir, workerId),
+      "boot-error",
+      error,
+    ).catch(() => {
+      process.stderr.write(`[afk] boot-error: ${error.message}\n`);
+      return undefined;
+    });
+    await cleanupBootFailure("boot-error");
     return HOST_CONFIG_EXIT_CODE;
   }
 
@@ -318,8 +338,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
       bootDeps = await buildBootDeps(ctx, bootOptions, nowS);
     }
   } catch (err) {
-    await recordBootError(bootstrap.workerDir, "boot-error", err).catch(() => {
+    retainedBootDiagnostic = await recordBootError(bootstrap.workerDir, "boot-error", err).catch(() => {
       process.stderr.write(`[afk] boot-error: ${err instanceof Error ? err.message : String(err)}\n`);
+      return undefined;
     });
     await cleanupBootFailure("boot-error");
     return 1;
@@ -444,6 +465,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     if (retireFile) {
       try { writeFileSync(retireFile, ""); } catch { /* best-effort */ }
     }
+    retainedBootDiagnostic = await recordBootError(bootstrap.workerDir, "boot-error", err).catch(() => undefined);
     await cleanupBootFailure("boot-error");
     return 1;
   }
@@ -699,8 +721,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
   try {
     summary = await runCastleWorkerDrain(deps, sessionCtx);
   } catch (err) {
-    await recordBootError(bootstrap.workerDir, "session-error", err).catch(() => {
+    retainedBootDiagnostic = await recordBootError(bootstrap.workerDir, "session-error", err).catch(() => {
       process.stderr.write(`[afk] session-error: ${err instanceof Error ? err.message : String(err)}\n`);
+      return undefined;
     });
     await cleanupBootFailure("session-error");
     return 1;
@@ -711,6 +734,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
   if (!summary.boot.precheck.ok) {
     const failed = summary.boot.precheck.failed;
     process.stderr.write(`[afk] precheck failed: ${failed}\n`);
+    retainedBootDiagnostic = await recordBootError(
+      bootstrap.workerDir,
+      "boot-error",
+      new Error(`precheck failed: ${failed}`),
+    ).catch(() => undefined);
     await cleanupBootFailure("boot-error");
     return 1;
   }

--- a/apps/dev/src/commands/run/disposable-cleanup.ts
+++ b/apps/dev/src/commands/run/disposable-cleanup.ts
@@ -22,6 +22,15 @@ export type DisposableDispatchCleanupResult =
   | { action: "not-disposable" }
   | { action: "closed"; issue: number; commentFailed?: true };
 
+function publishableDiagnostic(
+  diagnostic: DisposableDispatchBootFailure["retainedDiagnostic"],
+): NonNullable<DisposableDispatchBootFailure["retainedDiagnostic"]> | undefined {
+  if (diagnostic === undefined) return undefined;
+  if (!/^\.red\/tmp\/diagnostics\/[A-Za-z0-9._-]+$/.test(diagnostic.path)) return undefined;
+  if (!Number.isSafeInteger(diagnostic.retentionDays) || diagnostic.retentionDays < 1) return undefined;
+  return diagnostic;
+}
+
 function disposableTarget(input: DisposableDispatchBootFailure): number | undefined {
   if (input.declaredLane !== LABEL_GO_LANE && input.declaredLane !== LABEL_SCOUT_LANE) {
     return undefined;
@@ -45,7 +54,7 @@ export async function cleanupDisposableDispatchOnBootFailure(
   if (issue === undefined) return { action: "not-disposable" };
 
   let commentFailed = false;
-  const diagnostic = input.retainedDiagnostic;
+  const diagnostic = publishableDiagnostic(input.retainedDiagnostic);
   const diagnosticLine = diagnostic === undefined
     ? "No local diagnostics were retained for this pre-lane failure."
     : `Detailed diagnostics: \`${diagnostic.path}\` (retained for ${diagnostic.retentionDays} days).`;

--- a/apps/dev/src/commands/run/disposable-cleanup.ts
+++ b/apps/dev/src/commands/run/disposable-cleanup.ts
@@ -11,6 +11,11 @@ export interface DisposableDispatchBootFailure {
   consultedQueue: string;
   filter: SelectionFilter;
   failureType: "boot-error" | "session-error";
+  retainedDiagnostic?: {
+    /** Repo-relative path safe to publish in the Ticket comment. */
+    path: string;
+    retentionDays: number;
+  };
 }
 
 export type DisposableDispatchCleanupResult =
@@ -40,6 +45,10 @@ export async function cleanupDisposableDispatchOnBootFailure(
   if (issue === undefined) return { action: "not-disposable" };
 
   let commentFailed = false;
+  const diagnostic = input.retainedDiagnostic;
+  const diagnosticLine = diagnostic === undefined
+    ? "No local diagnostics were retained for this pre-lane failure."
+    : `Detailed diagnostics: \`${diagnostic.path}\` (retained for ${diagnostic.retentionDays} days).`;
   try {
     await deps.comment(
       issue,
@@ -50,7 +59,7 @@ export async function cleanupDisposableDispatchOnBootFailure(
         `- consulted queue: \`${input.consultedQueue}\``,
         `- failure class: \`${input.failureType}\``,
         "",
-        "Detailed diagnostics remain in the local Worker error lane.",
+        diagnosticLine,
       ].join("\n"),
     );
   } catch {

--- a/apps/dev/src/commands/run/disposable-cleanup.ts
+++ b/apps/dev/src/commands/run/disposable-cleanup.ts
@@ -22,6 +22,32 @@ export type DisposableDispatchCleanupResult =
   | { action: "not-disposable" }
   | { action: "closed"; issue: number; commentFailed?: true };
 
+type DisposableDispatchContext = Omit<
+  DisposableDispatchBootFailure,
+  "failureType" | "retainedDiagnostic"
+>;
+
+export function createDisposableBootFailureCleanup(
+  deps: DisposableDispatchCleanupDeps,
+  context: DisposableDispatchContext,
+  reportFailure: (error: unknown) => void,
+): (
+  failureType: DisposableDispatchBootFailure["failureType"],
+  retainedDiagnostic?: DisposableDispatchBootFailure["retainedDiagnostic"],
+) => Promise<void> {
+  return async (failureType, retainedDiagnostic) => {
+    try {
+      await cleanupDisposableDispatchOnBootFailure(deps, {
+        ...context,
+        failureType,
+        ...(retainedDiagnostic === undefined ? {} : { retainedDiagnostic }),
+      });
+    } catch (error) {
+      reportFailure(error);
+    }
+  };
+}
+
 function publishableDiagnostic(
   diagnostic: DisposableDispatchBootFailure["retainedDiagnostic"],
 ): NonNullable<DisposableDispatchBootFailure["retainedDiagnostic"]> | undefined {
@@ -42,9 +68,8 @@ function disposableTarget(input: DisposableDispatchBootFailure): number | undefi
 /**
  * Close a disposable dispatch Ticket when its Worker dies before processing it.
  *
- * The public comment deliberately carries only routing facts and a generic
- * failure class. The detailed exception stays in the local Worker error lane,
- * where hostnames and filesystem paths cannot leak into the Issue tracker.
+ * The public comment carries routing facts, a generic failure class, and only
+ * the validated repository-relative path of a bounded retained diagnosis.
  */
 export async function cleanupDisposableDispatchOnBootFailure(
   deps: DisposableDispatchCleanupDeps,

--- a/apps/dev/src/commands/run/state.ts
+++ b/apps/dev/src/commands/run/state.ts
@@ -10,6 +10,7 @@ import { initStateSync, workerStatePath, writeIdentitySync } from "../../core/st
 import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../../core/toon-snapshot.js";
 import type { LocMemo } from "../../core/loc-memo.js";
 import { LivenessLane, LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
+import { DIAGNOSTICS_TTL_S } from "../../core/tmp-janitor.js";
 
 const DEFAULT_RUNNER_TRANSIENT_COOLDOWN_S = 300;
 
@@ -100,7 +101,17 @@ export function encodeBootErrorPayload(payload: {
   return encodeDevSnapshotToon(payload);
 }
 
-export async function recordBootError(workerDir: string, type: "boot-error" | "session-error", err: unknown): Promise<void> {
+export interface RetainedBootDiagnostic {
+  /** Repository-relative path safe to publish in a Ticket comment. */
+  path: string;
+  retentionDays: number;
+}
+
+export async function recordBootError(
+  workerDir: string,
+  type: "boot-error" | "session-error",
+  err: unknown,
+): Promise<RetainedBootDiagnostic> {
   const message = err instanceof Error ? err.message : String(err);
   const stack = err instanceof Error ? err.stack : undefined;
   const payload: {
@@ -114,16 +125,25 @@ export async function recordBootError(workerDir: string, type: "boot-error" | "s
     message,
     stack,
   };
+  const encoded = encodeBootErrorPayload(payload);
   await fsx.ensureDir(workerDir);
-  await writeFile(join(workerDir, `${type}.log`), encodeBootErrorPayload(payload), "utf8");
+  await writeFile(join(workerDir, `${type}.log`), encoded, "utf8");
   const workerId = basename(workerDir);
   const redRoot = dirname(dirname(dirname(workerDir)));
+  const retainedName = `${workerId}-${type}.log`;
+  const retainedDir = join(redRoot, "tmp", "diagnostics");
+  await fsx.ensureDir(retainedDir);
+  await writeFile(join(retainedDir, retainedName), encoded, "utf8");
   await createCastleLaneWriters(createEnginePaths(redRoot)).worker(workerId).append({
     kind: `worker.${type}`,
     worker_id: workerId,
     payload: { type, at: payload.at, message },
   });
   process.stderr.write(`[afk] ${type}: ${message}\n`);
+  return {
+    path: `.red/tmp/diagnostics/${retainedName}`,
+    retentionDays: DIAGNOSTICS_TTL_S / 86400,
+  };
 }
 
 function runnerCircuitPath(circuitDir: string, runner: Runner): string {

--- a/apps/dev/src/commands/run/state.ts
+++ b/apps/dev/src/commands/run/state.ts
@@ -131,14 +131,14 @@ export async function recordBootError(
   const workerId = basename(workerDir);
   const redRoot = dirname(dirname(dirname(workerDir)));
   const retainedName = `${workerId}-${type}.log`;
-  const retainedDir = join(redRoot, "tmp", "diagnostics");
-  await fsx.ensureDir(retainedDir);
-  await writeFile(join(retainedDir, retainedName), encoded, "utf8");
   await createCastleLaneWriters(createEnginePaths(redRoot)).worker(workerId).append({
     kind: `worker.${type}`,
     worker_id: workerId,
     payload: { type, at: payload.at, message },
   });
+  const retainedDir = join(redRoot, "tmp", "diagnostics");
+  await fsx.ensureDir(retainedDir);
+  await writeFile(join(retainedDir, retainedName), encoded, "utf8");
   process.stderr.write(`[afk] ${type}: ${message}\n`);
   return {
     path: `.red/tmp/diagnostics/${retainedName}`,

--- a/apps/dev/tests/disposable-dispatch-cleanup.test.ts
+++ b/apps/dev/tests/disposable-dispatch-cleanup.test.ts
@@ -13,6 +13,10 @@ describe("cleanupDisposableDispatchOnBootFailure", () => {
         consultedQueue: "ready-for-agent",
         filter: { kind: "issues", numbers: [66] },
         failureType: "session-error",
+        retainedDiagnostic: {
+          path: ".red/tmp/diagnostics/wFAIL-session-error.log",
+          retentionDays: 30,
+        },
       },
     );
 
@@ -22,7 +26,27 @@ describe("cleanupDisposableDispatchOnBootFailure", () => {
     expect(comment.mock.calls[0]![1]).toContain("declared lane: `lane:go`");
     expect(comment.mock.calls[0]![1]).toContain("consulted queue: `ready-for-agent`");
     expect(comment.mock.calls[0]![1]).toContain("failed during Worker boot");
+    expect(comment.mock.calls[0]![1]).toContain(
+      "`.red/tmp/diagnostics/wFAIL-session-error.log` (retained for 30 days)",
+    );
     expect(close).toHaveBeenCalledWith(66);
+  });
+
+  it("says plainly when a pre-lane failure retained no readable diagnosis", async () => {
+    const comment = vi.fn(async (_issue: number, _body: string) => undefined);
+
+    await cleanupDisposableDispatchOnBootFailure(
+      { comment, close: vi.fn(async () => undefined) },
+      {
+        declaredLane: "lane:go",
+        consultedQueue: "lane:go",
+        filter: { kind: "issues", numbers: [3524] },
+        failureType: "boot-error",
+      },
+    );
+
+    expect(comment.mock.calls[0]![1]).toContain("No local diagnostics were retained");
+    expect(comment.mock.calls[0]![1]).not.toContain("remain in the local Worker error lane");
   });
 
   it("still closes the disposable Ticket when its explanatory comment fails", async () => {

--- a/apps/dev/tests/disposable-dispatch-cleanup.test.ts
+++ b/apps/dev/tests/disposable-dispatch-cleanup.test.ts
@@ -49,6 +49,24 @@ describe("cleanupDisposableDispatchOnBootFailure", () => {
     expect(comment.mock.calls[0]![1]).not.toContain("remain in the local Worker error lane");
   });
 
+  it("never publishes an absolute diagnostic path", async () => {
+    const comment = vi.fn(async (_issue: number, _body: string) => undefined);
+
+    await cleanupDisposableDispatchOnBootFailure(
+      { comment, close: vi.fn(async () => undefined) },
+      {
+        declaredLane: "lane:go",
+        consultedQueue: "lane:go",
+        filter: { kind: "issues", numbers: [3525] },
+        failureType: "boot-error",
+        retainedDiagnostic: { path: "/private/worker/boot-error.log", retentionDays: 30 },
+      },
+    );
+
+    expect(comment.mock.calls[0]![1]).toContain("No local diagnostics were retained");
+    expect(comment.mock.calls[0]![1]).not.toContain("/private/worker");
+  });
+
   it("still closes the disposable Ticket when its explanatory comment fails", async () => {
     const close = vi.fn(async (_issue: number) => undefined);
     const result = await cleanupDisposableDispatchOnBootFailure(

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -125,11 +125,6 @@ describe("castle MCP host adapter", () => {
         retentionDays: 30,
       });
 
-      // Replay the 2026-08-09 failure: the closed disposable Ticket causes the
-      // Worker's runtime lane to be reclaimed before a human opens the comment.
-      await rm(workerDir, { recursive: true, force: true });
-      await expect(readFile(join(cwd, retained.path), "utf8"))
-        .resolves.toContain("bundle coherence halted dispatch");
     } finally {
       stderr.mockRestore();
     }
@@ -154,6 +149,13 @@ describe("castle MCP host adapter", () => {
         }),
       }),
     ]);
+
+    // Replay the 2026-08-09 failure: the closed disposable Ticket causes the
+    // Worker's runtime lane to be reclaimed before a human opens the comment.
+    const retainedPath = join(cwd, ".red/tmp/diagnostics/wER01-session-error.log");
+    await rm(workerDir, { recursive: true, force: true });
+    await expect(readFile(retainedPath, "utf8"))
+      .resolves.toContain("bundle coherence halted dispatch");
   });
 
   it("bounds logs reads by limit and filters by kind before the limit", async () => {

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SpawnOptions } from "node:child_process";
@@ -115,7 +115,21 @@ describe("castle MCP host adapter", () => {
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     try {
-      await recordBootError(workerDir, "session-error", new Error("bundle coherence halted dispatch"));
+      const retained = await recordBootError(
+        workerDir,
+        "session-error",
+        new Error("bundle coherence halted dispatch"),
+      );
+      expect(retained).toEqual({
+        path: ".red/tmp/diagnostics/wER01-session-error.log",
+        retentionDays: 30,
+      });
+
+      // Replay the 2026-08-09 failure: the closed disposable Ticket causes the
+      // Worker's runtime lane to be reclaimed before a human opens the comment.
+      await rm(workerDir, { recursive: true, force: true });
+      await expect(readFile(join(cwd, retained.path), "utf8"))
+        .resolves.toContain("bundle coherence halted dispatch");
     } finally {
       stderr.mockRestore();
     }

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -124,7 +124,6 @@ describe("castle MCP host adapter", () => {
         path: ".red/tmp/diagnostics/wER01-session-error.log",
         retentionDays: 30,
       });
-
     } finally {
       stderr.mockRestore();
     }

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -176,6 +176,8 @@ and the declared sub-second branch-fault escape beside Validation moments) ->
 `plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md`;
 `/go` interactive admission (`REDSKILLED_INTERACTIVE_RESERVATION`) ->
 `plugins/dev/skills/engineering/go/SKILL.md`;
+`/go` disposable boot-failure diagnosis and its 30-day local retention ->
+`plugins/dev/skills/engineering/go/TROUBLESHOOTING.md`;
 the host view a terminal can read (the `redskilled` daemon's `dashboard`
 command, and the `statusline` line it shares a render with) ->
 `plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md`;

--- a/packaging/pi/dev/skills/engineering/go/TROUBLESHOOTING.md
+++ b/packaging/pi/dev/skills/engineering/go/TROUBLESHOOTING.md
@@ -2,6 +2,40 @@
 
 Use these playbooks when `/go` or `/go --scout` reaches a confusing terminal state. Follow the `writing-for-agents` TROUBLESHOOTING convention: Symptom -> Confirm -> Recover -> Root fix.
 
+## Disposable dispatch closed during Worker boot
+
+### Symptom
+
+A disposable `/go` or scout Ticket closes automatically because its Worker
+failed during boot, before processing began.
+
+### Confirm
+
+1. Read the closing comment. When the Worker opened a diagnosis, the comment
+   names its repository-relative path as
+   `.red/tmp/diagnostics/<worker-id>-<failure-class>.log` and states the bound.
+2. Open that exact file from the repository root. Boot diagnoses in this lane
+   are retained for **30 days**; the tmp janitor reclaims them only after that
+   age cap.
+3. When the failure happened before any diagnostic lane could open, require the
+   comment to say `No local diagnostics were retained`. Treat any comment that
+   points at an absent file as a reporting defect.
+
+### Recover
+
+1. Read the retained TOON payload for its failure class, timestamp, message,
+   and stack.
+2. Repair the named admission, configuration, or boot precondition, then issue
+   a fresh `/go` dispatch. The closed Ticket stays disposable history.
+3. If the 30-day bound elapsed, reconstruct from the host event/death lanes and
+   record that the local diagnosis expired; do not imply that it still exists.
+
+### Root fix
+
+Boot failures copy their detailed payload out of the reclaimable Worker lane
+before the disposable Ticket closes. The copy lives in the bounded diagnostics
+lane, while successful Workers keep the existing immediate completion sweep.
+
 ## Crashed-scout salvage
 
 ### Symptom

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -176,6 +176,8 @@ and the declared sub-second branch-fault escape beside Validation moments) ->
 `plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md`;
 `/go` interactive admission (`REDSKILLED_INTERACTIVE_RESERVATION`) ->
 `plugins/dev/skills/engineering/go/SKILL.md`;
+`/go` disposable boot-failure diagnosis and its 30-day local retention ->
+`plugins/dev/skills/engineering/go/TROUBLESHOOTING.md`;
 the host view a terminal can read (the `redskilled` daemon's `dashboard`
 command, and the `statusline` line it shares a render with) ->
 `plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md`;

--- a/plugins/dev/skills/engineering/go/TROUBLESHOOTING.md
+++ b/plugins/dev/skills/engineering/go/TROUBLESHOOTING.md
@@ -2,6 +2,40 @@
 
 Use these playbooks when `/go` or `/go --scout` reaches a confusing terminal state. Follow the `writing-for-agents` TROUBLESHOOTING convention: Symptom -> Confirm -> Recover -> Root fix.
 
+## Disposable dispatch closed during Worker boot
+
+### Symptom
+
+A disposable `/go` or scout Ticket closes automatically because its Worker
+failed during boot, before processing began.
+
+### Confirm
+
+1. Read the closing comment. When the Worker opened a diagnosis, the comment
+   names its repository-relative path as
+   `.red/tmp/diagnostics/<worker-id>-<failure-class>.log` and states the bound.
+2. Open that exact file from the repository root. Boot diagnoses in this lane
+   are retained for **30 days**; the tmp janitor reclaims them only after that
+   age cap.
+3. When the failure happened before any diagnostic lane could open, require the
+   comment to say `No local diagnostics were retained`. Treat any comment that
+   points at an absent file as a reporting defect.
+
+### Recover
+
+1. Read the retained TOON payload for its failure class, timestamp, message,
+   and stack.
+2. Repair the named admission, configuration, or boot precondition, then issue
+   a fresh `/go` dispatch. The closed Ticket stays disposable history.
+3. If the 30-day bound elapsed, reconstruct from the host event/death lanes and
+   record that the local diagnosis expired; do not imply that it still exists.
+
+### Root fix
+
+Boot failures copy their detailed payload out of the reclaimable Worker lane
+before the disposable Ticket closes. The copy lives in the bounded diagnostics
+lane, while successful Workers keep the existing immediate completion sweep.
+
 ## Crashed-scout salvage
 
 ### Symptom


### PR DESCRIPTION
Automated AFK landing for #3532. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3532

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788835194&installation_model_id=20659&pr_number=3536&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3536&signature=3abd86d47814cb2c024f64c767b1a513acab48c9719386620ee696480eb01348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->