### PR TITLE
fix: #3641 Orphan-reaper authority: gate through maySweepMachine, honest report mode, no test-seam bypass

### DIFF
--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -1710,10 +1710,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     return dead;
   }
   const orphanReaper = createRedskilledOrphanReaperRuntime({
-    authorized: maySweepMachine(
-      paths.machineClaimPath,
-      paths.machineClaimPathOfThisHost,
-    ),
+    authorized: maySweepMachine(paths.machineClaimPath, paths.machineClaimPathOfThisHost),
     interval_ms: options.orphanReaperMs, mode: options.orphanReaperMode, census: options.orphanCensus, active_worker_units: unitInventory, dump_files: options.orphanDumpFiles,
     read_starttime: options.orphanStarttime, kill_group: options.orphanKillGroup, report: options.orphanReport,
     clock, held_worker_ids: () => workers.keys(), live_births: async () => rehydrateWorkers(await eventLane.read()),

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -63,7 +63,6 @@ import {
   currentMachineOwner,
   describeMachineScope,
   RedskilledMachineHeldError,
-  resolveMachineClaimPath,
 } from "../machine-scope.js";
 import { createRedskilledOrphanReaperRuntime } from "../orphan-reaper.js";
 import { workerSpecFromLaunch, type RedskilledLaunchTemplate } from "../launch-template.js";
@@ -332,7 +331,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const stopProbe = options.stopWorker ?? stopWorker;
   const unitInventory = options.unitInventory ??
     (() =>
-      maySweepMachine(paths.machineClaimPath, resolveMachineClaimPath({ machineIdHash: paths.machineIdHash }))
+      maySweepMachine(paths.machineClaimPath, paths.machineClaimPathOfThisHost)
         ? listActiveWorkerUnits()
         : []);
   const unitMainPid = options.unitMainPid ?? detectUnitMainPid;
@@ -1711,8 +1710,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     return dead;
   }
   const orphanReaper = createRedskilledOrphanReaperRuntime({
-    authorized: options.orphanCensus != null ||
-      paths.machineClaimPath === resolveMachineClaimPath({ machineIdHash: paths.machineIdHash }),
+    authorized: maySweepMachine(
+      paths.machineClaimPath,
+      paths.machineClaimPathOfThisHost,
+    ),
     interval_ms: options.orphanReaperMs, mode: options.orphanReaperMode, census: options.orphanCensus, active_worker_units: unitInventory, dump_files: options.orphanDumpFiles,
     read_starttime: options.orphanStarttime, kill_group: options.orphanKillGroup, report: options.orphanReport,
     clock, held_worker_ids: () => workers.keys(), live_births: async () => rehydrateWorkers(await eventLane.read()),

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -143,7 +143,7 @@ export interface RedskilledDaemonOptions {
   readonly orphanReaperMs?: number;
   /** Operator kill-switch posture; defaults from `REDSKILLED_ORPHAN_REAPER`. */
   readonly orphanReaperMode?: RedskilledOrphanReaperMode;
-  /** Process-table census seam; supplying it explicitly authorizes a fixture sweep. */
+  /** Process-table census seam; authority still comes only from the machine claim. */
   readonly orphanCensus?: () => readonly RedskilledProcessCensusRow[] | Promise<readonly RedskilledProcessCensusRow[]>;
   /** Crash/core dump census seam; detection only and never an unlink authority. */
   readonly orphanDumpFiles?: () => readonly string[] | Promise<readonly string[]>;

--- a/apps/redskilled/src/orphan-reaper.ts
+++ b/apps/redskilled/src/orphan-reaper.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { readdir, readFile, readlink } from "node:fs/promises";
 import { join, normalize, sep } from "node:path";
 import { killTreeAndWait } from "@reddb-io/shared/kill-tree.js";
@@ -74,11 +75,24 @@ export const REDSKILLED_STAMPED_ORPHAN_GRACE_MS = 10 * 60_000;
 /** An unstamped process needs a longer window because it cannot prove its origin. */
 export const REDSKILLED_UNSTAMPED_SUSPECT_GRACE_MS = 30 * 60_000;
 
-/** Linux `/proc` exposes process clocks at this stable USER_HZ. */
-const REDSKILLED_PROC_CLOCK_TICKS_PER_SECOND = 100;
-
 export interface RedskilledProcessCensusOptions {
   readonly proc_root?: string;
+  /** Host USER_HZ; injected only when the proc tree belongs to another kernel. */
+  readonly clock_ticks_per_second?: number;
+}
+
+let cachedProcClockTicksPerSecond: number | null | undefined;
+
+/** Read this kernel's USER_HZ once; an unreadable rate makes process ages unknowable. */
+function hostProcClockTicksPerSecond(): number | null {
+  if (cachedProcClockTicksPerSecond !== undefined) return cachedProcClockTicksPerSecond;
+  const probe = spawnSync("getconf", ["CLK_TCK"], { encoding: "utf8" });
+  const ticks = Number((probe.stdout ?? "").trim());
+  cachedProcClockTicksPerSecond =
+    probe.error == null && probe.status === 0 && Number.isFinite(ticks) && ticks > 0
+      ? ticks
+      : null;
+  return cachedProcClockTicksPerSecond;
 }
 
 export interface ReapStampedOrphanIO {
@@ -150,6 +164,8 @@ export async function censusRedskilledProcesses(
 ): Promise<RedskilledProcessCensusRow[]> {
   const root = options.proc_root ?? "/proc";
   try {
+    const clockTicksPerSecond = options.clock_ticks_per_second ?? hostProcClockTicksPerSecond();
+    if (clockTicksPerSecond == null || !Number.isFinite(clockTicksPerSecond) || clockTicksPerSecond <= 0) return [];
     const uptimeSeconds = Number((await readFile(join(root, "uptime"), "utf8")).trim().split(/\s+/)[0]);
     if (!Number.isFinite(uptimeSeconds) || uptimeSeconds < 0) return [];
     const entries = await readdir(root);
@@ -187,7 +203,7 @@ export async function censusRedskilledProcesses(
         starttime: parsed.starttime,
         age_ms: Math.max(
           0,
-          (uptimeSeconds - Number(parsed.starttime) / REDSKILLED_PROC_CLOCK_TICKS_PER_SECOND) * 1_000,
+          (uptimeSeconds - Number(parsed.starttime) / clockTicksPerSecond) * 1_000,
         ),
         ...(workerId == null ? {} : { worker_id: workerId }),
         ...(bornAt == null ? {} : { born_at: bornAt }),

--- a/apps/redskilled/src/paths.ts
+++ b/apps/redskilled/src/paths.ts
@@ -52,6 +52,8 @@ export interface RedskilledPaths {
   readonly eventLanePath: string;
   /** The durable project registrations a successor daemon rehydrates. */
   readonly registrationIntentPath: string;
+  /** The canonical claim path resolved for this host and resolver environment. */
+  readonly machineClaimPathOfThisHost: string;
   /**
    * The machine-wide claim: the one record every OS user of this host can read.
    *
@@ -115,6 +117,11 @@ export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = 
     uid: options.uid,
   });
   const machineIdHash = resolveMachineIdHash(options);
+  const machineClaimPathOfThisHost = resolveMachineClaimPath({
+    env: options.env,
+    machineIdHash,
+    platform: options.platform,
+  });
   const homeDir = options.homeDir
     ?? options.env?.HOME
     ?? (options.runtimeDir == null ? process.env.HOME : options.runtimeDir)
@@ -132,8 +139,8 @@ export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = 
     // the socket stranded every drain when one process resolved XDG_RUNTIME_DIR
     // and its successor used the uid fallback (or vice versa).
     registrationIntentPath: join(redskilledHomeDir(homeDir), "redskilled.registrations.toon"),
-    machineClaimPath: options.machineClaimPath ??
-      resolveMachineClaimPath({ env: options.env, machineIdHash, platform: options.platform }),
+    machineClaimPathOfThisHost,
+    machineClaimPath: options.machineClaimPath ?? machineClaimPathOfThisHost,
   };
 }
 

--- a/apps/redskilled/tests/orphan-reaper.test.ts
+++ b/apps/redskilled/tests/orphan-reaper.test.ts
@@ -145,6 +145,38 @@ describe("the orphan reaper process census", () => {
 });
 
 describe("stamped orphan teardown", () => {
+  it("does not let an injected census authorize a non-arbiter daemon", async () => {
+    const root = await scratch("redskilled-orphan-authority-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}` },
+      runtimeDir: root,
+      machineClaimPath: join(root, "sandbox-machine-claim.toon"),
+    });
+    const mutations = { census: 0, adopt: 0, kill: 0 };
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      unitInventory: () => [],
+      orphanReaperMs: 0,
+      orphanCensus: async () => {
+        mutations.census += 1;
+        return [processRow()];
+      },
+      orphanStarttime: () => {
+        mutations.adopt += 1;
+        return "1200";
+      },
+      orphanKillGroup: async () => {
+        mutations.kill += 1;
+        return true;
+      },
+    });
+    daemons.push(daemon);
+
+    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 0, reaped: 0, suspects: 0 });
+    expect(mutations).toEqual({ census: 0, adopt: 0, kill: 0 });
+  });
+
   it("refuses to signal when the leader starttime changed after the census", async () => {
     const signalled: number[] = [];
     await expect(reapStampedOrphan(processRow(), {

--- a/apps/redskilled/tests/orphan-reaper.test.ts
+++ b/apps/redskilled/tests/orphan-reaper.test.ts
@@ -6,6 +6,7 @@ import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { createRedskilledEventLane, readRedskilledEvents } from "../src/event-lane.js";
 import {
   censusRedskilledProcesses,
+  createRedskilledOrphanReaperRuntime,
   DEFAULT_REDSKILLED_ORPHAN_REAPER_MS,
   reapStampedOrphan,
   redskilledOrphanReaperMode,
@@ -145,6 +146,46 @@ describe("the orphan reaper process census", () => {
 });
 
 describe("stamped orphan teardown", () => {
+  it("keeps report mode free of daemon-map, signal and event-lane mutations", async () => {
+    const mutations = { adopt: 0, kill: 0, laneWrites: 0 };
+    const runtime = createRedskilledOrphanReaperRuntime({
+      authorized: true,
+      interval_ms: 0,
+      mode: "report",
+      census: () => [
+        processRow(),
+        processRow({ worker_id: "hLIVE", pid: 4_243, pgid: 4_243, age_ms: 1_000 }),
+      ],
+      clock: () => "2026-08-11T10:10:00.000Z",
+      held_worker_ids: () => [],
+      live_births: () => [{
+        worker_id: "hLIVE",
+        project_label: "acme/widgets",
+        pid: 4_000,
+        started_at: "2026-08-11T10:00:00.000Z",
+        workspace_path: "/old/workspace",
+        isolated: true,
+        warnings: [],
+      }],
+      read_starttime: () => "1200",
+      kill_group: async () => {
+        mutations.kill += 1;
+        return true;
+      },
+      report: () => undefined,
+      adopt: (_worker, recordBirth) => {
+        mutations.adopt += 1;
+        if (recordBirth) mutations.laneWrites += 1;
+      },
+      record_reaped: () => {
+        mutations.laneWrites += 1;
+      },
+    });
+
+    await expect(runtime.sweep()).resolves.toEqual({ adopted: 0, reaped: 0, suspects: 0 });
+    expect(mutations).toEqual({ adopt: 0, kill: 0, laneWrites: 0 });
+  });
+
   it("does not let an injected census authorize a non-arbiter daemon", async () => {
     const root = await scratch("redskilled-orphan-authority-");
     const paths = resolveRedskilledPaths({

--- a/apps/redskilled/tests/orphan-reaper.test.ts
+++ b/apps/redskilled/tests/orphan-reaper.test.ts
@@ -116,7 +116,7 @@ describe("the daemon orphan-reaper control", () => {
 });
 
 describe("the orphan reaper process census", () => {
-  it("reads stamp, cwd, pgid, sid and starttime for a reparented candidate", async () => {
+  it("reads stamp, identity and age using the host's clock-tick rate", async () => {
     const root = await scratch("redskilled-orphan-proc-");
     const processDir = join(root, "4242");
     const cwd = join(root, "repo", ".red", "tmp", "workers", "wLOST", "3589", "worktree");
@@ -131,10 +131,10 @@ describe("the orphan reaper process census", () => {
     );
     await symlink(cwd, join(processDir, "cwd"));
 
-    await expect(censusRedskilledProcesses({ proc_root: root })).resolves.toEqual([processRow({
+    await expect(censusRedskilledProcesses({ proc_root: root, clock_ticks_per_second: 250 })).resolves.toEqual([processRow({
       sid: 4000,
       starttime: "900000",
-      age_ms: 1_000_000,
+      age_ms: 6_400_000,
       cwd,
     })]);
   });


### PR DESCRIPTION
Automated AFK landing for #3641. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3641

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789066616&installation_model_id=20659&pr_number=3649&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3649&signature=2bed37c5b9ad4cc8f301178037b9c28fe665e531dd7eb3a5df5527dcfe185352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->