### PR TITLE
fix: #3656 registration recovery becomes deterministic

### DIFF
--- a/apps/redskilled/src/daemon-events.ts
+++ b/apps/redskilled/src/daemon-events.ts
@@ -1,0 +1,79 @@
+/** Daemon-owned host-lane records that deliberately name no Worker. */
+import type { RedskilledHostEvent } from "./event-lane.js";
+
+export interface RecordDaemonStopInput {
+  readonly ts: string;
+  readonly pid: number;
+  readonly socketPath: string;
+  readonly reason: string;
+  readonly detail: string;
+  readonly signal?: string | null;
+}
+
+export interface RecordDaemonStartInput {
+  readonly ts: string;
+  readonly pid: number;
+  readonly socketPath: string;
+  readonly detail: string;
+}
+
+export interface RecordDaemonDeathInput {
+  readonly ts: string;
+  readonly pid: number;
+  readonly socketPath: string;
+  readonly detail: string;
+  readonly reason?: "silent-death";
+}
+
+export const REDSKILLED_DAEMON_EVENT_PREFIX = "daemon:";
+
+export function buildDaemonStopEvent(input: RecordDaemonStopInput): RedskilledHostEvent {
+  return buildDaemonLifecycleEvent("daemon-stop", input, input.reason, input.signal);
+}
+
+export function buildDaemonStartEvent(input: RecordDaemonStartInput): RedskilledHostEvent {
+  return buildDaemonLifecycleEvent("daemon-start", input, "started", null);
+}
+
+export function buildDaemonDeathEvent(input: RecordDaemonDeathInput): RedskilledHostEvent {
+  return buildDaemonLifecycleEvent("daemon-death", input, input.reason ?? "silent-death", null);
+}
+
+function buildDaemonLifecycleEvent(
+  kind: "daemon-start" | "daemon-death" | "daemon-stop",
+  input: RecordDaemonStartInput | RecordDaemonDeathInput | RecordDaemonStopInput,
+  reason: string,
+  signal: string | null | undefined,
+): RedskilledHostEvent {
+  return {
+    version: 1,
+    ts: input.ts,
+    kind,
+    event: kind,
+    worker_id: `${REDSKILLED_DAEMON_EVENT_PREFIX}${input.pid}`,
+    project_label: "",
+    pid: input.pid,
+    workspace_path: input.socketPath,
+    fork_sha: null,
+    log_path: null,
+    isolated: false,
+    unit: null,
+    memory_high: null,
+    memory_max: null,
+    cpu_weight: null,
+    admission_verdict: null,
+    phase: null,
+    step: null,
+    tokens: null,
+    tools: null,
+    runner: null,
+    model: null,
+    base_head_sha: null,
+    base_commits_ahead: null,
+    heal_kind: null,
+    detail: input.detail,
+    exit_code: null,
+    signal: signal ?? null,
+    reason,
+  };
+}

