### PR TITLE
merge: #3773 Validation quarantine parks green work: a passing check (exitCode 0) is recorded as the blocking failure

### DIFF
--- a/.changeset/evidence-outranks-duration.md
+++ b/.changeset/evidence-outranks-duration.md
@@ -1,0 +1,26 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Structured branch evidence outranks duration in the failed-Validation Verdict
+
+A suite-shaped command that exited in under a second was read as proof the
+suite never started, and therefore as an environment failure. The inference is
+invalid whenever turbo replays a cache hit: a cached task answers in
+milliseconds precisely because it does not need to start. Real compiler errors,
+failing assertions and guard findings came back in 26 and 45 milliseconds and
+were stamped `suspect-infra`, so the Re-seed budget was spent on the wrong
+repair and land-able work was parked into the human queue. Five parks in one day
+carried that stamp; every one verified by hand was a deterministic contract
+defect.
+
+Duration no longer decides on its own. A round whose output names a concrete
+compiler error, a failing assertion, or a guard finding is a BRANCH fault
+however fast it returned; the environment verdict is reserved for rounds that
+produced no such evidence.
+
+The narrower half of the old rule went with it. Concrete evidence used to count
+only when the diagnostic also named a file the branch had changed — so a real
+type error inherited from a stale base did not qualify, which is exactly the
+shape that misclassified. Evidence is now evidence regardless of which file it
+points at.

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -42,7 +42,8 @@ import {
   type ValidationTarget,
   type ValidationTargetKind,
 } from "./validation-command.js";
-import { blockingValidationChecks, decideVerdict, emptyEnvironmentLedger } from "./verdict.js";
+import { decideVerdict, emptyEnvironmentLedger } from "./verdict.js";
+import { applyValidationEvidence, reconcileValidationEvidence } from "./validation-evidence.js";
 
 /** Result of a single executed command. Mirrors a child-process completion. */
 export interface ExecResult {
@@ -447,56 +448,6 @@ export interface ClassifiableCheck {
   record: ValidationRecord;
 }
 
-export const ALL_GREEN_VALIDATION_INCONSISTENCY =
-  "aggregate validation result reported failure with all-green validation evidence; " +
-  "refusing blocked:validation park";
-
-/**
- * Reconcile the aggregate boolean against the durable per-command authority.
- * A failed record with exitCode 0 is internally contradictory; when no other
- * record can justify failure, preserve the green command fact and surface the
- * inconsistency instead of manufacturing a branch fault.
- */
-export function reconcileValidationEvidence<T extends ClassifiableCheck>(
-  reportedFailed: boolean,
-  checks: readonly T[],
-): { ok: boolean; checks: T[]; sidecar: string[]; inconsistency?: string } {
-  if (!reportedFailed || blockingValidationChecks(checks).length > 0 || checks.length === 0) {
-    return {
-      ok: !reportedFailed,
-      checks: [...checks],
-      sidecar: checks.map((check) => formatValidationLine(check.record)),
-    };
-  }
-  const allGreen = checks.every(
-    (check) => check.status !== "failed" || check.record.exitCode === 0,
-  );
-  if (!allGreen) {
-    return {
-      ok: false,
-      checks: [...checks],
-      sidecar: checks.map((check) => formatValidationLine(check.record)),
-    };
-  }
-  const reconciled = checks.map((check) => {
-    if (check.status !== "failed" || check.record.exitCode !== 0) return check;
-    const record: ValidationRecord = {
-      ...check.record,
-      status: "passed",
-      summary: "command exited 0",
-    };
-    delete record.suspectInfra;
-    delete record.infra;
-    return { ...check, status: "passed", record } as T;
-  });
-  return {
-    ok: true,
-    checks: reconciled,
-    sidecar: reconciled.map((check) => formatValidationLine(check.record)),
-    inconsistency: ALL_GREEN_VALIDATION_INCONSISTENCY,
-  };
-}
-
 /** Strip ANSI SGR sequences so identity matching survives coloured runner output.
  * Test runners colour their FAIL markers; the raw captured bytes keep the escape
  * codes, and an un-stripped `^\s*FAIL\b` never matches `\x1b[31m FAIL \x1b[0m`. */
@@ -654,7 +605,6 @@ export interface RunFeedbackInput {
 export interface RunFeedbackResult {
   /** False when any check failed — the merge gate (ADR 0008). */
   ok: boolean;
-  /** Loud evidence that a contradictory aggregate failure was refused. */
   evidenceInconsistency?: string;
   /** Every check that ran/skipped, in `script × scope` order. */
   checks: FeedbackCheck[];
@@ -1006,10 +956,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
 
     const evidence = reconcileValidationEvidence(failed, checks);
     return {
-      ok: evidence.ok,
-      checks: evidence.checks,
-      sidecar: evidence.sidecar,
-      ...(evidence.inconsistency ? { evidenceInconsistency: evidence.inconsistency } : {}),
+      ...evidence,
       baselineInconclusive: [],
       quarantined: [],
       ...(validationScope === undefined ? {} : { validationScope }),
@@ -1191,12 +1138,8 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     }
   }
 
-  const evidence = reconcileValidationEvidence(failed, checks);
-  if (evidence.inconsistency) {
-    checks.splice(0, checks.length, ...evidence.checks);
-    sidecar.splice(0, sidecar.length, ...evidence.sidecar);
-    failed = false;
-  }
+  const evidence = applyValidationEvidence(failed, checks, sidecar);
+  failed = evidence.failed;
 
   // Baseline comparison is meaningful only when Verdict sees no environment
   // refusal in the check records. Verdict remains the sole fault classifier.
@@ -1252,25 +1195,12 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     }
     failed = gateDecision.shouldBlock;
     return {
-      ok: !failed,
-      checks,
-      sidecar,
+      ok: !failed, checks, sidecar,
       baselineInconclusive: gateDecision.inconclusiveFailures,
-      baselineProbeRan: true,
-      baselineVerdict: gateDecision.verdict,
-      quarantined: quarantine,
-      ...(evidence.inconsistency ? { evidenceInconsistency: evidence.inconsistency } : {}),
+      baselineProbeRan: true, baselineVerdict: gateDecision.verdict, quarantined: quarantine,
+      ...(evidence.evidenceInconsistency ? { evidenceInconsistency: evidence.evidenceInconsistency } : {}),
       validationScope,
     };
   }
