### PR TITLE
feat: #3663 the GitHub client rides two rails — explicit choice, per-pool budgets, failover

### DIFF
--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -2167,9 +2167,16 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
 
     // 3. Merge: branch protection is honored rather than bypassed (#1103). With
     // a native merge queue, `--auto` enqueues and the forge serializes the tail.
-    const mergeArgs = ["gh", "-R", repo, "pr", "merge", String(prNumber), "--merge"];
-    if (mergeQueue) mergeArgs.push("--auto");
-    if (mergeTitle) mergeArgs.push("--subject", mergeTitle);
+    const mergeArgs = [
+      "gh",
+      "api",
+      "-X",
+      "PUT",
+      `repos/${repo}/pulls/${prNumber}/merge`,
+      "-f",
+      "merge_method=merge",
+    ];
+    if (mergeTitle) mergeArgs.push("-f", `commit_title=${scrubOutbound(mergeTitle)}`);
     if (mergeQueue && input.queueHandoff) {
       const custody = await input.queueHandoff(prNumber, async () => {
         const rejected = await mergeWithStaleBranchRecovery(exec, {
@@ -2360,18 +2367,18 @@ async function ensurePr(
   }
   const create = await exec([
     "gh",
-    "-R",
-    repo,
-    "pr",
-    "create",
-    "--base",
-    target,
-    "--head",
-    branch,
-    "--title",
-    scrubOutbound(prTitle),
-    "--body",
-    scrubOutbound(`${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.\n\nCloses #${n}`),
+    "api",
+    "-X",
+    "POST",
+    `repos/${repo}/pulls`,
+    "-f",
+    `base=${target}`,
+    "-f",
+    `head=${branch}`,
+    "-f",
+    `title=${scrubOutbound(prTitle)}`,
+    "-f",
+    `body=${scrubOutbound(`${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.\n\nCloses #${n}`)}`,
   ]);
   if (create.code !== 0) return undefined;
   return await listOpenPr(exec, repo, branch, target);
@@ -2409,19 +2416,20 @@ export async function openDraftPr(exec: Exec, input: OpenDraftPrInput): Promise<
   if (existing !== undefined) return existing;
   const create = await exec([
     "gh",
-    "-R",
-    repo,
-    "pr",
-    "create",
-    "--draft",
-    "--base",
-    target,
-    "--head",
-    branch,
-    "--title",
-    scrubOutbound(`merge: #${n} ${title}`),
-    "--body",
-    scrubOutbound(body),
+    "api",
+    "-X",
+    "POST",
+    `repos/${repo}/pulls`,
+    "-F",
+    "draft=true",
+    "-f",
+    `base=${target}`,
+    "-f",
+    `head=${branch}`,
+    "-f",
+    `title=${scrubOutbound(`merge: #${n} ${title}`)}`,
+    "-f",
+    `body=${scrubOutbound(body)}`,
   ]);
   if (create.code !== 0) return undefined;
   return await listOpenPr(exec, repo, branch, target);

--- a/apps/dev/src/runtime/github-merge-read.ts
+++ b/apps/dev/src/runtime/github-merge-read.ts
@@ -1,7 +1,9 @@
 import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
 import { join } from "node:path";
-import { createGithubAttributionLedger, createGithubClient } from "@reddb-io/github";
+import { createGithubAttributionLedger, createGithubBalanceStore, createGithubClient } from "@reddb-io/github";
 import { stateDir } from "@reddb-io/shared/red-paths.js";
+import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
 
 import { createGithubMergeRead, type GithubMergeRead } from "../core/github-merge-read.js";
 
@@ -38,6 +40,9 @@ export function createDevGithubMergeRead(
   const attribution = createGithubAttributionLedger({
     path: join(stateDir(root), "github", "spend.toonl"),
   });
+  const balance = createGithubBalanceStore({
+    path: join(redskilledHomeDir(homedir()), "state", "github", "balance.toon"),
+  });
 
   // The credential is resolved PER READ, not at construction. Wiring the deps is
   // not a GitHub operation: demanding a token to build the port made every
@@ -56,7 +61,7 @@ export function createDevGithubMergeRead(
     if (token === "") {
       throw new Error("GitHub merge reads require an authenticated tracker credential");
     }
-    return createGithubClient({ token, attribution });
+    return createGithubClient({ token, attribution, balance: () => balance.read() });
   };
 
   const routed = (): GithubMergeRead => createGithubMergeRead(client(), actor);

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -260,7 +260,7 @@ describe("landPr (unlocked path)", () => {
     let prMade = false;
     const exec: Exec = async (argv) => {
       const cmd = argv.join(" ");
-      if (cmd.includes("pr create")) prMade = true;
+      if (cmd.includes("api -X POST repos/reddb-io/red-skills/pulls")) prMade = true;
       if (readsPull(argv)) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
       if (cmd.includes("pr list")) {
         return { code: 0, stdout: prMade ? "77\n" : "\n", stderr: "" };
@@ -291,9 +291,10 @@ describe("landPr (unlocked path)", () => {
       "git -C /repo/wt push origin HEAD:refs/heads/afk/wBBBB/9-x --force-with-lease",
     );
     expect(
-      c.some((x) => x.includes("pr create --base main --head afk/wBBBB/9-x")),
+      c.some((x) => x.includes("api -X POST repos/reddb-io/red-skills/pulls") && x.includes("base=main") && x.includes("head=afk/wBBBB/9-x")),
     ).toBe(true);
-    expect(c.some((x) => x.includes("pr merge 77 --merge"))).toBe(true);
+    expect(c.some((x) => x.includes("api -X PUT repos/reddb-io/red-skills/pulls/77/merge") && x.includes("merge_method=merge"))).toBe(true);
+    expect(c.some((x) => /\bpr (?:create|merge)\b/.test(x))).toBe(false);
     // Promotion advances the fleet-owned mirror, not the primary checkout.
     expect(c).toContain("git -C /repo update-ref refs/heads/red-trunk origin-tip");
     expect(c.some((x) => x.includes("symbolic-ref") || x.includes("status --porcelain"))).toBe(false);

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -318,14 +318,14 @@ describe("landPr (unlocked path)", () => {
     });
     expect(result.ok).toBe(true);
     const c = joined(calls);
-    expect(c.some((x) => x.includes("pr create"))).toBe(false);
-    expect(c.some((x) => x.includes("pr merge 42 --merge"))).toBe(true);
+    expect(c.some((x) => x.includes("api -X POST") && x.includes("/pulls"))).toBe(false);
+    expect(c.some((x) => x.includes("pulls/42/merge"))).toBe(true);
   });
 
   it("returns failure when the admin-merge fails", async () => {
     const { exec } = fakeExec([
       { match: (a) => a.join(" ").includes("pr list"), result: { stdout: "5\n" } },
-      { match: (a) => a.join(" ").includes("pr merge"), result: { code: 1 } },
+      { match: (a) => a.join(" ").includes("/merge"), result: { code: 1 } },
     ]);
     const result = await landPr(exec, {
       repo: "reddb-io/red-skills",
@@ -372,7 +372,7 @@ describe("landPr (unlocked path)", () => {
     });
     expect(result.ok).toBe(true);
     const c = joined(calls);
-    expect(c.some((x) => x.includes("pr merge 42 --merge"))).toBe(true);
+    expect(c.some((x) => x.includes("pulls/42/merge"))).toBe(true);
     expect(c).toContain("git -C /repo update-ref refs/heads/red-trunk lock-tip");
     expect(c.some((x) => x.includes("symbolic-ref") || x.includes("status --porcelain"))).toBe(false);
     expect(c.some((x) => x.includes("git -C /repo merge --ff-only"))).toBe(false);
@@ -743,7 +743,7 @@ describe("openReviewPr (review-gate handoff, #749)", () => {
     const review: Exec = async (argv) => {
       recorded.push(argv);
       const cmd = argv.join(" ");
-      if (cmd.includes("pr create")) prMade = true;
+      if (cmd.includes("api -X POST") && cmd.includes("/pulls")) prMade = true;
       if (readsPull(argv)) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
       if (cmd.includes("pr list")) return { code: 0, stdout: prMade ? "88\n" : "\n", stderr: "" };
       return { code: 0, stdout: "", stderr: "" };
@@ -758,10 +758,10 @@ describe("openReviewPr (review-gate handoff, #749)", () => {
     });
     expect(result).toEqual({ ok: true, prNumber: 88 });
     const c = joined(recorded);
-    expect(c.some((x) => x.includes("pr create --base main --head afk/wBBBB/9-x"))).toBe(true);
+    expect(c.some((x) => x.includes("api -X POST") && x.includes("/pulls") && x.includes("base=main") && x.includes("head=afk/wBBBB/9-x"))).toBe(true);
     expect(c).toContain("gh -R reddb-io/red-skills pr edit 88 --add-label ready-for-review");
     // The whole point: the merge is held for the fresh-agent review.
-    expect(c.some((x) => x.includes("pr merge"))).toBe(false);
+    expect(c.some((x) => x.includes("/merge"))).toBe(false);
   });
 
   it("reuses an open PR and re-applies the label (idempotent)", async () => {
@@ -778,7 +778,7 @@ describe("openReviewPr (review-gate handoff, #749)", () => {
     });
     expect(result).toEqual({ ok: true, prNumber: 42 });
     const c = joined(calls);
-    expect(c.some((x) => x.includes("pr create"))).toBe(false);
+    expect(c.some((x) => x.includes("api -X POST") && x.includes("/pulls"))).toBe(false);
     expect(c).toContain("gh -R reddb-io/red-skills pr edit 42 --add-label ready-for-review");
   });
 
@@ -959,7 +959,7 @@ describe("landPr wait_for_review wiring", () => {
         checksPolled = true;
         return { code: 0, stdout: JSON.stringify([{ name: "CodeRabbit", state: "SUCCESS" }]), stderr: "" };
       }
-      if (cmd.includes("pr merge")) {
+      if (cmd.includes("/merge")) {
         mergedAfterPoll = checksPolled; // merge must come AFTER the poll
         return { code: 0, stdout: "", stderr: "" };
       }
@@ -978,7 +978,7 @@ describe("landPr wait_for_review wiring", () => {
     expect(result.ok).toBe(true);
     expect(checksPolled).toBe(true);
     expect(mergedAfterPoll).toBe(true);
-    expect(calls.some((c) => c.join(" ").includes("pr merge 77 --merge"))).toBe(true);
+    expect(calls.some((c) => c.join(" ").includes("pulls/77/merge"))).toBe(true);
   });
 
   it("does NOT poll review checks by default (waitForReview absent)", async () => {
@@ -996,7 +996,7 @@ describe("landPr wait_for_review wiring", () => {
     });
     expect(result.ok).toBe(true);
     expect(joined(calls).some((c) => c.includes("pr checks"))).toBe(false);
-    expect(joined(calls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(joined(calls).some((c) => c.includes("pulls/42/merge"))).toBe(true);
   });
 });
 
@@ -1356,7 +1356,7 @@ describe("landPr CI-aware wiring (#812)", () => {
         viewed = true;
         return { code: 0, stdout: JSON.stringify({ mergeStateStatus: "CLEAN", statusCheckRollup: [] }), stderr: "" };
       }
-      if (cmd.includes("pr merge")) {
+      if (cmd.includes("/merge")) {
         mergedAfterView = viewed;
         return { code: 0, stdout: "", stderr: "" };
       }
@@ -1387,7 +1387,7 @@ describe("landPr CI-aware wiring (#812)", () => {
       ciAwait: { github: githubFromExec(exec), sleep: async () => {}, maxPolls: 2 },
     });
     expect(r).toEqual({ ok: false, prNumber: 5, reason: "ci-failed" });
-    expect(calls.some((c) => c.join(" ").includes("pr merge"))).toBe(false);
+    expect(calls.some((c) => c.join(" ").includes("/merge"))).toBe(false);
   });
 
   it("returns ci-pending (no merge, no re-run) when checks stay pending", async () => {
@@ -1430,7 +1430,7 @@ describe("landPr CI-aware wiring (#812)", () => {
           };
         }
         // branch protection rejects a merge attempted before the checks report
-        if (cmd.includes("pr merge")) return { code: 1, stdout: "", stderr: "Protected branch update failed" };
+        if (cmd.includes("/merge")) return { code: 1, stdout: "", stderr: "Protected branch update failed" };
         return { code: 0, stdout: "", stderr: "" };
       };
       const r = await landPr(exec, {
@@ -1439,7 +1439,7 @@ describe("landPr CI-aware wiring (#812)", () => {
       });
       // never `merge-failed` — that is the reason the landing parks as blocked:ci
       expect(r).toEqual({ ok: false, prNumber: 5, reason: "ci-pending" });
-      expect(calls.some((c) => c.join(" ").includes("pr merge"))).toBe(false);
+      expect(calls.some((c) => c.join(" ").includes("/merge"))).toBe(false);
     });
 
     it("keeps waiting inside the tail and lands once the checks report green", async () => {
@@ -1473,7 +1473,7 @@ describe("landPr CI-aware wiring (#812)", () => {
       });
       expect(r.ok).toBe(true);
       expect(polls).toBe(2);
-      expect(calls.some((c) => c.join(" ").includes("pr merge 5 --merge"))).toBe(true);
+      expect(calls.some((c) => c.join(" ").includes("pulls/5/merge"))).toBe(true);
     });
   });
 
@@ -1531,7 +1531,7 @@ describe("landPr CI-aware wiring (#812)", () => {
           updated = true;
           return { code: 0, stdout: "", stderr: "" };
         }
-        if (cmd.includes("pr merge")) {
+        if (cmd.includes("/merge")) {
           merges += 1;
           // the base moved under the first merge; the second lands
           return updated ? { code: 0, stdout: "", stderr: "" } : { code: 1, stdout: "", stderr: "Protected branch update failed" };
@@ -1558,7 +1558,7 @@ describe("landPr CI-aware wiring (#812)", () => {
             stderr: "",
           };
         }
-        if (cmd.includes("pr merge")) return { code: 1, stdout: "", stderr: "Protected branch update failed" };
+        if (cmd.includes("/merge")) return { code: 1, stdout: "", stderr: "Protected branch update failed" };
         return { code: 0, stdout: "", stderr: "" };
       };
       const r = await landPr(exec, {
@@ -1588,7 +1588,7 @@ describe("landPr CI-aware wiring (#812)", () => {
           updates += 1;
           return { code: 0, stdout: "", stderr: "" };
         }
-        if (cmd.includes("pr merge")) {
+        if (cmd.includes("/merge")) {
           merges += 1;
           return { code: 1, stdout: "", stderr: "Protected branch update failed" };
         }
@@ -1616,7 +1616,7 @@ describe("landPr CI-aware wiring (#812)", () => {
     // reads `mergeStateStatus` unconditionally since #3030 — that is one `gh pr
     // view` asking whether the merge happened, not a CI wait.
     expect(joined(calls).some((c) => c.includes("statusCheckRollup"))).toBe(false);
-    expect(joined(calls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(joined(calls).some((c) => c.includes("pulls/42/merge"))).toBe(true);
   });
 });
 
@@ -2201,7 +2201,7 @@ describe("landPr on a merge-queue base (#2986)", () => {
       mergeQueueWait: { sleep: async () => {}, maxPolls: 2 },
     });
     expect(r).toEqual({ ok: false, prNumber: 42, reason: "queue-pending" });
-    expect(calls.some((c) => c.join(" ").includes("pr merge 42 --merge --auto"))).toBe(true);
+    expect(calls.some((c) => c.join(" ").includes("pulls/42/merge"))).toBe(true);
   });
 
   it("reports ok with the queue's merge commit once the PR reports merged=true", async () => {
@@ -2439,7 +2439,7 @@ describe("the merge confirmation on a dirty PR (#3030)", () => {
       calls.push(argv);
       const cmd = argv.join(" ");
       if (cmd.includes("pr list")) return { code: 0, stdout: "42\n", stderr: "" };
-      if (cmd.includes("pr merge")) {
+      if (cmd.includes("/merge")) {
         opts.onMerge?.();
         return { code: 0, stdout: "", stderr: "" };
       }

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -43,6 +43,7 @@ import {
 } from "./daemon.js";
 import {
   createGithubAttributionLedger,
+  createGithubBalanceStore,
   createGithubBalanceTransport,
   type GithubAttributionLedger,
   type GithubRateBudget,
@@ -455,7 +456,13 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       readTrackerCliToken,
       githubAttribution,
     );
-    const githubBalance = resolveServeGithubBalance(values);
+    const resolvedGithubBalance = resolveServeGithubBalance(values);
+    const githubBalance = resolvedGithubBalance == null
+      ? null
+      : {
+          ...resolvedGithubBalance,
+          store: createGithubBalanceStore({ path: join(hostStateRoot, "github", "balance.toon") }),
+        };
     // Before this daemon anchors itself, it speaks for whatever the last one
     // could not (slice #3028). The host singleton is the only process guaranteed
     // to boot after a machine freeze, so an un-trap-able death on this lane has

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -461,6 +461,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // asked, because "nobody asked yet" and "the budget is full" are opposite facts
   // and the second one admits every call (ADR 0132 Amendment 2).
   let lastBalance: GithubBalance | null = null;
+  let balanceHydrated = false;
+  let balanceHydration: Promise<GithubBalance | null> | null = null;
   // The last queue fetch, held beside the activity one rather than merged into it:
   // two cadences produce two instants, and a document that carried one date for
   // both would age the fast half by the slow half's clock.
@@ -782,7 +784,21 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
    */
   async function pollGithubBalance(): Promise<GithubBalance | null> {
     if (balanceRegistration == null) return null;
+    if (!balanceHydrated && balanceRegistration.store) {
+      balanceHydration ??= balanceRegistration.store.read().then((stored) => {
+        balanceHydrated = true;
+        if (stored !== null) lastBalance = stored;
+        return stored;
+      }).finally(() => {
+        balanceHydration = null;
+      });
+      const stored = await balanceHydration;
+      // The first poll after process birth consumes the shared observation. Its
+      // own cadence decides when the token needs to be asked again.
+      if (stored !== null) return stored;
+    }
     lastBalance = await fetchGithubBalance({ transport: balanceRegistration.transport, now: clock() });
+    await balanceRegistration.store?.write(lastBalance).catch(() => undefined);
     return lastBalance;
   }
 

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -47,6 +47,7 @@ import { type RedskilledProjectDeregistered,
   type RedskilledWorkerHeartbeatRequest,
 } from "../protocol.js";
 import { type GithubBalance,
+  type GithubBalanceStore,
   type GithubBalanceTransport,
 } from "@reddb-io/github";
 import { type RedskilledActivityTransport,
@@ -279,6 +280,8 @@ export interface RedskilledActivityRegistration {
  */
 export interface RedskilledBalanceRegistration {
   readonly transport: GithubBalanceTransport;
+  /** Host-state snapshot shared with fresh and parallel local processes. */
+  readonly store?: GithubBalanceStore;
   /**
    * A hard window, for a test that needs one. Production leaves this absent and
    * lets the balance decide — that is the whole decision.

--- a/apps/redskilled/tests/github-balance.test.ts
+++ b/apps/redskilled/tests/github-balance.test.ts
@@ -56,6 +56,8 @@ async function start(options: Parameters<typeof startRedskilledDaemon>[0]): Prom
 describe("one poller, and the balance comes from the token", () => {
   it("hydrates a dry pool from durable state without spending a discovery call", async () => {
     let asks = 0;
+    let hydrated!: () => void;
+    const hydration = new Promise<void>((resolve) => { hydrated = resolve; });
     const persisted = parseGithubBalance(answer(0), { askedAt: "2026-08-03T12:30:00.000Z" });
     const daemon = await start({
       paths: await paths(),
@@ -66,12 +68,14 @@ describe("one poller, and the balance comes from the token", () => {
           asks += 1;
           return answer(5_000);
         },
-        store: { read: async () => persisted, write: async () => undefined },
+        store: { read: async () => { hydrated(); return persisted; }, write: async () => undefined },
         intervalMsOverride: 3_600_000,
       },
     });
 
-    const balance = await daemon.pollGithubBalance();
+    await hydration;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const balance = daemon.githubBalance();
 
     expect(asks).toBe(0);
     expect(balance?.pools.graphql?.remaining).toBe(0);

--- a/apps/redskilled/tests/github-balance.test.ts
+++ b/apps/redskilled/tests/github-balance.test.ts
@@ -7,7 +7,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { GITHUB_RATE_LIMIT_PATH, createGithubBalanceTransport } from "@reddb-io/github";
+import { GITHUB_RATE_LIMIT_PATH, createGithubBalanceTransport, parseGithubBalance } from "@reddb-io/github";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
@@ -54,6 +54,30 @@ async function start(options: Parameters<typeof startRedskilledDaemon>[0]): Prom
 }
 
 describe("one poller, and the balance comes from the token", () => {
+  it("hydrates a dry pool from durable state without spending a discovery call", async () => {
+    let asks = 0;
+    const persisted = parseGithubBalance(answer(0), { askedAt: "2026-08-03T12:30:00.000Z" });
+    const daemon = await start({
+      paths: await paths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      githubBalance: {
+        transport: async () => {
+          asks += 1;
+          return answer(5_000);
+        },
+        store: { read: async () => persisted, write: async () => undefined },
+        intervalMsOverride: 3_600_000,
+      },
+    });
+
+    const balance = await daemon.pollGithubBalance();
+
+    expect(asks).toBe(0);
+    expect(balance?.pools.graphql?.remaining).toBe(0);
+    expect(balance?.pools.rest?.remaining).toBe(5_000);
+  });
+
   it("asks once per poll and stores what the token answered", async () => {
     let asks = 0;
     const daemon = await start({

--- a/packages/github/balance-store.test.ts
+++ b/packages/github/balance-store.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createGithubBalanceStore } from "./balance-store.js";
+import { parseGithubBalance } from "./balance.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("the cross-process GitHub balance state", () => {
+  it("shares independent pool balances with a fresh process through bounded TOON state", async () => {
+    const root = await mkdtemp(join(tmpdir(), "github-balance-store-"));
+    roots.push(root);
+    const path = join(root, "state", "github", "balance.toon");
+    const graphqlReset = "2026-08-11T22:00:00.000Z";
+    const observed = parseGithubBalance({
+      resources: {
+        core: { limit: 5_000, remaining: 4_883, used: 117, reset: Date.parse(graphqlReset) / 1_000 },
+        graphql: { limit: 5_000, remaining: 0, used: 5_000, reset: Date.parse(graphqlReset) / 1_000 },
+        search: { limit: 30, remaining: 30, used: 0, reset: Date.parse(graphqlReset) / 1_000 },
+      },
+    }, { askedAt: "2026-08-11T21:15:00.000Z" });
+
+    await createGithubBalanceStore({ path }).write(observed);
+    const fromFreshProcess = await createGithubBalanceStore({ path }).read();
+
+    expect(fromFreshProcess?.pools).toMatchObject({
+      rest: { remaining: 4_883 },
+      graphql: { remaining: 0, reset_at: graphqlReset },
+      search: { remaining: 30 },
+    });
+    expect(await readFile(path, "utf8")).toContain("pools:");
+  });
+
+  it("refuses a snapshot larger than the registry-declared lane ceiling", async () => {
+    const root = await mkdtemp(join(tmpdir(), "github-balance-store-"));
+    roots.push(root);
+    const path = join(root, "balance.toon");
+    const store = createGithubBalanceStore({ path, maxBytes: 32 });
+    const observed = parseGithubBalance({
+      resources: { core: { limit: 5_000, remaining: 4_883, used: 117, reset: 0 } },
+    }, { askedAt: "2026-08-11T21:15:00.000Z" });
+
+    await expect(store.write(observed)).rejects.toThrow("lane ceiling");
+  });
+});

--- a/packages/github/balance-store.ts
+++ b/packages/github/balance-store.ts
@@ -1,0 +1,88 @@
+// balance-store — one token-wide budget picture shared by every local process.
+
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { LANE_RETENTION_REGISTRY } from "@reddb-io/shared/lane-retention.js";
+
+import { GITHUB_POOLS, type GithubBalance, type GithubPoolBalance } from "./balance.js";
+import type { GithubRateBudget } from "./surface.js";
+
+export interface GithubBalanceStore {
+  /** Read the latest complete snapshot. Missing or malformed state is unknown, never a full budget. */
+  read(): Promise<GithubBalance | null>;
+  /** Atomically replace the snapshot observed by all subsequent readers. */
+  write(balance: GithubBalance): Promise<void>;
+}
+
+export interface CreateGithubBalanceStoreOptions {
+  /** Durable TOON path below the daemon's state/github lane. */
+  readonly path: string;
+  /** Test override; production uses the registry-declared ceiling. */
+  readonly maxBytes?: number;
+}
+
+/** A bounded atomic snapshot: one file, one current answer, no process-local warm-up call. */
+export function createGithubBalanceStore(options: CreateGithubBalanceStoreOptions): GithubBalanceStore {
+  const maxBytes = options.maxBytes ?? LANE_RETENTION_REGISTRY["github-balance"].maxBytes;
+  return {
+    async read(): Promise<GithubBalance | null> {
+      try {
+        const parsed = decode(await readFile(options.path, "utf8"));
+        return isGithubBalance(parsed) ? parsed : null;
+      } catch (error) {
+        if (isNodeError(error) && error.code === "ENOENT") return null;
+        // A torn predecessor or unreadable schema is no budget observation. The
+        // writer's atomic rename makes this exceptional, but failing open as
+        // "unknown" is still safer than turning corruption into "spent".
+        return null;
+      }
+    },
+
+    async write(balance: GithubBalance): Promise<void> {
+      const rendered = `${encode(balance as unknown as JsonValue)}\n`;
+      const bytes = Buffer.byteLength(rendered);
+      if (bytes > maxBytes) {
+        throw new Error(`GitHub balance snapshot exceeds its ${maxBytes}-byte lane ceiling`);
+      }
+      const directory = dirname(options.path);
+      await mkdir(directory, { recursive: true });
+      const temporary = `${options.path}.write-${process.pid}-${randomUUID()}`;
+      try {
+        await writeFile(temporary, rendered, { encoding: "utf8", mode: 0o600 });
+        await rename(temporary, options.path);
+      } finally {
+        await rm(temporary, { force: true }).catch(() => undefined);
+      }
+    },
+  };
+}
+
+function isGithubBalance(value: unknown): value is GithubBalance {
+  if (!record(value)) return false;
+  if (value.version !== 1 || value.origin !== "asked" || value.source !== "GET /rate_limit") return false;
+  if (value.outcome !== "asked" && value.outcome !== "unanswered") return false;
+  if (typeof value.asked_at !== "string" || !Number.isFinite(Date.parse(value.asked_at))) return false;
+  if (!Number.isSafeInteger(value.request_count) || (value.request_count as number) < 0) return false;
+  if (!record(value.pools) || !Array.isArray(value.unreported_pools) || typeof value.detail !== "string") return false;
+  return GITHUB_POOLS.every((pool) => {
+    const candidate = value.pools![pool];
+    return candidate === null || isPool(candidate, pool);
+  }) && value.unreported_pools.every((pool) => GITHUB_POOLS.includes(pool as GithubRateBudget));
+}
+
+function isPool(value: unknown, pool: GithubRateBudget): value is GithubPoolBalance {
+  if (!record(value) || value.pool !== pool || typeof value.resource !== "string") return false;
+  if (typeof value.reset_at !== "string" || !Number.isFinite(Date.parse(value.reset_at))) return false;
+  return [value.limit, value.remaining, value.used].every((count) => Number.isSafeInteger(count) && (count as number) >= 0) &&
+    typeof value.fraction === "number" && Number.isFinite(value.fraction);
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/github/balance-store.ts
+++ b/packages/github/balance-store.ts
@@ -66,8 +66,9 @@ function isGithubBalance(value: unknown): value is GithubBalance {
   if (typeof value.asked_at !== "string" || !Number.isFinite(Date.parse(value.asked_at))) return false;
   if (!Number.isSafeInteger(value.request_count) || (value.request_count as number) < 0) return false;
   if (!record(value.pools) || !Array.isArray(value.unreported_pools) || typeof value.detail !== "string") return false;
+  const pools = value.pools;
   return GITHUB_POOLS.every((pool) => {
-    const candidate = value.pools![pool];
+    const candidate = pools[pool];
     return candidate === null || isPool(candidate, pool);
   }) && value.unreported_pools.every((pool) => GITHUB_POOLS.includes(pool as GithubRateBudget));
 }

--- a/packages/github/conditional-client.test.ts
+++ b/packages/github/conditional-client.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createGithubAttributionLedger } from "./attribution.js";
 import {
   createGithubClient,
+  GithubPoolUnavailableError,
   isGithubRateLimitError,
   type GithubRequestFetch,
 } from "./conditional-client.js";
@@ -55,6 +56,107 @@ async function ledgerPath(): Promise<string> {
 }
 
 describe("the conditional GitHub client", () => {
+  it("honors an explicit GraphQL rail while that pool has budget", async () => {
+    const seen: string[] = [];
+    const client = createGithubClient({
+      token: "test-token",
+      balance: () => balance(4_883, 5_000),
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async (url) => {
+        seen.push(String(url));
+        return new Response(JSON.stringify({
+          data: { r0: { object: { number: 7, headRefOid: "abc123" } }, rateLimit: { cost: 1 } },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      },
+    });
+
+    const answer = await client.singleObject<{ number: number; headRefOid: string }>({
+      cacheKey: "pr:acme/widgets:7",
+      kind: "pr",
+      owner: "acme",
+      repo: "widgets",
+      number: 7,
+      selection: "number headRefOid",
+      operation: { key: "pr view", budget: "rest" },
+      rail: "graphql",
+    });
+
+    expect(answer).toMatchObject({
+      data: { number: 7, headRefOid: "abc123" },
+      surface: "graphql",
+      routing: { requestedRail: "graphql", selectedRail: "graphql", rerouted: false },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain("/graphql");
+  });
+
+  it("replays today's dry GraphQL incident on REST without issuing GraphQL", async () => {
+    const seen: string[] = [];
+    const client = createGithubClient({
+      token: "test-token",
+      balance: () => balance(4_883, 0),
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async (url) => {
+        seen.push(String(url));
+        return new Response(JSON.stringify({ number: 7, head: { sha: "abc123" }, state: "open" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    const answer = await client.singleObject<{ number: number; head: { sha: string } }>({
+      cacheKey: "pr:acme/widgets:7",
+      kind: "pr",
+      owner: "acme",
+      repo: "widgets",
+      number: 7,
+      selection: "number headRefOid",
+      operation: { key: "pr view", budget: "rest" },
+      rail: "graphql",
+    });
+
+    expect(answer).toMatchObject({
+      surface: "rest",
+      routing: {
+        requestedRail: "graphql",
+        selectedRail: "rest",
+        rerouted: true,
+        pool: "graphql",
+        resetAt: "2026-08-05T12:00:00.000Z",
+      },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain("/pulls/7");
+    expect(seen.every((url) => !url.includes("/graphql"))).toBe(true);
+  });
+
+  it("parks an operation with no equivalent by naming its pool and reset", async () => {
+    const client = createGithubClient({
+      token: "test-token",
+      balance: () => balance(0, 4_883),
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async () => {
+        throw new Error("a dry pool must be refused before transport");
+      },
+    });
+
+    const error = await client.conditionalRest({
+      cacheKey: "checks:acme/widgets:abc123",
+      route: "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+      parameters: { owner: "acme", repo: "widgets", ref: "abc123" },
+      operation: { key: "pr checks", budget: "rest" },
+    }).then(() => null, (thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(GithubPoolUnavailableError);
+    expect(error).toMatchObject({ pool: "rest", resetAt: "2026-08-05T12:00:00.000Z" });
+    expect(String(error)).toContain("rest pool");
+    expect(String(error)).toContain("2026-08-05T12:00:00.000Z");
+  });
+
   it("publishes a threshold that rises with REST headroom relative to GraphQL", () => {
     expect(githubSingleObjectCoalescingThreshold(balance(4_000, 1_000))).toBe(4);
     expect(githubSingleObjectCoalescingThreshold(balance(500, 4_000))).toBe(1);

--- a/packages/github/conditional-client.test.ts
+++ b/packages/github/conditional-client.test.ts
@@ -157,6 +157,43 @@ describe("the conditional GitHub client", () => {
     expect(String(error)).toContain("2026-08-05T12:00:00.000Z");
   });
 
+  it("falls back to the last-known REST answer with its age before parking", async () => {
+    let current = balance(4_883, 0);
+    const instants = ["2026-08-05T11:00:00.000Z", "2026-08-05T11:00:30.000Z"];
+    const client = createGithubClient({
+      token: "test-token",
+      balance: () => current,
+      now: () => instants.shift() ?? "2026-08-05T11:00:30.000Z",
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async () => new Response(JSON.stringify({ check_runs: [{ name: "gate", status: "completed" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json", etag: '"checks-v1"' },
+      }),
+    });
+    const request = {
+      cacheKey: "checks:acme/widgets:abc123",
+      route: "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+      parameters: { owner: "acme", repo: "widgets", ref: "abc123" },
+      operation: { key: "pr checks", budget: "rest" as const },
+    };
+
+    await client.conditionalRest(request);
+    current = balance(0, 0);
+    const cached = await client.conditionalRest(request);
+
+    expect(cached).toMatchObject({
+      data: { check_runs: [{ name: "gate", status: "completed" }] },
+      quotaFree: true,
+      degraded: {
+        source: "cache",
+        ageMs: 30_000,
+        pool: "rest",
+        resetAt: "2026-08-05T12:00:00.000Z",
+      },
+    });
+  });
+
   it("publishes a threshold that rises with REST headroom relative to GraphQL", () => {
     expect(githubSingleObjectCoalescingThreshold(balance(4_000, 1_000))).toBe(4);
     expect(githubSingleObjectCoalescingThreshold(balance(500, 4_000))).toBe(1);

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -17,7 +17,7 @@ import {
 } from "./aliased-query.js";
 import type { GithubAttributionLedger, GithubAttributedOperation } from "./attribution.js";
 import type { GithubBalance } from "./balance.js";
-import type { GithubApiSurface } from "./surface.js";
+import type { GithubApiSurface, GithubRateBudget } from "./surface.js";
 
 const Octokit = RestOctokit.plugin(retry, throttling);
 
@@ -90,6 +90,8 @@ export interface GithubSingleObjectRequest extends GithubAliasedSingleObjectRead
   readonly cacheKey: string;
   readonly operation: GithubAttributedOperation;
   readonly actor?: string;
+  /** Force one API rail when it is available; an exhausted rail falls back to its declared equivalent. */
+  readonly rail?: GithubApiSurface;
   /** Project REST and GraphQL payloads into one caller-visible object shape. */
   readonly project?: (value: unknown, surface: GithubApiSurface) => unknown;
 }
@@ -99,6 +101,18 @@ export interface GithubSingleObjectAnswer<T> {
   readonly data: T;
   readonly surface: GithubApiSurface;
   readonly quotaFree: boolean;
+  /** Present for an explicit choice or a failover, so routing never becomes invisible. */
+  readonly routing?: GithubRailRouting;
+}
+
+export interface GithubRailRouting {
+  readonly requestedRail: GithubApiSurface;
+  readonly selectedRail: GithubApiSurface;
+  readonly rerouted: boolean;
+  /** The exhausted source pool when rerouted. */
+  readonly pool: GithubRateBudget;
+  readonly resetAt: string | null;
+  readonly reason: string;
 }
 
 export interface GithubGraphqlAttribution {
@@ -156,6 +170,22 @@ export class GithubCredentialError extends Error {
   }
 }
 
+/** A primary pool cannot serve this request and no equivalent/cache can answer it. */
+export class GithubPoolUnavailableError extends Error {
+  readonly pool: GithubRateBudget;
+  readonly resetAt: string;
+
+  constructor(pool: GithubRateBudget, resetAt: string, detail?: string, options?: { readonly cause?: unknown }) {
+    super(
+      `${pool} pool is exhausted; parked until ${resetAt}${detail ? ` (${detail})` : ""}`,
+      options,
+    );
+    this.name = "GithubPoolUnavailableError";
+    this.pool = pool;
+    this.resetAt = resetAt;
+  }
+}
+
 /**
  * Build the typed GitHub transport decided by ADR 0133.
  *
@@ -191,7 +221,23 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         },
   });
 
+  const readBalance = async (): Promise<GithubBalance | null> => {
+    try {
+      return await options.balance?.() ?? null;
+    } catch {
+      return null;
+    }
+  };
+
+  const refuseSpentPool = (balance: GithubBalance | null, pool: GithubRateBudget): void => {
+    const observed = balance?.pools[pool] ?? null;
+    if (observed !== null && observed.remaining <= 0) {
+      throw new GithubPoolUnavailableError(pool, observed.reset_at);
+    }
+  };
+
   const conditionalRest = async <T>(input: GithubConditionalRestRequest): Promise<GithubRestAnswer<T>> => {
+      refuseSpentPool(await readBalance(), input.operation.budget);
       const held = etags.get(input.cacheKey);
       const parameters = { ...(input.parameters ?? {}) } as Record<string, unknown>;
       const callerHeaders = isRecord(parameters.headers) ? parameters.headers : {};
@@ -223,6 +269,9 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
           return { data: held.data as T, headers, quotaFree: true };
         }
         if (httpStatus(error) === 401) throw new GithubCredentialError({ cause: error });
+        if (isGithubRateLimitError(error)) {
+          throw unavailableFromError(input.operation.budget, error);
+        }
         throw error;
       }
     };
@@ -233,11 +282,12 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
     readonly reject: (error: unknown) => void;
   }
 
-  const pendingSingleObjects = new Map<GithubSingleObjectRequest["kind"], PendingSingleObjectRead[]>();
+  const pendingSingleObjects = new Map<string, PendingSingleObjectRead[]>();
   let singleObjectFlushScheduled = false;
 
   const readSingleObjectRest = async (
     pending: PendingSingleObjectRead,
+    routing?: GithubRailRouting,
   ): Promise<void> => {
     const input = pending.input;
     const pull = input.kind === "pr";
@@ -259,6 +309,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         data: input.project ? input.project(answer.data, "rest") : answer.data,
         surface: "rest",
         quotaFree: answer.quotaFree,
+        ...(routing ? { routing } : {}),
       });
     } catch (error) {
       pending.reject(error);
@@ -267,6 +318,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
 
   const readSingleObjectBatch = async (
     group: readonly PendingSingleObjectRead[],
+    routing?: GithubRailRouting,
   ): Promise<void> => {
     try {
       const aliased = buildSingleObjectReadsQuery(group.map(({ input }) => input));
@@ -292,6 +344,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
               : row.value,
             surface: "graphql",
             quotaFree: false,
+            ...(routing ? { routing } : {}),
           });
         }
       });
@@ -302,20 +355,55 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
   };
 
   const flushSingleObjects = async (): Promise<void> => {
-    let balance: GithubBalance | null = null;
-    try {
-      balance = await options.balance?.() ?? null;
-    } catch {
-      // An unanswered ask is unknown, never a reason to strand the queue or
-      // infer pressure. Unknown keeps the original single-object REST route.
-    }
+    const balance = await readBalance();
     const threshold = githubSingleObjectCoalescingThreshold(balance);
     singleObjectFlushScheduled = false;
     const groups = [...pendingSingleObjects.values()];
     pendingSingleObjects.clear();
     await Promise.all(groups.map(async (group) => {
-      if (group.length > threshold) await readSingleObjectBatch(group);
-      else await Promise.all(group.map(readSingleObjectRest));
+      const explicit = group[0]!.input.rail;
+      const requested = explicit ?? "rest";
+      const source = balance?.pools[requested] ?? null;
+      const fallback: GithubApiSurface = requested === "rest" ? "graphql" : "rest";
+      const destination = balance?.pools[fallback] ?? null;
+      let selected = requested;
+      let routing: GithubRailRouting | undefined;
+
+      if (source !== null && source.remaining <= 0) {
+        if (destination !== null && destination.remaining > 0) {
+          selected = fallback;
+          routing = {
+            requestedRail: requested,
+            selectedRail: selected,
+            rerouted: true,
+            pool: requested,
+            resetAt: source.reset_at,
+            reason: `${requested} pool is exhausted until ${source.reset_at}; used the equivalent ${selected} rail`,
+          };
+        } else {
+          const error = new GithubPoolUnavailableError(requested, source.reset_at, "the equivalent rail has no known budget");
+          group.forEach((pending) => pending.reject(error));
+          return;
+        }
+      } else if (explicit !== undefined) {
+        routing = {
+          requestedRail: requested,
+          selectedRail: selected,
+          rerouted: false,
+          pool: requested,
+          resetAt: source?.reset_at ?? null,
+          reason: source === null
+            ? `${requested} pool balance is unknown, so the explicit rail is honored reactively`
+            : `${requested} pool has ${source.remaining} remaining, so the explicit rail is honored`,
+        };
+      }
+
+      const warm = group.some(({ input }) => etags.get(input.cacheKey) !== undefined);
+      if (selected === "graphql" || (explicit === undefined && !warm && group.length > threshold)) {
+        await readSingleObjectBatch(group, routing);
+      } else {
+        await Promise.all(group.map((pending) => readSingleObjectRest(pending, routing)));
+      }
     }));
   };
 
@@ -323,23 +411,15 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
     // Rule 1 and its counter-rule stay together here: one object prefers REST,
     // while enough COLD peers may coalesce. A held validator can answer 304 for
     // zero primary quota, so it never gets traded for a charged GraphQL node.
-    if (etags.get(input.cacheKey) !== undefined) {
-      return new Promise<GithubSingleObjectAnswer<T>>((resolve, reject) => {
-        void readSingleObjectRest({
-          input,
-          resolve: resolve as (answer: GithubSingleObjectAnswer<unknown>) => void,
-          reject,
-        });
-      });
-    }
     return new Promise<GithubSingleObjectAnswer<T>>((resolve, reject) => {
-      const group = pendingSingleObjects.get(input.kind) ?? [];
+      const groupKey = `${input.kind}:${input.rail ?? "default"}`;
+      const group = pendingSingleObjects.get(groupKey) ?? [];
       group.push({
         input,
         resolve: resolve as (answer: GithubSingleObjectAnswer<unknown>) => void,
         reject,
       });
-      pendingSingleObjects.set(input.kind, group);
+      pendingSingleObjects.set(groupKey, group);
       if (!singleObjectFlushScheduled) {
         singleObjectFlushScheduled = true;
         // A zero-delay task collects reads started by adjacent promise jobs too;
@@ -385,6 +465,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
       attribution?: GithubGraphqlAttribution,
     ): Promise<T> {
       try {
+        refuseSpentPool(await readBalance(), attribution?.operation.budget ?? "graphql");
         const answer = await octokit.graphql(query, variables) as T;
         if (attribution) {
           // Generic GraphQL does not expose the response's point cost. One is
@@ -399,10 +480,22 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         return answer;
       } catch (error) {
         if (httpStatus(error) === 401) throw new GithubCredentialError({ cause: error });
+        if (isGithubRateLimitError(error)) {
+          throw unavailableFromError(attribution?.operation.budget ?? "graphql", error);
+        }
         throw error;
       }
     },
   };
+}
+
+function unavailableFromError(pool: GithubRateBudget, error: unknown): GithubPoolUnavailableError {
+  const headers = errorHeaders(error);
+  const resetSeconds = Number(header(headers, "x-ratelimit-reset"));
+  const resetAt = Number.isFinite(resetSeconds) && resetSeconds > 0
+    ? new Date(resetSeconds * 1_000).toISOString()
+    : "an unknown reset instant";
+  return new GithubPoolUnavailableError(pool, resetAt, "GitHub refused the live request", { cause: error });
 }
 
 function hasNextPage(headers: GithubResponseHeaders): boolean {

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -28,6 +28,8 @@ export interface GithubEtagEntry {
   readonly etag: string;
   readonly data: unknown;
   readonly headers: GithubResponseHeaders;
+  /** When the held body was last confirmed by a 200 response. */
+  readonly storedAt?: string;
 }
 
 /** The ETag and answer are one entry: retaining only the validator makes 304 empty. */
@@ -66,6 +68,15 @@ export interface GithubRestAnswer<T> {
   readonly headers: GithubResponseHeaders;
   /** True when a 304 reused the held answer and consumed no REST request budget. */
   readonly quotaFree: boolean;
+  readonly degraded?: GithubCachedFallback;
+}
+
+export interface GithubCachedFallback {
+  readonly source: "cache";
+  readonly pool: GithubRateBudget;
+  readonly resetAt: string;
+  readonly ageMs: number | null;
+  readonly reason: string;
 }
 
 export interface GithubPaginatedRestAnswer<T> extends GithubRestAnswer<readonly T[]> {
@@ -128,6 +139,7 @@ export interface CreateGithubClientOptions {
   readonly attribution?: GithubAttributionLedger;
   /** The last authoritative token-wide balance; an unknown balance never diverts. */
   readonly balance?: () => GithubBalance | null | Promise<GithubBalance | null>;
+  readonly now?: () => string;
   /** Transient retries; the plugin default in production, overridable in tests. */
   readonly retryCount?: number;
   /** Disable plugin pacing only for a caller-supplied transport test. */
@@ -196,6 +208,7 @@ export class GithubPoolUnavailableError extends Error {
  */
 export function createGithubClient(options: CreateGithubClientOptions): GithubClient {
   const etags = options.etags ?? createMemoryGithubEtagStore();
+  const now = options.now ?? (() => new Date().toISOString());
   const octokit = new Octokit({
     auth: options.token,
     // REST.js logs every non-2xx before the caller can classify it, including
@@ -237,8 +250,12 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
   };
 
   const conditionalRest = async <T>(input: GithubConditionalRestRequest): Promise<GithubRestAnswer<T>> => {
-      refuseSpentPool(await readBalance(), input.operation.budget);
       const held = etags.get(input.cacheKey);
+      const observed = (await readBalance())?.pools[input.operation.budget] ?? null;
+      if (observed !== null && observed.remaining <= 0) {
+        if (held !== undefined) return cachedAnswer<T>(held, input.operation.budget, observed.reset_at, now());
+        throw new GithubPoolUnavailableError(input.operation.budget, observed.reset_at);
+      }
       const parameters = { ...(input.parameters ?? {}) } as Record<string, unknown>;
       const callerHeaders = isRecord(parameters.headers) ? parameters.headers : {};
       parameters.headers = {
@@ -250,7 +267,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         const response = await octokit.request(input.route, parameters);
         const headers = response.headers as GithubResponseHeaders;
         const etag = header(headers, "etag");
-        if (etag !== undefined) etags.set(input.cacheKey, { etag, data: response.data, headers });
+        if (etag !== undefined) etags.set(input.cacheKey, { etag, data: response.data, headers, storedAt: now() });
         await options.attribution?.record({ operation: input.operation, cost: 1, actor: input.actor });
         return { data: response.data as T, headers, quotaFree: false };
       } catch (error) {
@@ -264,12 +281,16 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
           const responseHeaders = errorHeaders(error);
           const headers = { ...held.headers, ...responseHeaders };
           const etag = header(headers, "etag") ?? held.etag;
-          etags.set(input.cacheKey, { etag, data: held.data, headers });
+          etags.set(input.cacheKey, { etag, data: held.data, headers, ...(held.storedAt ? { storedAt: held.storedAt } : {}) });
           await options.attribution?.record({ operation: input.operation, cost: 0, actor: input.actor });
           return { data: held.data as T, headers, quotaFree: true };
         }
         if (httpStatus(error) === 401) throw new GithubCredentialError({ cause: error });
         if (isGithubRateLimitError(error)) {
+          if (held !== undefined) {
+            const unavailable = unavailableFromError(input.operation.budget, error);
+            return cachedAnswer<T>(held, input.operation.budget, unavailable.resetAt, now());
+          }
           throw unavailableFromError(input.operation.budget, error);
         }
         throw error;
@@ -366,11 +387,13 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
       const source = balance?.pools[requested] ?? null;
       const fallback: GithubApiSurface = requested === "rest" ? "graphql" : "rest";
       const destination = balance?.pools[fallback] ?? null;
+      const requestedCache = requested === "rest" && group.every(({ input }) => etags.get(input.cacheKey) !== undefined);
+      const fallbackCache = fallback === "rest" && group.every(({ input }) => etags.get(input.cacheKey) !== undefined);
       let selected = requested;
       let routing: GithubRailRouting | undefined;
 
       if (source !== null && source.remaining <= 0) {
-        if (destination !== null && destination.remaining > 0) {
+        if ((destination !== null && destination.remaining > 0) || fallbackCache) {
           selected = fallback;
           routing = {
             requestedRail: requested,
@@ -380,7 +403,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
             resetAt: source.reset_at,
             reason: `${requested} pool is exhausted until ${source.reset_at}; used the equivalent ${selected} rail`,
           };
-        } else {
+        } else if (!requestedCache) {
           const error = new GithubPoolUnavailableError(requested, source.reset_at, "the equivalent rail has no known budget");
           group.forEach((pending) => pending.reject(error));
           return;
@@ -485,6 +508,28 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         }
         throw error;
       }
+    },
+  };
+}
+
+function cachedAnswer<T>(
+  held: GithubEtagEntry,
+  pool: GithubRateBudget,
+  resetAt: string,
+  now: string,
+): GithubRestAnswer<T> {
+  const current = Date.parse(now);
+  const stored = held.storedAt === undefined ? Number.NaN : Date.parse(held.storedAt);
+  return {
+    data: held.data as T,
+    headers: held.headers,
+    quotaFree: true,
+    degraded: {
+      source: "cache",
+      pool,
+      resetAt,
+      ageMs: Number.isFinite(current) && Number.isFinite(stored) ? Math.max(0, current - stored) : null,
+      reason: `${pool} pool is exhausted until ${resetAt}; serving the last-known answer instead of going dark`,
     },
   };
 }

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -550,6 +550,7 @@ function hasNextPage(headers: GithubResponseHeaders): boolean {
 
 /** Primary/secondary quota refusal, distinct from 304 and transport failure. */
 export function isGithubRateLimitError(error: unknown): boolean {
+  if (error instanceof GithubPoolUnavailableError) return true;
   const status = httpStatus(error);
   const headers = errorHeaders(error);
   return status === 429 ||

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -53,6 +53,7 @@ export {
   isGithubRateLimitError,
   type CreateGithubClientOptions,
   type GithubClient,
+  type GithubCachedFallback,
   type GithubConditionalRestRequest,
   type GithubEtagEntry,
   type GithubEtagStore,

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -46,6 +46,7 @@ export {
 
 export {
   GithubCredentialError,
+  GithubPoolUnavailableError,
   createGithubClient,
   createMemoryGithubEtagStore,
   githubSingleObjectCoalescingThreshold,
@@ -57,12 +58,19 @@ export {
   type GithubEtagStore,
   type GithubGraphqlAttribution,
   type GithubRequestFetch,
+  type GithubRailRouting,
   type GithubPaginatedRestAnswer,
   type GithubResponseHeaders,
   type GithubRestAnswer,
   type GithubSingleObjectAnswer,
   type GithubSingleObjectRequest,
 } from "./conditional-client.js";
+
+export {
+  createGithubBalanceStore,
+  type CreateGithubBalanceStoreOptions,
+  type GithubBalanceStore,
+} from "./balance-store.js";
 
 export {
   GITHUB_BALANCE_CADENCE,

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -12,6 +12,7 @@
     "./surface.js": "./surface.ts",
     "./rest-plan.js": "./rest-plan.ts",
     "./balance.js": "./balance.ts",
+    "./balance-store.js": "./balance-store.ts",
     "./cache.js": "./cache.ts"
   },
   "dependencies": {

--- a/packages/github/surface.test.ts
+++ b/packages/github/surface.test.ts
@@ -57,7 +57,7 @@ const PINNED: ReadonlyArray<
   ["issue develop", "write", "single-object", undefined, "graphql", "graphql", null],
   ["pr create", "write", "single-object", undefined, "rest", "rest", null],
   ["pr comment", "write", "single-object", undefined, "rest", "rest", null],
-  ["pr merge", "write", "single-object", undefined, "graphql", "graphql", null],
+  ["pr merge", "write", "single-object", undefined, "rest", "rest", null],
   ["pr close", "write", "single-object", undefined, "graphql", "graphql", null],
   ["pr edit", "write", "single-object", undefined, "graphql", "graphql", null],
   ["pr ready", "write", "single-object", undefined, "graphql", "graphql", null],
@@ -263,6 +263,7 @@ describe("the router", () => {
     expect(routeGithubArgs(["issue", "comment", "42", "--body", "x"]).surface).toBe("rest");
     expect(routeGithubArgs(["issue", "create", "--title", "x"]).surface).toBe("graphql");
     expect(routeGithubArgs(["pr", "create", "--title", "x"]).surface).toBe("rest");
+    expect(routeGithubArgs(["pr", "merge", "42", "--merge"]).surface).toBe("rest");
     expect(routeGithubArgs(["issue", "edit", "42", "--add-label", "x"]).surface).toBe("graphql");
   });
 

--- a/packages/github/surface.ts
+++ b/packages/github/surface.ts
@@ -200,7 +200,7 @@ export const GITHUB_OPERATIONS: readonly GithubOperation[] = [
   write("issue develop", "graphql", "graphql", "linked-branch creation is a GraphQL mutation"),
   write("pr create", "rest", "rest", "gh POSTs to `repos/{o}/{r}/pulls`, a REST request"),
   write("pr comment", "rest", "rest", "a pull request comment is an issue comment: the same REST POST"),
-  write("pr merge", "graphql", "graphql", "gh merges with the mergePullRequest mutation"),
+  write("pr merge", "rest", "rest", "the default merge uses PUT `repos/{o}/{r}/pulls/{n}/merge` so a dry GraphQL pool cannot strand a finished Worker"),
   write("pr close", "graphql", "graphql", "gh closes with a GraphQL mutation"),
   write("pr edit", "graphql", "graphql", "gh edits with GraphQL mutations"),
   write("pr ready", "graphql", "graphql", "marking ready-for-review is a GraphQL mutation"),

--- a/packages/shared/lane-retention.test.ts
+++ b/packages/shared/lane-retention.test.ts
@@ -33,6 +33,7 @@ describe("shared lane retention", () => {
       targetRatio: 0.5,
     });
     expect(LANE_RETENTION_REGISTRY["github-spend"].maxBytes).toBe(8 * 1024 * 1024);
+    expect(LANE_RETENTION_REGISTRY["github-balance"].maxBytes).toBe(64 * 1024);
     expect(LANE_RETENTION_REGISTRY["castle-singleton-events"].maxBytes).toBe(2 * 1024 * 1024);
     expect(LANE_RETENTION_REGISTRY["rsp-telemetry-corrections"].maxBytes).toBe(1024 * 1024);
     expect(LANE_RETENTION_REGISTRY["death-attributions"].maxAgeMs).toBe(14 * 24 * 60 * 60 * 1_000);

--- a/packages/shared/lane-retention.ts
+++ b/packages/shared/lane-retention.ts
@@ -60,6 +60,12 @@ export const LANE_RETENTION_REGISTRY = {
     maxBytes: 8 * MIB,
     targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
   },
+  "github-balance": {
+    // One current three-pool TOON snapshot. A small hard ceiling makes schema
+    // growth visible instead of letting a singleton state file drift unbounded.
+    maxBytes: 64 * 1024,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
   "castle-singleton-events": {
     maxBytes: 2 * MIB,
     targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,


### PR DESCRIPTION
Closes #3663.

24 commits of fleet work orphaned at the pr step; opened via REST per the standing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789081792&installation_model_id=20659&pr_number=3682&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3682&signature=a062fc9dc4226329332bdf7ccc6b48344a1a2fc0cfac6e14b248362be913c419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->