### PR TITLE
fix(redskilled): the App is measured, not just spent

### DIFF
--- a/.changeset/daemon-measures-both-buckets.md
+++ b/.changeset/daemon-measures-both-buckets.md
@@ -1,0 +1,33 @@
+---
+"@reddb-io/github": patch
+"@reddb-io/red-skills": patch
+---
+
+The App is measured, not just spent
+
+A host declaring a GitHub App had two payers and one measurement. The daemon is
+the only process that writes the balance surfaces, and it asked exclusively on
+the operator's token: `balance.toon` held the person's ceiling, every
+`balance-history.toonl` row was stamped `pat`, and
+`balance-app-<installation>.toon` — named in the contract, exercised only by
+tests — was written by nobody. Meanwhile the App's bucket was spent entirely by
+other processes, so an installation carrying thousands of reads an hour appeared
+on no surface at all. A consumer plotting the machine saw one sawtooth and
+believed it was the whole story.
+
+The daemon now reads the `github_app` block from the host policy file and
+measures that ceiling beside the operator's, on the App's own installation
+token. Each payer writes its own snapshot, because two buckets summed into one
+document would have to pick an owner and the last writer would become the
+displayed truth for a ceiling the next request may not draw from. Both write
+their rows into the one history lane, labelled — one curve file, two separable
+series.
+
+The App is a payer to MEASURE here, never a credential the daemon acts as: it
+authenticates no write and routes no read, and a misdeclared block answers
+`null` rather than refusing to boot, because a daemon that would not serve a
+host over an optional number trades the machine for a graph.
+
+The dev runtime's spend ledger gained the same stamp. It recorded WHAT was spent
+and never WHOSE, so a host running both an App and a token produced one
+undifferentiated total — a number no ceiling could be checked against.

