### PR TITLE
chore: #3563 Statusline Bedrock segment and the ~5s micro-TTL for local git facts

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -14,7 +14,7 @@
 // else `.workspace.current_dir // .cwd`, else `process.cwd()`.
 
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { join, basename, dirname } from "node:path";
+import { join } from "node:path";
 // From the COMMAND module, never the CLI: cli.ts ends in a self-invocation
 // guard that is always true inside a single-file bundle, so importing it ships
 // a second argv-reading CLI inside every dev binary (#3546, canary catch).
@@ -23,16 +23,29 @@ import { configFile } from "@reddb-io/shared/red-paths.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { decode } from "@reddb-io/toon";
 import { readDevBundleCacheState } from "../core/bundle-version.js";
-import { type ProjectInput, type RspStatusInput, type StatuslinePreset } from "../core/statusline.js";
+import {
+  type ClaudeInput,
+  type ProjectInput,
+  type RspStatusInput,
+  type StatuslinePreset,
+} from "../core/statusline.js";
+import {
+  composeStatuslineLines,
+  renderStatuslineBedrock,
+  type StatuslineBedrockInput,
+} from "../core/statusline-bedrock.js";
 import { renderStatuslineLegend } from "../core/statusline-legend.js";
 import { loadConfig, getConfig } from "../core/config.js";
-import { git as gitExec } from "../runtime/exec.js";
 import { resolveRspConfig } from "../../../rsp/src/config.js";
 import { resolveResidentPaths } from "../../../rsp/src/resident-client.js";
 import {
+  collectStatuslineLocalGit,
   inferGitHubRepoSlug,
   refreshStatuslineCountCache,
   refreshStatuslineRepoCache,
+  resolveRepoBasename,
+  type StatuslineLocalGit,
+  type StatuslineLocalGitDeps,
 } from "../runtime/wire.js";
 import * as gitx from "../runtime/git.js";
 
@@ -262,20 +275,58 @@ export async function resolveProject(root: string): Promise<ProjectInput> {
   return withPointer;
 }
 
