### PR TITLE
fix: #3706 Orphan reaper starves after an event-lane rotation: census withheld for lack of birth proof

### DIFF
--- a/apps/redskilled/src/orphan-reaper.ts
+++ b/apps/redskilled/src/orphan-reaper.ts
@@ -17,6 +17,8 @@ export interface RedskilledProcessCensusRow {
   readonly age_ms: number;
   readonly worker_id?: string;
   readonly born_at?: string;
+  /** Active init-system unit stated by the process's birth environment. */
+  readonly unit?: string;
   readonly cwd?: string;
   readonly under_workers_lane: boolean;
 }
@@ -79,6 +81,8 @@ export interface RedskilledProcessCensusOptions {
   readonly proc_root?: string;
   /** Host USER_HZ; injected only when the proc tree belongs to another kernel. */
   readonly clock_ticks_per_second?: number;
+  /** Active units whose stamped leaders must remain visible even while held by init. */
+  readonly active_worker_units?: readonly string[];
 }
 
 let cachedProcClockTicksPerSecond: number | null | undefined;
@@ -155,15 +159,17 @@ export async function readRedskilledProcessStarttime(
 /**
  * Take one process-table snapshot for the reaper.
  *
- * Stat is read for every process. Environment and cwd are deliberately deferred
- * until a row says it was reparented to pid 1: those are sensitive and more
- * expensive reads, and no other row can become an orphan candidate.
+ * Stat is read for every process. Environment and cwd are normally deferred
+ * until a row says it was reparented to pid 1. When active units need birth
+ * recovery, environments are also inspected until their stamped leaders are
+ * found; unrelated rows are still discarded before cwd is read.
  */
 export async function censusRedskilledProcesses(
   options: RedskilledProcessCensusOptions = {},
 ): Promise<RedskilledProcessCensusRow[]> {
   const root = options.proc_root ?? "/proc";
   try {
+    const activeWorkerUnits = new Set(options.active_worker_units ?? []);
     const clockTicksPerSecond = options.clock_ticks_per_second ?? hostProcClockTicksPerSecond();
     if (clockTicksPerSecond == null || !Number.isFinite(clockTicksPerSecond) || clockTicksPerSecond <= 0) return [];
     const uptimeSeconds = Number((await readFile(join(root, "uptime"), "utf8")).trim().split(/\s+/)[0]);
@@ -178,7 +184,7 @@ export async function censusRedskilledProcesses(
       } catch {
         continue;
       }
-      if (parsed == null || parsed.ppid !== 1) continue;
+      if (parsed == null || (parsed.ppid !== 1 && activeWorkerUnits.size === 0)) continue;
 
       let environment = new Map<string, string>();
       let cwd: string | undefined;
@@ -187,6 +193,9 @@ export async function censusRedskilledProcesses(
       } catch {
         // An unreadable stamp leaves the row unstamped; cwd can still identify a suspect.
       }
+      const unit = stated(environment.get("RED_WORKER_SCOPE"));
+      const isActiveWorkerUnit = unit != null && activeWorkerUnits.has(unit);
+      if (parsed.ppid !== 1 && !isActiveWorkerUnit) continue;
       try {
         cwd = await readlink(join(root, entry, "cwd"));
       } catch {
@@ -207,6 +216,7 @@ export async function censusRedskilledProcesses(
         ),
         ...(workerId == null ? {} : { worker_id: workerId }),
         ...(bornAt == null ? {} : { born_at: bornAt }),
+        ...(isActiveWorkerUnit ? { unit } : {}),
         ...(cwd == null ? {} : { cwd }),
         under_workers_lane: cwd != null && isWorkersLanePath(cwd),
       });
@@ -357,13 +367,52 @@ export interface RedskilledOrphanReaperRuntime {
 
 const EMPTY_ORPHAN_SWEEP: RedskilledOrphanSweepOutcome = { adopted: 0, reaped: 0, suspects: 0 };
 
+interface RecoveredActiveUnitBirths {
+  readonly births: readonly RedskilledProcessCensusRow[];
+  readonly complete: boolean;
+}
+
+/** Rebuild live-birth proof only when every active unit has one stamped leader. PURE. */
+function recoverActiveUnitBirths(
+  processes: readonly RedskilledProcessCensusRow[],
+  activeWorkerUnits: readonly string[],
+): RecoveredActiveUnitBirths {
+  const requiredUnits = new Set(activeWorkerUnits);
+  const birthsByUnit = new Map<string, RedskilledProcessCensusRow>();
+  const workerUnits = new Map<string, string>();
+  let ambiguous = false;
+  for (const process of processes) {
+    const workerId = stated(process.worker_id);
+    const bornAt = stated(process.born_at);
+    const unit = stated(process.unit);
+    if (
+      workerId == null || bornAt == null || unit == null ||
+      process.pid !== process.pgid || !requiredUnits.has(unit)
+    ) continue;
+    const priorBirth = birthsByUnit.get(unit);
+    const priorUnit = workerUnits.get(workerId);
+    if (
+      (priorBirth != null && (priorBirth.worker_id !== workerId || priorBirth.born_at !== bornAt)) ||
+      (priorUnit != null && priorUnit !== unit)
+    ) {
+      ambiguous = true;
+      continue;
+    }
+    birthsByUnit.set(unit, process);
+    workerUnits.set(workerId, unit);
+  }
+  return {
+    births: [...birthsByUnit.values()],
+    complete: !ambiguous && birthsByUnit.size === requiredUnits.size,
+  };
+}
+
 /** Own the daemon's orphan census, decisions, action ordering and interval. */
 export function createRedskilledOrphanReaperRuntime(
   options: RedskilledOrphanReaperRuntimeOptions,
 ): RedskilledOrphanReaperRuntime {
   const intervalMs = options.interval_ms ?? DEFAULT_REDSKILLED_ORPHAN_REAPER_MS;
   const mode = options.mode ?? redskilledOrphanReaperMode();
-  const census = options.census ?? censusRedskilledProcesses;
   const readStarttime = options.read_starttime ?? readRedskilledProcessStarttime;
   const killGroup = options.kill_group ?? killTreeAndWait;
   const report = options.report ?? ((detail: string) => process.stderr.write(`redskilled: ${detail}\n`));
@@ -373,30 +422,49 @@ export function createRedskilledOrphanReaperRuntime(
   async function inspect(): Promise<{
     readonly selected: SelectedRedskilledProcessCensus;
     readonly liveBirths: ReadonlyMap<string, RedskilledWorkerView>;
+    readonly recoveredBirthIds: ReadonlySet<string>;
     readonly safeToAct: boolean;
   }> {
+    let activeWorkerUnits: readonly string[] = [];
+    let activeUnitProofAvailable = true;
+    try {
+      activeWorkerUnits = await Promise.resolve(options.active_worker_units?.() ?? []);
+    } catch {
+      activeUnitProofAvailable = false;
+    }
+
     let processes: readonly RedskilledProcessCensusRow[];
     try {
-      processes = await census();
+      processes = options.census == null
+        ? await censusRedskilledProcesses({ active_worker_units: activeWorkerUnits })
+        : await options.census();
     } catch {
       processes = [];
     }
 
     let births: readonly RedskilledWorkerView[] = [];
+    const recoveredBirthIds = new Set<string>();
     let safeToAct = true;
     if (processes.length > 0) {
       try {
         births = await options.live_births();
       } catch {
-        safeToAct = false;
-        report("orphan census withheld: the event lane could not prove which stamped Workers still have live births");
+        const recovered = recoverActiveUnitBirths(processes, activeWorkerUnits);
+        safeToAct = activeUnitProofAvailable && recovered.complete;
+        if (safeToAct) {
+          births = recovered.births.map((process) => workerFromOrphanProcess(process, options.clock));
+          for (const birth of births) recoveredBirthIds.add(birth.worker_id);
+          report(
+            `orphan birth proof re-derived from ${births.length} active stamped Worker unit(s); ` +
+            "the event lane can be reseeded before orphan teardown",
+          );
+        } else {
+          report("orphan census withheld: the event lane and active unit census could not prove which stamped Workers still have live births");
+        }
       }
     }
     const liveBirths = new Map(births.map((worker) => [worker.worker_id, worker]));
-    const [activeWorkerUnits, dumpFiles] = await Promise.all([
-      Promise.resolve(options.active_worker_units?.() ?? []).catch(() => []),
-      Promise.resolve(options.dump_files?.() ?? []).catch(() => []),
-    ]);
+    const dumpFiles = await Promise.resolve(options.dump_files?.() ?? []).catch(() => []);
     return {
       selected: selectRedskilledProcessCensus({
         processes,
@@ -406,6 +474,7 @@ export function createRedskilledOrphanReaperRuntime(
         dump_files: dumpFiles,
       }),
       liveBirths,
+      recoveredBirthIds,
       safeToAct,
     };
   }
@@ -428,7 +497,7 @@ export function createRedskilledOrphanReaperRuntime(
     if (!options.authorized || mode === "off" || sweeping) return { ...EMPTY_ORPHAN_SWEEP };
     sweeping = true;
     try {
-      const { selected, liveBirths, safeToAct } = await inspect();
+      const { selected, liveBirths, recoveredBirthIds, safeToAct } = await inspect();
       if (!safeToAct) return { ...EMPTY_ORPHAN_SWEEP };
       const candidates = selected.candidates;
       const counts = { adopted: 0, reaped: 0, suspects: 0 };
@@ -445,10 +514,17 @@ export function createRedskilledOrphanReaperRuntime(
           continue;
         }
         if (candidate.kind === "adopt") {
+          const recoveredBirth = recoveredBirthIds.has(candidate.process.worker_id!);
           await options.adopt(
-            workerFromOrphanProcess(candidate.process, options.clock, liveBirths.get(candidate.process.worker_id!)),
-            false,
-            candidate.detail,
+            workerFromOrphanProcess(
+              candidate.process,
+              options.clock,
+              recoveredBirth ? undefined : liveBirths.get(candidate.process.worker_id!),
+            ),
+            recoveredBirth,
+            recoveredBirth
+              ? `adopted from an active unit after event-lane birth proof was unavailable: ${candidate.detail}`
+              : candidate.detail,
           );
           counts.adopted += 1;
           report(candidate.detail);
@@ -533,7 +609,8 @@ function workerFromOrphanProcess(
     proc_start_time: processRow.starttime,
     started_at: birth?.started_at ?? processRow.born_at ?? inferredBirth,
     workspace_path: processRow.cwd ?? birth?.workspace_path ?? "",
-    isolated: false,
+    isolated: processRow.unit != null,
+    ...(processRow.unit == null ? {} : { unit: processRow.unit }),
     warnings: [
       ...(birth?.warnings ?? []),
       birth == null

--- a/apps/redskilled/tests/orphan-reaper.test.ts
+++ b/apps/redskilled/tests/orphan-reaper.test.ts
@@ -146,6 +146,70 @@ describe("the orphan reaper process census", () => {
 });
 
 describe("stamped orphan teardown", () => {
+  it("re-derives active unit births when the rotated event lane cannot prove them", async () => {
+    const activeUnit = "red-worker-acme-widgets-hlive.service";
+    const held = new Set<string>();
+    const adopted: Array<{ worker_id: string; record_birth: boolean; started_at: string; unit?: string }> = [];
+    const killed: number[] = [];
+    const reports: string[] = [];
+    const runtime = createRedskilledOrphanReaperRuntime({
+      authorized: true,
+      interval_ms: 0,
+      census: () => [
+        processRow({
+          worker_id: "hLIVE",
+          born_at: "2026-08-11T10:09:59.000Z",
+          pid: 4_241,
+          pgid: 4_241,
+          age_ms: 1_000,
+          unit: activeUnit,
+        }),
+        processRow(),
+      ],
+      active_worker_units: () => [activeUnit],
+      clock: () => "2026-08-11T10:10:00.000Z",
+      held_worker_ids: () => held,
+      live_births: () => {
+        throw new Error("the pre-rotation birth history is unavailable");
+      },
+      read_starttime: () => "1200",
+      kill_group: async (pgid) => {
+        killed.push(pgid);
+        return true;
+      },
+      report: (detail) => reports.push(detail),
+      adopt: (worker, recordBirth) => {
+        held.add(worker.worker_id);
+        adopted.push({
+          worker_id: worker.worker_id,
+          record_birth: recordBirth,
+          started_at: worker.started_at,
+          ...(worker.unit == null ? {} : { unit: worker.unit }),
+        });
+      },
+      record_reaped: (worker) => {
+        held.delete(worker.worker_id);
+      },
+    });
+
+    await expect(runtime.sweep()).resolves.toEqual({ adopted: 2, reaped: 1, suspects: 0 });
+    expect(adopted).toEqual([
+      {
+        worker_id: "hLIVE",
+        record_birth: true,
+        started_at: "2026-08-11T10:09:59.000Z",
+        unit: activeUnit,
+      },
+      {
+        worker_id: "hLOST",
+        record_birth: true,
+        started_at: "2026-08-11T10:00:00.000Z",
+      },
+    ]);
+    expect(killed).toEqual([4_242]);
+    expect(reports.join(" ")).not.toMatch(/census withheld/);
+  });
+
   it("keeps report mode free of daemon-map, signal and event-lane mutations", async () => {
     const mutations = { adopt: 0, kill: 0, laneWrites: 0 };
     const runtime = createRedskilledOrphanReaperRuntime({


### PR DESCRIPTION
Automated AFK landing for #3706. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3706

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789097294&installation_model_id=20659&pr_number=3711&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3711&signature=9050e011026b83542bcd08f963248c55d3889837ae85930e49e7b7c41765ac90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->