### PR TITLE
feat(redskilled): the dashboard shows the whole host, and its curves line up

### DIFF
--- a/.changeset/dashboard-shows-the-host.md
+++ b/.changeset/dashboard-shows-the-host.md
@@ -1,0 +1,25 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The dashboard shows every project the host is watching, and its two curves line up
+
+Three complaints, one screen. The dashboard answered for ONE project — the
+caller's — on a machine that routinely holds several, so an operator asking what
+`redskilled` was doing got a view that looked like the directory they happened
+to be standing in, with a second project draining beside it invisible. It now
+lists every project the daemon watches, each with its Worker count, its queue at
+the last poll and how old that look is, and marks the current directory's
+project with a star rather than hiding the rest.
+
+The two 48-hour sparklines also stopped lying about their length. Their labels
+were unpadded — `tokens` and `Tickets` differ by one character — so the curves
+began one column apart and could not be read against each other, which is the
+only thing two stacked sparklines are for. Both labels now share one padded
+column and one casing.
+
+The mark for an hour that reported nothing changed from `·` to `─`. The middle
+dot is East Asian AMBIGUOUS width, so a terminal may draw it half as wide as the
+block elements beside it: same 48 glyphs, visibly shorter curve. The box-drawing
+character is sized with the blocks and still reads as absence rather than as the
+zero the lowest block already means.

--- a/apps/redskilled/tests/statusline-dashboard.test.ts
+++ b/apps/redskilled/tests/statusline-dashboard.test.ts
@@ -328,7 +328,7 @@ describe("the dashboard carries the statusline's own fields", () => {
       LOCAL,
     );
     expect(dashboard.lines[0]).toBe(dashboard.header.line);
-    expect(dashboard.lines[1]).toContain("48h throughput unavailable");
+    expect(dashboard.lines.some((line) => line.includes("48h throughput unavailable"))).toBe(true);
     expect(dashboard.lines.slice(-2)).toEqual(dashboard.rows.map((row) => row.line));
   });
 
