### PR TITLE
fix: keep incumbent daemon until successor handshake

### DIFF
--- a/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
@@ -43,7 +43,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 export type CanaryLaneVariant = "healthy" | "unroutable";
 
 /** Whether a daemon answers on this sandbox's session socket. */
-export type CanaryDaemonState = "up" | "down";
+export type CanaryDaemonState = "up" | "down" | "broken-successor";
 
 export interface CanarySandbox {
   /** Repo root the workers are created in. */
@@ -280,9 +280,16 @@ export async function createCanarySandbox(
     env.REDSKILLED_BIN = daemonBin;
   }
 
+  if (daemon === "broken-successor") {
+    const cache = join(env.HOME, ".cache", "red-skills", "bundles");
+    await mkdir(cache, { recursive: true });
+    await writeFile(join(cache, "redskilled-1.0.1.bundle.min.mjs"), "process.exit(2);\n", "utf8");
+    env.REDSKILLED_NO_REGISTRY_PROBE = "1";
+  }
+
   daemonPaths.push(resolveRedskilledPaths({ env }));
 
-  if (daemon === "up") await startCanaryDaemon(built.redskilled, env, tracker);
+  if (daemon !== "down") await startCanaryDaemon(built.redskilled, env, tracker, daemon);
 
   return { root, mcpEntry, runtimeRoot, env, trackerRequests: tracker.requests };
 }
