### PR TITLE
fix: toon-watch writes the lockfile with a full install

### DIFF
--- a/.github/workflows/red-toon-watch.yml
+++ b/.github/workflows/red-toon-watch.yml
@@ -107,11 +107,13 @@ jobs:
           pnpm -C apps/dev dev toon-bump "$TARGET_VERSION"
           # `--no-frozen-lockfile` is not a loosening: pnpm turns frozen ON by
           # itself when CI=true, so the one command whose whole job is to WRITE
-          # the lockfile ran forbidden from writing it. The bump had never been
-          # exercised — three green days in a row were days with no release, and
-          # the first real one died on `no entry for '@reddb-io/toon@0.13.2'`,
-          # the version the previous line had just written into the catalog.
-          pnpm install --lockfile-only --no-frozen-lockfile
+          # the lockfile ran forbidden from writing it. A full install, not
+          # `--lockfile-only`: with only a catalog edit to look at, pnpm 11's
+          # up-to-date check skips resolution entirely under `--lockfile-only`
+          # and reports Done with the new version still absent — which is how
+          # the first post-outage bump died on `no entry for
+          # '@reddb-io/toon@0.25.0'` in the very next pnpm invocation.
+          REDDB_SKIP_POSTINSTALL=1 pnpm install --no-frozen-lockfile
           # The pi skill mirrors restate the derived pin sites, so `pi:packages:check` reddens on
           # any bump that does not regenerate them.
           pnpm pi:packages:build

--- a/apps/dev/tests/red-toon-watch-workflow.test.ts
+++ b/apps/dev/tests/red-toon-watch-workflow.test.ts
@@ -42,7 +42,11 @@ describe("red-toon-watch workflow contract", () => {
     expect(resolveRelease).toContain('echo "changed=false"');
     expect(bump).toContain("if: steps.release.outputs.changed == 'true'");
     expect(bump).toContain('pnpm -C apps/dev dev toon-bump "$TARGET_VERSION"');
-    expect(bump).toContain("pnpm install --lockfile-only");
+    // A full install, never `--lockfile-only`: under CI=true with only a
+    // catalog edit, pnpm 11 skips resolution for lockfile-only runs and the
+    // bumped version never reaches pnpm-lock.yaml.
+    expect(bump).toContain("pnpm install --no-frozen-lockfile");
+    expect(bump).not.toMatch(/pnpm install [^\n]*--lockfile-only/);
   });
 
   it("force-updates one rolling PR with trigger tag and sanitized release notes", async () => {


### PR DESCRIPTION
The first post-outage toon bump (0.22.0 -> 0.25.0, run 14:33 today) died on
`ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY: no entry for '@reddb-io/toon@0.25.0'`.

The bump verb rewrote every pin site correctly. The step that was supposed to
write the lockfile — `pnpm install --lockfile-only --no-frozen-lockfile` — reported
Done without resolving anything: under pnpm 11, a lockfile-only run whose only
change is a catalog edit passes the up-to-date check and skips resolution, so the
new version never reaches pnpm-lock.yaml. The next pnpm invocation
(`pi:packages:build`'s deps check) then finds the catalog and lockfile disagreeing
and fails.

Reproduced locally in a fresh clone under CI=true: `--lockfile-only` leaves zero
`@reddb-io/toon@0.26.2` entries; a full `pnpm install --no-frozen-lockfile`
resolves and writes them. The workflow now runs the full install (with
REDDB_SKIP_POSTINSTALL=1, same as the setup step), and the workflow contract test
pins the new shape.

After merge, dispatching red-toon-watch will produce the rolling bump PR to the
current stable (v0.26.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789148825&installation_model_id=20659&pr_number=3762&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3762&signature=cb946e42ea588c10da35a1a1b135f5ed1222aa0bd5b7150dca7be595b2b1e2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->