### PR TITLE
fix: routed sweep reads reach the tracker — gh refuses --slurp beside --jq

### DIFF
--- a/.changeset/sweep-reads-see-the-tracker.md
+++ b/.changeset/sweep-reads-see-the-tracker.md
@@ -1,0 +1,23 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Sweep reads reach the tracker again, and a blind one says so
+
+Every sweep listing was issuing `gh api --paginate --slurp … --jq …`, a flag
+combination the `gh` binary refuses outright (`the --slurp option is not
+supported with --jq or --template`). Each caller read the resulting non-zero
+exit as an empty collection, so the Unblock Sweep, the close cascade's dependent
+lookup, the parked-mechanical sweep, the open-PR census and the handoff comment
+read all reported "nothing found" against a full tracker. The Unblock Sweep
+answered `promoted: []` with two issues promotable and every `req:` blocker
+already closed; the comment read returned no comments, which is how Directive
+blocks carrying human guidance quietly stopped reaching Workers.
+
+The listings now paginate through the shared `@reddb-io/github` client, which
+removes the category rather than the instance: there is no argv to get wrong,
+page walking belongs to the client, and the reads inherit conditional caching,
+spend attribution and the retry policy the CLI path forfeited. A read that still
+fails answers with the same conservative empty collection — a sweep blind to the
+tracker must promote nothing — but now names the failure on stderr first, because
+an unreachable read and a quiet repository used to produce identical output.

--- a/apps/dev/src/runtime/gh/comments.ts
+++ b/apps/dev/src/runtime/gh/comments.ts
@@ -1,7 +1,13 @@
 import type { HandoffComment } from "../../core/handoff.js";
 import { classifySourceTrust, TRUSTED_ASSOCIATIONS, type SourceTrustLevel } from "../../core/source-trust.js";
 import type { ActorTrustVerdict } from "../../core/trust-gate.js";
-import { apiPath, runGithubRestRead, type GhContext } from "./common.js";
+import {
+  apiPath,
+  githubReadClient,
+  githubRepo,
+  runGithubRestRead,
+  type GhContext,
+} from "./common.js";
 
 export type CommentTrustResolver = (actor: string) => Promise<ActorTrustVerdict>;
 
@@ -126,27 +132,47 @@ export async function issueComments(
   issue: number,
   resolveTrust?: CommentTrustResolver,
 ): Promise<HandoffComment[]> {
-  const r = await runGithubRestRead(ctx, apiPath(ctx, `issues/${issue}/comments`), [
-    "--paginate", "--slurp", "--jq",
-    '{comments: (add | map({body: .body, author: {login: .user.login, is_bot: (.user.type == "Bot")}, authorAssociation: .author_association, createdAt: .created_at}))}',
-  ]);
-  if (r.code !== 0) return [];
-  let parsed: {
-    comments?: Array<{
-      body?: string;
-      author?: { login?: string; is_bot?: boolean };
-      authorAssociation?: string;
-      createdAt?: string;
-      reactionGroups?: RawGhComment["reactionGroups"];
-    }>;
-  };
+  // Paginated through the shared client rather than `gh api --paginate --slurp
+  // --jq`: the binary REFUSES `--slurp` beside `--jq`, and this caller read the
+  // resulting non-zero exit as "no comments". Directive blocks are how human
+  // guidance reaches a Worker, so the silent empty list did not degrade the
+  // read — it erased the instruction (#3734).
+  const repo = githubRepo(ctx);
+  if (!repo) return [];
+  let rows: readonly RestIssueComment[];
   try {
-    parsed = JSON.parse(r.stdout);
-  } catch {
+    const answer = await githubReadClient(ctx).conditionalPaginate<RestIssueComment>({
+      cacheKey: `gh:comments:${repo.owner}/${repo.repo}:${issue}`,
+      route: "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+      parameters: { ...repo, issue_number: issue, per_page: 100 },
+      operation: { key: "issue comments", budget: "rest" },
+      actor: "dev:comments",
+    });
+    rows = answer.data;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `🤖 /afk comment read failed for #${issue}; treating as empty: ${detail}\n`,
+    );
     return [];
   }
