### PR TITLE
fix: a 404 is an answer, not a failure — Worker boot froze for ~22 minutes asking for a file the repo does not have

### DIFF
--- a/.changeset/a-404-is-an-answer.md
+++ b/.changeset/a-404-is-an-answer.md
@@ -1,0 +1,26 @@
+---
+"@reddb-io/github": patch
+"@reddb-io/red-skills": patch
+---
+
+A 404 is an answer, not a failure: stop retrying absent resources
+
+The routed client's `doNotRetry` list held 304, 403 and 429 — every status
+whose meaning is "do not ask again" except the most common one. A 404 was
+retried with exponential backoff, so asking for a file a repository does not
+have cost four requests over 14 seconds instead of one answer.
+
+The trust gate asks for CODEOWNERS at three recognised locations, per actor,
+per candidate. In a repository with no CODEOWNERS that was 93 seconds of
+backoff per candidate, and a boot listing 14 of them froze for ~22 minutes:
+no child process, no log line, no socket, and `live=true` on every liveness
+surface — the exact shape an orchestrator hang wears.
+
+Two fixes, at the two layers that were wrong:
+
+- `packages/github` no longer retries a 404. Issue point reads are strongly
+  consistent by number, so nothing legitimate depended on re-asking; a caller
+  that awaits eventual consistency must say so with its own bounded loop.
+- The CODEOWNERS lookup is now resolved once per repository per process. The
+  file is a repository fact, but it was being read per actor. A read that
+  FAILED is never cached, so one blip cannot poison the trust signal.

--- a/apps/dev/src/runtime/gh/trust.ts
+++ b/apps/dev/src/runtime/gh/trust.ts
@@ -237,13 +237,25 @@ async function actorWriteAccess(ctx: GhContext, actor: string): Promise<boolean 
 /** The GitHub-recognised CODEOWNERS locations, in resolution order. */
 const CODEOWNERS_PATHS = [".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"];
 
