### PR TITLE
merge: #3657 Auto-spawned daemon lands in the caller's cgroup and dies with the terminal; prefer the supervisor unit or an own scope

### DIFF
--- a/apps/redskilled/src/daemon-placement.ts
+++ b/apps/redskilled/src/daemon-placement.ts
@@ -1,0 +1,270 @@
+/**
+ * daemon-placement — which resource group an AUTO-SPAWNED daemon is born into.
+ *
+ * ADR 0130 rule 7 makes auto-spawn the floor: the first client that needs a
+ * daemon starts one. It said nothing about *where* that daemon lands, and a
+ * `fork`ed child lands wherever its parent already is — on a desktop, inside
+ * `app.slice/app-gnome-<terminal>-….scope`. **systemd-oomd kills a cgroup, not a
+ * process** (#3657): pressure on the user manager took the terminal scope, and
+ * with it the whole host daemon and every Worker it held, by SIGKILL, leaving no
+ * record. The daemon a machine shares between all its projects must not be a
+ * tenant of the first terminal that happened to want one.
+ *
+ * **A transient scope, not a transient service** — the opposite of the choice
+ * `worker-placement` makes, and for the reason that module's own doc gives.
+ * A Worker must survive a daemon restart and be re-attachable by unit name, so it
+ * needs a unit the init system owns. An auto-spawned daemon needs something else:
+ * the environment of the session that asked for it. Credentials resolve in that
+ * environment (#3056), and a transient *service* is started by the user manager
+ * and inherits the MANAGER's environment — curing the blast radius by silently
+ * dropping the caller's tokens. `systemd-run --scope` moves its own process into
+ * a new scope and then `exec`s, so the daemon keeps the caller's environment
+ * verbatim while its cgroup becomes a SIBLING of the terminal's rather than a
+ * child of it. That is the whole fix: oomd shooting `app-…-wezterm-….scope` no
+ * longer touches `app.slice/redskilled-<session>.scope`.
+ *
+ * Once the optional user unit is installed it is the sole birth authority
+ * (Amendment 11, `client-rendezvous.ts`) and nothing here runs — this module owns
+ * the *unsupervised* floor, which is the state most machines are actually in.
+ *
+ * Planning is PURE over injected probes, on the `worker-placement` pattern: the
+ * one impure read of the host lives in {@link detectDaemonPlacementProbes}, so
+ * the systemd and no-systemd arms are both provable without spawning anything.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import { REDSKILLED_UNIT_NAME } from "./supervision.js";
+
+/** Env kill-switch: `REDSKILLED_DAEMON_PLACEMENT=off` forks as a child — loudly. */
+export const REDSKILLED_DAEMON_PLACEMENT_ENV = "REDSKILLED_DAEMON_PLACEMENT";
+
+/** The slice a scope of our own belongs in: the user manager's own app slice. */
+export const REDSKILLED_DAEMON_SLICE = "app.slice";
+
+export interface DaemonPlacementProbes {
+  /** `process.platform` — transient scopes are a Linux backend. */
+  readonly platform: NodeJS.Platform;
+  /** `systemd-run` on PATH, or null when the binary is absent. */
+  readonly systemdRun: string | null;
+  /** True when a systemd `--user` session is reachable. */
+  readonly userSession: boolean;
+}
+
+/** `transient-scope` is a group of the daemon's own; `none` is the caller's group. */
+export type DaemonPlacementBackend = "transient-scope" | "none";
+
+export interface DaemonPlacementPlan {
+  /** True when the daemon is born in a resource group of its own. */
+  readonly isolated: boolean;
+  readonly backend: DaemonPlacementBackend;
+  readonly command: string;
+  readonly args: readonly string[];
+  /** The transient scope unit's name, only under the `transient-scope` backend. */
+  readonly scope?: string;
+  /**
+   * Why the daemon is charged to its caller, and what that now costs. ALWAYS set
+   * when `isolated` is false — an unplaced daemon is never a silent one.
+   */
+  readonly warning?: string;
+}
+
+/**
+ * Probe the host for the backend it can actually offer.
+ *
+ * The `--user` session is proven by its private socket under `XDG_RUNTIME_DIR`,
+ * exactly as `worker-placement` proves it, so nothing is spawned on the start
+ * path to find out.
+ */
+export function detectDaemonPlacementProbes(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): DaemonPlacementProbes {
+  if (platform !== "linux") return { platform, systemdRun: null, userSession: false };
+  const runtimeDir = (env.XDG_RUNTIME_DIR ?? "").trim();
+  return {
+    platform,
+    systemdRun: which("systemd-run", env),
+    userSession: runtimeDir !== "" && existsSync(join(runtimeDir, "systemd", "private")),
+  };
+}
+
+/** True unless the env kill-switch declines placement for this host. */
+export function daemonPlacementEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const override = (env[REDSKILLED_DAEMON_PLACEMENT_ENV] ?? "").trim().toLowerCase();
+  if (override === "") return true;
+  return !["off", "false", "0", "no"].includes(override);
+}
+
+/**
+ * The transient scope's name: one per session location, never one per machine.
+ *
+ * Keyed by the session-key hash the socket is already keyed by, so a second
+ * runtime dir — an operator pinning `REDSKILLED_SESSION`, a test posing as
+ * another host — asks systemd for a name that is not already taken. A single
+ * shared name would make the second daemon's placement fail on a live unit.
+ */
+export function redskilledDaemonScopeName(sessionKeyHash: string): string {
+  return `redskilled-${slug(sessionKeyHash)}.scope`;
+}
+
+export interface PlanDaemonPlacementOptions {
+  /** The resolved entry binary — what actually runs the daemon. */
+  readonly command: string;
+  /** The daemon's own argv, including the `serve` subcommand and its flags. */
+  readonly args?: readonly string[];
+  /** This session's publishable identity, which names the scope. */
+  readonly sessionKeyHash: string;
+  readonly probes: DaemonPlacementProbes;
+  /** False when the env kill-switch declined placement host-wide. */
+  readonly enabled?: boolean;
+}
+
+/**
+ * Plan the launch argv for an auto-spawned daemon.
+ *
+ * When the host affords it, the daemon runs inside its own
+ * `redskilled-<session>.scope` under `app.slice`. Everywhere else the original
+ * argv comes back UNCHANGED with a warning: the daemon still starts — a host
+ * without systemd must not be a host without a daemon — but the downgrade, and
+ * the blast radius it restores, is never silent.
+ */
+export function planRedskilledDaemonPlacement(opts: PlanDaemonPlacementOptions): DaemonPlacementPlan {
+  const args = [...(opts.args ?? [])];
+  const unplaced = (reason: string): DaemonPlacementPlan => ({
+    isolated: false,
+    backend: "none",
+    command: opts.command,
+    args,
+    warning:
+      `${reason}: the daemon is born inside the resource group of whichever client first touched the socket, ` +
+      "so a memory-pressure kill or a closed terminal takes the whole host daemon and every Worker it holds — " +
+      `the session dies and the daemon dies with it. Install the optional user unit to place it permanently ` +
+      `(\`${REDSKILLED_UNIT_NAME}\`, Restart=always).`,
+  });
+
+  if (opts.enabled === false) {
+    return unplaced(`daemon placement disabled by ${REDSKILLED_DAEMON_PLACEMENT_ENV}`);
+  }
+  if (opts.probes.platform !== "linux") {
+    return unplaced(`transient-scope placement is the Linux backend (platform=${opts.probes.platform})`);
+  }
+  if (!opts.probes.systemdRun) return unplaced("transient-scope placement unavailable: systemd-run is not on PATH");
+  if (!opts.probes.userSession) {
+    return unplaced("transient-scope placement unavailable: no systemd --user session");
+  }
+
+  const scope = redskilledDaemonScopeName(opts.sessionKeyHash);
+  return {
+    isolated: true,
+    backend: "transient-scope",
+    scope,
+    command: opts.probes.systemdRun,
+    // `--collect` so a scope left behind by an unclean death is garbage-collected
+    // rather than blocking the next start on a name that is already taken;
+    // `--quiet` because the caller's stdio is `ignore` and the "Running scope as
+    // unit" line would go nowhere but a journal.
+    args: [
+      "--user",
+      "--scope",
+      "--quiet",
+      "--collect",
+      `--unit=${scope}`,
+      `--slice=${REDSKILLED_DAEMON_SLICE}`,
+      "--",
+      opts.command,
+      ...args,
+    ],
+  };
+}
+
+/** Where a daemon that is ALREADY running turned out to be charged. */
+export type DaemonCgroupPlacement = "own-unit" | "shared-group" | "unknown";
+
+export interface DaemonCgroupVerdict {
+  readonly placement: DaemonCgroupPlacement;
+  /** The cgroup path this verdict read, verbatim, or null when there was none. */
+  readonly cgroup: string | null;
+  /** What the placement means for this host. Always a sentence, never empty. */
+  readonly reason: string;
+}
+
+/**
+ * Classify the cgroup a running daemon sits in. PURE.
+ *
+ * The discrimination is the LEAF, because that is the group a kill lands on: a
+ * scope or service the daemon owns is one nothing else can take down, and any
+ * other group is somebody else's — a terminal's `app-…​.scope`, a login's
+ * `session-N.scope` — where the daemon is collateral.
+ *
+ * `unknown` is a first-class answer rather than a suspicion. A host with no
+ * cgroup filesystem (macOS, a WSL2 image without systemd) has no placement to
+ * report, and reddening over one would teach operators to ignore the row.
+ */
+export function classifyDaemonCgroup(cgroupPath: string | null | undefined): DaemonCgroupVerdict {
+  const cgroup = (cgroupPath ?? "").trim();
+  if (cgroup === "" || cgroup === "/") {
+    return {
+      placement: "unknown",
+      cgroup: cgroupPath ?? null,
+      reason:
+        "this host reports no cgroup for the daemon, so there is no resource group to name — " +
+        "nothing here says the daemon is misplaced, only that the placement cannot be read",
+    };
+  }
+  const leaf = cgroup.split("/").filter((part) => part !== "").pop() ?? "";
+  if (leaf === REDSKILLED_UNIT_NAME || /^redskilled-[a-z0-9-]+\.scope$/.test(leaf)) {
+    return {
+      placement: "own-unit",
+      cgroup,
+      reason: `the daemon holds its own resource group, ${leaf} — a kill aimed at a terminal cannot reach it`,
+    };
+  }
+  return {
+    placement: "shared-group",
+    cgroup,
+    reason:
+      `the daemon is charged to ${leaf}, a resource group it does not own — systemd-oomd kills a cgroup rather ` +
+      "than a process, so memory pressure on that group takes the daemon and every Worker it holds",
+  };
+}
+
+/**
+ * Read one process's unified cgroup path, or `null`. **Never throws.**
+ *
+ * `/proc/<pid>/cgroup` rather than `/proc/self/cgroup`: the question is where the
+ * daemon ended up, and a reporter that read its own placement would answer about
+ * the reporter. An unreadable `/proc` — no procfs, a pid that just exited, a
+ * foreign owner — is an absent answer, which {@link classifyDaemonCgroup} already
+ * has a word for.
+ */
+export function readProcessCgroupPath(pid: number): string | null {
+  try {
+    // cgroup v2 writes exactly one line, `0::<path>`; on a v1/hybrid host the
+    // unified controller is the same `0::` row, so one read answers both.
+    for (const line of readFileSync(`/proc/${pid}/cgroup`, "utf8").split("\n")) {
+      if (line.startsWith("0::")) return line.slice(3).trim();
+    }
+  } catch {
+    // Fall through: an unreadable placement is reported as unread, never as bad.
+  }
+  return null;
+}
+
+function which(binary: string, env: NodeJS.ProcessEnv): string | null {
+  for (const dir of (env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, binary);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function slug(value: string): string {
+  const cleaned = (value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32)
+    .replace(/-+$/g, "");
+  return cleaned || "session";
+}

--- a/apps/redskilled/tests/daemon-placement.test.ts
+++ b/apps/redskilled/tests/daemon-placement.test.ts
@@ -1,0 +1,153 @@
+// Where an AUTO-SPAWNED daemon is born, and how a host reports where the one it
+// already has ended up.
+//
+// The defect (#3657): auto-spawn forked the daemon as a child of whichever
+// client first touched the socket, so on a desktop the whole host daemon lived
+// inside `app-gnome-<terminal>-….scope`. systemd-oomd kills a CGROUP, not a
+// process, so closing — or pressuring — the terminal took the daemon and every
+// Worker with it. The cure is a resource group of the daemon's own.
+import { describe, expect, it } from "vitest";
+import {
+  classifyDaemonCgroup,
+  detectDaemonPlacementProbes,
+  daemonPlacementEnabled,
+  planRedskilledDaemonPlacement,
+  redskilledDaemonScopeName,
+  REDSKILLED_DAEMON_PLACEMENT_ENV,
+  type DaemonPlacementProbes,
+} from "../src/daemon-placement.js";
+
+const SESSION = "0123456789ab";
+
+const SYSTEMD_HOST: DaemonPlacementProbes = {
+  platform: "linux",
+  systemdRun: "/usr/bin/systemd-run",
+  userSession: true,
+};
+
+function plan(probes: DaemonPlacementProbes, overrides: { readonly enabled?: boolean } = {}) {
+  return planRedskilledDaemonPlacement({
+    command: "/usr/bin/node",
+    args: ["/bundles/redskilled.bundle.min.mjs", "serve", "--socket", "/run/user/1000/red/redskilled.sock"],
+    sessionKeyHash: SESSION,
+    probes,
+    ...overrides,
+  });
+}
+
+describe("auto-spawn placement", () => {
+  it("puts the daemon in a transient scope of its own, under the user's app slice", () => {
+    const placed = plan(SYSTEMD_HOST);
+
+    expect(placed.isolated).toBe(true);
+    expect(placed.backend).toBe("transient-scope");
+    expect(placed.scope).toBe(`redskilled-${SESSION}.scope`);
+    expect(placed.command).toBe("/usr/bin/systemd-run");
+    expect(placed.args.slice(0, placed.args.indexOf("--"))).toEqual([
+      "--user",
+      "--scope",
+      "--quiet",
+      "--collect",
+      `--unit=redskilled-${SESSION}.scope`,
+      "--slice=app.slice",
+    ]);
+    // Everything after `--` is the daemon argv, verbatim and in order.
+    expect(placed.args.slice(placed.args.indexOf("--") + 1)).toEqual([
+      "/usr/bin/node",
+      "/bundles/redskilled.bundle.min.mjs",
+      "serve",
+      "--socket",
+      "/run/user/1000/red/redskilled.sock",
+    ]);
+    expect(placed.warning).toBeUndefined();
+  });
+
+  it("names one scope per session location, so two runtime dirs never collide", () => {
+    expect(redskilledDaemonScopeName("aaaaaaaaaaaa")).toBe("redskilled-aaaaaaaaaaaa.scope");
+    expect(redskilledDaemonScopeName("bbbbbbbbbbbb")).not.toBe(redskilledDaemonScopeName("aaaaaaaaaaaa"));
+  });
+
+  it("degrades to the caller's own group, loudly, when systemd-run is not on PATH", () => {
+    const fallback = plan({ ...SYSTEMD_HOST, systemdRun: null });
+
+    expect(fallback.isolated).toBe(false);
+    expect(fallback.backend).toBe("none");
+    expect(fallback.command).toBe("/usr/bin/node");
+    expect(fallback.args[0]).toBe("/bundles/redskilled.bundle.min.mjs");
+    expect(fallback.warning).toMatch(/systemd-run is not on PATH/);
+    // The blast radius is the point of the sentence, not an aside.
+    expect(fallback.warning).toMatch(/dies with it/);
+  });
+
+  it("degrades with a sentence when there is no systemd --user session", () => {
+    const fallback = plan({ ...SYSTEMD_HOST, userSession: false });
+
+    expect(fallback.isolated).toBe(false);
+    expect(fallback.warning).toMatch(/no systemd --user session/);
+  });
+
+  it("degrades with a sentence on a platform that has no transient scopes at all", () => {
+    for (const platform of ["darwin", "win32"] as const) {
+      const fallback = plan({ platform, systemdRun: null, userSession: false });
+      expect(fallback.isolated).toBe(false);
+      expect(fallback.warning).toContain(`platform=${platform}`);
+    }
+  });
+
+  it("obeys the kill-switch, and still says what the caller now carries", () => {
+    const off = plan(SYSTEMD_HOST, { enabled: false });
+
+    expect(off.isolated).toBe(false);
+    expect(off.command).toBe("/usr/bin/node");
+    expect(off.warning).toContain(REDSKILLED_DAEMON_PLACEMENT_ENV);
+  });
+
+  it("reads the kill-switch the way every other one in this app is read", () => {
+    expect(daemonPlacementEnabled({})).toBe(true);
+    expect(daemonPlacementEnabled({ [REDSKILLED_DAEMON_PLACEMENT_ENV]: "" })).toBe(true);
+    expect(daemonPlacementEnabled({ [REDSKILLED_DAEMON_PLACEMENT_ENV]: "off" })).toBe(false);
+    expect(daemonPlacementEnabled({ [REDSKILLED_DAEMON_PLACEMENT_ENV]: "0" })).toBe(false);
+    expect(daemonPlacementEnabled({ [REDSKILLED_DAEMON_PLACEMENT_ENV]: "no" })).toBe(false);
+  });
+
+  it("probes a non-Linux host without pretending it has systemd", () => {
+    const probes = detectDaemonPlacementProbes({ PATH: "/usr/bin" }, "darwin");
+    expect(probes).toEqual({ platform: "darwin", systemdRun: null, userSession: false });
+  });
+});
+
+describe("where the daemon actually ended up", () => {
+  it("reads its own transient scope as isolated", () => {
+    const verdict = classifyDaemonCgroup(
+      `/user.slice/user-1000.slice/user@1000.service/app.slice/redskilled-${SESSION}.scope`,
+    );
+    expect(verdict.placement).toBe("own-unit");
+  });
+
+  it("reads the installed supervisor unit as isolated too", () => {
+    const verdict = classifyDaemonCgroup("/user.slice/user-1000.slice/user@1000.service/app.slice/redskilled.service");
+    expect(verdict.placement).toBe("own-unit");
+  });
+
+  it("names the terminal scope it found the daemon inside, and what kills it there", () => {
+    const verdict = classifyDaemonCgroup(
+      "/user.slice/user-1000.slice/user@1000.service/app.slice/app-gnome-wezterm-4242.scope",
+    );
+
+    expect(verdict.placement).toBe("shared-group");
+    expect(verdict.reason).toContain("app-gnome-wezterm-4242.scope");
+    expect(verdict.reason).toMatch(/memory pressure|oomd/i);
+  });
+
+  it("reads a login session scope as shared too — a login ends like a terminal does", () => {
+    expect(classifyDaemonCgroup("/user.slice/user-1000.slice/session-3.scope").placement).toBe("shared-group");
+  });
+
+  it("says `unknown` rather than guessing when there is no cgroup to read", () => {
+    for (const path of [null, "", "/"]) {
+      const verdict = classifyDaemonCgroup(path);
+      expect(verdict.placement).toBe("unknown");
+      expect(verdict.reason).not.toBe("");
+    }
+  });
+});


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3657 -->
🤖 **Re-seed trail** — #3657 on `afk/3657-auto-spawned-daemon-lands-in-the-caller`, lane `/afk`.

Rounds spent: 3/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3657 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/redskilled`]
{"schema":"red.afk.validation.v1","name":"feedback:pnpm typecheck","status":"failed","command":"pnpm typecheck","exitCode":2,"durationMs":5,"summary":"suspect-infra: `pnpm typecheck` exited 2 after 5ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. @reddb-io/code-nav-mcp:typecheck: cache hit, replaying logs b03a900966bd6a19 @reddb-io/brain:typecheck: $ tsc -p tsconfig.json --noEmit @reddb-io/code-nav-mcp:typecheck: $ tsc -p tsconfig.json @reddb-io/brand-tokens:typecheck: cache hit, replaying logs 3d44daaccf278674 @reddb-io/brand-tokens:typecheck: $ tsc -p tsconfig.json --noEmit @reddb-io/redskilled:typecheck: cache miss, executing 637d51170d9fe0de @reddb-io/redskilled:typecheck: $ tsc -p tsconfig.json --noEmit @reddb-io/redskilled:typecheck: tests/daemon-placement.test.ts(18,8): error TS2307: Cannot find module '../src/daemon-placement.js' or its corresponding type declarations. @reddb-io/redskilled:typecheck: [ELIFECYCLE] Command failed with exit code 2.   Tasks:    15 successful, 16 total Cached:    15 cached, 16 total   Time:    4.804s  Failed:    @reddb-io/redskilled#typecheck  [ELIFECYCLE] Command failed with exit code 2. $ turbo run typecheck --filter=!@reddb-io/red-castle --only • turbo 2.10.5 @reddb-io/redskilled#typechec","suspectInfra":true}
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":15,"summary":"suspect-infra: `pnpm -C apps/dev test:invariants` exited 1 after 15ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. failing: FAIL tests/file-size-guard.test.ts > file-size ratchet — a split nothing enforces is a split that comes back > holds the live tree to the threshold and the shrink-only baseline —  - Array [] + Array [ +   Object { +     \"kind\": \"over-baseline\", +     \"lines\": 2491, +     \"path\": \"apps/redskilled/src/daemon/lifecycle.ts\", +     \"reason\": \"apps/redskilled/src/daemon/lifecycle.ts grew from 2489 to 2491 lines. The baseline is shrink-only: lower the number as the file is decomposed, never raise it.\", +   }, + ]   ❯ tests/file-size-guard.test.ts:46:7      44|         : `file-size ratchet: ${findings.length} finding(s).\\n${render…      45|           `Baseline: apps/dev/src/core/file-size-guard.ts (FILE_SIZE_B…      46|     ).toEqual([]);        |       ^      47|   });      48|   ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯","suspectInfra":true}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3657