### PR TITLE
feat: #3727 Client mandate: hitl-card.ts rides packages/github (15 writes + 6 reads)

### DIFF
--- a/apps/dev/src/commands/hitl-card.ts
+++ b/apps/dev/src/commands/hitl-card.ts
@@ -12,7 +12,19 @@
 // by parseCardCommand (first non-blank line only) and classifyNaturalLanguage
 // (keyword matching). The issue body is never parsed for commands.
 
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import {
+  createGithubAttributionLedger,
+  createGithubClient,
+  planGithubRestRead,
+  planGithubWrite,
+  routeGithubArgs,
+  type GithubClient,
+  type GithubWritePlan,
+} from "@reddb-io/github";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
+import { stateDir } from "@reddb-io/shared/red-paths.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
 import { scrubOutbound } from "../runtime/outbound-redaction.js";
 import { parseTrustPolicy, resolveActorTrust } from "../core/trust-gate.js";
@@ -43,6 +55,7 @@ import {
   type CardCommand,
 } from "../core/hitl-card.js";
 import { enrichIssueReferences as enrichTicketRefs } from "../core/issue-reference.js";
+import { inferGitHubRepoSlug } from "../runtime/wire/github-slug.js";
 import { verifyFreshBase } from "./requeue.js";
 
 const FLAG_SCHEMA = {
@@ -69,14 +82,81 @@ function makeExec(cwd: string): Exec {
   return (args, opts) => run(args[0]!, args.slice(1), { cwd: opts?.cwd ?? cwd });
 }
 
-async function resolveRepo(exec: Exec, explicit?: string): Promise<string> {
+function resolveRepo(cwd: string, explicit?: string): string {
   if (explicit?.trim()) return explicit.trim();
-  const r = await exec(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]);
-  return r.code === 0 ? r.stdout.trim() : "";
+  return inferGitHubRepoSlug(cwd);
 }
 
 function repoArgs(repo: string): string[] {
   return repo ? ["--repo", repo] : [];
+}
+
+const ISSUE_VIEW_OPERATION = routeGithubArgs(["issue", "view"]);
+const PR_VIEW_OPERATION = routeGithubArgs(["pr", "view"]);
+const PR_LIST_OPERATION = routeGithubArgs(["pr", "list"]);
+const PR_CHECKS_OPERATION = routeGithubArgs(["pr", "checks"]);
+
+function repoParts(slug: string): { owner: string; repo: string } {
+  const slash = slug.indexOf("/");
+  if (slash <= 0 || slash === slug.length - 1) {
+    throw new Error(`HITL card GitHub access needs an owner/repo slug, received ${JSON.stringify(slug)}`);
+  }
+  return { owner: slug.slice(0, slash), repo: slug.slice(slash + 1) };
+}
+
+function readTrackerToken(): string | null {
+  const envToken = (
+    process.env.REDSKILLED_HOST_TOKEN ??
+    process.env.GITHUB_TOKEN ??
+    process.env.GH_TOKEN ??
+    ""
+  ).trim();
+  if (envToken !== "") return envToken;
+  try {
+    return execFileSync("gh", ["auth", "token"], {
+      encoding: "utf8",
+      timeout: 5_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function createHitlGithubClient(root: string): GithubClient {
+  const token = readTrackerToken();
+  if (token === null) throw new Error("HITL card GitHub access requires an authenticated tracker credential");
+  return createGithubClient({
+    token,
+    attribution: createGithubAttributionLedger({ path: join(stateDir(root), "github", "spend.toonl") }),
+  });
+}
+
+async function readSingleObject(
+  client: GithubClient,
+  kind: "issue" | "pr",
+  repo: string,
+  number: number,
+  fields: readonly string[],
+): Promise<Record<string, unknown>> {
+  const plan = planGithubRestRead({ kind, number, fields, repo });
+  if (plan.outcome !== "plan") throw new Error(plan.reason);
+  const parts = repoParts(repo);
+  const pull = kind === "pr";
+  const answer = await client.conditionalRest<unknown>({
+    cacheKey: `hitl-card:${kind}:${repo}:${number}:${fields.join(",")}`,
+    route: pull
+      ? "GET /repos/{owner}/{repo}/pulls/{pull_number}"
+      : "GET /repos/{owner}/{repo}/issues/{issue_number}",
+    parameters: { ...parts, ...(pull ? { pull_number: number } : { issue_number: number }) },
+    operation: pull ? PR_VIEW_OPERATION : ISSUE_VIEW_OPERATION,
+    actor: "hitl-card",
+  });
+  return plan.decode(JSON.stringify(answer.data));
+}
+
+async function runWrite(exec: Exec, plan: GithubWritePlan): Promise<{ code: number; stdout: string; stderr: string }> {
+  return exec([...plan.args]);
 }
 
 interface IssueData {
@@ -88,58 +168,56 @@ interface IssueData {
   comments: Array<{ id: number; body: string; databaseId?: number; createdAt?: string }>;
 }
 
-async function fetchIssue(exec: Exec, repo: string, issue: number): Promise<IssueData> {
-  const r = await exec([
-    "gh", "issue", "view", String(issue),
-    ...repoArgs(repo),
-    "--json", "number,title,url,body,labels,comments",
-  ]);
-  if (r.code !== 0) throw new Error(`fetch issue #${issue} failed: ${r.stderr.trim()}`);
-  const raw = JSON.parse(r.stdout) as {
+async function fetchIssue(client: GithubClient, repo: string, issue: number): Promise<IssueData> {
+  const parts = repoParts(repo);
+  const [raw, commentsAnswer] = await Promise.all([
+    readSingleObject(client, "issue", repo, issue, ["number", "title", "url", "body", "labels"]),
+    client.conditionalRest<Array<{ id?: number; body?: string; created_at?: string }>>({
+      cacheKey: `hitl-card:issue-comments:${repo}:${issue}`,
+      route: "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+      parameters: { ...parts, issue_number: issue, per_page: 100 },
+      operation: ISSUE_VIEW_OPERATION,
+      actor: "hitl-card",
+    }),
+  ]) as [Record<string, unknown> & {
     number?: number;
     title?: string;
     url?: string;
     body?: string;
     labels?: Array<{ name?: string }>;
-    comments?: Array<{ id?: number; body?: string; databaseId?: number; createdAt?: string }>;
-  };
+  }, { data: Array<{ id?: number; body?: string; created_at?: string }> }];
   return {
     number: Number(raw.number ?? issue),
     title: String(raw.title ?? ""),
     url: String(raw.url ?? ""),
     body: String(raw.body ?? ""),
     labels: (raw.labels ?? []).map((l) => String(l.name ?? "")).filter(Boolean),
-    comments: (raw.comments ?? []).map((c) => ({
+    comments: commentsAnswer.data.map((c) => ({
       id: Number(c.id ?? 0),
-      databaseId: c.databaseId,
+      databaseId: c.id,
       body: String(c.body ?? ""),
-      createdAt: c.createdAt ? String(c.createdAt) : undefined,
+      createdAt: c.created_at ? String(c.created_at) : undefined,
     })),
   };
 }
 
 async function fetchActionComments(
-  exec: Exec,
+  client: GithubClient,
   repo: string,
   issue: number,
 ): Promise<HitlCardActionComment[]> {
-  const repoPath = repo || "{owner}/{repo}";
-  const r = await exec([
-    "gh", "api",
-    `repos/${repoPath}/issues/${issue}/comments?per_page=100`,
-    "--paginate", "--slurp",
-  ]);
-  if (r.code !== 0) throw new Error(`fetch issue #${issue} comment identities failed: ${r.stderr.trim()}`);
-  const parsed = JSON.parse(r.stdout) as unknown;
-  const pages = Array.isArray(parsed) && parsed.every(Array.isArray)
-    ? parsed.flat()
-    : Array.isArray(parsed) ? parsed : [];
-  return pages.map((value) => {
-    const comment = value as {
+  const answer = await client.conditionalPaginate<{
       body?: string;
       created_at?: string;
       user?: { login?: string; type?: string };
-    };
+  }>({
+    cacheKey: `hitl-card:action-comments:${repo}:${issue}`,
+    route: "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+    parameters: { ...repoParts(repo), issue_number: issue },
+    operation: ISSUE_VIEW_OPERATION,
+    actor: "hitl-card",
+  });
+  return answer.data.map((comment) => {
     return {
       body: String(comment.body ?? ""),
       createdAt: comment.created_at ? String(comment.created_at) : undefined,
@@ -166,63 +244,68 @@ function parseActorIdentities(raw: string | undefined): HitlCardActorIdentity[] 
   });
 }
 
-async function fetchIssueReference(exec: Exec, repo: string, issue: number): Promise<{ number: number; title?: string; url?: string } | undefined> {
-  const r = await exec([
-    "gh", "issue", "view", String(issue),
-    ...repoArgs(repo),
-    "--json", "number,title,url",
-  ]);
-  if (r.code !== 0) return undefined;
+async function fetchIssueReference(client: GithubClient, repo: string, issue: number): Promise<{ number: number; title?: string; url?: string } | undefined> {
   try {
-    const raw = JSON.parse(r.stdout) as { number?: number; title?: string; url?: string };
+    const raw = await readSingleObject(client, "issue", repo, issue, ["number", "title", "url"]);
     return { number: Number(raw.number ?? issue), title: String(raw.title ?? ""), url: String(raw.url ?? "") };
   } catch {
     return undefined;
   }
 }
 
-async function fetchPrStatus(exec: Exec, repo: string, prNumber: number): Promise<PrStatus> {
-  const r = await exec([
-    "gh", "pr", "view", String(prNumber),
-    ...repoArgs(repo),
-    "--json", "number,mergeable,statusCheckRollup,headRefOid",
-  ]);
-  if (r.code !== 0) {
+async function fetchPrStatus(client: GithubClient, repo: string, prNumber: number): Promise<PrStatus> {
+  try {
+    const raw = await readSingleObject(client, "pr", repo, prNumber, ["number", "mergeable", "headRefOid"]);
+    const headRefOid = String(raw.headRefOid ?? "");
+    const parts = repoParts(repo);
+    const [checksAnswer, statusesAnswer] = headRefOid === "" ? [{ data: { check_runs: [] } }, { data: { statuses: [] } }] : await Promise.all([
+      client.conditionalRest<{ check_runs?: Array<{ conclusion?: string | null; status?: string | null }> }>({
+        cacheKey: `hitl-card:checks:${repo}:${headRefOid}`,
+        route: "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+        parameters: { ...parts, ref: headRefOid, per_page: 100 },
+        operation: PR_CHECKS_OPERATION,
+        actor: "hitl-card",
+      }),
+      client.conditionalRest<{ statuses?: Array<{ state?: string | null }> }>({
+        cacheKey: `hitl-card:statuses:${repo}:${headRefOid}`,
+        route: "GET /repos/{owner}/{repo}/commits/{ref}/status",
+        parameters: { ...parts, ref: headRefOid, per_page: 100 },
+        operation: PR_CHECKS_OPERATION,
+        actor: "hitl-card",
+      }),
+    ]);
+    const checks = [
+      ...(checksAnswer.data.check_runs ?? []),
+      ...(statusesAnswer.data.statuses ?? []),
+    ];
+    const ciResult = parseCiChecks(checks);
+    return {
+      number: prNumber,
+      ...ciResult,
+      mergeability: raw.mergeable === "MERGEABLE" ? "MERGEABLE"
+        : raw.mergeable === "CONFLICTING" ? "CONFLICTING"
+        : "UNKNOWN",
+      headSha: headRefOid ? headRefOid.slice(0, 7) : undefined,
+    };
+  } catch {
     return { number: prNumber, ci: "none", ciPassed: 0, ciTotal: 0, mergeability: "UNKNOWN" };
   }
-  const raw = JSON.parse(r.stdout) as {
-    number?: number;
-    mergeable?: string;
-    statusCheckRollup?: Array<{ conclusion?: string | null; state?: string | null }>;
-    headRefOid?: string;
-  };
-  const checks = raw.statusCheckRollup ?? [];
-  const ciResult = parseCiChecks(checks);
-  return {
-    number: prNumber,
-    ...ciResult,
-    mergeability: raw.mergeable === "MERGEABLE" ? "MERGEABLE"
-      : raw.mergeable === "CONFLICTING" ? "CONFLICTING"
-      : "UNKNOWN",
-    headSha: raw.headRefOid ? raw.headRefOid.slice(0, 7) : undefined,
-  };
 }
 
-async function findLinkedPr(exec: Exec, repo: string, issueNumber: number, blockerRef?: string): Promise<number | undefined> {
+async function findLinkedPr(client: GithubClient, repo: string, issueNumber: number, blockerRef?: string): Promise<number | undefined> {
   if (blockerRef) {
     const n = Number.parseInt(blockerRef, 10);
     if (Number.isInteger(n) && n > 0) return n;
   }
   // Fallback: search open PRs that mention this issue.
-  const r = await exec([
-    "gh", "pr", "list",
-    ...repoArgs(repo),
-    "--state", "open",
-    "--json", "number,body,title",
-    "--limit", "50",
-  ]);
-  if (r.code !== 0) return undefined;
-  const prs = JSON.parse(r.stdout) as Array<{ number: number; body: string; title: string }>;
+  const answer = await client.conditionalRest<Array<{ number: number; body: string | null; title: string }>>({
+    cacheKey: `hitl-card:open-prs:${repo}`,
+    route: "GET /repos/{owner}/{repo}/pulls",
+    parameters: { ...repoParts(repo), state: "open", per_page: 50 },
+    operation: PR_LIST_OPERATION,
+    actor: "hitl-card",
+  });
+  const prs = answer.data;
   const pattern = new RegExp(`(?:Refs?|Closes?|Fixes?|Resolves?)\\s+#${issueNumber}\\b`, "i");
   const match = prs.find((pr) => pattern.test(pr.body ?? "") || pattern.test(pr.title ?? ""));
   return match?.number;
@@ -235,15 +318,17 @@ function findCardComment(comments: IssueData["comments"]): { id: number; databas
 async function upsertCardComment(exec: Exec, repo: string, issueNumber: number, card: string, existing: { databaseId?: number } | undefined): Promise<void> {
   if (existing?.databaseId) {
     // Update existing comment via gh API.
-    await exec([
+    await runWrite(exec, planGithubWrite([
       "gh", "api",
       `repos/{owner}/{repo}/issues/comments/${existing.databaseId}`,
       "--method", "PATCH",
       "--field", `body=${scrubOutbound(card)}`,
       ...repoArgs(repo),
-    ]);
+    ]));
   } else {
-    await exec(["gh", "issue", "comment", String(issueNumber), ...repoArgs(repo), "--body", scrubOutbound(card)]);
+    await runWrite(exec, planGithubWrite([
+      "gh", "issue", "comment", String(issueNumber), ...repoArgs(repo), "--body", scrubOutbound(card),
+    ]));
   }
 }
 
@@ -270,7 +355,7 @@ export async function enforceHitlCardActionRate(
 
   if (rate.shouldPostStandDown) {
     const minutes = HITL_CARD_ACTION_WINDOW_MS / 60_000;
-    await exec([
+    await runWrite(exec, planGithubWrite([
       "gh", "issue", "comment", String(issueNumber),
       ...repoArgs(repo),
       "--body",
@@ -278,7 +363,7 @@ export async function enforceHitlCardActionRate(
         HITL_CARD_STAND_DOWN_MARKER,
         `🤖 HITL card loop suspected: ${HITL_CARD_ACTION_LIMIT} actions already ran in ${minutes} minutes; standing down.`,
       ].join("\n")),
-    ]);
+    ]));
   }
   stdout.write(`hitl-card act #${issueNumber}: action rate cap reached; standing down.\n`);
   return true;
@@ -288,18 +373,19 @@ export async function enforceHitlCardActionRate(
 
 async function cmdRender(
   exec: Exec,
+  client: GithubClient,
   repo: string,
   issueNumber: number,
   stdout: NodeJS.WritableStream,
 ): Promise<number> {
-  const issue = await fetchIssue(exec, repo, issueNumber);
+  const issue = await fetchIssue(client, repo, issueNumber);
   const blocker = parseCurrentBlocker(issue.body);
   const pendingDecisionRaw = blocker?.next ?? blocker?.summary ?? "Human guidance required.";
-  const pendingDecision = await enrichTicketRefs(pendingDecisionRaw, (n) => fetchIssueReference(exec, repo, n));
+  const pendingDecision = await enrichTicketRefs(pendingDecisionRaw, (n) => fetchIssueReference(client, repo, n));
 
-  const prNumber = await findLinkedPr(exec, repo, issueNumber, blocker?.ref);
+  const prNumber = await findLinkedPr(client, repo, issueNumber, blocker?.ref);
   const prStatus: PrStatus = prNumber
-    ? await fetchPrStatus(exec, repo, prNumber)
+    ? await fetchPrStatus(client, repo, prNumber)
     : { ci: "none", ciPassed: 0, ciTotal: 0, mergeability: "UNKNOWN" };
 
   const updatedAt = nowUtc();
@@ -315,11 +401,12 @@ async function cmdRender(
 
 async function cmdRefresh(
   exec: Exec,
+  client: GithubClient,
   repo: string,
   issueNumber: number,
   stdout: NodeJS.WritableStream,
 ): Promise<number> {
-  const issue = await fetchIssue(exec, repo, issueNumber);
+  const issue = await fetchIssue(client, repo, issueNumber);
   const existing = findCardComment(issue.comments);
   if (!existing) {
     process.stderr.write(`[afk] hitl-card refresh #${issueNumber}: no card comment found — run render first\n`);
@@ -327,9 +414,9 @@ async function cmdRefresh(
   }
 
   const blocker = parseCurrentBlocker(issue.body);
-  const prNumber = await findLinkedPr(exec, repo, issueNumber, blocker?.ref);
+  const prNumber = await findLinkedPr(client, repo, issueNumber, blocker?.ref);
   const prStatus: PrStatus = prNumber
-    ? await fetchPrStatus(exec, repo, prNumber)
+    ? await fetchPrStatus(client, repo, prNumber)
     : { ci: "none", ciPassed: 0, ciTotal: 0, mergeability: "UNKNOWN" };
 
   const updatedAt = nowUtc();
@@ -366,43 +453,43 @@ function directiveComment(action: CardCommand): string {
   ].join("\n");
 }
 
-async function executeApprove(exec: Exec, repo: string, issue: IssueData, prNumber: number, waitForCi: boolean): Promise<string> {
+async function executeApprove(exec: Exec, client: GithubClient, repo: string, issue: IssueData, prNumber: number, waitForCi: boolean): Promise<string> {
   if (waitForCi) {
-    const prStatus = await fetchPrStatus(exec, repo, prNumber);
+    const prStatus = await fetchPrStatus(client, repo, prNumber);
     if (prStatus.ci === "fail") return "CI checks failed — cannot approve.";
     if (prStatus.ci === "pending") return "CI checks are still pending — re-run `/approve-ci` once they complete.";
   }
 
-  const mergeResult = await exec([
+  const mergeResult = await runWrite(exec, planGithubWrite([
     "gh", "pr", "merge", String(prNumber),
     ...repoArgs(repo),
     "--admin", "--merge",
-  ]);
+  ]));
   if (mergeResult.code !== 0) {
     return `PR merge failed: ${mergeResult.stderr.trim() || mergeResult.stdout.trim()}`;
   }
 
-  await exec(["gh", "issue", "close", String(issue.number), ...repoArgs(repo)]);
+  await runWrite(exec, planGithubWrite(["gh", "issue", "close", String(issue.number), ...repoArgs(repo)]));
 
   // NOT a state transition: the issue was just CLOSED, so it EXITS the state
   // machine and the planner (which always lands on exactly one state role)
   // cannot express this shed. Same class as the reconcile land path's
-  // `landDropLabels` — deliberately left raw (#2663).
+  // `landDropLabels`; the write rail is still owned by packages/github (#2663).
   const blockedLabels = blockedLabelsIn(issue.labels);
   const removeLabels = [LABEL_HUMAN, ...blockedLabels];
   const editArgs = ["gh", "issue", "edit", String(issue.number), ...repoArgs(repo)];
   for (const l of removeLabels) editArgs.push("--remove-label", l);
-  await exec(editArgs);
+  await runWrite(exec, planGithubWrite(editArgs));
 
   return `PR #${prNumber} merged and issue #${issue.number} closed.`;
 }
 
 async function executeReject(exec: Exec, repo: string, issue: IssueData, prNumber: number, reason: string): Promise<string> {
-  const closeResult = await exec([
+  const closeResult = await runWrite(exec, planGithubWrite([
     "gh", "pr", "close", String(prNumber),
     ...repoArgs(repo),
     "--comment", scrubOutbound(reason ? `Rejected: ${reason}` : "Rejected by maintainer."),
-  ]);
+  ]));
   if (closeResult.code !== 0) {
     return `PR close failed: ${closeResult.stderr.trim()}`;
   }
@@ -411,7 +498,9 @@ async function executeReject(exec: Exec, repo: string, issue: IssueData, prNumbe
   // shed above this is NOT a planner transition — a rejected card hands the
   // issue back to a maintainer with no automated next state, which is the one
   // shape the one-state-role planner cannot express (#2663).
-  await exec(["gh", "issue", "edit", String(issue.number), ...repoArgs(repo), "--remove-label", LABEL_HUMAN]);
+  await runWrite(exec, planGithubWrite([
+    "gh", "issue", "edit", String(issue.number), ...repoArgs(repo), "--remove-label", LABEL_HUMAN,
+  ]));
   return `PR #${prNumber} closed. Issue #${issue.number} is open for manual follow-up.`;
 }
 
@@ -445,26 +534,26 @@ async function executeRequeue(exec: Exec, repo: string, issue: IssueData, guidan
           .map(([worker]) => worker)
           .sort();
         for (const worker of owners) {
-          await run([
+          await run([...planGithubWrite([
             "gh", "issue", "comment", String(number), ...repoArgs(repo),
             "--body", renderClaimComment({ worker }, "concede"),
-          ]);
+          ]).args]);
         }
         return owners;
       },
-      editBody: (number, body) => run([
+      editBody: (number, body) => run([...planGithubWrite([
         "gh", "issue", "edit", String(number), ...repoArgs(repo),
         "--body", scrubOutbound(body),
-      ]),
-      comment: (number, body) => run([
+      ]).args]),
+      comment: (number, body) => run([...planGithubWrite([
         "gh", "issue", "comment", String(number), ...repoArgs(repo),
         "--body", scrubOutbound(body),
-      ]),
+      ]).args]),
       editLabels: (number, remove, add) => {
         const args = ["gh", "issue", "edit", String(number), ...repoArgs(repo)];
         for (const label of remove) args.push("--remove-label", label);
         for (const label of add) args.push("--add-label", label);
-        return run(args);
+        return run([...planGithubWrite(args).args]);
       },
     },
     {
@@ -491,6 +580,7 @@ export async function cmdAct(
   receiptIdentities: readonly HitlCardActorIdentity[],
   cwd: string,
   stdout: NodeJS.WritableStream,
+  githubClient?: GithubClient,
 ): Promise<number> {
   // 0. Refuse automation before trust resolution or intent parsing. A PAT can
   // make workflow comments look human, so type/login and marker checks are all
@@ -511,11 +601,11 @@ export async function cmdAct(
   const ghCtx: GhContext = { cwd, repo };
   const trust = await resolveActorTrust(policy, commentAuthor, (login) => actorTrustSignals(ghCtx, login));
   if (!trust.executable) {
-    await exec([
+    await runWrite(exec, planGithubWrite([
       "gh", "issue", "comment", String(issueNumber),
       ...repoArgs(repo),
       "--body", scrubOutbound(`⛔ Action denied: ${trust.reason ?? "you are not a trusted maintainer"}.`),
-    ]);
+    ]));
     process.stderr.write(`[afk] hitl-card act #${issueNumber}: trust refused — ${trust.reason}\n`);
     return 1;
   }
@@ -524,20 +614,21 @@ export async function cmdAct(
   let command = parseCardCommand(commentBody);
   if (!command) command = classifyNaturalLanguage(commentBody);
   if (!command) {
-    await exec([
+    await runWrite(exec, planGithubWrite([
       "gh", "issue", "comment", String(issueNumber),
       ...repoArgs(repo),
       "--body",
       scrubOutbound("🤖 I couldn't identify your intent. Use `/approve`, `/approve-ci`, `/reject [reason]`, or `/requeue <guidance>`."),
-    ]);
+    ]));
     stdout.write(`hitl-card act #${issueNumber}: unrecognised command (NL classification returned nothing).\n`);
     return 0;
   }
 
   // 3. Fetch issue state and find linked PR.
+  const client = githubClient ?? createHitlGithubClient(cwd);
   const [issue, actionComments] = await Promise.all([
-    fetchIssue(exec, repo, issueNumber),
-    fetchActionComments(exec, repo, issueNumber),
+    fetchIssue(client, repo, issueNumber),
+    fetchActionComments(client, repo, issueNumber),
   ]);
   if (await enforceHitlCardActionRate(
     exec,
@@ -550,24 +641,24 @@ export async function cmdAct(
   )) return 0;
 
   const blocker = parseCurrentBlocker(issue.body);
-  const prNumber = await findLinkedPr(exec, repo, issueNumber, blocker?.ref);
+  const prNumber = await findLinkedPr(client, repo, issueNumber, blocker?.ref);
 
   if ((command.action === "approve" || command.action === "approve-ci" || command.action === "reject") && !prNumber) {
-    await exec([
+    await runWrite(exec, planGithubWrite([
       "gh", "issue", "comment", String(issueNumber),
       ...repoArgs(repo),
       "--body",
       scrubOutbound(`⚠️ Could not find a linked PR for #${issueNumber}. Post the PR number explicitly or use \`/requeue\` to send back to the agent.`),
-    ]);
+    ]));
     return 1;
   }
 
   // 4. Execute the action.
   let resultMessage: string;
   if (command.action === "approve") {
-    resultMessage = await executeApprove(exec, repo, issue, prNumber!, false);
+    resultMessage = await executeApprove(exec, client, repo, issue, prNumber!, false);
   } else if (command.action === "approve-ci") {
-    resultMessage = await executeApprove(exec, repo, issue, prNumber!, true);
+    resultMessage = await executeApprove(exec, client, repo, issue, prNumber!, true);
   } else if (command.action === "reject") {
     resultMessage = await executeReject(exec, repo, issue, prNumber!, command.args);
   } else {
@@ -575,16 +666,16 @@ export async function cmdAct(
   }
 
   // 5. Post directive comment + result.
-  await exec([
+  await runWrite(exec, planGithubWrite([
     "gh", "issue", "comment", String(issueNumber),
     ...repoArgs(repo),
     "--body", scrubOutbound(directiveComment(command)),
-  ]);
-  await exec([
+  ]));
+  await runWrite(exec, planGithubWrite([
     "gh", "issue", "comment", String(issueNumber),
     ...repoArgs(repo),
     "--body", scrubOutbound(`🤖 **${command.action}**: ${resultMessage}`),
-  ]);
+  ]));
 
   stdout.write(`hitl-card act #${issueNumber}: executed /${command.action} — ${resultMessage}\n`);
   return 0;
@@ -615,14 +706,14 @@ export async function hitlCardCommand(
 
   const root = (values.root as string | undefined)?.trim() || cwd;
   const exec = makeExec(root);
-  const repo = await resolveRepo(exec, values.repo as string | undefined);
+  const repo = resolveRepo(root, values.repo as string | undefined);
 
   try {
     if (subcommand === "render") {
-      return await cmdRender(exec, repo, issueNumber, stdout);
+      return await cmdRender(exec, createHitlGithubClient(root), repo, issueNumber, stdout);
     }
     if (subcommand === "refresh") {
-      return await cmdRefresh(exec, repo, issueNumber, stdout);
+      return await cmdRefresh(exec, createHitlGithubClient(root), repo, issueNumber, stdout);
     }
     // act
     const body = (values.body as string | undefined) ?? "";

--- a/apps/dev/src/core/github-read-route-guard.ts
+++ b/apps/dev/src/core/github-read-route-guard.ts
@@ -44,7 +44,6 @@ export interface GithubReadShelloutBaselineEntry {
  * when a site moves; never raise one to admit a fresh shell-out.
  */
 export const GITHUB_READ_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineEntry[] = [
-  { path: "apps/dev/src/commands/hitl-card.ts", count: 6, reason: "HITL card discovery still needs routed repo, issue, PR, comment, and list surfaces" },
   { path: "apps/dev/src/commands/requeue.ts", count: 2, reason: "requeue still resolves repository and issue state through the CLI" },
   { path: "apps/dev/src/commands/respond.ts", count: 2, reason: "respond still resolves repository and comment state through the CLI" },
   { path: "apps/dev/src/commands/review.ts", count: 1, reason: "review still resolves repository identity through the CLI" },
@@ -68,7 +67,6 @@ export const GITHUB_READ_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineE
 
 /** Raw mutation inventory. SHRINK ONLY: writes share the routed-client destination. */
 export const GITHUB_WRITE_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineEntry[] = [
-  { path: "apps/dev/src/commands/hitl-card.ts", count: 15, reason: "HITL actions still write comments, labels, issue state, and PR dispositions through gh" },
   { path: "apps/dev/src/core/merge.ts", count: 7, reason: "landing uses REST for create and merge, while draft readiness, labels, and update-branch still await routed mutations" },
   { path: "apps/dev/src/runtime/gh/issues.ts", count: 7, reason: "issue body, state, and label edits now use the write plan; comment, create, sub-issue, and label-resource mutations remain" },
   { path: "apps/dev/src/runtime/gh/manager-map.ts", count: 3, reason: "manager-map issue creation still awaits the shared mutation surface" },

--- a/apps/dev/tests/github-read-route-guard.test.ts
+++ b/apps/dev/tests/github-read-route-guard.test.ts
@@ -90,6 +90,15 @@ describe("GitHub reads route through @reddb-io/github (#3451)", () => {
     )?.count).toBe(7);
   });
 
+  it("routes every HITL card read and write through packages/github (#3727)", () => {
+    const path = "apps/dev/src/commands/hitl-card.ts";
+
+    expect(collectGithubReadRouteReport(ROOT).findings.filter((finding) => finding.path === path)).toEqual([]);
+    expect(collectGithubWriteRouteReport(ROOT).findings.filter((finding) => finding.path === path)).toEqual([]);
+    expect(GITHUB_READ_SHELLOUT_BASELINE.some((entry) => entry.path === path)).toBe(false);
+    expect(GITHUB_WRITE_SHELLOUT_BASELINE.some((entry) => entry.path === path)).toBe(false);
+  });
+
   it("rejects a new gh write and points it at the shared client", () => {
     const findings = collectGithubWriteShelloutsFromFiles([
       {

--- a/apps/dev/tests/hitl-card-command.test.ts
+++ b/apps/dev/tests/hitl-card-command.test.ts
@@ -78,7 +78,9 @@ describe("hitl-card command runaway guards", () => {
     const posted: string[] = [];
     const exec: HitlCardExec = async (args) => {
       const bodyIndex = args.indexOf("--body");
+      const restBody = args.find((arg) => arg.startsWith("body="));
       if (bodyIndex !== -1) posted.push(args[bodyIndex + 1] ?? "");
+      else if (restBody !== undefined) posted.push(restBody.slice("body=".length));
       return { code: 0, stdout: "", stderr: "" };
     };
     const output = capture();

--- a/apps/dev/tests/state-transition-contract.test.ts
+++ b/apps/dev/tests/state-transition-contract.test.ts
@@ -170,7 +170,7 @@ const ALLOWLIST = new Map<string, string>([
     "fleet-stop operator reconcile; runs under explicit human intent",
   ],
   [
-    'apps/dev/src/commands/hitl-card.ts :: await exec(["gh", "issue", "edit", String(issue.number), ...repoArgs(repo), "--remove-label", LABEL_HUMAN]);',
+    'apps/dev/src/commands/hitl-card.ts :: "gh", "issue", "edit", String(issue.number), ...repoArgs(repo), "--remove-label", LABEL_HUMAN, ]));',
     "HITL reject sheds the human gate with NO automated next state — the one shape a one-state-role plan cannot express (#2663)",
   ],
   // --- policy dispose sets applied through a planner-backed wrapper ---

--- a/packages/github/write-plan.test.ts
+++ b/packages/github/write-plan.test.ts
@@ -64,6 +64,24 @@ describe("planGithubWrite — the client owns the write rail", () => {
     expect(plan.args).toBe(argv);
   });
 
+  it("realizes an issue comment on REST", () => {
+    const plan = planGithubWrite([
+      "gh", "issue", "comment", "42", "--repo", "o/r", "--body", "resolved",
+    ]);
+    expect(plan).toEqual({
+      surface: "rest",
+      args: ["gh", "api", "-X", "POST", "repos/o/r/issues/42/comments", "-f", "body=resolved"],
+    });
+  });
+
+  it("preserves an explicit REST API mutation on the REST rail", () => {
+    const argv = [
+      "gh", "api", "repos/o/r/issues/comments/99", "--method", "PATCH", "--field", "body=updated",
+    ];
+    const plan = planGithubWrite(argv);
+    expect(plan).toEqual({ surface: "rest", args: argv });
+  });
+
   it("passes an unrouted write through unchanged", () => {
     const argv = ["gh", "-R", "o/r", "pr", "ready", "42"];
     const plan = planGithubWrite(argv);

--- a/packages/github/write-plan.ts
+++ b/packages/github/write-plan.ts
@@ -76,6 +76,10 @@ function commandPath(args: readonly string[]): string[] {
  * - `gh -R o/r pr merge <n> --merge --auto [...]`  → unchanged (GraphQL enqueue)
  * - `gh -R o/r pr create --base b --head h --title t --body y [--draft]`
  *   → REST `POST pulls`
+ * - `gh issue comment <n> -R o/r --body y`
+ *   → REST `POST issues/{n}/comments`
+ * - `gh api <rest-path> --method <verb> ...`
+ *   → unchanged on the explicitly selected REST rail
  *
  * Any other argv passes through unchanged on the GraphQL rail the gh CLI
  * defaults to — an unrouted write is the caller's existing behavior, never a
@@ -172,5 +176,19 @@ export function planGithubWrite(
       };
     }
   }
+  if (repo && group === "issue" && verb === "comment") {
+    const issueNumber = args[args.indexOf("comment") + 1];
+    const body = flagValue(args, "--body");
+    if (issueNumber && /^\d+$/.test(issueNumber) && body !== undefined) {
+      return {
+        surface: "rest",
+        args: [
+          "gh", "api", "-X", "POST", `repos/${repo}/issues/${issueNumber}/comments`,
+          "-f", `body=${body}`,
+        ],
+      };
+    }
+  }
+  if (group === "api" && verb !== "graphql") return { args, surface: "rest" };
   return { args, surface: "graphql" };
 }


### PR DESCRIPTION
Automated AFK landing for #3727. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3727

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789124995&installation_model_id=20659&pr_number=3736&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3736&signature=5736e652e6351acdd2f4e754be75e26a3f81aaefc82762d98aa044e85742d080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->