### PR TITLE
docs(redskilled): the daemon upgrades itself, and a registration is declared

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -46,6 +46,22 @@ plugins:
       #     this file every time, so changing this line alone does not move a
       #     registration that is already standing.
       default_runner: codex
+      # Maintainer decision 2026-08-13: this repo keeps a STANDING registration.
+      #
+      # A registration is a producer's lease, so without this block the repo is
+      # registered only while some producer happens to be alive and reads
+      # `rsk=unregistered` the moment one dies. The MCP resident's registration
+      # delivery re-registers whenever nothing standing is held, so declaring it
+      # here is what makes the reconnect survive a daemon restart, a plugin
+      # reload and a reboot.
+      #
+      # This is opt-in by design and there is no product default: a standing
+      # drain means the host births Workers here on its own. `target` is how
+      # many it may hold at once, under the host's own worker ceiling — lower it
+      # to share the machine, remove the block to stop drainage entirely.
+      standing:
+        runner: codex
+        target: 2
       models:
         # Maintainer decision 2026-08-05: exactly TWO runner/model combinations
         # exist in this repo — claude is `claude-opus-5` at high and codex is

--- a/packaging/pi/dev/skills/engineering/redskilled/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/redskilled/SKILL.md
@@ -116,7 +116,9 @@ Treat `redskilled` as the per-machine process authority: it owns Worker birth, d
    is the ordinary case, not a fault: the daemon is host-scoped and the operator
    works in personal repositories, other organisations and forks.
 
-4. **Restart and adopt** — stop the daemon through its reporting verb:
+4. **Restart and adopt — only once a verb is actually needed** (read *The daemon
+   upgrades itself* below before this step; a daemon that merely trails the
+   registry needs nothing from you). Stop the daemon through its reporting verb:
 
    ```bash
    npx -y -p @reddb-io/red-skills@<version> red-skills-redskilled stop
@@ -142,6 +144,55 @@ Treat `redskilled` as the per-machine process authority: it owns Worker birth, d
    `ceiling.worker_source: home-config`. A `flag` or `environment` source means
    a higher-precedence declaration still overrides the home policy; remove or
    change that declaration, repeat the restart, and read back again.
+
+## The daemon upgrades itself — read the clock before reaching for a verb
+
+**A daemon one version behind a fresh publish is not a fault; it is a daemon
+that has not looked yet.** `redskilled` replaces itself. A busy daemon re-reads
+the registry every fifteen minutes (`DEFAULT_REDSKILLED_REPLACE_CHECK_MS`), a
+starting one looks once at boot, and an idle one asks once at the idle boundary
+before it leaves. A publish therefore reaches the machine on its own, and the
+operator's part is usually to wait one interval and read again.
+
+**A replacement is a restart, never an evacuation.** Workers are init-system
+units (ADR 0130 rule 5), so they outlive the daemon that asked for them and the
+successor re-attaches by unit name. Nothing is stopped, drained, or re-queued —
+a version change is not a reason to protect running work.
+
+**The version a daemon reports is the version it RUNS.** `host-state`'s
+`daemon_version` is the running process; the published answer is carried beside
+it and never folded in. A daemon that substituted the resolved version for the
+running one would report a healthy zero skew while every Worker boot-halts.
+
+**A major boundary is held on purpose, and the hold is SAID.** The resolver
+adopts only inside the running major, but it still reports the newest published
+version whatever its major, states that not adopting it is deliberate, and names
+the step that crosses it. A stated refusal is a decision; a silent one is a bug.
+
+### Do not stop a daemon that is merely behind
+
+**`stop` is for a WEDGED daemon, never a BEHIND one.** Read `request_health`
+first: a daemon answering its own socket in single-digit milliseconds needs no
+verb from you.
+
+- ✅ **Do** wait one replace interval after a publish, then re-read `host-state`.
+- ✅ **Do** run the `unit install` → `stop` → `provision` sequence when the
+  daemon is genuinely stuck: it accepted a stop and did not exit, or its socket
+  stopped answering within the ready window.
+- ✅ **Do** reach for `systemctl --user restart redskilled.service` when a stop
+  was accepted but the process is still alive holding a dead socket. The
+  successor adopts the surviving Workers and the standing registrations.
+- ❌ Do **not** reach for `stop` because `daemon_version` trails the registry
+  minutes after a publish. A HEALTHY daemon can accept the stop, fail to finish
+  its bounded drain, and leave a live process holding a socket that no longer
+  answers — turning a machine that would have healed itself into one that needs
+  a manual `systemctl` restart.
+- ❌ Do **not** read a pinned `ExecStart` as proof the upgrade is broken. The
+  replacement WRITES that pin so its successor sticks, so a pin naming the old
+  bundle on a daemon that has not looked yet is the state *before* the look, not
+  evidence the look will fail. A pin outlives its daemon only when the daemon
+  wedged before it could replace itself — which is a wedge to cure, not a pin to
+  fight.
 
 ## Debug a Worker by issue
 
@@ -231,6 +282,44 @@ Treat `redskilled` as the per-machine process authority: it owns Worker birth, d
 </what-to-do>
 
 <supporting-info>
+
+## `rsk=unregistered` is a producer state, not a connection state
+
+**The statusline's `rsk=` token reports the Statusline Lifecycle, never the
+daemon's health.** `unregistered` means the socket ANSWERED and nothing is
+registering this repository — the daemon is up and no producer holds a
+registration here. It is distinct from `connecting` (probe in flight),
+`registering` (handshake in flight), and `bedrock-only` (probe disabled or
+unreachable). A `live` read renders no token at all, so silence is the healthy
+state. The read path only probes and never spawns the daemon, so the token is a
+report, never a repair.
+
+**A registration is a producer's LEASE, not a property of the repository.** It
+appears when a producer starts and ends when that producer dies, so a repo whose
+supervisor exited reads `unregistered` correctly. A stale pid file under
+`.red/tmp/supervisors/default/` is the residue of that death, not its cause.
+
+**A registration that outlives its producer is DECLARED, never inferred.** The
+MCP resident maintains one — `maintainStandingDrain` re-registers whenever
+nothing standing is held, which is what makes the reconnect survive a daemon
+restart, a plugin reload and a reboot — but only for a repo that declares it:
+
+```yaml
+plugins:
+  dev:
+    afk:
+      standing:
+        runner: codex
+        target: 2
+```
+
+Both keys are required (`afk.standing.runner`, `afk.standing.target`), and the
+target must be a positive integer; anything else resolves to no standing drain
+and the resident has nothing to keep alive. **There is deliberately no product
+default.** A standing drain means the host births Workers in that repo on its
+own, so a machine-wide default would start draining every enabled checkout
+without anyone asking. Absent the block, the registering verb is `project_start`
+(`/afk fleet`), and its registration dies with the producer it belongs to.
 
 ## Scope Boundary
 

--- a/plugins/dev/skills/engineering/redskilled/SKILL.md
+++ b/plugins/dev/skills/engineering/redskilled/SKILL.md
@@ -116,7 +116,9 @@ Treat `redskilled` as the per-machine process authority: it owns Worker birth, d
    is the ordinary case, not a fault: the daemon is host-scoped and the operator
    works in personal repositories, other organisations and forks.
 
-4. **Restart and adopt** — stop the daemon through its reporting verb:
+4. **Restart and adopt — only once a verb is actually needed** (read *The daemon
+   upgrades itself* below before this step; a daemon that merely trails the
+   registry needs nothing from you). Stop the daemon through its reporting verb:
 
    ```bash
    npx -y -p @reddb-io/red-skills@<version> red-skills-redskilled stop
