### PR TITLE
merge: #3774 A crashed Worker's claim is never reconciled: running label + dead pids + empty remote branch strands the issue forever

### DIFF
--- a/.changeset/reconcile-crashed-worker-claim.md
+++ b/.changeset/reconcile-crashed-worker-claim.md
@@ -1,0 +1,18 @@
+---
+"@reddb-io/red-castle": patch
+"@reddb-io/red-skills": patch
+---
+
+A crashed Worker's claim is reconciled instead of stranding its issue
+
+A Worker that died without conceding left three facts that never met: the
+issue still carried its `running` label, the pids it named were gone, and the
+remote branch it had pushed was empty. Each surface read one of the three and
+so each read the issue as someone else's live work — the claim never expired,
+no other Worker could take it, and the issue sat held by a process that no
+longer existed.
+
+Claim staleness now judges the process rather than the label. A claim whose
+pids are all dead is stale no matter what the label says, boot cleanup
+reconciles the stranded shape it finds, and `claim_status` reports the dead
+holder as dead rather than as an owner.

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -6,6 +6,7 @@ export {
   checkBootGuard,
   parseRunFlags,
   resolveRunDispatchIdentity,
+  runNeedsAdmittedFork,
   shouldSkipBootSweeps,
 } from "./run/flags.js";
 export { deriveActivity } from "./run/activity.js";

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -75,7 +75,7 @@ import { HOST_CONFIG_EXIT_CODE, sweepDiscardsWorkspace } from "../../core/worker
 import { LABEL_READY } from "../../core/triage-labels.js";
 import { evaluateClaimTrust, parseTrustPolicy } from "../../core/trust-gate.js";
 
-import { checkBootGuard, isNamespacedDispatch, parseRunFlags, resolveRunDispatchIdentity, shouldSkipBootSweeps, type RunOptions } from "./flags.js";
+import { checkBootGuard, isNamespacedDispatch, parseRunFlags, resolveRunDispatchIdentity, runNeedsAdmittedFork, shouldSkipBootSweeps, type RunOptions } from "./flags.js";
 import { buildProcessDeps, parseSlot, type CurrentAttempt } from "./process-deps.js";
 import { makeBootReconcileRunner, runReconcileWorker } from "./reconcile.js";
 import {
@@ -224,8 +224,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
     return runReconcileWorker(flags.reconcileIssue, runner, ctx, paths, workerId);
   }
 