--- a/apps/dev/src/runtime/gh/common.ts
+++ b/apps/dev/src/runtime/gh/common.ts
@@ -8,6 +8,7 @@ import {
   createGithubClient,
   createGithubInstallationLookup,
   githubCoveragePath,
+  githubIdentityRef,
   openGithubCoverageCache,
   planGithubRestRead,
   resolveGithubAppCredential,
@@ -219,6 +220,10 @@ export function githubReadClient(
     ...(app === null ? {} : { app }),
     attribution: createGithubAttributionLedger({
       path: join(stateDir(ctx.cwd), "github", "spend.toonl"),
+      // Which bucket this row drew from. Without it the ledger records WHAT was
+      // spent and never WHOSE, so a host running an App and a token produced one
+      // undifferentiated total — a number no ceiling can be checked against.
+      identity: githubIdentityRef(app === null ? { kind: "personal", token } : { kind: "app", app }),
     }),
   });
   routedClients.set(ctx, client);

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -27,6 +27,7 @@ import {
 import { isResolvedRedskilledEntry } from "./daemon-entry.js";
 import {
   readRedskilledHostConfig,
+  readRedskilledHostGithubApp,
   resolveRedskilledHostEventSinks,
   resolveRedskilledHostSettings,
 } from "./host-config.js";
@@ -55,6 +56,7 @@ import {
   type GithubAttributionLedger,
   type GithubRateBudget,
 } from "@reddb-io/github";
+import { resolveServeGithubCompanions } from "./github-companions.js";
 import { createGitHubActivityTransport } from "./repository-activity.js";
 import {
   reclaimRedskilledRuntimeDirs,
@@ -475,14 +477,26 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       githubAttribution,
     );
     const resolvedGithubBalance = resolveServeGithubBalance(values);
+    // The App is a PAYER to measure, never a credential this daemon acts as.
+    // Declared → its ceiling is asked on its own installation token and written
+    // to its own file, because two buckets summed into one document would make
+    // the last writer the displayed truth for a ceiling the next request may
+    // not draw from.
+    const hostApp = await readRedskilledHostGithubApp();
     const githubBalance = resolvedGithubBalance == null
       ? null
       : {
           ...resolvedGithubBalance,
+          // The operator's own ceiling keeps the unsuffixed name and the default
+          // `pat` stamp: this is the floor every surface already renders, and
+          // renaming it would move a file other processes read.
           store: createGithubBalanceStore({ path: join(hostStateRoot, "github", "balance.toon") }),
           history: createGithubBalanceHistory({
             path: join(hostStateRoot, "github", "balance-history.toonl"),
           }),
+          ...(hostApp === null
+            ? {}
+            : { companions: resolveServeGithubCompanions(hostApp, hostStateRoot) }),
         };
     // Before this daemon anchors itself, it speaks for whatever the last one
     // could not (slice #3028). The host singleton is the only process guaranteed

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -193,6 +193,7 @@ import {
   type RedskilledReplacementDecision,
   type RedskilledReplacementHoldReason,
 } from "../self-replace.js";
+import { measureGithubCompanions } from "../github-companions.js";
 import {
   createRedskilledLeaseStore,
   currentProcessOwner,
@@ -793,6 +794,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       fetchGithubBalance({ transport: balanceRegistration.transport, now: clock() }));
     await balanceRegistration.store?.write(lastBalance).catch(() => undefined);
     await balanceRegistration.history?.append(lastBalance).catch(() => undefined);
+    await measureGithubCompanions(balanceRegistration.companions ?? [], clock());
     return lastBalance;
   }
 

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -302,10 +302,34 @@ export interface RedskilledBalanceRegistration {
   /** Append-only forensic pool curve written from the same answers as the snapshot. */
   readonly history?: GithubBalanceHistory;
   /**
+   * Other payers on this host, each measured on its own credential.
+   *
+   * A GitHub App carries a bucket of its own, and the daemon used to ask only
+   * the operator's token — so an installation spending thousands of reads an
+   * hour appeared on no surface at all. Each companion is asked separately and
+   * writes its own files, because **two buckets are never summed**: a single
+   * document would have to pick an owner, and the last writer would become the
+   * displayed truth for a ceiling the next request will not draw from.
+   *
+   * A companion NEVER decides the daemon's own `githubBalance()` answer. That
+   * stays the primary's, the floor every surface already renders — a companion
+   * failing must cost nothing but its own row.
+   */
+  readonly companions?: readonly RedskilledBalanceCompanion[];
+  /**
    * A hard window, for a test that needs one. Production leaves this absent and
    * lets the balance decide — that is the whole decision.
    */
   readonly intervalMsOverride?: number;
+}
+
+/** One additional payer, measured beside the primary and written apart from it. */
+export interface RedskilledBalanceCompanion {
+  /** How this payer is named on the rows it writes, e.g. `app:153309957`. */
+  readonly identity: string;
+  readonly transport: GithubBalanceTransport;
+  readonly store?: GithubBalanceStore;
+  readonly history?: GithubBalanceHistory;
 }
 
 /**

--- a/apps/redskilled/src/github-companions.ts
+++ b/apps/redskilled/src/github-companions.ts
@@ -1,0 +1,78 @@
+// github-companions — the payers this host measures beside the operator's token.
+//
+// A host that declares a GitHub App has TWO ceilings and used to have one
+// measurement. The daemon is the only process that writes the balance surfaces
+// and it asked exclusively on the operator's credential, so an installation
+// spending thousands of reads an hour appeared nowhere: the snapshot measured
+// the person, every history row was stamped `pat`, and the App's own file was
+// named in the contract and written by nobody.
+//
+// **Two buckets are never summed.** Each payer answers for a ceiling the other's
+// requests do not draw from, so each gets its own snapshot — a single document
+// would have to pick an owner, making the last writer the displayed truth. The
+// history lane is deliberately shared: one curve file, two labelled series, so a
+// consumer separates them by identity instead of guessing which file is current.
+import { join } from "node:path";
+import {
+  createGithubAppBalanceTransport,
+  createGithubBalanceHistory,
+  createGithubBalanceStore,
+  createTimedGithubFetch,
+  DEFAULT_GITHUB_BALANCE_TIMEOUT_MS,
+  fetchGithubBalance,
+  githubBalanceFileName,
+  githubIdentityRef,
+  type GithubAppCredential,
+} from "@reddb-io/github";
+import type { RedskilledBalanceCompanion } from "./daemon/types.js";
+
+/**
+ * The companions a declared App contributes. One entry today; the shape is a
+ * list because "who pays on this host" is a set, not a second slot.
+ */
+export function resolveServeGithubCompanions(
+  app: GithubAppCredential,
+  hostStateRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): RedskilledBalanceCompanion[] {
+  const identity = githubIdentityRef({ kind: "app", app });
+  return [{
+    identity,
+    transport: createGithubAppBalanceTransport({
+      app,
+      ...(env.GITHUB_API_URL ? { origin: env.GITHUB_API_URL } : {}),
+      fetchImpl: createTimedGithubFetch({ timeoutMs: DEFAULT_GITHUB_BALANCE_TIMEOUT_MS }),
+    }),
+    store: createGithubBalanceStore({
+      path: join(hostStateRoot, "github", githubBalanceFileName({ kind: "app", app })),
+    }),
+    history: createGithubBalanceHistory({
+      path: join(hostStateRoot, "github", "balance-history.toonl"),
+      identity,
+    }),
+  }];
+}
+
+/**
+ * Measure every companion, each on its own credential.
+ *
+ * Nothing here may reach the daemon's own answer. `githubBalance()` stays the
+ * PRIMARY's — the operator's token is the floor every surface renders, and an
+ * App's ceiling cannot stand in for it on a repository the App does not cover.
+ * A companion that throws costs its own row and nothing else: a payer that
+ * cannot be measured is not a daemon that cannot serve.
+ */
+export async function measureGithubCompanions(
+  companions: readonly RedskilledBalanceCompanion[],
+  now: string,
+): Promise<void> {
+  for (const companion of companions) {
+    try {
+      const answer = await fetchGithubBalance({ transport: companion.transport, now });
+      await companion.store?.write(answer).catch(() => undefined);
+      await companion.history?.append(answer).catch(() => undefined);
+    } catch {
+      // Measured or not, the host keeps serving.
+    }
+  }
+}

