### PR TITLE
feat(redskilled): every ExecStart rides a bundle copy nothing prunes

### DIFF
--- a/.changeset/execstart-rides-the-stable-home.md
+++ b/.changeset/execstart-rides-the-stable-home.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Point every systemd `ExecStart` at a bundle copy nothing on the host prunes. The #3554 fix made unit commands absolute, but an absolute path into the npx cache or a mise toolchain dies the moment those are GC'd or pruned — the same dead unit wearing a longer name. Bundles now stabilize into `~/.red/redskilled/bundles/` (the daemon's own home) whenever their version is certain: the replacement resolver probes the stable home first and files cache hits into it, the supervised boot heal rewrites with the stable copy, and `provision --install-unit` / `unit install` install stable paths. Stabilization is an upgrade, never a precondition — no home, no certain version, or any filesystem refusal keeps the resolved entry untouched, and an env that names no HOME can never reach the real operator's home.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -63,6 +63,7 @@ import {
   type RedskilledUnitIO,
 } from "./supervision.js";
 import { isRedskilledSupervised } from "./self-replace.js";
+import { stabilizeRedskilledEntry } from "./stable-bundle.js";
 
 /**
  * Usage, as a CONSTANT — the answer owes nothing to the machine it is asked on.
@@ -498,7 +499,12 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
     // boot that would serve clients; the next supervised boot tries again.
     if (isRedskilledSupervised()) {
       try {
-        healRedskilledUnitDropIn({ socketPath: paths.socketPath });
+        healRedskilledUnitDropIn({
+          socketPath: paths.socketPath,
+          // The running version, so the rewrite can also stabilize the entry
+          // into the daemon home — the copy nothing on the host prunes.
+          version: values["daemon-version"] ?? readBuildInfo("redskilled").version,
+        });
       } catch {
         // The drop-in stays as it is.
       }
@@ -774,11 +780,17 @@ export async function runProvision(
       ? {}
       : { entryOverride: { serverCommand: io.client.serverCommand, serverArgs: io.client.serverArgs } }),
   });
-  const unit = values["install-unit"] && isResolvedRedskilledEntry(facts.entry)
+  // Stabilized when possible (#3554 closure): the installed unit outlives every
+  // cache, so its ExecStart points at the daemon-home copy when the resolved
+  // bundle's name states its version; anything else installs as resolved.
+  const unitEntry = isResolvedRedskilledEntry(facts.entry)
+    ? stabilizeRedskilledEntry(facts.entry, { homeDir })
+    : undefined;
+  const unit = values["install-unit"] && unitEntry != null
     ? await installRedskilledUserUnit({
         configHome: io.configHome ?? configHome(),
         unit: renderRedskilledUserUnit({
-          command: [facts.entry.command, ...facts.entry.args].join(" "),
+          command: [unitEntry.command, ...unitEntry.args].join(" "),
           socketPath: paths.socketPath,
         }),
       })

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -41,6 +41,11 @@ import { spawn } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { canonicalInvocation } from "@reddb-io/shared/canonical-invocation.js";
+import {
+  redskilledStableBundleDir,
+  stabilizeRedskilledEntry,
+  stableBundleHomeOf,
+} from "./stable-bundle.js";
 import { fetchPublishedVersionHorizon } from "@reddb-io/shared/bundle-fetch.js";
 import { compareSemver, parseSemver } from "@reddb-io/shared/self-update.js";
 import {
@@ -261,6 +266,7 @@ export function isRedskilledSupervised(env: NodeJS.ProcessEnv = process.env): bo
 
 /** Which candidate produced the successor — carried for diagnosis, never for logic. */
 export type RedskilledReplacementEntrySource =
+  | "stable-home"
   | "bundle-cache"
   | "caller-sibling-bundle"
   | "pinned-dispatch";
