### PR TITLE
fix: #3779 requeue refuses blocked:validation-infra: the machine-authority set lacks the vocabulary its own parks write

### DIFF
--- a/apps/dev/src/core/requeue.ts
+++ b/apps/dev/src/core/requeue.ts
@@ -51,6 +51,27 @@ export const REQUEUE_SUPPORTED_KINDS = new Set([
   "base-stale",
 ]);
 
+/**
+ * Park kinds that require human authority before the one requeue door may
+ * clear them. The transition-vocabulary guard proves this explicit set and
+ * {@link REQUEUE_SUPPORTED_KINDS} partition the complete Park census.
+ */
+export const HUMAN_ONLY_BLOCKER_KINDS = new Set([
+  "stalled",
+  "wall-clock-capped",
+  "crashed",
+  "signal-killed",
+  "dependency",
+  "quota",
+  "runner-transient",
+  "host-config",
+  "merge-conflict",
+  "ci",
+  "policy",
+  "trunk-diverged",
+  "budget",
+]);
+
 export interface RequeueInput {
   /** Machine callers are restricted to the mechanical allowlist; human callers may resolve any blocker kind. */
   authority?: RequeueAuthority;

--- a/apps/dev/src/core/requeue.ts
+++ b/apps/dev/src/core/requeue.ts
@@ -11,10 +11,10 @@
 // are its IO callers.
 //
 // #860 narrows the scope to explicitly supported transient parks. Alongside
-// `blocked:validation` and `blocked:spec`, `blocked:infra` and
-// `blocked:base-stale` are requeueable because a recovered mechanical fault
-// needs no new human decision. The IO caller freshness-gates `base-stale`
-// before applying this pure plan. Mixed
+// `blocked:validation`, `blocked:validation-infra`, and `blocked:spec`,
+// `blocked:infra` and `blocked:base-stale` are requeueable because a recovered
+// mechanical fault needs no new human decision. The IO caller freshness-gates
+// `base-stale` before applying this pure plan. Mixed
 // `blocked:*` states and label/body kind mismatches are refused without mutation
 // and direct the maintainer to `/hitl`.
 
@@ -45,6 +45,7 @@ import { LABEL_READY } from "./triage-labels.js";
  */
 export const REQUEUE_SUPPORTED_KINDS = new Set([
   "validation",
+  "validation-infra",
   "spec",
   "infra",
   "base-stale",
@@ -67,7 +68,7 @@ export type RequeueAuthority = "machine" | "human";
 
 /**
  * Is `kind` requeueable? The supported set is
- * `{validation, spec, infra, base-stale}`.
+ * `{validation, validation-infra, spec, infra, base-stale}`.
  */
 function kindRequeueable(kind: string): boolean {
   return REQUEUE_SUPPORTED_KINDS.has(kind);
@@ -174,10 +175,11 @@ export function isRequeueComplete(body: string, labels: readonly string[]): bool
  * labels, and add `ready-for-agent`. The body is always rewritten when a blocker
  * is active so the transition can never degrade into a label-only flip.
  *
- * Narrowed to explicit transient parks: `blocked:validation`, `blocked:spec`,
- * `blocked:infra`, and freshness-gated `blocked:base-stale`. Mixed `blocked:*`
- * states and label/body kind mismatches set `refuseForHitl: true` and direct
- * the caller to `/hitl` instead.
+ * Narrowed to explicit transient parks: `blocked:validation`,
+ * `blocked:validation-infra`, `blocked:spec`, `blocked:infra`, and
+ * freshness-gated `blocked:base-stale`. Mixed `blocked:*` states and label/body
+ * kind mismatches set `refuseForHitl: true` and direct the caller to `/hitl`
+ * instead.
  */
 export function planRequeue(input: RequeueInput): RequeuePlan {
   const authority = input.authority ?? "machine";
@@ -215,7 +217,7 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
   // Unsupported label kind → /hitl handles other human-input blocker types.
   if (authority === "machine" && labelKind !== null && !kindRequeueable(labelKind)) {
     return refuse(
-      `blocked:${labelKind} is not in the supported set for machine authority (validation, spec, infra, base-stale): use /hitl for human authority`,
+      `blocked:${labelKind} is not in the supported set for machine authority (validation, validation-infra, spec, infra, base-stale): use /hitl for human authority`,
       true,
       activeBlocker,
       input.body,
@@ -230,7 +232,7 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
     !kindRequeueable(activeBlocker.kind)
   ) {
     return refuse(
-      `active blocker kind "${activeBlocker.kind}" is not in the supported set for machine authority (validation, spec, infra, base-stale): use /hitl for human authority`,
+      `active blocker kind "${activeBlocker.kind}" is not in the supported set for machine authority (validation, validation-infra, spec, infra, base-stale): use /hitl for human authority`,
       true,
       activeBlocker,
       input.body,

--- a/apps/dev/tests/requeue.test.ts
+++ b/apps/dev/tests/requeue.test.ts
@@ -93,7 +93,7 @@ describe("requeue — label flip invariant", () => {
   });
 });
 
-describe("requeue — supported kinds (validation, spec, infra, base-stale)", () => {
+describe("requeue — supported kinds (validation, validation-infra, spec, infra, base-stale)", () => {
   it("clears the active blocker in the rewritten body instead of requiring manual editing", () => {
     const plan = planRequeue({
       body: parkedBody,

--- a/apps/dev/tests/requeue.test.ts
+++ b/apps/dev/tests/requeue.test.ts
@@ -30,6 +30,13 @@ const infraBlocker = {
   next: "Retry after the transient infrastructure fault clears.",
 };
 
+const validationInfraBlocker = {
+  status: "blocked" as const,
+  kind: "validation-infra",
+  summary: "The validation environment exhausted its retry budget.",
+  next: "Retry after the validation infrastructure recovers.",
+};
+
 const baseStaleBlocker = {
   status: "blocked" as const,
   kind: "base-stale",
@@ -58,6 +65,10 @@ const decisionBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${forma
 
 const infraBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${formatCurrentBlocker(
   infraBlocker,
+)}\n`;
+
+const validationInfraBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${formatCurrentBlocker(
+  validationInfraBlocker,
 )}\n`;
 
 const baseStaleBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${formatCurrentBlocker(
@@ -159,6 +170,21 @@ describe("requeue — supported kinds (validation, spec, infra, base-stale)", ()
     expect(plan.refuseForHitl).toBe(false);
     expect(plan.activeBlocker?.kind).toBe("infra");
     expect(plan.removeLabels).toEqual(expect.arrayContaining(["ready-for-human", "blocked:infra"]));
+    expect(plan.addLabels).toEqual(["ready-for-agent"]);
+  });
+
+  it("requeues a guided blocked:validation-infra park through the standard tool", () => {
+    const plan = planRequeue({
+      body: validationInfraBody,
+      labels: ["ready-for-human", "blocked:validation-infra"],
+      guidance: "Validation infrastructure recovered; retry the declared gate.",
+    });
+    expect(plan.requeueable).toBe(true);
+    expect(plan.refuseForHitl).toBe(false);
+    expect(plan.activeBlocker?.kind).toBe("validation-infra");
+    expect(plan.removeLabels).toEqual(
+      expect.arrayContaining(["ready-for-human", "blocked:validation-infra"]),
+    );
     expect(plan.addLabels).toEqual(["ready-for-agent"]);
   });
 

--- a/apps/dev/tests/transition-vocabulary.test.ts
+++ b/apps/dev/tests/transition-vocabulary.test.ts
@@ -8,6 +8,11 @@ import {
   blockedKindOf,
   blockedLabelsIn,
 } from "../src/core/state-transition.js";
+import {
+  HUMAN_ONLY_BLOCKER_KINDS,
+  REQUEUE_SUPPORTED_KINDS,
+  planRequeue,
+} from "../src/core/requeue.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SRC = join(HERE, "..", "src");
@@ -72,6 +77,39 @@ describe("ADR 0136 transition vocabulary", () => {
       expect(source, relative(SRC, path)).not.toMatch(/\.startsWith\(["']blocked:/);
       expect(source, relative(SRC, path)).not.toMatch(/\.slice\(["']blocked:["']\.length\)/);
       expect(source, relative(SRC, path)).not.toMatch(/\/\^blocked:\|ready-for-human/);
+    }
+  });
+
+  it("partitions every Park label into machine-supported or explicitly human-only requeue authority", () => {
+    expect([...HUMAN_ONLY_BLOCKER_KINDS]).toEqual([
+      "stalled",
+      "wall-clock-capped",
+      "crashed",
+      "signal-killed",
+      "dependency",
+      "quota",
+      "runner-transient",
+      "host-config",
+      "merge-conflict",
+      "ci",
+      "policy",
+      "trunk-diverged",
+      "budget",
+    ]);
+
+    for (const label of BLOCKED_LABELS) {
+      const kind = blockedKindOf(label)!;
+      const machineSupported = REQUEUE_SUPPORTED_KINDS.has(kind);
+      const humanOnly = HUMAN_ONLY_BLOCKER_KINDS.has(kind);
+      expect(machineSupported !== humanOnly, label).toBe(true);
+
+      const plan = planRequeue({
+        authority: machineSupported ? "machine" : "human",
+        body: "## Summary\nParked by the engine.\n",
+        labels: ["ready-for-human", label],
+        guidance: "The declared blocker has been resolved.",
+      });
+      expect(plan.requeueable, `${label}: ${plan.reason ?? "refused without reason"}`).toBe(true);
     }
   });
 


### PR DESCRIPTION
Automated AFK landing for #3779. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3779

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789176528&installation_model_id=20659&pr_number=3796&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3796&signature=7705eb02c07cf8e41f1a6e35acf26b9a19e79c4a47cd69bd7548334e5ac540bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->