-async function resolveRepoBasename(root: string): Promise<string> {
-  const fallback = basename(root);
-  const commonDir = await gitExec(["rev-parse", "--path-format=absolute", "--git-common-dir"], { cwd: root });
-  if (commonDir.code !== 0) return fallback;
-  const gitCommonDir = commonDir.stdout.trim();
-  if (!gitCommonDir) return fallback;
-  return basename(dirname(gitCommonDir)) || fallback;
+/** The block-2/3 render inputs read straight off the Claude Code stdin payload.
+ * They are the freshest facts on the line — this render tick's, with no cache
+ * between them and the operator — and the reason the bedrock is stdin-owned. */
+function claudeInputFrom(payload: ClaudePayload): ClaudeInput {
+  return {
+    model: payload.model?.display_name,
+    effort: payload.effort?.level,
+    contextTokens: payload.context_window?.total_input_tokens,
+    contextPercent: payload.context_window?.used_percentage,
+    usage5h: payload.rate_limits?.five_hour?.used_percentage,
+    usage7d: payload.rate_limits?.seven_day?.used_percentage,
+  };
 }
 
 /**
- * `statusline "<project-root>"` — resolve the root and opt-out, then print the
- * shared redskilled render. Emits nothing (and exits 0) only when the project
- * opted out. An unreachable daemon emits its explicit absence line and still
- * exits 0; it never falls back to project collectors or the tracker.
+ * Resolve the bedrock's inputs: the stdin payload (free), the running bundle
+ * version and its cache state (file reads), and the local git facts (one micro-
+ * TTL'd read, {@link collectStatuslineLocalGit}). Nothing here touches the
+ * network or the daemon — that is the whole membership rule of the segment.
+ */
+export async function resolveStatuslineBedrock(
+  root: string,
+  payload: ClaudePayload,
+  gitDeps: StatuslineLocalGitDeps = {},
+): Promise<StatuslineBedrockInput> {
+  const version = readBuildInfo("dev").version;
+  const bundleCache = readDevBundleCacheState(version);
+  const git: StatuslineLocalGit = await collectStatuslineLocalGit(root, gitDeps);
+  const project: ProjectInput = { basename: git.basename, version };
+  if (git.branch) project.branch = git.branch;
+  else if (git.detachedSha) project.detachedSha = git.detachedSha;
+  if (bundleCache.laneNewestVersion !== undefined) {
+    project.latestCachedVersion = bundleCache.laneNewestVersion;
+  }
+  if (bundleCache.pointerVersion) project.pointerVersion = bundleCache.pointerVersion;
+  return {
+    project,
+    claude: claudeInputFrom(payload),
+    localDiff: { localAdded: git.localAdded, localRemoved: git.localRemoved },
+  };
+}
+
+/**
+ * `statusline "<project-root>"` — resolve the root and opt-out, render the
+ * bedrock, then append the shared redskilled render as the tail. Emits nothing
+ * (and exits 0) only when the project opted out.
+ *
+ * The bedrock renders FIRST and unconditionally (ADR 0141 §1): an unreachable
+ * daemon costs the operator the tail, never the model, context, subscription
+ * windows, branch, local diff, or bundle version their own machine already
+ * holds. The tail is still the daemon's stated absence, never a fallback to
+ * project collectors or the tracker (#3546).
  */
 export async function statuslineCommand(
   args: string[],
@@ -306,12 +357,20 @@ export async function statuslineCommand(
   // the document's most useful information, so the compatibility spelling is a
   // no-op. All other flags are taste owned by the redskilled renderer.
   const daemonArgs = args.filter((arg) => arg !== rootArg && arg !== "--no-workers");
-  return runRedskilledStatusline(daemonArgs, {
+  const bedrock = renderStatuslineBedrock(await resolveStatuslineBedrock(root, payload));
+  // The tail is buffered rather than streamed so the bedrock can LEAD the header
+  // line the daemon opens with — one line, two segments, in that order.
+  const tail: string[] = [];
+  const code = await runRedskilledStatusline(daemonArgs, {
     cwd: root,
     write: (line) => {
-      stdout.write(line);
+      tail.push(line);
     },
   });
+  for (const line of composeStatuslineLines(bedrock, tail.join("").split("\n"))) {
+    stdout.write(`${line}\n`);
+  }
+  return code;
 }
 
 export async function statuslineRefreshCountsCommand(args: string[], cwd = process.cwd()): Promise<number> {

--- a/apps/dev/src/core/statusline-bedrock.ts
+++ b/apps/dev/src/core/statusline-bedrock.ts
@@ -1,0 +1,103 @@
+// core/statusline-bedrock — the Statusline Bedrock segment (ADR 0141 §1).
+//
+// The bedrock is everything the line can answer with ZERO network and ZERO
+// daemon: the Claude Code stdin payload (model·effort, context tokens/percent,
+// the `5h=`/`7d=` subscription windows), local git (repo basename, branch, local
+// diff), and the running bundle version. It renders on EVERY invocation — a
+// daemon that is down, connecting, or registering nothing costs the operator the
+// tail, never the facts their own machine already holds.
+//
+// The render is PURE, like its sibling in `core/statusline.ts`: the caller
+// injects already-resolved inputs and this module assembles text. The stdin
+// parse, the build-info read, and the micro-TTL git read live in the adapter
+// (`commands/statusline.ts`) and the wire (`runtime/wire/statusline-git.ts`).
+//
+// **Bedrock and tail are INTERNAL segments, not a configuration surface**
+// (ADR 0141 §5). Drawing the seam now is what lets operator-composable segment
+// selection land later without redrawing data ownership; the layout is fixed and
+// nothing reads a setting to change it.
+
+import {
+  renderContextBlock,
+  renderModelBlock,
+  renderProjectBlock,
+  renderProjectVersionLabel,
+  renderUsageBlock,
+  type ClaudeInput,
+  type ProjectInput,
+} from "./statusline.js";
+
+/** The bedrock's local git diff — the LOCAL branch delta vs the base ref. */
+export interface LocalDiffInput {
+  localAdded?: number;
+  localRemoved?: number;
+}
+
+/** Everything the bedrock renders, already resolved by the adapter. */
+export interface StatuslineBedrockInput {
+  project: ProjectInput;
+  claude?: ClaudeInput;
+  localDiff?: LocalDiffInput;
+}
+
+/**
+ * `loc=+A -R` for the LOCAL branch diff, each half emitted only when non-zero
+ * and the whole token dropped when both are — the no-zero-noise rule the AFK and
+ * repo blocks already follow. This is the same `loc=` the repo block used to
+ * carry; ownership moved, spelling did not.
+ */
+export function renderLocalDiffBlock(diff: LocalDiffInput | undefined): string | null {
+  if (!diff) return null;
+  const parts: string[] = [];
+  if (diff.localAdded && diff.localAdded > 0) parts.push(`+${diff.localAdded}`);
+  if (diff.localRemoved && diff.localRemoved > 0) parts.push(`-${diff.localRemoved}`);
+  return parts.length ? `loc=${parts.join(" ")}` : null;
+}
+
+/**
+ * `basename (branch) v<version>` — the project block with the bundle version
+ * ALWAYS shown. The header's own project block shows the version only when a
+ * newer bundle is cached; the bedrock states it unconditionally, because "which
+ * version is producing this line" is precisely the question asked when the rest
+ * of the line is missing.
+ */
+export function renderBedrockProjectBlock(project: ProjectInput): string {
+  const withoutVersion: ProjectInput = { ...project };
+  delete withoutVersion.version;
+  const base = renderProjectBlock(withoutVersion);
+  const version = renderProjectVersionLabel(project, "always");
+  return version ? `${base} ${version}` : base;
+}
+
+/**
+ * The bedrock segment, blocks joined by ` · ` exactly like the rest of the line.
+ * Never empty: the project block always renders, so a daemon-absent invocation
+ * still puts the operator's own facts on screen.
+ */
+export function renderStatuslineBedrock(input: StatuslineBedrockInput): string {
+  const sections: string[] = [renderBedrockProjectBlock(input.project)];
+  const model = renderModelBlock(input.claude);
+  if (model !== null) sections.push(model);
+  const context = renderContextBlock(input.claude);
+  if (context !== null) sections.push(context);
+  const usage = renderUsageBlock(input.claude);
+  if (usage !== null) sections.push(usage);
+  const localDiff = renderLocalDiffBlock(input.localDiff);
+  if (localDiff !== null) sections.push(localDiff);
+  return sections.join(" · ");
+}
+
+/**
+ * Join the bedrock to the daemon tail: the bedrock LEADS the header line and the
+ * tail's remaining lines follow untouched. A tail that produced nothing — an
+ * unreachable daemon, an empty document — leaves the bedrock alone on the line
+ * rather than an empty separator, because the seam is a composition rule, not a
+ * layout the tail can veto.
+ */
+export function composeStatuslineLines(bedrock: string, tail: readonly string[]): string[] {
+  const lines = [...tail];
+  while (lines.length > 0 && (lines[lines.length - 1] ?? "").trim() === "") lines.pop();
+  const [head, ...rest] = lines;
+  const header = head && head.trim() !== "" ? `${bedrock} · ${head}` : bedrock;
+  return [header, ...rest];
+}

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -43,6 +43,14 @@ export {
   refreshStatuslineRepoCache,
 } from "./wire/statusline.js";
 
+export type { StatuslineLocalGit, StatuslineLocalGitDeps } from "./wire/statusline-git.js";
+export {
+  STATUSLINE_GIT_MICRO_TTL_MS,
+  STATUSLINE_GIT_DEADLINE_MS,
+  collectStatuslineLocalGit,
+  resolveRepoBasename,
+} from "./wire/statusline-git.js";
+
 export { collectStatuslineDocs, collectDocsSweepInput, landDocsSweep } from "./wire/docs.js";
 
 export type { ReapInputs } from "./wire/reap.js";

--- a/apps/dev/src/runtime/wire/paths.ts
+++ b/apps/dev/src/runtime/wire/paths.ts
@@ -58,6 +58,8 @@ export interface AfkPaths {
   statuslineCachePath: string;
   /** Repo-global diffstat cache (statusline state lane). */
   statuslineRepoCachePath: string;
+  /** Local git bedrock facts under their own micro-TTL (statusline state lane). */
+  statuslineGitCachePath: string;
   /** Branch lock (state tier root). */
   branchLockPath: string;
   /** Global land lock (tmp tier — disposable coordination). */
@@ -110,6 +112,7 @@ export function afkPaths(root: string): AfkPaths {
     runnerCircuitDir: join(supervisorRuntime, "runner-circuit"),
     statuslineCachePath: join(statusline, "statusline-cache.toon"),
     statuslineRepoCachePath: join(statusline, "statusline-repo-cache.toon"),
+    statuslineGitCachePath: join(statusline, "statusline-git-cache.toon"),
     branchLockPath: rp.branchLockFile(root),
     landLockPath: join(tmp, "afk-land.lock"),
     claimsDir: rp.claimsDir(root),

--- a/apps/dev/src/runtime/wire/statusline-git.ts
+++ b/apps/dev/src/runtime/wire/statusline-git.ts
@@ -1,0 +1,197 @@
+// statusline-git — the LOCAL git facts of the Statusline Bedrock, under their
+// own ~5s micro-TTL (ADR 0141 §1).
+//
+// These facts used to ride the 15-minute remote-counter cache, which coupled a
+// cheap local subprocess to a network-bound TTL: the branch you just switched to
+// stayed wrong for a quarter of an hour because three `gh` calls were expensive.
+// Ownership is the split — local git answers with zero network and zero daemon,
+// so it gets a TTL sized to the operator's perception (~5s) rather than to
+// GitHub's rate limit.
+//
+// The micro-TTL is what keeps that cheap: Claude Code re-renders the statusline
+// on every tick, and a subprocess per tick is a subprocess per keystroke burst.
+// Within the TTL the render is a single file read; past it, one bounded refresh.
+// The refresh carries a deadline for the same reason the remote caches do — a
+// pathological `git diff` in a huge worktree must cost the operator freshness,
+// never a frozen prompt (#3546): a miss serves the last-known facts and lets the
+// in-flight read rewrite the cache for the next render.
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { basename, dirname } from "node:path";
+import { type JsonValue as ToonValue } from "@reddb-io/toon";
+import { encodeDevSnapshotToon } from "../../core/toon-snapshot.js";
+import { git as gitExec } from "../exec.js";
+import * as gitx from "../git.js";
+import { afkPaths } from "./paths.js";
+import { decodeCacheDocument, withTimeout } from "./statusline-cache.js";
+
+/**
+ * The bedrock's local-git freshness window. ~5s is the operator's perception
+ * floor: below it a human cannot tell the difference, above it a branch switch
+ * lingers on screen. It is deliberately three orders of magnitude under
+ * `STATUSLINE_CACHE_TTL_S` — that TTL exists to ration a network, this one to
+ * ration a fork.
+ */
+export const STATUSLINE_GIT_MICRO_TTL_MS = 5_000;
+
+/**
+ * The refresh deadline. A read that outlives it serves the previous facts and
+ * finishes into the cache, so the next render is fresh and this one is fast.
+ */
+export const STATUSLINE_GIT_DEADLINE_MS = 400;
+
+/** The local git facts the bedrock renders: no network, no daemon, no tracker. */
+export interface StatuslineLocalGit {
+  /** The repository's own basename — the worktree's, not the checkout dir's. */
+  basename: string;
+  /** Current branch, absent when HEAD is detached or the dir is not a repo. */
+  branch?: string;
+  /** Short HEAD sha, rendered only when there is no branch. */
+  detachedSha?: string;
+  /** Local branch insertions vs the base ref (committed + uncommitted). */
+  localAdded: number;
+  /** Local branch deletions vs the base ref (committed + uncommitted). */
+  localRemoved: number;
+}
+
+interface StatuslineGitCache extends StatuslineLocalGit {
+  /** The base ref the diff was measured against; a change invalidates the entry. */
+  baseRef: string;
+  /** Epoch milliseconds the facts were read. Milliseconds, because the TTL is. */
+  tsMs: number;
+}
+
+/** Injection seams. Production passes none; the micro-TTL test fakes fs + clock. */
+export interface StatuslineLocalGitDeps {
+  nowMs?: () => number;
+  ttlMs?: number;
+  deadlineMs?: number;
+  baseRef?: string;
+  /** Reads the cache document, or null when there is none. */
+  readCache?: (path: string) => string | null;
+  /** Writes the cache document. Best-effort in production. */
+  writeCache?: (path: string, text: string) => void;
+  /** The ONE git-subprocess reach — the thing the micro-TTL exists to skip. */
+  readGitFacts?: (root: string, baseRef: string) => Promise<StatuslineLocalGit>;
+}
+
+function readCacheFile(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function writeCacheFile(path: string, text: string): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, text, "utf8");
+    renameSync(tmp, path);
+  } catch {
+    // best-effort: a cache that cannot be written costs a subprocess, not a render
+  }
+}
+
+function decodeGitCache(text: string | null): StatuslineGitCache | null {
+  if (text === null) return null;
+  try {
+    const parsed = decodeCacheDocument(text) as Partial<StatuslineGitCache>;
+    const cached: StatuslineGitCache = {
+      basename: typeof parsed.basename === "string" ? parsed.basename : "",
+      localAdded: Number(parsed.localAdded ?? 0),
+      localRemoved: Number(parsed.localRemoved ?? 0),
+      baseRef: typeof parsed.baseRef === "string" ? parsed.baseRef : "",
+      tsMs: Number(parsed.tsMs ?? 0),
+    };
+    if (typeof parsed.branch === "string" && parsed.branch !== "") cached.branch = parsed.branch;
+    if (typeof parsed.detachedSha === "string" && parsed.detachedSha !== "") {
+      cached.detachedSha = parsed.detachedSha;
+    }
+    return cached.basename === "" ? null : cached;
+  } catch {
+    return null;
+  }
+}
+
+function factsOf(cached: StatuslineGitCache): StatuslineLocalGit {
+  const facts: StatuslineLocalGit = {
+    basename: cached.basename,
+    localAdded: cached.localAdded,
+    localRemoved: cached.localRemoved,
+  };
+  if (cached.branch) facts.branch = cached.branch;
+  if (cached.detachedSha) facts.detachedSha = cached.detachedSha;
+  return facts;
+}
+
+/**
+ * The repository's basename — resolved through `--git-common-dir` so a worktree
+ * under `.red/tmp/worktrees/<slug>` reads as the repo it belongs to rather than
+ * as its own scratch directory name. Falls back to the path basename whenever
+ * git cannot answer (not a repo, git absent).
+ */
+export async function resolveRepoBasename(root: string): Promise<string> {
+  const fallback = basename(root);
+  const commonDir = await gitExec(["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+    cwd: root,
+  });
+  if (commonDir.code !== 0) return fallback;
+  const gitCommonDir = commonDir.stdout.trim();
+  if (!gitCommonDir) return fallback;
+  return basename(dirname(gitCommonDir)) || fallback;
+}
+
+async function readGitFactsFromSubprocesses(
+  root: string,
+  baseRef: string,
+): Promise<StatuslineLocalGit> {
+  const ctx: gitx.GitContext = { cwd: root };
+  const [repoBasename, branch, sha, diff] = await Promise.all([
+    resolveRepoBasename(root),
+    gitx.currentBranch(ctx).catch(() => ""),
+    gitx.headShortSha(ctx).catch(() => ""),
+    gitx.diffstatShortstat(ctx, baseRef).catch(() => ({ added: 0, removed: 0 })),
+  ]);
+  const facts: StatuslineLocalGit = {
+    basename: repoBasename,
+    localAdded: diff.added,
+    localRemoved: diff.removed,
+  };
+  if (branch) facts.branch = branch;
+  else if (sha) facts.detachedSha = sha;
+  return facts;
+}
+
+/**
+ * The bedrock's local git facts, served from the micro-TTL entry in the
+ * statusline state lane. Within {@link STATUSLINE_GIT_MICRO_TTL_MS} of the last
+ * read this is ONE file read and NO subprocess; past it, one bounded refresh
+ * that rewrites the entry. Fail-open at every step: a broken cache, a failed
+ * read, or a missed deadline degrades to the last-known facts, and with neither
+ * to the path basename — never to a thrown render.
+ */
+export async function collectStatuslineLocalGit(
+  root: string,
+  deps: StatuslineLocalGitDeps = {},
+): Promise<StatuslineLocalGit> {
+  const now = (deps.nowMs ?? Date.now)();
+  const ttlMs = deps.ttlMs ?? STATUSLINE_GIT_MICRO_TTL_MS;
+  const baseRef = deps.baseRef ?? "origin/main";
+  const path = afkPaths(root).statuslineGitCachePath;
+  const cached = decodeGitCache((deps.readCache ?? readCacheFile)(path));
+  const ageMs = cached ? now - cached.tsMs : Number.POSITIVE_INFINITY;
+  if (cached && cached.baseRef === baseRef && ageMs >= 0 && ageMs < ttlMs) return factsOf(cached);
+
+  const write = deps.writeCache ?? writeCacheFile;
+  const refresh = (deps.readGitFacts ?? readGitFactsFromSubprocesses)(root, baseRef)
+    .then((facts) => {
+      write(path, encodeDevSnapshotToon({ ...facts, baseRef, tsMs: now } as unknown as ToonValue));
+      return facts;
+    })
+    .catch(() => null);
+  const refreshed = await withTimeout(refresh, deps.deadlineMs ?? STATUSLINE_GIT_DEADLINE_MS, null);
+  if (refreshed) return refreshed;
+  return cached ? factsOf(cached) : { basename: basename(root), localAdded: 0, localRemoved: 0 };
+}

--- a/apps/dev/tests/statusline-bedrock.test.ts
+++ b/apps/dev/tests/statusline-bedrock.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  composeStatuslineLines,
+  renderBedrockProjectBlock,
+  renderLocalDiffBlock,
+  renderStatuslineBedrock,
+} from "../src/core/statusline-bedrock.js";
+import { resolveStatuslineBedrock } from "../src/commands/statusline.js";
+import type { StatuslineLocalGit, StatuslineLocalGitDeps } from "../src/runtime/wire/statusline-git.js";
+
+const PROJECT = { basename: "red-skills", branch: "afk/3563-bedrock", version: "3.12.13" };
+
+const CLAUDE = {
+  model: "Opus",
+  effort: "high",
+  contextTokens: 47_000,
+  contextPercent: 24,
+  usage5h: 23,
+  usage7d: 41,
+};
+
+describe("statusline bedrock render", () => {
+  it("renders every zero-network fact in one segment", () => {
+    expect(
+      renderStatuslineBedrock({
+        project: PROJECT,
+        claude: CLAUDE,
+        localDiff: { localAdded: 142, localRemoved: 36 },
+      }),
+    ).toBe("red-skills (afk/3563-bedrock) v3.12.13 · Opus·high · 47k 24% · 5h=23% 7d=41% · loc=+142 -36");
+  });
+
+  it("states the running version even when no newer bundle is cached", () => {
+    // The header's project block shows the version only on an update; the
+    // bedrock always does — "which version drew this line" is exactly the
+    // question asked when the rest of the line is missing.
+    expect(renderBedrockProjectBlock(PROJECT)).toBe("red-skills (afk/3563-bedrock) v3.12.13");
+    expect(renderBedrockProjectBlock({ ...PROJECT, latestCachedVersion: "3.13.0" })).toBe(
+      "red-skills (afk/3563-bedrock) v3.12.13*",
+    );
+  });
+
+  it("keeps rendering when the stdin payload carries nothing", () => {
+    expect(renderStatuslineBedrock({ project: { basename: "red-skills" } })).toBe("red-skills");
+  });
+
+  it("renders a detached head and drops a zero local diff", () => {
+    expect(
+      renderStatuslineBedrock({
+        project: { basename: "red-skills", detachedSha: "7658ad2", version: "3.12.13" },
+        localDiff: { localAdded: 0, localRemoved: 0 },
+      }),
+    ).toBe("red-skills (detached 7658ad2) v3.12.13");
+  });
+
+  it("emits each half of the local diff only when non-zero", () => {
+    expect(renderLocalDiffBlock({ localAdded: 5, localRemoved: 0 })).toBe("loc=+5");
+    expect(renderLocalDiffBlock({ localAdded: 0, localRemoved: 7 })).toBe("loc=-7");
+    expect(renderLocalDiffBlock({})).toBeNull();
+  });
+});
+
+describe("bedrock/tail composition", () => {
+  it("leads the daemon's header line and leaves its remaining lines untouched", () => {
+    expect(composeStatuslineLines("bedrock", ["header", "worker one", "worker two", ""])).toEqual([
+      "bedrock · header",
+      "worker one",
+      "worker two",
+    ]);
+  });
+
+  it("stands alone when the tail produced nothing", () => {
+    expect(composeStatuslineLines("bedrock", [""])).toEqual(["bedrock"]);
+    expect(composeStatuslineLines("bedrock", [])).toEqual(["bedrock"]);
+  });
+});
+
+describe("bedrock input resolution", () => {
+  function gitDeps(facts: StatuslineLocalGit): StatuslineLocalGitDeps {
+    const files = new Map<string, string>();
+    return {
+      nowMs: () => 1_000,
+      readCache: (path) => files.get(path) ?? null,
+      writeCache: (path, text) => {
+        files.set(path, text);
+      },
+      readGitFacts: async () => facts,
+    };
+  }
+
+  it("builds the project block from the micro-TTL git facts, not from the cwd", async () => {
+    const input = await resolveStatuslineBedrock(
+      "/tmp/red-skills/.red/tmp/worktrees/manual/some-slug",
+      { model: { display_name: "Opus" }, effort: { level: "high" } },
+      gitDeps({ basename: "red-skills", branch: "main", localAdded: 4, localRemoved: 1 }),
+    );
+
+    expect(input.project.basename).toBe("red-skills");
+    expect(input.project.branch).toBe("main");
+    expect(input.project.version).toBeTruthy();
+    expect(input.localDiff).toEqual({ localAdded: 4, localRemoved: 1 });
+    expect(input.claude).toMatchObject({ model: "Opus", effort: "high" });
+  });
+
+  it("carries the stdin context and subscription windows through untouched", async () => {
+    const input = await resolveStatuslineBedrock(
+      "/tmp/red-skills",
+      {
+        context_window: { total_input_tokens: 47_000, used_percentage: 24 },
+        rate_limits: { five_hour: { used_percentage: 23 }, seven_day: { used_percentage: 41 } },
+      },
+      gitDeps({ basename: "red-skills", localAdded: 0, localRemoved: 0 }),
+    );
+
+    expect(input.claude).toMatchObject({
+      contextTokens: 47_000,
+      contextPercent: 24,
+      usage5h: 23,
+      usage7d: 41,
+    });
+  });
+});

--- a/apps/dev/tests/statusline-git-micro-ttl.test.ts
+++ b/apps/dev/tests/statusline-git-micro-ttl.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { decode } from "@reddb-io/toon";
+import {
+  STATUSLINE_GIT_MICRO_TTL_MS,
+  collectStatuslineLocalGit,
+  type StatuslineLocalGit,
+  type StatuslineLocalGitDeps,
+} from "../src/runtime/wire/statusline-git.js";
+import { afkPaths } from "../src/runtime/wire/paths.js";
+
+const ROOT = "/tmp/statusline-micro-ttl-fixture";
+
+/**
+ * A fake filesystem and a fake clock, so the micro-TTL is proven by the ONE
+ * thing it exists to control: how often the git subprocess reach is entered.
+ * Nothing here touches a disk or a real `git`.
+ */
+function harness(facts: Partial<StatuslineLocalGit> = {}) {
+  const files = new Map<string, string>();
+  let now = 1_000_000;
+  let gitReads = 0;
+  const deps: StatuslineLocalGitDeps = {
+    nowMs: () => now,
+    readCache: (path) => files.get(path) ?? null,
+    writeCache: (path, text) => {
+      files.set(path, text);
+    },
+    readGitFacts: async () => {
+      gitReads += 1;
+      return {
+        basename: "red-skills",
+        branch: `branch-${gitReads}`,
+        localAdded: 12,
+        localRemoved: 3,
+        ...facts,
+      };
+    },
+  };
+  return {
+    deps,
+    files,
+    gitReads: () => gitReads,
+    advance: (ms: number) => {
+      now += ms;
+    },
+  };
+}
+
+describe("statusline bedrock local git — the ~5s micro-TTL", () => {
+  it("reads git once and serves every render inside the TTL from the cache", async () => {
+    const h = harness();
+
+    const first = await collectStatuslineLocalGit(ROOT, h.deps);
+    expect(h.gitReads()).toBe(1);
+    expect(first).toEqual({
+      basename: "red-skills",
+      branch: "branch-1",
+      localAdded: 12,
+      localRemoved: 3,
+    });
+
+    // Claude Code re-renders on every tick: the ticks inside the window must
+    // cost a file read, never a fork.
+    h.advance(1);
+    expect(await collectStatuslineLocalGit(ROOT, h.deps)).toEqual(first);
+    h.advance(STATUSLINE_GIT_MICRO_TTL_MS - 2);
+    expect(await collectStatuslineLocalGit(ROOT, h.deps)).toEqual(first);
+    expect(h.gitReads()).toBe(1);
+  });
+
+  it("refreshes once the TTL has passed", async () => {
+    const h = harness();
+
+    await collectStatuslineLocalGit(ROOT, h.deps);
+    h.advance(STATUSLINE_GIT_MICRO_TTL_MS);
+    const refreshed = await collectStatuslineLocalGit(ROOT, h.deps);
+
+    expect(h.gitReads()).toBe(2);
+    expect(refreshed.branch).toBe("branch-2");
+  });
+
+  it("writes the entry as TOON in the statusline state lane", async () => {
+    const h = harness();
+
+    await collectStatuslineLocalGit(ROOT, h.deps);
+
+    const path = afkPaths(ROOT).statuslineGitCachePath;
+    expect(path).toBe(`${ROOT}/.red/state/statusline/statusline-git-cache.toon`);
+    const written = h.files.get(path) ?? "";
+    expect(written.startsWith("{")).toBe(false);
+    expect(decode(written)).toMatchObject({ basename: "red-skills", baseRef: "origin/main", tsMs: 1_000_000 });
+  });
+
+  it("invalidates the entry when the base ref changes", async () => {
+    const h = harness();
+
+    await collectStatuslineLocalGit(ROOT, h.deps);
+    const rebased = await collectStatuslineLocalGit(ROOT, { ...h.deps, baseRef: "origin/release" });
+
+    expect(h.gitReads()).toBe(2);
+    expect(rebased.branch).toBe("branch-2");
+  });
+
+  it("serves the last-known facts when the git read fails", async () => {
+    const h = harness();
+    await collectStatuslineLocalGit(ROOT, h.deps);
+    h.advance(STATUSLINE_GIT_MICRO_TTL_MS);
+
+    const served = await collectStatuslineLocalGit(ROOT, {
+      ...h.deps,
+      readGitFacts: async () => {
+        throw new Error("git is not on PATH");
+      },
+    });
+
+    expect(served.branch).toBe("branch-1");
+    expect(served.localAdded).toBe(12);
+  });
+
+  it("degrades to the path basename with neither a cache nor a working git", async () => {
+    const h = harness();
+
+    const served = await collectStatuslineLocalGit(ROOT, {
+      ...h.deps,
+      readGitFacts: async () => {
+        throw new Error("not a repository");
+      },
+    });
+
+    expect(served).toEqual({
+      basename: "statusline-micro-ttl-fixture",
+      localAdded: 0,
+      localRemoved: 0,
+    });
+  });
+
+  it("serves the last-known facts when the refresh misses its deadline", async () => {
+    const h = harness();
+    await collectStatuslineLocalGit(ROOT, h.deps);
+    h.advance(STATUSLINE_GIT_MICRO_TTL_MS);
+
+    const served = await collectStatuslineLocalGit(ROOT, {
+      ...h.deps,
+      deadlineMs: 1,
+      readGitFacts: () => new Promise<StatuslineLocalGit>(() => undefined),
+    });
+
+    expect(served.branch).toBe("branch-1");
+  });
+});

--- a/apps/dev/tests/statusline-render-path.test.ts
+++ b/apps/dev/tests/statusline-render-path.test.ts
@@ -2,12 +2,21 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { directCollector, runStatusline } = vi.hoisted(() => ({
+const { directCollector, localGit, runStatusline } = vi.hoisted(() => ({
   directCollector: vi.fn(() => {
     throw new Error("the render path called a project collector");
   }),
+  // The bedrock's ONE collector: local git under its micro-TTL. Zero network,
+  // zero daemon — the membership rule of the segment (ADR 0141 §1), so it is the
+  // one reach the render path is allowed to make.
+  localGit: vi.fn(async () => ({
+    basename: "red-skills",
+    branch: "afk/3563-bedrock",
+    localAdded: 142,
+    localRemoved: 36,
+  })),
   runStatusline: vi.fn(async (
     _args: readonly string[],
     io: { readonly cwd?: string; readonly write?: (line: string) => void },
@@ -23,6 +32,8 @@ const { directCollector, runStatusline } = vi.hoisted(() => ({
 vi.mock("@reddb-io/redskilled/statusline-command", () => ({ runStatusline }));
 
 vi.mock("../src/runtime/wire.js", () => ({
+  collectStatuslineLocalGit: localGit,
+  resolveRepoBasename: directCollector,
   collectStatuslineAfk: directCollector,
   collectStatuslineDocs: directCollector,
   collectStatuslineFleet: directCollector,
@@ -36,11 +47,31 @@ vi.mock("../src/runtime/wire.js", () => ({
 }));
 
 import { statuslineCommand } from "../src/commands/statusline.js";
+import { readBuildInfo } from "@reddb-io/build-info";
+
+const PAYLOAD = {
+  model: { display_name: "Opus" },
+  effort: { level: "high" },
+  context_window: { total_input_tokens: 47_000, used_percentage: 24 },
+  rate_limits: { five_hour: { used_percentage: 23 }, seven_day: { used_percentage: 41 } },
+};
 
 const roots: string[] = [];
+const cacheDir = process.env.RED_SKILLS_CACHE_DIR;
+
+beforeEach(async () => {
+  // An empty bundle cache, so the bedrock's version label is the build stamp
+  // alone: the developer's own `~/.cache` must not decide whether the rendered
+  // line carries the newer-bundle `*`.
+  const empty = await mkdtemp(join(tmpdir(), "statusline-render-path-cache-"));
+  roots.push(empty);
+  process.env.RED_SKILLS_CACHE_DIR = empty;
+});
 
 afterEach(async () => {
   vi.clearAllMocks();
+  if (cacheDir === undefined) delete process.env.RED_SKILLS_CACHE_DIR;
+  else process.env.RED_SKILLS_CACHE_DIR = cacheDir;
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
@@ -85,6 +116,9 @@ describe("dev statusline render path", () => {
       expect.objectContaining({ cwd: root }),
     );
     expect(directCollector).not.toHaveBeenCalled();
+    // The bedrock LEADS the daemon's header line; the Worker lines follow it
+    // untouched.
+    expect(out.text().split("\n")[0]).toContain(" · acme/widgets 1w 128M v3.12.10");
     expect(out.text()).toContain("run=codex gpt-5.6 xhigh");
     expect(out.text()).toContain("iss=3546");
     expect(out.text()).toContain("loc=+12 -3  tks=45k  tls=9 rsn=2 txt=1");
@@ -108,8 +142,47 @@ describe("dev statusline render path", () => {
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(""));
 
     expect(code).toBe(0);
-    expect(out.text()).toBe("redskilled unreachable — Worker state unknown\n");
+    expect(out.text()).toContain("redskilled unreachable — Worker state unknown");
     expect(directCollector).not.toHaveBeenCalled();
     expect(performance.now() - started).toBeLessThan(100);
+  });
+
+  it("renders the bedrock COMPLETE under a daemon-absent fixture", async () => {
+    // The daemon answers nothing at all — not even an absence line. Everything
+    // the operator's own machine holds must still reach the screen: model·effort
+    // and context and the subscription windows from stdin, basename/branch/diff
+    // from local git, and the running bundle version (ADR 0141 §1).
+    runStatusline.mockImplementationOnce(async () => 0);
+    const root = await mkdtemp(join(tmpdir(), "statusline-render-path-"));
+    roots.push(root);
+    const out = sink();
+
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(JSON.stringify(PAYLOAD)));
+
+    expect(code).toBe(0);
+    expect(out.text()).toBe(
+      `red-skills (afk/3563-bedrock) v${readBuildInfo("dev").version} · Opus·high · 47k 24% · ` +
+        "5h=23% 7d=41% · loc=+142 -36\n",
+    );
+    expect(localGit).toHaveBeenCalledOnce();
+    expect(directCollector).not.toHaveBeenCalled();
+  });
+
+  it("still renders the bedrock when the daemon states its absence", async () => {
+    runStatusline.mockImplementationOnce(async (_args, io) => {
+      io.write?.("redskilled unreachable — Worker state unknown\n");
+      return 0;
+    });
+    const root = await mkdtemp(join(tmpdir(), "statusline-render-path-"));
+    roots.push(root);
+    const out = sink();
+
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(JSON.stringify(PAYLOAD)));
+
+    expect(code).toBe(0);
+    expect(out.text()).toBe(
+      `red-skills (afk/3563-bedrock) v${readBuildInfo("dev").version} · Opus·high · 47k 24% · ` +
+        "5h=23% 7d=41% · loc=+142 -36 · redskilled unreachable — Worker state unknown\n",
+    );
   });
 });


### PR DESCRIPTION
Automated AFK landing for #3563. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3563

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789012955&installation_model_id=20659&pr_number=3569&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3569&signature=869cc6f19b29577932a5b3e7b14b795a2e4d8d560a4df5d63c3b49357cdcef18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->