@@ -268,6 +274,8 @@ export type RedskilledReplacementEntrySource =
 export interface ResolvedRedskilledReplacementEntry {
   readonly command: string;
   readonly args: readonly string[];
+  /** The bundle file the command runs, absent for an npx dispatch. */
+  readonly entry?: string;
   readonly version: string;
   readonly source: RedskilledReplacementEntrySource;
   readonly searched: readonly string[];
@@ -320,13 +328,30 @@ export function requireRedskilledReplacementEntry(
   const bundle = `redskilled-${version}.bundle.min.mjs`;
 
   const searched: string[] = [];
-  const candidates: Array<[string, RedskilledReplacementEntrySource]> = [
-    [join(redskilledBundleCacheRoot(env), bundle), "bundle-cache"],
-  ];
+  // The stable home is probed FIRST: it is the one directory nothing on the
+  // host prunes, so a copy there outranks the same bytes in a GC'd cache. A
+  // cache or sibling hit is stabilized INTO the home on the way out, so the
+  // ExecStart a supervised repoint writes never depends on cache retention.
+  // An env that names no HOME scopes both away — it describes a host whose
+  // operator home this resolution has no business reaching.
+  const home = stableBundleHomeOf(env);
+  const candidates: Array<[string, RedskilledReplacementEntrySource]> = [];
+  if (home != null) candidates.push([join(redskilledStableBundleDir(home), bundle), "stable-home"]);
+  candidates.push([join(redskilledBundleCacheRoot(env), bundle), "bundle-cache"]);
   if (callerEntry) candidates.push([join(dirname(resolve(callerEntry)), bundle), "caller-sibling-bundle"]);
   for (const [path, source] of candidates) {
     searched.push(path);
-    if (exists(path)) return { command: execPath, args: [path], version, source, searched };
+    if (exists(path)) {
+      return {
+        ...stabilizeRedskilledEntry(
+          { command: execPath, args: [path], entry: path },
+          { version, homeDir: home, exists },
+        ),
+        version,
+        source,
+        searched,
+      };
+    }
   }
   if (env.RED_SKILLS_NO_PINNED_DISPATCH === "1") throw new RedskilledReplacementEntryError(version, searched);
   // The command must be ABSOLUTE: this entry is also what a supervised

--- a/apps/redskilled/src/stable-bundle.ts
+++ b/apps/redskilled/src/stable-bundle.ts
@@ -1,0 +1,140 @@
+/**
+ * stable-bundle — the ExecStart target nothing on the host prunes.
+ *
+ * The #3554 fix made every unit writer emit an ABSOLUTE command, which closed
+ * the 203/EXEC hole but left the target's durability to whoever owns the
+ * directory it lives in: the npx cache is GC'd, a mise toolchain directory
+ * vanishes on `mise prune`, and a repo checkout moves. An absolute path into a
+ * pruned cache is the same dead unit wearing a longer name — systemd starts
+ * nothing, the boot self-heal never runs because there is no boot, and the
+ * host is back to hand surgery.
+ *
+ * The closure is a copy the daemon owns: `~/.red/redskilled/bundles/`, inside
+ * the host-scoped home that outlives every cache on the machine. Every writer
+ * that is about to put a `node <bundle>` pair into an `ExecStart` first
+ * stabilizes the bundle into that directory and points the unit at the copy.
+ * Node itself stays the irreducible dependency — a host that deletes its node
+ * has nothing any path can save.
+ *
+ * **Version attribution must be certain before a copy is named.** A stable file
+ * claims its version in its filename, and a resolver later probes it BY that
+ * name — a copy filed under a version it is not would serve wrong code with a
+ * straight face. So stabilization happens only when the attribution is
+ * authoritative: a replacement entry resolved FOR a version, a running daemon
+ * copying its own entry under its own reported version, or a source file whose
+ * basename already carries its version. Local builds are never stabilized —
+ * `0.0.0-dev` is one name for many different bytes.
+ *
+ * **The home is never created here** (ADR 0130 Amendment 2: the provisioner and
+ * the canonical log writer are the creators). A host without the home keeps
+ * the entry it resolved — stabilization is an upgrade to durability, not a
+ * precondition, and it must never break the upgrade it decorates: every
+ * filesystem failure returns the original entry untouched.
+ */
+import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
+import { parseSemver } from "@reddb-io/shared/self-update.js";
+
+/** Where stable copies live, under the daemon's host-scoped home. PURE. */
+export function redskilledStableBundleDir(homeDir: string = homedir()): string {
+  return join(redskilledHomeDir(homeDir), "bundles");
+}
+
+/** The stable file name for one version. One spelling, shared with the probes. */
+export function redskilledStableBundleName(version: string): string {
+  return `redskilled-${version}.bundle.min.mjs`;
+}
+
+const VERSIONED_BASENAME = /^redskilled-(.+)\.bundle\.min\.mjs$/;
+
+export interface StabilizableRedskilledEntry {
+  readonly command: string;
+  readonly args: readonly string[];
+  /** The bundle file the command runs, when the entry is a `node <file>` pair. */
+  readonly entry?: string;
+}
+
+export interface StabilizeRedskilledEntryOptions {
+  /**
+   * The version the entry is KNOWN to run, from an authoritative source. Absent,
+   * only a source whose basename already carries its version is stabilized.
+   */
+  readonly version?: string;
+  /**
+   * The operator home the stable directory hangs off. `undefined` (an env that
+   * names no home) disables stabilization; `homedir()` when omitted entirely.
+   */
+  readonly homeDir?: string | undefined;
+  readonly exists?: (path: string) => boolean;
+}
+
+/**
+ * Point an entry at its stable copy, creating the copy when absent.
+ *
+ * Returns the entry unchanged whenever stabilization is not safely possible:
+ * no entry file (an npx dispatch), no certain version, a local build, a host
+ * without the daemon home, or any filesystem refusal. The caller never has to
+ * distinguish — the returned entry is always runnable.
+ */
+export function stabilizeRedskilledEntry<T extends StabilizableRedskilledEntry>(
+  entry: T,
+  options: StabilizeRedskilledEntryOptions = {},
+): T {
+  const source = entry.entry;
+  if (source == null) return entry;
+  // Only the BUNDLE is copyable: the packaged shim resolves its bundle relative
+  // to itself, so a copy of the shim alone is a file that runs nothing.
+  if (!/^redskilled(-.+)?\.bundle\.min\.mjs$/.test(basename(source))) return entry;
+  const named = VERSIONED_BASENAME.exec(basename(source))?.[1];
+  const version = options.version ?? named;
+  // Same boundary as `isLocalRedskilledBuild`: a prerelease or build-stamped
+  // version is one name for many different bytes, so it is never filed.
+  if (version == null || parseSemver(version) === null || /[-+]/.test(version)) return entry;
+  // A stated-but-undefined home (an env that names none) disables stabilization
+  // outright; only a caller that says nothing at all gets the process default.
+  const homeDir = "homeDir" in options ? options.homeDir : homedir();
+  if (homeDir == null) return entry;
+  const exists = options.exists ?? existsSync;
+  const stableDir = redskilledStableBundleDir(homeDir);
+  const target = join(stableDir, redskilledStableBundleName(version));
+  if (resolve(source) === resolve(target)) return entry;
+  try {
+    // Amendment 2: the home has its two creators, and this is neither — a host
+    // without one keeps the resolved entry and loses nothing but durability.
+    if (!statSync(redskilledHomeDir(homeDir)).isDirectory()) return entry;
+    if (!exists(target)) {
+      mkdirSync(stableDir, { recursive: true, mode: 0o700 });
+      const temporary = `${target}.${process.pid}.tmp`;
+      writeFileSync(temporary, readFileSync(source), { mode: 0o755 });
+      renameSync(temporary, target);
+    }
+  } catch {
+    return entry;
+  }
+  return {
+    ...entry,
+    entry: target,
+    args: entry.args.map((arg) => (resolve(arg) === resolve(source) ? target : arg)),
+  };
+}
+
+/**
+ * The operator home an env describes — and ONLY what it describes.
+ *
+ * Deliberately no `homedir()` fallback: resolution scoped by an injected env
+ * (every test, some clients) must never reach the REAL operator's home through
+ * a default — a test that stabilized a fake bundle into the live
+ * `~/.red/redskilled/bundles/` would poison the very directory upgrades trust
+ * (the #3554 heal grew its identity gate for the same reason). A production
+ * process resolves under `process.env`, where HOME is set.
+ */
+export function stableBundleHomeOf(env: NodeJS.ProcessEnv): string | undefined {
+  return env.HOME?.trim() || undefined;
+}
+
+/** Re-exported pattern so probes and tests share one idea of a versioned name. */
+export function stableBundleVersionOf(path: string): string | undefined {
+  return VERSIONED_BASENAME.exec(basename(path))?.[1] ?? undefined;
+}

--- a/apps/redskilled/src/supervision.ts
+++ b/apps/redskilled/src/supervision.ts
@@ -37,6 +37,7 @@ import {
   type RedskilledServeTarget,
 } from "./daemon-entry.js";
 import type { RedskilledPaths } from "./paths.js";
+import { stabilizeRedskilledEntry, stableBundleHomeOf } from "./stable-bundle.js";
 
 /** The unit's name — one per machine, matching the daemon's own scope. */
 export const REDSKILLED_UNIT_NAME = "redskilled.service";
@@ -90,7 +91,14 @@ export function planRedskilledUnit(
   options: PlanRedskilledUnitOptions = {},
 ): RedskilledUnitPlan {
   const env = options.env ?? process.env;
-  const entry = requireRedskilledEntry(options.override ?? {}, options.entryLookup ?? {});
+  // Stabilized when the bundle's name already states its version: the unit
+  // outlives every cache, so its ExecStart should too (#3554 closure). An
+  // unversioned or shim entry is used as resolved — durability is an upgrade,
+  // never a precondition.
+  const entry = stabilizeRedskilledEntry(
+    requireRedskilledEntry(options.override ?? {}, options.entryLookup ?? {}),
+    { homeDir: stableBundleHomeOf(env) },
+  );
   const args = [
     ...entry.args,
     ...redskilledServeArgv(paths, options.idleMs == null ? {} : { idleMs: options.idleMs }),
@@ -236,6 +244,12 @@ export function healRedskilledUnitDropIn(
     readonly execPath?: string;
     /** This process's entry and everything after it; `process.argv.slice(1)` by default. */
     readonly argv?: readonly string[];
+    /**
+     * The version this process reports itself as. Stated, it lets the rewrite
+     * stabilize the running entry into the daemon home first, so the healed
+     * `ExecStart` points at the copy nothing on the host prunes.
+     */
+    readonly version?: string;
     readonly readFile?: (path: string) => string;
     readonly run?: (argv: readonly string[]) => RedskilledUnitRunResult;
   } = {},
@@ -255,7 +269,18 @@ export function healRedskilledUnitDropIn(
     return { path, status: "foreign", command };
   }
   const execPath = options.execPath ?? process.execPath;
-  const argv = [execPath, ...(options.argv ?? process.argv.slice(1))];
+  const tail = options.argv ?? process.argv.slice(1);
+  // The healed target should also be the DURABLE one: the running entry is
+  // copied into the daemon home when its version is certain, so the rewrite
+  // does not trade a relative command for an absolute path into a GC'd cache.
+  const stabilized = tail.length === 0 ? undefined : stabilizeRedskilledEntry(
+    { command: execPath, args: tail, entry: tail[0] },
+    {
+      homeDir: stableBundleHomeOf(options.env ?? process.env),
+      ...(options.version == null ? {} : { version: options.version }),
+    },
+  );
+  const argv = [execPath, ...(stabilized?.args ?? tail)];
   const healed = [
     "[Service]",
     "ExecStart=",

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -26,7 +26,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { readRedskilledHostState } from "../src/client.js";
 import { socketAnswers, startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
@@ -106,7 +106,10 @@ child.on("exit", (code) => process.exit(code ?? 0));
     paths: resolveRedskilledPaths({ env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root }, runtimeDir: root }),
     cacheDir,
     publishedBundle,
-    env: { ...process.env, RED_SKILLS_CACHE_DIR: cacheDir },
+    // HOME is scoped to the fixture: entry stabilization files bundles under
+    // the env's home, and a test env reaching the REAL ~/.red/redskilled/
+    // would poison the operator's stable-bundle directory with fake versions.
+    env: { ...process.env, HOME: root, RED_SKILLS_CACHE_DIR: cacheDir },
   };
 }
 
@@ -590,7 +593,10 @@ describe("the idle boundary, the only check a quiet host ever reaches", () => {
 
     // One read, at the boundary, and the successor runs the published version.
     expect(probes).toBe(1);
-    expect(spawns[0]).toContain(publishedBundle);
+    // The successor may run the stable-home copy of the published bundle —
+    // same bytes, the directory nothing prunes — so the pin is the VERSIONED
+    // basename, which both locations share and no other version can wear.
+    expect(spawns[0].join(" ")).toContain(basename(publishedBundle));
     expect(daemon.hostState().upgrade.replacement).toBe("in-progress");
     // It let go first, so the successor can take the session.
     expect(await socketAnswers(paths.socketPath)).toBe(false);
@@ -765,7 +771,10 @@ describe("the working daemon, which reaches no idle boundary at all", () => {
     expect(daemon.evaluateIdle()).toBe("held-by-registrations");
     expect(await until(async () => spawns.length > 0, 5_000)).toBe(true);
 
-    expect(spawns[0]).toContain(publishedBundle);
+    // The successor may run the stable-home copy of the published bundle —
+    // same bytes, the directory nothing prunes — so the pin is the VERSIONED
+    // basename, which both locations share and no other version can wear.
+    expect(spawns[0].join(" ")).toContain(basename(publishedBundle));
     expect(daemon.hostState().upgrade.replacement).toBe("in-progress");
     expect(daemon.hostState().upgrade.checks).toBeGreaterThan(0);
     // It let go of the session first, exactly as the idle route does.
@@ -791,7 +800,10 @@ describe("the working daemon, which reaches no idle boundary at all", () => {
     hold(daemon, paths.runtimeDir);
 
     expect(await until(async () => spawns.length > 0, 5_000)).toBe(true);
-    expect(spawns[0]).toContain(publishedBundle);
+    // The successor may run the stable-home copy of the published bundle —
+    // same bytes, the directory nothing prunes — so the pin is the VERSIONED
+    // basename, which both locations share and no other version can wear.
+    expect(spawns[0].join(" ")).toContain(basename(publishedBundle));
   });
 
   it("owes a successor no boot look, so a mis-resolving one cannot spin", async () => {
@@ -954,7 +966,10 @@ describe("a read the registry never answers", () => {
     running.push(daemon);
 
     expect(await daemon.checkForReplacement()).toMatchObject({ act: "replace", to: PUBLISHED_VERSION });
-    expect(spawns[0]).toContain(publishedBundle);
+    // The successor may run the stable-home copy of the published bundle —
+    // same bytes, the directory nothing prunes — so the pin is the VERSIONED
+    // basename, which both locations share and no other version can wear.
+    expect(spawns[0].join(" ")).toContain(basename(publishedBundle));
   });
 
   it("stays unknown when the host holds nothing either", async () => {

--- a/apps/redskilled/tests/stable-bundle.test.ts
+++ b/apps/redskilled/tests/stable-bundle.test.ts
@@ -1,0 +1,144 @@
+// The ExecStart target nothing on the host prunes (#3554 closure).
+//
+// The absolute-command fix left the unit's durability to whoever owns the
+// directory the path points into: the npx cache is GC'd and a mise toolchain
+// vanishes on prune, so an absolute path into either is a dead unit wearing a
+// longer name. These checks pin the closure — a copy in the daemon's own home —
+// and, just as deliberately, every case where stabilization must REFUSE:
+// a copy filed under a version it is not would serve wrong code by name, and a
+// copied shim is a file that runs nothing.
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  redskilledStableBundleDir,
+  redskilledStableBundleName,
+  stabilizeRedskilledEntry,
+} from "../src/stable-bundle.js";
+import { requireRedskilledReplacementEntry } from "../src/self-replace.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(): Promise<{ homeDir: string; sourceDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-stable-"));
+  roots.push(root);
+  const homeDir = join(root, "home");
+  await mkdir(join(homeDir, ".red", "redskilled"), { recursive: true });
+  const sourceDir = join(root, "cache");
+  await mkdir(sourceDir, { recursive: true });
+  return { homeDir, sourceDir };
+}
+
+describe("stabilizing an entry into the daemon home", () => {
+  it("copies a versioned bundle once and points the entry at the copy", async () => {
+    const { homeDir, sourceDir } = await scratch();
+    const source = join(sourceDir, "redskilled-4.0.0.bundle.min.mjs");
+    await writeFile(source, "the published bytes");
+    const entry = { command: "/usr/bin/node", args: [source], entry: source };
+
+    const stable = stabilizeRedskilledEntry(entry, { homeDir });
+
+    const target = join(redskilledStableBundleDir(homeDir), redskilledStableBundleName("4.0.0"));
+    expect(stable.entry).toBe(target);
+    expect(stable.args).toEqual([target]);
+    expect(stable.command).toBe("/usr/bin/node");
+    expect(readFileSync(target, "utf8")).toBe("the published bytes");
+
+    // Idempotent: a second pass finds the copy and copies nothing.
+    const again = stabilizeRedskilledEntry(entry, { homeDir });
+    expect(again.entry).toBe(target);
+  });
+
+  it("returns an already-stable entry unchanged", async () => {
+    const { homeDir } = await scratch();
+    const stableDir = redskilledStableBundleDir(homeDir);
+    await mkdir(stableDir, { recursive: true });
+    const target = join(stableDir, redskilledStableBundleName("4.0.0"));
+    await writeFile(target, "already home");
+    const entry = { command: "/usr/bin/node", args: [target], entry: target };
+
+    expect(stabilizeRedskilledEntry(entry, { homeDir })).toEqual(entry);
+  });
+
+  it("refuses without a certain version, and refuses a local build", async () => {
+    const { homeDir, sourceDir } = await scratch();
+    const unversioned = join(sourceDir, "redskilled.bundle.min.mjs");
+    await writeFile(unversioned, "whose version?");
+    const entry = { command: "/usr/bin/node", args: [unversioned], entry: unversioned };
+
+    // No version stated and none in the name: unchanged, nothing copied.
+    expect(stabilizeRedskilledEntry(entry, { homeDir })).toEqual(entry);
+    // A stated version fixes that.
+    const stable = stabilizeRedskilledEntry(entry, { homeDir, version: "4.1.0" });
+    expect(stable.entry).toBe(join(redskilledStableBundleDir(homeDir), redskilledStableBundleName("4.1.0")));
+    // A local build is one name for many different bytes: never filed.
+    expect(stabilizeRedskilledEntry(entry, { homeDir, version: "0.0.0-dev" })).toEqual(entry);
+  });
+
+  it("refuses a shim and an npx dispatch — only the bundle is copyable", async () => {
+    const { homeDir, sourceDir } = await scratch();
+    const shim = join(sourceDir, "red-skills-redskilled");
+    await writeFile(shim, "resolves its bundle relative to itself");
+
+    const shimEntry = { command: "/usr/bin/node", args: [shim], entry: shim };
+    expect(stabilizeRedskilledEntry(shimEntry, { homeDir, version: "4.0.0" })).toEqual(shimEntry);
+
+    const dispatch = { command: "/usr/local/bin/npx", args: ["-y", "-p", "@reddb-io/red-skills@4.0.0"] };
+    expect(stabilizeRedskilledEntry(dispatch, { homeDir })).toEqual(dispatch);
+    expect(existsSync(redskilledStableBundleDir(homeDir))).toBe(false);
+  });
+
+  it("loses only durability on a host without the daemon home", async () => {
+    const { homeDir, sourceDir } = await scratch();
+    await rm(join(homeDir, ".red", "redskilled"), { recursive: true });
+    const source = join(sourceDir, "redskilled-4.0.0.bundle.min.mjs");
+    await writeFile(source, "bytes");
+    const entry = { command: "/usr/bin/node", args: [source], entry: source };
+
+    // Amendment 2: this is not a home creator. The entry stays runnable as is.
+    expect(stabilizeRedskilledEntry(entry, { homeDir })).toEqual(entry);
+    expect(existsSync(join(homeDir, ".red", "redskilled"))).toBe(false);
+  });
+});
+
+describe("the replacement resolver rides the stable home", () => {
+  it("prefers an existing stable copy over every cache", async () => {
+    const { homeDir, sourceDir } = await scratch();
+    const stableDir = redskilledStableBundleDir(homeDir);
+    await mkdir(stableDir, { recursive: true });
+    const stable = join(stableDir, redskilledStableBundleName("4.2.0"));
+    await writeFile(stable, "the durable copy");
+    const cached = join(sourceDir, "redskilled-4.2.0.bundle.min.mjs");
+    await writeFile(cached, "the prunable copy");
+
+    const entry = requireRedskilledReplacementEntry("4.2.0", {
+      env: { HOME: homeDir, RED_SKILLS_CACHE_DIR: sourceDir },
+      callerEntry: "",
+    });
+
+    expect(entry.source).toBe("stable-home");
+    expect(entry.args).toEqual([stable]);
+  });
+
+  it("stabilizes a cache hit on the way out, so the repoint writes the durable path", async () => {
+    const { homeDir, sourceDir } = await scratch();
+    const cached = join(sourceDir, "redskilled-4.3.0.bundle.min.mjs");
+    await writeFile(cached, "published bytes");
+
+    const entry = requireRedskilledReplacementEntry("4.3.0", {
+      env: { HOME: homeDir, RED_SKILLS_CACHE_DIR: sourceDir },
+      callerEntry: "",
+    });
+
+    const target = join(redskilledStableBundleDir(homeDir), redskilledStableBundleName("4.3.0"));
+    expect(entry.source).toBe("bundle-cache");
+    expect(entry.args).toEqual([target]);
+    expect(readFileSync(target, "utf8")).toBe("published bytes");
+  });
+});


### PR DESCRIPTION
Closes the residual risk stated in #3555 (Refs #3554).

## The gap

The absolute-command fix closed 203/EXEC but left the target's durability to whoever owns its directory: the npx cache is GC'd, a mise toolchain vanishes on prune, a checkout moves. An absolute path into a pruned cache is the same dead unit wearing a longer name — and the boot self-heal cannot run, because there is no boot.

## The closure

A copy the daemon owns: `~/.red/redskilled/bundles/`, inside the host-scoped home that outlives every cache on the machine (ADR 0130 Amendment 2 ownership; the home is never *created* here — no home just means no durability upgrade).

- The replacement resolver probes the stable home **first** and stabilizes a cache/sibling hit into it on the way out — successor spawn and supervised repoint both ride the durable copy.
- The supervised boot heal stabilizes the running entry under the daemon's own reported version before rewriting the drop-in.
- `unit install` and `provision --install-unit` install stable paths when the resolved bundle's name states its version.

**Version attribution must be certain before a copy is named** — a stable file is probed by its filename. Stabilized only from an authoritative source; prerelease/build-stamped versions are never filed, the shim is never copied, and every refusal returns the resolved entry untouched.

**Test containment:** `stableBundleHomeOf` has no `homedir()` fallback — an injected env that names no HOME disables stabilization outright, so no test env can ever reach the real operator's `~/.red/redskilled/`. The session fixture pins HOME to its scratch root for the same reason.

Node stays the irreducible dependency; a host that deletes its node has nothing any path can save.

## Tests

- `stable-bundle.test.ts`: copy-once + idempotent, already-stable untouched, refuses (no version / local build / shim / npx dispatch / absent home)
- replacement resolver: prefers existing stable copy (`stable-home` source), stabilizes cache hits on the way out
- successor-spawn assertions pin the versioned basename (shared by cache and stable paths, unique to the version)
- full `apps/redskilled` suite + repo invariants green (one pre-existing host-local flake in `daemon-reattach-survivor`, green in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788991374&installation_model_id=20659&pr_number=3557&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3557&signature=244a6b6933bdb3858f0ce517fa9c18ee205576b396f2a328b4f5df03beb4caa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->