### PR TITLE
feat: #3663 the GitHub client rides two rails — explicit choice, per-pool budgets, failover (resume)

### DIFF
--- a/apps/dev/src/core/github-read-route-guard.ts
+++ b/apps/dev/src/core/github-read-route-guard.ts
@@ -1,4 +1,4 @@
-// github-read-route-guard — a shrink-only migration ratchet for raw `gh` reads.
+// github-read-route-guard — shrink-only migration ratchets for raw `gh` I/O.
 //
 // The destination is cardinal: every GitHub read crosses @reddb-io/github. The
 // baseline records unfinished source files, not permission for new call sites;
@@ -25,7 +25,7 @@ export const GITHUB_READ_EXEMPTIONS: readonly GithubReadRouteExemption[] = [
   },
   {
     id: "unsupported-mutation",
-    reason: "writes remain on gh until @reddb-io/github exposes their mutation; this ratchet constrains reads only",
+    reason: "writes are excluded from the read inventory and constrained independently by the write ratchet",
   },
   {
     id: "shared-client",
@@ -66,6 +66,19 @@ export const GITHUB_READ_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineE
   { path: "packages/red-castle/src/engine/tracker/github/adapter.ts", count: 2, reason: "the castle adapter still has two REST response reads awaiting client injection" },
 ];
 
