### PR TITLE
fix: rsp self-re-invocation keeps its runtime flags; fast-fallback bound measures the mechanism

### DIFF
--- a/apps/rsp/src/rsp-cli.ts
+++ b/apps/rsp/src/rsp-cli.ts
@@ -10,5 +10,10 @@ function isRspOnPath(): boolean {
 
 export function resolveRspInvocationPrefix(): string[] {
   if (isRspOnPath()) return ["rsp"];
-  return [process.execPath, process.argv[1]!];
+  // Re-invoking this entry must keep the runtime flags it was started with
+  // (e.g. `--import tsx` when running from source): `[execPath, argv[1]]`
+  // alone re-runs a loader-dependent entry without its loader, and the inner
+  // invocation dies with ERR_MODULE_NOT_FOUND instead of executing. For the
+  // shipped bundle execArgv is empty, so this is byte-identical there.
+  return [process.execPath, ...process.execArgv, process.argv[1]!];
 }

--- a/apps/rsp/tests/cli-resident.test.ts
+++ b/apps/rsp/tests/cli-resident.test.ts
@@ -55,6 +55,7 @@ import {
   spawn,
   startHungOldResident,
   stat,
+  TEST_RESIDENT_READY_TIMEOUT_MS,
   stopTrackedResidents,
   telemetrySpoolPath,
   tempRoot,
@@ -224,14 +225,23 @@ describe("rsp cli", () => {
     await waitForResidentSocket(root);
 
     const raw = runGit(["-C", root, "log"]);
-    const node = timedStatus(runNodeNoop);
     const wrapped = timedStatus(() => runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir }));
 
     expect(wrapped.status, `${wrapped.stdout.toString("utf8")}${wrapped.stderr.toString("utf8")}`).toBe(0);
     expect(wrapped.stderr).toEqual(Buffer.alloc(0));
     expect(wrapped.stdout.length).toBeLessThan(raw.stdout.length);
     expect(wrapped.stdout.toString("utf8")).toContain("recovery unavailable (resident cold) — re-run: git log");
-    expect(wrapped.elapsedMs - node.elapsedMs).toBeLessThan(normalizedDurationMs(250));
+    // The guarded regression is WAITING: a wrapper that blocks on the hung
+    // store open sits out the full resident ready timeout (the same
+    // normalized RSP_RESIDENT_READY_TIMEOUT_MS this child inherits), while
+    // the fallback path completes in ordinary cold-spawn time. Half the
+    // ready timeout separates the two decisively on any host; a wall-clock
+    // delta bound (formerly 250ms over a node-noop baseline) does not — a
+    // cold CI runner spends multiple seconds legitimately spawning the
+    // bundle and rendering `git log` (#3625 round 3).
+    expect(wrapped.elapsedMs, "fallback must not wait on the resident ready timeout").toBeLessThan(
+      TEST_RESIDENT_READY_TIMEOUT_MS / 2,
+    );
     await sendResidentRequest({ socketPath: paths.socketPath, timeoutMs: 200 }, {
       id: randomUUID(),
       op: "handover",

--- a/apps/rsp/tests/cli.helpers.ts
+++ b/apps/rsp/tests/cli.helpers.ts
@@ -184,7 +184,7 @@ function normalizedDeadlineMs(durationMs = 5_000): number {
 }
 
 const TEST_TELEMETRY_DRAIN_TIMEOUT_MS = normalizedTimeoutMs(TEST_NODE_NOOP_BASELINE_MS, 250, 2_000);
-const TEST_RESIDENT_READY_TIMEOUT_MS = normalizedDurationMs(10_000);
+export const TEST_RESIDENT_READY_TIMEOUT_MS = normalizedDurationMs(10_000);
 
 function testChildEnv(env: Record<string, string> = {}): NodeJS.ProcessEnv {
   return {

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -668,9 +668,12 @@ describe("rsp binary resolution guard", () => {
     });
 
     expect(res.status).toBe(0);
+    // The self-entry fallback keeps the runtime flags this process was
+    // started with (`--import` tsx here): without them the re-invocation of
+    // a loader-dependent entry cannot even load.
     expect(JSON.parse(res.stdout.toString("utf8"))).toMatchObject({
       hookSpecificOutput: {
-        updatedInput: { command: `${process.execPath} ${cli} proxy -- 'git status'` },
+        updatedInput: { command: `${process.execPath} --import ${tsxLoader} ${cli} proxy -- 'git status'` },
       },
     });
     const events = await readSpoolEvents(root);


### PR DESCRIPTION
Closes the last two reds of the rsp CI job's integration step (first-ever runner execution). The redirect one was a real product bug: the self-re-invocation prefix dropped process.execArgv, so any host without an rsp PATH shim re-entered source runs loaderless and emitted nothing. The timing one now bounds against the resident ready timeout instead of raw wall-clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrKC117zw4RxnBrTysaeAp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789146910&installation_model_id=20659&pr_number=3761&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3761&signature=a0ddcf983a00b6cecfc03c5dba66cb2fb0444e15d567b8b838f2bac157fbdf36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->