### PR TITLE
chore: hold lifecycle.ts to the 2489-line ratchet after the merge union

### DIFF
--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -2275,12 +2275,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   recoverRegistrations(clock());
   await recordDaemonBootRecovery({ eventLane, laneEvents, heldLease, ownerPid: owner.pid,
     startedAt, socketPath: paths.socketPath, recovery: bootRecovery });
-  // The bounded exception. A daemon that has just come back holds Workers it has
-  // never heard a heartbeat from, so for those — and only those — it reads the log
-  // ONCE, from the path the client GAVE at spawn and carried on the event lane. A
-  // Worker whose client gave no path stays without a line until it publishes one;
-  // guessing a filename inside its workspace would be the derived layout ADR 0130
-  // rule 3 forbids. Recovery is not the normal path.
+  // The bounded exception: for reattached Workers only, read the log ONCE, from
+  // the path the client GAVE at spawn and carried on the event lane. No path →
+  // no line until the Worker publishes one; guessing a filename would be the
+  // derived layout ADR 0130 rule 3 forbids. Recovery is not the normal path.
   for (const worker of reattachment.alive) {
     if (worker.log_path == null || logLines.has(worker.worker_id)) continue;
     const recovered = await readLogTail(worker.log_path).catch(() => null);


### PR DESCRIPTION
Main is red: PRs 3683 and 3688 each passed the file-size ratchet against their own bases, and their merge union left `apps/redskilled/src/daemon/lifecycle.ts` at 2491 lines against the shrink-only 2489 baseline — which is now failing `test-shard (4)` on every branch cut from main, including Version PR #3690.

Compresses the reattached-log comment by two lines; the constraint it states (client-given path only, ADR 0130 rule 3) survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrKC117zw4RxnBrTysaeAp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789091132&installation_model_id=20659&pr_number=3694&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3694&signature=6981e6aa70155b2680430541a00f270f4d277e9a2e7836e0c380a938e9191dea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->