### PR TITLE
chore: #3567 Statusline Lifecycle state machine, the rsk= token, and the 150ms socket deadline

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -15,10 +15,6 @@
 
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-// From the COMMAND module, never the CLI: cli.ts ends in a self-invocation
-// guard that is always true inside a single-file bundle, so importing it ships
-// a second argv-reading CLI inside every dev binary (#3546, canary catch).
-import { runStatusline as runRedskilledStatusline } from "@reddb-io/redskilled/statusline-command";
 import { configFile } from "@reddb-io/shared/red-paths.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { decode } from "@reddb-io/toon";
@@ -44,6 +40,7 @@ import {
   type StatuslineLocalGit,
   type StatuslineLocalGitDeps,
 } from "../runtime/wire.js";
+import { collectStatuslineTail } from "../runtime/wire/statusline-lifecycle.js";
 import * as gitx from "../runtime/git.js";
 
 /** Read the entire stdin stream as a UTF-8 string (empty when there is none). */
@@ -316,8 +313,8 @@ export async function resolveStatuslineBedrock(
 
 /**
  * `statusline "<project-root>"` — resolve the root and opt-out, render the
- * bedrock, then append the shared redskilled render as the tail. Emits nothing
- * (and exits 0) only when the project opted out.
+ * bedrock, then append the lifecycle-governed Shared redskilled tail. Emits
+ * nothing (and exits 0) only when the project opted out.
  *
  * The bedrock renders FIRST and unconditionally (ADR 0141 §1): an unreachable
  * daemon costs the operator the tail, never the model, context, subscription
@@ -344,10 +341,11 @@ export async function statuslineCommand(
 
   if (!statuslineEnabled(root)) return 0;
 
-  // One local socket read, one shared renderer. The daemon document already
-  // carries the Worker rows, repository activity, quota posture, liveness and
-  // staleness; asking project collectors for any of those facts here would put
-  // tracker and CI clients back in the terminal-prompt path (#3546).
+  // One bounded local socket probe, one Shared renderer. The daemon document
+  // already carries the Worker rows, repository activity, quota posture,
+  // liveness and staleness; asking project collectors for any of those facts
+  // here would put tracker and CI clients back in the terminal-prompt path
+  // (#3546). The probe-only wire never auto-spawns redskilled.
   //
   // `--no-workers` belonged to the retired two-producer adapter. Once the daemon
   // line reached Worker-row parity (#3151), suppressing its rows would discard
@@ -357,15 +355,9 @@ export async function statuslineCommand(
   const bedrock = renderStatuslineBedrock(await resolveStatuslineBedrock(root, payload));
   // The tail is buffered rather than streamed so the bedrock can LEAD the header
   // line the daemon opens with — one line, two segments, in that order.
-  const tail: string[] = [];
-  const code = await runRedskilledStatusline(daemonArgs, {
-    cwd: root,
-    write: (line) => {
-      tail.push(line);
-    },
-  });
-  for (const line of composeStatuslineLines(bedrock, tail.join("").split("\n"))) {
+  const tail = await collectStatuslineTail(root, daemonArgs);
+  for (const line of composeStatuslineLines(bedrock, tail.lines)) {
     stdout.write(`${line}\n`);
   }
-  return code;
+  return 0;
 }

--- a/apps/dev/src/core/statusline-lifecycle.ts
+++ b/apps/dev/src/core/statusline-lifecycle.ts
@@ -1,0 +1,76 @@
+/**
+ * The visible state of the statusline's one read from redskilled.
+ *
+ * `live` is deliberately quiet: current data is its own evidence. Every other
+ * state replaces the daemon tail with one compact token, except a deadline miss
+ * with a last-known tail, where the old data stays visible beside its age and
+ * the `degraded` token.
+ */
+import { formatAgeSeconds } from "@reddb-io/redskilled-render";
+
+export type StatuslineLifecycleState =
+  | "bedrock-only"
+  | "connecting"
+  | "registering"
+  | "unregistered"
+  | "live"
+  | "degraded";
+
+export type StatuslineSocketProbe = "disabled" | "connecting" | "unreachable" | "answered";
+export type StatuslineRegistrationPresence = "pending" | "absent" | "present";
+
+export interface StatuslineLifecycleInput {
+  readonly probe: StatuslineSocketProbe;
+  readonly registration?: StatuslineRegistrationPresence;
+  readonly payloadAgeMs?: number | null;
+  readonly stalenessWindowMs?: number;
+  /** A daemon may call a payload stale for a reason other than age. */
+  readonly payloadStale?: boolean;
+}
+
+/** Map wire facts to the one visible lifecycle state. PURE. */
+export function resolveStatuslineLifecycle(input: StatuslineLifecycleInput): StatuslineLifecycleState {
+  if (input.probe === "disabled" || input.probe === "unreachable") return "bedrock-only";
+  if (input.probe === "connecting") return "connecting";
+  if (input.registration === "pending") return "registering";
+  if (input.registration !== "present") return "unregistered";
+
+  const agePastWindow =
+    input.payloadAgeMs != null &&
+    Number.isFinite(input.payloadAgeMs) &&
+    input.stalenessWindowMs != null &&
+    input.payloadAgeMs > input.stalenessWindowMs;
+  return input.payloadStale === true || agePastWindow ? "degraded" : "live";
+}
+
+/** The compact lifecycle token; healthy data carries no redundant badge. PURE. */
+export function renderStatuslineLifecycleToken(state: StatuslineLifecycleState): string | null {
+  return state === "live" ? null : `rsk=${state}`;
+}
+
+export interface LifecycleTailInput {
+  readonly state: StatuslineLifecycleState;
+  readonly tail?: readonly string[];
+  /** Present only when `tail` is a last-known snapshot rather than this read. */
+  readonly cachedAgeMs?: number;
+}
+
+/**
+ * Render the lifecycle-owned tail segment. PURE.
+ *
+ * A live read passes the Shared render through untouched. A non-live read emits
+ * only its state token, unless the deadline fallback supplied a cached tail; in
+ * that case its head states both age and degradation while its Worker rows stay
+ * intact.
+ */
+export function lifecycleTailLines(input: LifecycleTailInput): string[] {
+  const tail = [...(input.tail ?? [])];
+  if (input.state === "live") return tail;
+
+  const token = renderStatuslineLifecycleToken(input.state)!;
+  if (input.cachedAgeMs == null || tail.length === 0) return [token];
+
+  const age = formatAgeSeconds(Math.max(0, input.cachedAgeMs)) ?? "0s";
+  const [head, ...rest] = tail;
+  return [`${head} · age=${age} · ${token}`, ...rest];
+}

--- a/apps/dev/src/runtime/wire/statusline-lifecycle.ts
+++ b/apps/dev/src/runtime/wire/statusline-lifecycle.ts
@@ -1,0 +1,192 @@
+/**
+ * The Statusline Lifecycle wire: one bounded, probe-only redskilled read and a
+ * last-known Shared-render tail in the statusline state lane.
+ */
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { probeStatusline } from "@reddb-io/redskilled/statusline-command";
+import type { RedskilledStatuslineProjectMatch } from "@reddb-io/redskilled-render";
+import { statuslineStateDir } from "@reddb-io/shared/red-paths.js";
+import { encodeDevSnapshotToon } from "../../core/toon-snapshot.js";
+import {
+  lifecycleTailLines,
+  resolveStatuslineLifecycle,
+  type StatuslineLifecycleState,
+  type StatuslineRegistrationPresence,
+} from "../../core/statusline-lifecycle.js";
+import { decodeCacheDocument, withTimeout } from "./statusline-git.js";
+
+export const STATUSLINE_SOCKET_DEADLINE_MS = 150;
+const STATUSLINE_TAIL_CACHE = "statusline-tail-cache.toon";
+
+/** The minimum daemon reply the lifecycle wire needs after the Shared render. */
+export interface StatuslineTailProbe {
+  readonly lines: readonly string[];
+  readonly generatedAt: string;
+  readonly payloadAgeMs: number | null;
+  readonly stalenessWindowMs: number;
+  readonly payloadStale: boolean;
+  readonly mode: "local" | "global";
+  readonly projectMatch: RedskilledStatuslineProjectMatch;
+}
+
+export type StatuslineTailProbeFn = (
+  args: readonly string[],
+  root: string,
+  deadlineMs: number,
+) => Promise<StatuslineTailProbe>;
+
+interface StatuslineTailCache {
+  readonly version: 1;
+  readonly lines: readonly string[];
+  readonly generatedAt: string;
+  readonly cachedAtMs: number;
+}
+
+export interface StatuslineTailWireDeps {
+  readonly nowMs?: () => number;
+  readonly deadlineMs?: number;
+  readonly probe?: StatuslineTailProbeFn;
+  readonly readCache?: (path: string) => string | null;
+  readonly writeCache?: (path: string, text: string) => void;
+}
+
+export interface StatuslineTailResult {
+  readonly state: StatuslineLifecycleState;
+  readonly lines: readonly string[];
+}
+
+type ProbeOutcome =
+  | { readonly kind: "answered"; readonly value: StatuslineTailProbe }
+  | { readonly kind: "unreachable" }
+  | { readonly kind: "connecting" };
+
+function readCacheFile(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function writeCacheFile(path: string, text: string): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, text, "utf8");
+    renameSync(tmp, path);
+  } catch {
+    // Best effort: an unwritable cache costs last-known data, never the bedrock.
+  }
+}
+
+function decodeTailCache(text: string | null): StatuslineTailCache | null {
+  if (text == null) return null;
+  try {
+    const value = decodeCacheDocument(text) as Partial<StatuslineTailCache>;
+    if (
+      value.version !== 1 ||
+      !Array.isArray(value.lines) ||
+      !value.lines.every((line) => typeof line === "string") ||
+      typeof value.generatedAt !== "string" ||
+      typeof value.cachedAtMs !== "number"
+    ) return null;
+    return value as StatuslineTailCache;
+  } catch {
+    return null;
+  }
+}
+
+function cacheAgeMs(cache: StatuslineTailCache, nowMs: number): number {
+  const generatedMs = Date.parse(cache.generatedAt);
+  return nowMs - (Number.isFinite(generatedMs) ? generatedMs : cache.cachedAtMs);
+}
+
+function registrationPresence(probe: StatuslineTailProbe): StatuslineRegistrationPresence {
+  if (probe.mode === "global" || probe.projectMatch === "matched") return "present";
+  if (probe.projectMatch === "name-only") return "pending";
+  return "absent";
+}
+
+async function productionProbe(
+  args: readonly string[],
+  root: string,
+  deadlineMs: number,
+): Promise<StatuslineTailProbe> {
+  const observed = await probeStatusline(args, {
+    cwd: root,
+    client: { requestTimeoutMs: deadlineMs },
+  });
+  return {
+    lines: observed.render.lines,
+    generatedAt: observed.payload.generated_at,
+    payloadAgeMs: observed.payload.staleness.age_ms,
+    stalenessWindowMs: observed.payload.staleness.threshold_ms,
+    payloadStale: observed.payload.staleness.stale,
+    mode: observed.render.mode,
+    projectMatch: observed.render.project_match,
+  };
+}
+
+/**
+ * Read and classify the daemon tail without ever spawning the daemon.
+ *
+ * The outer race is the prompt's wall-clock guarantee; the production probe
+ * gives the socket transport the same deadline so its losing request is also
+ * closed rather than left resident. A deadline miss with a cache serves that
+ * tail as degraded; with no cache it states that the probe is still connecting.
+ */
+export async function collectStatuslineTail(
+  root: string,
+  args: readonly string[],
+  deps: StatuslineTailWireDeps = {},
+): Promise<StatuslineTailResult> {
+  const nowMs = (deps.nowMs ?? Date.now)();
+  const deadlineMs = deps.deadlineMs ?? STATUSLINE_SOCKET_DEADLINE_MS;
+  const cachePath = join(statuslineStateDir(root), STATUSLINE_TAIL_CACHE);
+  const cache = decodeTailCache((deps.readCache ?? readCacheFile)(cachePath));
+  const attempt: Promise<ProbeOutcome> = (deps.probe ?? productionProbe)(args, root, deadlineMs).then(
+    (value) => ({ kind: "answered" as const, value }),
+    () => ({ kind: "unreachable" as const }),
+  );
+  const outcome = await withTimeout<ProbeOutcome>(attempt, deadlineMs, { kind: "connecting" });
+
+  if (outcome.kind === "connecting") {
+    if (cache != null) {
+      return {
+        state: "degraded",
+        lines: lifecycleTailLines({
+          state: "degraded",
+          tail: cache.lines,
+          cachedAgeMs: cacheAgeMs(cache, nowMs),
+        }),
+      };
+    }
+    return { state: "connecting", lines: lifecycleTailLines({ state: "connecting" }) };
+  }
+  if (outcome.kind === "unreachable") {
+    return { state: "bedrock-only", lines: lifecycleTailLines({ state: "bedrock-only" }) };
+  }
+
+  const reply = outcome.value;
+  const state = resolveStatuslineLifecycle({
+    probe: "answered",
+    registration: registrationPresence(reply),
+    payloadAgeMs: reply.payloadAgeMs,
+    stalenessWindowMs: reply.stalenessWindowMs,
+    payloadStale: reply.payloadStale,
+  });
+  if (state === "live") {
+    const value: StatuslineTailCache = {
+      version: 1,
+      lines: reply.lines,
+      generatedAt: reply.generatedAt,
+      cachedAtMs: nowMs,
+    };
+    (deps.writeCache ?? writeCacheFile)(cachePath, encodeDevSnapshotToon(value as never));
+  }
+  return {
+    state,
+    lines: lifecycleTailLines({ state, tail: state === "live" ? reply.lines : undefined }),
+  };
+}

