### PR TITLE
chore: #3590 The GitHub spend ledgers ride a keep-newest ceiling

### DIFF
--- a/packages/github/attribution.test.ts
+++ b/packages/github/attribution.test.ts
@@ -131,23 +131,43 @@ describe("the GitHub spend attribution ledger", () => {
     const maxBytes = 700;
     const ledger = createGithubAttributionLedger({ path, maxBytes });
 
+    let previousBytes = 0;
+    let trimmed = false;
+    for (let index = 0; index < 20; index += 1) {
+      await ledger.record({
+        operation: routeGithubArgs(["issue", "view", String(index)]),
+        cost: index + 1,
+        actor: `worker:w${String(index).padStart(2, "0")}`,
+        observedAt: `2026-08-03T12:${String(index).padStart(2, "0")}:00.000Z`,
+      });
+      const currentBytes = (await stat(path)).size;
+      if (currentBytes < previousBytes) {
+        expect(currentBytes).toBeLessThanOrEqual(Math.floor(maxBytes / 2));
+        trimmed = true;
+        break;
+      }
+      previousBytes = currentBytes;
+    }
+    expect(trimmed).toBe(true);
+
     await Promise.all(
-      Array.from({ length: 20 }, (_, index) =>
-        ledger.record({
+      Array.from({ length: 20 }, (_, offset) => {
+        const index = offset + 20;
+        return ledger.record({
           operation: routeGithubArgs(["issue", "view", String(index)]),
           cost: index + 1,
           actor: `worker:w${String(index).padStart(2, "0")}`,
           observedAt: `2026-08-03T12:${String(index).padStart(2, "0")}:00.000Z`,
-        }),
-      ),
+        });
+      }),
     );
 
     const raw = await readFile(path, "utf8");
     const rows = parseRecords(raw);
     expect(rows.length).toBeGreaterThan(0);
-    expect(rows.length).toBeLessThan(20);
+    expect(rows.length).toBeLessThan(40);
     expect((await stat(path)).size).toBeLessThanOrEqual(maxBytes);
-    expect(rows.at(-1)).toMatchObject({ actor: "worker:w19", cost: 20 });
+    expect(rows.at(-1)).toMatchObject({ actor: "worker:w39", cost: 40 });
 
     const report = await ledger.report({ from: HOUR_START, to: HOUR_END });
     expect(report.unreadable_records).toBe(0);

--- a/packages/github/attribution.test.ts
+++ b/packages/github/attribution.test.ts
@@ -1,6 +1,7 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { parseRecords } from "@reddb-io/toon";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createGithubAttributionLedger } from "./attribution.js";
@@ -123,5 +124,34 @@ describe("the GitHub spend attribution ledger", () => {
       { operation_key: "issue list", pool: "rest", actor: "worker:wONE", count: 1, cost: 8 },
       { operation_key: "issue list", pool: "rest", actor: "worker:wTWO", count: 1, cost: 3 },
     ]);
+  });
+
+  it("trims an over-ceiling lane to half while concurrent writes and reports stay serialized", async () => {
+    const path = await ledgerPath();
+    const maxBytes = 700;
+    const ledger = createGithubAttributionLedger({ path, maxBytes });
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        ledger.record({
+          operation: routeGithubArgs(["issue", "view", String(index)]),
+          cost: index + 1,
+          actor: `worker:w${String(index).padStart(2, "0")}`,
+          observedAt: `2026-08-03T12:${String(index).padStart(2, "0")}:00.000Z`,
+        }),
+      ),
+    );
+
+    const raw = await readFile(path, "utf8");
+    const rows = parseRecords(raw);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.length).toBeLessThan(20);
+    expect((await stat(path)).size).toBeLessThanOrEqual(maxBytes);
+    expect(rows.at(-1)).toMatchObject({ actor: "worker:w19", cost: 20 });
+
+    const report = await ledger.report({ from: HOUR_START, to: HOUR_END });
+    expect(report.unreadable_records).toBe(0);
+    expect(report.total_count).toBe(rows.length);
+    expect(report.total_cost).toBe(rows.reduce((sum, row) => sum + Number(row.cost), 0));
   });
 });

