### PR TITLE
chore: #3596 max_processes is enforced on Linux: TasksMax and the process budget evaluator

### DIFF
--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -52,6 +52,7 @@ import {
 } from "../host-state.js";
 import {
   evaluateMemoryBudgets,
+  evaluateProcessBudgets,
   sampleWorkerTrees,
   type RedskilledBudgetTermination,
   type RedskilledCpuReading,
@@ -1769,7 +1770,9 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     lastReading = rss;
     lastSampledAt = clock();
     recordCpuReading(reading.cpu_seconds, lastSampledAt);
-    const { terminations } = evaluateMemoryBudgets({ workers: live, rss });
+    const memory = evaluateMemoryBudgets({ workers: live, rss });
+    const processes = evaluateProcessBudgets({ workers: live, processes: reading.processes ?? {} });
+    const terminations = [...memory.terminations, ...processes.terminations];
     const done: RedskilledBudgetTermination[] = [];
     for (const termination of terminations) {
       if (await killWorkerOverBudget(termination.worker_id, termination.reason)) done.push(termination);

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -51,8 +51,7 @@ import {
   type RedskilledWorkerView,
 } from "../host-state.js";
 import {
-  evaluateMemoryBudgets,
-  evaluateProcessBudgets,
+  evaluateWorkerBudgets,
   sampleWorkerTrees,
   type RedskilledBudgetTermination,
   type RedskilledCpuReading,
@@ -1770,9 +1769,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     lastReading = rss;
     lastSampledAt = clock();
     recordCpuReading(reading.cpu_seconds, lastSampledAt);
-    const memory = evaluateMemoryBudgets({ workers: live, rss });
-    const processes = evaluateProcessBudgets({ workers: live, processes: reading.processes ?? {} });
-    const terminations = [...memory.terminations, ...processes.terminations];
+    const { terminations } = evaluateWorkerBudgets({ workers: live, rss, processes: reading.processes ?? {} });
     const done: RedskilledBudgetTermination[] = [];
     for (const termination of terminations) {
       if (await killWorkerOverBudget(termination.worker_id, termination.reason)) done.push(termination);

--- a/apps/redskilled/src/memory-sampler.ts
+++ b/apps/redskilled/src/memory-sampler.ts
@@ -118,6 +118,9 @@ export type RedskilledRssReading = Readonly<Record<string, number>>;
  */
 export type RedskilledCpuReading = Readonly<Record<string, number>>;
 
+/** Number of processes visited in each unisolated Worker's tree. */
+export type RedskilledProcessReading = Readonly<Record<string, number>>;
+
 /**
  * One tick's reading of the whole Worker set — both measurements, one walk.
  *
@@ -128,6 +131,8 @@ export type RedskilledCpuReading = Readonly<Record<string, number>>;
 export interface RedskilledTreeReading {
   readonly rss: RedskilledRssReading;
   readonly cpu_seconds: RedskilledCpuReading;
+  /** Optional for injected legacy samplers; the host sampler always states it. */
+  readonly processes?: RedskilledProcessReading;
   /**
    * Which instrument answered for each Worker, keyed by `worker_id`.
    *
@@ -142,6 +147,11 @@ export interface RedskilledTreeReading {
    * sampleWorkerTrees} always states it.
    */
   readonly sources?: Readonly<Record<string, RedskilledRssSource>>;
+}
+
+/** The complete reading returned by the daemon's host sampler. */
+export interface RedskilledSampledTreeReading extends RedskilledTreeReading {
+  readonly processes: RedskilledProcessReading;
 }
 
 /** Measures the whole Worker set in one call. Injected, so a test needs no process. */
@@ -301,13 +311,14 @@ const PAGE_SIZE_BYTES = 4096;
 export function sampleWorkerTrees(
   workers: readonly RedskilledWorkerView[],
   options: SampleWorkerTreesOptions = {},
-): RedskilledTreeReading {
+): RedskilledSampledTreeReading {
   const platform = options.platform ?? process.platform;
-  const empty: RedskilledTreeReading = { rss: {}, cpu_seconds: {}, sources: {} };
+  const empty: RedskilledSampledTreeReading = { rss: {}, cpu_seconds: {}, processes: {}, sources: {} };
   if (workers.length === 0) return empty;
 
   const rss: Record<string, number> = {};
   const cpuSeconds: Record<string, number> = {};
+  const processes: Record<string, number> = {};
   const sources: Record<string, RedskilledRssSource> = {};
 
   // The kernel's own charge first, for every Worker the daemon put in a unit.
@@ -323,10 +334,10 @@ export function sampleWorkerTrees(
   // The walk answers only for whoever the kernel did not: an unisolated Worker, a
   // host with no cgroup filesystem, or a unit whose directory is already gone.
   const remaining = workers.filter((worker) => sources[worker.worker_id] == null);
-  if (remaining.length === 0) return { rss, cpu_seconds: cpuSeconds, sources };
+  if (remaining.length === 0) return { rss, cpu_seconds: cpuSeconds, processes, sources };
 
   const table = readHostProcessTable(platform, options);
-  if (table.size === 0) return { rss, cpu_seconds: cpuSeconds, sources };
+  if (table.size === 0) return { rss, cpu_seconds: cpuSeconds, processes, sources };
 
   const children = new Map<number, number[]>();
   for (const entry of table.values()) {
@@ -339,6 +350,7 @@ export function sampleWorkerTrees(
     if (!table.has(worker.pid)) continue;
     let totalRss = 0;
     let totalCpu = 0;
+    let processCount = 0;
     const queue = [worker.pid];
     const seen = new Set<number>();
     while (queue.length > 0) {
@@ -347,15 +359,17 @@ export function sampleWorkerTrees(
       seen.add(pid);
       const entry = table.get(pid);
       if (!entry) continue;
+      processCount += 1;
       totalRss += entry.rssBytes;
       totalCpu += entry.cpuSeconds;
       for (const child of children.get(pid) ?? []) queue.push(child);
     }
     rss[worker.worker_id] = totalRss;
     cpuSeconds[worker.worker_id] = totalCpu;
+    processes[worker.worker_id] = processCount;
     sources[worker.worker_id] = "process-tree";
   }
-  return { rss, cpu_seconds: cpuSeconds, sources };
+  return { rss, cpu_seconds: cpuSeconds, processes, sources };
 }
 
 export interface SampleWorkerTreesOptions {

--- a/apps/redskilled/src/memory-sampler.ts
+++ b/apps/redskilled/src/memory-sampler.ts
@@ -61,7 +61,7 @@ export type RedskilledTerminationClassification = "budget-exceeded";
 export const REDSKILLED_STALL_CLASSIFICATION = "stalled";
 
 /** Which declared budget the floor enforced. The budget's own name, verbatim. */
-export type RedskilledBudgetName = "MemoryMax" | "MemoryHigh";
+export type RedskilledBudgetName = "MemoryMax" | "MemoryHigh" | "TasksMax";
 
 /**
  * One Worker the sampler measured over its budget.
@@ -74,16 +74,17 @@ export interface RedskilledBudgetTermination {
   readonly version: 1;
   readonly worker_id: string;
   readonly project_label: string;
-  readonly outcome: "terminated-over-memory-budget";
+  readonly outcome: "terminated-over-memory-budget" | "terminated-over-process-budget";
   readonly classification: RedskilledTerminationClassification;
   /** Never a stall — the daemon measured this Worker, it did not wait on it. */
   readonly stall: false;
   /** The budget that was exceeded, by its own name. */
   readonly budget_name: RedskilledBudgetName;
   /** The budget exactly as the client declared it, unparsed. */
-  readonly budget_declared: string;
-  readonly budget_bytes: number;
-  readonly observed_rss_bytes: number;
+  readonly budget_declared: string | number;
+  readonly budget_bytes?: number;
+  readonly observed_rss_bytes?: number;
+  readonly observed_processes?: number;
   /** The workspace whose branch or PR the client hands forward. */
   readonly workspace_path: string;
   /** A whole sentence naming the budget — what an operator reads. */
@@ -257,6 +258,42 @@ export function evaluateMemoryBudgets(input: {
   }
 
   return { terminations, unenforceable };
+}
+
+/** Judge unisolated process-tree counts against declared `max_processes`. PURE. */
+export function evaluateProcessBudgets(input: {
+  readonly workers: readonly RedskilledWorkerView[];
+  readonly processes: RedskilledProcessReading;
+}): RedskilledMemoryTickOutcome {
+  const terminations: RedskilledBudgetTermination[] = [];
+
+  for (const worker of input.workers) {
+    if (worker.isolated) continue;
+    const declared = appliedWorkerBudget(worker).max_processes;
+    if (declared == null || !Number.isSafeInteger(declared) || declared <= 0) continue;
+    const observed = input.processes[worker.worker_id];
+    if (typeof observed !== "number" || !Number.isSafeInteger(observed) || observed < 0) continue;
+    if (observed <= declared) continue;
+
+    const who = `Worker ${JSON.stringify(worker.worker_id)} of project ${JSON.stringify(worker.project_label)}`;
+    terminations.push({
+      version: 1,
+      worker_id: worker.worker_id,
+      project_label: worker.project_label,
+      outcome: "terminated-over-process-budget",
+      classification: "budget-exceeded",
+      stall: false,
+      budget_name: "TasksMax",
+      budget_declared: declared,
+      observed_processes: observed,
+      workspace_path: worker.workspace_path,
+      reason: `redskilled terminated ${who}: its process tree contained ${observed} processes, exceeding its TasksMax ` +
+        `budget of ${declared}. This is a budget termination, not a stall, and the work in ` +
+        `${JSON.stringify(worker.workspace_path)} is handed forward.`,
+    });
+  }
+
+  return { terminations, unenforceable: [] };
 }
 
 /** The terminal outcome document for one budgeted termination. PURE. */

--- a/apps/redskilled/src/memory-sampler.ts
+++ b/apps/redskilled/src/memory-sampler.ts
@@ -296,6 +296,21 @@ export function evaluateProcessBudgets(input: {
   return { terminations, unenforceable: [] };
 }
 
+/** Evaluate every software-enforced tree budget from one shared reading. PURE. */
+export function evaluateWorkerBudgets(input: {
+  readonly workers: readonly RedskilledWorkerView[];
+  readonly rss: RedskilledRssReading;
+  readonly processes: RedskilledProcessReading;
+  readonly sources?: Readonly<Record<string, RedskilledRssSource>>;
+}): RedskilledMemoryTickOutcome {
+  const memory = evaluateMemoryBudgets(input);
+  const processes = evaluateProcessBudgets(input);
+  return {
+    terminations: [...memory.terminations, ...processes.terminations],
+    unenforceable: [...memory.unenforceable, ...processes.unenforceable],
+  };
+}
+
 /** The terminal outcome document for one budgeted termination. PURE. */
 export function buildBudgetTermination(
   worker: RedskilledWorkerView,

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -97,9 +97,9 @@ export interface RedskilledWorkerBudget {
   readonly memory_max?: string;
   readonly cpu_weight?: number;
   /**
-   * `RLIMIT_NPROC`, honoured by the macOS backend and named as unenforced by the
-   * others — a declared limit that quietly did nothing is the failure every
-   * warning in this module exists to prevent.
+   * `RLIMIT_NPROC` on macOS and `TasksMax` on Linux. A declared limit that
+   * quietly did nothing is the failure every warning in this module exists to
+   * prevent.
    */
   readonly max_processes?: number;
   /** `RLIMIT_CPU` in seconds, on the same terms as {@link max_processes}. */
@@ -403,6 +403,7 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
   if (budget.memory_high != null) unitArgs.push(`--property=MemoryHigh=${budget.memory_high}`);
   if (budget.memory_max != null) unitArgs.push(`--property=MemoryMax=${budget.memory_max}`);
   if (budget.cpu_weight != null) unitArgs.push(`--property=CPUWeight=${budget.cpu_weight}`);
+  if (budget.max_processes != null) unitArgs.push(`--property=TasksMax=${budget.max_processes}`);
   // The Worker's own placement joins its environment, so the process that dies
   // inside this unit can name the unit that held it and the ceiling it carried.
   const environment = workerPlacementEnvironment(opts, {
@@ -414,7 +415,9 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
     unitArgs.push(`--setenv=${key}=${value}`);
   }
 
-  const unenforced = unenforcedPosixBudgetFields(opts.budget);
+  const unenforced = unenforcedPosixBudgetFields(
+    opts.budget == null ? undefined : { ...opts.budget, max_processes: undefined },
+  );
   return {
     isolated: true,
     backend: "transient-unit",

--- a/apps/redskilled/tests/macos-posix-limits.test.ts
+++ b/apps/redskilled/tests/macos-posix-limits.test.ts
@@ -147,7 +147,7 @@ describe("macOS placement — the memory ceiling it refuses to claim", () => {
       },
     });
 
-    expect(reading).toEqual({ rss: {}, cpu_seconds: {}, sources: {} });
+    expect(reading).toEqual({ rss: {}, cpu_seconds: {}, processes: {}, sources: {} });
   });
 
   it("parses `ps` output and ignores every line that is not a process row", () => {
@@ -275,11 +275,12 @@ describe("macOS placement — the rlimits it will and will not set", () => {
     expect(limits.note).toMatch(/cpu_seconds/);
   });
 
-  it("names POSIX-only budget fields as unenforced on a backend that has no equivalent", () => {
-    const linux = plan(LINUX, { budget: { memory_max: "4G", max_processes: 256 } });
+  it("keeps only POSIX-only budget fields in Linux's unenforced warning", () => {
+    const linux = plan(LINUX, { budget: { memory_max: "4G", max_processes: 256, cpu_seconds: 3600 } });
 
     expect(linux.backend).toBe("transient-unit");
-    expect(linux.budgetWarning).toMatch(/max_processes/);
+    expect(linux.budgetWarning).toMatch(/cpu_seconds/);
+    expect(linux.budgetWarning).not.toMatch(/max_processes/);
   });
 
   it("degrades to an unwrapped launch when the host has no POSIX shell to wrap it in", () => {

--- a/apps/redskilled/tests/memory-floor.test.ts
+++ b/apps/redskilled/tests/memory-floor.test.ts
@@ -369,7 +369,7 @@ describe("the memory floor", () => {
   });
 
   it("measures nothing when no process table can be read at all, rather than reporting zero", () => {
-    const empty = { rss: {}, cpu_seconds: {}, sources: {} };
+    const empty = { rss: {}, cpu_seconds: {}, processes: {}, sources: {} };
     expect(sampleWorkerTrees([worker()], { platform: "aix" })).toEqual(empty);
     expect(sampleWorkerTrees([worker()], { platform: "darwin", psTable: () => "" })).toEqual(empty);
   });

--- a/apps/redskilled/tests/memory-floor.test.ts
+++ b/apps/redskilled/tests/memory-floor.test.ts
@@ -120,6 +120,15 @@ describe("the memory floor", () => {
     expect(terminations[0]!.reason).toContain("TasksMax");
   });
 
+  it("never terminates a process-budgeted Worker from an absent count", () => {
+    const outcome = evaluateProcessBudgets({
+      workers: [worker({ isolated: false, unit: undefined, budget: { max_processes: 1 } })],
+      processes: {},
+    });
+
+    expect(outcome.terminations).toEqual([]);
+  });
+
   it("terminates a Worker over its budget against a synthetic sampler", async () => {
     const paths = await sessionPaths();
     const stopped: string[] = [];

--- a/apps/redskilled/tests/memory-floor.test.ts
+++ b/apps/redskilled/tests/memory-floor.test.ts
@@ -154,6 +154,34 @@ describe("the memory floor", () => {
     expect(daemon.workerCount()).toBe(0);
   });
 
+  it("routes an over-limit process tree through worker-budget-kill", async () => {
+    const paths = await sessionPaths();
+    const stopped: string[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      stopWorker: (w) => {
+        stopped.push(w.worker_id);
+        return true;
+      },
+      treeSampler: () => ({ rss: {}, cpu_seconds: {}, processes: { "w-1": 3 } }),
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker({ isolated: false, unit: undefined, budget: { max_processes: 2 } }));
+
+    const terminations = await daemon.sampleMemoryBudgets();
+    await daemon.flushEvents();
+
+    expect(terminations[0]).toMatchObject({ budget_name: "TasksMax", observed_processes: 3 });
+    expect(stopped).toEqual(["w-1"]);
+    expect(daemon.workerCount()).toBe(0);
+    expect((await readRedskilledEvents(paths.eventLanePath)).at(-1)).toMatchObject({
+      event: "worker-budget-kill",
+      worker_id: "w-1",
+    });
+  });
+
   it("names the budget that was exceeded in the terminal outcome", async () => {
     const paths = await sessionPaths();
     const daemon = await startRedskilledDaemon({

--- a/apps/redskilled/tests/memory-floor.test.ts
+++ b/apps/redskilled/tests/memory-floor.test.ts
@@ -273,6 +273,7 @@ describe("the memory floor", () => {
     const reading = sampleWorkerTrees([worker({ worker_id: "tree", pid: 100 })], { procRoot, platform: "linux" });
 
     expect(reading.rss.tree).toBe((10 + 20 + 30) * 4096);
+    expect(reading.processes.tree).toBe(3);
   });
 
   it("reads a process name containing spaces and parentheses without shifting fields", () => {

--- a/apps/redskilled/tests/memory-floor.test.ts
+++ b/apps/redskilled/tests/memory-floor.test.ts
@@ -10,6 +10,7 @@ import { readRedskilledEvents } from "../src/event-lane.js";
 import { isRedskilledWorkerView, type RedskilledWorkerView } from "../src/host-state.js";
 import {
   evaluateMemoryBudgets,
+  evaluateProcessBudgets,
   parseProcStat,
   REDSKILLED_STALL_CLASSIFICATION,
   resolveEnforcedBudget,
@@ -98,6 +99,27 @@ function worker(overrides: Partial<RedskilledWorkerView> = {}): RedskilledWorker
 }
 
 describe("the memory floor", () => {
+  it("names TasksMax in the termination for an over-limit unisolated tree", () => {
+    const { terminations } = evaluateProcessBudgets({
+      workers: [worker({ isolated: false, unit: undefined, budget: { max_processes: 2 } })],
+      processes: { "w-1": 3 },
+    });
+
+    expect(terminations).toEqual([
+      expect.objectContaining({
+        version: 1,
+        worker_id: "w-1",
+        outcome: "terminated-over-process-budget",
+        classification: "budget-exceeded",
+        stall: false,
+        budget_name: "TasksMax",
+        budget_declared: 2,
+        observed_processes: 3,
+      }),
+    ]);
+    expect(terminations[0]!.reason).toContain("TasksMax");
+  });
+
   it("terminates a Worker over its budget against a synthetic sampler", async () => {
     const paths = await sessionPaths();
     const stopped: string[] = [];

--- a/apps/redskilled/tests/worker-placement.test.ts
+++ b/apps/redskilled/tests/worker-placement.test.ts
@@ -97,6 +97,20 @@ describe("worker placement — Linux with a user session", () => {
     expect(placement.budgetWarning).toBeUndefined();
   });
 
+  it("carries max_processes as TasksMax exactly when it is declared", () => {
+    const declared = plan(LINUX_WITH_SESSION, {
+      budget: { max_processes: 32, cpu_seconds: 60 },
+    });
+    const absent = plan(LINUX_WITH_SESSION, { budget: { cpu_seconds: 60 } });
+
+    expect(declared.args.filter((arg) => arg.startsWith("--property=TasksMax="))).toEqual([
+      "--property=TasksMax=32",
+    ]);
+    expect(absent.args.some((arg) => arg.startsWith("--property=TasksMax="))).toBe(false);
+    expect(declared.budgetWarning).toMatch(/cpu_seconds/);
+    expect(declared.budgetWarning).not.toMatch(/max_processes/);
+  });
+
   it("hands the workspace path to the unit verbatim", () => {
     const placement = plan(LINUX_WITH_SESSION, { workspacePath: "/nowhere/near/a/repo/x y" });
 


### PR DESCRIPTION
Automated AFK landing for #3596. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3596

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789054245&installation_model_id=20659&pr_number=3619&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3619&signature=7fd94a0b6c0459cb6466cbaa6427adc66d20e24b54aa826c4f5b2f89c203092d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->