### PR TITLE
fix: #3777 redskilled test daemons inherit the real HOME and reap production Workers: a daemon must refuse to reap a Worker it has no birth record of

### DIFF
--- a/apps/redskilled/src/orphan-reaper.ts
+++ b/apps/redskilled/src/orphan-reaper.ts
@@ -51,6 +51,11 @@ export type RedskilledOrphanReaperCandidate =
       readonly detail: string;
     }
   | {
+      readonly kind: "stranger";
+      readonly process: RedskilledProcessCensusRow;
+      readonly detail: string;
+    }
+  | {
       readonly kind: "suspect";
       readonly process: RedskilledProcessCensusRow;
       readonly detail: string;
@@ -71,7 +76,7 @@ export interface SelectedRedskilledProcessCensus {
   readonly candidates: readonly RedskilledOrphanReaperCandidate[];
 }
 
-/** A stamped orphan is given this long to reconnect before the host reaps it. */
+/** A stamped stranger is given this long to reconnect before the host reports it. */
 export const REDSKILLED_STAMPED_ORPHAN_GRACE_MS = 10 * 60_000;
 
 /** An unstamped process needs a longer window because it cannot prove its origin. */
@@ -263,7 +268,7 @@ export function selectRedskilledProcessCensus(
       version: 1,
       active_worker_units: new Set(input.active_worker_units).size,
       daemon_held_workers: new Set(input.held_worker_ids).size,
-      stamped_orphans: candidates.filter((candidate) => candidate.kind === "reap").length,
+      stamped_orphans: candidates.filter((candidate) => candidate.kind === "stranger").length,
       unstamped_suspects: candidates.filter((candidate) => candidate.kind === "suspect").length,
       dump_files: new Set(input.dump_files).size,
     },
@@ -306,9 +311,9 @@ function selectOrphanReaperCandidatesOnly(
     }
     if (process.age_ms < REDSKILLED_STAMPED_ORPHAN_GRACE_MS) continue;
     selected.push({
-      kind: "reap",
+      kind: "stranger",
       process,
-      detail: `stamped Worker ${workerId} has no live birth and is at least 10 minutes old`,
+      detail: `stamped Worker ${workerId} has no birth record in this daemon and will never be signalled`,
     });
   }
   return selected;
