### PR TITLE
resume: #3674 (draft route for the pushed worker branch)

### DIFF
--- a/apps/redskilled/src/activity-cadence.ts
+++ b/apps/redskilled/src/activity-cadence.ts
@@ -117,6 +117,29 @@ export function nextActivityPollMs(input: RedskilledActivityCadenceInput): numbe
   return input.attended ? attendedMs : Math.max(attendedMs, unattendedMs);
 }
 
+/** The longest blind retry hold when GitHub supplied no usable reset instant. */
+export const REDSKILLED_ACTIVITY_RATE_LIMIT_MAX_BACKOFF_MS = REDSKILLED_AMORTIZED_MIN_MS;
+
+/**
+ * Turn an exhausted remote answer into the poller's next sleep.
+ *
+ * The reset is the next instant at which another answer can differ. A malformed
+ * or absent reset still slows the loop by four ordinary windows, while the cap
+ * prevents a corrupt timestamp from retiring the poller indefinitely.
+ */
+export function activityRateLimitBackoffMs(
+  limit: { readonly exhausted: boolean; readonly reset_at: string | null } | null,
+  baseMs: number,
+  nowMs: number,
+): number {
+  if (limit?.exhausted !== true) return baseMs;
+  const resetAtMs = limit.reset_at == null ? Number.NaN : Date.parse(limit.reset_at);
+  const waitMs = Number.isFinite(resetAtMs) && Number.isFinite(nowMs)
+    ? resetAtMs - nowMs + 1_000
+    : baseMs * 4;
+  return Math.min(REDSKILLED_ACTIVITY_RATE_LIMIT_MAX_BACKOFF_MS, Math.max(baseMs, waitMs));
+}
+
 export interface RedskilledActivityForwardInput {
   /** The window the pending poll was armed with; `null` when none is armed. */
   readonly pendingWindowMs: number | null;

--- a/apps/redskilled/src/daemon/activity-poller.ts
+++ b/apps/redskilled/src/daemon/activity-poller.ts
@@ -17,6 +17,7 @@
  * next cadence question rather than to the next daemon.
  */
 import {
+  activityRateLimitBackoffMs,
   activityPollComesForward,
   interactiveSessionsHolding,
   nextActivityPollMs,
@@ -35,6 +36,8 @@ export interface RedskilledActivityPollerOptions {
   readonly armed: boolean;
   /** Whether the daemon has begun letting go of its session. */
   readonly stopping: () => boolean;
+  /** Last remote quota answer; exhaustion parks the next cycle until reset. */
+  readonly rateLimit?: () => { readonly exhausted: boolean; readonly reset_at: string | null } | null;
 }
 
 export interface RedskilledActivityPoller {
@@ -61,6 +64,7 @@ export function createRedskilledActivityPoller(
   // mid-window can be told whether the wait it found is longer than the one
   // presence now asks for. `null` whenever no poll is armed.
   let armedWindowMs: number | null = null;
+  let polling = false;
 
   function cadenceMs(): number {
     return nextActivityPollMs({
@@ -69,17 +73,24 @@ export function createRedskilledActivityPoller(
     });
   }
 
+  function nextDelayMs(): number {
+    const cadence = cadenceMs();
+    return activityRateLimitBackoffMs(options.rateLimit?.() ?? null, cadence, Date.parse(options.clock()));
+  }
+
   function schedule(delayMs: number): void {
     if (options.stopping()) return;
     armedWindowMs = delayMs;
     timer = setTimeout(() => {
       timer = undefined;
       armedWindowMs = null;
+      polling = true;
       void options.poll()
         .catch(() => undefined)
         .finally(() => {
+          polling = false;
           if (options.stopping()) return;
-          schedule(cadenceMs());
+          schedule(nextDelayMs());
         });
     }, delayMs);
     timer.unref();
@@ -87,9 +98,15 @@ export function createRedskilledActivityPoller(
 
   return {
     arm() {
-      if (options.stopping() || timer != null || !options.armed || options.attendedMs <= 0) return;
-      void options.poll().catch(() => undefined);
-      schedule(cadenceMs());
+      if (options.stopping() || timer != null || polling || !options.armed || options.attendedMs <= 0) return;
+      polling = true;
+      void options.poll()
+        .catch(() => undefined)
+        .finally(() => {
+          polling = false;
+          if (options.stopping()) return;
+          schedule(nextDelayMs());
+        });
     },
 
     cadenceMs,

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -747,11 +747,6 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     void eventLane.recordWorker(appended.record).catch(() => undefined);
   }
 
-  /** Keep one Worker's ending, so the outcome rate rests on the same facts the lane does. */
-  function markWorkerOutcome(mark: RedskilledWorkerOutcomeMark): void {
-    outcomeMarks = pruneRedskilledMetricHistory([...outcomeMarks, mark], (entry) => entry.ts, { now: clock() });
-  }
-
   /**
    * One interval's activity fetch: ONE request, however many projects.
    *
@@ -1659,7 +1654,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     // describe the same ending at two different times.
     const input: RecordWorkerEventInput = { kind, worker, ts, detail, ...facts };
     if (kind === "worker-death" || kind === "worker-budget-kill") {
-      markWorkerOutcome({ worker_id: worker.worker_id, ts, outcome: kind });
+      const mark: RedskilledWorkerOutcomeMark = { worker_id: worker.worker_id, ts, outcome: kind };
+      outcomeMarks = pruneRedskilledMetricHistory([...outcomeMarks, mark], (entry) => entry.ts, { now: clock() });
       rememberObservedDeath(
         buildHostEvent(input),
         { startedAt: worker.started_at, ...(facts.refusal == null ? {} : { refusal: facts.refusal }) },

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -210,6 +210,8 @@ import {
   bootRefusalFromLog,
   observedWorkerDeath,
 } from "./tunables.js";
+import { createRemotePollDeadline } from "./remote-poll.js";
+import { createConfiguredRedskilledSelfPingMonitor } from "./self-ping.js";
 // Error moved to ./daemon/errors.ts — keep re-export for backward compat
 export { RedskilledAlreadyRunningError } from "../daemon/errors.js";
 
@@ -344,6 +346,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const publishedProbe = options.publishedVersion ?? ((running: string) => probePublishedRedskilledVersion(running));
   const replaceCheckMs = options.replaceCheckMs ?? DEFAULT_REDSKILLED_REPLACE_CHECK_MS;
   const publishedProbeTimeoutMs = options.publishedProbeTimeoutMs ?? DEFAULT_REDSKILLED_PUBLISHED_PROBE_TIMEOUT_MS;
+  const remotePoll = createRemotePollDeadline(options.remotePollTimeoutMs);
   const localEvidence = options.localPublishedEvidence ??
     ((running: string) => localRedskilledPublishedEvidence(running, options.replacementIO?.env ?? process.env));
   const bornByReplacement = options.bornByReplacement ?? isRedskilledBornByReplacement();
@@ -501,7 +504,9 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     attendedMs: activityMs,
     armed: queueRegistration != null || (activityRegistration != null && activityRegistration.projects.length > 0),
     stopping: () => stopping,
+    rateLimit: () => lastActivity?.rate_limit ?? null,
   });
+  const selfPingMonitor = createConfiguredRedskilledSelfPingMonitor(paths.socketPath, options);
   let resolveClosed!: () => void;
   const closed = new Promise<void>((resolve) => {
     resolveClosed = resolve;
@@ -666,6 +671,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       startedAt,
       ceiling,
       scope: describeMachineScope(machineClaimStore.claimPath, claimLabels, machineOwner),
+      requestHealth: selfPingMonitor.health(),
       workers: [...workers.values()],
       registrations: [...registrations.values()],
       demand: lastDemand,
@@ -755,15 +761,15 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
    * to pass for current, because the failure is itself the fact a consumer needs.
    */
   async function pollRepositoryActivity(): Promise<RedskilledRepositoryActivity | null> {
-    return lastActivity = await pollRegistrationActivity({
-      ...(activityRegistration == null ? {} : { explicit: activityRegistration }),
-      registrations: registrations.values(),
-      resolveHostTransport: () => {
-        armQueueTransport();
-        return queueTransport;
-      },
-      now: clock(), previous: lastActivity,
-    });
+    return lastActivity = await remotePoll("repository activity poll", () => pollRegistrationActivity({
+        ...(activityRegistration == null ? {} : { explicit: activityRegistration }),
+        registrations: registrations.values(),
+        resolveHostTransport: () => {
+          armQueueTransport();
+          return queueTransport;
+        },
+        now: clock(), previous: lastActivity,
+      }));
   }
 
   /** Ask the token once host-wide; every answer replaces the stored observation. */
@@ -777,7 +783,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       }).finally(() => { balanceHydration = null; });
       if ((await balanceHydration) !== null) return lastBalance;
     }
-    lastBalance = await fetchGithubBalance({ transport: balanceRegistration.transport, now: clock() });
+    lastBalance = await remotePoll("GitHub balance poll", () =>
+      fetchGithubBalance({ transport: balanceRegistration.transport, now: clock() }));
     await balanceRegistration.store?.write(lastBalance).catch(() => undefined);
     return lastBalance;
   }
@@ -804,17 +811,12 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         .then(() => {
           if (stopping) return;
           const nextMs = balanceRegistration.intervalMsOverride ??
-            githubBalanceCadenceMs(lastBalance ?? unaskedBalance(), { now: clock() });
+            githubBalanceCadenceMs(lastBalance ?? unaskedGithubBalance(clock()), { now: clock() });
           balanceTimer = setTimeout(tick, nextMs);
           balanceTimer.unref();
         });
     };
     tick();
-  }
-
-  /** The balance a daemon that has asked nothing holds — never a full budget. */
-  function unaskedBalance(): GithubBalance {
-    return unaskedGithubBalance(clock());
   }
 
   /**
@@ -890,12 +892,12 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       lastQueue = unconfiguredQueueDiscovery(projects, now, queueUnconfiguredReason);
       return lastQueue;
     }
-    lastQueue = await fetchQueueDiscovery({
-      projects,
-      transport: queueTransport,
-      now,
-      ...(queueRegistration?.batchSize == null ? {} : { batchSize: queueRegistration.batchSize }),
-    });
+    lastQueue = await remotePoll("queue poll", () => fetchQueueDiscovery({
+        projects,
+        transport: queueTransport!,
+        now,
+        ...(queueRegistration?.batchSize == null ? {} : { batchSize: queueRegistration.batchSize }),
+      }));
     // The depth this poll just counted is the renewal a project with open work
     // gets (Amendment 7), applied here rather than at the next read so a deadline
     // is never judged against a poll the daemon had already superseded.
@@ -2176,6 +2178,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     if (replaceTimer) clearInterval(replaceTimer);
     if (replaceBootTimer) clearTimeout(replaceBootTimer);
     activityPoller.stop();
+    selfPingMonitor.stop();
     if (balanceTimer) clearTimeout(balanceTimer);
     if (queueTimer) clearTimeout(queueTimer);
     if (demandTimer) clearInterval(demandTimer);
@@ -2289,9 +2292,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   server.on("connection", (socket) => {
     activeSockets.add(socket);
     socket.once("close", () => activeSockets.delete(socket));
-    armIdleTimer();
     handleSocket(socket, async (request, reply) => {
-      armIdleTimer();
+      if (request.op !== "ping" || request.self !== true) armIdleTimer();
       const response = await respond(request);
       reply(response);
       // The report is written to the caller BEFORE the daemon leaves: a stop that
@@ -2432,6 +2434,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   armBalanceTimer();
   armQueueTimer();
   armDemandTimer();
+  selfPingMonitor.arm();
 
   return {
     socketPath: paths.socketPath,

--- a/apps/redskilled/src/daemon/remote-poll.ts
+++ b/apps/redskilled/src/daemon/remote-poll.ts
@@ -1,0 +1,38 @@
+/** Hard wall-clock bound for one daemon-owned remote poll. */
+export const DEFAULT_REDSKILLED_REMOTE_POLL_TIMEOUT_MS = 10_000;
+
+/** Bind the daemon option once, then apply the same deadline to every poller. */
+export function createRemotePollDeadline(
+  timeoutMs = DEFAULT_REDSKILLED_REMOTE_POLL_TIMEOUT_MS,
+): <T>(label: string, poll: () => Promise<T>) => Promise<T> {
+  return async <T>(label: string, poll: () => Promise<T>) =>
+    await withinRemotePollDeadline(label, timeoutMs, poll);
+}
+
+/**
+ * Let a poller go back to sleep even when its transport never settles.
+ *
+ * The remote promise may still finish after the deadline when its transport has
+ * no cancellation surface. Callers must therefore commit fetched state only
+ * from this promise's resolved value, never from inside `poll`.
+ */
+export async function withinRemotePollDeadline<T>(
+  label: string,
+  timeoutMs: number,
+  poll: () => Promise<T>,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return await poll();
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`redskilled ${label} exceeded its ${timeoutMs}ms remote-call deadline`)),
+      timeoutMs,
+    );
+    timer.unref();
+  });
+  try {
+    return await Promise.race([Promise.resolve().then(poll), deadline]);
+  } finally {
+    if (timer != null) clearTimeout(timer);
+  }
+}

