### PR TITLE
feat: #3731 Client mandate: merge.ts remaining writes ride the write-plan (draft ready, labels, update-branch)

### DIFF
--- a/apps/dev/src/core/github-read-route-guard.ts
+++ b/apps/dev/src/core/github-read-route-guard.ts
@@ -61,7 +61,6 @@ export const GITHUB_READ_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineE
 
 /** Raw mutation inventory. SHRINK ONLY: writes share the routed-client destination. */
 export const GITHUB_WRITE_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineEntry[] = [
-  { path: "apps/dev/src/core/merge.ts", count: 7, reason: "landing uses REST for create and merge, while draft readiness, labels, and update-branch still await routed mutations" },
   { path: "apps/dev/src/runtime/gh/issues.ts", count: 7, reason: "issue body, state, and label edits now use the write plan; comment, create, sub-issue, and label-resource mutations remain" },
   { path: "apps/dev/src/runtime/gh/manager-map.ts", count: 3, reason: "manager-map issue creation still awaits the shared mutation surface" },
   { path: "apps/dev/src/runtime/merge-driver-io.ts", count: 2, reason: "the compatibility merge driver still shells out for update and merge" },

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -1623,7 +1623,9 @@ async function mergeWithStaleBranchRecovery(
     if (!diagnosis.retryable || round >= STALE_BRANCH_MERGE_ROUNDS) {
       return { ok: false, prNumber, reason: "merge-failed", mergeFailure: diagnosis };
     }
-    const updated = await exec(["gh", "-R", repo, "pr", "update-branch", String(prNumber)]);
+    const updated = await exec([
+      ...planGithubWrite(["gh", "-R", repo, "pr", "update-branch", String(prNumber)]).args,
+    ]);
     if (updated.code !== 0) {
       return {
         ok: false,
@@ -2352,7 +2354,9 @@ async function ensurePr(
     // is a no-op on a PR that is already ready, so mark unconditionally rather
     // than paying a state read to decide. Best-effort: a forge that refuses the
     // flip must not abort a landing that is otherwise green.
-    await exec(["gh", "-R", repo, "pr", "ready", String(existing)]);
+    await exec([
+      ...planGithubWrite(["gh", "-R", repo, "pr", "ready", String(existing)]).args,
+    ]);
     return existing;
   }
   // Canonical argv in, rail out: the client realizes the create on REST (#3663).
@@ -2419,7 +2423,9 @@ export async function openDraftPr(exec: Exec, input: OpenDraftPrInput): Promise<
  * and the Attempt record already carry the trail, so a failed mirror costs
  * fidelity on a projection, never the round. */
 export async function editPrBody(exec: Exec, repo: string, prNumber: number, body: string): Promise<boolean> {
-  const r = await exec(["gh", "-R", repo, "pr", "edit", String(prNumber), "--body", scrubOutbound(body)]);
+  const r = await exec([
+    ...planGithubWrite(["gh", "-R", repo, "pr", "edit", String(prNumber), "--body", scrubOutbound(body)]).args,
+  ]);
   return r.code === 0;
 }
 
@@ -2428,7 +2434,9 @@ export async function editPrBody(exec: Exec, repo: string, prNumber: number, bod
  * Issue answer the same query, and a forge that refuses it costs that query a
  * row, never the park. */
 export async function labelPr(exec: Exec, repo: string, prNumber: number, label: string): Promise<boolean> {
-  const r = await exec(["gh", "-R", repo, "pr", "edit", String(prNumber), "--add-label", label]);
+  const r = await exec([
+    ...planGithubWrite(["gh", "-R", repo, "pr", "edit", String(prNumber), "--add-label", label]).args,
+  ]);
   return r.code === 0;
 }
 
@@ -2472,7 +2480,9 @@ export async function openReviewPr(exec: Exec, input: OpenReviewPrInput): Promis
   const prNumber = await ensurePr(exec, { repo, branch, target, n, title });
   if (prNumber === undefined) return { ok: false };
 
-  const label = await exec(["gh", "-R", repo, "pr", "edit", String(prNumber), "--add-label", reviewLabel]);
+  const label = await exec([
+    ...planGithubWrite(["gh", "-R", repo, "pr", "edit", String(prNumber), "--add-label", reviewLabel]).args,
+  ]);
   if (label.code !== 0) return { ok: false, prNumber };
 
   return { ok: true, prNumber };

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -759,7 +759,9 @@ describe("openReviewPr (review-gate handoff, #749)", () => {
     expect(result).toEqual({ ok: true, prNumber: 88 });
     const c = joined(recorded);
     expect(c.some((x) => x.includes("api -X POST") && x.includes("/pulls") && x.includes("base=main") && x.includes("head=afk/wBBBB/9-x"))).toBe(true);
-    expect(c).toContain("gh -R reddb-io/red-skills pr edit 88 --add-label ready-for-review");
+    expect(c).toContain(
+      "gh api -X POST repos/reddb-io/red-skills/issues/88/labels -F labels[]=ready-for-review",
+    );
     // The whole point: the merge is held for the fresh-agent review.
     expect(c.some((x) => x.includes("/merge"))).toBe(false);
   });
@@ -779,13 +781,15 @@ describe("openReviewPr (review-gate handoff, #749)", () => {
     expect(result).toEqual({ ok: true, prNumber: 42 });
     const c = joined(calls);
     expect(c.some((x) => x.includes("api -X POST") && x.includes("/pulls"))).toBe(false);
-    expect(c).toContain("gh -R reddb-io/red-skills pr edit 42 --add-label ready-for-review");
+    expect(c).toContain(
+      "gh api -X POST repos/reddb-io/red-skills/issues/42/labels -F labels[]=ready-for-review",
+    );
   });
 
   it("fails when the label edit fails (PR still resolved)", async () => {
     const { exec } = fakeExec([
       { match: (a) => a.join(" ").includes("pr list"), result: { stdout: "5\n" } },
-      { match: (a) => a.join(" ").includes("pr edit"), result: { code: 1 } },
+      { match: (a) => a.join(" ").includes("issues/5/labels"), result: { code: 1 } },
     ]);
     const result = await openReviewPr(exec, {
       repo: "reddb-io/red-skills",
@@ -1613,7 +1617,7 @@ describe("landPr CI-aware wiring (#812)", () => {
             stderr: "",
           };
         }
-        if (cmd.includes("pr update-branch")) {
+        if (cmd.includes("pulls/5/update-branch")) {
           updated = true;
           return { code: 0, stdout: "", stderr: "" };
         }
@@ -1630,7 +1634,7 @@ describe("landPr CI-aware wiring (#812)", () => {
       });
       expect(r.ok).toBe(true);
       expect(merges).toBe(2);
-      expect(calls.some((c) => c.join(" ").includes("pr update-branch 5"))).toBe(true);
+      expect(calls.some((c) => c.join(" ").includes("api -X PUT repos/o/r/pulls/5/update-branch"))).toBe(true);
     });
 
     it("names the OBSERVED cause when the rejection is not a stale branch", async () => {
@@ -1670,7 +1674,7 @@ describe("landPr CI-aware wiring (#812)", () => {
             stderr: "",
           };
         }
-        if (cmd.includes("pr update-branch")) {
+        if (cmd.includes("pulls/5/update-branch")) {
           updates += 1;
           return { code: 0, stdout: "", stderr: "" };
         }

--- a/packages/github/write-plan.test.ts
+++ b/packages/github/write-plan.test.ts
@@ -92,9 +92,52 @@ describe("planGithubWrite — the client owns the write rail", () => {
     expect(plan).toEqual({ surface: "rest", args: argv });
   });
 
-  it("passes an unrouted write through unchanged", () => {
+  it("realizes a pull-request label addition on REST", () => {
+    const plan = planGithubWrite([
+      "gh", "-R", "o/r", "pr", "edit", "42", "--add-label", "ready-for-review",
+    ]);
+    expect(plan).toEqual({
+      surface: "rest",
+      args: [
+        "gh", "api", "-X", "POST", "repos/o/r/issues/42/labels",
+        "-F", "labels[]=ready-for-review",
+      ],
+    });
+  });
+
+  it("realizes a pull-request body edit on REST", () => {
+    const plan = planGithubWrite([
+      "gh", "-R", "o/r", "pr", "edit", "42", "--body", "updated trail",
+    ]);
+    expect(plan).toEqual({
+      surface: "rest",
+      args: [
+        "gh", "api", "-X", "PATCH", "repos/o/r/pulls/42",
+        "-f", "body=updated trail",
+      ],
+    });
+  });
+
+  it("does not partially realize a combined pull-request edit", () => {
+    const argv = [
+      "gh", "-R", "o/r", "pr", "edit", "42",
+      "--body", "updated trail", "--add-label", "ready-for-review",
+    ];
+    expect(planGithubWrite(argv)).toEqual({ surface: "graphql", args: argv });
+  });
+
+  it("realizes pull-request update-branch on REST", () => {
+    const plan = planGithubWrite([
+      "gh", "-R", "o/r", "pr", "update-branch", "42",
+    ]);
+    expect(plan).toEqual({
+      surface: "rest",
+      args: ["gh", "api", "-X", "PUT", "repos/o/r/pulls/42/update-branch"],
+    });
+  });
+
+  it("declares pull-request readiness as GraphQL-only", () => {
     const argv = ["gh", "-R", "o/r", "pr", "ready", "42"];
-    const plan = planGithubWrite(argv);
-    expect(plan.args).toBe(argv);
+    expect(planGithubWrite(argv)).toEqual({ surface: "graphql", args: argv });
   });
 });

--- a/packages/github/write-plan.ts
+++ b/packages/github/write-plan.ts
@@ -76,6 +76,10 @@ function commandPath(args: readonly string[]): string[] {
  * - `gh -R o/r pr merge <n> --merge --auto [...]`  → unchanged (GraphQL enqueue)
  * - `gh -R o/r pr create --base b --head h --title t --body y [--draft]`
  *   → REST `POST pulls`
+ * - `gh -R o/r pr edit <n> --body b` → REST `PATCH pulls/{n}`
+ * - `gh -R o/r pr edit <n> --add-label l` → REST `POST issues/{n}/labels`
+ * - `gh -R o/r pr ready <n>` → unchanged (GraphQL-only mutation)
+ * - `gh -R o/r pr update-branch <n>` → REST `PUT pulls/{n}/update-branch`
  * - `gh issue|pr comment <n> -R o/r --body y`
  *   → REST `POST issues/{n}/comments`
  * - `gh api <rest-path> --method <verb> ...`
@@ -173,6 +177,38 @@ export function planGithubWrite(
           "-f", `title=${title}`,
           ...(body !== undefined ? ["-f", `body=${body}`] : []),
         ],
+      };
+    }
+  }
+  if (repo && group === "pr" && verb === "ready") return { args, surface: "graphql" };
+  if (repo && group === "pr" && verb === "edit") {
+    const editAt = args.indexOf("edit");
+    const prNumber = args[editAt + 1];
+    const body = flagValue(args, "--body");
+    const addLabels = flagValues(args, "--add-label");
+    const supported = usesOnlyValueFlags(args, editAt + 2, new Set(["-R", "--repo", "--body", "--add-label"]));
+    if (supported && prNumber && /^\d+$/.test(prNumber) && body !== undefined && addLabels.length === 0) {
+      return {
+        surface: "rest",
+        args: ["gh", "api", "-X", "PATCH", `repos/${repo}/pulls/${prNumber}`, "-f", `body=${body}`],
+      };
+    }
+    if (supported && prNumber && /^\d+$/.test(prNumber) && body === undefined && addLabels.length > 0) {
+      return {
+        surface: "rest",
+        args: [
+          "gh", "api", "-X", "POST", `repos/${repo}/issues/${prNumber}/labels`,
+          ...addLabels.flatMap((label) => ["-F", `labels[]=${label}`]),
+        ],
+      };
+    }
+  }
+  if (repo && group === "pr" && verb === "update-branch") {
+    const prNumber = args[args.indexOf("update-branch") + 1];
+    if (prNumber && /^\d+$/.test(prNumber)) {
+      return {
+        surface: "rest",
+        args: ["gh", "api", "-X", "PUT", `repos/${repo}/pulls/${prNumber}/update-branch`],
       };
     }
   }


### PR DESCRIPTION
Automated AFK landing for #3731. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3731

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789125990&installation_model_id=20659&pr_number=3739&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3739&signature=f62390b2bf6f2b2aa332860080dd142dd4861edf46784e7e9f5042587a5c43c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->