### PR TITLE
feat: #3724 The inner-agent handoff mandates REST gh forms: raw gh convenience commands are the fleet's last GraphQL burn

### DIFF
--- a/apps/dev/src/core/github-read-route-guard.ts
+++ b/apps/dev/src/core/github-read-route-guard.ts
@@ -70,7 +70,7 @@ export const GITHUB_READ_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineE
 export const GITHUB_WRITE_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineEntry[] = [
   { path: "apps/dev/src/commands/hitl-card.ts", count: 15, reason: "HITL actions still write comments, labels, issue state, and PR dispositions through gh" },
   { path: "apps/dev/src/core/merge.ts", count: 7, reason: "landing uses REST for create and merge, while draft readiness, labels, and update-branch still await routed mutations" },
-  { path: "apps/dev/src/runtime/gh/issues.ts", count: 9, reason: "issue, comment, and label mutations still use the legacy CLI adapter" },
+  { path: "apps/dev/src/runtime/gh/issues.ts", count: 7, reason: "issue body, state, and label edits now use the write plan; comment, create, sub-issue, and label-resource mutations remain" },
   { path: "apps/dev/src/runtime/gh/manager-map.ts", count: 3, reason: "manager-map issue creation still awaits the shared mutation surface" },
   { path: "apps/dev/src/runtime/merge-driver-io.ts", count: 2, reason: "the compatibility merge driver still shells out for update and merge" },
   { path: "apps/dev/src/runtime/review-gh.ts", count: 3, reason: "review comments and labels still await routed mutations" },

--- a/apps/dev/src/runtime/gh/issues.ts
+++ b/apps/dev/src/runtime/gh/issues.ts
@@ -11,14 +11,27 @@ import {
   GITHUB_REST_CONCURRENCY,
   parseAliasedRepositoryResponse,
 } from "@reddb-io/shared/github-batch.js";
+import { planGithubWrite } from "@reddb-io/github";
 import { scrubOutbound } from "../outbound-redaction.js";
 import { repoArgs, runGh, type GhContext } from "./common.js";
 import { readSingleObject } from "./single-object.js";
 
-export async function viewLabels(ctx: GhContext, issue: number): Promise<string[]> {
+async function readLabelsForEdit(
+  ctx: GhContext,
+  issue: number,
+): Promise<{ ok: true; labels: string[] } | { ok: false }> {
   const read = await readSingleObject(ctx, "issue", issue, ["labels"]);
+  if (read.out.code !== 0 || !read.row) return { ok: false };
   const parsed = (read.row ?? {}) as { labels?: Array<{ name?: string }> };
-  return Array.isArray(parsed.labels) ? parsed.labels.map((l) => String(l.name ?? "")) : [];
+  return {
+    ok: true,
+    labels: Array.isArray(parsed.labels) ? parsed.labels.map((l) => String(l.name ?? "")) : [],
+  };
+}
+
+export async function viewLabels(ctx: GhContext, issue: number): Promise<string[]> {
+  const read = await readLabelsForEdit(ctx, issue);
+  return read.ok ? read.labels : [];
 }
 
 /**
@@ -63,11 +76,11 @@ export async function editLabels(
   remove: string[],
   add: string[],
 ): Promise<boolean> {
+  const current = await readLabelsForEdit(ctx, issue);
   if (add.includes(LABEL_READY)) {
-    const current = await viewLabels(ctx, issue);
     // Judge the RESULTING label set, so an edit that genuinely leaves the lane
     // (removing it in the same call) is not refused for a label it just shed.
-    const next = [...current.filter((label) => !remove.includes(label)), ...add];
+    const next = [...(current.ok ? current.labels : []).filter((label) => !remove.includes(label)), ...add];
     const refusal = laneIsolationRefusal("direct label write", next);
     if (refusal !== null) {
       process.stderr.write(`refused: #${issue} ${refusal.message}\n`);
@@ -77,7 +90,8 @@ export async function editLabels(
   const args = ["issue", "edit", String(issue), ...repoArgs(ctx)];
   for (const label of remove) args.push("--remove-label", label);
   for (const label of add) args.push("--add-label", label);
-  const r = await runGh(ctx, args);
+  const plan = planGithubWrite(["gh", ...args], current.ok ? { currentIssueLabels: current.labels } : {});
+  const r = await runGh(ctx, plan.args.slice(1));
   return r.code === 0;
 }
 
@@ -165,7 +179,10 @@ export async function listClaimComments(
 
 /** `gh issue edit --body …`. */
 export async function editBody(ctx: GhContext, issue: number, body: string): Promise<boolean> {
-  const r = await runGh(ctx, ["issue", "edit", String(issue), ...repoArgs(ctx), "--body", scrubOutbound(body)]);
+  const plan = planGithubWrite([
+    "gh", "issue", "edit", String(issue), ...repoArgs(ctx), "--body", scrubOutbound(body),
+  ]);
+  const r = await runGh(ctx, plan.args.slice(1));
   return r.code === 0;
 }
 
@@ -529,7 +546,10 @@ export async function ensureLabel(
 
 /** `gh issue close --reason completed`. */
 export async function closeIssue(ctx: GhContext, issue: number): Promise<void> {
-  await runGh(ctx, ["issue", "close", String(issue), ...repoArgs(ctx), "--reason", "completed"]);
+  const plan = planGithubWrite([
+    "gh", "issue", "close", String(issue), ...repoArgs(ctx), "--reason", "completed",
+  ]);
+  await runGh(ctx, plan.args.slice(1));
 }
 
 /** Full metadata for a single issue (`gh issue view --json number,title,body,labels`).

--- a/apps/dev/tests/afk-validation-authority-docs.test.ts
+++ b/apps/dev/tests/afk-validation-authority-docs.test.ts
@@ -68,6 +68,18 @@ describe("afk validation-authority docs contract (#1334)", () => {
   });
 });
 
+describe("afk inner-agent GitHub read rail (#3724)", () => {
+  it("requires explicit REST forms instead of GraphQL-backed gh convenience reads", async () => {
+    const prompt = await readAgentPrompt();
+
+    expect(prompt).toContain("GitHub reads use `gh api` REST forms");
+    expect(prompt).toContain("| Issue by number | `gh api repos/{owner}/{repo}/issues/{number}` |");
+    expect(prompt).toContain("| Pull request by number | `gh api repos/{owner}/{repo}/pulls/{number}` |");
+    expect(prompt).toContain("| Check runs for a commit | `gh api repos/{owner}/{repo}/commits/{sha}/check-runs` |");
+    expect(prompt).toContain("Never use `gh issue view`, `gh pr view`, or `gh pr checks`");
+  });
+});
+
 describe("afk primary-checkout safety contract (#2479)", () => {
   it("never snapshots a dirty primary before a worker reaches Landing", async () => {
     const [safety, operations] = await Promise.all([readAfkSafety(), readAfkOperations()]);

--- a/apps/dev/tests/gh-edit-labels-lane-isolation.test.ts
+++ b/apps/dev/tests/gh-edit-labels-lane-isolation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { editLabels, type GhContext } from "../src/runtime/gh.js";
+import { closeIssue, editBody, editLabels, type GhContext } from "../src/runtime/gh.js";
 import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
 import { readsIssue, restIssueBody } from "./support/gh-rest-fixtures.js";
 
@@ -15,18 +15,20 @@ import { readsIssue, restIssueBody } from "./support/gh-rest-fixtures.js";
 /** A gh fake answering the REST read of one issue with `labels`, and recording
  * every `issue edit` it is asked to perform. The label read routes to REST
  * (#3094): one issue by number is a single-object read. */
-function ghWith(labels: string[]): { ctx: GhContext; edits: string[][] } {
+function ghWith(labels: string[]): { ctx: GhContext; edits: string[][]; reads: { count: number } } {
   const edits: string[][] = [];
+  const reads = { count: 0 };
   const exec: ExecFn = (_bin, args) => {
     let out: ExecOutput = { code: 0, stdout: "", stderr: "" };
     if (readsIssue(args)) {
+      reads.count += 1;
       out = { code: 0, stdout: JSON.stringify(restIssueBody({ labels })), stderr: "" };
-    } else if (args[0] === "issue" && args[1] === "edit") {
+    } else {
       edits.push([...args]);
     }
     return Promise.resolve(out);
   };
-  return { ctx: { cwd: "/r", repo: "acme/widgets", exec }, edits };
+  return { ctx: { cwd: "/r", repo: "acme/widgets", exec }, edits, reads };
 }
 
 describe("editLabels — lane isolation backstop (#2894)", () => {
@@ -55,13 +57,15 @@ describe("editLabels — lane isolation backstop (#2894)", () => {
     stderr.mockRestore();
   });
 
-  it("promotes an ordinary backlog issue untouched, with no extra read", async () => {
-    const { ctx, edits } = ghWith(["ready-for-human"]);
+  it("promotes an ordinary backlog issue with a REST PATCH of the resulting labels", async () => {
+    const { ctx, edits, reads } = ghWith(["ready-for-human"]);
 
     expect(await editLabels(ctx, 42, ["ready-for-human"], ["ready-for-agent"])).toBe(true);
+    expect(reads.count).toBe(1);
     expect(edits).toHaveLength(1);
-    expect(edits[0]).toContain("--add-label");
-    expect(edits[0]).toContain("ready-for-agent");
+    expect(edits[0]).toEqual([
+      "api", "-X", "PATCH", "repos/acme/widgets/issues/42", "-F", "labels[]=ready-for-agent",
+    ]);
   });
 
   it("allows an edit that sheds the lane in the SAME call", async () => {
@@ -73,18 +77,36 @@ describe("editLabels — lane isolation backstop (#2894)", () => {
     expect(edits).toHaveLength(1);
   });
 
-  it("never reads the issue when the write is not a promotion", async () => {
-    const reads: string[][] = [];
+  it("reads labels before a non-promotion so the REST replacement preserves unrelated labels", async () => {
+    const { ctx, edits, reads } = ghWith(["type:bug", "running"]);
+
+    expect(await editLabels(ctx, 44, ["running"], ["ready-for-human"])).toBe(true);
+    expect(reads.count).toBe(1);
+    expect(edits[0]).toEqual([
+      "api", "-X", "PATCH", "repos/acme/widgets/issues/44",
+      "-F", "labels[]=type:bug", "-F", "labels[]=ready-for-human",
+    ]);
+  });
+});
+
+describe("issue edits — REST write plan (#3724)", () => {
+  it("routes body and state mutations through REST PATCH", async () => {
+    const calls: string[][] = [];
     const exec: ExecFn = (_bin, args) => {
-      reads.push([...args]);
+      calls.push([...args]);
       return Promise.resolve({ code: 0, stdout: "", stderr: "" });
     };
     const ctx: GhContext = { cwd: "/r", repo: "acme/widgets", exec };
 
-    expect(await editLabels(ctx, 44, ["running"], ["ready-for-human"])).toBe(true);
-    // Exactly one gh call: the edit itself. The guard costs nothing off the
-    // promotion path.
-    expect(reads).toHaveLength(1);
-    expect(reads[0]?.[1]).toBe("edit");
+    expect(await editBody(ctx, 45, "next body")).toBe(true);
+    await closeIssue(ctx, 45);
+
+    expect(calls).toEqual([
+      ["api", "-X", "PATCH", "repos/acme/widgets/issues/45", "-f", "body=next body"],
+      [
+        "api", "-X", "PATCH", "repos/acme/widgets/issues/45",
+        "-f", "state=closed", "-f", "state_reason=completed",
+      ],
+    ]);
   });
 });

--- a/apps/dev/tests/github-read-route-guard.test.ts
+++ b/apps/dev/tests/github-read-route-guard.test.ts
@@ -85,6 +85,9 @@ describe("GitHub reads route through @reddb-io/github (#3451)", () => {
     expect(formatGithubWriteRouteFailure(report, ["probe"])).toContain(
       `${report.findings.length} GitHub write shell-out(s) remain`,
     );
+    expect(GITHUB_WRITE_SHELLOUT_BASELINE.find(
+      (entry) => entry.path === "apps/dev/src/runtime/gh/issues.ts",
+    )?.count).toBe(7);
   });
 
   it("rejects a new gh write and points it at the shared client", () => {

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -144,4 +144,8 @@ export {
   type GithubSingleObjectKind,
 } from "./rest-plan.js";
 
-export { planGithubWrite, type GithubWritePlan } from "./write-plan.js";
+export {
+  planGithubWrite,
+  type GithubWriteContext,
+  type GithubWritePlan,
+} from "./write-plan.js";

--- a/packages/github/surface.test.ts
+++ b/packages/github/surface.test.ts
@@ -50,8 +50,8 @@ const PINNED: ReadonlyArray<
   ["api graphql", "read", "multi-node", "one-shot", "graphql", "graphql", null],
   ["api rest", "read", "single-object", "one-shot", "rest", "rest", null],
   ["issue create", "write", "single-object", undefined, "graphql", "graphql", null],
-  ["issue edit", "write", "single-object", undefined, "graphql", "graphql", null],
-  ["issue close", "write", "single-object", undefined, "graphql", "graphql", null],
+  ["issue edit", "write", "single-object", undefined, "rest", "rest", null],
+  ["issue close", "write", "single-object", undefined, "rest", "rest", null],
   ["issue reopen", "write", "single-object", undefined, "graphql", "graphql", null],
   ["issue comment", "write", "single-object", undefined, "rest", "rest", null],
   ["issue develop", "write", "single-object", undefined, "graphql", "graphql", null],
@@ -264,7 +264,7 @@ describe("the router", () => {
     expect(routeGithubArgs(["issue", "create", "--title", "x"]).surface).toBe("graphql");
     expect(routeGithubArgs(["pr", "create", "--title", "x"]).surface).toBe("rest");
     expect(routeGithubArgs(["pr", "merge", "42", "--merge"]).surface).toBe("rest");
-    expect(routeGithubArgs(["issue", "edit", "42", "--add-label", "x"]).surface).toBe("graphql");
+    expect(routeGithubArgs(["issue", "edit", "42", "--add-label", "x"]).surface).toBe("rest");
   });
 
   it("raises on an unclassified operation instead of defaulting to GraphQL", () => {

--- a/packages/github/surface.ts
+++ b/packages/github/surface.ts
@@ -191,10 +191,10 @@ export const GITHUB_OPERATIONS: readonly GithubOperation[] = [
   read("api graphql", "multi-node", "one-shot", "graphql", noFallback("the caller explicitly chose GraphQL"), "the caller supplies one explicit GraphQL query rather than a routed poll"),
   read("api rest", "single-object", "one-shot", "rest", noFallback("the caller explicitly chose REST"), "the caller supplies one explicit REST path rather than a routed poll"),
 
-  // ── writes: the surface is gh's, observed rather than chosen
+  // ── writes: the surface realized by the shared write plan
   write("issue create", "graphql", "graphql", "gh files an issue with the createIssue mutation — an exhausted GraphQL pool blocks filing"),
-  write("issue edit", "graphql", "graphql", "gh edits labels, body and assignees with GraphQL mutations"),
-  write("issue close", "graphql", "graphql", "gh closes with the closeIssue mutation"),
+  write("issue edit", "rest", "rest", "the write plan PATCHes labels and body at `repos/{o}/{r}/issues/{n}`"),
+  write("issue close", "rest", "rest", "the write plan PATCHes issue state and state reason at `repos/{o}/{r}/issues/{n}`"),
   write("issue reopen", "graphql", "graphql", "gh reopens with the reopenIssue mutation"),
   write("issue comment", "rest", "rest", "gh POSTs to `repos/{o}/{r}/issues/{n}/comments`, a REST request"),
   write("issue develop", "graphql", "graphql", "linked-branch creation is a GraphQL mutation"),

--- a/packages/github/write-plan.test.ts
+++ b/packages/github/write-plan.test.ts
@@ -32,6 +32,38 @@ describe("planGithubWrite — the client owns the write rail", () => {
     ]);
   });
 
+  it("realizes issue label and body edits as one REST PATCH", () => {
+    const plan = planGithubWrite([
+      "gh", "-R", "o/r", "issue", "edit", "42",
+      "--remove-label", "running", "--add-label", "ready-for-human", "--body", "next",
+    ], { currentIssueLabels: ["type:bug", "running"] });
+    expect(plan.surface).toBe("rest");
+    expect(plan.args).toEqual([
+      "gh", "api", "-X", "PATCH", "repos/o/r/issues/42",
+      "-f", "body=next",
+      "-F", "labels[]=type:bug",
+      "-F", "labels[]=ready-for-human",
+    ]);
+  });
+
+  it("realizes issue closure as a REST PATCH", () => {
+    const plan = planGithubWrite([
+      "gh", "-R", "o/r", "issue", "close", "42", "--reason", "completed",
+    ]);
+    expect(plan.surface).toBe("rest");
+    expect(plan.args).toEqual([
+      "gh", "api", "-X", "PATCH", "repos/o/r/issues/42",
+      "-f", "state=closed", "-f", "state_reason=completed",
+    ]);
+  });
+
+  it("passes an unsupported issue edit through unchanged", () => {
+    const argv = ["gh", "-R", "o/r", "issue", "edit", "42", "--title", "renamed"];
+    const plan = planGithubWrite(argv);
+    expect(plan.surface).toBe("graphql");
+    expect(plan.args).toBe(argv);
+  });
+
   it("passes an unrouted write through unchanged", () => {
     const argv = ["gh", "-R", "o/r", "pr", "ready", "42"];
     const plan = planGithubWrite(argv);

--- a/packages/github/write-plan.ts
+++ b/packages/github/write-plan.ts
@@ -17,9 +17,33 @@ export interface GithubWritePlan {
   readonly surface: "rest" | "graphql";
 }
 
+export interface GithubWriteContext {
+  /** Complete labels currently on an issue, needed to preserve add/remove semantics. */
+  readonly currentIssueLabels?: readonly string[];
+}
+
 function flagValue(args: readonly string[], flag: string): string | undefined {
   const at = args.indexOf(flag);
   return at >= 0 ? args[at + 1] : undefined;
+}
+
+function flagValues(args: readonly string[], flag: string): string[] {
+  const values: string[] = [];
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === flag && args[i + 1] !== undefined) values.push(args[i + 1]!);
+  }
+  return values;
+}
+
+function usesOnlyValueFlags(
+  args: readonly string[],
+  start: number,
+  allowed: ReadonlySet<string>,
+): boolean {
+  for (let i = start; i < args.length; i += 2) {
+    if (!allowed.has(args[i]!) || args[i + 1] === undefined) return false;
+  }
+  return true;
 }
 
 function repoOf(args: readonly string[]): string | undefined {
@@ -45,6 +69,9 @@ function commandPath(args: readonly string[]): string[] {
  * Realize one canonical gh write argv on its declared rail. PURE.
  *
  * Covered spellings — exactly the ones the engine's landing emits:
+ * - `gh -R o/r issue edit <n> --body b [--add-label/--remove-label ...]`
+ *   → REST `PATCH issues/{n}` (label edits require the current complete set)
+ * - `gh -R o/r issue close <n> --reason completed` → REST `PATCH issues/{n}`
  * - `gh -R o/r pr merge <n> --merge [--subject t]` → REST `PUT pulls/{n}/merge`
  * - `gh -R o/r pr merge <n> --merge --auto [...]`  → unchanged (GraphQL enqueue)
  * - `gh -R o/r pr create --base b --head h --title t --body y [--draft]`
@@ -54,9 +81,63 @@ function commandPath(args: readonly string[]): string[] {
  * defaults to — an unrouted write is the caller's existing behavior, never a
  * silent rewrite.
  */
-export function planGithubWrite(args: readonly string[]): GithubWritePlan {
+export function planGithubWrite(
+  args: readonly string[],
+  context: GithubWriteContext = {},
+): GithubWritePlan {
   const repo = repoOf(args);
   const [group, verb] = commandPath(args);
+  if (repo && group === "issue" && verb === "edit") {
+    const editAt = args.indexOf("edit");
+    const issueNumber = args[editAt + 1];
+    const body = flagValue(args, "--body");
+    const removeLabels = flagValues(args, "--remove-label");
+    const addLabels = flagValues(args, "--add-label");
+    const editsLabels = removeLabels.length > 0 || addLabels.length > 0;
+    const supported = usesOnlyValueFlags(
+      args,
+      editAt + 2,
+      new Set(["-R", "--repo", "--body", "--remove-label", "--add-label"]),
+    );
+    if (
+      supported
+      && (body !== undefined || editsLabels)
+      && issueNumber
+      && /^\d+$/.test(issueNumber)
+      && (!editsLabels || context.currentIssueLabels)
+    ) {
+      const labels = editsLabels
+        ? [...new Set([
+            ...context.currentIssueLabels!.filter((label) => !removeLabels.includes(label)),
+            ...addLabels,
+          ])]
+        : undefined;
+      return {
+        surface: "rest",
+        args: [
+          "gh", "api", "-X", "PATCH", `repos/${repo}/issues/${issueNumber}`,
+          ...(body !== undefined ? ["-f", `body=${body}`] : []),
+          ...(labels ? labels.length > 0
+            ? labels.flatMap((label) => ["-F", `labels[]=${label}`])
+            : ["-F", "labels[]"] : []),
+        ],
+      };
+    }
+  }
+  if (repo && group === "issue" && verb === "close") {
+    const issueNumber = args[args.indexOf("close") + 1];
+    if (issueNumber && /^\d+$/.test(issueNumber)) {
+      const reason = flagValue(args, "--reason");
+      return {
+        surface: "rest",
+        args: [
+          "gh", "api", "-X", "PATCH", `repos/${repo}/issues/${issueNumber}`,
+          "-f", "state=closed",
+          ...(reason ? ["-f", `state_reason=${reason}`] : []),
+        ],
+      };
+    }
+  }
   if (repo && group === "pr" && verb === "merge") {
     if (args.includes("--auto")) return { args, surface: "graphql" };
     const prNumber = args[args.indexOf("merge") + 1];

--- a/packaging/pi/dev/skills/engineering/afk/AGENT-PROMPT.md
+++ b/packaging/pi/dev/skills/engineering/afk/AGENT-PROMPT.md
@@ -10,6 +10,18 @@ You are an AFK agent invoked by `/afk`. You are running inside an isolated git w
 
 The handoff file's `<issue-body>` element wraps the issue body verbatim, which carries the `## Agent brief` markdown section written by `/triage`. Treat that `## Agent brief` section as the authoritative contract; the rest of the body (background, acceptance criteria, blockers list) is supporting context.
 
+## GitHub Read Rail (binding)
+
+GitHub reads use `gh api` REST forms. Never use `gh issue view`, `gh pr view`, or `gh pr checks`; those convenience commands spend the GraphQL pool outside the Worker's instrumented GitHub client. Use these equivalents directly so the read surface is explicit and attributable:
+
+| Read | Required REST form |
+| --- | --- |
+| Issue by number | `gh api repos/{owner}/{repo}/issues/{number}` |
+| Pull request by number | `gh api repos/{owner}/{repo}/pulls/{number}` |
+| Check runs for a commit | `gh api repos/{owner}/{repo}/commits/{sha}/check-runs` |
+
+For any other GitHub read, use its `gh api repos/{owner}/{repo}/...` REST endpoint. Do not use a `gh issue`, `gh pr`, or `gh search` convenience read as a substitute.
+
 ## Handoff Anatomy (read this carefully — it changes how you read the file)
 
 The handoff is rebuilt **fresh on every worker invocation** from the live issue. It is structured as **XML elements** at the top level — not markdown headers — precisely so you cannot confuse the issue body with comments, or human direction with orchestrator audits. The seven repository-orientation and conversational elements appear in this relative order (gate, resume, repair, and output-shaping sections may also appear at their documented seams):

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -155,6 +155,8 @@ structured `project_reset` repair) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` local validation authority (`plugins.dev.afk.validation.{iteration,post_done,landing}`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
+`/afk` inner-agent GitHub reads (explicit `gh api` REST forms for issues, pull
+requests, and check runs) -> `plugins/dev/skills/engineering/afk/AGENT-PROMPT.md`;
 `/afk` task-class runner routes (`plugins.dev.afk.routes.{validate,simple,complex,think}`),
 their override precedence, and `/red-setup` interview ->
 `plugins/dev/skills/engineering/red-setup/INTERVIEW.md` and

--- a/plugins/dev/skills/engineering/afk/AGENT-PROMPT.md
+++ b/plugins/dev/skills/engineering/afk/AGENT-PROMPT.md
@@ -10,6 +10,18 @@ You are an AFK agent invoked by `/afk`. You are running inside an isolated git w
 
 The handoff file's `<issue-body>` element wraps the issue body verbatim, which carries the `## Agent brief` markdown section written by `/triage`. Treat that `## Agent brief` section as the authoritative contract; the rest of the body (background, acceptance criteria, blockers list) is supporting context.
 
+## GitHub Read Rail (binding)
+
+GitHub reads use `gh api` REST forms. Never use `gh issue view`, `gh pr view`, or `gh pr checks`; those convenience commands spend the GraphQL pool outside the Worker's instrumented GitHub client. Use these equivalents directly so the read surface is explicit and attributable:
+
+| Read | Required REST form |
+| --- | --- |
+| Issue by number | `gh api repos/{owner}/{repo}/issues/{number}` |
+| Pull request by number | `gh api repos/{owner}/{repo}/pulls/{number}` |
+| Check runs for a commit | `gh api repos/{owner}/{repo}/commits/{sha}/check-runs` |
+
+For any other GitHub read, use its `gh api repos/{owner}/{repo}/...` REST endpoint. Do not use a `gh issue`, `gh pr`, or `gh search` convenience read as a substitute.
+
 ## Handoff Anatomy (read this carefully — it changes how you read the file)
 
 The handoff is rebuilt **fresh on every worker invocation** from the live issue. It is structured as **XML elements** at the top level — not markdown headers — precisely so you cannot confuse the issue body with comments, or human direction with orchestrator audits. The seven repository-orientation and conversational elements appear in this relative order (gate, resume, repair, and output-shaping sections may also appear at their documented seams):

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -155,6 +155,8 @@ structured `project_reset` repair) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` local validation authority (`plugins.dev.afk.validation.{iteration,post_done,landing}`) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
+`/afk` inner-agent GitHub reads (explicit `gh api` REST forms for issues, pull
+requests, and check runs) -> `plugins/dev/skills/engineering/afk/AGENT-PROMPT.md`;
 `/afk` task-class runner routes (`plugins.dev.afk.routes.{validate,simple,complex,think}`),
 their override precedence, and `/red-setup` interview ->
 `plugins/dev/skills/engineering/red-setup/INTERVIEW.md` and


### PR DESCRIPTION
Automated AFK landing for #3724. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3724

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789124513&installation_model_id=20659&pr_number=3735&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3735&signature=37f161d87fa7682ebcb24faede2ea0de35943db2a766156ed23c43e029f41211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->