### PR TITLE
chore(release): consolidated changeset for the rate-limit and daemon-truth train

### DIFF
--- a/.changeset/rate-limit-and-daemon-truth-train.md
+++ b/.changeset/rate-limit-and-daemon-truth-train.md
@@ -1,0 +1,26 @@
+---
+"@reddb-io/redskilled": minor
+"@reddb-io/dev": minor
+"@reddb-io/red-skills": minor
+"@reddb-io/rsp": minor
+---
+
+Rate-limit resilience and daemon truthfulness train.
+
+GitHub budget — the fixes for the GraphQL-exhaustion incident:
+
+- The quota wait stops hammering: the fallback backoff doubles per retry up to a 10-minute ceiling instead of retrying every 60 s (8,994 fixed-interval retries were measured in one evening), with an injectable reset probe seam (#3663).
+- The engine's landing pipeline rides REST rails where a REST equivalent exists, keeping the GraphQL pool for the operations that need it.
+
+Daemon truthfulness — a Worker is only dead when the host says so:
+
+- Boot censuses active systemd units before attributing deaths, ending the mass false "ended while no daemon was watching" verdicts for Workers that were alive the whole time (#3578).
+- Unit-path teardown confirms death instead of assuming it (#3642); a failed orphan reap no longer leaves a phantom birth (#3643); the demand formula counts busy Workers correctly (#3579); registration recovery is deterministic across boots (#3656).
+- The host event lane reader survives one historical malformed row instead of wedging the whole lane (#3651), and lane writes gain durability for attributions (#3646).
+
+Engine and surfaces:
+
+- The suspect-infra classifier stops calling branch faults infrastructure: repeated signatures with changed pinned behavior and fast exits carrying real diagnostics are branch verdicts now (#3648).
+- The janitor's worker-prune races with concurrent births are closed (#3650), and the promised 256 MiB live-log warning actually fires (#3644).
+- castle emits canonical TOON via the current encoder — no more hand-written non-canonical rows (#3662); rsp migrates to @reddb-io/toon 0.21 (#3624).
+- The statusline line reshape lands compact bedrock counters (#3606), and the interview-rounds convention is extracted to a shared reference consumed by start/wayfinder/reflect/hitl/to-spec (#3669).


### PR DESCRIPTION
Workers on this train shipped no changesets; this changeset names the whole span so the Version PR carries real release notes.

Covers: quota exponential backoff (#3663 slice, PR 3680), false-death census (#3578), unit-path teardown confirm (#3642), phantom-birth fix (#3643), demand formula (#3579), registration recovery (#3656), tolerant lane reader (#3651), attributions durability (#3646), suspect-infra classifier (#3648), janitor prune race (#3650), 256 MiB live-log warning (#3644), canonical TOON in castle (#3662), rsp on toon 0.21 (#3624), statusline reshape (#3606), interview-rounds reference (#3669).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrKC117zw4RxnBrTysaeAp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789086720&installation_model_id=20659&pr_number=3689&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3689&signature=fd8df622e8b0c6879a251ee427d3e2e5250a0abc1ec5ef7506ec8f5adad5d160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->