--- a/packages/github/attribution.ts
+++ b/packages/github/attribution.ts
@@ -205,9 +205,7 @@ function keepLastWithin(
 }
 
 function encodeRows(rows: readonly ToonlRecord[]): string {
-  if (rows.length === 0) return "";
-  const writer = encodeLines({ trailer: false });
-  return rows.map((row) => writer.push(row)).join("");
+  return rows.map((row) => encodeLines({ trailer: false }).push(row)).join("");
 }
 
 function makeObservation(

--- a/packages/github/attribution.ts
+++ b/packages/github/attribution.ts
@@ -8,6 +8,12 @@
 
 import { appendFile, mkdir, readFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import {
+  LANE_RETENTION_REGISTRY,
+  laneOverCeiling,
+  trimLaneKeepLast,
+  type LaneRetentionPolicy,
+} from "@reddb-io/shared/lane-retention.js";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
 
 import type { GithubRateBudget } from "./surface.js";
@@ -74,6 +80,8 @@ export interface CreateGithubAttributionLedgerOptions {
   /** Durable TOONL path. The caller owns where project/host state lives. */
   readonly path: string;
   readonly now?: () => string;
+  /** Override the production byte ceiling; exposed for tiny-lane tests. */
+  readonly maxBytes?: number;
 }
 
 /**
@@ -89,6 +97,11 @@ export function createGithubAttributionLedger(
   options: CreateGithubAttributionLedgerOptions,
 ): GithubAttributionLedger {
   const now = options.now ?? (() => new Date().toISOString());
+  const registeredPolicy = LANE_RETENTION_REGISTRY["github-spend"];
+  const retentionPolicy: LaneRetentionPolicy = {
+    ...registeredPolicy,
+    ...(options.maxBytes === undefined ? {} : { maxBytes: options.maxBytes }),
+  };
   // Serialize writes made by one process. Separate processes still append whole
   // JSONL records independently; rebuilding never depends on in-memory state.
   let pendingWrite: Promise<void> = Promise.resolve();
@@ -99,6 +112,19 @@ export function createGithubAttributionLedger(
       const segment = encodeLines().push(toToonlRecord(observation));
       pendingWrite = pendingWrite.then(async () => {
         await mkdir(dirname(options.path), { recursive: true });
+        const incomingBytes = Buffer.byteLength(segment);
+        if (await laneOverCeiling(options.path, incomingBytes, retentionPolicy)) {
+          const ceiling = retentionPolicy.maxBytes!;
+          if (incomingBytes > ceiling) {
+            throw new Error(`GitHub spend observation exceeds its ${ceiling}-byte lane ceiling`);
+          }
+          const rows = await readLaneRows(options.path);
+          const targetBytes = Math.max(
+            Math.floor(ceiling * registeredPolicy.targetRatio),
+            incomingBytes,
+          );
+          await trimLaneKeepLast(options.path, keepLastWithin(rows, incomingBytes, targetBytes));
+        }
         await appendFile(options.path, segment, "utf8");
       });
       return pendingWrite;
@@ -147,6 +173,41 @@ export function createGithubAttributionLedger(
       };
     },
   };
+}
+
+async function readLaneRows(path: string): Promise<ToonlRecord[]> {
+  try {
+    const raw = await readFile(path, "utf8");
+    return raw.trim() === "" ? [] : parseRecords(raw);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+function keepLastWithin(
+  rows: readonly ToonlRecord[],
+  incomingBytes: number,
+  targetBytes: number,
+): number {
+  let low = 0;
+  let high = rows.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const retained = encodeRows(rows.slice(-middle));
+    if (Buffer.byteLength(retained) + incomingBytes <= targetBytes) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return low;
+}
+
+function encodeRows(rows: readonly ToonlRecord[]): string {
+  if (rows.length === 0) return "";
+  const writer = encodeLines({ trailer: false });
+  return rows.map((row) => writer.push(row)).join("");
 }
 
 function makeObservation(

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -18,6 +18,7 @@
     "@octokit/plugin-retry": "^8.1.1",
     "@octokit/plugin-throttling": "^11.0.5",
     "@octokit/rest": "^22.0.1",
+    "@reddb-io/shared": "workspace:*",
     "@reddb-io/toon": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,6 +537,9 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
+      '@reddb-io/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@reddb-io/toon':
         specifier: 'catalog:'
         version: 0.13.0


### PR DESCRIPTION
Automated AFK landing for #3590. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3590

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789051434&installation_model_id=20659&pr_number=3616&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3616&signature=a1d3b34f042593ead34735b814300d3ff44534bbf1684d629e161cecb27e0d89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->