### PR TITLE
fix: observe GitHub App balance by identity

### DIFF
--- a/.changeset/identity-aware-github-balances.md
+++ b/.changeset/identity-aware-github-balances.md
@@ -1,0 +1,7 @@
+---
+"@reddb-io/dev": patch
+"@reddb-io/github": patch
+"@reddb-io/redskilled": patch
+---
+
+Observe optional GitHub App rate limits beside the personal token, label both balance-history series by payer, and attribute App-paid reads to the App in the spend ledger.

--- a/apps/dev/src/runtime/gh/common.ts
+++ b/apps/dev/src/runtime/gh/common.ts
@@ -8,6 +8,7 @@ import {
   createGithubClient,
   createGithubInstallationLookup,
   githubCoveragePath,
+  githubIdentityRef,
   openGithubCoverageCache,
   planGithubRestRead,
   resolveGithubAppCredential,
@@ -219,6 +220,7 @@ export function githubReadClient(
     ...(app === null ? {} : { app }),
     attribution: createGithubAttributionLedger({
       path: join(stateDir(ctx.cwd), "github", "spend.toonl"),
+      ...(app === null ? {} : { identity: githubIdentityRef({ kind: "app", app }) }),
     }),
   });
   routedClients.set(ctx, client);

--- a/apps/dev/tests/github-app-is-a-payer.test.ts
+++ b/apps/dev/tests/github-app-is-a-payer.test.ts
@@ -36,6 +36,7 @@ describe("the App is a payer, never an author", () => {
     expect(uses.length, "the App credential is resolved and passed, not spread around").toBeGreaterThan(0);
     // The one construction that may receive it.
     expect(withoutComments).toContain("createGithubClient({");
+    expect(withoutComments).toContain("identity: githubIdentityRef({ kind: \"app\", app })");
     // The exec surface must never see it: `runGh` builds its argv and options
     // from the context alone.
     const runGh = withoutComments.slice(withoutComments.indexOf("export function runGh"));

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -47,11 +47,14 @@ import {
 } from "./daemon.js";
 import {
   createGithubAttributionLedger,
+  createGithubAppBalanceTransport,
   createGithubBalanceHistory,
   createGithubBalanceStore,
   DEFAULT_GITHUB_BALANCE_TIMEOUT_MS,
   createTimedGithubFetch,
   createGithubBalanceTransport,
+  githubIdentityRef,
+  resolveGithubAppCredential,
   type GithubAttributionLedger,
   type GithubRateBudget,
 } from "@reddb-io/github";
@@ -341,10 +344,17 @@ export function resolveServeGithubBalance(
   values: { readonly "queue-endpoint"?: string },
   env: NodeJS.ProcessEnv = process.env,
   readTrackerToken: RedskilledTrackerTokenReader = readTrackerCliToken,
+  githubAppBlock?: unknown,
+  homeDir: string = homedir(),
 ): RedskilledBalanceRegistration | null {
   const host = resolveRedskilledHostToken(env, readTrackerToken);
   if (host == null) return null;
   const origin = env.GITHUB_API_URL;
+  const app = resolveGithubAppCredential({
+    env,
+    configBlock: githubAppBlock,
+    expandHome: (path) => path.startsWith("~/") ? join(homeDir, path.slice(2)) : path,
+  });
   return {
     // Bounded, so a stalled ask cannot outlive the poll that issued it and the
     // re-arm keeps happening (#3768). The poller's own remote-call deadline is
@@ -353,6 +363,16 @@ export function resolveServeGithubBalance(
       token: host.token,
       ...(origin ? { origin } : {}),
       fetchImpl: createTimedGithubFetch({ timeoutMs: DEFAULT_GITHUB_BALANCE_TIMEOUT_MS }),
+    }),
+    ...(app === null ? {} : {
+      observers: [{
+        identity: githubIdentityRef({ kind: "app", app }),
+        transport: createGithubAppBalanceTransport({
+          app,
+          ...(origin ? { origin } : {}),
+          fetchImpl: createTimedGithubFetch({ timeoutMs: DEFAULT_GITHUB_BALANCE_TIMEOUT_MS }),
+        }),
+      }],
     }),
   };
 }
@@ -474,7 +494,12 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       readTrackerCliToken,
       githubAttribution,
     );