--- a/apps/redskilled/src/daemon/boot-recovery.ts
+++ b/apps/redskilled/src/daemon/boot-recovery.ts
@@ -1,0 +1,80 @@
+/** Deterministic successor planning over durable registration and daemon facts. */
+import type { RedskilledEventLane, RedskilledHostEvent } from "../event-lane.js";
+import {
+  registrationRenewalStatus,
+  type RedskilledProjectRegistration,
+} from "../project-registration.js";
+import type { RedskilledWorkerView } from "../host-state.js";
+import type { RedskilledLease } from "../session-lease.js";
+
+export interface RegistrationBootRecovery {
+  readonly live: readonly RedskilledProjectRegistration[];
+  readonly recoverable: readonly RedskilledProjectRegistration[];
+  readonly abandoned: readonly RedskilledProjectRegistration[];
+}
+
+export function planRegistrationBootRecovery(
+  restored: readonly RedskilledProjectRegistration[],
+  workers: Iterable<RedskilledWorkerView>,
+  startedAt: string,
+): RegistrationBootRecovery {
+  const nowMs = Date.parse(startedAt);
+  const liveProjects = new Set([...workers].map((worker) => worker.project_label));
+  const live: RedskilledProjectRegistration[] = [];
+  const recoverable: RedskilledProjectRegistration[] = [];
+  const abandoned: RedskilledProjectRegistration[] = [];
+  for (const registration of restored) {
+    const renewByMs = Date.parse(registration.renew_by);
+    const renewal = Number.isFinite(nowMs)
+      ? registrationRenewalStatus(registration, nowMs)
+      : "renewing";
+    if (!Number.isFinite(renewByMs) || renewal !== "running-on" || liveProjects.has(registration.project_label)) {
+      live.push(registration);
+      continue;
+    }
+    abandoned.push(registration);
+    if (!Number.isFinite(nowMs) || nowMs - renewByMs <= registration.renew_within_ms) {
+      recoverable.push(registration);
+    }
+  }
+  return { live, recoverable, abandoned };
+}
+
+export async function recordDaemonBootRecovery(options: {
+  readonly eventLane: RedskilledEventLane;
+  readonly laneEvents: readonly RedskilledHostEvent[];
+  readonly heldLease?: RedskilledLease;
+  readonly ownerPid: number;
+  readonly startedAt: string;
+  readonly socketPath: string;
+  readonly recovery: RegistrationBootRecovery;
+}): Promise<void> {
+  const latest = [...options.laneEvents].reverse().find((event) =>
+    event.kind === "daemon-start" || event.kind === "daemon-death" || event.kind === "daemon-stop"
+  );
+  const predecessor = latest?.kind === "daemon-start"
+    ? { pid: latest.pid, socketPath: latest.workspace_path }
+    : latest == null && options.heldLease != null && options.heldLease.pid !== options.ownerPid
+      ? { pid: options.heldLease.pid, socketPath: options.heldLease.socket_path }
+      : null;
+  if (predecessor != null) {
+    await options.eventLane.recordDaemonDeath({
+      ts: options.startedAt,
+      pid: predecessor.pid,
+      socketPath: predecessor.socketPath,
+      detail: `redskilled recovered after daemon ${predecessor.pid} left no stop record`,
+      reason: "silent-death",
+    });
+  }
+  const restored = options.recovery.live.length + options.recovery.abandoned.length;
+  if (restored > 0 || predecessor != null) {
+    await options.eventLane.recordDaemonStart({
+      ts: options.startedAt,
+      pid: options.ownerPid,
+      socketPath: options.socketPath,
+      detail:
+        `redskilled boot read the host registration intent store: recovered ${options.recovery.live.length} live, ` +
+        `lapsed ${options.recovery.abandoned.length} abandoned`,
+    });
+  }
+}

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -71,6 +71,7 @@ import {
 } from "../registration-intent-store.js";
 import {
   buildProjectRegistration,
+  registrationRenewalStatus,
   renewProjectRegistration,
   RedskilledProjectUnregisteredError,
   sustainProjectRegistration,
@@ -403,20 +404,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // snapshot preserves that opaque intent across daemon replacement; its lease
   // deadline still decides whether the successor may keep using it.
   const restoredRegistrations = await registrationIntentStore.read().catch(() => []);
-  const restoredAtMs = Date.parse(startedAt);
   const registrations = new Map<string, RedskilledProjectRegistration>();
   // A lapsed record is retained for one more window so the next queue poll can
   // prove that work still exists and restore it without a person restating the
   // selector and launch. Bounded: a drained or one-window-old record is dropped.
   const recoverableRegistrations = new Map<string, RedskilledProjectRegistration>();
-  for (const restored of restoredRegistrations) {
-    const renewByMs = Date.parse(restored.renew_by);
-    if (!Number.isFinite(restoredAtMs) || !Number.isFinite(renewByMs) || renewByMs >= restoredAtMs) {
-      registrations.set(restored.project_label, restored);
-    } else if (restoredAtMs - renewByMs <= restored.renew_within_ms) {
-      recoverableRegistrations.set(restored.project_label, restored);
-    }
-  }
   const projectHooks = createRedskilledProjectHookRuntime({
     registration: (label) => registrations.get(label),
     liveWorkerIds: () => workers.keys(),
@@ -571,7 +563,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
    * the absence into a stated fact with an instant and a reason on it. Bounded on
    * purpose: this is the tail an operator asks about, not a history.
    */
-  function rememberLapse(registration: RedskilledProjectRegistration, nowMs: number): void {
+  function rememberLapse(
+    registration: RedskilledProjectRegistration,
+    nowMs: number,
+    detail?: string,
+  ): void {
     const at = Number.isFinite(nowMs) ? new Date(nowMs).toISOString() : registration.renew_by;
     lapses.push({
       project_label: registration.project_label,
@@ -580,7 +576,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       renew_by: registration.renew_by,
       renewals: registration.renewals,
       sustains: registration.sustains ?? 0,
-      detail:
+      detail: detail ??
         `redskilled dropped the registration for project ${JSON.stringify(registration.project_label)}: it stood ` +
         `until ${registration.renew_by} and nothing renewed it — no session spoke for it, and no poll found it ` +
         `work or a Worker to hold it up`,
@@ -2267,10 +2263,75 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     reattached.add(worker.worker_id);
     record("worker-birth", worker, "adopted from an active unit with no birth on this lane");
   }
+  // Reconcile durable intent only AFTER replay and host discovery have answered
+  // which Workers are actually alive. Restoring records before this point made
+  // an abandoned registration authoritative merely because its deadline had not
+  // arrived yet, so a successor refused the fresh project_start that was the
+  // only live statement of intent (#3656).
+  const restoredAtMs = Date.parse(startedAt);
+  let abandonedRegistrations = 0;
+  for (const restored of restoredRegistrations) {
+    const renewByMs = Date.parse(restored.renew_by);
+    const hasLiveWorker = [...workers.values()].some(
+      (worker) => worker.project_label === restored.project_label,
+    );
+    const renewal = Number.isFinite(restoredAtMs)
+      ? registrationRenewalStatus(restored, restoredAtMs)
+      : "renewing";
+    if (!Number.isFinite(renewByMs) || renewal !== "running-on" || hasLiveWorker) {
+      registrations.set(restored.project_label, restored);
+      continue;
+    }
+
+    abandonedRegistrations += 1;
+    // Keep one bounded polling chance for the same reason an ordinarily lapsed
+    // registration gets one: a fresh queue observation may prove that the
+    // project is still draining. This map never conflicts with project_start.
+    if (!Number.isFinite(restoredAtMs) || restoredAtMs - renewByMs <= restored.renew_within_ms) {
+      recoverableRegistrations.set(restored.project_label, restored);
+    }
+    rememberLapse(
+      restored,
+      restoredAtMs,
+      `redskilled lapsed the recovered registration for project ${JSON.stringify(restored.project_label)}: ` +
+        "no session renewed it on cadence and no attributed Worker is alive",
+    );
+  }
+  // Rewrite even when classification only removed intent. Otherwise the next
+  // successor would read the same abandoned record and make recovery appear
+  // nondeterministic from one boot to the next.
+  if (restoredRegistrations.length > 0) persistRegistrationIntent();
   // A successor can prove an expired-but-recoverable intent immediately from a
   // Worker the predecessor left running; no queue round-trip or human restart is
   // needed before that project is registered again.
   recoverRegistrations(clock());
+  const latestDaemonLifecycle = [...laneEvents].reverse().find((event) =>
+    event.kind === "daemon-start" || event.kind === "daemon-death" || event.kind === "daemon-stop"
+  );
+  const silentPredecessor = latestDaemonLifecycle?.kind === "daemon-start"
+    ? { pid: latestDaemonLifecycle.pid, socketPath: latestDaemonLifecycle.workspace_path }
+    : latestDaemonLifecycle == null && heldLease != null && heldLease.pid !== owner.pid
+      ? { pid: heldLease.pid, socketPath: heldLease.socket_path }
+      : null;
+  if (silentPredecessor != null) {
+    await eventLane.recordDaemonDeath({
+      ts: startedAt,
+      pid: silentPredecessor.pid,
+      socketPath: silentPredecessor.socketPath,
+      detail: `redskilled recovered after daemon ${silentPredecessor.pid} left no stop record`,
+      reason: "silent-death",
+    });
+  }
+  if (restoredRegistrations.length > 0 || silentPredecessor != null) {
+    await eventLane.recordDaemonStart({
+      ts: startedAt,
+      pid: owner.pid,
+      socketPath: paths.socketPath,
+      detail:
+        `redskilled boot read the host registration intent store: recovered ${registrations.size} live, ` +
+        `lapsed ${abandonedRegistrations} abandoned`,
+    });
+  }
   // The bounded exception. A daemon that has just come back holds Workers it has
   // never heard a heartbeat from, so for those — and only those — it reads the log
   // ONCE, from the path the client GAVE at spawn and carried on the event lane. A

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -3,6 +3,7 @@ import { mkdir, rm } from "node:fs/promises";
 import type { Server, Socket } from "node:net";
 import { dirname } from "node:path";
 import { isPidAlive } from "@reddb-io/shared/resident-core.js";
+import { planRegistrationBootRecovery, recordDaemonBootRecovery } from "./boot-recovery.js";
 import { bindExclusive, handleSocket, probeSocketOwnership } from "./socket.js";
 import { RedskilledAlreadyRunningError } from "./errors.js";
 import {
@@ -71,7 +72,6 @@ import {
 } from "../registration-intent-store.js";
 import {
   buildProjectRegistration,
-  registrationRenewalStatus,
   renewProjectRegistration,
   RedskilledProjectUnregisteredError,
   sustainProjectRegistration,
@@ -2263,75 +2263,16 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     reattached.add(worker.worker_id);
     record("worker-birth", worker, "adopted from an active unit with no birth on this lane");
   }
-  // Reconcile durable intent only AFTER replay and host discovery have answered
-  // which Workers are actually alive. Restoring records before this point made
-  // an abandoned registration authoritative merely because its deadline had not
-  // arrived yet, so a successor refused the fresh project_start that was the
-  // only live statement of intent (#3656).
-  const restoredAtMs = Date.parse(startedAt);
-  let abandonedRegistrations = 0;
-  for (const restored of restoredRegistrations) {
-    const renewByMs = Date.parse(restored.renew_by);
-    const hasLiveWorker = [...workers.values()].some(
-      (worker) => worker.project_label === restored.project_label,
-    );
-    const renewal = Number.isFinite(restoredAtMs)
-      ? registrationRenewalStatus(restored, restoredAtMs)
-      : "renewing";
-    if (!Number.isFinite(renewByMs) || renewal !== "running-on" || hasLiveWorker) {
-      registrations.set(restored.project_label, restored);
-      continue;
-    }
-
-    abandonedRegistrations += 1;
-    // Keep one bounded polling chance for the same reason an ordinarily lapsed
-    // registration gets one: a fresh queue observation may prove that the
-    // project is still draining. This map never conflicts with project_start.
-    if (!Number.isFinite(restoredAtMs) || restoredAtMs - renewByMs <= restored.renew_within_ms) {
-      recoverableRegistrations.set(restored.project_label, restored);
-    }
-    rememberLapse(
-      restored,
-      restoredAtMs,
-      `redskilled lapsed the recovered registration for project ${JSON.stringify(restored.project_label)}: ` +
-        "no session renewed it on cadence and no attributed Worker is alive",
-    );
-  }
-  // Rewrite even when classification only removed intent. Otherwise the next
-  // successor would read the same abandoned record and make recovery appear
-  // nondeterministic from one boot to the next.
+  const bootRecovery = planRegistrationBootRecovery(restoredRegistrations, workers.values(), startedAt);
+  for (const held of bootRecovery.live) registrations.set(held.project_label, held);
+  for (const held of bootRecovery.recoverable) recoverableRegistrations.set(held.project_label, held);
+  for (const held of bootRecovery.abandoned) rememberLapse(held, Date.parse(startedAt),
+    `redskilled lapsed the recovered registration for project ${JSON.stringify(held.project_label)}: ` +
+      "no session renewed it on cadence and no attributed Worker is alive");
   if (restoredRegistrations.length > 0) persistRegistrationIntent();
-  // A successor can prove an expired-but-recoverable intent immediately from a
-  // Worker the predecessor left running; no queue round-trip or human restart is
-  // needed before that project is registered again.
   recoverRegistrations(clock());
-  const latestDaemonLifecycle = [...laneEvents].reverse().find((event) =>
-    event.kind === "daemon-start" || event.kind === "daemon-death" || event.kind === "daemon-stop"
-  );
-  const silentPredecessor = latestDaemonLifecycle?.kind === "daemon-start"
-    ? { pid: latestDaemonLifecycle.pid, socketPath: latestDaemonLifecycle.workspace_path }
-    : latestDaemonLifecycle == null && heldLease != null && heldLease.pid !== owner.pid
-      ? { pid: heldLease.pid, socketPath: heldLease.socket_path }
-      : null;
-  if (silentPredecessor != null) {
-    await eventLane.recordDaemonDeath({
-      ts: startedAt,
-      pid: silentPredecessor.pid,
-      socketPath: silentPredecessor.socketPath,
-      detail: `redskilled recovered after daemon ${silentPredecessor.pid} left no stop record`,
-      reason: "silent-death",
-    });
-  }
-  if (restoredRegistrations.length > 0 || silentPredecessor != null) {
-    await eventLane.recordDaemonStart({
-      ts: startedAt,
-      pid: owner.pid,
-      socketPath: paths.socketPath,
-      detail:
-        `redskilled boot read the host registration intent store: recovered ${registrations.size} live, ` +
-        `lapsed ${abandonedRegistrations} abandoned`,
-    });
-  }
+  await recordDaemonBootRecovery({ eventLane, laneEvents, heldLease, ownerPid: owner.pid,
+    startedAt, socketPath: paths.socketPath, recovery: bootRecovery });
   // The bounded exception. A daemon that has just come back holds Workers it has
   // never heard a heartbeat from, so for those — and only those — it reads the log
   // ONCE, from the path the client GAVE at spawn and carried on the event lane. A

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -89,7 +89,12 @@ export const REDSKILLED_PUBLIC_HOST_EVENT_KINDS = [
 export type RedskilledPublicHostEventKind = typeof REDSKILLED_PUBLIC_HOST_EVENT_KINDS[number];
 
 /** The daemon-owned records that deliberately name no Worker. */
-export const REDSKILLED_DAEMON_EVENT_KINDS = ["demand-refusal", "daemon-stop"] as const;
+export const REDSKILLED_DAEMON_EVENT_KINDS = [
+  "demand-refusal",
+  "daemon-start",
+  "daemon-death",
+  "daemon-stop",
+] as const;
 
 export type RedskilledDaemonEventKind = typeof REDSKILLED_DAEMON_EVENT_KINDS[number];
 
@@ -244,6 +249,23 @@ export interface RecordDaemonStopInput {
   readonly signal?: string | null;
 }
 
+/** One daemon beginning to serve after reconciling durable host intent. */
+export interface RecordDaemonStartInput {
+  readonly ts: string;
+  readonly pid: number;
+  readonly socketPath: string;
+  readonly detail: string;
+}
+
+/** A successor's retroactive record for a predecessor that never said goodbye. */
+export interface RecordDaemonDeathInput {
+  readonly ts: string;
+  readonly pid: number;
+  readonly socketPath: string;
+  readonly detail: string;
+  readonly reason?: "silent-death";
+}
+
 /** One positive-depth project the demand loop deliberately did not birth for. */
 export interface RecordDemandRefusalInput {
   readonly ts: string;
@@ -297,11 +319,30 @@ export const REDSKILLED_DAEMON_EVENT_PREFIX = "daemon:";
 
 /** Build the daemon's own stop event. PURE. */
 export function buildDaemonStopEvent(input: RecordDaemonStopInput): RedskilledHostEvent {
+  return buildDaemonLifecycleEvent("daemon-stop", input, input.reason, input.signal);
+}
+
+/** Build the daemon's boot record after registration recovery has resolved. PURE. */
+export function buildDaemonStartEvent(input: RecordDaemonStartInput): RedskilledHostEvent {
+  return buildDaemonLifecycleEvent("daemon-start", input, "started", null);
+}
+
+/** Build a successor-authored death for a predecessor that left no stop. PURE. */
+export function buildDaemonDeathEvent(input: RecordDaemonDeathInput): RedskilledHostEvent {
+  return buildDaemonLifecycleEvent("daemon-death", input, input.reason ?? "silent-death", null);
+}
+
+function buildDaemonLifecycleEvent(
+  kind: "daemon-start" | "daemon-death" | "daemon-stop",
+  input: RecordDaemonStartInput | RecordDaemonDeathInput | RecordDaemonStopInput,
+  reason: string,
+  signal: string | null | undefined,
+): RedskilledHostEvent {
   return {
     version: 1,
     ts: input.ts,
-    kind: "daemon-stop",
-    event: "daemon-stop",
+    kind,
+    event: kind,
     worker_id: `${REDSKILLED_DAEMON_EVENT_PREFIX}${input.pid}`,
     project_label: "",
     pid: input.pid,
@@ -325,8 +366,8 @@ export function buildDaemonStopEvent(input: RecordDaemonStopInput): RedskilledHo
     heal_kind: null,
     detail: input.detail,
     exit_code: null,
-    signal: input.signal ?? null,
-    reason: input.reason,
+    signal: signal ?? null,
+    reason,
   };
 }
 
@@ -382,6 +423,10 @@ export interface RedskilledEventLane {
   recordWorker(input: RecordWorkerEventInput): Promise<RedskilledHostEvent>;
   /** Append one demand decision that refused an otherwise birth-eligible project. */
   recordDemandRefusal(input: RecordDemandRefusalInput): Promise<RedskilledHostEvent>;
+  /** Append the daemon's boot after durable intent and Worker reality agree. */
+  recordDaemonStart(input: RecordDaemonStartInput): Promise<RedskilledHostEvent>;
+  /** Append a successor's retroactive account of an unrecorded predecessor death. */
+  recordDaemonDeath(input: RecordDaemonDeathInput): Promise<RedskilledHostEvent>;
   /**
    * Append the daemon's own stop; resolves once the bytes are on the lane.
    *
@@ -436,6 +481,8 @@ export function createRedskilledEventLane(
     record: (input) => append(buildHostEvent(input)),
     recordWorker: (input) => append(buildHostEvent(input)),
     recordDemandRefusal: (input) => append(buildDemandRefusalEvent(input)),
+    recordDaemonStart: (input) => append(buildDaemonStartEvent(input)),
+    recordDaemonDeath: (input) => append(buildDaemonDeathEvent(input)),
     recordDaemonStop: (input) => append(buildDaemonStopEvent(input)),
     read: () => readRedskilledEvents(path),
     flush: async () => {
@@ -684,7 +731,7 @@ export function rehydrateWorkers(events: readonly RedskilledHostEvent[]): Redski
   for (const event of events) {
     // A daemon's own stop retires nothing: the daemon left and every Worker it
     // held is still running, which is exactly what the successor replays to find.
-    if (event.kind === "daemon-stop" || event.kind === "demand-refusal") continue;
+    if ((REDSKILLED_DAEMON_EVENT_KINDS as readonly RedskilledEventKind[]).includes(event.kind)) continue;
     if (event.kind === "worker-birth") alive.set(event.worker_id, toWorkerView(event));
     else if (event.kind === "worker-death" || event.kind === "worker-budget-kill") alive.delete(event.worker_id);
   }

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -72,7 +72,16 @@ export const REDSKILLED_WORKER_EVENT_KINDS = [
   "worker-heal",
   "worker-death",
   "worker-budget-kill",
-] & { includes(searchElement: RedskilledWorkerEventKind | "demand-refusal" | "daemon-stop"): boolean };
+] & {
+  includes(
+    searchElement:
+      | RedskilledWorkerEventKind
+      | "demand-refusal"
+      | "daemon-start"
+      | "daemon-death"
+      | "daemon-stop",
+  ): boolean;
+};
 
 /**
  * The host-event kinds external consumers may rely on (ADR 0140).

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -30,6 +30,23 @@
 import { appendFile, mkdir, open, readFile, rename, rm, stat, truncate, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { encodeToonlLines } from "@reddb-io/toon";
+import {
+  buildDaemonDeathEvent,
+  buildDaemonStartEvent,
+  buildDaemonStopEvent,
+  type RecordDaemonDeathInput,
+  type RecordDaemonStartInput,
+  type RecordDaemonStopInput,
+} from "./daemon-events.js";
+export {
+  buildDaemonDeathEvent,
+  buildDaemonStartEvent,
+  buildDaemonStopEvent,
+  REDSKILLED_DAEMON_EVENT_PREFIX,
+  type RecordDaemonDeathInput,
+  type RecordDaemonStartInput,
+  type RecordDaemonStopInput,
+} from "./daemon-events.js";
 import { decodeLaneRows } from "./event-lane-decode.js";
 import {
   readPositionedEventLane,
@@ -241,40 +258,6 @@ export interface RecordWorkerEventInput {
   readonly healKind?: string | null;
 }
 
-/**
- * One daemon leaving the session, and what it was holding when it did.
- *
- * The identity fields the flat shape insists on are answered about the daemon
- * itself — its pid, the socket it was serving — rather than left blank. Only the
- * project is empty, and truthfully so: a daemon's own life belongs to no project.
- */
-export interface RecordDaemonStopInput {
-  readonly ts: string;
-  readonly pid: number;
-  readonly socketPath: string;
-  readonly reason: string;
-  readonly detail: string;
-  /** The signal that asked for the stop, when one did. */
-  readonly signal?: string | null;
-}
-
-/** One daemon beginning to serve after reconciling durable host intent. */
-export interface RecordDaemonStartInput {
-  readonly ts: string;
-  readonly pid: number;
-  readonly socketPath: string;
-  readonly detail: string;
-}
-
-/** A successor's retroactive record for a predecessor that never said goodbye. */
-export interface RecordDaemonDeathInput {
-  readonly ts: string;
-  readonly pid: number;
-  readonly socketPath: string;
-  readonly detail: string;
-  readonly reason?: "silent-death";
-}
-
 /** One positive-depth project the demand loop deliberately did not birth for. */
 export interface RecordDemandRefusalInput {
   readonly ts: string;
@@ -320,63 +303,6 @@ export function buildHostEvent(input: RecordEventInput | RecordWorkerEventInput)
     exit_code: input.exitCode ?? null,
     signal: input.signal ?? null,
     reason: "reason" in input ? input.reason ?? null : null,
-  };
-}
-
-/** The prefix a `daemon-stop` names itself with, so no reader mistakes it for a Worker. */
-export const REDSKILLED_DAEMON_EVENT_PREFIX = "daemon:";
-
-/** Build the daemon's own stop event. PURE. */
-export function buildDaemonStopEvent(input: RecordDaemonStopInput): RedskilledHostEvent {
-  return buildDaemonLifecycleEvent("daemon-stop", input, input.reason, input.signal);
-}
-
-/** Build the daemon's boot record after registration recovery has resolved. PURE. */
-export function buildDaemonStartEvent(input: RecordDaemonStartInput): RedskilledHostEvent {
-  return buildDaemonLifecycleEvent("daemon-start", input, "started", null);
-}
-
-/** Build a successor-authored death for a predecessor that left no stop. PURE. */
-export function buildDaemonDeathEvent(input: RecordDaemonDeathInput): RedskilledHostEvent {
-  return buildDaemonLifecycleEvent("daemon-death", input, input.reason ?? "silent-death", null);
-}
-
-function buildDaemonLifecycleEvent(
-  kind: "daemon-start" | "daemon-death" | "daemon-stop",
-  input: RecordDaemonStartInput | RecordDaemonDeathInput | RecordDaemonStopInput,
-  reason: string,
-  signal: string | null | undefined,
-): RedskilledHostEvent {
-  return {
-    version: 1,
-    ts: input.ts,
-    kind,
-    event: kind,
-    worker_id: `${REDSKILLED_DAEMON_EVENT_PREFIX}${input.pid}`,
-    project_label: "",
-    pid: input.pid,
-    workspace_path: input.socketPath,
-    fork_sha: null,
-    log_path: null,
-    isolated: false,
-    unit: null,
-    memory_high: null,
-    memory_max: null,
-    cpu_weight: null,
-    admission_verdict: null,
-    phase: null,
-    step: null,
-    tokens: null,
-    tools: null,
-    runner: null,
-    model: null,
-    base_head_sha: null,
-    base_commits_ahead: null,
-    heal_kind: null,
-    detail: input.detail,
-    exit_code: null,
-    signal: signal ?? null,
-    reason,
   };
 }
 

--- a/apps/redskilled/tests/registration-boot-recovery.test.ts
+++ b/apps/redskilled/tests/registration-boot-recovery.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import {
+  createRedskilledEventLane,
+  readRedskilledEvents,
+} from "../src/event-lane.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import {
+  buildProjectRegistration,
+  type RedskilledProjectRegistrationRequest,
+} from "../src/project-registration.js";
+import { createRedskilledRegistrationIntentStore } from "../src/registration-intent-store.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-registration-recovery-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+    homeDir: root,
+  });
+}
+
+function request(
+  projectLabel: string,
+  overrides: Partial<RedskilledProjectRegistrationRequest> = {},
+): RedskilledProjectRegistrationRequest {
+  return {
+    project_label: projectLabel,
+    selector: "is:open label:ready-for-agent",
+    argv: ["red-skills-dev", "run"],
+    workspace_path: `/tmp/${projectLabel}`,
+    target: 1,
+    renew_within_ms: 600_000,
+    ...overrides,
+  };
+}
+
+describe("registration recovery after silent daemon death", () => {
+  it("keeps live intent, releases abandoned intent, and records exactly what boot recovered", async () => {
+    const paths = await sessionPaths();
+    const intent = createRedskilledRegistrationIntentStore(paths.registrationIntentPath);
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    const bootedAt = "2026-08-11T14:08:00.000Z";
+
+    const live = buildProjectRegistration(request("acme/live"), {
+      now: "2026-08-11T14:06:00.000Z",
+    });
+    const abandoned = buildProjectRegistration(request("acme/abandoned"), {
+      now: "2026-08-11T14:02:00.000Z",
+    });
+    await intent.replace([live, abandoned]);
+    await lane.recordDaemonStart({
+      ts: "2026-08-11T14:02:00.000Z",
+      pid: 4100,
+      socketPath: paths.socketPath,
+      detail: "redskilled started and recovered no registrations",
+    });
+
+    const successor = await startRedskilledDaemon({
+      paths,
+      clock: () => bootedAt,
+      sampleMs: 0,
+      demandMs: 0,
+      registrationSustainMs: 0,
+      unitInventory: () => [],
+    });
+    running.push(successor);
+
+    expect(successor.hostState().registrations?.map((entry) => entry.project_label)).toEqual(["acme/live"]);
+    expect(successor.hostState().lapsed_registrations?.map((entry) => entry.project_label)).toEqual([
+      "acme/abandoned",
+    ]);
+    expect(() => successor.registerProject(request("acme/abandoned"))).not.toThrow();
+
+    await successor.flushEvents();
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.slice(-2).map((event) => event.kind)).toEqual(["daemon-death", "daemon-start"]);
+    expect(events.at(-2)).toMatchObject({
+      pid: 4100,
+      reason: "silent-death",
+    });
+    expect(events.at(-1)?.detail).toContain(
+      "registration intent store: recovered 1 live, lapsed 1 abandoned",
+    );
+  });
+});


### PR DESCRIPTION
Closes #3656.

Orphaned at the pr step; opened via REST per the standing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789085433&installation_model_id=20659&pr_number=3688&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3688&signature=622bf1cf6878bf36cc07e99b6f6cbc3df22e59e8e07b0804f20d1e6ff0101839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->