@@ -504,11 +509,16 @@ export function createRedskilledOrphanReaperRuntime(
 
       for (const candidate of candidates) {
         if (mode === "report") {
-          if (candidate.kind === "suspect") counts.suspects += 1;
+          if (candidate.kind === "suspect" || candidate.kind === "stranger") counts.suspects += 1;
           report(`${candidate.detail}; report mode withheld adoption and signalling`);
           continue;
         }
         if (candidate.kind === "suspect") {
+          counts.suspects += 1;
+          report(candidate.detail);
+          continue;
+        }
+        if (candidate.kind === "stranger") {
           counts.suspects += 1;
           report(candidate.detail);
           continue;
@@ -567,7 +577,11 @@ export function createRedskilledOrphanReaperRuntime(
       mode: reportOnly ? "report" : "reap",
       census,
       actions: reportOnly
-        ? { adopted: 0, reaped: 0, suspects: census.unstamped_suspects }
+        ? {
+            adopted: 0,
+            reaped: 0,
+            suspects: census.stamped_orphans + census.unstamped_suspects,
+          }
         : await sweep(),
     };
   }

--- a/apps/redskilled/tests/orphan-reaper.test.ts
+++ b/apps/redskilled/tests/orphan-reaper.test.ts
@@ -56,15 +56,15 @@ function processRow(overrides: Partial<RedskilledProcessCensusRow> = {}): Redski
 }
 
 describe("the orphan reaper candidate selector", () => {
-  it("selects an unknown stamped process-group leader after the orphan grace", () => {
+  it("reports an unknown stamped process-group leader after the orphan grace", () => {
     expect(selectOrphanReaperCandidates({
       processes: [processRow()],
       held_worker_ids: new Set(),
       live_birth_ids: new Set(),
     })).toEqual([{
-      kind: "reap",
+      kind: "stranger",
       process: processRow(),
-      detail: "stamped Worker hLOST has no live birth and is at least 10 minutes old",
+      detail: "stamped Worker hLOST has no birth record in this daemon and will never be signalled",
     }]);
   });
 
@@ -192,7 +192,7 @@ describe("stamped orphan teardown", () => {
       },
     });
 
-    await expect(runtime.sweep()).resolves.toEqual({ adopted: 2, reaped: 1, suspects: 0 });
+    await expect(runtime.sweep()).resolves.toEqual({ adopted: 1, reaped: 0, suspects: 1 });
     expect(adopted).toEqual([
       {
         worker_id: "hLIVE",
@@ -200,13 +200,8 @@ describe("stamped orphan teardown", () => {
         started_at: "2026-08-11T10:09:59.000Z",
         unit: activeUnit,
       },
-      {
-        worker_id: "hLOST",
-        record_birth: true,
-        started_at: "2026-08-11T10:00:00.000Z",
-      },
     ]);
-    expect(killed).toEqual([4_242]);
+    expect(killed).toEqual([]);
     expect(reports.join(" ")).not.toMatch(/census withheld/);
   });
 
@@ -246,7 +241,7 @@ describe("stamped orphan teardown", () => {
       },
     });
 
-    await expect(runtime.sweep()).resolves.toEqual({ adopted: 0, reaped: 0, suspects: 0 });
+    await expect(runtime.sweep()).resolves.toEqual({ adopted: 0, reaped: 0, suspects: 1 });
     expect(mutations).toEqual({ adopt: 0, kill: 0, laneWrites: 0 });
   });
 
@@ -294,13 +289,14 @@ describe("stamped orphan teardown", () => {
     expect(signalled).toEqual([]);
   });
 
-  it("writes adopted birth before orphan-reaped death", async () => {
+  it("reports a stamped Worker with no birth record without adopting or signalling it", async () => {
     const root = await scratch("redskilled-orphan-daemon-");
     const paths = resolveRedskilledPaths({
       env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
       runtimeDir: root,
     });
     const killed: number[] = [];
+    const reports: string[] = [];
     const daemon = await startRedskilledDaemon({
       paths,
       idleMs: 60_000,
@@ -312,21 +308,22 @@ describe("stamped orphan teardown", () => {
         killed.push(pgid);
         return true;
       },
+      orphanReport: (detail) => reports.push(detail),
     });
     daemons.push(daemon);
 
-    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 1, reaped: 1, suspects: 0 });
+    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 0, reaped: 0, suspects: 1 });
     await daemon.flushEvents();
 
-    expect(killed).toEqual([4_242]);
+    expect(killed).toEqual([]);
     expect(daemon.workerCount()).toBe(0);
-    const events = await readRedskilledEvents(paths.eventLanePath);
-    expect(events.map((event) => event.kind)).toEqual(["worker-birth", "worker-death"]);
-    expect(events[0]!.detail).toMatch(/adopted stamped orphan/);
-    expect(events[1]!.detail).toMatch(/orphan-reaped/);
+    expect(await readRedskilledEvents(paths.eventLanePath)).toEqual([]);
+    expect(reports).toEqual([
+      "stamped Worker hLOST has no birth record in this daemon and will never be signalled",
+    ]);
   });
 
