### PR TITLE
chore: #3589 The daemon's orphan reaper: census, adopt-then-kill for stamped orphans, report for suspects

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -93,6 +93,7 @@ kill.
 | What the daemon remembers across a restart | `src/event-lane.ts` — bounded TOONL generations: Worker lifecycle, metric observations, and the daemon's own stop |
 | What a stop is giving up | `src/daemon-stop.ts` — the pure report: what is held, what survives, why it stopped |
 | Finding the Workers a restart left running | `src/reattach.ts` — the unit name first, the pid only as fallback |
+| Finding processes a crashed daemon left outside its Worker set | `src/orphan-reaper.ts` — pure candidate selection, `/proc` census, PID-reuse guard |
 | What the host has been promised | `src/budget-accounting.ts` — pure totals over the Worker set |
 | Reaching (and starting) the daemon | `src/client.ts` — auto-spawn, loser joins the winner |
 | Which file a spawn runs | `src/daemon-entry.ts` — the published bundle by name, never the caller's own entry |
@@ -162,6 +163,17 @@ kill.
   machine-wide claim sweeps — a second instance adopting the arbiter's Workers
   would be the same accounting hole from the other side — and
   `REDSKILLED_UNIT_DISCOVERY=off` declines the sweep outright.
+- **Stamped process orphans are reconciled on their own five-minute census.**
+  Only the machine-claim arbiter runs it. A reparented process carrying
+  `RED_WORKER_ID` is adopted when its event-lane birth is still live; without a
+  live birth it receives a ten-minute grace, is recorded as an adopted birth,
+  and is then stopped as a whole process group. The leader's `/proc` starttime
+  must still match the census immediately before signalling, so pid reuse costs
+  the reap rather than a stranger. An unstamped process under a canonical Worker
+  lane is reported after thirty minutes and is never signalled. Set
+  `REDSKILLED_ORPHAN_REAPER=report` to withhold no-birth orphan adoption and
+  teardown while retaining reports (live births are still reattached), or
+  `REDSKILLED_ORPHAN_REAPER=off` to skip the census.
 - **Host facts share one lane.** Worker lifecycle and cumulative metric
   observations are daemon-owned and live in the same append-only TOONL lane.
   The observations retain enough counter history to reconstruct the dashboard's

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -15,6 +15,7 @@
     "./host-config": "./src/host-config.ts",
     "./launch-template": "./src/launch-template.ts",
     "./live-metrics": "./src/live-metrics.ts",
+    "./orphan-reaper": "./src/orphan-reaper.ts",
     "./paths": "./src/paths.ts",
     "./project-breaker": "./src/project-breaker.ts",
     "./project-registration": "./src/project-registration.ts",

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -65,6 +65,7 @@ import {
   RedskilledMachineHeldError,
   resolveMachineClaimPath,
 } from "../machine-scope.js";