-  if (!Array.isArray(parsed.comments)) return [];
-  return projectComments(parsed.comments, resolveTrust);
+  return projectComments(
+    rows.map((row) => ({
+      body: String(row.body ?? ""),
+      author: { login: String(row.user?.login ?? ""), is_bot: row.user?.type === "Bot" },
+      authorAssociation: String(row.author_association ?? ""),
+      createdAt: String(row.created_at ?? ""),
+    })),
+    resolveTrust,
+  );
+}
+
+/** The REST shape of one issue comment, projected to what the handoff renders. */
+interface RestIssueComment {
+  readonly body?: string | null;
+  readonly user?: { readonly login?: string; readonly type?: string } | null;
+  readonly author_association?: string;
+  readonly created_at?: string;
 }
 
 function restCommentJq(): string {

--- a/apps/dev/src/runtime/gh/common.ts
+++ b/apps/dev/src/runtime/gh/common.ts
@@ -150,6 +150,22 @@ function injectedReadClient(ctx: GhContext): Pick<GithubClient, "conditionalRest
         const data = Array.isArray(parsed) ? (parsed as T[]) : [];
         return { data, headers: {}, quotaFree: false, requestCount: 1 };
       }
+      if (input.route === "GET /repos/{owner}/{repo}/pulls") {
+        // The routed open-PR read: the same plain `gh api --paginate` shape as
+        // the issues collection, returning full REST pull rows so the caller
+        // projects `head.ref` itself.
+        const owner = String(input.parameters?.owner ?? "");
+        const repo = String(input.parameters?.repo ?? "");
+        const query: string[] = [];
+        if (input.parameters?.state !== undefined) query.push("-f", `state=${String(input.parameters.state)}`);
+        query.push("-f", `per_page=${String(input.parameters?.per_page ?? 100)}`);
+        const args = ["api", "--paginate", `repos/${owner}/${repo}/pulls`, ...query];
+        const out = await ctx.exec!("gh", args, { cwd: ctx.cwd });
+        if (out.code !== 0) throw new Error(out.stderr || out.stdout);
+        const parsed = JSON.parse(out.stdout || "[]") as unknown;
+        const data = Array.isArray(parsed) ? (parsed as T[]) : [];
+        return { data, headers: {}, quotaFree: false, requestCount: 1 };
+      }
       const issue = String(input.parameters?.issue_number ?? "");
       const args = ["api", "--paginate", apiPath(ctx, `issues/${issue}/sub_issues`), "--jq", ".[] | {number}"];
       const out = await ctx.exec!("gh", args, { cwd: ctx.cwd });

--- a/apps/dev/src/runtime/gh/sweeps.ts
+++ b/apps/dev/src/runtime/gh/sweeps.ts
@@ -8,8 +8,73 @@ import {
 } from "../../core/triage-labels.js";
 import type { IssueOpenState } from "../../core/reclaim.js";
 import type { ReconcileSweepCandidate, UnblockCandidate } from "../../core/boot-sweep.js";
-import { apiPath, runGithubRestRead, type GhContext } from "./common.js";
+import { githubReadClient, githubRepo, type GhContext } from "./common.js";
 import { readSingleObject } from "./single-object.js";
