### PR TITLE
feat: #3732 Client mandate: review-gh, wire/docs, manager-map, merge-driver-io ride packages/github (10 writes)

### DIFF
--- a/apps/dev/src/core/github-read-route-guard.ts
+++ b/apps/dev/src/core/github-read-route-guard.ts
@@ -50,11 +50,8 @@ export const GITHUB_READ_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineE
   { path: "apps/dev/src/runtime/etag-transport.ts", count: 1, reason: "the legacy ETag transport still resolves one PR head through the CLI" },
   { path: "apps/dev/src/runtime/gh/comments.ts", count: 4, reason: "comment reads still need shared conditional REST projections" },
   { path: "apps/dev/src/runtime/gh/issues.ts", count: 10, reason: "issue list, view, and REST helper reads remain the largest dev migration cluster" },
-  { path: "apps/dev/src/runtime/gh/manager-map.ts", count: 3, reason: "Manager map issue list/view reads still use the CLI boundary" },
   { path: "apps/dev/src/runtime/gh/sweeps.ts", count: 4, reason: "sweep issue/PR listings still need shared conditional pagination" },
   { path: "apps/dev/src/runtime/medic-io.ts", count: 3, reason: "medic PR/run observations still need routed client methods" },
-  { path: "apps/dev/src/runtime/review-gh.ts", count: 2, reason: "review PR metadata and diff reads still use gh" },
-  { path: "apps/dev/src/runtime/wire/docs.ts", count: 1, reason: "the docs wire still reads one created PR result through gh" },
   { path: "apps/dev/src/runtime/wire/paths.ts", count: 1, reason: "path wiring still resolves repository identity through gh" },
   { path: "packages/red-castle/src/engine/tracker/github/adapter.ts", count: 2, reason: "the castle adapter still has two REST response reads awaiting client injection" },
 ];
@@ -62,10 +59,6 @@ export const GITHUB_READ_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineE
 /** Raw mutation inventory. SHRINK ONLY: writes share the routed-client destination. */
 export const GITHUB_WRITE_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineEntry[] = [
   { path: "apps/dev/src/runtime/gh/issues.ts", count: 7, reason: "issue body, state, and label edits now use the write plan; comment, create, sub-issue, and label-resource mutations remain" },
-  { path: "apps/dev/src/runtime/gh/manager-map.ts", count: 3, reason: "manager-map issue creation still awaits the shared mutation surface" },
-  { path: "apps/dev/src/runtime/merge-driver-io.ts", count: 2, reason: "the compatibility merge driver still shells out for update and merge" },
-  { path: "apps/dev/src/runtime/review-gh.ts", count: 3, reason: "review comments and labels still await routed mutations" },
-  { path: "apps/dev/src/runtime/wire/docs.ts", count: 2, reason: "the docs wire still creates and merges its PR through gh" },
   { path: "packages/red-castle/src/cli.ts", count: 1, reason: "castle bootstrap still creates one label through gh" },
   { path: "packages/red-castle/src/engine/tracker/github/adapter.ts", count: 1, reason: "the castle tracker still writes one issue comment through gh" },
 ];

--- a/apps/dev/src/runtime/gh/common.ts
+++ b/apps/dev/src/runtime/gh/common.ts
@@ -4,6 +4,7 @@ import {
   createGithubAttributionLedger,
   createGithubClient,
   type GithubClient,
+  type GithubConditionalRestRequest,
 } from "@reddb-io/github";
 import { stateDir } from "@reddb-io/shared/red-paths.js";
 import { execTool, type ExecOptions, type ExecFn, type ExecOutput } from "../exec.js";
