### PR TITLE
chore: #3585 Dead-worker workspaces gain the two-stage TTL

### DIFF
--- a/apps/dev/src/core/file-size-guard.ts
+++ b/apps/dev/src/core/file-size-guard.ts
@@ -45,7 +45,6 @@ export const FILE_SIZE_BASELINE: readonly FileSizeBaselineEntry[] = [
   { path: "apps/dev/src/runtime/doctor-classifiers.ts", lines: 900 },
   { path: "apps/dev/src/runtime/feedback-worktree.ts", lines: 1045 },
   { path: "apps/dev/src/runtime/git.ts", lines: 1023 },
-  { path: "apps/dev/src/runtime/tmp-janitor.ts", lines: 815 },
   { path: "apps/dev/tests/process-issue.test-helpers.ts", lines: 971 },
   { path: "apps/memory/src/bench-eval/runner.ts", lines: 1092 },
   { path: "apps/memory/src/cli/core.ts", lines: 1059 },

--- a/apps/dev/src/core/reclaim.ts
+++ b/apps/dev/src/core/reclaim.ts
@@ -22,6 +22,13 @@ export const ORPHAN_TTL_SHORT_S = 1 * 86400;
 export const DEFAULT_ATTEMPT_TTL_S = 14 * 86400;
 export const DEFAULT_ATTEMPT_KEEP = 5;
 
+/** Dead Workers with an OPEN issue keep their evidence but shed the expensive
+ * worktree at this age. */
+export const DEAD_WORKER_WORKTREE_TTL_S = 14 * 86400;
+
+/** Dead Workers with an OPEN issue are fully reclaimed at this age. */
+export const DEAD_WORKER_DIR_TTL_S = 45 * 86400;
+
 // ---------- orphan fate (prune_orphans) ----------
 
 /** Issue open/closed state as reported by `gh issue view --json state`. Any
@@ -180,46 +187,63 @@ export interface LivenessReclaimInput {
    * unreachable or stale daemon — spares the dir, because a reader that could
    * not reach the authority must never report a running Worker as gone (#2679). */
   liveness: WorkerProcessVerdict;
-  /** Whether the issue is in a post-mortem preservation state (`blocked:*` /
-   * `ready-for-human`, existing #256/#257 policy) — its JSONL/handoff is kept. */
-  preserved: boolean;
+  /** Tracker state for the represented issue. UNKNOWN is retained. */
+  issueState: "OPEN" | "CLOSED" | "UNKNOWN";
+  /** Workspace-directory mtime in epoch seconds, injected by the collector. */
+  mtimeS: number;
 }
 
 /** The reclaim decision for one dead-worker attempt dir. */
 export interface LivenessReclaimAction {
   attemptDir: string;
   worktreePath: string;
-  /** Always true for an emitted action — the disposable `worktree/` of a dead
-   * worker is ALWAYS removed, even when the JSONL is preserved. */
+  /** Always true for an emitted action: stage 1 strips the worktree, while an
+   * immediate CLOSED or stage-2 reclaim removes it with the parent dir. */
   removeWorktree: boolean;
-  /** Reclaim the WHOLE attempt dir. False when the issue is preserved (keep the
-   * JSONL/handoff for post-mortem; only the worktree goes). */
+  /** Reclaim the whole issue dir: immediately for CLOSED, at 45 days for OPEN. */
   reclaimDir: boolean;
+  /** Leave a one-line record beside the retained evidence after stage 1. */
+  writeTombstone: boolean;
 }
 
 /**
  * Plan the read-time liveness-gated reclaim (issue #1219). PURE — no I/O; the
- * caller resolves `liveness` and `preserved`.
+ * caller resolves liveness, issue state, age anchor, and clock.
  *   - A dir whose Worker the daemon has not called dead is NEVER touched.
- *   - A dead worker's `worktree/` is ALWAYS removed (disposable heavy dir).
- *   - A dead worker's whole attempt dir is reclaimed UNLESS the issue is
- *     preserved (blocked:* / ready-for-human), in which case the JSONL/handoff
- *     stay and only the worktree is torn down.
- * This runs immediately at read time, not gated on the boot orphan/attempt-cap
- * TTLs, so a killed/crashed worker leaves no graveyard behind it.
+ *   - A dead Worker's CLOSED issue dir is reclaimed immediately.
+ *   - A dead Worker's OPEN issue keeps everything for 14 days, then loses only
+ *     `worktree/` with a tombstone, then is fully reclaimed at 45 days.
+ *   - UNKNOWN tracker state is retained because uncertainty is not permission.
  */
 export function planLivenessReclaim(
   inputs: readonly LivenessReclaimInput[],
+  nowS: number,
 ): LivenessReclaimAction[] {
   const out: LivenessReclaimAction[] = [];
   for (const i of inputs) {
     if (i.liveness !== "dead") continue;
-    out.push({
-      attemptDir: i.attemptDir,
-      worktreePath: i.worktreePath,
-      removeWorktree: true,
-      reclaimDir: !i.preserved,
-    });
+    if (i.issueState === "CLOSED") {
+      out.push({
+        attemptDir: i.attemptDir,
+        worktreePath: i.worktreePath,
+        removeWorktree: true,
+        reclaimDir: true,
+        writeTombstone: false,
+      });
+      continue;
+    }
+    if (i.issueState === "UNKNOWN") continue;
+    if (i.issueState === "OPEN") {
+      const ageS = nowS - i.mtimeS;
+      if (ageS < DEAD_WORKER_WORKTREE_TTL_S) continue;
+      out.push({
+        attemptDir: i.attemptDir,
+        worktreePath: i.worktreePath,
+        removeWorktree: true,
+        reclaimDir: ageS >= DEAD_WORKER_DIR_TTL_S,
+        writeTombstone: ageS < DEAD_WORKER_DIR_TTL_S,
+      });
+    }
   }
   return out;
 }