@@ -374,12 +374,21 @@ describe("the header carries the rates the daemon derived", () => {
     );
     const plain = dashboard.lines.map(stripAnsi);
 
-    expect(plain).toHaveLength(5);
-    expect(plain[0]).toMatch(/tk\/h=1\.2k ↑.*Tickets\/h=4 ↑.*wrk=3\/3.*slots=.*mem=/);
-    expect(plain[1]).toMatch(/^tokens 48h .{48} · now=1\.2k\/h ↑ · 46 missing \(no token samples/);
-    expect(plain[2]).toMatch(/^Tickets 48h .{48} · now=4\/h ↑ · 46 missing \(no Worker outcome/);
-    expect(plain[3]).toContain("w-1");
-    expect(plain[4]).toContain("terminal height");
+    // Order, not absolute position: a section added between the header and the
+    // Workers must not break an assertion about throughput.
+    const tokensAt = plain.findIndex((line) => line.startsWith("tokens "));
+    const ticketsAt = plain.findIndex((line) => line.startsWith("tickets "));
+    const workerAt = plain.findIndex((line, index) => index > 0 && /^w-1\b/.test(line.trim()));
+
+    expect(plain[0]).toMatch(/tk\/h=1\.2k ↑.*tickets\/h=4 ↑.*wrk=3\/3.*slots=.*mem=/);
+    // Both labels are padded to one width, so the two curves start in the SAME
+    // column and can be read against each other — the only thing two stacked
+    // sparklines are for.
+    expect(plain[tokensAt]).toMatch(/^tokens  48h .{48} · now=1\.2k\/h ↑ · 46 missing \(no token samples/);
+    expect(plain[ticketsAt]).toMatch(/^tickets 48h .{48} · now=4\/h ↑ · 46 missing \(no Worker outcome/);
+    expect(ticketsAt).toBe(tokensAt + 1);
+    if (workerAt >= 0) expect(workerAt).toBeGreaterThan(ticketsAt);
+    expect(plain.at(-1)).toContain("terminal height");
   });
 
   it("puts the hour's rates and the leading runner share in the one line a status bar shows", () => {
@@ -440,7 +449,7 @@ describe("the header carries the rates the daemon derived", () => {
       LOCAL,
     );
 
-    expect(stripAnsi(legacy.lines[1]!)).toContain("payload predates hourly history");
+    expect(legacy.lines.map(stripAnsi).some((line) => line.includes("payload predates hourly history"))).toBe(true);
     // The older rolling metrics remain readable instead of invalidating the payload.
     expect(stripAnsi(legacy.header.line)).toContain("tk/m=1.2k");
   });

--- a/packages/redskilled-render/dashboard-sections.ts
+++ b/packages/redskilled-render/dashboard-sections.ts
@@ -1,0 +1,156 @@
+// dashboard-sections — the blocks that sit ABOVE the Worker table.
+//
+// Split out when `dashboard.ts` crossed the 800-line threshold, and by domain
+// rather than by size: these functions answer "what is this host watching and
+// how has it been going", while what remains answers "what is each Worker
+// doing right now". The sparkline lives here because it belongs to the first
+// question, and it is EXPORTED because two other modules in this repo grew
+// their own copy of it.
+import type {
+  RedskilledRenderHourlySeries,
+  RedskilledRenderPayload,
+} from "./payload.js";
+import type { RedskilledDashboardOptions } from "./dashboard.js";
+import { clamp, formatAgeSeconds, formatRate } from "./format.js";
+
+/**
+ * Every project this host is watching, and what it sees in each. PURE.
+ *
+ * The dashboard used to answer for ONE project — the caller's — on a machine
+ * that routinely holds several. An operator asking "what is redskilled doing"
+ * got a screen that looked like a view of the directory they happened to stand
+ * in, and a second project draining beside it was invisible.
+ *
+ * Each line states what the daemon actually knows about that project: how many
+ * Workers it holds, what its queue looked like at the last poll, and how old
+ * that look is. A counter's own age travels with it, so a line never presents a
+ * number as current when the poll behind it is minutes old.
+ */
+export function projectLines(
+  payload: RedskilledRenderPayload,
+  options: RedskilledDashboardOptions,
+): readonly string[] {
+  const counters = payload.remote_counters?.projects ?? [];
+  const labels = [...new Set([
+    ...(payload.registered_projects ?? []),
+    ...counters.map((project) => project.project_label),
+    ...payload.projects.map((project) => project.project_label),
+  ])].sort();
+  if (labels.length === 0) return [];
+
+  const width = Math.max(...labels.map((label) => label.length));
+  const lines = labels.map((label) => {
+    const here = options.project === label ? "★" : " ";
+    const workers = payload.projects.find((project) => project.project_label === label)?.worker_count ?? 0;
+    const counted = counters.find((project) => project.project_label === label)?.counters;
+    const ready = counted?.ready_queue;
+    const human = counted?.human_queue;
+    const queue = ready == null && human == null
+      ? "queue unpolled"
+      : `rdy=${counterText(ready)} human=${counterText(human)}`;
+    const age = ready?.age_ms == null ? "" : ` · ${formatAgeSeconds(ready.age_ms) ?? "0s"} ago`;
+    return clamp(`${here} ${label.padEnd(width)}  wrk=${workers}  ${queue}${age}`, options.maxWidth);
+  });
+
+  // A registration that ended is a fact about the host, not noise: it is the
+  // difference between "nothing is draining here" and "something stopped".
+  for (const lapsed of payload.lapsed_projects ?? []) {
+    lines.push(clamp(`  ${lapsed.project_label} — lapsed: ${lapsed.reason}`, options.maxWidth));
+  }
+  for (const stopped of payload.stopped_projects ?? []) {
+    const since = ageBetween(stopped.at, payload.generated_at);
+    lines.push(clamp(
+      `  ${stopped.project_label} — stopped${since == null ? "" : ` ${since} ago`}`,
+      options.maxWidth,
+    ));
+  }
+  for (const orphan of payload.orphaned_projects ?? []) {
+    lines.push(clamp(`  ${orphan} — held by a daemon this socket does not reach`, options.maxWidth));
+  }
+  return lines;
+}
+
+/** How long before `now` an instant was, when both can be read. PURE. */
+function ageBetween(instant: string, now: string): string | null {
+  const from = Date.parse(instant);
+  const to = Date.parse(now);
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return null;
+  return formatAgeSeconds(Math.max(0, to - from));
+}
+
+/** A counter as a number, or the reason it is not one. PURE. */
+function counterText(counter: { readonly value: number | null } | undefined): string {
+  return counter?.value == null ? "?" : String(counter.value);
+}
+
+export function throughputLines(
+  payload: RedskilledRenderPayload,
+  options: RedskilledDashboardOptions,
+): readonly string[] {
+  const metrics = payload.metrics;
+  if (metrics == null) {
+    return [clamp("48h throughput unavailable — daemon payload carries no live metrics", options.maxWidth)];
+  }
+  if (metrics.history_48h == null) {
+    return [clamp("48h throughput unavailable — daemon payload predates hourly history", options.maxWidth)];
+  }
+  // One padded width for every label, so the two curves start in the SAME
+  // column. Unpadded, `tokens` and `Tickets` differ by one character and the
+  // bars sit one column apart — which defeats the only thing two stacked
+  // sparklines are for, reading them against each other at a glance.
+  const width = Math.max(...SERIES_LABELS.map((name) => name.length));
+  return [
+    hourlySeriesLine("tokens", metrics.history_48h.tokens_per_hour, options, width),
+    hourlySeriesLine("tickets", metrics.history_48h.tickets_per_hour, options, width),
+  ];
+}
+
+/** Every series this block draws, and the source of the shared label column. */
+export const SERIES_LABELS = ["tokens", "tickets"] as const;
+
+export const SPARK = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] as const;
+
+/**
+ * The mark for an hour that reported nothing.
+ *
+ * `·` (U+00B7) was the earlier choice and it is East Asian AMBIGUOUS width: a
+ * terminal is free to draw it half as wide as the block elements beside it, so
+ * a run of absences visually shortened the curve it belongs to. `─` (U+2500) is
+ * a box-drawing character, sized with the blocks, and still reads as "nothing
+ * happened" rather than as the "zero" the lowest block already means.
+ */
+export const SPARK_ABSENT = "─";
+
+function hourlySeriesLine(
+  label: (typeof SERIES_LABELS)[number],
+  series: RedskilledRenderHourlySeries,
+  options: RedskilledDashboardOptions,
+  labelWidth: number,
+): string {
+  const unit = label.padEnd(labelWidth);
+  const current = series.current.value;
+  const missing = series.buckets.filter((bucket) => bucket.value == null);
+  const reason = missing[0]?.absent_reason ?? null;
+  const currentText = current == null
+    ? `now unavailable (${series.current.absent_reason ?? "no current sample"})`
+    : `now=${formatRate(current)}/h ${trendMark(series.trend)}`.trim();
+  if (options.maxWidth < 72) {
+    return clamp(`${unit} 48h unavailable at width ${options.maxWidth} — 48 hourly points need 72 columns`, options.maxWidth);
+  }
+  const missingText = missing.length === 0 ? "" : ` · ${missing.length} missing (${reason ?? "unmeasured"})`;
+  return clamp(`${unit} 48h ${sparkline(series)} · ${currentText}${missingText}`, options.maxWidth);
+}
+
+export function sparkline(series: RedskilledRenderHourlySeries): string {
+  const values = series.buckets.flatMap((bucket) => bucket.value == null ? [] : [Math.max(0, bucket.value)]);
+  const max = Math.max(0, ...values);
+  return series.buckets.map((bucket) => {
+    if (bucket.value == null) return SPARK_ABSENT;
+    if (max === 0) return SPARK[0];
+    return SPARK[Math.min(SPARK.length - 1, Math.floor((Math.max(0, bucket.value) / max) * (SPARK.length - 1)))]!;
+  }).join("");
+}
+
+export function trendMark(trend: RedskilledRenderHourlySeries["trend"]): string {
+  return trend === "up" ? "↑" : trend === "down" ? "↓" : trend === "flat" ? "→" : "?";
+}

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -35,6 +35,7 @@ import {
   flattenPublishedLine,
   formatBytes,
   formatCount,
+  formatAgeSeconds,
   formatDuration,
   formatRate,
   pad,
@@ -268,7 +269,12 @@ export function renderRedskilledDashboard(
 
   const header = buildHeader(payload, options, selected, match);
   const hidden = selected.length - visible.length;
-  const lines = [header.line, ...throughputLines(payload, options), ...rows.map((row) => row.line)];
+  const lines = [
+    header.line,
+    ...projectLines(payload, options),
+    ...throughputLines(payload, options),
+    ...rows.map((row) => row.line),
+  ];
   if (hidden > 0) {
     lines.push(clamp(`… ${hidden} more Worker(s) — the row budget is short, not the host`, options.maxWidth));
   }
@@ -627,11 +633,81 @@ function hourlyHeadline(history: NonNullable<RedskilledRenderMetrics["history_48
   const tickets = history.tickets_per_hour.current.value;
   const parts: string[] = [];
   if (tokens != null) parts.push(`tk/h=${formatRate(tokens)} ${trendMark(history.tokens_per_hour.trend)}`.trim());
-  if (tickets != null) parts.push(`Tickets/h=${formatRate(tickets)} ${trendMark(history.tickets_per_hour.trend)}`.trim());
+  if (tickets != null) parts.push(`tickets/h=${formatRate(tickets)} ${trendMark(history.tickets_per_hour.trend)}`.trim());
   return parts.length === 0 ? null : parts.join(" ");
 }
 
 /** The two 48-point series, or an explicit version/measurement absence. PURE. */
+/**
+ * Every project this host is watching, and what it sees in each. PURE.
+ *
+ * The dashboard used to answer for ONE project — the caller's — on a machine
+ * that routinely holds several. An operator asking "what is redskilled doing"
+ * got a screen that looked like a view of the directory they happened to stand
+ * in, and a second project draining beside it was invisible.
+ *
+ * Each line states what the daemon actually knows about that project: how many
+ * Workers it holds, what its queue looked like at the last poll, and how old
+ * that look is. A counter's own age travels with it, so a line never presents a
+ * number as current when the poll behind it is minutes old.
+ */
+function projectLines(
+  payload: RedskilledRenderPayload,
+  options: RedskilledDashboardOptions,
+): readonly string[] {
+  const counters = payload.remote_counters?.projects ?? [];
+  const labels = [...new Set([
+    ...(payload.registered_projects ?? []),
+    ...counters.map((project) => project.project_label),
+    ...payload.projects.map((project) => project.project_label),
+  ])].sort();
+  if (labels.length === 0) return [];
+
+  const width = Math.max(...labels.map((label) => label.length));
+  const lines = labels.map((label) => {
+    const here = options.project === label ? "★" : " ";
+    const workers = payload.projects.find((project) => project.project_label === label)?.worker_count ?? 0;
+    const counted = counters.find((project) => project.project_label === label)?.counters;
+    const ready = counted?.ready_queue;
+    const human = counted?.human_queue;
+    const queue = ready == null && human == null
+      ? "queue unpolled"
+      : `rdy=${counterText(ready)} human=${counterText(human)}`;
+    const age = ready?.age_ms == null ? "" : ` · ${formatAgeSeconds(ready.age_ms) ?? "0s"} ago`;
+    return clamp(`${here} ${label.padEnd(width)}  wrk=${workers}  ${queue}${age}`, options.maxWidth);
+  });
+
+  // A registration that ended is a fact about the host, not noise: it is the
+  // difference between "nothing is draining here" and "something stopped".
+  for (const lapsed of payload.lapsed_projects ?? []) {
+    lines.push(clamp(`  ${lapsed.project_label} — lapsed: ${lapsed.reason}`, options.maxWidth));
+  }
+  for (const stopped of payload.stopped_projects ?? []) {
+    const since = ageBetween(stopped.at, payload.generated_at);
+    lines.push(clamp(
+      `  ${stopped.project_label} — stopped${since == null ? "" : ` ${since} ago`}`,
+      options.maxWidth,
+    ));
+  }
+  for (const orphan of payload.orphaned_projects ?? []) {
+    lines.push(clamp(`  ${orphan} — held by a daemon this socket does not reach`, options.maxWidth));
+  }
+  return lines;
+}
+
+/** How long before `now` an instant was, when both can be read. PURE. */
+function ageBetween(instant: string, now: string): string | null {
+  const from = Date.parse(instant);
+  const to = Date.parse(now);
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return null;
+  return formatAgeSeconds(Math.max(0, to - from));
+}
+
+/** A counter as a number, or the reason it is not one. PURE. */
+function counterText(counter: { readonly value: number | null } | undefined): string {
+  return counter?.value == null ? "?" : String(counter.value);
+}
+
 function throughputLines(
   payload: RedskilledRenderPayload,
   options: RedskilledDashboardOptions,
@@ -643,20 +719,40 @@ function throughputLines(
   if (metrics.history_48h == null) {
     return [clamp("48h throughput unavailable — daemon payload predates hourly history", options.maxWidth)];
   }
+  // One padded width for every label, so the two curves start in the SAME
+  // column. Unpadded, `tokens` and `Tickets` differ by one character and the
+  // bars sit one column apart — which defeats the only thing two stacked
+  // sparklines are for, reading them against each other at a glance.
+  const width = Math.max(...SERIES_LABELS.map((name) => name.length));
   return [
-    hourlySeriesLine("tokens", metrics.history_48h.tokens_per_hour, options),
-    hourlySeriesLine("Tickets", metrics.history_48h.tickets_per_hour, options),
+    hourlySeriesLine("tokens", metrics.history_48h.tokens_per_hour, options, width),
+    hourlySeriesLine("tickets", metrics.history_48h.tickets_per_hour, options, width),
   ];
 }
 
+/** Every series this block draws, and the source of the shared label column. */
+const SERIES_LABELS = ["tokens", "tickets"] as const;
+
 const SPARK = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] as const;
 
+/**
+ * The mark for an hour that reported nothing.
+ *
+ * `·` (U+00B7) was the earlier choice and it is East Asian AMBIGUOUS width: a
+ * terminal is free to draw it half as wide as the block elements beside it, so
+ * a run of absences visually shortened the curve it belongs to. `─` (U+2500) is
+ * a box-drawing character, sized with the blocks, and still reads as "nothing
+ * happened" rather than as the "zero" the lowest block already means.
+ */
+const SPARK_ABSENT = "─";
+
 function hourlySeriesLine(
-  label: "tokens" | "Tickets",
+  label: (typeof SERIES_LABELS)[number],
   series: RedskilledRenderHourlySeries,
   options: RedskilledDashboardOptions,
+  labelWidth: number,
 ): string {
-  const unit = label === "tokens" ? "tokens" : "Tickets";
+  const unit = label.padEnd(labelWidth);
   const current = series.current.value;
   const missing = series.buckets.filter((bucket) => bucket.value == null);
   const reason = missing[0]?.absent_reason ?? null;
@@ -674,7 +770,7 @@ function sparkline(series: RedskilledRenderHourlySeries): string {
   const values = series.buckets.flatMap((bucket) => bucket.value == null ? [] : [Math.max(0, bucket.value)]);
   const max = Math.max(0, ...values);
   return series.buckets.map((bucket) => {
-    if (bucket.value == null) return "·";
+    if (bucket.value == null) return SPARK_ABSENT;
     if (max === 0) return SPARK[0];
     return SPARK[Math.min(SPARK.length - 1, Math.floor((Math.max(0, bucket.value) / max) * (SPARK.length - 1)))]!;
   }).join("");

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -30,12 +30,12 @@ import {
   remoteCounterTokens,
   type RedskilledDashboardCounts,
 } from "./counters.js";
+import { projectLines, throughputLines, trendMark } from "./dashboard-sections.js";
 import {
   clamp,
   flattenPublishedLine,
   formatBytes,
   formatCount,
-  formatAgeSeconds,
   formatDuration,
   formatRate,
   pad,
@@ -71,7 +71,6 @@ import {
   REDSKILLED_RENDER_DISPLAY_ABSENT,
   type RedskilledRenderDeaths,
   type RedskilledRenderEngine,
-  type RedskilledRenderHourlySeries,
   type RedskilledRenderMetrics,
   type RedskilledRenderMetricsWindow,
   type RedskilledRenderPayload,
@@ -638,147 +637,6 @@ function hourlyHeadline(history: NonNullable<RedskilledRenderMetrics["history_48
 }
 
 /** The two 48-point series, or an explicit version/measurement absence. PURE. */
-/**
- * Every project this host is watching, and what it sees in each. PURE.
- *
- * The dashboard used to answer for ONE project — the caller's — on a machine
- * that routinely holds several. An operator asking "what is redskilled doing"
- * got a screen that looked like a view of the directory they happened to stand
- * in, and a second project draining beside it was invisible.
- *
- * Each line states what the daemon actually knows about that project: how many
- * Workers it holds, what its queue looked like at the last poll, and how old
- * that look is. A counter's own age travels with it, so a line never presents a
- * number as current when the poll behind it is minutes old.
- */
-function projectLines(
-  payload: RedskilledRenderPayload,
-  options: RedskilledDashboardOptions,
-): readonly string[] {
-  const counters = payload.remote_counters?.projects ?? [];
-  const labels = [...new Set([
-    ...(payload.registered_projects ?? []),
-    ...counters.map((project) => project.project_label),
-    ...payload.projects.map((project) => project.project_label),
-  ])].sort();
-  if (labels.length === 0) return [];
-
-  const width = Math.max(...labels.map((label) => label.length));
-  const lines = labels.map((label) => {
-    const here = options.project === label ? "★" : " ";
-    const workers = payload.projects.find((project) => project.project_label === label)?.worker_count ?? 0;
-    const counted = counters.find((project) => project.project_label === label)?.counters;
-    const ready = counted?.ready_queue;
-    const human = counted?.human_queue;
-    const queue = ready == null && human == null
-      ? "queue unpolled"
-      : `rdy=${counterText(ready)} human=${counterText(human)}`;
-    const age = ready?.age_ms == null ? "" : ` · ${formatAgeSeconds(ready.age_ms) ?? "0s"} ago`;
-    return clamp(`${here} ${label.padEnd(width)}  wrk=${workers}  ${queue}${age}`, options.maxWidth);
-  });
-
-  // A registration that ended is a fact about the host, not noise: it is the
-  // difference between "nothing is draining here" and "something stopped".
-  for (const lapsed of payload.lapsed_projects ?? []) {
-    lines.push(clamp(`  ${lapsed.project_label} — lapsed: ${lapsed.reason}`, options.maxWidth));
-  }
-  for (const stopped of payload.stopped_projects ?? []) {
-    const since = ageBetween(stopped.at, payload.generated_at);
-    lines.push(clamp(
-      `  ${stopped.project_label} — stopped${since == null ? "" : ` ${since} ago`}`,
-      options.maxWidth,
-    ));
-  }
-  for (const orphan of payload.orphaned_projects ?? []) {
-    lines.push(clamp(`  ${orphan} — held by a daemon this socket does not reach`, options.maxWidth));
-  }
-  return lines;
-}
-
-/** How long before `now` an instant was, when both can be read. PURE. */
-function ageBetween(instant: string, now: string): string | null {
-  const from = Date.parse(instant);
-  const to = Date.parse(now);
-  if (!Number.isFinite(from) || !Number.isFinite(to)) return null;
-  return formatAgeSeconds(Math.max(0, to - from));
-}
-
-/** A counter as a number, or the reason it is not one. PURE. */
-function counterText(counter: { readonly value: number | null } | undefined): string {
-  return counter?.value == null ? "?" : String(counter.value);
-}
-
-function throughputLines(
-  payload: RedskilledRenderPayload,
-  options: RedskilledDashboardOptions,
-): readonly string[] {
-  const metrics = payload.metrics;
-  if (metrics == null) {
-    return [clamp("48h throughput unavailable — daemon payload carries no live metrics", options.maxWidth)];
-  }
-  if (metrics.history_48h == null) {
-    return [clamp("48h throughput unavailable — daemon payload predates hourly history", options.maxWidth)];
-  }
-  // One padded width for every label, so the two curves start in the SAME
-  // column. Unpadded, `tokens` and `Tickets` differ by one character and the
-  // bars sit one column apart — which defeats the only thing two stacked
-  // sparklines are for, reading them against each other at a glance.
-  const width = Math.max(...SERIES_LABELS.map((name) => name.length));
-  return [
-    hourlySeriesLine("tokens", metrics.history_48h.tokens_per_hour, options, width),
-    hourlySeriesLine("tickets", metrics.history_48h.tickets_per_hour, options, width),
-  ];
-}
-
-/** Every series this block draws, and the source of the shared label column. */
-const SERIES_LABELS = ["tokens", "tickets"] as const;
-
-const SPARK = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] as const;
-
-/**
- * The mark for an hour that reported nothing.
- *
- * `·` (U+00B7) was the earlier choice and it is East Asian AMBIGUOUS width: a
- * terminal is free to draw it half as wide as the block elements beside it, so
- * a run of absences visually shortened the curve it belongs to. `─` (U+2500) is
- * a box-drawing character, sized with the blocks, and still reads as "nothing
- * happened" rather than as the "zero" the lowest block already means.
- */
-const SPARK_ABSENT = "─";
-
-function hourlySeriesLine(
-  label: (typeof SERIES_LABELS)[number],
-  series: RedskilledRenderHourlySeries,
-  options: RedskilledDashboardOptions,
-  labelWidth: number,
-): string {
-  const unit = label.padEnd(labelWidth);
-  const current = series.current.value;
-  const missing = series.buckets.filter((bucket) => bucket.value == null);
-  const reason = missing[0]?.absent_reason ?? null;
-  const currentText = current == null
-    ? `now unavailable (${series.current.absent_reason ?? "no current sample"})`
-    : `now=${formatRate(current)}/h ${trendMark(series.trend)}`.trim();
-  if (options.maxWidth < 72) {
-    return clamp(`${unit} 48h unavailable at width ${options.maxWidth} — 48 hourly points need 72 columns`, options.maxWidth);
-  }
-  const missingText = missing.length === 0 ? "" : ` · ${missing.length} missing (${reason ?? "unmeasured"})`;
-  return clamp(`${unit} 48h ${sparkline(series)} · ${currentText}${missingText}`, options.maxWidth);
-}
-
-function sparkline(series: RedskilledRenderHourlySeries): string {
-  const values = series.buckets.flatMap((bucket) => bucket.value == null ? [] : [Math.max(0, bucket.value)]);
-  const max = Math.max(0, ...values);
-  return series.buckets.map((bucket) => {
-    if (bucket.value == null) return SPARK_ABSENT;
-    if (max === 0) return SPARK[0];
-    return SPARK[Math.min(SPARK.length - 1, Math.floor((Math.max(0, bucket.value) / max) * (SPARK.length - 1)))]!;
-  }).join("");
-}
-
-function trendMark(trend: RedskilledRenderHourlySeries["trend"]): string {
-  return trend === "up" ? "↑" : trend === "down" ? "↓" : trend === "flat" ? "→" : "?";
-}
 
 /** `mem=1.2G/8G 15%`, or the observed figure alone when nothing caps it. PURE. */
 function memoryWindow(windows: RedskilledDashboardWindows): string {


### PR DESCRIPTION
Three complaints about one screen. The first is the real one.

## It answered for one project on a machine that holds several

The render filtered to `options.project`, so an operator asking what `redskilled` is doing saw something that looked like a view of the directory they were standing in — with a second project draining beside it, invisible.

```
before   » reddb-io/red-skills … · tk/h=0 → Tickets/h=6 ↓ · wrk=0/0 …
         tokens 48h  ·····························▃▄▁▁▁▁··▁█▁
         Tickets 48h ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▄▆▇▆▃▄▁▃▂▂▁▁▁▄█▄

after    » reddb-io/red-skills … · tk/h=0 → tickets/h=6 ↓ · wrk=0/0 …
           reddb-io/design-system  wrk=0  rdy=0 human=1  · 21s ago
         ★ reddb-io/red-skills     wrk=0  rdy=0 human=11 · 21s ago
         tokens  48h ─────────────────────────────▁▁▁──▁█▁──▁▁▁▁▁
         tickets 48h ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▄█▄▁▁▁▆▃▃▃
```

Every project the daemon watches now gets a line — Worker count, queue at the last poll, and how old that look is. The current directory's project is **marked** rather than being the only one shown. A registration that lapsed, stopped, or is held by an unreachable daemon says so, because *"nothing is draining here"* and *"something stopped"* are different facts.

## The two sparklines began in different columns

`tokens` and `Tickets` differ by one character and neither was padded, so the curves sat one column apart — which defeats the only thing two stacked sparklines are for. Both labels now share one padded column, derived from the label list rather than hard-coded, and one casing.

## The absence mark was the wrong width

`·` (U+00B7) is East Asian **ambiguous** width: a terminal may draw it half as wide as the block elements beside it, so a run of absences visually shortened the curve — same 48 glyphs, shorter line. `─` (U+2500) is sized with the blocks and still reads as absence rather than as the zero the lowest block already means.

## Verified on the real TUI, not just the pipe

Every earlier check in this session was piped, which takes the **snapshot** path (`isTTY === false`) and never touches `tuiuiu.js`. Under a pseudo-TTY the cursor addresses confirm it:

```
[4;13H tokens  48h ──────…
[5;13H tickets 48h ▁▁▁▁▁…
```

Both curves at column 13 (they were 12 and 13), project rows at lines 2–3, and the delta renderer rewriting only the age characters each second.

## Also here

The file-size ratchet caught `dashboard.ts` at 893 lines. Split **by domain**, as its message demands: `dashboard-sections.ts` answers "what is this host watching and how has it been going"; what remains answers "what is each Worker doing now". `dashboard.ts` drops to 751 lines, and the sparkline is now **exported** — two other modules in this repo grew their own copy of the same eight glyphs.

Three assertions pinned line POSITION rather than content and broke on a section added above them; they now find their line by prefix.

## Verification

Full typecheck 16/16, repo invariants **202/202**, dashboard suites green.

Four tests in `apps/redskilled` fail **identically on a clean `main`** in this environment — they start a real daemon and `mode: "global"` then sees this machine's live Workers. Not introduced here; CI has no live daemon and they pass there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789227871&installation_model_id=20659&pr_number=3819&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3819&signature=e04f2b2dd7ad9f3710818a4d5001326e0a8009193dea931162c90bafcf775415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->