### PR TITLE
fix(dev): leave the argv tier in the comment reader, delete a promotion that never fired

### DIFF
--- a/.changeset/comments-argv-and-dead-promotion.md
+++ b/.changeset/comments-argv-and-dead-promotion.md
@@ -1,0 +1,28 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The comment reads leave the argv tier, and a promotion that never fired is deleted
+
+Three `gh api … --paginate --jq` sites survived in the comment reader — the same
+tier whose sibling took the whole sweep down when a flag combination the `gh`
+binary refuses shipped inside it. Two of the three had no production callers at
+all and are removed rather than migrated; the one real reader now paginates
+through the shared client.
+
+That reader decides whether a comment is CREATED or UPDATED, so it keeps its
+discriminated result: a transport failure answers `{ok:false}` with the thrown
+message, never a successful empty list. Degrading the two would post a duplicate
+comment on every outage. It also takes its own cache namespace — four readers
+share that route, and an idempotency check must not decide from a body another
+reader cached.
+
+A per-comment trust promotion goes with them. A maintainer's 👍 on one comment
+promoted that comment alone, precedence rule 4 of 5 in the source-trust
+taxonomy. It never fired in production: the field it read was supplied by no
+reader in the repository, and the REST payload carries reaction COUNTS without
+the reacting logins. Restoring the capability needs a per-comment
+`…/comments/{id}/reactions` read — an N+1 on a client that exists to conserve
+budget — which is a decision to take deliberately rather than a field to leave
+dangling. The rule, its input, and its dead readers are removed, and a test now
+pins the deletion instead of pinning the gap.

