### PR TITLE
fix(redskilled): never write a relative command into the unit's ExecStart

### DIFF
--- a/.changeset/execstart-never-relative.md
+++ b/.changeset/execstart-never-relative.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Never let the daemon's systemd unit die on a relative `ExecStart`. The in-major self-replacement's version-pinned dispatch wrote a bare `npx` into the supervisor drop-in, and systemd resolves `ExecStart` with the manager's PATH — 203/EXEC on every start where node comes from a version manager, until a manual `reset-failed`. The pinned dispatch now resolves `npx` to an absolute path through the daemon's own view (beside its node, then its PATH) and refuses the upgrade when it cannot; the unit repoint refuses any relative command before writing; and a supervised boot heals an already-poisoned drop-in for its own session with the running process's absolute invocation.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -55,12 +55,14 @@ import { runDashboard } from "./dashboard-command.js";
 import { runStatusline } from "./statusline-command.js";
 export { runStatusline } from "./statusline-command.js";
 import {
+  healRedskilledUnitDropIn,
   installRedskilledUnit,
   planRedskilledUnit,
   readRedskilledUnitStatus,
   uninstallRedskilledUnit,
   type RedskilledUnitIO,
 } from "./supervision.js";
+import { isRedskilledSupervised } from "./self-replace.js";
 
 /**
  * Usage, as a CONSTANT — the answer owes nothing to the machine it is asked on.
@@ -452,10 +454,11 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       id: `daemon:${process.pid}`,
       phase: "serving",
     });
+    const paths = servePaths(values);
     let daemon;
     try {
       daemon = await startRedskilledDaemon({
-        paths: servePaths(values),
+        paths,
         idleMs: hostSettings.idleMs,
         ceiling: hostSettings.ceiling,
         // The artifact states what it IS. Absent, the daemon reports the version
@@ -487,6 +490,18 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       // does not invent an unexplained disappearance for this orderly refusal.
       deaths.uninstall();
       return 0;
+    }
+    // A supervised boot proves the running invocation works — the one moment a
+    // drop-in poisoned with a relative ExecStart command (#3554) can be
+    // converged to this process's own absolute invocation. Best-effort by
+    // design: a heal that cannot read or write the drop-in must not cost the
+    // boot that would serve clients; the next supervised boot tries again.
+    if (isRedskilledSupervised()) {
+      try {
+        healRedskilledUnitDropIn({ socketPath: paths.socketPath });
+      } catch {
+        // The drop-in stays as it is.
+      }
     }
     // A signalled daemon LETS GO rather than being cut off: the stop path flushes
     // the event lane, releases the lease and unlinks the socket, so the successor

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -39,7 +39,7 @@
  */
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { canonicalInvocation } from "@reddb-io/shared/canonical-invocation.js";
 import { fetchPublishedVersionHorizon } from "@reddb-io/shared/bundle-fetch.js";
 import { compareSemver, parseSemver } from "@reddb-io/shared/self-update.js";
