### PR TITLE
merge: #3734 Client mandate: the amnesty ends — baselines to zero, the guard becomes absolute

### DIFF
--- a/apps/afk-container/package.json
+++ b/apps/afk-container/package.json
@@ -5,6 +5,9 @@
   "description": "AFK-in-a-box — a self-sufficient Docker image that drains ready-for-agent issues from GitHub repos through the existing AFK engine (red-skills-dev), one ephemeral run at a time. Stateless by construction: the issue and the run branch are the only state.",
   "license": "Apache-2.0",
   "type": "module",
+  "dependencies": {
+    "@reddb-io/github": "workspace:*"
+  },
   "scripts": {
     "test": "vitest run",
     "entrypoint": "node src/entrypoint.mjs"

--- a/apps/afk-container/src/queue.mjs
+++ b/apps/afk-container/src/queue.mjs
@@ -7,6 +7,8 @@
  * preflight would refuse a parked issue and the run would burn for nothing.
  */
 
+import { planGithubRestRead } from "@reddb-io/github";
+
 const PARKED_LABEL = "ready-for-human";
 const PARKED_PREFIX = "blocked:";
 
@@ -41,20 +43,16 @@ export function pickIssue(issues) {
  * @param {{ repo: string, label: string, exec: (cmd: string, args: string[]) => Promise<{code:number,stdout:string,stderr:string}> }} params
  */
 export async function listReadyIssues({ repo, label, exec }) {
-  const result = await exec("gh", [
-    "issue",
-    "list",
-    "--repo",
-    repo,
-    "--label",
-    label,
-    "--state",
-    "open",
-    "--limit",
-    "100",
-    "--json",
-    "number,createdAt,labels",
-  ]);
+  const plan = planGithubRestRead({
+    kind: "rest",
+    path: `repos/${repo}/issues`,
+    args: [
+      "-f", "state=open", "-f", `labels=${label}`, "-f", "per_page=100",
+      "--jq", 'map(select(.pull_request == null) | {number, createdAt: .created_at, labels})',
+    ],
+  });
+  if (plan.outcome !== "plan") throw new Error(plan.reason);
+  const result = await exec("gh", plan.args);
   if (result.code !== 0) {
     throw new Error(`gh issue list failed for ${repo} (exit ${result.code}): ${result.stderr.trim()}`);
   }

--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -47,7 +47,7 @@ import * as gitx from "../runtime/git.js";
 import type { GhContext } from "../runtime/gh.js";
 import type { GitContext } from "../runtime/git.js";
 import type { Runner } from "../types/runner.js";
-import { inferGithubRepoSlug } from "../runtime/wire/github-slug.js";
+import { inferGitHubRepoSlug } from "../runtime/wire/github-slug.js";
 
 export interface RequeueGh {
   view(issue: number): Promise<{ state: string; body: string; labels: string[] }>;
@@ -238,7 +238,7 @@ async function sweepRequeueClaims(gh: RequeueGh, issue: number): Promise<string[
 
 async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
   if (explicit?.trim()) return explicit.trim();
-  return inferGithubRepoSlug(cwd);
+  return inferGitHubRepoSlug(cwd);
 }
 
 /** Append one liveness-lane record so the (un-poisonable) liveness evaluator

--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -19,6 +19,7 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Writable } from "node:stream";
+import { planGithubRestRead } from "@reddb-io/github";
 import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 import { encodeToonlLines } from "@reddb-io/toon";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
@@ -46,6 +47,7 @@ import * as gitx from "../runtime/git.js";
 import type { GhContext } from "../runtime/gh.js";
 import type { GitContext } from "../runtime/git.js";
 import type { Runner } from "../types/runner.js";
+import { inferGithubRepoSlug } from "../runtime/wire/github-slug.js";
 
 export interface RequeueGh {
   view(issue: number): Promise<{ state: string; body: string; labels: string[] }>;
@@ -236,8 +238,7 @@ async function sweepRequeueClaims(gh: RequeueGh, issue: number): Promise<string[
 
 async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
   if (explicit?.trim()) return explicit.trim();
-  const r = await execTool("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], { cwd });
-  return r.code === 0 ? r.stdout.trim() : "";
+  return inferGithubRepoSlug(cwd);
 }
 
 /** Append one liveness-lane record so the (un-poisonable) liveness evaluator
@@ -368,8 +369,11 @@ async function runAdoptLanding(
     // us body+labels but not the title. The title is used in landing artifacts.
     let title = `Issue #${issue}`;
     try {
-      const r = await execTool("gh", ["issue", "view", String(issue), "--repo", repo, "--json", "title", "-q", ".title"], { cwd });
-      if (r.code === 0 && r.stdout.trim()) title = r.stdout.trim();
+      const read = planGithubRestRead({ kind: "issue", number: issue, fields: ["title"], repo });
+      if (read.outcome === "plan") {
+        const r = await execTool("gh", read.args, { cwd });
+        if (r.code === 0) title = String(read.decode(r.stdout).title ?? title);
+      }
     } catch { /* best-effort */ }
 
     const reconcileDeps: ReconcileDeps = {

--- a/apps/dev/src/commands/review.ts
+++ b/apps/dev/src/commands/review.ts
@@ -19,7 +19,7 @@ import { makeExtractReview, reviewFindingsSchema } from "../core/review-extract.
 import { buildReviewGh } from "../runtime/review-gh.js";
 import { actorTrustSignals, type GhContext } from "../runtime/gh.js";
 import { parseTrustPolicy, resolveActorTrust } from "../core/trust-gate.js";
-import { inferGithubRepoSlug } from "../runtime/wire/github-slug.js";
+import { inferGitHubRepoSlug } from "../runtime/wire/github-slug.js";
 
 const REVIEW_FLAG_SCHEMA = {
   pr: { kind: "value", coerce: (raw: string): number => Number(raw) },
@@ -34,7 +34,7 @@ function isRunner(value: string): value is AgentRunner {
 
 async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
   if (explicit?.trim()) return explicit.trim();
-  return inferGithubRepoSlug(cwd);
+  return inferGitHubRepoSlug(cwd);
 }
 
 /**

--- a/apps/dev/src/commands/review.ts
+++ b/apps/dev/src/commands/review.ts
@@ -19,6 +19,7 @@ import { makeExtractReview, reviewFindingsSchema } from "../core/review-extract.
 import { buildReviewGh } from "../runtime/review-gh.js";
 import { actorTrustSignals, type GhContext } from "../runtime/gh.js";
 import { parseTrustPolicy, resolveActorTrust } from "../core/trust-gate.js";
+import { inferGithubRepoSlug } from "../runtime/wire/github-slug.js";
 
 const REVIEW_FLAG_SCHEMA = {
   pr: { kind: "value", coerce: (raw: string): number => Number(raw) },
@@ -33,8 +34,7 @@ function isRunner(value: string): value is AgentRunner {
 
 async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
   if (explicit?.trim()) return explicit.trim();
-  const r = await execTool("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], { cwd });
-  return r.code === 0 ? r.stdout.trim() : "";
+  return inferGithubRepoSlug(cwd);
 }
 
 /**

--- a/apps/dev/src/core/github-read-route-guard.ts
+++ b/apps/dev/src/core/github-read-route-guard.ts
@@ -1,8 +1,7 @@
-// github-read-route-guard — shrink-only migration ratchets for raw `gh` I/O.
+// github-read-route-guard — absolute prohibition on raw `gh` I/O.
 //
 // The destination is cardinal: every GitHub read crosses @reddb-io/github. The
-// baseline records unfinished source files, not permission for new call sites;
-// an entry may only be removed or have its count lowered as reads migrate.
+// Every call site must cross one of the shared package's routed doors.
 
 import { readdirSync, readFileSync } from "node:fs";
 import { extname, join, relative } from "node:path";
@@ -39,20 +38,8 @@ export interface GithubReadShelloutBaselineEntry {
   readonly reason: string;
 }
 
-/**
- * Unfinished migration inventory. SHRINK ONLY: lower a count or delete an entry
- * when a site moves; never raise one to admit a fresh shell-out.
- */
-export const GITHUB_READ_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineEntry[] = [
-  { path: "apps/dev/src/commands/requeue.ts", count: 2, reason: "requeue still resolves repository and issue state through the CLI" },
-  { path: "apps/dev/src/commands/review.ts", count: 1, reason: "review still resolves repository identity through the CLI" },
-  { path: "apps/dev/src/core/merge.ts", count: 2, reason: "one-shot merge rejection diagnosis and queued-PR discovery remain after the two hot waits moved" },
-  { path: "apps/dev/src/runtime/etag-transport.ts", count: 1, reason: "the legacy ETag transport still resolves one PR head through the CLI" },
-  { path: "apps/dev/src/runtime/gh/comments.ts", count: 4, reason: "comment reads still need shared conditional REST projections" },
-  { path: "apps/dev/src/runtime/gh/sweeps.ts", count: 4, reason: "sweep issue/PR listings still need shared conditional pagination" },
-  { path: "apps/dev/src/runtime/medic-io.ts", count: 3, reason: "medic PR/run observations still need routed client methods" },
-  { path: "apps/dev/src/runtime/wire/paths.ts", count: 1, reason: "path wiring still resolves repository identity through gh" },
-];
+/** No grandfathered GitHub reads exist or may be added. */
+export const GITHUB_READ_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineEntry[] = [];
 
 /** Raw mutation inventory. SHRINK ONLY: writes share the routed-client destination. */
 export const GITHUB_WRITE_SHELLOUT_BASELINE: readonly GithubReadShelloutBaselineEntry[] = [
@@ -78,7 +65,7 @@ export interface GithubReadRouteReport {
 }
 
 const SOURCE_EXTENSIONS = new Set([".js", ".cjs", ".mjs", ".ts", ".cts", ".mts", ".tsx"]);
-export const GITHUB_ROUTE_SCAN_ROOTS = ["apps/dev/src", "apps/redskilled/src", "packages/red-castle/src"] as const;
+export const GITHUB_ROUTE_SCAN_ROOTS = ["apps", "packages"] as const;
 const SKIP_DIRS = new Set(["dist", "generated", "node_modules", "test", "tests", "__tests__", "fixtures"]);
 const GUARD_PATH = "apps/dev/src/core/github-read-route-guard.ts";
 
@@ -262,17 +249,18 @@ export function githubReadRouteViolations(report: GithubReadRouteReport): string
 
 export const githubWriteRouteViolations = githubReadRouteViolations;
 
+const ROUTING_DOORS =
+  "Use createGithubClient, planGithubRestRead, or planGithubWrite from @reddb-io/github.";
+
 export function formatGithubReadRouteFailure(
   report: GithubReadRouteReport,
   violations: readonly string[],
 ): string {
   if (violations.length === 0) return "";
   return [
-    `github-read-routing ratchet: ${report.findings.length} GitHub read shell-out(s) remain; ` +
-      `${violations.length} exceed the shrink-only baseline.`,
-    "Route reads through createGithubClient(...).conditionalRest / singleObject in @reddb-io/github.",
+    `github-read-routing guard: ${report.findings.length} raw GitHub read shell-out(s) found.`,
+    ROUTING_DOORS,
     ...violations.map((violation) => `  - ${violation}`),
-    "Baseline: apps/dev/src/core/github-read-route-guard.ts (GITHUB_READ_SHELLOUT_BASELINE); lower only.",
   ].join("\n");
 }
 
@@ -282,10 +270,8 @@ export function formatGithubWriteRouteFailure(
 ): string {
   if (violations.length === 0) return "";
   return [
-    `github-write-routing ratchet: ${report.findings.length} GitHub write shell-out(s) remain; ` +
-      `${violations.length} exceed the shrink-only baseline.`,
-    "Route writes through createGithubClient(...) in @reddb-io/github.",
+    `github-write-routing guard: ${report.findings.length} raw GitHub write shell-out(s) found.`,
+    ROUTING_DOORS,
     ...violations.map((violation) => `  - ${violation}`),
-    "Baseline: apps/dev/src/core/github-read-route-guard.ts (GITHUB_WRITE_SHELLOUT_BASELINE); lower only.",
   ].join("\n");
 }

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -1553,14 +1553,18 @@ async function readMergeStateView(
 ): Promise<MergeStateView> {
   try {
     if (github) return parseMergeStateView(await github.mergeState(repo, prNumber));
-    // Compatibility for non-polling callers not yet supplied the routed read
-    // port. This one-shot rejection diagnosis remains in the shrink-only
-    // inventory; the two repeated wait paths never reach it.
-    const result = await exec([
-      "gh", "-R", repo, "pr", "view", String(prNumber), "--json",
-      "mergeStateStatus,mergeable,baseRefOid,headRefOid,statusCheckRollup",
-    ]);
-    return result.code === 0 ? parseMergeStateView(result.stdout) : emptyMergeStateView();
+    const plan = planGithubRestRead({
+      kind: "pr",
+      number: prNumber,
+      fields: ["mergeStateStatus", "mergeable", "baseRefOid", "headRefOid"],
+      repo,
+    });
+    if (plan.outcome !== "plan") return emptyMergeStateView();
+    const argv = ["gh", ...plan.args];
+    const result = await exec(argv);
+    return result.code === 0
+      ? parseMergeStateView(JSON.stringify(plan.decode(result.stdout)))
+      : emptyMergeStateView();
   } catch {
     return emptyMergeStateView();
   }
@@ -2646,23 +2650,17 @@ export async function listOpenPr(
   branch: string,
   target: string,
 ): Promise<number | undefined> {
-  const res = await exec([
-    "gh",
-    "-R",
-    repo,
-    "pr",
-    "list",
-    "--head",
-    branch,
-    "--base",
-    target,
-    "--state",
-    "open",
-    "--json",
-    "number",
-    "--jq",
-    ".[0].number // empty",
-  ]);
+  const plan = planGithubRestRead({
+    kind: "rest",
+    path: `repos/${repo}/pulls`,
+    args: [
+      "-f", "state=open", "-f", "per_page=100", "--jq",
+      `map(select(.head.ref == ${JSON.stringify(branch)} and .base.ref == ${JSON.stringify(target)}))[0].number // empty`,
+    ],
+  });
+  if (plan.outcome !== "plan") return undefined;
+  const argv = ["gh", ...plan.args];
+  const res = await exec(argv);
   const text = res.stdout.trim();
   if (text === "") return undefined;
   const num = Number.parseInt(text, 10);

--- a/apps/dev/src/runtime/etag-transport.ts
+++ b/apps/dev/src/runtime/etag-transport.ts
@@ -5,6 +5,7 @@ import {
   createFileMergeDriverStore,
 } from "@reddb-io/red-castle/engine";
 import { WebhookForwarder } from "@reddb-io/shared/github-webhook.js";
+import { planGithubRestRead } from "@reddb-io/github";
 import type { ResidentWebhookForwarder } from "../resident-webhook.js";
 import {
   diffCheckRuns,
@@ -127,8 +128,9 @@ export class EtagPollingForwarder extends EventEmitter implements ResidentWebhoo
     const exec = this.options.exec ?? execTool;
     const conditional = async (path: string): Promise<ReturnType<typeof parseConditionalResponse>> => {
       const etag = this.etags.get(path);
-      const args = ["api", "-i", path, ...(etag ? ["-H", `If-None-Match: ${etag}`] : [])];
-      const r = await exec("gh", args, { cwd: this.options.root });
+      const plan = planGithubRestRead({ kind: "rest", path, args: ["-i", ...(etag ? ["-H", `If-None-Match: ${etag}`] : [])] });
+      if (plan.outcome !== "plan") throw new Error(plan.reason);
+      const r = await exec("gh", plan.args, { cwd: this.options.root });
       const parsed = parseConditionalResponse(r.stdout);
       // The quota taxonomy has one owner (`gh/quota.ts`); a rate limit is
       // raised as its own fault so the loop can pace on the reset instant.
@@ -161,15 +163,13 @@ export class EtagPollingForwarder extends EventEmitter implements ResidentWebhoo
     const state = await store.read();
     for (const record of Object.values(state.prs)) {
       if (record.status !== "armed") continue;
-      const head = await exec(
-        "gh",
-        ["pr", "view", String(record.pr), "--json", "headRefOid", "--jq", ".headRefOid"],
-        { cwd: this.options.root },
-      );
+      const headPlan = planGithubRestRead({ kind: "pr", number: record.pr, fields: ["headRefOid"] });
+      if (headPlan.outcome !== "plan") continue;
+      const head = await exec("gh", headPlan.args, { cwd: this.options.root });
       // A quota-exhausted head read means every later read in this cycle is
       // exhausted too — abort the cycle rather than spend the rest of it.
       if (isGhRateLimited(head)) throw new EtagQuotaExhaustedError({});
-      const sha = head.stdout.trim();
+      const sha = head.code === 0 ? String(headPlan.decode(head.stdout).headRefOid ?? "") : "";
       if (head.code !== 0 || sha === "") continue;
       const checks = await conditional(`repos/{owner}/{repo}/commits/${sha}/check-runs`);
       if (checks.status !== 200) continue;

--- a/apps/dev/src/runtime/gh/comments.ts
+++ b/apps/dev/src/runtime/gh/comments.ts
@@ -1,7 +1,7 @@
 import type { HandoffComment } from "../../core/handoff.js";
 import { classifySourceTrust, TRUSTED_ASSOCIATIONS, type SourceTrustLevel } from "../../core/source-trust.js";
 import type { ActorTrustVerdict } from "../../core/trust-gate.js";
-import { apiPath, repoArgs, runGh, type GhContext } from "./common.js";
+import { apiPath, runGithubRestRead, type GhContext } from "./common.js";
 
 export type CommentTrustResolver = (actor: string) => Promise<ActorTrustVerdict>;
 
@@ -126,7 +126,10 @@ export async function issueComments(
   issue: number,
   resolveTrust?: CommentTrustResolver,
 ): Promise<HandoffComment[]> {
-  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "comments"]);
+  const r = await runGithubRestRead(ctx, apiPath(ctx, `issues/${issue}/comments`), [
+    "--paginate", "--slurp", "--jq",
+    '{comments: (add | map({body: .body, author: {login: .user.login, is_bot: (.user.type == "Bot")}, authorAssociation: .author_association, createdAt: .created_at}))}',
+  ]);
   if (r.code !== 0) return [];
   let parsed: {
     comments?: Array<{
@@ -177,7 +180,7 @@ export async function readIssueComments(
   ctx: GhContext,
   issue: number,
 ): Promise<IssueCommentsReadResult> {
-  const r = await runGh(ctx, ["api", "--paginate", apiPath(ctx, `issues/${issue}/comments`), "--jq", restCommentWithIdJq()]);
+  const r = await runGithubRestRead(ctx, apiPath(ctx, `issues/${issue}/comments`), ["--paginate", "--jq", restCommentWithIdJq()]);
   if (r.code !== 0) return { ok: false, reason: `failed to read issue comments (gh exit ${r.code})` };
   const raw = parseStrictCommentJsonLines(r.stdout ?? "");
   if (!raw) return { ok: false, reason: "failed to parse issue comments JSON" };
@@ -204,7 +207,7 @@ export async function prComments(
   pr: number,
   resolveTrust?: CommentTrustResolver,
 ): Promise<HandoffComment[]> {
-  const r = await runGh(ctx, ["api", "--paginate", apiPath(ctx, `issues/${pr}/comments`), "--jq", restCommentJq()]);
+  const r = await runGithubRestRead(ctx, apiPath(ctx, `issues/${pr}/comments`), ["--paginate", "--jq", restCommentJq()]);
   if (r.code !== 0) return [];
   return projectComments(parseJsonLines(r.stdout) as RawGhComment[], resolveTrust);
 }
@@ -216,7 +219,7 @@ export async function prReviewComments(
   pr: number,
   resolveTrust?: CommentTrustResolver,
 ): Promise<HandoffComment[]> {
-  const r = await runGh(ctx, ["api", "--paginate", apiPath(ctx, `pulls/${pr}/comments`), "--jq", restCommentJq()]);
+  const r = await runGithubRestRead(ctx, apiPath(ctx, `pulls/${pr}/comments`), ["--paginate", "--jq", restCommentJq()]);
   if (r.code !== 0) return [];
   return projectComments(parseJsonLines(r.stdout) as RawGhComment[], resolveTrust);
 }

--- a/apps/dev/src/runtime/gh/common.ts
+++ b/apps/dev/src/runtime/gh/common.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import {
   createGithubAttributionLedger,
   createGithubClient,
+  planGithubRestRead,
   type GithubClient,
   type GithubConditionalRestRequest,
 } from "@reddb-io/github";
@@ -165,6 +166,18 @@ export function runGh(
   const fn = () => (ctx.exec ?? execTool)("gh", args, opts(ctx));
   if (runOpts.quota === "off") return fn();
   return withGhQuotaBackoff(fn, resolveGhQuotaBackoff(ctx.quotaBackoff));
+}
+
+/** Issue one explicit read-only REST endpoint through the package-owned planner. */
+export function runGithubRestRead(
+  ctx: GhContext,
+  path: string,
+  args: readonly string[] = [],
+  runOpts: RunGhOpts = {},
+): Promise<ExecOutput> {
+  const plan = planGithubRestRead({ kind: "rest", path, args });
+  if (plan.outcome !== "plan") throw new Error(plan.reason);
+  return runGh(ctx, plan.args, runOpts);
 }
 
 export function runRsp(ctx: GhContext, args: readonly string[]): Promise<ExecOutput> {

--- a/apps/dev/src/runtime/gh/sweeps.ts
+++ b/apps/dev/src/runtime/gh/sweeps.ts
@@ -8,7 +8,7 @@ import {
 } from "../../core/triage-labels.js";
 import type { IssueOpenState } from "../../core/reclaim.js";
 import type { ReconcileSweepCandidate, UnblockCandidate } from "../../core/boot-sweep.js";
-import { repoArgs, runGh, type GhContext } from "./common.js";
+import { apiPath, runGithubRestRead, type GhContext } from "./common.js";
 import { readSingleObject } from "./single-object.js";
 
 export async function orphanState(
@@ -72,21 +72,10 @@ export async function blockerState(ctx: GhContext, issue: number): Promise<strin
 }
 
 export async function listUnblockCandidates(ctx: GhContext): Promise<UnblockCandidate[]> {
-  const r = await runGh(ctx,
-    [
-      "issue",
-      "list",
-      ...repoArgs(ctx),
-      "--label",
-      LABEL_DEPENDENCY,
-      "--state",
-      "open",
-      "--limit",
-      "200",
-      "--json",
-      "number,body,labels",
-    ],
-  );
+  const r = await runGithubRestRead(ctx, apiPath(ctx, "issues"), [
+    "--paginate", "--slurp", "-f", "state=open", "-f", `labels=${LABEL_DEPENDENCY}`,
+    "-f", "per_page=100", "--jq", "add | map(select(.pull_request == null) | {number, body, labels})",
+  ]);
   if (r.code !== 0) return [];
   try {
     const rows = JSON.parse(r.stdout) as Array<{
@@ -111,21 +100,10 @@ export async function listByLabel(
   ctx: GhContext,
   label: string,
 ): Promise<{ number: number; labels: string[] }[]> {
-  const r = await runGh(ctx, 
-    [
-      "issue",
-      "list",
-      ...repoArgs(ctx),
-      "--label",
-      label,
-      "--state",
-      "open",
-      "--limit",
-      "200",
-      "--json",
-      "number,labels",
-    ],
-  );
+  const r = await runGithubRestRead(ctx, apiPath(ctx, "issues"), [
+    "--paginate", "--slurp", "-f", "state=open", "-f", `labels=${label}`,
+    "-f", "per_page=100", "--jq", "add | map(select(.pull_request == null) | {number, labels})",
+  ]);
   if (r.code !== 0) return [];
   try {
     const rows = JSON.parse(r.stdout) as Array<{ number?: number; labels?: Array<{ name?: string }> }>;
@@ -174,18 +152,9 @@ export async function listParkedMechanicalCandidates(
 
 /** List open issues carrying `label` with number, title, body, and labels. */
 async function listIssuesByLabel(ctx: GhContext, label: string): Promise<ReconcileSweepCandidate[]> {
-  const r = await runGh(ctx, [
-    "issue",
-    "list",
-    ...repoArgs(ctx),
-    "--label",
-    label,
-    "--state",
-    "open",
-    "--limit",
-    "200",
-    "--json",
-    "number,title,body,labels",
+  const r = await runGithubRestRead(ctx, apiPath(ctx, "issues"), [
+    "--paginate", "--slurp", "-f", "state=open", "-f", `labels=${label}`,
+    "-f", "per_page=100", "--jq", "add | map(select(.pull_request == null) | {number, title, body, labels})",
   ]);
   if (r.code !== 0) return [];
   try {
@@ -219,16 +188,9 @@ async function listIssuesByLabel(ctx: GhContext, label: string): Promise<Reconci
 export async function listOpenPullRequests(
   ctx: GhContext,
 ): Promise<Array<{ number: number; headRefName: string; body?: string }>> {
-  const r = await runGh(ctx, [
-    "pr",
-    "list",
-    ...repoArgs(ctx),
-    "--state",
-    "open",
-    "--limit",
-    "100",
-    "--json",
-    "number,headRefName,body",
+  const r = await runGithubRestRead(ctx, apiPath(ctx, "pulls"), [
+    "--paginate", "--slurp", "-f", "state=open", "-f", "per_page=100",
+    "--jq", "add | map({number, headRefName: .head.ref, body})",
   ]);
   if (r.code !== 0) return [];
   try {

--- a/apps/dev/src/runtime/medic-io.ts
+++ b/apps/dev/src/runtime/medic-io.ts
@@ -1,7 +1,9 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { planGithubRestRead } from "@reddb-io/github";
 import { git, gh, pnpm } from "./exec.js";
 import type { MedicIo } from "../core/pr-medic.js";
+import { inferGithubRepoSlug } from "./wire/github-slug.js";
 
 const MEDIC_LOG_TAIL_CHARS = 4000;
 
@@ -10,12 +12,16 @@ const MEDIC_LOG_TAIL_CHARS = 4000;
  * (`.red/tmp/worktrees/feedback/medic-<pr>`), created on first use and removed
  * by `cleanup` whatever the outcome. */
 export function createMedicIo(root: string, log?: (line: string) => void): MedicIo {
+  const repo = inferGithubRepoSlug(root);
+  const restPath = (suffix: string): string => `repos/${repo}/${suffix}`;
   const worktreeDir = (pr: number): string =>
     join(root, ".red", "tmp", "worktrees", "feedback", `medic-${pr}`);
   const branchOf = async (pr: number): Promise<string> => {
-    const r = await gh(["pr", "view", String(pr), "--json", "headRefName", "--jq", ".headRefName"], { cwd: root });
+    const plan = planGithubRestRead({ kind: "pr", number: pr, fields: ["headRefName"], repo });
+    if (plan.outcome !== "plan") throw new Error(plan.reason);
+    const r = await gh(plan.args, { cwd: root });
     if (r.code !== 0) throw new Error(`gh pr view #${pr} failed: ${r.stderr.trim()}`);
-    return r.stdout.trim();
+    return String(plan.decode(r.stdout).headRefName ?? "");
   };
   const ensureWorktree = async (pr: number): Promise<string> => {
     const dir = worktreeDir(pr);
@@ -35,13 +41,18 @@ export function createMedicIo(root: string, log?: (line: string) => void): Medic
       // Failing-log tail from the newest failed run on the PR branch.
       let logTail = "";
       const branch = await branchOf(pr);
-      const runs = await gh(
-        ["run", "list", "--branch", branch, "--limit", "5", "--json", "databaseId,conclusion", "--jq", '.[]|select(.conclusion=="failure")|.databaseId'],
-        { cwd: root },
-      );
+      const runsPlan = planGithubRestRead({
+        kind: "rest",
+        path: restPath("actions/runs"),
+        args: ["-f", `branch=${branch}`, "-f", "status=failure", "-f", "per_page=5", "--jq", ".workflow_runs[].id"],
+      });
+      if (runsPlan.outcome !== "plan") throw new Error(runsPlan.reason);
+      const runs = await gh(runsPlan.args, { cwd: root });
       const failedRun = runs.stdout.trim().split("\n").filter(Boolean)[0];
       if (failedRun) {
-        const logs = await gh(["run", "view", failedRun, "--log-failed"], { cwd: root });
+        const logsPlan = planGithubRestRead({ kind: "rest", path: restPath(`actions/runs/${failedRun}/logs`) });
+        if (logsPlan.outcome !== "plan") throw new Error(logsPlan.reason);
+        const logs = await gh(logsPlan.args, { cwd: root });
         logTail = logs.stdout.slice(-MEDIC_LOG_TAIL_CHARS);
       }
       // Conflicts: attempt the merge from main; collect conflicted contents.

--- a/apps/dev/src/runtime/medic-io.ts
+++ b/apps/dev/src/runtime/medic-io.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { planGithubRestRead } from "@reddb-io/github";
 import { git, gh, pnpm } from "./exec.js";
 import type { MedicIo } from "../core/pr-medic.js";
-import { inferGithubRepoSlug } from "./wire/github-slug.js";
+import { inferGitHubRepoSlug } from "./wire/github-slug.js";
 
 const MEDIC_LOG_TAIL_CHARS = 4000;
 
@@ -12,7 +12,7 @@ const MEDIC_LOG_TAIL_CHARS = 4000;
  * (`.red/tmp/worktrees/feedback/medic-<pr>`), created on first use and removed
  * by `cleanup` whatever the outcome. */
 export function createMedicIo(root: string, log?: (line: string) => void): MedicIo {
-  const repo = inferGithubRepoSlug(root);
+  const repo = inferGitHubRepoSlug(root);
   const restPath = (suffix: string): string => `repos/${repo}/${suffix}`;
   const worktreeDir = (pr: number): string =>
     join(root, ".red", "tmp", "worktrees", "feedback", `medic-${pr}`);

--- a/apps/dev/src/runtime/wire/paths.ts
+++ b/apps/dev/src/runtime/wire/paths.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import * as rp from "@reddb-io/shared/red-paths.js";
 import { PROJECT_SUPERVISOR_LANE } from "@reddb-io/red-castle/engine";
+import { inferGithubRepoSlug } from "./github-slug.js";
 
 export interface RepoContext {
   /** Primary checkout dir. */
@@ -11,11 +12,9 @@ export interface RepoContext {
   remote: string;
 }
 
-/** Resolve owner/repo from `gh repo view`, best-effort (empty when unavailable). */
+/** Resolve owner/repo from the configured git remote, best-effort. */
 export async function resolveRepoSlug(root: string): Promise<string> {
-  const { gh } = await import("../exec.js");
-  const r = await gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], { cwd: root });
-  return r.code === 0 ? r.stdout.trim() : "";
+  return inferGithubRepoSlug(root);
 }
 
 export async function resolveRepoContext(root = process.cwd()): Promise<RepoContext> {

--- a/apps/dev/src/runtime/wire/paths.ts
+++ b/apps/dev/src/runtime/wire/paths.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import * as rp from "@reddb-io/shared/red-paths.js";
 import { PROJECT_SUPERVISOR_LANE } from "@reddb-io/red-castle/engine";
-import { inferGithubRepoSlug } from "./github-slug.js";
+import { inferGitHubRepoSlug } from "./github-slug.js";
 
 export interface RepoContext {
   /** Primary checkout dir. */
@@ -14,7 +14,7 @@ export interface RepoContext {
 
 /** Resolve owner/repo from the configured git remote, best-effort. */
 export async function resolveRepoSlug(root: string): Promise<string> {
-  return inferGithubRepoSlug(root);
+  return inferGitHubRepoSlug(root);
 }
 
 export async function resolveRepoContext(root = process.cwd()): Promise<RepoContext> {

--- a/apps/dev/tests/github-read-route-guard.test.ts
+++ b/apps/dev/tests/github-read-route-guard.test.ts
@@ -20,7 +20,13 @@ import { REPO_INVARIANT_SUITES } from "../src/core/repo-invariants.js";
 const ROOT = join(import.meta.dirname, "..", "..", "..");
 
 describe("GitHub reads route through @reddb-io/github (#3451)", () => {
-  it("holds the live tree to the declared shrink-only baseline", () => {
+  it("has no amnesty for raw GitHub shell-outs anywhere in apps or packages (#3734)", () => {
+    expect(GITHUB_ROUTE_SCAN_ROOTS).toEqual(["apps", "packages"]);
+    expect(GITHUB_READ_SHELLOUT_BASELINE).toEqual([]);
+    expect(GITHUB_WRITE_SHELLOUT_BASELINE).toEqual([]);
+  });
+
+  it("rejects every raw GitHub read in the live tree", () => {
     const report = collectGithubReadRouteReport(ROOT);
     const violations = githubReadRouteViolations(report);
 
@@ -29,7 +35,7 @@ describe("GitHub reads route through @reddb-io/github (#3451)", () => {
       GITHUB_READ_SHELLOUT_BASELINE.reduce((sum, entry) => sum + entry.count, 0),
     );
     expect(formatGithubReadRouteFailure(report, ["probe"])).toContain(
-      `${report.findings.length} GitHub read shell-out(s) remain`,
+      `${report.findings.length} raw GitHub read shell-out(s) found`,
     );
   });
 
@@ -70,7 +76,8 @@ describe("GitHub reads route through @reddb-io/github (#3451)", () => {
     expect(violations).toHaveLength(1);
     expect(failure).toContain("apps/dev/src/new-poller.ts:3");
     expect(failure).toContain("createGithubClient");
-    expect(failure).toContain("conditionalRest / singleObject");
+    expect(failure).toContain("planGithubRestRead");
+    expect(failure).toContain("planGithubWrite");
   });
 
   it("does not classify authentication or a mutation as a read", () => {
@@ -86,7 +93,7 @@ describe("GitHub reads route through @reddb-io/github (#3451)", () => {
     ])).toEqual([]);
   });
 
-  it("holds raw GitHub writes to their own shrink-only baseline", () => {
+  it("rejects every raw GitHub write in the live tree", () => {
     const report = collectGithubWriteRouteReport(ROOT);
     const violations = githubWriteRouteViolations(report);
 
@@ -95,7 +102,7 @@ describe("GitHub reads route through @reddb-io/github (#3451)", () => {
       GITHUB_WRITE_SHELLOUT_BASELINE.reduce((sum, entry) => sum + entry.count, 0),
     );
     expect(formatGithubWriteRouteFailure(report, ["probe"])).toContain(
-      `${report.findings.length} GitHub write shell-out(s) remain`,
+      `${report.findings.length} raw GitHub write shell-out(s) found`,
     );
     const issuesPath = "apps/dev/src/runtime/gh/issues.ts";
     expect(GITHUB_READ_SHELLOUT_BASELINE.some((entry) => entry.path === issuesPath)).toBe(false);
@@ -172,14 +179,6 @@ describe("GitHub reads route through @reddb-io/github (#3451)", () => {
     expect(violations).toHaveLength(1);
     expect(failure).toContain("packages/red-castle/src/engine/new-writer.ts:3");
     expect(failure).toContain("createGithubClient");
-  });
-
-  it("sweeps red-castle alongside both daemon applications", () => {
-    expect(GITHUB_ROUTE_SCAN_ROOTS).toEqual([
-      "apps/dev/src",
-      "apps/redskilled/src",
-      "packages/red-castle/src",
-    ]);
   });
 
   it("runs in every validation cone", () => {

--- a/apps/memory/package.json
+++ b/apps/memory/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "catalog:",
     "@reddb-io/build-info": "workspace:*",
+    "@reddb-io/github": "workspace:*",
     "@reddb-io/sdk": "1.23.1",
     "@reddb-io/shared": "workspace:*",
     "@reddb-io/toon": "catalog:",

--- a/apps/memory/src/curate-skill/issue-filer.ts
+++ b/apps/memory/src/curate-skill/issue-filer.ts
@@ -16,6 +16,7 @@ import { spawnSync } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { planGithubWrite } from "@reddb-io/github";
 import { CURATE_CATEGORIES, type ArchiveCandidate, type CurateCategory } from "./types.js";
 
 const CATEGORY_HEADERS: Record<CurateCategory, string> = {
@@ -124,9 +125,10 @@ export async function fileBackgroundIssue(
   const bodyPath = join(tmp, "body.md");
   try {
     await writeFile(bodyPath, body, "utf8");
+    const plan = planGithubWrite(["gh", "issue", "create", "--title", title, "--body-file", bodyPath, "--label", label]);
     const proc = spawn(
-      "gh",
-      ["issue", "create", "--title", title, "--body-file", bodyPath, "--label", label],
+      plan.args[0]!,
+      plan.args.slice(1),
       { cwd: opts.cwd, encoding: "utf8" },
     );
     if (proc.status !== 0) {

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -140,6 +140,9 @@ export {
   type GithubRestRead,
   type GithubRestReadPlan,
   type GithubRestReadRequest,
+  type GithubRestEndpointReadRequest,
+  type GithubGraphqlReadRequest,
+  type GithubSingleObjectRestReadRequest,
   type GithubRestReadUnavailable,
   type GithubSingleObjectKind,
 } from "./rest-plan.js";

--- a/packages/github/rest-plan.test.ts
+++ b/packages/github/rest-plan.test.ts
@@ -176,6 +176,34 @@ describe("planGithubRestRead — what REST cannot answer", () => {
   });
 });
 
+describe("planGithubRestRead — explicit REST endpoints", () => {
+  it("plans a read-only collection without admitting mutation flags (#3734)", () => {
+    expect(planGithubRestRead({
+      kind: "rest",
+      path: "repos/o/r/issues",
+      args: ["--paginate", "-f", "state=open"],
+    })).toMatchObject({
+      outcome: "plan",
+      path: "repos/o/r/issues",
+      args: ["api", "repos/o/r/issues", "--method", "GET", "--paginate", "-f", "state=open"],
+    });
+    expect(planGithubRestRead({ kind: "rest", path: "repos/o/r/issues", args: ["-X", "POST"] })).toMatchObject({
+      outcome: "unavailable",
+    });
+  });
+
+  it("plans an attributed GraphQL read without exposing a mutation door (#3734)", () => {
+    expect(planGithubRestRead({ kind: "graphql", query: "query Viewer { viewer { login } }" })).toMatchObject({
+      outcome: "plan",
+      path: "graphql",
+      args: ["api", "graphql", "-f", "query=query Viewer { viewer { login } }"],
+    });
+    expect(planGithubRestRead({ kind: "graphql", query: "mutation { deleteProjectV2(input: {}) { clientMutationId } }" })).toMatchObject({
+      outcome: "unavailable",
+    });
+  });
+});
+
 describe("githubJsonFields", () => {
   it("splits gh's comma-separated field spec", () => {
     expect(githubJsonFields("state, labels ,comments")).toEqual(["state", "labels", "comments"]);

--- a/packages/github/rest-plan.ts
+++ b/packages/github/rest-plan.ts
@@ -44,7 +44,7 @@ export interface GithubRestReadUnavailable {
 
 export type GithubRestRead = GithubRestReadPlan | GithubRestReadUnavailable;
 
-export interface GithubRestReadRequest {
+export interface GithubSingleObjectRestReadRequest {
   readonly kind: GithubSingleObjectKind;
   readonly number: number;
   /** The `--json` field names the caller asked for. */
@@ -52,6 +52,22 @@ export interface GithubRestReadRequest {
   /** `owner/repo`; omitted uses gh's own `{owner}/{repo}` placeholders. */
   readonly repo?: string;
 }
+
+/** An explicit read-only REST endpoint whose exact response shape belongs to the caller. */
+export interface GithubRestEndpointReadRequest {
+  readonly kind: "rest";
+  readonly path: string;
+  /** Additional `gh api` read flags. Mutation methods and `--input` are refused. */
+  readonly args?: readonly string[];
+}
+
+export interface GithubGraphqlReadRequest {
+  readonly kind: "graphql";
+  readonly query: string;
+  readonly variables?: Readonly<Record<string, string | number | boolean>>;
+}
+
+export type GithubRestReadRequest = GithubSingleObjectRestReadRequest | GithubRestEndpointReadRequest | GithubGraphqlReadRequest;
 
 type Projection = (body: Record<string, unknown>) => unknown;
 
@@ -184,6 +200,49 @@ export function githubJsonFields(spec: string): string[] {
  * none. PURE — it builds an argv and a decoder and issues nothing itself.
  */
 export function planGithubRestRead(request: GithubRestReadRequest): GithubRestRead {
+  if (request.kind === "graphql") {
+    const query = request.query.trim();
+    if (query === "" || /\bmutation\b/i.test(query)) {
+      return { outcome: "unavailable", fields: [], reason: "the GraphQL read planner refuses empty or mutating documents" };
+    }
+    const variables = Object.entries(request.variables ?? {}).flatMap(([key, value]) => ["-F", `${key}=${String(value)}`]);
+    return {
+      outcome: "plan",
+      path: "graphql",
+      args: ["api", "graphql", ...variables, "-f", `query=${query}`],
+      decode(stdout: string): Record<string, unknown> {
+        const body = record(JSON.parse(stdout.trim() === "" ? "null" : stdout));
+        if (!body) throw new Error("GraphQL read returned a non-object payload");
+        return body;
+      },
+    };
+  }
+  if (request.kind === "rest") {
+    const path = request.path.trim();
+    const args = [...(request.args ?? [])];
+    const methodAt = args.findIndex((arg) => arg === "-X" || arg === "--method");
+    const method = methodAt < 0 ? "" : String(args[methodAt + 1] ?? "").toUpperCase();
+    const mutation = method !== "" && method !== "GET" && method !== "HEAD";
+    if (path === "" || mutation || args.includes("--input")) {
+      return {
+        outcome: "unavailable",
+        fields: [],
+        reason: path === "" ? "a REST read needs a non-empty path" : "the REST read planner refuses mutation arguments",
+      };
+    }
+    const needsExplicitGet = methodAt < 0 && args.some((arg) => arg === "-f" || arg === "--raw-field" || arg === "-F" || arg === "--field");
+    const plannedArgs = ["api", path, ...(needsExplicitGet ? ["--method", "GET"] : []), ...args];
+    return {
+      outcome: "plan",
+      path,
+      args: plannedArgs,
+      decode(stdout: string): Record<string, unknown> {
+        const body = record(JSON.parse(stdout.trim() === "" ? "null" : stdout));
+        if (!body) throw new Error(`REST read of ${path} returned a non-object payload`);
+        return body;
+      },
+    };
+  }
   const fields = [...new Set(request.fields.map((field) => field.trim()).filter((f) => f !== ""))];
   if (fields.length === 0) {
     return { outcome: "unavailable", fields: [], reason: "the read names no fields" };

--- a/packages/red-castle/.red-castle/agent-workflows/shared/review-context.ts
+++ b/packages/red-castle/.red-castle/agent-workflows/shared/review-context.ts
@@ -1,5 +1,6 @@
 import { gh, safeSh, sh } from "./common";
 import { parseDiffLines } from "./diff-lines";
+import { planGithubRestRead } from "@reddb-io/github";
 
 export interface ReviewThreadComment {
   readonly commentId: string;
@@ -25,9 +26,29 @@ export interface PullRequestContext {
 export const fetchPullRequestContext = (
   prNumber: string,
 ): PullRequestContext => {
-  const prView = JSON.parse(
-    gh(["pr", "view", prNumber, "--json", "title,body,comments"]),
-  ) as {
+  const repoSlug = process.env.GH_REPO || "{owner}/{repo}";
+  const rest = (path: string, args: readonly string[] = []): string => {
+    const plan = planGithubRestRead({ kind: "rest", path, args });
+    if (plan.outcome !== "plan") throw new Error(plan.reason);
+    return gh(plan.args);
+  };
+  const prPlan = planGithubRestRead({ kind: "pr", number: Number(prNumber), fields: ["title", "body"], ...(repoSlug.includes("{") ? {} : { repo: repoSlug }) });
+  if (prPlan.outcome !== "plan") throw new Error(prPlan.reason);
+  const pr = prPlan.decode(gh(prPlan.args));
+  const comments = JSON.parse(rest(`repos/${repoSlug}/issues/${prNumber}/comments`)) as Array<{
+    user?: { login?: string } | null;
+    body?: string;
+    created_at?: string;
+  }>;
+  const prView = {
+    title: String(pr.title ?? ""),
+    body: String(pr.body ?? ""),
+    comments: comments.map((comment) => ({
+      author: { login: comment.user?.login ?? "" },
+      body: comment.body ?? "",
+      createdAt: comment.created_at,
+    })),
+  } as {
     title: string;
     body?: string | null;
     comments: {
@@ -41,15 +62,15 @@ export const fetchPullRequestContext = (
     /(?:closes|fixes|resolves)\s+#(\d+)/i,
   );
   const issueNumber = issueMatch?.[1] ?? "";
-  const issueTitle = issueNumber
-    ? safeSh(`gh issue view ${issueNumber} --json title --jq .title`).trim()
-    : "";
+  const issuePlan = issueNumber ? planGithubRestRead({ kind: "issue", number: Number(issueNumber), fields: ["title", "body"], ...(repoSlug.includes("{") ? {} : { repo: repoSlug }) }) : null;
+  const issue = issuePlan?.outcome === "plan" ? issuePlan.decode(gh(issuePlan.args)) : {};
+  const issueTitle = String(issue.title ?? "");
   const linkedIssue = issueNumber
-    ? safeSh(`gh issue view ${issueNumber} --comments`)
+    ? JSON.stringify({ ...issue, comments: JSON.parse(rest(`repos/${repoSlug}/issues/${issueNumber}/comments`)) })
     : "(no linked issue found)";
 
   const reviews = JSON.parse(
-    gh(["api", `repos/{owner}/{repo}/pulls/${prNumber}/reviews`]),
+    rest(`repos/${repoSlug}/pulls/${prNumber}/reviews`),
   ) as {
     user?: { login: string } | null;
     body?: string | null;
@@ -83,20 +104,13 @@ query($owner:String!,$repo:String!,$number:Int!) {
   }
 }`;
 
-  const threadsParsed = JSON.parse(
-    gh([
-      "api",
-      "graphql",
-      "-F",
-      `owner=${owner}`,
-      "-F",
-      `repo=${repo}`,
-      "-F",
-      `number=${prNumber}`,
-      "-f",
-      `query=${query}`,
-    ]),
-  ) as {
+  const threadsPlan = planGithubRestRead({
+    kind: "graphql",
+    query,
+    variables: { owner: owner ?? "", repo: repo ?? "", number: Number(prNumber) },
+  });
+  if (threadsPlan.outcome !== "plan") throw new Error(threadsPlan.reason);
+  const threadsParsed = JSON.parse(gh(threadsPlan.args)) as {
     data?: {
       repository?: {
         pullRequest?: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,10 @@ importers:
         version: 5.9.3
 
   apps/afk-container:
+    dependencies:
+      '@reddb-io/github':
+        specifier: workspace:*
+        version: link:../../packages/github
     devDependencies:
       vitest:
         specifier: 'catalog:'
@@ -251,6 +255,9 @@ importers:
       '@reddb-io/build-info':
         specifier: workspace:*
         version: link:../../packages/build-info
+      '@reddb-io/github':
+        specifier: workspace:*
+        version: link:../../packages/github
       '@reddb-io/sdk':
         specifier: 1.23.1
         version: 1.23.1


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3734 -->
🤖 **Re-seed trail** — #3734 on `afk/3734-client-mandate-the-amnesty-ends-baseline`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3734; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3734 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: whole-workspace (trigger: `pnpm-lock.yaml`)
{"schema":"red.afk.validation.v1","name":"feedback:pnpm typecheck","status":"failed","command":"pnpm typecheck","exitCode":2,"durationMs":29,"summary":"suspect-infra: `pnpm typecheck` exited 2 after 29ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. @reddb-io/browser-bridge:typecheck: $ tsc -p tsconfig.json --noEmit @reddb-io/benchmark-code-understanding:typecheck: cache hit, replaying logs 9051f18630c19c33 @reddb-io/benchmark-code-understanding:typecheck: $ tsc -p tsconfig.json --noEmit @reddb-io/dev:typecheck: $ tsc -p tsconfig.json --noEmit @reddb-io/dev:typecheck: src/commands/requeue.ts(50,10): error TS2724: '\"../runtime/wire/github-slug.js\"' has no exported member named 'inferGithubRepoSlug'. Did you mean 'inferGitHubRepoSlug'? @reddb-io/dev:typecheck: src/commands/review.ts(22,10): error TS2724: '\"../runtime/wire/github-slug.js\"' has no exported member named 'inferGithubRepoSlug'. Did you mean 'inferGitHubRepoSlug'? @reddb-io/dev:typecheck: src/runtime/medic-io.ts(6,10): error TS2724: '\"./wire/github-slug.js\"' has no exported member named 'inferGithubRepoSlug'. Did you mean 'inferGitHubRepoSlug'? @reddb-io/dev:typecheck: src/runtime/wire/paths.ts(4,10): error TS2724: '\"./github-slug.js\"' has no exported member named 'inferG","suspectInfra":true}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3734