--- a/apps/redskilled/src/host-config.ts
+++ b/apps/redskilled/src/host-config.ts
@@ -10,6 +10,11 @@ import { homedir, totalmem } from "node:os";
 import { join } from "node:path";
 import { parse } from "yaml";
 import {
+  githubAppBlockIn,
+  resolveGithubAppCredential,
+  type GithubAppCredential,
+} from "@reddb-io/github";
+import {
   resolveHostCeiling,
   type RedskilledHostCeiling,
   type RedskilledHostSettingSource,
@@ -62,6 +67,33 @@ export function resolveRedskilledHostEventSinks(
     ...(config.notifications == null ? {} : { notifications: config.notifications }),
     platform,
   };
+}
+
+/**
+ * The GitHub App this host declares, or `null` when it declares none.
+ *
+ * The daemon needs it for ONE reason: to measure the App's ceiling beside the
+ * operator's. It never authenticates a write with it and never routes a read
+ * through it — that routing is per repository and belongs to the dev runtime,
+ * which is where the App actually spends. Here the App is a payer to MEASURE,
+ * not a credential to act as.
+ *
+ * A misdeclared block answers `null` rather than throwing: a daemon that
+ * refused to boot over an optional measurement would trade the whole host for a
+ * number. The dev runtime states the same refusal loudly where it matters.
+ */
+export async function readRedskilledHostGithubApp(
+  homeDir: string = homedir(),
+): Promise<GithubAppCredential | null> {
+  try {
+    const text = await readFile(join(homeDir, REDSKILLED_HOST_CONFIG_PATH), "utf8");
+    return resolveGithubAppCredential({
+      configBlock: githubAppBlockIn(parse(text) as unknown),
+      expandHome: (path) => (path.startsWith("~/") ? join(homeDir, path.slice(2)) : path),
+    });
+  } catch {
+    return null;
+  }
 }
 
 /** Read `plugins.dev.redskilled` from the operator's host file. */

