### PR TITLE
fix: CI installs tq from the GitHub release and the cone contract names a package still outside the cone

### DIFF
--- a/.github/workflows/red-rsp-benchmark-ci.yml
+++ b/.github/workflows/red-rsp-benchmark-ci.yml
@@ -27,13 +27,21 @@ jobs:
         with:
           node-version: 22
 
+      # From the GitHub release, not crates.io — same reasoning and same
+      # step shape as red-workspace-ci.yml, where the story of the lapsed
+      # crates token is told in full.
       - name: Install pinned tq
         env:
           TQ_VERSION: v0.22.0
         run: |
           set -euo pipefail
           tq_root="$RUNNER_TEMP/tq"
-          cargo install reddb-io-tq --version "${TQ_VERSION#v}" --locked --root "$tq_root"
+          mkdir -p "$tq_root/bin"
+          base="https://github.com/reddb-io/tq/releases/download/${TQ_VERSION}"
+          curl -fsSL --retry 3 -o "$tq_root/bin/tq" "$base/tq-linux-x86_64-static"
+          curl -fsSL --retry 3 -o "$tq_root/tq.sha256" "$base/tq-linux-x86_64-static.sha256"
+          echo "$(cut -d' ' -f1 "$tq_root/tq.sha256")  $tq_root/bin/tq" | sha256sum -c -
+          chmod +x "$tq_root/bin/tq"
           echo "$tq_root/bin" >> "$GITHUB_PATH"
           "$tq_root/bin/tq" --version
 

--- a/.github/workflows/red-rsp-benchmark-ci.yml
+++ b/.github/workflows/red-rsp-benchmark-ci.yml
@@ -38,8 +38,8 @@ jobs:
           tq_root="$RUNNER_TEMP/tq"
           mkdir -p "$tq_root/bin"
           base="https://github.com/reddb-io/tq/releases/download/${TQ_VERSION}"
-          curl -fsSL --retry 3 -o "$tq_root/bin/tq" "$base/tq-linux-x86_64-static"
-          curl -fsSL --retry 3 -o "$tq_root/tq.sha256" "$base/tq-linux-x86_64-static.sha256"
+          scripts/ci-fetch-with-retry.sh "$base/tq-linux-x86_64-static" "$tq_root/bin/tq"
+          scripts/ci-fetch-with-retry.sh "$base/tq-linux-x86_64-static.sha256" "$tq_root/tq.sha256"
           echo "$(cut -d' ' -f1 "$tq_root/tq.sha256")  $tq_root/bin/tq" | sha256sum -c -
           chmod +x "$tq_root/bin/tq"
           echo "$tq_root/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -242,6 +242,13 @@ jobs:
       # the real binary against produced TOONL lane files), so the required host
       # binary must exist here exactly as it does on dev machines (/red-setup)
       # and in red-rsp-benchmark-ci.yml. Same pinned installer, no fallback.
+      #
+      # From the GitHub release, not crates.io. tq's crates publish runs on a
+      # token that can lapse independently of the release itself — it did, at
+      # 0.21.0, with a 403 nobody saw — and when it lapses `cargo install`
+      # takes every branch of this repository down with it. The release asset
+      # is published by the same tag that would have fed crates.io, carries a
+      # checksum, and skips a full cargo build besides.
       - name: Install pinned tq
         if: env.RUN_DEV == 'true'
         env:
@@ -249,7 +256,12 @@ jobs:
         run: |
           set -euo pipefail
           tq_root="$RUNNER_TEMP/tq"
-          cargo install reddb-io-tq --version "${TQ_VERSION#v}" --locked --root "$tq_root"
+          mkdir -p "$tq_root/bin"
+          base="https://github.com/reddb-io/tq/releases/download/${TQ_VERSION}"
+          curl -fsSL --retry 3 -o "$tq_root/bin/tq" "$base/tq-linux-x86_64-static"
+          curl -fsSL --retry 3 -o "$tq_root/tq.sha256" "$base/tq-linux-x86_64-static.sha256"
+          echo "$(cut -d' ' -f1 "$tq_root/tq.sha256")  $tq_root/bin/tq" | sha256sum -c -
+          chmod +x "$tq_root/bin/tq"
           echo "$tq_root/bin" >> "$GITHUB_PATH"
           "$tq_root/bin/tq" --version
 

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -258,8 +258,8 @@ jobs:
           tq_root="$RUNNER_TEMP/tq"
           mkdir -p "$tq_root/bin"
           base="https://github.com/reddb-io/tq/releases/download/${TQ_VERSION}"
