### PR TITLE
fix: a Worker stop no longer holds the host daemon's socket for TimeoutStopSec

### DIFF
--- a/.changeset/stop-does-not-wedge-the-daemon.md
+++ b/.changeset/stop-does-not-wedge-the-daemon.md
@@ -1,0 +1,22 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+A Worker stop no longer takes the host's daemon off the air.
+
+The stop asked `systemctl --user stop <unit>` with `spawnSync` and waited for the
+job to finish. A runner that ignores SIGTERM does not finish it until systemd's
+`TimeoutStopSec` escalates — ninety seconds by default — and for all of that time
+the daemon that owns the machine's only socket answered nothing, so every session
+on the host read a routine `--once` Worker recycle as a dead daemon.
+
+- The stop request is placed with `--no-block` and spawned asynchronously, so the
+  event loop is never held: `ping`, `host-state` and every other read answer while
+  a stop is in flight. The death is still CONFIRMED before the caller is told — the
+  daemon escalates to the process-group teardown it already owned, on a five-second
+  grace of its own, rather than waiting on the init system's timeout.
+- Concurrent stops of the same Worker join one teardown, so a Worker is asked to
+  die once, its death reaches the event lane once, and its slot is given back once.
+  Stops of different Workers still overlap.
+- Worker units are created with `TimeoutStopSec=20`, so a stop the daemon is not
+  driving — an operator's, a shutdown's — also resolves in seconds.

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -332,6 +332,19 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const liveness = options.liveness ?? detectWorkerLiveness;
   const livenessGraceMs = options.livenessGraceMs ?? REDSKILLED_LIVENESS_GRACE_MS;
   const stopProbe = options.stopWorker ?? stopWorker;
+  /**
+   * The teardown each Worker is currently inside, keyed by its Worker id.
+   *
+   * A stop now yields to the event loop for as long as the host takes to
+   * confirm the death — which is the point — so two asks for the SAME Worker
+   * can overlap where a blocking stop accidentally serialised them. The map is
+   * what keeps the death bookkeeping exactly-once: the second ask joins the
+   * first's teardown instead of sending a second one, so one Worker is one
+   * death on the lane and one slot given back. Bounded by the live Worker set:
+   * an entry exists only while a teardown is in flight, and stops for DIFFERENT
+   * Workers still run at the same time.
+   */
+  const workerStops = new Map<string, Promise<boolean>>();
   const unitInventory = options.unitInventory ??
     (() =>
       maySweepMachine(paths.machineClaimPath, paths.machineClaimPathOfThisHost)
@@ -1502,17 +1515,44 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     orphanedRegistrations.delete(projectLabel);
   }
 
+  /**
+   * Tear one Worker down at most once, whoever asks and however often.
+   *
+   * `settle` is the daemon's own bookkeeping — forget the Worker, write its
+   * death, re-arm the idle gate — and it runs on the ONE teardown that actually
+   * happened, in the order it happened, never on a caller that merely joined.
+   * Every ask still gets the same truthful answer: the awaited promise resolves
+   * when the host has confirmed the death, not when the request was placed.
+   */
+  function endWorkerOnce(
+    worker: RedskilledWorkerView,
+    settle: (confirmed: boolean) => void,
+  ): Promise<boolean> {
+    const joined = workerStops.get(worker.worker_id);
+    if (joined != null) return joined;
+    const teardown = (async () => {
+      let confirmed = false;
+      // A refused stop still releases the daemon's claim; the caller's own event
+      // names what survived rather than forging host confirmation.
+      try { confirmed = (await stopProbe(worker)) === true; } catch {}
+      settle(confirmed);
+      return confirmed;
+    })().finally(() => {
+      if (workerStops.get(worker.worker_id) === teardown) workerStops.delete(worker.worker_id);
+    });
+    workerStops.set(worker.worker_id, teardown);
+    return teardown;
+  }
+
   /** Stop one Worker the daemon holds, and record its death. */
   async function stopWorkerNow(worker: RedskilledWorkerView, detail: string): Promise<boolean> {
-    let confirmed = false;
-    // A refused stop still releases the daemon's claim; the event names that the
-    // process group may survive rather than forging host confirmation.
-    try { confirmed = (await stopProbe(worker)) === true; } catch {}
-    forgetWorker(worker.worker_id);
-    const pgid = worker.pgid ?? worker.pid;
-    record("worker-death", worker, confirmed ? detail : `${detail}; unconfirmed-stop: the host did not confirm ` +
-      `process group ${pgid} stopped, so process group ${pgid} may still be alive`);
-    armIdleTimer();
+    await endWorkerOnce(worker, (confirmed) => {
+      forgetWorker(worker.worker_id);
+      const pgid = worker.pgid ?? worker.pid;
+      record("worker-death", worker, confirmed ? detail : `${detail}; unconfirmed-stop: the host did not confirm ` +
+        `process group ${pgid} stopped, so process group ${pgid} may still be alive`);
+      armIdleTimer();
+    });
     return true;
   }
 
