### PR TITLE
feat: #3730 Client mandate: respond, ship, doctor-classifiers ride packages/github (5 reads)

### DIFF
--- a/apps/dev/src/commands/respond.ts
+++ b/apps/dev/src/commands/respond.ts
@@ -10,6 +10,7 @@
 // code and the workflow requests no `contents: write`.
 
 import { Writable } from "node:stream";
+import { planGithubWrite, routeGithubArgs } from "@reddb-io/github";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { Output } from "@reddb-io/red-castle";
 import { execTool } from "../runtime/exec.js";
@@ -22,6 +23,10 @@ import { makeExplain, explainAnswerSchema } from "../core/comment-respond-extrac
 import { parseTrustPolicy, resolveActorTrust } from "../core/trust-gate.js";
 import { actorTrustSignals, type GhContext } from "../runtime/gh.js";
 import { reviewCommand } from "./review.js";
+import { createDevGithubClient } from "../runtime/github-merge-read.js";
+import { inferGitHubRepoSlug } from "../runtime/wire/github-slug.js";
+
+const REPO_VIEW_OPERATION = routeGithubArgs(["repo", "view"]);
 
 const RESPOND_FLAG_SCHEMA = {
   body: { kind: "value", coerce: (raw: string): string => raw },
@@ -39,8 +44,21 @@ function isRunner(value: string): value is AgentRunner {
 
 async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
   if (explicit?.trim()) return explicit.trim();
-  const r = await execTool("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], { cwd });
-  return r.code === 0 ? r.stdout.trim() : "";
+  const inferred = inferGitHubRepoSlug(cwd);
+  const [owner, repo] = inferred.split("/");
+  if (!owner || !repo) return "";
+  try {
+    const answer = await createDevGithubClient(cwd).conditionalRest<{ full_name?: string }>({
+      cacheKey: `respond:repo:${inferred}`,
+      route: "GET /repos/{owner}/{repo}",
+      parameters: { owner, repo },
+      operation: REPO_VIEW_OPERATION,
+      actor: "respond",
+    });
+    return answer.data?.full_name?.trim() || "";
+  } catch {
+    return "";
+  }
 }
 
 /** The parsed comment event the MCP `respond` op and the CLI command both feed to the value core. */
@@ -102,7 +120,11 @@ export async function executeRespond(
     async reply(target, replyBody) {
       const flag = isPr ? "pr" : "issue";
       const repoArgs = repo ? ["--repo", repo] : [];
-      await execTool("gh", [flag, "comment", String(target), ...repoArgs, "--body", scrubOutbound(replyBody)], { cwd: root });
+      const plan = planGithubWrite([
+        "gh", flag, "comment", String(target), ...repoArgs, "--body", scrubOutbound(replyBody),
+      ]);
+      const [command, ...args] = plan.args;
+      await execTool(command!, args, { cwd: root });
     },
   };
 

--- a/apps/dev/src/commands/ship.ts
+++ b/apps/dev/src/commands/ship.ts
@@ -5,7 +5,7 @@
 // `requeue --adopt-branch BRANCH` action into the no-agent landing lane
 // (ADR 0055). `collectShipFacts` survives as the PR-facts reader.
 
-import { execTool, type ExecOutput } from "../runtime/exec.js";
+import { createDevGithubMergeRead } from "../runtime/github-merge-read.js";
 import {
   advisoryReviewPending,
   normalizeRollupEntry,
@@ -13,24 +13,12 @@ import {
   type ShipCheck,
 } from "../core/ship.js";
 
-async function run(cmd: string, args: readonly string[], cwd: string): Promise<ExecOutput> {
-  return execTool(cmd, args, { cwd });
-}
-
 function parseJson<T>(stdout: string, fallback: T): T {
   try {
     return JSON.parse(stdout || "") as T;
   } catch {
     return fallback;
   }
-}
-
-async function required(cmd: string, args: readonly string[], cwd: string, label: string): Promise<ExecOutput> {
-  const r = await run(cmd, args, cwd);
-  if (r.code !== 0) {
-    throw new Error(`${label} failed: ${r.stderr.trim() || r.stdout.trim() || `${cmd} ${args.join(" ")}`}`);
-  }
-  return r;
 }
 
 interface ShipFacts {
@@ -49,27 +37,23 @@ interface PrView {
 }
 
 export async function collectShipFacts(cwd: string, repo: string, pr: number, reviewCheck: string): Promise<ShipFacts> {
-  const checksRes = await run("gh", ["pr", "checks", String(pr), "--repo", repo, "--json", "name,state,conclusion,bucket"], cwd);
+  const github = createDevGithubMergeRead(cwd, "ship-facts");
   let checksGreen = false;
   let checkSummary = "checks unavailable";
   let reviewPending = false;
-  if (checksRes.code === 0) {
-    const checks = parseJson<ShipCheck[]>(checksRes.stdout, []);
+  try {
+    const checks = parseJson<ShipCheck[]>(await github.reviewChecks(repo, pr), []);
     checksGreen = shipChecksAreGreen(checks);
     reviewPending = advisoryReviewPending(checks, reviewCheck);
     checkSummary = checks.length === 0 ? "no checks configured" : `${checks.filter((c) => shipChecksAreGreen([c])).length}/${checks.length} green`;
-  } else if (/no checks/i.test(`${checksRes.stdout}\n${checksRes.stderr}`)) {
-    checksGreen = true;
-    checkSummary = "no checks configured";
+  } catch (error) {
+    if (/no checks/i.test(error instanceof Error ? error.message : String(error))) {
+      checksGreen = true;
+      checkSummary = "no checks configured";
+    }
   }
 
-  const viewRes = await required(
-    "gh",
-    ["pr", "view", String(pr), "--repo", repo, "--json", "reviewDecision,reviews,statusCheckRollup"],
-    cwd,
-    "read PR reviews",
-  );
-  const view = parseJson<PrView>(viewRes.stdout, {});
+  const view = parseJson<PrView>(await github.shipPr(repo, pr), {});
 
   // When gh pr checks failed but gh pr view returned a populated statusCheckRollup,
   // use that rollup as the check source.

--- a/apps/dev/src/core/github-merge-read.ts
+++ b/apps/dev/src/core/github-merge-read.ts
@@ -24,6 +24,11 @@ export interface GithubMergeRead {
   requiredCheckContexts(repo: string, branch: string): Promise<string>;
 }
 
+export interface GithubShipRead extends GithubMergeRead {
+  /** Retired ship reader's `gh pr view` compatible review and rollup facts. */
+  shipPr(repo: string, prNumber: number): Promise<string>;
+}
+
 type JsonObject = Record<string, unknown>;
 
 interface PullObservation {
@@ -37,6 +42,15 @@ interface CheckRunList {
 
 interface CommitStatusList {
   readonly statuses?: unknown;
+}
+
+interface PullReview {
+  readonly state?: string | null;
+  readonly user?: { readonly login?: string | null } | null;
+}
+
+interface RequiredPullRequestReviews {
+  readonly required_approving_review_count?: number | null;
 }
 
 const PR_VIEW_OPERATION = routeGithubArgs(["pr", "view"]);
@@ -78,6 +92,12 @@ function rows(value: unknown): JsonObject[] {
   return Array.isArray(value) ? value.map(object).filter((row): row is JsonObject => row !== null) : [];
 }
 
+function httpStatus(error: unknown): number | null {
+  return typeof error === "object" && error !== null && "status" in error
+    ? Number((error as { status?: unknown }).status) || null
+    : null;
+}
+
 function checkRunState(run: JsonObject): string {
   const status = text(run.status).toUpperCase();
   const conclusion = text(run.conclusion).toUpperCase();
@@ -100,7 +120,7 @@ function rollup(checkRuns: unknown, statuses: unknown): JsonObject[] {
 }
 
 /** Build the merge reader over one resident/Worker-lifetime conditional client. */
-export function createGithubMergeRead(client: GithubClient, actor: string): GithubMergeRead {
+export function createGithubMergeRead(client: GithubClient, actor: string): GithubShipRead {
   if (actor.trim() === "") throw new Error("GitHub merge reads require a non-empty attribution actor");
 
   const readPull = async (
@@ -155,6 +175,37 @@ export function createGithubMergeRead(client: GithubClient, actor: string): Gith
     return { ...pull.projected, statusCheckRollup: await readRollup(slug, pull.headRefOid) };
   };
 
+  const readReviews = async (slug: string, prNumber: number): Promise<PullReview[]> => {
+    const repo = repoParts(slug);
+    const answer = await client.conditionalRest<PullReview[]>({
+      cacheKey: `merge:reviews:${slug}:${prNumber}`,
+      route: "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+      parameters: { ...repo, pull_number: prNumber, per_page: 100 },
+      operation: PR_VIEW_OPERATION,
+      actor,
+    });
+    return Array.isArray(answer.data) ? answer.data : [];
+  };
+
+  const requiredApprovalCount = async (slug: string, branch: string): Promise<number> => {
+    if (branch === "") return 0;
+    const repo = repoParts(slug);
+    try {
+      const answer = await client.conditionalRest<RequiredPullRequestReviews>({
+        cacheKey: `merge:required-reviews:${slug}:${branch}`,
+        route: "GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",
+        parameters: { ...repo, branch },
+        operation: API_REST_OPERATION,
+        actor,
+      });
+      const count = Number(answer.data?.required_approving_review_count ?? 0);
+      return Number.isSafeInteger(count) && count > 0 ? count : 0;
+    } catch (error) {
+      if (httpStatus(error) === 404) return 0;
+      throw error;
+    }
+  };
+
   return {
     async reviewChecks(slug, prNumber) {
       const pull = await readPull(slug, prNumber, ["headRefOid"]);
@@ -176,6 +227,27 @@ export function createGithubMergeRead(client: GithubClient, actor: string): Gith
 
     async driverPr(slug, prNumber) {
       return JSON.stringify(await composite(slug, prNumber, ["state", "mergeStateStatus", "headRefOid"]));
+    },
+
+    async shipPr(slug, prNumber) {
+      const pull = await readPull(slug, prNumber, ["headRefOid", "baseRefName"]);
+      const baseRefName = text(pull.projected.baseRefName);
+      const [statusCheckRollup, reviews, requiredApprovals] = await Promise.all([
+        readRollup(slug, pull.headRefOid),
+        readReviews(slug, prNumber),
+        requiredApprovalCount(slug, baseRefName),
+      ]);
+      const latestReviewByActor = new Map<string, string>();
+      for (const review of reviews) {
+        const login = text(review.user?.login);
+        if (login !== "") latestReviewByActor.set(login, text(review.state).toUpperCase());
+      }
+      const approvals = [...latestReviewByActor.values()].filter((state) => state === "APPROVED").length;
+      const changesRequested = reviews.some((review) => text(review.state).toUpperCase() === "CHANGES_REQUESTED");
+      const reviewDecision = changesRequested
+        ? "CHANGES_REQUESTED"
+        : approvals < requiredApprovals ? "REVIEW_REQUIRED" : approvals > 0 ? "APPROVED" : "";
+      return JSON.stringify({ reviewDecision, reviews, statusCheckRollup });
     },
 
     async requiredCheckContexts(slug, branch) {

--- a/apps/dev/src/core/github-read-route-guard.ts
+++ b/apps/dev/src/core/github-read-route-guard.ts
@@ -45,11 +45,8 @@ export interface GithubReadShelloutBaselineEntry {
  */
 export const GITHUB_READ_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineEntry[] = [
   { path: "apps/dev/src/commands/requeue.ts", count: 2, reason: "requeue still resolves repository and issue state through the CLI" },
-  { path: "apps/dev/src/commands/respond.ts", count: 2, reason: "respond still resolves repository and comment state through the CLI" },
   { path: "apps/dev/src/commands/review.ts", count: 1, reason: "review still resolves repository identity through the CLI" },
-  { path: "apps/dev/src/commands/ship.ts", count: 2, reason: "ship still reads PR checks and PR state through the CLI" },
   { path: "apps/dev/src/core/merge.ts", count: 2, reason: "one-shot merge rejection diagnosis and queued-PR discovery remain after the two hot waits moved" },
-  { path: "apps/dev/src/runtime/doctor-classifiers.ts", count: 1, reason: "doctor still probes one GitHub REST resource through gh api" },
   { path: "apps/dev/src/runtime/etag-transport.ts", count: 1, reason: "the legacy ETag transport still resolves one PR head through the CLI" },
   { path: "apps/dev/src/runtime/gh/comments.ts", count: 4, reason: "comment reads still need shared conditional REST projections" },
   { path: "apps/dev/src/runtime/gh/issues.ts", count: 10, reason: "issue list, view, and REST helper reads remain the largest dev migration cluster" },

--- a/apps/dev/src/runtime/doctor-classifiers.ts
+++ b/apps/dev/src/runtime/doctor-classifiers.ts
@@ -65,6 +65,7 @@ import {
 import { collectDocsSweepInput } from "./wire/docs.js";
 import type { RepoContext } from "./wire/paths.js";
 import { listDependencyEdgeTickets, type GhContext } from "./gh.js";
+import { createDevGithubMergeRead } from "./github-merge-read.js";
 import {
   judgePluginVersion,
   readInstalledPluginVersions,
@@ -831,17 +832,15 @@ async function readRequiredStatusChecks(
   trunk: string,
 ): Promise<readonly string[] | null> {
   if (!ctx.repo) return null;
-  const { execTool } = await import("./exec.js");
-  const endpoint = `repos/${ctx.repo}/branches/${encodeURIComponent(trunk)}/protection/required_status_checks/contexts`;
-  const result = await execTool("gh", ["api", endpoint], { cwd: ctx.root, timeoutMs: 20_000 });
-  if (result.code !== 0) return result.code === 1 && /404|not found/i.test(result.stderr) ? [] : null;
   try {
-    const parsed: unknown = JSON.parse(result.stdout);
+    const stdout = await createDevGithubMergeRead(ctx.root, "red-doctor")
+      .requiredCheckContexts(ctx.repo, trunk);
+    const parsed: unknown = JSON.parse(stdout);
     return Array.isArray(parsed)
       ? parsed.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "")
       : null;
-  } catch {
-    return null;
+  } catch (error) {
+    return /404|not found/i.test(message(error)) ? [] : null;
   }
 }
 

--- a/apps/dev/src/runtime/github-merge-read.ts
+++ b/apps/dev/src/runtime/github-merge-read.ts
@@ -1,11 +1,16 @@
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { createGithubAttributionLedger, createGithubBalanceStore, createGithubClient } from "@reddb-io/github";
+import {
+  createGithubAttributionLedger,
+  createGithubBalanceStore,
+  createGithubClient,
+  type GithubClient,
+} from "@reddb-io/github";
 import { stateDir } from "@reddb-io/shared/red-paths.js";
 import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
 
-import { createGithubMergeRead, type GithubMergeRead } from "../core/github-merge-read.js";
+import { createGithubMergeRead, type GithubShipRead } from "../core/github-merge-read.js";
 
 export interface CreateDevGithubMergeReadOptions {
   readonly env?: NodeJS.ProcessEnv;
@@ -31,11 +36,10 @@ function readTrackerToken(): string | null {
  * credential has been resolved. Every read after that point crosses the shared
  * conditional client and its durable attribution ledger.
  */
-export function createDevGithubMergeRead(
+function createDevGithubClientFactory(
   root: string,
-  actor: string,
   options: CreateDevGithubMergeReadOptions = {},
-): GithubMergeRead {
+): () => GithubClient {
   const env = options.env ?? process.env;
   const attribution = createGithubAttributionLedger({
     path: join(stateDir(root), "github", "spend.toonl"),
@@ -49,7 +53,7 @@ export function createDevGithubMergeRead(
   // wiring test require a real credential, which passed on a developer machine
   // with `gh` logged in and failed in CI where that context has none. Auth is a
   // precondition of reading, so the refusal belongs at the read.
-  const client = () => {
+  return () => {
     const token = (
       env.REDSKILLED_HOST_TOKEN ??
       env.GITHUB_TOKEN ??
@@ -59,16 +63,33 @@ export function createDevGithubMergeRead(
       ""
     ).trim();
     if (token === "") {
-      throw new Error("GitHub merge reads require an authenticated tracker credential");
+      throw new Error("GitHub reads require an authenticated tracker credential");
     }
     return createGithubClient({ token, attribution, balance: () => balance.read() });
   };
+}
 
-  const routed = (): GithubMergeRead => createGithubMergeRead(client(), actor);
+/** Build one authenticated, attributed shared GitHub client for command reads. */
+export function createDevGithubClient(
+  root: string,
+  options: CreateDevGithubMergeReadOptions = {},
+): GithubClient {
+  return createDevGithubClientFactory(root, options)();
+}
+
+export function createDevGithubMergeRead(
+  root: string,
+  actor: string,
+  options: CreateDevGithubMergeReadOptions = {},
+): GithubShipRead {
+  const client = createDevGithubClientFactory(root, options);
+
+  const routed = (): GithubShipRead => createGithubMergeRead(client(), actor);
   return {
     reviewChecks: (repo, pr) => routed().reviewChecks(repo, pr),
     mergeState: (repo, pr) => routed().mergeState(repo, pr),
     driverPr: (repo, pr) => routed().driverPr(repo, pr),
+    shipPr: (repo, pr) => routed().shipPr(repo, pr),
     requiredCheckContexts: (repo, branch) => routed().requiredCheckContexts(repo, branch),
   };
 }

--- a/apps/dev/tests/github-read-route-guard.test.ts
+++ b/apps/dev/tests/github-read-route-guard.test.ts
@@ -111,6 +111,23 @@ describe("GitHub reads route through @reddb-io/github (#3451)", () => {
     expect(GITHUB_WRITE_SHELLOUT_BASELINE.some((entry) => entry.path === path)).toBe(false);
   });
 
+  it("routes respond, ship, and doctor classifier GitHub I/O through packages/github (#3730)", () => {
+    const paths = [
+      "apps/dev/src/commands/respond.ts",
+      "apps/dev/src/commands/ship.ts",
+      "apps/dev/src/runtime/doctor-classifiers.ts",
+    ];
+    const readReport = collectGithubReadRouteReport(ROOT);
+    const writeReport = collectGithubWriteRouteReport(ROOT);
+
+    for (const path of paths) {
+      expect(readReport.findings.filter((finding) => finding.path === path)).toEqual([]);
+      expect(writeReport.findings.filter((finding) => finding.path === path)).toEqual([]);
+      expect(GITHUB_READ_SHELLOUT_BASELINE.some((entry) => entry.path === path)).toBe(false);
+      expect(GITHUB_WRITE_SHELLOUT_BASELINE.some((entry) => entry.path === path)).toBe(false);
+    }
+  });
+
   it("rejects a new gh write and points it at the shared client", () => {
     const findings = collectGithubWriteShelloutsFromFiles([
       {

--- a/apps/dev/tests/ship-facts.test.ts
+++ b/apps/dev/tests/ship-facts.test.ts
@@ -27,8 +27,11 @@ vi.mock("../src/runtime/exec.js", () => ({
   execTool: vi.fn(),
   pnpm: vi.fn(),
 }));
+vi.mock("../src/runtime/github-merge-read.js", () => ({
+  createDevGithubMergeRead: vi.fn(),
+}));
 
-import { execTool } from "../src/runtime/exec.js";
+import { createDevGithubMergeRead } from "../src/runtime/github-merge-read.js";
 import { collectShipFacts } from "../src/commands/ship.js";
 
 // ---------------------------------------------------------------------------
@@ -69,15 +72,15 @@ function prViewPayload(rollup: unknown[], reviewDecision = ""): string {
   return JSON.stringify({ reviewDecision, reviews: [], statusCheckRollup: rollup });
 }
 
-// Wire up the two gh calls that collectShipFacts makes.
+// Wire up the two routed reads that collectShipFacts makes.
 function setupMocks(checksCode: number, checksStdout: string, viewPayload: string): void {
-  vi.mocked(execTool).mockImplementation(async (_cmd, args) => {
-    if (Array.isArray(args) && args[1] === "checks") {
-      return { code: checksCode, stdout: checksStdout, stderr: checksCode !== 0 ? "API error" : "" };
-    }
-    // gh pr view — must succeed for required() not to throw
-    return { code: 0, stdout: viewPayload, stderr: "" };
-  });
+  vi.mocked(createDevGithubMergeRead).mockReturnValue({
+    reviewChecks: async () => {
+      if (checksCode !== 0) throw new Error("API error");
+      return checksStdout;
+    },
+    shipPr: async () => viewPayload,
+  } as never);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/github/write-plan.test.ts
+++ b/packages/github/write-plan.test.ts
@@ -74,6 +74,16 @@ describe("planGithubWrite — the client owns the write rail", () => {
     });
   });
 
+  it("realizes a pull request comment on the shared REST issue-comment endpoint", () => {
+    const plan = planGithubWrite([
+      "gh", "pr", "comment", "42", "--repo", "o/r", "--body", "resolved",
+    ]);
+    expect(plan).toEqual({
+      surface: "rest",
+      args: ["gh", "api", "-X", "POST", "repos/o/r/issues/42/comments", "-f", "body=resolved"],
+    });
+  });
+
   it("preserves an explicit REST API mutation on the REST rail", () => {
     const argv = [
       "gh", "api", "repos/o/r/issues/comments/99", "--method", "PATCH", "--field", "body=updated",

--- a/packages/github/write-plan.ts
+++ b/packages/github/write-plan.ts
@@ -76,7 +76,7 @@ function commandPath(args: readonly string[]): string[] {
  * - `gh -R o/r pr merge <n> --merge --auto [...]`  → unchanged (GraphQL enqueue)
  * - `gh -R o/r pr create --base b --head h --title t --body y [--draft]`
  *   → REST `POST pulls`
- * - `gh issue comment <n> -R o/r --body y`
+ * - `gh issue|pr comment <n> -R o/r --body y`
  *   → REST `POST issues/{n}/comments`
  * - `gh api <rest-path> --method <verb> ...`
  *   → unchanged on the explicitly selected REST rail
@@ -176,7 +176,7 @@ export function planGithubWrite(
       };
     }
   }
-  if (repo && group === "issue" && verb === "comment") {
+  if (repo && (group === "issue" || group === "pr") && verb === "comment") {
     const issueNumber = args[args.indexOf("comment") + 1];
     const body = flagValue(args, "--body");
     if (issueNumber && /^\d+$/.test(issueNumber) && body !== undefined) {


### PR DESCRIPTION
Automated AFK landing for #3730. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3730

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789125783&installation_model_id=20659&pr_number=3738&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3738&signature=f010d4525b5b9217e3a2dcdda32eca281d6fed29f3f8656e2f41648f51861b46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->