### PR TITLE
chore: #3564 Presence-driven cadence for the daemon's remote-counter poll

### DIFF
--- a/apps/redskilled/src/activity-cadence.ts
+++ b/apps/redskilled/src/activity-cadence.ts
@@ -1,0 +1,148 @@
+/**
+ * activity-cadence — how often the repository poll runs, decided by who is watching.
+ *
+ * ADR 0141 moves every remote counter into the daemon's own poll, and the
+ * operator's perceived reactivity comes from the per-render socket read rather
+ * than from that poll. So the poll decides one thing only: **how fresh the cache
+ * that read serves is** — and freshness is worth spending budget on exactly
+ * while somebody is looking at it.
+ *
+ * **Presence is READ off the registrations, never invented here.** A session
+ * that is alive renews the registration it holds, and
+ * `registrationRenewalStatus` already calls that `renewing`; its two other
+ * verdicts are a project the daemon holds up on its own observed work
+ * (`self-renewing`) and one running on toward its deadline (`running-on`), which
+ * are both work with nobody watching. A second notion of "attached" derived here
+ * would be a second authority on the same silence.
+ *
+ * **Two windows, and both of them legal.** The attended window is the Spec's
+ * ~15–30s; the unattended one is four minutes. Both sit inside the repo's
+ * cache-warm cadence rule — at or under 270 seconds, or at or over twenty
+ * minutes, and never in the roughly-300-second prompt-cache dead zone. The
+ * rejected alternative was the wished-for 5s poll: that is line reactivity, and
+ * the socket read already delivers it without spending GitHub budget.
+ *
+ * **The unattended window is a back-off, not a second speed.** It may only ever
+ * be SLOWER than the attended one, for the same reason the queue cadence may
+ * only slow: a host nobody is watching that polled harder than an attended one
+ * would spend more of exactly the budget its idleness was meant to save.
+ *
+ * **Why four minutes rather than twenty.** A cadence is chosen when the last
+ * poll finishes, so the unattended window is the worst case for how long an
+ * operator who just attached waits for a fresh number. `activityPollComesForward`
+ * closes most of that gap by re-arming a waiting poll the moment presence
+ * appears; the shorter of the two legal bands keeps the bound small anyway,
+ * because a back-off nobody nudged must still be honest.
+ *
+ * PURE.
+ */
+
+import {
+  registrationRenewalStatus,
+  type RedskilledProjectRegistration,
+} from "./project-registration.js";
+import { DEFAULT_REDSKILLED_ACTIVITY_MS } from "./repository-activity.js";
+
+/**
+ * The window between polls while nobody holds a registration open.
+ *
+ * At the cache-warm edge of the AFK polling cadence rule rather than in the
+ * ~300s dead zone next to it, and short enough that an operator who attaches to
+ * an idle host is never told a four-minute-old number for longer than that.
+ */
+export const REDSKILLED_ACTIVITY_UNATTENDED_MS = 240_000;
+
+/** The longest a recurring poll may run and still be cache-warm. */
+export const REDSKILLED_CACHE_WARM_MAX_MS = 270_000;
+
+/** The shortest an intentionally amortized recurring poll may run. */
+export const REDSKILLED_AMORTIZED_MIN_MS = 20 * 60_000;
+
+/**
+ * Whether a recurring cadence sits in one of the two legal bands. PURE.
+ *
+ * The rule is about DEFAULTS a daemon ships with, so this is a predicate a test
+ * pins the declared constants against rather than a refusal in the poll path: a
+ * caller that states its own interval — a test driving the loop at 10ms, an
+ * operator who knows what they are doing — is not choosing a prompt-cache
+ * cadence for anybody.
+ */
+export function isCacheWarmCadenceMs(everyMs: number): boolean {
+  if (!Number.isFinite(everyMs) || everyMs <= 0) return false;
+  return everyMs <= REDSKILLED_CACHE_WARM_MAX_MS || everyMs >= REDSKILLED_AMORTIZED_MIN_MS;
+}
+
+/**
+ * How many registrations a session is still speaking for, at one instant. PURE.
+ *
+ * An undatable clock counts NOBODY, which is the fail-closed answer: the cost of
+ * reading absence as presence is a host spending budget on counters no operator
+ * is reading, and the cost of the reverse is one slow window on a host whose
+ * clock is already broken.
+ */
+export function interactiveSessionsHolding(
+  registrations: Iterable<RedskilledProjectRegistration>,
+  nowMs: number,
+): number {
+  if (!Number.isFinite(nowMs)) return 0;
+  let held = 0;
+  for (const registration of registrations) {
+    if (registrationRenewalStatus(registration, nowMs) === "renewing") held += 1;
+  }
+  return held;
+}
+
+export interface RedskilledActivityCadenceInput {
+  /** Whether at least one interactive session holds a registration right now. */
+  readonly attended: boolean;
+  /** The tight window; the module default when absent or not a positive number. */
+  readonly attendedMs?: number;
+  /** The backed-off window; the module default under the same condition. */
+  readonly unattendedMs?: number;
+}
+
+/**
+ * The window between repository polls, given who is watching. PURE.
+ *
+ * Presence is the only input: the budget-aware client already refuses what the
+ * token cannot afford, and the rate-limit shape belongs to the poll that meets
+ * it (`nextQueuePollMs` reads that one). This answers the other question —
+ * whether the freshness is worth asking for at all.
+ */
+export function nextActivityPollMs(input: RedskilledActivityCadenceInput): number {
+  const attendedMs = positiveOr(input.attendedMs, DEFAULT_REDSKILLED_ACTIVITY_MS);
+  const unattendedMs = positiveOr(input.unattendedMs, REDSKILLED_ACTIVITY_UNATTENDED_MS);
+  // Never faster than the attended window when unattended: the back-off may only
+  // ever slow down, whatever a caller states.
+  return input.attended ? attendedMs : Math.max(attendedMs, unattendedMs);
+}
+
+export interface RedskilledActivityForwardInput {
+  /** The window the pending poll was armed with; `null` when none is armed. */
+  readonly pendingWindowMs: number | null;
+  /** The window in force now, as {@link nextActivityPollMs} answers it. */
+  readonly cadenceMs: number;
+}
+
+/**
+ * Whether a poll already waiting should be brought forward. PURE.
+ *
+ * **A cadence chosen when the last poll finished is deaf to what happened
+ * since.** An unattended host arms four minutes; a session that attaches ten
+ * seconds later would be served four-minute-old counters for four minutes more,
+ * which is exactly the stale-line complaint this whole cycle was written about.
+ *
+ * Only ever FORWARD, and only when the window actually shrank. A session going
+ * quiet leaves the tight poll already armed to run once more — one extra fetch,
+ * against re-arming logic that could otherwise push a waiting poll away
+ * indefinitely while a session renewed on a timer.
+ */
+export function activityPollComesForward(input: RedskilledActivityForwardInput): boolean {
+  if (input.pendingWindowMs == null) return false;
+  if (!Number.isFinite(input.pendingWindowMs) || !Number.isFinite(input.cadenceMs)) return false;
+  return input.cadenceMs < input.pendingWindowMs;
+}
+
+function positiveOr(value: number | undefined, fallback: number): number {
+  return value != null && Number.isFinite(value) && value > 0 ? value : fallback;
+}