@@ -1721,16 +1761,17 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   async function killWorkerOverBudget(workerId: string, detail: string): Promise<boolean> {
     const worker = workers.get(workerId);
     if (!worker) return false;
-    try {
-      await stopProbe(worker);
-    } catch {
-      // The kill is recorded either way: a stop the host refused still ends the
-      // daemon's claim on the budget, and a silent failure would leave the
-      // accounting holding room for a Worker nobody is tracking any more.
-    }
-    forgetWorker(workerId);
-    record("worker-budget-kill", worker, detail);
-    armIdleTimer();
+    // The kill is recorded either way: a stop the host refused still ends the
+    // daemon's claim on the budget, and a silent failure would leave the
+    // accounting holding room for a Worker nobody is tracking any more. It joins
+    // a teardown already in flight rather than starting a second one, so a floor
+    // tick that lands on a Worker a project is already stopping writes no second
+    // death and gives no second slot back.
+    await endWorkerOnce(worker, () => {
+      forgetWorker(workerId);
+      record("worker-budget-kill", worker, detail);
+      armIdleTimer();
+    });
     return true;
   }
 

--- a/apps/redskilled/src/reattach.ts
+++ b/apps/redskilled/src/reattach.ts
@@ -27,7 +27,7 @@
  *
  * The probes are injected, so both branches are provable without systemd.
  */
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { killTreeAndWait } from "@reddb-io/shared/kill-tree.js";
 import { isPidAlive } from "@reddb-io/shared/resident-core.js";
 import type { RedskilledWorkerView } from "./host-state.js";
