### PR TITLE
merge: #3748 The MCP client restores a dropped daemon connection by itself: reconnect with backoff across takeover, restart, and socket churn

### DIFF
--- a/apps/redskilled/src/client-reconnect.ts
+++ b/apps/redskilled/src/client-reconnect.ts
@@ -1,0 +1,99 @@
+/**
+ * client-reconnect — bounded patience for an established daemon connection.
+ *
+ * A successful reach is session-sticky; a failure never is. That distinction
+ * lets a long-lived MCP client follow socket churn without turning a genuinely
+ * absent first-time daemon into a replacement wait.
+ */
+import { redskilledPresenceAdvice, type RedskilledPresence } from "./daemon-presence.js";
+
+/** How long an established client follows a daemon through replacement. */
+export const DEFAULT_REDSKILLED_RECONNECT_TIMEOUT_MS = 30_000;
+/** The first reconnect pause; subsequent pauses double up to eight seconds. */
+export const DEFAULT_REDSKILLED_RECONNECT_BACKOFF_MS = 500;
+const MAX_REDSKILLED_RECONNECT_BACKOFF_MS = 8_000;
+
+const establishedSockets = new Set<string>();
+
+/** Transport silence: distinct from a daemon's application-level refusal. */
+export class RedskilledUnreachableError extends Error {
+  constructor(
+    readonly socketPath: string,
+    override readonly cause: unknown,
+    readonly presence?: RedskilledPresence,
+  ) {
+    super(
+      `redskilled daemon is unreachable on ${JSON.stringify(socketPath)}, so no Worker was started: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }${presence?.kind === "held-unresponsive" ? `. ${redskilledPresenceAdvice(presence)}` : ""}`,
+    );
+    this.name = "RedskilledUnreachableError";
+  }
+}
+
+/** Transport silence while a live pid still holds the daemon lease. */
+export class RedskilledDaemonHeldError extends RedskilledUnreachableError {
+  constructor(socketPath: string, override readonly presence: RedskilledPresence, cause: unknown) {
+    super(socketPath, cause, presence);
+    this.name = "RedskilledDaemonHeldError";
+  }
+}
+
+export interface RedskilledReconnectConfig {
+  /** Total patience for reconnecting through socket churn. */
+  readonly reconnectTimeoutMs?: number;
+  /** First exponential-backoff pause; injectable so transport tests stay fast. */
+  readonly reconnectInitialBackoffMs?: number;
+}
+
+interface RedskilledReconnectOperation<T> {
+  readonly socketPath: string;
+  readonly config: RedskilledReconnectConfig;
+  readonly attempt: (remainingMs: number) => Promise<T>;
+  readonly retryable: (error: unknown, previouslyEstablished: boolean) => boolean;
+  readonly exhausted?: (error: unknown, timeoutMs: number) => unknown;
+}
+
+/**
+ * Run one logical client operation through a bounded exponential-backoff
+ * window. Each attempt gets the remaining budget so nested reach/request work
+ * cannot silently mint a fresh thirty-second window.
+ */
+export async function reconnectRedskilled<T>(operation: RedskilledReconnectOperation<T>): Promise<T> {
+  const timeoutMs = operation.config.reconnectTimeoutMs ?? DEFAULT_REDSKILLED_RECONNECT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let backoffMs = operation.config.reconnectInitialBackoffMs ?? DEFAULT_REDSKILLED_RECONNECT_BACKOFF_MS;
+
+  for (;;) {
+    try {
+      const result = await operation.attempt(Math.max(0, deadline - Date.now()));
+      establishedSockets.add(operation.socketPath);
+      return result;
+    } catch (error) {
+      if (!operation.retryable(error, establishedSockets.has(operation.socketPath))) throw error;
+      if (Date.now() >= deadline) throw operation.exhausted?.(error, timeoutMs) ?? error;
+      await pauseUntil(deadline, backoffMs);
+      backoffMs = Math.min(backoffMs * 2, MAX_REDSKILLED_RECONNECT_BACKOFF_MS);
+    }
+  }
+}
+
+/** Preserve presence while making an exhausted replacement wait explicit. */
+export function redskilledReconnectExhausted(error: unknown, timeoutMs: number): unknown {
+  if (!(error instanceof RedskilledUnreachableError)) return error;
+  const holder = error.presence?.kind === "held-unresponsive" ? error.presence.holder : null;
+  const cause = new Error(
+    `daemon replacing/booting, retrying with exponential backoff for ${timeoutMs}ms exhausted` +
+      (holder == null ? "" : `; holder pid ${holder.pid}`),
+    { cause: error },
+  );
+  return holder == null || error.presence == null
+    ? new RedskilledUnreachableError(error.socketPath, cause, error.presence)
+    : new RedskilledDaemonHeldError(error.socketPath, error.presence, cause);
+}
+
+async function pauseUntil(deadline: number, backoffMs: number): Promise<void> {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) return;
+  await new Promise((resolve) => setTimeout(resolve, Math.min(backoffMs, remainingMs)));
+}

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -37,7 +37,6 @@ import { redskilledDashboardRequest } from "./dashboard-request.js";
 import { socketAnswers } from "./daemon.js";
 import {
   describeRedskilledPresence,
-  redskilledPresenceAdvice,
   type RedskilledPresence,
 } from "./daemon-presence.js";
 import { readRedskilledLeaseFile } from "./session-lease.js";
