### PR TITLE
chore: #3562 Daemon statusline payload ships the remote-counter block with ages

### DIFF
--- a/apps/redskilled/src/activity-report.ts
+++ b/apps/redskilled/src/activity-report.ts
@@ -1,0 +1,124 @@
+/**
+ * activity-report — the stored poll, dated for whoever reads it.
+ *
+ * **Fetching and dating are two domains.** `repository-activity` spends the
+ * request: it holds the token condition, the conditional-list plumbing and the
+ * rules about what a 304, a spent quota and an unreachable repository each mean.
+ * Nothing here talks to GitHub. This module takes the document that poll stored
+ * and answers one question — how old is it, and may it be presented as current.
+ *
+ * **Staleness travels inside the payload.** A surface that dated the answer
+ * itself would need the poll interval, the daemon's clock and its own read
+ * latency, and would get it subtly wrong in a different way per surface. The age
+ * is a field, and rendering it is the whole of a consumer's job.
+ *
+ * `remote-counters` is this module's sibling, not its replacement: this dates the
+ * POLL, which is what tells an operator whether the daemon still reaches GitHub,
+ * and that dates each COUNTER, which is what a line rendering several numbers
+ * side by side needs (ADR 0141).
+ *
+ * PURE.
+ */
+
+import {
+  DEFAULT_REDSKILLED_ACTIVITY_MS,
+  type RedskilledActivityRateLimit,
+  type RedskilledProjectActivity,
+  type RedskilledRepositoryActivity,
+} from "./repository-activity.js";
+
+/**
+ * How old counts may be before the payload calls them stale.
+ *
+ * Two poll windows, for the same reason the memory sampler uses two of its own:
+ * one missed interval is the jitter of a busy host or a slow API, and two is a
+ * poller that stopped.
+ */
+export const REDSKILLED_ACTIVITY_STALENESS_MS = 2 * DEFAULT_REDSKILLED_ACTIVITY_MS;
+
+/** One project's counts, dated — the shape a consumer renders. */
+export interface RedskilledActivityView extends RedskilledProjectActivity {
+  readonly fetched_at: string;
+  readonly age_ms: number | null;
+  readonly stale: boolean;
+}
+
+export interface RedskilledActivityReport {
+  readonly version: 1;
+  readonly fetched_at: string | null;
+  readonly age_ms: number | null;
+  readonly threshold_ms: number;
+  readonly stale: boolean;
+  readonly request_count: number;
+  readonly rate_limit: RedskilledActivityRateLimit;
+  readonly projects: readonly RedskilledActivityView[];
+  readonly reason: string;
+}
+
+/** Date the counts so the consumer renders the age instead of inventing it. PURE. */
+export function buildActivityReport(input: {
+  readonly activity: RedskilledRepositoryActivity | null;
+  readonly now: string;
+  readonly stalenessMs?: number;
+}): RedskilledActivityReport {
+  const threshold = input.stalenessMs ?? REDSKILLED_ACTIVITY_STALENESS_MS;
+  const activity = input.activity;
+  if (activity == null) {
+    return {
+      version: 1,
+      fetched_at: null,
+      age_ms: null,
+      threshold_ms: threshold,
+      stale: false,
+      request_count: 0,
+      rate_limit: { remaining: null, reset_at: null, exhausted: false, point_cost: null },
+      projects: [],
+      reason: "the daemon polls no repository, so there are no counts to age",
+    };
+  }
+  const nowMs = Date.parse(input.now);
+  const fetchedMs = Date.parse(activity.fetched_at);
+  const ageMs = Number.isFinite(nowMs) && Number.isFinite(fetchedMs) ? Math.max(0, nowMs - fetchedMs) : null;
+  const stale = ageMs == null || ageMs > threshold;
+  return {
+    version: 1,
+    fetched_at: activity.fetched_at,
+    age_ms: ageMs,
+    threshold_ms: threshold,
+    stale: activity.projects.length > 0 && stale,
+    request_count: activity.request_count,
+    rate_limit: activity.rate_limit,
+    projects: activity.projects.map((project) => ({
+      ...project,
+      fetched_at: activity.fetched_at,
+      age_ms: ageMs,
+      stale: stale,
+    })),
+    reason: activity.projects.length === 0
+      ? "the daemon polls no repository, so there are no counts to age"
+      : ageMs == null
+        ? "these counts carry no readable instant, so they cannot be presented as current"
+        : stale
+          ? `these counts are ${ageMs}ms old, past the ${threshold}ms window`
+          : `fetched ${ageMs}ms ago, within the ${threshold}ms window`,
+  };
+}
+
+/** True when `value` is a complete activity report — a client's fail-closed check. */
+export function isRedskilledActivityReport(value: unknown): value is RedskilledActivityReport {
+  if (!isRecord(value)) return false;
+  const report = value as Record<string, unknown>;
+  return report.version === 1 &&
+    (report.fetched_at === null || typeof report.fetched_at === "string") &&
+    (report.age_ms === null || typeof report.age_ms === "number") &&
+    typeof report.threshold_ms === "number" &&
+    typeof report.stale === "boolean" &&
+    Number.isInteger(report.request_count) &&
+    isRecord(report.rate_limit) &&
+    Array.isArray(report.projects) &&
+    typeof report.reason === "string";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/redskilled/src/remote-counters.ts
+++ b/apps/redskilled/src/remote-counters.ts
@@ -1,0 +1,250 @@
+/**
+ * remote-counters — what the tracker holds, counter by counter, each with its age.
+ *
+ * ADR 0141 decision 2 makes every remote counter daemon-owned: open pull
+ * requests, open Issues, and the ready and human queue counts come from one
+ * poll, on one cycle, in one payload. Decision 3 makes the read free of the
+ * network — a request never fetches, so what a surface renders is whatever the
+ * last poll stored, and the only honest way to serve that is to state how old it
+ * is.
+ *
+ * **The age is per COUNTER, not per poll.** `repository_activity` dates the poll,
+ * which is the right unit for "when did this daemon last talk to GitHub". It is
+ * the wrong unit for a line that renders four numbers side by side: a counter
+ * nobody asked for and a counter fetched a second ago sit in the same document,
+ * and one poll-wide `age_ms` describes neither. Here every counter carries the
+ * instant that produced IT.
+ *
+ * **Absent is not stale, and neither is zero.** Three facts wear the same shape
+ * on a naive render — "this queue has drained", "the quota was spent before we
+ * asked", "no label was ever named for this counter" — and only the first is a
+ * number. A counter with no value carries `null`, its own reason, and `stale:
+ * false`, because nothing old is being shown when nothing was ever shown.
+ *
+ * **Derived once, here, for every surface.** The alternative is each consumer
+ * subtracting instants itself, which is how three surfaces come to print three
+ * ages for one poll — the same reason the staleness block exists at all.
+ *
+ * PURE.
+ */
+
+import {
+  REDSKILLED_ACTIVITY_STALENESS_MS,
+  type RedskilledActivityOutcome,
+  type RedskilledProjectActivity,
+  type RedskilledRepositoryActivity,
+} from "./repository-activity.js";
+
+/**
+ * Every counter this block carries, in the order a line reads them.
+ *
+ * Named as a total set rather than left implicit in the record type, so a
+ * consumer can render "every counter" without knowing which ones exist and a
+ * daemon that grows one cannot ship it unnamed.
+ */
+export const REDSKILLED_REMOTE_COUNTER_NAMES = [
+  "open_pull_requests",
+  "open_issues",
+  "ready_queue",
+  "human_queue",
+] as const;
+
+export type RedskilledRemoteCounterName = typeof REDSKILLED_REMOTE_COUNTER_NAMES[number];
+
+/** One counter, and everything needed to render it without re-deriving anything. */
+export interface RedskilledRemoteCounter {
+  readonly name: RedskilledRemoteCounterName;
+  /** What the tracker held; `null` when this poll produced no such count. */
+  readonly value: number | null;
+  /** The instant that produced `value`; `null` exactly when `value` is. */
+  readonly fetched_at: string | null;
+  readonly age_ms: number | null;
+  readonly threshold_ms: number;
+  /** True when a value is being served past its window; never true of an absence. */
+  readonly stale: boolean;
+  /** Why this counter reads as it does, in a sentence a surface can show unchanged. */
+  readonly reason: string;
+}
+
+/** One project's counters, keyed by name so a consumer never searches a list. */
+export interface RedskilledProjectRemoteCounters {
+  readonly project_label: string;
+  /** `owner/name`, echoed back as registered. */
+  readonly repository: string;
+  readonly outcome: RedskilledActivityOutcome;
+  readonly counters: Readonly<Record<RedskilledRemoteCounterName, RedskilledRemoteCounter>>;
+}
+
+export interface RedskilledRemoteCounterReport {
+  readonly version: 1;
+  readonly threshold_ms: number;
+  readonly projects: readonly RedskilledProjectRemoteCounters[];
+  readonly reason: string;
+}
+
+/** The sentence a host that polls nothing answers with — one string, one meaning. */
+export const REDSKILLED_REMOTE_COUNTERS_UNPOLLED_REASON =
+  "this daemon polls no repository, so there are no remote counters to date";
+
+/**
+ * Date every counter of every polled project. PURE.
+ *
+ * The activity document is the one source: this projects it per counter and
+ * derives nothing GitHub was not asked for. A project the poll could not reach
+ * keeps every counter `null` and carries the poll's own sentence, so "the queue
+ * is empty" and "we could not ask" never render the same.
+ */
+export function buildRemoteCounterReport(input: {
+  readonly activity: RedskilledRepositoryActivity | null;
+  readonly now: string;
+  readonly stalenessMs?: number;
+}): RedskilledRemoteCounterReport {
+  const threshold = input.stalenessMs ?? REDSKILLED_ACTIVITY_STALENESS_MS;
+  const activity = input.activity;
+  if (activity == null || activity.projects.length === 0) {
+    return {
+      version: 1,
+      threshold_ms: threshold,
+      projects: [],
+      reason: REDSKILLED_REMOTE_COUNTERS_UNPOLLED_REASON,
+    };
+  }
+  const nowMs = Date.parse(input.now);
+  const fetchedMs = Date.parse(activity.fetched_at);
+  const ageMs = Number.isFinite(nowMs) && Number.isFinite(fetchedMs) ? Math.max(0, nowMs - fetchedMs) : null;
+
+  const projects = activity.projects.map((project) =>
+    buildProjectCounters(project, { fetchedAt: activity.fetched_at, ageMs, threshold })
+  );
+  return {
+    version: 1,
+    threshold_ms: threshold,
+    projects,
+    reason: ageMs == null
+      ? "these counters carry no readable instant, so none of them can be presented as current"
+      : `every counter here was produced by the poll of ${activity.fetched_at}, ${ageMs}ms ago`,
+  };
+}
+
+function buildProjectCounters(
+  project: RedskilledProjectActivity,
+  ctx: { readonly fetchedAt: string; readonly ageMs: number | null; readonly threshold: number },
+): RedskilledProjectRemoteCounters {
+  const counters = {} as Record<RedskilledRemoteCounterName, RedskilledRemoteCounter>;
+  for (const name of REDSKILLED_REMOTE_COUNTER_NAMES) {
+    counters[name] = buildCounter(name, valueOf(project, name), project, ctx);
+  }
+  return {
+    project_label: project.project_label,
+    repository: project.repository,
+    outcome: project.outcome,
+    counters,
+  };
+}
+
+/** What this poll produced for one counter; `null` is an absence, never a zero. */
+function valueOf(project: RedskilledProjectActivity, name: RedskilledRemoteCounterName): number | null {
+  const counts = project.counts;
+  if (counts == null) return null;
+  switch (name) {
+    case "open_pull_requests":
+      return counts.open_pull_requests;
+    case "open_issues":
+      return counts.open_issues;
+    case "ready_queue":
+      return counts.ready_queue;
+    case "human_queue":
+      return counts.human_queue;
+  }
+}
+
+function buildCounter(
+  name: RedskilledRemoteCounterName,
+  value: number | null,
+  project: RedskilledProjectActivity,
+  ctx: { readonly fetchedAt: string; readonly ageMs: number | null; readonly threshold: number },
+): RedskilledRemoteCounter {
+  const absent = {
+    name,
+    value: null,
+    fetched_at: null,
+    age_ms: null,
+    threshold_ms: ctx.threshold,
+    // An absence is not stale: staleness is a claim about a number being shown,
+    // and there is no number here. Calling it stale would put a warning on a
+    // counter nobody ever asked for.
+    stale: false,
+  } as const;
+  if (value == null) {
+    return {
+      ...absent,
+      // The poll's own sentence when the poll is why there is no number, so a
+      // spent quota reaches the surface in the words of the fetch that met it.
+      reason: project.outcome === "counted"
+        ? `this poll produced no ${name}, so it is absent rather than zero`
+        : project.detail,
+    };
+  }
+  if (ctx.ageMs == null) {
+    return {
+      name,
+      value,
+      fetched_at: ctx.fetchedAt,
+      age_ms: null,
+      threshold_ms: ctx.threshold,
+      stale: true,
+      reason: `this ${name} carries no readable instant, so it cannot be presented as current`,
+    };
+  }
+  const stale = ctx.ageMs > ctx.threshold;
+  return {
+    name,
+    value,
+    fetched_at: ctx.fetchedAt,
+    age_ms: ctx.ageMs,
+    threshold_ms: ctx.threshold,
+    stale,
+    reason: stale
+      ? `this ${name} is ${ctx.ageMs}ms old, past the ${ctx.threshold}ms window`
+      : `counted ${ctx.ageMs}ms ago, within the ${ctx.threshold}ms window`,
+  };
+}
+
+/** True when `value` is a complete counter report — a client's fail-closed check. */
+export function isRedskilledRemoteCounterReport(value: unknown): value is RedskilledRemoteCounterReport {
+  if (!isRecord(value)) return false;
+  const report = value as Record<string, unknown>;
+  return report.version === 1 &&
+    typeof report.threshold_ms === "number" &&
+    typeof report.reason === "string" &&
+    Array.isArray(report.projects) &&
+    report.projects.every(isProjectRemoteCounters);
+}
+
+function isProjectRemoteCounters(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const project = value as Record<string, unknown>;
+  if (typeof project.project_label !== "string" || typeof project.repository !== "string") return false;
+  if (typeof project.outcome !== "string" || !isRecord(project.counters)) return false;
+  const counters = project.counters as Record<string, unknown>;
+  // Every counter, or none of them: a block missing one name is a shape a
+  // consumer would have to existence-check, which is what carrying the absence
+  // as a value exists to avoid.
+  return REDSKILLED_REMOTE_COUNTER_NAMES.every((name) => isRemoteCounter(counters[name]));
+}
+
+function isRemoteCounter(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const counter = value as Record<string, unknown>;
+  return typeof counter.name === "string" &&
+    (counter.value === null || typeof counter.value === "number") &&
+    (counter.fetched_at === null || typeof counter.fetched_at === "string") &&
+    (counter.age_ms === null || typeof counter.age_ms === "number") &&
+    typeof counter.threshold_ms === "number" &&
+    typeof counter.stale === "boolean" &&
+    typeof counter.reason === "string";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/redskilled/src/remote-counters.ts
+++ b/apps/redskilled/src/remote-counters.ts
@@ -28,11 +28,11 @@
  * PURE.
  */
 
-import {
-  REDSKILLED_ACTIVITY_STALENESS_MS,
-  type RedskilledActivityOutcome,
-  type RedskilledProjectActivity,
-  type RedskilledRepositoryActivity,
+import { REDSKILLED_ACTIVITY_STALENESS_MS } from "./activity-report.js";
+import type {
+  RedskilledActivityOutcome,
+  RedskilledProjectActivity,
+  RedskilledRepositoryActivity,
 } from "./repository-activity.js";
 
 /**

--- a/apps/redskilled/src/repository-activity.ts
+++ b/apps/redskilled/src/repository-activity.ts
@@ -13,6 +13,13 @@
  * returns without interpreting, exactly as it carries a Worker's last logged line
  * without parsing it.
  *
+ * **ADR 0141 adds two label NAMES, and no meaning.** The ready and human queue
+ * counters moved here from the statusline's own `gh` cache, so a project hands
+ * over the two strings whose open Issues it wants counted apart. The daemon
+ * compares those strings to the label names the representation already carries
+ * and stores two more integers; what makes a label a queue stays with the
+ * project, exactly as a selector it carries but never parses does.
+ *
  * **N round trips, usually zero budget.** Each project has three stable REST
  * list representations. Their ETags make an unchanged collection answer 304,
  * which costs no API budget; GraphQL charged the full aggregate on every poll.
@@ -104,6 +111,25 @@ export interface RedskilledProjectRepository {
   readonly name: string;
   /** The credential this project insists on; anything but the host's is refused. */
   readonly token_ref?: string;
+  /**
+   * The two labels whose open Issues this project wants counted separately.
+   *
+   * Carried, never interpreted: the daemon matches the strings it was handed
+   * against the label names the representation already carries, exactly as it
+   * carries a selector it never parses. What `ready-for-agent` MEANS stays with
+   * the project (ADR 0130 rule 3) — the daemon only knows that two of the
+   * integers it stores were counted by these two names.
+   *
+   * Absent leaves both queue counters `null` rather than zero, because a project
+   * that named no label has an uncounted queue, not a drained one.
+   */
+  readonly queue_labels?: RedskilledActivityQueueLabels;
+}
+
+/** Which label names the ready and human queue counters are keyed by. */
+export interface RedskilledActivityQueueLabels {
+  readonly ready: string;
+  readonly human: string;
 }
 
 /** Raised when a registered project asks to be polled with its own credential. */
@@ -123,12 +149,24 @@ export class RedskilledSplitCredentialError extends Error {
   }
 }
 
-/** What this project's tracker holds, as three integers and nothing more. */
+/** What this project's tracker holds, as integers and nothing more. */
 export interface RedskilledActivityCounts {
   readonly open_pull_requests: number;
   readonly open_issues: number;
   /** Issues and pull requests closed inside the window the fetch asked for. */
   readonly recently_closed: number;
+  /**
+   * Open Issues carrying this project's ready label; `null` when none was named.
+   *
+   * **Counted off the representation the open-Issue count already paid for.**
+   * The open-Issue list carries every item's label names, so a second request
+   * per label would spend budget for bytes this poll already holds — and ADR
+   * 0141 decision 2 moved these counters here precisely to stop the statusline
+   * spending its own quota on them.
+   */
+  readonly ready_queue: number | null;
+  /** Open Issues carrying this project's human label; `null` when none was named. */
+  readonly human_queue: number | null;
 }
 
 /**
@@ -293,6 +331,11 @@ export function parseRepositoryActivityResponse(
             open_pull_requests: openPullRequests,
             open_issues: openIssues,
             recently_closed: recentlyClosed,
+            // The aliased query asks for no label breakdown, so this path
+            // produces no queue counters — and says so with `null` rather than
+            // handing a consumer two zeros it would render as a drained queue.
+            ready_queue: null,
+            human_queue: null,
           },
           detail: `counted ${repository} for project ${JSON.stringify(project.project_label)}`,
         };
@@ -454,6 +497,7 @@ async function fetchConditionalRepositoryActivity(
       ],
     ] as const;
     const counts: number[] = [];
+    let queue: RedskilledActivityQueueCounts = { ready_queue: null, human_queue: null };
     try {
       for (const [kind, route, parameters] of queries) {
         const answer = await list({
@@ -466,6 +510,11 @@ async function fetchConditionalRepositoryActivity(
         const items = kind === "open-prs"
           ? answer.data
           : answer.data.filter((item) => !isRecord(item.pull_request));
+        // The queue counters come out of the open-Issue representation rather
+        // than out of two more label-filtered lists: this poll already holds
+        // every open Issue with its labels, so counting them here is free of
+        // both requests and budget.
+        if (kind === "open-issues" && project.queue_labels != null) queue = countQueueLabels(items, project.queue_labels);
         counts.push(kind === "recently-closed"
           ? items.filter((item) => stringValue(item.closed_at) >= operation.closed_since).length
           : items.length);
@@ -479,6 +528,7 @@ async function fetchConditionalRepositoryActivity(
           open_pull_requests: counts[0]!,
           open_issues: counts[1]!,
           recently_closed: counts[2]!,
+          ...queue,
         },
         detail: `counted ${repository} for project ${JSON.stringify(project.project_label)}`,
       });
@@ -647,6 +697,34 @@ function restBaseUrl(endpoint: string): string {
   return url.toString().replace(/\/$/, "");
 }
 
+/** The two label-keyed counters, as the counted half of one poll's counts. */
+type RedskilledActivityQueueCounts = Pick<RedskilledActivityCounts, "ready_queue" | "human_queue">;
+
+/**
+ * Count the open Issues carrying each named label. PURE.
+ *
+ * The names are compared, never read: this is a string equality over what the
+ * representation already carries, which is the whole of what the daemon does
+ * with a label.
+ */
+function countQueueLabels(
+  items: readonly Record<string, unknown>[],
+  labels: RedskilledActivityQueueLabels,
+): RedskilledActivityQueueCounts {
+  const carries = (item: Record<string, unknown>, label: string): boolean =>
+    Array.isArray(item.labels) && item.labels.some((entry) => labelName(entry) === label);
+  return {
+    ready_queue: items.filter((item) => carries(item, labels.ready)).length,
+    human_queue: items.filter((item) => carries(item, labels.human)).length,
+  };
+}
+
+/** A label's name, from either REST shape: the object, or the bare string. */
+function labelName(entry: unknown): string {
+  if (typeof entry === "string") return entry;
+  return isRecord(entry) ? stringValue(entry.name) : "";
+}
+
 function activityRateLimitFromHeaders(headers: GithubResponseHeaders): RedskilledActivityRateLimit {
   const remaining = integerHeader(headers, "x-ratelimit-remaining");
   const resetSeconds = integerHeader(headers, "x-ratelimit-reset");
@@ -692,6 +770,15 @@ function assertActivityProjects(projects: readonly RedskilledProjectRepository[]
     }
     if (seen.has(project.project_label)) {
       throw new Error(`redskilled holds one repository per project, and ${JSON.stringify(project.project_label)} is registered twice`);
+    }
+    // A blank label matches nothing and would be counted as a drained queue —
+    // the one answer this module refuses everywhere else. A project that names
+    // no labels at all is legal; naming an empty one is not.
+    if (project.queue_labels != null && (project.queue_labels.ready === "" || project.queue_labels.human === "")) {
+      throw new Error(
+        `project ${JSON.stringify(project.project_label)} declares an empty queue label: a label that names nothing ` +
+          `would be counted as an empty queue, so state both label names or state neither`,
+      );
     }
     seen.add(project.project_label);
   }

--- a/apps/redskilled/src/repository-activity.ts
+++ b/apps/redskilled/src/repository-activity.ts
@@ -49,6 +49,13 @@
  * aliased-query constants below stay explicit for migration adapters; they are
  * not a second production surface decision.
  *
+ * **Dating the answer is not this module's job.** What the stored document MEANS
+ * to a reader — how old it is, whether it may be shown as current, how each
+ * counter is presented — lives in `./activity-report.js` and
+ * `./remote-counters.js`. Here is the spend: the token condition, the
+ * conditional lists, and what a 304, a spent quota and an unreachable repository
+ * each amount to.
+ *
  * PURE, apart from `fetchRepositoryActivity`, whose transport is injected.
  */
 
@@ -83,15 +90,6 @@ export const REDSKILLED_ACTIVITY_BATCH_SIZE = 100;
 
 /** Default window between polls: activity moves at human speed, not at sampler speed. */
 export const DEFAULT_REDSKILLED_ACTIVITY_MS = 60_000;
-
-/**
- * How old counts may be before the payload calls them stale.
- *
- * Two poll windows, for the same reason the memory sampler uses two of its own:
- * one missed interval is the jitter of a busy host or a slow API, and two is a
- * poller that stopped.
- */
-export const REDSKILLED_ACTIVITY_STALENESS_MS = 2 * DEFAULT_REDSKILLED_ACTIVITY_MS;
 
 /** How far back "recently closed" reaches, when a caller states no window. */
 export const DEFAULT_REDSKILLED_ACTIVITY_CLOSED_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
@@ -560,96 +558,6 @@ async function fetchConditionalRepositoryActivity(
     rate_limit: rateLimit,
     projects,
   };
-}
-
-/** One project's counts, dated — the shape a consumer renders. */
-export interface RedskilledActivityView extends RedskilledProjectActivity {
-  readonly fetched_at: string;
-  readonly age_ms: number | null;
-  readonly stale: boolean;
-}
-
-export interface RedskilledActivityReport {
-  readonly version: 1;
-  readonly fetched_at: string | null;
-  readonly age_ms: number | null;
-  readonly threshold_ms: number;
-  readonly stale: boolean;
-  readonly request_count: number;
-  readonly rate_limit: RedskilledActivityRateLimit;
-  readonly projects: readonly RedskilledActivityView[];
-  readonly reason: string;
-}
-
-/**
- * Date the counts so the consumer renders the age instead of inventing it. PURE.
- *
- * Staleness travels inside the payload for the same reason it does everywhere
- * else here: a surface that had to date the answer itself would need the poll
- * interval, the daemon's clock and its own read latency, and would get it subtly
- * wrong in a different way per surface.
- */
-export function buildActivityReport(input: {
-  readonly activity: RedskilledRepositoryActivity | null;
-  readonly now: string;
-  readonly stalenessMs?: number;
-}): RedskilledActivityReport {
-  const threshold = input.stalenessMs ?? REDSKILLED_ACTIVITY_STALENESS_MS;
-  const activity = input.activity;
-  if (activity == null) {
-    return {
-      version: 1,
-      fetched_at: null,
-      age_ms: null,
-      threshold_ms: threshold,
-      stale: false,
-      request_count: 0,
-      rate_limit: { remaining: null, reset_at: null, exhausted: false, point_cost: null },
-      projects: [],
-      reason: "the daemon polls no repository, so there are no counts to age",
-    };
-  }
-  const nowMs = Date.parse(input.now);
-  const fetchedMs = Date.parse(activity.fetched_at);
-  const ageMs = Number.isFinite(nowMs) && Number.isFinite(fetchedMs) ? Math.max(0, nowMs - fetchedMs) : null;
-  const stale = ageMs == null || ageMs > threshold;
-  return {
-    version: 1,
-    fetched_at: activity.fetched_at,
-    age_ms: ageMs,
-    threshold_ms: threshold,
-    stale: activity.projects.length > 0 && stale,
-    request_count: activity.request_count,
-    rate_limit: activity.rate_limit,
-    projects: activity.projects.map((project) => ({
-      ...project,
-      fetched_at: activity.fetched_at,
-      age_ms: ageMs,
-      stale: stale,
-    })),
-    reason: activity.projects.length === 0
-      ? "the daemon polls no repository, so there are no counts to age"
-      : ageMs == null
-        ? "these counts carry no readable instant, so they cannot be presented as current"
-        : stale
-          ? `these counts are ${ageMs}ms old, past the ${threshold}ms window`
-          : `fetched ${ageMs}ms ago, within the ${threshold}ms window`,
-  };
-}
-
-/** True when `value` is a complete activity report — a client's fail-closed check. */
-export function isRedskilledActivityReport(value: unknown): value is RedskilledActivityReport {
-  if (!isRecord(value)) return false;
-  const report = value as Record<string, unknown>;
-  return report.version === 1 &&
-    (report.fetched_at === null || typeof report.fetched_at === "string") &&
-    (report.age_ms === null || typeof report.age_ms === "number") &&
-    typeof report.threshold_ms === "number" &&
-    typeof report.stale === "boolean" &&
-    Number.isInteger(report.request_count) &&
-    isRecord(report.rate_limit) &&
-    Array.isArray(report.projects) &&
-    typeof report.reason === "string";
 }
 
 /**

--- a/apps/redskilled/src/statusline-extras.ts
+++ b/apps/redskilled/src/statusline-extras.ts
@@ -1,0 +1,95 @@
+/**
+ * statusline-extras — the blocks that scale with Worker count, served on request.
+ *
+ * **A withheld fact and a missing one are opposite things** (ADR 0132 decision
+ * 2). The skeleton — Workers, projects, budget — is served on every response,
+ * because ADR 0130 rule 9 already entitles a session to the whole machine and
+ * withholding it buys only a second round trip. What scales with Worker count
+ * travels on request, and the response SAYS which blocks it left out: a Worker
+ * whose vitals nobody asked for carries the same `rss_bytes: null` a Worker
+ * nobody measured carries, and only `withheld` tells them apart.
+ *
+ * Its own module rather than a corner of the payload's, because this is a
+ * different question: `statusline-payload` decides what one answer CONTAINS, and
+ * this decides how much of that answer one reader asked for.
+ *
+ * PURE — one payload in, one payload out, nothing read and nothing stored.
+ */
+
+import type {
+  RedskilledStatuslinePayload,
+  RedskilledStatuslineVitals,
+  RedskilledStatuslineWorkerLog,
+} from "./statusline-payload.js";
+
+/**
+ * One block that scales with Worker count, and so travels on request.
+ *
+ * Named individually rather than as one `verbose` boolean because the surfaces
+ * want different subsets: a statusline wants vitals and no logs, a dashboard
+ * wants the display records, and a health probe wants none of the three.
+ */
+export type RedskilledStatuslineExtra = "logs" | "vitals" | "display";
+
+/** Every extra there is, so a caller can ask for the skeleton by subtracting. */
+export const REDSKILLED_STATUSLINE_EXTRAS: readonly RedskilledStatuslineExtra[] = ["logs", "vitals", "display"];
+
+/**
+ * Which extras a reader wants; an omitted flag is a block it does not need.
+ *
+ * A record of opt-INS rather than opt-outs: the expensive direction should be
+ * the one a caller had to type.
+ */
+export interface RedskilledStatuslineExtrasRequest {
+  readonly logs?: boolean;
+  readonly vitals?: boolean;
+  readonly display?: boolean;
+}
+
+/**
+ * The same payload with the extras nobody asked for removed. PURE.
+ *
+ * **A withheld block is replaced by its own honest absence, never deleted**: the
+ * shape stays total, so a consumer written against the full document renders a
+ * skeleton response without a single existence check. What it must not do is
+ * read the absence as a measurement — which is exactly what `withheld` is for.
+ *
+ * `undefined` extras means the whole document, because that is what every client
+ * pinned to an older bundle asks for by saying nothing (ADR 0130 rule 3). A
+ * caller that wants less says so.
+ */
+export function withholdStatuslineExtras(
+  payload: RedskilledStatuslinePayload,
+  extras: RedskilledStatuslineExtrasRequest | undefined,
+): RedskilledStatuslinePayload {
+  if (extras === undefined) return payload;
+  const withheld = REDSKILLED_STATUSLINE_EXTRAS.filter((extra) => extras[extra] !== true);
+  if (withheld.length === 0) return payload;
+  const keep = (extra: RedskilledStatuslineExtra) => extras[extra] === true;
+  return {
+    ...payload,
+    workers: payload.workers.map((worker) => ({
+      ...worker,
+      ...(keep("vitals") ? {} : { vitals: WITHHELD_VITALS, budget: { ...worker.budget, used_bytes: null, used_fraction: null } }),
+      ...(keep("logs") ? {} : { log: WITHHELD_LOG }),
+      ...(keep("display") ? {} : { display: null, display_published_at: null }),
+    })),
+    withheld,
+  };
+}
+
+/** The vitals of a Worker nobody asked about — total in shape, empty in fact. */
+const WITHHELD_VITALS: RedskilledStatuslineVitals = {
+  rss_bytes: null,
+  sampled_at: null,
+  age_ms: null,
+  fresh: false,
+  rss_source: null,
+};
+
+/** The log of a Worker nobody asked about. `null`, exactly as an unpublished one. */
+const WITHHELD_LOG: RedskilledStatuslineWorkerLog = {
+  last_line: null,
+  published_at: null,
+  source: null,
+};

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -32,16 +32,17 @@ import type { RedskilledHostState, RedskilledRssSource, RedskilledWorkerView } f
 import { isRedskilledStatuslineMetrics, type RedskilledStatuslineMetrics } from "./live-metrics.js";
 import { resolveEnforcedBudget, type RedskilledBudgetName, type RedskilledRssReading } from "./memory-sampler.js";
 import {
+  buildActivityReport,
+  isRedskilledActivityReport,
+  type RedskilledActivityReport,
+} from "./activity-report.js";
+import {
   buildRemoteCounterReport,
   isRedskilledRemoteCounterReport,
   type RedskilledRemoteCounterReport,
 } from "./remote-counters.js";