-    const resolvedGithubBalance = resolveServeGithubBalance(values);
+    const resolvedGithubBalance = resolveServeGithubBalance(
+      values,
+      process.env,
+      readTrackerCliToken,
+      hostConfig.githubApp,
+    );
     const githubBalance = resolvedGithubBalance == null
       ? null
       : {
@@ -482,7 +507,15 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
           store: createGithubBalanceStore({ path: join(hostStateRoot, "github", "balance.toon") }),
           history: createGithubBalanceHistory({
             path: join(hostStateRoot, "github", "balance-history.toonl"),
+            identity: "pat",
           }),
+          observers: resolvedGithubBalance.observers?.map((observer) => ({
+            ...observer,
+            history: createGithubBalanceHistory({
+              path: join(hostStateRoot, "github", "balance-history.toonl"),
+              identity: observer.identity,
+            }),
+          })),
         };
     // Before this daemon anchors itself, it speaks for whatever the last one
     // could not (slice #3028). The host singleton is the only process guaranteed

--- a/apps/redskilled/src/daemon/github-balance-observers.ts
+++ b/apps/redskilled/src/daemon/github-balance-observers.ts
@@ -1,0 +1,19 @@
+import { fetchGithubBalance } from "@reddb-io/github";
+
+import type { RedskilledBalanceObserver } from "./types.js";
+
+type RemotePoll = <T>(label: string, poll: () => Promise<T>) => Promise<T>;
+
+/** Observe optional payers without replacing the personal balance used by policy. */
+export async function pollGithubBalanceObservers(
+  observers: readonly RedskilledBalanceObserver[] | undefined,
+  remotePoll: RemotePoll,
+  now: () => string,
+): Promise<void> {
+  for (const observer of observers ?? []) {
+    const observed = await remotePoll(`GitHub balance poll (${observer.identity})`, () =>
+      fetchGithubBalance({ transport: observer.transport, now: now() }));
+    await observer.store?.write(observed).catch(() => undefined);
+    await observer.history?.append(observed).catch(() => undefined);
+  }
+}

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -787,13 +787,27 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         if (stored !== null) lastBalance = stored;
         return stored;
       }).finally(() => { balanceHydration = null; });
-      if ((await balanceHydration) !== null) return lastBalance;
+      if ((await balanceHydration) !== null) {
+        await pollGithubBalanceObservers();
+        return lastBalance;
+      }
     }
     lastBalance = await remotePoll("GitHub balance poll", () =>
       fetchGithubBalance({ transport: balanceRegistration.transport, now: clock() }));
     await balanceRegistration.store?.write(lastBalance).catch(() => undefined);
     await balanceRegistration.history?.append(lastBalance).catch(() => undefined);
+    await pollGithubBalanceObservers();
     return lastBalance;
+  }
+
+  /** Observe optional payers without replacing the personal balance used by policy. */
+  async function pollGithubBalanceObservers(): Promise<void> {
+    for (const observer of balanceRegistration?.observers ?? []) {
+      const observed = await remotePoll(`GitHub balance poll (${observer.identity})`, () =>
+        fetchGithubBalance({ transport: observer.transport, now: clock() }));
+      await observer.store?.write(observed).catch(() => undefined);
+      await observer.history?.append(observed).catch(() => undefined);
+    }
   }
 
   /**

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -218,6 +218,7 @@ import {
 } from "./tunables.js";
 import { replaceWithViableSuccessor } from "./takeover.js";
 import { createRemotePollDeadline } from "./remote-poll.js";
+import { pollGithubBalanceObservers } from "./github-balance-observers.js";
 import { createConfiguredRedskilledSelfPingMonitor } from "./self-ping.js";
 import { resolveUnitDeath } from "./unit-death.js";
 // Error moved to ./daemon/errors.ts — keep re-export for backward compat
@@ -787,27 +788,15 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         if (stored !== null) lastBalance = stored;
         return stored;
       }).finally(() => { balanceHydration = null; });
-      if ((await balanceHydration) !== null) {
-        await pollGithubBalanceObservers();
-        return lastBalance;
-      }
+      if ((await balanceHydration) !== null)
+        return pollGithubBalanceObservers(balanceRegistration.observers, remotePoll, clock).then(() => lastBalance);
     }
     lastBalance = await remotePoll("GitHub balance poll", () =>
       fetchGithubBalance({ transport: balanceRegistration.transport, now: clock() }));
     await balanceRegistration.store?.write(lastBalance).catch(() => undefined);
     await balanceRegistration.history?.append(lastBalance).catch(() => undefined);
-    await pollGithubBalanceObservers();
+    await pollGithubBalanceObservers(balanceRegistration.observers, remotePoll, clock);
     return lastBalance;
-  }
-
-  /** Observe optional payers without replacing the personal balance used by policy. */
-  async function pollGithubBalanceObservers(): Promise<void> {
-    for (const observer of balanceRegistration?.observers ?? []) {
-      const observed = await remotePoll(`GitHub balance poll (${observer.identity})`, () =>
-        fetchGithubBalance({ transport: observer.transport, now: clock() }));
-      await observer.store?.write(observed).catch(() => undefined);
-      await observer.history?.append(observed).catch(() => undefined);
-    }
   }
 
   /**

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -301,11 +301,21 @@ export interface RedskilledBalanceRegistration {
   readonly store?: GithubBalanceStore;
   /** Append-only forensic pool curve written from the same answers as the snapshot. */
   readonly history?: GithubBalanceHistory;
