### PR TITLE
chore: #3594 Worker logs trim at quiescent points and liveness is capped

### DIFF
--- a/apps/dev/src/runtime/wire/settings.ts
+++ b/apps/dev/src/runtime/wire/settings.ts
@@ -20,6 +20,7 @@ import {
 import { isRunner, type Runner } from "../../types/runner.js";
 import * as gitx from "../git.js";
 import { afkPaths } from "./paths.js";
+import { runWithQuiescentWorkerLogTrim } from "../worker-log-retention.js";
 
 export interface RunSettings {
   sandbox: SandboxMode;
@@ -258,7 +259,7 @@ export function makeRunAgent(
       branch: input.branch,
       attemptDir: laneAttemptDir,
     });
-    return runAgent(deps, {
+    return runWithQuiescentWorkerLogTrim(input.logPath, () => runAgent(deps, {
       ...input,
       sandboxMode: effectiveSandbox,
       // Stable container image (#2340). Per-call input wins (the untrusted-author
@@ -288,6 +289,6 @@ export function makeRunAgent(
             inspectTree: () => inspectProcessTreeNative(process.pid),
           }
         : {}),
-    });
+    }));
   };
 }

--- a/apps/dev/src/runtime/wire/settings.ts
+++ b/apps/dev/src/runtime/wire/settings.ts
@@ -259,7 +259,7 @@ export function makeRunAgent(
       branch: input.branch,
       attemptDir: laneAttemptDir,
     });
-    return runWithQuiescentWorkerLogTrim(input.logPath, () => runAgent(deps, {
+    const invoke = () => runAgent(deps, {
       ...input,
       sandboxMode: effectiveSandbox,
       // Stable container image (#2340). Per-call input wins (the untrusted-author
@@ -289,6 +289,9 @@ export function makeRunAgent(
             inspectTree: () => inspectProcessTreeNative(process.pid),
           }
         : {}),
-    }));
+    });
+    return input.logPath === undefined
+      ? invoke()
+      : runWithQuiescentWorkerLogTrim(input.logPath, invoke);
   };
 }

--- a/apps/dev/src/runtime/worker-log-retention.ts
+++ b/apps/dev/src/runtime/worker-log-retention.ts
@@ -1,0 +1,57 @@
+import { readFile } from "node:fs/promises";
+import {
+  LANE_RETENTION_REGISTRY,
+  trimLaneKeepLast,
+  type TrimLaneKeepLastOptions,
+} from "@reddb-io/shared/lane-retention.js";
+import { parseRecords } from "@reddb-io/toon";
+
+export interface WorkerLogRetentionOptions {
+  /** Tiny override for posed tests; production uses the shared registry. */
+  readonly maxLines?: number;
+  readonly trimOptions?: TrimLaneKeepLastOptions;
+}
+
+function maxLines(options: WorkerLogRetentionOptions): number {
+  return options.maxLines ?? LANE_RETENTION_REGISTRY["worker-log"].maxLines;
+}
+
+/**
+ * Bound one Worker's structured log only after its foreign file logger has
+ * closed. The caller owns that lifecycle proof; this function performs no
+ * rename unless the complete record count is actually over the ceiling.
+ */
+export async function trimWorkerLogAtQuiescentPoint(
+  path: string,
+  options: WorkerLogRetentionOptions = {},
+): Promise<boolean> {
+  const keepLast = maxLines(options);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+  if (parseRecords(raw).length <= keepLast) return false;
+  await trimLaneKeepLast(path, keepLast, options.trimOptions);
+  return true;
+}
+
+/**
+ * The runner promise settles only after Sandcastle closes its file logger.
+ * Keeping the trim in this `finally` boundary makes both success and failure
+ * quiescent without ever rotating the lane during an in-flight invocation.
+ * Retention is best-effort and must not replace the runner's real outcome.
+ */
+export async function runWithQuiescentWorkerLogTrim<T>(
+  path: string,
+  run: () => Promise<T>,
+  options: WorkerLogRetentionOptions = {},
+): Promise<T> {
+  try {
+    return await run();
+  } finally {
+    await trimWorkerLogAtQuiescentPoint(path, options).catch(() => {});
+  }
+}

--- a/apps/dev/tests/log-cursor.test.ts
+++ b/apps/dev/tests/log-cursor.test.ts
@@ -8,6 +8,7 @@ import {
   readLogLineCursors,
 } from "../src/runtime/log-cursor.js";
 import { appendRecordToonlTaggedRow } from "../src/core/jsonl-log.js";
