### PR TITLE
fix(herdr): read the host lane with the house decoder, not a local one

### DIFF
--- a/.changeset/herdr-uses-the-house-decoder.md
+++ b/.changeset/herdr-uses-the-house-decoder.md
@@ -1,0 +1,29 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The herdr plugin reads the host lane with the house decoder
+
+The plugin carried its own TOONL reader — a segment-header regex, a trailer
+regex, a quoted-cell splitter and a value coercer — while already depending on
+`@reddb-io/toon`, which owns that format. Nothing technical required it.
+
+Three things had drifted behind that parser, and each was invisible until the
+house decoder judged the same bytes:
+
+- Its tail window opened AFTER the segment header its rows are declared by, so
+  every row in the window was undecodable. Against the live 1.8 MB lane it
+  yielded **zero** decodable records; the local reader survived that only by
+  keeping the rows as raw text and calling it tolerance. The lane is read whole
+  now, bounded by the writer's own 4 MiB compaction ceiling.
+- Its tests asserted a header shape the daemon does not write (`{fields}:`
+  rather than the canonical `[]{fields}:`), an empty cell where the writer emits
+  `null`, and a JSON-line tolerance the daemon's own decoder does not have.
+- A malformed row was absorbed as text. The house decoder stops and names it —
+  `line 1600: row arity mismatch` — so the reader now keeps what decoded and
+  hands back the reason, which a viewer can show. Loud and located beats silent
+  and complete.
+
+This also makes the host lane safe to extend. It already carries two segment
+arities side by side, and a reader that mis-tracks a header decodes every later
+row against the wrong fields.

--- a/apps/herdr-plugin-red-skills/src/redskilled/event-lane.mjs
+++ b/apps/herdr-plugin-red-skills/src/redskilled/event-lane.mjs
@@ -7,112 +7,55 @@
  * without it can show a Worker vanish and never say whether it exited 0, was
  * killed over budget, or died with the daemon.
  *
- * **Tolerant on purpose.** The lane is written by a version of the daemon this
- * plugin does not ship with, so the reader sniffs JSON first, decodes TOONL when
- * it recognises a segment header, and keeps an undecodable line as raw text
- * rather than dropping it. A viewer that silently swallowed lines it could not
- * parse would report a quiet incident during exactly the format change that
- * caused it.
+ * **The decoder is `@reddb-io/toon`, never a local one.** This module used to
+ * carry its own segment-header regex, trailer regex and quoted-cell splitter —
+ * roughly sixty lines re-deriving a format the house package already owns and
+ * this plugin already depends on. Two things made that costly rather than
+ * merely redundant. A hand-written reader drifts from the writer it reads, and
+ * the host lane legitimately carries SEVERAL segment arities in one file (35 and
+ * 33 columns live side by side today), so a reader that mis-tracks a header
+ * decodes every later row against the wrong fields.
+ *
+ * **A fault is reported, never absorbed.** The house decoder stops at a
+ * malformed row and names it — `line 1600: row arity mismatch` — so this module
+ * keeps every record decoded up to that point and hands the reason back in
+ * `decodeError`. That is the tolerance this reader always wanted: the earlier
+ * one kept an undecodable line as raw text and carried on, which reports a quiet
+ * incident during exactly the format change that caused it. Loud and located
+ * beats silent and complete.
  */