+  /** Additional credential ceilings observed on the same host cadence. */
+  readonly observers?: readonly RedskilledBalanceObserver[];
   /**
    * A hard window, for a test that needs one. Production leaves this absent and
    * lets the balance decide — that is the whole decision.
    */
   readonly intervalMsOverride?: number;
+}
+
+export interface RedskilledBalanceObserver {
+  /** Stable payer label written into history, e.g. `app:153309957`. */
+  readonly identity: string;
+  readonly transport: GithubBalanceTransport;
+  readonly store?: GithubBalanceStore;
+  readonly history?: GithubBalanceHistory;
 }
 
 /**

--- a/apps/redskilled/src/host-config.ts
+++ b/apps/redskilled/src/host-config.ts
@@ -30,6 +30,8 @@ export interface RedskilledHostConfig {
   readonly memoryCeiling?: string;
   readonly validationCeiling?: string;
   readonly idleMs?: string;
+  /** Optional GitHub App payer; validation stays in @reddb-io/github. */
+  readonly githubApp?: Readonly<Record<string, unknown>>;
   /** Operator-scoped programs fired for public Worker lifecycle changes. */
   readonly hooks?: Partial<Record<RedskilledPublicHostEventKind, RedskilledLaunchTemplate>>;
   /** Public Worker lifecycle changes also surfaced through the native desktop sink. */
@@ -86,6 +88,7 @@ export async function readRedskilledHostConfig(
       ...scalarAt(redskilled, "memory_ceiling", "memoryCeiling"),
       ...scalarAt(redskilled, "validation_ceiling", "validationCeiling"),
       ...scalarAt(redskilled, "idle_ms", "idleMs"),
+      ...mappingPropertyAt(redskilled, "github_app", "githubApp"),
       ...hooksAt(redskilled),
       ...notificationsAt(redskilled),
     };
@@ -95,6 +98,17 @@ export async function readRedskilledHostConfig(
     warn(`redskilled: malformed host config ${JSON.stringify(path)}; using environment and defaults instead: ${errorMessage(error)}`);
     return {};
   }
+}
+
+function mappingPropertyAt<K extends keyof RedskilledHostConfig>(
+  values: Readonly<Record<string, unknown>>,
+  path: string,
+  key: K,
+): Pick<RedskilledHostConfig, K> | Record<never, never> {
+  const value = values[path];
+  if (value === undefined || value === null) return {};
+  if (!isMapping(value)) throw new Error(`${path} must be a map`);
+  return { [key]: value } as Pick<RedskilledHostConfig, K>;
 }
 
 /** Resolve every daemon-owned setting under one explicit precedence table. */

--- a/apps/redskilled/tests/github-balance-history.test.ts
+++ b/apps/redskilled/tests/github-balance-history.test.ts
@@ -83,4 +83,34 @@ describe("redskilled GitHub balance history", () => {
       0,
     ]);
   });