+import { createCastleLaneWriters, createEnginePaths } from "@reddb-io/red-castle/engine";
 
 describe("monitor log cursor", () => {
   it("counts only appended log lines after the first read", async () => {
@@ -72,5 +73,35 @@ describe("monitor log cursor", () => {
     });
     const second = await collectLogLineCounts(cache, [log]);
     expect(second.get(log)).toEqual({ lines: 2, newLines: 1 });
+  });
+
+  it("rescans a writer-capped liveness lane after its cursor is invalidated", async () => {
+    const root = await mkdtemp(join(tmpdir(), "afk-log-cursor-liveness-"));
+    const writers = createCastleLaneWriters(createEnginePaths(join(root, ".red")), {
+      clock: () => "2026-07-15T12:00:00.000Z",
+      livenessMaxBytes: 640,
+    });
+    const writer = writers.liveness("wAB12");
+    for (let beat = 1; beat <= 5; beat += 1) {
+      await writer.append({
+        kind: "worker.heartbeat",
+        worker_id: "wAB12",
+        payload: { signal: `before-${beat}` },
+      });
+    }
+    const first = await countLogLinesSinceCursor(writer.path, undefined);
+
+    for (let beat = 1; beat <= 5; beat += 1) {
+      await writer.append({
+        kind: "worker.heartbeat",
+        worker_id: "wAB12",
+        payload: { signal: `after-${beat}` },
+      });
+    }
+    const second = await countLogLinesSinceCursor(writer.path, first?.cursor);
+
+    expect(second).not.toBeNull();
+    expect(second!.count.newLines).toBeGreaterThan(0);
+    expect(second!.cursor.size).toBeLessThanOrEqual(640);
   });
 });

--- a/apps/dev/tests/worker-log-retention.test.ts
+++ b/apps/dev/tests/worker-log-retention.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  runWithQuiescentWorkerLogTrim,
+  trimWorkerLogAtQuiescentPoint,
+} from "../src/runtime/worker-log-retention.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+function lane(ids: readonly string[]): string {
+  const writer = encodeLines({ trailer: false });
+  return ids
+    .map((id) => writer.push({ id } satisfies ToonlRecord))
+    .join("");
+}
+
+describe("worker log retention", () => {
+  it("trims an oversized log at a quiescent boundary and the next invocation appends", async () => {
+    const root = await mkdtemp(join(tmpdir(), "worker-log-retention-"));
+    roots.push(root);
+    const path = join(root, "worker.log.toonl");
+    await writeFile(path, lane(["one", "two", "three", "four"]), "utf8");
+
+    expect(
+      await trimWorkerLogAtQuiescentPoint(path, {
+        maxLines: 3,
+        trimOptions: { runTq: async () => false },
+      }),
+    ).toBe(true);
+
+    await writeFile(path, lane(["five"]), { encoding: "utf8", flag: "a" });
+    expect(parseRecords(await readFile(path, "utf8")).map((row) => row.id)).toEqual([
+      "two",
+      "three",
+      "four",
+      "five",
+    ]);
+  });
+
+  it("never trims while the runner still owns its live file logger", async () => {
+    const root = await mkdtemp(join(tmpdir(), "worker-log-retention-live-"));
+    roots.push(root);
+    const path = join(root, "worker.log.toonl");
+    const oversized = lane(["one", "two", "three"]);
+    await writeFile(path, oversized, "utf8");
+
+    let settle!: () => void;
+    const liveRun = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    const wrapped = runWithQuiescentWorkerLogTrim(
+      path,
+      () => liveRun,
+      { maxLines: 2, trimOptions: { runTq: async () => false } },
+    );
+
+    await Promise.resolve();
+    expect(await readFile(path, "utf8")).toBe(oversized);
+
+    settle();
+    await wrapped;
+    expect(parseRecords(await readFile(path, "utf8")).map((row) => row.id)).toEqual([
+      "two",
+      "three",
+    ]);
+  });
+});

