### PR TITLE
chore: #3592 The castle singleton-event lane enforces a byte ceiling

### DIFF
--- a/packages/red-castle/src/engine/singleton-event-lane.test.ts
+++ b/packages/red-castle/src/engine/singleton-event-lane.test.ts
@@ -74,4 +74,42 @@ describe("castle singleton event lane", () => {
     expect(bytes.trimStart().startsWith("{")).toBe(false);
     expect(parseRecords(bytes)).toHaveLength(3);
   });
+
+  it("rewrites an overflowing lane to half its byte ceiling and preserves tail reads", async () => {
+    const root = join(
+      tmpdir(),
+      `castle-singleton-events-${crypto.randomUUID()}`,
+    );
+    roots.push(root);
+    const paths = createEnginePaths(join(root, ".red"));
+    const lane = createSingletonEventLane(paths, {
+      maxBytes: 600,
+    });
+
+    for (let delivery = 1; delivery <= 5; delivery += 1) {
+      await lane.append({
+        at: `2026-07-22T19:00:0${delivery}.000Z`,
+        singleton: "github-webhook",
+        kind: "github.delivery",
+        payload: { delivery: `d${delivery}`, detail: "xxxxxxxx" },
+      });
+    }
+
+    const bytes = await readFile(singletonEventLanePath(paths), "utf8");
+    expect(Buffer.byteLength(bytes)).toBeLessThanOrEqual(300);
+    expect(await lane.read({ tail: 2 })).toEqual([
+      {
+        at: "2026-07-22T19:00:04.000Z",
+        singleton: "github-webhook",
+        kind: "github.delivery",
+        payload: { delivery: "d4", detail: "xxxxxxxx" },
+      },
+      {
+        at: "2026-07-22T19:00:05.000Z",
+        singleton: "github-webhook",
+        kind: "github.delivery",
+        payload: { delivery: "d5", detail: "xxxxxxxx" },
+      },
+    ]);
+  });
 });

--- a/packages/red-castle/src/engine/singleton-event-lane.ts
+++ b/packages/red-castle/src/engine/singleton-event-lane.ts
@@ -8,6 +8,12 @@
  */
 import { appendFile, mkdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import {
+  LANE_RETENTION_REGISTRY,
+  laneOverCeiling,
+  trimLaneKeepLast,
+  type LaneRetentionPolicy,
+} from "@reddb-io/shared/lane-retention.js";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
 import type { EnginePaths } from "./paths.js";
 
@@ -31,6 +37,8 @@ export interface SingletonEventLaneFs {
 export interface SingletonEventLaneOptions {
   readonly fs?: SingletonEventLaneFs;
   readonly clock?: () => string;
+  /** Override the production byte ceiling; exposed for tiny-lane tests. */
+  readonly maxBytes?: number;
 }
 
 export interface SingletonEventReadOptions {
@@ -99,6 +107,31 @@ function assertTail(tail: number | undefined): void {
   }
 }
 
+function encodeRows(rows: readonly ToonlRecord[]): string {
+  if (rows.length === 0) return "";
+  const writer = encodeLines({ trailer: false });
+  return rows.map((row) => writer.push(row)).join("");
+}
+
+function keepLastWithin(
+  rows: readonly ToonlRecord[],
+  incomingBytes: number,
+  targetBytes: number,
+): number {
+  let low = 0;
+  let high = rows.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const retained = rows.slice(-middle);
+    if (Buffer.byteLength(encodeRows(retained)) + incomingBytes <= targetBytes) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return low;
+}
+
 export function singletonEventLanePath(paths: EnginePaths): string {
   return join(paths.castleStateRoot, "singleton-events.toonl");
 }
@@ -110,14 +143,41 @@ export function createSingletonEventLane(
   const fs = options.fs ?? { appendFile, mkdir, readFile };
   const clock = options.clock ?? (() => new Date().toISOString());
   const path = singletonEventLanePath(paths);
+  const registeredPolicy = LANE_RETENTION_REGISTRY["castle-singleton-events"];
+  const retentionPolicy: LaneRetentionPolicy = {
+    ...registeredPolicy,
+    ...(options.maxBytes === undefined ? {} : { maxBytes: options.maxBytes }),
+  };
 
   return {
     path,
 
     async append(input) {
       const event = validateEvent({ at: input.at ?? clock(), ...input });
+      const encoded = encodeLines().push(toRow(event));
+      const incomingBytes = Buffer.byteLength(encoded);
       await fs.mkdir(dirname(path), { recursive: true });
-      await fs.appendFile(path, encodeLines().push(toRow(event)), "utf8");
+      if (await laneOverCeiling(path, incomingBytes, retentionPolicy)) {
+        const ceiling = retentionPolicy.maxBytes!;
+        if (incomingBytes > ceiling) {
+          throw new Error(
+            `singleton event exceeds its ${ceiling}-byte lane ceiling`,
+          );
+        }
+        const raw = await fs.readFile(path, "utf8");
+        const rows = parseRecords(raw);
+        const halfTarget = Math.floor(
+          ceiling * registeredPolicy.targetRatio,
+        );
+        const targetBytes = Math.max(halfTarget, incomingBytes);
+        const keepLast = keepLastWithin(
+          rows,
+          incomingBytes,
+          targetBytes,
+        );
+        await trimLaneKeepLast(path, keepLast);
+      }
+      await fs.appendFile(path, encoded, "utf8");
       return event;
     },
 


### PR DESCRIPTION
Automated AFK landing for #3592. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3592

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789049420&installation_model_id=20659&pr_number=3611&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3611&signature=4b670e449c6b5a16d63eda9094547dd1a249f54c0149364621febb4cd85a8990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->