### PR TITLE
fix: the quota wait aims at the reset, every GitHub call carries a deadline, and the budget gate is off by default

### DIFF
--- a/apps/dev/src/runtime/gh/band.ts
+++ b/apps/dev/src/runtime/gh/band.ts
@@ -32,9 +32,11 @@
 // most one socket round trip per cadence — the same reason the balance is polled
 // rather than checked before each call (ADR 0084's lesson).
 
+import { resolveGithubBudgetGateMode } from "./budget-gate-config.js";
 import {
   admitGithubOperation,
   balanceFromReport,
+  githubBudgetGateEnabled,
   createGithubCache,
   describeGithubCacheRead,
   githubBalanceCadenceMs,
@@ -205,6 +207,13 @@ let defaultGate: GhBandGate | null = null;
  */
 export function resolveGhBandGate(injected?: GhBandGate): GhBandGate {
   if (injected) return injected;
+  // **OFF BY DEFAULT, and opt-in by config** (`github.budget_gate`). The band's
+  // ordering is still right when an operator wants it, but the quota belongs to
+  // whoever owns the token: a client that refuses a read because ITS reading of
+  // a balance says so is deciding how an operator may spend their own budget. It
+  // is also the second half of #3768 — a gate must first HAVE a balance, so
+  // every read waited on the ask, and a stalled ask wedged reads unrelated to it.
+  if (!githubBudgetGateEnabled(resolveGithubBudgetGateMode())) return OPEN_GH_BAND_GATE;
   defaultGate ??= createGhBandGate({ readBalance: daemonGhBalanceReader() });
   return defaultGate;
 }

--- a/apps/dev/src/runtime/gh/budget-gate-config.ts
+++ b/apps/dev/src/runtime/gh/budget-gate-config.ts
@@ -1,0 +1,77 @@
+// gh/budget-gate-config.ts — where `github.budget_gate` is read from.
+//
+// The switch itself lives in `@reddb-io/github` (`budget-gate.ts`); this module
+// is only the layering, because a library that went looking for a repository's
+// `.red/config.yaml` would be a second reader of a document the consumer owns.
+//
+// **Three layers, most specific first**: the env, then this repository, then the
+// operator's host file. The env is a single run's answer, the repository's file
+// is the project's, and `~/.red/config.yaml` is the machine's — an operator who
+// wants the band everywhere states it once, and a repository that needs it can
+// still say so alone.
+//
+// **Unreadable is `off`.** This is consulted on the path that decides whether
+// GitHub gets asked at all, so a malformed YAML file must not be the thing that
+// starts refusing an operator's own reads. Every failure resolves to the default.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+import {
+  DEFAULT_GITHUB_BUDGET_GATE,
+  GITHUB_BUDGET_GATE_ENV,
+  githubBudgetGate,
+  type GithubBudgetGateMode,
+} from "@reddb-io/github";
+import { configFile } from "@reddb-io/shared/red-paths.js";
+
+/** Resolved once per process: this is read per gh call and is a file read. */
+let cached: GithubBudgetGateMode | null = null;
+
+/**
+ * The mode this process runs under. PURE apart from the two file reads it caches.
+ *
+ * `root` and `env` are injectable so a test states its own layering rather than
+ * writing to the operator's real home directory.
+ */
+export function resolveGithubBudgetGateMode(options: {
+  readonly root?: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  /** Bypass the process cache; tests that vary the layering need this. */
+  readonly fresh?: boolean;
+} = {}): GithubBudgetGateMode {
+  if (!options.fresh && cached !== null) return cached;
+  const env = options.env ?? process.env;
+  const declared = env[GITHUB_BUDGET_GATE_ENV];
+  const resolved = declared !== undefined && declared.trim() !== ""
+    ? githubBudgetGate(declared)
+    : githubBudgetGate(
+      readDeclaredGate(configFile(options.root ?? process.cwd())) ??
+        readDeclaredGate(join(homedir(), ".red", "config.yaml")),
+    );
+  if (!options.fresh) cached = resolved;
+  return resolved;
+}
+
+/** Forget the cached mode. For tests, and for a config reload. */
+export function forgetGithubBudgetGateMode(): void {
+  cached = null;
+}
+
+/** The `github.budget_gate` value a config file declares, or `undefined`. */
+function readDeclaredGate(path: string): unknown {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(readFileSync(path, "utf8"));
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const github = (parsed as Record<string, unknown>).github;
+  if (typeof github !== "object" || github === null) return undefined;
+  const declared = (github as Record<string, unknown>).budget_gate;
+  return declared === undefined ? undefined : declared;
+}
+
+export { DEFAULT_GITHUB_BUDGET_GATE };

--- a/apps/dev/src/runtime/gh/quota-reset-probe.ts
+++ b/apps/dev/src/runtime/gh/quota-reset-probe.ts
@@ -1,0 +1,49 @@
+// gh/quota-reset-probe.ts — the reset instant a quota wait aims at.
+//
+// `withGhQuotaBackoff` has always described "one free probe per wait": sleep
+// until the drained pool actually refills, and retry once, instead of pacing
+// blind. The probe was never installed by the production factory — `probeResetMs`
+// had no default — so every real quota wait in the tree fell through to the
+// doubling fallback: 60s, 120s, 240s, 480s, then ten-minute silences under a
+// thirty-minute cap. That is the fifteen-minute `queue_status` of #3768. It was
+// not a deadlock and nothing was broken: the call was asleep, on purpose, for a
+// duration nobody chose, and returned the right answer when it woke.
+//
+// **The reset is already known, host-wide and free.** The daemon polls
+// `GET /rate_limit` for the whole machine, so the answer costs this process a
+// unix-socket read rather than a request — which is the reason to aim rather
+// than to guess. An absent daemon yields `null` and the fallback still paces the
+// retries, one rung at a time.
+
+import { daemonGhBalanceReader, type GhBalanceReader } from "./band.js";
+import type { GithubRateBudget } from "@reddb-io/github";
+
+/** Pools in the order a blind caller cares about: the tightest window first. */
+const PROBE_POOLS: readonly GithubRateBudget[] = ["search", "graphql", "rest"];
+
+/**
+ * When the drained pool next refills, in epoch ms — or `null` when unknown.
+ *
+ * The soonest reset across the pools is the honest answer to an unattributed
+ * rate limit: the caller's response said "you are limited" without saying which
+ * ledger, and waiting for the LATEST reset would sit out a window that had
+ * already reopened. A retry that arrives early costs one refused request and one
+ * more rung; a retry that arrives ten minutes late costs ten minutes.
+ */
+export function createDaemonQuotaResetProbe(
+  readBalance: GhBalanceReader = daemonGhBalanceReader(),
+): () => Promise<number | null> {
+  return async (): Promise<number | null> => {
+    const balance = await readBalance();
+    if (balance == null) return null;
+    let soonest: number | null = null;
+    for (const pool of PROBE_POOLS) {
+      const observed = balance.pools[pool];
+      if (observed == null || observed.reset_at === "") continue;
+      const resetMs = Date.parse(observed.reset_at);
+      if (!Number.isFinite(resetMs)) continue;
+      if (soonest === null || resetMs < soonest) soonest = resetMs;
+    }
+    return soonest;
+  };
+}

--- a/apps/dev/src/runtime/gh/quota.ts
+++ b/apps/dev/src/runtime/gh/quota.ts
@@ -20,6 +20,7 @@
 
 import { isGithubQuotaText } from "@reddb-io/shared/github-quota.js";
 
