### PR TITLE
fix(dev): a stale statusline cache never blocks the render

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -40,6 +40,7 @@ import {
   collectStatuslineWorkers,
   inferGitHubRepoSlug,
   refreshStatuslineCountCache,
+  refreshStatuslineRepoCache,
   resolveStatuslineCacheTtl,
 } from "../runtime/wire.js";
 import * as gitx from "../runtime/git.js";
@@ -407,14 +408,22 @@ export async function statuslineRefreshCountsCommand(args: string[], cwd = proce
   const root = args[0] ?? cwd;
   let repo = "";
   let lock = "";
+  let baseRef = "";
   for (let i = 1; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === "--repo") {
       repo = args[++i] ?? "";
     } else if (arg === "--lock") {
       lock = args[++i] ?? "";
+    } else if (arg === "--base-ref") {
+      baseRef = args[++i] ?? "";
     }
   }
   await refreshStatuslineCountCache(root, repo || inferGitHubRepoSlug(root), lock || undefined);
+  // Same child, second cache: the repo stats expire on the same render as the
+  // counts, and a second detached process would buy nothing but a second lock.
+  if (baseRef !== "") {
+    await refreshStatuslineRepoCache({ root, repo, remote: "origin" }, baseRef).catch(() => undefined);
+  }
   return 0;
 }

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -40,6 +40,7 @@ export {
   collectStatuslineValidationGate,
   collectStatuslineWorkers,
   collectStatuslineRepo,
+  refreshStatuslineRepoCache,
 } from "./wire/statusline.js";
 
 export { collectStatuslineDocs, collectDocsSweepInput, landDocsSweep } from "./wire/docs.js";

