### PR TITLE
chore: #3568 Castle MCP counter surfaces serve from the daemon payload

### DIFF
--- a/apps/dev/src/mcp/dependencies.ts
+++ b/apps/dev/src/mcp/dependencies.ts
@@ -25,6 +25,7 @@ import { matchesSelector } from "../core/session.js";
 import * as ghx from "../runtime/gh.js";
 import {
   createRedskilledBirthPort,
+  resolveProjectLabel,
 } from "../runtime/redskilled-birth.js";
 import {
   afkPaths,
@@ -63,8 +64,16 @@ import {
   listDisposableWorktrees,
   partitionReadyForAgentByTrust,
   removeDisposableWorktree,
+  type StatuslineAggregateReaders,
 } from "./queue.js";
 import { eventsSinceImpl } from "./events.js";
+
+export interface CastleMcpReadPorts {
+  statuslinePayload?: StatuslineAggregateReaders["statuslinePayload"];
+  projectLabel?: StatuslineAggregateReaders["projectLabel"];
+  listCandidates?: typeof listCandidates;
+  listHitlCandidates?: typeof listHitlCandidates;
+}
 
 export function withCachedDeps(
   deps: CastleMcpDependencies,
@@ -139,6 +148,7 @@ export function withCachedDeps(
 export function createCastleMcpDependencies(
   root = process.cwd(),
   operations: DevAfkMcpOperations = createDefaultDevAfkMcpOperations(root),
+  readers: CastleMcpReadPorts = {},
 ): CastleMcpDependencies {
   const baseDeps: CastleMcpDependencies = {
     projectStatus: () => projectStatus(root),
@@ -189,8 +199,8 @@ export function createCastleMcpDependencies(
       const context = await resolveRepoContext(root);
       const gh = { cwd: root, repo: context.repo };
       let [readyForAgent, readyForHuman] = await Promise.all([
-        listCandidates(gh),
-        listHitlCandidates(gh),
+        (readers.listCandidates ?? listCandidates)(gh),
+        (readers.listHitlCandidates ?? listHitlCandidates)(gh),
       ]);
       // Scoped preview: apply a fleet selector (tags/user/spec/lane/…) over the
       // ready pool, mirroring exactly what a fleet with that selector would see.
@@ -346,7 +356,13 @@ export function createCastleMcpDependencies(
     triage: (input) => operations.triage(input),
     respond: (input) => operations.respond(input),
     deadendAudit: () => operations.deadendAudit(),
-    statuslineAggregate: () => collectStatuslineAggregate(root),
+    statuslineAggregate: () =>
+      collectStatuslineAggregate(root, {
+        statuslinePayload:
+          readers.statuslinePayload
+          ?? (() => createRedskilledBirthPort({ root }).statuslinePayload()),
+        projectLabel: readers.projectLabel ?? (() => resolveProjectLabel(root)),
+      }),
     eventsSince: (input) => eventsSinceImpl(root, input),
   };
   return withCachedDeps(baseDeps, new ResidentReadCache());

--- a/apps/dev/src/mcp/queue.ts
+++ b/apps/dev/src/mcp/queue.ts
@@ -7,6 +7,7 @@ import type {
   WorktreeRemoveInput,
 } from "@reddb-io/red-castle/mcp-server";
 import { readBuildInfo } from "@reddb-io/build-info";
+import type { RedskilledRenderPayload } from "@reddb-io/redskilled-render";
 import type { HitlCandidate } from "../core/hitl-selection.js";
 import type { IssueCandidate } from "../core/session.js";
 import {
@@ -25,6 +26,10 @@ import {
   type TrustProvenance,
 } from "../core/trust-gate.js";
 import * as gitx from "../runtime/git.js";
+import {
+  createRedskilledBirthPort,
+  resolveProjectLabel,
+} from "../runtime/redskilled-birth.js";
 
 import { projectStatus } from "./project.js";
 import { workerVitals } from "./vitals.js";
@@ -128,14 +133,38 @@ export async function removeDisposableWorktree(root: string, input: WorktreeRemo
  * from the Claude Code statusline stdin payload and are deliberately absent —
  * the tool must not fake them.
  */
-export async function collectStatuslineAggregate(root: string) {
+export interface StatuslineAggregateReaders {
+  statuslinePayload(): Promise<
+    Pick<RedskilledRenderPayload, "remote_counters" | "repository_activity">
+  >;
+  projectLabel(): string;
+}
+
+export async function collectStatuslineAggregate(
+  root: string,
+  readers: StatuslineAggregateReaders = {
+    statuslinePayload: () =>
+      createRedskilledBirthPort({ root }).statuslinePayload(),
+    projectLabel: () => resolveProjectLabel(root),
+  },
+) {
   const repoCtx = {
     root,
     repo: inferGitHubRepoSlug(root),
     remote: "origin",
   };
 
-  const [project, localGit, docs, afkBlock, fleetChip, fleet, workers, validationGate] =
+  const [
+    project,
+    localGit,
+    docs,
+    afkBlock,
+    fleetChip,
+    fleet,
+    workers,
+    validationGate,
+    daemonPayload,
+  ] =
     await Promise.all([
       resolveProject(root),
       collectStatuslineLocalGit(root),
@@ -145,7 +174,28 @@ export async function collectStatuslineAggregate(root: string) {
       projectStatus(root).catch(() => null),
       workerVitals(root),
       collectStatuslineValidationGate(root),
+      readers.statuslinePayload().catch(() => undefined),
     ]);
+
+  const projectLabel = readers.projectLabel();
+  const counterProject = daemonPayload?.remote_counters?.projects.find(
+    (candidate) => candidate.project_label === projectLabel,
+  );
+  const activityProject = daemonPayload?.repository_activity?.projects.find(
+    (candidate) => candidate.project_label === projectLabel,
+  );
+  const remoteCounters = daemonPayload?.remote_counters == null
+    ? null
+    : {
+        ...daemonPayload.remote_counters,
+        projects: counterProject == null ? [] : [counterProject],
+      };
+  const repositoryActivity = daemonPayload?.repository_activity == null
+    ? null
+    : {
+        ...daemonPayload.repository_activity,
+        projects: activityProject == null ? [] : [activityProject],
+      };
 
   return {
     project: {
@@ -157,23 +207,21 @@ export async function collectStatuslineAggregate(root: string) {
       pointer_version: project.pointerVersion ?? null,
       docs_unlanded: docs?.count ?? 0,
     },
-    /**
-     * The LOCAL repository facts, and honest nulls where the remote ones were.
-     *
-     * The open-PR/open-issue counts came from this app's own `gh` cache, which is
-     * gone (ADR 0141 decision 2): every remote counter is the daemon's, served
-     * dated on its statusline payload, and this tool reads that payload in #3568.
-     * Until it does the numbers are `null` — an absence a consumer can see —
-     * rather than a zero that reads as an empty repository. The diffstat stays
-     * here because it never needed a network.
-     */
+    /** Flattened compatibility values, all sourced from the daemon payload. */
     repo: {
-      open_prs: null,
-      today_prs: null,
-      open_issues: null,
+      open_prs: counterProject?.counters.open_pull_requests.value
+        ?? activityProject?.counts?.open_pull_requests
+        ?? null,
+      today_prs: activityProject?.counts?.recently_closed ?? null,
+      open_issues: counterProject?.counters.open_issues.value
+        ?? activityProject?.counts?.open_issues
+        ?? null,
       local_added: localGit.localAdded,
       local_removed: localGit.localRemoved,
     },
+    /** The daemon's own dated blocks, scoped to this MCP's project. */
+    remote_counters: remoteCounters,
+    repository_activity: repositoryActivity,
     docs: { unlanded: docs?.count ?? 0 },
     validation_gate: validationGate,
     fleet,
@@ -205,10 +253,10 @@ export async function collectStatuslineAggregate(root: string) {
      * it — summed across live workers, including the fleet runner/model/effort
      * label the per-worker rows carry individually. Null when no live worker. */
     afk: afkBlock,
-    /** The queue depths, on the same terms as the counts above: daemon-owned. */
+    /** Flattened compatibility values from the same dated counter block above. */
     queue: {
-      ready_for_agent: null,
-      ready_for_human: null,
+      ready_for_agent: counterProject?.counters.ready_queue.value ?? null,
+      ready_for_human: counterProject?.counters.human_queue.value ?? null,
     },
   };
 }
@@ -218,4 +266,3 @@ export async function collectStatuslineAggregate(root: string) {
 export type StatuslineAggregate = Awaited<
   ReturnType<typeof collectStatuslineAggregate>
 >;
-

--- a/apps/dev/src/runtime/redskilled-birth.ts
+++ b/apps/dev/src/runtime/redskilled-birth.ts
@@ -47,7 +47,10 @@ import {
   readRedskilledUnitStatus,
   type RedskilledUnitStatus,
 } from "@reddb-io/redskilled/supervision";
-import type { RedskilledDashboard } from "@reddb-io/redskilled-render";
+import type {
+  RedskilledDashboard,
+  RedskilledRenderPayload,
+} from "@reddb-io/redskilled-render";
 import type {
   RedskilledProjectRegistration,
   RedskilledProjectRegistrationRequest,
@@ -153,6 +156,8 @@ export interface RedskilledBirthPort {
   hostState(): Promise<RedskilledHostState>;
   /** Read the daemon's structured global dashboard, never this project's slice. */
   hostDashboard(): Promise<RedskilledDashboard>;
+  /** Read the daemon's dated statusline payload without fetching any tracker state. */
+  statuslinePayload(): Promise<RedskilledRenderPayload>;
   /** Audit host provisioning without creating a home, bundle, daemon, or unit. */
   provisionCheck(): Promise<RedskilledProvisionReport>;
   /** Read whether the optional host supervisor unit is installed and running. */
@@ -303,6 +308,14 @@ export function createRedskilledBirthPort(options: CreateRedskilledBirthOptions)
 
     async hostDashboard() {
       return await readRedskilledDashboardRender(paths, { mode: "global" }, config);
+    },
+
+    async statuslinePayload() {
+      return await readRedskilledStatuslinePayload(paths, config, {
+        logs: false,
+        vitals: false,
+        display: false,
+      });
     },
 
     async provisionCheck() {

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -11,6 +11,7 @@ import {
   castleLanePath,
   createEnginePaths,
 } from "@reddb-io/red-castle/engine";
+import { createCastleMcpTools } from "@reddb-io/red-castle/mcp-server";
 import { afkPaths } from "../src/runtime/wire.js";
 import { recordBootError } from "../src/commands/run/state.js";
 import {
@@ -677,6 +678,82 @@ describe("rsp wait MCP tools", () => {
 });
 
 describe("statusline_aggregate MCP tool", () => {
+  it("serves dated repository and queue counters from the daemon payload without tracker reads", async () => {
+    const cwd = await root();
+    const projectLabel = cwd.split("/").at(-1)!;
+    const counter = (
+      name: "open_pull_requests" | "open_issues" | "ready_queue" | "human_queue",
+      value: number,
+      ageMs: number,
+    ) => ({
+      name,
+      value,
+      fetched_at: "2026-08-11T12:00:00.000Z",
+      age_ms: ageMs,
+      threshold_ms: 60_000,
+      stale: ageMs > 60_000,
+      reason: `daemon fixture ${name}`,
+    });
+    const remoteCounters = {
+      version: 1 as const,
+      threshold_ms: 60_000,
+      projects: [{
+        project_label: projectLabel,
+        repository: "acme/widgets",
+        outcome: "counted",
+        counters: {
+          open_pull_requests: counter("open_pull_requests", 3, 5_000),
+          open_issues: counter("open_issues", 24, 65_000),
+          ready_queue: counter("ready_queue", 7, 15_000),
+          human_queue: counter("human_queue", 2, 75_000),
+        },
+      }],
+      reason: "daemon fixture",
+    };
+    const trackerReads: string[] = [];
+    const deps = createCastleMcpDependencies(cwd, fakeOperations(), {
+      statuslinePayload: async () => ({
+        remote_counters: remoteCounters,
+        repository_activity: {
+          fetched_at: "2026-08-11T12:00:00.000Z",
+          age_ms: 5_000,
+          stale: false,
+          projects: [{
+            project_label: projectLabel,
+            repository: "acme/widgets",
+            counts: { open_pull_requests: 3, open_issues: 24, recently_closed: 5 },
+          }],
+          reason: "daemon fixture",
+        },
+      }),
+      listCandidates: async () => {
+        trackerReads.push("ready-for-agent");
+        return [];
+      },
+      listHitlCandidates: async () => {
+        trackerReads.push("ready-for-human");
+        return [];
+      },
+    });
+    const aggregate = createCastleMcpTools(deps)
+      .find((tool) => tool.name === "statusline_aggregate")!;
+
+    await expect(aggregate.invoke({})).resolves.toMatchObject({
+      remote_counters: remoteCounters,
+      repo: { open_prs: 3, today_prs: 5, open_issues: 24 },
+      queue: { ready_for_agent: 7, ready_for_human: 2 },
+    });
+    expect(remoteCounters.projects[0]!.counters.open_issues).toMatchObject({
+      age_ms: 65_000,
+      stale: true,
+    });
+    expect(remoteCounters.projects[0]!.counters.human_queue).toMatchObject({
+      age_ms: 75_000,
+      stale: true,
+    });
+    expect(trackerReads).toEqual([]);
+  });
+
   it("returns the payload shape with project, repo, fleet, workers, and queue", async () => {
     const cwd = await root();
     const deps = createCastleMcpDependencies(cwd, fakeOperations());

--- a/apps/dev/tests/statusline-aggregate-coverage.test.ts
+++ b/apps/dev/tests/statusline-aggregate-coverage.test.ts
@@ -61,13 +61,70 @@ const PAYLOAD: StatuslineAggregate = {
     docs_unlanded: 2,
   },
   repo: {
-    // The remote counters are the daemon's since ADR 0141 decision 2; the tool
-    // states their absence until #3568 reads them off the payload.
-    open_prs: null,
-    today_prs: null,
-    open_issues: null,
+    open_prs: 3,
+    today_prs: 5,
+    open_issues: 24,
     local_added: 40,
     local_removed: 7,
+  },
+  remote_counters: {
+    version: 1,
+    threshold_ms: 60_000,
+    projects: [{
+      project_label: "red-skills",
+      repository: "reddb-io/red-skills",
+      outcome: "counted",
+      counters: {
+        open_pull_requests: {
+          name: "open_pull_requests",
+          value: 3,
+          fetched_at: "2026-08-11T12:00:00.000Z",
+          age_ms: 5_000,
+          threshold_ms: 60_000,
+          stale: false,
+          reason: "counted by daemon",
+        },
+        open_issues: {
+          name: "open_issues",
+          value: 24,
+          fetched_at: "2026-08-11T12:00:00.000Z",
+          age_ms: 5_000,
+          threshold_ms: 60_000,
+          stale: false,
+          reason: "counted by daemon",
+        },
+        ready_queue: {
+          name: "ready_queue",
+          value: 6,
+          fetched_at: "2026-08-11T12:00:00.000Z",
+          age_ms: 5_000,
+          threshold_ms: 60_000,
+          stale: false,
+          reason: "counted by daemon",
+        },
+        human_queue: {
+          name: "human_queue",
+          value: 1,
+          fetched_at: "2026-08-11T12:00:00.000Z",
+          age_ms: 5_000,
+          threshold_ms: 60_000,
+          stale: false,
+          reason: "counted by daemon",
+        },
+      },
+    }],
+    reason: "daemon fixture",
+  },
+  repository_activity: {
+    fetched_at: "2026-08-11T12:00:00.000Z",
+    age_ms: 5_000,
+    stale: false,
+    projects: [{
+      project_label: "red-skills",
+      repository: "reddb-io/red-skills",
+      counts: { open_pull_requests: 3, open_issues: 24, recently_closed: 5 },
+    }],
+    reason: "daemon fixture",
   },
   docs: { unlanded: 2 },
   validation_gate: { occupied: 2, total: 3 },
@@ -139,7 +196,7 @@ const PAYLOAD: StatuslineAggregate = {
     effort: "high",
     sourceCounts: [{ origin: "afk", count: 2 }],
   },
-  queue: { ready_for_agent: null, ready_for_human: null },
+  queue: { ready_for_agent: 6, ready_for_human: 1 },
 };
 
 /**


### PR DESCRIPTION
Automated AFK landing for #3568. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3568

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789039220&installation_model_id=20659&pr_number=3574&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3574&signature=db2bb5a21bac588a8588fd858a40da721f016a1b2caf6f2a79caa4c01740fbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->