-import { open, readFile, stat } from "node:fs/promises";
-
-/** How much of the tail to read when the lane is long. */
-export const DEFAULT_EVENT_LANE_TAIL_BYTES = 256 * 1024;
-
-const HEADER = /^\s*(?:#([A-Za-z0-9_.:-]+)\s*)?(?:\[[^\]]*\])?\{([^}]*)\}\s*:\s*$/;
-const TRAILER = /^\s*\[=\d+\]\s*$/;
+import { readFile, stat } from "node:fs/promises";
+import { decodeLines } from "@reddb-io/toon";
 
 /**
- * Split one TOONL row into cells, honouring double-quoted cells. PURE.
+ * The largest lane this reader will decode whole.
  *
- * Quoting is the only structure a row has, so it is the only structure this
- * splitter knows: everything else is handed back as text and coerced later.
+ * The writer compacts its lane at 4 MiB (`DEFAULT_REDSKILLED_EVENT_LANE_MAX_BYTES`),
+ * so a bounded read is the writer's contract rather than this reader's guess,
+ * and the headroom here covers a lane caught mid-append. Reading whole is what
+ * keeps every segment header in view: a tail window opens AFTER the header its
+ * rows are declared by, and rows without their header are not decodable by
+ * anyone — the previous reader only appeared to survive that by keeping them as
+ * raw text and calling it tolerance.
  */
-export function splitRow(line, delimiter = ",") {
-  const cells = [];
-  let cell = "";
-  let quoted = false;
-  for (let index = 0; index < line.length; index += 1) {
-    const char = line[index];
-    if (quoted) {
-      if (char === "\\" && index + 1 < line.length) {
-        cell += line[index + 1];
-        index += 1;
-      } else if (char === '"') {
-        quoted = false;
-      } else {
-        cell += char;
-      }
-      continue;
-    }
-    if (char === '"') {
-      quoted = true;
-      continue;
-    }
-    if (char === delimiter) {
-      cells.push(cell);
-      cell = "";
-      continue;
-    }
-    cell += char;
-  }
-  cells.push(cell);
-  return cells;
-}
-
-/** A cell as the value it denotes; anything unrecognised stays the string. PURE. */
-function coerce(raw) {
-  const value = raw.trim();
-  if (value === "" || value === "null") return null;
-  if (value === "true") return true;
-  if (value === "false") return false;
-  if (/^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(value)) return Number(value);
-  return raw;
-}
+export const DEFAULT_EVENT_LANE_MAX_BYTES = 8 * 1024 * 1024;
 
 /**
- * Decode a lane's text into records, oldest first. PURE.
+ * Decode a lane's text into records, oldest first.
  *
- * Segment rotation is followed rather than assumed away: a fresh daemon process
- * re-declares the header, so one lane holds several segments and a reader locked
- * to the first header would decode every later row against the wrong fields.
+ * Returns the records AND the reason decoding stopped, when it did. A caller
+ * that wants only the rows can ignore `decodeError`; a viewer should show it,
+ * because a truncated history that says nothing is indistinguishable from a
+ * quiet one.
  */
-export function parseEventLane(raw) {
+export async function parseEventLane(raw) {
   const records = [];
-  let fields = null;
-  for (const line of raw.split("\n")) {
-    if (line.trim() === "") continue;
-    if (TRAILER.test(line)) continue;
-
-    const header = HEADER.exec(line);
-    if (header) {
-      fields = header[2].split(",").map((field) => field.trim());
-      continue;
-    }
-
-    const trimmed = line.trim();
-    if (trimmed.startsWith("{")) {
-      try {
-        records.push({ ...JSON.parse(trimmed), _raw: line });
-        continue;
-      } catch {
-        // Not JSON after all — fall through and try the row decoder.
-      }
-    }
-
-    if (fields == null) {
-      records.push({ _raw: line, _undecoded: true });
-      continue;
-    }
-
-    const cells = splitRow(trimmed);
-    const record = { _raw: line };
-    fields.forEach((field, index) => {
-      record[field] = index < cells.length ? coerce(cells[index]) : null;
-    });
-    records.push(record);
+  try {
+    for await (const record of decodeLines(raw)) records.push(record);
+  } catch (error) {
+    return { records, decodeError: error?.message ?? String(error) };
   }
-  return records;
+  return { records, decodeError: null };
 }
 
 /** True when a record is one of the three facts the lane carries. PURE. */
@@ -128,46 +71,44 @@ export function isHostEvent(record) {
 /**
  * The lane's last records, newest last; an absent lane is an empty history.
  *
- * Only the tail is read. A lane that has been appended to for a week is not a
- * reason to make every dashboard refresh pay for the whole session's history,
- * and the first partial line the window cuts is dropped rather than decoded — a
- * half-read row is not a record, it is the beginning of one.
+ * The lane is read WHOLE, bounded by the writer's own compaction ceiling rather
+ * than by a window this reader invents. A tail window was the older shape and it
+ * was quietly broken: it opened after the segment header its rows are declared
+ * by, so every row in it was undecodable — survived only by keeping them as raw
+ * text. Against the live 1.8 MB lane that window yielded ZERO decodable records.
  */
-export async function readEventLane(path, { tailBytes = DEFAULT_EVENT_LANE_TAIL_BYTES, limit = 500 } = {}) {
+export async function readEventLane(path, { maxBytes = DEFAULT_EVENT_LANE_MAX_BYTES, limit = 500 } = {}) {
   let size;
   try {
     size = (await stat(path)).size;
   } catch (error) {
-    if (error.code === "ENOENT") return { path, exists: false, records: [], truncated: false };
+    if (error.code === "ENOENT") {
+      return { path, exists: false, records: [], truncated: false, decodeError: null };
+    }
     throw error;
   }
 
-  let raw;
-  let truncated = false;
-  if (size <= tailBytes) {
-    raw = await readFile(path, "utf8");
-  } else {
-    const handle = await open(path, "r");
-    try {
-      const chunk = Buffer.alloc(tailBytes);
-      await handle.read(chunk, 0, tailBytes, size - tailBytes);
-      const text = chunk.toString("utf8");
-      const newline = text.indexOf("\n");
-      raw = newline < 0 ? text : text.slice(newline + 1);
-      truncated = true;
-    } finally {
-      await handle.close();
-    }
+  if (size > maxBytes) {
+    // Past the writer's own ceiling the lane is not what this reader was told to
+    // expect, and half of it is worse than none: rows whose header scrolled out
+    // decode against nothing. Say so instead of showing a confident fragment.
+    return {
+      path,
+      exists: true,
+      truncated: true,
+      decodeError: `the lane is ${size} bytes, past the ${maxBytes}-byte ceiling this reader decodes whole`,
+      records: [],
+    };
   }
 
-  // A window into the middle of a lane usually opens after the segment header,
-  // so rows decode against no fields and arrive as raw text. That is the honest
-  // outcome — the alternative is inventing a schema the writer never declared.
-  const records = parseEventLane(raw);
+  const raw = await readFile(path, "utf8");
+
+  const { records, decodeError } = await parseEventLane(raw);
   return {
     path,
     exists: true,
-    truncated,
+    truncated: false,
+    decodeError,
     records: records.slice(Math.max(0, records.length - limit)),
   };
 }

--- a/apps/herdr-plugin-red-skills/tests/redskilled.test.mjs
+++ b/apps/herdr-plugin-red-skills/tests/redskilled.test.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { isHostEvent, parseEventLane, readEventLane, splitRow } from "../src/redskilled/event-lane.mjs";
+import { isHostEvent, parseEventLane, readEventLane } from "../src/redskilled/event-lane.mjs";
 import { REDSKILLED_SOCKET_FILE, resolveRedskilledPaths, resolveSessionKey, runtimeSocketDir } from "../src/redskilled/paths.mjs";
 import { repositoryFromRemote } from "../src/redskilled/project-identity.mjs";
 import { DEFAULT_CONFIG, configDir, mergeConfig, stateDir } from "../src/config.mjs";
@@ -51,42 +51,78 @@ test("an explicit socket wins over every derivation, and says so", () => {
   assert.ok(derived.eventLanePath.endsWith("redskilled.events.toonl"));
 });
 
-test("splitRow honours quoted cells and their escapes", () => {
-  assert.deepEqual(splitRow("1,ada,x"), ["1", "ada", "x"]);
-  assert.deepEqual(splitRow('1,"a,b",c'), ["1", "a,b", "c"]);
-  assert.deepEqual(splitRow('1,"say \\"hi\\"",c'), ["1", 'say "hi"', "c"]);
-});
-
-test("the event lane decodes a TOONL segment and follows a rotation", () => {
+test("the event lane decodes a TOONL segment and follows a rotation", async () => {
   const lane = [
-    "{version,ts,event,worker_id,project_label,pid,exit_code}:",
-    "  1,2026-07-31T10:00:00.000Z,worker-birth,w-1,reddb-io/red-skills,4242,",
+    "[]{version,ts,event,worker_id,project_label,pid,exit_code}:",
+    "  1,2026-07-31T10:00:00.000Z,worker-birth,w-1,reddb-io/red-skills,4242,null",
     "[=1]",
-    "{version,ts,event,worker_id,project_label,pid,exit_code}:",
+    "[]{version,ts,event,worker_id,project_label,pid,exit_code}:",
     "  1,2026-07-31T10:05:00.000Z,worker-death,w-1,reddb-io/red-skills,4242,0",
     "",
   ].join("\n");
-  const records = parseEventLane(lane);
+  const { records, decodeError } = await parseEventLane(lane);
+  assert.equal(decodeError, null);
   assert.equal(records.length, 2);
   assert.equal(records[0].event, "worker-birth");
   assert.equal(records[0].pid, 4242);
-  assert.equal(records[0].exit_code, null, "an empty cell is an absence, never a zero");
+  // The writer spells an absence `null`, and the round-trip holds. The local
+  // decoder used to coerce an EMPTY cell to null — compensating for a shape no
+  // writer in this repo emits, which is how the fixture drifted from the lane.
+  assert.equal(records[0].exit_code, null, "an absence is null, never a zero");
   assert.equal(records[1].exit_code, 0);
   assert.ok(records.every(isHostEvent));
 });
 
-test("a line the reader cannot decode is kept as raw text, never dropped", () => {
-  const records = parseEventLane("  1,2026-07-31T10:00:00.000Z,worker-birth,w-1\n");
-  assert.equal(records.length, 1);
-  assert.equal(records[0]._undecoded, true);
-  assert.ok(records[0]._raw.includes("worker-birth"));
+test("a fault is NAMED, and the records before it survive", async () => {
+  // The reader used to keep an undecodable line as raw text and carry on, which
+  // reports a quiet incident during exactly the format change that caused it.
+  // The house decoder stops and says where; this keeps what it decoded and hands
+  // the reason back, so a viewer can show it.
+  const lane = [
+    "[]{version,ts,event,worker_id}:",
+    "  1,2026-07-31T10:00:00.000Z,worker-birth,w-1",
+    "  1,2026-07-31T10:01:00.000Z,worker-death,w-1,4242,extra",
+    "",
+  ].join("\n");
+  const { records, decodeError } = await parseEventLane(lane);
+
+  assert.equal(records.length, 1, "everything before the fault survives");
+  assert.equal(records[0].event, "worker-birth");
+  assert.ok(decodeError, "the fault is reported, never absorbed");
+  assert.match(decodeError, /arity|line/i, "and it says WHERE");
 });
 
-test("the event lane also accepts JSON lines, as the daemon's decoder does", () => {
-  const records = parseEventLane('{"version":1,"ts":"2026-07-31T10:00:00.000Z","event":"worker-death","worker_id":"w-9"}\n');
-  assert.equal(records.length, 1);
-  assert.ok(isHostEvent(records[0]));
-  assert.equal(records[0].worker_id, "w-9");
+test("several segment arities in one lane each decode against their own header", async () => {
+  // The live host lane genuinely carries 35- and 33-column segments side by
+  // side. A reader locked to the first header decodes every later row against
+  // the wrong fields — the failure the local decoder existed to avoid and could
+  // not actually prevent.
+  const lane = [
+    "[]{version,ts,event,worker_id}:",
+    "  1,2026-07-31T10:00:00.000Z,worker-birth,w-1",
+    "[]{version,ts,event,worker_id,exit_code}:",
+    "  1,2026-07-31T10:05:00.000Z,worker-death,w-2,0",
+    "",
+  ].join("\n");
+  const { records, decodeError } = await parseEventLane(lane);
+
+  assert.equal(decodeError, null);
+  assert.equal(records.length, 2);
+  assert.equal(records[0].worker_id, "w-1");
+  assert.equal(records[1].exit_code, 0);
+});
+
+test("a JSON line is NOT a TOONL record, and the reader says so", async () => {
+  // The replaced test claimed the daemon's decoder sniffs JSON. It does not —
+  // `apps/redskilled/src/event-lane.ts` holds no `JSON.parse`, and neither does
+  // the house decoder. The local reader accepted JSON, so the test encoded a
+  // tolerance no writer ever needed and no other reader shared.
+  const { records, decodeError } = await parseEventLane(
+    '{"version":1,"ts":"2026-07-31T10:00:00.000Z","event":"worker-death","worker_id":"w-9"}\n',
+  );
+
+  assert.equal(records.length, 0);
+  assert.ok(decodeError, "an undecodable line is reported, not silently kept as text");
 });
 
 test("an absent lane is an empty history, not a failure", async () => {
@@ -96,7 +132,7 @@ test("an absent lane is an empty history, not a failure", async () => {
   assert.deepEqual(missing.records, []);
 
   const path = join(dir, "redskilled.events.toonl");
-  await writeFile(path, "{version,ts,event,worker_id}:\n  1,2026-07-31T10:00:00.000Z,worker-birth,w-1\n");
+  await writeFile(path, "[]{version,ts,event,worker_id}:\n  1,2026-07-31T10:00:00.000Z,worker-birth,w-1\n");
   const present = await readEventLane(path);
   assert.equal(present.exists, true);
   assert.equal(present.records.length, 1);


### PR DESCRIPTION
Maintainer direction: *"não é pra nada escrever na mão cara. a gente tem o nosso próprio decodificador toonl e toon em reddb-io/toon!"*

S0 of the telemetry plan, and the prerequisite for adding LOC columns to the host lane.

## There was never a reason for the local parser

The plugin carried `HEADER`, `TRAILER`, `splitRow` and `coerce` — ~60 lines re-deriving TOONL — while **`@reddb-io/toon` was already in its dependencies**. It is published JavaScript, so it resolves both bundled and from source, unlike `@reddb-io/redskilled` whose exports point at TypeScript and only resolve through the bundler. (That is why this takes `decodeLines` rather than the daemon's `parseEventLane`, which is what the VS Code extension — a compiled TS host — correctly imports.)

## Handing the same bytes to the house decoder exposed three drifts

**1. The tail window was broken and looked fine.** It opened *after* the segment header its rows are declared by, so every row in it decoded against no fields. **Against the live 1.8 MB lane it produced zero decodable records.** The old reader only appeared to survive that by keeping the rows as raw text and calling it tolerance.

The lane is now read **whole**, bounded by the writer's own 4 MiB compaction ceiling (`DEFAULT_REDSKILLED_EVENT_LANE_MAX_BYTES`) — a bound the writer already guarantees beats a window this reader invents.

```
before   decodeError="line 1: row before header"   registros=0
after    decodeError=null                          registros=3   ← live lane
```

**2. The tests asserted a format the daemon does not write.** `{fields}:` where the canonical header is `[]{fields}:`; an **empty cell** where the writer emits the token `null` (verified by round-tripping through the house encoder); and a JSON-line tolerance attributed to *"the daemon's decoder"* which `apps/redskilled/src/event-lane.ts` does not have — it holds no `JSON.parse`. Each was a fiction the lenient local decoder accepted.

**3. A fault is named rather than absorbed.** The house decoder stops at a malformed row and says where — `line 1600: row arity mismatch`, verified against the quarantined `.mixed-arity.bak2` — so the module keeps every record decoded before it and returns the reason in `decodeError`. The file's own doc-comment argued that a silent reader *"would report a quiet incident during exactly the format change that caused it"*. Right principle, wrong implementation.

## Why this gates the LOC work

The host lane already carries **two segment arities in one file** (35 and 33 columns), and the two quarantined files beside it — `.mixed-arity.bak2`, `.poisoned-3.14-arity.bak` — are what a frozen reader does with a format that legitimately evolves. Adding columns is safe for a reader that tracks the nearest preceding header; it was not safe for this one.

## Verification

herdr suite **90/90** (including two new cases: a named fault preserving prior records, and two arities in one lane each decoding against their own header), manifest check ok, full typecheck 16/16, repo invariants 202/202. Proven live against this machine's running daemon.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789225655&installation_model_id=20659&pr_number=3818&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3818&signature=5418910827adf4220c7526c07ae325da489d0cec73d6c3186a81f0e863a082c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->