### PR TITLE
chore: #3593 Death attributions gain age and size retention

### DIFF
--- a/packages/shared/death-attribution.test.ts
+++ b/packages/shared/death-attribution.test.ts
@@ -7,17 +7,19 @@
 // evidence object stands in for the code an operator actually runs.
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   attributeDeath,
   buildProcessPresence,
   collectHostDeathEvidence,
   decodeDeathAttributions,
+  encodeDeathAttributions,
   formatDeathAttributions,
   readProcessPresences,
   runBootDeathReaper,
   writeProcessPresence,
+  type DeathAttribution,
   type ProcessPresence,
 } from "./death-attribution.js";
 import {
@@ -31,7 +33,7 @@ import {
   type DeathRecorderHost,
   type ProcessResourceSample,
 } from "./death-record.js";
-import { deathPresenceDirIn } from "./red-paths.js";
+import { deathAttributionFileIn, deathPresenceDirIn } from "./red-paths.js";
 
 const roots: string[] = [];
 
@@ -76,6 +78,25 @@ function presence(overrides: Partial<ProcessPresence> = {}): ProcessPresence {
     boot_id: "boot-a",
     cgroup: "/user.slice/user-1000.slice/session-3.scope",
     last_phase: "gate",
+    ...overrides,
+  };
+}
+
+function laneAttribution(overrides: Partial<DeathAttribution> = {}): DeathAttribution {
+  return {
+    version: 1,
+    ts: "2026-08-08T20:00:00.000Z",
+    kind: "worker",
+    id: "retained",
+    pid: 4242,
+    last_seen: "2026-08-08T19:59:00.000Z",
+    last_phase: "gate",
+    sender_class: "unknown",
+    confidence: "none",
+    signal: null,
+    host_boot_changed: false,
+    evidence: [],
+    checked: [],
     ...overrides,
   };
 }
