### PR TITLE
fix: the release no longer depends on a download it never uses

### DIFF
--- a/.changeset/release-not-hostage-to-a-download.md
+++ b/.changeset/release-not-hostage-to-a-download.md
@@ -1,0 +1,17 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The release no longer depends on a download it never uses
+
+Publishing 3.17.3 failed at `pnpm install`: `@reddb-io/sdk`'s postinstall
+fetches the `red` binary from GitHub Releases and got an HTTP 503, then a 404.
+The Version PR was already merged, so `main` carried the bumped versions while
+the registry carried nothing — and the publish job only fires on that merge,
+so there was no path back except a fresh version cycle.
+
+The release job builds and publishes packages; it runs no SDK. Both of its
+installs now set `REDDB_SKIP_POSTINSTALL=1`, which is the difference between a
+release that depends on our own artifacts and one that depends on someone
+else's uptime. Fixed in the generator (`apps/release`) as well as the emitted
+workflow, so `/red-setup` does not regenerate the fragility.

--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Enable the repository package manager
         run: corepack enable
       - name: Install workspace dependencies
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
       - name: Maintain Version PR
         env:
@@ -51,6 +53,8 @@ jobs:
       - name: Enable the repository package manager
         run: corepack enable
       - name: Install workspace dependencies
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
       - name: Publish Release
         env:

--- a/apps/release/src/workflow-generator.ts
+++ b/apps/release/src/workflow-generator.ts
@@ -24,6 +24,16 @@ const TOOLCHAIN_STEPS: readonly string[] = [
   "      - name: Enable the repository package manager",
   "        run: corepack enable",
   "      - name: Install workspace dependencies",
+  // A dependency's postinstall that DOWNLOADS a binary makes the release
+  // hostage to a host the release never uses: `@reddb-io/sdk` fetches the
+  // `red` binary from GitHub Releases, and one 503 there failed the publish of
+  // an already-merged Version PR — versions bumped on main, nothing on the
+  // registry, and no path back except a fresh version cycle. The release job
+  // builds and publishes packages; it runs no SDK. Skipping the download is
+  // the difference between a release that depends on our own artifacts and one
+  // that depends on someone else's uptime.
+  "        env:",
+  "          REDDB_SKIP_POSTINSTALL: \"1\"",
   "        run: pnpm install --frozen-lockfile",
 ];
 const RELEASE_BOT = "red-skills-release[bot]";

--- a/apps/release/tests/fixtures/workflows/auto-vendored.yml
+++ b/apps/release/tests/fixtures/workflows/auto-vendored.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Enable the repository package manager
         run: corepack enable
       - name: Install workspace dependencies
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
       - name: Publish Release
         env:

--- a/apps/release/tests/fixtures/workflows/auto.yml
+++ b/apps/release/tests/fixtures/workflows/auto.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Enable the repository package manager
         run: corepack enable
       - name: Install workspace dependencies
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
       - name: Publish Release
         env:

--- a/apps/release/tests/fixtures/workflows/version-pr-vendored.yml
+++ b/apps/release/tests/fixtures/workflows/version-pr-vendored.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Enable the repository package manager
         run: corepack enable
       - name: Install workspace dependencies
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
       - name: Maintain Version PR
         env:
@@ -51,6 +53,8 @@ jobs:
       - name: Enable the repository package manager
         run: corepack enable
       - name: Install workspace dependencies
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
       - name: Publish Release
         env:

--- a/apps/release/tests/fixtures/workflows/version-pr.yml
+++ b/apps/release/tests/fixtures/workflows/version-pr.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Enable the repository package manager
         run: corepack enable
       - name: Install workspace dependencies
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
       - name: Maintain Version PR
         env:
@@ -51,6 +53,8 @@ jobs:
       - name: Enable the repository package manager
         run: corepack enable
       - name: Install workspace dependencies
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
       - name: Publish Release
         env:


### PR DESCRIPTION
## What broke

Publishing **3.17.3 failed** — and it failed after the point of no return.

The Version PR (#3772) merged, so `main` carries the bumped versions and the consumed changesets. Then `publish-release` died at `pnpm install`, because `@reddb-io/sdk`'s postinstall downloads the `red` binary from GitHub Releases:

```
reddb: downloading red v1.23.1 for linux/x64 from reddb-io/reddb
reddb: postinstall could not download the red binary (HTTP 503 ...)
Install failed
ELIFECYCLE  Command failed with exit code 1
```

A re-run failed the same way. So the repository says 3.17.3 shipped and the registry still serves 3.17.2, with **no path back**: `publish-release` fires only on the Version PR merge, and that merge has already happened.

## The fix

The release job builds and publishes packages. **It runs no SDK** — the binary it was waiting on is never used by anything in that job. Both installs now set `REDDB_SKIP_POSTINSTALL=1`.

Fixed in `apps/release`'s generator as well as the emitted workflow, so the next `/red-setup` refresh does not regenerate the fragility. The four golden fixtures move with it.

## Why this matters beyond today

A release pipeline that reaches a third party's uptime for an artifact it does not consume can fail at the one moment failure is most expensive: after the version bump has landed. This is the same shape as the dead ends the house invariants already record — an instruction pointing at its own precondition.

## Verification

`pnpm -C apps/release exec vitest run tests/workflow-generator.test.ts` — 10 passed (4 golden comparisons updated with the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789161065&installation_model_id=20659&pr_number=3781&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3781&signature=0e6194d5d7bf0b9b9a13dd94d089f38599372e49933f46dcdc1dd37c8b787c62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->