### PR TITLE
fix(redskilled): the installed unit points somewhere durable

### DIFF
--- a/.changeset/installed-unit-is-durable.md
+++ b/.changeset/installed-unit-is-durable.md
@@ -1,0 +1,21 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+An installed daemon unit points somewhere durable
+
+The operator-facing install runs through `npx`, which hands the daemon an entry
+inside `~/.npm/_npx/<hash>/` — a directory npm prunes on its own schedule. The
+installed unit named that path, so a pruned cache leaves a daemon that cannot
+start, discovered after a reboot when nobody is watching.
+
+The stabilizer that copies such a bundle into `~/.red/redskilled/bundles/`
+already existed. What it lacked was the one argument that lets it name a
+destination: the version. It infers one from the bundle's filename, and an npx
+dispatch always delivers the UNVERSIONED asset name, so it declined every time
+and the raw cache path flowed into `ExecStart`. Both install paths now state the
+version from the build stamp they already read.
+
+A genuinely unversioned local build is still used as resolved. Durability is an
+upgrade, never a precondition — copying a developer's own daemon out from under
+them mid-session would be the worse failure.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -742,7 +742,7 @@ export async function runUnit(
     return 0;
   }
   if (action === "install") {
-    const installed = await installRedskilledUnit(planRedskilledUnit(paths), io.unitIO ?? {});
+    const installed = await installRedskilledUnit(planRedskilledUnit(paths, { version: readBuildInfo("redskilled").version }), io.unitIO ?? {});
     write(`${JSON.stringify(installed, null, 2)}\n`);
     return installed.installed ? 0 : 1;
   }