@@ -142,6 +144,55 @@ Treat `redskilled` as the per-machine process authority: it owns Worker birth, d
    `ceiling.worker_source: home-config`. A `flag` or `environment` source means
    a higher-precedence declaration still overrides the home policy; remove or
    change that declaration, repeat the restart, and read back again.
+
+## The daemon upgrades itself — read the clock before reaching for a verb
+
+**A daemon one version behind a fresh publish is not a fault; it is a daemon
+that has not looked yet.** `redskilled` replaces itself. A busy daemon re-reads
+the registry every fifteen minutes (`DEFAULT_REDSKILLED_REPLACE_CHECK_MS`), a
+starting one looks once at boot, and an idle one asks once at the idle boundary
+before it leaves. A publish therefore reaches the machine on its own, and the
+operator's part is usually to wait one interval and read again.
+
+**A replacement is a restart, never an evacuation.** Workers are init-system
+units (ADR 0130 rule 5), so they outlive the daemon that asked for them and the
+successor re-attaches by unit name. Nothing is stopped, drained, or re-queued —
+a version change is not a reason to protect running work.
+
+**The version a daemon reports is the version it RUNS.** `host-state`'s
+`daemon_version` is the running process; the published answer is carried beside
+it and never folded in. A daemon that substituted the resolved version for the
+running one would report a healthy zero skew while every Worker boot-halts.
+
+**A major boundary is held on purpose, and the hold is SAID.** The resolver
+adopts only inside the running major, but it still reports the newest published
+version whatever its major, states that not adopting it is deliberate, and names
+the step that crosses it. A stated refusal is a decision; a silent one is a bug.
+
+### Do not stop a daemon that is merely behind
+
+**`stop` is for a WEDGED daemon, never a BEHIND one.** Read `request_health`
+first: a daemon answering its own socket in single-digit milliseconds needs no
+verb from you.
+
+- ✅ **Do** wait one replace interval after a publish, then re-read `host-state`.
+- ✅ **Do** run the `unit install` → `stop` → `provision` sequence when the
+  daemon is genuinely stuck: it accepted a stop and did not exit, or its socket
+  stopped answering within the ready window.
+- ✅ **Do** reach for `systemctl --user restart redskilled.service` when a stop
+  was accepted but the process is still alive holding a dead socket. The
+  successor adopts the surviving Workers and the standing registrations.
+- ❌ Do **not** reach for `stop` because `daemon_version` trails the registry
+  minutes after a publish. A HEALTHY daemon can accept the stop, fail to finish
+  its bounded drain, and leave a live process holding a socket that no longer
+  answers — turning a machine that would have healed itself into one that needs
+  a manual `systemctl` restart.
+- ❌ Do **not** read a pinned `ExecStart` as proof the upgrade is broken. The
+  replacement WRITES that pin so its successor sticks, so a pin naming the old
+  bundle on a daemon that has not looked yet is the state *before* the look, not
+  evidence the look will fail. A pin outlives its daemon only when the daemon
+  wedged before it could replace itself — which is a wedge to cure, not a pin to
+  fight.
 
 ## Debug a Worker by issue
 