-  it("closes an adopted birth when the process group survives teardown", async () => {
+  it("never invents an adoption when an unknown stamped process group survives", async () => {
     const root = await scratch("redskilled-orphan-survivor-");
     const paths = resolveRedskilledPaths({
       env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
@@ -347,14 +344,12 @@ describe("stamped orphan teardown", () => {
     });
     daemons.push(daemon);
 
-    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 1, reaped: 0, suspects: 0 });
+    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 0, reaped: 0, suspects: 1 });
     await daemon.flushEvents();
 
-    expect(killed).toEqual([4_242]);
+    expect(killed).toEqual([]);
     expect(daemon.workerCount()).toBe(0);
-    const events = await readRedskilledEvents(paths.eventLanePath);
-    expect(events.map((event) => event.kind)).toEqual(["worker-birth", "worker-death"]);
-    expect(events[1]!.detail).toMatch(/group-survived: process group 4242/);
+    expect(await readRedskilledEvents(paths.eventLanePath)).toEqual([]);
   });
 
   it("adopts a stamped process whose live birth has no holder", async () => {
@@ -426,7 +421,7 @@ describe("stamped orphan teardown", () => {
     });
     daemons.push(daemon);
 
-    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 0, reaped: 0, suspects: 1 });
+    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 0, reaped: 0, suspects: 2 });
     expect(signalled).toEqual([]);
     expect(reports).toHaveLength(2);
     expect(reports.join(" ")).toMatch(/never be signalled/);

--- a/apps/redskilled/tests/reap-command.test.ts
+++ b/apps/redskilled/tests/reap-command.test.ts
@@ -72,7 +72,7 @@ describe("redskilled reap --report", () => {
         unstamped_suspects: 1,
         dump_files: 1,
       },
-      actions: { adopted: 0, reaped: 0, suspects: 1 },
+      actions: { adopted: 0, reaped: 0, suspects: 2 },
     });
     expect(signalled).toEqual([]);
   });

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -109,7 +109,14 @@ child.on("exit", (code) => process.exit(code ?? 0));
     // HOME is scoped to the fixture: entry stabilization files bundles under
     // the env's home, and a test env reaching the REAL ~/.red/redskilled/
     // would poison the operator's stable-bundle directory with fake versions.
-    env: { ...process.env, HOME: root, RED_SKILLS_CACHE_DIR: cacheDir },
+    env: {
+      ...process.env,
+      HOME: root,
+      XDG_RUNTIME_DIR: root,
+      REDSKILLED_SESSION: `test:${root}`,
+      REDSKILLED_MACHINE_DIR: root,
+      RED_SKILLS_CACHE_DIR: cacheDir,
+    },
   };
 }
 

--- a/apps/redskilled/tests/support/test-host-isolation.ts
+++ b/apps/redskilled/tests/support/test-host-isolation.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach } from "vitest";
+
+const parent = join(tmpdir(), "redskilled-test-host");
+const root = join(parent, String(process.pid));
+
+mkdirSync(root, { recursive: true });
+reapDeadSandboxes(parent);
+
+const isolatedEnvironment = {
+  HOME: join(root, "home"),
+  XDG_RUNTIME_DIR: join(root, "runtime"),
+  REDSKILLED_MACHINE_DIR: join(root, "machine"),
+  REDSKILLED_TEST_HOST_ROOT: root,
+} as const;
+
+Object.assign(process.env, isolatedEnvironment);
+mkdirSync(isolatedEnvironment.HOME, { recursive: true });
+mkdirSync(isolatedEnvironment.XDG_RUNTIME_DIR, { recursive: true });
+mkdirSync(isolatedEnvironment.REDSKILLED_MACHINE_DIR, { recursive: true });
+
+export function assertIsolatedHostIdentity(env: NodeJS.ProcessEnv = process.env): void {
+  for (const [name, expected] of Object.entries(isolatedEnvironment)) {
+    if (env[name] !== expected) {
+      throw new Error(
+        `redskilled test host identity escaped its sandbox: ${name} must remain pinned for every test`,
+      );
+    }
+  }
+}
+
+beforeEach(() => assertIsolatedHostIdentity());
+afterEach(() => assertIsolatedHostIdentity());
+
+process.on("exit", () => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function reapDeadSandboxes(sandboxParent: string): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(sandboxParent);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const pid = Number(entry);
+    if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid || isAlive(pid)) continue;
+    rmSync(join(sandboxParent, entry), { recursive: true, force: true });
+  }
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}

