### PR TITLE
chore: #3546 The statusline calls GitHub on every render

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -15,7 +15,10 @@
 
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
-import { runStatusline as runRedskilledStatusline } from "@reddb-io/redskilled/cli";
+// From the COMMAND module, never the CLI: cli.ts ends in a self-invocation
+// guard that is always true inside a single-file bundle, so importing it ships
+// a second argv-reading CLI inside every dev binary (#3546, canary catch).
+import { runStatusline as runRedskilledStatusline } from "@reddb-io/redskilled/statusline-command";
 import { configFile } from "@reddb-io/shared/red-paths.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { decode } from "@reddb-io/toon";

--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -1,14 +1,11 @@
-// commands/statusline.ts — native port of scripts/statusline.sh (the /afk
-// statusline aggregator for Claude Code).
+// commands/statusline.ts — the project command adapter for the host-scoped
+// redskilled statusline.
 //
-// This is the IO half: it reads the Claude Code statusline JSON payload from
-// stdin (cwd, model, effort, context window), resolves the project root, honours
-// the per-project `.red/config.yaml` opt-out, reads the git branch, aggregates
-// the live /afk worker state (with a 180 s / 3 min GitHub-count cache, configurable
-// via RED_AFK_STATUSLINE_CACHE_TTL_S / afk.statusline_cache_ttl), and feeds it all
-// into the PURE renderer in core/statusline.ts. The render assembly itself —
-// block order, optional-drop, ` · ` joins, token humanizing — lives entirely in
-// core/statusline.ts and is exercised by tests/statusline.test.ts.
+// The render path resolves the project root and opt-out, then delegates to the
+// daemon client. It performs one local socket read and never runs a project
+// collector, tracker client, or CI-log client. The legacy collector helpers stay
+// exported below for non-render consumers during their migration, but the prompt
+// path cannot reach them (#3546).
 //
 // Invocation: `node bin/afk.mjs statusline "<project-root>"` with the payload on
 // stdin. The root arg wins when it is a real directory (wire it as
@@ -18,30 +15,21 @@
 
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
+import { runStatusline as runRedskilledStatusline } from "@reddb-io/redskilled/cli";
 import { configFile } from "@reddb-io/shared/red-paths.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { decode } from "@reddb-io/toon";
-import { resolveBase } from "../core/base-resolver.js";
 import { readDevBundleCacheState } from "../core/bundle-version.js";
-import { type ClaudeInput, type ProjectInput, type RspStatusInput, type StatuslinePreset } from "../core/statusline.js";
+import { type ProjectInput, type RspStatusInput, type StatuslinePreset } from "../core/statusline.js";
 import { renderStatuslineLegend } from "../core/statusline-legend.js";
-import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
-import { branchLockPath, readLockedBranch } from "../runtime/lock.js";
 import { git as gitExec } from "../runtime/exec.js";
 import { resolveRspConfig } from "../../../rsp/src/config.js";
 import { resolveResidentPaths } from "../../../rsp/src/resident-client.js";
 import {
-  collectStatuslineAfk,
-  collectStatuslineDocs,
-  collectStatuslineFleet,
-  collectStatuslineValidationGate,
-  collectStatuslineRepo,
-  collectStatuslineWorkers,
   inferGitHubRepoSlug,
   refreshStatuslineCountCache,
   refreshStatuslineRepoCache,
-  resolveStatuslineCacheTtl,
 } from "../runtime/wire.js";
 import * as gitx from "../runtime/git.js";
 
@@ -280,45 +268,11 @@ async function resolveRepoBasename(root: string): Promise<string> {
   return basename(dirname(gitCommonDir)) || fallback;
 }
 
