### PR TITLE
fix: #3578 daemon death verdicts consult liveness anchors, not the watch

### DIFF
--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -2236,7 +2236,12 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   );
   observations = replayRedskilledMetricObservations(laneEvents, clock());
   const replayed = rehydrateWorkers(laneEvents);
-  const reattachment = await reattachWorkers(replayed, liveness);
+  // Take the active-unit census before attributing any replayed birth as dead.
+  // A per-Worker probe can miss during a watch gap; an independently active unit
+  // is still a Worker the successor can re-attach, never evidence of a death.
+  const activeUnits = new Set(await Promise.resolve(unitInventory()).catch(() => []));
+  const reattachment = await reattachWorkers(replayed, (worker) =>
+    worker.unit != null && activeUnits.has(worker.unit) ? true : liveness(worker));
   for (const worker of reattachment.alive) {
     // Named, never dropped: a Worker whose owning project the lane no longer
     // carries is still a live process charged to this machine, and the label it
@@ -2257,7 +2262,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // unit nobody accounts for is adopted rather than left outside the budget
   // (#2917). Failing to ask costs the sweep and never the start.
   const discovered = discoverUnownedWorkers({
-    units: await Promise.resolve(unitInventory()).catch(() => []),
+    units: [...activeUnits],
     held: [...workers.values()],
     mainPid: unitMainPid,
     now: startedAt,

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -2236,9 +2236,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   );
   observations = replayRedskilledMetricObservations(laneEvents, clock());
   const replayed = rehydrateWorkers(laneEvents);
-  // Take the active-unit census before attributing any replayed birth as dead.
-  // A per-Worker probe can miss during a watch gap; an independently active unit
-  // is still a Worker the successor can re-attach, never evidence of a death.
+  // Census active units before attributing deaths: an active unit is re-attachable, not dead.
   const activeUnits = new Set(await Promise.resolve(unitInventory()).catch(() => []));
   const reattachment = await reattachWorkers(replayed, (worker) =>
     worker.unit != null && activeUnits.has(worker.unit) ? true : liveness(worker));
@@ -2256,11 +2254,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   for (const worker of reattachment.dead) {
     record("worker-death", worker, "the Worker ended while no daemon was watching");
   }
-  // The lane is this daemon's memory, not the machine's: a Worker whose birth was
-  // never written — or was written and then falsely retired — is invisible to the
-  // replay and very much alive to the host. So the host itself is asked, and a
-  // unit nobody accounts for is adopted rather than left outside the budget
-  // (#2917). Failing to ask costs the sweep and never the start.
+  // The lane is this daemon's memory, not the machine's: a birth never written —
+  // or falsely retired — is invisible to the replay and alive to the host. So the
+  // host is asked, and an unaccounted unit is adopted rather than left outside
+  // the budget (#2917). Failing to ask costs the sweep and never the start.
   const discovered = discoverUnownedWorkers({
     units: [...activeUnits],
     held: [...workers.values()],

--- a/apps/redskilled/tests/daemon-reattach-survivor.test.ts
+++ b/apps/redskilled/tests/daemon-reattach-survivor.test.ts
@@ -23,6 +23,7 @@ import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   ensureRedskilledDaemon,
+  publishRedskilledWorkerLogLine,
   readRedskilledHostState,
   startRedskilledWorker,
   type RedskilledClientConfig,
@@ -206,6 +207,48 @@ describe("a launch client that dies is not a Worker that died", () => {
     expect(second.hostState().workers.map((worker) => worker.worker_id)).toEqual(["wWTVC"]);
     expect(second.reattached().map((worker) => worker.worker_id)).toEqual(["wWTVC"]);
     expect(second.hostState().budget_accounting.worker_count).toBe(1);
+  });
+
+  it("keeps a re-attachable Worker when its active unit contradicts a missed liveness probe", async () => {
+    const paths = await sessionPaths();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    const worker: RedskilledWorkerView = {
+      worker_id: "hBQ3P",
+      project_label: "reddb-io/red-skills",
+      pid: 137_871,
+      started_at: "2026-08-11T19:40:00.000Z",
+      workspace_path: "/tmp/ws",
+      isolated: true,
+      unit: "red-worker-reddb-io-red-skills-hbq3p.service",
+      warnings: [],
+    };
+    await lane.record({ event: "worker-birth", worker, ts: worker.started_at });
+
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      // A watch gap is not a death: the host's active-unit census is the
+      // independent liveness anchor that still sees this Worker.
+      liveness: () => false,
+      unitInventory: () => [worker.unit!],
+      unitMainPid: () => 137_873,
+    });
+    running.push(daemon);
+
+    expect(daemon.hostState().workers.map((view) => view.worker_id)).toEqual([worker.worker_id]);
+    expect(daemon.hostState().workers[0]!.project_label).toBe(worker.project_label);
+    expect(daemon.hostState().workers[0]!.pid).toBe(137_873);
+
+    const heartbeat = await publishRedskilledWorkerLogLine(
+      paths,
+      { worker_id: worker.worker_id, line: "still working", session_project: worker.project_label },
+      { sessionProject: worker.project_label },
+    );
+    expect(heartbeat.accepted).toBe(true);
+
+    await daemon.flushEvents();
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.map((event) => event.event)).toEqual(["worker-birth"]);
   });
 
   it("still records a death when the process that exited WAS the Worker", async () => {


### PR DESCRIPTION
Closes #3578.

Orphaned at the pr step; opened via REST per the standing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789081794&installation_model_id=20659&pr_number=3683&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3683&signature=fbcfed12aec0d5ce7dcecb4ee00e4dd9486e14a26b84e7dcaac971da79c61729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->