### PR TITLE
chore: #3784 /go: Harden the GitHub 404/CODEOWNERS fix before the next release, and add th

### DIFF
--- a/.changeset/harden-github-worker-release.md
+++ b/.changeset/harden-github-worker-release.md
@@ -1,0 +1,18 @@
+---
+"@reddb-io/github": patch
+"@reddb-io/red-skills": patch
+---
+
+Harden GitHub reads and Worker operations for the next patch release.
+
+- Preserve every definitive GitHub response as a single request while leaving
+  transient server and network failures retryable. CODEOWNERS is shared across
+  one trust evaluation, then refreshed for the next evaluation so revoked or
+  changed ownership is observed without a process restart.
+- Keep read-after-write recovery where its context belongs: `/go` performs a
+  targeted, bounded read-back of the Ticket it just created.
+- Restage generated Pi packages after landing reconciliation, use the canonical
+  statusline invocation, and keep the incumbent daemon alive until its successor
+  completes the handoff.
+- Make Worker progress easier to interpret with clearer phase, step, activity,
+  and clock reporting.

--- a/apps/dev/src/commands/run/ports/gh.ts
+++ b/apps/dev/src/commands/run/ports/gh.ts
@@ -34,7 +34,7 @@ export function buildGhPort(ghCtx: GhContext): ProcessIssueDeps["gh"] {
     // repo with no allowlist fails closed while a private one stays permissive.
     repoVisibility: () => ghx.repoVisibility(ghCtx),
     // Dynamic-base trust signals (write-access / CODEOWNERS) for the fail-closed author + promoter check (#1101, reusing #747).
-    actorTrustSignals: (actor) => ghx.actorTrustSignals(ghCtx, actor),
+    actorTrustSignals: ghx.createActorTrustLookup(ghCtx),
     externalApprovalActors: (issue) => ghx.externalApprovalActors(ghCtx, issue), // /approve-external authors, trust-resolved on claim (#2603)
     // HITL decision card (#935, S11a): post/update the card on escalation.
     // Best-effort: errors are caught in routeRecovery so they never block

--- a/apps/dev/src/mcp/dependencies.ts
+++ b/apps/dev/src/mcp/dependencies.ts
@@ -218,7 +218,7 @@ export function createCastleMcpDependencies(
         policy,
         {
           issueTrust: (candidate) => ghx.issueTrust(gh, candidate.number),
-          actorTrustSignals: (actor) => ghx.actorTrustSignals(gh, actor),
+          actorTrustSignals: ghx.createActorTrustLookup(gh),
         },
       );
       return buildQueueStatus(eligible, heldForSummon, readyForHuman);

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -63,6 +63,7 @@ export {
   issueAuthor,
   repoVisibility,
   actorTrustSignals,
+  createActorTrustLookup,
   externalApprovalActors,
 } from "./gh/trust.js";
 export { issueMeta } from "./gh/meta.js";

--- a/apps/dev/src/runtime/gh/trust.ts
+++ b/apps/dev/src/runtime/gh/trust.ts
@@ -197,15 +197,37 @@ function commentBearsApprovalMarker(body: string): boolean {
  *     → `admin` / `maintain` / `write` count as write-or-higher;
  *   - CODEOWNERS: fetch the repo CODEOWNERS file (the three GitHub-recognised
  *     locations) and test whether `@actor` appears as an owner token.
- * Bound to an `ActorTrustLookup` by the caller as `(actor) => actorTrustSignals(ctx, actor)`.
+ * A one-off call is one independent evaluation. Callers judging several actors
+ * together use {@link createActorTrustLookup} so those actors share one
+ * CODEOWNERS resolution without carrying it into a later evaluation.
  */
 export async function actorTrustSignals(
   ctx: GhContext,
   actor: string,
 ): Promise<{ hasWriteAccess?: boolean; inCodeowners?: boolean }> {
+  return createActorTrustLookup(ctx)(actor);
+}
+
+/**
+ * Bind one trust evaluation to a repository context. CODEOWNERS is resolved at
+ * most once per repository for the returned lookup, including a definitive
+ * absence, and is forgotten when the caller releases the lookup.
+ */
+export function createActorTrustLookup(
+  ctx: GhContext,
+): (actor: string) => Promise<{ hasWriteAccess?: boolean; inCodeowners?: boolean }> {
+  const codeownersByRepo = new Map<string, Promise<string | null | undefined>>();
+  return (actor) => actorTrustSignalsInEvaluation(ctx, actor, codeownersByRepo);
+}
+
+async function actorTrustSignalsInEvaluation(
+  ctx: GhContext,
+  actor: string,
+  codeownersByRepo: Map<string, Promise<string | null | undefined>>,
+): Promise<{ hasWriteAccess?: boolean; inCodeowners?: boolean }> {
   const [hasWriteAccess, inCodeowners] = await Promise.all([
     actorWriteAccess(ctx, actor),
-    actorInCodeowners(ctx, actor),
+    actorInCodeowners(ctx, actor, codeownersByRepo),
   ]);
   return { hasWriteAccess, inCodeowners };
 }
@@ -236,18 +258,6 @@ async function actorWriteAccess(ctx: GhContext, actor: string): Promise<boolean 
 
 /** The GitHub-recognised CODEOWNERS locations, in resolution order. */
 const CODEOWNERS_PATHS = [".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"];
-
-/**
- * The CODEOWNERS file resolved once per repository per process.
- *
- * The file is a REPOSITORY fact, but the trust gate asks it per candidate: a
- * boot listing 14 candidates re-read the same three locations 14 times. In a
- * repo that has no CODEOWNERS, every one of those was three 404s, which is why
- * this cache is load-bearing rather than an optimization. `null` records the
- * definitive absence; a read that FAILED is never cached, so one blip cannot
- * poison the trust signal for the rest of the process.
- */
-const codeownersByRepo = new Map<string, Promise<string | null | undefined>>();
 
 /** Read the first CODEOWNERS location that resolves. `null` when every
  * recognised location answered a definitive 404, `undefined` when no read
@@ -281,7 +291,11 @@ async function readRepoCodeowners(
 /** Resolve whether `@actor` is an owner token in the repo CODEOWNERS file.
  * undefined when no read succeeded (transient/auth) and `false` when a file was
  * read but the actor is absent (or no CODEOWNERS exists at all). */
-async function actorInCodeowners(ctx: GhContext, actor: string): Promise<boolean | undefined> {
+async function actorInCodeowners(
+  ctx: GhContext,
+  actor: string,
+  codeownersByRepo: Map<string, Promise<string | null | undefined>>,
+): Promise<boolean | undefined> {
   const repo = githubRepo(ctx);
   if (!repo) return undefined;
   const key = `${repo.owner}/${repo.repo}`;
@@ -296,12 +310,6 @@ async function actorInCodeowners(ctx: GhContext, actor: string): Promise<boolean
     return undefined;
   }
   return content === null ? false : codeownersHasOwner(content, actor);
-}
-
-/** Forget the per-process CODEOWNERS resolutions. Tests only: a cache that
- * survives between cases would answer the next case's first read. */
-export function resetCodeownersCache(): void {
-  codeownersByRepo.clear();
 }
 
 /** True when `@actor` (case-insensitive) appears as an owner token on any

--- a/apps/dev/tests/gh-export-surface.test.ts
+++ b/apps/dev/tests/gh-export-surface.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_GH_EXPORTS = [
   "countStatuslineQueueCounts",
   "countUnlabeled",
   "crashedClaimState",
+  "createActorTrustLookup",
   "createIssue",
   "editBody",
   "editComment",

--- a/apps/dev/tests/gh-trust-codeowners-cache.test.ts
+++ b/apps/dev/tests/gh-trust-codeowners-cache.test.ts
@@ -1,8 +1,7 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { GithubClient } from "@reddb-io/github";
 import type { GhContext } from "../src/runtime/gh.js";
-// The reset is a test-only seam; the barrel keeps its published surface.
-import { actorTrustSignals, resetCodeownersCache } from "../src/runtime/gh/trust.js";
+import { actorTrustSignals, createActorTrustLookup } from "../src/runtime/gh/trust.js";
 
 /** A routed client that answers 404 for every CODEOWNERS location and counts
  * the asks, plus a permission read so the parallel signal resolves. */
@@ -27,22 +26,44 @@ function context(github: GithubClient): GhContext {
 }
 
 describe("CODEOWNERS resolution is a repository fact", () => {
-  beforeEach(() => {
-    resetCodeownersCache();
-  });
-
-  it("reads the recognised locations once, however many actors are judged", async () => {
+  it("reads the recognised locations once for all actors in one evaluation", async () => {
     const seen: string[] = [];
-    const ctx = context(countingClient(seen));
+    const lookup = createActorTrustLookup(context(countingClient(seen)));
 
     for (const actor of ["ana", "bruno", "carol", "dan"]) {
-      const signals = await actorTrustSignals(ctx, actor);
+      const signals = await lookup(actor);
       expect(signals.inCodeowners).toBe(false);
     }
 
     // Four actors, one repository: the trust gate asked per candidate and a
     // boot listing 14 of them paid three 404s each.
     expect(seen).toEqual([".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"]);
+  });
+
+  it("observes changed owners in a later independent evaluation", async () => {
+    let content = "* @ana";
+    let codeownersReads = 0;
+    const github = {
+      conditionalRest: async (request: { parameters?: Record<string, unknown> }) => {
+        const path = String(request.parameters?.path ?? "");
+        if (path === "") return { data: { permission: "read" }, headers: {}, quotaFree: false, requestCount: 1 };
+        codeownersReads += 1;
+        return { data: content, headers: {}, quotaFree: false, requestCount: 1 };
+      },
+      conditionalPaginate: async () => { throw new Error("unexpected conditionalPaginate"); },
+      graphql: async () => { throw new Error("unexpected graphql"); },
+      singleObject: async () => { throw new Error("unexpected singleObject"); },
+    } as unknown as GithubClient;
+    const ctx = context(github);
+
+    const firstEvaluation = createActorTrustLookup(ctx);
+    expect((await firstEvaluation("ana")).inCodeowners).toBe(true);
+
+    content = "* @bruno";
+    const laterEvaluation = createActorTrustLookup(ctx);
+    expect((await laterEvaluation("ana")).inCodeowners).toBe(false);
+    expect((await laterEvaluation("bruno")).inCodeowners).toBe(true);
+    expect(codeownersReads).toBe(2);
   });
 
   it("never caches an unavailable signal, so one blip cannot poison the process", async () => {

--- a/packages/github/conditional-client.test.ts
+++ b/packages/github/conditional-client.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createGithubAttributionLedger } from "./attribution.js";
 import {
@@ -795,6 +795,39 @@ describe("the balance watches; by default it stops nothing (#3768)", () => {
 });
 
 describe("a 404 is an answer, not a failure", () => {
+  it.each([304, 400, 401, 403, 404, 410, 422, 429, 451])(
+    "asks once when GitHub gives the definitive status %i",
+    async (status) => {
+      vi.useFakeTimers();
+      let calls = 0;
+      const client = createGithubClient({
+        token: "test-token",
+        retryCount: 3,
+        throttle: false,
+        fetchImpl: async () => {
+          calls += 1;
+          return new Response(status === 304 ? null : JSON.stringify({ message: "definitive answer" }), {
+            status,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      });
+
+      const answer = client.conditionalRest({
+        cacheKey: `definitive:${status}`,
+        route: "GET /repos/{owner}/{repo}/contents/{path}",
+        parameters: { owner: "acme", repo: "widgets", path: "CODEOWNERS" },
+        operation: { key: "api rest", budget: "rest" },
+      }).catch(() => undefined);
+      await vi.runAllTimersAsync();
+      await answer;
+      vi.useRealTimers();
+
+      expect(calls).toBe(1);
+    },
+    60_000,
+  );
+
   it("asks once for an absent resource instead of retrying it", async () => {
     let calls = 0;
     const client = createGithubClient({

--- a/packages/github/conditional-client.ts
+++ b/packages/github/conditional-client.ts
@@ -255,15 +255,13 @@ export function createGithubClient(options: CreateGithubClientOptions): GithubCl
     ...(options.baseUrl ? { baseUrl: options.baseUrl } : {}),
     request: { fetch: timedFetch as unknown as GithubRequestFetch },
     retry: {
-      // A 404 is an ANSWER, not a failure: the resource is absent and asking
-      // again cannot change that. Retrying one cost 93s of exponential backoff
-      // per CODEOWNERS lookup in a repo that has no CODEOWNERS file, and the
-      // trust gate asks per candidate — a boot that froze for ~22 minutes with
-      // no child, no log and `live=true` on every surface. Issue point reads
-      // are strongly consistent by number, so nothing legitimate depends on
-      // re-asking a 404; a caller awaiting eventual consistency must say so
-      // with its own bounded loop rather than paying this on every read.
-      doNotRetry: [304, 403, 404, 429],
+      // A definitive HTTP answer is not a transient transport failure. In
+      // particular, retrying an absent CODEOWNERS path cost 93s of backoff per
+      // lookup. Read-after-write consistency belongs to the caller that knows
+      // it just wrote: /go owns a targeted bounded issue read-back, while the
+      // shared transport preserves Octokit's full definitive set plus 304,
+      // 410, 429 and 451 rather than retrying every ordinary point read.
+      doNotRetry: [304, 400, 401, 403, 404, 410, 422, 429, 451],
       ...(options.retryCount === undefined ? {} : { retries: options.retryCount }),
     },
     throttle: options.throttle === false


### PR DESCRIPTION
Automated AFK landing for #3784. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3784

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789165163&installation_model_id=20659&pr_number=3785&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3785&signature=7599708881c945ea7a595a69118efdecdf9c675e45cce634421dd264e6d298d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->