### PR TITLE
chore: #3597 Core dumps are capped: LimitCORE=0 on units and ulimit wrap for unisolated

### DIFF
--- a/apps/redskilled/src/posix-limits.ts
+++ b/apps/redskilled/src/posix-limits.ts
@@ -139,32 +139,35 @@ export function planPosixLimits(
 /**
  * The shell argv that applies these limits and then becomes the Worker. PURE.
  *
- * The command and its arguments ride as `"$0"` and `"$@"` rather than being
+ * The command and its arguments ride after a `--` placeholder and are executed
+ * as `"$@"` rather than being
  * interpolated into the script, so a workspace, a flag or a path containing
  * spaces or quotes is passed through byte-for-byte — a launcher that quoted its
  * own payload into a script would be one argument away from running something
  * else. `exec` is what makes the shell disappear: the Worker keeps the pid the
- * daemon sampled and there is no extra process between it and its limits.
+ * daemon sampled and there is no extra process between it and its limits. The
+ * core-dump cap is unconditional; callers without any other POSIX limits use the
+ * same argv shape with `limits` absent.
  */
 export function posixLimitsShellArgv(input: {
-  readonly limits: RedskilledPosixLimits;
+  readonly limits?: RedskilledPosixLimits;
   readonly nice: string | null;
   readonly command: string;
   readonly args: readonly string[];
 }): readonly string[] {
   const { limits } = input;
-  const lines: string[] = [];
+  const lines = ["ulimit -c 0"];
   // A ulimit the host refuses (a hard limit already lower) prints and continues:
   // a Worker that never started because it could not lower a soft limit would be
   // a worse outcome than one running under the limit it inherited.
-  if (limits.max_processes != null) lines.push(`ulimit -u ${limits.max_processes}`);
-  if (limits.cpu_seconds != null) lines.push(`ulimit -t ${limits.cpu_seconds}`);
+  if (limits?.max_processes != null) lines.push(`ulimit -u ${limits.max_processes}`);
+  if (limits?.cpu_seconds != null) lines.push(`ulimit -t ${limits.cpu_seconds}`);
   lines.push(
-    limits.nice != null && input.nice != null
-      ? `exec ${quote(input.nice)} -n ${limits.nice} "$0" "$@"`
-      : 'exec "$0" "$@"',
+    limits?.nice != null && input.nice != null
+      ? `exec ${quote(input.nice)} -n ${limits.nice} "$@"`
+      : 'exec "$@"',
   );
-  return ["-c", lines.join("\n"), input.command, ...input.args];
+  return ["-c", lines.join("\n"), "--", input.command, ...input.args];
 }
 
 /**

--- a/apps/redskilled/src/posix-limits.ts
+++ b/apps/redskilled/src/posix-limits.ts
@@ -1,5 +1,5 @@
 /**
- * posix-limits — the macOS placement backend, and the ceiling it refuses to claim.
+ * posix-limits — the POSIX launch boundary and the macOS limits it can carry.
  *
  * **macOS has no resource-group equivalent, and this backend does not pretend
  * otherwise.** Linux gets a cgroup through a transient unit and Windows gets a
@@ -18,7 +18,9 @@
  * **An rlimit is set only where it behaves predictably.** `ulimit -u` and
  * `ulimit -t` are carried when a client declares them and dropped, by name, when
  * the declared value cannot become one — never silently rounded into something
- * nobody asked for.
+ * nobody asked for. `ulimit -c 0` is unconditional: the same shell argv is also
+ * used by unisolated Linux Workers, so neither POSIX launch leaves a core dump
+ * behind.
  *
  * PURE, entirely: the host is read in `worker-placement`'s probe and nowhere here,
  * which is what lets every case be proven on a machine that is not a Mac.

--- a/apps/redskilled/src/provision.ts
+++ b/apps/redskilled/src/provision.ts
@@ -431,6 +431,7 @@ export function renderRedskilledUserUnit(input: RedskilledUserUnitInput): string
     "",
     "[Service]",
     "Type=simple",
+    "LimitCORE=0",
     `ExecStart=${input.command} serve${socketFlag}`,
     "Restart=always",
     "RestartSec=2",

--- a/apps/redskilled/src/supervision.ts
+++ b/apps/redskilled/src/supervision.ts
@@ -124,6 +124,7 @@ function renderUnit(command: string, args: readonly string[], paths: RedskilledP
     "",
     "[Service]",
     "Type=simple",
+    "LimitCORE=0",
     `ExecStart=${[command, ...args].map(quoteUnitWord).join(" ")}`,
     // The whole reason the unit exists: a daemon that dies comes back without a
     // client having to want work first.

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -394,6 +394,7 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
     "--wait",
     `--unit=${unit}`,
     `--working-directory=${opts.workspacePath}`,
+    "--property=LimitCORE=0",
   ];
   // `--pipe` connects the unit's stdio to this process's, which is what makes an
   // inherited log fd reach the Worker at all. Without it a transient unit writes

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -193,9 +193,7 @@ export function detectWorkerPlacementProbes(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
 ): WorkerPlacementProbes {
-  const noPosix = posixLimitsUnavailable(
-    `POSIX rlimit and priority placement is the macOS backend (platform=${platform})`,
-  );
+  const noPosix = posixLimitsUnavailable(`POSIX shell placement is unavailable on platform=${platform}`);
   if (platform === "win32") {
     return {
       platform,
@@ -221,7 +219,7 @@ export function detectWorkerPlacementProbes(
     systemdRun: which("systemd-run", env),
     userSession,
     jobObjects: noJobObjects,
-    posix: noPosix,
+    posix: detectPosixReach(env),
   };
 }
 
@@ -341,27 +339,36 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
   const declaredBudget = budget.memory_high != null || budget.memory_max != null || budget.cpu_weight != null;
   const target = opts.target ?? { isolation: "transient-unit" as const };
 
-  const unisolated = (warning: string): WorkerPlacementPlan => ({
-    isolated: false,
-    backend: "none",
-    command: opts.command,
-    args,
-    cwd: opts.workspacePath,
-    warning,
-    budget,
-    ...(ceilingValue != null ? { memoryCeiling: ceilingValue } : {}),
-    // The Worker still learns its ceiling here, and learns WHY it has no scope:
-    // an unscoped death that named neither would be the silent degradation this
-    // whole module refuses.
-    environment: workerPlacementEnvironment(opts, {
-      scope: null,
-      memory_ceiling: ceilingValue,
-      scope_degradation: warning,
-    }),
-    ...(declaredBudget
-      ? { budgetWarning: "a budget was declared but this placement cannot enforce it: the daemon's RSS sampling is the only remaining floor" }
-      : {}),
-  });
+  const unisolated = (isolationWarning: string): WorkerPlacementPlan => {
+    const reach = opts.probes.posix;
+    const coreLimited = opts.probes.platform === "linux" && reach.available;
+    const warning = opts.probes.platform === "linux" && !reach.available
+      ? `${isolationWarning}; core dumps are not capped because ${reach.reason}`
+      : isolationWarning;
+    return {
+      isolated: false,
+      backend: "none",
+      command: coreLimited ? reach.shell : opts.command,
+      args: coreLimited
+        ? posixLimitsShellArgv({ nice: null, command: opts.command, args })
+        : args,
+      cwd: opts.workspacePath,
+      warning,
+      budget,
+      ...(ceilingValue != null ? { memoryCeiling: ceilingValue } : {}),
+      // The Worker still learns its ceiling here, and learns WHY it has no scope:
+      // an unscoped death that named neither would be the silent degradation this
+      // whole module refuses.
+      environment: workerPlacementEnvironment(opts, {
+        scope: null,
+        memory_ceiling: ceilingValue,
+        scope_degradation: warning,
+      }),
+      ...(declaredBudget
+        ? { budgetWarning: "a budget was declared but this placement cannot enforce it: the daemon's RSS sampling is the only remaining floor" }
+        : {}),
+    };
+  };
 
   if (target.isolation === "inherit") {
     return unisolated("placement target is `inherit`: the Worker is charged to the daemon's own resource group, so a memory-pressure kill can land on the daemon and every Worker it holds");

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -59,17 +59,16 @@ export interface WorkerPlacementProbes {
    */
   readonly jobObjects: RedskilledJobObjectReach;
   /**
-   * Whether POSIX rlimits and priority are reachable here, and when not, why.
+   * Whether the POSIX shell launch boundary is reachable here, and when not, why.
    *
-   * The macOS arm of the same shape `jobObjects` has, for the same reason: this
-   * backend is the one that adds real teeth without adding a memory ceiling, so
-   * a host that cannot even reach it must degrade with a sentence rather than a
-   * flag.
+   * macOS uses it for rlimits and priority; unisolated Linux uses the same argv
+   * boundary to disable core dumps. A host that cannot reach it must degrade
+   * with a sentence rather than a flag.
    */
   readonly posix: RedskilledPosixReach;
 }
 