--- a/apps/redskilled/src/daemon/self-ping.ts
+++ b/apps/redskilled/src/daemon/self-ping.ts
@@ -1,0 +1,139 @@
+import { randomUUID } from "node:crypto";
+import type { RedskilledRequestHealth } from "../host-state.js";
+import { sendRedskilledRequest } from "../protocol.js";
+
+export const DEFAULT_REDSKILLED_SELF_PING_INTERVAL_MS = 5_000;
+export const DEFAULT_REDSKILLED_SELF_PING_TIMEOUT_MS = 150;
+export const DEFAULT_REDSKILLED_SELF_PING_MISS_THRESHOLD = 3;
+
+export interface RedskilledSelfPingMonitorOptions {
+  readonly probe: () => Promise<unknown>;
+  readonly intervalMs: number;
+  readonly timeoutMs: number;
+  readonly missThreshold: number;
+}
+
+export interface RedskilledSelfPingMonitor {
+  arm(): void;
+  stop(): void;
+  health(): RedskilledRequestHealth;
+}
+
+export interface ConfiguredRedskilledSelfPingOptions {
+  readonly selfPingIntervalMs?: number;
+  readonly selfPingTimeoutMs?: number;
+  readonly selfPingMissThreshold?: number;
+  readonly selfPing?: () => Promise<unknown>;
+}
+
+/** Production socket probe with all daemon defaults resolved in one module. */
+export function createConfiguredRedskilledSelfPingMonitor(
+  socketPath: string,
+  options: ConfiguredRedskilledSelfPingOptions = {},
+): RedskilledSelfPingMonitor {
+  const timeoutMs = options.selfPingTimeoutMs ?? DEFAULT_REDSKILLED_SELF_PING_TIMEOUT_MS;
+  return createRedskilledSelfPingMonitor({
+    intervalMs: options.selfPingIntervalMs ?? DEFAULT_REDSKILLED_SELF_PING_INTERVAL_MS,
+    timeoutMs,
+    missThreshold: options.selfPingMissThreshold ?? DEFAULT_REDSKILLED_SELF_PING_MISS_THRESHOLD,
+    probe: options.selfPing ?? (async () => {
+      const response = await sendRedskilledRequest(
+        { socketPath, timeoutMs },
+        { id: randomUUID(), op: "ping", self: true },
+      );
+      if (!response.ok) throw new Error(response.error);
+    }),
+  });
+}
+
+/** Watch the daemon's real socket path without ever sharing a poller's promise. */
+export function createRedskilledSelfPingMonitor(
+  options: RedskilledSelfPingMonitorOptions,
+): RedskilledSelfPingMonitor {
+  let timer: NodeJS.Timeout | undefined;
+  let stopped = false;
+  let expectedAtMs: number | null = null;
+  let consecutiveMisses = 0;
+  let lastProbeAt: string | null = null;
+  let lastSuccessAt: string | null = null;
+  let lastFailureAt: string | null = null;
+  let detail = "the daemon has not self-pinged yet";
+  const threshold = Math.max(1, Math.floor(options.missThreshold));
+
+  function miss(count: number, at: string, reason: string): void {
+    consecutiveMisses += Math.max(1, count);
+    lastFailureAt = at;
+    detail = reason;
+  }
+
+  function schedule(): void {
+    if (stopped || options.intervalMs <= 0) return;
+    expectedAtMs = Date.now() + options.intervalMs;
+    timer = setTimeout(() => void tick(), options.intervalMs);
+    timer.unref();
+  }
+
+  async function tick(): Promise<void> {
+    timer = undefined;
+    const startedMs = Date.now();
+    const at = new Date(startedMs).toISOString();
+    lastProbeAt = at;
+    const overdueIntervals = expectedAtMs == null
+      ? 0
+      : Math.max(0, Math.floor((startedMs - expectedAtMs) / Math.max(1, options.intervalMs)));
+    if (overdueIntervals > 0) {
+      miss(
+        overdueIntervals,
+        at,
+        `the daemon event loop missed ${overdueIntervals} scheduled self-ping interval(s) before this probe ran`,
+      );
+    }
+
+    let deadline: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        Promise.resolve().then(options.probe),
+        new Promise<never>((_resolve, reject) => {
+          deadline = setTimeout(
+            () => reject(new Error(`self-ping exceeded ${options.timeoutMs}ms`)),
+            Math.max(1, options.timeoutMs),
+          );
+          deadline.unref();
+        }),
+      ]);
+      const elapsedMs = Date.now() - startedMs;
+      if (elapsedMs > options.timeoutMs) throw new Error(`self-ping answered after ${elapsedMs}ms`);
+      lastSuccessAt = new Date().toISOString();
+      if (overdueIntervals === 0) {
+        consecutiveMisses = 0;
+        detail = `the daemon answered its own socket in ${elapsedMs}ms`;
+      }
+    } catch (error) {
+      miss(1, new Date().toISOString(), error instanceof Error ? error.message : String(error));
+    } finally {
+      if (deadline != null) clearTimeout(deadline);
+      schedule();
+    }
+  }
+
+  return {
+    arm() {
+      if (stopped || timer != null || options.intervalMs <= 0) return;
+      schedule();
+    },
+    stop() {
+      stopped = true;
+      if (timer != null) clearTimeout(timer);
+      timer = undefined;
+    },
+    health: () => ({
+      status: consecutiveMisses >= threshold ? "degraded" : "healthy",
+      consecutive_misses: consecutiveMisses,
+      miss_threshold: threshold,
+      last_probe_at: lastProbeAt,
+      last_success_at: lastSuccessAt,
+      last_failure_at: lastFailureAt,
+      detail,
+    }),
+  };
+}

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -79,6 +79,16 @@ import { type RedskilledLease,
 } from "../session-lease.js";
 export interface RedskilledDaemonOptions {
   readonly paths: RedskilledPaths;
+  /** Hard deadline for each daemon-owned GitHub call; 0 or below disables it. */
+  readonly remotePollTimeoutMs?: number;
+  /** Self-request cadence; 0 or below disables request-lane monitoring. */
+  readonly selfPingIntervalMs?: number;
+  /** Wall-clock deadline for one self-request. */
+  readonly selfPingTimeoutMs?: number;
+  /** Consecutive misses that make host-state report the lane degraded. */
+  readonly selfPingMissThreshold?: number;
+  /** Test seam; production probes the daemon's own socket. */
+  readonly selfPing?: () => Promise<unknown>;
   readonly daemonVersion?: string;
   /**
    * The verdicts this host's boot reaper posed, carried into every surface.

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -288,6 +288,17 @@ export interface RedskilledOrphanedRegistration {
   readonly registered_at?: string;
 }
 
+/** The daemon's independent proof that its request lane still answers. */
+export interface RedskilledRequestHealth {
+  readonly status: "healthy" | "degraded";
+  readonly consecutive_misses: number;
+  readonly miss_threshold: number;
+  readonly last_probe_at: string | null;
+  readonly last_success_at: string | null;
+  readonly last_failure_at: string | null;
+  readonly detail: string;
+}
+
 export interface RedskilledHostState {
   readonly version: 1;
   readonly protocol_version: number;
@@ -306,6 +317,7 @@ export interface RedskilledHostState {
    * state its own scope would leave a second one detectable only by its damage.
    */
   readonly scope?: RedskilledScopeState;
+  readonly request_health?: RedskilledRequestHealth;
   readonly workers: readonly RedskilledWorkerView[];
   readonly projects: readonly RedskilledProjectView[];
   /**
@@ -356,6 +368,8 @@ export interface BuildHostStateInput {
   readonly ceiling?: RedskilledHostCeiling;
   /** The scope block; absent leaves the document without one rather than inventing it. */
   readonly scope?: RedskilledScopeState;
+  /** Independent socket self-ping state; absent for older daemons. */
+  readonly requestHealth?: RedskilledRequestHealth;
   readonly workers?: readonly RedskilledWorkerView[];
   /**
    * The host memory ceiling the accounting is judged against; `null` is unbounded.
@@ -426,6 +440,7 @@ export function buildHostState(input: BuildHostStateInput): RedskilledHostState 
     started_at: input.startedAt,
     ...(input.ceiling == null ? {} : { ceiling: input.ceiling }),
     ...(input.scope == null ? {} : { scope: input.scope }),
+    ...(input.requestHealth == null ? {} : { request_health: input.requestHealth }),
     workers,
     projects: [...counts.entries()]
       .map(([project_label, worker_count]) => ({ project_label, worker_count }))
@@ -558,6 +573,7 @@ export function isRedskilledHostState(value: unknown): value is RedskilledHostSt
     // Same tolerance the upgrade block gets, for the same reason: a daemon from a
     // bundle that predates the scope block still answers completely.
     (state.scope === undefined || isRedskilledScopeState(state.scope)) &&
+    (state.request_health === undefined || isRedskilledRequestHealth(state.request_health)) &&
     // The same tolerance again, and for the same reason: a daemon from a bundle
     // that predates Amendment 4 answers completely without a registrations block,
     // while a block that IS there and is the wrong shape still fails closed.
@@ -577,6 +593,18 @@ export function isRedskilledHostState(value: unknown): value is RedskilledHostSt
     // make an older daemon's complete answer read as malformed — while a field
     // that IS there and is the wrong shape still fails closed.
     (state.upgrade === undefined || isRedskilledUpgradeState(state.upgrade));
+}
+
+function isRedskilledRequestHealth(value: unknown): value is RedskilledRequestHealth {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const health = value as Record<string, unknown>;
+  return (health.status === "healthy" || health.status === "degraded") &&
+    Number.isInteger(health.consecutive_misses) &&
+    Number.isInteger(health.miss_threshold) &&
+    (health.last_probe_at === null || typeof health.last_probe_at === "string") &&
+    (health.last_success_at === null || typeof health.last_success_at === "string") &&
+    (health.last_failure_at === null || typeof health.last_failure_at === "string") &&
+    typeof health.detail === "string";
 }
 
 function isBirthLatch(value: unknown): value is RedskilledBirthLatch {

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -195,7 +195,7 @@ export interface RedskilledDashboardRenderRequest {
 }
 
 export type RedskilledRequest =
-  | { id: string; op: "ping" }
+  | { id: string; op: "ping"; self?: true }
   | { id: string; op: "host-state" }
   | { id: string; op: "reap"; report?: boolean }
   | { id: string; op: "statusline-payload"; session_project?: string; extras?: RedskilledStatuslineExtrasRequest }

--- a/apps/redskilled/src/queue-discovery.ts
+++ b/apps/redskilled/src/queue-discovery.ts
@@ -31,6 +31,7 @@
  */
 
 import {
+  githubRateLimitResetAt,
   isGithubRateLimitError,
   type GithubAttributedOperation,
   type GithubResponseHeaders,
@@ -375,7 +376,7 @@ async function fetchConditionalQueueDiscovery(
       const rateLimited = isGithubRateLimitError(error);
       rateLimit = mergeRateLimit(rateLimit, {
         remaining: null,
-        reset_at: null,
+        reset_at: rateLimited ? githubRateLimitResetAt(error) : null,
         exhausted: rateLimited,
       });
       projects.push({

--- a/apps/redskilled/src/repository-activity-conditional.ts
+++ b/apps/redskilled/src/repository-activity-conditional.ts
@@ -1,6 +1,7 @@
 /** Presence-driven conditional REST polling for repository activity. */
 
 import {
+  githubRateLimitResetAt,
   isGithubRateLimitError,
   type GithubAttributedOperation,
   type GithubResponseHeaders,
@@ -128,7 +129,7 @@ export async function fetchConditionalRepositoryActivity(
       const rateLimited = isGithubRateLimitError(error);
       rateLimit = mergeActivityRateLimit(rateLimit, {
         remaining: null,
-        reset_at: null,
+        reset_at: rateLimited ? githubRateLimitResetAt(error) : null,
         exhausted: rateLimited,
         point_cost: null,
       });

--- a/apps/redskilled/tests/activity-cadence.test.ts
+++ b/apps/redskilled/tests/activity-cadence.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   activityPollComesForward,
+  activityRateLimitBackoffMs,
   interactiveSessionsHolding,
   isCacheWarmCadenceMs,
   nextActivityPollMs,
@@ -83,6 +84,19 @@ describe("the poll cadence follows presence", () => {
     expect(nextActivityPollMs({ attended: true, attendedMs: 0 })).toBe(DEFAULT_REDSKILLED_ACTIVITY_MS);
     expect(nextActivityPollMs({ attended: false, unattendedMs: Number.NaN }))
       .toBe(REDSKILLED_ACTIVITY_UNATTENDED_MS);
+  });
+});
+
+describe("a rate-limited activity poll sleeps the poller", () => {
+  it("parks until reset instead of retrying on the attended request cadence", () => {
+    expect(activityRateLimitBackoffMs({
+      exhausted: true,
+      reset_at: new Date(T0_MS + 90_000).toISOString(),
+    }, 20_000, T0_MS)).toBe(91_000);
+  });
+
+  it("does not change the cadence after an ordinary answer", () => {
+    expect(activityRateLimitBackoffMs({ exhausted: false, reset_at: null }, 20_000, T0_MS)).toBe(20_000);
   });
 });
 
@@ -200,6 +214,32 @@ const REGISTRATION_REQUEST = {
 } as const;
 
 describe("the daemon's own loop spends at the window presence asks for", () => {
+  it("parks the live poller after a rate-limit refusal", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval", "setTimeout", "clearTimeout"] });
+    let calls = 0;
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      repositoryActivity: {
+        projects: [{ project_label: "acme/p0", owner: "acme", name: "p0" }],
+        hostTokenRef: "host",
+        intervalMs: 10,
+        transport: async () => {
+          calls += 1;
+          throw new Error("API rate limit exceeded");
+        },
+      },
+    });
+    running.push(daemon);
+    daemon.registerProject({ ...REGISTRATION_REQUEST });
+
+    await vi.advanceTimersByTimeAsync(39);
+    expect(calls).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(calls).toBe(2);
+  });
+
   it("holds an idle host at the back-off, then tightens the moment a session registers", async () => {
     // Only the intervals are faked: the daemon's start still does real I/O, and
     // a fake clock over all of it would stall the bind rather than the timers.

--- a/apps/redskilled/tests/request-lane-liveness.test.ts
+++ b/apps/redskilled/tests/request-lane-liveness.test.ts
@@ -1,0 +1,196 @@
+// A tracker call may outlive a whole operator session. It must never become the
+// daemon's request lane: socket reads, writes, dispatch, and stop are all local
+// operations and remain answerable while the poller is parked behind GitHub.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import {
+  publishRedskilledWorkerLogLine,
+  readRedskilledHostState,
+  registerRedskilledProject,
+  startRedskilledWorker,
+} from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import { sendRedskilledRequest } from "../src/protocol.js";
+import type { RedskilledActivityTransport } from "../src/repository-activity.js";
+import { REDSKILLED_WORKER_DISPLAY_ABSENT } from "../src/worker-display.js";
+import type { LaunchedWorker, LaunchWorkerOptions } from "../src/worker-launch.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+function localLaunch(options: LaunchWorkerOptions): LaunchedWorker {
+  const worker = {
+    worker_id: options.spec.worker_id ?? "wLOCAL",
+    project_label: options.spec.project_label,
+    workspace_path: options.spec.workspace_path,
+    pid: 7_674,
+    started_at: options.clock!(),
+    isolated: false,
+    warnings: [],
+  };
+  return {
+    worker,
+    admission: options.admission,
+    warnings: [],
+    plan: {
+      backend: "none",
+      command: options.spec.command,
+      args: [...(options.spec.args ?? [])],
+      isolated: false,
+      warnings: [],
+    } as unknown as LaunchedWorker["plan"],
+    child: { pid: worker.pid, once: () => undefined, unref: () => undefined } as unknown as LaunchedWorker["child"],
+  };
+}
+
+describe("the daemon request lane during a stalled GitHub poll", () => {
+  it("does not mistake its own liveness probes for user activity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-self-ping-idle-"));
+    roots.push(root);
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 20,
+      sampleMs: 0,
+      selfPingIntervalMs: 5,
+      selfPingTimeoutMs: 2,
+    });
+    running.push(daemon);
+
+    await expect(Promise.race([
+      daemon.closed.then(() => "closed"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("still open"), 100)),
+    ])).resolves.toBe("closed");
+  });
+
+  it("reports consecutive self-ping misses on host state", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-self-ping-"));
+    roots.push(root);
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      selfPingIntervalMs: 5,
+      selfPingTimeoutMs: 2,
+      selfPingMissThreshold: 2,
+      selfPing: async () => await new Promise<never>(() => undefined),
+    });
+    running.push(daemon);
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const health = (daemon.hostState() as unknown as Record<string, unknown>).request_health;
+    expect(health).toMatchObject({
+      status: "degraded",
+      consecutive_misses: expect.any(Number),
+      miss_threshold: 2,
+    });
+  });
+
+  it("keeps local requests and metrics live, and releases the poller at its deadline", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-request-lane-"));
+    roots.push(root);
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const never = new Promise<unknown>(() => undefined);
+    const transport = (() => never) as RedskilledActivityTransport;
+    let minute = 0;
+    const daemon = await startRedskilledDaemon({
+      paths,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      idleMs: 60_000,
+      sampleMs: 0,
+      demandMs: 0,
+      launch: localLaunch,
+      clock: () => new Date(Date.parse("2026-08-11T20:00:00.000Z") + minute * 60_000).toISOString(),
+      queueDiscovery: { transport, intervalMs: 0 },
+      githubBalance: { transport: () => never },
+      remotePollTimeoutMs: 25,
+    });
+    running.push(daemon);
+
+    await registerRedskilledProject(paths, {
+      project_label: "acme/widgets",
+      selector: "repo:acme/widgets is:issue is:open label:ready-for-agent",
+      queue_poll: { owner: "acme", repo: "widgets", labels: ["ready-for-agent"] },
+      argv: ["work"],
+      workspace_path: root,
+      target: 1,
+    }, { requestTimeoutMs: 150 });
+
+    const stalledPoll = daemon.pollQueueDiscovery().then(
+      () => "completed",
+      (error: unknown) => error instanceof Error ? error.message : String(error),
+    );
+    const stalledActivity = daemon.pollRepositoryActivity().then(
+      () => "completed",
+      (error: unknown) => error instanceof Error ? error.message : String(error),
+    );
+    const stalledBalance = daemon.pollGithubBalance().then(
+      () => "completed",
+      (error: unknown) => error instanceof Error ? error.message : String(error),
+    );
+
+    const ping = await sendRedskilledRequest(
+      { socketPath: paths.socketPath, timeoutMs: 150 },
+      { id: "ping-under-stall", op: "ping" },
+    );
+    expect(ping.ok).toBe(true);
+
+    const started = await startRedskilledWorker(paths, {
+      worker_id: "wLOCAL",
+      project_label: "acme/widgets",
+      workspace_path: root,
+      command: "work",
+    }, { requestTimeoutMs: 150 });
+    await publishRedskilledWorkerLogLine(paths, {
+      worker_id: started.worker.worker_id,
+      session_project: "acme/widgets",
+      line: "still working",
+      display: { ...REDSKILLED_WORKER_DISPLAY_ABSENT, tokens: 120, tools: 3 },
+    }, { requestTimeoutMs: 150 });
+    minute = 1;
+    await publishRedskilledWorkerLogLine(paths, {
+      worker_id: started.worker.worker_id,
+      session_project: "acme/widgets",
+      line: "still working",
+      display: { ...REDSKILLED_WORKER_DISPLAY_ABSENT, tokens: 240, tools: 5 },
+    }, { requestTimeoutMs: 150 });
+
+    const state = await readRedskilledHostState(paths, { requestTimeoutMs: 150 });
+    expect(state.workers.map((worker) => worker.worker_id)).toContain("wLOCAL");
+    expect(daemon.statuslinePayload().metrics?.hour.tokens_per_min.value).not.toBeNull();
+
+    for (const poll of [stalledPoll, stalledActivity, stalledBalance]) {
+      const pollOutcome = await Promise.race([
+        poll,
+        new Promise<string>((resolve) => setTimeout(() => resolve("still pending"), 100)),
+      ]);
+      expect(pollOutcome).toContain("deadline");
+    }
+
+    const shutdown = await sendRedskilledRequest(
+      { socketPath: paths.socketPath, timeoutMs: 150 },
+      { id: "shutdown-under-stall", op: "shutdown" },
+    );
+    expect(shutdown.ok).toBe(true);
+  });
+});

