### PR TITLE
fix: #3650 the janitor's worktree prune gains an expire grace and stops racing births

### DIFF
--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -798,12 +798,12 @@ export async function worktreeRemove(ctx: GitContext, path: string): Promise<voi
 }
 
 /**
- * Run `git worktree prune` to drop stale entries from git's internal worktree
- * registry after orphaned worktree dirs have been removed from disk. Best-effort:
- * never throws so a prune failure does not abort the janitor sweep.
+ * Drop stale registrations after orphaned dirs disappear. The one-hour expiry
+ * guards a sibling Worker whose `worktree add` is still materialising; failures
+ * remain best-effort so janitor sweeps never abort.
  */
 export async function worktreePrune(ctx: GitContext): Promise<void> {
-  await runGit(ctx, ["worktree", "prune"]);
+  await runGit(ctx, ["worktree", "prune", "--expire=1.hour.ago"]);
 }
 
 /** The GitExec executor for remote-branch.ts live-branch push/delete helpers. */

--- a/apps/dev/tests/runtime-git-worktree-prune.test.ts
+++ b/apps/dev/tests/runtime-git-worktree-prune.test.ts
@@ -1,0 +1,68 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readdir, rename, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { worktreePrune } from "../src/runtime/git.js";
+
+const execFileP = promisify(execFile);
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileP("git", args, {
+    cwd,
+    env: { ...process.env, LC_ALL: "C" },
+  });
+  return stdout.trim();
+}
+
+async function ageTree(path: string, date: Date): Promise<void> {
+  for (const entry of await readdir(path, { withFileTypes: true })) {
+    const child = join(path, entry.name);
+    if (entry.isDirectory()) await ageTree(child, date);
+    else await utimes(child, date, date);
+  }
+  await utimes(path, date, date);
+}
+
+describe("worktreePrune", () => {
+  it("preserves a sibling birth while reaping an aged stale registration", async () => {
+    const root = await mkdtemp(join(tmpdir(), "worktree-prune-grace-"));
+    const repo = join(root, "repo");
+    const youngWorktree = join(root, "young-birth");
+    const oldWorktree = join(root, "old-stale");
+    const pausedYoungWorktree = join(root, "paused-young-birth");
+    const removedOldWorktree = join(root, "removed-old-stale");
+
+    try {
+      await git(root, ["init", "--initial-branch=main", repo]);
+      await git(repo, ["config", "user.email", "agent@example.test"]);
+      await git(repo, ["config", "user.name", "Agent"]);
+      await writeFile(join(repo, "base.txt"), "base\n");
+      await git(repo, ["add", "base.txt"]);
+      await git(repo, ["commit", "-m", "initial"]);
+
+      await git(repo, ["worktree", "add", "-b", "young-birth", youngWorktree]);
+      await git(repo, ["worktree", "add", "-b", "old-stale", oldWorktree]);
+      await rename(youngWorktree, pausedYoungWorktree);
+      await rename(oldWorktree, removedOldWorktree);
+
+      const registrations = join(repo, ".git", "worktrees");
+      const youngRegistration = join(registrations, "young-birth");
+      const oldRegistration = join(registrations, "old-stale");
+      await ageTree(oldRegistration, new Date(Date.now() - 2 * 60 * 60 * 1_000));
+
+      await worktreePrune({ cwd: repo });
+
+      await expect(stat(youngRegistration)).resolves.toBeDefined();
+      await expect(stat(oldRegistration)).rejects.toMatchObject({ code: "ENOENT" });
+
+      // Finish the posed sibling birth after the boot-time prune. Its checkout
+      // remains usable only when the young registration survived the race.
+      await rename(pausedYoungWorktree, youngWorktree);
+      await expect(git(youngWorktree, ["status", "--short"])).resolves.toBe("");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #3650.

Worker hUYLS completed the fix and hit the GraphQL rate limit at the pr step; opening via REST. Landing with CI as judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789069820&installation_model_id=20659&pr_number=3664&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3664&signature=28b46fc009e987b7a24c1afc72332ca86535c5727b0db14b79ce8feaf6a28cf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->