@@ -96,6 +95,13 @@ import { clampPublishedWorkerDisplay } from "./worker-display.js";
 import { clampPublishedLogLine } from "./worker-log.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
 import { refuseWhenMachineIsHeld, resolveRedskilledClientEndpoint, startThroughInstalledSupervisor } from "./client-rendezvous.js";
+import {
+  reconnectRedskilled,
+  redskilledReconnectExhausted,
+  RedskilledDaemonHeldError,
+  RedskilledUnreachableError,
+  type RedskilledReconnectConfig,
+} from "./client-reconnect.js";
 
 // The entry resolver is re-exported here because reaching the daemon and
 // resolving what to spawn are one story for a caller, and a second import path
@@ -135,54 +141,15 @@ export {
   type RedskilledPresenceKind,
 } from "./daemon-presence.js";
 
+export {
+  DEFAULT_REDSKILLED_RECONNECT_BACKOFF_MS,
+  DEFAULT_REDSKILLED_RECONNECT_TIMEOUT_MS,
+  RedskilledDaemonHeldError,
+  RedskilledUnreachableError,
+} from "./client-reconnect.js";
+
 /** How long a client waits for a daemon — its own or the race winner's — to answer. */
 export const DEFAULT_REDSKILLED_READY_TIMEOUT_MS = 10_000;
-
-/**
- * Raised when no daemon could be reached, so nothing was born.
- *
- * A distinct type because the two refusals a caller can get mean opposite
- * things: an admission refusal is the host saying "not this Worker, not now",
- * while this one is the host saying nothing at all. Both end in no Worker — the
- * fail-closed rule (ADR 0130 rule 6) — and only one of them is a fault.
- */
-export class RedskilledUnreachableError extends Error {
-  constructor(
-    readonly socketPath: string,
-    override readonly cause: unknown,
-    /**
-     * Which of the three silences this was, when it could be established.
-     *
-     * Carried on the error rather than left to each surface to re-derive: a
-     * consumer that re-probed would be asking a second time, a second later, and
-     * could print an answer the failure it is reporting never had (#3092).
-     */
-    readonly presence?: RedskilledPresence,
-  ) {
-    super(
-      `redskilled daemon is unreachable on ${JSON.stringify(socketPath)}, so no Worker was started: ${
-        cause instanceof Error ? cause.message : String(cause)
-      }${presence != null && presence.kind === "held-unresponsive" ? `. ${redskilledPresenceAdvice(presence)}` : ""}`,
-    );
-    this.name = "RedskilledUnreachableError";
-  }
-}
-
-/**
- * Raised when the daemon IS there — a live pid holds this socket's lease — and
- * still did not answer.
- *
- * A subclass rather than a sibling, so every consumer that already fails closed
- * on {@link RedskilledUnreachableError} keeps doing so, while a surface that
- * renders operator advice can tell the two apart and stop telling an operator to
- * install a daemon that is running (#3092).
- */
-export class RedskilledDaemonHeldError extends RedskilledUnreachableError {
-  constructor(socketPath: string, override readonly presence: RedskilledPresence, cause: unknown) {
-    super(socketPath, cause, presence);
-    this.name = "RedskilledDaemonHeldError";
-  }
-}
 
 /**
  * Raised when the daemon answered a request with an application-level refusal.
@@ -220,7 +187,7 @@ export async function probeRedskilledPresence(
   });
 }
 
-export interface RedskilledClientConfig {
+export interface RedskilledClientConfig extends RedskilledReconnectConfig {
   /** The command that runs the daemon; defaults to the resolved published bundle. */
   readonly serverCommand?: string;
   readonly serverArgs?: readonly string[];