--- a/apps/dev/src/runtime/wire/statusline-cache.ts
+++ b/apps/dev/src/runtime/wire/statusline-cache.ts
@@ -72,6 +72,15 @@ export interface StatuslineRefreshSpawnOptions {
   spawn?: DetachedSpawn;
   nowS?: number;
   argv1?: string;
+  /**
+   * The base ref whose repo stats the same detached process should refresh.
+   *
+   * One child rather than two: both caches expire on the same render and both
+   * are refreshed from the same repository, so a second process would double the
+   * spawn cost and the lock bookkeeping to save nothing. Absent, the child
+   * refreshes only the counts, exactly as before.
+   */
+  baseRef?: string;
 }
 
 export function statuslineCountCachePath(root: string): string {
@@ -261,6 +270,7 @@ export function startDetachedStatuslineCountRefresh(
       repo,
       "--lock",
       lockPath,
+      ...(options.baseRef ? ["--base-ref", options.baseRef] : []),
     ], {
       detached: true,
       stdio: "ignore",

--- a/apps/dev/src/runtime/wire/statusline.ts
+++ b/apps/dev/src/runtime/wire/statusline.ts
@@ -610,10 +610,41 @@ function writeRepoStatsCacheAtomic(path: string, cache: RepoStatsCache): void {
  * pays one bounded refresh (issue #1178 — never a per-render git diff). Every
  * field is fail-open: any gh/git error leaves it 0.
  */
+/**
+ * Rewrite the repo-stats cache from the network. Used by the DETACHED refresher.
+ *
+ * It exists so the render path never has to: a short-lived statusline process
+ * that awaited this was putting `gh` latency in front of a terminal prompt.
+ */
+export async function refreshStatuslineRepoCache(
+  ctx: RepoContext,
+  baseRef: string,
+): Promise<void> {
+  const cachePath = afkPaths(ctx.root).statuslineRepoCachePath;
+  const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo || inferGitHubRepoSlug(ctx.root) };
+  const [openPrs, todayPrs, openIssues, diff] = await Promise.all([
+    ghx.countOpenPrs(ghCtx),
+    ghx.countPrsCreatedToday(ghCtx),
+    ghx.countOpenIssues(ghCtx),
+    gitx.diffstatShortstat({ cwd: ctx.root }, baseRef),
+  ]);
+  writeRepoStatsCacheAtomic(cachePath, {
+    baseRef,
+    openPrs,
+    todayPrs,
+    openIssues,
+    localAdded: diff.added,
+    localRemoved: diff.removed,
+    ts: Math.floor(Date.now() / 1000),
+  });
+}
+
 export async function collectStatuslineRepo(
   ctx: RepoContext,
   cacheTtlS: number = STATUSLINE_CACHE_TTL_S,
   baseRef = "origin/main",
+  /** Spawn injection for tests; production callers omit it. */
+  refreshSpawn: StatuslineRefreshSpawnOptions = {},
 ): Promise<RepoInput> {
   const paths = afkPaths(ctx.root);
   const cachePath = paths.statuslineRepoCachePath;
@@ -627,7 +658,6 @@ export async function collectStatuslineRepo(
   let localRemoved = cacheMatchesBase ? (cached?.localRemoved ?? 0) : 0;
 
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
-  let repoRefreshSucceeded = false;
   const refresh = async (): Promise<void> => {
     // The local branch diff (committed + uncommitted) vs the resolved base ref
     // is folded into the same refresh as the gh counts — diffstatShortstat
@@ -645,7 +675,6 @@ export async function collectStatuslineRepo(
     openIssues = i;
     localAdded = diff.added;
     localRemoved = diff.removed;
-    repoRefreshSucceeded = true;
     writeRepoStatsCacheAtomic(cachePath, {
       baseRef,
       openPrs: p,
@@ -660,12 +689,19 @@ export async function collectStatuslineRepo(
   if (!cached || !cacheMatchesBase) {
     await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
   } else if (nowS - cached.ts >= cacheTtlS) {
-    // Stale: await a bounded refresh so the cache is rewritten before the
-    // process exits. Shows the previous value on timeout (fail-open). When
-    // refresh fails, mark the age so the renderer can signal staleness.
-    const staleAgeS = nowS - cached.ts;
-    await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
-    if (!repoRefreshSucceeded) repoCacheAgeS = staleAgeS;
+    // Stale: serve the previous value NOW and let a detached child rewrite the
+    // cache for the next render — the shape `collectStatuslineAfk` above has
+    // used all along. Awaiting the refresh here put up to
+    // STATUSLINE_GH_COLD_TIMEOUT_MS of network on the path that redraws a
+    // terminal prompt, and the whole render measured 8s against a 15-minute TTL:
+    // once every TTL, a prompt froze while three `gh` calls ran. The age travels
+    // out so the renderer can say the counts are old, which is the honest answer
+    // and costs nothing.
+    repoCacheAgeS = nowS - cached.ts;
+    startDetachedStatuslineCountRefresh(
+      { ...ctx, repo: ghCtx.repo },
+      { ...refreshSpawn, nowS, baseRef },
+    );
   }
 
   return { openPrs, todayPrs, openIssues, localAdded, localRemoved, cacheAgeS: repoCacheAgeS };

--- a/apps/dev/tests/wire-boot.test.ts
+++ b/apps/dev/tests/wire-boot.test.ts
@@ -230,3 +230,71 @@ describe("statusline refresh lock — TOON round-trip seam", () => {
     }
   });
 });
+
+// The repo collector used to AWAIT its stale refresh, putting up to 5s of `gh`
+// on the path that redraws a terminal prompt — measured at 8s per render against
+// a 15-minute TTL. Stale now means: serve the old value, date it, and hand the
+// network to the same detached child the AFK collector has always used.
+describe("collectStatuslineRepo — stale cache never blocks the render (#3546)", () => {
+  const seedRepoCache = (root: string, ts: number, baseRef: string): void => {
+    const cachePath = afkPaths(root).statuslineRepoCachePath;
+    mkdirSync(dirname(cachePath), { recursive: true });
+    writeFileSync(
+      cachePath,
+      encode({ baseRef, openPrs: 3, todayPrs: 1, openIssues: 7, localAdded: 4, localRemoved: 2, ts }),
+      "utf8",
+    );
+  };
+
+  it("serves the stale counts immediately and spawns the detached refresh with the base ref", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
+    try {
+      const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 60;
+      seedRepoCache(root, staleTs, "origin/main");
+      const rec = detachedSpawnRecorder();
+
+      const started = Date.now();
+      const repo = await collectStatuslineRepo(
+        { root, repo: "o/r", remote: "origin" },
+        STATUSLINE_CACHE_TTL_S,
+        "origin/main",
+        { spawn: rec.spawn, argv1: "/tmp/afk.mjs" },
+      );
+      const elapsedMs = Date.now() - started;
+
+      // The old values render now; their age travels out instead of a wait.
+      expect(repo.openPrs).toBe(3);
+      expect(repo.openIssues).toBe(7);
+      expect(repo.cacheAgeS).toBeGreaterThanOrEqual(STATUSLINE_CACHE_TTL_S);
+      // One detached child, carrying the base ref so it can rewrite BOTH caches.
+      expect(rec.calls).toHaveLength(1);
+      expect(rec.calls[0]?.args).toContain("--base-ref");
+      expect(rec.calls[0]?.args).toContain("origin/main");
+      // No network wait on the render path: far under the 5s cold budget.
+      expect(elapsedMs).toBeLessThan(1000);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a fresh cache spawns nothing and reports no age", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
+    try {
+      seedRepoCache(root, nowS(), "origin/main");
+      const rec = detachedSpawnRecorder();
+
+      const repo = await collectStatuslineRepo(
+        { root, repo: "o/r", remote: "origin" },
+        STATUSLINE_CACHE_TTL_S,
+        "origin/main",
+        { spawn: rec.spawn, argv1: "/tmp/afk.mjs" },
+      );
+
+      expect(repo.openPrs).toBe(3);
+      expect(repo.cacheAgeS).toBeUndefined();
+      expect(rec.calls).toHaveLength(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/dev/tests/wire-statusline.test.ts
+++ b/apps/dev/tests/wire-statusline.test.ts
@@ -496,7 +496,11 @@ describe("statusline repo slug inference", () => {
 // ---------------------------------------------------------------------------
 
 describe("collectStatuslineRepo — cache discipline", () => {
-  it("stale cache: awaits gh + rewrites cache before returning", async () => {
+  // #3546 changed the stale contract: the render serves the old value and a
+  // DETACHED child rewrites the cache. The render process itself must leave the
+  // file untouched — awaiting the rewrite here is exactly the prompt freeze the
+  // change removed (8s measured, once per TTL, per session).
+  it("stale cache: serves the old value and leaves the rewrite to the detached child", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
     try {
       const tmpDir = join(root, ".red", "tmp");
@@ -507,12 +511,23 @@ describe("collectStatuslineRepo — cache discipline", () => {
       const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 10;
       writeFileSync(cachePath, JSON.stringify({ openPrs: 3, openIssues: 5, ts: staleTs }), "utf8");
 
-      await withFakeGh(() => collectStatuslineRepo({ root, repo: "", remote: "origin" }));
+      const rec = detachedSpawnRecorder();
+      const repo = await withFakeGh(() =>
+        collectStatuslineRepo({ root, repo: "o/r", remote: "origin" }, undefined, "origin/main", {
+          spawn: rec.spawn,
+          argv1: "/tmp/afk.mjs",
+        }),
+      );
 
-      const raw = readFileSync(cachePath, "utf8");
-      expect(raw.trimStart().startsWith("{")).toBe(false);
-      const cache = decode(raw) as { openPrs: number; openIssues: number; ts: number };
-      expect(cache.ts).toBeGreaterThan(staleTs); // ts advanced beyond the stale value
+      // Old values render now, dated; the file is untouched by the render process.
+      expect(repo.openPrs).toBe(3);
+      expect(repo.cacheAgeS).toBeGreaterThanOrEqual(STATUSLINE_CACHE_TTL_S);
+      // Still the exact JSON we seeded: the render process never rewrote it.
+      const cache = JSON.parse(readFileSync(cachePath, "utf8")) as { ts: number };
+      expect(cache.ts).toBe(staleTs);
+      // Exactly one child, carrying the base ref so it rewrites BOTH caches.
+      expect(rec.calls).toHaveLength(1);
+      expect(rec.calls[0]?.args).toContain("--base-ref");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -622,7 +637,10 @@ describe("collectStatuslineRepo — cache discipline", () => {
     }
   });
 
-  it("stale cache: folds the local diffstat into the same refresh (#1178)", async () => {
+  // #1178 folded the diffstat into the network refresh; #3546 moved that whole
+  // refresh into the detached child. The fold is preserved there: one child,
+  // one refresh, counts and diffstat together (`refreshStatuslineRepoCache`).
+  it("stale cache: the diffstat travels with the refresh, in the child (#1178, #3546)", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
     try {
       const tmpDir = join(root, ".red", "tmp");
@@ -637,18 +655,21 @@ describe("collectStatuslineRepo — cache discipline", () => {
         "utf8",
       );
 
-      await withFakeGh(() => collectStatuslineRepo({ root, repo: "", remote: "origin" }));
+      const rec = detachedSpawnRecorder();
+      const repo = await withFakeGh(() =>
+        collectStatuslineRepo({ root, repo: "o/r", remote: "origin" }, undefined, "origin/main", {
+          spawn: rec.spawn,
+          argv1: "/tmp/afk.mjs",
+        }),
+      );
 
-      const cache = readToonCache<{
-        localAdded: number;
-        localRemoved: number;
-        ts: number;
-      }>(cachePath);
-      expect(cache.ts).toBeGreaterThan(staleTs); // refreshed
-      // The diff fields are rewritten by the same refresh (root is not a git
-      // repo → freshly-measured 0/0, overwriting the stale 99/11).
-      expect(cache.localAdded).toBe(0);
-      expect(cache.localRemoved).toBe(0);
+      // The stale diff fields render as-is; the child owns the re-measure.
+      expect(repo.localAdded).toBe(99);
+      expect(repo.localRemoved).toBe(11);
+      expect(rec.calls).toHaveLength(1);
+      // The child gets the base ref, which is what the diffstat is measured against.
+      const argv = rec.calls[0]?.args ?? [];
+      expect(argv[argv.indexOf("--base-ref") + 1]).toBe("origin/main");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## The freeze

Once per 15-minute TTL, a terminal prompt froze while the statusline's repo collector awaited three `gh` calls under a 5-second timeout. Measured: **8.16 s** for one render, the single largest CPU consumer on the machine while it ran (109%, load 10.5 on 12 CPUs). With two sessions open, a freeze every few minutes — the terminal felt broken.

## The asymmetry

The file already contained the right answer. `collectStatuslineAfk` serves the stale value, dates it, and hands the network to a detached child (`startDetachedStatuslineCountRefresh`) that rewrites the cache for the *next* render. `collectStatuslineRepo`, three hundred lines below, awaited its refresh instead — its own comment said "await a bounded refresh so the cache is rewritten before the process exits".

## What changed

- The repo collector's stale branch serves the old counts immediately and spawns the **same** detached child the AFK collector uses — no new process shape, no new lock.
- `statusline-refresh-counts` learns `--base-ref` and rewrites **both** caches in one child, because both expire on the same render and a second child would buy a second lock and nothing else.
- The cold path (no cache at all) still awaits under its 5 s budget: with nothing to serve, a bounded wait beats an empty line.
- `cacheAgeS` still travels out so the renderer can say the counts are old — the honest answer, at no cost.

## Verification

The regression test seeds an expired cache and asserts the collector returns the old counts **in under a second** while spawning exactly one child carrying the base ref. Restoring the old awaiting branch fails it (verified: 1 failed / 11 passed).

`pnpm typecheck` 16/16 · `test:invariants` 185/185 · `wire-boot` 12/12 · `statusline-command` + `wire-runtime` 68/68.

Refs #3546

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788957601&installation_model_id=20659&pr_number=3547&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3547&signature=ceaa5eb72a1db607c3c8269e685153d721aa5d5e3d879b19c0050b612e4d42a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->