+
+/**
+ * One issue-collection read, paginated by the shared client.
+ *
+ * These listings used to be `gh api` invocations carrying `--paginate --slurp
+ * … --jq …`, a flag combination the `gh` binary REFUSES (`the --slurp option is
+ * not supported with --jq or --template`). The planner that shaped that argv
+ * could not have caught it: it validates the REQUEST — no mutation, an explicit
+ * `--method GET` so `-f` params stay in the query string — while the
+ * incompatibility lives in the CLI. The caller then read the non-zero exit as an
+ * empty collection, so the Unblock Sweep, the close cascade's dependent lookup
+ * and the parked-mechanical sweep all reported "nothing to do" while the
+ * tracker was full (#3734 introduced it; the sweep answered `promoted: []`
+ * against two promotable issues).
+ *
+ * Paginating through the typed client removes the whole category: there is no
+ * argv to get wrong, `per_page` and page walking are the client's concern, and
+ * the read inherits conditional caching, spend attribution and the retry policy
+ * the CLI path forfeited.
+ */
+interface GithubIssueListItem {
+  readonly number?: number;
+  readonly title?: string;
+  readonly body?: string | null;
+  readonly labels?: ReadonlyArray<string | { readonly name?: string }>;
+  readonly pull_request?: unknown;
+}
+
+/** Label names as plain strings, whichever shape the REST payload used. */
+function labelNames(labels: GithubIssueListItem["labels"]): string[] {
+  if (!Array.isArray(labels)) return [];
+  return labels.map((label) => (typeof label === "string" ? label : String(label.name ?? "")));
+}
+
+/**
+ * Name a failed sweep read on stderr before answering with the conservative
+ * empty collection.
+ *
+ * The empty answer itself is deliberate — a sweep that cannot see the tracker
+ * must not promote, reconcile or excuse anything. What was NOT deliberate is
+ * doing it in silence: an unreachable read and a genuinely quiet repository
+ * produced byte-identical output, which is how a broken listing survived a day
+ * of sweeps reporting success.
+ */
+function reportSweepReadFailure(surface: string, error: unknown): void {
+  const detail = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`🤖 /afk sweep read failed (${surface}); treating as empty: ${detail}\n`);
+}
+
+async function listIssuesViaClient(
+  ctx: GhContext,
+  cacheKey: string,
+  parameters: Readonly<Record<string, unknown>>,
+): Promise<readonly GithubIssueListItem[]> {
+  const repo = githubRepo(ctx);
+  if (!repo) throw new Error("GitHub sweep listing needs an owner/repository slug");
+  const answer = await githubReadClient(ctx).conditionalPaginate<GithubIssueListItem>({
+    cacheKey: `gh:sweeps:${repo.owner}/${repo.repo}:${cacheKey}`,
+    route: "GET /repos/{owner}/{repo}/issues",
+    parameters: { ...repo, per_page: 100, state: "open", ...parameters },
+    operation: { key: "issue list", budget: "rest" },
+    actor: "dev:sweeps",
+  });
+  return answer.data.filter((issue) => issue.pull_request == null);
+}
 
 export async function orphanState(
   ctx: GhContext,
@@ -72,24 +137,17 @@ export async function blockerState(ctx: GhContext, issue: number): Promise<strin
 }
 
 export async function listUnblockCandidates(ctx: GhContext): Promise<UnblockCandidate[]> {
-  const r = await runGithubRestRead(ctx, apiPath(ctx, "issues"), [
-    "--paginate", "--slurp", "-f", "state=open", "-f", `labels=${LABEL_DEPENDENCY}`,
-    "-f", "per_page=100", "--jq", "add | map(select(.pull_request == null) | {number, body, labels})",
-  ]);
-  if (r.code !== 0) return [];
   try {
-    const rows = JSON.parse(r.stdout) as Array<{
-      number?: number;
-      body?: string;
-      labels?: Array<{ name?: string }>;
-    }>;
-    if (!Array.isArray(rows)) return [];
+    const rows = await listIssuesViaClient(ctx, `unblock:${LABEL_DEPENDENCY}`, {
+      labels: LABEL_DEPENDENCY,
+    });
     return rows.map((row): UnblockCandidate => ({
       number: Number(row.number ?? 0),
       body: String(row.body ?? ""),
-      labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")) : [],
+      labels: labelNames(row.labels),
     }));
-  } catch {
+  } catch (error) {
+    reportSweepReadFailure("unblock candidates", error);
     return [];
   }
 }
@@ -100,19 +158,14 @@ export async function listByLabel(
   ctx: GhContext,
   label: string,
 ): Promise<{ number: number; labels: string[] }[]> {
-  const r = await runGithubRestRead(ctx, apiPath(ctx, "issues"), [
-    "--paginate", "--slurp", "-f", "state=open", "-f", `labels=${label}`,
-    "-f", "per_page=100", "--jq", "add | map(select(.pull_request == null) | {number, labels})",
-  ]);
-  if (r.code !== 0) return [];
   try {
-    const rows = JSON.parse(r.stdout) as Array<{ number?: number; labels?: Array<{ name?: string }> }>;
-    if (!Array.isArray(rows)) return [];
+    const rows = await listIssuesViaClient(ctx, `by-label:${label}`, { labels: label });
     return rows.map((row) => ({
       number: Number(row.number ?? 0),
-      labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")) : [],
+      labels: labelNames(row.labels),
     }));
-  } catch {
+  } catch (error) {
+    reportSweepReadFailure(`issues labelled ${label}`, error);
     return [];
   }
 }
