### PR TITLE
feat: #3723 redskilled logs periodic GitHub rate-limit snapshots for forensic timelines

### DIFF
--- a/apps/dev/src/core/operational-probes/lane-census.ts
+++ b/apps/dev/src/core/operational-probes/lane-census.ts
@@ -174,6 +174,11 @@ function staticRegistrations(projectRoot: string, hostRoot: string): LaneRegistr
       join(hostState, "github", "spend.toonl"),
       LANE_RETENTION_REGISTRY["github-spend"],
     ),
+    host(
+      "github-balance-history",
+      join(hostState, "github", "balance-history.toonl"),
+      LANE_RETENTION_REGISTRY["github-balance-history"],
+    ),
   ];
 }
 

--- a/apps/dev/tests/lane-census.test.ts
+++ b/apps/dev/tests/lane-census.test.ts
@@ -83,12 +83,14 @@ describe("lane census operational probe", () => {
         "rsp-telemetry.spool.toonl.42.1783958744462.drain",
       );
       const hostEvents = join(hostRoot, "redskilled.log.toonl");
+      const balanceHistory = join(hostRoot, "state", "github", "balance-history.toonl");
       await Promise.all([
         mkdir(join(projectRoot, ".red", "state", "deaths"), { recursive: true }),
         mkdir(join(projectRoot, ".red", "tmp", "workers", "wTEST"), { recursive: true }),
         mkdir(join(projectRoot, ".red", "state", "unknown"), { recursive: true }),
         mkdir(join(projectRoot, ".red", "state", "rsp"), { recursive: true }),
         mkdir(hostRoot, { recursive: true }),
+        mkdir(join(hostRoot, "state", "github"), { recursive: true }),
       ]);
       await Promise.all([
         writeFile(projectDeaths, "header\nrecord\n"),
@@ -97,6 +99,7 @@ describe("lane census operational probe", () => {
         writeFile(deadTemp, "partial"),
         writeFile(deadDrain, "pending telemetry"),
         writeFile(hostEvents, "host-event\n"),
+        writeFile(balanceHistory, "[1]{pool}:\ngraphql\n"),
       ]);
 
       const input = await collectLaneCensusProbeInput({
@@ -124,6 +127,13 @@ describe("lane census operational probe", () => {
           id: "redskilled-events",
           tier: "host",
           path: "[host]/redskilled.log.toonl",
+          lines: 1,
+        }),
+        expect.objectContaining({
+          id: "github-balance-history",
+          tier: "host",
+          path: "[host]/state/github/balance-history.toonl",
+          maxBytes: 2 * 1024 * 1024,
           lines: 1,
         }),
       ]));

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -43,6 +43,7 @@ import {
 } from "./daemon.js";
 import {
   createGithubAttributionLedger,
+  createGithubBalanceHistory,
   createGithubBalanceStore,
   createGithubBalanceTransport,
   type GithubAttributionLedger,
@@ -462,6 +463,9 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       : {
           ...resolvedGithubBalance,
           store: createGithubBalanceStore({ path: join(hostStateRoot, "github", "balance.toon") }),
+          history: createGithubBalanceHistory({
+            path: join(hostStateRoot, "github", "balance-history.toonl"),
+          }),
         };
     // Before this daemon anchors itself, it speaks for whatever the last one
     // could not (slice #3028). The host singleton is the only process guaranteed

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -781,6 +781,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     lastBalance = await remotePoll("GitHub balance poll", () =>
       fetchGithubBalance({ transport: balanceRegistration.transport, now: clock() }));
     await balanceRegistration.store?.write(lastBalance).catch(() => undefined);
+    await balanceRegistration.history?.append(lastBalance).catch(() => undefined);
     return lastBalance;
   }
 

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -47,6 +47,7 @@ import { type RedskilledProjectDeregistered,
   type RedskilledWorkerHeartbeatRequest,
 } from "../protocol.js";
 import { type GithubBalance,
+  type GithubBalanceHistory,
   type GithubBalanceStore,
   type GithubBalanceTransport,
 } from "@reddb-io/github";
@@ -292,6 +293,8 @@ export interface RedskilledBalanceRegistration {
   readonly transport: GithubBalanceTransport;
   /** Host-state snapshot shared with fresh and parallel local processes. */
   readonly store?: GithubBalanceStore;
+  /** Append-only forensic pool curve written from the same answers as the snapshot. */
+  readonly history?: GithubBalanceHistory;
   /**
    * A hard window, for a test that needs one. Production leaves this absent and
    * lets the balance decide — that is the whole decision.

--- a/apps/redskilled/tests/github-balance-history.test.ts
+++ b/apps/redskilled/tests/github-balance-history.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createGithubBalanceHistory,
+  parseGithubBalance,
+} from "@reddb-io/github";
+import { parseRecords } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+
+const daemons: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(daemons.splice(0).map((daemon) => daemon.stop().catch(() => undefined)));
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function answer(graphqlRemaining: number): unknown {
+  const reset = Date.parse("2026-08-11T22:00:00.000Z") / 1_000;
+  return {
+    resources: {
+      core: { limit: 5_000, remaining: 4_883, used: 117, reset },
+      graphql: { limit: 5_000, remaining: graphqlRemaining, used: 5_000 - graphqlRemaining, reset },
+      search: { limit: 30, remaining: 30, used: 0, reset },
+    },
+  };
+}
+
+describe("redskilled GitHub balance history", () => {
+  it("piggybacks every pool row on asks without making another GitHub request", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-balance-history-"));
+    roots.push(root);
+    const historyPath = join(root, "state", "github", "balance-history.toonl");
+    let hydrated!: () => void;
+    const hydration = new Promise<void>((resolve) => { hydrated = resolve; });
+    const initial = parseGithubBalance(answer(1_000), { askedAt: "2026-08-11T20:59:00.000Z" });
+    const remaining = [1_000, 700, 0];
+    let asks = 0;
+    const daemon = await startRedskilledDaemon({
+      paths: resolveRedskilledPaths({
+        env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+        runtimeDir: root,
+      }),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      githubBalance: {
+        transport: async () => {
+          const value = remaining[asks]!;
+          asks += 1;
+          return answer(value);
+        },
+        store: {
+          read: async () => { hydrated(); return initial; },
+          write: async () => undefined,
+        },
+        history: createGithubBalanceHistory({
+          path: historyPath,
+          clock: () => "2026-08-11T21:59:59.000Z",
+        }),
+        intervalMsOverride: 3_600_000,
+      },
+    });
+    daemons.push(daemon);
+    await hydration;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await daemon.pollGithubBalance();
+    await daemon.pollGithubBalance();
+    await daemon.pollGithubBalance();
+
+    const rows = parseRecords(await readFile(historyPath, "utf8"));
+    expect(asks).toBe(3);
+    expect(rows).toHaveLength(9);
+    expect(rows.filter((row) => row.pool === "graphql").map((row) => row.remaining)).toEqual([
+      1_000,
+      700,
+      0,
+    ]);
+  });
+});

--- a/packages/github/balance-history.test.ts
+++ b/packages/github/balance-history.test.ts
@@ -1,0 +1,97 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseRecords } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createGithubBalanceHistory } from "./balance-history.js";
+import { parseGithubBalance } from "./balance.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function answer(graphqlRemaining: number): unknown {
+  const reset = Date.parse("2026-08-11T22:00:00.000Z") / 1_000;
+  return {
+    resources: {
+      core: { limit: 5_000, remaining: 4_883, used: 117, reset },
+      graphql: { limit: 5_000, remaining: graphqlRemaining, used: 5_000 - graphqlRemaining, reset },
+      search: { limit: 30, remaining: 30, used: 0, reset },
+    },
+  };
+}
+
+describe("the GitHub pool curve", () => {
+  it("keeps readable pool rows for regular asks, reserved-band entry, and zero crossing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "github-balance-history-"));
+    roots.push(root);
+    const path = join(root, "balance-history.toonl");
+    const instants = [
+      "2026-08-11T21:00:01.000Z",
+      "2026-08-11T21:10:01.000Z",
+      "2026-08-11T21:10:16.000Z",
+    ];
+    const history = createGithubBalanceHistory({ path, clock: () => instants.shift()! });
+
+    await history.append(parseGithubBalance(answer(1_000), { askedAt: "2026-08-11T21:00:00.000Z" }));
+    await history.append(parseGithubBalance(answer(700), { askedAt: "2026-08-11T21:10:00.000Z" }));
+    await history.append(parseGithubBalance(answer(0), { askedAt: "2026-08-11T21:10:15.000Z" }));
+
+    const rows = parseRecords(await readFile(path, "utf8"));
+    expect(rows).toHaveLength(9);
+    expect(rows.filter((row) => row.pool === "graphql")).toEqual([
+      {
+        ts: "2026-08-11T21:00:01.000Z",
+        pool: "graphql",
+        remaining: 1_000,
+        used: 4_000,
+        limit: 5_000,
+        reset_at: 1_786_485_600,
+        asked_at: "2026-08-11T21:00:00.000Z",
+      },
+      {
+        ts: "2026-08-11T21:10:01.000Z",
+        pool: "graphql",
+        remaining: 700,
+        used: 4_300,
+        limit: 5_000,
+        reset_at: 1_786_485_600,
+        asked_at: "2026-08-11T21:10:00.000Z",
+      },
+      {
+        ts: "2026-08-11T21:10:16.000Z",
+        pool: "graphql",
+        remaining: 0,
+        used: 5_000,
+        limit: 5_000,
+        reset_at: 1_786_485_600,
+        asked_at: "2026-08-11T21:10:15.000Z",
+      },
+    ]);
+  });
+
+  it("keeps the newest complete rows under the history lane ceiling", async () => {
+    const root = await mkdtemp(join(tmpdir(), "github-balance-history-"));
+    roots.push(root);
+    const path = join(root, "balance-history.toonl");
+    const history = createGithubBalanceHistory({
+      path,
+      maxBytes: 800,
+      clock: () => "2026-08-11T21:59:59.000Z",
+    });
+
+    for (let remaining = 19; remaining >= 0; remaining -= 1) {
+      await history.append(parseGithubBalance(answer(remaining), {
+        askedAt: `2026-08-11T21:${String(40 - remaining).padStart(2, "0")}:00.000Z`,
+      }));
+    }
+
+    const rows = parseRecords(await readFile(path, "utf8"));
+    expect((await stat(path)).size).toBeLessThanOrEqual(800);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.at(-2)).toMatchObject({ pool: "graphql", remaining: 0, used: 5_000 });
+  });
+});

--- a/packages/github/balance-history.ts
+++ b/packages/github/balance-history.ts
@@ -1,0 +1,114 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import {
+  LANE_RETENTION_REGISTRY,
+  laneOverCeiling,
+  trimLaneKeepLast,
+} from "@reddb-io/shared/lane-retention.js";
+import { encodeToonlLines } from "@reddb-io/toon";
+import { parseRecords } from "@reddb-io/toon";
+
+import { GITHUB_POOLS, type GithubBalance } from "./balance.js";
+import type { GithubRateBudget } from "./surface.js";
+
+export interface GithubBalanceHistoryRow {
+  readonly ts: string;
+  readonly pool: GithubRateBudget;
+  readonly remaining: number;
+  readonly used: number;
+  readonly limit: number;
+  readonly reset_at: number;
+  readonly asked_at: string;
+}
+
+export interface GithubBalanceHistory {
+  append(balance: GithubBalance): Promise<void>;
+}
+
+export interface CreateGithubBalanceHistoryOptions {
+  readonly path: string;
+  readonly clock?: () => string;
+  /** Test override; production uses the registry-declared ceiling. */
+  readonly maxBytes?: number;
+}
+
+/** Append the authoritative answer as one readable row per reported pool. */
+export function createGithubBalanceHistory(
+  options: CreateGithubBalanceHistoryOptions,
+): GithubBalanceHistory {
+  const clock = options.clock ?? (() => new Date().toISOString());
+  const policy = LANE_RETENTION_REGISTRY["github-balance-history"];
+  const maxBytes = options.maxBytes ?? policy.maxBytes;
+  let pendingWrite = Promise.resolve();
+  return {
+    async append(balance): Promise<void> {
+      const ts = clock();
+      const rows: GithubBalanceHistoryRow[] = [];
+      for (const pool of GITHUB_POOLS) {
+        const observed = balance.pools[pool];
+        if (observed === null) continue;
+        rows.push({
+          ts,
+          pool,
+          remaining: observed.remaining,
+          used: observed.used,
+          limit: observed.limit,
+          reset_at: Math.floor(Date.parse(observed.reset_at) / 1_000),
+          asked_at: balance.asked_at,
+        });
+      }
+      if (rows.length === 0) return;
+      const writer = encodeToonlLines({ trailer: false });
+      const segment = rows.map((row) => writer.push(row)).join("");
+      const incomingBytes = Buffer.byteLength(segment);
+      pendingWrite = pendingWrite.then(async () => {
+        await mkdir(dirname(options.path), { recursive: true });
+        if (incomingBytes > maxBytes) {
+          throw new Error(`GitHub balance history observation exceeds its ${maxBytes}-byte lane ceiling`);
+        }
+        if (await laneOverCeiling(options.path, incomingBytes, { maxBytes })) {
+          const existing = await readRows(options.path);
+          const targetBytes = Math.max(Math.floor(maxBytes * policy.targetRatio), incomingBytes);
+          await trimLaneKeepLast(
+            options.path,
+            keepLastWithin(existing, incomingBytes, targetBytes),
+          );
+        }
+        await appendFile(options.path, segment, { encoding: "utf8", mode: 0o600 });
+      });
+      return pendingWrite;
+    },
+  };
+}
+
+type ToonlRecord = Record<string, string | number | boolean | null>;
+
+async function readRows(path: string): Promise<ToonlRecord[]> {
+  try {
+    const raw = await readFile(path, "utf8");
+    return raw.trim() === "" ? [] : parseRecords(raw);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+function keepLastWithin(
+  rows: readonly ToonlRecord[],
+  incomingBytes: number,
+  targetBytes: number,
+): number {
+  let low = 0;
+  let high = rows.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const retained = encodeRows(rows.slice(-middle));
+    if (Buffer.byteLength(retained) + incomingBytes <= targetBytes) low = middle;
+    else high = middle - 1;
+  }
+  return low;
+}
+
+function encodeRows(rows: readonly ToonlRecord[]): string {
+  return rows.map((row) => encodeToonlLines({ trailer: false }).push(row)).join("");
+}

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -75,6 +75,13 @@ export {
 } from "./balance-store.js";
 
 export {
+  createGithubBalanceHistory,
+  type CreateGithubBalanceHistoryOptions,
+  type GithubBalanceHistory,
+  type GithubBalanceHistoryRow,
+} from "./balance-history.js";
+
+export {
   GITHUB_BALANCE_CADENCE,
   GITHUB_DIVERSION_BANDS,
   GITHUB_BALANCE_MIN_CADENCE_MS,

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -13,6 +13,7 @@
     "./rest-plan.js": "./rest-plan.ts",
     "./balance.js": "./balance.ts",
     "./balance-store.js": "./balance-store.ts",
+    "./balance-history.js": "./balance-history.ts",
     "./cache.js": "./cache.ts"
   },
   "dependencies": {

--- a/packages/shared/lane-retention.test.ts
+++ b/packages/shared/lane-retention.test.ts
@@ -36,6 +36,7 @@ describe("shared lane retention", () => {
     });
     expect(LANE_RETENTION_REGISTRY["github-spend"].maxBytes).toBe(8 * 1024 * 1024);
     expect(LANE_RETENTION_REGISTRY["github-balance"].maxBytes).toBe(64 * 1024);
+    expect(LANE_RETENTION_REGISTRY["github-balance-history"].maxBytes).toBe(2 * 1024 * 1024);
     expect(LANE_RETENTION_REGISTRY["castle-singleton-events"].maxBytes).toBe(2 * 1024 * 1024);
     expect(LANE_RETENTION_REGISTRY["rsp-telemetry-corrections"].maxBytes).toBe(1024 * 1024);
     expect(LANE_RETENTION_REGISTRY["death-attributions"].maxAgeMs).toBe(14 * 24 * 60 * 60 * 1_000);

--- a/packages/shared/lane-retention.ts
+++ b/packages/shared/lane-retention.ts
@@ -68,6 +68,10 @@ export const LANE_RETENTION_REGISTRY = {
     maxBytes: 64 * 1024,
     targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
   },
+  "github-balance-history": {
+    maxBytes: 2 * MIB,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
   "castle-singleton-events": {
     maxBytes: 2 * MIB,
     targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,


### PR DESCRIPTION
Automated AFK landing for #3723. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3723

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789123611&installation_model_id=20659&pr_number=3725&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3725&signature=ac4f18aefbdfb78efeff4b640c00c13fa58e61a01a26c3afb48f3eeffe40bbaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->