### PR TITLE
chore(release): queue the render-path and lane-compaction fixes

### DIFF
--- a/.changeset/render-path-owns-no-network.md
+++ b/.changeset/render-path-owns-no-network.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/dev": patch
+---
+
+Remove every network call from the statusline render path and stop a full event lane from paying a whole compaction per event.
+
+The statusline now performs one local socket read and never runs a project collector, tracker client, or CI-log client — the cold path included. A command another package imports runs nothing on import: the daemon's statusline command moved out of the CLI entry module, whose self-invocation guard is always true inside a single-file bundle and was shipping a second argv-reading CLI inside every dev binary.
+
+The host event lane at its cap no longer rewrites its full contents on every appended event; the bound, boot-replay ceiling, and rebaseline contract are unchanged.


### PR DESCRIPTION
Queues #3550 and #3551 so both fixes reach installed terminals. Refs #3546 #3540. (#3508 remains the ticket for the gate that would make this manual step unnecessary — fifth hand-written entry this weekend.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788980312&installation_model_id=20659&pr_number=3552&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3552&signature=51f61f391aed429bd6ea2c03fcada5890250bc2356b2f43bd118fccc104029b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->