### PR TITLE
test(redskilled): judge both arms of the balance wiring

### DIFF
--- a/.changeset/serve-balance-wiring-is-testable.md
+++ b/.changeset/serve-balance-wiring-is-testable.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Both arms of the balance wiring are judged, not just the one with an App
+
+The composition of the daemon's balance registration lived as an inline ternary
+inside `serve`, so the arm that matters most could not be tested: a host that
+declares no GitHub App must produce exactly the registration it produced before
+companions existed. That arm is now a named function with a test, and the test
+distinguishes `undefined` from `[]` — an empty companion list would still send
+the poller round a loop for a payer nobody declared.
+
+Salvaged from a duplicate pull request that was closed as superseded; its one
+non-redundant case was this seam.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -48,15 +48,13 @@ import {
 } from "./daemon.js";
 import {
   createGithubAttributionLedger,
-  createGithubBalanceHistory,
-  createGithubBalanceStore,
   DEFAULT_GITHUB_BALANCE_TIMEOUT_MS,
   createTimedGithubFetch,
   createGithubBalanceTransport,
   type GithubAttributionLedger,
   type GithubRateBudget,
 } from "@reddb-io/github";
-import { resolveServeGithubCompanions } from "./github-companions.js";
+import { resolveServeGithubBalanceRegistration } from "./github-companions.js";
 import { createGitHubActivityTransport } from "./repository-activity.js";
 import {
   reclaimRedskilledRuntimeDirs,
@@ -482,22 +480,11 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
     // to its own file, because two buckets summed into one document would make
     // the last writer the displayed truth for a ceiling the next request may
     // not draw from.
-    const hostApp = await readRedskilledHostGithubApp();
-    const githubBalance = resolvedGithubBalance == null
-      ? null
-      : {
-          ...resolvedGithubBalance,
-          // The operator's own ceiling keeps the unsuffixed name and the default
-          // `pat` stamp: this is the floor every surface already renders, and
-          // renaming it would move a file other processes read.
-          store: createGithubBalanceStore({ path: join(hostStateRoot, "github", "balance.toon") }),
-          history: createGithubBalanceHistory({
-            path: join(hostStateRoot, "github", "balance-history.toonl"),
-          }),
-          ...(hostApp === null
-            ? {}
-            : { companions: resolveServeGithubCompanions(hostApp, hostStateRoot) }),
-        };
+    const githubBalance = resolveServeGithubBalanceRegistration(
+      resolvedGithubBalance,
+      await readRedskilledHostGithubApp(),
+      hostStateRoot,
+    );
     // Before this daemon anchors itself, it speaks for whatever the last one
     // could not (slice #3028). The host singleton is the only process guaranteed
     // to boot after a machine freeze, so an un-trap-able death on this lane has

--- a/apps/redskilled/src/github-companions.ts
+++ b/apps/redskilled/src/github-companions.ts
@@ -24,7 +24,10 @@ import {
   githubIdentityRef,
   type GithubAppCredential,
 } from "@reddb-io/github";
-import type { RedskilledBalanceCompanion } from "./daemon/types.js";
+import type {
+  RedskilledBalanceCompanion,
+  RedskilledBalanceRegistration,
+} from "./daemon/types.js";
 
 /**
  * The companions a declared App contributes. One entry today; the shape is a
@@ -75,4 +78,34 @@ export async function measureGithubCompanions(
       // Measured or not, the host keeps serving.
     }
   }
+}
+
+/**
+ * Compose the whole balance registration: the operator's own ceiling, plus a
+ * companion for each declared payer.
+ *
+ * Extracted from `serve` so BOTH arms can be judged. The absent-App arm is the
+ * one that matters most and the one an inline ternary hid: a host that declares
+ * no App must produce a registration byte-identical to the one it produced
+ * before companions existed, or every operator without an App pays for a
+ * feature they did not adopt.
+ */
+export function resolveServeGithubBalanceRegistration(
+  resolved: { readonly transport: RedskilledBalanceRegistration["transport"] } | null,
+  app: GithubAppCredential | null,
+  hostStateRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): RedskilledBalanceRegistration | null {
+  if (resolved === null) return null;
+  return {
+    ...resolved,
+    // The operator's own ceiling keeps the unsuffixed name and the default
+    // `pat` stamp: this is the floor every surface already renders, and
+    // renaming it would move a file other processes read.
+    store: createGithubBalanceStore({ path: join(hostStateRoot, "github", "balance.toon") }),
+    history: createGithubBalanceHistory({
+      path: join(hostStateRoot, "github", "balance-history.toonl"),
+    }),
+    ...(app === null ? {} : { companions: resolveServeGithubCompanions(app, hostStateRoot, env) }),
+  };
 }

--- a/apps/redskilled/tests/daemon-measures-both-buckets.test.ts
+++ b/apps/redskilled/tests/daemon-measures-both-buckets.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { resolveServeGithubCompanions } from "../src/github-companions.js";
+import {
+  resolveServeGithubBalanceRegistration,
+  resolveServeGithubCompanions,
+} from "../src/github-companions.js";
 import { readRedskilledHostGithubApp } from "../src/host-config.js";
 
 /**
@@ -86,5 +89,32 @@ describe("two buckets are measured apart", () => {
     // consumer plotting the machine separates them by identity rather than by
     // guessing which file was current.
     expect(companion?.identity).toBe("app:153309957");
+  });
+});
+
+describe("a host that declares no App pays for nothing it did not adopt", () => {
+  const transport = async () => ({});
+  const app = { appId: "4575633", installationId: "153309957", privateKeyPath: "/k.pem" };
+
+  it("declares one companion when the host declares an App", () => {
+    const registration = resolveServeGithubBalanceRegistration({ transport }, app, "/state", {});
+
+    expect(registration?.companions?.map((c) => c.identity)).toEqual(["app:153309957"]);
+  });
+
+  it("declares NO companions when it does not", () => {
+    // The arm that matters most, and the one an inline ternary hid: a host with
+    // no App must produce the registration it produced before companions
+    // existed. `undefined` and `[]` are not the same answer — an empty array
+    // would still send the poller round a loop for a payer nobody declared.
+    const registration = resolveServeGithubBalanceRegistration({ transport }, null, "/state", {});
+
+    expect(registration?.companions).toBeUndefined();
+    expect(registration?.store).toBeDefined();
+    expect(registration?.history).toBeDefined();
+  });
+
+  it("answers null when there is no credential to ask with at all", () => {
+    expect(resolveServeGithubBalanceRegistration(null, app, "/state", {})).toBeNull();
   });
 });


### PR DESCRIPTION
## What this closes

The composition of the daemon's balance registration lived as an inline ternary inside `serve`:

```ts
...(hostApp === null ? {} : { companions: resolveServeGithubCompanions(hostApp, hostStateRoot) }),
```

So the arm that matters most could not be tested. **A host declaring no GitHub App must produce exactly the registration it produced before companions existed** — and that is the common case, the one every operator without an App runs, and the one no test watched.

It is now `resolveServeGithubBalanceRegistration`, with tests for all three outcomes: an App declared (one companion, named `app:153309957`), no App (**`companions` absent**, store and history still present), and no credential at all (null).

The `undefined` vs `[]` distinction is deliberate and asserted — an empty companion list would still send the balance poller round a loop for a payer nobody declared.

## Provenance

Salvaged from PR #3806, which duplicated the already-merged #3807 and was closed as superseded. Three of its four test cases were already covered by #3807; this seam was the one that was not. It lands in the existing suite beside its siblings rather than in a file of its own.

`apps/redskilled/src/cli.ts` also loses two now-unused imports and drops to 993 lines.

## Verification

`daemon-measures-both-buckets` 8/8, full typecheck 16/16, repo invariants 202/202.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789216554&installation_model_id=20659&pr_number=3812&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3812&signature=5f6d6dbe6d2c350e590f31e80b7d55b41a2fce24be349f24a824f4e1a1ccde39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->