### PR TITLE
fix: #3707 Test sandboxes share ~/.red/redskilled with the operator's real daemon: canary workers born and reaped on the host lane

### DIFF
--- a/apps/dev/src/runtime/outbound-redaction.ts
+++ b/apps/dev/src/runtime/outbound-redaction.ts
@@ -81,8 +81,11 @@ function scrubKeyValueSecrets(input: string): string {
 
 function scrubHomeIdentity(input: string, options: ScrubOutboundOptions): string {
   let out = input;
-  const home = options.homeDir || homedir();
-  if (home) out = replaceLiteral(out, home, "[REDACTED_HOME]");
+  // Both the stated home AND the process's real one: a caller that names a
+  // home is adding a target, not exempting the machine's own identity — and a
+  // pinned test HOME outside /home/<user> would otherwise sail through.
+  const homes = new Set([options.homeDir, homedir()].filter((h): h is string => !!h));
+  for (const home of homes) out = replaceLiteral(out, home, "[REDACTED_HOME]");
   out = out.replace(/\/home\/([A-Za-z0-9._-]+)(?![A-Za-z0-9._-])/g, "/home/[REDACTED_USER]");
   out = out.replace(/\/Users\/([A-Za-z0-9._-]+)(?![A-Za-z0-9._-])/g, "/Users/[REDACTED_USER]");
   return out;

--- a/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
+++ b/apps/dev/tests/fixtures/mcp-lane-canary/sandbox.ts
@@ -21,6 +21,9 @@
 // indistinguishable from the one-daemon-per-project failure ADR 0130 exists to
 // prevent. The sandbox therefore pins `XDG_RUNTIME_DIR` too: every process in
 // the lane derives the same runtime dir, and it is a temp dir cleanup removes.
+// Its HOME is pinned for the same reason: the durable event and death lanes and
+// stable bundles belong below the sandbox's `~/.red/redskilled`, never below the
+// operator's real home.
 
 import { build } from "esbuild";
 import { execFileSync, spawn } from "node:child_process";
@@ -240,6 +243,10 @@ export async function createCanarySandbox(
     // the machine-wide claim (ADR 0130 Amendment 3) that refuses a second daemon
     // on a real host cannot refuse the harness against the developer's own.
     REDSKILLED_MACHINE_DIR: join(root, "machine"),
+    // Durable daemon state is independently home-scoped. A unique socket and
+    // machine claim do not stop births and deaths crossing into the operator's
+    // real lane unless the whole child-process family shares this scratch HOME.
+    HOME: join(root, "home"),
   };
 
   // Loud, not hopeful: `runtimeSocketDir` silently falls back to `tmpdir()` when

--- a/apps/dev/tests/mcp-lane-canary-e2e.test.ts
+++ b/apps/dev/tests/mcp-lane-canary-e2e.test.ts
@@ -198,9 +198,9 @@ describe("the shipped redskilled-mcp bundle carries the canary", () => {
 
 // Deliberately LAST in the file: the closing case runs the harness's own
 // cleanup, which drops the shared bundle cache every earlier test reuses.
-describe("the canary's daemon lives in a runtime directory the sandbox owns (#2884)", () => {
+describe("the canary's daemon runtime and home belong to the sandbox (#2884, #3707)", () => {
   it(
-    "writes its socket, lease and lane outside the operator's runtime directory",
+    "writes its socket, lease and durable event lane inside sandbox-owned roots",
     async () => {
       const sandbox = await createCanarySandbox("healthy");
       const paths = resolveRedskilledPaths({ env: sandbox.env });
@@ -210,6 +210,8 @@ describe("the canary's daemon lives in a runtime directory the sandbox owns (#28
       expect(paths.runtimeDir.startsWith(`${sandbox.runtimeRoot}/`)).toBe(true);
       expect(existsSync(paths.socketPath)).toBe(true);
       expect(existsSync(paths.leasePath)).toBe(true);
+      expect(paths.eventLanePath.startsWith(`${sandbox.root}/`)).toBe(true);
+      expect(paths.registrationIntentPath.startsWith(`${sandbox.root}/`)).toBe(true);
 
       // The path this sandbox WOULD have used before the fix: same session key,
       // the operator's real environment. Nothing may exist there. This is a pure

--- a/apps/dev/tests/redskilled-test-isolation.test.ts
+++ b/apps/dev/tests/redskilled-test-isolation.test.ts
@@ -39,6 +39,10 @@ describe("the test host is the sandbox's, not the operator's", () => {
     // The machine claim lives in a SHARED directory by design, so an unpinned
     // read finds the live claim of the operator's daemon rather than nothing.
     expect(paths.machineClaimPath.startsWith(ISOLATED_REDSKILLED_HOST_ROOT)).toBe(true);
+    // The durable host lane is derived from the daemon's home, independently
+    // of its runtime and machine scope. Leaving HOME ambient lets sandbox
+    // births and deaths cross into the operator's real daemon history.
+    expect(paths.eventLanePath.startsWith(ISOLATED_REDSKILLED_HOST_ROOT)).toBe(true);
   });
 
   it("resolves an auto-spawn entry that cannot start a daemon", () => {

--- a/apps/dev/tests/support/redskilled-isolation.ts
+++ b/apps/dev/tests/support/redskilled-isolation.ts
@@ -14,7 +14,7 @@
  * one has to remember it. The canary's sandbox stays as it is — it pins the
  * environment of the child processes it launches, which no setup file can do.
  *
- * Four pins, and each closes a different way to the operator's host:
+ * Six pins, and each closes a different way to the operator's host:
  *
  * 1. `REDSKILLED_SESSION` — the scope itself. A key nothing else uses means the
  *    derived socket is one no daemon on this machine is listening on.
@@ -31,7 +31,11 @@
  *    daemon it is asserting the absence of. Pinned to a path that does not
  *    exist: the spawn fails immediately, by name, without a network fetch.
  *
- * 5. `RED_DEV_ENGINE_FLOOR` — the dispatch engine floor (#3031). Its default
+ * 5. `HOME` — the host-scoped daemon home. The event lane, death lane and
+ *    durable bundles live below `~/.red/redskilled`; leaving it ambient lets a
+ *    sandbox daemon read and write the operator's real history.
+ *
+ * 6. `RED_DEV_ENGINE_FLOOR` — the dispatch engine floor (#3031). Its default
  *    policy makes every dispatch surface read the npm dist-tag, so an unpinned
  *    suite would put a NETWORK call behind `dispatchIssue` and let the
  *    operator's registry decide a unit test. Pinned `off`: a suite that means to
@@ -68,6 +72,7 @@ export function pinIsolatedRedskilledHost(env: NodeJS.ProcessEnv = process.env):
   env.REDSKILLED_SESSION = `red-skills-test-host:${root}`;
   env.XDG_RUNTIME_DIR = join(root, "runtime");
   env.REDSKILLED_MACHINE_DIR = join(root, "machine");
+  env.HOME = join(root, "home");
   // Named for what it is, so the failure a spawn reports reads as the pin rather
   // than as a broken installation.
   env.REDSKILLED_BIN = join(root, "no-daemon-in-this-sandbox");


### PR DESCRIPTION
Automated AFK landing for #3707. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3707

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789097314&installation_model_id=20659&pr_number=3712&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3712&signature=20f89e789815a85b96244a6c62325f6beeea193ba978f2ccf82374f1277d7a5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->