@@ -834,7 +834,13 @@ export async function runProvision(
   // cache, so its ExecStart points at the daemon-home copy when the resolved
   // bundle's name states its version; anything else installs as resolved.
   const unitEntry = isResolvedRedskilledEntry(facts.entry)
-    ? stabilizeRedskilledEntry(facts.entry, { homeDir })
+    // Same reason as `planRedskilledUnit`: the version comes from the build
+    // stamp because an npx-resolved entry carries none in its name, and a unit
+    // pointing into a prunable cache is a daemon that stops starting.
+    ? stabilizeRedskilledEntry(facts.entry, {
+        homeDir,
+        version: readBuildInfo("redskilled").version,
+      })
     : undefined;
   const unit = values["install-unit"] && unitEntry != null
     ? await installRedskilledUserUnit({

--- a/apps/redskilled/src/supervision.ts
+++ b/apps/redskilled/src/supervision.ts
@@ -77,6 +77,17 @@ export interface PlanRedskilledUnitOptions {
   /** Where to look for the published bundle when no command is stated. */
   readonly entryLookup?: RedskilledEntryLookup;
   readonly idleMs?: number;
+  /**
+   * The version this daemon IS, so a cache-resident bundle can be copied
+   * somewhere durable before the unit names it.
+   *
+   * Absent, `stabilizeRedskilledEntry` cannot name a destination and returns
+   * the entry untouched — which is correct for a local build and wrong for the
+   * npx dispatch, because npx always delivers the UNVERSIONED asset name. That
+   * is how an installed unit came to point inside `~/.npm/_npx/`, a directory
+   * npm may prune, leaving a daemon that cannot start.
+   */
+  readonly version?: string;
 }
 
 /**
@@ -91,13 +102,18 @@ export function planRedskilledUnit(
   options: PlanRedskilledUnitOptions = {},
 ): RedskilledUnitPlan {
   const env = options.env ?? process.env;
-  // Stabilized when the bundle's name already states its version: the unit
-  // outlives every cache, so its ExecStart should too (#3554 closure). An
-  // unversioned or shim entry is used as resolved — durability is an upgrade,
-  // never a precondition.
+  // The unit outlives every cache, so its ExecStart must too (#3554 closure).
+  // The caller states the version because the RESOLVED name usually cannot:
+  // an npx dispatch hands over `redskilled.bundle.min.mjs`, with no version in
+  // it, so a stabilizer left to read the basename declines and the unit ends up
+  // naming a path inside `~/.npm/_npx/`. A shim or a genuinely local build is
+  // still used as resolved — durability is an upgrade, never a precondition.
   const entry = stabilizeRedskilledEntry(
     requireRedskilledEntry(options.override ?? {}, options.entryLookup ?? {}),
-    { homeDir: stableBundleHomeOf(env) },
+    {
+      homeDir: stableBundleHomeOf(env),
+      ...(options.version === undefined ? {} : { version: options.version }),
+    },
   );
   const args = [
     ...entry.args,

--- a/apps/redskilled/tests/installed-unit-is-durable.test.ts
+++ b/apps/redskilled/tests/installed-unit-is-durable.test.ts
@@ -1,0 +1,82 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { REDSKILLED_BUNDLE_ASSET } from "../src/daemon-entry.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import { planRedskilledUnit } from "../src/supervision.js";
+
+/**
+ * A unit outlives every cache it was installed from.
+ *
+ * The operator-facing install runs through `npx`, which hands the daemon an
+ * entry inside `~/.npm/_npx/<hash>/` — a directory npm prunes on its own
+ * schedule. An `ExecStart` naming that path is a daemon that stops starting for
+ * a reason nothing on the machine explains, and the failure surfaces at the
+ * worst moment: after a reboot, when the operator is not watching.
+ *
+ * The stabilizer that copies such a bundle into `~/.red/redskilled/bundles/`
+ * already existed. What it lacked was the version — the one argument that lets
+ * it name a destination — because the npx entry is always the UNVERSIONED asset
+ * name and the caller never stated one. No test asserted the installed target
+ * was durable, so the entry went out pointing at the cache and nothing objected.
+ */
+const roots: string[] = [];
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+/** A host whose resolved entry sits in a prunable npx cache, as `npx` delivers it. */
+async function npxHost(): Promise<{ paths: ReturnType<typeof resolveRedskilledPaths>; cacheEntry: string; home: string }> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-durable-"));
+  roots.push(root);
+
+  // The shape npx produces: a hashed cache directory, and the bundle inside it
+  // carrying the plain asset name with no version anywhere in the path.
+  const cache = join(root, ".npm", "_npx", "71151dc9e0daee0b", "node_modules", "@reddb-io", "red-skills", "dist");
+  await mkdir(cache, { recursive: true });
+  const cacheEntry = join(cache, REDSKILLED_BUNDLE_ASSET);
+  await writeFile(cacheEntry, "// bundle", { mode: 0o755 });
+
+  // The daemon home must already exist: this provisions nothing (ADR 0130
+  // Amendment 2), it only copies into a home somebody else created.
+  await mkdir(join(root, ".red", "redskilled"), { recursive: true });
+
+  const paths = resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+  return { paths, cacheEntry, home: root };
+}
+
+describe("an installed unit points somewhere durable", () => {
+  it("copies a cache-resident bundle into the daemon home before naming it", async () => {
+    const { paths, cacheEntry, home } = await npxHost();
+
+    const plan = planRedskilledUnit(paths, {
+      env: { HOME: home },
+      entryLookup: { callerEntry: cacheEntry, execPath: "/usr/bin/node", execArgv: [] },
+      version: "3.18.2",
+    });
+
+    expect(plan.text).not.toContain("_npx");
+    expect(plan.args.some((arg) => arg.includes(join(".red", "redskilled", "bundles")))).toBe(true);
+    expect(plan.args.some((arg) => arg.endsWith("redskilled-3.18.2.bundle.min.mjs"))).toBe(true);
+  });
+
+  it("leaves the entry alone when no version can name a destination", async () => {
+    // A local build is not a point on the published lane, so there is nothing to
+    // copy it AS. Using it as resolved is correct — durability is an upgrade,
+    // never a precondition, and taking a developer's own daemon away mid-session
+    // would be the worse failure.
+    const { paths, cacheEntry, home } = await npxHost();
+
+    const plan = planRedskilledUnit(paths, {
+      env: { HOME: home },
+      entryLookup: { callerEntry: cacheEntry, execPath: "/usr/bin/node", execArgv: [] },
+    });
+
+    expect(plan.args).toContain(cacheEntry);
+  });
+});


### PR DESCRIPTION
Defect #7 — the last of the seven-defect plan.

## What breaks

The operator-facing install runs through `npx`, which resolves the entry to:

```
~/.npm/_npx/71151dc9e0daee0b/node_modules/@reddb-io/red-skills/dist/redskilled.bundle.min.mjs
```

`installRedskilledUnit` writes that into `ExecStart` and, in the same step, **removes the `10-current-entry.conf` drop-in that used to pin a stable path**. So the unit names a directory npm prunes on its own schedule.

A pruned cache is a daemon that will not start — found after a reboot, by someone who changed nothing.

## Why the existing repair no-opped

`stabilizeRedskilledEntry` exists for exactly this and **was already being called**. It declines when it cannot name a destination, and it infers the version from the bundle's *filename*:

```ts
const named = VERSIONED_BASENAME.exec(basename(source))?.[1];
const version = options.version ?? named;
if (version == null || …) return entry;
```

npx always delivers `redskilled.bundle.min.mjs` — **unversioned**. So the stabilizer declined on the one path that most needs it, and the comment above the call ("an unversioned or shim entry is used as resolved") read as intent rather than gap.

Both install paths — `planRedskilledUnit` and `provision --install-unit` — now state the version from `readBuildInfo("redskilled")`, which each file already reads a few hundred lines away.

A genuinely unversioned **local build** still flows through untouched: a source checkout is not a point on the published lane, and copying a developer's own daemon out from under them mid-session is the worse failure.

## The missing assertion is why this landed

Two tests exercise this path and **neither judges the target**: `stable-bundle.test.ts` pins the stabilizer's no-op (still correct, for a local build), and `self-supervision.test.ts` asserts the ExecStart names the raw resolved bundle. Nothing anywhere asserted the installed unit's target was durable.

The new test poses the npx shape — hashed cache directory, unversioned asset name, an existing daemon home — and **fails with `expected … not to contain '_npx'`** when the version is withheld again. Verified by reverting the fix.

## Verification

`installed-unit-is-durable` 2/2, `stable-bundle` + `self-supervision` + `provision` 41/41 together, full typecheck 16/16, repo invariants 202/202.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789218278&installation_model_id=20659&pr_number=3815&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3815&signature=13ae165a17d477834f491029d49b1fe8656742dcdb52bcfef05b3c2fdcbceb02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->