### PR TITLE
fix: the union's two stragglers and the release entries the train forgot

### DIFF
--- a/.changeset/quota-wait-aims-at-reset.md
+++ b/.changeset/quota-wait-aims-at-reset.md
@@ -1,0 +1,30 @@
+---
+"@reddb-io/github": patch
+"@reddb-io/red-skills": patch
+"@reddb-io/redskilled": patch
+---
+
+The quota wait aims at the pool's reset instead of doubling blindly, every GitHub call carries a deadline, and the budget gate defaults off.
+
+A rate-limited read used to sleep on a blind 60s→600s doubling ladder under a
+30-minute cap — the aimed one-probe-per-wait the backoff promised was never
+installed in production, so a pool that reset in sixty seconds froze queue
+reads, workers, and MCP tools for up to fifteen minutes with no record on any
+surface.
+
+- The reset probe is installed: a rate-limit wait sleeps until the pool
+  actually refills, and the doubling ladder is only the fallback it was meant
+  to be.
+- Every GitHub call the client issues — reads, writes, and the balance ask —
+  now rides a shared deadline; a stalled connection becomes a loud bounded
+  error instead of a silent epoll sleep.
+- The budget gate defaults OFF: the quota belongs to the operator, so nothing
+  is refused, deferred, or held on balance posture, and the read path never
+  asks for the balance at all. Telemetry (balance history, spend ledger,
+  rate-limit reporting) records in both modes. Opt in with
+  `github.budget_gate: on` in the repository's or the host's
+  `.red/config.yaml`, or `RED_GITHUB_BUDGET_GATE` for one run; the
+  `/redskilled` skill documents the key.
+- One failed spend-ledger write no longer poisons every later record for the
+  life of the process, and the single-object flush can no longer strand its
+  queue.

--- a/.changeset/toon-and-tq-ride-0-26-2.md
+++ b/.changeset/toon-and-tq-ride-0-26-2.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+toon and tq ride 0.26.2 across the catalog, every pin site, and the Pi mirrors.
+
+The pnpm catalog, the host-toolchain doctor's pin, both CI workflows'
+`TQ_VERSION`, and the red-setup interview move together from 0.22.0 to 0.26.2,
+with the generated Pi mirrors regenerated to match. The 0.26 encoder's new
+`primitiveArrayColumns`/`objectArrayColumns` options are available but not yet
+enabled by any writer, so no persisted file changes shape.

--- a/apps/dev/src/runtime/gh/budget-gate-config.ts
+++ b/apps/dev/src/runtime/gh/budget-gate-config.ts
@@ -19,7 +19,6 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import yaml from "js-yaml";
 import {
-  DEFAULT_GITHUB_BUDGET_GATE,
   GITHUB_BUDGET_GATE_ENV,
   githubBudgetGate,
   type GithubBudgetGateMode,
@@ -74,4 +73,4 @@ function readDeclaredGate(path: string): unknown {
   return declared === undefined ? undefined : declared;
 }
 
-export { DEFAULT_GITHUB_BUDGET_GATE };
+export { DEFAULT_GITHUB_BUDGET_GATE } from "@reddb-io/github";

--- a/packages/red-castle/src/engine/workflow-wait.test.ts
+++ b/packages/red-castle/src/engine/workflow-wait.test.ts
@@ -116,6 +116,8 @@ describe("castle workflow wait", () => {
     const client = createGithubClient({
       token: "fixture-token",
       balance: () => githubBalance(remaining),
+      // The budget gate defaults OFF; this test exercises the opted-in path.
+      budgetGate: "on",
       fetchImpl,
       retryCount: 0,
       throttle: false,


### PR DESCRIPTION
Repairs the two reds my #3768 admin-merge left on main (castle workflow-wait opts into the budget gate it tests; DEFAULT_GITHUB_BUDGET_GATE becomes an export-from) and adds the changesets for the quota/deadline/budget-gate fix and the toon/tq 0.26.2 bump so the release bot has something to version.

Verified: workflow-wait 8/8, import-hygiene 2/2, red-castle full 1837 passed, typecheck 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrKC117zw4RxnBrTysaeAp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789152649&installation_model_id=20659&pr_number=3770&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3770&signature=0dd37d9615c1638979509ea3877e3217ae0d65c309b2192ed1b3dee086e4666f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->