### PR TITLE
fix: #3652 redskilled-mcp auto-spawn resolves its own bundle as the daemon entry and exits 2

### DIFF
--- a/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
@@ -211,7 +211,8 @@ export async function createCanarySandbox(
   });
   const mcpEntry = join(dist, "redskilled-mcp.bundle.min.mjs");
   await copyFile(built.mcp, mcpEntry);
-  await copyFile(built.redskilled, join(dist, "redskilled.bundle.min.mjs"));
+  const daemonSibling = join(dist, "redskilled.bundle.min.mjs");
+  await copyFile(built.redskilled, daemonSibling);
   await copyFile(built.dev[variant], join(dist, "dev.bundle.min.mjs"));
 
   // A session key nothing else on the host shares, so "no daemon" is a fact
@@ -257,6 +258,20 @@ export async function createCanarySandbox(
   trackers.push(tracker);
   env.REDSKILLED_HOST_TOKEN = "canary-token";
   env.GITHUB_GRAPHQL_URL = tracker.endpoint;
+  // The isolation pin points REDSKILLED_BIN at a named non-path so no operator
+  // bundle can answer for the sandbox. The DOWN walk wants exactly that cold
+  // start, so there — and only there — the pin is re-aimed at the sandbox's own
+  // daemon, as an executable shim because the env override is spawned directly
+  // as a command (#3652). The UP walk keeps the poison pin: its daemon is
+  // already running, and a spawnable override would hand every transient socket
+  // hiccup a second competing daemon.
+  if (daemon === "down") {
+    const daemonBin = join(dist, "redskilled-bin");
+    await writeFile(daemonBin, `#!/bin/sh\nexec "${process.execPath}" "${daemonSibling}" "$@"\n`, {
+      mode: 0o755,
+    });
+    env.REDSKILLED_BIN = daemonBin;
+  }
 
   daemonPaths.push(resolveRedskilledPaths({ env }));
 

--- a/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
@@ -32,6 +32,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { terminatePid } from "@reddb-io/shared/resident-core.js";
 import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
+import { stopRedskilledDaemon } from "@reddb-io/redskilled/client";
 import { sendRedskilledRequest } from "@reddb-io/redskilled/protocol";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -130,6 +131,7 @@ interface BuiltBundles {
 let bundles: Promise<BuiltBundles> | undefined;
 const sandboxes: string[] = [];
 const daemonPids: number[] = [];
+const daemonPaths: ReturnType<typeof resolveRedskilledPaths>[] = [];
 const trackers: CanaryTracker[] = [];
 let sessions = 0;
 
@@ -154,7 +156,7 @@ export function buildCanaryBundles(): Promise<BuiltBundles> {
     const dir = await mkdtemp(join(tmpdir(), "mcp-canary-bundles-"));
     sandboxes.push(dir);
     const mcp = join(dir, "redskilled-mcp.bundle.min.mjs");
-    const redskilled = join(dir, "redskilled.bundle.mjs");
+    const redskilled = join(dir, "redskilled.bundle.min.mjs");
     const healthy = join(dir, "dev-healthy.bundle.min.mjs");
     const unroutable = join(dir, "dev-unroutable.bundle.min.mjs");
     await Promise.all([
@@ -209,6 +211,7 @@ export async function createCanarySandbox(
   });
   const mcpEntry = join(dist, "redskilled-mcp.bundle.min.mjs");
   await copyFile(built.mcp, mcpEntry);
+  await copyFile(built.redskilled, join(dist, "redskilled.bundle.min.mjs"));
   await copyFile(built.dev[variant], join(dist, "dev.bundle.min.mjs"));
 
   // A session key nothing else on the host shares, so "no daemon" is a fact
@@ -253,6 +256,9 @@ export async function createCanarySandbox(
   const tracker = await startCanaryTracker();
   trackers.push(tracker);
   env.REDSKILLED_HOST_TOKEN = "canary-token";
+  env.GITHUB_GRAPHQL_URL = tracker.endpoint;
+
+  daemonPaths.push(resolveRedskilledPaths({ env }));
 
   if (daemon === "up") await startCanaryDaemon(built.redskilled, env, tracker);
 
@@ -327,6 +333,11 @@ async function pings(socketPath: string): Promise<boolean> {
  */
 export async function cleanupCanarySandboxes(): Promise<void> {
   bundles = undefined;
+  await Promise.all(
+    daemonPaths.splice(0).map((paths) =>
+      stopRedskilledDaemon(paths, { settleTimeoutMs: 2_000 }).catch(() => undefined),
+    ),
+  );
   await Promise.all(daemonPids.splice(0).map((pid) => terminatePid(pid, 2_000)));
   // After the daemons: a tracker closed while one still polls it would answer a
   // live poller with a connection error, which is a fact about this cleanup

--- a/apps/dev/tests/mcp-lane-canary-e2e.test.ts
+++ b/apps/dev/tests/mcp-lane-canary-e2e.test.ts
@@ -7,7 +7,7 @@
 //
 //   daemon up   -> green: a registration the daemon holds, and no process of
 //                  the project's own anywhere under it
-//   daemon down -> RED at `project_start`, naming the socket (ADR 0130 rule 6)
+//   daemon down -> green after the MCP lane auto-spawns the shipped daemon sibling
 //
 // Under ADR 0130 Amendment 3 (#2902) the project no longer resolves a slot entry
 // at all — it registers an argv and the host runs it. So #2677's byte-level
@@ -123,38 +123,28 @@ describe("MCP lane canary over the real transport", () => {
 
 describe("the socket boundary the lane grew under ADR 0130 (#2794, #2851)", () => {
   it(
-    "goes RED at project_start when no daemon answers, and starts nothing at all",
+    "auto-spawns the daemon from the MCP bundle's sibling and completes the walk",
     async () => {
       // Identical to the green walk in every byte except one: no daemon is
-      // listening on this sandbox's session socket.
-      //
-      // Before the cutover (#2851) this walk got as far as `daemon_reach`: the
-      // project spawned its own workers, so the lane produced a live worker it
-      // could not vouch for. Now that the daemon owns every birth, the failure
-      // moved EARLIER and got louder — the start itself refuses, because a
-      // project the host never registered is work nothing will ever drive.
-      // Failing at the start is the stronger signal: nothing was started, so
-      // there is no unvouched worker left running to reason about.
+      // listening on this sandbox's session socket. `project_start` therefore
+      // has to take the MCP-only cold-start path before the same public walk can
+      // register, poll, birth, read and stop.
       const { result, socketPath } = await walk("healthy", 3_000, "down");
 
-      expect(result.ok).toBe(false);
-      expect(result.inertStep).toBe("project_start");
-      const byStep = new Map(result.steps.map((step) => [step.step, step.verdict]));
-      expect(byStep.get("connect")).toBe("ok");
-      expect(byStep.get("project_start")).toBe("inert");
-      // Nothing downstream ran, and nothing downstream needed to.
-      expect(byStep.get("registration_held")).toBe("skipped");
-      expect(byStep.get("no_project_process")).toBe("skipped");
-      expect(byStep.get("queue_polled")).toBe("skipped");
-      expect(byStep.get("worker_born")).toBe("skipped");
-      expect(result.workers).toHaveLength(0);
-      // Loudly, and naming the socket rather than the tool: the operator's next
-      // move is on that path, and "project_start failed" alone would send them
-      // to the wrong process entirely.
-      expect(result.summary).toContain("project_start");
-      expect(result.summary).toContain("redskilled");
+      expect(result.inertStep).toBeUndefined();
+      expect(result.ok).toBe(true);
+      expect(result.steps.map((step) => step.verdict)).toEqual([
+        "ok",
+        "ok",
+        "ok",
+        "ok",
+        "ok",
+        "ok",
+        "ok",
+        "ok",
+      ]);
       expect(socketPath).toBeTruthy();
-      expect(result.summary).toContain(socketPath!);
+      expect(existsSync(socketPath!)).toBe(true);
     },
     TIMEOUT,
   );

--- a/apps/redskilled/src/daemon-entry.ts
+++ b/apps/redskilled/src/daemon-entry.ts
@@ -169,7 +169,11 @@ export function redskilledBundleCacheRoot(env: NodeJS.ProcessEnv = process.env):
 }
 
 const VERSIONED_BUNDLE = /^([a-z0-9-]+)-(.+)\.bundle\.min\.mjs$/;
-const REDSKILLED_VERSIONED_BUNDLE = /^redskilled-(.+)\.bundle\.min\.mjs$/;
+// `(?!mcp[.-])` bars the one sibling that wears the daemon's name plus a
+// surface suffix rather than a version: `redskilled-mcp[...].bundle.min.mjs`.
+// Without it the MCP host recognized ITSELF as a daemon entry, spawned its own
+// bundle as the daemon, and the child exited 2 (#3652).
+const REDSKILLED_VERSIONED_BUNDLE = /^redskilled-(?!mcp[.-])(.+)\.bundle\.min\.mjs$/;
 const PLUGIN_ROOT_VARS = [
   "RED_SKILLS_DEV_PLUGIN_ROOT",
   "CLAUDE_PLUGIN_ROOT",
@@ -273,7 +277,11 @@ function* entryCandidates(
     const dir = dirname(resolve(callerEntry));
     yield [join(dir, REDSKILLED_BUNDLE_ASSET), "caller-sibling-bundle"];
     const versioned = VERSIONED_BUNDLE.exec(basename(callerEntry));
-    if (versioned) yield [join(dir, `redskilled-${versioned[2]}.bundle.min.mjs`), "caller-sibling-bundle"];
+    // A caller named `redskilled-mcp[...]` backtracks to suffix `mcp[...]`;
+    // yielding that sibling would be the caller spawning itself (#3652).
+    if (versioned && !/^mcp([.-]|$)/.test(versioned[2]!)) {
+      yield [join(dir, `redskilled-${versioned[2]}.bundle.min.mjs`), "caller-sibling-bundle"];
+    }
     yield [join(dir, "..", "dist", REDSKILLED_BUNDLE_ASSET), "caller-sibling-bundle"];
   }
   for (const variable of PLUGIN_ROOT_VARS) {


### PR DESCRIPTION
Automated AFK landing for #3652. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3652

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789093615&installation_model_id=20659&pr_number=3698&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3698&signature=7b84ae6ed502293ebea51bba16a000f8c76b367f5bbbc3e830a53962c04ff649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->