### PR TITLE
fix: quota backoff doubles instead of hammering (Refs #3672, #3663)

### DIFF
--- a/apps/dev/src/runtime/gh/quota.ts
+++ b/apps/dev/src/runtime/gh/quota.ts
@@ -59,15 +59,29 @@ export interface GhQuotaBackoffOpts {
   capMs?: number;
   /**
    * How long to sleep between retries when no server-supplied reset time is
-   * available. Default: 60 seconds.
+   * available. Default: 60 seconds, DOUBLING each retry up to 10 minutes —
+   * a fixed 60s cadence turned six waiting Workers into ~9,000 retries in one
+   * evening (issue #3672's field data, 2026-08-11).
    */
   defaultWaitMs?: number;
+  /**
+   * Ask GitHub when the drained pool resets, in epoch ms, or null when the
+   * answer is unavailable. No default: the routed client owns the balance ask
+   * (`GET /rate_limit` through @reddb-io/github), so a caller with client
+   * access injects the probe and the wait becomes one well-aimed sleep.
+   * Absent a probe, the doubling fallback below paces the retries.
+   */
+  probeResetMs?: () => Promise<number | null>;
 }
 
 /** Maximum total wall-clock wait before the failing response is returned. */
 export const DEFAULT_CAP_MS = 30 * 60 * 1000; // 30 minutes
-/** Sleep between retries when no server-supplied reset time is available. */
+/** First sleep between retries when no reset time is known. */
 export const DEFAULT_WAIT_MS = 60 * 1000;      // 60 seconds
+/** Ceiling for the doubling fallback wait. */
+export const MAX_FALLBACK_WAIT_MS = 10 * 60 * 1000; // 10 minutes
+/** Safety margin added past the probed reset instant. */
+export const RESET_MARGIN_MS = 5 * 1000;
 
 /**
  * Emit the wait as operator-visible `quota-wait` activity. The exec helpers hold
@@ -124,6 +138,7 @@ export function defaultGhQuotaBackoff(
     onWait: overrides.onWait ?? ((remainingMs) => announceQuotaWait(remainingMs, Math.min(waitMs, remainingMs))),
     capMs,
     defaultWaitMs: waitMs,
+    ...(overrides.probeResetMs ? { probeResetMs: overrides.probeResetMs } : {}),
   };
 }
 
@@ -151,12 +166,13 @@ export async function withGhQuotaBackoff(
   opts: GhQuotaBackoffOpts,
 ): Promise<ExecOutput> {
   const capMs = opts.capMs ?? DEFAULT_CAP_MS;
-  const waitMs = opts.defaultWaitMs ?? DEFAULT_WAIT_MS;
+  const baseWaitMs = opts.defaultWaitMs ?? DEFAULT_WAIT_MS;
 
   let result = await fn();
   if (!isGhRateLimited(result)) return result;
 
   const deadlineMs = opts.nowMs() + capMs;
+  let fallbackWaitMs = baseWaitMs;
 
   while (isGhRateLimited(result)) {
     const remainingMs = deadlineMs - opts.nowMs();
@@ -165,7 +181,17 @@ export async function withGhQuotaBackoff(
       // explicit quota reason rather than looping forever.
       return result;
     }
-    const sleepForMs = Math.min(waitMs, remainingMs);
+    // One free probe per wait: sleeping until the pool actually refills turns
+    // the 60s hammer (~30 retries per window) into a single well-aimed retry.
+    const resetMs = (await opts.probeResetMs?.().catch(() => null)) ?? null;
+    const untilResetMs = resetMs === null ? null : resetMs + RESET_MARGIN_MS - opts.nowMs();
+    const sleepForMs = Math.min(
+      untilResetMs !== null && untilResetMs > 0 ? untilResetMs : fallbackWaitMs,
+      remainingMs,
+    );
+    if (untilResetMs === null || untilResetMs <= 0) {
+      fallbackWaitMs = Math.min(fallbackWaitMs * 2, MAX_FALLBACK_WAIT_MS);
+    }
     opts.onWait?.(remainingMs);
     await opts.sleepMs(sleepForMs);
     result = await fn();

--- a/apps/dev/tests/gh-quota.test.ts
+++ b/apps/dev/tests/gh-quota.test.ts
@@ -169,6 +169,29 @@ describe("withGhQuotaBackoff", () => {
     expect(slept.length).toBe(2);
   });
 
+  it("doubles the fallback wait each retry instead of hammering a fixed cadence (#3672)", async () => {
+    const { opts, slept } = fakeBackoff({ capMs: 60 * 60_000, defaultWaitMs: 1_000 });
+    let call = 0;
+    const fn = vi.fn(async (): Promise<ExecOutput> => (++call < 5 ? rateLimitedOutput() : successOutput("ok")));
+    const r = await withGhQuotaBackoff(fn, opts);
+    expect(r.code).toBe(0);
+    // 1s, 2s, 4s, 8s — six Workers on a fixed 60s cadence produced ~9,000
+    // retries in one evening; the doubling is what keeps a drained hour cheap.
+    expect(slept).toEqual([1_000, 2_000, 4_000, 8_000]);
+  });
+
+  it("sleeps to the probed reset instant when a probe is injected", async () => {
+    const { opts, slept } = fakeBackoff({ capMs: 60 * 60_000, defaultWaitMs: 1_000 });
+    const withProbe: GhQuotaBackoffOpts = { ...opts, probeResetMs: async () => opts.nowMs() + 30_000 };
+    let call = 0;
+    const fn = vi.fn(async (): Promise<ExecOutput> => (++call < 2 ? rateLimitedOutput() : successOutput("ok")));
+    const r = await withGhQuotaBackoff(fn, withProbe);
+    expect(r.code).toBe(0);
+    // One sleep, aimed past the reset (probe + 5s margin), not a 60s hammer.
+    expect(slept.length).toBe(1);
+    expect(slept[0]).toBeGreaterThanOrEqual(30_000);
+  });
+
   it("returns the rate-limit output after the cap is exhausted by sleeps", async () => {
     const { opts } = fakeBackoff({ capMs: 5_000, defaultWaitMs: 6_000 });
     // After the first sleep of 5000ms, the fake clock is at 5000ms → remaining = 0 → stop.


### PR DESCRIPTION
Field data 2026-08-11: six Workers in quota-wait at a fixed 60s cadence logged ~9,000 retries and re-drained the GraphQL pool minutes after every hourly reset. This lands the highest-leverage slice tonight: exponential fallback (60s→10min ceiling) plus an injectable reset probe seam for the routed client. The full park-instead-of-wait (#3672) and the REST landing migration (#3663) stay with their tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789077801&installation_model_id=20659&pr_number=3680&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3680&signature=37bc39c26b7fbb1a08e01ec7121e360819f912a2b2ab6c9475a63562b6cf98ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->