### PR TITLE
fix(dev): a dead Worker's empty lane is no longer immortal

### DIFF
--- a/.changeset/worker-lane-drains.md
+++ b/.changeset/worker-lane-drains.md
@@ -1,0 +1,26 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A dead Worker's empty lane is no longer immortal
+
+The worker-directory janitor asked two questions of every lane — is every
+represented issue closed, and has an open-issue lane outlived its TTL — and both
+gate on the lane having at least one parseable issue child. A lane with none
+answered `false` to both and was spared at ANY age, forever.
+
+That is the common end state, not an edge case: a Worker whose workspaces were
+already reclaimed, or that died before claiming anything, keeps only its log and
+its pid file. Seventy-six such lanes were being reported as workers on one host
+while this sweep ran every five minutes and freed none of them.
+
+An aged, empty lane whose Worker the daemon calls dead is now reclaimed on the
+same 45-day TTL an open-issue lane already uses. Two things are deliberately
+unchanged: a FRESH empty lane is still spared, because a Worker that has just
+died still owns evidence somebody may be reading, and a lane the daemon cannot
+answer for is still spared at any age — only a fresh `dead` verdict releases
+one, never the absence of a pid file.
+
+This bounds the growth rather than shrinking it today: on a host measured while
+writing this, all twenty empty lanes were hours old, so none was yet eligible.
+The defect was that they would never have become eligible at all.

--- a/apps/dev/src/core/tmp-janitor.ts
+++ b/apps/dev/src/core/tmp-janitor.ts
@@ -312,7 +312,24 @@ export function planWorkerDirJanitor(
       everyIssueKnown &&
       anyIssueOpen &&
       nowS - entry.mtimeS >= DEAD_WORKER_DIR_TTL_S;
-    if (entry.liveness === "dead" && (everyIssueClosed || openIssueTtlExpired)) {
+    // The CORPSE case, and the one that made this lane grow without bound: a
+    // dead Worker whose directory holds no parseable issue child at all —
+    // because its workspaces were already reclaimed, or because it died before
+    // claiming anything. Both predicates above gate on `issues.length > 0`, so
+    // such a lane answered `false` to every question and fell to `spare` at ANY
+    // age, forever. Seventy-six of them were reported as workers on this host
+    // while the sweep ran every five minutes and freed none.
+    //
+    // It is held to the same TTL as an open-issue lane rather than removed on
+    // sight: a Worker that has just died still owns evidence somebody may be
+    // reading, and `liveness === "dead"` is the daemon's fresh answer, never a
+    // missing pid file (#2679).
+    const emptyLaneTtlExpired =
+      issues.length === 0 && nowS - entry.mtimeS >= DEAD_WORKER_DIR_TTL_S;
+    if (
+      entry.liveness === "dead" &&
+      (everyIssueClosed || openIssueTtlExpired || emptyLaneTtlExpired)
+    ) {
       reclaim.push(entry);
     } else {
       spare.push(entry);

--- a/apps/dev/tests/tmp-janitor.test.ts
+++ b/apps/dev/tests/tmp-janitor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { DEAD_WORKER_DIR_TTL_S } from "../src/core/reclaim.js";
 import {
   auditTmpRoot,
   DIAGNOSTICS_TTL_S,
@@ -213,8 +214,28 @@ describe("planWorkerDirJanitor", () => {
     expect(planWorkerDirJanitor([open, unknown], NOW)).toEqual({ reclaim: [], spare: [open, unknown] });
   });
 
-  it("spares dead worker dirs with no issue-bearing attempts", () => {
+  it("spares a FRESH dead worker dir with no issue-bearing attempts", () => {
+    // Spared for its AGE, not for its emptiness: a Worker that has just died
+    // still owns evidence somebody may be reading.
     const entry = worker({ issues: [] });
+    expect(planWorkerDirJanitor([entry], NOW)).toEqual({ reclaim: [], spare: [entry] });
+  });
+
+  it("reclaims an AGED dead worker dir with no issue-bearing attempts", () => {
+    // The corpse case, and the one that made this lane grow without bound.
+    // `everyIssueClosed` and `everyIssueKnown` both gate on `issues.length > 0`,
+    // so a lane whose workspaces were already reclaimed — or that died before
+    // claiming anything — answered `false` to every question and was spared at
+    // ANY age, forever. Seventy-six of them were reported as workers on one host
+    // while this sweep ran every five minutes and freed none of them.
+    const entry = worker({ issues: [], mtimeS: NOW - DEAD_WORKER_DIR_TTL_S });
+    expect(planWorkerDirJanitor([entry], NOW)).toEqual({ reclaim: [entry], spare: [] });
+  });
+
+  it("still spares an aged EMPTY lane the daemon cannot answer for", () => {
+    // Age never overrides an unreachable authority: only a fresh `dead` verdict
+    // releases a lane, never the absence of one (#2679).
+    const entry = worker({ issues: [], liveness: "unknown", mtimeS: NOW - DEAD_WORKER_DIR_TTL_S });
     expect(planWorkerDirJanitor([entry], NOW)).toEqual({ reclaim: [], spare: [entry] });
   });
 


### PR DESCRIPTION
Defect #6 of the seven-defect plan.

## The hole

`planWorkerDirJanitor` asks two questions, and **both gate on `issues.length > 0`**:

```ts
const everyIssueClosed = issues.length > 0 && issues.every(i => i.state === "CLOSED");
const everyIssueKnown  = issues.length > 0 && issues.every(i => i.state !== "UNKNOWN");
```

A lane with no parseable issue child answers `false` to both — so `openIssueTtlExpired` is `false` too — and falls to `spare` **at any age, forever**.

That is the common end state, not an edge case: a Worker whose workspaces were already reclaimed, or that died before claiming anything, keeps only `worker.log.toonl` and its pid file.

It is the decisive hole of three. The shell reaper (`reapDeadEmptyWorkerShells`) skips any lane holding a log; the artifact planner files that log as permanent `evidence`. **76 such lanes were reported as workers on one host while this sweep ran every five minutes and freed none.**

## The fix, and the two refusals kept on purpose

An aged empty lane whose Worker the daemon calls **dead** is reclaimed on the same 45-day TTL an open-issue lane already uses. Both of these stay, and are tested:

- **A fresh empty lane is still spared** — a Worker that has just died still owns evidence somebody may be reading, and `/redskilled <issue>` reads exactly that log.
- **A lane the daemon cannot answer for is still spared at any age.** Only a fresh `dead` verdict releases one, never a missing pid file — keying on absence is what deleted a live lane and kept the dead ones (#2679).

The existing empty-lane test is kept and renamed to say what it actually pins: spared for its **age**, not for its emptiness.

## Scope note — the number matters

**This bounds the growth; it does not shrink it today.** Measured on the host while writing this: 34 lanes, 20 of them empty, and every one of those **hours old**. None was yet eligible.

The defect was never that old lanes lingered — it was that none would *ever* have become eligible.

## Correction to the plan

The plan assumed no timer ran this sweep. That was wrong: the MCP resident runs `buildProjectBootSweeps` every five minutes and reaches the janitor. The schedule was never missing — which is precisely why the predicate hole was invisible. The sweep ran, and freed nothing.

## Verification

`tmp-janitor` 54/54 (two new cases: aged-empty reclaimed, aged-empty-but-unknown still spared), full typecheck 16/16, repo invariants 202/202.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789217754&installation_model_id=20659&pr_number=3814&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3814&signature=fe37455761b493246e4b11e5f7d6a0ec7c8c01b77f6d834dcc849e3c032bb77c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->