### PR TITLE
merge: #3644 The promised 256 MiB live-log warning does not exist

### DIFF
--- a/apps/dev/src/core/operational-probes/lane-census.ts
+++ b/apps/dev/src/core/operational-probes/lane-census.ts
@@ -1,8 +1,9 @@
 import { createReadStream } from "node:fs";
-import { readdir, stat } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
 import { isAbsolute, join, relative } from "node:path";
 import {
   LANE_RETENTION_REGISTRY,
+  LIVE_WORKER_LOG_WARNING_THRESHOLD_BYTES,
   type LaneRetentionPolicy,
 } from "@reddb-io/shared/lane-retention.js";
 import {
@@ -48,10 +49,18 @@ export interface LaneCensusTemp {
   readonly pidAlive: boolean;
 }
 
+export interface LaneCensusLiveLog {
+  readonly path: string;
+  readonly bytes: number;
+  readonly warnBytes: number;
+}
+
 export interface LaneCensusProbeInput {
   readonly lanes: readonly LaneCensusLane[];
   readonly unregisteredToonl: readonly string[];
   readonly temps: readonly LaneCensusTemp[];
+  /** Live Workers' logs over the warning threshold — detection only (#3644). */
+  readonly liveLogs?: readonly LaneCensusLiveLog[];
 }
 
 export interface CollectLaneCensusOptions {
@@ -59,6 +68,8 @@ export interface CollectLaneCensusOptions {
   /** The already-resolved daemon home, injected to keep private paths out of results. */
   readonly hostRoot: string;
   readonly isPidAlive?: (pid: number) => boolean | Promise<boolean>;
+  /** Stat seam for the live-log size read; defaults to fs stat. */
+  readonly readStat?: (path: string) => Promise<{ size: number }> | { size: number };
 }
 
 interface LaneRegistration {
@@ -288,10 +299,29 @@ export async function collectLaneCensusProbeInput(
     });
   }
 
+  const readStat = options.readStat ?? stat;
+  const liveLogs: LaneCensusLiveLog[] = [];
+  for (const absolutePath of workerFiles) {
+    const segments = slash(relative(workersRoot, absolutePath)).split("/");
+    if (segments.length !== 2 || segments[1] !== "worker.log.toonl") continue;
+    const pidPath = join(workersRoot, segments[0]!, "worker.pid");
+    if (!workerFiles.includes(pidPath)) continue;
+    const pid = Number((await readFile(pidPath, "utf8").catch(() => "")).trim());
+    if (!Number.isInteger(pid) || pid <= 0 || !(await isPidAlive(pid))) continue;
+    const size = (await readStat(absolutePath)).size;
+    if (size <= LIVE_WORKER_LOG_WARNING_THRESHOLD_BYTES) continue;
+    liveLogs.push({
+      path: projectDisplay(projectRoot, absolutePath),
+      bytes: size,
+      warnBytes: LIVE_WORKER_LOG_WARNING_THRESHOLD_BYTES,
+    });
+  }
+
   return {
     lanes: (await Promise.all(registrations.map(inspectLane))).sort((a, b) => a.path.localeCompare(b.path)),
     unregisteredToonl,
     temps: temps.sort((a, b) => a.path.localeCompare(b.path)),
+    liveLogs: liveLogs.sort((a, b) => a.path.localeCompare(b.path)),
   };
 }
 
@@ -321,8 +351,13 @@ export function runLaneCensusProbe(input: LaneCensusProbeInput | undefined): Ope
 
   const over = input.lanes.filter(laneOverCeiling);
   const deadTemps = input.temps.filter((temp) => !temp.pidAlive);
-  const red = over.length > 0 || input.unregisteredToonl.length > 0 || deadTemps.length > 0;
+  const liveLogs = input.liveLogs ?? [];
+  const red = over.length > 0 || input.unregisteredToonl.length > 0 || deadTemps.length > 0
+    || liveLogs.length > 0;
   const details = input.lanes.map(laneEvidence);
+  for (const log of liveLogs) {
+    details.push(`live-log=${log.path} ${log.bytes}/${log.warnBytes} bytes [over]`);
+  }
   if (input.unregisteredToonl.length > 0) {
     details.push(`unregistered=${input.unregisteredToonl.join(",")}`);
   }

--- a/apps/dev/tests/lane-census.test.ts
+++ b/apps/dev/tests/lane-census.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -124,6 +124,38 @@ describe("lane census operational probe", () => {
         pid: 42,
         pidAlive: false,
       });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a live Worker log over 256 MiB as red with its path and size", async () => {
+    const root = await mkdtemp(join(tmpdir(), "lane-census-live-log-"));
+    const projectRoot = join(root, "project");
+    const hostRoot = join(root, "host");
+    const workerRoot = join(projectRoot, ".red", "tmp", "workers", "wLIVE");
+    const workerLog = join(workerRoot, "worker.log.toonl");
+    const warningBytes = 256 * 1024 * 1024;
+    try {
+      await mkdir(workerRoot, { recursive: true });
+      await writeFile(join(workerRoot, "worker.pid"), String(process.pid));
+      await writeFile(workerLog, "oversized\n");
+
+      const input = await collectLaneCensusProbeInput({
+        projectRoot,
+        hostRoot,
+        isPidAlive: (pid) => pid === process.pid,
+        readStat: async (path) => path === workerLog
+          ? { size: warningBytes + 1 }
+          : stat(path),
+      });
+      const result = runLaneCensusProbe(input);
+
+      expect(result).toMatchObject({ verdict: "red" });
+      expect(result.evidence).toContain(
+        ".red/tmp/workers/wLIVE/worker.log.toonl",
+      );
+      expect(result.evidence).toContain("268435457/268435456 bytes");
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/shared/lane-retention.ts
+++ b/packages/shared/lane-retention.ts
@@ -29,6 +29,7 @@ const execFileAsync = promisify(execFile);
 
 export const DEFAULT_LANE_RETENTION_TARGET_RATIO = 0.5;
 export const LANE_RETENTION_TQ_TIMEOUT_MS = 5_000;
+export const LIVE_WORKER_LOG_WARNING_THRESHOLD_BYTES = 256 * 1024 * 1024;
 
 /** A lane declares only the ceilings meaningful to its own record stream. */
 export interface LaneRetentionPolicy {


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3644 -->
🤖 **Re-seed trail** — #3644 on `afk/3644-the-promised-256-mib-live-log-warning-do`, lane `/afk`.

Rounds spent: 3/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3644; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

Closes #3644