--- a/packages/github/conditional-client.test.ts
+++ b/packages/github/conditional-client.test.ts
@@ -7,6 +7,7 @@ import { createGithubAttributionLedger } from "./attribution.js";
 import {
   createGithubClient,
   GithubPoolUnavailableError,
+  githubRateLimitResetAt,
   isGithubRateLimitError,
   type GithubRequestFetch,
 } from "./conditional-client.js";
@@ -20,6 +21,22 @@ const SEARCH_POLL: GithubAttributedOperation = {
 };
 
 const roots: string[] = [];
+
+describe("rate-limit reset evidence", () => {
+  it("reads the primary reset instant from a refused response", () => {
+    expect(githubRateLimitResetAt({
+      status: 403,
+      response: { headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "1" } },
+    }, 0)).toBe("1970-01-01T00:00:01.000Z");
+  });
+
+  it("dates a secondary-limit retry-after from the refusal instant", () => {
+    expect(githubRateLimitResetAt({
+      status: 429,
+      response: { headers: { "retry-after": "60" } },
+    }, 0)).toBe("1970-01-01T00:01:00.000Z");
+  });
+});
 
 function balance(restRemaining: number, graphqlRemaining: number): GithubBalance {
   const reset = "2026-08-05T12:00:00.000Z";

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -558,6 +558,23 @@ export function isGithubRateLimitError(error: unknown): boolean {
     (error instanceof Error && /secondary rate|rate limit/i.test(error.message));
 }
 
+/** Reset instant carried by a primary or secondary rate-limit refusal. */
+export function githubRateLimitResetAt(error: unknown, nowMs = Date.now()): string | null {
+  const headers = errorHeaders(error);
+  const resetSeconds = Number(header(headers, "x-ratelimit-reset"));
+  if (Number.isFinite(resetSeconds) && resetSeconds >= 0) {
+    return new Date(resetSeconds * 1_000).toISOString();
+  }
+  const retryAfter = header(headers, "retry-after");
+  if (retryAfter == null) return null;
+  const delaySeconds = Number(retryAfter);
+  if (Number.isFinite(delaySeconds) && delaySeconds >= 0 && Number.isFinite(nowMs)) {
+    return new Date(nowMs + delaySeconds * 1_000).toISOString();
+  }
+  const retryAtMs = Date.parse(retryAfter);
+  return Number.isFinite(retryAtMs) ? new Date(retryAtMs).toISOString() : null;
+}
+
 function httpStatus(error: unknown): number | undefined {
   if (!isRecord(error)) return undefined;
   return typeof error.status === "number" ? error.status : undefined;

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -50,6 +50,7 @@ export {
   createGithubClient,
   createMemoryGithubEtagStore,
   githubSingleObjectCoalescingThreshold,
+  githubRateLimitResetAt,
   isGithubRateLimitError,
   type CreateGithubClientOptions,
   type GithubClient,


### PR DESCRIPTION
Draft route so a resume never dies on the orphaned-work refusal. The resuming worker finishes and marks ready.

Refs #3674

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789103284&installation_model_id=20659&pr_number=3722&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3722&signature=16dd7b07eaabcc99d56cd92b79a8611df4010a72f3cb1491f2addee213310b46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->