@@ -41,7 +41,8 @@ export type RedskilledStopProbe = (worker: RedskilledWorkerView) => boolean | Pr
 
 /** Injectable host operations for a deterministic unit-teardown proof. */
 export interface RedskilledStopWorkerIO {
-  readonly stopUnit: (unit: string) => void;
+  /** Places the stop request; awaited, so a blocking implementation is refusable by type. */
+  readonly stopUnit: (unit: string) => void | Promise<void>;
   readonly unitActive: (unit: string) => boolean;
   readonly leaderAlive: (pid: number) => boolean;
   readonly killTree: (pgid: number) => boolean | Promise<boolean>;
@@ -283,6 +284,18 @@ export function nameUnownedProject(worker: RedskilledWorkerView): RedskilledWork
 }
 
 /**
+ * How long the daemon lets a stopping Worker leave on its own terms.
+ *
+ * `killTreeAndWait`'s own default grace is 2s, which is a teardown budget and
+ * not a shutdown budget: a runner asked to stop mid-turn has a transcript and a
+ * lock file to flush. Five seconds is long enough for that and short enough that
+ * a stop is still an operation an operator waits through, rather than the
+ * ninety-second `TimeoutStopSec` escalation the init system would otherwise be
+ * the only thing ending.
+ */
+const REDSKILLED_UNIT_STOP_GRACE_TRIES = 50;
+
+/**
  * Stop one Worker: the unit by name, or the recorded process group.
  *
  * A successful `systemctl stop` is only a request receipt: death is confirmed by
@@ -290,27 +303,57 @@ export function nameUnownedProject(worker: RedskilledWorkerView): RedskilledWork
  * less escalates through the same TERM→grace→KILL→confirm process-group teardown
  * as an unisolated Worker. Legacy records without `pgid` use the detached leader
  * pid, which is the group id by the launch contract.
+ *
+ * **The stop request is asked for, never waited on.** `systemctl --user stop`
+ * without `--no-block` does not return until the job finishes, and a job whose
+ * runner ignores SIGTERM does not finish until `TimeoutStopSec` escalates —
+ * ninety seconds by default. Spent inside the daemon that is the whole machine's
+ * only socket, that wait is the outage: the request is placed and the daemon
+ * then confirms the death itself, on its own grace, through the escalation it
+ * already owned. What replaced the init system's timeout is this function's, and
+ * it is measured in seconds.
  */
