### PR TITLE
chore: #3528 A synchronous daemon hook waits under a declared, bounded contract

### DIFF
--- a/apps/dev/src/core/declared-wait-guard.ts
+++ b/apps/dev/src/core/declared-wait-guard.ts
@@ -87,6 +87,7 @@ export interface DeclaredWait {
  */
 export const WAIT_SCAN_ROOTS: readonly string[] = [
   "apps/dev/src",
+  "apps/redskilled/src",
   "packages/red-castle/src",
 ];
 
@@ -674,6 +675,51 @@ export const DECLARED_WAITS: readonly DeclaredWait[] = [
     escalation:
       "returns false; the caller must NOT tear down the worktree an uninterruptible-sleep worker still sits in",
     heartbeat: { silent: "a seconds-long drain whose boolean return is the report" },
+  },
+  {
+    path: "apps/redskilled/src/client-rendezvous.ts",
+    fn: "waitForSupervisedDaemon",
+    subject: "the installed supervisor's daemon answering on its same-user client socket",
+    deadline: "`readyTimeoutMs`, or the client's bounded default ready window",
+    escalation: "throws that the installed unit did not expose a daemon inside the ready window",
+    heartbeat: { silent: "a 25ms local socket rendezvous whose terminal throw names the socket" },
+  },
+  {
+    path: "apps/redskilled/src/client.ts",
+    fn: "waitOutTheLeaseHolder",
+    subject: "the live daemon named by the existing lease beginning to answer its socket",
+    deadline: "`readyTimeoutMs`, default `DEFAULT_REDSKILLED_READY_TIMEOUT_MS`",
+    escalation:
+      "re-probes the holder, then returns when it exited or throws `RedskilledDaemonHeldError` without spawning a rival",
+    heartbeat: { silent: "a 25ms local socket rendezvous whose typed terminal result is the report" },
+  },
+  {
+    path: "apps/redskilled/src/client.ts",
+    fn: "<module>",
+    subject: "the stopping daemon releasing its socket, lease and external pid",
+    deadline: "the caller's `settleTimeoutMs`, default 5 seconds",
+    escalation: "returns `complete: false` with the deadline and every anchor still pending",
+    heartbeat: { silent: "a five-second local teardown drain whose returned pending list is the report" },
+  },
+  {
+    path: "apps/redskilled/src/client.ts",
+    fn: "waitForDaemon",
+    subject: "the spawned or concurrently starting daemon answering its socket",
+    deadline: "`readyTimeoutMs`, default `DEFAULT_REDSKILLED_READY_TIMEOUT_MS`",
+    escalation: "throws the spawn failure, the held spawn-lock owner, or the daemon's missed ready window",
+    heartbeat: { silent: "a 25ms local socket rendezvous whose terminal throw names what did not start" },
+  },
+  {
+    path: "apps/redskilled/src/project-hook.ts",
+    fn: "waitForSyncHook",
+    subject: "the admitted project hook process reaching a terminal Worker event",
+    deadline: "the registering project's mandatory finite, positive `deadline_ms`",
+    escalation:
+      "records the expiry on the host event lane, stops waiting, and proceeds with Worker birth for every project",
+    heartbeat: {
+      silent:
+        "the wait is per admitted hook, polls at most every 10ms, and its terminal expiry is the durable lane record",
+    },
   },
   {
     path: "packages/red-castle/src/Orchestrator.ts",

--- a/apps/dev/tests/declared-wait-guard.test.ts
+++ b/apps/dev/tests/declared-wait-guard.test.ts
@@ -72,6 +72,18 @@ describe("the live engine declares every wait it holds (#3024)", () => {
     expect(keys).toContain("apps/dev/src/core/merge.ts waitForReviewCheck");
   });
 
+  it("declares the synchronous daemon hook as bounded and fail-open", () => {
+    const hookWait = DECLARED_WAITS.find(
+      (wait) => wait.path === "apps/redskilled/src/project-hook.ts" && wait.fn === "waitForSyncHook",
+    );
+
+    expect(hookWait?.subject).toContain("project hook process");
+    expect(hookWait?.deadline).toContain("deadline_ms");
+    expect(hookWait?.deadline).not.toBe("unbounded");
+    expect(hookWait?.escalation).toContain("records");
+    expect(hookWait?.escalation).toContain("proceeds");
+  });
+
   it("names an escalation for every declared wait — a wait with none is a hang with extra steps", () => {
     for (const wait of DECLARED_WAITS) {
       expect(wait.subject.length, `${wait.path} ${wait.fn}`).toBeGreaterThan(0);
@@ -81,7 +93,7 @@ describe("the live engine declares every wait it holds (#3024)", () => {
   });
 
   it("scans the engine packages, and says which", () => {
-    expect(WAIT_SCAN_ROOTS).toEqual(["apps/dev/src", "packages/red-castle/src"]);
+    expect(WAIT_SCAN_ROOTS).toEqual(["apps/dev/src", "apps/redskilled/src", "packages/red-castle/src"]);
   });
 });
 

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -419,10 +419,16 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     liveWorkerIds: () => workers.keys(),
     admit,
     start: (spec, admission) => startWorker(spec, { admission, hook: true }).worker,
-    refuse: (projectLabel, detail) => {
-      void eventLane.recordDemandRefusal({ ts: clock(), projectLabel, detail }).catch(() => undefined);
-    },
+    refuse: (projectLabel, detail) => void eventLane.recordDemandRefusal({ ts: clock(), projectLabel, detail }).catch(() => undefined),
+    recordExpiry: (projectLabel, detail) => void eventLane.recordDemandRefusal({ ts: clock(), projectLabel, detail }).catch(() => undefined),
   });
+  let workerBirthTail: Promise<void> = Promise.resolve();
+  function startAfterProjectHooks<T>(start: () => T | Promise<T>): Promise<T> {
+    const turn = workerBirthTail.then(async () => { await projectHooks.waitForSettled(); const result = await start();
+      await projectHooks.waitForSettled(); return result; });
+    workerBirthTail = turn.then(() => undefined, () => undefined);
+    return turn;
+  }
   const activeSockets = new Set<Socket>();
   // The last thing the sampler measured, kept so a read is dated rather than
   // dating itself: staleness belongs to the daemon that took the measurement.
@@ -461,9 +467,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // host-wide because the ceiling that produced it is — a refusal aimed at one
   // project would let the next one walk into the same wall.
   let lastDemand: RedskilledDemandTick | null = null;
-  // The registrations this daemon dropped, newest last. Kept because a lapse is
-  // otherwise only an absence, and an absence is what let a stopped drain read as
-  // a healthy one (#2973).
+  // Registrations dropped by this daemon, retained so a stopped drain is not a healthy-looking absence (#2973).
   const lapses: RedskilledRegistrationLapse[] = [];
   // A deliberate stop is not a lapse and not an absence nobody can explain.
   // Retained on the same bounded tail as lapses so `project_stop` remains visible
@@ -979,7 +983,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         );
         try {
           if (registration?.trunk == null) {
-            launched = startWorker(spec);
+            launched = await startAfterProjectHooks(() => startWorker(spec));
           } else {
             const trunk = { workspace_path: birth.workspace_path, trunk: registration.trunk };
             const admission = admit(spec);
@@ -990,7 +994,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
               fork = refreshFork(trunk);
               burstForks.set(key, fork);
             }
-            launched = await admitAndStartWorker(spec, trunk, fork, admission);
+            launched = await startAfterProjectHooks(() => admitAndStartWorker(spec, trunk, fork, admission));
           }
         } catch (err) {
           refusal = err instanceof Error ? err.message : String(err);
@@ -1677,8 +1681,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   /**
-   * Ask the host about EVERY Worker it holds, and retire the ones it no longer
-   * confirms. Returns the Workers that were retired.
+   * Ask the host about every Worker it holds; return and retire those no longer confirmed.
    *
    * **Every record, not just the re-attached ones (#3123).** The narrow sweep
    * trusted a child handle to deliver each birth's death, and a record whose
@@ -2384,12 +2387,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         if (!reach.permitted) return { id: request.id, ok: false, error: reach.reason };
         // A spec without trunk coordinates is an older client inside the same
         // one-release compatibility window as a grant without `fork_sha`.
-        const launched = request.spec.trunk == null
+        const launched = await startAfterProjectHooks(() => request.spec.trunk == null
           ? startWorker(request.spec)
-          : await admitAndStartWorker(request.spec, {
-            workspace_path: request.spec.workspace_path,
-            trunk: request.spec.trunk,
-          });
+          : admitAndStartWorker(request.spec, {
+            workspace_path: request.spec.workspace_path, trunk: request.spec.trunk,
+          }));
         // The acknowledgement waits for the birth to reach the lane. A client told
         // "your Worker exists" by a daemon that is then replaced a millisecond
         // later — the ordinary operation — would otherwise leave a live Worker
@@ -2453,7 +2455,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     sweepWorkerLiveness,
     publishWorkerHeartbeat,
     reattached: () => [...reattached].map((id) => workers.get(id)).filter((w): w is RedskilledWorkerView => w != null),
-    flushEvents: () => eventLane.flush(),
+    flushEvents: async () => { await workerBirthTail; await projectHooks.waitForSettled(); await eventLane.flush(); },
     trackWorker(worker) {
       workers.set(worker.worker_id, worker);
       record("worker-birth", worker, null);

--- a/apps/redskilled/src/project-hook.ts
+++ b/apps/redskilled/src/project-hook.ts
@@ -1,4 +1,4 @@
-/** Project-scoped async hooks, dispatched through ordinary Worker admission and birth. */
+/** Project-scoped hooks, dispatched through ordinary Worker admission and birth. */
 import type { RedskilledAdmissionVerdict } from "./admission.js";
 import {
   REDSKILLED_PUBLIC_HOST_EVENT_KINDS,
@@ -16,6 +16,7 @@ export interface RedskilledProjectHookRuntimeOptions {
   readonly admit: (spec: RedskilledWorkerSpec) => RedskilledAdmissionVerdict;
   readonly start: (spec: RedskilledWorkerSpec, admission: RedskilledAdmissionVerdict) => RedskilledWorkerView;
   readonly refuse: (projectLabel: string, detail: string) => void;
+  readonly recordExpiry: (projectLabel: string, detail: string) => void;
 }
 
 export interface RedskilledProjectHookRuntime {
@@ -23,12 +24,35 @@ export interface RedskilledProjectHookRuntime {
   track(workerId: string): void;
   /** Observe a recorded Worker event, firing only project-declared public kinds. */
   onEvent(kind: RedskilledWorkerEventKind, worker: RedskilledWorkerView): void;
+  /** Resolve when every synchronous hook fired so far has exited or expired. */
+  waitForSettled(): Promise<void>;
+}
+
+interface SyncHookWaitOptions {
+  readonly deadlineMs: number;
+  readonly waiting: () => boolean;
+  readonly expire: () => void;
+}
+
+/** Wait for one synchronous hook, proceeding and recording when its bound expires. */
+export async function waitForSyncHook(options: SyncHookWaitOptions): Promise<void> {
+  const startedAt = Date.now();
+  for (;;) {
+    if (!options.waiting()) return;
+    const remainingMs = options.deadlineMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) {
+      options.expire();
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, Math.min(remainingMs, 10)));
+  }
 }
 
 export function createRedskilledProjectHookRuntime(
   options: RedskilledProjectHookRuntimeOptions,
 ): RedskilledProjectHookRuntime {
   const hookWorkers = new Set<string>();
+  const syncWaits = new Set<Promise<void>>();
 
   function fire(kind: RedskilledPublicHostEventKind, eventWorker: RedskilledWorkerView): void {
     const template = options.registration(eventWorker.project_label)?.hooks?.[kind];
@@ -43,6 +67,22 @@ export function createRedskilledProjectHookRuntime(
       if (!admission.admitted) throw new RedskilledAdmissionError(admission.reason, admission);
       const hook = options.start(spec, admission);
       hookWorkers.add(hook.worker_id);
+      if (template.mode === "sync") {
+        const deadlineMs = template.deadline_ms!;
+        const wait = waitForSyncHook({
+          deadlineMs,
+          waiting: () => hookWorkers.has(hook.worker_id),
+          expire: () => {
+            options.recordExpiry(
+              eventWorker.project_label,
+              `project ${JSON.stringify(eventWorker.project_label)} sync ${kind} hook exceeded its declared ` +
+                `${deadlineMs}ms deadline; redskilled stopped waiting and proceeded`,
+            );
+          },
+        });
+        syncWaits.add(wait);
+        void wait.finally(() => syncWaits.delete(wait));
+      }
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       options.refuse(
@@ -63,6 +103,9 @@ export function createRedskilledProjectHookRuntime(
       if (isHookWorker && (kind === "worker-death" || kind === "worker-budget-kill")) {
         hookWorkers.delete(worker.worker_id);
       }
+    },
+    async waitForSettled() {
+      while (syncWaits.size > 0) await Promise.all(syncWaits);
     },
   };
 }

--- a/apps/redskilled/src/project-registration.ts
+++ b/apps/redskilled/src/project-registration.ts
@@ -58,9 +58,15 @@ import {
 } from "./event-lane.js";
 import type { RedskilledQueueOutcome } from "./queue-discovery.js";
 
-/** Async launch templates a project asks the daemon to fire for public host events. */
+/** One project-owned notification, asynchronous unless it declares a bounded wait. */
+export type RedskilledProjectHook = RedskilledLaunchTemplate & {
+  readonly mode?: "async" | "sync";
+  readonly deadline_ms?: number;
+};
+
+/** Launch templates a project asks the daemon to fire for public host events. */
 export type RedskilledProjectHooks = Partial<
-  Readonly<Record<RedskilledPublicHostEventKind, RedskilledLaunchTemplate>>
+  Readonly<Record<RedskilledPublicHostEventKind, RedskilledProjectHook>>
 >;
 
 /**
@@ -153,7 +159,7 @@ export interface RedskilledProjectRegistrationRequest {
    * registration for stating no path.
    */
   readonly log_path?: string;
-  /** Project-scoped, async notifications keyed by the public host-event vocabulary. */
+  /** Project-scoped notifications keyed by the public host-event vocabulary. */
   readonly hooks?: RedskilledProjectHooks;
   /** How many Workers this project wants; the host still decides how many it gets. */
   readonly target: number;
@@ -173,7 +179,7 @@ export interface RedskilledProjectRegistration {
   readonly env: Readonly<Record<string, string>>;
   /** The declared log-path template; absent when this project declared none. */
   readonly log_path?: string;
-  /** Project-scoped, async notifications keyed by the public host-event vocabulary. */
+  /** Project-scoped notifications keyed by the public host-event vocabulary. */
   readonly hooks?: RedskilledProjectHooks;
   readonly target: number;
   /** The daemon's own clock, at the instant it accepted this registration. */
@@ -682,7 +688,7 @@ function requireProjectHooks(value: unknown, projectLabel: string): RedskilledPr
         `${JSON.stringify(projectLabel)}`,
     );
   }
-  const hooks: Partial<Record<RedskilledPublicHostEventKind, RedskilledLaunchTemplate>> = {};
+  const hooks: Partial<Record<RedskilledPublicHostEventKind, RedskilledProjectHook>> = {};
   for (const [kind, launch] of Object.entries(value as Record<string, unknown>)) {
     if (!REDSKILLED_PUBLIC_HOST_EVENT_KINDS.includes(kind as RedskilledPublicHostEventKind)) {
       throw new Error(
@@ -696,12 +702,30 @@ function requireProjectHooks(value: unknown, projectLabel: string): RedskilledPr
       );
     }
     const template = launch as Record<string, unknown>;
+    const mode = template.mode ?? "async";
+    if (mode !== "async" && mode !== "sync") {
+      throw new Error(
+        `redskilled needs hook ${JSON.stringify(kind)} for project ${JSON.stringify(projectLabel)} mode to be ` +
+          `"async" or "sync", not ${JSON.stringify(mode)}`,
+      );
+    }
+    if (mode === "sync" &&
+      (typeof template.deadline_ms !== "number" ||
+        !Number.isFinite(template.deadline_ms) ||
+        template.deadline_ms <= 0)) {
+      throw new Error(
+        `redskilled cannot register sync ${kind} hook for project ${JSON.stringify(projectLabel)} without a ` +
+          `finite, positive deadline_ms: ${JSON.stringify(template.deadline_ms)} is not a bounded deadline`,
+      );
+    }
     hooks[kind as RedskilledPublicHostEventKind] = {
       argv: requireLaunchArgv(template.argv, projectLabel),
       env: requireLaunchEnv(template.env, projectLabel),
       ...(template.log_path == null
         ? {}
         : { log_path: requireLaunchLogPath(template.log_path, projectLabel) }),
+      ...(template.mode == null ? {} : { mode }),
+      ...(mode === "sync" ? { deadline_ms: template.deadline_ms as number } : {}),
     };
   }
   return hooks;
@@ -717,7 +741,12 @@ function isProjectHooksShape(value: unknown): value is RedskilledProjectHooks {
       template.argv.length > 0 &&
       template.argv.every((word) => typeof word === "string" && word !== "") &&
       (template.env === undefined || isLaunchEnvShape(template.env)) &&
-      (template.log_path === undefined || (typeof template.log_path === "string" && template.log_path !== ""));
+      (template.log_path === undefined || (typeof template.log_path === "string" && template.log_path !== "")) &&
+      (template.mode === undefined || template.mode === "async" || template.mode === "sync") &&
+      (template.mode !== "sync" ||
+        (typeof template.deadline_ms === "number" &&
+          Number.isFinite(template.deadline_ms) &&
+          template.deadline_ms > 0));
   });
 }
 