--- a/apps/dev/src/core/tmp-janitor.ts
+++ b/apps/dev/src/core/tmp-janitor.ts
@@ -19,6 +19,7 @@
 // janitor never deletes outside its known lanes.
 
 import { isAbsolute, relative, resolve, sep } from "node:path";
+import { DEAD_WORKER_DIR_TTL_S } from "./reclaim.js";
 import type { WorkerProcessVerdict } from "./worker-reclaim.js";
 
 /**
@@ -270,6 +271,8 @@ export interface WorkerDirIssueState {
 
 export interface WorkerDirJanitorEntry {
   path: string;
+  /** Directory mtime in epoch seconds, collected once for the pure TTL plan. */
+  mtimeS: number;
   /**
    * The DAEMON's verdict on the Worker that owns this dir (Spec #2772 US 46).
    * `unknown` — an unreachable or stale daemon — is not `dead`, so it spares the
@@ -294,12 +297,22 @@ export interface WorkerDirJanitorPlan {
  * missing pid file is what deleted a live lane and kept the dead ones (#2679).
  * A missing pid file is therefore not even an input here — only the daemon's own
  * fresh answer can release a dir. */
-export function planWorkerDirJanitor(entries: readonly WorkerDirJanitorEntry[]): WorkerDirJanitorPlan {
+export function planWorkerDirJanitor(
+  entries: readonly WorkerDirJanitorEntry[],
+  nowS: number,
+): WorkerDirJanitorPlan {
   const reclaim: WorkerDirJanitorEntry[] = [];
   const spare: WorkerDirJanitorEntry[] = [];
   for (const entry of entries) {
     const issues = entry.issues;
-    if (entry.liveness === "dead" && issues.length > 0 && issues.every((issue) => issue.state === "CLOSED")) {
+    const everyIssueClosed = issues.length > 0 && issues.every((issue) => issue.state === "CLOSED");
+    const everyIssueKnown = issues.length > 0 && issues.every((issue) => issue.state !== "UNKNOWN");
+    const anyIssueOpen = issues.some((issue) => issue.state === "OPEN");
+    const openIssueTtlExpired =
+      everyIssueKnown &&
+      anyIssueOpen &&
+      nowS - entry.mtimeS >= DEAD_WORKER_DIR_TTL_S;
+    if (entry.liveness === "dead" && (everyIssueClosed || openIssueTtlExpired)) {
       reclaim.push(entry);
     } else {
       spare.push(entry);

--- a/apps/dev/src/runtime/tmp-janitor.ts
+++ b/apps/dev/src/runtime/tmp-janitor.ts
@@ -19,7 +19,6 @@ import {
 } from "../core/tmp-janitor.js";
 import {
   planWorkerReclaim,
-  type WorkerArtifact,
   type WorkerProcessVerdict,
   type WorkerReclaimPlan,
 } from "../core/worker-reclaim.js";
@@ -41,6 +40,10 @@ import {
   type DaemonWorkerSet,
   type DaemonWorkerSetReader,
 } from "./liveness-anchor.js";
+import {
+  collectWorkerWorkspaceArtifacts,
+  writeWorktreeReclaimTombstone,
+} from "./worker-workspace-retention.js";
 
 export const ORPHAN_TEST_RUNNER_MIN_AGE_S = 300;
 
@@ -277,41 +280,6 @@ function sweepLiveness(
     ask(workerId, evidence.has(workerId) || extraEvidence);
 }
 
-/**
- * Every artifact the Worker lanes hold, attributed to its owning Worker.
- *
- * The workspace path is DERIVED from the Worker's identity (ADR 0103/0105) — it
- * is a pure function of `workers/{id}/{issue}/worktree` — and the daemon still
- * decides whether the bytes go.
- */
-async function collectWorkerArtifacts(tmpDir: string): Promise<{
-  artifacts: WorkerArtifact[];
-  observedPaths: string[];
-}> {
-  const artifacts: WorkerArtifact[] = [];
-  const observedPaths: string[] = [];
-  for (const workersRoot of allWorkersRoots(tmpDir)) {
-    for (const worker of await listNames(workersRoot)) {
-      for (const issue of await listNames(join(workersRoot, worker))) {
-        const issueDir = join(workersRoot, worker, issue);
-        const worktree = join(issueDir, "worktree");
-        try {
-          if (!(await stat(worktree)).isDirectory()) continue;
-        } catch {
-          continue; // No workspace under this Worker's issue dir.
-        }
-        observedPaths.push(worktree);
-        artifacts.push({ worker_id: worker, kind: "worktree", path: worktree });
-        const log = join(workersRoot, worker, "worker.log.toonl");
-        if (await readText(log) !== null) {
-          artifacts.push({ worker_id: worker, kind: "log", path: log });
-        }
-      }
-    }
-  }
-  return { artifacts, observedPaths };
-}
-
 async function collectWorkerEntries(
   tmpDir: string,
   lookup: IssueStateLookup,
@@ -322,9 +290,11 @@ async function collectWorkerEntries(
     const workers = await listNames(workersRoot);
     for (const worker of workers) {
       const workerPath = join(workersRoot, worker);
+      let mtimeS: number;
       try {
         const st = await stat(workerPath);
         if (!st.isDirectory()) continue;
+        mtimeS = Math.floor(st.mtimeMs / 1000);
       } catch {
         continue;
       }
@@ -345,6 +315,7 @@ async function collectWorkerEntries(
       }
       out.push({
         path: workerPath,
+        mtimeS,
         liveness: verdict,
         issues: [...issues].map(([issue, state]) => ({ issue, state })),
       });
@@ -537,7 +508,7 @@ export async function collectTmpJanitorReport(
     await readDaemon(sources.daemon ?? readDaemonWorkerSet),
     await collectWorkerEvidence(tmpDir),
   );
-  const workerArtifacts = await collectWorkerArtifacts(tmpDir);
+  const workerArtifacts = await collectWorkerWorkspaceArtifacts(tmpDir, lookup);
   const workerReclaim = planWorkerReclaim(workerArtifacts.artifacts, {
     liveness: (workerId) => liveness(workerId),
     nowIso: new Date(nowS * 1000).toISOString(),
@@ -576,7 +547,7 @@ export async function collectTmpJanitorReport(
     }),
     workerReclaim,
     workerStateRecords,
-    staleWorkers: planWorkerDirJanitor(workers),
+    staleWorkers: planWorkerDirJanitor(workers, nowS),
     staleSupervisors: planSupervisorLaneJanitor(supervisorEntries),
     orphanFeedback,
     orphanTestRunners,
@@ -587,6 +558,7 @@ export async function applyTmpJanitorReport(
   tmpDir: string,
   report: TmpJanitorReport,
   options: TmpJanitorSources & {
+    nowS?: number;
     worktreePrune?: () => Promise<void>;
     reapProcessGroup?: (pgid: number) => Promise<boolean>;
     log?: (line: string) => void;
@@ -663,6 +635,9 @@ export async function applyTmpJanitorReport(
       continue;
     }
     await rm(path, { recursive: true, force: true });
+    if (verdict.artifact.reclaim_after !== undefined) {
+      await writeWorktreeReclaimTombstone(path, options.nowS ?? Date.now() / 1000);
+    }
     result.removals.push({ path, livenessVerdict: "worker-dead" });
     result.workerWorkspaces.push(path);
   }
@@ -811,5 +786,8 @@ export async function runTmpJanitor(
 ): Promise<TmpJanitorRunResult> {
   const report = await collectTmpJanitorReport(tmpDir, nowS, lookup, options);
   if (!options.fix) return report;
-  return { ...report, applied: await applyTmpJanitorReport(tmpDir, report, options) };
+  return {
+    ...report,
+    applied: await applyTmpJanitorReport(tmpDir, report, { ...options, nowS }),
+  };
 }

--- a/apps/dev/src/runtime/wire/monitor.ts
+++ b/apps/dev/src/runtime/wire/monitor.ts
@@ -1,4 +1,5 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { readPublishedBundleVersion } from "../../core/published-version.js";
 import { decodeDevSnapshotSniff } from "../../core/toon-snapshot.js";
@@ -12,8 +13,6 @@ import { planLivenessReclaim, type LivenessReclaimInput } from "../../core/recla
 import type { WorkerProcessVerdict } from "../../core/worker-reclaim.js";
 import { readWorkerLivenessForTmpPath } from "../tmp-janitor.js";
 import { readHistoryRecords, type HistoryRecord } from "../../core/history.js";
-import { LABEL_HUMAN } from "../../core/triage-labels.js";
-import { blockedLabelsIn } from "../../core/state-transition.js";
 import {
   createEnginePaths,
   readCastleMonitorFleetState,
@@ -25,6 +24,10 @@ import * as gitx from "../git.js";
 import * as fsx from "../fs.js";
 import { collectLogLineCounts } from "../log-cursor.js";
 import { reapableWorktreeUnder } from "../supervisor-fs.js";
+import {
+  WORKTREE_RECLAIM_TOMBSTONE,
+  worktreeReclaimTombstoneLine,
+} from "../worker-workspace-retention.js";
 import { afkPaths } from "./paths.js";
 
 export interface MonitorInputs {
@@ -179,22 +182,25 @@ export interface DeadWorkerSweepDeps {
    * pid-file seam here, because keying reclaim on a pid file is what deleted a
    * live lane and kept the dead ones (#2679). */
   workerLiveness?: (workerDir: string) => Promise<WorkerProcessVerdict>;
-  /** Whether an issue is in a post-mortem preservation state (blocked:* /
-   * ready-for-human). Default `gh issue view --json labels`. Returns `true`
-   * (conservative — keep the JSONL) whenever it cannot resolve. */
-  isPreserved?: (issue: number) => Promise<boolean>;
+  /** Current tracker state. UNKNOWN conservatively retains the workspace. */
+  issueState?: (issue: number) => Promise<"OPEN" | "CLOSED" | "UNKNOWN">;
+  /** Worker-state mtime in epoch seconds; sibling tombstones do not reset it. */
+  dirMtimeS?: (statePath: string) => number | undefined;
+  /** Injected clock for the pure two-stage TTL planner. */
+  nowS?: number;
   /** `git worktree remove --force`. Default runtime git against `root`. */
   removeWorktree?: (worktreePath: string) => Promise<void>;
   /** `rm -rf`. Default `fsx.removeDir`. */
   removeDir?: (dir: string) => Promise<void>;
   /** Path existence probe. Default `existsSync`. */
   exists?: (path: string) => boolean;
+  /** Tombstone writer, injected so the stage-one side effect is testable. */
+  writeTombstone?: (path: string, contents: string) => Promise<void>;
 }
 
 /**
- * Read-time liveness-gated teardown (issue #1219): as workers finish/crash, take
- * them out of context — remove the heavy local `worktree/` and reclaim the
- * attempt dir immediately, without waiting for the boot TTLs (reclaim.ts). Runs
+ * Read-time liveness-gated teardown (issue #1219): as workers finish/crash,
+ * enforce the CLOSED-immediate / OPEN-two-stage policy from the pure planner. Runs
  * across the SAME namespace union the reader uses (workers/go-workers/
  * scout-workers) since it consumes {@link readAllWorkerStates} records.
  *
@@ -202,9 +208,8 @@ export interface DeadWorkerSweepDeps {
  *   - NEVER touch a dir whose OWNING Worker the daemon has not called dead — the
  *     verdict is per-Worker (shared across its attempts), so a Worker live on a
  *     later attempt keeps ALL its dirs.
- *   - A dead worker's disposable `worktree/` is ALWAYS removed.
- *   - The whole attempt dir is reclaimed UNLESS the issue is preserved
- *     (blocked:* / ready-for-human), where the JSONL/handoff stay for post-mortem.
+ *   - CLOSED issue dirs go immediately; OPEN issue dirs strip at 14 days and go
+ *     at 45 days; UNKNOWN issue state is retained.
  *
  * Best-effort throughout: every fs/git/gh failure is swallowed so the sweep never
  * breaks the read it rides on. Returns the reclaimed attempt-dir paths.
@@ -220,24 +225,31 @@ export async function reclaimDeadWorkers(
     deps.workerLiveness ??
     ((workerDir: string): Promise<WorkerProcessVerdict> =>
       readWorkerLivenessForTmpPath(afkPaths(root).tmpDir, workerDir));
-  const isPreserved =
-    deps.isPreserved ??
-    (async (issue: number): Promise<boolean> => {
+  const issueState =
+    deps.issueState ??
+    (async (issue: number): Promise<"OPEN" | "CLOSED" | "UNKNOWN"> => {
+      const state = await ghx.blockerState({ cwd: root, repo }, issue);
+      return state === "OPEN" || state === "CLOSED" ? state : "UNKNOWN";
+    });
+  const dirMtimeS =
+    deps.dirMtimeS ??
+    ((dir: string): number | undefined => {
       try {
-        const labels = await ghx.viewLabels({ cwd: root, repo }, issue);
-        // Empty labels (gh failed) → conservative: keep the JSONL.
-        if (labels.length === 0) return true;
-        return labels.includes(LABEL_HUMAN) || blockedLabelsIn(labels).length > 0;
+        return Math.floor(statSync(dir).mtimeMs / 1000);
       } catch {
-        return true;
+        return undefined;
       }
     });
+  const nowS = deps.nowS ?? Math.floor(Date.now() / 1000);
   const removeWorktree =
     deps.removeWorktree ??
     (async (worktreePath: string): Promise<void> => {
       await gitx.worktreeRemove({ cwd: root }, worktreePath);
     });
   const removeDir = deps.removeDir ?? ((dir: string) => fsx.removeDir(dir));
+  const writeTombstone =
+    deps.writeTombstone ??
+    ((path: string, contents: string): Promise<void> => writeFile(path, contents, "utf8"));
 
   // The daemon's verdict per Worker, memoized so a Worker's several attempt dirs
   // ask once. An unreachable daemon answers `unknown`, which spares the dir.
@@ -250,7 +262,7 @@ export async function reclaimDeadWorkers(
     return verdict;
   };
 
-  // Build the pure planner inputs, resolving preservation only for dead workers.
+  // Build the pure planner inputs, resolving tracker state only for dead workers.
   const inputs: LivenessReclaimInput[] = [];
   for (const rec of records) {
     const attemptDir = dirname(rec.path);
@@ -260,22 +272,31 @@ export async function reclaimDeadWorkers(
     const liveness = rec.renderableLive ? "unknown" : await workerVerdict(workerDir);
     const num = rec.state.current.number;
     const issue = typeof num === "number" ? num : Number.parseInt(String(num), 10);
-    const preserved =
-      Number.isFinite(issue) && issue > 0 ? await isPreserved(issue) : true;
+    const state =
+      Number.isFinite(issue) && issue > 0 ? await issueState(issue) : "UNKNOWN";
     inputs.push({
       attemptDir,
       // Current workers use the conventional direct child. During rollout,
       // hygiene may still discover a legacy nested worktree for removal only.
       worktreePath: reapableWorktreeUnder(attemptDir) ?? join(attemptDir, "worktree"),
       liveness,
-      preserved,
+      issueState: state,
+      mtimeS: dirMtimeS(rec.path) ?? nowS,
     });
   }
 
   const reclaimed: string[] = [];
-  for (const action of planLivenessReclaim(inputs)) {
+  for (const action of planLivenessReclaim(inputs, nowS)) {
+    let worktreeRemoved = false;
     if (action.removeWorktree && exists(action.worktreePath)) {
       await removeWorktree(action.worktreePath).catch(() => undefined);
+      worktreeRemoved = true;
+    }
+    if (action.writeTombstone && worktreeRemoved) {
+      await writeTombstone(
+        join(action.attemptDir, WORKTREE_RECLAIM_TOMBSTONE),
+        worktreeReclaimTombstoneLine(nowS),
+      ).catch(() => undefined);
     }
     if (action.reclaimDir) {
       await removeDir(action.attemptDir).catch(() => undefined);
@@ -294,10 +315,9 @@ export async function collectMonitorInputs(root = process.cwd(), repo = ""): Pro
   let workers = await readCastleMonitorWorkers(castlePaths);
   if (workers.length === 0) {
     const records = await readAllWorkerStates(paths.tmpDir);
-    // Read-time liveness-gated teardown (issue #1219): reclaim dead-worker
-    // worktrees/dirs immediately, not on the boot TTL. Best-effort — a failure
-    // here never blocks the render. Live-worker dirs and blocked/ready-for-human
-    // post-mortem artifacts are preserved (planLivenessReclaim).
+    // Read-time liveness-gated teardown (issue #1219): enforce the same
+    // CLOSED-immediate / OPEN-two-stage policy as the boot janitor. Best-effort
+    // — a failure here never blocks the render.
     await reclaimDeadWorkers(root, records, repo).catch(() => undefined);
     await fsx.reapDeadEmptyWorkerShells(paths.tmpDir).catch(() => undefined);
     const currentRecords = currentRenderableWorkerRecords(records);

--- a/apps/dev/src/runtime/worker-workspace-retention.ts
+++ b/apps/dev/src/runtime/worker-workspace-retention.ts
@@ -1,0 +1,89 @@
+import { readdir, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { DEAD_WORKER_WORKTREE_TTL_S } from "../core/reclaim.js";
+import type { WorkerArtifact } from "../core/worker-reclaim.js";
+import { allWorkersRoots, parseReapableWorkerPath } from "../core/worker-paths.js";
+
+export const WORKTREE_RECLAIM_TOMBSTONE = "worktree.reclaimed";
+
+type IssueStateLookup = (issue: number) => "OPEN" | "CLOSED" | "UNKNOWN";
+
+async function listNames(path: string): Promise<string[]> {
+  try {
+    return await readdir(path);
+  } catch {
+    return [];
+  }
+}
+
+/** Collect workspace and evidence artifacts with the OPEN-issue stage-1 hold. */
+export async function collectWorkerWorkspaceArtifacts(
+  tmpDir: string,
+  lookup: IssueStateLookup,
+): Promise<{ artifacts: WorkerArtifact[]; observedPaths: string[] }> {
+  const artifacts: WorkerArtifact[] = [];
+  const observedPaths: string[] = [];
+  for (const workersRoot of allWorkersRoots(tmpDir)) {
+    for (const worker of await listNames(workersRoot)) {
+      const workerPath = join(workersRoot, worker);
+      let workerMtimeS: number;
+      try {
+        const workerStat = await stat(workerPath);
+        if (!workerStat.isDirectory()) continue;
+        workerMtimeS = Math.floor(workerStat.mtimeMs / 1000);
+      } catch {
+        continue;
+      }
+      for (const issue of await listNames(workerPath)) {
+        const issueDir = join(workerPath, issue);
+        const parsed = parseReapableWorkerPath(issueDir);
+        if (!parsed) continue;
+        const worktree = join(issueDir, "worktree");
+        try {
+          if (!(await stat(worktree)).isDirectory()) continue;
+        } catch {
+          continue;
+        }
+        observedPaths.push(worktree);
+        const issueState = lookup(parsed.issue);
+        artifacts.push({
+          worker_id: worker,
+          kind: "worktree",
+          path: worktree,
+          ...(issueState === "OPEN"
+            ? {
+                reclaim_after: new Date(
+                  (workerMtimeS + DEAD_WORKER_WORKTREE_TTL_S) * 1000,
+                ).toISOString(),
+              }
+            : issueState === "UNKNOWN"
+              ? { reclaimable: false, reason: "the represented issue state is unknown" }
+              : {}),
+        });
+        const log = join(dirname(issueDir), "worker.log.toonl");
+        try {
+          await stat(log);
+          artifacts.push({ worker_id: worker, kind: "log", path: log });
+        } catch {
+          // No evidence log in this Worker lane.
+        }
+      }
+    }
+  }
+  return { artifacts, observedPaths };
+}
+
+export function worktreeReclaimTombstoneLine(nowS: number): string {
+  return `worktree reclaimed at ${new Date(nowS * 1000).toISOString()}\n`;
+}
+
+export async function writeWorktreeReclaimTombstone(
+  worktreePath: string,
+  nowS: number,
+): Promise<void> {
+  await writeFile(
+    join(dirname(worktreePath), WORKTREE_RECLAIM_TOMBSTONE),
+    worktreeReclaimTombstoneLine(nowS),
+    "utf8",
+  );
+}

--- a/apps/dev/tests/boot-cleanup.test.ts
+++ b/apps/dev/tests/boot-cleanup.test.ts
@@ -167,6 +167,7 @@ describe("runBoot tmp janitor", () => {
             reclaim: [
               {
                 path: "/p/.red/tmp/workers/wOLD",
+                mtimeS: NOW,
                 liveness: "dead",
                 issues: [{ issue: 9, state: "CLOSED" }],
               },
@@ -284,6 +285,7 @@ describe("runBoot tmp janitor", () => {
             reclaim: [
               {
                 path: "/p/.red/tmp/workers/wLIVE",
+                mtimeS: NOW,
                 liveness: "dead",
                 issues: [{ issue: 9, state: "CLOSED" }],
               },

--- a/apps/dev/tests/reclaim.test.ts
+++ b/apps/dev/tests/reclaim.test.ts
@@ -199,39 +199,46 @@ describe("planAttemptCap", () => {
 
 // issue #1219 PART 4: liveness-gated read-time reclaim planner.
 describe("planLivenessReclaim (issue #1219)", () => {
+  const NOW = 2_000_000_000;
   const input = (over: Partial<LivenessReclaimInput>): LivenessReclaimInput => ({
     attemptDir: "/r/.red/tmp/workers/wA/5-a1",
     worktreePath: "/r/.red/tmp/workers/wA/5-a1/worktree",
     liveness: "dead",
-    preserved: false,
+    issueState: "CLOSED",
+    mtimeS: NOW,
     ...over,
   });
 
   it("never touches a dir the daemon has not called dead", () => {
-    expect(planLivenessReclaim([input({ liveness: "unknown" })])).toEqual([]);
+    expect(planLivenessReclaim([input({ liveness: "unknown" })], NOW)).toEqual([]);
   });
 
   it("never touches a live worker's dir", () => {
-    expect(planLivenessReclaim([input({ liveness: "alive" })])).toEqual([]);
+    expect(planLivenessReclaim([input({ liveness: "alive" })], NOW)).toEqual([]);
   });
 
-  it("reclaims a dead, non-preserved worker's whole dir (worktree + dir)", () => {
-    const [action] = planLivenessReclaim([input({ liveness: "dead", preserved: false })]);
-    expect(action.removeWorktree).toBe(true);
-    expect(action.reclaimDir).toBe(true);
-  });
-
-  it("removes only the worktree of a dead but preserved worker (keeps JSONL/handoff)", () => {
-    const [action] = planLivenessReclaim([input({ liveness: "dead", preserved: true })]);
+  it("strips a dead Worker's worktree at the 14-day OPEN-issue threshold", () => {
+    const [action] = planLivenessReclaim(
+      [input({ issueState: "OPEN", mtimeS: NOW - 14 * DAY })],
+      NOW,
+    );
     expect(action.removeWorktree).toBe(true);
     expect(action.reclaimDir).toBe(false);
+    expect(action.writeTombstone).toBe(true);
+  });
+
+  it("reclaims a dead Worker's CLOSED issue immediately", () => {
+    const [action] = planLivenessReclaim([input({ issueState: "CLOSED" })], NOW);
+    expect(action.removeWorktree).toBe(true);
+    expect(action.reclaimDir).toBe(true);
+    expect(action.writeTombstone).toBe(false);
   });
 
   it("keeps a live worker's dir while reclaiming a sibling dead worker", () => {
     const actions = planLivenessReclaim([
       input({ attemptDir: "/r/.red/tmp/workers/wLIVE/5-a1", liveness: "alive" }),
-      input({ attemptDir: "/r/.red/tmp/go-workers/wDEAD/6-a1", liveness: "dead", preserved: false }),
-    ]);
+      input({ attemptDir: "/r/.red/tmp/go-workers/wDEAD/6-a1", liveness: "dead" }),
+    ], NOW);
     expect(actions.map((a) => a.attemptDir)).toEqual(["/r/.red/tmp/go-workers/wDEAD/6-a1"]);
   });
 });

--- a/apps/dev/tests/tmp-janitor-daemon-reclaim.test.ts
+++ b/apps/dev/tests/tmp-janitor-daemon-reclaim.test.ts
@@ -5,7 +5,7 @@
 // (#2679): the live lanes carry NO pid file at all, and the dead ones do. A
 // janitor keyed on pid files gets each of these exactly backwards.
 
-import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -58,6 +58,7 @@ const noDaemon: DaemonWorkerSetReader = async () => null;
 
 /** A Worker workspace with a git worktree and a log beside it, and no pid file. */
 async function workspace(tmp: string, worker: string, issue: number): Promise<{
+  issueDir: string;
   worktree: string;
   log: string;
 }> {
@@ -66,7 +67,7 @@ async function workspace(tmp: string, worker: string, issue: number): Promise<{
   await mkdir(join(worktree, "node_modules"), { recursive: true });
   const log = join(dirname(issueDir), "worker.log.toonl");
   await writeFile(log, "", "utf8");
-  return { worktree, log };
+  return { issueDir, worktree, log };
 }
 
 async function exists(path: string): Promise<boolean> {
@@ -97,10 +98,13 @@ describe("the janitor reclaims on the daemon's process truth", () => {
     expect(await exists(worktree)).toBe(true);
   });
 
-  it("reclaims a dead Worker's workspace and keeps the evidence beside it", async () => {
+  it("strips a dead Worker's OPEN-issue worktree at 14 days and leaves a tombstone with its evidence", async () => {
     const root = await tempRoot();
     const tmp = join(root, ".red", "tmp");
-    const { worktree, log } = await workspace(tmp, "wDONE", 2789);
+    const { issueDir, worktree, log } = await workspace(tmp, "wDONE", 2789);
+    const threshold = NOW - 14 * 86_400;
+    await utimes(issueDir, threshold, threshold);
+    await utimes(dirname(issueDir), threshold, threshold);
 
     // Issue OPEN, so the whole-dir rule stays out of it: the workspace goes
     // because the daemon does not name its Worker, with nothing else to help.
@@ -112,6 +116,28 @@ describe("the janitor reclaims on the daemon's process truth", () => {
     expect(result.applied?.workerWorkspaces).toEqual([worktree]);
     expect(await exists(worktree)).toBe(false);
     expect(await exists(log)).toBe(true);
+    expect(await exists(issueDir)).toBe(true);
+    expect(await readFile(join(issueDir, "worktree.reclaimed"), "utf8")).toBe(
+      `worktree reclaimed at ${NOW_ISO}\n`,
+    );
+  });
+
+  it("reclaims a dead Worker's whole OPEN-issue directory at 45 days", async () => {
+    const root = await tempRoot();
+    const tmp = join(root, ".red", "tmp");
+    const { issueDir } = await workspace(tmp, "wEXPIRED", 3585);
+    const workerDir = dirname(issueDir);
+    const threshold = NOW - 45 * 86_400;
+    await utimes(issueDir, threshold, threshold);
+    await utimes(workerDir, threshold, threshold);
+
+    const result = await runTmpJanitor(tmp, NOW, () => "OPEN", {
+      fix: true,
+      daemon: daemonNaming(),
+    });
+
+    expect(result.applied?.staleWorkers).toEqual([workerDir]);
+    expect(await exists(workerDir)).toBe(false);
   });
 
   it("never reclaims through a pid file: an unanswered daemon spares everything", async () => {

--- a/apps/dev/tests/tmp-janitor.test.ts
+++ b/apps/dev/tests/tmp-janitor.test.ts
@@ -183,6 +183,7 @@ describe("planWorkerDirJanitor", () => {
   function worker(over: Partial<WorkerDirJanitorEntry>): WorkerDirJanitorEntry {
     return {
       path: "/red/tmp/workers/w1",
+      mtimeS: NOW,
       liveness: "dead",
       issues: [{ issue: 1, state: "CLOSED" }],
       ...over,
@@ -191,35 +192,35 @@ describe("planWorkerDirJanitor", () => {
 
   it("reclaims dead worker dirs when every represented issue is closed", () => {
     const entry = worker({ issues: [{ issue: 10, state: "CLOSED" }, { issue: 11, state: "CLOSED" }] });
-    expect(planWorkerDirJanitor([entry])).toEqual({ reclaim: [entry], spare: [] });
+    expect(planWorkerDirJanitor([entry], NOW)).toEqual({ reclaim: [entry], spare: [] });
   });
 
   it("spares worker dirs the daemon calls alive", () => {
     const entry = worker({ liveness: "alive" });
-    expect(planWorkerDirJanitor([entry])).toEqual({ reclaim: [], spare: [entry] });
+    expect(planWorkerDirJanitor([entry], NOW)).toEqual({ reclaim: [], spare: [entry] });
   });
 
   it("spares a worker dir the daemon could not answer for, closed issues and all", () => {
     // The pid-keyed predecessor read a missing pid file as death and reclaimed
     // exactly this dir. An unreachable authority is not evidence (#2679).
     const entry = worker({ liveness: "unknown" });
-    expect(planWorkerDirJanitor([entry])).toEqual({ reclaim: [], spare: [entry] });
+    expect(planWorkerDirJanitor([entry], NOW)).toEqual({ reclaim: [], spare: [entry] });
   });
 
   it("spares worker dirs with open or unknown issues", () => {
     const open = worker({ path: "/red/tmp/workers/w-open", issues: [{ issue: 1, state: "OPEN" }] });
     const unknown = worker({ path: "/red/tmp/workers/w-unknown", issues: [{ issue: 2, state: "UNKNOWN" }] });
-    expect(planWorkerDirJanitor([open, unknown])).toEqual({ reclaim: [], spare: [open, unknown] });
+    expect(planWorkerDirJanitor([open, unknown], NOW)).toEqual({ reclaim: [], spare: [open, unknown] });
   });
 
   it("spares dead worker dirs with no issue-bearing attempts", () => {
     const entry = worker({ issues: [] });
-    expect(planWorkerDirJanitor([entry])).toEqual({ reclaim: [], spare: [entry] });
+    expect(planWorkerDirJanitor([entry], NOW)).toEqual({ reclaim: [], spare: [entry] });
   });
 
   it("reclaims a dead worker dir whose every issue is closed", () => {
     const entry = worker({ issues: [{ issue: 1, state: "CLOSED" }] });
-    expect(planWorkerDirJanitor([entry])).toEqual({ reclaim: [entry], spare: [] });
+    expect(planWorkerDirJanitor([entry], NOW)).toEqual({ reclaim: [entry], spare: [] });
   });
 });
 

--- a/apps/dev/tests/wire-reclaim.test.ts
+++ b/apps/dev/tests/wire-reclaim.test.ts
@@ -43,7 +43,7 @@ function harness(over: Partial<DeadWorkerSweepDeps> = {}): {
   const deps: DeadWorkerSweepDeps = {
     // The daemon's verdict: dead unless a test overrides it.
     workerLiveness: async () => "dead",
-    isPreserved: async () => false,
+    issueState: async () => "CLOSED",
     exists: () => true,
     removeWorktree: async (p) => {
       removedWorktrees.push(p);
@@ -58,6 +58,7 @@ function harness(over: Partial<DeadWorkerSweepDeps> = {}): {
 
 describe("reclaimDeadWorkers (issue #1219)", () => {
   const ROOT = "/r";
+  const NOW = 2_000_000_000;
 
   it("reclaims a dead, non-preserved worker's worktree AND attempt dir", async () => {
     const { deps, removedWorktrees, removedDirs } = harness();
@@ -65,6 +66,25 @@ describe("reclaimDeadWorkers (issue #1219)", () => {
     expect(removedWorktrees).toEqual(["/r/.red/tmp/workers/wDEAD/5-a1/worktree"]);
     expect(removedDirs).toEqual(["/r/.red/tmp/workers/wDEAD/5-a1"]);
     expect(reclaimed).toEqual(["/r/.red/tmp/workers/wDEAD/5-a1"]);
+  });
+
+  it("leaves a freshly dead Worker's OPEN-issue workspace untouched", async () => {
+    const { deps, removedWorktrees, removedDirs } = harness({
+      issueState: async () => "OPEN",
+      dirMtimeS: () => NOW,
+      nowS: NOW,
+    });
+
+    const reclaimed = await reclaimDeadWorkers(
+      ROOT,
+      [record(ROOT, "wFRESH", 3585, false)],
+      "",
+      deps,
+    );
+
+    expect(removedWorktrees).toEqual([]);
+    expect(removedDirs).toEqual([]);
+    expect(reclaimed).toEqual([]);
   });
 
   it("NEVER touches a dir whose Worker the daemon names", async () => {
@@ -75,8 +95,12 @@ describe("reclaimDeadWorkers (issue #1219)", () => {
     expect(reclaimed).toEqual([]);
   });
 
-  it("removes ONLY the worktree of a dead but preserved worker (keeps the JSONL)", async () => {
-    const { deps, removedWorktrees, removedDirs } = harness({ isPreserved: async () => true });
+  it("removes only the worktree of a 14-day dead Worker with an OPEN issue", async () => {
+    const { deps, removedWorktrees, removedDirs } = harness({
+      issueState: async () => "OPEN",
+      dirMtimeS: () => NOW - 14 * 86_400,
+      nowS: NOW,
+    });
     const reclaimed = await reclaimDeadWorkers(ROOT, [record(ROOT, "wBLOCKED", 6, false)], "", deps);
     expect(removedWorktrees).toEqual(["/r/.red/tmp/workers/wBLOCKED/6-a1/worktree"]);
     expect(removedDirs).toEqual([]);


### PR DESCRIPTION
Automated AFK landing for #3585. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3585

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789047575&installation_model_id=20659&pr_number=3608&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3608&signature=a995d09e1af57b3e0588d5af7ebbb26035c81afb718ce4556872ed8f485b93e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->