### PR TITLE
fix: #3642 Unit-path Worker teardown confirms death instead of taking systemctl's word

### DIFF
--- a/apps/redskilled/src/reattach.ts
+++ b/apps/redskilled/src/reattach.ts
@@ -36,8 +36,16 @@ import { DEFAULT_WORKER_UNIT_PREFIX } from "./worker-placement.js";
 /** Answers "is this Worker still running?" for one Worker. */
 export type RedskilledLivenessProbe = (worker: RedskilledWorkerView) => boolean | Promise<boolean>;
 
-/** Stops one Worker; returns whether the host accepted the stop. */
+/** Stops one Worker; returns whether the host confirmed its death. */
 export type RedskilledStopProbe = (worker: RedskilledWorkerView) => boolean | Promise<boolean>;
+
+/** Injectable host operations for a deterministic unit-teardown proof. */
+export interface RedskilledStopWorkerIO {
+  readonly stopUnit: (unit: string) => void;
+  readonly unitActive: (unit: string) => boolean;
+  readonly leaderAlive: (pid: number) => boolean;
+  readonly killTree: (pgid: number) => boolean | Promise<boolean>;
+}
 
 export interface ReattachOutcome {
   /** Workers the host still confirms; the restarted daemon adopts these. */
@@ -277,15 +285,32 @@ export function nameUnownedProject(worker: RedskilledWorkerView): RedskilledWork
 /**
  * Stop one Worker: the unit by name, or the recorded process group.
  *
- * Stopping the unit rather than the pid is what makes the kill total — a Worker
- * that forked children would otherwise leave them behind, still charged to the
- * budget the daemon just decided to reclaim. Legacy records without `pgid` use
- * the detached leader pid, which is the group id by the launch contract.
+ * A successful `systemctl stop` is only a request receipt: death is confirmed by
+ * both the unit becoming inactive and its recorded leader disappearing. Anything
+ * less escalates through the same TERM→grace→KILL→confirm process-group teardown
+ * as an unisolated Worker. Legacy records without `pgid` use the detached leader
+ * pid, which is the group id by the launch contract.
  */
-export function stopWorker(worker: RedskilledWorkerView): boolean | Promise<boolean> {
+export function stopWorker(
+  worker: RedskilledWorkerView,
+  io: RedskilledStopWorkerIO = DEFAULT_STOP_WORKER_IO,
+): boolean | Promise<boolean> {
   if (worker.unit != null && worker.unit !== "") {
-    const stop = spawnSync("systemctl", ["--user", "stop", worker.unit], { stdio: "ignore" });
-    return stop.error == null && stop.status === 0;
+    try {
+      io.stopUnit(worker.unit);
+    } catch {
+      // A failed stop request still reaches the process-group escalation below.
+    }
+    if (!io.unitActive(worker.unit) && !io.leaderAlive(worker.pid)) return true;
   }
-  return killTreeAndWait(worker.pgid ?? worker.pid);
+  return io.killTree(worker.pgid ?? worker.pid);
 }
+
+const DEFAULT_STOP_WORKER_IO: RedskilledStopWorkerIO = {
+  stopUnit: (unit) => {
+    spawnSync("systemctl", ["--user", "stop", unit], { stdio: "ignore" });
+  },
+  unitActive: isUnitActive,
+  leaderAlive: isPidAlive,
+  killTree: killTreeAndWait,
+};

--- a/apps/redskilled/tests/reattach-stop.test.ts
+++ b/apps/redskilled/tests/reattach-stop.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import { stopWorker } from "../src/reattach.js";
+
+const UNIT_WORKER: RedskilledWorkerView = {
+  worker_id: "wUNIT",
+  project_label: "acme/widgets",
+  pid: 4_242,
+  pgid: 4_343,
+  started_at: "2026-08-11T10:00:00.000Z",
+  workspace_path: "/workspaces/acme",
+  isolated: true,
+  unit: "red-worker-acme-wUNIT.service",
+  warnings: [],
+};
+
+describe("unit-held Worker teardown", () => {
+  it("escalates a successful unit stop whose leader survives and reports the refusal", async () => {
+    const stoppedUnits: string[] = [];
+    const killedGroups: number[] = [];
+
+    const contained = await stopWorker(UNIT_WORKER, {
+      stopUnit: (unit) => stoppedUnits.push(unit),
+      unitActive: () => false,
+      leaderAlive: () => true,
+      killTree: async (pgid) => {
+        killedGroups.push(pgid);
+        return false;
+      },
+    });
+
+    expect(stoppedUnits).toEqual(["red-worker-acme-wUNIT.service"]);
+    expect(killedGroups).toEqual([4_343]);
+    expect({ contained }).toEqual({ contained: false });
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3642. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3642

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789082005&installation_model_id=20659&pr_number=3684&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3684&signature=357f564fac1cee3f016cd6a6994dff78d0c1c89eeac969fd730c770dbe616ad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->