### PR TITLE
fix: #3655 version takeover seats the successor before abdicating

### DIFF
--- a/apps/dev/tests/mcp-lane-canary-e2e.test.ts
+++ b/apps/dev/tests/mcp-lane-canary-e2e.test.ts
@@ -23,6 +23,8 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
 import { decode } from "@reddb-io/toon";
+import { readRedskilledHostState } from "@reddb-io/redskilled/client";
+import { readRedskilledEvents } from "@reddb-io/redskilled/event-lane";
 import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
 import { runMcpLaneCanary } from "../src/core/mcp-lane-canary.js";
 import {
@@ -155,6 +157,30 @@ describe("the socket boundary the lane grew under ADR 0130 (#2794, #2851)", () =
       expect(result.summary).toContain("redskilled");
       expect(socketPath).toBeTruthy();
       expect(result.summary).toContain(socketPath!);
+    },
+    TIMEOUT,
+  );
+});
+
+describe("MCP lane canary — failed version takeover", () => {
+  it(
+    "keeps the incumbent live when a deliberately broken successor exits at boot",
+    async () => {
+      const sandbox = await createCanarySandbox("healthy", "broken-successor");
+      const paths = resolveRedskilledPaths({ env: sandbox.env });
+      const deadline = Date.now() + 30_000;
+      let failure = false;
+      while (Date.now() < deadline) {
+        failure = (await readRedskilledEvents(paths.eventLanePath)).some(
+          (event) => event.event === "daemon-takeover-failed",
+        );
+        if (failure) break;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+
+      expect(failure).toBe(true);
+      const incumbent = await readRedskilledHostState(paths, { readyTimeoutMs: 5_000 });
+      expect(incumbent.daemon_version).toBe("1.0.0");
     },
     TIMEOUT,
   );

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -64,7 +64,7 @@ import {
   uninstallRedskilledUnit,
   type RedskilledUnitIO,
 } from "./supervision.js";
-import { isRedskilledSupervised } from "./self-replace.js";
+import { awaitRedskilledTakeoverCommit, isRedskilledSupervised } from "./self-replace.js";
 import { stabilizeRedskilledEntry } from "./stable-bundle.js";
 
 /**
@@ -472,6 +472,10 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
     const paths = servePaths(values);
     let daemon;
     try {
+      // A replacement boots this entry while the incumbent still owns the
+      // session. Reaching here proves the successor loaded and configured; it
+      // waits for the incumbent's commit before competing for the singleton.
+      await awaitRedskilledTakeoverCommit();
       daemon = await startRedskilledDaemon({
         paths,
         idleMs: hostSettings.idleMs,

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -181,10 +181,12 @@ import {
   prepareRedskilledReplacement,
   probePublishedRedskilledVersion,
   readPublishedObservation,
+  stageRedskilledReplacementSuccessor,
   type RedskilledMajorHold,
   type RedskilledPublishedObservation,
   type RedskilledReplacementDecision,
   type RedskilledReplacementHoldReason,
+  type RedskilledSuccessorControl,
 } from "../self-replace.js";
 import {
   createRedskilledLeaseStore,
@@ -448,6 +450,9 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   let publishedChecks = 0;
   let publishedHoldReason: RedskilledReplacementHoldReason | null = null;
   let replacementState: "none" | "pending" | "in-progress" = "none";
+  // A broken published entry must not be hammered on every overlapping timer or
+  // idle decision. The incumbent keeps serving during this one-minute hold.
+  let nextTakeoverAttemptAtMs = 0;
   // The world's newest version whatever its major, and the hold it implies. Kept
   // beside the in-major answer because that one is capped by construction: on its
   // own it cannot tell a current daemon from one holding at a boundary (#2926).
@@ -1884,17 +1889,43 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   async function checkForReplacement(): Promise<RedskilledReplacementDecision> {
     const decision = await observePublishedVersion();
     if (decision.act !== "replace" || replacementState === "in-progress") return decision;
+    const nowMs = Date.parse(clock());
+    if (Number.isFinite(nowMs) && nowMs < nextTakeoverAttemptAtMs) return decision;
     // The successor is found FIRST. A published bundle this host cannot reach
     // costs the upgrade and nothing else: the throw leaves this daemon serving,
     // still holding every Worker, still reporting the version it actually runs.
     const prepared = prepareRedskilledReplacement(decision, replacementIO, paths, idleMs);
+    if (Number.isFinite(nowMs)) nextTakeoverAttemptAtMs = nowMs + 60_000;
+    let successor: RedskilledSuccessorControl | undefined;
+    try {
+      successor = await stageRedskilledReplacementSuccessor(prepared, paths, {
+        ...(idleMs == null ? {} : { idleMs }),
+        io: replacementIO,
+      });
+    } catch {
+      replacementState = "pending";
+      await eventLane.recordDaemonTakeoverFailed({
+        ts: clock(),
+        pid: owner.pid,
+        socketPath: paths.socketPath,
+        detail:
+          `redskilled ${decision.to} failed its takeover boot handshake; incumbent ${daemonVersion} remains live`,
+      });
+      return decision;
+    }
     replacementState = "in-progress";
     await eventLane.flush().catch(() => undefined);
     await registrationIntentStore.flush().catch(() => undefined);
-    await stop({ reason: "replaced" });
+    try {
+      await stop({ reason: "replaced" });
+    } catch (error) {
+      successor?.abort();
+      throw error;
+    }
     completeRedskilledReplacement(prepared, paths, {
       ...(idleMs == null ? {} : { idleMs }),
       io: replacementIO,
+      ...(successor == null ? {} : { successor }),
     });
     return decision;
   }

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -72,7 +72,11 @@ export const REDSKILLED_WORKER_EVENT_KINDS = [
   "worker-heal",
   "worker-death",
   "worker-budget-kill",
-] & { includes(searchElement: RedskilledWorkerEventKind | "demand-refusal" | "daemon-stop"): boolean };
+] & {
+  includes(
+    searchElement: RedskilledWorkerEventKind | "demand-refusal" | "daemon-stop" | "daemon-takeover-failed",
+  ): boolean;
+};
 
 /**
  * The host-event kinds external consumers may rely on (ADR 0140).
@@ -89,7 +93,11 @@ export const REDSKILLED_PUBLIC_HOST_EVENT_KINDS = [
 export type RedskilledPublicHostEventKind = typeof REDSKILLED_PUBLIC_HOST_EVENT_KINDS[number];
 
 /** The daemon-owned records that deliberately name no Worker. */
-export const REDSKILLED_DAEMON_EVENT_KINDS = ["demand-refusal", "daemon-stop"] as const;
+export const REDSKILLED_DAEMON_EVENT_KINDS = [
+  "demand-refusal",
+  "daemon-stop",
+  "daemon-takeover-failed",
+] as const;
 
 export type RedskilledDaemonEventKind = typeof REDSKILLED_DAEMON_EVENT_KINDS[number];
 
@@ -251,6 +259,14 @@ export interface RecordDemandRefusalInput {
   readonly detail: string;
 }
 
+/** One successor that failed its boot handshake while the incumbent stayed live. */
+export interface RecordDaemonTakeoverFailedInput {
+  readonly ts: string;
+  readonly pid: number;
+  readonly socketPath: string;
+  readonly detail: string;
+}
+
 /** Build one event from a Worker view. PURE. */
 export function buildHostEvent(input: RecordEventInput | RecordWorkerEventInput): RedskilledHostEvent {
   const budget = input.worker.budget ?? {};
@@ -365,6 +381,43 @@ export function buildDemandRefusalEvent(input: RecordDemandRefusalInput): Redski
   };
 }
 
+/** Build a failed takeover without forging a daemon departure. PURE. */
+export function buildDaemonTakeoverFailedEvent(
+  input: RecordDaemonTakeoverFailedInput,
+): RedskilledHostEvent {
+  return {
+    version: 1,
+    ts: input.ts,
+    kind: "daemon-takeover-failed",
+    event: "daemon-takeover-failed",
+    worker_id: `${REDSKILLED_DAEMON_EVENT_PREFIX}${input.pid}`,
+    project_label: "",
+    pid: input.pid,
+    workspace_path: input.socketPath,
+    fork_sha: null,
+    log_path: null,
+    isolated: false,
+    unit: null,
+    memory_high: null,
+    memory_max: null,
+    cpu_weight: null,
+    admission_verdict: null,
+    phase: null,
+    step: null,
+    tokens: null,
+    tools: null,
+    runner: null,
+    model: null,
+    base_head_sha: null,
+    base_commits_ahead: null,
+    heal_kind: null,
+    detail: input.detail,
+    exit_code: null,
+    signal: null,
+    reason: "successor-boot-failed",
+  };
+}
+
 /**
  * An open lane writer.
  *
@@ -382,6 +435,8 @@ export interface RedskilledEventLane {
   recordWorker(input: RecordWorkerEventInput): Promise<RedskilledHostEvent>;
   /** Append one demand decision that refused an otherwise birth-eligible project. */
   recordDemandRefusal(input: RecordDemandRefusalInput): Promise<RedskilledHostEvent>;
+  /** Append a failed takeover while the incumbent still owns the live session. */
+  recordDaemonTakeoverFailed(input: RecordDaemonTakeoverFailedInput): Promise<RedskilledHostEvent>;
   /**
    * Append the daemon's own stop; resolves once the bytes are on the lane.
    *
@@ -436,6 +491,7 @@ export function createRedskilledEventLane(
     record: (input) => append(buildHostEvent(input)),
     recordWorker: (input) => append(buildHostEvent(input)),
     recordDemandRefusal: (input) => append(buildDemandRefusalEvent(input)),
+    recordDaemonTakeoverFailed: (input) => append(buildDaemonTakeoverFailedEvent(input)),
     recordDaemonStop: (input) => append(buildDaemonStopEvent(input)),
     read: () => readRedskilledEvents(path),
     flush: async () => {
@@ -684,7 +740,7 @@ export function rehydrateWorkers(events: readonly RedskilledHostEvent[]): Redski
   for (const event of events) {
     // A daemon's own stop retires nothing: the daemon left and every Worker it
     // held is still running, which is exactly what the successor replays to find.
-    if (event.kind === "daemon-stop" || event.kind === "demand-refusal") continue;
+    if ((REDSKILLED_DAEMON_EVENT_KINDS as readonly RedskilledEventKind[]).includes(event.kind)) continue;
     if (event.kind === "worker-birth") alive.set(event.worker_id, toWorkerView(event));
     else if (event.kind === "worker-death" || event.kind === "worker-budget-kill") alive.delete(event.worker_id);
   }

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -38,7 +38,9 @@
  * PURE apart from the injected spawn, exit and existence lookups.
  */
 import { spawn } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { createConnection, createServer, type Socket } from "node:net";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { canonicalInvocation } from "@reddb-io/shared/canonical-invocation.js";
 import {
@@ -105,6 +107,13 @@ export const REDSKILLED_NO_REGISTRY_PROBE_ENV = "REDSKILLED_NO_REGISTRY_PROBE";
  * tight loop. A successor born this way waits for the ordinary interval instead.
  */
 export const REDSKILLED_BORN_BY_REPLACEMENT_ENV = "REDSKILLED_BORN_BY_REPLACEMENT";
+
+/** Private rendezvous carried only between an incumbent and its staged successor. */
+export const REDSKILLED_TAKEOVER_SOCKET_ENV = "REDSKILLED_TAKEOVER_SOCKET";
+export const REDSKILLED_TAKEOVER_TOKEN_ENV = "REDSKILLED_TAKEOVER_TOKEN";
+
+/** A boot that cannot reach the handshake inside this window is not viable. */
+export const DEFAULT_REDSKILLED_TAKEOVER_HANDSHAKE_MS = 10_000;
 
 /** True when a replacement started this process, so its boot check is not owed. */
 export function isRedskilledBornByReplacement(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -406,7 +415,10 @@ export interface RedskilledReplacementIO {
   /** Resolves what runs the new version; the version-pinned resolver by default. */
   readonly resolveEntry?: (version: string) => ResolvedRedskilledReplacementEntry;
   /** Starts the successor, detached; a real spawn by default. */
-  readonly spawnSuccessor?: (entry: ResolvedRedskilledReplacementEntry, argv: readonly string[]) => void;
+  readonly spawnSuccessor?: (
+    entry: ResolvedRedskilledReplacementEntry,
+    argv: readonly string[],
+  ) => void | RedskilledSuccessorControl | Promise<void | RedskilledSuccessorControl>;
   /** Repoints a supervising unit before the old daemon releases its socket. */
   readonly repointSupervisor?: (
     entry: ResolvedRedskilledReplacementEntry,
@@ -428,6 +440,14 @@ export interface PreparedRedskilledReplacement {
 
 export interface RedskilledReplacementOutcome extends PreparedRedskilledReplacement {
   readonly exitCode?: number;
+}
+
+/** A successor that reached its boot boundary and is waiting for ownership. */
+export interface RedskilledSuccessorControl {
+  /** Tell the viable successor that the incumbent has released the session. */
+  commit(): void;
+  /** Take back a staged successor when the incumbent cannot complete its stop. */
+  abort(): void;
 }
 
 /**
@@ -460,6 +480,28 @@ export function prepareRedskilledReplacement(
 }
 
 /**
+ * Start the successor while the incumbent still owns the live session.
+ *
+ * A production successor reaches the CLI boot boundary, proves that by answering
+ * a private handshake, then waits. Injected spawns may return no control handle;
+ * that preserves the public test seam while still making a rejected async boot a
+ * takeover failure rather than a daemon stop.
+ */
+export async function stageRedskilledReplacementSuccessor(
+  prepared: PreparedRedskilledReplacement,
+  target: RedskilledServeTarget,
+  options: { readonly idleMs?: number; readonly io?: RedskilledReplacementIO } = {},
+): Promise<RedskilledSuccessorControl | undefined> {
+  if (prepared.via === "supervisor-exit") return undefined;
+  const io = options.io ?? {};
+  const argv = [
+    ...prepared.entry.args,
+    ...redskilledServeArgv(target, options.idleMs == null ? {} : { idleMs: options.idleMs }),
+  ];
+  return await (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env, target))(prepared.entry, argv);
+}
+
+/**
  * Complete one replacement, on a daemon that has ALREADY let go of the session.
  *
  * The order is not negotiable: the old process releases the socket and the lease
@@ -470,23 +512,44 @@ export function prepareRedskilledReplacement(
 export function completeRedskilledReplacement(
   prepared: PreparedRedskilledReplacement,
   target: RedskilledServeTarget,
-  options: { readonly idleMs?: number; readonly io?: RedskilledReplacementIO } = {},
+  options: {
+    readonly idleMs?: number;
+    readonly io?: RedskilledReplacementIO;
+    readonly successor?: RedskilledSuccessorControl;
+  } = {},
 ): RedskilledReplacementOutcome {
   const io = options.io ?? {};
   if (prepared.via === "supervisor-exit") {
     (io.exit ?? defaultExit)(REDSKILLED_REPLACE_EXIT_CODE);
     return { ...prepared, exitCode: REDSKILLED_REPLACE_EXIT_CODE };
   }
+  if (options.successor != null) {
+    options.successor.commit();
+    return prepared;
+  }
   const argv = [
     ...prepared.entry.args,
     ...redskilledServeArgv(target, options.idleMs == null ? {} : { idleMs: options.idleMs }),
   ];
-  (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env))(prepared.entry, argv);
+  (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env, target))(prepared.entry, argv);
   return prepared;
 }
 
-function defaultSpawnSuccessor(env: NodeJS.ProcessEnv | undefined) {
-  return (entry: ResolvedRedskilledReplacementEntry, argv: readonly string[]): void => {
+function defaultSpawnSuccessor(env: NodeJS.ProcessEnv | undefined, target: RedskilledServeTarget) {
+  return async (
+    entry: ResolvedRedskilledReplacementEntry,
+    argv: readonly string[],
+  ): Promise<RedskilledSuccessorControl> => {
+    const handshakePath = join(dirname(target.socketPath), `.takeover-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+    const token = randomUUID();
+    const server = createServer();
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once("error", rejectListen);
+      server.listen(handshakePath, () => {
+        server.off("error", rejectListen);
+        resolveListen();
+      });
+    });
     const child = spawn(entry.command, [...argv], {
       detached: true,
       stdio: "ignore",
@@ -494,11 +557,112 @@ function defaultSpawnSuccessor(env: NodeJS.ProcessEnv | undefined) {
         ...(env ?? process.env),
         REDSKILLED_DAEMON: "1",
         [REDSKILLED_BORN_BY_REPLACEMENT_ENV]: "1",
+        [REDSKILLED_TAKEOVER_SOCKET_ENV]: handshakePath,
+        [REDSKILLED_TAKEOVER_TOKEN_ENV]: token,
       },
     });
-    child.on("error", () => undefined);
     child.unref();
+    return await new Promise<RedskilledSuccessorControl>((resolveReady, rejectReady) => {
+      let settled = false;
+      let peer: Socket | undefined;
+      const deadline = setTimeout(() => fail(new Error("successor did not answer the takeover handshake")),
+        DEFAULT_REDSKILLED_TAKEOVER_HANDSHAKE_MS);
+      deadline.unref();
+
+      const cleanupListener = (): void => {
+        clearTimeout(deadline);
+        child.off("error", onError);
+        child.off("exit", onExit);
+      };
+      const closeServer = (): void => {
+        server.close(() => rmSync(handshakePath, { force: true }));
+      };
+      const fail = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        cleanupListener();
+        peer?.destroy();
+        closeServer();
+        child.kill("SIGTERM");
+        rejectReady(error);
+      };
+      const onError = (): void => fail(new Error("successor failed before its takeover handshake"));
+      const onExit = (code: number | null): void =>
+        fail(new Error(`successor exited before its takeover handshake (code ${code ?? "unknown"})`));
+      child.once("error", onError);
+      child.once("exit", onExit);
+      server.on("connection", (socket) => {
+        if (peer != null) {
+          socket.destroy();
+          return;
+        }
+        peer = socket;
+        let line = "";
+        socket.setEncoding("utf8");
+        socket.on("data", (chunk: string) => {
+          line += chunk;
+          if (!line.includes("\n")) return;
+          if (line.slice(0, line.indexOf("\n")) !== token) {
+            fail(new Error("successor answered the takeover handshake with the wrong token"));
+            return;
+          }
+          if (settled) return;
+          settled = true;
+          cleanupListener();
+          resolveReady({
+            commit() {
+              socket.end("commit\n");
+              closeServer();
+            },
+            abort() {
+              socket.end("abort\n");
+              closeServer();
+              child.kill("SIGTERM");
+            },
+          });
+        });
+        socket.once("error", () => fail(new Error("successor takeover handshake disconnected")));
+        socket.once("close", () => fail(new Error("successor takeover handshake closed before readiness")));
+      });
+    });
   };
+}
+
+/** Wait at the successor's boot boundary until the incumbent grants ownership. */
+export async function awaitRedskilledTakeoverCommit(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const socketPath = env[REDSKILLED_TAKEOVER_SOCKET_ENV]?.trim();
+  const token = env[REDSKILLED_TAKEOVER_TOKEN_ENV]?.trim();
+  if (!socketPath && !token) return;
+  if (!socketPath || !token) throw new Error("incomplete redskilled takeover handshake");
+  await new Promise<void>((resolveCommit, rejectCommit) => {
+    const socket = createConnection(socketPath);
+    let line = "";
+    const deadline = setTimeout(() => {
+      socket.destroy();
+      rejectCommit(new Error("redskilled takeover commit timed out"));
+    }, DEFAULT_REDSKILLED_TAKEOVER_HANDSHAKE_MS);
+    deadline.unref();
+    const finish = (error?: Error): void => {
+      clearTimeout(deadline);
+      socket.destroy();
+      if (error == null) resolveCommit();
+      else rejectCommit(error);
+    };
+    socket.setEncoding("utf8");
+    socket.once("connect", () => socket.write(`${token}\n`));
+    socket.on("data", (chunk: string) => {
+      line += chunk;
+      if (!line.includes("\n")) return;
+      const verdict = line.slice(0, line.indexOf("\n"));
+      finish(verdict === "commit" ? undefined : new Error("redskilled takeover was aborted"));
+    });
+    socket.once("error", () => finish(new Error("redskilled takeover handshake failed")));
+    socket.once("close", () => {
+      if (!line.includes("\n")) finish(new Error("redskilled takeover handshake closed before commit"));
+    });
+  });
 }
 
 function defaultExit(code: number): void {

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -498,7 +498,8 @@ export async function stageRedskilledReplacementSuccessor(
     ...prepared.entry.args,
     ...redskilledServeArgv(target, options.idleMs == null ? {} : { idleMs: options.idleMs }),
   ];
-  return await (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env, target))(prepared.entry, argv);
+  const successor = await (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env, target))(prepared.entry, argv);
+  return successor ?? { commit() {}, abort() {} };
 }
 
 /**

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -113,7 +113,7 @@ export const REDSKILLED_TAKEOVER_SOCKET_ENV = "REDSKILLED_TAKEOVER_SOCKET";
 export const REDSKILLED_TAKEOVER_TOKEN_ENV = "REDSKILLED_TAKEOVER_TOKEN";
 
 /** A boot that cannot reach the handshake inside this window is not viable. */
-export const DEFAULT_REDSKILLED_TAKEOVER_HANDSHAKE_MS = 10_000;
+export const DEFAULT_REDSKILLED_TAKEOVER_HANDSHAKE_MS = 30_000;
 
 /** True when a replacement started this process, so its boot check is not owed. */
 export function isRedskilledBornByReplacement(env: NodeJS.ProcessEnv = process.env): boolean {

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -401,6 +401,7 @@ describe("a daemon that has observed a newer published version", () => {
       idleMs: 60_000,
       replaceCheckMs: 0,
       daemonVersion: RUNNING_VERSION,
+      supervised: false,
       publishedVersion: async () => PUBLISHED_VERSION,
       eventLane: lane,
       replacementIO: {

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -393,6 +393,37 @@ describe("the successor entry", () => {
 });
 
 describe("a daemon that has observed a newer published version", () => {
+  it("keeps serving and records the failed takeover when the successor exits at boot", async () => {
+    const { paths, env } = await session();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      replaceCheckMs: 0,
+      daemonVersion: RUNNING_VERSION,
+      publishedVersion: async () => PUBLISHED_VERSION,
+      eventLane: lane,
+      replacementIO: {
+        env,
+        spawnSuccessor: async () => {
+          throw new Error("deliberately broken successor exited 2");
+        },
+      },
+    });
+    running.push(daemon);
+
+    await daemon.checkForReplacement();
+
+    expect(await socketAnswers(paths.socketPath)).toBe(true);
+    expect(daemon.hostState().daemon_version).toBe(RUNNING_VERSION);
+    expect(await lane.read()).toContainEqual(
+      expect.objectContaining({
+        event: "daemon-takeover-failed",
+        detail: expect.stringContaining(PUBLISHED_VERSION),
+      }),
+    );
+  });
+
   it("keeps reporting the version it is RUNNING while the replacement is pending", async () => {
     const { paths, env } = await session();
     const daemon = await startRedskilledDaemon({


### PR DESCRIPTION
Closes #3655.

Orphaned at the pr step; opened via REST per the standing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789085431&installation_model_id=20659&pr_number=3687&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3687&signature=d10df4a42ce5ba98ed569a44d98c8d816402e8c4b3d5512f0a240c55f1d4b830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->