-
-  return {
-    ok: !failed,
-    checks,
-    sidecar,
-    baselineInconclusive: [],
-    quarantined: quarantine,
-    ...(evidence.inconsistency ? { evidenceInconsistency: evidence.inconsistency } : {}),
-    validationScope,
-  };
+  return { ok: !failed, checks, sidecar, baselineInconclusive: [], quarantined: quarantine, ...(evidence.evidenceInconsistency ? { evidenceInconsistency: evidence.evidenceInconsistency } : {}), validationScope };
 }

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -418,11 +418,16 @@ function buildRanRecord(input: {
   command: string;
   exitCode: number;
   durationMs: number;
+  output: string;
   summary: string;
   setup?: string;
   infra?: "stall";
 }): ValidationRecord {
-  const suspect = isSuspectInfraFailure({ status: input.status, durationMs: input.durationMs });
+  const suspect = isSuspectInfraFailure({
+    status: input.status,
+    durationMs: input.durationMs,
+    output: input.output,
+  });
   const summary = suspect
     ? suspectInfraSummary({
         command: input.command,
@@ -941,13 +946,15 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       const durationMs = now() - start;
       const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
       if (status === "failed") failed = true;
+      const output = joinCommandOutput(result.stdout, result.stderr);
       const record = buildRanRecord({
         name,
         status,
         command,
         exitCode: result.code,
         durationMs,
-        summary: outputSummary(status, joinCommandOutput(result.stdout, result.stderr)),
+        output,
+        summary: outputSummary(status, output),
         setup: result.setup,
         infra: result.infraEvidence?.kind,
       });
@@ -1038,13 +1045,15 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
       if (status === "failed") failed = true;
       const command = recordedValidationCommand(composed, script, excludeArgs, result.commandDir);
-      const summary = outputSummary(status, joinCommandOutput(result.stdout, result.stderr));
+      const output = joinCommandOutput(result.stdout, result.stderr);
+      const summary = outputSummary(status, output);
       const record = buildRanRecord({
         name,
         status,
         command,
         exitCode: result.code,
         durationMs,
+        output,
         summary,
         setup: result.setup,
         infra: result.infraEvidence?.kind,
@@ -1072,13 +1081,15 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") failed = true;
     const command = recordedValidationCommand(composed, "typecheck", [], result.commandDir);
-    const summary = outputSummary(status, joinCommandOutput(result.stdout, result.stderr));
+    const output = joinCommandOutput(result.stdout, result.stderr);
+    const summary = outputSummary(status, output);
     const record = buildRanRecord({
       name,
       status,
       command,
       exitCode: result.code,
       durationMs,
+      output,
       summary,
       setup: result.setup,
       infra: result.infraEvidence?.kind,
@@ -1130,6 +1141,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
         command,
         exitCode: result.code,
         durationMs,
+        output,
         summary,
         setup: result.setup,
         infra: result.infraEvidence?.kind,

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -44,6 +44,9 @@ import {
 } from "./validation-command.js";
 import { decideVerdict, emptyEnvironmentLedger } from "./verdict.js";
 import { applyValidationEvidence, reconcileValidationEvidence } from "./validation-evidence.js";
+import { namedFailures, outputSummary } from "./validation-output.js";
+
+export { namedFailures, outputSummary };
 
 /** Result of a single executed command. Mirrors a child-process completion. */
 export interface ExecResult {
@@ -451,69 +454,6 @@ export function formatValidationLine(record: ValidationRecord): string {
 export interface ClassifiableCheck {
   status: ValidationStatus;
   record: ValidationRecord;
-}
-
-/** Strip ANSI SGR sequences so identity matching survives coloured runner output.
- * Test runners colour their FAIL markers; the raw captured bytes keep the escape
- * codes, and an un-stripped `^\s*FAIL\b` never matches `\x1b[31m FAIL \x1b[0m`. */
-function stripAnsi(line: string): string {
-  // eslint-disable-next-line no-control-regex
-  return line.replace(/\x1b\[[0-9;]*m/g, "");
-}
-
-/** Patterns that name WHICH check failed, as opposed to how many did.
- * Vitest emits `FAIL  <file> > <suite> > <test>`; cargo emits `<name> ... FAILED`
- * and `---- <name> stdout ----`. Every one of them prints ABOVE the run's
- * trailing counters, which is precisely why a tail slice loses them. */
-const FAILURE_IDENTITY_PATTERNS: readonly RegExp[] = [
-  /^\s*FAIL\s+\S.*$/,
-  /^\s*\S.*\.{3}\s+FAILED\s*$/,
-  /^\s*----\s+\S.*\s+stdout\s+----\s*$/,
-];
-
-/** How many distinct failing identities to name before eliding the rest. A run
- * with dozens of failures is a systemic break, not a list to read line by line. */
-const MAX_NAMED_FAILURES = 5;
-
-/** Scan the WHOLE output for lines that name a failing check, deduped and in
- * first-seen order. Returns [] when the runner names nothing recognisable, which
- * keeps the tail-only summary as the honest fallback rather than inventing one. */
-export function namedFailures(output: string): string[] {
-  const seen = new Set<string>();
-  for (const raw of output.split("\n")) {
-    const line = stripAnsi(raw).replace(/\s+/g, " ").trim();
-    if (line === "") continue;
-    if (!FAILURE_IDENTITY_PATTERNS.some((re) => re.test(line))) continue;
-    seen.add(line);
-    if (seen.size >= MAX_NAMED_FAILURES) break;
-  }
-  return [...seen];
-}
-
-/**
- * Short summary for a finished check — the port of afk_validation_output_summary.
- * A passing check is always `command exited 0`; a failing check surfaces the
- * identities of the checks that failed followed by a trailing slice of its
- * captured output (joined to one line, capped at 1000 chars), or `command exited
- * non-zero` when there is nothing to show.
- *
- * The identity prefix exists because the tail alone is NOT actionable: a runner
- * prints `Tests 2 failed | 3750 passed` at the very end but names the two
- * failures higher up, so a park built from the tail says how many broke while
- * dropping which — forcing a human (or a whole CI round-trip) to re-derive what
- * the gate already had in hand. The identities lead because they are the part a
- * reader acts on, and the 1000-char cap is applied last so a verbose tail can
- * never crowd them out.
- */
-export function outputSummary(status: ValidationStatus, output: string): string {
-  if (status === "passed") return "command exited 0";
-  const trimmed = output.replace(/\n+$/, "");
-  if (trimmed === "") return "command exited non-zero";
-  const lines = trimmed.split("\n");
-  const tail = lines.slice(-20).join(" ");
-  const named = namedFailures(trimmed);
-  if (named.length === 0) return tail.slice(0, 1000);
-  return `failing: ${named.join(" | ")} — ${tail}`.slice(0, 1000);
 }
 
 // ---------- orchestration ----------

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -44,9 +44,12 @@ import {
 } from "./validation-command.js";
 import { decideVerdict, emptyEnvironmentLedger } from "./verdict.js";
 import { applyValidationEvidence, reconcileValidationEvidence } from "./validation-evidence.js";
-import { namedFailures, outputSummary } from "./validation-output.js";
+import { outputSummary } from "./validation-output.js";
 
-export { namedFailures, outputSummary };
+// Re-exported from the source rather than imported-then-exported: a binding a
+// module only forwards is not a binding it USES, and the import-hygiene ratchet
+// counts the difference.
+export { namedFailures, outputSummary } from "./validation-output.js";
 
 /** Result of a single executed command. Mirrors a child-process completion. */
 export interface ExecResult {

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -42,7 +42,7 @@ import {
   type ValidationTarget,
   type ValidationTargetKind,
 } from "./validation-command.js";
-import { decideVerdict, emptyEnvironmentLedger } from "./verdict.js";
+import { blockingValidationChecks, decideVerdict, emptyEnvironmentLedger } from "./verdict.js";
 
 /** Result of a single executed command. Mirrors a child-process completion. */
 export interface ExecResult {
@@ -447,6 +447,56 @@ export interface ClassifiableCheck {
   record: ValidationRecord;
 }
 
+export const ALL_GREEN_VALIDATION_INCONSISTENCY =
+  "aggregate validation result reported failure with all-green validation evidence; " +
+  "refusing blocked:validation park";
+
+/**
+ * Reconcile the aggregate boolean against the durable per-command authority.
+ * A failed record with exitCode 0 is internally contradictory; when no other
+ * record can justify failure, preserve the green command fact and surface the
+ * inconsistency instead of manufacturing a branch fault.
+ */
+export function reconcileValidationEvidence<T extends ClassifiableCheck>(
+  reportedFailed: boolean,
+  checks: readonly T[],
+): { ok: boolean; checks: T[]; sidecar: string[]; inconsistency?: string } {
+  if (!reportedFailed || blockingValidationChecks(checks).length > 0 || checks.length === 0) {
+    return {
+      ok: !reportedFailed,
+      checks: [...checks],
+      sidecar: checks.map((check) => formatValidationLine(check.record)),
+    };
+  }
+  const allGreen = checks.every(
+    (check) => check.status !== "failed" || check.record.exitCode === 0,
+  );
+  if (!allGreen) {
+    return {
+      ok: false,
+      checks: [...checks],
+      sidecar: checks.map((check) => formatValidationLine(check.record)),
+    };
+  }
+  const reconciled = checks.map((check) => {
+    if (check.status !== "failed" || check.record.exitCode !== 0) return check;
+    const record: ValidationRecord = {
+      ...check.record,
+      status: "passed",
+      summary: "command exited 0",
+    };
+    delete record.suspectInfra;
+    delete record.infra;
+    return { ...check, status: "passed", record } as T;
+  });
+  return {
+    ok: true,
+    checks: reconciled,
+    sidecar: reconciled.map((check) => formatValidationLine(check.record)),
+    inconsistency: ALL_GREEN_VALIDATION_INCONSISTENCY,
+  };
+}
+
 /** Strip ANSI SGR sequences so identity matching survives coloured runner output.
  * Test runners colour their FAIL markers; the raw captured bytes keep the escape
  * codes, and an un-stripped `^\s*FAIL\b` never matches `\x1b[31m FAIL \x1b[0m`. */
@@ -604,6 +654,8 @@ export interface RunFeedbackInput {
 export interface RunFeedbackResult {
   /** False when any check failed — the merge gate (ADR 0008). */
   ok: boolean;
+  /** Loud evidence that a contradictory aggregate failure was refused. */
+  evidenceInconsistency?: string;
   /** Every check that ran/skipped, in `script × scope` order. */
   checks: FeedbackCheck[];
   /** The sidecar lines, one JSONL record per check, in the same order. */
@@ -952,10 +1004,12 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       push({ name, script: "test", label: "operator", scope: "", status, record });
     }
 
+    const evidence = reconcileValidationEvidence(failed, checks);
     return {
-      ok: !failed,
-      checks,
-      sidecar,
+      ok: evidence.ok,
+      checks: evidence.checks,
+      sidecar: evidence.sidecar,
+      ...(evidence.inconsistency ? { evidenceInconsistency: evidence.inconsistency } : {}),
       baselineInconclusive: [],
       quarantined: [],
       ...(validationScope === undefined ? {} : { validationScope }),
@@ -1137,6 +1191,13 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     }
   }
 
+  const evidence = reconcileValidationEvidence(failed, checks);
+  if (evidence.inconsistency) {
+    checks.splice(0, checks.length, ...evidence.checks);
+    sidecar.splice(0, sidecar.length, ...evidence.sidecar);
+    failed = false;
+  }
+
   // Baseline comparison is meaningful only when Verdict sees no environment
   // refusal in the check records. Verdict remains the sole fault classifier.
   const checksFault = failed
@@ -1198,9 +1259,18 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       baselineProbeRan: true,
       baselineVerdict: gateDecision.verdict,
       quarantined: quarantine,
+      ...(evidence.inconsistency ? { evidenceInconsistency: evidence.inconsistency } : {}),
       validationScope,
     };
   }
 
-  return { ok: !failed, checks, sidecar, baselineInconclusive: [], quarantined: quarantine, validationScope };
+  return {
+    ok: !failed,
+    checks,
+    sidecar,
+    baselineInconclusive: [],
+    quarantined: quarantine,
+    ...(evidence.inconsistency ? { evidenceInconsistency: evidence.inconsistency } : {}),
+    validationScope,
+  };
 }

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -185,6 +185,7 @@ import {
   type Verdict,
 } from "../verdict.js";
 import { abortAfterClaim, claimLost, emitBackpressureReview, emitDone, handoffForManualLanding, handoffForReview, hookContext, isRunnerRecoverableOutcome, landLockBackoff, mergeFailed, ciBlocked, prLandingBlocked, trunkDivergedBlocked, onErrorContext, parseHookEnv, postAttemptContext, recordOutcomeBestEffort, releaseOwnedClaim, runCascadeRebase, runCloseCascade, runnerRecoverable, terminalFailure, writeValidationSidecar, type StageCommon } from "./terminal.js";
+import { reportValidationEvidenceInconsistency } from "./validation-park.js";
 import { parseRecords } from "@reddb-io/toon";
 
 /** Recorded when the forge refused the merge and the PR state did not explain it
@@ -225,8 +226,6 @@ function setupFailureExcerpt(log: string | null | undefined): string | undefined
   if (setupFailure < 0) return undefined;
   return lines.slice(setupFailure, setupFailure + 4).join("\n");
 }
-
-
 export async function processIssue(
   deps: ProcessIssueDeps,
   input: ProcessIssueInput,
@@ -1559,14 +1558,7 @@ export async function processIssue(
           : { commands: deps.feedbackCommands, commandExec: deps.backpressure }),
       });
     }
-    if (feedback.evidenceInconsistency) {
-      const note = `🤖 ${reseedLane}: INCONSISTENT Validation result — ${feedback.evidenceInconsistency}.`;
-      deps.appendIterLog(note);
-      deps.recordWorkerEvent?.("worker.validation_evidence_inconsistency", {
-        stage: "feedback",
-        reason: feedback.evidenceInconsistency,
-      });
-    }
+    reportValidationEvidenceInconsistency(feedback, reseedLane, deps);
     markProcessSafetyStep("post-agent:feedback-done");
     const baseMergeGeometry = deps.baseMergeReversionGeometry?.(workerBranch);
     if (baseMergeGeometry) {

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1559,6 +1559,14 @@ export async function processIssue(
           : { commands: deps.feedbackCommands, commandExec: deps.backpressure }),
       });
     }
+    if (feedback.evidenceInconsistency) {
+      const note = `🤖 ${reseedLane}: INCONSISTENT Validation result — ${feedback.evidenceInconsistency}.`;
+      deps.appendIterLog(note);
+      deps.recordWorkerEvent?.("worker.validation_evidence_inconsistency", {
+        stage: "feedback",
+        reason: feedback.evidenceInconsistency,
+      });
+    }
     markProcessSafetyStep("post-agent:feedback-done");
     const baseMergeGeometry = deps.baseMergeReversionGeometry?.(workerBranch);
     if (baseMergeGeometry) {

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -19,12 +19,10 @@ import {
   type SandboxMode,
 } from "../execution.js";
 import {
-  VALIDATION_SCHEMA,
   runFeedback,
   type Exec as PnpmExec,
   type PackageLayout,
   type RunFeedbackResult,
-  type ValidationRecord,
 } from "../feedback.js";
 import {
   computeValidationScope,
@@ -115,6 +113,7 @@ import {
 } from "../triage-labels.js";
 import type { ProcessIssueDeps, ProcessIssueInput, ProcessIssueResult, ProcessOutcome, WorkerBaseResolution } from "./types.js";
 import { formatBaseResolution, markTerminalState, recoveryOrdinalFor } from "./types.js";
+import { validationBlockerSummary } from "./validation-park.js";
 import { recordIssueHeal } from "@reddb-io/red-castle/engine";
 import { editIssueLifecycleLabels, routeRecovery } from "./recovery.js";
 export async function writeValidationSidecar(
@@ -243,73 +242,6 @@ export function oneLine(value: string | undefined, fallback: string): string {
     .find((part) => part.length > 0);
   return line ?? fallback;
 }
-
-function validationRecords(value: string | undefined): ValidationRecord[] {
-  if (!value) return [];
-  const records: ValidationRecord[] = [];
-  for (const line of value.split("\n")) {
-    try {
-      const parsed = JSON.parse(line) as Partial<ValidationRecord>;
-      if (
-        parsed.schema === VALIDATION_SCHEMA &&
-        typeof parsed.name === "string" &&
-        (parsed.status === "passed" || parsed.status === "failed" || parsed.status === "skipped")
-      ) {
-        records.push(parsed as ValidationRecord);
-      }
-    } catch {
-      // Scope headers and prose are not validation records.
-    }
-  }
-  return records;
-}
-
-function hasNonValidationRecord(value: string | undefined): boolean {
-  if (!value) return false;
-  return value.split("\n").some((line) => {
-    try {
-      const parsed = JSON.parse(line) as { schema?: unknown };
-      return typeof parsed.schema === "string" && parsed.schema !== VALIDATION_SCHEMA;
-    } catch {
-      return false;
-    }
-  });
-}
-
-/** Select the exact command fact that licenses a validation Park. */
-function validationBlockerSummary(value: string | undefined): string | undefined {
-  const records = validationRecords(value);
-  if (records.length === 0) return undefined;
-  const failed = records.filter((record) => record.status === "failed");
-  const contradictory = failed.find((record) => record.exitCode === 0);
-  if (contradictory) {
-    throw new Error(
-      `validation blocker rejected: ${contradictory.name} carries exitCode 0`,
-    );
-  }
-  if (failed.length === 0) {
-    // A different structured safety finding (for example branch reversion)
-    // independently licenses this Park; its formatter owns the summary.
-    if (hasNonValidationRecord(value)) return undefined;
-    throw new Error(
-      "validation blocker rejected: park path received all-green validation evidence",
-    );
-  }
-  const record = failed[0]!;
-  if (record.command) {
-    if (record.exitCode === undefined || !Number.isFinite(record.exitCode)) {
-      throw new Error(
-        `validation blocker rejected: ${record.name} names a command without a non-zero exitCode`,
-      );
-    }
-    return (
-      `Validation command \`${record.command}\` failed with exitCode ${record.exitCode}: ` +
-      `${record.summary ?? record.name}`
-    );
-  }
-  return record.summary ?? record.name;
-}
-
 export function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodies): CurrentBlocker | null {
   switch (outcome) {
     case "blocked":
@@ -321,9 +253,7 @@ export function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodi
     case "feedback-failed":
       return makeBlocker({
         kind: "validation",
-        summary:
-          validationBlockerSummary(sections.validation) ??
-          oneLine(sections.validation ?? sections.log, "Validation failed after implementation."),
+        summary: validationBlockerSummary(sections.validation) ?? oneLine(sections.validation ?? sections.log, "Validation failed after implementation."),
         next: "Decide whether to fix forward, change scope, or adjust the acceptance criteria.",
       });
     case "no-sentinel":

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -19,10 +19,12 @@ import {
   type SandboxMode,
 } from "../execution.js";
 import {
+  VALIDATION_SCHEMA,
   runFeedback,
   type Exec as PnpmExec,
   type PackageLayout,
   type RunFeedbackResult,
+  type ValidationRecord,
 } from "../feedback.js";
 import {
   computeValidationScope,
@@ -241,6 +243,73 @@ export function oneLine(value: string | undefined, fallback: string): string {
     .find((part) => part.length > 0);
   return line ?? fallback;
 }
+
+function validationRecords(value: string | undefined): ValidationRecord[] {
+  if (!value) return [];
+  const records: ValidationRecord[] = [];
+  for (const line of value.split("\n")) {
+    try {
+      const parsed = JSON.parse(line) as Partial<ValidationRecord>;
+      if (
+        parsed.schema === VALIDATION_SCHEMA &&
+        typeof parsed.name === "string" &&
+        (parsed.status === "passed" || parsed.status === "failed" || parsed.status === "skipped")
+      ) {
+        records.push(parsed as ValidationRecord);
+      }
+    } catch {
+      // Scope headers and prose are not validation records.
+    }
+  }
+  return records;
+}
+
+function hasNonValidationRecord(value: string | undefined): boolean {
+  if (!value) return false;
+  return value.split("\n").some((line) => {
+    try {
+      const parsed = JSON.parse(line) as { schema?: unknown };
+      return typeof parsed.schema === "string" && parsed.schema !== VALIDATION_SCHEMA;
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** Select the exact command fact that licenses a validation Park. */
+function validationBlockerSummary(value: string | undefined): string | undefined {
+  const records = validationRecords(value);
+  if (records.length === 0) return undefined;
+  const failed = records.filter((record) => record.status === "failed");
+  const contradictory = failed.find((record) => record.exitCode === 0);
+  if (contradictory) {
+    throw new Error(
+      `validation blocker rejected: ${contradictory.name} carries exitCode 0`,
+    );
+  }
+  if (failed.length === 0) {
+    // A different structured safety finding (for example branch reversion)
+    // independently licenses this Park; its formatter owns the summary.
+    if (hasNonValidationRecord(value)) return undefined;
+    throw new Error(
+      "validation blocker rejected: park path received all-green validation evidence",
+    );
+  }
+  const record = failed[0]!;
+  if (record.command) {
+    if (record.exitCode === undefined || !Number.isFinite(record.exitCode)) {
+      throw new Error(
+        `validation blocker rejected: ${record.name} names a command without a non-zero exitCode`,
+      );
+    }
+    return (
+      `Validation command \`${record.command}\` failed with exitCode ${record.exitCode}: ` +
+      `${record.summary ?? record.name}`
+    );
+  }
+  return record.summary ?? record.name;
+}
+
 export function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodies): CurrentBlocker | null {
   switch (outcome) {
     case "blocked":
@@ -252,7 +321,9 @@ export function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodi
     case "feedback-failed":
       return makeBlocker({
         kind: "validation",
-        summary: oneLine(sections.validation ?? sections.log, "Validation failed after implementation."),
+        summary:
+          validationBlockerSummary(sections.validation) ??
+          oneLine(sections.validation ?? sections.log, "Validation failed after implementation."),
         next: "Decide whether to fix forward, change scope, or adjust the acceptance criteria.",
       });
     case "no-sentinel":

--- a/apps/dev/src/core/process-issue/terminal.ts
+++ b/apps/dev/src/core/process-issue/terminal.ts
@@ -359,7 +359,6 @@ export function parkLoopFor(
     nowEpoch: deps.nowEpoch(),
   });
 }
-
 export function shouldPreserveCurrentBlocker(existing: CurrentBlocker | null, next: CurrentBlocker): boolean {
   if (!existing) return false;
   if (next.kind !== "runner") return false;

--- a/apps/dev/src/core/process-issue/validation-park.ts
+++ b/apps/dev/src/core/process-issue/validation-park.ts
@@ -1,0 +1,86 @@
+import {
+  VALIDATION_SCHEMA,
+  type RunFeedbackResult,
+  type ValidationRecord,
+} from "../feedback.js";
+import type { ProcessIssueDeps } from "./types.js";
+
+function validationRecords(value: string | undefined): ValidationRecord[] {
+  if (!value) return [];
+  const records: ValidationRecord[] = [];
+  for (const line of value.split("\n")) {
+    try {
+      const parsed = JSON.parse(line) as Partial<ValidationRecord>;
+      if (
+        parsed.schema === VALIDATION_SCHEMA &&
+        typeof parsed.name === "string" &&
+        (parsed.status === "passed" || parsed.status === "failed" || parsed.status === "skipped")
+      ) {
+        records.push(parsed as ValidationRecord);
+      }
+    } catch {
+      // Scope headers and prose are not validation records.
+    }
+  }
+  return records;
+}
+
+function hasNonValidationRecord(value: string | undefined): boolean {
+  if (!value) return false;
+  return value.split("\n").some((line) => {
+    try {
+      const parsed = JSON.parse(line) as { schema?: unknown };
+      return typeof parsed.schema === "string" && parsed.schema !== VALIDATION_SCHEMA;
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** Select the exact command fact that licenses a validation Park. */
+export function validationBlockerSummary(value: string | undefined): string | undefined {
+  const records = validationRecords(value);
+  if (records.length === 0) return undefined;
+  const failed = records.filter((record) => record.status === "failed");
+  const contradictory = failed.find((record) => record.exitCode === 0);
+  if (contradictory) {
+    throw new Error(
+      `validation blocker rejected: ${contradictory.name} carries exitCode 0`,
+    );
+  }
+  if (failed.length === 0) {
+    // A different structured safety finding (for example branch reversion)
+    // independently licenses this Park; its formatter owns the summary.
+    if (hasNonValidationRecord(value)) return undefined;
+    throw new Error(
+      "validation blocker rejected: park path received all-green validation evidence",
+    );
+  }
+  const record = failed[0]!;
+  if (record.command) {
+    if (record.exitCode === undefined || !Number.isFinite(record.exitCode)) {
+      throw new Error(
+        `validation blocker rejected: ${record.name} names a command without a non-zero exitCode`,
+      );
+    }
+    return (
+      `Validation command \`${record.command}\` failed with exitCode ${record.exitCode}: ` +
+      `${record.summary ?? record.name}`
+    );
+  }
+  return record.summary ?? record.name;
+}
+
+export function reportValidationEvidenceInconsistency(
+  feedback: Pick<RunFeedbackResult, "evidenceInconsistency">,
+  reseedLane: string,
+  deps: Pick<ProcessIssueDeps, "appendIterLog" | "recordWorkerEvent">,
+): void {
+  if (!feedback.evidenceInconsistency) return;
+  const reason = feedback.evidenceInconsistency;
+  deps.appendIterLog(`🤖 ${reseedLane}: INCONSISTENT Validation result — ${reason}.`);
+  deps.recordWorkerEvent?.("worker.validation_evidence_inconsistency", {
+    stage: "feedback",
+    reason,
+  });
+}

--- a/apps/dev/src/core/validation-command.ts
+++ b/apps/dev/src/core/validation-command.ts
@@ -19,9 +19,10 @@
 //      nothing, so it may not consume a re-seed round or park a branch — the
 //      same honesty rule the admission verdicts follow: a refusal carries what
 //      it judged.
-//   3. **A suite-shaped command that exits in under a second did not run a
-//      suite.** The record carries `suspectInfra` and says why, rather than
-//      leaving the operator to spot the duration.
+//   3. **A suite-shaped command that exits in under a second without a concrete
+//      diagnostic may not have run a suite.** Turbo cache hits can return real
+//      compiler, assertion, and guard failures in milliseconds, so structured
+//      branch evidence always outranks duration.
 //
 // A branch TOKEN is left verbatim on purpose. The AFK gate is posed with the
 // worker branch name (`afk/<n>-<slug>`), which the feedback-worktree executor
@@ -43,11 +44,9 @@ export const VALIDATION_TARGET_MISSING_MARKER = "validation worktree directory i
 export const SUSPECT_INFRA_MARKER = "suspect-infra";
 
 /**
- * How fast a suite-shaped command has to exit before its verdict is suspect.
- * `pnpm`'s own startup — resolving the workspace, spawning the script — costs
- * more than this on every host we run on, so a sub-second exit means the suite
- * never started. Deliberately coarse: the claim is "this did not run", not a
- * performance budget.
+ * How fast an evidence-free suite-shaped failure has to exit before its verdict
+ * is suspect. Duration alone proves nothing because turbo can replay a cached
+ * task in milliseconds; a concrete compiler, assertion, or guard finding wins.
  */
 export const SUITE_MIN_PLAUSIBLE_MS = 1000;
 
@@ -57,17 +56,13 @@ const CONCRETE_DIAGNOSTIC_PATTERNS: readonly RegExp[] = [
   /^\s*FAIL\s+\S.*$/m,
   /^\s*\S.*\.{3}\s+FAILED\s*$/m,
   /^\s*----\s+\S.*\s+stdout\s+----\s*$/m,
+  /\bAssertionError\b/,
+  /\b(?:expected|received)\b.*\b(?:to|equal|match|contain|be)\b/i,
+  /\b(?:file-size-guard|invariant)\b.*\b(?:failed|finding|grew|exceeded|violation)\b/i,
 ];
 
-function diagnosticNamesBranchFile(output: string, branchFiles: readonly string[]): boolean {
-  if (!CONCRETE_DIAGNOSTIC_PATTERNS.some((pattern) => pattern.test(output))) return false;
-  const normalizedOutput = output.replaceAll("\\", "/");
-  return branchFiles.some((file) => {
-    const normalizedFile = file.replace(/^\.\//, "").replaceAll("\\", "/");
-    const parts = normalizedFile.split("/").filter(Boolean);
-    const suffixes = parts.map((_, index) => parts.slice(index).join("/"));
-    return suffixes.some((suffix) => suffix.includes("/") && normalizedOutput.includes(suffix));
-  });
+function hasConcreteBranchEvidence(output: string): boolean {
+  return CONCRETE_DIAGNOSTIC_PATTERNS.some((pattern) => pattern.test(output));
 }
 
 /**
@@ -261,14 +256,11 @@ export function isSuspectInfraFailure(input: {
   durationMs?: number;
   /** Captured compiler/test output, inspected before duration can classify it. */
   output?: string;
-  /** Repo-relative files changed by the branch being judged. */
+  /** Retained for caller compatibility; concrete diagnostics no longer need path matching. */
   branchFiles?: readonly string[];
 }): boolean {
   if (input.status !== "failed") return false;
-  if (
-    input.output !== undefined &&
-    diagnosticNamesBranchFile(input.output, input.branchFiles ?? [])
-  ) {
+  if (input.output !== undefined && hasConcreteBranchEvidence(input.output)) {
     return false;
   }
   const { durationMs } = input;
@@ -285,7 +277,7 @@ export function suspectInfraSummary(input: {
 }): string {
   const head =
     `${SUSPECT_INFRA_MARKER}: \`${input.command}\` exited ${input.exitCode} after ` +
-    `${input.durationMs}ms — under ${SUITE_MIN_PLAUSIBLE_MS}ms is too fast for a suite ` +
-    `command to have started, so read this as an environment failure before the branch's`;
+    `${input.durationMs}ms without a concrete compiler, assertion, or guard finding; ` +
+    `the command may not have started, so inspect the environment before charging the branch`;
   return input.summary === "" ? head : `${head}. ${input.summary}`;
 }

--- a/apps/dev/src/core/validation-evidence.ts
+++ b/apps/dev/src/core/validation-evidence.ts
@@ -9,7 +9,7 @@ export const ALL_GREEN_VALIDATION_INCONSISTENCY =
 export function reconcileValidationEvidence<T extends ClassifiableCheck>(
   reportedFailed: boolean,
   checks: readonly T[],
-): { ok: boolean; checks: T[]; sidecar: string[]; inconsistency?: string } {
+): { ok: boolean; checks: T[]; sidecar: string[]; evidenceInconsistency?: string } {
   if (!reportedFailed || blockingValidationChecks(checks).length > 0 || checks.length === 0) {
     return {
       ok: !reportedFailed,
@@ -42,6 +42,22 @@ export function reconcileValidationEvidence<T extends ClassifiableCheck>(
     ok: true,
     checks: reconciled,
     sidecar: reconciled.map((check) => JSON.stringify(check.record)),
-    inconsistency: ALL_GREEN_VALIDATION_INCONSISTENCY,
+    evidenceInconsistency: ALL_GREEN_VALIDATION_INCONSISTENCY,
+  };
+}
+
+export function applyValidationEvidence<T extends ClassifiableCheck>(
+  reportedFailed: boolean,
+  checks: T[],
+  sidecar: string[],
+): { failed: boolean; evidenceInconsistency?: string } {
+  const reconciled = reconcileValidationEvidence(reportedFailed, checks);
+  checks.splice(0, checks.length, ...reconciled.checks);
+  sidecar.splice(0, sidecar.length, ...reconciled.sidecar);
+  return {
+    failed: !reconciled.ok,
+    ...(reconciled.evidenceInconsistency
+      ? { evidenceInconsistency: reconciled.evidenceInconsistency }
+      : {}),
   };
 }

--- a/apps/dev/src/core/validation-evidence.ts
+++ b/apps/dev/src/core/validation-evidence.ts
@@ -1,0 +1,47 @@
+import type { ClassifiableCheck, ValidationRecord } from "./feedback.js";
+import { blockingValidationChecks } from "./verdict.js";
+
+export const ALL_GREEN_VALIDATION_INCONSISTENCY =
+  "aggregate validation result reported failure with all-green validation evidence; " +
+  "refusing blocked:validation park";
+
+/** Reconcile an aggregate failure against the durable per-command authority. */
+export function reconcileValidationEvidence<T extends ClassifiableCheck>(
+  reportedFailed: boolean,
+  checks: readonly T[],
+): { ok: boolean; checks: T[]; sidecar: string[]; inconsistency?: string } {
+  if (!reportedFailed || blockingValidationChecks(checks).length > 0 || checks.length === 0) {
+    return {
+      ok: !reportedFailed,
+      checks: [...checks],
+      sidecar: checks.map((check) => JSON.stringify(check.record)),
+    };
+  }
+  const allGreen = checks.every(
+    (check) => check.status !== "failed" || check.record.exitCode === 0,
+  );
+  if (!allGreen) {
+    return {
+      ok: false,
+      checks: [...checks],
+      sidecar: checks.map((check) => JSON.stringify(check.record)),
+    };
+  }
+  const reconciled = checks.map((check) => {
+    if (check.status !== "failed" || check.record.exitCode !== 0) return check;
+    const record: ValidationRecord = {
+      ...check.record,
+      status: "passed",
+      summary: "command exited 0",
+    };
+    delete record.suspectInfra;
+    delete record.infra;
+    return { ...check, status: "passed", record } as T;
+  });
+  return {
+    ok: true,
+    checks: reconciled,
+    sidecar: reconciled.map((check) => JSON.stringify(check.record)),
+    inconsistency: ALL_GREEN_VALIDATION_INCONSISTENCY,
+  };
+}

--- a/apps/dev/src/core/validation-output.ts
+++ b/apps/dev/src/core/validation-output.ts
@@ -1,0 +1,40 @@
+import type { ValidationStatus } from "./feedback.js";
+
+/** Strip ANSI SGR sequences so identity matching survives coloured runner output. */
+function stripAnsi(line: string): string {
+  // eslint-disable-next-line no-control-regex
+  return line.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/** Patterns that name which check failed, rather than only how many did. */
+const FAILURE_IDENTITY_PATTERNS: readonly RegExp[] = [
+  /^\s*FAIL\s+\S.*$/,
+  /^\s*\S.*\.{3}\s+FAILED\s*$/,
+  /^\s*----\s+\S.*\s+stdout\s+----\s*$/,
+];
+
+const MAX_NAMED_FAILURES = 5;
+
+/** Return distinct failing identities in first-seen order. */
+export function namedFailures(output: string): string[] {
+  const seen = new Set<string>();
+  for (const raw of output.split("\n")) {
+    const line = stripAnsi(raw).replace(/\s+/g, " ").trim();
+    if (line === "") continue;
+    if (!FAILURE_IDENTITY_PATTERNS.some((pattern) => pattern.test(line))) continue;
+    seen.add(line);
+    if (seen.size >= MAX_NAMED_FAILURES) break;
+  }
+  return [...seen];
+}
+
+/** Build the bounded, actionable summary stored with one finished check. */
+export function outputSummary(status: ValidationStatus, output: string): string {
+  if (status === "passed") return "command exited 0";
+  const trimmed = output.replace(/\n+$/, "");
+  if (trimmed === "") return "command exited non-zero";
+  const tail = trimmed.split("\n").slice(-20).join(" ");
+  const named = namedFailures(trimmed);
+  if (named.length === 0) return tail.slice(0, 1000);
+  return `failing: ${named.join(" | ")} — ${tail}`.slice(0, 1000);
+}

--- a/apps/dev/src/core/verdict.ts
+++ b/apps/dev/src/core/verdict.ts
@@ -104,7 +104,10 @@ function normaliseCap(cap: number): number {
   return Number.isInteger(cap) && cap >= 0 ? cap : 0;
 }
 
-function failedChecks(checks: readonly ClassifiableCheck[]): readonly ClassifiableCheck[] {
+/** Failed checks whose durable record can actually justify a failed round. */
+export function blockingValidationChecks(
+  checks: readonly ClassifiableCheck[],
+): readonly ClassifiableCheck[] {
   return checks.filter((check) => check.status === "failed" && check.record.exitCode !== 0);
 }
 
@@ -113,7 +116,7 @@ function checkEnvironmentCause(
   checks: readonly ClassifiableCheck[],
   subsecondFailuresAreBranchFault: boolean,
 ): Exclude<EnvironmentCause, "stale-base-drift"> | undefined {
-  for (const check of failedChecks(checks)) {
+  for (const check of blockingValidationChecks(checks)) {
     const record = check.record;
     if (record.suspectInfra === true && !subsecondFailuresAreBranchFault) return "suspect-infra";
     if (record.infra === "stall") return "stall";
@@ -182,6 +185,11 @@ function remediationFor(input: VerdictInput, fault: VerdictFault): VerdictRemedi
  * only park that environment fault, never transmute it into branch blame.
  */
 export function decideVerdict(input: VerdictInput): Verdict {
+  if (blockingValidationChecks(input.checks).length === 0) {
+    throw new Error(
+      "Verdict refused a failed Validation round with all-green validation evidence",
+    );
+  }
   const fault = faultFor(input);
   const remediation = remediationFor(input, fault);
   if (remediation?.kind === "agent-correction") {

--- a/apps/dev/src/core/verdict.ts
+++ b/apps/dev/src/core/verdict.ts
@@ -186,9 +186,12 @@ function remediationFor(input: VerdictInput, fault: VerdictFault): VerdictRemedi
  */
 export function decideVerdict(input: VerdictInput): Verdict {
   if (blockingValidationChecks(input.checks).length === 0) {
-    throw new Error(
-      "Verdict refused a failed Validation round with all-green validation evidence",
-    );
+    return {
+      fault: { kind: "branch" },
+      budgetEffect: { kind: "none" },
+      parkNow: false,
+      reason: "Verdict refused to park a failed Validation round with all-green validation evidence",
+    };
   }
   const fault = faultFor(input);
   const remediation = remediationFor(input, fault);

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -423,6 +423,35 @@ describe("runFeedback", () => {
     expect(check?.record.summary).toContain("suspect-infra");
   });
 
+  it("records a turbo-cached compiler diagnostic as a branch fault (#3773)", async () => {
+    const layout = fakeLayout({
+      packages: ["apps/dev"],
+      scripts: { "apps/dev": ["typecheck"] },
+    });
+    const { exec } = fakeExec([
+      {
+        match: (a) => a.includes("typecheck"),
+        result: {
+          code: 2,
+          stdout: "apps/dev/src/runtime/wire/boot.ts(649,21): error TS2345: Argument is not assignable",
+        },
+      },
+    ]);
+    const result = await runFeedback(exec, {
+      worktree: "afk/3773-validation-evidence",
+      worktreeKind: "branch",
+      scopes: ["apps/dev"],
+      layout,
+      now: fakeClock(26),
+    });
+
+    const check = result.checks.find((ch) => ch.name === "typecheck:apps/dev");
+    expect(check?.record.durationMs).toBe(26);
+    expect(check?.record.exitCode).toBe(2);
+    expect(check?.record.suspectInfra).toBeUndefined();
+    expect(verdictIsEnvironment(result)).toBe(false);
+  });
+
   it("leaves a plausibly-timed failure unflagged (#3041)", async () => {
     const layout = fakeLayout({
       packages: ["apps/dev"],

--- a/apps/dev/tests/process-issue.validation.test.ts
+++ b/apps/dev/tests/process-issue.validation.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./process-issue.test-helpers.js";
 import type { AttemptProgressInfo, ConfigValues, ProcessIssueDeps } from "./process-issue.test-helpers.js";
 import { failureSignature } from "../src/core/failure-signature.js";
+import { blockerForFailure } from "../src/core/process-issue/terminal.js";
 import type { BranchReversionGeometry } from "../src/core/branch-reversion.js";
 
 function addedFilePatch(file: string, lines: number): string {
@@ -199,6 +200,62 @@ describe("processIssue — feedback fail", () => {
       "post_feedback",
     ]);
     expect(trace.pushedAttempt).toEqual([]);
+  });
+
+  it("REGRESSION: DONE plus all-green post_done evidence lands instead of parking", async () => {
+    const { deps, input, trace } = harness({ outcome: "done" });
+    deps.validationMoments = { post_done: ["pnpm test", "pnpm typecheck"] };
+    let typecheckCodeReads = 0;
+    deps.backpressure = async ({ command }) => {
+      if (command === "pnpm test") return { code: 0, stdout: "", stderr: "" };
+      // Pose the field incident at the lifecycle seam: the aggregate observed a
+      // failure, but the durable command record (the evidence authority) carries
+      // exitCode 0. A validation park must refuse this contradiction.
+      return Object.defineProperty(
+        { stdout: "", stderr: "" },
+        "code",
+        { enumerable: true, get: () => (typecheckCodeReads++ === 0 ? 1 : 0) },
+      ) as { code: number; stdout: string; stderr: string };
+    };
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.closed).toEqual([9]);
+    expect(trace.pushedAttempt.length).toBeGreaterThan(0);
+    expect(trace.labelEdits.some((edit) => edit.add.includes("blocked:validation"))).toBe(false);
+    expect(trace.iterLogs.some((line) => line.includes("all-green validation evidence"))).toBe(true);
+  });
+
+  it("records the exact non-zero command when earlier validation checks passed", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackFailures: [["build"]],
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    const blocker = parseCurrentBlocker(trace.bodyEdits.at(-1)?.body ?? "");
+    expect(blocker).toMatchObject({
+      kind: "validation",
+      summary: expect.stringContaining("build"),
+    });
+    expect(blocker?.summary).toContain("exitCode 1");
+    expect(blocker?.summary).not.toContain('"name":"test:root"');
+  });
+
+  it("rejects a validation blocker record carrying exitCode 0", () => {
+    const greenRecord = JSON.stringify({
+      schema: "red.afk.validation.v1",
+      name: "validation:post_done",
+      status: "failed",
+      command: "pnpm test",
+      exitCode: 0,
+    });
+
+    expect(() => blockerForFailure("feedback-failed", { validation: greenRecord }))
+      .toThrow(/exitCode 0/);
   });
 
   it("treats an unbuildable baseline as free infra that cannot charge the branch", async () => {

--- a/apps/dev/tests/validation-command.test.ts
+++ b/apps/dev/tests/validation-command.test.ts
@@ -194,6 +194,27 @@ describe("suspect-infra duration", () => {
     })).toBe(false);
   });
 
+  it("lets structured branch evidence outrank a turbo-cached sub-second duration (#3773)", () => {
+    expect(isSuspectInfraFailure({
+      status: "failed",
+      durationMs: 26,
+      output: "apps/dev/src/runtime/wire/boot.ts(649,21): error TS2345: Argument is not assignable",
+    })).toBe(false);
+    expect(isSuspectInfraFailure({
+      status: "failed",
+      durationMs: 45,
+      output: "file-size-guard: apps/dev/src/core/boot.ts grew from 1606 to 1633 lines",
+    })).toBe(false);
+  });
+
+  it("may still classify an evidence-free sub-second failure as infrastructure (#3773)", () => {
+    expect(isSuspectInfraFailure({
+      status: "failed",
+      durationMs: 26,
+      output: "command exited non-zero",
+    })).toBe(true);
+  });
+
   it("leaves a plausible failure, a fast pass, and an unmeasured check alone", () => {
     expect(isSuspectInfraFailure({ status: "failed", durationMs: SUITE_MIN_PLAUSIBLE_MS })).toBe(false);
     expect(isSuspectInfraFailure({ status: "passed", durationMs: 3 })).toBe(false);

--- a/apps/dev/tests/verdict.test.ts
+++ b/apps/dev/tests/verdict.test.ts
@@ -27,6 +27,20 @@ function failedCheck(overrides: Partial<ClassifiableCheck["record"]> = {}): Clas
   };
 }
 
+function passedCheck(): ClassifiableCheck {
+  return {
+    status: "passed",
+    record: {
+      schema: "red.afk.validation.v1",
+      name: "validation:post_done",
+      status: "passed",
+      command: "pnpm test",
+      exitCode: 0,
+      durationMs: 400,
+    },
+  };
+}
+
 function ledger(rounds: EnvironmentLedger["rounds"], cap = 2): EnvironmentLedger {
   return { cap, rounds };
 }
@@ -208,6 +222,15 @@ describe("decideVerdict — one fault, budget effect, and park decision", () => 
       parkNow: true,
       parkReason: "branch-exhausted",
     });
+  });
+
+  it("refuses a failed-round verdict when the supplied evidence is all green", () => {
+    expect(() => decideVerdict({
+      checks: [passedCheck()],
+      signature: SIGNATURE,
+      history: { environment: emptyEnvironmentLedger(2), branchBudgetAvailable: false },
+      environment: {},
+    })).toThrow(/all-green validation evidence/);
   });
 });
 

--- a/apps/dev/tests/verdict.test.ts
+++ b/apps/dev/tests/verdict.test.ts
@@ -234,6 +234,8 @@ describe("decideVerdict — one fault, budget effect, and park decision", () => 
 
     expect(verdict.fault).toEqual({ kind: "branch" });
     expect(verdict.budgetEffect).toEqual({ kind: "none" });
+    expect(verdict.parkNow).toBe(false);
+    expect(verdict.reason).toContain("all-green validation evidence");
   });
 });
 

--- a/apps/dev/tests/verdict.test.ts
+++ b/apps/dev/tests/verdict.test.ts
@@ -224,13 +224,16 @@ describe("decideVerdict — one fault, budget effect, and park decision", () => 
     });
   });
 
-  it("refuses a failed-round verdict when the supplied evidence is all green", () => {
-    expect(() => decideVerdict({
+  it("never classifies all-green evidence as an environment failure", () => {
+    const verdict = decideVerdict({
       checks: [passedCheck()],
       signature: SIGNATURE,
       history: { environment: emptyEnvironmentLedger(2), branchBudgetAvailable: false },
       environment: {},
-    })).toThrow(/all-green validation evidence/);
+    });
+
+    expect(verdict.fault).toEqual({ kind: "branch" });
+    expect(verdict.budgetEffect).toEqual({ kind: "none" });
   });
 });
 

--- a/packaging/pi/dev/skills/engineering/afk/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/afk/SKILL.md
@@ -201,9 +201,11 @@ Read the focused reference before touching that concern:
   intent wakes the Custodian's repair Worker through ordinary admission.
 - The **Verdict** is the one pure failed-Validation decision. Checks, history,
   and environment facts enter; fault, budget effect, and park-now leave. There
-  is no runtime classification hook: the sole operator escape is the declared
+  is no runtime classification hook. Concrete compiler, assertion, and guard
+  evidence is branch fault at any duration; only an evidence-free sub-second
+  failure may be suspect infrastructure. The declared
   `plugins.dev.afk.validation.subsecond_failures_are_branch_fault` policy beside
-  the Validation moments.
+  the Validation moments makes even that fallback branch-owned.
 - The **Park** has one door. `blocker-state` alone parses, writes, and clears the
   active blocker (malformed blocked records stay active and named), and every
   return to `ready-for-agent` calls `applyRequeue` with `machine` or `human`

--- a/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
@@ -186,11 +186,13 @@ list and also skips loudly.
 | Merge queue | The repository's required CI checks run on the merge group. This is configured at the forge, not in RedSkills. | The merge queue is the CI-side final Validation moment and owns freshness against the merged result. |
 
 `plugins.dev.afk.validation.subsecond_failures_are_branch_fault` is an optional
-boolean declaration beside that schedule. Leave it absent/`false` for the safe
-default: a failed suite command measured under one second is environment fault.
-Set it to `true` only when this repository's declared suite legitimately finishes
-that quickly; its fast failures are then branch fault. This declaration replaces
-the removed runtime classification hook.
+boolean declaration beside that schedule. Verdict first trusts structured branch
+evidence: a compiler diagnostic, failing assertion, or invariant finding is a
+branch fault at any duration, including a turbo cache hit returned in milliseconds.
+Without concrete evidence, an absent/`false` declaration lets a sub-second failure
+remain suspect infrastructure; set it to `true` when every fast failure in this
+repository should default to branch fault. This declaration replaces the removed
+runtime classification hook.
 
 `setup` and `format` remain separate declarations rather than Validation
 moments. `/red-setup` inventories the repository's real scripts, proposes the

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -174,7 +174,8 @@ and ends, Verdict has no classification hook, and the Park exposes one
 authority-parameterized requeue door) ->
 `plugins/dev/skills/engineering/afk/SKILL.md`;
 `/afk` Verdict policy (one capped environment ledger, repeated-signature park,
-and the declared sub-second branch-fault escape beside Validation moments) ->
+concrete branch evidence outranking duration, and the declared fallback for
+evidence-free sub-second failures beside Validation moments) ->
 `plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md` and
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` after-fork reversion/test-line intent finding

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -201,9 +201,11 @@ Read the focused reference before touching that concern:
   intent wakes the Custodian's repair Worker through ordinary admission.
 - The **Verdict** is the one pure failed-Validation decision. Checks, history,
   and environment facts enter; fault, budget effect, and park-now leave. There
-  is no runtime classification hook: the sole operator escape is the declared
+  is no runtime classification hook. Concrete compiler, assertion, and guard
+  evidence is branch fault at any duration; only an evidence-free sub-second
+  failure may be suspect infrastructure. The declared
   `plugins.dev.afk.validation.subsecond_failures_are_branch_fault` policy beside
-  the Validation moments.
+  the Validation moments makes even that fallback branch-owned.
 - The **Park** has one door. `blocker-state` alone parses, writes, and clears the
   active blocker (malformed blocked records stay active and named), and every
   return to `ready-for-agent` calls `applyRequeue` with `machine` or `human`

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -186,11 +186,13 @@ list and also skips loudly.
 | Merge queue | The repository's required CI checks run on the merge group. This is configured at the forge, not in RedSkills. | The merge queue is the CI-side final Validation moment and owns freshness against the merged result. |
 
 `plugins.dev.afk.validation.subsecond_failures_are_branch_fault` is an optional
-boolean declaration beside that schedule. Leave it absent/`false` for the safe
-default: a failed suite command measured under one second is environment fault.
-Set it to `true` only when this repository's declared suite legitimately finishes
-that quickly; its fast failures are then branch fault. This declaration replaces
-the removed runtime classification hook.
+boolean declaration beside that schedule. Verdict first trusts structured branch
+evidence: a compiler diagnostic, failing assertion, or invariant finding is a
+branch fault at any duration, including a turbo cache hit returned in milliseconds.
+Without concrete evidence, an absent/`false` declaration lets a sub-second failure
+remain suspect infrastructure; set it to `true` when every fast failure in this
+repository should default to branch fault. This declaration replaces the removed
+runtime classification hook.
 
 `setup` and `format` remain separate declarations rather than Validation
 moments. `/red-setup` inventories the repository's real scripts, proposes the

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -174,7 +174,8 @@ and ends, Verdict has no classification hook, and the Park exposes one
 authority-parameterized requeue door) ->
 `plugins/dev/skills/engineering/afk/SKILL.md`;
 `/afk` Verdict policy (one capped environment ledger, repeated-signature park,
-and the declared sub-second branch-fault escape beside Validation moments) ->
+concrete branch evidence outranking duration, and the declared fallback for
+evidence-free sub-second failures beside Validation moments) ->
 `plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md` and
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` after-fork reversion/test-line intent finding


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3773 -->
🤖 **Re-seed trail** — #3773 on `afk/3773-validation-quarantine-parks-green-work-a`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: simple-tier feedback failed for #3773; re-seeding on the complex tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3773 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/afk-container`, `apps/benchmark-code-understanding`, `apps/benchmark-memory`, `apps/brain`, `apps/code-nav`, `apps/dev`, `apps/herdr-plugin-red-skills`, `apps/memory`, `apps/opencode-host`, `apps/red-browser`, `apps/redskilled`, `apps/release`, `apps/rsp`, `apps/vscode-extension-red-skills`, `packages/brand-tokens`, `packages/browser-bridge`, `packages/build-info`, `packages/cdp-driver`, `packages/github`, `packages/red-castle`, `packages/redskilled-render`, `packages/shared`]
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":50,"summary":"suspect-infra: `pnpm -C apps/dev test:invariants` exited 1 after 50ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. failing: FAIL tests/file-size-guard.test.ts > file-size ratchet — a split nothing enforces is a split that comes back > holds the live tree to the threshold and the shrink-only baseline —  - Array [] + Array [ +   Object { +     \"kind\": \"over-baseline\", +     \"lines\": 1218, +     \"path\": \"apps/dev/src/core/feedback.ts\", +     \"reason\": \"apps/dev/src/core/feedback.ts grew from 1206 to 1218 lines. The baseline is shrink-only: lower the number as the file is decomposed, never raise it.\", +   }, + ]   ❯ tests/file-size-guard.test.ts:46:7      44|         : `file-size ratchet: ${findings.length} finding(s).\\n${render…      45|           `Baseline: apps/dev/src/core/file-size-guard.ts (FILE_SIZE_B…      46|     ).toEqual([]);        |       ^      47|   });      48|   ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯","suspectInfra":true}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3773