--- a/apps/redskilled/tests/daemon-measures-both-buckets.test.ts
+++ b/apps/redskilled/tests/daemon-measures-both-buckets.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveServeGithubCompanions } from "../src/github-companions.js";
+import { readRedskilledHostGithubApp } from "../src/host-config.js";
+
+/**
+ * The App was a payer nobody measured.
+ *
+ * `balance.toon` and `balance-history.toonl` were written by ONE process — the
+ * host daemon — asking on ONE credential, the operator's token. The App's bucket
+ * was spent entirely by other processes, so an installation could carry
+ * thousands of reads an hour and appear on no surface: the snapshot measured the
+ * person, every history row was stamped `pat`, and
+ * `balance-app-<installation>.toon` was named in the contract and written by
+ * nobody. Redwall plotted a single sawtooth and called it the machine.
+ */
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function tempHome(block: string | null): string {
+  const home = mkdtempSync(join(tmpdir(), "redskilled-host-"));
+  roots.push(home);
+  mkdirSync(join(home, ".red"), { recursive: true });
+  writeFileSync(
+    join(home, ".red", "config.yaml"),
+    ["plugins:", "  dev:", "    redskilled:", "      worker_ceiling: 6", ...(block ? [block] : [])]
+      .join("\n"),
+  );
+  return home;
+}
+
+const DECLARED = [
+  "      github_app:",
+  '        app_id: "4575633"',
+  '        installation_id: "153309957"',
+  "        private_key: ~/.red/redskilled/github-app.pem",
+].join("\n");
+
+describe("the daemon reads the App this host declares", () => {
+  it("resolves the declared block and expands its home-relative key path", async () => {
+    const home = tempHome(DECLARED);
+    const app = await readRedskilledHostGithubApp(home);
+
+    expect(app).not.toBeNull();
+    expect(app?.appId).toBe("4575633");
+    expect(app?.installationId).toBe("153309957");
+    expect(app?.privateKeyPath).toBe(join(home, ".red", "redskilled", "github-app.pem"));
+  });
+
+  it("answers null for a host that declares none, leaving today's behaviour exactly as it was", async () => {
+    expect(await readRedskilledHostGithubApp(tempHome(null))).toBeNull();
+  });
+
+  it("answers null for a PARTIAL block instead of refusing to boot", async () => {
+    // The dev runtime refuses a partial declaration loudly, because a silent
+    // fallback there restores the shared personal bucket the App was adopted to
+    // end. Here the App is only a measurement, and a daemon that would not serve
+    // a host over an optional number trades the machine for a graph.
+    const home = tempHome(['      github_app:', '        app_id: "4575633"'].join("\n"));
+    expect(await readRedskilledHostGithubApp(home)).toBeNull();
+  });
+});
+
+describe("two buckets are measured apart", () => {
+  const app = { appId: "4575633", installationId: "153309957", privateKeyPath: "/k.pem" };
+
+  it("gives the App its own snapshot file, never the personal one", () => {
+    const [companion] = resolveServeGithubCompanions(app, "/state", {});
+
+    expect(companion?.identity).toBe("app:153309957");
+    // A single document would have to pick an owner, and the last writer would
+    // become the displayed truth for a ceiling the next request may not use.
+    expect(companion?.store).toBeDefined();
+    expect(companion?.history).toBeDefined();
+    expect(companion?.transport).toBeTypeOf("function");
+  });
+
+  it("stamps the App's rows so one shared history holds two separable series", () => {
+    const [companion] = resolveServeGithubCompanions(app, "/state", {});
+    // The lane is shared on purpose — one curve file, two labelled series — so a
+    // consumer plotting the machine separates them by identity rather than by
+    // guessing which file was current.
+    expect(companion?.identity).toBe("app:153309957");
+  });
+});

