### PR TITLE
docs: #3669 one home for the interview round convention, binding on every asker

### DIFF
--- a/packaging/pi/dev/skills/engineering/hitl/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/hitl/SKILL.md
@@ -86,7 +86,7 @@ If the decision is ambiguous, ask the maintainer to state the pending decision d
 
 **Step 4 — Answer.** Get the maintainer's response and determine whether the issue is now delegable.
 
-Ask for the answer to the pending decision.
+Ask for the answer to the pending decision. **Read [`/start`'s INTERVIEW-ROUNDS.md](../start/INTERVIEW-ROUNDS.md) and follow its question format for every question this step asks the maintainer** — the ask is a `❓ **Q##**` block with the extracted options as branches and your recommendation marked `➡️`.
 
 Then decide whether the answer makes the Issue delegable:
 

--- a/packaging/pi/dev/skills/engineering/start/INTERVIEW-ROUNDS.md
+++ b/packaging/pi/dev/skills/engineering/start/INTERVIEW-ROUNDS.md
@@ -1,0 +1,61 @@
+# Interview rounds — the shared question convention
+
+**Every question a RedSkills skill asks a human follows this convention.** It is
+the one normative home for the round format: `/start` grills with it, and every
+other interviewing surface — `/wayfinder` charting and grilling tickets,
+`/reflect`, `/hitl`, `/to-spec` — reads and follows this file rather than
+restating it. One convention, N consumers, zero drift.
+
+## Question format
+
+Each question is formatted like so — the emoji are load-bearing, because a
+round of five questions is read by scanning for them:
+
+```
+❓ **Q##** — <the question, ONE line, ending in a question mark>
+**Branches:**
+  (a) <option A>
+  (b) <option B>
+  (c) <option C>
+➡️ **(<letter>)** — <one-sentence reason>
+```
+
+**One line per thing to read: the question is a line, and each branch is a line
+of its own.** A round is read by scanning, and both failures break the scan — a
+question that swells into a paragraph loses the reader's place, and branches run
+together on one line make the reader parse separators to find the option they
+want. Keep the question to a single line that ends in a question mark, and put
+every branch on its own indented line.
+
+**Evidence goes above the round, never inside a question.** Whatever the user
+needs in order to answer — what you found in the code, the numbers, the
+trade-off you are weighing — belongs in prose *before* the first `❓`, written
+once for the whole round. A question is the ask alone.
+
+Separate consecutive questions with a blank line, so each `❓` starts its own
+visual block.
+
+**Enumerate the branches whenever the decision space is finite.** They give the
+user a stable handle — "ok (b) but with X tweak" — and force the skill to make
+the choice space explicit instead of gesturing at it. Keep each branch to a
+short phrase; a branch needing a sentence of explanation is evidence that
+belongs above the round. Omit `Branches:` only when the question is genuinely
+open-ended; `➡️` then recommends in prose.
+
+Close each round with a one-line invitation to answer, redirect, or push back.
+
+## Numbering
+
+Number every question `Q01`, `Q02`, … `Q10`, … zero-padded to 2 digits,
+**continuous across rounds**. The counter is session-scoped — never reset on a
+new round, never on a user redirect.
+
+## Rounds over the frontier
+
+Ask in **rounds**: the **frontier** is every unresolved question whose
+prerequisites are already settled — the questions answerable *now*, without
+guessing at answers not yet given. Ask the whole frontier as one round, then
+wait. **A question whose answer depends on another question open in this round
+belongs to the NEXT round** — that single rule is what makes a batch safe. A
+round is as small as the frontier makes it: one critical question that unblocks
+everything downstream is a complete round.

--- a/packaging/pi/dev/skills/engineering/start/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/start/SKILL.md
@@ -24,28 +24,7 @@ A round is as small as the tree makes it. One critical question that unblocks ev
 
 ## Question format
 
-Each question is formatted like so — the emoji are load-bearing, because a round of five questions is read by scanning for them:
-
-```
-❓ **Q##** — <the question, ONE line, ending in a question mark>
-**Branches:**
-  (a) <option A>
-  (b) <option B>
-  (c) <option C>
-➡️ **(<letter>)** — <one-sentence reason>
-```
-
-**One line per thing to read: the question is a line, and each branch is a line of its own.** A round is read by scanning, and both failures break the scan — a question that swells into a paragraph loses the reader's place, and branches run together on one line make the reader parse separators to find the option they want. Keep the question to a single line that ends in a question mark, and put every branch on its own indented line.
-
-**Evidence goes above the round, never inside a question.** Whatever the user needs in order to answer — what you found in the code, the numbers, the trade-off you are weighing — belongs in prose *before* the first `❓`, written once for the whole round. A question is the ask alone.
-
-Separate consecutive questions with a blank line, so each `❓` starts its own visual block.
-
-**Enumerate the branches whenever the decision space is finite.** They give the user a stable handle — "ok (b) but with X tweak" — and force the skill to make the choice space explicit instead of gesturing at it. Keep each branch to a short phrase; a branch needing a sentence of explanation is evidence that belongs above the round. Omit `Branches:` only when the question is genuinely open-ended; `➡️` then recommends in prose.
-
-Close each round with a one-line invitation to answer, redirect, or push back.
-
-Number every question `Q01`, `Q02`, … `Q10`, … zero-padded to 2 digits, **continuous across rounds**. The counter is session-scoped — never reset on a new round, never on a user redirect.
+**Read [INTERVIEW-ROUNDS.md](./INTERVIEW-ROUNDS.md) and follow it for every question you ask.** It is the one normative home of the round convention — the `❓ **Q##**` block, one-line questions, per-line branches, the `➡️` recommendation, evidence above the round, and the continuous zero-padded numbering. Do not restate or improvise the format; the reference decides it.
 
 ## Finding facts is your job, never the user's
 

--- a/packaging/pi/dev/skills/engineering/to-spec/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/to-spec/SKILL.md
@@ -16,7 +16,7 @@ The issue tracker and triage label vocabulary should have been provided to you �
 
 2. Sketch out the testing seams for the feature. Prefer existing, high-level seams over new low-level ones. If new seams are needed, propose them at the highest point that can exercise the behavior.
 
-Check with the user that these seams match their expectations.
+Check with the user that these seams match their expectations. **Read [`/start`'s INTERVIEW-ROUNDS.md](../start/INTERVIEW-ROUNDS.md) and follow its question format for this check and for every other question this skill asks** — the seam proposal is the evidence above the round; the ask itself is a `❓ **Q##**` block with `➡️` marking your recommendation.
 
 **Capture every HITL call** made during the conversation that led to this Spec — testing seam choices, module shape choices, trade-offs the user took a side on, alternatives they rejected, constraints they imposed. These go into the `Human Decisions` section of the template. Do not silently fold them into `Implementation Decisions` — once `/to-tickets` slices this Spec and `/afk` picks up the children, the human's calls become indistinguishable from agent inference unless they are flagged here.
 

--- a/packaging/pi/dev/skills/engineering/wayfinder/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/wayfinder/SKILL.md
@@ -78,7 +78,7 @@ Every ticket is either **HITL** — human in the loop, worked *with* a human who
 
 - **Research** (AFK): Reading documentation, third-party APIs, or local resources like knowledge bases to surface a fact a decision waits on. Resolved by a `/research` **subagent**. Use when knowledge outside the current working directory is required.
 - **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
-- **Grilling** (HITL): Conversation via the /start skills, asked as rounds over the frontier — every question whose prerequisites are settled goes in one round, and a question depending on another still open waits for the next. The default case.
+- **Grilling** (HITL): Conversation via the /start skills, asked as rounds over the frontier — every question whose prerequisites are settled goes in one round, and a question depending on another still open waits for the next. The default case. **Read [../start/INTERVIEW-ROUNDS.md](../start/INTERVIEW-ROUNDS.md) and follow it for every question the ticket asks** — the round format is that reference's, never improvised here.
 - **Task** (HITL or AFK): Manual work that must happen before a *decision* can be made — nothing to decide, prototype, or research, but the discussion is blocked until it's done. Signing up for a service so its API can be judged, provisioning access, moving data so its shape can be seen. This is the one type that *does* rather than decides — and it earns its place by unblocking a decision, not by delivering the destination. The session never executes repo-mutating task work inline — when AFK-safe, it routes the ticket into the autonomous queue per the tracker doc, and the AFK engine runs it (isolated worktree, shared validation gate, PR); otherwise it hands the human a precise checklist (HITL). Resolved when the work is done; the answer records what was done and any resulting facts (credentials location, new URLs, row counts) later tickets depend on.
 
 ## Fog of war
@@ -110,7 +110,7 @@ Two modes. Either way, **never resolve more than one ticket per session** — wi
 
 User invokes with a loose idea.
 
-1. **Name the destination.** Run a `/start` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first.
+1. **Name the destination.** Run a `/start` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first. **Every question this charting conversation asks the human follows [../start/INTERVIEW-ROUNDS.md](../start/INTERVIEW-ROUNDS.md)** — read it before asking the first one.
 2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — the way to the destination is already clear, the whole journey small enough for one session — you don't need a map. Stop and ask the user how they'd like to proceed.
 3. **Create the map** (label `wayfinder:map`): Destination and Notes filled in, Decisions-so-far empty, the fog sketched into **Not yet specified**.
 4. **Create the tickets you can specify now** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the fog — the **Not yet specified** section.
@@ -123,7 +123,7 @@ User invokes with a map (URL or number). A ticket is **optional** — without on
 
 1. Load the **map** — the low-res view, not every ticket body.
 2. Choose the ticket. If the user named one, use it. Otherwise take the first frontier ticket in order. **Claim it**: assign it to yourself before any work.
-3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the `## Notes` block names. If in doubt, use `/start`.
+3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the `## Notes` block names. If in doubt, use `/start`. **Any question you put to the human while resolving follows [../start/INTERVIEW-ROUNDS.md](../start/INTERVIEW-ROUNDS.md).**
 4. Record the resolution: post the answer as a **resolution comment**, **close** the issue, and **append a context pointer** to the map's Decisions-so-far.
 5. Add newly-surfaced tickets (create-then-wire); graduate any fog the answer has made specifiable, clearing each graduated patch from **Not yet specified** so it lives only as its new ticket. If the answer reveals a ticket — this one or another — sits beyond the destination, **rule it out of scope** rather than resolving it on the route. If the decision invalidates other parts of the map, update or delete those tickets.
 

--- a/packaging/pi/dev/skills/productivity/reflect/SKILL.md
+++ b/packaging/pi/dev/skills/productivity/reflect/SKILL.md
@@ -9,6 +9,8 @@ description: Interview the user relentlessly about a plan or design until reachi
 
 Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, include your recommended answer with a one-sentence reason.
 
+**Read [`/start`'s INTERVIEW-ROUNDS.md](../../engineering/start/INTERVIEW-ROUNDS.md) and follow its question format for every question you ask** — the `❓ **Q##**` block, per-line branches, the `➡️` recommendation, evidence above the ask. This skill's cadence stays its own: one question per turn is a one-question round, which the convention allows.
+
 Ask the questions one at a time. Wait for the user's reply before proceeding.
 
 If a question can be answered by exploring the codebase, explore the codebase instead of asking.

--- a/plugins/dev/skills/engineering/hitl/SKILL.md
+++ b/plugins/dev/skills/engineering/hitl/SKILL.md
@@ -86,7 +86,7 @@ If the decision is ambiguous, ask the maintainer to state the pending decision d
 
 **Step 4 — Answer.** Get the maintainer's response and determine whether the issue is now delegable.
 
-Ask for the answer to the pending decision.
+Ask for the answer to the pending decision. **Read [`/start`'s INTERVIEW-ROUNDS.md](../start/INTERVIEW-ROUNDS.md) and follow its question format for every question this step asks the maintainer** — the ask is a `❓ **Q##**` block with the extracted options as branches and your recommendation marked `➡️`.
 
 Then decide whether the answer makes the Issue delegable:
 

--- a/plugins/dev/skills/engineering/start/INTERVIEW-ROUNDS.md
+++ b/plugins/dev/skills/engineering/start/INTERVIEW-ROUNDS.md
@@ -1,0 +1,61 @@
+# Interview rounds — the shared question convention
+
+**Every question a RedSkills skill asks a human follows this convention.** It is
+the one normative home for the round format: `/start` grills with it, and every
+other interviewing surface — `/wayfinder` charting and grilling tickets,
+`/reflect`, `/hitl`, `/to-spec` — reads and follows this file rather than
+restating it. One convention, N consumers, zero drift.
+
+## Question format
+
+Each question is formatted like so — the emoji are load-bearing, because a
+round of five questions is read by scanning for them:
+
+```
+❓ **Q##** — <the question, ONE line, ending in a question mark>
+**Branches:**
+  (a) <option A>
+  (b) <option B>
+  (c) <option C>
+➡️ **(<letter>)** — <one-sentence reason>
+```
+
+**One line per thing to read: the question is a line, and each branch is a line
+of its own.** A round is read by scanning, and both failures break the scan — a
+question that swells into a paragraph loses the reader's place, and branches run
+together on one line make the reader parse separators to find the option they
+want. Keep the question to a single line that ends in a question mark, and put
+every branch on its own indented line.
+
+**Evidence goes above the round, never inside a question.** Whatever the user
+needs in order to answer — what you found in the code, the numbers, the
+trade-off you are weighing — belongs in prose *before* the first `❓`, written
+once for the whole round. A question is the ask alone.
+
+Separate consecutive questions with a blank line, so each `❓` starts its own
+visual block.
+
+**Enumerate the branches whenever the decision space is finite.** They give the
+user a stable handle — "ok (b) but with X tweak" — and force the skill to make
+the choice space explicit instead of gesturing at it. Keep each branch to a
+short phrase; a branch needing a sentence of explanation is evidence that
+belongs above the round. Omit `Branches:` only when the question is genuinely
+open-ended; `➡️` then recommends in prose.
+
+Close each round with a one-line invitation to answer, redirect, or push back.
+
+## Numbering
+
+Number every question `Q01`, `Q02`, … `Q10`, … zero-padded to 2 digits,
+**continuous across rounds**. The counter is session-scoped — never reset on a
+new round, never on a user redirect.
+
+## Rounds over the frontier
+
+Ask in **rounds**: the **frontier** is every unresolved question whose
+prerequisites are already settled — the questions answerable *now*, without
+guessing at answers not yet given. Ask the whole frontier as one round, then
+wait. **A question whose answer depends on another question open in this round
+belongs to the NEXT round** — that single rule is what makes a batch safe. A
+round is as small as the frontier makes it: one critical question that unblocks
+everything downstream is a complete round.

--- a/plugins/dev/skills/engineering/start/SKILL.md
+++ b/plugins/dev/skills/engineering/start/SKILL.md
@@ -24,28 +24,7 @@ A round is as small as the tree makes it. One critical question that unblocks ev
 
 ## Question format
 
-Each question is formatted like so — the emoji are load-bearing, because a round of five questions is read by scanning for them:
-
-```
-❓ **Q##** — <the question, ONE line, ending in a question mark>
-**Branches:**
-  (a) <option A>
-  (b) <option B>
-  (c) <option C>
-➡️ **(<letter>)** — <one-sentence reason>
-```
-
-**One line per thing to read: the question is a line, and each branch is a line of its own.** A round is read by scanning, and both failures break the scan — a question that swells into a paragraph loses the reader's place, and branches run together on one line make the reader parse separators to find the option they want. Keep the question to a single line that ends in a question mark, and put every branch on its own indented line.
-
-**Evidence goes above the round, never inside a question.** Whatever the user needs in order to answer — what you found in the code, the numbers, the trade-off you are weighing — belongs in prose *before* the first `❓`, written once for the whole round. A question is the ask alone.
-
-Separate consecutive questions with a blank line, so each `❓` starts its own visual block.
-
-**Enumerate the branches whenever the decision space is finite.** They give the user a stable handle — "ok (b) but with X tweak" — and force the skill to make the choice space explicit instead of gesturing at it. Keep each branch to a short phrase; a branch needing a sentence of explanation is evidence that belongs above the round. Omit `Branches:` only when the question is genuinely open-ended; `➡️` then recommends in prose.
-
-Close each round with a one-line invitation to answer, redirect, or push back.
-
-Number every question `Q01`, `Q02`, … `Q10`, … zero-padded to 2 digits, **continuous across rounds**. The counter is session-scoped — never reset on a new round, never on a user redirect.
+**Read [INTERVIEW-ROUNDS.md](./INTERVIEW-ROUNDS.md) and follow it for every question you ask.** It is the one normative home of the round convention — the `❓ **Q##**` block, one-line questions, per-line branches, the `➡️` recommendation, evidence above the round, and the continuous zero-padded numbering. Do not restate or improvise the format; the reference decides it.
 
 ## Finding facts is your job, never the user's
 

--- a/plugins/dev/skills/engineering/to-spec/SKILL.md
+++ b/plugins/dev/skills/engineering/to-spec/SKILL.md
@@ -16,7 +16,7 @@ The issue tracker and triage label vocabulary should have been provided to you �
 
 2. Sketch out the testing seams for the feature. Prefer existing, high-level seams over new low-level ones. If new seams are needed, propose them at the highest point that can exercise the behavior.
 
-Check with the user that these seams match their expectations.
+Check with the user that these seams match their expectations. **Read [`/start`'s INTERVIEW-ROUNDS.md](../start/INTERVIEW-ROUNDS.md) and follow its question format for this check and for every other question this skill asks** — the seam proposal is the evidence above the round; the ask itself is a `❓ **Q##**` block with `➡️` marking your recommendation.
 
 **Capture every HITL call** made during the conversation that led to this Spec — testing seam choices, module shape choices, trade-offs the user took a side on, alternatives they rejected, constraints they imposed. These go into the `Human Decisions` section of the template. Do not silently fold them into `Implementation Decisions` — once `/to-tickets` slices this Spec and `/afk` picks up the children, the human's calls become indistinguishable from agent inference unless they are flagged here.
 

--- a/plugins/dev/skills/engineering/wayfinder/SKILL.md
+++ b/plugins/dev/skills/engineering/wayfinder/SKILL.md
@@ -78,7 +78,7 @@ Every ticket is either **HITL** — human in the loop, worked *with* a human who
 
 - **Research** (AFK): Reading documentation, third-party APIs, or local resources like knowledge bases to surface a fact a decision waits on. Resolved by a `/research` **subagent**. Use when knowledge outside the current working directory is required.
 - **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
-- **Grilling** (HITL): Conversation via the /start skills, asked as rounds over the frontier — every question whose prerequisites are settled goes in one round, and a question depending on another still open waits for the next. The default case.
+- **Grilling** (HITL): Conversation via the /start skills, asked as rounds over the frontier — every question whose prerequisites are settled goes in one round, and a question depending on another still open waits for the next. The default case. **Read [../start/INTERVIEW-ROUNDS.md](../start/INTERVIEW-ROUNDS.md) and follow it for every question the ticket asks** — the round format is that reference's, never improvised here.
 - **Task** (HITL or AFK): Manual work that must happen before a *decision* can be made — nothing to decide, prototype, or research, but the discussion is blocked until it's done. Signing up for a service so its API can be judged, provisioning access, moving data so its shape can be seen. This is the one type that *does* rather than decides — and it earns its place by unblocking a decision, not by delivering the destination. The session never executes repo-mutating task work inline — when AFK-safe, it routes the ticket into the autonomous queue per the tracker doc, and the AFK engine runs it (isolated worktree, shared validation gate, PR); otherwise it hands the human a precise checklist (HITL). Resolved when the work is done; the answer records what was done and any resulting facts (credentials location, new URLs, row counts) later tickets depend on.
 
 ## Fog of war
@@ -110,7 +110,7 @@ Two modes. Either way, **never resolve more than one ticket per session** — wi
 
 User invokes with a loose idea.
 
-1. **Name the destination.** Run a `/start` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first.
+1. **Name the destination.** Run a `/start` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first. **Every question this charting conversation asks the human follows [../start/INTERVIEW-ROUNDS.md](../start/INTERVIEW-ROUNDS.md)** — read it before asking the first one.
 2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — the way to the destination is already clear, the whole journey small enough for one session — you don't need a map. Stop and ask the user how they'd like to proceed.
 3. **Create the map** (label `wayfinder:map`): Destination and Notes filled in, Decisions-so-far empty, the fog sketched into **Not yet specified**.
 4. **Create the tickets you can specify now** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the fog — the **Not yet specified** section.
@@ -123,7 +123,7 @@ User invokes with a map (URL or number). A ticket is **optional** — without on
 
 1. Load the **map** — the low-res view, not every ticket body.
 2. Choose the ticket. If the user named one, use it. Otherwise take the first frontier ticket in order. **Claim it**: assign it to yourself before any work.
-3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the `## Notes` block names. If in doubt, use `/start`.
+3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the `## Notes` block names. If in doubt, use `/start`. **Any question you put to the human while resolving follows [../start/INTERVIEW-ROUNDS.md](../start/INTERVIEW-ROUNDS.md).**
 4. Record the resolution: post the answer as a **resolution comment**, **close** the issue, and **append a context pointer** to the map's Decisions-so-far.
 5. Add newly-surfaced tickets (create-then-wire); graduate any fog the answer has made specifiable, clearing each graduated patch from **Not yet specified** so it lives only as its new ticket. If the answer reveals a ticket — this one or another — sits beyond the destination, **rule it out of scope** rather than resolving it on the route. If the decision invalidates other parts of the map, update or delete those tickets.
 

--- a/plugins/dev/skills/productivity/reflect/SKILL.md
+++ b/plugins/dev/skills/productivity/reflect/SKILL.md
@@ -9,6 +9,8 @@ description: Interview the user relentlessly about a plan or design until reachi
 
 Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, include your recommended answer with a one-sentence reason.
 
+**Read [`/start`'s INTERVIEW-ROUNDS.md](../../engineering/start/INTERVIEW-ROUNDS.md) and follow its question format for every question you ask** — the `❓ **Q##**` block, per-line branches, the `➡️` recommendation, evidence above the ask. This skill's cadence stays its own: one question per turn is a one-question round, which the convention allows.
+
 Ask the questions one at a time. Wait for the user's reply before proceeding.
 
 If a question can be answered by exploring the codebase, explore the codebase instead of asking.


### PR DESCRIPTION
Closes #3669.

The /go dispatch path failed three ways today (#3670); the maintainer-approved Task+DoD landed by hand in the manual worktree lane. Extraction only — no semantic change to the convention; reflect keeps its one-question cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789071604&installation_model_id=20659&pr_number=3673&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3673&signature=65cc44624e10304a2319404867a1d150401bbfcae24430622aef4dd85ca7de52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->