### PR TITLE
chore(release): queue the Worker-birth reliability fixes

### DIFF
--- a/.changeset/workers-survive-a-shared-checkout.md
+++ b/.changeset/workers-survive-a-shared-checkout.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/dev": patch
+---
+
+Stop two conditions in a shared checkout from killing Workers at boot.
+
+A Worker branches from the fork SHA the host granted, never from the operator's local trunk, so uncommitted work in the primary checkout cannot affect it. Boot already exempted Worker sessions from a stale local trunk, but named only one of the two ways the guard reports uncommitted work: a dirty path that had also moved upstream fell through and halted the session. Three Workers died at boot in seventeen seconds over two dirty files on a branch none of them would touch, and the fourth failure opened the birth breaker for ten minutes.
+
+The abandoned-index-lock reclaimer no longer robs a Git process mid-write. It judged a lock abandoned from two facts — zero bytes, and no live process holding it open — and a lock created microseconds earlier satisfies both, because Git creates it empty and has not yet opened it for writing. Deleting it killed the owner with `fatal: Could not write new index file`, an error naming no lock and therefore reaching no recovery. Reclamation now also requires the lock to be old enough that its owner cannot still be acquiring it, and the failure is recognised from both ends of the contention: the process that could not take the lock, and the process whose lock was taken.


### PR DESCRIPTION
Two boot-killing conditions in a shared checkout landed on main (#3543) and `.changeset/` is empty again, so the release engine would answer `empty-queue` and neither fix would reach a running daemon.

#3508 is the ticket for the gate that would make this commit unnecessary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788949919&installation_model_id=20659&pr_number=3544&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3544&signature=025ad4403b84b635e00d698aa0b564a832e156519ec4d7366cc50d4871843c14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->