--- a/apps/redskilled/src/activity-report.ts
+++ b/apps/redskilled/src/activity-report.ts
@@ -28,13 +28,24 @@ import {
 } from "./repository-activity.js";
 
 /**
- * How old counts may be before the payload calls them stale.
+ * How many poll windows old counts may be before the payload calls them stale.
  *
- * Two poll windows, for the same reason the memory sampler uses two of its own:
- * one missed interval is the jitter of a busy host or a slow API, and two is a
- * poller that stopped.
+ * Two, for the same reason the memory sampler uses two of its own: one missed
+ * interval is the jitter of a busy host or a slow API, and two is a poller that
+ * stopped.
+ *
+ * A factor rather than only a constant, because the cadence it multiplies is no
+ * longer one number: a presence-driven poll runs at two windows (ADR 0141), and
+ * a threshold pinned to the tight one would mark every counter on an idle host
+ * stale — reporting a poller that is working exactly as asked as one that broke.
+ * The daemon states the window in force; this is the default for a caller that
+ * states none.
  */
-export const REDSKILLED_ACTIVITY_STALENESS_MS = 2 * DEFAULT_REDSKILLED_ACTIVITY_MS;
+export const REDSKILLED_ACTIVITY_STALENESS_FACTOR = 2;
+
+/** The staleness window of an ATTENDED poll — the default when none is stated. */
+export const REDSKILLED_ACTIVITY_STALENESS_MS =
+  REDSKILLED_ACTIVITY_STALENESS_FACTOR * DEFAULT_REDSKILLED_ACTIVITY_MS;
 
 /** One project's counts, dated — the shape a consumer renders. */
 export interface RedskilledActivityView extends RedskilledProjectActivity {

--- a/apps/redskilled/src/daemon/activity-poller.ts
+++ b/apps/redskilled/src/daemon/activity-poller.ts
@@ -1,0 +1,122 @@
+/**
+ * activity-poller — the repository poll's loop, kept out of the lifecycle.
+ *
+ * The POLICY is `../activity-cadence.js` and is pure; this is the small amount
+ * of state that policy needs to act on a running daemon: which timeout is
+ * waiting, and what window it was armed with. Both live here rather than among
+ * the lifecycle's other fields because the whole of what a caller does with them
+ * is `arm`, `nudge`, `cadenceMs` and `stop`.
+ *
+ * **The window is chosen per poll, not once** (ADR 0141). The re-arm is a
+ * timeout the poll itself schedules, exactly as the queue poller's is: a fixed
+ * interval would have to choose between the attended and the idle host before
+ * either existed.
+ *
+ * **Presence is read live, never copied in.** The registrations are handed over
+ * as a thunk, so a session that registers between two polls is visible to the
+ * next cadence question rather than to the next daemon.
+ */
+import {
+  activityPollComesForward,
+  interactiveSessionsHolding,
+  nextActivityPollMs,
+} from "../activity-cadence.js";
+import type { RedskilledProjectRegistration } from "../project-registration.js";
+
+export interface RedskilledActivityPollerOptions {
+  /** Spend one interval's fetch. A rejection is the loop's to swallow. */
+  readonly poll: () => Promise<unknown>;
+  /** The registrations presence is read off — asked, never held. */
+  readonly registrations: () => Iterable<RedskilledProjectRegistration>;
+  readonly clock: () => string;
+  /** The attended window; the cadence module's default at 0 or below. */
+  readonly attendedMs: number;
+  /** Whether this daemon has a repository to poll at all. */
+  readonly armed: boolean;
+  /** Whether the daemon has begun letting go of its session. */
+  readonly stopping: () => boolean;
+}
+
+export interface RedskilledActivityPoller {
+  /**
+   * Fetch once, then run on the window presence asks for.
+   *
+   * The immediate fetch is why a daemon that just started is never empty; the
+   * interval after it is the tracker's rather than the sampler's, because
+   * repository activity moves at human speed and costs shared quota.
+   */
+  arm(): void;
+  /** The window in force right now — what the payload's staleness is two of. */
+  cadenceMs(): number;
+  /** Bring a waiting poll forward, because a session just spoke. */
+  nudge(): void;
+  stop(): void;
+}
+
+export function createRedskilledActivityPoller(
+  options: RedskilledActivityPollerOptions,
+): RedskilledActivityPoller {
+  let timer: NodeJS.Timeout | undefined;
+  // The window the WAITING poll was armed with, so a session that attaches
+  // mid-window can be told whether the wait it found is longer than the one
+  // presence now asks for. `null` whenever no poll is armed.
+  let armedWindowMs: number | null = null;
+
+  function cadenceMs(): number {
+    return nextActivityPollMs({
+      attended: interactiveSessionsHolding(options.registrations(), Date.parse(options.clock())) > 0,
+      attendedMs: options.attendedMs,
+    });
+  }
+
+  function schedule(delayMs: number): void {
+    if (options.stopping()) return;
+    armedWindowMs = delayMs;
+    timer = setTimeout(() => {
+      timer = undefined;
+      armedWindowMs = null;
+      void options.poll()
+        .catch(() => undefined)
+        .finally(() => {
+          if (options.stopping()) return;
+          schedule(cadenceMs());
+        });
+    }, delayMs);
+    timer.unref();
+  }
+
+  return {
+    arm() {
+      if (options.stopping() || timer != null || !options.armed || options.attendedMs <= 0) return;
+      void options.poll().catch(() => undefined);
+      schedule(cadenceMs());
+    },
+
+    cadenceMs,
+
+    /**
+     * The daemon holds no connection to a session, so presence arrives as a
+     * registration message and nothing else. Without this, an operator who
+     * attaches to an idle host ten seconds after its last poll is served
+     * four-minute-old counters for four minutes more — the stale-line complaint
+     * this cycle exists to end.
+     *
+     * Only ever forward, and only when the window actually shrank, so a session
+     * renewing on a timer can never push a waiting poll away.
+     */
+    nudge() {
+      if (options.stopping() || timer == null) return;
+      const next = cadenceMs();
+      if (!activityPollComesForward({ pendingWindowMs: armedWindowMs, cadenceMs: next })) return;
+      clearTimeout(timer);
+      timer = undefined;
+      schedule(next);
+    },
+
+    stop() {
+      if (timer != null) clearTimeout(timer);
+      timer = undefined;
+      armedWindowMs = null;
+    },
+  };
+}

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -118,6 +118,8 @@ import {
   fetchRepositoryActivity,
   type RedskilledRepositoryActivity,
 } from "../repository-activity.js";
+import { createRedskilledActivityPoller } from "./activity-poller.js";
+import { REDSKILLED_ACTIVITY_STALENESS_FACTOR } from "../activity-report.js";
 import {
   DEFAULT_REDSKILLED_QUEUE_MS,
   fetchQueueDiscovery,
@@ -490,7 +492,6 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   let demandTimer: NodeJS.Timeout | undefined;
   let replaceTimer: NodeJS.Timeout | undefined;
   let replaceBootTimer: NodeJS.Timeout | undefined;
-  let activityTimer: NodeJS.Timeout | undefined;
   // A timeout rather than an interval: the window between two balance asks is
   // recomputed from the answer each time, so the poller re-arms itself instead of
   // running on a constant it would have to choose in advance.
@@ -503,6 +504,14 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // The one append that says this daemon left, held so every route to a stop —
   // the op, a signal, idle, a handover — writes it exactly once.
   let departure: Promise<unknown> | null = null;
+  const activityPoller = createRedskilledActivityPoller({
+    poll: () => pollRepositoryActivity(),
+    registrations: () => registrations.values(),
+    clock,
+    attendedMs: activityMs,
+    armed: activityRegistration != null && activityRegistration.projects.length > 0,
+    stopping: () => stopping,
+  });
   let resolveClosed!: () => void;
   const closed = new Promise<void>((resolve) => {
     resolveClosed = resolve;
@@ -707,6 +716,9 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       now: clock(),
       reattachedWorkerIds: [...reattached],
       repositoryActivity: lastActivity,
+      // Two windows of the cadence IN FORCE: a threshold pinned to the attended
+      // one would report an idle host's deliberate back-off as a stopped poller.
+      activityStalenessMs: REDSKILLED_ACTIVITY_STALENESS_FACTOR * activityPoller.cadenceMs(),
       githubBalance: lastBalance,
       ...(deathAttributions === undefined ? {} : { deaths: deathAttributions }),
       // Derived here, once, for every surface: the observation history belongs
@@ -1365,6 +1377,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     });
     registrations.set(registration.project_label, registration);
     persistRegistrationIntent();
+    // Somebody is watching now: a poll waiting out an idle window comes forward.
+    activityPoller.nudge();
     // A current registration outranks every historical absence. Remove the old
     // tail now so a later deliberate stop cannot uncover an older lapse and lie
     // about which transition happened most recently.
@@ -1430,6 +1444,9 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     });
     registrations.set(registration.project_label, registration);
     persistRegistrationIntent();