@@ -231,6 +282,44 @@ Treat `redskilled` as the per-machine process authority: it owns Worker birth, d
 </what-to-do>
 
 <supporting-info>
+
+## `rsk=unregistered` is a producer state, not a connection state
+
+**The statusline's `rsk=` token reports the Statusline Lifecycle, never the
+daemon's health.** `unregistered` means the socket ANSWERED and nothing is
+registering this repository — the daemon is up and no producer holds a
+registration here. It is distinct from `connecting` (probe in flight),
+`registering` (handshake in flight), and `bedrock-only` (probe disabled or
+unreachable). A `live` read renders no token at all, so silence is the healthy
+state. The read path only probes and never spawns the daemon, so the token is a
+report, never a repair.
+
+**A registration is a producer's LEASE, not a property of the repository.** It
+appears when a producer starts and ends when that producer dies, so a repo whose
+supervisor exited reads `unregistered` correctly. A stale pid file under
+`.red/tmp/supervisors/default/` is the residue of that death, not its cause.
+
+**A registration that outlives its producer is DECLARED, never inferred.** The
+MCP resident maintains one — `maintainStandingDrain` re-registers whenever
+nothing standing is held, which is what makes the reconnect survive a daemon
+restart, a plugin reload and a reboot — but only for a repo that declares it:
+
+```yaml
+plugins:
+  dev:
+    afk:
+      standing:
+        runner: codex
+        target: 2
+```
+
+Both keys are required (`afk.standing.runner`, `afk.standing.target`), and the
+target must be a positive integer; anything else resolves to no standing drain
+and the resident has nothing to keep alive. **There is deliberately no product
+default.** A standing drain means the host births Workers in that repo on its
+own, so a machine-wide default would start draining every enabled checkout
+without anyone asking. Absent the block, the registering verb is `project_start`
+(`/afk fleet`), and its registration dies with the producer it belongs to.
 
 ## Scope Boundary
 


### PR DESCRIPTION
Two operator dead ends cost a session today. Neither was written down, and both were reasoned about wrongly as a result.

## A daemon behind a fresh publish is not a fault

`redskilled` replaces itself: a busy daemon re-reads the registry every fifteen minutes (`DEFAULT_REDSKILLED_REPLACE_CHECK_MS`), a starting one looks at boot, an idle one asks once at the idle boundary before it leaves.

Reading `daemon_version` one minute after a publish and reaching for `stop` skips that mechanism — and the cost is not zero. A **healthy** daemon (`request_health` green, answering its own socket in 1 ms) accepted the stop, failed to finish its bounded drain, and left a live process holding a socket that no longer answered. A machine that would have healed itself within one interval instead needed a manual `systemctl --user restart`.

The skill now states the intervals, separates a **wedged** daemon from a **behind** one, and refuses the pinned `ExecStart` as evidence of a broken upgrade — the replacement *writes* that pin so its successor sticks. A pin outlives its daemon only when the daemon wedged before it could replace itself, which is a wedge to cure rather than a pin to fight.

## `rsk=unregistered` is a producer state, not a connection state

The token reports the Statusline Lifecycle (#3567): the socket **answered** and nothing is registering this repository. It reads like a broken connection and is not one. `live` renders no token, so silence is health; the read path only probes and never spawns the daemon.

A registration is a producer's **lease** — it ends when that producer dies, and a stale pid file under `.red/tmp/supervisors/default/` is the residue rather than the cause.

## A registration that outlives its producer is declared

The MCP resident already maintains one: `maintainStandingDrain` re-registers whenever nothing standing is held, which is exactly what survives a daemon restart, a plugin reload and a reboot. But it only acts on a repo that declares both `afk.standing.runner` and `afk.standing.target` — and neither key has a product default.

That absence is deliberate and the skill now says so: a standing drain births Workers on its own, so a machine-wide default would start draining every enabled checkout without anyone asking.

This repo now declares one (`codex`, target 2), which is precisely what its own `rsk=unregistered` was reporting the absence of.

## Scope

Documentation plus one repo config declaration. No `apps/` or `packages/` change, so the release-entry gate does not apply (`release entry not required — no apps/ or packages/ paths changed`). The `packaging/pi/` mirror is regenerated, not hand-edited.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789192842&installation_model_id=20659&pr_number=3805&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3805&signature=f4143d1622066d83af7d92de3578c60f6bb8599f57e9c5d8efc975560924a317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->