--- a/packages/red-castle/src/LivenessLane.ts
+++ b/packages/red-castle/src/LivenessLane.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { parseRecords } from "@reddb-io/toon";
+import { LANE_RETENTION_REGISTRY } from "@reddb-io/shared/lane-retention.js";
 import type { AgentStreamEvent } from "./AgentStreamEmitter.js";
 import {
   appendCastleLaneRecord,
@@ -77,7 +78,7 @@ export class LivenessLane {
       at: new Date(record.at).toISOString(),
       kind: "worker.heartbeat",
       payload: { signal: kind },
-    });
+    }, { retentionPolicy: LANE_RETENTION_REGISTRY["worker-liveness"] });
     return record;
   }
 }

--- a/packages/red-castle/src/engine/lane-writers.test.ts
+++ b/packages/red-castle/src/engine/lane-writers.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { readFile, rm } from "node:fs/promises";
+import { readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { decode, parseRecords } from "@reddb-io/toon";
@@ -98,6 +98,29 @@ describe("castle lane writers", () => {
         payload: { runner: "codex" },
       },
     ]);
+  });
+
+  it("caps liveness on append with a tiny ceiling and keeps the newest beat", async () => {
+    const paths = createEnginePaths(redRoot);
+    const maxBytes = 420;
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-16T20:00:00.000Z",
+      livenessMaxBytes: maxBytes,
+    });
+    const writer = writers.liveness("wAB12");
+
+    for (let beat = 1; beat <= 12; beat += 1) {
+      await writer.append({
+        kind: "worker.heartbeat",
+        worker_id: "wAB12",
+        payload: { signal: `beat-${beat}` },
+      });
+    }
+
+    expect((await stat(writer.path)).size).toBeLessThanOrEqual(maxBytes);
+    const records = await readCastleLaneRecords(writer.path);
+    expect(records.length).toBeLessThan(12);
+    expect(records.at(-1)?.payload).toEqual({ signal: "beat-12" });
   });
 
   it("writes worker and supervisor state snapshots as TOON state.toon documents", async () => {

--- a/packages/red-castle/src/engine/lane-writers.ts
+++ b/packages/red-castle/src/engine/lane-writers.ts
@@ -7,6 +7,12 @@ import {
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import {
+  LANE_RETENTION_REGISTRY,
+  laneOverCeiling,
+  trimLaneKeepLast,
+  type LaneRetentionPolicy,
+} from "@reddb-io/shared/lane-retention.js";
+import {
   decode,
   encode,
   encodeLines,
@@ -41,6 +47,33 @@ export const CASTLE_LANE_FILENAMES = {
 } as const;
 
 export type CastleLaneName = keyof typeof CASTLE_LANE_FILENAMES;
+
+function encodedRows(rows: readonly ToonlRecord[]): string {
+  if (rows.length === 0) return "";
+  const writer = encodeLines({ trailer: false });
+  return rows.map((row) => writer.push(row)).join("");
+}
+
+function keepLastWithinByteTarget(
+  rows: readonly ToonlRecord[],
+  incomingBytes: number,
+  targetBytes: number,
+): number {
+  let low = 0;
+  let high = rows.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (
+      Buffer.byteLength(encodedRows(rows.slice(-middle))) + incomingBytes <=
+      targetBytes
+    ) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return low;
+}
 
 const CONTRACT_FIELDS = new Map(
   CASTLE_PUBLISHED_CONTRACTS.map((contract) => [
@@ -165,9 +198,40 @@ export function validateCastleHistoryRecord(
 async function appendToonlRecord<T extends Record<string, unknown>>(
   path: string,
   record: T,
+  retentionPolicy?: LaneRetentionPolicy,
 ): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
-  await appendFile(path, encodeLines().push(toToonlRecord(record)), "utf8");
+  const encoded = encodeLines().push(toToonlRecord(record));
+  if (
+    retentionPolicy?.maxBytes !== undefined &&
+    await laneOverCeiling(path, Buffer.byteLength(encoded), retentionPolicy)
+  ) {
+    const ceiling = retentionPolicy.maxBytes;
+    const incomingBytes = Buffer.byteLength(encoded);
+    if (incomingBytes > ceiling) {
+      throw new Error(`castle lane record exceeds its ${ceiling}-byte ceiling`);
+    }
+    let raw = "";
+    try {
+      raw = await readFile(path, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    const rows = raw === "" ? [] : parseRecords(raw);
+    const targetBytes = Math.max(
+      incomingBytes,
+      Math.floor(ceiling * (retentionPolicy.targetRatio ?? 0.5)),
+    );
+    const keepLast = keepLastWithinByteTarget(
+      rows,
+      incomingBytes,
+      targetBytes,
+    );
+    await trimLaneKeepLast(path, keepLast);
+  }
+  // `appendFile` opens and closes the lane for every beat. That close-before-
+  // next-stat lifecycle is what makes the preceding atomic replacement safe.
+  await appendFile(path, encoded, "utf8");
 }
 
 function toToonlRecord(record: Record<string, unknown>): ToonlRecord {
@@ -216,11 +280,13 @@ function normalizeCastleHistoryRecord(record: unknown): CastleHistoryRecord {
 export async function appendCastleLaneRecord(
   path: string,
   record: CastleLaneRecord,
+  options: { readonly retentionPolicy?: LaneRetentionPolicy } = {},
 ): Promise<CastleLaneRecord> {
   const validated = validateCastleLaneRecord(record);
   await appendToonlRecord(
     path,
     validated as unknown as Record<string, unknown>,
+    options.retentionPolicy,
   );
   return validated;
 }
@@ -332,16 +398,26 @@ export interface CastleLaneWriters {
 
 export interface CastleLaneWritersOptions {
   readonly clock?: () => string;
+  /** Tiny override for posed tests; production uses the shared 1 MiB policy. */
+  readonly livenessMaxBytes?: number;
 }
 
-function makeLaneWriter(path: string, clock: () => string): CastleLaneWriter {
+function makeLaneWriter(
+  path: string,
+  clock: () => string,
+  retentionPolicy?: LaneRetentionPolicy,
+): CastleLaneWriter {
   return {
     path,
     async append(record) {
-      return appendCastleLaneRecord(path, {
-        at: record.at ?? clock(),
-        ...record,
-      });
+      return appendCastleLaneRecord(
+        path,
+        {
+          at: record.at ?? clock(),
+          ...record,
+        },
+        { retentionPolicy },
+      );
     },
   };
 }
@@ -351,6 +427,12 @@ export function createCastleLaneWriters(
   options: CastleLaneWritersOptions = {},
 ): CastleLaneWriters {
   const clock = options.clock ?? (() => new Date().toISOString());
+  const livenessPolicy: LaneRetentionPolicy = {
+    ...LANE_RETENTION_REGISTRY["worker-liveness"],
+    ...(options.livenessMaxBytes === undefined
+      ? {}
+      : { maxBytes: options.livenessMaxBytes }),
+  };
   return {
     worker: (id) => makeLaneWriter(castleLanePath(paths, "worker", id), clock),
     supervisor: (id) =>
@@ -358,6 +440,10 @@ export function createCastleLaneWriters(
     monitor: (id) =>
       makeLaneWriter(castleLanePath(paths, "monitor", id), clock),
     liveness: (workerId) =>
-      makeLaneWriter(castleLanePath(paths, "liveness", workerId), clock),
+      makeLaneWriter(
+        castleLanePath(paths, "liveness", workerId),
+        clock,
+        livenessPolicy,
+      ),
   };
 }

--- a/packages/shared/lane-retention.test.ts
+++ b/packages/shared/lane-retention.test.ts
@@ -37,6 +37,7 @@ describe("shared lane retention", () => {
     expect(LANE_RETENTION_REGISTRY["rsp-telemetry-corrections"].maxBytes).toBe(1024 * 1024);
     expect(LANE_RETENTION_REGISTRY["death-attributions"].maxAgeMs).toBe(14 * 24 * 60 * 60 * 1_000);
     expect(LANE_RETENTION_REGISTRY["worker-log"].maxLines).toBe(50_000);
+    expect(LANE_RETENTION_REGISTRY["worker-liveness"].maxBytes).toBe(1024 * 1024);
   });
 
   it("checks an append ceiling with exactly one stat in async and exit-handler paths", async () => {

--- a/packages/shared/lane-retention.ts
+++ b/packages/shared/lane-retention.ts
@@ -80,6 +80,10 @@ export const LANE_RETENTION_REGISTRY = {
     maxLines: 50_000,
     targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
   },
+  "worker-liveness": {
+    maxBytes: MIB,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
   "castle-history": {
     maxLines: 10_000,
     targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,


### PR DESCRIPTION
Automated AFK landing for #3594. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3594

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789051306&installation_model_id=20659&pr_number=3615&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3615&signature=3a8d3cda47662c33e73c16421f8a7ec5d243c8e6ad3528a0ecebdb8fee41e067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->