### PR TITLE
feat: #3708 Producer births workers against the lagging search count: once-workers boot, find no claim, and die within 30s

### DIFF
--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -908,10 +908,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   /**
    * One tick of the demand loop: what may be asked for, asked for.
    *
-   * The depths come from the last poll rather than from a fetch of this tick's
-   * own: one aliased request per interval is the whole point of Amendment 3, and
-   * a tick that fetched would spend the quota the batching saves. A depth nobody
-   * measured yet holds its project back rather than standing in for a zero.
+   * A last poll may decline a birth; a positive one is confirmed through the
+   * direct REST list and re-planned, so search is never the only birth witness.
    *
    * **A refusal ends the tick and arms the backoff.** The host refused on a
    * host-wide ceiling, so every further request this tick would meet the same
@@ -938,9 +936,6 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       for (const worker of workers.values()) {
         live[worker.project_label] = (live[worker.project_label] ?? 0) + 1;
       }
-      const queue: Record<string, number | null> = {};
-      for (const project of lastQueue?.projects ?? []) queue[project.project_label] = project.depth;
-
       const nowMs = Date.parse(at);
       const demandNowMs = Number.isFinite(nowMs) ? nowMs : 0;
       // A half-open Worker closes the latch only after proving it survived the
@@ -952,21 +947,26 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
           birthHealth[projectLabel] = resetBirthHealth();
         }
       }
-      const plan = planHostDemand({
-        projects: [...registrations.values()].map((registration) => ({
-          project_label: registration.project_label,
-          selector: registration.selector,
-          argv: registration.argv,
-          workspace_path: registration.workspace_path,
-          target: registration.target,
-        })),
-        queue,
-        live,
-        nowMs: demandNowMs,
-        backoffUntilMs: demandBackoffUntilMs,
-        birthHealth,
-      });
-
+      const planCurrentDemand = () =>
+        planHostDemand({
+          projects: [...registrations.values()].map((registration) => ({
+            project_label: registration.project_label,
+            selector: registration.selector,
+            argv: registration.argv,
+            workspace_path: registration.workspace_path,
+            target: registration.target,
+          })),
+          queue: Object.fromEntries((lastQueue?.projects ?? []).map((project) => [project.project_label, project.depth])),
+          live,
+          nowMs: demandNowMs,
+          backoffUntilMs: demandBackoffUntilMs,
+          birthHealth,
+        });
+      let plan = planCurrentDemand();
+      if (plan.births.length > 0) {
+        await pollQueueDiscovery();
+        plan = planCurrentDemand();
+      }
       const granted: RedskilledDemandGrant[] = [];
       const burstForks = new Map<string, Promise<string>>();
       let refusal: string | null = null;

--- a/apps/redskilled/tests/queue-transport-supply.test.ts
+++ b/apps/redskilled/tests/queue-transport-supply.test.ts
@@ -52,8 +52,13 @@ async function sessionPaths(): Promise<RedskilledPaths> {
 }
 
 /** A tracker that answers every conditional REST search with one depth. */
-async function trackerStandingIn(depth: number): Promise<{ url: string; requests: string[] }> {
+async function trackerStandingIn(depth: number): Promise<{
+  url: string;
+  requests: string[];
+  setDepth(depth: number): void;
+}> {
   const requests: string[] = [];
+  let currentDepth = depth;
   const server = createServer((req, res) => {
     const url = new URL(req.url ?? "/", "http://tracker.invalid");
     const query = url.searchParams.get("q") ?? "";
@@ -63,11 +68,17 @@ async function trackerStandingIn(depth: number): Promise<{ url: string; requests
       etag: `"${Buffer.from(query).toString("base64url")}"`,
       "x-ratelimit-remaining": "4900",
     });
-    res.end(JSON.stringify(Array.from({ length: depth }, (_, index) => ({ number: index + 1 }))));
+    res.end(JSON.stringify(Array.from({ length: currentDepth }, (_, index) => ({ number: index + 1 }))));
   });
   servers.push(server);
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-  return { url: `http://127.0.0.1:${(server.address() as AddressInfo).port}/graphql`, requests };
+  return {
+    url: `http://127.0.0.1:${(server.address() as AddressInfo).port}/graphql`,
+    requests,
+    setDepth(nextDepth: number) {
+      currentDepth = nextDepth;
+    },
+  };
 }
 
 function registration(label: string, workspace: string, target = 1) {
@@ -84,6 +95,40 @@ function registration(label: string, workspace: string, target = 1) {
 }
 
 describe("whatever registers a project reaches the tracker for it", () => {
+  it("confirms the direct label depth before birthing from an older positive sample", async () => {
+    const tracker = await trackerStandingIn(4);
+    const paths = await sessionPaths();
+    const workspace = await scratch("redskilled-workspace-");
+    const launched: unknown[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      idleMs: 60_000,
+      demandMs: 0,
+      launch: (options) => {
+        launched.push(options);
+        throw new Error("a stale queue witness must not reach Worker birth");
+      },
+      queueDiscovery: {
+        ...resolveServeQueueDiscovery({ "queue-endpoint": tracker.url }, { [REDSKILLED_HOST_TOKEN_ENV]: "t" }),
+        intervalMs: 0,
+      },
+    });
+    running.push(daemon);
+
+    await registerRedskilledProject(paths, registration("acme/widgets", workspace, 4), { readyTimeoutMs: 5_000 });
+    await daemon.pollQueueDiscovery();
+    tracker.setDepth(0);
+
+    const tick = await daemon.driveDemand();
+
+    expect(tracker.requests).toHaveLength(2);
+    expect(tick.requested).toBe(0);
+    expect(tick.granted).toEqual([]);
+    expect(launched).toEqual([]);
+  });
+
   it("births a Worker for a registered project with a matching queue, end to end", async () => {
     const tracker = await trackerStandingIn(3);
     const paths = await sessionPaths();
@@ -109,7 +154,8 @@ describe("whatever registers a project reaches the tracker for it", () => {
     await daemon.pollQueueDiscovery();
     const tick = await daemon.driveDemand();
 
-    expect(tracker.requests).toHaveLength(1);
+    // The periodic sample is followed by the demand tick's direct pre-birth confirmation.
+    expect(tracker.requests).toHaveLength(2);
     expect(tick.granted).toHaveLength(1);
     expect(daemon.workerCount()).toBe(1);
     // The Worker really ran: the machine has a process's output on it.


### PR DESCRIPTION
Automated AFK landing for #3708. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3708

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789097846&installation_model_id=20659&pr_number=3713&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3713&signature=812c27b38c2bc2c75033b5a9b9832e00e39a1b9eae2f65c41666b99f6beef471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->