### PR TITLE
fix: #3651 event-lane readers skip undecodable historical rows instead of dying

### DIFF
--- a/apps/redskilled/src/event-lane-decode.ts
+++ b/apps/redskilled/src/event-lane-decode.ts
@@ -1,0 +1,45 @@
+/**
+ * event-lane-decode — the tolerant row decoder for the host event lane.
+ *
+ * A canonical append-only lane outlives daemon generations, so it can hold rows
+ * an older writer shaped differently (issue #3651: one 3.14.0 `demand-refusal`
+ * row disagreed with its own header's arity and a strict reader died on it,
+ * first killing dispatch, then wedging the daemon's own writer). A historical
+ * row that fails to decode is skipped and counted — never fatal to a live
+ * operation — and the skip is reported once, naming the lines, so a genuine
+ * format bug still has a voice.
+ */
+
+import { parseRecords, type ToonlRecord } from "@reddb-io/toon";
+
+export interface RedskilledDecodedLane {
+  readonly records: ToonlRecord[];
+  /** 1-indexed lines whose rows no governing header could decode. */
+  readonly malformed: number[];
+}
+
+/**
+ * Decode lane lines into records, skipping rows their header cannot hold. PURE
+ * over its input; the caller owns reporting the malformed count.
+ */
+export function decodeLaneRows(lines: readonly string[]): RedskilledDecodedLane {
+  const records: ToonlRecord[] = [];
+  const malformed: number[] = [];
+  let header: string | null = null;
+  for (const [index, line] of lines.entries()) {
+    if (/^\[\d*\]\{.*\}:$/.test(line)) {
+      header = line;
+      continue;
+    }
+    if (header == null) {
+      malformed.push(index + 1);
+      continue;
+    }
+    try {
+      records.push(...parseRecords(`${header}\n${line}\n`));
+    } catch {
+      malformed.push(index + 1);
+    }
+  }
+  return { records, malformed };
+}

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -29,7 +29,9 @@
  */
 import { appendFile, mkdir, open, readFile, rename, rm, stat, truncate, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
+import { encodeLines, type ToonlRecord } from "@reddb-io/toon";
+
+import { decodeLaneRows } from "./event-lane-decode.js";
 import {
   readPositionedEventLane,
   type EventLanePosition,
@@ -653,11 +655,8 @@ function isPublicHostEvent(event: RedskilledHostEvent): event is RedskilledPubli
 }
 
 /**
- * Decode a lane's text into events, dropping a crash-truncated tail. PURE.
- *
- * Only a line the writer never terminated is dropped, and only from the end: a
- * reader that skipped every line it could not decode would silently swallow a
- * genuine format bug in the middle of the lane as if it were a crash.
+ * Decode a lane's text into events: the crash-truncated tail is dropped, and
+ * historical rows no header can hold are skipped by `decodeLaneRows`. PURE.
  */
 export function parseEventLane(raw: string): RedskilledHostEvent[] {
   const lines = raw.split("\n");
@@ -665,24 +664,7 @@ export function parseEventLane(raw: string): RedskilledHostEvent[] {
   // that slot is the half-written line a crash left behind.
   lines.pop();
   if (lines.length === 0) return [];
-  const records: ToonlRecord[] = [];
-  const malformed: number[] = [];
-  let header: string | null = null;
-  for (const [index, line] of lines.entries()) {
-    if (/^\[\d*\]\{.*\}:$/.test(line)) {
-      header = line;
-      continue;
-    }
-    if (header == null) {
-      malformed.push(index + 1);
-      continue;
-    }
-    try {
-      records.push(...parseRecords(`${header}\n${line}\n`));
-    } catch {
-      malformed.push(index + 1);
-    }
-  }
+  const { records, malformed } = decodeLaneRows(lines);
   if (malformed.length > 0) {
     console.warn(`redskilled event lane skipped ${malformed.length} malformed row(s) at line ${malformed.join(", ")}`);
   }

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -665,7 +665,27 @@ export function parseEventLane(raw: string): RedskilledHostEvent[] {
   // that slot is the half-written line a crash left behind.
   lines.pop();
   if (lines.length === 0) return [];
-  const records = parseRecords(`${lines.join("\n")}\n`);
+  const records: ToonlRecord[] = [];
+  const malformed: number[] = [];
+  let header: string | null = null;
+  for (const [index, line] of lines.entries()) {
+    if (/^\[\d*\]\{.*\}:$/.test(line)) {
+      header = line;
+      continue;
+    }
+    if (header == null) {
+      malformed.push(index + 1);
+      continue;
+    }
+    try {
+      records.push(...parseRecords(`${header}\n${line}\n`));
+    } catch {
+      malformed.push(index + 1);
+    }
+  }
+  if (malformed.length > 0) {
+    console.warn(`redskilled event lane skipped ${malformed.length} malformed row(s) at line ${malformed.join(", ")}`);
+  }
   return records.filter(isHostEventRecord).map(fromRow);
 }
 

--- a/apps/redskilled/tests/event-lane-query.test.ts
+++ b/apps/redskilled/tests/event-lane-query.test.ts
@@ -1,10 +1,10 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   REDSKILLED_WORKER_EVENT_KINDS,
   createRedskilledEventLane,
@@ -63,6 +63,24 @@ function workerEvent(kind: RecordWorkerEventInput["kind"]): RecordWorkerEventInp
 }
 
 describe("queryable daemon worker-event log", () => {
+  it("skips and reports a historical mixed-arity row between schema segments", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-mixed-arity-"));
+    roots.push(root);
+    const path = join(root, "redskilled.log.toonl");
+    await createRedskilledEventLane(path).recordWorker(workerEvent("worker-birth"));
+    await createRedskilledEventLane(path).recordWorker({ ...workerEvent("worker-activity"), ts: "2026-08-05T09:01:00.000Z" });
+    const lines = (await readFile(path, "utf8")).trimEnd().split("\n");
+    lines.splice(1, 0, "1,bad,mixed-arity,row");
+    await writeFile(path, `${lines.join("\n")}\n`);
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const events = await createRedskilledEventLane(path).read();
+
+    expect(events.map((event) => event.kind)).toEqual(["worker-birth", "worker-activity"]);
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("1 malformed row(s)"));
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("line 2"));
+    warning.mockRestore();
+  });
   it("pins every worker record to the stable kind vocabulary", async () => {
     const root = await mkdtemp(join(tmpdir(), "redskilled-query-log-"));
     roots.push(root);


### PR DESCRIPTION
Closes #3651.

Worker hD4HG implemented and pushed this, then the feedback validation parked it as suspect-infra (repeated-signature) — the same classifier defect tracked in #3648, observed here on the fix for the OTHER half of the incident. Landing through the no-agent gate with CI as judge, per the standing pattern for infra-misclassified parks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789068333&installation_model_id=20659&pr_number=3661&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3661&signature=6d456c976856bc61d700804f1dc088923d6a43be07241293813daabb7ce35dcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->