### PR TITLE
chore(release): consolidated changeset for the two-rails and resume-repair train

### DIFF
--- a/.changeset/two-rails-and-resume-repair-train.md
+++ b/.changeset/two-rails-and-resume-repair-train.md
@@ -1,0 +1,26 @@
+---
+"@reddb-io/redskilled": minor
+"@reddb-io/dev": minor
+"@reddb-io/red-skills": minor
+"@reddb-io/rsp": minor
+---
+
+Two-rails GitHub client and resume-repair train.
+
+GitHub budget — the structural end of the GraphQL exhaustion incidents:
+
+- The GitHub client rides two rails with an explicit REST/GraphQL choice per operation, per-pool budget awareness, and failover routing that never goes dark (#3663). Engine writes that have a REST equivalent leave the GraphQL pool.
+- The producer sizes births from a direct label read instead of the lagging search index, ending the boot-and-die once-workers that followed every requeue (#3708).
+
+Resume repair — a preserved worker branch can be finished again:
+
+- Resuming an issue whose branch exists with no open PR opens the draft route itself instead of dying on the orphaned-work refusal (#3704).
+- A failed feedback validation on an inherited diff becomes the agent's first work item instead of a suspect-infra park, so red WIP branches converge instead of cycling (#3705).
+
+Host hygiene:
+
+- The orphan reaper re-proves births from active units and worker env stamps after an event-lane rotation instead of withholding its census forever (#3706).
+- Test sandboxes pin the daemon home, so suite daemons stop writing to the operator's real event lane; the outbound scrubber now redacts the union of the stated and the process home (#3707).
+- The MCP host never recognizes its own bundle as the daemon entry (the exit-2 auto-spawn loop), and the daemon-entry probes refuse the mcp suffix (#3652).
+- Worker liveness disproof (pid 0, dead pid) bars the live claim without hiding the worker: what cannot be proven live lands in unattributed (#3660).
+- An auto-spawned daemon prefers the supervisor unit or an own scope instead of dying with the caller's terminal (#3657), and stop tells the truth about an alive daemon that misses the ping deadline (#3658).


### PR DESCRIPTION
Workers on this train shipped no changesets; this changeset names the whole span since 3.16.0 so the Version PR carries real release notes. Covers #3663, #3708, #3704, #3705, #3706, #3707, #3652, #3660, #3657, #3658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrKC117zw4RxnBrTysaeAp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789098331&installation_model_id=20659&pr_number=3714&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3714&signature=c7dfc51f46b919d3ea77015ee01c122a5067a4aefe0a67a21cdb27c363c84935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->