### PR TITLE
fix: #3605 The remote-counter poll never arms on a real host: registration must hand it the transport

### DIFF
--- a/apps/dev/src/core/registration-query.ts
+++ b/apps/dev/src/core/registration-query.ts
@@ -18,7 +18,7 @@
 //
 // PURE — string in, string out, no tracker, no filesystem, no process.
 
-import { LABEL_READY, TAG_LABEL_PREFIX } from "./triage-labels.js";
+import { LABEL_HUMAN, LABEL_READY, TAG_LABEL_PREFIX } from "./triage-labels.js";
 
 /** The facets a registration may narrow its queue with. Mirrors `WorkSelector`. */
 export interface RegistrationQuerySelector {
@@ -44,6 +44,10 @@ export interface RegistrationPollPlan {
   readonly repo: string;
   readonly labels: readonly string[];
   readonly creator?: string;
+  readonly counter_labels: {
+    readonly ready: string;
+    readonly human: string;
+  };
 }
 
 /**
@@ -84,7 +88,8 @@ export function buildRegistrationQuery(input: RegistrationQueryInput): string {
 export function buildRegistrationPollPlan(input: RegistrationQueryInput): RegistrationPollPlan {
   const [owner, repo] = requireRepo(input.repo);
   const selector = input.selector ?? {};
-  const labels = [input.readyLabel ?? LABEL_READY];
+  const readyLabel = input.readyLabel ?? LABEL_READY;
+  const labels = [readyLabel];
   if (selector.lane != null && selector.lane !== "") labels.push(`lane:${selector.lane}`);
   if (selector.label != null && selector.label !== "") labels.push(selector.label);
   for (const tag of selector.tags ?? []) {
@@ -93,7 +98,15 @@ export function buildRegistrationPollPlan(input: RegistrationQueryInput): Regist
   const creator = selector.user != null && selector.user !== "" && selector.user !== "@me"
     ? selector.user
     : undefined;
-  return { owner, repo, labels, ...(creator === undefined ? {} : { creator }) };
+  return {
+    owner,
+    repo,
+    labels,
+    ...(creator === undefined ? {} : { creator }),
+    // Both names cross the registration boundary. The daemon compares them to
+    // tracker data but never learns what makes either one a workflow queue.
+    counter_labels: { ready: readyLabel, human: LABEL_HUMAN },
+  };
 }
 
 /**

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -239,6 +239,7 @@ describe("starting work registers the project", () => {
       owner: "acme",
       repo: "widgets",
       labels: ["ready-for-agent", "lane:go"],
+      counter_labels: { ready: "ready-for-agent", human: "ready-for-human" },
     });
     expect(started.warnings).toEqual([expect.stringContaining("issues")]);
     // The argv is what runs when a Worker is born for this project, so it carries

--- a/apps/dev/tests/registration-query.test.ts
+++ b/apps/dev/tests/registration-query.test.ts
@@ -45,6 +45,7 @@ describe("the query a registration hands the host", () => {
       repo: "widgets",
       labels: ["ready-for-agent", "lane:go", "type:ticket", "tag:alpha", "tag:beta"],
       creator: "octocat",
+      counter_labels: { ready: "ready-for-agent", human: "ready-for-human" },
     });
   });
 

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -117,10 +117,10 @@ import { commandOp, evaluateSessionReach, type RedskilledSessionOp } from "../se
 import {
   assertOneHostToken,
   DEFAULT_REDSKILLED_ACTIVITY_MS,
-  fetchRepositoryActivity,
   type RedskilledRepositoryActivity,
 } from "../repository-activity.js";
 import { createRedskilledActivityPoller } from "./activity-poller.js";
+import { pollRegistrationActivity } from "./registration-activity.js";
 import { REDSKILLED_ACTIVITY_STALENESS_FACTOR } from "../activity-report.js";
 import {
   DEFAULT_REDSKILLED_QUEUE_MS,
@@ -511,7 +511,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     registrations: () => registrations.values(),
     clock,
     attendedMs: activityMs,
-    armed: activityRegistration != null && activityRegistration.projects.length > 0,
+    armed: queueRegistration != null || (activityRegistration != null && activityRegistration.projects.length > 0),
     stopping: () => stopping,
   });
   let resolveClosed!: () => void;
@@ -763,15 +763,15 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
    * to pass for current, because the failure is itself the fact a consumer needs.
    */
   async function pollRepositoryActivity(): Promise<RedskilledRepositoryActivity | null> {
-    if (activityRegistration == null || activityRegistration.projects.length === 0) return null;
-    lastActivity = await fetchRepositoryActivity({
-      projects: activityRegistration.projects,
-      hostTokenRef: activityRegistration.hostTokenRef,
-      transport: activityRegistration.transport,
-      closedWindowMs: activityRegistration.closedWindowMs,
+    return lastActivity = await pollRegistrationActivity({
+      ...(activityRegistration == null ? {} : { explicit: activityRegistration }),
+      registrations: registrations.values(),
+      resolveHostTransport: () => {
+        armQueueTransport();
+        return queueTransport;
+      },
       now: clock(),
     });
-    return lastActivity;
   }
 
   /**

--- a/apps/redskilled/src/daemon/registration-activity.ts
+++ b/apps/redskilled/src/daemon/registration-activity.ts
@@ -1,0 +1,62 @@
+/**
+ * Adapt live project registrations to the repository-activity poll.
+ *
+ * The project authors repository coordinates and counter-label names; the
+ * daemon only copies those strings into the budget-aware tracker request.
+ */
+import type { RedskilledProjectRegistration } from "../project-registration.js";
+import {
+  fetchRepositoryActivity,
+  type RedskilledActivityTransport,
+  type RedskilledProjectRepository,
+  type RedskilledRepositoryActivity,
+} from "../repository-activity.js";
+
+interface ExplicitActivityRegistration {
+  readonly projects: readonly RedskilledProjectRepository[];
+  readonly hostTokenRef: string;
+  readonly transport: RedskilledActivityTransport;
+  readonly closedWindowMs?: number;
+}
+
+export interface RegistrationActivityPollInput {
+  readonly explicit?: ExplicitActivityRegistration;
+  readonly registrations: Iterable<RedskilledProjectRegistration>;
+  readonly resolveHostTransport: () => RedskilledActivityTransport | undefined;
+  readonly now: string;
+}
+
+/** Fetch one cycle, or return honest absence when no registration can be polled. */
+export async function pollRegistrationActivity(
+  input: RegistrationActivityPollInput,
+): Promise<RedskilledRepositoryActivity | null> {
+  const projects = input.explicit?.projects ?? registeredActivityProjects(input.registrations);
+  if (projects.length === 0) return null;
+  const transport = input.explicit?.transport ?? input.resolveHostTransport();
+  if (transport == null) return null;
+  return await fetchRepositoryActivity({
+    projects,
+    hostTokenRef: input.explicit?.hostTokenRef ?? "host",
+    transport,
+    ...(input.explicit?.closedWindowMs == null ? {} : { closedWindowMs: input.explicit.closedWindowMs }),
+    now: input.now,
+  });
+}
+
+/** Repository plans stated by current registrations, ordered like host state. */
+function registeredActivityProjects(
+  registrations: Iterable<RedskilledProjectRegistration>,
+): readonly RedskilledProjectRepository[] {
+  return [...registrations]
+    .flatMap((registration): readonly RedskilledProjectRepository[] => {
+      const poll = registration.queue_poll;
+      if (poll == null) return [];
+      return [{
+        project_label: registration.project_label,
+        owner: poll.owner,
+        name: poll.repo,
+        ...(poll.counter_labels == null ? {} : { queue_labels: poll.counter_labels }),
+      }];
+    })
+    .sort((left, right) => left.project_label.localeCompare(right.project_label));
+}

--- a/apps/redskilled/src/project-registration.ts
+++ b/apps/redskilled/src/project-registration.ts
@@ -111,6 +111,11 @@ export interface RedskilledQueuePollPlan {
   readonly repo: string;
   readonly labels: readonly string[];
   readonly creator?: string;
+  readonly counter_labels?: RedskilledCounterLabels;
+}
+
+export interface RedskilledCounterLabels {
+  readonly ready: string; readonly human: string;
 }
 
 /** The remote branch whose fetched commit becomes every admitted Worker's fork. */
@@ -775,7 +780,10 @@ function isQueuePollPlanShape(value: unknown): value is RedskilledQueuePollPlan 
     Array.isArray(plan.labels) &&
     plan.labels.length > 0 &&
     plan.labels.every((label) => typeof label === "string" && label !== "") &&
-    (plan.creator === undefined || typeof plan.creator === "string");
+    (plan.creator === undefined || typeof plan.creator === "string") && (plan.counter_labels === undefined ||
+      (typeof plan.counter_labels === "object" && plan.counter_labels !== null &&
+        typeof (plan.counter_labels as Record<string, unknown>).ready === "string" && (plan.counter_labels as Record<string, unknown>).ready !== "" &&
+        typeof (plan.counter_labels as Record<string, unknown>).human === "string" && (plan.counter_labels as Record<string, unknown>).human !== ""));
 }
 
 /** True when `value` is a map of strings to strings — a launch env's whole shape. */

--- a/apps/redskilled/tests/registration-counter-poll.test.ts
+++ b/apps/redskilled/tests/registration-counter-poll.test.ts
@@ -1,0 +1,137 @@
+// A real project registration must arm both tracker polls (#3605).
+//
+// The selector poll already receives the daemon's host-scoped transport. The
+// activity poll used to require a separate boot-only project list, so the
+// ordinary project_start/MCP registration could never produce remote counters.
+// This test poses the shipped boundary: real daemon, real socket registration,
+// production budget-aware transport, and one tracker standing in for GitHub.
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { registerRedskilledProject } from "../src/client.js";
+import { REDSKILLED_HOST_TOKEN_ENV, resolveServeQueueDiscovery } from "../src/cli.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+const servers: Server[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const server of servers.splice(0)) await new Promise<void>((resolve) => server.close(() => resolve()));
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-counter-supply-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+async function trackerStandingIn(): Promise<{
+  readonly url: string;
+  readonly requests: Array<{ readonly path: string; readonly authorization: string | undefined }>;
+}> {
+  const requests: Array<{ path: string; authorization: string | undefined }> = [];
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://tracker.invalid");
+    requests.push({ path: `${url.pathname}?${url.searchParams.toString()}`, authorization: req.headers.authorization });
+
+    let body: readonly Record<string, unknown>[];
+    if (url.pathname.endsWith("/pulls")) {
+      body = [{ number: 1 }, { number: 2 }];
+    } else if (url.searchParams.get("state") === "closed") {
+      body = [{ number: 20, closed_at: "2026-08-11T12:00:00.000Z" }];
+    } else if (url.searchParams.has("labels")) {
+      body = [{ number: 10, labels: [{ name: "ready-for-agent" }] }];
+    } else {
+      body = [
+        { number: 10, labels: [{ name: "ready-for-agent" }] },
+        { number: 11, labels: [{ name: "ready-for-human" }] },
+        { number: 12, labels: [] },
+      ];
+    }
+    res.writeHead(200, {
+      "content-type": "application/json",
+      etag: `"${requests.length}"`,
+      "x-ratelimit-remaining": "4900",
+    });
+    res.end(JSON.stringify(body));
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return { url: `http://127.0.0.1:${(server.address() as AddressInfo).port}/graphql`, requests };
+}
+
+describe("the registration supplies the remote-counter poll", () => {
+  it("fills the dated counters in one poll cycle through the selector's transport", async () => {
+    const tracker = await trackerStandingIn();
+    const paths = await sessionPaths();
+    const queueDiscovery = resolveServeQueueDiscovery(
+      { "queue-endpoint": tracker.url },
+      { [REDSKILLED_HOST_TOKEN_ENV]: "shared-host-token" },
+    );
+    const daemon = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      idleMs: 60_000,
+      demandMs: 0,
+      queueDiscovery: { ...queueDiscovery, intervalMs: 0 },
+    });
+    running.push(daemon);
+
+    // No registration means no repository and no invented zero or fetch.
+    const absent = daemon.statuslinePayload();
+    expect(absent.repository_activity.fetched_at).toBeNull();
+    expect(absent.remote_counters?.projects).toEqual([]);
+    expect(tracker.requests).toHaveLength(0);
+
+    // Both label names are project-authored. The daemon compares strings but
+    // never learns what either label means.
+    const queuePoll = {
+      owner: "acme",
+      repo: "widgets",
+      labels: ["ready-for-agent"],
+      counter_labels: { ready: "ready-for-agent", human: "ready-for-human" },
+    };
+    await registerRedskilledProject(paths, {
+      project_label: "acme/widgets",
+      selector: "repo:acme/widgets is:issue is:open label:ready-for-agent",
+      queue_poll: queuePoll,
+      argv: [process.execPath, "worker.mjs"],
+      workspace_path: "/workspace/acme/widgets",
+      target: 0,
+    }, { readyTimeoutMs: 5_000 });
+
+    await daemon.pollQueueDiscovery();
+    await daemon.pollRepositoryActivity();
+
+    const payload = daemon.statuslinePayload();
+    const counters = payload.remote_counters!.projects[0]!.counters;
+    expect(counters.open_pull_requests).toMatchObject({ value: 2, fetched_at: expect.any(String) });
+    expect(counters.open_issues).toMatchObject({ value: 3, fetched_at: expect.any(String) });
+    expect(counters.ready_queue).toMatchObject({ value: 1, fetched_at: expect.any(String) });
+    expect(counters.human_queue).toMatchObject({ value: 1, fetched_at: expect.any(String) });
+    expect(payload.repository_activity.projects[0]).toMatchObject({
+      counts: { recently_closed: 1 },
+      fetched_at: expect.any(String),
+    });
+
+    // One selector list plus the activity cycle's three lists. Payload reads
+    // remain cache-only, and every request used the one registration transport.
+    daemon.statuslinePayload();
+    daemon.statuslinePayload();
+    expect(tracker.requests).toHaveLength(4);
+    expect(tracker.requests.every((request) => request.authorization === "token shared-host-token")).toBe(true);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3605. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3605

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789055130&installation_model_id=20659&pr_number=3621&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3621&signature=92ddb51d41568ca942be2986fad1e72d71d465ed7492982797ec9280eebb8441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->