@@ -294,6 +301,7 @@ async function startCanaryDaemon(
   entry: string,
   env: Record<string, string>,
   tracker: CanaryTracker,
+  state: Exclude<CanaryDaemonState, "down"> = "up",
 ): Promise<void> {
   const paths = resolveRedskilledPaths({ env });
   await mkdir(dirname(paths.socketPath), { recursive: true, mode: 0o700 });
@@ -309,7 +317,8 @@ async function startCanaryDaemon(
       "--machine-id-hash", paths.machineIdHash,
       // Longer than any canary walk: an idle exit mid-probe would read as a
       // broken socket boundary when it is only a bored daemon.
-      "--idle-ms", "600000",
+      "--idle-ms", state === "broken-successor" ? "100" : "600000",
+      ...(state === "broken-successor" ? ["--daemon-version", "1.0.0"] : []),
       // The lane's own cadence, compressed. The production windows are fifteen
       // seconds apiece and a probe that waited two of them would time out on a
       // healthy host; what is under test is that the loop RUNS, not how slowly.

--- a/apps/dev/tests/mcp-lane-canary-e2e.test.ts
+++ b/apps/dev/tests/mcp-lane-canary-e2e.test.ts
@@ -23,6 +23,8 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
 import { decode } from "@reddb-io/toon";
+import { readRedskilledHostState } from "@reddb-io/redskilled/client";
+import { readRedskilledEvents } from "@reddb-io/redskilled/event-lane";
 import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
 import { runMcpLaneCanary } from "../src/core/mcp-lane-canary.js";
 import {
@@ -145,6 +147,30 @@ describe("the socket boundary the lane grew under ADR 0130 (#2794, #2851)", () =
       ]);
       expect(socketPath).toBeTruthy();
       expect(existsSync(socketPath!)).toBe(true);
+    },
+    TIMEOUT,
+  );
+});
+
+describe("MCP lane canary — failed version takeover", () => {
+  it(
+    "keeps the incumbent live when a deliberately broken successor exits at boot",
+    async () => {
+      const sandbox = await createCanarySandbox("healthy", "broken-successor");
+      const paths = resolveRedskilledPaths({ env: sandbox.env });
+      const deadline = Date.now() + 30_000;
+      let failure = false;
+      while (Date.now() < deadline) {
+        failure = (await readRedskilledEvents(paths.eventLanePath)).some(
+          (event) => event.event === "daemon-takeover-failed",
+        );
+        if (failure) break;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+
+      expect(failure).toBe(true);
+      const incumbent = await readRedskilledHostState(paths, { readyTimeoutMs: 5_000 });
+      expect(incumbent.daemon_version).toBe("1.0.0");
     },
     TIMEOUT,
   );

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -68,7 +68,7 @@ import {
   uninstallRedskilledUnit,
   type RedskilledUnitIO,
 } from "./supervision.js";
-import { isRedskilledSupervised } from "./self-replace.js";
+import { awaitRedskilledTakeoverCommit, isRedskilledSupervised } from "./self-replace.js";
 import { stabilizeRedskilledEntry } from "./stable-bundle.js";
 
 /**
@@ -492,6 +492,10 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
     const paths = servePaths(values);
     let daemon;
     try {
+      // A replacement boots this entry while the incumbent still owns the
+      // session. Reaching here proves the successor loaded and configured; it
+      // waits for the incumbent's commit before competing for the singleton.
+      await awaitRedskilledTakeoverCommit();
       daemon = await startRedskilledDaemon({
         paths,
         idleMs: hostSettings.idleMs,

--- a/apps/redskilled/src/daemon-events.ts
+++ b/apps/redskilled/src/daemon-events.ts
@@ -25,6 +25,13 @@ export interface RecordDaemonDeathInput {
   readonly reason?: "silent-death";
 }
 
+export interface RecordDaemonTakeoverFailedInput {
+  readonly ts: string;
+  readonly pid: number;
+  readonly socketPath: string;
+  readonly detail: string;
+}
+
 export const REDSKILLED_DAEMON_EVENT_PREFIX = "daemon:";
 
 export function buildDaemonStopEvent(input: RecordDaemonStopInput): RedskilledHostEvent {
@@ -39,9 +46,19 @@ export function buildDaemonDeathEvent(input: RecordDaemonDeathInput): Redskilled
   return buildDaemonLifecycleEvent("daemon-death", input, input.reason ?? "silent-death", null);
 }
 
+export function buildDaemonTakeoverFailedEvent(
+  input: RecordDaemonTakeoverFailedInput,
+): RedskilledHostEvent {
+  return buildDaemonLifecycleEvent("daemon-takeover-failed", input, "successor-boot-failed", null);
+}
+
 function buildDaemonLifecycleEvent(
-  kind: "daemon-start" | "daemon-death" | "daemon-stop",
-  input: RecordDaemonStartInput | RecordDaemonDeathInput | RecordDaemonStopInput,
+  kind: "daemon-start" | "daemon-death" | "daemon-stop" | "daemon-takeover-failed",
+  input:
+    | RecordDaemonStartInput
+    | RecordDaemonDeathInput
+    | RecordDaemonStopInput
+    | RecordDaemonTakeoverFailedInput,
   reason: string,
   signal: string | null | undefined,
 ): RedskilledHostEvent {

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -188,10 +188,12 @@ import {
   prepareRedskilledReplacement,
   probePublishedRedskilledVersion,
   readPublishedObservation,
+  stageRedskilledReplacementSuccessor,
   type RedskilledMajorHold,
   type RedskilledPublishedObservation,
   type RedskilledReplacementDecision,
   type RedskilledReplacementHoldReason,
+  type RedskilledSuccessorControl,
 } from "../self-replace.js";
 import {
   createRedskilledLeaseStore,
@@ -451,6 +453,9 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   let publishedChecks = 0;
   let publishedHoldReason: RedskilledReplacementHoldReason | null = null;
   let replacementState: "none" | "pending" | "in-progress" = "none";
+  // A broken published entry must not be hammered on every overlapping timer or
+  // idle decision. The incumbent keeps serving during this one-minute hold.
+  let nextTakeoverAttemptAtMs = 0;
   // The world's newest version whatever its major, and the hold it implies. Kept
   // beside the in-major answer because that one is capped by construction: on its
   // own it cannot tell a current daemon from one holding at a boundary (#2926).
@@ -1874,17 +1879,43 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   async function checkForReplacement(): Promise<RedskilledReplacementDecision> {
     const decision = await observePublishedVersion();
     if (decision.act !== "replace" || replacementState === "in-progress") return decision;
+    const nowMs = Date.parse(clock());
+    if (Number.isFinite(nowMs) && nowMs < nextTakeoverAttemptAtMs) return decision;
     // The successor is found FIRST. A published bundle this host cannot reach
     // costs the upgrade and nothing else: the throw leaves this daemon serving,
     // still holding every Worker, still reporting the version it actually runs.
     const prepared = prepareRedskilledReplacement(decision, replacementIO, paths, idleMs);
+    if (Number.isFinite(nowMs)) nextTakeoverAttemptAtMs = nowMs + 60_000;
+    let successor: RedskilledSuccessorControl | undefined;
+    try {
+      successor = await stageRedskilledReplacementSuccessor(prepared, paths, {
+        ...(idleMs == null ? {} : { idleMs }),
+        io: replacementIO,
+      });
+    } catch {
+      replacementState = "pending";
+      await eventLane.recordDaemonTakeoverFailed({
+        ts: clock(),
+        pid: owner.pid,
+        socketPath: paths.socketPath,
+        detail:
+          `redskilled ${decision.to} failed its takeover boot handshake; incumbent ${daemonVersion} remains live`,
+      });
+      return decision;
+    }
     replacementState = "in-progress";
     await eventLane.flush().catch(() => undefined);
     await registrationIntentStore.flush().catch(() => undefined);
-    await stop({ reason: "replaced" });
+    try {
+      await stop({ reason: "replaced" });
+    } catch (error) {
+      successor?.abort();
+      throw error;
+    }
     completeRedskilledReplacement(prepared, paths, {
       ...(idleMs == null ? {} : { idleMs }),
       io: replacementIO,
+      ...(successor == null ? {} : { successor }),
     });
     return decision;
   }

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -177,7 +177,6 @@ import {
   type RedskilledWorkerLogLine,
 } from "../worker-log.js";
 import {
-  completeRedskilledReplacement,
   DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
   isLocalRedskilledBuild,
   isRedskilledBornByReplacement,
@@ -185,15 +184,12 @@ import {
   localRedskilledPublishedEvidence,
   planRedskilledMajorHold,
   planRedskilledReplacement,
-  prepareRedskilledReplacement,
   probePublishedRedskilledVersion,
   readPublishedObservation,
-  stageRedskilledReplacementSuccessor,
   type RedskilledMajorHold,
   type RedskilledPublishedObservation,
   type RedskilledReplacementDecision,
   type RedskilledReplacementHoldReason,
-  type RedskilledSuccessorControl,
 } from "../self-replace.js";
 import {
   createRedskilledLeaseStore,
@@ -218,6 +214,7 @@ import {
   bootRefusalFromLog,
   observedWorkerDeath,
 } from "./tunables.js";
+import { replaceWithViableSuccessor } from "./takeover.js";
 import { createRemotePollDeadline } from "./remote-poll.js";
 import { createConfiguredRedskilledSelfPingMonitor } from "./self-ping.js";
 // Error moved to ./daemon/errors.ts — keep re-export for backward compat
@@ -453,8 +450,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   let publishedChecks = 0;
   let publishedHoldReason: RedskilledReplacementHoldReason | null = null;
   let replacementState: "none" | "pending" | "in-progress" = "none";
-  // A broken published entry must not be hammered on every overlapping timer or
-  // idle decision. The incumbent keeps serving during this one-minute hold.
+  // Do not hammer one broken successor from overlapping checks.
   let nextTakeoverAttemptAtMs = 0;
   // The world's newest version whatever its major, and the hold it implies. Kept
   // beside the in-major answer because that one is capped by construction: on its
@@ -1869,54 +1865,27 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     return decision;
   }
 
-  /**
-   * Observe, then hand the session over when a newer version is published.
-   *
-   * The order is the contract: flush the lane, let go of the socket and the
-   * lease, and only then start the successor — a successor racing this process
-   * for the exclusive bind would die, and the machine would keep the old bundle.
-   */
+  /** Observe, prove a viable successor, then hand over the session. */
   async function checkForReplacement(): Promise<RedskilledReplacementDecision> {
     const decision = await observePublishedVersion();
     if (decision.act !== "replace" || replacementState === "in-progress") return decision;
     const nowMs = Date.parse(clock());
     if (Number.isFinite(nowMs) && nowMs < nextTakeoverAttemptAtMs) return decision;
-    // The successor is found FIRST. A published bundle this host cannot reach
-    // costs the upgrade and nothing else: the throw leaves this daemon serving,
-    // still holding every Worker, still reporting the version it actually runs.
-    const prepared = prepareRedskilledReplacement(decision, replacementIO, paths, idleMs);
     if (Number.isFinite(nowMs)) nextTakeoverAttemptAtMs = nowMs + 60_000;
-    let successor: RedskilledSuccessorControl | undefined;
-    try {
-      successor = await stageRedskilledReplacementSuccessor(prepared, paths, {
-        ...(idleMs == null ? {} : { idleMs }),
-        io: replacementIO,
-      });
-    } catch {
-      replacementState = "pending";
-      await eventLane.recordDaemonTakeoverFailed({
-        ts: clock(),
-        pid: owner.pid,
-        socketPath: paths.socketPath,
-        detail:
-          `redskilled ${decision.to} failed its takeover boot handshake; incumbent ${daemonVersion} remains live`,
-      });
-      return decision;
-    }
-    replacementState = "in-progress";
-    await eventLane.flush().catch(() => undefined);
-    await registrationIntentStore.flush().catch(() => undefined);
-    try {
-      await stop({ reason: "replaced" });
-    } catch (error) {
-      successor?.abort();
-      throw error;
-    }
-    completeRedskilledReplacement(prepared, paths, {
-      ...(idleMs == null ? {} : { idleMs }),
+    const replaced = await replaceWithViableSuccessor({
+      decision,
       io: replacementIO,
-      ...(successor == null ? {} : { successor }),
+      paths,
+      ...(idleMs == null ? {} : { idleMs }),
+      incumbentVersion: daemonVersion,
+      incumbentPid: owner.pid,
+      clock,
+      eventLane,
+      flushRegistration: () => registrationIntentStore.flush(),
+      stop: () => stop({ reason: "replaced" }),
+      onViable: () => { replacementState = "in-progress"; },
     });
+    if (!replaced) replacementState = "pending";
     return decision;
   }
 

--- a/apps/redskilled/src/daemon/takeover.ts
+++ b/apps/redskilled/src/daemon/takeover.ts
@@ -1,0 +1,63 @@
+/** The transactional boundary between a live incumbent and its successor. */
+import type { RedskilledEventLane } from "../event-lane.js";
+import type { RedskilledPaths } from "../paths.js";
+import {
+  completeRedskilledReplacement,
+  prepareRedskilledReplacement,
+  stageRedskilledReplacementSuccessor,
+  type RedskilledReplacementDecision,
+  type RedskilledReplacementIO,
+} from "../self-replace.js";
+
+export interface ReplaceWithViableSuccessorInput {
+  readonly decision: Extract<RedskilledReplacementDecision, { act: "replace" }>;
+  readonly io: RedskilledReplacementIO;
+  readonly paths: RedskilledPaths;
+  readonly idleMs?: number;
+  readonly incumbentVersion: string;
+  readonly incumbentPid: number;
+  readonly clock: () => string;
+  readonly eventLane: RedskilledEventLane;
+  readonly flushRegistration: () => Promise<void>;
+  readonly stop: () => Promise<void>;
+  readonly onViable: () => void;
+}
+
+/** Prove succession before stopping the incumbent; false leaves it live. */
+export async function replaceWithViableSuccessor(
+  input: ReplaceWithViableSuccessorInput,
+): Promise<boolean> {
+  const prepared = prepareRedskilledReplacement(input.decision, input.io, input.paths, input.idleMs);
+  const options = {
+    ...(input.idleMs == null ? {} : { idleMs: input.idleMs }),
+    io: input.io,
+  };
+  let successor;
+  try {
+    successor = await stageRedskilledReplacementSuccessor(prepared, input.paths, options);
+  } catch {
+    await input.eventLane.recordDaemonTakeoverFailed({
+      ts: input.clock(),
+      pid: input.incumbentPid,
+      socketPath: input.paths.socketPath,
+      detail:
+        `redskilled ${input.decision.to} failed its takeover boot handshake; ` +
+        `incumbent ${input.incumbentVersion} remains live`,
+    });
+    return false;
+  }
+  input.onViable();
+  await input.eventLane.flush().catch(() => undefined);
+  await input.flushRegistration().catch(() => undefined);
+  try {
+    await input.stop();
+  } catch (error) {
+    successor?.abort();
+    throw error;
+  }
+  completeRedskilledReplacement(prepared, input.paths, {
+    ...options,
+    ...(successor == null ? {} : { successor }),
+  });
+  return true;
+}

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -96,7 +96,8 @@ export const REDSKILLED_WORKER_EVENT_KINDS = [
       | "demand-refusal"
       | "daemon-start"
       | "daemon-death"
-      | "daemon-stop",
+      | "daemon-stop"
+      | "daemon-takeover-failed",
   ): boolean;
 };
 
@@ -120,6 +121,7 @@ export const REDSKILLED_DAEMON_EVENT_KINDS = [
   "daemon-start",
   "daemon-death",
   "daemon-stop",
+  "daemon-takeover-failed",
 ] as const;
 
 export type RedskilledDaemonEventKind = typeof REDSKILLED_DAEMON_EVENT_KINDS[number];
@@ -265,6 +267,14 @@ export interface RecordDemandRefusalInput {
   readonly detail: string;
 }
 
+/** One successor that failed its boot handshake while the incumbent stayed live. */
+export interface RecordDaemonTakeoverFailedInput {
+  readonly ts: string;
+  readonly pid: number;
+  readonly socketPath: string;
+  readonly detail: string;
+}
+
 /** Build one event from a Worker view. PURE. */
 export function buildHostEvent(input: RecordEventInput | RecordWorkerEventInput): RedskilledHostEvent {
   const budget = input.worker.budget ?? {};
@@ -341,6 +351,43 @@ export function buildDemandRefusalEvent(input: RecordDemandRefusalInput): Redski
   };
 }
 
+/** Build a failed takeover without forging a daemon departure. PURE. */
+export function buildDaemonTakeoverFailedEvent(
+  input: RecordDaemonTakeoverFailedInput,
+): RedskilledHostEvent {
+  return {
+    version: 1,
+    ts: input.ts,
+    kind: "daemon-takeover-failed",
+    event: "daemon-takeover-failed",
+    worker_id: `${REDSKILLED_DAEMON_EVENT_PREFIX}${input.pid}`,
+    project_label: "",
+    pid: input.pid,
+    workspace_path: input.socketPath,
+    fork_sha: null,
+    log_path: null,
+    isolated: false,
+    unit: null,
+    memory_high: null,
+    memory_max: null,
+    cpu_weight: null,
+    admission_verdict: null,
+    phase: null,
+    step: null,
+    tokens: null,
+    tools: null,
+    runner: null,
+    model: null,
+    base_head_sha: null,
+    base_commits_ahead: null,
+    heal_kind: null,
+    detail: input.detail,
+    exit_code: null,
+    signal: null,
+    reason: "successor-boot-failed",
+  };
+}
+
 /**
  * An open lane writer.
  *
@@ -362,6 +409,8 @@ export interface RedskilledEventLane {
   recordDaemonStart(input: RecordDaemonStartInput): Promise<RedskilledHostEvent>;
   /** Append a successor's retroactive account of an unrecorded predecessor death. */
   recordDaemonDeath(input: RecordDaemonDeathInput): Promise<RedskilledHostEvent>;
+  /** Append a failed takeover while the incumbent still owns the live session. */
+  recordDaemonTakeoverFailed(input: RecordDaemonTakeoverFailedInput): Promise<RedskilledHostEvent>;
   /**
    * Append the daemon's own stop; resolves once the bytes are on the lane.
    *
@@ -418,6 +467,7 @@ export function createRedskilledEventLane(
     recordDemandRefusal: (input) => append(buildDemandRefusalEvent(input)),
     recordDaemonStart: (input) => append(buildDaemonStartEvent(input)),
     recordDaemonDeath: (input) => append(buildDaemonDeathEvent(input)),
+    recordDaemonTakeoverFailed: (input) => append(buildDaemonTakeoverFailedEvent(input)),
     recordDaemonStop: (input) => append(buildDaemonStopEvent(input)),
     read: () => readRedskilledEvents(path),
     flush: async () => {

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -34,18 +34,22 @@ import {
   buildDaemonDeathEvent,
   buildDaemonStartEvent,
   buildDaemonStopEvent,
+  buildDaemonTakeoverFailedEvent,
   type RecordDaemonDeathInput,
   type RecordDaemonStartInput,
   type RecordDaemonStopInput,
+  type RecordDaemonTakeoverFailedInput,
 } from "./daemon-events.js";
 export {
   buildDaemonDeathEvent,
   buildDaemonStartEvent,
   buildDaemonStopEvent,
+  buildDaemonTakeoverFailedEvent,
   REDSKILLED_DAEMON_EVENT_PREFIX,
   type RecordDaemonDeathInput,
   type RecordDaemonStartInput,
   type RecordDaemonStopInput,
+  type RecordDaemonTakeoverFailedInput,
 } from "./daemon-events.js";
 import { decodeLaneRows } from "./event-lane-decode.js";
 import {
@@ -267,14 +271,6 @@ export interface RecordDemandRefusalInput {
   readonly detail: string;
 }
 
-/** One successor that failed its boot handshake while the incumbent stayed live. */
-export interface RecordDaemonTakeoverFailedInput {
-  readonly ts: string;
-  readonly pid: number;
-  readonly socketPath: string;
-  readonly detail: string;
-}
-
 /** Build one event from a Worker view. PURE. */
 export function buildHostEvent(input: RecordEventInput | RecordWorkerEventInput): RedskilledHostEvent {
   const budget = input.worker.budget ?? {};
@@ -348,43 +344,6 @@ export function buildDemandRefusalEvent(input: RecordDemandRefusalInput): Redski
     exit_code: null,
     signal: null,
     reason: null,
-  };
-}
-
-/** Build a failed takeover without forging a daemon departure. PURE. */
-export function buildDaemonTakeoverFailedEvent(
-  input: RecordDaemonTakeoverFailedInput,
-): RedskilledHostEvent {
-  return {
-    version: 1,
-    ts: input.ts,
-    kind: "daemon-takeover-failed",
-    event: "daemon-takeover-failed",
-    worker_id: `${REDSKILLED_DAEMON_EVENT_PREFIX}${input.pid}`,
-    project_label: "",
-    pid: input.pid,
-    workspace_path: input.socketPath,
-    fork_sha: null,
-    log_path: null,
-    isolated: false,
-    unit: null,
-    memory_high: null,
-    memory_max: null,
-    cpu_weight: null,
-    admission_verdict: null,
-    phase: null,
-    step: null,
-    tokens: null,
-    tools: null,
-    runner: null,
-    model: null,
-    base_head_sha: null,
-    base_commits_ahead: null,
-    heal_kind: null,
-    detail: input.detail,
-    exit_code: null,
-    signal: null,
-    reason: "successor-boot-failed",
   };
 }
 

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -38,7 +38,9 @@
  * PURE apart from the injected spawn, exit and existence lookups.
  */
 import { spawn } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { createConnection, createServer, type Socket } from "node:net";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { canonicalInvocation } from "@reddb-io/shared/canonical-invocation.js";
 import {
@@ -105,6 +107,13 @@ export const REDSKILLED_NO_REGISTRY_PROBE_ENV = "REDSKILLED_NO_REGISTRY_PROBE";
  * tight loop. A successor born this way waits for the ordinary interval instead.
  */
 export const REDSKILLED_BORN_BY_REPLACEMENT_ENV = "REDSKILLED_BORN_BY_REPLACEMENT";
+
+/** Private rendezvous carried only between an incumbent and its staged successor. */
+export const REDSKILLED_TAKEOVER_SOCKET_ENV = "REDSKILLED_TAKEOVER_SOCKET";
+export const REDSKILLED_TAKEOVER_TOKEN_ENV = "REDSKILLED_TAKEOVER_TOKEN";
+
+/** A boot that cannot reach the handshake inside this window is not viable. */
+export const DEFAULT_REDSKILLED_TAKEOVER_HANDSHAKE_MS = 10_000;
 
 /** True when a replacement started this process, so its boot check is not owed. */
 export function isRedskilledBornByReplacement(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -406,7 +415,10 @@ export interface RedskilledReplacementIO {
   /** Resolves what runs the new version; the version-pinned resolver by default. */
   readonly resolveEntry?: (version: string) => ResolvedRedskilledReplacementEntry;
   /** Starts the successor, detached; a real spawn by default. */
-  readonly spawnSuccessor?: (entry: ResolvedRedskilledReplacementEntry, argv: readonly string[]) => void;
+  readonly spawnSuccessor?: (
+    entry: ResolvedRedskilledReplacementEntry,
+    argv: readonly string[],
+  ) => void | RedskilledSuccessorControl | Promise<void | RedskilledSuccessorControl>;
   /** Repoints a supervising unit before the old daemon releases its socket. */
   readonly repointSupervisor?: (
     entry: ResolvedRedskilledReplacementEntry,
@@ -428,6 +440,14 @@ export interface PreparedRedskilledReplacement {
 
 export interface RedskilledReplacementOutcome extends PreparedRedskilledReplacement {
   readonly exitCode?: number;
+}
+
+/** A successor that reached its boot boundary and is waiting for ownership. */
+export interface RedskilledSuccessorControl {
+  /** Tell the viable successor that the incumbent has released the session. */
+  commit(): void;
+  /** Take back a staged successor when the incumbent cannot complete its stop. */
+  abort(): void;
 }
 
 /**
@@ -460,6 +480,28 @@ export function prepareRedskilledReplacement(
 }
 
 /**
+ * Start the successor while the incumbent still owns the live session.
+ *
+ * A production successor reaches the CLI boot boundary, proves that by answering
+ * a private handshake, then waits. Injected spawns may return no control handle;
+ * that preserves the public test seam while still making a rejected async boot a
+ * takeover failure rather than a daemon stop.
+ */
+export async function stageRedskilledReplacementSuccessor(
+  prepared: PreparedRedskilledReplacement,
+  target: RedskilledServeTarget,
+  options: { readonly idleMs?: number; readonly io?: RedskilledReplacementIO } = {},
+): Promise<RedskilledSuccessorControl | undefined> {
+  if (prepared.via === "supervisor-exit") return undefined;
+  const io = options.io ?? {};
+  const argv = [
+    ...prepared.entry.args,
+    ...redskilledServeArgv(target, options.idleMs == null ? {} : { idleMs: options.idleMs }),
+  ];
+  return await (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env, target))(prepared.entry, argv);
+}
+
+/**
  * Complete one replacement, on a daemon that has ALREADY let go of the session.
  *
  * The order is not negotiable: the old process releases the socket and the lease
@@ -470,23 +512,44 @@ export function prepareRedskilledReplacement(
 export function completeRedskilledReplacement(
   prepared: PreparedRedskilledReplacement,
   target: RedskilledServeTarget,
-  options: { readonly idleMs?: number; readonly io?: RedskilledReplacementIO } = {},
+  options: {
+    readonly idleMs?: number;
+    readonly io?: RedskilledReplacementIO;
+    readonly successor?: RedskilledSuccessorControl;
+  } = {},
 ): RedskilledReplacementOutcome {
   const io = options.io ?? {};
   if (prepared.via === "supervisor-exit") {
     (io.exit ?? defaultExit)(REDSKILLED_REPLACE_EXIT_CODE);
     return { ...prepared, exitCode: REDSKILLED_REPLACE_EXIT_CODE };
   }
+  if (options.successor != null) {
+    options.successor.commit();
+    return prepared;
+  }
   const argv = [
     ...prepared.entry.args,
     ...redskilledServeArgv(target, options.idleMs == null ? {} : { idleMs: options.idleMs }),
   ];
-  (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env))(prepared.entry, argv);
+  (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env, target))(prepared.entry, argv);
   return prepared;
 }
 
-function defaultSpawnSuccessor(env: NodeJS.ProcessEnv | undefined) {
-  return (entry: ResolvedRedskilledReplacementEntry, argv: readonly string[]): void => {
+function defaultSpawnSuccessor(env: NodeJS.ProcessEnv | undefined, target: RedskilledServeTarget) {
+  return async (
+    entry: ResolvedRedskilledReplacementEntry,
+    argv: readonly string[],
+  ): Promise<RedskilledSuccessorControl> => {
+    const handshakePath = join(dirname(target.socketPath), `.takeover-${process.pid}-${randomUUID().slice(0, 8)}.sock`);
+    const token = randomUUID();
+    const server = createServer();
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once("error", rejectListen);
+      server.listen(handshakePath, () => {
+        server.off("error", rejectListen);
+        resolveListen();
+      });
+    });
     const child = spawn(entry.command, [...argv], {
       detached: true,
       stdio: "ignore",
@@ -494,11 +557,112 @@ function defaultSpawnSuccessor(env: NodeJS.ProcessEnv | undefined) {
         ...(env ?? process.env),
         REDSKILLED_DAEMON: "1",
         [REDSKILLED_BORN_BY_REPLACEMENT_ENV]: "1",
+        [REDSKILLED_TAKEOVER_SOCKET_ENV]: handshakePath,
+        [REDSKILLED_TAKEOVER_TOKEN_ENV]: token,
       },
     });
-    child.on("error", () => undefined);
     child.unref();
+    return await new Promise<RedskilledSuccessorControl>((resolveReady, rejectReady) => {
+      let settled = false;
+      let peer: Socket | undefined;
+      const deadline = setTimeout(() => fail(new Error("successor did not answer the takeover handshake")),
+        DEFAULT_REDSKILLED_TAKEOVER_HANDSHAKE_MS);
+      deadline.unref();
+
+      const cleanupListener = (): void => {
+        clearTimeout(deadline);
+        child.off("error", onError);
+        child.off("exit", onExit);
+      };
+      const closeServer = (): void => {
+        server.close(() => rmSync(handshakePath, { force: true }));
+      };
+      const fail = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        cleanupListener();
+        peer?.destroy();
+        closeServer();
+        child.kill("SIGTERM");
+        rejectReady(error);
+      };
+      const onError = (): void => fail(new Error("successor failed before its takeover handshake"));
+      const onExit = (code: number | null): void =>
+        fail(new Error(`successor exited before its takeover handshake (code ${code ?? "unknown"})`));
+      child.once("error", onError);
+      child.once("exit", onExit);
+      server.on("connection", (socket) => {
+        if (peer != null) {
+          socket.destroy();
+          return;
+        }
+        peer = socket;
+        let line = "";
+        socket.setEncoding("utf8");
+        socket.on("data", (chunk: string) => {
+          line += chunk;
+          if (!line.includes("\n")) return;
+          if (line.slice(0, line.indexOf("\n")) !== token) {
+            fail(new Error("successor answered the takeover handshake with the wrong token"));
+            return;
+          }
+          if (settled) return;
+          settled = true;
+          cleanupListener();
+          resolveReady({
+            commit() {
+              socket.end("commit\n");
+              closeServer();
+            },
+            abort() {
+              socket.end("abort\n");
+              closeServer();
+              child.kill("SIGTERM");
+            },
+          });
+        });
+        socket.once("error", () => fail(new Error("successor takeover handshake disconnected")));
+        socket.once("close", () => fail(new Error("successor takeover handshake closed before readiness")));
+      });
+    });
   };
+}
+
+/** Wait at the successor's boot boundary until the incumbent grants ownership. */
+export async function awaitRedskilledTakeoverCommit(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const socketPath = env[REDSKILLED_TAKEOVER_SOCKET_ENV]?.trim();
+  const token = env[REDSKILLED_TAKEOVER_TOKEN_ENV]?.trim();
+  if (!socketPath && !token) return;
+  if (!socketPath || !token) throw new Error("incomplete redskilled takeover handshake");
+  await new Promise<void>((resolveCommit, rejectCommit) => {
+    const socket = createConnection(socketPath);
+    let line = "";
+    const deadline = setTimeout(() => {
+      socket.destroy();
+      rejectCommit(new Error("redskilled takeover commit timed out"));
+    }, DEFAULT_REDSKILLED_TAKEOVER_HANDSHAKE_MS);
+    deadline.unref();
+    const finish = (error?: Error): void => {
+      clearTimeout(deadline);
+      socket.destroy();
+      if (error == null) resolveCommit();
+      else rejectCommit(error);
+    };
+    socket.setEncoding("utf8");
+    socket.once("connect", () => socket.write(`${token}\n`));
+    socket.on("data", (chunk: string) => {
+      line += chunk;
+      if (!line.includes("\n")) return;
+      const verdict = line.slice(0, line.indexOf("\n"));
+      finish(verdict === "commit" ? undefined : new Error("redskilled takeover was aborted"));
+    });
+    socket.once("error", () => finish(new Error("redskilled takeover handshake failed")));
+    socket.once("close", () => {
+      if (!line.includes("\n")) finish(new Error("redskilled takeover handshake closed before commit"));
+    });
+  });
 }
 
 function defaultExit(code: number): void {

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -498,7 +498,8 @@ export async function stageRedskilledReplacementSuccessor(
     ...prepared.entry.args,
     ...redskilledServeArgv(target, options.idleMs == null ? {} : { idleMs: options.idleMs }),
   ];
-  return await (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env, target))(prepared.entry, argv);
+  const successor = await (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env, target))(prepared.entry, argv);
+  return successor ?? { commit() {}, abort() {} };
 }
 
 /**

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -418,7 +418,7 @@ export interface RedskilledReplacementIO {
   readonly spawnSuccessor?: (
     entry: ResolvedRedskilledReplacementEntry,
     argv: readonly string[],
-  ) => void | RedskilledSuccessorControl | Promise<void | RedskilledSuccessorControl>;
+  ) => unknown;
   /** Repoints a supervising unit before the old daemon releases its socket. */
   readonly repointSupervisor?: (
     entry: ResolvedRedskilledReplacementEntry,
@@ -499,7 +499,13 @@ export async function stageRedskilledReplacementSuccessor(
     ...redskilledServeArgv(target, options.idleMs == null ? {} : { idleMs: options.idleMs }),
   ];
   const successor = await (io.spawnSuccessor ?? defaultSpawnSuccessor(io.env, target))(prepared.entry, argv);
-  return successor ?? { commit() {}, abort() {} };
+  return isSuccessorControl(successor) ? successor : { commit() {}, abort() {} };
+}
+
+function isSuccessorControl(value: unknown): value is RedskilledSuccessorControl {
+  if (value == null || typeof value !== "object") return false;
+  const candidate = value as Partial<RedskilledSuccessorControl>;
+  return typeof candidate.commit === "function" && typeof candidate.abort === "function";
 }
 
 /**

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -113,7 +113,7 @@ export const REDSKILLED_TAKEOVER_SOCKET_ENV = "REDSKILLED_TAKEOVER_SOCKET";
 export const REDSKILLED_TAKEOVER_TOKEN_ENV = "REDSKILLED_TAKEOVER_TOKEN";
 
 /** A boot that cannot reach the handshake inside this window is not viable. */
-export const DEFAULT_REDSKILLED_TAKEOVER_HANDSHAKE_MS = 10_000;
+export const DEFAULT_REDSKILLED_TAKEOVER_HANDSHAKE_MS = 30_000;
 
 /** True when a replacement started this process, so its boot check is not owed. */
 export function isRedskilledBornByReplacement(env: NodeJS.ProcessEnv = process.env): boolean {

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -401,6 +401,7 @@ describe("a daemon that has observed a newer published version", () => {
       idleMs: 60_000,
       replaceCheckMs: 0,
       daemonVersion: RUNNING_VERSION,
+      supervised: false,
       publishedVersion: async () => PUBLISHED_VERSION,
       eventLane: lane,
       replacementIO: {

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -393,6 +393,37 @@ describe("the successor entry", () => {
 });
 
 describe("a daemon that has observed a newer published version", () => {
+  it("keeps serving and records the failed takeover when the successor exits at boot", async () => {
+    const { paths, env } = await session();
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      replaceCheckMs: 0,
+      daemonVersion: RUNNING_VERSION,
+      publishedVersion: async () => PUBLISHED_VERSION,
+      eventLane: lane,
+      replacementIO: {
+        env,
+        spawnSuccessor: async () => {
+          throw new Error("deliberately broken successor exited 2");
+        },
+      },
+    });
+    running.push(daemon);
+
+    await daemon.checkForReplacement();
+
+    expect(await socketAnswers(paths.socketPath)).toBe(true);
+    expect(daemon.hostState().daemon_version).toBe(RUNNING_VERSION);
+    expect(await lane.read()).toContainEqual(
+      expect.objectContaining({
+        event: "daemon-takeover-failed",
+        detail: expect.stringContaining(PUBLISHED_VERSION),
+      }),
+    );
+  });
+
   it("keeps reporting the version it is RUNNING while the replacement is pending", async () => {
     const { paths, env } = await session();
     const daemon = await startRedskilledDaemon({


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3655 -->
🤖 **Re-seed trail** — #3655 on `afk/3655-version-takeover-abdicates-before-the-su`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3655; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3655 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/dev`, `apps/redskilled`, `apps/rsp`]
{"schema":"red.afk.validation.v1","name":"feedback:pnpm typecheck","status":"failed","command":"pnpm typecheck","exitCode":2,"durationMs":13,"summary":"suspect-infra: `pnpm typecheck` exited 2 after 13ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. @reddb-io/redskilled:typecheck:   Type 'number' is not assignable to type 'void | RedskilledSuccessorControl | Promise<void | RedskilledSuccessorControl>'. @reddb-io/redskilled:typecheck: tests/self-replacement.test.ts(880,29): error TS2322: Type '(entry: ResolvedRedskilledReplacementEntry, argv: readonly string[]) => number' is not assignable to type '(entry: ResolvedRedskilledReplacementEntry, argv: readonly string[]) => void | RedskilledSuccessorControl | Promise<void | RedskilledSuccessorControl>'. @reddb-io/redskilled:typecheck:   Type 'number' is not assignable to type 'void | RedskilledSuccessorControl | Promise<void | RedskilledSuccessorControl>'. @reddb-io/redskilled:typecheck: tests/self-replacement.test.ts(906,29): error TS2322: Type '(entry: ResolvedRedskilledReplacementEntry) => number' is not assignable to type '(entry: ResolvedRedskilledReplacementEntry, argv: readonly string[]) => void | RedskilledSuccessorControl | Promise<void | RedskilledSuccessorControl>'. @reddb-io","suspectInfra":true}
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":78,"summary":"suspect-infra: `pnpm -C apps/dev test:invariants` exited 1 after 78ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. failing: FAIL tests/file-size-guard.test.ts > file-size ratchet — a split nothing enforces is a split that comes back > holds the live tree to the threshold and the shrink-only baseline — +     \"path\": \"apps/redskilled/src/daemon/lifecycle.ts\", +     \"reason\": \"apps/redskilled/src/daemon/lifecycle.ts grew from 2489 to 2515 lines. The baseline is shrink-only: lower the number as the file is decomposed, never raise it.\", +   }, +   Object { +     \"kind\": \"over-threshold\", +     \"lines\": 832, +     \"path\": \"apps/redskilled/src/event-lane.ts\", +     \"reason\": \"apps/redskilled/src/event-lane.ts is 832 lines, over the 800-line threshold. Split it by domain — the baseline records debt that predates this ratchet, never a new file.\", +   }, + ]   ❯ tests/file-size-guard.test.ts:46:7      44|         : `file-size ratchet: ${findings.length} finding(s).\\n${render…      45|           `Baseline: apps/dev/src/core/file-size-guard.ts (FILE_SIZE_B…      46|     ).toEqual([]);        |       ^      47|","suspectInfra":true}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3655