### PR TITLE
chore: changeset for the statusline brand re-theme

### DIFF
--- a/.changeset/statusline-brand-retheme.md
+++ b/.changeset/statusline-brand-retheme.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/dev": minor
+"@reddb-io/redskilled": minor
+---
+
+Re-theme the statusline under the bedrock/tail split (PR #3599). The shared render palette now derives every tone from published brand tokens (ADR 0137): the project block is the brand field (`brand.primary` ground, `brand.on-primary` ink), the model block recedes to `neutral.900`/paper, the lifecycle bar is a neutral intensity ramp, and `red.500` is the one failure spotlight — the pre-brand hand-tuned wine palette is deleted and the truecolor extinction ratchet now sweeps the render package. The Statusline Bedrock gains a themed render (brand field + kv hierarchy) pinned to be the plain render byte for byte behind the paint, the lifecycle tokens (`rsk=`, `age=`) paint in the same kv convention, and `NO_COLOR` restores the plain line end to end, stripping the daemon tail at the adapter boundary.


### PR DESCRIPTION
PR #3599 (statusline brand re-theme) landed without its release intent, so the release train has nothing to version. This adds the changeset — minor for `@reddb-io/dev` and `@reddb-io/redskilled`, matching the ADR 0141 precedent — so the Version-PR opens and the repaint ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789046095&installation_model_id=20659&pr_number=3602&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3602&signature=63cce6104a38f9a30c8f00d1e9f5f125eaafebab88ec91fe68d7316b52ceef7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->