### PR TITLE
fix: #3579 Demand formula under-asks: busy Workers on de-queued issues suppress freshly promoted work

### DIFF
--- a/apps/redskilled/src/demand-loop.ts
+++ b/apps/redskilled/src/demand-loop.ts
@@ -12,10 +12,10 @@
  * live Worker at the same instant.
  *
  * **The queue bounds the target, and the target bounds nothing else.** A project
- * asks for `min(target, depth) - live` Workers: a registration states how wide
- * the project may go, the queue states how much work exists to go wide on, and
- * the smaller of the two is the honest answer. A loop that asked for the target
- * regardless of depth would birth Workers for work that is not there.
+ * asks for `min(target - live, depth)` Workers: live Workers consume capacity,
+ * while the queue depth counts work still available for a new Worker. A loop
+ * that asked for the remaining capacity regardless of depth would birth Workers
+ * for work that is not there.
  *
  * **A depth is never invented.** `0` means the queue drained; an absent depth
  * means nobody counted it, and the two are told apart in the sentence a reader
@@ -255,9 +255,10 @@ export function planHostDemand(input: PlanHostDemandInput): RedskilledDemandPlan
       continue;
     }
 
-    // The queue bounds the target: a project may be as wide as it registered
-    // for, but never wider than the work that exists to be done.
-    const wanted = Math.max(0, Math.min(Math.max(0, project.target), depth) - live);
+    // Live Workers consume project capacity, while queue depth counts work that
+    // remains available for new Workers. A Worker already busy on de-queued work
+    // therefore cannot consume a freshly queued item as well.
+    const wanted = Math.max(0, Math.min(Math.max(0, project.target - live), depth));
     if (wanted === 0) {
       intents.push({
         ...base,

--- a/apps/redskilled/tests/demand-loop.test.ts
+++ b/apps/redskilled/tests/demand-loop.test.ts
@@ -56,6 +56,18 @@ describe("planHostDemand — how many Workers each project may ask for", () => {
     expect(plan.intents[0]!.wanted).toBe(1);
   });
 
+  it("does not let a live Worker on de-queued work suppress a fresh queue item", () => {
+    const plan = planHostDemand({
+      projects: [project("acme/widgets", { target: 2 })],
+      queue: { "acme/widgets": 1 },
+      live: { "acme/widgets": 1 },
+      nowMs: NOW_MS,
+    });
+
+    expect(plan.births).toHaveLength(1);
+    expect(plan.intents[0]!.wanted).toBe(1);
+  });
+
   it("counts the Workers a project already holds against its target", () => {
     const plan = planHostDemand({
       projects: [project("acme/widgets", { target: 3 })],


### PR DESCRIPTION
Automated AFK landing for #3579. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3579

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789082117&installation_model_id=20659&pr_number=3686&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3686&signature=df57aca4c96c8bfcb36847888f39668bf67bd767263db840c7384f21ab75d878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->