+import { createDaemonQuotaResetProbe } from "./quota-reset-probe.js";
 import type { ExecOutput } from "../exec.js";
 
 // The quota taxonomy itself — primary limits, secondary/abuse limits, GraphQL
@@ -59,17 +60,18 @@ export interface GhQuotaBackoffOpts {
   capMs?: number;
   /**
    * How long to sleep between retries when no server-supplied reset time is
-   * available. Default: 60 seconds, DOUBLING each retry up to 10 minutes —
+   * available. Default: 60 seconds, DOUBLING each retry up to one minute —
    * a fixed 60s cadence turned six waiting Workers into ~9,000 retries in one
    * evening (issue #3672's field data, 2026-08-11).
    */
   defaultWaitMs?: number;
   /**
-   * Ask GitHub when the drained pool resets, in epoch ms, or null when the
-   * answer is unavailable. No default: the routed client owns the balance ask
-   * (`GET /rate_limit` through @reddb-io/github), so a caller with client
-   * access injects the probe and the wait becomes one well-aimed sleep.
-   * Absent a probe, the doubling fallback below paces the retries.
+   * When the drained pool resets, in epoch ms, or null when the answer is
+   * unavailable. **Defaulted by `defaultGhQuotaBackoff` to the daemon's
+   * host-wide balance** — an option documented as having no default is one
+   * production never exercises, which is how every real wait here came to pace
+   * blind (#3768). An injected probe still wins; `null` still falls through to
+   * the doubling fallback below.
    */
   probeResetMs?: () => Promise<number | null>;
 }
@@ -78,8 +80,18 @@ export interface GhQuotaBackoffOpts {
 export const DEFAULT_CAP_MS = 30 * 60 * 1000; // 30 minutes
 /** First sleep between retries when no reset time is known. */
 export const DEFAULT_WAIT_MS = 60 * 1000;      // 60 seconds
-/** Ceiling for the doubling fallback wait. */
-export const MAX_FALLBACK_WAIT_MS = 10 * 60 * 1000; // 10 minutes
+/**
+ * Ceiling for the doubling fallback wait.
+ *
+ * Sixty seconds, not ten minutes (#3768). The fallback is what paces a wait that
+ * could not learn the real reset instant, and a rung that long is indistinguishable
+ * from a hang to whoever is holding the call: the fifteen-minute `queue_status`
+ * was four of these rungs and nothing else. With the reset probe installed by
+ * default the fallback is now the rare path, and a rare path is exactly the one
+ * that must stay short — an aimed wait sleeps until the pool refills, a blind one
+ * checks back every minute.
+ */
+export const MAX_FALLBACK_WAIT_MS = 60 * 1000; // 60 seconds
 /** Safety margin added past the probed reset instant. */
 export const RESET_MARGIN_MS = 5 * 1000;
 
@@ -138,7 +150,12 @@ export function defaultGhQuotaBackoff(
     onWait: overrides.onWait ?? ((remainingMs) => announceQuotaWait(remainingMs, Math.min(waitMs, remainingMs))),
     capMs,
     defaultWaitMs: waitMs,
-    ...(overrides.probeResetMs ? { probeResetMs: overrides.probeResetMs } : {}),
+    // Installed BY DEFAULT (#3768). A probe whose only populator was a test is a
+    // probe that never ran, and the aimed sleep this option exists for was the
+    // thing production never got — every real wait paced blind instead. The
+    // daemon already holds the reset instant host-wide, so this costs a socket
+    // read rather than a request, and an absent daemon still yields the fallback.
+    probeResetMs: overrides.probeResetMs ?? createDaemonQuotaResetProbe(),
   };
 }
 

--- a/apps/dev/tests/gh-band.test.ts
+++ b/apps/dev/tests/gh-band.test.ts
@@ -3,14 +3,15 @@
 // the claim, a landing and a finishing Worker's closing comment keep passing
 // until the pool has nothing left at all. A balance nobody could ask for opens
 // the gate rather than closing it.
-import { parseGithubBalance, type GithubBalance } from "@reddb-io/github";
-import { describe, expect, it } from "vitest";
+import { GITHUB_BUDGET_GATE_ENV, parseGithubBalance, type GithubBalance } from "@reddb-io/github";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   OPEN_GH_BAND_GATE,
   createGhBandGate,
   resolveGhBandGate,
 } from "../src/runtime/gh/band.js";
+import { forgetGithubBudgetGateMode } from "../src/runtime/gh/budget-gate-config.js";
 import { tryReadGhJsonRows } from "../src/runtime/gh/read.js";
 
 const NOW = "2026-08-03T12:00:00.000Z";
@@ -93,9 +94,28 @@ describe("the band refuses convenience, never the claim", () => {
   });
 });
 