@@ -289,7 +289,7 @@ export class RedskilledReplacementEntryError extends Error {
   constructor(version: string, searched: readonly string[]) {
     super(
       `${REDSKILLED_REPLACEMENT_ENTRY_UNRESOLVED}: the published redskilled bundle ${version} exists on no ` +
-        `reachable path and the version-pinned dispatch is disabled\nsearched:\n${
+        `reachable path and the version-pinned dispatch is disabled or resolves no absolute npx\nsearched:\n${
           searched.map((path) => `  ${path}`).join("\n")
         }`,
     );
@@ -329,13 +329,52 @@ export function requireRedskilledReplacementEntry(
     if (exists(path)) return { command: execPath, args: [path], version, source, searched };
   }
   if (env.RED_SKILLS_NO_PINNED_DISPATCH === "1") throw new RedskilledReplacementEntryError(version, searched);
+  // The command must be ABSOLUTE: this entry is also what a supervised
+  // replacement writes into the unit's ExecStart, and systemd resolves that
+  // binary with the MANAGER's PATH — system directories only on hosts whose
+  // node comes from a version manager, where a bare `npx` is 203/EXEC on every
+  // start until a human runs `reset-failed` (#3554). An unresolvable npx costs
+  // the upgrade, never the machine.
+  const npx = resolveAbsoluteNpx(env, exists, execPath, searched);
+  if (npx == null) throw new RedskilledReplacementEntryError(version, searched);
   return {
-    command: env.RED_SKILLS_NPX || "npx",
+    command: npx,
     args: ["-y", "-p", `@reddb-io/red-skills@${version}`, "red-skills-redskilled"],
     version,
     source: "pinned-dispatch",
     searched,
   };
+}
+
+/**
+ * An absolute path to `npx`, or null when the host offers none.
+ *
+ * An absolute `RED_SKILLS_NPX` is honored as stated; a relative one names the
+ * binary to find rather than where it is. The search is the resolving
+ * process's own view — the directory beside its node first, because every node
+ * install ships an `npx` sibling, then its PATH — and every miss lands in
+ * `searched` so the refusal names where it looked.
+ */
+function resolveAbsoluteNpx(
+  env: NodeJS.ProcessEnv,
+  exists: (path: string) => boolean,
+  execPath: string,
+  searched: string[],
+): string | null {
+  const stated = env.RED_SKILLS_NPX?.trim();
+  if (stated && isAbsolute(stated)) return stated;
+  const names = process.platform === "win32"
+    ? [stated || "npx.cmd", "npx.cmd", "npx.exe", "npx"]
+    : [stated || "npx"];
+  const directories = [dirname(execPath), ...(env.PATH ?? "").split(delimiter).filter((dir) => dir.length > 0)];
+  for (const name of new Set(names)) {
+    for (const directory of directories) {
+      const candidate = join(directory, name);
+      searched.push(candidate);
+      if (exists(candidate)) return candidate;
+    }
+  }
+  return null;
 }
 
 export interface RedskilledReplacementIO {

--- a/apps/redskilled/src/supervision.ts
+++ b/apps/redskilled/src/supervision.ts
@@ -26,9 +26,9 @@
 import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdir, rm, writeFile } from "node:fs/promises";
-import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import {
   redskilledServeArgv,
   requireRedskilledEntry,
@@ -160,6 +160,18 @@ export function repointRedskilledUnitForReplacement(
     readonly run?: (argv: readonly string[]) => RedskilledUnitRunResult;
   } = {},
 ): string {
+  // systemd resolves the ExecStart binary with the MANAGER's PATH, which the
+  // unit's own Environment=PATH never touches — a relative command here is
+  // 203/EXEC on every restart until a human runs `reset-failed` (#3554). The
+  // refusal happens before any write, so the serving daemon stays up on its
+  // current ExecStart: an upgrade may be delayed, a unit is never poisoned.
+  if (!isAbsolute(entry.command)) {
+    throw new Error(
+      `redskilled refused to write the relative command "${entry.command}" into the supervisor drop-in: ` +
+        "systemd resolves ExecStart with the manager's PATH, so a relative command dies with 203/EXEC " +
+        "on hosts whose node comes from a version manager (#3554)",
+    );
+  }
   const path = redskilledReplacementDropInPath(options.env ?? process.env);
   const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
   const argv = [
@@ -184,6 +196,95 @@ export function repointRedskilledUnitForReplacement(
     );
   }
   return path;
+}
+
+/** What healing the current-entry drop-in found and did. */
+export interface RedskilledUnitHealReport {
+  readonly path: string;
+  /**
+   * `absent` — no drop-in to heal; `absolute` — already healthy, untouched;
+   * `healed` — relative command rewritten to this process's own absolute
+   * invocation; `unparsed` — no readable ExecStart, left alone; `foreign` —
+   * the drop-in serves some other session's socket, never ours to rewrite.
+   */
+  readonly status: "absent" | "absolute" | "healed" | "unparsed" | "foreign";
+  /** The ExecStart command the drop-in carried, when one was readable. */
+  readonly command?: string;
+}
+
+/**
+ * Heal a current-entry drop-in whose `ExecStart` names a relative command.
+ *
+ * The recovery half of the #3554 fix: hosts that already carry a relative
+ * `npx` drop-in are dead on every systemd start — but the SAME daemon still
+ * comes up through client auto-spawn or an operator's hand-start, and a
+ * supervised boot proves the running invocation works. So a daemon booting
+ * supervised rewrites the poisoned drop-in with its own absolute invocation
+ * (`process.execPath`, its own entry, its live argv) and reloads systemd,
+ * converging the host without manual surgery. An absolute drop-in is left
+ * byte-for-byte untouched, and so is one that does not name `socketPath` —
+ * the drop-in describes ONE session's daemon, and only that daemon, proven by
+ * serving the same socket, may rewrite it: a test or foreign-session process
+ * that healed it would poison the unit with an argv it never served.
+ */
+export function healRedskilledUnitDropIn(
+  options: {
+    readonly env?: NodeJS.ProcessEnv;
+    /** The socket THIS process serves — its claim to the drop-in. */
+    readonly socketPath?: string;
+    /** This process's absolute node; `process.execPath` by default. */
+    readonly execPath?: string;
+    /** This process's entry and everything after it; `process.argv.slice(1)` by default. */
+    readonly argv?: readonly string[];
+    readonly readFile?: (path: string) => string;
+    readonly run?: (argv: readonly string[]) => RedskilledUnitRunResult;
+  } = {},
+): RedskilledUnitHealReport {
+  const path = redskilledReplacementDropInPath(options.env ?? process.env);
+  let text: string;
+  try {
+    text = (options.readFile ?? ((p: string) => readFileSync(p, "utf8")))(path);
+  } catch {
+    return { path, status: "absent" };
+  }
+  const words = execStartWordsOf(text);
+  const command = words?.[0];
+  if (words == null || command == null) return { path, status: "unparsed" };
+  if (isAbsolute(command)) return { path, status: "absolute", command };
+  if (options.socketPath == null || !words.includes(options.socketPath)) {
+    return { path, status: "foreign", command };
+  }
+  const execPath = options.execPath ?? process.execPath;
+  const argv = [execPath, ...(options.argv ?? process.argv.slice(1))];
+  const healed = [
+    "[Service]",
+    "ExecStart=",
+    `ExecStart=${argv.map(quoteUnitWord).join(" ")}`,
+    "",
+  ].join("\n");
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(temporary, healed, { encoding: "utf8", mode: 0o600 });
+  renameSync(temporary, path);
+  // A failed reload is not undone: the file on disk is already correct, and
+  // systemd reads it on its own next reload or login — later beats never.
+  (options.run ?? defaultRun)(["systemctl", "--user", "daemon-reload"]);
+  return { path, status: "healed", command };
+}
+
+/** The words of the LAST non-empty `ExecStart=` line, unquoted. */
+function execStartWordsOf(unitText: string): readonly string[] | undefined {
+  let words: string[] | undefined;
+  for (const line of unitText.split("\n")) {
+    const value = line.trim().startsWith("ExecStart=") ? line.trim().slice("ExecStart=".length).trim() : undefined;
+    if (!value) continue;
+    words = value.split(/\s+/).map(
+      (word) =>
+        word.startsWith('"') && word.endsWith('"') && word.length > 1
+          ? word.slice(1, -1).replace(/\\\\/g, "\\").replace(/\\"/g, '"')
+          : word,
+    );
+  }
+  return words;
 }
 
 /** A word for `ExecStart`: quoted only when it would otherwise split or escape. */

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -26,7 +26,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { readRedskilledHostState } from "../src/client.js";
 import { socketAnswers, startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
@@ -314,6 +314,9 @@ describe("the successor entry", () => {
     const dispatch = requireRedskilledReplacementEntry("2.7.0", { env: missing, callerEntry: "" });
     expect(dispatch.source).toBe("pinned-dispatch");
     expect(dispatch.args).toEqual(["-y", "-p", "@reddb-io/red-skills@2.7.0", "red-skills-redskilled"]);
+    // Never a bare `npx`: this command also lands in a systemd ExecStart, which
+    // the manager resolves with ITS PATH — relative there is 203/EXEC (#3554).
+    expect(isAbsolute(dispatch.command)).toBe(true);
 
     const error = (() => {
       try {
@@ -331,6 +334,58 @@ describe("the successor entry", () => {
     expect((error as RedskilledReplacementEntryError).searched.join("\n")).toContain(
       "redskilled-2.7.0.bundle.min.mjs",
     );
+  });
+
+  it("resolves the pinned dispatch to the npx beside its own node, through the process's view", async () => {
+    const { env } = await session();
+    const npx = "/fake/toolchain/node-lts/bin/npx";
+
+    const dispatch = requireRedskilledReplacementEntry("2.7.0", {
+      env: { ...env, RED_SKILLS_NPX: "npx", PATH: "/usr/bin:/bin" },
+      callerEntry: "",
+      execPath: "/fake/toolchain/node-lts/bin/node",
+      exists: (path) => path === npx,
+    });
+
+    expect(dispatch.source).toBe("pinned-dispatch");
+    expect(dispatch.command).toBe(npx);
+  });
+
+  it("honors an absolute RED_SKILLS_NPX exactly as stated", async () => {
+    const { env } = await session();
+
+    const dispatch = requireRedskilledReplacementEntry("2.7.0", {
+      env: { ...env, RED_SKILLS_NPX: "/opt/tools/npx" },
+      callerEntry: "",
+      exists: () => false,
+    });
+
+    expect(dispatch.command).toBe("/opt/tools/npx");
+  });
+
+  it("refuses the pinned dispatch when no npx resolves to an absolute path — the upgrade waits, the unit is never poisoned", async () => {
+    const { env } = await session();
+
+    const error = (() => {
+      try {
+        requireRedskilledReplacementEntry("2.7.0", {
+          env: { ...env, PATH: "/usr/bin:/bin" },
+          callerEntry: "",
+          execPath: "/fake/toolchain/node-lts/bin/node",
+          exists: () => false,
+        });
+        return null;
+      } catch (err) {
+        return err;
+      }
+    })();
+
+    expect(error).toBeInstanceOf(RedskilledReplacementEntryError);
+    // The refusal names where it looked for npx, beside the bundle paths.
+    expect((error as RedskilledReplacementEntryError).searched.join("\n")).toContain(
+      join("/fake/toolchain/node-lts/bin", "npx"),
+    );
+    expect((error as RedskilledReplacementEntryError).searched.join("\n")).toContain(join("/usr/bin", "npx"));
   });
 });
 

--- a/apps/redskilled/tests/self-supervision.test.ts
+++ b/apps/redskilled/tests/self-supervision.test.ts
@@ -36,6 +36,7 @@ import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { sendRedskilledRequest } from "../src/protocol.js";
 import { REDSKILLED_REPLACE_EXIT_CODE } from "../src/self-replace.js";
 import {
+  healRedskilledUnitDropIn,
   installRedskilledUnit,
   planRedskilledUnit,
   readRedskilledUnitStatus,
@@ -246,6 +247,94 @@ describe("the user unit that supervises the daemon", () => {
     expect(dropIn).toContain(publishedBundle);
     expect(dropIn).toContain(paths.socketPath);
     expect(reload.calls).toEqual([["systemctl", "--user", "daemon-reload"]]);
+  });
+
+  it("refuses to repoint the unit to a relative command before writing anything — 203/EXEC is never installed", async () => {
+    const { paths } = await host();
+    const env = { HOME: paths.runtimeDir };
+    const reload = recordingRun();
+
+    // systemd resolves ExecStart with the MANAGER's PATH, so a bare `npx` is
+    // unresolvable on hosts whose node comes from a version manager (#3554).
+    expect(() =>
+      repointRedskilledUnitForReplacement(
+        { command: "npx", args: ["-y", "-p", "@reddb-io/red-skills@9.9.9", "red-skills-redskilled"] },
+        paths,
+        { env, run: reload.run },
+      ),
+    ).toThrow(/relative command "npx"/);
+
+    // Nothing was written and systemd was never reloaded: the serving daemon
+    // stays up on its current ExecStart, the upgrade merely waits.
+    expect(existsSync(redskilledReplacementDropInPath(env))).toBe(false);
+    expect(reload.calls).toEqual([]);
+  });
+
+  it("heals a drop-in poisoned with a relative command into this process's own absolute invocation", async () => {
+    const { paths } = await host();
+    const env = { HOME: paths.runtimeDir };
+    const dropIn = redskilledReplacementDropInPath(env);
+    await mkdir(resolve(dropIn, ".."), { recursive: true });
+    await writeFile(
+      dropIn,
+      `[Service]\nExecStart=\nExecStart=npx -y -p @reddb-io/red-skills@9.9.9 red-skills-redskilled serve --socket ${paths.socketPath}\n`,
+    );
+    const reload = recordingRun();
+
+    const report = healRedskilledUnitDropIn({
+      env,
+      socketPath: paths.socketPath,
+      execPath: "/fake/toolchain/node-lts/bin/node",
+      argv: ["/fake/bundle/redskilled.bundle.min.mjs", "serve", "--socket", paths.socketPath],
+      run: reload.run,
+    });
+
+    expect(report).toEqual({ path: dropIn, status: "healed", command: "npx" });
+    const healed = readFileSync(dropIn, "utf8");
+    expect(healed).toContain("ExecStart=\n");
+    expect(healed).toContain(
+      `ExecStart=/fake/toolchain/node-lts/bin/node /fake/bundle/redskilled.bundle.min.mjs serve --socket ${paths.socketPath}`,
+    );
+    expect(reload.calls).toEqual([["systemctl", "--user", "daemon-reload"]]);
+  });
+
+  it("never rewrites a drop-in that serves some other session's socket — a test or foreign process has no claim", async () => {
+    const { paths } = await host();
+    const env = { HOME: paths.runtimeDir };
+    const dropIn = redskilledReplacementDropInPath(env);
+    const poisoned =
+      "[Service]\nExecStart=\nExecStart=npx -y -p @reddb-io/red-skills@9.9.9 red-skills-redskilled serve --socket /run/someone-else.sock\n";
+    await mkdir(resolve(dropIn, ".."), { recursive: true });
+    await writeFile(dropIn, poisoned);
+    const reload = recordingRun();
+
+    const report = healRedskilledUnitDropIn({ env, socketPath: paths.socketPath, run: reload.run });
+
+    expect(report).toEqual({ path: dropIn, status: "foreign", command: "npx" });
+    expect(readFileSync(dropIn, "utf8")).toBe(poisoned);
+    expect(reload.calls).toEqual([]);
+  });
+
+  it("leaves an absolute drop-in byte-for-byte untouched, and reports an absent one without inventing it", async () => {
+    const { paths } = await host();
+    const env = { HOME: paths.runtimeDir };
+    const dropIn = redskilledReplacementDropInPath(env);
+
+    expect(healRedskilledUnitDropIn({ env, run: recordingRun().run })).toEqual({
+      path: dropIn,
+      status: "absent",
+    });
+
+    const absolute = "[Service]\nExecStart=\nExecStart=/usr/bin/node /opt/redskilled.bundle.min.mjs serve\n";
+    await mkdir(resolve(dropIn, ".."), { recursive: true });
+    await writeFile(dropIn, absolute);
+    const reload = recordingRun();
+
+    const report = healRedskilledUnitDropIn({ env, run: reload.run });
+
+    expect(report).toEqual({ path: dropIn, status: "absolute", command: "/usr/bin/node" });
+    expect(readFileSync(dropIn, "utf8")).toBe(absolute);
+    expect(reload.calls).toEqual([]);
   });
 
   it("revives a cleanly self-stopped daemon with no client asking for work", async () => {


### PR DESCRIPTION
Fixes #3554.

## The failure

The in-major self-replacement's version-pinned dispatch fallback returned `command: "npx"` — relative — and the supervised repoint wrote that argv verbatim into the `10-current-entry.conf` drop-in. systemd resolves the `ExecStart` binary with the **manager's** PATH (system directories only where node comes from mise/nvm; the unit's own `Environment=PATH` has no effect on that resolution), so every start died with 203/EXEC, `Restart=always` burned the start-limit burst, and the daemon stayed dead until a manual `systemctl --user reset-failed`. Client auto-spawn kept answering reads, so the host presented half-alive for hours.

Triage note: the issue title attributes the relative `ExecStart` to `provision`, but the base unit writers were already absolute (`process.execPath` + bundle path); the one writer that spelled a relative command is the pinned-dispatch → repoint pair, verified on the reporting host.

## The survival strategy — three layers

1. **No writer emits a relative `ExecStart`.** The pinned dispatch resolves `npx` absolute through the daemon's own view — beside its node first (every node install ships an npx sibling), then its PATH — honoring an absolute `RED_SKILLS_NPX` as stated. Every miss lands in `searched` so the refusal names where it looked.
2. **Fail closed without dying.** No absolute npx → the existing replacement-entry error ("delay the upgrade, keep serving"). The repoint independently refuses any relative command *before* writing anything — an upgrade may wait; a unit is never poisoned.
3. **Supervised boots heal already-poisoned hosts.** A daemon starting under the unit rewrites a drop-in whose `ExecStart` command is relative with its own absolute invocation + `daemon-reload` — gated on the drop-in naming the socket this process serves, so a test or foreign-session daemon has no claim (`foreign`, untouched).

Residual risk stated honestly: an absolute path into a prunable toolchain (mise upgrade, npx cache GC) can still go stale; recovery there is layer 3 plus client auto-spawn, and a stable-home bundle copy under `~/.red/redskilled/` remains a separate enhancement.

## Tests

- pinned dispatch resolves absolute (faked lookup), honors absolute `RED_SKILLS_NPX`, refuses with named search paths when nothing resolves
- repoint with a relative command throws before the drop-in exists, no `daemon-reload`
- heal: poisoned own-session drop-in rewritten + reloaded; absolute drop-in byte-for-byte untouched; absent reported; foreign-session drop-in never rewritten
- full `apps/redskilled` suite, typecheck, and repo invariants green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788988619&installation_model_id=20659&pr_number=3555&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3555&signature=0ca6deee005f7ffa73c3055928452a1ffbab52701367b04354f343ab5e290ae5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->