### PR TITLE
chore: #3633 red-castle: expand ownership of command waits and webhook wake behavior

### DIFF
--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -24,6 +24,8 @@ export * from "./lifecycle-hooks.js";
 export * from "./terminal-events.js";
 export * from "./validation-cone.js";
 export * from "./worker-drain.js";
+export * from "./workflow-wait.js";
+export * from "./workflow-webhook.js";
 export * from "./config.js";
 export * from "./drain.js";
 export * from "./work-selector.js";

--- a/packages/red-castle/src/engine/workflow-wait.test.ts
+++ b/packages/red-castle/src/engine/workflow-wait.test.ts
@@ -1,0 +1,327 @@
+import { createGithubClient, type GithubBalance } from "@reddb-io/github";
+import { mkdtemp, rm } from "node:fs/promises";
+import { EventEmitter } from "node:events";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createEnginePaths,
+  createSingletonEventLane,
+  createSingletonLeaseStore,
+  createWebhookWakeSource,
+  waitForCommand,
+  waitForGithubWorkflow,
+  type WebhookForwarderPort,
+} from "./index.js";
+
+function githubBalance(remaining: number): GithubBalance {
+  return {
+    version: 1,
+    origin: "asked",
+    outcome: "asked",
+    source: "GET /rate_limit",
+    asked_at: "1970-01-01T00:00:00.000Z",
+    request_count: 1,
+    pools: {
+      rest: {
+        pool: "rest",
+        resource: "core",
+        limit: 5_000,
+        remaining,
+        used: 5_000 - remaining,
+        reset_at: "1970-01-01T00:00:01.000Z",
+        fraction: remaining / 5_000,
+      },
+      graphql: null,
+      search: null,
+    },
+    unreported_pools: ["graphql", "search"],
+    detail: "fixture",
+  };
+}
+
+describe("castle workflow wait", () => {
+  it("keeps a successful command result when notification fails", async () => {
+    const notify = vi.fn(async () => {
+      throw new Error("notification transport unavailable");
+    });
+
+    const result = await waitForCommand({
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('ready')"],
+      timeoutMs: 5_000,
+      notify,
+    });
+
+    expect(result).toMatchObject({
+      status: "success",
+      exitCode: 0,
+      summary: "command exited successfully",
+      stdout: "ready",
+      stderr: "",
+      notification: {
+        status: "failure",
+        error: "notification transport unavailable",
+      },
+    });
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "success", exitCode: 0 }),
+    );
+  });
+
+  it("terminates a command when its wait times out", async () => {
+    const result = await waitForCommand({
+      command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1_000)"],
+      timeoutMs: 25,
+      terminateGraceMs: 25,
+    });
+
+    expect(result).toMatchObject({
+      status: "timeout",
+      exitCode: 2,
+      summary: "command timed out after 25ms",
+    });
+  });
+
+  it("cancels a command and reports an indeterminate workflow result", async () => {
+    const abort = new AbortController();
+    setTimeout(() => abort.abort(), 25);
+
+    const result = await waitForCommand({
+      command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1_000)"],
+      timeoutMs: 5_000,
+      terminateGraceMs: 25,
+      signal: abort.signal,
+    });
+
+    expect(result).toMatchObject({
+      status: "indeterminate",
+      exitCode: 2,
+      summary: "command wait cancelled",
+    });
+  });
+
+  it("honors the repository GitHub budget before polling again", async () => {
+    let remaining = 0;
+    let nowMs = 0;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ status: "completed" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const client = createGithubClient({
+      token: "fixture-token",
+      balance: () => githubBalance(remaining),
+      fetchImpl,
+      retryCount: 0,
+      throttle: false,
+    });
+    const sleep = vi.fn(async (ms: number) => {
+      nowMs += ms;
+      remaining = 4_999;
+    });
+
+    const result = await waitForGithubWorkflow({
+      client,
+      timeoutMs: 5_000,
+      pollIntervalMs: 50,
+      now: () => nowMs,
+      sleep,
+      probe: async (github) => {
+        await github.conditionalRest({
+          cacheKey: "workflow:42",
+          route: "GET /repos/{owner}/{repo}/actions/runs/{run_id}",
+          parameters: { owner: "acme", repo: "widgets", run_id: 42 },
+          operation: { key: "run view", budget: "rest" },
+        });
+        return {
+          status: "success",
+          exitCode: 0,
+          summary: "run 42 succeeded",
+        };
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "success",
+      exitCode: 0,
+      summary: "run 42 succeeded",
+    });
+    expect(sleep).toHaveBeenCalledWith(1_000, expect.any(AbortSignal));
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("wakes GitHub polling from the resident webhook lane", async () => {
+    const root = await mkdtemp(join(tmpdir(), "castle-workflow-webhook-"));
+    const paths = createEnginePaths(join(root, ".red"));
+    const leases = createSingletonLeaseStore(paths, { isPidAlive: () => true });
+    await leases.acquire("github-webhook", {
+      pid: 4_100,
+      startTime: "resident-start",
+    });
+    const lane = createSingletonEventLane(paths);
+    const source = createWebhookWakeSource({
+      cwd: root,
+      cancelSignal: new AbortController().signal,
+      leases,
+      lane,
+      isLeaseHolderLive: async () => true,
+      pollIntervalMs: 5,
+    });
+    const client = createGithubClient({
+      token: "fixture-token",
+      fetchImpl: async () => {
+        throw new Error("probe fixture does not use transport");
+      },
+      retryCount: 0,
+      throttle: false,
+    });
+    let probes = 0;
+    const started = Date.now();
+
+    const result = await waitForGithubWorkflow({
+      client,
+      timeoutMs: 5_000,
+      pollIntervalMs: 10_000,
+      webhook: { source, kind: "run", target: "42" },
+      probe: async () => {
+        probes += 1;
+        if (probes === 1) {
+          setTimeout(
+            () =>
+              void lane.append({
+                singleton: "github-webhook",
+                kind: "github.webhook.delivery",
+                payload: { workflow_run: { id: 42 } },
+              }),
+            20,
+          );
+          return { status: "running", exitCode: 2, summary: "run pending" };
+        }
+        return { status: "success", exitCode: 0, summary: "run 42 succeeded" };
+      },
+    });
+
+    expect(result.status).toBe("success");
+    expect(probes).toBe(2);
+    expect(Date.now() - started).toBeLessThan(1_000);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("falls back to polling when webhook ownership is unavailable", async () => {
+    const root = await mkdtemp(join(tmpdir(), "castle-workflow-polling-"));
+    const source = createWebhookWakeSource({
+      cwd: root,
+      cancelSignal: new AbortController().signal,
+    });
+    const client = createGithubClient({
+      token: "fixture-token",
+      fetchImpl: async () => {
+        throw new Error("probe fixture does not use transport");
+      },
+      retryCount: 0,
+      throttle: false,
+    });
+    const notify = vi.fn(async () => {
+      throw new Error("notification failed");
+    });
+    let nowMs = 0;
+    let probes = 0;
+
+    const result = await waitForGithubWorkflow({
+      client,
+      timeoutMs: 1_000,
+      pollIntervalMs: 50,
+      now: () => nowMs,
+      sleep: async (ms) => {
+        nowMs += ms;
+      },
+      webhook: { source, kind: "pr", target: "7" },
+      notify,
+      probe: async () => {
+        probes += 1;
+        return probes === 1
+          ? { status: "running", exitCode: 2, summary: "checks pending" }
+          : { status: "failure", exitCode: 1, summary: "checks failed" };
+      },
+    });
+
+    expect(source.mode).toBe("polling");
+    expect(probes).toBe(2);
+    expect(result).toMatchObject({
+      status: "failure",
+      exitCode: 1,
+      summary: "checks failed",
+      notification: { status: "failure", error: "notification failed" },
+    });
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("delegates webhook wake to a per-wait forwarder without a resident", async () => {
+    const root = await mkdtemp(join(tmpdir(), "castle-workflow-forwarder-"));
+    const expectedWake = new AbortController().signal;
+    const forwarder = new EventEmitter() as WebhookForwarderPort;
+    forwarder.mode = "polling";
+    forwarder.start = vi.fn();
+    forwarder.stop = vi.fn(async () => undefined);
+    forwarder.makeWakeSignalFor = vi.fn(() => () => expectedWake);
+    const makeForwarder = vi.fn(() => forwarder);
+    const source = createWebhookWakeSource({
+      cwd: root,
+      cancelSignal: new AbortController().signal,
+      makeForwarder,
+    });
+
+    await source.start();
+
+    expect(makeForwarder).toHaveBeenCalledTimes(1);
+    expect(forwarder.start).toHaveBeenCalledTimes(1);
+    expect(source.makeWakeSignalFor("run", "42")()).toBe(expectedWake);
+
+    await source.stop();
+    expect(forwarder.stop).toHaveBeenCalledTimes(1);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("reports only GitHub workflow state transitions and the final outcome", async () => {
+    const client = createGithubClient({
+      token: "fixture-token",
+      fetchImpl: async () => {
+        throw new Error("probe fixture does not use transport");
+      },
+      retryCount: 0,
+      throttle: false,
+    });
+    const transitions: string[] = [];
+    let nowMs = 0;
+    let probes = 0;
+
+    await waitForGithubWorkflow({
+      client,
+      timeoutMs: 1_000,
+      pollIntervalMs: 10,
+      now: () => nowMs,
+      sleep: async (ms) => {
+        nowMs += ms;
+      },
+      onTransition: async (observation) => {
+        transitions.push(`${observation.status}:${observation.summary}`);
+      },
+      probe: async () => {
+        probes += 1;
+        return probes < 3
+          ? { status: "running", exitCode: 2, summary: "checks pending" }
+          : { status: "success", exitCode: 0, summary: "checks passed" };
+      },
+    });
+
+    expect(transitions).toEqual([
+      "running:checks pending",
+      "success:checks passed",
+    ]);
+  });
+});

--- a/packages/red-castle/src/engine/workflow-wait.ts
+++ b/packages/red-castle/src/engine/workflow-wait.ts
@@ -1,0 +1,322 @@
+import { spawn } from "node:child_process";
+import {
+  GithubPoolUnavailableError,
+  githubRateLimitResetAt,
+  type GithubClient,
+} from "@reddb-io/github";
+import { killTreeAndWait } from "@reddb-io/shared/kill-tree.js";
+import type { WebhookWakeSource } from "./workflow-webhook.js";
+
+export type WorkflowWaitStatus =
+  "success" | "failure" | "timeout" | "indeterminate";
+
+export type WorkflowWaitExitCode = 0 | 1 | 2;
+
+export interface WorkflowWaitResult {
+  readonly status: WorkflowWaitStatus;
+  readonly exitCode: WorkflowWaitExitCode;
+  readonly summary: string;
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly notification: WorkflowWaitNotification;
+}
+
+export type WorkflowWaitNotification =
+  | { readonly status: "success" }
+  | { readonly status: "failure"; readonly error: string };
+
+export interface CommandWaitOptions {
+  readonly command: string;
+  readonly args?: readonly string[];
+  readonly cwd?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly timeoutMs: number;
+  readonly terminateGraceMs?: number;
+  readonly signal?: AbortSignal;
+  readonly notify?: (result: WorkflowWaitResult) => void | Promise<void>;
+}
+
+export interface WorkflowWaitObservation {
+  readonly status: WorkflowWaitStatus | "running";
+  readonly exitCode: WorkflowWaitExitCode;
+  readonly summary: string;
+}
+
+export interface GithubWorkflowWaitOptions {
+  readonly client: GithubClient;
+  readonly probe: (
+    client: GithubClient,
+  ) => WorkflowWaitObservation | Promise<WorkflowWaitObservation>;
+  readonly timeoutMs: number;
+  readonly pollIntervalMs: number;
+  readonly signal?: AbortSignal;
+  readonly onTransition?: (
+    observation: WorkflowWaitObservation,
+  ) => void | Promise<void>;
+  readonly webhook?: {
+    readonly source: WebhookWakeSource;
+    readonly kind: "pr" | "run";
+    readonly target: string;
+  };
+  readonly notify?: (result: WorkflowWaitResult) => void | Promise<void>;
+  /** Injectable monotonic clock used by deterministic wait fixtures. */
+  readonly now?: () => number;
+  /** Injectable cancellable sleep used by deterministic wait fixtures. */
+  readonly sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+}
+
+export async function waitForCommand(
+  options: CommandWaitOptions,
+): Promise<WorkflowWaitResult> {
+  const child = spawn(options.command, [...(options.args ?? [])], {
+    cwd: options.cwd,
+    env: options.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32",
+  });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
+  child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+
+  const result = await new Promise<WorkflowWaitResult>((resolve) => {
+    let settled = false;
+    let terminating = false;
+    let timer: NodeJS.Timeout;
+    const finish = (result: WorkflowWaitResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", onAbort);
+      resolve(result);
+    };
+    const terminate = (
+      status: "timeout" | "indeterminate",
+      summary: string,
+    ) => {
+      if (settled || terminating) return;
+      terminating = true;
+      const graceMs = options.terminateGraceMs ?? 2_000;
+      const pollMs = Math.max(1, Math.min(100, graceMs));
+      const graceTries = Math.max(1, Math.ceil(graceMs / pollMs));
+      const pid = child.pid;
+      void (
+        pid
+          ? killTreeAndWait(pid, { graceTries, pollMs })
+          : Promise.resolve(true)
+      ).then((cleaned) => {
+        finish({
+          status: cleaned ? status : "indeterminate",
+          exitCode: 2,
+          summary: cleaned
+            ? summary
+            : `${summary}; could not verify process cleanup`,
+          stdout: Buffer.concat(stdout).toString("utf8"),
+          stderr: Buffer.concat(stderr).toString("utf8"),
+          notification: { status: "success" },
+        });
+      });
+    };
+    const onAbort = () => terminate("indeterminate", "command wait cancelled");
+    child.once("error", (error) => {
+      finish({
+        status: "failure",
+        exitCode: 1,
+        summary: error.message,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        notification: { status: "success" },
+      });
+    });
+    child.once("close", (code, signal) => {
+      if (terminating) return;
+      const success = code === 0;
+      finish({
+        status: success ? "success" : "failure",
+        exitCode: success ? 0 : 1,
+        summary: success
+          ? "command exited successfully"
+          : `command exited with ${signal ?? code ?? "unknown"}`,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        notification: { status: "success" },
+      });
+    });
+    timer = setTimeout(
+      () =>
+        terminate("timeout", `command timed out after ${options.timeoutMs}ms`),
+      options.timeoutMs,
+    );
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+    if (options.signal?.aborted) onAbort();
+  });
+
+  return await withNotification(result, options.notify);
+}
+
+/**
+ * Wait for a GitHub-backed workflow through the repository's budget-aware
+ * client. Reads are serial: a new probe never starts before the previous one
+ * and its budget-directed delay have settled.
+ */
+export async function waitForGithubWorkflow(
+  options: GithubWorkflowWaitOptions,
+): Promise<WorkflowWaitResult> {
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? sleepUntil;
+  const signal = options.signal ?? new AbortController().signal;
+  const deadline = now() + options.timeoutMs;
+  const webhook = options.webhook;
+  let lastTransition = "";
+  const reportTransition = async (observation: WorkflowWaitObservation) => {
+    const transition = `${observation.status}\0${observation.summary}`;
+    if (transition === lastTransition) return;
+    lastTransition = transition;
+    await options.onTransition?.(observation);
+  };
+  await webhook?.source.start().catch(() => undefined);
+
+  try {
+    while (now() < deadline) {
+      if (signal.aborted) {
+        return await withNotification(
+          workflowResult("indeterminate", 2, "workflow wait cancelled"),
+          options.notify,
+        );
+      }
+
+      let observation: WorkflowWaitObservation;
+      try {
+        observation = await options.probe(options.client);
+      } catch (error) {
+        const delayMs = Math.min(
+          githubRetryDelay(error, now(), options.pollIntervalMs),
+          Math.max(0, deadline - now()),
+        );
+        await pause(
+          delayMs,
+          signal,
+          sleep,
+          webhook?.source.makeWakeSignalFor(webhook.kind, webhook.target)(),
+        );
+        continue;
+      }
+      await reportTransition(observation).catch(() => undefined);
+
+      if (
+        observation.status !== "running" &&
+        observation.status !== "indeterminate"
+      ) {
+        return await withNotification(
+          workflowResult(
+            observation.status,
+            observation.exitCode,
+            observation.summary,
+          ),
+          options.notify,
+        );
+      }
+
+      await pause(
+        Math.min(options.pollIntervalMs, Math.max(0, deadline - now())),
+        signal,
+        sleep,
+        webhook?.source.makeWakeSignalFor(webhook.kind, webhook.target)(),
+      );
+    }
+
+    return await withNotification(
+      workflowResult(
+        "timeout",
+        2,
+        `workflow timed out after ${options.timeoutMs}ms`,
+      ),
+      options.notify,
+    );
+  } finally {
+    await webhook?.source.stop().catch(() => undefined);
+  }
+}
+
+function workflowResult(
+  status: WorkflowWaitStatus,
+  exitCode: WorkflowWaitExitCode,
+  summary: string,
+): WorkflowWaitResult {
+  return {
+    status,
+    exitCode,
+    summary,
+    notification: { status: "success" },
+  };
+}
+
+async function withNotification(
+  result: WorkflowWaitResult,
+  notify: CommandWaitOptions["notify"],
+): Promise<WorkflowWaitResult> {
+  if (!notify) return result;
+  try {
+    await notify(result);
+    return result;
+  } catch (error) {
+    return {
+      ...result,
+      notification: {
+        status: "failure",
+        error: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+function githubRetryDelay(
+  error: unknown,
+  nowMs: number,
+  fallbackMs: number,
+): number {
+  const resetAt =
+    error instanceof GithubPoolUnavailableError
+      ? error.resetAt
+      : githubRateLimitResetAt(error, nowMs);
+  if (!resetAt) return fallbackMs;
+  const resetMs = Date.parse(resetAt);
+  if (!Number.isFinite(resetMs)) return fallbackMs;
+  return Math.max(fallbackMs, resetMs - nowMs);
+}
+
+async function sleepUntil(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal.aborted) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(done, ms);
+    const onAbort = () => done();
+    function done() {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function pause(
+  ms: number,
+  cancelSignal: AbortSignal,
+  sleep: (ms: number, signal: AbortSignal) => Promise<void>,
+  wakeSignal: AbortSignal | undefined,
+): Promise<void> {
+  if (!wakeSignal) return await sleep(ms, cancelSignal);
+  if (wakeSignal.aborted || cancelSignal.aborted || ms <= 0) return;
+  await new Promise<void>((resolve) => {
+    const controller = new AbortController();
+    const done = () => {
+      wakeSignal.removeEventListener("abort", done);
+      cancelSignal.removeEventListener("abort", done);
+      controller.abort();
+      resolve();
+    };
+    wakeSignal.addEventListener("abort", done, { once: true });
+    cancelSignal.addEventListener("abort", done, { once: true });
+    void sleep(ms, controller.signal).then(done, done);
+  });
+}

--- a/packages/red-castle/src/engine/workflow-webhook.ts
+++ b/packages/red-castle/src/engine/workflow-webhook.ts
@@ -1,0 +1,244 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { join } from "node:path";
+import {
+  deliveryMatchesPr,
+  deliveryMatchesRun,
+  GITHUB_WEBHOOK_DELIVERY_KIND,
+  GITHUB_WEBHOOK_SINGLETON,
+  type WebhookDelivery,
+  WebhookForwarder as SharedWebhookForwarder,
+  type WebhookMode,
+} from "@reddb-io/shared/github-webhook.js";
+import { killTreeAndWait } from "@reddb-io/shared/kill-tree.js";
+import { resolveRepoRoot } from "@reddb-io/shared/repo-root.js";
+import { createEnginePaths } from "./paths.js";
+import {
+  createSingletonEventLane,
+  type SingletonEventLane,
+} from "./singleton-event-lane.js";
+import {
+  createSingletonLeaseStore,
+  type SingletonLease,
+  type SingletonLeaseStore,
+} from "./singleton-lease.js";
+
+export interface WebhookWakeSourceOptions {
+  readonly cwd: string;
+  readonly cancelSignal: AbortSignal;
+  readonly leases?: SingletonLeaseStore;
+  readonly lane?: SingletonEventLane;
+  readonly isLeaseHolderLive?: (lease: SingletonLease) => Promise<boolean>;
+  readonly pollIntervalMs?: number;
+  readonly makeForwarder?: (
+    cwd: string,
+    cancelSignal: AbortSignal,
+  ) => WebhookForwarderPort;
+}
+
+export interface WebhookForwarderPort extends EventEmitter {
+  mode: WebhookMode;
+  start(): void;
+  stop(): Promise<void>;
+  makeWakeSignalFor(
+    kind: "pr" | "run",
+    target: string,
+  ): () => AbortSignal | undefined;
+}
+
+interface ResolvedWebhookWakeSourceOptions extends WebhookWakeSourceOptions {
+  readonly leases: SingletonLeaseStore;
+  readonly lane: SingletonEventLane;
+  readonly isLeaseHolderLive: (lease: SingletonLease) => Promise<boolean>;
+  readonly makeForwarder: (
+    cwd: string,
+    cancelSignal: AbortSignal,
+  ) => WebhookForwarderPort;
+}
+
+export interface WebhookWakeSource extends EventEmitter {
+  readonly mode: WebhookMode;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  makeWakeSignalFor(
+    kind: "pr" | "run",
+    target: string,
+  ): () => AbortSignal | undefined;
+}
+
+class CastleWebhookWakeSource
+  extends EventEmitter
+  implements WebhookWakeSource
+{
+  private _mode: WebhookMode = "polling";
+  private cursor = 0;
+  private timer: NodeJS.Timeout | undefined;
+  private fallback: WebhookForwarderPort | undefined;
+  private stopped = false;
+  private syncing = false;
+
+  constructor(private readonly options: ResolvedWebhookWakeSourceOptions) {
+    super();
+  }
+
+  get mode(): WebhookMode {
+    return this.fallback?.mode ?? this._mode;
+  }
+
+  async start(): Promise<void> {
+    const lease = await this.options.leases
+      .read(GITHUB_WEBHOOK_SINGLETON)
+      .catch(() => undefined);
+    if (!lease || !(await this.options.isLeaseHolderLive(lease))) {
+      this.startFallback();
+      return;
+    }
+    const events = await this.options.lane.read().catch(() => undefined);
+    if (!events) {
+      this.degradeToFallback();
+      return;
+    }
+    this.cursor = events.length;
+    this._mode = "webhook";
+    this.emit("mode-changed", this._mode);
+    this.timer = setInterval(
+      () => void this.sync().catch(() => this.degradeToFallback()),
+      this.options.pollIntervalMs ?? 100,
+    );
+    this.timer.unref();
+    this.options.cancelSignal.addEventListener(
+      "abort",
+      () => void this.stop(),
+      { once: true },
+    );
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    if (this.timer) clearInterval(this.timer);
+    await this.fallback?.stop();
+    this.emit("stopped");
+  }
+
+  makeWakeSignalFor(
+    kind: "pr" | "run",
+    target: string,
+  ): () => AbortSignal | undefined {
+    return () => {
+      if (this.fallback) {
+        return this.fallback.makeWakeSignalFor(kind, target)();
+      }
+      if (this._mode !== "webhook" || this.stopped) return undefined;
+      const controller = new AbortController();
+      const onDelivery = (delivery: WebhookDelivery) => {
+        const matches =
+          kind === "pr"
+            ? deliveryMatchesPr(delivery, target)
+            : deliveryMatchesRun(delivery, target);
+        if (!matches) return;
+        cleanup();
+        controller.abort();
+      };
+      const cleanup = () => {
+        this.off("delivery", onDelivery);
+        this.off("stopped", cleanup);
+      };
+      this.on("delivery", onDelivery);
+      this.once("stopped", cleanup);
+      return controller.signal;
+    };
+  }
+
+  private startFallback(): void {
+    if (this.fallback || this.stopped) return;
+    this.fallback = this.options.makeForwarder(
+      this.options.cwd,
+      this.options.cancelSignal,
+    );
+    this.fallback.on("mode-changed", (mode: WebhookMode) => {
+      this.emit("mode-changed", mode);
+    });
+    this.fallback.on("delivery", (delivery: WebhookDelivery) => {
+      this.emit("delivery", delivery);
+    });
+    this.fallback.start();
+  }
+
+  private degradeToFallback(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+    this._mode = "polling";
+    this.startFallback();
+  }
+
+  private async sync(): Promise<void> {
+    if (this.syncing || this.stopped) return;
+    this.syncing = true;
+    try {
+      const events = await this.options.lane.read();
+      if (events.length < this.cursor) this.cursor = 0;
+      const unseen = events.slice(this.cursor);
+      this.cursor = events.length;
+      for (const event of unseen) {
+        if (
+          event.singleton === GITHUB_WEBHOOK_SINGLETON &&
+          event.kind === GITHUB_WEBHOOK_DELIVERY_KIND &&
+          event.payload
+        ) {
+          this.emit("delivery", event.payload as WebhookDelivery);
+        }
+      }
+      const lease = await this.options.leases.read(GITHUB_WEBHOOK_SINGLETON);
+      if (!lease || !(await this.options.isLeaseHolderLive(lease))) {
+        this.degradeToFallback();
+      }
+    } finally {
+      this.syncing = false;
+    }
+  }
+}
+
+export function createWebhookWakeSource(
+  options: WebhookWakeSourceOptions,
+): WebhookWakeSource {
+  const root = resolveRepoRoot(options.cwd);
+  const paths = createEnginePaths(join(root, ".red"));
+  return new CastleWebhookWakeSource({
+    ...options,
+    leases: options.leases ?? createSingletonLeaseStore(paths),
+    lane: options.lane ?? createSingletonEventLane(paths),
+    isLeaseHolderLive:
+      options.isLeaseHolderLive ??
+      (async (lease) => {
+        try {
+          process.kill(lease.pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      }),
+    makeForwarder:
+      options.makeForwarder ??
+      ((cwd, cancelSignal) =>
+        new SharedWebhookForwarder(
+          { cwd, cancelSignal },
+          terminateWebhookForwarder,
+        )),
+  });
+}
+
+async function terminateWebhookForwarder(
+  child: ChildProcess,
+  graceMs: number,
+): Promise<void> {
+  if (!child.pid) {
+    child.kill("SIGKILL");
+    return;
+  }
+  const pollMs = Math.max(1, Math.min(100, graceMs));
+  await killTreeAndWait(child.pid, {
+    graceTries: Math.max(1, Math.ceil(graceMs / pollMs)),
+    pollMs,
+  });
+}


### PR DESCRIPTION
Automated AFK landing for #3633. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3633

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789128495&installation_model_id=20659&pr_number=3744&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3744&signature=31da33f31444bdd0d32674f41165fc3f727a1fd8b0bf5d7c03ef5d3c9893ef54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->