@@ -152,26 +205,16 @@ export async function listParkedMechanicalCandidates(
 
 /** List open issues carrying `label` with number, title, body, and labels. */
 async function listIssuesByLabel(ctx: GhContext, label: string): Promise<ReconcileSweepCandidate[]> {
-  const r = await runGithubRestRead(ctx, apiPath(ctx, "issues"), [
-    "--paginate", "--slurp", "-f", "state=open", "-f", `labels=${label}`,
-    "-f", "per_page=100", "--jq", "add | map(select(.pull_request == null) | {number, title, body, labels})",
-  ]);
-  if (r.code !== 0) return [];
   try {
-    const rows = JSON.parse(r.stdout) as Array<{
-      number?: number;
-      title?: string;
-      body?: string;
-      labels?: Array<{ name?: string }>;
-    }>;
-    if (!Array.isArray(rows)) return [];
+    const rows = await listIssuesViaClient(ctx, `mechanical:${label}`, { labels: label });
     return rows.map((row): ReconcileSweepCandidate => ({
       number: Number(row.number ?? 0),
       title: String(row.title ?? ""),
       body: String(row.body ?? ""),
-      labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")) : [],
+      labels: labelNames(row.labels),
     }));
-  } catch {
+  } catch (error) {
+    reportSweepReadFailure(`parked candidates labelled ${label}`, error);
     return [];
   }
 }
@@ -188,23 +231,29 @@ async function listIssuesByLabel(ctx: GhContext, label: string): Promise<Reconci
 export async function listOpenPullRequests(
   ctx: GhContext,
 ): Promise<Array<{ number: number; headRefName: string; body?: string }>> {
-  const r = await runGithubRestRead(ctx, apiPath(ctx, "pulls"), [
-    "--paginate", "--slurp", "-f", "state=open", "-f", "per_page=100",
-    "--jq", "add | map({number, headRefName: .head.ref, body})",
-  ]);
-  if (r.code !== 0) return [];
+  const repo = githubRepo(ctx);
+  if (!repo) return [];
   try {
-    const rows = JSON.parse(r.stdout || "[]") as unknown;
-    if (!Array.isArray(rows)) return [];
-    return rows
-      .map((row) => row as { number?: unknown; headRefName?: unknown; body?: unknown })
+    const answer = await githubReadClient(ctx).conditionalPaginate<{
+      number?: number;
+      head?: { ref?: string };
+      body?: string | null;
+    }>({
+      cacheKey: `gh:sweeps:${repo.owner}/${repo.repo}:open-pulls`,
+      route: "GET /repos/{owner}/{repo}/pulls",
+      parameters: { ...repo, per_page: 100, state: "open" },
+      operation: { key: "pr list", budget: "rest" },
+      actor: "dev:sweeps",
+    });
+    return answer.data
       .map((row) => ({
         number: Number(row.number ?? 0),
-        headRefName: String(row.headRefName ?? ""),
+        headRefName: String(row.head?.ref ?? ""),
         ...(typeof row.body === "string" ? { body: row.body } : {}),
       }))
       .filter((row) => row.number > 0 && row.headRefName.length > 0);
-  } catch {
+  } catch (error) {
+    reportSweepReadFailure("open pull requests", error);
     return [];
   }
 }

--- a/apps/dev/tests/companion-io.test.ts
+++ b/apps/dev/tests/companion-io.test.ts
@@ -50,14 +50,20 @@ function ghRouter(opts: { body?: string; comments?: string[]; labels?: string[] 
     const a = [...argv];
     // Single-object + comment-list reads route through REST (`gh api repos/...`,
     // #3730) rather than `gh issue view`; match on the REST path shape instead.
-    if (a[0] === "api" && typeof a[1] === "string" && a[1].endsWith("/comments")) {
+    // The comment list paginates through the shared client, so the path is no
+    // longer argv[1] (`--paginate` precedes it) and the payload is a RAW REST
+    // array. The old fixture answered the hand-rolled `{comments: […]}` jq
+    // projection, a shape the `gh` binary could never have produced here — the
+    // argv that asked for it was refused outright (#3734).
+    if (a[0] === "api" && a.some((arg) => typeof arg === "string" && arg.endsWith("/comments"))
+      && !a.includes("-X")) {
       const comments = (opts.comments ?? []).map((b) => ({
         body: b,
-        author: { login: "someone", is_bot: false },
-        authorAssociation: "NONE",
-        createdAt: undefined,
+        user: { login: "someone", type: "User" },
+        author_association: "NONE",
+        created_at: "2026-08-13T00:00:00Z",
       }));
-      return Promise.resolve(ok(JSON.stringify({ comments })));
+      return Promise.resolve(ok(JSON.stringify(comments)));
     }
     if (a[0] === "api" && typeof a[1] === "string" && /\/issues\/\d+$/.test(a[1])) {
       const labels = (opts.labels ?? []).map((name) => ({ name }));

--- a/apps/dev/tests/gh-issue-comments-trust.test.ts
+++ b/apps/dev/tests/gh-issue-comments-trust.test.ts
@@ -19,15 +19,24 @@ function ghReturning(stdout: string, code = 0): GhContext {
   return { cwd: "/r", repo: "acme/widgets", exec };
 }
 
-const COMMENTS = JSON.stringify({
-  comments: [
-    { body: "bot chatter", author: { login: "dependabot", is_bot: true }, authorAssociation: "NONE" },
-    { body: "owner order", author: { login: "maint", is_bot: false }, authorAssociation: "OWNER" },
-    { body: "collab order", author: { login: "friend", is_bot: false }, authorAssociation: "COLLABORATOR" },
-    { body: "stranger order", author: { login: "stranger", is_bot: false }, authorAssociation: "NONE" },
-    { body: "allowlisted order", author: { login: "trusted-ext", is_bot: false }, authorAssociation: "CONTRIBUTOR" },
-  ],
+/** One raw REST comment row, the shape the paginated read actually returns. */
+const restComment = (body: string, login: string, association: string, bot = false) => ({
+  body,
+  user: { login, type: bot ? "Bot" : "User" },
+  author_association: association,
+  created_at: "2026-08-13T00:00:00Z",
 });
+
+// The fixture used to answer `{comments: […]}` — the projection a hand-rolled
+// jq pipeline was meant to produce. That argv was refused by `gh`, so the shape
+// never existed outside this file (#3734).
+const COMMENTS = JSON.stringify([
+  restComment("bot chatter", "dependabot", "NONE", true),
+  restComment("owner order", "maint", "OWNER"),
+  restComment("collab order", "friend", "COLLABORATOR"),
+  restComment("stranger order", "stranger", "NONE"),
+  restComment("allowlisted order", "trusted-ext", "CONTRIBUTOR"),
+]);
 
 describe("issueComments — source-trust projection (#1100)", () => {
   it("classifies bots as automation and trusted associations as trusted without a lookup", async () => {
@@ -56,25 +65,19 @@ describe("issueComments — source-trust projection (#1100)", () => {
     expect(out[4]).toMatchObject({ author: "trusted-ext", sourceTrust: "trusted" });
   });
 
-  it("promotes only the outside comment with a maintainer thumbs-up reaction", async () => {
-    const comments = JSON.stringify({
-      comments: [
-        {
-          body: "useful outside suggestion",
-          author: { login: "stranger", is_bot: false },
-          authorAssociation: "NONE",
-          reactionGroups: [
-            { content: "THUMBS_UP", users: { nodes: [{ login: "maintainer" }] } },
-          ],
-        },
-        {
-          body: "second outside suggestion",
-          author: { login: "stranger", is_bot: false },
-          authorAssociation: "NONE",
-          reactionGroups: [],
-        },
-      ],
-    });
+  it("cannot promote an outside comment on a reaction this read does not carry", async () => {
+    // `projectComments` reads `reactionGroups` to promote a stranger whose
+    // suggestion a maintainer thumbed up. NOTHING supplies that field: neither
+    // the refused jq pipeline this read used to build, nor `restCommentJq`, and
+    // the REST comment list carries reaction COUNTS rather than the reacting
+    // logins. The promotion therefore never fired in production — this fixture
+    // used to hand the field in directly and so pinned a behaviour the shipped
+    // command could not reach. The gap is stated here rather than simulated,
+    // and closing it needs its own read (`…/comments/{id}/reactions`).
+    const comments = JSON.stringify([
+      restComment("useful outside suggestion", "stranger", "NONE"),
+      restComment("second outside suggestion", "stranger", "NONE"),
+    ]);
     const resolveTrust = async (actor: string): Promise<ActorTrustVerdict> =>
       actor === "maintainer"
         ? { executable: true, basis: "write-access" }
@@ -82,7 +85,7 @@ describe("issueComments — source-trust projection (#1100)", () => {
 
     const out = await issueComments(ghReturning(comments), 7, resolveTrust);
 
-    expect(out[0]).toMatchObject({ author: "stranger", sourceTrust: "trusted" });
+    expect(out[0]).toMatchObject({ author: "stranger", sourceTrust: "dubious" });
     expect(out[1]).toMatchObject({ author: "stranger", sourceTrust: "dubious" });
   });
 

--- a/apps/dev/tests/process-deps-ports.test.ts
+++ b/apps/dev/tests/process-deps-ports.test.ts
@@ -229,10 +229,13 @@ describe("buildLookups", () => {
 
   it("censuses open PRs through the gh slug and drops malformed rows", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-ports-lookups-prs-"));
+    // Raw REST pull rows: the head ref arrives as `head.ref` and the caller
+    // projects it. The flattened `headRefName` this fixture used to answer came
+    // from a jq pipeline `gh` refused to run (#3734).
     const rows = JSON.stringify([
-      { number: 12, headRefName: "afk/2667", body: "Refs #2667" },
-      { number: 0, headRefName: "afk/broken" },
-      { number: 13, headRefName: "" },
+      { number: 12, head: { ref: "afk/2667" }, body: "Refs #2667" },
+      { number: 0, head: { ref: "afk/broken" } },
+      { number: 13, head: { ref: "" } },
     ]);
     const { exec, trace } = makeFakeExec((cmd) => (cmd === "gh" ? rows : ""));
 

--- a/apps/dev/tests/sweep-reads-see-the-tracker.test.ts
+++ b/apps/dev/tests/sweep-reads-see-the-tracker.test.ts
@@ -1,0 +1,185 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  listByLabel,
+  listOpenPullRequests,
+  listParkedMechanicalCandidates,
+  listUnblockCandidates,
+} from "../src/runtime/gh/sweeps.js";
+import { issueComments } from "../src/runtime/gh/comments.js";
+import type { GhContext } from "../src/runtime/gh/common.js";
+
+/**
+ * A sweep that cannot see the tracker must SAY SO.
+ *
+ * The regression these tests pin cost a working day of silence: the routed-read
+ * refactor gave every sweep listing an argv carrying `--paginate --slurp … --jq
+ * …`, a combination the `gh` binary refuses outright. Each caller read the
+ * non-zero exit as an empty collection, so the Unblock Sweep, the close
+ * cascade's dependent lookup, the parked-mechanical sweep and the handoff
+ * comment read all reported "nothing found" against a full tracker — and the
+ * Unblock Sweep answered `promoted: []` while two issues sat promotable.
+ *
+ * Two properties keep that from coming back. The rows a working read returns
+ * must REACH the caller, and a failing read must be reported rather than
+ * disguised as a quiet repository.
+ */
+
+function contextWith(
+  paginate: (input: { route: string; parameters?: Readonly<Record<string, unknown>> }) => unknown,
+): GhContext {
+  return {
+    repo: "reddb-io/red-skills",
+    cwd: "/nowhere",
+    github: {
+      conditionalPaginate: async (request: {
+        route: string;
+        parameters?: Readonly<Record<string, unknown>>;
+      }) => {
+        const data = paginate(request);
+        if (data instanceof Error) throw data;
+        return { data, headers: {}, quotaFree: false, requestCount: 1 } as never;
+      },
+      conditionalRest: async () => {
+        throw new Error("these sweeps paginate; a single read is the wrong route");
+      },
+    },
+  } as unknown as GhContext;
+}
+
+describe("a sweep read reaches the tracker", () => {
+  it("hands the unblock planner the candidates the tracker actually holds", async () => {
+    const ctx = contextWith(() => [
+      { number: 3629, body: "", labels: [{ name: "blocked:dependency" }, { name: "req:3628" }] },
+      { number: 3507, body: "", labels: [{ name: "blocked:dependency" }, { name: "req:3503" }] },
+      // A pull request shares the issues collection and must not be swept.
+      { number: 3795, body: "", labels: [], pull_request: { url: "…" } },
+    ]);
+
+    const candidates = await listUnblockCandidates(ctx);
+
+    expect(candidates.map((c) => c.number)).toEqual([3629, 3507]);
+    expect(candidates[0]?.labels).toContain("req:3628");
+  });
+
+  it("asks for the dependency label, not for every open issue", async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const ctx = contextWith((request) => {
+      seen.push({ ...request.parameters });
+      return [];
+    });
+
+    await listUnblockCandidates(ctx);
+
+    expect(seen[0]?.labels).toBe("blocked:dependency");
+    expect(seen[0]?.state).toBe("open");
+  });
+
+  it("carries the close cascade's dependent lookup", async () => {
+    const ctx = contextWith(() => [{ number: 3630, labels: [{ name: "req:3629" }] }]);
+    expect(await listByLabel(ctx, "req:3629")).toEqual([{ number: 3630, labels: ["req:3629"] }]);
+  });
+
+  it("carries the parked mechanical candidates, de-duplicated across labels", async () => {
+    const ctx = contextWith(() => [{ number: 42, title: "t", body: "b", labels: [] }]);
+    const parked = await listParkedMechanicalCandidates(ctx);
+    expect(parked.map((c) => c.number)).toEqual([42]);
+  });
+
+  it("projects an open pull request from its REST head ref", async () => {
+    const ctx = contextWith(() => [{ number: 7, head: { ref: "afk/7-thing" }, body: "Closes #6" }]);
+    expect(await listOpenPullRequests(ctx)).toEqual([
+      { number: 7, headRefName: "afk/7-thing", body: "Closes #6" },
+    ]);
+  });
+
+  it("delivers the Directive comments that carry human guidance", async () => {
+    const ctx = contextWith(() => [
+      {
+        body: "<details data-kind=\"directive\">…</details>",
+        user: { login: "filipeforattini", type: "User" },
+        author_association: "OWNER",
+        created_at: "2026-08-13T00:00:00Z",
+      },
+    ]);
+
+    const comments = await issueComments(ctx, 3773);
+
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("data-kind=\"directive\"");
+    expect(comments[0]?.author).toBe("filipeforattini");
+  });
+});
+
+describe("a failed sweep read is named, never disguised as an empty tracker", () => {
+  const cases: Array<[string, (ctx: GhContext) => Promise<unknown>]> = [
+    ["unblock candidates", (ctx) => listUnblockCandidates(ctx)],
+    ["dependent lookup", (ctx) => listByLabel(ctx, "req:1")],
+    ["parked candidates", (ctx) => listParkedMechanicalCandidates(ctx)],
+    ["open pull requests", (ctx) => listOpenPullRequests(ctx)],
+    ["issue comments", (ctx) => issueComments(ctx, 1)],
+  ];
+
+  for (const [name, read] of cases) {
+    it(`reports the failure behind ${name} while still answering conservatively`, async () => {
+      const written: string[] = [];
+      const stderr = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+        written.push(String(chunk));
+        return true;
+      });
+      const ctx = contextWith(() => new Error("HttpError: 503 Service Unavailable"));
+
+      try {
+        // The empty answer is deliberate: a sweep blind to the tracker promotes
+        // nothing. Only the SILENCE was the defect.
+        expect(await read(ctx)).toEqual([]);
+        expect(written.join("")).toContain("503 Service Unavailable");
+      } finally {
+        stderr.mockRestore();
+      }
+    });
+  }
+});
+
+describe("no GitHub read argv pairs --slurp with --jq", () => {
+  // The planner shapes the REQUEST and cannot know which flag combinations the
+  // installed `gh` rejects, so the incompatibility is pinned here instead. `gh`
+  // answers `the --slurp option is not supported with --jq or --template` and
+  // exits non-zero; every caller reads that as an empty collection.
+  const ROOTS = ["apps", "packages"];
+  const REPO = join(import.meta.dirname, "..", "..", "..");
+
+  function sourceFiles(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+      if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
+      const path = join(dir, entry);
+      if (statSync(path).isDirectory()) sourceFiles(path, out);
+      else if (entry.endsWith(".ts") || entry.endsWith(".mts")) out.push(path);
+    }
+    return out;
+  }
+
+  it("finds no source that builds the refused combination", () => {
+    const offenders: string[] = [];
+    for (const root of ROOTS) {
+      for (const file of sourceFiles(join(REPO, root))) {
+        const source = readFileSync(file, "utf8");
+        for (const [index, line] of source.split("\n").entries()) {
+          // A rejection list naming the flags is the opposite of building one.
+          if (!line.includes('"--slurp"')) continue;
+          if (/\.includes\(|\bincludes\b\s*\(/.test(line)) continue;
+          const window = source.split("\n").slice(index, index + 6).join("\n");
+          if (window.includes('"--jq"')) {
+            offenders.push(`${file.slice(REPO.length + 1)}:${index + 1}`);
+          }
+        }
+      }
+    }
+    expect(
+      offenders,
+      `gh refuses --slurp beside --jq; these argv builders would exit non-zero and read as empty:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/apps/dev/tests/wiring-integration.test.ts
+++ b/apps/dev/tests/wiring-integration.test.ts
@@ -379,14 +379,11 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
       // editLabels reads the current set, then PATCHes the FULL set (#3728).
       { cmd: "gh", args: ["api", "repos/acme/widgets/issues/42"], cwd: root },
       { cmd: "gh", args: ["api", "-X", "PATCH", "repos/acme/widgets/issues/42", "-F", "labels[]=running"], cwd: root },
-      {
-        cmd: "gh",
-        args: [
-          "api", "repos/acme/widgets/issues/42/comments", "--paginate", "--slurp", "--jq",
-          '{comments: (add | map({body: .body, author: {login: .user.login, is_bot: (.user.type == "Bot")}, authorAssociation: .author_association, createdAt: .created_at}))}',
-        ],
-        cwd: root,
-      },
+      // The handoff comment read paginates through the shared client. It used to
+      // build `--paginate --slurp … --jq …`, which the `gh` binary REFUSES; the
+      // fake exec here recorded that argv without ever running it, so this
+      // assertion pinned a command production could not execute (#3734).
+      { cmd: "gh", args: ["api", "--paginate", "repos/acme/widgets/issues/42/comments"], cwd: root },
       { cmd: "gh", args: ["api", "repos/acme/widgets/issues/42"], cwd: root },
       { cmd: "git", args: ["-C", root, "push", "origin", `${branch}:refs/heads/${branch}`], cwd: root },
       { cmd: "git", args: ["-C", root, "merge", "--ff-only", "origin/main"], cwd: root },
@@ -401,9 +398,8 @@ describe("wiring integration — real buildProcessDeps over a fake exec", () => 
       {
         cmd: "gh",
         args: [
-          "api", "repos/acme/widgets/issues", "--method", "GET", "--paginate", "--slurp",
+          "api", "--paginate", "repos/acme/widgets/issues",
           "-f", "state=open", "-f", "labels=req:42", "-f", "per_page=100",
-          "--jq", "add | map(select(.pull_request == null) | {number, labels})",
         ],
         cwd: root,
       },


### PR DESCRIPTION
## What was broken

Every sweep listing built `gh api --paginate --slurp … --jq …`. The `gh` binary refuses that combination outright:

```
the `--slurp` option is not supported with `--jq` or `--template`
```

Each caller read the non-zero exit as an empty collection (`if (r.code !== 0) return []`), so five reads reported "nothing found" against a full tracker:

| function | what went dark |
| --- | --- |
| `listUnblockCandidates` | the Unblock Sweep promoted nothing, ever |
| `listByLabel` | the close cascade could not find its dependents |
| `listIssuesByLabel` | the parked-mechanical sweep saw no parks |
| `listOpenPullRequests` | the branch census excused nothing |
| `issueComments` | Directive blocks stopped reaching Workers |

**Both dependency-clearing paths were down at the same time.** That is why `ready-for-agent` kept falling to near zero against a full backlog: the periodic sweep could not see the blocked issues, and the close cascade could not see their dependents. Observed live before the fix — `unblock_sweep` answered `promoted: []` while #3629 (`req:3628`, closed) and #3507 (`req:3503`, closed) were both promotable.

The comment read is the quiet one. `issueComments` backs the handoff projection that carries human guidance, so an empty list did not degrade the read — it erased the instruction.

## Why the planner could not catch it

`runGithubRestRead` does route through `@reddb-io/github`, but only as a **planner**: it validates the request, refuses mutations, and inserts the explicit `--method GET` that keeps `-f` params in the query string instead of a POST body. That part is correct and load-bearing. The incompatibility lives in the CLI, not in the plan — no request-shaped validator can know which flag pairs the installed binary rejects.

So this does not drop a flag. The listings now paginate through the shared client, the tier `trust.ts` / `queue.ts` / `candidates.ts` already reached, which removes the category instead of the instance: no argv to get wrong, page walking belongs to the client, and the reads regain conditional caching, spend attribution and the retry policy the shell-out path forfeited.

## Failure is now loud

A failing read still answers with the conservative empty collection — a sweep blind to the tracker must promote, reconcile and excuse nothing — but names the failure on stderr first. **The silence was the defect, not the caution.**

## Why it survived a day

Two things hid it, and both are addressed:

1. `if (r.code !== 0) return []` made an unreachable read and a quiet repository byte-identical.
2. `wiring-integration.test.ts` **asserted the exact broken argv**. Its exec boundary is a fake that records arguments without running them, so a command the real binary rejects looked identical to one it accepts. The test pinned the defect in place. That assertion is corrected here, and a new guard fails on any source pairing `--slurp` with `--jq`.

## Verification

- `tests/sweep-reads-see-the-tracker.test.ts` — 12 tests: rows from a working read reach each caller, a throwing read is reported *and* answers empty, and the argv guard sweeps `apps/` + `packages/`.
- The guard fails without the fix; it is what caught the two stale assertions in `wiring-integration.test.ts`.
- Full typecheck 16/16, repo invariants 202/202.
- **Live against this repository:** `listUnblockCandidates` returns the 6 blocked issues (#3640, #3636, #3632, #3630, #3629, #3507) where the shipped code returns 0.

Introduced by #3734.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789181091&installation_model_id=20659&pr_number=3798&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3798&signature=35ff3d52311d6d36c51c1e5c2f5e857782c904441bd5fdbd1f2a0dc895f312b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->