+
+  it("records the person and the optional App as two independent series", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-identity-balance-history-"));
+    roots.push(root);
+    const historyPath = join(root, "state", "github", "balance-history.toonl");
+    const daemon = await startRedskilledDaemon({
+      paths: resolveRedskilledPaths({
+        env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+        runtimeDir: root,
+      }),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      githubBalance: {
+        transport: async () => answer(4_400),
+        history: createGithubBalanceHistory({ path: historyPath, identity: "pat" }),
+        observers: [{
+          identity: "app:153309957",
+          transport: async () => answer(4_900),
+          history: createGithubBalanceHistory({ path: historyPath, identity: "app:153309957" }),
+        }],
+        intervalMsOverride: 3_600_000,
+      },
+    });
+    daemons.push(daemon);
+
+    await daemon.pollGithubBalance();
+
+    const rows = parseRecords(await readFile(historyPath, "utf8"));
+    expect(new Set(rows.map((row) => row.identity))).toEqual(new Set(["pat", "app:153309957"]));
+  });
 });

--- a/apps/redskilled/tests/github-balance.test.ts
+++ b/apps/redskilled/tests/github-balance.test.ts
@@ -3,7 +3,7 @@
 // answer without interpreting it, never invents a full budget for a balance
 // nobody asked for, and puts the posture on the payload so "the queue looks
 // empty" and "we are out of quota" are never the same screen.
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -16,6 +16,7 @@ import { renderRedskilledStatusline } from "@reddb-io/redskilled-render";
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { isRedskilledStatuslinePayload } from "../src/statusline-payload.js";
+import { resolveServeGithubBalance } from "../src/cli.js";
 
 let daemons: RedskilledDaemon[] = [];
 let dirs: string[] = [];
@@ -216,6 +217,29 @@ describe("the ask reaches the authoritative endpoint", () => {
     expect(seen[0]!.url).toContain(`/${GITHUB_RATE_LIMIT_PATH}`);
     expect(seen[0]!.method).toBe("GET");
     expect(payload).toBeTruthy();
+  });
+
+  it("adds the optional App as a separately named observer", async () => {
+    const home = await mkdtemp(join(tmpdir(), "redskilled-app-balance-"));
+    dirs.push(home);
+    const privateKey = join(home, "github-app.pem");
+    await writeFile(privateKey, "test-only-private-key");
+
+    const registration = resolveServeGithubBalance(
+      {},
+      {},
+      () => "personal-token",
+      { app_id: "4575633", installation_id: "153309957", private_key: privateKey },
+      home,
+    );
+
+    expect(registration?.observers?.map((observer) => observer.identity)).toEqual(["app:153309957"]);
+  });
+
+  it("keeps the App optional", () => {
+    const registration = resolveServeGithubBalance({}, {}, () => "personal-token", undefined, "/home/operator");
+
+    expect(registration?.observers).toBeUndefined();
   });
 });
 

