### PR TITLE
feat: #3606 statusline reshape — compact bedrock, honest counters, connection-status tail

### DIFF
--- a/apps/dev/src/core/statusline-bedrock-style.ts
+++ b/apps/dev/src/core/statusline-bedrock-style.ts
@@ -46,8 +46,9 @@ import {
   type StatuslineBedrockInput,
 } from "./statusline-bedrock.js";
 
-/** ` · ` drawn in the transparent zone — the same separator the plain render
- * uses, so stripping the paint recovers the plain line byte for byte. */
+/** A plain inter-block space in the transparent zone. */
+const SOFT_SPACE = `${SOFT} `;
+/** The lifecycle's cached-tail suffix still owns its explicit boundaries. */
 const SOFT_SEPARATOR = `${SOFT} · `;
 
 /** Paint every `k=v` in a transparent-zone block: paper KEY, default-fg VALUE,
@@ -79,16 +80,16 @@ function paintProjectBlock(input: StatuslineBedrockInput): string {
 export function renderStatuslineBedrockThemed(input: StatuslineBedrockInput): string {
   let line = paintProjectBlock(input);
   const model = renderModelBlock(input.claude);
-  if (model !== null) line += `${SOFT_SEPARATOR}${MODEL_BG}${PAPER}${model}${NOBG}`;
+  if (model !== null) line += `${SOFT_SPACE}${MODEL_BG}${PAPER}${model}${NOBG}`;
   const context = renderContextBlock(input.claude);
-  if (context !== null) line += `${SOFT_SEPARATOR}${VAL}${context}`;
+  if (context !== null) line += `${SOFT_SPACE}${KEY}ctx=${VAL}${context}`;
   const usage = renderUsageBlock(input.claude);
-  if (usage !== null) line += `${SOFT_SEPARATOR}${paintKeyValues(usage)}`;
+  if (usage !== null) line += `${SOFT_SPACE}${paintKeyValues(usage)}`;
   const localDiff = renderLocalDiffBlock(input.localDiff);
   // `loc=`'s value is the whole signed pair — `+A -R` with its space — so the
   // generic \S+ matcher would leave the removed half outside the VALUE tone.
   if (localDiff !== null) {
-    line += `${SOFT_SEPARATOR}${KEY}loc=${VAL}${localDiff.slice("loc=".length)}`;
+    line += `${SOFT_SPACE}${KEY}loc=${VAL}${localDiff.slice("loc=".length)}`;
   }
   return `${line}${RESET}`;
 }

--- a/apps/dev/src/core/statusline-bedrock.ts
+++ b/apps/dev/src/core/statusline-bedrock.ts
@@ -70,7 +70,8 @@ export function renderBedrockProjectBlock(project: ProjectInput): string {
 }
 
 /**
- * The bedrock segment, blocks joined by ` · ` exactly like the rest of the line.
+ * The bedrock segment, space-separated so the only ` · ` on its header is
+ * the boundary before the daemon tail.
  * Never empty: the project block always renders, so a daemon-absent invocation
  * still puts the operator's own facts on screen.
  */
@@ -79,12 +80,12 @@ export function renderStatuslineBedrock(input: StatuslineBedrockInput): string {
   const model = renderModelBlock(input.claude);
   if (model !== null) sections.push(model);
   const context = renderContextBlock(input.claude);
-  if (context !== null) sections.push(context);
+  if (context !== null) sections.push(`ctx=${context}`);
   const usage = renderUsageBlock(input.claude);
   if (usage !== null) sections.push(usage);
   const localDiff = renderLocalDiffBlock(input.localDiff);
   if (localDiff !== null) sections.push(localDiff);
-  return sections.join(" · ");
+  return sections.join(" ");
 }
 
 /**

--- a/apps/dev/src/mcp/queue.ts
+++ b/apps/dev/src/mcp/queue.ts
@@ -212,7 +212,9 @@ export async function collectStatuslineAggregate(
       open_prs: counterProject?.counters.open_pull_requests.value
         ?? activityProject?.counts?.open_pull_requests
         ?? null,
-      today_prs: activityProject?.counts?.recently_closed ?? null,
+      today_prs: counterProject?.counters.merged_today.value
+        ?? activityProject?.counts?.merged_today
+        ?? null,
       open_issues: counterProject?.counters.open_issues.value
         ?? activityProject?.counts?.open_issues
         ?? null,

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -682,7 +682,7 @@ describe("statusline_aggregate MCP tool", () => {
     const cwd = await root();
     const projectLabel = cwd.split("/").at(-1)!;
     const counter = (
-      name: "open_pull_requests" | "open_issues" | "ready_queue" | "human_queue",
+      name: "open_pull_requests" | "open_issues" | "merged_today" | "ready_queue" | "human_queue",
       value: number,
       ageMs: number,
     ) => ({
@@ -704,6 +704,7 @@ describe("statusline_aggregate MCP tool", () => {
         counters: {
           open_pull_requests: counter("open_pull_requests", 3, 5_000),
           open_issues: counter("open_issues", 24, 65_000),
+          merged_today: counter("merged_today", 6, 25_000),
           ready_queue: counter("ready_queue", 7, 15_000),
           human_queue: counter("human_queue", 2, 75_000),
         },
@@ -721,7 +722,7 @@ describe("statusline_aggregate MCP tool", () => {
           projects: [{
             project_label: projectLabel,
             repository: "acme/widgets",
-            counts: { open_pull_requests: 3, open_issues: 24, recently_closed: 5 },
+            counts: { open_pull_requests: 3, open_issues: 24, merged_today: 6, recently_closed: 5 },
           }],
           reason: "daemon fixture",
         },
@@ -740,7 +741,7 @@ describe("statusline_aggregate MCP tool", () => {
 
     await expect(aggregate.invoke({})).resolves.toMatchObject({
       remote_counters: remoteCounters,
-      repo: { open_prs: 3, today_prs: 5, open_issues: 24 },
+      repo: { open_prs: 3, today_prs: 6, open_issues: 24 },
       queue: { ready_for_agent: 7, ready_for_human: 2 },
     });
     expect(remoteCounters.projects[0]!.counters.open_issues).toMatchObject({

--- a/apps/dev/tests/statusline-aggregate-coverage.test.ts
+++ b/apps/dev/tests/statusline-aggregate-coverage.test.ts
@@ -93,6 +93,15 @@ const PAYLOAD: StatuslineAggregate = {
           stale: false,
           reason: "counted by daemon",
         },
+        merged_today: {
+          name: "merged_today",
+          value: 5,
+          fetched_at: "2026-08-11T12:00:00.000Z",
+          age_ms: 5_000,
+          threshold_ms: 60_000,
+          stale: false,
+          reason: "counted by daemon",
+        },
         ready_queue: {
           name: "ready_queue",
           value: 6,
@@ -122,7 +131,7 @@ const PAYLOAD: StatuslineAggregate = {
     projects: [{
       project_label: "red-skills",
       repository: "reddb-io/red-skills",
-      counts: { open_pull_requests: 3, open_issues: 24, recently_closed: 5 },
+      counts: { open_pull_requests: 3, open_issues: 24, merged_today: 5, recently_closed: 5 },
     }],
     reason: "daemon fixture",
   },

--- a/apps/dev/tests/statusline-bedrock-style.test.ts
+++ b/apps/dev/tests/statusline-bedrock-style.test.ts
@@ -75,7 +75,7 @@ describe("the themed bedrock is the plain bedrock behind the » mark", () => {
       `${IDENTITY_BG}${IDENTITY_INK}» ${BOLD}red-skills${NOBOLD} (afk/3563-bedrock) v3.12.13${NOBG}`,
     );
     expect(line).toContain(`${MODEL_BG}${PAPER}Opus·high${NOBG}`);
-    expect(line).toContain(`${VAL}47k 24%`);
+    expect(line).toContain(`${KEY}ctx=${VAL}47k 24%`);
     expect(line).toContain(`${KEY}5h=${VAL}23%`);
     expect(line).toContain(`${KEY}7d=${VAL}41%`);
     expect(line).toContain(`${KEY}loc=${VAL}+142`);

--- a/apps/dev/tests/statusline-bedrock.test.ts
+++ b/apps/dev/tests/statusline-bedrock.test.ts
@@ -27,7 +27,7 @@ describe("statusline bedrock render", () => {
         claude: CLAUDE,
         localDiff: { localAdded: 142, localRemoved: 36 },
       }),
-    ).toBe("red-skills (afk/3563-bedrock) v3.12.13 · Opus·high · 47k 24% · 5h=23% 7d=41% · loc=+142 -36");
+    ).toBe("red-skills (afk/3563-bedrock) v3.12.13 Opus·high ctx=47k 24% 5h=23% 7d=41% loc=+142 -36");
   });
 
   it("states the running version even when no newer bundle is cached", () => {

--- a/apps/dev/tests/statusline-counters.test.ts
+++ b/apps/dev/tests/statusline-counters.test.ts
@@ -1,8 +1,8 @@
 /**
  * The tail counters ride the daemon payload (ADR 0141 decision 2, #3566).
  *
- * The claim under test is what an OPERATOR sees: `prs=`, `iss=`, `rdy=` and
- * `hmn=` reach the statusline from the daemon document, each stating its own age
+ * The claim under test is what an OPERATOR sees: `rdy=`, `iss=`, `pr=` and
+ * `mrg=` reach the statusline from the daemon document, each stating its own age
  * when it is served past the daemon's window — and no local `gh` count cache
  * stands anywhere between the fixture and the line.
  *
@@ -126,7 +126,7 @@ function daemonPayload(ageMs: number): RedskilledRenderPayload {
     known_projects: [PROJECT],
     registered_projects: [PROJECT],
     remote_counters: counters(
-      { open_pull_requests: 3, open_issues: 24, ready_queue: 5, human_queue: 2 },
+      { open_pull_requests: 3, open_issues: 24, merged_today: 7, ready_queue: 5, human_queue: 2 },
       ageMs,
     ),
   };
@@ -198,16 +198,18 @@ async function render(ageMs: number): Promise<string> {
 }
 
 describe("statusline tail counters", () => {
-  it("renders all four from the daemon payload, behind the bedrock", async () => {
+  it("renders the compact panorama from the daemon payload, behind the bedrock", async () => {
     const line = await render(5_000);
 
-    expect(line).toContain("prs=3 iss=24 rdy=5 hmn=2");
+    expect(line).toContain("0w idle rdy=5 iss=24 pr=3 mrg=7 0B v3.12.13");
+    expect(line).not.toContain("acme/widgets");
+    expect(line.match(/ · /g)).toHaveLength(1);
     // The bedrock still LEADS: the counters are the tail's, and the tail follows.
-    expect(line.indexOf("red-skills (afk/3566-counters)")).toBeLessThan(line.indexOf("prs=3"));
+    expect(line.indexOf("red-skills (afk/3566-counters)")).toBeLessThan(line.indexOf("rdy=5"));
     expect(line).toContain("loc=+12 -3");
   });
 
   it("states each counter's age when the daemon served it past its window", async () => {
-    expect(await render(900_000)).toContain("prs=3(15m) iss=24(15m) rdy=5(15m) hmn=2(15m)");
+    expect(await render(900_000)).toContain("rdy=5(15m) iss=24(15m) pr=3(15m) mrg=7(15m)");
   });
 });

--- a/apps/dev/tests/statusline-lifecycle.test.ts
+++ b/apps/dev/tests/statusline-lifecycle.test.ts
@@ -45,7 +45,7 @@ describe("Statusline Lifecycle render", () => {
 
 function probe(overrides: Partial<StatuslineTailProbe> = {}): StatuslineTailProbe {
   return {
-    lines: ["acme/widgets 1w 128M", "w123 working"],
+    lines: ["1w rdy=5 iss=24 pr=3 mrg=7 128M", "w123 working"],
     generatedAt: "2026-08-11T12:00:00.000Z",
     payloadAgeMs: 5_000,
     stalenessWindowMs: 30_000,
@@ -111,7 +111,7 @@ describe("Statusline Lifecycle wire", () => {
     expect(elapsed).toBeLessThan(100);
     expect(served.state).toBe("degraded");
     expect(served.lines).toEqual([
-      "acme/widgets 1w 128M · age=17s · rsk=degraded",
+      "1w rdy=5 iss=24 pr=3 mrg=7 128M · age=17s · rsk=degraded",
       "w123 working",
     ]);
   });

--- a/apps/dev/tests/statusline-render-path.test.ts
+++ b/apps/dev/tests/statusline-render-path.test.ts
@@ -26,7 +26,7 @@ const { directCollector, localGit, probeStatusline, spawned } = vi.hoisted(() =>
     },
     render: {
       lines: [
-        "acme/widgets 1w 128M v3.12.10",
+        "1w rdy=5 iss=24 pr=3 mrg=7 128M v3.12.10",
         "w123  ███▶░░  run=codex gpt-5.6 xhigh  iss=3546  implementing·tests  00:02:03  loc=+12 -3  tks=45k  tls=9 rsn=2 txt=1",
       ],
       mode: "local",
@@ -155,7 +155,7 @@ describe("dev statusline render path", () => {
     expect(directCollector).not.toHaveBeenCalled();
     // The bedrock LEADS the daemon's header line; the Worker lines follow it
     // untouched.
-    expect(out.text().split("\n")[0]).toContain(" · acme/widgets 1w 128M v3.12.10");
+    expect(out.text().split("\n")[0]).toContain(" · 1w rdy=5 iss=24 pr=3 mrg=7 128M v3.12.10");
     expect(out.text()).toContain("run=codex gpt-5.6 xhigh");
     expect(out.text()).toContain("iss=3546");
     expect(out.text()).toContain("loc=+12 -3  tks=45k  tls=9 rsn=2 txt=1");
@@ -195,8 +195,8 @@ describe("dev statusline render path", () => {
 
     expect(code).toBe(0);
     expect(out.text()).toBe(
-      `red-skills (afk/3563-bedrock) v${readBuildInfo("dev").version} · Opus·high · 47k 24% · ` +
-        "5h=23% 7d=41% · loc=+142 -36 · rsk=bedrock-only\n",
+      `red-skills (afk/3563-bedrock) v${readBuildInfo("dev").version} Opus·high ctx=47k 24% ` +
+        "5h=23% 7d=41% loc=+142 -36 · rsk=bedrock-only\n",
     );
     expect(localGit).toHaveBeenCalledOnce();
     expect(directCollector).not.toHaveBeenCalled();
@@ -212,8 +212,8 @@ describe("dev statusline render path", () => {
 
     expect(code).toBe(0);
     expect(out.text()).toBe(
-      `red-skills (afk/3563-bedrock) v${readBuildInfo("dev").version} · Opus·high · 47k 24% · ` +
-        "5h=23% 7d=41% · loc=+142 -36 · rsk=bedrock-only\n",
+      `red-skills (afk/3563-bedrock) v${readBuildInfo("dev").version} Opus·high ctx=47k 24% ` +
+        "5h=23% 7d=41% loc=+142 -36 · rsk=bedrock-only\n",
     );
   });
 
@@ -273,7 +273,7 @@ describe("dev statusline render path — colour", () => {
     expect(header).toContain(`${IDENTITY_BG}${IDENTITY_INK}» ${BOLD}red-skills`);
     // The plain content survives under the paint — the seam and the daemon head
     // are byte-identical to the NO_COLOR render.
-    expect(stripAnsi(header)).toContain(" · acme/widgets 1w 128M v3.12.10");
+    expect(stripAnsi(header)).toContain(" · 1w rdy=5 iss=24 pr=3 mrg=7 128M v3.12.10");
     expect(adapterMs).toBeLessThan(100);
   });
 
@@ -289,8 +289,8 @@ describe("dev statusline render path — colour", () => {
     expect(code).toBe(0);
     expect(out.text()).toContain(`${KEY}rsk=${DIM}bedrock-only`);
     expect(stripAnsi(out.text())).toBe(
-      `» red-skills (afk/3563-bedrock) v${readBuildInfo("dev").version} · Opus·high · 47k 24% · ` +
-        "5h=23% 7d=41% · loc=+142 -36 · rsk=bedrock-only\n",
+      `» red-skills (afk/3563-bedrock) v${readBuildInfo("dev").version} Opus·high ctx=47k 24% ` +
+        "5h=23% 7d=41% loc=+142 -36 · rsk=bedrock-only\n",
     );
   });
 
@@ -304,7 +304,7 @@ describe("dev statusline render path — colour", () => {
         staleness: { age_ms: 5_000, threshold_ms: 30_000, stale: false },
       },
       render: {
-        lines: [`[1macme/widgets[0m 1w`, `[39mw123 iss=42[0m`],
+        lines: [`[1m1w rdy=5 iss=24 pr=3 mrg=7[0m`, `[39mw123 iss=42[0m`],
         mode: "local",
         project_match: "matched",
       },
@@ -317,6 +317,6 @@ describe("dev statusline render path — colour", () => {
 
     expect(code).toBe(0);
     expect(out.text()).not.toContain("[");
-    expect(out.text()).toContain(" · acme/widgets 1w\nw123 iss=42\n");
+    expect(out.text()).toContain(" · 1w rdy=5 iss=24 pr=3 mrg=7\nw123 iss=42\n");
   });
 });

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -770,6 +770,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         return queueTransport;
       },
       now: clock(),
+      previous: lastActivity,
     });
   }
 

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -769,8 +769,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         armQueueTransport();
         return queueTransport;
       },
-      now: clock(),
-      previous: lastActivity,
+      now: clock(), previous: lastActivity,
     });
   }
 

--- a/apps/redskilled/src/daemon/registration-activity.ts
+++ b/apps/redskilled/src/daemon/registration-activity.ts
@@ -24,6 +24,7 @@ export interface RegistrationActivityPollInput {
   readonly registrations: Iterable<RedskilledProjectRegistration>;
   readonly resolveHostTransport: () => RedskilledActivityTransport | undefined;
   readonly now: string;
+  readonly previous?: RedskilledRepositoryActivity | null;
 }
 
 /** Fetch one cycle, or return honest absence when no registration can be polled. */