--- a/apps/dev/tests/statusline-counters.test.ts
+++ b/apps/dev/tests/statusline-counters.test.ts
@@ -25,7 +25,7 @@ import {
   type RedskilledRenderPayload,
 } from "@reddb-io/redskilled-render";
 
-const { localGit, runStatusline } = vi.hoisted(() => ({
+const { localGit, runStatusline, probeStatusline } = vi.hoisted(() => ({
   localGit: vi.fn(async () => ({
     basename: "red-skills",
     branch: "afk/3566-counters",
@@ -36,9 +36,14 @@ const { localGit, runStatusline } = vi.hoisted(() => ({
     _args: readonly string[],
     _io: { readonly write?: (line: string) => void },
   ) => 0),
+  // The lifecycle wire (#3567) reaches the daemon through `probeStatusline`;
+  // unstubbed it rejects, which is the honest daemon-absent default.
+  probeStatusline: vi.fn(async (): Promise<unknown> => {
+    throw new Error("no daemon in this test");
+  }),
 }));
 
-vi.mock("@reddb-io/redskilled/statusline-command", () => ({ runStatusline }));
+vi.mock("@reddb-io/redskilled/statusline-command", () => ({ runStatusline, probeStatusline }));
 vi.mock("../src/runtime/wire.js", () => ({
   collectStatuslineLocalGit: localGit,
   resolveRepoBasename: localGit,
@@ -129,16 +134,21 @@ function daemonPayload(ageMs: number): RedskilledRenderPayload {
 
 /** The daemon, posed as the one thing it is here: a payload and the real render. */
 function serve(ageMs: number): void {
-  runStatusline.mockImplementationOnce(async (
-    _args: readonly string[],
-    io: { readonly write?: (line: string) => void },
-  ) => {
+  // The counters' own ages live inside the payload fixture (per-token ages,
+  // ADR 0141); the PAYLOAD stays fresh, so the lifecycle resolves `live` and
+  // the tail renders — counter age is data, never a lifecycle state.
+  probeStatusline.mockImplementationOnce(async () => {
     const render = renderRedskilledStatusline(daemonPayload(ageMs), {
       ...REDSKILLED_STATUSLINE_DEFAULTS,
       project: PROJECT,
     });
-    io.write?.(`${render.lines.join("\n")}\n`);
-    return 0;
+    return {
+      render: { lines: render.lines, mode: "project", project_match: "matched" },
+      payload: {
+        generated_at: new Date().toISOString(),
+        staleness: { age_ms: 1_000, threshold_ms: 30_000, stale: false },
+      },
+    };
   });
 }
 

--- a/apps/dev/tests/statusline-lifecycle.test.ts
+++ b/apps/dev/tests/statusline-lifecycle.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  lifecycleTailLines,
+  renderStatuslineLifecycleToken,
+  resolveStatuslineLifecycle,
+  type StatuslineLifecycleState,
+} from "../src/core/statusline-lifecycle.js";
+import {
+  collectStatuslineTail,
+  type StatuslineTailProbe,
+  type StatuslineTailWireDeps,
+} from "../src/runtime/wire/statusline-lifecycle.js";
+
+const ROOT = "/tmp/statusline-lifecycle-fixture";
+
+describe("Statusline Lifecycle render", () => {
+  it.each([
+    "bedrock-only",
+    "connecting",
+    "registering",
+    "unregistered",
+    "degraded",
+  ] satisfies StatuslineLifecycleState[])("renders %s as the compact rsk token", (state) => {
+    expect(renderStatuslineLifecycleToken(state)).toBe(`rsk=${state}`);
+    expect(lifecycleTailLines({ state })).toEqual([`rsk=${state}`]);
+  });
+
+  it("renders no lifecycle token in live", () => {
+    expect(renderStatuslineLifecycleToken("live")).toBeNull();
+    expect(lifecycleTailLines({ state: "live", tail: ["daemon tail"] })).toEqual(["daemon tail"]);
+  });
+
+  it.each([
+    [{ probe: "disabled" }, "bedrock-only"],
+    [{ probe: "unreachable" }, "bedrock-only"],
+    [{ probe: "connecting" }, "connecting"],
+    [{ probe: "answered", registration: "pending" }, "registering"],
+    [{ probe: "answered", registration: "absent" }, "unregistered"],
+    [{ probe: "answered", registration: "present", payloadAgeMs: 30_001, stalenessWindowMs: 30_000 }, "degraded"],
+    [{ probe: "answered", registration: "present", payloadAgeMs: 30_000, stalenessWindowMs: 30_000 }, "live"],
+  ] as const)("maps %o to %s", (input, expected) => {
+    expect(resolveStatuslineLifecycle(input)).toBe(expected);
+  });
+});
+
+function probe(overrides: Partial<StatuslineTailProbe> = {}): StatuslineTailProbe {
+  return {
+    lines: ["acme/widgets 1w 128M", "w123 working"],
+    generatedAt: "2026-08-11T12:00:00.000Z",
+    payloadAgeMs: 5_000,
+    stalenessWindowMs: 30_000,
+    payloadStale: false,
+    mode: "local",
+    projectMatch: "matched",
+    ...overrides,
+  };
+}
+
+function harness(now = Date.parse("2026-08-11T12:00:05.000Z")) {
+  const files = new Map<string, string>();
+  let clock = now;
+  const deps: StatuslineTailWireDeps = {
+    nowMs: () => clock,
+    readCache: (path) => files.get(path) ?? null,
+    writeCache: (path, text) => {
+      files.set(path, text);
+    },
+  };
+  return {
+    deps,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+  };
+}
+
+describe("Statusline Lifecycle wire", () => {
+  it("distinguishes an in-flight registration from a repo nobody is registering", async () => {
+    const h = harness();
+
+    const registering = await collectStatuslineTail(ROOT, [], {
+      ...h.deps,
+      probe: async () => probe({ projectMatch: "name-only" }),
+    });
+    const unregistered = await collectStatuslineTail(ROOT, [], {
+      ...h.deps,
+      probe: async () => probe({ projectMatch: "unregistered" }),
+    });
+
+    expect(registering).toEqual({ state: "registering", lines: ["rsk=registering"] });
+    expect(unregistered).toEqual({ state: "unregistered", lines: ["rsk=unregistered"] });
+  });
+
+  it("serves the last-known tail with age and degraded state inside the socket deadline", async () => {
+    const h = harness();
+    const live = await collectStatuslineTail(ROOT, [], {
+      ...h.deps,
+      probe: async () => probe(),
+    });
+    expect(live.state).toBe("live");
+
+    h.advance(12_000);
+    const started = performance.now();
+    const served = await collectStatuslineTail(ROOT, [], {
+      ...h.deps,
+      deadlineMs: 25,
+      probe: () => new Promise<StatuslineTailProbe>(() => undefined),
+    });
+    const elapsed = performance.now() - started;
+
+    expect(elapsed).toBeLessThan(100);
+    expect(served.state).toBe("degraded");
+    expect(served.lines).toEqual([
+      "acme/widgets 1w 128M · age=17s · rsk=degraded",
+      "w123 working",
+    ]);
+  });
+
+  it("renders connecting on a deadline miss when no last-known tail exists", async () => {
+    const h = harness();
+    const served = await collectStatuslineTail(ROOT, [], {
+      ...h.deps,
+      deadlineMs: 5,
+      probe: () => new Promise<StatuslineTailProbe>(() => undefined),
+    });
+
+    expect(served).toEqual({ state: "connecting", lines: ["rsk=connecting"] });
+  });
+
+  it("renders bedrock-only when the socket probe rejects promptly", async () => {
+    const h = harness();
+    const served = await collectStatuslineTail(ROOT, [], {
+      ...h.deps,
+      probe: async () => {
+        throw new Error("socket unavailable");
+      },
+    });
+
+    expect(served).toEqual({ state: "bedrock-only", lines: ["rsk=bedrock-only"] });
+  });
+});

--- a/apps/dev/tests/statusline-render-path.test.ts
+++ b/apps/dev/tests/statusline-render-path.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { directCollector, localGit, runStatusline, spawned } = vi.hoisted(() => ({
+const { directCollector, localGit, probeStatusline, spawned } = vi.hoisted(() => ({
   directCollector: vi.fn(() => {
     throw new Error("the render path called a project collector");
   }),
@@ -19,19 +19,23 @@ const { directCollector, localGit, runStatusline, spawned } = vi.hoisted(() => (
     localAdded: 142,
     localRemoved: 36,
   })),
-  runStatusline: vi.fn(async (
-    _args: readonly string[],
-    io: { readonly cwd?: string; readonly write?: (line: string) => void },
-  ) => {
-    io.write?.(
-      "acme/widgets 1w 128M v3.12.10\n" +
-      "w123  ███▶░░  run=codex gpt-5.6 xhigh  iss=3546  implementing·tests  00:02:03  loc=+12 -3  tks=45k  tls=9 rsn=2 txt=1\n",
-    );
-    return 0;
-  }),
+  probeStatusline: vi.fn(async () => ({
+    payload: {
+      generated_at: "2026-08-11T12:00:00.000Z",
+      staleness: { age_ms: 5_000, threshold_ms: 30_000, stale: false },
+    },
+    render: {
+      lines: [
+        "acme/widgets 1w 128M v3.12.10",
+        "w123  ███▶░░  run=codex gpt-5.6 xhigh  iss=3546  implementing·tests  00:02:03  loc=+12 -3  tks=45k  tls=9 rsn=2 txt=1",
+      ],
+      mode: "local",
+      project_match: "matched",
+    },
+  })),
 }));
 
-vi.mock("@reddb-io/redskilled/statusline-command", () => ({ runStatusline }));
+vi.mock("@reddb-io/redskilled/statusline-command", () => ({ probeStatusline }));
 
 // Every process this render could start, recorded rather than run. The counters
 // are the daemon's (ADR 0141 decision 2) and the local count caches are deleted,
@@ -129,10 +133,10 @@ describe("dev statusline render path", () => {
     const adapterMs = performance.now() - started;
 
     expect(code).toBe(0);
-    expect(runStatusline).toHaveBeenCalledOnce();
-    expect(runStatusline).toHaveBeenCalledWith(
+    expect(probeStatusline).toHaveBeenCalledOnce();
+    expect(probeStatusline).toHaveBeenCalledWith(
       ["global", "--verbose"],
-      expect.objectContaining({ cwd: root }),
+      expect.objectContaining({ cwd: root, client: { requestTimeoutMs: 150 } }),
     );
     expect(directCollector).not.toHaveBeenCalled();
     // The bedrock LEADS the daemon's header line; the Worker lines follow it
@@ -148,11 +152,8 @@ describe("dev statusline render path", () => {
     expect(adapterMs).toBeLessThan(100);
   });
 
-  it("prints the daemon client's stated absence promptly without a tracker fallback", async () => {
-    runStatusline.mockImplementationOnce(async (_args, io) => {
-      io.write?.("redskilled unreachable — Worker state unknown\n");
-      return 0;
-    });
+  it("prints the bedrock-only lifecycle promptly without a tracker fallback", async () => {
+    probeStatusline.mockRejectedValueOnce(new Error("socket unavailable"));
     const root = await mkdtemp(join(tmpdir(), "statusline-render-path-"));
     roots.push(root);
     const out = sink();
@@ -161,7 +162,7 @@ describe("dev statusline render path", () => {
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(""));
 
     expect(code).toBe(0);
-    expect(out.text()).toContain("redskilled unreachable — Worker state unknown");
+    expect(out.text()).toContain("rsk=bedrock-only");
     expect(directCollector).not.toHaveBeenCalled();
     expect(performance.now() - started).toBeLessThan(100);
   });
@@ -171,7 +172,7 @@ describe("dev statusline render path", () => {
     // the operator's own machine holds must still reach the screen: model·effort
     // and context and the subscription windows from stdin, basename/branch/diff
     // from local git, and the running bundle version (ADR 0141 §1).
-    runStatusline.mockImplementationOnce(async () => 0);
+    probeStatusline.mockRejectedValueOnce(new Error("socket unavailable"));
     const root = await mkdtemp(join(tmpdir(), "statusline-render-path-"));
     roots.push(root);
     const out = sink();
@@ -181,17 +182,14 @@ describe("dev statusline render path", () => {
     expect(code).toBe(0);
     expect(out.text()).toBe(
       `red-skills (afk/3563-bedrock) v${readBuildInfo("dev").version} · Opus·high · 47k 24% · ` +
-        "5h=23% 7d=41% · loc=+142 -36\n",
+        "5h=23% 7d=41% · loc=+142 -36 · rsk=bedrock-only\n",
     );
     expect(localGit).toHaveBeenCalledOnce();
     expect(directCollector).not.toHaveBeenCalled();
   });
 
-  it("still renders the bedrock when the daemon states its absence", async () => {
-    runStatusline.mockImplementationOnce(async (_args, io) => {
-      io.write?.("redskilled unreachable — Worker state unknown\n");
-      return 0;
-    });
+  it("still renders the bedrock when the daemon probe fails", async () => {
+    probeStatusline.mockRejectedValueOnce(new Error("socket unavailable"));
     const root = await mkdtemp(join(tmpdir(), "statusline-render-path-"));
     roots.push(root);
     const out = sink();
@@ -201,7 +199,7 @@ describe("dev statusline render path", () => {
     expect(code).toBe(0);
     expect(out.text()).toBe(
       `red-skills (afk/3563-bedrock) v${readBuildInfo("dev").version} · Opus·high · 47k 24% · ` +
-        "5h=23% 7d=41% · loc=+142 -36 · redskilled unreachable — Worker state unknown\n",
+        "5h=23% 7d=41% · loc=+142 -36 · rsk=bedrock-only\n",
     );
   });
 
@@ -211,12 +209,9 @@ describe("dev statusline render path", () => {
 
     // Daemon answering, daemon silent, daemon stating its absence: all three are
     // render paths, and none of them may reach a tracker client.
-    runStatusline.mockImplementationOnce(async () => 0);
+    probeStatusline.mockRejectedValueOnce(new Error("socket unavailable"));
     await statuslineCommand([root], root, sink().stream, fakeStdin(JSON.stringify(PAYLOAD)));
-    runStatusline.mockImplementationOnce(async (_args, io) => {
-      io.write?.("redskilled unreachable — Worker state unknown\n");
-      return 0;
-    });
+    probeStatusline.mockRejectedValueOnce(new Error("socket unavailable"));
     await statuslineCommand([root], root, sink().stream, fakeStdin("{}"));
     await statuslineCommand([root, "global"], root, sink().stream, fakeStdin("{}"));
 

--- a/apps/redskilled/src/statusline-command.ts
+++ b/apps/redskilled/src/statusline-command.ts
@@ -16,14 +16,66 @@
  * daemon was down would render an outage as calm. An unreachable host is a
  * stated absence on stdout and a diagnosis on stderr.
  */
-import { readRedskilledStatuslineRender, type RedskilledClientConfig } from "./client.js";
+import {
+  readRedskilledStatuslineRender,
+  type RedskilledClientConfig,
+} from "./client.js";
+import { probeRedskilledStatuslinePayload } from "./statusline-probe.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
 import {
   parseRedskilledStatuslineFlags,
   resolveRedskilledStatuslineOptions,
 } from "./statusline-config.js";
 import { readStatuslineProject } from "./statusline-project.js";
-import { renderRedskilledStatuslineAbsence } from "@reddb-io/redskilled-render";
+import type { RedskilledStatuslinePayload } from "./statusline-payload.js";
+import {
+  renderRedskilledStatusline,
+  renderRedskilledStatuslineAbsence,
+  type RedskilledStatuslineRender,
+} from "@reddb-io/redskilled-render";
+
+export interface RedskilledStatuslineProbe {
+  readonly payload: RedskilledStatuslinePayload;
+  readonly render: RedskilledStatuslineRender;
+}
+
+/**
+ * Read one already-running daemon and return both its payload and Shared render.
+ *
+ * This is the importable seam for prompt hosts that need lifecycle facts beside
+ * the rendered tail. It is probe-only by construction: unlike `runStatusline`,
+ * it never enters the client's daemon-start path.
+ */
+export async function probeStatusline(
+  args: readonly string[],
+  io: {
+    readonly cwd?: string;
+    readonly paths?: RedskilledPaths;
+    readonly warn?: (line: string) => void;
+    readonly client?: RedskilledClientConfig;
+  } = {},
+): Promise<RedskilledStatuslineProbe> {
+  const warn = io.warn ?? ((line: string) => process.stderr.write(line));
+  const parsed = parseRedskilledStatuslineFlags(args);
+  const project = readStatuslineProject(io.cwd ?? process.cwd());
+  const resolved = resolveRedskilledStatuslineOptions({
+    ...(project.configText == null ? {} : { configText: project.configText }),
+    project: project.label,
+    flags: parsed.flags,
+  });
+  for (const warning of [...resolved.warnings, ...parsed.warnings]) {
+    warn(`redskilled statusline: ignoring ${warning.key}=${warning.value} — ${warning.reason}\n`);
+  }
+  const payload = await probeRedskilledStatuslinePayload(
+    io.paths ?? resolveRedskilledPaths(),
+    {
+      ...(io.client ?? {}),
+      ...(resolved.options.project == null ? {} : { sessionProject: resolved.options.project }),
+    },
+    { vitals: true, logs: resolved.options.verbose, display: true },
+  );
+  return { payload, render: renderRedskilledStatusline(payload, resolved.options) };
+}
 
 export async function runStatusline(
   args: readonly string[],

--- a/apps/redskilled/src/statusline-probe.ts
+++ b/apps/redskilled/src/statusline-probe.ts
@@ -1,0 +1,53 @@
+/** A bounded, probe-only statusline payload read for prompt renderers. */
+import { randomUUID } from "node:crypto";
+import {
+  RedskilledRequestRefusedError,
+  RedskilledUnreachableError,
+  type RedskilledClientConfig,
+} from "./client.js";
+import { resolveRedskilledClientEndpoint } from "./client-rendezvous.js";
+import type { RedskilledPaths } from "./paths.js";
+import {
+  isRedskilledStatuslinePayload,
+  sendRedskilledRequest,
+  type RedskilledStatuslinePayload,
+} from "./protocol.js";
+import type { RedskilledStatuslineExtrasRequest } from "./statusline-payload.js";
+
+/**
+ * Probe the statusline payload from an already-running daemon.
+ *
+ * Unlike the ordinary client read, this path NEVER calls
+ * `ensureRedskilledDaemon`: a prompt renderer may observe the daemon, but it may
+ * not birth one. The caller owns the short request deadline appropriate to its
+ * surface (the Dev statusline uses 150ms).
+ */
+export async function probeRedskilledStatuslinePayload(
+  paths: RedskilledPaths,
+  config: RedskilledClientConfig = {},
+  extras?: RedskilledStatuslineExtrasRequest,
+): Promise<RedskilledStatuslinePayload> {
+  const endpoint = (await resolveRedskilledClientEndpoint(paths)).paths;
+  let response;
+  try {
+    response = await sendRedskilledRequest(
+      { socketPath: endpoint.socketPath, timeoutMs: config.requestTimeoutMs ?? 2_000 },
+      {
+        id: randomUUID(),
+        op: "statusline-payload",
+        ...(config.sessionProject != null ? { session_project: config.sessionProject } : {}),
+        ...(extras == null ? {} : { extras }),
+      },
+    );
+  } catch (err) {
+    // Do not run a second presence probe here. This read owns one socket attempt
+    // and one deadline; another diagnostic reach could freeze the prompt after
+    // the operation it was diagnosing had already timed out.
+    throw new RedskilledUnreachableError(endpoint.socketPath, err);
+  }
+  if (!response.ok) throw new RedskilledRequestRefusedError(response.error);
+  if (!isRedskilledStatuslinePayload(response.value)) {
+    throw new Error("redskilled daemon returned a malformed statusline payload");
+  }
+  return response.value;
+}


### PR DESCRIPTION
Automated AFK landing for #3567. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3567

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789039474&installation_model_id=20659&pr_number=3575&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3575&signature=3a000779aa3dceacf781ebd7f9e32b4665df3c4eec87d3b1e6946ef5551e8a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->