-describe("absence of injection is not absence of the band", () => {
-  it("hands back a real gate when no caller injected one", () => {
+describe("the band is opt-in; the quota belongs to the operator (#3768)", () => {
+  const declared = process.env[GITHUB_BUDGET_GATE_ENV];
+
+  afterEach(() => {
+    if (declared === undefined) delete process.env[GITHUB_BUDGET_GATE_ENV];
+    else process.env[GITHUB_BUDGET_GATE_ENV] = declared;
+    forgetGithubBudgetGateMode();
+  });
+
+  it("hands back the OPEN gate when nobody asked for the band", () => {
+    delete process.env[GITHUB_BUDGET_GATE_ENV];
+    forgetGithubBudgetGateMode();
+    expect(resolveGhBandGate()).toBe(OPEN_GH_BAND_GATE);
+  });
+
+  it("hands back a real gate once the operator declared the band", () => {
+    process.env[GITHUB_BUDGET_GATE_ENV] = "on";
+    forgetGithubBudgetGateMode();
     expect(resolveGhBandGate()).not.toBe(OPEN_GH_BAND_GATE);
+  });
+
+  it("still lets a caller inject its own gate either way", () => {
     expect(resolveGhBandGate(OPEN_GH_BAND_GATE)).toBe(OPEN_GH_BAND_GATE);
   });
 });

--- a/apps/dev/tests/gh-budget-gate.test.ts
+++ b/apps/dev/tests/gh-budget-gate.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { GITHUB_BUDGET_GATE_ENV } from "@reddb-io/github";
+import { resolveGithubBudgetGateMode } from "../src/runtime/gh/budget-gate-config.js";
+import { createDaemonQuotaResetProbe } from "../src/runtime/gh/quota-reset-probe.js";
+import { defaultGhQuotaBackoff, MAX_FALLBACK_WAIT_MS } from "../src/runtime/gh/quota.js";
+import type { GithubBalance } from "@reddb-io/github";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+async function repoWith(configYaml: string | null): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "gh-budget-gate-"));
+  roots.push(root);
+  if (configYaml !== null) {
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), configYaml, "utf8");
+  }
+  return root;
+}
+
+function balanceWith(resetAt: Partial<Record<"rest" | "graphql" | "search", string>>): GithubBalance {
+  const pool = (name: "rest" | "graphql" | "search") =>
+    resetAt[name] === undefined ? null : {
+      pool: name,
+      resource: name,
+      limit: 100,
+      remaining: 0,
+      used: 100,
+      reset_at: resetAt[name]!,
+      fraction: 0,
+    };
+  return {
+    version: 1,
+    origin: "asked",
+    outcome: "asked",
+    source: "GET /rate_limit",
+    asked_at: "2026-08-12T17:38:03.795Z",
+    request_count: 1,
+    pools: { rest: pool("rest"), graphql: pool("graphql"), search: pool("search") },
+    unreported_pools: [],
+    detail: "test balance",
+  } as GithubBalance;
+}
+
+describe("the GitHub budget gate is opt-in (#3768)", () => {
+  it("is off when the project declared nothing — the quota is the operator's", async () => {
+    const root = await repoWith(null);
+    expect(resolveGithubBudgetGateMode({ root, env: {}, fresh: true })).toBe("off");
+  });
+
+  it("is off when the config file mentions other things", async () => {
+    const root = await repoWith("plugins:\n  dev:\n    enabled: true\n");
+    expect(resolveGithubBudgetGateMode({ root, env: {}, fresh: true })).toBe("off");
+  });
+
+  it("turns on when the project declares github.budget_gate", async () => {
+    const root = await repoWith("github:\n  budget_gate: on\n");
+    expect(resolveGithubBudgetGateMode({ root, env: {}, fresh: true })).toBe("on");
+  });
+
+  it("lets the env override one run without touching the file", async () => {
+    const root = await repoWith("github:\n  budget_gate: on\n");
+    expect(resolveGithubBudgetGateMode({
+      root,
+      env: { [GITHUB_BUDGET_GATE_ENV]: "off" },
+      fresh: true,
+    })).toBe("off");
+  });
+
+  it("reads an unparseable config as off rather than as a refusal", async () => {
+    const root = await repoWith("github: [this is not: valid yaml\n");
+    expect(resolveGithubBudgetGateMode({ root, env: {}, fresh: true })).toBe("off");
+  });
+});
+
+describe("a quota wait aims at the real reset (#3768)", () => {
+  it("is installed by default, so no production wait paces blind", () => {
+    expect(defaultGhQuotaBackoff().probeResetMs).toBeTypeOf("function");
+  });
+
+  it("keeps a blind fallback rung short enough to read as a wait, not a hang", () => {
+    expect(MAX_FALLBACK_WAIT_MS).toBeLessThanOrEqual(60_000);
+  });
+
+  it("answers with the soonest reset across the pools", async () => {
+    const probe = createDaemonQuotaResetProbe(async () => balanceWith({
+      search: "2026-08-12T17:39:04.000Z",
+      rest: "2026-08-12T17:47:42.000Z",
+    }));
+    expect(await probe()).toBe(Date.parse("2026-08-12T17:39:04.000Z"));
+  });
+
+  it("answers null when no daemon holds a balance, so the fallback still paces", async () => {
+    const probe = createDaemonQuotaResetProbe(async () => null);
+    expect(await probe()).toBeNull();
+  });
+});

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -45,6 +45,8 @@ import {
   createGithubAttributionLedger,
   createGithubBalanceHistory,
   createGithubBalanceStore,
+  DEFAULT_GITHUB_BALANCE_TIMEOUT_MS,
+  createTimedGithubFetch,
   createGithubBalanceTransport,
   type GithubAttributionLedger,
   type GithubRateBudget,
@@ -340,7 +342,14 @@ export function resolveServeGithubBalance(
   if (host == null) return null;
   const origin = env.GITHUB_API_URL;
   return {
-    transport: createGithubBalanceTransport({ token: host.token, ...(origin ? { origin } : {}) }),
+    // Bounded, so a stalled ask cannot outlive the poll that issued it and the
+    // re-arm keeps happening (#3768). The poller's own remote-call deadline is
+    // the second bound; this one tears the socket down rather than abandoning it.
+    transport: createGithubBalanceTransport({
+      token: host.token,
+      ...(origin ? { origin } : {}),
+      fetchImpl: createTimedGithubFetch({ timeoutMs: DEFAULT_GITHUB_BALANCE_TIMEOUT_MS }),
+    }),
   };
 }
 

--- a/apps/rsp/src/resident-github.ts
+++ b/apps/rsp/src/resident-github.ts
@@ -1,5 +1,8 @@
 import { join } from "node:path";
 import {
+  DEFAULT_GITHUB_BALANCE_TIMEOUT_MS,
+  createTimedGithubFetch,
+  withGithubDeadline,
   createGithubBalanceTransport,
   createGithubAttributionLedger,
   createGithubClient,
@@ -50,14 +53,23 @@ export function createCachedGithubBalanceReader(
   token: string,
   origin?: string,
 ): () => Promise<GithubBalance | null> {
-  const transport = createGithubBalanceTransport({ token, ...(origin ? { origin } : {}) });
+  // Bounded at the transport: a balance ask that never settles is the shape that
+  // wedged every reader joined to it (#3768).
+  const transport = createGithubBalanceTransport({
+    token,
+    ...(origin ? { origin } : {}),
+    fetchImpl: createTimedGithubFetch({ timeoutMs: DEFAULT_GITHUB_BALANCE_TIMEOUT_MS }),
+  });
   let held: GithubBalance | null = null;
   let freshUntil = 0;
   let inFlight: Promise<GithubBalance | null> | null = null;
   return async (): Promise<GithubBalance | null> => {
     const now = Date.now();
     if (now < freshUntil) return held;
-    if (inFlight !== null) return await inFlight;
+    // A JOINER INHERITS THE DEADLINE, never the leader's patience. Awaiting the
+    // shared promise bare is what turned one stalled ask into every later
+    // caller's stall: the joiner had issued nothing and could not give up.
+    if (inFlight !== null) return await joinBalance(inFlight);
     const askedAt = new Date(now).toISOString();
     inFlight = fetchGithubBalance({ transport, now: askedAt }).then((answer) => {
       held = answer;
@@ -66,8 +78,24 @@ export function createCachedGithubBalanceReader(
     }).finally(() => {
       inFlight = null;
     });
-    return await inFlight;
+    return await joinBalance(inFlight);
   };
+}
+
+/**
+ * Await a balance ask under a deadline; an unanswered one is `null`.
+ *
+ * `null` is unknown, and unknown OPENS the gate — the same degradation an absent
+ * daemon or an absent credential produces. A balance nobody could read is a
+ * reporting failure, and turning a reporting failure into a refusal is how one
+ * slow endpoint becomes an outage.
+ */
+async function joinBalance(pending: Promise<GithubBalance | null>): Promise<GithubBalance | null> {
+  try {
+    return await withGithubDeadline("balance ask", DEFAULT_GITHUB_BALANCE_TIMEOUT_MS, () => pending);
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/packages/github/attribution.test.ts
+++ b/packages/github/attribution.test.ts
@@ -175,3 +175,31 @@ describe("the GitHub spend attribution ledger", () => {
     expect(report.total_cost).toBe(rows.reduce((sum, row) => sum + Number(row.cost), 0));
   });
 });
+
+describe("a failed ledger write (#3768)", () => {
+  it("fails its own caller and no one else", async () => {
+    // A record larger than the whole lane can never be appended: the ledger
+    // throws rather than trimming everything away. Before this, that one throw
+    // poisoned the shared write chain, so every LATER record rejected without
+    // running — and because a GitHub read awaits the ledger, the client stopped
+    // reading for the life of the process.
+    const path = await ledgerPath();
+    const ledger = createGithubAttributionLedger({ path, maxBytes: 4_096 });
+    const operation = routeGithubArgs(["issue", "view", "7"]);
+
+    const refused = await ledger
+      .record({ operation, cost: 1, actor: "x".repeat(8_192), observedAt: HOUR_START })
+      .then(() => null, (thrown: unknown) => thrown);
+    expect(String(refused)).toContain("lane ceiling");
+
+    await expect(
+      ledger.record({ operation, cost: 1, actor: "worker:w1", observedAt: HOUR_START }),
+    ).resolves.toBeUndefined();
+    await expect(
+      ledger.record({ operation, cost: 1, actor: "worker:w2", observedAt: HOUR_START }),
+    ).resolves.toBeUndefined();
+
+    const report = await ledger.report({ from: HOUR_START, to: HOUR_END });
+    expect(report.total_count).toBe(2);
+  });
+});

--- a/packages/github/attribution.ts
+++ b/packages/github/attribution.ts
@@ -112,7 +112,14 @@ export function createGithubAttributionLedger(
     record(input): Promise<void> {
       const observation = makeObservation(input.operation, input.cost, input.observedAt ?? now(), input.actor);
       const segment = encodeToonlLines().push(toToonlRecord(observation));
-      pendingWrite = pendingWrite.then(async () => {
+      // A FAILED write must not become every later caller's failure. Chaining the
+      // tail onto the raw promise meant one rejection — the lane-ceiling throw
+      // below, an ENOSPC — poisoned the chain permanently: every subsequent
+      // `record` returned an already-rejected promise, its body never ran, and
+      // because a GitHub read awaits this ledger, the whole client stopped
+      // reading for the life of the process. The tail therefore carries ordering
+      // only; the failure travels to the ONE caller that caused it.
+      const settled = pendingWrite.then(async () => {
         await mkdir(dirname(options.path), { recursive: true });
         const incomingBytes = Buffer.byteLength(segment);
         if (await laneOverCeiling(options.path, incomingBytes, retentionPolicy)) {
@@ -129,7 +136,8 @@ export function createGithubAttributionLedger(
         }
         await appendFile(options.path, segment, "utf8");
       });
-      return pendingWrite;
+      pendingWrite = settled.then(() => undefined, () => undefined);
+      return settled;
     },
 
     async report(input): Promise<GithubSpendAttributionReport> {

--- a/packages/github/budget-gate.test.ts
+++ b/packages/github/budget-gate.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_GITHUB_BUDGET_GATE,
+  GITHUB_BUDGET_GATE_ENV,
+  githubBudgetGate,
+  githubBudgetGateEnabled,
+  githubBudgetGateFromEnv,
+} from "./budget-gate.js";
+
+describe("the budget gate's default", () => {
+  it("is off, because the quota belongs to the operator", () => {
+    expect(DEFAULT_GITHUB_BUDGET_GATE).toBe("off");
+    expect(githubBudgetGateEnabled(undefined)).toBe(false);
+    expect(githubBudgetGateFromEnv({})).toBe("off");
+  });
+});
+
+describe("reading a declared mode", () => {
+  it("turns the spellings an operator actually writes on", () => {
+    for (const declared of ["on", "ON", " enabled ", "true", true]) {
+      expect(githubBudgetGate(declared)).toBe("on");
+    }
+    expect(githubBudgetGateEnabled(githubBudgetGateFromEnv({ [GITHUB_BUDGET_GATE_ENV]: "on" }))).toBe(true);
+  });
+
+  it("reads anything else as off rather than as an error", () => {
+    for (const declared of ["off", "no", "", "  ", "yes-please", 1, null, undefined, {}]) {
+      expect(githubBudgetGate(declared)).toBe("off");
+    }
+  });
+});

--- a/packages/github/budget-gate.ts
+++ b/packages/github/budget-gate.ts
@@ -1,0 +1,64 @@
+// budget-gate.ts — the balance may WATCH every call; by default it stops none.
+//
+// **The quota belongs to the operator.** The reserved band was written so a
+// spent pool refused a convenience read before it refused a claim, and the
+// ordering is still right — but it was on by default, which made the client the
+// authority on how an operator may spend their own token. An operator who wants
+// to burn the whole quota is not making a mistake the library gets to prevent.
+//
+// **Off by default is also the hang's cure.** A gate that refuses on a balance
+// must first HAVE a balance, so every read waited on a balance ask, and a stalled
+// ask wedged reads that had nothing to do with it (#3768). With the gate off
+// nothing on the read path waits for the balance at all: the ask stays a
+// background observation and the read goes straight to GitHub.
+//
+// **Telemetry is not gating and does not move.** The balance-history lane, the
+// spend ledger and the rate-limit reporting all keep running in both modes. What
+// this switch controls is exactly one thing: whether an observation is allowed to
+// turn into a refusal.
+
+/** Whether the balance may refuse a call, or only describe one. */
+export type GithubBudgetGateMode = "off" | "on";
+
+/** Off: a client that was told nothing never refuses on budget. */
+export const DEFAULT_GITHUB_BUDGET_GATE: GithubBudgetGateMode = "off";
+
+/** The config key that turns the gate on, in `.red/config.yaml`. */
+export const GITHUB_BUDGET_GATE_CONFIG_KEY = "github.budget_gate";
+
+/** The env override, for a single run that wants the other mode. */
+export const GITHUB_BUDGET_GATE_ENV = "RED_GITHUB_BUDGET_GATE";
+
+/**
+ * Read a declared mode out of whatever a config or env produced. PURE.
+ *
+ * Anything unrecognised is `off`, not an error: this is read on the path that
+ * decides whether GitHub gets asked at all, and a typo in a config key must not
+ * be the thing that starts refusing an operator's own reads.
+ */
+export function githubBudgetGate(value: unknown): GithubBudgetGateMode {
+  if (value === true) return "on";
+  if (typeof value !== "string") return DEFAULT_GITHUB_BUDGET_GATE;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "on" || normalized === "enabled" || normalized === "true"
+    ? "on"
+    : DEFAULT_GITHUB_BUDGET_GATE;
+}
+
+/** True when the balance is allowed to refuse. PURE. */
+export function githubBudgetGateEnabled(mode: GithubBudgetGateMode | undefined): boolean {
+  return (mode ?? DEFAULT_GITHUB_BUDGET_GATE) === "on";
+}
+
+/**
+ * The mode this process runs under when nothing was injected. PURE given `env`.
+ *
+ * The env is the only source this package reads: a repository's `.red/config.yaml`
+ * is the consumer's file, and a library that went looking for it would be a
+ * second reader of a document the consumer already owns.
+ */
+export function githubBudgetGateFromEnv(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): GithubBudgetGateMode {
+  return githubBudgetGate(env[GITHUB_BUDGET_GATE_ENV]);
+}

--- a/packages/github/conditional-client.test.ts
+++ b/packages/github/conditional-client.test.ts
@@ -150,9 +150,10 @@ describe("the conditional GitHub client", () => {
     expect(seen.every((url) => !url.includes("/graphql"))).toBe(true);
   });
 
-  it("parks an operation with no equivalent by naming its pool and reset", async () => {
+  it("parks an operation with no equivalent by naming its pool and reset, with the gate ON", async () => {
     const client = createGithubClient({
       token: "test-token",
+      budgetGate: "on",
       balance: () => balance(0, 4_883),
       retryCount: 0,
       throttle: false,
@@ -179,6 +180,7 @@ describe("the conditional GitHub client", () => {
     const instants = ["2026-08-05T11:00:00.000Z", "2026-08-05T11:00:30.000Z"];
     const client = createGithubClient({
       token: "test-token",
+      budgetGate: "on",
       balance: () => current,
       now: () => instants.shift() ?? "2026-08-05T11:00:30.000Z",
       retryCount: 0,
@@ -315,6 +317,7 @@ describe("the conditional GitHub client", () => {
     const seen: string[] = [];
     const client = createGithubClient({
       token: "test-token",
+      budgetGate: "on",
       balance: () => pendingBalance,
       retryCount: 0,
       throttle: false,
@@ -649,5 +652,144 @@ describe("the conditional GitHub client", () => {
       .then(() => null, (thrown: unknown) => thrown);
 
     expect(isGithubRateLimitError(error)).toBe(true);
+  });
+});
+
+describe("the balance watches; by default it stops nothing (#3768)", () => {
+  it("issues a read a spent pool would have refused, because the gate is off", async () => {
+    const seen: string[] = [];
+    const client = createGithubClient({
+      token: "test-token",
+      // Spent on both rails: the gate, when on, refuses this before transport.
+      balance: () => balance(0, 0),
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async (url) => {
+        seen.push(String(url));
+        return new Response(JSON.stringify({ check_runs: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    const answer = await client.conditionalRest({
+      cacheKey: "checks:acme/widgets:abc123",
+      route: "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+      parameters: { owner: "acme", repo: "widgets", ref: "abc123" },
+      operation: { key: "pr checks", budget: "rest" },
+    });
+
+    expect(answer.data).toEqual({ check_runs: [] });
+    expect(seen).toHaveLength(1);
+  });
+
+  it("never waits on the balance it will not consult", async () => {
+    let asked = 0;
+    const client = createGithubClient({
+      token: "test-token",
+      // A provider that never settles: the wedge shape of #3768.
+      balance: () => {
+        asked += 1;
+        return new Promise<never>(() => undefined);
+      },
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async () => new Response(JSON.stringify({ check_runs: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    });
+
+    const startedAt = Date.now();
+    const answer = await client.conditionalRest({
+      cacheKey: "checks:acme/widgets:abc123",
+      route: "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+      parameters: { owner: "acme", repo: "widgets", ref: "abc123" },
+      operation: { key: "pr checks", budget: "rest" },
+    });
+
+    expect(answer.data).toEqual({ check_runs: [] });
+    expect(asked).toBe(0);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it("bounds the balance a coalescing flush DOES consult, so one stall is not every read", async () => {
+    const seen: string[] = [];
+    const client = createGithubClient({
+      token: "test-token",
+      balanceTimeoutMs: 25,
+      // The flush reads the balance to pick a rail; a stalled ask must degrade to
+      // unknown rather than hold every joined read.
+      balance: () => new Promise<never>(() => undefined),
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async (url) => {
+        seen.push(String(url));
+        return new Response(JSON.stringify({ number: 7, state: "open" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+    const read = (number: number) => client.singleObject<{ number: number }>({
+      cacheKey: `pr:acme/widgets:${number}`,
+      kind: "pr",
+      owner: "acme",
+      repo: "widgets",
+      number,
+      selection: "number",
+      operation: { key: "pr view", budget: "rest" },
+    });
+
+    const startedAt = Date.now();
+    const answers = await Promise.all([read(7), read(8)]);
+
+    expect(answers.map(({ surface }) => surface)).toEqual(["rest", "rest"]);
+    expect(seen).toHaveLength(2);
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  it("still refuses a spent pool when the operator turned the gate on", async () => {
+    const client = createGithubClient({
+      token: "test-token",
+      budgetGate: "on",
+      balance: () => balance(0, 0),
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: async () => {
+        throw new Error("a gated dry pool must be refused before transport");
+      },
+    });
+
+    const error = await client.conditionalRest({
+      cacheKey: "checks:acme/widgets:abc123",
+      route: "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+      parameters: { owner: "acme", repo: "widgets", ref: "abc123" },
+      operation: { key: "pr checks", budget: "rest" },
+    }).then(() => null, (thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(GithubPoolUnavailableError);
+  });
+
+  it("times a read out loudly instead of hanging on a silent transport", async () => {
+    const client = createGithubClient({
+      token: "test-token",
+      timeoutMs: 25,
+      retryCount: 0,
+      throttle: false,
+      fetchImpl: () => new Promise<Response>(() => undefined),
+    });
+
+    const startedAt = Date.now();
+    const error = await client.conditionalRest({
+      cacheKey: "checks:acme/widgets:abc123",
+      route: "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+      parameters: { owner: "acme", repo: "widgets", ref: "abc123" },
+      operation: { key: "pr checks", budget: "rest" },
+    }).then(() => null, (thrown: unknown) => thrown);
+
+    expect(String(error)).toContain("deadline");
+    expect(Date.now() - startedAt).toBeLessThan(10_000);
   });
 });

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -17,6 +17,17 @@ import {
 } from "./aliased-query.js";
 import type { GithubAttributionLedger, GithubAttributedOperation } from "./attribution.js";
 import type { GithubBalance } from "./balance.js";
+import {
+  DEFAULT_GITHUB_BALANCE_TIMEOUT_MS,
+  createTimedGithubFetch,
+  githubRequestTimeoutMs,
+  withGithubDeadline,
+} from "./deadline.js";
+import {
+  githubBudgetGateEnabled,
+  githubBudgetGateFromEnv,
+  type GithubBudgetGateMode,
+} from "./budget-gate.js";
 import type { GithubApiSurface, GithubRateBudget } from "./surface.js";
 
 const Octokit = RestOctokit.plugin(retry, throttling);
@@ -144,6 +155,18 @@ export interface CreateGithubClientOptions {
   readonly retryCount?: number;
   /** Disable plugin pacing only for a caller-supplied transport test. */
   readonly throttle?: boolean;
+  /**
+   * Whether the balance may REFUSE a call, or only describe one. Off by default:
+   * the quota is the operator's to spend (`budget-gate.ts`).
+   */
+  readonly budgetGate?: GithubBudgetGateMode;
+  /** Per-request deadline; the env-tunable process default when absent. */
+  readonly timeoutMs?: number;
+  /**
+   * Deadline for one balance read. Shorter than a request's, because an unknown
+   * balance is a legal answer and a known one is never worth a stall.
+   */
+  readonly balanceTimeoutMs?: number;
 }
 
 /**
@@ -209,6 +232,15 @@ export class GithubPoolUnavailableError extends Error {
 export function createGithubClient(options: CreateGithubClientOptions): GithubClient {
   const etags = options.etags ?? createMemoryGithubEtagStore();
   const now = options.now ?? (() => new Date().toISOString());
+  // Bounded at the transport, so a route added later inherits the deadline
+  // instead of having to remember it (`deadline.ts`).
+  const timeoutMs = options.timeoutMs ?? githubRequestTimeoutMs();
+  const balanceTimeoutMs = options.balanceTimeoutMs ?? Math.min(timeoutMs || DEFAULT_GITHUB_BALANCE_TIMEOUT_MS, DEFAULT_GITHUB_BALANCE_TIMEOUT_MS);
+  const gated = githubBudgetGateEnabled(options.budgetGate ?? githubBudgetGateFromEnv());
+  const timedFetch = createTimedGithubFetch({
+    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl as unknown as typeof fetch } : {}),
+    timeoutMs,
+  });
   const octokit = new Octokit({
     auth: options.token,
     // REST.js logs every non-2xx before the caller can classify it, including
@@ -221,7 +253,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
       error: () => undefined,
     },
     ...(options.baseUrl ? { baseUrl: options.baseUrl } : {}),
-    ...(options.fetchImpl ? { request: { fetch: options.fetchImpl } } : {}),
+    request: { fetch: timedFetch as unknown as GithubRequestFetch },
     retry: {
       doNotRetry: [304, 403, 429],
       ...(options.retryCount === undefined ? {} : { retries: options.retryCount }),
@@ -234,15 +266,23 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
         },
   });
 
+  // A balance is an OPTIMIZATION here, never a precondition: it picks a rail and,
+  // when the gate is on, refuses a spent pool. So the read is bounded and a
+  // stalled provider degrades to `null` — unknown — rather than holding the call
+  // that asked for it. This is the joiner half of #3768: one wedged balance ask
+  // must not become every caller's wait.
   const readBalance = async (): Promise<GithubBalance | null> => {
+    if (options.balance === undefined) return null;
     try {
-      return await options.balance?.() ?? null;
+      return await withGithubDeadline("balance read", balanceTimeoutMs, async () =>
+        await options.balance!() ?? null);
     } catch {
       return null;
     }
   };
 
   const refuseSpentPool = (balance: GithubBalance | null, pool: GithubRateBudget): void => {
+    if (!gated) return;
     const observed = balance?.pools[pool] ?? null;
     if (observed !== null && observed.remaining <= 0) {
       throw new GithubPoolUnavailableError(pool, observed.reset_at);
@@ -251,7 +291,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
 
   const conditionalRest = async <T>(input: GithubConditionalRestRequest): Promise<GithubRestAnswer<T>> => {
       const held = etags.get(input.cacheKey);
-      const observed = (await readBalance())?.pools[input.operation.budget] ?? null;
+      const observed = gated ? (await readBalance())?.pools[input.operation.budget] ?? null : null;
       if (observed !== null && observed.remaining <= 0) {
         if (held !== undefined) return cachedAnswer<T>(held, input.operation.budget, observed.reset_at, now());
         throw new GithubPoolUnavailableError(input.operation.budget, observed.reset_at);
@@ -376,14 +416,39 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
   };
 
   const flushSingleObjects = async (): Promise<void> => {
-    const balance = await readBalance();
-    const threshold = githubSingleObjectCoalescingThreshold(balance);
-    singleObjectFlushScheduled = false;
-    const groups = [...pendingSingleObjects.values()];
-    pendingSingleObjects.clear();
+    // **THE FLUSH IS THE ONLY DRAIN, so it must always reach one.** A caller
+    // enqueued here holds a promise nothing else can settle, and while
+    // `singleObjectFlushScheduled` is true no second flush is scheduled — so a
+    // throw anywhere above the drain strands every waiting read forever, which
+    // is the shape #3768 wore. The balance read above is bounded (`readBalance`),
+    // and this frame guarantees the rest: the flag is cleared and every stranded
+    // read is REJECTED, because a loud failure is a caller that can retry and a
+    // pending promise is a caller that cannot.
+    try {
+      const balance = await readBalance();
+      const threshold = githubSingleObjectCoalescingThreshold(balance);
+      singleObjectFlushScheduled = false;
+      const groups = [...pendingSingleObjects.values()];
+      pendingSingleObjects.clear();
+      await drainSingleObjectGroups(groups, balance, threshold);
+    } catch (error) {
+      singleObjectFlushScheduled = false;
+      const stranded = [...pendingSingleObjects.values()];
+      pendingSingleObjects.clear();
+      for (const group of stranded) group.forEach((pending) => pending.reject(error));
+    }
+  };
+
+  const drainSingleObjectGroups = async (
+    groups: readonly PendingSingleObjectRead[][],
+    balance: GithubBalance | null,
+    threshold: number,
+  ): Promise<void> => {
     await Promise.all(groups.map(async (group) => {
       const explicit = group[0]!.input.rail;
       const requested = explicit ?? "rest";
+      // Rerouting off an exhausted rail is routing and stays on in both modes;
+      // REFUSING when no rail can answer is the gate's, and stays off by default.
       const source = balance?.pools[requested] ?? null;
       const fallback: GithubApiSurface = requested === "rest" ? "graphql" : "rest";
       const destination = balance?.pools[fallback] ?? null;
@@ -403,7 +468,7 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
             resetAt: source.reset_at,
             reason: `${requested} pool is exhausted until ${source.reset_at}; used the equivalent ${selected} rail`,
           };
-        } else if (!requestedCache) {
+        } else if (!requestedCache && gated) {
           const error = new GithubPoolUnavailableError(requested, source.reset_at, "the equivalent rail has no known budget");
           group.forEach((pending) => pending.reject(error));
           return;

--- a/packages/github/deadline.test.ts
+++ b/packages/github/deadline.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_GITHUB_REQUEST_TIMEOUT_MS,
+  GITHUB_REQUEST_TIMEOUT_ENV,
+  GithubTimeoutError,
+  createTimedGithubFetch,
+  githubRequestTimeoutMs,
+  isGithubTimeoutError,
+  withGithubDeadline,
+} from "./deadline.js";
+
+const never = new Promise<never>(() => undefined);
+
+describe("the request bound this process runs under", () => {
+  it("is the documented default when the operator declared nothing", () => {
+    expect(githubRequestTimeoutMs({})).toBe(DEFAULT_GITHUB_REQUEST_TIMEOUT_MS);
+  });
+
+  it("honours a declared override", () => {
+    expect(githubRequestTimeoutMs({ [GITHUB_REQUEST_TIMEOUT_ENV]: "1500" })).toBe(1_500);
+  });
+
+  it("ignores a malformed override rather than bricking every read", () => {
+    expect(githubRequestTimeoutMs({ [GITHUB_REQUEST_TIMEOUT_ENV]: "soon" }))
+      .toBe(DEFAULT_GITHUB_REQUEST_TIMEOUT_MS);
+    expect(githubRequestTimeoutMs({ [GITHUB_REQUEST_TIMEOUT_ENV]: "-5" }))
+      .toBe(DEFAULT_GITHUB_REQUEST_TIMEOUT_MS);
+  });
+});
+
+describe("a fetch that never answers", () => {
+  it("becomes a bounded, named error instead of a forever", async () => {
+    const timed = createTimedGithubFetch({ timeoutMs: 25, fetchImpl: async () => await never });
+    const startedAt = Date.now();
+
+    const error = await timed("https://api.github.com/repos/acme/widgets/issues/7")
+      .then(() => null, (thrown: unknown) => thrown);
+
+    expect(isGithubTimeoutError(error)).toBe(true);
+    expect((error as GithubTimeoutError).timeoutMs).toBe(25);
+    expect(String(error)).toContain("/repos/acme/widgets/issues/7");
+    expect(String(error)).toContain(GITHUB_REQUEST_TIMEOUT_ENV);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it("aborts the transport rather than merely abandoning it", async () => {
+    let observed: AbortSignal | undefined;
+    const timed = createTimedGithubFetch({
+      timeoutMs: 25,
+      fetchImpl: async (_input, init) => {
+        observed = init?.signal ?? undefined;
+        return await never;
+      },
+    });
+
+    await timed("https://api.github.com/rate_limit").catch(() => undefined);
+
+    expect(observed?.aborted).toBe(true);
+  });
+
+  it("never renames a caller's own cancellation as a timeout", async () => {
+    const controller = new AbortController();
+    const timed = createTimedGithubFetch({
+      timeoutMs: 10_000,
+      fetchImpl: async (_input, init) =>
+        await new Promise<Response>((_resolve, reject) => {
+          const abort = () => reject(new Error("caller aborted"));
+          if (init?.signal?.aborted) abort();
+          init?.signal?.addEventListener("abort", abort);
+        }),
+    });
+
+    const pending = timed("https://api.github.com/rate_limit", { signal: controller.signal });
+    controller.abort();
+    const error = await pending.then(() => null, (thrown: unknown) => thrown);
+
+    expect(isGithubTimeoutError(error)).toBe(false);
+    expect(String(error)).toContain("caller aborted");
+  });
+
+  it("leaves the bound off entirely when the operator disabled it", async () => {
+    const answer = new Response("{}", { status: 200 });
+    const timed = createTimedGithubFetch({ timeoutMs: 0, fetchImpl: async () => answer });
+    await expect(timed("https://api.github.com/rate_limit")).resolves.toBe(answer);
+  });
+});
+
+describe("a joiner waiting on someone else's promise", () => {
+  it("inherits its own deadline rather than the leader's patience", async () => {
+    const startedAt = Date.now();
+
+    const error = await withGithubDeadline("balance ask", 25, () => never)
+      .then(() => null, (thrown: unknown) => thrown);
+
+    expect(isGithubTimeoutError(error)).toBe(true);
+    expect(String(error)).toContain("balance ask");
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it("returns the answer untouched when it arrives in time", async () => {
+    await expect(withGithubDeadline("balance ask", 5_000, async () => 41 + 1)).resolves.toBe(42);
+  });
+
+  it("passes a genuine failure through as itself", async () => {
+    const boom = new Error("GitHub refused with HTTP 401");
+    await expect(withGithubDeadline("balance ask", 5_000, async () => {
+      throw boom;
+    })).rejects.toBe(boom);
+  });
+});

--- a/packages/github/deadline.ts
+++ b/packages/github/deadline.ts
@@ -1,0 +1,165 @@
+// deadline.ts — every GitHub call this package issues is bounded, and a stall
+// becomes a loud error instead of a quiet forever.
+//
+// **A hang is not a slow success.** Node's `fetch` applies no total-request
+// deadline: a socket that stops answering after the request is written leaves the
+// promise pending until undici's own five-minute header timeout, and octokit's
+// retry plugin then pays that cost again per attempt. The observed shape (#3768)
+// was a fifteen-minute freeze that finally returned the right answer — nothing in
+// the process was broken, nothing logged, and every liveness surface read the
+// caller as healthy, because a patient wait and a wedged one are the same
+// observation from outside.
+//
+// **The bound belongs to the transport, not to each call site.** A deadline
+// spelled at one call site is a deadline missing from the next one written, so
+// the timed fetch wraps whatever `fetch` the client was given and every request
+// inherits it — including the ones this package does not know about yet.
+//
+// **A joiner inherits the bound too.** The second half of that freeze was a
+// single-flight cache: one stalled balance ask, and every later caller awaited
+// the same dead promise having issued nothing itself. `withGithubDeadline` is
+// what a coalescing reader wraps its shared promise in, so joining a stalled
+// leader costs the joiner its own deadline rather than the leader's patience.
+
+/** How long one GitHub request may take before it is a failure. */
+export const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
+
+/** How long a balance ask may take. Shorter: an unknown balance is a legal answer. */
+export const DEFAULT_GITHUB_BALANCE_TIMEOUT_MS = 10_000;
+
+/** The operator's override, in milliseconds. `0` disables the bound entirely. */
+export const GITHUB_REQUEST_TIMEOUT_ENV = "RED_GITHUB_REQUEST_TIMEOUT_MS";
+
+/**
+ * One GitHub call that passed its deadline.
+ *
+ * The message carries the subject and the bound, because the operator reading it
+ * is deciding whether the network is slow or the bound is wrong, and cannot tell
+ * those apart from the word "timeout".
+ */
+export class GithubTimeoutError extends Error {
+  readonly subject: string;
+  readonly timeoutMs: number;
+
+  constructor(subject: string, timeoutMs: number, options?: { readonly cause?: unknown }) {
+    super(
+      `GitHub ${subject} passed its ${timeoutMs}ms deadline and was abandoned; ` +
+        `raise ${GITHUB_REQUEST_TIMEOUT_ENV} if this host is genuinely this slow`,
+      options,
+    );
+    this.name = "GithubTimeoutError";
+    this.subject = subject;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/** True when `error` is this package's own deadline refusal. */
+export function isGithubTimeoutError(error: unknown): error is GithubTimeoutError {
+  return error instanceof GithubTimeoutError;
+}
+
+/**
+ * The request bound this process runs under. PURE given `env`.
+ *
+ * An unreadable or negative override is the default rather than an error: this
+ * is read on the hot path, and a typo in an env var must not be the thing that
+ * takes GitHub reads down.
+ */
+export function githubRequestTimeoutMs(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): number {
+  const raw = env[GITHUB_REQUEST_TIMEOUT_ENV];
+  if (raw === undefined || raw.trim() === "") return DEFAULT_GITHUB_REQUEST_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_GITHUB_REQUEST_TIMEOUT_MS;
+  return Math.trunc(parsed);
+}
+
+/**
+ * Run `work` under a deadline, without waiting for `work` to notice.
+ *
+ * The abandoned promise may still settle later — a transport with no cancellation
+ * surface cannot be recalled — so a caller must commit state only from THIS
+ * promise's value, never from inside `work`. A rejection the abandoned work
+ * produces afterwards is swallowed here, because an unhandled rejection from a
+ * call nobody is waiting for is noise that reads as a second failure.
+ */
+export async function withGithubDeadline<T>(
+  subject: string,
+  timeoutMs: number,
+  work: () => Promise<T>,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return await work();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new GithubTimeoutError(subject, timeoutMs)), timeoutMs);
+    timer.unref?.();
+  });
+  const running = Promise.resolve().then(work);
+  running.catch(() => undefined);
+  try {
+    return await Promise.race([running, deadline]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+export interface CreateTimedGithubFetchOptions {
+  /** The transport to bound; the platform `fetch` when absent. */
+  readonly fetchImpl?: typeof fetch;
+  /** The bound; the env-tunable process default when absent. */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * `fetch`, bounded — the shape every GitHub transport in this package is built on.
+ *
+ * **The signal and the race are both required, and they do different jobs.** The
+ * signal is the cancellation: aborting tears the socket down, so an abandoned
+ * request stops holding a connection and stops counting against the pool. The
+ * race is the guarantee: a transport that does not honour its signal — a shim, a
+ * mock, an interceptor written before signals existed — would otherwise turn a
+ * bounded call back into a forever, which is the exact defect this module exists
+ * to end. A bound that only works when the transport cooperates is not a bound.
+ *
+ * A caller that brought its own signal keeps it — both are honoured, and only the
+ * deadline's own abort is renamed, so a caller that cancelled deliberately never
+ * reads its own cancellation as a timeout.
+ */
+export function createTimedGithubFetch(options: CreateTimedGithubFetchOptions = {}): typeof fetch {
+  const call = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? githubRequestTimeoutMs();
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return call;
+  return (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+    const deadline = AbortSignal.timeout(timeoutMs);
+    const caller = init?.signal ?? null;
+    const signal = caller == null ? deadline : AbortSignal.any([caller, deadline]);
+    const subject = describeRequest(input);
+    try {
+      return await withGithubDeadline(subject, timeoutMs, async () =>
+        await call(input, { ...(init ?? {}), signal }));
+    } catch (error) {
+      if (isGithubTimeoutError(error)) throw error;
+      if (deadline.aborted && caller?.aborted !== true) {
+        throw new GithubTimeoutError(subject, timeoutMs, { cause: error });
+      }
+      throw error;
+    }
+  }) as typeof fetch;
+}
+
+/** The subject a timeout names: the route, never the token-bearing headers. */
+function describeRequest(input: Parameters<typeof fetch>[0]): string {
+  const url = typeof input === "string"
+    ? input
+    : input instanceof URL
+    ? input.href
+    : typeof (input as { url?: unknown }).url === "string"
+    ? (input as { url: string }).url
+    : "request";
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
+}

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -35,6 +35,28 @@ export {
 } from "./surface.js";
 
 export {
+  DEFAULT_GITHUB_BALANCE_TIMEOUT_MS,
+  DEFAULT_GITHUB_REQUEST_TIMEOUT_MS,
+  GITHUB_REQUEST_TIMEOUT_ENV,
+  GithubTimeoutError,
+  createTimedGithubFetch,
+  githubRequestTimeoutMs,
+  isGithubTimeoutError,
+  withGithubDeadline,
+  type CreateTimedGithubFetchOptions,
+} from "./deadline.js";
+
+export {
+  DEFAULT_GITHUB_BUDGET_GATE,
+  GITHUB_BUDGET_GATE_CONFIG_KEY,
+  GITHUB_BUDGET_GATE_ENV,
+  githubBudgetGate,
+  githubBudgetGateEnabled,
+  githubBudgetGateFromEnv,
+  type GithubBudgetGateMode,
+} from "./budget-gate.js";
+
+export {
   createGithubAttributionLedger,
   type GithubAttributedOperation,
   type CreateGithubAttributionLedgerOptions,

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -12,6 +12,8 @@
     "./surface.js": "./surface.ts",
     "./rest-plan.js": "./rest-plan.ts",
     "./balance.js": "./balance.ts",
+    "./deadline.js": "./deadline.ts",
+    "./budget-gate.js": "./budget-gate.ts",
     "./balance-store.js": "./balance-store.ts",
     "./balance-history.js": "./balance-history.ts",
     "./cache.js": "./cache.ts"

--- a/packaging/pi/dev/skills/engineering/redskilled/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/redskilled/SKILL.md
@@ -203,6 +203,32 @@ Use the ADR 0091 npm direct-run form for every daemon operation. The published
 binary is `red-skills-redskilled`; `redskilled` is only the daemon's name, and a
 bare invocation is not installed on an operator's machine by default.
 
+## GitHub budget gate — off by default, opt-in by config
+
+**The quota belongs to the operator, so nothing is refused on budget posture.**
+By default no read or write is blocked, deferred, or held waiting for a fresh
+balance: if you want to spend the whole token, the client lets you. What stays on
+in both modes is the *telemetry* — the balance-history lane, the spend ledger and
+the rate-limit reporting all keep recording. The gate controls exactly one thing:
+whether an observation is allowed to become a refusal.
+
+**Turn it on with `github.budget_gate`.** The key is read from the project's
+`.red/config.yaml` first, then the operator's host `~/.red/config.yaml`; the
+env var `RED_GITHUB_BUDGET_GATE` overrides both for a single run. Anything other
+than `on` — including an absent key and an unparseable file — is `off`, because a
+typo must never be the thing that starts refusing your own reads.
+
+```yaml
+# .red/config.yaml (this project) or ~/.red/config.yaml (this machine)
+github:
+  budget_gate: on
+```
+
+**Turn it on when you share one token across projects and want the claim to
+outlive the convenience reads** — with the gate on, a pool inside its reserved
+band refuses convenience reads first and keeps admitting the claim, a landing and
+a finishing Worker's closing comment. Leave it off for a token you alone spend.
+
 ## Where the evidence lives
 
 | Surface | Path | What it answers |

--- a/plugins/dev/skills/engineering/redskilled/SKILL.md
+++ b/plugins/dev/skills/engineering/redskilled/SKILL.md
@@ -203,6 +203,32 @@ Use the ADR 0091 npm direct-run form for every daemon operation. The published
 binary is `red-skills-redskilled`; `redskilled` is only the daemon's name, and a
 bare invocation is not installed on an operator's machine by default.
 
+## GitHub budget gate — off by default, opt-in by config
+
+**The quota belongs to the operator, so nothing is refused on budget posture.**
+By default no read or write is blocked, deferred, or held waiting for a fresh
+balance: if you want to spend the whole token, the client lets you. What stays on
+in both modes is the *telemetry* — the balance-history lane, the spend ledger and
+the rate-limit reporting all keep recording. The gate controls exactly one thing:
+whether an observation is allowed to become a refusal.
+
+**Turn it on with `github.budget_gate`.** The key is read from the project's
+`.red/config.yaml` first, then the operator's host `~/.red/config.yaml`; the
+env var `RED_GITHUB_BUDGET_GATE` overrides both for a single run. Anything other
+than `on` — including an absent key and an unparseable file — is `off`, because a
+typo must never be the thing that starts refusing your own reads.
+
+```yaml
+# .red/config.yaml (this project) or ~/.red/config.yaml (this machine)
+github:
+  budget_gate: on
+```
+
+**Turn it on when you share one token across projects and want the claim to
+outlive the convenience reads** — with the gate on, a pool inside its reserved
+band refuses convenience reads first and keeps admitting the claim, a landing and
+a finishing Worker's closing comment. Leave it off for a token you alone spend.
+
 ## Where the evidence lives
 
 | Surface | Path | What it answers |


### PR DESCRIPTION
Root cause of today's 15-minute freezes: withGhQuotaBackoff's aimed reset probe was never installed in production (probeResetMs had no default), so every rate-limit wait fell through to the blind 60s→600s doubling ladder — while the pool reset in 60 seconds. Four amplifiers cured: no GitHub call carried a timeout, single-flight balance joiners had no deadline, the single-object flush could strand its queue, and one failed spend-ledger write poisoned every later record().

Maintainer decision applied: the budget gate defaults OFF (the quota belongs to the operator); with the gate off the read path never asks for the balance at all. Telemetry unchanged. Opt-in via github.budget_gate: on in .red/config.yaml (project or host), RED_GITHUB_BUDGET_GATE per run; documented in the /redskilled skill (+ Pi mirror).

Verified: packages/github 501, apps/rsp 473, apps/dev gh cluster 143 + 9 new gate tests, invariants 194, typecheck 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrKC117zw4RxnBrTysaeAp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789151984&installation_model_id=20659&pr_number=3768&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3768&signature=2b272472ad8cee6f29c66e5df4a12963c68f705ed0ce8808b0dff6c113500a36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->