### PR TITLE
fix: #3705 Feedback validation of an inherited red branch parks as suspect-infra instead of handing the failure to the agent

### DIFF
--- a/apps/dev/src/core/branch-resume.ts
+++ b/apps/dev/src/core/branch-resume.ts
@@ -154,6 +154,7 @@ export function extractFailureReason(priorAttemptContext: string | undefined): s
 // the gate did NOT pass — a full agent iteration is still required.
 const GATE_STAGE_REASONS = new Set([
   "feedback-failed",
+  "feedback-failed-infra",
   "no-sentinel",
   "stalled",
   // A wall-clock cap (#2701) stops the worker MID-GATE: the branch carries real

--- a/apps/dev/tests/process-issue-resume.test.ts
+++ b/apps/dev/tests/process-issue-resume.test.ts
@@ -119,6 +119,24 @@ describe("branch-resume: non-gate-green resume path (issue #2397)", () => {
 
     expect(trace.freshWorkerBranchCalls).toHaveLength(0);
   });
+
+  it("hands an inherited suspect-infra feedback failure to the agent before re-validation (#3705)", async () => {
+    const failure =
+      "feedback-failed-infra: pnpm typecheck exit 2; suspect-infra repeated signature v1:510a86ed26095749";
+    const { deps, input, trace } = harness({
+      prevFailureContext: gateStageFailed(failure),
+    });
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+
+    const result = await import("../src/core/process-issue.js").then((m) =>
+      m.processIssue(deps, input),
+    );
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.runAgentCalls[0]?.handoffContent).toContain(failure);
+    expect(trace.iterLogs.some((line) => line.includes("gate-green fast path"))).toBe(false);
+  });
 });
 
 describe("branch-resume: explicit restart override (issue #2397)", () => {


### PR DESCRIPTION
Automated AFK landing for #3705. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3705

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789096972&installation_model_id=20659&pr_number=3709&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3709&signature=54656aade2fbe6430c2b0fff31165699ca678bdf6d32af0024297e08123b06ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->