### PR TITLE
chore(release): queue the statusline bedrock and lifecycle feature

### DIFF
--- a/.changeset/statusline-bedrock-lifecycle.md
+++ b/.changeset/statusline-bedrock-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/dev": minor
+"@reddb-io/redskilled": minor
+---
+
+Decouple the statusline by data ownership (ADR 0141, Spec #3561). The Statusline Bedrock — model·effort, context, subscription windows, repo/branch/diff, bundle version — renders zero-network on every invocation, with local git facts under their own ~5s micro-TTL. Every remote counter (`prs=`, `iss=`, `rdy=`, `hmn=`) moves into the redskilled daemon's presence-driven repository-activity poll (~15–30s while a session is registered, backed off idle, under the budget-aware GitHub client) and ships in the statusline payload with per-counter ages; the local 15-minute `gh` count caches are deleted. A request never fetches: MCP and statusline reads always serve from the daemon's cache with age stated. The statusline↔daemon relationship becomes a visible lifecycle — `bedrock-only`, `connecting`, `registering`, `unregistered`, `live`, `degraded` — rendered as a compact `rsk=<state>` token in place of the tail when not live, with a hard ~150ms socket deadline serving the last-known tail with its age so the prompt never freezes. Castle MCP counter surfaces answer from the same daemon payload.


### PR DESCRIPTION
Consolidated release entry for Spec #3561 (ADR 0141) — the 7 AFK slices merged without changesets, so the feature was on main with no Version-PR queued. Minor bump: operator-visible statusline feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789041318&installation_model_id=20659&pr_number=3576&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3576&signature=754e178734c4a9c2f0a70db9dc6d5ba2705ea676fc9fbbee363b69f40095f677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->