+import { createRedskilledOrphanReaperRuntime } from "../orphan-reaper.js";
 import { workerSpecFromLaunch, type RedskilledLaunchTemplate } from "../launch-template.js";
 import {
   createRedskilledRegistrationIntentStore,
@@ -88,6 +89,7 @@ import {
   nameUnownedProject,
   reattachWorkers,
   REDSKILLED_LIVENESS_GRACE_MS,
+  sweepHeldWorkerLiveness,
   stopWorker,
 } from "../reattach.js";
 import {
@@ -1697,38 +1699,33 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     deathAttributions = pruneRedskilledMetricHistory(merged, (death) => death.ts, { now: clock() });
   }
 
-  /**
-   * Ask the host about every Worker it holds; return and retire those no longer confirmed.
-   *
-   * **Every record, not just the re-attached ones (#3123).** The narrow sweep
-   * trusted a child handle to deliver each birth's death, and a record whose
-   * launch client died without one — its pid reclaimed, its unit gone — then held
-   * a slot for two hours with no verb able to release it: the daemon's statusline
-   * said `1w` while the project's own read said none, and the machine refused to
-   * birth anything at `target: 1`. Two hours is not a race.
-   *
-   * The grace window is what keeps that from becoming the opposite bug: a Worker
-   * born a moment ago has not necessarily reached the init system, so probing it
-   * would reap a Worker mid-birth. Younger than {@link REDSKILLED_LIVENESS_GRACE_MS}
-   * is left to the child handle, which is authoritative for exactly that window.
-   */
   async function sweepWorkerLiveness(): Promise<readonly RedskilledWorkerView[]> {
-    const nowMs = Date.parse(clock());
-    const held = [...workers.values()].filter((worker) => {
-      if (reattached.has(worker.worker_id)) return true;
-      const bornMs = Date.parse(worker.started_at);
-      return !Number.isFinite(bornMs) || nowMs - bornMs >= livenessGraceMs;
+    const dead = await sweepHeldWorkerLiveness({
+      workers: [...workers.values()], reattached_worker_ids: reattached,
+      now_ms: Date.parse(clock()), grace_ms: livenessGraceMs, probe: liveness,
+      on_dead: (worker) => {
+        forgetWorker(worker.worker_id); record("worker-death", worker, "the host no longer confirms this Worker");
+      },
     });
-    if (held.length === 0) return [];
-    const { dead } = await reattachWorkers(held, liveness);
-    for (const worker of dead) {
-      forgetWorker(worker.worker_id);
-      record("worker-death", worker, "the host no longer confirms this Worker");
-    }
     if (dead.length > 0) armIdleTimer();
     return dead;
   }
 
+  const orphanReaper = createRedskilledOrphanReaperRuntime({
+    authorized: options.orphanCensus != null ||
+      paths.machineClaimPath === resolveMachineClaimPath({ machineIdHash: paths.machineIdHash }),
+    interval_ms: options.orphanReaperMs, mode: options.orphanReaperMode, census: options.orphanCensus,
+    read_starttime: options.orphanStarttime, kill_group: options.orphanKillGroup, report: options.orphanReport,
+    clock, held_worker_ids: () => workers.keys(), live_births: async () => rehydrateWorkers(await eventLane.read()),
+    adopt: async (worker, recordBirth, detail) => {
+      workers.set(worker.worker_id, worker); reattached.add(worker.worker_id);
+      if (recordBirth) { record("worker-birth", worker, detail); await eventLane.flush(); }
+      armIdleTimer();
+    },
+    record_reaped: async (worker, detail) => {
+      forgetWorker(worker.worker_id); record("worker-death", worker, detail); await eventLane.flush(); armIdleTimer();
+    },
+  });
   async function killWorkerOverBudget(workerId: string, detail: string): Promise<boolean> {
     const worker = workers.get(workerId);
     if (!worker) return false;
@@ -2182,6 +2179,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     if (sampleTimer) clearInterval(sampleTimer);
     if (leaseTimer) clearInterval(leaseTimer);
     if (registrationTimer) clearInterval(registrationTimer);
+    orphanReaper.stop();
     if (replaceTimer) clearInterval(replaceTimer);
     if (replaceBootTimer) clearTimeout(replaceBootTimer);
     activityPoller.stop();
@@ -2428,6 +2426,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   armSampleTimer();
   armLeaseTimer();
   armRegistrationTimer();
+  orphanReaper.arm();
   armReplaceTimer();
   activityPoller.arm();
   armBalanceTimer();
@@ -2453,6 +2452,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     driveDemand,
     demand: () => lastDemand,
     sweepWorkerLiveness,
+    sweepOrphanProcesses: () => stopping ? Promise.resolve({ adopted: 0, reaped: 0, suspects: 0 }) : orphanReaper.sweep(),
     publishWorkerHeartbeat,
     reattached: () => [...reattached].map((id) => workers.get(id)).filter((w): w is RedskilledWorkerView => w != null),
     flushEvents: async () => { await workerBirthTail; await projectHooks.waitForSettled(); await eventLane.flush(); },

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -21,6 +21,10 @@ import { type RedskilledBudgetTermination,
 import { type RedskilledMachineClaimStore,
   type RedskilledMachineOwner,
 } from "../machine-scope.js";
+import type {
+  RedskilledOrphanReaperMode,
+  RedskilledProcessCensusRow,
+} from "../orphan-reaper.js";
 import { type RedskilledLaunchTemplate } from "../launch-template.js";
 import type { RedskilledPaths } from "../paths.js";
 import { type RedskilledRegistrationIntentStore,
@@ -134,6 +138,18 @@ export interface RedskilledDaemonOptions {
   readonly leaseRenewMs?: number;
   /** Window between registration sustain passes; 0 or below leaves the belt unarmed. */
   readonly registrationSustainMs?: number;
+  /** Independent orphan-census cadence; 0 or below leaves the timer unarmed. */
+  readonly orphanReaperMs?: number;
+  /** Operator kill-switch posture; defaults from `REDSKILLED_ORPHAN_REAPER`. */
+  readonly orphanReaperMode?: RedskilledOrphanReaperMode;
+  /** Process-table census seam; supplying it explicitly authorizes a fixture sweep. */
+  readonly orphanCensus?: () => readonly RedskilledProcessCensusRow[] | Promise<readonly RedskilledProcessCensusRow[]>;
+  /** PID-reuse verification seam, immediately before a stamped group kill. */
+  readonly orphanStarttime?: (pid: number) => string | null | Promise<string | null>;
+  /** Whole-process-group escalating teardown seam. */
+  readonly orphanKillGroup?: (pgid: number) => boolean | Promise<boolean>;
+  /** Where suspects and withheld actions are reported. */
+  readonly orphanReport?: (detail: string) => void;
   /**
    * How the daemon performs a bounded read after restart or pre-heartbeat death.
    *
@@ -475,6 +491,8 @@ export interface RedskilledDaemon {
   demand(): RedskilledDemandTick | null;
   /** Re-probe every held Worker, retiring the ones the host no longer confirms. */
   sweepWorkerLiveness(): Promise<readonly RedskilledWorkerView[]>;
+  /** Census, adopt, reap or report orphan process groups once. */
+  sweepOrphanProcesses(): Promise<{ readonly adopted: number; readonly reaped: number; readonly suspects: number }>;
   /** The Workers this daemon adopted at start rather than birthing itself. */
   reattached(): readonly RedskilledWorkerView[];
   /** Resolves once every event handed to the lane has reached disk. */

--- a/apps/redskilled/src/memory-sampler.ts
+++ b/apps/redskilled/src/memory-sampler.ts
@@ -511,9 +511,13 @@ export function parseCgroupCpuStat(raw: string): number | null {
 }
 
 /** One `/proc` row, in the kernel's own units. */
-interface ProcessEntry {
+export interface ProcessEntry {
   readonly pid: number;
   readonly ppid: number;
+  readonly pgid: number;
+  readonly sid: number;
+  /** Linux process birth discriminator, in clock ticks since boot. */
+  readonly starttime: string;
   readonly rssPages: number;
   /** `utime + stime`, in the clock ticks `/proc` counts them in. */
   readonly cpuTicks: number;
@@ -670,17 +674,25 @@ export function parseProcStat(raw: string): ProcessEntry | null {
   const pid = Number(raw.slice(0, raw.indexOf(" ")));
   const fields = raw.slice(close + 1).trim().split(/\s+/);
   // Fields after `comm` are 1-indexed from `state` (field 3), so `ppid` (field 4)
-  // is index 1, `utime` (field 14) is index 11, `stime` (field 15) is index 12 and
-  // `rss` (field 24) is index 21.
+  // is index 1, `pgrp` (field 5) is index 2, `session` (field 6) is index 3,
+  // `utime` (field 14) is index 11, `stime` (field 15) is index 12, `starttime`
+  // (field 22) is index 19 and `rss` (field 24) is index 21.
   const ppid = Number(fields[1]);
+  const pgid = Number(fields[2]);
+  const sid = Number(fields[3]);
   const utime = Number(fields[11]);
   const stime = Number(fields[12]);
+  const starttime = fields[19];
   const rssPages = Number(fields[21]);
-  if (!Number.isSafeInteger(pid) || !Number.isSafeInteger(ppid) || !Number.isFinite(rssPages)) return null;
+  if (![pid, ppid, pgid, sid].every(Number.isSafeInteger) || !Number.isFinite(rssPages)) return null;
   if (!Number.isFinite(utime) || !Number.isFinite(stime)) return null;
+  if (starttime == null || !/^\d+$/.test(starttime) || !Number.isSafeInteger(Number(starttime))) return null;
   return {
     pid,
     ppid,
+    pgid,
+    sid,
+    starttime,
     rssPages: Math.max(0, rssPages),
     cpuTicks: Math.max(0, utime) + Math.max(0, stime),
   };

--- a/apps/redskilled/src/orphan-reaper.ts
+++ b/apps/redskilled/src/orphan-reaper.ts
@@ -1,0 +1,409 @@
+import { readdir, readFile, readlink } from "node:fs/promises";
+import { join, normalize, sep } from "node:path";
+import { killTreeAndWait } from "@reddb-io/shared/kill-tree.js";
+import type { RedskilledWorkerView } from "./host-state.js";
+import { parseProcStat } from "./memory-sampler.js";
+import { REDSKILLED_UNOWNED_PROJECT_LABEL } from "./reattach.js";
+
+/** One process from the daemon's process-table census. */
+export interface RedskilledProcessCensusRow {
+  readonly pid: number;
+  readonly ppid: number;
+  readonly pgid: number;
+  readonly sid: number;
+  /** Linux `/proc/<pid>/stat` field 22, in clock ticks since boot. */
+  readonly starttime: string;
+  readonly age_ms: number;
+  readonly worker_id?: string;
+  readonly born_at?: string;
+  readonly cwd?: string;
+  readonly under_workers_lane: boolean;
+}
+
+export interface SelectOrphanReaperCandidatesInput {
+  readonly processes: readonly RedskilledProcessCensusRow[];
+  /** Worker ids this daemon already holds in memory. */
+  readonly held_worker_ids: ReadonlySet<string>;
+  /** Worker ids with an unmatched birth on the durable event lane. */
+  readonly live_birth_ids: ReadonlySet<string>;
+}
+
+export type RedskilledOrphanReaperCandidate =
+  | {
+      readonly kind: "reap";
+      readonly process: RedskilledProcessCensusRow;
+      readonly detail: string;
+    }
+  | {
+      readonly kind: "adopt";
+      readonly process: RedskilledProcessCensusRow;
+      readonly detail: string;
+    }
+  | {
+      readonly kind: "suspect";
+      readonly process: RedskilledProcessCensusRow;
+      readonly detail: string;
+    };
+
+/** A stamped orphan is given this long to reconnect before the host reaps it. */
+export const REDSKILLED_STAMPED_ORPHAN_GRACE_MS = 10 * 60_000;
+
+/** An unstamped process needs a longer window because it cannot prove its origin. */
+export const REDSKILLED_UNSTAMPED_SUSPECT_GRACE_MS = 30 * 60_000;
+
+/** Linux `/proc` exposes process clocks at this stable USER_HZ. */
+const REDSKILLED_PROC_CLOCK_TICKS_PER_SECOND = 100;
+
+export interface RedskilledProcessCensusOptions {
+  readonly proc_root?: string;
+}
+
+export interface ReapStampedOrphanIO {
+  /** Re-read `/proc/<leader>/stat` immediately before signalling. */
+  readonly read_starttime: (pid: number) => string | null | Promise<string | null>;
+  /** Adopt and durably record the verified identity before teardown begins. */
+  readonly after_verified?: () => void | Promise<void>;
+  /** Graceful whole-group teardown with escalation and confirmation. */
+  readonly kill_group: (pgid: number) => boolean | Promise<boolean>;
+}
+
+export interface ReapStampedOrphanOutcome {
+  readonly reaped: boolean;
+  readonly reason: "orphan-reaped" | "leader-starttime-changed" | "group-survived";
+}
+
+/** Verify the leader identity from the census, then tear down its whole group. */
+export async function reapStampedOrphan(
+  process: RedskilledProcessCensusRow,
+  io: ReapStampedOrphanIO,
+): Promise<ReapStampedOrphanOutcome> {
+  const currentStarttime = await io.read_starttime(process.pid);
+  if (currentStarttime !== process.starttime) {
+    return { reaped: false, reason: "leader-starttime-changed" };
+  }
+  await io.after_verified?.();
+  const reaped = (await io.kill_group(process.pgid)) === true;
+  return reaped
+    ? { reaped: true, reason: "orphan-reaped" }
+    : { reaped: false, reason: "group-survived" };
+}
+
+/** The orphan census has an independent five-minute daemon cadence. */
+export const DEFAULT_REDSKILLED_ORPHAN_REAPER_MS = 5 * 60_000;
+
+export type RedskilledOrphanReaperMode = "reap" | "report" | "off";
+
+/** Resolve the operator kill-switch; every unrecognised value keeps the safe default. */
+export function redskilledOrphanReaperMode(
+  env: NodeJS.ProcessEnv = process.env,
+): RedskilledOrphanReaperMode {
+  const stated = (env.REDSKILLED_ORPHAN_REAPER ?? "").trim().toLowerCase();
+  if (stated === "off") return "off";
+  if (stated === "report") return "report";
+  return "reap";
+}
+
+/** Re-read one Linux process birth discriminator; `null` is never a match. */
+export async function readRedskilledProcessStarttime(
+  pid: number,
+  procRoot = "/proc",
+): Promise<string | null> {
+  try {
+    return parseProcStat(await readFile(join(procRoot, String(pid), "stat"), "utf8"))?.starttime ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Take one process-table snapshot for the reaper.
+ *
+ * Stat is read for every process. Environment and cwd are deliberately deferred
+ * until a row says it was reparented to pid 1: those are sensitive and more
+ * expensive reads, and no other row can become an orphan candidate.
+ */
+export async function censusRedskilledProcesses(
+  options: RedskilledProcessCensusOptions = {},
+): Promise<RedskilledProcessCensusRow[]> {
+  const root = options.proc_root ?? "/proc";
+  try {
+    const uptimeSeconds = Number((await readFile(join(root, "uptime"), "utf8")).trim().split(/\s+/)[0]);
+    if (!Number.isFinite(uptimeSeconds) || uptimeSeconds < 0) return [];
+    const entries = await readdir(root);
+    const rows: RedskilledProcessCensusRow[] = [];
+    for (const entry of entries) {
+      if (!/^\d+$/.test(entry)) continue;
+      let parsed: ReturnType<typeof parseProcStat>;
+      try {
+        parsed = parseProcStat(await readFile(join(root, entry, "stat"), "utf8"));
+      } catch {
+        continue;
+      }
+      if (parsed == null || parsed.ppid !== 1) continue;
+
+      let environment = new Map<string, string>();
+      let cwd: string | undefined;
+      try {
+        environment = parseProcessEnvironment(await readFile(join(root, entry, "environ"), "utf8"));
+      } catch {
+        // An unreadable stamp leaves the row unstamped; cwd can still identify a suspect.
+      }
+      try {
+        cwd = await readlink(join(root, entry, "cwd"));
+      } catch {
+        // An unreadable cwd is not evidence that the process belongs to a Worker.
+      }
+
+      const workerId = stated(environment.get("RED_WORKER_ID"));
+      const bornAt = stated(environment.get("RED_WORKER_BORN_AT"));
+      rows.push({
+        pid: parsed.pid,
+        ppid: parsed.ppid,
+        pgid: parsed.pgid,
+        sid: parsed.sid,
+        starttime: parsed.starttime,
+        age_ms: Math.max(
+          0,
+          (uptimeSeconds - Number(parsed.starttime) / REDSKILLED_PROC_CLOCK_TICKS_PER_SECOND) * 1_000,
+        ),
+        ...(workerId == null ? {} : { worker_id: workerId }),
+        ...(bornAt == null ? {} : { born_at: bornAt }),
+        ...(cwd == null ? {} : { cwd }),
+        under_workers_lane: cwd != null && isWorkersLanePath(cwd),
+      });
+    }
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/** Decode the NUL-separated bytes Linux exposes for one process environment. */
+function parseProcessEnvironment(raw: string): Map<string, string> {
+  const environment = new Map<string, string>();
+  for (const field of raw.split("\0")) {
+    const equals = field.indexOf("=");
+    if (equals <= 0) continue;
+    environment.set(field.slice(0, equals), field.slice(equals + 1));
+  }
+  return environment;
+}
+
+function stated(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed == null || trimmed === "" ? undefined : trimmed;
+}
+
+/** True only for the canonical disposable Worker workspace lanes. */
+function isWorkersLanePath(path: string): boolean {
+  const parts = normalize(path).split(sep).filter(Boolean);
+  for (let index = 0; index < parts.length - 2; index += 1) {
+    if (parts[index] !== ".red" || parts[index + 1] !== "tmp") continue;
+    return ["workers", "go-workers", "scout-workers"].includes(parts[index + 2] ?? "");
+  }
+  return false;
+}
+
+/** Select the process-table rows on which the daemon may act. PURE. */
+export function selectOrphanReaperCandidates(
+  input: SelectOrphanReaperCandidatesInput,
+): RedskilledOrphanReaperCandidate[] {
+  const selected: RedskilledOrphanReaperCandidate[] = [];
+  for (const process of input.processes) {
+    if (!Number.isFinite(process.age_ms) || process.age_ms < 0) continue;
+    const workerId = process.worker_id?.trim();
+    if (workerId == null || workerId === "") {
+      if (
+        process.ppid === 1 &&
+        process.under_workers_lane &&
+        process.age_ms >= REDSKILLED_UNSTAMPED_SUSPECT_GRACE_MS
+      ) {
+        selected.push({
+          kind: "suspect",
+          process,
+          detail:
+            `unstamped process ${process.pid} was reparented under a workers lane and is at least 30 minutes old; ` +
+            "it will never be signalled",
+        });
+      }
+      continue;
+    }
+    if (process.pid !== process.pgid || input.held_worker_ids.has(workerId)) continue;
+    if (input.live_birth_ids.has(workerId)) {
+      selected.push({
+        kind: "adopt",
+        process,
+        detail: `stamped Worker ${workerId} has a live birth but no daemon holder`,
+      });
+      continue;
+    }
+    if (process.age_ms < REDSKILLED_STAMPED_ORPHAN_GRACE_MS) continue;
+    selected.push({
+      kind: "reap",
+      process,
+      detail: `stamped Worker ${workerId} has no live birth and is at least 10 minutes old`,
+    });
+  }
+  return selected;
+}
+
+export interface RedskilledOrphanSweepOutcome {
+  readonly adopted: number;
+  readonly reaped: number;
+  readonly suspects: number;
+}
+
+export interface RedskilledOrphanReaperRuntimeOptions {
+  readonly authorized: boolean;
+  readonly interval_ms?: number;
+  readonly mode?: RedskilledOrphanReaperMode;
+  readonly census?: () => readonly RedskilledProcessCensusRow[] | Promise<readonly RedskilledProcessCensusRow[]>;
+  readonly read_starttime?: (pid: number) => string | null | Promise<string | null>;
+  readonly kill_group?: (pgid: number) => boolean | Promise<boolean>;
+  readonly report?: (detail: string) => void;
+  readonly clock: () => string;
+  readonly held_worker_ids: () => Iterable<string>;
+  readonly live_births: () => readonly RedskilledWorkerView[] | Promise<readonly RedskilledWorkerView[]>;
+  /** Put an adopted Worker in the daemon set and optionally record its new birth. */
+  readonly adopt: (worker: RedskilledWorkerView, recordBirth: boolean, detail: string) => void | Promise<void>;
+  /** Forget an adopted Worker after its group is confirmed dead and record death. */
+  readonly record_reaped: (worker: RedskilledWorkerView, detail: string) => void | Promise<void>;
+}
+
+export interface RedskilledOrphanReaperRuntime {
+  readonly sweep: () => Promise<RedskilledOrphanSweepOutcome>;
+  readonly arm: () => void;
+  readonly stop: () => void;
+}
+
+const EMPTY_ORPHAN_SWEEP: RedskilledOrphanSweepOutcome = { adopted: 0, reaped: 0, suspects: 0 };
+
+/** Own the daemon's orphan census, decisions, action ordering and interval. */
+export function createRedskilledOrphanReaperRuntime(
+  options: RedskilledOrphanReaperRuntimeOptions,
+): RedskilledOrphanReaperRuntime {
+  const intervalMs = options.interval_ms ?? DEFAULT_REDSKILLED_ORPHAN_REAPER_MS;
+  const mode = options.mode ?? redskilledOrphanReaperMode();
+  const census = options.census ?? censusRedskilledProcesses;
+  const readStarttime = options.read_starttime ?? readRedskilledProcessStarttime;
+  const killGroup = options.kill_group ?? killTreeAndWait;
+  const report = options.report ?? ((detail: string) => process.stderr.write(`redskilled: ${detail}\n`));
+  let timer: NodeJS.Timeout | undefined;
+  let sweeping = false;
+
+  async function sweep(): Promise<RedskilledOrphanSweepOutcome> {
+    if (!options.authorized || mode === "off" || sweeping) return { ...EMPTY_ORPHAN_SWEEP };
+    sweeping = true;
+    try {
+      let processes: readonly RedskilledProcessCensusRow[];
+      try {
+        processes = await census();
+      } catch {
+        processes = [];
+      }
+      if (processes.length === 0) return { ...EMPTY_ORPHAN_SWEEP };
+
+      let births: readonly RedskilledWorkerView[];
+      try {
+        births = await options.live_births();
+      } catch {
+        report("orphan census withheld: the event lane could not prove which stamped Workers still have live births");
+        return { ...EMPTY_ORPHAN_SWEEP };
+      }
+      const liveBirths = new Map(births.map((worker) => [worker.worker_id, worker]));
+      const candidates = selectOrphanReaperCandidates({
+        processes,
+        held_worker_ids: new Set(options.held_worker_ids()),
+        live_birth_ids: new Set(liveBirths.keys()),
+      });
+      const counts = { adopted: 0, reaped: 0, suspects: 0 };
+
+      for (const candidate of candidates) {
+        if (candidate.kind === "suspect") {
+          counts.suspects += 1;
+          report(candidate.detail);
+          continue;
+        }
+        if (candidate.kind === "adopt") {
+          await options.adopt(
+            workerFromOrphanProcess(candidate.process, options.clock, liveBirths.get(candidate.process.worker_id!)),
+            false,
+            candidate.detail,
+          );
+          counts.adopted += 1;
+          report(candidate.detail);
+          continue;
+        }
+        if (mode === "report") {
+          report(`${candidate.detail}; report mode withheld adoption and signalling`);
+          continue;
+        }
+
+        const adopted = workerFromOrphanProcess(candidate.process, options.clock);
+        let verified = false;
+        const outcome = await reapStampedOrphan(candidate.process, {
+          read_starttime: readStarttime,
+          after_verified: async () => {
+            verified = true;
+            await options.adopt(adopted, true, `adopted stamped orphan before group teardown: ${candidate.detail}`);
+            counts.adopted += 1;
+          },
+          kill_group: killGroup,
+        });
+        if (!outcome.reaped || !verified) {
+          report(`${candidate.detail}; ${outcome.reason}`);
+          continue;
+        }
+        await options.record_reaped(adopted, `orphan-reaped: ${candidate.detail}`);
+        counts.reaped += 1;
+      }
+      return counts;
+    } finally {
+      sweeping = false;
+    }
+  }
+
+  function arm(): void {
+    if (timer != null || intervalMs <= 0 || mode === "off" || !options.authorized) return;
+    timer = setInterval(() => void sweep().catch(() => undefined), intervalMs);
+    timer.unref();
+  }
+
+  return {
+    sweep,
+    arm,
+    stop: () => {
+      if (timer != null) clearInterval(timer);
+      timer = undefined;
+    },
+  };
+}
+
+function workerFromOrphanProcess(
+  processRow: RedskilledProcessCensusRow,
+  clock: () => string,
+  birth?: RedskilledWorkerView,
+): RedskilledWorkerView {
+  const nowMs = Date.parse(clock());
+  const inferredBirth = Number.isFinite(nowMs)
+    ? new Date(Math.max(0, nowMs - processRow.age_ms)).toISOString()
+    : clock();
+  const { unit: _unit, ...birthWithoutUnit } = birth ?? {};
+  return {
+    ...birthWithoutUnit,
+    worker_id: processRow.worker_id!,
+    project_label: birth?.project_label ?? REDSKILLED_UNOWNED_PROJECT_LABEL,
+    pid: processRow.pid,
+    pgid: processRow.pgid,
+    proc_start_time: processRow.starttime,
+    started_at: birth?.started_at ?? processRow.born_at ?? inferredBirth,
+    workspace_path: processRow.cwd ?? birth?.workspace_path ?? "",
+    isolated: false,
+    warnings: [
+      ...(birth?.warnings ?? []),
+      birth == null
+        ? "adopted by the orphan reaper from the host process table: no daemon holder or live birth remained, so the owning project and budget are unknown"
+        : "adopted by the orphan reaper from a live event-lane birth whose daemon holder was missing; the process-table identity now anchors it",
+    ],
+  };
+}

--- a/apps/redskilled/src/reattach.ts
+++ b/apps/redskilled/src/reattach.ts
@@ -72,6 +72,34 @@ export async function reattachWorkers(
   return { alive, dead };
 }
 
+export interface SweepHeldWorkerLivenessInput {
+  readonly workers: readonly RedskilledWorkerView[];
+  readonly reattached_worker_ids: ReadonlySet<string>;
+  readonly now_ms: number;
+  readonly grace_ms: number;
+  readonly probe: RedskilledLivenessProbe;
+  readonly on_dead: (worker: RedskilledWorkerView) => void | Promise<void>;
+}
+
+/**
+ * Probe every held Worker old enough to judge, retiring those the host no
+ * longer confirms. Reattached Workers have no child handle, so they are always
+ * eligible; newborns retain their grace while the init system creates a unit.
+ */
+export async function sweepHeldWorkerLiveness(
+  input: SweepHeldWorkerLivenessInput,
+): Promise<readonly RedskilledWorkerView[]> {
+  const held = input.workers.filter((worker) => {
+    if (input.reattached_worker_ids.has(worker.worker_id)) return true;
+    const bornMs = Date.parse(worker.started_at);
+    return !Number.isFinite(bornMs) || input.now_ms - bornMs >= input.grace_ms;
+  });
+  if (held.length === 0) return [];
+  const { dead } = await reattachWorkers(held, input.probe);
+  for (const worker of dead) await input.on_dead(worker);
+  return dead;
+}
+
 /**
  * How long a newborn Worker is exempt from the liveness sweep.
  *

--- a/apps/redskilled/tests/memory-floor.test.ts
+++ b/apps/redskilled/tests/memory-floor.test.ts
@@ -41,6 +41,9 @@ async function sessionPaths(): Promise<RedskilledPaths> {
 interface StatRow {
   readonly pid: number;
   readonly ppid: number;
+  readonly pgid?: number;
+  readonly sid?: number;
+  readonly starttime?: number;
   readonly rssPages: number;
   readonly utime?: number;
   readonly stime?: number;
@@ -53,12 +56,16 @@ interface StatRow {
  * the reader walks past `comm` instead of splitting on it.
  */
 function procStatLine(row: StatRow): string {
-  // Fields after `comm`: index 0 `state`, 1 `ppid`, 11 `utime`, 12 `stime`, 21 `rss`.
+  // Fields after `comm`: index 0 `state`, 1 `ppid`, 2 `pgrp`, 3 `session`,
+  // 11 `utime`, 12 `stime`, 19 `starttime`, 21 `rss`.
   const after = Array.from({ length: 22 }, () => "0");
   after[0] = "S";
   after[1] = String(row.ppid);
+  after[2] = String(row.pgid ?? row.pid);
+  after[3] = String(row.sid ?? row.pid);
   after[11] = String(row.utime ?? 0);
   after[12] = String(row.stime ?? 0);
+  after[19] = String(row.starttime ?? 100);
   after[21] = String(row.rssPages);
   return `${row.pid} (my prog (x)) ${after.join(" ")}\n`;
 }
@@ -269,8 +276,24 @@ describe("the memory floor", () => {
   });
 
   it("reads a process name containing spaces and parentheses without shifting fields", () => {
-    expect(parseProcStat(procStatLine({ pid: 77, ppid: 5, rssPages: 12, utime: 300, stime: 100 })))
-      .toEqual({ pid: 77, ppid: 5, rssPages: 12, cpuTicks: 400 });
+    expect(parseProcStat(procStatLine({
+      pid: 77,
+      ppid: 5,
+      pgid: 70,
+      sid: 60,
+      starttime: 12_345,
+      rssPages: 12,
+      utime: 300,
+      stime: 100,
+    }))).toEqual({
+      pid: 77,
+      ppid: 5,
+      pgid: 70,
+      sid: 60,
+      starttime: "12345",
+      rssPages: 12,
+      cpuTicks: 400,
+    });
   });
 
   it("measures a host with no /proc from its own process table instead of giving up", () => {

--- a/apps/redskilled/tests/orphan-reaper.test.ts
+++ b/apps/redskilled/tests/orphan-reaper.test.ts
@@ -1,0 +1,267 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { createRedskilledEventLane, readRedskilledEvents } from "../src/event-lane.js";
+import {
+  censusRedskilledProcesses,
+  DEFAULT_REDSKILLED_ORPHAN_REAPER_MS,
+  reapStampedOrphan,
+  redskilledOrphanReaperMode,
+  selectOrphanReaperCandidates,
+  type RedskilledProcessCensusRow,
+} from "../src/orphan-reaper.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+
+const roots: string[] = [];
+const daemons: RedskilledDaemon[] = [];
+
+afterEach(async () => {
+  for (const daemon of daemons.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function procStat(row: { pid: number; ppid: number; pgid: number; sid: number; starttime: number }): string {
+  const fields = Array.from({ length: 22 }, () => "0");
+  fields[0] = "S";
+  fields[1] = String(row.ppid);
+  fields[2] = String(row.pgid);
+  fields[3] = String(row.sid);
+  fields[19] = String(row.starttime);
+  return `${row.pid} (worker with spaces) ${fields.join(" ")}\n`;
+}
+
+function processRow(overrides: Partial<RedskilledProcessCensusRow> = {}): RedskilledProcessCensusRow {
+  return {
+    pid: 4_242,
+    ppid: 1,
+    pgid: 4_242,
+    sid: 4_242,
+    starttime: "1200",
+    age_ms: 10 * 60_000,
+    worker_id: "hLOST",
+    born_at: "2026-08-11T10:00:00.000Z",
+    cwd: "/repo/.red/tmp/workers/wLOST/3589/worktree",
+    under_workers_lane: true,
+    ...overrides,
+  };
+}
+
+describe("the orphan reaper candidate selector", () => {
+  it("selects an unknown stamped process-group leader after the orphan grace", () => {
+    expect(selectOrphanReaperCandidates({
+      processes: [processRow()],
+      held_worker_ids: new Set(),
+      live_birth_ids: new Set(),
+    })).toEqual([{
+      kind: "reap",
+      process: processRow(),
+      detail: "stamped Worker hLOST has no live birth and is at least 10 minutes old",
+    }]);
+  });
+
+  it("adopts a stamped process with a live birth but no daemon holder", () => {
+    expect(selectOrphanReaperCandidates({
+      processes: [processRow({ age_ms: 1_000 })],
+      held_worker_ids: new Set(),
+      live_birth_ids: new Set(["hLOST"]),
+    })).toEqual([{
+      kind: "adopt",
+      process: processRow({ age_ms: 1_000 }),
+      detail: "stamped Worker hLOST has a live birth but no daemon holder",
+    }]);
+  });
+
+  it("reports an aged unstamped process reparented under a workers lane", () => {
+    expect(selectOrphanReaperCandidates({
+      processes: [processRow({ worker_id: undefined, born_at: undefined, age_ms: 30 * 60_000 })],
+      held_worker_ids: new Set(),
+      live_birth_ids: new Set(),
+    })).toEqual([{
+      kind: "suspect",
+      process: processRow({ worker_id: undefined, born_at: undefined, age_ms: 30 * 60_000 }),
+      detail: "unstamped process 4242 was reparented under a workers lane and is at least 30 minutes old; it will never be signalled",
+    }]);
+  });
+
+  it("ignores strangers, held Workers, young stamps and stamped descendants", () => {
+    expect(selectOrphanReaperCandidates({
+      processes: [
+        processRow({ worker_id: undefined, under_workers_lane: false, cwd: "/srv/stranger", age_ms: 60 * 60_000 }),
+        processRow({ worker_id: "hHELD" }),
+        processRow({ worker_id: "hYOUNG", age_ms: 10 * 60_000 - 1 }),
+        processRow({ worker_id: "hCHILD", pid: 4_243, pgid: 4_242 }),
+      ],
+      held_worker_ids: new Set(["hHELD"]),
+      live_birth_ids: new Set(),
+    })).toEqual([]);
+  });
+});
+
+describe("the daemon orphan-reaper control", () => {
+  it("runs every five minutes and obeys off/report kill-switch values", () => {
+    expect(DEFAULT_REDSKILLED_ORPHAN_REAPER_MS).toBe(5 * 60_000);
+    expect(redskilledOrphanReaperMode({})).toBe("reap");
+    expect(redskilledOrphanReaperMode({ REDSKILLED_ORPHAN_REAPER: "report" })).toBe("report");
+    expect(redskilledOrphanReaperMode({ REDSKILLED_ORPHAN_REAPER: "off" })).toBe("off");
+  });
+});
+
+describe("the orphan reaper process census", () => {
+  it("reads stamp, cwd, pgid, sid and starttime for a reparented candidate", async () => {
+    const root = await scratch("redskilled-orphan-proc-");
+    const processDir = join(root, "4242");
+    const cwd = join(root, "repo", ".red", "tmp", "workers", "wLOST", "3589", "worktree");
+    await mkdir(processDir, { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    await writeFile(join(root, "uptime"), "10000.00 0.00\n", "utf8");
+    await writeFile(join(processDir, "stat"), procStat({ pid: 4242, ppid: 1, pgid: 4242, sid: 4000, starttime: 900000 }), "utf8");
+    await writeFile(
+      join(processDir, "environ"),
+      "RED_WORKER_ID=hLOST\0RED_WORKER_BORN_AT=2026-08-11T10:00:00.000Z\0",
+      "utf8",
+    );
+    await symlink(cwd, join(processDir, "cwd"));
+
+    await expect(censusRedskilledProcesses({ proc_root: root })).resolves.toEqual([processRow({
+      sid: 4000,
+      starttime: "900000",
+      age_ms: 1_000_000,
+      cwd,
+    })]);
+  });
+
+  it("turns a census failure into an empty snapshot", async () => {
+    await expect(censusRedskilledProcesses({ proc_root: join(tmpdir(), "missing-redskilled-proc") }))
+      .resolves.toEqual([]);
+  });
+});
+
+describe("stamped orphan teardown", () => {
+  it("refuses to signal when the leader starttime changed after the census", async () => {
+    const signalled: number[] = [];
+    await expect(reapStampedOrphan(processRow(), {
+      read_starttime: () => "1201",
+      kill_group: async (pgid) => {
+        signalled.push(pgid);
+        return true;
+      },
+    })).resolves.toEqual({ reaped: false, reason: "leader-starttime-changed" });
+    expect(signalled).toEqual([]);
+  });
+
+  it("writes adopted birth before orphan-reaped death", async () => {
+    const root = await scratch("redskilled-orphan-daemon-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const killed: number[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      unitInventory: () => [],
+      orphanReaperMs: 0,
+      orphanCensus: async () => [processRow()],
+      orphanStarttime: () => "1200",
+      orphanKillGroup: async (pgid) => {
+        killed.push(pgid);
+        return true;
+      },
+    });
+    daemons.push(daemon);
+
+    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 1, reaped: 1, suspects: 0 });
+    await daemon.flushEvents();
+
+    expect(killed).toEqual([4_242]);
+    expect(daemon.workerCount()).toBe(0);
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.map((event) => event.kind)).toEqual(["worker-birth", "worker-death"]);
+    expect(events[0]!.detail).toMatch(/adopted stamped orphan/);
+    expect(events[1]!.detail).toMatch(/orphan-reaped/);
+  });
+
+  it("adopts a stamped process whose live birth has no holder", async () => {
+    const root = await scratch("redskilled-orphan-adopt-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    let snapshot: RedskilledProcessCensusRow[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      unitInventory: () => [],
+      orphanReaperMs: 0,
+      orphanCensus: async () => snapshot,
+      orphanReport: () => undefined,
+    });
+    daemons.push(daemon);
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    await lane.recordWorker({
+      kind: "worker-birth",
+      worker: {
+        worker_id: "hLOST",
+        project_label: "acme/widgets",
+        pid: 4_000,
+        started_at: "2026-08-11T10:00:00.000Z",
+        workspace_path: "/old/workspace",
+        isolated: true,
+        unit: "red-worker-hLOST.service",
+        warnings: [],
+      },
+      ts: "2026-08-11T10:00:00.000Z",
+    });
+    snapshot = [processRow({ age_ms: 1_000 })];
+
+    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 1, reaped: 0, suspects: 0 });
+    expect(daemon.hostState().workers[0]).toMatchObject({
+      worker_id: "hLOST",
+      project_label: "acme/widgets",
+      pid: 4_242,
+      isolated: false,
+    });
+    expect(daemon.hostState().workers[0]!.unit).toBeUndefined();
+  });
+
+  it("reports unstamped suspects and report-mode stamped orphans without signalling either", async () => {
+    const root = await scratch("redskilled-orphan-report-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const reports: string[] = [];
+    const signalled: number[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      unitInventory: () => [],
+      orphanReaperMs: 0,
+      orphanReaperMode: "report",
+      orphanCensus: async () => [
+        processRow(),
+        processRow({ worker_id: undefined, born_at: undefined, pid: 5_000, pgid: 5_000, age_ms: 30 * 60_000 }),
+      ],
+      orphanKillGroup: async (pgid) => {
+        signalled.push(pgid);
+        return true;
+      },
+      orphanReport: (detail) => reports.push(detail),
+    });
+    daemons.push(daemon);
+
+    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 0, reaped: 0, suspects: 1 });
+    expect(signalled).toEqual([]);
+    expect(reports).toHaveLength(2);
+    expect(reports.join(" ")).toMatch(/never be signalled/);
+    expect(reports.join(" ")).toMatch(/report mode withheld adoption and signalling/);
+  });
+});

--- a/apps/redskilled/tests/wsl2-host.test.ts
+++ b/apps/redskilled/tests/wsl2-host.test.ts
@@ -12,12 +12,14 @@
 // stands on has nothing to read there; that boundary is stated in the app README
 // where an operator will meet it, and the last case in this file holds the
 // README to it.
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { isPidAlive, UNIX_SOCKET_PATH_LIMIT } from "@reddb-io/shared/resident-core.js";
 import { evaluateWorkerAdmission, UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { readRedskilledEvents } from "../src/event-lane.js";
 import { evaluateMemoryBudgets, sampleWorkerTrees } from "../src/memory-sampler.js";
 import {
   createRedskilledMachineClaimStore,
@@ -25,17 +27,73 @@ import {
   resolveMachineClaimPath,
 } from "../src/machine-scope.js";
 import { resolveRedskilledPaths, resolveSessionKey, REDSKILLED_SOCKET_FILE } from "../src/paths.js";
+import { censusRedskilledProcesses } from "../src/orphan-reaper.js";
 import { stopWorker } from "../src/reattach.js";
 import { launchWorker } from "../src/worker-launch.js";
 import { detectWorkerPlacementProbes, planWorkerPlacement } from "../src/worker-placement.js";
 import type { RedskilledWorkerView } from "../src/host-state.js";
 
 const roots: string[] = [];
+const daemons: RedskilledDaemon[] = [];
 const restoreEnv: Array<() => void> = [];
 
 afterEach(async () => {
+  for (const daemon of daemons.splice(0)) await daemon.stop().catch(() => undefined);
   for (const restore of restoreEnv.splice(0)) restore();
   for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("WSL2 — the daemon reaps a stamped orphan from a synthetic /proc", () => {
+  it("adopts the census identity, group-kills it, then records orphan-reaped death", async () => {
+    const root = await scratch("redskilled-wsl-orphan-");
+    const procRoot = join(root, "proc");
+    const processDir = join(procRoot, "4242");
+    const cwd = join(root, "repo", ".red", "tmp", "workers", "wLOST", "3589", "worktree");
+    await mkdir(processDir, { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    const fields = Array.from({ length: 22 }, () => "0");
+    fields[0] = "S";
+    fields[1] = "1";
+    fields[2] = "4242";
+    fields[3] = "4242";
+    fields[19] = "900000";
+    await writeFile(join(procRoot, "uptime"), "10000.00 0.00\n", "utf8");
+    await writeFile(join(processDir, "stat"), `4242 (orphan tree) ${fields.join(" ")}\n`, "utf8");
+    await writeFile(
+      join(processDir, "environ"),
+      "RED_WORKER_ID=hLOST\0RED_WORKER_BORN_AT=2026-08-11T10:00:00.000Z\0",
+      "utf8",
+    );
+    await symlink(cwd, join(processDir, "cwd"));
+
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const killed: number[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      unitInventory: () => [],
+      orphanReaperMs: 0,
+      orphanCensus: () => censusRedskilledProcesses({ proc_root: procRoot }),
+      orphanStarttime: () => "900000",
+      orphanKillGroup: async (pgid) => {
+        killed.push(pgid);
+        return true;
+      },
+    });
+    daemons.push(daemon);
+
+    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 1, reaped: 1, suspects: 0 });
+    await daemon.flushEvents();
+
+    expect(killed).toEqual([4_242]);
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.map((event) => event.kind)).toEqual(["worker-birth", "worker-death"]);
+    expect(events[0]!.detail).toMatch(/adopted stamped orphan/);
+    expect(events[1]!.detail).toMatch(/orphan-reaped/);
+  });
 });
 
 async function scratch(prefix: string): Promise<string> {


### PR DESCRIPTION
Automated AFK landing for #3589. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3589

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789050758&installation_model_id=20659&pr_number=3614&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3614&signature=ff466d44ad48a28314a536ba893cde5af86666ae7aeaba133d6d70556f76ef75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->