--- a/apps/redskilled/tests/project-hook.test.ts
+++ b/apps/redskilled/tests/project-hook.test.ts
@@ -182,6 +182,48 @@ describe("a project-scoped daemon hook", () => {
     ]);
   });
 
+  it("expires a sync hook onto the lane and releases another project's Worker birth", async () => {
+    const root = await scratch("redskilled-project-hook-");
+    const workspace = await scratch("redskilled-project-hook-workspace-");
+    const otherWorkspace = await scratch("redskilled-project-hook-other-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const launched: LaunchWorkerOptions[] = [];
+    const daemon = await startRedskilledDaemon({ paths, launch: recordingLaunch(launched), sampleMs: 0 });
+    running.push(daemon);
+    daemon.registerProject({
+      ...registration(workspace, ["notify"]),
+      hooks: {
+        "worker-birth": { argv: ["notify"], mode: "sync", deadline_ms: 20 },
+      },
+    });
+
+    const startedAt = Date.now();
+    daemon.startWorker(source(workspace));
+    await daemon.flushEvents();
+    daemon.startWorker({
+      worker_id: "other-source",
+      project_label: "acme/gadgets",
+      workspace_path: otherWorkspace,
+      command: "work",
+    });
+    await daemon.flushEvents();
+
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(launched.map((entry) => entry.spec.project_label)).toEqual([
+      PROJECT,
+      PROJECT,
+      "acme/gadgets",
+    ]);
+    const expiry = (await readRedskilledEvents(paths.eventLanePath)).find(
+      (event) => event.kind === "demand-refusal" && event.project_label === PROJECT,
+    );
+    expect(expiry?.detail).toContain("sync worker-birth hook exceeded its declared 20ms deadline");
+    expect(expiry?.detail).toContain("stopped waiting and proceeded");
+  });
+
   it("leaves an unregistered project byte-for-byte on the existing event path", async () => {
     const root = await scratch("redskilled-project-hook-");
     const workspace = await scratch("redskilled-project-hook-workspace-");

--- a/apps/redskilled/tests/project-registration.test.ts
+++ b/apps/redskilled/tests/project-registration.test.ts
@@ -229,6 +229,19 @@ describe("redskilled project registration", () => {
     expect(defaulted.renew_by).toBe(new Date(Date.parse(NOW) + REDSKILLED_REGISTRATION_TTL_MS).toISOString());
   });
 
+  it("refuses a synchronous project hook without its mandatory deadline at registration", () => {
+    expect(() =>
+      buildProjectRegistration(
+        request({
+          hooks: {
+            "worker-birth": { argv: ["notify"], mode: "sync" },
+          },
+        }),
+        { now: NOW },
+      )
+    ).toThrow(/sync.*worker-birth.*deadline_ms/i);
+  });
+
   it("accepts an older daemon's answer that carries no registrations block", async () => {
     const paths = await sessionPaths();
     const daemon = await startRedskilledDaemon({ paths });


### PR DESCRIPTION
Automated AFK landing for #3528. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3528

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788869030&installation_model_id=20659&pr_number=3538&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3538&signature=b0f25f68c4e86b4c877edf6ed737a30f18da8dd522186010928991345f1f7425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->