--- a/apps/dev/src/core/source-trust.ts
+++ b/apps/dev/src/core/source-trust.ts
@@ -60,10 +60,6 @@ export interface SourceTrustInput {
    * honour the allowlist / write-access / CODEOWNERS overrides for an author whose
    * association alone does not qualify. */
   trustVerdict?: ActorTrustVerdict;
-  /** True when a maintainer applied 👍 to this specific comment. This is a
-   * per-comment promotion signal; it does not change the author's default trust
-   * on any other comment. */
-  maintainerThumbsUp?: boolean;
 }
 
 /**
@@ -72,11 +68,18 @@ export interface SourceTrustInput {
  *   2. author association OWNER/MEMBER/COLLABORATOR → trusted
  *   3. a POSITIVE trust-gate override (allowlist /
  *      write-access / codeowners)                  → trusted
- *   4. maintainer 👍 on this comment               → trusted
- *   5. everything else                             → dubious
+ *   4. everything else                             → dubious
  *
  * Note `permissive-default` never promotes: the guidance channel requires a
  * positive source signal, not the absence of one.
+ *
+ * A fifth rule used to sit at position 4: a maintainer's 👍 on one comment
+ * promoted that comment alone. It never fired. The field it keyed on was
+ * supplied by no reader in the repository — not the jq projection it was written
+ * for, and not the REST payload, which carries reaction COUNTS without the
+ * reacting logins. Restoring it needs a per-comment
+ * `…/comments/{id}/reactions` read, which is an N+1 on a budget-aware client;
+ * that is a decision to take deliberately, not a field to leave dangling.
  */
 export function classifySourceTrust(input: SourceTrustInput): SourceTrustLevel {
   if (input.isBot) return "automation";
@@ -88,8 +91,6 @@ export function classifySourceTrust(input: SourceTrustInput): SourceTrustLevel {
   if (verdict?.executable && verdict.basis !== undefined && TRUSTED_BASES.has(verdict.basis)) {
     return "trusted";
   }
-
-  if (input.maintainerThumbsUp) return "trusted";
 
   return "dubious";
 }

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -34,7 +34,7 @@ export {
 } from "./gh/issues.js";
 export type { DependencyEdgeTicketRow, DependencyEdgeTicketScan } from "./gh/issues.js";
 export type { CommentTrustResolver } from "./gh/comments.js";
-export { issueComments, readIssueComments, prComments, prReviewComments } from "./gh/comments.js";
+export { issueComments, readIssueComments } from "./gh/comments.js";
 export type { StatuslineQueueCounts } from "./gh/queue.js";
 export {
   queueVisibilityProbeInput,

--- a/apps/dev/src/runtime/gh/comments.ts
+++ b/apps/dev/src/runtime/gh/comments.ts
@@ -1,13 +1,7 @@
 import type { HandoffComment } from "../../core/handoff.js";
 import { classifySourceTrust, TRUSTED_ASSOCIATIONS, type SourceTrustLevel } from "../../core/source-trust.js";
 import type { ActorTrustVerdict } from "../../core/trust-gate.js";
-import {
-  apiPath,
-  githubReadClient,
-  githubRepo,
-  runGithubRestRead,
-  type GhContext,
-} from "./common.js";
+import { githubReadClient, githubRepo, type GhContext } from "./common.js";
 
 export type CommentTrustResolver = (actor: string) => Promise<ActorTrustVerdict>;
 
@@ -17,10 +11,6 @@ interface RawGhComment {
   author?: { login?: string; is_bot?: boolean };
   authorAssociation?: string;
   createdAt?: string;
-  reactionGroups?: Array<{
-    content?: string;
-    users?: { nodes?: Array<{ login?: string }> };
-  }>;
 }
 
 export interface IssueCommentForUpdate {
@@ -35,48 +25,13 @@ export type IssueCommentsReadResult =
   | { ok: true; comments: IssueCommentForUpdate[] }
   | { ok: false; reason: string };
 
-function parseJsonLines(stdout: string): unknown[] {
-  const out: unknown[] = [];
-  for (const line of stdout.split("\n")) {
-    const t = line.trim();
-    if (!t) continue;
-    try {
-      out.push(JSON.parse(t));
-    } catch {
-      // tolerate malformed jq lines; callers degrade to the valid subset.
-    }
-  }
-  return out;
-}
-
-function thumbsUpReactors(comment: RawGhComment): string[] {
-  const reactors: string[] = [];
-  for (const group of comment.reactionGroups ?? []) {
-    if (String(group.content ?? "").toUpperCase() !== "THUMBS_UP") continue;
-    for (const node of group.users?.nodes ?? []) {
-      const login = String(node.login ?? "").trim();
-      if (login) reactors.push(login);
-    }
-  }
-  return reactors;
-}
-
-function isMaintainerThumbsUp(verdict: ActorTrustVerdict | undefined): boolean {
-  return (
-    verdict?.executable === true &&
-    (verdict.basis === "write-access" || verdict.basis === "codeowners")
-  );
-}
-
 /** Project GitHub comments to handoff comments with the source-trust taxonomy.
  * Bot authors resolve to `automation` and OWNER/MEMBER/COLLABORATOR associations
  * to `trusted` from the projection alone; every other author is resolved through
  * the injected `resolveTrust` primitive so allowlist / write-access / CODEOWNERS
- * overrides still promote. A maintainer's THUMBS_UP reaction promotes only the
- * reacted comment; it does not change the author's trust on sibling comments.
- * Results are memoised per login within the call. When `resolveTrust` is omitted
- * the level is decided from association + bot status only (a non-collaborator
- * falls to `dubious`, and reaction promotion is unavailable). */
+ * overrides still promote. Results are memoised per login within the call. When
+ * `resolveTrust` is omitted the level is decided from association + bot status
+ * only, so a non-collaborator falls to `dubious`. */
 async function projectComments(
   raw: readonly RawGhComment[],
   resolveTrust?: CommentTrustResolver,
@@ -105,19 +60,11 @@ async function projectComments(
     // otherwise-dubious human author is resolved through the trust primitive.
     const associationTrusted = TRUSTED_ASSOCIATIONS.has((authorAssociation ?? "").trim().toUpperCase());
     const trustVerdict = isBot || associationTrusted ? undefined : await resolveVerdict(login);
-    const maintainerThumbsUp = (
-      await Promise.all(thumbsUpReactors(c).map((actor) => resolveVerdict(actor)))
-    ).some(isMaintainerThumbsUp);
     out.push({
       body: String(c.body ?? ""),
       author: login,
       createdAt: c.createdAt ? String(c.createdAt) : undefined,
-      sourceTrust: classifySourceTrust({
-        authorAssociation,
-        isBot,
-        trustVerdict,
-        maintainerThumbsUp,
-      }),
+      sourceTrust: classifySourceTrust({ authorAssociation, isBot, trustVerdict }),
     });
   }
   return out;
@@ -175,77 +122,55 @@ interface RestIssueComment {
   readonly created_at?: string;
 }
 
-function restCommentJq(): string {
-  return '.[] | {body: .body, author: {login: .user.login, is_bot: (.user.type == "Bot")}, authorAssociation: .author_association, createdAt: .created_at}';
+/** The REST shape this reader needs: the handoff fields plus the numeric id. */
+interface RestIssueCommentWithId extends RestIssueComment {
+  readonly id?: number;
 }
 
-function restCommentWithIdJq(): string {
-  return '.[] | {id: .id, body: .body, author: {login: .user.login, is_bot: (.user.type == "Bot")}, authorAssociation: .author_association, createdAt: .created_at}';
-}
-
-function parseStrictCommentJsonLines(stdout: string): RawGhComment[] | undefined {
-  const out: RawGhComment[] = [];
-  for (const line of stdout.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      const parsed = JSON.parse(trimmed) as RawGhComment;
-      if (!Number.isFinite(Number(parsed.id))) return undefined;
-      out.push(parsed);
-    } catch {
-      return undefined;
-    }
-  }
-  return out;
-}
-
-/** REST-backed issue comments for mutation-sensitive idempotency checks. Unlike
- * issueComments(), this preserves the numeric REST id and reports read/parse
- * failure separately from a successful empty list. */
+/**
+ * REST-backed issue comments for mutation-sensitive idempotency checks.
+ *
+ * Unlike `issueComments`, this preserves the numeric REST id and reports a read
+ * failure SEPARATELY from a successful empty list. The distinction is the whole
+ * point: the caller decides from this answer whether to CREATE a comment or
+ * UPDATE one, so degrading a transport failure to "no comments" would post a
+ * duplicate on every outage.
+ */
 export async function readIssueComments(
   ctx: GhContext,
   issue: number,
 ): Promise<IssueCommentsReadResult> {
-  const r = await runGithubRestRead(ctx, apiPath(ctx, `issues/${issue}/comments`), ["--paginate", "--jq", restCommentWithIdJq()]);
-  if (r.code !== 0) return { ok: false, reason: `failed to read issue comments (gh exit ${r.code})` };
-  const raw = parseStrictCommentJsonLines(r.stdout ?? "");
-  if (!raw) return { ok: false, reason: "failed to parse issue comments JSON" };
+  const repo = githubRepo(ctx);
+  if (!repo) return { ok: false, reason: "reading issue comments needs an owner/repository slug" };
+  let rows: readonly RestIssueCommentWithId[];
+  try {
+    const answer = await githubReadClient(ctx).conditionalPaginate<RestIssueCommentWithId>({
+      // Its OWN cache namespace. Four readers already share this route, and an
+      // idempotency check must never decide from a body another reader cached.
+      cacheKey: `gh:comments-for-update:${repo.owner}/${repo.repo}:${issue}`,
+      route: "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+      parameters: { ...repo, issue_number: issue, per_page: 100 },
+      operation: { key: "issue comments", budget: "rest" },
+      actor: "dev:comments-for-update",
+    });
+    rows = answer.data;
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) };
+  }
+  if (rows.some((row) => !Number.isFinite(Number(row.id)))) {
+    return { ok: false, reason: "an issue comment carried no numeric id" };
+  }
   return {
     ok: true,
-    comments: raw.map((comment) => ({
-      id: Number(comment.id),
-      body: String(comment.body ?? ""),
-      author: comment.author?.login ? String(comment.author.login) : undefined,
-      createdAt: comment.createdAt ? String(comment.createdAt) : undefined,
+    comments: rows.map((row) => ({
+      id: Number(row.id),
+      body: String(row.body ?? ""),
+      author: row.user?.login ? String(row.user.login) : undefined,
+      createdAt: row.created_at ? String(row.created_at) : undefined,
       sourceTrust: classifySourceTrust({
-        authorAssociation: comment.authorAssociation,
-        isBot: comment.author?.is_bot === true,
+        authorAssociation: row.author_association,
+        isBot: row.user?.type === "Bot",
       }),
     })),
   };
-}
-
-/** PR top-level comments use GitHub's issue-comment API. Project them with the
- * exact same source-trust rule as issue comments so only trusted-source
- * directives can become authoritative guidance. */
-export async function prComments(
-  ctx: GhContext,
-  pr: number,
-  resolveTrust?: CommentTrustResolver,
-): Promise<HandoffComment[]> {
-  const r = await runGithubRestRead(ctx, apiPath(ctx, `issues/${pr}/comments`), ["--paginate", "--jq", restCommentJq()]);
-  if (r.code !== 0) return [];
-  return projectComments(parseJsonLines(r.stdout) as RawGhComment[], resolveTrust);
-}
-
-/** PR review comments use a separate pull-review-comment API but share the same
- * source-trust projection as issue and PR comments. */
-export async function prReviewComments(
-  ctx: GhContext,
-  pr: number,
-  resolveTrust?: CommentTrustResolver,
-): Promise<HandoffComment[]> {
-  const r = await runGithubRestRead(ctx, apiPath(ctx, `pulls/${pr}/comments`), ["--paginate", "--jq", restCommentJq()]);
-  if (r.code !== 0) return [];
-  return projectComments(parseJsonLines(r.stdout) as RawGhComment[], resolveTrust);
 }

--- a/apps/dev/tests/gh-export-surface.test.ts
+++ b/apps/dev/tests/gh-export-surface.test.ts
@@ -58,8 +58,6 @@ const EXPECTED_GH_EXPORTS = [
   "listUnblockCandidates",
   "orphanState",
   "postClaimComment",
-  "prComments",
-  "prReviewComments",
   "queueVisibilityProbeInput",
   "readIssueBody",
   "readIssueComments",

--- a/apps/dev/tests/gh-issue-comments-trust.test.ts
+++ b/apps/dev/tests/gh-issue-comments-trust.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { issueComments, prComments, prReviewComments, type GhContext } from "../src/runtime/gh.js";
+import { issueComments, type GhContext } from "../src/runtime/gh.js";
+import { classifySourceTrust } from "../src/core/source-trust.js";
 import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
 import type { ActorTrustVerdict } from "../src/core/trust-gate.js";
 
@@ -65,28 +66,16 @@ describe("issueComments — source-trust projection (#1100)", () => {
     expect(out[4]).toMatchObject({ author: "trusted-ext", sourceTrust: "trusted" });
   });
 
-  it("cannot promote an outside comment on a reaction this read does not carry", async () => {
-    // `projectComments` reads `reactionGroups` to promote a stranger whose
-    // suggestion a maintainer thumbed up. NOTHING supplies that field: neither
-    // the refused jq pipeline this read used to build, nor `restCommentJq`, and
-    // the REST comment list carries reaction COUNTS rather than the reacting
-    // logins. The promotion therefore never fired in production — this fixture
-    // used to hand the field in directly and so pinned a behaviour the shipped
-    // command could not reach. The gap is stated here rather than simulated,
-    // and closing it needs its own read (`…/comments/{id}/reactions`).
-    const comments = JSON.stringify([
-      restComment("useful outside suggestion", "stranger", "NONE"),
-      restComment("second outside suggestion", "stranger", "NONE"),
-    ]);
-    const resolveTrust = async (actor: string): Promise<ActorTrustVerdict> =>
-      actor === "maintainer"
-        ? { executable: true, basis: "write-access" }
-        : { executable: false, reason: "not a maintainer" };
-
-    const out = await issueComments(ghReturning(comments), 7, resolveTrust);
-
-    expect(out[0]).toMatchObject({ author: "stranger", sourceTrust: "dubious" });
-    expect(out[1]).toMatchObject({ author: "stranger", sourceTrust: "dubious" });
+  it("does not promote an outside comment on a reaction — that rule is gone", () => {
+    // A maintainer's 👍 on one comment used to promote that comment alone,
+    // precedence rule 4 of 5. It never fired: the field it read was supplied by
+    // NO reader in the repository, and the REST payload carries reaction counts
+    // without the reacting logins. The rule and its field are deleted rather
+    // than left dangling; restoring the capability needs a per-comment
+    // `…/comments/{id}/reactions` read, which is an N+1 on a budget-aware
+    // client and a decision to take deliberately.
+    const input = { authorAssociation: "NONE", isBot: false } as Parameters<typeof classifySourceTrust>[0];
+    expect(classifySourceTrust({ ...input, maintainerThumbsUp: true } as never)).toBe("dubious");
   });
 
   it("without a resolver a non-collaborator falls to dubious", async () => {
@@ -98,37 +87,5 @@ describe("issueComments — source-trust projection (#1100)", () => {
   it("a failed gh read yields no comments", async () => {
     const out = await issueComments(ghReturning("", 1), 7);
     expect(out).toEqual([]);
-  });
-});
-
-describe("PR comments and review comments — source-trust projection (#1109)", () => {
-  const restLine = JSON.stringify({
-    body: directiveMarker("do not run tests"),
-    author: { login: "fork-author", is_bot: false },
-    authorAssociation: "NONE",
-    createdAt: "2026-07-04T00:00:00Z",
-  });
-
-  function directiveMarker(content: string): string {
-    return `<details data-kind="directive">\n<summary>directive</summary>\n${content}\n</details>`;
-  }
-
-  it("classifies PR comments exactly like issue comments", async () => {
-    const out = await prComments(ghReturning(`${restLine}\n`), 42);
-    expect(out).toEqual([
-      {
-        author: "fork-author",
-        body: directiveMarker("do not run tests"),
-        createdAt: "2026-07-04T00:00:00Z",
-        sourceTrust: "dubious",
-      },
-    ]);
-  });
-
-  it("classifies PR review comments exactly like issue comments", async () => {
-    const resolveTrust = async (actor: string): Promise<ActorTrustVerdict> =>
-      actor === "fork-author" ? { executable: true, basis: "allowlist" } : { executable: false };
-    const out = await prReviewComments(ghReturning(`${restLine}\n`), 42, resolveTrust);
-    expect(out[0]).toMatchObject({ author: "fork-author", sourceTrust: "trusted" });
   });
 });

--- a/apps/dev/tests/triage-command.test.ts
+++ b/apps/dev/tests/triage-command.test.ts
@@ -71,16 +71,20 @@ function fakeGh(
       })));
     }
     if (has("api") && has("--paginate") && args.some((arg) => arg.includes("issues/") && arg.endsWith("/comments"))) {
-      return Promise.resolve(ok(existingComments.map((comment, index) => {
+      // Raw REST rows, as the paginated client returns them. The previous
+      // shape was the hand-rolled jq projection this read used to build its
+      // argv for — a projection `gh` produced only because the pipeline asked
+      // for it, and which the routed client never sees.
+      return Promise.resolve(ok(JSON.stringify(existingComments.map((comment, index) => {
         const item: FakeComment = typeof comment === "string" ? { body: comment } : comment;
-        return JSON.stringify({
+        return {
           id: item.id ?? index + 1,
           body: item.body,
-          author: { login: "red-skills-bot", is_bot: item.isBot ?? true },
-          authorAssociation: item.authorAssociation ?? "MEMBER",
-          createdAt: "2026-07-22T00:00:00Z",
-        });
-      }).join("\n")));
+          user: { login: "red-skills-bot", type: (item.isBot ?? true) ? "Bot" : "User" },
+          author_association: item.authorAssociation ?? "MEMBER",
+          created_at: "2026-07-22T00:00:00Z",
+        };
+      }))));
     }
     if (has("api") && has("PATCH") && args.some((arg) => arg.includes("issues/comments/"))) {
       const idArg = args.find((arg) => arg.includes("issues/comments/")) ?? "";


### PR DESCRIPTION
Closes defects #4 and #5 of the seven-defect plan. They live in one file, so they land as one change.

## Not three migrations — one, plus two deletions

| function | production callers |
| --- | --- |
| `readIssueComments` | **one** — the triage idempotency check |
| `prComments` | **none** |
| `prReviewComments` | **none** |

The two dead ones were held alive only by name pins in `gh-export-surface.test.ts`. Removing them also removes the jq builders and line parsers that existed for them alone — and the need for a `pulls/{n}/comments` branch in the injected test client, which a migration would have required.

## The one real migration keeps its discriminated result

`readIssueComments` decides whether a comment is **created or updated**. `conditionalPaginate` throws where the argv returned an exit code, so the catch rebuilds `{ok:false}` with the thrown message.

**Collapsing that into an empty list would post a duplicate comment on every transport failure** — the same silent-degradation shape this file's other reader was fixed for two days ago.

It also takes its own cache namespace: four readers now share `GET /repos/{owner}/{repo}/issues/{issue_number}/comments`, and an idempotency check must not decide from a body another reader cached.

## The 👍 promotion is deleted, not repaired

It was precedence rule 4 of 5 in the source-trust taxonomy: an outside contributor's one comment promoted because a maintainer with write-access or CODEOWNERS reacted to it.

**It has never once run.** Nothing in the repository produces `reactionGroups` — not the jq projection it was written for, not `restCommentJq`, and not the REST payload, which carries reaction *counts* without the reacting logins.

Making it real needs `GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions` **per comment** — an N+1 on a client whose whole purpose is conserving budget. That is a decision to take deliberately; a field nobody fills is not a feature.

Maintainer decision on this was taken before the work started: delete.

The test that pinned the *gap* now pins the *deletion*, and names what closing it would cost.

## Verification

`gh-issue-comments-trust` 5/5, `triage-command` 13/13, `gh-export-surface` 2/2, `handoff` + `source-trust` green (94 across the five suites), full typecheck 16/16, repo invariants 202/202.

`triage-command.test.ts`'s fixture moves from the hand-rolled jq projection to raw REST rows — as written it would have thrown, which is exactly how the sibling defect stayed hidden.

`comments.ts` drops from 252 to 176 lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789217210&installation_model_id=20659&pr_number=3813&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3813&signature=ac14c09b32559d7f65a472c256dfa7a230e93ec2d5286c8d638c0c54ed946062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->