@@ -269,6 +290,43 @@ describe("the presence anchor", () => {
 });
 
 describe("the boot reaper", () => {
+  it("retains attribution history for fourteen days and one MiB, preserving unknown timestamps", () => {
+    const stateRoot = scratch();
+    const now = Date.parse("2026-08-15T20:00:00.000Z");
+    const recent = Array.from({ length: 1_200 }, (_, index) =>
+      laneAttribution({
+        id: `recent-${index}`,
+        ts: new Date(now - 1_000 + index).toISOString(),
+        checked: [`source-${index}-${"x".repeat(1_000)}`],
+      }),
+    );
+    const attributionPath = deathAttributionFileIn(stateRoot);
+    mkdirSync(dirname(attributionPath), { recursive: true });
+    writeFileSync(
+      attributionPath,
+      encodeDeathAttributions([
+        laneAttribution({ id: "too-old", ts: "2026-07-01T00:00:00.000Z" }),
+        laneAttribution({ id: "unknown-age", ts: "not-a-timestamp" }),
+        ...recent,
+      ]),
+    );
+    writeProcessPresence(deathPresenceDirIn(stateRoot), presence());
+
+    const result = runBootDeathReaper({
+      stateRoot,
+      evidence: collectHostDeathEvidence({ procRoot: poseProc("boot-a", [1]), journalPaths: [] }),
+      now: () => new Date(now).toISOString(),
+    });
+    const retained = decodeDeathAttributions(result.laneText());
+
+    expect(retained.map((entry) => entry.id)).not.toContain("too-old");
+    expect(retained.map((entry) => entry.id)).toContain("unknown-age");
+    expect(retained.map((entry) => entry.id)).not.toContain("recent-0");
+    expect(retained.map((entry) => entry.id)).toContain("recent-1199");
+    expect(retained.map((entry) => entry.id)).toContain("wOLFU");
+    expect(Buffer.byteLength(result.laneText())).toBeLessThanOrEqual(1024 * 1024);
+  });
+
   it("compacts an oversized death lane before serve boot returns", () => {
     const stateRoot = scratch();
     const lanePath = deathLaneFileIn(stateRoot);

--- a/packages/shared/death-attribution.ts
+++ b/packages/shared/death-attribution.ts
@@ -32,6 +32,7 @@ import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "n
 import { join } from "node:path";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
 import { deathAttributionFileIn, deathLaneFileIn, deathPresenceDirIn } from "./red-paths.js";
+import { LANE_RETENTION_REGISTRY } from "./lane-retention.js";
 import {
   compactProcessDeathLane,
   decodeProcessDeathRecords,
@@ -71,6 +72,18 @@ export {
 
 /** The attribution shape's version. */
 export const DEATH_ATTRIBUTION_VERSION = 1;
+
+/** Attribution history remains useful for fourteen days. */
+export const DEATH_ATTRIBUTION_LANE_RETENTION_MS =
+  LANE_RETENTION_REGISTRY["death-attributions"].maxAgeMs;
+
+/** The largest attribution-lane generation a boot asks readers to decode. */
+export const DEATH_ATTRIBUTION_LANE_MAX_BYTES =
+  LANE_RETENTION_REGISTRY["death-attributions"].maxBytes;
+
+/** A rewrite leaves half the generation free for later boot attributions. */
+const DEATH_ATTRIBUTION_LANE_TARGET_RATIO =
+  LANE_RETENTION_REGISTRY["death-attributions"].targetRatio;
 
 /** Who ended the process. Five classes, one of which is honest ignorance. */
 export type DeathSenderClass =
@@ -480,7 +493,13 @@ export function runBootDeathReaper(options: BootDeathReaperOptions): BootDeathRe
 
   const reapedAtMs = Date.parse(reapedAt);
   if (Number.isFinite(reapedAtMs)) compactProcessDeathLane(deathLaneFileIn(options.stateRoot), reapedAtMs);
-  if (attributions.length > 0) appendAttributions(attributionPath, attributions);
+  if (attributions.length > 0) {
+    appendAttributions(
+      attributionPath,
+      attributions,
+      Number.isFinite(reapedAtMs) ? reapedAtMs : Date.now(),
+    );
+  }
 
   return {
     attributions,
@@ -525,12 +544,17 @@ export function formatDeathAttributions(result: BootDeathReaperResult): string {
   return `death reaper: attributed ${result.attributions.length}${verdicts}${skipped}`;
 }
 
-function appendAttributions(path: string, attributions: readonly DeathAttribution[]): void {
+function appendAttributions(
+  path: string,
+  attributions: readonly DeathAttribution[],
+  nowMs: number,
+): void {
   try {
     mkdirSync(join(path, ".."), { recursive: true, mode: 0o700 });
     const existing = readOrEmpty(path);
-    const prefix = existing === "" || existing.endsWith("\n") ? "" : "\n";
-    writeFileSync(path, `${existing}${prefix}${encodeDeathAttributions(attributions)}`, {
+    const combined = [...decodeDeathAttributions(existing), ...attributions];
+    const retained = retainAttributions(combined, nowMs);
+    writeFileSync(path, encodeDeathAttributions(retained), {
       encoding: "utf8",
       mode: 0o600,
     });
@@ -538,6 +562,44 @@ function appendAttributions(path: string, attributions: readonly DeathAttributio
     // Best effort by contract: a lane that cannot be written must not turn a
     // boot-time investigation into a boot-time failure.
   }
+}
+
+/** Preserve unknown timestamps, then keep the newest dated history that fits. */
+function retainAttributions(
+  attributions: readonly DeathAttribution[],
+  nowMs: number,
+): DeathAttribution[] {
+  const cutoff = nowMs - DEATH_ATTRIBUTION_LANE_RETENTION_MS;
+  const ageRetained = attributions.filter((attribution) => {
+    const timestamp = Date.parse(attribution.ts);
+    return !Number.isFinite(timestamp) || timestamp >= cutoff;
+  });
+  if (Buffer.byteLength(encodeDeathAttributions(ageRetained)) <= DEATH_ATTRIBUTION_LANE_MAX_BYTES) {
+    return ageRetained;
+  }
+
+  const targetBytes = Math.floor(
+    DEATH_ATTRIBUTION_LANE_MAX_BYTES * DEATH_ATTRIBUTION_LANE_TARGET_RATIO,
+  );
+  const pinnedIndices = new Set<number>();
+  const optionalIndices: number[] = [];
+  ageRetained.forEach((attribution, index) => {
+    if (Number.isFinite(Date.parse(attribution.ts))) optionalIndices.push(index);
+    else pinnedIndices.add(index);
+  });
+
+  let low = 0;
+  let high = optionalIndices.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    const selected = new Set([...pinnedIndices, ...optionalIndices.slice(middle)]);
+    const candidate = ageRetained.filter((_attribution, index) => selected.has(index));
+    if (Buffer.byteLength(encodeDeathAttributions(candidate)) <= targetBytes) high = middle;
+    else low = middle + 1;
+  }
+
+  const selected = new Set([...pinnedIndices, ...optionalIndices.slice(low)]);
+  return ageRetained.filter((_attribution, index) => selected.has(index));
 }
 
 function readOrEmpty(path: string): string {


### PR DESCRIPTION
Automated AFK landing for #3593. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3593

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789050497&installation_model_id=20659&pr_number=3613&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3613&signature=ce38042ecd1721396048597e982b779ac60d0ae37970e3413e65ae7e09932cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->