### PR TITLE
chore(release): queue the project-hook span

### DIFF
--- a/.changeset/project-hooks-and-honest-dispatch-failures.md
+++ b/.changeset/project-hooks-and-honest-dispatch-failures.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/dev": patch
+---
+
+Let a project register hooks the daemon calls when its Workers are born and die, and stop three dispatch failures from naming causes nobody verified.
+
+A project may now declare hooks inside its registration: the daemon runs them through ordinary admission, charged to that project's budget and recorded on the host event lane, so a hook is a birth the host judged rather than a stray process. Asynchronous hooks fire and are never waited for — a hook that throws or hangs changes nothing about the work. A synchronous hook carries a mandatory deadline and a declared wait, because the daemon is one process per machine and an unbounded hook would stall Worker birth for every project on the host.
+
+Three failures now report what happened. A Worker the host granted and then refused at boot is attributed as a boot refusal instead of an unreachable daemon, so no failure path recommends stopping a healthy singleton. A targeted dispatch resolves its issue by number rather than through the queue search, so a Worker no longer refuses over an issue the dispatch just created. And a boot diagnosis is retained under a bounded budget, so the pointer in the closing comment reaches something a reader can open.


### PR DESCRIPTION
`main` is 46 commits past `v3.12.7` with an empty `.changeset/` queue, so the release engine answers `{"kind":"idle","reason":"empty-queue"}` and none of it ships.

Among those commits are **both halves of project hooks** — the thing being waited on — plus three dispatch failures that stopped naming causes nobody had verified.

One entry rather than six: the span is one story, and a reader of the release notes wants what changed, not the ticket numbers it arrived in.

#3508 is the ticket for the gate that should have refused every one of those merges for carrying no release entry. This is the manual cure it exists to make unnecessary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788921046&installation_model_id=20659&pr_number=3539&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3539&signature=44741fac348ff83672ceb63e55333f65960750c1c210a00279d33fd3f3770d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->