+    // A renewal is a session saying "I am still here" — the same presence a
+    // registration carries, and the same reason not to wait out a back-off.
+    activityPoller.nudge();
     armIdleTimer();
     return {
       version: 1,
@@ -1956,23 +1973,6 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   /**
-   * Arm the poller, once, on its own window.
-   *
-   * Its interval is the tracker's rather than the sampler's: repository activity
-   * moves at human speed and costs shared quota, so polling it as often as the
-   * process table would spend a budget every project on the host draws from.
-   */
-  function armActivityTimer(): void {
-    if (stopping || activityTimer != null) return;
-    if (activityRegistration == null || activityRegistration.projects.length === 0 || activityMs <= 0) return;
-    void pollRepositoryActivity().catch(() => undefined);
-    activityTimer = setInterval(() => {
-      void pollRepositoryActivity().catch(() => undefined);
-    }, activityMs);
-    activityTimer.unref();
-  }
-
-  /**
    * Arm the queue poller on ITS window, which is not the activity poller's.
    *
    * Armed even with nothing registered, unlike the activity poller: the selectors
@@ -2184,7 +2184,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     if (registrationTimer) clearInterval(registrationTimer);
     if (replaceTimer) clearInterval(replaceTimer);
     if (replaceBootTimer) clearTimeout(replaceBootTimer);
-    if (activityTimer) clearInterval(activityTimer);
+    activityPoller.stop();
     if (balanceTimer) clearTimeout(balanceTimer);
     if (queueTimer) clearTimeout(queueTimer);
     if (demandTimer) clearInterval(demandTimer);
@@ -2429,7 +2429,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   armLeaseTimer();
   armRegistrationTimer();
   armReplaceTimer();
-  armActivityTimer();
+  activityPoller.arm();
   armBalanceTimer();
   armQueueTimer();
   armDemandTimer();

--- a/apps/redskilled/src/repository-activity.ts
+++ b/apps/redskilled/src/repository-activity.ts
@@ -88,8 +88,20 @@ export function githubEndpointFor(surface: GithubApiSurface, origin = "https://a
 /** How many repositories one aliased query may span. */
 export const REDSKILLED_ACTIVITY_BATCH_SIZE = 100;
 
-/** Default window between polls: activity moves at human speed, not at sampler speed. */
-export const DEFAULT_REDSKILLED_ACTIVITY_MS = 60_000;
+/**
+ * Default window between polls while an interactive session is watching.
+ *
+ * **The ATTENDED half of a presence-driven cadence** (ADR 0141): the Spec's
+ * ~15–30s, spent only while at least one session holds a registration open. The
+ * backed-off half, and the presence rule that chooses between them, live in
+ * `./activity-cadence.js` — this module spends the request and holds no policy
+ * about when to.
+ *
+ * Not the wished-for 5s: that is line reactivity, and the statusline's
+ * per-render socket read already delivers it against the daemon's cache without
+ * spending GitHub budget.
+ */
+export const DEFAULT_REDSKILLED_ACTIVITY_MS = 20_000;
 
 /** How far back "recently closed" reaches, when a caller states no window. */
 export const DEFAULT_REDSKILLED_ACTIVITY_CLOSED_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;

--- a/apps/redskilled/tests/activity-cadence.test.ts
+++ b/apps/redskilled/tests/activity-cadence.test.ts
@@ -1,0 +1,318 @@
+// The repository poll spends budget for whoever is watching (ADR 0141, #3564).
+//
+// The counters used to come from a local `gh` cache under a fifteen-minute TTL,
+// so an operator watching the line could not react to the repository. Moving the
+// fetch into the daemon fixes the freshness and creates the opposite hazard: a
+// host nobody is attached to would poll GitHub forever at the attended rate.
+//
+// Presence is the input, and it is the daemon's existing one — a session that is
+// alive renews the registration it holds, which `registrationRenewalStatus`
+// already calls `renewing`. Everything here drives that with a fake clock.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  activityPollComesForward,
+  interactiveSessionsHolding,
+  isCacheWarmCadenceMs,
+  nextActivityPollMs,
+  REDSKILLED_AMORTIZED_MIN_MS,
+  REDSKILLED_ACTIVITY_UNATTENDED_MS,
+  REDSKILLED_CACHE_WARM_MAX_MS,
+} from "../src/activity-cadence.js";
+import { DEFAULT_REDSKILLED_ACTIVITY_MS } from "../src/repository-activity.js";
+import { REDSKILLED_ACTIVITY_STALENESS_FACTOR } from "../src/activity-report.js";
+import {
+  buildProjectRegistration,
+  renewProjectRegistration,
+  sustainProjectRegistration,
+  REDSKILLED_REGISTRATION_TTL_MS,
+  type RedskilledProjectRegistration,
+} from "../src/project-registration.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+
+const T0 = "2026-08-11T09:00:00.000Z";
+const T0_MS = Date.parse(T0);
+
+/** A fake clock the daemon and the pure helpers can share. */
+function fakeClock(startMs: number): { now: () => string; advance: (ms: number) => void } {
+  let atMs = startMs;
+  return {
+    now: () => new Date(atMs).toISOString(),
+    advance: (ms: number) => {
+      atMs += ms;
+    },
+  };
+}
+
+function registration(atMs: number, label = "acme/p0"): RedskilledProjectRegistration {
+  return buildProjectRegistration(
+    { project_label: label, selector: "{}", argv: ["node", "dev.mjs", "run"], workspace_path: `/w/${label}`, target: 1 },
+    { now: new Date(atMs).toISOString() },
+  );
+}
+
+describe("the poll cadence follows presence", () => {
+  it("tightens to the attended window while a session holds a registration", () => {
+    expect(nextActivityPollMs({ attended: true })).toBe(DEFAULT_REDSKILLED_ACTIVITY_MS);
+  });
+
+  it("backs off when no session holds one", () => {
+    expect(nextActivityPollMs({ attended: false })).toBe(REDSKILLED_ACTIVITY_UNATTENDED_MS);
+  });
+
+  it("honors a stated attended window, and still backs off from it", () => {
+    expect(nextActivityPollMs({ attended: true, attendedMs: 15_000 })).toBe(15_000);
+    expect(nextActivityPollMs({ attended: false, attendedMs: 15_000 })).toBe(REDSKILLED_ACTIVITY_UNATTENDED_MS);
+  });
+
+  it("never polls FASTER unattended than attended, whatever a caller states", () => {
+    // The back-off may only ever slow down. A host nobody is watching that polled
+    // harder than an attended one would spend more of exactly the budget its
+    // idleness was meant to save.
+    for (const attendedMs of [15_000, 30_000, 120_000, 600_000]) {
+      const idle = nextActivityPollMs({ attended: false, attendedMs, unattendedMs: 1_000 });
+      expect(idle, `attended ${attendedMs}ms`).toBeGreaterThanOrEqual(attendedMs);
+    }
+  });
+
+  it("falls back to its own windows when a caller states nonsense", () => {
+    expect(nextActivityPollMs({ attended: true, attendedMs: 0 })).toBe(DEFAULT_REDSKILLED_ACTIVITY_MS);
+    expect(nextActivityPollMs({ attended: false, unattendedMs: Number.NaN }))
+      .toBe(REDSKILLED_ACTIVITY_UNATTENDED_MS);
+  });
+});
+
+describe("both declared cadences are legal under the cache-warm rule", () => {
+  it("keeps the attended window inside the Spec's 15–30s band", () => {
+    expect(DEFAULT_REDSKILLED_ACTIVITY_MS).toBeGreaterThanOrEqual(15_000);
+    expect(DEFAULT_REDSKILLED_ACTIVITY_MS).toBeLessThanOrEqual(30_000);
+  });
+
+  it("keeps every cadence out of the ~300s prompt-cache dead zone", () => {
+    // At or under 270s, or at or over 20 minutes. Never between them.
+    for (const cadence of [DEFAULT_REDSKILLED_ACTIVITY_MS, REDSKILLED_ACTIVITY_UNATTENDED_MS]) {
+      expect(isCacheWarmCadenceMs(cadence), `${cadence}ms`).toBe(true);
+    }
+    expect(isCacheWarmCadenceMs(300_000)).toBe(false);
+    expect(isCacheWarmCadenceMs(REDSKILLED_CACHE_WARM_MAX_MS)).toBe(true);
+    expect(isCacheWarmCadenceMs(REDSKILLED_CACHE_WARM_MAX_MS + 1)).toBe(false);
+    expect(isCacheWarmCadenceMs(REDSKILLED_AMORTIZED_MIN_MS)).toBe(true);
+  });
+
+  it("keeps the back-off short enough that an attaching operator waits one window", () => {
+    // The unattended window is also the worst case for how long somebody who
+    // just attached is told an old number by a plainly-armed interval.
+    expect(REDSKILLED_ACTIVITY_UNATTENDED_MS).toBeLessThanOrEqual(REDSKILLED_CACHE_WARM_MAX_MS);
+  });
+});
+
+describe("presence is read off the registrations", () => {
+  it("counts a registration a session was heard from inside the renewal cadence", () => {
+    const held = registration(T0_MS);
+
+    expect(interactiveSessionsHolding([held], T0_MS)).toBe(1);
+    expect(interactiveSessionsHolding([held], T0_MS + REDSKILLED_REGISTRATION_TTL_MS / 2 - 1)).toBe(1);
+  });
+
+  it("stops counting one the session has gone quiet on", () => {
+    const held = registration(T0_MS);
+
+    expect(interactiveSessionsHolding([held], T0_MS + REDSKILLED_REGISTRATION_TTL_MS / 2 + 1)).toBe(0);
+  });
+
+  it("counts it again the moment the session renews", () => {
+    const quietMs = T0_MS + REDSKILLED_REGISTRATION_TTL_MS / 2 + 1;
+    const renewed = renewProjectRegistration(registration(T0_MS), { now: new Date(quietMs).toISOString() });
+
+    expect(interactiveSessionsHolding([renewed], quietMs)).toBe(1);
+  });
+
+  it("does NOT count a drain the daemon is holding up on its own", () => {
+    // A self-renewing registration is an autonomous drain nobody is watching —
+    // the exact host this back-off exists for. Counting it as presence would
+    // make an unattended AFK host poll at the attended rate forever.
+    const quietMs = T0_MS + REDSKILLED_REGISTRATION_TTL_MS / 2 + 1;
+    const sustained = sustainProjectRegistration(registration(T0_MS), {
+      now: new Date(quietMs).toISOString(),
+      queue: { outcome: "counted", depth: 4 },
+    });
+
+    expect(sustained.verdict).toBe("open-work");
+    expect(interactiveSessionsHolding([sustained.registration], quietMs)).toBe(0);
+  });
+
+  it("counts nobody on a host with nothing registered, or with an unreadable clock", () => {
+    expect(interactiveSessionsHolding([], T0_MS)).toBe(0);
+    // Fail closed toward spending nothing: reading absence as presence costs
+    // budget on counters no operator is reading.
+    expect(interactiveSessionsHolding([registration(T0_MS)], Number.NaN)).toBe(0);
+  });
+});
+
+describe("a waiting poll is brought forward when a session appears", () => {
+  it("comes forward when an idle host's window is longer than presence now asks for", () => {
+    expect(activityPollComesForward({
+      pendingWindowMs: REDSKILLED_ACTIVITY_UNATTENDED_MS,
+      cadenceMs: nextActivityPollMs({ attended: true }),
+    })).toBe(true);
+  });
+
+  it("stays put when the window in force is the one already armed", () => {
+    // A session renewing on a timer must never be able to push a waiting poll
+    // away — that is a poll that never runs, dressed as freshness.
+    const attended = nextActivityPollMs({ attended: true });
+    expect(activityPollComesForward({ pendingWindowMs: attended, cadenceMs: attended })).toBe(false);
+  });
+
+  it("never pushes a tight poll out because a session went quiet", () => {
+    expect(activityPollComesForward({
+      pendingWindowMs: nextActivityPollMs({ attended: true }),
+      cadenceMs: REDSKILLED_ACTIVITY_UNATTENDED_MS,
+    })).toBe(false);
+  });
+
+  it("does nothing when no poll is armed, or when a window will not compare", () => {
+    expect(activityPollComesForward({ pendingWindowMs: null, cadenceMs: 20_000 })).toBe(false);
+    expect(activityPollComesForward({ pendingWindowMs: Number.NaN, cadenceMs: 20_000 })).toBe(false);
+    expect(activityPollComesForward({ pendingWindowMs: 240_000, cadenceMs: Number.NaN })).toBe(false);
+  });
+});
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+const REGISTRATION_REQUEST = {
+  project_label: "acme/p0",
+  selector: "{}",
+  argv: ["node", "dev.mjs", "run"],
+  workspace_path: "/w/p0",
+  target: 1,
+} as const;
+
+describe("the daemon's own loop spends at the window presence asks for", () => {
+  it("holds an idle host at the back-off, then tightens the moment a session registers", async () => {
+    // Only the intervals are faked: the daemon's start still does real I/O, and
+    // a fake clock over all of it would stall the bind rather than the timers.
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval", "setTimeout", "clearTimeout"] });
+    let calls = 0;
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      repositoryActivity: {
+        projects: [{ project_label: "acme/p0", owner: "acme", name: "p0" }],
+        hostTokenRef: "host",
+        intervalMs: 1_000,
+        transport: async () => {
+          calls += 1;
+          return { data: { rateLimit: { remaining: 4_900, resetAt: null } } };
+        },
+      },
+    });
+    running.push(daemon);
+
+    // One fetch at arming, so a daemon that just started is never empty. Then
+    // silence: five attended windows pass and nobody is watching, so the poll is
+    // still waiting out its four-minute one.
+    expect(calls).toBe(1);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(calls).toBe(1);
+
+    // A session registers. The waiting poll comes forward, and every window
+    // after it is the attended one.
+    daemon.registerProject({ ...REGISTRATION_REQUEST });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(calls).toBe(6);
+  });
+
+  it("goes back to the back-off once the session stops speaking for its project", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval", "setTimeout", "clearTimeout"] });
+    let calls = 0;
+    const clock = fakeClock(T0_MS);
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      clock: clock.now,
+      repositoryActivity: {
+        projects: [{ project_label: "acme/p0", owner: "acme", name: "p0" }],
+        hostTokenRef: "host",
+        intervalMs: 1_000,
+        transport: async () => {
+          calls += 1;
+          return { data: { rateLimit: { remaining: 4_900, resetAt: null } } };
+        },
+      },
+    });
+    running.push(daemon);
+    daemon.registerProject({ ...REGISTRATION_REQUEST });
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    const attended = calls;
+    expect(attended).toBeGreaterThan(1);
+
+    // The record still stands — it has not lapsed — but no session has spoken
+    // for it inside the renewal cadence, so the host is unwatched again.
+    clock.advance(REDSKILLED_REGISTRATION_TTL_MS / 2 + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const backedOff = calls;
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(calls).toBe(backedOff);
+  });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-cadence-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+describe("the daemon states the window its counters were promised at", () => {
+  it("moves the payload's staleness threshold as presence comes and goes", async () => {
+    // The cadence is not on the wire, but the promise it makes is: the payload's
+    // threshold is two windows of the cadence in force, so an idle host's
+    // four-minute-old counters are not reported as a poller that stopped.
+    const clock = fakeClock(T0_MS);
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      clock: clock.now,
+    });
+    running.push(daemon);
+
+    const thresholdMs = (): number => daemon.statuslinePayload().repository_activity.threshold_ms;
+    const attended = REDSKILLED_ACTIVITY_STALENESS_FACTOR * DEFAULT_REDSKILLED_ACTIVITY_MS;
+    const unattended = REDSKILLED_ACTIVITY_STALENESS_FACTOR * REDSKILLED_ACTIVITY_UNATTENDED_MS;
+
+    expect(thresholdMs()).toBe(unattended);
+
+    daemon.registerProject({
+      project_label: "acme/p0",
+      selector: "{}",
+      argv: ["node", "dev.mjs", "run"],
+      workspace_path: "/w/p0",
+      target: 1,
+    });
+    expect(thresholdMs()).toBe(attended);
+
+    // The session stops speaking for it. The record still stands — it has not
+    // lapsed — but nobody is watching, so the poll backs off.
+    clock.advance(REDSKILLED_REGISTRATION_TTL_MS / 2 + 1_000);
+    expect(thresholdMs()).toBe(unattended);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3564. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3564

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789015670&installation_model_id=20659&pr_number=3571&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3571&signature=7a56a865ce1ed2179a7420f24968ddf9afb1f990d96dc8603caeaf101405c55d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->