--- a/packages/github/app-balance.test.ts
+++ b/packages/github/app-balance.test.ts
@@ -1,0 +1,120 @@
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { createGithubAppBalanceTransport, mintGithubInstallationToken } from "./app-balance.js";
+import { githubAppBlockIn, githubBalanceFileName, githubIdentityRef } from "./app-credential.js";
+import type { GithubAppCredential } from "./app-credential.js";
+
+// A real key, so the mint exercises the real signature rather than stopping at
+// an unreadable file — the failure this pins is a REJECTED mint, not a missing
+// one, and the two look identical from outside if nothing ever signs.
+const keyRoot = mkdtempSync(join(tmpdir(), "app-balance-"));
+const keyPath = join(keyRoot, "key.pem");
+writeFileSync(
+  keyPath,
+  generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs1", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  }).privateKey,
+);
+afterAll(() => rmSync(keyRoot, { recursive: true, force: true }));
+
+const APP: GithubAppCredential = {
+  appId: "4575633",
+  installationId: "153309957",
+  privateKeyPath: keyPath,
+};
+
+describe("the App's ceiling is asked on the App's own credential", () => {
+  it("mints a fresh installation token per ask, so nothing goes stale unwatched", async () => {
+    const asked: string[] = [];
+    let mints = 0;
+    const transport = createGithubAppBalanceTransport({
+      app: APP,
+      mintToken: async () => `token-${++mints}`,
+      fetchImpl: (async (url: string, init: { headers: Record<string, string> }) => {
+        asked.push(`${String(url)} ${init.headers.authorization}`);
+        return { ok: true, json: async () => ({ resources: {} }) };
+      }) as unknown as typeof fetch,
+    });
+
+    await transport();
+    await transport();
+
+    // An installation token lives an hour and a balance ask is rare; a cached
+    // one would expire exactly when nobody is looking.
+    expect(mints).toBe(2);
+    expect(asked[0]).toContain("bearer token-1");
+    expect(asked[1]).toContain("bearer token-2");
+    expect(asked[0]).toContain("/rate_limit");
+  });
+
+  it("honours an enterprise origin on the mint", async () => {
+    const seen: string[] = [];
+    const call = (async (url: string) => {
+      seen.push(String(url));
+      return { ok: true, json: async () => ({ token: "t" }) };
+    }) as unknown as typeof fetch;
+
+    const token = await mintGithubInstallationToken(APP, {
+      origin: "https://ghe.example/api/v3",
+      fetchImpl: call,
+    });
+
+    expect(token).toBe("t");
+    expect(seen[0]).toBe("https://ghe.example/api/v3/app/installations/153309957/access_tokens");
+  });
+
+  it("refuses a granted response that carries no token", async () => {
+    await expect(
+      mintGithubInstallationToken(APP, {
+        fetchImpl: (async () => ({ ok: true, json: async () => ({}) })) as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/carried no token/);
+  });
+
+  it("refuses a mint the server did not grant, rather than asking with an empty token", async () => {
+    await expect(
+      mintGithubInstallationToken(APP, {
+        fetchImpl: (async () => ({ ok: false, status: 401 })) as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/401/);
+  });
+});
+
+describe("two buckets are two files and two labels", () => {
+  it("names the App's snapshot after its installation", () => {
+    expect(githubBalanceFileName({ kind: "app", app: APP })).toBe("balance-app-153309957.toon");
+    expect(githubBalanceFileName({ kind: "personal", token: "pat" })).toBe("balance.toon");
+  });
+
+  it("labels the rows so a plotted series knows whose ceiling it measures", () => {
+    expect(githubIdentityRef({ kind: "app", app: APP })).toBe("app:153309957");
+    expect(githubIdentityRef({ kind: "personal", token: "pat" })).toBe("pat");
+  });
+});
+
+describe("one namer for where the App block lives", () => {
+  // The daemon and the dev runtime parse the same file with different YAML
+  // dependencies, so the PATH is the one thing they must agree on. Two hand
+  // written navigations drift, and the drifted one reads no App at all — which
+  // is indistinguishable from a host that declared none.
+  it("finds the block the operator declares", () => {
+    const document = {
+      plugins: { dev: { redskilled: { github_app: { app_id: "1", installation_id: "2", private_key: "k" } } } },
+    };
+    expect(githubAppBlockIn(document)).toEqual({ app_id: "1", installation_id: "2", private_key: "k" });
+  });
+
+  it("answers null for every shape that does not carry one", () => {
+    expect(githubAppBlockIn(null)).toBeNull();
+    expect(githubAppBlockIn("not a document")).toBeNull();
+    expect(githubAppBlockIn({})).toBeNull();
+    expect(githubAppBlockIn({ plugins: { dev: {} } })).toBeNull();
+    expect(githubAppBlockIn({ plugins: { dev: { redskilled: { worker_ceiling: 6 } } } })).toBeNull();
+  });
+});

--- a/packages/github/app-balance.ts
+++ b/packages/github/app-balance.ts
@@ -1,0 +1,81 @@
+// app-balance — the App's own ceiling, asked on the App's own credential.
+//
+// The balance surfaces were written by ONE process (the host daemon) asking on
+// ONE credential (the operator's token), while the App's bucket was spent by
+// other processes entirely. So an installation could carry thousands of reads
+// an hour and appear nowhere: `balance.toon` measured the person, the history
+// stamped every row `pat`, and `balance-app-<installation>.toon` — named in the
+// contract and exercised only by tests — was written by nobody.
+//
+// **Two buckets are never summed, so they are asked separately.** This transport
+// is the App half. It answers the same `/rate_limit` shape as the personal one,
+// which is what lets both write the same document to different files rather than
+// one document that would have to pick an owner.
+//
+// **A fresh installation token per ask, deliberately.** An installation token
+// lives one hour and a balance ask is rare, so minting one per call costs a
+// request the App itself pays for and removes expiry bookkeeping entirely — the
+// alternative is a cached token that goes stale exactly when nobody is watching.
+import type { GithubAppCredential } from "./app-credential.js";
+import { signGithubAppJwt } from "./app-credential.js";
+import { GITHUB_RATE_LIMIT_PATH, type GithubBalanceTransport } from "./balance.js";
+
+/** Mint an installation access token for `app`. Throws with GitHub's own words. */
+export async function mintGithubInstallationToken(
+  app: GithubAppCredential,
+  options: { readonly origin?: string; readonly fetchImpl?: typeof fetch } = {},
+): Promise<string> {
+  const origin = options.origin ?? "https://api.github.com";
+  const call = options.fetchImpl ?? fetch;
+  const jwt = await signGithubAppJwt(app);
+  const response = await call(
+    `${origin}/app/installations/${app.installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${jwt}`, accept: "application/vnd.github+json" },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `minting an installation token for app ${app.appId} returned ${response.status}`,
+    );
+  }
+  const body = (await response.json()) as { token?: unknown };
+  const token = typeof body.token === "string" ? body.token : "";
+  if (token === "") throw new Error("the installation token response carried no token");
+  return token;
+}
+
+/**
+ * The App's `/rate_limit`, asked as the installation.
+ *
+ * Shaped exactly like {@link createGithubBalanceTransport} so the caller cannot
+ * tell the two apart — the difference belongs in WHERE the answer is written,
+ * never in how it is read.
+ */
+export function createGithubAppBalanceTransport(options: {
+  readonly app: GithubAppCredential;
+  readonly origin?: string;
+  readonly fetchImpl?: typeof fetch;
+  /** Injected in tests; production mints through the App's own JWT. */
+  readonly mintToken?: (app: GithubAppCredential) => Promise<string>;
+}): GithubBalanceTransport {
+  const origin = options.origin ?? "https://api.github.com";
+  const call = options.fetchImpl ?? fetch;
+  const mint = options.mintToken ??
+    ((app: GithubAppCredential) => mintGithubInstallationToken(app, {
+      ...(options.origin === undefined ? {} : { origin: options.origin }),
+      ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
+    }));
+  return async (): Promise<unknown> => {
+    const token = await mint(options.app);
+    const response = await call(`${origin}/${GITHUB_RATE_LIMIT_PATH}`, {
+      method: "GET",
+      headers: {
+        authorization: `bearer ${token}`,
+        accept: "application/vnd.github+json",
+      },
+    });
+    return await response.json();
+  };
+}

--- a/packages/github/app-credential.ts
+++ b/packages/github/app-credential.ts
@@ -221,6 +221,26 @@ export function githubIdentityRef(identity: GithubIdentity): string {
 }
 
 /**
+ * Where the `github_app` block lives inside a parsed host config document.
+ *
+ * The daemon and the dev runtime each parse `~/.red/config.yaml` with their own
+ * YAML dependency, so the PATH is the one thing they must agree on. Two hand-
+ * written navigations of the same four keys drift into two different answers —
+ * one of them silently reading no App at all, which is indistinguishable from a
+ * host that declared none.
+ */
+export function githubAppBlockIn(document: unknown): unknown {
+  if (document === null || typeof document !== "object") return null;
+  const plugins = (document as Record<string, unknown>).plugins;
+  if (plugins === null || typeof plugins !== "object") return null;
+  const dev = (plugins as Record<string, unknown>).dev;
+  if (dev === null || typeof dev !== "object") return null;
+  const redskilled = (dev as Record<string, unknown>).redskilled;
+  if (redskilled === null || typeof redskilled !== "object") return null;
+  return (redskilled as Record<string, unknown>).github_app ?? null;
+}
+
+/**
  * Read the App credential from an operator's parsed host config.
  *
  * The environment is for a one-run override; the FILE is the onboarding

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -181,6 +181,7 @@ export {
   GITHUB_APP_KEY_ENV,
   createGithubIdentityRouter,
   createGithubInstallationLookup,
+  githubAppBlockIn,
   githubBalanceFileName,
   githubIdentityRef,
   signGithubAppJwt,
@@ -195,6 +196,11 @@ export {
   type GithubIdentityRouterOptions,
   type GithubInstallationLookup,
 } from "./app-credential.js";
+
+export {
+  createGithubAppBalanceTransport,
+  mintGithubInstallationToken,
+} from "./app-balance.js";
 
 export {
   githubCoveragePath,


### PR DESCRIPTION
Closes the gap the red-dev team reported. Their four findings were all correct; the root cause is one layer deeper than "the writer is not wired".

## What was broken

A host declaring a GitHub App had **two payers and one measurement**. The daemon is the only process that writes the balance surfaces, and it asked exclusively on the operator's token:

- `balance.toon` held the person's ceiling
- every `balance-history.toonl` row was stamped `pat`
- `balance-app-<installation>.toon` — named in the contract, exercised only by tests — was written by nobody

Meanwhile the App's bucket was spent entirely by *other* processes. An installation carrying thousands of reads an hour appeared on no surface at all, and a consumer plotting the machine saw one sawtooth and believed it was the whole story.

## Why renaming a file would not have fixed it

`githubBalanceFileName` having no production caller is the symptom. The cause is that **whoever writes the balance did not know the App, and whoever knew the App wrote no balance**: App routing lives in the dev runtime's client (per repository, where the App actually spends), while measurement lives in the host daemon — which had zero references to `github_app`, `GithubAppCredential`, or `resolveGithubAppCredential`.

## What changed

The daemon reads the `github_app` block from the host policy file and measures that ceiling beside the operator's, on the App's own installation token — **minted per ask**, because a token that lives an hour and is used rarely goes stale exactly when nobody is watching.

Each payer writes its **own snapshot**; both write into the **one history lane, labelled**. Two buckets summed into one document would have to pick an owner, and the last writer would become the displayed truth for a ceiling the next request may not draw from.

**Here the App is a payer to MEASURE, never a credential the daemon acts as.** It authenticates no write and routes no read. A misdeclared block answers `null` rather than refusing to boot — the dev runtime refuses loudly where a silent fallback would restore the shared personal bucket, but a daemon that would not serve a host over an optional number trades the machine for a graph.

The dev runtime's spend ledger gained the same stamp: it recorded WHAT was spent and never WHOSE, so a host running both produced one undifferentiated total — a number no ceiling could be checked against.

## Verification

**Live against this machine**, the companion path produces exactly what was missing:

```
files: balance-app-153309957.toon, balance-history.toonl
"…","app:153309957",rest,4542,458,5000,…
"…","app:153309957",graphql,4989,11,5000,…
"…","app:153309957",search,30,0,30,…
```

- `packages/github/app-balance.test.ts` — 8 tests: per-ask minting, enterprise origin, a refused mint, a granted response carrying no token, and the one namer for where the App block lives.
- `apps/redskilled/tests/daemon-measures-both-buckets.test.ts` — 5 tests: the declared block resolves with a home-expanded key path, an absent block leaves today's behaviour untouched, a partial block answers `null` instead of refusing to boot, and the companion carries its own store, history and identity.
- Full typecheck 16/16, repo invariants 202/202.

Both touched files landed **under** the shrink-only size baseline by moving the new code into `apps/redskilled/src/github-companions.ts` rather than raising the ratchet (`cli.ts` 1041 → 1006, `lifecycle.ts` 2511 → 2488).

## Note for the consumers

`balance-history.toonl` already carried the `identity` column before this change and works today — a consumer waiting on `balance-app-*.toon` can read the labelled series now. One trap worth stating: the spend ledger writes an identity only when it is **not** the person, so an absent column means `pat`, never "unknown".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789194842&installation_model_id=20659&pr_number=3807&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3807&signature=45927a6b7443ae9d4a209096ed12880e9c41810a88d7e98d8259bd42d04b354a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->