### PR TITLE
resume: #3704 (draft route for the pushed worker branch)

### DIFF
--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -2642,7 +2642,7 @@ export async function resolveMergeConflict(
 }
 
 /** Resolve the open PR number for `<branch>` → `<target>`, or undefined. */
-async function listOpenPr(
+export async function listOpenPr(
   exec: Exec,
   repo: string,
   branch: string,

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -65,6 +65,7 @@ import {
   type WaitForReviewInput,
   type CiAwaitInput,
 } from "../merge.js";
+import { ensureResumeRoute } from "./resume-route.js";
 import type { LandLock } from "../land-lock.js";
 import { doLanding, type LandingPhase, type LandingPostMergeValidation } from "../landing.js";
 import { markProcessSafetyStep } from "../process-safety.js";
@@ -476,18 +477,16 @@ export async function processIssue(
     );
   }
 
-  // Branch-resume logic (issue #2397): discover a prior pushed branch so re-claim
-  // can continue instead of rebuilding from scratch. Explicit restart overrides a
-  // branch-only resume, but never silently supersedes an existing open PR.
+  // Branch resume (#2397): continue a prior pushed branch instead of rebuilding.
+  // Explicit restart overrides branch-only resume, never an existing open PR.
   const allBranches = await deps.lookups.discoverBranches?.() ?? [];
   const humanGuidanceForResume = buildHumanGuidance(comments);
   const explicitRestart = isExplicitRestartRequested(humanGuidanceForResume);
   const candidateBranch = discoverResumableBranch(allBranches, issue);
   // Issue #2865 — ask git what the branch HOLDS before deciding its fate. The
-  // ref name is not evidence: worktree creation pushes `afk/<issue>-<slug>`
-  // before the agent writes a line, so a dead Worker's nine committed slices and
-  // an empty placeholder read identically by name. Whatever this Worker declines
-  // to adopt, `prepareFreshWorkerBranch` deletes from origin.
+  // A ref name is not evidence: worktree creation pushes `afk/<issue>-<slug>`
+  // before the agent writes, so committed work and an empty placeholder look
+  // identical. Anything declined is deleted by `prepareFreshWorkerBranch`.
   const candidateCommitsAhead = candidateBranch
     ? await deps.lookups.branchCommitsAhead?.(candidateBranch.branch, base).catch(() => undefined)
     : undefined;
@@ -510,6 +509,7 @@ export async function processIssue(
     : adoption.kind === "adopt"
       ? candidateBranch
       : null;
+  await ensureResumeRoute(deps.mergeExec, { adoption, repo: input.repo, target: trunk, issue });
   const failureReason = extractFailureReason(prevFailureContext);
   const carriedValidationSignature = parseValidationFailureSignature(failureReason);
   const usesDeclaredValidationMoments = deps.validationMoments !== undefined;

--- a/apps/dev/src/core/process-issue/resume-route.ts
+++ b/apps/dev/src/core/process-issue/resume-route.ts
@@ -1,0 +1,54 @@
+// Resume routing — repair custody for preserved Worker commits before the next
+// Worker starts. The exit-time orphan refusal still owns newly-pushed work.
+
+import { scrubOutbound } from "../../runtime/outbound-redaction.js";
+import type { BranchAdoption } from "../branch-resume.js";
+import { listOpenPr, type Exec } from "../merge.js";
+
+export interface ResumeRouteInput {
+  readonly adoption: BranchAdoption;
+  readonly repo: string;
+  readonly target: string;
+  readonly issue: number;
+}
+
+/**
+ * Open the durable draft route for a preserved branch proven to carry commits.
+ * The head/base probe makes this idempotent across concurrent claims and forge
+ * races; Landing later reuses the same pull request and marks it ready.
+ */
+export async function ensureResumeRoute(
+  exec: Exec,
+  input: ResumeRouteInput,
+): Promise<number | undefined> {
+  const { adoption, repo, target, issue } = input;
+  if (
+    adoption.kind !== "adopt" ||
+    adoption.commitsAhead === undefined ||
+    adoption.commitsAhead <= 0 ||
+    adoption.hasOpenPullRequest
+  ) {
+    return undefined;
+  }
+
+  const existing = await listOpenPr(exec, repo, adoption.branch, target);
+  if (existing !== undefined) return existing;
+  const create = await exec([
+    "gh",
+    "-R",
+    repo,
+    "pr",
+    "create",
+    "--draft",
+    "--base",
+    target,
+    "--head",
+    adoption.branch,
+    "--title",
+    scrubOutbound(`resume: #${issue}`),
+    "--body",
+    scrubOutbound(`Resuming preserved Worker commits for #${issue}.\n\nCloses #${issue}`),
+  ]);
+  if (create.code !== 0) return undefined;
+  return await listOpenPr(exec, repo, adoption.branch, target);
+}

--- a/apps/dev/tests/process-issue-resume.test.ts
+++ b/apps/dev/tests/process-issue-resume.test.ts
@@ -302,6 +302,42 @@ describe("branch adoption is decided on commits, not on the ref name (issue #286
     expect(trace.handoffs[0]?.content ?? "").toContain("<resume-from-branch>");
   });
 
+  it("opens a draft route before resuming a preserved branch with commits", async () => {
+    let routeWasOpenWhenAgentStarted = false;
+    const { deps, input, trace } = harness({
+      onRunAgent: async () => {
+        routeWasOpenWhenAgentStarted = trace.mergeCalls.some((argv) =>
+          argv.join(" ").includes("pr create --draft --base main")
+        );
+      },
+    });
+    deps.lookups.discoverBranches = async () => PRIOR_REFS;
+    Object.assign(deps.lookups, {
+      branchCommitsAhead: async () => 9,
+      discoverOpenPullRequests: async () => [],
+    });
+
+    await import("../src/core/process-issue.js").then((m) => m.processIssue(deps, input));
+
+    expect(routeWasOpenWhenAgentStarted).toBe(true);
+    expect(trace.mergeCalls).toContainEqual([
+      "gh",
+      "-R",
+      "o/r",
+      "pr",
+      "create",
+      "--draft",
+      "--base",
+      "main",
+      "--head",
+      PRIOR_BRANCH,
+      "--title",
+      "resume: #9",
+      "--body",
+      expect.stringContaining("Closes #9"),
+    ]);
+  });
+
   it("records on the issue why a restart refused a branch that carries work", async () => {
     const { deps, input, trace } = harness({});
     deps.lookups.discoverBranches = async () => PRIOR_REFS;


### PR DESCRIPTION
Draft route so the resume does not die on the very refusal #3704 fixes.

Refs #3704

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789097039&installation_model_id=20659&pr_number=3710&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3710&signature=729b99f3c3931a24021ee1059dc5635cf9bfecd83b37f03f9e5f1566f503ef98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->