-          curl -fsSL --retry 3 -o "$tq_root/bin/tq" "$base/tq-linux-x86_64-static"
-          curl -fsSL --retry 3 -o "$tq_root/tq.sha256" "$base/tq-linux-x86_64-static.sha256"
+          scripts/ci-fetch-with-retry.sh "$base/tq-linux-x86_64-static" "$tq_root/bin/tq"
+          scripts/ci-fetch-with-retry.sh "$base/tq-linux-x86_64-static.sha256" "$tq_root/tq.sha256"
           echo "$(cut -d' ' -f1 "$tq_root/tq.sha256")  $tq_root/bin/tq" | sha256sum -c -
           chmod +x "$tq_root/bin/tq"
           echo "$tq_root/bin" >> "$GITHUB_PATH"

--- a/apps/dev/tests/ci-fetch-retry.test.ts
+++ b/apps/dev/tests/ci-fetch-retry.test.ts
@@ -144,19 +144,27 @@ describe("ci-fetch-with-retry", () => {
 });
 
 describe("CI setup network fetches", () => {
-  it("installs workspace-CI tq from the pinned official crate", async () => {
+  // From the pinned official GitHub release, no longer the crate: tq's
+  // crates.io publish runs on a token that lapsed at 0.21.0 (403, unseen)
+  // and `cargo install` took every branch of this repository down with it.
+  // The pin's guarantees carry over — one official binary, one pinned tag,
+  // checksum-verified, fetched through the shared retrying fetcher.
+  it("installs workspace-CI tq from the pinned official release", async () => {
     const step = stepBody(await readWorkflow("red-workspace-ci.yml"), "Install pinned tq");
 
-    expect(step).toContain('cargo install reddb-io-tq --version "${TQ_VERSION#v}" --locked');
+    expect(step).toContain('scripts/ci-fetch-with-retry.sh "$base/tq-linux-x86_64-static"');
+    expect(step).toContain("https://github.com/reddb-io/tq/releases/download/${TQ_VERSION}");
+    expect(step).toContain("sha256sum -c -");
     expect(step).toContain('tq_root="$RUNNER_TEMP/tq"');
     expect(step).not.toContain("../toon");
     expect(step).not.toContain("curl ");
   });
 
-  it("installs benchmark-CI tq from the pinned official crate", async () => {
+  it("installs benchmark-CI tq from the pinned official release", async () => {
     const step = stepBody(await readWorkflow("red-rsp-benchmark-ci.yml"), "Install pinned tq");
 
-    expect(step).toContain('cargo install reddb-io-tq --version "${TQ_VERSION#v}" --locked');
+    expect(step).toContain('scripts/ci-fetch-with-retry.sh "$base/tq-linux-x86_64-static"');
+    expect(step).toContain("sha256sum -c -");
     expect(step).toContain('"$tq_root/bin/tq" --version');
     expect(step).not.toContain("../toon");
     expect(step).not.toContain("curl ");

--- a/scripts/test-ci-affected-scope.sh
+++ b/scripts/test-ci-affected-scope.sh
@@ -63,7 +63,13 @@ assert_field "$shared" "s.mode" "cone" "shared-package change stays in cone mode
 assert_field "$shared" "s.testPackages.includes('packages/shared')" "true" "shared cone includes the touched package"
 assert_field "$shared" "s.testPackages.includes('apps/dev')" "true" "shared cone includes apps/dev (a dependent)"
 assert_field "$shared" "s.testPackages.includes('apps/opencode-host')" "true" "shared cone includes apps/opencode-host (a dependent)"
-assert_field "$shared" "s.testPackages.includes('apps/afk-container')" "false" "shared cone excludes an unrelated package"
+# red-browser, not afk-container: the "unrelated" example has to be a package
+# with no path to packages/shared in the workspace graph, and afk-container
+# stopped being one when packages/github (its dependency) took a dependency on
+# shared. red-browser's workspace deps are the browser-bridge/cdp-driver pair,
+# neither of which reaches shared. If this assertion trips, first check whether
+# the example rotted the same way before suspecting the cone computation.
+assert_field "$shared" "s.testPackages.includes('apps/red-browser')" "false" "shared cone excludes an unrelated package"
 
 # ---------- unclassifiable / global-blast-radius changes ----------
 

--- a/scripts/test-workflow-security-pins.sh
+++ b/scripts/test-workflow-security-pins.sh
@@ -51,15 +51,23 @@ grep -qF 'ref: ${{ github.event.pull_request.base.sha || github.event.repository
 grep -qF 'ref: ${{ github.event.pull_request.base.sha }}' .github/workflows/archive/red-hitl-card.yml ||
   fail "red-hitl-card.yml must checkout the base PR SHA before running the launcher"
 
+# The pinned official tq, from its GitHub release rather than crates.io.
+# The crates publish runs on a token that lapses independently of the
+# release itself — it did, at 0.21.0, with a 403 nobody saw, and
+# `cargo install` took every branch of this repository down with it.
+# What the pin has to guarantee is unchanged: one official binary, one
+# pinned tag, checksum-verified, no fallback and no sibling checkout.
 for workflow in \
   .github/workflows/red-workspace-ci.yml \
   .github/workflows/red-rsp-benchmark-ci.yml; do
-  grep -qF 'cargo install reddb-io-tq --version "${TQ_VERSION#v}" --locked --root "$tq_root"' "$workflow" ||
-    fail "$workflow must install the pinned official reddb-io-tq crate"
+  grep -qF 'https://github.com/reddb-io/tq/releases/download/${TQ_VERSION}' "$workflow" ||
+    fail "$workflow must install the pinned official tq release"
+  grep -qF 'sha256sum -c -' "$workflow" ||
+    fail "$workflow must verify the downloaded tq binary against its published checksum"
   grep -qF 'tq_root="$RUNNER_TEMP/tq"' "$workflow" ||
-    fail "$workflow must isolate the tq package-manager prefix under RUNNER_TEMP"
+    fail "$workflow must isolate the tq install prefix under RUNNER_TEMP"
   grep -qF '"$tq_root/bin/tq" --version' "$workflow" ||
-    fail "$workflow must verify the package-manager-installed tq binary"
+    fail "$workflow must verify the installed tq binary runs"
   if grep -qE '(\.\./toon|target/debug/tq|path = .*toon)' "$workflow"; then
     fail "$workflow must not source tq from a sibling checkout or local build"
   fi


### PR DESCRIPTION
Every branch in this repository is currently red for two reasons that have nothing to do with any of them:

1. **`cargo install reddb-io-tq --version 0.22.0` fails** — crates.io stopped at 0.21.0 because tq's crates publish has been dying with `403 Forbidden: authentication failed` (see reddb-io/tq's Release runs; the `CARGO_REGISTRY_TOKEN` needs rotating). The install now pulls `tq-linux-x86_64-static` from the GitHub release for the same pinned tag, verifies its published sha256, and skips a cargo build besides. Verified locally: checksum OK, `tq 0.22.0`.

2. **The affected-scope contract's "unrelated package" rotted.** `packages/github` took a dependency on `packages/shared` (afk/3723), which made `apps/afk-container` a transitive dependent — so "shared cone excludes an unrelated package" started failing everywhere. The example is now `apps/red-browser` (browser-bridge/cdp-driver only, no path to shared), with a comment telling the next reader to check for the same rot before suspecting the cone computation. All 58 contract assertions pass locally.

Rotating tq's crates.io token still matters for `cargo install` users, but this repository's CI no longer goes down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789134262&installation_model_id=20659&pr_number=3754&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3754&signature=a78a18b65c3ae9b74eaaacbb723a7375b5d3817517d7d73243772ad86ce31248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->