--- a/apps/redskilled/tests/test-host-isolation.test.ts
+++ b/apps/redskilled/tests/test-host-isolation.test.ts
@@ -1,0 +1,33 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import { assertIsolatedHostIdentity } from "./support/test-host-isolation.js";
+
+const SETUP_FILE = "./tests/support/test-host-isolation.ts";
+
+describe("the redskilled test host", () => {
+  it("is wired for every test file rather than relying on individual fixtures", () => {
+    const config = readFileSync(join(import.meta.dirname, "..", "vitest.config.ts"), "utf8");
+
+    expect(config).toContain(SETUP_FILE);
+  });
+
+  it("resolves every ambient host-owned path inside the sandbox", () => {
+    const paths = resolveRedskilledPaths();
+
+    expect(process.env.REDSKILLED_TEST_HOST_ROOT).toBeTruthy();
+    const root = process.env.REDSKILLED_TEST_HOST_ROOT!;
+    expect(homedir().startsWith(root)).toBe(true);
+    expect(paths.runtimeDir.startsWith(root)).toBe(true);
+    expect(paths.machineClaimPath.startsWith(root)).toBe(true);
+    expect(paths.eventLanePath.startsWith(root)).toBe(true);
+    expect(paths.registrationIntentPath.startsWith(root)).toBe(true);
+  });
+
+  it("refuses a test that restores host identity before making a mutation", () => {
+    expect(() => assertIsolatedHostIdentity({ ...process.env, HOME: "/outside-the-test-sandbox" }))
+      .toThrow(/HOME must remain pinned/);
+  });
+});

--- a/apps/redskilled/tests/wsl2-host.test.ts
+++ b/apps/redskilled/tests/wsl2-host.test.ts
@@ -43,8 +43,8 @@ afterEach(async () => {
   for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
 });
 
-describe("WSL2 — the daemon reaps a stamped orphan from a synthetic /proc", () => {
-  it("adopts the census identity, group-kills it, then records orphan-reaped death", async () => {
+describe("WSL2 — a synthetic /proc cannot confer Worker ownership", () => {
+  it("reports a stamped fixture Worker without a birth record and leaves it untouched", async () => {
     const root = await scratch("redskilled-wsl-orphan-");
     const procRoot = join(root, "proc");
     const processDir = join(procRoot, "4242");
@@ -85,14 +85,11 @@ describe("WSL2 — the daemon reaps a stamped orphan from a synthetic /proc", ()
     });
     daemons.push(daemon);
 
-    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 1, reaped: 1, suspects: 0 });
+    await expect(daemon.sweepOrphanProcesses()).resolves.toEqual({ adopted: 0, reaped: 0, suspects: 1 });
     await daemon.flushEvents();
 
-    expect(killed).toEqual([4_242]);
-    const events = await readRedskilledEvents(paths.eventLanePath);
-    expect(events.map((event) => event.kind)).toEqual(["worker-birth", "worker-death"]);
-    expect(events[0]!.detail).toMatch(/adopted stamped orphan/);
-    expect(events[1]!.detail).toMatch(/orphan-reaped/);
+    expect(killed).toEqual([]);
+    expect(await readRedskilledEvents(paths.eventLanePath)).toEqual([]);
   });
 });
 

--- a/apps/redskilled/vitest.config.ts
+++ b/apps/redskilled/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
+    setupFiles: ["./tests/support/test-host-isolation.ts"],
     environment: "node",
     pool: "forks",
     fileParallelism: false,


### PR DESCRIPTION
Automated AFK landing for #3777. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3777

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789174902&installation_model_id=20659&pr_number=3792&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3792&signature=3c4b002ada66f7b185fb9d77b62a13c6eb4c7b1806db6f07c061276192bca5cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->