### PR TITLE
resume: #3577 (draft route for the pushed worker branch)

### DIFF
--- a/apps/dev/src/mcp/handlers.ts
+++ b/apps/dev/src/mcp/handlers.ts
@@ -5,6 +5,7 @@ import {
   armPr,
   createEnginePaths,
   createFileMergeDriverStore,
+  createSingletonLeaseStore,
   releasePr,
 } from "@reddb-io/red-castle/engine";
 import { resolveHitlDecision } from "../core/hitl-resolve.js";
@@ -58,6 +59,21 @@ import { collectDeadendAuditReport } from "../runtime/deadend-audit-report.js";
 
 import type { DevAfkMcpOperations, DevAfkMcpRuntime } from "./operations.js";
 import { dispatchArgs, buildWaitArgs, defaultMcpRuntime, resolveConfiguredBase, latestClaimPerWorker } from "./operations.js";
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+async function mergeDriverIsTicking(root: string): Promise<boolean> {
+  const paths = createEnginePaths(join(root, ".red"));
+  const lease = await createSingletonLeaseStore(paths).read("merge-driver");
+  return lease !== undefined && isProcessAlive(lease.pid);
+}
 
 export function buildMcpLandingFireHook(
   root: string,
@@ -425,6 +441,11 @@ export function createDefaultDevAfkMcpOperations(
       };
     },
     async mergeArm(input: { pr: number }) {
+      if (!(await mergeDriverIsTicking(root))) {
+        throw new Error(
+          `merge_arm refused for PR #${input.pr}: missing live merge-driver process; no tick source will act on this record`,
+        );
+      }
       const store = createFileMergeDriverStore(createEnginePaths(join(root, ".red")));
       const record = await armPr(store, input.pr, Math.floor(Date.now() / 1000));
       return { armed: { pr: record.pr, status: record.status, armed_at_epoch: record.armedAtEpoch } };
@@ -432,10 +453,15 @@ export function createDefaultDevAfkMcpOperations(
     async mergeStatus() {
       const store = createFileMergeDriverStore(createEnginePaths(join(root, ".red")));
       const state = await store.read();
+      const ticking = await mergeDriverIsTicking(root);
       return {
+        driver: { process: "merge-driver", status: ticking ? "ticking" : "missing" },
         prs: Object.values(state.prs).map((record) => ({
           pr: record.pr,
           status: record.status,
+          ...(record.status === "armed"
+            ? { actionability: ticking ? "driver-ticking" : "orphaned" }
+            : {}),
           attempts: record.attempts,
           armed_at_epoch: record.armedAtEpoch,
           updated_at_epoch: record.updatedAtEpoch,
@@ -578,4 +604,3 @@ export function createDefaultDevAfkMcpOperations(
     deadendAudit: () => collectDeadendAuditReport(root),
   };
 }
-

--- a/apps/dev/tests/mcp-adapter.test.ts
+++ b/apps/dev/tests/mcp-adapter.test.ts
@@ -8,8 +8,10 @@ import { waitsDir } from "@reddb-io/shared/red-paths.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   appendCastleLaneRecord,
+  armPr,
   castleLanePath,
   createEnginePaths,
+  createFileMergeDriverStore,
 } from "@reddb-io/red-castle/engine";
 import { createCastleMcpTools } from "@reddb-io/red-castle/mcp-server";
 import { afkPaths } from "../src/runtime/wire.js";
@@ -80,6 +82,35 @@ describe("redskilled MCP host adapter", () => {
   // published-entry path (`resolveDevScriptPath`, covered by its own suite): the
   // adapter's copy existed only to hand a bundle to its own `spawn`, and since
   // #2976 the daemon is the one that runs it.
+
+  it("reports an armed PR as orphaned when no merge-driver process is ticking", async () => {
+    const cwd = await root();
+    const store = createFileMergeDriverStore(createEnginePaths(join(cwd, ".red")));
+    await armPr(store, 3577, 1_800_000_000);
+
+    const status = (await createCastleMcpDependencies(cwd).mergeStatus()) as {
+      driver: { process: string; status: string };
+      prs: Array<{ pr: number; actionability: string }>;
+    };
+
+    expect(status.driver).toEqual({ process: "merge-driver", status: "missing" });
+    expect(status.prs).toContainEqual(
+      expect.objectContaining({
+        pr: 3577,
+        actionability: "orphaned",
+      }),
+    );
+  });
+
+  it("refuses to arm a PR when the merge-driver process is missing", async () => {
+    const cwd = await root();
+    const deps = createCastleMcpDependencies(cwd);
+
+    await expect(deps.mergeArm({ pr: 3577 })).rejects.toThrow(
+      "missing live merge-driver process",
+    );
+    await expect(deps.mergeStatus()).resolves.toMatchObject({ prs: [] });
+  });
 
   // Three consecutive dispatches died silently leaving only `worker.pid` — the
   // spawn discarded stdout/stderr, so a boot death left zero evidence (#2385).

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -240,16 +240,18 @@ const SURFACE: ReadonlyArray<{
     name: "merge_arm",
     title: "Arm PR for the merge driver",
     description:
-      "MUTATING: hand one open PR to the project merge driver — it owns the PR to a terminal state " +
+      "MUTATING: hand one open PR to a live project merge-driver process — it owns the PR to a terminal state " +
       "(update-branch when BEHIND, merge-commit once green at head, bounded retries, " +
-      "needs-medic/needs-human classification) without GitHub native auto-merge.",
+      "needs-medic/needs-human classification) without GitHub native auto-merge. " +
+      "Refuses when the merge-driver process is missing so custody cannot become orphaned.",
     schema: ["pr"],
   },
   {
     name: "merge_status",
     title: "Read merge driver state",
     description:
-      "Return the driver's durable per-PR records: armed set, attempts, last observed state, " +
+      "Return whether the merge-driver process is ticking plus durable per-PR records: " +
+      "armed records labeled driver-ticking or orphaned, attempts, last observed state, " +
       "and terminal classifications.",
     schema: [],
   },

--- a/packages/red-castle/src/mcp/merge.ts
+++ b/packages/red-castle/src/mcp/merge.ts
@@ -17,9 +17,10 @@ export function createMergeTools(deps: MergeDependencies): CastleMcpTool[] {
       name: "merge_arm",
       title: "Arm PR for the merge driver",
       description:
-        "MUTATING: hand one open PR to the project merge driver — it owns the PR to a terminal state " +
+        "MUTATING: hand one open PR to a live project merge-driver process — it owns the PR to a terminal state " +
         "(update-branch when BEHIND, merge-commit once green at head, bounded retries, " +
-        "needs-medic/needs-human classification) without GitHub native auto-merge.",
+        "needs-medic/needs-human classification) without GitHub native auto-merge. " +
+        "Refuses when the merge-driver process is missing so custody cannot become orphaned.",
       inputSchema: { pr: z.number().int().positive() },
       invoke: ({ pr }) => deps.mergeArm({ pr: pr as number }),
     },
@@ -27,7 +28,8 @@ export function createMergeTools(deps: MergeDependencies): CastleMcpTool[] {
       name: "merge_status",
       title: "Read merge driver state",
       description:
-        "Return the driver's durable per-PR records: armed set, attempts, last observed state, " +
+        "Return whether the merge-driver process is ticking plus durable per-PR records: " +
+        "armed records labeled driver-ticking or orphaned, attempts, last observed state, " +
         "and terminal classifications.",
       inputSchema: {},
       invoke: () => deps.mergeStatus(),

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -201,19 +201,23 @@ cached, the next round retries it, and the round consumes no Re-seed budget.
 `1/1 100%` with no attempt. Release it through the tool, never by flipping
 labels by hand.
 
-### Merge driver — armed PRs land without native auto-merge
+### Merge driver — explicit recovery custody
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `merge_arm` | mutating | Hand one open PR to the project merge driver — it owns the PR to a terminal state. |
-| `merge_status` | read | The driver's durable per-PR records: armed set, attempts, terminal classifications. |
+| `merge_arm` | mutating | Hand one open PR to a live `merge-driver` process; refuses when that process is missing so custody cannot become orphaned. |
+| `merge_status` | read | Whether the `merge-driver` process is `ticking` or `missing`, plus durable per-PR records whose `actionability` distinguishes armed records as `driver-ticking` or `orphaned`. |
 | `merge_release` | mutating | Stop driver ownership of one PR (record kept as `released`). |
 
-The driver (#2512) runs in the project MCP resident on a fixed cadence: BEHIND →
+When the recovery driver (#2512) is running, its fixed cadence handles BEHIND →
 update-branch, green at head → merge with the merge-commit strategy (never an
-admin override), transient faults → bounded retries, DIRTY or failing checks →
-terminal `needs-medic`/`needs-human` classification instead of a loop. Its
-state survives resident restarts in `.red/state/castle/merge-driver.toon`.
+admin override), transient faults → bounded retries, and DIRTY or failing
+checks → terminal `needs-medic`/`needs-human` classification instead of a loop.
+Its state survives process restarts in `.red/state/castle/merge-driver.toon`.
+The ordinary MCP session no longer starts this loop (ADR 0136): native intent
+and the Queue Custodian own the normal landing tail. Therefore `merge_arm`
+fails loudly unless a live recovery process owns the `merge-driver` singleton;
+`merge_status` marks any older armed record `orphaned` when that owner is gone.
 
 ### Worktree — the disposable pool
 


### PR DESCRIPTION
Draft route so the engine's deadend audit stops refusing the resumed branch (pushed work with no open pull request). The resuming worker finishes the work and marks it ready.

Refs #3577

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789095527&installation_model_id=20659&pr_number=3703&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3703&signature=6fc95eee77d749d16a7c766e2cb911136623395c2442146e90230079b22de45e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->