### PR TITLE
chore(release): queue the statusline freeze fix

### DIFF
--- a/.changeset/statusline-stale-never-blocks.md
+++ b/.changeset/statusline-stale-never-blocks.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Stop a stale statusline cache from freezing the terminal prompt. The repo collector awaited its own network refresh when the cache expired — up to five seconds of `gh` on the path that redraws a prompt, measured at eight seconds per render. Stale now serves the previous value with its age stated, and one detached child rewrites both caches for the next render.


### PR DESCRIPTION
Queues #3547 so the fix reaches installed terminals. Refs #3546. (#3508 remains the ticket for the gate that would make this manual step unnecessary.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788959680&installation_model_id=20659&pr_number=3548&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3548&signature=ba471fd33b3bc063a8166bfefa901384ce88cfbd4403e1e3fddac13d64acee2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->