### PR TITLE
fix: #3648 The suspect-infra classifier calls branch faults infrastructure: repeated signatures with changed pinned behavior, and fast exits carrying real diagnostics

### DIFF
--- a/apps/dev/src/core/validation-command.ts
+++ b/apps/dev/src/core/validation-command.ts
@@ -51,6 +51,25 @@ export const SUSPECT_INFRA_MARKER = "suspect-infra";
  */
 export const SUITE_MIN_PLAUSIBLE_MS = 1000;
 
+const CONCRETE_DIAGNOSTIC_PATTERNS: readonly RegExp[] = [
+  /\berror\s+TS\d{4}\b/,
+  /\berror\[E\d{4}\]/,
+  /^\s*FAIL\s+\S.*$/m,
+  /^\s*\S.*\.{3}\s+FAILED\s*$/m,
+  /^\s*----\s+\S.*\s+stdout\s+----\s*$/m,
+];
+
+function diagnosticNamesBranchFile(output: string, branchFiles: readonly string[]): boolean {
+  if (!CONCRETE_DIAGNOSTIC_PATTERNS.some((pattern) => pattern.test(output))) return false;
+  const normalizedOutput = output.replaceAll("\\", "/");
+  return branchFiles.some((file) => {
+    const normalizedFile = file.replace(/^\.\//, "").replaceAll("\\", "/");
+    const parts = normalizedFile.split("/").filter(Boolean);
+    const suffixes = parts.map((_, index) => parts.slice(index).join("/"));
+    return suffixes.some((suffix) => suffix.includes("/") && normalizedOutput.includes(suffix));
+  });
+}
+
 /**
  * What the `worktree` token IS.
  *
@@ -240,8 +259,18 @@ export function recordedValidationCommand(
 export function isSuspectInfraFailure(input: {
   status: string;
   durationMs?: number;
+  /** Captured compiler/test output, inspected before duration can classify it. */
+  output?: string;
+  /** Repo-relative files changed by the branch being judged. */
+  branchFiles?: readonly string[];
 }): boolean {
   if (input.status !== "failed") return false;
+  if (
+    input.output !== undefined &&
+    diagnosticNamesBranchFile(input.output, input.branchFiles ?? [])
+  ) {
+    return false;
+  }
   const { durationMs } = input;
   if (durationMs === undefined || !Number.isFinite(durationMs) || durationMs < 0) return false;
   return durationMs < SUITE_MIN_PLAUSIBLE_MS;

--- a/apps/dev/tests/validation-command.test.ts
+++ b/apps/dev/tests/validation-command.test.ts
@@ -179,6 +179,21 @@ describe("suspect-infra duration", () => {
     expect(isSuspectInfraFailure({ status: "failed", durationMs: SUITE_MIN_PLAUSIBLE_MS - 1 })).toBe(true);
   });
 
+  it("keeps fast compiler diagnostics on changed branch files as branch faults (#3648)", () => {
+    expect(isSuspectInfraFailure({
+      status: "failed",
+      durationMs: 44,
+      output: "apps/dev/src/render.ts(19,7): error TS2322: Type 'RemoteCounters' is not assignable",
+      branchFiles: ["apps/dev/src/render.ts"],
+    })).toBe(false);
+    expect(isSuspectInfraFailure({
+      status: "failed",
+      durationMs: 44,
+      output: "error[E0308]: mismatched types\n  --> crates/toon/src/parser.rs:19:7",
+      branchFiles: ["crates/toon/src/parser.rs"],
+    })).toBe(false);
+  });
+
   it("leaves a plausible failure, a fast pass, and an unmeasured check alone", () => {
     expect(isSuspectInfraFailure({ status: "failed", durationMs: SUITE_MIN_PLAUSIBLE_MS })).toBe(false);
     expect(isSuspectInfraFailure({ status: "passed", durationMs: 3 })).toBe(false);


### PR DESCRIPTION
Automated AFK landing for #3648. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3648

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789075016&installation_model_id=20659&pr_number=3677&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3677&signature=ff7635456f1e43ba45427a3a6e1471b2565616874a9b33476b7689e01b73783a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->