-import {
-  buildActivityReport,
-  isRedskilledActivityReport,
-  type RedskilledActivityReport,
-  type RedskilledRepositoryActivity,
-} from "./repository-activity.js";
+import type { RedskilledRepositoryActivity } from "./repository-activity.js";
+import type { RedskilledStatuslineExtra } from "./statusline-extras.js";
 import type { RedskilledWorkerDisplay, RedskilledWorkerDisplayRecord } from "./worker-display.js";
 import {
   buildDeaths,
@@ -75,6 +76,17 @@ export {
   type RedskilledStatuslineDeath,
   type RedskilledStatuslineDeaths,
 } from "./statusline-deaths.js";
+
+// How much of this document one reader asked for is its own question, answered
+// in `./statusline-extras.js`. Re-exported because the payload interface NAMES
+// the extras — `withheld` is typed by them — and because every caller of the
+// withholding already imports this module for the payload it withholds from.
+export {
+  REDSKILLED_STATUSLINE_EXTRAS,
+  withholdStatuslineExtras,
+  type RedskilledStatuslineExtra,
+  type RedskilledStatuslineExtrasRequest,
+} from "./statusline-extras.js";
 
 // The remote-counter block's own judgements — which counters exist, when an age
 // makes one stale, what an absence reads as — live in `./remote-counters.js`.
@@ -405,78 +417,6 @@ export interface RedskilledStatuslinePayload {
    */
   readonly withheld?: readonly RedskilledStatuslineExtra[];
 }
-
-/**
- * One block that scales with Worker count, and so travels on request.
- *
- * Named individually rather than as one `verbose` boolean because the surfaces
- * want different subsets: a statusline wants vitals and no logs, a dashboard
- * wants the display records, and a health probe wants none of the three.
- */
-export type RedskilledStatuslineExtra = "logs" | "vitals" | "display";
-
-/** Every extra there is, so a caller can ask for the skeleton by subtracting. */
-export const REDSKILLED_STATUSLINE_EXTRAS: readonly RedskilledStatuslineExtra[] = ["logs", "vitals", "display"];
-
-/**
- * Which extras a reader wants; an omitted flag is a block it does not need.
- *
- * A record of opt-INS rather than opt-outs: the expensive direction should be
- * the one a caller had to type.
- */
-export interface RedskilledStatuslineExtrasRequest {
-  readonly logs?: boolean;
-  readonly vitals?: boolean;
-  readonly display?: boolean;
-}
-
-/**
- * The same payload with the extras nobody asked for removed. PURE.
- *
- * **A withheld block is replaced by its own honest absence, never deleted**: the
- * shape stays total, so a consumer written against the full document renders a
- * skeleton response without a single existence check. What it must not do is
- * read the absence as a measurement — which is exactly what `withheld` is for.
- *
- * `undefined` extras means the whole document, because that is what every client
- * pinned to an older bundle asks for by saying nothing (ADR 0130 rule 3). A
- * caller that wants less says so.
- */
-export function withholdStatuslineExtras(
-  payload: RedskilledStatuslinePayload,
-  extras: RedskilledStatuslineExtrasRequest | undefined,
-): RedskilledStatuslinePayload {
-  if (extras === undefined) return payload;
-  const withheld = REDSKILLED_STATUSLINE_EXTRAS.filter((extra) => extras[extra] !== true);
-  if (withheld.length === 0) return payload;
-  const keep = (extra: RedskilledStatuslineExtra) => extras[extra] === true;
-  return {
-    ...payload,
-    workers: payload.workers.map((worker) => ({
-      ...worker,
-      ...(keep("vitals") ? {} : { vitals: WITHHELD_VITALS, budget: { ...worker.budget, used_bytes: null, used_fraction: null } }),
-      ...(keep("logs") ? {} : { log: WITHHELD_LOG }),
-      ...(keep("display") ? {} : { display: null, display_published_at: null }),
-    })),
-    withheld,
-  };
-}
-
-/** The vitals of a Worker nobody asked about — total in shape, empty in fact. */
-const WITHHELD_VITALS: RedskilledStatuslineVitals = {
-  rss_bytes: null,
-  sampled_at: null,
-  age_ms: null,
-  fresh: false,
-  rss_source: null,
-};
-
-/** The log of a Worker nobody asked about. `null`, exactly as an unpublished one. */
-const WITHHELD_LOG: RedskilledStatuslineWorkerLog = {
-  last_line: null,
-  published_at: null,
-  source: null,
-};
 
 export interface BuildStatuslinePayloadInput {
   readonly hostState: RedskilledHostState;

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -32,6 +32,11 @@ import type { RedskilledHostState, RedskilledRssSource, RedskilledWorkerView } f
 import { isRedskilledStatuslineMetrics, type RedskilledStatuslineMetrics } from "./live-metrics.js";
 import { resolveEnforcedBudget, type RedskilledBudgetName, type RedskilledRssReading } from "./memory-sampler.js";
 import {
+  buildRemoteCounterReport,
+  isRedskilledRemoteCounterReport,
+  type RedskilledRemoteCounterReport,
+} from "./remote-counters.js";
+import {
   buildActivityReport,
   isRedskilledActivityReport,
   type RedskilledActivityReport,
@@ -70,6 +75,21 @@ export {
   type RedskilledStatuslineDeath,
   type RedskilledStatuslineDeaths,
 } from "./statusline-deaths.js";
+
+// The remote-counter block's own judgements — which counters exist, when an age
+// makes one stale, what an absence reads as — live in `./remote-counters.js`.
+// They are re-exported for the same reason the death block's are: this module's
+// payload interface NAMES them, so a consumer typing a payload reaches them from
+// the module it already imports.
+export {
+  isRedskilledRemoteCounterReport,
+  REDSKILLED_REMOTE_COUNTER_NAMES,
+  REDSKILLED_REMOTE_COUNTERS_UNPOLLED_REASON,
+  type RedskilledProjectRemoteCounters,
+  type RedskilledRemoteCounter,
+  type RedskilledRemoteCounterName,
+  type RedskilledRemoteCounterReport,
+} from "./remote-counters.js";
 
 /** What a Worker is doing, as the daemon knows it. */
 export type RedskilledWorkerState = "running" | "reattached";
@@ -306,6 +326,25 @@ export interface RedskilledStatuslinePayload {
    * interval, and one number ageing does not make the other one old.
    */
   readonly repository_activity: RedskilledActivityReport;
+  /**
+   * The same poll's counters, one by one, each carrying its own age.
+   *
+   * Beside `repository_activity` rather than inside it, because the two answer
+   * different questions: the report dates the POLL — the fact an operator needs
+   * to know whether this daemon is still talking to GitHub — and this block
+   * dates each COUNTER, which is what a line rendering four numbers side by side
+   * needs (ADR 0141 decision 2). One poll-wide age describes an unasked counter
+   * and a second-old one equally badly.
+   *
+   * A counter with no value carries `null` and its own reason, never a zero: "the
+   * queue has drained", "the quota was spent" and "no label was ever named" are
+   * three different facts and only the first is a number.
+   *
+   * OPTIONAL on the wire (ADR 0130 rule 3): a daemon that predates this block
+   * answers completely without it, and a consumer that finds it absent must
+   * render nothing rather than an empty queue.
+   */
+  readonly remote_counters?: RedskilledRemoteCounterReport;
   /**
    * What the TOKEN has left, asked rather than counted, with its own age.
    *
@@ -590,6 +629,14 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
       now: input.now,
       stalenessMs: input.activityStalenessMs,
     }),
+    // The same document, projected per counter rather than per poll. Both blocks
+    // are derived from ONE stored activity, so no surface can render two ages
+    // for one fetch — the projection is the point, a second source would not be.
+    remote_counters: buildRemoteCounterReport({
+      activity: input.repositoryActivity ?? null,
+      now: input.now,
+      ...(input.activityStalenessMs === undefined ? {} : { stalenessMs: input.activityStalenessMs }),
+    }),
     ...(input.deaths === undefined
       ? {}
       : { deaths: buildDeaths(input.deaths, input.recentDeathLimit ?? REDSKILLED_RECENT_DEATH_LIMIT) }),
@@ -828,6 +875,10 @@ export function isRedskilledStatuslinePayload(value: unknown): value is Redskill
     // a field this consumer did not ask for would lose the Worker set — the very
     // version skew one host-scoped daemon exists to stop managing (ADR 0130).
     (payload.repository_activity === undefined || isRedskilledActivityReport(payload.repository_activity)) &&
+    // Absent is accepted for the same reason, and for one more: this block is
+    // newer than the report beside it, so a daemon one release behind serves
+    // every counter's value without their per-counter ages.
+    (payload.remote_counters === undefined || isRedskilledRemoteCounterReport(payload.remote_counters)) &&
     // Absent is accepted for the same reason: a daemon older than the balance
     // poller answers completely without it, and a consumer that rejected the
     // whole payload would lose the Worker set over a badge.

--- a/apps/redskilled/tests/conditional-polling.test.ts
+++ b/apps/redskilled/tests/conditional-polling.test.ts
@@ -108,4 +108,92 @@ describe("the daemon's conditional REST poll path", () => {
       '"closed-v1"',
     ]);
   });
+
+  it("counts the ready and human queues off the open-Issue list it already paid for", async () => {
+    const paths: string[] = [];
+    const fetchImpl: typeof fetch = async (url) => {
+      const parsed = new URL(String(url));
+      paths.push(`${parsed.pathname}?${parsed.searchParams.get("state")}`);
+      if (parsed.pathname.endsWith("/pulls")) {
+        return json([{ number: 1 }, { number: 2 }]);
+      }
+      if (parsed.searchParams.get("state") === "closed") return json([]);
+      return json([
+        { number: 10, labels: [{ name: "ready-for-agent" }] },
+        { number: 11, labels: [{ name: "ready-for-agent" }, { name: "type:spec" }] },
+        { number: 12, labels: [{ name: "ready-for-human" }] },
+        { number: 13, labels: [] },
+        // A pull request answered by the Issues route is not an Issue, and it is
+        // not a queue item either — the same filter the open count already uses.
+        { number: 14, labels: [{ name: "ready-for-agent" }], pull_request: {} },
+      ]);
+    };
+    const transport = createGitHubActivityTransport({
+      token: "test-token",
+      endpoint: "https://tracker.example/graphql",
+      fetchImpl,
+      retryCount: 0,
+      throttle: false,
+    });
+
+    const activity = await fetchRepositoryActivity({
+      projects: [{
+        project_label: "acme/widgets",
+        owner: "acme",
+        name: "widgets",
+        queue_labels: { ready: "ready-for-agent", human: "ready-for-human" },
+      }],
+      hostTokenRef: "host",
+      transport,
+      now: FIRST,
+    });
+
+    expect(activity.projects[0]).toMatchObject({
+      outcome: "counted",
+      counts: { open_pull_requests: 2, open_issues: 4, ready_queue: 2, human_queue: 1 },
+    });
+    // Three collections, three requests: the queue counters are a filter over
+    // bytes this poll already holds, never two more label-filtered lists.
+    expect(activity.request_count).toBe(3);
+    expect(paths).toHaveLength(3);
+  });
+
+  it("leaves both queue counters absent when a project names no label", async () => {
+    const transport = createGitHubActivityTransport({
+      token: "test-token",
+      endpoint: "https://tracker.example/graphql",
+      fetchImpl: (async () => json([{ number: 1, labels: [{ name: "ready-for-agent" }] }])) as unknown as typeof fetch,
+      retryCount: 0,
+      throttle: false,
+    });
+
+    const activity = await fetchRepositoryActivity({
+      projects: [{ project_label: "acme/widgets", owner: "acme", name: "widgets" }],
+      hostTokenRef: "host",
+      transport,
+      now: FIRST,
+    });
+
+    // The label is right there in the answer, and it is still not counted: a
+    // project that named no label has an uncounted queue, not a drained one.
+    expect(activity.projects[0]!.counts).toMatchObject({ ready_queue: null, human_queue: null });
+  });
+
+  it("refuses a project that names an empty label rather than counting nothing", async () => {
+    await expect(fetchRepositoryActivity({
+      projects: [{
+        project_label: "acme/widgets",
+        owner: "acme",
+        name: "widgets",
+        queue_labels: { ready: "", human: "ready-for-human" },
+      }],
+      hostTokenRef: "host",
+      transport: (async () => ({})) as never,
+      now: FIRST,
+    })).rejects.toThrow(/empty queue label/);
+  });
 });
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+}

--- a/apps/redskilled/tests/repository-activity.test.ts
+++ b/apps/redskilled/tests/repository-activity.test.ts
@@ -12,15 +12,17 @@ import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { isRedskilledStatuslinePayload } from "../src/statusline-payload.js";
 import {
-  assertOneHostToken,
   buildActivityReport,
+  isRedskilledActivityReport,
+  REDSKILLED_ACTIVITY_STALENESS_MS,
+} from "../src/activity-report.js";
+import {
+  assertOneHostToken,
   buildRepositoryActivityQuery,
   createGitHubActivityTransport,
   emptyRepositoryActivity,
   fetchRepositoryActivity,
-  isRedskilledActivityReport,
   parseRepositoryActivityResponse,
-  REDSKILLED_ACTIVITY_STALENESS_MS,
   RedskilledSplitCredentialError,
   type RedskilledProjectRepository,
 } from "../src/repository-activity.js";

--- a/apps/redskilled/tests/repository-activity.test.ts
+++ b/apps/redskilled/tests/repository-activity.test.ts
@@ -168,7 +168,15 @@ describe("counts are stored and returned, never interpreted", () => {
       counts: { open_pull_requests: 7, open_issues: 3, recently_closed: 11 },
     });
     // A genuinely empty tracker IS a zero — this is the only outcome that carries one.
-    expect(activity.projects[1]!.counts).toEqual({ open_pull_requests: 0, open_issues: 0, recently_closed: 0 });
+    // The queue counters stay null even here: the aliased query asked for no
+    // label breakdown, so nothing counted them and nothing may read as drained.
+    expect(activity.projects[1]!.counts).toEqual({
+      open_pull_requests: 0,
+      open_issues: 0,
+      recently_closed: 0,
+      ready_queue: null,
+      human_queue: null,
+    });
   });
 
   it("counts recently closed work from the window the query stated", () => {
@@ -396,6 +404,8 @@ describe("the daemon serves the counts it polled", () => {
       open_pull_requests: 4,
       open_issues: 9,
       recently_closed: 2,
+      ready_queue: null,
+      human_queue: null,
     });
     expect(payload.repository_activity.projects[0]!.age_ms).not.toBeNull();
     expect(payload.repository_activity.age_ms).not.toBeNull();

--- a/apps/redskilled/tests/statusline-payload.test.ts
+++ b/apps/redskilled/tests/statusline-payload.test.ts
@@ -14,6 +14,12 @@ import {
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import type { RedskilledWorkerView } from "../src/host-state.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import type {
+  RedskilledActivityCounts,
+  RedskilledActivityOutcome,
+  RedskilledRepositoryActivity,
+} from "../src/repository-activity.js";
+import { REDSKILLED_REMOTE_COUNTER_NAMES } from "../src/remote-counters.js";
 import {
   buildStatuslinePayload,
   isRedskilledStatuslinePayload,
@@ -319,6 +325,127 @@ describe("the statusline payload", () => {
     expect(payload.daemon.pid).toBe(daemon.hostState().pid);
     expect(payload.daemon.daemon_version).toBe(daemon.hostState().daemon_version);
     expect(payload.host.budget_accounting).toEqual(daemon.hostState().budget_accounting);
+  });
+});
+
+// ADR 0141 decision 2: every remote counter is daemon-owned, and decision 3 says
+// a request never fetches — so the counters ride the payload with the age stated
+// per counter. An unpolled counter is absent, never a zero: "the queue is empty"
+// and "nobody asked" are opposite facts about a repository.
+const POLLED_AT = "2026-08-11T12:00:00.000Z";
+
+function counts(overrides: Partial<RedskilledActivityCounts> = {}): RedskilledActivityCounts {
+  return {
+    open_pull_requests: 3,
+    open_issues: 24,
+    recently_closed: 5,
+    ready_queue: 1,
+    human_queue: 11,
+    ...overrides,
+  };
+}
+
+function activityOf(
+  projectCounts: RedskilledActivityCounts | null,
+  outcome: RedskilledActivityOutcome = "counted",
+  detail = "counted acme/widgets for project \"acme/widgets\"",
+): RedskilledRepositoryActivity {
+  return {
+    version: 1,
+    fetched_at: POLLED_AT,
+    request_count: 3,
+    project_count: 1,
+    rate_limit: { remaining: 4_900, reset_at: null, exhausted: false, point_cost: null },
+    projects: [{
+      project_label: "acme/widgets",
+      repository: "acme/widgets",
+      outcome,
+      counts: projectCounts,
+      detail,
+    }],
+  };
+}
+
+function payloadWith(activity: RedskilledRepositoryActivity | null, now: string) {
+  return buildStatuslinePayload({
+    hostState: hostStateOf([worker()]),
+    ceiling: UNBOUNDED_HOST_CEILING,
+    rss: {},
+    sampledAt: null,
+    now,
+    ...(activity === null ? {} : { repositoryActivity: activity }),
+  });
+}
+
+describe("the remote-counter block", () => {
+  it("ships every counter the daemon polled, each carrying its own age", () => {
+    const payload = payloadWith(activityOf(counts()), "2026-08-11T12:00:05.000Z");
+    const block = payload.remote_counters!;
+    const project = block.projects[0]!;
+
+    expect(project.project_label).toBe("acme/widgets");
+    expect(project.repository).toBe("acme/widgets");
+    expect(Object.keys(project.counters).sort()).toEqual([...REDSKILLED_REMOTE_COUNTER_NAMES].sort());
+    expect(project.counters.open_pull_requests).toMatchObject({ value: 3, fetched_at: POLLED_AT, age_ms: 5_000, stale: false });
+    expect(project.counters.open_issues).toMatchObject({ value: 24, age_ms: 5_000 });
+    expect(project.counters.ready_queue).toMatchObject({ value: 1, fetched_at: POLLED_AT, age_ms: 5_000, stale: false });
+    expect(project.counters.human_queue).toMatchObject({ value: 11, age_ms: 5_000 });
+    expect(isRedskilledStatuslinePayload(payload)).toBe(true);
+  });
+
+  it("carries a counter nobody polled as absent, never as a zero", () => {
+    const payload = payloadWith(
+      activityOf(counts({ ready_queue: null, human_queue: null })),
+      "2026-08-11T12:00:05.000Z",
+    );
+    const counters = payload.remote_counters!.projects[0]!.counters;
+
+    expect(counters.ready_queue.value).toBeNull();
+    expect(counters.ready_queue.fetched_at).toBeNull();
+    expect(counters.ready_queue.age_ms).toBeNull();
+    // Absent is not stale: nothing old is being shown, nothing was ever asked.
+    expect(counters.ready_queue.stale).toBe(false);
+    expect(counters.ready_queue.reason).toContain("absent rather than zero");
+    expect(counters.human_queue.value).toBeNull();
+    // Its neighbours still answer — one unpolled counter is a fact about itself.
+    expect(counters.open_issues.value).toBe(24);
+  });
+
+  it("states the age rather than presenting an old counter as current", () => {
+    const payload = payloadWith(activityOf(counts()), "2026-08-11T12:10:00.000Z");
+    const counters = payload.remote_counters!.projects[0]!.counters;
+
+    expect(counters.ready_queue.stale).toBe(true);
+    expect(counters.ready_queue.age_ms).toBe(600_000);
+    expect(counters.ready_queue.reason).toContain("past the");
+    expect(counters.open_pull_requests.stale).toBe(true);
+  });
+
+  it("keeps a spent quota out of the counters it would have read as empty", () => {
+    const payload = payloadWith(
+      activityOf(null, "rate-limited", "the host token's quota was spent before acme/widgets answered"),
+      "2026-08-11T12:00:05.000Z",
+    );
+    const project = payload.remote_counters!.projects[0]!;
+
+    expect(project.outcome).toBe("rate-limited");
+    for (const name of REDSKILLED_REMOTE_COUNTER_NAMES) {
+      expect(project.counters[name].value).toBeNull();
+      expect(project.counters[name].stale).toBe(false);
+      expect(project.counters[name].reason).toContain("quota");
+    }
+  });
+
+  it("is honestly empty when the daemon polled nothing, and validates without the block", () => {
+    const payload = payloadWith(null, "2026-08-11T12:00:00.000Z");
+
+    expect(payload.remote_counters!.projects).toEqual([]);
+    expect(payload.remote_counters!.reason).toContain("no repository");
+    expect(isRedskilledStatuslinePayload(payload)).toBe(true);
+    // A daemon older than this block answers completely without it, and a
+    // consumer must not reject the Worker set over a badge (ADR 0130 rule 3).
+    const { remote_counters: _absent, ...older } = payload;
+    expect(isRedskilledStatuslinePayload(older)).toBe(true);
   });
 });
 

--- a/apps/redskilled/tests/statusline-string.test.ts
+++ b/apps/redskilled/tests/statusline-string.test.ts
@@ -333,6 +333,11 @@ describe("one renderer, machine-wide", () => {
     "apps/redskilled/src/statusline-render.ts",
     "apps/redskilled/src/dashboard-render.ts",
     "apps/redskilled/src/statusline-payload.ts",
+    // How much of the payload one reader asked for, which is the payload's own
+    // question rather than a second surface's: it takes a payload and returns
+    // the same payload with blocks nobody asked for replaced by their honest
+    // absence, and renders not one character.
+    "apps/redskilled/src/statusline-extras.ts",
     // The implementation, not the façade `daemon.ts`, which forwards only. The
     // daemon's payload types and its intervals live beside it, so all three are
     // consumers — the split moved the code, not the consumption.


### PR DESCRIPTION
Automated AFK landing for #3562. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3562

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789013309&installation_model_id=20659&pr_number=3570&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3570&signature=4f2a4874ba9d775d219179fe1a57976d9132525dd0b546c191e972bf7a424d12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->