@@ -274,6 +241,21 @@ export interface RedskilledClientConfig {
 export async function ensureRedskilledDaemon(
   paths: RedskilledPaths,
   config: RedskilledClientConfig = {},
+): Promise<"already-running" | "spawned" | "joined"> {
+  return await reconnectRedskilled({
+    socketPath: paths.socketPath,
+    config,
+    attempt: () => ensureRedskilledDaemonOnce(paths, config),
+    retryable: (error, established) =>
+      error instanceof RedskilledDaemonHeldError ||
+      (error instanceof RedskilledUnreachableError && established),
+    exhausted: redskilledReconnectExhausted,
+  });
+}
+
+async function ensureRedskilledDaemonOnce(
+  paths: RedskilledPaths,
+  config: RedskilledClientConfig,
 ): Promise<"already-running" | "spawned" | "joined"> {
   const endpoint = await resolveRedskilledClientEndpoint(paths);
   try {
@@ -418,28 +400,37 @@ export async function requestRedskilled(
   request: RedskilledRequestBody,
   config: RedskilledClientConfig = {},
 ): Promise<unknown> {
-  await ensureRedskilledDaemon(paths, config);
-  // A supervised cold start may publish its rendezvous only after systemd
-  // starts it, so resolve again before sending the actual request.
-  const endpoint = (await resolveRedskilledClientEndpoint(paths)).paths;
-  let response;
-  try {
-    response = await sendRedskilledRequest(
-      { socketPath: endpoint.socketPath, timeoutMs: config.requestTimeoutMs ?? 2_000 },
-      { ...request, id: randomUUID() } as RedskilledRequest,
-    );
-  } catch (err) {
-    // A socket that answered a ping and then died mid-request is still the host
-    // saying nothing; only an `ok: false` answer is the host refusing something.
-    // Which of the three silences it became is read now, while it is true.
-    throw new RedskilledUnreachableError(
-      endpoint.socketPath,
-      err,
-      await probeRedskilledPresence(endpoint).catch(() => undefined),
-    );
-  }
-  if (!response.ok) throw new RedskilledRequestRefusedError(response.error);
-  return response.value;
+  // One logical call keeps one id across transport retries. Besides making the
+  // wire trace honest, this lets a daemon-side dedupe remain possible without a
+  // future client change for mutating requests.
+  const id = randomUUID();
+  return await reconnectRedskilled({
+    socketPath: paths.socketPath,
+    config,
+    attempt: async (remainingMs) => {
+      await ensureRedskilledDaemon(paths, { ...config, reconnectTimeoutMs: remainingMs });
+      // A supervised cold start may publish its rendezvous only after systemd
+      // starts it, so resolve again before every send, including reconnects.
+      const endpoint = (await resolveRedskilledClientEndpoint(paths)).paths;
+      let response;
+      try {
+        response = await sendRedskilledRequest(
+          { socketPath: endpoint.socketPath, timeoutMs: config.requestTimeoutMs ?? 2_000 },
+          { ...request, id } as RedskilledRequest,
+        );
+      } catch (error) {
+        throw new RedskilledUnreachableError(
+          endpoint.socketPath,
+          error,
+          await probeRedskilledPresence(endpoint).catch(() => undefined),
+        );
+      }
+      if (!response.ok) throw new RedskilledRequestRefusedError(response.error);
+      return response.value;
+    },
+    retryable: (error, established) => error instanceof RedskilledUnreachableError && established,
+    exhausted: redskilledReconnectExhausted,
+  });
 }
 
 /**

--- a/apps/redskilled/tests/client-reconnect.test.ts
+++ b/apps/redskilled/tests/client-reconnect.test.ts
@@ -1,0 +1,145 @@
+// An established client survives daemon replacement without asking its operator
+// to retry the MCP tool call. Cold-start rendezvous already waits for one ready
+// window; replacement must outlive that window and keep joining with backoff.
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { encode, type JsonValue } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ensureRedskilledDaemon, readRedskilledHostState } from "../src/client.js";
+import { handleSocket, startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import type { RedskilledLease } from "../src/session-lease.js";
+
+const running: RedskilledDaemon[] = [];
+const servers: Server[] = [];
+const sockets: Socket[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const socket of sockets.splice(0)) socket.destroy();
+  for (const server of servers.splice(0)) await new Promise<void>((resolve) => server.close(() => resolve()));
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("an established client across daemon replacement", () => {
+  it("joins a restart that lasts longer than one ready window", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-client-reconnect-"));
+    roots.push(root);
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const first = await startRedskilledDaemon({ paths, idleMs: 60_000 });
+    running.push(first);
+
+    const config = {
+      readyTimeoutMs: 40,
+      reconnectTimeoutMs: 1_000,
+      reconnectInitialBackoffMs: 20,
+      supervisor: { installed: () => true, start: () => undefined },
+    };
+    await readRedskilledHostState(paths, config);
+    await first.stop();
+
+    const replacement = new Promise<RedskilledDaemon>((resolve, reject) => {
+      setTimeout(() => {
+        startRedskilledDaemon({ paths, idleMs: 60_000 }).then(resolve, reject);
+      }, 150);
+    });
+
+    const after = await readRedskilledHostState(paths, config);
+    const second = await replacement;
+    running.push(second);
+
+    expect(after.pid).toBe(second.lease.pid);
+  });
+
+  it("reports a live takeover holder as replacing or booting while retrying", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-client-takeover-"));
+    roots.push(root);
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const server = createServer((socket) => sockets.push(socket));
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(paths.socketPath, () => resolve());
+    });
+    const now = new Date().toISOString();
+    const lease = {
+      version: 1,
+      pid: process.pid,
+      start_time: now,
+      session_key_hash: paths.sessionKeyHash,
+      machine_id_hash: paths.machineIdHash,
+      socket_path: paths.socketPath,
+      acquired_at: now,
+      renewed_at: now,
+    } satisfies RedskilledLease;
+    await writeFile(paths.leasePath, `${encode(lease as unknown as JsonValue)}\n`, "utf8");
+
+    const error = await ensureRedskilledDaemon(paths, {
+      readyTimeoutMs: 30,
+      reconnectTimeoutMs: 600,
+      reconnectInitialBackoffMs: 10,
+    }).then((value) => value as never, (cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/replacing\/booting, retrying/);
+    expect((error as Error).message).toContain(`pid ${process.pid}`);
+    expect((error as Error).message).not.toContain("Install and start");
+    expect((error as Error).message).not.toContain("redskilled provision");
+  });
+
+  it("re-probes when the daemon drops after ping but before the request answer", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-client-request-drop-"));
+    roots.push(root);
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    let dropped = false;
+    let replacement!: Promise<RedskilledDaemon>;
+    const server = createServer((socket) => handleSocket(socket, async (request, respond) => {
+      if (request.op === "ping") {
+        respond({
+          id: request.id,
+          ok: true,
+          value: { pong: true, protocol_version: 1, daemon_version: "replacing", pid: process.pid },
+        });
+        return;
+      }
+      dropped = true;
+      socket.destroy();
+      replacement = new Promise<RedskilledDaemon>((resolve, reject) => {
+        server.close(() => {
+          setTimeout(() => startRedskilledDaemon({ paths, idleMs: 60_000 }).then(resolve, reject), 100);
+        });
+      });
+    }));
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(paths.socketPath, () => resolve());
+    });
+
+    const state = await readRedskilledHostState(paths, {
+      readyTimeoutMs: 40,
+      requestTimeoutMs: 100,
+      reconnectTimeoutMs: 1_000,
+      reconnectInitialBackoffMs: 20,
+      supervisor: { installed: () => true, start: () => undefined },
+    });
+    const second = await replacement;
+    running.push(second);
+
+    expect(dropped).toBe(true);
+    expect(state.pid).toBe(second.lease.pid);
+  });
+});


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3748 -->
🤖 **Re-seed trail** — #3748 on `afk/3748-the-mcp-client-restores-a-dropped-daemon`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3748; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3748 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/redskilled`]
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":36,"summary":"suspect-infra: `pnpm -C apps/dev test:invariants` exited 1 after 36ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. failing: FAIL tests/file-size-guard.test.ts > file-size ratchet — a split nothing enforces is a split that comes back > holds the live tree to the threshold and the shrink-only baseline —  - Array [] + Array [ +   Object { +     \"kind\": \"over-baseline\", +     \"lines\": 1061, +     \"path\": \"apps/redskilled/src/client.ts\", +     \"reason\": \"apps/redskilled/src/client.ts grew from 1003 to 1061 lines. The baseline is shrink-only: lower the number as the file is decomposed, never raise it.\", +   }, + ]   ❯ tests/file-size-guard.test.ts:46:7      44|         : `file-size ratchet: ${findings.length} finding(s).\\n${render…      45|           `Baseline: apps/dev/src/core/file-size-guard.ts (FILE_SIZE_B…      46|     ).toEqual([]);        |       ^      47|   });      48|   ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯","suspectInfra":true}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3748