-/** Resolve whether `@actor` is an owner token in the repo CODEOWNERS file. Reads
- * the recognised locations in order; the first that resolves is parsed. undefined
- * when no read succeeded (transient/auth) and `false` when a file was read but
- * the actor is absent (or no CODEOWNERS exists at all). */
-async function actorInCodeowners(ctx: GhContext, actor: string): Promise<boolean | undefined> {
-  const repo = githubRepo(ctx);
-  if (!repo) return undefined;
+/**
+ * The CODEOWNERS file resolved once per repository per process.
+ *
+ * The file is a REPOSITORY fact, but the trust gate asks it per candidate: a
+ * boot listing 14 candidates re-read the same three locations 14 times. In a
+ * repo that has no CODEOWNERS, every one of those was three 404s, which is why
+ * this cache is load-bearing rather than an optimization. `null` records the
+ * definitive absence; a read that FAILED is never cached, so one blip cannot
+ * poison the trust signal for the rest of the process.
+ */
+const codeownersByRepo = new Map<string, Promise<string | null | undefined>>();
+
+/** Read the first CODEOWNERS location that resolves. `null` when every
+ * recognised location answered a definitive 404, `undefined` when no read
+ * succeeded (transient/auth). */
+async function readRepoCodeowners(
+  ctx: GhContext,
+  repo: { owner: string; repo: string },
+): Promise<string | null | undefined> {
   let sawDefinitiveMiss = false;
   for (const path of CODEOWNERS_PATHS) {
     try {
@@ -254,7 +266,7 @@ async function actorInCodeowners(ctx: GhContext, actor: string): Promise<boolean
         operation: { key: "api rest", budget: "rest" },
         actor: "dev:trust",
       });
-      return codeownersHasOwner(String(answer.data ?? ""), actor);
+      return String(answer.data ?? "");
     } catch (error) {
       if (errorStatus(error) === 404) {
         sawDefinitiveMiss = true;
@@ -263,8 +275,33 @@ async function actorInCodeowners(ctx: GhContext, actor: string): Promise<boolean
       return undefined; // transient/auth failure — signal not available
     }
   }
-  // Every location returned a definitive 404 → there is no CODEOWNERS file.
-  return sawDefinitiveMiss ? false : undefined;
+  return sawDefinitiveMiss ? null : undefined;
+}
+
+/** Resolve whether `@actor` is an owner token in the repo CODEOWNERS file.
+ * undefined when no read succeeded (transient/auth) and `false` when a file was
+ * read but the actor is absent (or no CODEOWNERS exists at all). */
+async function actorInCodeowners(ctx: GhContext, actor: string): Promise<boolean | undefined> {
+  const repo = githubRepo(ctx);
+  if (!repo) return undefined;
+  const key = `${repo.owner}/${repo.repo}`;
+  let pending = codeownersByRepo.get(key);
+  if (pending === undefined) {
+    pending = readRepoCodeowners(ctx, repo);
+    codeownersByRepo.set(key, pending);
+  }
+  const content = await pending;
+  if (content === undefined) {
+    codeownersByRepo.delete(key); // an unavailable signal is not an answer to keep
+    return undefined;
+  }
+  return content === null ? false : codeownersHasOwner(content, actor);
+}
+
+/** Forget the per-process CODEOWNERS resolutions. Tests only: a cache that
+ * survives between cases would answer the next case's first read. */
+export function resetCodeownersCache(): void {
+  codeownersByRepo.clear();
 }
 
 /** True when `@actor` (case-insensitive) appears as an owner token on any

--- a/apps/dev/tests/gh-trust-codeowners-cache.test.ts
+++ b/apps/dev/tests/gh-trust-codeowners-cache.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { GithubClient } from "@reddb-io/github";
+import type { GhContext } from "../src/runtime/gh.js";
+// The reset is a test-only seam; the barrel keeps its published surface.
+import { actorTrustSignals, resetCodeownersCache } from "../src/runtime/gh/trust.js";
+
+/** A routed client that answers 404 for every CODEOWNERS location and counts
+ * the asks, plus a permission read so the parallel signal resolves. */
+function countingClient(seen: string[]): GithubClient {
+  return {
+    conditionalRest: async (request: { parameters?: Record<string, unknown> }) => {
+      const path = String(request.parameters?.path ?? "");
+      if (path !== "") {
+        seen.push(path);
+        throw Object.assign(new Error("Not Found"), { status: 404 });
+      }
+      return { data: { permission: "write" }, headers: {}, quotaFree: false, requestCount: 1 };
+    },
+    conditionalPaginate: async () => { throw new Error("unexpected conditionalPaginate"); },
+    graphql: async () => { throw new Error("unexpected graphql"); },
+    singleObject: async () => { throw new Error("unexpected singleObject"); },
+  } as unknown as GithubClient;
+}
+
+function context(github: GithubClient): GhContext {
+  return { repo: "acme/widgets", cwd: "/tmp", github } as GhContext;
+}
+
+describe("CODEOWNERS resolution is a repository fact", () => {
+  beforeEach(() => {
+    resetCodeownersCache();
+  });
+
+  it("reads the recognised locations once, however many actors are judged", async () => {
+    const seen: string[] = [];
+    const ctx = context(countingClient(seen));
+
+    for (const actor of ["ana", "bruno", "carol", "dan"]) {
+      const signals = await actorTrustSignals(ctx, actor);
+      expect(signals.inCodeowners).toBe(false);
+    }
+
+    // Four actors, one repository: the trust gate asked per candidate and a
+    // boot listing 14 of them paid three 404s each.
+    expect(seen).toEqual([".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"]);
+  });
+
+  it("never caches an unavailable signal, so one blip cannot poison the process", async () => {
+    let failNext = true;
+    const seen: string[] = [];
+    const github = {
+      conditionalRest: async (request: { parameters?: Record<string, unknown> }) => {
+        const path = String(request.parameters?.path ?? "");
+        if (path === "") return { data: { permission: "read" }, headers: {}, quotaFree: false, requestCount: 1 };
+        seen.push(path);
+        if (failNext) throw Object.assign(new Error("bad gateway"), { status: 502 });
+        throw Object.assign(new Error("Not Found"), { status: 404 });
+      },
+      conditionalPaginate: async () => { throw new Error("unexpected conditionalPaginate"); },
+      graphql: async () => { throw new Error("unexpected graphql"); },
+      singleObject: async () => { throw new Error("unexpected singleObject"); },
+    } as unknown as GithubClient;
+    const ctx = context(github);
+
+    expect((await actorTrustSignals(ctx, "ana")).inCodeowners).toBeUndefined();
+    failNext = false;
+    expect((await actorTrustSignals(ctx, "ana")).inCodeowners).toBe(false);
+    expect(seen.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/github/conditional-client.test.ts
+++ b/packages/github/conditional-client.test.ts
@@ -793,3 +793,31 @@ describe("the balance watches; by default it stops nothing (#3768)", () => {
     expect(Date.now() - startedAt).toBeLessThan(10_000);
   });
 });
+
+describe("a 404 is an answer, not a failure", () => {
+  it("asks once for an absent resource instead of retrying it", async () => {
+    let calls = 0;
+    const client = createGithubClient({
+      token: "test-token",
+      throttle: false,
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response(JSON.stringify({ message: "Not Found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    const error = await client.conditionalRest({
+      cacheKey: "codeowners:acme/widgets:.github/CODEOWNERS",
+      route: "GET /repos/{owner}/{repo}/contents/{path}",
+      parameters: { owner: "acme", repo: "widgets", path: ".github/CODEOWNERS" },
+      operation: { key: "api rest", budget: "rest" },
+    }).then(() => null, (thrown: unknown) => thrown);
+
+    expect((error as { status?: number }).status).toBe(404);
+    // Retrying cost 93s of backoff per CODEOWNERS lookup and froze Worker boot.
+    expect(calls).toBe(1);
+  }, 60_000);
+});

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -255,7 +255,15 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
     ...(options.baseUrl ? { baseUrl: options.baseUrl } : {}),
     request: { fetch: timedFetch as unknown as GithubRequestFetch },
     retry: {
-      doNotRetry: [304, 403, 429],
+      // A 404 is an ANSWER, not a failure: the resource is absent and asking
+      // again cannot change that. Retrying one cost 93s of exponential backoff
+      // per CODEOWNERS lookup in a repo that has no CODEOWNERS file, and the
+      // trust gate asks per candidate — a boot that froze for ~22 minutes with
+      // no child, no log and `live=true` on every surface. Issue point reads
+      // are strongly consistent by number, so nothing legitimate depends on
+      // re-asking a 404; a caller awaiting eventual consistency must say so
+      // with its own bounded loop rather than paying this on every read.
+      doNotRetry: [304, 403, 404, 429],
       ...(options.retryCount === undefined ? {} : { retries: options.retryCount }),
     },
     throttle: options.throttle === false

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -201,19 +201,23 @@ cached, the next round retries it, and the round consumes no Re-seed budget.
 `1/1 100%` with no attempt. Release it through the tool, never by flipping
 labels by hand.
 
-### Merge driver — armed PRs land without native auto-merge
+### Merge driver — explicit recovery custody
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `merge_arm` | mutating | Hand one open PR to the project merge driver — it owns the PR to a terminal state. |
-| `merge_status` | read | The driver's durable per-PR records: armed set, attempts, terminal classifications. |
+| `merge_arm` | mutating | Hand one open PR to a live `merge-driver` process; refuses when that process is missing so custody cannot become orphaned. |
+| `merge_status` | read | Whether the `merge-driver` process is `ticking` or `missing`, plus durable per-PR records whose `actionability` distinguishes armed records as `driver-ticking` or `orphaned`. |
 | `merge_release` | mutating | Stop driver ownership of one PR (record kept as `released`). |
 
-The driver (#2512) runs in the project MCP resident on a fixed cadence: BEHIND →
+When the recovery driver (#2512) is running, its fixed cadence handles BEHIND →
 update-branch, green at head → merge with the merge-commit strategy (never an
-admin override), transient faults → bounded retries, DIRTY or failing checks →
-terminal `needs-medic`/`needs-human` classification instead of a loop. Its
-state survives resident restarts in `.red/state/castle/merge-driver.toon`.
+admin override), transient faults → bounded retries, and DIRTY or failing
+checks → terminal `needs-medic`/`needs-human` classification instead of a loop.
+Its state survives process restarts in `.red/state/castle/merge-driver.toon`.
+The ordinary MCP session no longer starts this loop (ADR 0136): native intent
+and the Queue Custodian own the normal landing tail. Therefore `merge_arm`
+fails loudly unless a live recovery process owns the `merge-driver` singleton;
+`merge_status` marks any older armed record `orphaned` when that owner is gone.
 
 ### Worktree — the disposable pool
 


### PR DESCRIPTION
## What broke

Every `red-skills` Worker born today froze at boot: no child process, no log line beyond the validation schedule, no socket, and `live=true` on every liveness surface. The statusline showed `hb=?` for 33 minutes at a time. The queue did not drain.

## Root cause, measured

The routed client's `doNotRetry` list held `[304, 403, 429]` — every status whose meaning is "do not ask again" except the most common one. **A 404 was retried with exponential backoff.**

The trust gate asks for CODEOWNERS at three recognised locations, **per actor, per candidate**. This repository has no CODEOWNERS file, so each lookup was three 404s, each retried four times:

```
.github/CODEOWNERS: status 404 after 15035ms
CODEOWNERS:         status 404 after 39107ms
docs/CODEOWNERS:    status 404 after 39108ms
```

**93 seconds per candidate.** A boot listing 14 candidates froze for ~22 minutes before touching any work. `toon` and `design-system` Workers ran only because their queues are short, not because they were spared.

Captured with a `--require` preload tapping `globalThis.fetch` before the bundle binds it — the growing gaps between three identical 404s are the whole story:

```
20:42:03.208 GET .../contents/.github%2FCODEOWNERS -> 404
20:42:04.420 GET .../contents/.github%2FCODEOWNERS -> 404   (+1.2s)
20:42:08.707 GET .../contents/.github%2FCODEOWNERS -> 404   (+4.3s)
```

## The fix, at both wrong layers

- **`packages/github` no longer retries a 404.** Issue point reads are strongly consistent by number, so nothing legitimate depended on re-asking; a caller awaiting eventual consistency must say so with its own bounded loop rather than making every read pay for it.
- **CODEOWNERS resolves once per repository per process.** The file is a repository fact that was being read as an actor fact. A read that FAILED is never cached, so one blip cannot poison the trust signal for the rest of the process.

## Verification

Both tests fail without their fix — checked by reverting each in place:

- `conditional-client.test.ts` — counts requests for one 404. Without the fix: `expected 4 to be 1`, taking 14s.
- `gh-trust-codeowners-cache.test.ts` — counts location reads across four actors. Without the cache: both cases fail.

`pnpm typecheck` clean · `pnpm -C apps/dev test:invariants` 194 passed.

## Related

The silent-freeze shape is the one ADR-declared waits exist to refuse (#2985): a retry ladder inside a client creates no child, opens no socket and writes nothing, so every liveness surface reads the stall as a healthy Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789159865&installation_model_id=20659&pr_number=3780&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3780&signature=0b8cd7c83236ac104bb2cc8189be42a4806fa40c0221af16234635a8f18e5251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->