### PR TITLE
fix: #3660 Dead workers listed as live with pid 0 despite the launcher env carrying the declared id (#3081 symptom persists)

### DIFF
--- a/apps/dev/src/core/project-attribution.ts
+++ b/apps/dev/src/core/project-attribution.ts
@@ -19,9 +19,10 @@
  * PURE: every input is passed in, the host's answer included.
  */
 
-/** What this module needs of a live Worker: the one id it is filed under. */
+/** What this module needs to prove a Worker is live and join its project id. */
 export interface AttributableWorker {
-  readonly state: { readonly worker_id: string };
+  readonly state: { readonly worker_id: string; readonly pid: number };
+  readonly pidLive?: boolean;
 }
 
 export interface ProjectAttributionInput<W extends AttributableWorker> {
@@ -34,6 +35,14 @@ export interface ProjectAttributionInput<W extends AttributableWorker> {
    * holds none.
    */
   readonly hostWorkerIds: readonly string[] | null;
+  /**
+   * Whether the held launch explicitly declares `RED_AFK_WORKER_ID`.
+   *
+   * Only `false` is evidence for the #3081 diagnosis. A missing registration or
+   * a launch that DID declare the env cannot prove that a disjoint id was minted
+   * because the declaration was absent.
+   */
+  readonly workerIdEnvDeclared?: boolean;
   /**
    * When the host says each of its Workers was born, by id.
    *
@@ -105,16 +114,22 @@ export function attributeProjectWorkers<W extends AttributableWorker>(
 ): ProjectAttribution<W> {
   const held = input.hostWorkerIds;
   const ourWorkerIds = new Set(held ?? []);
+  // A fresh heartbeat says a row was recently written; it does not make pid 0
+  // or a dead pid into a live process. Qualify the input before either rendering
+  // it or using it as evidence for an identity warning (#3660).
+  const runningWorkers = input.workers.filter(
+    (worker) => worker.state.pid > 0 && worker.pidLive === true,
+  );
   const ours = (worker: W): boolean => ourWorkerIds.has(worker.state.worker_id);
-  const live = input.workers.filter(ours);
-  const unattributed = input.workers.filter((worker) => !ours(worker));
+  const live = runningWorkers.filter(ours);
+  const unattributed = runningWorkers.filter((worker) => !ours(worker));
   const warnings: string[] = [];
   if (held == null) {
     warnings.push(
       "the redskilled daemon did not answer, so no live Worker could be attributed to this project: every one of " +
         "them is listed as unattributed because ownership is the host's answer, never a guess made from a pid",
     );
-  } else if (held.length > 0 && input.workers.length === 0 && allSettled(input, held)) {
+  } else if (held.length > 0 && runningWorkers.length === 0 && allSettled(input, held)) {
     // The #3123 signature: the host counts Workers this checkout can see no trace
     // of, and none of them is young enough for a birth in progress to explain it.
     // Silence here is what let `live_workers: []` sit beside `busy: 1` for two
@@ -125,15 +140,20 @@ export function attributeProjectWorkers<W extends AttributableWorker>(
         "not one of them is running here: the daemon's count and this project's own read disagree, which is a record " +
         "outliving its Worker — the host's liveness sweep reaps it, and `worker_stop <id>` releases it now (#3123)",
     );
-  } else if (held.length > 0 && input.workers.length > 0 && live.length === 0) {
+  } else if (
+    held.length > 0 &&
+    runningWorkers.length > 0 &&
+    live.length === 0 &&
+    input.workerIdEnvDeclared === false
+  ) {
     // The #3081 signature, stated where it is read. Two disjoint id spaces and a
     // genuinely-foreign Worker set produce the same empty list, and reporting
     // neither is how a project came to render its own busy fleet as idle.
     warnings.push(
-      `the host holds ${held.length} Worker(s) for this project and ${input.workers.length} live Worker(s) are ` +
+      `the host holds ${held.length} Worker(s) for this project and ${runningWorkers.length} live Worker(s) are ` +
         `running here, and not one of them matches: the host ids ` +
         `(${[...ourWorkerIds].slice(0, 3).join(", ")}) and the project ids ` +
-        `(${input.workers.slice(0, 3).map((w) => w.state.worker_id).join(", ")}) are disjoint, which means a Worker ` +
+        `(${runningWorkers.slice(0, 3).map((w) => w.state.worker_id).join(", ")}) are disjoint, which means a Worker ` +
         `was born without the \`RED_AFK_WORKER_ID\` its launch declared and minted a second identity (#3081)`,
     );
   }

--- a/apps/dev/src/core/project-attribution.ts
+++ b/apps/dev/src/core/project-attribution.ts
@@ -115,14 +115,17 @@ export function attributeProjectWorkers<W extends AttributableWorker>(
   const held = input.hostWorkerIds;
   const ourWorkerIds = new Set(held ?? []);
   // A fresh heartbeat says a row was recently written; it does not make pid 0
-  // or a dead pid into a live process. Qualify the input before either rendering
-  // it or using it as evidence for an identity warning (#3660).
-  const runningWorkers = input.workers.filter(
-    (worker) => worker.state.pid > 0 && worker.pidLive === true,
-  );
+  // or a dead pid into a live process. Disproof (pid 0, explicit pidLive:false)
+  // only bars the LIVE claim — a caller that never checked stays claimable, or
+  // every unqualified caller would render its fleet empty. The worker itself
+  // stays VISIBLE: what liveness cannot prove lands in unattributed rather than
+  // vanishing, which is how a dead pid was listed as live in the first place
+  // (#3660) — the cure is honest placement, not a smaller report.
+  const running = (worker: W): boolean => worker.state.pid > 0 && worker.pidLive !== false;
+  const runningWorkers = input.workers.filter(running);
   const ours = (worker: W): boolean => ourWorkerIds.has(worker.state.worker_id);
   const live = runningWorkers.filter(ours);
-  const unattributed = runningWorkers.filter((worker) => !ours(worker));
+  const unattributed = input.workers.filter((worker) => !ours(worker) || !running(worker));
   const warnings: string[] = [];
   if (held == null) {
     warnings.push(

--- a/apps/dev/src/mcp/project.ts
+++ b/apps/dev/src/mcp/project.ts
@@ -103,9 +103,9 @@ export async function projectStatus(root: string): Promise<ProjectStatusOutput> 
   ]);
   const held = registrationState?.held;
   const lapse = registrationState?.lapse;
-  const allLiveWorkers = monitor.workers.filter(
-    (worker) => worker.pidLive === true || worker.live,
-  );
+  // No pre-filter: attribution owns the liveness qualification, and a worker
+  // liveness cannot prove must land in unattributed, not vanish (#3660).
+  const allLiveWorkers = monitor.workers;
   // Attribution is the HOST's, never a pid map of our own: a Worker is ours when
   // the daemon says its project is ours. A stamp for another project — or none
   // at all — lands in the unattributed bucket even when the pid looks familiar.

--- a/apps/dev/tests/project-worker-identity.test.ts
+++ b/apps/dev/tests/project-worker-identity.test.ts
@@ -183,7 +183,7 @@ describe("attributing live Workers to this project", () => {
     expect(attribution.warnings).toEqual([]);
   });
 
-  it("drops pid-zero and dead-pid rows before attribution", () => {
+  it("bars pid-zero and dead-pid rows from the live claim, but keeps them visible", () => {
     const attribution = attributeProjectWorkers({
       workers: [
         worker("pid-zero", 0, false),
@@ -193,8 +193,14 @@ describe("attributing live Workers to this project", () => {
       workerIdEnvDeclared: true,
     });
 
+    // Disproof bars LIVE; it never shrinks the report. A dead row rendered as
+    // live was the #3660 bug — a dead row vanishing entirely would be the
+    // opposite lie, so both land in unattributed.
     expect(attribution.live).toEqual([]);
-    expect(attribution.unattributed).toEqual([]);
+    expect(attribution.unattributed.map((w) => w.state.worker_id)).toEqual([
+      "pid-zero",
+      "dead-pid",
+    ]);
     expect(attribution.warnings).toEqual([]);
   });
 

--- a/apps/dev/tests/project-worker-identity.test.ts
+++ b/apps/dev/tests/project-worker-identity.test.ts
@@ -114,7 +114,10 @@ describe("host-side and project-side worker ids", () => {
 });
 
 describe("attributing live Workers to this project", () => {
-  const worker = (id: string) => ({ state: { worker_id: id } });
+  const worker = (id: string, pid = process.pid, pidLive = true) => ({
+    state: { worker_id: id, pid },
+    pidLive,
+  });
 
   it("lists a Worker born from a registration as this project's own", () => {
     const hostWorkerId = "2aa48bea-81a5-409d-9310-ab0a9805";
@@ -160,12 +163,39 @@ describe("attributing live Workers to this project", () => {
     const attribution = attributeProjectWorkers({
       workers: [worker("wS807"), worker("wVHHH")],
       hostWorkerIds: ["2aa48bea-81a5-409d-9310-ab0a9805", "8c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f"],
+      workerIdEnvDeclared: false,
     });
 
     expect(attribution.live).toEqual([]);
     expect(attribution.warnings).toHaveLength(1);
     expect(attribution.warnings[0]).toContain("disjoint");
     expect(attribution.warnings[0]).toContain("#3081");
+  });
+
+  it("does not blame a declared launch env for disjoint live ids", () => {
+    const attribution = attributeProjectWorkers({
+      workers: [worker("project-id")],
+      hostWorkerIds: ["host-id"],
+      workerIdEnvDeclared: true,
+    });
+
+    expect(attribution.live).toEqual([]);
+    expect(attribution.warnings).toEqual([]);
+  });
+
+  it("drops pid-zero and dead-pid rows before attribution", () => {
+    const attribution = attributeProjectWorkers({
+      workers: [
+        worker("pid-zero", 0, false),
+        worker("dead-pid", 919_191, false),
+      ],
+      hostWorkerIds: ["host-id"],
+      workerIdEnvDeclared: true,
+    });
+
+    expect(attribution.live).toEqual([]);
+    expect(attribution.unattributed).toEqual([]);
+    expect(attribution.warnings).toEqual([]);
   });
 
   it("says the host did not answer rather than calling every Worker foreign", () => {


### PR DESCRIPTION
Automated AFK landing for #3660. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3660

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789093631&installation_model_id=20659&pr_number=3699&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3699&signature=ed5cc2acc3ebcb529927e7972506bb68acec3d06a224c364dc89d6c3afb031e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->