### PR TITLE
chore: #3582 The process-death lane stops decoding itself on every exit: amortized trigger and size cap

### DIFF
--- a/packages/shared/death-attribution.test.ts
+++ b/packages/shared/death-attribution.test.ts
@@ -5,7 +5,7 @@
 // read for real, and a presence anchor left behind exactly as an un-trap-able
 // death leaves one. So the collector under test is the SHIPPED one — no fake
 // evidence object stands in for the code an operator actually runs.
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -21,6 +21,7 @@ import {
   type ProcessPresence,
 } from "./death-attribution.js";
 import {
+  PROCESS_DEATH_LANE_MAX_BYTES,
   PROCESS_DEATH_LANE_RETENTION_MS,
   appendProcessDeathRecord,
   buildProcessDeathRecord,
@@ -268,6 +269,38 @@ describe("the presence anchor", () => {
 });
 
 describe("the boot reaper", () => {
+  it("compacts an oversized death lane before serve boot returns", () => {
+    const stateRoot = scratch();
+    const lanePath = deathLaneFileIn(stateRoot);
+    const record = buildProcessDeathRecord(
+      {
+        ts: "2026-08-08T20:00:00.000Z",
+        kind: "worker",
+        id: "oversized-at-boot",
+        pid: 4242,
+        exit_path: "exit",
+        exit_code: 0,
+        last_phase: "done",
+        detail: "x".repeat(1_000),
+      },
+      SAMPLE,
+    );
+    appendProcessDeathRecord(lanePath, record);
+    const segment = readFileSync(lanePath, "utf8");
+    writeFileSync(
+      lanePath,
+      segment.repeat(Math.ceil((PROCESS_DEATH_LANE_MAX_BYTES + 1) / Buffer.byteLength(segment))),
+    );
+
+    runBootDeathReaper({
+      stateRoot,
+      evidence: collectHostDeathEvidence({ procRoot: poseProc("boot-a", [1]), journalPaths: [] }),
+      now: () => "2026-08-08T20:00:00.000Z",
+    });
+
+    expect(statSync(lanePath).size).toBeLessThanOrEqual(PROCESS_DEATH_LANE_MAX_BYTES / 2);
+  });
+
   it("attributes the absent-but-expected record and clears its anchor", () => {
     const stateRoot = scratch();
     const dir = deathPresenceDirIn(stateRoot);

--- a/packages/shared/death-record.test.ts
+++ b/packages/shared/death-record.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, truncateSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, truncateSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -6,14 +6,17 @@ import { parseRecords } from "@reddb-io/toon";
 import {
   DEATH_PHASE_UNSTARTED,
   PROCESS_DEATH_LANE_RETENTION_MS,
+  PROCESS_DEATH_LANE_MAX_BYTES,
   activeDeathRecorder,
   appendProcessDeathRecord,
   buildProcessDeathRecord,
+  compactProcessDeathLane,
   decodeProcessDeathRecords,
   deathLaneFile,
   deathLaneFileIn,
   installDeathRecorder,
   markDeathPhase,
+  nodeDeathLaneIo,
   UNSCOPED_PROCESS,
   readProcessDeathLane,
   sampleProcessResources,
@@ -341,6 +344,82 @@ describe("death-record", () => {
     expect(records.map((r) => r.kind)).toEqual(["launcher", "worker"]);
   });
 
+  it("appends below the lane ceiling without reading the lane", () => {
+    let inspections = 0;
+    let reads = 0;
+    const io = {
+      ...nodeDeathLaneIo,
+      inspect(path: string) {
+        inspections += 1;
+        return nodeDeathLaneIo.inspect(path);
+      },
+      read(path: string) {
+        reads += 1;
+        return nodeDeathLaneIo.read(path);
+      },
+    };
+
+    appendProcessDeathRecord(
+      lanePath,
+      buildProcessDeathRecord(
+        {
+          ts: "2026-08-08T20:00:00.000Z",
+          kind: "worker",
+          id: "under-ceiling",
+          pid: 42,
+          exit_path: "exit",
+          exit_code: 0,
+          last_phase: "done",
+        },
+        sampleProcessResources(poseHost()),
+      ),
+      io,
+    );
+
+    expect(inspections).toBe(1);
+    expect(reads).toBe(0);
+  });
+
+  it("compacts exactly once to half the ceiling when an append fills the lane", () => {
+    const record = buildProcessDeathRecord(
+      {
+        ts: "2026-08-08T20:00:00.000Z",
+        kind: "worker",
+        id: "fills-lane",
+        pid: 43,
+        exit_path: "exit",
+        exit_code: 0,
+        last_phase: "done",
+        detail: "x".repeat(1_000),
+      },
+      sampleProcessResources(poseHost()),
+    );
+    appendProcessDeathRecord(lanePath, record);
+    const segment = readFileSync(lanePath, "utf8");
+    const segmentBytes = Buffer.byteLength(segment);
+    writeFileSync(lanePath, segment.repeat(Math.floor(PROCESS_DEATH_LANE_MAX_BYTES / segmentBytes)));
+
+    let reads = 0;
+    let replacements = 0;
+    const io = {
+      ...nodeDeathLaneIo,
+      read(path: string) {
+        reads += 1;
+        return nodeDeathLaneIo.read(path);
+      },
+      replace(path: string, text: string) {
+        replacements += 1;
+        nodeDeathLaneIo.replace(path, text);
+      },
+    };
+
+    appendProcessDeathRecord(lanePath, record, io);
+
+    expect(reads).toBe(1);
+    expect(replacements).toBe(1);
+    expect(statSync(lanePath).size).toBeLessThanOrEqual(PROCESS_DEATH_LANE_MAX_BYTES / 2);
+  });
+
   it("keeps fourteen days of deaths and drops older history when the lane advances", () => {
     const now = Date.parse("2026-08-08T20:00:00.000Z");
     const recordAt = (id: string, at: number) =>
@@ -360,8 +439,35 @@ describe("death-record", () => {
     appendProcessDeathRecord(lanePath, recordAt("too-old", now - PROCESS_DEATH_LANE_RETENTION_MS - 1));
     appendProcessDeathRecord(lanePath, recordAt("cutoff", now - PROCESS_DEATH_LANE_RETENTION_MS));
     appendProcessDeathRecord(lanePath, recordAt("recent", now));
+    compactProcessDeathLane(lanePath, now);
 
     expect(readProcessDeathLane(lanePath).map((record) => record.id)).toEqual(["cutoff", "recent"]);
+  });
+
+  it("preserves records whose timestamp cannot be parsed during retention", () => {
+    const now = Date.parse("2026-08-08T20:00:00.000Z");
+    const record = (id: string, ts: string) =>
+      buildProcessDeathRecord(
+        {
+          ts,
+          kind: "worker",
+          id,
+          pid: 44,
+          exit_path: "exit",
+          exit_code: 0,
+          last_phase: "done",
+        },
+        sampleProcessResources(poseHost()),
+      );
+
+    appendProcessDeathRecord(lanePath, record("unknown", "not-a-timestamp"));
+    appendProcessDeathRecord(
+      lanePath,
+      record("too-old", new Date(now - PROCESS_DEATH_LANE_RETENTION_MS - 1).toISOString()),
+    );
+    compactProcessDeathLane(lanePath, now);
+
+    expect(readProcessDeathLane(lanePath).map((entry) => entry.id)).toEqual(["unknown"]);
   });
 
   it("answers the process-wide phase marker and lets go on uninstall", () => {

--- a/packages/shared/death-record.ts
+++ b/packages/shared/death-record.ts
@@ -27,7 +27,18 @@
  * in flight when the process leaves is the very silence the record exists to
  * break.
  */
-import { appendFileSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
 import { UNSCOPED_PROCESS, readWorkerScopeFacts, type WorkerScopeFacts } from "./worker-scope.js";
@@ -50,10 +61,16 @@ export const PROCESS_DEATH_RECORD_VERSION = 1;
 
 /**
  * Deaths remain useful for fourteen days. Older host history no longer explains
- * the processes and anchors present today, so every writer advances the lane to
- * this explicit age window before appending its own record.
+ * the processes and anchors present today, so each size-triggered or boot
+ * compaction advances the lane to this explicit age window.
  */
 export const PROCESS_DEATH_LANE_RETENTION_MS = 14 * 24 * 60 * 60 * 1_000;
+
+/** The largest death-lane generation an exit handler asks a reader to decode. */
+export const PROCESS_DEATH_LANE_MAX_BYTES = 4 * 1024 * 1024;
+
+/** A rewrite leaves half the generation free, amortizing the next full decode. */
+const PROCESS_DEATH_LANE_COMPACTION_TARGET_RATIO = 0.5;
 
 /**
  * Which of the engine's three process classes died.
@@ -222,10 +239,10 @@ export function sampleProcessResources(host: DeathRecorderHost): ProcessResource
 /** The synchronous file operations the lane needs; injected so a test can pose them. */
 export interface DeathLaneIo {
   mkdir(dir: string): void;
-  /** True when the lane is absent or already ends on a line boundary. */
-  endsClean(path: string): boolean;
+  /** One-stat append inspection; an absent lane is empty and clean. */
+  inspect(path: string): { readonly size: number; readonly endsClean: boolean };
   append(path: string, text: string): void;
-  /** Atomically replace a complete lane after retention has removed old rows. */
+  /** Atomically replace a complete lane after age/size compaction. */
   replace(path: string, text: string): void;
   read(path: string): string;
 }
@@ -235,20 +252,25 @@ export const nodeDeathLaneIo: DeathLaneIo = {
   mkdir(dir) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   },
-  endsClean(path) {
+  inspect(path) {
     let size: number;
     try {
       size = statSync(path).size;
-    } catch {
-      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return { size: 0, endsClean: true };
+      throw error;
     }
-    if (size === 0) return true;
-    // Reading the tail byte alone would need an open/read/close dance in a path
-    // that must not throw; the lane is small and this runs once per process life.
+    if (size === 0) return { size, endsClean: true };
+    let descriptor: number | undefined;
     try {
-      return readFileSync(path, "utf8").endsWith("\n");
+      descriptor = openSync(path, "r");
+      const tail = Buffer.allocUnsafe(1);
+      readSync(descriptor, tail, 0, 1, size - 1);
+      return { size, endsClean: tail[0] === 0x0a };
     } catch {
-      return true;
+      return { size, endsClean: true };
+    } finally {
+      if (descriptor !== undefined) closeSync(descriptor);
     }
   },
   append(path, text) {
@@ -290,11 +312,24 @@ export function appendProcessDeathRecord(
   record: ProcessDeathRecord,
   io: DeathLaneIo = nodeDeathLaneIo,
 ): ProcessDeathRecord {
-  const recordedAt = Date.parse(record.ts);
-  if (Number.isFinite(recordedAt)) compactProcessDeathLane(lanePath, recordedAt, io);
   const line = encodeLines({ trailer: false }).push(toRow(record));
+  const lineBytes = Buffer.byteLength(line);
+  const inspection = io.inspect(lanePath);
+  const separatorBytes = inspection.endsClean ? 0 : 1;
+  const recordedAt = Date.parse(record.ts);
+  const compactedAt = Number.isFinite(recordedAt) ? recordedAt : Date.now();
+  let compacted = false;
+  if (inspection.size + separatorBytes + lineBytes > PROCESS_DEATH_LANE_MAX_BYTES) {
+    const targetBytes = Math.max(
+      0,
+      Math.floor(PROCESS_DEATH_LANE_MAX_BYTES * PROCESS_DEATH_LANE_COMPACTION_TARGET_RATIO) -
+        lineBytes,
+    );
+    compactProcessDeathLaneToTarget(lanePath, compactedAt, io, targetBytes);
+    compacted = true;
+  }
   io.mkdir(dirname(lanePath));
-  if (!io.endsClean(lanePath)) io.append(lanePath, "\n");
+  if (!compacted && !inspection.endsClean && inspection.size > 0) io.append(lanePath, "\n");
   io.append(lanePath, line);
   return record;
 }
@@ -311,24 +346,72 @@ export function compactProcessDeathLane(
   nowMs: number = Date.now(),
   io: DeathLaneIo = nodeDeathLaneIo,
 ): ProcessDeathRecord[] {
+  return compactProcessDeathLaneToTarget(lanePath, nowMs, io);
+}
+
+function compactProcessDeathLaneToTarget(
+  lanePath: string,
+  nowMs: number,
+  io: DeathLaneIo,
+  forcedTargetBytes?: number,
+): ProcessDeathRecord[] {
+  let raw: string;
   let records: ProcessDeathRecord[];
   try {
-    records = decodeProcessDeathRecords(io.read(lanePath));
+    raw = io.read(lanePath);
+    records = decodeProcessDeathRecords(raw);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
     throw error;
   }
 
   const cutoff = nowMs - PROCESS_DEATH_LANE_RETENTION_MS;
-  const retained = records.filter((record) => {
+  const ageRetained = records.filter((record) => {
     const timestamp = Date.parse(record.ts);
     return !Number.isFinite(timestamp) || timestamp >= cutoff;
   });
-  if (retained.length === records.length) return retained;
+  const oversized = Buffer.byteLength(raw) > PROCESS_DEATH_LANE_MAX_BYTES;
+  const targetBytes = forcedTargetBytes ??
+    (oversized
+      ? Math.floor(PROCESS_DEATH_LANE_MAX_BYTES * PROCESS_DEATH_LANE_COMPACTION_TARGET_RATIO)
+      : undefined);
+  const retained = targetBytes === undefined ? ageRetained : retainDeathRecordsWithin(ageRetained, targetBytes);
+  if (forcedTargetBytes === undefined && !oversized && retained.length === records.length) return retained;
 
-  const encoder = encodeLines({ trailer: false });
-  io.replace(lanePath, retained.map((record) => encoder.push(toRow(record))).join(""));
+  io.replace(lanePath, encodeDeathLane(retained));
   return retained;
+}
+
+/** Preserve unknown timestamps, then keep the newest dated history that fits. */
+function retainDeathRecordsWithin(
+  records: readonly ProcessDeathRecord[],
+  targetBytes: number,
+): ProcessDeathRecord[] {
+  const pinnedIndices = new Set<number>();
+  const optionalIndices: number[] = [];
+  records.forEach((record, index) => {
+    if (Number.isFinite(Date.parse(record.ts))) optionalIndices.push(index);
+    else pinnedIndices.add(index);
+  });
+
+  let low = 0;
+  let high = optionalIndices.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    const selected = new Set([...pinnedIndices, ...optionalIndices.slice(middle)]);
+    const candidate = records.filter((_record, index) => selected.has(index));
+    if (Buffer.byteLength(encodeDeathLane(candidate)) <= targetBytes) high = middle;
+    else low = middle + 1;
+  }
+
+  const selected = new Set([...pinnedIndices, ...optionalIndices.slice(low)]);
+  return records.filter((_record, index) => selected.has(index));
+}
+
+function encodeDeathLane(records: readonly ProcessDeathRecord[]): string {
+  if (records.length === 0) return "";
+  const encoder = encodeLines({ trailer: false });
+  return records.map((record) => encoder.push(toRow(record))).join("");
 }
 
 /**


### PR DESCRIPTION
Automated AFK landing for #3582. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3582

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789046078&installation_model_id=20659&pr_number=3601&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3601&signature=c8a0ec9cfad615968a234debb9ec5df1d87aa54362a202c4b668dc4b5434dd3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->