### PR TITLE
fix: #3643 A failed orphan reap leaves a phantom birth on the event lane

### DIFF
--- a/apps/redskilled/src/orphan-reaper.ts
+++ b/apps/redskilled/src/orphan-reaper.ts
@@ -466,6 +466,12 @@ export function createRedskilledOrphanReaperRuntime(
           kill_group: killGroup,
         });
         if (!outcome.reaped || !verified) {
+          if (verified && outcome.reason === "group-survived") {
+            await options.record_reaped(
+              adopted,
+              `group-survived: process group ${candidate.process.pgid} survived orphan teardown; ${candidate.detail}`,
+            );
+          }
           report(`${candidate.detail}; ${outcome.reason}`);
           continue;
         }

--- a/apps/redskilled/tests/orphan-reaper.test.ts
+++ b/apps/redskilled/tests/orphan-reaper.test.ts
@@ -262,6 +262,37 @@ describe("stamped orphan teardown", () => {
     expect(events[1]!.detail).toMatch(/orphan-reaped/);
   });
 
+  it("closes an adopted birth when the process group survives teardown", async () => {
+    const root = await scratch("redskilled-orphan-survivor-");
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const killed: number[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      unitInventory: () => [],
+      orphanReaperMs: 0,
+      orphanCensus: async () => [processRow()],
+      orphanStarttime: () => "1200",
+      orphanKillGroup: async (pgid) => {
+        killed.push(pgid);
+        return false;
+      },
+    });
+    daemons.push(daemon);
+
+    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 1, reaped: 0, suspects: 0 });
+    await daemon.flushEvents();
+
+    expect(killed).toEqual([4_242]);
+    expect(daemon.workerCount()).toBe(0);
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.map((event) => event.kind)).toEqual(["worker-birth", "worker-death"]);
+    expect(events[1]!.detail).toMatch(/group-survived: process group 4242/);
+  });
+
   it("adopts a stamped process whose live birth has no holder", async () => {
     const root = await scratch("redskilled-orphan-adopt-");
     const paths = resolveRedskilledPaths({


### PR DESCRIPTION
Automated AFK landing for #3643. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3643

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789082089&installation_model_id=20659&pr_number=3685&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3685&signature=a7f4d7ee976f9b5add064b75c68313ff5e98b07f07e6017e80d61ee4f4127811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->