-/** Project the Claude Code payload into the renderer's block-2/3 input. */
-function resolveClaude(payload: ClaudePayload): ClaudeInput | undefined {
-  const model = payload.model?.display_name;
-  const effort = payload.effort?.level;
-  const tokens = payload.context_window?.total_input_tokens;
-  const pct = payload.context_window?.used_percentage;
-  // Rate-limit windows (Pro/Max only, after the first API response): pass through
-  // only when present so the renderer stays graceful for non-Pro/Max sessions.
-  const usage5h = payload.rate_limits?.five_hour?.used_percentage;
-  const usage7d = payload.rate_limits?.seven_day?.used_percentage;
-  if (
-    model === undefined &&
-    tokens === undefined &&
-    usage5h === undefined &&
-    usage7d === undefined
-  ) {
-    return undefined;
-  }
-  return {
-    model: model || undefined,
-    effort: effort || undefined,
-    contextTokens: tokens,
-    contextPercent: pct,
-    usage5h,
-    usage7d,
-  };
-}
-
 /**
- * `statusline "<project-root>" [--no-workers]` — read the Claude Code payload on
- * stdin, resolve the root, honour the opt-out, and emit ONE compact line via the
- * pure renderer. Emits nothing (and exits 0) when the per-project opt-out is set.
- *
- * **`--no-workers` renders the repo header and no Worker rows.** The daemon owns
- * the Worker line (ADR 0130 rule 10) and serves it finished, so a host that wants
- * both facts asks each producer for the one it owns rather than letting this
- * command format Workers a second time (#2928). The flag is additive: absent, the
- * command behaves exactly as it did, which keeps the Codex footer and every
- * non-daemon host on one call.
+ * `statusline "<project-root>"` — resolve the root and opt-out, then print the
+ * shared redskilled render. Emits nothing (and exits 0) only when the project
+ * opted out. An unreachable daemon emits its explicit absence line and still
+ * exits 0; it never falls back to project collectors or the tracker.
  */
 export async function statuslineCommand(
   args: string[],
@@ -330,78 +284,31 @@ export async function statuslineCommand(
     stdout.write(`${renderStatuslineLegend()}\n`);
     return 0;
   }
-  const withoutWorkers = args.includes("--no-workers");
-
-  // The first NON-flag word, so a caller may put `--no-workers` before the root
-  // without the flag being resolved as a directory.
-  const rootArg = args.find((arg) => !arg.startsWith("--"));
+  // A real directory is the legacy positional root. Other non-flag words (for
+  // example redskilled's `global` mode) belong to the daemon renderer.
+  const rootArg = args.find((arg) => !arg.startsWith("--") && isDir(arg));
   const text = await readStdin(stdin);
   const payload = parsePayload(text);
   const root = resolveRoot(rootArg, payload, cwd);
 
   if (!statuslineEnabled(root)) return 0;
 
-  const project = await resolveProject(root);
-  const claude = resolveClaude(payload);
-
-  // No `gh repo view` round-trip: like statusline.sh, the gh probes run from the
-  // project root and let gh infer the repo from cwd (repo slug ""). The repo
-  // header stats (line 1) render ALWAYS; the AFK block (line 2) only with live
-  // workers, so both collectors run every render (each cheap + cached).
-  const repoCtx = { root, repo: inferGitHubRepoSlug(root), remote: "origin" };
-  // Resolve the cache TTL ONCE here (env > afk.statusline_cache_ttl config > 180,
-  // #1217) and thread it into both collectors — the hot render path never loads
-  // config a second time per collector.
-  const cfg = loadConfig(configFile(root), { warn: () => undefined });
-  const preset = resolveStatuslinePreset(cfg);
-  const cacheTtlS = resolveStatuslineCacheTtl(process.env, (key) => getConfig(cfg, key));
-  const base = await resolveBase(
-    { issueBody: "" },
-    {
-      readLockedBranch: () => readLockedBranch(branchLockPath(root)),
-      configLockedBranch: getConfig(cfg, "dev.lock.branch"),
-      configTrunk: getConfig(cfg, "dev.trunk"),
-      fetchIssueBody: async () => undefined,
+  // One local socket read, one shared renderer. The daemon document already
+  // carries the Worker rows, repository activity, quota posture, liveness and
+  // staleness; asking project collectors for any of those facts here would put
+  // tracker and CI clients back in the terminal-prompt path (#3546).
+  //
+  // `--no-workers` belonged to the retired two-producer adapter. Once the daemon
+  // line reached Worker-row parity (#3151), suppressing its rows would discard
+  // the document's most useful information, so the compatibility spelling is a
+  // no-op. All other flags are taste owned by the redskilled renderer.
+  const daemonArgs = args.filter((arg) => arg !== rootArg && arg !== "--no-workers");
+  return runRedskilledStatusline(daemonArgs, {
+    cwd: root,
+    write: (line) => {
+      stdout.write(line);
     },
-  );
-  const repoLocBaseRef = `origin/${base}`;
-  // The aggregate AFK block feeds the plain single-line form (NO_COLOR / Codex);
-  // the per-worker records feed the themed multi-line form (Claude Code). Both
-  // read the same worker states — cheap file reads — so the two forms stay in
-  // sync while each renders its own layout.
-  const [repo, docs, afk, rawFleet, workers, rsp, validationGate] = await Promise.all([
-    collectStatuslineRepo(repoCtx, cacheTtlS, repoLocBaseRef),
-    collectStatuslineDocs(repoCtx, base),
-    collectStatuslineAfk(repoCtx, cacheTtlS).then((a) => a ?? undefined),
-    collectStatuslineFleet(repoCtx),
-    // Not merely dropped from the render: not COLLECTED. The rows this produces
-    // are the daemon's to serve, and a collector that still walked every
-    // worker's state file per tick would be paying for a second renderer's
-    // input after the second renderer was taken off the line.
-    withoutWorkers ? Promise.resolve([]) : collectStatuslineWorkers(repoCtx),
-    resolveStatuslineRsp(root),
-    collectStatuslineValidationGate(root),
-  ]);
-  const fleet =
-    rawFleet && rawFleet.bundleVersion !== undefined
-      ? { ...rawFleet, latestBundleVersion: project.latestCachedVersion ?? project.version, pointerVersion: project.pointerVersion }
-      : rawFleet;
-
-  // Theme on by default (the multi-line wine layout: a repo-global header line
-  // then one line per live worker); honour NO_COLOR for plain consumers (the
-  // single-line aggregate — the Codex-footer form), matching the de-facto colour
-  // opt-out. Claude Code exports $COLUMNS (v2.1.153+) as the width budget.
-  const color = !process.env.NO_COLOR;
-  const columns = Number.parseInt(process.env.COLUMNS ?? "", 10);
-  const nowS = Math.floor(Date.now() / 1000);
-  const line = renderStatuslineThemed({ project, claude, repo, docs, fleet, afk, rsp, validationGate }, color, {
-    columns: Number.isFinite(columns) && columns > 0 ? columns : undefined,
-    workers,
-    now: nowS,
-    preset,
   });
-  stdout.write(`${line}\n`);
-  return 0;
 }
 
 export async function statuslineRefreshCountsCommand(args: string[], cwd = process.cwd()): Promise<number> {

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -314,7 +314,15 @@ describe("statusline command — pure helpers", () => {
   });
 });
 
-describe("statusline command — rendered line", () => {
+// Retired by #3546. These fixtures deliberately run with no daemon and assert
+// that the command reconstructs a line from project files, tracker caches and
+// local Worker state. That fallback is now the defect: it is how `gh issue
+// list`, `gh api .../events` and `gh run view --log-failed` reached every prompt
+// render. The live command contract is pinned in statusline-render-path.test.ts;
+// the shared daemon payload/render details stay pinned in apps/redskilled and
+// packages/redskilled-render. Keep this block as migration history until the
+// legacy collector exports are removed, but never run it as a statusline test.
+describe.skip("statusline command — retired project-collector renderer", () => {
   let root: string;
   let oldNoColor: string | undefined;
 

--- a/apps/dev/tests/statusline-render-path.test.ts
+++ b/apps/dev/tests/statusline-render-path.test.ts
@@ -20,7 +20,7 @@ const { directCollector, runStatusline } = vi.hoisted(() => ({
   }),
 }));
 
-vi.mock("@reddb-io/redskilled/cli", () => ({ runStatusline }));
+vi.mock("@reddb-io/redskilled/statusline-command", () => ({ runStatusline }));
 
 vi.mock("../src/runtime/wire.js", () => ({
   collectStatuslineAfk: directCollector,

--- a/apps/dev/tests/statusline-render-path.test.ts
+++ b/apps/dev/tests/statusline-render-path.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { directCollector, runStatusline } = vi.hoisted(() => ({
+  directCollector: vi.fn(() => {
+    throw new Error("the render path called a project collector");
+  }),
+  runStatusline: vi.fn(async (
+    _args: readonly string[],
+    io: { readonly cwd?: string; readonly write?: (line: string) => void },
+  ) => {
+    io.write?.(
+      "acme/widgets 1w 128M v3.12.10\n" +
+      "w123  ███▶░░  run=codex gpt-5.6 xhigh  iss=3546  implementing·tests  00:02:03  loc=+12 -3  tks=45k  tls=9 rsn=2 txt=1\n",
+    );
+    return 0;
+  }),
+}));
+
+vi.mock("@reddb-io/redskilled/cli", () => ({ runStatusline }));
+
+vi.mock("../src/runtime/wire.js", () => ({
+  collectStatuslineAfk: directCollector,
+  collectStatuslineDocs: directCollector,
+  collectStatuslineFleet: directCollector,
+  collectStatuslineRepo: directCollector,
+  collectStatuslineValidationGate: directCollector,
+  collectStatuslineWorkers: directCollector,
+  inferGitHubRepoSlug: directCollector,
+  refreshStatuslineCountCache: directCollector,
+  refreshStatuslineRepoCache: directCollector,
+  resolveStatuslineCacheTtl: directCollector,
+}));
+
+import { statuslineCommand } from "../src/commands/statusline.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function fakeStdin(text: string): NodeJS.ReadableStream & { isTTY?: boolean } {
+  const stream = Readable.from([text]) as Readable & { isTTY?: boolean };
+  stream.isTTY = false;
+  return stream;
+}
+
+function sink(): { stream: NodeJS.WritableStream; text: () => string } {
+  let output = "";
+  return {
+    stream: {
+      write(chunk: string | Uint8Array): boolean {
+        output += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+        return true;
+      },
+    } as unknown as NodeJS.WritableStream,
+    text: () => output,
+  };
+}
+
+describe("dev statusline render path", () => {
+  it("renders the daemon document without invoking a project collector or API client", async () => {
+    const root = await mkdtemp(join(tmpdir(), "statusline-render-path-"));
+    roots.push(root);
+    const out = sink();
+
+    const started = performance.now();
+    const code = await statuslineCommand(
+      [root, "global", "--verbose", "--no-workers"],
+      root,
+      out.stream,
+      fakeStdin(JSON.stringify({ workspace: { project_dir: root } })),
+    );
+    const adapterMs = performance.now() - started;
+
+    expect(code).toBe(0);
+    expect(runStatusline).toHaveBeenCalledOnce();
+    expect(runStatusline).toHaveBeenCalledWith(
+      ["global", "--verbose"],
+      expect.objectContaining({ cwd: root }),
+    );
+    expect(directCollector).not.toHaveBeenCalled();
+    expect(out.text()).toContain("run=codex gpt-5.6 xhigh");
+    expect(out.text()).toContain("iss=3546");
+    expect(out.text()).toContain("loc=+12 -3  tks=45k  tls=9 rsn=2 txt=1");
+    // Repro baseline from #3546: daemon read 0.53s; old dev render 7.03–8.08s.
+    // The adapter adds less than 100ms in-process, keeping total render time in
+    // the daemon read's order of magnitude while leaving socket time measurable
+    // in the daemon client rather than hiding it behind tracker subprocesses.
+    expect(adapterMs).toBeLessThan(100);
+  });
+
+  it("prints the daemon client's stated absence promptly without a tracker fallback", async () => {
+    runStatusline.mockImplementationOnce(async (_args, io) => {
+      io.write?.("redskilled unreachable — Worker state unknown\n");
+      return 0;
+    });
+    const root = await mkdtemp(join(tmpdir(), "statusline-render-path-"));
+    roots.push(root);
+    const out = sink();
+
+    const started = performance.now();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(""));
+
+    expect(code).toBe(0);
+    expect(out.text()).toBe("redskilled unreachable — Worker state unknown\n");
+    expect(directCollector).not.toHaveBeenCalled();
+    expect(performance.now() - started).toBeLessThan(100);
+  });
+});

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -25,9 +25,10 @@
     "./statusline-payload": "./src/statusline-payload.ts",
     "./supervision": "./src/supervision.ts",
     "./worker-display": "./src/worker-display.ts",
-    "./worker-launch": "./src/worker-launch.ts"
+    "./worker-launch": "./src/worker-launch.ts",
+    "./statusline-command": "./src/statusline-command.ts"
   },
-  "description": "redskilled — the host-scoped execution daemon (ADR 0130): exactly one singleton per machine behind a unix socket, owning Worker processes across every project on that machine while each project's bundle keeps owning the work.",
+  "description": "redskilled \u2014 the host-scoped execution daemon (ADR 0130): exactly one singleton per machine behind a unix socket, owning Worker processes across every project on that machine while each project's bundle keeps owning the work.",
   "license": "Apache-2.0",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -19,7 +19,6 @@ import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
 import {
   ensureRedskilledDaemon,
   readRedskilledHostState,
-  readRedskilledStatuslineRender,
   stopRedskilledDaemon,
   type RedskilledClientConfig,
 } from "./client.js";
@@ -52,13 +51,9 @@ import {
   type RedskilledReclaimOptions,
 } from "./reclaim.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
-import {
-  parseRedskilledStatuslineFlags,
-  resolveRedskilledStatuslineOptions,
-} from "./statusline-config.js";
-import { renderRedskilledStatuslineAbsence } from "@reddb-io/redskilled-render";
 import { runDashboard } from "./dashboard-command.js";
-import { readStatuslineProject } from "./statusline-project.js";
+import { runStatusline } from "./statusline-command.js";
+export { runStatusline } from "./statusline-command.js";
 import {
   installRedskilledUnit,
   planRedskilledUnit,
@@ -685,73 +680,6 @@ export async function runUnit(
     return 0;
   }
   throw new Error(`unsupported redskilled unit action ${JSON.stringify(action)}: expected install, uninstall or status`);
-}
-
-/**
- * `redskilled statusline [global] [--verbose] [--flags]` — the whole of an agent
- * host's job.
- *
- * The host runs this and prints the one line it writes; it decides nothing about
- * shape, order, width or degradation, because the layout belongs to
- * `@reddb-io/redskilled-render` and to nothing else (ADR 0132 decision 1). The
- * PAYLOAD crosses the socket and the line is drawn here (decision 9): a
- * `statusLine` entry is a shell command, not an MCP client, and what keeps this
- * surface from drifting away from the MCP one is shared code rather than a
- * shared string. Config is read HERE, on the client side, and only decided
- * values reach the render.
- *
- * **It always writes a line and always exits 0.** A statusline that printed
- * nothing when the daemon was down would be indistinguishable from a machine
- * with no Workers — the operator would read an outage as calm — so an
- * unreachable host renders as a stated absence and the diagnosis goes to stderr,
- * where a host's statusline plumbing does not put it on screen.
- */
-export async function runStatusline(
-  args: readonly string[],
-  io: {
-    readonly cwd?: string;
-    /** The session's socket; derived from the environment when absent. */
-    readonly paths?: RedskilledPaths;
-    readonly write?: (line: string) => void;
-    readonly warn?: (line: string) => void;
-    /** How to reach the daemon; injected so a test can pose as a dead host. */
-    readonly client?: RedskilledClientConfig;
-    /** The clock, for the one instant no daemon supplies: an absence's own. */
-    readonly now?: () => string;
-  } = {},
-): Promise<number> {
-  const write = io.write ?? ((line: string) => process.stdout.write(line));
-  const warn = io.warn ?? ((line: string) => process.stderr.write(line));
-
-  const parsed = parseRedskilledStatuslineFlags(args);
-  const project = readStatuslineProject(io.cwd ?? process.cwd());
-  const resolved = resolveRedskilledStatuslineOptions({
-    ...(project.configText == null ? {} : { configText: project.configText }),
-    project: project.label,
-    flags: parsed.flags,
-  });
-  for (const warning of [...resolved.warnings, ...parsed.warnings]) {
-    warn(`redskilled statusline: ignoring ${warning.key}=${warning.value} — ${warning.reason}\n`);
-  }
-
-  let render;
-  try {
-    render = await readRedskilledStatuslineRender(io.paths ?? resolveRedskilledPaths(), resolved.options, {
-      ...(io.client ?? {}),
-      ...(resolved.options.project == null ? {} : { sessionProject: resolved.options.project }),
-    });
-  } catch (err) {
-    warn(`redskilled statusline: ${err instanceof Error ? err.message : String(err)}\n`);
-    render = renderRedskilledStatuslineAbsence({
-      options: resolved.options,
-      generated_at: (io.now ?? (() => new Date().toISOString()))(),
-    });
-  }
-  // Every line the shared render produced, in order — one write, whatever the
-  // taste. With `--verbose` that is the Worker line plus a second line per
-  // Worker; the host still decides nothing about shape.
-  write(`${render.lines.join("\n")}\n`);
-  return 0;
 }
 
 const PROVISION_FLAGS = {

--- a/apps/redskilled/src/statusline-command.ts
+++ b/apps/redskilled/src/statusline-command.ts
@@ -1,0 +1,74 @@
+/**
+ * statusline-command — `redskilled statusline`, importable without the CLI.
+ *
+ * It sits apart from `cli.ts` because that module ends in a self-invocation
+ * guard, and inside a single-file bundle the guard is ALWAYS true: every inlined
+ * module shares the bundle's own `import.meta.url`, which is exactly
+ * `process.argv[1]`. A consumer that imported `runStatusline` from the CLI
+ * therefore shipped a second, argv-reading CLI inside its own binary — the
+ * castle-mcp canary caught it as a host-state document splashed across a stdout
+ * that must carry one TOON report (#3546). A command another package may import
+ * lives in a module that runs nothing on import.
+ *
+ * The command's contract is unchanged from where it lived: config is read HERE,
+ * on the client side, and only decided values reach the render; it always writes
+ * a line and always exits 0, because a statusline that printed nothing when the
+ * daemon was down would render an outage as calm. An unreachable host is a
+ * stated absence on stdout and a diagnosis on stderr.
+ */
+import { readRedskilledStatuslineRender, type RedskilledClientConfig } from "./client.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
+import {
+  parseRedskilledStatuslineFlags,
+  resolveRedskilledStatuslineOptions,
+} from "./statusline-config.js";
+import { readStatuslineProject } from "./statusline-project.js";
+import { renderRedskilledStatuslineAbsence } from "@reddb-io/redskilled-render";
+
+export async function runStatusline(
+  args: readonly string[],
+  io: {
+    readonly cwd?: string;
+    /** The session's socket; derived from the environment when absent. */
+    readonly paths?: RedskilledPaths;
+    readonly write?: (line: string) => void;
+    readonly warn?: (line: string) => void;
+    /** How to reach the daemon; injected so a test can pose as a dead host. */
+    readonly client?: RedskilledClientConfig;
+    /** The clock, for the one instant no daemon supplies: an absence's own. */
+    readonly now?: () => string;
+  } = {},
+): Promise<number> {
+  const write = io.write ?? ((line: string) => process.stdout.write(line));
+  const warn = io.warn ?? ((line: string) => process.stderr.write(line));
+
+  const parsed = parseRedskilledStatuslineFlags(args);
+  const project = readStatuslineProject(io.cwd ?? process.cwd());
+  const resolved = resolveRedskilledStatuslineOptions({
+    ...(project.configText == null ? {} : { configText: project.configText }),
+    project: project.label,
+    flags: parsed.flags,
+  });
+  for (const warning of [...resolved.warnings, ...parsed.warnings]) {
+    warn(`redskilled statusline: ignoring ${warning.key}=${warning.value} — ${warning.reason}\n`);
+  }
+
+  let render;
+  try {
+    render = await readRedskilledStatuslineRender(io.paths ?? resolveRedskilledPaths(), resolved.options, {
+      ...(io.client ?? {}),
+      ...(resolved.options.project == null ? {} : { sessionProject: resolved.options.project }),
+    });
+  } catch (err) {
+    warn(`redskilled statusline: ${err instanceof Error ? err.message : String(err)}\n`);
+    render = renderRedskilledStatuslineAbsence({
+      options: resolved.options,
+      generated_at: (io.now ?? (() => new Date().toISOString()))(),
+    });
+  }
+  // Every line the shared render produced, in order — one write, whatever the
+  // taste. With `--verbose` that is the Worker line plus a second line per
+  // Worker; the host still decides nothing about shape.
+  write(`${render.lines.join("\n")}\n`);
+  return 0;
+}


### PR DESCRIPTION
Automated AFK landing for #3546. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3546

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788977242&installation_model_id=20659&pr_number=3550&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3550&signature=acc8b084d89dafed3dbd1e8d189da7ec440268b1cd341b88917762af2ea05607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->