### PR TITLE
chore: #3583 Every Worker spawn carries the attribution stamp and records its process group

### DIFF
--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -124,6 +124,10 @@ export interface RedskilledHostEvent {
   readonly worker_id: string;
   readonly project_label: string;
   readonly pid: number;
+  /** Detached process-group leader, when the birth writer recorded it. */
+  readonly pgid?: number;
+  /** OS process start discriminator, absent on legacy lanes or read failure. */
+  readonly proc_start_time?: string;
   readonly workspace_path: string;
   /** Granted fork point, null on legacy and non-trunk births. */
   readonly fork_sha?: string | null;
@@ -257,6 +261,10 @@ export function buildHostEvent(input: RecordEventInput | RecordWorkerEventInput)
     worker_id: input.worker.worker_id,
     project_label: input.worker.project_label,
     pid: input.worker.pid,
+    ...(input.worker.pgid == null ? {} : { pgid: input.worker.pgid }),
+    ...(input.worker.proc_start_time == null
+      ? {}
+      : { proc_start_time: input.worker.proc_start_time }),
     workspace_path: input.worker.workspace_path,
     fork_sha: input.worker.fork_sha ?? null,
     log_path: input.worker.log_path ?? null,
@@ -710,6 +718,10 @@ export function toWorkerView(event: RedskilledHostEvent): RedskilledWorkerView {
     worker_id: event.worker_id,
     project_label: event.project_label,
     pid: event.pid,
+    ...(event.pgid == null ? {} : { pgid: event.pgid }),
+    ...(event.proc_start_time == null
+      ? {}
+      : { proc_start_time: event.proc_start_time }),
     started_at: event.ts,
     workspace_path: event.workspace_path,
     ...(event.fork_sha != null ? { fork_sha: event.fork_sha } : {}),
@@ -743,6 +755,10 @@ function fromRow(record: ToonlRecord): RedskilledHostEvent {
     worker_id: String(record.worker_id),
     project_label: text(record.project_label) ?? "",
     pid: Number(record.pid ?? 0),
+    ...(record.pgid == null || record.pgid === "" ? {} : { pgid: Number(record.pgid) }),
+    ...(text(record.proc_start_time) == null
+      ? {}
+      : { proc_start_time: text(record.proc_start_time)! }),
     workspace_path: text(record.workspace_path) ?? "",
     fork_sha: text(record.fork_sha),
     log_path: text(record.log_path),

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -55,6 +55,10 @@ export interface RedskilledWorkerView {
   readonly worker_id: string;
   readonly project_label: string;
   readonly pid: number;
+  /** Process group leader; equals {@link pid} for the detached birth. */
+  readonly pgid?: number;
+  /** OS process start discriminator paired with {@link pid}, when readable. */
+  readonly proc_start_time?: string;
   readonly started_at: string;
   /** The path the client handed over, used verbatim as the Worker's workspace. */
   readonly workspace_path: string;
@@ -512,6 +516,8 @@ export function isRedskilledWorkerView(value: unknown): value is RedskilledWorke
   return typeof worker.worker_id === "string" &&
     typeof worker.project_label === "string" &&
     Number.isInteger(worker.pid) &&
+    (worker.pgid === undefined || Number.isInteger(worker.pgid)) &&
+    (worker.proc_start_time === undefined || typeof worker.proc_start_time === "string") &&
     typeof worker.started_at === "string" &&
     typeof worker.workspace_path === "string" &&
     (worker.fork_sha === undefined || typeof worker.fork_sha === "string") &&

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -20,7 +20,7 @@
  */
 import { randomInt } from "node:crypto";
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { encodeLines } from "@reddb-io/toon";
 import { pathWithEngineNode } from "@reddb-io/shared/engine-node.js";
@@ -279,6 +279,7 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
   const clock = options.clock ?? (() => new Date().toISOString());
   const workerId = (spec.worker_id ?? options.workerId)?.trim()
     || mintHostWorkerId(options.liveWorkerIds ?? []);
+  const bornAt = clock();
   const probes = options.probes ?? detectWorkerPlacementProbes(env);
   // Resolved HERE, at the instant this Worker exists, and never earlier (#3440).
   // A client that cannot know the id the daemon is about to mint declares
@@ -313,6 +314,7 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
   };
   const plan = planWorkerPlacement({
     workerId,
+    bornAt,
     projectLabel: spec.project_label,
     workspacePath: spec.workspace_path,
     command: spec.command,
@@ -350,6 +352,7 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     child.once("error", () => undefined);
     throw new RedskilledWorkerSpecError(`redskilled could not spawn ${JSON.stringify(plan.command)} for worker ${workerId}`);
   }
+  const procStartTime = readProcStartTime(child.pid);
 
   // The Windows backend isolates AFTER the spawn, because Node offers no way to
   // start a process already inside a job. The window between the two is bounded
@@ -380,7 +383,13 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     worker_id: workerId,
     project_label: spec.project_label,
     pid: child.pid,
-    started_at: clock(),
+    // Detached spawn makes the child the leader of a new process group, so the
+    // pgid is the child pid by construction on every platform where Node accepts
+    // this option. Paired with the kernel start tick when Linux exposes it, the
+    // pid remains an identity even after the number is eventually reused.
+    pgid: child.pid,
+    ...(procStartTime == null ? {} : { proc_start_time: procStartTime }),
+    started_at: bornAt,
     workspace_path: spec.workspace_path,
     // Reported only when the daemon ACTUALLY opened it (#3440). A view carrying
     // a path nothing ever created is what made a worker-death event name a file
@@ -419,6 +428,21 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     child,
     ...(placed?.job != null ? { job: placed.job } : {}),
   };
+}
+
+/** Read Linux `/proc/<pid>/stat` field 22, omitting it on every unavailable host. */
+function readProcStartTime(pid: number): string | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const commEnd = stat.lastIndexOf(")");
+    if (commEnd < 0) return null;
+    // The slice begins at field 3 (`state`), making field 22 index 19. Reading
+    // past the final `)` keeps spaces and parentheses in `comm` from shifting it.
+    const value = stat.slice(commEnd + 1).trim().split(/\s+/)[19];
+    return value != null && /^\d+$/.test(value) ? value : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -280,6 +280,8 @@ export function workerUnitName(
 
 export interface PlanWorkerPlacementOptions {
   readonly workerId: string;
+  /** Birth instant stamped into every environment when this plan launches. */
+  readonly bornAt?: string;
   readonly projectLabel: string;
   /** The workspace path, used verbatim — the daemon derives nothing from it. */
   readonly workspacePath: string;
@@ -351,7 +353,7 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
     // The Worker still learns its ceiling here, and learns WHY it has no scope:
     // an unscoped death that named neither would be the silent degradation this
     // whole module refuses.
-    environment: workerScopeEnvironment({
+    environment: workerPlacementEnvironment(opts, {
       scope: null,
       memory_ceiling: ceilingValue,
       scope_degradation: warning,
@@ -403,7 +405,7 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
   if (budget.cpu_weight != null) unitArgs.push(`--property=CPUWeight=${budget.cpu_weight}`);
   // The Worker's own placement joins its environment, so the process that dies
   // inside this unit can name the unit that held it and the ceiling it carried.
-  const environment = workerScopeEnvironment({
+  const environment = workerPlacementEnvironment(opts, {
     scope: unit,
     memory_ceiling: ceilingValue,
     scope_degradation: null,
@@ -470,7 +472,7 @@ function planPosixLimitsPlacement(
     ...(ceilingValue != null ? { memoryCeiling: ceilingValue } : {}),
     // No scope: macOS has no resource group to name, so the Worker is told its
     // ceiling and told, in the same breath, that nothing but the floor holds it.
-    environment: workerScopeEnvironment({
+    environment: workerPlacementEnvironment(opts, {
       scope: null,
       memory_ceiling: ceilingValue,
       scope_degradation: warning,
@@ -529,7 +531,7 @@ function planJobObjectPlacement(
     ...(ceilingValue != null ? { memoryCeiling: ceilingValue } : {}),
     // The job IS the scope on Windows, so the Worker names it exactly as a Linux
     // Worker names its unit — one vocabulary, whichever kernel drew the wall.
-    environment: workerScopeEnvironment({
+    environment: workerPlacementEnvironment(opts, {
       scope: name,
       memory_ceiling: ceilingValue,
       scope_degradation: null,
@@ -541,6 +543,19 @@ function planJobObjectPlacement(
       ? `${limits.note}; the daemon's RSS sampling floor is the ceiling for that budget`
       : null, unenforcedPosixBudgetFields(opts.budget))),
   };
+}
+
+/** Join process attribution to placement facts once for every backend. PURE. */
+function workerPlacementEnvironment(
+  opts: Pick<PlanWorkerPlacementOptions, "workerId" | "bornAt">,
+  facts: Parameters<typeof workerScopeEnvironment>[0],
+): Record<string, string> {
+  return workerScopeEnvironment(
+    facts,
+    opts.bornAt == null
+      ? undefined
+      : { worker_id: opts.workerId, born_at: opts.bornAt },
+  );
 }
 
 /** Join what a placement could not carry into one warning, or into none. PURE. */

--- a/apps/redskilled/tests/public-host-event-contract.test.ts
+++ b/apps/redskilled/tests/public-host-event-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   REDSKILLED_PUBLIC_HOST_EVENT_KINDS,
   buildHostEvent,
+  toWorkerView,
   type RecordWorkerEventInput,
   type RedskilledPublicHostEventKind,
 } from "../src/event-lane.js";
@@ -23,8 +24,10 @@ const PUBLIC_HOST_EVENT_FIELDS = [
   "memory_high",
   "memory_max",
   "model",
+  "pgid",
   "phase",
   "pid",
+  "proc_start_time",
   "project_label",
   "reason",
   "runner",
@@ -43,6 +46,8 @@ const worker: RedskilledWorkerView = {
   worker_id: "wPUB1",
   project_label: "acme/widgets",
   pid: 4242,
+  pgid: 4242,
+  proc_start_time: "987654",
   started_at: "2026-08-08T12:00:00.000Z",
   workspace_path: "/tmp/worker",
   fork_sha: "aaaa1111",
@@ -94,6 +99,17 @@ describe("public host-event contract", () => {
         Object.keys(event).sort(),
         `${kind} public host-event field set`,
       ).toEqual(PUBLIC_HOST_EVENT_FIELDS);
+      expect(event).toMatchObject({ pgid: 4242, proc_start_time: "987654" });
     }
+  });
+
+  it("rehydrates a legacy event that has no process identity fields", () => {
+    const event = buildHostEvent(publicInputs["worker-birth"]);
+    const { pgid: _pgid, proc_start_time: _procStartTime, ...legacy } = event;
+
+    expect(toWorkerView(legacy)).toMatchObject({
+      worker_id: "wPUB1",
+      pid: 4242,
+    });
   });
 });

--- a/apps/redskilled/tests/worker-placement.test.ts
+++ b/apps/redskilled/tests/worker-placement.test.ts
@@ -3,6 +3,7 @@
 // Worker gets a transient SERVICE unit (never a scope — a scope dies with the
 // caller), and without one the launch still happens but says so out loud.
 import { describe, expect, it } from "vitest";
+import { WORKER_BORN_AT_ENV, WORKER_ID_ENV } from "@reddb-io/shared/worker-scope.js";
 import {
   DEFAULT_WORKER_UNIT_PREFIX,
   placementEnabled,
@@ -104,9 +105,14 @@ describe("worker placement — Linux with a user session", () => {
   });
 
   it("passes the Worker's environment through the unit, not through the daemon's", () => {
-    const placement = plan(LINUX_WITH_SESSION, { env: { RED_WORKER: "1" } });
+    const placement = plan(LINUX_WITH_SESSION, {
+      bornAt: "2026-08-11T13:00:00.000Z",
+      env: { RED_WORKER: "1" },
+    });
 
     expect(placement.args).toContain("--setenv=RED_WORKER=1");
+    expect(placement.args).toContain(`--setenv=${WORKER_ID_ENV}=wQ9F2`);
+    expect(placement.args).toContain(`--setenv=${WORKER_BORN_AT_ENV}=2026-08-11T13:00:00.000Z`);
   });
 });
 

--- a/apps/redskilled/tests/wsl2-host.test.ts
+++ b/apps/redskilled/tests/wsl2-host.test.ts
@@ -144,10 +144,14 @@ describe("WSL2 — a Worker is born, unisolated, and the loss is named", () => {
     const launched = launchWorker({
       admission: evaluateWorkerAdmission({ ceiling: UNBOUNDED_HOST_CEILING, workers: [] }),
       spec: {
+        worker_id: "wWSL2",
         project_label: "acme/widgets",
         workspace_path: workspace,
         command: process.execPath,
-        args: ["-e", "require('node:fs').writeFileSync('proof.txt', process.cwd());"],
+        args: [
+          "-e",
+          "require('node:fs').writeFileSync('proof.json', JSON.stringify({ cwd: process.cwd(), worker_id: process.env.RED_WORKER_ID, born_at: process.env.RED_WORKER_BORN_AT })); setTimeout(() => {}, 250);",
+        ],
         budget: { memory_max: "4G" },
       },
       probes: WSL2_PROBES,
@@ -155,6 +159,8 @@ describe("WSL2 — a Worker is born, unisolated, and the loss is named", () => {
     });
 
     expect(launched.worker.pid).toBeGreaterThan(0);
+    expect(launched.worker.pgid).toBe(launched.worker.pid);
+    expect(launched.worker.proc_start_time).toMatch(/^\d+$/);
     expect(launched.worker.isolated).toBe(false);
     expect(launched.worker.unit).toBeUndefined();
     // The warning reaches the caller AND stays on the record the Worker keeps for
@@ -162,10 +168,14 @@ describe("WSL2 — a Worker is born, unisolated, and the loss is named", () => {
     expect(launched.warnings.join(" ")).toMatch(/systemd-run is not on PATH/);
     expect(launched.worker.warnings).toEqual(launched.warnings);
 
-    const proof = join(workspace, "proof.txt");
+    const proof = join(workspace, "proof.json");
     for (let attempt = 0; attempt < 100; attempt += 1) {
       try {
-        expect(await readFile(proof, "utf8")).toBe(workspace);
+        expect(JSON.parse(await readFile(proof, "utf8"))).toEqual({
+          cwd: workspace,
+          worker_id: launched.worker.worker_id,
+          born_at: launched.worker.started_at,
+        });
         return;
       } catch {
         await new Promise((resolve) => setTimeout(resolve, 50));

--- a/packages/shared/worker-scope.ts
+++ b/packages/shared/worker-scope.ts
@@ -7,8 +7,9 @@
  * no idea which unit held it, so its own death record — the one artifact written
  * by the thing that died — could not say what contained it (Spec #3022, #3029).
  *
- * The contract is three environment variables, stated by the host at birth and
- * read by the Worker on the way out. Environment rather than a file because a
+ * The contract is the Worker's identity and birth instant plus three placement
+ * facts, stated by the host at birth and read by the Worker on the way out.
+ * Environment rather than a file because a
  * transient unit already carries `--setenv` and a Worker that had to find a file
  * would have to learn a layout the daemon deliberately does not teach it.
  *
@@ -28,6 +29,18 @@ export const WORKER_SCOPE_CEILING_ENV = "RED_WORKER_MEMORY_CEILING";
 
 /** Why the process is unscoped, when it is — never an absent scope alone. */
 export const WORKER_SCOPE_DEGRADATION_ENV = "RED_WORKER_SCOPE_DEGRADATION";
+
+/** The daemon-minted Worker identity carried by every process it births. */
+export const WORKER_ID_ENV = "RED_WORKER_ID";
+
+/** The daemon clock instant at which this Worker was born. */
+export const WORKER_BORN_AT_ENV = "RED_WORKER_BORN_AT";
+
+/** Stable attribution stamped onto a Worker's environment at birth. */
+export interface WorkerAttributionFacts {
+  readonly worker_id: string;
+  readonly born_at: string;
+}
 
 /**
  * Where a process runs and under what ceiling.
@@ -67,13 +80,21 @@ export function readWorkerScopeFacts(env: NodeJS.ProcessEnv): WorkerScopeFacts {
 }
 
 /**
- * The environment a host hands a Worker so it can read its own placement. PURE.
+ * The environment a host hands a Worker so it can read its attribution and
+ * placement. PURE.
  *
  * A fact the host does not have is OMITTED rather than set empty, so the Worker
  * inherits nothing it would have to reinterpret.
  */
-export function workerScopeEnvironment(facts: WorkerScopeFacts): Record<string, string> {
+export function workerScopeEnvironment(
+  facts: WorkerScopeFacts,
+  attribution?: WorkerAttributionFacts,
+): Record<string, string> {
   const environment: Record<string, string> = {};
+  if (attribution != null) {
+    environment[WORKER_ID_ENV] = attribution.worker_id;
+    environment[WORKER_BORN_AT_ENV] = attribution.born_at;
+  }
   if (facts.scope != null && facts.scope !== "") environment[WORKER_SCOPE_ENV] = facts.scope;
   if (facts.memory_ceiling != null && facts.memory_ceiling !== "") {
     environment[WORKER_SCOPE_CEILING_ENV] = facts.memory_ceiling;


### PR DESCRIPTION
Automated AFK landing for #3583. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3583

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789045957&installation_model_id=20659&pr_number=3600&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3600&signature=692713602d0196f9ce3e232440e9a9251cf66b30cecaea642038cb43b1c0042c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->