### PR TITLE
fix: #3778 A partial trust-read failure renders the ready queue as empty: eligible=[] is indistinguishable from a real empty queue

### DIFF
--- a/apps/dev/src/mcp/dependencies.ts
+++ b/apps/dev/src/mcp/dependencies.ts
@@ -213,7 +213,7 @@ export function createCastleMcpDependencies(
       }
       const config = loadConfig(afkPaths(root).configPath, { warn: () => undefined });
       const policy = parseTrustPolicy(config, await ghx.repoVisibility(gh));
-      const { eligible, heldForSummon } = await partitionReadyForAgentByTrust(
+      const { eligible, heldForSummon, errors } = await partitionReadyForAgentByTrust(
         readyForAgent,
         policy,
         {
@@ -221,7 +221,7 @@ export function createCastleMcpDependencies(
           actorTrustSignals: ghx.createActorTrustLookup(gh),
         },
       );
-      return buildQueueStatus(eligible, heldForSummon, readyForHuman);
+      return buildQueueStatus(eligible, heldForSummon, readyForHuman, errors);
     },
     workerDispatch: (input) => {
       if (input.issue !== undefined) {

--- a/apps/dev/src/mcp/queue.ts
+++ b/apps/dev/src/mcp/queue.ts
@@ -38,6 +38,7 @@ export function buildQueueStatus(
   eligibleForAgent: readonly IssueCandidate[],
   heldForSummon: readonly IssueCandidate[],
   readyForHuman: readonly HitlCandidate[],
+  errors: readonly QueueStatusError[] = [],
 ): QueueStatusOutput {
   const projectCandidate = ({ body: _body, author: _author, ...candidate }: IssueCandidate) => candidate;
   return {
@@ -51,7 +52,40 @@ export function buildQueueStatus(
       ready_for_agent_held: heldForSummon.length,
       ready_for_human: readyForHuman.length,
     },
+    degraded: errors.length > 0,
+    errors: [...errors],
   };
+}
+
+export interface QueueStatusError {
+  kind: "trust-read";
+  number: number;
+  message: string;
+}
+
+export const DEFAULT_QUEUE_TRUST_READ_DEADLINE_MS = 30_000;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function withDeadline<T>(promise: Promise<T>, deadline: number, message: string): Promise<T> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(
+      () => rejectPromise(new Error(message)),
+      Math.max(0, deadline - Date.now()),
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolvePromise(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        rejectPromise(error);
+      },
+    );
+  });
 }
 
 export async function partitionReadyForAgentByTrust(
@@ -60,27 +94,50 @@ export async function partitionReadyForAgentByTrust(
   deps: {
     issueTrust(candidate: IssueCandidate): Promise<TrustProvenance>;
     actorTrustSignals: ActorTrustLookup;
+    trustReadDeadlineMs?: number;
   },
 ): Promise<{
   eligible: IssueCandidate[];
   heldForSummon: IssueCandidate[];
+  errors: QueueStatusError[];
 }> {
   const eligible: IssueCandidate[] = [];
   const heldForSummon: IssueCandidate[] = [];
+  const errors: QueueStatusError[] = [];
   const gateActive = policy.enabled || policy.failClosed === true;
-  for (const candidate of candidates) {
-    if (!gateActive) {
-      eligible.push(candidate);
-      continue;
+  if (!gateActive) return { eligible: [...candidates], heldForSummon, errors };
+  const deadlineMs = deps.trustReadDeadlineMs ?? DEFAULT_QUEUE_TRUST_READ_DEADLINE_MS;
+  const deadline = Date.now() + deadlineMs;
+
+  const results = await Promise.all(candidates.map(async (candidate) => {
+    try {
+      const verdict = await withDeadline(
+        (async () => evaluateClaimTrust(
+          policy,
+          await deps.issueTrust(candidate),
+          deps.actorTrustSignals,
+        ))(),
+        deadline,
+        `trust read timed out after ${deadlineMs}ms`,
+      );
+      return { candidate, status: "success", executable: verdict.executable } as const;
+    } catch (error) {
+      return { candidate, status: "error", error: errorMessage(error) } as const;
     }
-    const verdict = await evaluateClaimTrust(
-      policy,
-      await deps.issueTrust(candidate),
-      deps.actorTrustSignals,
-    );
-    (verdict.executable ? eligible : heldForSummon).push(candidate);
+  }));
+
+  for (const result of results) {
+    if (result.status === "error") {
+      errors.push({
+        kind: "trust-read",
+        number: result.candidate.number,
+        message: result.error,
+      });
+    } else {
+      (result.executable ? eligible : heldForSummon).push(result.candidate);
+    }
   }
-  return { eligible, heldForSummon };
+  return { eligible, heldForSummon, errors };
 }
 
 /** Every checkout under the disposable `.red/tmp/worktrees/<lane>/` lanes, in

--- a/apps/dev/tests/castle-mcp-output-contracts.test.ts
+++ b/apps/dev/tests/castle-mcp-output-contracts.test.ts
@@ -213,6 +213,8 @@ describe("dev:afk observability output contracts", () => {
         ready_for_agent_held: 1,
         ready_for_human: 1,
       },
+      degraded: false,
+      errors: [],
     });
   });
 });

--- a/apps/dev/tests/queue-status-trust.test.ts
+++ b/apps/dev/tests/queue-status-trust.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { partitionReadyForAgentByTrust } from "../src/mcp-adapter.js";
+import {
+  buildQueueStatus,
+  partitionReadyForAgentByTrust,
+} from "../src/mcp-adapter.js";
 import type { IssueCandidate } from "../src/core/session.js";
 import type { TrustPolicy } from "../src/core/trust-gate.js";
 
@@ -35,4 +38,77 @@ describe("queue_status trust partition", () => {
     expect(partition.eligible).toEqual([]);
     expect(partition.heldForSummon.map((candidate) => candidate.number)).toEqual([2062]);
   });
+
+  it("keeps successful candidates visible and degrades the queue when a middle trust read fails", async () => {
+    const candidates: IssueCandidate[] = [
+      { number: 3777, title: "first", body: "", labels: ["ready-for-agent"], author: "maintainer" },
+      { number: 3778, title: "middle", body: "", labels: ["ready-for-agent"], author: "maintainer" },
+      { number: 3779, title: "last", body: "", labels: ["ready-for-agent"], author: "maintainer" },
+    ];
+    const policy: TrustPolicy = {
+      enabled: false,
+      allowlist: [],
+      visibility: "public",
+      failClosed: true,
+    };
+    let started = 0;
+    let releaseBatch!: () => void;
+    const batchStarted = new Promise<void>((resolve) => {
+      releaseBatch = resolve;
+    });
+
+    const partition = await partitionReadyForAgentByTrust(candidates, policy, {
+      issueTrust: async (candidate) => {
+        started += 1;
+        if (started === candidates.length) releaseBatch();
+        await batchStarted;
+        if (candidate.number === 3778) throw new Error("trust endpoint unavailable");
+        return { author: candidate.author, readyForAgentActor: "maintainer" };
+      },
+      actorTrustSignals: async () => ({ hasWriteAccess: true, inCodeowners: false }),
+    });
+    const queue = buildQueueStatus(
+      partition.eligible,
+      partition.heldForSummon,
+      [],
+      partition.errors,
+    );
+
+    expect(queue.ready_for_agent.eligible.map((candidate) => candidate.number)).toEqual([
+      3777,
+      3779,
+    ]);
+    expect(queue.ready_for_agent.held_for_summon).toEqual([]);
+    expect(queue.degraded).toBe(true);
+    expect(queue.errors).toEqual([
+      { kind: "trust-read", number: 3778, message: "trust endpoint unavailable" },
+    ]);
+  }, 1_000);
+
+  it("bounds the trust batch when one candidate never answers", async () => {
+    const candidates: IssueCandidate[] = [
+      { number: 3780, title: "answered", body: "", labels: ["ready-for-agent"], author: "maintainer" },
+      { number: 3781, title: "stalled", body: "", labels: ["ready-for-agent"], author: "maintainer" },
+    ];
+    const policy: TrustPolicy = {
+      enabled: false,
+      allowlist: [],
+      visibility: "public",
+      failClosed: true,
+    };
+
+    const partition = await partitionReadyForAgentByTrust(candidates, policy, {
+      issueTrust: async (candidate) => {
+        if (candidate.number === 3781) return await new Promise(() => undefined);
+        return { author: candidate.author, readyForAgentActor: "maintainer" };
+      },
+      actorTrustSignals: async () => ({ hasWriteAccess: true, inCodeowners: false }),
+      trustReadDeadlineMs: 10,
+    });
+
+    expect(partition.eligible.map((candidate) => candidate.number)).toEqual([3780]);
+    expect(partition.errors).toEqual([
+      { kind: "trust-read", number: 3781, message: "trust read timed out after 10ms" },
+    ]);
+  }, 500);
 });

--- a/apps/dev/tests/resident-read-cache.test.ts
+++ b/apps/dev/tests/resident-read-cache.test.ts
@@ -95,6 +95,8 @@ function makeFakeDeps(): Pick<
           ready_for_agent_held: 0,
           ready_for_human: 0,
         },
+        degraded: false,
+        errors: [],
       };
     }),
     claimStatus: vi.fn(async () => { count("claimStatus"); return { issue: 2370, records: [], holders: [] }; }),

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -89,6 +89,8 @@ function deps(): CastleMcpDependencies {
         ready_for_agent_held: 0,
         ready_for_human: 0,
       },
+      degraded: false,
+      errors: [],
     })),
     deadendAudit: vi.fn(async () => ({ total: 0, classes: [] })),
     eventsSince: vi.fn(async (input) => {

--- a/packages/red-castle/src/mcp/contracts.test.ts
+++ b/packages/red-castle/src/mcp/contracts.test.ts
@@ -190,6 +190,8 @@ describe("observability output contracts", () => {
           ready_for_agent_held: 0,
           ready_for_human: 0,
         },
+        degraded: false,
+        errors: [],
       })),
     } as unknown as CastleMcpDependencies;
     const tools = createCastleMcpTools(deps);

--- a/packages/red-castle/src/mcp/contracts.ts
+++ b/packages/red-castle/src/mcp/contracts.ts
@@ -422,6 +422,14 @@ export const queueStatusOutputSchema = z.object({
     ready_for_agent_held: z.number(),
     ready_for_human: z.number(),
   }),
+  degraded: z.boolean(),
+  errors: z.array(
+    z.object({
+      kind: z.literal("trust-read"),
+      number: z.number(),
+      message: z.string(),
+    }),
+  ),
 });
 
 export type QueueStatusOutput = z.infer<typeof queueStatusOutputSchema>;

--- a/packages/red-castle/src/mcp/observability.ts
+++ b/packages/red-castle/src/mcp/observability.ts
@@ -85,7 +85,7 @@ export function createObservabilityTools(
       name: "queue_status",
       title: "Read AFK queues",
       description:
-        "Return ready-for-agent and ready-for-human queue candidates. Pass `selector` to preview the producer's scoped view of the ready queue (same facets as its work selector, e.g. tags/user).",
+        "Return ready-for-agent and ready-for-human queue candidates, retaining successful candidates and naming partial trust-read failures as a degraded result. Pass `selector` to preview the producer's scoped view of the ready queue (same facets as its work selector, e.g. tags/user).",
       inputSchema: {
         selector: z.object(workSelectorShape).optional(),
       },

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -250,13 +250,15 @@ fails loudly unless a live recovery process owns the `merge-driver` singleton;
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `queue_status` | read | Trust-partitioned `ready-for-agent` candidates (`eligible` and `held_for_summon`) plus `ready-for-human`. Optional `selector` previews one fleet's scoped view (same facets as fleet selectors, e.g. `tags`/`user`). |
+| `queue_status` | read | Trust-partitioned `ready-for-agent` candidates (`eligible` and `held_for_summon`) plus `ready-for-human`. `degraded: true` names partial trust-read failures in `errors` while retaining successfully read candidates. Optional `selector` previews one fleet's scoped view (same facets as fleet selectors, e.g. `tags`/`user`). |
 | `events_since` | read | AFK history events and Worker lane records after an opaque cursor, plus the next cursor. |
 | `deadend_audit` | read | Every stuck AFK pattern with its recommended cure: dangling claims, red PRs with dead owners, superseded PRs, executable Tickets carrying an active Current blocker, dependency blocks whose `req:*` targets all closed, human-queue age outliers, and stale worktrees. Cache-backed — repeated calls within the refresh window cost zero GitHub quota. Detection only. |
 
 `help` is the first call when operating a drain. Use `queue_status` when its
 answer calls for the tracker-backed queue census: zero eligible `ready-for-agent`
 entries with a non-empty open backlog is a flow bug to census, not a clean stop.
+Treat `degraded: true` as a failed census, even when both candidate arrays are
+empty; use the named `errors` instead of concluding that the queue is empty.
 That rule includes a non-empty queue whose every entry is `held_for_summon`;
 release it with `triage:summon`, `dev triage --summon`, or
 `afk.trust-gate.allowlist`.

--- a/packaging/pi/dev/skills/engineering/afk/monitor.md
+++ b/packaging/pi/dev/skills/engineering/afk/monitor.md
@@ -22,6 +22,8 @@ command renders the same truth for a human terminal. See [`MCP.md`](./MCP.md).
 a non-empty open backlog is a flow bug to diagnose, never a clean stop. A
 non-empty `held_for_summon` bucket is still zero drainable work; release it with
 `triage:summon`, `dev triage --summon`, or `afk.trust-gate.allowlist`.
+When it reports `degraded: true`, treat the census as failed and read its named
+`errors`; empty candidate arrays in a degraded answer do not mean an empty queue.
 
 ## The binding mirror rule (authoritative — stated once)
 

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -250,13 +250,15 @@ fails loudly unless a live recovery process owns the `merge-driver` singleton;
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `queue_status` | read | Trust-partitioned `ready-for-agent` candidates (`eligible` and `held_for_summon`) plus `ready-for-human`. Optional `selector` previews one fleet's scoped view (same facets as fleet selectors, e.g. `tags`/`user`). |
+| `queue_status` | read | Trust-partitioned `ready-for-agent` candidates (`eligible` and `held_for_summon`) plus `ready-for-human`. `degraded: true` names partial trust-read failures in `errors` while retaining successfully read candidates. Optional `selector` previews one fleet's scoped view (same facets as fleet selectors, e.g. `tags`/`user`). |
 | `events_since` | read | AFK history events and Worker lane records after an opaque cursor, plus the next cursor. |
 | `deadend_audit` | read | Every stuck AFK pattern with its recommended cure: dangling claims, red PRs with dead owners, superseded PRs, executable Tickets carrying an active Current blocker, dependency blocks whose `req:*` targets all closed, human-queue age outliers, and stale worktrees. Cache-backed — repeated calls within the refresh window cost zero GitHub quota. Detection only. |
 
 `help` is the first call when operating a drain. Use `queue_status` when its
 answer calls for the tracker-backed queue census: zero eligible `ready-for-agent`
 entries with a non-empty open backlog is a flow bug to census, not a clean stop.
+Treat `degraded: true` as a failed census, even when both candidate arrays are
+empty; use the named `errors` instead of concluding that the queue is empty.
 That rule includes a non-empty queue whose every entry is `held_for_summon`;
 release it with `triage:summon`, `dev triage --summon`, or
 `afk.trust-gate.allowlist`.

--- a/plugins/dev/skills/engineering/afk/monitor.md
+++ b/plugins/dev/skills/engineering/afk/monitor.md
@@ -22,6 +22,8 @@ command renders the same truth for a human terminal. See [`MCP.md`](./MCP.md).
 a non-empty open backlog is a flow bug to diagnose, never a clean stop. A
 non-empty `held_for_summon` bucket is still zero drainable work; release it with
 `triage:summon`, `dev triage --summon`, or `afk.trust-gate.allowlist`.
+When it reports `degraded: true`, treat the census as failed and read its named
+`errors`; empty candidate arrays in a degraded answer do not mean an empty queue.
 
 ## The binding mirror rule (authoritative — stated once)
 


### PR DESCRIPTION
Automated AFK landing for #3778. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3778

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789175769&installation_model_id=20659&pr_number=3794&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3794&signature=b595933443ab427107a388722b697599db1d90536a5da7634fea8ba28aaec67c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->