@@ -40,6 +41,7 @@ export async function pollRegistrationActivity(
     transport,
     ...(input.explicit?.closedWindowMs == null ? {} : { closedWindowMs: input.explicit.closedWindowMs }),
     now: input.now,
+    ...(input.previous === undefined ? {} : { previous: input.previous }),
   });
 }
 

--- a/apps/redskilled/src/remote-counters.ts
+++ b/apps/redskilled/src/remote-counters.ts
@@ -34,6 +34,7 @@ import type {
   RedskilledProjectActivity,
   RedskilledRepositoryActivity,
 } from "./repository-activity.js";
+import { REDSKILLED_PANORAMA_REFRESH_MS } from "./repository-activity.js";
 
 /**
  * Every counter this block carries, in the order a line reads them.
@@ -45,6 +46,7 @@ import type {
 export const REDSKILLED_REMOTE_COUNTER_NAMES = [
   "open_pull_requests",
   "open_issues",
+  "merged_today",
   "ready_queue",
   "human_queue",
 ] as const;
@@ -98,8 +100,10 @@ export function buildRemoteCounterReport(input: {
   readonly activity: RedskilledRepositoryActivity | null;
   readonly now: string;
   readonly stalenessMs?: number;
+  readonly panoramaStalenessMs?: number;
 }): RedskilledRemoteCounterReport {
   const threshold = input.stalenessMs ?? REDSKILLED_ACTIVITY_STALENESS_MS;
+  const panoramaThreshold = input.panoramaStalenessMs ?? REDSKILLED_PANORAMA_REFRESH_MS;
   const activity = input.activity;
   if (activity == null || activity.projects.length === 0) {
     return {
@@ -110,29 +114,39 @@ export function buildRemoteCounterReport(input: {
     };
   }
   const nowMs = Date.parse(input.now);
-  const fetchedMs = Date.parse(activity.fetched_at);
-  const ageMs = Number.isFinite(nowMs) && Number.isFinite(fetchedMs) ? Math.max(0, nowMs - fetchedMs) : null;
-
   const projects = activity.projects.map((project) =>
-    buildProjectCounters(project, { fetchedAt: activity.fetched_at, ageMs, threshold })
+    buildProjectCounters(project, { fetchedAt: activity.fetched_at, nowMs, threshold, panoramaThreshold })
   );
   return {
     version: 1,
     threshold_ms: threshold,
     projects,
-    reason: ageMs == null
+    reason: !Number.isFinite(nowMs) || !Number.isFinite(Date.parse(activity.fetched_at))
       ? "these counters carry no readable instant, so none of them can be presented as current"
-      : `every counter here was produced by the poll of ${activity.fetched_at}, ${ageMs}ms ago`,
+      : `these counters carry their queue and panorama poll instants as of ${activity.fetched_at}`,
   };
 }
 
 function buildProjectCounters(
   project: RedskilledProjectActivity,
-  ctx: { readonly fetchedAt: string; readonly ageMs: number | null; readonly threshold: number },
+  ctx: {
+    readonly fetchedAt: string;
+    readonly nowMs: number;
+    readonly threshold: number;
+    readonly panoramaThreshold: number;
+  },
 ): RedskilledProjectRemoteCounters {
   const counters = {} as Record<RedskilledRemoteCounterName, RedskilledRemoteCounter>;
   for (const name of REDSKILLED_REMOTE_COUNTER_NAMES) {
-    counters[name] = buildCounter(name, valueOf(project, name), project, ctx);
+    const panorama = name === "open_pull_requests" || name === "open_issues" || name === "merged_today";
+    const fetchedAt = panorama ? project.panorama_fetched_at ?? ctx.fetchedAt : project.queue_fetched_at ?? ctx.fetchedAt;
+    const fetchedMs = Date.parse(fetchedAt);
+    const ageMs = Number.isFinite(ctx.nowMs) && Number.isFinite(fetchedMs) ? Math.max(0, ctx.nowMs - fetchedMs) : null;
+    counters[name] = buildCounter(name, valueOf(project, name), project, {
+      fetchedAt,
+      ageMs,
+      threshold: panorama ? ctx.panoramaThreshold : ctx.threshold,
+    });
   }
   return {
     project_label: project.project_label,
@@ -151,6 +165,8 @@ function valueOf(project: RedskilledProjectActivity, name: RedskilledRemoteCount
       return counts.open_pull_requests;
     case "open_issues":
       return counts.open_issues;
+    case "merged_today":
+      return counts.merged_today ?? null;
     case "ready_queue":
       return counts.ready_queue;
     case "human_queue":

--- a/apps/redskilled/src/repository-activity-conditional.ts
+++ b/apps/redskilled/src/repository-activity-conditional.ts
@@ -1,0 +1,220 @@
+/** Presence-driven conditional REST polling for repository activity. */
+
+import {
+  isGithubRateLimitError,
+  type GithubAttributedOperation,
+  type GithubResponseHeaders,
+} from "@reddb-io/github";
+import type {
+  FetchRepositoryActivityInput,
+  RedskilledActivityCounts,
+  RedskilledActivityOperation,
+  RedskilledActivityQueueLabels,
+  RedskilledActivityRateLimit,
+  RedskilledProjectActivity,
+  RedskilledRepositoryActivity,
+} from "./repository-activity.js";
+
+/** Panorama totals refresh on a human-glance cadence while queue depth stays attended-fast. */
+export const REDSKILLED_PANORAMA_REFRESH_MS = 4 * 60 * 1_000;
+
+const REDSKILLED_ACTIVITY_REST_OPERATION: GithubAttributedOperation = {
+  key: "redskilled repository activity poll",
+  budget: "rest",
+};
+const REDSKILLED_MERGED_TODAY_OPERATION: GithubAttributedOperation = {
+  key: "redskilled merged-today poll",
+  budget: "search",
+};
+
+export async function fetchConditionalRepositoryActivity(
+  input: FetchRepositoryActivityInput,
+  operation: RedskilledActivityOperation,
+): Promise<RedskilledRepositoryActivity> {
+  const nowMs = Date.parse(input.now);
+  const list = input.transport.conditionalList!;
+  const count = input.transport.conditionalCount!;
+  const previous = new Map((input.previous?.projects ?? []).map((entry) => [entry.project_label, entry]));
+  const panoramaRefreshMs = input.panoramaRefreshMs ?? REDSKILLED_PANORAMA_REFRESH_MS;
+  const projects: RedskilledProjectActivity[] = [];
+  let requestCount = 0;
+  let rateLimit: RedskilledActivityRateLimit = {
+    remaining: null,
+    reset_at: null,
+    exhausted: false,
+    point_cost: null,
+  };
+
+  for (const project of input.projects) {
+    const repository = `${project.owner}/${project.name}`;
+    const held = previous.get(project.project_label);
+    const heldAt = Date.parse(held?.panorama_fetched_at ?? input.previous?.fetched_at ?? "");
+    const refreshPanorama = held?.counts == null || !Number.isFinite(nowMs) || !Number.isFinite(heldAt) ||
+      nowMs - heldAt >= panoramaRefreshMs;
+    try {
+      const issueParams = { owner: project.owner, repo: project.name, state: "open" };
+      const issueAnswer = await list({
+        cacheKey: `activity:${repository}:open-issues:${JSON.stringify(issueParams)}`,
+        route: "GET /repos/{owner}/{repo}/issues",
+        parameters: issueParams,
+        operation: REDSKILLED_ACTIVITY_REST_OPERATION,
+      });
+      requestCount += issueAnswer.requestCount;
+      rateLimit = mergeActivityRateLimit(rateLimit, activityRateLimitFromHeaders(issueAnswer.headers));
+      const openIssues = issueAnswer.data.filter((item) => !isRecord(item.pull_request));
+      const queue = project.queue_labels == null
+        ? { ready_queue: null, human_queue: null }
+        : countQueueLabels(openIssues, project.queue_labels);
+
+      let panorama = held?.counts ?? null;
+      if (refreshPanorama) {
+        const prParams = { owner: project.owner, repo: project.name, state: "open" };
+        const closedParams = { owner: project.owner, repo: project.name, state: "closed", since: operation.closed_since };
+        const mergedParams = { q: `repo:${repository} is:pr is:merged merged:>=${operation.merged_since}`, per_page: 1 };
+        const prAnswer = await list({
+          cacheKey: `activity:${repository}:open-prs:${JSON.stringify(prParams)}`,
+          route: "GET /repos/{owner}/{repo}/pulls",
+          parameters: prParams,
+          operation: REDSKILLED_ACTIVITY_REST_OPERATION,
+        });
+        const closedAnswer = await list({
+          cacheKey: `activity:${repository}:recently-closed:${JSON.stringify(closedParams)}`,
+          route: "GET /repos/{owner}/{repo}/issues",
+          parameters: closedParams,
+          operation: REDSKILLED_ACTIVITY_REST_OPERATION,
+        });
+        const mergedAnswer = await count({
+          cacheKey: `activity:${repository}:merged-today:${operation.merged_since}`,
+          route: "GET /search/issues",
+          parameters: mergedParams,
+          operation: REDSKILLED_MERGED_TODAY_OPERATION,
+        });
+        requestCount += prAnswer.requestCount + closedAnswer.requestCount + mergedAnswer.requestCount;
+        for (const headers of [prAnswer.headers, closedAnswer.headers, mergedAnswer.headers]) {
+          rateLimit = mergeActivityRateLimit(rateLimit, activityRateLimitFromHeaders(headers));
+        }
+        const recentlyClosed = closedAnswer.data
+          .filter((item) => !isRecord(item.pull_request))
+          .filter((item) => stringValue(item.closed_at) >= operation.closed_since).length;
+        if (!Number.isSafeInteger(mergedAnswer.data.total_count) || mergedAnswer.data.total_count < 0) {
+          throw new Error(`GitHub returned no merged-today count for ${repository}`);
+        }
+        panorama = {
+          open_pull_requests: prAnswer.data.length,
+          open_issues: openIssues.length,
+          recently_closed: recentlyClosed,
+          merged_today: mergedAnswer.data.total_count,
+          ready_queue: queue.ready_queue,
+          human_queue: queue.human_queue,
+        };
+      }
+      if (panorama == null) throw new Error(`no panorama cache exists for ${repository}`);
+      projects.push({
+        project_label: project.project_label,
+        repository,
+        outcome: "counted",
+        counts: {
+          open_pull_requests: panorama.open_pull_requests,
+          open_issues: panorama.open_issues,
+          recently_closed: panorama.recently_closed,
+          merged_today: panorama.merged_today,
+          ...queue,
+        },
+        panorama_fetched_at: refreshPanorama ? input.now : held?.panorama_fetched_at ?? input.previous?.fetched_at ?? input.now,
+        queue_fetched_at: input.now,
+        detail: `counted ${repository} for project ${JSON.stringify(project.project_label)}`,
+      });
+    } catch (error) {
+      const rateLimited = isGithubRateLimitError(error);
+      rateLimit = mergeActivityRateLimit(rateLimit, {
+        remaining: null,
+        reset_at: null,
+        exhausted: rateLimited,
+        point_cost: null,
+      });
+      const failure = error instanceof Error ? error.message : String(error);
+      projects.push(held?.counts == null
+        ? {
+            project_label: project.project_label,
+            repository,
+            outcome: rateLimited ? "rate-limited" : "unreachable",
+            counts: null,
+            detail: `the activity fetch failed before ${repository} answered: ${failure}`,
+          }
+        : {
+            ...held,
+            // Preserve both cache instants so consumers age last-known values honestly.
+            detail: `serving last-known counters after the activity fetch failed: ${failure}`,
+          });
+    }
+  }
+
+  return {
+    version: 1,
+    fetched_at: input.now,
+    request_count: requestCount,
+    project_count: projects.length,
+    rate_limit: rateLimit,
+    projects,
+  };
+}
+
+type RedskilledActivityQueueCounts = Pick<RedskilledActivityCounts, "ready_queue" | "human_queue">;
+
+function countQueueLabels(
+  items: readonly Record<string, unknown>[],
+  labels: RedskilledActivityQueueLabels,
+): RedskilledActivityQueueCounts {
+  const carries = (item: Record<string, unknown>, label: string): boolean =>
+    Array.isArray(item.labels) && item.labels.some((entry) => labelName(entry) === label);
+  return {
+    ready_queue: items.filter((item) => carries(item, labels.ready)).length,
+    human_queue: items.filter((item) => carries(item, labels.human)).length,
+  };
+}
+
+function labelName(entry: unknown): string {
+  if (typeof entry === "string") return entry;
+  return isRecord(entry) ? stringValue(entry.name) : "";
+}
+
+function activityRateLimitFromHeaders(headers: GithubResponseHeaders): RedskilledActivityRateLimit {
+  const remaining = integerHeader(headers, "x-ratelimit-remaining");
+  const resetSeconds = integerHeader(headers, "x-ratelimit-reset");
+  return {
+    remaining,
+    reset_at: resetSeconds == null ? null : new Date(resetSeconds * 1000).toISOString(),
+    exhausted: remaining === 0,
+    point_cost: null,
+  };
+}
+
+function mergeActivityRateLimit(
+  held: RedskilledActivityRateLimit,
+  next: RedskilledActivityRateLimit,
+): RedskilledActivityRateLimit {
+  const remaining = next.remaining == null
+    ? held.remaining
+    : held.remaining == null ? next.remaining : Math.min(held.remaining, next.remaining);
+  return {
+    remaining,
+    reset_at: next.reset_at ?? held.reset_at,
+    exhausted: held.exhausted || next.exhausted,
+    point_cost: null,
+  };
+}
+
+function integerHeader(headers: GithubResponseHeaders, name: string): number | null {
+  const raw = headers[name];
+  if (typeof raw !== "string" && typeof raw !== "number") return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}