+/** Raw mutation inventory. SHRINK ONLY: writes share the routed-client destination. */
+export const GITHUB_WRITE_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineEntry[] = [
+  { path: "apps/dev/src/commands/hitl-card.ts", count: 15, reason: "HITL actions still write comments, labels, issue state, and PR dispositions through gh" },
+  { path: "apps/dev/src/core/merge.ts", count: 7, reason: "landing uses REST for create and merge, while draft readiness, labels, and update-branch still await routed mutations" },
+  { path: "apps/dev/src/runtime/gh/issues.ts", count: 9, reason: "issue, comment, and label mutations still use the legacy CLI adapter" },
+  { path: "apps/dev/src/runtime/gh/manager-map.ts", count: 3, reason: "manager-map issue creation still awaits the shared mutation surface" },
+  { path: "apps/dev/src/runtime/merge-driver-io.ts", count: 2, reason: "the compatibility merge driver still shells out for update and merge" },
+  { path: "apps/dev/src/runtime/review-gh.ts", count: 3, reason: "review comments and labels still await routed mutations" },
+  { path: "apps/dev/src/runtime/wire/docs.ts", count: 2, reason: "the docs wire still creates and merges its PR through gh" },
+  { path: "packages/red-castle/src/cli.ts", count: 1, reason: "castle bootstrap still creates one label through gh" },
+  { path: "packages/red-castle/src/engine/tracker/github/adapter.ts", count: 1, reason: "the castle tracker still writes one issue comment through gh" },
+];
+
 export interface GithubReadSourceFile {
   readonly relativePath: string;
   readonly sourceText: string;
@@ -86,7 +99,7 @@ export interface GithubReadRouteReport {
 }
 
 const SOURCE_EXTENSIONS = new Set([".js", ".cjs", ".mjs", ".ts", ".cts", ".mts", ".tsx"]);
-const SCAN_ROOTS = ["apps/dev/src", "apps/redskilled/src", "packages/red-castle/src"] as const;
+export const GITHUB_ROUTE_SCAN_ROOTS = ["apps/dev/src", "apps/redskilled/src", "packages/red-castle/src"] as const;
 const SKIP_DIRS = new Set(["dist", "generated", "node_modules", "test", "tests", "__tests__", "fixtures"]);
 const GUARD_PATH = "apps/dev/src/core/github-read-route-guard.ts";
 
@@ -160,6 +173,10 @@ function exempt(words: readonly string[], path: readonly string[]): boolean {
   return path[0] === "api" && apiMutation(words);
 }
 
+function writeCommand(words: readonly string[], path: readonly string[]): boolean {
+  return WRITE_COMMANDS.has(path.join(" ")) || (path[0] === "api" && apiMutation(words));
+}
+
 function replacement(path: readonly string[]): string {
   const key = path.join(" ") || "GitHub read";
   if (["issue view", "pr view", "repo view", "run view", "release view"].includes(key)) {
@@ -168,7 +185,7 @@ function replacement(path: readonly string[]): string {
   return "createGithubClient(...).conditionalRest / singleObject through @reddb-io/github";
 }
 
-function collectFile(file: GithubReadSourceFile): GithubReadShelloutFinding[] {
+function collectFile(file: GithubReadSourceFile, kind: "read" | "write"): GithubReadShelloutFinding[] {
   if (file.relativePath === GUARD_PATH) return [];
   const source = ts.createSourceFile(file.relativePath, file.sourceText, ts.ScriptTarget.Latest, true);
   const findings: GithubReadShelloutFinding[] = [];
@@ -177,13 +194,17 @@ function collectFile(file: GithubReadSourceFile): GithubReadShelloutFinding[] {
       const words = candidateWords(node);
       if (words) {
         const path = commandPath(words);
-        if (path.length > 0 && !exempt(words, path)) {
+        const isWrite = writeCommand(words, path);
+        const selected = kind === "write" ? isWrite : !isWrite && !exempt(words, path);
+        if (path.length > 0 && selected) {
           const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
           findings.push({
             path: file.relativePath,
             line,
             command: path.join(" "),
-            route: replacement(path),
+            route: kind === "write"
+              ? "createGithubClient(...).mutation through @reddb-io/github"
+              : replacement(path),
             snippet: node.getText(source).replace(/\s+/g, " ").slice(0, 180),
           });
         }
@@ -198,7 +219,13 @@ function collectFile(file: GithubReadSourceFile): GithubReadShelloutFinding[] {
 export function collectGithubReadShelloutsFromFiles(
   files: readonly GithubReadSourceFile[],
 ): GithubReadShelloutFinding[] {
-  return files.flatMap(collectFile).sort((a, b) => a.path.localeCompare(b.path) || a.line - b.line);
+  return files.flatMap((file) => collectFile(file, "read")).sort((a, b) => a.path.localeCompare(b.path) || a.line - b.line);
+}
+
+export function collectGithubWriteShelloutsFromFiles(
+  files: readonly GithubReadSourceFile[],
+): GithubReadShelloutFinding[] {
+  return files.flatMap((file) => collectFile(file, "write")).sort((a, b) => a.path.localeCompare(b.path) || a.line - b.line);
 }
 
 function readTree(root: string): GithubReadSourceFile[] {
@@ -214,7 +241,7 @@ function readTree(root: string): GithubReadSourceFile[] {
       files.push({ relativePath: relative(root, path).replaceAll("\\", "/"), sourceText: readFileSync(path, "utf8") });
     }
   };
-  for (const scanRoot of SCAN_ROOTS) walk(join(root, scanRoot));
+  for (const scanRoot of GITHUB_ROUTE_SCAN_ROOTS) walk(join(root, scanRoot));
   return files;
 }
 
@@ -222,6 +249,14 @@ export function collectGithubReadRouteReport(root: string): GithubReadRouteRepor
   return {
     findings: collectGithubReadShelloutsFromFiles(readTree(root)),
     baseline: GITHUB_READ_SHELLOUT_BASELINE,
+    exemptions: GITHUB_READ_EXEMPTIONS,
+  };
+}
+
+export function collectGithubWriteRouteReport(root: string): GithubReadRouteReport {
+  return {
+    findings: collectGithubWriteShelloutsFromFiles(readTree(root)),
+    baseline: GITHUB_WRITE_SHELLOUT_BASELINE,
     exemptions: GITHUB_READ_EXEMPTIONS,
   };
 }
@@ -243,6 +278,8 @@ export function githubReadRouteViolations(report: GithubReadRouteReport): string
   return violations;
 }
 
+export const githubWriteRouteViolations = githubReadRouteViolations;
+
 export function formatGithubReadRouteFailure(
   report: GithubReadRouteReport,
   violations: readonly string[],
@@ -254,5 +291,19 @@ export function formatGithubReadRouteFailure(
     "Route reads through createGithubClient(...).conditionalRest / singleObject in @reddb-io/github.",
     ...violations.map((violation) => `  - ${violation}`),
     "Baseline: apps/dev/src/core/github-read-route-guard.ts (GITHUB_READ_SHELLOUT_BASELINE); lower only.",
+  ].join("\n");
+}
+
+export function formatGithubWriteRouteFailure(
+  report: GithubReadRouteReport,
+  violations: readonly string[],
+): string {
+  if (violations.length === 0) return "";
+  return [
+    `github-write-routing ratchet: ${report.findings.length} GitHub write shell-out(s) remain; ` +
+      `${violations.length} exceed the shrink-only baseline.`,
+    "Route writes through createGithubClient(...) in @reddb-io/github.",
+    ...violations.map((violation) => `  - ${violation}`),
+    "Baseline: apps/dev/src/core/github-read-route-guard.ts (GITHUB_WRITE_SHELLOUT_BASELINE); lower only.",
   ].join("\n");
 }

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -2167,9 +2167,8 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
 
     // 3. Merge: branch protection is honored rather than bypassed (#1103). With
     // a native merge queue, `--auto` enqueues and the forge serializes the tail.
-    const mergeArgs = ["gh", "-R", repo, "pr", "merge", String(prNumber), "--merge"];
-    if (mergeQueue) mergeArgs.push("--auto");
-    if (mergeTitle) mergeArgs.push("--subject", mergeTitle);
+    const mergeArgs = ["gh", "api", "-X", "PUT", `repos/${repo}/pulls/${prNumber}/merge`, "-f", "merge_method=merge"];
+    if (mergeTitle) mergeArgs.push("-f", `commit_title=${scrubOutbound(mergeTitle)}`);
     if (mergeQueue && input.queueHandoff) {
       const custody = await input.queueHandoff(prNumber, async () => {
         const rejected = await mergeWithStaleBranchRecovery(exec, {
@@ -2359,19 +2358,16 @@ async function ensurePr(
     return existing;
   }
   const create = await exec([
-    "gh",
-    "-R",
-    repo,
-    "pr",
-    "create",
-    "--base",
-    target,
-    "--head",
-    branch,
-    "--title",
-    scrubOutbound(prTitle),
-    "--body",
-    scrubOutbound(`${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.\n\nCloses #${n}`),
+    "gh", "api", "-X", "POST",
+    `repos/${repo}/pulls`,
+    "-f",
+    `base=${target}`,
+    "-f",
+    `head=${branch}`,
+    "-f",
+    `title=${scrubOutbound(prTitle)}`,
+    "-f",
+    `body=${scrubOutbound(`${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.\n\nCloses #${n}`)}`,
   ]);
   if (create.code !== 0) return undefined;
   return await listOpenPr(exec, repo, branch, target);
@@ -2389,6 +2385,8 @@ export interface OpenDraftPrInput {
   n: number;
   /** Issue title, for the PR title. */
   title: string;
+  /** Exact draft title when a caller owns a more specific custody label. */
+  prTitle?: string;
   /** The trail body the draft mirrors. */
   body: string;
 }
@@ -2404,24 +2402,22 @@ export interface OpenDraftPrInput {
  * Landing then reuses it and marks it ready; opening a second is a defect.
  */
 export async function openDraftPr(exec: Exec, input: OpenDraftPrInput): Promise<number | undefined> {
-  const { repo, branch, target, n, title, body } = input;
+  const { repo, branch, target, n, title, body, prTitle = `merge: #${n} ${title}` } = input;
   const existing = await listOpenPr(exec, repo, branch, target);
   if (existing !== undefined) return existing;
   const create = await exec([
-    "gh",
-    "-R",
-    repo,
-    "pr",
-    "create",
-    "--draft",
-    "--base",
-    target,
-    "--head",
-    branch,
-    "--title",
-    scrubOutbound(`merge: #${n} ${title}`),
-    "--body",
-    scrubOutbound(body),
+    "gh", "api", "-X", "POST",
+    `repos/${repo}/pulls`,
+    "-F",
+    "draft=true",
+    "-f",
+    `base=${target}`,
+    "-f",
+    `head=${branch}`,
+    "-f",
+    `title=${scrubOutbound(prTitle)}`,
+    "-f",
+    `body=${scrubOutbound(body)}`,
   ]);
   if (create.code !== 0) return undefined;
   return await listOpenPr(exec, repo, branch, target);

--- a/apps/dev/src/core/process-issue/resume-route.ts
+++ b/apps/dev/src/core/process-issue/resume-route.ts
@@ -1,9 +1,8 @@
 // Resume routing — repair custody for preserved Worker commits before the next
 // Worker starts. The exit-time orphan refusal still owns newly-pushed work.
 
-import { scrubOutbound } from "../../runtime/outbound-redaction.js";
 import type { BranchAdoption } from "../branch-resume.js";
-import { listOpenPr, type Exec } from "../merge.js";
+import { openDraftPr, type Exec } from "../merge.js";
 
 export interface ResumeRouteInput {
   readonly adoption: BranchAdoption;
@@ -31,24 +30,13 @@ export async function ensureResumeRoute(
     return undefined;
   }
 
-  const existing = await listOpenPr(exec, repo, adoption.branch, target);
-  if (existing !== undefined) return existing;
-  const create = await exec([
-    "gh",
-    "-R",
+  return await openDraftPr(exec, {
     repo,
-    "pr",
-    "create",
-    "--draft",
-    "--base",
+    branch: adoption.branch,
     target,
-    "--head",
-    adoption.branch,
-    "--title",
-    scrubOutbound(`resume: #${issue}`),
-    "--body",
-    scrubOutbound(`Resuming preserved Worker commits for #${issue}.\n\nCloses #${issue}`),
-  ]);
-  if (create.code !== 0) return undefined;
-  return await listOpenPr(exec, repo, adoption.branch, target);
+    n: issue,
+    title: "",
+    prTitle: `resume: #${issue}`,
+    body: `Resuming preserved Worker commits for #${issue}.\n\nCloses #${issue}`,
+  });
 }

--- a/apps/dev/src/runtime/github-merge-read.ts
+++ b/apps/dev/src/runtime/github-merge-read.ts
@@ -1,7 +1,9 @@
 import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
 import { join } from "node:path";
-import { createGithubAttributionLedger, createGithubClient } from "@reddb-io/github";
+import { createGithubAttributionLedger, createGithubBalanceStore, createGithubClient } from "@reddb-io/github";
 import { stateDir } from "@reddb-io/shared/red-paths.js";
+import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
 
 import { createGithubMergeRead, type GithubMergeRead } from "../core/github-merge-read.js";
 
@@ -38,6 +40,9 @@ export function createDevGithubMergeRead(
   const attribution = createGithubAttributionLedger({
     path: join(stateDir(root), "github", "spend.toonl"),
   });
+  const balance = createGithubBalanceStore({
+    path: join(redskilledHomeDir(homedir()), "state", "github", "balance.toon"),
+  });
 
   // The credential is resolved PER READ, not at construction. Wiring the deps is
   // not a GitHub operation: demanding a token to build the port made every
@@ -56,7 +61,7 @@ export function createDevGithubMergeRead(
     if (token === "") {
       throw new Error("GitHub merge reads require an authenticated tracker credential");
     }
-    return createGithubClient({ token, attribution });
+    return createGithubClient({ token, attribution, balance: () => balance.read() });
   };
 
   const routed = (): GithubMergeRead => createGithubMergeRead(client(), actor);

--- a/apps/dev/tests/afk-e2e-local.test.ts
+++ b/apps/dev/tests/afk-e2e-local.test.ts
@@ -12,6 +12,12 @@ import { classifyMergeState } from "../src/core/merge.js";
 import { readsPull, restPullBody } from "./support/gh-rest-fixtures.js";
 import { githubMergeReadFromExec } from "./support/github-merge-read.js";
 
+const isRestCreatePullCall = (args: readonly string[]): boolean =>
+  args.includes("POST") && args.some((arg) => /\/pulls$/.test(arg));
+
+const isRestMergePullCall = (args: readonly string[]): boolean =>
+  args.includes("PUT") && args.some((arg) => /\/pulls\/\d+\/merge$/.test(arg));
+
 // AFK end-to-end lifecycle harness against a REAL local git repo.
 //
 // process-issue.test.ts drives the SAME `processIssue(deps, input)` orchestrator
@@ -179,7 +185,7 @@ async function setup(opts: {
       // Reuse-or-create: empty until `pr create` mints a number.
       return { code: 0, stdout: state.prNumber ? `${state.prNumber}\n` : "", stderr: "" };
     }
-    if (sub === "create") {
+    if (sub === "create" || isRestCreatePullCall(argv)) {
       state.prNumber = 101;
       return { code: 0, stdout: "", stderr: "" };
     }
@@ -238,7 +244,7 @@ async function setup(opts: {
         stderr: "",
       };
     }
-    if (sub === "merge") {
+    if (sub === "merge" || isRestMergePullCall(argv)) {
       // A real land: fast-forward origin/main to the worker branch tip so the
       // "merge" is observable in the temp repo. Never lands in the conflict scenario.
       if (opts.conflict || !state.workerBranchRef) {

--- a/apps/dev/tests/github-read-route-guard.test.ts
+++ b/apps/dev/tests/github-read-route-guard.test.ts
@@ -4,10 +4,16 @@ import { describe, expect, it } from "vitest";
 import {
   GITHUB_READ_EXEMPTIONS,
   GITHUB_READ_SHELLOUT_BASELINE,
+  GITHUB_ROUTE_SCAN_ROOTS,
+  GITHUB_WRITE_SHELLOUT_BASELINE,
   collectGithubReadRouteReport,
   collectGithubReadShelloutsFromFiles,
+  collectGithubWriteRouteReport,
+  collectGithubWriteShelloutsFromFiles,
   formatGithubReadRouteFailure,
+  formatGithubWriteRouteFailure,
   githubReadRouteViolations,
+  githubWriteRouteViolations,
 } from "../src/core/github-read-route-guard.js";
 import { REPO_INVARIANT_SUITES } from "../src/core/repo-invariants.js";
 
@@ -66,6 +72,43 @@ describe("GitHub reads route through @reddb-io/github (#3451)", () => {
         `,
       },
     ])).toEqual([]);
+  });
+
+  it("holds raw GitHub writes to their own shrink-only baseline", () => {
+    const report = collectGithubWriteRouteReport(ROOT);
+    const violations = githubWriteRouteViolations(report);
+
+    expect(violations, formatGithubWriteRouteFailure(report, violations)).toEqual([]);
+    expect(report.findings.length).toBeLessThanOrEqual(
+      GITHUB_WRITE_SHELLOUT_BASELINE.reduce((sum, entry) => sum + entry.count, 0),
+    );
+    expect(formatGithubWriteRouteFailure(report, ["probe"])).toContain(
+      `${report.findings.length} GitHub write shell-out(s) remain`,
+    );
+  });
+
+  it("rejects a new gh write and points it at the shared client", () => {
+    const findings = collectGithubWriteShelloutsFromFiles([
+      {
+        relativePath: "packages/red-castle/src/engine/new-writer.ts",
+        sourceText: `\nexport async function merge(runGh: any) {\n  return runGh(["pr", "merge", "42", "--merge"]);\n}\n`,
+      },
+    ]);
+    const report = { findings, baseline: [], exemptions: GITHUB_READ_EXEMPTIONS };
+    const violations = githubWriteRouteViolations(report);
+    const failure = formatGithubWriteRouteFailure(report, violations);
+
+    expect(violations).toHaveLength(1);
+    expect(failure).toContain("packages/red-castle/src/engine/new-writer.ts:3");
+    expect(failure).toContain("createGithubClient");
+  });
+
+  it("sweeps red-castle alongside both daemon applications", () => {
+    expect(GITHUB_ROUTE_SCAN_ROOTS).toEqual([
+      "apps/dev/src",
+      "apps/redskilled/src",
+      "packages/red-castle/src",
+    ]);
   });
 
   it("runs in every validation cone", () => {

--- a/apps/dev/tests/landing-conflict-resolution.test.ts
+++ b/apps/dev/tests/landing-conflict-resolution.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { RWT, doLanding, harness, joined, type LandLock } from "./landing.test-support.js";
 
+const isRestMergeCall = (args: readonly string[]): boolean =>
+  args.includes("PUT") && args.some((arg) => /\/pulls\/\d+\/merge$/.test(arg));
+
 describe("doLanding — first-attempt mechanical conflict resolution (#2072)", () => {
   it("PR rebase conflict resolved mechanically → revalidates inside the land-lock before merging", async () => {
     const trace: string[] = [];
@@ -33,7 +36,7 @@ describe("doLanding — first-attempt mechanical conflict resolution (#2072)", (
     };
     const exec = h.deps.mergeExec;
     h.deps.mergeExec = async (args) => {
-      if (args.join(" ").includes("pr merge")) trace.push("merge");
+      if (isRestMergeCall(args)) trace.push("merge");
       return exec(args);
     };
 
@@ -72,7 +75,7 @@ describe("doLanding — first-attempt mechanical conflict resolution (#2072)", (
     expect(h.postMergeGateDirs).toEqual([]);
     const j = joined(h.mergeCalls);
     expect(j).toContain(`git -C ${RWT} rebase --abort`);
-    expect(j.some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergeCall)).toBe(false);
   });
 });
 
@@ -114,7 +117,7 @@ describe("doLanding — agent-tier semantic conflict resolution (#2075)", () => 
     };
     const exec = h.deps.mergeExec;
     h.deps.mergeExec = async (args) => {
-      if (args.join(" ").includes("pr merge")) trace.push("merge");
+      if (isRestMergeCall(args)) trace.push("merge");
       return exec(args);
     };
 
@@ -154,7 +157,7 @@ describe("doLanding — agent-tier semantic conflict resolution (#2075)", () => 
     expect(h.mechanicalResolverDirs).toEqual([RWT]);
     expect(h.agentResolverDirs).toEqual([RWT]);
     expect(h.postMergeGateDirs).toEqual([RWT]);
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergeCall)).toBe(false);
   });
 
   it("agent tier exhaustion aborts and parks as pr-conflict", async () => {
@@ -175,6 +178,6 @@ describe("doLanding — agent-tier semantic conflict resolution (#2075)", () => 
     expect(h.postMergeGateDirs).toEqual([]);
     const j = joined(h.mergeCalls);
     expect(j).toContain(`git -C ${RWT} rebase --abort`);
-    expect(j.some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergeCall)).toBe(false);
   });
 });

--- a/apps/dev/tests/landing-quota.test.ts
+++ b/apps/dev/tests/landing-quota.test.ts
@@ -1,5 +1,5 @@
 // landing-quota.test.ts — verifies that the admin-PR landing path survives a
-// GitHub quota window. The `gh pr merge` call fails once with a REST rate-limit,
+// GitHub quota window. The REST pull-request merge fails once with a rate-limit,
 // the quota backoff waits (fake clock), and the retry succeeds so the landing
 // completes without the attempt being discarded or the issue misrouted.
 
@@ -14,6 +14,9 @@ const REPO = "owner/repo";
 const BRANCH = "afk/w1/42-fix";
 const BASE = "main";
 const ISSUE = 42;
+
+const isRestMergeCall = (args: readonly string[]): boolean =>
+  args.includes("PUT") && args.some((arg) => /\/pulls\/\d+\/merge$/.test(arg));
 
 /**
  * Build a fake ExecFn that handles the minimal gh / git calls landPr issues.
@@ -33,8 +36,8 @@ function buildFakeExec(prMergeResponses: ExecOutput[]): {
     if (cmd === "gh" && args.includes("list")) {
       return { code: 0, stdout: "77\n", stderr: "" };
     }
-    // gh pr merge — drain the provided response queue
-    if (cmd === "gh" && args.includes("merge")) {
+    // REST pull-request merge — drain the provided response queue
+    if (cmd === "gh" && isRestMergeCall(args)) {
       const resp = prMergeResponses[mergeIdx++] ?? { code: 0, stdout: "", stderr: "" };
       return resp;
     }
@@ -69,7 +72,7 @@ function buildFakeExec(prMergeResponses: ExecOutput[]): {
 }
 
 describe("landing survives a github quota window", () => {
-  it("retries gh pr merge after a rate-limit and lands successfully (fake clock)", async () => {
+  it("retries the REST merge after a rate-limit and lands successfully (fake clock)", async () => {
     const { exec, calls } = buildFakeExec([
       // First attempt: REST 403 rate-limited
       { code: 1, stdout: "", stderr: "HTTP 403: API rate limit exceeded" },
@@ -110,7 +113,7 @@ describe("landing survives a github quota window", () => {
     expect(result.ok).toBe(true);
     expect(result.prNumber).toBe(77);
 
-    // Exactly one sleep fired (the quota wait between the two pr merge calls).
+    // Exactly one sleep fired (the quota wait between the two REST merge calls).
     expect(sleptMs.length).toBe(1);
     // onWait was called to signal 'quota-wait' activity.
     expect(onWaitMs.length).toBe(1);
@@ -118,8 +121,8 @@ describe("landing survives a github quota window", () => {
     // The merged commit sha was resolved and returned.
     expect("mergeSha" in result && result.mergeSha).toBe("deadbeef");
 
-    // Exactly two gh pr merge calls: the rate-limited one and the retry.
-    const mergeCalls = calls.filter((c) => c[0] === "gh" && c.includes("merge"));
+    // Exactly two REST merge calls: the rate-limited one and the retry.
+    const mergeCalls = calls.filter((c) => c[0] === "gh" && isRestMergeCall(c));
     expect(mergeCalls.length).toBe(2);
   });
 

--- a/apps/dev/tests/landing-serialized.test.ts
+++ b/apps/dev/tests/landing-serialized.test.ts
@@ -125,7 +125,7 @@ describe("doLanding — serialized landing (#1337)", () => {
     expect(fs.files.size).toBe(0);
   });
 
-  it("native merge queue → no land-lock is taken and the PR is enqueued with --auto", async () => {
+  it("native merge queue → no land-lock is taken and the PR merge rides REST", async () => {
     let acquires = 0;
     const countingLock: LandLock = {
       acquire: async () => {
@@ -151,7 +151,10 @@ describe("doLanding — serialized landing (#1337)", () => {
     });
     // The forge serializes; double-serializing would only add latency.
     expect(acquires).toBe(0);
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge --auto"))).toBe(true);
+    expect(joined(h.mergeCalls).some((c) =>
+      c.includes("gh api -X PUT repos/o/r/pulls/42/merge") && c.includes("merge_method=merge")
+    )).toBe(true);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
   });
 
   it("native merge queue on the DIRECT path still takes the land-lock (no PR to enqueue)", async () => {
@@ -193,9 +196,10 @@ describe("doLanding — serialized landing (#1337)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// The enqueue is not the merge (#2986). `gh pr merge --auto` exits 0 the moment
-// the PR joins the queue; the merge group's CI then runs for minutes and may
-// hand the PR back. The landing used to read that exit 0 as "landed" and let its
+// A merge request is not proof of the merge (#2986). The REST merge request can
+// return before the forge reports the PR merged; the merge group's CI may then
+// run for minutes and hand the PR back. Landing used to read that exit 0 as
+// "landed" and let its
 // caller close the issue, strip its labels and delete the remote branch — so a
 // rejected merge group left a closed issue whose code never reached the base.
 // Every result below is what gates those steps: only `ok: true` unlocks them.

--- a/apps/dev/tests/landing.test-support.ts
+++ b/apps/dev/tests/landing.test-support.ts
@@ -6,6 +6,12 @@ export { doLanding, createFileLandLock, type LandLock, type LandLockDeps, type L
 import type { ExecResult } from "../src/core/merge.js";
 import { readsPull, restPullBody } from "./support/gh-rest-fixtures.js";
 
+const isRestCreatePullCall = (args: readonly string[]): boolean =>
+  args.includes("POST") && args.some((arg) => /\/pulls$/.test(arg));
+
+const isRestMergePullCall = (args: readonly string[]): boolean =>
+  args.includes("PUT") && args.some((arg) => /\/pulls\/\d+\/merge$/.test(arg));
+
 // doLanding owns the flag-toggled landing (ADR 0030 amended by #842 / 0031):
 // push → pre_merge → integrate → land → (direct conflict self-resolve) →
 // post_merge. Before this extraction the sequence was only exercised through
@@ -261,7 +267,7 @@ export function harness(opts: Opts = {}): Harness {
         if (opts.createPr && !prCreated) return { code: 0, stdout: "", stderr: "" };
         return { code: 0, stdout: "42\n", stderr: "" };
       }
-      if (argv.includes("pr") && argv.includes("create")) {
+      if (isRestCreatePullCall(argv)) {
         prCreated = true;
         return { code: 0, stdout: "", stderr: "" };
       }
@@ -359,7 +365,7 @@ export function harness(opts: Opts = {}): Harness {
       if (j.includes("api repos/o/r/branches/main/protection/required_status_checks/contexts")) {
         return { code: 0, stdout: JSON.stringify(["ci"]), stderr: "" };
       }
-      if (j.includes("pr merge")) {
+      if (isRestMergePullCall(argv)) {
         return { code: opts.prMergeCode ?? 0, stdout: "", stderr: opts.prMergeCode ? "merge rejected" : "" };
       }
       return { code: 0, stdout: "", stderr: "" };

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -6,6 +6,12 @@ import { readsPull, restPullBody } from "./support/gh-rest-fixtures.js";
 
 const DEV_SRC = join(import.meta.dirname, "..", "src");
 
+const isRestCreatePullCall = (args: readonly string[]): boolean =>
+  args.includes("POST") && args.some((arg) => /\/pulls$/.test(arg));
+
+const isRestMergePullCall = (args: readonly string[]): boolean =>
+  args.includes("PUT") && args.some((arg) => /\/pulls\/\d+\/merge$/.test(arg));
+
 describe("doLanding — happy paths", () => {
   it("unlocked → pushes, fires both hooks, lands via admin PR", async () => {
     const h = harness({ locked: false });
@@ -17,7 +23,7 @@ describe("doLanding — happy paths", () => {
     expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
     const j = joined(h.mergeCalls);
     expect(j.some((c) => c.includes("pr list"))).toBe(true);
-    expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(true);
     // unlocked never merges the attempt branch locally.
     expect(j.some((c) => c.includes("merge --no-ff afk/"))).toBe(false);
     expect(h.landingPhases).toEqual(["gate", "push-pr", "cascade"]);
@@ -29,7 +35,7 @@ describe("doLanding — happy paths", () => {
     expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     const checksIdx = j.findIndex((c) => c.includes("pr checks"));
-    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
+    const mergeIdx = h.mergeCalls.findIndex(isRestMergePullCall);
     expect(checksIdx).toBeGreaterThanOrEqual(0);
     expect(mergeIdx).toBeGreaterThan(checksIdx);
   });
@@ -38,7 +44,7 @@ describe("doLanding — happy paths", () => {
     const h = harness({ locked: false, onPrResolvedAbort: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: false, reason: "pr-resolved-abort", locked: false, prNumber: 42 });
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
   });
 
   it("unlocked, default (no wait_for_review) → never polls review checks", async () => {
@@ -52,7 +58,7 @@ describe("doLanding — happy paths", () => {
     const h = harness({ locked: false });
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
-    const mergeCall = h.mergeCalls.find((c) => c.join(" ").includes("pr merge"));
+    const mergeCall = h.mergeCalls.find(isRestMergePullCall);
     expect(mergeCall).toBeDefined();
     expect(mergeCall!.join(" ")).not.toContain("--admin");
   });
@@ -63,7 +69,8 @@ describe("doLanding — happy paths", () => {
     expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     expect(j.some((c) => c.includes(`merge --no-ff --no-verify ${DEFAULT_BRANCH_TIP}`))).toBe(true);
-    expect(j.some((c) => c.includes("pr list") || c.includes("pr merge"))).toBe(false);
+    expect(j.some((c) => c.includes("pr list"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
     expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
   });
 
@@ -103,8 +110,8 @@ describe("doLanding — after-fork intent barrier (#3279)", () => {
 
     expect(result).toEqual({ ok: false, reason: "intent-finding", locked: false });
     expect(checked).toEqual([RWT]);
-    expect(joined(h.mergeCalls).some((call) => call.includes("pr create"))).toBe(false);
-    expect(joined(h.mergeCalls).some((call) => call.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestCreatePullCall)).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
   });
 
   it("checks the integrated direct worktree before merging the attempt", async () => {
@@ -151,9 +158,11 @@ describe("doLanding — conventional landing titles (#1267)", () => {
     expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     expect(j).toContain(
-      "gh -R o/r pr create --base main --head afk/wAAAA/9-fix-the-thing --title feat: #9 Fix the thing --body Automated AFK landing for #9. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.\n\nCloses #9",
+      "gh api -X POST repos/o/r/pulls -f base=main -f head=afk/wAAAA/9-fix-the-thing -f title=feat: #9 Fix the thing -f body=Automated AFK landing for #9. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.\n\nCloses #9",
     );
-    expect(j).toContain("gh -R o/r pr merge 42 --merge --subject feat: #9 Fix the thing");
+    expect(j).toContain(
+      "gh api -X PUT repos/o/r/pulls/42/merge -f merge_method=merge -f commit_title=feat: #9 Fix the thing",
+    );
   });
 });
 
@@ -165,7 +174,7 @@ describe("doLanding — fleet mirror decouples landing from the primary checkout
     expect(h.pushedAttempt.length).toBe(1);
     expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
     const j = joined(h.mergeCalls);
-    expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(true);
     expect(j.some((c) => c.includes("refs/heads/main"))).toBe(false);
     expect(j.some((c) => c.includes("symbolic-ref") || c.includes("status --porcelain"))).toBe(false);
     expect(j).toContain("git -C /repo update-ref refs/heads/red-trunk 0r1g1nsha");
@@ -189,7 +198,7 @@ describe("doLanding — fleet mirror decouples landing from the primary checkout
       const j = c.join(" ");
       expect(j.includes("reset")).toBe(false);
       expect(j.includes("stash")).toBe(false);
-      expect(j.includes("commit")).toBe(false);
+      expect(c.includes("commit")).toBe(false);
       expect(j.includes("checkout")).toBe(false);
       expect(j.includes("switch")).toBe(false);
     }
@@ -201,7 +210,7 @@ describe("doLanding — fleet mirror decouples landing from the primary checkout
     const h = harness({ locked: false, trunk: "absent" });
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(true);
     expect(joined(h.mergeCalls)).toContain("git -C /repo update-ref refs/heads/red-trunk 0r1g1nsha");
   });
 
@@ -210,7 +219,7 @@ describe("doLanding — fleet mirror decouples landing from the primary checkout
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
-    expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(true);
     expect(j.some((c) => c.includes("git -C /repo merge --ff-only"))).toBe(false);
     expect(j).toContain("git -C /repo update-ref refs/heads/red-trunk 0r1g1nsha");
   });
@@ -279,7 +288,7 @@ describe("doLanding — abort / failure short-circuits", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     // It still admin-merged the PR.
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(true);
     // The primary checkout was never touched by a destructive op (no reset/abort).
     expect(h.mergeCalls.every((c) => !c.includes("reset"))).toBe(true);
   });
@@ -441,7 +450,7 @@ describe("doLanding — CI-aware merge (#812)", () => {
     });
     const j = joined(h.mergeCalls);
     const viewIdx = j.findIndex((c) => c.includes("pr view"));
-    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
+    const mergeIdx = h.mergeCalls.findIndex(isRestMergePullCall);
     expect(viewIdx).toBeGreaterThanOrEqual(0);
     expect(mergeIdx).toBeGreaterThan(viewIdx);
   });
@@ -450,7 +459,7 @@ describe("doLanding — CI-aware merge (#812)", () => {
     const h = harness({ locked: false, ciAware: "ci-failed" });
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: false, reason: "ci-failed", locked: false, prNumber: 42 });
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
     // post_merge never fires on a failed land.
     expect(h.firedHooks).toEqual(["pre_merge"]);
   });
@@ -459,7 +468,7 @@ describe("doLanding — CI-aware merge (#812)", () => {
     const h = harness({ locked: false, ciAware: "ci-pending" });
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: false, reason: "ci-pending", locked: false, prNumber: 42 });
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
   });
 
   it("a wedged merge poll emits landing heartbeats for every bounded poll before parking", async () => {
@@ -476,7 +485,7 @@ describe("doLanding — CI-aware merge (#812)", () => {
         detail: expect.objectContaining({ status: "poll", pr_number: 42, attempt: 2, max_polls: 2 }),
       }),
     ]);
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
   });
 
   it("a real DIRTY conflict preserves the PR number for the caller's merge-conflict handoff", async () => {
@@ -512,7 +521,7 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
     const pushIdx = j.findIndex(
       (c) => c === `git -C ${RWT} push origin HEAD:refs/heads/afk/wAAAA/9-fix-the-thing --force-with-lease`,
     );
-    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
+    const mergeIdx = h.mergeCalls.findIndex(isRestMergePullCall);
     expect(fetchIdx).toBeGreaterThanOrEqual(0);
     expect(rebaseIdx).toBeGreaterThan(fetchIdx);
     expect(pushIdx).toBeGreaterThan(rebaseIdx);
@@ -535,7 +544,7 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
     expect(j).toContain(`git -C ${RWT} rebase --abort`);
     // Never force-pushed, never admin-merged, post_merge never fired.
     expect(j.some((c) => c.includes("--force-with-lease"))).toBe(false);
-    expect(j.some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
     expect(h.firedHooks).toEqual(["pre_merge"]);
     // The primary checkout is never touched destructively.
     expect(j.some((c) => c.includes("git -C /repo reset") || c.includes("git -C /repo rebase"))).toBe(false);
@@ -552,7 +561,7 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
     const j = joined(h.mergeCalls);
     // The doomed sequential rebase never starts, and nothing is merged.
     expect(j.some((c) => c === `git -C ${RWT} rebase origin/main`)).toBe(false);
-    expect(j.some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
     expect(h.removedRebaseWorktrees).toEqual([RWT]);
   });
 
@@ -574,7 +583,7 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
     // Three force-with-lease pushes (1 + 2 retries) then gives up — never merges.
     const pushes = j.filter((c) => c.includes("--force-with-lease")).length;
     expect(pushes).toBe(3);
-    expect(j.some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
   });
 
   it("no provisioner → aborts as infra and never admin-merges", async () => {
@@ -587,7 +596,7 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
       locked: false,
     });
     expect(joined(h.mergeCalls).some((c) => c.includes("--force-with-lease"))).toBe(false);
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
   });
 
   it("worktree could not be provisioned → aborts as infra and never admin-merges", async () => {
@@ -600,7 +609,7 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
       locked: false,
     });
     expect(joined(h.mergeCalls).some((c) => c.includes("--force-with-lease"))).toBe(false);
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
   });
 
   it("the DIRECT (non-PR) path ignores the rebase provisioner (it integrates origin itself)", async () => {
@@ -616,7 +625,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
   // The flag (openPr = afk.worktree_launches_pull_request) chooses PR vs direct;
   // the lock only resolves `base`. Four cells: {no lock, lock=X} × {true, false}.
   // `prMerged` = the admin-PR path ran; `directMerged` = the worktree merge ran.
-  const prMerged = (j: string[]) => j.some((c) => c.includes("pr merge 42 --merge"));
+  const prMerged = (calls: readonly string[][]) => calls.some(isRestMergePullCall);
   const directMerged = (j: string[]) => j.some((c) => c.includes("merge --no-ff --no-verify"));
 
   it("returns the forge merge SHA from a completed PR landing", async () => {
@@ -654,7 +663,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
-    expect(prMerged(j)).toBe(true);
+    expect(prMerged(h.mergeCalls)).toBe(true);
     expect(directMerged(j)).toBe(false);
     // PR base is the resolved base (main here) — the reused-PR lookup keys on it.
     expect(j.some((c) => c.includes("pr list") && c.includes("--base main"))).toBe(true);
@@ -668,8 +677,8 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     const j = joined(h.mergeCalls);
     expect(directMerged(j)).toBe(true);
     // No PR opened/merged at all.
-    expect(prMerged(j)).toBe(false);
-    expect(j.some((c) => c.includes("pr list") || c.includes("pr merge"))).toBe(false);
+    expect(prMerged(h.mergeCalls)).toBe(false);
+    expect(j.some((c) => c.includes("pr list"))).toBe(false);
     // Merge ran in the isolated worktree, pushing main from its HEAD.
     expect(j).toContain(`git -C ${WT} push origin HEAD:refs/heads/main`);
   });
@@ -706,7 +715,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     // PR path → no captured sha; locked echoes input.locked=true.
     expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
-    expect(prMerged(j)).toBe(true);
+    expect(prMerged(h.mergeCalls)).toBe(true);
     // The PR targeted the lock branch as its base (PR #42 reused via pr list).
     expect(j.some((c) => c.includes("pr list") && c.includes("--base feature-locked"))).toBe(true);
     // No local direct merge of the attempt branch.
@@ -726,7 +735,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     // The ADR 0083 precondition READS refs/heads/main (the trunk, read-only); the
     // landing's WRITE ops (merge/push) must never target main.
     expect(j.some((c) => (c.includes("merge --") || c.includes("push ")) && c.includes("main"))).toBe(false);
-    expect(prMerged(j)).toBe(false);
+    expect(prMerged(h.mergeCalls)).toBe(false);
   });
 
   it("afk.merge.* still governs the PR merge: lock=X + true + wait_for_review polls before the admin-merge", async () => {
@@ -736,7 +745,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
     const checksIdx = j.findIndex((c) => c.includes("pr checks"));
-    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
+    const mergeIdx = h.mergeCalls.findIndex(isRestMergePullCall);
     expect(checksIdx).toBeGreaterThanOrEqual(0);
     expect(mergeIdx).toBeGreaterThan(checksIdx);
   });
@@ -760,7 +769,7 @@ describe("doLanding — post-land promotion advances red-trunk, not the primary 
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
-    expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(true);
     expect(j).toContain("git -C /repo update-ref refs/heads/red-trunk 0r1g1nsha");
     expect(j.some((c) => c.includes("symbolic-ref") || c.includes("status --porcelain"))).toBe(false);
     expect(destructivePrimaryWrites(h)).toEqual([]);
@@ -772,7 +781,7 @@ describe("doLanding — post-land promotion advances red-trunk, not the primary 
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
-    expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(true);
     expect(j).toContain("git -C /repo update-ref refs/heads/red-trunk 0r1g1nsha");
     expect(j.some((c) => c.includes("status --porcelain"))).toBe(false);
     expect(destructivePrimaryWrites(h)).toEqual([]);
@@ -887,7 +896,7 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
     });
     expect(h.postMergeGateDirs).toEqual([]);
     // The admin-merge still happened.
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(true);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(true);
     expect(h.landingPhases).toEqual(["gate", "push-pr", "wait", "cascade"]);
   });
 
@@ -905,7 +914,7 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
       },
     });
     expect(h.postMergeGateDirs).toEqual([RWT]);
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(true);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(true);
   });
 
   it("direct path: gate wired + fails → returns post-merge-gate, nothing pushed to remote", async () => {
@@ -929,7 +938,7 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
     // Gate was called with the rebase worktree.
     expect(h.postMergeGateDirs).toEqual([RWT]);
     // No admin-merge was attempted.
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.mergeCalls.some(isRestMergePullCall)).toBe(false);
   });
 
   it("direct path: gate failure aborts before the merge but worktree is still torn down", async () => {

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -260,7 +260,7 @@ describe("landPr (unlocked path)", () => {
     let prMade = false;
     const exec: Exec = async (argv) => {
       const cmd = argv.join(" ");
-      if (cmd.includes("pr create")) prMade = true;
+      if (cmd.includes("api -X POST repos/reddb-io/red-skills/pulls")) prMade = true;
       if (readsPull(argv)) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
       if (cmd.includes("pr list")) {
         return { code: 0, stdout: prMade ? "77\n" : "\n", stderr: "" };
@@ -291,9 +291,10 @@ describe("landPr (unlocked path)", () => {
       "git -C /repo/wt push origin HEAD:refs/heads/afk/wBBBB/9-x --force-with-lease",
     );
     expect(
-      c.some((x) => x.includes("pr create --base main --head afk/wBBBB/9-x")),
+      c.some((x) => x.includes("api -X POST repos/reddb-io/red-skills/pulls") && x.includes("base=main") && x.includes("head=afk/wBBBB/9-x")),
     ).toBe(true);
-    expect(c.some((x) => x.includes("pr merge 77 --merge"))).toBe(true);
+    expect(c.some((x) => x.includes("api -X PUT repos/reddb-io/red-skills/pulls/77/merge") && x.includes("merge_method=merge"))).toBe(true);
+    expect(c.some((x) => /\bpr (?:create|merge)\b/.test(x))).toBe(false);
     // Promotion advances the fleet-owned mirror, not the primary checkout.
     expect(c).toContain("git -C /repo update-ref refs/heads/red-trunk origin-tip");
     expect(c.some((x) => x.includes("symbolic-ref") || x.includes("status --porcelain"))).toBe(false);
@@ -317,14 +318,14 @@ describe("landPr (unlocked path)", () => {
     });
     expect(result.ok).toBe(true);
     const c = joined(calls);
-    expect(c.some((x) => x.includes("pr create"))).toBe(false);
-    expect(c.some((x) => x.includes("pr merge 42 --merge"))).toBe(true);
+    expect(c.some((x) => x.includes("api -X POST") && x.includes("/pulls"))).toBe(false);
+    expect(c.some((x) => x.includes("pulls/42/merge"))).toBe(true);
   });
 
   it("returns failure when the admin-merge fails", async () => {
     const { exec } = fakeExec([
       { match: (a) => a.join(" ").includes("pr list"), result: { stdout: "5\n" } },
-      { match: (a) => a.join(" ").includes("pr merge"), result: { code: 1 } },
+      { match: (a) => a.join(" ").includes("/merge"), result: { code: 1 } },
     ]);
     const result = await landPr(exec, {
       repo: "reddb-io/red-skills",
@@ -371,7 +372,7 @@ describe("landPr (unlocked path)", () => {
     });
     expect(result.ok).toBe(true);
     const c = joined(calls);
-    expect(c.some((x) => x.includes("pr merge 42 --merge"))).toBe(true);
+    expect(c.some((x) => x.includes("pulls/42/merge"))).toBe(true);
     expect(c).toContain("git -C /repo update-ref refs/heads/red-trunk lock-tip");
     expect(c.some((x) => x.includes("symbolic-ref") || x.includes("status --porcelain"))).toBe(false);
     expect(c.some((x) => x.includes("git -C /repo merge --ff-only"))).toBe(false);
@@ -742,7 +743,7 @@ describe("openReviewPr (review-gate handoff, #749)", () => {
     const review: Exec = async (argv) => {
       recorded.push(argv);
       const cmd = argv.join(" ");
-      if (cmd.includes("pr create")) prMade = true;
+      if (cmd.includes("api -X POST") && cmd.includes("/pulls")) prMade = true;
       if (readsPull(argv)) return { code: 0, stdout: MERGED_PR_VIEW, stderr: "" };
       if (cmd.includes("pr list")) return { code: 0, stdout: prMade ? "88\n" : "\n", stderr: "" };
       return { code: 0, stdout: "", stderr: "" };
@@ -757,10 +758,10 @@ describe("openReviewPr (review-gate handoff, #749)", () => {
     });
     expect(result).toEqual({ ok: true, prNumber: 88 });
     const c = joined(recorded);
-    expect(c.some((x) => x.includes("pr create --base main --head afk/wBBBB/9-x"))).toBe(true);
+    expect(c.some((x) => x.includes("api -X POST") && x.includes("/pulls") && x.includes("base=main") && x.includes("head=afk/wBBBB/9-x"))).toBe(true);
     expect(c).toContain("gh -R reddb-io/red-skills pr edit 88 --add-label ready-for-review");
     // The whole point: the merge is held for the fresh-agent review.
-    expect(c.some((x) => x.includes("pr merge"))).toBe(false);
+    expect(c.some((x) => x.includes("/merge"))).toBe(false);
   });
 
   it("reuses an open PR and re-applies the label (idempotent)", async () => {
@@ -777,7 +778,7 @@ describe("openReviewPr (review-gate handoff, #749)", () => {
     });
     expect(result).toEqual({ ok: true, prNumber: 42 });
     const c = joined(calls);
-    expect(c.some((x) => x.includes("pr create"))).toBe(false);
+    expect(c.some((x) => x.includes("api -X POST") && x.includes("/pulls"))).toBe(false);
     expect(c).toContain("gh -R reddb-io/red-skills pr edit 42 --add-label ready-for-review");
   });
 
@@ -958,7 +959,7 @@ describe("landPr wait_for_review wiring", () => {
         checksPolled = true;
         return { code: 0, stdout: JSON.stringify([{ name: "CodeRabbit", state: "SUCCESS" }]), stderr: "" };
       }
-      if (cmd.includes("pr merge")) {
+      if (cmd.includes("/merge")) {
         mergedAfterPoll = checksPolled; // merge must come AFTER the poll
         return { code: 0, stdout: "", stderr: "" };
       }
@@ -977,7 +978,7 @@ describe("landPr wait_for_review wiring", () => {
     expect(result.ok).toBe(true);
     expect(checksPolled).toBe(true);
     expect(mergedAfterPoll).toBe(true);
-    expect(calls.some((c) => c.join(" ").includes("pr merge 77 --merge"))).toBe(true);
+    expect(calls.some((c) => c.join(" ").includes("pulls/77/merge"))).toBe(true);
   });
 
   it("does NOT poll review checks by default (waitForReview absent)", async () => {
@@ -995,7 +996,7 @@ describe("landPr wait_for_review wiring", () => {
     });
     expect(result.ok).toBe(true);
     expect(joined(calls).some((c) => c.includes("pr checks"))).toBe(false);
-    expect(joined(calls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(joined(calls).some((c) => c.includes("pulls/42/merge"))).toBe(true);
   });
 });
 
@@ -1355,7 +1356,7 @@ describe("landPr CI-aware wiring (#812)", () => {
         viewed = true;
         return { code: 0, stdout: JSON.stringify({ mergeStateStatus: "CLEAN", statusCheckRollup: [] }), stderr: "" };
       }
-      if (cmd.includes("pr merge")) {
+      if (cmd.includes("/merge")) {
         mergedAfterView = viewed;
         return { code: 0, stdout: "", stderr: "" };
       }
@@ -1386,7 +1387,7 @@ describe("landPr CI-aware wiring (#812)", () => {
       ciAwait: { github: githubFromExec(exec), sleep: async () => {}, maxPolls: 2 },
     });
     expect(r).toEqual({ ok: false, prNumber: 5, reason: "ci-failed" });
-    expect(calls.some((c) => c.join(" ").includes("pr merge"))).toBe(false);
+    expect(calls.some((c) => c.join(" ").includes("/merge"))).toBe(false);
   });
 
   it("returns ci-pending (no merge, no re-run) when checks stay pending", async () => {
@@ -1429,7 +1430,7 @@ describe("landPr CI-aware wiring (#812)", () => {
           };
         }
         // branch protection rejects a merge attempted before the checks report
-        if (cmd.includes("pr merge")) return { code: 1, stdout: "", stderr: "Protected branch update failed" };
+        if (cmd.includes("/merge")) return { code: 1, stdout: "", stderr: "Protected branch update failed" };
         return { code: 0, stdout: "", stderr: "" };
       };
       const r = await landPr(exec, {
@@ -1438,7 +1439,7 @@ describe("landPr CI-aware wiring (#812)", () => {
       });
       // never `merge-failed` — that is the reason the landing parks as blocked:ci
       expect(r).toEqual({ ok: false, prNumber: 5, reason: "ci-pending" });
-      expect(calls.some((c) => c.join(" ").includes("pr merge"))).toBe(false);
+      expect(calls.some((c) => c.join(" ").includes("/merge"))).toBe(false);
     });
 
     it("keeps waiting inside the tail and lands once the checks report green", async () => {
@@ -1472,7 +1473,7 @@ describe("landPr CI-aware wiring (#812)", () => {
       });
       expect(r.ok).toBe(true);
       expect(polls).toBe(2);
-      expect(calls.some((c) => c.join(" ").includes("pr merge 5 --merge"))).toBe(true);
+      expect(calls.some((c) => c.join(" ").includes("pulls/5/merge"))).toBe(true);
     });
   });
 
@@ -1530,7 +1531,7 @@ describe("landPr CI-aware wiring (#812)", () => {
           updated = true;
           return { code: 0, stdout: "", stderr: "" };
         }
-        if (cmd.includes("pr merge")) {
+        if (cmd.includes("/merge")) {
           merges += 1;
           // the base moved under the first merge; the second lands
           return updated ? { code: 0, stdout: "", stderr: "" } : { code: 1, stdout: "", stderr: "Protected branch update failed" };
@@ -1557,7 +1558,7 @@ describe("landPr CI-aware wiring (#812)", () => {
             stderr: "",
           };
         }
-        if (cmd.includes("pr merge")) return { code: 1, stdout: "", stderr: "Protected branch update failed" };
+        if (cmd.includes("/merge")) return { code: 1, stdout: "", stderr: "Protected branch update failed" };
         return { code: 0, stdout: "", stderr: "" };
       };
       const r = await landPr(exec, {
@@ -1587,7 +1588,7 @@ describe("landPr CI-aware wiring (#812)", () => {
           updates += 1;
           return { code: 0, stdout: "", stderr: "" };
         }
-        if (cmd.includes("pr merge")) {
+        if (cmd.includes("/merge")) {
           merges += 1;
           return { code: 1, stdout: "", stderr: "Protected branch update failed" };
         }
@@ -1615,7 +1616,7 @@ describe("landPr CI-aware wiring (#812)", () => {
     // reads `mergeStateStatus` unconditionally since #3030 — that is one `gh pr
     // view` asking whether the merge happened, not a CI wait.
     expect(joined(calls).some((c) => c.includes("statusCheckRollup"))).toBe(false);
-    expect(joined(calls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(joined(calls).some((c) => c.includes("pulls/42/merge"))).toBe(true);
   });
 });
 
@@ -2200,7 +2201,7 @@ describe("landPr on a merge-queue base (#2986)", () => {
       mergeQueueWait: { sleep: async () => {}, maxPolls: 2 },
     });
     expect(r).toEqual({ ok: false, prNumber: 42, reason: "queue-pending" });
-    expect(calls.some((c) => c.join(" ").includes("pr merge 42 --merge --auto"))).toBe(true);
+    expect(calls.some((c) => c.join(" ").includes("pulls/42/merge"))).toBe(true);
   });
 
   it("reports ok with the queue's merge commit once the PR reports merged=true", async () => {
@@ -2438,7 +2439,7 @@ describe("the merge confirmation on a dirty PR (#3030)", () => {
       calls.push(argv);
       const cmd = argv.join(" ");
       if (cmd.includes("pr list")) return { code: 0, stdout: "42\n", stderr: "" };
-      if (cmd.includes("pr merge")) {
+      if (cmd.includes("/merge")) {
         opts.onMerge?.();
         return { code: 0, stdout: "", stderr: "" };
       }

--- a/apps/dev/tests/outbound-redaction.test.ts
+++ b/apps/dev/tests/outbound-redaction.test.ts
@@ -9,6 +9,8 @@ import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
 
 const LEAK_ENV_KEY = "RED_SKILLS_TEST_TOKEN";
 const LEAK_ENV_VALUE = "red-skills-test-token-123456";
+const isRestCreatePullCall = (args: readonly string[]): boolean =>
+  args.includes("POST") && args.some((arg) => /\/pulls$/.test(arg));
 const LEAK_TEXT = [
   "session https://claude.ai/code/session_abc123_X-y",
   `literal ${LEAK_ENV_VALUE}`,
@@ -157,7 +159,7 @@ describe("GitHub outbound write seams", () => {
     const exec: Exec = async (args) => {
       calls.push([...args]);
       if (args.includes("list")) {
-        const previousCreates = calls.filter((call) => call.includes("create")).length;
+        const previousCreates = calls.filter(isRestCreatePullCall).length;
         return { code: 0, stdout: previousCreates > 0 ? "88\n" : "", stderr: "" };
       }
       return { code: 0, stdout: "", stderr: "" };
@@ -178,7 +180,7 @@ describe("GitHub outbound write seams", () => {
       mergeQueueWait: { sleep: async () => {}, maxPolls: 1 },
     });
 
-    const create = calls.find((args) => args.includes("create"));
+    const create = calls.find(isRestCreatePullCall);
     expect(create).toBeTruthy();
     expectScrubbed(create!.join("\n"));
     expect(create!.join("\n")).toContain("Closes #1365");

--- a/apps/dev/tests/process-issue-resume.test.ts
+++ b/apps/dev/tests/process-issue-resume.test.ts
@@ -307,7 +307,7 @@ describe("branch adoption is decided on commits, not on the ref name (issue #286
     const { deps, input, trace } = harness({
       onRunAgent: async () => {
         routeWasOpenWhenAgentStarted = trace.mergeCalls.some((argv) =>
-          argv.join(" ").includes("pr create --draft --base main")
+          argv.includes("POST") && argv.includes("draft=true") && argv.includes("base=main")
         );
       },
     });
@@ -322,19 +322,20 @@ describe("branch adoption is decided on commits, not on the ref name (issue #286
     expect(routeWasOpenWhenAgentStarted).toBe(true);
     expect(trace.mergeCalls).toContainEqual([
       "gh",
-      "-R",
-      "o/r",
-      "pr",
-      "create",
-      "--draft",
-      "--base",
-      "main",
-      "--head",
-      PRIOR_BRANCH,
-      "--title",
-      "resume: #9",
-      "--body",
-      expect.stringContaining("Closes #9"),
+      "api",
+      "-X",
+      "POST",
+      "repos/o/r/pulls",
+      "-F",
+      "draft=true",
+      "-f",
+      "base=main",
+      "-f",
+      `head=${PRIOR_BRANCH}`,
+      "-f",
+      "title=resume: #9",
+      "-f",
+      expect.stringContaining("body=Resuming preserved Worker commits for #9."),
     ]);
   });
 

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -43,6 +43,7 @@ import {
 } from "./daemon.js";
 import {
   createGithubAttributionLedger,
+  createGithubBalanceStore,
   createGithubBalanceTransport,
   type GithubAttributionLedger,
   type GithubRateBudget,
@@ -455,7 +456,13 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       readTrackerCliToken,
       githubAttribution,
     );
-    const githubBalance = resolveServeGithubBalance(values);
+    const resolvedGithubBalance = resolveServeGithubBalance(values);
+    const githubBalance = resolvedGithubBalance == null
+      ? null
+      : {
+          ...resolvedGithubBalance,
+          store: createGithubBalanceStore({ path: join(hostStateRoot, "github", "balance.toon") }),
+        };
     // Before this daemon anchors itself, it speaks for whatever the last one
     // could not (slice #3028). The host singleton is the only process guaranteed
     // to boot after a machine freeze, so an un-trap-able death on this lane has

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -448,11 +448,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // The last activity fetch, kept for the same reason the RSS reading is: a read
   // between two polls is dated by the poll it came from, never by the read.
   let lastActivity: RedskilledRepositoryActivity | null = null;
-  // The last balance the TOKEN answered with — the only copy on this host, and
-  // not a number this process maintains. It is `null` until something has been
-  // asked, because "nobody asked yet" and "the budget is full" are opposite facts
-  // and the second one admits every call (ADR 0132 Amendment 2).
-  let lastBalance: GithubBalance | null = null;
+  // The last TOKEN answer; null means unasked, never "full budget" (ADR 0132 Amendment 2).
+  let lastBalance: GithubBalance | null = null, balanceHydrated = false, balanceHydration: Promise<GithubBalance | null> | null = null;
   // The last queue fetch, held beside the activity one rather than merged into it:
   // two cadences produce two instants, and a document that carried one date for
   // both would age the fast half by the slow half's clock.
@@ -769,16 +766,19 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     });
   }
 
-  /**
-   * Ask the token what it has left. ONE request, and one poller host-wide.
-   *
-   * The answer replaces the stored one whatever it says, including when it says
-   * nothing: a refusal that left the last good balance standing would keep
-   * admitting convenience reads against a number the token stopped confirming.
-   */
+  /** Ask the token once host-wide; every answer replaces the stored observation. */
   async function pollGithubBalance(): Promise<GithubBalance | null> {
     if (balanceRegistration == null) return null;
+    if (!balanceHydrated && balanceRegistration.store) {
+      balanceHydration ??= balanceRegistration.store.read().then((stored) => {
+        balanceHydrated = true;
+        if (stored !== null) lastBalance = stored;
+        return stored;
+      }).finally(() => { balanceHydration = null; });
+      if ((await balanceHydration) !== null) return lastBalance;
+    }
     lastBalance = await fetchGithubBalance({ transport: balanceRegistration.transport, now: clock() });
+    await balanceRegistration.store?.write(lastBalance).catch(() => undefined);
     return lastBalance;
   }
 

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -47,6 +47,7 @@ import { type RedskilledProjectDeregistered,
   type RedskilledWorkerHeartbeatRequest,
 } from "../protocol.js";
 import { type GithubBalance,
+  type GithubBalanceStore,
   type GithubBalanceTransport,
 } from "@reddb-io/github";
 import { type RedskilledActivityTransport,
@@ -279,6 +280,8 @@ export interface RedskilledActivityRegistration {
  */
 export interface RedskilledBalanceRegistration {
   readonly transport: GithubBalanceTransport;
+  /** Host-state snapshot shared with fresh and parallel local processes. */
+  readonly store?: GithubBalanceStore;
   /**
    * A hard window, for a test that needs one. Production leaves this absent and
    * lets the balance decide — that is the whole decision.

--- a/apps/redskilled/tests/github-balance.test.ts
+++ b/apps/redskilled/tests/github-balance.test.ts
@@ -7,7 +7,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { GITHUB_RATE_LIMIT_PATH, createGithubBalanceTransport } from "@reddb-io/github";
+import { GITHUB_RATE_LIMIT_PATH, createGithubBalanceTransport, parseGithubBalance } from "@reddb-io/github";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
@@ -54,6 +54,34 @@ async function start(options: Parameters<typeof startRedskilledDaemon>[0]): Prom
 }
 
 describe("one poller, and the balance comes from the token", () => {
+  it("hydrates a dry pool from durable state without spending a discovery call", async () => {
+    let asks = 0;
+    let hydrated!: () => void;
+    const hydration = new Promise<void>((resolve) => { hydrated = resolve; });
+    const persisted = parseGithubBalance(answer(0), { askedAt: "2026-08-03T12:30:00.000Z" });
+    const daemon = await start({
+      paths: await paths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      githubBalance: {
+        transport: async () => {
+          asks += 1;
+          return answer(5_000);
+        },
+        store: { read: async () => { hydrated(); return persisted; }, write: async () => undefined },
+        intervalMsOverride: 3_600_000,
+      },
+    });
+
+    await hydration;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const balance = daemon.githubBalance();
+
+    expect(asks).toBe(0);
+    expect(balance?.pools.graphql?.remaining).toBe(0);
+    expect(balance?.pools.rest?.remaining).toBe(5_000);
+  });
+
   it("asks once per poll and stores what the token answered", async () => {
     let asks = 0;
     const daemon = await start({

--- a/packages/github/balance-store.test.ts
+++ b/packages/github/balance-store.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createGithubBalanceStore } from "./balance-store.js";
+import { parseGithubBalance } from "./balance.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("the cross-process GitHub balance state", () => {
+  it("shares independent pool balances with a fresh process through bounded TOON state", async () => {
+    const root = await mkdtemp(join(tmpdir(), "github-balance-store-"));
+    roots.push(root);
+    const path = join(root, "state", "github", "balance.toon");
+    const graphqlReset = "2026-08-11T22:00:00.000Z";
+    const observed = parseGithubBalance({
+      resources: {
+        core: { limit: 5_000, remaining: 4_883, used: 117, reset: Date.parse(graphqlReset) / 1_000 },
+        graphql: { limit: 5_000, remaining: 0, used: 5_000, reset: Date.parse(graphqlReset) / 1_000 },
+        search: { limit: 30, remaining: 30, used: 0, reset: Date.parse(graphqlReset) / 1_000 },
+      },
+    }, { askedAt: "2026-08-11T21:15:00.000Z" });
+
+    await createGithubBalanceStore({ path }).write(observed);
+    const fromFreshProcess = await createGithubBalanceStore({ path }).read();
+
+    expect(fromFreshProcess?.pools).toMatchObject({
+      rest: { remaining: 4_883 },
+      graphql: { remaining: 0, reset_at: graphqlReset },
+      search: { remaining: 30 },
+    });
+    expect(await readFile(path, "utf8")).toContain("pools:");
+  });
+
+  it("refuses a snapshot larger than the registry-declared lane ceiling", async () => {
+    const root = await mkdtemp(join(tmpdir(), "github-balance-store-"));
+    roots.push(root);
+    const path = join(root, "balance.toon");
+    const store = createGithubBalanceStore({ path, maxBytes: 32 });
+    const observed = parseGithubBalance({
+      resources: { core: { limit: 5_000, remaining: 4_883, used: 117, reset: 0 } },
+    }, { askedAt: "2026-08-11T21:15:00.000Z" });
+
+    await expect(store.write(observed)).rejects.toThrow("lane ceiling");
+  });
+});

--- a/packages/github/balance-store.ts
+++ b/packages/github/balance-store.ts
@@ -1,0 +1,89 @@
+// balance-store — one token-wide budget picture shared by every local process.
+
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { LANE_RETENTION_REGISTRY } from "@reddb-io/shared/lane-retention.js";
+
+import { GITHUB_POOLS, type GithubBalance, type GithubPoolBalance } from "./balance.js";
+import type { GithubRateBudget } from "./surface.js";
+
+export interface GithubBalanceStore {
+  /** Read the latest complete snapshot. Missing or malformed state is unknown, never a full budget. */
+  read(): Promise<GithubBalance | null>;
+  /** Atomically replace the snapshot observed by all subsequent readers. */
+  write(balance: GithubBalance): Promise<void>;
+}
+
+export interface CreateGithubBalanceStoreOptions {
+  /** Durable TOON path below the daemon's state/github lane. */
+  readonly path: string;
+  /** Test override; production uses the registry-declared ceiling. */
+  readonly maxBytes?: number;
+}
+
+/** A bounded atomic snapshot: one file, one current answer, no process-local warm-up call. */
+export function createGithubBalanceStore(options: CreateGithubBalanceStoreOptions): GithubBalanceStore {
+  const maxBytes = options.maxBytes ?? LANE_RETENTION_REGISTRY["github-balance"].maxBytes;
+  return {
+    async read(): Promise<GithubBalance | null> {
+      try {
+        const parsed = decode(await readFile(options.path, "utf8"));
+        return isGithubBalance(parsed) ? parsed : null;
+      } catch (error) {
+        if (isNodeError(error) && error.code === "ENOENT") return null;
+        // A torn predecessor or unreadable schema is no budget observation. The
+        // writer's atomic rename makes this exceptional, but failing open as
+        // "unknown" is still safer than turning corruption into "spent".
+        return null;
+      }
+    },
+
+    async write(balance: GithubBalance): Promise<void> {
+      const rendered = `${encode(balance as unknown as JsonValue)}\n`;
+      const bytes = Buffer.byteLength(rendered);
+      if (bytes > maxBytes) {
+        throw new Error(`GitHub balance snapshot exceeds its ${maxBytes}-byte lane ceiling`);
+      }
+      const directory = dirname(options.path);
+      await mkdir(directory, { recursive: true });
+      const temporary = `${options.path}.write-${process.pid}-${randomUUID()}`;
+      try {
+        await writeFile(temporary, rendered, { encoding: "utf8", mode: 0o600 });
+        await rename(temporary, options.path);
+      } finally {
+        await rm(temporary, { force: true }).catch(() => undefined);
+      }
+    },
+  };
+}
+
+function isGithubBalance(value: unknown): value is GithubBalance {
+  if (!record(value)) return false;
+  if (value.version !== 1 || value.origin !== "asked" || value.source !== "GET /rate_limit") return false;
+  if (value.outcome !== "asked" && value.outcome !== "unanswered") return false;
+  if (typeof value.asked_at !== "string" || !Number.isFinite(Date.parse(value.asked_at))) return false;
+  if (!Number.isSafeInteger(value.request_count) || (value.request_count as number) < 0) return false;
+  if (!record(value.pools) || !Array.isArray(value.unreported_pools) || typeof value.detail !== "string") return false;
+  const pools = value.pools;
+  return GITHUB_POOLS.every((pool) => {
+    const candidate = pools[pool];
+    return candidate === null || isPool(candidate, pool);
+  }) && value.unreported_pools.every((pool) => GITHUB_POOLS.includes(pool as GithubRateBudget));
+}
+
+function isPool(value: unknown, pool: GithubRateBudget): value is GithubPoolBalance {
+  if (!record(value) || value.pool !== pool || typeof value.resource !== "string") return false;
+  if (typeof value.reset_at !== "string" || !Number.isFinite(Date.parse(value.reset_at))) return false;
+  return [value.limit, value.remaining, value.used].every((count) => Number.isSafeInteger(count) && (count as number) >= 0) &&
+    typeof value.fraction === "number" && Number.isFinite(value.fraction);
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/github/conditional-client.test.ts
+++ b/packages/github/conditional-client.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createGithubAttributionLedger } from "./attribution.js";
 import {
   createGithubClient,
+  GithubPoolUnavailableError,
   isGithubRateLimitError,
   type GithubRequestFetch,
 } from "./conditional-client.js";
@@ -55,6 +56,144 @@ async function ledgerPath(): Promise<string> {
 }
 
 describe("the conditional GitHub client", () => {
+  it("honors an explicit GraphQL rail while that pool has budget", async () => {
+    const seen: string[] = [];
+    const client = createGithubClient({
+      token: "test-token",
+      balance: () => balance(4_883, 5_000),
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async (url) => {
+        seen.push(String(url));
+        return new Response(JSON.stringify({
+          data: { r0: { object: { number: 7, headRefOid: "abc123" } }, rateLimit: { cost: 1 } },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      },
+    });
+
+    const answer = await client.singleObject<{ number: number; headRefOid: string }>({
+      cacheKey: "pr:acme/widgets:7",
+      kind: "pr",
+      owner: "acme",
+      repo: "widgets",
+      number: 7,
+      selection: "number headRefOid",
+      operation: { key: "pr view", budget: "rest" },
+      rail: "graphql",
+    });
+
+    expect(answer).toMatchObject({
+      data: { number: 7, headRefOid: "abc123" },
+      surface: "graphql",
+      routing: { requestedRail: "graphql", selectedRail: "graphql", rerouted: false },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain("/graphql");
+  });
+
+  it("replays today's dry GraphQL incident on REST without issuing GraphQL", async () => {
+    const seen: string[] = [];
+    const client = createGithubClient({
+      token: "test-token",
+      balance: () => balance(4_883, 0),
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async (url) => {
+        seen.push(String(url));
+        return new Response(JSON.stringify({ number: 7, head: { sha: "abc123" }, state: "open" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    const answer = await client.singleObject<{ number: number; head: { sha: string } }>({
+      cacheKey: "pr:acme/widgets:7",
+      kind: "pr",
+      owner: "acme",
+      repo: "widgets",
+      number: 7,
+      selection: "number headRefOid",
+      operation: { key: "pr view", budget: "rest" },
+      rail: "graphql",
+    });
+
+    expect(answer).toMatchObject({
+      surface: "rest",
+      routing: {
+        requestedRail: "graphql",
+        selectedRail: "rest",
+        rerouted: true,
+        pool: "graphql",
+        resetAt: "2026-08-05T12:00:00.000Z",
+      },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain("/pulls/7");
+    expect(seen.every((url) => !url.includes("/graphql"))).toBe(true);
+  });
+
+  it("parks an operation with no equivalent by naming its pool and reset", async () => {
+    const client = createGithubClient({
+      token: "test-token",
+      balance: () => balance(0, 4_883),
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async () => {
+        throw new Error("a dry pool must be refused before transport");
+      },
+    });
+
+    const error = await client.conditionalRest({
+      cacheKey: "checks:acme/widgets:abc123",
+      route: "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+      parameters: { owner: "acme", repo: "widgets", ref: "abc123" },
+      operation: { key: "pr checks", budget: "rest" },
+    }).then(() => null, (thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(GithubPoolUnavailableError);
+    expect(error).toMatchObject({ pool: "rest", resetAt: "2026-08-05T12:00:00.000Z" });
+    expect(String(error)).toContain("rest pool");
+    expect(String(error)).toContain("2026-08-05T12:00:00.000Z");
+  });
+
+  it("falls back to the last-known REST answer with its age before parking", async () => {
+    let current = balance(4_883, 0);
+    const instants = ["2026-08-05T11:00:00.000Z", "2026-08-05T11:00:30.000Z"];
+    const client = createGithubClient({
+      token: "test-token",
+      balance: () => current,
+      now: () => instants.shift() ?? "2026-08-05T11:00:30.000Z",
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async () => new Response(JSON.stringify({ check_runs: [{ name: "gate", status: "completed" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json", etag: '"checks-v1"' },
+      }),
+    });
+    const request = {
+      cacheKey: "checks:acme/widgets:abc123",
+      route: "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+      parameters: { owner: "acme", repo: "widgets", ref: "abc123" },
+      operation: { key: "pr checks", budget: "rest" as const },
+    };
+
+    await client.conditionalRest(request);
+    current = balance(0, 0);
+    const cached = await client.conditionalRest(request);
+
+    expect(cached).toMatchObject({
+      data: { check_runs: [{ name: "gate", status: "completed" }] },
+      quotaFree: true,
+      degraded: {
+        source: "cache",
+        ageMs: 30_000,
+        pool: "rest",
+        resetAt: "2026-08-05T12:00:00.000Z",
+      },
+    });
+  });
+
   it("publishes a threshold that rises with REST headroom relative to GraphQL", () => {
     expect(githubSingleObjectCoalescingThreshold(balance(4_000, 1_000))).toBe(4);
     expect(githubSingleObjectCoalescingThreshold(balance(500, 4_000))).toBe(1);

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -17,7 +17,7 @@ import {
 } from "./aliased-query.js";
 import type { GithubAttributionLedger, GithubAttributedOperation } from "./attribution.js";
 import type { GithubBalance } from "./balance.js";
-import type { GithubApiSurface } from "./surface.js";
+import type { GithubApiSurface, GithubRateBudget } from "./surface.js";
 
 const Octokit = RestOctokit.plugin(retry, throttling);
 
@@ -28,6 +28,8 @@ export interface GithubEtagEntry {
   readonly etag: string;
   readonly data: unknown;
   readonly headers: GithubResponseHeaders;
+  /** When the held body was last confirmed by a 200 response. */
+  readonly storedAt?: string;
 }
 
 /** The ETag and answer are one entry: retaining only the validator makes 304 empty. */
@@ -66,6 +68,15 @@ export interface GithubRestAnswer<T> {
   readonly headers: GithubResponseHeaders;
   /** True when a 304 reused the held answer and consumed no REST request budget. */
   readonly quotaFree: boolean;
+  readonly degraded?: GithubCachedFallback;
+}
+
+export interface GithubCachedFallback {
+  readonly source: "cache";
+  readonly pool: GithubRateBudget;
+  readonly resetAt: string;
+  readonly ageMs: number | null;
+  readonly reason: string;
 }
 
 export interface GithubPaginatedRestAnswer<T> extends GithubRestAnswer<readonly T[]> {
@@ -90,6 +101,8 @@ export interface GithubSingleObjectRequest extends GithubAliasedSingleObjectRead
   readonly cacheKey: string;
   readonly operation: GithubAttributedOperation;
   readonly actor?: string;
+  /** Force one API rail when it is available; an exhausted rail falls back to its declared equivalent. */
+  readonly rail?: GithubApiSurface;
   /** Project REST and GraphQL payloads into one caller-visible object shape. */
   readonly project?: (value: unknown, surface: GithubApiSurface) => unknown;
 }
@@ -99,6 +112,18 @@ export interface GithubSingleObjectAnswer<T> {
   readonly data: T;
   readonly surface: GithubApiSurface;
   readonly quotaFree: boolean;
+  /** Present for an explicit choice or a failover, so routing never becomes invisible. */
+  readonly routing?: GithubRailRouting;
+}
+
+export interface GithubRailRouting {
+  readonly requestedRail: GithubApiSurface;
+  readonly selectedRail: GithubApiSurface;
+  readonly rerouted: boolean;
+  /** The exhausted source pool when rerouted. */
+  readonly pool: GithubRateBudget;
+  readonly resetAt: string | null;
+  readonly reason: string;
 }
 
 export interface GithubGraphqlAttribution {
@@ -114,6 +139,7 @@ export interface CreateGithubClientOptions {
   readonly attribution?: GithubAttributionLedger;
   /** The last authoritative token-wide balance; an unknown balance never diverts. */
   readonly balance?: () => GithubBalance | null | Promise<GithubBalance | null>;
+  readonly now?: () => string;
   /** Transient retries; the plugin default in production, overridable in tests. */
   readonly retryCount?: number;
   /** Disable plugin pacing only for a caller-supplied transport test. */
@@ -156,6 +182,22 @@ export class GithubCredentialError extends Error {
   }
 }
 
+/** A primary pool cannot serve this request and no equivalent/cache can answer it. */
+export class GithubPoolUnavailableError extends Error {
+  readonly pool: GithubRateBudget;
+  readonly resetAt: string;
+
+  constructor(pool: GithubRateBudget, resetAt: string, detail?: string, options?: { readonly cause?: unknown }) {
+    super(
+      `${pool} pool is exhausted; parked until ${resetAt}${detail ? ` (${detail})` : ""}`,
+      options,
+    );
+    this.name = "GithubPoolUnavailableError";
+    this.pool = pool;
+    this.resetAt = resetAt;
+  }
+}
+
 /**
  * Build the typed GitHub transport decided by ADR 0133.
  *
@@ -166,6 +208,7 @@ export class GithubCredentialError extends Error {
  */
 export function createGithubClient(options: CreateGithubClientOptions): GithubClient {
   const etags = options.etags ?? createMemoryGithubEtagStore();
+  const now = options.now ?? (() => new Date().toISOString());
   const octokit = new Octokit({
     auth: options.token,
     // REST.js logs every non-2xx before the caller can classify it, including
@@ -191,8 +234,28 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         },
   });
 
+  const readBalance = async (): Promise<GithubBalance | null> => {
+    try {
+      return await options.balance?.() ?? null;
+    } catch {
+      return null;
+    }
+  };
+
+  const refuseSpentPool = (balance: GithubBalance | null, pool: GithubRateBudget): void => {
+    const observed = balance?.pools[pool] ?? null;
+    if (observed !== null && observed.remaining <= 0) {
+      throw new GithubPoolUnavailableError(pool, observed.reset_at);
+    }
+  };
+
   const conditionalRest = async <T>(input: GithubConditionalRestRequest): Promise<GithubRestAnswer<T>> => {
       const held = etags.get(input.cacheKey);
+      const observed = (await readBalance())?.pools[input.operation.budget] ?? null;
+      if (observed !== null && observed.remaining <= 0) {
+        if (held !== undefined) return cachedAnswer<T>(held, input.operation.budget, observed.reset_at, now());
+        throw new GithubPoolUnavailableError(input.operation.budget, observed.reset_at);
+      }
       const parameters = { ...(input.parameters ?? {}) } as Record<string, unknown>;
       const callerHeaders = isRecord(parameters.headers) ? parameters.headers : {};
       parameters.headers = {
@@ -204,7 +267,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         const response = await octokit.request(input.route, parameters);
         const headers = response.headers as GithubResponseHeaders;
         const etag = header(headers, "etag");
-        if (etag !== undefined) etags.set(input.cacheKey, { etag, data: response.data, headers });
+        if (etag !== undefined) etags.set(input.cacheKey, { etag, data: response.data, headers, storedAt: now() });
         await options.attribution?.record({ operation: input.operation, cost: 1, actor: input.actor });
         return { data: response.data as T, headers, quotaFree: false };
       } catch (error) {
@@ -218,11 +281,18 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
           const responseHeaders = errorHeaders(error);
           const headers = { ...held.headers, ...responseHeaders };
           const etag = header(headers, "etag") ?? held.etag;
-          etags.set(input.cacheKey, { etag, data: held.data, headers });
+          etags.set(input.cacheKey, { etag, data: held.data, headers, ...(held.storedAt ? { storedAt: held.storedAt } : {}) });
           await options.attribution?.record({ operation: input.operation, cost: 0, actor: input.actor });
           return { data: held.data as T, headers, quotaFree: true };
         }
         if (httpStatus(error) === 401) throw new GithubCredentialError({ cause: error });
+        if (isGithubRateLimitError(error)) {
+          if (held !== undefined) {
+            const unavailable = unavailableFromError(input.operation.budget, error);
+            return cachedAnswer<T>(held, input.operation.budget, unavailable.resetAt, now());
+          }
+          throw unavailableFromError(input.operation.budget, error);
+        }
         throw error;
       }
     };
@@ -233,11 +303,12 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
     readonly reject: (error: unknown) => void;
   }
 
-  const pendingSingleObjects = new Map<GithubSingleObjectRequest["kind"], PendingSingleObjectRead[]>();
+  const pendingSingleObjects = new Map<string, PendingSingleObjectRead[]>();
   let singleObjectFlushScheduled = false;
 
   const readSingleObjectRest = async (
     pending: PendingSingleObjectRead,
+    routing?: GithubRailRouting,
   ): Promise<void> => {
     const input = pending.input;
     const pull = input.kind === "pr";
@@ -259,6 +330,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         data: input.project ? input.project(answer.data, "rest") : answer.data,
         surface: "rest",
         quotaFree: answer.quotaFree,
+        ...(routing ? { routing } : {}),
       });
     } catch (error) {
       pending.reject(error);
@@ -267,6 +339,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
 
   const readSingleObjectBatch = async (
     group: readonly PendingSingleObjectRead[],
+    routing?: GithubRailRouting,
   ): Promise<void> => {
     try {
       const aliased = buildSingleObjectReadsQuery(group.map(({ input }) => input));
@@ -292,6 +365,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
               : row.value,
             surface: "graphql",
             quotaFree: false,
+            ...(routing ? { routing } : {}),
           });
         }
       });
@@ -302,20 +376,57 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
   };
 
   const flushSingleObjects = async (): Promise<void> => {
-    let balance: GithubBalance | null = null;
-    try {
-      balance = await options.balance?.() ?? null;
-    } catch {
-      // An unanswered ask is unknown, never a reason to strand the queue or
-      // infer pressure. Unknown keeps the original single-object REST route.
-    }
+    const balance = await readBalance();
     const threshold = githubSingleObjectCoalescingThreshold(balance);
     singleObjectFlushScheduled = false;
     const groups = [...pendingSingleObjects.values()];
     pendingSingleObjects.clear();
     await Promise.all(groups.map(async (group) => {
-      if (group.length > threshold) await readSingleObjectBatch(group);
-      else await Promise.all(group.map(readSingleObjectRest));
+      const explicit = group[0]!.input.rail;
+      const requested = explicit ?? "rest";
+      const source = balance?.pools[requested] ?? null;
+      const fallback: GithubApiSurface = requested === "rest" ? "graphql" : "rest";
+      const destination = balance?.pools[fallback] ?? null;
+      const requestedCache = requested === "rest" && group.every(({ input }) => etags.get(input.cacheKey) !== undefined);
+      const fallbackCache = fallback === "rest" && group.every(({ input }) => etags.get(input.cacheKey) !== undefined);
+      let selected = requested;
+      let routing: GithubRailRouting | undefined;
+
+      if (source !== null && source.remaining <= 0) {
+        if ((destination !== null && destination.remaining > 0) || fallbackCache) {
+          selected = fallback;
+          routing = {
+            requestedRail: requested,
+            selectedRail: selected,
+            rerouted: true,
+            pool: requested,
+            resetAt: source.reset_at,
+            reason: `${requested} pool is exhausted until ${source.reset_at}; used the equivalent ${selected} rail`,
+          };
+        } else if (!requestedCache) {
+          const error = new GithubPoolUnavailableError(requested, source.reset_at, "the equivalent rail has no known budget");
+          group.forEach((pending) => pending.reject(error));
+          return;
+        }
+      } else if (explicit !== undefined) {
+        routing = {
+          requestedRail: requested,
+          selectedRail: selected,
+          rerouted: false,
+          pool: requested,
+          resetAt: source?.reset_at ?? null,
+          reason: source === null
+            ? `${requested} pool balance is unknown, so the explicit rail is honored reactively`
+            : `${requested} pool has ${source.remaining} remaining, so the explicit rail is honored`,
+        };
+      }
+
+      const warm = group.some(({ input }) => etags.get(input.cacheKey) !== undefined);
+      if (selected === "graphql" || (explicit === undefined && !warm && group.length > threshold)) {
+        await readSingleObjectBatch(group, routing);
+      } else {
+        await Promise.all(group.map((pending) => readSingleObjectRest(pending, routing)));
+      }
     }));
   };
 
@@ -323,23 +434,15 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
     // Rule 1 and its counter-rule stay together here: one object prefers REST,
     // while enough COLD peers may coalesce. A held validator can answer 304 for
     // zero primary quota, so it never gets traded for a charged GraphQL node.
-    if (etags.get(input.cacheKey) !== undefined) {
-      return new Promise<GithubSingleObjectAnswer<T>>((resolve, reject) => {
-        void readSingleObjectRest({
-          input,
-          resolve: resolve as (answer: GithubSingleObjectAnswer<unknown>) => void,
-          reject,
-        });
-      });
-    }
     return new Promise<GithubSingleObjectAnswer<T>>((resolve, reject) => {
-      const group = pendingSingleObjects.get(input.kind) ?? [];
+      const groupKey = `${input.kind}:${input.rail ?? "default"}`;
+      const group = pendingSingleObjects.get(groupKey) ?? [];
       group.push({
         input,
         resolve: resolve as (answer: GithubSingleObjectAnswer<unknown>) => void,
         reject,
       });
-      pendingSingleObjects.set(input.kind, group);
+      pendingSingleObjects.set(groupKey, group);
       if (!singleObjectFlushScheduled) {
         singleObjectFlushScheduled = true;
         // A zero-delay task collects reads started by adjacent promise jobs too;
@@ -385,6 +488,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
       attribution?: GithubGraphqlAttribution,
     ): Promise<T> {
       try {
+        refuseSpentPool(await readBalance(), attribution?.operation.budget ?? "graphql");
         const answer = await octokit.graphql(query, variables) as T;
         if (attribution) {
           // Generic GraphQL does not expose the response's point cost. One is
@@ -399,10 +503,44 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         return answer;
       } catch (error) {
         if (httpStatus(error) === 401) throw new GithubCredentialError({ cause: error });
+        if (isGithubRateLimitError(error)) {
+          throw unavailableFromError(attribution?.operation.budget ?? "graphql", error);
+        }
         throw error;
       }
     },
   };
+}
+
+function cachedAnswer<T>(
+  held: GithubEtagEntry,
+  pool: GithubRateBudget,
+  resetAt: string,
+  now: string,
+): GithubRestAnswer<T> {
+  const current = Date.parse(now);
+  const stored = held.storedAt === undefined ? Number.NaN : Date.parse(held.storedAt);
+  return {
+    data: held.data as T,
+    headers: held.headers,
+    quotaFree: true,
+    degraded: {
+      source: "cache",
+      pool,
+      resetAt,
+      ageMs: Number.isFinite(current) && Number.isFinite(stored) ? Math.max(0, current - stored) : null,
+      reason: `${pool} pool is exhausted until ${resetAt}; serving the last-known answer instead of going dark`,
+    },
+  };
+}
+
+function unavailableFromError(pool: GithubRateBudget, error: unknown): GithubPoolUnavailableError {
+  const headers = errorHeaders(error);
+  const resetSeconds = Number(header(headers, "x-ratelimit-reset"));
+  const resetAt = Number.isFinite(resetSeconds) && resetSeconds > 0
+    ? new Date(resetSeconds * 1_000).toISOString()
+    : "an unknown reset instant";
+  return new GithubPoolUnavailableError(pool, resetAt, "GitHub refused the live request", { cause: error });
 }
 
 function hasNextPage(headers: GithubResponseHeaders): boolean {
@@ -412,6 +550,7 @@ function hasNextPage(headers: GithubResponseHeaders): boolean {
 
 /** Primary/secondary quota refusal, distinct from 304 and transport failure. */
 export function isGithubRateLimitError(error: unknown): boolean {
+  if (error instanceof GithubPoolUnavailableError) return true;
   const status = httpStatus(error);
   const headers = errorHeaders(error);
   return status === 429 ||

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -46,23 +46,32 @@ export {
 
 export {
   GithubCredentialError,
+  GithubPoolUnavailableError,
   createGithubClient,
   createMemoryGithubEtagStore,
   githubSingleObjectCoalescingThreshold,
   isGithubRateLimitError,
   type CreateGithubClientOptions,
   type GithubClient,
+  type GithubCachedFallback,
   type GithubConditionalRestRequest,
   type GithubEtagEntry,
   type GithubEtagStore,
   type GithubGraphqlAttribution,
   type GithubRequestFetch,
+  type GithubRailRouting,
   type GithubPaginatedRestAnswer,
   type GithubResponseHeaders,
   type GithubRestAnswer,
   type GithubSingleObjectAnswer,
   type GithubSingleObjectRequest,
 } from "./conditional-client.js";
+
+export {
+  createGithubBalanceStore,
+  type CreateGithubBalanceStoreOptions,
+  type GithubBalanceStore,
+} from "./balance-store.js";
 
 export {
   GITHUB_BALANCE_CADENCE,

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -12,6 +12,7 @@
     "./surface.js": "./surface.ts",
     "./rest-plan.js": "./rest-plan.ts",
     "./balance.js": "./balance.ts",
+    "./balance-store.js": "./balance-store.ts",
     "./cache.js": "./cache.ts"
   },
   "dependencies": {

--- a/packages/github/surface.test.ts
+++ b/packages/github/surface.test.ts
@@ -57,7 +57,7 @@ const PINNED: ReadonlyArray<
   ["issue develop", "write", "single-object", undefined, "graphql", "graphql", null],
   ["pr create", "write", "single-object", undefined, "rest", "rest", null],
   ["pr comment", "write", "single-object", undefined, "rest", "rest", null],
-  ["pr merge", "write", "single-object", undefined, "graphql", "graphql", null],
+  ["pr merge", "write", "single-object", undefined, "rest", "rest", null],
   ["pr close", "write", "single-object", undefined, "graphql", "graphql", null],
   ["pr edit", "write", "single-object", undefined, "graphql", "graphql", null],
   ["pr ready", "write", "single-object", undefined, "graphql", "graphql", null],
@@ -263,6 +263,7 @@ describe("the router", () => {
     expect(routeGithubArgs(["issue", "comment", "42", "--body", "x"]).surface).toBe("rest");
     expect(routeGithubArgs(["issue", "create", "--title", "x"]).surface).toBe("graphql");
     expect(routeGithubArgs(["pr", "create", "--title", "x"]).surface).toBe("rest");
+    expect(routeGithubArgs(["pr", "merge", "42", "--merge"]).surface).toBe("rest");
     expect(routeGithubArgs(["issue", "edit", "42", "--add-label", "x"]).surface).toBe("graphql");
   });
 

--- a/packages/github/surface.ts
+++ b/packages/github/surface.ts
@@ -200,7 +200,7 @@ export const GITHUB_OPERATIONS: readonly GithubOperation[] = [
   write("issue develop", "graphql", "graphql", "linked-branch creation is a GraphQL mutation"),
   write("pr create", "rest", "rest", "gh POSTs to `repos/{o}/{r}/pulls`, a REST request"),
   write("pr comment", "rest", "rest", "a pull request comment is an issue comment: the same REST POST"),
-  write("pr merge", "graphql", "graphql", "gh merges with the mergePullRequest mutation"),
+  write("pr merge", "rest", "rest", "the default merge uses PUT `repos/{o}/{r}/pulls/{n}/merge` so a dry GraphQL pool cannot strand a finished Worker"),
   write("pr close", "graphql", "graphql", "gh closes with a GraphQL mutation"),
   write("pr edit", "graphql", "graphql", "gh edits with GraphQL mutations"),
   write("pr ready", "graphql", "graphql", "marking ready-for-review is a GraphQL mutation"),

--- a/packages/shared/lane-retention.test.ts
+++ b/packages/shared/lane-retention.test.ts
@@ -35,6 +35,7 @@ describe("shared lane retention", () => {
       targetRatio: 0.5,
     });
     expect(LANE_RETENTION_REGISTRY["github-spend"].maxBytes).toBe(8 * 1024 * 1024);
+    expect(LANE_RETENTION_REGISTRY["github-balance"].maxBytes).toBe(64 * 1024);
     expect(LANE_RETENTION_REGISTRY["castle-singleton-events"].maxBytes).toBe(2 * 1024 * 1024);
     expect(LANE_RETENTION_REGISTRY["rsp-telemetry-corrections"].maxBytes).toBe(1024 * 1024);
     expect(LANE_RETENTION_REGISTRY["death-attributions"].maxAgeMs).toBe(14 * 24 * 60 * 60 * 1_000);

--- a/packages/shared/lane-retention.ts
+++ b/packages/shared/lane-retention.ts
@@ -62,6 +62,12 @@ export const LANE_RETENTION_REGISTRY = {
     maxBytes: 8 * MIB,
     targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
   },
+  "github-balance": {
+    // One current three-pool TOON snapshot. A small hard ceiling makes schema
+    // growth visible instead of letting a singleton state file drift unbounded.
+    maxBytes: 64 * 1024,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
   "castle-singleton-events": {
     maxBytes: 2 * MIB,
     targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,


### PR DESCRIPTION
Draft route for the 24-commit branch the engine's deadend audit flagged as orphaned work (pushed work with no open pull request). Opened so the resuming worker has a route to main; not ready for review until the branch's remaining slices land.

Refs #3663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrKC117zw4RxnBrTysaeAp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789093971&installation_model_id=20659&pr_number=3700&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3700&signature=f216b5838b2e86eee700a5cc48427ab97e98ff677ba5076c03f941dddb7bdc0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->