### PR TITLE
chore: #3584 historyTrim gains its production caller at dev boot

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -382,10 +382,10 @@ export interface DocsSweepLandResult {
 }
 
 export type DocsSweepLander = (plan: DocsSweepPlan) => Promise<DocsSweepLandResult>;
-
 /** All injected IO + lookups for the boot run. */
 export interface BootDeps {
   fs: BootFs;
+  trimHistory(): Promise<number | null>;
   gh: BootGh;
   git: BootGit;
   lookups: BootLookups;
@@ -419,7 +419,6 @@ export interface BootDeps {
   /** Landing lane for the Docs Sweep. Absent is valid only when the plan is clean. */
   docsSweepLander?: DocsSweepLander;
 }
-
 function shortSha(sha: string | undefined): string {
   return sha ? sha.slice(0, 12) : "unknown";
 }
@@ -915,8 +914,7 @@ export interface BootResult {
  *
  *   0. host prerequisites   — required commands + Bash baseline; failure halts.
  *   1. precheck             — hard preconditions; a failure aborts the run.
- *   2. bootstrap            — ensure .red/tmp + .red/state, gitignore lines,
- *                             per-worker dir + worker.pid (via fs).
+ *   2. bootstrap + trim     — ensure dirs/worker pid; full boots cap castle history.
  *   3. orphan cleanup       — decideOrphanFate per dead-worker attempt dir, then
  *                             apply remove / restore-and-remove / keep (gh + fs).
  *   4. attempt cap          — planAttemptCap per issue, remove the reclaimed dirs.
@@ -1029,6 +1027,8 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
   if (options.skipSweeps) {
     return { precheck: pre, operationalProbes, quarantinedIssues, bootstrap: { ok: true } };
   }
+
+  await deps.trimHistory();
 
   // ---- 3. orphan cleanup ----
   const orphanCleanup = await runOrphanCleanup(deps, options);

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -22,6 +22,7 @@ import {
   type HostPrerequisiteProbeInput,
 } from "../../core/operational-probes.js";
 import { resolveSupervisorConfig } from "../../core/supervisor.js";
+import { historyTrim } from "../../core/history.js";
 import { evaluateFastForwardLocalTarget, fastForwardLocalTarget } from "../../core/merge.js";
 import { liveIssueFromBranch, type IssueMeta } from "../../core/branch-cleanup.js";
 import { readWorkerState } from "../../core/worker-state-reader.js";
@@ -515,6 +516,7 @@ export async function buildBootDeps(
       reapDeadEmptyWorkerShells: fsx.reapDeadEmptyWorkerShells,
       reapProcessGroup: (pgid) => killTreeAndWait(pgid),
     },
+    trimHistory: () => historyTrim(paths.historyPath),
     gh: {
       ensureLabel: (name) => ghx.ensureLabel(ghCtx, name),
       editLabels: async (issue, remove, add) => {
@@ -658,6 +660,7 @@ export function buildMinimalBootDeps(ctx: RepoContext, nowS: number): BootDeps {
       writeWorkerPid: fsx.writeWorkerPid,
       removeDir: fsx.removeDir,
     },
+    trimHistory: async () => unreachable(),
     gh: {
       editLabels: async () => unreachable(),
       comment: async () => unreachable(),

--- a/apps/dev/tests/boot.helpers.ts
+++ b/apps/dev/tests/boot.helpers.ts
@@ -54,6 +54,7 @@ export function makeDeps(over: Partial<{
   workerLivenessVerdict: BootDeps["fs"]["workerLivenessVerdict"];
   workerWorkspaceLivenessVerdict: BootDeps["fs"]["workerWorkspaceLivenessVerdict"];
   workerStateRecordLivenessVerdict: BootDeps["fs"]["workerStateRecordLivenessVerdict"];
+  trimHistory: BootDeps["trimHistory"];
   viewLabels: (issue: number) => Promise<string[]>;
   env: Record<string, string | undefined>;
   config: Record<string, string | undefined>;
@@ -119,6 +120,7 @@ export function makeDeps(over: Partial<{
           }
         : {}),
     },
+    trimHistory: over.trimHistory ?? (async () => null),
     gh: {
       async editLabels(issue, remove, add) {
         calls.push(`gh.editLabels:${issue}`);

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -1,5 +1,13 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { facts, precheck } from "./boot.helpers.js";
+import {
+  HISTORY_MAX_LINES_DEFAULT,
+  historyTrim,
+  parseHistoryLines,
+} from "../src/core/history.js";
+import { facts, makeDeps, options, precheck, runBoot } from "./boot.helpers.js";
 
 // ---------- precheck ----------
 
@@ -130,5 +138,44 @@ describe("precheck", () => {
     const r = precheck(facts({ pnpmInstalled: false }));
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.warnings).toEqual(["pnpm not on PATH; feedback loops will be skipped"]);
+  });
+});
+
+describe("history trim at boot", () => {
+  it("runs once and shrinks an oversized castle history fixture to the default", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dev-boot-history-"));
+    const historyPath = join(root, ".red", "state", "castle", "history.toonl");
+    await mkdir(join(historyPath, ".."), { recursive: true });
+    const fixtureLines = Array.from(
+      { length: HISTORY_MAX_LINES_DEFAULT + 1 },
+      (_, index) => {
+        const issue = index + 1;
+        return `  t${issue},${issue},wBOOT,${issue},done,0,codex,null,null`;
+      },
+    );
+    await writeFile(
+      historyPath,
+      [
+        `[${fixtureLines.length}]{ts,epoch,worker,issue,event,duration_s,runner,merge_sha,reason}:`,
+        ...fixtureLines,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    let trimCalls = 0;
+    const { deps } = makeDeps({
+      trimHistory: async () => {
+        trimCalls += 1;
+        return historyTrim(historyPath);
+      },
+    });
+
+    await runBoot(deps, options());
+
+    const history = parseHistoryLines(await readFile(historyPath, "utf8"));
+    expect(trimCalls).toBe(1);
+    expect(history).toHaveLength(HISTORY_MAX_LINES_DEFAULT);
+    expect(history[0]?.issue).toBe(2);
+    expect(history.at(-1)?.issue).toBe(HISTORY_MAX_LINES_DEFAULT + 1);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #3584. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3584

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789046854&installation_model_id=20659&pr_number=3604&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3604&signature=b6521e9bd8052cfc26510a77a8efaf98a88c6a70746d3129fb6f4c84b2f72d08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->