### PR TITLE
chore: #3540 A full event lane pays a whole compaction per event

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -34,9 +34,19 @@ consumer must ignore kinds outside the public set.
 The lane is append-only within a generation and rotates atomically at 4 MiB.
 Compaction keeps every live Worker's birth and the newest history that fits, so
 daemon boot replays a fixed upper bound without losing a process it must
-re-attach. A reader may start at the new generation's head: every public death
-and budget-kill repeats the Worker's identity and can be understood without its
-birth.
+re-attach. Ordinary compaction targets 2 MiB, leaving about 2 MiB for subsequent
+appends before another replacement. In steady state that is approximately one
+byte rewritten by compaction per newly appended encoded byte, plus the append
+itself, instead of a 4 MiB rewrite per event. A live-Worker birth baseline larger
+than 2 MiB necessarily reduces that headroom but may never cross the 4 MiB hard
+ceiling.
+
+`tests/event-lane-rotation.test.ts` measures generation replacements rather than
+wall-clock timing: after warmup, its representative 8 KiB lane and 120-byte
+refusal details previously replaced the generation 40 times for 40 appends; the
+regression bound is at most 8 replacements for those 40 appends. A reader may
+start at the new generation's head: every public death and budget-kill repeats
+the Worker's identity and can be understood without its birth.
 
 A stateful consumer should use `readRedskilledEventsFrom` positions (or preserve
 the same generation-and-offset semantics in another language). A position from

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -188,6 +188,9 @@ export const REDSKILLED_EVENT_LANE_FILE = "redskilled.log.toonl";
 /** The most history one daemon generation asks every successor to replay. */
 export const DEFAULT_REDSKILLED_EVENT_LANE_MAX_BYTES = 4 * 1024 * 1024;
 
+/** Keep half a generation free so a full lane amortizes its next rewrite. */
+const REDSKILLED_EVENT_LANE_COMPACTION_TARGET_RATIO = 0.5;
+
 export interface RecordEventInput {
   readonly event: RedskilledEventKind;
   readonly worker: RedskilledWorkerView;
@@ -403,9 +406,11 @@ export function createRedskilledEventLane(
     const write = tail.then(async () => {
       await mkdir(dirname(path), { recursive: true, mode: 0o700 });
       await dropIncompleteTail(path);
-      await appendFile(path, emitter.push(toRow(event)), { encoding: "utf8", mode: 0o600 });
-      if ((await stat(path)).size > maxBytes) {
-        await rotateEventLane(path, maxBytes);
+      const encoded = emitter.push(toRow(event));
+      if (await appendFits(path, encoded, maxBytes)) {
+        await appendFile(path, encoded, { encoding: "utf8", mode: 0o600 });
+      } else {
+        await rotateEventLane(path, maxBytes, event);
         // The compact generation has its own header. A new emitter makes the
         // next append a complete segment even when its schema changes later.
         emitter = encodeLines({ trailer: false });
@@ -429,10 +434,33 @@ export function createRedskilledEventLane(
   };
 }
 
-/** Atomically replace an oversized generation with the boot-complete suffix. */
-async function rotateEventLane(path: string, maxBytes: number): Promise<void> {
-  const events = await readRedskilledEvents(path);
-  const compact = compactEventLane(events, maxBytes);
+/** Whether one encoded append stays inside the hard generation ceiling. */
+async function appendFits(path: string, encoded: string, maxBytes: number): Promise<boolean> {
+  let currentBytes = 0;
+  try {
+    currentBytes = (await stat(path)).size;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  return currentBytes + Buffer.byteLength(encoded) <= maxBytes;
+}
+
+/** Atomically replace a full generation, including the append that filled it. */
+async function rotateEventLane(
+  path: string,
+  maxBytes: number,
+  incoming: RedskilledHostEvent,
+): Promise<void> {
+  const events = [...await readRedskilledEvents(path), incoming];
+  const requiredIndices = new Set([events.length - 1]);
+  const targetBytes = Math.floor(maxBytes * REDSKILLED_EVENT_LANE_COMPACTION_TARGET_RATIO);
+  let compact: RedskilledHostEvent[];
+  try {
+    compact = compactEventLane(events, targetBytes, requiredIndices);
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.startsWith("redskilled event-lane baseline exceeds")) throw error;
+    compact = compactEventLane(events, maxBytes, requiredIndices);
+  }
   const temporary = `${path}.rotate-${process.pid}`;
   try {
     await writeFile(temporary, encodeEventLane(compact), { encoding: "utf8", mode: 0o600 });
@@ -453,9 +481,10 @@ async function rotateEventLane(path: string, maxBytes: number): Promise<void> {
 export function compactEventLane(
   events: readonly RedskilledHostEvent[],
   maxBytes: number,
+  requiredIndices: ReadonlySet<number> = new Set(),
 ): RedskilledHostEvent[] {
   const liveIds = new Set(rehydrateWorkers(events).map((worker) => worker.worker_id));
-  const pinnedIndices = new Set<number>();
+  const pinnedIndices = new Set(requiredIndices);
   for (let index = events.length - 1; index >= 0 && liveIds.size > 0; index -= 1) {
     const event = events[index]!;
     if (event.kind !== "worker-birth" || !liveIds.has(event.worker_id)) continue;

--- a/apps/redskilled/tests/event-lane-rotation.test.ts
+++ b/apps/redskilled/tests/event-lane-rotation.test.ts
@@ -30,6 +30,42 @@ function worker(workerId: string): RedskilledWorkerView {
 }
 
 describe("the bounded host event lane", () => {
+  it("amortizes compaction across steady-state appends after the lane fills", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-compaction-cost-"));
+    roots.push(root);
+    const maxBytes = 8_192;
+    const lane = createRedskilledEventLane(join(root, "redskilled.log.toonl"), { maxBytes });
+
+    await lane.recordWorker({
+      kind: "worker-birth",
+      worker: worker("w-live"),
+      ts: "2026-08-08T09:00:00.000Z",
+    });
+    for (let index = 0; index < 80; index += 1) {
+      await lane.recordDemandRefusal({
+        ts: new Date(Date.parse("2026-08-08T09:01:00.000Z") + index).toISOString(),
+        projectLabel: "acme/widgets",
+        detail: `warmup-${index}-${"x".repeat(120)}`,
+      });
+    }
+
+    let position = (await readRedskilledEventsFrom(lane.path)).position!;
+    let replacements = 0;
+    for (let index = 0; index < 40; index += 1) {
+      await lane.recordDemandRefusal({
+        ts: new Date(Date.parse("2026-08-08T10:00:00.000Z") + index).toISOString(),
+        projectLabel: "acme/widgets",
+        detail: `steady-${index}-${"x".repeat(120)}`,
+      });
+      const next = (await readRedskilledEventsFrom(lane.path)).position!;
+      if (next.generation !== position.generation) replacements += 1;
+      position = next;
+      expect((await stat(lane.path)).size).toBeLessThanOrEqual(maxBytes);
+    }
+
+    expect(replacements).toBeLessThanOrEqual(8);
+  });
+
   it("rotates before the lane can make boot replay unbounded and retains live Worker births", async () => {
     const root = await mkdtemp(join(tmpdir(), "redskilled-rotation-"));
     roots.push(root);


### PR DESCRIPTION
Automated AFK landing for #3540. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3540

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788977299&installation_model_id=20659&pr_number=3551&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3551&signature=efab3e2cf01e0abca1f38460322afed7617d65f842fc5d714c8c5c8deb8ab93f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->