### PR TITLE
fix: loc outlives every other vital on the statusline Worker row

### DIFF
--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -539,6 +539,17 @@ function stalenessMark(payload: RedskilledRenderPayload): string {
 }
 
 /**
+ * Which columns yield first when a Worker row exceeds the width budget.
+ * Free-text tallies go before whole-run counters, and `loc` — the diff the
+ * Worker produced, the one cell that answers "what did it do?" — outlives
+ * every other vital. Identity/liveness columns (wid, iss, phase, hb) are
+ * deliberately absent: they fall only to the positional fallback.
+ */
+const WORKER_COLUMN_DROP_ORDER: readonly RedskilledDashboardColumn[] = [
+  "txt", "rsn", "ctx", "tks", "tls", "eta", "base", "elapsed", "run", "org", "loc",
+];
+
+/**
  * One coloured, aligned Worker row. The values come from the dashboard's cell
  * composer; this density owns only colour and width.
  */
@@ -562,6 +573,16 @@ function renderWorkerRows(
     rows.some((row) => width(row[column]) > 0));
   const columns = [...populated];
   let widths = workerWidths(rows, columns);
+  // Width pressure sheds annotations before results: the positional tail-pop
+  // this replaces ate `loc` — the Worker's actual work product — while keeping
+  // free-text counters, because the vitals happen to sit last in column order.
+  for (const drop of WORKER_COLUMN_DROP_ORDER) {
+    if (columns.length <= 1 || workerRowWidth(widths, columns) <= options.maxWidth) break;
+    const at = columns.indexOf(drop);
+    if (at < 0) continue;
+    columns.splice(at, 1);
+    widths = workerWidths(rows, columns);
+  }
   while (columns.length > 1 && workerRowWidth(widths, columns) > options.maxWidth) {
     columns.pop();
     widths = workerWidths(rows, columns);

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -308,6 +308,17 @@ describe("the statusline Worker table (#3151)", () => {
     expect(row).toContain("ctx=108k");
     expect(row).toContain("hb=3s");
   });
+
+  it("keeps loc on the row at the default width — annotations yield first", () => {
+    // The regression this pins: at maxWidth 120 the positional tail-pop ate
+    // loc/tls/rsn/txt while keeping eta and base, so a Worker deep in a big
+    // diff rendered as if it had produced nothing.
+    const doc = payload({ workers: [worker({ display: display({ added: 1394, removed: 7397 }) })] });
+    const row = stripAnsi(renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 120 }).lines[1]!);
+    expect(row).toContain("loc=+1394 -7397");
+    expect(row).toContain("hb=3s");
+    expect(row).toContain("iss=3096");
+  });
 });
 
 describe("the coloured panel and dashboard (#3152)", () => {


### PR DESCRIPTION
Explicit width-pressure drop order in the Worker row renderer: annotations (txt, rsn, ctx, tks) yield first, loc last — the diff a Worker produced is the one cell that answers what it did. Pinned by test at the default width. Rides the 3.17.1 train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrKC117zw4RxnBrTysaeAp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789146613&installation_model_id=20659&pr_number=3760&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3760&signature=5bbcbf067333093738d41a4e838ce4a8b906d729206f4b4cd0dee4ccff54d555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->