-/** The POSIX shell a macOS launch wraps itself in. Present on every Unix host. */
+/** The POSIX shell a launch wraps itself in when the host actually has it. */
 export const POSIX_SHELL_PATH = "/bin/sh";
 
 /**
@@ -319,8 +318,9 @@ export interface PlanWorkerPlacementOptions {
  *
  * When the host affords it, the Worker runs under a transient
  * `<prefix>-<project>-<worker>.service` carrying the budget as unit properties.
- * Otherwise the original argv is returned unchanged WITH a warning — the launch
- * still happens, but a downgrade is never silent.
+ * An unisolated Linux launch still crosses the POSIX shell boundary to disable
+ * core dumps; without that shell the original argv is returned WITH a warning.
+ * The launch still happens, but a downgrade is never silent.
  */
 export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPlacementPlan {
   const args = [...(opts.args ?? [])];

--- a/apps/redskilled/tests/macos-posix-limits.test.ts
+++ b/apps/redskilled/tests/macos-posix-limits.test.ts
@@ -84,8 +84,12 @@ describe("macOS placement — resolved from probes, with nothing spawned", () =>
     expect(placement.command).toBe("/bin/sh");
     expect(placement.args.slice(-4)).toEqual(["/usr/bin/node", "worker.js", "--issue", "2782"]);
     expect(placement.args[0]).toBe("-c");
-    expect(placement.args[1]).toMatch(/exec '\/usr\/bin\/nice' -n \d+ "\$0" "\$@"/);
+    expect(placement.args[1]).toMatch(/exec '\/usr\/bin\/nice' -n \d+ "\$@"/);
     expect(placement.cwd).toBe("/given/workspace");
+  });
+
+  it("disables core dumps before applying the remaining POSIX launch controls", () => {
+    expect(plan(DARWIN).args[1]).toMatch(/^ulimit -c 0\n/);
   });
 
   it("reads the host once, in the probe, and never on the planning path", () => {
@@ -228,7 +232,7 @@ describe("macOS placement — priority control, the tooth this backend really ha
     const placement = plan(DARWIN_WITHOUT_NICE);
 
     expect(placement.posix?.nice).toBeUndefined();
-    expect(placement.args[1]).toContain('exec "$0" "$@"');
+    expect(placement.args[1]).toContain('exec "$@"');
     expect(placement.warning).toMatch(/no priority control/);
   });
 

--- a/apps/redskilled/tests/provision.test.ts
+++ b/apps/redskilled/tests/provision.test.ts
@@ -345,6 +345,7 @@ describe("the optional supervising unit", () => {
     });
 
     expect(unit).toContain("Restart=always");
+    expect(unit).toContain("LimitCORE=0");
     expect(unit).toContain("StartLimitIntervalSec=60");
     expect(unit).toContain("StartLimitBurst=5");
     expect(unit).toContain("ExecStart=/usr/bin/node /bundles/redskilled.bundle.min.mjs serve");

--- a/apps/redskilled/tests/self-supervision.test.ts
+++ b/apps/redskilled/tests/self-supervision.test.ts
@@ -172,6 +172,7 @@ describe("the user unit that supervises the daemon", () => {
     }
     // The whole reason the unit exists.
     expect(plan.text).toContain("Restart=always");
+    expect(plan.text).toContain("LimitCORE=0");
     expect(plan.text).toContain("StartLimitIntervalSec=60");
     expect(plan.text).toContain("StartLimitBurst=5");
     expect(plan.text).toContain(`Environment="${REDSKILLED_SUPERVISED_ENV}=1"`);

--- a/apps/redskilled/tests/worker-placement.test.ts
+++ b/apps/redskilled/tests/worker-placement.test.ts
@@ -116,11 +116,13 @@ describe("worker placement — Linux with a user session", () => {
       budget: { max_processes: 32, cpu_seconds: 60 },
     });
     const absent = plan(LINUX_WITH_SESSION, { budget: { cpu_seconds: 60 } });
+    const declaredPlacementArgs = declared.args.slice(0, declared.args.indexOf("--"));
+    const absentPlacementArgs = absent.args.slice(0, absent.args.indexOf("--"));
 
-    expect(declared.args.filter((arg) => arg.startsWith("--property=TasksMax="))).toEqual([
+    expect(declaredPlacementArgs.filter((arg) => arg.startsWith("--property=TasksMax="))).toEqual([
       "--property=TasksMax=32",
     ]);
-    expect(absent.args.some((arg) => arg.startsWith("--property=TasksMax="))).toBe(false);
+    expect(absentPlacementArgs.some((arg) => arg.startsWith("--property=TasksMax="))).toBe(false);
     expect(declared.budgetWarning).toMatch(/cpu_seconds/);
     expect(declared.budgetWarning).not.toMatch(/max_processes/);
   });

--- a/apps/redskilled/tests/worker-placement.test.ts
+++ b/apps/redskilled/tests/worker-placement.test.ts
@@ -97,6 +97,18 @@ describe("worker placement — Linux with a user session", () => {
     expect(placement.budgetWarning).toBeUndefined();
   });
 
+  it("disables core dumps independently of the declared budget", () => {
+    const declared = plan(LINUX_WITH_SESSION);
+    const absent = plan(LINUX_WITH_SESSION, { budget: undefined });
+
+    for (const placement of [declared, absent]) {
+      const separator = placement.args.indexOf("--");
+      expect(placement.args.slice(0, separator).filter((arg) => arg.startsWith("--property=LimitCORE="))).toEqual([
+        "--property=LimitCORE=0",
+      ]);
+    }
+  });
+
   it("carries max_processes as TasksMax exactly when it is declared", () => {
     const declared = plan(LINUX_WITH_SESSION, {
       budget: { max_processes: 32, cpu_seconds: 60 },

--- a/apps/redskilled/tests/worker-placement.test.ts
+++ b/apps/redskilled/tests/worker-placement.test.ts
@@ -15,29 +15,31 @@ import {
 
 const NO_JOB_OBJECTS = { available: false, reason: "Job Object placement is the Windows backend (platform=linux)" } as const;
 
-const NO_POSIX = { available: false, reason: "POSIX rlimit and priority placement is the macOS backend (platform=linux)" } as const;
+const LINUX_POSIX = { available: true, shell: "/bin/sh", nice: null } as const;
+const NO_POSIX = { available: false, reason: "no POSIX shell was found at /bin/sh" } as const;
 
 const LINUX_WITH_SESSION: WorkerPlacementProbes = {
   platform: "linux",
   systemdRun: "/usr/bin/systemd-run",
   userSession: true,
   jobObjects: NO_JOB_OBJECTS,
-  posix: NO_POSIX,
+  posix: LINUX_POSIX,
 };
 const LINUX_WITHOUT_SESSION: WorkerPlacementProbes = {
   platform: "linux",
   systemdRun: "/usr/bin/systemd-run",
   userSession: false,
   jobObjects: NO_JOB_OBJECTS,
-  posix: NO_POSIX,
+  posix: LINUX_POSIX,
 };
 const LINUX_WITHOUT_SYSTEMD: WorkerPlacementProbes = {
   platform: "linux",
   systemdRun: null,
   userSession: false,
   jobObjects: NO_JOB_OBJECTS,
-  posix: NO_POSIX,
+  posix: LINUX_POSIX,
 };
+const LINUX_WITHOUT_SHELL: WorkerPlacementProbes = { ...LINUX_WITHOUT_SYSTEMD, posix: NO_POSIX };
 // An OS with neither backend: the case that proves an unknown platform still
 // launches and still says what it gave up. macOS has its own backend now, so it
 // is no longer the example of a host with nothing.
@@ -147,8 +149,16 @@ describe("worker placement — Linux without a user session", () => {
     const placement = plan(LINUX_WITHOUT_SESSION);
 
     expect(placement.isolated).toBe(false);
-    expect(placement.command).toBe("/usr/bin/node");
-    expect(placement.args).toEqual(["worker.js", "--issue", "2774"]);
+    expect(placement.command).toBe("/bin/sh");
+    expect(placement.args).toEqual([
+      "-c",
+      'ulimit -c 0\nexec "$@"',
+      "--",
+      "/usr/bin/node",
+      "worker.js",
+      "--issue",
+      "2774",
+    ]);
     expect(placement.cwd).toBe("/given/workspace");
     expect(placement.unit).toBeUndefined();
     expect(placement.warning).toMatch(/no systemd --user session/);
@@ -161,6 +171,15 @@ describe("worker placement — Linux without a user session", () => {
 
   it("warns about the missing binary when systemd-run is not on PATH", () => {
     expect(plan(LINUX_WITHOUT_SYSTEMD).warning).toMatch(/systemd-run is not on PATH/);
+  });
+
+  it("degrades loudly when /bin/sh is absent and cannot cap core dumps", () => {
+    const placement = plan(LINUX_WITHOUT_SHELL);
+
+    expect(placement.command).toBe("/usr/bin/node");
+    expect(placement.args).toEqual(["worker.js", "--issue", "2774"]);
+    expect(placement.warning).toMatch(/core dumps are not capped/);
+    expect(placement.warning).toMatch(/no POSIX shell/);
   });
 });
 

--- a/apps/redskilled/tests/wsl2-host.test.ts
+++ b/apps/redskilled/tests/wsl2-host.test.ts
@@ -153,9 +153,10 @@ describe("WSL2 — the probes a host without systemd answers", () => {
     // Worker would inherit, and the session is proven by its private socket.
     expect(probes.systemdRun).toBeNull();
     expect(probes.userSession).toBe(false);
-    // The other two backends belong to other platforms, and each says which.
+    // Job Objects belong to another platform. The POSIX shell is still reachable
+    // here because an unisolated Linux launch uses it to disable core dumps.
     expect(probes.jobObjects.available).toBe(false);
-    expect(probes.posix.available).toBe(false);
+    expect(probes.posix).toMatchObject({ available: true, shell: "/bin/sh" });
   });
 
   it("still finds no session when XDG_RUNTIME_DIR names a directory with no systemd socket in it", async () => {
@@ -171,7 +172,7 @@ describe("WSL2 — the probes a host without systemd answers", () => {
 describe("WSL2 — a Worker is born, unisolated, and the loss is named", () => {
   const WSL2_PROBES = detectWorkerPlacementProbes(WSL2_ENV, "linux");
 
-  it("plans an unwrapped launch and names systemd-run as what it could not reach", () => {
+  it("wraps the unisolated launch to disable core dumps and names the isolation it lost", () => {
     const plan = planWorkerPlacement({
       workerId: "wWSL2",
       projectLabel: "acme/widgets",
@@ -184,9 +185,14 @@ describe("WSL2 — a Worker is born, unisolated, and the loss is named", () => {
 
     expect(plan.backend).toBe("none");
     expect(plan.isolated).toBe(false);
-    // The argv is the caller's own, untouched — there is no launcher to wrap it in.
-    expect(plan.command).toBe("/usr/bin/node");
-    expect(plan.args).toEqual(["worker.js"]);
+    expect(plan.command).toBe("/bin/sh");
+    expect(plan.args).toEqual([
+      "-c",
+      'ulimit -c 0\nexec "$@"',
+      "--",
+      "/usr/bin/node",
+      "worker.js",
+    ]);
     expect(plan.cwd).toBe("/home/wsluser/acme");
     expect(plan.unit).toBeUndefined();
     expect(plan.warning).toMatch(/systemd-run is not on PATH/);
@@ -209,7 +215,7 @@ describe("WSL2 — a Worker is born, unisolated, and the loss is named", () => {
         command: process.execPath,
         args: [
           "-e",
-          "require('node:fs').writeFileSync('proof.json', JSON.stringify({ cwd: process.cwd(), worker_id: process.env.RED_WORKER_ID, born_at: process.env.RED_WORKER_BORN_AT })); setTimeout(() => {}, 250);",
+          "const { execFileSync } = require('node:child_process'); require('node:fs').writeFileSync('proof.json', JSON.stringify({ cwd: process.cwd(), worker_id: process.env.RED_WORKER_ID, born_at: process.env.RED_WORKER_BORN_AT, core_limit: execFileSync('/bin/sh', ['-c', 'ulimit -c'], { encoding: 'utf8' }).trim() })); setTimeout(() => {}, 250);",
         ],
         budget: { memory_max: "4G" },
       },
@@ -234,6 +240,7 @@ describe("WSL2 — a Worker is born, unisolated, and the loss is named", () => {
           cwd: workspace,
           worker_id: launched.worker.worker_id,
           born_at: launched.worker.started_at,
+          core_limit: "0",
         });
         return;
       } catch {


### PR DESCRIPTION
Automated AFK landing for #3597. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3597

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789056038&installation_model_id=20659&pr_number=3622&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3622&signature=162fd2e31b9dd0e5d11656d6282997a9630b43b7238ced42c17333206687b674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->