--- a/apps/redskilled/src/repository-activity.ts
+++ b/apps/redskilled/src/repository-activity.ts
@@ -102,6 +102,8 @@ export const REDSKILLED_ACTIVITY_BATCH_SIZE = 100;
  * spending GitHub budget.
  */
 export const DEFAULT_REDSKILLED_ACTIVITY_MS = 20_000;
+/** Panorama totals refresh on a human-glance cadence while queue depth stays attended-fast. */
+export const REDSKILLED_PANORAMA_REFRESH_MS = 4 * 60 * 1_000;
 
 /** How far back "recently closed" reaches, when a caller states no window. */
 export const DEFAULT_REDSKILLED_ACTIVITY_CLOSED_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
@@ -163,6 +165,8 @@ export class RedskilledSplitCredentialError extends Error {
 export interface RedskilledActivityCounts {
   readonly open_pull_requests: number;
   readonly open_issues: number;
+  /** Pull requests merged since the operator's local calendar day began. */
+  readonly merged_today?: number;
   /** Issues and pull requests closed inside the window the fetch asked for. */
   readonly recently_closed: number;
   /**
@@ -196,6 +200,9 @@ export interface RedskilledProjectActivity {
   readonly outcome: RedskilledActivityOutcome;
   /** The counts; `null` for every outcome but `counted`, never a zero. */
   readonly counts: RedskilledActivityCounts | null;
+  /** The independent cache instants for the slow panorama and fast queue tiers. */
+  readonly panorama_fetched_at?: string;
+  readonly queue_fetched_at?: string;
   readonly detail: string;
 }
 
@@ -231,6 +238,7 @@ export interface RedskilledRepositoryActivity {
 export interface RedskilledActivityAlias {
   readonly alias: string;
   readonly search_alias: string;
+  readonly merged_alias: string;
   readonly project: RedskilledProjectRepository;
 }
 
@@ -239,6 +247,8 @@ export interface RedskilledActivityOperation {
   readonly aliases: readonly RedskilledActivityAlias[];
   /** The instant `recently_closed` counts back from, as the query states it. */
   readonly closed_since: string;
+  /** Operator-local day used by the merged-PR search. */
+  readonly merged_since: string;
 }
 
 /**
@@ -277,16 +287,24 @@ export function buildRepositoryActivityQuery(
   const nowMs = Date.parse(options.now);
   if (!Number.isFinite(nowMs)) throw new Error(`redskilled activity fetch needs an instant, not ${JSON.stringify(options.now)}`);
   const closedSince = new Date(nowMs - Math.max(0, windowMs)).toISOString();
+  const localNow = new Date(nowMs);
+  const mergedSince = [
+    localNow.getFullYear(),
+    String(localNow.getMonth() + 1).padStart(2, "0"),
+    String(localNow.getDate()).padStart(2, "0"),
+  ].join("-");
 
   const aliases: RedskilledActivityAlias[] = projects.map((project, index) => ({
     alias: `r${index}`,
     search_alias: `c${index}`,
+    merged_alias: `m${index}`,
     project,
   }));
-  const fields = aliases.flatMap(({ alias, search_alias, project }) => {
+  const fields = aliases.flatMap(({ alias, search_alias, merged_alias, project }) => {
     const owner = JSON.stringify(project.owner);
     const name = JSON.stringify(project.name);
     const search = JSON.stringify(`repo:${project.owner}/${project.name} is:closed closed:>=${closedSince}`);
+    const merged = JSON.stringify(`repo:${project.owner}/${project.name} is:pr is:merged merged:>=${mergedSince}`);
     return [
       `  ${alias}: repository(owner: ${owner}, name: ${name}) {`,
       "    nameWithOwner",
@@ -294,6 +312,7 @@ export function buildRepositoryActivityQuery(
       "    open_issues: issues(states: OPEN) { totalCount }",
       "  }",
       `  ${search_alias}: search(query: ${search}, type: ISSUE, first: 1) { issueCount }`,
+      `  ${merged_alias}: search(query: ${merged}, type: ISSUE, first: 1) { issueCount }`,
     ];
   });
   const query = [
@@ -302,7 +321,7 @@ export function buildRepositoryActivityQuery(
     ...fields,
     "}",
   ].join("\n");
-  return { query, aliases, closed_since: closedSince };
+  return { query, aliases, closed_since: closedSince, merged_since: mergedSince };
 }
 
 /**
@@ -324,15 +343,17 @@ export function parseRepositoryActivityResponse(
   const errors = Array.isArray(root.errors) ? root.errors.map(asRecord) : [];
   const rateLimit = readRateLimit(data.rateLimit, errors);
 
-  const projects = operation.aliases.map(({ alias, search_alias, project }): RedskilledProjectActivity => {
+  const projects = operation.aliases.map(({ alias, search_alias, merged_alias, project }): RedskilledProjectActivity => {
     const repository = project.owner + "/" + project.name;
     const node = data[alias];
-    const aliasError = errors.find((candidate) => pathIncludes(candidate.path, alias) || pathIncludes(candidate.path, search_alias));
+    const aliasError = errors.find((candidate) =>
+      pathIncludes(candidate.path, alias) || pathIncludes(candidate.path, search_alias) || pathIncludes(candidate.path, merged_alias));
     if (isRecord(node)) {
       const openPullRequests = totalCount(node.open_pull_requests);
       const openIssues = totalCount(node.open_issues);
       const recentlyClosed = issueCount(data[search_alias]);
-      if (openPullRequests != null && openIssues != null && recentlyClosed != null) {
+      const mergedToday = issueCount(data[merged_alias]);
+      if (openPullRequests != null && openIssues != null && recentlyClosed != null && mergedToday != null) {
         return {
           project_label: project.project_label,
           repository,
@@ -340,6 +361,7 @@ export function parseRepositoryActivityResponse(
           counts: {
             open_pull_requests: openPullRequests,
             open_issues: openIssues,
+            merged_today: mergedToday,
             recently_closed: recentlyClosed,
             // The aliased query asks for no label breakdown, so this path
             // produces no queue counters — and says so with `null` rather than
@@ -347,6 +369,8 @@ export function parseRepositoryActivityResponse(
             ready_queue: null,
             human_queue: null,
           },
+          panorama_fetched_at: options.fetchedAt,
+          queue_fetched_at: options.fetchedAt,
           detail: `counted ${repository} for project ${JSON.stringify(project.project_label)}`,
         };
       }
@@ -413,6 +437,9 @@ export interface RedskilledActivityTransport {
   conditionalList?(
     input: RedskilledConditionalListRequest,
   ): Promise<GithubPaginatedRestAnswer<Record<string, unknown>>>;
+  conditionalCount?(
+    input: RedskilledConditionalListRequest,
+  ): Promise<{ readonly data: { readonly total_count: number }; readonly headers: GithubResponseHeaders; readonly requestCount: number }>;
 }
 
 export interface FetchRepositoryActivityInput {
@@ -421,6 +448,8 @@ export interface FetchRepositoryActivityInput {
   readonly transport: RedskilledActivityTransport;
   readonly now: string;
   readonly closedWindowMs?: number;
+  readonly previous?: RedskilledRepositoryActivity | null;
+  readonly panoramaRefreshMs?: number;
 }
 
 /**
@@ -436,7 +465,9 @@ export async function fetchRepositoryActivity(
 ): Promise<RedskilledRepositoryActivity> {
   if (input.projects.length === 0) return emptyRepositoryActivity(input.now);
   assertOneHostToken(input.projects, input.hostTokenRef);
-  if (input.transport.conditionalList) return await fetchConditionalRepositoryActivity(input);
+  if (input.transport.conditionalList && input.transport.conditionalCount) {
+    return await fetchConditionalRepositoryActivity(input);
+  }
   const operation = buildRepositoryActivityQuery(input.projects, {
     now: input.now,
     closedWindowMs: input.closedWindowMs,
@@ -468,6 +499,10 @@ const REDSKILLED_ACTIVITY_REST_OPERATION: GithubAttributedOperation = {
   key: "redskilled repository activity poll",
   budget: "rest",
 };
+const REDSKILLED_MERGED_TODAY_OPERATION: GithubAttributedOperation = {
+  key: "redskilled merged-today poll",
+  budget: "search",
+};
 
 async function fetchConditionalRepositoryActivity(
   input: FetchRepositoryActivityInput,
@@ -486,6 +521,9 @@ async function fetchConditionalRepositoryActivity(
     closedWindowMs: input.closedWindowMs,
   });
   const list = input.transport.conditionalList!;
+  const count = input.transport.conditionalCount!;
+  const previous = new Map((input.previous?.projects ?? []).map((entry) => [entry.project_label, entry]));
+  const panoramaRefreshMs = input.panoramaRefreshMs ?? REDSKILLED_PANORAMA_REFRESH_MS;
   const projects: RedskilledProjectActivity[] = [];
   let requestCount = 0;
   let rateLimit: RedskilledActivityRateLimit = {
@@ -497,49 +535,81 @@ async function fetchConditionalRepositoryActivity(
 
   for (const project of input.projects) {
     const repository = `${project.owner}/${project.name}`;
-    const queries = [
-      ["open-prs", "GET /repos/{owner}/{repo}/pulls", { owner: project.owner, repo: project.name, state: "open" }],
-      ["open-issues", "GET /repos/{owner}/{repo}/issues", { owner: project.owner, repo: project.name, state: "open" }],
-      [
-        "recently-closed",
-        "GET /repos/{owner}/{repo}/issues",
-        { owner: project.owner, repo: project.name, state: "closed", since: operation.closed_since },
-      ],
-    ] as const;
-    const counts: number[] = [];
-    let queue: RedskilledActivityQueueCounts = { ready_queue: null, human_queue: null };
+    const held = previous.get(project.project_label);
+    const heldAt = Date.parse(held?.panorama_fetched_at ?? input.previous?.fetched_at ?? "");
+    const refreshPanorama = held?.counts == null || !Number.isFinite(nowMs) || !Number.isFinite(heldAt) ||
+      nowMs - heldAt >= panoramaRefreshMs;
     try {
-      for (const [kind, route, parameters] of queries) {
-        const answer = await list({
-          cacheKey: `activity:${repository}:${kind}:${JSON.stringify(parameters)}`,
-          route,
-          parameters,
+      const issueParams = { owner: project.owner, repo: project.name, state: "open" };
+      const issueAnswer = await list({
+        cacheKey: `activity:${repository}:open-issues:${JSON.stringify(issueParams)}`,
+        route: "GET /repos/{owner}/{repo}/issues",
+        parameters: issueParams,
+        operation: REDSKILLED_ACTIVITY_REST_OPERATION,
+      });
+      requestCount += issueAnswer.requestCount;
+      rateLimit = mergeActivityRateLimit(rateLimit, activityRateLimitFromHeaders(issueAnswer.headers));
+      const openIssues = issueAnswer.data.filter((item) => !isRecord(item.pull_request));
+      const queue = project.queue_labels == null
+        ? { ready_queue: null, human_queue: null }
+        : countQueueLabels(openIssues, project.queue_labels);
+
+      let panorama = held?.counts ?? null;
+      if (refreshPanorama) {
+        const prParams = { owner: project.owner, repo: project.name, state: "open" };
+        const closedParams = { owner: project.owner, repo: project.name, state: "closed", since: operation.closed_since };
+        const mergedParams = { q: `repo:${repository} is:pr is:merged merged:>=${operation.merged_since}`, per_page: 1 };
+        const prAnswer = await list({
+          cacheKey: `activity:${repository}:open-prs:${JSON.stringify(prParams)}`,
+          route: "GET /repos/{owner}/{repo}/pulls",
+          parameters: prParams,
           operation: REDSKILLED_ACTIVITY_REST_OPERATION,
         });
-        requestCount += answer.requestCount;
-        const items = kind === "open-prs"
-          ? answer.data
-          : answer.data.filter((item) => !isRecord(item.pull_request));
-        // The queue counters come out of the open-Issue representation rather
-        // than out of two more label-filtered lists: this poll already holds
-        // every open Issue with its labels, so counting them here is free of
-        // both requests and budget.
-        if (kind === "open-issues" && project.queue_labels != null) queue = countQueueLabels(items, project.queue_labels);
-        counts.push(kind === "recently-closed"
-          ? items.filter((item) => stringValue(item.closed_at) >= operation.closed_since).length
-          : items.length);
-        rateLimit = mergeActivityRateLimit(rateLimit, activityRateLimitFromHeaders(answer.headers));
+        const closedAnswer = await list({
+          cacheKey: `activity:${repository}:recently-closed:${JSON.stringify(closedParams)}`,
+          route: "GET /repos/{owner}/{repo}/issues",
+          parameters: closedParams,
+          operation: REDSKILLED_ACTIVITY_REST_OPERATION,
+        });
+        const mergedAnswer = await count({
+          cacheKey: `activity:${repository}:merged-today:${operation.merged_since}`,
+          route: "GET /search/issues",
+          parameters: mergedParams,
+          operation: REDSKILLED_MERGED_TODAY_OPERATION,
+        });
+        requestCount += prAnswer.requestCount + closedAnswer.requestCount + mergedAnswer.requestCount;
+        for (const headers of [prAnswer.headers, closedAnswer.headers, mergedAnswer.headers]) {
+          rateLimit = mergeActivityRateLimit(rateLimit, activityRateLimitFromHeaders(headers));
+        }
+        const recentlyClosed = closedAnswer.data
+          .filter((item) => !isRecord(item.pull_request))
+          .filter((item) => stringValue(item.closed_at) >= operation.closed_since).length;
+        if (!Number.isSafeInteger(mergedAnswer.data.total_count) || mergedAnswer.data.total_count < 0) {
+          throw new Error(`GitHub returned no merged-today count for ${repository}`);
+        }
+        panorama = {
+          open_pull_requests: prAnswer.data.length,
+          open_issues: openIssues.length,
+          recently_closed: recentlyClosed,
+          merged_today: mergedAnswer.data.total_count,
+          ready_queue: queue.ready_queue,
+          human_queue: queue.human_queue,
+        };
       }
+      if (panorama == null) throw new Error(`no panorama cache exists for ${repository}`);
       projects.push({
         project_label: project.project_label,
         repository,
         outcome: "counted",
         counts: {
-          open_pull_requests: counts[0]!,
-          open_issues: counts[1]!,
-          recently_closed: counts[2]!,
+          open_pull_requests: panorama.open_pull_requests,
+          open_issues: panorama.open_issues,
+          recently_closed: panorama.recently_closed,
+          merged_today: panorama.merged_today,
           ...queue,
         },
+        panorama_fetched_at: refreshPanorama ? input.now : held?.panorama_fetched_at ?? input.previous?.fetched_at ?? input.now,
+        queue_fetched_at: input.now,
         detail: `counted ${repository} for project ${JSON.stringify(project.project_label)}`,
       });
     } catch (error) {
@@ -550,15 +620,22 @@ async function fetchConditionalRepositoryActivity(
         exhausted: rateLimited,
         point_cost: null,
       });
-      projects.push({
-        project_label: project.project_label,
-        repository,
-        outcome: rateLimited ? "rate-limited" : "unreachable",
-        counts: null,
-        detail:
-          `the activity fetch failed before ${repository} answered: ` +
-          `${error instanceof Error ? error.message : String(error)}`,
-      });
+      const failure = error instanceof Error ? error.message : String(error);
+      projects.push(held?.counts == null
+        ? {
+            project_label: project.project_label,
+            repository,
+            outcome: rateLimited ? "rate-limited" : "unreachable",
+            counts: null,
+            detail: `the activity fetch failed before ${repository} answered: ${failure}`,
+          }
+        : {
+            ...held,
+            // Last-known values retain BOTH of their original instants. The
+            // counter projection will age them honestly while the next cycle
+            // tries again; a transient refusal must not erase the panorama.
+            detail: `serving last-known counters after the activity fetch failed: ${failure}`,
+          });
     }
   }
 
@@ -605,6 +682,15 @@ export function createGitHubActivityTransport(options: {
       parameters: input.parameters,
       operation: input.operation,
     });
+  transport.conditionalCount = async (input) => {
+    const answer = await client.conditionalRest<{ total_count: number }>({
+      cacheKey: input.cacheKey,
+      route: input.route,
+      parameters: input.parameters,
+      operation: input.operation,
+    });
+    return { data: answer.data, headers: answer.headers, requestCount: 1 };
+  };
   return transport;
 }
 

--- a/apps/redskilled/src/repository-activity.ts
+++ b/apps/redskilled/src/repository-activity.ts
@@ -62,7 +62,6 @@
 import {
   createGithubClient,
   githubSurfaceFor,
-  isGithubRateLimitError,
   type GithubApiSurface,
   type GithubAttributionLedger,
   type GithubAttributedOperation,
@@ -70,6 +69,9 @@ import {
   type GithubPaginatedRestAnswer,
   type GithubResponseHeaders,
 } from "@reddb-io/github";
+import { fetchConditionalRepositoryActivity } from "./repository-activity-conditional.js";
+
+export { REDSKILLED_PANORAMA_REFRESH_MS } from "./repository-activity-conditional.js";
 
 /**
  * The gh argv this poll is equivalent to. It exists so the surface below is a
@@ -103,8 +105,6 @@ export const REDSKILLED_ACTIVITY_BATCH_SIZE = 100;
  */
 export const DEFAULT_REDSKILLED_ACTIVITY_MS = 20_000;
 /** Panorama totals refresh on a human-glance cadence while queue depth stays attended-fast. */
-export const REDSKILLED_PANORAMA_REFRESH_MS = 4 * 60 * 1_000;
-
 /** How far back "recently closed" reaches, when a caller states no window. */
 export const DEFAULT_REDSKILLED_ACTIVITY_CLOSED_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -466,7 +466,12 @@ export async function fetchRepositoryActivity(
   if (input.projects.length === 0) return emptyRepositoryActivity(input.now);
   assertOneHostToken(input.projects, input.hostTokenRef);
   if (input.transport.conditionalList && input.transport.conditionalCount) {
-    return await fetchConditionalRepositoryActivity(input);
+    const nowMs = Date.parse(input.now);
+    const queryNow = Number.isFinite(nowMs)
+      ? new Date(Math.floor(nowMs / (60 * 60 * 1000)) * 60 * 60 * 1000).toISOString()
+      : input.now;
+    const operation = buildRepositoryActivityQuery(input.projects, { now: queryNow, closedWindowMs: input.closedWindowMs });
+    return await fetchConditionalRepositoryActivity(input, operation);
   }
   const operation = buildRepositoryActivityQuery(input.projects, {
     now: input.now,
@@ -493,160 +498,6 @@ export async function fetchRepositoryActivity(
       })),
     };
   }
-}
-
-const REDSKILLED_ACTIVITY_REST_OPERATION: GithubAttributedOperation = {
-  key: "redskilled repository activity poll",
-  budget: "rest",
-};
-const REDSKILLED_MERGED_TODAY_OPERATION: GithubAttributedOperation = {
-  key: "redskilled merged-today poll",
-  budget: "search",
-};
-
-async function fetchConditionalRepositoryActivity(
-  input: FetchRepositoryActivityInput,
-): Promise<RedskilledRepositoryActivity> {
-  assertActivityProjects(input.projects);
-  // A sliding timestamp would make the recently-closed URL different on every
-  // poll and therefore impossible to revalidate. Bucket that human-speed count
-  // by hour: its seven-day meaning changes by at most one hour, while 59 of 60
-  // minute polls can reuse the same representation validator.
-  const nowMs = Date.parse(input.now);
-  const queryNow = Number.isFinite(nowMs)
-    ? new Date(Math.floor(nowMs / (60 * 60 * 1000)) * 60 * 60 * 1000).toISOString()
-    : input.now;
-  const operation = buildRepositoryActivityQuery(input.projects, {
-    now: queryNow,
-    closedWindowMs: input.closedWindowMs,
-  });
-  const list = input.transport.conditionalList!;
-  const count = input.transport.conditionalCount!;
-  const previous = new Map((input.previous?.projects ?? []).map((entry) => [entry.project_label, entry]));
-  const panoramaRefreshMs = input.panoramaRefreshMs ?? REDSKILLED_PANORAMA_REFRESH_MS;
-  const projects: RedskilledProjectActivity[] = [];
-  let requestCount = 0;
-  let rateLimit: RedskilledActivityRateLimit = {
-    remaining: null,
-    reset_at: null,
-    exhausted: false,
-    point_cost: null,
-  };
-
-  for (const project of input.projects) {
-    const repository = `${project.owner}/${project.name}`;
-    const held = previous.get(project.project_label);
-    const heldAt = Date.parse(held?.panorama_fetched_at ?? input.previous?.fetched_at ?? "");
-    const refreshPanorama = held?.counts == null || !Number.isFinite(nowMs) || !Number.isFinite(heldAt) ||
-      nowMs - heldAt >= panoramaRefreshMs;
-    try {
-      const issueParams = { owner: project.owner, repo: project.name, state: "open" };
-      const issueAnswer = await list({
-        cacheKey: `activity:${repository}:open-issues:${JSON.stringify(issueParams)}`,
-        route: "GET /repos/{owner}/{repo}/issues",
-        parameters: issueParams,
-        operation: REDSKILLED_ACTIVITY_REST_OPERATION,
-      });
-      requestCount += issueAnswer.requestCount;
-      rateLimit = mergeActivityRateLimit(rateLimit, activityRateLimitFromHeaders(issueAnswer.headers));
-      const openIssues = issueAnswer.data.filter((item) => !isRecord(item.pull_request));
-      const queue = project.queue_labels == null
-        ? { ready_queue: null, human_queue: null }
-        : countQueueLabels(openIssues, project.queue_labels);
-
-      let panorama = held?.counts ?? null;
-      if (refreshPanorama) {
-        const prParams = { owner: project.owner, repo: project.name, state: "open" };
-        const closedParams = { owner: project.owner, repo: project.name, state: "closed", since: operation.closed_since };
-        const mergedParams = { q: `repo:${repository} is:pr is:merged merged:>=${operation.merged_since}`, per_page: 1 };
-        const prAnswer = await list({
-          cacheKey: `activity:${repository}:open-prs:${JSON.stringify(prParams)}`,
-          route: "GET /repos/{owner}/{repo}/pulls",
-          parameters: prParams,
-          operation: REDSKILLED_ACTIVITY_REST_OPERATION,
-        });
-        const closedAnswer = await list({
-          cacheKey: `activity:${repository}:recently-closed:${JSON.stringify(closedParams)}`,
-          route: "GET /repos/{owner}/{repo}/issues",
-          parameters: closedParams,
-          operation: REDSKILLED_ACTIVITY_REST_OPERATION,
-        });
-        const mergedAnswer = await count({
-          cacheKey: `activity:${repository}:merged-today:${operation.merged_since}`,
-          route: "GET /search/issues",
-          parameters: mergedParams,
-          operation: REDSKILLED_MERGED_TODAY_OPERATION,
-        });
-        requestCount += prAnswer.requestCount + closedAnswer.requestCount + mergedAnswer.requestCount;
-        for (const headers of [prAnswer.headers, closedAnswer.headers, mergedAnswer.headers]) {
-          rateLimit = mergeActivityRateLimit(rateLimit, activityRateLimitFromHeaders(headers));
-        }
-        const recentlyClosed = closedAnswer.data
-          .filter((item) => !isRecord(item.pull_request))
-          .filter((item) => stringValue(item.closed_at) >= operation.closed_since).length;
-        if (!Number.isSafeInteger(mergedAnswer.data.total_count) || mergedAnswer.data.total_count < 0) {
-          throw new Error(`GitHub returned no merged-today count for ${repository}`);
-        }
-        panorama = {
-          open_pull_requests: prAnswer.data.length,
-          open_issues: openIssues.length,
-          recently_closed: recentlyClosed,
-          merged_today: mergedAnswer.data.total_count,
-          ready_queue: queue.ready_queue,
-          human_queue: queue.human_queue,
-        };
-      }
-      if (panorama == null) throw new Error(`no panorama cache exists for ${repository}`);
-      projects.push({
-        project_label: project.project_label,
-        repository,
-        outcome: "counted",
-        counts: {
-          open_pull_requests: panorama.open_pull_requests,
-          open_issues: panorama.open_issues,
-          recently_closed: panorama.recently_closed,
-          merged_today: panorama.merged_today,
-          ...queue,
-        },
-        panorama_fetched_at: refreshPanorama ? input.now : held?.panorama_fetched_at ?? input.previous?.fetched_at ?? input.now,
-        queue_fetched_at: input.now,
-        detail: `counted ${repository} for project ${JSON.stringify(project.project_label)}`,
-      });
-    } catch (error) {
-      const rateLimited = isGithubRateLimitError(error);
-      rateLimit = mergeActivityRateLimit(rateLimit, {
-        remaining: null,
-        reset_at: null,
-        exhausted: rateLimited,
-        point_cost: null,
-      });
-      const failure = error instanceof Error ? error.message : String(error);
-      projects.push(held?.counts == null
-        ? {
-            project_label: project.project_label,
-            repository,
-            outcome: rateLimited ? "rate-limited" : "unreachable",
-            counts: null,
-            detail: `the activity fetch failed before ${repository} answered: ${failure}`,
-          }
-        : {
-            ...held,
-            // Last-known values retain BOTH of their original instants. The
-            // counter projection will age them honestly while the next cycle
-            // tries again; a transient refusal must not erase the panorama.
-            detail: `serving last-known counters after the activity fetch failed: ${failure}`,
-          });
-    }
-  }
-
-  return {
-    version: 1,
-    fetched_at: input.now,
-    request_count: requestCount,
-    project_count: projects.length,
-    rate_limit: rateLimit,
-    projects,
-  };
 }
 
 /**
@@ -701,67 +552,6 @@ function restBaseUrl(endpoint: string): string {
   url.search = "";
   url.hash = "";
   return url.toString().replace(/\/$/, "");
-}
-
-/** The two label-keyed counters, as the counted half of one poll's counts. */
-type RedskilledActivityQueueCounts = Pick<RedskilledActivityCounts, "ready_queue" | "human_queue">;
-
-/**
- * Count the open Issues carrying each named label. PURE.
- *
- * The names are compared, never read: this is a string equality over what the
- * representation already carries, which is the whole of what the daemon does
- * with a label.
- */
-function countQueueLabels(
-  items: readonly Record<string, unknown>[],
-  labels: RedskilledActivityQueueLabels,
-): RedskilledActivityQueueCounts {
-  const carries = (item: Record<string, unknown>, label: string): boolean =>
-    Array.isArray(item.labels) && item.labels.some((entry) => labelName(entry) === label);
-  return {
-    ready_queue: items.filter((item) => carries(item, labels.ready)).length,
-    human_queue: items.filter((item) => carries(item, labels.human)).length,
-  };
-}
-
-/** A label's name, from either REST shape: the object, or the bare string. */
-function labelName(entry: unknown): string {
-  if (typeof entry === "string") return entry;
-  return isRecord(entry) ? stringValue(entry.name) : "";
-}
-
-function activityRateLimitFromHeaders(headers: GithubResponseHeaders): RedskilledActivityRateLimit {
-  const remaining = integerHeader(headers, "x-ratelimit-remaining");
-  const resetSeconds = integerHeader(headers, "x-ratelimit-reset");
-  return {
-    remaining,
-    reset_at: resetSeconds == null ? null : new Date(resetSeconds * 1000).toISOString(),
-    exhausted: remaining === 0,
-    point_cost: null,
-  };
-}
-
-function mergeActivityRateLimit(
-  held: RedskilledActivityRateLimit,
-  next: RedskilledActivityRateLimit,
-): RedskilledActivityRateLimit {
-  const remaining = next.remaining == null
-    ? held.remaining
-    : held.remaining == null ? next.remaining : Math.min(held.remaining, next.remaining);
-  return {
-    remaining,
-    reset_at: next.reset_at ?? held.reset_at,
-    exhausted: held.exhausted || next.exhausted,
-    point_cost: null,
-  };
-}
-
-function integerHeader(headers: GithubResponseHeaders, name: string): number | null {
-  const raw = headers[name];
-  if (typeof raw !== "string" && typeof raw !== "number") return null;
-  const value = Number(raw);
-  return Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 function assertActivityProjects(projects: readonly RedskilledProjectRepository[]): void {

--- a/apps/redskilled/src/statusline-deaths.ts
+++ b/apps/redskilled/src/statusline-deaths.ts
@@ -39,6 +39,8 @@ export const REDSKILLED_BOOT_LOOP_MIN_DEATHS = 3;
 
 /** How many verdicts a payload carries before the rest are counted instead. */
 export const REDSKILLED_RECENT_DEATH_LIMIT = 4;
+/** A class is an alarm about the current scene, not a durable history label. */
+export const REDSKILLED_DEATH_CLASS_FRESHNESS_MS = 10 * 60 * 1_000;
 
 /**
  * One posed death, reduced to what a surface prints.
@@ -88,6 +90,8 @@ export interface RedskilledStatuslineDeaths {
   readonly latest: RedskilledStatuslineDeath | null;
   /** The newest verdict whose evidence names a sender, independent of the capped receipt list. */
   readonly latest_sender_attributed: RedskilledStatuslineDeath | null;
+  /** The sender class still current enough to alarm; `null` keeps only the aggregate. */
+  readonly current_sender_attributed?: RedskilledStatuslineDeath | null;
   /** When the reaper concluded; `null` when it attributed nothing. */
   readonly reaped_at: string | null;
   /** A repeated same-project boot refusal, absent when the deaths do not establish one. */
@@ -106,6 +110,7 @@ export interface RedskilledStatuslineBootLoop {
 export function buildDeaths(
   attributions: readonly RedskilledDeathObservation[],
   limit: number,
+  options: { readonly now?: string; readonly healthyFleet?: boolean; readonly freshnessMs?: number } = {},
 ): RedskilledStatuslineDeaths {
   const ordered = [...attributions].sort((a, b) => (instant(b.ts) ?? 0) - (instant(a.ts) ?? 0));
   const recent = ordered.slice(0, Math.max(0, Math.floor(limit))).map(statuslineDeath);
@@ -114,13 +119,21 @@ export function buildDeaths(
       attribution.observed_exit === true ||
       (attribution.sender_class !== "unknown" && attribution.confidence !== "none"),
   );
-  const bootLoop = buildBootLoop(ordered);
+  const latestSender = senderAttributed[0] == null ? null : statuslineDeath(senderAttributed[0]);
+  const nowMs = options.now == null ? null : instant(options.now);
+  const latestMs = latestSender == null ? null : instant(latestSender.ts);
+  const freshnessMs = options.freshnessMs ?? REDSKILLED_DEATH_CLASS_FRESHNESS_MS;
+  const bootLoop = buildBootLoop(ordered, { nowMs, freshnessMs });
+  const currentSender = options.healthyFleet === true || nowMs == null || latestMs == null || nowMs - latestMs > freshnessMs
+    ? null
+    : latestSender;
   return {
     count: ordered.length,
     sender_attributed_count: senderAttributed.length,
     recent,
     latest: recent[0] ?? null,
-    latest_sender_attributed: senderAttributed[0] == null ? null : statuslineDeath(senderAttributed[0]),
+    latest_sender_attributed: latestSender,
+    current_sender_attributed: currentSender,
     reaped_at: recent[0]?.ts ?? null,
     ...(bootLoop == null ? {} : { boot_loop: bootLoop }),
   };
@@ -145,6 +158,7 @@ function statuslineDeath(attribution: RedskilledDeathObservation): RedskilledSta
 /** Reduce the rolling death window to its strongest same-project boot loop. PURE. */
 function buildBootLoop(
   ordered: readonly RedskilledDeathObservation[],
+  current: { readonly nowMs: number | null; readonly freshnessMs: number },
 ): RedskilledStatuslineBootLoop | null {
   const byProject = new Map<string, RedskilledDeathObservation[]>();
   for (const death of ordered) {
@@ -166,6 +180,7 @@ function buildBootLoop(
     .map(([projectLabel, deaths]): RedskilledStatuslineBootLoop | null => {
       const newest = deaths[0]!;
       const newestAt = instant(newest.ts)!;
+      if (current.nowMs == null || current.nowMs - newestAt > current.freshnessMs) return null;
       const oldestAt = Math.min(...deaths.map((death) => instant(death.ts)!));
       const refusal = newest.detail?.trim() || newest.evidence[0]?.trim();
       if (refusal == null || refusal === "") return null;

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -583,7 +583,7 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
       : {
           deaths: buildDeaths(input.deaths, input.recentDeathLimit ?? REDSKILLED_RECENT_DEATH_LIMIT, {
             now: input.now,
-            healthyFleet: healthyFleet(input.hostState),
+            healthyFleet: (input.hostState.registrations ?? []).length > 0 && (input.hostState.registrations ?? []).every((registration) => input.hostState.workers.filter((worker) => worker.project_label === registration.project_label).length >= Math.max(0, registration.target)),
           }),
         }),
     engine: buildEngine(input.hostState),
@@ -591,18 +591,6 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
     // holds, and a second derivation here would be a second authority on them.
     ...(input.metrics === undefined ? {} : { metrics: input.metrics }),
   };
-}
-
-/** True once every registered project has its admitted live Worker target. PURE. */
-function healthyFleet(hostState: RedskilledHostState): boolean {
-  const registrations = hostState.registrations ?? [];
-  if (registrations.length === 0) return false;
-  const liveByProject = new Map<string, number>();
-  for (const worker of hostState.workers) {
-    liveByProject.set(worker.project_label, (liveByProject.get(worker.project_label) ?? 0) + 1);
-  }
-  return registrations.every((registration) =>
-    (liveByProject.get(registration.project_label) ?? 0) >= Math.max(0, registration.target));
 }
 
 /**

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -71,6 +71,7 @@ export {
   type RedskilledDeathObservation,
   REDSKILLED_BOOT_LOOP_MIN_DEATHS,
   REDSKILLED_BOOT_REFUSAL_MAX_UPTIME_S,
+  REDSKILLED_DEATH_CLASS_FRESHNESS_MS,
   REDSKILLED_RECENT_DEATH_LIMIT,
   type RedskilledStatuslineBootLoop,
   type RedskilledStatuslineDeath,
@@ -579,12 +580,29 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
     }),
     ...(input.deaths === undefined
       ? {}
-      : { deaths: buildDeaths(input.deaths, input.recentDeathLimit ?? REDSKILLED_RECENT_DEATH_LIMIT) }),
+      : {
+          deaths: buildDeaths(input.deaths, input.recentDeathLimit ?? REDSKILLED_RECENT_DEATH_LIMIT, {
+            now: input.now,
+            healthyFleet: healthyFleet(input.hostState),
+          }),
+        }),
     engine: buildEngine(input.hostState),
     // Echoed, never recomputed: the rates rest on a history only the daemon
     // holds, and a second derivation here would be a second authority on them.
     ...(input.metrics === undefined ? {} : { metrics: input.metrics }),
   };
+}
+
+/** True once every registered project has its admitted live Worker target. PURE. */
+function healthyFleet(hostState: RedskilledHostState): boolean {
+  const registrations = hostState.registrations ?? [];
+  if (registrations.length === 0) return false;
+  const liveByProject = new Map<string, number>();
+  for (const worker of hostState.workers) {
+    liveByProject.set(worker.project_label, (liveByProject.get(worker.project_label) ?? 0) + 1);
+  }
+  return registrations.every((registration) =>
+    (liveByProject.get(registration.project_label) ?? 0) >= Math.max(0, registration.target));
 }
 
 /**

--- a/apps/redskilled/tests/conditional-polling.test.ts
+++ b/apps/redskilled/tests/conditional-polling.test.ts
@@ -13,6 +13,41 @@ const FIRST = "2026-08-04T12:00:00.000Z";
 const SECOND = "2026-08-04T12:00:15.000Z";
 
 describe("the daemon's conditional REST poll path", () => {
+  it("serves last-known panorama and queue values with their original instants on degradation", async () => {
+    let failing = false;
+    const transport = createGitHubActivityTransport({
+      token: "test-token",
+      endpoint: "https://tracker.example/graphql",
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async (url) => {
+        if (failing) throw new Error("tracker unavailable");
+        const path = new URL(String(url)).pathname;
+        if (path.endsWith("/search/issues")) return json({ total_count: 4, items: [] });
+        if (path.endsWith("/pulls")) return json([{ number: 1 }, { number: 2 }]);
+        return json([{ number: 1, closed_at: "2026-08-04T11:00:00.000Z", labels: [] }]);
+      },
+    });
+    const input = {
+      projects: [{
+        project_label: "acme/widgets",
+        owner: "acme",
+        name: "widgets",
+        queue_labels: { ready: "ready-for-agent", human: "ready-for-human" },
+      }],
+      hostTokenRef: "host",
+      transport,
+    };
+    const fresh = await fetchRepositoryActivity({ ...input, now: FIRST });
+    failing = true;
+    const degraded = await fetchRepositoryActivity({ ...input, now: SECOND, previous: fresh });
+
+    expect(degraded.projects[0]!.counts).toEqual(fresh.projects[0]!.counts);
+    expect(degraded.projects[0]!.panorama_fetched_at).toBe(FIRST);
+    expect(degraded.projects[0]!.queue_fetched_at).toBe(FIRST);
+    expect(degraded.projects[0]!.detail).toContain("serving last-known");
+  });
+
   it("returns the held queue depth when GitHub answers 304", async () => {
     const headers: Headers[] = [];
     const fetchImpl: typeof fetch = async (_url, init) => {
@@ -58,18 +93,26 @@ describe("the daemon's conditional REST poll path", () => {
     expect(headers[1]!.get("if-none-match")).toBe('"queue-v1"');
   });
 
-  it("reuses every held activity count when all three collections answer 304", async () => {
+  it("reuses every held activity count when all four panorama reads answer 304", async () => {
     const requests: Array<{ readonly path: string; readonly etag: string | null }> = [];
     const fetchImpl: typeof fetch = async (url, init) => {
       const parsed = new URL(String(url));
       const path = parsed.pathname;
       const etag = new Headers(init?.headers).get("if-none-match");
       requests.push({ path, etag });
-      const kind = path.endsWith("/pulls") ? "prs" : parsed.searchParams.get("state") === "open" ? "issues" : "closed";
+      const kind = path.endsWith("/search/issues")
+        ? "merged"
+        : path.endsWith("/pulls") ? "prs" : parsed.searchParams.get("state") === "open" ? "issues" : "closed";
       if (etag === `"${kind}-v1"`) {
         return new Response(null, { status: 304, headers: { etag } });
       }
-      const count = kind === "prs" ? 2 : kind === "issues" ? 3 : 5;
+      const count = kind === "prs" ? 2 : kind === "issues" ? 3 : kind === "merged" ? 4 : 5;
+      if (kind === "merged") {
+        return new Response(JSON.stringify({ total_count: count, items: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json", etag: `"${kind}-v1"` },
+        });
+      }
       const items = Array.from({ length: count }, (_, index) => ({
         number: index + 1,
         ...(kind === "closed" ? { closed_at: "2026-08-04T11:00:00.000Z" } : {}),
@@ -93,19 +136,25 @@ describe("the daemon's conditional REST poll path", () => {
     };
 
     const fresh = await fetchRepositoryActivity({ ...input, now: FIRST });
-    const unchanged = await fetchRepositoryActivity({ ...input, now: SECOND });
+    const unchanged = await fetchRepositoryActivity({
+      ...input,
+      now: SECOND,
+      previous: fresh,
+      panoramaRefreshMs: 0,
+    });
 
     expect(fresh.projects[0]).toMatchObject({
       outcome: "counted",
-      counts: { open_pull_requests: 2, open_issues: 3, recently_closed: 5 },
+      counts: { open_pull_requests: 2, open_issues: 3, recently_closed: 5, merged_today: 4 },
     });
-    expect(unchanged.projects).toEqual(fresh.projects);
-    expect(unchanged.request_count).toBe(3);
-    expect(requests).toHaveLength(6);
-    expect(requests.slice(3).map((request) => request.etag)).toEqual([
-      '"prs-v1"',
+    expect(unchanged.projects[0]!.counts).toEqual(fresh.projects[0]!.counts);
+    expect(unchanged.request_count).toBe(4);
+    expect(requests).toHaveLength(8);
+    expect(requests.slice(4).map((request) => request.etag)).toEqual([
       '"issues-v1"',
+      '"prs-v1"',
       '"closed-v1"',
+      '"merged-v1"',
     ]);
   });
 
@@ -114,6 +163,7 @@ describe("the daemon's conditional REST poll path", () => {
     const fetchImpl: typeof fetch = async (url) => {
       const parsed = new URL(String(url));
       paths.push(`${parsed.pathname}?${parsed.searchParams.get("state")}`);
+      if (parsed.pathname.endsWith("/search/issues")) return json({ total_count: 3, items: [] });
       if (parsed.pathname.endsWith("/pulls")) {
         return json([{ number: 1 }, { number: 2 }]);
       }
@@ -152,17 +202,19 @@ describe("the daemon's conditional REST poll path", () => {
       outcome: "counted",
       counts: { open_pull_requests: 2, open_issues: 4, ready_queue: 2, human_queue: 1 },
     });
-    // Three collections, three requests: the queue counters are a filter over
+    // Four reads, with queue counters still a filter over the open-Issue bytes:
     // bytes this poll already holds, never two more label-filtered lists.
-    expect(activity.request_count).toBe(3);
-    expect(paths).toHaveLength(3);
+    expect(activity.request_count).toBe(4);
+    expect(paths).toHaveLength(4);
   });
 
   it("leaves both queue counters absent when a project names no label", async () => {
     const transport = createGitHubActivityTransport({
       token: "test-token",
       endpoint: "https://tracker.example/graphql",
-      fetchImpl: (async () => json([{ number: 1, labels: [{ name: "ready-for-agent" }] }])) as unknown as typeof fetch,
+      fetchImpl: (async (url: string | URL | Request) => String(url).includes("/search/issues")
+        ? json({ total_count: 0, items: [] })
+        : json([{ number: 1, labels: [{ name: "ready-for-agent" }] }])) as unknown as typeof fetch,
       retryCount: 0,
       throttle: false,
     });

--- a/apps/redskilled/tests/registration-counter-poll.test.ts
+++ b/apps/redskilled/tests/registration-counter-poll.test.ts
@@ -49,6 +49,14 @@ async function trackerStandingIn(): Promise<{
     let body: readonly Record<string, unknown>[];
     if (url.pathname.endsWith("/pulls")) {
       body = [{ number: 1 }, { number: 2 }];
+    } else if (url.pathname.endsWith("/search/issues")) {
+      res.writeHead(200, {
+        "content-type": "application/json",
+        etag: `"${requests.length}"`,
+        "x-ratelimit-remaining": "4900",
+      });
+      res.end(JSON.stringify({ total_count: 4, items: [] }));
+      return;
     } else if (url.searchParams.get("state") === "closed") {
       body = [{ number: 20, closed_at: "2026-08-11T12:00:00.000Z" }];
     } else if (url.searchParams.has("labels")) {
@@ -120,6 +128,7 @@ describe("the registration supplies the remote-counter poll", () => {
     const counters = payload.remote_counters!.projects[0]!.counters;
     expect(counters.open_pull_requests).toMatchObject({ value: 2, fetched_at: expect.any(String) });
     expect(counters.open_issues).toMatchObject({ value: 3, fetched_at: expect.any(String) });
+    expect(counters.merged_today).toMatchObject({ value: 4, fetched_at: expect.any(String), age_ms: expect.any(Number) });
     expect(counters.ready_queue).toMatchObject({ value: 1, fetched_at: expect.any(String) });
     expect(counters.human_queue).toMatchObject({ value: 1, fetched_at: expect.any(String) });
     expect(payload.repository_activity.projects[0]).toMatchObject({
@@ -127,11 +136,21 @@ describe("the registration supplies the remote-counter poll", () => {
       fetched_at: expect.any(String),
     });
 
-    // One selector list plus the activity cycle's three lists. Payload reads
+    // One selector list plus the activity cycle's four reads. Payload reads
     // remain cache-only, and every request used the one registration transport.
     daemon.statuslinePayload();
     daemon.statuslinePayload();
-    expect(tracker.requests).toHaveLength(4);
+    expect(tracker.requests).toHaveLength(5);
+
+    // The next attended cycle refreshes only the open-Issue representation that
+    // feeds the ready queue. Panorama counts remain last-known and retain their
+    // own earlier instant until their longer tier expires.
+    const panoramaAt = counters.merged_today.fetched_at;
+    await daemon.pollRepositoryActivity();
+    const refreshed = daemon.statuslinePayload().remote_counters!.projects[0]!.counters;
+    expect(tracker.requests).toHaveLength(6);
+    expect(refreshed.ready_queue.fetched_at).not.toBeNull();
+    expect(refreshed.merged_today.fetched_at).toBe(panoramaAt);
     expect(tracker.requests.every((request) => request.authorization === "token shared-host-token")).toBe(true);
   });
 });

--- a/apps/redskilled/tests/registration-sustain.test.ts
+++ b/apps/redskilled/tests/registration-sustain.test.ts
@@ -506,7 +506,8 @@ describe("a surface tells a registration from a name", () => {
     const render = renderRedskilledStatusline(payloadOf(["acme/widgets"], [worker]), options());
 
     expect(render.project_match).toBe("matched");
-    expect(render.line).toContain("acme/widgets 1w");
+    expect(render.line).toContain("1w 0B v0.1.0");
+    expect(render.line).not.toContain("acme/widgets");
     expect(render.line).not.toContain("unregistered");
   });
 
@@ -516,7 +517,8 @@ describe("a surface tells a registration from a name", () => {
     const render = renderRedskilledStatusline(payloadOf([], [worker]), options());
 
     expect(render.project_match).toBe("name-only");
-    expect(render.line).toContain("acme/widgets 1w");
+    expect(render.line).toContain("1w !unregistered 0B v0.1.0");
+    expect(render.line).not.toContain("acme/widgets");
     expect(render.line).toContain("!unregistered");
     expect(render.line).not.toContain("idle");
   });

--- a/apps/redskilled/tests/render-contract.test.ts
+++ b/apps/redskilled/tests/render-contract.test.ts
@@ -88,7 +88,8 @@ describe("one render module, and the daemon's payload satisfies it", () => {
       ...REDSKILLED_STATUSLINE_DEFAULTS,
       project: "acme/widgets",
     });
-    expect(drawn.line).toContain("acme/widgets 1w");
+    expect(drawn.line).toContain("1w !unregistered 512M");
+    expect(drawn.line).not.toContain("acme/widgets");
     // Known by NAME: this daemon holds the Worker and no registration for its
     // project, and the shared render says so from the payload alone (#2973).
     expect(drawn.project_match).toBe("name-only");

--- a/apps/redskilled/tests/repository-activity.test.ts
+++ b/apps/redskilled/tests/repository-activity.test.ts
@@ -62,6 +62,7 @@ function answer(
       open_issues: { totalCount: issues },
     };
     data[`c${index}`] = { issueCount: closed };
+    data[`m${index}`] = { issueCount: 0 };
   });
   return { data };
 }
@@ -76,6 +77,8 @@ describe("one request per interval, whatever the project count", () => {
     for (let index = 0; index < projects.length; index += 1) {
       expect(operation.query).toContain(`r${index}: repository(owner: "acme", name: "p${index}")`);
       expect(operation.query).toContain(`c${index}: search(`);
+      expect(operation.query).toContain(`m${index}: search(`);
+      expect(operation.query).toContain("is:pr is:merged merged:>=2026-07-30");
     }
   });
 
@@ -171,7 +174,7 @@ describe("counts are stored and returned, never interpreted", () => {
       project_label: "acme/p0",
       repository: "acme/p0",
       outcome: "counted",
-      counts: { open_pull_requests: 7, open_issues: 3, recently_closed: 11 },
+      counts: { open_pull_requests: 7, open_issues: 3, recently_closed: 11, merged_today: 0 },
     });
     // A genuinely empty tracker IS a zero — this is the only outcome that carries one.
     // The queue counters stay null even here: the aliased query asked for no
@@ -180,6 +183,7 @@ describe("counts are stored and returned, never interpreted", () => {
       open_pull_requests: 0,
       open_issues: 0,
       recently_closed: 0,
+      merged_today: 0,
       ready_queue: null,
       human_queue: null,
     });
@@ -240,8 +244,10 @@ describe("an unreachable repository fails loudly", () => {
         rateLimit: { remaining: 4900, resetAt: "2026-07-30T13:00:00.000Z" },
         r0: { nameWithOwner: "acme/p0", open_pull_requests: { totalCount: 2 }, open_issues: { totalCount: 5 } },
         c0: { issueCount: 1 },
+        m0: { issueCount: 0 },
         r1: null,
         c1: null,
+        m1: null,
       },
       errors: [{ type: "NOT_FOUND", path: ["r1"], message: "Could not resolve to a Repository with the name 'acme/p1'." }],
     };
@@ -275,7 +281,7 @@ describe("a rate-limited fetch is not an empty one", () => {
     const projects = [project(0)];
     const operation = buildRepositoryActivityQuery(projects, { now: NOW });
     const payload = {
-      data: { rateLimit: { remaining: 0, resetAt: "2026-07-30T13:00:00.000Z" }, r0: null, c0: null },
+      data: { rateLimit: { remaining: 0, resetAt: "2026-07-30T13:00:00.000Z" }, r0: null, c0: null, m0: null },
       errors: [{ type: "RATE_LIMITED", path: ["r0"], message: "API rate limit exceeded" }],
     };
 
@@ -463,6 +469,7 @@ describe("the daemon serves the counts it polled", () => {
     expect(payload.repository_activity.projects[0]!.counts).toEqual({
       open_pull_requests: 4,
       open_issues: 9,
+      merged_today: 0,
       recently_closed: 2,
       ready_queue: null,
       human_queue: null,

--- a/apps/redskilled/tests/statusline-dashboard.test.ts
+++ b/apps/redskilled/tests/statusline-dashboard.test.ts
@@ -317,8 +317,8 @@ describe("the dashboard carries the statusline's own fields", () => {
     expect(header.model).toBe("claude·opus·high");
     expect(header.counts).toMatchObject({ open_pull_requests: 3, open_issues: 24, recently_closed: 7 });
     expect(stripAnsi(header.line)).toContain("» acme/widgets v0.1.0");
-    expect(stripAnsi(header.line)).toContain("prs=3");
-    expect(stripAnsi(header.line)).toContain("cpr=7");
+    expect(stripAnsi(header.line)).toContain("pr=3");
+    expect(stripAnsi(header.line)).not.toContain("cpr=");
     expect(stripAnsi(header.line)).toContain("iss=24");
   });
 

--- a/apps/redskilled/tests/statusline-deaths.test.ts
+++ b/apps/redskilled/tests/statusline-deaths.test.ts
@@ -92,6 +92,7 @@ function bootRefusal(id: string, ts: string): DeathAttribution {
 function payloadWith(
   deaths: readonly DeathAttribution[] | undefined,
   published?: { version: string | null; newer?: boolean; newest?: string | null },
+  healthy = false,
 ) {
   return buildStatuslinePayload({
     hostState: buildHostState({
@@ -101,6 +102,25 @@ function payloadWith(
       pid: 99,
       startedAt: "2026-07-29T00:00:00.000Z",
       workers: [worker()],
+      ...(healthy
+        ? {
+            registrations: [{
+              version: 1 as const,
+              project_label: "acme/widgets",
+              selector: "opaque",
+              argv: ["opaque"],
+              workspace_path: "/tmp/acme",
+              env: {},
+              target: 1,
+              registered_at: "2026-07-29T00:00:00.000Z",
+              renew_within_ms: 60_000,
+              renew_by: "2026-07-29T01:01:00.000Z",
+              renewed_at: "2026-07-29T01:00:00.000Z",
+              renewals: 1,
+              launch_revision: 0,
+            }],
+          }
+        : {}),
       ...(published == null
         ? {}
         : {
@@ -141,6 +161,7 @@ describe("the aggregate carries what could not be explained", () => {
       recent: [],
       latest: null,
       latest_sender_attributed: null,
+      current_sender_attributed: null,
       reaped_at: null,
     });
   });
@@ -208,6 +229,35 @@ describe("the aggregate says which engine answered, and whether it is current", 
 });
 
 describe("the statusline head answers both questions", () => {
+  it("keeps the aggregate after the death class ages out", () => {
+    const fresh = renderRedskilledStatusline(payloadWith([
+      attribution({ ts: "2026-07-29T00:50:06.000Z" }),
+    ]), {
+      ...REDSKILLED_STATUSLINE_DEFAULTS,
+      project: "acme/widgets",
+    });
+    const old = renderRedskilledStatusline(payloadWith([
+      attribution({ ts: "2026-07-29T00:50:04.000Z" }),
+    ]), {
+      ...REDSKILLED_STATUSLINE_DEFAULTS,
+      project: "acme/widgets",
+    });
+
+    expect(fresh.line).toContain("†1 oomd");
+    expect(old.line).toContain("†1");
+    expect(old.line).not.toContain("oomd");
+  });
+
+  it("clears the class once every registered target is healthy again", () => {
+    const render = renderRedskilledStatusline(payloadWith([attribution()], undefined, true), {
+      ...REDSKILLED_STATUSLINE_DEFAULTS,
+      project: "acme/widgets",
+    });
+
+    expect(render.line).toContain("†1");
+    expect(render.line).not.toContain("oomd");
+  });
+
   it("renders the engine version and the newest death's class", () => {
     const render = renderRedskilledStatusline(payloadWith([attribution()]), {
       ...REDSKILLED_STATUSLINE_DEFAULTS,
@@ -235,9 +285,9 @@ describe("the statusline head answers both questions", () => {
 
   it("names a repeated boot refusal as a loop, with its span and repair clue", () => {
     const payload = payloadWith([
-      bootRefusal("worker:w-9", "2026-07-29T00:04:00.000Z"),
-      bootRefusal("worker:w-9", "2026-07-29T00:02:00.000Z"),
-      bootRefusal("worker:w-9", "2026-07-29T00:00:00.000Z"),
+      bootRefusal("worker:w-9", "2026-07-29T00:59:00.000Z"),
+      bootRefusal("worker:w-9", "2026-07-29T00:57:00.000Z"),
+      bootRefusal("worker:w-9", "2026-07-29T00:55:00.000Z"),
     ]);
     const render = renderRedskilledStatusline(payload, {
       ...REDSKILLED_STATUSLINE_DEFAULTS,

--- a/apps/redskilled/tests/statusline-local-project.test.ts
+++ b/apps/redskilled/tests/statusline-local-project.test.ts
@@ -120,7 +120,8 @@ describe("the local statusline mode, invoked inside a registered project", () =>
     // fixture produced before #2928 was `project unknown 0w 0B idle`.
     expect(written[0]).not.toContain("project unknown");
     expect(written[0]).not.toContain("idle");
-    expect(written[0]).toContain("reddb-io/red-skills 3w");
+    expect(written[0]).toContain("3w !unregistered 21M");
+    expect(written[0]).not.toContain("reddb-io/red-skills");
     for (const id of ["w-1", "w-2", "w-3"]) expect(written[0]).toContain(id);
   });
 
@@ -147,7 +148,8 @@ describe("the local statusline mode, invoked inside a registered project", () =>
     const code = await runStatusline([], { cwd, paths, write: (line) => written.push(line), warn: () => undefined });
 
     expect(code).toBe(0);
-    expect(written[0]).toContain("acme/declared 1w");
+    expect(written[0]).toContain("1w !unregistered 7M");
+    expect(written[0]).not.toContain("acme/declared");
   });
 });
 
@@ -198,7 +200,8 @@ describe("`project unknown`", () => {
     expect(render.line).not.toContain("project unknown");
     // An idle project says so, which is the fact `project unknown` must never
     // stand in for: one means "nothing running", the other "nobody knows you".
-    expect(render.line).toContain("acme/widgets 0w");
+    expect(render.line).toContain("0w idle");
+    expect(render.line).not.toContain("acme/widgets");
     expect(render.line).toContain("idle");
   });
 
@@ -209,7 +212,7 @@ describe("`project unknown`", () => {
     );
 
     expect(render.project_match).toBe("unregistered");
-    expect(render.line).toBe("acme/widgets 0w 0B idle v0.1.0");
+    expect(render.line).toBe("0w idle 0B v0.1.0");
     expect(render.repair).toBeUndefined();
     expect(render.repair_reason).toBeUndefined();
   });

--- a/apps/redskilled/tests/statusline-payload.test.ts
+++ b/apps/redskilled/tests/statusline-payload.test.ts
@@ -373,6 +373,7 @@ function counts(overrides: Partial<RedskilledActivityCounts> = {}): RedskilledAc
   return {
     open_pull_requests: 3,
     open_issues: 24,
+    merged_today: 7,
     recently_closed: 5,
     ready_queue: 1,
     human_queue: 11,
@@ -423,6 +424,7 @@ describe("the remote-counter block", () => {
     expect(Object.keys(project.counters).sort()).toEqual([...REDSKILLED_REMOTE_COUNTER_NAMES].sort());
     expect(project.counters.open_pull_requests).toMatchObject({ value: 3, fetched_at: POLLED_AT, age_ms: 5_000, stale: false });
     expect(project.counters.open_issues).toMatchObject({ value: 24, age_ms: 5_000 });
+    expect(project.counters.merged_today).toMatchObject({ value: 7, fetched_at: POLLED_AT, age_ms: 5_000 });
     expect(project.counters.ready_queue).toMatchObject({ value: 1, fetched_at: POLLED_AT, age_ms: 5_000, stale: false });
     expect(project.counters.human_queue).toMatchObject({ value: 11, age_ms: 5_000 });
     expect(isRedskilledStatuslinePayload(payload)).toBe(true);
@@ -471,9 +473,9 @@ describe("the remote-counter block", () => {
     }
   });
 
-  it("reaches the statusline tail as the four counters a reader sees", () => {
+  it("reaches the statusline tail as the compact panorama a reader sees", () => {
     // The seam between the block this daemon composes and the line a reader
-    // gets: one poll in, four dated numbers out, drawn by the shared renderer
+    // gets: one poll in, the dated panorama out, drawn by the shared renderer
     // rather than by an assertion's own idea of the layout.
     const payload = payloadWith(activityOf(counts()), "2026-08-11T12:00:05.000Z");
 
@@ -482,7 +484,8 @@ describe("the remote-counter block", () => {
       { ...REDSKILLED_STATUSLINE_DEFAULTS, project: "acme/widgets" },
     ).line);
 
-    expect(line).toContain("prs=3 cpr=5 iss=24 rdy=1 hmn=11");
+    expect(line).toContain("rdy=1 iss=24 pr=3 mrg=7");
+    expect(line).not.toContain("cpr=");
   });
 
   it("is honestly empty when the daemon polled nothing, and validates without the block", () => {

--- a/apps/redskilled/tests/statusline-string.test.ts
+++ b/apps/redskilled/tests/statusline-string.test.ts
@@ -159,7 +159,7 @@ describe("the rendered statusline", () => {
     expect(render.generated_at).toBe(payload.generated_at);
   });
 
-  it("defaults to the local project's Workers and names no other project", () => {
+  it("defaults to the local project's Workers without repeating the project in the tail", () => {
     const payload = payloadOf(
       [worker(), worker({ worker_id: "w-2", project_label: "acme/gadgets", pid: 43 })],
       { "w-1": 512 * MB, "w-2": 128 * MB },
@@ -168,7 +168,8 @@ describe("the rendered statusline", () => {
     const render = renderRedskilledStatusline(payload, options({ project: "acme/widgets" }));
 
     expect(render.mode).toBe("local");
-    expect(render.line).toContain("acme/widgets 1w");
+    expect(render.line).toContain("1w !unregistered 512M v0.1.0");
+    expect(render.line).not.toContain("acme/widgets");
     expect(stripAnsi(render.lines[1]!)).toContain("w-1");
     expect(render.lines.join("\n")).not.toContain("w-2");
     expect(render.lines.join("\n")).not.toContain("acme/gadgets");
@@ -265,7 +266,7 @@ describe("the rendered statusline", () => {
     const render = renderRedskilledStatusline(idle, options({ project: "acme/widgets" }));
     expect(render.stale).toBe(false);
     expect(render.project_match).toBe("matched");
-    expect(render.line).toBe("acme/widgets 0w 0B idle v0.1.0");
+    expect(render.line).toBe("0w idle 0B v0.1.0");
   });
 });
 
@@ -346,6 +347,10 @@ describe("one renderer, machine-wide", () => {
     "apps/redskilled/src/daemon/tunables.ts",
     "apps/redskilled/src/protocol.ts",
     "apps/redskilled/src/client.ts",
+    // Probe-only transport and its command adapter carry the typed payload to
+    // the shared renderer; neither draws an independent statusline.
+    "apps/redskilled/src/statusline-probe.ts",
+    "apps/redskilled/src/statusline-command.ts",
   ]);
 
   it("keeps every other surface — every agent host included — on the string", () => {
@@ -450,6 +455,7 @@ describe("the host's whole job", () => {
     // The defect: `project unknown 0w` while the daemon held a labelled Worker.
     expect(written[0]).not.toContain("project unknown");
     expect(written[0]).not.toContain("0w");
-    expect(written[0]).toContain("reddb-io/red-skills");
+    expect(written[0]).toContain("1w !unregistered 512M");
+    expect(written[0]).not.toContain("reddb-io/red-skills");
   });
 });

--- a/packages/redskilled-render/counters.ts
+++ b/packages/redskilled-render/counters.ts
@@ -34,22 +34,21 @@ export const REDSKILLED_COUNTER_LABELS: ReadonlyArray<{
   readonly name: RedskilledRenderCounterName;
   readonly key: string;
 }> = [
-  { name: "open_pull_requests", key: "prs" },
-  { name: "open_issues", key: "iss" },
   { name: "ready_queue", key: "rdy" },
-  { name: "human_queue", key: "hmn" },
+  { name: "open_issues", key: "iss" },
+  { name: "open_pull_requests", key: "pr" },
+  { name: "merged_today", key: "mrg" },
 ];
 
 /**
  * The counter tokens for one project, ready to be joined into a head. PURE.
  *
- * Ordered `prs cpr iss rdy hmn`: the repository's own totals, then what closed
- * inside the poll's window, then the two queues an operator acts on. `cpr` comes
- * from the activity report rather than the counter block because it is not one
- * of the four dated counters — it is the poll's own window figure.
+ * Ordered `rdy iss pr mrg`: the actionable queue first, then the compact
+ * repository panorama. The older seven-day `cpr` and human-queue cells remain
+ * available as structured dashboard counts but no longer spend tail width.
  *
- * A daemon that predates the counter block still renders `prs`/`cpr`/`iss` from
- * the poll-dated counts (ADR 0130 rule 3); it simply cannot date them
+ * A daemon that predates the counter block still renders `pr`/`iss` from the
+ * poll-dated counts (ADR 0130 rule 3); it simply cannot date them
  * individually, and the caller's blanket staleness marker stays its answer.
  */
 export function remoteCounterTokens(
@@ -60,10 +59,6 @@ export function remoteCounterTokens(
   const activity = activityProject(payload, project);
   const tokens: string[] = [];
   for (const { name, key } of REDSKILLED_COUNTER_LABELS) {
-    if (key === "iss") {
-      const closed = activity?.counts?.recently_closed;
-      if (closed != null) tokens.push(`cpr=${closed}`);
-    }
     const token = counterToken(key, block?.counters[name], fallbackValue(activity, name));
     if (token != null) tokens.push(token);
   }
@@ -73,6 +68,7 @@ export function remoteCounterTokens(
 /** The repo-global counts a header carries as structure, each `null` when unpolled. */
 export interface RedskilledDashboardCounts {
   readonly open_pull_requests: number | null;
+  readonly merged_today: number | null;
   /** Pull requests and Issues closed inside the poller's window — the `cpr` cell. */
   readonly recently_closed: number | null;
   readonly open_issues: number | null;
@@ -101,6 +97,7 @@ export function dashboardCounts(
   return {
     open_pull_requests: dated?.counters.open_pull_requests.value
       ?? activity?.counts?.open_pull_requests ?? null,
+    merged_today: dated?.counters.merged_today.value ?? activity?.counts?.merged_today ?? null,
     recently_closed: activity?.counts?.recently_closed ?? null,
     open_issues: dated?.counters.open_issues.value ?? activity?.counts?.open_issues ?? null,
     ready_queue: dated?.counters.ready_queue.value ?? null,
@@ -144,6 +141,7 @@ function fallbackValue(
   if (counts == null) return null;
   if (name === "open_pull_requests") return counts.open_pull_requests;
   if (name === "open_issues") return counts.open_issues;
+  if (name === "merged_today") return counts.merged_today ?? null;
   // The queue counts exist only on the dated block: a daemon that never counted
   // them has no number to fall back to, and inventing a zero would render an
   // empty queue for a poll that never asked.

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -472,8 +472,11 @@ function buildHeader(
   if (deaths != null && deaths.count > 0 && deaths.latest != null) {
     const loop = deaths.boot_loop;
     const refusal = flattenPublishedLine(loop?.latest_refusal);
+    const current = Object.prototype.hasOwnProperty.call(deaths, "current_sender_attributed")
+      ? deaths.current_sender_attributed ?? null
+      : deaths.latest;
     parts.push(loop == null
-      ? `${DEATH_MARK}${deaths.count} ${deaths.latest.sender_class}`
+      ? `${DEATH_MARK}${deaths.count}${current == null ? "" : ` ${current.sender_class}`}`
       : `${DEATH_MARK}${deaths.count} boot-refused ×${loop.count} in ${compactLoopSpan(loop.span_ms)}` +
         (refusal == null ? "" : ` — ${refusal}`));
   }

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -311,15 +311,13 @@ function renderHead(
     parts.push(`host ${workerActivity(payload.workers, payload.host.worker_count)}/${payload.host.project_count}p`);
     parts.push(memoryFigure(payload, options));
   } else if (match === "matched" || match === "unregistered") {
-    parts.push(`${options.project} ${workerActivity(workers, workers.length)}`);
-    parts.push(memoryFigure(payload, options));
+    parts.push(workerActivity(workers, workers.length));
     if (workers.length === 0) parts.push("idle");
   } else if (match === "name-only") {
     // The Workers still count — they are running — but the line says out loud
     // that the host holds no registration, and it never says `idle`: a project
     // nothing will be born for is stopped, not resting (#2973).
-    parts.push(`${options.project} ${workerActivity(workers, workers.length)}`);
-    parts.push(memoryFigure(payload, options));
+    parts.push(workerActivity(workers, workers.length));
     parts.push(UNREGISTERED_MARK);
   } else {
     // NOT `0w idle`. An unmatched directory has no Worker count to report — the
@@ -333,6 +331,9 @@ function renderHead(
   // repository's queue depth on it would be attributed to every project on the
   // machine.
   if (options.mode !== "global") parts.push(...remoteCounterTokens(payload, options.project));
+  if (options.mode !== "global" && (match === "matched" || match === "unregistered" || match === "name-only")) {
+    parts.push(memoryFigure(payload, options));
+  }
   parts.push(engineMark(payload));
   const budget = budgetMark(payload);
   if (budget != null) parts.push(budget);
@@ -429,7 +430,10 @@ function deathMark(payload: RedskilledRenderPayload): string | null {
     return `${DEATH_MARK}${count} boot-refused ×${loop.count} in ${compactLoopSpan(loop.span_ms)}` +
       (refusal == null ? "" : ` — ${refusal}`);
   }
-  return `${DEATH_MARK}${count} ${latest.sender_class}`;
+  const current = Object.prototype.hasOwnProperty.call(deaths, "current_sender_attributed")
+    ? deaths.current_sender_attributed ?? null
+    : latest;
+  return current == null ? `${DEATH_MARK}${count}` : `${DEATH_MARK}${count} ${current.sender_class}`;
 }
 
 /** A loop span without zero-valued trailing units (`4m`, not `4m0s`). PURE. */

--- a/packages/redskilled-render/panel.ts
+++ b/packages/redskilled-render/panel.ts
@@ -190,10 +190,13 @@ function panelNotes(
   const notes: string[] = [];
   const deaths = payload.deaths;
   if (deaths != null && deaths.count > 0 && deaths.latest != null) {
+    const current = Object.prototype.hasOwnProperty.call(deaths, "current_sender_attributed")
+      ? deaths.current_sender_attributed ?? null
+      : deaths.latest;
     notes.push(
       clamp(
-        `${DEATH_MARK} ${deaths.count} posed death(s) — newest ${deaths.latest.sender_class}/` +
-          `${deaths.latest.confidence} on pid ${deaths.latest.pid}`,
+        `${DEATH_MARK} ${deaths.count} posed death(s)` +
+          (current == null ? "" : ` — newest ${current.sender_class}/${current.confidence} on pid ${current.pid}`),
         options.maxWidth,
       ),
     );

--- a/packages/redskilled-render/payload.ts
+++ b/packages/redskilled-render/payload.ts
@@ -226,6 +226,8 @@ export interface RedskilledRenderDeaths {
   readonly latest: RedskilledRenderDeath | null;
   /** Optional for the same rolling-upgrade window as `sender_attributed_count`. */
   readonly latest_sender_attributed?: RedskilledRenderDeath | null;
+  /** Optional for rolling compatibility; null means the historical class is no longer current. */
+  readonly current_sender_attributed?: RedskilledRenderDeath | null;
   readonly reaped_at: string | null;
   readonly boot_loop?: RedskilledRenderBootLoop;
 }
@@ -316,6 +318,7 @@ export interface RedskilledRenderHourlyHistory {
 export interface RedskilledRenderActivityCounts {
   readonly open_pull_requests: number;
   readonly open_issues: number;
+  readonly merged_today?: number;
   readonly recently_closed: number;
 }
 
@@ -345,6 +348,7 @@ export interface RedskilledRenderActivity {
 export const REDSKILLED_RENDER_COUNTER_NAMES = [
   "open_pull_requests",
   "open_issues",
+  "merged_today",
   "ready_queue",
   "human_queue",
 ] as const;

--- a/packages/redskilled-render/tests/counters.test.ts
+++ b/packages/redskilled-render/tests/counters.test.ts
@@ -19,36 +19,35 @@ import { counters, payload } from "./fixture.js";
 const LOCAL = { ...REDSKILLED_STATUSLINE_DEFAULTS, project: "acme/widgets" };
 const TABLE = { ...REDSKILLED_DASHBOARD_DEFAULTS, project: "acme/widgets" };
 
-const FOUR = { open_pull_requests: 3, open_issues: 24, ready_queue: 5, human_queue: 2 };
+const FIVE = { open_pull_requests: 3, open_issues: 24, merged_today: 7, ready_queue: 5, human_queue: 2 };
 
 describe("remote counters ride the daemon payload", () => {
-  it("renders all four counters on the statusline head, in reading order", () => {
+  it("renders the compact daemon tail without repeating the project label", () => {
     const line = stripAnsi(
-      renderRedskilledStatusline(payload({ remote_counters: counters(FOUR) }), LOCAL).line,
+      renderRedskilledStatusline(payload({ remote_counters: counters(FIVE) }), LOCAL).line,
     );
 
-    expect(line).toContain("prs=3 iss=24 rdy=5 hmn=2");
-    // Ahead of the version, with the project they describe.
-    expect(line.indexOf("prs=3")).toBeLessThan(line.indexOf("v3.3.11"));
+    expect(line).toBe("1w rdy=5 iss=24 pr=3 mrg=7 512M v3.3.11");
+    expect(line).not.toContain("acme/widgets");
   });
 
   it("states the age of a counter served past its window, and only then", () => {
     const fresh = stripAnsi(
       renderRedskilledStatusline(
-        payload({ remote_counters: counters(FOUR, { ageMs: 5_000, thresholdMs: 120_000 }) }),
+        payload({ remote_counters: counters(FIVE, { ageMs: 5_000, thresholdMs: 120_000 }) }),
         LOCAL,
       ).line,
     );
     const stale = stripAnsi(
       renderRedskilledStatusline(
-        payload({ remote_counters: counters(FOUR, { ageMs: 900_000, thresholdMs: 120_000 }) }),
+        payload({ remote_counters: counters(FIVE, { ageMs: 900_000, thresholdMs: 120_000 }) }),
         LOCAL,
       ).line,
     );
 
-    expect(fresh).toContain("prs=3 iss=24 rdy=5 hmn=2");
+    expect(fresh).toContain("rdy=5 iss=24 pr=3 mrg=7");
     expect(fresh).not.toContain("(");
-    expect(stale).toContain("prs=3(15m) iss=24(15m) rdy=5(15m) hmn=2(15m)");
+    expect(stale).toContain("rdy=5(15m) iss=24(15m) pr=3(15m) mrg=7(15m)");
   });
 
   it("costs the line nothing for a counter this poll never produced", () => {
@@ -61,7 +60,7 @@ describe("remote counters ride the daemon payload", () => {
 
     // NOT `rdy=0`: a queue nobody counted and a queue that drained are different
     // facts, and only one of them is a number.
-    expect(line).toContain("prs=3 iss=24");
+    expect(line).toContain("iss=24 pr=3");
     expect(line).not.toContain("rdy=");
     expect(line).not.toContain("hmn=");
   });
@@ -69,38 +68,39 @@ describe("remote counters ride the daemon payload", () => {
   it("draws no repository counters on a host-wide head", () => {
     const line = stripAnsi(
       renderRedskilledStatusline(
-        payload({ remote_counters: counters(FOUR) }),
+        payload({ remote_counters: counters(FIVE) }),
         { ...LOCAL, mode: "global" },
       ).line,
     );
 
-    expect(line).not.toContain("prs=");
+    expect(line).not.toContain("pr=");
     expect(line).not.toContain("rdy=");
   });
 
   it("draws nothing for a project this host holds no counters for", () => {
     expect(
-      remoteCounterTokens(payload({ remote_counters: counters(FOUR) }), "other/repo"),
+      remoteCounterTokens(payload({ remote_counters: counters(FIVE) }), "other/repo"),
     ).toEqual([]);
-    expect(remoteCounterTokens(payload({ remote_counters: counters(FOUR) }), null)).toEqual([]);
+    expect(remoteCounterTokens(payload({ remote_counters: counters(FIVE) }), null)).toEqual([]);
   });
 
   it("gives the table and the line the same counters for one poll", () => {
     const document = payload({
-      remote_counters: counters(FOUR, { ageMs: 900_000, thresholdMs: 120_000 }),
+      remote_counters: counters(FIVE, { ageMs: 900_000, thresholdMs: 120_000 }),
     });
     const line = stripAnsi(renderRedskilledStatusline(document, LOCAL).line);
     const header = stripAnsi(renderRedskilledDashboard(document, TABLE).header.line);
 
     // The table separates its parts and the line does not; the counters, their
     // order and their ages are the same poll either way.
-    expect(header).toContain("prs=3(15m) · iss=24(15m) · rdy=5(15m) · hmn=2(15m)");
+    expect(header).toContain("rdy=5(15m) · iss=24(15m) · pr=3(15m) · mrg=7(15m)");
     expect(header).not.toContain("!counts stale");
-    for (const token of ["prs=3(15m)", "iss=24(15m)", "rdy=5(15m)", "hmn=2(15m)"]) {
+    for (const token of ["rdy=5(15m)", "iss=24(15m)", "pr=3(15m)", "mrg=7(15m)"]) {
       expect(line).toContain(token);
     }
     expect(renderRedskilledDashboard(document, TABLE).header.counts).toMatchObject({
       open_pull_requests: 3,
+      merged_today: 7,
       open_issues: 24,
       ready_queue: 5,
       human_queue: 2,
@@ -130,9 +130,11 @@ describe("remote counters ride the daemon payload", () => {
     const line = stripAnsi(renderRedskilledStatusline(document, LOCAL).line);
     const header = stripAnsi(renderRedskilledDashboard(document, TABLE).header.line);
 
-    expect(line).toContain("prs=3 cpr=7 iss=24");
+    expect(line).toContain("iss=24 pr=3");
+    expect(line).not.toContain("cpr=");
     expect(line).not.toContain("rdy=");
-    expect(header).toContain("prs=3 · cpr=7 · iss=24");
+    expect(header).toContain("iss=24 · pr=3");
+    expect(header).not.toContain("cpr=");
     expect(header).toContain("!counts stale");
   });
 });

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -110,7 +110,7 @@ describe("one module, three densities", () => {
     const table = renderRedskilledDashboard(doc, { ...REDSKILLED_DASHBOARD_DEFAULTS, project: "acme/widgets" });
 
     expect(line.lines).toHaveLength(2);
-    expect(line.line).toContain("acme/widgets 1w");
+    expect(line.line).toBe("1w 512M v3.3.11");
     expect(stripAnsi(line.lines[1]!)).toContain("w-1");
     // The panel's FIRST row is the line density's own output, not a second
     // spelling of it — the composition is the no-drift guarantee.
@@ -182,7 +182,7 @@ describe("one module, three densities", () => {
     const doc = payload();
     const drawn = renderRedskilled(doc, { density: "panel", options: { project: "acme/widgets" } });
     expect(drawn.density).toBe("panel");
-    expect(drawn.lines[0]).toContain("acme/widgets");
+    expect(drawn.lines[0]).toContain("1w 512M v3.3.11");
     expect(renderRedskilled(doc, { density: "line", options: { project: "acme/widgets" } }).lines)
       .toEqual(renderRedskilledStatusline(doc, LOCAL).lines);
   });
@@ -455,7 +455,7 @@ describe("an unknown project's registration history (#3191)", () => {
     expect(rendered.project_match).toBe("unregistered");
     expect(rendered.repair).toBeUndefined();
     expect(rendered.repair_reason).toBeUndefined();
-    expect(rendered.line).toBe("acme/widgets 0w 0B idle v3.3.11");
+    expect(rendered.line).toBe("0w idle 0B v3.3.11");
   });
 
   it.each([


### PR DESCRIPTION
Closes #3606.

Worker hFB4Q completed the reshape (dictated compact format, mrg=/pr= counters, cpr= killed, death-token freshness, panorama cache tiers) and hit the GraphQL rate limit at the pr step; opening via REST. Landing with CI as judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789069822&installation_model_id=20659&pr_number=3665&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3665&signature=fb816253810c146492f1d96c1caa0d783fbdc179195a8962cdb8be301a0d910c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->