### PR TITLE
fix: #3646 lane write durability — attributions temp+rename, drain temps visible to the sweeper

### DIFF
--- a/apps/dev/src/core/operational-probes/lane-census.ts
+++ b/apps/dev/src/core/operational-probes/lane-census.ts
@@ -3,6 +3,7 @@ import { readdir, stat } from "node:fs/promises";
 import { isAbsolute, join, relative } from "node:path";
 import {
   LANE_RETENTION_REGISTRY,
+  laneTempOwnerPid,
   type LaneRetentionPolicy,
 } from "@reddb-io/shared/lane-retention.js";
 import {
@@ -242,8 +243,6 @@ function defaultPidAlive(pid: number): boolean {
   }
 }
 
-const LANE_TEMP_PID = /\.(?:rotate|retaining)-(\d+)(?:-|$)/;
-
 /** Collects bounded lane usage without mutating either project or host state. */
 export async function collectLaneCensusProbeInput(
   options: CollectLaneCensusOptions,
@@ -278,9 +277,8 @@ export async function collectLaneCensusProbeInput(
   const isPidAlive = options.isPidAlive ?? defaultPidAlive;
   const temps: LaneCensusTemp[] = [];
   for (const path of [...projectStateFiles, ...workerFiles, ...hostRootFiles, ...hostStateFiles]) {
-    const match = LANE_TEMP_PID.exec(path);
-    if (!match) continue;
-    const pid = Number(match[1]);
+    const pid = laneTempOwnerPid(path);
+    if (pid === null) continue;
     temps.push({
       path: safeDisplay(projectRoot, hostRoot, path),
       pid,

--- a/apps/dev/tests/lane-census.test.ts
+++ b/apps/dev/tests/lane-census.test.ts
@@ -75,11 +75,19 @@ describe("lane census operational probe", () => {
       const workerLog = join(projectRoot, ".red", "tmp", "workers", "wTEST", "worker.log.toonl");
       const unknown = join(projectRoot, ".red", "state", "unknown", "events.toonl");
       const deadTemp = `${projectDeaths}.rotate-42`;
+      const deadDrain = join(
+        projectRoot,
+        ".red",
+        "state",
+        "rsp",
+        "rsp-telemetry.spool.toonl.42.1783958744462.drain",
+      );
       const hostEvents = join(hostRoot, "redskilled.log.toonl");
       await Promise.all([
         mkdir(join(projectRoot, ".red", "state", "deaths"), { recursive: true }),
         mkdir(join(projectRoot, ".red", "tmp", "workers", "wTEST"), { recursive: true }),
         mkdir(join(projectRoot, ".red", "state", "unknown"), { recursive: true }),
+        mkdir(join(projectRoot, ".red", "state", "rsp"), { recursive: true }),
         mkdir(hostRoot, { recursive: true }),
       ]);
       await Promise.all([
@@ -87,6 +95,7 @@ describe("lane census operational probe", () => {
         writeFile(workerLog, "[3]{msg}:\none\ntwo\nthree\n"),
         writeFile(unknown, "mystery\n"),
         writeFile(deadTemp, "partial"),
+        writeFile(deadDrain, "pending telemetry"),
         writeFile(hostEvents, "host-event\n"),
       ]);
 
@@ -121,6 +130,11 @@ describe("lane census operational probe", () => {
       expect(input.unregisteredToonl).toEqual([".red/state/unknown/events.toonl"]);
       expect(input.temps).toContainEqual({
         path: ".red/state/deaths/deaths.toonl.rotate-42",
+        pid: 42,
+        pidAlive: false,
+      });
+      expect(input.temps).toContainEqual({
+        path: ".red/state/rsp/rsp-telemetry.spool.toonl.42.1783958744462.drain",
         pid: 42,
         pidAlive: false,
       });

--- a/apps/rsp/src/telemetry/spool.ts
+++ b/apps/rsp/src/telemetry/spool.ts
@@ -1,5 +1,15 @@
 import { randomUUID, createHash } from "node:crypto";
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  writeSync,
+} from "node:fs";
 import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { rspStateDir } from "@reddb-io/shared/red-paths.js";
@@ -82,10 +92,16 @@ export async function appendTelemetryEvent(
   appendTelemetryEventSync(rootDir, event, retention);
 }
 
+export interface AppendTelemetryEventSyncOptions {
+  /** Test seam for posing a drain rename immediately after an append. */
+  readonly afterWrite?: (path: string, attempt: number) => void;
+}
+
 export function appendTelemetryEventSync(
   rootDir: string,
   event: RspTelemetryEvent,
   retention: LaneRetentionPolicy = LANE_RETENTION_REGISTRY["rsp-telemetry-spool"],
+  options: AppendTelemetryEventSyncOptions = {},
 ): void {
   try {
     const resolvedRoot = resolveRootForTelemetryWrite(rootDir);
@@ -103,9 +119,37 @@ export function appendTelemetryEventSync(
       parseSpoolEntries,
       formatSpoolRow,
     );
-    appendFileSync(path, line, { encoding: "utf8", mode: 0o600 });
+    appendSpoolLineSync(path, line, options);
     if (droppedBytes > 0) appendRetentionCorrection(resolvedRoot, "telemetry spool retention", droppedBytes);
   } catch {}
+}
+
+/**
+ * Append to the active inode, then prove it is still the inode at the active
+ * path. A drainer can rename between open and write; retrying the same spool id
+ * makes that race at-least-once rather than silently lossy.
+ */
+function appendSpoolLineSync(
+  path: string,
+  line: string,
+  options: AppendTelemetryEventSyncOptions,
+): void {
+  let attempt = 0;
+  while (true) {
+    const descriptor = openSync(path, "a", 0o600);
+    try {
+      writeSync(descriptor, line, undefined, "utf8");
+      attempt += 1;
+      options.afterWrite?.(path, attempt);
+      const opened = fstatSync(descriptor);
+      const active = statSync(path);
+      if (opened.dev === active.dev && opened.ino === active.ino) return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    } finally {
+      closeSync(descriptor);
+    }
+  }
 }
 
 function compactTelemetryEventForSpool(event: RspTelemetryEvent): RspTelemetryEvent {

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { renameSync, rmSync, writeFileSync } from "node:fs";
+import { appendTelemetryEventSync } from "../src/telemetry.js";
 import {
   appendTelemetryEvent,
   calibratedTelemetryTiming,
@@ -86,6 +88,32 @@ describe("rsp telemetry spool", () => {
       collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
       id: "lost",
     })).resolves.toBeUndefined();
+  });
+
+  it("retries an append whose inode is renamed away during the write", async () => {
+    const root = await tempRoot();
+    const spool = telemetrySpoolPath(root);
+    const draining = `${spool}.999999.1783958744462.drain`;
+    let raced = false;
+
+    appendTelemetryEventSync(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "rename-race",
+      command: "git status",
+    }, undefined, {
+      afterWrite(path, attempt) {
+        if (attempt !== 1) return;
+        raced = true;
+        renameSync(path, draining);
+        writeFileSync(path, "", { mode: 0o600 });
+        rmSync(draining);
+      },
+    });
+
+    expect(raced).toBe(true);
+    await expect(readSpoolRows(root)).resolves.toEqual([
+      expect.objectContaining({ event: expect.objectContaining({ id: "rename-race" }) }),
+    ]);
   });
 
   it("trims an overflowing spool and corrects the drain with the dropped byte count", async () => {

--- a/packages/shared/death-attribution.test.ts
+++ b/packages/shared/death-attribution.test.ts
@@ -8,7 +8,8 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as laneRetention from "./lane-retention.js";
 import {
   attributeDeath,
   buildProcessPresence,
@@ -290,6 +291,23 @@ describe("the presence anchor", () => {
 });
 
 describe("the boot reaper", () => {
+  it("replaces attribution history through the shared temp+rename primitive", () => {
+    const stateRoot = scratch();
+    writeProcessPresence(deathPresenceDirIn(stateRoot), presence());
+    const replace = vi.spyOn(laneRetention, "replaceLaneAtomicallySync");
+
+    runBootDeathReaper({
+      stateRoot,
+      evidence: collectHostDeathEvidence({ procRoot: poseProc("boot-a", [1]), journalPaths: [] }),
+      now: () => "2026-08-01T11:00:00.000Z",
+    });
+
+    expect(replace).toHaveBeenCalledWith(
+      deathAttributionFileIn(stateRoot),
+      expect.stringContaining("wOLFU"),
+    );
+  });
+
   it("retains attribution history for fourteen days and one MiB, preserving unknown timestamps", () => {
     const stateRoot = scratch();
     const now = Date.parse("2026-08-15T20:00:00.000Z");

--- a/packages/shared/death-attribution.ts
+++ b/packages/shared/death-attribution.ts
@@ -28,11 +28,11 @@
  * by posing its files, the way WSL2 support was proven, and the code an operator
  * runs is the code under test.
  */
-import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { encodeLines, parseRecords, type ToonlRecord } from "@reddb-io/toon";
 import { deathAttributionFileIn, deathLaneFileIn, deathPresenceDirIn } from "./red-paths.js";
-import { LANE_RETENTION_REGISTRY } from "./lane-retention.js";
+import { LANE_RETENTION_REGISTRY, replaceLaneAtomicallySync } from "./lane-retention.js";
 import {
   compactProcessDeathLane,
   decodeProcessDeathRecords,
@@ -554,10 +554,7 @@ function appendAttributions(
     const existing = readOrEmpty(path);
     const combined = [...decodeDeathAttributions(existing), ...attributions];
     const retained = retainAttributions(combined, nowMs);
-    writeFileSync(path, encodeDeathAttributions(retained), {
-      encoding: "utf8",
-      mode: 0o600,
-    });
+    replaceLaneAtomicallySync(path, encodeDeathAttributions(retained));
   } catch {
     // Best effort by contract: a lane that cannot be written must not turn a
     // boot-time investigation into a boot-time failure.

--- a/packages/shared/lane-retention.test.ts
+++ b/packages/shared/lane-retention.test.ts
@@ -85,25 +85,30 @@ describe("shared lane retention", () => {
     expect(parseRecords(raw).map((row) => row.id)).toEqual(["two", "three"]);
   });
 
-  it("sweeps only rotate and retaining temps owned by dead pids", async () => {
+  it("sweeps only rotate, retaining, and rsp drain temps owned by dead pids", async () => {
     const root = await mkdtemp(join(tmpdir(), "lane-retention-sweep-"));
     roots.push(root);
     const liveRotate = join(root, "host.toonl.rotate-222");
     const deadRotate = join(root, "host.toonl.rotate-111");
     const deadRetaining = join(root, "deaths.toonl.retaining-111");
+    const deadDrain = join(root, "rsp-telemetry.spool.toonl.111.1783958744462.drain");
+    const liveDrain = join(root, "rsp-telemetry.spool.toonl.222.1783958744463.drain");
     const unrelated = join(root, "notes.tmp-111");
     await Promise.all([
       writeFile(liveRotate, "live"),
       writeFile(deadRotate, "dead"),
       writeFile(deadRetaining, "dead"),
+      writeFile(deadDrain, "dead"),
+      writeFile(liveDrain, "live"),
       writeFile(unrelated, "not a lane temp"),
     ]);
 
     const result = await sweepLaneTemps(root, { isPidAlive: (pid) => pid === 222 });
 
-    expect(result.removed.sort()).toEqual([deadRetaining, deadRotate].sort());
-    expect(result.preserved).toEqual([liveRotate]);
+    expect(result.removed.sort()).toEqual([deadDrain, deadRetaining, deadRotate].sort());
+    expect(result.preserved.sort()).toEqual([liveDrain, liveRotate].sort());
     await expect(readFile(liveRotate, "utf8")).resolves.toBe("live");
+    await expect(readFile(liveDrain, "utf8")).resolves.toBe("live");
     await expect(readFile(unrelated, "utf8")).resolves.toBe("not a lane temp");
   });
 });

--- a/packages/shared/lane-retention.ts
+++ b/packages/shared/lane-retention.ts
@@ -247,7 +247,14 @@ function pidAlive(pid: number): boolean {
   }
 }
 
-const LANE_TEMP_PID = /\.(?:rotate|retaining)-(\d+)(?:-|$)/;
+const LANE_REPLACEMENT_TEMP_PID = /\.(?:rotate|retaining)-(\d+)(?:-|$)/;
+const RSP_DRAIN_TEMP_PID = /rsp-telemetry\.spool\.(?:toonl|jsonl)\.(\d+)\.\d+\.drain$/;
+
+/** Return the owning pid for every temporary lane generation known to retention. */
+export function laneTempOwnerPid(path: string): number | null {
+  const match = LANE_REPLACEMENT_TEMP_PID.exec(path) ?? RSP_DRAIN_TEMP_PID.exec(path);
+  return match === null ? null : Number(match[1]);
+}
 
 /** Recursively remove only replacement temps whose owning pid is dead. */
 export async function sweepLaneTemps(
@@ -273,9 +280,8 @@ export async function sweepLaneTemps(
         continue;
       }
       if (!entry.isFile()) continue;
-      const match = LANE_TEMP_PID.exec(entry.name);
-      if (match === null) continue;
-      const pid = Number(match[1]);
+      const pid = laneTempOwnerPid(entry.name);
+      if (pid === null) continue;
       if (await isPidAlive(pid)) {
         preserved.push(path);
         continue;


### PR DESCRIPTION
Closes #3646.

Worker hBQ3P completed the work; the pr step hit the drained GraphQL pool (same shape as #3606/#3650 today — tracked in #3663). Opened via REST, landing with CI as judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789070995&installation_model_id=20659&pr_number=3668&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3668&signature=ee840d8b34b92f928a0da4647ff846e7fa123995b365816f81fa0a2f1961060f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->