-export function stopWorker(
+export async function stopWorker(
   worker: RedskilledWorkerView,
   io: RedskilledStopWorkerIO = DEFAULT_STOP_WORKER_IO,
-): boolean | Promise<boolean> {
+): Promise<boolean> {
   if (worker.unit != null && worker.unit !== "") {
     try {
-      io.stopUnit(worker.unit);
+      await io.stopUnit(worker.unit);
     } catch {
       // A failed stop request still reaches the process-group escalation below.
     }
     if (!io.unitActive(worker.unit) && !io.leaderAlive(worker.pid)) return true;
   }
-  return io.killTree(worker.pgid ?? worker.pid);
+  return await io.killTree(worker.pgid ?? worker.pid);
+}
+
+/**
+ * The stop request, as argv — and `--no-block` is the whole of the fix.
+ *
+ * Without it `systemctl stop` returns when the JOB finishes, which for a runner
+ * that ignores SIGTERM is `TimeoutStopSec` later. Named here rather than written
+ * inline so the flag is pinnable: it is the difference between a stop and an
+ * outage, and nothing else in the argv carries any weight.
+ */
+export function redskilledUnitStopArgv(unit: string): readonly string[] {
+  return ["--user", "stop", "--no-block", unit];
 }
 
 const DEFAULT_STOP_WORKER_IO: RedskilledStopWorkerIO = {
-  stopUnit: (unit) => {
-    spawnSync("systemctl", ["--user", "stop", unit], { stdio: "ignore" });
+  // `spawn` rather than `spawnSync` so that even placing the request cannot hold
+  // the event loop. Neither the exit code nor the output is read: a refused stop
+  // is indistinguishable here from one the init system accepted and could not
+  // finish, and the only thing that settles either is the liveness escalation
+  // the caller runs next.
+  stopUnit: async (unit) => {
+    await new Promise<void>((resolve) => {
+      const request = spawn("systemctl", [...redskilledUnitStopArgv(unit)], { stdio: "ignore" });
+      request.once("error", () => resolve());
+      request.once("close", () => resolve());
+    });
   },
   unitActive: isUnitActive,
   leaderAlive: isPidAlive,
-  killTree: killTreeAndWait,
+  killTree: (pgid) => killTreeAndWait(pgid, { graceTries: REDSKILLED_UNIT_STOP_GRACE_TRIES }),
 };

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -43,6 +43,17 @@ export const REDSKILLED_PLACEMENT_ENV = "REDSKILLED_PLACEMENT";
 /** The unit-name prefix when a client states none. */
 export const DEFAULT_WORKER_UNIT_PREFIX = "red-worker";
 
+/**
+ * How long the init system waits for a stopping Worker before SIGKILL.
+ *
+ * systemd's default is ninety seconds, which is a budget for a database
+ * flushing to disk and not for an agent runner that never installed a SIGTERM
+ * handler in the first place. Twenty seconds is more than any Worker has been
+ * seen to need to leave on its own and short enough that a `deactivating` unit
+ * is a moment rather than an outage.
+ */
+export const REDSKILLED_WORKER_STOP_TIMEOUT_SEC = 20;
+
 export interface WorkerPlacementProbes {
   /** `process.platform` — transient units are a Linux backend. */
   readonly platform: NodeJS.Platform;
@@ -402,6 +413,13 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
     `--unit=${unit}`,
     `--working-directory=${opts.workspacePath}`,
     "--property=LimitCORE=0",
+    // A SIGTERM-deaf runner is the common case, not the exception, so the unit
+    // states its own escalation rather than inheriting the ninety-second default:
+    // whatever else is holding a stop — an operator's `systemctl stop`, a
+    // shutdown, a daemon that is gone — resolves it in twenty seconds. This is a
+    // floor under the host, not the daemon's own path: the daemon confirms a
+    // death on its own shorter grace and never waits on this timer.
+    `--property=TimeoutStopSec=${REDSKILLED_WORKER_STOP_TIMEOUT_SEC}`,
   ];
   // `--pipe` connects the unit's stdio to this process's, which is what makes an
   // inherited log fd reach the Worker at all. Without it a transient unit writes

--- a/apps/redskilled/tests/reattach-stop.test.ts
+++ b/apps/redskilled/tests/reattach-stop.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { RedskilledWorkerView } from "../src/host-state.js";
-import { stopWorker } from "../src/reattach.js";
+import { redskilledUnitStopArgv, stopWorker } from "../src/reattach.js";
 
 const UNIT_WORKER: RedskilledWorkerView = {
   worker_id: "wUNIT",
@@ -20,7 +20,9 @@ describe("unit-held Worker teardown", () => {
     const killedGroups: number[] = [];
 
     const contained = await stopWorker(UNIT_WORKER, {
-      stopUnit: (unit) => stoppedUnits.push(unit),
+      stopUnit: (unit) => {
+        stoppedUnits.push(unit);
+      },
       unitActive: () => false,
       leaderAlive: () => true,
       killTree: async (pgid) => {
@@ -32,5 +34,47 @@ describe("unit-held Worker teardown", () => {
     expect(stoppedUnits).toEqual(["red-worker-acme-wUNIT.service"]);
     expect(killedGroups).toEqual([4_343]);
     expect({ contained }).toEqual({ contained: false });
+  });
+
+  it("asks for the stop without waiting for the init system to finish it", () => {
+    // The daemon that sends this owns the whole machine's socket. A stop that
+    // waited for the job would hold that socket for `TimeoutStopSec` every time
+    // a SIGTERM-deaf runner was recycled, and every session on the host would
+    // read the silence as a dead daemon.
+    expect(redskilledUnitStopArgv("red-worker-acme-wUNIT.service")).toEqual([
+      "--user",
+      "stop",
+      "--no-block",
+      "red-worker-acme-wUNIT.service",
+    ]);
+  });
+
+  it("waits for a stop request that answers asynchronously before judging the unit", async () => {
+    const order: string[] = [];
+    let releaseRequest: () => void = () => undefined;
+    const placed = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+
+    const contained = stopWorker(UNIT_WORKER, {
+      stopUnit: async () => {
+        order.push("requested");
+        await placed;
+      },
+      // Read only after the request has been placed; a probe run before it would
+      // judge the unit on a stop nobody had asked for yet.
+      unitActive: () => {
+        order.push("probed");
+        return false;
+      },
+      leaderAlive: () => false,
+      killTree: () => true,
+    });
+
+    expect(order).toEqual(["requested"]);
+    releaseRequest();
+
+    expect(await contained).toBe(true);
+    expect(order).toEqual(["requested", "probed"]);
   });
 });

--- a/apps/redskilled/tests/stop-does-not-wedge-the-socket.test.ts
+++ b/apps/redskilled/tests/stop-does-not-wedge-the-socket.test.ts
@@ -1,0 +1,194 @@
+// One Worker stop took the whole machine's daemon off the air for ninety
+// seconds, and every MCP client on the host read that as a dead daemon.
+//
+// The stop asked `systemctl --user stop <unit>` and WAITED for the job to
+// finish. A runner that ignores SIGTERM does not finish it — the unit sits in
+// `deactivating (stop-sigterm)` until `TimeoutStopSec` escalates to SIGKILL —
+// and because the request was placed with `spawnSync`, the daemon's event loop
+// was held for the whole of it. Workers are `--once` and recycle constantly, so
+// this fired many times an hour, and each time a `ping` with a ten-second
+// deadline came back as "daemon unreachable".
+//
+// These checks pin the three things the fix owes: a read still answers while a
+// stop is in flight, the stop's own answer still means the host confirmed the
+// death, and one Worker is still one death however many callers ask at once.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readRedskilledHostState } from "../src/client.js";
+import { socketAnswers, startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { createRedskilledEventLane, readRedskilledEvents } from "../src/event-lane.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { sendRedskilledRequest, type RedskilledWorkerCommandResult } from "../src/protocol.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-stop-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+function workerView(): RedskilledWorkerView {
+  return {
+    worker_id: "w-sigterm-deaf",
+    project_label: "reddb-io/red-skills",
+    pid: 4_242,
+    pgid: 4_242,
+    started_at: "2026-08-11T10:00:00.000Z",
+    workspace_path: "/tmp/workspace",
+    isolated: true,
+    unit: "red-worker-reddb-io-red-skills-w-sigterm-deaf.service",
+    warnings: [],
+  };
+}
+
+/**
+ * A stop that has been asked for and has not come back — the wedge, posed.
+ *
+ * The daemon's real stop escalates to a process-group kill and resolves in
+ * seconds; what a test needs is the shape, not the duration, so the host's
+ * confirmation is a promise the test settles by hand. `entered` is how a check
+ * knows the daemon is genuinely inside the stop rather than about to be.
+ */
+function poseSlowStop() {
+  let confirm: (confirmed: boolean) => void = () => undefined;
+  let announceEntry: () => void = () => undefined;
+  const entered = new Promise<void>((resolve) => {
+    announceEntry = resolve;
+  });
+  const confirmed = new Promise<boolean>((resolve) => {
+    confirm = resolve;
+  });
+  let calls = 0;
+  return {
+    entered,
+    calls: () => calls,
+    confirm,
+    stopWorker: () => {
+      calls += 1;
+      announceEntry();
+      return confirmed;
+    },
+  };
+}
+
+/**
+ * Ask the daemon to stop one Worker, on the wire and with no client wrapper.
+ *
+ * The raw request is deliberate: it connects the instant it is called, so two of
+ * them reach the daemon in the order they were written, which is what lets an
+ * overlap be posed rather than hoped for.
+ */
+function commandStop(paths: RedskilledPaths, id: string): Promise<RedskilledWorkerCommandResult> {
+  return sendRedskilledRequest(
+    { socketPath: paths.socketPath, timeoutMs: 5_000 },
+    { id, op: "worker-command", command: { command: "stop", worker_id: "w-sigterm-deaf" } },
+  ).then((response) => {
+    if (!response.ok) throw new Error(response.error);
+    return response.value as RedskilledWorkerCommandResult;
+  });
+}
+
+/** Put one live Worker on the lane and adopt it into a fresh daemon. */
+async function daemonHoldingOneWorker(
+  paths: RedskilledPaths,
+  stopWorker: () => Promise<boolean>,
+): Promise<RedskilledDaemon> {
+  const lane = createRedskilledEventLane(paths.eventLanePath);
+  await lane.record({ event: "worker-birth", worker: workerView(), ts: "2026-08-11T10:00:00.000Z" });
+  const daemon = await startRedskilledDaemon({
+    paths,
+    idleMs: 60_000,
+    sampleMs: 0,
+    liveness: () => true,
+    stopWorker,
+    // The host running this suite has Workers of its own; the daemon under test
+    // holds exactly the one the lane gave it.
+    unitInventory: () => [],
+  });
+  running.push(daemon);
+  expect(daemon.workerCount()).toBe(1);
+  return daemon;
+}
+
+describe("a Worker stop the host is slow to confirm", () => {
+  it("answers ping and host-state while the stop is still in flight", async () => {
+    const paths = await sessionPaths();
+    const stop = poseSlowStop();
+    await daemonHoldingOneWorker(paths, stop.stopWorker);
+
+    const commanded = commandStop(paths, "stop-1");
+    await stop.entered;
+
+    // The reads that every session on the machine makes, taken at the one
+    // instant the old daemon could not take them. `socketAnswers` is the
+    // diagnosis's own probe: a bare `ping` with a quarter-second deadline, which
+    // a wedged dispatcher fails by saying nothing.
+    expect(await socketAnswers(paths.socketPath)).toBe(true);
+    const state = await readRedskilledHostState(paths);
+    // Still held: a Worker whose death nobody has confirmed is a Worker, and
+    // reporting the slot free here would let the next admission double-spend it.
+    expect(state.workers.map((worker) => worker.worker_id)).toEqual(["w-sigterm-deaf"]);
+
+    stop.confirm(true);
+    await commanded;
+  });
+
+  it("reports the stop applied only once the host confirmed the death", async () => {
+    const paths = await sessionPaths();
+    const stop = poseSlowStop();
+    const daemon = await daemonHoldingOneWorker(paths, stop.stopWorker);
+
+    const commanded = commandStop(paths, "stop-1");
+    await stop.entered;
+    // The acknowledgement is not a receipt for the request: while the host has
+    // confirmed nothing, the caller has been told nothing and the slot stands.
+    expect(daemon.workerCount()).toBe(1);
+
+    stop.confirm(true);
+    const result = await commanded;
+
+    expect({ applied: result.applied, command: result.command }).toEqual({ applied: true, command: "stop" });
+    expect(result.detail).toContain("redskilled stopped Worker");
+    expect(daemon.workerCount()).toBe(0);
+  });
+
+  it("records one death and frees one slot when two callers stop the same Worker at once", async () => {
+    const paths = await sessionPaths();
+    const stop = poseSlowStop();
+    const daemon = await daemonHoldingOneWorker(paths, stop.stopWorker);
+
+    const first = commandStop(paths, "stop-1");
+    await stop.entered;
+    const second = commandStop(paths, "stop-2");
+    // A round trip opened AFTER the second stop, and answered: the daemon takes
+    // its connections in the order they arrived, so an answer here is proof the
+    // second stop has already been dispatched and is genuinely overlapping the
+    // first rather than racing the confirmation below.
+    expect(await socketAnswers(paths.socketPath)).toBe(true);
+
+    stop.confirm(true);
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    await daemon.flushEvents();
+
+    // Both callers are answered truthfully — the Worker they asked about is
+    // gone — and the host was asked to kill it exactly once.
+    expect([firstResult.applied, secondResult.applied]).toEqual([true, true]);
+    expect(stop.calls()).toBe(1);
+    expect(daemon.workerCount()).toBe(0);
+    const events = await readRedskilledEvents(paths.eventLanePath);
+    expect(events.filter((event) => event.event === "worker-death")).toHaveLength(1);
+  });
+});

--- a/apps/redskilled/tests/worker-placement.test.ts
+++ b/apps/redskilled/tests/worker-placement.test.ts
@@ -9,6 +9,7 @@ import {
   placementEnabled,
   planWorkerPlacement,
   REDSKILLED_PLACEMENT_ENV,
+  REDSKILLED_WORKER_STOP_TIMEOUT_SEC,
   workerUnitName,
   type WorkerPlacementProbes,
 } from "../src/worker-placement.js";
@@ -109,6 +110,20 @@ describe("worker placement — Linux with a user session", () => {
         "--property=LimitCORE=0",
       ]);
     }
+  });
+
+  it("states its own stop timeout rather than inheriting systemd's ninety seconds", () => {
+    // A runner that ignores SIGTERM is the common case here, so a unit left on
+    // the default sits in `deactivating` for a minute and a half whenever
+    // anything on the host stops it. The unit carries the shorter escalation
+    // itself, so it holds for an operator's `systemctl stop` and for a daemon
+    // that is no longer there — not only for the path the daemon drives.
+    const placement = plan(LINUX_WITH_SESSION);
+    const placementArgs = placement.args.slice(0, placement.args.indexOf("--"));
+    expect(placementArgs.filter((arg) => arg.startsWith("--property=TimeoutStopSec="))).toEqual([
+      `--property=TimeoutStopSec=${REDSKILLED_WORKER_STOP_TIMEOUT_SEC}`,
+    ]);
+    expect(REDSKILLED_WORKER_STOP_TIMEOUT_SEC).toBeLessThan(90);
   });
 
   it("carries max_processes as TasksMax exactly when it is declared", () => {


### PR DESCRIPTION
The daemon read as "dying toda hora": every MCP client ping (10s deadline) reported it unreachable, in bursts, many times an hour. Diagnosed live on the maintainer's host, then fixed.

## Root cause

Not a crash and not an op queue — `stopUnit` ran `spawnSync("systemctl", ["--user", "stop", unit])` inside the daemon's single thread (`reattach.ts`). Without `--no-block`, `systemctl stop` returns only when the *job* finishes; a SIGTERM-deaf runner (codex) makes that `TimeoutStopSec` = 90s. For those 90 seconds the event loop is gone — accept, ops, timers, everything — and since `--once` Workers recycle constantly, the wedge fired on every recycle. The moment systemd's SIGKILL landed, ping answered in 0.00s again.

## Fix

- `stopUnit` places the request with `systemctl --user stop --no-block` (async spawn) and the daemon confirms the death itself through the TERM→grace→KILL→confirm escalation it already owned, with the grace raised to 5s — `applied: true` still means the host confirmed the death, it just arrives in seconds instead of 90.
- The accidental one-teardown-at-a-time serialization becomes explicit: `workerStops` dedupes concurrent stops per Worker (`endWorkerOnce`), so a budget kill landing on a Worker a project is already stopping writes one death and frees one slot. Different Workers still overlap.
- Worker units now carry `TimeoutStopSec=20` as a floor under paths the daemon does not own (operator stop, host shutdown).

## Tests

`stop-does-not-wedge-the-socket.test.ts` drives the diagnosis's own probe: bare `ping` on the wire with a 250ms deadline while a stop the host is slow to confirm is in flight. Plus: stop applied only on confirmed death, exactly-once bookkeeping under concurrent stops (verified red without the `lifecycle.ts` change), non-blocking stop argv, async stop confirmation, and the unit timeout property. `apps/redskilled` typecheck and repo-wide typecheck/lint clean; the 77 pre-existing environment-dependent test failures on the diagnosis host are byte-identical between this branch and main.

Out of scope, worth follow-ups: the codex runner ignoring SIGTERM (`apps/dev`), and the MCP client's 10s ping deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789133476&installation_model_id=20659&pr_number=3752&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3752&signature=283311e31729a9314f5404ea478013507289b412fbe505fa3cf05bbabcb65f05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->