-  const forkSha = process.env.RED_AFK_FORK_SHA?.trim();
-  if (!forkSha) {
+  const forkSha = process.env.RED_AFK_FORK_SHA?.trim() ?? "";
+  if (runNeedsAdmittedFork(flags) && !forkSha) {
     const error = new Error("redskilled granted this Worker no fork SHA — refusing unadmitted birth");
     retainedBootDiagnostic = await retainBootFailure("boot-error", error);
     await cleanupBootFailure("boot-error", retainedBootDiagnostic);

--- a/apps/dev/src/commands/run/flags.ts
+++ b/apps/dev/src/commands/run/flags.ts
@@ -87,6 +87,11 @@ export function shouldSkipBootSweeps(
   return supervisorSweepsDone || filter.kind === "issues";
 }
 
+/** Boot-only Workers reconcile shared state; they never check out or process work. */
+export function runNeedsAdmittedFork(flags: Pick<ParsedRunFlags, "bootOnly">): boolean {
+  return !flags.bootOnly;
+}
+
 /** Raised when --alternate is combined with --runner (mutually exclusive). */
 export class RunFlagError extends Error {
   constructor(message: string) {

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -52,12 +52,10 @@ import {
 } from "./boot-sweep.js";
 import {
   planStaleClaimSweep,
-  renderConcededClaimSweepAudit,
-  renderDeadClaimSweepAudit,
-  renderStaleClaimSweepAudit,
   resolveClaimReaperConfig,
   type ClaimedIssue,
 } from "./claim-staleness.js";
+import { planClaimRecovery } from "./claim-recovery.js";
 import { renderConcedeOnBehalf } from "./claim.js";
 import {
   planDocsSweep,
@@ -95,14 +93,7 @@ import { pathIsInsideTmp, removableUnknownTmpRoots } from "./tmp-janitor.js";
 import type { TmpJanitorPlan, WorkerDirJanitorPlan } from "./tmp-janitor.js";
 import type { WorkerProcessVerdict, WorkerReclaimPlan } from "./worker-reclaim.js";
 import type { WorkerStateRecordReclaimPlan } from "./worker-state-reclaim.js";
-import {
-  LABEL_GO_LANE,
-  LABEL_HUMAN,
-  LABEL_QUARANTINE,
-  LABEL_READY,
-  LABEL_RUNNING,
-  LABEL_SCOUT_LANE,
-} from "./triage-labels.js";
+import { LABEL_HUMAN, LABEL_QUARANTINE, LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
 import { readHitlTypeLabels } from "./config.js";
 import { blockedLabelsIn, isRefused, planTransition, type StateTransition } from "./state-transition.js";
 import {
@@ -1305,52 +1296,14 @@ async function runStaleClaimSweep(deps: BootDeps): Promise<StaleClaimSweepResult
           );
         }
       }
-      const parked = currentLabels.includes(LABEL_HUMAN) || blockedLabelsIn(currentLabels).length > 0;
-      const isolatedLane = currentLabels.includes(LABEL_GO_LANE)
-        ? LABEL_GO_LANE
-        : currentLabels.includes(LABEL_SCOUT_LANE)
-          ? LABEL_SCOUT_LANE
-          : undefined;
-      let destination = LABEL_READY;
-      if (parked) {
-        // A parked issue only sheds the stale `running` projection — the park
-        // itself is the authoritative state and must survive the sweep (#968).
-        await deps.gh.editLabels(p.issue, [LABEL_RUNNING], []);
-      } else if (isolatedLane) {
-        // go/scout lanes are executable by their lane label alone. Restoring the
-        // fleet label would cross the isolation boundary and lose the pre-claim
-        // route the crashed Worker took.
-        destination = isolatedLane;
-        await deps.gh.editLabels(p.issue, [LABEL_RUNNING], []);
-      } else {
-        const plan = planTransition(currentLabels, { kind: "queue" });
-        if (isRefused(plan)) {
-          // A refused queue (e.g. dangling req:* edges without blocked:dependency)
-          // is a poison signal — shed `running` but never re-admit the issue.
-          deps.log?.(`boot claim-sweep queue refused for #${p.issue}: ${plan.reason}`);
-          await deps.gh.editLabels(p.issue, [LABEL_RUNNING], []);
-        } else {
-          await deps.gh.editLabels(p.issue, [...plan.remove], [...plan.add]);
-        }
+      const recovery = planClaimRecovery(currentLabels, p, claimedIssue);
+      if (recovery.refusalReason) {
+        deps.log?.(`boot claim-sweep queue refused for #${p.issue}: ${recovery.refusalReason}`);
       }
-      const deadOwners = new Set(claimedIssue?.deadOwners ?? []);
-      const concededOwners = p.concededOwners ?? [];
-      const releaseAudit = concededOwners.length > 0
-        ? renderConcededClaimSweepAudit(concededOwners, destination)
-        : p.staleOwners.some((owner) => deadOwners.has(owner))
-          ? renderDeadClaimSweepAudit(p.staleOwners, destination)
-          : renderStaleClaimSweepAudit(p.staleOwners, destination);
-      const zeroCommitBranches = (claimedIssue?.attemptBranches ?? [])
-        .filter((branch) => branch.commitsAhead === 0)
-        .map((branch) => `\`${branch.branch}\``);
-      const branchAudit = zeroCommitBranches.length === 0
-        ? ""
-        : `\n\nRemote attempt ${zeroCommitBranches.length === 1 ? "branch" : "branches"} ` +
-          `${zeroCommitBranches.join(", ")} carried zero commits ahead of trunk and remained for branch cleanup policy.`;
-      const body = releaseAudit + branchAudit;
-      await deps.gh.comment(p.issue, body);
+      await deps.gh.editLabels(p.issue, recovery.remove, recovery.add);
+      await deps.gh.comment(p.issue, recovery.audit);
       released.push(p.issue);
-      if (concededOwners.length > 0) repairedConceded.push(p.issue);
+      if ((p.concededOwners?.length ?? 0) > 0) repairedConceded.push(p.issue);
     } catch {
       // Best-effort: a failed release leaves the issue for the next boot's sweep.
     }

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -95,7 +95,14 @@ import { pathIsInsideTmp, removableUnknownTmpRoots } from "./tmp-janitor.js";
 import type { TmpJanitorPlan, WorkerDirJanitorPlan } from "./tmp-janitor.js";
 import type { WorkerProcessVerdict, WorkerReclaimPlan } from "./worker-reclaim.js";
 import type { WorkerStateRecordReclaimPlan } from "./worker-state-reclaim.js";
-import { LABEL_HUMAN, LABEL_QUARANTINE, LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
+import {
+  LABEL_GO_LANE,
+  LABEL_HUMAN,
+  LABEL_QUARANTINE,
+  LABEL_READY,
+  LABEL_RUNNING,
+  LABEL_SCOUT_LANE,
+} from "./triage-labels.js";
 import { readHitlTypeLabels } from "./config.js";
 import { blockedLabelsIn, isRefused, planTransition, type StateTransition } from "./state-transition.js";
 import {
@@ -1299,9 +1306,21 @@ async function runStaleClaimSweep(deps: BootDeps): Promise<StaleClaimSweepResult
         }
       }
       const parked = currentLabels.includes(LABEL_HUMAN) || blockedLabelsIn(currentLabels).length > 0;
+      const isolatedLane = currentLabels.includes(LABEL_GO_LANE)
+        ? LABEL_GO_LANE
+        : currentLabels.includes(LABEL_SCOUT_LANE)
+          ? LABEL_SCOUT_LANE
+          : undefined;
+      let destination = LABEL_READY;
       if (parked) {
         // A parked issue only sheds the stale `running` projection — the park
         // itself is the authoritative state and must survive the sweep (#968).
+        await deps.gh.editLabels(p.issue, [LABEL_RUNNING], []);
+      } else if (isolatedLane) {
+        // go/scout lanes are executable by their lane label alone. Restoring the
+        // fleet label would cross the isolation boundary and lose the pre-claim
+        // route the crashed Worker took.
+        destination = isolatedLane;
         await deps.gh.editLabels(p.issue, [LABEL_RUNNING], []);
       } else {
         const plan = planTransition(currentLabels, { kind: "queue" });
@@ -1316,11 +1335,19 @@ async function runStaleClaimSweep(deps: BootDeps): Promise<StaleClaimSweepResult
       }
       const deadOwners = new Set(claimedIssue?.deadOwners ?? []);
       const concededOwners = p.concededOwners ?? [];
-      const body = concededOwners.length > 0
-        ? renderConcededClaimSweepAudit(concededOwners)
+      const releaseAudit = concededOwners.length > 0
+        ? renderConcededClaimSweepAudit(concededOwners, destination)
         : p.staleOwners.some((owner) => deadOwners.has(owner))
-          ? renderDeadClaimSweepAudit(p.staleOwners)
-          : renderStaleClaimSweepAudit(p.staleOwners);
+          ? renderDeadClaimSweepAudit(p.staleOwners, destination)
+          : renderStaleClaimSweepAudit(p.staleOwners, destination);
+      const zeroCommitBranches = (claimedIssue?.attemptBranches ?? [])
+        .filter((branch) => branch.commitsAhead === 0)
+        .map((branch) => `\`${branch.branch}\``);
+      const branchAudit = zeroCommitBranches.length === 0
+        ? ""
+        : `\n\nRemote attempt ${zeroCommitBranches.length === 1 ? "branch" : "branches"} ` +
+          `${zeroCommitBranches.join(", ")} carried zero commits ahead of trunk and remained for branch cleanup policy.`;
+      const body = releaseAudit + branchAudit;
       await deps.gh.comment(p.issue, body);
       released.push(p.issue);
       if (concededOwners.length > 0) repairedConceded.push(p.issue);

--- a/apps/dev/src/core/claim-recovery.ts
+++ b/apps/dev/src/core/claim-recovery.ts
@@ -37,8 +37,8 @@ export function planClaimRecovery(
   const transition = parked || isolatedLane ? undefined : planTransition(currentLabels, { kind: "queue" });
   const refused = transition && isRefused(transition) ? transition : undefined;
   const destination = isolatedLane ?? LABEL_READY;
-  const remove = refused || !transition ? [LABEL_RUNNING] : [...transition.remove];
-  const add = refused || !transition ? [] : [...transition.add];
+  const remove = !transition || isRefused(transition) ? [LABEL_RUNNING] : [...transition.remove];
+  const add = !transition || isRefused(transition) ? [] : [...transition.add];
 
   const deadOwners = new Set(claimedIssue?.deadOwners ?? []);
   const concededOwners = release.concededOwners ?? [];

--- a/apps/dev/src/core/claim-recovery.ts
+++ b/apps/dev/src/core/claim-recovery.ts
@@ -1,0 +1,65 @@
+import {
+  renderConcededClaimSweepAudit,
+  renderDeadClaimSweepAudit,
+  renderStaleClaimSweepAudit,
+  type ClaimedIssue,
+  type StaleClaimRelease,
+} from "./claim-staleness.js";
+import { blockedLabelsIn, isRefused, planTransition } from "./state-transition.js";
+import {
+  LABEL_GO_LANE,
+  LABEL_HUMAN,
+  LABEL_READY,
+  LABEL_RUNNING,
+  LABEL_SCOUT_LANE,
+} from "./triage-labels.js";
+
+export interface ClaimRecoveryPlan {
+  readonly remove: string[];
+  readonly add: string[];
+  readonly destination: string;
+  readonly refusalReason?: string;
+  readonly audit: string;
+}
+
+/** Plan the label restoration and audit for one stale or daemon-dead claim. */
+export function planClaimRecovery(
+  currentLabels: readonly string[],
+  release: StaleClaimRelease,
+  claimedIssue?: ClaimedIssue,
+): ClaimRecoveryPlan {
+  const parked = currentLabels.includes(LABEL_HUMAN) || blockedLabelsIn(currentLabels).length > 0;
+  const isolatedLane = currentLabels.includes(LABEL_GO_LANE)
+    ? LABEL_GO_LANE
+    : currentLabels.includes(LABEL_SCOUT_LANE)
+      ? LABEL_SCOUT_LANE
+      : undefined;
+  const transition = parked || isolatedLane ? undefined : planTransition(currentLabels, { kind: "queue" });
+  const refused = transition && isRefused(transition) ? transition : undefined;
+  const destination = isolatedLane ?? LABEL_READY;
+  const remove = refused || !transition ? [LABEL_RUNNING] : [...transition.remove];
+  const add = refused || !transition ? [] : [...transition.add];
+
+  const deadOwners = new Set(claimedIssue?.deadOwners ?? []);
+  const concededOwners = release.concededOwners ?? [];
+  const releaseAudit = concededOwners.length > 0
+    ? renderConcededClaimSweepAudit(concededOwners, destination)
+    : release.staleOwners.some((owner) => deadOwners.has(owner))
+      ? renderDeadClaimSweepAudit(release.staleOwners, destination)
+      : renderStaleClaimSweepAudit(release.staleOwners, destination);
+  const zeroCommitBranches = (claimedIssue?.attemptBranches ?? [])
+    .filter((branch) => branch.commitsAhead === 0)
+    .map((branch) => `\`${branch.branch}\``);
+  const branchAudit = zeroCommitBranches.length === 0
+    ? ""
+    : `\n\nRemote attempt ${zeroCommitBranches.length === 1 ? "branch" : "branches"} ` +
+      `${zeroCommitBranches.join(", ")} carried zero commits ahead of trunk and remained for branch cleanup policy.`;
+
+  return {
+    remove,
+    add,
+    destination,
+    ...(refused ? { refusalReason: refused.reason } : {}),
+    audit: releaseAudit + branchAudit,
+  };
+}

--- a/apps/dev/src/mcp/handlers.ts
+++ b/apps/dev/src/mcp/handlers.ts
@@ -56,6 +56,8 @@ import { collectActivityReview } from "../commands/activity-review.js";
 import { executeTriage } from "../commands/triage.js";
 import { executeRespond } from "../commands/respond.js";
 import { collectDeadendAuditReport } from "../runtime/deadend-audit-report.js";
+import { createRedskilledBirthPort } from "../runtime/redskilled-birth.js";
+import { hostFingerprintPrefix } from "../core/host-identity.js";
 
 import type { DevAfkMcpOperations, DevAfkMcpRuntime } from "./operations.js";
 import { dispatchArgs, buildWaitArgs, defaultMcpRuntime, resolveConfiguredBase, latestClaimPerWorker } from "./operations.js";
@@ -480,24 +482,34 @@ export function createDefaultDevAfkMcpOperations(
     async claimStatus(input) {
       const context = await resolveRepoContext(root);
       const gh = { cwd: context.root, repo: context.repo };
+      const deadWorkerIds = new Set(
+        await createRedskilledBirthPort({ root }).recordedDeadWorkerIds().catch(() => []),
+      );
+      const localPrefix = hostFingerprintPrefix();
+      const daemonRecordedDead = (worker: string): boolean =>
+        worker.startsWith(localPrefix) && deadWorkerIds.has(worker.slice(localPrefix.length));
       const statusOf = async (issue: number) => {
         const records = parseClaimRecords(await ghx.listClaimComments(gh, issue));
         const latest = latestClaimPerWorker(records);
         const holders = [...latest.values()].filter((record) => record.kind === "claim");
+        const deadHolders = holders.filter((record) => daemonRecordedDead(record.worker));
         return {
           issue,
+          daemon_recorded_dead: deadHolders.map((record) => record.worker),
           records: records.map((record) => ({
             comment_id: record.commentId,
             worker: record.worker,
             kind: record.kind,
             runner: record.runner ?? "",
             created_at: record.createdAt ?? "",
+            daemon_liveness: daemonRecordedDead(record.worker) ? "dead" : "unknown",
           })),
           holders: holders.map((record) => ({
             worker: record.worker,
             comment_id: record.commentId,
             runner: record.runner ?? "",
             created_at: record.createdAt ?? "",
+            daemon_liveness: daemonRecordedDead(record.worker) ? "dead" : "unknown",
           })),
         };
       };

--- a/apps/dev/src/mcp/project.ts
+++ b/apps/dev/src/mcp/project.ts
@@ -344,9 +344,10 @@ export async function projectStart(
   // so a claim whose pid died during setup cannot leave `running` stranded.
   // This remains project-authored work: the daemon carries the hook without
   // learning what a claim, label, branch or queue lane means.
+  const reconciliationLaunch = registrationLaunch({ runner: input.runner, logPath: logPathTemplate });
   const workerDeathHook = {
-    ...launch,
-    argv: [...launch.argv, "--boot-only"],
+    ...reconciliationLaunch,
+    argv: [...reconciliationLaunch.argv, "--boot-only"],
     mode: "sync" as const,
     deadline_ms: 120_000,
   };

--- a/apps/dev/src/mcp/project.ts
+++ b/apps/dev/src/mcp/project.ts
@@ -339,6 +339,17 @@ export async function projectStart(
   // its slot and its runner — lived in a builder nothing called. A Worker born
   // without its id minted a second one, and no surface could join the two.
   const launch = registrationLaunch({ runner: input.runner, selector: input.selector, logPath: logPathTemplate });
+  // A Worker's death is the daemon's authoritative liveness verdict. Run one
+  // boot-only reconciliation before another birth can consume the freed slot,
+  // so a claim whose pid died during setup cannot leave `running` stranded.
+  // This remains project-authored work: the daemon carries the hook without
+  // learning what a claim, label, branch or queue lane means.
+  const workerDeathHook = {
+    ...launch,
+    argv: [...launch.argv, "--boot-only"],
+    mode: "sync" as const,
+    deadline_ms: 120_000,
+  };
 
   let registered;
   try {
@@ -358,6 +369,7 @@ export async function projectStart(
       // (#3118) and the worker id it assigns — that the pure builder re-pins.
       env: launch.env ?? {},
       ...(launch.log_path == null ? {} : { log_path: launch.log_path }),
+      hooks: { "worker-death": workerDeathHook },
       target: input.target,
       ...(options.standing === true ? { standing: true } : {}),
     });
@@ -466,6 +478,7 @@ export async function drain(
       ...(held.trunk == null ? {} : { trunk: held.trunk }),
       env: { ...held.env },
       ...(held.log_path == null ? {} : { log_path: held.log_path }),
+      ...(held.hooks == null ? {} : { hooks: held.hooks }),
       target: action.target,
       ...(options.standing === true || held.standing === true ? { standing: true } : {}),
       renew_within_ms: held.renew_within_ms,
@@ -492,6 +505,7 @@ export async function drain(
       ...(held.trunk == null ? {} : { trunk: held.trunk }),
       env: { ...held.env },
       ...(held.log_path == null ? {} : { log_path: held.log_path }),
+      ...(held.hooks == null ? {} : { hooks: held.hooks }),
       target: held.target,
       standing: true,
       renew_within_ms: held.renew_within_ms,

--- a/apps/dev/src/runtime/redskilled-birth.ts
+++ b/apps/dev/src/runtime/redskilled-birth.ts
@@ -235,6 +235,8 @@ export interface RedskilledBirthPort {
    * process that knows when the birth happened.
    */
   workerBirths(): Promise<Readonly<Record<string, string>>>;
+  /** Workers whose latest lifecycle verdict in the daemon lane is death. */
+  recordedDeadWorkerIds(): Promise<readonly string[]>;
   /** Extra host capacity reserved above the ordinary Worker ceiling. */
   interactiveReservation(): Promise<number>;
   /**
@@ -400,6 +402,18 @@ export function createRedskilledBirthPort(options: CreateRedskilledBirthOptions)
 
     async workerBirths() {
       return Object.fromEntries((await readProjectWorkers()).map((w) => [w.worker_id, w.started_at]));
+    },
+
+    async recordedDeadWorkerIds() {
+      const dead = new Set<string>();
+      for (const event of await readRedskilledEvents(paths.eventLanePath)) {
+        if (event.project_label !== projectLabel) continue;
+        if (event.kind === "worker-birth") dead.delete(event.worker_id);
+        if (event.kind === "worker-death" || event.kind === "worker-budget-kill") {
+          dead.add(event.worker_id);
+        }
+      }
+      return [...dead];
     },
 
     async interactiveReservation() {

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -493,9 +493,12 @@ export async function buildBootDeps(
   const issueStates = await ghx.listIssueStates(ghCtx);
   const branchCache = await resolveBranchIssueCache(ghCtx, options, issueStates);
   const liveBranchCommitByIssue = new Map<number, number>();
+  const liveBranchesByIssue = new Map<number, string[]>();
   for (const ref of options.branches.remoteLiveRefs) {
     const issue = liveIssueFromBranch(ref.branch);
-    if (issue === null || !Number.isFinite(ref.commitS)) continue;
+    if (issue === null) continue;
+    liveBranchesByIssue.set(issue, [...(liveBranchesByIssue.get(issue) ?? []), ref.branch]);
+    if (!Number.isFinite(ref.commitS)) continue;
     const previous = liveBranchCommitByIssue.get(issue);
     if (previous === undefined || ref.commitS! > previous) liveBranchCommitByIssue.set(issue, ref.commitS!);
   }
@@ -637,12 +640,26 @@ export async function buildBootDeps(
               const pid = existsSync(pidPath) ? Number(readFileSync(pidPath, "utf8").trim()) : Number.NaN;
               (Number.isInteger(pid) && isLivePid(pid) ? liveOwners : deadOwners).push(worker);
             }
+            const attemptBranches = deadOwners.length === 0
+              ? undefined
+              : await Promise.all((liveBranchesByIssue.get(issue) ?? []).map(async (branch) => {
+                  const commitsAhead = await gitx.branchCommitsAhead(
+                    gitCtx,
+                    branch,
+                    options.branches.trunk,
+                  );
+                  return {
+                    branch,
+                    ...(commitsAhead === undefined ? {} : { commitsAhead }),
+                  };
+                }));
             claimed.push({
               issue,
               records,
               deadOwners,
               liveOwners,
               attemptBranchCommitS: liveBranchCommitByIssue.get(issue),
+              ...(attemptBranches === undefined ? {} : { attemptBranches }),
             });
           } catch {
             // best-effort: skip an issue whose claim comments cannot be read.

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -492,6 +492,7 @@ export async function buildBootDeps(
   // ONE batched issue-state fetch backs every per-issue boot lookup below.
   const issueStates = await ghx.listIssueStates(ghCtx);
   const branchCache = await resolveBranchIssueCache(ghCtx, options, issueStates);
+  const trunk = options.branches.trunk ?? options.precheck.configuredTrunk ?? DEFAULT_BRANCH;
   const liveBranchCommitByIssue = new Map<number, number>();
   const liveBranchesByIssue = new Map<number, string[]>();
   for (const ref of options.branches.remoteLiveRefs) {
@@ -646,7 +647,7 @@ export async function buildBootDeps(
                   const commitsAhead = await gitx.branchCommitsAhead(
                     gitCtx,
                     branch,
-                    options.branches.trunk,
+                    trunk,
                   );
                   return {
                     branch,

--- a/apps/dev/tests/boot-cleanup.test.ts
+++ b/apps/dev/tests/boot-cleanup.test.ts
@@ -808,6 +808,39 @@ describe("runBoot cross-host stale-claim sweep (#627)", () => {
     expect(ghCalls.comment[0].body).toContain("worker.pid");
   });
 
+  it("restores a dead claim to its isolated pre-claim lane", async () => {
+    const claimedIssues = async () => [
+      { issue: 42, records: [claim(10, "host1:wXY", 120)], deadOwners: ["host1:wXY"] },
+    ];
+    const viewLabels = async () => ["running", "lane:go"];
+    const { deps, ghCalls } = makeDeps({ claimedIssues, viewLabels });
+
+    const r = await runBoot(deps, options());
+
+    expect(r.staleClaimSweep).toEqual({ released: [42] });
+    expect(ghCalls.editLabels).toEqual([{ issue: 42, remove: ["running"], add: [] }]);
+    expect(ghCalls.comment[0].body).toContain("`lane:go`");
+    expect(ghCalls.comment[0].body).not.toContain("back to `ready-for-agent`");
+  });
+
+  it("audits the zero-commit remote branch left by a crash during setup", async () => {
+    const claimedIssues = async () => [
+      {
+        issue: 42,
+        records: [claim(10, "host1:wXY", 120)],
+        deadOwners: ["host1:wXY"],
+        attemptBranches: [{ branch: "afk/wXY/42-crash", commitsAhead: 0 }],
+      },
+    ];
+    const { deps, ghCalls } = makeDeps({ claimedIssues });
+
+    const r = await runBoot(deps, options());
+
+    expect(r.staleClaimSweep).toEqual({ released: [42] });
+    expect(ghCalls.comment[0].body).toContain("`afk/wXY/42-crash`");
+    expect(ghCalls.comment[0].body).toContain("zero commits");
+  });
+
   it("honours RED_AFK_CLAIM_REFRESH_S / tolerance from env", async () => {
     // 700s old: stale under the default 1200s window? no. Tighten the window to
     // 60×(1+0)=60s via env → 700s is now stale.

--- a/apps/dev/tests/claim-status-dead.test.ts
+++ b/apps/dev/tests/claim-status-dead.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+const claims = vi.hoisted(() => [] as Array<{ id: number; body: string }>);
+const deadWorkerIds = vi.hoisted(() => ["wDEAD"] as string[]);
+
+vi.mock("../src/runtime/gh.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../src/runtime/gh.js")>(),
+  listClaimComments: vi.fn(async () => claims),
+}));
+
+vi.mock("../src/runtime/wire.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../src/runtime/wire.js")>(),
+  resolveRepoContext: vi.fn(async (root: string) => ({ root, repo: "acme/widgets" })),
+}));
+
+vi.mock("../src/runtime/redskilled-birth.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../src/runtime/redskilled-birth.js")>(),
+  createRedskilledBirthPort: vi.fn(() => ({
+    recordedDeadWorkerIds: async () => deadWorkerIds,
+  })),
+}));
+
+import { createDefaultDevAfkMcpOperations } from "../src/mcp-adapter.js";
+import { renderClaimComment } from "../src/core/claim.js";
+import { workerIdentity } from "../src/core/host-identity.js";
+
+describe("claim_status daemon liveness", () => {
+  it("names a current holder whose death the daemon recorded", async () => {
+    const dead = workerIdentity("wDEAD");
+    const alive = workerIdentity("wLIVE");
+    claims.splice(
+      0,
+      claims.length,
+      { id: 1, body: renderClaimComment({ worker: dead, runner: "codex" }, "claim") },
+      { id: 2, body: renderClaimComment({ worker: alive, runner: "claude" }, "claim") },
+    );
+
+    await expect(createDefaultDevAfkMcpOperations("project").claimStatus({ issue: 3774 }))
+      .resolves.toMatchObject({
+        issue: 3774,
+        daemon_recorded_dead: [dead],
+        holders: expect.arrayContaining([
+          expect.objectContaining({ worker: dead, daemon_liveness: "dead" }),
+          expect.objectContaining({ worker: alive, daemon_liveness: "unknown" }),
+        ]),
+      });
+  });
+});

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -241,6 +241,19 @@ describe("starting work registers the project", () => {
     expect(spawn.mock.calls.filter((call) => (call[1] ?? []).includes("__supervise"))).toEqual([]);
   });
 
+  it("registers worker-death as one bounded claim-reconciliation cycle", async () => {
+    const daemon = await liveHost();
+    const root = await project();
+
+    await createCastleMcpDependencies(root).projectStart({ runner: "codex", target: 1 });
+
+    const hook = daemon.registrations()[0]?.hooks?.["worker-death"];
+    expect(hook).toMatchObject({ mode: "sync" });
+    expect(hook?.deadline_ms).toBeGreaterThan(0);
+    expect(hook?.argv).toEqual(expect.arrayContaining(["run", "--boot-only"]));
+    expect(hook?.env).toMatchObject({ RED_AFK_RUNNER: "codex" });
+  });
+
   it("carries the project's selector and argv unmodified", async () => {
     const daemon = await liveHost();
     const root = await project();

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -245,12 +245,17 @@ describe("starting work registers the project", () => {
     const daemon = await liveHost();
     const root = await project();
 
-    await createCastleMcpDependencies(root).projectStart({ runner: "codex", target: 1 });
+    await createCastleMcpDependencies(root).projectStart({
+      runner: "codex",
+      target: 1,
+      selector: { issues: [3774] },
+    });
 
     const hook = daemon.registrations()[0]?.hooks?.["worker-death"];
     expect(hook).toMatchObject({ mode: "sync" });
     expect(hook?.deadline_ms).toBeGreaterThan(0);
     expect(hook?.argv).toEqual(expect.arrayContaining(["run", "--boot-only"]));
+    expect(hook?.argv).not.toContain("--selector");
     expect(hook?.env).toMatchObject({ RED_AFK_RUNNER: "codex" });
   });
 

--- a/apps/dev/tests/redskilled-birth.test.ts
+++ b/apps/dev/tests/redskilled-birth.test.ts
@@ -168,6 +168,7 @@ describe("a project's Worker is born by the daemon", () => {
     // so it must arrive structurally rather than inside the daemon's prose.
     expect(death.exit_code).toBe(78);
     expect(death.project_label).toBe("acme/widgets");
+    await expect(port.recordedDeadWorkerIds()).resolves.toContain("wDEAD");
   });
 
   it("drains each host event exactly once, so a death is never counted twice", async () => {

--- a/apps/dev/tests/run-flags.test.ts
+++ b/apps/dev/tests/run-flags.test.ts
@@ -13,6 +13,7 @@ import {
   RunFlagError,
   deriveActivity,
   resolveRunDispatchIdentity,
+  runNeedsAdmittedFork,
   shouldSkipBootSweeps,
   initBootWorkerState,
 } from "../src/commands/run.js";
@@ -217,6 +218,11 @@ describe("parseRunFlags", () => {
   it("parses --boot-only as a boolean, defaulting to false", () => {
     expect(parseRunFlags(["--boot-only"]).bootOnly).toBe(true);
     expect(parseRunFlags([]).bootOnly).toBe(false);
+  });
+
+  it("lets boot-only reconciliation run without an admitted work fork", () => {
+    expect(runNeedsAdmittedFork(parseRunFlags(["--boot-only"]))).toBe(false);
+    expect(runNeedsAdmittedFork(parseRunFlags([]))).toBe(true);
   });
 
   it("parses --alternate and --fallback-runner as booleans", () => {

--- a/packages/red-castle/src/engine/tracker/claim-staleness.ts
+++ b/packages/red-castle/src/engine/tracker/claim-staleness.ts
@@ -254,6 +254,8 @@ export interface ClaimedIssue {
   /** Most recent commit epoch across this issue's live attempt branches. When
    * recent enough, it proves active progress even if the claim marker is old. */
   attemptBranchCommitS?: number;
+  /** Remote attempt branches and their distance from trunk, for release audit. */
+  attemptBranches?: readonly { branch: string; commitsAhead?: number }[];
   /** Claim owners proven dead on this host by their per-worker `worker.pid`. */
   deadOwners?: readonly string[];
   /** Claim owners proven LIVE on this host by their per-worker `worker.pid`.
@@ -273,20 +275,26 @@ export interface StaleClaimRelease {
 /** Render the single audit comment the boot sweep posts when it releases an
  * issue whose owner died on another host (#627) — the visible record that the
  * issue returned to the executable pool. */
-export function renderStaleClaimSweepAudit(staleOwners: readonly string[]): string {
+export function renderStaleClaimSweepAudit(
+  staleOwners: readonly string[],
+  destination = "ready-for-agent",
+): string {
   const who = staleOwners.map((w) => `\`${w}\``).join(", ");
   return (
-    `🤖 AFK cross-host stale-claim sweep: released this issue back to \`ready-for-agent\` — ` +
+    `🤖 AFK cross-host stale-claim sweep: released this issue back to \`${destination}\` — ` +
     `${staleOwners.length === 1 ? "the claim" : "the claims"} held by ${who} stopped refreshing ` +
     `past the staleness window (owner presumed dead on another host).`
   );
 }
 
 /** Render the audit comment for an immediate same-host ghost-claim release. */
-export function renderDeadClaimSweepAudit(staleOwners: readonly string[]): string {
+export function renderDeadClaimSweepAudit(
+  staleOwners: readonly string[],
+  destination = "ready-for-agent",
+): string {
   const who = staleOwners.map((w) => `\`${w}\``).join(", ");
   return (
-    `🤖 AFK same-host ghost-claim sweep: released this issue back to \`ready-for-agent\` — ` +
+    `🤖 AFK same-host ghost-claim sweep: released this issue back to \`${destination}\` — ` +
     `${staleOwners.length === 1 ? "the claim" : "the claims"} held by ${who} had a dead \`worker.pid\`.`
   );
 }
@@ -294,10 +302,13 @@ export function renderDeadClaimSweepAudit(staleOwners: readonly string[]): strin
 /** Render the audit comment for a stranded label projection: all claim markers
  * ended in concede but the issue still carried `running`, so the sweep returned
  * it to the executable pool. */
-export function renderConcededClaimSweepAudit(concededOwners: readonly string[]): string {
+export function renderConcededClaimSweepAudit(
+  concededOwners: readonly string[],
+  destination = "ready-for-agent",
+): string {
   const who = concededOwners.map((w) => `\`${w}\``).join(", ");
   return (
-    `🤖 AFK claim-label sweep: released this issue back to \`ready-for-agent\` — ` +
+    `🤖 AFK claim-label sweep: released this issue back to \`${destination}\` — ` +
     `${concededOwners.length === 1 ? "the latest claim marker" : "the latest claim markers"} for ${who} ` +
     `ended in concede while the issue was still labeled \`running\`.`
   );


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3774 -->
🤖 **Re-seed trail** — #3774 on `afk/3774-a-crashed-worker-s-claim-is-never-reconc`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3774; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3774 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/dev`, `packages/red-castle`]
{"schema":"red.afk.validation.v1","name":"feedback:pnpm typecheck","status":"failed","command":"pnpm typecheck","exitCode":2,"durationMs":26,"summary":"suspect-infra: `pnpm typecheck` exited 2 after 26ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. @reddb-io/red-browser:typecheck: $ tsc -p tsconfig.json --noEmit @reddb-io/brand-tokens:typecheck: cache hit, replaying logs 1e3a327a8c50feca @reddb-io/brand-tokens:typecheck: $ tsc -p tsconfig.json --noEmit @reddb-io/red-skills:typecheck: cache hit, replaying logs 7085057631cb1b85 @reddb-io/red-skills:typecheck: $ tsc -p tsconfig.json --noEmit @reddb-io/dev:typecheck: $ tsc -p tsconfig.json --noEmit @reddb-io/dev:typecheck: src/runtime/wire/boot.ts(649,21): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'. @reddb-io/dev:typecheck:   Type 'undefined' is not assignable to type 'string'. @reddb-io/dev:typecheck: [ELIFECYCLE] Command failed with exit code 2.   Tasks:    15 successful, 16 total Cached:    15 cached, 16 total   Time:    25.311s  Failed:    @reddb-io/dev#typecheck  [ELIFECYCLE] Command failed with exit code 2. $ turbo run typecheck --filter=!@reddb-io/red-castle --only • turbo 2.10.5 @reddb-io/dev#typecheck:  ERROR  command ","suspectInfra":true}
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":45,"summary":"suspect-infra: `pnpm -C apps/dev test:invariants` exited 1 after 45ms — under 1000ms is too fast for a suite command to have started, so read this as an environment failure before the branch's. failing: FAIL tests/file-size-guard.test.ts > file-size ratchet — a split nothing enforces is a split that comes back > holds the live tree to the threshold and the shrink-only baseline —  - Array [] + Array [ +   Object { +     \"kind\": \"over-baseline\", +     \"lines\": 1633, +     \"path\": \"apps/dev/src/core/boot.ts\", +     \"reason\": \"apps/dev/src/core/boot.ts grew from 1606 to 1633 lines. The baseline is shrink-only: lower the number as the file is decomposed, never raise it.\", +   }, + ]   ❯ tests/file-size-guard.test.ts:46:7      44|         : `file-size ratchet: ${findings.length} finding(s).\\n${render…      45|           `Baseline: apps/dev/src/core/file-size-guard.ts (FILE_SIZE_B…      46|     ).toEqual([]);        |       ^      47|   });      48|   ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯","suspectInfra":true}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3774