### PR TITLE
chore: #3587 Shared lane-retention: policy registry, tq-first trimming, and dead-temp sweeps

### DIFF
--- a/apps/dev/src/commands/boot-sweeps.ts
+++ b/apps/dev/src/commands/boot-sweeps.ts
@@ -11,6 +11,7 @@ import {
   formatDeathAttributions,
   runBootDeathReaper,
 } from "@reddb-io/shared/death-attribution.js";
+import { sweepLaneTemps } from "@reddb-io/shared/lane-retention.js";
 import { stateDir } from "@reddb-io/shared/red-paths.js";
 import {
   afkPaths,
@@ -88,6 +89,7 @@ export function buildProjectBootSweeps(
     // deaths from the last boot are attributed while the evidence is freshest,
     // and a precheck failure below must not be what buries them. Local files
     // only, so it costs nothing and cannot throw.
+    await sweepLaneTemps(stateDir(root)).catch(() => undefined);
     log(formatDeathAttributions(runBootDeathReaper({ stateRoot: stateDir(root) })));
     const nowS = Math.floor(Date.now() / 1000);
     const facts = await collectBootPrecheckFacts(ctx, { log });

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -64,6 +64,8 @@ import {
   safetyLogPath,
 } from "../../core/process-safety.js";
 import { deathLaneFile, installDeathRecorder } from "@reddb-io/shared/death-record.js";
+import { sweepLaneTemps } from "@reddb-io/shared/lane-retention.js";
+import { stateDir } from "@reddb-io/shared/red-paths.js";
 import { dirname, join } from "node:path";
 import { workerIdentity } from "../../core/host-identity.js";
 import { initStateSync, readPidStartTime, updateState, workerStatePath, writeIdentitySync } from "../../core/state.js";
@@ -127,6 +129,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // canonical state or supervisor tmp lanes before this worker reads/writes supervisor/circuit state
   // (issue #1685). Idempotent + best-effort — a second boot is a no-op.
   await migrateLegacyDevPaths(cwd).catch(() => undefined);
+  await sweepLaneTemps(stateDir(ctx.root)).catch(() => undefined);
   const hostProfile = await readHostCapabilityProfile(
     createEnginePaths(join(ctx.root, ".red")),
   );

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -16,6 +16,7 @@ import { parseFlags, routeCommand } from "@reddb-io/shared/args.js";
 import { deathLaneFileIn, installDeathRecorder } from "@reddb-io/shared/death-record.js";
 import { formatDeathAttributions, runBootDeathReaper } from "@reddb-io/shared/death-attribution.js";
 import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
+import { sweepLaneTemps } from "@reddb-io/shared/lane-retention.js";
 import {
   ensureRedskilledDaemon,
   readRedskilledHostState,
@@ -447,6 +448,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
     // could not (slice #3028). The host singleton is the only process guaranteed
     // to boot after a machine freeze, so an un-trap-able death on this lane has
     // nowhere else to be attributed. Local files only; it never throws.
+    await sweepLaneTemps(hostStateRoot).catch(() => undefined);
     const reaped = runBootDeathReaper({ stateRoot: hostStateRoot });
     process.stderr.write(`${formatDeathAttributions(reaped)}\n`);
     const deaths = installDeathRecorder({

--- a/packages/shared/death-record.ts
+++ b/packages/shared/death-record.ts
@@ -34,10 +34,7 @@ import {
   openSync,
   readFileSync,
   readSync,
-  renameSync,
-  rmSync,
   statSync,
-  writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
@@ -49,6 +46,11 @@ import {
   type ProcessPresence,
 } from "./death-presence.js";
 import { DEATH_PRESENCE_DIR } from "./red-paths.js";
+import {
+  LANE_RETENTION_REGISTRY,
+  laneSizeOverCeiling,
+  replaceLaneAtomicallySync,
+} from "./lane-retention.js";
 
 export { DEATH_LANE_DIR, DEATH_LANE_FILE, deathLaneDirIn, deathLaneFile, deathLaneFileIn, deathsStateDir } from "./red-paths.js";
 // The placement vocabulary travels with the record that carries it, so a reader
@@ -64,13 +66,16 @@ export const PROCESS_DEATH_RECORD_VERSION = 1;
  * the processes and anchors present today, so each size-triggered or boot
  * compaction advances the lane to this explicit age window.
  */
-export const PROCESS_DEATH_LANE_RETENTION_MS = 14 * 24 * 60 * 60 * 1_000;
+export const PROCESS_DEATH_LANE_RETENTION_MS =
+  LANE_RETENTION_REGISTRY["process-deaths"].maxAgeMs;
 
 /** The largest death-lane generation an exit handler asks a reader to decode. */
-export const PROCESS_DEATH_LANE_MAX_BYTES = 4 * 1024 * 1024;
+export const PROCESS_DEATH_LANE_MAX_BYTES =
+  LANE_RETENTION_REGISTRY["process-deaths"].maxBytes;
 
 /** A rewrite leaves half the generation free, amortizing the next full decode. */
-const PROCESS_DEATH_LANE_COMPACTION_TARGET_RATIO = 0.5;
+const PROCESS_DEATH_LANE_COMPACTION_TARGET_RATIO =
+  LANE_RETENTION_REGISTRY["process-deaths"].targetRatio;
 
 /**
  * Which of the engine's three process classes died.
@@ -277,14 +282,7 @@ export const nodeDeathLaneIo: DeathLaneIo = {
     appendFileSync(path, text, { encoding: "utf8", mode: 0o600 });
   },
   replace(path, text) {
-    const temporary = `${path}.retaining-${process.pid}`;
-    try {
-      writeFileSync(temporary, text, { encoding: "utf8", mode: 0o600 });
-      renameSync(temporary, path);
-    } catch (error) {
-      rmSync(temporary, { force: true });
-      throw error;
-    }
+    replaceLaneAtomicallySync(path, text);
   },
   read(path) {
     return readFileSync(path, "utf8");
@@ -319,7 +317,11 @@ export function appendProcessDeathRecord(
   const recordedAt = Date.parse(record.ts);
   const compactedAt = Number.isFinite(recordedAt) ? recordedAt : Date.now();
   let compacted = false;
-  if (inspection.size + separatorBytes + lineBytes > PROCESS_DEATH_LANE_MAX_BYTES) {
+  if (laneSizeOverCeiling(
+    inspection.size,
+    separatorBytes + lineBytes,
+    LANE_RETENTION_REGISTRY["process-deaths"],
+  )) {
     const targetBytes = Math.max(
       0,
       Math.floor(PROCESS_DEATH_LANE_MAX_BYTES * PROCESS_DEATH_LANE_COMPACTION_TARGET_RATIO) -

--- a/packages/shared/lane-retention.test.ts
+++ b/packages/shared/lane-retention.test.ts
@@ -1,0 +1,108 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  LANE_RETENTION_REGISTRY,
+  laneOverCeiling,
+  laneOverCeilingSync,
+  sweepLaneTemps,
+  trimLaneKeepLast,
+  type LaneRetentionStat,
+  type LaneRetentionStatSync,
+} from "./lane-retention.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function encodedLane(ids: readonly string[]): string {
+  const writer = encodeLines({ trailer: false });
+  return ids.map((id, index) => writer.push({ id, ordinal: index } satisfies ToonlRecord)).join("");
+}
+
+describe("shared lane retention", () => {
+  it("declares the state-tier lane policies with the amortized half-full target", () => {
+    expect(LANE_RETENTION_REGISTRY["process-deaths"]).toEqual({
+      maxBytes: 4 * 1024 * 1024,
+      maxAgeMs: 14 * 24 * 60 * 60 * 1_000,
+      targetRatio: 0.5,
+    });
+    expect(LANE_RETENTION_REGISTRY["github-spend"].maxBytes).toBe(8 * 1024 * 1024);
+    expect(LANE_RETENTION_REGISTRY["castle-singleton-events"].maxBytes).toBe(2 * 1024 * 1024);
+    expect(LANE_RETENTION_REGISTRY["rsp-telemetry-corrections"].maxBytes).toBe(1024 * 1024);
+    expect(LANE_RETENTION_REGISTRY["death-attributions"].maxAgeMs).toBe(14 * 24 * 60 * 60 * 1_000);
+    expect(LANE_RETENTION_REGISTRY["worker-log"].maxLines).toBe(50_000);
+  });
+
+  it("checks an append ceiling with exactly one stat in async and exit-handler paths", async () => {
+    let asyncStats = 0;
+    const asyncStat: LaneRetentionStat = async () => {
+      asyncStats += 1;
+      return { size: 90 };
+    };
+    expect(await laneOverCeiling("lane.toonl", 11, { maxBytes: 100 }, asyncStat)).toBe(true);
+    expect(asyncStats).toBe(1);
+
+    let syncStats = 0;
+    const syncStat: LaneRetentionStatSync = () => {
+      syncStats += 1;
+      return { size: 90 };
+    };
+    expect(laneOverCeilingSync("lane.toonl", 10, { maxBytes: 100 }, syncStat)).toBe(false);
+    expect(syncStats).toBe(1);
+  });
+
+  it("keeps a tq-trimmed lane decodable with its header intact when tq is present", async () => {
+    if (spawnSync("tq", ["--version"], { stdio: "ignore" }).status !== 0) return;
+    const root = await mkdtemp(join(tmpdir(), "lane-retention-tq-"));
+    roots.push(root);
+    const lane = join(root, "events.toonl");
+    await writeFile(lane, encodedLane(["one", "two", "three"]), "utf8");
+
+    expect(await trimLaneKeepLast(lane, 2)).toBe("tq");
+
+    const raw = await readFile(lane, "utf8");
+    expect(raw.startsWith("[]")).toBe(true);
+    expect(parseRecords(raw).map((row) => row.id)).toEqual(["two", "three"]);
+  });
+
+  it("falls back to JS and keeps the replacement lane decodable with its header intact", async () => {
+    const root = await mkdtemp(join(tmpdir(), "lane-retention-js-"));
+    roots.push(root);
+    const lane = join(root, "events.toonl");
+    await writeFile(lane, encodedLane(["one", "two", "three"]), "utf8");
+
+    expect(await trimLaneKeepLast(lane, 2, { runTq: async () => false })).toBe("js");
+
+    const raw = await readFile(lane, "utf8");
+    expect(raw.startsWith("[]")).toBe(true);
+    expect(parseRecords(raw).map((row) => row.id)).toEqual(["two", "three"]);
+  });
+
+  it("sweeps only rotate and retaining temps owned by dead pids", async () => {
+    const root = await mkdtemp(join(tmpdir(), "lane-retention-sweep-"));
+    roots.push(root);
+    const liveRotate = join(root, "host.toonl.rotate-222");
+    const deadRotate = join(root, "host.toonl.rotate-111");
+    const deadRetaining = join(root, "deaths.toonl.retaining-111");
+    const unrelated = join(root, "notes.tmp-111");
+    await Promise.all([
+      writeFile(liveRotate, "live"),
+      writeFile(deadRotate, "dead"),
+      writeFile(deadRetaining, "dead"),
+      writeFile(unrelated, "not a lane temp"),
+    ]);
+
+    const result = await sweepLaneTemps(root, { isPidAlive: (pid) => pid === 222 });
+
+    expect(result.removed.sort()).toEqual([deadRetaining, deadRotate].sort());
+    expect(result.preserved).toEqual([liveRotate]);
+    await expect(readFile(liveRotate, "utf8")).resolves.toBe("live");
+    await expect(readFile(unrelated, "utf8")).resolves.toBe("not a lane temp");
+  });
+});

--- a/packages/shared/lane-retention.ts
+++ b/packages/shared/lane-retention.ts
@@ -1,0 +1,288 @@
+/**
+ * Shared lifecycle policy and mechanics for bounded TOONL lanes.
+ *
+ * Writers own retention. The cheap append path performs one stat and leaves a
+ * rewritten generation half empty; boot sweeps only remove replacement files
+ * whose writer is provably dead. Trimming never appends marker rows because
+ * several lanes have closed record vocabularies.
+ */
+import { execFile } from "node:child_process";
+import {
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import {
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_LANE_RETENTION_TARGET_RATIO = 0.5;
+export const LANE_RETENTION_TQ_TIMEOUT_MS = 5_000;
+
+/** A lane declares only the ceilings meaningful to its own record stream. */
+export interface LaneRetentionPolicy {
+  readonly maxBytes?: number;
+  readonly maxLines?: number;
+  readonly maxAgeMs?: number;
+  readonly targetRatio?: number;
+}
+
+export type RegisteredLaneRetentionPolicy = LaneRetentionPolicy & {
+  readonly targetRatio: number;
+};
+
+const MIB = 1024 * 1024;
+const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1_000;
+
+/**
+ * Policies decided by Spec #3581. Later writer slices consume this registry
+ * rather than repeating ceilings beside each append implementation.
+ */
+export const LANE_RETENTION_REGISTRY = {
+  "process-deaths": {
+    maxBytes: 4 * MIB,
+    maxAgeMs: FOURTEEN_DAYS_MS,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
+  "github-spend": {
+    maxBytes: 8 * MIB,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
+  "castle-singleton-events": {
+    maxBytes: 2 * MIB,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
+  "rsp-telemetry-spool": {
+    maxBytes: 8 * MIB,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
+  "rsp-telemetry-corrections": {
+    maxBytes: MIB,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
+  "death-attributions": {
+    maxBytes: MIB,
+    maxAgeMs: FOURTEEN_DAYS_MS,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
+  "worker-log": {
+    maxLines: 50_000,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
+  "castle-history": {
+    maxLines: 10_000,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
+} as const satisfies Readonly<Record<string, RegisteredLaneRetentionPolicy>>;
+
+export type LaneRetentionPolicyName = keyof typeof LANE_RETENTION_REGISTRY;
+
+export type LaneRetentionStat = (path: string) => Promise<{ readonly size: number }>;
+export type LaneRetentionStatSync = (path: string) => { readonly size: number };
+
+function maxBytes(policy: LaneRetentionPolicy): number | undefined {
+  const ceiling = policy.maxBytes;
+  if (ceiling !== undefined && (!Number.isSafeInteger(ceiling) || ceiling < 0)) {
+    throw new Error("lane retention maxBytes must be a non-negative safe integer");
+  }
+  return ceiling;
+}
+
+function absentLane(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+/** One-stat ceiling check for ordinary asynchronous writers. */
+export async function laneOverCeiling(
+  path: string,
+  incomingBytes: number,
+  policy: LaneRetentionPolicy,
+  readStat: LaneRetentionStat = stat,
+): Promise<boolean> {
+  const ceiling = maxBytes(policy);
+  if (ceiling === undefined) return false;
+  let size = 0;
+  try {
+    size = (await readStat(path)).size;
+  } catch (error) {
+    if (!absentLane(error)) throw error;
+  }
+  return size + incomingBytes > ceiling;
+}
+
+/** The same one-stat check for exit handlers, which cannot await. */
+export function laneOverCeilingSync(
+  path: string,
+  incomingBytes: number,
+  policy: LaneRetentionPolicy,
+  readStat: LaneRetentionStatSync = statSync,
+): boolean {
+  const ceiling = maxBytes(policy);
+  if (ceiling === undefined) return false;
+  let size = 0;
+  try {
+    size = readStat(path).size;
+  } catch (error) {
+    if (!absentLane(error)) throw error;
+  }
+  return size + incomingBytes > ceiling;
+}
+
+/** Apply a ceiling to an already-inspected size without another filesystem read. */
+export function laneSizeOverCeiling(
+  currentBytes: number,
+  incomingBytes: number,
+  policy: LaneRetentionPolicy,
+): boolean {
+  const ceiling = maxBytes(policy);
+  return ceiling !== undefined && currentBytes + incomingBytes > ceiling;
+}
+
+export type LaneTrimMethod = "tq" | "js";
+
+export interface TrimLaneKeepLastOptions {
+  readonly timeoutMs?: number;
+  /** Return true only when tq completed the in-place replacement. */
+  readonly runTq?: (path: string, keepLast: number, timeoutMs: number) => Promise<boolean>;
+}
+
+async function runTqTrim(path: string, keepLast: number, timeoutMs: number): Promise<boolean> {
+  try {
+    await execFileAsync("tq", ["trim", "--keep-last", String(keepLast), "--in-place", path], {
+      timeout: timeoutMs,
+      windowsHide: true,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertKeepLast(keepLast: number): void {
+  if (!Number.isSafeInteger(keepLast) || keepLast < 0) {
+    throw new Error("lane retention keepLast must be a non-negative safe integer");
+  }
+}
+
+function encodeRows(rows: readonly ToonlRecord[]): string {
+  if (rows.length === 0) return "";
+  const writer = encodeLines({ trailer: false });
+  return rows.map((row) => writer.push(row)).join("");
+}
+
+/** Atomic replacement used by asynchronous lane writers and the JS trimmer. */
+export async function replaceLaneAtomically(path: string, text: string): Promise<void> {
+  const temporary = `${path}.retaining-${process.pid}`;
+  try {
+    await writeFile(temporary, text, { encoding: "utf8", mode: 0o600 });
+    await rename(temporary, path);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+/** Atomic replacement for a dying process's synchronous exit handler. */
+export function replaceLaneAtomicallySync(path: string, text: string): void {
+  const temporary = `${path}.retaining-${process.pid}`;
+  try {
+    writeFileSync(temporary, text, { encoding: "utf8", mode: 0o600 });
+    renameSync(temporary, path);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+}
+
+/**
+ * Keep the newest complete TOONL records. The pinned tq binary gets first
+ * refusal; missing, failed, or timed-out tq falls back to a decoder round trip.
+ */
+export async function trimLaneKeepLast(
+  path: string,
+  keepLast: number,
+  options: TrimLaneKeepLastOptions = {},
+): Promise<LaneTrimMethod> {
+  assertKeepLast(keepLast);
+  const timeoutMs = options.timeoutMs ?? LANE_RETENTION_TQ_TIMEOUT_MS;
+  const tq = options.runTq ?? runTqTrim;
+  if (await tq(path, keepLast, timeoutMs)) return "tq";
+
+  const raw = await readFile(path, "utf8");
+  const complete = raw.endsWith("\n") ? raw : raw.slice(0, raw.lastIndexOf("\n") + 1);
+  const rows = complete === "" ? [] : parseRecords(complete);
+  const kept = keepLast === 0 ? [] : rows.slice(-keepLast);
+  await replaceLaneAtomically(path, encodeRows(kept));
+  return "js";
+}
+
+export interface SweepLaneTempsOptions {
+  readonly isPidAlive?: (pid: number) => boolean | Promise<boolean>;
+}
+
+export interface SweepLaneTempsResult {
+  readonly removed: string[];
+  readonly preserved: string[];
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+const LANE_TEMP_PID = /\.(?:rotate|retaining)-(\d+)(?:-|$)/;
+
+/** Recursively remove only replacement temps whose owning pid is dead. */
+export async function sweepLaneTemps(
+  root: string,
+  options: SweepLaneTempsOptions = {},
+): Promise<SweepLaneTempsResult> {
+  const removed: string[] = [];
+  const preserved: string[] = [];
+  const isPidAlive = options.isPidAlive ?? pidAlive;
+
+  const visit = async (dir: string): Promise<void> => {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch (error) {
+      if (absentLane(error)) return;
+      throw error;
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await visit(path);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const match = LANE_TEMP_PID.exec(entry.name);
+      if (match === null) continue;
+      const pid = Number(match[1]);
+      if (await isPidAlive(pid)) {
+        preserved.push(path);
+        continue;
+      }
+      await rm(path, { force: true });
+      removed.push(path);
+    }
+  };
+
+  await visit(root);
+  removed.sort();
+  preserved.sort();
+  return { removed, preserved };
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,6 +20,7 @@
     "./github-batch.js": "./github-batch.ts",
     "./github-quota.js": "./github-quota.ts",
     "./github-webhook.js": "./github-webhook.ts",
+    "./lane-retention.js": "./lane-retention.ts",
     "./log.js": "./log.ts",
     "./outcome-event.js": "./outcome-event.ts",
     "./plugin-gate.js": "./plugin-gate.ts",


### PR DESCRIPTION
Automated AFK landing for #3587. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3587

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789048179&installation_model_id=20659&pr_number=3609&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3609&signature=59e85b31e9c37536732c45e20bf3cc29b911329313e1a86836958686a4790231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->