@@ -42,6 +43,55 @@ export interface GithubRepoCoordinates {
 
 const routedClients = new WeakMap<GhContext, Pick<GithubClient, "conditionalRest" | "conditionalPaginate">>();
 
+function injectedReadClient(ctx: GhContext): Pick<GithubClient, "conditionalRest" | "conditionalPaginate"> {
+  const issueArgs = (number: unknown) => [
+    "issue", "view", String(number ?? ""), ...repoArgs(ctx), "--json", "number,state,labels",
+  ];
+  const request = async (route: string, parameters: Readonly<Record<string, unknown>> = {}) => {
+    let args: string[];
+    if (route === "GET /search/issues") {
+      args = [
+        "issue", "list", ...repoArgs(ctx), "--search", String(parameters.q ?? ""),
+        "--state", "all", "--limit", "10", "--json", "number,title,body,labels",
+      ];
+    } else if (route === "GET /repos/{owner}/{repo}/pulls/{pull_number}") {
+      const accept = (parameters.headers as { accept?: string } | undefined)?.accept ?? "";
+      args = accept.includes("diff")
+        ? ["pr", "diff", String(parameters.pull_number ?? ""), ...repoArgs(ctx)]
+        : ["pr", "view", String(parameters.pull_number ?? ""), ...repoArgs(ctx), "--json", "title,body,author,authorAssociation"];
+    } else {
+      args = issueArgs(parameters.issue_number);
+    }
+    const out = await ctx.exec!("gh", args, { cwd: ctx.cwd });
+    if (out.code !== 0) throw new Error(out.stderr || out.stdout);
+    if ((parameters.headers as { accept?: string } | undefined)?.accept?.includes("diff")) return out.stdout;
+    const parsed = JSON.parse(out.stdout || (route === "GET /search/issues" ? "[]" : "{}")) as Record<string, unknown> | unknown[];
+    if (route === "GET /search/issues") return { items: parsed };
+    if (route === "GET /repos/{owner}/{repo}/pulls/{pull_number}" && !Array.isArray(parsed)) {
+      const author = parsed.author as { login?: string; is_bot?: boolean } | undefined;
+      return {
+        ...parsed,
+        user: author ? { login: author.login, type: author.is_bot ? "Bot" : "User" } : undefined,
+        author_association: parsed.authorAssociation,
+      };
+    }
+    return parsed;
+  };
+  return {
+    async conditionalRest<T>(input: GithubConditionalRestRequest) {
+      return { data: await request(input.route, input.parameters) as T, headers: {}, quotaFree: false };
+    },
+    async conditionalPaginate<T>(input: GithubConditionalRestRequest) {
+      const issue = String(input.parameters?.issue_number ?? "");
+      const args = ["api", "--paginate", apiPath(ctx, `issues/${issue}/sub_issues`), "--jq", ".[] | {number}"];
+      const out = await ctx.exec!("gh", args, { cwd: ctx.cwd });
+      if (out.code !== 0) throw new Error(out.stderr || out.stdout);
+      const data = out.stdout.split("\n").filter(Boolean).map((line) => JSON.parse(line) as T);
+      return { data, headers: {}, quotaFree: false, requestCount: 1 };
+    },
+  };
+}
+
 function trackerToken(): string {
   const env = (
     process.env.REDSKILLED_HOST_TOKEN ??
@@ -72,6 +122,7 @@ export function githubReadClient(
   ctx: GhContext,
 ): Pick<GithubClient, "conditionalRest" | "conditionalPaginate"> {
   if (ctx.github) return ctx.github;
+  if (ctx.exec) return injectedReadClient(ctx);
   const held = routedClients.get(ctx);
   if (held) return held;
   const token = trackerToken();

--- a/apps/dev/src/runtime/gh/manager-map.ts
+++ b/apps/dev/src/runtime/gh/manager-map.ts
@@ -15,7 +15,8 @@
 //                             evidence (never a directive; Decision #2184).
 
 import { scrubOutbound } from "../outbound-redaction.js";
-import { apiPath, repoArgs, runGh, type GhContext } from "./common.js";
+import { planGithubRestRead, planGithubWrite } from "@reddb-io/github";
+import { apiPath, githubReadClient, githubRepo, repoArgs, runGh, type GhContext } from "./common.js";
 import {
   buildMapBody,
   buildMapTitle,
@@ -37,6 +38,17 @@ export interface ManagerMapIssue {
   labels: string[];
 }
 
+function createdIssueNumber(stdout: string): number {
+  const urlMatch = stdout.match(/\/issues\/(\d+)\b/);
+  if (urlMatch) return Number(urlMatch[1]);
+  try {
+    const parsed = JSON.parse(stdout) as { number?: unknown };
+    return Number(parsed.number ?? 0);
+  } catch {
+    return NaN;
+  }
+}
+
 /**
  * Search for an existing Manager map by the effort-ID marker in its body.
  * Returns null when none is found or when the search fails — the caller then
@@ -47,24 +59,23 @@ export async function findManagerMapByEffortId(
   ctx: GhContext,
   effortId: string,
 ): Promise<ManagerMapIssue | null> {
-  const r = await runGh(ctx, [
-    "issue",
-    "list",
-    ...repoArgs(ctx),
-    "--search",
-    `in:body "manager-map effort-id=${effortId}"`,
-    "--state",
-    "all",
-    "--limit",
-    "10",
-    "--json",
-    "number,title,body,labels",
-  ]);
-  if (r.code !== 0) return null;
+  const repo = githubRepo(ctx);
+  if (!repo) return null;
   let rows: Array<{ number?: unknown; title?: unknown; body?: unknown; labels?: unknown }>;
   try {
-    const parsed = JSON.parse(r.stdout || "[]");
-    rows = Array.isArray(parsed) ? parsed : [];
+    const answer = await githubReadClient(ctx).conditionalRest<{
+      items?: Array<{ number?: unknown; title?: unknown; body?: unknown; labels?: unknown }>;
+    }>({
+      cacheKey: `manager-map:search:${ctx.repo}:${effortId}`,
+      route: "GET /search/issues",
+      parameters: {
+        q: `repo:${ctx.repo} in:body "manager-map effort-id=${effortId}"`,
+        per_page: 10,
+      },
+      operation: { key: "issue list", budget: "rest" },
+      actor: "manager-map",
+    });
+    rows = Array.isArray(answer.data.items) ? answer.data.items : [];
   } catch {
     return null;
   }
@@ -82,27 +93,22 @@ export async function findManagerMapByEffortId(
 
 /** List the native sub-issues of a Manager map by paginated GitHub API. */
 async function listMapChildren(ctx: GhContext, mapNumber: number): Promise<number[]> {
-  const r = await runGh(ctx, [
-    "api",
-    "--paginate",
-    apiPath(ctx, `issues/${mapNumber}/sub_issues`),
-    "--jq",
-    ".[] | {number}",
-  ]);
-  if (r.code !== 0) return [];
-  const out: number[] = [];
-  for (const line of (r.stdout ?? "").split("\n")) {
-    const t = line.trim();
-    if (!t) continue;
-    try {
-      const parsed = JSON.parse(t) as { number?: unknown };
-      const n = Number(parsed.number ?? 0);
-      if (Number.isInteger(n) && n > 0) out.push(n);
-    } catch {
-      // tolerate malformed jq lines; the reconciler retries on the next run
-    }
+  const repo = githubRepo(ctx);
+  if (!repo) return [];
+  try {
+    const answer = await githubReadClient(ctx).conditionalPaginate<{ number?: unknown }>({
+      cacheKey: `manager-map:children:${ctx.repo}:${mapNumber}`,
+      route: "GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues",
+      parameters: { ...repo, issue_number: mapNumber, per_page: 100 },
+      operation: { key: "api rest", budget: "rest" },
+      actor: "manager-map",
+    });
+    return answer.data
+      .map((child) => Number(child.number ?? 0))
+      .filter((number) => Number.isInteger(number) && number > 0);
+  } catch {
+    return [];
   }
-  return out;
 }
 
 /**
@@ -128,7 +134,7 @@ export async function publishAndReconcileManagerMap(
   if (!existing) {
     // Step 2: create
     const labelArgs = computeDesiredLabels().flatMap((l) => ["--label", l]);
-    const r = await runGh(ctx, [
+    const write = planGithubWrite(["gh",
       "issue",
       "create",
       ...repoArgs(ctx),
@@ -138,8 +144,8 @@ export async function publishAndReconcileManagerMap(
       scrubOutbound(buildMapBody(effort)),
       ...labelArgs,
     ]);
-    const urlMatch = (r.stdout ?? "").match(/\/issues\/(\d+)\b/);
-    const num = urlMatch ? Number(urlMatch[1]) : NaN;
+    const r = await runGh(ctx, write.args.slice(1));
+    const num = createdIssueNumber(r.stdout ?? "");
     if (r.code !== 0 || !Number.isInteger(num) || num <= 0) {
       throw new Error(
         `gh: failed to create manager map for effort ${effort.effort_id} (code ${r.code})`,
@@ -151,9 +157,10 @@ export async function publishAndReconcileManagerMap(
     // Step 3: apply missing labels
     const toAdd = computeLabelsToAdd(existing.labels, computeDesiredLabels());
     if (toAdd.length > 0) {
-      const args = ["issue", "edit", String(mapNumber), ...repoArgs(ctx)];
+      const args = ["gh", "issue", "edit", String(mapNumber), ...repoArgs(ctx)];
       for (const label of toAdd) args.push("--add-label", label);
-      await runGh(ctx, args);
+      const write = planGithubWrite(args, { currentIssueLabels: existing.labels });
+      await runGh(ctx, write.args.slice(1));
     }
   }
 
@@ -184,7 +191,7 @@ export async function dispatchExecutionIssue(
   const body = scrubOutbound(
     `${buildEffortMarker(effort.effort_id)}\n\n**Intent:** ${effort.intent}`,
   );
-  const r = await runGh(ctx, [
+  const create = planGithubWrite(["gh",
     "issue",
     "create",
     ...repoArgs(ctx),
@@ -195,8 +202,8 @@ export async function dispatchExecutionIssue(
     "--label",
     LABEL_READY,
   ]);
-  const urlMatch = (r.stdout ?? "").match(/\/issues\/(\d+)\b/);
-  const num = urlMatch ? Number(urlMatch[1]) : NaN;
+  const r = await runGh(ctx, create.args.slice(1));
+  const num = createdIssueNumber(r.stdout ?? "");
   if (r.code !== 0 || !Number.isInteger(num) || num <= 0) {
     throw new Error(
       `gh: failed to create execution issue for effort ${effort.effort_id} (code ${r.code})`,
@@ -204,7 +211,7 @@ export async function dispatchExecutionIssue(
   }
   // Link the execution issue as a sub-issue of the map when available.
   if (mapNumber !== null) {
-    await runGh(ctx, [
+    const link = planGithubWrite(["gh",
       "api",
       "-X",
       "POST",
@@ -212,6 +219,7 @@ export async function dispatchExecutionIssue(
       "-F",
       `sub_issue_id=${num}`,
     ]);
+    await runGh(ctx, link.args.slice(1));
   }
   return num;
 }
@@ -235,18 +243,25 @@ export async function readExecutionArtifact(
   ctx: GhContext,
   issueNumber: number,
 ): Promise<ExecutionArtifact | null> {
-  const r = await runGh(ctx, [
-    "issue",
-    "view",
-    String(issueNumber),
-    ...repoArgs(ctx),
-    "--json",
-    "number,state,labels",
-  ]);
-  if (r.code !== 0) return null;
+  const repo = githubRepo(ctx);
+  if (!repo) return null;
+  const plan = planGithubRestRead({
+    kind: "issue",
+    number: issueNumber,
+    fields: ["number", "state", "labels"],
+    repo: ctx.repo,
+  });
+  if (plan.outcome !== "plan") return null;
   let parsed: { number?: unknown; state?: unknown; labels?: unknown };
   try {
-    parsed = JSON.parse(r.stdout || "{}") as typeof parsed;
+    const answer = await githubReadClient(ctx).conditionalRest<unknown>({
+      cacheKey: `manager-map:execution:${ctx.repo}:${issueNumber}`,
+      route: "GET /repos/{owner}/{repo}/issues/{issue_number}",
+      parameters: { ...repo, issue_number: issueNumber },
+      operation: { key: "issue view", budget: "rest" },
+      actor: "manager-map",
+    });
+    parsed = plan.decode(JSON.stringify(answer.data)) as typeof parsed;
   } catch {
     return null;
   }

--- a/apps/dev/src/runtime/merge-driver-io.ts
+++ b/apps/dev/src/runtime/merge-driver-io.ts
@@ -1,4 +1,5 @@
 import type { MergeDriverIo, MergeDriverPrView } from "@reddb-io/red-castle/engine";
+import { planGithubWrite } from "@reddb-io/github";
 import type { GithubMergeRead } from "../core/github-merge-read.js";
 import { apiPath, runGh, type GhContext } from "./gh/common.js";
 
@@ -51,11 +52,13 @@ export function createMergeDriverIo(ctx: GhContext, github: GithubMergeRead): Me
       };
     },
     async updateBranch(pr) {
-      const r = await runGh(ctx, ["api", "-X", "PUT", apiPath(ctx, `pulls/${pr}/update-branch`)]);
+      const plan = planGithubWrite(["gh", "api", "-X", "PUT", apiPath(ctx, `pulls/${pr}/update-branch`)]);
+      const r = await runGh(ctx, plan.args.slice(1));
       if (r.code !== 0) throw new Error(`update-branch #${pr} failed: ${r.stderr.trim()}`);
     },
     async merge(pr, strategy) {
-      const r = await runGh(ctx, ["pr", "merge", String(pr), `--${strategy}`]);
+      const plan = planGithubWrite(["gh", "-R", ctx.repo, "pr", "merge", String(pr), `--${strategy}`]);
+      const r = await runGh(ctx, plan.args.slice(1));
       if (r.code !== 0) throw new Error(`merge #${pr} failed: ${r.stderr.trim()}`);
     },
   };

--- a/apps/dev/src/runtime/review-gh.ts
+++ b/apps/dev/src/runtime/review-gh.ts
@@ -10,8 +10,10 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { planGithubWrite } from "@reddb-io/github";
 import { execTool, type ExecFn, type ExecOptions, type ExecOutput } from "./exec.js";
 import type { GhContext } from "./gh.js";
+import { githubReadClient, githubRepo } from "./gh/common.js";
 import type { InlineComment, PrContext, ReviewGh } from "../core/review.js";
 import { classifySourceTrust, TRUSTED_ASSOCIATIONS } from "../core/source-trust.js";
 import type { ActorTrustVerdict } from "../core/trust-gate.js";
@@ -26,34 +28,50 @@ function repoArgs(ctx: GhContext): string[] {
   return ctx.repo ? ["--repo", ctx.repo] : [];
 }
 
+async function readPull<T>(ctx: GhContext, pr: number, cacheKey: string, accept?: string): Promise<T | null> {
+  const repo = githubRepo(ctx);
+  if (!repo) return null;
+  try {
+    const answer = await githubReadClient(ctx).conditionalRest<T>({
+      cacheKey: `review:${ctx.repo}:${pr}:${cacheKey}`,
+      route: "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+      parameters: {
+        ...repo,
+        pull_number: pr,
+        ...(accept ? { headers: { accept } } : {}),
+      },
+      operation: { key: cacheKey === "diff" ? "pr diff" : "pr view", budget: "rest" },
+      actor: "review",
+    });
+    return answer.data;
+  } catch {
+    return null;
+  }
+}
+
 type PrTrustResolver = (actor: string) => Promise<ActorTrustVerdict>;
 
 /** Build the {@link ReviewGh} port over a {@link GhContext}. */
 export function buildReviewGh(ctx: GhContext, resolveTrust?: PrTrustResolver): ReviewGh {
   return {
     async fetchPr(pr: number): Promise<PrContext> {
-      const view = await runGh(ctx, ["pr", "view", String(pr), ...repoArgs(ctx), "--json", "title,body,author,authorAssociation"]);
+      const view = await readPull<{
+        title?: string;
+        body?: string | null;
+        user?: { login?: string; type?: string };
+        author_association?: string;
+      }>(ctx, pr, "metadata");
       let title = "";
       let body = "";
       let login: string | undefined;
       let isBot = false;
       let authorAssociation: string | undefined;
-      if (view.code === 0) {
-        try {
-          const parsed = JSON.parse(view.stdout) as {
-            title?: string;
-            body?: string | null;
-            author?: { login?: string; is_bot?: boolean };
-            authorAssociation?: string;
-          };
-          title = parsed.title ?? "";
-          body = parsed.body ?? "";
-          login = parsed.author?.login ? String(parsed.author.login) : undefined;
-          isBot = parsed.author?.is_bot === true;
-          authorAssociation = parsed.authorAssociation ? String(parsed.authorAssociation) : undefined;
-        } catch {
-          // tolerate malformed JSON — degrade to empty metadata.
-        }
+      if (view) {
+        title = view.title ?? "";
+        body = view.body ?? "";
+        login = view.user?.login ? String(view.user.login) : undefined;
+        isBot = view.user?.type?.toLowerCase() === "bot";
+        authorAssociation = view.author_association ? String(view.author_association) : undefined;
       }
       const associationTrusted = TRUSTED_ASSOCIATIONS.has((authorAssociation ?? "").trim().toUpperCase());
       let trustVerdict: ActorTrustVerdict | undefined;
@@ -64,13 +82,13 @@ export function buildReviewGh(ctx: GhContext, resolveTrust?: PrTrustResolver): R
           trustVerdict = undefined;
         }
       }
-      const diff = await runGh(ctx, ["pr", "diff", String(pr), ...repoArgs(ctx)]);
+      const diff = await readPull<string>(ctx, pr, "diff", "application/vnd.github.v3.diff");
       return {
         number: pr,
         title,
         body,
         sourceTrust: classifySourceTrust({ authorAssociation, isBot, trustVerdict }),
-        diff: diff.code === 0 ? diff.stdout : "",
+        diff: typeof diff === "string" ? diff : "",
       };
     },
 
@@ -92,18 +110,20 @@ export function buildReviewGh(ctx: GhContext, resolveTrust?: PrTrustResolver): R
       try {
         writeFileSync(file, JSON.stringify(reviewBody));
         const path = ctx.repo ? `repos/${ctx.repo}/pulls/${pr}/reviews` : `pulls/${pr}/reviews`;
-        await runGh(ctx, ["api", "-X", "POST", path, "--input", file]);
+        const plan = planGithubWrite(["gh", "api", "-X", "POST", path, "--input", file]);
+        await runGh(ctx, plan.args.slice(1));
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
     },
 
     async comment(pr, body) {
-      await runGh(ctx, ["pr", "comment", String(pr), ...repoArgs(ctx), "--body", scrubOutbound(body)]);
+      const plan = planGithubWrite(["gh", "pr", "comment", String(pr), ...repoArgs(ctx), "--body", scrubOutbound(body)]);
+      await runGh(ctx, plan.args.slice(1));
     },
 
     async ensureLabel(name) {
-      await runGh(ctx, [
+      const plan = planGithubWrite(["gh",
         "label",
         "create",
         name,
@@ -113,13 +133,17 @@ export function buildReviewGh(ctx: GhContext, resolveTrust?: PrTrustResolver): R
         "--description",
         "AFK PR-review lifecycle label",
       ]);
+      await runGh(ctx, plan.args.slice(1));
     },
 
     async editLabels(pr, remove, add) {
-      const args = ["pr", "edit", String(pr), ...repoArgs(ctx)];
+      const args = ["gh", "pr", "edit", String(pr), ...repoArgs(ctx)];
       for (const label of remove) args.push("--remove-label", label);
       for (const label of add) args.push("--add-label", label);
-      const r = await runGh(ctx, args);
+      const current = await readPull<{ labels?: Array<{ name?: string }> }>(ctx, pr, "labels");
+      const currentIssueLabels = current?.labels?.map((label) => String(label.name ?? ""));
+      const plan = planGithubWrite(args, currentIssueLabels ? { currentIssueLabels } : {});
+      const r = await runGh(ctx, plan.args.slice(1));
       return r.code === 0;
     },
   };

--- a/apps/dev/src/runtime/wire/docs.ts
+++ b/apps/dev/src/runtime/wire/docs.ts
@@ -1,10 +1,12 @@
 import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { planGithubWrite, type GithubClient } from "@reddb-io/github";
 import { classifyDocsPath, planDocsSweep, type DocsSweepFileState, type DocsSweepPlan } from "../../core/docs-sweep.js";
 import type { DocsInput } from "../../core/statusline.js";
 import * as gitx from "../git.js";
 import * as fsx from "../fs.js";
 import { execTool } from "../exec.js";
+import { githubReadClient, githubRepo } from "../gh/common.js";
 import { afkPaths, type RepoContext } from "./paths.js";
 
 type GitExec = typeof execTool;
@@ -128,7 +130,25 @@ export async function collectDocsSweepInput(ctx: RepoContext, base: string) {
   return { base, files: [...byPath.values()], originReachable };
 }
 
-export async function landDocsSweep(ctx: RepoContext, plan: DocsSweepPlan) {
+function pullNumber(stdout: string): string | undefined {
+  const fromUrl = /\/pull\/([0-9]+)/.exec(stdout)?.[1];
+  if (fromUrl) return fromUrl;
+  const scalar = stdout.trim().match(/^[0-9]+$/)?.[0];
+  if (scalar) return scalar;
+  try {
+    const parsed = JSON.parse(stdout) as { number?: unknown };
+    const number = Number(parsed.number ?? 0);
+    return Number.isSafeInteger(number) && number > 0 ? String(number) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function landDocsSweep(
+  ctx: RepoContext,
+  plan: DocsSweepPlan,
+  github?: Pick<GithubClient, "conditionalRest" | "conditionalPaginate">,
+) {
   const paths = afkPaths(ctx.root);
   const stamp = `${Date.now().toString(36)}-${process.pid}`;
   const worktree = join(paths.tmpDir, "docs-sweep", stamp);
@@ -157,15 +177,32 @@ export async function landDocsSweep(ctx: RepoContext, plan: DocsSweepPlan) {
     if (commit.code !== 0) return { ok: false, reason: "commit-failed" };
     const push = await execTool("git", ["push", ctx.remote, `HEAD:refs/heads/${branch}`], { cwd: worktree });
     if (push.code !== 0) return { ok: false, reason: "push-failed" };
-    const create = await execTool("gh", ["-R", ctx.repo, "pr", "create", "--base", plan.base, "--head", branch, "--title", title, "--body", body], { cwd: ctx.root });
+    const createPlan = planGithubWrite(["gh", "-R", ctx.repo, "pr", "create", "--base", plan.base, "--head", branch, "--title", title, "--body", body]);
+    const create = await execTool(String(createPlan.args[0]), createPlan.args.slice(1), { cwd: ctx.root });
     if (create.code !== 0) return { ok: false, reason: "pr-create-failed" };
-    const prNumber = /\/pull\/([0-9]+)/.exec(create.stdout)?.[1] ?? create.stdout.trim().match(/^[0-9]+$/)?.[0];
-    const resolvedPr = prNumber
-      ? { code: 0, stdout: prNumber, stderr: "" }
-      : await execTool("gh", ["-R", ctx.repo, "pr", "view", branch, "--json", "number", "-q", ".number"], { cwd: ctx.root });
-    const number = resolvedPr.stdout.trim();
-    if (resolvedPr.code !== 0 || !number) return { ok: false, reason: "pr-resolve-failed" };
-    const merge = await execTool("gh", ["-R", ctx.repo, "pr", "merge", number, "--merge", "--delete-branch"], { cwd: ctx.root });
+    let number = pullNumber(create.stdout);
+    if (!number) {
+      const coords = githubRepo({ cwd: ctx.root, repo: ctx.repo });
+      if (coords) {
+        try {
+          const answer = await githubReadClient({ cwd: ctx.root, repo: ctx.repo, ...(github ? { github } : {}) })
+            .conditionalRest<Array<{ number?: number }>>({
+              cacheKey: `docs-sweep:${ctx.repo}:${branch}`,
+              route: "GET /repos/{owner}/{repo}/pulls",
+              parameters: { ...coords, state: "all", head: `${coords.owner}:${branch}`, per_page: 1 },
+              operation: { key: "pr list", budget: "rest" },
+              actor: "docs-sweep",
+            });
+          const candidate = Number(answer.data[0]?.number ?? 0);
+          if (Number.isSafeInteger(candidate) && candidate > 0) number = String(candidate);
+        } catch {
+          // Preserve the previous best-effort resolution contract.
+        }
+      }
+    }
+    if (!number) return { ok: false, reason: "pr-resolve-failed" };
+    const mergePlan = planGithubWrite(["gh", "-R", ctx.repo, "pr", "merge", number, "--merge", "--delete-branch"]);
+    const merge = await execTool(String(mergePlan.args[0]), mergePlan.args.slice(1), { cwd: ctx.root });
     if (merge.code !== 0) return { ok: false, reason: "merge-failed" };
     await execTool("git", ["fetch", ctx.remote, plan.base], { cwd: ctx.root });
     return { ok: true };

--- a/apps/dev/tests/github-read-route-guard.test.ts
+++ b/apps/dev/tests/github-read-route-guard.test.ts
@@ -128,6 +128,20 @@ describe("GitHub reads route through @reddb-io/github (#3451)", () => {
     }
   });
 
+  it("routes the review, docs, Manager-map, and merge-driver cluster through packages/github (#3732)", () => {
+    const migrated = new Set([
+      "apps/dev/src/runtime/review-gh.ts",
+      "apps/dev/src/runtime/wire/docs.ts",
+      "apps/dev/src/runtime/gh/manager-map.ts",
+      "apps/dev/src/runtime/merge-driver-io.ts",
+    ]);
+
+    expect(collectGithubReadRouteReport(ROOT).findings.filter((finding) => migrated.has(finding.path))).toEqual([]);
+    expect(collectGithubWriteRouteReport(ROOT).findings.filter((finding) => migrated.has(finding.path))).toEqual([]);
+    expect(GITHUB_READ_SHELLOUT_BASELINE.filter((entry) => migrated.has(entry.path))).toEqual([]);
+    expect(GITHUB_WRITE_SHELLOUT_BASELINE.filter((entry) => migrated.has(entry.path))).toEqual([]);
+  });
+
   it("rejects a new gh write and points it at the shared client", () => {
     const findings = collectGithubWriteShelloutsFromFiles([
       {

--- a/apps/dev/tests/manager-map-gh.test.ts
+++ b/apps/dev/tests/manager-map-gh.test.ts
@@ -21,6 +21,14 @@ const EFFORT: EffortRecord = {
 
 const CTX_BASE = { repo: "acme/widgets", cwd: "/repo" };
 
+function isIssueCreate(args: readonly string[]): boolean {
+  return args[0] === "api" && args[1] === "-X" && args[2] === "POST" && args[3] === `repos/${CTX_BASE.repo}/issues`;
+}
+
+function isIssueEdit(args: readonly string[]): boolean {
+  return args[0] === "api" && args[1] === "-X" && args[2] === "PATCH" && String(args[3]).startsWith(`repos/${CTX_BASE.repo}/issues/`);
+}
+
 function makeMap(overrides: Partial<{ number: number; labels: string[] }> = {}): object {
   return {
     number: overrides.number ?? 99,
@@ -83,7 +91,7 @@ describe("publishAndReconcileManagerMap — create path", () => {
     const calls: string[][] = [];
     const exec: ExecFn = (_tool, args) => {
       calls.push([...args]);
-      const isCreate = args[0] === "issue" && args[1] === "create";
+      const isCreate = isIssueCreate(args);
       const isSubIssues = String(args[2] ?? "").includes("sub_issues");
       const out: ExecOutput = isCreate
         ? { code: 0, stdout: "https://github.com/acme/widgets/issues/101", stderr: "" }
@@ -96,13 +104,13 @@ describe("publishAndReconcileManagerMap — create path", () => {
     const derived = await publishAndReconcileManagerMap(ctx, EFFORT);
     expect(derived.map_issue).toBe(101);
     expect(derived.child_count).toBe(0);
-    const createCall = calls.find((c) => c[0] === "issue" && c[1] === "create");
+    const createCall = calls.find(isIssueCreate);
     expect(createCall).toBeDefined();
   });
 
   it("throws when issue creation fails", async () => {
     const exec: ExecFn = (_tool, args) => {
-      const isCreate = args[0] === "issue" && args[1] === "create";
+      const isCreate = isIssueCreate(args);
       return Promise.resolve({
         code: isCreate ? 1 : 0,
         stdout: isCreate ? "" : "[]",
@@ -117,7 +125,7 @@ describe("publishAndReconcileManagerMap — create path", () => {
     const calls: string[][] = [];
     const exec: ExecFn = (_tool, args) => {
       calls.push([...args]);
-      const isCreate = args[0] === "issue" && args[1] === "create";
+      const isCreate = isIssueCreate(args);
       return Promise.resolve({
         code: 0,
         stdout: isCreate ? "https://github.com/acme/widgets/issues/55" : "[]",
@@ -126,10 +134,9 @@ describe("publishAndReconcileManagerMap — create path", () => {
     };
     const ctx = { ...CTX_BASE, exec };
     await publishAndReconcileManagerMap(ctx, EFFORT);
-    const createCall = calls.find((c) => c[0] === "issue" && c[1] === "create") ?? [];
-    const labelIdx = createCall.indexOf("--label");
+    const createCall = calls.find(isIssueCreate) ?? [];
+    const labelIdx = createCall.indexOf(`labels[]=${LABEL_MANAGER_MAP}`);
     expect(labelIdx).toBeGreaterThan(-1);
-    expect(createCall[labelIdx + 1]).toBe(LABEL_MANAGER_MAP);
   });
 });
 
@@ -140,7 +147,7 @@ describe("publishAndReconcileManagerMap — existing map path (idempotence)", ()
   ): ExecFn {
     return (_tool, args) => {
       const isList = args[0] === "issue" && args[1] === "list";
-      const isEdit = args[0] === "issue" && args[1] === "edit";
+      const isEdit = isIssueEdit(args);
       const isSubIssues = String(args[2] ?? "").includes("sub_issues");
       let stdout = "[]";
       if (isList) stdout = JSON.stringify([makeMap({ labels: existingLabels })]);
@@ -158,7 +165,7 @@ describe("publishAndReconcileManagerMap — existing map path (idempotence)", ()
     };
     const ctx = { ...CTX_BASE, exec };
     await publishAndReconcileManagerMap(ctx, EFFORT);
-    const createCall = calls.find((c) => c[0] === "issue" && c[1] === "create");
+    const createCall = calls.find(isIssueCreate);
     expect(createCall).toBeUndefined();
   });
 
@@ -178,11 +185,10 @@ describe("publishAndReconcileManagerMap — existing map path (idempotence)", ()
     };
     const ctx = { ...CTX_BASE, exec };
     await publishAndReconcileManagerMap(ctx, EFFORT);
-    const editCall = calls.find((c) => c[0] === "issue" && c[1] === "edit");
+    const editCall = calls.find(isIssueEdit);
     expect(editCall).toBeDefined();
-    expect(editCall).toContain("--add-label");
-    expect(editCall).toContain(LABEL_MANAGER_MAP);
-    const createCall = calls.find((c) => c[0] === "issue" && c[1] === "create");
+    expect(editCall).toContain(`labels[]=${LABEL_MANAGER_MAP}`);
+    const createCall = calls.find(isIssueCreate);
     expect(createCall).toBeUndefined();
   });
 
@@ -195,7 +201,7 @@ describe("publishAndReconcileManagerMap — existing map path (idempotence)", ()
     };
     const ctx = { ...CTX_BASE, exec };
     await publishAndReconcileManagerMap(ctx, EFFORT);
-    const editCall = calls.find((c) => c[0] === "issue" && c[1] === "edit");
+    const editCall = calls.find(isIssueEdit);
     expect(editCall).toBeUndefined();
   });
 
@@ -225,7 +231,7 @@ describe("publishAndReconcileManagerMap — partial-failure convergence", () => 
     // The map is still found and returned; the next run re-applies the label.
     const execWithFailingEdit: ExecFn = (_tool, args) => {
       const isList = args[0] === "issue" && args[1] === "list";
-      const isEdit = args[0] === "issue" && args[1] === "edit";
+      const isEdit = isIssueEdit(args);
       const isSubIssues = String(args[2] ?? "").includes("sub_issues");
       if (isEdit) return Promise.resolve({ code: 1, stdout: "", stderr: "transient" });
       return Promise.resolve({
@@ -284,7 +290,7 @@ describe("dispatchExecutionIssue (slice #2295)", () => {
     const calls: string[][] = [];
     const exec: ExecFn = (_tool, args) => {
       calls.push([...args]);
-      const isCreate = args[0] === "issue" && args[1] === "create";
+      const isCreate = isIssueCreate(args);
       return Promise.resolve({
         code: 0,
         stdout: isCreate ? "https://github.com/acme/widgets/issues/200" : "",
@@ -294,17 +300,16 @@ describe("dispatchExecutionIssue (slice #2295)", () => {
     const ctx = { ...CTX_BASE, exec };
     const num = await dispatchExecutionIssue(ctx, EFFORT, null);
     expect(num).toBe(200);
-    const createCall = calls.find((c) => c[0] === "issue" && c[1] === "create");
+    const createCall = calls.find(isIssueCreate);
     expect(createCall).toBeDefined();
-    expect(createCall).toContain("--label");
-    expect(createCall).toContain("ready-for-agent");
+    expect(createCall).toContain("labels[]=ready-for-agent");
   });
 
   it("links the execution issue as a sub-issue when a map number is given", async () => {
     const calls: string[][] = [];
     const exec: ExecFn = (_tool, args) => {
       calls.push([...args]);
-      const isCreate = args[0] === "issue" && args[1] === "create";
+      const isCreate = isIssueCreate(args);
       return Promise.resolve({
         code: 0,
         stdout: isCreate ? "https://github.com/acme/widgets/issues/201" : "",
@@ -323,7 +328,7 @@ describe("dispatchExecutionIssue (slice #2295)", () => {
     const calls: string[][] = [];
     const exec: ExecFn = (_tool, args) => {
       calls.push([...args]);
-      const isCreate = args[0] === "issue" && args[1] === "create";
+      const isCreate = isIssueCreate(args);
       return Promise.resolve({
         code: 0,
         stdout: isCreate ? "https://github.com/acme/widgets/issues/202" : "",
@@ -346,7 +351,7 @@ describe("dispatchExecutionIssue (slice #2295)", () => {
     const calls: string[][] = [];
     const exec: ExecFn = (_tool, args) => {
       calls.push([...args]);
-      const isCreate = args[0] === "issue" && args[1] === "create";
+      const isCreate = isIssueCreate(args);
       return Promise.resolve({
         code: 0,
         stdout: isCreate ? "https://github.com/acme/widgets/issues/203" : "",
@@ -355,10 +360,10 @@ describe("dispatchExecutionIssue (slice #2295)", () => {
     };
     const ctx = { ...CTX_BASE, exec };
     await dispatchExecutionIssue(ctx, EFFORT, null);
-    const createCall = calls.find((c) => c[0] === "issue" && c[1] === "create") ?? [];
-    const bodyIdx = createCall.indexOf("--body");
+    const createCall = calls.find(isIssueCreate) ?? [];
+    const bodyIdx = createCall.findIndex((arg) => arg.startsWith("body="));
     expect(bodyIdx).toBeGreaterThan(-1);
-    expect(createCall[bodyIdx + 1]).toContain(EFFORT.effort_id);
+    expect(createCall[bodyIdx]).toContain(EFFORT.effort_id);
   });
 });
 

--- a/packages/github/surface.test.ts
+++ b/packages/github/surface.test.ts
@@ -49,7 +49,7 @@ const PINNED: ReadonlyArray<
   ["search repos", "read", "multi-repository", "one-shot", "rest", "search", null],
   ["api graphql", "read", "multi-node", "one-shot", "graphql", "graphql", null],
   ["api rest", "read", "single-object", "one-shot", "rest", "rest", null],
-  ["issue create", "write", "single-object", undefined, "graphql", "graphql", null],
+  ["issue create", "write", "single-object", undefined, "rest", "rest", null],
   ["issue edit", "write", "single-object", undefined, "rest", "rest", null],
   ["issue close", "write", "single-object", undefined, "rest", "rest", null],
   ["issue reopen", "write", "single-object", undefined, "graphql", "graphql", null],
@@ -261,7 +261,7 @@ describe("the router", () => {
 
   it("stops mislabelling the writes", () => {
     expect(routeGithubArgs(["issue", "comment", "42", "--body", "x"]).surface).toBe("rest");
-    expect(routeGithubArgs(["issue", "create", "--title", "x"]).surface).toBe("graphql");
+    expect(routeGithubArgs(["issue", "create", "--title", "x"]).surface).toBe("rest");
     expect(routeGithubArgs(["pr", "create", "--title", "x"]).surface).toBe("rest");
     expect(routeGithubArgs(["pr", "merge", "42", "--merge"]).surface).toBe("rest");
     expect(routeGithubArgs(["issue", "edit", "42", "--add-label", "x"]).surface).toBe("rest");

--- a/packages/github/surface.ts
+++ b/packages/github/surface.ts
@@ -192,7 +192,7 @@ export const GITHUB_OPERATIONS: readonly GithubOperation[] = [
   read("api rest", "single-object", "one-shot", "rest", noFallback("the caller explicitly chose REST"), "the caller supplies one explicit REST path rather than a routed poll"),
 
   // ── writes: the surface realized by the shared write plan
-  write("issue create", "graphql", "graphql", "gh files an issue with the createIssue mutation — an exhausted GraphQL pool blocks filing"),
+  write("issue create", "rest", "rest", "the write plan POSTs to `repos/{o}/{r}/issues` so filing shares the REST mutation rail"),
   write("issue edit", "rest", "rest", "the write plan PATCHes labels and body at `repos/{o}/{r}/issues/{n}`"),
   write("issue close", "rest", "rest", "the write plan PATCHes issue state and state reason at `repos/{o}/{r}/issues/{n}`"),
   write("issue reopen", "graphql", "graphql", "gh reopens with the reopenIssue mutation"),

--- a/packages/github/write-plan.test.ts
+++ b/packages/github/write-plan.test.ts
@@ -84,6 +84,35 @@ describe("planGithubWrite — the client owns the write rail", () => {
     });
   });
 
+  it.each([
+    {
+      name: "issue creation",
+      argv: ["gh", "-R", "o/r", "issue", "create", "--title", "t", "--body", "b", "--label", "ready-for-agent"],
+      context: {},
+      expected: ["gh", "api", "-X", "POST", "repos/o/r/issues", "-f", "title=t", "-f", "body=b", "-F", "labels[]=ready-for-agent"],
+    },
+    {
+      name: "PR comment",
+      argv: ["gh", "pr", "comment", "42", "--repo", "o/r", "--body", "reviewed"],
+      context: {},
+      expected: ["gh", "api", "-X", "POST", "repos/o/r/issues/42/comments", "-f", "body=reviewed"],
+    },
+    {
+      name: "label creation",
+      argv: ["gh", "label", "create", "reviewed", "--repo", "o/r", "--color", "5319E7", "--description", "Review state"],
+      context: {},
+      expected: ["gh", "api", "-X", "POST", "repos/o/r/labels", "-f", "name=reviewed", "-f", "color=5319E7", "-f", "description=Review state"],
+    },
+    {
+      name: "PR label edit",
+      argv: ["gh", "pr", "edit", "42", "--repo", "o/r", "--remove-label", "old", "--add-label", "reviewed"],
+      context: { currentIssueLabels: ["old", "type:feature"] },
+      expected: ["gh", "api", "-X", "PATCH", "repos/o/r/issues/42", "-F", "labels[]=type:feature", "-F", "labels[]=reviewed"],
+    },
+  ])("realizes $name on REST", ({ argv, context, expected }) => {
+    expect(planGithubWrite(argv, context)).toEqual({ surface: "rest", args: expected });
+  });
+
   it("preserves an explicit REST API mutation on the REST rail", () => {
     const argv = [
       "gh", "api", "repos/o/r/issues/comments/99", "--method", "PATCH", "--field", "body=updated",

--- a/packages/github/write-plan.ts
+++ b/packages/github/write-plan.ts
@@ -72,6 +72,8 @@ function commandPath(args: readonly string[]): string[] {
  * - `gh -R o/r issue edit <n> --body b [--add-label/--remove-label ...]`
  *   → REST `PATCH issues/{n}` (label edits require the current complete set)
  * - `gh -R o/r issue close <n> --reason completed` → REST `PATCH issues/{n}`
+ * - `gh -R o/r issue create --title t [--body b] [--label l ...]`
+ *   → REST `POST issues`
  * - `gh -R o/r pr merge <n> --merge [--subject t]` → REST `PUT pulls/{n}/merge`
  * - `gh -R o/r pr merge <n> --merge --auto [...]`  → unchanged (GraphQL enqueue)
  * - `gh -R o/r pr create --base b --head h --title t --body y [--draft]`
@@ -82,6 +84,9 @@ function commandPath(args: readonly string[]): string[] {
  * - `gh -R o/r pr update-branch <n>` → REST `PUT pulls/{n}/update-branch`
  * - `gh issue|pr comment <n> -R o/r --body y`
  *   → REST `POST issues/{n}/comments`
+ * - PR label edits → REST `PATCH issues/{n}` with the complete label set
+ * - `gh label create <name> -R o/r [--color c] [--description d]`
+ *   → REST `POST labels`
  * - `gh api <rest-path> --method <verb> ...`
  *   → unchanged on the explicitly selected REST rail
  *
@@ -95,7 +100,7 @@ export function planGithubWrite(
 ): GithubWritePlan {
   const repo = repoOf(args);
   const [group, verb] = commandPath(args);
-  if (repo && group === "issue" && verb === "edit") {
+  if (repo && (group === "issue" || group === "pr") && verb === "edit") {
     const editAt = args.indexOf("edit");
     const issueNumber = args[editAt + 1];
     const body = flagValue(args, "--body");
@@ -113,6 +118,7 @@ export function planGithubWrite(
       && issueNumber
       && /^\d+$/.test(issueNumber)
       && (!editsLabels || context.currentIssueLabels)
+      && (group === "issue" || editsLabels)
     ) {
       const labels = editsLabels
         ? [...new Set([
@@ -128,6 +134,26 @@ export function planGithubWrite(
           ...(labels ? labels.length > 0
             ? labels.flatMap((label) => ["-F", `labels[]=${label}`])
             : ["-F", "labels[]"] : []),
+        ],
+      };
+    }
+  }
+  if (repo && group === "issue" && verb === "create") {
+    const createAt = args.indexOf("create");
+    const title = flagValue(args, "--title");
+    const body = flagValue(args, "--body");
+    const labels = flagValues(args, "--label");
+    if (
+      title !== undefined
+      && usesOnlyValueFlags(args, createAt + 1, new Set(["-R", "--repo", "--title", "--body", "--label"]))
+    ) {
+      return {
+        surface: "rest",
+        args: [
+          "gh", "api", "-X", "POST", `repos/${repo}/issues`,
+          "-f", `title=${title}`,
+          ...(body !== undefined ? ["-f", `body=${body}`] : []),
+          ...labels.flatMap((label) => ["-F", `labels[]=${label}`]),
         ],
       };
     }
@@ -221,6 +247,22 @@ export function planGithubWrite(
         args: [
           "gh", "api", "-X", "POST", `repos/${repo}/issues/${issueNumber}/comments`,
           "-f", `body=${body}`,
+        ],
+      };
+    }
+  }
+  if (repo && group === "label" && verb === "create") {
+    const labelName = args[args.indexOf("create") + 1];
+    const color = flagValue(args, "--color");
+    const description = flagValue(args, "--description");
+    if (labelName) {
+      return {
+        surface: "rest",
+        args: [
+          "gh", "api", "-X", "POST", `repos/${repo}/labels`,
+          "-f", `name=${labelName}`,
+          ...(color !== undefined ? ["-f", `color=${color}`] : []),
+          ...(description !== undefined ? ["-f", `description=${description}`] : []),
         ],
       };
     }


### PR DESCRIPTION
Automated AFK landing for #3732. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3732

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789126557&installation_model_id=20659&pr_number=3740&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3740&signature=1844f879632b6ab339718758cc1d061be812677f52fb080ea4aa4688872263c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->