### PR TITLE
fix(dev): declare the dispatch-candidate resolver on the gh barrel

### DIFF
--- a/apps/dev/tests/gh-export-surface.test.ts
+++ b/apps/dev/tests/gh-export-surface.test.ts
@@ -63,6 +63,7 @@ const EXPECTED_GH_EXPORTS = [
   "readIssueBody",
   "readIssueComments",
   "repoVisibility",
+  "resolveDispatchCandidates",
   "resolveSelectorUser",
   "resolveViewerLogin",
   "viewIssueFull",


### PR DESCRIPTION
`main` is red at `ed38ffdfc`.

The #3529 fork-grant fix added `resolveDispatchCandidates` to the `gh.ts` barrel without declaring it in `EXPECTED_GH_EXPORTS`, and `gh-export-surface` refuses an undeclared public name. That refusal is the guard working: the barrel's surface changes deliberately or not at all.

The shape is right and stays as it is — the implementation lives in the split module `runtime/gh/candidates.ts`, the barrel re-exports it, and `commands/run/command.ts` consumes it from there. Only the declaration was missing.

**This blocks more than itself.** Every branch cut from the red commit inherits the failure, so #3534, #3535 and #3536 are all failing `test-shard (4)` on a defect none of them introduced.

Verified locally: `gh-export-surface` 2/2, `pnpm typecheck` 16/16, `pnpm -C apps/dev test:invariants` 184/184.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788866505&installation_model_id=20659&pr_number=3537&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3537&signature=a4a719eee95b28f568335a57fdbf69f49bd98f17a7644a5fb903ff32e759de9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->