--- a/apps/redskilled/tests/host-config.test.ts
+++ b/apps/redskilled/tests/host-config.test.ts
@@ -42,6 +42,10 @@ describe("the daemon-owned host config", () => {
       "      memory_ceiling: 8G",
       "      validation_ceiling: 3",
       "      idle_ms: 61000",
+      "      github_app:",
+      "        app_id: '4575633'",
+      "        installation_id: '153309957'",
+      "        private_key: ~/.red/redskilled/github-app.pem",
       "      hooks:",
       "        worker-birth:",
       "          argv: [/usr/local/bin/redwall, refresh]",
@@ -58,6 +62,11 @@ describe("the daemon-owned host config", () => {
       memoryCeiling: "8G",
       validationCeiling: "3",
       idleMs: "61000",
+      githubApp: {
+        app_id: "4575633",
+        installation_id: "153309957",
+        private_key: "~/.red/redskilled/github-app.pem",
+      },
       hooks: {
         "worker-birth": {
           argv: ["/usr/local/bin/redwall", "refresh"],

--- a/packages/github/app-balance-transport.ts
+++ b/packages/github/app-balance-transport.ts
@@ -1,0 +1,27 @@
+import { createAppAuth } from "@octokit/auth-app";
+
+import { readGithubAppPrivateKey, type GithubAppCredential } from "./app-credential.js";
+import { createGithubBalanceTransport, type GithubBalanceTransport } from "./balance.js";
+
+/** Ask one App installation's independent balance with a renewable token. */
+export function createGithubAppBalanceTransport(options: {
+  readonly app: GithubAppCredential;
+  readonly origin?: string;
+  readonly fetchImpl?: typeof fetch;
+  /** Test seam that returns a short-lived installation token. */
+  readonly authenticate?: () => Promise<string>;
+}): GithubBalanceTransport {
+  const authenticate = options.authenticate ?? (() => {
+    const appAuth = createAppAuth({
+      appId: options.app.appId,
+      installationId: options.app.installationId,
+      privateKey: readGithubAppPrivateKey(options.app),
+    });
+    return async () => (await appAuth({ type: "installation" })).token;
+  })();
+  return async () => await createGithubBalanceTransport({
+    token: await authenticate(),
+    ...(options.origin ? { origin: options.origin } : {}),
+    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+  })();
+}

--- a/packages/github/balance.test.ts
+++ b/packages/github/balance.test.ts
@@ -9,7 +9,6 @@ import {
   admitGithubCall,
   admitGithubOperation,
   buildGithubBalanceReport,
-  createGithubAppBalanceTransport,
   fetchGithubBalance,
   githubBalanceCadenceMs,
   githubBalancePosture,
@@ -17,6 +16,7 @@ import {
   parseGithubBalance,
   unaskedGithubBalance,
 } from "./balance.js";
+import { createGithubAppBalanceTransport } from "./app-balance-transport.js";
 import { routeGithubArgs } from "./surface.js";
 
 const ASKED_AT = "2026-08-03T12:00:00.000Z";

--- a/packages/github/balance.test.ts
+++ b/packages/github/balance.test.ts
@@ -9,6 +9,7 @@ import {
   admitGithubCall,
   admitGithubOperation,
   buildGithubBalanceReport,
+  createGithubAppBalanceTransport,
   fetchGithubBalance,
   githubBalanceCadenceMs,
   githubBalancePosture,
@@ -97,6 +98,27 @@ describe("the balance is asked, never derived", () => {
     expect(calls).toBe(1);
     expect(balance.request_count).toBe(1);
     expect(balance.outcome).toBe("asked");
+  });
+
+  it("asks the App installation's independent balance with a renewable token", async () => {
+    const authorizations: string[] = [];
+    let authentications = 0;
+    const transport = createGithubAppBalanceTransport({
+      app: { appId: "4575633", installationId: "153309957", privateKeyPath: "/not-read-in-test.pem" },
+      authenticate: async () => {
+        authentications += 1;
+        return "installation-token";
+      },
+      fetchImpl: (async (_url: string, init?: RequestInit) => {
+        authorizations.push(new Headers(init?.headers).get("authorization") ?? "");
+        return { ok: true, status: 200, json: async () => payload() } as Response;
+      }) as typeof fetch,
+    });
+
+    await transport();
+
+    expect(authentications).toBe(1);
+    expect(authorizations).toEqual(["bearer installation-token"]);
   });
 
   it("has no accumulator to seed: an unasked balance knows nothing", () => {

--- a/packages/github/balance.ts
+++ b/packages/github/balance.ts
@@ -48,9 +48,6 @@
 // PURE, apart from `fetchGithubBalance` and `createGithubBalanceTransport`, whose
 // transport is injected.
 
-import { createAppAuth } from "@octokit/auth-app";
-
-import { readGithubAppPrivateKey, type GithubAppCredential } from "./app-credential.js";
 import type { GithubApiSurface, GithubOperation, GithubRateBudget } from "./surface.js";
 
 /**
@@ -887,40 +884,6 @@ export function createGithubBalanceTransport(options: {
       throw new Error(`the balance ask was refused with HTTP ${response.status}`);
     }
     return await response.json();
-  };
-}
-
-/**
- * The same authoritative balance ask, authenticated as one App installation.
- *
- * The auth strategy owns the expiring installation token. Callers keep the App
- * facts, never a token that becomes dead during a daemon's second hour.
- */
-export function createGithubAppBalanceTransport(options: {
-  readonly app: GithubAppCredential;
-  readonly origin?: string;
-  readonly fetchImpl?: typeof fetch;
-  /** Test seam that returns a short-lived installation token. */
-  readonly authenticate?: () => Promise<string>;
-}): GithubBalanceTransport {
-  const authenticate = options.authenticate ?? (() => {
-    const appAuth = createAppAuth({
-      appId: options.app.appId,
-      installationId: options.app.installationId,
-      privateKey: readGithubAppPrivateKey(options.app),
-    });
-    return async () => {
-      const authentication = await appAuth({ type: "installation" });
-      return authentication.token;
-    };
-  })();
-  return async () => {
-    const token = await authenticate();
-    return await createGithubBalanceTransport({
-      token,
-      ...(options.origin ? { origin: options.origin } : {}),
-      ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
-    })();
   };
 }
 

--- a/packages/github/balance.ts
+++ b/packages/github/balance.ts
@@ -48,6 +48,9 @@
 // PURE, apart from `fetchGithubBalance` and `createGithubBalanceTransport`, whose
 // transport is injected.
 
+import { createAppAuth } from "@octokit/auth-app";
+
+import { readGithubAppPrivateKey, type GithubAppCredential } from "./app-credential.js";
 import type { GithubApiSurface, GithubOperation, GithubRateBudget } from "./surface.js";
 
 /**
@@ -884,6 +887,40 @@ export function createGithubBalanceTransport(options: {
       throw new Error(`the balance ask was refused with HTTP ${response.status}`);
     }
     return await response.json();
+  };
+}
+
+/**
+ * The same authoritative balance ask, authenticated as one App installation.
+ *
+ * The auth strategy owns the expiring installation token. Callers keep the App
+ * facts, never a token that becomes dead during a daemon's second hour.
+ */
+export function createGithubAppBalanceTransport(options: {
+  readonly app: GithubAppCredential;
+  readonly origin?: string;
+  readonly fetchImpl?: typeof fetch;
+  /** Test seam that returns a short-lived installation token. */
+  readonly authenticate?: () => Promise<string>;
+}): GithubBalanceTransport {
+  const authenticate = options.authenticate ?? (() => {
+    const appAuth = createAppAuth({
+      appId: options.app.appId,
+      installationId: options.app.installationId,
+      privateKey: readGithubAppPrivateKey(options.app),
+    });
+    return async () => {
+      const authentication = await appAuth({ type: "installation" });
+      return authentication.token;
+    };
+  })();
+  return async () => {
+    const token = await authenticate();
+    return await createGithubBalanceTransport({
+      token,
+      ...(options.origin ? { origin: options.origin } : {}),
+      ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+    })();
   };
 }
 

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -118,6 +118,7 @@ export {
   balanceFromReport,
   buildGithubBalanceReport,
   createGithubBalanceTransport,
+  createGithubAppBalanceTransport,
   fetchGithubBalance,
   githubBalanceCadenceMs,
   githubBalancePosture,

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -118,7 +118,6 @@ export {
   balanceFromReport,
   buildGithubBalanceReport,
   createGithubBalanceTransport,
-  createGithubAppBalanceTransport,
   fetchGithubBalance,
   githubBalanceCadenceMs,
   githubBalancePosture,
@@ -143,6 +142,8 @@ export {
   type GithubDiversionInput,
   type GithubPoolBalance,
 } from "./balance.js";
+
+export { createGithubAppBalanceTransport } from "./app-balance-transport.js";
 
 export {
   DEFAULT_GITHUB_CACHE_CAPACITY,


### PR DESCRIPTION
## What changed

- teach the host config and redskilled daemon about the optional GitHub App payer
- ask the App installation rate-limit independently and append PAT/App rows to `balance-history.toonl` with stable identities
- attribute App-paid reads in `spend.toonl` while preserving absent identity as PAT
- add a renewable App balance transport and a release changeset

## Why

The daemon was the sole writer of balance surfaces but only polled the personal token. The App-aware read client paid with the App without writing a balance or payer identity, so consumers such as redwall could never recover the four independent REST/GraphQL numbers.

## Impact

Hosts without `github_app` behave exactly as before. Configured hosts produce `pat` and `app:<installation>` history series; consumers can show both without inventing `balance-app-*` files or summing independent quotas.

## Validation

- redskilled targeted tests: 23 passed
- GitHub package and App payer tests: 31 passed
- redskilled and dev TypeScript checks passed
- oxlint passed on all changed TypeScript files
- release-entry and changeset validators passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789194735&installation_model_id=20659&pr_number=3806&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3806&signature=3deab8f68fa3a8a74b504566a6dc60f6bcf9c61de8b6dc608dfb038409a0bf3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->